### PR TITLE
typing: expand strict mypy phase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     rev: v1.15.0
     hooks:
       - id: mypy
-        args: [--ignore-missing-imports, --no-error-summary, --follow-imports=skip]
+        args: [--ignore-missing-imports, --no-error-summary, --disable-error-code, import-untyped]
         files: ^src/
         additional_dependencies: [types-PyYAML]
         pass_filenames: true

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test:  ## Run unit tests
 
 lint:  ## Run linters (ruff + mypy)
 	ruff check src/ tests/
-	mypy src/ --ignore-missing-imports
+	mypy src/ --ignore-missing-imports --disable-error-code import-untyped
 
 format:  ## Format code with ruff
 	ruff format src/ tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,7 @@ show_error_codes = true
 [[tool.mypy.overrides]]
 module = [
     "agent_bom.api.audit_log",
+    "agent_bom.api.auth",
     "agent_bom.api.compliance_signing",
     "agent_bom.api.dashboard_csp",
     "agent_bom.api.exception_store",
@@ -221,13 +222,16 @@ module = [
     "agent_bom.api.idempotency_store",
     "agent_bom.api.mcp_observation_store",
     "agent_bom.api.metrics",
+    "agent_bom.api.models",
     "agent_bom.api.policy_store",
     "agent_bom.api.schedule_store",
     "agent_bom.api.scim",
     "agent_bom.api.scim_store",
     "agent_bom.api.storage_schema",
+    "agent_bom.api.tenant_quota",
     "agent_bom.api.tenant_quota_store",
     "agent_bom.api.tracing",
+    "agent_bom.models",
     "agent_bom.backpressure",
     "agent_bom.proxy_sandbox",
 ]

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -994,7 +994,7 @@ class AIBOMReport:
         """
         return any(a.agent_type != AgentType.CUSTOM for a in self.agents)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if not self.tool_version:
             from agent_bom import __version__
 

--- a/tests/test_mypy_policy.py
+++ b/tests/test_mypy_policy.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_api_and_core_models_are_in_strict_mypy_phase() -> None:
+    """Issue #1969: API/model typing should advance module-by-module."""
+    data = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    overrides = data["tool"]["mypy"]["overrides"]
+    strict_modules = set(overrides[0]["module"])
+
+    assert {
+        "agent_bom.api.auth",
+        "agent_bom.api.models",
+        "agent_bom.api.scim",
+        "agent_bom.api.tenant_quota",
+        "agent_bom.models",
+    }.issubset(strict_modules)
+    assert overrides[0]["disallow_untyped_defs"] is True
+    assert overrides[0]["disallow_incomplete_defs"] is True


### PR DESCRIPTION
## Summary
- add `agent_bom.api.auth`, `agent_bom.api.models`, `agent_bom.api.tenant_quota`, and `agent_bom.models` to the strict mypy phase
- annotate the remaining untyped model hook needed for that stricter phase
- align local/pre-commit mypy invocation with the CI import-untyped handling
- add a regression test that pins the API/model strict-typing phase

Related typing tracker: issue 1969. This PR intentionally does not close it.

## Verification
- `uv run --frozen mypy src/ --ignore-missing-imports --disable-error-code import-untyped --cache-dir /tmp/agent-bom-mypy-src`
- `uv run --frozen pytest -q tests/test_mypy_policy.py`
- `uv run --frozen ruff check src/ tests/test_mypy_policy.py`
- `pre-commit run mypy --files src/agent_bom/models.py`
- `git diff --check`

## Follow-up boundary
This does not close the typing tracker. A full strict run over `src/agent_bom/api` still reports 157 errors across 29 files, so the remaining API route/store modules need separate typed phases.
