### PR TITLE
feat(scanner): promote GPU containers and k8s GPU clusters into the unified graph

### DIFF
--- a/src/agent_bom/cloud/gpu_infra.py
+++ b/src/agent_bom/cloud/gpu_infra.py
@@ -605,7 +605,11 @@ def gpu_infra_to_agents(report: GpuInfraReport) -> list[Agent]:
     """Convert GpuInfraReport to Agent objects for inclusion in AIBOMReport.
 
     Each GPU container becomes an Agent with its image name as the MCP server.
-    K8s GPU nodes appear as a synthetic "k8s-gpu-cluster" agent.
+    K8s GPU nodes appear as a synthetic "k8s-gpu-cluster" agent. Both shapes
+    populate ``Agent.metadata["cloud_origin"]`` so the unified-graph builder
+    can promote the underlying GPU asset (vendor, runtime, container/node id)
+    into ``cloud_resource`` lineage nodes via the existing promoter in
+    ``src/agent_bom/graph/builder.py``.
     """
     agents: list[Agent] = []
 
@@ -623,24 +627,53 @@ def gpu_infra_to_agents(report: GpuInfraReport) -> list[Agent]:
             transport=TransportType.STDIO,
             packages=packages,
         )
+        cloud_origin = {
+            "provider": "gpu",
+            "service": "container_runtime",
+            "resource_type": c.gpu_vendor or "unknown",
+            "resource_id": c.container_id,
+            "resource_name": c.name or c.container_id,
+            "scope": {
+                "image": c.image,
+                "gpu_requested": c.gpu_requested,
+                "cuda_version": c.cuda_version,
+                "cudnn_version": c.cudnn_version,
+            },
+        }
         agent = Agent(
             name=c.name or c.container_id,
             agent_type=AgentType.CUSTOM,
             config_path=f"docker://{c.container_id}",
             source="gpu_infra",
             mcp_servers=[server],
+            metadata={"cloud_origin": cloud_origin},
         )
         agents.append(agent)
 
-    # Aggregate K8s GPU nodes as a single agent
+    # Aggregate K8s GPU nodes as a single agent. Lineage promotion happens at
+    # the cluster level so dashboards see one cloud_resource per cluster, not
+    # one per GPU node — node-level facts live in the scope envelope.
     if report.gpu_nodes:
         total_gpus = sum(n.gpu_capacity for n in report.gpu_nodes)
+        vendors = sorted({n.gpu_vendor for n in report.gpu_nodes if n.gpu_vendor})
         node_server = MCPServer(
             name=f"k8s-gpu-cluster ({len(report.gpu_nodes)} nodes, {total_gpus} GPUs)",
             command="",
             transport=TransportType.STDIO,
             packages=[],
         )
+        cloud_origin = {
+            "provider": "gpu",
+            "service": "kubernetes",
+            "resource_type": vendors[0] if len(vendors) == 1 else "mixed" if vendors else "unknown",
+            "resource_id": "k8s-gpu-cluster",
+            "resource_name": "k8s-gpu-cluster",
+            "scope": {
+                "node_count": len(report.gpu_nodes),
+                "gpu_capacity_total": total_gpus,
+                "vendors": vendors,
+            },
+        }
         agents.append(
             Agent(
                 name="k8s-gpu-cluster",
@@ -648,6 +681,7 @@ def gpu_infra_to_agents(report: GpuInfraReport) -> list[Agent]:
                 config_path="k8s://gpu-nodes",
                 source="gpu_infra",
                 mcp_servers=[node_server],
+                metadata={"cloud_origin": cloud_origin},
             )
         )
 

--- a/tests/test_gpu_infra.py
+++ b/tests/test_gpu_infra.py
@@ -174,6 +174,51 @@ def test_gpu_infra_to_agents_k8s_nodes():
     assert "12 GPUs" in agents[0].mcp_servers[0].name
 
 
