### PR TITLE
ci: restore stable Python container base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## ── Builder stage ────────────────────────────────────────────────────────────
-FROM python:3.15.0a8-alpine3.23@sha256:67a4b22b18852de8a9f668937641d2926e2dc9832b4a24ed29c9f5afb125251d AS builder
+FROM python:3.14.3-alpine3.23@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510 AS builder
 
 WORKDIR /app
 ARG HTTP_PROXY
@@ -28,7 +28,7 @@ COPY src/ ./src/
 RUN pip install --no-cache-dir --prefix=/install ".[api]"
 
 ## ── Runtime stage ────────────────────────────────────────────────────────────
-FROM python:3.15.0a8-alpine3.23@sha256:67a4b22b18852de8a9f668937641d2926e2dc9832b4a24ed29c9f5afb125251d
+FROM python:3.14.3-alpine3.23@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510
 
 ARG VERSION=0.81.3
 ARG HTTP_PROXY


### PR DESCRIPTION
Summary
- restore the root Dockerfile builder/runtime base image to the stable pinned Python 3.14 Alpine image
- undo the Python 3.15 alpha base image that broke main Docker multi-arch builds
- keep the image digest pinned

Why
#1925 was opened after main failed in `Docker (multi-arch)`. The failing build used Python 3.15 alpha and failed while building `watchfiles`/PyO3 because the current PyO3 version supports Python up to 3.14. This PR restores the last known compatible Python image for the release path.

Validation
- `git diff --check`
- pre-commit hooks on commit
- Docker build could not be run locally because the local Docker daemon is not running; CI `Docker (multi-arch)` is the validation gate for this fix.

Closes #1925