### PR TITLE
security: add adaptive enrichment backpressure

### DIFF
--- a/src/agent_bom/backpressure.py
+++ b/src/agent_bom/backpressure.py
@@ -179,7 +179,7 @@ def describe_backpressure_posture() -> dict[str, Any]:
         "enabled": enabled,
         "status": "active" if any(path["state"] == "open" for path in paths) else "ready",
         "paths": paths,
-        "notes": "Process-local adaptive backpressure. Static budgets still apply before traversal.",
+        "notes": "Process-local adaptive backpressure. Static budgets and source circuit breakers still apply.",
     }
 
 

--- a/src/agent_bom/enrichment.py
+++ b/src/agent_bom/enrichment.py
@@ -15,6 +15,7 @@ from typing import Optional
 import httpx
 from rich.console import Console
 
+from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
 from agent_bom.config import ENRICHMENT_MAX_CACHE_ENTRIES as _MAX_ENRICHMENT_CACHE_ENTRIES
 from agent_bom.config import ENRICHMENT_TTL_SECONDS as _ENRICHMENT_TTL
 from agent_bom.enrichment_posture import record_enrichment_source
@@ -43,6 +44,19 @@ _ENRICHMENT_CACHE_DIR = Path.home() / ".agent-bom"
 _nvd_file_cache: dict[str, dict] = {}
 _epss_file_cache: dict[str, dict] = {}
 _enrichment_cache_loaded = False
+
+
+def _record_enrichment_backpressure(exc: BackpressureRejectedError) -> None:
+    """Record adaptive shedding without failing the whole scan."""
+    message = f"adaptive backpressure: {exc.reason}; retry after {exc.retry_after_seconds}s"
+    record_enrichment_source("runtime_backpressure", "failure", error=message)
+    try:
+        from agent_bom.scanners.state import record_scan_warning
+
+        record_scan_warning("external enrichment skipped by adaptive backpressure")
+    except Exception as warning_exc:  # pragma: no cover - defensive against import cycles
+        _logger.debug("Failed to record enrichment backpressure scan warning: %s", warning_exc)
+    _logger.warning("External enrichment skipped by adaptive backpressure: %s", message)
 
 
 def _evict_oldest(cache: dict[str, dict], max_entries: int) -> None:
