### PR TITLE
Add curated MCP blocklist scan findings

### DIFF
--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -67,6 +67,14 @@ CVE-2025-XXXX (CRITICAL)
 
 **What agent-bom does:** scans every package in every discovered server against OSV, NVD, EPSS, CISA KEV, and GHSA. Maps CVE → package → server → agent → credentials → tools (blast radius).
 
+agent-bom also ships a bundled curated MCP blocklist at `src/agent_bom/data/mcp-blocklist.json`.
+During agent scans, discovered MCP server names, registry IDs, package names, and launch commands
+are checked offline against that file:
+
+- Exact blocklist matches produce a `critical` `MCP_BLOCKLIST` finding and mark the server as security-blocked in the report.
+- Pattern matches produce a `high` `MCP_BLOCKLIST` finding by default and add a server security warning.
+- The blocklist is local package data in this phase. Scans do not query a real-time threat-feed API.
+
 ### 3.2 Tool poisoning — description injection
 
 MCP tool descriptions are plain text shown to the agent. A malicious server (or a compromised legitimate server) can inject instructions into those descriptions:
@@ -218,6 +226,10 @@ blast_radius        — blast radius for a specific CVE
 - **Does not modify MCP configs** unless you explicitly run `agent-bom proxy-configure --apply`.
 - **Does not send telemetry.** Only package name + version leaves your machine for CVE lookups (OSV, NVD, EPSS). See [PERMISSIONS.md](PERMISSIONS.md).
 - **Does not replace IAM or network controls.** It is a detection and enforcement layer, not a perimeter.
+- **Does not prove malicious intent from blocklist patterns.** Pattern matches are suspicious-name heuristics and can produce false positives.
+- **Does not catch every malicious server.** Regex and exact-name matching can miss obfuscated payloads, renamed packages, and previously unknown campaigns.
+- **Does not sandbox MCP servers.** Blocklist findings are scan-time detection signals; runtime process isolation must be provided by your OS/container platform or by explicit sandbox configuration.
+- **Does not remove trust-on-first-use risk in proxy mode.** Pre-compromised servers should be scanned before being trusted by a client or wrapped by the proxy.
 
 ---
 

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -601,9 +601,13 @@ def _run_scan_sync(job: ScanJob) -> None:
 
         # ── Output phase ──
         pipeline.start_step("output", "Building report...")
+        from agent_bom.finding import blast_radius_to_finding
+        from agent_bom.mcp_blocklist import blocklist_findings_for_agents
         from agent_bom.models import AIBOMReport
 
-        report = AIBOMReport(agents=agents, blast_radii=blast_radii, scan_id=job.job_id)
+        report_findings = [blast_radius_to_finding(br) for br in blast_radii]
+        report_findings.extend(blocklist_findings_for_agents(agents))
+        report = AIBOMReport(agents=agents, blast_radii=blast_radii, findings=report_findings, scan_id=job.job_id)
         report_json = to_json(report)
         report_json["warnings"] = warnings_all
         with lock:

--- a/src/agent_bom/cli/_scan_runner.py
+++ b/src/agent_bom/cli/_scan_runner.py
@@ -61,6 +61,7 @@ def run_default_scan(cfg: ScanConfig, con: "Console") -> ScanResult:
     from agent_bom.cli.agents._discovery import run_local_discovery
     from agent_bom.discovery import discover_all
     from agent_bom.finding import blast_radius_to_finding
+    from agent_bom.mcp_blocklist import blocklist_findings_for_agents
     from agent_bom.models import AIBOMReport
     from agent_bom.parsers import extract_packages
     from agent_bom.scanners import IncompleteScanError, scan_agents_sync
@@ -197,6 +198,7 @@ def run_default_scan(cfg: ScanConfig, con: "Console") -> ScanResult:
 
     # ── Build report ─────────────────────────────────────────────────
     findings = [blast_radius_to_finding(br) for br in blast_radii]
