### PR TITLE
security: require digest-aware MCP sandbox images

### DIFF
--- a/src/agent_bom/cli/_runtime.py
+++ b/src/agent_bom/cli/_runtime.py
@@ -83,6 +83,13 @@ from rich.console import Console
     help="Container image used to run non-container server commands in --isolate mode.",
 )
 @click.option(
+    "--sandbox-image-pin-policy",
+    default=None,
+    envvar="AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY",
+    type=click.Choice(["off", "warn", "enforce"]),
+    help="Require digest-pinned sandbox images: off, warn, or enforce.",
+)
+@click.option(
     "--sandbox-mount",
     multiple=True,
     metavar="HOST:CONTAINER[:ro|rw]",
@@ -138,6 +145,7 @@ def proxy_cmd(
     isolate,
     sandbox_runtime,
     sandbox_image,
+    sandbox_image_pin_policy,
     sandbox_mount,
     sandbox_cpus,
     sandbox_memory,
@@ -227,6 +235,7 @@ def proxy_cmd(
             enabled=isolate,
             runtime=sandbox_runtime,
             image=sandbox_image,
+            image_pin_policy=sandbox_image_pin_policy,
             mounts=tuple(sandbox_mount),
             cpus=sandbox_cpus,
             memory=sandbox_memory,

--- a/src/agent_bom/cli/run.py
+++ b/src/agent_bom/cli/run.py
@@ -166,6 +166,13 @@ def _resolve_server_command(server: str) -> list[str]:
     help="Container image used to run non-container server commands in --isolate mode.",
 )
 @click.option(
+    "--sandbox-image-pin-policy",
+    default=None,
+    envvar="AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY",
+    type=click.Choice(["off", "warn", "enforce"]),
+    help="Require digest-pinned sandbox images: off, warn, or enforce.",
+)
+@click.option(
     "--sandbox-mount",
     multiple=True,
     metavar="HOST:CONTAINER[:ro|rw]",
@@ -215,6 +222,7 @@ def run_cmd(
     isolate: bool,
     sandbox_runtime: str | None,
     sandbox_image: str | None,
+    sandbox_image_pin_policy: str | None,
     sandbox_mount: tuple[str, ...],
     sandbox_cpus: str | None,
     sandbox_memory: str | None,
@@ -281,6 +289,7 @@ def run_cmd(
             enabled=isolate,
             runtime=sandbox_runtime,
             image=sandbox_image,
+            image_pin_policy=sandbox_image_pin_policy,
             mounts=sandbox_mount,
             cpus=sandbox_cpus,
             memory=sandbox_memory,

--- a/src/agent_bom/proxy_sandbox.py
+++ b/src/agent_bom/proxy_sandbox.py
@@ -10,6 +10,7 @@ from typing import Literal
 
 SandboxRuntime = Literal["auto", "docker", "podman"]
 SandboxEgressPolicy = Literal["deny", "allow_all"]
+SandboxImagePinPolicy = Literal["off", "warn", "enforce"]
 
 _DEFAULT_SANDBOX_CPUS = "1"
 _DEFAULT_SANDBOX_MEMORY = "512m"
@@ -63,6 +64,7 @@ class SandboxConfig:
     enabled: bool = False
     runtime: SandboxRuntime = "auto"
     image: str | None = None
+    image_pin_policy: SandboxImagePinPolicy = "warn"
     mounts: tuple[SandboxMount, ...] = field(default_factory=tuple)
     network: str = "none"
     egress_policy: SandboxEgressPolicy = "deny"
@@ -82,6 +84,9 @@ class SandboxConfig:
             "enabled": self.enabled,
             "runtime": self.runtime,
             "image": self.image,
+            "image_pinned": _image_reference_has_digest(self.image),
+            "image_pin_policy": self.image_pin_policy,
+            "image_pin_warning": _image_pin_warning(self.image, self.image_pin_policy),
             "network": _effective_network(self),
             "egress_policy": self.egress_policy,
             "cpus": self.cpus,
@@ -158,6 +163,7 @@ def sandbox_config_from_env(
     pids_limit: int | None = None,
     tmpfs_size: str | None = None,
     timeout_seconds: int | None = None,
+    image_pin_policy: str | None = None,
 ) -> SandboxConfig:
     """Build sandbox config from CLI values and AGENT_BOM_MCP_SANDBOX_* env vars."""
     if enabled is None:
@@ -172,6 +178,9 @@ def sandbox_config_from_env(
     if requested_egress not in {"deny", "allow_all"}:
         raise ValueError("sandbox egress policy must be deny or allow-all")
     requested_image = image or os.environ.get("AGENT_BOM_MCP_SANDBOX_IMAGE")
+    requested_image_pin_policy = (image_pin_policy or os.environ.get("AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY") or "warn").strip().lower()
+    if requested_image_pin_policy not in {"off", "warn", "enforce"}:
+        raise ValueError("sandbox image pin policy must be off, warn, or enforce")
     env_mounts = tuple(item.strip() for item in os.environ.get("AGENT_BOM_MCP_SANDBOX_MOUNTS", "").split(",") if item.strip())
     parsed_mounts = tuple(parse_sandbox_mount(item) for item in (*mounts, *env_mounts))
     requested_user = user or os.environ.get("AGENT_BOM_MCP_SANDBOX_USER")
@@ -192,6 +201,7 @@ def sandbox_config_from_env(
         enabled=enabled,
         runtime=requested_runtime,  # type: ignore[arg-type]
         image=requested_image,
+        image_pin_policy=requested_image_pin_policy,  # type: ignore[arg-type]
         mounts=parsed_mounts,
         user=requested_user,
         egress_policy=requested_egress,  # type: ignore[arg-type]
@@ -226,15 +236,20 @@ def build_sandboxed_command(server_cmd: list[str], config: SandboxConfig) -> tup
         image_index = _container_image_index(server_cmd)
         before_image = _strip_conflicting_run_options(server_cmd[2:image_index])
         image_and_args = server_cmd[image_index:]
+        if image_and_args:
+            _validate_image_pin_policy(image_and_args[0], config.image_pin_policy)
         command = [runtime, "run", *before_image, *docker_args, *image_and_args]
         evidence = dict(config.evidence())
         evidence.update({"runtime": runtime, "mode": "harden_existing_container"})
         if image_and_args:
             evidence["image"] = image_and_args[0]
+            evidence["image_pinned"] = _image_reference_has_digest(image_and_args[0])
+            evidence["image_pin_warning"] = _image_pin_warning(image_and_args[0], config.image_pin_policy)
         return command, evidence
 
     if not config.image:
         raise RuntimeError("MCP sandbox isolation for non-container commands requires --sandbox-image or AGENT_BOM_MCP_SANDBOX_IMAGE")
+    _validate_image_pin_policy(config.image, config.image_pin_policy)
     command = [runtime, "run", *docker_args, config.image, *server_cmd]
     evidence = dict(config.evidence())
     evidence.update({"runtime": runtime, "mode": "wrap_command_in_image"})
@@ -324,6 +339,24 @@ def _effective_network(config: SandboxConfig) -> str:
     if config.network != "none":
         return config.network
     return "none" if config.egress_policy == "deny" else "bridge"
+
+
+def _image_reference_has_digest(image: str | None) -> bool:
+    if not image or "@sha256:" not in image:
+        return False
+    digest = image.rsplit("@sha256:", 1)[1]
+    return len(digest) == 64 and all(ch in "0123456789abcdefABCDEF" for ch in digest)
+
+
+def _image_pin_warning(image: str | None, policy: SandboxImagePinPolicy) -> str | None:
+    if policy != "warn" or _image_reference_has_digest(image):
+        return None
+    return "sandbox image is mutable; use an image digest or enforce pinning for production isolation"
+
+
+def _validate_image_pin_policy(image: str, policy: SandboxImagePinPolicy) -> None:
+    if policy == "enforce" and not _image_reference_has_digest(image):
+        raise RuntimeError("MCP sandbox image pin policy requires a digest reference such as image:tag@sha256:<digest>")
 
 
 def _optional_positive_int(env_name: str, *, default: int | None = None) -> int | None:

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -186,6 +186,8 @@ def test_run_passes_sandbox_config_to_run_proxy():
                 "podman",
                 "--sandbox-image",
                 "ghcr.io/acme/mcp-sandbox:1",
+                "--sandbox-image-pin-policy",
+                "warn",
             ],
         )
     assert result.exit_code == 0

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -100,6 +100,8 @@ def test_proxy_cmd_passes_sandbox_config():
                 "docker",
                 "--sandbox-image",
                 "ghcr.io/acme/mcp-sandbox:1",
+                "--sandbox-image-pin-policy",
+                "enforce",
                 "--sandbox-cpus",
                 "0.5",
                 "--sandbox-memory",
@@ -122,6 +124,7 @@ def test_proxy_cmd_passes_sandbox_config():
     assert config.enabled is True
     assert config.runtime == "docker"
     assert config.image == "ghcr.io/acme/mcp-sandbox:1"
+    assert config.image_pin_policy == "enforce"
     assert config.cpus == "0.5"
     assert config.memory == "256m"
     assert config.pids_limit == 64

--- a/tests/test_proxy_sandbox.py
+++ b/tests/test_proxy_sandbox.py
@@ -11,6 +11,8 @@ from agent_bom.proxy_sandbox import (
     sandbox_config_from_env,
 )
 
+PINNED_IMAGE = "ghcr.io/acme/mcp-sandbox:1@sha256:" + "a" * 64
+
 
 def test_parse_sandbox_mount_defaults_to_readonly(tmp_path):
     mount = parse_sandbox_mount(f"{tmp_path}:/workspace")
@@ -78,6 +80,7 @@ def test_sandbox_config_from_env_parses_operator_values(monkeypatch, tmp_path):
     monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX", "true")
     monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX_RUNTIME", "podman")
     monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX_IMAGE", "ghcr.io/acme/mcp-sandbox:1")
+    monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY", "enforce")
     monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX_MOUNTS", f"{tmp_path}:/workspace")
 
     config = sandbox_config_from_env()
@@ -85,6 +88,7 @@ def test_sandbox_config_from_env_parses_operator_values(monkeypatch, tmp_path):
     assert config.enabled is True
     assert config.runtime == "podman"
     assert config.image == "ghcr.io/acme/mcp-sandbox:1"
+    assert config.image_pin_policy == "enforce"
     assert config.mounts[0].target == "/workspace"
 
 
@@ -113,6 +117,9 @@ def test_sandbox_config_defaults_are_bounded_and_network_none(monkeypatch):
     assert evidence["pids_limit"] == 256
     assert evidence["tmpfs_size"] == "64m"
     assert evidence["timeout_seconds"] == 300
+    assert evidence["image_pin_policy"] == "warn"
+    assert evidence["image_pinned"] is False
+    assert evidence["image_pin_warning"]
 
 
 def test_build_sandboxed_command_wraps_non_container_command(monkeypatch):
@@ -143,6 +150,30 @@ def test_build_sandboxed_command_wraps_non_container_command(monkeypatch):
     assert evidence["mode"] == "wrap_command_in_image"
     assert evidence["enabled"] is True
     assert evidence["timeout_seconds"] == 300
+    assert evidence["image_pin_policy"] == "warn"
+    assert evidence["image_pinned"] is False
+    assert evidence["image_pin_warning"]
+
+
+def test_build_sandboxed_command_records_digest_pinned_image(monkeypatch):
+    monkeypatch.setattr("agent_bom.proxy_sandbox.resolve_container_runtime", lambda runtime: "docker")
+    config = SandboxConfig(enabled=True, runtime="docker", image=PINNED_IMAGE, image_pin_policy="enforce")
+
+    command, evidence = build_sandboxed_command(["npx", "--yes", "@mcp/server"], config)
+
+    assert PINNED_IMAGE in command
+    assert evidence["image"] == PINNED_IMAGE
+    assert evidence["image_pinned"] is True
+    assert evidence["image_pin_policy"] == "enforce"
+    assert evidence["image_pin_warning"] is None
+
+
+def test_build_sandboxed_command_rejects_tag_only_image_in_enforce_mode(monkeypatch):
+    monkeypatch.setattr("agent_bom.proxy_sandbox.resolve_container_runtime", lambda runtime: "docker")
+    config = SandboxConfig(enabled=True, runtime="docker", image="ghcr.io/acme/server:1", image_pin_policy="enforce")
+
+    with pytest.raises(RuntimeError, match="requires a digest"):
+        build_sandboxed_command(["npx", "@mcp/server"], config)
 
 
 def test_build_sandboxed_command_hardens_existing_container_run(monkeypatch):
@@ -158,6 +189,16 @@ def test_build_sandboxed_command_hardens_existing_container_run(monkeypatch):
     assert evidence["mode"] == "harden_existing_container"
     assert evidence["runtime"] == "podman"
     assert evidence["image"] == "ghcr.io/acme/server:1"
+    assert evidence["image_pinned"] is False
+    assert evidence["image_pin_warning"]
+
+
+def test_build_sandboxed_command_enforces_digest_for_existing_container_run(monkeypatch):
+    monkeypatch.setattr("agent_bom.proxy_sandbox.resolve_container_runtime", lambda runtime: "docker")
+    config = SandboxConfig(enabled=True, runtime="docker", image_pin_policy="enforce")
+
+    with pytest.raises(RuntimeError, match="requires a digest"):
+        build_sandboxed_command(["docker", "run", "ghcr.io/acme/server:1"], config)
 
 
 def test_build_sandboxed_command_strips_weaker_existing_container_flags(monkeypatch):


### PR DESCRIPTION
Summary
- adds sandbox image pin policy: off, warn, enforce
- accepts digest-bearing references such as image:tag@sha256:<digest>
- rejects mutable tag-only sandbox images in enforce mode
- records image_pinned, image_pin_policy, and warning evidence in sandbox posture
- applies the policy to both wrapped command images and hardened docker/podman run commands
- wires CLI/env controls through agent-bom proxy and agent-bom run

Why
#1906 tracks the remaining sandbox image provenance gap. Tag-only images are useful during local development, but production isolation needs an enforceable digest posture and auditable evidence when mutable images are allowed.

Validation
- uv run pytest tests/test_proxy_sandbox.py tests/test_cli_runtime.py tests/test_cli_run.py -q
- uv run ruff check src/agent_bom/proxy_sandbox.py src/agent_bom/cli/_runtime.py src/agent_bom/cli/run.py tests/test_proxy_sandbox.py tests/test_cli_runtime.py tests/test_cli_run.py
- uv run mypy src/agent_bom/proxy_sandbox.py src/agent_bom/cli/_runtime.py src/agent_bom/cli/run.py
- git diff --check
- pre-commit hooks on commit

Closes #1906