### PR TITLE
perf: publish local scale evidence

### DIFF
--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -15,8 +15,20 @@ Current evidence pages:
 - [`fleet-reconciliation.md`](fleet-reconciliation.md) — fleet and Kubernetes
   reconciliation latency.
 
+Current raw result artifact:
+
+- [`results/scale-evidence-local-2026-04-26.json`](results/scale-evidence-local-2026-04-26.json)
+  — local synthetic graph build/query and Kubernetes reconciliation CPU-path
+  run on macOS arm64 with Python 3.13.5.
+
 Run the structure check before publishing release numbers:
 
 ```bash
 python scripts/check_scale_evidence.py
+```
+
+Regenerate the local synthetic result set:
+
+```bash
+uv run python scripts/run_scale_evidence.py
 ```

--- a/docs/perf/fleet-reconciliation.md
+++ b/docs/perf/fleet-reconciliation.md
@@ -1,56 +1,62 @@
 # Fleet Reconciliation Evidence
 
-Evidence status: scaffold
-Owner issue: #1806
+Evidence status: measured
+Owner issue: #1895
+Parent issue: #1806
+Raw result artifact: `docs/perf/results/scale-evidence-local-2026-04-26.json`
 
 ## Claim
 
-Fleet and Kubernetes reconciliation can process repeated snapshots at 1k / 5k /
-10k host or workload scale while preserving stable identity, added/changed/
-missing/stale state, and control-plane ingest SLOs.
+Local synthetic Kubernetes reconciliation can process repeated 1k / 5k / 10k
+observation snapshots while preserving stable identity and added / changed /
+missing / stale state. This page does not claim control-plane HTTP ingest,
+Postgres persistence, or EKS scheduler latency; those remain tracked in #1806.
 
 ## Scope
 
 - `agent-bom fleet reconcile-k8s`
-- control-plane fleet snapshot push
 - repeated snapshot deduplication
 - added / changed / missing / stale reconciliation output
+- synthetic Kubernetes inventory observations at 1k / 5k / 10k scale
+
+Excluded from this measured run:
+
+- control-plane fleet snapshot push
+- Postgres persistence
 - graph selector/drilldown latency after fleet ingestion
+- live Kubernetes API list/watch latency
 
 ## Environment
 
-Record the exact environment before publishing measured numbers:
-
-- Hardware:
-- CPU:
-- Memory:
-- Kubernetes version:
-- Postgres version:
-- Dataset shape:
-- agent-bom commit:
+- Platform: macOS-26.4.1-arm64-arm-64bit-Mach-O
+- Machine: arm64
+- Processor: arm
+- Python: 3.13.5
+- Kubernetes version: none; synthetic observation list only
+- Postgres version: none; in-process reconciliation only
+- Dataset shape: synthetic observations with stable tenant, cluster,
+  namespace, workload, agent, server, image, endpoint, and node metadata.
+- agent-bom commit: generated from the PR branch that introduced
+  `scripts/run_scale_evidence.py`
 
 ## Commands
 
 ```bash
-agent-bom fleet reconcile-k8s --snapshot current.json --previous previous.json --format json
-curl -X POST "$AGENT_BOM_BASE_URL/v1/fleet/sync" \
-  -H "Authorization: Bearer $AGENT_BOM_API_TOKEN" \
-  -H "Content-Type: application/json" \
-  --data @current.json
+uv run python scripts/run_scale_evidence.py
+python scripts/check_scale_evidence.py
 ```
 
 ## Results
 
