### PR TITLE
fix(readme): repair self-hosted mermaid + drop redundant engine-internals image

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,20 +153,11 @@ Agent-centered shared-infrastructure graph — selected agents, their shared MCP
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/scan-pipeline-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/scan-pipeline-light.svg" alt="agent-bom scan pipeline — discover, scan, analyze, report, enforce" width="900" />
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/scan-pipeline-light.svg" alt="agent-bom scan pipeline — discover, scan, analyze, report, enforce" width="900" style="max-width: 100%; height: auto;" />
   </picture>
 </p>
 
-Inside the engine: parsers, taint, call graph, blast-radius scoring.
-
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/engine-internals-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/engine-internals-light.svg" alt="agent-bom engine internals" width="900" />
-  </picture>
-</p>
-
-External calls are limited to package metadata, version lookups, and CVE enrichment.
+Inside the engine: parsers, taint, call graph, blast-radius scoring. External calls are limited to package metadata, version lookups, and CVE enrichment.
 
 </details>
 
@@ -190,11 +181,16 @@ Two diagrams explain the self-hosted shape without collapsing into one overloade
 - [Enterprise Self-Hosted Data and Runtime Flow](site-docs/deployment/overview.md#enterprise-self-hosted-data-and-runtime-flow)
 
 ```mermaid
+%%{init: {"theme":"base","themeVariables":{"primaryColor":"#0f172a","primaryBorderColor":"#6366f1","primaryTextColor":"#e0e7ff","lineColor":"#64748b"}}}%%
 flowchart LR
-    Scan["Scans + Fleet"] --> API["API + UI + Postgres"]
-    API --> Graph["Findings + Graph + Audit"]
-    API --> Gateway["Optional Gateway"]
-    API --> Proxy["Optional Proxy"]
+    classDef ctrl fill:#0f172a,stroke:#6366f1,color:#e0e7ff
+    classDef data fill:#0f172a,stroke:#f59e0b,color:#fef3c7
+    classDef edge fill:#0f172a,stroke:#38bdf8,color:#e0f2fe
+
+    Scan["Scans + Fleet"]:::data --> API["API + UI + Postgres"]:::ctrl
+    API --> Graph["Findings + Graph + Audit"]:::data
+    API --> Gateway["Optional Gateway"]:::edge
+    API --> Proxy["Optional Proxy"]:::edge
 ```
 
 Deployment truth:


### PR DESCRIPTION
## Summary

Two README rendering bugs surfaced in dark-mode viewers / GitHub:

### 1. Self-hosted mermaid rendered as a blank box

The small flowchart under \"Two diagrams explain the self-hosted shape\" was using the default mermaid theme, which leaves text invisible against GitHub's dark canvas. The neighboring \`site-docs/deployment/overview.md\` diagrams render fine because each block declares an explicit theme + \`classDef\` styling.

Adopt the same shape here:
\`\`\`mermaid
%%{init: {\"theme\":\"base\",\"themeVariables\":{...}}}%%
flowchart LR
    classDef ctrl fill:#0f172a,stroke:#6366f1,color:#e0e7ff
    ...
\`\`\`

No diagram content changes — only the rendering contract.

### 2. Two redundant pipeline images stacked

The collapsible \"How a scan moves through the system\" block embedded both:
- \`scan-pipeline-{light,dark}.svg\` — 5 stages (discover/scan/analyze/report/enforce)
- \`engine-internals-{light,dark}.svg\` — a 4-stage rephrasing of the same pipeline

On dense viewports the second image's labels overlapped its container; on desktop the duplication added scroll without new information.

**Resolution**: keep the stronger 5-stage \`scan-pipeline\` image (covers the \`enforce\` column the engine-internals one omits), fold the engine-internals one-liner gloss (\"parsers, taint, call graph, blast-radius scoring\") into the existing prose, and add \`max-width: 100%; height: auto\` so the kept image wraps cleanly on narrow viewports.

## Test plan
- [x] Mermaid renders with visible nodes/edges in GitHub dark mode (verified locally via mermaid live editor with the same init block)
- [x] No content removed beyond the redundant image — gloss prose preserved
- [ ] CI green