+    findings.extend(blocklist_findings_for_agents(agents))
     report = AIBOMReport(
         agents=agents,
         blast_radii=blast_radii,

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -1317,8 +1317,10 @@ def scan(
         _scan_sources.append("agent_discovery")
 
     from agent_bom.finding import blast_radius_to_finding
+    from agent_bom.mcp_blocklist import blocklist_findings_for_agents
 
     _findings = [blast_radius_to_finding(br) for br in blast_radii]
+    _findings.extend(blocklist_findings_for_agents(agents))
 
     # Generate deterministic scan ID from content fingerprint (same inputs → same ID)
     import hashlib as _hashlib

--- a/src/agent_bom/data/mcp-blocklist.json
+++ b/src/agent_bom/data/mcp-blocklist.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "updated": "2026-04-28",
+  "description": "Curated MCP server blocklist and suspicious-name patterns. Exact entries require confirmation; pattern entries are heuristic and may produce false positives.",
+  "entries": [
+    {
+      "id": "suspicious-credential-exfiltration-name",
+      "title": "Suspicious credential exfiltration server name",
+      "description": "Server name, registry id, package name, or command contains terms commonly used by credential theft or exfiltration tooling.",
+      "match_type": "pattern",
+      "patterns": [
+        "(^|[-_./@])credential[-_]?stealer($|[-_./])",
+        "(^|[-_./@])secret[-_]?exfil(trate|tration)?($|[-_./])",
+        "(^|[-_./@])token[-_]?grabber($|[-_./])"
+      ],
+      "severity": "high",
+      "source": "agent-bom-curated",
+      "references": []
+    }
+  ]
+}

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -46,6 +46,7 @@ class FindingType(str, Enum):
     BROWSER_EXT = "BROWSER_EXT"  # Suspicious browser extension
     LICENSE = "LICENSE"  # License compliance violation
     RATE_LIMIT = "RATE_LIMIT"  # Rate limit abuse by MCP tool
+    MCP_BLOCKLIST = "MCP_BLOCKLIST"  # Curated malicious/suspicious MCP server match
 
 
 class FindingSource(str, Enum):
@@ -185,6 +186,49 @@ class Finding:
     def effective_severity(self) -> str:
         """Return the best severity value: vendor > cvss > base severity."""
         return self.vendor_severity or self.cvss_severity or self.severity
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serializable finding payload."""
+        return {
+            "id": self.id,
+            "finding_type": self.finding_type.value,
+            "source": self.source.value,
+            "asset": {
+                "name": self.asset.name,
+                "asset_type": self.asset.asset_type,
+                "identifier": self.asset.identifier,
+                "location": self.asset.location,
+                "stable_id": self.asset.stable_id,
+            },
+            "severity": self.severity,
+            "effective_severity": self.effective_severity(),
+            "vendor_severity": self.vendor_severity,
+            "cvss_severity": self.cvss_severity,
+            "title": self.title,
+            "description": self.description,
+            "cve_id": self.cve_id,
+            "cwe_ids": self.cwe_ids,
+            "cvss_score": self.cvss_score,
+            "epss_score": self.epss_score,
+            "is_kev": self.is_kev,
+            "fixed_version": self.fixed_version,
+            "remediation_guidance": self.remediation_guidance,
+            "compliance_tags": self.all_compliance_tags(),
+            "owasp_tags": self.owasp_tags,
+            "atlas_tags": self.atlas_tags,
+            "attack_tags": self.attack_tags,
+            "nist_ai_rmf_tags": self.nist_ai_rmf_tags,
+            "owasp_mcp_tags": self.owasp_mcp_tags,
+            "owasp_agentic_tags": self.owasp_agentic_tags,
+            "eu_ai_act_tags": self.eu_ai_act_tags,
+            "nist_csf_tags": self.nist_csf_tags,
+            "iso_27001_tags": self.iso_27001_tags,
+            "soc2_tags": self.soc2_tags,
+            "cis_tags": self.cis_tags,
+            "related_findings": self.related_findings,
+            "evidence": self.evidence,
+            "risk_score": self.risk_score,
+        }
 
 
 def blast_radius_to_finding(br: object) -> "Finding":

--- a/src/agent_bom/mcp_blocklist.py
+++ b/src/agent_bom/mcp_blocklist.py
@@ -1,0 +1,204 @@
+"""Curated MCP server blocklist matching.
+
+Phase 1 intentionally stays offline and bundled. It checks discovered server
+identity strings against exact entries and suspicious patterns, then emits
+unified findings and server warnings for existing scan surfaces.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from importlib import resources
+from typing import Any
+
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType
+from agent_bom.models import Agent, MCPServer
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MCPBlocklistMatch:
+    """One blocklist hit against a discovered MCP server."""
+
+    entry_id: str
+    title: str
+    description: str
+    match_type: str
+    severity: str
+    matched_value: str
+    source: str
+    references: tuple[str, ...] = ()
+
+
+def load_mcp_blocklist() -> dict[str, Any]:
+    """Load the bundled MCP blocklist data.
+
+    Returns an empty blocklist if the package data is unavailable or malformed
+    so scans do not fail closed because of a catalog packaging issue.
+    """
+    try:
+        text = resources.files("agent_bom.data").joinpath("mcp-blocklist.json").read_text(encoding="utf-8")
+        data = json.loads(text)
+    except (json.JSONDecodeError, OSError, FileNotFoundError) as exc:
+        logger.warning("Failed to load MCP blocklist: %s", exc)
+        return {"entries": []}
+    return data if isinstance(data, dict) else {"entries": []}
+
+
+def _norm(value: object) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip().lower())
+
+
+def _server_match_values(server: MCPServer) -> list[str]:
+    values: list[str] = [
+        server.name,
+        server.registry_id or "",
+        server.command,
+        " ".join([server.command, *server.args]).strip(),
+        server.url or "",
+    ]
+    values.extend(pkg.name for pkg in server.packages)
+    values.extend(pkg.purl or "" for pkg in server.packages)
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        cleaned = str(value or "").strip()
+        key = _norm(cleaned)
+        if cleaned and key not in seen:
+            seen.add(key)
+            result.append(cleaned)
+    return result
+
+
+def match_mcp_server(server: MCPServer, blocklist: dict[str, Any] | None = None) -> list[MCPBlocklistMatch]:
+    """Return blocklist matches for one MCP server.
+
+    Exact matches are critical by policy. Pattern matches are high severity by
+    default unless an entry explicitly lowers the severity for future data.
+    """
+    data = blocklist if blocklist is not None else load_mcp_blocklist()
+    raw_entries = data.get("entries", []) if isinstance(data, dict) else []
+    entries = raw_entries if isinstance(raw_entries, list) else []
+    values = _server_match_values(server)
+    normalized_values = {_norm(value): value for value in values}
+
+    matches: list[MCPBlocklistMatch] = []
+    seen: set[tuple[str, str, str]] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_id = str(entry.get("id") or "mcp-blocklist-entry")
+        title = str(entry.get("title") or "MCP server blocklist match")
+        description = str(entry.get("description") or "")
+        source = str(entry.get("source") or "agent-bom-curated")
+        references = tuple(str(ref) for ref in entry.get("references", []) if isinstance(ref, str))
+
+        exact_values: list[object] = []
+        for field_name in ("names", "exact", "registry_ids", "packages"):
+            raw_values = entry.get(field_name, [])
+            if isinstance(raw_values, list):
+                exact_values.extend(raw_values)
+        if exact_values:
+            for raw_exact in exact_values:
+                expected = _norm(raw_exact)
+                if not expected or expected not in normalized_values:
+                    continue
+                key = (entry_id, "exact", expected)
+                if key in seen:
+                    continue
+                seen.add(key)
+                matches.append(
+                    MCPBlocklistMatch(
+                        entry_id=entry_id,
+                        title=title,
+                        description=description,
+                        match_type="exact",
+                        severity="critical",
+                        matched_value=normalized_values[expected],
+                        source=source,
+                        references=references,
+                    )
+                )
+
+        patterns = entry.get("patterns", [])
+        if not isinstance(patterns, list):
+            continue
+        for raw_pattern in patterns:
+            if not isinstance(raw_pattern, str) or not raw_pattern.strip():
+                continue
+            try:
+                pattern = re.compile(raw_pattern, re.IGNORECASE)
+            except re.error as exc:
+                logger.warning("Invalid MCP blocklist pattern %r in %s: %s", raw_pattern, entry_id, exc)
+                continue
+            for value in values:
+                if not pattern.search(value):
+                    continue
+                key = (entry_id, "pattern", raw_pattern)
+                if key in seen:
+                    continue
+                seen.add(key)
+                severity = str(entry.get("severity") or "high").lower()
+                matches.append(
+                    MCPBlocklistMatch(
+                        entry_id=entry_id,
+                        title=title,
+                        description=description,
+                        match_type="pattern",
+                        severity=severity if severity in {"critical", "high", "medium", "low"} else "high",
+                        matched_value=value,
+                        source=source,
+                        references=references,
+                    )
+                )
+                break
+
+    return matches
+
+
+def blocklist_findings_for_agents(agents: list[Agent], blocklist: dict[str, Any] | None = None) -> list[Finding]:
+    """Create unified findings for MCP blocklist hits and stamp server warnings."""
+    findings: list[Finding] = []
+    for agent in agents:
+        for server in agent.mcp_servers:
+            for match in match_mcp_server(server, blocklist):
+                warning = f"MCP_BLOCKLIST[{match.severity}/{match.match_type}]: {match.entry_id} matched {match.matched_value!r}"
+                if warning not in server.security_warnings:
+                    server.security_warnings.append(warning)
+                if match.severity == "critical":
+                    server.security_blocked = True
+
+                findings.append(
+                    Finding(
+                        finding_type=FindingType.MCP_BLOCKLIST,
+                        source=FindingSource.MCP_SCAN,
+                        asset=Asset(
+                            name=server.name,
+                            asset_type="mcp_server",
+                            identifier=server.registry_id,
+                            location=server.config_path or server.command or None,
+                        ),
+                        severity=match.severity,
+                        title=match.title,
+                        description=match.description,
+                        remediation_guidance="Remove or disable the matched MCP server until the blocklist entry is reviewed.",
+                        owasp_mcp_tags=["MCP04", "MCP07"],
+                        evidence={
+                            "agent_name": agent.name,
+                            "server_name": server.name,
+                            "server_stable_id": server.stable_id,
+                            "entry_id": match.entry_id,
+                            "match_type": match.match_type,
+                            "matched_value": match.matched_value,
+                            "blocklist_source": match.source,
+                            "references": list(match.references),
+                        },
+                        risk_score=10.0 if match.severity == "critical" else 8.0,
+                    )
+                )
+    return findings

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -758,6 +758,7 @@ def to_json(report: AIBOMReport) -> dict:
             }
             for br in report.blast_radii
         ],
