### PR TITLE
feat(graph): add direct cloud_principal → agent MANAGES edge

### DIFF
--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -1041,6 +1041,25 @@ def _add_agent_cloud_lineage(
             evidence={"source": "cloud_principal", "principal_type": principal.get("principal_type", "")},
         )
     )
+    # Direct principal → agent edge so single-hop "which principals can
+    # reach this agent?" queries don't have to traverse the intermediate
+    # cloud_resource node. The intermediate edges (principal → resource,
+    # resource → agent) above stay so the lineage is fully reconstructable.
+    # `via` records that the relationship is mediated by a cloud_resource
+    # so consumers can distinguish direct ownership from cloud-mediated
+    # operation when they need to.
+    graph.add_edge(
+        UnifiedEdge(
+            source=principal_node_id,
+            target=agent_id,
+            relationship=RelationshipType.MANAGES,
+            evidence={
+                "source": "cloud_principal",
+                "principal_type": principal.get("principal_type", ""),
+                "via": resource_node_id,
+            },
+        )
+    )
 
 
 def _add_framework_topology(graph: UnifiedGraph, framework_agents: Any, data_source: str) -> None:

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -168,6 +168,44 @@ class TestBuildUnifiedGraphFromReport:
         assert g.has_edge("provider:gcp", resource_id)
         assert g.has_edge(resource_id, "agent:claude-desktop")
         assert g.has_edge(principal_id, resource_id)
+        # Direct principal → agent edge (audit P0 #1): single-hop reach so
+        # "which principals can touch this agent?" doesn't have to traverse
+        # the cloud_resource intermediate.
+        assert g.has_edge(principal_id, "agent:claude-desktop")
+        principal_to_agent = next(
+            (
+                e
+                for e in g.edges
+                if e.source == principal_id and e.target == "agent:claude-desktop" and e.relationship == RelationshipType.MANAGES
+            ),
+            None,
+        )
+        assert principal_to_agent is not None
+        # The `via` evidence preserves the lineage so consumers can tell the
+        # principal-to-agent relationship is mediated by a cloud_resource
+        # rather than direct ownership.
+        assert principal_to_agent.evidence.get("via") == resource_id
+
+    def test_no_principal_agent_edge_when_principal_metadata_absent(self):
+        # If cloud_origin is present but cloud_principal is missing, only
+        # the resource-side lineage is created — no service_account node,
+        # and definitely no orphan principal → agent edge.
+        report = _minimal_report()
+        report["agents"][0]["source"] = "gcp-cloud-run"
+        report["agents"][0]["metadata"] = {
+            "cloud_origin": {
+                "provider": "gcp",
+                "service": "cloud-run",
+                "resource_type": "service",
+                "resource_id": "no-principal",
+                "resource_name": "no-principal",
+            },
+        }
+        g = build_unified_graph_from_report(report)
+        sa_nodes = [n for n in g.nodes_by_type(EntityType.SERVICE_ACCOUNT)]
+        assert sa_nodes == []
+        principal_to_agent = [e for e in g.edges if e.source.startswith("service_account:") and e.target == "agent:claude-desktop"]
+        assert principal_to_agent == []
 
     def test_gpu_container_metadata_promotes_to_cloud_resource(self):
         # gpu_infra_to_agents (src/agent_bom/cloud/gpu_infra.py) attaches a


### PR DESCRIPTION
## Summary

Closes audit P0 #1.

#1941 added \`principal → cloud_resource\` and \`cloud_resource → agent\` edges, but the principal was never wired directly to the agent. Single-hop "which principals can reach this agent?" queries had to traverse the intermediate cloud_resource node — fragile and silently degrades when callers iterate the immediate neighbours of an agent node.

This change adds the direct edge in \`_promote_cloud_origin_lineage\` right after the existing \`principal → resource MANAGES\` edge:

\`\`\`
principal_node_id  →  agent_id   (MANAGES, via=resource_node_id)
\`\`\`

The intermediate edges stay so the lineage is fully reconstructable; the new edge is purely additive. The \`via\` field on the evidence dict records that the relationship is mediated by a \`cloud_resource\` so consumers can distinguish direct ownership from cloud-mediated operation when they need to.

## Tests
- \`test_cloud_origin_metadata_becomes_lineage_nodes\` extended: asserts the direct \`principal → agent\` edge exists and \`evidence.via\` matches the cloud_resource id
- \`test_no_principal_agent_edge_when_principal_metadata_absent\` (new): guards the negative path — cloud_origin without cloud_principal must not emit the new edge or any service_account node

## Test plan
- [x] \`pytest tests/test_graph_builder.py -q\` — 34 passed (was 33)
- [x] \`ruff check\` — clean