### PR TITLE
feat(secrets): add customer rotation adapter evidence

### DIFF
--- a/docs/ENTERPRISE_SECURITY_POSTURE.md
+++ b/docs/ENTERPRISE_SECURITY_POSTURE.md
@@ -121,6 +121,22 @@ generic secret-manager command templates; and lists rollout, verification, and
 timestamp-recording steps. The response is designed for change tickets and does
 not automate custody-sensitive secret generation.
 
+The rotation-plan response now exposes an explicit `rotation_adapter` object
+for the configured `AGENT_BOM_SECRET_PROVIDER`. Supported adapters are:
+
+| Provider value | Custody boundary | Rotation model |
+| --- | --- | --- |
+| `aws_secrets_manager` | Customer AWS account | `put-secret-value`, rollout restart, lifecycle verification |
+| `hashicorp_vault` | Customer Vault cluster | `vault kv put`, rollout restart, lifecycle verification |
+| `external_secrets` / `csi` | Customer upstream provider | Rotate upstream, wait for Kubernetes Secret sync, rollout restart |
+| `kubernetes_secret` | Customer Kubernetes Secret | Apply a rotated env-file secret manifest, rollout restart |
+| `operator_secret_manager` | Customer secret manager | Generic operator-owned change ticket and rollout |
+
+Every adapter response sets `secret_values_included=false`, names the expected
+secret-manager audit evidence, and includes a timestamp-recording command for
+the matching `*_LAST_ROTATED` metadata. `agent-bom` never fetches or returns the
+secret material.
+
 `agent-bom` does not replace the customer's KMS, Vault, IdP, or privileged
 access management system. The product exposes posture and supports rotation
 paths; the operator owns secret authority, approval workflow, and key custody.

--- a/src/agent_bom/api/secret_lifecycle.py
+++ b/src/agent_bom/api/secret_lifecycle.py
@@ -6,6 +6,11 @@ import os
 from datetime import datetime, timezone
 from typing import Any
 
+from agent_bom.api.secret_rotation_adapters import (
+    resolve_secret_rotation_adapter,
+    supported_secret_rotation_adapters,
+)
+
 
 def _env_enabled(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
@@ -207,10 +212,14 @@ def _external_secret_provider_posture() -> dict[str, Any]:
     vault_addr = os.environ.get("VAULT_ADDR", "").strip()
     aws_region = os.environ.get("AWS_REGION", "").strip() or os.environ.get("AWS_DEFAULT_REGION", "").strip()
     configured = bool(provider or external_secrets or vault_addr or aws_region)
+    resolved_provider = provider or ("hashicorp_vault" if vault_addr else "aws_environment" if aws_region else None)
+    adapter = resolve_secret_rotation_adapter(resolved_provider)
     return {
         "status": "configured" if configured else "not_declared",
         "configured": configured,
-        "provider": provider or ("hashicorp_vault" if vault_addr else "aws_environment" if aws_region else None),
+        "provider": resolved_provider,
+        "rotation_adapter": adapter.describe(),
+        "supported_rotation_adapters": supported_secret_rotation_adapters(),
         "external_secrets_enabled": external_secrets,
         "vault_addr_configured": bool(vault_addr),
         "aws_region_configured": bool(aws_region),
@@ -222,29 +231,6 @@ def _external_secret_provider_posture() -> dict[str, Any]:
                 "AGENT_BOM_SECRET_PROVIDER or use External Secrets/CSI."
             )
         ),
