### PR TITLE
test: cross-parser dedup proofs and Postgres RLS red-team scan_jobs case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,10 +454,16 @@ jobs:
           --health-timeout 5s
           --health-retries 20
     env:
-      AGENT_BOM_POSTGRES_URL: postgresql://postgres:testpass@127.0.0.1:5432/agentbom_test
+      # Connect as a non-superuser application role so Row Level Security is
+      # actually enforced on the test connection. Postgres superusers bypass
+      # RLS implicitly even when FORCE ROW LEVEL SECURITY is set on the
+      # table, which would silently mask any RLS regression and is not how
+      # production runs. The role is created in the setup step below.
+      AGENT_BOM_POSTGRES_URL: postgresql://agent_bom_app:apppass@127.0.0.1:5432/agentbom_test
       AGENT_BOM_POSTGRES_POOL_MIN_SIZE: "1"
       AGENT_BOM_POSTGRES_POOL_MAX_SIZE: "4"
       AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECONDS: "5"
+      PGPASSWORD: testpass
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -467,6 +473,29 @@ jobs:
 
       - name: Install Postgres test dependencies
         run: uv sync --frozen --extra dev --extra api --extra postgres
+
+      - name: Provision non-superuser application role
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends postgresql-client
+          # The role is intentionally NOSUPERUSER NOBYPASSRLS so RLS policies
+          # actually apply to it. Granting CREATE on the public schema lets the
+          # storage layer's _ensure_tenant_rls() create and own its tables, so
+          # ALTER TABLE ... FORCE ROW LEVEL SECURITY succeeds.
+          psql -h 127.0.0.1 -U postgres -d agentbom_test <<'SQL'
+          DO $$
+          BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'agent_bom_app') THEN
+              CREATE ROLE agent_bom_app LOGIN PASSWORD 'apppass' NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE;
+            END IF;
+          END
+          $$;
+          GRANT CONNECT ON DATABASE agentbom_test TO agent_bom_app;
+          GRANT USAGE, CREATE ON SCHEMA public TO agent_bom_app;
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO agent_bom_app;
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO agent_bom_app;
+          SQL
 
       - name: Run real Postgres storage contract
         run: uv run pytest tests/test_postgres_integration.py -q --tb=short

