### PR TITLE
refactor(ui): extract presentation helpers from lib/api.ts (#1965 phase 1)

### DIFF
--- a/ui/lib/api-format.ts
+++ b/ui/lib/api-format.ts
@@ -1,0 +1,48 @@
+/**
+ * Presentation helpers shared across the dashboard. Lives next to
+ * `api.ts` because callers currently import these from `@/lib/api`;
+ * `api.ts` re-exports each one to preserve that surface while letting
+ * the actual implementations live in this smaller, single-purpose
+ * module. First step toward the broader `ui/lib/api.ts` decomposition
+ * tracked in #1965.
+ */
+
+import type { Agent } from "./api";
+
+export function severityColor(severity: string): string {
+  switch (severity?.toLowerCase()) {
+    case "critical":
+      return "text-red-400 bg-red-950 border-red-800";
+    case "high":
+      return "text-orange-400 bg-orange-950 border-orange-800";
+    case "medium":
+      return "text-yellow-400 bg-yellow-950 border-yellow-800";
+    case "low":
+      return "text-blue-400 bg-blue-950 border-blue-800";
+    default:
+      return "text-zinc-400 bg-zinc-800 border-zinc-700";
+  }
+}
+
+export function severityDot(severity: string): string {
+  switch (severity?.toLowerCase()) {
+    case "critical":
+      return "bg-red-500";
+    case "high":
+      return "bg-orange-500";
+    case "medium":
+      return "bg-yellow-500";
+    case "low":
+      return "bg-blue-500";
+    default:
+      return "bg-zinc-500";
+  }
+}
+
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+
+export function isConfigured(agent: Agent): boolean {
+  return agent.status !== "installed-not-configured";
+}

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -2104,31 +2104,10 @@ export interface AuditIntegrityResponse {
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+//
+// Implementations moved to ./api-format as the first incremental step
+// toward the broader ui/lib/api.ts decomposition tracked in #1965. These
+// re-exports keep every existing `import { severityColor } from "@/lib/api"`
+// working unchanged so callers don't need to migrate in one big bang.
 
-export function severityColor(severity: string): string {
-  switch (severity?.toLowerCase()) {
-    case "critical": return "text-red-400 bg-red-950 border-red-800";
-    case "high":     return "text-orange-400 bg-orange-950 border-orange-800";
-    case "medium":   return "text-yellow-400 bg-yellow-950 border-yellow-800";
-    case "low":      return "text-blue-400 bg-blue-950 border-blue-800";
-    default:         return "text-zinc-400 bg-zinc-800 border-zinc-700";
-  }
-}
-
-export function severityDot(severity: string): string {
-  switch (severity?.toLowerCase()) {
-    case "critical": return "bg-red-500";
-    case "high":     return "bg-orange-500";
-    case "medium":   return "bg-yellow-500";
-    case "low":      return "bg-blue-500";
-    default:         return "bg-zinc-500";
-  }
-}
-
-export function formatDate(iso: string): string {
-  return new Date(iso).toLocaleString();
-}
-
-export function isConfigured(agent: Agent): boolean {
-  return agent.status !== "installed-not-configured";
-}
+export { severityColor, severityDot, formatDate, isConfigured } from "./api-format";


### PR DESCRIPTION
## Summary

First incremental step toward the broader \`ui/lib/api.ts\` decomposition tracked in #1965. The file is currently 2,134 lines — the largest TS module in the dashboard — and bundles three concerns into one module:

1. ~110 type / interface declarations.
2. The \`api\` object with its ~100 method shorthands.
3. Standalone presentation helpers (\`severityColor\`, \`severityDot\`, \`formatDate\`, \`isConfigured\`).

#3 is the smallest, most isolated cluster and the safest to move first. This PR extracts those four helpers into a new \`ui/lib/api-format.ts\` and re-exports them from \`lib/api.ts\` so every existing \`import { severityColor } from \"@/lib/api\"\` keeps working unchanged. **50+ call sites stay untouched.**

## What ships

- \`ui/lib/api-format.ts\` (new) — the four helpers, with their original implementations preserved verbatim.
- \`ui/lib/api.ts\` — implementations replaced by a single \`export { ... } from \"./api-format\"\` re-export. Inline comment links the move to #1965.

## Test plan

- [x] \`npm run typecheck\` — \`tsc --noEmit\` clean.
- [x] \`npm run lint\` — eslint clean.
- [x] \`npm run test:run\` — vitest 144/144 passed.

## Out of scope (future #1965 phases)

- Lifting the type / interface declarations into \`api-types.ts\`.
- Splitting the \`api\` object into per-domain modules (\`api/scan.ts\`, \`api/graph.ts\`, etc.).

Refs #1965 (one phase of that work).