### PR TITLE
ci: mirror code scanning configs on PRs

### DIFF
--- a/.github/workflows/pr-security-gate.yml
+++ b/.github/workflows/pr-security-gate.yml
@@ -22,6 +22,53 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  code-scanning-config-pr:
+    name: Code scanning config placeholders
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Write empty agent-bom SARIF
+        run: |
+          mkdir -p sarif
+          cat > sarif/empty-agent-bom.sarif <<'EOF'
+          {
+            "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+            "version": "2.1.0",
+            "runs": [
+              {
+                "tool": {
+                  "driver": {
+                    "name": "agent-bom",
+                    "version": "0.0.0",
+                    "informationUri": "https://github.com/msaad00/agent-bom"
+                  }
+                },
+                "results": []
+              }
+            ]
+          }
+          EOF
+
+      - name: Upload scheduled config placeholder
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          sarif_file: sarif/empty-agent-bom.sarif
+          category: agent-bom-scheduled
+
+      - name: Upload dependency self-scan config placeholder
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          sarif_file: sarif/empty-agent-bom.sarif
+          category: agent-bom-self-dep
+
+      - name: Upload SAST self-scan config placeholder
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          sarif_file: sarif/empty-agent-bom.sarif
+          category: agent-bom-self-sast
+
   pip-audit-pr:
     name: pip-audit on PR
     runs-on: ubuntu-latest


### PR DESCRIPTION
Summary
- add lightweight PR SARIF placeholder uploads for the existing agent-bom scheduled/self-scan code-scanning categories
- keep the expensive scheduled/post-merge scans on their current workflows
- remove the neutral "3 configurations not found" PR code-scanning warning by making PR configuration sets match main

Why
GitHub code scanning compares PR alerts against configurations present on main. The agent-bom scheduled and post-merge self-scan categories only existed on main/scheduled runs, so PRs showed a neutral configuration warning even when checks passed. This PR uploads empty SARIF for those categories on pull_request so the comparison can complete cleanly without running the heavy scans on every PR.

Validation
- `uv run python -c "import pathlib, yaml; [yaml.safe_load(p.read_text()) for p in pathlib.Path('.github/workflows').glob('*.yml')]; print('workflow yaml ok')"`
- `git diff --check`
- pre-commit hooks on commit

Refs #1908