+def test_gpu_infra_to_agents_attaches_cloud_origin_for_containers():
+    # The unified-graph builder reads agent.metadata["cloud_origin"] to
+    # promote GPU containers into cloud_resource lineage nodes via the
+    # existing cloud-origin promoter. Without this envelope the GPU vendor
+    # and runtime stay invisible in the graph.
+    containers = [
+        GpuContainer(
+            container_id="ctr-abc",
+            name="training-worker",
+            image="nvcr.io/nvidia/pytorch:23.10-py3",
+            status="running",
+            is_nvidia_base=True,
+            cuda_version="12.2",
+            cudnn_version="8.9",
+            gpu_requested=True,
+            gpu_vendor="nvidia",
+        ),
+    ]
+    report = GpuInfraReport(gpu_containers=containers, dcgm_endpoints=[], gpu_nodes=[], warnings=[])
+    agents = gpu_infra_to_agents(report)
+    origin = agents[0].metadata["cloud_origin"]
+    assert origin["provider"] == "gpu"
+    assert origin["service"] == "container_runtime"
+    assert origin["resource_type"] == "nvidia"
+    assert origin["resource_id"] == "ctr-abc"
+    assert origin["scope"]["cuda_version"] == "12.2"
+    assert origin["scope"]["gpu_requested"] is True
+
+
+def test_gpu_infra_to_agents_attaches_cloud_origin_for_k8s_cluster():
+    nodes = [
+        GpuNode(name="node-1", gpu_vendor="nvidia", gpu_capacity=4, gpu_allocatable=4, gpu_allocated=0, cuda_driver_version="525"),
+        GpuNode(name="node-2", gpu_vendor="nvidia", gpu_capacity=8, gpu_allocatable=6, gpu_allocated=2, cuda_driver_version="525"),
+    ]
+    report = GpuInfraReport(gpu_containers=[], dcgm_endpoints=[], gpu_nodes=nodes, warnings=[])
+    agents = gpu_infra_to_agents(report)
+    origin = agents[0].metadata["cloud_origin"]
+    assert origin["provider"] == "gpu"
+    assert origin["service"] == "kubernetes"
+    assert origin["resource_id"] == "k8s-gpu-cluster"
+    assert origin["scope"]["node_count"] == 2
+    assert origin["scope"]["gpu_capacity_total"] == 12
+    assert origin["scope"]["vendors"] == ["nvidia"]
+
+
 def test_gpu_infra_to_agents_no_cuda_version():
     """Container without CUDA version produces agent with no packages."""
     containers = [

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -169,6 +169,72 @@ class TestBuildUnifiedGraphFromReport:
         assert g.has_edge(resource_id, "agent:claude-desktop")
         assert g.has_edge(principal_id, resource_id)
 
+    def test_gpu_container_metadata_promotes_to_cloud_resource(self):
+        # gpu_infra_to_agents (src/agent_bom/cloud/gpu_infra.py) attaches a
+        # cloud_origin envelope so the existing promoter creates a
+        # cloud_resource:gpu:... lineage node for each container. This test
+        # asserts the contract end-to-end via the report-shaped dict, which
+        # is what the unified-graph builder consumes.
+        report = _minimal_report()
+        report["agents"][0]["source"] = "gpu_infra"
+        report["agents"][0]["metadata"] = {
+            "cloud_origin": {
+                "provider": "gpu",
+                "service": "container_runtime",
+                "resource_type": "nvidia",
+                "resource_id": "ctr-abc123",
+                "resource_name": "training-worker",
+                "scope": {
+                    "image": "nvcr.io/nvidia/pytorch:23.10-py3",
+                    "gpu_requested": True,
+                    "cuda_version": "12.2",
+                    "cudnn_version": "8.9",
+                },
+            },
+        }
+
+        g = build_unified_graph_from_report(report)
+
+        resource_id = "cloud_resource:gpu:container_runtime:nvidia:ctr-abc123"
+        resource = g.nodes.get(resource_id)
+        assert resource is not None
+        assert resource.entity_type == EntityType.CLOUD_RESOURCE
+        assert resource.label == "training-worker"
+        assert resource.attributes["cloud_origin"]["scope"]["cuda_version"] == "12.2"
+        assert resource.dimensions.cloud_provider == "gpu"
+        assert g.has_edge("provider:gpu", resource_id)
+        assert g.has_edge(resource_id, "agent:claude-desktop")
+
+    def test_k8s_gpu_cluster_promotes_with_aggregated_scope(self):
+        # The aggregated k8s-gpu-cluster agent rolls multiple GPU nodes into
+        # a single cloud_resource so dashboards see one cluster, not one node
+        # per row. Per-node facts live in the scope envelope.
+        report = _minimal_report()
+        report["agents"][0]["source"] = "gpu_infra"
+        report["agents"][0]["metadata"] = {
+            "cloud_origin": {
+                "provider": "gpu",
+                "service": "kubernetes",
+                "resource_type": "nvidia",
+                "resource_id": "k8s-gpu-cluster",
+                "resource_name": "k8s-gpu-cluster",
+                "scope": {
+                    "node_count": 4,
+                    "gpu_capacity_total": 32,
+                    "vendors": ["nvidia"],
+                },
+            },
+        }
+
+        g = build_unified_graph_from_report(report)
+
+        resource_id = "cloud_resource:gpu:kubernetes:nvidia:k8s-gpu-cluster"
+        resource = g.nodes.get(resource_id)
+        assert resource is not None
+        assert resource.attributes["cloud_origin"]["scope"]["node_count"] == 4
+        assert resource.attributes["cloud_origin"]["scope"]["gpu_capacity_total"] == 32
+        assert g.has_edge(resource_id, "agent:claude-desktop")
+
     def test_server_nodes(self):
         g = build_unified_graph_from_report(_minimal_report())
         servers = g.nodes_by_type(EntityType.SERVER)


### PR DESCRIPTION
## Summary

Closes the remaining acceptance criteria from #1890 after #1941 added the cloud-origin lineage promoter, #1946 added framework-agent topology edges, and #1948 added the AI observability SDK inventory.

GPU container and \`k8s-gpu-cluster\` agents already round-tripped through \`gpu_infra_to_agents\` into the AIBOM report, but they did not carry a \`cloud_origin\` envelope, so the unified-graph builder had no way to promote the underlying GPU asset (vendor, runtime, container or cluster id) into a \`cloud_resource\` lineage node. The graph carried the agent but not the infrastructure beneath it.

This change attaches a \`cloud_origin\` envelope to both shapes so the existing promoter in \`src/agent_bom/graph/builder.py\` creates:

- \`cloud_resource:gpu:container_runtime:<vendor>:<container-id>\` per GPU container, with image, \`gpu_requested\`, CUDA/cuDNN versions in scope
- \`cloud_resource:gpu:kubernetes:<vendor-or-mixed>:k8s-gpu-cluster\` aggregated per scan, with \`node_count\`, \`gpu_capacity_total\`, vendors in scope

Cluster-level aggregation keeps dashboards readable: one \`cloud_resource\` per cluster, not one per node. Per-node facts live in the scope envelope and remain queryable.

Verifies that the principal→resource \`MANAGES\` edge and the span attributes on \`graph.build_unified_graph_from_report\` (already populated at \`builder.py:729-736\`) need no further changes.

Closes #1890

## Test plan

- [x] \`pytest tests/test_graph_builder.py tests/test_gpu_infra.py -q\` — 85 passed
- [x] New \`test_gpu_container_metadata_promotes_to_cloud_resource\` and \`test_k8s_gpu_cluster_promotes_with_aggregated_scope\` cover the builder side
- [x] New \`test_gpu_infra_to_agents_attaches_cloud_origin_for_containers\` and \`..._for_k8s_cluster\` cover the conversion side
- [x] Span attributes verified populated at \`builder.py:729-736\`