### PR TITLE
audit P1: backpressure jitter + sandbox posture + auth_policy docstring scope

### DIFF
--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -515,11 +515,14 @@ async def list_keys(request: Request) -> dict:
 
 @router.get("/v1/auth/policy", tags=["enterprise"])
 async def auth_policy(request: Request) -> dict:
-    """Report API key and rate-limit key rotation policy + status.
+    """Report control-plane operator posture for auth, rate-limit and runtime safety controls.
 
-    Operators surface this in dashboards and runbooks to confirm that
-    rotation cadence is enforced and that no fingerprint key has aged
-    past the configured maximum.
+    Intended for operator runbooks and posture dashboards. The payload is the
+    process-wide control-plane configuration (rotation policy, header gates,
+    sandbox defaults, identity provisioning posture) — it is not a tenant-scoped
+    record. The only tenant-scoped fields are ``tenant_quota_runtime`` (the
+    effective quotas for the calling tenant) and the resolved tenant id used to
+    derive them; everything else describes the deployment as a whole.
     """
     from agent_bom.api.audit_log import describe_audit_hmac_status
     from agent_bom.api.auth import get_api_key_policy
@@ -539,6 +542,7 @@ async def auth_policy(request: Request) -> dict:
     from agent_bom.api.storage_schema import describe_control_plane_storage_schema
     from agent_bom.api.tenant_quota import default_tenant_quotas, get_tenant_quota_runtime
     from agent_bom.backpressure import describe_backpressure_posture
+    from agent_bom.proxy_sandbox import describe_proxy_sandbox_posture
 
     api_policy = get_api_key_policy()
     rl_status = get_rate_limit_key_status()
@@ -577,6 +581,7 @@ async def auth_policy(request: Request) -> dict:
         "proxy_control_plane_mtls": describe_proxy_control_plane_mtls_posture(),
         "security_headers": describe_security_header_posture(),
         "backpressure": describe_backpressure_posture(),
+        "proxy_sandbox": describe_proxy_sandbox_posture(),
         "secret_integrity": {
             "audit_hmac": describe_audit_hmac_status(),
             "compliance_signing": describe_signing_posture(),

--- a/src/agent_bom/backpressure.py
+++ b/src/agent_bom/backpressure.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 import random
 import time
@@ -75,10 +76,18 @@ class BackpressureController:
                 self.last_trigger_reason = "p99_latency_threshold"
 
     def retry_after_seconds(self, now: float | None = None) -> int:
+        # Multiplicative jitter in [-15%, +35%]. The previous additive form
+        # `int(base + uniform(0, base*0.3) + 0.999)` collapsed to a single
+        # value (typically 2) when base ≈ 1s — which is the most common
+        # path because base is clamped to max(1.0, ...) — re-creating the
+        # thundering-herd this jitter exists to prevent. Using a
+        # multiplicative range that straddles the base makes math.ceil
+        # return at least two distinct values for any base ≥ 1, while
+        # still rounding up so retry-after never tells a client "0".
         now = time.monotonic() if now is None else now
         base = max(1.0, self.open_until_monotonic - now)
-        jitter = random.uniform(0.0, base * 0.3)
-        return max(1, int(base + jitter + 0.999))
+        jitter_factor = random.uniform(0.85, 1.35)
+        return max(1, math.ceil(base * jitter_factor))
 
     @property
     def p95_ms(self) -> float:

--- a/src/agent_bom/proxy_sandbox.py
+++ b/src/agent_bom/proxy_sandbox.py
@@ -374,3 +374,25 @@ def _validate_positive_int(label: str, value: int) -> int:
     if value <= 0:
         raise ValueError(f"{label} must be a positive integer")
     return value
+
+
+def describe_proxy_sandbox_posture() -> dict[str, object]:
+    """Return non-secret operator posture for the MCP proxy sandbox defaults.
+
+    Surfaces the process-wide default for ``image_pin_policy`` (resolved from
+    ``AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY``) so operators can verify in a
+    dashboard whether mutable image references would be rejected before a
+    proxied MCP server starts. Per-server configs may override the default.
+    """
+    raw = (os.environ.get("AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY") or "warn").strip().lower()
+    default_policy: SandboxImagePinPolicy = raw if raw in {"off", "warn", "enforce"} else "warn"  # type: ignore[assignment]
+    return {
+        "image_pin_policy_default": default_policy,
+        "image_pin_policy_env": "AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY",
+        "production_recommendation": "enforce",
+        "notes": (
+            "Default 'warn' surfaces a non-blocking warning when a sandbox image is not pinned to a digest. "
+            "Set the env to 'enforce' in production so unpinned image references are rejected at proxy start. "
+            "Per-server SandboxConfig.image_pin_policy overrides this process-wide default."
+        ),
+    }

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -247,6 +247,9 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert isinstance(body["backpressure"]["enabled"], bool)
     assert body["backpressure"]["status"] in {"ready", "active"}
     assert isinstance(body["backpressure"]["paths"], list)
+    assert body["proxy_sandbox"]["image_pin_policy_default"] in {"off", "warn", "enforce"}
+    assert body["proxy_sandbox"]["production_recommendation"] == "enforce"
+    assert body["proxy_sandbox"]["image_pin_policy_env"] == "AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY"
     assert body["secret_integrity"]["audit_hmac"]["status"] in {"configured", "ephemeral"}
     assert body["secret_integrity"]["audit_hmac"]["rotation_tracking_supported"] is True
     assert body["secret_integrity"]["audit_hmac"]["rotation_status"] in {

--- a/tests/test_backpressure.py
+++ b/tests/test_backpressure.py
@@ -46,7 +46,28 @@ def test_retry_after_seconds_adds_bounded_jitter(monkeypatch) -> None:
     controller.open_until_monotonic = 110.0
     monkeypatch.setattr("agent_bom.backpressure.random.uniform", lambda low, high: high)
 
-    assert controller.retry_after_seconds(now=100.0) == 13
+    # base = 10s, jitter_factor = 1.35 (mocked to high) → ceil(13.5) = 14.
+    assert controller.retry_after_seconds(now=100.0) == 14
+
+
+def test_retry_after_seconds_produces_distinct_values_at_base_one_second() -> None:
+    # Regression: the original additive jitter (`int(base + uniform(0, base*0.3) + 0.999)`)
+    # collapsed to a single value (2) for the most common case where base ≈ 1s
+    # because the controller clamps base to max(1.0, ...). Multiplicative jitter
+    # over [0.85, 1.35] must yield at least two distinct ceil values per call set.
+    controller = BackpressureController(
+        path="graph",
+        max_concurrency=1,
+        p99_threshold_ms=1,
+        cooldown_seconds=1,
+        min_samples=1,
+    )
+    controller.open_until_monotonic = 100.0
+    samples = {controller.retry_after_seconds(now=99.5) for _ in range(64)}
+
+    assert len(samples) >= 2, f"jitter collapsed to single value: {samples}"
+    assert min(samples) >= 1
+    assert max(samples) <= 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Three small operator-posture and runtime-safety fixes from the post-merge audit.

### 1. Backpressure retry-after jitter (audit P1 #5)

`BackpressureController.retry_after_seconds` previously used additive jitter:

```python
int(base + uniform(0, base*0.3) + 0.999)
```

When the controller cools down after p99 violation, `base` is clamped to `max(1.0, ...)`. With base ≈ 1s the formula collapses to `int(1 + uniform(0, 0.3) + 0.999) == 2` for every caller — re-creating the thundering-herd that jitter exists to prevent.

Replaced with multiplicative jitter in `[0.85, 1.35]`, then `math.ceil` so retry-after never tells a client `0`. The new form yields at least two distinct ceil values for any base ≥ 1. Added a regression test `test_retry_after_seconds_produces_distinct_values_at_base_one_second` that fails under the old math.

`src/agent_bom/backpressure.py` — `import math` added; `retry_after_seconds` rewritten with an inline comment explaining *why* the previous form failed so a future reader doesn't roll back to the simpler-looking version.

### 2. Surface MCP sandbox posture on `/v1/auth/policy` (audit P1 #7)

Operators currently have no way to confirm from the posture endpoint whether their deployment would block an unpinned MCP server image. Per-server `SandboxConfig.image_pin_policy` already records the value in scan evidence, but the deployment-wide default (env-resolved) was not surfaced.

Added `describe_proxy_sandbox_posture()` in `src/agent_bom/proxy_sandbox.py` returning the resolved default plus operator guidance (`production_recommendation: "enforce"`). Wired into `auth_policy()` as a new `proxy_sandbox` block alongside `backpressure` and `security_headers`.

### 3. Scope `auth_policy` docstring (audit P1 #10)

The previous docstring described the payload as "API key and rate-limit key rotation policy + status," but the response also includes 18+ control-plane posture blocks (HSTS, CSP, mTLS, sandbox, identity provisioning, secret lifecycle, …). The audit flagged ambiguity about whether the endpoint exposes tenant state.

Rewrote to state explicitly: this is control-plane operator posture, not tenant-scoped data; only `tenant_quota_runtime` is bound to the calling tenant.

## Test plan

- [x] `pytest tests/test_backpressure.py tests/test_api_operator_policy.py tests/test_proxy_sandbox.py` — 65 passed
- [x] `ruff check` on touched files — clean
- [x] `mypy` on `backpressure.py`, `proxy_sandbox.py`, `enterprise.py` — clean
- [x] New regression test for backpressure jitter variance
- [x] Operator-policy test updated to assert the new `proxy_sandbox` posture block