### PR TITLE
chore(deps): upgrade pip 25.3 → 26.1 in runtime images (clears CVE-2026-1703)

### DIFF
--- a/deploy/docker/pip-requirements.txt
+++ b/deploy/docker/pip-requirements.txt
@@ -1,4 +1,11 @@
-# Intentionally empty.
+# Pip itself is upgraded over the version bundled with the pinned Python base
+# image to clear pip's own published advisories. Hashes are required because
+# the runtime stage installs with `--require-hashes`.
 #
-# Runtime images use the pip bundled with the pinned Python base image instead
-# of installing pip as an application dependency.
+# When bumping: `python scripts/refresh_pip_requirements.py` if available, else
+# `curl -fsSL https://pypi.org/pypi/pip/<version>/json | jq -r '.urls[] | "sha256:" + .digests.sha256'`
+# and copy the wheel + sdist hashes below.
+
+pip==26.1 \
+    --hash=sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1 \
+    --hash=sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3


### PR DESCRIPTION
## Summary

Self-scan on \`agentbom/agent-bom:0.82.2\` reports 3 CVEs:

| CVE | Sev | Package | Fixable | Action |
|---|---|---|---|---|
| CVE-2026-1703 | 2.0 (Low) | pypi/pip/25.3 | ✅ | Bump pip → 26.x (this PR) |
| CVE-2026-3219 | 4.6 (Medium) | pypi/pip/25.3 | ❌ | No upstream fix yet — track, not block |
| CVE-2025-60876 | 6.5 (Medium) | apk/alpine/busybox | ❌ | Sits in alpine base layer; clears when upstream alpine ships patched base |

This PR closes the one fixable item.

## How

Pip 25.3 is the version bundled with the \`python:3.14.3-alpine3.23\` base image. Every runtime stage already runs:

\`\`\`dockerfile
RUN pip install --no-cache-dir --require-hashes -r /tmp/pip-req.txt && rm /tmp/pip-req.txt
\`\`\`

across \`Dockerfile\`, \`Dockerfile.sse\`, \`Dockerfile.mcp\`, \`Dockerfile.snowpark\`, and \`Dockerfile.runtime\`, all sharing \`deploy/docker/pip-requirements.txt\`. That file was previously empty (\"intentionally empty\" comment); now it carries pip itself with hashes, so all five runtime images upgrade pip in one place.

Pip is published as both a wheel and an sdist; both hashes are pinned so \`--require-hashes\` is satisfied no matter which artifact pip 26.1's installer prefers on alpine.

## Verification

- Hashes pulled from \`https://pypi.org/pypi/pip/26.1/json\` and pinned in the requirements file.
- After merge + new tag, self-scan on the published image should drop CVE-2026-1703 from the dashboard.

## Out of scope

The two non-fixable Mediums above. CVE-2026-3219 will close when pip ships the fix; CVE-2025-60876 when alpine bumps the base. Both are tracked through self-scan dashboards on each release; neither warrants a release-time block since neither has a fix path that's actionable from this repo.

## Test plan

- [x] hashes verified against PyPI JSON API
- [ ] CI green on this PR
- [ ] After merge + next tag, self-scan on \`agentbom/agent-bom:<v>\` no longer reports CVE-2026-1703