### PR TITLE
security: expand MCP blocklist coverage and early gating

### DIFF
--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -73,7 +73,9 @@ are checked offline against that file:
 
 - Exact blocklist matches produce a `critical` `MCP_BLOCKLIST` finding and mark the server as security-blocked in the report.
 - Pattern matches produce a `high` `MCP_BLOCKLIST` finding by default and add a server security warning.
-- The blocklist is local package data in this phase. Scans do not query a real-time threat-feed API.
+- Critical matches found from the initial server identity are marked before dependency extraction, so CLI/API scans skip deeper package extraction for that server.
+- The blocklist is local package data in this phase. Scans do not query a real-time threat-feed API, and agent-bom does not ship a hidden remote kill switch.
+- Endpoint and gateway enforcement stays operator-controlled: teams can use these `security_blocked` signals in fleet policy, MDM rollout, gateway policy, or CI gates, while scan-only runs report the finding without deleting local files or stopping third-party processes.
 
 ### 3.2 Tool poisoning — description injection
 

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -518,6 +518,12 @@ def _run_scan_sync(job: ScanJob) -> None:
             job.completed_at = _now()
             return
 
+        from agent_bom.mcp_blocklist import flag_blocklisted_mcp_servers
+
+        blocked_servers = flag_blocklisted_mcp_servers(agents)
+        if blocked_servers:
+            pipeline.update_step("discovery", f"MCP blocklist flagged {blocked_servers} server(s)")
+
         # ── Extraction phase ──
         pipeline.start_step("extraction", f"Extracting packages from {len(agents)} agent(s)...")
         total_pkgs = 0

--- a/src/agent_bom/cli/_inventory.py
+++ b/src/agent_bom/cli/_inventory.py
@@ -15,6 +15,7 @@ from rich.console import Console
 from agent_bom.cli._common import _make_console
 from agent_bom.discovery import discover_all
 from agent_bom.inventory import _inventory_schema_path, _inventory_validator
+from agent_bom.mcp_blocklist import flag_blocklisted_mcp_servers
 from agent_bom.models import AIBOMReport
 from agent_bom.output import print_agent_tree, print_summary
 from agent_bom.parsers import extract_packages
@@ -75,6 +76,8 @@ def inventory(config: Optional[str], project: Optional[str], transitive: bool, m
         con.print("\n[bold blue]Extracting package dependencies...[/bold blue]\n")
         if transitive:
             con.print(f"  [cyan]Transitive resolution enabled (max depth: {max_depth})[/cyan]\n")
+
+    flag_blocklisted_mcp_servers(agents)
 
     for agent in agents:
         for server in agent.mcp_servers:

--- a/src/agent_bom/cli/_scan_runner.py
+++ b/src/agent_bom/cli/_scan_runner.py
@@ -61,7 +61,7 @@ def run_default_scan(cfg: ScanConfig, con: "Console") -> ScanResult:
     from agent_bom.cli.agents._discovery import run_local_discovery
     from agent_bom.discovery import discover_all
     from agent_bom.finding import blast_radius_to_finding
-    from agent_bom.mcp_blocklist import blocklist_findings_for_agents
+    from agent_bom.mcp_blocklist import blocklist_findings_for_agents, flag_blocklisted_mcp_servers
     from agent_bom.models import AIBOMReport
     from agent_bom.parsers import extract_packages
     from agent_bom.scanners import IncompleteScanError, scan_agents_sync
@@ -163,6 +163,7 @@ def run_default_scan(cfg: ScanConfig, con: "Console") -> ScanResult:
     )
 
     agents = ctx.agents