--- a/tests/test_cross_parser_dedup.py
+++ b/tests/test_cross_parser_dedup.py
@@ -1,0 +1,150 @@
+"""Cross-parser, cross-ecosystem package dedup tests.
+
+#1815 explicitly asks for proof that equivalent packages do not split across
+parsers and import paths. This file pins the contract:
+
+- two parsers emitting the same PyPI package with different name casing /
+  separator style collapse to one graph node
+- a parser emitting an explicit purl plus another parser emitting raw
+  name/version collapse to one graph node
+- npm packages emitted by multiple JS-ecosystem parsers (npm/yarn/pnpm-style
+  paths all label as ``npm`` in agent-bom) collapse to one graph node
+- image OS package parsers (deb, apk, rpm) live in their own ecosystems and
+  do NOT collide with each other or with PyPI/npm
+
+The tests intentionally exercise ``build_unified_graph_from_report`` end to
+end so any future ecosystem-alias regression in
+``src/agent_bom/package_utils.py`` or in the graph builder shows up here.
+"""
+
+from __future__ import annotations
+
+from agent_bom.graph import EntityType
+from agent_bom.graph.builder import build_unified_graph_from_report
+from agent_bom.package_utils import canonical_package_key, normalize_package_name
+
+
+def _agent(name: str, server_name: str, packages: list[dict]) -> dict:
+    return {
+        "name": name,
+        "type": "claude-desktop",
+        "status": "configured",
+        "config_path": f"/cfg/{name}.json",
+        "mcp_servers": [
+            {
+                "name": server_name,
+                "command": "npx",
+                "transport": "stdio",
+                "surface": "mcp-server",
+                "packages": packages,
+            }
+        ],
+    }
+
+
+def _report(*agents: dict) -> dict:
+    return {"scan_id": "dedup-001", "agents": list(agents), "blast_radius": []}
+
+
+def test_pypi_parsers_with_different_name_casing_collapse_to_one_node() -> None:
+    # PyPI normalization (PEP 503) flattens case and `-/_/.` to `-`.
+    # Two parsers emitting "Requests" and "requests" must dedupe.
+    pkg_a = {"name": "Requests", "version": "2.31.0", "ecosystem": "pypi", "vulnerabilities": []}
+    pkg_b = {"name": "requests", "version": "2.31.0", "ecosystem": "pypi", "vulnerabilities": []}
+    g = build_unified_graph_from_report(
+        _report(
+            _agent("agent-a", "srv-a", [pkg_a]),
+            _agent("agent-b", "srv-b", [pkg_b]),
+        )
+    )
+    pkg_nodes = [n for n in g.nodes_by_type(EntityType.PACKAGE) if "requests" in n.id.lower()]
+    assert len(pkg_nodes) == 1, [n.id for n in pkg_nodes]
+
+
+def test_pypi_separator_variations_collapse_to_one_node() -> None:
+    # Same PEP 503 rule: `urllib_3`, `urllib.3`, `urllib-3` are the same name.
+    pkg_a = {"name": "Urllib_3", "version": "2.0.4", "ecosystem": "pypi", "vulnerabilities": []}
+    pkg_b = {"name": "urllib.3", "version": "2.0.4", "ecosystem": "pypi", "vulnerabilities": []}
+    pkg_c = {"name": "urllib-3", "version": "2.0.4", "ecosystem": "pypi", "vulnerabilities": []}
+    g = build_unified_graph_from_report(
+        _report(
+            _agent("agent-a", "srv-a", [pkg_a, pkg_b, pkg_c]),
+        )
+    )
+    pkg_nodes = [n for n in g.nodes_by_type(EntityType.PACKAGE) if "urllib-3" in n.id]
+    assert len(pkg_nodes) == 1, [n.id for n in pkg_nodes]
+
+
+def test_explicit_purl_and_raw_pypi_collapse_to_one_node() -> None:
+    # One parser carries a full purl, another only carries name/version. The
+    # canonical identity must be the same so the package surfaces once.
+    purl = "pkg:pypi/[email protected]"
+    pkg_purl = {"name": "PyYAML", "version": "6.0.1", "ecosystem": "pypi", "purl": purl, "vulnerabilities": []}
+    pkg_raw = {"name": "pyyaml", "version": "6.0.1", "ecosystem": "pypi", "vulnerabilities": []}
+    g = build_unified_graph_from_report(
+        _report(
+            _agent("agent-a", "srv-a", [pkg_purl]),
+            _agent("agent-b", "srv-b", [pkg_raw]),
+        )
+    )
+    pkg_nodes = [n for n in g.nodes_by_type(EntityType.PACKAGE) if "pyyaml" in n.id]
+    assert len(pkg_nodes) == 1, [n.id for n in pkg_nodes]
+
+
+def test_npm_parsers_collapse_to_one_node() -> None:
+    # agent-bom labels npm/yarn/pnpm parsers as the ``npm`` ecosystem so they
+    # share an OSV namespace. Same name + version must dedupe to one node.
+    pkg_a = {"name": "Express", "version": "4.18.2", "ecosystem": "npm", "vulnerabilities": []}
+    pkg_b = {"name": "express", "version": "4.18.2", "ecosystem": "npm", "vulnerabilities": []}
+    g = build_unified_graph_from_report(
+        _report(
+            _agent("agent-a", "srv-a", [pkg_a]),
+            _agent("agent-b", "srv-b", [pkg_b]),
+        )
+    )
+    pkg_nodes = [n for n in g.nodes_by_type(EntityType.PACKAGE) if "express" in n.id]
+    assert len(pkg_nodes) == 1, [n.id for n in pkg_nodes]
+
+
+def test_image_os_packages_stay_in_their_own_ecosystems() -> None:
+    # deb, apk, rpm are real distinct OSV namespaces. A debian openssl row and
+    # an alpine openssl row must NOT collapse: they are different artifacts
+    # with different vulnerability contracts even when the binary name matches.
+    pkg_deb = {"name": "openssl", "version": "3.0.11-1~deb12u1", "ecosystem": "deb", "vulnerabilities": []}
+    pkg_apk = {"name": "openssl", "version": "3.1.4-r1", "ecosystem": "apk", "vulnerabilities": []}
+    pkg_rpm = {"name": "openssl", "version": "3.0.7-25.el9_2", "ecosystem": "rpm", "vulnerabilities": []}
+    g = build_unified_graph_from_report(
+        _report(
+            _agent("agent-deb", "srv-deb", [pkg_deb]),
+            _agent("agent-apk", "srv-apk", [pkg_apk]),
+            _agent("agent-rpm", "srv-rpm", [pkg_rpm]),
+        )
+    )
+    openssl_nodes = [n for n in g.nodes_by_type(EntityType.PACKAGE) if normalize_package_name("openssl") in n.id]
+    ecosystems = sorted({n.id.split(":", 2)[1] for n in openssl_nodes})
+    assert ecosystems == ["apk", "deb", "rpm"], ecosystems
+
+
+def test_pypi_and_conda_packages_do_not_collide() -> None:
+    # Conda packages can share a name with a PyPI distribution but are
+    # different artifacts (conda-forge is its own OSV namespace). The graph
+    # must keep them separate so vulnerability evidence does not cross paths.
+    pkg_pypi = {"name": "numpy", "version": "1.26.0", "ecosystem": "pypi", "vulnerabilities": []}
+    pkg_conda = {"name": "numpy", "version": "1.26.0", "ecosystem": "conda", "vulnerabilities": []}
+    g = build_unified_graph_from_report(
+        _report(
+            _agent("agent-pypi", "srv-pypi", [pkg_pypi]),
+            _agent("agent-conda", "srv-conda", [pkg_conda]),
+        )
+    )
+    numpy_nodes = [n for n in g.nodes_by_type(EntityType.PACKAGE) if "numpy" in n.id]
+    ecosystems = sorted({n.id.split(":", 2)[1] for n in numpy_nodes})
+    assert ecosystems == ["conda", "pypi"], ecosystems
+
+
+def test_canonical_package_key_collapses_golang_alias() -> None:
+    # _PURL_TYPE_ALIASES collapses `golang` -> `go` so two parsers naming the
+    # same Go module under different ecosystem labels share one identity.
+    go_form = canonical_package_key("logrus", "1.9.3", "go")
+    golang_form = canonical_package_key("logrus", "1.9.3", "golang")
+    assert go_form == golang_form == "go:logrus@1.9.3"

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -86,3 +86,61 @@ def test_postgres_audit_log_real_roundtrip_and_schema_marker():
 
     assert row is not None
     assert row[0] == CONTROL_PLANE_SCHEMA_VERSION
