### PR TITLE
Derive compliance coverage table from metadata

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -200,8 +200,9 @@ graph LR
 
 ### Coverage per framework
 
-agent-bom ships a curated control set per framework, sized to the AI/MCP/agent threat surface rather than a generic compliance scanner's full catalog. Numbers below count the controls that are **bundled and actively mapped** by `compliance_utils.py` and the UI catalogs in `ui/lib/api.ts`; AISVS is counted as a benchmark surface. They are intentionally a subset; consult each framework's source standard for full coverage.
+agent-bom ships a curated control set per framework, sized to the AI/MCP/agent threat surface rather than a generic compliance scanner's full catalog. Numbers below count the controls that are **bundled and actively mapped** by the canonical metadata in `src/agent_bom/compliance_coverage.py`; AISVS is counted from the benchmark check registry. They are intentionally a subset; consult each framework's source standard for full coverage.
 
+<!-- compliance-coverage:start -->
 | Family | Framework | Bundled controls | Source-standard size (approx.) | What's covered |
 |---|---|---|---|---|
 | OWASP | LLM Top 10 (2025) | 10 / 10 | 10 | Full Top-10 |
@@ -210,16 +211,18 @@ agent-bom ships a curated control set per framework, sized to the AI/MCP/agent t
 | OWASP | AISVS v1.0 | 9 checks | ~50 verification reqs | Programmatically verifiable subset (AI-4/5/6/7/8 categories) |
 | NIST / FedRAMP | AI RMF 1.0 | 14 subcategories | ~70 | Govern / Map / Measure / Manage controls relevant to AI supply chain + MCP |
 | NIST / FedRAMP | CSF 2.0 | 14 categories | ~108 | Supply-chain, identity, asset, monitoring categories |
-| NIST / FedRAMP | 800-53 Rev 5 | Derived per finding | ~1,006 | Vulnerability-driven mapping (RA-5, SI-2, etc.); not a fixed bundle |
-| NIST / FedRAMP | FedRAMP Moderate | Derived from 800-53 | ~325 | Subset of 800-53 controls in the Moderate baseline |
-| MITRE | ATLAS | 13 techniques | ~90 | LLM/AI techniques: prompt injection, jailbreak, supply-chain, exfiltration, agent tool abuse |
+| NIST / FedRAMP | 800-53 Rev 5 | 29 controls | ~1,006 | Vulnerability-driven mapping (RA-5, SI-2, etc.); not a complete catalog |
+| NIST / FedRAMP | FedRAMP Moderate | 25 controls | ~325 | Subset of 800-53 controls in the Moderate baseline |
+| MITRE | ATLAS | 65 techniques | ~90 | LLM/AI techniques: prompt injection, jailbreak, supply-chain, exfiltration, agent tool abuse |
 | Regulatory | EU AI Act | 6 articles | ~113 | Articles 5/6/9/10/15/17 (prohibited practices, high-risk classification, risk mgmt, data governance, accuracy/cybersecurity, QMS) |
 | Regulatory | ISO/IEC 27001:2022 | 9 Annex A controls | 93 | Supplier, vulnerability, cryptography, secure-dev, evidence collection |
 | Regulatory | SOC 2 TSC | 9 criteria | ~64 | Common Criteria 6.x / 7.x / 8.x / 9.x (access, monitoring, change mgmt, vendor risk) |
 | Regulatory | CIS Controls v8 | 10 safeguards | 153 | Software inventory, vulnerability mgmt, secure-dev (CIS 02 / 07 / 16) |
 | Regulatory | CMMC 2.0 Level 2 | 17 practices | 110 | RA / SI / SC / CM / AC / IA practices most relevant to vulnerable-package risk |
+| Regulatory | PCI DSS v4.0 | 12 requirements | 12 | Requirements 2/3/4/5/6/7/8/10/11/12 for vulnerable-package and evidence risk |
+<!-- compliance-coverage:end -->
 
-The bundled list is editable: see `src/agent_bom/compliance_utils.py` for the `BlastRadius` field map and `ui/lib/api.ts` for the per-control human-readable catalogs (constants `OWASP_LLM_TOP10`, `MITRE_ATLAS`, `NIST_AI_RMF`, etc.). 800-53 / FedRAMP tags are emitted per-finding from `vuln_compliance.py` rather than a static catalog because they're CVE-derived.
+The bundled list is editable: see `src/agent_bom/compliance_coverage.py` for the framework metadata and `src/agent_bom/compliance_utils.py` for the `BlastRadius` field map. The UI consumes the same API response shape, so product coverage and dashboard controls should stay aligned with these catalogs.
 
 ---
 

