### PR TITLE
docs: align ops and frontend hygiene

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/bin/bash
+set -euo pipefail
 # ClusterFuzzLite build script for agent-bom.
 #
 # Installs atheris and agent-bom, then copies fuzz targets to $OUT.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,41 @@ jobs:
           print(f"CHANGELOG entry present: {tag}")
           PY
 
+      - name: Verify auxiliary versions track the release tag
+        run: |
+          python3 - <<'PY'
+          import json
+          import re
+          from pathlib import Path
+
+          tag = "${{ steps.meta.outputs.version }}"
+          errors: list[str] = []
+
+          # Helm chart `version:` (chart SemVer) and `appVersion:` both track the platform tag.
+          chart_text = Path("deploy/helm/agent-bom/Chart.yaml").read_text(encoding="utf-8")
+          chart_version = re.search(r"^version:\s*(\S+)", chart_text, re.M)
+          chart_app_version = re.search(r'^appVersion:\s*"([^"]+)"', chart_text, re.M)
+          if not chart_version:
+              errors.append("Chart.yaml: version: not found")
+          elif chart_version.group(1) != tag:
+              errors.append(f"Chart.yaml version {chart_version.group(1)} does not match tag {tag}")
+          if not chart_app_version:
+              errors.append("Chart.yaml: appVersion: not found")
+          elif chart_app_version.group(1) != tag:
+              errors.append(f"Chart.yaml appVersion {chart_app_version.group(1)} does not match tag {tag}")
+
+          # ui/package.json `version` tracks the platform tag so the published image and
+          # the bundle manifest agree on what version is shipping.
+          ui_pkg = json.loads(Path("ui/package.json").read_text(encoding="utf-8"))
+          ui_version = ui_pkg.get("version")
+          if ui_version != tag:
+              errors.append(f"ui/package.json version {ui_version!r} does not match tag {tag}")
+
+          if errors:
+              raise SystemExit("\n".join(errors))
+          print(f"Auxiliary versions aligned with {tag}: chart, appVersion, ui/package.json")
+          PY
+
       - name: Block Finder duplicate artifacts
         run: python3 scripts/check_duplicate_artifacts.py
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,7 @@ pytest tests/test_core.py -v        # specific file
 - **Types:** Type hints on all new public functions. `mypy` is run in CI.
 - **No `print()`** — use `console.print()` (Rich) in CLI code, `logging` in library code.
 - **No stubs or vaporware** — only document and claim features that are implemented and tested.
+- **Shell scripts:** every script must enable strict mode at the top. Bash scripts (`#!/usr/bin/env bash` or `#!/bin/bash`) must use `set -euo pipefail`. POSIX `sh` scripts (`#!/bin/sh`) must use `set -eu` — `pipefail` is a non-POSIX extension and is intentionally omitted on `sh` shebangs to keep endpoint installers (Jamf, Kandji, Alpine `ash`) portable.
 
 Pre-commit hooks enforce ruff on every commit. Install once with `pre-commit install`.
 

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: agent-bom
 description: Open security scanner and graph for AI supply chain and infrastructure — discover agents and MCP, map blast radius, and inspect runtime.
-version: 0.1.0
+version: 0.81.3
 appVersion: "0.81.3"
 type: application
 keywords:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,8 +137,11 @@ nav:
       - MCP Tools: reference/mcp-tools.md
       - CLI Commands: reference/cli.md
       - CLI Debug Guide: reference/cli-debug.md
+      - CLI Exit Codes and HTTP Status Mapping: reference/exit-codes.md
       - Remediate Output Contract: reference/remediate-output.md
       - Configuration: reference/configuration.md