@@ -473,8 +487,14 @@ async def enrich_vulnerabilities(
 
             return result_data, skipped, len(nvd_needed)
 
-        # Run all three concurrently
-        epss_data, kev_data, nvd_result = await asyncio.gather(_fetch_epss(), _fetch_kev(), _fetch_nvd())
+        # Run all three concurrently, bounded by adaptive runtime posture.
+        try:
+            async with adaptive_backpressure("enrichment"):
+                epss_data, kev_data, nvd_result = await asyncio.gather(_fetch_epss(), _fetch_kev(), _fetch_nvd())
+        except BackpressureRejectedError as exc:
+            _record_enrichment_backpressure(exc)
+            console.print("  [yellow]⚠[/yellow] External enrichment skipped by adaptive backpressure")
+            return 0
         nvd_data, nvd_skipped, nvd_total = nvd_result
 
         # Report results

--- a/tests/test_backpressure.py
+++ b/tests/test_backpressure.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import patch
 
 import pytest
 
@@ -10,18 +11,27 @@ from agent_bom.backpressure import (
     describe_backpressure_posture,
     reset_backpressure_for_tests,
 )
+from agent_bom.enrichment import enrich_vulnerabilities
+from agent_bom.models import Severity, Vulnerability
+from agent_bom.scanners.state import consume_scan_warnings, reset_scan_warnings
 
 
 @pytest.fixture(autouse=True)
 def _reset_backpressure(monkeypatch):
     reset_backpressure_for_tests()
+    reset_scan_warnings()
     monkeypatch.delenv("AGENT_BOM_BACKPRESSURE_ENABLED", raising=False)
     monkeypatch.delenv("AGENT_BOM_BACKPRESSURE_GRAPH_CONCURRENCY", raising=False)
     monkeypatch.delenv("AGENT_BOM_BACKPRESSURE_GRAPH_P99_MS", raising=False)
     monkeypatch.delenv("AGENT_BOM_BACKPRESSURE_GRAPH_COOLDOWN_SECONDS", raising=False)
     monkeypatch.delenv("AGENT_BOM_BACKPRESSURE_GRAPH_MIN_SAMPLES", raising=False)
+    monkeypatch.delenv("AGENT_BOM_BACKPRESSURE_ENRICHMENT_CONCURRENCY", raising=False)
+    monkeypatch.delenv("AGENT_BOM_BACKPRESSURE_ENRICHMENT_P99_MS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_BACKPRESSURE_ENRICHMENT_COOLDOWN_SECONDS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_BACKPRESSURE_ENRICHMENT_MIN_SAMPLES", raising=False)
     yield
     reset_backpressure_for_tests()
+    reset_scan_warnings()
 
 
 @pytest.mark.asyncio
@@ -76,3 +86,37 @@ async def test_backpressure_opens_after_p99_threshold_and_recovers(monkeypatch) 
     posture = describe_backpressure_posture()
     graph = next(path for path in posture["paths"] if path["path"] == "graph")
     assert graph["state"] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_enrichment_backpressure_sheds_with_scan_warning(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_BACKPRESSURE_ENRICHMENT_P99_MS", "1")
+    monkeypatch.setenv("AGENT_BOM_BACKPRESSURE_ENRICHMENT_MIN_SAMPLES", "1")
+    monkeypatch.setenv("AGENT_BOM_BACKPRESSURE_ENRICHMENT_COOLDOWN_SECONDS", "30")
+
+    vuln = Vulnerability(id="CVE-2026-0001", summary="test", severity=Severity.HIGH)
+    calls = 0
+
+    async def _slow_epss(cve_ids, client):  # noqa: ARG001
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.01)
+        return {}
+
+    with (
+        patch("agent_bom.enrichment.fetch_epss_scores", side_effect=_slow_epss),
+        patch("agent_bom.enrichment.fetch_cisa_kev_catalog", return_value={}),
+        patch("agent_bom.enrichment._save_enrichment_cache"),
+    ):
+        first = await enrich_vulnerabilities([vuln], enable_nvd=False, enable_epss=True, enable_kev=False)
+        second = await enrich_vulnerabilities([vuln], enable_nvd=False, enable_epss=True, enable_kev=False)
+
+    assert first == 0
+    assert second == 0
+    assert calls == 1
+    assert "external enrichment skipped by adaptive backpressure" in consume_scan_warnings()
+
+    posture = describe_backpressure_posture()
+    enrichment = next(path for path in posture["paths"] if path["path"] == "enrichment")
+    assert enrichment["state"] == "open"
+    assert enrichment["reason"] == "p99_latency_threshold"


### PR DESCRIPTION
Summary
- extend adaptive backpressure from #1913 to the external enrichment path
- shed degraded enrichment with an explicit scan warning instead of blocking or failing the full scan
- record runtime_backpressure posture evidence and expose enrichment state through the existing backpressure posture endpoint
- broaden backpressure tests to cover enrichment p99 cooldown and scan-warning behavior

Why
This is the second focused #1897 child, stacked on #1913 so it reuses the same controller and operator posture model. Graph requests return bounded 429s; enrichment is optional, so degraded enrichment is skipped with evidence and the scan continues.

Validation
- uv run pytest tests/test_backpressure.py -q
- uv run pytest tests/test_cwe_enrichment.py::test_enrich_skips_nvd_when_cwe_known tests/test_cwe_enrichment.py::test_enrich_skips_nvd_entirely_when_all_have_cwe tests/test_cwe_enrichment.py::test_enrich_extracts_cwe_from_nvd_response -q
- uv run ruff check src/agent_bom/backpressure.py src/agent_bom/enrichment.py tests/test_backpressure.py
- uv run mypy src/agent_bom/backpressure.py src/agent_bom/enrichment.py
- git diff --check
- pre-commit hooks on commit

Refs #1897
Refs #1839