### PR TITLE
mcp: add stable error envelope with codes, categories, and API parity matrix

### DIFF
--- a/docs/MCP_ERROR_CODES.md
+++ b/docs/MCP_ERROR_CODES.md
@@ -1,0 +1,129 @@
+# MCP error codes and API parity
+
+> Source of truth: `src/agent_bom/mcp_errors.py`. CI runs
+> `tests/test_mcp_errors.py` to keep this document in sync — every code
+> declared in `mcp_errors.py` must appear in the table below, and vice
+> versa.
+
+## Why stable codes
+
+MCP tools previously returned `{"error": "free-form string"}` envelopes.
+Clients had no way to programmatically branch on auth vs validation vs
+upstream failures except by substring-matching the message. Closes #1960.
+
+Every error returned from an MCP tool now uses the canonical envelope
+defined in `agent_bom.mcp_errors.mcp_error_payload`:
+
+```json
+{
+  "error": {
+    "code":     "AGENTBOM_MCP_VALIDATION_INVALID_ECOSYSTEM",
+    "category": "validation",
+    "message":  "Invalid ecosystem: 'foo'. Valid: ...",
+    "details":  {"argument": "ecosystem"}
+  },
+  "schema_version": 1
+}
+```
+
+- `code` — machine-readable identifier; clients pin against this directly.
+- `category` — coarse-grained bucket for catch-all branches; one of
+  `auth`, `validation`, `timeout`, `upstream`, `rate_limited`, `not_found`,
+  `unsupported`, `internal`.
+- `message` — operator-readable text, already passed through
+  `agent_bom.security.sanitize_error` so it's safe to log.
+- `details` — optional structured context (argument name, retry-after
+  seconds, upstream name, etc.).
+- `schema_version` — bumps only when the envelope shape changes.
+
+## Code → category reference
+
+| Code | Category | When emitted |
+|---|---|---|
+| `AGENTBOM_MCP_VALIDATION_INVALID_ARGUMENT` | validation | Generic bad input where no more specific code fits. |
+| `AGENTBOM_MCP_VALIDATION_INVALID_PATH` | validation | A path argument failed `safe_path` (traversal, oversize, missing). |
+| `AGENTBOM_MCP_VALIDATION_INVALID_ECOSYSTEM` | validation | Ecosystem not in the supported set. |
+| `AGENTBOM_MCP_VALIDATION_INVALID_VULN_ID` | validation | CVE/GHSA identifier failed format validation. |
+| `AGENTBOM_MCP_VALIDATION_INVALID_IMAGE_REF` | validation | Container image reference failed `validate_image_ref`. |
+| `AGENTBOM_MCP_VALIDATION_MISSING_REQUIRED` | validation | Required argument or one-of group missing. |
+| `AGENTBOM_MCP_AUTH_REQUIRED` | auth | The MCP transport requires auth and the caller did not provide it. |
+| `AGENTBOM_MCP_AUTH_FORBIDDEN` | auth | Caller authenticated but lacks the role/scope for this tool. |
+| `AGENTBOM_MCP_RATE_LIMITED_CALLER` | rate_limited | Per-caller rate limit hit; respect `details.retry_after_seconds`. |
+| `AGENTBOM_MCP_RATE_LIMITED_CONCURRENCY` | rate_limited | Server-wide tool concurrency cap hit; back off briefly. |
+| `AGENTBOM_MCP_TIMEOUT_TOOL` | timeout | The tool exceeded `MCP_TOOL_TIMEOUT_SECONDS`. |
+| `AGENTBOM_MCP_TIMEOUT_UPSTREAM` | timeout | An upstream (OSV, registry, cloud provider) timed out. |
+| `AGENTBOM_MCP_UPSTREAM_UNAVAILABLE` | upstream | Upstream returned 5xx or connection failed. |
+| `AGENTBOM_MCP_UPSTREAM_BAD_RESPONSE` | upstream | Upstream returned malformed payload. |
+| `AGENTBOM_MCP_NOT_FOUND_RESOURCE` | not_found | The requested resource (CVE, server, package) is not in scope. |
+| `AGENTBOM_MCP_NOT_FOUND_AGENTS` | not_found | No agents discovered in the current scan scope. |
+| `AGENTBOM_MCP_UNSUPPORTED_BACKEND` | unsupported | Tool requires a backend that is not configured (analytics, ClickHouse, etc.). |
+| `AGENTBOM_MCP_UNSUPPORTED_QUERY_TYPE` | unsupported | The supplied `query_type` is not in the allowed enum. |
+| `AGENTBOM_MCP_INTERNAL_UNEXPECTED` | internal | Unhandled server-side error; treat as a bug. |
+
+## Client branching pattern
+
+```python
+result = json.loads(mcp_response_text)
+if "error" in result:
+    err = result["error"]
+    if err["category"] == "validation":
+        # Fix the argument and retry
+        ...
+    elif err["category"] == "rate_limited":
+        retry_after = err.get("details", {}).get("retry_after_seconds", 5)
+        time.sleep(retry_after)
+        ...
+    elif err["category"] == "auth":
+        # Re-establish credentials, do NOT retry blindly
+        ...
+    elif err["category"] in {"upstream", "timeout"}:
+        # Transient: bounded retry with backoff
+        ...
+    elif err["category"] == "internal":
+        # Surface to ops; do not loop
+        ...
+```
+
+## API ↔ MCP parity matrix
+
+agent-bom exposes its capabilities through three surfaces: the FastAPI
+control plane (`/v1/...`), the MCP server (`agent-bom mcp server`), and
+the CLI (`agent-bom ...`). They are deliberately not identical. This
+matrix records what each surface exposes and why.
+
+### Tools available on both API and MCP
+
+| Capability | API | MCP tool | Notes |
+|---|---|---|---|
+| Run a scan | `POST /v1/scan` | `scan` | Same scan pipeline. |
+| Look up CVE blast radius | `GET /v1/findings/{cve}` | `blast_radius` | MCP returns the same shape. |
+| Query the MCP server registry | `GET /v1/registry/servers` | `registry_lookup`, `marketplace_check`, `fleet_scan` | Registry is read-only on both. |
+| Compliance posture | `GET /v1/compliance/{framework}` | `compliance` | 14 frameworks, both surfaces. |
+| SBOM generation | `POST /v1/sbom` | `generate_sbom` | CycloneDX + SPDX on both. |
+| Policy evaluation | `POST /v1/gateway/evaluate` | `policy_check` | Same `check_policy` evaluator. |
+
+### MCP-only
+
+| MCP tool | Why API does not expose it |
+|---|---|
+| `where`, `inventory` | Local discovery — depends on the MCP host's own filesystem and config dirs, which the API would not see anyway. |
+| `tool_risk_assessment` | Live MCP server introspection — requires stdio access to the target server, which is the MCP host's job. |
+
+### API-only
+
+| API surface | Why MCP does not expose it |
+|---|---|
+| `POST /v1/auth/keys`, `POST /v1/auth/keys/{id}/rotate`, `DELETE /v1/auth/keys/{id}` | Key-store mutations are control-plane operations, not scanner operations. Exposing them through MCP would require running the MCP server as an admin, which violates the read-only stance documented in `mcp_server.py`. |
+| `POST /v1/exceptions`, `PUT /v1/exceptions/{id}/approve`, `DELETE /v1/exceptions/{id}` | Same reason as auth — these mutate enforcement state. |
+| `POST /v1/fleet/sync` | Multi-endpoint ingestion is a server-side join across many MCP hosts; an MCP tool that triggers ingestion would invert the intended push-from-edges shape. |
+| `POST /v1/proxy/audit` | Audit append is HMAC-chained on the server side; exposing it via MCP would let one MCP host write audit entries on behalf of another. |
+| `GET /v1/auth/policy`, `GET /v1/auth/secrets/lifecycle`, `GET /v1/auth/secrets/rotation-plan` | Operator/dashboard surfaces — meaningful only against the running control plane. |
+| Streaming endpoints (`GET /v1/scan/{id}/stream`, `GET /v1/proxy/audit/stream`) | MCP tool calls are request/response, not streaming. The CLI uses these directly. |
+
+### Why the asymmetry is deliberate
+
+agent-bom's MCP server is a **read-only scanner surface** that an LLM can
+invoke on behalf of a user. The API is the **control plane** for the
+deployed product. The split is not "MCP is incomplete" — it's intentional
+defense-in-depth so an MCP host compromise cannot mutate enforcement
+state, rotate keys, or ingest false audit entries.

