### PR TITLE
feat(contracts): generate JSON Schema v1 from Pydantic API models (#1963)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,15 +624,17 @@ jobs:
       - name: Verify product surface contract
         run: python scripts/check_product_surface_contract.py
 
+      - name: Install dependencies for CLI smoke checks
+        run: uv sync --frozen --extra dev --extra api --extra mcp-server
+
       - name: Verify v1 schemas match Pydantic models
         # Drift gate for #1963: any change to agent_bom.api.models must be
         # accompanied by a refreshed docs/schemas/v1/ so SDK consumers are
         # never reading a stale contract. Regenerate locally with
-        # `python scripts/generate_v1_schemas.py` to refresh.
-        run: PYTHONPATH=src python scripts/generate_v1_schemas.py --check
-
-      - name: Install dependencies for CLI smoke checks
-        run: uv sync --frozen --extra dev --extra api --extra mcp-server
+        # `python scripts/generate_v1_schemas.py` to refresh. Runs after
+        # `uv sync --extra api` so pydantic + the model module are
+        # importable.
+        run: uv run python scripts/generate_v1_schemas.py --check
 
       - name: Validate canonical README commands parse
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,6 +624,13 @@ jobs:
       - name: Verify product surface contract
         run: python scripts/check_product_surface_contract.py
 
+      - name: Verify v1 schemas match Pydantic models
+        # Drift gate for #1963: any change to agent_bom.api.models must be
+        # accompanied by a refreshed docs/schemas/v1/ so SDK consumers are
+        # never reading a stale contract. Regenerate locally with
+        # `python scripts/generate_v1_schemas.py` to refresh.
+        run: PYTHONPATH=src python scripts/generate_v1_schemas.py --check
+
       - name: Install dependencies for CLI smoke checks
         run: uv sync --frozen --extra dev --extra api --extra mcp-server
 

--- a/docs/schemas/v1/AnalyticsHealth.json
+++ b/docs/schemas/v1/AnalyticsHealth.json
@@ -1,0 +1,50 @@
+{
+  "properties": {
+    "backend": {
+      "default": "disabled",
+      "title": "Backend",
+      "type": "string"
+    },
+    "buffered": {
+      "default": false,
+      "title": "Buffered",
+      "type": "boolean"
+    },
+    "clickhouse_url_configured": {
+      "default": false,
+      "title": "Clickhouse Url Configured",
+      "type": "boolean"
+    },
+    "enabled": {
+      "default": false,
+      "title": "Enabled",
+      "type": "boolean"
+    },
+    "flush_interval_seconds": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Flush Interval Seconds"
+    },
+    "max_batch": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Max Batch"
+    }
+  },
+  "title": "AnalyticsHealth",
+  "type": "object"
+}

--- a/docs/schemas/v1/BrowserExtensionsRequest.json
+++ b/docs/schemas/v1/BrowserExtensionsRequest.json
@@ -1,0 +1,12 @@
+{
+  "description": "Request body for POST /v1/scan/browser-extensions.",
+  "properties": {
+    "include_low_risk": {
+      "default": false,
+      "title": "Include Low Risk",
+      "type": "boolean"
+    }
+  },
+  "title": "BrowserExtensionsRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/ComplianceAuditIntegrity.json
+++ b/docs/schemas/v1/ComplianceAuditIntegrity.json
@@ -1,0 +1,21 @@
+{
+  "properties": {
+    "checked": {
+      "default": 0,
+      "title": "Checked",
+      "type": "integer"
+    },
+    "tampered": {
+      "default": 0,
+      "title": "Tampered",
+      "type": "integer"
+    },
+    "verified": {
+      "default": 0,
+      "title": "Verified",
+      "type": "integer"
+    }
+  },
+  "title": "ComplianceAuditIntegrity",
+  "type": "object"
+}

--- a/docs/schemas/v1/ComplianceEvidenceItem.json
+++ b/docs/schemas/v1/ComplianceEvidenceItem.json
@@ -1,0 +1,85 @@
+{
+  "properties": {
+    "agents_at_risk": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Agents At Risk",
+      "type": "array"
+    },
+    "control_tag": {
+      "title": "Control Tag",
+      "type": "string"
+    },
+    "finding_id": {
+      "title": "Finding Id",
+      "type": "string"
+    },
+    "fixed_version": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Fixed Version"
+    },
+    "package": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Package"
+    },
+    "scan_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Scan Id"
+    },
+    "severity": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Severity"
+    },
+    "vulnerability_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Vulnerability Id"
+    }
+  },
+  "required": [
+    "finding_id",
+    "control_tag"
+  ],
+  "title": "ComplianceEvidenceItem",
+  "type": "object"
+}

