### PR TITLE
security: document proxy control-plane mTLS posture

### DIFF
--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -205,6 +205,46 @@ Production deployments must keep cryptographic keys separated by purpose:
 
 Do not reuse the API key or audit HMAC key as a rate-limit, browser-session, or proxy-attestation secret. Set `AGENT_BOM_TRUST_PROXY_AUTH_ISSUER` when the upstream proxy can inject a stable issuer identifier; the API will then reject trusted-proxy requests from any other issuer.
 
+### Proxy-to-control-plane mTLS posture
+
+`agent-bom` does not terminate app-native mTLS inside the FastAPI control
+plane. In production, terminate TLS and verify proxy or gateway client
+certificates at the ingress, Envoy sidecar, or service mesh boundary, then keep
+trusted-proxy header attestation enabled so direct client-supplied identity
+headers remain ignored.
+
+Declare the operator posture with:
+
+```bash
+AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_MODE=delegated
+AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_PROVIDER=istio
+AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_CLIENT_CA_REF=secret/agent-bom/proxy-client-ca
+AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_EVIDENCE_REF=deploy/helm/agent-bom/templates/controlplane-istio-peer-authentication.yaml
+AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_CERT_HEADER=x-forwarded-client-cert
+AGENT_BOM_TRUST_PROXY_AUTH=1
+AGENT_BOM_TRUST_PROXY_AUTH_SECRET=<32+ byte shared attestation secret>
+AGENT_BOM_TRUST_PROXY_AUTH_ISSUER=edge-envoy
+```
+
+`GET /v1/auth/policy` exposes `proxy_control_plane_mtls` with one of three
+honest states:
+
+- `disabled` — no mTLS posture has been declared.
+- `needs_evidence` — delegated mTLS is declared, but client-CA evidence,
+  evidence reference, or trusted-proxy issuer pinning is incomplete.
+- `ok` — delegated mTLS is declared, client-CA evidence is referenced, and
+  trusted-proxy auth is issuer-pinned.
+
+For NGINX, set `ssl_verify_client on;`, trust the proxy client CA with
+`ssl_client_certificate`, and forward only sanitized identity headers from the
+verified location block. For Envoy, use `DownstreamTlsContext` with
+`require_client_certificate: true` and forward `x-forwarded-client-cert` only
+after SAN/URI validation. For Istio, use `PeerAuthentication` `STRICT` plus an
+`AuthorizationPolicy` that limits caller identities to the proxy/gateway service
+accounts. In all three patterns, `AGENT_BOM_TRUST_PROXY_AUTH_SECRET` and
+`AGENT_BOM_TRUST_PROXY_AUTH_ISSUER` remain the application-level guard against
+spoofed `X-Agent-Bom-*` headers.
+
 API-local filesystem scan endpoints are meant for workstation pilots. In EKS
 and other shared control planes, keep `AGENT_BOM_API_LOCAL_PATH_SCANS=disabled`
 and collect filesystem evidence through endpoint agents or mounted tenant

--- a/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
+++ b/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
@@ -194,6 +194,7 @@ Horizontal scale via Helm HPA on both control plane and gateway. ClickHouse is t
 - **OIDC** — any IdP (Okta, Auth0, Azure AD, Google). Config in [`api/oidc.py`](../src/agent_bom/api/oidc.py).
 - **SAML** — SP metadata at [`/v1/auth/saml/metadata`](../src/agent_bom/api/saml.py). Install `pip install 'agent-bom[saml]'`.
 - **Trusted proxy headers** — RBAC via `X-Agent-Bom-Role` + `X-Agent-Bom-Tenant-ID` only when an authed reverse proxy also injects `X-Agent-Bom-Proxy-Secret` matching a 32+ byte `AGENT_BOM_TRUST_PROXY_AUTH_SECRET`. Set `AGENT_BOM_TRUST_PROXY_AUTH_ISSUER` to pin a stable upstream proxy issuer. Direct client-supplied role/tenant headers are ignored. [`rbac.py require_authenticated_permission`](../src/agent_bom/rbac.py).
+- **Proxy-to-control-plane mTLS posture** — mTLS is delegated to ingress, Envoy, or the service mesh rather than terminated inside the FastAPI app. Set `AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_MODE=delegated` plus client-CA and evidence refs, then verify `proxy_control_plane_mtls` in `/v1/auth/policy`. The app still requires trusted-proxy shared-secret attestation and issuer pinning so certificate-verified proxies cannot be bypassed by raw `X-Agent-Bom-*` headers.
 - **Gateway upstream auth** — `none`, `bearer` (env), `oauth2_client_credentials` with token cache + early refresh — [`gateway_upstreams.py UpstreamConfig.resolve_auth_headers`](../src/agent_bom/gateway_upstreams.py). Snowflake MCPs use the OAuth2 path.
 
 ### 2.11 Secrets never touch agent-bom's disk

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -130,6 +130,77 @@ def get_trusted_proxy_auth_status() -> dict[str, object]:
     }
 
 