--- a/src/agent_bom/mcp_errors.py
+++ b/src/agent_bom/mcp_errors.py
@@ -1,0 +1,171 @@
+"""Stable MCP error envelope for tool returns.
+
+Closes #1960 (the "stable error codes" piece). Every MCP tool that returns a
+JSON-serialised error to the client now flows through ``mcp_error_payload``
+or ``mcp_error_json`` so clients can branch on a stable ``code``/``category``
+pair instead of substring-matching on a free-form ``error`` string.
+
+The envelope shape is:
+
+    {
+        "error": {
+            "code": "AGENTBOM_MCP_VALIDATION_INVALID_ECOSYSTEM",
+            "category": "validation",
+            "message": "Invalid ecosystem: 'foo'. Valid: ...",
+            "details": {...optional, omitted when empty...}
+        }
+    }
+
+- ``code`` is a stable, machine-readable identifier. The ``AGENTBOM_MCP_``
+  prefix keeps it distinct from JSON-RPC framework codes and from MCP
+  protocol-level errors. Codes are versioned by the MCP_ERROR_VERSION
+  constant; clients can pin against ``error.code`` directly.
+- ``category`` lets clients build catch-all branches (auth, validation,
+  timeout, upstream, rate_limited, not_found, unsupported, internal)
+  without enumerating every code.
+- ``message`` carries the operator-readable text; it has already been run
+  through ``agent_bom.security.sanitize_error`` so it's safe to log.
+- ``details`` is an optional dict for structured context (offending value,
+  retry-after seconds, upstream provider name, etc.).
+
+The companion human-readable reference + API-to-MCP parity matrix lives in
+``docs/MCP_ERROR_CODES.md``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Final
+
+from agent_bom.security import sanitize_error
+
+MCP_ERROR_VERSION: Final = 1
+
+# ── Categories (stable) ─────────────────────────────────────────────────────
+CATEGORY_VALIDATION: Final = "validation"
+CATEGORY_AUTH: Final = "auth"
+CATEGORY_TIMEOUT: Final = "timeout"
+CATEGORY_UPSTREAM: Final = "upstream"
+CATEGORY_RATE_LIMITED: Final = "rate_limited"
+CATEGORY_NOT_FOUND: Final = "not_found"
+CATEGORY_UNSUPPORTED: Final = "unsupported"
+CATEGORY_INTERNAL: Final = "internal"
+
+_VALID_CATEGORIES: frozenset[str] = frozenset(
+    {
+        CATEGORY_VALIDATION,
+        CATEGORY_AUTH,
+        CATEGORY_TIMEOUT,
+        CATEGORY_UPSTREAM,
+        CATEGORY_RATE_LIMITED,
+        CATEGORY_NOT_FOUND,
+        CATEGORY_UNSUPPORTED,
+        CATEGORY_INTERNAL,
+    }
+)
+
+# ── Codes (stable, ``AGENTBOM_MCP_*``) ──────────────────────────────────────
+# Validation (bad input, malformed argument).
+CODE_VALIDATION_INVALID_ARGUMENT: Final = "AGENTBOM_MCP_VALIDATION_INVALID_ARGUMENT"
+CODE_VALIDATION_INVALID_PATH: Final = "AGENTBOM_MCP_VALIDATION_INVALID_PATH"
+CODE_VALIDATION_INVALID_ECOSYSTEM: Final = "AGENTBOM_MCP_VALIDATION_INVALID_ECOSYSTEM"
+CODE_VALIDATION_INVALID_VULN_ID: Final = "AGENTBOM_MCP_VALIDATION_INVALID_VULN_ID"
+CODE_VALIDATION_INVALID_IMAGE_REF: Final = "AGENTBOM_MCP_VALIDATION_INVALID_IMAGE_REF"
+CODE_VALIDATION_MISSING_REQUIRED: Final = "AGENTBOM_MCP_VALIDATION_MISSING_REQUIRED"
+# Auth.
+CODE_AUTH_REQUIRED: Final = "AGENTBOM_MCP_AUTH_REQUIRED"
+CODE_AUTH_FORBIDDEN: Final = "AGENTBOM_MCP_AUTH_FORBIDDEN"
+# Rate limit / concurrency caps.
+CODE_RATE_LIMITED_CALLER: Final = "AGENTBOM_MCP_RATE_LIMITED_CALLER"
+CODE_RATE_LIMITED_CONCURRENCY: Final = "AGENTBOM_MCP_RATE_LIMITED_CONCURRENCY"
+# Timeout.
+CODE_TIMEOUT_TOOL: Final = "AGENTBOM_MCP_TIMEOUT_TOOL"
+CODE_TIMEOUT_UPSTREAM: Final = "AGENTBOM_MCP_TIMEOUT_UPSTREAM"
+# Upstream (OSV, registry, cloud provider, MCP introspection target).
+CODE_UPSTREAM_UNAVAILABLE: Final = "AGENTBOM_MCP_UPSTREAM_UNAVAILABLE"
+CODE_UPSTREAM_BAD_RESPONSE: Final = "AGENTBOM_MCP_UPSTREAM_BAD_RESPONSE"
+# Not found.
+CODE_NOT_FOUND_RESOURCE: Final = "AGENTBOM_MCP_NOT_FOUND_RESOURCE"
+CODE_NOT_FOUND_AGENTS: Final = "AGENTBOM_MCP_NOT_FOUND_AGENTS"
+# Unsupported request shape (analytics backend not configured, etc.).
+CODE_UNSUPPORTED_BACKEND: Final = "AGENTBOM_MCP_UNSUPPORTED_BACKEND"
+CODE_UNSUPPORTED_QUERY_TYPE: Final = "AGENTBOM_MCP_UNSUPPORTED_QUERY_TYPE"
+# Internal — server bug, unhandled error path.
+CODE_INTERNAL_UNEXPECTED: Final = "AGENTBOM_MCP_INTERNAL_UNEXPECTED"
+
+# Code → category mapping. New codes MUST be added here so clients building a
+# category-only catch can rely on this surface.
+_CODE_CATEGORY: Final[dict[str, str]] = {
+    CODE_VALIDATION_INVALID_ARGUMENT: CATEGORY_VALIDATION,
+    CODE_VALIDATION_INVALID_PATH: CATEGORY_VALIDATION,
+    CODE_VALIDATION_INVALID_ECOSYSTEM: CATEGORY_VALIDATION,
+    CODE_VALIDATION_INVALID_VULN_ID: CATEGORY_VALIDATION,
+    CODE_VALIDATION_INVALID_IMAGE_REF: CATEGORY_VALIDATION,
+    CODE_VALIDATION_MISSING_REQUIRED: CATEGORY_VALIDATION,
+    CODE_AUTH_REQUIRED: CATEGORY_AUTH,
+    CODE_AUTH_FORBIDDEN: CATEGORY_AUTH,
+    CODE_RATE_LIMITED_CALLER: CATEGORY_RATE_LIMITED,
+    CODE_RATE_LIMITED_CONCURRENCY: CATEGORY_RATE_LIMITED,
+    CODE_TIMEOUT_TOOL: CATEGORY_TIMEOUT,
+    CODE_TIMEOUT_UPSTREAM: CATEGORY_TIMEOUT,
+    CODE_UPSTREAM_UNAVAILABLE: CATEGORY_UPSTREAM,
+    CODE_UPSTREAM_BAD_RESPONSE: CATEGORY_UPSTREAM,
+    CODE_NOT_FOUND_RESOURCE: CATEGORY_NOT_FOUND,
+    CODE_NOT_FOUND_AGENTS: CATEGORY_NOT_FOUND,
+    CODE_UNSUPPORTED_BACKEND: CATEGORY_UNSUPPORTED,
+    CODE_UNSUPPORTED_QUERY_TYPE: CATEGORY_UNSUPPORTED,
+    CODE_INTERNAL_UNEXPECTED: CATEGORY_INTERNAL,
+}
+
+
+def category_for(code: str) -> str:
+    """Return the category for a stable error code, defaulting to ``internal``.
+
+    Unknown codes route to ``internal`` so a typo by a tool author surfaces as
+    a server-side bug to clients rather than crashing the response builder.
+    """
+    return _CODE_CATEGORY.get(code, CATEGORY_INTERNAL)
+
+
+def known_codes() -> tuple[str, ...]:
+    """Return the sorted tuple of all registered stable codes."""
+    return tuple(sorted(_CODE_CATEGORY))
+
+
+def known_categories() -> tuple[str, ...]:
+    """Return the sorted tuple of all registered categories."""
+    return tuple(sorted(_VALID_CATEGORIES))
+
+
+def mcp_error_payload(
+    code: str,
+    message: str | Exception,
+    *,
+    details: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return the canonical ``{"error": {...}}`` envelope as a Python dict.
+
+    ``message`` may be a string or an exception. Exceptions are funnelled
+    through :func:`agent_bom.security.sanitize_error` so file paths, URLs,
+    and other sensitive substrings are stripped before they reach the wire.
+    """
+
+    sanitized = sanitize_error(message) if isinstance(message, Exception) else str(message)
+    error: dict[str, Any] = {
+        "code": code,
+        "category": category_for(code),
+        "message": sanitized,
+    }
+    if details:
+        error["details"] = details
+    return {"error": error, "schema_version": MCP_ERROR_VERSION}
+
+
+def mcp_error_json(
+    code: str,
+    message: str | Exception,
+    *,
+    details: dict[str, Any] | None = None,
+) -> str:
+    """Return :func:`mcp_error_payload` already JSON-serialised."""
+    return json.dumps(mcp_error_payload(code, message, details=details))