--- a/docs/schemas/v1/ComplianceReportBundle.json
+++ b/docs/schemas/v1/ComplianceReportBundle.json
@@ -1,0 +1,328 @@
+{
+  "$defs": {
+    "ComplianceAuditIntegrity": {
+      "properties": {
+        "checked": {
+          "default": 0,
+          "title": "Checked",
+          "type": "integer"
+        },
+        "tampered": {
+          "default": 0,
+          "title": "Tampered",
+          "type": "integer"
+        },
+        "verified": {
+          "default": 0,
+          "title": "Verified",
+          "type": "integer"
+        }
+      },
+      "title": "ComplianceAuditIntegrity",
+      "type": "object"
+    },
+    "ComplianceEvidenceItem": {
+      "properties": {
+        "agents_at_risk": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Agents At Risk",
+          "type": "array"
+        },
+        "control_tag": {
+          "title": "Control Tag",
+          "type": "string"
+        },
+        "finding_id": {
+          "title": "Finding Id",
+          "type": "string"
+        },
+        "fixed_version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Fixed Version"
+        },
+        "package": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Package"
+        },
+        "scan_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Scan Id"
+        },
+        "severity": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Severity"
+        },
+        "vulnerability_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Vulnerability Id"
+        }
+      },
+      "required": [
+        "finding_id",
+        "control_tag"
+      ],
+      "title": "ComplianceEvidenceItem",
+      "type": "object"
+    },
+    "ComplianceReportControl": {
+      "properties": {
+        "control_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Control Id"
+        },
+        "control_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Control Name"
+        },
+        "evidence": {
+          "items": {
+            "$ref": "#/$defs/ComplianceEvidenceItem"
+          },
+          "title": "Evidence",
+          "type": "array"
+        },
+        "finding_count": {
+          "default": 0,
+          "title": "Finding Count",
+          "type": "integer"
+        },
+        "status": {
+          "default": "unknown",
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "title": "ComplianceReportControl",
+      "type": "object"
+    },
+    "ComplianceReportScope": {
+      "properties": {
+        "audit_event_count": {
+          "default": 0,
+          "title": "Audit Event Count",
+          "type": "integer"
+        },
+        "control_count": {
+          "default": 0,
+          "title": "Control Count",
+          "type": "integer"
+        },
+        "finding_count": {
+          "default": 0,
+          "title": "Finding Count",
+          "type": "integer"
+        },
+        "since": {
+          "title": "Since",
+          "type": "string"
+        },
+        "until": {
+          "title": "Until",
+          "type": "string"
+        }
+      },
+      "required": [
+        "since",
+        "until"
+      ],
+      "title": "ComplianceReportScope",
+      "type": "object"
+    },
+    "ComplianceReportSummary": {
+      "properties": {
+        "fail": {
+          "default": 0,
+          "title": "Fail",
+          "type": "integer"
+        },
+        "pass": {
+          "title": "Pass",
+          "type": "integer"
+        },
+        "score": {
+          "default": 100.0,
+          "title": "Score",
+          "type": "number"
+        },
+        "warning": {
+          "default": 0,
+          "title": "Warning",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "pass"
+      ],
+      "title": "ComplianceReportSummary",
+      "type": "object"
+    },
+    "ComplianceThreatModel": {
+      "properties": {
+        "confidentiality": {
+          "title": "Confidentiality",
+          "type": "string"
+        },
+        "integrity": {
+          "title": "Integrity",
+          "type": "string"
+        },
+        "non_repudiation": {
+          "title": "Non Repudiation",
+          "type": "string"
+        },
+        "replay": {
+          "title": "Replay",
+          "type": "string"
+        }
+      },
+      "required": [
+        "integrity",
+        "confidentiality",
+        "replay",
+        "non_repudiation"
+      ],
+      "title": "ComplianceThreatModel",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "audit_events": {
+      "items": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Audit Events",
+      "type": "array"
+    },
+    "audit_log_integrity": {
+      "$ref": "#/$defs/ComplianceAuditIntegrity"
+    },
+    "controls": {
+      "items": {
+        "$ref": "#/$defs/ComplianceReportControl"
+      },
+      "title": "Controls",
+      "type": "array"
+    },
+    "expires_at": {
+      "title": "Expires At",
+      "type": "string"
+    },
+    "framework": {
+      "title": "Framework",
+      "type": "string"
+    },
+    "framework_key": {
+      "title": "Framework Key",
+      "type": "string"
+    },
+    "framework_label": {
+      "title": "Framework Label",
+      "type": "string"
+    },
+    "generated_at": {
+      "title": "Generated At",
+      "type": "string"
+    },
+    "nonce": {
+      "title": "Nonce",
+      "type": "string"
+    },
+    "schema_version": {
+      "default": "v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "scope": {
+      "$ref": "#/$defs/ComplianceReportScope"
+    },
+    "signature_algorithm": {
+      "title": "Signature Algorithm",
+      "type": "string"
+    },
+    "summary": {
+      "$ref": "#/$defs/ComplianceReportSummary"
+    },
+    "tenant_id": {
+      "title": "Tenant Id",
+      "type": "string"
+    },
+    "threat_model": {
+      "$ref": "#/$defs/ComplianceThreatModel"
+    }
+  },
+  "required": [
+    "framework",
+    "framework_key",
+    "framework_label",
+    "tenant_id",
+    "generated_at",
+    "expires_at",
+    "nonce",
+    "scope",
+    "summary",
+    "audit_log_integrity",
+    "signature_algorithm",
+    "threat_model"
+  ],
+  "title": "ComplianceReportBundle",
+  "type": "object"
+}

--- a/docs/schemas/v1/ComplianceReportControl.json
+++ b/docs/schemas/v1/ComplianceReportControl.json
@@ -1,0 +1,134 @@
+{
+  "$defs": {
+    "ComplianceEvidenceItem": {
+      "properties": {
+        "agents_at_risk": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Agents At Risk",
+          "type": "array"
+        },
+        "control_tag": {
+          "title": "Control Tag",
+          "type": "string"
+        },
+        "finding_id": {
+          "title": "Finding Id",
+          "type": "string"
+        },
+        "fixed_version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Fixed Version"
+        },
+        "package": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Package"
+        },
+        "scan_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Scan Id"
+        },
+        "severity": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Severity"
+        },
+        "vulnerability_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Vulnerability Id"
+        }
+      },
+      "required": [
+        "finding_id",
+        "control_tag"
+      ],
+      "title": "ComplianceEvidenceItem",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "control_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Control Id"
+    },
+    "control_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Control Name"
+    },
+    "evidence": {
+      "items": {
+        "$ref": "#/$defs/ComplianceEvidenceItem"
+      },
+      "title": "Evidence",
+      "type": "array"
+    },
+    "finding_count": {
+      "default": 0,
+      "title": "Finding Count",
+      "type": "integer"
+    },
+    "status": {
+      "default": "unknown",
+      "title": "Status",
+      "type": "string"
+    }
+  },
+  "title": "ComplianceReportControl",
+  "type": "object"
+}

--- a/docs/schemas/v1/ComplianceReportScope.json
+++ b/docs/schemas/v1/ComplianceReportScope.json
@@ -1,0 +1,33 @@
+{
+  "properties": {
+    "audit_event_count": {
+      "default": 0,
+      "title": "Audit Event Count",
+      "type": "integer"
+    },
+    "control_count": {
+      "default": 0,
+      "title": "Control Count",
+      "type": "integer"
+    },
+    "finding_count": {
+      "default": 0,
+      "title": "Finding Count",
+      "type": "integer"
+    },
+    "since": {
+      "title": "Since",
+      "type": "string"
+    },
+    "until": {
+      "title": "Until",
+      "type": "string"
+    }
+  },
+  "required": [
+    "since",
+    "until"
+  ],
+  "title": "ComplianceReportScope",
+  "type": "object"
+}

