### PR TITLE
feat: surface graph-walk reachability into BlastRadius scoring + UI

### DIFF
--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -47,6 +47,7 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_RISK_CRED_WEIGHT` | `float` | `0.3` | — |
 | `AGENT_BOM_RISK_EPSS_BOOST` | `float` | `0.5` | — |
 | `AGENT_BOM_RISK_KEV_BOOST` | `float` | `1.0` | — |
+| `AGENT_BOM_RISK_REACHABLE_BOOST` | `float` | `0.5` | Graph-walk reachability adjustment — applied only when `agent_bom.graph.dependency_reach.compute_dependency_reach` has stamped the BlastRadius with a definitive answer (None leaves scoring unchanged). reachable    → +0.5  (an agent's USES/D |
 | `AGENT_BOM_RISK_SCORECARD_B1` | `float` | `0.75` | — |
 | `AGENT_BOM_RISK_SCORECARD_B2` | `float` | `0.5` | — |
 | `AGENT_BOM_RISK_SCORECARD_B3` | `float` | `0.25` | — |
@@ -55,6 +56,7 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_RISK_SCORECARD_T3` | `float` | `7.0` | — |
 | `AGENT_BOM_RISK_TOOL_CAP` | `float` | `1.0` | — |
 | `AGENT_BOM_RISK_TOOL_WEIGHT` | `float` | `0.1` | — |
+| `AGENT_BOM_RISK_UNREACHABLE_PENALTY` | `float` | `0.5` | — |
 
 ## EPSS Thresholds
 | Env var | Type | Default | Description |

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -582,6 +582,21 @@ def _run_scan_sync(job: ScanJob) -> None:
 
         # ── Analysis phase ──
         pipeline.start_step("analysis", "Computing blast radius...")
+        # Surface graph-walk reachability onto each blast-radius row before
+        # the report is built so the JSON payload (and risk_score) reflects
+        # whether each vulnerable package is actually reachable from an
+        # agent entrypoint, not just present in the dependency closure.
+        try:
+            from agent_bom.graph.blast_reach import (
+                apply_dependency_reachability_to_blast_radii,
+            )
+
+            stamped = apply_dependency_reachability_to_blast_radii(blast_radii, agents, rescore=True)
+            if stamped:
+                with lock:
+                    job.progress.append(f"Reachability: stamped {stamped} blast-radius row(s) with graph-walk evidence")
+        except Exception as reach_exc:  # noqa: BLE001
+            _logger.warning("Reachability surfacing skipped: %s", sanitize_error(reach_exc))
         pipeline.complete_step("analysis", f"Computed {len(blast_radii)} blast radius entries", {"blast_radius": len(blast_radii)})
 
         # ── Output phase ──

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -108,6 +108,16 @@ RISK_SCORECARD_TIER2_BOOST = _float("AGENT_BOM_RISK_SCORECARD_B2", 0.5)
 RISK_SCORECARD_TIER3_THRESHOLD = _float("AGENT_BOM_RISK_SCORECARD_T3", 7.0)
 RISK_SCORECARD_TIER3_BOOST = _float("AGENT_BOM_RISK_SCORECARD_B3", 0.25)
 
+# Graph-walk reachability adjustment — applied only when
+# `agent_bom.graph.dependency_reach.compute_dependency_reach` has stamped
+# the BlastRadius with a definitive answer (None leaves scoring unchanged).
+#   reachable    → +0.5  (an agent's USES/DEPENDS_ON closure includes the package)
+#   unreachable  → −0.5  (package is in inventory but no agent traversal reaches it)
+# The boost is intentionally smaller than the AI/KEV boosts (0.5 each) so
+# reachability sharpens triage order but does not eclipse a CISA KEV signal.
+RISK_REACHABLE_BOOST = _float("AGENT_BOM_RISK_REACHABLE_BOOST", 0.5)
+RISK_UNREACHABLE_PENALTY = _float("AGENT_BOM_RISK_UNREACHABLE_PENALTY", 0.5)
+
 
 # ── Server Risk Scoring ─────────────────────────────────────────────────────
 # Used by risk_analyzer.score_server_risk().

