### PR TITLE
security: add adaptive graph backpressure

### DIFF
--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -1156,6 +1156,15 @@ async def get_enrichment_posture() -> dict:
     return describe_enrichment_posture()
 
 
+@router.get("/v1/posture/backpressure", tags=["compliance"])
+async def get_backpressure_posture() -> dict:
+    """Report adaptive runtime backpressure state for expensive paths."""
+
+    from agent_bom.backpressure import describe_backpressure_posture
+
+    return describe_backpressure_posture()
+
+
 @router.get("/v1/posture/counts", tags=["compliance"])
 async def get_posture_counts(request: Request) -> dict:
     """Aggregate vulnerability counts across all completed scans.

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -28,6 +28,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
 from agent_bom.api.stores import _get_graph_store
+from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
 from agent_bom.graph import SEVERITY_RANK, EntityType, GraphFilterOptions, RelationshipType, UnifiedGraph
 from agent_bom.security import sanitize_error
 
@@ -155,7 +156,11 @@ def _enforce_graph_query_budget(body: GraphQueryRequest) -> dict[str, int]:
 
 async def _graph_store_call(fn, /, *args, **kwargs):
     """Run sync graph store methods off the event loop."""
-    return await asyncio.to_thread(fn, *args, **kwargs)
+    try:
+        async with adaptive_backpressure("graph"):
+            return await asyncio.to_thread(fn, *args, **kwargs)
+    except BackpressureRejectedError as exc:
+        raise HTTPException(status_code=429, detail=exc.to_dict(), headers={"Retry-After": str(exc.retry_after_seconds)}) from exc
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/src/agent_bom/backpressure.py
+++ b/src/agent_bom/backpressure.py
@@ -1,0 +1,188 @@
+"""Adaptive process-local backpressure controls for expensive runtime paths."""
+
+from __future__ import annotations
+
+import os
+import time
+from collections import deque
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Any, AsyncIterator
+
+
+class BackpressureRejectedError(RuntimeError):
+    """Raised when a runtime path is shedding work under pressure."""
+
+    def __init__(self, path: str, reason: str, retry_after_seconds: int) -> None:
+        super().__init__(f"{path} backpressure active: {reason}")
+        self.path = path
+        self.reason = reason
+        self.retry_after_seconds = retry_after_seconds
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "message": "Backpressure active for runtime path",
+            "path": self.path,
+            "reason": self.reason,
+            "retry_after_seconds": self.retry_after_seconds,
+        }
+
+
+@dataclass
+class BackpressureController:
+    """Small adaptive controller with concurrency and p99-triggered cooldown."""
+
+    path: str
+    max_concurrency: int
+    p99_threshold_ms: float
+    cooldown_seconds: int
+    min_samples: int
+    window_size: int = 128
+    active: int = 0
+    rejected: int = 0
+    completed: int = 0
+    open_until_monotonic: float = 0.0
+    last_trigger_reason: str = ""
+    _latencies_ms: deque[float] = field(default_factory=deque)
+    _lock: Lock = field(default_factory=Lock)
+
+    def try_enter(self) -> None:
+        now = time.monotonic()
+        with self._lock:
+            if now < self.open_until_monotonic:
+                self.rejected += 1
+                raise BackpressureRejectedError(self.path, self.last_trigger_reason or "latency_degraded", self.retry_after_seconds(now))
+            if self.open_until_monotonic:
+                self.open_until_monotonic = 0.0
+                self.last_trigger_reason = ""
+                self._latencies_ms.clear()
+            if self.active >= self.max_concurrency:
+                self.rejected += 1
+                raise BackpressureRejectedError(self.path, "concurrency_limit", 1)
+            self.active += 1
+
+    def exit(self, latency_ms: float) -> None:
+        with self._lock:
+            self.active = max(self.active - 1, 0)
+            self.completed += 1
+            self._latencies_ms.append(latency_ms)
+            while len(self._latencies_ms) > self.window_size:
+                self._latencies_ms.popleft()
+            if len(self._latencies_ms) >= self.min_samples and self.p99_ms > self.p99_threshold_ms:
+                self.open_until_monotonic = time.monotonic() + self.cooldown_seconds
+                self.last_trigger_reason = "p99_latency_threshold"
+
+    def retry_after_seconds(self, now: float | None = None) -> int:
+        now = time.monotonic() if now is None else now
+        return max(1, int(self.open_until_monotonic - now + 0.999))
+
+    @property
+    def p95_ms(self) -> float:
+        return _percentile(list(self._latencies_ms), 0.95)
+
+    @property
+    def p99_ms(self) -> float:
+        return _percentile(list(self._latencies_ms), 0.99)
+
+    def describe(self) -> dict[str, Any]:
+        now = time.monotonic()
+        open_state = now < self.open_until_monotonic
+        return {
+            "path": self.path,
+            "state": "open" if open_state else "closed",
+            "reason": self.last_trigger_reason if open_state else "",
+            "active": self.active,
+            "max_concurrency": self.max_concurrency,
+            "completed": self.completed,
+            "rejected": self.rejected,
+            "latency_samples": len(self._latencies_ms),
+            "p95_ms": round(self.p95_ms, 2),
+            "p99_ms": round(self.p99_ms, 2),
+            "p99_threshold_ms": self.p99_threshold_ms,
+            "retry_after_seconds": self.retry_after_seconds(now) if open_state else 0,
+        }
+
+
+_CONTROLLERS: dict[str, BackpressureController] = {}
+_CONTROLLERS_LOCK = Lock()
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, int(round((len(ordered) - 1) * percentile))))
+    return ordered[index]
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int, *, minimum: int, maximum: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return min(max(value, minimum), maximum)
+
+
+def _path_env_key(path: str, suffix: str) -> str:
+    normalized = "".join(ch if ch.isalnum() else "_" for ch in path.upper()).strip("_")
+    return f"AGENT_BOM_BACKPRESSURE_{normalized}_{suffix}"
+
+
+def _controller_for(path: str) -> BackpressureController:
+    with _CONTROLLERS_LOCK:
+        controller = _CONTROLLERS.get(path)
+        if controller is not None:
+            return controller
+        controller = BackpressureController(
+            path=path,
+            max_concurrency=_env_int(_path_env_key(path, "CONCURRENCY"), 8, minimum=1, maximum=1024),
+            p99_threshold_ms=float(_env_int(_path_env_key(path, "P99_MS"), 2500, minimum=1, maximum=120_000)),
+            cooldown_seconds=_env_int(_path_env_key(path, "COOLDOWN_SECONDS"), 10, minimum=1, maximum=3600),
+            min_samples=_env_int(_path_env_key(path, "MIN_SAMPLES"), 20, minimum=1, maximum=10_000),
+        )
+        _CONTROLLERS[path] = controller
+        return controller
+
+
+@asynccontextmanager
+async def adaptive_backpressure(path: str) -> AsyncIterator[None]:
+    """Apply adaptive backpressure around a runtime operation."""
+    if not _env_bool("AGENT_BOM_BACKPRESSURE_ENABLED", True):
+        yield
+        return
+    controller = _controller_for(path)
+    controller.try_enter()
+    started = time.perf_counter()
+    try:
+        yield
+    finally:
+        controller.exit((time.perf_counter() - started) * 1000)
+
+
+def describe_backpressure_posture() -> dict[str, Any]:
+    """Return non-secret operator posture for adaptive backpressure."""
+    enabled = _env_bool("AGENT_BOM_BACKPRESSURE_ENABLED", True)
+    with _CONTROLLERS_LOCK:
+        paths = [controller.describe() for controller in sorted(_CONTROLLERS.values(), key=lambda c: c.path)]
+    return {
+        "enabled": enabled,
+        "status": "active" if any(path["state"] == "open" for path in paths) else "ready",
+        "paths": paths,
+        "notes": "Process-local adaptive backpressure. Static budgets still apply before traversal.",
+    }
+
+
+def reset_backpressure_for_tests() -> None:
+    with _CONTROLLERS_LOCK:
+        _CONTROLLERS.clear()

--- a/tests/test_backpressure.py
+++ b/tests/test_backpressure.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agent_bom.backpressure import (
+    BackpressureRejectedError,
+    adaptive_backpressure,
+    describe_backpressure_posture,
+    reset_backpressure_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_backpressure(monkeypatch):
+    reset_backpressure_for_tests()
+    monkeypatch.delenv("AGENT_BOM_BACKPRESSURE_ENABLED", raising=False)
+    monkeypatch.delenv("AGENT_BOM_BACKPRESSURE_GRAPH_CONCURRENCY", raising=False)
+    monkeypatch.delenv("AGENT_BOM_BACKPRESSURE_GRAPH_P99_MS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_BACKPRESSURE_GRAPH_COOLDOWN_SECONDS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_BACKPRESSURE_GRAPH_MIN_SAMPLES", raising=False)
+    yield
+    reset_backpressure_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_backpressure_records_normal_path_posture() -> None:
+    async with adaptive_backpressure("graph"):
+        await asyncio.sleep(0)
+
+    posture = describe_backpressure_posture()
+    graph = next(path for path in posture["paths"] if path["path"] == "graph")
+
+    assert posture["status"] == "ready"
+    assert graph["state"] == "closed"
+    assert graph["completed"] == 1
+    assert graph["rejected"] == 0
+
+
+@pytest.mark.asyncio
+async def test_backpressure_rejects_when_concurrency_is_saturated(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_BACKPRESSURE_GRAPH_CONCURRENCY", "1")
+
+    async with adaptive_backpressure("graph"):
+        with pytest.raises(BackpressureRejectedError) as exc:
+            async with adaptive_backpressure("graph"):
+                pass
+
+    assert exc.value.reason == "concurrency_limit"
+    posture = describe_backpressure_posture()
+    graph = next(path for path in posture["paths"] if path["path"] == "graph")
+    assert graph["rejected"] == 1
+
+
+@pytest.mark.asyncio
+async def test_backpressure_opens_after_p99_threshold_and_recovers(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_BACKPRESSURE_GRAPH_P99_MS", "1")
+    monkeypatch.setenv("AGENT_BOM_BACKPRESSURE_GRAPH_MIN_SAMPLES", "1")
+    monkeypatch.setenv("AGENT_BOM_BACKPRESSURE_GRAPH_COOLDOWN_SECONDS", "1")
+
+    async with adaptive_backpressure("graph"):
+        await asyncio.sleep(0.01)
+
+    with pytest.raises(BackpressureRejectedError) as exc:
+        async with adaptive_backpressure("graph"):
+            pass
+
+    assert exc.value.reason == "p99_latency_threshold"
+    assert describe_backpressure_posture()["status"] == "active"
+
+    await asyncio.sleep(1.05)
+    async with adaptive_backpressure("graph"):
+        pass
+
+    posture = describe_backpressure_posture()
+    graph = next(path for path in posture["paths"] if path["path"] == "graph")
+    assert graph["state"] == "closed"

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -922,6 +923,33 @@ class TestGraphStoreBackendSelection:
         assert "latest_snapshot_id" in helper_calls
         assert "page_nodes" in helper_calls
         assert "search_nodes" in helper_calls
+
+    def test_graph_route_returns_429_when_backpressure_opens(self, recording_graph_store, monkeypatch):
+        from agent_bom.backpressure import reset_backpressure_for_tests
+
+        monkeypatch.setenv("AGENT_BOM_BACKPRESSURE_GRAPH_P99_MS", "1")
+        monkeypatch.setenv("AGENT_BOM_BACKPRESSURE_GRAPH_MIN_SAMPLES", "1")
+        monkeypatch.setenv("AGENT_BOM_BACKPRESSURE_GRAPH_COOLDOWN_SECONDS", "30")
+        reset_backpressure_for_tests()
+
+        original_latest_snapshot_id = recording_graph_store.latest_snapshot_id
+
+        def _slow_latest_snapshot_id(*, tenant_id: str = "") -> str:
+            time.sleep(0.01)
+            return original_latest_snapshot_id(tenant_id=tenant_id)
+
+        monkeypatch.setattr(recording_graph_store, "latest_snapshot_id", _slow_latest_snapshot_id)
+        client = TestClient(app)
+
+        try:
+            response = client.get("/v1/graph")
+            assert response.status_code == 429
+            body = response.json()["detail"]
+            assert body["path"] == "graph"
+            assert body["reason"] == "p99_latency_threshold"
+            assert int(response.headers["Retry-After"]) >= 1
+        finally:
+            reset_backpressure_for_tests()
 
     def test_graph_search_forwards_slice_filters(self, recording_graph_store):
         recording_graph_store.graph.add_node(


### PR DESCRIPTION
Summary
- add process-local adaptive backpressure controller with concurrency and p99-triggered cooldown
- wrap graph store calls so saturated/degraded graph paths return explicit 429 with Retry-After
- expose /v1/posture/backpressure for operator-visible state
- add regressions for normal, saturated, p99-open, recovery, and route-level 429 behavior

Why
This is the first focused #1897 child. It keeps static graph query budgets intact and adds adaptive behavior for degraded graph paths without broad scanner/runtime refactors.

Validation
- uv run pytest tests/test_backpressure.py tests/test_graph_api.py::TestGraphStoreBackendSelection::test_graph_route_returns_429_when_backpressure_opens tests/test_graph_api.py::TestGraphStoreBackendSelection::test_graph_routes_offload_store_calls_to_thread -q
- uv run ruff check src/agent_bom/backpressure.py src/agent_bom/api/routes/graph.py src/agent_bom/api/routes/compliance.py tests/test_backpressure.py tests/test_graph_api.py
- uv run mypy src/agent_bom/backpressure.py src/agent_bom/api/routes/graph.py src/agent_bom/api/routes/compliance.py
- git diff --check
- pre-commit hooks on commit

Refs #1897
Refs #1839