### PR TITLE
chore: audit P2 hygiene + CI stranded-PR runbook

### DIFF
--- a/.github/workflows/dependabot-ui-lockfile-normalize.yml
+++ b/.github/workflows/dependabot-ui-lockfile-normalize.yml
@@ -33,10 +33,17 @@ jobs:
           node-version: '22'
 
       - name: Normalize UI lockfile
+        # We invoke `npm install --package-lock-only --ignore-scripts` directly
+        # instead of `npm run lock:normalize`. This is a `pull_request_target`
+        # workflow with a privileged GITHUB_TOKEN; running an npm script
+        # defined in the PR-supplied `ui/package.json` would let a Dependabot
+        # branch redefine `scripts.lock:normalize` and execute arbitrary code
+        # with that token. The inline form keeps the resolver behavior
+        # identical (lockfile-only resolve, no install scripts) without
+        # trusting the PR's `scripts` block.
         run: |
           cd ui
-          npm ci --ignore-scripts
-          npm run lock:normalize
+          npm install --package-lock-only --ignore-scripts
 
       - name: Commit normalized lockfile
         run: |

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,45 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-Work targeting the next release.
+### Added
+- **Cloud origin lineage in the unified graph** — agents discovered with cloud metadata now promote `cloud_principal`, `cloud_resource`, and direct principal→agent edges so single-hop reachability queries no longer have to traverse the intermediate cloud_resource node.
+- **GPU and k8s GPU promotion** — GPU containers and Kubernetes GPU clusters now flow into the unified graph alongside the rest of the inventory.
+- **Static multi-agent topology edges** — framework-level agent topology is now materialized as graph edges so reviewers can see which agents delegate to which.
+- **System prompt and MCP prompt inventory** — system prompts and MCP server prompts are now captured as policy evidence and surfaced through the standard inventory paths.
+- **AI observability SDK inventory** — observability SDKs are detected and recorded as managed inventory.
+- **MCP stable error envelope** — MCP responses now carry stable `code` / `category` / `details` / `schema_version` fields and a published API parity matrix so SDK consumers can branch on machine-readable errors.
+- **Vanilla EKS production preset** — `deploy/helm/agent-bom/examples/eks-vanilla-values.yaml` ships a production-shaped preset for self-hosted EKS rollouts.
+- **Customer secret rotation adapter evidence** — secret rotation adapters now emit deterministic evidence so operators can prove a managed key was rotated by their KMS, not the platform.
+- **Native control-plane mTLS fallback** — the API can terminate mTLS itself when no mesh or front proxy is available, with a posture surface on `/v1/auth/policy`.
+- **Frontend API error taxonomy + GET caching/dedup** — the dashboard API client now exposes a typed error taxonomy and dedupes/caches GET requests with prefix-scoped invalidation.
+
+### Changed
+- **Centralised tenant resolution for CLI and MCP** — CLI and MCP entry points now resolve tenant id through one shared helper instead of per-surface ad-hoc logic.
+- **Backpressure posture surfaced on `/v1/auth/policy`** — the operator policy endpoint now reports adaptive backpressure state (paths, p99, retry-after) alongside the auth and rate-limit posture.
+- **CSP source-of-truth centralised** — `ui/next.config.ts` and `ui/vercel.json` now share one CSP definition; `script-src 'unsafe-inline'` is temporarily restored pending the hash-pinning collector.
+- **Docker compose deployment** — platform compose files now use Docker secrets for Postgres credentials and align healthchecks across services.
+- **Docker base alignment** — runtime images now use LTS base versions and the build pipeline gates on the Glama and image-policy checks.
+- **Floating reference policy** — references to mutable upstream tags are now disallowed in build inputs by automated policy.
+- **Postgres sizing guidance + weekly scale-evidence regen** — `docs/perf/` documents `pg_size_pretty` sizing for 1k/5k/10k estates and a scheduled CI run keeps `docs/perf/results/` fresh.
+- **Generated `AGENT_BOM_*` env reference** — the env-var reference is now generated from `config.py` and CI fails if the doc drifts from the source.
+
+### Fixed
+- **Release and post-merge job timeouts** — every release-pipeline and post-merge-self-scan job now has an explicit `timeout-minutes`; runaway jobs no longer hold scarce runners.
+- **Container rescan checkout pinned to v6** — the daily image rescan now uses a v6-pinned `actions/checkout` SHA aligned with the rest of the pipeline.
+- **main-ui-smoke boot script** — the standalone container boot script now assembles the `.next/static` tree explicitly (`rm`/`mkdir`/`cp -a`) so a missing source dir no longer aborts the smoke under `set -e`.
+- **Frontend contract hygiene** — closed frontend contract gaps surfaced by the post-v0.81.3 audit.
+- **Audit contract runtime gaps** — closed runtime gaps in audit-log integrity, signing, and lifecycle posture surfaced by the post-v0.81.3 audit.
+- **Adaptive backpressure retry-after jitter** — retry-after now uses multiplicative jitter so colocated callers don't all retry on the same boundary at base ≈ 1s.
+
+### Security
+- **Auth middleware hardening** — header normalisation, exempt-path startup assertions, and tightened trust-proxy posture across the auth middleware stack.
+- **MCP sandbox `image_pin_policy` posture surfaced** — `/v1/auth/policy` now reports the deployment-wide default and recommends `enforce` for production.
+- **Cross-parser dedup proofs + Postgres RLS red-team test for `scan_jobs`** — added structural and runtime guards proving a session bound to tenant B cannot read tenant A `scan_jobs` rows under a non-superuser role.
+- **Dependabot UI lockfile workflow no longer trusts the PR `scripts.lock:normalize` entry** — replaces the `npm run lock:normalize` step with an inline `npm install --package-lock-only --ignore-scripts` so a Dependabot branch can't redefine the script under a privileged `pull_request_target` token.
+
+### Internal
+- **Tracked Finder duplicate artifacts blocked** — CI now refuses to merge tracked macOS Finder duplicate files (e.g. `… 2.md`).
+- **Real Postgres integration contract** — `tests/test_postgres_integration.py` now exercises real Postgres for job, audit, and RLS contracts.
 
 ---
 

