### PR TITLE
ci: verify osv scanner downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,9 +101,12 @@ jobs:
 
       - name: OSV Scanner (all lockfiles)
         run: |
-          curl -fsSL -o /usr/local/bin/osv-scanner \
-            https://github.com/google/osv-scanner/releases/download/v2.3.3/osv-scanner_linux_amd64
-          chmod +x /usr/local/bin/osv-scanner
+          OSV_SCANNER_VERSION="v2.3.3"
+          OSV_SCANNER_SHA256="777b4bb7ddd10bdcc8a1aa398d37d05e91e866e7586f9cff3fca2f72b8153033"
+          curl -fsSL -o /tmp/osv-scanner \
+            "https://github.com/google/osv-scanner/releases/download/${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64"
+          echo "${OSV_SCANNER_SHA256}  /tmp/osv-scanner" | sha256sum -c -
+          install -m 0755 /tmp/osv-scanner /usr/local/bin/osv-scanner
           # Scan main lockfile (all pinned deps for every extra, including transitive)
           # osv-scanner v2 syntax: scan --lockfile=<path>
           # Scan main lockfile — pass if only unfixable CVEs remain (FIXED VERSION = --)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -540,9 +540,12 @@ jobs:
 
       - name: OSV scanner (ui lockfile) — block release on fixable CVEs
         run: |
-          curl -fsSL -o /usr/local/bin/osv-scanner \
-            https://github.com/google/osv-scanner/releases/download/v2.3.3/osv-scanner_linux_amd64
-          chmod +x /usr/local/bin/osv-scanner
+          OSV_SCANNER_VERSION="v2.3.3"
+          OSV_SCANNER_SHA256="777b4bb7ddd10bdcc8a1aa398d37d05e91e866e7586f9cff3fca2f72b8153033"
+          curl -fsSL -o /tmp/osv-scanner \
+            "https://github.com/google/osv-scanner/releases/download/${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64"
+          echo "${OSV_SCANNER_SHA256}  /tmp/osv-scanner" | sha256sum -c -
+          install -m 0755 /tmp/osv-scanner /usr/local/bin/osv-scanner
           osv-scanner scan --config osv-scanner.toml --lockfile=ui/package-lock.json 2>&1 | tee /tmp/osv-ui-release.txt || {
             FIXABLE=$(grep -E "^\|" /tmp/osv-ui-release.txt | grep -v "| -- " | grep -v "OSV URL" | grep -v "+--" | head -5)
             if [ -n "$FIXABLE" ]; then


### PR DESCRIPTION
Summary\n- pin OSV-Scanner v2.3.3 linux/amd64 downloads to the official release asset SHA256\n- verify the checksum before installing the binary in PR CI and release gates\n- keep existing OSV scan behavior and fixable-CVE handling unchanged\n\nWhy\nThe CI/CD audit flagged that OSV-Scanner was downloaded with curl directly into the runner without checksum verification. This keeps the current scanner version but makes the download supply-chain posture match the Helm download pattern already used elsewhere.\n\nValidation\n- uv run python -c "import pathlib, yaml; [yaml.safe_load(p.read_text()) for p in pathlib.Path('.github/workflows').glob('*.yml')]; print('workflow yaml ok')"\n- git diff --check\n- pre-commit hooks on commit\n\nRefs #1908