### PR TITLE
feat(discovery): correlate local agents with AWS Bedrock under strict triplet bar (#1892 Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Cross-environment correlation framework + AWS Bedrock matcher** — local agents and cloud-discovered Bedrock runtimes are now matched on the strict triplet of cloud account ID + region + model ID. Strong matches emit `CORRELATES_WITH` graph edges; partial matches stay visible as `POSSIBLY_CORRELATES_WITH` with a `matched_signals` evidence list so reviewers can see candidates without the platform conflating them. Phase 1 of #1892; Phase 2 (Azure OpenAI / Functions, #1992) and Phase 3 (GCP Vertex / Cloud Run, #1993) plug into the same dispatch.
 - **Cloud origin lineage in the unified graph** — agents discovered with cloud metadata now promote `cloud_principal`, `cloud_resource`, and direct principal→agent edges so single-hop reachability queries no longer have to traverse the intermediate cloud_resource node.
 - **GPU and k8s GPU promotion** — GPU containers and Kubernetes GPU clusters now flow into the unified graph alongside the rest of the inventory.
 - **Static multi-agent topology edges** — framework-level agent topology is now materialized as graph edges so reviewers can see which agents delegate to which.

--- a/src/agent_bom/cross_env_correlation.py
+++ b/src/agent_bom/cross_env_correlation.py
@@ -1,0 +1,389 @@
+"""Correlate locally-discovered agents with cloud-discovered runtimes.
+
+This is the framework piece that backs issue #1892 — proving that a local
+agent (Cursor, Claude Desktop, framework code on a developer machine) is
+talking to a specific cloud runtime (AWS Bedrock, Azure OpenAI, GCP Vertex)
+under a specific identity.
+
+Bar for the strong edge
+-----------------------
+A `CORRELATES_WITH` edge is reserved for HIGH-confidence matches: the local
+agent and the cloud agent must agree on **all three** of the strong identity
+signals for the provider — for AWS Bedrock those are the cloud account ID,
+the region, and the model ID. SDK presence or a single-signal model-name
+substring match is not enough — it would silently merge unrelated agents
+across accounts or environments.
+
+Partial matches are still useful, so they emit `POSSIBLY_CORRELATES_WITH`
+with a `matched_signals` evidence list. Operators see the candidate without
+the platform pretending it is the same agent.
+
+Phase 1 ships AWS Bedrock. Phase 2 will add Azure OpenAI / Functions and
+Phase 3 will add GCP Vertex / Cloud Run. The provider-specific extractor +
+matcher pair is the only thing each phase adds; the dispatch and edge
+emission stay shared.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Iterable, Mapping, TypeAlias, Union
+
+from agent_bom.models import Agent
+
+# An agent record can flow into the matcher either as the rich `Agent`
+# dataclass (used by Python callers and tests) or as the serialized-dict
+# shape that already lives inside the scan report (used by the graph
+# builder). The strong-signal extractors only need a handful of fields, so
+# we normalize both shapes through `_AgentView` instead of forcing one
+# canonical type on every caller.
+AgentLike: TypeAlias = Union[Agent, Mapping[str, Any]]
+
+# ---------------------------------------------------------------------------
+# Strict-bar requirement: at least this many of the strong signals (account,
+# region, model_id) must match for a HIGH-confidence edge. Three out of three
+# is the strict bar; we keep it as a constant so the threshold is one place.
+# ---------------------------------------------------------------------------
+_HIGH_CONFIDENCE_REQUIRED_SIGNALS = 3
+
+
+class CorrelationConfidence(str, Enum):
+    """Confidence level of a cross-environment correlation match."""
+
+    HIGH = "high"
+    LOW = "low"
+
+
+@dataclass(frozen=True)
+class CorrelationMatch:
+    """One correlation between a local agent and a cloud runtime.
+
+    `matched_signals` lists the strong identity signals that agreed (subset of
+    {"account_id", "region", "model_id"} for AWS Bedrock; analogous tuples for
+    Azure / GCP in later phases). It is part of the edge evidence so an
+    operator can see why we drew this particular line.
+    """
+
+    local_agent_name: str
+    local_agent_type: str
+    cloud_agent_name: str
+    cloud_provider: str
+    cloud_service: str
+    cloud_account_id: str | None
+    cloud_region: str | None
+    cloud_model_id: str | None
+    confidence: CorrelationConfidence
+    matched_signals: tuple[str, ...]
+    rationale: str
+
+
+@dataclass(frozen=True)
+class _LocalAwsEvidence:
+    """Strong AWS identity signals pulled from a locally-discovered agent."""
+
+    agent_name: str
+    agent_type: str
+    account_ids: frozenset[str]
+    regions: frozenset[str]
+    model_ids: frozenset[str]
+
+
+@dataclass(frozen=True)
+class _CloudBedrockAgent:
+    """Strong identity signals for a cloud-discovered Bedrock agent."""
+
+    agent_name: str
+    arn: str
+    account_id: str | None
+    region: str | None
+    model_id: str | None
+
+
+# ---------------------------------------------------------------------------
+# Bedrock identity extractors
+# ---------------------------------------------------------------------------
+
+# Authoritative: regional Bedrock ARN. The account segment can be empty for
+# legacy ARNs that omit it; we treat that as "account unknown" rather than
+# guessing.
+_BEDROCK_ARN_RE = re.compile(r"^arn:aws:bedrock:([a-z0-9-]+):([0-9]{0,12}):")
+
+# Local env-var keys that surface AWS account, region, and Bedrock model id
+# without requiring source-code analysis. Operators set these explicitly when
+# wiring an agent to Bedrock; if any of them is present we treat it as an
+# explicit declaration of intent.
+_AWS_ACCOUNT_ENV_KEYS = ("AWS_ACCOUNT_ID", "AWS_DEFAULT_ACCOUNT", "BEDROCK_ACCOUNT_ID")
+_AWS_REGION_ENV_KEYS = ("AWS_REGION", "AWS_DEFAULT_REGION", "BEDROCK_REGION")
+_BEDROCK_MODEL_ENV_KEYS = (
+    "BEDROCK_MODEL_ID",
+    "BEDROCK_FOUNDATION_MODEL",
+    "AWS_BEDROCK_MODEL_ID",
+)
+# Endpoint URLs surface region (and sometimes a custom account); we parse
+# both so an explicit endpoint counts the same as AWS_REGION.
+_AWS_ENDPOINT_ENV_KEYS = (
+    "AWS_ENDPOINT_URL_BEDROCK",
+    "AWS_ENDPOINT_URL_BEDROCK_RUNTIME",
+    "BEDROCK_ENDPOINT_URL",
+)
+_BEDROCK_ENDPOINT_RE = re.compile(
+    r"https?://bedrock(?:-runtime)?\.([a-z0-9-]+)\.amazonaws\.com",
+)
+
+
+def _parse_account_and_region_from_arn(arn: str) -> tuple[str | None, str | None]:
+    match = _BEDROCK_ARN_RE.search(arn)
+    if not match:
+        return None, None
+    region = match.group(1) or None
+    account = match.group(2) or None
+    return account, region
+
+
+def _looks_like_bedrock_model_id(value: str) -> bool:
+    # Bedrock foundation/inference IDs are dotted vendor-prefixed identifiers
+    # such as `anthropic.claude-3-5-sonnet-20241022-v2:0`,
+    # `amazon.titan-text-express-v1`, `meta.llama3-70b-instruct-v1:0`. The
+    # leading vendor segment + dot is the cheap, accurate gate; substring
+    # matching against vendor names alone is what burned PR #1994 (it counts
+    # any string containing "claude" as a Bedrock match).
+    if "." not in value:
+        return False
+    vendor = value.split(".", 1)[0].lower()
+    return vendor in {
+        "anthropic",
+        "amazon",
+        "meta",
+        "mistral",
+        "ai21",
+        "cohere",
+        "stability",
+    }
+
+
+@dataclass(frozen=True)
+class _AgentView:
+    """Read-only normalized view over either an Agent or a serialized dict."""
+
+    name: str
+    agent_type: str
+    config_path: str
+    version: str
+    metadata: Mapping[str, Any]
+    mcp_server_envs: tuple[Mapping[str, Any], ...]
+
+
+def _normalize(agent: AgentLike) -> _AgentView:
+    if isinstance(agent, Agent):
+        return _AgentView(
+            name=agent.name,
+            agent_type=agent.agent_type.value,
+            config_path=str(agent.config_path or ""),
+            version=str(agent.version or ""),
+            metadata=agent.metadata or {},
+            mcp_server_envs=tuple((server.env or {}) for server in agent.mcp_servers),
+        )
+
+    metadata = agent.get("metadata") or {}
+    mcp_servers = agent.get("mcp_servers") or []
+    envs: list[Mapping[str, Any]] = []
+    for server in mcp_servers:
+        if not isinstance(server, Mapping):
+            continue
+        env = server.get("env")
+        if isinstance(env, Mapping):
+            envs.append(env)
+    return _AgentView(
+        name=str(agent.get("name", "")),
+        agent_type=str(agent.get("agent_type", "")),
+        config_path=str(agent.get("config_path", "") or ""),
+        version=str(agent.get("version", "") or ""),
+        metadata=metadata if isinstance(metadata, Mapping) else {},
+        mcp_server_envs=tuple(envs),
+    )
+
+
+def _extract_local_aws_evidence(view: _AgentView) -> _LocalAwsEvidence | None:
+    if _is_cloud_discovered(view):
+        return None
+
+    accounts: set[str] = set()
+    regions: set[str] = set()
+    models: set[str] = set()
+
+    for env in view.mcp_server_envs:
+        for key, value in env.items():
+            if not isinstance(value, str) or not value:
+                continue
+            if key in _AWS_ACCOUNT_ENV_KEYS and value.isdigit() and len(value) == 12:
+                accounts.add(value)
+            elif key in _AWS_REGION_ENV_KEYS:
+                regions.add(value.strip().lower())
+            elif key in _BEDROCK_MODEL_ENV_KEYS and _looks_like_bedrock_model_id(value):
+                models.add(value.strip())
+            elif key in _AWS_ENDPOINT_ENV_KEYS:
+                endpoint_match = _BEDROCK_ENDPOINT_RE.search(value)
+                if endpoint_match:
+                    regions.add(endpoint_match.group(1).lower())
+
+    raw_explicit = view.metadata.get("aws")
+    explicit_aws: Mapping[str, Any] = raw_explicit if isinstance(raw_explicit, Mapping) else {}
+    explicit_account = str(explicit_aws.get("account_id", "")).strip()
+    if explicit_account.isdigit() and len(explicit_account) == 12:
+        accounts.add(explicit_account)
+    explicit_region = str(explicit_aws.get("region", "")).strip().lower()
+    if explicit_region:
+        regions.add(explicit_region)
+    explicit_model = str(explicit_aws.get("bedrock_model_id", "")).strip()
+    if _looks_like_bedrock_model_id(explicit_model):
+        models.add(explicit_model)
+
+    if not (accounts or regions or models):
+        return None
+
+    return _LocalAwsEvidence(
+        agent_name=view.name,
+        agent_type=view.agent_type,
+        account_ids=frozenset(accounts),
+        regions=frozenset(regions),
+        model_ids=frozenset(models),
+    )
+
+
+def _extract_cloud_bedrock_agent(view: _AgentView) -> _CloudBedrockAgent | None:
+    cloud_origin = view.metadata.get("cloud_origin") if isinstance(view.metadata.get("cloud_origin"), Mapping) else None
+    if not cloud_origin or cloud_origin.get("provider") != "aws" or cloud_origin.get("service") != "bedrock":
+        return None
+
+    arn = str(cloud_origin.get("resource_id") or view.config_path or "")
+    arn_account, arn_region = _parse_account_and_region_from_arn(arn)
+
+    scope = cloud_origin.get("scope") or {}
+    scope_account = str(scope.get("account_id") or "").strip() if isinstance(scope, Mapping) else ""
+    account_id = scope_account or arn_account
+
+    location = str(cloud_origin.get("location") or "").strip().lower()
+    region = location or arn_region
+
+    foundation_model = view.version.strip()
+    model_id = foundation_model if _looks_like_bedrock_model_id(foundation_model) else None
+
+    return _CloudBedrockAgent(
+        agent_name=view.name,
+        arn=arn,
+        account_id=account_id,
+        region=region,
+        model_id=model_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bedrock matcher
+# ---------------------------------------------------------------------------
+
+
+def _match_bedrock(
+    local: _LocalAwsEvidence,
+    cloud: _CloudBedrockAgent,
+) -> CorrelationMatch | None:
+    matched: list[str] = []
+
+    if cloud.account_id and cloud.account_id in local.account_ids:
+        matched.append("account_id")
+    if cloud.region and cloud.region in local.regions:
+        matched.append("region")
+    if cloud.model_id and cloud.model_id in local.model_ids:
+        matched.append("model_id")
+
+    if not matched:
+        return None
+
+    confidence = CorrelationConfidence.HIGH if len(matched) >= _HIGH_CONFIDENCE_REQUIRED_SIGNALS else CorrelationConfidence.LOW
+
+    rationale_parts = []
+    if "account_id" in matched:
+        rationale_parts.append(f"account {cloud.account_id}")
+    if "region" in matched:
+        rationale_parts.append(f"region {cloud.region}")
+    if "model_id" in matched:
+        rationale_parts.append(f"model {cloud.model_id}")
+
+    rationale = (
+        "Strong triplet (account + region + model) matched."
+        if confidence is CorrelationConfidence.HIGH
+        else "Partial match — kept as low-confidence candidate. Matched: " + ", ".join(rationale_parts) + "."
+    )
+
+    return CorrelationMatch(
+        local_agent_name=local.agent_name,
+        local_agent_type=local.agent_type,
+        cloud_agent_name=cloud.agent_name,
+        cloud_provider="aws",
+        cloud_service="bedrock",
+        cloud_account_id=cloud.account_id,
+        cloud_region=cloud.region,
+        cloud_model_id=cloud.model_id,
+        confidence=confidence,
+        matched_signals=tuple(matched),
+        rationale=rationale,
+    )
+
+
+def correlate_bedrock(agents: Iterable[AgentLike]) -> list[CorrelationMatch]:
+    """Match local agents to cloud-discovered Bedrock agents."""
+    local_evidence: list[_LocalAwsEvidence] = []
+    cloud_bedrock: list[_CloudBedrockAgent] = []
+
+    for agent in agents:
+        view = _normalize(agent)
+        cloud = _extract_cloud_bedrock_agent(view)
+        if cloud is not None:
+            cloud_bedrock.append(cloud)
+            continue
+        local = _extract_local_aws_evidence(view)
+        if local is not None:
+            local_evidence.append(local)
+
+    matches: list[CorrelationMatch] = []
+    for local in local_evidence:
+        for cloud in cloud_bedrock:
+            match = _match_bedrock(local, cloud)
+            if match is not None:
+                matches.append(match)
+    return matches
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestrator. Phase 2 (Azure) and Phase 3 (GCP) plug in here.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CrossEnvironmentResult:
+    """All cross-environment matches produced for one scan."""
+
+    matches: tuple[CorrelationMatch, ...] = field(default_factory=tuple)
+
+    def by_confidence(self, confidence: CorrelationConfidence) -> tuple[CorrelationMatch, ...]:
+        return tuple(match for match in self.matches if match.confidence is confidence)
+
+
+def correlate_cross_environment(agents: Iterable[AgentLike]) -> CrossEnvironmentResult:
+    """Run every provider-specific matcher over the agent set."""
+    materialized = list(agents)
+    matches: list[CorrelationMatch] = []
+    matches.extend(correlate_bedrock(materialized))
+    return CrossEnvironmentResult(matches=tuple(matches))
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_cloud_discovered(view: _AgentView) -> bool:
+    """Cloud-discovered agents carry a `cloud_origin` envelope."""
+    cloud_origin = view.metadata.get("cloud_origin")
+    return isinstance(cloud_origin, Mapping) and bool(cloud_origin.get("provider"))

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -648,6 +648,9 @@ def build_unified_graph_from_report(
     if isinstance(ai_inventory, dict):
         _add_framework_topology(graph, ai_inventory.get("framework_agents", []), data_source_tag)
 
+    # ── Cross-environment correlation (#1892 Phase 1: AWS Bedrock) ──
+    _add_cross_env_correlation(graph, agents_data, data_source_tag)
+
     # ── Runtime session graph (dynamic edges) ──────────────────────
     runtime_graph = report_json.get("runtime_session_graph")
     if runtime_graph:
@@ -1060,6 +1063,63 @@ def _add_agent_cloud_lineage(
             },
         )
     )
+
+
+def _add_cross_env_correlation(
+    graph: UnifiedGraph,
+    agents_data: Any,
+    data_source: str,
+) -> None:
+    """Emit local↔cloud correlation edges across all configured providers.
+
+    The strict-bar matcher in :mod:`agent_bom.cross_env_correlation` decides
+    whether each candidate qualifies for ``CORRELATES_WITH`` (HIGH-confidence
+    triplet match) or only ``POSSIBLY_CORRELATES_WITH`` (single-signal). Both
+    relationships carry the matched signals and rationale so reviewers can see
+    why the platform drew the line.
+    """
+    from agent_bom.cross_env_correlation import (
+        CorrelationConfidence,
+        correlate_cross_environment,
+    )
+
+    if not isinstance(agents_data, list):
+        return
+    result = correlate_cross_environment(agents_data)
+    if not result.matches:
+        return
+
+    for match in result.matches:
+        local_id = f"agent:{match.local_agent_name}"
+        cloud_id = f"agent:{match.cloud_agent_name}"
+        # Only wire edges between agents we already added as nodes — the
+        # matcher operates over the report payload but the graph may have
+        # filtered some agents out earlier.
+        if not graph.get_node(local_id) or not graph.get_node(cloud_id):
+            continue
+        relationship = (
+            RelationshipType.CORRELATES_WITH
+            if match.confidence is CorrelationConfidence.HIGH
+            else RelationshipType.POSSIBLY_CORRELATES_WITH
+        )
+        graph.add_edge(
+            UnifiedEdge(
+                source=local_id,
+                target=cloud_id,
+                relationship=relationship,
+                evidence={
+                    "data_source": data_source,
+                    "confidence": match.confidence.value,
+                    "matched_signals": list(match.matched_signals),
+                    "cloud_provider": match.cloud_provider,
+                    "cloud_service": match.cloud_service,
+                    "cloud_account_id": match.cloud_account_id or "",
+                    "cloud_region": match.cloud_region or "",
+                    "cloud_model_id": match.cloud_model_id or "",
+                    "rationale": match.rationale,
+                },
+            )
+        )
 
 
 def _add_framework_topology(graph: UnifiedGraph, framework_agents: Any, data_source: str) -> None:

--- a/src/agent_bom/graph/container.py
+++ b/src/agent_bom/graph/container.py
@@ -860,4 +860,7 @@ RELATIONSHIP_LEGEND: list[LegendEntry] = [
     LegendEntry(key="invoked", label="Invoked (runtime)", color="#10b981"),
     LegendEntry(key="accessed", label="Accessed (runtime)", color="#3b82f6"),
     LegendEntry(key="delegated_to", label="Delegated To (runtime)", color="#a855f7"),
+    # Cross-environment correlation (#1892)
+    LegendEntry(key="correlates_with", label="Correlates With (cross-env)", color="#0ea5e9"),
+    LegendEntry(key="possibly_correlates_with", label="Possibly Correlates With (low confidence)", color="#7dd3fc"),
 ]

--- a/src/agent_bom/graph/types.py
+++ b/src/agent_bom/graph/types.py
@@ -72,6 +72,14 @@ class RelationshipType(str, Enum):
     ACCESSED = "accessed"  # tool → resource (runtime)
     DELEGATED_TO = "delegated_to"  # agent → agent (runtime)
 
+    # ── Cross-environment correlation (#1892) ──
+    # CORRELATES_WITH is reserved for HIGH-confidence local↔cloud agent
+    # matches (cloud account/subscription/project + region/location + model
+    # ID all match). POSSIBLY_CORRELATES_WITH carries partial matches so
+    # they stay visible without being conflated with the strict path.
+    CORRELATES_WITH = "correlates_with"  # local agent ↔ cloud agent (high)
+    POSSIBLY_CORRELATES_WITH = "possibly_correlates_with"  # local ↔ cloud (low)
+
 
 class NodeStatus(str, Enum):
     """Lifecycle status of a graph node."""

--- a/tests/test_cross_env_correlation.py
+++ b/tests/test_cross_env_correlation.py
@@ -1,0 +1,219 @@
+"""Cross-environment correlation tests (#1892 Phase 1: AWS Bedrock).
+
+The matcher in :mod:`agent_bom.cross_env_correlation` ships under a strict
+bar: a ``CORRELATES_WITH`` edge requires the local agent and the cloud agent
+to agree on the **full triplet** of strong identity signals — cloud account
+ID, region, and model ID. Anything weaker stays in the ``POSSIBLY_CORRELATES_WITH``
+lane so reviewers can see candidates without the platform pretending they are
+the same agent. PR #1994 was closed because earlier matchers did not respect
+this bar; these tests lock the bar in place.
+"""
+
+from __future__ import annotations
+
+from agent_bom.cross_env_correlation import (
+    CorrelationConfidence,
+    correlate_bedrock,
+    correlate_cross_environment,
+)
+
+_BEDROCK_ARN = "arn:aws:bedrock:us-east-1:111122223333:agent/AGENTID01"
+_MODEL = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+_OTHER_MODEL = "amazon.titan-text-express-v1"
+
+
+def _local_agent(
+    *,
+    name: str = "cursor-dev",
+    account_id: str | None = "111122223333",
+    region: str | None = "us-east-1",
+    model_id: str | None = _MODEL,
+    extra_env: dict[str, str] | None = None,
+) -> dict:
+    env: dict[str, str] = {}
+    if account_id is not None:
+        env["AWS_ACCOUNT_ID"] = account_id
+    if region is not None:
+        env["AWS_REGION"] = region
+    if model_id is not None:
+        env["BEDROCK_MODEL_ID"] = model_id
+    if extra_env:
+        env.update(extra_env)
+    return {
+        "name": name,
+        "agent_type": "cursor",
+        "config_path": "/home/dev/.cursor/mcp.json",
+        "version": "0.42.0",
+        "metadata": {},
+        "mcp_servers": [{"name": "bedrock-mcp", "env": env}],
+    }
+
+
+def _cloud_bedrock_agent(
+    *,
+    name: str = "bedrock:prod-agent",
+    arn: str = _BEDROCK_ARN,
+    model_id: str = _MODEL,
+    region: str = "us-east-1",
+    account_id: str = "111122223333",
+) -> dict:
+    return {
+        "name": name,
+        "agent_type": "custom",
+        "config_path": arn,
+        "source": "aws-bedrock",
+        "version": model_id,
+        "metadata": {
+            "cloud_origin": {
+                "provider": "aws",
+                "service": "bedrock",
+                "resource_type": "agent",
+                "resource_id": arn,
+                "resource_name": name.split(":", 1)[-1],
+                "location": region,
+                "scope": {"account_id": account_id} if account_id else {},
+            }
+        },
+        "mcp_servers": [],
+    }
+
+
+def test_full_triplet_match_is_high_confidence() -> None:
+    matches = correlate_bedrock([_local_agent(), _cloud_bedrock_agent()])
+
+    assert len(matches) == 1
+    match = matches[0]
+    assert match.confidence is CorrelationConfidence.HIGH
+    assert set(match.matched_signals) == {"account_id", "region", "model_id"}
+    assert match.cloud_account_id == "111122223333"
+    assert match.cloud_region == "us-east-1"
+    assert match.cloud_model_id == _MODEL
+    assert match.cloud_provider == "aws"
+    assert match.cloud_service == "bedrock"
+    assert "Strong triplet" in match.rationale
+
+
+def test_only_model_id_matches_is_low_confidence() -> None:
+    # Same model ID, different account, different region — the case PR #1994
+    # was rejected for. Must be visible as a low-confidence candidate, never
+    # as the strong CORRELATES_WITH edge.
+    local = _local_agent(account_id="999988887777", region="eu-west-1")
+
+    matches = correlate_bedrock([local, _cloud_bedrock_agent()])
+
+    assert len(matches) == 1
+    match = matches[0]
+    assert match.confidence is CorrelationConfidence.LOW
+    assert match.matched_signals == ("model_id",)
+    assert "Partial match" in match.rationale
+
+
+def test_account_and_region_without_model_is_low_confidence() -> None:
+    # The local agent declares the right AWS scope but does not name the
+    # specific model — still a low-confidence candidate, not a strong match.
+    local = _local_agent(model_id=None)
+
+    matches = correlate_bedrock([local, _cloud_bedrock_agent()])
+
+    assert len(matches) == 1
+    match = matches[0]
+    assert match.confidence is CorrelationConfidence.LOW
+    assert set(match.matched_signals) == {"account_id", "region"}
+
+
+def test_sdk_presence_alone_is_not_a_match() -> None:
+    # Local agent only signals "I have AWS env set" with no Bedrock-shaped
+    # account, region, or model values. The matcher must not emit any edge —
+    # the bar from PR #1994 is exactly this case.
+    local = _local_agent(
+        account_id=None,
+        region=None,
+        model_id=None,
+        extra_env={"AWS_PROFILE": "dev", "AWS_SDK_LOAD_CONFIG": "1"},
+    )
+
+    matches = correlate_bedrock([local, _cloud_bedrock_agent()])
+
+    assert matches == []
+
+
+def test_no_cross_account_false_match_when_only_region_matches() -> None:
+    # Both have us-east-1 but different account IDs and unrelated models.
+    # Region-only is a single weak signal; the matcher must not treat the
+    # local agent as related to a totally different account's model.
+    local = _local_agent(
+        account_id="999988887777",
+        region="us-east-1",
+        model_id=_OTHER_MODEL,
+    )
+
+    matches = correlate_bedrock([local, _cloud_bedrock_agent()])
+
+    assert len(matches) == 1
+    assert matches[0].confidence is CorrelationConfidence.LOW
+    assert matches[0].matched_signals == ("region",)
+
+
+def test_endpoint_url_supplies_region_when_aws_region_is_absent() -> None:
+    local = _local_agent(region=None, extra_env={"AWS_ENDPOINT_URL_BEDROCK": "https://bedrock-runtime.us-east-1.amazonaws.com"})
+
+    matches = correlate_bedrock([local, _cloud_bedrock_agent()])
+
+    assert len(matches) == 1
+    match = matches[0]
+    assert match.confidence is CorrelationConfidence.HIGH
+    assert "region" in match.matched_signals
+
+
+def test_account_id_must_be_twelve_digits() -> None:
+    # A twelve-character non-numeric env value is not an AWS account ID.
+    local = _local_agent(account_id="abcdefghijkl")
+
+    matches = correlate_bedrock([local, _cloud_bedrock_agent()])
+
+    assert len(matches) == 1
+    assert matches[0].confidence is CorrelationConfidence.LOW
+    assert "account_id" not in matches[0].matched_signals
+
+
+def test_unknown_vendor_model_string_is_not_treated_as_bedrock_id() -> None:
+    # A free-text "claude" string is not a valid Bedrock model id (no vendor
+    # prefix). The matcher must reject it so substring tricks don't sneak in.
+    local = _local_agent(model_id="claude")
+
+    matches = correlate_bedrock([local, _cloud_bedrock_agent()])
+
+    assert len(matches) == 1
+    assert matches[0].confidence is CorrelationConfidence.LOW
+    assert "model_id" not in matches[0].matched_signals
+
+
+def test_cross_environment_orchestrator_returns_typed_result() -> None:
+    result = correlate_cross_environment([_local_agent(), _cloud_bedrock_agent()])
+
+    high = result.by_confidence(CorrelationConfidence.HIGH)
+    assert len(high) == 1
+    low = result.by_confidence(CorrelationConfidence.LOW)
+    assert low == ()
+
+
+def test_metadata_aws_block_supplies_signals_when_env_is_absent() -> None:
+    local = {
+        "name": "ci-pipeline",
+        "agent_type": "custom",
+        "config_path": "/repo/.github/workflows/deploy.yml",
+        "version": "",
+        "metadata": {
+            "aws": {
+                "account_id": "111122223333",
+                "region": "us-east-1",
+                "bedrock_model_id": _MODEL,
+            }
+        },
+        "mcp_servers": [],
+    }
+
+    matches = correlate_bedrock([local, _cloud_bedrock_agent()])
+
+    assert len(matches) == 1
+    assert matches[0].confidence is CorrelationConfidence.HIGH

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -685,3 +685,111 @@ class TestFrameworkTopology:
         edge = next(edge for edge in g.edges if edge.source == "framework-agent:crew" and edge.target == "framework-agent:researcher")
         assert edge.relationship == RelationshipType.DELEGATED_TO
         assert edge.evidence["source"] == "source-ast"
+
+
+class TestCrossEnvironmentCorrelation:
+    """Cross-environment correlation lands on the unified graph as edges."""
+
+    def _report_with_local_and_bedrock(self, *, local_account: str, local_region: str, local_model: str | None) -> dict:
+        env: dict[str, str] = {"AWS_ACCOUNT_ID": local_account, "AWS_REGION": local_region}
+        if local_model is not None:
+            env["BEDROCK_MODEL_ID"] = local_model
+        return {
+            "scan_id": "test-cross-env",
+            "agents": [
+                {
+                    "name": "cursor-dev",
+                    "type": "cursor",
+                    "agent_type": "cursor",
+                    "status": "configured",
+                    "config_path": "/home/dev/.cursor/mcp.json",
+                    "version": "0.42.0",
+                    "metadata": {},
+                    "mcp_servers": [
+                        {
+                            "name": "bedrock-mcp",
+                            "command": "python",
+                            "transport": "stdio",
+                            "surface": "mcp-server",
+                            "env": env,
+                            "packages": [],
+                            "tools": [],
+                            "credential_env_vars": [],
+                        }
+                    ],
+                },
+                {
+                    "name": "bedrock:prod-agent",
+                    "type": "custom",
+                    "agent_type": "custom",
+                    "source": "aws-bedrock",
+                    "status": "configured",
+                    "config_path": "arn:aws:bedrock:us-east-1:111122223333:agent/AGENTID01",
+                    "version": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+                    "metadata": {
+                        "cloud_origin": {
+                            "provider": "aws",
+                            "service": "bedrock",
+                            "resource_type": "agent",
+                            "resource_id": "arn:aws:bedrock:us-east-1:111122223333:agent/AGENTID01",
+                            "resource_name": "prod-agent",
+                            "location": "us-east-1",
+                            "scope": {"account_id": "111122223333"},
+                        }
+                    },
+                    "mcp_servers": [],
+                },
+            ],
+        }
+
+    def test_full_triplet_emits_correlates_with_edge(self):
+        report = self._report_with_local_and_bedrock(
+            local_account="111122223333",
+            local_region="us-east-1",
+            local_model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+        )
+
+        g = build_unified_graph_from_report(report)
+
+        edge = next(
+            (edge for edge in g.edges if edge.source == "agent:cursor-dev" and edge.target == "agent:bedrock:prod-agent"),
+            None,
+        )
+        assert edge is not None
+        assert edge.relationship == RelationshipType.CORRELATES_WITH
+        assert edge.evidence["confidence"] == "high"
+        assert set(edge.evidence["matched_signals"]) == {"account_id", "region", "model_id"}
+
+    def test_partial_match_emits_possibly_correlates_with_edge(self):
+        report = self._report_with_local_and_bedrock(
+            local_account="999988887777",
+            local_region="eu-west-1",
+            local_model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+        )
+
+        g = build_unified_graph_from_report(report)
+
+        edge = next(
+            (edge for edge in g.edges if edge.source == "agent:cursor-dev" and edge.target == "agent:bedrock:prod-agent"),
+            None,
+        )
+        assert edge is not None
+        assert edge.relationship == RelationshipType.POSSIBLY_CORRELATES_WITH
+        assert edge.evidence["confidence"] == "low"
+        assert edge.evidence["matched_signals"] == ["model_id"]
+
+    def test_sdk_presence_alone_does_not_emit_edge(self):
+        report = self._report_with_local_and_bedrock(
+            local_account="111122223333",
+            local_region="us-east-1",
+            local_model=None,
+        )
+        # Strip account too — leave only AWS_PROFILE-style noise.
+        report["agents"][0]["mcp_servers"][0]["env"] = {"AWS_PROFILE": "dev"}
+
+        g = build_unified_graph_from_report(report)
+
+        cross_edges = [
+            edge for edge in g.edges if edge.relationship in (RelationshipType.CORRELATES_WITH, RelationshipType.POSSIBLY_CORRELATES_WITH)
+        ]
+        assert cross_edges == []

--- a/ui/lib/graph-schema.ts
+++ b/ui/lib/graph-schema.ts
@@ -65,6 +65,9 @@ export enum RelationshipType {
   INVOKED = "invoked",
   ACCESSED = "accessed",
   DELEGATED_TO = "delegated_to",
+  // Cross-environment correlation (#1892)
+  CORRELATES_WITH = "correlates_with",
+  POSSIBLY_CORRELATES_WITH = "possibly_correlates_with",
 }
 
 export enum NodeStatus {
@@ -334,6 +337,8 @@ export const RELATIONSHIP_COLOR_MAP: Record<string, string> = {
   [RelationshipType.INVOKED]: "#10b981",
   [RelationshipType.ACCESSED]: "#3b82f6",
   [RelationshipType.DELEGATED_TO]: "#a855f7",
+  [RelationshipType.CORRELATES_WITH]: "#0ea5e9",
+  [RelationshipType.POSSIBLY_CORRELATES_WITH]: "#7dd3fc",
 };
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Re-attempts the cross-environment correlation framework that PR #1994 was closed for. The previous matcher counted SDK presence and substring model hits as enough to draw a `correlates_with` edge — that bar conflates unrelated agents across accounts and was rightly rejected. This PR ships the framework under a strict bar with a separate low-confidence lane, and unblocks Phases 2 (#1992 Azure) and 3 (#1993 GCP).

## The bar

A `CORRELATES_WITH` edge requires the local agent and the cloud agent to agree on **all three** strong identity signals for AWS Bedrock:

- cloud account ID,
- region, and
- foundation model ID.

Anything weaker emits a `POSSIBLY_CORRELATES_WITH` edge with a `matched_signals` evidence list so reviewers can see the candidate without the platform pretending it is the same agent. **SDK presence alone never emits an edge.**

## What ships

### Module: `src/agent_bom/cross_env_correlation.py` (new)

- `CorrelationConfidence` (HIGH | LOW), `CorrelationMatch`, `CrossEnvironmentResult` public types.
- `correlate_bedrock(agents)` matcher.
- `correlate_cross_environment(agents)` orchestrator — Phase 2 (Azure) and Phase 3 (GCP) plug in as additional provider matchers here.
- Strict extractors:
  - **Local side** pulls account/region/model from `mcp_servers[].env` (`AWS_ACCOUNT_ID`, `AWS_REGION`, `BEDROCK_MODEL_ID`, `AWS_ENDPOINT_URL_BEDROCK`, …) and from a `metadata.aws` block. Account ID is validated as a 12-digit string. Endpoint URLs are parsed for region.
  - **Cloud side** parses Bedrock ARN for account + region, reads `cloud_origin.scope.account_id` / `location`, and accepts `version` as the foundation model **only when it has a known Bedrock vendor prefix** (`anthropic.`, `amazon.`, `meta.`, `mistral.`, `ai21.`, `cohere.`, `stability.`). The vendor-prefix gate is what stops "claude" or "gpt" from sneaking in as model matches — that was the specific failure mode of #1994.
- Accepts both `Agent` dataclasses and the serialized-dict shape that flows through the graph builder via a small `_AgentView` adapter, so the matcher is callable both from Python tests and from the builder pipeline.

### Graph plumbing

- `src/agent_bom/graph/types.py` — adds `RelationshipType.CORRELATES_WITH` (HIGH) and `RelationshipType.POSSIBLY_CORRELATES_WITH` (LOW) under a new "Cross-environment correlation" section.
- `src/agent_bom/graph/builder.py` — `_add_cross_env_correlation` runs after `_add_framework_topology`. Emits one edge per match with the full evidence dict (confidence, matched_signals, account, region, model, rationale).

### Tests

- `tests/test_cross_env_correlation.py` (new, 10 cases): full-triplet match → HIGH; model-only → LOW; account+region only → LOW; SDK-only → no edge; cross-account region-only → LOW (false-positive guard); endpoint-URL region derivation; account-ID format gate; vendor-prefix gate on model id; orchestrator return shape; `metadata.aws` extraction.
- `tests/test_graph_builder.py::TestCrossEnvironmentCorrelation` (3 new): triplet → `CORRELATES_WITH` edge; partial → `POSSIBLY_CORRELATES_WITH` edge; SDK presence → no cross-env edges.

## Test plan

- [x] `pytest tests/test_cross_env_correlation.py tests/test_graph_builder.py -q` — **47 passed**.
- [x] `ruff check` on touched files — clean.
- [x] `mypy src/agent_bom/cross_env_correlation.py src/agent_bom/graph/builder.py src/agent_bom/graph/types.py` — clean.
- [x] The cross-account region-only case PR #1994 was rejected for is now a regression test.

## Out of scope (next PRs)

- **Phase 2** (#1992) — Azure OpenAI / Functions matcher: subscription ID + region + deployment name.
- **Phase 3** (#1993) — GCP Vertex / Cloud Run matcher: project ID + location + endpoint name.
- New scanner discovery work to populate the local AWS env signals more thoroughly. The framework consumes evidence already present in the scan report; broader discovery is its own work.

Closes #1892 Phase 1. Reopens the path for #1992 and #1993.