### PR TITLE
ci: scheduled auto-retrigger workflow for stranded PRs

### DIFF
--- a/.github/workflows/auto-retrigger-stranded.yml
+++ b/.github/workflows/auto-retrigger-stranded.yml
@@ -1,0 +1,102 @@
+name: Auto-Retrigger Stranded PRs
+
+# Permanent fix for the recurring "PR frozen after Update branch" pattern.
+#
+# When auto-merge or the "Update branch" button advances a PR's head SHA,
+# the resulting commit is authored by GITHUB_TOKEN. GitHub Actions
+# intentionally does NOT trigger pull_request workflows from
+# GITHUB_TOKEN-authored events (anti-loop guard), so the PR ends up with
+# zero check-runs on the current head and stays mergeable_state=blocked
+# forever. Background: docs/operations/CI_RUNBOOK.md.
+#
+# This workflow polls every 5 minutes (or on demand), finds PRs whose
+# current head SHA has no check-runs, and runs scripts/retrigger_stranded_pr.sh
+# (close + reopen) which fires the pull_request workflows from scratch.
+#
+# Triggered from a workflow (not GITHUB_TOKEN's push), the close/reopen
+# events are properly recorded and our pull_request hooks fire on the
+# new head SHA — exactly the result a manual retrigger gives.
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"   # every 5 minutes
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: auto-retrigger-stranded
+  cancel-in-progress: false
+
+jobs:
+  scan:
+    name: Scan and retrigger
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Find and retrigger stranded PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUIRED_CHECK: "Lint and Type Check"
+          # Skip PRs younger than this — give pull_request workflows a
+          # chance to start before we declare them stranded. The retrigger
+          # script also no-ops when the required check is already present,
+          # but skipping young PRs keeps the workflow log readable.
+          MIN_AGE_MINUTES: "10"
+        run: |
+          set -euo pipefail
+          echo "Listing open PRs…"
+          mapfile -t PRS < <(
+            gh pr list \
+              --state open \
+              --limit 50 \
+              --json number,headRefOid,updatedAt,isDraft \
+              --jq '.[] | select(.isDraft == false) | "\(.number) \(.headRefOid) \(.updatedAt)"'
+          )
+
+          NOW_EPOCH="$(date -u +%s)"
+          STRANDED=0
+          RETRIGGERED=0
+
+          for line in "${PRS[@]}"; do
+            read -r PR SHA UPDATED <<< "$line"
+            UPDATED_EPOCH="$(date -u -d "$UPDATED" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED" +%s)"
+            AGE_SECONDS=$(( NOW_EPOCH - UPDATED_EPOCH ))
+            if [ "$AGE_SECONDS" -lt $(( 60 * MIN_AGE_MINUTES )) ]; then
+              echo "PR #${PR}: too young (${AGE_SECONDS}s old), skipping."
+              continue
+            fi
+
+            HITS="$(
+              gh api "repos/${{ github.repository }}/commits/${SHA}/check-runs" \
+                --jq "[.check_runs[] | select(.name == \"${REQUIRED_CHECK}\")] | length"
+            )"
+
+            if [ "$HITS" -gt 0 ]; then
+              echo "PR #${PR}: ${HITS} '${REQUIRED_CHECK}' run(s) on head ${SHA:0:8} — healthy."
+              continue
+            fi
+
+            STRANDED=$(( STRANDED + 1 ))
+            echo "PR #${PR}: 0 '${REQUIRED_CHECK}' runs on head ${SHA:0:8} — stranded."
+
+            if [ -x scripts/retrigger_stranded_pr.sh ]; then
+              if scripts/retrigger_stranded_pr.sh "$PR"; then
+                RETRIGGERED=$(( RETRIGGERED + 1 ))
+              else
+                echo "PR #${PR}: retrigger script failed (continuing with next PR)."
+              fi
+            else
+              echo "scripts/retrigger_stranded_pr.sh not executable on this checkout; skipping."
+            fi
+          done
+
+          echo
+          echo "Summary: ${STRANDED} stranded PR(s), ${RETRIGGERED} retriggered."