--- a/scripts/generate_compliance_coverage_table.py
+++ b/scripts/generate_compliance_coverage_table.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Generate or verify the architecture compliance coverage table."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "ARCHITECTURE.md"
+START = "<!-- compliance-coverage:start -->"
+END = "<!-- compliance-coverage:end -->"
+
+sys.path.insert(0, str(ROOT / "src"))
+
+from agent_bom.compliance_coverage import render_compliance_coverage_table  # noqa: E402
+
+
+def _expected_doc(current: str) -> str:
+    start_idx = current.index(START)
+    end_idx = current.index(END, start_idx)
+    generated = START + "\n" + render_compliance_coverage_table() + "\n" + END
+    return current[:start_idx] + generated + current[end_idx + len(END) :]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="Fail if docs/ARCHITECTURE.md coverage table has drifted")
+    args = parser.parse_args()
+
+    current = DOC.read_text(encoding="utf-8")
+    try:
+        expected = _expected_doc(current)
+    except ValueError as exc:
+        raise SystemExit(f"{DOC.relative_to(ROOT)} is missing compliance coverage markers") from exc
+
+    if args.check:
+        if current != expected:
+            print(
+                "docs/ARCHITECTURE.md compliance coverage table is stale; run `python scripts/generate_compliance_coverage_table.py`.",
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+
+    DOC.write_text(expected, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -254,9 +254,7 @@ async def get_compliance(request: Request) -> dict:
 
     Returns per-control pass/warning/fail status and an overall compliance score.
     """
-    from agent_bom.atlas import ATLAS_TECHNIQUES
-    from agent_bom.nist_ai_rmf import NIST_AI_RMF
-    from agent_bom.owasp import OWASP_LLM_TOP10
+    from agent_bom.compliance_coverage import TAG_MAPPED_FRAMEWORKS
 
     tenant_jobs = _tenant_jobs(request)
 
@@ -332,32 +330,9 @@ async def get_compliance(request: Request) -> dict:
             )
         return controls
 
-    from agent_bom.cis_controls import CIS_CONTROLS
-    from agent_bom.cmmc import CMMC_PRACTICES
-    from agent_bom.eu_ai_act import EU_AI_ACT
-    from agent_bom.fedramp import FEDRAMP_MODERATE
-    from agent_bom.iso_27001 import ISO_27001
-    from agent_bom.nist_800_53 import NIST_800_53
-    from agent_bom.nist_csf import NIST_CSF
-    from agent_bom.owasp_agentic import OWASP_AGENTIC_TOP10
-    from agent_bom.owasp_mcp import OWASP_MCP_TOP10
-    from agent_bom.pci_dss import PCI_DSS_REQUIREMENTS
-    from agent_bom.soc2 import SOC2_TSC
-
-    owasp = _build_controls(OWASP_LLM_TOP10, "owasp_tags", "code")
-    owasp_mcp = _build_controls(OWASP_MCP_TOP10, "owasp_mcp_tags", "code")
-    atlas = _build_controls(ATLAS_TECHNIQUES, "atlas_tags", "code")
-    nist = _build_controls(NIST_AI_RMF, "nist_ai_rmf_tags", "code")
-    owasp_agentic = _build_controls(OWASP_AGENTIC_TOP10, "owasp_agentic_tags", "code")
-    eu_ai_act = _build_controls(EU_AI_ACT, "eu_ai_act_tags", "code")
-    nist_csf = _build_controls(NIST_CSF, "nist_csf_tags", "code")
-    iso27001 = _build_controls(ISO_27001, "iso_27001_tags", "code")
-    soc2 = _build_controls(SOC2_TSC, "soc2_tags", "code")
-    cis = _build_controls(CIS_CONTROLS, "cis_tags", "code")
-    cmmc = _build_controls(CMMC_PRACTICES, "cmmc_tags", "code")
-    nist_800_53 = _build_controls(NIST_800_53, "nist_800_53_tags", "code")
-    fedramp = _build_controls({c: c for c in FEDRAMP_MODERATE}, "fedramp_tags", "code")
-    pci_dss = _build_controls(PCI_DSS_REQUIREMENTS, "pci_dss_tags", "code")
+    framework_controls = {
+        metadata.output_key: _build_controls(dict(metadata.catalog), metadata.tag_field, "code") for metadata in TAG_MAPPED_FRAMEWORKS
+    }
 
     def _count_statuses(controls: list[dict]) -> tuple[int, int, int]:
         p = sum(1 for c in controls if c["status"] == "pass")
@@ -365,22 +340,7 @@ async def get_compliance(request: Request) -> dict:
         f = sum(1 for c in controls if c["status"] == "fail")
         return p, w, f
 
-    all_frameworks = [
-        owasp,
-        owasp_mcp,
-        atlas,
-        nist,
-        owasp_agentic,
-        eu_ai_act,
-        nist_csf,
-        iso27001,
-        soc2,
-        cis,
-        cmmc,
-        nist_800_53,
-        fedramp,
-        pci_dss,
-    ]
+    all_frameworks = list(framework_controls.values())
     total_controls = sum(len(fw) for fw in all_frameworks)
     total_pass = sum(_count_statuses(fw)[0] for fw in all_frameworks)
     any_fail = any(_count_statuses(fw)[2] > 0 for fw in all_frameworks)
@@ -394,24 +354,24 @@ async def get_compliance(request: Request) -> dict:
     else:
         overall_status = "pass"
 
-    op, ow, of_ = _count_statuses(owasp)
-    mp, mw, mf = _count_statuses(owasp_mcp)
-    ap, aw, af = _count_statuses(atlas)
-    np_, nw, nf = _count_statuses(nist)
-    oap, oaw, oaf = _count_statuses(owasp_agentic)
-    eup, euw, euf = _count_statuses(eu_ai_act)
-    ncp, ncw, ncf = _count_statuses(nist_csf)
-    ip, iw, if2 = _count_statuses(iso27001)
-    sp, sw, sf = _count_statuses(soc2)
-    cp, cw, cf = _count_statuses(cis)
-    cmp, cmw, cmf = _count_statuses(cmmc)
-    n8p, n8w, n8f = _count_statuses(nist_800_53)
-    frp, frw, frf = _count_statuses(fedramp)
-    pp, pw, pf = _count_statuses(pci_dss)
     aisvs = _latest_aisvs_benchmark_from_jobs(tenant_jobs)
     aisvs_summary = aisvs["summary"]
+    summary: dict[str, int | float] = {}
+    for metadata in TAG_MAPPED_FRAMEWORKS:
+        passed, warned, failed = _count_statuses(framework_controls[metadata.output_key])
+        summary[f"{metadata.summary_prefix}_pass"] = passed
+        summary[f"{metadata.summary_prefix}_warn"] = warned
+        summary[f"{metadata.summary_prefix}_fail"] = failed
+    summary.update(
+        {
+            "aisvs_pass": aisvs_summary["pass"],
+            "aisvs_fail": aisvs_summary["fail"],
+            "aisvs_error": aisvs_summary["error"],
+            "aisvs_not_applicable": aisvs_summary["not_applicable"],
+        }
+    )
 
-    return {
+    response: dict[str, Any] = {
         "overall_score": overall_score,
         "overall_status": overall_status,
         "scan_count": scan_count,
@@ -419,70 +379,12 @@ async def get_compliance(request: Request) -> dict:
         "has_mcp_context": has_mcp_context,
         "has_agent_context": has_agent_context,
         "scan_sources": sorted(all_scan_sources),
-        "owasp_llm_top10": owasp,
-        "owasp_mcp_top10": owasp_mcp,
-        "mitre_atlas": atlas,
-        "nist_ai_rmf": nist,
-        "owasp_agentic_top10": owasp_agentic,
-        "eu_ai_act": eu_ai_act,
-        "nist_csf": nist_csf,
-        "iso_27001": iso27001,
-        "soc2": soc2,
-        "cis_controls": cis,
-        "cmmc": cmmc,
-        "nist_800_53": nist_800_53,
-        "fedramp": fedramp,
-        "pci_dss": pci_dss,
         "aisvs_benchmark": aisvs,
-        "summary": {
-            "owasp_pass": op,
-            "owasp_warn": ow,
-            "owasp_fail": of_,
-            "owasp_mcp_pass": mp,
-            "owasp_mcp_warn": mw,
-            "owasp_mcp_fail": mf,
-            "atlas_pass": ap,
-            "atlas_warn": aw,
-            "atlas_fail": af,
-            "nist_pass": np_,
-            "nist_warn": nw,
-            "nist_fail": nf,
-            "owasp_agentic_pass": oap,
-            "owasp_agentic_warn": oaw,
-            "owasp_agentic_fail": oaf,
-            "eu_ai_act_pass": eup,
-            "eu_ai_act_warn": euw,
-            "eu_ai_act_fail": euf,
-            "nist_csf_pass": ncp,
-            "nist_csf_warn": ncw,
-            "nist_csf_fail": ncf,
-            "iso_27001_pass": ip,
-            "iso_27001_warn": iw,
-            "iso_27001_fail": if2,
-            "soc2_pass": sp,
-            "soc2_warn": sw,
-            "soc2_fail": sf,
-            "cis_pass": cp,
-            "cis_warn": cw,
-            "cis_fail": cf,
-            "cmmc_pass": cmp,
-            "cmmc_warn": cmw,
-            "cmmc_fail": cmf,
-            "nist_800_53_pass": n8p,
-            "nist_800_53_warn": n8w,
-            "nist_800_53_fail": n8f,
-            "fedramp_pass": frp,
-            "fedramp_warn": frw,
-            "fedramp_fail": frf,
-            "pci_dss_pass": pp,
-            "pci_dss_warn": pw,
-            "pci_dss_fail": pf,
-            "aisvs_pass": aisvs_summary["pass"],
-            "aisvs_fail": aisvs_summary["fail"],
-            "aisvs_error": aisvs_summary["error"],
-            "aisvs_not_applicable": aisvs_summary["not_applicable"],
-        },
+        "summary": summary,
     }
+    for metadata in TAG_MAPPED_FRAMEWORKS:
+        response[metadata.output_key] = framework_controls[metadata.output_key]
+    return response
 
 
 @router.get("/v1/cis/checks", tags=["compliance"])
@@ -986,22 +888,9 @@ async def get_compliance_by_framework(request: Request, framework: str) -> dict:
 
     full = await get_compliance(request)
 
-    framework_map = {
-        "owasp-llm": "owasp_llm_top10",
-        "owasp-mcp": "owasp_mcp_top10",
-        "atlas": "mitre_atlas",
-        "nist": "nist_ai_rmf",
-        "owasp-agentic": "owasp_agentic_top10",
-        "eu-ai-act": "eu_ai_act",
-        "nist-csf": "nist_csf",
-        "iso-27001": "iso_27001",
-        "soc2": "soc2",
-        "cis": "cis_controls",
-        "cmmc": "cmmc",
-        "nist-800-53": "nist_800_53",
-        "fedramp": "fedramp",
-        "pci-dss": "pci_dss",
-    }
+    from agent_bom.compliance_coverage import framework_output_key_by_slug
+
+    framework_map = framework_output_key_by_slug()
 
     key = framework_map.get(framework.lower())
     if not key:
@@ -1168,22 +1057,9 @@ async def export_compliance_report(
         raise HTTPException(status_code=400, detail="since must be earlier than until")
 
     full = await get_compliance(request)
-    framework_map = {
-        "owasp-llm": ("owasp_llm_top10", "OWASP LLM Top 10"),
-        "owasp-mcp": ("owasp_mcp_top10", "OWASP MCP Top 10"),
-        "atlas": ("mitre_atlas", "MITRE ATLAS"),
-        "nist": ("nist_ai_rmf", "NIST AI RMF"),
-        "owasp-agentic": ("owasp_agentic_top10", "OWASP Agentic Top 10"),
-        "eu-ai-act": ("eu_ai_act", "EU AI Act"),
-        "nist-csf": ("nist_csf", "NIST CSF"),
-        "iso-27001": ("iso_27001", "ISO 27001"),
-        "soc2": ("soc2", "SOC 2"),
-        "cis": ("cis_controls", "CIS Controls"),
-        "cmmc": ("cmmc", "CMMC"),
-        "nist-800-53": ("nist_800_53", "NIST 800-53"),
-        "fedramp": ("fedramp", "FedRAMP"),
-        "pci-dss": ("pci_dss", "PCI DSS"),
-    }
+    from agent_bom.compliance_coverage import framework_report_labels_by_slug
+
+    framework_map = framework_report_labels_by_slug()
     key_label = framework_map.get(framework.lower())
     if not key_label:
         raise HTTPException(

--- a/src/agent_bom/cloud/aisvs_benchmark.py
+++ b/src/agent_bom/cloud/aisvs_benchmark.py
@@ -599,6 +599,8 @@ _AVAILABLE_CHECKS: dict[str, tuple[str, Any]] = {
     "AI-8.1": ("_check_ai_8_1", _check_ai_8_1),
 }
 
+AISVS_CHECK_IDS: tuple[str, ...] = tuple(_AVAILABLE_CHECKS)
+
 
 def run_benchmark(
     checks: list[str] | None = None,

--- a/src/agent_bom/compliance_coverage.py
+++ b/src/agent_bom/compliance_coverage.py
@@ -1,0 +1,325 @@
+"""Canonical compliance framework coverage metadata."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from agent_bom.atlas import ATLAS_TECHNIQUES
+from agent_bom.cis_controls import CIS_CONTROLS
+from agent_bom.cloud.aisvs_benchmark import AISVS_CHECK_IDS
+from agent_bom.cmmc import CMMC_PRACTICES
+from agent_bom.eu_ai_act import EU_AI_ACT
+from agent_bom.fedramp import FEDRAMP_MODERATE
+from agent_bom.iso_27001 import ISO_27001
+from agent_bom.nist_800_53 import NIST_800_53
+from agent_bom.nist_ai_rmf import NIST_AI_RMF
+from agent_bom.nist_csf import NIST_CSF
+from agent_bom.owasp import OWASP_LLM_TOP10
+from agent_bom.owasp_agentic import OWASP_AGENTIC_TOP10
+from agent_bom.owasp_mcp import OWASP_MCP_TOP10
+from agent_bom.pci_dss import PCI_DSS_REQUIREMENTS
+from agent_bom.soc2 import SOC2_TSC
+
+
+@dataclass(frozen=True)
+class ComplianceFrameworkMetadata:
+    """Metadata shared by compliance APIs and docs coverage disclosures."""
+
+    family: str
+    framework: str
+    slug: str
+    output_key: str
+    summary_prefix: str
+    tag_field: str
+    catalog: Mapping[str, str]
+    report_label: str
+    bundled_unit: str
+    source_standard_size: str
+    coverage: str
+    full_catalog_size: int | None = None
+
+    @property
+    def control_count(self) -> int:
+        return len(self.catalog)
+
+    @property
+    def bundled_controls_label(self) -> str:
+        if self.full_catalog_size is not None:
+            return f"{self.control_count} / {self.full_catalog_size}"
+        return f"{self.control_count} {self.bundled_unit}"
+
+
+@dataclass(frozen=True)
+class ComplianceBenchmarkMetadata:
+    """Metadata for benchmark-style compliance surfaces."""
+
+    family: str
+    framework: str
+    slug: str
+    check_ids: tuple[str, ...]
+    source_standard_size: str
+    coverage: str
+
+    @property
+    def check_count(self) -> int:
+        return len(self.check_ids)
+
+    @property
+    def bundled_controls_label(self) -> str:
+        return f"{self.check_count} checks"
+
+
+TAG_MAPPED_FRAMEWORKS: tuple[ComplianceFrameworkMetadata, ...] = (
+    ComplianceFrameworkMetadata(
+        family="OWASP",
+        framework="LLM Top 10 (2025)",
+        slug="owasp-llm",
+        output_key="owasp_llm_top10",
+        summary_prefix="owasp",
+        tag_field="owasp_tags",
+        catalog=OWASP_LLM_TOP10,
+        report_label="OWASP LLM Top 10",
+        bundled_unit="controls",
+        source_standard_size="10",
+        coverage="Full Top-10",
+        full_catalog_size=10,
+    ),
+    ComplianceFrameworkMetadata(
+        family="OWASP",
+        framework="MCP Top 10 (2025)",
+        slug="owasp-mcp",
+        output_key="owasp_mcp_top10",
+        summary_prefix="owasp_mcp",
+        tag_field="owasp_mcp_tags",
+        catalog=OWASP_MCP_TOP10,
+        report_label="OWASP MCP Top 10",
+        bundled_unit="controls",
+        source_standard_size="10",
+        coverage="Full Top-10",
+        full_catalog_size=10,
+    ),
+    ComplianceFrameworkMetadata(
+        family="OWASP",
+        framework="Agentic Top 10 (2026)",
+        slug="owasp-agentic",
+        output_key="owasp_agentic_top10",
+        summary_prefix="owasp_agentic",
+        tag_field="owasp_agentic_tags",
+        catalog=OWASP_AGENTIC_TOP10,
+        report_label="OWASP Agentic Top 10",
+        bundled_unit="controls",
+        source_standard_size="10",
+        coverage="Full Top-10",
+        full_catalog_size=10,
+    ),
+    ComplianceFrameworkMetadata(
+        family="NIST / FedRAMP",
+        framework="AI RMF 1.0",
+        slug="nist",
+        output_key="nist_ai_rmf",
+        summary_prefix="nist",
+        tag_field="nist_ai_rmf_tags",
+        catalog=NIST_AI_RMF,
+        report_label="NIST AI RMF",
+        bundled_unit="subcategories",
+        source_standard_size="~70",
+        coverage="Govern / Map / Measure / Manage controls relevant to AI supply chain + MCP",
+    ),
+    ComplianceFrameworkMetadata(
+        family="NIST / FedRAMP",
+        framework="CSF 2.0",
+        slug="nist-csf",
+        output_key="nist_csf",
+        summary_prefix="nist_csf",
+        tag_field="nist_csf_tags",
+        catalog=NIST_CSF,
+        report_label="NIST CSF",
+        bundled_unit="categories",
+        source_standard_size="~108",
+        coverage="Supply-chain, identity, asset, monitoring categories",
+    ),
+    ComplianceFrameworkMetadata(
+        family="NIST / FedRAMP",
+        framework="800-53 Rev 5",
+        slug="nist-800-53",
+        output_key="nist_800_53",
+        summary_prefix="nist_800_53",
+        tag_field="nist_800_53_tags",
+        catalog=NIST_800_53,
+        report_label="NIST 800-53",
+        bundled_unit="controls",
+        source_standard_size="~1,006",
+        coverage="Vulnerability-driven mapping (RA-5, SI-2, etc.); not a complete catalog",
+    ),
+    ComplianceFrameworkMetadata(
+        family="NIST / FedRAMP",
+        framework="FedRAMP Moderate",
+        slug="fedramp",
+        output_key="fedramp",
+        summary_prefix="fedramp",
+        tag_field="fedramp_tags",
+        catalog={control: control for control in sorted(FEDRAMP_MODERATE)},
+        report_label="FedRAMP",
+        bundled_unit="controls",
+        source_standard_size="~325",
+        coverage="Subset of 800-53 controls in the Moderate baseline",
+    ),
+    ComplianceFrameworkMetadata(
+        family="MITRE",
+        framework="ATLAS",
+        slug="atlas",
+        output_key="mitre_atlas",
+        summary_prefix="atlas",
+        tag_field="atlas_tags",
+        catalog=ATLAS_TECHNIQUES,
+        report_label="MITRE ATLAS",
+        bundled_unit="techniques",
+        source_standard_size="~90",
+        coverage="LLM/AI techniques: prompt injection, jailbreak, supply-chain, exfiltration, agent tool abuse",
+    ),
+    ComplianceFrameworkMetadata(
+        family="Regulatory",
+        framework="EU AI Act",
+        slug="eu-ai-act",
+        output_key="eu_ai_act",
+        summary_prefix="eu_ai_act",
+        tag_field="eu_ai_act_tags",
+        catalog=EU_AI_ACT,
+        report_label="EU AI Act",
+        bundled_unit="articles",
+        source_standard_size="~113",
+        coverage=(
+            "Articles 5/6/9/10/15/17 (prohibited practices, high-risk classification, risk mgmt, "
+            "data governance, accuracy/cybersecurity, QMS)"
+        ),
+    ),
+    ComplianceFrameworkMetadata(
+        family="Regulatory",
+        framework="ISO/IEC 27001:2022",
+        slug="iso-27001",
+        output_key="iso_27001",
+        summary_prefix="iso_27001",
+        tag_field="iso_27001_tags",
+        catalog=ISO_27001,
+        report_label="ISO 27001",
+        bundled_unit="Annex A controls",
+        source_standard_size="93",
+        coverage="Supplier, vulnerability, cryptography, secure-dev, evidence collection",
+    ),
+    ComplianceFrameworkMetadata(
+        family="Regulatory",
+        framework="SOC 2 TSC",
+        slug="soc2",
+        output_key="soc2",
+        summary_prefix="soc2",
+        tag_field="soc2_tags",
+        catalog=SOC2_TSC,
+        report_label="SOC 2",
+        bundled_unit="criteria",
+        source_standard_size="~64",
+        coverage="Common Criteria 6.x / 7.x / 8.x / 9.x (access, monitoring, change mgmt, vendor risk)",
+    ),
+    ComplianceFrameworkMetadata(
+        family="Regulatory",
+        framework="CIS Controls v8",
+        slug="cis",
+        output_key="cis_controls",
+        summary_prefix="cis",
+        tag_field="cis_tags",
+        catalog=CIS_CONTROLS,
+        report_label="CIS Controls",
+        bundled_unit="safeguards",
+        source_standard_size="153",
+        coverage="Software inventory, vulnerability mgmt, secure-dev (CIS 02 / 07 / 16)",
+    ),
+    ComplianceFrameworkMetadata(
+        family="Regulatory",
+        framework="CMMC 2.0 Level 2",
+        slug="cmmc",
+        output_key="cmmc",
+        summary_prefix="cmmc",
+        tag_field="cmmc_tags",
+        catalog=CMMC_PRACTICES,
+        report_label="CMMC",
+        bundled_unit="practices",
+        source_standard_size="110",
+        coverage="RA / SI / SC / CM / AC / IA practices most relevant to vulnerable-package risk",
+    ),
+    ComplianceFrameworkMetadata(
+        family="Regulatory",
+        framework="PCI DSS v4.0",
+        slug="pci-dss",
+        output_key="pci_dss",
+        summary_prefix="pci_dss",
+        tag_field="pci_dss_tags",
+        catalog=PCI_DSS_REQUIREMENTS,
+        report_label="PCI DSS",
+        bundled_unit="requirements",
+        source_standard_size="12",
+        coverage="Requirements 2/3/4/5/6/7/8/10/11/12 for vulnerable-package and evidence risk",
+    ),
+)
+
+AISVS_BENCHMARK = ComplianceBenchmarkMetadata(
+    family="OWASP",
+    framework="AISVS v1.0",
+    slug="aisvs",
+    check_ids=AISVS_CHECK_IDS,
+    source_standard_size="~50 verification reqs",
+    coverage="Programmatically verifiable subset (AI-4/5/6/7/8 categories)",
+)
+
+
+def framework_output_key_by_slug() -> dict[str, str]:
+    """Return API output keys keyed by public framework slug."""
+
+    return {metadata.slug: metadata.output_key for metadata in TAG_MAPPED_FRAMEWORKS}
+
+
+def framework_report_labels_by_slug() -> dict[str, tuple[str, str]]:
+    """Return API output keys and report labels keyed by public framework slug."""
+
+    return {metadata.slug: (metadata.output_key, metadata.report_label) for metadata in TAG_MAPPED_FRAMEWORKS}
+
+
+def render_compliance_coverage_table() -> str:
+    """Render the committed architecture coverage table from metadata."""
+
+    lines = [
+        "| Family | Framework | Bundled controls | Source-standard size (approx.) | What's covered |",
+        "|---|---|---|---|---|",
+    ]
+    rows = [
+        *(
+            (
+                metadata.family,
+                metadata.framework,
+                metadata.bundled_controls_label,
+                metadata.source_standard_size,
+                metadata.coverage,
+            )
+            for metadata in TAG_MAPPED_FRAMEWORKS[:3]
+        ),
+        (
+            AISVS_BENCHMARK.family,
+            AISVS_BENCHMARK.framework,
+            AISVS_BENCHMARK.bundled_controls_label,
+            AISVS_BENCHMARK.source_standard_size,
+            AISVS_BENCHMARK.coverage,
+        ),
+        *(
+            (
+                metadata.family,
+                metadata.framework,
+                metadata.bundled_controls_label,
+                metadata.source_standard_size,
+                metadata.coverage,
+            )
+            for metadata in TAG_MAPPED_FRAMEWORKS[3:]
+        ),
+    ]
+    lines.extend(
+        f"| {family} | {framework} | {bundled} | {source_size} | {coverage} |" for family, framework, bundled, source_size, coverage in rows
+    )
+    return "\n".join(lines)

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -6,6 +6,7 @@ from starlette.testclient import TestClient
 
 from agent_bom.api.server import JobStatus, _get_store, app
 from agent_bom.api.store import InMemoryJobStore
+from agent_bom.compliance_coverage import TAG_MAPPED_FRAMEWORKS
 from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
 
 _AUTH_HEADERS = proxy_headers(tenant="default")
@@ -76,6 +77,11 @@ def test_compliance_no_scans():
     for c in data["owasp_llm_top10"]:
         assert c["status"] == "pass"
         assert c["findings"] == 0
+    for metadata in TAG_MAPPED_FRAMEWORKS:
+        assert len(data[metadata.output_key]) == metadata.control_count
+        assert data["summary"][f"{metadata.summary_prefix}_pass"] == metadata.control_count
+        assert data["summary"][f"{metadata.summary_prefix}_warn"] == 0
+        assert data["summary"][f"{metadata.summary_prefix}_fail"] == 0
     _clear_jobs()
 
 

--- a/tests/test_compliance_coverage.py
+++ b/tests/test_compliance_coverage.py
@@ -1,0 +1,59 @@
+"""Drift checks for compliance coverage disclosures."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from agent_bom.cloud.aisvs_benchmark import AISVS_CHECK_IDS
+from agent_bom.compliance_coverage import (
+    AISVS_BENCHMARK,
+    TAG_MAPPED_FRAMEWORKS,
+    framework_output_key_by_slug,
+    framework_report_labels_by_slug,
+    render_compliance_coverage_table,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+ARCHITECTURE = ROOT / "docs" / "ARCHITECTURE.md"
+START = "<!-- compliance-coverage:start -->"
+END = "<!-- compliance-coverage:end -->"
+
+
+def _coverage_table_from_architecture() -> str:
+    text = ARCHITECTURE.read_text(encoding="utf-8")
+    start = text.index(START) + len(START)
+    end = text.index(END, start)
+    return text[start:end].strip()
+
+
+def test_architecture_coverage_table_is_generated_from_metadata() -> None:
+    assert _coverage_table_from_architecture() == render_compliance_coverage_table()
+
+
+def test_coverage_generator_check_passes() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/generate_compliance_coverage_table.py", "--check"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_api_framework_maps_are_derived_from_metadata() -> None:
+    output_map = framework_output_key_by_slug()
+    report_map = framework_report_labels_by_slug()
+
+    assert output_map == {metadata.slug: metadata.output_key for metadata in TAG_MAPPED_FRAMEWORKS}
+    assert report_map == {metadata.slug: (metadata.output_key, metadata.report_label) for metadata in TAG_MAPPED_FRAMEWORKS}
+    assert output_map["pci-dss"] == "pci_dss"
+
+
+def test_aisvs_coverage_uses_benchmark_registry() -> None:
+    assert AISVS_BENCHMARK.check_ids == AISVS_CHECK_IDS
+    assert AISVS_BENCHMARK.check_count == len(AISVS_CHECK_IDS)
+    assert f"{AISVS_BENCHMARK.check_count} checks" in render_compliance_coverage_table()


### PR DESCRIPTION
Closes #2055.

## Summary
- Adds canonical compliance coverage metadata and uses it to render the architecture coverage table.
- Derives compliance API framework maps and report labels from that metadata.
- Exposes AISVS check IDs from the benchmark registry and adds drift tests for docs/API alignment.

## Validation
- uv run pytest tests/test_compliance.py tests/test_compliance_coverage.py tests/test_compliance_report.py tests/test_aisvs_benchmark.py
- uv run ruff check src/agent_bom/compliance_coverage.py src/agent_bom/api/routes/compliance.py src/agent_bom/cloud/aisvs_benchmark.py scripts/generate_compliance_coverage_table.py tests/test_compliance.py tests/test_compliance_coverage.py
- uv run mypy src/agent_bom/compliance_coverage.py src/agent_bom/api/routes/compliance.py src/agent_bom/cloud/aisvs_benchmark.py
- python scripts/generate_compliance_coverage_table.py --check
- git diff --check

Note: the local commit hook full-repo mypy check still reports existing Snowflake typing errors in src/agent_bom/cloud/snowflake.py outside this PR.