-    }
-
-
-def _provider_command(provider: str | None, secret_name: str, source_env: str | None) -> dict[str, str]:
-    label = source_env or secret_name
-    if provider == "aws_secrets_manager":
-        return {
-            "tool": "aws-secrets-manager",
-            "command": f"aws secretsmanager put-secret-value --secret-id <secret-id-for-{label}> --secret-string file://<new-secret-file>",
-        }
-    if provider == "hashicorp_vault":
-        return {
-            "tool": "vault",
-            "command": f"vault kv put <mount/path/agent-bom> {label}=@<new-secret-file>",
-        }
-    if provider in {"external_secrets", "csi"}:
-        return {
-            "tool": provider,
-            "command": "rotate the upstream provider value, then let External Secrets/CSI refresh the mounted Kubernetes Secret",
-        }
-    return {
-        "tool": "operator-secret-manager",
-        "command": f"update {label} in the customer secret manager; do not put raw secret values in Git or Helm values",
     }
 
 
@@ -267,6 +253,7 @@ def _rotation_action(name: str, posture: dict[str, Any], provider: str | None) -
     last_rotated_env = f"{source_env}_LAST_ROTATED" if source_env else f"AGENT_BOM_{name.upper()}_LAST_ROTATED"
     status = str(posture.get("rotation_status") or posture.get("status") or "unknown")
     needs_rotation = status in {"missing_required", "max_age_exceeded", "rotation_due", "unknown_age", "ephemeral"}
