### PR TITLE
security(frontend): remove unsafe-inline from script-src and centralize CSP source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,15 @@ jobs:
           cd ui
           npm run lint
 
+      - name: UI security headers in sync (next.config + vercel.json)
+        # Source: ui/lib/security-headers.mjs
+        # Sync script: ui/scripts/sync-vercel-headers.mjs
+        # Fails if ui/vercel.json drifts from the canonical security-headers
+        # module — closes #1954 against silent CSP regressions.
+        run: |
+          cd ui
+          npm run headers:check
+
       - name: UI tests
         run: |
           cd ui

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -170,15 +170,30 @@ def test_hsts_preload_is_operator_opt_in(monkeypatch):
 
 
 def test_ui_csp_headers_do_not_allow_eval():
-    """Static and hosted UI headers should not permit eval-style script execution."""
+    """Static and hosted UI headers should not permit eval-style script execution.
+
+    The CSP source was centralized to ui/lib/security-headers.mjs in #1954.
+    next.config.ts now imports from there; vercel.json is regenerated from
+    the same module by ui/scripts/sync-vercel-headers.mjs and verified by
+    the vitest sync test. The source-of-truth and the rendered output must
+    both forbid eval-style execution.
+    """
     root = Path(__file__).parent.parent
-    next_config = (root / "ui" / "next.config.ts").read_text(encoding="utf-8")
+    canonical = (root / "ui" / "lib" / "security-headers.mjs").read_text(encoding="utf-8")
     vercel_config = (root / "ui" / "vercel.json").read_text(encoding="utf-8")
 
-    assert "'unsafe-eval'" not in next_config
+    assert "'unsafe-eval'" not in canonical
     assert "'unsafe-eval'" not in vercel_config
-    assert "script-src-attr 'none'" in next_config
+    assert "script-src-attr 'none'" in canonical
     assert "script-src-attr 'none'" in vercel_config
+    # script-src must NOT carry 'unsafe-inline' anymore — closes the XSS sink
+    # that previously let any injected inline <script> run regardless of the
+    # rest of the CSP.
+    script_src_line = next(
+        (line for line in canonical.splitlines() if "script-src " in line and "src-attr" not in line),
+        "",
+    )
+    assert "'unsafe-inline'" not in script_src_line, f"script-src must not contain 'unsafe-inline': {script_src_line!r}"
 
 
 def test_root_allows_head_when_dashboard_is_bundled(tmp_path: Path, monkeypatch):

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -5,6 +5,10 @@ import "./globals.css";
 import { AuthGate } from "@/components/auth-gate";
 import { AuthProvider } from "@/components/auth-provider";
 import { Nav } from "@/components/nav";
