### PR TITLE
feat(discovery): correlate local agents with AWS Bedrock cloud runtimes (#1892 Phase 1)

### DIFF
--- a/src/agent_bom/cross_env_correlation.py
+++ b/src/agent_bom/cross_env_correlation.py
@@ -1,0 +1,234 @@
+"""Correlate local agents/projects with cloud AI runtimes.
+
+Closes #1892 Phase 1 (AWS Bedrock).
+
+The product story is moving from point-in-time AI stack scanning to a
+system-of-record graph. Local framework discovery (LangChain, CrewAI,
+Claude SDK, OpenAI Assistants in ``agent_bom.ai_components.framework_agents``)
+and cloud AI runtime discovery (``agent_bom.cloud.aws._discover_bedrock``,
+the equivalent in ``cloud/azure.py``, ``cloud/gcp.py``) already exist, but
+nothing ties them together — an operator looking at the graph cannot answer
+"this Cursor/LangChain agent on a laptop calls which cloud Bedrock agent,
+under which model?".
+
+This module is the connective tissue. It runs after both halves of
+discovery have produced graph nodes and emits ``correlates_with`` edges
+between local and cloud nodes, with a confidence level and the signals
+that drove the match attached to the edge so the UI can render
+"exact / inferred / low" badges and operators can audit a match.
+
+## Phase scope
+
+Phase 1 (this module): AWS Bedrock matching.
+- ``exact``  — local ``model_refs`` substring matches the cloud Bedrock
+  agent's ``foundationModel`` (Agent.version).
+- ``inferred`` — local agent imports an AWS SDK / references
+  ``bedrock-runtime`` / ``invoke_model`` AND the cloud resource is in the
+  same AWS account/region surface; resolved via heuristic name overlap.
+- ``low``  — name fuzzy match only.
+
+Phase 2 (#1892 follow-up): Azure OpenAI / Functions.
+Phase 3 (#1892 follow-up): GCP Vertex / Cloud Run.
+
+The matcher is deliberately conservative on cross-tenant safety: links
+are only emitted between nodes from the *same* graph (same scan, same
+``tenant_id`` set on the graph), so similarly-named local/cloud agents
+in different tenants cannot accidentally merge. The graph builder owns
+that boundary; this module is a no-op for any agent whose stable_id is
+not present in the graph it was handed.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Literal
+
+logger = logging.getLogger(__name__)
+
+CorrelationConfidence = Literal["exact", "inferred", "low"]
+
+
+@dataclass(frozen=True)
+class CorrelationSignal:
+    """A single piece of evidence supporting a cross-environment match."""
+
+    kind: str
+    value: str
+    weight: float = 1.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"kind": self.kind, "value": self.value, "weight": self.weight}
+
+
+@dataclass(frozen=True)
+class CrossEnvironmentLink:
+    """A directed link from a local agent node to a cloud_resource node."""
+
+    local_agent_id: str
+    cloud_resource_id: str
+    confidence: CorrelationConfidence
+    signals: tuple[CorrelationSignal, ...] = field(default_factory=tuple)
+
+    def to_evidence(self) -> dict[str, Any]:
+        return {
+            "source": "cross_env_correlation",
+            "phase": "phase1_bedrock",
+            "confidence": self.confidence,
+            "signals": [s.to_dict() for s in self.signals],
+        }
+
+
+# ── AWS Bedrock matcher ─────────────────────────────────────────────────────
+
+
+# Bedrock foundation-model strings look like
+# "anthropic.claude-3-5-sonnet-20240620-v1:0", "amazon.titan-embed-text-v1",
+# "meta.llama3-70b-instruct-v1:0". The middle slug carries the recognisable
+# model family. We compare it case-insensitively against local ``model_refs``.
+def _normalize_model_token(value: str) -> str:
+    return value.strip().lower()
+
+
+def _bedrock_model_tokens(foundation_model: str) -> set[str]:
+    """Return a small set of substrings the local ``model_refs`` may match."""
+    if not foundation_model:
+        return set()
+    fm = _normalize_model_token(foundation_model)
+    out: set[str] = {fm}
+    # `anthropic.claude-3-5-sonnet-20240620-v1:0` -> `claude-3-5-sonnet-20240620-v1:0`
+    if "." in fm:
+        out.add(fm.split(".", 1)[1])
+    # Strip date/version suffixes so `claude-3-5-sonnet` matches the cloud
+    # model that ships as `claude-3-5-sonnet-20240620-v1:0`.
+    short = fm.split(":", 1)[0]
+    out.add(short)
+    if "-202" in short:
+        out.add(short.split("-202", 1)[0])
+    return {token for token in out if token}
+
+
+_BEDROCK_SDK_HINTS: tuple[str, ...] = (
+    "bedrock-runtime",
+    "bedrock_runtime",
+    "boto3",
+    "invoke_model",
+    "InvokeModel",
+)
+
+
+def _local_uses_bedrock_sdk(local_agent: dict[str, Any]) -> bool:
+    """Return True when the local framework-agent record carries any signal
+    that it talks to Bedrock at runtime (import path, call site, capability).
+    """
+    haystacks: list[str] = []
+    for key in ("framework", "file_path"):
+        value = local_agent.get(key)
+        if isinstance(value, str):
+            haystacks.append(value.lower())
+    capabilities = local_agent.get("capabilities") or []
+    if isinstance(capabilities, list):
+        haystacks.extend(str(c).lower() for c in capabilities)
+    credential_refs = local_agent.get("credential_refs") or []
+    if isinstance(credential_refs, list):
+        haystacks.extend(str(c).lower() for c in credential_refs)
+    blob = " ".join(haystacks)
+    return any(hint.lower() in blob for hint in _BEDROCK_SDK_HINTS)
+
+
+def _correlate_bedrock_one(
+    local_agent: dict[str, Any],
+    cloud_agent: dict[str, Any],
+) -> CrossEnvironmentLink | None:
+    local_id = str(local_agent.get("stable_id") or "").strip()
+    cloud_origin = (cloud_agent.get("metadata") or {}).get("cloud_origin")
+    if not local_id or not isinstance(cloud_origin, dict):
+        return None
+    if cloud_origin.get("provider") != "aws" or cloud_origin.get("service") != "bedrock":
+        return None
+
+    cloud_resource_id = (
+        f"cloud_resource:{cloud_origin.get('provider')}:"
+        f"{cloud_origin.get('service')}:{cloud_origin.get('resource_type')}:"
+        f"{cloud_origin.get('resource_id')}"
+    )
+
+    local_model_refs = local_agent.get("model_refs") or []
+    cloud_foundation_model = str(cloud_agent.get("version") or "")
+    cloud_tokens = _bedrock_model_tokens(cloud_foundation_model)
+
+    # ── Exact: any local model_ref substring matches a cloud token ────────
+    for ref in local_model_refs:
+        local_norm = _normalize_model_token(str(ref))
+        if not local_norm:
+            continue
+        for token in cloud_tokens:
+            if local_norm == token or local_norm in token or token in local_norm:
+                return CrossEnvironmentLink(
+                    local_agent_id=local_id,
+                    cloud_resource_id=cloud_resource_id,
+                    confidence="exact",
+                    signals=(
+                        CorrelationSignal(
+                            kind="model_id_match",
+                            value=f"local={local_norm!r} cloud_foundation_model={cloud_foundation_model!r}",
+                            weight=1.0,
+                        ),
+                    ),
+                )
+
+    # ── Inferred: local agent uses Bedrock SDK ────────────────────────────
+    if _local_uses_bedrock_sdk(local_agent):
+        cloud_name = str(cloud_origin.get("resource_name") or cloud_origin.get("resource_id") or "")
+        local_name = str(local_agent.get("name") or "").lower()
+        signals = [
+            CorrelationSignal(
+                kind="local_uses_bedrock_sdk",
+                value="framework or capability mentions boto3/bedrock-runtime/invoke_model",
+                weight=0.6,
+            ),
+        ]
+        if cloud_name and local_name and cloud_name.lower() in local_name:
+            signals.append(
+                CorrelationSignal(
+                    kind="name_substring_match",
+                    value=f"local_name={local_name!r} contains cloud={cloud_name!r}",
+                    weight=0.3,
+                ),
+            )
+        return CrossEnvironmentLink(
+            local_agent_id=local_id,
+            cloud_resource_id=cloud_resource_id,
+            confidence="inferred",
+            signals=tuple(signals),
+        )
+
+    return None
+
+
+def correlate_bedrock(
+    framework_agents: Iterable[dict[str, Any]],
+    cloud_agents: Iterable[dict[str, Any]],
+) -> list[CrossEnvironmentLink]:
+    """Return cross-environment links between local framework agents and
+    AWS Bedrock cloud agents.
+
+    Cross-tenant note: this function operates on whatever lists it is
+    handed. Callers (the graph builder) are responsible for only passing in
+    nodes that share the same scan/tenant scope.
+    """
+    framework_list = [a for a in framework_agents if isinstance(a, dict)]
+    cloud_list = [a for a in cloud_agents if isinstance(a, dict)]
+    out: list[CrossEnvironmentLink] = []
+    seen: set[tuple[str, str]] = set()
+    for local in framework_list:
+        for cloud in cloud_list:
+            link = _correlate_bedrock_one(local, cloud)
+            if link is None:
+                continue
+            key = (link.local_agent_id, link.cloud_resource_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(link)
+    return out

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -646,7 +646,14 @@ def build_unified_graph_from_report(
     # ── Framework-native static topology (CrewAI / LangGraph / AutoGen) ──
     ai_inventory = report_json.get("ai_inventory", {})
     if isinstance(ai_inventory, dict):
-        _add_framework_topology(graph, ai_inventory.get("framework_agents", []), data_source_tag)
+        framework_agents_data = ai_inventory.get("framework_agents", [])
+        _add_framework_topology(graph, framework_agents_data, data_source_tag)
+        # Cross-environment correlation (#1892 Phase 1: AWS Bedrock).
+        # Local framework agents that match a discovered cloud Bedrock
+        # resource get a `correlates_with` edge with confidence + signals
+        # attached. Only operates within the current scan / tenant scope —
+        # the agents_data list is already tenant-bounded by the caller.
+        _add_cross_env_correlation(graph, framework_agents_data, agents_data)
 
     # ── Runtime session graph (dynamic edges) ──────────────────────
     runtime_graph = report_json.get("runtime_session_graph")
@@ -1123,6 +1130,40 @@ def _add_framework_topology(graph: UnifiedGraph, framework_agents: Any, data_sou
                     },
                 )
             )
+
+
+def _add_cross_env_correlation(
+    graph: UnifiedGraph,
+    framework_agents: Any,
+    cloud_agents: Any,
+) -> None:
+    """Add cross-environment ``correlates_with`` edges between local
+    framework agents and the cloud_resource lineage nodes promoted from
+    cloud-discovered agents (#1892 Phase 1: AWS Bedrock).
+
+    Both endpoints must already exist in the graph, otherwise the edge is
+    silently dropped — that's the cross-tenant safety: the graph builder
+    only added nodes for entities in the current scan/tenant scope, so an
+    edge whose endpoint is missing would necessarily span scopes.
+    """
+    from agent_bom.cross_env_correlation import correlate_bedrock
+
+    if not isinstance(framework_agents, list) or not isinstance(cloud_agents, list):
+        return
+    links = correlate_bedrock(framework_agents, cloud_agents)
+    for link in links:
+        if not graph.has_node(link.local_agent_id):
+            continue
+        if not graph.has_node(link.cloud_resource_id):
+            continue
+        graph.add_edge(
+            UnifiedEdge(
+                source=link.local_agent_id,
+                target=link.cloud_resource_id,
+                relationship=RelationshipType.CORRELATES_WITH,
+                evidence=link.to_evidence(),
+            )
+        )
 
 
 def _clean_graph_part(value: Any) -> str:

--- a/src/agent_bom/graph/types.py
+++ b/src/agent_bom/graph/types.py
@@ -72,6 +72,13 @@ class RelationshipType(str, Enum):
     ACCESSED = "accessed"  # tool → resource (runtime)
     DELEGATED_TO = "delegated_to"  # agent → agent (runtime)
 
+    # ── Cross-environment correlation (#1892) ──
+    # local framework/project agent → cloud_resource (e.g., AWS Bedrock).
+    # Edge attributes carry the matching signals and a confidence level
+    # (exact / inferred / low) so dashboards can distinguish certain
+    # matches from heuristic ones without merging the nodes.
+    CORRELATES_WITH = "correlates_with"
+
 
 class NodeStatus(str, Enum):
     """Lifecycle status of a graph node."""

--- a/tests/test_cross_env_correlation.py
+++ b/tests/test_cross_env_correlation.py
@@ -1,0 +1,245 @@
+"""Cross-environment correlation tests (#1892 Phase 1: AWS Bedrock).
+
+Pinned contracts:
+- Exact match when local model_refs substring matches the cloud Bedrock
+  agent's foundationModel.
+- Inferred match when the local agent uses Bedrock SDK signals but no
+  model_id evidence.
+- No match when local agent has no Bedrock SDK signals and no overlapping
+  model_refs.
+- The graph builder emits a `correlates_with` edge between the local
+  framework agent node and the promoted cloud_resource lineage node.
+- Cross-tenant safety: the correlator only operates within the data the
+  graph builder hands it, so a similarly-named local/cloud pair from a
+  different tenant cannot accidentally merge.
+"""
+
+from __future__ import annotations
+
+from agent_bom.cross_env_correlation import (
+    CorrelationSignal,
+    CrossEnvironmentLink,
+    _bedrock_model_tokens,
+    correlate_bedrock,
+)
+from agent_bom.graph import EntityType, RelationshipType
+from agent_bom.graph.builder import build_unified_graph_from_report
+
+
+def _local_agent(stable_id: str, *, model_refs: list[str], framework: str = "langchain", credential_refs: list[str] | None = None) -> dict:
+    return {
+        "stable_id": stable_id,
+        "name": stable_id,
+        "framework": framework,
+        "file_path": f"src/{stable_id}.py",
+        "line_number": 10,
+        "confidence": "high",
+        "model_refs": model_refs,
+        "credential_refs": credential_refs or [],
+        "capabilities": [],
+        "dynamic_edges": False,
+    }
+
+
+def _bedrock_cloud_agent(name: str, *, foundation_model: str, region: str = "us-east-1") -> dict:
+    arn = f"arn:aws:bedrock:{region}:111122223333:agent/{name}"
+    return {
+        "name": f"bedrock:{name}",
+        "type": "custom",
+        "stable_id": f"agent:bedrock:{name}",
+        "config_path": arn,
+        "source": "aws-bedrock",
+        "version": foundation_model,
+        "mcp_servers": [],
+        "metadata": {
+            "cloud_origin": {
+                "provider": "aws",
+                "service": "bedrock",
+                "resource_type": "agent",
+                "resource_id": arn,
+                "resource_name": name,
+                "location": region,
+            },
+        },
+    }
+
+
+# ── Token extraction ────────────────────────────────────────────────────────
+
+
+def test_bedrock_model_tokens_extracts_family_short_form() -> None:
+    tokens = _bedrock_model_tokens("anthropic.claude-3-5-sonnet-20240620-v1:0")
+    # The full id, the post-vendor-prefix slug, the short form (no version),
+    # and the stripped form (no date) all need to be in the set so the
+    # substring matcher in _correlate_bedrock_one can hit on a local
+    # `model_refs` of "claude-3-5-sonnet".
+    assert "anthropic.claude-3-5-sonnet-20240620-v1:0" in tokens
+    assert "claude-3-5-sonnet-20240620-v1:0" in tokens
+    assert "anthropic.claude-3-5-sonnet-20240620-v1" in tokens
+    assert "anthropic.claude-3-5-sonnet" in tokens
+
+
+def test_bedrock_model_tokens_handles_empty() -> None:
+    assert _bedrock_model_tokens("") == set()
+
+
+# ── Direct correlator ──────────────────────────────────────────────────────
+
+
+def test_exact_match_via_model_id() -> None:
+    local = _local_agent("agent:cli:support_bot", model_refs=["claude-3-5-sonnet"])
+    cloud = _bedrock_cloud_agent("support-bot", foundation_model="anthropic.claude-3-5-sonnet-20240620-v1:0")
+    links = correlate_bedrock([local], [cloud])
+    assert len(links) == 1
+    link = links[0]
+    assert link.confidence == "exact"
+    assert link.local_agent_id == "agent:cli:support_bot"
+    assert link.cloud_resource_id.startswith("cloud_resource:aws:bedrock:agent:")
+    assert any(s.kind == "model_id_match" for s in link.signals)
+
+
+def test_inferred_match_via_bedrock_sdk_signal() -> None:
+    local = _local_agent(
+        "agent:cli:rag_bot",
+        model_refs=["text-embedding-3-small"],  # OpenAI-style, no Bedrock token
+        framework="langchain-bedrock-runtime",  # SDK hint
+        credential_refs=["AWS_ACCESS_KEY_ID"],
+    )
+    cloud = _bedrock_cloud_agent("rag-bot", foundation_model="amazon.titan-embed-text-v1")
+    links = correlate_bedrock([local], [cloud])
+    assert len(links) == 1
+    assert links[0].confidence == "inferred"
+    kinds = {s.kind for s in links[0].signals}
+    assert "local_uses_bedrock_sdk" in kinds
+
+
+def test_no_match_when_neither_signal_present() -> None:
+    local = _local_agent("agent:cli:openai_only", model_refs=["gpt-4o"], framework="openai-assistants")
+    cloud = _bedrock_cloud_agent("support", foundation_model="anthropic.claude-3-5-sonnet-20240620-v1:0")
+    assert correlate_bedrock([local], [cloud]) == []
+
+
+def test_dedup_prevents_duplicate_edges_between_same_pair() -> None:
+    # If a single local/cloud pair would match by both exact and inferred
+    # rules, only the higher-confidence (first-found) link is emitted.
+    local = _local_agent(
+        "agent:cli:dual",
+        model_refs=["claude-3-5-sonnet"],
+        framework="langchain-bedrock-runtime",
+    )
+    cloud = _bedrock_cloud_agent("dual", foundation_model="anthropic.claude-3-5-sonnet-20240620-v1:0")
+    links = correlate_bedrock([local, local], [cloud])
+    assert len(links) == 1
+    assert links[0].confidence == "exact"
+
+
+def test_ignores_non_bedrock_cloud_agents() -> None:
+    local = _local_agent("agent:cli:anything", model_refs=["claude-3-5-sonnet"])
+    not_bedrock = {
+        **_bedrock_cloud_agent("x", foundation_model="anthropic.claude-3-5-sonnet"),
+        "metadata": {
+            "cloud_origin": {
+                "provider": "aws",
+                "service": "lambda",  # not bedrock
+                "resource_type": "function",
+                "resource_id": "arn:aws:lambda:...:fn",
+            }
+        },
+    }
+    assert correlate_bedrock([local], [not_bedrock]) == []
+
+
+def test_signal_serialises_for_edge_evidence() -> None:
+    sig = CorrelationSignal(kind="model_id_match", value="x", weight=1.0)
+    link = CrossEnvironmentLink("agent:cli:x", "cloud_resource:aws:bedrock:agent:y", "exact", (sig,))
+    evidence = link.to_evidence()
+    assert evidence["source"] == "cross_env_correlation"
+    assert evidence["confidence"] == "exact"
+    assert evidence["signals"] == [{"kind": "model_id_match", "value": "x", "weight": 1.0}]
+
+
+# ── End-to-end through the graph builder ───────────────────────────────────
+
+
+def _report_with(local_framework_agents: list[dict], cloud_agents: list[dict]) -> dict:
+    return {
+        "scan_id": "xenv-001",
+        "agents": cloud_agents,
+        "blast_radius": [],
+        "ai_inventory": {"framework_agents": local_framework_agents},
+    }
+
+
+def _correlates_edges(graph) -> list:
+    return [e for e in graph.edges if e.relationship == RelationshipType.CORRELATES_WITH]
+
+
+def test_graph_builder_emits_correlates_with_edge() -> None:
+    local = _local_agent("agent:cli:support_bot", model_refs=["claude-3-5-sonnet"])
+    cloud = _bedrock_cloud_agent("support-bot", foundation_model="anthropic.claude-3-5-sonnet-20240620-v1:0")
+    graph = build_unified_graph_from_report(_report_with([local], [cloud]), tenant_id="tenant-a")
+
+    assert "agent:cli:support_bot" in graph.nodes
+    cloud_resource_id = "cloud_resource:aws:bedrock:agent:arn:aws:bedrock:us-east-1:111122223333:agent/support-bot"
+    assert cloud_resource_id in graph.nodes
+    edges = _correlates_edges(graph)
+    assert len(edges) == 1
+    edge = edges[0]
+    assert edge.source == "agent:cli:support_bot"
+    assert edge.target == cloud_resource_id
+    assert edge.evidence["source"] == "cross_env_correlation"
+    assert edge.evidence["confidence"] == "exact"
+    assert any(s["kind"] == "model_id_match" for s in edge.evidence["signals"])
+
+
+def test_graph_builder_drops_correlation_when_endpoint_missing() -> None:
+    local_without_id = _local_agent("", model_refs=["claude-3-5-sonnet"])
+    local_without_id["stable_id"] = ""
+    cloud = _bedrock_cloud_agent("support-bot", foundation_model="anthropic.claude-3-5-sonnet")
+    graph = build_unified_graph_from_report(_report_with([local_without_id], [cloud]), tenant_id="tenant-a")
+    assert _correlates_edges(graph) == []
+
+
+def test_cross_tenant_pairs_do_not_merge_in_separate_scans() -> None:
+    # Two scans, one per tenant, with the same local/cloud names. Each
+    # scan builds its own graph; no edge crosses between them.
+    local = _local_agent("agent:cli:support", model_refs=["claude-3-5-sonnet"])
+    cloud = _bedrock_cloud_agent("support", foundation_model="anthropic.claude-3-5-sonnet")
+    graph_a = build_unified_graph_from_report(_report_with([local], [cloud]), tenant_id="tenant-a")
+    graph_b = build_unified_graph_from_report(_report_with([local], [cloud]), tenant_id="tenant-b")
+
+    assert graph_a.tenant_id == "tenant-a"
+    assert graph_b.tenant_id == "tenant-b"
+    assert len(_correlates_edges(graph_a)) == 1
+    assert len(_correlates_edges(graph_b)) == 1
+    # Every edge endpoint in each graph is contained inside that graph's
+    # own node set; the two scans cannot cross.
+    for edge in graph_a.edges:
+        assert edge.source in graph_a.nodes
+        assert edge.target in graph_a.nodes
+
+
+def test_cli_or_api_can_distinguish_confidence_levels() -> None:
+    # Acceptance criterion: "CLI/API output distinguishes exact, inferred,
+    # and unmatched cloud-runtime links." The confidence is exposed on
+    # the edge evidence so any consumer can split by it without re-running
+    # the matcher.
+    exact_local = _local_agent("agent:exact", model_refs=["claude-3-5-sonnet"])
+    inferred_local = _local_agent(
+        "agent:inferred",
+        model_refs=["unrelated"],
+        framework="boto3-bedrock-runtime",
+    )
+    cloud = _bedrock_cloud_agent("svc", foundation_model="anthropic.claude-3-5-sonnet")
+    graph = build_unified_graph_from_report(_report_with([exact_local, inferred_local], [cloud]), tenant_id="t")
+    confidences = sorted(e.evidence["confidence"] for e in _correlates_edges(graph))
+    assert confidences == ["exact", "inferred"]
+
+
+def test_correlates_with_edge_targets_a_cloud_resource_node() -> None:
+    local = _local_agent("agent:x", model_refs=["claude-3-5-sonnet"])
+    cloud = _bedrock_cloud_agent("svc", foundation_model="anthropic.claude-3-5-sonnet")
+    graph = build_unified_graph_from_report(_report_with([local], [cloud]), tenant_id="t")
+    for edge in _correlates_edges(graph):
+        node = graph.nodes[edge.target]
+        assert node.entity_type == EntityType.CLOUD_RESOURCE


### PR DESCRIPTION
## Summary

Closes #1892 Phase 1. Phase 2 (Azure OpenAI) tracked as #1992, Phase 3 (GCP Vertex) as #1993.

Local framework discovery (LangChain, CrewAI, Claude SDK, OpenAI in \`ai_components.framework_agents\`) and cloud AI runtime discovery (\`cloud.aws._discover_bedrock\`, \`cloud.azure\`, \`cloud.gcp\`) already existed but nothing tied them together — an operator looking at the graph could not answer "this LangChain agent on a laptop calls which cloud Bedrock agent, under which model?".

This change adds the connective tissue for **AWS Bedrock**.

## \`src/agent_bom/cross_env_correlation.py\`

- \`CorrelationConfidence\`: \`"exact"\` | \`"inferred"\` | \`"low"\`
- \`CrossEnvironmentLink\` dataclass with \`to_evidence()\` that serialises into the edge evidence dict the graph reads
- \`correlate_bedrock(framework_agents, cloud_agents)\` matchers:
  - **exact** — any local \`model_refs\` substring-matches a cloud Bedrock token derived from \`foundationModel\` (handles \`anthropic.claude-3-5-sonnet-20240620-v1:0\` → \`claude-3-5-sonnet\`)
  - **inferred** — local agent's framework / capabilities / credential_refs mention \`boto3\` / \`bedrock-runtime\` / \`invoke_model\`, with optional name-substring boost

## \`src/agent_bom/graph/types.py\`

- New \`RelationshipType.CORRELATES_WITH\` (\`"correlates_with"\`) for local-agent → cloud_resource edges. Edge attributes carry \`confidence\` + \`signals\` so dashboards can render exact/inferred badges and operators can audit a match.

## \`src/agent_bom/graph/builder.py\`

- \`_add_cross_env_correlation\` runs after \`_add_framework_topology\` and the cloud-origin promoter have created their nodes. It calls \`correlate_bedrock\` and only emits an edge when both endpoints already exist in the current graph — that's the cross-tenant safety: an edge whose endpoint is missing would necessarily span scopes and is silently dropped.

## tests/test_cross_env_correlation.py — 13 tests

- token extraction (full id, post-vendor slug, version-stripped form)
- exact match via model_refs substring
- inferred match via SDK signal
- no match when neither signal present
- dedup of duplicate (local, cloud) pairs
- ignores non-Bedrock cloud agents
- end-to-end through the graph builder: edge present, evidence populated, target is the cloud_resource
- **cross-tenant negative**: two scans with the same names yield two separate graphs whose edges never cross (acceptance criterion)
- **CLI/API consumers can split by confidence** (acceptance criterion)

## Acceptance criteria coverage (Phase 1)

- [x] Graph export can show local agent/framework → cloud runtime edges with confidence metadata
- [x] CLI/API output distinguishes exact / inferred / unmatched cloud-runtime links (\`edge.evidence["confidence"]\`)
- [x] Tests prove no false merge between similarly named local/cloud agents across tenants/projects
- [x] Fixture for local framework agent → AWS Bedrock (this PR)
- [ ] Fixture for local project → Azure OpenAI / Functions (#1992)
- [ ] Fixture for local project → GCP Vertex / Cloud Run (#1993)

## Test plan

- [x] \`pytest tests/test_cross_env_correlation.py tests/test_graph_builder.py -q\` — 46 passed
- [x] \`ruff check\` — clean