### PR TITLE
ci: bound workflow job timeouts

### DIFF
--- a/.github/workflows/airgap-image-bundle.yml
+++ b/.github/workflows/airgap-image-bundle.yml
@@ -23,6 +23,7 @@ jobs:
   bundle:
     name: Build air-gapped image bundle
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/backup-restore.yml
+++ b/.github/workflows/backup-restore.yml
@@ -30,6 +30,7 @@ jobs:
   roundtrip:
     name: Dump → S3 → restore → verify
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     # aws-cli honors AWS_ENDPOINT_URL / AWS_ENDPOINT_URL_S3 in v2 so the
     # production restore script runs unmodified against MinIO.
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
   changes:
     name: PR Path Classifier
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
     if: github.event_name == 'pull_request'
@@ -61,6 +62,7 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     permissions:
       contents: read
     steps:
@@ -178,6 +180,7 @@ jobs:
   lint:
     name: Lint and Type Check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -199,6 +202,7 @@ jobs:
   ui:
     name: UI Validate
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     permissions:
       contents: read
     steps:
@@ -294,6 +298,7 @@ jobs:
   helm-profiles:
     name: Helm Profile Validate
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -317,6 +322,7 @@ jobs:
   endpoint-packaging:
     name: Endpoint Packaging (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     permissions:
       contents: read
     strategy:
@@ -383,6 +389,7 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     permissions:
       contents: read
     strategy:
@@ -419,6 +426,7 @@ jobs:
     name: Test (Alpine/musl)
     if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.alpine == 'true')
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     permissions:
       contents: read
     needs: [changes]
@@ -448,6 +456,7 @@ jobs:
   base-branch-check:
     name: PR Base Branch Guard
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
     if: github.event_name == 'pull_request'
@@ -469,6 +478,7 @@ jobs:
   version-check:
     name: Version Alignment
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -509,6 +519,7 @@ jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     needs: [security, lint, test]
@@ -536,6 +547,7 @@ jobs:
     name: Docker (multi-arch)
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
     needs: [security, lint, test]
@@ -621,6 +633,7 @@ jobs:
     name: agent-bom Self-Scan
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [test]
     permissions:
       contents: read
@@ -673,6 +686,7 @@ jobs:
     name: Dogfood GitHub Action
     if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.action == 'true')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     needs: [changes]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,7 @@ jobs:
   analyze-python:
     name: Analyze (python)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       security-events: write
       actions: read
@@ -47,6 +48,7 @@ jobs:
   analyze-actions:
     name: Analyze (actions)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/container-rescan.yml
+++ b/.github/workflows/container-rescan.yml
@@ -15,6 +15,7 @@ jobs:
   rescan:
     name: Rescan — ${{ matrix.platform }}
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 35
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,6 +11,7 @@ jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:


### PR DESCRIPTION
Summary\n- add explicit timeout-minutes to protected CI jobs, CodeQL, dependency review, container rescan, airgap bundle, and backup/restore workflows\n- keep required check names and security gates unchanged\n- bound hung jobs so runner failures become explicit instead of parking for the default six-hour ceiling\n\nWhy\n#1908 tracks protected PR pipeline latency and reliability. #1915 handled the P0 release/audit gates; this PR closes the timeout hygiene item without weakening any branch-protection check.\n\nValidation\n- uv run python -c "import pathlib, yaml; [yaml.safe_load(p.read_text()) for p in pathlib.Path('.github/workflows').glob('*.yml')]; print('workflow yaml ok')"\n- git diff --check\n- pre-commit hooks on commit\n\nRefs #1908\nRefs #1780