-Measured results are intentionally not filled in this scaffold PR.
-
-| Estate size | Snapshot shape | Reconcile wall time | Push p95 | Push p99 | Dedup latency | Result artifact |
-|---:|---|---:|---:|---:|---:|---|
-| 1k hosts | TBD | TBD | TBD | TBD | TBD | TBD |
-| 5k hosts | TBD | TBD | TBD | TBD | TBD | TBD |
-| 10k hosts | TBD | TBD | TBD | TBD | TBD | TBD |
+| Estate size | Previous | Current | Changed | Missing | Unchanged | Wall time | Observations/sec | Result artifact |
+|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| 1k observations | 1,000 | 965 | 56 | 35 | 909 | 26.670 ms | 73,677.83 | `results/scale-evidence-local-2026-04-26.json` |
+| 5k observations | 5,000 | 4,827 | 284 | 173 | 4,543 | 138.489 ms | 70,958.47 | `results/scale-evidence-local-2026-04-26.json` |
+| 10k observations | 10,000 | 9,655 | 568 | 345 | 9,087 | 304.328 ms | 64,585.00 | `results/scale-evidence-local-2026-04-26.json` |
 
 ## Gaps
 
-- Add or document fixture generation for 1k / 5k / 10k snapshots.
-- Replace scaffold rows with measured values from a reproducible run.
-- Attach raw benchmark JSON under `docs/perf/results/`.
+- Add control-plane `/v1/fleet/sync` HTTP ingest p95/p99.
+- Add Postgres-backed fleet-store persistence latency.
+- Add live Kubernetes API discovery latency.
+- Add graph selector/drilldown latency after fleet ingestion.

--- a/docs/perf/ingest-throughput.md
+++ b/docs/perf/ingest-throughput.md
@@ -1,54 +1,63 @@
 # Graph Ingest Throughput Evidence
 
-Evidence status: scaffold
-Owner issue: #1806
+Evidence status: measured
+Owner issue: #1895
+Parent issue: #1806
+Raw result artifact: `docs/perf/results/scale-evidence-local-2026-04-26.json`
 
 ## Claim
 
-Graph save throughput remains bounded by batch/window size rather than total
-graph size, and `AGENT_BOM_GRAPH_WRITE_BATCH_SIZE` gives operators one tuning
-knob across SQLite and Postgres write paths.
+Local synthetic graph build throughput stays above 20k nodes/sec at 1k, 5k,
+and 10k agent-estate sizes for the in-process graph-builder hot path. This
+page does not claim SQLite/Postgres persistence throughput; persistence
+batch-size evidence remains tracked in #1806.
 
 ## Scope
 
-- SQLite graph store writes
-- Postgres graph store writes
-- node, edge, search-row, attack-path, and interaction-risk persistence
-- batch-size sensitivity for small, default, and large batches
+- `build_unified_graph_from_report`
+- synthetic AIBOM graph construction from serialized report JSON
+- node and edge construction for agents, MCP servers, packages, tools,
+  credentials, and vulnerability blast-radius rows
+
+Excluded from this measured run:
+
+- SQLite graph-store persistence
+- Postgres graph-store persistence
+- search-row, attack-path, and interaction-risk persistence
+- `AGENT_BOM_GRAPH_WRITE_BATCH_SIZE` sensitivity
 
 ## Environment
 
-Record the exact environment before publishing measured numbers:
-
-- Hardware:
-- CPU:
-- Memory:
-- Storage:
-- Database backend:
-- agent-bom commit:
+- Platform: macOS-26.4.1-arm64-arm-64bit-Mach-O
+- Machine: arm64
+- Processor: arm
+- Python: 3.13.5
+- Database backend: none; in-process graph-builder CPU path only
+- Dataset shape: synthetic AIBOM report with 1 MCP server, 2 packages, and 1
+  tool per agent; every tenth agent includes one credential and one
+  vulnerability blast-radius row.
+- agent-bom commit: generated from the PR branch that introduced
+  `scripts/run_scale_evidence.py`
 
 ## Commands
 
 ```bash
-pytest tests/benchmarks/test_graph_hot_paths.py --benchmark-only
-AGENT_BOM_GRAPH_WRITE_BATCH_SIZE=100 pytest tests/benchmarks/ --benchmark-only -k graph
-AGENT_BOM_GRAPH_WRITE_BATCH_SIZE=1000 pytest tests/benchmarks/ --benchmark-only -k graph
-AGENT_BOM_GRAPH_WRITE_BATCH_SIZE=5000 pytest tests/benchmarks/ --benchmark-only -k graph
+uv run python scripts/run_scale_evidence.py
+python scripts/check_scale_evidence.py
 ```
 
 ## Results
 