--- a/docs/operations/CI_RUNBOOK.md
+++ b/docs/operations/CI_RUNBOOK.md
@@ -44,9 +44,27 @@ The script:
 The script no-ops when the required check is already present, so it is safe to
 run on any PR.
 
-### Permanent fix options (settings change required)
+### Permanent fix: scheduled auto-retrigger (recommended, already on)
 
-Pick one — none of these can be enabled from a workflow file alone.
+`.github/workflows/auto-retrigger-stranded.yml` runs `scripts/retrigger_stranded_pr.sh`
+against every open PR whose current head SHA has zero `Lint and Type Check`
+runs. Cron is `*/5 * * * *`, plus `workflow_dispatch` for on-demand. Once
+this workflow is on the default branch, stranded PRs unstrand themselves
+within five minutes — no operator action required.
+
+Operator-side troubleshooting if a strand persists past ~10 minutes:
+
+- Did the workflow itself run? `gh run list --workflow=auto-retrigger-stranded.yml --limit 5`
+- Was the PR younger than `MIN_AGE_MINUTES` (10 min)? It's intentionally
+  skipped to give the initial `pull_request` workflow a chance to start.
+- Did `gh api commits/{sha}/check-runs` return zero, or is there a
+  different check name now? Update `REQUIRED_CHECK` in the workflow if
+  the canonical check is renamed.
+
+### Permanent fix alternatives (settings change required)
+
+The auto-retrigger workflow above is the cheapest path. The following
+alternatives still apply if you prefer settings-level fixes; pick one.
 
 | Option | Where | Tradeoff |
 |---|---|---|
@@ -68,23 +86,20 @@ on:
 so once branch protection is flipped, the queue runs the same checks that
 gate PRs today — no workflow edits required.
 
-#### How to flip it
+#### How to flip it (UI-only as of 2026-04)
 
-The merge queue cannot be enabled via the legacy `branches/{branch}/protection`
-REST endpoint. Use the **repository rulesets** API (or the Settings UI). The
-helper script wraps the API call:
+REST attempts return HTTP 422 "Invalid rule 'merge_queue'" on this repo's
+auth path. The Settings UI is the only supported toggle today.
 
-```sh
-# preview the payload (no changes made)
-scripts/enable_merge_queue.sh --dry-run
+1. https://github.com/msaad00/agent-bom/settings/branches
+2. Edit the rule for `main`
+3. Check ✅ **Require merge queue**
+4. Set merge method to **Squash** and pin the same required status checks
+   used today (Lint and Type Check, Test (Python 3.11/3.13/3.14), Build
+   Package, Security Scan, CodeQL)
+5. Save
 
-# enable on main (requires admin token; one-time)
-GH_TOKEN=<admin-pat> scripts/enable_merge_queue.sh
-```
-
-If you prefer the UI: **Settings → Branches → main → Edit rule →** check
-"Require merge queue", set the same status-check list as today, save. Confirm
-with `gh api repos/<owner>/<repo>/branches/main/protection --jq .required_status_checks`.
+Verify with `scripts/enable_merge_queue.sh --check`.
 
 After enabling, "Update branch" disappears from the PR view; the
 `Merge when ready` button puts the PR into the queue, which rebases + tests

--- a/scripts/enable_merge_queue.sh
+++ b/scripts/enable_merge_queue.sh
@@ -1,109 +1,67 @@
 #!/usr/bin/env bash
-# Enable GitHub merge queue on `main` so PRs stop getting stranded by
-# GITHUB_TOKEN-authored "Update branch" pushes.
+# Print the supported path for enabling GitHub merge queue on `main`.
 #
-# Background: the legacy branches/{branch}/protection REST endpoint does not
-# expose merge_queue config. Merge queue is configured via the repository
-# rulesets API (or the Settings UI). This script writes a ruleset whose
-# required_status_checks match the current branch-protection rule.
+# Why this is no longer a one-shot script
+# ───────────────────────────────────────
+# As of 2026-04, GitHub returns HTTP 422 "Invalid rule 'merge_queue'" when
+# a `merge_queue` rule is POSTed to repos/{owner}/{repo}/rulesets, even on
+# personal repos with `repo`-scoped tokens. The legacy
+# branches/{branch}/protection endpoint never exposed merge_queue at all.
+# The Settings UI is the only supported toggle.
+#
+# For the recurring stranded-CI pain that motivated wanting merge queue,
+# `.github/workflows/auto-retrigger-stranded.yml` is the practical fix:
+# it polls open PRs every 5 minutes and runs scripts/retrigger_stranded_pr.sh
+# against any whose current head SHA has zero check-runs. That neutralises
+# the GITHUB_TOKEN-authored-merge anti-loop guard without needing
+# repo-settings changes.
 #
 # Usage:
-#   scripts/enable_merge_queue.sh --dry-run   # preview the payload
-#   GH_TOKEN=<admin-pat> scripts/enable_merge_queue.sh
+#   scripts/enable_merge_queue.sh         # print steps
+#   scripts/enable_merge_queue.sh --check # print current ruleset/protection state
 #
-# Requires: gh CLI authenticated against the repo with admin scope (the
-# default user token from `gh auth login` lacks `administration:write` on
-# org repos; use a fine-grained PAT if needed).
 
 set -euo pipefail
-
-DRY_RUN="false"
-if [ "${1:-}" = "--dry-run" ]; then
-  DRY_RUN="true"
-fi
 
 REPO="${GH_REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
 BRANCH="main"
 
-# These are the canonical required checks today. Keep this list in sync with
-# the branch-protection rule until both move to the same source of truth
-# (the ruleset itself once merge queue is on).
-REQUIRED_CHECKS=(
-  "Lint and Type Check"
-  "Test (Python 3.11)"
-  "Test (Python 3.13)"
-  "Test (Python 3.14)"
-  "Build Package"
-  "Security Scan"
-  "CodeQL"
-)
-
-# Build the JSON checks array.
-CHECKS_JSON="$(printf '%s\n' "${REQUIRED_CHECKS[@]}" | jq -R . | jq -s 'map({context: ., integration_id: null})')"
-
-PAYLOAD="$(jq -n \
-  --arg name "merge-queue-${BRANCH}" \
-  --arg ref "refs/heads/${BRANCH}" \
-  --argjson checks "${CHECKS_JSON}" \
-  '{
-    name: $name,
-    target: "branch",
-    enforcement: "active",
-    conditions: { ref_name: { include: [$ref], exclude: [] } },
-    rules: [
-      { type: "deletion" },
-      { type: "non_fast_forward" },
-      { type: "required_signatures" },
-      { type: "pull_request",
-        parameters: {
-          required_approving_review_count: 1,
-          dismiss_stale_reviews_on_push: false,
-          require_code_owner_review: false,
-          require_last_push_approval: false,
-          required_review_thread_resolution: false
-        }
-      },
-      { type: "required_status_checks",
-        parameters: {
-          strict_required_status_checks_policy: false,
-          required_status_checks: $checks
-        }
-      },
-      { type: "merge_queue",
-        parameters: {
-          check_response_timeout_minutes: 60,
-          grouping_strategy: "ALLGREEN",
-          max_entries_to_build: 5,
-          max_entries_to_merge: 5,
-          merge_method: "SQUASH",
-          min_entries_to_merge: 1,
-          min_entries_to_merge_wait_minutes: 5
-        }
-      }
-    ]
-  }')"
-
-if [ "${DRY_RUN}" = "true" ]; then
-  printf "Would POST the following ruleset to repos/%s/rulesets:\n\n%s\n" \
-    "${REPO}" "${PAYLOAD}"
+if [ "${1:-}" = "--check" ]; then
+  echo "Repo: ${REPO}@${BRANCH}"
+  echo
+  echo "Active rulesets touching '${BRANCH}':"
+  gh api "repos/${REPO}/rules/branches/${BRANCH}" \
+    --jq '[.[] | .type] // [] | unique' 2>/dev/null || echo "  (none / 404)"
+  echo
+  echo "Branch-protection rule fields:"
+  gh api "repos/${REPO}/branches/${BRANCH}/protection" \
+    --jq 'keys' 2>/dev/null || echo "  (no legacy branch-protection rule)"
+  echo
+  echo "Auto-retrigger workflow status:"
+  gh workflow view auto-retrigger-stranded.yml --json state 2>/dev/null \
+    --jq '"  state=\(.state)"' || echo "  (workflow not present on default branch yet)"
   exit 0
 fi
 