--- a/docs/schemas/v1/ComplianceReportSummary.json
+++ b/docs/schemas/v1/ComplianceReportSummary.json
@@ -1,0 +1,28 @@
+{
+  "properties": {
+    "fail": {
+      "default": 0,
+      "title": "Fail",
+      "type": "integer"
+    },
+    "pass": {
+      "title": "Pass",
+      "type": "integer"
+    },
+    "score": {
+      "default": 100.0,
+      "title": "Score",
+      "type": "number"
+    },
+    "warning": {
+      "default": 0,
+      "title": "Warning",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "pass"
+  ],
+  "title": "ComplianceReportSummary",
+  "type": "object"
+}

--- a/docs/schemas/v1/ComplianceThreatModel.json
+++ b/docs/schemas/v1/ComplianceThreatModel.json
@@ -1,0 +1,28 @@
+{
+  "properties": {
+    "confidentiality": {
+      "title": "Confidentiality",
+      "type": "string"
+    },
+    "integrity": {
+      "title": "Integrity",
+      "type": "string"
+    },
+    "non_repudiation": {
+      "title": "Non Repudiation",
+      "type": "string"
+    },
+    "replay": {
+      "title": "Replay",
+      "type": "string"
+    }
+  },
+  "required": [
+    "integrity",
+    "confidentiality",
+    "replay",
+    "non_repudiation"
+  ],
+  "title": "ComplianceThreatModel",
+  "type": "object"
+}

--- a/docs/schemas/v1/CreateKeyRequest.json
+++ b/docs/schemas/v1/CreateKeyRequest.json
@@ -1,0 +1,37 @@
+{
+  "properties": {
+    "expires_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Expires At"
+    },
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "role": {
+      "default": "viewer",
+      "title": "Role",
+      "type": "string"
+    },
+    "scopes": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Scopes",
+      "type": "array"
+    }
+  },
+  "required": [
+    "name"
+  ],
+  "title": "CreateKeyRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/DatasetCardsRequest.json
+++ b/docs/schemas/v1/DatasetCardsRequest.json
@@ -1,0 +1,17 @@
+{
+  "description": "Request body for POST /v1/scan/dataset-cards.",
+  "properties": {
+    "directories": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Directories",
+      "type": "array"
+    }
+  },
+  "required": [
+    "directories"
+  ],
+  "title": "DatasetCardsRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/EvaluateRequest.json
+++ b/docs/schemas/v1/EvaluateRequest.json
@@ -1,0 +1,23 @@
+{
+  "properties": {
+    "agent_name": {
+      "default": "",
+      "title": "Agent Name",
+      "type": "string"
+    },
+    "arguments": {
+      "additionalProperties": true,
+      "title": "Arguments",
+      "type": "object"
+    },
+    "tool_name": {
+      "title": "Tool Name",
+      "type": "string"
+    }
+  },
+  "required": [
+    "tool_name"
+  ],
+  "title": "EvaluateRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/ExceptionRequest.json
+++ b/docs/schemas/v1/ExceptionRequest.json
@@ -1,0 +1,43 @@
+{
+  "properties": {
+    "expires_at": {
+      "default": "",
+      "title": "Expires At",
+      "type": "string"
+    },
+    "package_name": {
+      "title": "Package Name",
+      "type": "string"
+    },
+    "reason": {
+      "default": "",
+      "title": "Reason",
+      "type": "string"
+    },
+    "requested_by": {
+      "default": "",
+      "title": "Requested By",
+      "type": "string"
+    },
+    "server_name": {
+      "default": "",
+      "title": "Server Name",
+      "type": "string"
+    },
+    "tenant_id": {
+      "default": "default",
+      "title": "Tenant Id",
+      "type": "string"
+    },
+    "vuln_id": {
+      "title": "Vuln Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "vuln_id",
+    "package_name"
+  ],
+  "title": "ExceptionRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/FalsePositiveRequest.json
+++ b/docs/schemas/v1/FalsePositiveRequest.json
@@ -1,0 +1,29 @@
+{
+  "description": "Request body for POST /v1/findings/false-positive.",
+  "properties": {
+    "marked_by": {
+      "default": "",
+      "title": "Marked By",
+      "type": "string"
+    },
+    "package": {
+      "title": "Package",
+      "type": "string"
+    },
+    "reason": {
+      "default": "",
+      "title": "Reason",
+      "type": "string"
+    },
+    "vulnerability_id": {
+      "title": "Vulnerability Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "vulnerability_id",
+    "package"
+  ],
+  "title": "FalsePositiveRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/FindingFeedbackRequest.json
+++ b/docs/schemas/v1/FindingFeedbackRequest.json
@@ -1,0 +1,52 @@
+{
+  "description": "Request body for POST /v1/findings/feedback.",
+  "properties": {
+    "expires_at": {
+      "default": "",
+      "maxLength": 64,
+      "title": "Expires At",
+      "type": "string"
+    },
+    "package": {
+      "default": "*",
+      "maxLength": 256,
+      "minLength": 1,
+      "title": "Package",
+      "type": "string"
+    },
+    "reason": {
+      "default": "",
+      "maxLength": 2000,
+      "title": "Reason",
+      "type": "string"
+    },
+    "server_name": {
+      "default": "",
+      "maxLength": 256,
+      "title": "Server Name",
+      "type": "string"
+    },
+    "state": {
+      "default": "false_positive",
+      "enum": [
+        "false_positive",
+        "accepted_risk",
+        "not_applicable",
+        "fixed_verified"
+      ],
+      "title": "State",
+      "type": "string"
+    },
+    "vulnerability_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "title": "Vulnerability Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "vulnerability_id"
+  ],
+  "title": "FindingFeedbackRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/FleetAgentUpdate.json
+++ b/docs/schemas/v1/FleetAgentUpdate.json
@@ -1,0 +1,57 @@
+{
+  "properties": {
+    "environment": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Environment"
+    },
+    "notes": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Notes"
+    },
+    "owner": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Owner"
+    },
+    "tags": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Tags"
+    }
+  },
+  "title": "FleetAgentUpdate",
+  "type": "object"
+}

--- a/docs/schemas/v1/HealthResponse.json
+++ b/docs/schemas/v1/HealthResponse.json
@@ -1,0 +1,179 @@
+{
+  "$defs": {
+    "AnalyticsHealth": {
+      "properties": {
+        "backend": {
+          "default": "disabled",
+          "title": "Backend",
+          "type": "string"
+        },
+        "buffered": {
+          "default": false,
+          "title": "Buffered",
+          "type": "boolean"
+        },
+        "clickhouse_url_configured": {
+          "default": false,
+          "title": "Clickhouse Url Configured",
+          "type": "boolean"
+        },
+        "enabled": {
+          "default": false,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "flush_interval_seconds": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Flush Interval Seconds"
+        },
+        "max_batch": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Batch"
+        }
+      },
+      "title": "AnalyticsHealth",
+      "type": "object"
+    },
+    "StorageHealth": {
+      "properties": {
+        "audit_log": {
+          "default": "inmemory",
+          "title": "Audit Log",
+          "type": "string"
+        },
+        "control_plane_backend": {
+          "default": "inmemory",
+          "title": "Control Plane Backend",
+          "type": "string"
+        },
+        "exception_store": {
+          "default": "inmemory",
+          "title": "Exception Store",
+          "type": "string"
+        },
+        "fleet_store": {
+          "default": "inmemory",
+          "title": "Fleet Store",
+          "type": "string"
+        },
+        "graph_store": {
+          "default": "inmemory",
+          "title": "Graph Store",
+          "type": "string"
+        },
+        "job_store": {
+          "default": "inmemory",
+          "title": "Job Store",
+          "type": "string"
+        },
+        "key_store": {
+          "default": "inmemory",
+          "title": "Key Store",
+          "type": "string"
+        },
+        "policy_store": {
+          "default": "inmemory",
+          "title": "Policy Store",
+          "type": "string"
+        },
+        "schedule_store": {
+          "default": "inmemory",
+          "title": "Schedule Store",
+          "type": "string"
+        },
+        "source_store": {
+          "default": "inmemory",
+          "title": "Source Store",
+          "type": "string"
+        },
+        "trend_store": {
+          "default": "inmemory",
+          "title": "Trend Store",
+          "type": "string"
+        }
+      },
+      "title": "StorageHealth",
+      "type": "object"
+    },
+    "TracingHealth": {
+      "properties": {
+        "otlp_endpoint_configured": {
+          "default": false,
+          "title": "Otlp Endpoint Configured",
+          "type": "boolean"
+        },
+        "otlp_export": {
+          "default": "disabled",
+          "title": "Otlp Export",
+          "type": "string"
+        },
+        "otlp_headers_configured": {
+          "default": false,
+          "title": "Otlp Headers Configured",
+          "type": "boolean"
+        },
+        "w3c_baggage": {
+          "default": true,
+          "title": "W3C Baggage",
+          "type": "boolean"
+        },
+        "w3c_trace_context": {
+          "default": true,
+          "title": "W3C Trace Context",
+          "type": "boolean"
+        },
+        "w3c_tracestate": {
+          "default": true,
+          "title": "W3C Tracestate",
+          "type": "boolean"
+        }
+      },
+      "title": "TracingHealth",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "analytics": {
+      "$ref": "#/$defs/AnalyticsHealth"
+    },
+    "status": {
+      "default": "ok",
+      "title": "Status",
+      "type": "string"
+    },
+    "storage": {
+      "$ref": "#/$defs/StorageHealth"
+    },
+    "tracing": {
+      "$ref": "#/$defs/TracingHealth"
+    },
+    "version": {
+      "title": "Version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "version",
+    "tracing",
+    "analytics",
+    "storage"
+  ],
+  "title": "HealthResponse",
+  "type": "object"
+}

--- a/docs/schemas/v1/JiraTicketRequest.json
+++ b/docs/schemas/v1/JiraTicketRequest.json
@@ -1,0 +1,30 @@
+{
+  "description": "Request body for POST /v1/findings/jira.",
+  "properties": {
+    "email": {
+      "title": "Email",
+      "type": "string"
+    },
+    "finding": {
+      "additionalProperties": true,
+      "title": "Finding",
+      "type": "object"
+    },
+    "jira_url": {
+      "title": "Jira Url",
+      "type": "string"
+    },
+    "project_key": {
+      "title": "Project Key",
+      "type": "string"
+    }
+  },
+  "required": [
+    "jira_url",
+    "email",
+    "project_key",
+    "finding"
+  ],
+  "title": "JiraTicketRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/ModelFilesRequest.json
+++ b/docs/schemas/v1/ModelFilesRequest.json
@@ -1,0 +1,22 @@
+{
+  "description": "Request body for POST /v1/scan/model-files.",
+  "properties": {
+    "directories": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Directories",
+      "type": "array"
+    },
+    "verify_hashes": {
+      "default": false,
+      "title": "Verify Hashes",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "directories"
+  ],
+  "title": "ModelFilesRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/ModelProvenanceRequest.json
+++ b/docs/schemas/v1/ModelProvenanceRequest.json
@@ -1,0 +1,21 @@
+{
+  "description": "Request body for POST /v1/scan/model-provenance.",
+  "properties": {
+    "hf_models": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Hf Models",
+      "type": "array"
+    },
+    "ollama_models": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Ollama Models",
+      "type": "array"
+    }
+  },
+  "title": "ModelProvenanceRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/PolicyCreate.json
+++ b/docs/schemas/v1/PolicyCreate.json
@@ -1,0 +1,57 @@
+{
+  "properties": {
+    "bound_agent_types": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Bound Agent Types",
+      "type": "array"
+    },
+    "bound_agents": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Bound Agents",
+      "type": "array"
+    },
+    "bound_environments": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Bound Environments",
+      "type": "array"
+    },
+    "description": {
+      "default": "",
+      "title": "Description",
+      "type": "string"
+    },
+    "enabled": {
+      "default": true,
+      "title": "Enabled",
+      "type": "boolean"
+    },
+    "mode": {
+      "default": "audit",
+      "title": "Mode",
+      "type": "string"
+    },
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "rules": {
+      "items": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Rules",
+      "type": "array"
+    }
+  },
+  "required": [
+    "name"
+  ],
+  "title": "PolicyCreate",
+  "type": "object"
+}

--- a/docs/schemas/v1/PolicyUpdate.json
+++ b/docs/schemas/v1/PolicyUpdate.json
@@ -1,0 +1,115 @@
+{
+  "properties": {
+    "bound_agent_types": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Bound Agent Types"
+    },
+    "bound_agents": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Bound Agents"
+    },
+    "bound_environments": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Bound Environments"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Description"
+    },
+    "enabled": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Enabled"
+    },
+    "mode": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Mode"
+    },
+    "name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Name"
+    },
+    "rules": {
+      "anyOf": [
+        {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Rules"
+    }
+  },
+  "title": "PolicyUpdate",
+  "type": "object"
+}

