### PR TITLE
ci: harden dependency governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,14 @@
 # Default code owners — PRs require review from at least one owner
 * @msaad00 @andres-linero
+
+# Release and supply-chain control surfaces.
+/.github/workflows/release.yml @msaad00 @andres-linero
+/.github/workflows/ci.yml @msaad00 @andres-linero
+/.github/workflows/pr-security-gate.yml @msaad00 @andres-linero
+/.github/workflows/cve-freshness.yml @msaad00 @andres-linero
+/.github/workflows/dependabot-auto-approve.yml @msaad00 @andres-linero
+/.github/dependabot.yml @msaad00 @andres-linero
+/.github/CODEOWNERS @msaad00 @andres-linero
+/.trivyignore @msaad00 @andres-linero
+/Dockerfile @msaad00 @andres-linero
+/ui/Dockerfile @msaad00 @andres-linero

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,7 @@
 
 ## Checklist
 - [ ] Version bumped if this is a release PR (`scripts/bump-version.py`)
+- [ ] CHANGELOG entry added if this changes released behavior, user-facing docs, packaging, deployment, security posture, or compatibility
 - [ ] Docs/diagrams updated if features changed (`ARCHITECTURE.md`, `README.md`, SVGs)
 - [ ] No secrets, credentials, or personally identifiable data in diff
 - [ ] Backend, CLI, UI, docs, schema, deploy config, and tests are aligned for this change

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,24 @@ updates:
       - "dependencies"
       - "github-actions"
 
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "docker"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "docker"
+    directory: "/ui"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "docker"
+    open-pull-requests-limit: 5
+
   - package-ecosystem: "pip"
     directory: "/"
     schedule:

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -19,10 +19,16 @@ permissions:
 jobs:
   auto-approve:
     if: >-
-      github.actor == 'dependabot[bot]' ||
-      github.actor == 'app/dependabot' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      github.event.pull_request.user.login == 'app/dependabot'
+      (
+        github.actor == 'dependabot[bot]' ||
+        github.actor == 'app/dependabot'
+      ) &&
+      (
+        github.event.pull_request.user.login == 'dependabot[bot]' ||
+        github.event.pull_request.user.login == 'app/dependabot'
+      ) &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'dependabot/')
     runs-on: ubuntu-latest
     steps:
       - name: Fetch dependabot metadata


### PR DESCRIPTION
Summary\n- add Dependabot Docker ecosystem coverage for the root Dockerfile and UI Dockerfile\n- tighten Dependabot auto-approve so only bot-authored, same-repo dependabot/* branches qualify after quarantine\n- add CODEOWNERS entries for release, CI, dependency, Docker, and scanner-ignore control files\n- add a PR-template CHANGELOG checkbox for release-visible behavior/security/deploy changes\n\nWhy\nThis addresses the next small CI/CD audit items after #1915/#1916/#1917: dependency ecosystem coverage, safer auto-approval eligibility, path-specific ownership for sensitive workflow/supply-chain files, and release-note hygiene. It does not change required checks or weaken branch protection.\n\nValidation\n- uv run python -c "import pathlib, yaml; [yaml.safe_load(p.read_text()) for p in pathlib.Path('.github/workflows').glob('*.yml')]; yaml.safe_load(pathlib.Path('.github/dependabot.yml').read_text()); print('yaml ok')"\n- git diff --check\n- pre-commit hooks on commit\n\nRefs #1908\nRefs #1780