### PR TITLE
refactor: split CLI scan mode setup

### DIFF
--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -8,7 +8,6 @@ this namespace.
 
 from __future__ import annotations
 
-import importlib.metadata
 import json
 import sys
 from contextlib import nullcontext as _nullcontext
@@ -28,9 +27,11 @@ from agent_bom.cli._common import (
 from agent_bom.cli.agents._cloud import run_benchmarks, run_cloud_discovery
 from agent_bom.cli.agents._context import ScanContext
 from agent_bom.cli.agents._discovery import run_local_discovery
+from agent_bom.cli.agents._modes import apply_demo_mode, apply_self_scan_mode, validate_skill_mode
 from agent_bom.cli.agents._output import _format_text, render_output
 from agent_bom.cli.agents._post import compute_exit_code, run_integrations
 from agent_bom.cli.agents._preflight import emit_dry_run_plan, run_iac_only_scan
+from agent_bom.cli.agents._self_scan import _build_self_scan_inventory
 from agent_bom.cli.options import scan_options
 from agent_bom.discovery import discover_all
 from agent_bom.models import AIBOMReport
@@ -70,52 +71,6 @@ from agent_bom.parsers import extract_packages
 from agent_bom.resolver import consume_performance_stats as consume_resolution_performance
 from agent_bom.resolver import resolve_all_versions_sync
 from agent_bom.scanners import IncompleteScanError, consume_scan_performance, consume_scan_warnings, scan_agents_sync
-
-
-def _build_self_scan_inventory() -> dict[str, list[dict[str, object]]]:
-    """Build a deterministic self-scan inventory for the installed package."""
-    import importlib.metadata as _meta
-
-    pkgs: list[dict[str, str]] = []
-    seen: set[tuple[str, str, str]] = set()
-
-    dist = _meta.distribution("agent-bom")
-    for req_str in dist.requires or []:
-        name = req_str.split(";")[0].split("[")[0].strip()
-        for op in (">=", "<=", "==", "!=", "~=", ">", "<"):
-            if op in name:
-                name = name[: name.index(op)].strip()
-                break
-        if not name:
-            continue
-        try:
-            version = _meta.version(name)
-        except _meta.PackageNotFoundError:
-            continue
-        key = (name.lower(), version, "pypi")
-        if key in seen:
-            continue
-        seen.add(key)
-        pkgs.append({"name": name, "version": version, "ecosystem": "pypi"})
-
-    return {
-        "agents": [
-            {
-                "name": "agent-bom",
-                "agent_type": "custom",
-                "source": "agent-bom --self-scan",
-                "config_path": "self-scan://agent-bom",
-                "mcp_servers": [
-                    {
-                        "name": "agent-bom-mcp-server",
-                        "command": "agent-bom mcp-server",
-                        "transport": "stdio",
-                        "packages": pkgs,
-                    }
-                ],
-            }
-        ]
-    }
 
 
 @click.command()
@@ -381,51 +336,17 @@ def scan(
     # Users should use --preset ci for CI-specific defaults.
     # The ci_detect module is available for programmatic use.
 
-    # ── Self-scan mode: scan agent-bom's own installed dependencies ──
-    if self_scan:
-        import json as _json
-        import os as _os
-        import tempfile as _tempfile
-
-        try:
-            _self_inventory = _build_self_scan_inventory()
-        except importlib.metadata.PackageNotFoundError:
-            click.echo("Error: agent-bom package not found. Install it first.", err=True)
-            sys.exit(2)
-        _sf_fd, _sf_path = _tempfile.mkstemp(suffix=".json", prefix="agent-bom-self-scan-")
-        with _os.fdopen(_sf_fd, "w") as _sf:
-            _json.dump(_self_inventory, _sf)
-        inventory = _sf_path
-        enrich = True
-
-    # ── Demo mode: load a curated sample agent + MCP environment ───────────
-    if demo:
-        import json as _json
-        import os as _os
-        import tempfile as _tempfile
-
-        from agent_bom.demo import DEMO_INVENTORY
-
-        _demo_fd, _demo_path = _tempfile.mkstemp(suffix=".json", prefix="agent-bom-demo-")
-        with _os.fdopen(_demo_fd, "w") as _df:
-            _json.dump(DEMO_INVENTORY, _df)
-        inventory = _demo_path
-        enrich = True
-        compliance = True  # Show compliance frameworks in demo
-        # Skip CWD auto-detection in demo mode — only scan the curated sample
-        if not project:
-            project = _tempfile.mkdtemp(prefix="agent-bom-demo-dir-")
-        # Override config_path in demo inventory to show clean paths (no /tmp leaks)
-        for agent_data in DEMO_INVENTORY.get("agents", []):
-            agent_data.setdefault("config_path", f"~/.config/{agent_data.get('agent_type', 'agent')}/config.json")
-        # Disable IaC auto-detection — point iac_paths to empty temp dir
-        # so the `if not iac_paths` auto-detection check doesn't trigger
-        iac_paths = (project,)  # temp dir has no Dockerfiles/K8s/Terraform
-
-    # Mutual exclusivity: --no-skill and --skill-only cannot be used together
-    if no_skill and skill_only:
-        click.echo("Error: --no-skill and --skill-only are mutually exclusive.", err=True)
-        sys.exit(2)
+    # ── Self-scan/demo modes materialize synthetic inventories before discovery ──
+    inventory, enrich = apply_self_scan_mode(self_scan=self_scan, inventory=inventory, enrich=enrich)
+    project, inventory, enrich, compliance, iac_paths = apply_demo_mode(
+        demo=demo,
+        project=project,
+        inventory=inventory,
+        enrich=enrich,
+        compliance=compliance,
+        iac_paths=iac_paths,
+    )
+    validate_skill_mode(no_skill=no_skill, skill_only=skill_only)
 
     # Route console output based on flags
     is_stdout = output == "-"

--- a/src/agent_bom/cli/agents/_modes.py
+++ b/src/agent_bom/cli/agents/_modes.py
@@ -1,0 +1,71 @@
+"""Mode-specific scan command setup."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import os
+import sys
+import tempfile
+from typing import Optional
+
+import click
+
+from agent_bom.cli.agents._self_scan import _build_self_scan_inventory
+
+
+def apply_self_scan_mode(*, self_scan: bool, inventory: Optional[str], enrich: bool) -> tuple[Optional[str], bool]:
+    """Materialize a self-scan inventory file when requested."""
+    if not self_scan:
+        return inventory, enrich
+
+    try:
+        self_inventory = _build_self_scan_inventory()
+    except importlib.metadata.PackageNotFoundError:
+        click.echo("Error: agent-bom package not found. Install it first.", err=True)
+        sys.exit(2)
+
+    fd, path = tempfile.mkstemp(suffix=".json", prefix="agent-bom-self-scan-")
+    with os.fdopen(fd, "w") as out:
+        json.dump(self_inventory, out)
+    return path, True
+
+
+def apply_demo_mode(
+    *,
+    demo: bool,
+    project: Optional[str],
+    inventory: Optional[str],
+    enrich: bool,
+    compliance: bool,
+    iac_paths: tuple,
+) -> tuple[Optional[str], Optional[str], bool, bool, tuple]:
+    """Materialize the curated demo inventory and skip ambient discovery."""
+    if not demo:
+        return project, inventory, enrich, compliance, iac_paths
+
+    from agent_bom.demo import DEMO_INVENTORY
+
+    fd, path = tempfile.mkstemp(suffix=".json", prefix="agent-bom-demo-")
+    with os.fdopen(fd, "w") as out:
+        json.dump(DEMO_INVENTORY, out)
+
+    inventory = path
+    enrich = True
+    compliance = True
+    if not project:
+        project = tempfile.mkdtemp(prefix="agent-bom-demo-dir-")
+    for agent_data in DEMO_INVENTORY.get("agents", []):
+        agent_data.setdefault("config_path", f"~/.config/{agent_data.get('agent_type', 'agent')}/config.json")
+
+    # Disable IaC auto-detection: point iac_paths at the empty demo project so
+    # the later "if not iac_paths" detection branch does not run.
+    iac_paths = (project,)
+    return project, inventory, enrich, compliance, iac_paths
+
+
+def validate_skill_mode(*, no_skill: bool, skill_only: bool) -> None:
+    """Reject mutually exclusive skill discovery flags."""
+    if no_skill and skill_only:
+        click.echo("Error: --no-skill and --skill-only are mutually exclusive.", err=True)
+        sys.exit(2)

--- a/src/agent_bom/cli/agents/_self_scan.py
+++ b/src/agent_bom/cli/agents/_self_scan.py
@@ -1,0 +1,49 @@
+"""Self-scan inventory construction for the scan command."""
+
+from __future__ import annotations
+
+import importlib.metadata as metadata
+
+
+def _build_self_scan_inventory() -> dict[str, list[dict[str, object]]]:
+    """Build a deterministic self-scan inventory for the installed package."""
+    pkgs: list[dict[str, str]] = []
+    seen: set[tuple[str, str, str]] = set()
+
+    dist = metadata.distribution("agent-bom")
+    for req_str in dist.requires or []:
+        name = req_str.split(";")[0].split("[")[0].strip()
+        for op in (">=", "<=", "==", "!=", "~=", ">", "<"):
+            if op in name:
+                name = name[: name.index(op)].strip()
+                break
+        if not name:
+            continue
+        try:
+            version = metadata.version(name)
+        except metadata.PackageNotFoundError:
+            continue
+        key = (name.lower(), version, "pypi")
+        if key in seen:
+            continue
+        seen.add(key)
+        pkgs.append({"name": name, "version": version, "ecosystem": "pypi"})
+
+    return {
+        "agents": [
+            {
+                "name": "agent-bom",
+                "agent_type": "custom",
+                "source": "agent-bom --self-scan",
+                "config_path": "self-scan://agent-bom",
+                "mcp_servers": [
+                    {
+                        "name": "agent-bom-mcp-server",
+                        "command": "agent-bom mcp-server",
+                        "transport": "stdio",
+                        "packages": pkgs,
+                    }
+                ],
+            }
+        ]
+    }

--- a/src/agent_bom/cloud/databricks_security.py
+++ b/src/agent_bom/cloud/databricks_security.py
@@ -581,7 +581,7 @@ def run_security_checks(
     except Exception as exc:
         raise CloudDiscoveryError(f"Could not connect to Databricks workspace: {exc}") from exc
 
-    resolved_host = host or os.environ.get("DATABRICKS_HOST", "unknown")
+    resolved_host = host if host is not None else (os.environ.get("DATABRICKS_HOST") or "unknown")
     report = DatabricksSecurityReport(workspace_host=resolved_host)
 
     for check_fn in _ALL_CHECKS:

--- a/src/agent_bom/cloud/snowflake.py
+++ b/src/agent_bom/cloud/snowflake.py
@@ -59,6 +59,13 @@ from .base import CloudDiscoveryError
 logger = logging.getLogger(__name__)
 
 
+def _env_or_value(value: str | None, env_var: str, default: str = "") -> str:
+    """Resolve an optional CLI value against an environment fallback."""
+    if value is not None:
+        return value
+    return os.environ.get(env_var) or default
+
+
 def _resolve_snowflake_auth(
     conn_kwargs: dict[str, Any],
     authenticator: str | None,
@@ -155,8 +162,8 @@ def _get_connection(
             "snowflake-connector-python is required for Snowflake access. Install with: pip install 'agent-bom[snowflake]'"
         ) from exc
 
-    resolved_account = account or os.environ.get("SNOWFLAKE_ACCOUNT", "")
-    resolved_user = user or os.environ.get("SNOWFLAKE_USER", "")
+    resolved_account = _env_or_value(account, "SNOWFLAKE_ACCOUNT")
+    resolved_user = _env_or_value(user, "SNOWFLAKE_USER")
     if not resolved_account:
         raise CloudDiscoveryError("SNOWFLAKE_ACCOUNT not set.")
 
@@ -201,8 +208,8 @@ def discover(
     agents: list[Agent] = []
     warnings: list[str] = []
 
-    resolved_account = account or os.environ.get("SNOWFLAKE_ACCOUNT", "")
-    resolved_user = user or os.environ.get("SNOWFLAKE_USER", "")
+    resolved_account = _env_or_value(account, "SNOWFLAKE_ACCOUNT")
+    resolved_user = _env_or_value(user, "SNOWFLAKE_USER")
 
     if not resolved_account:
         warnings.append("SNOWFLAKE_ACCOUNT not set. Provide --snowflake-account or set the SNOWFLAKE_ACCOUNT env var.")
@@ -946,8 +953,8 @@ def discover_governance(
     Raises:
         CloudDiscoveryError: if snowflake-connector-python is not installed.
     """
-    resolved_account = account or os.environ.get("SNOWFLAKE_ACCOUNT", "")
-    resolved_user = user or os.environ.get("SNOWFLAKE_USER", "")
+    resolved_account = _env_or_value(account, "SNOWFLAKE_ACCOUNT")
+    resolved_user = _env_or_value(user, "SNOWFLAKE_USER")
     report = GovernanceReport(account=resolved_account)
     days = _coerce_snowflake_days(days)
 
@@ -1622,8 +1629,8 @@ def discover_activity(
     Returns:
         ActivityTimeline with query history and observability events.
     """
-    resolved_account = account or os.environ.get("SNOWFLAKE_ACCOUNT", "")
-    resolved_user = user or os.environ.get("SNOWFLAKE_USER", "")
+    resolved_account = _env_or_value(account, "SNOWFLAKE_ACCOUNT")
+    resolved_user = _env_or_value(user, "SNOWFLAKE_USER")
     timeline = ActivityTimeline(account=resolved_account)
     days = _coerce_snowflake_days(days, max_days=365)
 


### PR DESCRIPTION
Summary
- move self-scan inventory construction into a focused CLI agents module while preserving the existing agent_bom.cli.agents import target
- move self-scan/demo/skill-mode setup out of the scan command body
- normalize optional Snowflake/Databricks environment fallback typing surfaced by the commit hook

Why
This continues the cli/agents package split without breaking existing tests that patch agent_bom.cli.agents symbols directly. It closes the focused CLI package portion of the module organization tracker.

Validation
- uv run ruff check src/agent_bom/cli/agents src/agent_bom/cloud/snowflake.py src/agent_bom/cloud/databricks_security.py tests/test_self_scan.py tests/test_cli_scan.py
- uv run mypy src/agent_bom/cli/agents src/agent_bom/cloud/snowflake.py src/agent_bom/cloud/databricks_security.py
- uv run pytest tests/test_self_scan.py tests/test_cli_scan.py tests/test_auto_update_db.py tests/test_project_mode.py tests/test_snowflake_governance.py tests/test_snowflake_activity.py tests/test_databricks_security.py -q
- git diff --check

Closes #1970
Refs #1969