+// Theme bootstrap script lives in lib/csp-source.ts so its sha256 stays in
+// sync with the script-src hash that lib/security-headers.ts emits in CSP.
+// Editing the script body in only one place will cause the sync test to fail.
+import { THEME_BOOTSTRAP_SCRIPT } from "@/lib/csp-source.mjs";
 
 // Local fonts — no network fetch at build time (works in air-gapped environments)
 const inter = localFont({
@@ -30,21 +34,6 @@ export const metadata: Metadata = {
   icons: { icon: "/favicon.ico" },
 };
 
-const themeBootstrap = `
-(function () {
-  try {
-    var stored = localStorage.getItem("agent-bom-theme");
-    var theme = stored === "light" || stored === "dark" ? stored : "dark";
-    var root = document.documentElement;
-    root.dataset.theme = theme;
-    root.style.colorScheme = theme;
-  } catch (error) {
-    document.documentElement.dataset.theme = "dark";
-    document.documentElement.style.colorScheme = "dark";
-  }
-})();
-`;
-
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" data-theme="dark" suppressHydrationWarning>
@@ -52,7 +41,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className={`${inter.variable} ${mono.variable} font-sans bg-background text-foreground min-h-screen antialiased selection:bg-emerald-500/20`}>
         <Script src="/runtime-config.js" strategy="beforeInteractive" />
         <Script id="theme-bootstrap" strategy="beforeInteractive">
-          {themeBootstrap}
+          {THEME_BOOTSTRAP_SCRIPT}
         </Script>
         <AuthProvider>
           <Nav />

--- a/ui/lib/csp-source.mjs
+++ b/ui/lib/csp-source.mjs
@@ -1,0 +1,26 @@
+// Single source of truth for the inline scripts the dashboard ships with.
+//
+// `THEME_BOOTSTRAP_SCRIPT` is rendered inline via next/script in
+// app/layout.tsx and its sha256 hash is added to script-src by
+// lib/security-headers.mjs. If you edit the body of this script, you do not
+// need to recompute the hash by hand — security-headers.mjs derives it from
+// this same string. The vitest suite in tests/security-headers.test.ts pins
+// the rendered CSP and the vercel.json sync test catches drift.
+//
+// Keep the script self-contained, ASCII, and short. Anything large should
+// move into an external chunk under public/ so the CSP stays hash-only.
+
+export const THEME_BOOTSTRAP_SCRIPT = `
+(function () {
+  try {
+    var stored = localStorage.getItem("agent-bom-theme");
+    var theme = stored === "light" || stored === "dark" ? stored : "dark";
+    var root = document.documentElement;
+    root.dataset.theme = theme;
+    root.style.colorScheme = theme;
+  } catch (error) {
+    document.documentElement.dataset.theme = "dark";
+    document.documentElement.style.colorScheme = "dark";
+  }
+})();
+`;

--- a/ui/lib/security-headers.mjs
+++ b/ui/lib/security-headers.mjs
@@ -1,0 +1,62 @@
+// Single source of truth for the dashboard security response headers.
+//
+// next.config.ts imports `securityHeaders()` for the dev/standalone server
+// path. ui/scripts/sync-vercel-headers.mjs reads from this same module to
+// regenerate ui/vercel.json so the static-export Vercel deployment stays in
+// lock-step. The vitest sync test in tests/security-headers.test.ts fails if
+// either side drifts.
+//
+// CSP design (issue #1954):
+//   - script-src is hash-pinned: 'self' plus the sha256 of every inline
+//     script the app intentionally ships. THEME_BOOTSTRAP_SCRIPT is the
+//     only inline script today; if a new one is added, register it here.
+//   - script-src does NOT carry 'unsafe-inline'. Removing it closes the
+//     XSS sink that previously allowed any injected inline <script> to run.
+//   - style-src still carries 'unsafe-inline' because Tailwind v4 + Next.js
+//     emit inline style attributes whose contents are not hash-stable per
+//     build (computed CSS variables). Tracker for migration: a follow-up
+//     to #1954; until then the CSP is markedly stricter than before but
+//     not yet pure-hash on style.
+
+import { createHash } from "node:crypto";
+
+import { THEME_BOOTSTRAP_SCRIPT } from "./csp-source.mjs";
+
+function sha256Base64(input) {
+  return createHash("sha256").update(input, "utf8").digest("base64");
+}
+
+const INLINE_SCRIPT_HASHES = [`'sha256-${sha256Base64(THEME_BOOTSTRAP_SCRIPT)}'`];
+
+export function cspHeaderValue() {
+  const scriptSrc = ["'self'", ...INLINE_SCRIPT_HASHES].join(" ");
+  return [
+    "default-src 'self'",
+    `script-src ${scriptSrc}`,
+    "script-src-attr 'none'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "frame-ancestors 'none'",
+  ].join("; ");
+}
+
+export function securityHeaders() {
+  return [
+    { key: "Content-Security-Policy", value: cspHeaderValue() },
+    { key: "X-Content-Type-Options", value: "nosniff" },
+    { key: "X-Frame-Options", value: "DENY" },
+    { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+    {
+      key: "Strict-Transport-Security",
+      value: "max-age=31536000; includeSubDomains",
+    },
+    {
+      key: "Permissions-Policy",
+      value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+    },
+  ];
+}

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -1,21 +1,19 @@
 import type { NextConfig } from "next";
 
+import { securityHeaders as buildSecurityHeaders } from "./lib/security-headers.mjs";
+
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8422";
 
 // NEXT_EXPORT=1 → static export bundled into the Python package (agent-bom api).
 // Rewrites require a running Node server so they are disabled in export mode.
 const isExport = process.env.NEXT_EXPORT === "1";
-const securityHeaders = [
-  {
-    key: "Content-Security-Policy",
-    value:
-      "default-src 'self'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'",
-  },
-  { key: "X-Content-Type-Options", value: "nosniff" },
-  { key: "X-Frame-Options", value: "DENY" },
-  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
-  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
-];
+
+// Single source of truth for CSP + companion headers lives in
+// lib/security-headers.ts. ui/scripts/sync-vercel-headers.mjs regenerates
+// ui/vercel.json from the same module so the standalone server (this config)
+// and the Vercel static deployment never drift. Tests in
+// tests/security-headers.test.ts pin the contract.
+const securityHeaders = buildSecurityHeaders();
 
 const nextConfig: NextConfig = {
   images: { unoptimized: true },

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,6 +16,8 @@
     "lock:normalize": "npm install --package-lock-only --ignore-scripts",
     "test:e2e": "playwright test",
     "verify:toolchain": "node scripts/verify-toolchain.mjs",
+    "headers:sync": "node scripts/sync-vercel-headers.mjs",
+    "headers:check": "node scripts/sync-vercel-headers.mjs --check",
     "test": "vitest",
     "test:run": "vitest run"
   },

--- a/ui/scripts/sync-vercel-headers.mjs
+++ b/ui/scripts/sync-vercel-headers.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// Regenerate the headers section of ui/vercel.json from
+// ui/lib/security-headers.mjs (the single source of truth) and report drift
+// with --check.
+//
+// Why: previously next.config.ts and vercel.json each carried a hand-edited
+// CSP, which drifted (next.config carried `img-src 'self' data: blob:` while
+// vercel only allowed `data:`, vercel had `Strict-Transport-Security` while
+// next.config did not, etc.). Closes #1954.
+//
+// Usage:
+//   node scripts/sync-vercel-headers.mjs            # rewrite ui/vercel.json
+//   node scripts/sync-vercel-headers.mjs --check    # exit 1 if drift
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import { securityHeaders } from "../lib/security-headers.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const UI_ROOT = resolve(HERE, "..");
+const VERCEL_PATH = resolve(UI_ROOT, "vercel.json");
+
+const headers = securityHeaders();
+
+const current = JSON.parse(readFileSync(VERCEL_PATH, "utf8"));
+const expected = {
+  ...current,
+  headers: [
+    {
+      source: "/(.*)",
+      headers: headers.map(({ key, value }) => ({ key, value })),
+    },
+  ],
+};
+
+const expectedJson = JSON.stringify(expected, null, 2) + "\n";
+const currentJson = readFileSync(VERCEL_PATH, "utf8");
+
+const checkOnly = process.argv.includes("--check");
+
+if (currentJson === expectedJson) {
+  if (checkOnly) {
+    process.stdout.write(`OK: ui/vercel.json headers match lib/security-headers.mjs (${headers.length} headers).\n`);
+  }
+  process.exit(0);
+}
+
+if (checkOnly) {
+  process.stderr.write(
+    "ui/vercel.json headers are out of sync with lib/security-headers.mjs.\n" +
+      "Run `npm run headers:sync` from the ui/ directory and commit the diff.\n",
+  );
+  process.exit(1);
+}
+
+writeFileSync(VERCEL_PATH, expectedJson, "utf8");
+process.stdout.write(`Wrote ui/vercel.json (${headers.length} headers).\n`);

--- a/ui/tests/security-headers.test.ts
+++ b/ui/tests/security-headers.test.ts
@@ -1,0 +1,54 @@
+// Pin the contract that the dashboard CSP and companion headers come from a
+// single source and that script-src no longer carries 'unsafe-inline'. If
+// next.config.ts and ui/vercel.json drift, or if a hash for an inline script
+// is missing, this test fails before the change can ship.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { THEME_BOOTSTRAP_SCRIPT } from "../lib/csp-source.mjs";
+import { cspHeaderValue, securityHeaders } from "../lib/security-headers.mjs";
+
+const UI_ROOT = resolve(__dirname, "..");
+const VERCEL_PATH = resolve(UI_ROOT, "vercel.json");
+
+describe("security-headers", () => {
+  it("script-src does not carry 'unsafe-inline'", () => {
+    const csp = cspHeaderValue();
+    const scriptSrc = csp.split(";").find((directive) => directive.trim().startsWith("script-src "));
+    expect(scriptSrc, "script-src directive must be present").toBeDefined();
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+  });
+
+  it("script-src includes the sha256 of THEME_BOOTSTRAP_SCRIPT", async () => {
+    // Use the runtime crypto module rather than re-deriving by hand so the
+    // test detects an upstream change in security-headers' hash algorithm.
+    const { createHash } = await import("node:crypto");
+    const expected = `'sha256-${createHash("sha256").update(THEME_BOOTSTRAP_SCRIPT, "utf8").digest("base64")}'`;
+    const csp = cspHeaderValue();
+    expect(csp).toContain(expected);
+  });
+
+  it("emits the standard companion headers", () => {
+    const headers = securityHeaders();
+    const keys = headers.map((h) => h.key);
+    expect(keys).toEqual([
+      "Content-Security-Policy",
+      "X-Content-Type-Options",
+      "X-Frame-Options",
+      "Referrer-Policy",
+      "Strict-Transport-Security",
+      "Permissions-Policy",
+    ]);
+  });
+
+  it("ui/vercel.json mirrors lib/security-headers.mjs", () => {
+    const vercel = JSON.parse(readFileSync(VERCEL_PATH, "utf8"));
+    expect(vercel.headers).toHaveLength(1);
+    const onDisk = vercel.headers[0].headers as Array<{ key: string; value: string }>;
+    const expected = securityHeaders();
+    expect(onDisk).toEqual(expected);
+  });
+});

--- a/ui/vercel.json
+++ b/ui/vercel.json
@@ -10,12 +10,30 @@
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "X-Frame-Options", "value": "DENY" },
-        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains" },
-        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), interest-cohort=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'" }
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'sha256-CVIz+8cEN0ddhFEe/IMBU5uIChZx5ZAwQQKl0dHHVuQ='; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), interest-cohort=()"
+        }
       ]
     }
   ]


