### PR TITLE
feat(scanner): add graph-walk dependency reachability engine (#1896)

### DIFF
--- a/src/agent_bom/graph/__init__.py
+++ b/src/agent_bom/graph/__init__.py
@@ -16,6 +16,12 @@ from agent_bom.graph.container import (
     LegendEntry,
     UnifiedGraph,
 )
+from agent_bom.graph.dependency_reach import (
+    PackageReachability,
+    ReachabilityReport,
+    VulnerabilityReachability,
+    compute_dependency_reach,
+)
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import NodeDimensions, UnifiedNode, stable_node_id
 from agent_bom.graph.ocsf import ENTITY_OCSF_MAP, FINDING_ENTITY_TYPES, ocsf_type_uid
@@ -78,6 +84,11 @@ __all__ = [
     "compute_delta_alerts",
     "dispatch_delta_alerts",
     "format_alerts_for_siem",
+    # Dependency reachability (#1896)
+    "PackageReachability",
+    "VulnerabilityReachability",
+    "ReachabilityReport",
+    "compute_dependency_reach",
     # Util
     "_now_iso",
 ]

--- a/src/agent_bom/graph/dependency_reach.py
+++ b/src/agent_bom/graph/dependency_reach.py
@@ -1,0 +1,220 @@
+"""Graph-walk dependency reachability engine.
+
+Closes #1896. The blast-radius scoring before this module gave every CVE
+the same prominence whether the vulnerable package was a direct
+import of a runtime entrypoint or three hops down a dependency tree
+that no live code exercises. Operators with thousands of findings need
+to triage the *reachable* CVEs first; the lockfile alone cannot tell
+them which is which.
+
+This engine answers two questions for every vulnerability node in the
+unified graph:
+
+1. **Is it reachable from any agent entrypoint?** — boolean. ``False``
+   means the package sits in the dependency closure of an agent's MCP
+   server but no traversal of ``USES`` → ``DEPENDS_ON`` edges connects
+   the agent to that package. (In practice this is rare given how the
+   builder wires edges, so it works as a structural sanity gate.)
+2. **What is the shortest reach distance?** — integer hop count from
+   the closest agent. ``1`` means an agent's own MCP server depends on
+   the vulnerable package directly; higher values are deeper transitive
+   dependencies. The smaller the distance, the more directly the agent
+   is exposed.
+
+The result is a ``VulnerabilityReachability`` per vulnerability node
+plus a per-package summary the report layer can join into the existing
+blast-radius rows. The walker is purely a read-side function — no graph
+mutation — so it is safe to call from the API, the CLI, or a snapshot
+re-analysis pipeline.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.types import EntityType, RelationshipType
+
+# Edges the walker is allowed to follow when expanding from an agent
+# toward its dependency closure. Anything else (vuln edges, runtime
+# events, lateral movement) would inflate reach with paths that are
+# not "this agent depends on that code".
+_REACH_EDGE_TYPES: frozenset[RelationshipType] = frozenset(
+    {
+        RelationshipType.USES,
+        RelationshipType.DEPENDS_ON,
+        RelationshipType.CONTAINS,
+        RelationshipType.PROVIDES_TOOL,
+    }
+)
+
+# Edges that connect a vulnerability to its affected package.
+_VULN_TO_PACKAGE_EDGE_TYPES: frozenset[RelationshipType] = frozenset(
+    {
+        RelationshipType.AFFECTS,
+        RelationshipType.VULNERABLE_TO,
+    }
+)
+
+
+@dataclass(frozen=True)
+class PackageReachability:
+    """Reach information for a single package node."""
+
+    package_id: str
+    reachable_from: tuple[str, ...]
+    """Agent node ids whose dependency closure includes this package."""
+
+    min_hop_distance: int
+    """Smallest number of edges from any reaching agent. ``0`` when no agent reaches the package."""
+
+    @property
+    def reachable(self) -> bool:
+        return bool(self.reachable_from)
+
+
+@dataclass(frozen=True)
+class VulnerabilityReachability:
+    """Reach information for a vulnerability node, derived from its packages."""
+
+    vulnerability_id: str
+    package_ids: tuple[str, ...]
+    """Package nodes the vulnerability is attached to."""
+
+    reachable_from: tuple[str, ...]
+    """Agent node ids that reach at least one affected package."""
+
+    min_hop_distance: int
+    """Smallest hop distance to any affected package. ``0`` when unreachable."""
+
+    @property
+    def reachable(self) -> bool:
+        return bool(self.reachable_from)
+
+
+@dataclass(frozen=True)
+class ReachabilityReport:
+    """Complete reachability analysis for one graph."""
+
+    packages: dict[str, PackageReachability]
+    vulnerabilities: dict[str, VulnerabilityReachability]
+
+    @property
+    def reachable_vulnerability_ids(self) -> tuple[str, ...]:
+        return tuple(sorted(v.vulnerability_id for v in self.vulnerabilities.values() if v.reachable))
+
+
+def compute_dependency_reach(graph: UnifiedGraph) -> ReachabilityReport:
+    """Walk the graph from every agent entrypoint and compute reachability.
+
+    Two-pass BFS:
+      1. From each agent node, BFS along ``_REACH_EDGE_TYPES`` and record
+         the minimum hop distance per package node it can reach.
+      2. For every vulnerability node, look at the packages it is bound
+         to via ``AFFECTS`` / ``VULNERABLE_TO`` and surface the union of
+         reaching agents plus the smallest hop count across them.
+    """
+    package_reach: dict[str, dict[str, int]] = {}
+
+    agent_ids = [node.id for node in graph.nodes_by_type(EntityType.AGENT)]
+    for agent_id in agent_ids:
+        for node_id, hops in _bfs_distances_along(graph, agent_id, _REACH_EDGE_TYPES).items():
+            target = graph.get_node(node_id)
+            if target is None or target.entity_type is not EntityType.PACKAGE:
+                continue
+            current = package_reach.setdefault(node_id, {})
+            existing = current.get(agent_id)
+            if existing is None or hops < existing:
+                current[agent_id] = hops
+
+    packages: dict[str, PackageReachability] = {}
+    for node in graph.nodes_by_type(EntityType.PACKAGE):
+        reach_map = package_reach.get(node.id, {})
+        if reach_map:
+            sorted_agents = tuple(sorted(reach_map))
+            min_hops = min(reach_map.values())
+        else:
+            sorted_agents = ()
+            min_hops = 0
+        packages[node.id] = PackageReachability(
+            package_id=node.id,
+            reachable_from=sorted_agents,
+            min_hop_distance=min_hops,
+        )
+
+    vulnerabilities: dict[str, VulnerabilityReachability] = {}
+    for node in graph.nodes_by_type(EntityType.VULNERABILITY):
+        affected_packages = _vulnerability_packages(graph, node.id)
+        agents_reaching: set[str] = set()
+        best_hops: int | None = None
+        for pkg_id in affected_packages:
+            pkg_info = packages.get(pkg_id)
+            if pkg_info is None or not pkg_info.reachable:
+                continue
+            agents_reaching.update(pkg_info.reachable_from)
+            if best_hops is None or pkg_info.min_hop_distance < best_hops:
+                best_hops = pkg_info.min_hop_distance
+        vulnerabilities[node.id] = VulnerabilityReachability(
+            vulnerability_id=node.id,
+            package_ids=tuple(sorted(affected_packages)),
+            reachable_from=tuple(sorted(agents_reaching)),
+            min_hop_distance=best_hops if best_hops is not None else 0,
+        )
+
+    return ReachabilityReport(packages=packages, vulnerabilities=vulnerabilities)
+
+
+def _bfs_distances_along(
+    graph: UnifiedGraph,
+    start_id: str,
+    allowed_relationships: frozenset[RelationshipType],
+) -> dict[str, int]:
+    """Return ``{node_id: min_hop_distance}`` reachable from start_id.
+
+    Walks only edges whose relationship is in ``allowed_relationships``.
+    Honors edge direction: bidirectional edges are stored under both
+    endpoints' adjacency lists already, so a simple forward BFS is
+    enough.
+    """
+    distances: dict[str, int] = {start_id: 0}
+    queue: deque[str] = deque([start_id])
+    while queue:
+        current_id = queue.popleft()
+        current_dist = distances[current_id]
+        edges: list[UnifiedEdge] = graph.adjacency.get(current_id, [])
+        for edge in edges:
+            if edge.relationship not in allowed_relationships:
+                continue
+            # The forward index already includes bidirectional reversals,
+            # so the "next hop" is simply the edge target as the engine
+            # sees it from this side.
+            neighbour = edge.target if edge.source == current_id else edge.source
+            if neighbour in distances:
+                continue
+            distances[neighbour] = current_dist + 1
+            queue.append(neighbour)
+    return distances
+
+
+def _vulnerability_packages(graph: UnifiedGraph, vuln_id: str) -> set[str]:
+    """Return package node ids that this vulnerability is attached to."""
+    out: set[str] = set()
+    for edge in graph.adjacency.get(vuln_id, []):
+        if edge.relationship not in _VULN_TO_PACKAGE_EDGE_TYPES:
+            continue
+        other = edge.target if edge.source == vuln_id else edge.source
+        node = graph.get_node(other)
+        if node is None or node.entity_type is not EntityType.PACKAGE:
+            continue
+        out.add(other)
+    for edge in graph.reverse_adjacency.get(vuln_id, []):
+        if edge.relationship not in _VULN_TO_PACKAGE_EDGE_TYPES:
+            continue
+        other = edge.source if edge.target == vuln_id else edge.target
+        node = graph.get_node(other)
+        if node is None or node.entity_type is not EntityType.PACKAGE:
+            continue
+        out.add(other)
+    return out

--- a/tests/test_dependency_reach.py
+++ b/tests/test_dependency_reach.py
@@ -1,0 +1,161 @@
+"""Graph-walk dependency reachability tests (#1896).
+
+Locks the engine's reach math so a future graph-builder change can't
+silently invert which CVEs are flagged as reachable. Each test builds
+a small UnifiedGraph by hand — no scan-report shape to debug, no
+network — so failures point straight at the walker logic.
+"""
+
+from __future__ import annotations
+
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.dependency_reach import compute_dependency_reach
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+
+
+def _node(node_id: str, entity_type: EntityType, label: str | None = None) -> UnifiedNode:
+    return UnifiedNode(id=node_id, entity_type=entity_type, label=label or node_id)
+
+
+def _edge(src: str, dst: str, relationship: RelationshipType) -> UnifiedEdge:
+    return UnifiedEdge(source=src, target=dst, relationship=relationship)
+
+
+def _build_chain_graph() -> UnifiedGraph:
+    """agent → server → package(direct) → package(transitive) ← vuln."""
+    g = UnifiedGraph(scan_id="chain", tenant_id="t1")
+    g.add_node(_node("agent:cursor", EntityType.AGENT))
+    g.add_node(_node("server:mcp-fs", EntityType.SERVER))
+    g.add_node(_node("pkg:direct@1.0", EntityType.PACKAGE))
+    g.add_node(_node("pkg:transitive@2.0", EntityType.PACKAGE))
+    g.add_node(_node("vuln:CVE-2026-0001", EntityType.VULNERABILITY))
+
+    g.add_edge(_edge("agent:cursor", "server:mcp-fs", RelationshipType.USES))
+    g.add_edge(_edge("server:mcp-fs", "pkg:direct@1.0", RelationshipType.DEPENDS_ON))
+    g.add_edge(_edge("pkg:direct@1.0", "pkg:transitive@2.0", RelationshipType.DEPENDS_ON))
+    g.add_edge(_edge("pkg:transitive@2.0", "vuln:CVE-2026-0001", RelationshipType.VULNERABLE_TO))
+    return g
+
+
+def test_direct_dependency_is_reachable_at_distance_two() -> None:
+    g = _build_chain_graph()
+
+    report = compute_dependency_reach(g)
+    direct = report.packages["pkg:direct@1.0"]
+
+    # agent → server (1 hop) → pkg (1 hop) = 2 hops total.
+    assert direct.reachable
+    assert direct.reachable_from == ("agent:cursor",)
+    assert direct.min_hop_distance == 2
+
+
+def test_transitive_dependency_keeps_climbing_distance() -> None:
+    g = _build_chain_graph()
+
+    report = compute_dependency_reach(g)
+    transitive = report.packages["pkg:transitive@2.0"]
+
+    assert transitive.reachable
+    assert transitive.min_hop_distance == 3
+
+
+def test_vulnerability_reach_picks_smallest_package_distance() -> None:
+    g = _build_chain_graph()
+    # Add an unrelated agent that depends directly on the transitive
+    # package — its distance to the vulnerable package is shorter.
+    g.add_node(_node("agent:claude", EntityType.AGENT))
+    g.add_node(_node("server:other", EntityType.SERVER))
+    g.add_edge(_edge("agent:claude", "server:other", RelationshipType.USES))
+    g.add_edge(_edge("server:other", "pkg:transitive@2.0", RelationshipType.DEPENDS_ON))
+
+    report = compute_dependency_reach(g)
+    vuln = report.vulnerabilities["vuln:CVE-2026-0001"]
+
+    assert vuln.reachable
+    # Minimum reach is the closer route: agent:claude → server → pkg = 2.
+    assert vuln.min_hop_distance == 2
+    assert set(vuln.reachable_from) == {"agent:cursor", "agent:claude"}
+
+
+def test_island_vulnerability_is_not_reachable() -> None:
+    """A vulnerability on an orphan package — no agent owns it."""
+    g = UnifiedGraph(scan_id="island", tenant_id="t1")
+    g.add_node(_node("agent:cursor", EntityType.AGENT))
+    g.add_node(_node("pkg:orphan@1", EntityType.PACKAGE))
+    g.add_node(_node("vuln:CVE-2026-9999", EntityType.VULNERABILITY))
+    # No USES / DEPENDS_ON edge from agent reaches pkg:orphan.
+    g.add_edge(_edge("pkg:orphan@1", "vuln:CVE-2026-9999", RelationshipType.VULNERABLE_TO))
+
+    report = compute_dependency_reach(g)
+    pkg = report.packages["pkg:orphan@1"]
+    vuln = report.vulnerabilities["vuln:CVE-2026-9999"]
+
+    assert not pkg.reachable
+    assert pkg.reachable_from == ()
+    assert pkg.min_hop_distance == 0
+    assert not vuln.reachable
+    assert vuln.reachable_from == ()
+
+
+def test_vuln_attached_via_affects_edge_is_recognized() -> None:
+    """``AFFECTS`` (vuln → package) and ``VULNERABLE_TO`` (package → vuln)
+    are both valid attachments. The walker must accept either direction
+    so an upstream vendor's directional convention does not mask reach."""
+    g = UnifiedGraph(scan_id="affects", tenant_id="t1")
+    g.add_node(_node("agent:cursor", EntityType.AGENT))
+    g.add_node(_node("server:mcp", EntityType.SERVER))
+    g.add_node(_node("pkg:p", EntityType.PACKAGE))
+    g.add_node(_node("vuln:CVE-2026-1234", EntityType.VULNERABILITY))
+    g.add_edge(_edge("agent:cursor", "server:mcp", RelationshipType.USES))
+    g.add_edge(_edge("server:mcp", "pkg:p", RelationshipType.DEPENDS_ON))
+    g.add_edge(_edge("vuln:CVE-2026-1234", "pkg:p", RelationshipType.AFFECTS))
+
+    report = compute_dependency_reach(g)
+    vuln = report.vulnerabilities["vuln:CVE-2026-1234"]
+
+    assert vuln.reachable
+    assert vuln.min_hop_distance == 2
+
+
+def test_vulnerability_with_no_packages_is_unreachable() -> None:
+    """A vulnerability node with no AFFECTS / VULNERABLE_TO edge is structurally
+    detached and cannot be reached, regardless of agents present."""
+    g = UnifiedGraph(scan_id="dangling", tenant_id="t1")
+    g.add_node(_node("agent:cursor", EntityType.AGENT))
+    g.add_node(_node("vuln:CVE-2026-0042", EntityType.VULNERABILITY))
+
+    report = compute_dependency_reach(g)
+    vuln = report.vulnerabilities["vuln:CVE-2026-0042"]
+
+    assert vuln.package_ids == ()
+    assert not vuln.reachable
+    assert vuln.min_hop_distance == 0
+
+
+def test_reachable_vulnerability_ids_summary_is_sorted() -> None:
+    g = _build_chain_graph()
+    g.add_node(_node("vuln:CVE-2026-0002", EntityType.VULNERABILITY))
+    g.add_edge(_edge("pkg:direct@1.0", "vuln:CVE-2026-0002", RelationshipType.VULNERABLE_TO))
+
+    report = compute_dependency_reach(g)
+
+    assert report.reachable_vulnerability_ids == ("vuln:CVE-2026-0001", "vuln:CVE-2026-0002")
+
+
+def test_walker_does_not_traverse_runtime_or_lateral_edges() -> None:
+    """Only DEPENDS_ON / USES / CONTAINS / PROVIDES_TOOL count as
+    structural reach. Runtime INVOKED / SHARES_SERVER edges are
+    different concerns and must not inflate reach distance."""
+    g = UnifiedGraph(scan_id="lateral", tenant_id="t1")
+    g.add_node(_node("agent:a", EntityType.AGENT))
+    g.add_node(_node("agent:b", EntityType.AGENT))
+    g.add_node(_node("pkg:lateral@1", EntityType.PACKAGE))
+    # agent:a is laterally connected to agent:b, but nothing depends on
+    # the package — reach should not flow through SHARES_SERVER.
+    g.add_edge(_edge("agent:a", "agent:b", RelationshipType.SHARES_SERVER))
+    g.add_edge(_edge("agent:b", "pkg:lateral@1", RelationshipType.SHARES_SERVER))
+
+    report = compute_dependency_reach(g)
+    assert not report.packages["pkg:lateral@1"].reachable


### PR DESCRIPTION
## Summary

Closes #1896. The blast-radius scoring before this gave every CVE the same prominence whether the vulnerable package was a direct import of a runtime entrypoint or three hops down a dependency tree no live code exercises. Operators with thousands of findings need the **reachable** CVEs first; the lockfile alone cannot tell them which is which.

This PR ships the **engine half** of #1896.

## What ships

- **\`src/agent_bom/graph/dependency_reach.py\`** — pure read-side BFS that walks every \`AGENT\` node forward along \`{USES, DEPENDS_ON, CONTAINS, PROVIDES_TOOL}\` edges, records the minimum hop distance per \`PACKAGE\` node it can reach, then surfaces per-\`VULNERABILITY\`:
  - \`reachable: bool\` — can any agent's dependency closure touch the affected package?
  - \`reachable_from: tuple[agent_id, ...]\` — which agents.
  - \`min_hop_distance: int\` — smallest distance to the closest affected package; smaller = more directly exposed.

  Walker explicitly **excludes** runtime/lateral edges (\`INVOKED\`, \`SHARES_SERVER\`, …) so reach reflects structural dependency ownership, not co-occurrence. Both \`VULNERABLE_TO\` and \`AFFECTS\` edges are recognised so an upstream vendor's directional convention can't mask a finding.

- **\`src/agent_bom/graph/__init__.py\`** exports the new \`PackageReachability\` / \`VulnerabilityReachability\` / \`ReachabilityReport\` types and the \`compute_dependency_reach()\` entry point.

- **\`tests/test_dependency_reach.py\`** (8 cases):
  - Direct dep at distance 2.
  - Transitive dep at distance 3.
  - Multi-agent reach picks the smaller distance.
  - Island package not reachable (no path from any agent).
  - \`AFFECTS\` direction works.
  - Vuln with no packages stays unreachable.
  - Summary list is sorted.
  - Walker refuses to traverse \`SHARES_SERVER\` / \`INVOKED\` (lateral/runtime edges shouldn't inflate reach).

## Why ship the engine separately

The engine is intentionally **read-only and zero-side-effect**, so the API, CLI, and snapshot re-analysis paths can all call it. Surfacing the reach score in the existing blast-radius scoring + the dashboard UI is left for the next phase so that integration can land separately and be reviewed against existing scoring tests — no risk of regressing the scoring behaviour with an engine PR.

## Test plan

- [x] \`pytest tests/test_dependency_reach.py tests/test_graph_builder.py -q\` — **46 passed** (8 new + 38 existing builder).
- [x] \`ruff check\` on touched files — clean.
- [x] \`mypy src/agent_bom/graph/dependency_reach.py\` — clean.

Closes #1896 (engine half — surfacing in blast_radius scoring will follow as a focused integration PR).