### PR TITLE
deploy: add vanilla EKS production preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,8 @@ Backend defaults:
 | Need | Start here |
 |---|---|
 | fastest local pilot | [Deployment Overview](site-docs/deployment/overview.md) |
-| self-host in your AWS / EKS | [Deploy In Your Own AWS / EKS Infrastructure](site-docs/deployment/own-infra-eks.md) |
+| self-host in vanilla AWS / EKS | [Vanilla EKS Quickstart](site-docs/deployment/eks-vanilla-quickstart.md) |
+| self-host with mesh / ESO / cert-manager | [Deploy In Your Own AWS / EKS Infrastructure](site-docs/deployment/own-infra-eks.md) |
 | endpoint inventory and laptop rollout | [Endpoint Fleet](site-docs/deployment/endpoint-fleet.md) |
 | proxy and gateway runtime operations | [Runtime Operations](site-docs/deployment/runtime-operations.md) |
 | trust model, auth, tenant isolation | [ENTERPRISE_SECURITY_PLAYBOOK.md](docs/ENTERPRISE_SECURITY_PLAYBOOK.md) |

--- a/deploy/helm/agent-bom/examples/README.md
+++ b/deploy/helm/agent-bom/examples/README.md
@@ -11,6 +11,7 @@ product split.
 | `sqlite-pilot` | `eks-control-plane-sqlite-pilot-values.yaml` | Single-node packaged demo or short-lived pilot where Postgres is not ready yet |
 | `focused-pilot` | `eks-mcp-pilot-values.yaml` | Narrow EKS pilot with control plane, scanner, and tightened ingress |
 | `production` | `eks-production-values.yaml` | Postgres-backed production EKS rollout with autoscaling, backup, and ExternalSecrets |
+| `eks-vanilla` | `eks-vanilla-values.yaml` | Postgres-backed production EKS rollout with ALB, IRSA, Kubernetes Secrets, and no service mesh / ESO / cert-manager requirement |
 | `mesh-hardening` | `eks-istio-kyverno-values.yaml` | Overlay for Istio mTLS/authz and Kyverno policy-controller packaging |
 | `snowflake-backend` | `eks-snowflake-values.yaml` | Overlay for Snowflake governance and selected store parity, not a claim of full control-plane replacement |
 | `gateway-runtime` | `eks-mcp-pilot-values.yaml` + `gateway-upstreams.example.yaml` | Focused pilot plus central gateway rendering for shared MCP relay/policy |
@@ -61,7 +62,9 @@ python scripts/install_helm_profile.py production \
 
 - Start with `focused-pilot` for the narrow customer EKS story.
 - Use `sqlite-pilot` only for demos or single-node packaged pilots.
-- Move to `production` once Postgres, ingress, and backup ownership are real.
+- Move to `eks-vanilla` when you run EKS with ALB, IRSA, RDS/Postgres, and
+  Kubernetes Secrets but not Istio, External Secrets Operator, or cert-manager.
+- Move to `production` when you also run External Secrets and cert-manager.
 - Treat `mesh-hardening` and `snowflake-backend` as overlays, not separate products.
 - Treat `snowflake-backend` as a warehouse-native deployment mode with explicit parity boundaries, not the default production path.
 - Gateway remains an optional runtime surface layered onto the control plane, not a mandatory chokepoint.

