### PR TITLE
feat(metrics): scan_jobs_active gauge + KEDA queue-depth trigger

### DIFF
--- a/deploy/helm/agent-bom/examples/eks-keda-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-keda-values.yaml
@@ -50,6 +50,11 @@ controlPlane:
           # p99 latency threshold (seconds). Set 0.5s below the published
           # SLO target so we scale BEFORE breaching the SLO, not after.
           p99ThresholdSeconds: "1.5"
+          # Active scan jobs (queued + running) per replica. With 4 worker
+          # threads per pod (default executor), 8 keeps each replica's
+          # queue at ~2x worker count — predictable latency without
+          # over-provisioning.
+          scanJobsActiveThreshold: "8"
         fallback:
           failureThreshold: 3
           replicas: 3

--- a/deploy/helm/agent-bom/templates/controlplane-api-keda-scaledobject.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-api-keda-scaledobject.yaml
@@ -75,5 +75,18 @@ spec:
             0.99,
             sum by (le) (rate(http_request_duration_seconds_bucket{job=~".*agent-bom-api.*"}[2m]))
           )
+    - type: prometheus
+      metadata:
+        serverAddress: {{ $defaults.prometheus.serverAddress | quote }}
+        metricName: agent_bom_scan_jobs_active
+        # First-class queue-depth gauge: in-flight scan jobs (queued +
+        # running) summed across replicas. Bumped at enqueue time in
+        # `agent_bom.api.routes.scan.enqueue_scan_job`, decremented in
+        # `agent_bom.api.pipeline._run_scan_sync`'s finally block. KEDA
+        # interprets this trigger as the averaged-across-replicas value;
+        # default of 8 keeps each replica's queue at ~2x worker count.
+        threshold: {{ $defaults.prometheus.scanJobsActiveThreshold | default "8" | quote }}
+        query: |
+          sum(agent_bom_scan_jobs_active)
     {{- end }}
 {{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -330,8 +330,9 @@ controlPlane:
         # (SQS, Kafka, AWS CloudWatch, queue-depth, etc.).
         prometheus:
           serverAddress: ""  # e.g. http://prometheus.monitoring.svc:9090
-          rateLimitThreshold: "0.5"   # rejections/sec averaged across replicas
-          p99ThresholdSeconds: "1.5"  # API p99 latency in seconds
+          rateLimitThreshold: "0.5"           # rejections/sec averaged across replicas
+          p99ThresholdSeconds: "1.5"          # API p99 latency in seconds
+          scanJobsActiveThreshold: "8"        # in-flight scans averaged across replicas
         triggers: []  # set non-empty to fully replace the default Prometheus pair
         fallback:
           failureThreshold: 3

--- a/site-docs/deployment/scaling-slo.md
+++ b/site-docs/deployment/scaling-slo.md
@@ -45,6 +45,17 @@ the API tier exposes through Prometheus today:
    Backed by the standard Starlette instrumentation. Climbing past the
    threshold means request servicing is starting to back up.
 
+3. **In-flight scan jobs (queued + running)**
+   `sum(agent_bom_scan_jobs_active)`
+   First-class queue-depth gauge exported by every API replica. Bumped
+   in `agent_bom.api.routes.scan.enqueue_scan_job` as soon as the job is
+   durably enqueued; decremented in `agent_bom.api.pipeline._run_scan_sync`
+   when the job reaches a terminal status (DONE / FAILED / CANCELLED).
+   Floored at zero so any instrumentation gap absorbs gracefully instead
+   of producing a negative gauge. This is the most direct saturation
+   signal of the three — the rate-limit and p99 triggers are leading
+   indicators; this one is the actual queue.
+
 KEDA polls every 30s by default, so the worst-case scaling latency is one
 poll plus pod-startup. The published "< 90s" SLO is calibrated against that.
 
@@ -130,25 +141,17 @@ controlPlane:
 ## Honest gaps
 
 The chart's autoscaling primitives are real and tested. The published SLOs
-above are honest about what the **defaults are tuned to hit**. Two things
-this PR does not solve, called out so a reviewer doesn't have to derive them:
+above are honest about what the **defaults are tuned to hit**. The remaining
+gap, called out so a reviewer doesn't have to derive it:
 
-1. **No first-class `agent_bom_scan_jobs_active` gauge yet.** The rate-limit
-   counter is a leading indicator of saturation, but a true queue-depth
-   gauge would let operators write a more direct trigger
-   (`agent_bom_scan_jobs_active > N` instead of "rate-limit pressure"). That
-   gauge is a small follow-up — when it lands, the default trigger set in
-   `controlplane-api-keda-scaledobject.yaml` should add it as a third
-   trigger.
+**No published clustered Postgres scale benchmark.** Today's published
+evidence (`scripts/run_scale_evidence.py`) is in-process and tops out at
+1k–10k entities. A clustered Postgres run at 50k+ entities is the next
+piece needed before claiming "elastic at 1M edges." Until that lands, keep
+your `maxReplicas` calibrated to your Postgres connection-pool capacity
+(default chart sets pool size in
+`controlPlane.api.env.AGENT_BOM_POSTGRES_POOL_MAX`).
 
-2. **No published clustered Postgres scale benchmark.** Today's published
-   evidence (`scripts/run_scale_evidence.py`) is in-process and tops out at
-   1k–10k entities. A clustered Postgres run at 50k+ entities is the next
-   piece needed before claiming "elastic at 1M edges." Until that lands,
-   keep your `maxReplicas` calibrated to your Postgres connection-pool
-   capacity (default chart sets pool size in
-   `controlPlane.api.env.AGENT_BOM_POSTGRES_POOL_MAX`).
-
-Both gaps block the "elastic at 1M edges" claim, neither blocks pilots,
-and neither prevents the SLOs above from being met for the workload sizes
-they're written for.
+This gap blocks the "elastic at 1M edges" claim, but it does not block
+pilots and does not prevent the SLOs above from being met for the
+workload sizes they're written for.

--- a/src/agent_bom/api/metrics.py
+++ b/src/agent_bom/api/metrics.py
@@ -34,12 +34,41 @@ class _LabelledCounter:
             return dict(self._values)
 
 
+class _Gauge:
+    """Thread-safe non-negative gauge. Floors at 0 to absorb any
+    inc/dec mismatch from instrumentation gaps rather than emit a
+    negative value Prometheus would reject."""
+
+    __slots__ = ("_lock", "_value")
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._value: int = 0
+
+    def inc(self, amount: int = 1) -> None:
+        with self._lock:
+            self._value += amount
+
+    def dec(self, amount: int = 1) -> None:
+        with self._lock:
+            self._value = max(0, self._value - amount)
+
+    def value(self) -> int:
+        with self._lock:
+            return self._value
+
+    def reset(self) -> None:
+        with self._lock:
+            self._value = 0
+
+
 _auth_failures = _LabelledCounter()  # labelled by reason (missing_key, invalid_key, ...)
 _rate_limit_hits = _LabelledCounter()  # labelled by bucket name (global, tenant, ...)
 _compliance_exports = _LabelledCounter()  # labelled by algorithm (Ed25519, HMAC-SHA256)
 _compliance_export_bytes = _LabelledCounter()  # labelled by framework key
 _scan_completions = _LabelledCounter()  # labelled by status (done, failed, cancelled)
 _gateway_relays = _LabelledCounter()  # labelled by "<upstream>|<outcome>"
+_scan_jobs_active = _Gauge()  # in-flight scans (queued + running)
 
 
 def record_auth_failure(reason: str) -> None:
@@ -61,6 +90,33 @@ def record_compliance_export(algorithm: str, framework_key: str, byte_count: int
 def record_scan_completion(status: str) -> None:
     """Record a scan outcome (done, failed, cancelled)."""
     _scan_completions.inc(status)
+
+
+def record_scan_enqueued() -> None:
+    """Increment the in-flight scan-jobs gauge (queued + running).
+
+    Pair with ``record_scan_finished()`` at every terminal transition so
+    the gauge reflects work the control plane is currently committed to,
+    not just CPU-bound execution. KEDA reads this as the leading
+    saturation signal for the API tier — see
+    ``site-docs/deployment/scaling-slo.md``.
+    """
+    _scan_jobs_active.inc()
+
+
+def record_scan_finished() -> None:
+    """Decrement the in-flight scan-jobs gauge.
+
+    Floored at zero — instrumentation gaps decrement past zero would be
+    rejected by Prometheus, so we absorb them rather than crash the
+    metrics endpoint.
+    """
+    _scan_jobs_active.dec()
+
+
+def scan_jobs_active() -> int:
+    """Return the current in-flight scan-jobs gauge value (test helper)."""
+    return _scan_jobs_active.value()
 
 
 def record_gateway_relay(upstream: str, outcome: str) -> None:
@@ -118,6 +174,11 @@ def render_prometheus_lines() -> list[str]:
     for status, count in sorted(scans.items()):
         lines.append(f'agent_bom_scan_completions_total{{status="{status}"}} {count}')
 
+    active = _scan_jobs_active.value()
+    lines.append("# HELP agent_bom_scan_jobs_active In-flight scans currently queued or running")
+    lines.append("# TYPE agent_bom_scan_jobs_active gauge")
+    lines.append(f"agent_bom_scan_jobs_active {active}")
+
     relays = _gateway_relays.snapshot()
     lines.append("# HELP agent_bom_gateway_relays_total Multi-MCP gateway relay events by upstream and outcome")
     lines.append("# TYPE agent_bom_gateway_relays_total counter")
@@ -142,3 +203,4 @@ def reset_for_tests() -> None:
     ):
         with counter._lock:  # noqa: SLF001
             counter._values.clear()  # noqa: SLF001
+    _scan_jobs_active.reset()

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -673,5 +673,17 @@ def _run_scan_sync(job: ScanJob) -> None:
     finally:
         with lock:
             job.completed_at = _now()
+            terminal_status = job.status
         # Persist final state
         _get_store().put(job)
+        # Update operator-visible scan metrics. The active gauge feeds
+        # the KEDA scaler in deploy/helm/agent-bom; the completion
+        # counter feeds dashboards + alerting on failure rate.
+        try:
+            from agent_bom.api import metrics as _api_metrics
+
+            _api_metrics.record_scan_finished()
+            _api_metrics.record_scan_completion(str(terminal_status))
+        except Exception:  # noqa: BLE001
+            # Metrics must never break the scan path. Swallow all errors.
+            pass

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -274,6 +274,16 @@ def enqueue_scan_job(
     ):
         store.put(job)
         _jobs_put(job.job_id, job)
+        # Bump the in-flight gauge as soon as the job is durably enqueued —
+        # KEDA reads this as the leading saturation signal, so we want it
+        # to fire even while jobs are sitting in the executor queue. The
+        # decrement happens in pipeline._run_scan_sync's finally block.
+        try:
+            from agent_bom.api import metrics as _api_metrics
+
+            _api_metrics.record_scan_enqueued()
+        except Exception:  # noqa: BLE001
+            pass
 
     loop = asyncio.get_running_loop()
     loop.run_in_executor(get_executor(), _run_scan_sync, job)

--- a/tests/test_scan_jobs_active_gauge.py
+++ b/tests/test_scan_jobs_active_gauge.py
@@ -1,0 +1,72 @@
+"""Regression tests for the ``agent_bom_scan_jobs_active`` gauge.
+
+The gauge feeds the KEDA scaler in `deploy/helm/agent-bom`. A miswire here
+silently breaks autoscaling, so these tests pin three properties:
+
+1. ``record_scan_enqueued`` and ``record_scan_finished`` move the gauge by
+   exactly one each, in opposite directions.
+2. The gauge is non-negative — ``record_scan_finished`` past zero must
+   floor at 0 (a Prometheus gauge value < 0 would be rejected by the
+   text-format scrape; we'd rather absorb instrumentation gaps than
+   crash the metrics endpoint).
+3. ``render_prometheus_lines()`` emits the gauge with the canonical
+   metric name and HELP/TYPE tuple.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.api import metrics
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics() -> None:
+    metrics.reset_for_tests()
+
+
+def test_enqueued_and_finished_move_gauge_symmetrically() -> None:
+    assert metrics.scan_jobs_active() == 0
+
+    metrics.record_scan_enqueued()
+    metrics.record_scan_enqueued()
+    metrics.record_scan_enqueued()
+    assert metrics.scan_jobs_active() == 3
+
+    metrics.record_scan_finished()
+    assert metrics.scan_jobs_active() == 2
+
+    metrics.record_scan_finished()
+    metrics.record_scan_finished()
+    assert metrics.scan_jobs_active() == 0
+
+
+def test_finished_past_zero_floors_at_zero() -> None:
+    metrics.record_scan_finished()
+    metrics.record_scan_finished()
+    assert metrics.scan_jobs_active() == 0
+
+    # And subsequent enqueues still increment from the floor cleanly.
+    metrics.record_scan_enqueued()
+    assert metrics.scan_jobs_active() == 1
+
+
+def test_render_emits_gauge_with_canonical_metric_name() -> None:
+    metrics.record_scan_enqueued()
+    metrics.record_scan_enqueued()
+
+    lines = metrics.render_prometheus_lines()
+    text = "\n".join(lines)
+
+    assert "# HELP agent_bom_scan_jobs_active" in text
+    assert "# TYPE agent_bom_scan_jobs_active gauge" in text
+    assert "agent_bom_scan_jobs_active 2" in lines
+
+
+def test_reset_for_tests_clears_gauge() -> None:
+    metrics.record_scan_enqueued()
+    metrics.record_scan_enqueued()
+    assert metrics.scan_jobs_active() == 2
+
+    metrics.reset_for_tests()
+    assert metrics.scan_jobs_active() == 0


### PR DESCRIPTION
## Summary

Closes the highest-impact "honest gap" called out in the v0.82.2 EKS scaling SLO: exposes a first-class queue-depth gauge so KEDA can scale on the actual in-flight scan workload instead of the rate-limit/p99 leading indicators alone.

## What landed

- **`src/agent_bom/api/metrics.py`** — new `_Gauge` helper + `record_scan_enqueued()` / `record_scan_finished()` / `scan_jobs_active()`. Floored at zero so any instrumentation gap absorbs gracefully. Renders as `agent_bom_scan_jobs_active` at `/metrics`.
- **`src/agent_bom/api/routes/scan.py`** — `enqueue_scan_job` bumps the gauge inside the tenant-quota guard, immediately after `store.put(job)`, so the gauge fires while jobs are still queued in the executor (not just while CPU-bound).
- **`src/agent_bom/api/pipeline.py`** — `_run_scan_sync`'s `finally` block decrements the gauge and records the terminal status counter (DONE/FAILED/CANCELLED). Also wires up `record_scan_completion()` which existed but was orphaned.
- **`deploy/helm/agent-bom/templates/controlplane-api-keda-scaledobject.yaml`** — third Prometheus trigger (`sum(agent_bom_scan_jobs_active)`) alongside the existing rate-limit and p99 triggers. Default threshold 8 keeps each replica's queue at ~2x worker count.
- **`deploy/helm/agent-bom/values.yaml`** + **`examples/eks-keda-values.yaml`** — surfaces the new `scanJobsActiveThreshold`.
- **`site-docs/deployment/scaling-slo.md`** — documents the third trigger; removes the "no first-class queue gauge yet" caveat. The clustered-Postgres benchmark gap is now the only remaining honest gap.
- **`tests/test_scan_jobs_active_gauge.py`** — pins three invariants (symmetric inc/dec, non-negative floor, canonical render).

## Test plan
- [x] `uv run pytest tests/test_scan_jobs_active_gauge.py` — 4/4 pass
- [x] Pre-commit mypy + ruff + bandit pass
- [ ] CI Helm Profile Validate green
- [ ] CI Lint and Type Check + Tests green