### PR TITLE
typing: phase strict mypy onto four more API store modules (#1969)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,9 +213,13 @@ show_error_codes = true
 # New modules land here first; expand the glob as older modules are retyped.
 [[tool.mypy.overrides]]
 module = [
+    "agent_bom.api.audit_log",
     "agent_bom.api.compliance_signing",
     "agent_bom.api.dashboard_csp",
+    "agent_bom.api.exception_store",
+    "agent_bom.api.mcp_observation_store",
     "agent_bom.api.metrics",
+    "agent_bom.api.policy_store",
     "agent_bom.api.scim",
     "agent_bom.api.storage_schema",
     "agent_bom.api.tenant_quota_store",

--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -24,7 +24,7 @@ import threading
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Protocol
+from typing import Any, Protocol
 from uuid import uuid4
 
 from agent_bom.api.storage_schema import ensure_sqlite_schema_version
@@ -172,7 +172,7 @@ class AuditEntry:
     action: str = ""  # scan, policy_eval, fleet_change, exception, alert, config
     actor: str = ""  # API key prefix, role, or "system"
     resource: str = ""  # e.g., "job/abc123", "fleet/agent-1", "exception/exc-1"
-    details: dict = field(default_factory=dict)
+    details: dict[str, Any] = field(default_factory=dict)
     prev_signature: str = ""
     hmac_signature: str = ""
 
@@ -207,7 +207,7 @@ class AuditEntry:
             self.hmac_signature, self._legacy_hmac()
         )
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "entry_id": self.entry_id,
             "timestamp": self.timestamp,
@@ -380,10 +380,12 @@ class SQLiteAuditLog:
 
     @property
     def _conn(self) -> sqlite3.Connection:
-        if not hasattr(self._local, "conn") or self._local.conn is None:
-            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
-            self._local.conn.execute("PRAGMA journal_mode=WAL")
-        return self._local.conn
+        conn: sqlite3.Connection | None = getattr(self._local, "conn", None)
+        if conn is None:
+            conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            conn.execute("PRAGMA journal_mode=WAL")
+            self._local.conn = conn
+        return conn
 
     def _init_db(self) -> None:
         ensure_sqlite_schema_version(self._conn, "audit_log")
@@ -470,8 +472,8 @@ class SQLiteAuditLog:
         offset: int = 0,
         tenant_id: str | None = None,
     ) -> list[AuditEntry]:
-        clauses = []
-        params: list = []
+        clauses: list[str] = []
+        params: list[Any] = []
         if tenant_id is not None:
             clauses.append("json_extract(details, '$.tenant_id') = ?")
             params.append(tenant_id)

--- a/src/agent_bom/api/exception_store.py
+++ b/src/agent_bom/api/exception_store.py
@@ -17,7 +17,7 @@ import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Protocol
+from typing import Any, Protocol
 from uuid import uuid4
 
 from agent_bom.api.storage_schema import ensure_sqlite_schema_version
@@ -75,7 +75,7 @@ class VulnException:
         srv_match = self.server_name == "*" or self.server_name == server_name or not self.server_name
         return vuln_match and pkg_match and srv_match
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "exception_id": self.exception_id,
             "vuln_id": self.vuln_id,
@@ -152,10 +152,12 @@ class SQLiteExceptionStore:
 
     @property
     def _conn(self) -> sqlite3.Connection:
-        if not hasattr(self._local, "conn") or self._local.conn is None:
-            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
-            self._local.conn.execute("PRAGMA journal_mode=WAL")
-        return self._local.conn
+        conn: sqlite3.Connection | None = getattr(self._local, "conn", None)
+        if conn is None:
+            conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            conn.execute("PRAGMA journal_mode=WAL")
+            self._local.conn = conn
+        return conn
 
     def _init_db(self) -> None:
         ensure_sqlite_schema_version(self._conn, "exceptions")
@@ -247,8 +249,8 @@ class SQLiteExceptionStore:
         return cursor.rowcount > 0
 
     def list_all(self, status: str | None = None, tenant_id: str = "default") -> list[VulnException]:
-        clauses = ["tenant_id = ?"]
-        params: list = [tenant_id]
+        clauses: list[str] = ["tenant_id = ?"]
+        params: list[Any] = [tenant_id]
         if status:
             clauses.append("status = ?")
             params.append(status)

--- a/src/agent_bom/api/mcp_observation_store.py
+++ b/src/agent_bom/api/mcp_observation_store.py
@@ -43,12 +43,14 @@ class MCPObservation(BaseModel):
     @field_validator("tenant_id", mode="before")
     @classmethod
     def _normalize_tenant_id(cls, value: str | None) -> str:
-        return normalize_tenant_id(value)
+        result: str = normalize_tenant_id(value)
+        return result
 
     @field_validator("first_seen", "last_seen", "last_synced", "updated_at", mode="before")
     @classmethod
     def _normalize_timestamp(cls, value: str | None) -> str | None:
-        return normalize_timestamp(value)
+        result: str | None = normalize_timestamp(value)
+        return result
 
 
 def _pick_timestamp(*values: str | None, prefer: str) -> str | None:
@@ -130,10 +132,12 @@ class SQLiteMCPObservationStore:
 
     @property
     def _conn(self) -> sqlite3.Connection:
-        if not hasattr(self._local, "conn") or self._local.conn is None:
-            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
-            self._local.conn.execute("PRAGMA journal_mode=WAL")
-        return self._local.conn
+        conn: sqlite3.Connection | None = getattr(self._local, "conn", None)
+        if conn is None:
+            conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            conn.execute("PRAGMA journal_mode=WAL")
+            self._local.conn = conn
+        return conn
 
     def _init_db(self) -> None:
         ensure_sqlite_schema_version(self._conn, "mcp_observations")
@@ -173,7 +177,8 @@ class SQLiteMCPObservationStore:
         ).fetchone()
         if row is None:
             return None
-        return MCPObservation.model_validate_json(row[0])
+        obs: MCPObservation = MCPObservation.model_validate_json(row[0])
+        return obs
 
     def list_by_tenant(self, tenant_id: str) -> list[MCPObservation]:
         rows = self._conn.execute(

--- a/src/agent_bom/api/policy_store.py
+++ b/src/agent_bom/api/policy_store.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import sqlite3
 import threading
 from enum import Enum
-from typing import Protocol
+from typing import Any, Protocol
 
 from pydantic import BaseModel
 
@@ -62,7 +62,7 @@ class PolicyAuditEntry(BaseModel):
     rule_id: str
     agent_name: str
     tool_name: str
-    arguments_preview: dict = {}
+    arguments_preview: dict[str, Any] = {}
     action_taken: str  # "blocked" | "alerted" | "allowed"
     reason: str
     timestamp: str = ""
@@ -176,10 +176,12 @@ class SQLitePolicyStore:
 
     @property
     def _conn(self) -> sqlite3.Connection:
-        if not hasattr(self._local, "conn") or self._local.conn is None:
-            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
-            self._local.conn.execute("PRAGMA journal_mode=WAL")
-        return self._local.conn
+        conn: sqlite3.Connection | None = getattr(self._local, "conn", None)
+        if conn is None:
+            conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            conn.execute("PRAGMA journal_mode=WAL")
+            self._local.conn = conn
+        return conn
 
     def _init_db(self) -> None:
         c = self._conn
@@ -248,7 +250,8 @@ class SQLitePolicyStore:
         row = self._conn.execute(sql, params).fetchone()
         if row is None:
             return None
-        return GatewayPolicy.model_validate_json(row[0])
+        policy: GatewayPolicy = GatewayPolicy.model_validate_json(row[0])
+        return policy
 
     def delete_policy(self, policy_id: str, tenant_id: str | None = None) -> bool:
         sql = "DELETE FROM gateway_policies WHERE policy_id = ?"

--- a/src/agent_bom/api/stores.py
+++ b/src/agent_bom/api/stores.py
@@ -162,7 +162,7 @@ def set_policy_store(store: Any) -> None:
 _analytics_store: Any = None
 
 
-def _get_analytics_store():
+def _get_analytics_store() -> Any:
     """Get the active analytics store, defaulting to NullAnalyticsStore."""
     global _analytics_store
     if _analytics_store is None:


### PR DESCRIPTION
## Summary

Phase 2 of the strict-mypy migration tracked in **#1969**. Adds four API store modules to the \`[tool.mypy.overrides]\` strict block.

| Module | Before | After |
|---|---|---|
| \`agent_bom.api.audit_log\` | global config (untyped-defs allowed) | \`disallow_untyped_defs = true\` |
| \`agent_bom.api.exception_store\` | global config | strict |
| \`agent_bom.api.mcp_observation_store\` | global config | strict |
| \`agent_bom.api.policy_store\` | global config | strict |

Strict module count **9 → 13**. Same shape as the prior phase (#2003).

## Type-tightening (zero behavior change)

- **Threadlocal sqlite3.Connection helpers** (4 modules) — replace \`hasattr(self._local, 'conn')\` guard with a typed local; \`getattr\` returns \`sqlite3.Connection | None\`, so the property returns \`Connection\` without \`Any\` leaking.
- **Fully parameterized generics**: \`dict[str, Any]\` / \`list[Any]\` / \`list[str]\` on \`AuditEntry.details\`, \`AuditEntry.to_dict\`, \`VulnException.to_dict\`, \`PolicyAuditEntry.arguments_preview\`, audit_log query clauses/params, exception_store \`list_all\` clauses/params.
- **Pydantic boundaries**: \`field_validator\` and \`model_validate_json\` results assigned to typed locals before return — required because pre-commit's \`mypy --follow-imports=skip\` pass does not see Pydantic's overload returns and would otherwise emit \`[no-any-return]\`.
- **\`stores._get_analytics_store\`**: explicit \`-> Any\` return type so callers in strict modules don't trip \`[no-untyped-call]\`.

## Verification

\`\`\`
uv run mypy --strict src/agent_bom/api/{audit_log,exception_store,
  mcp_observation_store,policy_store}.py     Success: no issues found
uv run mypy src/agent_bom                    Success: 415 source files
uv run mypy --ignore-missing-imports --no-error-summary
  --follow-imports=skip src/agent_bom        no errors
\`\`\`

Last invocation matches pre-commit's exact mypy flags so the pre-commit gate is provably clean.

## Test plan

- [x] mypy strict on the four modules (above)
- [x] mypy global on full src (above)
- [x] pre-commit local run (above)
- [ ] CI green on this PR