--- a/docs/schemas/v1/PromptScanRequest.json
+++ b/docs/schemas/v1/PromptScanRequest.json
@@ -1,0 +1,21 @@
+{
+  "description": "Request body for POST /v1/scan/prompt-scan.",
+  "properties": {
+    "directories": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Directories",
+      "type": "array"
+    },
+    "files": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Files",
+      "type": "array"
+    }
+  },
+  "title": "PromptScanRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/ProxyAuditIngestRequest.json
+++ b/docs/schemas/v1/ProxyAuditIngestRequest.json
@@ -1,0 +1,42 @@
+{
+  "properties": {
+    "alerts": {
+      "items": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Alerts",
+      "type": "array"
+    },
+    "idempotency_key": {
+      "default": "",
+      "title": "Idempotency Key",
+      "type": "string"
+    },
+    "session_id": {
+      "default": "",
+      "title": "Session Id",
+      "type": "string"
+    },
+    "source_id": {
+      "default": "",
+      "title": "Source Id",
+      "type": "string"
+    },
+    "summary": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Summary"
+    }
+  },
+  "title": "ProxyAuditIngestRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/PushPayload.json
+++ b/docs/schemas/v1/PushPayload.json
@@ -1,0 +1,48 @@
+{
+  "additionalProperties": true,
+  "properties": {
+    "agents": {
+      "items": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Agents",
+      "type": "array"
+    },
+    "blast_radii": {
+      "items": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "title": "Blast Radii",
+      "type": "array"
+    },
+    "idempotency_key": {
+      "default": "",
+      "title": "Idempotency Key",
+      "type": "string"
+    },
+    "source_id": {
+      "default": "",
+      "title": "Source Id",
+      "type": "string"
+    },
+    "warnings": {
+      "items": {
+        "anyOf": [
+          {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "title": "Warnings",
+      "type": "array"
+    }
+  },
+  "title": "PushPayload",
+  "type": "object"
+}

--- a/docs/schemas/v1/RotateKeyRequest.json
+++ b/docs/schemas/v1/RotateKeyRequest.json
@@ -1,0 +1,42 @@
+{
+  "properties": {
+    "expires_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Expires At"
+    },
+    "name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Name"
+    },
+    "overlap_seconds": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Overlap Seconds"
+    }
+  },
+  "title": "RotateKeyRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/SAMLLoginRequest.json
+++ b/docs/schemas/v1/SAMLLoginRequest.json
@@ -1,0 +1,25 @@
+{
+  "properties": {
+    "relay_state": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Relay State"
+    },
+    "saml_response": {
+      "title": "Saml Response",
+      "type": "string"
+    }
+  },
+  "required": [
+    "saml_response"
+  ],
+  "title": "SAMLLoginRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/ScanJob.json
+++ b/docs/schemas/v1/ScanJob.json
@@ -1,0 +1,287 @@
+{
+  "$defs": {
+    "JobStatus": {
+      "enum": [
+        "pending",
+        "running",
+        "done",
+        "failed",
+        "cancelled"
+      ],
+      "title": "JobStatus",
+      "type": "string"
+    },
+    "ScanRequest": {
+      "description": "Options accepted by POST /v1/scan \u2014 mirrors agent-bom scan CLI flags.",
+      "properties": {
+        "agent_projects": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Agent Projects",
+          "type": "array"
+        },
+        "connectors": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Connectors",
+          "type": "array"
+        },
+        "dynamic_discovery": {
+          "default": false,
+          "title": "Dynamic Discovery",
+          "type": "boolean"
+        },
+        "dynamic_max_depth": {
+          "default": 4,
+          "title": "Dynamic Max Depth",
+          "type": "integer"
+        },
+        "enrich": {
+          "default": false,
+          "title": "Enrich",
+          "type": "boolean"
+        },
+        "exclude_agents": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Exclude Agents",
+          "type": "array"
+        },
+        "exclude_servers": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Exclude Servers",
+          "type": "array"
+        },
+        "filesystem_paths": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Filesystem Paths",
+          "type": "array"
+        },
+        "format": {
+          "default": "json",
+          "title": "Format",
+          "type": "string"
+        },
+        "gha_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Gha Path"
+        },
+        "images": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Images",
+          "type": "array"
+        },
+        "inventory": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inventory"
+        },
+        "jupyter_dirs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Jupyter Dirs",
+          "type": "array"
+        },
+        "k8s": {
+          "default": false,
+          "title": "K8S",
+          "type": "boolean"
+        },
+        "k8s_namespace": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "K8S Namespace"
+        },
+        "min_severity": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Min Severity"
+        },
+        "sbom": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sbom"
+        },
+        "scope_agents": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Scope Agents",
+          "type": "array"
+        },
+        "scope_servers": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Scope Servers",
+          "type": "array"
+        },
+        "tf_dirs": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Tf Dirs",
+          "type": "array"
+        }
+      },
+      "title": "ScanRequest",
+      "type": "object"
+    }
+  },
+  "description": "Represents a running or completed scan job.",
+  "properties": {
+    "completed_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Completed At"
+    },
+    "created_at": {
+      "title": "Created At",
+      "type": "string"
+    },
+    "error": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Error"
+    },
+    "job_id": {
+      "title": "Job Id",
+      "type": "string"
+    },
+    "progress": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Progress",
+      "type": "array"
+    },
+    "request": {
+      "$ref": "#/$defs/ScanRequest"
+    },
+    "result": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Result"
+    },
+    "source_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Source Id"
+    },
+    "started_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Started At"
+    },
+    "status": {
+      "$ref": "#/$defs/JobStatus",
+      "default": "pending"
+    },
+    "tenant_id": {
+      "default": "default",
+      "title": "Tenant Id",
+      "type": "string"
+    },
+    "triggered_by": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Triggered By"
+    }
+  },
+  "required": [
+    "job_id",
+    "created_at",
+    "request"
+  ],
+  "title": "ScanJob",
+  "type": "object"
+}