--- a/docs/operations/CI_RUNBOOK.md
+++ b/docs/operations/CI_RUNBOOK.md
@@ -1,0 +1,85 @@
+# CI Runbook
+
+Operational guidance for the agent-bom CI pipeline. Use this when a PR is
+stuck, a workflow fails unexpectedly, or you need to retrigger checks.
+
+---
+
+## Stranded PRs (zero check runs on the current head SHA)
+
+### Symptom
+
+A PR sits in `mergeable_state: blocked` with no checks visible in the GitHub
+UI. `gh pr view <N> --json statusCheckRollup` returns `[]`. The PR was passing
+its required checks before, then someone clicked **Update branch** (or the
+`auto-merge` bot did) and the new merge commit has no workflow runs at all.
+
+### Root cause
+
+GitHub Actions does not recursively trigger workflows from events whose actor
+is `GITHUB_TOKEN`. When auto-merge — or the **Update branch** button — pushes
+the merge-from-base commit to a PR head, that push is authored by
+`GITHUB_TOKEN`. `pull_request` workflows therefore do not fire on that head
+SHA, leaving the PR stranded with the previous head's checks marked stale by
+`required_status_checks.strict = true`.
+
+This is documented behavior, not an agent-bom-specific bug:
+<https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow>
+
+### Fix the stranded PR (one-shot)
+
+```sh
+scripts/retrigger_stranded_pr.sh <PR_NUMBER>
+```
+
+The script:
+
+1. Resolves the PR's current head SHA.
+2. Checks whether the canonical required check (`Lint and Type Check`) ran
+   against that SHA via `repos/.../commits/<sha>/check-runs`.
+3. If not, closes the PR and immediately reopens it. The `pull_request
+   reopened` event always fires `pull_request` workflows, so all required
+   checks restart on the up-to-date head.
+
+The script no-ops when the required check is already present, so it is safe to
+run on any PR.
+
+### Permanent fix options (settings change required)
+
+Pick one — none of these can be enabled from a workflow file alone.
+
+| Option | Where | Tradeoff |
+|---|---|---|
+| **Enable merge queue on `main`** | Settings → Branches → main protection rule → "Require merge queue" | Cleanest. The `merge_group: types: [checks_requested]` trigger already exists in `ci.yml`, so the queue starts working immediately. PRs no longer need to be rebased before merge. |
+| **Set `required_status_checks.strict = false`** | Settings → Branches → main protection rule → uncheck "Require branches to be up to date before merging" | Simplest. Removes the need to rebase, so "Update branch" is no longer needed. Loses the guarantee that CI passed against current `main` — relies on post-merge workflows to catch regressions. |
+| **Use a GitHub App / PAT for auto-merge** | Replace the bot identity for `Update branch` pushes | Pushes from a non-`GITHUB_TOKEN` identity do fire workflows. Requires creating + scoping a dedicated app or token. |
+
+The merge queue is the recommended option for this repo because the workflow
+is already wired for `merge_group`.
+
+---
+
+## Other recurring CI gotchas
+
+### `pull_request_target` workflows
+
+Workflows that need write access to the repo from a PR (e.g. the Dependabot
+lockfile normalizer) use `pull_request_target` so the `GITHUB_TOKEN` carries
+write scopes. Two hard rules apply to anything we add to that family:
+
+1. Never run a script defined inside the PR's working tree (`npm run …`,
+   `make …` against PR `Makefile`, `tox` against PR `tox.ini`, etc.). A PR
+   can redefine those scripts to exfiltrate the privileged token.
+2. Always use `--ignore-scripts` (or the equivalent) on package installers so
+   transitive postinstall hooks cannot execute either.
+
+`.github/workflows/dependabot-ui-lockfile-normalize.yml` is the canonical
+example: it runs `npm install --package-lock-only --ignore-scripts` directly
+instead of `npm run lock:normalize`.
+
+### Required checks renamed
+
+If a workflow job is renamed, its old name stays as a required context until
+someone updates the branch protection rule. Symptom: every PR is blocked on a
+check name that no longer exists. Fix: Settings → Branches → main protection
+rule → re-select required contexts.

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -168,6 +168,19 @@ def main() -> int:
         if versions and versions != {version}:
             _fail(f"{path.relative_to(ROOT)} contains stale managed image version(s): {sorted(versions)} != {version}")
 
