### PR TITLE
fix deploy and docs audit findings

### DIFF
--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -163,6 +163,8 @@ refresh, enrichment, SIEM, OTLP, and webhooks is operator-controlled.
 - HTTPS for every external hop
 - private in-cluster traffic or service-mesh mTLS for internal hops
 - auth on every non-loopback control-plane surface
+- production profiles set `AGENT_BOM_DISABLE_DOCS=1` so `/docs`, `/redoc`, and `/openapi.json` are not exposed as unauthenticated helper routes
+- shared control-plane profiles set `AGENT_BOM_API_LOCAL_PATH_SCANS=disabled`; enable API-local filesystem scans only for an explicit single-tenant mounted workspace
 - RBAC and tenant scoping on sensitive routes
 - rate limiting, audit trails, and signed release artifacts
 - HMAC-backed tamper evidence for exported bundles

--- a/deploy/docker-compose.fullstack.yml
+++ b/deploy/docker-compose.fullstack.yml
@@ -30,7 +30,7 @@ services:
     image: agentbom/agent-bom:0.82.3
     container_name: agent-bom-api
     restart: unless-stopped
-    command: api --host 0.0.0.0 --port 8422
+    command: api --host 0.0.0.0 --port 8422 --allow-insecure-no-auth
     environment:
       AGENT_BOM_POSTGRES_URL: >-
         postgresql://${POSTGRES_USER:-agent_bom}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-agent_bom}
@@ -46,12 +46,14 @@ services:
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
       # Optional: protect the API with a key
       AGENT_BOM_API_KEY: ${AGENT_BOM_API_KEY:-}
+      # Local dev stack only: filesystem scans should be explicit in shared API setups.
+      AGENT_BOM_API_LOCAL_PATH_SCANS: ${AGENT_BOM_API_LOCAL_PATH_SCANS:-disabled}
     ports:
-      - "${API_PORT:-8422}:8422"
+      - "127.0.0.1:${API_PORT:-8422}:8422"
     volumes:
       # Mount host MCP config dirs read-only so the API can discover local agents
-      - ~/.config:/root/.config:ro
-      - ~/.claude:/root/.claude:ro
+      - ~/.config:/home/abom/.config:ro
+      - ~/.claude:/home/abom/.claude:ro
     networks:
       - agent-bom
     depends_on:
@@ -76,7 +78,7 @@ services:
     container_name: agent-bom-ui
     restart: unless-stopped
     ports:
-      - "${UI_PORT:-3000}:3000"
+      - "127.0.0.1:${UI_PORT:-3000}:3000"
     networks:
       - agent-bom
     depends_on:
@@ -103,7 +105,7 @@ services:
       POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256 --auth-local=scram-sha-256"
     ports:
       # Only expose locally — remove in production
-      - "${POSTGRES_PORT:-5432}:5432"
+      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./supabase/postgres/init-wrapper.sh:/docker-entrypoint-initdb.d/00-init-wrapper.sh:ro

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -31,6 +31,7 @@ version: "3.8"
 #   cp .env.example .env                     # set POSTGRES_APP_PASSWORD only
 #   echo -n "$POSTGRES_PASSWORD" > deploy/secrets/postgres_password
 #   chmod 0400 deploy/secrets/postgres_password
+#   export AGENT_BOM_API_KEY="$(openssl rand -hex 32)"  # or set OIDC env below
 #   docker compose -f deploy/docker-compose.platform.yml up --build
 
 services:
@@ -83,6 +84,11 @@ services:
     environment:
       # Use app user (DML only) when available, fall back to admin for dev
       - AGENT_BOM_POSTGRES_URL=postgresql://${POSTGRES_APP_USER:-${POSTGRES_USER:-agent_bom}}:${POSTGRES_APP_PASSWORD:-${POSTGRES_PASSWORD:?err}}@postgres:5432/${POSTGRES_DB:-agent_bom}