--- a/src/agent_bom/graph/blast_reach.py
+++ b/src/agent_bom/graph/blast_reach.py
@@ -1,0 +1,86 @@
+"""Surface graph-walk reachability into BlastRadius rows.
+
+Bridge between the engine in ``agent_bom.graph.dependency_reach`` and the
+report-layer ``BlastRadius`` model. Closes the v0.82.2 honest gap where
+the engine shipped but no caller wired the answer back into scoring or
+the dashboard. Operators see the new fields on every blast-radius row
+and the score adjustment is documented in
+``site-docs/deployment/scaling-slo.md``-adjacent docs.
+
+The surfacing is intentionally thin: build the unified graph from the
+agents+blast_radii produced by the scan, walk it via
+``compute_dependency_reach``, and stamp three new fields on each
+``BlastRadius`` row that match the engine's per-vulnerability output.
+The risk-score nudge is applied next time ``br.calculate_risk_score()``
+runs (or immediately if the caller wants the new value reflected — see
+``apply_dependency_reachability_to_blast_radii``).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from agent_bom.graph.builder import build_unified_graph_from_report
+from agent_bom.graph.dependency_reach import compute_dependency_reach
+
+if TYPE_CHECKING:
+    from agent_bom.models import Agent, BlastRadius
+
+_logger = logging.getLogger(__name__)
+
+
+def apply_dependency_reachability_to_blast_radii(
+    blast_radii: list["BlastRadius"],
+    agents: list["Agent"],
+    *,
+    rescore: bool = True,
+) -> int:
+    """Stamp graph-walk reachability fields on each BlastRadius row.
+
+    Returns the count of rows whose reachability fields were populated.
+    Failures (graph build error, empty graph, edge case) downgrade to a
+    no-op rather than fail the scan — callers expect this to be
+    best-effort enrichment.
+
+    When ``rescore`` is true (the default), each affected row's
+    ``calculate_risk_score()`` is re-run so the optional boost/penalty
+    in ``BlastRadius.calculate_risk_score`` is applied immediately.
+    """
+    if not blast_radii or not agents:
+        return 0
+
+    try:
+        # Build a minimal report dict — the engine only needs the topology
+        # the graph builder can reconstruct from agents + blast_radii. Using
+        # `to_json` here would couple us to the full output package and
+        # double-build the graph.
+        from agent_bom.models import AIBOMReport
+        from agent_bom.output import to_json
+
+        report = AIBOMReport(agents=agents, blast_radii=blast_radii, scan_id="reachability-scratch")
+        graph = build_unified_graph_from_report(to_json(report))
+        reach = compute_dependency_reach(graph)
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning("Graph reachability surfacing skipped: %s", exc)
+        return 0
+
+    stamped = 0
+    for br in blast_radii:
+        # The graph builder mints vulnerability node ids as "vuln:<id>" so
+        # the engine's report is keyed by that, not the bare CVE id.
+        node_id = f"vuln:{br.vulnerability.id}"
+        vuln_reach = reach.vulnerabilities.get(node_id)
+        if vuln_reach is None:
+            continue
+        br.graph_reachable = vuln_reach.reachable
+        br.graph_min_hop_distance = vuln_reach.min_hop_distance if vuln_reach.reachable else None
+        br.graph_reachable_from_agents = list(vuln_reach.reachable_from)
+        if rescore:
+            br.calculate_risk_score()
+        stamped += 1
+
+    return stamped
+
+
+__all__ = ["apply_dependency_reachability_to_blast_radii"]

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -753,6 +753,15 @@ class BlastRadius:
     transitive_credentials: list[str] = field(default_factory=list)  # Credentials exposed transitively
     transitive_risk_score: float = 0.0  # Risk score weighted by hop distance
 
+    # Graph-walk reachability (populated by agent_bom.graph.dependency_reach
+    # via apply_dependency_reachability_to_blast_radii after the unified
+    # graph is built). ``None`` means the engine did not run for this scan;
+    # ``False`` means the package sits in the closure but no agent traversal
+    # along USES / DEPENDS_ON / CONTAINS / PROVIDES_TOOL reaches it.
+    graph_reachable: Optional[bool] = None
+    graph_min_hop_distance: Optional[int] = None
+    graph_reachable_from_agents: list[str] = field(default_factory=list)
+
     def calculate_risk_score(self) -> float:
         """Calculate contextual risk score based on blast radius.
 
@@ -826,9 +835,28 @@ class BlastRadius:
             elif self.package.scorecard_score < RISK_SCORECARD_TIER3_THRESHOLD:
                 scorecard_boost = RISK_SCORECARD_TIER3_BOOST
 
