### PR TITLE
Consume SCIM roles in API auth

### DIFF
--- a/src/agent_bom/api/auth.py
+++ b/src/agent_bom/api/auth.py
@@ -154,6 +154,96 @@ class ApiKeyPolicy:
     max_overlap_seconds: int = 24 * 60 * 60
 
 
+@dataclass(frozen=True)
+class SCIMRoleResolution:
+    """Runtime auth role resolved from tenant-bound SCIM lifecycle state."""
+
+    matched: bool
+    active: bool
+    role: Role | None = None
+    user_id: str | None = None
+    user_name: str | None = None
+
+
+def _dedupe_subjects(subjects: tuple[object, ...]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for subject in subjects:
+        candidate = str(subject or "").strip()
+        if not candidate:
+            continue
+        key = candidate.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(candidate)
+    return deduped
+
+
+def _highest_role(values: list[str]) -> Role | None:
+    best: Role | None = None
+    for value in values:
+        try:
+            candidate = Role(str(value).strip().lower())
+        except ValueError:
+            continue
+        if best is None or _ROLE_HIERARCHY[candidate] > _ROLE_HIERARCHY[best]:
+            best = candidate
+    return best
+
+
+def resolve_scim_user_role(tenant_id: str, *subjects: object) -> SCIMRoleResolution:
+    """Resolve an active SCIM user's highest role within one tenant.
+
+    The resolver is intentionally tenant-scoped and only matches indexed SCIM
+    identity fields so runtime auth does not scan all provisioned users.
+    """
+
+    from agent_bom.api.scim import scim_enabled_from_env
+
+    if not scim_enabled_from_env():
+        return SCIMRoleResolution(matched=False, active=False)
+
+    candidates = _dedupe_subjects(subjects)
+    if not tenant_id or not candidates:
+        return SCIMRoleResolution(matched=False, active=False)
+
+    from agent_bom.api.stores import _get_scim_store
+    from agent_bom.platform_invariants import normalize_tenant_id
+
+    tenant = normalize_tenant_id(tenant_id)
+    users = []
+    seen_users: set[str] = set()
+    store = _get_scim_store()
+    for subject in candidates:
+        for attr in ("userName", "externalId", "id"):
+            for user in store.list_users(tenant, filter_attr=attr, filter_value=subject):
+                key = f"{user.tenant_id}:{user.user_id}"
+                if key not in seen_users:
+                    seen_users.add(key)
+                    users.append(user)
+
+    if not users:
+        return SCIMRoleResolution(matched=False, active=False)
+
+    active_users = [user for user in users if user.active]
+    if not active_users:
+        user = users[0]
+        return SCIMRoleResolution(matched=True, active=False, user_id=user.user_id, user_name=user.user_name)
+
+    best_user = active_users[0]
+    best_role: Role | None = None
+    for user in active_users:
+        role = _highest_role(user.roles)
+        if role is None:
+            role = Role.VIEWER
+        if best_role is None or _ROLE_HIERARCHY[role] > _ROLE_HIERARCHY[best_role]:
+            best_role = role
+            best_user = user
+
+    return SCIMRoleResolution(matched=True, active=True, role=best_role, user_id=best_user.user_id, user_name=best_user.user_name)
+
+
 def get_api_key_policy() -> ApiKeyPolicy:
     """Load API key lifetime policy from env with safe defaults."""
     default_ttl = int(os.environ.get("AGENT_BOM_API_KEY_DEFAULT_TTL_SECONDS", str(30 * 24 * 60 * 60)))

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -31,6 +31,7 @@ from agent_bom.api.tracing import configure_otel_tracing, make_request_trace
 if TYPE_CHECKING:
     from datetime import datetime
 
+    from agent_bom.api.auth import Role
     from agent_bom.api.oidc import OIDCConfig
 
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -803,6 +804,38 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                 return scope
         return None
 
+    @staticmethod
+    def _role_allows(actual: Role, required: Role) -> bool:
+        from agent_bom.api.auth import _ROLE_HIERARCHY
+
+        return _ROLE_HIERARCHY.get(actual, 0) >= _ROLE_HIERARCHY.get(required, 0)
+
+    @staticmethod
+    def _record_scim_role_state(request: StarletteRequest, *, user_id: str | None, user_name: str | None) -> None:
+        request.state.auth_role_source = "scim"
+        request.state.scim_user_id = user_id
+        request.state.scim_user_name = user_name
+
+    def _resolve_runtime_role(
+        self,
+        request: StarletteRequest,
+        *,
+        tenant_id: str,
+        upstream_role: Role | None,
+        subjects: tuple[object, ...],
+    ) -> tuple[Role | None, JSONResponse | None]:
+        from agent_bom.api.auth import resolve_scim_user_role
+
+        resolution = resolve_scim_user_role(tenant_id, *subjects)
+        if not resolution.matched:
+            return upstream_role, None
+        if not resolution.active:
+            return None, JSONResponse(status_code=401, content={"detail": "Unauthorized — SCIM user is inactive"})
+        if resolution.role is None:
+            return None, JSONResponse(status_code=403, content={"detail": "Forbidden — SCIM user has no runtime role"})
+        self._record_scim_role_state(request, user_id=resolution.user_id, user_name=resolution.user_name)
+        return resolution.role, None
+
     async def dispatch(self, request: StarletteRequest, call_next):
         if request.url.path in self._EXEMPT_PATHS:
             return await call_next(request)
@@ -862,12 +895,24 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             try:
                 _claims, oidc_role = oidc_cfg.verify(raw_key)
                 required = self._required_role(request.method, request.url.path)
-                from agent_bom.api.auth import _ROLE_HIERARCHY, Role
+                from agent_bom.api.auth import Role
 
-                if _ROLE_HIERARCHY.get(Role(oidc_role), 0) >= _ROLE_HIERARCHY.get(Role(required), 0):
-                    request.state.api_key_name = _claims.get("email") or _claims.get("sub", "oidc-user")
-                    request.state.api_key_role = oidc_role
-                    request.state.tenant_id = oidc_cfg.resolve_tenant(_claims)
+                tenant_id = oidc_cfg.resolve_tenant(_claims)
+                subject = _claims.get("email") or _claims.get("preferred_username") or _claims.get("sub", "oidc-user")
+                upstream_role = Role(oidc_role)
+                effective_role, scim_error = self._resolve_runtime_role(
+                    request,
+                    tenant_id=tenant_id,
+                    upstream_role=upstream_role,
+                    subjects=(subject, _claims.get("email"), _claims.get("preferred_username"), _claims.get("upn"), _claims.get("sub")),
+                )
+                if scim_error is not None:
+                    return scim_error
+                required_role = Role(required)
+                if effective_role is not None and self._role_allows(effective_role, required_role):
+                    request.state.api_key_name = subject
+                    request.state.api_key_role = effective_role.value
+                    request.state.tenant_id = tenant_id
                     request.state.auth_method = "oidc"
                     # Short issuer suffix helps operators recognize which IdP
                     # resolved the token without leaking the full URL to all
@@ -875,9 +920,10 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                     issuer = str(_claims.get("iss") or "")
                     request.state.auth_issuer = issuer.rsplit("/", 1)[-1][:64] if issuer else None
                     return await self._call_with_tenant_context(request, call_next)
+                actual_role = effective_role.value if effective_role else oidc_role
                 return JSONResponse(
                     status_code=403,
-                    content={"detail": f"Forbidden — requires {required} role, OIDC token has {oidc_role}"},
+                    content={"detail": f"Forbidden — requires {required} role, OIDC session has {actual_role}"},
                 )
             except OIDCError as exc:
                 record_oidc_decode_failure()
@@ -893,10 +939,21 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             if api_key:
                 required = self._required_role(request.method, request.url.path)
                 required_role = Role(required)
-                if not api_key.has_role(required_role):
+                effective_role = api_key.role
+                if api_key.name.startswith("saml:"):
+                    effective_role, scim_error = self._resolve_runtime_role(
+                        request,
+                        tenant_id=api_key.tenant_id,
+                        upstream_role=api_key.role,
+                        subjects=(api_key.name.removeprefix("saml:"), api_key.name),
+                    )
+                    if scim_error is not None:
+                        return scim_error
+                    effective_role = effective_role or api_key.role
+                if not self._role_allows(effective_role, required_role):
                     return JSONResponse(
                         status_code=403,
-                        content={"detail": f"Forbidden — requires {required} role, you have {api_key.role.value}"},
+                        content={"detail": f"Forbidden — requires {required} role, you have {effective_role.value}"},
                     )
                 required_scope = self._required_scope(request.method, request.url.path)
                 if not api_key.has_scope(required_scope):
@@ -905,7 +962,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                         content={"detail": f"Forbidden — requires scope {required_scope}"},
                     )
                 request.state.api_key_name = api_key.name
