### PR TITLE
ops(ci): document + script merge-queue enablement to end stranded CI

### DIFF
--- a/docs/operations/CI_RUNBOOK.md
+++ b/docs/operations/CI_RUNBOOK.md
@@ -55,7 +55,43 @@ Pick one — none of these can be enabled from a workflow file alone.
 | **Use a GitHub App / PAT for auto-merge** | Replace the bot identity for `Update branch` pushes | Pushes from a non-`GITHUB_TOKEN` identity do fire workflows. Requires creating + scoping a dedicated app or token. |
 
 The merge queue is the recommended option for this repo because the workflow
-is already wired for `merge_group`.
+is already wired for `merge_group`. The three required-status-check workflows
+(`ci.yml`, `codeql.yml`, `pr-security-gate.yml`) all declare:
+
+```yaml
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+```
+
+so once branch protection is flipped, the queue runs the same checks that
+gate PRs today — no workflow edits required.
+
+#### How to flip it
+
+The merge queue cannot be enabled via the legacy `branches/{branch}/protection`
+REST endpoint. Use the **repository rulesets** API (or the Settings UI). The
+helper script wraps the API call:
+
+```sh
+# preview the payload (no changes made)
+scripts/enable_merge_queue.sh --dry-run
+
+# enable on main (requires admin token; one-time)
+GH_TOKEN=<admin-pat> scripts/enable_merge_queue.sh
+```
+
+If you prefer the UI: **Settings → Branches → main → Edit rule →** check
+"Require merge queue", set the same status-check list as today, save. Confirm
+with `gh api repos/<owner>/<repo>/branches/main/protection --jq .required_status_checks`.
+
+After enabling, "Update branch" disappears from the PR view; the
+`Merge when ready` button puts the PR into the queue, which rebases + tests
+the merge candidate against current `main` and only fast-forwards once green.
+Stranded-CI from `GITHUB_TOKEN` pushes is no longer reachable: the queue
+authors its merge commits with a non-`GITHUB_TOKEN` identity, so workflows
+fire normally.
 
 ---
 