+      - AGENT_BOM_API_KEY=${AGENT_BOM_API_KEY:-}
+      - AGENT_BOM_OIDC_ISSUER=${AGENT_BOM_OIDC_ISSUER:-}
+      - AGENT_BOM_OIDC_AUDIENCE=${AGENT_BOM_OIDC_AUDIENCE:-}
+      - AGENT_BOM_DISABLE_DOCS=1
+      - AGENT_BOM_API_LOCAL_PATH_SCANS=disabled
       - CORS_ORIGINS=http://localhost:3000,http://ui:3000
       - NVD_API_KEY=${NVD_API_KEY:-}
     depends_on:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -42,8 +42,8 @@ services:
       # Mount local config directories (read-only)
       # macOS/Linux: ~/.config, ~/.claude
       # Windows: use %APPDATA% paths or run via WSL2
-      - ~/.config:/root/.config:ro
-      - ~/.claude:/root/.claude:ro
+      - ~/.config:/home/abom/.config:ro
+      - ~/.claude:/home/abom/.claude:ro
       # Mount current directory for output
       - ./reports:/workspace/reports
       # Mount test configs

--- a/deploy/helm/agent-bom/examples/eks-production-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-production-values.yaml
@@ -15,6 +15,10 @@ controlPlane:
     env:
       - name: AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT
         value: "1"
+      - name: AGENT_BOM_DISABLE_DOCS
+        value: "1"
+      - name: AGENT_BOM_API_LOCAL_PATH_SCANS
+        value: "disabled"
       - name: AGENT_BOM_POSTGRES_POOL_MIN_SIZE
         value: "5"
       - name: AGENT_BOM_POSTGRES_POOL_MAX_SIZE

--- a/deploy/helm/agent-bom/examples/eks-snowflake-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-snowflake-values.yaml
@@ -39,6 +39,10 @@ controlPlane:
       # Backend selection — Snowflake stores scan jobs, fleet, policies, audit
       - name: AGENT_BOM_STORE_BACKEND
         value: "snowflake"
+      - name: AGENT_BOM_DISABLE_DOCS
+        value: "1"
+      - name: AGENT_BOM_API_LOCAL_PATH_SCANS
+        value: "disabled"
       - name: AGENT_BOM_FLEET_STORE_BACKEND
         value: "snowflake"
       - name: AGENT_BOM_POLICY_STORE_BACKEND

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -87,7 +87,7 @@ docker build -t agent-bom:latest .
 # Scan mounted directory
 docker run --rm \
   -v $(pwd):/workspace \
-  -v ~/.config:/root/.config:ro \
+  -v ~/.config:/home/abom/.config:ro \
   agent-bom:latest scan --enrich --output /workspace/report.json
 
 # Scan with environment variables
@@ -251,7 +251,7 @@ spec:
                   key: snowflake-account
             volumeMounts:
             - name: config-volume
-              mountPath: /root/.config
+              mountPath: /home/abom/.config
               readOnly: true
             - name: output-volume
               mountPath: /output

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -456,7 +456,7 @@ AmazonEC2ReadOnlyAccess
 
 ```bash
 docker run --rm \
-  -v ~/.config:/root/.config:ro \
+  -v ~/.config:/home/abom/.config:ro \
   -v $(pwd):/workspace:ro \
   agentbom/agent-bom:0.82.3 agents --format json
 ```

--- a/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
+++ b/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
@@ -109,7 +109,7 @@ Two channels — text and visual — both covered:
 - Detect + alert — called inside `run_proxy` on every response.
 - Redact in place — `Shield.redact(text)` returns a sanitized string.
 - Severity-tagged — credentials are `CRITICAL`, PII is `HIGH`.
-- Tests: [`tests/test_runtime_credential_leak.py`](../tests/test_runtime_credential_leak.py).
+- Tests: [`tests/test_runtime_detectors.py`](../tests/test_runtime_detectors.py).
 
 **Visual channel — [`VisualLeakDetector`](../src/agent_bom/runtime/visual_leak_detector.py)** (opt-in: `pip install 'agent-bom[visual]'`). MCPs wrapping browsers or screen-capture tools (Playwright-MCP, Puppeteer-MCP, Cursor/Claude screen-read) can leak creds + PII through pixels the text scanner misses.
 

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -216,7 +216,7 @@ blast_radius        — blast radius for a specific CVE
 - **Does not run MCP servers.** Read-only. Never starts or restarts a server.
 - **Does not store credentials.** Only env var *names* (not values) appear in reports.
 - **Does not modify MCP configs** unless you explicitly run `agent-bom proxy-configure --apply`.
