### PR TITLE
test(postgres): add real integration contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
     outputs:
       action: ${{ steps.classify.outputs.action }}
       alpine: ${{ steps.classify.outputs.alpine }}
+      postgres: ${{ steps.classify.outputs.postgres }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -43,19 +44,25 @@ jobs:
           changed="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
           action=false
           alpine=false
+          postgres=false
           if printf '%s\n' "$changed" | grep -Eq '^(action\.yml|\.github/actions/|tests/fixtures/test-(sbom|policy)\.json$)'; then
             action=true
           fi
           if printf '%s\n' "$changed" | grep -Eq '^(src/|tests/|pyproject\.toml|uv\.lock|Dockerfile|scripts/|\.github/actions/setup-python/)'; then
             alpine=true
           fi
+          if printf '%s\n' "$changed" | grep -Eq '^(src/agent_bom/api/postgres_|src/agent_bom/api/storage_schema\.py|tests/test_postgres_|\.github/workflows/ci\.yml$)'; then
+            postgres=true
+          fi
           echo "action=${action}" >> "$GITHUB_OUTPUT"
           echo "alpine=${alpine}" >> "$GITHUB_OUTPUT"
+          echo "postgres=${postgres}" >> "$GITHUB_OUTPUT"
           {
             echo "### PR path classification"
             echo ""
             echo "- GitHub Action dogfood required: \`${action}\`"
             echo "- Alpine/musl compatibility required: \`${alpine}\`"
+            echo "- Real Postgres integration required: \`${postgres}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # 1. Security Scanning
@@ -424,6 +431,45 @@ jobs:
           else
             uv run pytest tests/ -q --tb=short -m "not network"
           fi
+
+  postgres-integration:
+    name: Postgres Integration Contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: changes
+    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.postgres == 'true')
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: testpass
+          POSTGRES_DB: agentbom_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d agentbom_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      AGENT_BOM_POSTGRES_URL: postgresql://postgres:testpass@127.0.0.1:5432/agentbom_test
+      AGENT_BOM_POSTGRES_POOL_MIN_SIZE: "1"
+      AGENT_BOM_POSTGRES_POOL_MAX_SIZE: "4"
+      AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECONDS: "5"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: '3.11'
+
+      - name: Install Postgres test dependencies
+        run: uv sync --frozen --extra dev --extra api --extra postgres
+
+      - name: Run real Postgres storage contract
+        run: uv run pytest tests/test_postgres_integration.py -q --tb=short
 
   # 3b. Alpine/musl compatibility test
   # Runs the test suite inside an Alpine Linux container (musl libc) to catch

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -1,0 +1,88 @@
+"""Real PostgreSQL integration contract.
+
+These tests are intentionally opt-in for local runs. CI provides a Postgres
+service and sets AGENT_BOM_POSTGRES_URL so the storage contract is exercised
+against a real server instead of the MockConnection unit-test harness.
+"""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("AGENT_BOM_POSTGRES_URL"),
+    reason="AGENT_BOM_POSTGRES_URL is required for real Postgres integration tests",
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_postgres_pool():
+    from agent_bom.api import postgres_common
+
+    postgres_common.reset_pool()
+    yield
+    pool = postgres_common._pool
+    if pool is not None:
+        pool.close()
+    postgres_common.reset_pool()
+
+
+def test_postgres_job_store_real_roundtrip_and_tenant_filter():
+    from agent_bom.api.postgres_store import PostgresJobStore
+    from agent_bom.api.server import JobStatus, ScanJob, ScanRequest
+
+    store = PostgresJobStore()
+    suffix = uuid4().hex
+    job_id = f"pg-contract-{suffix}"
+    job = ScanJob(
+        job_id=job_id,
+        tenant_id=f"tenant-{suffix}",
+        triggered_by="ci-postgres-contract",
+        status=JobStatus.PENDING,
+        created_at="2026-04-25T00:00:00Z",
+        request=ScanRequest(format="json"),
+    )
+
+    store.put(job)
+
+    same_tenant = store.get(job_id, tenant_id=job.tenant_id)
+    other_tenant = store.get(job_id, tenant_id=f"other-{suffix}")
+
+    assert same_tenant is not None
+    assert same_tenant.job_id == job_id
+    assert same_tenant.triggered_by == "ci-postgres-contract"
+    assert other_tenant is None
+    assert any(item.job_id == job_id for item in store.list_all(tenant_id=job.tenant_id))
+
+
+def test_postgres_audit_log_real_roundtrip_and_schema_marker():
+    from agent_bom.api.audit_log import AuditEntry
+    from agent_bom.api.postgres_store import PostgresAuditLog, _get_pool
+    from agent_bom.api.storage_schema import CONTROL_PLANE_SCHEMA_VERSION
+
+    suffix = uuid4().hex
+    tenant_id = f"tenant-{suffix}"
+    store = PostgresAuditLog()
+    entry = AuditEntry(
+        action="scan",
+        actor="ci",
+        resource=f"job/{suffix}",
+        details={"tenant_id": tenant_id, "packages": 3},
+    )
+
+    store.append(entry)
+
+    entries = store.list_entries(action="scan", tenant_id=tenant_id, limit=5)
+    assert any(item.entry_id == entry.entry_id and item.verify() for item in entries)
+
+    with _get_pool().connection() as conn:
+        row = conn.execute(
+            "SELECT version FROM control_plane_schema_versions WHERE component = %s",
+            ("audit_log",),
+        ).fetchone()
+
+    assert row is not None
+    assert row[0] == CONTROL_PLANE_SCHEMA_VERSION


### PR DESCRIPTION
Summary
- add an opt-in real Postgres integration test file for job-store and audit-log roundtrips
- verify tenant-filtered job lookup/listing plus audit HMAC verification and schema marker persistence against a real database
- add a path-aware CI Postgres service job so Postgres/storage changes are exercised outside the mocked unit-test harness

Why
This closes the mocked-only Postgres testing gap without adding a local testcontainers dependency or slowing unrelated PRs. Local runs skip unless AGENT_BOM_POSTGRES_URL is configured; CI supplies a postgres:16-alpine service when relevant paths change and on main.

Validation
- uv run pytest tests/test_postgres_integration.py -q --tb=short
- uv run ruff check tests/test_postgres_integration.py
- uv run mypy tests/test_postgres_integration.py
- uv run python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/ci.yml').read_text()); print('yaml ok')"
- git diff --check
- pre-commit hooks on commit

Closes #1930