### PR TITLE
fix(security): close OpenSSF Scorecard regressions (Dangerous-Workflow, Token-Permissions, Vulnerabilities)

### DIFF
--- a/.github/workflows/dependabot-ui-lockfile-normalize.yml
+++ b/.github/workflows/dependabot-ui-lockfile-normalize.yml
@@ -7,9 +7,7 @@ on:
       - 'ui/package.json'
       - 'ui/package-lock.json'
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   normalize-ui-lockfile:
@@ -20,11 +18,18 @@ jobs:
       github.event.pull_request.user.login == 'app/dependabot'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Check out Dependabot branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          # Pin to the immutable head SHA captured at workflow trigger time so
+          # the actor cannot mutate the branch between job dispatch and
+          # checkout. Scorecard's Dangerous-Workflow check flags `head.ref`
+          # in `pull_request_target` because the ref is mutable.
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -47,6 +52,12 @@ jobs:
           npm install --package-lock-only --ignore-scripts
 
       - name: Commit normalized lockfile
+        # HEAD_REF goes through the env (not direct `${{ }}` expansion in the
+        # shell body) so a maliciously named branch can't inject shell
+        # metacharacters. We checked out by SHA, so we are in detached HEAD
+        # and must push back to the PR's branch by full refspec.
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           if git diff --quiet -- ui/package-lock.json; then
             echo "No normalized lockfile changes to commit."
@@ -57,4 +68,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add ui/package-lock.json
           git commit -m "chore(ui): normalize package-lock under pinned npm"
-          git push
+          git push origin "HEAD:refs/heads/${HEAD_REF}"

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -77,3 +77,30 @@ reason = "Flask session cookie disclosure — fixed in 2.3.8, our locked version
 [[IgnoredVulns]]
 id = "PYSEC-2023-62"
 reason = "Flask alias (GHSA-m2qf-hxjv-5gpq) — fixed in 3.1.3"
+
+# ── requests — FIXED in 2.33.0 (our locked version is 2.33.1) ───────────────
+
+[[IgnoredVulns]]
+id = "GHSA-gc5v-m9x4-r6x2"
+reason = "requests <2.33.0 .netrc credential leak — fixed in 2.33.0, our locked version is 2.33.1"
+
+# ── Test-fixture suppressions (PackageOverrides) ────────────────────────────
+# tests/fixtures/test-sbom-vuln.cdx.json deliberately ships vulnerable
+# package versions so the scanner's CVE-detection path can be exercised in
+# integration tests. These exact versions never appear in any deployable
+# manifest (see uv.lock), so suppressing them by name+version cannot mask a
+# real production exposure.
+
+[[PackageOverrides]]
+name = "flask"
+version = "2.2.0"
+ecosystem = "PyPI"
+ignore = true
+reason = "Intentionally-vulnerable test fixture (tests/fixtures/test-sbom-vuln.cdx.json); not a deployed dependency."
+
+[[PackageOverrides]]
+name = "werkzeug"
+version = "2.2.0"
+ecosystem = "PyPI"
+ignore = true
+reason = "Intentionally-vulnerable test fixture (tests/fixtures/test-sbom-vuln.cdx.json); not a deployed dependency."

--- a/tests/fixtures/test-sbom.cdx.json
+++ b/tests/fixtures/test-sbom.cdx.json
@@ -31,8 +31,8 @@
     {
       "type": "library",
       "name": "requests",
-      "version": "2.32.4",
-      "purl": "pkg:pypi/requests@2.32.4"
+      "version": "2.33.1",
+      "purl": "pkg:pypi/requests@2.33.1"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Scorecard score regressed **8.x → 5.6** after the new dependabot UI lockfile normalize workflow landed. This PR closes all three actionable zero findings in the latest run (`https://api.securityscorecards.dev/projects/github.com/msaad00/agent-bom`).

| Check | Before | Cause | Action |
|---|---|---|---|
| Dangerous-Workflow | 0 (CRITICAL) | `dependabot-ui-lockfile-normalize.yml:24` checked out `${{ github.event.pull_request.head.ref }}` under `pull_request_target` — mutable-ref untrusted checkout | Switch `ref` to immutable `head.sha`; push back via env-var refspec |
| Token-Permissions | 0 (HIGH) | Same workflow held top-level `contents: write` + `pull-requests: write` | Top-level → `permissions: {}`; writes declared at job level only |
| Vulnerabilities | 0 (HIGH) — 12 findings | Two CycloneDX fixtures under `tests/fixtures/` were treated as prod manifests by Scorecard's osv-scanner pass | Bump `requests` in non-vuln fixture to 2.33.1; declare the two intentionally-vuln fixture pins under `[[PackageOverrides]]` in `osv-scanner.toml`; add the missing `GHSA-gc5v-m9x4-r6x2` to `[[IgnoredVulns]]` |

The intentionally-vulnerable fixture (`test-sbom-vuln.cdx.json`) keeps its vulnerable pins — that fixture's whole purpose is exercising CVE detection in scanner integration tests. The override is name+version-scoped, and `uv.lock` already pins fixed versions for real prod (flask 3.1.3, werkzeug 3.1.8, requests 2.33.1, aiohttp 3.13.5, cryptography 46.0.7, tornado 6.5.5), so the suppression cannot mask a deployable exposure.

### Out of scope
- **Maintained = 0** — Scorecard heuristic ("repo created within last 90 days"); self-resolves as the window expires.
- **CI-Tests / SAST / Packaging / Signed-Releases = `?`** — Scorecard internal-error retries; clear on the next weekly run with no code change required.

### Release coupling
Latest tag is **v0.82.0** (commit \`62918240\`). v0.82.1 hotfix is queued in **#2022** but not yet merged. Land this PR first, then rebase #2022 on top so the v0.82.1 release ships with the Scorecard fixes baked in.

## Test plan
- [x] `python scripts/check_release_consistency.py` — local pass
- [x] `python scripts/check_workflow_timeouts.py` — local pass
- [ ] CI green on this PR
- [ ] After merge, wait one Scorecard cycle and verify overall score ≥ 8.0 with Dangerous-Workflow / Token-Permissions / Vulnerabilities each ≥ 7
- [ ] Rebase #2022 onto main and ship v0.82.1