-- **Does not send telemetry.** Only package name + version leaves your machine for CVE lookups (OSV, NVD, EPSS). See [PERMISSIONS.md](../PERMISSIONS.md).
+- **Does not send telemetry.** Only package name + version leaves your machine for CVE lookups (OSV, NVD, EPSS). See [PERMISSIONS.md](PERMISSIONS.md).
 - **Does not replace IAM or network controls.** It is a detection and enforcement layer, not a perimeter.
 
 ---

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -122,7 +122,7 @@ control-plane audit path.
 
 ```bash
 docker run -it --rm \
-  -v ~/.config:/root/.config:ro \
+  -v ~/.config:/home/abom/.config:ro \
   agentbom/agent-bom:latest mcp server
 ```
 

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -269,4 +269,4 @@ agent-bom agents --snowflake --snowflake-authenticator oauth
 
 ## Reporting a Security Issue
 
-See [SECURITY.md](SECURITY.md) for responsible disclosure via GitHub Security Advisories.
+See [SECURITY.md](../SECURITY.md) for responsible disclosure via GitHub Security Advisories.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -2,7 +2,7 @@
 
 This document enumerates trust boundaries, threat actors, attack surfaces,
 and mitigations for agent-bom. It satisfies the OpenSSF Best Practices Silver
-"assurance case" criterion and complements [SECURITY.md](SECURITY.md).
+"assurance case" criterion and complements [SECURITY.md](../SECURITY.md).
 
 ---
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,6 +1,8 @@
 # Architecture Decision Records
 
-This directory contains Architecture Decision Records (ADRs) for agent-bom.
+This directory contains the original Architecture Decision Records (ADRs) for
+agent-bom. New ADRs live in [`docs/decisions`](../decisions/README.md), which
+is the canonical decision log for current work.
 
 ADRs document significant technical decisions — the context, options considered,
 and rationale for the chosen approach. They help current and future contributors
@@ -22,7 +24,7 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records).
 
 ## Adding a new ADR
 
-1. Copy `template.md` to `NNN-short-title.md`
-2. Fill in all sections
-3. Add entry to the index table above
+1. Use `docs/decisions/_template.md`
+2. Add the new record under `docs/decisions/`
+3. Add it to the `docs/decisions/README.md` index
 4. Submit as part of your PR

--- a/docs/skills/mcp-server-review.md
+++ b/docs/skills/mcp-server-review.md
@@ -30,7 +30,7 @@ agent-bom api &
 curl http://127.0.0.1:8422/v1/registry/<server-name> | python3 -m json.tool
 ```
 
-Or browse the registry file: [`src/agent_bom/mcp_registry.json`](src/agent_bom/mcp_registry.json)
+Or browse the registry file: [`src/agent_bom/mcp_registry.json`](../../src/agent_bom/mcp_registry.json)
 
 The registry provides:
 - **Verified status** — has the server been independently verified?

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -50,8 +50,8 @@ Mount your MCP client configs for auto-discovery:
 
 ```bash
 docker run --rm \
-  -v "$HOME/.config:/root/.config:ro" \
-  -v "$HOME/Library/Application Support:/root/Library/Application Support:ro" \
+  -v "$HOME/.config:/home/abom/.config:ro" \
+  -v "$HOME/Library/Application Support:/home/abom/Library/Application Support:ro" \
   ghcr.io/msaad00/agent-bom:latest scan
 ```
 

--- a/site-docs/getting-started/install.md
+++ b/site-docs/getting-started/install.md
@@ -25,8 +25,8 @@ docker run --rm ghcr.io/msaad00/agent-bom:latest scan
 
 # With host config access (for MCP client discovery)
 docker run --rm \
-  -v "$HOME/.config:/root/.config:ro" \
-  -v "$HOME/Library/Application Support:/root/Library/Application Support:ro" \
+  -v "$HOME/.config:/home/abom/.config:ro" \
+  -v "$HOME/Library/Application Support:/home/abom/Library/Application Support:ro" \
   ghcr.io/msaad00/agent-bom:latest scan
 ```
 

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -88,6 +88,45 @@ def test_platform_compose_uses_docker_secrets_for_postgres_password() -> None:
     )
 
 
