### PR TITLE
fix: harden audit contract runtime gaps

### DIFF
--- a/contracts/v1/examples/scan-report.minimal.json
+++ b/contracts/v1/examples/scan-report.minimal.json
@@ -16,6 +16,7 @@
     {
       "name": "demo-agent",
       "stable_id": "agent:demo-agent",
+      "agent_type": "custom",
       "type": "custom",
       "status": "configured",
       "mcp_servers": []

--- a/contracts/v1/scan-report.schema.json
+++ b/contracts/v1/scan-report.schema.json
@@ -27,11 +27,24 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["name", "stable_id", "type", "status", "mcp_servers"],
+        "required": ["name", "stable_id", "status", "mcp_servers"],
+        "anyOf": [
+          { "required": ["agent_type"] },
+          { "required": ["type"] }
+        ],
         "properties": {
           "name": { "type": "string", "minLength": 1 },
           "stable_id": { "type": "string", "minLength": 1 },
-          "type": { "type": "string", "minLength": 1 },
+          "agent_type": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Canonical agent type field used by the Python model and UI clients."
+          },
+          "type": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Backward-compatible alias for agent_type retained for v1 scan-report consumers."
+          },
           "status": { "type": "string", "minLength": 1 },
           "mcp_servers": { "type": "array" }
         },

--- a/src/agent_bom/ai_enrich.py
+++ b/src/agent_bom/ai_enrich.py
@@ -53,6 +53,11 @@ _cache: dict[str, str] = {}
 _cache_lock = threading.RLock()
 
 
+def _response_text(value: object) -> str:
+    """Return stripped provider text only when the provider returned a string."""
+    return value.strip() if isinstance(value, str) else ""
+
+
 def _ai_cache_get(key: str) -> str | None:
     """Read a cached AI response with synchronization."""
     with _cache_lock:
@@ -202,7 +207,9 @@ async def _call_ollama_direct(prompt: str, model: str, max_tokens: int = 500) ->
             )
             if resp.status_code == 200:
                 data = resp.json()
-                text = data.get("message", {}).get("content", "").strip()
+                message = data.get("message", {})
+                content = message.get("content") if isinstance(message, dict) else None
+                text = _response_text(content)
                 if text:
                     _ai_cache_put(key, text)
                     return text
@@ -232,7 +239,9 @@ async def _call_llm_via_litellm(prompt: str, model: str, max_tokens: int = 500) 
             max_tokens=max_tokens,
             temperature=0.3,
         )
-        text = response.choices[0].message.content.strip()
+        text = _response_text(response.choices[0].message.content)
+        if not text:
+            return None
         _ai_cache_put(key, text)
         return text
     except ImportError:
@@ -272,7 +281,7 @@ async def _call_huggingface(
             max_tokens=max_tokens,
             temperature=0.3,
         )
-        text = response.choices[0].message.content.strip()
+        text = _response_text(response.choices[0].message.content)
         if text:
             _ai_cache_put(key, text)
             return text

--- a/src/agent_bom/cli/_analysis.py
+++ b/src/agent_bom/cli/_analysis.py
@@ -381,7 +381,8 @@ def dashboard_cmd(report: Optional[str], port: int):
         cmd += ["--", "--report", report]
 
     try:
-        subprocess.run(cmd, check=True)
+        # Foreground server command: intentionally runs until the operator stops it.
+        subprocess.run(cmd, check=True, timeout=None)
     except KeyboardInterrupt:
         pass
     except subprocess.CalledProcessError as exc:

--- a/src/agent_bom/deploy_teardown.py
+++ b/src/agent_bom/deploy_teardown.py
@@ -24,6 +24,7 @@ class CommandStep:
     label: str
     command: tuple[str, ...]
     required: bool = True
+    timeout_seconds: int = 600
 
 
 @dataclass(frozen=True)
@@ -97,12 +98,14 @@ def build_reference_teardown_plan(
                 f"--timeout={max(1, wait_timeout_seconds)}s",
             ),
             required=False,
+            timeout_seconds=max(1, wait_timeout_seconds) + 30,
         )
         if delete_namespace:
             namespace_delete_step = CommandStep(
                 label="Delete the dedicated namespace after Helm resources are gone",
                 command=("kubectl", "delete", "namespace", namespace, "--ignore-not-found=true"),
                 required=False,
+                timeout_seconds=600,
             )
 
     if not skip_terraform_destroy:
@@ -111,6 +114,7 @@ def build_reference_teardown_plan(
             label="Destroy the product-owned AWS baseline",
             command=(terraform_exec, f"-chdir={terraform_root}", "destroy", "-auto-approve"),
             required=True,
+            timeout_seconds=3600,
         )
 
     if delete_local_state:
@@ -118,6 +122,7 @@ def build_reference_teardown_plan(
             label="Delete the local generated state and summaries",
             command=("rm", "-rf", str(state_root)),
             required=False,
+            timeout_seconds=300,
         )
 
     return TeardownPlan(
@@ -202,7 +207,7 @@ def _run_step(step: CommandStep, *, dry_run: bool) -> None:
     if dry_run:
         sys.stdout.write(f"+ {shlex.join(step.command)}\n")
         return
-    subprocess.run(step.command, check=step.required)
+    subprocess.run(step.command, check=step.required, timeout=step.timeout_seconds)
 
 
 def execute_teardown_plan(plan: TeardownPlan, *, dry_run: bool = False) -> str:

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -278,6 +278,7 @@ def _build_inventory_snapshot(report: AIBOMReport) -> dict:
             {
                 "id": agent.stable_id,
                 "name": agent.name,
+                "agent_type": agent.agent_type.value,
                 "type": agent.agent_type.value,
                 "status": agent.status.value,
                 "config_path": agent.config_path,
@@ -527,6 +528,7 @@ def to_json(report: AIBOMReport) -> dict:
             {
                 "name": agent.name,
                 "stable_id": agent.stable_id,
+                "agent_type": agent.agent_type.value,
                 "type": agent.agent_type.value,
                 "config_path": agent.config_path,
                 "source": agent.source,

--- a/tests/test_audit_round2.py
+++ b/tests/test_audit_round2.py
@@ -104,6 +104,15 @@ def test_ai_cache_put_bounded():
         ai_enrich._cache.clear()
 
 
+def test_ai_response_text_ignores_missing_provider_content():
+    """AI providers may return None content for filtered or empty completions."""
+    from agent_bom import ai_enrich
+
+    assert ai_enrich._response_text(None) == ""
+    assert ai_enrich._response_text({"content": "not-a-string"}) == ""
+    assert ai_enrich._response_text("  actionable summary  ") == "actionable summary"
+
+
 # ── Proxy metrics bounds ─────────────────────────────────────────────────────
 
 

--- a/tests/test_contract_schemas.py
+++ b/tests/test_contract_schemas.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 import jsonschema
+
+from agent_bom.models import Agent, AgentStatus, AgentType, AIBOMReport
+from agent_bom.output import to_json
 
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACTS = ROOT / "contracts" / "v1"
@@ -29,3 +33,38 @@ def test_contract_examples_match_their_schema() -> None:
         schema_path = CONTRACTS / example_path.name.replace(".minimal.json", ".schema.json")
         assert schema_path.exists(), f"missing schema for {example_path.name}"
         jsonschema.validate(_load(example_path), _load(schema_path))
+
+
+def test_scan_report_serializer_matches_contract_schema() -> None:
+    """Guard the public scan-report contract boundary.
+
+    The Python/UI model uses ``agent_type``. The v1 scan report keeps ``type``
+    as a compatibility alias so old and new consumers can validate safely.
+    """
+    report = AIBOMReport(
+        agents=[
+            Agent(
+                name="demo-agent",
+                agent_type=AgentType.CLAUDE_DESKTOP,
+                config_path="/tmp/claude.json",
+                status=AgentStatus.CONFIGURED,
+            )
+        ],
+        generated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        scan_id="scan-contract-001",
+        tool_version="0.81.3",
+    )
+
+    payload = to_json(report)
+    jsonschema.validate(payload, _load(CONTRACTS / "scan-report.schema.json"))
+
+    agent_payload = payload["agents"][0]
+    assert agent_payload["agent_type"] == "claude-desktop"
+    assert agent_payload["type"] == "claude-desktop"
+
+
+def test_scan_report_contract_accepts_agent_type_without_legacy_type() -> None:
+    payload = _load(CONTRACTS / "examples" / "scan-report.minimal.json")
+    payload["agents"][0].pop("type")
+
+    jsonschema.validate(payload, _load(CONTRACTS / "scan-report.schema.json"))

--- a/tests/test_deploy_teardown.py
+++ b/tests/test_deploy_teardown.py
@@ -81,7 +81,8 @@ def test_cli_teardown_runs_expected_commands(tmp_path: Path, monkeypatch):
 
     commands: list[tuple[str, ...]] = []
 
-    def fake_run(cmd: tuple[str, ...] | list[str], check: bool = True):
+    def fake_run(cmd: tuple[str, ...] | list[str], check: bool = True, timeout: int | None = None):
+        assert timeout is not None
         commands.append(tuple(cmd))
         return subprocess.CompletedProcess(cmd, 0)
 

--- a/tests/test_subprocess_timeout_policy.py
+++ b/tests/test_subprocess_timeout_policy.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src" / "agent_bom"
+TIMEOUT_ENFORCED = {"run", "check_call", "check_output"}
+
+
+def test_blocking_subprocess_helpers_declare_timeout() -> None:
+    """Keep blocking subprocess helpers bounded or explicitly marked long-running."""
+    missing: list[str] = []
+
+    for path in sorted(SRC.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr not in TIMEOUT_ENFORCED:
+                continue
+            if not isinstance(node.func.value, ast.Name) or node.func.value.id != "subprocess":
+                continue
+            if not any(keyword.arg == "timeout" for keyword in node.keywords):
+                rel = path.relative_to(ROOT)
+                missing.append(f"{rel}:{node.lineno} subprocess.{node.func.attr}")
+
+    assert not missing, "subprocess calls missing timeout=:\n" + "\n".join(missing)


### PR DESCRIPTION
## Summary
- fix the scan-report contract drift by emitting canonical agent_type plus legacy type, and updating the v1 schema to validate either field
- guard AI enrichment providers that return null or non-string message content
- add finite subprocess timeouts for teardown commands and enforce timeout= on blocking subprocess helpers

Closes #1952

## Validation
- uv run pytest tests/test_contract_schemas.py tests/test_output_cov.py::test_to_json_with_agents tests/test_audit_round2.py::test_ai_response_text_ignores_missing_provider_content tests/test_deploy_teardown.py::test_cli_teardown_runs_expected_commands tests/test_subprocess_timeout_policy.py -q
- uv run ruff check src/agent_bom/output/json_fmt.py src/agent_bom/ai_enrich.py src/agent_bom/deploy_teardown.py src/agent_bom/cli/_analysis.py tests/test_contract_schemas.py tests/test_audit_round2.py tests/test_deploy_teardown.py tests/test_subprocess_timeout_policy.py