### PR TITLE
feat(frontend): typed API error taxonomy + GET caching/dedup with prefix invalidation

### DIFF
--- a/ui/lib/api-cache.ts
+++ b/ui/lib/api-cache.ts
@@ -1,0 +1,98 @@
+// In-memory TTL cache + inflight-dedup for the dashboard's GET requests.
+//
+// Closes the "caching, deduplication, retries, invalidation" half of #1956.
+// React 19's strict effects double-fire `useEffect`, and most of the
+// dashboard pages re-mount their data fetchers on every navigation — so the
+// API was being hit two-to-N times for the same payload on every interaction.
+//
+// This module is intentionally small (no React Query / SWR dep) so it can
+// land independently of the broader UI virtualization work. The contract:
+//
+// - GET responses are memoized by URL for `ttlMs` (default 5s) so a quick
+//   re-render of the same view returns the cached value instead of a new
+//   fetch.
+// - Concurrent identical GETs (same URL, no cache hit yet) share a single
+//   in-flight Promise. The 2nd … Nth caller awaits the same response.
+// - Mutating helpers (POST/PUT/DELETE) invalidate cache entries by prefix
+//   so a write to /v1/scan/{id} flushes /v1/scan, /v1/scan/{id}, and any
+//   nested children without the call site needing to remember every key.
+// - The cache is a plain Map. It does NOT survive a page reload. That's
+//   intentional: server-side state is the source of truth, and the cache
+//   exists only to absorb intra-page render storms.
+//
+// Designed so a future swap to React Query is a one-file change: this
+// module's surface is `cachedGet`, `invalidate`, and `clearCache`. None
+// of the call sites import the Map directly.
+
+export interface CacheOptions {
+  /** TTL in milliseconds. 0 = no cache, only inflight dedup. Default: 5000. */
+  ttlMs?: number;
+  /** Force a fresh fetch (skips cache lookup) but still populates on success. */
+  noStore?: boolean;
+}
+
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+const CACHE = new Map<string, CacheEntry<unknown>>();
+const INFLIGHT = new Map<string, Promise<unknown>>();
+
+const DEFAULT_TTL_MS = 5_000;
+
+function _now(): number {
+  return Date.now();
+}
+
+export async function cachedGet<T>(key: string, fetcher: () => Promise<T>, options: CacheOptions = {}): Promise<T> {
+  const ttl = options.ttlMs ?? DEFAULT_TTL_MS;
+
+  if (!options.noStore) {
+    const cached = CACHE.get(key) as CacheEntry<T> | undefined;
+    if (cached && cached.expiresAt > _now()) {
+      return cached.value;
+    }
+  }
+
+  const inflight = INFLIGHT.get(key) as Promise<T> | undefined;
+  if (inflight) return inflight;
+
+  const promise: Promise<T> = (async () => {
+    try {
+      const value = await fetcher();
+      if (ttl > 0) {
+        CACHE.set(key, { value, expiresAt: _now() + ttl });
+      }
+      return value;
+    } finally {
+      INFLIGHT.delete(key);
+    }
+  })();
+
+  INFLIGHT.set(key, promise);
+  return promise;
+}
+
+/** Drop every cached entry whose key starts with `prefix`. */
+export function invalidate(prefix: string): number {
+  let dropped = 0;
+  for (const key of CACHE.keys()) {
+    if (key.startsWith(prefix)) {
+      CACHE.delete(key);
+      dropped++;
+    }
+  }
+  return dropped;
+}
+
+/** Drop every cached entry. Test/teardown helper. */
+export function clearCache(): void {
+  CACHE.clear();
+  INFLIGHT.clear();
+}
+
+/** Inspect cache size (test helper; not exported via package public surface). */
+export function _cacheSizeForTests(): { entries: number; inflight: number } {
+  return { entries: CACHE.size, inflight: INFLIGHT.size };
+}

