### PR TITLE
feat(scanner): add AI observability SDK inventory

### DIFF
--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -54,6 +54,17 @@ A vulnerability in `nvidia-cudnn-cu12` or `hip-python` doesn't just affect one m
 | `ray` | Distributed computing |
 | `clearml` | ML pipeline management |
 
+### AI observability and evaluation tracing
+
+| Package | Description |
+|---------|-------------|
+| `langsmith` | LangSmith tracing and evaluation telemetry |
+| `langfuse` | Langfuse traces, sessions, scores, and prompt telemetry |
+| `braintrust` | Braintrust evaluation and experiment telemetry |
+| `arize`, `arize-phoenix` | Arize/Phoenix observability and OpenInference traces |
+| `trubrics` | Trubrics feedback and evaluation telemetry |
+| `@helicone/helicone` | Helicone request and LLM observability instrumentation |
+
 ## Scanning GPU container images
 
 ### NVIDIA CUDA images

--- a/site-docs/architecture/ai-infrastructure.md
+++ b/site-docs/architecture/ai-infrastructure.md
@@ -11,6 +11,7 @@ For the comprehensive guide, see [AI_INFRASTRUCTURE_SCANNING.md](https://github.
 | **Container Images** | Native OCI package discovery across OS and language packages |
 | **Kubernetes** | Namespace enumeration, pod MCP detection |
 | **Cloud** | AWS, Snowflake, Azure ML, GCP Vertex AI, Databricks, HuggingFace, Ollama |
+| **AI observability** | LangSmith, Langfuse, Braintrust, Arize/Phoenix, Trubrics, Helicone SDK inventory |
 | **Code** | SAST via Semgrep with CWE mapping |
 
 ## Cloud providers

--- a/src/agent_bom/ai_components/models.py
+++ b/src/agent_bom/ai_components/models.py
@@ -24,6 +24,7 @@ class AIComponentType(str, Enum):
     API_KEY = "api_key"  # hardcoded API key in source
     DEPRECATED_MODEL = "deprecated_model"  # gpt-3.5-turbo, text-davinci-003
     MLOPS = "mlops"  # mlflow, wandb, neptune
+    OBSERVABILITY = "observability"  # langsmith, langfuse, helicone, arize, braintrust
     INFERENCE_SERVER = "inference_server"  # vllm, triton, tgi
     INVISIBLE_UNICODE = "invisible_unicode"  # GlassWorm-style zero-width / RTL override chars in source
 

--- a/src/agent_bom/ai_components/patterns.py
+++ b/src/agent_bom/ai_components/patterns.py
@@ -248,6 +248,13 @@ PYTHON_SDK_PATTERNS: list[SDKPattern] = [
     SDKPattern(re.compile(_py_import("wandb")), "wandb", AIComponentType.MLOPS, "wandb", "pypi", "python"),
     SDKPattern(re.compile(_py_import("neptune")), "neptune", AIComponentType.MLOPS, "neptune", "pypi", "python"),
     SDKPattern(re.compile(_py_import("clearml")), "clearml", AIComponentType.MLOPS, "clearml", "pypi", "python"),
+    # AI observability / eval tracing
+    SDKPattern(re.compile(_py_import("langsmith")), "langsmith", AIComponentType.OBSERVABILITY, "langsmith", "pypi", "python"),
+    SDKPattern(re.compile(_py_import("langfuse")), "langfuse", AIComponentType.OBSERVABILITY, "langfuse", "pypi", "python"),
+    SDKPattern(re.compile(_py_import("arize")), "arize", AIComponentType.OBSERVABILITY, "arize", "pypi", "python"),
+    SDKPattern(re.compile(_py_import("phoenix")), "phoenix", AIComponentType.OBSERVABILITY, "arize-phoenix", "pypi", "python"),
+    SDKPattern(re.compile(_py_import("braintrust")), "braintrust", AIComponentType.OBSERVABILITY, "braintrust", "pypi", "python"),
+    SDKPattern(re.compile(_py_import("trubrics")), "trubrics", AIComponentType.OBSERVABILITY, "trubrics", "pypi", "python"),
     # Inference servers
     SDKPattern(re.compile(_py_import("vllm")), "vllm", AIComponentType.INFERENCE_SERVER, "vllm", "pypi", "python"),
 ]
@@ -361,6 +368,18 @@ JS_SDK_PATTERNS: list[SDKPattern] = [
         "npm",
         "javascript",
     ),
+    # AI observability / eval tracing
+    SDKPattern(re.compile(_js_import("langsmith")), "langsmith", AIComponentType.OBSERVABILITY, "langsmith", "npm", "javascript"),
+    SDKPattern(re.compile(_js_import("langfuse")), "langfuse", AIComponentType.OBSERVABILITY, "langfuse", "npm", "javascript"),
+    SDKPattern(
+        re.compile(_js_import("@helicone/helicone")),
+        "helicone",
+        AIComponentType.OBSERVABILITY,
+        "@helicone/helicone",
+        "npm",
+        "javascript",
+    ),
+    SDKPattern(re.compile(_js_import("braintrust")), "braintrust", AIComponentType.OBSERVABILITY, "braintrust", "npm", "javascript"),
 ]
 
 # ── Java SDK patterns ────────────────────────────────────────────────────────