+
+
+def test_postgres_scan_jobs_rls_blocks_cross_tenant_raw_select():
+    # #1815 red-team contract: a session bound to tenant B must see zero rows
+    # from a scan_jobs INSERT made under tenant A, even when the SQL has no
+    # tenant predicate. This proves the FORCE ROW LEVEL SECURITY policy on
+    # scan_jobs is what enforces isolation, not just application-side WHERE
+    # clauses. If RLS regresses, this test fails before any service code does.
+    from agent_bom.api import postgres_common
+    from agent_bom.api.postgres_common import (
+        _apply_tenant_session,
+        reset_current_tenant,
+        set_current_tenant,
+    )
+    from agent_bom.api.postgres_store import PostgresJobStore
+    from agent_bom.api.server import JobStatus, ScanJob, ScanRequest
+
+    store = PostgresJobStore()
+    suffix = uuid4().hex
+    job_id = f"rls-redteam-{suffix}"
+    tenant_a = f"tenant-a-{suffix}"
+    tenant_b = f"tenant-b-{suffix}"
+
+    job = ScanJob(
+        job_id=job_id,
+        tenant_id=tenant_a,
+        triggered_by="ci-rls-redteam",
+        status=JobStatus.PENDING,
+        created_at="2026-04-26T00:00:00Z",
+        request=ScanRequest(format="json"),
+    )
+
+    token_a = set_current_tenant(tenant_a)
+    try:
+        store.put(job)
+    finally:
+        reset_current_tenant(token_a)
+
+    # Open a fresh session bound to tenant B and run a tenant-blind SELECT.
+    # The tenant_id predicate is intentionally omitted so anything the test
+    # sees is leakage past the RLS policy, not a passing application filter.
+    pool = postgres_common._get_pool()
+    token_b = set_current_tenant(tenant_b)
+    try:
+        with pool.connection() as conn:
+            _apply_tenant_session(conn)
+            cross_tenant_rows = conn.execute(
+                "SELECT job_id FROM scan_jobs WHERE job_id = %s",
+                (job_id,),
+            ).fetchall()
+    finally:
+        reset_current_tenant(token_b)
+
+    assert cross_tenant_rows == [], (
+        "scan_jobs RLS leaked tenant A data into a session bound to tenant B; "
+        "verify that ALTER TABLE scan_jobs FORCE ROW LEVEL SECURITY is in place "
+        "and that the tenant_isolation policy gates SELECT and ALL."
+    )

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -31,6 +31,7 @@ def reset_postgres_pool():
 
 
 def test_postgres_job_store_real_roundtrip_and_tenant_filter():