-if [ -z "${GH_TOKEN:-}" ]; then
-  echo "GH_TOKEN is required (admin-scope PAT). Run with --dry-run to preview." >&2
-  exit 64
-fi
+cat <<EOF
+Merge queue cannot currently be enabled via REST on this repo's auth path.
 
-echo "Creating merge-queue ruleset on ${REPO}@${BRANCH}…"
-echo "${PAYLOAD}" | gh api \
-  --method POST \
-  -H "Accept: application/vnd.github+json" \
-  "repos/${REPO}/rulesets" \
-  --input -
+Supported steps (one-time):
 
-echo
-echo "Done. Verify in Settings → Rules → Rulesets, or with:"
-echo "  gh api repos/${REPO}/rulesets --jq '.[] | select(.name == \"merge-queue-${BRANCH}\")'"
-echo
-echo "Note: if a legacy branch-protection rule on '${BRANCH}' is still active,"
-echo "either delete it (Settings → Branches) or trust the ruleset to take over."
+  1. https://github.com/${REPO}/settings/branches
+  2. Edit the rule for '${BRANCH}' (or add one if absent)
+  3. Check  ✅  Require merge queue
+  4. Set the merge method to Squash and the same required status checks
+     used today (Lint and Type Check, Test (Python 3.11/3.13/3.14),
+     Build Package, Security Scan, CodeQL)
+  5. Save
+
+Verify with:
+
+  scripts/enable_merge_queue.sh --check
+
+Until the toggle is on, the practical fix for stranded PRs is the
+scheduled workflow at .github/workflows/auto-retrigger-stranded.yml,
+which auto-runs scripts/retrigger_stranded_pr.sh every 5 minutes. No
+operator action needed once it's on the default branch.
+EOF


### PR DESCRIPTION
## Summary

The merge-queue path documented in #2034 turns out to be **UI-only** — GitHub returns `HTTP 422 "Invalid rule 'merge_queue'"` when the rule is POSTed via repository rulesets, even on personal repos with `repo`-scoped tokens. The legacy `branches/{branch}/protection` endpoint never exposed `merge_queue`.

Rather than wait for GitHub to publish a stable REST surface, this PR gives operators a **cheap, no-settings-required permanent fix** for the recurring "PR frozen after Update branch" pattern.

## What landed

- **`.github/workflows/auto-retrigger-stranded.yml`** — cron every 5 min (plus `workflow_dispatch`). Lists open non-draft PRs older than 10 min, checks whether the canonical `Lint and Type Check` ran on the current head SHA, and runs `scripts/retrigger_stranded_pr.sh` against any that come up empty.
- **`scripts/enable_merge_queue.sh`** — pivoted from "do it via REST" to "print the UI steps and verify state via `--check`". Documents the 422 observation up front so the next person doesn't waste time on the REST path.
- **`docs/operations/CI_RUNBOOK.md`** — promotes the auto-retrigger workflow to the recommended permanent fix; demotes the merge-queue-via-REST path to "UI only" with the GitHub URL pre-filled.

## Why a 5-minute cadence

Stranded PRs are not user-blocking in the latency sense — the operator has already approved and is waiting on CI. Five minutes is short enough that operators don't reach for the manual script, long enough to avoid double-firing when a freshly-pushed PR's `pull_request` workflow is still spinning up. `MIN_AGE_MINUTES=10` is the additional guard that prevents declaring a PR stranded before its initial workflow run has had a chance to register check-runs at all.

## What this does not solve

GITHUB_TOKEN-authored events still don't fire `pull_request` workflows — that's GitHub's intentional anti-loop guard. We just unblock the resulting strand by close+reopen, which fires `pull_request: reopened` and reruns the gate. If GitHub later exposes merge queue via REST, the helper script will be the natural place to add the toggle back.

## Test plan
- [x] Manual: ran `scripts/retrigger_stranded_pr.sh` against #2030 / #2031 / #2034 / #2035 successfully
- [x] Workflow YAML parses cleanly (pre-commit `check yaml` passed)
- [ ] First scheduled run after merge picks up any subsequent stranded PR within 5 min
- [ ] CI green