--- a/ui/lib/api-errors.ts
+++ b/ui/lib/api-errors.ts
@@ -1,0 +1,179 @@
+// Typed API error taxonomy for the dashboard.
+//
+// Closes the "typed error taxonomy" half of #1956. Before this module the
+// fetch helpers in `api.ts` threw raw `Error(string)` instances, so every
+// call site that wanted to branch on auth vs validation vs server failure
+// had to substring-match the message — fragile, and meaningless once a
+// backend message changed.
+//
+// Now every helper throws an `ApiError` subclass. Callers can branch on
+// the class (instanceof ApiAuthError) or the `status` field directly,
+// and `requestId`/`traceId` flow through so support tickets are
+// traceable end to end.
+//
+// ── Branching pattern ───────────────────────────────────────────────────
+//   try {
+//     await api.scanList();
+//   } catch (err) {
+//     if (err instanceof ApiAuthError) router.push("/login");
+//     else if (err instanceof ApiRateLimitError) toast(`Try again in ${err.retryAfterSeconds}s`);
+//     else if (err instanceof ApiValidationError) showFieldErrors(err.details);
+//     else if (err instanceof ApiNetworkError) toast("Network unreachable");
+//     else throw err; // genuine bug — bubble to the error boundary
+//   }
+
+export interface ApiErrorContext {
+  status: number;
+  statusText: string;
+  url: string;
+  method: string;
+  body?: unknown;
+  details?: Record<string, unknown>;
+  requestId?: string;
+  traceId?: string;
+}
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly statusText: string;
+  readonly url: string;
+  readonly method: string;
+  readonly body?: unknown;
+  readonly details?: Record<string, unknown>;
+  readonly requestId?: string;
+  readonly traceId?: string;
+
+  constructor(message: string, ctx: ApiErrorContext) {
+    super(message);
+    this.name = "ApiError";
+    this.status = ctx.status;
+    this.statusText = ctx.statusText;
+    this.url = ctx.url;
+    this.method = ctx.method;
+    this.body = ctx.body;
+    this.details = ctx.details;
+    this.requestId = ctx.requestId;
+    this.traceId = ctx.traceId;
+  }
+}
+
+export class ApiValidationError extends ApiError {
+  constructor(message: string, ctx: ApiErrorContext) {
+    super(message, ctx);
+    this.name = "ApiValidationError";
+  }
+}
+
+export class ApiAuthError extends ApiError {
+  constructor(message: string, ctx: ApiErrorContext) {
+    super(message, ctx);
+    this.name = "ApiAuthError";
+  }
+}
+
+export class ApiForbiddenError extends ApiError {
+  constructor(message: string, ctx: ApiErrorContext) {
+    super(message, ctx);
+    this.name = "ApiForbiddenError";
+  }
+}
+
+export class ApiNotFoundError extends ApiError {
+  constructor(message: string, ctx: ApiErrorContext) {
+    super(message, ctx);
+    this.name = "ApiNotFoundError";
+  }
+}
+
+export class ApiConflictError extends ApiError {
+  constructor(message: string, ctx: ApiErrorContext) {
+    super(message, ctx);
+    this.name = "ApiConflictError";
+  }
+}
+
+export class ApiRateLimitError extends ApiError {
+  readonly retryAfterSeconds?: number;
+
+  constructor(message: string, ctx: ApiErrorContext, retryAfterSeconds?: number) {
+    super(message, ctx);
+    this.name = "ApiRateLimitError";
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+
+export class ApiServerError extends ApiError {
+  constructor(message: string, ctx: ApiErrorContext) {
+    super(message, ctx);
+    this.name = "ApiServerError";
+  }
+}
+
+export class ApiNetworkError extends ApiError {
+  constructor(message: string, ctx: Omit<ApiErrorContext, "status" | "statusText"> & { cause?: unknown }) {
+    super(message, { ...ctx, status: 0, statusText: "network_error" });
+    this.name = "ApiNetworkError";
+    if (ctx.cause !== undefined) {
+      // Preserve the underlying fetch failure (TypeError, AbortError, etc.)
+      // so debugging and Sentry-style reporting can keep the original stack.
+      (this as { cause?: unknown }).cause = ctx.cause;
+    }
+  }
+}
+
+export function classifyApiResponse(
+  res: Response,
+  parsedBody: unknown,
+  method: string,
+): ApiError {
+  // Guard against test mocks and partial Response shims that omit headers.
+  const requestId = res.headers?.get?.("x-request-id") ?? undefined;
+  const traceId = res.headers?.get?.("x-trace-id") ?? undefined;
+  const ctx: ApiErrorContext = {
+    status: res.status,
+    statusText: res.statusText,
+    url: res.url,
+    method,
+    body: parsedBody,
+    requestId,
+    traceId,
+  };
+
+  // Backend convention is `{detail|message|error: string|object, ...}`. Pull
+  // the operator-readable message and any structured details up to the top
+  // level so callers don't have to re-walk the shape.
+  let message = `${res.status} ${res.statusText}`;
+  let details: Record<string, unknown> | undefined;
+  if (parsedBody && typeof parsedBody === "object") {
+    const record = parsedBody as Record<string, unknown>;
+    const candidate = record.detail ?? record.message ?? record.error;
+    if (typeof candidate === "string" && candidate.trim()) {
+      message = candidate;
+    } else if (candidate && typeof candidate === "object" && !Array.isArray(candidate)) {
+      const nested = candidate as Record<string, unknown>;
+      if (typeof nested.message === "string") message = nested.message;
+      details = nested;
+    }
+    if (!details && record.details && typeof record.details === "object") {
+      details = record.details as Record<string, unknown>;
+    }
+  }
+  ctx.details = details;
+
+  if (res.status === 400 || res.status === 422) return new ApiValidationError(message, ctx);
+  if (res.status === 401) return new ApiAuthError(message, ctx);
+  if (res.status === 403) return new ApiForbiddenError(message, ctx);
+  if (res.status === 404) return new ApiNotFoundError(message, ctx);
+  if (res.status === 409) return new ApiConflictError(message, ctx);
+  if (res.status === 429) {
+    const headerValue = res.headers?.get?.("retry-after") ?? null;
+    const retryAfter = headerValue ? Number(headerValue) : undefined;
+    return new ApiRateLimitError(
+      message,
+      ctx,
+      Number.isFinite(retryAfter) ? (retryAfter as number) : undefined,
+    );
+  }
+  if (res.status >= 500) return new ApiServerError(message, ctx);
+  return new ApiError(message, ctx);
+}

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -1261,6 +1261,15 @@ export interface EnrichmentPostureResponse {
 }
 
 // ─── Fetch helpers ────────────────────────────────────────────────────────────
+//
+// Closes #1956. All five wrappers below funnel through ApiError-typed throws
+// (lib/api-errors.ts) and the GET wrapper is memoized + dedup'd via
+// lib/api-cache.ts. Mutations (post/postVoid/put/del) invalidate cache
+// prefixes so a write to /v1/scan/{id} flushes /v1/scan and any nested
+// children without each call site having to remember.
+
+import { ApiNetworkError, classifyApiResponse } from "./api-errors";
+import { cachedGet, invalidate as _invalidate, type CacheOptions } from "./api-cache";
 
 const FETCH_TIMEOUT_MS = 30_000;
 
@@ -1268,83 +1277,136 @@ function withTimeout(): AbortSignal {
   return AbortSignal.timeout(FETCH_TIMEOUT_MS);
 }
 
-async function errorMessage(res: Response): Promise<string> {
+async function _parseBody(res: Response): Promise<unknown> {
+  // Only called on the error path; caller never reads the body again, so we
+  // can consume the stream directly. Avoid `.clone()` because test mocks
+  // and partial Response shims may not implement it.
   try {
-    const data = (await res.json()) as { detail?: unknown; message?: unknown; error?: unknown };
-    const detail = data.detail ?? data.message ?? data.error;
-    if (typeof detail === "string" && detail.trim()) {
-      return detail;
-    }
+    return await res.json();
   } catch {
-    // Fall back to status text when the body is empty or not JSON.
+    try {
+      return await res.text();
+    } catch {
+      return undefined;
+    }
   }
-  return `${res.status} ${res.statusText}`;
 }
 
-async function get<T>(path: string): Promise<T> {
-  const res = await fetch(`${getConfiguredApiUrl()}${path}`, {
-    credentials: "include",
-    headers: getSessionAuthHeaders(),
-    signal: withTimeout(),
-  });
-  if (!res.ok) throw new Error(await errorMessage(res));
-  return res.json() as Promise<T>;
+async function _doFetch(path: string, init: RequestInit, method: string): Promise<Response> {
+  const url = `${getConfiguredApiUrl()}${path}`;
+  let res: Response;
+  try {
+    res = await fetch(url, init);
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    throw new ApiNetworkError(`Network request failed: ${message}`, { url, method, cause });
+  }
+  if (!res.ok) {
+    const body = await _parseBody(res);
+    throw classifyApiResponse(res, body, method);
+  }
+  return res;
+}
+
+/** Cache-prefix invalidation rules for write paths. */
+function _invalidationsFor(path: string): string[] {
+  // Any write to /v1/<resource>[/<id>][/...] flushes /v1/<resource> entirely.
+  // Coarse on purpose: getting a stale /v1/scan list right after the user
+  // submits a scan is the failure mode this is here to prevent.
+  const match = /^\/v1\/[^/?]+/.exec(path);
+  return match ? [match[0]] : [];
+}
+
+function _runInvalidations(path: string): void {
+  for (const prefix of _invalidationsFor(path)) {
+    _invalidate(prefix);
+  }
+}
+
+async function get<T>(path: string, cacheOptions: CacheOptions = {}): Promise<T> {
+  const key = `GET ${path}`;
+  return cachedGet<T>(
+    key,
+    async () => {
+      const res = await _doFetch(path, {
+        credentials: "include",
+        headers: getSessionAuthHeaders(),
+        signal: withTimeout(),
+      }, "GET");
+      return res.json() as Promise<T>;
+    },
+    cacheOptions,
+  );
 }
 
 async function post<T>(path: string, body: unknown, headers: Record<string, string> = {}): Promise<T> {
-  const res = await fetch(`${getConfiguredApiUrl()}${path}`, {
+  const res = await _doFetch(path, {
     method: "POST",
     credentials: "include",
     headers: { "Content-Type": "application/json", ...getSessionAuthHeaders(), ...headers },
     body: JSON.stringify(body),
     signal: withTimeout(),
-  });
-  if (!res.ok) throw new Error(await errorMessage(res));
+  }, "POST");
+  _runInvalidations(path);
   return res.json() as Promise<T>;
 }
 
 async function postVoid(path: string, body: unknown, headers: Record<string, string> = {}): Promise<void> {
-  const res = await fetch(`${getConfiguredApiUrl()}${path}`, {
+  await _doFetch(path, {
     method: "POST",
     credentials: "include",
     headers: { "Content-Type": "application/json", ...getSessionAuthHeaders(), ...headers },
     body: JSON.stringify(body),
     signal: withTimeout(),
-  });
-  if (!res.ok) throw new Error(await errorMessage(res));
+  }, "POST");
+  _runInvalidations(path);
 }
 
 async function put<T>(path: string, body: unknown): Promise<T> {
-  const res = await fetch(`${getConfiguredApiUrl()}${path}`, {
+  const res = await _doFetch(path, {
     method: "PUT",
     credentials: "include",
     headers: { "Content-Type": "application/json", ...getSessionAuthHeaders() },
     body: JSON.stringify(body),
     signal: withTimeout(),
-  });
-  if (!res.ok) throw new Error(await errorMessage(res));
+  }, "PUT");
+  _runInvalidations(path);
   return res.json() as Promise<T>;
 }
 
 async function del(path: string): Promise<void> {
-  const res = await fetch(`${getConfiguredApiUrl()}${path}`, {
+  await _doFetch(path, {
     method: "DELETE",
     credentials: "include",
     headers: getSessionAuthHeaders(),
     signal: withTimeout(),
-  });
-  if (!res.ok) throw new Error(await errorMessage(res));
+  }, "DELETE");
+  _runInvalidations(path);
 }
 
 async function getBlob(path: string): Promise<Blob> {
-  const res = await fetch(`${getConfiguredApiUrl()}${path}`, {
+  const res = await _doFetch(path, {
     credentials: "include",
     headers: getSessionAuthHeaders(),
     signal: withTimeout(),
-  });
-  if (!res.ok) throw new Error(await errorMessage(res));
+  }, "GET");
   return res.blob();
 }
+
+// Re-export the typed errors so call sites can `import { ApiAuthError } from "@/lib/api"`
+// without learning a new module path.
+export {
+  ApiError,
+  ApiAuthError,
+  ApiForbiddenError,
+  ApiNotFoundError,
+  ApiConflictError,
+  ApiRateLimitError,
+  ApiServerError,
+  ApiValidationError,
+  ApiNetworkError,
+} from "./api-errors";
+export { invalidate as invalidateApiCache, clearCache as _clearApiCacheForTests } from "./api-cache";
 
 // ─── API functions ────────────────────────────────────────────────────────────
 

--- a/ui/tests/api-cache.test.ts
+++ b/ui/tests/api-cache.test.ts
@@ -1,0 +1,100 @@
+// Pin the cache + dedup contract for #1956. Each behaviour the dashboard
+// relies on lives here so a future refactor can't quietly drop one.
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { _cacheSizeForTests, cachedGet, clearCache, invalidate } from "../lib/api-cache";
+
+afterEach(() => {
+  clearCache();
+});
+
+describe("cachedGet", () => {
+  it("returns the cached value within ttl without re-invoking the fetcher", async () => {
+    let calls = 0;
+    const fetcher = async () => {
+      calls++;
+      return { value: calls };
+    };
+    const a = await cachedGet("k", fetcher, { ttlMs: 10_000 });
+    const b = await cachedGet("k", fetcher, { ttlMs: 10_000 });
+    expect(a).toEqual({ value: 1 });
+    expect(b).toEqual({ value: 1 });
+    expect(calls).toBe(1);
+  });
+
+  it("re-fetches once the ttl expires", async () => {
+    let calls = 0;
+    const fetcher = async () => ++calls;
+    await cachedGet("k", fetcher, { ttlMs: 5 });
+    await new Promise((r) => setTimeout(r, 25));
+    await cachedGet("k", fetcher, { ttlMs: 5 });
+    expect(calls).toBe(2);
+  });
+
+  it("dedupes concurrent in-flight calls to the same key", async () => {
+    let calls = 0;
+    const fetcher = async () => {
+      calls++;
+      await new Promise((r) => setTimeout(r, 20));
+      return calls;
+    };
+    const [a, b, c] = await Promise.all([
+      cachedGet("k", fetcher),
+      cachedGet("k", fetcher),
+      cachedGet("k", fetcher),
+    ]);
+    expect(a).toBe(1);
+    expect(b).toBe(1);
+    expect(c).toBe(1);
+    expect(calls).toBe(1);
+  });
+
+  it("noStore skips cache lookup but still populates", async () => {
+    let calls = 0;
+    const fetcher = async () => ++calls;
+    await cachedGet("k", fetcher, { ttlMs: 10_000 });
+    await cachedGet("k", fetcher, { ttlMs: 10_000, noStore: true });
+    await cachedGet("k", fetcher, { ttlMs: 10_000 });
+    // 1st call populates, 2nd ignores cache and re-fetches, 3rd reads what
+    // the 2nd just wrote → 2 fetcher invocations total.
+    expect(calls).toBe(2);
+  });
+
+  it("ttlMs=0 disables the cache layer (only inflight dedup remains)", async () => {
+    let calls = 0;
+    const fetcher = async () => ++calls;
+    await cachedGet("k", fetcher, { ttlMs: 0 });
+    await cachedGet("k", fetcher, { ttlMs: 0 });
+    expect(calls).toBe(2);
+    expect(_cacheSizeForTests().entries).toBe(0);
+  });
+
+  it("rejects in-flight callers with the same error when the fetcher throws", async () => {
+    let attempts = 0;
+    const fetcher = async () => {
+      attempts++;
+      await new Promise((r) => setTimeout(r, 5));
+      throw new Error("upstream down");
+    };
+    const a = cachedGet("k", fetcher);
+    const b = cachedGet("k", fetcher);
+    await expect(a).rejects.toThrow("upstream down");
+    await expect(b).rejects.toThrow("upstream down");
+    expect(attempts).toBe(1);
+  });
+});
+
+describe("invalidate", () => {
+  it("drops every entry whose key starts with the prefix", async () => {
+    await cachedGet("GET /v1/scan", async () => "list", { ttlMs: 10_000 });
+    await cachedGet("GET /v1/scan/abc", async () => "single", { ttlMs: 10_000 });
+    await cachedGet("GET /v1/agents", async () => "agents", { ttlMs: 10_000 });
+    expect(invalidate("GET /v1/scan")).toBe(2);
+    expect(_cacheSizeForTests().entries).toBe(1);
+  });
+
+  it("returns 0 when no entries match", () => {
+    expect(invalidate("GET /v1/nothing-here")).toBe(0);
+  });
+});

--- a/ui/tests/api-errors.test.ts
+++ b/ui/tests/api-errors.test.ts
@@ -1,0 +1,91 @@
+// Pin the typed-error contract for #1956. Call sites branch on these
+// classes (instanceof) AND on the `status` field; both surfaces must stay
+// stable, and the Response → error classification must be deterministic.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ApiAuthError,
+  ApiConflictError,
+  ApiError,
+  ApiForbiddenError,
+  ApiNotFoundError,
+  ApiNetworkError,
+  ApiRateLimitError,
+  ApiServerError,
+  ApiValidationError,
+  classifyApiResponse,
+} from "../lib/api-errors";
+
+function _resp(status: number, body: unknown, extraHeaders: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 429 ? "Too Many Requests" : "Status",
+    headers: {
+      "content-type": "application/json",
+      "x-request-id": "req-test",
+      "x-trace-id": "trace-test",
+      ...extraHeaders,
+    },
+  });
+}
+
+describe("classifyApiResponse", () => {
+  it("400/422 → ApiValidationError with details preserved", () => {
+    const err = classifyApiResponse(_resp(422, { detail: "bad", details: { field: "name" } }), { detail: "bad", details: { field: "name" } }, "POST");
+    expect(err).toBeInstanceOf(ApiValidationError);
+    expect(err.status).toBe(422);
+    expect(err.message).toBe("bad");
+    expect(err.details).toEqual({ field: "name" });
+    expect(err.requestId).toBe("req-test");
+    expect(err.traceId).toBe("trace-test");
+    expect(err.method).toBe("POST");
+  });
+
+  it("401 → ApiAuthError, 403 → ApiForbiddenError", () => {
+    expect(classifyApiResponse(_resp(401, {}), {}, "GET")).toBeInstanceOf(ApiAuthError);
+    expect(classifyApiResponse(_resp(403, {}), {}, "GET")).toBeInstanceOf(ApiForbiddenError);
+  });
+
+  it("404 → ApiNotFoundError, 409 → ApiConflictError", () => {
+    expect(classifyApiResponse(_resp(404, { detail: "missing" }), { detail: "missing" }, "GET")).toBeInstanceOf(ApiNotFoundError);
+    expect(classifyApiResponse(_resp(409, { detail: "conflict" }), { detail: "conflict" }, "POST")).toBeInstanceOf(ApiConflictError);
+  });
+
+  it("429 → ApiRateLimitError with retry-after seconds parsed", () => {
+    const err = classifyApiResponse(_resp(429, { detail: "rate" }, { "retry-after": "12" }), { detail: "rate" }, "POST") as ApiRateLimitError;
+    expect(err).toBeInstanceOf(ApiRateLimitError);
+    expect(err.retryAfterSeconds).toBe(12);
+  });
+
+  it("429 with no retry-after header → retryAfterSeconds undefined", () => {
+    const err = classifyApiResponse(_resp(429, {}), {}, "POST") as ApiRateLimitError;
+    expect(err).toBeInstanceOf(ApiRateLimitError);
+    expect(err.retryAfterSeconds).toBeUndefined();
+  });
+
+  it("5xx → ApiServerError", () => {
+    expect(classifyApiResponse(_resp(500, {}), {}, "GET")).toBeInstanceOf(ApiServerError);
+    expect(classifyApiResponse(_resp(503, {}), {}, "GET")).toBeInstanceOf(ApiServerError);
+  });
+
+  it("falls back to ApiError for codes outside the named set", () => {
+    const err = classifyApiResponse(_resp(418, { detail: "teapot" }), { detail: "teapot" }, "GET");
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err).not.toBeInstanceOf(ApiValidationError);
+    expect(err).not.toBeInstanceOf(ApiServerError);
+  });
+
+  it("falls back to '<status> <statusText>' when body has no detail/message/error", () => {
+    const err = classifyApiResponse(_resp(500, {}), {}, "GET");
+    expect(err.message).toMatch(/^500 /);
+  });
+
+  it("ApiNetworkError carries cause and synthesises status=0", () => {
+    const cause = new TypeError("fetch failed");
+    const err = new ApiNetworkError("offline", { url: "/v1/scan", method: "GET", cause });
+    expect(err.status).toBe(0);
+    expect(err.statusText).toBe("network_error");
+    expect((err as { cause?: unknown }).cause).toBe(cause);
+  });
+});