+    helm_chart = ROOT / "deploy" / "helm" / "agent-bom" / "Chart.yaml"
+    helm_text = helm_chart.read_text()
+    chart_version = re.search(r"^version:\s*(\S+)\s*$", helm_text, re.M)
+    chart_app_version = re.search(r'^appVersion:\s*"([^"]+)"\s*$', helm_text, re.M)
+    if chart_version is None or chart_app_version is None:
+        _fail('deploy/helm/agent-bom/Chart.yaml must declare both `version:` and `appVersion: "..."`')
+    elif chart_version.group(1) != version or chart_app_version.group(1) != version:
+        _fail(
+            "deploy/helm/agent-bom/Chart.yaml is out of sync with pyproject.toml: "
+            f"chart.version={chart_version.group(1)}, chart.appVersion={chart_app_version.group(1)}, expected {version}. "
+            "Run scripts/bump-version.py to refresh both fields together."
+        )
+
     print("README/PyPI/docs release consistency checks passed")
     return 0
 

--- a/scripts/retrigger_stranded_pr.sh
+++ b/scripts/retrigger_stranded_pr.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Retrigger required CI on a PR whose head SHA was advanced by a
+# GITHUB_TOKEN-authored push (auto-merge "Update branch", merge bots).
+# Such pushes do not fire `pull_request` workflows, so the PR sits in
+# `mergeable_state: blocked` with zero check runs on the current head.
+#
+# This script:
+#   1. Reads the PR's current head SHA.
+#   2. Checks whether the canonical required check ("Lint and Type Check")
+#      has run against that SHA.
+#   3. If not, closes + reopens the PR — the `reopened` action fires
+#      `pull_request` workflows again from scratch.
+#
+# Usage:
+#   scripts/retrigger_stranded_pr.sh <PR_NUMBER>
+#
+# Requires: gh CLI authenticated against the repo.
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <PR_NUMBER>" >&2
+  exit 64
+fi
+
+PR="$1"
+REQUIRED_CHECK="${REQUIRED_CHECK:-Lint and Type Check}"
+REPO="${GH_REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+
+HEAD_SHA="$(gh api "repos/${REPO}/pulls/${PR}" --jq .head.sha)"
+if [ -z "${HEAD_SHA}" ]; then
+  echo "could not resolve head SHA for PR #${PR}" >&2
+  exit 1
+fi
+
+CHECK_HITS="$(
+  gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+    --jq "[.check_runs[] | select(.name == \"${REQUIRED_CHECK}\")] | length"
+)"
+
+if [ "${CHECK_HITS}" -gt 0 ]; then
+  echo "PR #${PR}: head ${HEAD_SHA} already has '${REQUIRED_CHECK}' (count=${CHECK_HITS}). No retrigger needed."
+  exit 0
+fi
+
+echo "PR #${PR}: head ${HEAD_SHA} has 0 '${REQUIRED_CHECK}' runs. Closing + reopening to retrigger required workflows."
+gh pr close "${PR}" --comment "auto-retrigger: required CI did not fire on head ${HEAD_SHA} (likely a GITHUB_TOKEN-authored 'Update branch' merge). Reopening to re-run checks."
+sleep 2
+gh pr reopen "${PR}" --comment "reopened to retrigger required checks against the up-to-date head."
+echo "PR #${PR}: retrigger requested. Workflows should appear in ~10s."