--- a/deploy/helm/agent-bom/examples/eks-vanilla-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-vanilla-values.yaml
@@ -1,0 +1,146 @@
+# Vanilla EKS production profile.
+#
+# Use this when the cluster does not run Istio, External Secrets Operator, or
+# cert-manager. It is still a production-shaped profile: HA API/UI replicas,
+# HPA, RDS/Postgres via Kubernetes Secret, ALB ingress, IRSA, and persistent
+# browser/audit/trusted-proxy secrets. For laptop-speed demos, use
+# eks-control-plane-sqlite-pilot-values.yaml instead.
+
+controlPlane:
+  enabled: true
+  serviceMesh:
+    enabled: false
+  externalSecrets:
+    enabled: false
+  observability:
+    grafanaDashboard:
+      enabled: true
+    prometheusRule:
+      enabled: true
+  podAntiAffinity:
+    enabled: true
+  priorityClass:
+    create: true
+    name: agent-bom-control-plane
+  api:
+    replicas: 2
+    env:
+      - name: AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT
+        value: "1"
+      - name: AGENT_BOM_REQUIRE_SHARED_SCIM_STORE
+        value: "1"
+      - name: AGENT_BOM_SECRET_PROVIDER
+        value: "kubernetes_secret"
+      - name: AGENT_BOM_REQUIRE_AUDIT_HMAC
+        value: "1"
+      - name: AGENT_BOM_POSTGRES_POOL_MIN_SIZE
+        value: "5"
+      - name: AGENT_BOM_POSTGRES_POOL_MAX_SIZE
+        value: "20"
+      - name: AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECONDS
+        value: "5"
+      - name: AGENT_BOM_POSTGRES_STATEMENT_TIMEOUT_MS
+        value: "15000"
+      - name: AGENT_BOM_API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT
+        value: "25"
+      - name: AGENT_BOM_API_MAX_RETAINED_JOBS_PER_TENANT
+        value: "1000"
+      - name: AGENT_BOM_API_MAX_FLEET_AGENTS_PER_TENANT
+        value: "5000"
+      - name: AGENT_BOM_API_MAX_SCHEDULES_PER_TENANT
+        value: "250"
+    autoscaling:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 6
+      targetCPUUtilizationPercentage: 70
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 300
+    envFrom:
+      - secretRef:
+          name: agent-bom-control-plane-db
+      - secretRef:
+          name: agent-bom-control-plane-auth
+  ui:
+    replicas: 2
+    autoscaling:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 4
+      targetCPUUtilizationPercentage: 70
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 300
+    env:
+      - name: NEXT_PUBLIC_API_URL
+        value: ""
+  ingress:
+    enabled: true
+    className: alb
+    annotations:
+      alb.ingress.kubernetes.io/scheme: internal
+      alb.ingress.kubernetes.io/target-type: ip
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+      alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:REPLACE_ME_REGION:REPLACE_ME_ACCOUNT_ID:certificate/REPLACE_ME_CERTIFICATE_ID
+      alb.ingress.kubernetes.io/ssl-redirect: "443"
+      # Optional:
+      # alb.ingress.kubernetes.io/wafv2-acl-arn: arn:aws:wafv2:REPLACE_ME_REGION:REPLACE_ME_ACCOUNT_ID:regional/webacl/REPLACE_ME_NAME/REPLACE_ME_ID
+    hosts:
+      - host: agent-bom.internal.example.com
+    tls: []
+  backup:
+    enabled: true
+    schedule: "0 3 * * *"
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::REPLACE_ME_ACCOUNT_ID:role/REPLACE_ME_AGENT_BOM_BACKUP_ROLE
+    destination:
+      bucket: agent-bom-prod-backups
+      prefix: agent-bom/postgres
+      bucketRegion: REPLACE_ME_BUCKET_REGION
+      encryption:
+        enabled: true
+        mode: aws:kms
+        kmsKeyId: alias/agent-bom-backups
+    envFrom:
+      - secretRef:
+          name: agent-bom-control-plane-db
+
+scanner:
+  enabled: true
+  allNamespaces: true
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::REPLACE_ME_ACCOUNT_ID:role/REPLACE_ME_AGENT_BOM_DISCOVERY_ROLE
+  extraArgs:
+    - --k8s-mcp
+    - --k8s-all-namespaces
+    - --introspect
+    - --enforce
+    - --preset
+    - enterprise
+
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::REPLACE_ME_ACCOUNT_ID:role/REPLACE_ME_AGENT_BOM_DISCOVERY_ROLE
+
+monitor:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+
+topologySpread:
+  enabled: true
+
+networkPolicy:
+  enabled: true
+  # ALB target-type ip traffic reaches pod IPs directly; Kubernetes
+  # NetworkPolicy cannot select the ALB as a pod. Keep egress policy enabled,
+  # then enable restricted ingress only when your CNI supports ALB source CIDR
+  # controls or you provide explicit ingress rules for your environment.
+  restrictIngress: false
+
+pdb:
+  enabled: true
+  minAvailable: 1