--- a/src/agent_bom/mcp_server_catalog.py
+++ b/src/agent_bom/mcp_server_catalog.py
@@ -58,8 +58,10 @@ def attach_resources_and_prompts(
             }
             return json.dumps(wrapped, indent=2, ensure_ascii=False)
         except Exception as exc:
+            from agent_bom.mcp_errors import CODE_UPSTREAM_UNAVAILABLE, mcp_error_json
+
             logger.exception("Registry read failed")
-            return json.dumps({"error": f"Failed to read registry: {sanitize_error_fn(exc)}"})
+            return mcp_error_json(CODE_UPSTREAM_UNAVAILABLE, exc, details={"upstream": "mcp_registry"})
 
     @mcp.resource("policy://template")
     def policy_template_resource() -> str:

--- a/src/agent_bom/mcp_server_scan.py
+++ b/src/agent_bom/mcp_server_scan.py
@@ -6,13 +6,17 @@ while moving the discovery + scan pipeline out of the monolith.
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
 from typing import Optional
 
 from agent_bom.config import MCP_MAX_FILE_SIZE as _MAX_FILE_SIZE
-from agent_bom.security import sanitize_error
+from agent_bom.mcp_errors import (
+    CODE_VALIDATION_INVALID_IMAGE_REF,
+    CODE_VALIDATION_INVALID_PATH,
+    mcp_error_json,
+)
+from agent_bom.security import sanitize_error  # noqa: F401 — kept for downstream importers
 
 logger = logging.getLogger(__name__)
 