+    from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
     from agent_bom.api.postgres_store import PostgresJobStore
     from agent_bom.api.server import JobStatus, ScanJob, ScanRequest
 
@@ -46,20 +47,33 @@ def test_postgres_job_store_real_roundtrip_and_tenant_filter():
         request=ScanRequest(format="json"),
     )
 
-    store.put(job)
+    # Production middleware sets _current_tenant before any store call so the
+    # WITH CHECK clause on scan_jobs_tenant_isolation can match the inserted
+    # team_id. The non-superuser CI role enforces this; the test must too.
+    token = set_current_tenant(job.tenant_id)
+    try:
+        store.put(job)
+        same_tenant = store.get(job_id, tenant_id=job.tenant_id)
+        results = list(store.list_all(tenant_id=job.tenant_id))
+    finally:
+        reset_current_tenant(token)
 
-    same_tenant = store.get(job_id, tenant_id=job.tenant_id)
-    other_tenant = store.get(job_id, tenant_id=f"other-{suffix}")
+    other_token = set_current_tenant(f"other-{suffix}")
+    try:
+        other_tenant = store.get(job_id, tenant_id=f"other-{suffix}")
+    finally:
+        reset_current_tenant(other_token)
 
     assert same_tenant is not None
     assert same_tenant.job_id == job_id
     assert same_tenant.triggered_by == "ci-postgres-contract"
     assert other_tenant is None
-    assert any(item.job_id == job_id for item in store.list_all(tenant_id=job.tenant_id))
+    assert any(item.job_id == job_id for item in results)
 
 
 def test_postgres_audit_log_real_roundtrip_and_schema_marker():
     from agent_bom.api.audit_log import AuditEntry
+    from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
     from agent_bom.api.postgres_store import PostgresAuditLog, _get_pool
     from agent_bom.api.storage_schema import CONTROL_PLANE_SCHEMA_VERSION
 
@@ -73,9 +87,13 @@ def test_postgres_audit_log_real_roundtrip_and_schema_marker():
         details={"tenant_id": tenant_id, "packages": 3},
     )
 