-                request.state.api_key_role = api_key.role.value
+                request.state.api_key_role = effective_role.value
                 request.state.tenant_id = api_key.tenant_id
                 request.state.api_key_id = api_key.key_id
                 request.state.api_key_scopes = list(api_key.scopes)
@@ -952,7 +1009,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         return await self._call_with_tenant_context(request, call_next)
 
     async def _try_browser_session_auth(self, request: StarletteRequest, call_next, token: str):
-        from agent_bom.api.auth import _ROLE_HIERARCHY, Role, get_key_store
+        from agent_bom.api.auth import Role, get_key_store
 
         try:
             payload = verify_browser_session_token(token)
@@ -960,11 +1017,26 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         except (BrowserSessionError, ValueError):
             return JSONResponse(status_code=401, content={"detail": "Unauthorized — invalid browser session"})
 
+        subject = str(payload.get("sub") or "browser-session")
+        tenant_id = str(payload.get("tenant_id") or "default")
+        auth_method = str(payload.get("auth_method") or "browser_session")
+        effective_role = session_role
+        if auth_method in {"oidc", "saml"} or subject.startswith("saml:"):
+            resolved_role, scim_error = self._resolve_runtime_role(
+                request,
+                tenant_id=tenant_id,
+                upstream_role=session_role,
+                subjects=(subject.removeprefix("saml:"), subject),
+            )
+            if scim_error is not None:
+                return scim_error
+            effective_role = resolved_role or session_role
+
         required = Role(self._required_role(request.method, request.url.path))
