### PR TITLE
Reconcile active scan job gauge

### DIFF
--- a/src/agent_bom/api/metrics.py
+++ b/src/agent_bom/api/metrics.py
@@ -57,6 +57,10 @@ class _Gauge:
         with self._lock:
             return self._value
 
+    def set(self, value: int) -> None:
+        with self._lock:
+            self._value = max(0, value)
+
     def reset(self) -> None:
         with self._lock:
             self._value = 0
@@ -117,6 +121,11 @@ def record_scan_finished() -> None:
 def scan_jobs_active() -> int:
     """Return the current in-flight scan-jobs gauge value (test helper)."""
     return _scan_jobs_active.value()
+
+
+def reconcile_scan_jobs_active(active_count: int) -> None:
+    """Set the in-flight scan-jobs gauge from durable job-store state."""
+    _scan_jobs_active.set(active_count)
 
 
 def record_gateway_relay(upstream: str, outcome: str) -> None:

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -690,14 +690,16 @@ def _run_scan_sync(job: ScanJob) -> None:
             job.completed_at = _now()
             terminal_status = job.status
         # Persist final state
-        _get_store().put(job)
+        store = _get_store()
+        store.put(job)
         # Update operator-visible scan metrics. The active gauge feeds
         # the KEDA scaler in deploy/helm/agent-bom; the completion
         # counter feeds dashboards + alerting on failure rate.
         try:
             from agent_bom.api import metrics as _api_metrics
+            from agent_bom.api.scan_job_reconciliation import reconcile_scan_jobs_active
 
-            _api_metrics.record_scan_finished()
+            reconcile_scan_jobs_active(store)
             _api_metrics.record_scan_completion(str(terminal_status))
         except Exception:  # noqa: BLE001
             # Metrics must never break the scan path. Swallow all errors.

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -46,6 +46,7 @@ from agent_bom.api.models import (
     TrainingPipelinesRequest,
 )
 from agent_bom.api.pipeline import _now, _run_scan_sync, get_executor