+        "findings": [finding.to_dict() for finding in report.to_findings()],
         "threat_framework_summary": _build_framework_summary(report.blast_radii),
         "scorecard_summary": summarize_scorecard_coverage(all_packages).to_dict(),
         "remediation_plan": _build_remediation_json(report),

--- a/tests/test_mcp_blocklist.py
+++ b/tests/test_mcp_blocklist.py
@@ -1,0 +1,101 @@
+from agent_bom.mcp_blocklist import blocklist_findings_for_agents, match_mcp_server
+from agent_bom.models import Agent, AgentType, AIBOMReport, MCPServer, Package
+from agent_bom.output import to_json
+
+
+def _agent_with_server(server: MCPServer) -> Agent:
+    return Agent(
+        name="test-agent",
+        agent_type=AgentType.CLAUDE_DESKTOP,
+        config_path="/tmp/claude.json",
+        mcp_servers=[server],
+    )
+
+
+def test_exact_blocklist_match_is_critical_and_blocks_server() -> None:
+    blocklist = {
+        "entries": [
+            {
+                "id": "confirmed-bad-server",
+                "title": "Confirmed malicious MCP server",
+                "description": "Confirmed malicious behavior.",
+                "names": ["evil-mcp"],
+            }
+        ]
+    }
+    server = MCPServer(name="evil-mcp", command="npx", args=["evil-mcp"])
+    agent = _agent_with_server(server)
+
+    findings = blocklist_findings_for_agents([agent], blocklist)
+
+    assert len(findings) == 1
+    assert findings[0].severity == "critical"
+    assert findings[0].finding_type.value == "MCP_BLOCKLIST"
+    assert findings[0].evidence["match_type"] == "exact"
+    assert server.security_blocked is True
+    assert any("MCP_BLOCKLIST[critical/exact]" in warning for warning in server.security_warnings)
+
+
+def test_pattern_blocklist_match_is_high_warning() -> None:
+    blocklist = {
+        "entries": [
+            {
+                "id": "suspicious-token-grabber",
+                "title": "Suspicious token grabber name",
+                "patterns": ["token[-_]?grabber"],
+            }
+        ]
+    }
+    server = MCPServer(name="workspace-token-grabber", command="uvx", args=["workspace-token-grabber"])
+
+    matches = match_mcp_server(server, blocklist)
+
+    assert len(matches) == 1
+    assert matches[0].severity == "high"
+    assert matches[0].match_type == "pattern"
+
+
+def test_blocklist_checks_package_identity_values() -> None:
+    blocklist = {
+        "entries": [
+            {
+                "id": "bad-package",
+                "title": "Blocked package-backed MCP server",
+                "packages": ["@bad/mcp-server"],
+            }
+        ]
+    }
+    server = MCPServer(
+        name="renamed-server",
+        command="npx",
+        args=["@bad/mcp-server"],
+        packages=[Package(name="@bad/mcp-server", version="1.0.0", ecosystem="npm")],
+    )
+
+    matches = match_mcp_server(server, blocklist)
+
+    assert len(matches) == 1
+    assert matches[0].severity == "critical"
+    assert matches[0].matched_value == "@bad/mcp-server"
+
+
+def test_json_output_includes_mcp_blocklist_findings() -> None:
+    blocklist = {
+        "entries": [
+            {
+                "id": "confirmed-bad-server",
+                "title": "Confirmed malicious MCP server",
+                "names": ["evil-mcp"],
+            }
+        ]
+    }
+    server = MCPServer(name="evil-mcp", command="npx", args=["evil-mcp"])
+    agent = _agent_with_server(server)
+    findings = blocklist_findings_for_agents([agent], blocklist)
+
+    payload = to_json(AIBOMReport(agents=[agent], findings=findings))
+
+    assert payload["findings"][0]["finding_type"] == "MCP_BLOCKLIST"
+    assert payload["findings"][0]["severity"] == "critical"
+    assert payload["findings"][0]["evidence"]["entry_id"] == "confirmed-bad-server"
+    assert payload["agents"][0]["mcp_servers"][0]["security_blocked"] is True


### PR DESCRIPTION
## Summary
- add a bundled MCP blocklist data file and offline matcher for exact and pattern hits
- emit MCP_BLOCKLIST unified findings, server warnings, and security_blocked for critical exact matches
- serialize unified findings in JSON output and document Phase 1 limitations

Closes #565

## Validation
- pytest tests/test_mcp_blocklist.py tests/test_finding.py -q
- pytest tests/test_output_formats.py tests/test_output_cov.py tests/test_core.py -q
- python -m ruff check src/agent_bom/mcp_blocklist.py src/agent_bom/finding.py src/agent_bom/cli/_scan_runner.py src/agent_bom/cli/agents/__init__.py src/agent_bom/api/pipeline.py src/agent_bom/output/json_fmt.py tests/test_mcp_blocklist.py
- python -m mypy src/agent_bom/mcp_blocklist.py src/agent_bom/finding.py src/agent_bom/api/pipeline.py src/agent_bom/cli/_scan_runner.py src/agent_bom/output/json_fmt.py

Note: full pre-commit mypy is currently blocked by unrelated existing errors in src/agent_bom/cloud/snowflake.py and src/agent_bom/cloud/databricks_security.py.