-Measured results are intentionally not filled in this scaffold PR.
-
-| Backend | Batch size | Estate size | Nodes/sec | Edges/sec | Peak RSS | Result artifact |
-|---|---:|---:|---:|---:|---:|---|
-| SQLite | 100 | TBD | TBD | TBD | TBD | TBD |
-| SQLite | 1,000 | TBD | TBD | TBD | TBD | TBD |
-| Postgres | 1,000 | TBD | TBD | TBD | TBD | TBD |
-| Postgres | 5,000 | TBD | TBD | TBD | TBD | TBD |
+| Backend | Estate size | Nodes | Edges | Build wall time | Nodes/sec | Edges/sec | RSS delta | Result artifact |
+|---|---:|---:|---:|---:|---:|---:|---:|---|
+| in-process builder | 1k agents | 5,201 | 5,200 | 236.100 ms | 22,028.78 | 22,024.54 | 45.016 MiB | `results/scale-evidence-local-2026-04-26.json` |
+| in-process builder | 5k agents | 26,001 | 26,000 | 193.444 ms | 134,410.88 | 134,405.71 | 44.156 MiB | `results/scale-evidence-local-2026-04-26.json` |
+| in-process builder | 10k agents | 52,001 | 52,000 | 446.970 ms | 116,341.21 | 116,338.97 | 60.703 MiB | `results/scale-evidence-local-2026-04-26.json` |
 
 ## Gaps
 
-- Add write-path benchmark cases for persistence, not only graph build CPU.
-- Replace scaffold rows with measured values from a reproducible run.
-- Attach raw benchmark JSON under `docs/perf/results/`.
+- Add SQLite and Postgres persistence throughput measurements.
+- Add batch-size sensitivity for `AGENT_BOM_GRAPH_WRITE_BATCH_SIZE`.
+- Add search-row, attack-path, and interaction-risk persistence throughput.
+- Add EKS/RDS hardware profile results before using these numbers for hosted
+  enterprise SLOs.

--- a/docs/perf/p95-p99-graph-query.md
+++ b/docs/perf/p95-p99-graph-query.md
@@ -1,66 +1,79 @@
 # Graph Query p95/p99 Evidence
 
-Evidence status: scaffold
-Owner issue: #1806
+Evidence status: measured
+Owner issue: #1895
+Parent issue: #1806
+Raw result artifact: `docs/perf/results/scale-evidence-local-2026-04-26.json`
 
 ## Claim
 
-Graph search, selector, neighborhood, diff, and attack-path drilldown APIs stay
-within the published operator SLOs for 1k / 5k / 10k agent estates when the UI
-uses windowed selectors and bounded graph queries.
+Local synthetic graph search, selector, and bounded-neighborhood CPU paths stay
+sub-millisecond at 1k / 5k / 10k agent-estate sizes when callers use bounded
+selectors and bounded graph traversal. This page does not claim HTTP API,
+Postgres, diff, or attack-path drilldown latency; those remain tracked in
+#1806.
 
 ## Scope
 
-- `GET /v1/graph`
 - `GET /v1/graph/search`
-- `GET /v1/graph/{node_id}`
-- `GET /v1/graph/diff`
+- agent selector/filter path
+- bounded neighborhood traversal via `UnifiedGraph.traverse_subgraph`
+- synthetic graph sizes: 1k, 5k, and 10k agents
+
+Excluded from this measured run:
+
+- HTTP/API overhead
+- Postgres graph-store persistence and SQL query plans
+- graph diff API
 - materialized attack-path drilldowns
+- browser layout and interaction timings
 
 ## Environment
 
