### PR TITLE
fix(ui-image): pick lightningcss native binding by TARGETARCH (unblocks arm64)

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -13,9 +13,18 @@ COPY package.json package-lock.json* ./
 RUN npm ci --ignore-scripts
 # Next's webpack CSS pipeline requires lightningcss' native Linux binding.
 # Some npm versions omit optional platform bindings during lockfile-driven
-# installs, so pin the Linux binding in the image rather than relying on host
-# lockfile resolution behavior.
-RUN npm install --no-save --ignore-scripts lightningcss-linux-x64-gnu@1.32.0
+# installs, so pin the binding explicitly in the image. Buildx injects
+# TARGETARCH automatically (amd64 / arm64) when building multi-arch — pick
+# the matching prebuilt so `docker buildx --platform linux/amd64,linux/arm64`
+# does not try to install the x64 binary on an arm64 stage.
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH:-amd64}" in \
+      amd64) pkg="lightningcss-linux-x64-gnu@1.32.0" ;; \
+      arm64) pkg="lightningcss-linux-arm64-gnu@1.32.0" ;; \
+      *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    npm install --no-save --ignore-scripts "$pkg"
 
 # ── Stage 2: Build ────────────────────────────────────────────────────────────
 # pending-digest


### PR DESCRIPTION
## Summary

Closes the v0.82.1 release-pipeline failure on **\`Publish UI image\`** ([failed run](https://github.com/msaad00/agent-bom/actions/runs/25014397123)). The other 12 release jobs passed (PyPI, Docker Hub main image, Helm, Sigstore, SLSA, SBOM all green); only the multi-arch UI image build broke.

## Root cause

\`ui/Dockerfile:18\` hard-pinned the x64 native binding:

\`\`\`dockerfile
RUN npm install --no-save --ignore-scripts lightningcss-linux-x64-gnu@1.32.0
\`\`\`

\`docker/build-push-action\` runs \`buildx --platform linux/amd64,linux/arm64\` (release.yml:370), so the \`deps\` stage runs once per arch. On the arm64 stage, npm correctly rejects the x64 binary:

\`\`\`
npm error notsup Unsupported platform for lightningcss-linux-x64-gnu@1.32.0:
  wanted {os: linux, cpu: x64} (current: {os: linux, cpu: arm64})
ERROR: process \"/bin/sh -c npm install --no-save --ignore-scripts
  lightningcss-linux-x64-gnu@1.32.0\" did not complete successfully: exit code: 1
\`\`\`

## Fix

Consume the \`TARGETARCH\` build arg that buildx already injects, and install the matching prebuilt only:

\`\`\`dockerfile
ARG TARGETARCH
RUN set -eux; \\
    case \"\${TARGETARCH:-amd64}\" in \\
      amd64) pkg=\"lightningcss-linux-x64-gnu@1.32.0\" ;; \\
      arm64) pkg=\"lightningcss-linux-arm64-gnu@1.32.0\" ;; \\
      *) echo \"unsupported TARGETARCH=\${TARGETARCH}\" >&2; exit 1 ;; \\
    esac; \\
    npm install --no-save --ignore-scripts \"\$pkg\"
\`\`\`

Verified both binaries exist on npm at 1.32.0:
- \`lightningcss-linux-x64-gnu@1.32.0\` → os=linux, cpu=x64, libc=glibc
- \`lightningcss-linux-arm64-gnu@1.32.0\` → os=linux, cpu=arm64, libc=glibc

The \`amd64\` default keeps the existing single-arch local-dev path (\`docker build -f ui/Dockerfile ui\`) working — that's the same path used by the in-line **Smoke test UI container** step at release.yml:337, which builds without \`--platform\` and would otherwise pass an empty TARGETARCH.

## Why not change the smoke test instead

The smoke test isn't broken — it builds for the runner's host arch and exercises the container end-to-end. The break is only in the multi-arch publish step, which is exactly what \`TARGETARCH\` exists for.

## Release coupling

v0.82.1 cannot be re-published (project policy: never re-tag). After this lands, \`v0.82.2\` will need to be cut to ship the corrected \`agentbom/agent-bom-ui:0.82.2\` and \`:latest\`. The main image \`agentbom/agent-bom:0.82.1\`, PyPI \`agent-bom 0.82.1\`, and Helm chart \`0.82.1\` are unaffected and remain published.

## Test plan

- [x] \`docker buildx build --platform linux/amd64 -f ui/Dockerfile ui\` (host-native sanity)
- [ ] CI green on this PR
- [ ] After merge, on \`v0.82.2\`: \`Publish UI image\` job succeeds and publishes \`agentbom/agent-bom-ui:0.82.2\` + \`:latest\` for both \`linux/amd64\` and \`linux/arm64\`