--- a/tests/test_ai_components.py
+++ b/tests/test_ai_components.py
@@ -112,12 +112,18 @@ class TestPatternCoverage:
         assert "chromadb" in names
         assert "mlflow" in names
         assert "vllm" in names
+        assert "langsmith" in names
+        assert "langfuse" in names
+        assert "phoenix" in names
+        assert "braintrust" in names
 
     def test_js_has_patterns(self):
         names = {p.name for p in SDK_PATTERNS_BY_LANGUAGE["javascript"]}
         assert "openai" in names
         assert "anthropic" in names
         assert "langchain" in names
+        assert "langfuse" in names
+        assert "helicone" in names
 
     def test_all_sdk_patterns_combined(self):
         assert len(ALL_SDK_PATTERNS) >= 50  # 40+ Python + JS + Java + Go + Rust + Ruby
@@ -177,6 +183,25 @@ class TestScanner:
         assert "openai" in names
         assert "langchain" in names
         assert "chromadb" in names
+
+    def test_scan_ai_observability_imports(self, tmp_path: Path):
+        (tmp_path / "observability.py").write_text(
+            "from langsmith import Client\n"
+            "from langfuse import Langfuse\n"
+            "import phoenix as px\n"
+            "import braintrust\n"
+            "from arize import Client as ArizeClient\n"
+        )
+        (tmp_path / "observability.ts").write_text(
+            'import { Langfuse } from "langfuse";\nimport { HeliconeManualLogger } from "@helicone/helicone";\n'
+        )
+
+        report = scan_source(str(tmp_path))
+        observability = [c for c in report.components if c.component_type == AIComponentType.OBSERVABILITY]
+        names = {c.name for c in observability}
+
+        assert {"langsmith", "langfuse", "phoenix", "braintrust", "arize", "helicone"}.issubset(names)
+        assert {c.ecosystem for c in observability} == {"pypi", "npm"}
 
     def test_scan_js_imports(self, tmp_project: Path):
         report = scan_source(str(tmp_project))


### PR DESCRIPTION
Summary
- add a first-class AI observability component type to source inventory
- detect LangSmith, Langfuse, Arize/Phoenix, Braintrust, Trubrics, and Helicone SDK usage across Python and JavaScript/TypeScript
- update AI infrastructure docs so observability/eval tracing coverage is explicit

Why
The refreshed audit correctly rescored AI infrastructure discovery upward for cloud/GPU/inference coverage, but generic AI observability and eval tracing SDKs remained the biggest static inventory gap. This PR closes that narrow gap without claiming hosted vendor API enumeration.

Validation
- uv run pytest tests/test_ai_components.py -q
- uv run ruff check src/agent_bom/ai_components/models.py src/agent_bom/ai_components/patterns.py tests/test_ai_components.py
- uv run mypy src/agent_bom/ai_components/models.py src/agent_bom/ai_components/patterns.py src/agent_bom/ai_components/scanner.py
- git diff --check
- pre-commit hooks on commit

Refs #1892
Refs #1890