-Record the exact environment before publishing measured numbers:
-
-- Hardware:
-- CPU:
-- Memory:
-- Postgres version:
-- Dataset shape:
-- agent-bom commit:
+- Platform: macOS-26.4.1-arm64-arm-64bit-Mach-O
+- Machine: arm64
+- Processor: arm
+- Python: 3.13.5
+- Dataset shape: synthetic AIBOM report with 1 MCP server, 2 packages, and 1
+  tool per agent; every tenth agent includes one credential and one
+  vulnerability blast-radius row.
+- agent-bom commit: generated from the PR branch that introduced
+  `scripts/run_scale_evidence.py`
 
 ## Commands
 
 ```bash
-export AGENT_BOM_BASE_URL=https://agent-bom.internal.example.com
-export AGENT_BOM_API_TOKEN=replace-me
-export AGENT_BOM_GRAPH_SCAN_ID=replace-me
-
-k6 run deploy/loadtest/k6-graph-api.js
+uv run python scripts/run_scale_evidence.py
+python scripts/check_scale_evidence.py
 ```
 
 ## Results
 
-Measured results are intentionally not filled in this scaffold PR.
-
-| Estate size | Endpoint group | p95 | p99 | Target | Result artifact |
-|---:|---|---:|---:|---:|---|
-| 1k agents | graph search/selectors | TBD | TBD | TBD | TBD |
-| 5k agents | graph search/selectors | TBD | TBD | TBD | TBD |
-| 10k agents | graph search/selectors | TBD | TBD | TBD | TBD |
+| Estate size | Nodes | Edges | Operation | p50 | p95 | p99 | Runs | Result artifact |
+|---:|---:|---:|---|---:|---:|---:|---:|---|
+| 1k agents | 5,201 | 5,200 | search | 0.087 ms | 0.096 ms | 0.102 ms | 30 | `results/scale-evidence-local-2026-04-26.json` |
+| 1k agents | 5,201 | 5,200 | agent selector | 0.079 ms | 0.100 ms | 0.118 ms | 30 | `results/scale-evidence-local-2026-04-26.json` |
+| 1k agents | 5,201 | 5,200 | bounded neighborhood | 0.001 ms | 0.004 ms | 0.011 ms | 30 | `results/scale-evidence-local-2026-04-26.json` |
+| 5k agents | 26,001 | 26,000 | search | 0.087 ms | 0.094 ms | 0.108 ms | 30 | `results/scale-evidence-local-2026-04-26.json` |
+| 5k agents | 26,001 | 26,000 | agent selector | 0.378 ms | 0.459 ms | 0.482 ms | 30 | `results/scale-evidence-local-2026-04-26.json` |
+| 5k agents | 26,001 | 26,000 | bounded neighborhood | 0.001 ms | 0.003 ms | 0.012 ms | 30 | `results/scale-evidence-local-2026-04-26.json` |
+| 10k agents | 52,001 | 52,000 | search | 0.086 ms | 0.096 ms | 0.109 ms | 30 | `results/scale-evidence-local-2026-04-26.json` |
+| 10k agents | 52,001 | 52,000 | agent selector | 0.765 ms | 0.896 ms | 0.943 ms | 30 | `results/scale-evidence-local-2026-04-26.json` |
+| 10k agents | 52,001 | 52,000 | bounded neighborhood | 0.001 ms | 0.003 ms | 0.012 ms | 30 | `results/scale-evidence-local-2026-04-26.json` |
 
 ## EXPLAIN ANALYZE
 
-Attach representative query plans for the hot Postgres graph paths:
+Not covered by this local synthetic run. Add representative Postgres query
+plans under #1806 when the API/Postgres benchmark lane is measured:
 
-- graph node search:
-- node detail:
-- attack-path drilldown:
-- graph diff:
+- graph node search
+- node detail
+- attack-path drilldown
+- graph diff
 
 ## Gaps
 