+    flag_blocklisted_mcp_servers(agents)
 
     # ── Package extraction ───────────────────────────────────────────
     total_packages = 0

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -697,6 +697,10 @@ def scan(
     agents = ctx.agents
     ctx.step_timings["cloud"] = _time.monotonic() - _step_t0
 
+    from agent_bom.mcp_blocklist import flag_blocklisted_mcp_servers
+
+    flag_blocklisted_mcp_servers(agents)
+
     # Step 2: Extract packages
     _step_t0 = _time.monotonic()
     total_packages = 0

--- a/src/agent_bom/data/mcp-blocklist.json
+++ b/src/agent_bom/data/mcp-blocklist.json
@@ -1,8 +1,70 @@
 {
   "schema_version": 1,
   "updated": "2026-04-28",
-  "description": "Curated MCP server blocklist and suspicious-name patterns. Exact entries require confirmation; pattern entries are heuristic and may produce false positives.",
+  "description": "Curated MCP server blocklist and suspicious-name patterns. Exact entries require confirmation; pattern entries include heuristic names and boundary-aware package identity matches.",
   "entries": [
+    {
+      "id": "malicious-npm-postmark-mcp",
+      "title": "Malicious Postmark MCP npm package",
+      "description": "The postmark-mcp npm package impersonated Postmark's MCP server and exfiltrated outgoing email via hidden BCC behavior. Remove discovered installations and rotate exposed credentials.",
+      "match_type": "pattern",
+      "patterns": [
+        "(^|\\s)postmark-mcp(@[^\\s]+)?(\\s|$)",
+        "^pkg:npm/postmark-mcp(@|$)"
+      ],
+      "severity": "critical",
+      "source": "agent-bom-curated",
+      "references": [
+        "https://security.snyk.io/vuln/SNYK-JS-POSTMARKMCP-13052679",
+        "https://postmarkapp.com/blog/information-regarding-malicious-postmark-mcp-package"
+      ]
+    },
+    {
+      "id": "malicious-npm-lanyer640-mcp-runcommand-server",
+      "title": "Malicious MCP run command npm package",
+      "description": "The @lanyer640/mcp-runcommand-server npm package was reported as malicious and associated with reverse-shell or malicious-domain behavior. Treat hosts that installed or ran it as potentially compromised.",
+      "match_type": "pattern",
+      "patterns": [
+        "(^|\\s)@lanyer640/mcp-runcommand-server(@[^\\s]+)?(\\s|$)",
+        "^pkg:npm/%40lanyer640/mcp-runcommand-server(@|$)"
+      ],
+      "severity": "critical",
+      "source": "agent-bom-curated",
+      "references": [
+        "https://osv.dev/vulnerability/MAL-2025-47838",
+        "https://checkmarx.com/zero-post/npm-malware-alert-lanyer640-mcp-runcommand-server-with-reverse-shell/"
+      ]
+    },
+    {
+      "id": "malicious-npm-mcp-server-todo",
+      "title": "Malicious MCP todo npm package",
+      "description": "The mcp-server-todo npm package is cataloged as a malicious MCP package with all public versions affected. Avoid installation and remove discovered copies.",
+      "match_type": "pattern",
+      "patterns": [
+        "(^|\\s)mcp-server-todo(@[^\\s]+)?(\\s|$)",
+        "^pkg:npm/mcp-server-todo(@|$)"
+      ],
+      "severity": "critical",
+      "source": "agent-bom-curated",
+      "references": [
+        "https://security.snyk.io/vuln/SNYK-JS-MCPSERVERTODO-15870341"
+      ]
+    },
+    {
+      "id": "malicious-npm-ids-enterprise-mcp-server-0-0-2",
+      "title": "Compromised IDS Enterprise MCP npm package version",
+      "description": "ids-enterprise-mcp-server version 0.0.2 was reported as containing Shai-Hulud 2.0 malware that harvests credentials and attempts to infect GitHub and npm repositories.",
+      "match_type": "pattern",
+      "patterns": [
+        "(^|\\s)ids-enterprise-mcp-server@0\\.0\\.2(\\s|$)",
+        "^pkg:npm/ids-enterprise-mcp-server@0\\.0\\.2$"
+      ],
+      "severity": "critical",
+      "source": "agent-bom-curated",
+      "references": [
+        "https://advisories.gitlab.com/pkg/npm/ids-enterprise-mcp-server/GMS-2025-481/"
+      ]
+    },
     {
       "id": "suspicious-credential-exfiltration-name",
       "title": "Suspicious credential exfiltration server name",

--- a/src/agent_bom/mcp_blocklist.py
+++ b/src/agent_bom/mcp_blocklist.py
@@ -161,17 +161,42 @@ def match_mcp_server(server: MCPServer, blocklist: dict[str, Any] | None = None)
     return matches
 
 
+def _stamp_server_match(server: MCPServer, match: MCPBlocklistMatch) -> bool:
+    warning = f"MCP_BLOCKLIST[{match.severity}/{match.match_type}]: {match.entry_id} matched {match.matched_value!r}"
+    if warning not in server.security_warnings:
+        server.security_warnings.append(warning)
+    if match.severity == "critical":
+        server.security_blocked = True
+        return True
+    return False
+
+
+def flag_blocklisted_mcp_servers(agents: list[Agent], blocklist: dict[str, Any] | None = None) -> int:
+    """Stamp blocklist warnings on discovered MCP servers.
+
+    This is intentionally side-effect only so scan pipelines can run it before
+    package extraction and avoid deeper inspection of a server that already
+    matches a confirmed critical blocklist entry by name, command, registry id,
+    or package identity carried in the discovered config.
+    """
+    flagged = 0
+    for agent in agents:
+        for server in agent.mcp_servers:
+            server_flagged = False
+            for match in match_mcp_server(server, blocklist):
+                server_flagged = _stamp_server_match(server, match) or server_flagged
+            if server_flagged:
+                flagged += 1
+    return flagged
+
+
 def blocklist_findings_for_agents(agents: list[Agent], blocklist: dict[str, Any] | None = None) -> list[Finding]:
     """Create unified findings for MCP blocklist hits and stamp server warnings."""
     findings: list[Finding] = []
     for agent in agents:
         for server in agent.mcp_servers:
             for match in match_mcp_server(server, blocklist):
-                warning = f"MCP_BLOCKLIST[{match.severity}/{match.match_type}]: {match.entry_id} matched {match.matched_value!r}"
-                if warning not in server.security_warnings:
-                    server.security_warnings.append(warning)
-                if match.severity == "critical":
-                    server.security_blocked = True
+                _stamp_server_match(server, match)
 
                 findings.append(
                     Finding(

--- a/tests/test_cli_inventory.py
+++ b/tests/test_cli_inventory.py
@@ -108,6 +108,24 @@ def test_inventory_security_blocked():
         mock_extract.assert_not_called()
 
 
+def test_inventory_blocklist_match_skips_package_extraction():
+    """Known malicious MCP identities are blocked before extraction."""
+    runner = CliRunner()
+    from agent_bom.models import Agent, AgentType, MCPServer, TransportType
+
+    mock_server = MCPServer(name="mail", command="npx", args=["-y", "postmark-mcp"], transport=TransportType.STDIO)
+    mock_agent = Agent(name="a", agent_type=AgentType.CUSTOM, config_path="/t", mcp_servers=[mock_server])
+
+    with (
+        patch("agent_bom.cli._inventory.discover_all", return_value=[mock_agent]),
+        patch("agent_bom.cli._inventory.extract_packages") as mock_extract,
+    ):
+        result = runner.invoke(inventory, [])
+        assert result.exit_code == 0
+        mock_extract.assert_not_called()
+        assert mock_server.security_blocked is True
+
+
 # ---------------------------------------------------------------------------
 # validate
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_blocklist.py
+++ b/tests/test_mcp_blocklist.py
@@ -1,4 +1,4 @@
-from agent_bom.mcp_blocklist import blocklist_findings_for_agents, match_mcp_server
+from agent_bom.mcp_blocklist import blocklist_findings_for_agents, load_mcp_blocklist, match_mcp_server
 from agent_bom.models import Agent, AgentType, AIBOMReport, MCPServer, Package
 from agent_bom.output import to_json
 
@@ -99,3 +99,37 @@ def test_json_output_includes_mcp_blocklist_findings() -> None:
     assert payload["findings"][0]["severity"] == "critical"
     assert payload["findings"][0]["evidence"]["entry_id"] == "confirmed-bad-server"
     assert payload["agents"][0]["mcp_servers"][0]["security_blocked"] is True
+
+
+def test_bundled_blocklist_matches_curated_malicious_mcp_packages() -> None:
+    blocklist = load_mcp_blocklist()
+    cases = [
+        ("npx", ["-y", "postmark-mcp"], "malicious-npm-postmark-mcp"),
+        ("npx", ["-y", "@lanyer640/mcp-runcommand-server"], "malicious-npm-lanyer640-mcp-runcommand-server"),
+        ("uvx", ["mcp-server-todo"], "malicious-npm-mcp-server-todo"),
+    ]
+
+    for command, args, expected_entry_id in cases:
+        matches = match_mcp_server(MCPServer(name="candidate", command=command, args=args), blocklist)
+        match = next(match for match in matches if match.entry_id == expected_entry_id)
+
+        assert match.severity == "critical"
+        assert match.match_type == "pattern"
+
+
+def test_bundled_blocklist_keeps_version_specific_mcp_package_pinned() -> None:
+    blocklist = load_mcp_blocklist()
+
+    vulnerable = MCPServer(name="ids", command="npx", args=["ids-enterprise-mcp-server@0.0.2"])
+    unpinned = MCPServer(name="ids", command="npx", args=["ids-enterprise-mcp-server"])
+
+    assert [
+        match.entry_id
+        for match in match_mcp_server(vulnerable, blocklist)
+        if match.entry_id == "malicious-npm-ids-enterprise-mcp-server-0-0-2"
+    ]
+    assert not [
+        match.entry_id
+        for match in match_mcp_server(unpinned, blocklist)
+        if match.entry_id == "malicious-npm-ids-enterprise-mcp-server-0-0-2"
+    ]

--- a/tests/test_mcp_blocklist.py
+++ b/tests/test_mcp_blocklist.py
@@ -1,4 +1,4 @@
-from agent_bom.mcp_blocklist import blocklist_findings_for_agents, load_mcp_blocklist, match_mcp_server
+from agent_bom.mcp_blocklist import blocklist_findings_for_agents, flag_blocklisted_mcp_servers, load_mcp_blocklist, match_mcp_server
 from agent_bom.models import Agent, AgentType, AIBOMReport, MCPServer, Package
 from agent_bom.output import to_json
 
@@ -99,6 +99,25 @@ def test_json_output_includes_mcp_blocklist_findings() -> None:
     assert payload["findings"][0]["severity"] == "critical"
     assert payload["findings"][0]["evidence"]["entry_id"] == "confirmed-bad-server"
     assert payload["agents"][0]["mcp_servers"][0]["security_blocked"] is True
+
+
+def test_flag_blocklisted_servers_blocks_before_report_building() -> None:
+    blocklist = {
+        "entries": [
+            {
+                "id": "confirmed-bad-server",
+                "title": "Confirmed malicious MCP server",
+                "patterns": ["evil-mcp"],
+                "severity": "critical",
+            }
+        ]
+    }
+    server = MCPServer(name="renamed", command="npx", args=["evil-mcp"])
+    agent = _agent_with_server(server)
+
+    assert flag_blocklisted_mcp_servers([agent], blocklist) == 1
+    assert server.security_blocked is True
+    assert any("confirmed-bad-server" in warning for warning in server.security_warnings)
 
 
 def test_bundled_blocklist_matches_curated_malicious_mcp_packages() -> None:


### PR DESCRIPTION
## Summary
- expand the bundled MCP blocklist with documented malicious MCP npm package identities
- include boundary-aware package/command patterns for common `npx` and package-url discovery surfaces
- add focused tests for bundled blocklist coverage and the version-pinned IDS Enterprise MCP entry

## Validation
- `python -m json.tool src/agent_bom/data/mcp-blocklist.json >/dev/null`
- `pytest tests/test_mcp_blocklist.py`
- `ruff check tests/test_mcp_blocklist.py`
- `git diff --check`