+    adapter = resolve_secret_rotation_adapter(provider)
     return {
         "name": name,
         "status": status,
@@ -278,7 +265,7 @@ def _rotation_action(name: str, posture: dict[str, Any], provider: str | None) -
         "rotation_days": posture.get("rotation_days"),
         "max_age_days": posture.get("max_age_days"),
         "provider": provider or "operator_secret_manager",
-        "provider_rotation": _provider_command(provider, name, source_env),
+        "provider_rotation": adapter.rotation_step(secret_name=name, source_env=source_env, last_rotated_env=last_rotated_env),
         "rollout": {
             "required": needs_rotation,
             "commands": [
@@ -293,6 +280,7 @@ def _rotation_action(name: str, posture: dict[str, Any], provider: str | None) -
         "record_timestamp": {
             "env": last_rotated_env,
             "value_format": "ISO-8601 UTC timestamp, for example 2026-04-24T00:00:00+00:00",
+            "adapter_command": adapter.timestamp_command(last_rotated_env=last_rotated_env),
         },
         "notes": posture.get("rotation_message") or posture.get("message") or "",
     }
@@ -314,6 +302,8 @@ def build_secret_rotation_plan(posture: dict[str, Any] | None = None) -> dict[st
         "generated_from": "/v1/auth/secrets/lifecycle",
         "secret_values_included": False,
         "provider": provider_name or "operator_secret_manager",
+        "rotation_adapter": resolve_secret_rotation_adapter(provider_name).describe(),
+        "supported_rotation_adapters": supported_secret_rotation_adapters(),
         "external_secret_provider_configured": bool(provider_info.get("configured")) if isinstance(provider_info, dict) else False,
         "action_count": len(active_actions),
         "actions": active_actions,

--- a/src/agent_bom/api/secret_rotation_adapters.py
+++ b/src/agent_bom/api/secret_rotation_adapters.py
@@ -1,0 +1,167 @@
+"""Non-secret secret-manager rotation adapter metadata.
+
+These adapters intentionally do not generate, read, or write secret values.
+They describe the operator-controlled rotation path for the configured
+customer secret manager so posture endpoints can produce stable evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SecretRotationAdapter:
+    """Describe one supported customer-secret-manager rotation path."""
+
+    name: str
+    tool: str
+    aliases: tuple[str, ...]
+    custody: str
+    rotation_model: str
+    command_template: str
+    timestamp_template: str
+    evidence: tuple[str, ...]
+
+    def command(self, *, secret_name: str, source_env: str | None) -> str:
+        label = source_env or secret_name
+        return self.command_template.format(label=label, secret_name=secret_name)
+
+    def timestamp_command(self, *, last_rotated_env: str) -> str:
+        return self.timestamp_template.format(last_rotated_env=last_rotated_env)
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "tool": self.tool,
+            "aliases": list(self.aliases),
+            "custody": self.custody,
+            "rotation_model": self.rotation_model,
+            "secret_values_included": False,
+            "evidence": list(self.evidence),
+        }
+
+    def rotation_step(
+        self,
+        *,
+        secret_name: str,
+        source_env: str | None,
+        last_rotated_env: str,
+    ) -> dict[str, Any]:
+        return {
+            "adapter": self.name,
+            "tool": self.tool,
+            "custody": self.custody,
+            "rotation_model": self.rotation_model,
+            "secret_values_included": False,
+            "command": self.command(secret_name=secret_name, source_env=source_env),
+            "timestamp_command": self.timestamp_command(last_rotated_env=last_rotated_env),
+            "evidence": list(self.evidence),
+        }
+
+
+_AWS = SecretRotationAdapter(
+    name="aws_secrets_manager",
+    tool="aws-secrets-manager",
+    aliases=("aws_secrets_manager", "aws-secrets-manager", "aws", "secretsmanager"),
+    custody="customer_aws_account",
+    rotation_model="put-secret-value_then_rollout_restart",
+    command_template=("aws secretsmanager put-secret-value --secret-id <secret-id-for-{label}> --secret-string file://<new-secret-file>"),
+    timestamp_template=(
+        "aws secretsmanager put-secret-value --secret-id <secret-id-for-{last_rotated_env}> --secret-string '<iso-8601-utc-timestamp>'"
+    ),
+    evidence=(
+        "Secrets Manager version ID for the rotated secret",
+        "CloudTrail PutSecretValue event ID",
+        "Kubernetes rollout restart and rollout status output",
+        "/v1/auth/secrets/lifecycle response after rotation",
+    ),
+)
+
+_VAULT = SecretRotationAdapter(
+    name="hashicorp_vault",
+    tool="vault",
+    aliases=("hashicorp_vault", "vault", "hashicorp-vault"),
+    custody="customer_vault_cluster",
+    rotation_model="kv_write_then_rollout_restart",
+    command_template="vault kv put <mount/path/agent-bom> {label}=@<new-secret-file>",
+    timestamp_template="vault kv put <mount/path/agent-bom> {last_rotated_env}=<iso-8601-utc-timestamp>",
+    evidence=(
+        "Vault write response or audit device request ID",
+        "Vault secret version for the rotated key",
+        "Kubernetes rollout restart and rollout status output",
+        "/v1/auth/secrets/lifecycle response after rotation",
+    ),
+)
+
+_EXTERNAL_SECRETS = SecretRotationAdapter(
+    name="external_secrets",
+    tool="external-secrets",
+    aliases=("external_secrets", "external-secrets", "eso", "csi"),
+    custody="customer_external_provider",
+    rotation_model="rotate_upstream_provider_then_wait_for_secret_sync",
+    command_template=(
+        "rotate {label} in the upstream provider, then wait for External Secrets or CSI to refresh the mounted Kubernetes Secret"
+    ),
+    timestamp_template=(
+        "set {last_rotated_env}=<iso-8601-utc-timestamp> in the upstream provider and wait for External Secrets or CSI sync"
+    ),
+    evidence=(
+        "ExternalSecret or SecretProviderClass sync condition",
+        "Kubernetes Secret resourceVersion after sync",
+        "Kubernetes rollout restart and rollout status output",
+        "/v1/auth/secrets/lifecycle response after rotation",
+    ),
+)
+
+_KUBERNETES_SECRET = SecretRotationAdapter(
+    name="kubernetes_secret",
+    tool="kubectl",
+    aliases=("kubernetes_secret", "kubernetes", "k8s", "k8s_secret"),
+    custody="customer_kubernetes_secret",
+    rotation_model="apply_secret_manifest_then_rollout_restart",
+    command_template=(
+        "kubectl create secret generic agent-bom-control-plane-auth "
+        "--from-env-file=<rotated-env-file> -n agent-bom --dry-run=client -o yaml | kubectl apply -f -"
+    ),
+    timestamp_template=(
+        "set {last_rotated_env}=<iso-8601-utc-timestamp> in <rotated-env-file>, then re-apply the Kubernetes Secret manifest"
+    ),
+    evidence=(
+        "Kubernetes Secret resourceVersion after apply",
+        "Kubernetes rollout restart and rollout status output",
+        "/v1/auth/secrets/lifecycle response after rotation",
+    ),
+)
+
+_GENERIC = SecretRotationAdapter(
+    name="operator_secret_manager",
+    tool="operator-secret-manager",
+    aliases=("operator_secret_manager", "generic", "customer_secret_manager"),
+    custody="customer_secret_manager",
+    rotation_model="operator_controlled_secret_swap_then_rollout_restart",
+    command_template="update {label} in the customer secret manager; do not put raw secret values in Git or Helm values",
+    timestamp_template="record {last_rotated_env}=<iso-8601-utc-timestamp> next to the rotated secret metadata",
+    evidence=(
+        "customer change ticket or secret-manager audit event",
+        "Kubernetes rollout restart and rollout status output",
+        "/v1/auth/secrets/lifecycle response after rotation",
+    ),
+)
+
+_ADAPTERS = (_AWS, _VAULT, _EXTERNAL_SECRETS, _KUBERNETES_SECRET, _GENERIC)
+_BY_ALIAS = {alias: adapter for adapter in _ADAPTERS for alias in adapter.aliases}
+
+
+def supported_secret_rotation_adapters() -> list[dict[str, Any]]:
+    """Return the non-secret supported adapter catalog."""
+
+    return [adapter.describe() for adapter in _ADAPTERS]
+
+
+def resolve_secret_rotation_adapter(provider: str | None) -> SecretRotationAdapter:
+    """Resolve a configured provider to a supported adapter."""
+
+    normalized = (provider or "").strip().lower().replace("-", "_")
+    return _BY_ALIAS.get(normalized, _GENERIC)

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -455,6 +455,8 @@ def test_auth_policy_reports_secret_lifecycle_posture(monkeypatch: pytest.Monkey
     assert lifecycle["status"] == "blocked"
     assert lifecycle["external_secret_provider"]["status"] == "configured"
     assert lifecycle["external_secret_provider"]["provider"] == "aws_secrets_manager"
+    assert lifecycle["external_secret_provider"]["rotation_adapter"]["name"] == "aws_secrets_manager"
+    assert "aws_secrets_manager" in {adapter["name"] for adapter in lifecycle["external_secret_provider"]["supported_rotation_adapters"]}
     assert lifecycle["secrets"]["browser_session_signing"]["status"] == "configured"
     assert lifecycle["secrets"]["browser_session_signing"]["rotation_status"] == "ok"
     assert lifecycle["secrets"]["browser_session_signing"]["age_days"] == 12
@@ -505,17 +507,55 @@ def test_auth_secret_rotation_plan_is_non_secret_and_actionable(monkeypatch: pyt
     assert plan["status"] == "action_required"
     assert plan["secret_values_included"] is False
     assert plan["provider"] == "aws_secrets_manager"
+    assert plan["rotation_adapter"]["name"] == "aws_secrets_manager"
     assert plan["action_count"] >= 1
     assert "super-secret-token" not in str(plan)
     scim_action = next(action for action in plan["actions"] if action["name"] == "scim_bearer")
     assert scim_action["status"] == "max_age_exceeded"
     assert scim_action["source_env"] == "AGENT_BOM_SCIM_BEARER_TOKEN"
     assert scim_action["last_rotated_env"] == "AGENT_BOM_SCIM_BEARER_TOKEN_LAST_ROTATED"
+    assert scim_action["provider_rotation"]["adapter"] == "aws_secrets_manager"
     assert scim_action["provider_rotation"]["tool"] == "aws-secrets-manager"
+    assert scim_action["provider_rotation"]["custody"] == "customer_aws_account"
+    assert scim_action["provider_rotation"]["secret_values_included"] is False
     assert "aws secretsmanager put-secret-value" in scim_action["provider_rotation"]["command"]
+    assert scim_action["provider_rotation"]["evidence"]
     assert scim_action["rollout"]["required"] is True
     assert "kubectl rollout restart deployment/agent-bom-api -n agent-bom" in scim_action["rollout"]["commands"]
     assert scim_action["record_timestamp"]["value_format"].startswith("ISO-8601")
+    assert "AGENT_BOM_SCIM_BEARER_TOKEN_LAST_ROTATED" in scim_action["record_timestamp"]["adapter_command"]
+
+
+def test_auth_secret_rotation_plan_supports_vault_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_rate_limit_env(monkeypatch)
+    monkeypatch.setenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY", "browser-secret")
+    monkeypatch.setenv("AGENT_BOM_CONTROL_PLANE_REPLICAS", "2")
+    monkeypatch.setenv("AGENT_BOM_SECRET_PROVIDER", "hashicorp_vault")
+
+    client = TestClient(app)
+    plan = client.get("/v1/auth/secrets/rotation-plan").json()
+
+    assert "browser-secret" not in str(plan)
+    assert plan["rotation_adapter"]["name"] == "hashicorp_vault"
+    browser_action = next(action for action in plan["actions"] if action["name"] == "browser_session_signing")
+    assert browser_action["provider_rotation"]["adapter"] == "hashicorp_vault"
+    assert browser_action["provider_rotation"]["tool"] == "vault"
+    assert "vault kv put" in browser_action["provider_rotation"]["command"]
+
+
+def test_auth_secret_rotation_plan_supports_kubernetes_secret_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_rate_limit_env(monkeypatch)
+    monkeypatch.setenv("AGENT_BOM_CONTROL_PLANE_REPLICAS", "2")
+    monkeypatch.setenv("AGENT_BOM_SECRET_PROVIDER", "kubernetes_secret")
+
+    client = TestClient(app)
+    plan = client.get("/v1/auth/secrets/rotation-plan").json()
+
+    assert plan["rotation_adapter"]["name"] == "kubernetes_secret"
+    browser_action = next(action for action in plan["actions"] if action["name"] == "browser_session_signing")
+    assert browser_action["provider_rotation"]["tool"] == "kubectl"
+    assert "--from-env-file=<rotated-env-file>" in browser_action["provider_rotation"]["command"]
+    assert browser_action["provider_rotation"]["secret_values_included"] is False
 
 
 def test_auth_quota_update_persists_tenant_override(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Summary
- add a non-secret rotation adapter registry for AWS Secrets Manager, HashiCorp Vault, External Secrets/CSI, Kubernetes Secrets, and generic customer secret managers
- expose adapter custody, rotation model, evidence expectations, timestamp commands, and `secret_values_included=false` in secret lifecycle and rotation-plan posture
- keep rotation operator-owned: agent-bom returns commands/evidence metadata but never reads, generates, or returns secret material
- document the supported adapter matrix in the enterprise security posture guide

Why
#1804 asks for customer secret-manager rotation adapters while preserving customer key custody. The existing rotation-plan endpoint already produced broad command strings; this makes the provider behavior explicit, testable, and evidence-oriented without turning agent-bom into the owner of customer secrets.

Validation
- uv run pytest tests/test_api_operator_policy.py -q
- uv run ruff check src/agent_bom/api/secret_rotation_adapters.py src/agent_bom/api/secret_lifecycle.py tests/test_api_operator_policy.py
- uv run mypy src/agent_bom/api/secret_rotation_adapters.py src/agent_bom/api/secret_lifecycle.py
- git diff --check
- pre-commit hooks on commit

Closes #1804
