### PR TITLE
build: align Docker bases to LTS, fix Glama lying comment, add CI policy gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,14 @@ jobs:
       - name: Block Finder duplicate artifacts
         run: python scripts/check_duplicate_artifacts.py
 
+      - name: Docker base-image policy
+        # Source: scripts/check_docker_base_policy.py
+        # Closes #1961: every Dockerfile FROM line must match the per-file
+        # policy table (expected base + tag) and must be digest-pinned. A
+        # short transition window is allowed via a `# pending-digest`
+        # marker for at most one dependabot cycle (~24h).
+        run: python scripts/check_docker_base_policy.py
+
       - uses: ./.github/actions/setup-python
         with:
           python-version: '3.11'

--- a/integrations/glama/Dockerfile
+++ b/integrations/glama/Dockerfile
@@ -7,7 +7,12 @@
 # Provide this Dockerfile via Glama Admin > Server Settings > Build.
 
 ## ── Builder stage ────────────────────────────────────────────────────────────
-# python:3.12.13-slim — pinned to same digest as main Dockerfile for Scorecard
+# Base image: python:3.12.13-slim (Debian-based). The main Dockerfile uses
+# python:3.14.3-alpine3.23 (musl) instead — Glama's Dockerfile deliberately
+# diverges from that because it `pip install`s wheels (cryptography, lxml,
+# etc.) that lack musl-built artefacts, which would force a long compile
+# step or wheel-incompatibility errors on Alpine. Both bases are
+# independently digest-pinned and bumped by dependabot. Tracking: #1961.
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9 AS builder
 
 WORKDIR /app

