### PR TITLE
docs: define enterprise support model

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Backend defaults:
 | trust model, auth, tenant isolation | [ENTERPRISE_SECURITY_PLAYBOOK.md](docs/ENTERPRISE_SECURITY_PLAYBOOK.md) |
 | procurement security posture | [ENTERPRISE_SECURITY_POSTURE.md](docs/ENTERPRISE_SECURITY_POSTURE.md) |
 | procurement evidence packet | [ENTERPRISE_PROCUREMENT_PACKET.md](docs/ENTERPRISE_PROCUREMENT_PACKET.md) |
+| support, patch, and disclosure model | [ENTERPRISE_SUPPORT_MODEL.md](docs/ENTERPRISE_SUPPORT_MODEL.md) |
 | SOC 2 / ISO / CIS control mapping | [CONTROL_MAPPING.md](docs/CONTROL_MAPPING.md) |
 
 <details>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,10 @@
 
 Report privately via [GitHub Security Advisories](https://github.com/msaad00/agent-bom/security/advisories/new).
 
+For procurement-facing support boundaries, patch cadence, escalation paths, and
+release-note security language, see
+[docs/ENTERPRISE_SUPPORT_MODEL.md](docs/ENTERPRISE_SUPPORT_MODEL.md).
+
 **Response SLA:**
 - Acknowledgement within **48 hours**
 - Triage and severity assessment within **5 business days**
@@ -18,6 +22,10 @@ Report privately via [GitHub Security Advisories](https://github.com/msaad00/age
 |---------|-----------|
 | Latest  | ✓ Yes     |
 | < Latest | ✗ No — upgrade to the latest release |
+
+The open-source project supports the latest released tag. Older release lines
+are not maintained as long-term support branches unless a separate commercial
+or customer-specific agreement exists.
 
 ## Security Design
 

--- a/docs/ENTERPRISE_PROCUREMENT_PACKET.md
+++ b/docs/ENTERPRISE_PROCUREMENT_PACKET.md
@@ -24,7 +24,7 @@ controls are complete.
 | Security testing | CodeQL, gitleaks, dependency review, pip audit, fuzzing, SSRF/authz/tenant tests | `docs/PENTEST_READINESS.md`, `.github/workflows/codeql.yml`, `.github/workflows/pr-security-gate.yml` |
 | Operations | Helm profiles, backup/restore, airgap bundle, runtime operations | `site-docs/deployment/control-plane-helm.md`, `site-docs/deployment/backup-restore.md`, `site-docs/deployment/airgapped-image-bundle.md` |
 | Scale | fleet/graph pagination and benchmark targets documented; larger enterprise evidence still expanding | `docs/PERFORMANCE_BENCHMARKS.md`, `site-docs/deployment/performance-and-sizing.md` |
-| Support and disclosure | product vulnerability disclosure documented; customer incident process remains customer-owned | `SECURITY.md`, `docs/ENTERPRISE_SECURITY_POSTURE.md` |
+| Support and disclosure | product vulnerability disclosure, patch cadence, support boundaries, and customer incident ownership documented | `SECURITY.md`, `docs/ENTERPRISE_SUPPORT_MODEL.md`, `docs/ENTERPRISE_SECURITY_POSTURE.md` |
 
 ## Customer-Owned Evidence
 
@@ -39,6 +39,8 @@ artifacts alongside the product evidence above:
 - SIEM routing, alert ownership, incident response, and escalation contacts
 - data retention schedule, DPA, subprocessor review, and support-access policy
 - release approval record for the exact tag deployed
+- internal escalation contacts for platform, security, IdP, cloud, and database
+  owners
 
 ## Evidence Collection Checklist
 
@@ -56,6 +58,9 @@ artifacts alongside the product evidence above:
    customer's latest production restore exercise.
 7. Attach customer-owned IdP, KMS, network, retention, and incident-response
    evidence.
+8. Attach the self-hosted support boundary and escalation record from
+   `docs/ENTERPRISE_SUPPORT_MODEL.md`, plus any customer-owned support contract
+   or internal incident workflow.
 
 ## Current Gaps Before Fortune-500 Procurement Claims
 
@@ -63,8 +68,9 @@ These tracks are intentionally explicit so the release does not overclaim:
 
 - deeper SOC 2 / ISO / CIS / NIST mapping from each control to exact tests,
   logs, and exported evidence
-- procurement-ready legal templates such as customer-owned DPA, subprocessors,
-  and support-access language
+- procurement-ready legal templates such as customer-owned DPA and
+  subprocessors; support boundaries are documented, but paid support terms
+  remain separate from the OSS project
 - real Vault/KMS/Secrets Manager rotation adapters beyond posture and operator
   planning
 - published IdP compatibility evidence for Okta, Microsoft Entra, and Google

--- a/docs/ENTERPRISE_SECURITY_POSTURE.md
+++ b/docs/ENTERPRISE_SECURITY_POSTURE.md
@@ -139,6 +139,9 @@ Relevant security signals:
 Incident response ownership remains with the self-hosting organization. The
 published security policy defines maintainer disclosure SLAs for product
 vulnerabilities; customer deployment incidents follow customer process.
+`docs/ENTERPRISE_SUPPORT_MODEL.md` defines the supported-version window, patch
+cadence, escalation paths, and the boundary between product vulnerabilities and
+customer-operated incidents.
 
 ## Security Header Posture
 
@@ -192,6 +195,7 @@ A procurement packet should include:
 - `docs/THREAT_MODEL.md`
 - `docs/SUPPLY_CHAIN.md`
 - `docs/RELEASE_VERIFICATION.md`
+- `docs/ENTERPRISE_SUPPORT_MODEL.md`
 - `docs/PENTEST_READINESS.md`
 - `site-docs/deployment/customer-data-and-support-boundary.md`
 - customer-owned DPA, subprocessors, support-access policy, and retention

--- a/docs/ENTERPRISE_SUPPORT_MODEL.md
+++ b/docs/ENTERPRISE_SUPPORT_MODEL.md
@@ -1,0 +1,143 @@
+# Enterprise Support, Patch, And Disclosure Model
+
+This document defines the support and response model for self-hosted
+`agent-bom` deployments. It is written for procurement and security review. It
+does not create a paid support contract, hosted-service SLA, or legal DPA.
+
+## Support Channels
+
+| Channel | Use for | Boundary |
+|---|---|---|
+| GitHub issues | bugs, feature requests, documentation gaps, non-sensitive operational questions | public, best-effort OSS support |
+| GitHub Security Advisories | suspected product vulnerabilities, exploit details, bypasses, sensitive reports | private security disclosure path |
+| Customer-owned incident process | compromised hosts, leaked customer credentials, IdP events, cloud account incidents | operated by the deploying organization |
+
+Do not post secrets, customer data, exploit details, private logs, or tenant
+identifiers in public GitHub issues.
+
+## Supported Version Window
+
+For the open-source project, the supported version is the latest released tag.
+Security fixes target the latest release line first. Older releases are not
+maintained as long-term support branches unless a separate commercial or
+customer-specific agreement exists.
+
+| Version line | OSS support posture |
+|---|---|
+| Latest release | security fixes and compatibility fixes target this line |
+| Previous releases | upgrade guidance only unless a coordinated security embargo requires a temporary backport |
+| Unreleased `main` | development branch, not a supported production version |
+
+Operators should pin exact release tags and verify release artifacts with
+`docs/RELEASE_VERIFICATION.md` before production rollout.
+
+## Patch Cadence
+
+| Patch type | Target behavior |
+|---|---|
+| Critical security fix | patched release as soon as practical after validation; coordinated with GHSA/CVE publication when warranted |
+| High security fix | patched release after triage, regression tests, and release verification pass |
+| Medium/low security fix | next scheduled patch or minor release unless active exploitation changes priority |
+| Non-security bug fix | regular release cadence, prioritized by impact and reproducibility |
+| Documentation-only clarification | can ship independently when it reduces operator risk or procurement ambiguity |
+
+Release notes should call out security-impacting changes explicitly under a
+security or hardening heading. Use concrete language: what changed, who is
+affected, whether the default posture changed, and whether operators must rotate
+secrets, update policy, or change deployment configuration.
+
+## Vulnerability Severity And Response Targets
+
+Security reports are triaged with CVSS-style severity and product-specific
+context. The targets below are response goals, not contractual SLAs.
+
+| Severity | Examples | Target response |
+|---|---|---|
+| Critical | remote code execution in default control-plane path, auth bypass, tenant isolation bypass with cross-tenant data exposure | acknowledge within 48 hours; triage within 5 business days; urgent patch target after validated fix |
+| High | sandbox escape in agent-bom-managed process, privilege escalation, stored secret exposure, reliable policy bypass | acknowledge within 48 hours; triage within 5 business days; patch in the next security release |
+| Medium | denial-of-service requiring authenticated access, detector bypass with limited impact, hardening gap in non-default mode | acknowledge within 48 hours; triage within 5 business days; schedule into a normal patch train |
+| Low | documentation ambiguity, warning-quality issue, non-sensitive information exposure, defense-in-depth polish | acknowledge and track publicly or privately as appropriate |
+
+Active exploitation, public proof-of-concept code, or a credible downstream
+supply-chain risk can raise priority regardless of the initial severity.
+
+## Responsible Disclosure
+
+Report suspected vulnerabilities privately through GitHub Security Advisories:
+
+<https://github.com/msaad00/agent-bom/security/advisories/new>
+
+The disclosure flow is:
+
+1. Reporter submits a private advisory with affected version, impact, and
+   reproduction details.
+2. Maintainer acknowledges receipt and assigns an initial severity.
+3. Maintainer validates the issue, prepares a private fix branch, and requests
+   a CVE/GHSA when warranted.
+4. Patch, release notes, and advisory publication are coordinated so users can
+   upgrade before exploit details are broadly amplified.
+5. Reporter credit is included unless anonymity is requested.
+
+The coordinated disclosure embargo policy remains the source of truth in
+`SECURITY.md`.
+
+## Customer Incident Versus Product Vulnerability
+
+`agent-bom` is a self-hosted product. The deploying organization owns the
+runtime environment, network, identity provider, cloud accounts, data stores,
+secrets, endpoint controls, monitoring, and incident response.
+
+| Scenario | Primary owner |
+|---|---|
+| A bug in agent-bom allows auth bypass, cross-tenant leakage, policy bypass, or sandbox escape | agent-bom security disclosure process |
+| A customer cloud credential is leaked outside agent-bom | customer incident process |
+| A customer's IdP, ingress, service mesh, or KMS is misconfigured | customer platform/security team |
+| A vulnerable dependency affects agent-bom release artifacts | agent-bom security disclosure process |
+| A customer-operated database, bucket, or backup is exposed | customer incident process |
+
+When a customer incident reveals a product weakness, open a private security
+advisory with the product-specific evidence and keep customer incident data out
+of public issues.
+
+## Escalation Path For Self-Hosted Deployments
+
+For production-impacting self-hosted issues:
+
+1. Confirm the release tag, commit SHA, deployment mode, and whether local
+   changes are present.
+2. Capture non-secret posture from `/v1/auth/policy`,
+   `/v1/auth/secrets/lifecycle`, `/v1/posture/enrichment`, `/readyz`, and
+   `/metrics`.
+3. Attach sanitized logs, sanitized Helm values, and failing command output.
+4. Use a public GitHub issue for non-sensitive bugs or a private security
+   advisory for vulnerability evidence.
+5. Keep raw secrets, tenant data, customer identifiers, kubeconfigs, and cloud
+   credentials out of all public artifacts.
+
+## Release Note Security Language
+
+Security-impacting release notes should include:
+
+- affected surface
+- previous behavior
+- new behavior
+- default posture
+- operator action required
+- linked issue or advisory
+- validation summary
+
+Example:
+
+```md
+Security: MCP sandbox mounts now reject sensitive host paths by default. Prior
+versions allowed broader operator-supplied mounts in isolated mode. Operators
+using custom `--sandbox-mount` values should verify that only intended
+read-only project paths are mounted. Refs #1905.
+```
+
+## Non-Claims
+
+This model does not claim SOC 2, ISO 27001 certification, FedRAMP
+authorization, hosted SaaS availability SLAs, 24/7 pager coverage, or customer
+incident-response ownership. Those require separate legal, operational, and
+external attestation work.


### PR DESCRIPTION
Summary
- add a procurement-facing enterprise support, patch, and disclosure model
- define latest-release support posture, patch cadence, severity response targets, disclosure flow, self-hosted escalation path, and customer incident boundaries
- link the model from SECURITY.md, README, enterprise security posture, and the procurement packet

Why
#1809 was the remaining support/procurement docs gap before release. This keeps the wording honest: OSS support is latest-release and best-effort, security disclosure is private through GHSA, customer deployment incidents remain customer-owned, and paid/hosted support claims are explicitly non-claims.

Validation
- git diff --check
- rg -n "ENTERPRISE_SUPPORT_MODEL|Fortune|SLA|TODO|TBD|turnkey|guarantee" README.md SECURITY.md docs/ENTERPRISE_SUPPORT_MODEL.md docs/ENTERPRISE_SECURITY_POSTURE.md docs/ENTERPRISE_PROCUREMENT_PACKET.md
- uv run python -m compileall -q src tests
- pre-commit hooks on commit

Closes #1809
Refs #1805
Refs #1808