### PR TITLE
ci: harden release checkout credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}  # all permissions denied by default; jobs declare only what they need
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   version-guard:
     name: Verify tag/version alignment
@@ -17,6 +21,8 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: meta
@@ -73,6 +79,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-python
         with:
@@ -130,6 +138,8 @@ jobs:
       attestations: write   # required for SBOM + provenance attestations
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: meta
@@ -263,6 +273,8 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: meta
@@ -380,6 +392,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-python
         with:
@@ -412,6 +426,8 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: meta
@@ -475,6 +491,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Build release candidate image
         run: docker build -t agent-bom:release-test .
@@ -501,6 +519,8 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-python
         with:
@@ -558,6 +578,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-python
         with:


### PR DESCRIPTION
Summary\n- add release workflow concurrency so two tag releases for the same ref cannot race release side effects\n- set persist-credentials: false on release checkouts that do not push back to git\n- intentionally keep credentials on the GitHub Release job because it owns the optional floating major tag update path\n\nWhy\nThis addresses the CI/CD audit hygiene item around checkout credentials in privileged release jobs and the release concurrency race. It preserves the existing release permissions model and avoids changing publishing behavior.\n\nValidation\n- uv run python -c "import pathlib, yaml; [yaml.safe_load(p.read_text()) for p in pathlib.Path('.github/workflows').glob('*.yml')]; print('workflow yaml ok')"\n- git diff --check\n- pre-commit hooks on commit\n\nRefs #1908\nRefs #1780