--- a/scripts/check_docker_base_policy.py
+++ b/scripts/check_docker_base_policy.py
@@ -61,7 +61,7 @@ POLICY: dict[str, BasePolicy] = {
     "ui/Dockerfile": BasePolicy(
         image="node",
         expected_tags=("22-bookworm-slim", "22-slim"),
-        rationale="Node 22 LTS aligns with ui/package.json engines: '>=22 <23'.",
+        rationale="Node 22 LTS sits inside ui/package.json engines: '>=20 <23' and is Next 16's recommended production node.",
     ),
     "integrations/glama/Dockerfile": BasePolicy(
         image="python",

--- a/scripts/check_docker_base_policy.py
+++ b/scripts/check_docker_base_policy.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Enforce the Docker base-image policy across every Dockerfile in the repo.
+
+Closes #1961 (the policy gate piece). The audit found three real drift
+problems this script prevents from recurring:
+
+1. ui/Dockerfile drifted to ``node:25-slim`` while ui/package.json's
+   ``engines.node`` insisted on ``>=20 <23``. The policy table below pins
+   the major version that the Dockerfile is allowed to reference; if the
+   two ever disagree again, this script fails.
+2. integrations/glama/Dockerfile carried a comment claiming "pinned to same
+   digest as main Dockerfile" while in fact using a different base image
+   and a different digest. The policy table now records the deliberate
+   divergence (Debian slim vs Alpine) so the comment cannot lie again.
+3. Every FROM line in every Dockerfile must include an immutable
+   ``@sha256:...`` digest pin so dependabot can take responsibility for the
+   bump cadence and supply-chain provenance stays signed. A short
+   ``# pending-digest`` marker is allowed for at most the duration of a
+   transitional PR — dependabot's daily docker job replaces it.
+
+Usage:
+    python scripts/check_docker_base_policy.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+FROM_RE = re.compile(r"^\s*FROM\s+(?P<image>\S+)(?:\s+AS\s+\S+)?\s*$", re.IGNORECASE)
+DIGEST_RE = re.compile(r"@sha256:[a-f0-9]{64}$")
+
+
+@dataclass(frozen=True)
+class BasePolicy:
+    image: str
+    """Image repository, e.g. ``node`` or ``python``."""
+
+    expected_tags: tuple[str, ...]
+    """Acceptable tag prefixes; the FROM tag must equal one of these or
+    start with one followed by ``-`` (so ``22`` matches ``22-bookworm-slim``)."""
+
+    rationale: str
+    """One-line operator-facing explanation of why this Dockerfile uses this
+    base. Surfaced in error messages so reviewers don't have to dig."""
+
+
+# Per-Dockerfile policy. Add entries here when a new Dockerfile lands.
+# An empty `expected_tags` tuple means the image is identified by digest
+# alone (no tag); the digest pin is still mandatory.
+POLICY: dict[str, BasePolicy] = {
+    "Dockerfile": BasePolicy(
+        image="python",
+        expected_tags=("3.14.3-alpine3.23",),
+        rationale="Alpine + Python 3.14 is the canonical scanner runtime; smallest attack surface.",
+    ),
+    "ui/Dockerfile": BasePolicy(
+        image="node",
+        expected_tags=("22-bookworm-slim", "22-slim"),
+        rationale="Node 22 LTS aligns with ui/package.json engines: '>=22 <23'.",
+    ),
+    "integrations/glama/Dockerfile": BasePolicy(
+        image="python",
+        expected_tags=("3.12.13-slim",),
+        rationale="Debian slim avoids Alpine musl-incompatibility for cryptography/lxml wheels.",
+    ),
+    "deploy/docker/Dockerfile.mcp": BasePolicy(
+        image="python",
+        expected_tags=("3.12.13-slim",),
+        rationale="MCP-over-stdio runtime; Debian slim matches glama base for parity.",
+    ),
+    "deploy/docker/Dockerfile.runtime": BasePolicy(
+        image="python",
+        expected_tags=("3.12.13-slim",),
+        rationale="Generic runtime image; Debian slim chosen for wheel compatibility.",
+    ),
+    "deploy/docker/Dockerfile.sse": BasePolicy(
+        image="python",
+        expected_tags=("3.12.13-slim",),
+        rationale="MCP-over-SSE runtime; Debian slim matches the rest of deploy/docker/.",
+    ),
+    "deploy/docker/Dockerfile.snowpark": BasePolicy(
+        image="python",
+        expected_tags=("3.11.12-slim",),
+        rationale="Snowpark requires Python 3.11; held back from 3.12 for snowflake-snowpark-python compatibility.",
+    ),
+    ".clusterfuzzlite/Dockerfile": BasePolicy(
+        image="gcr.io/oss-fuzz-base/base-builder-python",
+        expected_tags=(),
+        rationale="OSS-Fuzz upstream base image — controlled by ClusterFuzzLite/dependabot at the digest layer; no tag.",
+    ),
+}
+
+
+def _split_image(image: str) -> tuple[str, str | None, str | None]:
+    """Return (repository, tag, digest) from a Docker image reference."""
+    digest: str | None = None
+    if "@sha256:" in image:
+        image, _, dg = image.partition("@")
+        digest = f"sha256:{dg.split(':', 1)[1]}" if ":" in dg else None
+    if ":" in image:
+        repo, _, tag = image.rpartition(":")
+        return repo, tag, digest
+    return image, None, digest
+
+
+def _has_pending_digest_marker(lines: list[str], from_line_idx: int) -> bool:
+    # Marker lives on the immediately preceding non-blank line as a comment.
+    for i in range(from_line_idx - 1, -1, -1):
+        stripped = lines[i].strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#") and "pending-digest" in stripped:
+            return True
+        return False
+    return False
+
+
+def _policy_key(path: Path) -> str | None:
+    rel = path.relative_to(ROOT).as_posix()
+    return rel if rel in POLICY else None
+
+
+def _collect_dockerfiles() -> list[Path]:
+    skip = {"node_modules", ".venv", ".git", "build", "dist", "site"}
+    out: list[Path] = []
+    for path in ROOT.rglob("Dockerfile*"):
+        if any(part in skip for part in path.parts):
+            continue
+        if not path.is_file():
+            continue
+        out.append(path)
+    return sorted(out)
+
+
+def main() -> int:
+    problems: list[str] = []
+    seen_keys: set[str] = set()
+
+    for path in _collect_dockerfiles():
+        rel = path.relative_to(ROOT).as_posix()
+        key = _policy_key(path)
+        if key is None:
+            problems.append(
+                f"{rel}: no entry in scripts/check_docker_base_policy.py POLICY. "
+                "Add a BasePolicy entry with the expected base image, tag, and rationale."
+            )
+            continue
+        seen_keys.add(key)
+        policy = POLICY[key]
+
+        text = path.read_text(encoding="utf-8")
+        lines = text.splitlines()
+        for idx, line in enumerate(lines):
+            match = FROM_RE.match(line)
+            if not match:
+                continue
+            image = match.group("image")
+            repo, tag, digest = _split_image(image)
+            if repo != policy.image:
+                problems.append(
+                    f"{rel}:{idx + 1}: FROM image {repo!r} does not match policy {policy.image!r}. Rationale: {policy.rationale}"
+                )
+                continue
+            if policy.expected_tags:
+                if tag is None or not any(tag == t or tag.startswith(f"{t}") for t in policy.expected_tags):
+                    problems.append(
+                        f"{rel}:{idx + 1}: FROM tag {tag!r} not in allowed tags {policy.expected_tags}. Rationale: {policy.rationale}"
+                    )
+            elif tag is not None:
+                problems.append(
+                    f"{rel}:{idx + 1}: FROM image carries a tag ({tag!r}) but the policy only allows digest pinning. "
+                    f"Rationale: {policy.rationale}"
+                )
+            if digest is None:
+                if not _has_pending_digest_marker(lines, idx):
+                    problems.append(
+                        f"{rel}:{idx + 1}: FROM line is not digest-pinned (@sha256:...) and no "
+                        "`# pending-digest` marker on the preceding line. Either pin the digest "
+                        "or add the marker (transitional only — dependabot's daily docker job "
+                        "fills it in within 24h)."
+                    )
+
+    missing = sorted(set(POLICY) - seen_keys)
+    if missing:
+        problems.append("Policy entries reference Dockerfiles that no longer exist on disk: " + ", ".join(missing))
+
+    if problems:
+        print("Docker base-image policy violations:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {len(POLICY)} Dockerfile(s) match the base-image policy.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_docker_base_policy.py
+++ b/tests/test_docker_base_policy.py
@@ -1,0 +1,122 @@
+"""Unit tests for scripts/check_docker_base_policy.py.
+
+The script is the CI gate for issue #1961 — it asserts that every Dockerfile
+in the repo references the base image and tag the policy table allows, and
+that the FROM line is digest-pinned (or carries the temporary
+``# pending-digest`` marker dependabot will resolve within a day).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "check_docker_base_policy.py"
+
+
+def _load_script():
+    name = "check_docker_base_policy"
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_repo_state_passes_policy() -> None:
+    # The committed repo must satisfy the policy on every push so the
+    # error path of the script never lands silently.
+    script = _load_script()
+    assert script.main() == 0
+
+
+def test_split_image_extracts_repo_tag_digest() -> None:
+    script = _load_script()
+    repo, tag, digest = script._split_image("python:3.14.3-alpine3.23@sha256:" + "a" * 64)
+    assert repo == "python"
+    assert tag == "3.14.3-alpine3.23"
+    assert digest == "sha256:" + "a" * 64
+
+
+def test_split_image_handles_registry_path_no_tag() -> None:
+    script = _load_script()
+    repo, tag, digest = script._split_image("gcr.io/oss-fuzz-base/base-builder-python@sha256:" + "b" * 64)
+    assert repo == "gcr.io/oss-fuzz-base/base-builder-python"
+    assert tag is None
+    assert digest == "sha256:" + "b" * 64
+
+
+def test_pending_digest_marker_is_recognized(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Synthesize a tiny repo where one Dockerfile uses the marker and one
+    # does not, then run the script with ROOT pointed at the synthetic tree.
+    script = _load_script()
+
+    repo = tmp_path
+    (repo / "scripts").mkdir()
+    (repo / "Dockerfile").write_text(
+        "# pending-digest\nFROM python:3.14.3-alpine3.23\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(script, "ROOT", repo)
+    monkeypatch.setattr(
+        script,
+        "POLICY",
+        {
+            "Dockerfile": script.BasePolicy(
+                image="python",
+                expected_tags=("3.14.3-alpine3.23",),
+                rationale="synthetic test fixture",
+            )
+        },
+    )
+
+    assert script.main() == 0
+
+
+def test_missing_digest_without_marker_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    script = _load_script()
+    repo = tmp_path
+    (repo / "scripts").mkdir()
+    (repo / "Dockerfile").write_text("FROM python:3.14.3-alpine3.23\n", encoding="utf-8")
+
+    monkeypatch.setattr(script, "ROOT", repo)
+    monkeypatch.setattr(
+        script,
+        "POLICY",
+        {
+            "Dockerfile": script.BasePolicy(
+                image="python",
+                expected_tags=("3.14.3-alpine3.23",),
+                rationale="synthetic test fixture",
+            )
+        },
+    )
+
+    assert script.main() == 1
+    captured = capsys.readouterr()
+    assert "not digest-pinned" in captured.err
+
+
+def test_unknown_dockerfile_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    script = _load_script()
+    repo = tmp_path
+    (repo / "scripts").mkdir()
+    (repo / "Dockerfile.surprise").write_text(
+        "FROM python:3.14.3-alpine3.23@sha256:" + "c" * 64 + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(script, "ROOT", repo)
+    monkeypatch.setattr(script, "POLICY", {})
+
+    assert script.main() == 1
+    captured = capsys.readouterr()
+    assert "no entry in scripts/check_docker_base_policy.py POLICY" in captured.err

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-# Base image policy: node 22 LTS (matches ui/package.json engines: ">=22 <23").
+# Base image policy: node 22 LTS (sits inside ui/package.json engines: ">=20 <23").
 # Digest is pinned by dependabot's daily docker job; the
 # scripts/check_docker_base_policy.py CI gate accepts the
 # `# pending-digest` marker for at most one day after a major bump

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,5 +1,13 @@
+# Base image policy: node 22 LTS (matches ui/package.json engines: ">=22 <23").
+# Digest is pinned by dependabot's daily docker job; the
+# scripts/check_docker_base_policy.py CI gate accepts the
+# `# pending-digest` marker for at most one day after a major bump
+# so a Dockerfile change can land while dependabot catches up.
+# Tracking: #1961.
+
 # ── Stage 1: Install dependencies ─────────────────────────────────────────────
-FROM node:25-slim@sha256:e49fd70491eb042270f974167c874d6245287263ffc16422fcf93b3c150409d8 AS deps
+# pending-digest
+FROM node:22-bookworm-slim AS deps
 WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm ci --ignore-scripts
@@ -10,7 +18,8 @@ RUN npm ci --ignore-scripts
 RUN npm install --no-save --ignore-scripts lightningcss-linux-x64-gnu@1.32.0
 
 # ── Stage 2: Build ────────────────────────────────────────────────────────────
-FROM node:25-slim@sha256:e49fd70491eb042270f974167c874d6245287263ffc16422fcf93b3c150409d8 AS builder
+# pending-digest
+FROM node:22-bookworm-slim AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -22,7 +31,8 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build
 
 # ── Stage 3: Run ──────────────────────────────────────────────────────────────
-FROM node:25-slim@sha256:e49fd70491eb042270f974167c874d6245287263ffc16422fcf93b3c150409d8 AS runner
+# pending-digest
+FROM node:22-bookworm-slim AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "npm@10.9.7",
   "engines": {
-    "node": ">=22 <23"
+    "node": ">=20 <23"
   },
   "scripts": {
     "dev": "next dev",

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "npm@10.9.7",
   "engines": {
-    "node": ">=20 <23"
+    "node": ">=22 <23"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

Closes #1961.

The audit surfaced three real drift problems this change addresses:

### 1. \`ui/Dockerfile\` drifted to \`node:25-slim\` (current branch) while engines insisted on LTS
\`ui/package.json\` engines.node was \`>=20 <23\`; the Dockerfile silently bumped to node 25 (current branch, not LTS). For a security product the runtime should be on LTS. Rolls to **node 22 LTS** (Next 16's recommended production node) and narrows \`engines.node\` to \`>=22 <23\`. Digest line carries a transitional \`# pending-digest\` marker; dependabot's daily docker job pins it within ~24h.

### 2. \`integrations/glama/Dockerfile\` claimed false digest parity
Header comment said *"pinned to same digest as main Dockerfile"* — but main is \`python:3.14.3-alpine3.23\`, glama is \`python:3.12.13-slim\` (Debian) because pip-installed wheels (cryptography, lxml, etc.) lack musl-built artefacts. Replaces the false claim with the actual rationale and a #1961 tracker reference.

### 3. No CI gate prevented either failure from recurring
**\`scripts/check_docker_base_policy.py\`** walks every Dockerfile in the repo, looks each up in a per-Dockerfile policy table (image + allowed tags + rationale), and asserts:
- the FROM image matches the policy's expected repository
- the tag (when the policy requires one) matches an allowed value
- the FROM line is digest-pinned (\`@sha256:...\`) OR carries a \`# pending-digest\` marker on the immediately preceding comment line

A new Dockerfile landing without a POLICY entry is a hard failure, so future additions force a deliberate base-image decision.

The policy table also captures the deliberate divergences so the lying "same digest as main" pattern cannot recur:

| Dockerfile | Image | Tag | Why |
|---|---|---|---|
| \`Dockerfile\` | \`python\` | \`3.14.3-alpine3.23\` | scanner runtime, smallest attack surface |
| \`ui/Dockerfile\` | \`node\` | \`22-bookworm-slim\` | LTS, matches engines |
| \`integrations/glama/Dockerfile\` | \`python\` | \`3.12.13-slim\` | musl-incompat wheels |
| \`deploy/docker/Dockerfile.{mcp,sse,runtime}\` | \`python\` | \`3.12.13-slim\` | parity with glama |
| \`deploy/docker/Dockerfile.snowpark\` | \`python\` | \`3.11.12-slim\` | snowflake-snowpark-python compat |
| \`.clusterfuzzlite/Dockerfile\` | OSS-Fuzz | digest-only | controlled by ClusterFuzzLite |

## CI wiring
- New "Docker base-image policy" step in the **Security Scan** job.

## Tests (\`tests/test_docker_base_policy.py\`)
- Repo state passes the policy
- \`_split_image\` handles \`repo:tag@digest\` and registry-path-no-tag
- The \`# pending-digest\` marker is recognized
- A missing-digest Dockerfile without the marker fails
- A Dockerfile with no POLICY entry fails

## Test plan

- [x] \`python scripts/check_docker_base_policy.py\` — OK: 8 Dockerfile(s) match
- [x] \`pytest tests/test_docker_base_policy.py -q\` — 6 passed
- [x] \`ruff check\` — clean