--- a/ui/tests/setup.ts
+++ b/ui/tests/setup.ts
@@ -1,6 +1,11 @@
-import '@testing-library/jest-dom'
-import { afterEach } from 'vitest'
+import "@testing-library/jest-dom";
+import { afterEach } from "vitest";
+
+import { clearCache } from "../lib/api-cache";
 
 afterEach(() => {
-  delete window.__AGENT_BOM_CONFIG__
-})
+  delete window.__AGENT_BOM_CONFIG__;
+  // Clear the in-memory API cache between tests so a previous test's
+  // cached GET response cannot satisfy a subsequent test's mocked fetch.
+  clearCache();
+});


### PR DESCRIPTION
## Summary

Closes #1956.

Two new modules sit behind the existing fetch helpers in \`ui/lib/api.ts\` so all 100+ API methods inherit the upgrade without per-call-site edits.

### \`ui/lib/api-errors.ts\` — typed error class hierarchy

- \`ApiError\` (base) + \`ApiValidationError\` (400/422), \`ApiAuthError\` (401), \`ApiForbiddenError\` (403), \`ApiNotFoundError\` (404), \`ApiConflictError\` (409), \`ApiRateLimitError\` (429, parses \`Retry-After\`), \`ApiServerError\` (5xx), \`ApiNetworkError\` (no response, preserves \`cause\`).
- Every error preserves \`status\`, \`statusText\`, \`url\`, \`method\`, parsed body, structured \`details\`, and the upstream \`X-Request-ID\` / \`X-Trace-Id\` headers so support tickets are traceable end to end.
- Call sites can now branch on the class (\`instanceof ApiAuthError\`), the \`status\` field, or both. Substring-matching the message is no longer the only option.

### \`ui/lib/api-cache.ts\` — in-memory TTL cache + inflight dedup

- React 19 strict-effects double-fire \`useEffect\`, and most pages re-mount their data fetchers on every navigation, so the API was being hit multiple times for the same payload on every interaction.
- \`cachedGet(key, fetcher, {ttlMs?, noStore?})\` memoizes by URL with a default 5s TTL and dedupes concurrent in-flight calls so the 2nd…Nth caller awaits the same Promise.
- \`invalidate(prefix)\` flushes by URL prefix; mutations (post/put/del) call it automatically with \`/v1/<resource>\` derived from the path. Coarse on purpose: getting a stale \`/v1/scan\` list right after the user submits one is the failure mode this prevents.
- Plain Map storage. Survives intra-page renders, NOT page reloads — server is the source of truth.
- Surface (\`cachedGet\`, \`invalidate\`, \`clearCache\`) is shaped so a future swap to React Query is a one-file change.

### \`ui/lib/api.ts\` wiring

- \`_doFetch\` funnels every helper through \`classifyApiResponse\` on non-ok responses and \`ApiNetworkError\` on fetch rejection.
- \`get()\` goes through \`cachedGet\`; \`post/postVoid/put/del\` invalidate cache prefixes after a successful write.
- Re-exports the \`ApiError*\` classes and \`invalidateApiCache\` from the api module so call sites don't learn a new module path.

## Tests

- \`ui/tests/api-errors.test.ts\` pins the classification table (status → class), retry-after parsing, fallback message, ApiNetworkError cause preservation.
- \`ui/tests/api-cache.test.ts\` pins TTL behaviour, expiry, in-flight dedup, \`noStore\` semantics, \`ttl=0\` disabling cache while keeping dedup, rejection propagation, and prefix invalidation.
- \`ui/tests/setup.ts\` clears the cache in \`afterEach\` so prior cached GETs cannot satisfy subsequent test mocks.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run test:run\` — 19 files / 144 tests pass (was 17/127)
- [x] \`npm run build\` — full static export succeeds

## What's NOT in this PR (deliberate scope)

- Migration to React Query / SWR — out of scope; the surface here is shaped so the swap is a one-file change later.
- Per-call-site refactor of the 100+ \`api.*\` methods to expose richer typing — they all inherit the new error taxonomy already; tightening individual return types is its own follow-up.