+_PROXY_CONTROL_PLANE_MTLS_MODES = {"disabled", "delegated"}
+
+
+def describe_proxy_control_plane_mtls_posture() -> dict[str, object]:
+    """Return non-secret proxy-to-control-plane mTLS posture.
+
+    agent-bom does not terminate app-native mTLS inside FastAPI. Production
+    deployments should enforce client certificate verification in the
+    ingress, reverse proxy, or service mesh, then keep trusted-proxy header
+    attestation enabled so direct client-supplied identity headers are ignored.
+    """
+
+    raw_mode = os.environ.get("AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_MODE", "disabled").strip().lower() or "disabled"
+    provider = os.environ.get("AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_PROVIDER", "").strip()
+    client_ca_ref = os.environ.get("AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_CLIENT_CA_REF", "").strip()
+    evidence_ref = os.environ.get("AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_EVIDENCE_REF", "").strip()
+    cert_header = os.environ.get("AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_CERT_HEADER", "").strip()
+    trusted_proxy = get_trusted_proxy_auth_status()
+
+    base: dict[str, object] = {
+        "mode": raw_mode,
+        "supported_modes": sorted(_PROXY_CONTROL_PLANE_MTLS_MODES),
+        "mode_env": "AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_MODE",
+        "provider": provider or None,
+        "client_ca_ref_configured": bool(client_ca_ref),
+        "client_cert_header_configured": bool(cert_header),
+        "evidence_ref": evidence_ref or None,
+        "trusted_proxy_auth_status": trusted_proxy.get("status"),
+        "trusted_proxy_issuer_pinned": bool(trusted_proxy.get("issuer_pinned")),
+        "app_native_mtls": "not_implemented",
+    }
+    if raw_mode not in _PROXY_CONTROL_PLANE_MTLS_MODES:
+        return {
+            **base,
+            "status": "misconfigured",
+            "enforced": False,
+            "message": (
+                "Unsupported AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_MODE. Use disabled or delegated; "
+                "terminate and verify mTLS in ingress, Envoy, or a service mesh."
+            ),
+        }
+    if raw_mode == "disabled":
+        return {
+            **base,
+            "status": "disabled",
+            "enforced": False,
+            "message": "Proxy-to-control-plane mTLS posture is disabled or not declared.",
+        }
+
+    trusted_ok = trusted_proxy.get("status") == "ok"
+    status = "ok" if client_ca_ref and evidence_ref and trusted_ok else "needs_evidence"
+    missing = []
+    if not client_ca_ref:
+        missing.append("AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_CLIENT_CA_REF")
+    if not evidence_ref:
+        missing.append("AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_EVIDENCE_REF")
+    if not trusted_ok:
+        missing.append("trusted proxy auth with issuer pinning")
+    return {
+        **base,
+        "status": status,
+        "enforced": True,
+        "missing_evidence": missing,
+        "message": (
+            "Delegated mTLS is declared and backed by client-CA evidence plus trusted-proxy issuer pinning."
+            if status == "ok"
+            else "Delegated mTLS is declared, but operator evidence is incomplete."
+        ),
+    }
+
+
 def _hsts_max_age_seconds() -> int:
     raw = (os.environ.get("AGENT_BOM_HSTS_MAX_AGE_SECONDS") or "31536000").strip()
     try:

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -518,6 +518,7 @@ async def auth_policy(request: Request) -> dict:
     from agent_bom.api.auth import get_api_key_policy
     from agent_bom.api.compliance_signing import describe_signing_posture
     from agent_bom.api.middleware import (
+        describe_proxy_control_plane_mtls_posture,
         describe_security_header_posture,
         get_auth_runtime_status,
         get_rate_limit_key_status,
@@ -565,6 +566,7 @@ async def auth_policy(request: Request) -> dict:
         },
         "rate_limit_runtime": rl_runtime,
         "trusted_proxy_auth": get_trusted_proxy_auth_status(),