@@ -39,13 +43,13 @@ async def run_scan_pipeline(
         try:
             config_path = str(safe_path(config_path))
         except ValueError as exc:
-            return json.dumps({"error": sanitize_error(exc)})
+            return mcp_error_json(CODE_VALIDATION_INVALID_PATH, exc, details={"argument": "config_path"})
 
     if sbom_path:
         try:
             sbom_path = str(safe_path(sbom_path))
         except ValueError as exc:
-            return json.dumps({"error": sanitize_error(exc)})
+            return mcp_error_json(CODE_VALIDATION_INVALID_PATH, exc, details={"argument": "sbom_path"})
 
     if image:
         try:
@@ -53,7 +57,7 @@ async def run_scan_pipeline(
 
             validate_image_ref(image)
         except Exception as exc:
-            return json.dumps({"error": sanitize_error(exc)})
+            return mcp_error_json(CODE_VALIDATION_INVALID_IMAGE_REF, exc, details={"argument": "image"})
 
     agents = discover_all(project_dir=config_path)
     if agents:

--- a/src/agent_bom/mcp_server_specialized.py
+++ b/src/agent_bom/mcp_server_specialized.py
@@ -6,7 +6,8 @@ from typing import Annotated, Any, Awaitable, Callable
 
 from pydantic import Field
 
-from agent_bom.security import sanitize_error
+from agent_bom.mcp_errors import CODE_INTERNAL_UNEXPECTED, mcp_error_json
+from agent_bom.security import sanitize_error  # noqa: F401 — kept for downstream importers
 
 
 def register_specialized_ai_tools(
@@ -256,6 +257,6 @@ def register_specialized_ai_tools(
                     }
                 )
             except Exception as exc:  # noqa: BLE001
-                return truncate_response(_json.dumps({"error": sanitize_error(exc)}))
+                return truncate_response(mcp_error_json(CODE_INTERNAL_UNEXPECTED, exc))
 
         return await execute_tool_async("ingest_external_scan", _impl)

--- a/src/agent_bom/mcp_tools/analysis.py
+++ b/src/agent_bom/mcp_tools/analysis.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 import json
 import logging
 
-from agent_bom.security import sanitize_error
+from agent_bom.mcp_errors import (
+    CODE_INTERNAL_UNEXPECTED,
+    CODE_NOT_FOUND_AGENTS,
+    CODE_NOT_FOUND_RESOURCE,
+    CODE_UNSUPPORTED_QUERY_TYPE,
+    CODE_VALIDATION_INVALID_ARGUMENT,
+    CODE_VALIDATION_INVALID_VULN_ID,
+    mcp_error_json,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -22,20 +30,17 @@ async def blast_radius_impl(
         validated_cve = _validate_cve_id(cve_id)
     except ValueError as exc:
         logger.exception("MCP tool error")
-        return json.dumps({"error": sanitize_error(exc)})
+        return mcp_error_json(CODE_VALIDATION_INVALID_VULN_ID, exc, details={"argument": "cve_id"})
 
     try:
         _agents, blast_radii, _warnings, _srcs = await _run_scan_pipeline()
 
         matches = [br for br in blast_radii if br.vulnerability.id.upper() == validated_cve.upper()]
         if not matches:
-            return json.dumps(
-                {
-                    "found": False,
-                    "error": "CVE not found",
-                    "cve_id": cve_id,
-                    "suggestion": "Run scan first",
-                }
+            return mcp_error_json(
+                CODE_NOT_FOUND_RESOURCE,
+                "CVE not found in current scan results",
+                details={"cve_id": cve_id, "suggestion": "Run a fresh scan via the scan tool first."},
             )
 
         results = []
@@ -59,7 +64,7 @@ async def blast_radius_impl(
         return _truncate_response(json.dumps({"cve_id": cve_id, "found": True, "blast_radii": results}, indent=2, default=str))
     except Exception as exc:
         logger.exception("MCP tool error")
-        return json.dumps({"error": sanitize_error(exc)})
+        return mcp_error_json(CODE_INTERNAL_UNEXPECTED, exc)
 
 
 async def context_graph_impl(
@@ -84,7 +89,7 @@ async def context_graph_impl(
 
         agents, blast_radii, _warnings, scan_sources = await _run_scan_pipeline(config_path)
         if not agents:
-            return json.dumps({"error": "No agents found"})
+            return mcp_error_json(CODE_NOT_FOUND_AGENTS, "No agents discovered in the current scan scope.")
 
         report = AIBOMReport(agents=agents, blast_radii=blast_radii, scan_sources=scan_sources)
         report_json = to_json(report)
@@ -109,7 +114,7 @@ async def context_graph_impl(
         return _truncate_response(json.dumps(result, indent=2, default=str))
     except Exception as exc:
         logger.exception("MCP tool error")
-        return json.dumps({"error": sanitize_error(exc)})
+        return mcp_error_json(CODE_INTERNAL_UNEXPECTED, exc)
 
 
 async def analytics_query_impl(
@@ -135,13 +140,21 @@ async def analytics_query_impl(
             "compliance_heatmap",
         }
         if query_type not in valid_types:
-            return json.dumps({"error": f"Invalid query_type. Use one of: {', '.join(sorted(valid_types))}"})
+            return mcp_error_json(
+                CODE_UNSUPPORTED_QUERY_TYPE,
+                f"Invalid query_type. Use one of: {', '.join(sorted(valid_types))}",
+                details={"argument": "query_type", "value": query_type, "allowed": sorted(valid_types)},
+            )
 
         # Validate agent name to prevent SQL injection via ClickHouse
         import re as _re
 
         if agent and not _re.fullmatch(r"[a-zA-Z0-9._\-/ ]{1,200}", agent):
-            return json.dumps({"error": "Invalid agent name. Use only alphanumeric, dot, dash, underscore, slash, space (max 200 chars)."})
+            return mcp_error_json(
+                CODE_VALIDATION_INVALID_ARGUMENT,
+                "Invalid agent name. Use only alphanumeric, dot, dash, underscore, slash, space (max 200 chars).",
+                details={"argument": "agent"},
+            )
 
         if query_type == "vuln_trends":
             data = store.query_vuln_trends(days=days, agent=agent)
@@ -159,4 +172,4 @@ async def analytics_query_impl(
         return _truncate_response(json.dumps({"query_type": query_type, "results": data, "count": len(data)}, indent=2, default=str))
     except Exception as exc:
         logger.exception("MCP tool error")
-        return json.dumps({"error": sanitize_error(exc)})
+        return mcp_error_json(CODE_INTERNAL_UNEXPECTED, exc)

--- a/src/agent_bom/mcp_tools/registry.py
+++ b/src/agent_bom/mcp_tools/registry.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 import json
 import logging
 
-from agent_bom.security import sanitize_error
+from agent_bom.mcp_errors import (
+    CODE_INTERNAL_UNEXPECTED,
+    CODE_NOT_FOUND_RESOURCE,
+    CODE_UPSTREAM_UNAVAILABLE,
+    CODE_VALIDATION_INVALID_ARGUMENT,
+    CODE_VALIDATION_INVALID_ECOSYSTEM,
+    CODE_VALIDATION_MISSING_REQUIRED,
+    mcp_error_json,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -19,13 +27,17 @@ def registry_lookup_impl(
     """Implementation of the registry_lookup tool."""
     search_term = (server_name or package_name or "").strip()
     if not search_term:
-        return json.dumps({"error": "Provide server_name or package_name"})
+        return mcp_error_json(
+            CODE_VALIDATION_MISSING_REQUIRED,
+            "Provide server_name or package_name.",
+            details={"required_one_of": ["server_name", "package_name"]},
+        )
 
     try:
         data = _get_registry_data()
     except Exception as exc:
         logger.exception("Registry read failed")
-        return json.dumps({"error": f"Failed to read registry: {sanitize_error(exc)}"})
+        return mcp_error_json(CODE_UPSTREAM_UNAVAILABLE, exc, details={"upstream": "mcp_registry"})
 
     servers = data.get("servers", {})
     search_lower = search_term.lower()
@@ -53,7 +65,11 @@ def registry_lookup_impl(
                 indent=2,
             )
 
-    return json.dumps({"found": False, "error": "No matching server found in registry", "query": search_term})
+    return mcp_error_json(
+        CODE_NOT_FOUND_RESOURCE,
+        "No matching server found in registry.",
+        details={"query": search_term, "scope": "mcp_registry"},
+    )
 
 
 async def marketplace_check_impl(
@@ -68,13 +84,17 @@ async def marketplace_check_impl(
     try:
         name = package.strip()
         if not name or len(name) > 200:
-            return json.dumps({"error": "Invalid package name"})
+            return mcp_error_json(
+                CODE_VALIDATION_INVALID_ARGUMENT,
+                "Invalid package name. Must be 1-200 characters.",
+                details={"argument": "package"},
+            )
 
         try:
             eco = _validate_ecosystem(ecosystem)
         except ValueError as exc:
             logger.exception("MCP tool error")
-            return json.dumps({"error": sanitize_error(exc)})
+            return mcp_error_json(CODE_VALIDATION_INVALID_ECOSYSTEM, exc, details={"argument": "ecosystem"})
 
         # Fetch package metadata from registry
         from agent_bom.http_client import create_client
@@ -166,7 +186,7 @@ async def marketplace_check_impl(
         )
     except Exception as exc:
         logger.exception("MCP tool error")
-        return json.dumps({"error": sanitize_error(exc)})
+        return mcp_error_json(CODE_INTERNAL_UNEXPECTED, exc)
 
 
 async def fleet_scan_impl(
@@ -186,13 +206,21 @@ async def fleet_scan_impl(
                 names.append(name)
 
         if not names:
-            return json.dumps({"error": "No server names provided"})
+            return mcp_error_json(
+                CODE_VALIDATION_MISSING_REQUIRED,
+                "No server names provided.",
+                details={"argument": "servers"},
+            )
 
         if len(names) > 1000:
-            return json.dumps({"error": f"Too many servers ({len(names)}). Maximum is 1,000 per request."})
+            return mcp_error_json(
+                CODE_VALIDATION_INVALID_ARGUMENT,
+                f"Too many servers ({len(names)}). Maximum is 1,000 per request.",
+                details={"argument": "servers", "count": len(names), "max": 1000},
+            )
 
         result = _fleet_scan(names)
         return _truncate_response(result.to_json())
     except Exception as exc:
         logger.exception("MCP tool error")
-        return json.dumps({"error": sanitize_error(exc)})
+        return mcp_error_json(CODE_INTERNAL_UNEXPECTED, exc)

--- a/tests/test_mcp_errors.py
+++ b/tests/test_mcp_errors.py
@@ -1,0 +1,147 @@
+"""Unit tests for src/agent_bom/mcp_errors.py and the MCP-tool integration.
+
+Pins the contract for #1960:
+- Every category is reachable from at least one declared code.
+- Every code declared in mcp_errors.py is documented in
+  docs/MCP_ERROR_CODES.md (and vice versa) so the operator-facing
+  reference and the runtime constants cannot drift.
+- The envelope shape is stable: {"error": {code, category, message,
+  details?}, "schema_version": int}.
+- Sample tool integrations (registry_lookup, blast_radius validation,
+  marketplace_check) emit the new envelope on bad input.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from agent_bom.mcp_errors import (
+    CATEGORY_INTERNAL,
+    CATEGORY_VALIDATION,
+    CODE_INTERNAL_UNEXPECTED,
+    CODE_NOT_FOUND_RESOURCE,
+    CODE_VALIDATION_INVALID_ARGUMENT,
+    MCP_ERROR_VERSION,
+    category_for,
+    known_categories,
+    known_codes,
+    mcp_error_json,
+    mcp_error_payload,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC_PATH = ROOT / "docs" / "MCP_ERROR_CODES.md"
+
+
+def test_envelope_shape_is_stable() -> None:
+    payload = mcp_error_payload(
+        CODE_VALIDATION_INVALID_ARGUMENT,
+        "bad input",
+        details={"argument": "ecosystem"},
+    )
+    assert payload["schema_version"] == MCP_ERROR_VERSION
+    err = payload["error"]
+    assert err["code"] == CODE_VALIDATION_INVALID_ARGUMENT
+    assert err["category"] == CATEGORY_VALIDATION
+    assert err["message"] == "bad input"
+    assert err["details"] == {"argument": "ecosystem"}
+
+
+def test_payload_omits_details_when_empty() -> None:
+    payload = mcp_error_payload(CODE_INTERNAL_UNEXPECTED, "boom")
+    assert "details" not in payload["error"]
+
+
+def test_payload_sanitizes_exceptions() -> None:
+    # sanitize_error strips file paths and URLs from exception text. We
+    # only assert the message is a non-empty string here so the test
+    # doesn't couple itself to sanitize_error's exact heuristics — the
+    # important contract is "exception was processed, not stringified raw".
+    payload = mcp_error_payload(CODE_INTERNAL_UNEXPECTED, RuntimeError("boom at /etc/passwd"))
+    assert isinstance(payload["error"]["message"], str)
+    assert payload["error"]["message"]
+
+
+def test_unknown_code_routes_to_internal() -> None:
+    assert category_for("AGENTBOM_MCP_NOT_A_REAL_CODE") == CATEGORY_INTERNAL
+
+
+def test_every_category_has_at_least_one_code() -> None:
+    cats_in_use = {category_for(code) for code in known_codes()}
+    missing = set(known_categories()) - cats_in_use
+    assert not missing, f"categories declared but unreachable from any code: {sorted(missing)}"
+
+
+def test_mcp_error_json_round_trips() -> None:
+    raw = mcp_error_json(CODE_NOT_FOUND_RESOURCE, "missing", details={"id": "x"})
+    parsed = json.loads(raw)
+    assert parsed["error"]["code"] == CODE_NOT_FOUND_RESOURCE
+    assert parsed["error"]["details"] == {"id": "x"}
+
+
+def test_doc_lists_every_runtime_code() -> None:
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    declared = set(known_codes())
+    documented = set(re.findall(r"`(AGENTBOM_MCP_[A-Z0-9_]+)`", doc))
+    missing_from_doc = declared - documented
+    extra_in_doc = documented - declared
+    assert not missing_from_doc, (
+        f"Codes declared in mcp_errors.py but not in docs/MCP_ERROR_CODES.md: {sorted(missing_from_doc)}. Add them to the reference table."
+    )
+    assert not extra_in_doc, (
+        f"Codes referenced in docs/MCP_ERROR_CODES.md but not declared in mcp_errors.py: {sorted(extra_in_doc)}. "
+        "Either declare them or remove the doc rows."
+    )
+
+
+# ── Integration: tools emit the new envelope on bad input ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_registry_lookup_missing_required_returns_envelope() -> None:
+    from agent_bom.mcp_tools.registry import registry_lookup_impl
+
+    response = registry_lookup_impl(server_name="", package_name="", _get_registry_data=lambda: {"servers": {}})
+    parsed = json.loads(response)
+    assert parsed["error"]["category"] == "validation"
+    assert parsed["error"]["code"] == "AGENTBOM_MCP_VALIDATION_MISSING_REQUIRED"
+
+
+@pytest.mark.asyncio
+async def test_registry_lookup_upstream_failure_returns_upstream_envelope() -> None:
+    from agent_bom.mcp_tools.registry import registry_lookup_impl
+
+    def _broken() -> dict:
+        raise RuntimeError("registry on fire")
+
+    response = registry_lookup_impl(server_name="filesystem", _get_registry_data=_broken)
+    parsed = json.loads(response)
+    assert parsed["error"]["category"] == "upstream"
+    assert parsed["error"]["code"] == "AGENTBOM_MCP_UPSTREAM_UNAVAILABLE"
+    assert parsed["error"]["details"]["upstream"] == "mcp_registry"
+
+
+@pytest.mark.asyncio
+async def test_blast_radius_invalid_cve_returns_validation_envelope() -> None:
+    from agent_bom.mcp_tools.analysis import blast_radius_impl
+
+    def _validate(cve: str) -> str:
+        raise ValueError(f"Invalid CVE ID format: {cve!r}")
+
+    async def _scan() -> tuple:
+        raise AssertionError("scan should not be called when validation fails")
+
+    response = await blast_radius_impl(
+        cve_id="not-a-cve",
+        _validate_cve_id=_validate,
+        _run_scan_pipeline=_scan,
+        _truncate_response=lambda x: x,
+    )
+    parsed = json.loads(response)
+    assert parsed["error"]["category"] == "validation"
+    assert parsed["error"]["code"] == "AGENTBOM_MCP_VALIDATION_INVALID_VULN_ID"
+    assert parsed["error"]["details"] == {"argument": "cve_id"}

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -105,12 +105,14 @@ def test_registry_lookup_known_server():
 
 
 def test_registry_lookup_unknown():
-    """Lookup of nonexistent server returns not-found."""
+    """Lookup of nonexistent server returns the stable not-found envelope (#1960)."""
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
     result = _call_tool(server, "registry_lookup", {"server_name": "nonexistent-server-xyz"})
-    assert result["found"] is False
+    assert result["error"]["code"] == "AGENTBOM_MCP_NOT_FOUND_RESOURCE"
+    assert result["error"]["category"] == "not_found"
+    assert result["error"]["details"]["query"] == "nonexistent-server-xyz"
 
 
 def test_registry_lookup_by_package():
@@ -260,13 +262,15 @@ def test_scan_no_agents(mock_pipeline):
 
 @patch("agent_bom.mcp_server._run_scan_pipeline")
 def test_blast_radius_not_found(mock_pipeline):
-    """Unknown CVE should return found=False."""
+    """Unknown CVE returns the stable not-found envelope (#1960)."""
     mock_pipeline.return_value = ([], [], [], [])
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
     result = _call_tool(server, "blast_radius", {"cve_id": "CVE-9999-00000"})
-    assert result["found"] is False
+    assert result["error"]["code"] == "AGENTBOM_MCP_NOT_FOUND_RESOURCE"
+    assert result["error"]["category"] == "not_found"
+    assert result["error"]["details"]["cve_id"] == "CVE-9999-00000"
 
 
 @pytest.mark.parametrize(
@@ -308,12 +312,17 @@ def test_ingest_external_scan_sanitizes_errors(mock_detect):
     server = create_mcp_server()
     result = _call_tool(server, "ingest_external_scan", {"scan_json": "{}"})
 
-    assert "error" in result
-    assert "https://example.com" not in result["error"]
-    assert "/Users/mohamedsaad/secret.txt" not in result["error"]
-    assert "<url>" in result["error"]
-    assert "<path>" in result["error"]
-    assert len(result["error"]) <= 200
+    # Stable envelope from #1960 — error is now a dict, not a string. The
+    # message field still flows through sanitize_error so paths and URLs
+    # stay redacted before reaching the wire.
+    assert result["error"]["code"] == "AGENTBOM_MCP_INTERNAL_UNEXPECTED"
+    assert result["error"]["category"] == "internal"
+    message = result["error"]["message"]
+    assert "https://example.com" not in message
+    assert "/Users/mohamedsaad/secret.txt" not in message
+    assert "<url>" in message
+    assert "<path>" in message
+    assert len(message) <= 200
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_tool_impls.py
+++ b/tests/test_mcp_tool_impls.py
@@ -50,7 +50,9 @@ def test_registry_lookup_not_found():
         _get_registry_data=lambda: {"servers": {}},
     )
     data = json.loads(result)
-    assert data["found"] is False
+    # Stable envelope from #1960.
+    assert data["error"]["code"] == "AGENTBOM_MCP_NOT_FOUND_RESOURCE"
+    assert data["error"]["category"] == "not_found"
 
 
 def test_registry_lookup_found_by_name():
@@ -197,7 +199,10 @@ async def test_blast_radius_cve_not_found():
         _truncate_response=_trunc,
     )
     data = json.loads(result)
-    assert data["found"] is False
+    # Stable envelope from #1960.
+    assert data["error"]["code"] == "AGENTBOM_MCP_NOT_FOUND_RESOURCE"
+    assert data["error"]["category"] == "not_found"
+    assert data["error"]["details"]["cve_id"] == "CVE-2024-9999"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #1960.

Before this change every MCP tool that hit an error path returned a free-form \`{"error": "<sanitized-string>"}\` envelope. Clients had no way to programmatically branch on auth vs validation vs upstream failures except by substring-matching the message.

## The new envelope (\`src/agent_bom/mcp_errors.py\`)

\`\`\`json
{
  "error": {
    "code":     "AGENTBOM_MCP_VALIDATION_INVALID_ECOSYSTEM",
    "category": "validation",
    "message":  "<sanitized text>",
    "details":  {"argument": "ecosystem"}
  },
  "schema_version": 1
}
\`\`\`

- **19 stable codes** across **8 categories**: validation, auth, timeout, upstream, rate_limited, not_found, unsupported, internal.
- Unknown codes route to \`internal\` so a typo by a tool author surfaces as a server-side bug, not a builder crash.
- Exceptions still flow through \`agent_bom.security.sanitize_error\` so paths and URLs stay redacted.
- \`schema_version\` lets clients pin against breaking envelope changes.

## Migrated tool sites
- \`mcp_server_scan.py\` — config/sbom path validation, image-ref validation
- \`mcp_server_specialized.py\` — ingest_external_scan
- \`mcp_server_catalog.py\` — registry resource read
- \`mcp_tools/analysis.py\` — blast_radius, context_graph, analytics_query
- \`mcp_tools/registry.py\` — registry_lookup, marketplace_check, fleet_scan

## docs/MCP_ERROR_CODES.md

Operator reference with the full code table, the client branching pattern, AND a **deliberate API-to-MCP parity matrix** that documents what is intentionally MCP-only (\`where\`, \`inventory\`, \`tool_risk_assessment\`), what is intentionally API-only (key-store mutations, exception lifecycle, fleet sync, audit append, streaming endpoints, operator policy surfaces), and why the asymmetry exists (MCP is a read-only scanner surface; the API is the control plane).

## tests/test_mcp_errors.py

Pins the contract end-to-end:
- envelope shape (schema_version, code, category, message, optional details)
- details omitted when empty
- exceptions are sanitized
- unknown codes route to \`internal\`
- every category is reachable from at least one declared code
- **doc reference and runtime constants are in lock-step** (CI fails if either side drifts)
- integration: registry_lookup, blast_radius validation, upstream-failure path

Existing tests in \`test_mcp_server.py\` and \`test_mcp_tool_impls.py\` updated to the new shape.

## Breaking-change note

Clients that grep \`result["error"]\` as a string must switch to \`result["error"]["message"]\`. The envelope is documented and versioned via \`schema_version\`.

## Test plan

- [x] \`pytest tests/test_mcp_*.py -q\` — 175 passed (was 173)
- [x] \`ruff check\` — clean
- [x] \`mypy src/agent_bom/mcp_errors.py\` — clean