--- a/deploy/helm/agent-bom/templates/tests/test-connection.yaml
+++ b/deploy/helm/agent-bom/templates/tests/test-connection.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.tests.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "agent-bom.name" . }}-test-connection"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: helm-test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  securityContext:
+    {{- toYaml .Values.podSecurityContext | nindent 4 }}
+  containers:
+    - name: test-connection
+      image: "{{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}"
+      imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      resources:
+        {{- toYaml .Values.tests.resources | nindent 8 }}
+      command:
+        - python
+        - -c
+        - |
+          from __future__ import annotations
+
+          import sys
+          import urllib.request
+
+          checks = [
+              "http://{{ include "agent-bom.name" . }}-api:{{ .Values.controlPlane.api.port }}/health",
+              "http://{{ include "agent-bom.name" . }}-api:{{ .Values.controlPlane.api.port }}/readyz",
+          ]
+          {{- if and .Values.tests.includeUi .Values.controlPlane.ui.enabled .Values.controlPlane.ui.service.enabled }}
+          checks.append("http://{{ include "agent-bom.name" . }}-ui:{{ .Values.controlPlane.ui.port }}/")
+          {{- end }}
+
+          for url in checks:
+              with urllib.request.urlopen(url, timeout=5) as response:
+                  if response.status >= 400:
+                      raise SystemExit(f"{url} returned HTTP {response.status}")
+                  print(f"ok {url} {response.status}")
+          sys.exit(0)
+{{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -28,6 +28,21 @@ topologySpread:
     enabled: true
     topologyKey: kubernetes.io/hostname
 
+tests:
+  enabled: true
+  includeUi: true
+  image:
+    repository: agentbom/agent-bom
+    tag: "0.81.3"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+
 scanner:
   enabled: true
   schedule: "0 */6 * * *"

--- a/site-docs/deployment/eks-vanilla-quickstart.md
+++ b/site-docs/deployment/eks-vanilla-quickstart.md
@@ -1,0 +1,114 @@
+# Vanilla EKS Quickstart
+
+Use this path for a production-shaped EKS install that does not depend on
+Istio, External Secrets Operator, or cert-manager. The profile uses AWS Load
+Balancer Controller, IRSA, RDS/Postgres, and Kubernetes Secrets.
+
+Choose the right profile first:
+
+| Need | Profile |
+| --- | --- |
+| Laptop-speed demo | `eks-control-plane-sqlite-pilot-values.yaml` |
+| Vanilla EKS production | `eks-vanilla-values.yaml` |
+| Mesh-hardened production | `eks-istio-kyverno-values.yaml` |
+
+## Prerequisites
+
+- EKS cluster with AWS Load Balancer Controller installed
+- ACM certificate ARN for the control-plane hostname
+- RDS/Postgres URL for `AGENT_BOM_POSTGRES_URL`
+- IRSA role ARN for scanner/API AWS read access and backup access
+- Helm 3
+
+## 1. Create The Namespace
+
+```bash
+kubectl create namespace agent-bom
+```
+
+## 2. Create Secret Env Files
+
+Create `agent-bom-db.env` locally:
+
+```bash
+AGENT_BOM_POSTGRES_URL=postgresql://agent_bom:REPLACE_ME@REPLACE_ME_RDS_ENDPOINT:5432/agent_bom
+```
+
+Create `agent-bom-auth.env` locally:
+
+```bash
+AGENT_BOM_AUDIT_HMAC_KEY=REPLACE_ME_32_BYTES_OR_LONGER
+AGENT_BOM_AUDIT_HMAC_KEY_LAST_ROTATED=2026-04-26T00:00:00+00:00
+AGENT_BOM_BROWSER_SESSION_SIGNING_KEY=REPLACE_ME_32_BYTES_OR_LONGER
+AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_LAST_ROTATED=2026-04-26T00:00:00+00:00
+AGENT_BOM_RATE_LIMIT_KEY=REPLACE_ME_32_BYTES_OR_LONGER
+AGENT_BOM_RATE_LIMIT_KEY_LAST_ROTATED=2026-04-26T00:00:00+00:00
+AGENT_BOM_TRUST_PROXY_AUTH_SECRET=REPLACE_ME_32_BYTES_OR_LONGER
+AGENT_BOM_TRUST_PROXY_AUTH_ISSUER=aws-alb
+```
+
+Add OIDC, SAML, or SCIM values to the same auth env file when those features
+are enabled. Keep the env files in your secret-management workflow, not in Git.
+
+Apply the Kubernetes Secrets:
+
+```bash
+kubectl create secret generic agent-bom-control-plane-db \
+  --namespace agent-bom \
+  --from-env-file=agent-bom-db.env
+
+kubectl create secret generic agent-bom-control-plane-auth \
+  --namespace agent-bom \
+  --from-env-file=agent-bom-auth.env
+```
+
+## 3. Customize The Values File
+
+Copy the shipped profile and replace placeholders:
+
+```bash
+cp deploy/helm/agent-bom/examples/eks-vanilla-values.yaml ./agent-bom-eks-vanilla-values.yaml
+```
+
+Update:
+
+- `alb.ingress.kubernetes.io/certificate-arn`
+- `controlPlane.ingress.hosts[0].host`
+- IRSA role ARNs
+- backup bucket, region, and KMS key
+
+## 4. Install
+
+```bash
+helm upgrade --install agent-bom deploy/helm/agent-bom \
+  --namespace agent-bom \
+  --create-namespace \
+  -f ./agent-bom-eks-vanilla-values.yaml
+```
+
+## 5. Verify
+
+```bash
+kubectl get ingress -n agent-bom
+curl -fsS https://agent-bom.internal.example.com/health
+curl -fsS https://agent-bom.internal.example.com/readyz
+helm test agent-bom -n agent-bom
+```
+
+The API uses `/health` for liveness and `/readyz` for dependency readiness.
+Gateway and sidecar runtime surfaces use `/healthz`.
+
+## NetworkPolicy Note
+
+The vanilla profile keeps NetworkPolicy enabled for egress controls, but it
+does not enable restricted ingress by default. With ALB `target-type: ip`, data
+traffic reaches pod IPs directly and cannot be selected as an in-cluster
+controller pod. Enable restricted ingress only after you add environment-specific
+CIDR or CNI policy controls that match your ALB data path.
+
+## Going Further
+
+- Mesh and policy-controller hardening:
+  `deploy/helm/agent-bom/examples/eks-istio-kyverno-values.yaml`
+- Full EKS operator guide: `site-docs/deployment/own-infra-eks.md`
+- Postgres ownership: `site-docs/deployment/postgres-provisioning.md`

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -95,7 +95,8 @@ Use these pages in this order:
 | If you need... | Read this first | Then use... |
 |---|---|---|
 | the fastest pilot | this page | `deploy/docker-compose.pilot.yml` |
-| the paved production rollout | this page | [Deploy In Your Own AWS / EKS Infrastructure](own-infra-eks.md) |
+| vanilla EKS production | this page | [Vanilla EKS Quickstart](eks-vanilla-quickstart.md) |
+| mesh / ESO / cert-manager production | this page | [Deploy In Your Own AWS / EKS Infrastructure](own-infra-eks.md) |
 | a focused endpoint + MCP pilot | this page | [Enterprise MCP / Endpoint Pilot](enterprise-pilot.md) |
 | raw Helm, Docker, Terraform, or Kubernetes details | this page | the matching reference page only after you know you are leaving the paved path |
 

--- a/src/agent_bom/deploy_profiles.py
+++ b/src/agent_bom/deploy_profiles.py
@@ -46,6 +46,11 @@ def helm_validation_profiles(repo_root: Path) -> list[HelmValidationProfile]:
             values_files=(examples / "eks-production-values.yaml",),
         ),
         HelmValidationProfile(
+            name="eks-vanilla",
+            description="Production EKS profile using ALB, IRSA, Kubernetes Secrets, and RDS/Postgres.",
+            values_files=(examples / "eks-vanilla-values.yaml",),
+        ),
+        HelmValidationProfile(
             name="mesh-hardening",
             description="Istio and Kyverno hardening overlay for operator-managed clusters.",
             values_files=(examples / "eks-istio-kyverno-values.yaml",),

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -275,6 +275,7 @@ def test_helm_examples_readme_is_shipped():
     body = readme.read_text()
     assert "focused-pilot" in body
     assert "sqlite-pilot" in body
+    assert "eks-vanilla" in body
     assert "gateway-runtime" in body
     assert "install_helm_profile.py" in body
 
@@ -593,6 +594,48 @@ def test_production_values_enable_operator_defaults():
     assert production["topologySpread"]["enabled"] is True
     assert production["networkPolicy"]["restrictIngress"] is True
     assert "cert-manager.io/cluster-issuer" in production["controlPlane"]["ingress"]["annotations"]
+
+
+def test_eks_vanilla_values_enable_ha_without_mesh_or_external_secret_dependencies():
+    """Vanilla EKS profile should be production-shaped without mesh/ESO/cert-manager."""
+    values = yaml.safe_load((HELM_DIR / "examples" / "eks-vanilla-values.yaml").read_text())
+    control_plane = values["controlPlane"]
+    api = control_plane["api"]
+    ui = control_plane["ui"]
+
+    assert control_plane["enabled"] is True
+    assert control_plane["serviceMesh"]["enabled"] is False
+    assert control_plane["externalSecrets"]["enabled"] is False
+    assert api["replicas"] == 2
+    assert ui["replicas"] == 2
+    assert api["autoscaling"]["enabled"] is True
+    assert ui["autoscaling"]["enabled"] is True
+    assert api["envFrom"] == [
+        {"secretRef": {"name": "agent-bom-control-plane-db"}},
+        {"secretRef": {"name": "agent-bom-control-plane-auth"}},
+    ]
+    env = {entry["name"]: entry["value"] for entry in api["env"]}
+    assert env["AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT"] == "1"
+    assert env["AGENT_BOM_REQUIRE_SHARED_SCIM_STORE"] == "1"
+    assert env["AGENT_BOM_SECRET_PROVIDER"] == "kubernetes_secret"
+    assert env["AGENT_BOM_REQUIRE_AUDIT_HMAC"] == "1"
+    assert control_plane["ingress"]["className"] == "alb"
+    annotations = control_plane["ingress"]["annotations"]
+    assert annotations["alb.ingress.kubernetes.io/target-type"] == "ip"
+    assert "alb.ingress.kubernetes.io/certificate-arn" in annotations
+    assert values["networkPolicy"]["enabled"] is True
+    assert values["networkPolicy"]["restrictIngress"] is False
+    assert values["topologySpread"]["enabled"] is True
+    assert values["pdb"]["enabled"] is True
+
+
+def test_helm_test_connection_template_checks_api_health_and_readyz():
+    """Helm test should probe the API's real health endpoints."""
+    template = (HELM_DIR / "templates" / "tests" / "test-connection.yaml").read_text()
+    assert '"helm.sh/hook": test' in template
+    assert "/health" in template
+    assert "/readyz" in template
+    assert "/healthz" not in template
 
 
 def test_external_secret_template_supports_top_level_secret_store_defaults():

--- a/tests/test_deploy_profiles.py
+++ b/tests/test_deploy_profiles.py
@@ -17,6 +17,7 @@ def test_helm_validation_profiles_reference_existing_chart_assets():
         "sqlite-pilot",
         "focused-pilot",
         "production",
+        "eks-vanilla",
         "mesh-hardening",
         "snowflake-backend",
         "gateway-runtime",


### PR DESCRIPTION
Summary
- add an EKS vanilla production Helm profile for ALB + IRSA + RDS/Postgres + Kubernetes Secrets, without Istio, External Secrets Operator, or cert-manager assumptions
- add a Helm test pod that checks the API `/health` and `/readyz` endpoints and optionally checks the UI service
- wire the new profile into the packaged Helm profile registry and existing profile validation matrix
- publish a vanilla EKS quickstart and link it from the README/deployment overview

Why
The chart already supports both enterprise mesh/ESO/cert-manager installs and vanilla Kubernetes primitives, but only the mesh/ExternalSecrets production example was fully copyable. This makes vanilla EKS a first-class, render-validated production path while keeping the SQLite profile as the single-node demo path.

Notes
- The vanilla profile is HA by default: API/UI replicas start at 2 with HPA enabled.
- Secrets are provided via Kubernetes Secret env files to avoid shell-history leakage and preserve customer custody.
- NetworkPolicy remains enabled for egress controls, but restricted ingress is off by default because ALB `target-type: ip` traffic does not originate from an in-cluster controller pod.

Validation
- uv run pytest tests/test_deploy_manifests.py tests/test_deploy_profiles.py -q
- uv run ruff check src/agent_bom/deploy_profiles.py tests/test_deploy_manifests.py tests/test_deploy_profiles.py
- uv run mypy src/agent_bom/deploy_profiles.py
- python3 scripts/validate_helm_profiles.py --list
- git diff --check
- pre-commit hooks on commit

Could not run `python3 scripts/validate_helm_profiles.py --profile eks-vanilla` locally because Helm is not installed in this environment; the profile is wired into the existing CI Helm validation path.

Refs #1807
Refs #1839
