### PR TITLE
ci: block tracked Finder duplicate artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Block Finder duplicate artifacts
+        run: python scripts/check_duplicate_artifacts.py
+
       - uses: ./.github/actions/setup-python
         with:
           python-version: '3.11'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,9 @@ jobs:
           print(f"CHANGELOG entry present: {tag}")
           PY
 
+      - name: Block Finder duplicate artifacts
+        run: python3 scripts/check_duplicate_artifacts.py
+
   docs-site:
     name: Rebuild and deploy docs
     needs: version-guard

--- a/scripts/check_duplicate_artifacts.py
+++ b/scripts/check_duplicate_artifacts.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Fail when Finder-style duplicate artifacts are tracked.
+
+macOS Finder copies such as ``foo 2.py`` and duplicated directories such as
+``contracts/v1 2`` are easy to miss in reviews but can be included in source
+distributions and release archives. This guard checks tracked paths only, so
+local virtualenvs, node_modules, and generated build output do not create noise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_DUPLICATE_COMPONENT_RE = re.compile(r"^.+ [2-9](?:\.[^.\\/]+)?$")
+_IGNORED_PREFIXES = (
+    ".git/",
+    ".venv/",
+    "node_modules/",
+    "ui/node_modules/",
+    "ui/out/",
+    "site/",
+)
+
+
+def _tracked_paths() -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=False,
+    )
+    return [part.decode("utf-8", errors="replace") for part in result.stdout.split(b"\0") if part]
+
+
+def _load_paths(path: Path) -> list[str]:
+    return [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def find_duplicate_artifacts(paths: list[str]) -> list[str]:
+    matches: list[str] = []
+    for raw in paths:
+        normalized = raw.replace("\\", "/")
+        if normalized.startswith("./"):
+            normalized = normalized[2:]
+        if not normalized or normalized.startswith(_IGNORED_PREFIXES):
+            continue
+        components = normalized.split("/")
+        if any(_DUPLICATE_COMPONENT_RE.match(component) for component in components):
+            matches.append(normalized)
+    return sorted(set(matches))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--paths-file",
+        type=Path,
+        help="Optional newline-delimited path list for tests; defaults to git ls-files.",
+    )
+    args = parser.parse_args(argv)
+
+    paths = _load_paths(args.paths_file) if args.paths_file else _tracked_paths()
+    duplicates = find_duplicate_artifacts(paths)
+    if not duplicates:
+        print("No tracked Finder-style duplicate artifacts found.")
+        return 0
+
+    print("Tracked Finder-style duplicate artifacts found:", file=sys.stderr)
+    for path in duplicates:
+        print(f"- {path}", file=sys.stderr)
+    print(
+        "\nRemove these files or rename them intentionally before merging/releasing.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_duplicate_artifact_guard.py
+++ b/tests/test_duplicate_artifact_guard.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_duplicate_artifacts import find_duplicate_artifacts, main
+
+
+def test_duplicate_artifact_guard_detects_finder_copies() -> None:
+    paths = [
+        "src/agent_bom/model_advisories.py",
+        "src/agent_bom/model_advisories 2.py",
+        "contracts/v1/scan.schema.json",
+        "contracts/v1 2/scan.schema.json",
+        "tests/test_cloud_resilience 3.py",
+    ]
+
+    assert find_duplicate_artifacts(paths) == [
+        "contracts/v1 2/scan.schema.json",
+        "src/agent_bom/model_advisories 2.py",
+        "tests/test_cloud_resilience 3.py",
+    ]
+
+
+def test_duplicate_artifact_guard_ignores_untracked_noise_prefixes() -> None:
+    paths = [
+        "ui/node_modules/package 2/index.js",
+        "ui/out/graph 2/index.html",
+        "site/deployment/docker 2/index.html",
+        ".venv/lib/python/site-packages/pkg 2.py",
+        "src/agent_bom/model_advisories.py",
+    ]
+
+    assert find_duplicate_artifacts(paths) == []
+
+
+def test_duplicate_artifact_guard_cli_returns_failure_for_duplicates(tmp_path: Path, capsys) -> None:
+    paths = tmp_path / "paths.txt"
+    paths.write_text("src/agent_bom/model_advisories 2.py\nsrc/agent_bom/model_advisories.py\n", encoding="utf-8")
+
+    assert main(["--paths-file", str(paths)]) == 1
+    captured = capsys.readouterr()
+    assert "model_advisories 2.py" in captured.err


### PR DESCRIPTION
Summary
- add a tracked-path guard that fails on Finder-style duplicate artifacts such as `foo 2.py`, `foo 3.py`, or `contracts/v1 2/...`
- wire the guard into protected CI and the release version gate so duplicates cannot ship in source distributions or release archives
- add focused tests for duplicate detection and ignored local/generated noise prefixes

Why
Current `main` no longer has tracked duplicate artifacts, but this was a real release-quality failure mode. This PR turns the one-time cleanup into a permanent guardrail instead of relying on manual review to catch stale Finder copies.

Validation
- python scripts/check_duplicate_artifacts.py
- uv run pytest tests/test_duplicate_artifact_guard.py -q
- git diff --check
- pre-commit hooks on commit

Refs P0 duplicate-artifact cleanup
Refs #1805