+  - Integrations:
+      - Smithery: integrations/smithery.md
   - API Reference:
       - Models: api/models.md
       - Output: api/output.md

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -38,9 +38,13 @@ VERSION_LOCATIONS: list[tuple[str, re.Pattern, str]] = [
     ("deploy/docker-compose.fullstack.yml", re.compile(r"(agentbom/agent-bom(?:-ui)?:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
     ("deploy/docker-compose.platform.yml", re.compile(r"(agentbom/agent-bom(?:-ui)?:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
     ("deploy/k8s/daemonset.yaml", re.compile(r"(agentbom/agent-bom:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
-    # Helm chart
+    # Helm chart — both chart `version:` and `appVersion:` track the platform release
+    ("deploy/helm/agent-bom/Chart.yaml", re.compile(r"^(version:\s*)\S+", re.M), r"\g<1>{v}"),
     ("deploy/helm/agent-bom/Chart.yaml", re.compile(r'^(appVersion:\s*")[^"]+(")', re.M), r"\g<1>{v}\g<2>"),
     ("deploy/helm/agent-bom/values.yaml", re.compile(r'^(\s*tag:\s*")[^"]+(")', re.M), r"\g<1>{v}\g<2>"),
+    # Frontend package — UI version tracks the platform release so the docker image and
+    # the Next.js build manifest agree on what version is shipping
+    ("ui/package.json", re.compile(r'^(\s*"version":\s*")[^"]+(",?)', re.M), r"\g<1>{v}\g<2>"),
 ]
 
 OPENCLAW_SKILL_PATTERNS: list[tuple[str, re.Pattern, str]] = [

--- a/site-docs/integrations/smithery.md
+++ b/site-docs/integrations/smithery.md
@@ -1,0 +1,82 @@
+# Smithery Integration
+
+agent-bom is published in the [Smithery](https://smithery.ai) MCP catalog. This page
+documents the field-naming convention used by Smithery's session config and how those
+values map to the environment variables the agent-bom MCP server actually reads.
+
+## Why two naming conventions exist
+
+agent-bom standardises on `AGENT_BOM_*` snake-case environment variables across CLI,
+API, Helm values, Docker Compose, and the runtime MCP server. Smithery's
+`configSchema` follows the [JSON Schema](https://json-schema.org/) draft convention
+used by the Smithery SDK and hosted UI, which expects camelCase property names. As a
+result, the public Smithery integration manifest at `integrations/smithery.yaml`
+declares config fields in camelCase, while the agent-bom code path that consumes them
+expects snake-case env vars.
+
+This is not a drift bug — it is the documented translation boundary between two
+ecosystems. Smithery's runner is responsible for promoting session config values into
+the process environment before invoking `agent_bom.mcp_server.create_smithery_server`.
+
+## Mapping table
+
+The current `integrations/smithery.yaml` schema declares two optional config fields.
+The Smithery runner promotes each camelCase key into the corresponding env var before
+the agent-bom MCP server starts.
+
+| Smithery `configSchema` field | Type   | Promoted env var            | Read by                                    | Effect                                                                              |
+| ----------------------------- | ------ | --------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------- |
+| `nvdApiKey`                   | string | `NVD_API_KEY`               | `agent_bom.enrichment` (NVD CVSS lookup)    | Lifts NVD enrichment rate limit from 5 requests / 30s to 50 requests / 30s.         |
+| `clickhouseUrl`               | string | `AGENT_BOM_CLICKHOUSE_URL`  | `agent_bom.cloud.clickhouse` and CLI flags  | Enables ClickHouse-backed vulnerability trend storage and posture history.          |
+
+`NVD_API_KEY` is intentionally not prefixed with `AGENT_BOM_` because the value is the
+NVD-issued key itself, not an agent-bom configuration knob — multiple tools in the
+same workspace may share it.
+
+## Self-hosting outside Smithery
+
+When operating the MCP server yourself (Railway, Docker, Helm, Glama, OpenClaw, or any
+non-Smithery runtime), set the snake-case environment variables directly. The
+camelCase `configSchema` is purely a Smithery surface and has no effect on a
+self-hosted deployment.
+
+```bash
+# Railway, Fly, Render, Docker, etc.
+export NVD_API_KEY="<your-nvd-api-key>"
+export AGENT_BOM_CLICKHOUSE_URL="https://<host>:8443"
+agent-bom serve mcp
+```
+
+```yaml
+# Helm values.yaml
+controlPlane:
+  api:
+    env:
+      - name: NVD_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: agent-bom-control-plane-auth
+            key: nvd-api-key
+      - name: AGENT_BOM_CLICKHOUSE_URL
+        value: "http://clickhouse:8123"
+```
+
+## Adding new Smithery config fields
+
+When a new env var becomes operator-tunable through Smithery:
+
+1. Add the field to `integrations/smithery.yaml` `configSchema.properties` using
+   **camelCase** (Smithery convention).
+2. Add a row to the [Mapping table](#mapping-table) above with the snake-case env
+   var, the consuming module, and the effect.
+3. Confirm the agent-bom code path reads the env var via `os.environ` (not the
+   camelCase key), so self-hosted and Smithery-hosted deployments behave identically.
+4. Smoke-test the Smithery deployment by setting the field via Smithery's UI and
+   confirming the runtime reads the promoted env var.
+
+## Related references
+
+- [Smithery integration manifest](https://github.com/msaad00/agent-bom/blob/main/integrations/smithery.yaml)
+- [agent-bom configuration reference](../reference/configuration.md)
+- [MCP tools reference](../reference/mcp-tools.md)
+- [Hosted MCP overview](../deployment/overview.md)

--- a/site-docs/reference/exit-codes.md
+++ b/site-docs/reference/exit-codes.md
@@ -1,0 +1,103 @@
+# CLI Exit Codes and HTTP Status Mapping
+
+agent-bom exposes the same domain through a CLI, an HTTP API, an MCP server, and a
+GitHub Action. CI gates and shell pipelines branch on `agent-bom`'s exit code; HTTP
+clients branch on the API's status code. This page is the single contract that
+documents both, so a script writer never has to read the source to know what an
+exit code means.
+
+## CLI exit-code contract
+
+| Code  | Name                | Meaning                                                                                                       | Typical sources                                                            |
+| ----- | ------------------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `0`   | success             | Command completed; no findings or all findings under the configured severity threshold.                        | Any subcommand that finished cleanly.                                      |
+| `1`   | operational failure | A precondition failed: missing config, unreachable backend, missing required env var, dependency not present.  | `--clickhouse-url` missing, NVD unreachable, optional dependency not installed. |
+| `2`   | usage or empty      | Invalid arguments, no input to act on, or report contained no rows after filtering.                            | Click `UsageError` (auto), `agent-bom skills audit` with no skill files, empty result rendering. |
+| `3`   | (reserved)          | Reserved for "policy gate failed" — declared so future policy commands have a stable code to use.              | Not yet emitted.                                                           |
+| `4`   | (reserved)          | Reserved for "auth required" / "auth invalid" on commands that talk to an authenticated control plane.        | Not yet emitted.                                                           |
+| `5`   | (reserved)          | Reserved for "remote control-plane error" (5xx response from the API).                                         | Not yet emitted.                                                           |
+| `130` | interrupted         | Process received `SIGINT` (`Ctrl-C`) — POSIX convention, kept for shell idiom compatibility.                  | Long-running `agent-bom proxy` / `agent-bom serve` / `agent-bom scan`.      |
+| `*`   | subprocess passthrough | When agent-bom shells out (e.g. native scanner binaries), the child's non-zero exit code is propagated.    | `agent-bom shield`, `agent-bom run` proxy invocations.                     |
+
+The unreserved codes (`0`, `1`, `2`, `130`) are stable today. Codes `3`, `4`, `5` are
+reserved so future product growth has a clean place to land without re-numbering
+existing codes — operators may rely on `if [ "$rc" -eq 0 ]` and on the
+`rc != 0` family without further branching today.
+
+## API status-code contract
+
+| Status | Meaning                                                                                          | Where it's raised                                                              |
+| ------ | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| `200`  | Success.                                                                                         | All successful reads and writes.                                               |
+| `201`  | Created.                                                                                         | `POST /v1/scan`, `POST /v1/auth/keys`, SCIM `POST /Users`/`/Groups`.            |
+| `204`  | Deleted.                                                                                         | DELETEs that succeed without a body.                                           |
+| `400`  | Bad request — payload validation passed Pydantic but failed business-rule validation.            | Tenant-quota update with negative caps, invalid filter combinations.           |
+| `401`  | Unauthenticated — no valid API key, OIDC bearer, SAML session, or trusted-proxy attestation.     | Middleware before route resolution.                                            |
+| `403`  | Authenticated but not authorized — RBAC scope rule rejected the call.                            | Cross-tenant access attempt, viewer role attempting admin operation.           |
+| `404`  | Resource not found.                                                                              | Scan job, agent, registry server, key, or graph node not present in tenant.    |
+| `409`  | Conflict — idempotency clash, duplicate key creation, concurrent state mutation.                 | API key rotation, scan-job lifecycle conflicts.                                |
+| `422`  | Pydantic validation failure — payload shape rejected.                                            | FastAPI request-body validation.                                               |
+| `429`  | Rate limited — per-tenant quota or global rate limit hit.                                        | Middleware `PostgresRateLimitStore`.                                           |
+| `500`  | Server error — unexpected exception inside route logic.                                          | Bugs, downstream timeouts that escape retry budgets.                           |
+| `502`  | Upstream bad-gateway — proxied call (e.g. external scanner) returned an unparseable response.    | External scanner adapters.                                                     |
+| `503`  | Backend unavailable — Postgres, ClickHouse, or another required dependency is down.              | Health probes, dependency-aware routes.                                        |
+
+All errors return `{"detail": "<message>"}` per FastAPI default. The UI client at
+`ui/lib/api.ts` parses `detail`, `message`, and `error` so that any of those keys
+surface to operators with a useful string.
+
+## How CLI codes correspond to API statuses
+
+This is the explicit mapping that the CLI applies when it talks to the API and
+needs to translate an HTTP outcome into a process exit code. It's not a reflexive
+1:1 mapping — several HTTP codes collapse into a single CLI code because shells
+care about families, not individual semantics.
+
+| CLI exit code | HTTP status family                                | Why                                                                                            |
+| ------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `0`           | `2xx`                                             | The command did what it asked.                                                                 |
+| `2`           | `400` `422`                                       | Caller sent something invalid — usage error, fix the input.                                    |
+| `4` (reserved) | `401` `403`                                       | Caller is not (or not yet) authorized — fix credentials, not the input.                       |
+| `1`           | `404` `409`                                       | Operational state issue — resource missing, conflict — retryable after correcting state.       |
+| `1`           | `429`                                             | Throttled — retry with backoff. Today flattens to `1`; future revisions may use a dedicated code. |
+| `5` (reserved) | `5xx`                                             | Control-plane fault — agent-bom is not at fault, retry or escalate.                            |
+| `130`         | n/a                                               | Operator pressed `Ctrl-C`; never originates from an HTTP response.                              |
+
+Until reserved codes (`3`/`4`/`5`) are emitted, the safe shell idiom is:
+
+```bash
+agent-bom scan ./project --output sarif > out.sarif
+rc=$?
+case "$rc" in
+  0)   echo "ok" ;;
+  2)   echo "usage / empty"; exit 0 ;;     # treat empty as non-failure in some pipelines
+  130) echo "interrupted"; exit 130 ;;     # propagate Ctrl-C semantics
+  *)   echo "failed (rc=$rc)"; exit "$rc" ;;
+esac
+```
+
+## GitHub Action `action.yml` outputs
+
+The composite action surfaces both the CLI exit code and a parsed-status output so
+downstream steps can branch without re-parsing logs. When agent-bom finds findings
+above the configured severity floor the step still exits `0` — the action sets
+`outputs.findings` for the caller to gate on. Hard failures (`rc != 0` and not an
+empty/usage outcome) bubble up so the workflow turns red.
+
+| Output         | Type   | Source                               | Notes                                                                                  |
+| -------------- | ------ | ------------------------------------ | -------------------------------------------------------------------------------------- |
+| `findings`     | string | parsed from JSON / SARIF             | `"true"` when at least one finding crosses the configured severity floor.              |
+| `report-path`  | string | computed                             | Absolute path to the JSON / SARIF / HTML report inside the runner workspace.           |
+| `sarif-path`   | string | computed                             | Absolute path to the SARIF report when `--output sarif` was selected.                  |
+| `exit-code`    | string | propagated CLI exit code             | Same value documented in [CLI exit-code contract](#cli-exit-code-contract).            |
+
+## Stability guarantees
+
+- **`0`, `1`, `2`, `130`, and the subprocess passthrough are stable** and will not be
+  re-numbered within a major version.
+- **`3`, `4`, `5` are reserved** and will be assigned only to the meanings declared
+  above.
+- The HTTP status mapping is a binding contract for shell pipelines; future status
+  codes added to the API will fold into the same families described above unless a
+  new CLI code is introduced (in which case it will be drawn from the reserved set,
+  not allocated above `5`).

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -29,6 +29,7 @@ from agent_bom.api.middleware import (
     get_rate_limit_runtime_status,
     get_trusted_proxy_auth_status,
 )
+from agent_bom.api.scim import describe_scim_posture
 from agent_bom.api.server import app
 from agent_bom.api.storage_schema import (
     CONTROL_PLANE_SCHEMA_TABLE,
@@ -651,10 +652,7 @@ def test_auth_policy_flags_clustered_scim_without_postgres(monkeypatch: pytest.M
     monkeypatch.setenv("AGENT_BOM_SCIM_BEARER_TOKEN", "super-secret")
     monkeypatch.setenv("AGENT_BOM_CONTROL_PLANE_REPLICAS", "3")
 
-    client = TestClient(app)
-    body = client.get("/v1/auth/policy").json()
-
-    scim = body["identity_provisioning"]["scim"]
+    scim = describe_scim_posture()
     assert scim["configured"] is True
     assert scim["status"] == "misconfigured"
     assert scim["configured_api_replicas"] == 3

--- a/ui/eslint.config.mjs
+++ b/ui/eslint.config.mjs
@@ -24,6 +24,10 @@ const eslintConfig = defineConfig([
       ...nextPlugin.configs["core-web-vitals"].rules,
       "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "warn",
+      // Lock-in: the codebase is currently free of `any` casts across the UI
+      // tree. Promote from the default `warn` to `error` so a regression is
+      // caught at PR time rather than discovered after merge.
+      "@typescript-eslint/no-explicit-any": "error",
     },
   },
 ]);

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -4149,6 +4149,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -6089,6 +6090,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -6121,6 +6123,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6141,6 +6144,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6161,6 +6165,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6181,6 +6186,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6201,6 +6207,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6221,6 +6228,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6241,6 +6249,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6261,6 +6270,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6281,6 +6291,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6301,6 +6312,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6321,6 +6333,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,17 +1,16 @@
 {
   "name": "ui",
-  "version": "0.1.0",
+  "version": "0.81.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.1.0",
+      "version": "0.81.3",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
         "@tanstack/react-table": "^8.21.3",
         "@xyflow/react": "^12.10.2",
-        "lightningcss": "^1.32.0",
         "lucide-react": "^1.11.0",
         "next": "^16.2.4",
         "react": "19.2.5",
@@ -33,6 +32,7 @@
         "eslint-config-next": "^16.2.4",
         "eslint-plugin-react-hooks": "^7.0.1",
         "jsdom": "^29.0.2",
+        "lightningcss": "^1.32.0",
         "tailwindcss": "^4.2.3",
         "typescript": "^6",
         "typescript-eslint": "^8.59.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.1.0",
+  "version": "0.81.3",
   "private": true,
   "packageManager": "npm@10.9.7",
   "engines": {
@@ -23,7 +23,6 @@
     "@dagrejs/dagre": "^3.0.0",
     "@tanstack/react-table": "^8.21.3",
     "@xyflow/react": "^12.10.2",
-    "lightningcss": "^1.32.0",
     "lucide-react": "^1.11.0",
     "next": "^16.2.4",
     "react": "19.2.5",
@@ -48,6 +47,7 @@
     "eslint-config-next": "^16.2.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "jsdom": "^29.0.2",
+    "lightningcss": "^1.32.0",
     "tailwindcss": "^4.2.3",
     "typescript": "^6",
     "typescript-eslint": "^8.59.0",


### PR DESCRIPTION
## Summary
- document CLI exit-code and HTTP status mapping, plus Smithery camelCase-to-env translation
- align UI and Helm release versions with the platform release and add release-time drift checks
- tighten shell strict-mode guidance, UI lint hygiene, and the UI lockfile after moving `lightningcss` to dev dependencies
- keep clustered SCIM posture coverage compatible with the rate-limit fail-closed startup guard

## Why
This closes several small audit follow-ups from the latest issue sweep without touching the larger runtime/security work. It makes release-facing docs and version checks explicit, and keeps frontend dependency hygiene enforceable in CI.

## Validation
- `npm --prefix ui run lint`
- `npm --prefix ui run typecheck`
- `uv run mkdocs build --strict --site-dir /tmp/agent-bom-pr1-mkdocs-site`
- `uv run pytest tests/test_api_operator_policy.py -q`
- `uv run pytest tests/test_api_scim_lifecycle.py::test_scim_store_fails_closed_without_postgres_for_multi_replica tests/test_api_operator_policy.py::test_auth_policy_flags_clustered_scim_without_postgres -q`
- `uv run pytest tests/test_contract_schemas.py -q`
- `uv run pytest tests/test_scale_evidence.py -q`
- `git diff --check`

Closes #1957
Closes #1968
Closes #1972
Closes #1973
Refs #1966
Refs #1967