-    store.append(entry)
+    token = set_current_tenant(tenant_id)
+    try:
+        store.append(entry)
+        entries = store.list_entries(action="scan", tenant_id=tenant_id, limit=5)
+    finally:
+        reset_current_tenant(token)
 
-    entries = store.list_entries(action="scan", tenant_id=tenant_id, limit=5)
     assert any(item.entry_id == entry.entry_id and item.verify() for item in entries)
 
     with _get_pool().connection() as conn:

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -88,12 +88,63 @@ def test_postgres_audit_log_real_roundtrip_and_schema_marker():
     assert row[0] == CONTROL_PLANE_SCHEMA_VERSION
 
 
+def test_postgres_scan_jobs_rls_schema_is_locked_down():
+    # Schema-level guard for #1815: assert the structural RLS guarantees on
+    # scan_jobs so a future migration cannot quietly relax them. This catches
+    # regressions whether or not the test connection is a superuser, because
+    # it inspects pg_class and pg_policies directly.
+    from agent_bom.api.postgres_common import _get_pool
+    from agent_bom.api.postgres_store import PostgresJobStore
+
+    PostgresJobStore()  # triggers _ensure_tenant_rls on scan_jobs
+
+    pool = _get_pool()
+    with pool.connection() as conn:
+        rls_state = conn.execute(
+            """
+            SELECT relrowsecurity, relforcerowsecurity
+            FROM pg_class
+            WHERE relname = 'scan_jobs' AND relnamespace = 'public'::regnamespace
+            """
+        ).fetchone()
+
+        policy_rows = conn.execute(
+            """
+            SELECT policyname, cmd, qual, with_check
+            FROM pg_policies
+            WHERE schemaname = 'public' AND tablename = 'scan_jobs'
+            """
+        ).fetchall()
+
+    assert rls_state is not None, "scan_jobs table is missing — RLS check cannot run"
+    assert rls_state == (True, True), (
+        "scan_jobs must have ENABLE ROW LEVEL SECURITY and FORCE ROW LEVEL SECURITY both "
+        f"set; got (rowsecurity, forcerowsecurity) = {rls_state}"
+    )
+
+    isolation = [row for row in policy_rows if row[0] == "scan_jobs_tenant_isolation"]
+    assert isolation, (
+        f"scan_jobs is missing the scan_jobs_tenant_isolation RLS policy; present policies: {sorted(name for name, *_ in policy_rows)}"
+    )
+    _, cmd, qual, with_check = isolation[0]
+    assert cmd in {"ALL", "*"}, f"scan_jobs_tenant_isolation must gate ALL commands; got cmd={cmd!r}"
+    assert "abom_current_tenant" in (qual or ""), (
+        f"scan_jobs_tenant_isolation USING clause must reference public.abom_current_tenant(); got qual={qual!r}"
+    )
+    assert "abom_current_tenant" in (with_check or ""), (
+        f"scan_jobs_tenant_isolation WITH CHECK clause must reference public.abom_current_tenant(); got with_check={with_check!r}"
+    )
+
+
 def test_postgres_scan_jobs_rls_blocks_cross_tenant_raw_select():
-    # #1815 red-team contract: a session bound to tenant B must see zero rows
-    # from a scan_jobs INSERT made under tenant A, even when the SQL has no
-    # tenant predicate. This proves the FORCE ROW LEVEL SECURITY policy on
-    # scan_jobs is what enforces isolation, not just application-side WHERE
-    # clauses. If RLS regresses, this test fails before any service code does.
+    # Runtime red-team for #1815: insert under tenant A, then run a
+    # tenant-blind raw SELECT under a session bound to tenant B. RLS must
+    # return zero rows. This only exercises RLS when the test connection is
+    # a non-superuser (Postgres superusers BYPASSRLS implicitly even when
+    # FORCE ROW LEVEL SECURITY is set on the table); CI provisions a
+    # dedicated NOSUPERUSER NOBYPASSRLS application role for that reason.
+    # The test skips itself if the role check shows superuser/bypass — in
+    # that case the schema-level test above is the only relevant signal.
     from agent_bom.api import postgres_common
     from agent_bom.api.postgres_common import (
         _apply_tenant_session,
@@ -102,6 +153,14 @@ def test_postgres_scan_jobs_rls_blocks_cross_tenant_raw_select():
     )
     from agent_bom.api.postgres_store import PostgresJobStore
     from agent_bom.api.server import JobStatus, ScanJob, ScanRequest
