### PR TITLE
chore(ui): adopt Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Install dependencies
         run: uv sync --frozen --extra dev
@@ -277,7 +277,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Install UI dependencies
         run: |

--- a/.github/workflows/dependabot-ui-lockfile-normalize.yml
+++ b/.github/workflows/dependabot-ui-lockfile-normalize.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Normalize UI lockfile
         # We invoke `npm install --package-lock-only --ignore-scripts` directly

--- a/.github/workflows/main-ui-smoke.yml
+++ b/.github/workflows/main-ui-smoke.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Install UI deps
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Build dashboard
         run: |

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -22,7 +22,7 @@ agent-bom publishes two images. They are a deployment-flexibility split, **not a
 | Image | Base | What's inside | When to pull it |
 |---|---|---|---|
 | `agentbom/agent-bom` | Python 3.14 Alpine (~150 MB) | FastAPI/Starlette + scanner + cloud SDKs + MCP server. The pre-built Next.js dashboard is **bundled inside the wheel** as static assets. | Always. Single-host pilots and `pip install` users only need this one. |
-| `agentbom/agent-bom-ui` | Node 22 Debian slim (~250 MB) | Next.js standalone server only. No Python, no cloud SDKs, no MCP runtime. | K8s deployments that want the UI tier scaled / deployed / restricted independently of the API tier. |
+| `agentbom/agent-bom-ui` | Node 24 Debian slim (~250 MB) | Next.js standalone server only. No Python, no cloud SDKs, no MCP runtime. | K8s deployments that want the UI tier scaled / deployed / restricted independently of the API tier. |
 
 ### Why the API image alone serves the dashboard
 
@@ -42,7 +42,7 @@ Reasons that hold up:
 1. **Independent scaling.** UI is light SSR + static; API does CPU-heavy scanning. Kubernetes wants different replica counts and different HPA / KEDA triggers (see [`scaling-slo.md`](../site-docs/deployment/scaling-slo.md)). Co-locating them forces every UI scale event to also start a Python interpreter.
 2. **Smaller attack surface for the UI tier.** No `boto3` / `azure-*` / `google-cloud-*` SDKs reachable from the UI container, no MCP subprocess, no cloud creds in scope. The ExternalSecrets / IRSA bindings can stay scoped to the API Deployment alone.
 3. **Independent dep churn.** UI deps (recharts, lucide-react, react-virtual) update fast and noisy; backend deps (boto3, OSV libs) update slow and quiet. Two images means UI patch releases ship without forcing a backend image rebuild.
-4. **Different runtimes.** A combined image would carry both Python 3.14 and Node 22 — roughly doubles the image footprint and the security-advisory surface.
+4. **Different runtimes.** A combined image would carry both Python 3.14 and Node 24 — roughly doubles the image footprint and the security-advisory surface.
 
 Reasons that **do not** hold up:
 

--- a/scripts/check_docker_base_policy.py
+++ b/scripts/check_docker_base_policy.py
@@ -5,7 +5,7 @@ Closes #1961 (the policy gate piece). The audit found three real drift
 problems this script prevents from recurring:
 
 1. ui/Dockerfile drifted to ``node:25-slim`` while ui/package.json's
-   ``engines.node`` insisted on ``>=20 <23``. The policy table below pins
+   ``engines.node`` insisted on a Node LTS range. The policy table below pins
    the major version that the Dockerfile is allowed to reference; if the
    two ever disagree again, this script fails.
 2. integrations/glama/Dockerfile carried a comment claiming "pinned to same
@@ -70,8 +70,8 @@ POLICY: dict[str, BasePolicy] = {
     ),
     "ui/Dockerfile": BasePolicy(
         image="node",
-        expected_tags=("22-bookworm-slim", "22-slim"),
-        rationale="Node 22 LTS sits inside ui/package.json engines: '>=20 <23' and is Next 16's recommended production node.",
+        expected_tags=("24-bookworm-slim", "24-slim"),
+        rationale="Node 24 LTS sits inside ui/package.json engines: '>=22 <25' and is the canonical UI runtime.",
     ),
     "integrations/glama/Dockerfile": BasePolicy(
         image="python",

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-# Base image policy: node 22 LTS (sits inside ui/package.json engines: ">=20 <23").
+# Base image policy: node 24 LTS (sits inside ui/package.json engines: ">=22 <25").
 # Digest is pinned by dependabot's daily docker job; the
 # scripts/check_docker_base_policy.py CI gate accepts the
 # `# pending-digest` marker for at most one day after a major bump
@@ -6,7 +6,7 @@
 # Tracking: #1961.
 
 # ── Stage 1: Install dependencies ─────────────────────────────────────────────
-FROM node:22-bookworm-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c AS deps
+FROM node:24-bookworm-slim@sha256:03eae3ef7e88a9de535496fb488d67e02b9d96a063a8967bae657744ecd513f2 AS deps
 WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm ci --ignore-scripts
@@ -26,7 +26,7 @@ RUN set -eux; \
     npm install --no-save --ignore-scripts "$pkg"
 
 # ── Stage 2: Build ────────────────────────────────────────────────────────────
-FROM node:22-bookworm-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c AS builder
+FROM node:24-bookworm-slim@sha256:03eae3ef7e88a9de535496fb488d67e02b9d96a063a8967bae657744ecd513f2 AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -38,7 +38,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build
 
 # ── Stage 3: Run ──────────────────────────────────────────────────────────────
-FROM node:22-bookworm-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c AS runner
+FROM node:24-bookworm-slim@sha256:03eae3ef7e88a9de535496fb488d67e02b9d96a063a8967bae657744ecd513f2 AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -41,7 +41,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=20 <23"
+        "node": ">=22 <25"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -7085,7 +7085,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "npm@10.9.7",
   "engines": {
-    "node": ">=20 <23"
+    "node": ">=22 <25"
   },
   "scripts": {
     "dev": "next dev",

--- a/ui/scripts/verify-toolchain.mjs
+++ b/ui/scripts/verify-toolchain.mjs
@@ -77,7 +77,7 @@ if (nextMajor === 16 && ![9, 10].includes(eslintMajor)) {
   );
 }
 
-if (!Number.isInteger(nodeMajor) || nodeMajor < 20 || nodeMajor > 22) {
+if (!Number.isInteger(nodeMajor) || nodeMajor < 22 || nodeMajor > 24) {
   fail(`UI runtime must stay within the declared Node range ${nodeEngines}; found Node ${process.versions.node}.`);
 }
 


### PR DESCRIPTION
## Summary
- move the UI runtime contract from Node 22 to Node 24 LTS
- update the digest-pinned UI Dockerfile, Docker base policy gate, CI/release Node setup, and UI package engines
- refresh the UI lockfile normalization result and enterprise deployment docs

Closes #2023

## Verification
- `uv run python scripts/check_docker_base_policy.py`
- `cd ui && npx -y -p node@24 node scripts/verify-toolchain.mjs`
- `cd ui && npm run lock:normalize`
- `cd ui && npm run typecheck`
- `cd ui && npm run test:run`
- `cd ui && npm run headers:check && npm run bundle:check`
- `uv run pytest -q tests/test_docker_base_policy.py tests/test_product_surface_contract.py`
- `uv run python scripts/check_product_surface_contract.py`
- `git diff --check`

Note: local Docker daemon was unavailable, so the Node 24 runtime gate was run through the `node@24` npm package instead of a Docker container.