-- Replace scaffold rows with measured values from a reproducible run.
-- Attach raw k6 output or benchmark JSON under `docs/perf/results/`.
-- Confirm whether the run includes local endpoint, Kubernetes, cloud/SaaS,
-  MCP registry, package, vulnerability, model/dataset, and exposure-path
-  objects.
+- Add API/k6 p95/p99 with auth, tenant, and network overhead.
+- Add Postgres graph-store p95/p99 and `EXPLAIN ANALYZE` plans.
+- Add graph diff and materialized attack-path drilldown measurements.
+- Add browser/UI interaction and layout timing for large estates.

--- a/docs/perf/results/scale-evidence-local-2026-04-26.json
+++ b/docs/perf/results/scale-evidence-local-2026-04-26.json
@@ -1,0 +1,149 @@
+{
+  "environment": {
+    "machine": "arm64",
+    "platform": "macOS-26.4.1-arm64-arm-64bit-Mach-O",
+    "processor": "arm",
+    "python": "3.13.5"
+  },
+  "fleet": [
+    {
+      "current": 965,
+      "estate_size_observations": 1000,
+      "observations_per_second": 73677.83,
+      "previous": 1000,
+      "summary": {
+        "added": 0,
+        "changed": 56,
+        "current": 965,
+        "missing": 35,
+        "previous": 1000,
+        "stale": 0,
+        "unchanged": 909
+      },
+      "wall_ms": 26.67
+    },
+    {
+      "current": 4827,
+      "estate_size_observations": 5000,
+      "observations_per_second": 70958.47,
+      "previous": 5000,
+      "summary": {
+        "added": 0,
+        "changed": 284,
+        "current": 4827,
+        "missing": 173,
+        "previous": 5000,
+        "stale": 0,
+        "unchanged": 4543
+      },
+      "wall_ms": 138.489
+    },
+    {
+      "current": 9655,
+      "estate_size_observations": 10000,
+      "observations_per_second": 64585.0,
+      "previous": 10000,
+      "summary": {
+        "added": 0,
+        "changed": 568,
+        "current": 9655,
+        "missing": 345,
+        "previous": 10000,
+        "stale": 0,
+        "unchanged": 9087
+      },
+      "wall_ms": 304.328
+    }
+  ],
+  "gaps": [
+    "Postgres persistence throughput is not measured by this local synthetic run.",
+    "HTTP API p95/p99 under k6 is not measured by this local synthetic run.",
+    "EKS multi-node HA behavior remains tracked in #1806."
+  ],
+  "generated_at": "2026-04-26T04:14:33.751023+00:00",
+  "graph": [
+    {
+      "agent_selector": {
+        "p50_ms": 0.079,
+        "p95_ms": 0.1,
+        "p99_ms": 0.118,
+        "runs": 30
+      },
+      "bounded_neighborhood": {
+        "p50_ms": 0.001,
+        "p95_ms": 0.004,
+        "p99_ms": 0.011,
+        "runs": 30
+      },
+      "build_ms": 236.1,
+      "edges": 5200,
+      "edges_per_second": 22024.54,
+      "estate_size_agents": 1000,
+      "nodes": 5201,
+      "nodes_per_second": 22028.78,
+      "rss_delta_mb": 45.016,
+      "search": {
+        "p50_ms": 0.087,
+        "p95_ms": 0.096,
+        "p99_ms": 0.102,
+        "runs": 30
+      }
+    },
+    {
+      "agent_selector": {
+        "p50_ms": 0.378,
+        "p95_ms": 0.459,
+        "p99_ms": 0.482,
+        "runs": 30
+      },
+      "bounded_neighborhood": {
+        "p50_ms": 0.001,
+        "p95_ms": 0.003,
+        "p99_ms": 0.012,
+        "runs": 30
+      },
+      "build_ms": 193.444,
+      "edges": 26000,
+      "edges_per_second": 134405.71,
+      "estate_size_agents": 5000,
+      "nodes": 26001,
+      "nodes_per_second": 134410.88,
+      "rss_delta_mb": 44.156,
+      "search": {
+        "p50_ms": 0.087,
+        "p95_ms": 0.094,
+        "p99_ms": 0.108,
+        "runs": 30
+      }
+    },
+    {
+      "agent_selector": {
+        "p50_ms": 0.765,
+        "p95_ms": 0.896,
+        "p99_ms": 0.943,
+        "runs": 30
+      },
+      "bounded_neighborhood": {
+        "p50_ms": 0.001,
+        "p95_ms": 0.003,
+        "p99_ms": 0.012,
+        "runs": 30
+      },
+      "build_ms": 446.97,
+      "edges": 52000,
+      "edges_per_second": 116338.97,
+      "estate_size_agents": 10000,
+      "nodes": 52001,
+      "nodes_per_second": 116341.21,
+      "rss_delta_mb": 60.703,
+      "search": {
+        "p50_ms": 0.086,
+        "p95_ms": 0.096,
+        "p99_ms": 0.109,
+        "runs": 30
+      }
+    }
+  ],
+  "schema_version": 1,
+  "scope": "local synthetic CPU benchmark; Postgres/EKS/load-test evidence remains tracked in #1806"
+}

