### PR TITLE
security: redact MCP launch metadata surfaces

### DIFF
--- a/src/agent_bom/ai_enrich.py
+++ b/src/agent_bom/ai_enrich.py
@@ -36,6 +36,7 @@ from rich.console import Console
 
 from agent_bom.config import AI_CACHE_MAX_ENTRIES as _MAX_AI_CACHE
 from agent_bom.config import OLLAMA_BASE_URL
+from agent_bom.security import sanitize_command_args
 
 if TYPE_CHECKING:
     from pydantic import BaseModel
@@ -927,9 +928,10 @@ def _build_mcp_config_analysis_prompt(report: "AIBOMReport") -> str:
         for server in agent.mcp_servers[:10]:
             creds = server.credential_names
             tools = [t.name for t in server.tools[:10]]
+            server_args = sanitize_command_args(server.args[:5])
             server_configs.append(
                 f"- Server: {server.name}\n"
-                f"  Command: {server.command} {' '.join(server.args[:5])}\n"
+                f"  Command: {server.command} {' '.join(server_args)}\n"
                 f"  Transport: {server.transport.value}\n"
                 f"  Tools: {', '.join(tools) or 'unknown'}\n"
                 f"  Credentials: {', '.join(creds) or 'none'}\n"

--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -28,6 +28,7 @@ from typing import Any, Protocol
 from uuid import uuid4
 
 from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+from agent_bom.security import sanitize_sensitive_payload
 
 logger = logging.getLogger(__name__)
 _AUDIT_DETAIL_KEY_RE = re.compile(r"[^a-zA-Z0-9_.:-]+")
@@ -594,7 +595,8 @@ def _sanitize_detail_value(value: object, *, depth: int = 0) -> object:
     if value is None or isinstance(value, bool | int | float):
         return value
     if isinstance(value, str):
-        text = value.replace("\r", " ").replace("\n", " ").replace("\t", " ")
+        sanitized = sanitize_sensitive_payload(value, max_str_len=_MAX_AUDIT_DETAIL_STRING_LENGTH)
+        text = str(sanitized).replace("\r", " ").replace("\n", " ").replace("\t", " ")
         return text[:_MAX_AUDIT_DETAIL_STRING_LENGTH]
     if isinstance(value, dict):
         out: dict[str, object] = {}
@@ -602,15 +604,22 @@ def _sanitize_detail_value(value: object, *, depth: int = 0) -> object:
             if index >= _MAX_AUDIT_DETAIL_COLLECTION_ITEMS:
                 out["_truncated"] = True
                 break
-            out[_sanitize_detail_key(raw_key)] = _sanitize_detail_value(raw_value, depth=depth + 1)
+            clean_key = _sanitize_detail_key(raw_key)
+            out[clean_key] = _sanitize_detail_value(
+                sanitize_sensitive_payload(raw_value, key=clean_key, max_str_len=_MAX_AUDIT_DETAIL_STRING_LENGTH),
+                depth=depth + 1,
+            )
         return out
     if isinstance(value, list | tuple | set):
         items = list(value)
-        list_out = [_sanitize_detail_value(item, depth=depth + 1) for item in items[:_MAX_AUDIT_DETAIL_COLLECTION_ITEMS]]
+        list_out = [
+            _sanitize_detail_value(sanitize_sensitive_payload(item, max_str_len=_MAX_AUDIT_DETAIL_STRING_LENGTH), depth=depth + 1)
+            for item in items[:_MAX_AUDIT_DETAIL_COLLECTION_ITEMS]
+        ]
         if len(items) > _MAX_AUDIT_DETAIL_COLLECTION_ITEMS:
             list_out.append("[truncated]")
         return list_out
-    return str(value)[:_MAX_AUDIT_DETAIL_STRING_LENGTH]
+    return str(sanitize_sensitive_payload(value, max_str_len=_MAX_AUDIT_DETAIL_STRING_LENGTH))[:_MAX_AUDIT_DETAIL_STRING_LENGTH]
 
 
 def sanitize_audit_details(details: dict[str, object]) -> dict[str, object]:
@@ -620,7 +629,10 @@ def sanitize_audit_details(details: dict[str, object]) -> dict[str, object]:
         if index >= _MAX_AUDIT_DETAIL_KEYS:
             sanitized["_truncated"] = True
             break
-        sanitized[_sanitize_detail_key(raw_key)] = _sanitize_detail_value(raw_value)
+        clean_key = _sanitize_detail_key(raw_key)
+        sanitized[clean_key] = _sanitize_detail_value(
+            sanitize_sensitive_payload(raw_value, key=clean_key, max_str_len=_MAX_AUDIT_DETAIL_STRING_LENGTH)
+        )
 
     encoded = json.dumps(sanitized, sort_keys=True, default=str, ensure_ascii=False).encode("utf-8")
     if len(encoded) <= _MAX_AUDIT_DETAILS_JSON_BYTES:

--- a/src/agent_bom/api/mcp_observation_store.py
+++ b/src/agent_bom/api/mcp_observation_store.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field, field_validator
 from agent_bom.api.storage_schema import ensure_sqlite_schema_version
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.platform_invariants import normalize_tenant_id, normalize_timestamp, now_utc_iso
+from agent_bom.security import sanitize_command_args, sanitize_security_warnings, sanitize_text, sanitize_url
 
 
 class MCPObservation(BaseModel):
@@ -61,6 +62,30 @@ class MCPObservation(BaseModel):
         if not isinstance(value, list):
             return []
         return [sanitize_security_intelligence_entry(item) for item in value if isinstance(item, dict)]
+
+    @field_validator("args", mode="before")
+    @classmethod
+    def _sanitize_args(cls, value: object) -> list[str]:
+        if not isinstance(value, list):
+            return []
+        return sanitize_command_args(value)
+
+    @field_validator("security_warnings", mode="before")
+    @classmethod
+    def _sanitize_security_warnings(cls, value: object) -> list[str]:
+        if not isinstance(value, list):
+            return []
+        return sanitize_security_warnings(value)
+
+    @field_validator("url", mode="before")
+    @classmethod
+    def _sanitize_url(cls, value: object) -> str | None:
+        return sanitize_url(str(value)) if value else None
+
+    @field_validator("command", mode="before")
+    @classmethod
+    def _sanitize_command(cls, value: object) -> str:
+        return sanitize_text(value, max_len=200)
 
 
 def _pick_timestamp(*values: str | None, prefer: str) -> str | None:

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
 # ─── Enums ─────────────────────────────────────────────────────────────────
 
@@ -110,6 +110,22 @@ class ScanJob(BaseModel):
     error: str | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @field_serializer("request", return_type=ScanRequest)
+    def _serialize_request(self, value: ScanRequest) -> ScanRequest:
+        from agent_bom.security import sanitize_sensitive_payload
+
+        sanitized = sanitize_sensitive_payload(value.model_dump())
+        payload = sanitized if isinstance(sanitized, dict) else {}
+        result: ScanRequest = ScanRequest.model_validate(payload)
+        return result
+
+    @field_serializer("progress", return_type=list[str])
+    def _serialize_progress(self, value: list[str]) -> list[str]:
+        from agent_bom.security import sanitize_sensitive_payload
+
+        sanitized = sanitize_sensitive_payload(value)
+        return sanitized if isinstance(sanitized, list) else []
 
 
 # ─── Meta Models ───────────────────────────────────────────────────────────

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -22,7 +22,15 @@ from typing import Any
 from agent_bom import __version__
 from agent_bom.api.models import JobStatus, ScanJob, StepStatus
 from agent_bom.api.stores import _get_analytics_store, _get_fleet_store, _get_graph_store, _get_store, _job_lock
-from agent_bom.security import sanitize_error
+from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
+from agent_bom.security import (
+    sanitize_command_args,
+    sanitize_env_vars,
+    sanitize_error,
+    sanitize_security_warnings,
+    sanitize_text,
+    sanitize_url,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -326,15 +334,19 @@ def _run_scan_sync(job: ScanJob) -> None:
                     servers.append(
                         MCPServer(
                             name=s.get("name", "unknown"),
-                            command=s.get("command", ""),
-                            args=s.get("args", []),
-                            env=s.get("env", {}),
+                            command=sanitize_text(s.get("command", ""), max_len=200),
+                            args=sanitize_command_args(list(s.get("args", []) or [])),
+                            env=sanitize_env_vars(dict(s.get("env", {}) or {})),
                             transport=TransportType(s.get("transport", "stdio")),
-                            url=s.get("url"),
+                            url=sanitize_url(str(s.get("url") or "")) if s.get("url") else None,
                             config_path=s.get("config_path"),
                             security_blocked=bool(s.get("security_blocked", False)),
-                            security_warnings=list(s.get("security_warnings", []) or []),
-                            security_intelligence=list(s.get("security_intelligence", []) or []),
+                            security_warnings=sanitize_security_warnings(list(s.get("security_warnings", []) or [])),
+                            security_intelligence=[
+                                sanitize_security_intelligence_entry(item)
+                                for item in (s.get("security_intelligence", []) or [])
+                                if isinstance(item, dict)
+                            ],
                         )
                     )
                 agents.append(

--- a/src/agent_bom/api/routes/discovery.py
+++ b/src/agent_bom/api/routes/discovery.py
@@ -19,7 +19,14 @@ from agent_bom.api.mcp_observation_store import MCPObservation, merge_observatio
 from agent_bom.api.models import JobStatus
 from agent_bom.api.stores import _get_fleet_store, _get_mcp_observation_store, _get_store
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
-from agent_bom.security import sanitize_error
+from agent_bom.security import (
+    sanitize_command_args,
+    sanitize_env_vars,
+    sanitize_error,
+    sanitize_security_warnings,
+    sanitize_text,
+    sanitize_url,
+)
 
 router = APIRouter()
 _logger = logging.getLogger(__name__)
@@ -179,12 +186,14 @@ def _serialize_agent(
 
         server_payload["auth_mode"] = auth_mode
         server_payload["has_credentials"] = has_credentials
+        server_payload["command"] = sanitize_text(getattr(server, "command", ""), max_len=200)
+        server_payload["env"] = sanitize_env_vars(dict(getattr(server, "env", {}) or {}))
         server_payload["credential_env_vars"] = credential_names
         server_payload["security_blocked"] = bool(getattr(server, "security_blocked", False))
-        server_payload.setdefault("args", list(getattr(server, "args", []) or []))
-        server_payload.setdefault("url", server_url)
+        server_payload["args"] = sanitize_command_args(list(getattr(server, "args", []) or []))
+        server_payload["url"] = sanitize_url(server_url)
         server_payload.setdefault("config_path", getattr(server, "config_path", None))
-        server_payload["security_warnings"] = list(getattr(server, "security_warnings", []) or [])
+        server_payload["security_warnings"] = sanitize_security_warnings(list(getattr(server, "security_warnings", []) or []))
         server_payload["security_intelligence"] = _merge_security_intelligence(list(getattr(server, "security_intelligence", []) or []))
         observation_id, legacy_observation_id = _observation_ids(agent, server)
         stored_observation = (observation_index or {}).get(observation_id)
@@ -195,7 +204,7 @@ def _serialize_agent(
             {"present": False, "scan_sources": [], "first_seen": None, "last_seen": None},
         )
         gateway_state = (gateway_index or {}).get(
-            (server.name, server_url or ""),
+            (server.name, sanitize_url(server_url) or ""),
             {"gateway_registered": False, "source_agents": []},
         )
         observed_via = ["local_discovery"]
@@ -212,7 +221,7 @@ def _serialize_agent(
             server_payload["security_blocked"] = bool(server_payload["security_blocked"]) or stored_observation.security_blocked
             server_payload["security_warnings"] = _merge_strings(
                 list(server_payload.get("security_warnings", []) or []),
-                stored_observation.security_warnings,
+                sanitize_security_warnings(stored_observation.security_warnings),
             )
             server_payload["security_intelligence"] = _merge_security_intelligence(
                 list(server_payload.get("security_intelligence", []) or []),
@@ -311,14 +320,14 @@ def _persist_agent_observations(
             server_name=server.name,
             agent_name=agent.name,
             transport=getattr(getattr(server, "transport", ""), "value", getattr(server, "transport", "")) or "",
-            url=server_url,
+            url=sanitize_url(server_url),
             auth_mode=auth_mode,
-            command=getattr(server, "command", "") or "",
-            args=list(getattr(server, "args", []) or []),
+            command=sanitize_text(getattr(server, "command", ""), max_len=200),
+            args=sanitize_command_args(list(getattr(server, "args", []) or [])),
             config_path=getattr(server, "config_path", None),
             credential_env_vars=credential_names,
             security_blocked=bool(getattr(server, "security_blocked", False)),
-            security_warnings=list(getattr(server, "security_warnings", []) or []),
+            security_warnings=sanitize_security_warnings(list(getattr(server, "security_warnings", []) or [])),
             security_intelligence=list(getattr(server, "security_intelligence", []) or []),
             observed_via=observed_via,
             observed_scopes=observed_scopes,

--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -20,6 +20,7 @@ from agent_bom.api.mcp_observation_store import MCPObservation, merge_observatio
 from agent_bom.api.models import FleetAgentUpdate, PushPayload, StateUpdate
 from agent_bom.api.stores import _get_fleet_store, _get_idempotency_store, _get_mcp_observation_store
 from agent_bom.api.tenant_quota import enforce_fleet_agents_quota, tenant_quota_guard
+from agent_bom.security import sanitize_command_args, sanitize_security_warnings, sanitize_text, sanitize_url
 
 router = APIRouter()
 
@@ -220,14 +221,14 @@ def _persist_payload_observations(tenant_id: str, agent: dict, *, last_discovery
             server_name=server_name,
             agent_name=agent_name,
             transport=transport,
-            url=server_url,
+            url=sanitize_url(server_url),
             auth_mode=auth_mode,
-            command=str(server.get("command") or ""),
-            args=list(server.get("args", []) or []),
+            command=sanitize_text(server.get("command", ""), max_len=200),
+            args=sanitize_command_args(list(server.get("args", []) or [])),
             config_path=server.get("config_path"),
             credential_env_vars=credential_names,
             security_blocked=bool(server.get("security_blocked", False)),
-            security_warnings=list(server.get("security_warnings", []) or []),
+            security_warnings=sanitize_security_warnings(list(server.get("security_warnings", []) or [])),
             security_intelligence=list(server.get("security_intelligence", []) or []),
             observed_via=["fleet_sync"],
             observed_scopes=["endpoint"],

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -22,8 +22,16 @@ from agent_bom.api.pipeline import _persist_graph_snapshot
 from agent_bom.api.stores import _get_analytics_store, _get_fleet_store, _get_store
 from agent_bom.api.tenant_quota import enforce_retained_jobs_quota, tenant_quota_guard
 from agent_bom.graph.severity import ocsf_to_severity
+from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.rbac import require_authenticated_permission
-from agent_bom.security import sanitize_error
+from agent_bom.security import (
+    sanitize_command_args,
+    sanitize_env_vars,
+    sanitize_error,
+    sanitize_security_warnings,
+    sanitize_text,
+    sanitize_url,
+)
 
 router = APIRouter()
 _logger = logging.getLogger(__name__)
@@ -66,6 +74,26 @@ def _normalize_pushed_report(body: PushPayload, *, fallback_scan_id: str) -> dic
         if agent_type:
             agent["type"] = agent_type
             agent["agent_type"] = agent_type
+        sanitized_servers: list[dict] = []
+        for raw_server in agent.get("mcp_servers", []) or agent.get("servers", []) or []:
+            if not isinstance(raw_server, dict):
+                continue
+            server = dict(raw_server)
+            server["command"] = sanitize_text(server.get("command", ""), max_len=200)
+            server["args"] = sanitize_command_args(list(server.get("args", []) or []))
+            server["url"] = sanitize_url(str(server.get("url") or "")) if server.get("url") else None
+            server["env"] = sanitize_env_vars(dict(server.get("env", {}) or {}))
+            server["security_warnings"] = sanitize_security_warnings(list(server.get("security_warnings", []) or []))
+            server["security_intelligence"] = [
+                sanitize_security_intelligence_entry(item)
+                for item in (server.get("security_intelligence", []) or [])
+                if isinstance(item, dict)
+            ]
+            sanitized_servers.append(server)
+        if "mcp_servers" in agent:
+            agent["mcp_servers"] = sanitized_servers
+        elif sanitized_servers:
+            agent["servers"] = sanitized_servers
         normalized_agents.append(agent)
     report["agents"] = normalized_agents
     return report

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 from agent_bom.api.models import ProxyAuditIngestRequest
 from agent_bom.api.stores import _get_idempotency_store
+from agent_bom.security import sanitize_sensitive_payload
 
 router = APIRouter()
 
@@ -46,14 +47,16 @@ _proxy_metrics: dict | None = None
 def push_proxy_alert(alert: dict) -> None:
     """Called by the proxy to record a runtime alert (in-process path)."""
     global _proxy_alerts_total
-    _proxy_alerts.append(alert)
+    sanitized = sanitize_sensitive_payload(alert)
+    _proxy_alerts.append(sanitized if isinstance(sanitized, dict) else {})
     _proxy_alerts_total += 1
 
 
 def push_proxy_metrics(metrics: dict) -> None:
     """Called by the proxy to record latest metrics summary."""
     global _proxy_metrics
-    _proxy_metrics = metrics
+    sanitized = sanitize_sensitive_payload(metrics)
+    _proxy_metrics = sanitized if isinstance(sanitized, dict) else {}
 
 
 @router.post("/v1/proxy/audit", tags=["proxy"])
@@ -174,7 +177,9 @@ def _read_alerts_from_log(path: _Path) -> list[dict]:
                 try:
                     record = _json.loads(line)
                     if record.get("type") == "runtime_alert":
-                        alerts.append(record)
+                        sanitized = sanitize_sensitive_payload(record)
+                        if isinstance(sanitized, dict):
+                            alerts.append(sanitized)
                 except (ValueError, KeyError):
                     continue
     except OSError:

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -218,15 +218,18 @@ def _visible_to_tenant(job: ScanJob, tenant_id: str) -> bool:
 
 def _job_summary_payload(job: ScanJob) -> dict[str, Any]:
     """Build a lightweight summary payload for list surfaces."""
+    from agent_bom.security import sanitize_sensitive_payload
+
     result = job.result if isinstance(job.result, dict) else {}
     summary = result.get("summary") if isinstance(result.get("summary"), dict) else None
+    request_payload = sanitize_sensitive_payload(job.request.model_dump(exclude_defaults=True, exclude_none=True))
     return {
         "job_id": job.job_id,
         "tenant_id": job.tenant_id,
         "status": job.status,
         "created_at": job.created_at,
         "completed_at": job.completed_at,
-        "request": job.request.model_dump(exclude_defaults=True, exclude_none=True),
+        "request": request_payload if isinstance(request_payload, dict) else {},
         "summary": summary,
         "scan_timestamp": result.get("scan_timestamp"),
         "pushed": bool(result.get("pushed")),
@@ -597,15 +600,18 @@ async def stream_scan(request: Request, job_id: str):
             with lock:
                 new_lines = list(current.progress[sent:])
                 status = current.status
+            from agent_bom.security import sanitize_sensitive_payload
+
             for line in new_lines:
                 try:
                     parsed = _json.loads(line)
                     if isinstance(parsed, dict) and parsed.get("type") == "step":
+                        parsed = sanitize_sensitive_payload(parsed)
                         yield {"data": _json.dumps(parsed)}
                     else:
-                        yield {"data": _json.dumps({"type": "progress", "message": line})}
+                        yield {"data": _json.dumps({"type": "progress", "message": sanitize_sensitive_payload(line)})}
                 except (_json.JSONDecodeError, ValueError):
-                    yield {"data": _json.dumps({"type": "progress", "message": line})}
+                    yield {"data": _json.dumps({"type": "progress", "message": sanitize_sensitive_payload(line)})}
                 sent += 1
             if status in (JobStatus.DONE, JobStatus.FAILED, JobStatus.CANCELLED):
                 yield {"data": _json.dumps({"type": "done", "status": status, "job_id": job_id})}

--- a/src/agent_bom/audit_integrity.py
+++ b/src/agent_bom/audit_integrity.py
@@ -1,0 +1,45 @@
+"""Shared audit-chain integrity helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from cryptography.hazmat.primitives.ciphers import algorithms
+from cryptography.hazmat.primitives.cmac import CMAC
+
+_AUDIT_CHAIN_FALLBACK_KEY = b"agent-bom-audit-chain-v1"
+
+
+def audit_chain_key() -> bytes:
+    """Return the operator HMAC key, or a deterministic local fallback."""
+    configured = (os.environ.get("AGENT_BOM_AUDIT_HMAC_KEY") or "").strip()
+    return configured.encode("utf-8") if configured else _AUDIT_CHAIN_FALLBACK_KEY
+
+
+def _audit_chain_cmac_key() -> bytes:
+    raw = audit_chain_key()
+    if len(raw) in {16, 24, 32}:
+        return raw
+    if len(raw) < 16:
+        return raw.ljust(16, b"\0")
+    if len(raw) < 24:
+        return raw.ljust(24, b"\0")
+    if len(raw) < 32:
+        return raw.ljust(32, b"\0")
+    return raw[:32]
+
+
+def canonical_audit_payload(payload: dict[str, Any]) -> str:
+    """Serialize an audit payload deterministically for integrity checks."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def compute_audit_record_mac(payload: dict[str, Any], prev_hash: str) -> str:
+    """Return the chain MAC for a redacted audit payload."""
+    canonical = canonical_audit_payload(payload)
+    message = f"{prev_hash}|{canonical}".encode("utf-8")
+    mac = CMAC(algorithms.AES(_audit_chain_cmac_key()))
+    mac.update(message)
+    return mac.finalize().hex()

--- a/src/agent_bom/audit_replay.py
+++ b/src/agent_bom/audit_replay.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
+from agent_bom.audit_integrity import compute_audit_record_mac
+
 # ─── Entry dataclasses ────────────────────────────────────────────────────────
 
 
@@ -243,8 +245,7 @@ def verify_hash_chain(path: Path) -> tuple[int, int]:
         actual_prev = str(entry.get("prev_hash", ""))
         actual_hash = str(entry.get("record_hash", ""))
         payload = {k: v for k, v in entry.items() if k not in {"prev_hash", "record_hash"}}
-        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
-        expected_hash = hashlib.sha256(f"{actual_prev}|{canonical}".encode("utf-8")).hexdigest()
+        expected_hash = compute_audit_record_mac(payload, actual_prev)
 
         if actual_prev == previous_hash and actual_hash and hmac.compare_digest(actual_hash, expected_hash):
             verified += 1

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -728,7 +728,10 @@ def scan(
             for server in agent.mcp_servers:
                 if server.security_blocked:
                     if not quiet:
-                        con.print(f"    [yellow]⚠ {server.name}: blocked — {', '.join(server.security_warnings)}[/yellow]")
+                        from agent_bom.security import sanitize_security_warnings
+
+                        warnings = ", ".join(sanitize_security_warnings(server.security_warnings))
+                        con.print(f"    [yellow]⚠ {server.name}: blocked — {warnings}[/yellow]")
                     continue
                 pre_populated = list(server.packages)
                 if self_scan and pre_populated:

--- a/src/agent_bom/event_normalization.py
+++ b/src/agent_bom/event_normalization.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
+from agent_bom.security import sanitize_sensitive_payload, sanitize_text
+
 _RESOURCE_ARG_TYPES = {
     "path": "path",
     "url": "url",
@@ -26,7 +28,11 @@ _RUNTIME_DETAIL_TARGET_LIST_FIELDS = {
 def _scalar_attributes(attributes: Mapping[str, Any] | None) -> dict[str, Any]:
     if not attributes:
         return {}
-    return {key: value for key, value in attributes.items() if isinstance(value, (str, int, float, bool)) and value not in ("", None)}
+    return {
+        sanitize_text(key, max_len=200): sanitize_sensitive_payload(value, key=key)
+        for key, value in attributes.items()
+        if isinstance(value, (str, int, float, bool)) and value not in ("", None)
+    }
 
 
 def build_event_ref(
@@ -39,15 +45,17 @@ def build_event_ref(
     attributes: Mapping[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     """Return a stable event relationship reference."""
-    if not ref_id:
+    safe_ref_id = sanitize_sensitive_payload(ref_id, key=source_field or ref_type)
+    safe_name = sanitize_sensitive_payload(name, key=source_field or ref_type) if name else None
+    if not safe_ref_id:
         return None
 
     ref: dict[str, Any] = {
         "type": ref_type,
-        "id": ref_id,
+        "id": str(safe_ref_id),
     }
-    if name:
-        ref["name"] = name
+    if safe_name:
+        ref["name"] = str(safe_name)
     if role:
         ref["role"] = role
     if source_field:

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -248,11 +248,13 @@ def blast_radius_to_finding(br: object) -> "Finding":
     # Asset: primary server or package
     if br.affected_servers:
         primary_server = br.affected_servers[0]
+        from agent_bom.security import sanitize_launch_command
+
         asset = Asset(
             name=primary_server.name,
             asset_type="mcp_server",
             identifier=None,
-            location=primary_server.command or None,
+            location=sanitize_launch_command(primary_server.command, primary_server.args) or None,
         )
     else:
         asset = Asset(

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -18,7 +18,9 @@ from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import NodeDimensions, UnifiedNode
 from agent_bom.graph.severity import SEVERITY_RISK_SCORE
 from agent_bom.graph.types import EntityType, RelationshipType
+from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.package_utils import canonical_package_key, normalize_package_name
+from agent_bom.security import sanitize_security_warnings, sanitize_text, sanitize_url
 
 try:
     from agent_bom.constants import is_credential_key as _is_credential_key
@@ -142,14 +144,19 @@ def build_unified_graph_from_report(
                     entity_type=EntityType.SERVER,
                     label=srv_name,
                     attributes={
-                        "command": srv_dict.get("command", ""),
+                        "command": sanitize_text(srv_dict.get("command", "")),
                         "transport": srv_dict.get("transport", ""),
-                        "url": srv_dict.get("url", ""),
+                        "url": sanitize_url(str(srv_dict.get("url") or "")) or "",
                         "auth_mode": srv_dict.get("auth_mode", ""),
                         "mcp_version": srv_dict.get("mcp_version", ""),
                         "has_credentials": srv_dict.get("has_credentials", False),
                         "security_blocked": srv_dict.get("security_blocked", False),
-                        "security_intelligence": srv_dict.get("security_intelligence", []),
+                        "security_warnings": sanitize_security_warnings(list(srv_dict.get("security_warnings", []) or [])),
+                        "security_intelligence": [
+                            sanitize_security_intelligence_entry(item)
+                            for item in (srv_dict.get("security_intelligence", []) or [])
+                            if isinstance(item, dict)
+                        ],
                         "security_intelligence_count": len(srv_dict.get("security_intelligence", []) or []),
                         "agent": agent_name,
                         "stable_id": srv_dict.get("stable_id", ""),

--- a/src/agent_bom/history.py
+++ b/src/agent_bom/history.py
@@ -10,6 +10,7 @@ from typing import Optional
 from agent_bom.models import Package
 from agent_bom.package_utils import canonical_package_key
 from agent_bom.sbom import parse_sbom_document
+from agent_bom.security import sanitize_path_label
 
 HISTORY_DIR = Path.home() / ".agent-bom" / "history"
 
@@ -73,7 +74,7 @@ def _synthetic_report_from_packages(
         },
         "scan_sources": ["sbom"],
         "sbom_baseline": {
-            "source_path": str(source_path),
+            "source_path": sanitize_path_label(source_path),
             "source_name": source_name,
             "format": format_name,
             "package_count": len(package_dicts),

--- a/src/agent_bom/jupyter.py
+++ b/src/agent_bom/jupyter.py
@@ -178,7 +178,7 @@ def scan_jupyter_notebooks(
             # Skip common false positives
             if key_value in ("your_api_key_here", "YOUR_API_KEY", "test", "example"):
                 continue
-            warnings.append(f"Jupyter: possible hardcoded API key in {nb_path.name} (value starts with '{key_value[:8]}...')")
+            warnings.append(f"Jupyter: possible hardcoded API key in {nb_path.name} (value redacted)")
 
         # Skip notebooks with no AI-related findings
         if not seen_packages and not credential_env_vars:

--- a/src/agent_bom/mcp_blocklist.py
+++ b/src/agent_bom/mcp_blocklist.py
@@ -17,13 +17,13 @@ from urllib.parse import urlsplit, urlunsplit
 
 from agent_bom.finding import Asset, Finding, FindingSource, FindingType
 from agent_bom.models import Agent, MCPServer
+from agent_bom.security import sanitize_command_args
 
 logger = logging.getLogger(__name__)
 
 _CONFIDENCE_LEVELS = {"confirmed_malicious", "suspicious", "heuristic"}
 _RECOMMENDATIONS = {"block", "warn", "review"}
 _SOURCE_TYPES = {"security_advisory", "vendor_statement", "community_report", "package_registry", "heuristic"}
-_SENSITIVE_ARG_RE = re.compile(r"(token|secret|password|credential|api[-_]?key|access[-_]?key|auth)", re.IGNORECASE)
 
 
 @dataclass(frozen=True)
@@ -138,38 +138,7 @@ def _safe_references(values: tuple[str, ...] | list[object]) -> list[str]:
 
 def _safe_match_value(value: str) -> str:
     """Return evidence-safe match text without raw secret-bearing values."""
-    parts = str(value or "").split()
-    if not parts:
-        return ""
-
-    redacted: list[str] = []
-    redact_next = False
-    for part in parts:
-        if redact_next:
-            redacted.append("<redacted>")
-            redact_next = False
-            continue
-
-        if "=" in part:
-            key, _sep, raw_value = part.partition("=")
-            if _SENSITIVE_ARG_RE.search(key):
-                redacted.append(f"{key}=<redacted>")
-                continue
-            if "://" in raw_value:
-                redacted.append(f"{key}={_safe_url(raw_value)}")
-                continue
-
-        if "://" in part:
-            redacted.append(_safe_url(part))
-            continue
-
-        if part.startswith("-") and _SENSITIVE_ARG_RE.search(part):
-            redacted.append(part)
-            redact_next = True
-            continue
-
-        redacted.append(part)
-
+    redacted = sanitize_command_args(str(value or "").split())
     safe = " ".join(redacted)
     return safe if len(safe) <= 180 else f"{safe[:177]}..."
 

--- a/src/agent_bom/mcp_introspect.py
+++ b/src/agent_bom/mcp_introspect.py
@@ -25,6 +25,7 @@ from typing import Optional
 
 from agent_bom.mcp_tool_rules import evaluate_tool
 from agent_bom.models import MCPPrompt, MCPResource, MCPServer, MCPTool, TransportType
+from agent_bom.security import sanitize_sensitive_payload, sanitize_text
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +35,15 @@ _PATH_HINT_RE = re.compile(r"(path|file|dir|cwd|workspace)", re.IGNORECASE)
 _URL_HINT_RE = re.compile(r"(url|uri|endpoint|host|domain|webhook)", re.IGNORECASE)
 _SHELL_HINT_RE = re.compile(r"(cmd|command|shell|exec|script)", re.IGNORECASE)
 _PROMPT_HINT_RE = re.compile(r"(prompt|instruction|system|markdown|html|svg)", re.IGNORECASE)
+
+
+def _safe_runtime_text(value: object, *, max_len: int = 1000) -> str:
+    """Sanitize runtime-supplied introspection text before display or export."""
+    return sanitize_text(value, max_len=max_len)
+
+
+def _safe_runtime_value(value: object, *, max_len: int = 1000) -> object:
+    return sanitize_sensitive_payload(value, max_str_len=max_len)
 
 
 class IntrospectionError(Exception):
@@ -102,10 +112,10 @@ class ServerIntrospection:
 
     def to_dict(self, *, include_runtime_objects: bool = False) -> dict:
         payload = {
-            "server_name": self.server_name,
+            "server_name": _safe_runtime_text(self.server_name, max_len=300),
             "success": self.success,
-            "protocol_version": self.protocol_version,
-            "auth_mode": self.auth_mode,
+            "protocol_version": _safe_runtime_value(self.protocol_version, max_len=100),
+            "auth_mode": _safe_runtime_value(self.auth_mode, max_len=100),
             "configured_fingerprint": self.configured_fingerprint,
             "runtime_fingerprint": self.runtime_fingerprint,
             "configured_tool_count": self.configured_tool_count,
@@ -114,54 +124,54 @@ class ServerIntrospection:
             "tool_count": self.tool_count,
             "resource_count": self.resource_count,
             "prompt_count": self.prompt_count,
-            "tools_added": self.tools_added,
-            "tools_removed": self.tools_removed,
-            "resources_added": self.resources_added,
-            "resources_removed": self.resources_removed,
-            "prompts_added": self.prompts_added,
-            "prompts_removed": self.prompts_removed,
-            "tool_schema_findings": self.tool_schema_findings,
-            "tool_schema_rule_findings": self.tool_schema_rule_findings,
-            "resource_findings": self.resource_findings,
-            "prompt_findings": self.prompt_findings,
+            "tools_added": _safe_runtime_value(self.tools_added),
+            "tools_removed": _safe_runtime_value(self.tools_removed),
+            "resources_added": _safe_runtime_value(self.resources_added),
+            "resources_removed": _safe_runtime_value(self.resources_removed),
+            "prompts_added": _safe_runtime_value(self.prompts_added),
+            "prompts_removed": _safe_runtime_value(self.prompts_removed),
+            "tool_schema_findings": _safe_runtime_value(self.tool_schema_findings),
+            "tool_schema_rule_findings": _safe_runtime_value(self.tool_schema_rule_findings),
+            "resource_findings": _safe_runtime_value(self.resource_findings),
+            "prompt_findings": _safe_runtime_value(self.prompt_findings),
             "has_drift": self.has_drift,
             "capability_risk_score": self.capability_risk_score,
             "capability_risk_level": self.capability_risk_level,
             "capability_counts": self.capability_counts,
-            "capability_tools": self.capability_tools,
-            "dangerous_combinations": self.dangerous_combinations,
-            "risk_justification": self.risk_justification,
-            "tool_risk_profiles": self.tool_risk_profiles,
-            "error": self.error,
+            "capability_tools": _safe_runtime_value(self.capability_tools),
+            "dangerous_combinations": _safe_runtime_value(self.dangerous_combinations),
+            "risk_justification": _safe_runtime_value(self.risk_justification),
+            "tool_risk_profiles": _safe_runtime_value(self.tool_risk_profiles),
+            "error": _safe_runtime_value(self.error),
         }
         if include_runtime_objects:
             payload["runtime_tools"] = [
                 {
-                    "name": t.name,
-                    "description": t.description,
-                    "schema_findings": t.schema_findings,
-                    "schema_rule_findings": t.schema_rule_findings,
+                    "name": _safe_runtime_text(t.name, max_len=300),
+                    "description": _safe_runtime_text(t.description, max_len=1000),
+                    "schema_findings": _safe_runtime_value(t.schema_findings),
+                    "schema_rule_findings": _safe_runtime_value(t.schema_rule_findings),
                     "risk_score": t.risk_score,
                 }
                 for t in self.runtime_tools
             ]
             payload["runtime_resources"] = [
                 {
-                    "uri": r.uri,
-                    "name": r.name,
-                    "description": r.description,
-                    "mime_type": r.mime_type,
-                    "content_findings": r.content_findings,
+                    "uri": _safe_runtime_text(r.uri, max_len=1000),
+                    "name": _safe_runtime_text(r.name, max_len=300),
+                    "description": _safe_runtime_text(r.description, max_len=1000),
+                    "mime_type": _safe_runtime_text(r.mime_type, max_len=200),
+                    "content_findings": _safe_runtime_value(r.content_findings),
                     "risk_score": r.risk_score,
                 }
                 for r in self.runtime_resources
             ]
             payload["runtime_prompts"] = [
                 {
-                    "name": p.name,
-                    "description": p.description,
-                    "arguments": p.arguments,
-                    "content_findings": p.content_findings,
+                    "name": _safe_runtime_text(p.name, max_len=300),
+                    "description": _safe_runtime_text(p.description, max_len=1000),
+                    "arguments": _safe_runtime_value(p.arguments),
+                    "content_findings": _safe_runtime_value(p.content_findings),
                     "risk_score": p.risk_score,
                 }
                 for p in self.runtime_prompts
@@ -395,7 +405,7 @@ async def _introspect_stdio(
     except TimeoutError:
         result.error = f"Connection timed out after {timeout}s"
     except Exception as exc:
-        result.error = str(exc)
+        result.error = _safe_runtime_text(exc)
 
     return result
 
@@ -425,7 +435,7 @@ async def _introspect_sse(
     except TimeoutError:
         result.error = f"Connection timed out after {timeout}s"
     except Exception as exc:
-        result.error = str(exc)
+        result.error = _safe_runtime_text(exc)
 
     return result
 
@@ -452,7 +462,7 @@ async def _query_capabilities(
             result.runtime_tools.append(runtime_tool)
         tools_ok = True
     except Exception as exc:
-        logger.warning("tools/list failed for %s: %s — drift detection skipped", server.name, exc)
+        logger.warning("tools/list failed for %s: %s — drift detection skipped", _safe_runtime_text(server.name), _safe_runtime_text(exc))
 
     # ── Resources ──────────────────────────────────────────────────────
     resources_ok = False
@@ -469,7 +479,7 @@ async def _query_capabilities(
             result.runtime_resources.append(runtime_resource)
         resources_ok = True
     except Exception as exc:
-        logger.warning("resources/list failed for %s: %s", server.name, exc)
+        logger.warning("resources/list failed for %s: %s", _safe_runtime_text(server.name), _safe_runtime_text(exc))
 
     # ── Prompts ────────────────────────────────────────────────────────
     prompts_ok = False
@@ -498,7 +508,7 @@ async def _query_capabilities(
                 result.runtime_prompts.append(runtime_prompt)
             prompts_ok = True
         except Exception as exc:
-            logger.warning("prompts/list failed for %s: %s", server.name, exc)
+            logger.warning("prompts/list failed for %s: %s", _safe_runtime_text(server.name), _safe_runtime_text(exc))
 
     result.success = True
 
@@ -583,7 +593,7 @@ async def introspect_servers(
                 ServerIntrospection(
                     server_name=introspectable[i].name,
                     success=False,
-                    error=str(result),
+                    error=_safe_runtime_text(result),
                 )
             )
         else:

--- a/src/agent_bom/output/console_render.py
+++ b/src/agent_bom/output/console_render.py
@@ -10,6 +10,7 @@ from rich.tree import Tree
 
 from agent_bom.models import AgentStatus, AIBOMReport, BlastRadius, Severity
 from agent_bom.output.compact import _coverage_bar, _pct
+from agent_bom.security import sanitize_command_args
 
 console = Console()
 
@@ -447,9 +448,10 @@ def print_agent_tree(report: AIBOMReport) -> None:
                 elif plevel == "medium":
                     priv_indicator = " [yellow]🛡 elevated[/yellow]"
 
+            server_args = sanitize_command_args(server.args[:2])
             server_branch = agent_tree.add(
                 f"\U0001f50c MCP Server: [bold cyan]{server.name}[/bold cyan] "
-                f"({server.command} {' '.join(server.args[:2])})"
+                f"({server.command} {' '.join(server_args)})"
                 f"{vuln_indicator}{cred_indicator}{priv_indicator}"
             )
 

--- a/src/agent_bom/output/cyclonedx_fmt.py
+++ b/src/agent_bom/output/cyclonedx_fmt.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 
 from agent_bom import __version__
 from agent_bom.models import AIBOMReport
-from agent_bom.security import sanitize_launch_command
+from agent_bom.security import sanitize_launch_command, sanitize_path_label
 
 
 def _sanitize_bom_ref(raw: str) -> str:
@@ -287,7 +287,7 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
                 "description": f"AI Agent ({agent.agent_type.value})",
                 "properties": [
                     {"name": "agent-bom:type", "value": "ai-agent"},
-                    {"name": "agent-bom:config-path", "value": agent.config_path},
+                    {"name": "agent-bom:config-path", "value": sanitize_path_label(agent.config_path) if agent.config_path else ""},
                     {"name": "agent-bom:status", "value": agent.status.value},
                 ],
             }

--- a/src/agent_bom/output/cyclonedx_fmt.py
+++ b/src/agent_bom/output/cyclonedx_fmt.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 
 from agent_bom import __version__
 from agent_bom.models import AIBOMReport
+from agent_bom.security import sanitize_launch_command
 
 
 def _sanitize_bom_ref(raw: str) -> str:
@@ -298,7 +299,7 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
 
             server_props = [
                 {"name": "agent-bom:type", "value": "mcp-server"},
-                {"name": "agent-bom:command", "value": server.command},
+                {"name": "agent-bom:command", "value": sanitize_launch_command(server.command, server.args)},
                 {"name": "agent-bom:transport", "value": server.transport.value},
             ]
             if server.has_credentials:

--- a/src/agent_bom/output/graph.py
+++ b/src/agent_bom/output/graph.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, TypedDict
 
 from agent_bom.graph import SEVERITY_BADGE as _SEVERITY_BADGE
 from agent_bom.graph import SEVERITY_RANK as _SEVERITY_RANK
-from agent_bom.security import sanitize_launch_command
+from agent_bom.security import sanitize_launch_command, sanitize_path_label
 
 if TYPE_CHECKING:
     from agent_bom.models import AIBOMReport, BlastRadius
@@ -167,7 +167,7 @@ def build_graph_elements(
                     "type": "agent",
                     "tip": (f"Agent: {agent.name}\nType: {agent.agent_type.value}\nSource: {source}\nServers: {len(agent.mcp_servers)}"),
                     "agentType": agent.agent_type.value,
-                    "configPath": agent.config_path or "",
+                    "configPath": sanitize_path_label(agent.config_path) if agent.config_path else "",
                     "source": source,
                     "serverCount": len(agent.mcp_servers),
                     "packageCount": agent.total_packages,

--- a/src/agent_bom/output/graph.py
+++ b/src/agent_bom/output/graph.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, TypedDict
 
 from agent_bom.graph import SEVERITY_BADGE as _SEVERITY_BADGE
 from agent_bom.graph import SEVERITY_RANK as _SEVERITY_RANK
+from agent_bom.security import sanitize_launch_command
 
 if TYPE_CHECKING:
     from agent_bom.models import AIBOMReport, BlastRadius
@@ -224,7 +225,7 @@ def build_graph_elements(
                         "label": server_label,
                         "type": stype,
                         "tip": f"MCP Server: {srv.name}{pkg_note}{cinfo}",
-                        "command": ((srv.command or "") + " " + " ".join((srv.args or [])[:3]))[:80].strip(),
+                        "command": sanitize_launch_command(srv.command or "", srv.args or [], max_args=3)[:80],
                         "packageCount": len(srv.packages),
                         "vulnPackageCount": vulnerable_pkg_count,
                         "vulnCount": total_pkg_vulns,

--- a/src/agent_bom/output/html.py
+++ b/src/agent_bom/output/html.py
@@ -21,6 +21,8 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from agent_bom.security import sanitize_launch_command
+
 if TYPE_CHECKING:
     from agent_bom.models import AIBOMReport, BlastRadius
 
@@ -854,8 +856,7 @@ def _inventory_cards(report: "AIBOMReport") -> str:
 
             cmd = ""
             if srv.command:
-                cmd_parts = [srv.command] + srv.args[:3]
-                cmd = _esc(" ".join(cmd_parts))
+                cmd = _esc(sanitize_launch_command(srv.command, srv.args, max_args=3))
                 if srv.args and len(srv.args) > 3:
                     cmd += f' <span style="color:#334155">&hellip;+{len(srv.args) - 3} args</span>'
 

--- a/src/agent_bom/output/html.py
+++ b/src/agent_bom/output/html.py
@@ -21,7 +21,7 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from agent_bom.security import sanitize_launch_command
+from agent_bom.security import sanitize_launch_command, sanitize_path_label
 
 if TYPE_CHECKING:
     from agent_bom.models import AIBOMReport, BlastRadius
@@ -944,7 +944,7 @@ def _inventory_cards(report: "AIBOMReport") -> str:
             f"</summary>"
             f'<div class="agent-detail">'
             f'<div style="font-size:.72rem;color:#475569;margin-bottom:12px">'
-            f"{_esc(agent.agent_type.value)} &middot; {_esc(agent.config_path or '')}"
+            f"{_esc(agent.agent_type.value)} &middot; {_esc(sanitize_path_label(agent.config_path) if agent.config_path else '')}"
             f"</div>"
             f"{servers_content}"
             f"</div>"

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from agent_bom.compliance_utils import effective_blast_radius_tags
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
+from agent_bom.security import sanitize_command_args, sanitize_security_warnings, sanitize_text, sanitize_url
 
 
 def _severity_state(severity: Severity) -> str:
@@ -296,8 +297,8 @@ def _build_inventory_snapshot(report: AIBOMReport) -> dict:
                     "fingerprint": server.fingerprint,
                     "auth_mode": server.auth_mode,
                     "transport": server.transport.value,
-                    "command": server.command,
-                    "url": server.url,
+                    "command": sanitize_text(server.command),
+                    "url": sanitize_url(server.url),
                     "tool_ids": [],
                     "resource_ids": [],
                     "prompt_ids": [],
@@ -542,15 +543,15 @@ def to_json(report: AIBOMReport) -> dict:
                         "surface": server.surface.value,
                         "fingerprint": server.fingerprint,
                         "command": server.command,
-                        "args": server.args,
+                        "args": sanitize_command_args(server.args),
                         "transport": server.transport.value,
-                        "url": server.url,
+                        "url": sanitize_url(server.url),
                         "auth_mode": server.auth_mode,
                         "mcp_version": server.mcp_version,
                         "has_credentials": server.has_credentials,
                         "credential_env_vars": server.credential_names,
                         "security_blocked": server.security_blocked,
-                        "security_warnings": server.security_warnings,
+                        "security_warnings": sanitize_security_warnings(server.security_warnings),
                         "security_intelligence": server.security_intelligence,
                         "discovery_sources": server.discovery_sources,
                         "tools": [

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from agent_bom.compliance_utils import effective_blast_radius_tags
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
-from agent_bom.security import sanitize_command_args, sanitize_security_warnings, sanitize_text, sanitize_url
+from agent_bom.security import sanitize_command_args, sanitize_path_label, sanitize_security_warnings, sanitize_text, sanitize_url
 
 
 def _severity_state(severity: Severity) -> str:
@@ -282,7 +282,7 @@ def _build_inventory_snapshot(report: AIBOMReport) -> dict:
                 "agent_type": agent.agent_type.value,
                 "type": agent.agent_type.value,
                 "status": agent.status.value,
-                "config_path": agent.config_path,
+                "config_path": sanitize_path_label(agent.config_path) if agent.config_path else "",
                 "server_ids": server_ids,
             }
         )
@@ -531,7 +531,7 @@ def to_json(report: AIBOMReport) -> dict:
                 "stable_id": agent.stable_id,
                 "agent_type": agent.agent_type.value,
                 "type": agent.agent_type.value,
-                "config_path": agent.config_path,
+                "config_path": sanitize_path_label(agent.config_path) if agent.config_path else "",
                 "source": agent.source,
                 "status": agent.status.value,
                 "metadata": agent.metadata,

--- a/src/agent_bom/parsers/skill_audit.py
+++ b/src/agent_bom/parsers/skill_audit.py
@@ -22,6 +22,7 @@ from typing import Any, NamedTuple, Optional
 
 from agent_bom.models import TransportType
 from agent_bom.parsers.skills import SkillMetadata, SkillScanResult
+from agent_bom.security import sanitize_url
 
 logger = logging.getLogger(__name__)
 
@@ -1320,7 +1321,7 @@ def _check_server(
                     title=f"External URL on server '{srv.name}'",
                     detail=(
                         f"MCP server config '{srv.name}' (from JSON block in {source_file}) "
-                        f"connects to external URL '{srv.url}'. "
+                        f"connects to external URL '{sanitize_url(srv.url)}'. "
                         "Data sent to this server may leave your network."
                     ),
                     source_file=source_file,

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -639,7 +639,7 @@ async def _proxy_sse_server(
         for alert in alerts:
             alert_dict = alert.to_dict()
             runtime_alerts.append(alert_dict)
-            logger.warning("Runtime alert: %s", alert.message)
+            logger.warning("Runtime alert: %s", alert_dict.get("message", "runtime alert"))
             if log_f:
                 write_audit_record(log_f, alert_dict)
                 log_f.flush()

--- a/src/agent_bom/proxy_audit.py
+++ b/src/agent_bom/proxy_audit.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import IO, Optional
 
 from agent_bom.agent_identity import ANONYMOUS
+from agent_bom.audit_integrity import compute_audit_record_mac
 from agent_bom.event_normalization import build_proxy_event_relationships
 
 logger = logging.getLogger(__name__)
@@ -400,24 +401,26 @@ class ProxyMetricsServer:
 
 def _truncate_args(args: dict, max_value_len: int = 200) -> dict:
     """Truncate long argument values for logging; redact credential keys/values."""
-    from agent_bom.security import sanitize_env_vars
+    from agent_bom.security import sanitize_sensitive_payload
 
-    str_vals = {k: v for k, v in args.items() if isinstance(v, str)}
-    sanitized = sanitize_env_vars(str_vals)
+    sanitized = sanitize_sensitive_payload(args, max_str_len=max_value_len)
+    if not isinstance(sanitized, dict):
+        return {}
 
-    result = {}
-    for key, value in args.items():
-        if isinstance(value, str):
-            san = sanitized.get(key, value)
-            if san == "***REDACTED***":
-                result[key] = san
-            elif len(san) > max_value_len:
-                result[key] = san[:max_value_len] + "...<truncated>"
-            else:
-                result[key] = san
-        else:
-            result[key] = value
-    return result
+    def _mark_truncated(raw_value: object, clean_value: object) -> object:
+        if isinstance(raw_value, str) and isinstance(clean_value, str):
+            if len(raw_value) > max_value_len and "<redacted" not in clean_value.lower() and clean_value != "***REDACTED***":
+                suffix = "... [truncated]"
+                return clean_value[: max(0, max_value_len - len(suffix))] + suffix
+            return clean_value
+        if isinstance(raw_value, dict) and isinstance(clean_value, dict):
+            return {key: _mark_truncated(raw_value.get(key), value) for key, value in clean_value.items()}
+        if isinstance(raw_value, list) and isinstance(clean_value, list):
+            return [_mark_truncated(raw_value[index] if index < len(raw_value) else None, value) for index, value in enumerate(clean_value)]
+        return clean_value
+
+    marked = _mark_truncated(args, sanitized)
+    return marked if isinstance(marked, dict) else sanitized
 
 
 def log_tool_call(
@@ -432,13 +435,14 @@ def log_tool_call(
     tenant_id: str = "default",
 ) -> None:
     """Append a tool call record to the audit JSONL log."""
+    sanitized_arguments = _truncate_args(arguments)
     record: dict = {
         "ts": datetime.now(timezone.utc).isoformat(),
         "type": "tools/call",
         "tool": tool_name,
         "agent_id": agent_id,
         "tenant_id": tenant_id,
-        "args": _truncate_args(arguments),
+        "args": sanitized_arguments,
         "policy": policy_result,
     }
     if reason:
@@ -449,7 +453,7 @@ def log_tool_call(
         record["message_id"] = message_id
     event_relationships = build_proxy_event_relationships(
         tool_name=tool_name,
-        arguments=arguments,
+        arguments=sanitized_arguments,
         agent_id=agent_id,
         anonymous_id=ANONYMOUS,
     )
@@ -500,9 +504,15 @@ def compute_response_hmac(payload: dict, key: str) -> str:
 
 def _record_digest(record: dict) -> str:
     payload = {k: v for k, v in record.items() if k not in {"prev_hash", "record_hash"}}
-    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     prev_hash = str(record.get("prev_hash", ""))
-    return hashlib.sha256(f"{prev_hash}|{canonical}".encode("utf-8")).hexdigest()
+    return compute_audit_record_mac(payload, prev_hash)
+
+
+def _sanitize_audit_record(record: dict) -> dict:
+    from agent_bom.security import sanitize_sensitive_payload
+
+    sanitized = sanitize_sensitive_payload(record)
+    return sanitized if isinstance(sanitized, dict) else {}
 
 
 def _audit_chain_key(log_file: "IO[str] | RotatingAuditLog") -> str:
@@ -524,8 +534,9 @@ def write_audit_record(log_file: "IO[str] | RotatingAuditLog", record: dict) -> 
     log_key = _audit_chain_key(log_file)
     with _AUDIT_CHAIN_LOCK:
         prev_hash = _AUDIT_CHAIN_STATE.get(log_key, "")
-        payload = dict(record)
+        payload = _sanitize_audit_record(record)
         payload["prev_hash"] = prev_hash
+        payload["record_hash_algorithm"] = "aes-cmac-128"
         payload["record_hash"] = _record_digest(payload)
         log_file.write(json.dumps(payload) + "\n")
         _AUDIT_CHAIN_STATE[log_key] = payload["record_hash"]

--- a/src/agent_bom/push.py
+++ b/src/agent_bom/push.py
@@ -18,6 +18,8 @@ import uuid
 
 import httpx
 
+from agent_bom.security import sanitize_command_args, sanitize_env_vars, sanitize_security_warnings, sanitize_text, sanitize_url
+
 logger = logging.getLogger(__name__)
 
 
@@ -87,9 +89,20 @@ def _looks_like_secret(key: str) -> bool:
 
 def _redact_nested_secrets(value):
     if isinstance(value, dict):
-        redacted = {}
+        redacted: dict[object, object] = {}
         for key, child in value.items():
-            if _looks_like_secret(str(key)) and isinstance(child, (str, int, float, bool)):
+            key_text = str(key)
+            if key_text == "args" and isinstance(child, list):
+                redacted[key] = sanitize_command_args(child)
+            elif key_text == "command" and isinstance(child, str):
+                redacted[key] = sanitize_text(child, max_len=200)
+            elif key_text == "url" and isinstance(child, str):
+                redacted[key] = sanitize_url(child)
+            elif key_text == "env" and isinstance(child, dict):
+                redacted[key] = sanitize_env_vars(child)
+            elif key_text == "security_warnings" and isinstance(child, list):
+                redacted[key] = sanitize_security_warnings(child)
+            elif _looks_like_secret(key_text) and isinstance(child, (str, int, float, bool)):
                 redacted[key] = "***REDACTED***"
             else:
                 redacted[key] = _redact_nested_secrets(child)

--- a/src/agent_bom/push.py
+++ b/src/agent_bom/push.py
@@ -166,10 +166,12 @@ async def _push_async(
             try:
                 resp = await client.post(push_url, json=sanitized, headers=headers)
             except (httpx.HTTPError, ValueError, OSError) as exc:
-                last_error = f"{type(exc).__name__}: {exc}"
+                from agent_bom.security import sanitize_error
+
+                last_error = f"{type(exc).__name__}: {sanitize_error(exc)}"
                 logger.warning(
                     "Push to %s attempt %d/%d failed with %s",
-                    push_url,
+                    sanitize_url(push_url),
                     attempt,
                     max_attempts,
                     last_error,
@@ -179,7 +181,7 @@ async def _push_async(
                 if resp.status_code < 300:
                     logger.info(
                         "Results pushed to %s (status=%d, attempt=%d)",
-                        push_url,
+                        sanitize_url(push_url),
                         resp.status_code,
                         attempt,
                     )
@@ -187,15 +189,15 @@ async def _push_async(
                 if resp.status_code not in retryable_status:
                     logger.warning(
                         "Push to %s rejected with non-retryable status %d — %s",
-                        push_url,
+                        sanitize_url(push_url),
                         resp.status_code,
-                        resp.text[:200],
+                        sanitize_text(resp.text[:200]),
                     )
                     return False
-                last_error = resp.text[:200]
+                last_error = sanitize_text(resp.text[:200])
                 logger.warning(
                     "Push to %s attempt %d/%d returned retryable status %d",
-                    push_url,
+                    sanitize_url(push_url),
                     attempt,
                     max_attempts,
                     resp.status_code,

--- a/src/agent_bom/runtime/detectors.py
+++ b/src/agent_bom/runtime/detectors.py
@@ -36,6 +36,7 @@ from agent_bom.runtime.patterns import (
 from agent_bom.runtime.patterns import (
     PII_PATTERNS as _PII_PATTERNS,
 )
+from agent_bom.security import sanitize_sensitive_payload, sanitize_text
 
 
 class AlertSeverity(str, Enum):
@@ -60,10 +61,10 @@ class Alert:
         return {
             "type": "runtime_alert",
             "ts": self.timestamp,
-            "detector": self.detector,
+            "detector": sanitize_text(self.detector, max_len=100),
             "severity": self.severity.value,
-            "message": self.message,
-            "details": self.details,
+            "message": sanitize_text(self.message, max_len=500),
+            "details": sanitize_sensitive_payload(self.details),
         }
 
 
@@ -269,7 +270,7 @@ class ArgumentAnalyzer:
                                 "tool": tool_name,
                                 "argument": arg_name,
                                 "pattern": pattern_name,
-                                "value_preview": arg_value[:100],
+                                "value_preview": sanitize_sensitive_payload(arg_value[:100], key=arg_name),
                             },
                         )
                     )

--- a/src/agent_bom/runtime/protection.py
+++ b/src/agent_bom/runtime/protection.py
@@ -37,6 +37,7 @@ from agent_bom.runtime.detectors import (
     ToolDriftDetector,
     VectorDBInjectionDetector,
 )
+from agent_bom.security import sanitize_sensitive_payload, sanitize_text
 
 logger = logging.getLogger(__name__)
 
@@ -150,11 +151,11 @@ class RuntimeSessionNode:
 
     def to_dict(self) -> dict[str, object]:
         return {
-            "id": self.id,
-            "kind": self.kind,
-            "label": self.label,
+            "id": sanitize_text(self.id, max_len=300),
+            "kind": sanitize_text(self.kind, max_len=100),
+            "label": sanitize_text(self.label, max_len=300),
             "first_seen": self.first_seen,
-            "metadata": self.metadata,
+            "metadata": sanitize_sensitive_payload(self.metadata),
         }
 
 
@@ -170,11 +171,11 @@ class RuntimeSessionEdge:
 
     def to_dict(self) -> dict[str, object]:
         return {
-            "source": self.source,
-            "target": self.target,
-            "relation": self.relation,
+            "source": sanitize_text(self.source, max_len=300),
+            "target": sanitize_text(self.target, max_len=300),
+            "relation": sanitize_text(self.relation, max_len=100),
             "timestamp": self.timestamp,
-            "metadata": self.metadata,
+            "metadata": sanitize_sensitive_payload(self.metadata),
         }
 
 
@@ -221,10 +222,10 @@ class RuntimeSessionGraph:
                 timeline.append(
                     {
                         "timestamp": node.first_seen,
-                        "kind": node.kind,
-                        "id": node.id,
-                        "label": node.label,
-                        "metadata": node.metadata,
+                        "kind": sanitize_text(node.kind, max_len=100),
+                        "id": sanitize_text(node.id, max_len=300),
+                        "label": sanitize_text(node.label, max_len=300),
+                        "metadata": sanitize_sensitive_payload(node.metadata),
                     }
                 )
         for edge in self.edges:
@@ -232,10 +233,10 @@ class RuntimeSessionGraph:
                 {
                     "timestamp": edge.timestamp,
                     "kind": "interaction",
-                    "source": edge.source,
-                    "target": edge.target,
-                    "relation": edge.relation,
-                    "metadata": edge.metadata,
+                    "source": sanitize_text(edge.source, max_len=300),
+                    "target": sanitize_text(edge.target, max_len=300),
+                    "relation": sanitize_text(edge.relation, max_len=100),
+                    "metadata": sanitize_sensitive_payload(edge.metadata),
                 }
             )
         timeline.sort(key=lambda item: str(item.get("timestamp", "")))
@@ -472,7 +473,7 @@ class ProtectionEngine:
             call_key,
             "tool_call",
             tool_name,
-            metadata={"arguments": arguments, "agent_id": agent_id or ""},
+            metadata={"arguments": sanitize_sensitive_payload(arguments), "agent_id": agent_id or ""},
         )
         self._session_graph.add_edge(agent_key, call_key, "invokes")
         self._session_graph.add_edge(call_key, tool_key, "targets")
@@ -485,7 +486,7 @@ class ProtectionEngine:
             response_key,
             "tool_response",
             tool_name,
-            metadata={"preview": response_text[:200], "length": len(response_text)},
+            metadata={"preview": sanitize_sensitive_payload(response_text[:200], key="response_preview"), "length": len(response_text)},
         )
         self._session_graph.add_edge(tool_key, response_key, "returns")
 

--- a/src/agent_bom/security.py
+++ b/src/agent_bom/security.py
@@ -379,6 +379,68 @@ def sanitize_security_warnings(values: list[Any] | tuple[Any, ...]) -> list[str]
     return [sanitize_text(value) for value in values if str(value or "").strip()]
 
 
+def _key_looks_sensitive(key: object) -> bool:
+    return any(re.search(pattern, str(key).lower()) for pattern in SENSITIVE_PATTERNS)
+
+
+def _key_looks_like_url(key: object) -> bool:
+    key_text = str(key).lower()
+    return key_text in {"url", "uri", "endpoint", "webhook"} or key_text.endswith(("_url", "_uri", "_endpoint", "_webhook"))
+
+
+def _key_looks_like_path(key: object) -> bool:
+    key_text = str(key).lower()
+    path_terms = ("path", "file", "dir", "directory", "cwd", "workspace", "config_path", "source_path")
+    return any(term in key_text for term in path_terms)
+
+
+def _looks_like_path_value(value: str) -> bool:
+    if not value or "://" in value:
+        return False
+    return value.startswith("/") or value.startswith("~/") or bool(re.match(r"^[A-Za-z]:[\\/]", value))
+
+
+def sanitize_path_label(value: object) -> str:
+    """Return a non-revealing label for local filesystem paths."""
+    text = sanitize_log_label(value, max_len=1000)
+    basename = re.split(r"[\\/]+", text.rstrip("/\\"))[-1] if text else ""
+    basename = sanitize_text(basename or "path", max_len=80)
+    if not basename or _key_looks_sensitive(basename) or _looks_sensitive_value(basename):
+        basename = "path"
+    return f"<path:{basename}>"
+
+
+def sanitize_sensitive_payload(value: object, *, key: object | None = None, max_str_len: int = 1000, depth: int = 0) -> object:
+    """Recursively redact sensitive runtime/audit payloads before persistence/export."""
+    if depth >= 8:
+        return "[truncated]"
+    if value is None or isinstance(value, bool | int | float):
+        return value
+    if isinstance(value, str):
+        if key is not None and _key_looks_sensitive(key):
+            return "***REDACTED***"
+        if key is not None and _key_looks_like_url(key):
+            return sanitize_url(value)
+        if "://" in value:
+            return sanitize_text(value, max_len=max_str_len)
+        if key is not None and _key_looks_like_path(key) and _looks_like_path_value(value):
+            return sanitize_path_label(value)
+        if _looks_like_path_value(value):
+            return sanitize_path_label(value)
+        if _looks_sensitive_value(value):
+            return "***REDACTED***"
+        return sanitize_text(value, max_len=max_str_len)
+    if isinstance(value, dict):
+        sanitized: dict[str, object] = {}
+        for raw_key, raw_value in value.items():
+            clean_key = sanitize_text(raw_key, max_len=200)
+            sanitized[clean_key] = sanitize_sensitive_payload(raw_value, key=clean_key, max_str_len=max_str_len, depth=depth + 1)
+        return sanitized
+    if isinstance(value, list | tuple | set):
+        return [sanitize_sensitive_payload(item, key=key, max_str_len=max_str_len, depth=depth + 1) for item in list(value)]
+    return sanitize_text(value, max_len=max_str_len)
+
+
 def validate_file_size(path: Path, max_size_bytes: int = 10 * 1024 * 1024) -> None:
     """
     Validate that a file is not too large (DoS prevention).
@@ -658,6 +720,8 @@ __all__ = [
     "sanitize_command_args",
     "sanitize_launch_command",
     "sanitize_security_warnings",
+    "sanitize_sensitive_payload",
+    "sanitize_path_label",
     "sanitize_text",
     "sanitize_url",
     "validate_file_size",

--- a/src/agent_bom/security.py
+++ b/src/agent_bom/security.py
@@ -11,6 +11,7 @@ import re
 from collections import Counter
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 logger = logging.getLogger(__name__)
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
@@ -294,6 +295,90 @@ def sanitize_env_vars(env: dict[str, Any]) -> dict[str, str]:
     return sanitized
 
 
+def sanitize_url(value: str | None) -> str | None:
+    """Strip credentials, query strings, and fragments from display/export URLs."""
+    if value is None:
+        return None
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return "<redacted-url>"
+    if not parsed.scheme or not parsed.netloc:
+        return value
+    host = parsed.hostname or parsed.netloc.rsplit("@", 1)[-1]
+    if parsed.port:
+        host = f"{host}:{parsed.port}"
+    return urlunsplit((parsed.scheme, host, parsed.path, "", ""))
+
+
+def sanitize_text(value: object, max_len: int = 1000) -> str:
+    """Redact credential-shaped substrings and credential-bearing URLs in text."""
+    text = sanitize_log_label(value, max_len=max_len)
+    text = re.sub(r"https?://[^\s\"'<>]+", lambda match: str(sanitize_url(match.group(0)) or ""), text)
+    for pattern in _VALUE_CREDENTIAL_PATTERNS:
+        text = pattern.sub("<redacted>", text)
+    return text[:max_len]
+
+
+def _looks_sensitive_value(value: str) -> bool:
+    return sanitize_env_vars({"ARG": value}).get("ARG") == "***REDACTED***"
+
+
+def sanitize_command_args(args: list[Any] | tuple[Any, ...]) -> list[str]:
+    """Redact secret-bearing command arguments while preserving launch shape."""
+    sanitized: list[str] = []
+    redact_next = False
+    for raw_arg in args:
+        arg = str(raw_arg)
+        if redact_next:
+            sanitized.append("<redacted>")
+            redact_next = False
+            continue
+
+        if "=" in arg:
+            key, _sep, raw_value = arg.partition("=")
+            if any(re.search(pattern, key.lower()) for pattern in SENSITIVE_PATTERNS):
+                sanitized.append(f"{key}=<redacted>")
+                continue
+            if "://" in raw_value:
+                sanitized.append(f"{key}={sanitize_url(raw_value)}")
+                continue
+            if _looks_sensitive_value(raw_value):
+                sanitized.append(f"{key}=<redacted>")
+                continue
+
+        if "://" in arg:
+            sanitized.append(str(sanitize_url(arg) or ""))
+            continue
+
+        if _looks_sensitive_value(arg):
+            sanitized.append("<redacted>")
+            continue
+
+        if arg.startswith("-") and any(re.search(pattern, arg.lower()) for pattern in SENSITIVE_PATTERNS):
+            sanitized.append(arg)
+            redact_next = True
+            continue
+
+        sanitized.append(arg)
+    return sanitized
+
+
+def sanitize_launch_command(command: object, args: list[Any] | tuple[Any, ...] | None = None, *, max_args: int | None = None) -> str:
+    """Return a safe command label for display/export surfaces."""
+    safe_command = sanitize_text(command, max_len=200)
+    raw_args = list(args or [])
+    if max_args is not None:
+        raw_args = raw_args[:max_args]
+    safe_args = sanitize_command_args(raw_args)
+    return " ".join([part for part in [safe_command, *safe_args] if part]).strip()
+
+
+def sanitize_security_warnings(values: list[Any] | tuple[Any, ...]) -> list[str]:
+    """Redact warning text before persistence or UI/API export."""
+    return [sanitize_text(value) for value in values if str(value or "").strip()]
+
+
 def validate_file_size(path: Path, max_size_bytes: int = 10 * 1024 * 1024) -> None:
     """
     Validate that a file is not too large (DoS prevention).
@@ -520,7 +605,7 @@ def validate_mcp_server_config(server_config: dict) -> None:
         raise SecurityError("Server env must be a dictionary")
     validate_environment(env)
 
-    logger.info(f"MCP server config validated: {command or server_config.get('url', 'unknown')}")
+    logger.info("MCP server config validated: %s", sanitize_text(command or server_config.get("url", "unknown")))
 
 
 # Docker/OCI image reference pattern — must start with alphanum, no shell metacharacters
@@ -570,6 +655,11 @@ __all__ = [
     "validate_environment",
     "validate_path",
     "sanitize_env_vars",
+    "sanitize_command_args",
+    "sanitize_launch_command",
+    "sanitize_security_warnings",
+    "sanitize_text",
+    "sanitize_url",
     "validate_file_size",
     "validate_json_file",
     "validate_url",

--- a/src/agent_bom/skills_service.py
+++ b/src/agent_bom/skills_service.py
@@ -14,6 +14,7 @@ from agent_bom.integrity import verify_instruction_file
 from agent_bom.parsers.skill_audit import SkillAuditResult, audit_skill_result
 from agent_bom.parsers.skills import SkillScanResult, discover_skill_files, parse_skill_file
 from agent_bom.parsers.trust_assessment import TrustAssessmentResult, assess_trust
+from agent_bom.security import sanitize_command_args
 from agent_bom.skill_bundles import SkillBundle, build_skill_bundle
 from agent_bom.skill_intel import ThreatIntelResult, ThreatIntelStatus, lookup_bundle_threat_intel
 from agent_bom.skills_catalog import catalog_scan_timestamp, load_skills_catalog, save_skills_catalog
@@ -62,7 +63,7 @@ class SkillFileReport:
                 {
                     "name": server.name,
                     "command": server.command,
-                    "args": list(server.args),
+                    "args": sanitize_command_args(server.args),
                     "transport": server.transport.value,
                 }
                 for server in self.scan.servers

--- a/tests/test_agent_identity.py
+++ b/tests/test_agent_identity.py
@@ -265,3 +265,31 @@ def test_log_tool_call_blocked_carries_agent_id():
     assert record["agent_id"] == "bad-bot"
     assert record["policy"] == "blocked"
     assert record["event_relationships"]["actor"]["id"] == "bad-bot"
+
+
+def test_log_tool_call_redacts_nested_arguments_and_relationships():
+    buf = io.StringIO()
+    token = "ghp_" + "abcdefghijklmnopqrstuvwxyz" + "123456"
+    api_key = "sk-" + "live-" + "abcdefghijklmnopqrstuvwxyz"
+    log_tool_call(
+        buf,
+        "fetch",
+        {
+            "url": f"https://user:pass@example.com/callback?token={token}",
+            "body": {"api_key": api_key},
+            "path": "/Users/alice/prod-secrets/openai-key.env",
+        },
+        agent_id="agent-eve",
+    )
+
+    raw = buf.getvalue()
+    record = json.loads(raw)
+    encoded = json.dumps(record)
+    assert "user:pass" not in encoded
+    assert token not in encoded
+    assert "sk-live" not in encoded
+    assert "/Users/alice" not in encoded
+    assert "prod-secrets" not in encoded
+    assert "token=" not in encoded
+    assert record["args"]["url"] == "https://example.com/callback"
+    assert record["event_relationships"]["resources"][0]["id"] == "https://example.com/callback"

--- a/tests/test_ai_enrich.py
+++ b/tests/test_ai_enrich.py
@@ -1176,6 +1176,20 @@ def test_build_mcp_config_analysis_prompt():
     assert "auth_missing" in prompt
 
 
+def test_build_mcp_config_analysis_prompt_redacts_command_args():
+    """Prompt should not send raw token-bearing launch args to an LLM provider."""
+    from agent_bom.ai_enrich import _build_mcp_config_analysis_prompt
+
+    raw_token = "ghp_" + "A" * 36
+    server = MCPServer(name="sensitive", command="npx", args=["server", "--token", raw_token])
+    agent = Agent(name="agent", agent_type=AgentType.CUSTOM, config_path="/tmp/agent.json", mcp_servers=[server])
+
+    prompt = _build_mcp_config_analysis_prompt(AIBOMReport(agents=[agent]))
+
+    assert raw_token not in prompt
+    assert "--token <redacted>" in prompt
+
+
 @pytest.mark.asyncio
 async def test_analyze_mcp_config_security_with_mock():
     """Should return structured analysis when LLM returns valid JSON."""

--- a/tests/test_alert_dispatcher.py
+++ b/tests/test_alert_dispatcher.py
@@ -151,7 +151,7 @@ def test_dispatcher_dispatch_alert_object():
     assert stored["detector"] == "test"
     assert stored["severity"] == "high"
     assert stored["event_relationships"]["targets"][0]["id"] == "read_file"
-    assert stored["event_relationships"]["resources"][0]["id"] == "/tmp/example.txt"
+    assert stored["event_relationships"]["resources"][0]["id"] == "<path:example.txt>"
 
 
 def test_dispatcher_dispatch_runtime_dict_adds_relationships():
@@ -171,7 +171,7 @@ def test_dispatcher_dispatch_runtime_dict_adds_relationships():
     stored = d.list_alerts()[0]
     assert stored["event_relationships"]["actor"]["id"] == "agent-1"
     assert stored["event_relationships"]["targets"][0]["id"] == "exec"
-    assert stored["event_relationships"]["resources"][0]["id"] == "/etc/passwd"
+    assert stored["event_relationships"]["resources"][0]["id"] == "<path:passwd>"
 
 
 def test_dispatcher_add_webhook(monkeypatch):

--- a/tests/test_api_agent_detail.py
+++ b/tests/test_api_agent_detail.py
@@ -22,7 +22,7 @@ def _mock_agents():
         args=["-y", "test-server"],
         env={"API_KEY": "sk-test", "DEBUG": "1"},
         transport=TransportType.SSE,
-        url="https://mcp.example.internal/sse",
+        url="https://user:pass@mcp.example.internal/sse?token=raw-secret#frag",
         packages=[
             Package(name="express", version="4.18.2", ecosystem="npm"),
         ],
@@ -102,7 +102,7 @@ def _mock_observation_store() -> InMemoryMCPObservationStore:
             server_name="test-server",
             agent_name="test-agent",
             transport="sse",
-            url="https://mcp.example.internal/sse",
+            url="https://user:pass@mcp.example.internal/sse?token=raw-secret#frag",
             auth_mode="env-credentials",
             command="npx",
             args=["-y", "test-server"],
@@ -285,6 +285,11 @@ def test_agent_detail_exposes_server_provenance(_fleet, _mock):
         assert resp.status_code == 200
         server = resp.json()["agent"]["mcp_servers"][0]
         assert server["security_blocked"] is True
+        assert server["url"] == "https://mcp.example.internal/sse"
+        assert server["env"]["API_KEY"] == "***REDACTED***"
+        assert "sk-test" not in str(server)
+        assert "raw-secret" not in str(server)
+        assert "user:pass" not in str(server)
         assert server["security_intelligence"][0]["entry_id"] == "intel-a"
         assert "raw-secret" not in server["security_intelligence"][0]["matched_value"]
         assert server["security_intelligence"][0]["references"] == ["https://example.com/advisory"]

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -252,7 +252,8 @@ def test_create_scan_with_options():
     assert resp.status_code == 202
     body = resp.json()
     assert body["triggered_by"] == "api"
-    assert body["request"]["inventory"] == "/tmp/agents.json"
+    assert body["request"]["inventory"] == "<path:agents.json>"
+    assert "/tmp" not in body["request"]["inventory"]
     assert body["request"]["enrich"] is True
     assert body["request"]["format"] == "cyclonedx"
 

--- a/tests/test_api_proxy_scorecard.py
+++ b/tests/test_api_proxy_scorecard.py
@@ -217,6 +217,36 @@ def test_proxy_audit_ingest_updates_alerts_and_status():
     proxy_mod._proxy_metrics = None
 
 
+def test_proxy_alert_api_redacts_runtime_alert_details():
+    import agent_bom.api.routes.proxy as proxy_mod
+
+    proxy_mod._proxy_alerts.clear()
+    github_token = "ghp_" + "abcdefghijklmnopqrstuvwxyz" + "123456"
+    api_key = "sk-" + "live-" + "abcdefghijklmnopqrstuvwxyz"
+    push_proxy_alert(
+        {
+            "type": "runtime_alert",
+            "detector": "argument_analyzer",
+            "severity": "high",
+            "message": "danger",
+            "details": {
+                "url": f"https://user:pass@example.com/callback?token={github_token}",
+                "value_preview": api_key,
+                "path": "/Users/alice/prod-secrets/openai-key.env",
+            },
+        }
+    )
+
+    data = TestClient(app).get("/v1/proxy/alerts").json()
+    encoded = json.dumps(data)
+    assert "user:pass" not in encoded
+    assert "token=" not in encoded
+    assert "sk-live" not in encoded
+    assert "/Users/alice" not in encoded
+    assert "prod-secrets" not in encoded
+    proxy_mod._proxy_alerts.clear()
+
+
 def test_proxy_audit_ingest_is_idempotent():
     import agent_bom.api.routes.proxy as proxy_mod
 

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -381,6 +381,8 @@ async def test_receive_push_normalizes_report_contract_and_persists_graph(tmp_pa
                         {
                             "name": "filesystem",
                             "command": "npx",
+                            "args": ["server", "--token", "ghp_" + "A" * 36],
+                            "url": "https://user:pass@example.com/sse?token=raw-secret#frag",
                             "packages": [
                                 {
                                     "name": "pillow",
@@ -388,7 +390,7 @@ async def test_receive_push_normalizes_report_contract_and_persists_graph(tmp_pa
                                     "version": "9.0.0",
                                 }
                             ],
-                            "env": {"OPENAI_API_KEY": "redacted"},
+                            "env": {"OPENAI_API_KEY": "sk-live-secret-value"},
                         }
                     ],
                 }
@@ -417,6 +419,11 @@ async def test_receive_push_normalizes_report_contract_and_persists_graph(tmp_pa
     assert pushed_job.result["blast_radii"][0]["vulnerability_id"] == "CVE-2026-0001"
     assert pushed_job.result["agents"][0]["type"] == "claude-desktop"
     assert pushed_job.result["agents"][0]["agent_type"] == "claude-desktop"
+    pushed_server = pushed_job.result["agents"][0]["mcp_servers"][0]
+    assert pushed_server["args"] == ["server", "--token", "<redacted>"]
+    assert pushed_server["url"] == "https://example.com/sse"
+    assert pushed_server["env"]["OPENAI_API_KEY"] == "***REDACTED***"
+    assert "raw-secret" not in str(pushed_job.result)
 
     graph_store = SQLiteGraphStore(tmp_path / "graph.db")
     snapshots = graph_store.list_snapshots(tenant_id="tenant-alpha")

--- a/tests/test_audit_replay.py
+++ b/tests/test_audit_replay.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import tempfile
 from pathlib import Path
 
+from agent_bom.audit_integrity import compute_audit_record_mac
 from agent_bom.audit_replay import (
     AlertEntry,
     AuditLog,
@@ -42,8 +42,9 @@ def _chained(entries: list[dict]) -> list[dict]:
     for entry in entries:
         payload = dict(entry)
         payload["prev_hash"] = prev_hash
-        canonical = json.dumps(entry, sort_keys=True, separators=(",", ":"))
-        payload["record_hash"] = hashlib.sha256(f"{prev_hash}|{canonical}".encode("utf-8")).hexdigest()
+        payload["record_hash_algorithm"] = "aes-cmac-128"
+        digest_payload = {k: v for k, v in payload.items() if k not in {"prev_hash", "record_hash"}}
+        payload["record_hash"] = compute_audit_record_mac(digest_payload, prev_hash)
         prev_hash = payload["record_hash"]
         chained.append(payload)
     return chained

--- a/tests/test_audit_round2.py
+++ b/tests/test_audit_round2.py
@@ -8,6 +8,30 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+
+def test_audit_details_redact_nested_secrets_and_urls():
+    from agent_bom.api.audit_log import sanitize_audit_details
+
+    github_token = "ghp_" + "abcdefghijklmnopqrstuvwxyz" + "123456"
+    api_key = "sk-" + "live-" + "abcdefghijklmnopqrstuvwxyz"
+    details = sanitize_audit_details(
+        {
+            "url": f"https://user:pass@siem.example/ingest?token={github_token}",
+            "token": api_key,
+            "nested": {"path": "/Users/alice/prod-secrets/openai-key.env"},
+        }
+    )
+
+    encoded = str(details)
+    assert "user:pass" not in encoded
+    assert "token=" not in encoded
+    assert "sk-live" not in encoded
+    assert "/Users/alice" not in encoded
+    assert "prod-secrets" not in encoded
+    assert details["url"] == "https://siem.example/ingest"
+    assert details["token"] == "***REDACTED***"
+
+
 # ── Content-Length validation ────────────────────────────────────────────────
 
 

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -118,6 +118,29 @@ class TestBuildUnifiedGraphFromReport:
         providers = g.nodes_by_type(EntityType.PROVIDER)
         assert len(providers) == 1
         assert providers[0].label == "local"
+
+    def test_server_launch_attributes_are_redacted(self):
+        token = "ghp_" + "A" * 36
+        report = _minimal_report()
+        server = report["agents"][0]["mcp_servers"][0]
+        server["url"] = f"https://user:pass@example.com/sse?token={token}"
+        server["command"] = f"npx {token}"
+        server["security_warnings"] = [f"token {token}"]
+        server["security_intelligence"] = [
+            {
+                "entry_id": "intel",
+                "matched_value": f"server --token {token}",
+                "references": ["javascript:alert(1)", "https://example.com/advisory#frag"],
+            }
+        ]
+
+        g = build_unified_graph_from_report(report)
+        node = next(n for n in g.nodes_by_type(EntityType.SERVER) if n.label == "mcp-fs")
+
+        assert token not in str(node.attributes)
+        assert node.attributes["url"] == "https://example.com/sse"
+        assert node.attributes["security_warnings"] == ["token <redacted>"]
+        assert node.attributes["security_intelligence"][0]["references"] == ["https://example.com/advisory"]
         assert g.has_edge("provider:local", "agent:claude-desktop")
 
     def test_cloud_origin_metadata_becomes_lineage_nodes(self):

--- a/tests/test_mcp_blocklist.py
+++ b/tests/test_mcp_blocklist.py
@@ -116,10 +116,18 @@ def test_json_output_includes_mcp_blocklist_findings() -> None:
 
 
 def test_match_values_are_redacted_before_output() -> None:
+    raw_token = "ghp_" + "A" * 36
     server = MCPServer(
         name="runner",
         command="npx",
-        args=["credential-stealer", "--api-key", "sk-live-secret", "url=https://user:pass@example.com/path?token=secret"],
+        args=[
+            "credential-stealer",
+            "--api-key",
+            "sk-live-secret",
+            raw_token,
+            "session=" + raw_token,
+            "url=https://user:pass@example.com/path?token=secret",
+        ],
     )
     blocklist = {
         "entries": [
@@ -139,11 +147,21 @@ def test_match_values_are_redacted_before_output() -> None:
     }
 
     match = match_mcp_server(server, blocklist)[0]
+    agent = _agent_with_server(server)
+    findings = blocklist_findings_for_agents([agent], blocklist)
+    json_payload = json.dumps(to_json(AIBOMReport(agents=[agent], findings=findings)))
+    sarif_payload = json.dumps(to_sarif(AIBOMReport(agents=[agent], findings=findings)))
 
     assert "sk-live-secret" not in match.matched_value
+    assert raw_token not in match.matched_value
     assert "user:pass" not in match.matched_value
     assert "token=secret" not in match.matched_value
     assert "--api-key <redacted>" in match.matched_value
+    for payload in (json_payload, sarif_payload):
+        assert "sk-live-secret" not in payload
+        assert raw_token not in payload
+        assert "user:pass" not in payload
+        assert "token=secret" not in payload
 
 
 def test_sarif_output_includes_mcp_blocklist_findings() -> None:

--- a/tests/test_mcp_introspect.py
+++ b/tests/test_mcp_introspect.py
@@ -46,6 +46,25 @@ def test_server_introspection_with_drift():
     assert result.has_drift
 
 
+def test_server_introspection_to_dict_redacts_runtime_text():
+    from agent_bom.mcp_introspect import ServerIntrospection
+
+    github_token = "ghp_" + "abcdefghijklmnopqrstuvwxyz" + "123456"
+    api_key = "sk-" + "live-" + "abcdefghijklmnopqrstuvwxyz"
+    result = ServerIntrospection(
+        server_name=f"https://user:pass@example.com/sse?token={github_token}",
+        success=False,
+        error=f"failed with {api_key} at /Users/alice/prod-secrets/openai-key.env",
+    )
+
+    encoded = str(result.to_dict())
+    assert "user:pass" not in encoded
+    assert "token=" not in encoded
+    assert "sk-live" not in encoded
+    assert "/Users/alice" not in encoded
+    assert "prod-secrets" not in encoded
+
+
 def test_server_introspection_with_tools():
     from agent_bom.mcp_introspect import ServerIntrospection, _apply_runtime_risk
 

--- a/tests/test_mcp_observation_store.py
+++ b/tests/test_mcp_observation_store.py
@@ -78,12 +78,16 @@ def test_observation_sanitizes_security_intelligence() -> None:
                 "references": ["https://example.com/advisory#fragment", "javascript:alert(1)"],
             }
         ],
+        args=["bad", "--token", "raw-secret"],
+        url="https://user:pass@example.com/sse?token=raw-secret#frag",
     )
 
     intel = observation.security_intelligence[0]
     assert "raw-secret" not in str(intel["matched_value"])
     assert "user:pass" not in str(intel["matched_value"])
     assert intel["references"] == ["https://example.com/advisory"]
+    assert observation.args == ["bad", "--token", "<redacted>"]
+    assert observation.url == "https://example.com/sse"
 
 
 def test_inmemory_store_revalidates_observation_before_write() -> None:

--- a/tests/test_output_cov.py
+++ b/tests/test_output_cov.py
@@ -399,6 +399,20 @@ class TestToCyclonedx:
         # Vulnerabilities may be in a nested structure depending on CycloneDX version
         assert len(cdx["components"]) >= 1
 
+    def test_mcp_command_property_redacts_args(self):
+        token = "ghp_" + "A" * 36
+        server = _make_server()
+        server.args = ["server", "--token", token]
+        agent = _make_agent(servers=[server])
+
+        cdx = to_cyclonedx(_make_report(agents=[agent]))
+        payload = str(cdx)
+
+        assert token not in payload
+        server_component = next(component for component in cdx["components"] if component["name"] == server.name)
+        command_prop = next(prop for prop in server_component["properties"] if prop["name"] == "agent-bom:command")
+        assert command_prop["value"] == "npx server --token <redacted>"
+
 
 # ── to_spdx ──────────────────────────────────────────────────────────────────
 
@@ -408,6 +422,24 @@ class TestToSpdx:
         report = _make_report()
         spdx = to_spdx(report)
         assert spdx["spdxVersion"] == "SPDX-3.0"
+
+
+def test_json_output_redacts_server_launch_fields():
+    token = "ghp_" + "A" * 36
+    server = _make_server()
+    server.args = ["server", "--token", token]
+    server.url = f"https://user:pass@example.com/sse?token={token}"
+    server.env = {"API_KEY": token}
+    server.security_warnings = [f"token {token}"]
+    agent = _make_agent(servers=[server])
+
+    payload = to_json(_make_report(agents=[agent]))
+    server_payload = payload["agents"][0]["mcp_servers"][0]
+
+    assert token not in str(payload)
+    assert server_payload["args"] == ["server", "--token", "<redacted>"]
+    assert server_payload["url"] == "https://example.com/sse"
+    assert server_payload["security_warnings"] == ["token <redacted>"]
 
     def test_with_agents_and_vulns(self):
         pkg = _make_pkg()

--- a/tests/test_protection_engine.py
+++ b/tests/test_protection_engine.py
@@ -77,6 +77,31 @@ def test_process_tool_call_clean():
     assert status["tool_calls_analyzed"] == 1
 
 
+def test_session_graph_redacts_runtime_arguments_and_responses():
+    engine = ProtectionEngine()
+    engine.start()
+    github_token = "ghp_" + "abcdefghijklmnopqrstuvwxyz" + "123456"
+    api_key = "sk-" + "live-" + "abcdefghijklmnopqrstuvwxyz"
+    _run(
+        engine.process_tool_call(
+            "fetch",
+            {
+                "url": f"https://user:pass@example.com/callback?token={github_token}",
+                "path": "/Users/alice/prod-secrets/openai-key.env",
+            },
+        )
+    )
+    _run(engine.process_tool_response("fetch", f"model returned {api_key} in text"))
+
+    encoded = str(engine.status()["session_graph"])
+    assert "user:pass" not in encoded
+    assert "token=" not in encoded
+    assert "ghp_" not in encoded
+    assert "sk-live" not in encoded
+    assert "/Users/alice" not in encoded
+    assert "prod-secrets" not in encoded
+
+
 def test_process_tool_call_dangerous_args():
     """Shell injection patterns should trigger alerts."""
     engine = ProtectionEngine()

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -56,6 +56,33 @@ def test_audit_chain_uses_path_key_across_reopened_handles(tmp_path):
     assert len(_AUDIT_CHAIN_STATE) == 1
 
 
+def test_write_audit_record_sanitizes_generic_records():
+    token = "ghp_" + "abcdefghijklmnopqrstuvwxyz" + "123456"
+    buf = io.StringIO()
+
+    payload = write_audit_record(
+        buf,
+        {
+            "type": "runtime_alert",
+            "details": {
+                "password": "secret-value",
+                "url": f"https://user:pass@example.com/callback?token={token}",
+                "path": "/Users/alice/private/key.txt",
+            },
+        },
+    )
+
+    encoded = json.dumps(payload)
+    assert "secret-value" not in encoded
+    assert "user:pass" not in encoded
+    assert token not in encoded
+    assert "/Users/alice" not in encoded
+    assert payload["details"]["password"] == "***REDACTED***"
+    assert payload["details"]["url"] == "https://example.com/callback"
+    assert payload["details"]["path"] == "<path:key.txt>"
+    assert payload["record_hash_algorithm"] == "aes-cmac-128"
+
+
 @pytest.mark.asyncio
 async def test_read_bounded_line_discards_oversized_line_and_resyncs():
     reader = asyncio.StreamReader(limit=32)
@@ -69,8 +96,10 @@ async def test_read_bounded_line_discards_oversized_line_and_resyncs():
 
 @pytest.fixture(autouse=True)
 def _reset_policy_cache_signer():
+    _AUDIT_CHAIN_STATE.clear()
     _reset_gateway_policy_cache_signer_for_tests()
     yield
+    _AUDIT_CHAIN_STATE.clear()
     _reset_gateway_policy_cache_signer_for_tests()
 
 
@@ -142,9 +171,10 @@ def test_log_tool_call():
     assert record["tool"] == "read_file"
     assert record["policy"] == "allowed"
     assert "ts" in record
-    assert record["args"]["path"] == "/etc/hosts"
+    assert record["args"]["path"] == "<path:hosts>"
     assert record["prev_hash"] == ""
-    assert len(record["record_hash"]) == 64
+    assert record["record_hash_algorithm"] == "aes-cmac-128"
+    assert len(record["record_hash"]) == 32
 
 
 # ── check_policy ─────────────────────────────────────────────────────────────

--- a/tests/test_proxy_helpers.py
+++ b/tests/test_proxy_helpers.py
@@ -184,7 +184,7 @@ def test_log_tool_call_basic():
     assert record["tenant_id"] == "default"
     assert record["event_relationships"]["source"] == "proxy_tool_call"
     assert record["event_relationships"]["targets"][0]["id"] == "read_file"
-    assert record["event_relationships"]["resources"][0]["id"] == "/tmp"
+    assert record["event_relationships"]["resources"][0]["id"] == "<path:tmp>"
 
 
 def test_log_tool_call_blocked():

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -97,6 +97,35 @@ class TestSanitizeResults:
         assert meta["tools"][0]["auth_token"] == "***REDACTED***"
         assert meta["tools"][0]["name"] == "search"
 
+    def test_redacts_mcp_launch_fields(self):
+        token = "ghp_" + "A" * 36
+        results = {
+            "agents": [
+                {
+                    "name": "agent-1",
+                    "mcp_servers": [
+                        {
+                            "name": "srv",
+                            "command": "npx",
+                            "args": ["server", "--token", token],
+                            "url": f"https://user:pass@example.com/sse?token={token}",
+                            "env": {"API_KEY": token, "DEBUG": "1"},
+                            "security_warnings": [f"token {token}"],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        sanitized = sanitize_results(results)
+        payload = sanitized["agents"][0]["mcp_servers"][0]
+
+        assert token not in str(sanitized)
+        assert payload["args"] == ["server", "--token", "<redacted>"]
+        assert payload["url"] == "https://example.com/sse"
+        assert payload["env"] == {"API_KEY": "***REDACTED***", "DEBUG": "1"}
+        assert payload["security_warnings"] == ["token <redacted>"]
+
     def test_adds_source_id(self):
         results = {"agents": []}
         sanitized = sanitize_results(results)

--- a/tests/test_runtime_detectors.py
+++ b/tests/test_runtime_detectors.py
@@ -30,6 +30,28 @@ def test_alert_to_dict():
     assert "ts" in d
 
 
+def test_alert_to_dict_redacts_sensitive_details():
+    github_token = "ghp_" + "abcdefghijklmnopqrstuvwxyz" + "123456"
+    api_key = "sk-" + "live-" + "abcdefghijklmnopqrstuvwxyz"
+    alert = Alert(
+        detector="argument_analyzer",
+        severity=AlertSeverity.HIGH,
+        message="Dangerous argument",
+        details={
+            "url": f"https://user:pass@example.com/callback?token={github_token}",
+            "value_preview": api_key,
+            "path": "/Users/alice/prod-secrets/openai-key.env",
+        },
+    )
+
+    encoded = str(alert.to_dict())
+    assert "user:pass" not in encoded
+    assert "token=" not in encoded
+    assert "sk-live" not in encoded
+    assert "/Users/alice" not in encoded
+    assert "prod-secrets" not in encoded
+
+
 def test_alert_severity_enum():
     assert AlertSeverity.CRITICAL.value == "critical"
     assert AlertSeverity.INFO.value == "info"

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -372,6 +372,38 @@ def test_sanitize_error_string():
     assert "error message" in result
 
 
+def test_sanitize_sensitive_payload_redacts_nested_runtime_values():
+    from agent_bom.security import sanitize_sensitive_payload
+
+    github_token = "ghp_" + "abcdefghijklmnopqrstuvwxyz" + "123456"
+    api_key = "sk-" + "live-" + "abcdefghijklmnopqrstuvwxyz"
+    slack_token = "xoxb-" + "1234567890-" + "abcdefghijklmnop"
+    payload = {
+        "url": f"https://alice:secret@example.com/callback?token={github_token}",
+        "body": {"api_key": api_key},
+        "path": "/Users/alice/prod-secrets/openai-key.env",
+        "items": [slack_token],
+    }
+
+    result = sanitize_sensitive_payload(payload)
+    encoded = str(result)
+    assert "alice:secret" not in encoded
+    assert "token=" not in encoded
+    assert "sk-live" not in encoded
+    assert "xoxb-" not in encoded
+    assert "/Users/alice" not in encoded
+    assert "prod-secrets" not in encoded
+    assert "<path:" in encoded
+
+
+def test_sanitize_sensitive_payload_preserves_safe_shape():
+    from agent_bom.security import sanitize_sensitive_payload
+
+    result = sanitize_sensitive_payload({"package": "express", "version": "4.18.2", "count": 2})
+
+    assert result == {"package": "express", "version": "4.18.2", "count": 2}
+
+
 # ---------------------------------------------------------------------------
 # create_safe_subprocess_env
 # ---------------------------------------------------------------------------

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -12,9 +12,11 @@ from agent_bom.security import (
     _is_obfuscated_credential,
     _shannon_entropy,
     create_safe_subprocess_env,
+    sanitize_command_args,
     sanitize_env_vars,
     sanitize_error,
     sanitize_log_label,
+    sanitize_url,
     validate_arguments,
     validate_command,
     validate_environment,
@@ -186,6 +188,33 @@ def test_sanitize_env_vars_safe():
     result = sanitize_env_vars({"HOME": "/home/user", "LANG": "en_US.UTF-8"})
     assert result["HOME"] == "/home/user"
     assert result["LANG"] == "en_US.UTF-8"
+
+
+def test_sanitize_command_args_redacts_secret_values_and_urls():
+    github_token = "ghp_" + "A" * 36
+    result = sanitize_command_args(
+        [
+            "server",
+            "--api-key",
+            "sk-live-secret",
+            github_token,
+            "session=" + github_token,
+            "callback=https://user:pass@example.com/path?token=secret",
+        ]
+    )
+
+    assert result == [
+        "server",
+        "--api-key",
+        "<redacted>",
+        "<redacted>",
+        "session=<redacted>",
+        "callback=https://example.com/path",
+    ]
+
+
+def test_sanitize_url_strips_credentials_query_and_fragment():
+    assert sanitize_url("https://user:pass@example.com/path?token=secret#frag") == "https://example.com/path"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_skills_service.py
+++ b/tests/test_skills_service.py
@@ -52,6 +52,29 @@ def test_scan_skill_targets_records_catalog_and_intel(tmp_path):
     assert payload["generated_at"].endswith("Z")
 
 
+def test_scan_skill_targets_redacts_server_args_in_output(tmp_path):
+    raw_token = "ghp_" + "A" * 36
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text(
+        "# Skill\n\n"
+        "```json\n"
+        "{\n"
+        '  "mcpServers": {\n'
+        '    "sensitive": {\n'
+        '      "command": "npx",\n'
+        f'      "args": ["server", "--token", "{raw_token}"]\n'
+        "    }\n"
+        "  }\n"
+        "}\n"
+        "```\n"
+    )
+
+    payload = scan_skill_targets([skill_file]).to_dict()
+
+    assert raw_token not in json.dumps(payload)
+    assert payload["files"][0]["servers"][0]["args"] == ["server", "--token", "<redacted>"]
+
+
 def test_rescan_skill_catalog_marks_missing_entries_unavailable(tmp_path):
     """Rescanning a catalog should mark missing paths as unavailable."""
     skill_file = tmp_path / "CLAUDE.md"

--- a/ui/app/agents/page.tsx
+++ b/ui/app/agents/page.tsx
@@ -133,6 +133,29 @@ function safeReferenceHref(reference: string): string | null {
   }
 }
 
+function safeDisplayUrl(value: string | undefined): string {
+  if (!value) return "";
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:" ? `${url.protocol}//${url.host}${url.pathname}` : value;
+  } catch {
+    return value;
+  }
+}
+
+function safeCommandLine(command: string | undefined, args: string[] | undefined): string {
+  return [command, ...(args ?? [])]
+    .filter((part): part is string => Boolean(part))
+    .map((part) => (/(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{30,}|(?:sk|pk|rk)[-_](?:live|test|prod)[-_]\w{10,}/i.test(part) ? "<redacted>" : part))
+    .join(" ");
+}
+
+function safeDisplayText(value: string): string {
+  return value
+    .replace(/https?:\/\/[^\s"'<>]+/g, (match) => safeDisplayUrl(match))
+    .replace(/(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{30,}|(?:sk|pk|rk)[-_](?:live|test|prod)[-_]\w{10,}/gi, "<redacted>");
+}
+
 // ─── Agents List View ───────────────────────────────────────────────────────
 
 function AgentsList() {
@@ -784,7 +807,7 @@ function AgentDetail({ agentName }: { agentName: string }) {
                               Command
                             </div>
                             <div className="font-mono text-xs text-zinc-300 break-all">
-                              {[srv.command, ...(srv.args || [])].join(" ")}
+                              {safeCommandLine(srv.command, srv.args)}
                             </div>
                           </div>
                         )}
@@ -794,7 +817,7 @@ function AgentDetail({ agentName }: { agentName: string }) {
                               <Link2 className="h-3.5 w-3.5" />
                               Remote URL
                             </div>
-                            <div className="font-mono text-xs text-zinc-300 break-all">{srv.url}</div>
+                            <div className="font-mono text-xs text-zinc-300 break-all">{safeDisplayUrl(srv.url)}</div>
                           </div>
                         )}
                       </div>
@@ -864,7 +887,7 @@ function AgentDetail({ agentName }: { agentName: string }) {
                           <div className="space-y-1">
                             {srv.security_warnings?.map((warning) => (
                               <div key={warning} className="rounded border border-rose-900/60 bg-rose-950/20 px-3 py-2 text-xs text-rose-300">
-                                {warning}
+                                {safeDisplayText(warning)}
                               </div>
                             ))}
                           </div>

--- a/ui/lib/unified-graph-flow.ts
+++ b/ui/lib/unified-graph-flow.ts
@@ -28,6 +28,15 @@ export interface UnifiedGraphFlowSummary {
   runtimeEdges: number;
 }
 
+function safeGraphConnection(value: string): string {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:" ? `${url.protocol}//${url.host}${url.pathname}` : value;
+  } catch {
+    return value.replace(/(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{30,}|(?:sk|pk|rk)[-_](?:live|test|prod)[-_]\w{10,}/gi, "<redacted>");
+  }
+}
+
 export interface UnifiedGraphFlowResult {
   nodes: Node<LineageNodeData>[];
   edges: Edge[];
@@ -316,7 +325,7 @@ function toLineageData(
       data.serverCount = countReachableTypes(node.id, outgoing, nodeById, new Set([EntityType.SERVER]), 4);
       break;
     case "server":
-      data.command = stringAttr(node, "command") || stringAttr(node, "transport") || stringAttr(node, "url");
+      data.command = safeGraphConnection(stringAttr(node, "command") || stringAttr(node, "transport") || stringAttr(node, "url"));
       data.toolCount = countOutgoing(node.id, outgoing, RelationshipType.PROVIDES_TOOL);
       data.credentialCount = countOutgoing(node.id, outgoing, RelationshipType.EXPOSES_CRED);
       data.packageCount = countOutgoing(node.id, outgoing, RelationshipType.DEPENDS_ON);


### PR DESCRIPTION
Summary
- add shared sanitizers for MCP launch args, command labels, URLs, warning text, and persisted observation fields
- redact launch metadata across JSON/API job results, push/fleet ingestion, graph attributes, SARIF/finding locations, HTML/graph/CycloneDX exports, AI prompts, skill scan output, and agent UI fallback rendering
- keep useful operator context: command/package/server identity, arg shape, credential env var names, sanitized remote host/path, warnings, and attack path remain visible without raw tokens or embedded URL credentials
- remove hardcoded Jupyter API-key prefix disclosure from warnings

Why
This turns the trust-boundary rule into implementation: agent-bom should show teams what agent/server/config produced a finding and what attack path matters, but should not persist, export, display, or send raw launch tokens, URL credentials, env values, or matched secret-like values.

Validation
- pytest tests/test_mcp_blocklist.py::test_match_values_are_redacted_before_output tests/test_mcp_observation_store.py::test_observation_sanitizes_security_intelligence tests/test_api_agent_detail.py::test_agent_detail_exposes_server_provenance tests/test_security.py::test_sanitize_command_args_redacts_secret_values_and_urls tests/test_security.py::test_sanitize_url_strips_credentials_query_and_fragment tests/test_ai_enrich.py::test_build_mcp_config_analysis_prompt_redacts_command_args tests/test_skills_service.py::test_scan_skill_targets_redacts_server_args_in_output tests/test_push.py::TestSanitizeResults::test_redacts_mcp_launch_fields tests/test_graph_builder.py::TestBuildUnifiedGraphFromReport::test_server_launch_attributes_are_redacted tests/test_output_cov.py::TestToCyclonedx::test_mcp_command_property_redacts_args tests/test_output_cov.py::test_json_output_redacts_server_launch_fields tests/test_api_tenant_isolation.py::test_receive_push_normalizes_report_contract_and_persists_graph tests/test_jupyter.py::test_scan_hardcoded_key_warning -q
- ruff check changed Python files and tests
- mypy changed Python files
- npm --prefix ui run typecheck
- npm --prefix ui run lint
- git diff --check

Refs #2067