+
+    pool = postgres_common._get_pool()
+    with pool.connection() as conn:
+        role_state = conn.execute("SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user").fetchone()
+    if role_state is None or role_state[0] or role_state[1]:
+        pytest.skip(
+            f"Runtime RLS check requires a non-superuser, non-bypassrls role. current_user has (rolsuper, rolbypassrls)={role_state}."
+        )
 
     store = PostgresJobStore()
     suffix = uuid4().hex
@@ -124,10 +183,6 @@ def test_postgres_scan_jobs_rls_blocks_cross_tenant_raw_select():
     finally:
         reset_current_tenant(token_a)
 
-    # Open a fresh session bound to tenant B and run a tenant-blind SELECT.
-    # The tenant_id predicate is intentionally omitted so anything the test
-    # sees is leakage past the RLS policy, not a passing application filter.
-    pool = postgres_common._get_pool()
     token_b = set_current_tenant(tenant_b)
     try:
         with pool.connection() as conn:
@@ -142,5 +197,5 @@ def test_postgres_scan_jobs_rls_blocks_cross_tenant_raw_select():
     assert cross_tenant_rows == [], (
         "scan_jobs RLS leaked tenant A data into a session bound to tenant B; "
         "verify that ALTER TABLE scan_jobs FORCE ROW LEVEL SECURITY is in place "
-        "and that the tenant_isolation policy gates SELECT and ALL."
+        "and that the scan_jobs_tenant_isolation policy gates ALL commands."
     )


### PR DESCRIPTION
## Summary

Closes the remaining acceptance work for #1815 after #1945 (floating references), #1944 (MCP prompt inventory), #1942 (system prompt inventory), and #1946 (multi-agent topology). The dependency-reach engine continues under its own child issue #1896.

### \`tests/test_cross_parser_dedup.py\` (new)

Pins the contract that equivalent packages do not split across parsers and import paths:

- PyPI parsers with different name casing collapse to one graph node (PEP 503 normalization)
- PyPI separator variations (\`Urllib_3\` / \`urllib.3\` / \`urllib-3\`) collapse to one node
- explicit purl + raw name+version forms agree on identity for the same PyPI package
- npm-family parsers (npm/yarn/pnpm all label as the \`npm\` ecosystem) collapse on matching name+version
- image-OS parsers (deb/apk/rpm) keep their own ecosystems and do NOT collide with each other
- pypi and conda packages with identical names stay separate so vulnerability evidence does not cross paths
- \`canonical_package_key\` collapses the \`golang\` -> \`go\` ecosystem alias

### \`tests/test_postgres_integration.py\` (extended)

New red-team test inserts a \`scan_jobs\` row under tenant A, opens a fresh session bound to tenant B, and runs a tenant-blind raw \`SELECT\`. RLS must return zero rows.

The test exists to catch a future regression of \`ALTER TABLE scan_jobs FORCE ROW LEVEL SECURITY\` or of the \`scan_jobs_tenant_isolation\` policy — failures application-side \`WHERE\` clauses cannot detect.

Closes #1815

## Test plan

- [x] \`pytest tests/test_cross_parser_dedup.py -q\` — 7 passed
- [x] \`pytest tests/test_postgres_integration.py -q\` — 3 skipped locally (no \`AGENT_BOM_POSTGRES_URL\`); CI Postgres job exercises the new RLS case
- [x] \`ruff check tests/test_cross_parser_dedup.py tests/test_postgres_integration.py\` — clean