--- a/scripts/check_scale_evidence.py
+++ b/scripts/check_scale_evidence.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Verify the scale-evidence documentation scaffold is release-ready.
 
-This intentionally checks structure, not performance values. The first PR for
-#1806 should make the evidence lanes hard to forget without pretending the
-numbers have already been measured.
+This checks structure and verifies measured pages point at checked-in raw
+artifacts without pretending local synthetic results cover the broader
+enterprise/EKS evidence tracked in #1806.
 """
 
 from __future__ import annotations
@@ -22,7 +22,7 @@ REQUIRED_FILES = (
 
 REQUIRED_MARKERS = (
     "Evidence status:",
-    "Owner issue: #1806",
+    "Owner issue:",
     "## Claim",
     "## Scope",
     "## Environment",
@@ -42,6 +42,15 @@ def _check_file(path: Path) -> list[str]:
             errors.append(f"{path.relative_to(ROOT)} missing marker: {marker}")
     if "TBD" not in text and "Evidence status: measured" not in text:
         errors.append(f"{path.relative_to(ROOT)} must either keep TBD placeholders or declare measured evidence")
+    if "Evidence status: measured" in text:
+        marker = "Raw result artifact: `"
+        if marker not in text:
+            errors.append(f"{path.relative_to(ROOT)} missing measured raw result artifact")
+        else:
+            artifact = text.split(marker, 1)[1].split("`", 1)[0]
+            artifact_path = ROOT / artifact
+            if not artifact_path.exists():
+                errors.append(f"{path.relative_to(ROOT)} references missing raw result artifact: {artifact}")
     return errors
 
 

--- a/scripts/run_scale_evidence.py
+++ b/scripts/run_scale_evidence.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Generate local synthetic scale evidence for graph and fleet hot paths.
+
+The output is intentionally explicit about scope: this is a reproducible local
+benchmark for graph build/query and Kubernetes reconciliation CPU paths. It is
+not a substitute for the broader Postgres/EKS/load-test evidence tracked in
+#1806.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import resource
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from agent_bom.fleet.k8s_reconcile import reconcile_k8s_inventory
+from agent_bom.graph.builder import build_unified_graph_from_report
+from agent_bom.graph.types import EntityType
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT = ROOT / "docs" / "perf" / "results" / "scale-evidence-local-2026-04-26.json"
+ESTATE_SIZES = (1_000, 5_000, 10_000)
+
+
+def _rss_mb() -> float:
+    usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if platform.system() == "Darwin":
+        return usage / (1024 * 1024)
+    return usage / 1024
+
+
+def _percentiles(values_ms: list[float]) -> dict[str, float]:
+    if not values_ms:
+        return {"p50_ms": 0.0, "p95_ms": 0.0, "p99_ms": 0.0}
+    ordered = sorted(values_ms)
+
+    def pct(percent: float) -> float:
+        idx = min(len(ordered) - 1, max(0, round((len(ordered) - 1) * percent)))
+        return round(ordered[idx], 3)
+
+    return {
+        "p50_ms": pct(0.50),
+        "p95_ms": pct(0.95),
+        "p99_ms": pct(0.99),
+    }
+
+
+def _time_call(fn, *args, repeat: int = 25, **kwargs) -> dict[str, Any]:
+    values: list[float] = []
+    result: Any = None
+    for _ in range(repeat):
+        started = time.perf_counter()
+        result = fn(*args, **kwargs)
+        values.append((time.perf_counter() - started) * 1000)
+    return {**_percentiles(values), "runs": repeat, "last_result": result}
+
+
+def _synth_report(n_agents: int) -> dict[str, Any]:
+    agents: list[dict[str, Any]] = []
+    blast_radius: list[dict[str, Any]] = []
+    for idx in range(n_agents):
+        package_a = f"pkg-{idx}-core"
+        package_b = f"pkg-{idx}-tool"
+        agent_name = f"agent-{idx}"
+        server_name = f"server-{idx}"
+        agents.append(
+            {
+                "name": agent_name,
+                "type": "claude-desktop" if idx % 2 == 0 else "cursor",
+                "status": "configured",
+                "mcp_servers": [
+                    {
+                        "name": server_name,
+                        "transport": "sse",
+                        "url": f"https://mcp-{idx}.example.internal/sse",
+                        "surface": "mcp-server",
+                        "credential_env_vars": [f"AGENT_{idx}_TOKEN"] if idx % 10 == 0 else [],
+                        "packages": [
+                            {"name": package_a, "version": "1.0.0", "ecosystem": "npm", "is_direct": True},
+                            {"name": package_b, "version": "2.0.0", "ecosystem": "pypi", "is_direct": False},
+                        ],
+                        "tools": [{"name": f"tool-{idx}"}],
+                    }
+                ],
+            }
+        )
+        if idx % 10 == 0:
+            blast_radius.append(
+                {
+                    "vulnerability_id": f"CVE-2026-{idx:06d}",
+                    "severity": ["critical", "high", "medium", "low"][(idx // 10) % 4],
+                    "package_name": package_a,
+                    "package": package_a,
+                    "package_version": "1.0.0",
+                    "fixed_version": "1.0.1",
+                    "affected_agents": [agent_name],
+                    "affected_servers": [{"name": server_name}],
+                    "owasp_tags": ["LLM05"],
+                    "soc2_tags": ["CC6.1"],
+                }
+            )
+    return {
+        "scan_id": f"scale-evidence-{n_agents}",
+        "generated_at": "2026-04-26T00:00:00Z",
+        "tool_version": "local",
+        "scan_sources": ["synthetic-scale-evidence"],
+        "agents": agents,
+        "blast_radius": blast_radius,
+    }
+
+
+def _synth_observations(
+    n_items: int,
+    *,
+    changed_every: int = 17,
+    missing_every: int = 29,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    previous: list[dict[str, Any]] = []
+    current: list[dict[str, Any]] = []
+    for idx in range(n_items):
+        base = {
+            "tenant_id": "scale-evidence",
+            "cluster": "eks-scale",
+            "namespace": f"team-{idx % 25}",
+            "workload": f"agent-workload-{idx}",
+            "agent_name": f"agent-{idx}",
+            "server_name": f"server-{idx}",
+            "surface": "mcp-server",
+            "node_name": f"ip-10-0-{idx % 255}-{idx % 31}",
+            "image": f"example.com/agent-{idx % 50}:1.0.0",
+            "endpoint": f"https://agent-{idx}.example.internal",
+            "observed_at": "2026-04-26T00:00:00+00:00",
+            "discovery_sources": ["k8s", "mcp"],
+        }
+        previous.append(dict(base))
+        if idx % missing_every == 0:
+            continue
+        updated = dict(base)
+        if idx % changed_every == 0:
+            updated["image"] = f"example.com/agent-{idx % 50}:1.0.1"
+        current.append(updated)
+    return previous, current
+
+
+def _measure_graph(n_agents: int) -> dict[str, Any]:
+    report = _synth_report(n_agents)
+    rss_before = _rss_mb()
+    started = time.perf_counter()
+    graph = build_unified_graph_from_report(report)
+    build_ms = (time.perf_counter() - started) * 1000
+    rss_after = _rss_mb()
+    roots = [f"agent:{idx}" for idx in range(0, n_agents, max(1, n_agents // 25))]
+
+    search = _time_call(graph.search_nodes, "agent-", repeat=30, limit=80)
+    selectors = _time_call(graph.filter_nodes, repeat=30, entity_types={EntityType.AGENT})
+    neighborhood = _time_call(graph.traverse_subgraph, roots[:3], repeat=30, max_depth=3, max_nodes=500, max_edges=5_000)
+
+    return {
+        "estate_size_agents": n_agents,
+        "nodes": len(graph.nodes),
+        "edges": len(graph.edges),
+        "build_ms": round(build_ms, 3),
+        "nodes_per_second": round(len(graph.nodes) / max(build_ms / 1000, 0.001), 2),
+        "edges_per_second": round(len(graph.edges) / max(build_ms / 1000, 0.001), 2),
+        "rss_delta_mb": round(max(0.0, rss_after - rss_before), 3),
+        "search": {k: v for k, v in search.items() if k != "last_result"},
+        "agent_selector": {k: v for k, v in selectors.items() if k != "last_result"},
+        "bounded_neighborhood": {k: v for k, v in neighborhood.items() if k != "last_result"},
+    }
+
+
+def _measure_fleet(n_items: int) -> dict[str, Any]:
+    previous, current = _synth_observations(n_items)
+    started = time.perf_counter()
+    result = reconcile_k8s_inventory(previous, current)
+    wall_ms = (time.perf_counter() - started) * 1000
+    return {
+        "estate_size_observations": n_items,
+        "previous": len(previous),
+        "current": len(current),
+        "wall_ms": round(wall_ms, 3),
+        "observations_per_second": round((len(previous) + len(current)) / max(wall_ms / 1000, 0.001), 2),
+        "summary": result["summary"],
+    }
+
+
+def generate() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "scope": "local synthetic CPU benchmark; Postgres/EKS/load-test evidence remains tracked in #1806",
+        "environment": {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            "machine": platform.machine(),
+            "processor": platform.processor(),
+        },
+        "graph": [_measure_graph(size) for size in ESTATE_SIZES],
+        "fleet": [_measure_fleet(size) for size in ESTATE_SIZES],
+        "gaps": [
+            "Postgres persistence throughput is not measured by this local synthetic run.",
+            "HTTP API p95/p99 under k6 is not measured by this local synthetic run.",
+            "EKS multi-node HA behavior remains tracked in #1806.",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+    evidence = generate()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(args.output.relative_to(ROOT))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Summary
- add a reproducible local synthetic scale-evidence generator for graph build/query and Kubernetes reconciliation CPU paths
- check in raw 1k/5k/10k result JSON under docs/perf/results
- replace the perf scaffold tables with measured local numbers and explicit exclusions for Postgres, EKS, k6/API, and browser timing
- tighten the scale evidence checker so measured pages must reference checked-in raw artifacts

Why
This closes the narrow graph/fleet benchmark publication child with measured, reproducible local evidence while keeping the broader enterprise evidence tracker honest. The docs now say exactly what was measured and what remains under #1806.

Validation
- uv run python scripts/run_scale_evidence.py
- uv run python scripts/check_scale_evidence.py
- uv run pytest tests/test_scale_evidence.py -q
- uv run ruff check scripts/check_scale_evidence.py scripts/run_scale_evidence.py tests/test_scale_evidence.py
- uv run mypy scripts/check_scale_evidence.py scripts/run_scale_evidence.py
- git diff --check
- pre-commit hooks on commit

Closes #1895
Refs #1806