--- a/docs/schemas/v1/ScanRequest.json
+++ b/docs/schemas/v1/ScanRequest.json
@@ -1,0 +1,162 @@
+{
+  "description": "Options accepted by POST /v1/scan \u2014 mirrors agent-bom scan CLI flags.",
+  "properties": {
+    "agent_projects": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Agent Projects",
+      "type": "array"
+    },
+    "connectors": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Connectors",
+      "type": "array"
+    },
+    "dynamic_discovery": {
+      "default": false,
+      "title": "Dynamic Discovery",
+      "type": "boolean"
+    },
+    "dynamic_max_depth": {
+      "default": 4,
+      "title": "Dynamic Max Depth",
+      "type": "integer"
+    },
+    "enrich": {
+      "default": false,
+      "title": "Enrich",
+      "type": "boolean"
+    },
+    "exclude_agents": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Exclude Agents",
+      "type": "array"
+    },
+    "exclude_servers": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Exclude Servers",
+      "type": "array"
+    },
+    "filesystem_paths": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Filesystem Paths",
+      "type": "array"
+    },
+    "format": {
+      "default": "json",
+      "title": "Format",
+      "type": "string"
+    },
+    "gha_path": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Gha Path"
+    },
+    "images": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Images",
+      "type": "array"
+    },
+    "inventory": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Inventory"
+    },
+    "jupyter_dirs": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Jupyter Dirs",
+      "type": "array"
+    },
+    "k8s": {
+      "default": false,
+      "title": "K8S",
+      "type": "boolean"
+    },
+    "k8s_namespace": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "K8S Namespace"
+    },
+    "min_severity": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Min Severity"
+    },
+    "sbom": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Sbom"
+    },
+    "scope_agents": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Scope Agents",
+      "type": "array"
+    },
+    "scope_servers": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Scope Servers",
+      "type": "array"
+    },
+    "tf_dirs": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Tf Dirs",
+      "type": "array"
+    }
+  },
+  "title": "ScanRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/ScheduleCreate.json
+++ b/docs/schemas/v1/ScheduleCreate.json
@@ -1,0 +1,33 @@
+{
+  "properties": {
+    "cron_expression": {
+      "title": "Cron Expression",
+      "type": "string"
+    },
+    "enabled": {
+      "default": true,
+      "title": "Enabled",
+      "type": "boolean"
+    },
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "scan_config": {
+      "additionalProperties": true,
+      "title": "Scan Config",
+      "type": "object"
+    },
+    "tenant_id": {
+      "default": "default",
+      "title": "Tenant Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "cron_expression"
+  ],
+  "title": "ScheduleCreate",
+  "type": "object"
+}

--- a/docs/schemas/v1/SourceCreate.json
+++ b/docs/schemas/v1/SourceCreate.json
@@ -1,0 +1,93 @@
+{
+  "$defs": {
+    "SourceKind": {
+      "enum": [
+        "scan.repo",
+        "scan.image",
+        "scan.iac",
+        "scan.cloud",
+        "scan.mcp_config",
+        "connector.cloud_read_only",
+        "connector.registry",
+        "connector.warehouse",
+        "ingest.fleet_sync",
+        "ingest.trace_push",
+        "ingest.result_push",
+        "ingest.artifact_import",
+        "runtime.proxy",
+        "runtime.gateway"
+      ],
+      "title": "SourceKind",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "config": {
+      "additionalProperties": true,
+      "title": "Config",
+      "type": "object"
+    },
+    "connector_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Connector Name"
+    },
+    "credential_mode": {
+      "default": "none",
+      "title": "Credential Mode",
+      "type": "string"
+    },
+    "credential_ref": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Credential Ref"
+    },
+    "description": {
+      "default": "",
+      "title": "Description",
+      "type": "string"
+    },
+    "display_name": {
+      "title": "Display Name",
+      "type": "string"
+    },
+    "enabled": {
+      "default": true,
+      "title": "Enabled",
+      "type": "boolean"
+    },
+    "kind": {
+      "$ref": "#/$defs/SourceKind"
+    },
+    "owner": {
+      "default": "",
+      "title": "Owner",
+      "type": "string"
+    },
+    "tenant_id": {
+      "default": "default",
+      "title": "Tenant Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "display_name",
+    "kind"
+  ],
+  "title": "SourceCreate",
+  "type": "object"
+}

--- a/docs/schemas/v1/SourceRecord.json
+++ b/docs/schemas/v1/SourceRecord.json
@@ -1,0 +1,194 @@
+{
+  "$defs": {
+    "SourceKind": {
+      "enum": [
+        "scan.repo",
+        "scan.image",
+        "scan.iac",
+        "scan.cloud",
+        "scan.mcp_config",
+        "connector.cloud_read_only",
+        "connector.registry",
+        "connector.warehouse",
+        "ingest.fleet_sync",
+        "ingest.trace_push",
+        "ingest.result_push",
+        "ingest.artifact_import",
+        "runtime.proxy",
+        "runtime.gateway"
+      ],
+      "title": "SourceKind",
+      "type": "string"
+    },
+    "SourceStatus": {
+      "enum": [
+        "configured",
+        "healthy",
+        "degraded",
+        "disabled"
+      ],
+      "title": "SourceStatus",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "config": {
+      "additionalProperties": true,
+      "title": "Config",
+      "type": "object"
+    },
+    "connector_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Connector Name"
+    },
+    "created_at": {
+      "default": "",
+      "title": "Created At",
+      "type": "string"
+    },
+    "credential_mode": {
+      "default": "none",
+      "title": "Credential Mode",
+      "type": "string"
+    },
+    "credential_ref": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Credential Ref"
+    },
+    "description": {
+      "default": "",
+      "title": "Description",
+      "type": "string"
+    },
+    "display_name": {
+      "title": "Display Name",
+      "type": "string"
+    },
+    "enabled": {
+      "default": true,
+      "title": "Enabled",
+      "type": "boolean"
+    },
+    "kind": {
+      "$ref": "#/$defs/SourceKind"
+    },
+    "last_job_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Last Job Id"
+    },
+    "last_run_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Last Run At"
+    },
+    "last_run_status": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Last Run Status"
+    },
+    "last_test_message": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Last Test Message"
+    },
+    "last_test_status": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Last Test Status"
+    },
+    "last_tested_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Last Tested At"
+    },
+    "owner": {
+      "default": "",
+      "title": "Owner",
+      "type": "string"
+    },
+    "source_id": {
+      "title": "Source Id",
+      "type": "string"
+    },
+    "status": {
+      "$ref": "#/$defs/SourceStatus",
+      "default": "configured"
+    },
+    "tenant_id": {
+      "default": "default",
+      "title": "Tenant Id",
+      "type": "string"
+    },
+    "updated_at": {
+      "default": "",
+      "title": "Updated At",
+      "type": "string"
+    }
+  },
+  "required": [
+    "source_id",
+    "display_name",
+    "kind"
+  ],
+  "title": "SourceRecord",
+  "type": "object"
+}

