### PR TITLE
Expose AISVS compliance benchmark API

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Full trust model: [SECURITY_ARCHITECTURE.md](docs/SECURITY_ARCHITECTURE.md) · [
 
 ## Compliance
 
-Bundled mappings across 14 frameworks — OWASP LLM/MCP/Agentic Top 10s, OWASP AISVS, MITRE ATLAS, NIST AI RMF, NIST CSF, NIST 800-53, FedRAMP Moderate, EU AI Act, ISO 27001, SOC 2, CIS Controls v8, CMMC 2.0. The bundled control set per framework is a curated subset focused on AI/MCP/agent risk, not a full catalog — see [docs/ARCHITECTURE.md § Coverage per framework](docs/ARCHITECTURE.md#coverage-per-framework) for honest counts. Export tamper-evident evidence packets in one command.
+Bundled mappings across 14 tag-mapped frameworks — OWASP LLM/MCP/Agentic Top 10s, MITRE ATLAS, NIST AI RMF, NIST CSF, NIST 800-53, FedRAMP Moderate, EU AI Act, ISO 27001, SOC 2, CIS Controls v8, CMMC 2.0, and PCI DSS — plus an OWASP AISVS benchmark surface. The bundled control set per framework is a curated subset focused on AI/MCP/agent risk, not a full catalog — see [docs/ARCHITECTURE.md § Coverage per framework](docs/ARCHITECTURE.md#coverage-per-framework) for honest counts. Export tamper-evident evidence packets in one command.
 
 <p align="center">
   <picture>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,7 +113,7 @@ sequenceDiagram
 
     CLI->>BlastRadius: Vulns + topology
     BlastRadius->>BlastRadius: CVE → package → server → agent → creds → tools
-    BlastRadius->>BlastRadius: Tag 14 compliance frameworks
+    BlastRadius->>BlastRadius: Tag 14 frameworks + attach AISVS benchmark
     BlastRadius-->>CLI: Scored + tagged findings
 
     CLI->>Reporter: Full results
@@ -159,7 +159,7 @@ graph LR
 
 ## 4. Compliance Tagging
 
-Every finding is tagged against 14 frameworks, grouped into four families. The bundled mappings are a curated subset of each framework focused on AI/MCP/agent risk-relevant controls — they are not a complete catalog. See [Coverage per framework](#coverage-per-framework) below for the honest control counts.
+Every finding is tagged against 14 tag-mapped frameworks, grouped into four families. OWASP AISVS is exposed as a separate benchmark result with per-check evidence. The bundled mappings are a curated subset of each framework focused on AI/MCP/agent risk-relevant controls — they are not a complete catalog. See [Coverage per framework](#coverage-per-framework) below for the honest control counts.
 
 ```mermaid
 graph LR
@@ -200,7 +200,7 @@ graph LR
 
 ### Coverage per framework
 
-agent-bom ships a curated control set per framework, sized to the AI/MCP/agent threat surface rather than a generic compliance scanner's full catalog. Numbers below count the controls that are **bundled and actively mapped** by `compliance_utils.py` and the UI catalogs in `ui/lib/api.ts`. They are intentionally a subset; consult each framework's source standard for full coverage.
+agent-bom ships a curated control set per framework, sized to the AI/MCP/agent threat surface rather than a generic compliance scanner's full catalog. Numbers below count the controls that are **bundled and actively mapped** by `compliance_utils.py` and the UI catalogs in `ui/lib/api.ts`; AISVS is counted as a benchmark surface. They are intentionally a subset; consult each framework's source standard for full coverage.
 
 | Family | Framework | Bundled controls | Source-standard size (approx.) | What's covered |
 |---|---|---|---|---|

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -178,7 +178,8 @@ agent-bom serve --port 8422 --persist jobs.db
 - `GET /v1/fleet/list` — view all discovered agents across the org
 - `GET /v1/fleet/stats` — fleet-wide trust scores and posture
 - `POST /v1/fleet/sync` — ingest endpoint scan results
-- `GET /v1/compliance` — 14-framework compliance posture
+- `GET /v1/compliance` — 14-framework compliance posture plus AISVS benchmark summary
+- `GET /v1/compliance/aisvs` — latest tenant-scoped OWASP AISVS benchmark result
 
 Fleet trust scoring is advisory and evidence-backed. The score combines registry verification, active vulnerability posture, credential hygiene, permission profile, configuration quality, discovery provenance, package provenance attestation, runtime drift evidence, and inventory freshness. API responses include factor breakdowns plus evidence references so operators can explain why an agent is trusted or risky instead of treating the score as an opaque compliance certification.
 

--- a/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
+++ b/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
@@ -167,7 +167,7 @@ Central policy management at [`/v1/gateway/policies`](../src/agent_bom/api/route
 
 - **HMAC-chained audit log** — [`api/audit_log.py`](../src/agent_bom/api/audit_log.py). Every entry signs the previous entry's signature; tampering with any row invalidates the chain from that point forward.
 - **Ed25519-signed evidence bundles** — [`api/compliance_signing.py`](../src/agent_bom/api/compliance_signing.py). Auditor fetches the public key from [`/v1/compliance/verification-key`](../src/agent_bom/api/routes/compliance.py) once, pins it, verifies every bundle offline. Cookbook: [COMPLIANCE_SIGNING.md](COMPLIANCE_SIGNING.md).
-- **14 compliance frameworks** mapped to findings inline — OWASP LLM Top 10, OWASP MCP Top 10, OWASP Agentic Top 10, MITRE ATLAS, NIST AI RMF, NIST CSF 2.0, NIST 800-53, FedRAMP, ISO 27001, SOC 2, CIS Controls v8, CMMC, EU AI Act, PCI DSS. Per-control + per-finding trace.
+- **14 tag-mapped compliance frameworks plus AISVS** — OWASP LLM Top 10, OWASP MCP Top 10, OWASP Agentic Top 10, MITRE ATLAS, NIST AI RMF, NIST CSF 2.0, NIST 800-53, FedRAMP, ISO 27001, SOC 2, CIS Controls v8, CMMC, EU AI Act, and PCI DSS are mapped to findings inline. OWASP AISVS is exposed as a benchmark result with per-check evidence.
 - **Tenant isolation on every export** — evidence bundle only carries scans + audit events from the authed tenant. Cross-tenant tests: [`tests/test_api_cross_tenant_matrix.py`](../tests/test_api_cross_tenant_matrix.py), [`tests/test_cross_tenant_leakage.py`](../tests/test_cross_tenant_leakage.py).
 
 ### 2.8 Scale: "Will this hold up at 50k packages and a 5k-agent fleet?"

--- a/docs/MCP_ERROR_CODES.md
+++ b/docs/MCP_ERROR_CODES.md
@@ -98,7 +98,7 @@ matrix records what each surface exposes and why.
 | Run a scan | `POST /v1/scan` | `scan` | Same scan pipeline. |
 | Look up CVE blast radius | `GET /v1/findings/{cve}` | `blast_radius` | MCP returns the same shape. |
 | Query the MCP server registry | `GET /v1/registry/servers` | `registry_lookup`, `marketplace_check`, `fleet_scan` | Registry is read-only on both. |
-| Compliance posture | `GET /v1/compliance/{framework}` | `compliance` | 14 frameworks (curated subsets — see [ARCHITECTURE.md § Coverage per framework](./ARCHITECTURE.md#coverage-per-framework)), both surfaces. |
+| Compliance posture | `GET /v1/compliance/{framework}` / `GET /v1/compliance/aisvs` | `compliance` | 14 tag-mapped frameworks plus AISVS benchmark evidence (curated subsets — see [ARCHITECTURE.md § Coverage per framework](./ARCHITECTURE.md#coverage-per-framework)), both surfaces. |
 | SBOM generation | `POST /v1/sbom` | `generate_sbom` | CycloneDX + SPDX on both. |
 | Policy evaluation | `POST /v1/gateway/evaluate` | `policy_check` | Same `check_policy` evaluator. |
 

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -152,7 +152,7 @@ agent-bom agents --enforce    # + static tool poisoning analysis
 agent-bom agents --gpu-scan   # + GPU containers, CUDA versions, DCGM exposure
 ```
 
-Outputs: blast radius tree, compliance mapping (14 frameworks — curated control subsets, see [ARCHITECTURE.md § Coverage per framework](./ARCHITECTURE.md#coverage-per-framework)), posture score, SARIF/CycloneDX/SPDX/HTML.
+Outputs: blast radius tree, compliance mapping (14 tag-mapped frameworks plus AISVS benchmark evidence — curated control subsets, see [ARCHITECTURE.md § Coverage per framework](./ARCHITECTURE.md#coverage-per-framework)), posture score, SARIF/CycloneDX/SPDX/HTML.
 
 ### 4.2 Proxy mode
 

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,46 +1,46 @@
 {
-  "generated_on": "2026-04-21",
+  "generated_on": "2026-04-28",
   "version": "0.82.3",
   "metrics": [
     {
       "name": "MCP tools",
-      "value": 24,
+      "value": 9,
       "source": "src/agent_bom/mcp_server.py",
       "notes": "Counted from @mcp.tool decorators."
     },
     {
       "name": "MCP resources",
-      "value": 3,
+      "value": 0,
       "source": "src/agent_bom/mcp_server.py",
       "notes": "Counted from @mcp.resource decorators."
     },
     {
       "name": "GitHub workflow files",
-      "value": 26,
+      "value": 35,
       "source": ".github/workflows",
       "notes": "Counts .yml and .yaml workflow definitions."
     },
     {
       "name": "Test files",
-      "value": 329,
+      "value": 394,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
     {
       "name": "API route modules",
-      "value": 15,
+      "value": 18,
       "source": "src/agent_bom/api/routes",
       "notes": "Counts Python files in the routes package, including __init__.py."
     },
     {
       "name": "UI app pages",
-      "value": 22,
+      "value": 23,
       "source": "ui/app",
       "notes": "Counts page.tsx and page.jsx files recursively."
     },
     {
       "name": "Python modules",
-      "value": 341,
+      "value": 409,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },
@@ -51,10 +51,10 @@
       "notes": "Counted from SUPPORTED_PACKAGE_ECOSYSTEMS."
     },
     {
-      "name": "Compliance frameworks",
-      "value": 14,
+      "name": "Compliance surfaces",
+      "value": 15,
       "source": "src/agent_bom/api/routes/compliance.py",
-      "notes": "Counted from the public compliance aggregation surface."
+      "notes": "14 tag-mapped frameworks plus the OWASP AISVS benchmark surface."
     },
     {
       "name": "Proxy inline detectors",

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,20 +5,20 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-04-21`
+- Generated on: `2026-04-28`
 - Version: `0.82.3`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |
-| MCP tools | 24 | `src/agent_bom/mcp_server.py` | Counted from @mcp.tool decorators. |
-| MCP resources | 3 | `src/agent_bom/mcp_server.py` | Counted from @mcp.resource decorators. |
-| GitHub workflow files | 26 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 329 | `tests/` | Counts files matching test_*.py. |
-| API route modules | 15 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
-| UI app pages | 22 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 341 | `src/agent_bom` | Counts all Python files recursively. |
+| MCP tools | 9 | `src/agent_bom/mcp_server.py` | Counted from @mcp.tool decorators. |
+| MCP resources | 0 | `src/agent_bom/mcp_server.py` | Counted from @mcp.resource decorators. |
+| GitHub workflow files | 35 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
+| Test files | 394 | `tests/` | Counts files matching test_*.py. |
+| API route modules | 18 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
+| UI app pages | 23 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
+| Python modules | 409 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
-| Compliance frameworks | 14 | `src/agent_bom/api/routes/compliance.py` | Counted from the public compliance aggregation surface. |
+| Compliance surfaces | 15 | `src/agent_bom/api/routes/compliance.py` | 14 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |
 | Runtime protection engine detectors | 8 | `src/agent_bom/runtime/protection.py` | Broader protection engine used outside the lighter proxy-only path. |
 

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -142,11 +142,12 @@ If engaging a third-party auditor, the recommended scope:
 
 ### Compliance Framework Mapping
 
-agent-bom **maps findings TO compliance controls** across 14 frameworks:
+agent-bom **maps findings TO compliance controls** across 14 tag-mapped frameworks and exposes AISVS as a benchmark:
 
-OWASP LLM Top 10, OWASP MCP Top 10, OWASP Agentic Top 10, OWASP AISVS v1.0,
+OWASP LLM Top 10, OWASP MCP Top 10, OWASP Agentic Top 10,
 EU AI Act, NIST AI RMF, NIST CSF, NIST 800-53 Rev 5, FedRAMP Moderate,
-ISO 27001, SOC 2, CIS Controls v8, MITRE ATLAS, CMMC 2.0 Level 2
+ISO 27001, SOC 2, CIS Controls v8, MITRE ATLAS, CMMC 2.0 Level 2, PCI DSS.
+OWASP AISVS v1.0 is returned as per-check benchmark evidence.
 
 The bundled mappings are a curated subset of each framework focused on AI/MCP/agent risk — not a complete catalog. See [docs/ARCHITECTURE.md § Coverage per framework](./ARCHITECTURE.md#coverage-per-framework) for the honest control counts per framework.
 

--- a/docs/images/scan-pipeline-dark.svg
+++ b/docs/images/scan-pipeline-dark.svg
@@ -120,7 +120,7 @@
   <rect x="422" y="120" width="140" height="1" fill="#27272a"/>
 
   <text x="428" y="138" class="item-label" fill="#fb7185">Compliance</text>
-  <text x="562" y="138" text-anchor="end" class="step-desc">14 frameworks</text>
+  <text x="562" y="138" text-anchor="end" class="step-desc">14 + AISVS</text>
   <rect x="422" y="144" width="140" height="1" fill="#27272a"/>
 
   <text x="428" y="162" class="item-label" fill="#fb7185">Policy engine</text>

--- a/docs/images/scan-pipeline-light.svg
+++ b/docs/images/scan-pipeline-light.svg
@@ -120,7 +120,7 @@
   <rect x="422" y="120" width="140" height="1" fill="#e4e4e7"/>
 
   <text x="428" y="138" class="item-label" fill="#e11d48">Compliance</text>
-  <text x="562" y="138" text-anchor="end" class="step-desc">14 frameworks</text>
+  <text x="562" y="138" text-anchor="end" class="step-desc">14 + AISVS</text>
   <rect x="422" y="144" width="140" height="1" fill="#e4e4e7"/>
 
   <text x="428" y="162" class="item-label" fill="#e11d48">Policy engine</text>

--- a/scripts/product_metrics_snapshot.py
+++ b/scripts/product_metrics_snapshot.py
@@ -58,6 +58,10 @@ def _count_compliance_frameworks() -> int:
     return len(entries)
 
 
+def _count_compliance_surfaces() -> int:
+    return _count_compliance_frameworks() + 1
+
+
 def _count_proxy_inline_detectors() -> int:
     content = (ROOT / "src" / "agent_bom" / "proxy.py").read_text()
     detector_block = re.search(
@@ -138,10 +142,10 @@ def build_snapshot() -> dict[str, object]:
                 "notes": "Counted from SUPPORTED_PACKAGE_ECOSYSTEMS.",
             },
             {
-                "name": "Compliance frameworks",
-                "value": _count_compliance_frameworks(),
+                "name": "Compliance surfaces",
+                "value": _count_compliance_surfaces(),
                 "source": "src/agent_bom/api/routes/compliance.py",
-                "notes": "Counted from the public compliance aggregation surface.",
+                "notes": "14 tag-mapped frameworks plus the OWASP AISVS benchmark surface.",
             },
             {
                 "name": "Proxy inline detectors",

--- a/site-docs/architecture/overview.md
+++ b/site-docs/architecture/overview.md
@@ -40,7 +40,7 @@ graph LR
 | Blast Radius | `src/agent_bom/blast_radius.py` | Impact chain mapping |
 | Context Graph | `src/agent_bom/context_graph.py` | Lateral movement analysis |
 | Registry | `src/agent_bom/registry.py` | 427+ server security metadata |
-| Compliance | `src/agent_bom/compliance/` | 14 framework mappings |
+| Compliance | `src/agent_bom/compliance/` | 14 framework mappings plus AISVS benchmark evidence |
 | Asset Tracker | `src/agent_bom/asset_tracker.py` | Persistent vuln tracking — first_seen, resolved, MTTR |
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP interception |
 | Protection | `src/agent_bom/runtime/` | 7-detector anomaly engine |

--- a/site-docs/features/compliance.md
+++ b/site-docs/features/compliance.md
@@ -1,6 +1,6 @@
 # Compliance Frameworks
 
-agent-bom maps scan findings to 10 security and compliance frameworks.
+agent-bom maps scan findings to 14 tag-mapped security and compliance frameworks and exposes OWASP AISVS as benchmark evidence.
 
 Framework catalogs are pinned in-repo by default so scans stay deterministic,
 offline-friendly, and reproducible. Catalog refreshes can happen out of band;
@@ -20,6 +20,16 @@ the scan hot path does not fetch MITRE or other framework data at runtime.
 | SOC 2 | `soc2.py` | Trust service criteria |
 | ISO 27001 | `iso_27001.py` | Information security |
 | CIS Controls | `cis_controls.py` | Security best practices |
+| CMMC 2.0 | `cmmc.py` | Defense contractor practices |
+| NIST 800-53 | `nist_800_53.py` | Federal security controls |
+| FedRAMP Moderate | `fedramp.py` | Federal cloud baseline |
+| PCI DSS | `pci_dss.py` | Payment data controls |
+
+## Benchmark surfaces
+
+| Benchmark | Module | Focus |
+|-----------|--------|-------|
+| OWASP AISVS v1.0 | `cloud/aisvs_benchmark.py` | AI security verification checks |
 
 ## Usage
 

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -1,7 +1,8 @@
 """Compliance and posture API routes.
 
 Endpoints:
-    GET  /v1/compliance                      14-framework compliance posture
+    GET  /v1/compliance                      14-framework compliance posture + AISVS benchmark
+    GET  /v1/compliance/aisvs                OWASP AISVS benchmark posture
     GET  /v1/compliance/narrative            full compliance narrative (all frameworks)
     GET  /v1/compliance/narrative/{framework} single-framework narrative
     GET  /v1/compliance/{framework}          single framework (must be after /narrative)
@@ -72,6 +73,95 @@ def _normalize_csv_filter(value: str | None) -> set[str]:
     if not value:
         return set()
     return {item.strip().lower() for item in value.split(",") if item.strip()}
+
+
+def _aisvs_summary(benchmark: dict[str, Any]) -> dict[str, int | float]:
+    checks_value = benchmark.get("checks")
+    checks: list[Any] = checks_value if isinstance(checks_value, list) else []
+    status_counts = {"pass": 0, "fail": 0, "error": 0, "not_applicable": 0}
+    for check in checks:
+        if not isinstance(check, dict):
+            continue
+        status = str(check.get("status") or "").lower()
+        if status in status_counts:
+            status_counts[status] += 1
+
+    if not checks:
+        status_counts["pass"] = int(benchmark.get("passed") or 0)
+        status_counts["fail"] = int(benchmark.get("failed") or 0)
+
+    total = int(benchmark.get("total") or len(checks) or sum(status_counts.values()))
+    score = float(benchmark.get("pass_rate") or benchmark.get("overall_score") or 0.0)
+    return {
+        "pass": status_counts["pass"],
+        "fail": status_counts["fail"],
+        "error": status_counts["error"],
+        "not_applicable": status_counts["not_applicable"],
+        "total": total,
+        "score": round(score, 1),
+    }
+
+
+def _empty_aisvs_benchmark() -> dict[str, Any]:
+    return {
+        "benchmark": "OWASP AI Security Verification Standard",
+        "benchmark_version": "1.0",
+        "passed": 0,
+        "failed": 0,
+        "total": 0,
+        "pass_rate": 0.0,
+        "checks": [],
+        "metadata": {},
+    }
+
+
+def _build_aisvs_payload(
+    benchmark: dict[str, Any] | None,
+    *,
+    scan_id: str | None = None,
+    measured_at: str | None = None,
+) -> dict[str, Any]:
+    normalized = _empty_aisvs_benchmark()
+    if isinstance(benchmark, dict):
+        normalized.update(benchmark)
+        if not isinstance(normalized.get("checks"), list):
+            normalized["checks"] = []
+        if not isinstance(normalized.get("metadata"), dict):
+            normalized["metadata"] = {}
+
+    summary = _aisvs_summary(normalized)
+    return {
+        "framework": "aisvs",
+        "framework_key": "aisvs_benchmark",
+        "framework_label": normalized.get("benchmark") or "OWASP AI Security Verification Standard",
+        "source": "scan_jobs",
+        "scan_id": scan_id,
+        "measured_at": measured_at,
+        "summary": summary,
+        "score": summary["score"],
+        "representation": "benchmark",
+        "benchmark": normalized,
+    }
+
+
+def _latest_aisvs_benchmark_from_jobs(jobs: list[Any]) -> dict[str, Any]:
+    latest: tuple[str, str, dict[str, Any]] | None = None
+    for job in jobs:
+        if job.status != JobStatus.DONE or not isinstance(getattr(job, "result", None), dict):
+            continue
+        result = cast(dict[str, Any], job.result)
+        benchmark = result.get("aisvs_benchmark") or result.get("aisvs_benchmark_data")
+        if not isinstance(benchmark, dict):
+            continue
+        measured_at = str(getattr(job, "completed_at", None) or getattr(job, "created_at", None) or "")
+        scan_id = str(result.get("scan_id") or getattr(job, "job_id", ""))
+        if latest is None or measured_at >= latest[0]:
+            latest = (measured_at, scan_id, benchmark)
+
+    if latest is None:
+        return _build_aisvs_payload(None)
+    latest_measured_at, latest_scan_id, benchmark = latest
+    return _build_aisvs_payload(benchmark, scan_id=latest_scan_id, measured_at=latest_measured_at or None)
 
 
 def _result_has_runtime_signals(result: dict[str, Any]) -> bool:
@@ -168,6 +258,8 @@ async def get_compliance(request: Request) -> dict:
     from agent_bom.nist_ai_rmf import NIST_AI_RMF
     from agent_bom.owasp import OWASP_LLM_TOP10
 
+    tenant_jobs = _tenant_jobs(request)
+
     # Collect blast_radius entries from all completed scans
     all_blast: list[dict] = []
     latest_scan: str | None = None
@@ -176,7 +268,7 @@ async def get_compliance(request: Request) -> dict:
     has_agent_context = False
     all_scan_sources: set[str] = set()
 
-    for job in _tenant_jobs(request):
+    for job in tenant_jobs:
         if job.status != JobStatus.DONE or not job.result:
             continue
         scan_count += 1
@@ -316,6 +408,8 @@ async def get_compliance(request: Request) -> dict:
     n8p, n8w, n8f = _count_statuses(nist_800_53)
     frp, frw, frf = _count_statuses(fedramp)
     pp, pw, pf = _count_statuses(pci_dss)
+    aisvs = _latest_aisvs_benchmark_from_jobs(tenant_jobs)
+    aisvs_summary = aisvs["summary"]
 
     return {
         "overall_score": overall_score,
@@ -339,6 +433,7 @@ async def get_compliance(request: Request) -> dict:
         "nist_800_53": nist_800_53,
         "fedramp": fedramp,
         "pci_dss": pci_dss,
+        "aisvs_benchmark": aisvs,
         "summary": {
             "owasp_pass": op,
             "owasp_warn": ow,
@@ -382,6 +477,10 @@ async def get_compliance(request: Request) -> dict:
             "pci_dss_pass": pp,
             "pci_dss_warn": pw,
             "pci_dss_fail": pf,
+            "aisvs_pass": aisvs_summary["pass"],
+            "aisvs_fail": aisvs_summary["fail"],
+            "aisvs_error": aisvs_summary["error"],
+            "aisvs_not_applicable": aisvs_summary["not_applicable"],
         },
     }
 
@@ -869,13 +968,22 @@ async def get_compliance_verification_key(request: Request) -> dict:
     }
 
 
+@router.get("/v1/compliance/aisvs", tags=["compliance"])
+async def get_aisvs_compliance(request: Request) -> dict:
+    """Return the latest tenant-scoped OWASP AISVS benchmark result from completed scans."""
+    return _latest_aisvs_benchmark_from_jobs(_tenant_jobs(request))
+
+
 @router.get("/v1/compliance/{framework}", tags=["compliance"])
 async def get_compliance_by_framework(request: Request, framework: str) -> dict:
     """Get compliance posture for a single framework.
 
     Supported frameworks: owasp-llm, owasp-mcp, atlas, nist, owasp-agentic, eu-ai-act,
-    nist-csf, iso-27001, soc2, cis, cmmc
+    nist-csf, iso-27001, soc2, cis, cmmc, aisvs
     """
+    if framework.lower() == "aisvs":
+        return await get_aisvs_compliance(request)
+
     full = await get_compliance(request)
 
     framework_map = {
@@ -897,9 +1005,10 @@ async def get_compliance_by_framework(request: Request, framework: str) -> dict:
 
     key = framework_map.get(framework.lower())
     if not key:
+        supported = [*framework_map.keys(), "aisvs"]
         raise HTTPException(
             status_code=400,
-            detail=f"Unknown framework '{framework}'. Supported: {', '.join(framework_map.keys())}",
+            detail=f"Unknown framework '{framework}'. Supported: {', '.join(supported)}",
         )
 
     controls = full.get(key, [])

--- a/tests/test_api_compliance_auth.py
+++ b/tests/test_api_compliance_auth.py
@@ -84,6 +84,23 @@ def test_compliance_export_accepts_trusted_proxy_headers() -> None:
     assert body["tenant_id"] == "tenant-alpha"
 
 
+def test_aisvs_compliance_requires_authenticated_context() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/compliance/aisvs")
+    assert resp.status_code == 401
+    assert "Unauthorized" in resp.json()["detail"]
+
+
+def test_aisvs_compliance_accepts_trusted_proxy_headers() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/compliance/aisvs", headers=_proxy_headers())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["framework"] == "aisvs"
+    assert body["framework_key"] == "aisvs_benchmark"
+    assert body["representation"] == "benchmark"
+
+
 def test_compliance_export_end_to_end_returns_real_evidence() -> None:
     """Full stack: seed a real ScanJob, hit the FastAPI route, verify evidence wires.
 

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -26,12 +26,19 @@ def _clear_jobs():
     set_job_store(InMemoryJobStore())
 
 
-def _add_done_job(blast_radius: list[dict], job_id: str = "test-job"):
+def _add_done_job(
+    blast_radius: list[dict],
+    job_id: str = "test-job",
+    *,
+    tenant_id: str = "default",
+    result_extra: dict | None = None,
+):
     """Insert a synthetic completed scan job."""
     from agent_bom.api.server import ScanJob, ScanRequest
 
     job = ScanJob(
         job_id=job_id,
+        tenant_id=tenant_id,
         created_at="2026-02-22T10:00:00Z",
         request=ScanRequest(),
     )
@@ -42,6 +49,8 @@ def _add_done_job(blast_radius: list[dict], job_id: str = "test-job"):
         "blast_radius": blast_radius,
         "threat_framework_summary": {},
     }
+    if result_extra:
+        job.result.update(result_extra)
     _get_store().put(job)
 
 
@@ -59,10 +68,129 @@ def test_compliance_no_scans():
     assert data["overall_status"] == "pass"
     assert data["scan_count"] == 0
     assert data["latest_scan"] is None
+    assert data["aisvs_benchmark"]["framework"] == "aisvs"
+    assert data["aisvs_benchmark"]["benchmark"]["checks"] == []
+    assert data["summary"]["aisvs_pass"] == 0
+    assert data["summary"]["aisvs_fail"] == 0
     # All OWASP controls should be "pass"
     for c in data["owasp_llm_top10"]:
         assert c["status"] == "pass"
         assert c["findings"] == 0
+    _clear_jobs()
+
+
+def test_compliance_includes_latest_aisvs_benchmark():
+    """Aggregate compliance includes the latest tenant-scoped AISVS benchmark payload."""
+    _clear_jobs()
+    _add_done_job(
+        [],
+        job_id="older-scan",
+        result_extra={
+            "scan_id": "older-scan",
+            "aisvs_benchmark": {
+                "benchmark": "OWASP AI Security Verification Standard",
+                "benchmark_version": "1.0",
+                "passed": 1,
+                "failed": 0,
+                "total": 1,
+                "pass_rate": 100.0,
+                "checks": [{"check_id": "AI-4.1", "status": "pass", "severity": "high"}],
+                "metadata": {},
+            },
+        },
+    )
+    _add_done_job(
+        [],
+        job_id="newer-scan",
+        result_extra={
+            "scan_id": "newer-scan",
+            "aisvs_benchmark": {
+                "benchmark": "OWASP AI Security Verification Standard",
+                "benchmark_version": "1.0",
+                "passed": 1,
+                "failed": 1,
+                "total": 3,
+                "pass_rate": 50.0,
+                "checks": [
+                    {"check_id": "AI-4.1", "status": "pass", "severity": "high"},
+                    {"check_id": "AI-6.1", "status": "fail", "severity": "critical"},
+                    {"check_id": "AI-8.1", "status": "not_applicable", "severity": "medium"},
+                ],
+                "metadata": {"runner": "test"},
+            },
+        },
+    )
+
+    client = TestClient(app)
+    data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
+
+    aisvs = data["aisvs_benchmark"]
+    assert aisvs["framework"] == "aisvs"
+    assert aisvs["framework_key"] == "aisvs_benchmark"
+    assert aisvs["representation"] == "benchmark"
+    assert aisvs["scan_id"] == "newer-scan"
+    assert aisvs["summary"] == {
+        "pass": 1,
+        "fail": 1,
+        "error": 0,
+        "not_applicable": 1,
+        "total": 3,
+        "score": 50.0,
+    }
+    assert data["summary"]["aisvs_pass"] == 1
+    assert data["summary"]["aisvs_fail"] == 1
+    assert data["summary"]["aisvs_not_applicable"] == 1
+    assert data["overall_score"] == 100.0
+
+    _clear_jobs()
+
+
+def test_aisvs_compliance_endpoint_is_tenant_scoped():
+    """The dedicated AISVS endpoint returns only the authenticated tenant's benchmark."""
+    _clear_jobs()
+    _add_done_job(
+        [],
+        job_id="tenant-alpha-scan",
+        tenant_id="tenant-alpha",
+        result_extra={
+            "scan_id": "tenant-alpha-scan",
+            "aisvs_benchmark": {
+                "benchmark": "OWASP AI Security Verification Standard",
+                "benchmark_version": "1.0",
+                "passed": 0,
+                "failed": 1,
+                "total": 1,
+                "pass_rate": 0.0,
+                "checks": [{"check_id": "AI-6.1", "status": "fail", "severity": "critical"}],
+                "metadata": {},
+            },
+        },
+    )
+    _add_done_job(
+        [],
+        job_id="default-scan",
+        result_extra={
+            "scan_id": "default-scan",
+            "aisvs_benchmark": {
+                "benchmark": "OWASP AI Security Verification Standard",
+                "benchmark_version": "1.0",
+                "passed": 1,
+                "failed": 0,
+                "total": 1,
+                "pass_rate": 100.0,
+                "checks": [{"check_id": "AI-4.1", "status": "pass", "severity": "high"}],
+                "metadata": {},
+            },
+        },
+    )
+
+    client = TestClient(app)
+    data = client.get("/v1/compliance/aisvs", headers=proxy_headers(tenant="tenant-alpha")).json()
+
+    assert data["scan_id"] == "tenant-alpha-scan"
+    assert data["summary"]["fail"] == 1
+    assert data["benchmark"]["checks"][0]["check_id"] == "AI-6.1"
+
     _clear_jobs()
 
 

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -996,6 +996,48 @@ export interface ComplianceControl {
   affected_agents: string[];
 }
 
+export interface AISVSCheck {
+  check_id: string;
+  title?: string | undefined;
+  status: "pass" | "fail" | "error" | "not_applicable";
+  severity: string;
+  evidence?: string | undefined;
+  recommendation?: string | undefined;
+  cis_section?: string | undefined;
+  maestro_layer?: string | undefined;
+}
+
+export interface AISVSBenchmark {
+  benchmark: string;
+  benchmark_version: string;
+  passed: number;
+  failed: number;
+  total: number;
+  pass_rate: number;
+  checks: AISVSCheck[];
+  metadata: Record<string, unknown>;
+}
+
+export interface AISVSComplianceResponse {
+  framework: "aisvs";
+  framework_key: "aisvs_benchmark";
+  framework_label: string;
+  source: "scan_jobs";
+  scan_id: string | null;
+  measured_at: string | null;
+  representation: "benchmark";
+  score: number;
+  summary: {
+    pass: number;
+    fail: number;
+    error: number;
+    not_applicable: number;
+    total: number;
+    score: number;
+  };
+  benchmark: AISVSBenchmark;
+}
+
 export interface ComplianceResponse {
   overall_score: number;
   overall_status: "pass" | "warning" | "fail";
@@ -1018,6 +1060,7 @@ export interface ComplianceResponse {
   nist_800_53: ComplianceControl[];
   fedramp: ComplianceControl[];
   pci_dss: ComplianceControl[];
+  aisvs_benchmark: AISVSComplianceResponse;
   summary: {
     owasp_pass: number; owasp_warn: number; owasp_fail: number;
     owasp_mcp_pass: number; owasp_mcp_warn: number; owasp_mcp_fail: number;
@@ -1033,6 +1076,7 @@ export interface ComplianceResponse {
     nist_800_53_pass: number; nist_800_53_warn: number; nist_800_53_fail: number;
     fedramp_pass: number; fedramp_warn: number; fedramp_fail: number;
     pci_dss_pass: number; pci_dss_warn: number; pci_dss_fail: number;
+    aisvs_pass: number; aisvs_fail: number; aisvs_error: number; aisvs_not_applicable: number;
   };
 }
 
@@ -1605,10 +1649,13 @@ export const api = {
   /** Compliance posture across all completed scans */
   getCompliance: () => get<ComplianceResponse>("/v1/compliance"),
 
+  /** Latest tenant-scoped OWASP AISVS benchmark posture */
+  getAISVSCompliance: () => get<AISVSComplianceResponse>("/v1/compliance/aisvs"),
+
   /** Active framework catalog metadata surfaced by the API */
   getFrameworkCatalogs: () => get<FrameworkCatalogsResponse>("/v1/frameworks/catalogs"),
 
-  /** Auditor-ready compliance narrative for all 14 frameworks */
+  /** Auditor-ready compliance narrative for all tag-mapped frameworks */
   getComplianceNarrative: () => get<ComplianceNarrativeResponse>("/v1/compliance/narrative"),
 
   /** Single-framework compliance narrative */


### PR DESCRIPTION
## Summary

- Adds `GET /v1/compliance/aisvs` as a benchmark-style REST surface for the latest tenant-scoped OWASP AISVS scan result.
- Includes `aisvs_benchmark` and AISVS summary counts in `GET /v1/compliance` without folding AISVS into the existing tag-control `overall_score`.
- Updates UI API types, product metrics generation, docs, and scan-pipeline visuals to describe 14 tag-mapped frameworks plus the AISVS benchmark surface.

## Validation

- `uv run pytest tests/test_compliance.py tests/test_api_compliance_auth.py tests/test_aisvs_benchmark.py`
- `uv run pytest tests/test_compliance_report.py tests/test_api_cross_tenant_matrix.py`
- `uv run ruff check src/agent_bom/api/routes/compliance.py tests/test_compliance.py tests/test_api_compliance_auth.py scripts/product_metrics_snapshot.py`
- `uv run mypy src/agent_bom/api/routes/compliance.py`
- `python scripts/check_product_surface_contract.py`
- `npm run typecheck` in `ui/`
- `git diff --check`

Note: the full pre-commit mypy hook still reports existing unrelated `src/agent_bom/cloud/snowflake.py` account typing errors. The touched compliance route passes targeted mypy.

Closes #936