+        "proxy_control_plane_mtls": describe_proxy_control_plane_mtls_posture(),
         "security_headers": describe_security_header_posture(),
         "secret_integrity": {
             "audit_hmac": describe_audit_hmac_status(),

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -23,6 +23,7 @@ from agent_bom.api import server as _server_mod
 from agent_bom.api import stores as _stores
 from agent_bom.api.middleware import (
     APIKeyMiddleware,
+    describe_proxy_control_plane_mtls_posture,
     get_rate_limit_key_status,
     get_rate_limit_runtime_status,
     get_trusted_proxy_auth_status,
@@ -72,6 +73,11 @@ def _clear_rate_limit_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("AGENT_BOM_REQUIRE_SCIM", raising=False)
     monkeypatch.delenv("AGENT_BOM_SECRET_PROVIDER", raising=False)
     monkeypatch.delenv("AGENT_BOM_EXTERNAL_SECRETS_ENABLED", raising=False)
+    monkeypatch.delenv("AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_MODE", raising=False)
+    monkeypatch.delenv("AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_PROVIDER", raising=False)
+    monkeypatch.delenv("AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_CLIENT_CA_REF", raising=False)
+    monkeypatch.delenv("AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_EVIDENCE_REF", raising=False)
+    monkeypatch.delenv("AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_CERT_HEADER", raising=False)
 
 
 def _reload_config() -> None:
@@ -192,6 +198,9 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "shared_across_replicas" in body["rate_limit_runtime"]
     assert "configured_api_replicas" in body["rate_limit_runtime"]
     assert "fail_closed" in body["rate_limit_runtime"]
+    assert body["proxy_control_plane_mtls"]["mode"] == "disabled"
+    assert body["proxy_control_plane_mtls"]["status"] == "disabled"
+    assert body["proxy_control_plane_mtls"]["app_native_mtls"] == "not_implemented"
     assert body["security_headers"]["hsts"]["preload"] is False
     assert body["security_headers"]["hsts"]["header"] == "max-age=31536000; includeSubDomains"
     assert body["security_headers"]["csp"]["dashboard"]["mode"] in {"inline_compat", "hash_manifest"}
@@ -251,6 +260,43 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
         "google_cloud_identity",
     }
     assert "service_keys" in body["identity_provisioning"]["session_revocation"]
+
+
+def test_proxy_control_plane_mtls_posture_requires_delegated_evidence(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_rate_limit_env(monkeypatch)
+    monkeypatch.setenv("AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_MODE", "delegated")
+    posture = describe_proxy_control_plane_mtls_posture()
+
+    assert posture["mode"] == "delegated"
+    assert posture["status"] == "needs_evidence"
+    assert posture["enforced"] is True
+    assert "AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_CLIENT_CA_REF" in posture["missing_evidence"]
+    assert "trusted proxy auth with issuer pinning" in posture["missing_evidence"]
+
+
+def test_proxy_control_plane_mtls_posture_reports_ok_when_delegated_and_attested(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_rate_limit_env(monkeypatch)
+    monkeypatch.setenv("AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_MODE", "delegated")
+    monkeypatch.setenv("AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_PROVIDER", "istio")
+    monkeypatch.setenv("AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_CLIENT_CA_REF", "secret/agent-bom/proxy-client-ca")
+    monkeypatch.setenv(
+        "AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_EVIDENCE_REF",
+        "deploy/helm/agent-bom/templates/controlplane-istio-peer-authentication.yaml",
+    )
+    monkeypatch.setenv("AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_CERT_HEADER", "x-forwarded-client-cert")
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", PROXY_SECRET)
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH_ISSUER", "edge-envoy")
+
+    posture = describe_proxy_control_plane_mtls_posture()
+
+    assert posture["status"] == "ok"
+    assert posture["provider"] == "istio"
+    assert posture["client_ca_ref_configured"] is True
+    assert posture["client_cert_header_configured"] is True
+    assert posture["trusted_proxy_auth_status"] == "ok"
+    assert posture["trusted_proxy_issuer_pinned"] is True
+    assert posture["missing_evidence"] == []
 
 
 def test_auth_policy_redacts_oidc_config_errors(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Summary
- add non-secret proxy-to-control-plane mTLS posture to /v1/auth/policy
- document the supported delegated pattern for ingress, Envoy, and service mesh mTLS
- keep the boundary explicit: agent-bom does not terminate app-native mTLS in FastAPI; trusted-proxy shared-secret attestation and issuer pinning remain required
- add regression coverage for disabled, incomplete delegated, and fully attested delegated posture states

Why
#1898 is the remaining #1839 defense-in-depth slice. The release-safe design is to surface delegated mTLS as operator posture instead of overclaiming app-native TLS termination. Operators can now prove whether proxy/control-plane mTLS is disabled, declared but missing evidence, or backed by client-CA evidence plus issuer-pinned trusted-proxy auth.

Validation
- uv run pytest tests/test_api_operator_policy.py -q
- uv run ruff check src/agent_bom/api/middleware.py src/agent_bom/api/routes/enterprise.py tests/test_api_operator_policy.py
- uv run mypy src/agent_bom/api/middleware.py src/agent_bom/api/routes/enterprise.py
- git diff --check
- pre-commit hooks on commit

Refs #1839
Closes #1898