### PR TITLE
security: fail closed clustered browser auth

### DIFF
--- a/src/agent_bom/api/browser_session.py
+++ b/src/agent_bom/api/browser_session.py
@@ -31,6 +31,26 @@ class BrowserSessionError(Exception):
     """Raised when a browser session token is absent, invalid, or expired."""
 
 
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _configured_api_replicas() -> int:
+    raw = os.environ.get("AGENT_BOM_CONTROL_PLANE_REPLICAS", "").strip()
+    if not raw:
+        return 1
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        _logger.warning("Invalid AGENT_BOM_CONTROL_PLANE_REPLICAS=%r; defaulting to 1", raw)
+        return 1
+
+
+def persistent_browser_session_signing_required() -> bool:
+    """Clustered control planes need a stable key shared by every replica."""
+    return _configured_api_replicas() > 1 or _env_flag("AGENT_BOM_REQUIRE_BROWSER_SESSION_SIGNING_KEY")
+
+
 def _b64encode(raw: bytes) -> str:
     return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
 
@@ -50,6 +70,8 @@ def _signing_key() -> bytes:
             600_000,
             dklen=32,
         )
+    if persistent_browser_session_signing_required():
+        raise BrowserSessionError("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY is required for clustered browser-session auth")
     _logger.warning(
         "AGENT_BOM_BROWSER_SESSION_SIGNING_KEY is not set; browser sessions use an ephemeral signing key "
         "and will be invalid after process restart"

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -71,6 +71,23 @@ def _env_flag(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
+def clustered_control_plane_required() -> bool:
+    """Return true when process-local control-plane state is unsafe."""
+    return _env_flag("AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT") or _configured_api_replicas() > 1
+
+
+def static_api_key_allowed() -> bool:
+    """Static API keys are a single-tenant pilot shortcut, not clustered auth."""
+    return not clustered_control_plane_required()
+
+
+def static_api_key_rejection_message() -> str:
+    return (
+        "AGENT_BOM_API_KEY static-key auth is disabled for clustered control planes. "
+        "Use tenant-scoped API keys, OIDC, SAML, or trusted proxy auth instead."
+    )
+
+
 def _secret_min_bytes(secret: str) -> int:
     return len(secret.encode("utf-8"))
 
@@ -544,6 +561,8 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
 
     def __init__(self, app: ASGIApp, api_key: str) -> None:
         super().__init__(app)
+        if api_key and not static_api_key_allowed():
+            raise RuntimeError(static_api_key_rejection_message())
         self._api_key = api_key
         self._trusted_proxy_auth = _env_flag("AGENT_BOM_TRUST_PROXY_AUTH")
         self._trusted_proxy_secret = os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", "").strip()
@@ -938,7 +957,7 @@ def _configured_api_replicas() -> int:
 
 
 def _shared_rate_limit_required() -> bool:
-    return _env_flag("AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT") or _configured_api_replicas() > 1
+    return clustered_control_plane_required()
 
 
 def get_rate_limit_runtime_status() -> dict[str, object]:

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -254,18 +254,21 @@ def _set_browser_session_cookie(
     key_id: str | None = None,
     scopes: list[str] | None = None,
 ) -> None:
-    from agent_bom.api.browser_session import CSRF_COOKIE_NAME, SESSION_COOKIE_NAME, create_browser_session_token
+    from agent_bom.api.browser_session import CSRF_COOKIE_NAME, SESSION_COOKIE_NAME, BrowserSessionError, create_browser_session_token
 
     max_age = _session_cookie_max_age()
-    token, csrf = create_browser_session_token(
-        subject=subject,
-        role=role,
-        tenant_id=tenant_id,
-        auth_method=auth_method,
-        key_id=key_id,
-        scopes=scopes,
-        max_age_seconds=max_age,
-    )
+    try:
+        token, csrf = create_browser_session_token(
+            subject=subject,
+            role=role,
+            tenant_id=tenant_id,
+            auth_method=auth_method,
+            key_id=key_id,
+            scopes=scopes,
+            max_age_seconds=max_age,
+        )
+    except BrowserSessionError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
     secure = _session_cookie_secure(request)
     response.set_cookie(
         SESSION_COOKIE_NAME,
@@ -329,6 +332,10 @@ async def create_browser_session(request: Request, response: Response, body: Bro
 
     static_key = os.environ.get("AGENT_BOM_API_KEY", "")
     if static_key and secrets.compare_digest(raw_key, static_key):
+        from agent_bom.api.middleware import static_api_key_allowed, static_api_key_rejection_message
+
+        if not static_api_key_allowed():
+            raise HTTPException(status_code=503, detail=static_api_key_rejection_message())
         _set_browser_session_cookie(
             response,
             request,

--- a/src/agent_bom/api/secret_lifecycle.py
+++ b/src/agent_bom/api/secret_lifecycle.py
@@ -22,6 +22,20 @@ def _env_int(name: str) -> int | None:
     return parsed if parsed >= 0 else None
 
 
+def _configured_api_replicas() -> int:
+    raw = os.environ.get("AGENT_BOM_CONTROL_PLANE_REPLICAS", "").strip()
+    if not raw:
+        return 1
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 1
+
+
+def _browser_signing_key_required() -> bool:
+    return _configured_api_replicas() > 1 or _env_enabled("AGENT_BOM_REQUIRE_BROWSER_SESSION_SIGNING_KEY")
+
+
 def _rotation_posture(
     *,
     configured: bool,
@@ -150,24 +164,13 @@ def _env_secret_posture(
 
 def _browser_session_signing_posture() -> dict[str, Any]:
     dedicated = os.environ.get("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY", "").strip()
-    audit = os.environ.get("AGENT_BOM_AUDIT_HMAC_KEY", "").strip()
-    static_api = os.environ.get("AGENT_BOM_API_KEY", "").strip()
+    required = _browser_signing_key_required()
 
     if dedicated:
         source = "AGENT_BOM_BROWSER_SESSION_SIGNING_KEY"
-        inherited_from = None
-        configured = True
-    elif audit:
-        source = "AGENT_BOM_AUDIT_HMAC_KEY"
-        inherited_from = "audit_hmac"
-        configured = True
-    elif static_api:
-        source = "AGENT_BOM_API_KEY"
-        inherited_from = "static_api_key"
         configured = True
     else:
         source = None
-        inherited_from = None
         configured = False
 
     rotation = _rotation_posture(
@@ -176,19 +179,24 @@ def _browser_session_signing_posture() -> dict[str, Any]:
         last_rotated_env="AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_LAST_ROTATED",
         rotation_days_env="AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_ROTATION_DAYS",
         max_age_days_env="AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_MAX_AGE_DAYS",
-        not_configured_status="ephemeral",
+        not_configured_status="missing_required" if required else "ephemeral",
         not_configured_message=(
-            "Browser sessions use a process-ephemeral signing key. Sessions are invalidated on restart and rotation age is not stable."
+            "Browser sessions require AGENT_BOM_BROWSER_SESSION_SIGNING_KEY because the control plane is clustered."
+            if required
+            else (
+                "Browser sessions use a process-ephemeral signing key. Sessions are invalidated on restart and rotation age is not stable."
+            )
         ),
     )
     return {
         "name": "browser_session_signing",
-        "status": "configured" if configured else "ephemeral",
+        "status": "configured" if configured else ("missing_required" if required else "ephemeral"),
         "configured": configured,
-        "required": False,
+        "required": required,
         "source": source,
         "dedicated_key_configured": bool(dedicated),
-        "inherited_from": inherited_from,
+        "inherited_from": None,
+        "configured_api_replicas": _configured_api_replicas(),
         **rotation,
     }
 

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -16,6 +16,7 @@ from agent_bom.api.browser_session import (
     CSRF_COOKIE_NAME,
     CSRF_HEADER_NAME,
     SESSION_COOKIE_NAME,
+    BrowserSessionError,
     create_browser_session_token,
     revoke_browser_session_token,
 )
@@ -87,6 +88,39 @@ def test_browser_session_cookies_use_strict_samesite(monkeypatch):
     assert all("SameSite=strict" in value for value in set_cookie_values)
     assert any("HttpOnly" in value and SESSION_COOKIE_NAME in value for value in set_cookie_values)
     assert any(CSRF_COOKIE_NAME in value for value in set_cookie_values)
+
+
+def test_browser_session_requires_persistent_key_when_clustered(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY", raising=False)
+    monkeypatch.setenv("AGENT_BOM_CONTROL_PLANE_REPLICAS", "2")
+
+    with pytest.raises(BrowserSessionError, match="BROWSER_SESSION_SIGNING_KEY is required"):
+        create_browser_session_token(
+            subject="dashboard-user",
+            role="admin",
+            tenant_id="tenant-alpha",
+            auth_method="browser_session",
+            max_age_seconds=300,
+        )
+
+
+@pytest.mark.asyncio
+async def test_static_browser_session_exchange_fails_closed_when_clustered(monkeypatch):
+    from fastapi import HTTPException
+
+    from agent_bom.api.routes import enterprise
+
+    enterprise._AUTH_SESSION_ATTEMPTS.clear()
+    monkeypatch.setenv("AGENT_BOM_API_KEY", "valid-key")
+    monkeypatch.setenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY", "stable-browser-session-key")
+    monkeypatch.setenv("AGENT_BOM_CONTROL_PLANE_REPLICAS", "2")
+    request = SimpleNamespace(headers={}, client=SimpleNamespace(host="203.0.113.20"))
+
+    with pytest.raises(HTTPException) as error:
+        await enterprise.create_browser_session(request, Response(), enterprise.BrowserSessionRequest(api_key="valid-key"))
+
+    assert error.value.status_code == 503
+    assert "static-key auth is disabled" in error.value.detail
 
 
 def test_trust_headers_present():
@@ -221,6 +255,24 @@ def test_api_key_middleware_accepts_signed_browser_session(monkeypatch):
         "tenant": "tenant-alpha",
         "method": "browser_session_static_api_key",
     }
+
+
+def test_static_api_key_middleware_fails_closed_when_clustered(monkeypatch):
+    """The static key shortcut must not pin all tenants to default in clustered mode."""
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    async def dummy(request):
+        return StarletteJSONResponse({"ok": True})
+
+    monkeypatch.setenv("AGENT_BOM_CONTROL_PLANE_REPLICAS", "2")
+    test_app = Starlette(routes=[Route("/v1/test", dummy)])
+    test_app.add_middleware(APIKeyMiddleware, api_key="static-key")
+    client = TestClient(test_app)
+
+    with pytest.raises(RuntimeError, match="static-key auth is disabled"):
+        client.get("/v1/test", headers={"Authorization": "Bearer static-key"})
 
 
 def test_api_key_middleware_rejects_browser_session_without_csrf(monkeypatch):

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -64,6 +64,7 @@ def _clear_rate_limit_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_LAST_ROTATED", raising=False)
     monkeypatch.delenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_ROTATION_DAYS", raising=False)
     monkeypatch.delenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_MAX_AGE_DAYS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_REQUIRE_BROWSER_SESSION_SIGNING_KEY", raising=False)
     monkeypatch.delenv("AGENT_BOM_SCIM_BEARER_TOKEN", raising=False)
     monkeypatch.delenv("AGENT_BOM_SCIM_BEARER_TOKEN_ID", raising=False)
     monkeypatch.delenv("AGENT_BOM_SCIM_BEARER_TOKEN_LAST_ROTATED", raising=False)
@@ -215,7 +216,11 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
         "max_age_exceeded",
     }
     assert body["secret_lifecycle"]["status"] in {"ok", "attention_required", "blocked"}
-    assert body["secret_lifecycle"]["secrets"]["browser_session_signing"]["status"] in {"configured", "ephemeral"}
+    assert body["secret_lifecycle"]["secrets"]["browser_session_signing"]["status"] in {
+        "configured",
+        "ephemeral",
+        "missing_required",
+    }
     assert body["secret_lifecycle"]["secrets"]["scim_bearer"]["status"] in {"configured", "not_configured", "missing_required"}
     assert body["secret_lifecycle"]["external_secret_provider"]["status"] in {"configured", "not_declared"}
     assert body["tenant_quotas"]["active_scan_jobs"] >= 1
@@ -354,6 +359,25 @@ def test_auth_policy_reports_secret_lifecycle_posture(monkeypatch: pytest.Monkey
 
     endpoint = client.get("/v1/auth/secrets/lifecycle").json()
     assert endpoint["secrets"]["scim_bearer"]["rotation_status"] == "max_age_exceeded"
+
+
+def test_auth_policy_requires_browser_session_signing_key_for_clustered_control_plane(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_rate_limit_env(monkeypatch)
+    monkeypatch.setenv("AGENT_BOM_CONTROL_PLANE_REPLICAS", "2")
+
+    from agent_bom.api.secret_lifecycle import describe_secret_lifecycle_posture
+
+    lifecycle = describe_secret_lifecycle_posture()
+    signing = lifecycle["secrets"]["browser_session_signing"]
+
+    assert signing["status"] == "missing_required"
+    assert signing["required"] is True
+    assert signing["configured"] is False
+    assert signing["configured_api_replicas"] == 2
+    assert signing["rotation_status"] == "missing_required"
+    assert "AGENT_BOM_BROWSER_SESSION_SIGNING_KEY" in signing["rotation_message"]
 
 
 def test_auth_secret_rotation_plan_is_non_secret_and_actionable(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Summary
- fail closed when AGENT_BOM_API_KEY static-key auth is used with clustered control-plane posture
- require AGENT_BOM_BROWSER_SESSION_SIGNING_KEY for clustered browser-session issuance/verification
- make secret lifecycle posture report browser-session signing as missing_required instead of implying audit/static keys sign sessions
- add regression coverage for static-key rejection, clustered browser-session signing, and operator posture

Why
#1928 is the focused release-risk fix from the v0.81.3 audit. Static-key auth is acceptable for single-node pilots, but in clustered/multi-tenant control planes it silently pins all access to tenant_id=default. Browser sessions also need a stable signing key shared by every replica; process-ephemeral signing is fine for local pilots but brittle in clustered deployments.

Validation
- uv run pytest tests/test_api_hardening.py::test_browser_session_requires_persistent_key_when_clustered tests/test_api_hardening.py::test_static_browser_session_exchange_fails_closed_when_clustered tests/test_api_hardening.py::test_static_api_key_middleware_fails_closed_when_clustered tests/test_api_operator_policy.py::test_auth_policy_requires_browser_session_signing_key_for_clustered_control_plane -q
- uv run pytest tests/test_api_hardening.py tests/test_api_operator_policy.py -q
- uv run ruff check src/agent_bom/api/browser_session.py src/agent_bom/api/middleware.py src/agent_bom/api/routes/enterprise.py src/agent_bom/api/secret_lifecycle.py tests/test_api_hardening.py tests/test_api_operator_policy.py
- uv run mypy src/agent_bom/api/browser_session.py src/agent_bom/api/middleware.py src/agent_bom/api/routes/enterprise.py src/agent_bom/api/secret_lifecycle.py
- git diff --check
- pre-commit hooks on commit

Closes #1928
Refs #1750
Refs #1839