### PR TITLE
chore: audit-3 P2 cleanup — pending-digest ageing gate, role rule, fallback chain, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p>
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
-<p align="center"><b>Open security scanner for AI supply chain and infrastructure — agents, MCP servers, packages, containers, cloud, GPU, and runtime.</b></p>
+<p align="center"><b>Open security scanner for AI supply chain and infrastructure — agents, MCP servers, packages, containers, cloud (AWS, Azure, GCP, Snowflake, Databricks, CoreWeave, Nebius), GPU, and runtime.</b></p>
 
 <p align="center">Every CVE in your AI stack is a credential leak waiting to happen. <code>agent-bom</code> follows the chain end-to-end and tells you exactly which fix collapses it.</p>
 

--- a/scripts/check_docker_base_policy.py
+++ b/scripts/check_docker_base_policy.py
@@ -24,8 +24,11 @@ Usage:
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -33,6 +36,13 @@ ROOT = Path(__file__).resolve().parents[1]
 
 FROM_RE = re.compile(r"^\s*FROM\s+(?P<image>\S+)(?:\s+AS\s+\S+)?\s*$", re.IGNORECASE)
 DIGEST_RE = re.compile(r"@sha256:[a-f0-9]{64}$")
+
+# A `# pending-digest` marker is a transitional escape hatch: dependabot's
+# daily docker job is supposed to replace it within 24h. Anything older
+# than this window is the marker overstaying its purpose, which is what
+# the audit-3 finding flagged. Override via `PENDING_DIGEST_MAX_AGE_SECONDS`
+# for one-off bootstraps where dependabot needs a longer cycle.
+_PENDING_DIGEST_DEFAULT_MAX_AGE_SECONDS = 24 * 60 * 60
 
 
 @dataclass(frozen=True)
@@ -108,16 +118,57 @@ def _split_image(image: str) -> tuple[str, str | None, str | None]:
     return image, None, digest
 
 
-def _has_pending_digest_marker(lines: list[str], from_line_idx: int) -> bool:
-    # Marker lives on the immediately preceding non-blank line as a comment.
+def _find_pending_digest_marker_line(lines: list[str], from_line_idx: int) -> int | None:
+    """Return the 1-based line number of the marker, or None if absent.
+
+    Marker lives on the immediately preceding non-blank line as a comment.
+    """
     for i in range(from_line_idx - 1, -1, -1):
         stripped = lines[i].strip()
         if not stripped:
             continue
         if stripped.startswith("#") and "pending-digest" in stripped:
-            return True
-        return False
-    return False
+            return i + 1
+        return None
+    return None
+
+
+def _pending_digest_max_age_seconds() -> int:
+    raw = (os.environ.get("PENDING_DIGEST_MAX_AGE_SECONDS") or "").strip()
+    if not raw:
+        return _PENDING_DIGEST_DEFAULT_MAX_AGE_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        return _PENDING_DIGEST_DEFAULT_MAX_AGE_SECONDS
+    return max(value, 0)
+
+
+def _git_blame_commit_timestamp(path: Path, line_number: int) -> int | None:
+    """Return the commit Unix timestamp for a given line, or None on failure.
+
+    Uses `git blame --porcelain` so the timestamp comes from the commit that
+    last touched the line, not the file. Skips silently when git is not
+    available or the file is not tracked — the policy gate degrades to its
+    pre-ageing behaviour rather than blocking unrelated work.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "blame", "--porcelain", "-L", f"{line_number},{line_number}", "--", str(path)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    for entry in result.stdout.splitlines():
+        if entry.startswith("committer-time "):
+            try:
+                return int(entry.split(" ", 1)[1].strip())
+            except (IndexError, ValueError):
+                return None
+    return None
 
 
 def _policy_key(path: Path) -> str | None:
@@ -177,13 +228,28 @@ def main() -> int:
                     f"Rationale: {policy.rationale}"
                 )
             if digest is None:
-                if not _has_pending_digest_marker(lines, idx):
+                marker_line = _find_pending_digest_marker_line(lines, idx)
+                if marker_line is None:
                     problems.append(
                         f"{rel}:{idx + 1}: FROM line is not digest-pinned (@sha256:...) and no "
                         "`# pending-digest` marker on the preceding line. Either pin the digest "
                         "or add the marker (transitional only — dependabot's daily docker job "
                         "fills it in within 24h)."
                     )
+                    continue
+                marker_ts = _git_blame_commit_timestamp(path, marker_line)
+                max_age = _pending_digest_max_age_seconds()
+                if marker_ts is not None and max_age > 0:
+                    age = int(time.time()) - marker_ts
+                    if age > max_age:
+                        age_hours = age // 3600
+                        max_hours = max_age // 3600
+                        problems.append(
+                            f"{rel}:{marker_line}: `# pending-digest` marker is {age_hours}h old "
+                            f"(policy max {max_hours}h). Dependabot should have replaced it by now — "
+                            "either pin the digest manually, retrigger dependabot's docker job, or "
+                            "rebump the marker line if the bump was deliberately delayed."
+                        )
 
     missing = sorted(set(POLICY) - seen_keys)
     if missing:

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -665,8 +665,13 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
     )
 
     # Ordered route rules so narrower enterprise paths win over broad prefixes.
+    # Narrower posture sub-paths come before the `/v1/posture` viewer rule for
+    # readability — they would inherit `viewer` via the broad prefix anyway,
+    # but listing them explicitly makes the role intent of each subroute easy
+    # to grep and audit.
     _ROLE_RULES: tuple[tuple[str, str, str], ...] = (
         ("GET", "/v1/compliance", "viewer"),
+        ("GET", "/v1/posture/backpressure", "viewer"),
         ("GET", "/v1/posture", "viewer"),
         ("GET", "/v1/auth/debug", "viewer"),
         ("GET", "/v1/auth/me", "viewer"),

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -948,8 +948,18 @@ def _add_agent_cloud_lineage(
     if not isinstance(origin, dict):
         return
 
-    provider = _clean_graph_part(origin.get("provider")) or _clean_graph_part(agent_dict.get("source")) or "cloud"
-    service = _clean_graph_part(origin.get("service")) or "unknown-service"
+    # Cloud sources are conventionally named `<provider>-<service>` (e.g.
+    # "aws-bedrock", "azure-openai", "gcp-vertex-ai") so we can recover the
+    # service name from the agent's `source` field when `cloud_origin` lacks
+    # it. This mirrors the secondary fallback chain that `provider` already
+    # uses and avoids the literal "unknown-service" placeholder leaking into
+    # the graph just because one cloud discoverer forgot to populate the
+    # service slot.
+    raw_source = str(agent_dict.get("source") or "").strip()
+    source_service_fallback = raw_source.split("-", 1)[1] if "-" in raw_source else ""
+
+    provider = _clean_graph_part(origin.get("provider")) or _clean_graph_part(raw_source) or "cloud"
+    service = _clean_graph_part(origin.get("service")) or _clean_graph_part(source_service_fallback) or "unknown-service"
     resource_type = _clean_graph_part(origin.get("resource_type")) or "resource"
     resource_id = _clean_graph_part(origin.get("resource_id")) or _clean_graph_part(origin.get("resource_name"))
     if not resource_id:


### PR DESCRIPTION
## Summary

Closes the four small items left over from audit-3 in one focused PR. Every fix is either a CI safety net, a clarity edit, or a defensive fallback — non-blocking by design.

## What ships

### 1. \`pending-digest\` marker ageing CI gate

\`scripts/check_docker_base_policy.py\` previously accepted any \`# pending-digest\` marker indefinitely. The audit's concern: the four markers across \`ui/Dockerfile\` would silently outstay their stated 24h window if dependabot's docker job missed the bump.

Now the script reads each marker's \`git blame --porcelain\` committer-time and fails the gate if the marker is older than \`PENDING_DIGEST_MAX_AGE_SECONDS\` (default **86400 = 24h**, override via env for one-off bootstraps). When git is not available or the file is untracked the check degrades to its previous behaviour rather than blocking unrelated work.

### 2. Explicit \`_ROLE_RULES\` entry for \`/v1/posture/backpressure\`

Adds the narrower entry before \`/v1/posture\` for grep/audit clarity. The broader prefix already covered the route via \`path.startswith\`, so this is **intent-only** — no behaviour change.

### 3. \`_clean_graph_part\` fallback chain for \`service\`

\`provider\` already had a two-source chain (\`origin.get(\"provider\")\` → \`agent_dict.get(\"source\")\` → \`\"cloud\"\`), but \`service\` jumped straight to the \`\"unknown-service\"\` literal. Cloud sources are conventionally named \`<provider>-<service>\` (e.g. \`aws-bedrock\`, \`azure-openai\`, \`gcp-vertex-ai\`), so we can recover the service segment from \`agent_dict.get(\"source\")\` when \`cloud_origin\` forgets to populate it. \`resource_type\` keeps the literal placeholder — there is no defensible secondary source to chain to.

### 4. README cloud CSP inventory

\`README.md:17\` listed \"cloud\" without enumerating which CSPs the scanner actually covers. Updated to \`cloud (AWS, Azure, GCP, Snowflake, Databricks, CoreWeave, Nebius)\` so first-time readers see the breadth in the storefront line.

## Test plan

- [x] \`pytest tests/test_graph_builder.py tests/test_api_operator_policy.py -q\` — **74 passed**.
- [x] \`python scripts/check_docker_base_policy.py\` — OK: 8 Dockerfile(s) match the base-image policy. Markers are 5.5h old, well under 24h.
- [x] \`python scripts/check_release_consistency.py\` — clean (README change is to the descriptive line, not an asserted marker).
- [x] \`ruff check\` + \`mypy\` on touched files — clean.

## No tracking issue

audit-3 is the user-shared audit thread, not a GitHub issue, so no \`Closes #\` link applies.