+from agent_bom.api.scan_job_reconciliation import reconcile_scan_jobs_active
 from agent_bom.api.stores import (
     _get_store,
     _job_lock,
@@ -274,14 +275,10 @@ def enqueue_scan_job(
     ):
         store.put(job)
         _jobs_put(job.job_id, job)
-        # Bump the in-flight gauge as soon as the job is durably enqueued —
-        # KEDA reads this as the leading saturation signal, so we want it
-        # to fire even while jobs are sitting in the executor queue. The
-        # decrement happens in pipeline._run_scan_sync's finally block.
+        # Recompute after durable enqueue so the gauge survives missed
+        # increments and reflects queued + running work from the store.
         try:
-            from agent_bom.api import metrics as _api_metrics
-
-            _api_metrics.record_scan_enqueued()
+            reconcile_scan_jobs_active(store)
         except Exception:  # noqa: BLE001
             pass
 

--- a/src/agent_bom/api/scan_job_reconciliation.py
+++ b/src/agent_bom/api/scan_job_reconciliation.py
@@ -1,0 +1,86 @@
+"""Store-backed reconciliation for scan job lifecycle metrics."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from agent_bom.api.models import JobStatus, ScanJob
+
+ACTIVE_SCAN_JOB_STATUSES = frozenset({JobStatus.PENDING, JobStatus.RUNNING})
+
+
+def is_active_scan_job(job: ScanJob) -> bool:
+    return job.status in ACTIVE_SCAN_JOB_STATUSES
+
+
+def active_scan_job_count(store: Any, tenant_id: str | None = None) -> int:
+    return sum(1 for job in store.list_all(tenant_id=tenant_id) if is_active_scan_job(job))
+
+
+def reconcile_scan_jobs_active(store: Any, tenant_id: str | None = None) -> int:
+    """Recompute the active scan gauge from the durable job store."""
+    from agent_bom.api import metrics
+
+    count = active_scan_job_count(store, tenant_id=tenant_id)
+    metrics.reconcile_scan_jobs_active(count)
+    return count
+
+
+def _parse_created_at(job: ScanJob) -> datetime | None:
+    if not job.created_at:
+        return None
+    try:
+        return datetime.fromisoformat(job.created_at.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+
+
+def fail_stale_active_scan_jobs(
+    store: Any,
+    *,
+    timeout_seconds: int,
+    now: datetime | None = None,
+    reason: str = "Timed out (stuck in active scan state)",
+) -> int:
+    """Mark active jobs older than timeout_seconds as failed."""
+    current = now or datetime.now(timezone.utc)
+    failed = 0
+    for job in store.list_all():
+        if not is_active_scan_job(job):
+            continue
+        created = _parse_created_at(job)
+        if created is None:
+            continue
+        if (current - created).total_seconds() <= timeout_seconds:
+            continue
+        job.status = JobStatus.FAILED
+        job.error = reason
+        job.completed_at = current.isoformat()
+        store.put(job)
+        failed += 1
+    return failed
+
+
+def fail_orphaned_active_scan_jobs(
+    store: Any,
+    *,
+    reason: str = "Interrupted before completion; in-process executor state was lost",
+) -> int:
+    """Fail active jobs found during process startup.
+
+    Scan execution is in-process. If a new API process sees PENDING/RUNNING
+    rows in the durable store, those rows belonged to a previous executor and
+    will not resume automatically.
+    """
+    now = datetime.now(timezone.utc)
+    failed = 0
+    for job in store.list_all():
+        if not is_active_scan_job(job):
+            continue
+        job.status = JobStatus.FAILED
+        job.error = reason
+        job.completed_at = now.isoformat()
+        store.put(job)
+        failed += 1
+    return failed

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -344,6 +344,15 @@ async def _lifespan(app_instance: FastAPI):
         _logger.debug("rate_limit_key_rotation status check skipped", exc_info=True)
 
     global _cleanup_task
+    from agent_bom.api.scan_job_reconciliation import fail_orphaned_active_scan_jobs, reconcile_scan_jobs_active
+
+    try:
+        store = _get_store()
+        fail_orphaned_active_scan_jobs(store)
+        reconcile_scan_jobs_active(store)
+    except Exception:  # noqa: BLE001
+        _logger.debug("scan job metric startup reconciliation skipped", exc_info=True)
+
     _cleanup_task = asyncio.create_task(_cleanup_loop())
 
     # Start scheduler background loop
@@ -373,8 +382,15 @@ async def _lifespan(app_instance: FastAPI):
             lambda: enforce_active_scan_quota(tenant_id),
             lambda: enforce_retained_jobs_quota(tenant_id),
         ):
-            _get_store().put(job)
+            store = _get_store()
+            store.put(job)
             _jobs_put(job.job_id, job)
+            try:
+                from agent_bom.api.scan_job_reconciliation import reconcile_scan_jobs_active
+
+                reconcile_scan_jobs_active(store)
+            except Exception:  # noqa: BLE001
+                pass
         loop = asyncio.get_running_loop()
         loop.run_in_executor(get_executor(), _run_scan, job)
         return job.job_id
@@ -602,10 +618,13 @@ async def _cleanup_loop():
     """Background task that removes expired jobs and unsticks RUNNING jobs."""
     while True:
         await asyncio.sleep(300)
-        _get_store().cleanup_expired(_JOB_TTL_SECONDS)
+        store = _get_store()
+        store.cleanup_expired(_JOB_TTL_SECONDS)
         # Unstick jobs that have been RUNNING for too long
         try:
             from datetime import datetime, timezone
+
+            from agent_bom.api.scan_job_reconciliation import fail_stale_active_scan_jobs, reconcile_scan_jobs_active
 
             now = datetime.now(timezone.utc)
             with _jobs_lock:
@@ -617,8 +636,11 @@ async def _cleanup_loop():
                                 job.status = JobStatus.FAILED
                                 job.error = "Timed out (stuck in RUNNING state)"
                                 job.completed_at = now.isoformat()
+                                store.put(job)
                         except (ValueError, TypeError):
                             pass
+            fail_stale_active_scan_jobs(store, timeout_seconds=_STUCK_JOB_TIMEOUT, now=now)
+            reconcile_scan_jobs_active(store)
         except Exception:  # noqa: BLE001
             pass
 

--- a/tests/test_scan_jobs_active_gauge.py
+++ b/tests/test_scan_jobs_active_gauge.py
@@ -18,6 +18,13 @@ from __future__ import annotations
 import pytest
 
 from agent_bom.api import metrics
+from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+from agent_bom.api.scan_job_reconciliation import (
+    fail_orphaned_active_scan_jobs,
+    fail_stale_active_scan_jobs,
+    reconcile_scan_jobs_active,
+)
+from agent_bom.api.store import InMemoryJobStore
 
 
 @pytest.fixture(autouse=True)
@@ -69,4 +76,60 @@ def test_reset_for_tests_clears_gauge() -> None:
     assert metrics.scan_jobs_active() == 2
 
     metrics.reset_for_tests()
+    assert metrics.scan_jobs_active() == 0
+
+
+def _job(job_id: str, status: JobStatus, created_at: str = "2026-04-28T00:00:00+00:00") -> ScanJob:
+    return ScanJob(job_id=job_id, status=status, created_at=created_at, request=ScanRequest())
+
+
+def test_reconcile_sets_gauge_from_durable_active_jobs() -> None:
+    store = InMemoryJobStore()
+    store.put(_job("pending", JobStatus.PENDING))
+    store.put(_job("running", JobStatus.RUNNING))
+    store.put(_job("done", JobStatus.DONE))
+
+    metrics.record_scan_enqueued()
+    metrics.record_scan_enqueued()
+    metrics.record_scan_enqueued()
+    metrics.record_scan_enqueued()
+    assert metrics.scan_jobs_active() == 4
+
+    assert reconcile_scan_jobs_active(store) == 2
+    assert metrics.scan_jobs_active() == 2
+
+
+def test_fail_stale_active_jobs_then_reconcile_clears_leaked_gauge() -> None:
+    store = InMemoryJobStore()
+    store.put(_job("old-pending", JobStatus.PENDING, "2026-04-28T00:00:00+00:00"))
+    store.put(_job("old-running", JobStatus.RUNNING, "2026-04-28T00:00:00+00:00"))
+    store.put(_job("fresh-running", JobStatus.RUNNING, "2026-04-28T00:29:40+00:00"))
+
+    from datetime import datetime, timezone
+
+    failed = fail_stale_active_scan_jobs(
+        store,
+        timeout_seconds=1800,
+        now=datetime(2026, 4, 28, 0, 30, 1, tzinfo=timezone.utc),
+    )
+
+    assert failed == 2
+    assert store.get("old-pending").status == JobStatus.FAILED
+    assert store.get("old-running").status == JobStatus.FAILED
+    assert store.get("fresh-running").status == JobStatus.RUNNING
+    assert reconcile_scan_jobs_active(store) == 1
+    assert metrics.scan_jobs_active() == 1
+
+
+def test_startup_orphan_cleanup_fails_active_jobs() -> None:
+    store = InMemoryJobStore()
+    store.put(_job("orphan-pending", JobStatus.PENDING))
+    store.put(_job("orphan-running", JobStatus.RUNNING))
+    store.put(_job("done", JobStatus.DONE))
+
+    assert fail_orphaned_active_scan_jobs(store) == 2
+    assert store.get("orphan-pending").status == JobStatus.FAILED
+    assert store.get("orphan-running").status == JobStatus.FAILED
+    assert store.get("done").status == JobStatus.DONE
+    assert reconcile_scan_jobs_active(store) == 0
     assert metrics.scan_jobs_active() == 0


### PR DESCRIPTION
## Summary

Closes #2054.

- recompute `scan_jobs_active` from durable scan job state instead of relying only on paired enqueue/finish calls
- reconcile after API enqueues, scheduler enqueues, pipeline terminal writes, cleanup, and startup
- fail orphaned active jobs on startup because in-process executor state cannot resume after process loss
- add regression coverage for stale active jobs and startup orphan cleanup

## Validation

- `uv run pytest tests/test_scan_jobs_active_gauge.py`
- `uv run ruff check src/agent_bom/api/metrics.py src/agent_bom/api/scan_job_reconciliation.py src/agent_bom/api/routes/scan.py src/agent_bom/api/pipeline.py src/agent_bom/api/server.py tests/test_scan_jobs_active_gauge.py`
- `uv run mypy src/agent_bom/api/metrics.py src/agent_bom/api/scan_job_reconciliation.py src/agent_bom/api/routes/scan.py src/agent_bom/api/pipeline.py src/agent_bom/api/server.py`

Note: the full pre-commit MyPy hook still reports unrelated existing Snowflake errors in `src/agent_bom/cloud/snowflake.py` around optional `account` values.