-        if _ROLE_HIERARCHY.get(session_role, 0) < _ROLE_HIERARCHY.get(required, 0):
+        if not self._role_allows(effective_role, required):
             return JSONResponse(
                 status_code=403,
-                content={"detail": f"Forbidden — requires {required.value} role, browser session has {session_role.value}"},
+                content={"detail": f"Forbidden — requires {required.value} role, browser session has {effective_role.value}"},
             )
 
         if request.method not in {"GET", "HEAD", "OPTIONS"}:
@@ -975,7 +1047,6 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
 
         store = get_key_store()
         key_id = str(payload.get("key_id") or "")
-        tenant_id = str(payload.get("tenant_id") or "default")
         if key_id:
             stored = store.get(key_id)
             if stored is None or stored.tenant_id != tenant_id or not stored.is_usable():
@@ -984,12 +1055,12 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             if not stored.has_scope(required_scope):
                 return JSONResponse(status_code=403, content={"detail": f"Forbidden — requires scope {required_scope}"})
 
-        request.state.api_key_name = str(payload.get("sub") or "browser-session")
-        request.state.api_key_role = session_role.value
+        request.state.api_key_name = subject
+        request.state.api_key_role = effective_role.value
         request.state.tenant_id = tenant_id
         request.state.api_key_id = key_id or None
         request.state.api_key_scopes = list(payload.get("scopes") or [])
-        request.state.auth_method = str(payload.get("auth_method") or "browser_session")
+        request.state.auth_method = auth_method
         return await self._call_with_tenant_context(request, call_next)
 
     async def _try_proxy_header_auth(self, request: StarletteRequest, call_next):
@@ -998,7 +1069,13 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
 
         role_header = request.headers.get("x-agent-bom-role", "").strip().lower()
         tenant_id = request.headers.get("x-agent-bom-tenant-id", "").strip()
-        if not role_header:
+        subject = (
+            request.headers.get("x-agent-bom-subject")
+            or request.headers.get("x-forwarded-email")
+            or request.headers.get("x-auth-request-email")
+            or ""
+        )
+        if not role_header and not subject:
             return None
         if not self._trusted_proxy_secret:
             _logger.error("AGENT_BOM_TRUST_PROXY_AUTH is enabled without AGENT_BOM_TRUST_PROXY_AUTH_SECRET")
@@ -1024,27 +1101,35 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                 content={"detail": "Authentication required — trusted proxy requests must include X-Agent-Bom-Tenant-ID"},
             )
 
-        from agent_bom.api.auth import _ROLE_HIERARCHY, Role
+        from agent_bom.api.auth import Role
 