--- a/ui/app/proxy/page.tsx
+++ b/ui/app/proxy/page.tsx
@@ -73,16 +73,30 @@ export default function ProxyDashboard() {
   const [severityFilter, setSeverityFilter] = useState<string>("");
   const wsRef = useRef<WebSocket | null>(null);
 
-  // Fetch initial data
+  // Fetch initial data. Status and alerts are independent — render whichever
+  // resolves successfully so a transient alerts failure doesn't blank the
+  // status header (and vice-versa). Surface the first failure as a banner.
   const load = () => {
     setLoading(true);
     setError(null);
-    Promise.all([api.getProxyStatus(), api.getProxyAlerts({ limit: 200 })])
-      .then(([s, a]) => {
-        setStatus(s);
-        setAlerts(a.alerts);
+    // `Promise.allSettled` never rejects, so a .catch handler would be dead
+    // code. The leading `void` tells eslint that intent and silences the
+    // no-floating-promises rule without adding a no-op catch.
+    void Promise.allSettled([api.getProxyStatus(), api.getProxyAlerts({ limit: 200 })])
+      .then(([statusResult, alertsResult]) => {
+        const failures: string[] = [];
+        if (statusResult.status === "fulfilled") {
+          setStatus(statusResult.value);
+        } else {
+          failures.push(`status: ${statusResult.reason?.message ?? "request failed"}`);
+        }
+        if (alertsResult.status === "fulfilled") {
+          setAlerts(alertsResult.value.alerts);
+        } else {
+          failures.push(`alerts: ${alertsResult.reason?.message ?? "request failed"}`);
+        }
+        setError(failures.length === 0 ? null : failures.join("; "));
       })
-      .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
   };
 


### PR DESCRIPTION
## Summary

Closes the small-but-recurring hygiene findings from the post-v0.81.3 audit, plus the CI-stranded-PR pattern that has caused multiple manual retriggers (most recently #1996).

### CI hygiene
- Drop the unused `develop` branch filter from `dependency-review.yml` — the repo only ships `main`.
- The Dependabot UI lockfile normalizer no longer runs `npm run lock:normalize`. Under `pull_request_target` that step would invoke a script defined inside the PR-supplied `ui/package.json`, which a Dependabot branch could redefine to exfiltrate the privileged `GITHUB_TOKEN`. Replaced with the inline equivalent `npm install --package-lock-only --ignore-scripts` — same lockfile resolver behaviour, no script execution against PR-supplied `package.json`.

### Release consistency
- `scripts/check_release_consistency.py` now asserts that `deploy/helm/agent-bom/Chart.yaml` keeps both `version:` and `appVersion:` in lockstep with `pyproject.toml`. `scripts/bump-version.py` already updates them; this is the missing failure mode for manual edits and stale releases.

### CHANGELOG
- Backfill `[Unreleased]` with the work that landed since v0.81.3 — cloud origin lineage, GPU/k8s GPU promotion, multi-agent topology edges, MCP prompt + system prompt inventory, MCP stable error envelope, vanilla EKS preset, native control-plane mTLS fallback, frontend API error taxonomy, Postgres sizing + scheduled scale-evidence regen, RLS red-team test for scan_jobs, and the auth-middleware/backpressure/sandbox posture surfacing.

### Frontend
- `ui/app/proxy/page.tsx` now uses `Promise.allSettled` for the parallel proxy status + alerts fetch. A transient alerts request failure no longer blanks the status header (and vice-versa); both partial failures are joined into a single banner.

### CI stranded-PR fix (recurring issue)

**Root cause**: GitHub Actions does not recursively trigger workflows for events whose actor is `GITHUB_TOKEN`. When auto-merge — or the **Update branch** button — pushes the merge-from-base commit to a PR head, that push is authored by `GITHUB_TOKEN`. `pull_request` workflows therefore do not fire on the new head SHA, leaving the PR stranded with `mergeable_state: blocked` and zero check runs.

This PR ships:
- `scripts/retrigger_stranded_pr.sh` — one-shot helper. Resolves a PR's current head SHA, checks whether `Lint and Type Check` ran against it, and closes+reopens the PR when the canonical required check is absent. Safe to run on any PR (no-ops when checks are already present).
- `docs/operations/CI_RUNBOOK.md` — explains the GITHUB_TOKEN workflow-trigger limitation, plus three permanent-fix options:
  1. **Enable merge queue on `main`** (recommended; `ci.yml` already declares `merge_group: types: [checks_requested]`).
  2. **Set `required_status_checks.strict = false`** (simplest; loses the rebase-against-main guarantee).
  3. **Use a GitHub App / PAT for auto-merge** (pushes from a non-`GITHUB_TOKEN` identity do fire workflows).

All three are settings changes that the operator owns; this PR does not change branch protection.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — vitest 144/144
- [x] `ruff check scripts/check_release_consistency.py` — clean
- [x] `python scripts/check_release_consistency.py` — passes (helm assertion verifies)
- [x] `bash -n scripts/retrigger_stranded_pr.sh` — shellcheck syntax clean
- [x] Postgres RLS coverage already in place via #1980; tests skip locally without Postgres