--- a/docs/schemas/v1/SourceUpdate.json
+++ b/docs/schemas/v1/SourceUpdate.json
@@ -1,0 +1,126 @@
+{
+  "$defs": {
+    "SourceStatus": {
+      "enum": [
+        "configured",
+        "healthy",
+        "degraded",
+        "disabled"
+      ],
+      "title": "SourceStatus",
+      "type": "string"
+    }
+  },
+  "properties": {
+    "config": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Config"
+    },
+    "connector_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Connector Name"
+    },
+    "credential_mode": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Credential Mode"
+    },
+    "credential_ref": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Credential Ref"
+    },
+    "description": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Description"
+    },
+    "display_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Display Name"
+    },
+    "enabled": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Enabled"
+    },
+    "owner": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Owner"
+    },
+    "status": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SourceStatus"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    }
+  },
+  "title": "SourceUpdate",
+  "type": "object"
+}

--- a/docs/schemas/v1/StateUpdate.json
+++ b/docs/schemas/v1/StateUpdate.json
@@ -1,0 +1,18 @@
+{
+  "properties": {
+    "reason": {
+      "default": "",
+      "title": "Reason",
+      "type": "string"
+    },
+    "state": {
+      "title": "State",
+      "type": "string"
+    }
+  },
+  "required": [
+    "state"
+  ],
+  "title": "StateUpdate",
+  "type": "object"
+}

--- a/docs/schemas/v1/StorageHealth.json
+++ b/docs/schemas/v1/StorageHealth.json
@@ -1,0 +1,61 @@
+{
+  "properties": {
+    "audit_log": {
+      "default": "inmemory",
+      "title": "Audit Log",
+      "type": "string"
+    },
+    "control_plane_backend": {
+      "default": "inmemory",
+      "title": "Control Plane Backend",
+      "type": "string"
+    },
+    "exception_store": {
+      "default": "inmemory",
+      "title": "Exception Store",
+      "type": "string"
+    },
+    "fleet_store": {
+      "default": "inmemory",
+      "title": "Fleet Store",
+      "type": "string"
+    },
+    "graph_store": {
+      "default": "inmemory",
+      "title": "Graph Store",
+      "type": "string"
+    },
+    "job_store": {
+      "default": "inmemory",
+      "title": "Job Store",
+      "type": "string"
+    },
+    "key_store": {
+      "default": "inmemory",
+      "title": "Key Store",
+      "type": "string"
+    },
+    "policy_store": {
+      "default": "inmemory",
+      "title": "Policy Store",
+      "type": "string"
+    },
+    "schedule_store": {
+      "default": "inmemory",
+      "title": "Schedule Store",
+      "type": "string"
+    },
+    "source_store": {
+      "default": "inmemory",
+      "title": "Source Store",
+      "type": "string"
+    },
+    "trend_store": {
+      "default": "inmemory",
+      "title": "Trend Store",
+      "type": "string"
+    }
+  },
+  "title": "StorageHealth",
+  "type": "object"
+}