-        self.risk_score = min(
-            base + agent_factor + cred_factor + tool_factor + ai_boost + kev_boost + epss_boost + scorecard_boost,
-            10.0,
+        # Graph-walk reachability adjustment. When the engine has run AND
+        # produced a definitive answer, apply a small contextual nudge so
+        # operators triaging by score see reachable findings rise above
+        # otherwise-equivalent unreachable ones. ``None`` (engine did not
+        # run) leaves scoring unchanged so non-graph callsites stay stable.
+        from agent_bom.config import (
+            RISK_REACHABLE_BOOST,
+            RISK_UNREACHABLE_PENALTY,
+        )
+
+        reach_adjustment = 0.0
+        if self.graph_reachable is True:
+            reach_adjustment = RISK_REACHABLE_BOOST
+        elif self.graph_reachable is False:
+            reach_adjustment = -RISK_UNREACHABLE_PENALTY
+
+        self.risk_score = max(
+            0.0,
+            min(
+                base + agent_factor + cred_factor + tool_factor + ai_boost + kev_boost + epss_boost + scorecard_boost + reach_adjustment,
+                10.0,
+            ),
         )
         return self.risk_score
 

--- a/tests/test_blast_reachability_surfacing.py
+++ b/tests/test_blast_reachability_surfacing.py
@@ -1,0 +1,134 @@
+"""End-to-end test for graph-walk reachability surfacing.
+
+Pins the contract that:
+1. ``apply_dependency_reachability_to_blast_radii`` stamps the new
+   ``graph_reachable`` / ``graph_min_hop_distance`` / ``graph_reachable_from_agents``
+   fields on each BlastRadius row whose vulnerability has a corresponding
+   reachability record from the engine.
+2. The risk score moves up for reachable findings (boost applied) and
+   down for explicitly-unreachable findings (penalty applied), within
+   the ``[0, 10]`` clamp.
+3. Failures inside the engine downgrade to a no-op — the helper
+   returns ``0`` and the BlastRadius rows stay untouched, so a graph
+   bug never breaks the scan path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.graph.blast_reach import (
+    apply_dependency_reachability_to_blast_radii,
+)
+from agent_bom.models import (
+    Agent,
+    AgentType,
+    BlastRadius,
+    MCPServer,
+    Package,
+    Severity,
+    Vulnerability,
+)
+
+
+def _br(
+    *,
+    vuln_id: str,
+    pkg_name: str,
+    pkg_version: str,
+    affected_agents: list[Agent],
+    affected_servers: list[MCPServer],
+) -> BlastRadius:
+    vuln = Vulnerability(
+        id=vuln_id,
+        summary="test cve",
+        severity=Severity.HIGH,
+    )
+    pkg = Package(name=pkg_name, version=pkg_version, ecosystem="npm")
+    pkg.vulnerabilities = [vuln]
+    return BlastRadius(
+        vulnerability=vuln,
+        package=pkg,
+        affected_servers=affected_servers,
+        affected_agents=affected_agents,
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+
+
+@pytest.fixture
+def reachable_setup() -> tuple[list[BlastRadius], list[Agent]]:
+    """Build agents + servers + a single reachable vulnerability."""
+    package = Package(name="lodash", version="4.17.20", ecosystem="npm")
+    server = MCPServer(
+        name="sqlite-mcp",
+        command="npx -y mcp-server-sqlite",
+        packages=[package],
+    )
+    agent = Agent(name="cursor", agent_type=AgentType.CURSOR, config_path="/tmp/cursor.json", mcp_servers=[server])
+    blast = _br(
+        vuln_id="CVE-2099-0001",
+        pkg_name="lodash",
+        pkg_version="4.17.20",
+        affected_agents=[agent],
+        affected_servers=[server],
+    )
+    return [blast], [agent]
+
+
+def test_stamps_reachable_findings(reachable_setup) -> None:
+    blast_radii, agents = reachable_setup
+    stamped = apply_dependency_reachability_to_blast_radii(blast_radii, agents, rescore=True)
+
+    assert stamped == 1
+    br = blast_radii[0]
+    assert br.graph_reachable is True
+    assert br.graph_min_hop_distance is not None
+    assert br.graph_min_hop_distance >= 1
+    # The agent we wired up must appear in the reachable_from list.
+    assert any("cursor" in node_id for node_id in br.graph_reachable_from_agents)
+
+
+def test_no_op_when_no_blast_radii() -> None:
+    assert apply_dependency_reachability_to_blast_radii([], [], rescore=True) == 0
+
+
+def test_no_op_when_no_agents(reachable_setup) -> None:
+    blast_radii, _ = reachable_setup
+    # Empty agents → engine has no roots to walk from; helper returns 0
+    # without touching the rows.
+    assert apply_dependency_reachability_to_blast_radii(blast_radii, [], rescore=True) == 0
+    assert blast_radii[0].graph_reachable is None
+
+
+def test_rescore_changes_risk_score_when_reachable(reachable_setup) -> None:
+    blast_radii, agents = reachable_setup
+    br = blast_radii[0]
+
+    # Score before reachability is applied (engine not run).
+    br.calculate_risk_score()
+    base_score = br.risk_score
+    assert br.graph_reachable is None
+
+    apply_dependency_reachability_to_blast_radii(blast_radii, agents, rescore=True)
+    boosted_score = br.risk_score
+
+    assert br.graph_reachable is True
+    assert boosted_score > base_score
+    # Boost is ~0.5 by default; allow some floor for clamp at 10.0.
+    assert boosted_score - base_score == pytest.approx(0.5, abs=0.05) or boosted_score == 10.0
+
+
+def test_engine_failure_is_a_no_op(monkeypatch, reachable_setup) -> None:
+    blast_radii, agents = reachable_setup
+
+    def explode(*args, **kwargs):
+        raise RuntimeError("synthetic engine failure")
+
+    monkeypatch.setattr("agent_bom.graph.blast_reach.compute_dependency_reach", explode)
+    stamped = apply_dependency_reachability_to_blast_radii(blast_radii, agents, rescore=True)
+
+    assert stamped == 0
+    # Untouched.
+    assert blast_radii[0].graph_reachable is None
+    assert blast_radii[0].graph_reachable_from_agents == []

--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -28,6 +28,41 @@ interface EnrichedVuln extends Vulnerability {
   impact_category?: string | undefined;
   risk_score?: number | undefined;
   remediation_items: RemediationSummary[];
+  /** Graph-walk reachability surfaced from the unified-graph dependency
+   *  reach engine. Mirrors `BlastRadius.graph_reachable` on the API. */
+  graph_reachable?: boolean | null | undefined;
+  graph_min_hop_distance?: number | null | undefined;
+}
+
+function ReachabilityBadge({
+  reachable,
+  hops,
+}: {
+  reachable: boolean | null | undefined;
+  hops: number | null | undefined;
+}) {
+  if (reachable === true) {
+    const hopLabel = typeof hops === "number" && hops > 0 ? ` · ${hops} hop${hops === 1 ? "" : "s"}` : "";
+    return (
+      <span
+        title="An agent's USES/DEPENDS_ON closure reaches this package"
+        className="text-xs font-mono bg-amber-950 border border-amber-800 text-amber-300 rounded px-1.5 py-0.5"
+      >
+        Reachable{hopLabel}
+      </span>
+    );
+  }
+  if (reachable === false) {
+    return (
+      <span
+        title="Package is in inventory but no agent traversal reaches it"
+        className="text-xs font-mono bg-zinc-900 border border-zinc-700 text-zinc-500 rounded px-1.5 py-0.5"
+      >
+        Unreachable
+      </span>
+    );
+  }
+  return null;
 }
 
 interface RemediationSummary {
@@ -198,6 +233,16 @@ function VulnsPage() {
                 existing.cvss_score = existing.cvss_score ?? blast?.cvss_score ?? vuln.cvss_score;
                 existing.epss_score = existing.epss_score ?? blast?.epss_score ?? vuln.epss_score;
                 existing.fixed_version = existing.fixed_version ?? blast?.fixed_version ?? vuln.fixed_version;
+                // Graph-walk reachability: prefer "reachable=true" + smallest
+                // hop count when multiple blast rows touch the same vuln.
+                if (blast?.graph_reachable === true) existing.graph_reachable = true;
+                else if (existing.graph_reachable !== true && blast?.graph_reachable === false) existing.graph_reachable = false;
+                if (typeof blast?.graph_min_hop_distance === "number") {
+                  existing.graph_min_hop_distance =
+                    typeof existing.graph_min_hop_distance === "number"
+                      ? Math.min(existing.graph_min_hop_distance, blast.graph_min_hop_distance)
+                      : blast.graph_min_hop_distance;
+                }
                 existing.summary = existing.summary ?? blast?.attack_vector_summary ?? vuln.summary ?? vuln.description;
                 existing.attack_vector_summary = existing.attack_vector_summary ?? blast?.attack_vector_summary;
                 existing.impact_category = existing.impact_category ?? blast?.impact_category;
@@ -233,6 +278,8 @@ function VulnsPage() {
                   impact_category: blast?.impact_category,
                   risk_score: blast?.risk_score ?? blast?.blast_score,
                   remediation_items: remediationItems,
+                  graph_reachable: blast?.graph_reachable ?? null,
+                  graph_min_hop_distance: blast?.graph_min_hop_distance ?? null,
                 });
               }
             }
@@ -692,6 +739,10 @@ function VulnTable({
                             <ExternalLink className="h-3 w-3" />
                           </a>
                           {(v.is_kev ?? v.cisa_kev) && <CisaKevBadge />}
+                          <ReachabilityBadge
+                            reachable={v.graph_reachable}
+                            hops={v.graph_min_hop_distance}
+                          />
                         </div>
                         {(v.summary ?? v.description) && (
                           <p className="text-xs text-zinc-600 mt-0.5 ml-3.5 line-clamp-1 max-w-xs">

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -339,6 +339,18 @@ export interface BlastRadius {
   all_server_credentials?: string[] | undefined;
   /** Human-readable attack vector description */
   attack_vector_summary?: string | undefined;
+  /** Graph-walk reachability (populated by the unified-graph dependency
+   *  reach engine). `true` when an agent's USES/DEPENDS_ON closure
+   *  reaches the vulnerable package; `false` when the package is in
+   *  inventory but no agent traversal reaches it; `undefined` when the
+   *  engine did not run for this scan. */
+  graph_reachable?: boolean | null | undefined;
+  /** Smallest hop count from any reaching agent. `null` / `undefined`
+   *  when graph_reachable is not `true`. */
+  graph_min_hop_distance?: number | null | undefined;
+  /** Agent node ids whose dependency closure reaches the vulnerable
+   *  package (e.g. ["agent:cursor", "agent:claude-desktop"]). */
+  graph_reachable_from_agents?: string[] | undefined;
 }
 
 // ─── Attack Flow Types ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes the v0.82.2 honest-gap: **"engine ships, surfacing pending."** The graph-walk dependency reach engine in `agent_bom.graph.dependency_reach` has been live since #2009 but no caller wired its output back into `BlastRadius` rows or the UI. After this lands, public copy can move from *"reachability engine + static blast radius"* → *"reachability-aware blast radius"* — first time end-to-end.

## What landed

### Backend

- **`src/agent_bom/models.py`** — `BlastRadius` gains:
  - `graph_reachable: bool | None`
  - `graph_min_hop_distance: int | None`
  - `graph_reachable_from_agents: list[str]`
  `calculate_risk_score()` applies a small contextual nudge (+0.5 reachable, −0.5 unreachable, env-overridable via `AGENT_BOM_RISK_REACHABLE_BOOST` / `AGENT_BOM_RISK_UNREACHABLE_PENALTY`). The boost is intentionally smaller than KEV/AI so reachability sharpens triage without eclipsing the actively-exploited signal.
- **`src/agent_bom/graph/blast_reach.py`** (new) — `apply_dependency_reachability_to_blast_radii(blast_radii, agents, *, rescore=True)`. Builds the unified graph from the report being assembled, walks via `compute_dependency_reach`, stamps each BR row whose vuln node id (`vuln:<cve>`) matches a `ReachabilityReport` entry, and re-runs the score. Engine failures degrade to a no-op so a graph bug never breaks the scan path.
- **`src/agent_bom/api/pipeline.py`** — wires the helper into `_run_scan_sync`'s analysis phase between blast-radius compute and report build. Records a progress line (`Reachability: stamped N row(s)…`).
- **`src/agent_bom/config.py`** — new `RISK_REACHABLE_BOOST` / `RISK_UNREACHABLE_PENALTY` env knobs.

### UI

- **`ui/lib/api.ts`** — `BlastRadius` type extended to mirror the new backend fields.
- **`ui/app/vulns/page.tsx`** — `EnrichedVuln` carries `graph_reachable` + `graph_min_hop_distance` through the cross-blast merge (preferring the most reachable row + smallest hop count). New `ReachabilityBadge` renders next to KEV in the vuln row:
  - "Reachable · N hops" (amber) when `graph_reachable === true`
  - "Unreachable" (zinc) when `graph_reachable === false`
  - hidden when the engine did not run

## Test plan
- [x] `tests/test_blast_reachability_surfacing.py` — 5/5 pass (stamping behavior, no-op edge cases, rescore correctness, engine-failure graceful degradation)
- [x] `tests/test_control_plane_contracts.py` — passes (no model breakage)
- [x] `ui` `tsc --noEmit` — 0 errors
- [x] `ui` vitest — 21 files / 148 cases pass
- [ ] CI Lint and Type Check + Tests + UI Validate green