-        try:
-            proxy_role = Role(role_header)
-        except ValueError:
-            return JSONResponse(status_code=403, content={"detail": f"Invalid proxy role '{role_header}'"})
+        proxy_role: Role | None = None
+        if role_header:
+            try:
+                proxy_role = Role(role_header)
+            except ValueError:
+                return JSONResponse(status_code=403, content={"detail": f"Invalid proxy role '{role_header}'"})
+
+        effective_role, scim_error = self._resolve_runtime_role(
+            request,
+            tenant_id=tenant_id,
+            upstream_role=proxy_role,
+            subjects=(subject,),
+        )
+        if scim_error is not None:
+            return scim_error
+        if effective_role is None:
+            return JSONResponse(status_code=403, content={"detail": "Forbidden — trusted proxy role required"})
 
         required = Role(self._required_role(request.method, request.url.path))
-        if _ROLE_HIERARCHY.get(proxy_role, 0) < _ROLE_HIERARCHY.get(required, 0):
+        if not self._role_allows(effective_role, required):
             return JSONResponse(
                 status_code=403,
-                content={"detail": f"Forbidden — requires {required.value} role, proxy session has {proxy_role.value}"},
+                content={"detail": f"Forbidden — requires {required.value} role, proxy session has {effective_role.value}"},
             )
 
-        request.state.api_key_name = (
-            request.headers.get("x-agent-bom-subject")
-            or request.headers.get("x-forwarded-email")
-            or request.headers.get("x-auth-request-email")
-            or "proxy-header"
-        )
-        request.state.api_key_role = proxy_role.value
+        request.state.api_key_name = subject or "proxy-header"
+        request.state.api_key_role = effective_role.value
         request.state.tenant_id = tenant_id
         request.state.auth_method = "proxy_header"
         request.state.proxy_auth_attested = True
@@ -1057,7 +1142,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                 actor=str(request.state.api_key_name),
                 resource=str(request.url.path),
                 tenant_id=tenant_id,
-                role=proxy_role.value,
+                role=effective_role.value,
                 issuer=presented_issuer or None,
             )
         except Exception:  # pragma: no cover - audit side effects must not block auth

--- a/src/agent_bom/api/routes/scim.py
+++ b/src/agent_bom/api/routes/scim.py
@@ -9,7 +9,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Query, Request, Response
 
 from agent_bom.api.audit_log import log_action
-from agent_bom.api.scim import extract_scim_roles, scim_base_path, scim_role_attribute
+from agent_bom.api.scim import extract_scim_roles, scim_base_path, scim_enabled_from_env, scim_role_attribute
 from agent_bom.api.scim_store import SCIMGroup, SCIMUser
 from agent_bom.api.stores import _get_scim_store
 from agent_bom.platform_invariants import now_utc_iso
@@ -140,7 +140,7 @@ def _user_to_scim(user: SCIMUser, request: Request) -> dict[str, Any]:
             "tenantIdSource": "AGENT_BOM_SCIM_TENANT_ID",
             "roles": user.roles,
             "memberships": memberships,
-            "runtimeAuthEnforced": False,
+            "runtimeAuthEnforced": scim_enabled_from_env(),
         },
         "meta": {
             "resourceType": "User",

--- a/src/agent_bom/api/scim.py
+++ b/src/agent_bom/api/scim.py
@@ -173,11 +173,12 @@ def describe_scim_posture() -> dict[str, object]:
             "payload_tenant_attributes_ignored": True,
         },
         "provisioning_authority": "scim_lifecycle_store",
-        "auth_authority": "api_key_oidc_saml_or_trusted_proxy",
-        "runtime_auth_enforced": False,
+        "auth_authority": "api_key_oidc_saml_trusted_proxy_with_scim_role_overlay",
+        "runtime_auth_enforced": configured,
         "deprovisioning_boundary": (
-            "SCIM deactivate/delete updates provisioned lifecycle state and audit evidence. Runtime OIDC, SAML, "
-            "reverse-proxy, and API-key sessions are revoked by their own upstream auth path."
+            "SCIM deactivate/delete updates provisioned lifecycle state and constrains runtime OIDC, SAML, "
+            "browser, and trusted reverse-proxy roles when the authenticated subject matches a tenant-local SCIM user. "
+            "Long-lived service API keys remain governed by API-key lifecycle controls."
         ),
         "groups_required": groups_required,
         "verified_idp_templates": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,9 @@ def _reset_registry_state() -> None:
 def _reset_api_runtime_state() -> None:
     try:
         from agent_bom.api import server as api_server
