### PR TITLE
ci: harden release and audit gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           node-version: '22'
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --frozen --extra dev
 
       - name: Bandit (Static Security Analysis)
         run: uv run bandit -r src/ --severity-level medium
@@ -142,7 +142,8 @@ jobs:
           scan-type: fs
           scan-ref: .
           format: table
-          severity: HIGH,CRITICAL
+          severity: MEDIUM,HIGH,CRITICAL,UNKNOWN
+          ignore-unfixed: true
           exit-code: '1'
           trivyignores: .trivyignore
 
@@ -187,7 +188,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --frozen --extra dev
 
       - name: Ruff
         run: uv run ruff check src/
@@ -333,7 +334,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --frozen --extra dev
 
       - name: Generate endpoint bundle
         env:
@@ -401,7 +402,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --extra dev --extra api --extra mcp-server
+        run: uv sync --frozen --extra dev --extra api --extra mcp-server
 
       - name: Run tests
         run: |
@@ -437,7 +438,7 @@ jobs:
 
       - name: Install project dependencies
         run: |
-          uv sync --extra dev --extra api --extra mcp-server
+          uv sync --frozen --extra dev --extra api --extra mcp-server
 
       - name: Run tests (musl)
         run: |
@@ -489,7 +490,7 @@ jobs:
         run: python scripts/check_product_surface_contract.py
 
       - name: Install dependencies for CLI smoke checks
-        run: uv sync --extra dev --extra api --extra mcp-server
+        run: uv sync --frozen --extra dev --extra api --extra mcp-server
 
       - name: Validate canonical README commands parse
         run: |
@@ -631,7 +632,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom from source
-        run: uv sync --extra dev
+        run: uv sync --frozen --extra dev
 
       - name: Generate real SBOM from installed packages (pip-audit CycloneDX)
         run: |

--- a/.github/workflows/cve-freshness.yml
+++ b/.github/workflows/cve-freshness.yml
@@ -13,21 +13,33 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read  # checkout only; no SARIF upload (schedule-only category breaks PR checks)
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-python
         with:
           python-version: "3.11"
       - name: Install dependencies
-        run: uv sync --extra dev
-      - name: pip-audit
-        run: uv run --with pip-audit pip-audit --ignore-vuln CVE-2026-3219 || true
-      - name: agent-bom self-scan
+        run: uv sync --frozen --extra dev
+      - name: pip-audit freshness gate
         run: |
-          uv run agent-bom sbom tests/fixtures/test-sbom.cdx.json -f sarif -o results.sarif || true
-          if [ ! -f results.sarif ]; then
-            echo '{"version":"0.81.3","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.81.3"}},"results":[]}]}' > results.sarif
-          fi
-      # CVE freshness results are logged in workflow output.
-      # We skip upload-sarif because this workflow only runs on schedule (not PRs),
-      # and a schedule-only SARIF category causes "1 configuration not found" on PRs.
+          uv run --with pip-audit pip-audit --ignore-vuln CVE-2026-3219 \
+            --format json \
+            --output pip-audit-freshness.json
+      - name: agent-bom self-scan freshness gate
+        run: |
+          mkdir -p sarif
+          uv run agent-bom scan --self-scan \
+            --format sarif \
+            -o sarif/cve-freshness-self-scan.sarif \
+            --fail-on-severity high \
+            --exclude-unfixable \
+            --quiet
+      - name: Upload CVE freshness evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cve-freshness-evidence
+          path: |
+            pip-audit-freshness.json
+            sarif/cve-freshness-self-scan.sarif

--- a/.github/workflows/pr-security-gate.yml
+++ b/.github/workflows/pr-security-gate.yml
@@ -1,6 +1,6 @@
 name: PR Security Gate
 
-# Hard gate on PRs: pip-audit must pass (HIGH+ severity fails the build)
+# Hard gate on PRs: pip-audit must pass using machine-readable JSON output
 # and agent-bom self-scans its own installed deps. This complements the
 # existing cve-freshness.yml scheduled job by catching regressions on PRs,
 # not just twice a week.
@@ -35,29 +35,55 @@ jobs:
           python-version: "3.11"
 
       - name: Install runtime deps (not dev) — scan the shipping dep set
-        run: uv sync --extra api --extra postgres --extra mcp-server --extra oidc
+        run: uv sync --frozen --extra api --extra postgres --extra mcp-server --extra oidc
 
-      - name: Run pip-audit with strict severity gate
+      - name: Run pip-audit with JSON gate
         run: |