+def test_platform_api_fails_closed_for_auth_docs_and_local_scans() -> None:
+    path = COMPOSE_DIR / "docker-compose.platform.yml"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    api = (data.get("services") or {}).get("api") or {}
+    env = api.get("environment") or []
+    env_map = {item.split("=", 1)[0]: item.split("=", 1)[1] for item in env if isinstance(item, str) and "=" in item}
+
+    assert "AGENT_BOM_API_KEY" in env_map
+    assert "AGENT_BOM_OIDC_ISSUER" in env_map
+    assert "--allow-insecure-no-auth" not in api.get("command", "")
+    assert env_map.get("AGENT_BOM_DISABLE_DOCS") == "1"
+    assert env_map.get("AGENT_BOM_API_LOCAL_PATH_SCANS") == "disabled"
+
+
+def test_fullstack_is_loopback_only_and_matches_runtime_user_home() -> None:
+    path = COMPOSE_DIR / "docker-compose.fullstack.yml"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    api = (data.get("services") or {}).get("api") or {}
+
+    assert "--allow-insecure-no-auth" in api.get("command", "")
+    assert api.get("ports") == ["127.0.0.1:${API_PORT:-8422}:8422"]
+    assert "~/.config:/home/abom/.config:ro" in (api.get("volumes") or [])
+    assert "~/.claude:/home/abom/.claude:ro" in (api.get("volumes") or [])
+
+
+def test_active_docker_docs_do_not_mount_config_under_root_home() -> None:
+    active_docs = [
+        ROOT / "docs" / "DEPLOYMENT.md",
+        ROOT / "docs" / "ENTERPRISE_DEPLOYMENT.md",
+        ROOT / "docs" / "MCP_SERVER.md",
+        ROOT / "site-docs" / "getting-started" / "install.md",
+        ROOT / "site-docs" / "deployment" / "docker.md",
+        COMPOSE_DIR / "docker-compose.yml",
+        COMPOSE_DIR / "docker-compose.fullstack.yml",
+    ]
+    offenders = [str(path.relative_to(ROOT)) for path in active_docs if "/root/.config" in path.read_text(encoding="utf-8")]
+    assert not offenders
+
+
 @pytest.mark.parametrize("path", _compose_files(), ids=lambda p: p.name)
 def test_compose_file_declares_profile_header(path: Path) -> None:
     text = path.read_text(encoding="utf-8")

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ overrides = [{ name = "python-dotenv", specifier = ">=1.2.2" }]
 
 [[package]]
 name = "agent-bom"
-version = "0.81.3"
+version = "0.82.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- harden compose and production Helm defaults for auth, docs, and API-local filesystem scans
- mount host MCP config under the non-root runtime user in active compose/docs examples
- repair audit-discovered local docs links and mark docs/decisions as the canonical ADR log
- pin structural tests for the compose/docs contracts and keep uv.lock release metadata aligned

Closes #2045
Closes #2046
Closes #2047
Closes #2048

## Verification
- `uv run pytest -q tests/test_compose_secrets_healthcheck.py tests/test_deploy_manifests.py tests/test_product_surface_contract.py`
- `env POSTGRES_PASSWORD=test POSTGRES_APP_PASSWORD=test AGENT_BOM_API_KEY=test docker compose -f deploy/docker-compose.fullstack.yml config`
- `env POSTGRES_PASSWORD=test POSTGRES_APP_PASSWORD=test AGENT_BOM_API_KEY=test docker compose -f deploy/docker-compose.platform.yml config`
- `uv run python scripts/check_release_consistency.py`
- `uv run python scripts/check_product_surface_contract.py`
- `git diff --check`
- focused markdown link check for repaired docs