+        from agent_bom.api.stores import set_scim_store
 
+        set_scim_store(None)
         api_server.configure_api(api_key=None)
     except Exception:
         pass

--- a/tests/test_api_auth_boundary.py
+++ b/tests/test_api_auth_boundary.py
@@ -2,9 +2,30 @@
 
 from starlette.testclient import TestClient
 
+from agent_bom.api.scim_store import InMemorySCIMStore, SCIMUser
 from agent_bom.api.server import app
+from agent_bom.api.stores import set_scim_store
 
 PROXY_SECRET = "test-proxy-secret-with-32-plus-bytes"
+
+
+def _configure_trusted_proxy_with_scim(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", PROXY_SECRET)
+    monkeypatch.setenv("AGENT_BOM_SCIM_BEARER_TOKEN", "scim-secret")
+
+    from agent_bom.api import server as api_server
+
+    api_server.configure_api(api_key=None)
+
+
+def _proxy_headers(*, subject: str, role: str = "viewer", tenant_id: str = "tenant-alpha") -> dict[str, str]:
+    return {
+        "X-Agent-Bom-Role": role,
+        "X-Agent-Bom-Subject": subject,
+        "X-Agent-Bom-Tenant-ID": tenant_id,
+        "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
+    }
 
 
 def test_gateway_policy_create_rejects_spoofed_role_without_attestation() -> None:
@@ -59,3 +80,75 @@ def test_attested_proxy_headers_reject_wrong_secret(monkeypatch) -> None:
     )
 
     assert response.status_code == 401