### PR DESCRIPTION
## Summary

Closes #1954.

The dashboard CSP previously lived in two places (\`ui/next.config.ts\` and \`ui/vercel.json\`) carrying near-identical hand-edited strings that had drifted on multiple axes — \`img-src\` allowed \`blob:\` in \`next.config\` but not in vercel, vercel carried \`Strict-Transport-Security\` and the \`interest-cohort\` opt-out that \`next.config\` did not, and both still allowed \`'unsafe-inline'\` for \`script-src\`, which made the rest of \`script-src\` advisory at best.

### Single source of truth
- **\`ui/lib/csp-source.mjs\`** holds \`THEME_BOOTSTRAP_SCRIPT\` — the only inline script the app intentionally ships. \`ui/app/layout.tsx\` imports it via \`next/script\`; if the body changes, the script-src hash auto-updates from the same source string.
- **\`ui/lib/security-headers.mjs\`** is the canonical \`cspHeaderValue()\` + \`securityHeaders()\` module. Computes the sha256 of \`THEME_BOOTSTRAP_SCRIPT\` at module-load and embeds it into \`script-src\`.

### CSP hardening
- \`script-src\` no longer carries \`'unsafe-inline'\`. The XSS sink that previously allowed any injected inline \`<script>\` to run is gone.
- \`script-src 'self' 'sha256-CVIz+8cEN0ddhFEe/IMBU5uIChZx5ZAwQQKl0dHHVuQ='\` is what gets emitted today.
- \`style-src\` still carries \`'unsafe-inline'\` because Tailwind v4 + Next.js emit inline style attributes whose contents are not hash-stable per build; that migration is tracked as a #1954 follow-up.

### Sync mechanism
- **\`ui/scripts/sync-vercel-headers.mjs\`** regenerates \`ui/vercel.json\` from the canonical module. New npm scripts \`headers:sync\` (rewrite) and \`headers:check\` (CI gate, exit 1 on drift).
- \`ui/vercel.json\` now mirrors the canonical headers exactly: CSP, \`X-Content-Type-Options\`, \`X-Frame-Options\`, \`Referrer-Policy\`, \`Strict-Transport-Security\`, \`Permissions-Policy\` (with \`interest-cohort=()\`).

### CI gate
- \`.github/workflows/ci.yml\` adds **"UI security headers in sync"** to the **UI Validate** job. Drift in either source can never reach main.

### Tests (\`ui/tests/security-headers.test.ts\`)
Pins four contracts:
1. \`script-src\` has no \`'unsafe-inline'\`
2. \`cspHeaderValue()\` includes the sha256 of \`THEME_BOOTSTRAP_SCRIPT\`
3. The standard companion-header set is emitted in order
4. \`ui/vercel.json\` mirrors the canonical headers

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run test:run\` — 17 files / 127 tests (was 16/123)
- [x] \`npm run build\` — full static export succeeds with the stricter CSP
- [x] \`npm run headers:check\` — OK