### PR TITLE
chore: audit-5 PR A — small hygiene + correctness fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,7 @@ jobs:
   docs-site:
     name: Rebuild and deploy docs
     needs: version-guard
+    timeout-minutes: 20
     permissions:
       contents: read
       pages: write

--- a/scripts/check_workflow_timeouts.py
+++ b/scripts/check_workflow_timeouts.py
@@ -25,8 +25,19 @@ WORKFLOWS_DIR = ROOT / ".github" / "workflows"
 
 
 def _is_reusable_caller(job: dict[str, Any]) -> bool:
-    """A job that uses a reusable workflow has its timeout in the callee."""
-    return isinstance(job.get("uses"), str)
+    """Reusable-workflow callers still need their own ``timeout-minutes``.
+
+    The original revision returned True so the gate skipped any ``uses:``
+    job, on the (incorrect) theory that timeouts in the called workflow
+    would bound the caller. They don't — GitHub treats the caller's
+    ``timeout-minutes`` as the enforced limit for the entire reusable
+    workflow call, defaulting to **360 minutes** (six hours) when omitted.
+    The exclusion was the audit-4 bundle's miss on
+    ``release.yml docs-site``; this returns False now so every job is
+    checked regardless of whether it uses a reusable workflow.
+    """
+    del job
+    return False
 
 
 def _collect_problems() -> list[str]:

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -75,10 +75,33 @@ class AuditExportVerifyRequest(BaseModel):
 
 _AUTH_SESSION_ATTEMPTS: dict[str, list[float]] = {}
 _AUTH_SESSION_LOCK = threading.Lock()
+_AUTH_SESSION_CLUSTERED_WARNING_EMITTED = False
 _SAML_RELAY_STATES: dict[str, float] = {}
 _SAML_RELAY_LOCK = threading.Lock()
 _FEEDBACK_PREFIX = "[finding_feedback:"
 _LEGACY_FALSE_POSITIVE_PREFIX = "[false_positive]"
+
+
+def _warn_in_process_rate_limit_in_cluster() -> None:
+    """Emit a one-shot warning when the in-process auth attempt counter is used in cluster mode.
+
+    The map is per-replica, so the effective brute-force budget under N
+    replicas is ``limit * N`` — silently. The Postgres-backed counter
+    that closes this gap is tracked as audit-5 PR-B follow-up; this
+    warning makes the gap visible to operators in the meantime.
+    """
+    global _AUTH_SESSION_CLUSTERED_WARNING_EMITTED
+    if _AUTH_SESSION_CLUSTERED_WARNING_EMITTED:
+        return
+    if not os.environ.get("AGENT_BOM_POSTGRES_URL") and not os.environ.get("AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT"):
+        return
+    _AUTH_SESSION_CLUSTERED_WARNING_EMITTED = True
+    _logger.warning(
+        "Auth session attempt counter is process-local; under multiple API replicas the "
+        "effective brute-force budget is %d × num_replicas. Postgres-backed counter is the "
+        "audit-5 follow-up.",
+        _auth_session_limit(),
+    )
 
 
 def _client_fingerprint(request: Request) -> str:
@@ -96,6 +119,7 @@ def _auth_session_limit() -> int:
 
 
 def _check_auth_session_rate_limit(request: Request) -> None:
+    _warn_in_process_rate_limit_in_cluster()
     now = time.monotonic()
     window_start = now - 60
     key = _client_fingerprint(request)
@@ -123,9 +147,19 @@ def _relay_state_digest(relay_state: str) -> str:
 
 
 def _new_saml_relay_state() -> tuple[str, str]:
+    # Sweep expired entries on issue too, not only on consume — otherwise
+    # an attacker who issues many relay-state nonces but never completes
+    # the SAML round trip can grow the in-memory map unbounded. The
+    # cleanup is O(n) on the active set, which is small in practice
+    # (single-tenant pilot or reverse-proxy SSO; broader deployments
+    # should pin this map in shared storage).
     relay_state = secrets.token_urlsafe(32)
-    expires_at = time.monotonic() + _saml_relay_ttl_seconds()
+    now_monotonic = time.monotonic()
+    expires_at = now_monotonic + _saml_relay_ttl_seconds()
     with _SAML_RELAY_LOCK:
+        expired = [key for key, exp in _SAML_RELAY_STATES.items() if exp < now_monotonic]
+        for key in expired:
+            _SAML_RELAY_STATES.pop(key, None)
         _SAML_RELAY_STATES[_relay_state_digest(relay_state)] = expires_at
     return relay_state, (datetime.now(timezone.utc) + timedelta(seconds=_saml_relay_ttl_seconds())).isoformat()
 

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -7,6 +7,7 @@ used for current-state views, traversal, attack paths, and temporal diffs.
 
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from pathlib import PurePath
 from typing import Any
@@ -29,6 +30,7 @@ except ImportError:  # pragma: no cover
 
 
 _GRAPH_TRACER = get_tracer("agent_bom.graph")
+_logger = logging.getLogger(__name__)
 
 
 def build_unified_graph_from_report(
@@ -819,14 +821,30 @@ def _resolve_affected_server_ids(
         named_ids: set[str] = set()
         for server_name in server_names:
             named_ids.update(server_name_to_agent_servers.get(server_name, {}).values())
-        candidate_ids = (candidate_ids & named_ids) if candidate_ids else named_ids
+        narrowed = (candidate_ids & named_ids) if candidate_ids else named_ids
+        if candidate_ids and named_ids and not narrowed:
+            _logger.debug(
+                "blast-radius narrow-by-server collapsed to empty: pkg=%s servers=%s candidates=%s",
+                pkg_name,
+                sorted(server_names),
+                sorted(candidate_ids),
+            )
+        candidate_ids = narrowed
 
     agent_names = {str(agent).strip() for agent in br_dict.get("affected_agents", []) if str(agent).strip()}
     if agent_names:
         agent_ids: set[str] = set()
         for agent_name in agent_names:
             agent_ids.update(agent_to_server_ids.get(agent_name, set()))
-        candidate_ids = (candidate_ids & agent_ids) if candidate_ids else agent_ids
+        narrowed = (candidate_ids & agent_ids) if candidate_ids else agent_ids
+        if candidate_ids and agent_ids and not narrowed:
+            _logger.debug(
+                "blast-radius narrow-by-agent collapsed to empty: pkg=%s agents=%s candidates=%s",
+                pkg_name,
+                sorted(agent_names),
+                sorted(candidate_ids),
+            )
+        candidate_ids = narrowed
 
     return sorted(candidate_ids)
 

--- a/src/agent_bom/graph/container.py
+++ b/src/agent_bom/graph/container.py
@@ -148,10 +148,26 @@ class UnifiedGraph:
 
         Reverse adjacency is ONLY added for bidirectional edges.
         Directed edges are one-way in the adjacency map.
+
+        When the (source, target, relationship) triple already exists,
+        the new edge's ``evidence`` dict is **merged into** the kept
+        edge instead of being silently dropped. The graph builder adds
+        the same logical edge from multiple paths (package-path edge
+        first, blast-radius edge second); without the merge, the second
+        caller's evidence (cvss, epss, kev, attack tags) was lost.
         """
         rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship)
         key = (edge.source, edge.target, rel)
         if key in self._edge_keys:
+            if edge.evidence:
+                for stored in self.adjacency.get(edge.source, []):
+                    if stored.target == edge.target and stored.relationship == edge.relationship:
+                        for evidence_key, value in edge.evidence.items():
+                            if value in (None, "", [], {}):
+                                continue
+                            if evidence_key not in stored.evidence or stored.evidence[evidence_key] in (None, "", [], {}):
+                                stored.evidence[evidence_key] = value
+                        break
             return
         self._edge_keys.add(key)
         self.edges.append(edge)

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -825,3 +825,45 @@ class TestCrossEnvironmentCorrelation:
         assert "agent:cursor-dev" in cloud_neighbor_targets, (
             "reverse lookup from cloud agent failed — bidirectional flag isn't being honored"
         )
+
+
+class TestEdgeEvidenceMerge:
+    """Audit-5: re-adding the same (source, target, relationship) edge
+    must merge the new evidence keys into the kept edge instead of
+    silently dropping them. The graph builder hits this whenever the
+    package-path edge is added before the blast-radius edge for the
+    same package; without the merge, cvss / epss / kev / attack-tag
+    evidence on the second-arriving edge was lost."""
+
+    def test_second_add_merges_evidence_keys(self):
+        from agent_bom.graph.container import UnifiedGraph
+        from agent_bom.graph.edge import UnifiedEdge
+        from agent_bom.graph.types import RelationshipType
+
+        g = UnifiedGraph(scan_id="merge", tenant_id="t1")
+        g.add_edge(
+            UnifiedEdge(
+                source="server:s",
+                target="pkg:p",
+                relationship=RelationshipType.DEPENDS_ON,
+                evidence={"data_source": "package-path", "is_direct": True},
+            )
+        )
+        g.add_edge(
+            UnifiedEdge(
+                source="server:s",
+                target="pkg:p",
+                relationship=RelationshipType.DEPENDS_ON,
+                evidence={"cvss": 7.5, "epss": 0.42, "kev": True, "is_direct": False},
+            )
+        )
+
+        kept = next(e for e in g.edges if e.source == "server:s" and e.target == "pkg:p")
+        # Second-add evidence keys land on the kept edge.
+        assert kept.evidence.get("cvss") == 7.5
+        assert kept.evidence.get("epss") == 0.42
+        assert kept.evidence.get("kev") is True
+        # Original keys preserved (not overwritten by truthy defaults).
+        assert kept.evidence.get("data_source") == "package-path"
+        # Conflict on existing key: kept side wins (no overwrite).
+        assert kept.evidence.get("is_direct") is True


### PR DESCRIPTION
## Summary

Closes the small tractable items from the audit-5 review of #2008. Multi-replica safety items (Postgres-backed counters + advisory locks + slowloris floor + fleet sync race) ship in **PR B** (next).

### 1. \`release.yml\` docs-site missed timeout — gate also missed it

Audit-4's sweep added \`timeout-minutes\` to 29 jobs but skipped \`release.yml::docs-site\`. The gate's \`_is_reusable_caller()\` returned \`True\` for any job with \`uses:\`, on the (incorrect) theory that the called workflow's per-job timeouts would bound the caller. They don't — GitHub treats the caller's \`timeout-minutes\` as the limit for the entire reusable workflow call, defaulting to **360 minutes** (six hours) when omitted.

**Fix**: \`timeout-minutes: 20\` on docs-site + flip the gate's helper to \`False\` so the same miss can't recur.

### 2. SAML relay-state cleanup runs only on consume

\`_new_saml_relay_state()\` inserted into \`_SAML_RELAY_STATES\` but never swept expired entries. An attacker who issued nonces but never completed the SAML round trip could grow the in-memory map unbounded. Sweep on issue too.

### 3. Graph \`add_edge\` dropped second-add evidence on dedup

When the builder added the package-path edge first and the blast-radius edge second for the same \`(source, target, relationship)\`, the second edge's evidence (cvss, epss, kev, attack tags) was silently discarded. Now the dedup branch merges new evidence keys into the kept edge — kept side wins on key conflicts. Adds \`TestEdgeEvidenceMerge\`.

### 4. \`_resolve_affected_server_ids\` intersection collapse is now logged

Narrow-by-server / narrow-by-agent intersections silently emptied when filters were disjoint. Adds a debug log so report inconsistency surfaces in operator logs without changing the production narrow-by-all-filters semantics.

### 5. Auth session attempt counter is now visibly clustered-unsafe

\`_AUTH_SESSION_ATTEMPTS\` is process-local — under N replicas the brute-force budget is silently \`limit × N\`. **PR B** replaces it with a Postgres-backed counter when \`AGENT_BOM_POSTGRES_URL\` is set; **this PR** adds a one-shot WARNING log on first use whenever clustered mode is detected so operators see the gap in the meantime.

## Test plan

- [x] \`pytest tests/test_graph_builder.py tests/test_api_operator_policy.py tests/test_api_hardening.py -q\` — **123 passed** (1 new + 122 existing).
- [x] \`python scripts/check_workflow_timeouts.py\` — clean.
- [x] \`ruff check\` + \`mypy\` on touched files — clean.

PR B follows with the multi-replica work.