--- a/docs/schemas/v1/TenantQuotaUpdateRequest.json
+++ b/docs/schemas/v1/TenantQuotaUpdateRequest.json
@@ -1,0 +1,58 @@
+{
+  "properties": {
+    "active_scan_jobs": {
+      "anyOf": [
+        {
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Active Scan Jobs"
+    },
+    "fleet_agents": {
+      "anyOf": [
+        {
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Fleet Agents"
+    },
+    "retained_scan_jobs": {
+      "anyOf": [
+        {
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Retained Scan Jobs"
+    },
+    "schedules": {
+      "anyOf": [
+        {
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Schedules"
+    }
+  },
+  "title": "TenantQuotaUpdateRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/TracingHealth.json
+++ b/docs/schemas/v1/TracingHealth.json
@@ -1,0 +1,36 @@
+{
+  "properties": {
+    "otlp_endpoint_configured": {
+      "default": false,
+      "title": "Otlp Endpoint Configured",
+      "type": "boolean"
+    },
+    "otlp_export": {
+      "default": "disabled",
+      "title": "Otlp Export",
+      "type": "string"
+    },
+    "otlp_headers_configured": {
+      "default": false,
+      "title": "Otlp Headers Configured",
+      "type": "boolean"
+    },
+    "w3c_baggage": {
+      "default": true,
+      "title": "W3C Baggage",
+      "type": "boolean"
+    },
+    "w3c_trace_context": {
+      "default": true,
+      "title": "W3C Trace Context",
+      "type": "boolean"
+    },
+    "w3c_tracestate": {
+      "default": true,
+      "title": "W3C Tracestate",
+      "type": "boolean"
+    }
+  },
+  "title": "TracingHealth",
+  "type": "object"
+}

--- a/docs/schemas/v1/TrainingPipelinesRequest.json
+++ b/docs/schemas/v1/TrainingPipelinesRequest.json
@@ -1,0 +1,17 @@
+{
+  "description": "Request body for POST /v1/scan/training-pipelines.",
+  "properties": {
+    "directories": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Directories",
+      "type": "array"
+    }
+  },
+  "required": [
+    "directories"
+  ],
+  "title": "TrainingPipelinesRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/VersionInfo.json
+++ b/docs/schemas/v1/VersionInfo.json
@@ -1,0 +1,23 @@
+{
+  "properties": {
+    "api_version": {
+      "default": "v1",
+      "title": "Api Version",
+      "type": "string"
+    },
+    "python_package": {
+      "default": "agent-bom",
+      "title": "Python Package",
+      "type": "string"
+    },
+    "version": {
+      "title": "Version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "version"
+  ],
+  "title": "VersionInfo",
+  "type": "object"
+}

--- a/docs/schemas/v1/index.json
+++ b/docs/schemas/v1/index.json
@@ -1,0 +1,202 @@
+{
+  "generator": "scripts/generate_v1_schemas.py",
+  "models": [
+    {
+      "doc": "",
+      "name": "AnalyticsHealth",
+      "schema": "AnalyticsHealth.json"
+    },
+    {
+      "doc": "Request body for POST /v1/scan/browser-extensions.",
+      "name": "BrowserExtensionsRequest",
+      "schema": "BrowserExtensionsRequest.json"
+    },
+    {
+      "doc": "",
+      "name": "ComplianceAuditIntegrity",
+      "schema": "ComplianceAuditIntegrity.json"
+    },
+    {
+      "doc": "",
+      "name": "ComplianceEvidenceItem",
+      "schema": "ComplianceEvidenceItem.json"
+    },
+    {
+      "doc": "",
+      "name": "ComplianceReportBundle",
+      "schema": "ComplianceReportBundle.json"
+    },
+    {
+      "doc": "",
+      "name": "ComplianceReportControl",
+      "schema": "ComplianceReportControl.json"
+    },
+    {
+      "doc": "",
+      "name": "ComplianceReportScope",
+      "schema": "ComplianceReportScope.json"
+    },
+    {
+      "doc": "",
+      "name": "ComplianceReportSummary",
+      "schema": "ComplianceReportSummary.json"
+    },
+    {
+      "doc": "",
+      "name": "ComplianceThreatModel",
+      "schema": "ComplianceThreatModel.json"
+    },
+    {
+      "doc": "",
+      "name": "CreateKeyRequest",
+      "schema": "CreateKeyRequest.json"
+    },
+    {
+      "doc": "Request body for POST /v1/scan/dataset-cards.",
+      "name": "DatasetCardsRequest",
+      "schema": "DatasetCardsRequest.json"
+    },
+    {
+      "doc": "",
+      "name": "EvaluateRequest",
+      "schema": "EvaluateRequest.json"
+    },
+    {
+      "doc": "",
+      "name": "ExceptionRequest",
+      "schema": "ExceptionRequest.json"
+    },
+    {
+      "doc": "Request body for POST /v1/findings/false-positive.",
+      "name": "FalsePositiveRequest",
+      "schema": "FalsePositiveRequest.json"
+    },
+    {
+      "doc": "Request body for POST /v1/findings/feedback.",
+      "name": "FindingFeedbackRequest",
+      "schema": "FindingFeedbackRequest.json"
+    },
+    {
+      "doc": "",
+      "name": "FleetAgentUpdate",
+      "schema": "FleetAgentUpdate.json"
+    },
+    {
+      "doc": "",
+      "name": "HealthResponse",
+      "schema": "HealthResponse.json"
+    },
+    {
+      "doc": "Request body for POST /v1/findings/jira.",
+      "name": "JiraTicketRequest",
+      "schema": "JiraTicketRequest.json"
+    },
+    {
+      "doc": "Request body for POST /v1/scan/model-files.",
+      "name": "ModelFilesRequest",
+      "schema": "ModelFilesRequest.json"
+    },
+    {
+      "doc": "Request body for POST /v1/scan/model-provenance.",
+      "name": "ModelProvenanceRequest",
+      "schema": "ModelProvenanceRequest.json"
+    },
+    {
+      "doc": "",
+      "name": "PolicyCreate",
+      "schema": "PolicyCreate.json"
+    },
+    {
+      "doc": "",
+      "name": "PolicyUpdate",
+      "schema": "PolicyUpdate.json"
+    },
+    {
+      "doc": "Request body for POST /v1/scan/prompt-scan.",
+      "name": "PromptScanRequest",
+      "schema": "PromptScanRequest.json"
+    },
+    {
+      "doc": "",
+      "name": "ProxyAuditIngestRequest",
+      "schema": "ProxyAuditIngestRequest.json"
+    },
+    {
+      "doc": "",
+      "name": "PushPayload",
+      "schema": "PushPayload.json"
+    },
+    {
+      "doc": "",
+      "name": "RotateKeyRequest",
+      "schema": "RotateKeyRequest.json"
+    },
+    {
+      "doc": "",
+      "name": "SAMLLoginRequest",
+      "schema": "SAMLLoginRequest.json"
+    },
+    {
+      "doc": "Represents a running or completed scan job.",
+      "name": "ScanJob",
+      "schema": "ScanJob.json"
+    },
+    {
+      "doc": "Options accepted by POST /v1/scan \u2014 mirrors agent-bom scan CLI flags.",
+      "name": "ScanRequest",
+      "schema": "ScanRequest.json"
+    },
+    {
+      "doc": "",
+      "name": "ScheduleCreate",
+      "schema": "ScheduleCreate.json"
+    },
+    {
+      "doc": "",
+      "name": "SourceCreate",
+      "schema": "SourceCreate.json"
+    },
+    {
+      "doc": "",
+      "name": "SourceRecord",
+      "schema": "SourceRecord.json"
+    },
+    {
+      "doc": "",
+      "name": "SourceUpdate",
+      "schema": "SourceUpdate.json"
+    },
+    {
+      "doc": "",
+      "name": "StateUpdate",
+      "schema": "StateUpdate.json"
+    },
+    {
+      "doc": "",
+      "name": "StorageHealth",
+      "schema": "StorageHealth.json"
+    },
+    {
+      "doc": "",
+      "name": "TenantQuotaUpdateRequest",
+      "schema": "TenantQuotaUpdateRequest.json"
+    },
+    {
+      "doc": "",
+      "name": "TracingHealth",
+      "schema": "TracingHealth.json"
+    },
+    {
+      "doc": "Request body for POST /v1/scan/training-pipelines.",
+      "name": "TrainingPipelinesRequest",
+      "schema": "TrainingPipelinesRequest.json"
+    },
+    {
+      "doc": "",
+      "name": "VersionInfo",
+      "schema": "VersionInfo.json"
+    }
+  ],
+  "source_module": "agent_bom.api.models",
+  "version": "v1"
+}

--- a/scripts/generate_v1_schemas.py
+++ b/scripts/generate_v1_schemas.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Generate JSON Schema (draft 2020-12) for every Pydantic model in
+``agent_bom.api.models`` and write them under ``docs/schemas/v1/``.
+
+Closes #1963. SDK consumers and downstream platform integrations need a
+stable contract surface they can codegen against; the Pydantic models
+already are the source of truth, so the cleanest contract is the
+JSON Schema they emit. The committed schemas are the published artifact
+and ``--check`` mode asserts that every regen matches them so an
+unintended model edit cannot ship without updating the contract.
+
+Usage:
+
+    python scripts/generate_v1_schemas.py            # write fresh schemas
+    python scripts/generate_v1_schemas.py --check    # CI drift gate
+
+The generator is intentionally side-effect-free: it imports the models
+module, walks every public Pydantic class, and serialises the schema
+into a per-model file. No network, no I/O beyond ``docs/schemas/v1/``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import inspect
+import json
+import sys
+from pathlib import Path
+
+from pydantic import BaseModel
+
+import agent_bom.api.models as models_module
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIR = ROOT / "docs" / "schemas" / "v1"
+INDEX_FILE = SCHEMA_DIR / "index.json"
+
+
+# Models reachable from `agent_bom.api.models`. Filter to classes
+# defined in that module (skip imported BaseModel re-exports) and only
+# proper Pydantic models.
+def _public_models() -> list[type[BaseModel]]:
+    out: list[type[BaseModel]] = []
+    for name, obj in vars(models_module).items():
+        if name.startswith("_"):
+            continue
+        if not inspect.isclass(obj):
+            continue
+        if not issubclass(obj, BaseModel) or obj is BaseModel:
+            continue
+        # Only the models defined in this module — skip transitive imports
+        # like `from pydantic import BaseModel` and any re-exports from
+        # other internal modules (we want the v1 surface to be one file).
+        if obj.__module__ != models_module.__name__:
+            continue
+        out.append(obj)
+    return sorted(out, key=lambda cls: cls.__name__)
+
+
+def _schema_payload(cls: type[BaseModel]) -> dict[str, object]:
+    return cls.model_json_schema(mode="serialization")
+
+
+def _write_schema(cls: type[BaseModel]) -> tuple[Path, str]:
+    SCHEMA_DIR.mkdir(parents=True, exist_ok=True)
+    payload = _schema_payload(cls)
+    rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    path = SCHEMA_DIR / f"{cls.__name__}.json"
+    return path, rendered
+
+
+def _write_index(classes: list[type[BaseModel]]) -> tuple[Path, str]:
+    payload = {
+        "version": "v1",
+        "generator": "scripts/generate_v1_schemas.py",
+        "source_module": models_module.__name__,
+        "models": [
+            {
+                "name": cls.__name__,
+                "schema": f"{cls.__name__}.json",
+                "doc": (cls.__doc__ or "").strip().splitlines()[0] if cls.__doc__ else "",
+            }
+            for cls in classes
+        ],
+    }
+    rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    return INDEX_FILE, rendered
+
+
+def _diff_message(path: Path, expected: str) -> str | None:
+    if not path.exists():
+        return f"missing: {path.relative_to(ROOT)}"
+    actual = path.read_text(encoding="utf-8")
+    if actual != expected:
+        return f"drift: {path.relative_to(ROOT)} differs from generated output"
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail when committed schemas diverge from generated output. CI gate.",
+    )
+    args = parser.parse_args()
+
+    classes = _public_models()
+    if not classes:
+        print("ERROR: no Pydantic models found in agent_bom.api.models", file=sys.stderr)
+        return 1
+
+    pending: list[tuple[Path, str]] = []
+    for cls in classes:
+        pending.append(_write_schema(cls))
+    pending.append(_write_index(classes))
+
+    if args.check:
+        problems: list[str] = []
+        for path, content in pending:
+            problem = _diff_message(path, content)
+            if problem is not None:
+                problems.append(problem)
+        # Also catch deletions: every committed file must correspond to a
+        # generated entry, otherwise a model rename would leave a stale
+        # schema sitting in the published surface.
+        expected_paths = {path for path, _ in pending}
+        if SCHEMA_DIR.exists():
+            for existing in SCHEMA_DIR.iterdir():
+                if existing.is_file() and existing not in expected_paths:
+                    problems.append(f"stale: {existing.relative_to(ROOT)} no longer matches a model")
+        if problems:
+            print("docs/schemas/v1/ is out of sync with agent_bom.api.models:", file=sys.stderr)
+            for problem in problems:
+                print(f"  - {problem}", file=sys.stderr)
+            print(
+                "Run `python scripts/generate_v1_schemas.py` to refresh the contracts.",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"OK: docs/schemas/v1/ matches {len(classes)} models in agent_bom.api.models")
+        return 0
+
+    SCHEMA_DIR.mkdir(parents=True, exist_ok=True)
+    written = 0
+    for path, content in pending:
+        if not path.exists() or path.read_text(encoding="utf-8") != content:
+            path.write_text(content, encoding="utf-8")
+            written += 1
+    print(f"Wrote {written} schema file(s) under docs/schemas/v1/ ({len(classes)} models total).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

SDK consumers and downstream platform integrations need a stable contract surface they can codegen against. The Pydantic models in \`agent_bom.api.models\` are already the source of truth; this PR publishes them as **JSON Schema (draft 2020-12)** under \`docs/schemas/v1/\` and gates drift in CI.

## What ships

- **\`scripts/generate_v1_schemas.py\`** — walks every public Pydantic class in \`agent_bom.api.models\`, serialises each to a per-model schema file via \`model.model_json_schema(mode=\"serialization\")\`, and writes them sorted/stable so diffs are reviewable. Default mode rewrites; \`--check\` mode is the CI gate.
- **\`docs/schemas/v1/\`** — 39 model schemas + an \`index.json\` manifest with name, schema filename, and one-line docstring for each model.
- **\`.github/workflows/ci.yml\`** — new \"Verify v1 schemas match Pydantic models\" step that calls the generator with \`--check\` and surfaces a refresh hint when models change without the contracts being regenerated.

## Why this shape

- **One file per model** so a renamed/removed model leaves a clean diff and the generator can detect stale files separately.
- **\`mode=\"serialization\"\`** so the schema reflects what the API actually emits (computed fields, alias_generator) rather than the validation-time view.
- **\`json.dumps(..., indent=2, sort_keys=True)\`** so reviewers always see the same key ordering — keeps the per-PR diff minimal.

## Test plan

- [x] \`PYTHONPATH=src python scripts/generate_v1_schemas.py\` — wrote 40 files (39 models + index).
- [x] \`PYTHONPATH=src python scripts/generate_v1_schemas.py --check\` — passes.
- [x] Spot-check \`docs/schemas/v1/ScanRequest.json\` for shape and defaults — reflects POST /v1/scan correctly.

Closes #1963.