### PR TITLE
ci: bound release/post-merge job timeouts + align container-rescan checkout to v6

### DIFF
--- a/.github/workflows/container-rescan.yml
+++ b/.github/workflows/container-rescan.yml
@@ -34,7 +34,7 @@ jobs:
             sarif_category: container-arm64
     steps:
       - name: Check out repository
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Pull ${{ matrix.platform }} image
         run: docker pull --platform ${{ matrix.platform }} agentbom/agent-bom:latest

--- a/.github/workflows/post-merge-self-scan.yml
+++ b/.github/workflows/post-merge-self-scan.yml
@@ -23,6 +23,7 @@ jobs:
   self-sast-scan:
     name: Self SAST scan
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       security-events: write  # required: SARIF upload to GitHub Security tab
@@ -178,6 +179,7 @@ jobs:
   generate-sbom:
     name: Generate SBOM
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
   version-guard:
     name: Verify tag/version alignment
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:
@@ -113,6 +114,7 @@ jobs:
     name: Build distribution
     needs: version-guard
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
@@ -151,6 +153,7 @@ jobs:
     name: Publish to PyPI
     needs: [build, self-scan-gate, container-gate]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment:
       name: pypi
       url: https://pypi.org/p/agent-bom
@@ -170,6 +173,7 @@ jobs:
     name: Publish to Docker Hub
     needs: [build, self-scan-gate, container-gate]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write       # required for SLSA provenance attestation
@@ -305,6 +309,7 @@ jobs:
     name: Publish UI image
     needs: [build, self-scan-gate, container-gate]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write
@@ -426,6 +431,7 @@ jobs:
     name: Self-scan published image
     needs: docker-publish
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
@@ -457,6 +463,7 @@ jobs:
     name: Publish Helm chart to OCI
     needs: [version-guard, self-scan-gate, container-gate]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: write
@@ -525,6 +532,7 @@ jobs:
     name: Container release gate
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -552,6 +560,7 @@ jobs:
     name: Self-scan release gate
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       security-events: write
@@ -615,6 +624,7 @@ jobs:
     name: Generate CycloneDX SBOM
     needs: [build, self-scan-gate]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -642,6 +652,7 @@ jobs:
     name: Sign distribution with Sigstore
     needs: [build, self-scan-gate]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       id-token: write  # required for Sigstore OIDC
@@ -671,6 +682,7 @@ jobs:
     name: Generate SLSA provenance
     needs: [build, self-scan-gate]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       id-token: write
       contents: read
@@ -724,6 +736,7 @@ jobs:
     name: Create GitHub Release
     needs: [pypi-publish, docker-publish, docker-publish-ui, published-image-self-scan, sign, provenance, sbom, helm-publish]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary

Closes the audit's P0 #2 / #3 / #4 in one CI-only PR. Lowest-risk subset of the punchlist — pure workflow-file changes, no code or tests touched.

### #1916 sweep never reached release/post-merge

The earlier timeout-minutes hardening covered \`.github/workflows/ci.yml\` but missed the release pipeline. Today a hung publish, sign, or scan step would stall a release indefinitely. Adds explicit ceilings:

- **release.yml: 13 jobs** — version-guard 10m, build 20m, pypi-publish 15m, docker-publish 30m, docker-publish-ui 30m, published-image-self-scan 20m, helm-publish 15m, container-gate 10m, self-scan-gate 10m, sbom 15m, sign 10m, provenance 15m, github-release 10m
- **post-merge-self-scan.yml: 2 jobs** — self-sast-scan 20m, generate-sbom 15m

\`docs-site\` is a reusable workflow call (\`uses: ./.github/workflows/docs.yml\`) so its timeouts live on the called jobs, not here.

### container-rescan checkout drift

\`container-rescan.yml\` was the only workflow still pinned to \`actions/checkout\` v5 (\`f43a0e5...\`); every other workflow had moved to v6 (\`de0fac2e...\`). After this change the repo has exactly **one** checkout SHA across all workflows — future dependabot bumps stay coherent.

## Test plan

- [x] \`yaml.safe_load\` passes for both touched workflow files
- [x] \`grep -rE "checkout@[a-f0-9]{40}" .github/workflows/ | grep -oE "checkout@..." | sort -u\` returns exactly one SHA
- [x] All 13 release.yml jobs and both post-merge-self-scan.yml jobs now declare timeout-minutes