-          # Fail on HIGH or CRITICAL findings. Medium + Low become advisory
-          # so we're not blocked by transitive noise, but HIGH+ is a gate.
+          set +e
           uv run --with pip-audit pip-audit --ignore-vuln CVE-2026-3219 \
             -s osv \
-            --format columns \
-            | tee audit.txt
+            --format json \
+            --output audit.json
+          set -e
 
-          # Extract highest severity — fail if HIGH or CRITICAL is present.
-          if grep -qiE '\b(HIGH|CRITICAL)\b' audit.txt; then
-            echo "::error::pip-audit found HIGH or CRITICAL vulnerabilities — see the log above"
-            exit 1
-          fi
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path("audit.json")
+          if not path.is_file():
+              raise SystemExit("pip-audit did not produce audit.json")
+          data = json.loads(path.read_text(encoding="utf-8"))
+          fixable = []
+          severe = []
+          for dependency in data.get("dependencies", []):
+              dep_name = dependency.get("name", "<unknown>")
+              dep_version = dependency.get("version", "<unknown>")
+              for vuln in dependency.get("vulns", []):
+                  vuln_id = vuln.get("id", "<unknown>")
+                  severity = str(vuln.get("severity") or vuln.get("severity_level") or "").upper()
+                  fix_versions = vuln.get("fix_versions") or []
+                  if severity in {"HIGH", "CRITICAL"}:
+                      severe.append(f"{dep_name} {dep_version} {vuln_id} severity={severity}")
+                  if fix_versions:
+                      fixable.append(f"{dep_name} {dep_version} {vuln_id} fixes={','.join(fix_versions)}")
+          if severe:
+              print("::error::pip-audit found HIGH/CRITICAL vulnerabilities:")
+              print("\n".join(severe[:20]))
+              raise SystemExit(1)
+          if fixable:
+              print("::error::pip-audit found vulnerabilities with available fixes:")
+              print("\n".join(fixable[:20]))
+              raise SystemExit(1)
+          print("pip-audit JSON gate passed: no HIGH/CRITICAL or fixable findings")
+          PY
 
       - name: Upload pip-audit report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pip-audit-report
-          path: audit.txt
+          path: audit.json
 
   self-scan-pr:
     name: agent-bom self-scan on PR
@@ -73,7 +99,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install agent-bom + dev extras
-        run: uv sync --extra dev
+        run: uv sync --frozen --extra dev
 
       - name: Self-scan fixture SBOM for regressions
         id: self_scan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,22 @@ jobs:
           print(f"Version aligned: {pkg}")
           PY
 
+      - name: Verify CHANGELOG contains release entry
+        run: |
+          python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          tag = "${{ steps.meta.outputs.version }}"
+          changelog = Path("CHANGELOG.md")
+          if not changelog.is_file():
+              raise SystemExit("CHANGELOG.md not found")
+          text = changelog.read_text(encoding="utf-8")
+          if not re.search(rf"^## \[{re.escape(tag)}\](?:\s|$)", text, re.M):
+              raise SystemExit(f"CHANGELOG.md is missing release entry: ## [{tag}]")
+          print(f"CHANGELOG entry present: {tag}")
+          PY
+
   docs-site:
     name: Rebuild and deploy docs
     needs: version-guard
@@ -491,7 +507,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install agent-bom (from source)
-        run: uv sync --extra dev
+        run: uv sync --frozen --extra dev
 
       - name: Verify release consistency map
         run: python scripts/check_release_consistency.py
@@ -548,7 +564,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --frozen --extra dev
 
       - name: Generate CycloneDX SBOM (cyclonedx-py — standard)
         run: uv run --with cyclonedx-bom==7.2.2 cyclonedx-py environment -o agent-bom-sbom.cdx.json


### PR DESCRIPTION
Summary
- add a release guard that requires CHANGELOG.md to contain the tagged version entry
- run protected CI/release uv sync paths with --frozen so lockfile drift fails fast
- replace the PR pip-audit column grep with a JSON parser that fails on HIGH/CRITICAL metadata when present and on fixable findings
- make cve-freshness fail visibly and upload evidence instead of swallowing pip-audit/self-scan failures
- align PR Trivy filesystem severity/ignore-unfixed behavior with the release gate

Why
This addresses the confirmed P0 CI/CD audit findings without weakening required checks or changing branch protection. Broader P1/P2 items such as checkout credential minimization, CODEOWNERS expansion, and cross-platform unit coverage should stay in follow-up PRs.

Validation
- python3 YAML parse for all .github/workflows/*.yml
- python3 dry-run of the CHANGELOG gate against current pyproject version
- uv run python scripts/check_product_surface_contract.py
- git diff --check
- pre-commit hooks on commit

Refs #1908
Refs #1780