+
+
+def test_scim_role_can_authorize_attested_proxy_subject(monkeypatch) -> None:
+    _configure_trusted_proxy_with_scim(monkeypatch)
+    store = InMemorySCIMStore()
+    store.put_user(SCIMUser(tenant_id="tenant-alpha", user_name="alice@example.com", roles=["admin"]))
+    set_scim_store(store)
+    client = TestClient(app)
+
+    response = client.get("/v1/auth/policy", headers=_proxy_headers(subject="alice@example.com", role="viewer"))
+
+    assert response.status_code == 200
+
+
+def test_scim_role_is_tenant_scoped_for_attested_proxy_subject(monkeypatch) -> None:
+    _configure_trusted_proxy_with_scim(monkeypatch)
+    store = InMemorySCIMStore()
+    store.put_user(SCIMUser(tenant_id="tenant-beta", user_name="alice@example.com", roles=["admin"]))
+    set_scim_store(store)
+    client = TestClient(app)
+
+    response = client.get("/v1/auth/policy", headers=_proxy_headers(subject="alice@example.com", role="viewer", tenant_id="tenant-alpha"))
+
+    assert response.status_code == 403
+
+
+def test_scim_role_downgrades_attested_proxy_role_when_subject_matches(monkeypatch) -> None:
+    _configure_trusted_proxy_with_scim(monkeypatch)
+    store = InMemorySCIMStore()
+    store.put_user(SCIMUser(tenant_id="tenant-alpha", user_name="alice@example.com", roles=["viewer"]))
+    set_scim_store(store)
+    client = TestClient(app)
+
+    response = client.get("/v1/auth/policy", headers=_proxy_headers(subject="alice@example.com", role="admin"))
+
+    assert response.status_code == 403
+
+
+def test_inactive_scim_user_rejects_attested_proxy_subject(monkeypatch) -> None:
+    _configure_trusted_proxy_with_scim(monkeypatch)
+    store = InMemorySCIMStore()
+    store.put_user(SCIMUser(tenant_id="tenant-alpha", user_name="alice@example.com", active=False, roles=["admin"]))
+    set_scim_store(store)
+    client = TestClient(app)
+
+    response = client.get("/v1/auth/policy", headers=_proxy_headers(subject="alice@example.com", role="admin"))
+
+    assert response.status_code == 401
+
+
+def test_scim_role_does_not_downgrade_regular_service_api_key(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_SCIM_BEARER_TOKEN", "scim-secret")
+    from agent_bom.api import server as api_server
+    from agent_bom.api.auth import KeyStore, Role, create_api_key, get_key_store, set_key_store
+
+    api_server.configure_api(api_key=None)
+    scim_store = InMemorySCIMStore()
+    scim_store.put_user(SCIMUser(tenant_id="tenant-alpha", user_name="alice@example.com", roles=["viewer"]))
+    set_scim_store(scim_store)
+    original_key_store = get_key_store()
+    key_store = KeyStore()
+    raw_key, api_key = create_api_key("alice@example.com", Role.ADMIN, tenant_id="tenant-alpha")
+    key_store.add(api_key)
+    set_key_store(key_store)
+    client = TestClient(app)
+
+    try:
+        response = client.get("/v1/auth/policy", headers={"Authorization": f"Bearer {raw_key}"})
+    finally:
+        set_key_store(original_key_store)
+
+    assert response.status_code == 200

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -304,7 +304,7 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert body["identity_provisioning"]["scim"]["base_path"] == "/scim/v2"
     assert body["identity_provisioning"]["scim"]["token_configured"] is False
     assert body["identity_provisioning"]["scim"]["runtime_auth_enforced"] is False
-    assert body["identity_provisioning"]["scim"]["auth_authority"] == "api_key_oidc_saml_or_trusted_proxy"
+    assert body["identity_provisioning"]["scim"]["auth_authority"] == "api_key_oidc_saml_trusted_proxy_with_scim_role_overlay"
     assert body["identity_provisioning"]["scim"]["provisioning_authority"] == "scim_lifecycle_store"
     assert {entry["idp"] for entry in body["identity_provisioning"]["scim"]["verified_idp_templates"]} == {
         "okta",
@@ -685,8 +685,8 @@ def test_auth_policy_reports_scim_configuration_posture(monkeypatch: pytest.Monk
     }
     assert body["identity_provisioning"]["scim"]["external_id_attribute"] == "employeeNumber"
     assert body["identity_provisioning"]["scim"]["groups_required"] is True
-    assert body["identity_provisioning"]["scim"]["runtime_auth_enforced"] is False
-    assert "SCIM deactivate/delete" in body["identity_provisioning"]["scim"]["deprovisioning_boundary"]
+    assert body["identity_provisioning"]["scim"]["runtime_auth_enforced"] is True
+    assert "trusted reverse-proxy roles" in body["identity_provisioning"]["scim"]["deprovisioning_boundary"]
 
 
 def test_auth_policy_flags_clustered_scim_without_postgres(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_api_scim_lifecycle.py
+++ b/tests/test_api_scim_lifecycle.py
@@ -75,7 +75,7 @@ def test_scim_user_create_list_patch_and_deactivate(scim_client: TestClient) -> 
     assert user["roles"] == [{"value": "viewer", "display": "viewer", "type": "agent_bom"}]
     assert user[AGENT_BOM_USER_EXTENSION]["tenantId"] == "tenant-alpha"
     assert user[AGENT_BOM_USER_EXTENSION]["tenantIdSource"] == "AGENT_BOM_SCIM_TENANT_ID"
-    assert user[AGENT_BOM_USER_EXTENSION]["runtimeAuthEnforced"] is False
+    assert user[AGENT_BOM_USER_EXTENSION]["runtimeAuthEnforced"] is True
     assert user[AGENT_BOM_USER_EXTENSION]["memberships"] == [
         {"tenantId": "tenant-alpha", "role": "viewer", "active": True, "source": "scim"}
     ]


### PR DESCRIPTION
## Summary
- Add a tenant-scoped SCIM role resolver that maps provisioned `user.roles` into the existing API `Role` hierarchy.
- Apply SCIM role authority to identity-based runtime auth paths: OIDC, SAML-minted keys/browser sessions, and trusted-proxy subjects.
- Preserve ordinary long-lived service API-key behavior, even when a service key name matches a SCIM user.
- Update SCIM posture and SCIM user extension metadata to disclose runtime role enforcement when SCIM is configured.

## Validation
- `uv run pytest tests/test_api_auth_boundary.py tests/test_api_scim_lifecycle.py tests/test_api_operator_policy.py`
- `uv run ruff check src/agent_bom/api/auth.py src/agent_bom/api/middleware.py src/agent_bom/api/scim.py src/agent_bom/api/routes/scim.py tests/test_api_auth_boundary.py tests/test_api_operator_policy.py tests/test_api_scim_lifecycle.py tests/conftest.py`
- `uv run mypy src/agent_bom/api/auth.py src/agent_bom/api/middleware.py src/agent_bom/api/scim.py src/agent_bom/api/routes/scim.py`

Note: the full pre-commit mypy hook still reports existing unrelated errors in `src/agent_bom/cloud/snowflake.py` for nullable `account` arguments.

Closes #2056