--- a/scripts/enable_merge_queue.sh
+++ b/scripts/enable_merge_queue.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Enable GitHub merge queue on `main` so PRs stop getting stranded by
+# GITHUB_TOKEN-authored "Update branch" pushes.
+#
+# Background: the legacy branches/{branch}/protection REST endpoint does not
+# expose merge_queue config. Merge queue is configured via the repository
+# rulesets API (or the Settings UI). This script writes a ruleset whose
+# required_status_checks match the current branch-protection rule.
+#
+# Usage:
+#   scripts/enable_merge_queue.sh --dry-run   # preview the payload
+#   GH_TOKEN=<admin-pat> scripts/enable_merge_queue.sh
+#
+# Requires: gh CLI authenticated against the repo with admin scope (the
+# default user token from `gh auth login` lacks `administration:write` on
+# org repos; use a fine-grained PAT if needed).
+
+set -euo pipefail
+
+DRY_RUN="false"
+if [ "${1:-}" = "--dry-run" ]; then
+  DRY_RUN="true"
+fi
+
+REPO="${GH_REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+BRANCH="main"
+
+# These are the canonical required checks today. Keep this list in sync with
+# the branch-protection rule until both move to the same source of truth
+# (the ruleset itself once merge queue is on).
+REQUIRED_CHECKS=(
+  "Lint and Type Check"
+  "Test (Python 3.11)"
+  "Test (Python 3.13)"
+  "Test (Python 3.14)"
+  "Build Package"
+  "Security Scan"
+  "CodeQL"
+)
+
+# Build the JSON checks array.
+CHECKS_JSON="$(printf '%s\n' "${REQUIRED_CHECKS[@]}" | jq -R . | jq -s 'map({context: ., integration_id: null})')"
+
+PAYLOAD="$(jq -n \
+  --arg name "merge-queue-${BRANCH}" \
+  --arg ref "refs/heads/${BRANCH}" \
+  --argjson checks "${CHECKS_JSON}" \
+  '{
+    name: $name,
+    target: "branch",
+    enforcement: "active",
+    conditions: { ref_name: { include: [$ref], exclude: [] } },
+    rules: [
+      { type: "deletion" },
+      { type: "non_fast_forward" },
+      { type: "required_signatures" },
+      { type: "pull_request",
+        parameters: {
+          required_approving_review_count: 1,
+          dismiss_stale_reviews_on_push: false,
+          require_code_owner_review: false,
+          require_last_push_approval: false,
+          required_review_thread_resolution: false
+        }
+      },
+      { type: "required_status_checks",
+        parameters: {
+          strict_required_status_checks_policy: false,
+          required_status_checks: $checks
+        }
+      },
+      { type: "merge_queue",
+        parameters: {
+          check_response_timeout_minutes: 60,
+          grouping_strategy: "ALLGREEN",
+          max_entries_to_build: 5,
+          max_entries_to_merge: 5,
+          merge_method: "SQUASH",
+          min_entries_to_merge: 1,
+          min_entries_to_merge_wait_minutes: 5
+        }
+      }
+    ]
+  }')"
+
+if [ "${DRY_RUN}" = "true" ]; then
+  printf "Would POST the following ruleset to repos/%s/rulesets:\n\n%s\n" \
+    "${REPO}" "${PAYLOAD}"
+  exit 0
+fi
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "GH_TOKEN is required (admin-scope PAT). Run with --dry-run to preview." >&2
+  exit 64
+fi
+
+echo "Creating merge-queue ruleset on ${REPO}@${BRANCH}…"
+echo "${PAYLOAD}" | gh api \
+  --method POST \
+  -H "Accept: application/vnd.github+json" \
+  "repos/${REPO}/rulesets" \
+  --input -
+
+echo
+echo "Done. Verify in Settings → Rules → Rulesets, or with:"
+echo "  gh api repos/${REPO}/rulesets --jq '.[] | select(.name == \"merge-queue-${BRANCH}\")'"
+echo
+echo "Note: if a legacy branch-protection rule on '${BRANCH}' is still active,"
+echo "either delete it (Settings → Branches) or trust the ruleset to take over."


### PR DESCRIPTION
## Summary

Adds the missing operator-level fix for the recurring "PR frozen after Update branch" pattern. The runbook already named merge queue as the recommended fix; this PR makes it actionable.

## What changed

- **`docs/operations/CI_RUNBOOK.md`** now spells out:
  - Which workflows are already merge-queue-ready (they all are — `ci.yml`, `codeql.yml`, `pr-security-gate.yml` declare `merge_group: types: [checks_requested]`).
  - Why the legacy `branches/{branch}/protection` REST endpoint cannot enable merge queue, and that the **repository rulesets** API is the right surface.
  - A copy-pasteable `gh api` flow via the new script.
  - The UI fallback path (Settings → Branches → "Require merge queue").
- **`scripts/enable_merge_queue.sh`** writes a `merge-queue-main` ruleset that pins the same seven required status checks branch protection already enforces (Lint and Type Check, Test (Python 3.11/3.13/3.14), Build Package, Security Scan, CodeQL). `--dry-run` prints the payload; admin token via `GH_TOKEN` performs the create.

## Why this closes the recurring strand

Once the ruleset is active, "Update branch" disappears from the PR view; the queue rebases + re-tests the merge candidate against current `main` and only fast-forwards when green. Stranded-CI from `GITHUB_TOKEN`-authored merges is no longer reachable because the queue's merge identity is not `GITHUB_TOKEN`.

## Test plan
- [x] `scripts/enable_merge_queue.sh --dry-run` prints a valid ruleset JSON with `pull_request`, `required_status_checks`, and `merge_queue` rule blocks
- [ ] CI green
- [ ] (one-time, manual) Run with `GH_TOKEN=<admin-pat>` to enable on `main`