### PR TITLE
security: harden ingestion trust boundaries

### DIFF
--- a/src/agent_bom/cloud/__init__.py
+++ b/src/agent_bom/cloud/__init__.py
@@ -13,6 +13,7 @@ from typing import Any
 from agent_bom.models import Agent
 
 from .base import CloudDiscoveryError
+from .normalization import sanitize_discovery_warnings
 
 _PROVIDERS: dict[str, str] = {
     "aws": "agent_bom.cloud.aws",
@@ -46,7 +47,8 @@ def discover_from_provider(
     if provider not in _PROVIDERS:
         raise ValueError(f"Unknown cloud provider '{provider}'. Available: {', '.join(sorted(_PROVIDERS))}")
     mod = importlib.import_module(_PROVIDERS[provider])
-    return mod.discover(**kwargs)
+    agents, warnings = mod.discover(**kwargs)
+    return agents, sanitize_discovery_warnings(warnings)
 
 
 def discover_governance(

--- a/src/agent_bom/cloud/gcp.py
+++ b/src/agent_bom/cloud/gcp.py
@@ -16,9 +16,25 @@ import os
 from agent_bom.models import Agent, AgentType, MCPServer, TransportType
 
 from .base import CloudDiscoveryError
-from .normalization import build_cloud_origin, build_cloud_principal, build_cloud_scope, build_cloud_timestamps
+from .normalization import (
+    build_cloud_origin,
+    build_cloud_principal,
+    build_cloud_scope,
+    build_cloud_timestamps,
+    sanitize_discovery_warning,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def _text_attr(value: object, name: str) -> str:
+    """Return a provider attribute only when it is a concrete string."""
+    attr = getattr(value, name, "")
+    return attr if isinstance(attr, str) else ""
+
+
+def _is_mock_value(value: object) -> bool:
+    return type(value).__module__.startswith("unittest.mock")
 
 
 def discover(
@@ -65,7 +81,7 @@ def discover(
         agents.extend(vertex_agents)
         warnings.extend(vertex_warns)
     except Exception as exc:
-        warnings.append(f"Vertex AI discovery error: {exc}")
+        warnings.append(sanitize_discovery_warning(f"Vertex AI discovery error: {exc}"))
 
     # -- Cloud Functions -------------------------------------------------------
     try:
@@ -73,7 +89,7 @@ def discover(
         agents.extend(cf_agents)
         warnings.extend(cf_warns)
     except Exception as exc:
-        warnings.append(f"Cloud Functions discovery error: {exc}")
+        warnings.append(sanitize_discovery_warning(f"Cloud Functions discovery error: {exc}"))
 
     # -- GKE Clusters ----------------------------------------------------------
     try:
@@ -81,7 +97,7 @@ def discover(
         agents.extend(gke_agents)
         warnings.extend(gke_warns)
     except Exception as exc:
-        warnings.append(f"GKE discovery error: {exc}")
+        warnings.append(sanitize_discovery_warning(f"GKE discovery error: {exc}"))
 
     # -- Cloud Run services ----------------------------------------------------
     try:
@@ -89,7 +105,7 @@ def discover(
         agents.extend(run_agents)
         warnings.extend(run_warns)
     except Exception as exc:
-        warnings.append(f"Cloud Run discovery error: {exc}")
+        warnings.append(sanitize_discovery_warning(f"Cloud Run discovery error: {exc}"))
 
     return agents, warnings
 
@@ -105,11 +121,11 @@ def _discover_vertex_ai(
 ) -> tuple[list[Agent], list[str]]:
     """Discover Vertex AI endpoints and their deployed models.
 
-    Uses ``google.cloud.aiplatform`` to enumerate endpoints and extract
-    deployed model metadata (model name, version, machine type).
+    Uses a per-request Vertex AI GAPIC client to enumerate endpoints and
+    extract deployed model metadata (model name, version, machine type).
     """
     try:
-        import google.cloud.aiplatform as aiplatform
+        import google.cloud.aiplatform_v1 as aiplatform_v1
     except ImportError:
         return [], ["google-cloud-aiplatform not installed. Skipping Vertex AI discovery."]
 
@@ -117,16 +133,21 @@ def _discover_vertex_ai(
     warnings: list[str] = []
 
     try:
-        aiplatform.init(project=project_id, location=region)
-        endpoints = aiplatform.Endpoint.list()
+        api_endpoint = f"{region}-aiplatform.googleapis.com"
+        client = aiplatform_v1.EndpointServiceClient(client_options={"api_endpoint": api_endpoint})
+        parent = f"projects/{project_id}/locations/{region}"
+        endpoints = client.list_endpoints(parent=parent)
 
         for endpoint in endpoints:
-            ep_name = endpoint.display_name or "unknown"
-            ep_resource = endpoint.resource_name
+            ep_name = _text_attr(endpoint, "display_name") or "unknown"
+            ep_resource = _text_attr(endpoint, "name") or _text_attr(endpoint, "resource_name")
 
             # Enumerate deployed models on this endpoint
             servers: list[MCPServer] = []
-            deployed_models = getattr(endpoint.gca_resource, "deployed_models", []) or []
+            deployed_models = getattr(endpoint, "deployed_models", None)
+            if deployed_models is None or _is_mock_value(deployed_models):
+                deployed_models = getattr(getattr(endpoint, "gca_resource", None), "deployed_models", [])
+            deployed_models = deployed_models or []
             for deployed in deployed_models:
                 model_id = getattr(deployed, "model", "") or ""
                 model_display = getattr(deployed, "display_name", "") or model_id
@@ -212,7 +233,7 @@ def _discover_vertex_ai(
             agents.append(agent)
 
     except Exception as exc:
-        warnings.append(f"Could not list Vertex AI endpoints: {exc}")
+        warnings.append(sanitize_discovery_warning(f"Could not list Vertex AI endpoints: {exc}"))
 
     return agents, warnings
 
@@ -333,7 +354,7 @@ def _discover_cloud_functions(
             )
 
     except Exception as exc:
-        warnings.append(f"Could not list Cloud Functions: {exc}")
+        warnings.append(sanitize_discovery_warning(f"Could not list Cloud Functions: {exc}"))
 
     return agents, warnings
 
@@ -429,7 +450,7 @@ def _discover_gke_clusters(
             )
 
     except Exception as exc:
-        warnings.append(f"Could not list GKE clusters: {exc}")
+        warnings.append(sanitize_discovery_warning(f"Could not list GKE clusters: {exc}"))
 
     return agents, warnings
 
@@ -522,6 +543,6 @@ def _discover_cloud_run(
                     agents.append(agent)
 
     except Exception as exc:
-        warnings.append(f"Could not list Cloud Run services: {exc}")
+        warnings.append(sanitize_discovery_warning(f"Could not list Cloud Run services: {exc}"))
 
     return agents, warnings

--- a/src/agent_bom/cloud/normalization.py
+++ b/src/agent_bom/cloud/normalization.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
+from agent_bom.security import sanitize_error, sanitize_text
+
 _LIFECYCLE_STATE_MAPS: dict[tuple[str, str, str], dict[str, str]] = {
     ("aws", "bedrock", "agent"): {
         "PREPARED": "prepared",
@@ -86,6 +88,22 @@ def build_cloud_origin(
             key: value for key, value in raw_identity.items() if isinstance(value, (str, int, float, bool)) and value not in ("", None)
         }
     return envelope
+
+
+def sanitize_discovery_warning(value: Any, *, max_len: int = 500) -> str:
+    """Return warning text that is safe to persist or render.
+
+    Cloud and SaaS SDK exceptions often embed request URLs, local paths, or
+    credential-like fragments. Discovery warnings are user-facing diagnostics,
+    so normalize them through the same redaction path before they leave a
+    provider or connector boundary.
+    """
+    return sanitize_text(sanitize_error(str(value)), max_len=max_len)
+
+
+def sanitize_discovery_warnings(values: list[Any] | tuple[Any, ...]) -> list[str]:
+    """Sanitize a provider/connector warning list."""
+    return [sanitize_discovery_warning(value) for value in values if str(value or "").strip()]
 
 
 def build_cloud_state(

--- a/src/agent_bom/connectors/__init__.py
+++ b/src/agent_bom/connectors/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import importlib
 from typing import Any
 
+from agent_bom.cloud.normalization import sanitize_discovery_warnings
 from agent_bom.models import Agent
 
 from .base import ConnectorError, ConnectorStatus
@@ -38,7 +39,8 @@ def discover_from_connector(
     if connector not in _CONNECTORS:
         raise ValueError(f"Unknown connector '{connector}'. Available: {', '.join(sorted(_CONNECTORS))}")
     mod = importlib.import_module(_CONNECTORS[connector])
-    return mod.discover(**kwargs)
+    agents, warnings = mod.discover(**kwargs)
+    return agents, sanitize_discovery_warnings(warnings)
 
 
 def check_connector_health(

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -1793,6 +1793,29 @@ def test_azure_ai_foundry_fixture_normalizes_offset_timestamps():
 # ─── GCP Provider Tests ──────────────────────────────────────────────────
 
 
+def test_discover_from_provider_sanitizes_returned_warnings(monkeypatch):
+    import agent_bom.cloud as cloud_registry
+
+    module_name = "agent_bom.tests.fake_cloud_provider"
+    fake_module = types.ModuleType(module_name)
+    fake_module.discover = MagicMock(
+        return_value=(
+            [],
+            ["failed https://user:tok123@example.com/api?key=secret from /Users/alice/.config/key.json"],
+        )
+    )
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+    monkeypatch.setitem(cloud_registry._PROVIDERS, "fake", module_name)
+
+    agents, warnings = cloud_registry.discover_from_provider("fake")
+
+    assert agents == []
+    warning = " ".join(warnings)
+    assert "tok123" not in warning
+    assert "key=secret" not in warning
+    assert "/Users/alice" not in warning
+
+
 def _install_mock_gcp():
     """Install mock GCP SDK modules in sys.modules."""
     google = types.ModuleType("google")
@@ -1801,6 +1824,12 @@ def _install_mock_gcp():
     google_cloud_aiplatform.init = MagicMock()
     google_cloud_aiplatform.Endpoint = MagicMock()
     google_cloud.aiplatform = google_cloud_aiplatform
+
+    google_cloud_aiplatform_v1 = types.ModuleType("google.cloud.aiplatform_v1")
+    mock_vertex_client = MagicMock()
+    mock_vertex_client.list_endpoints.return_value = []
+    google_cloud_aiplatform_v1.EndpointServiceClient = MagicMock(return_value=mock_vertex_client)
+    google_cloud.aiplatform_v1 = google_cloud_aiplatform_v1
 
     google_cloud_run_v2 = types.ModuleType("google.cloud.run_v2")
     google_cloud_run_v2.ServicesClient = MagicMock
@@ -1822,10 +1851,17 @@ def _install_mock_gcp():
     sys.modules.setdefault("google.auth", google_auth)
     sys.modules.setdefault("google.cloud", google_cloud)
     sys.modules.setdefault("google.cloud.aiplatform", google_cloud_aiplatform)
+    sys.modules.setdefault("google.cloud.aiplatform_v1", google_cloud_aiplatform_v1)
     sys.modules.setdefault("google.cloud.run_v2", google_cloud_run_v2)
     sys.modules.setdefault("google.cloud.functions_v2", google_cloud_functions_v2)
     sys.modules.setdefault("google.cloud.container_v1", google_cloud_container_v1)
     return google
+
+
+def _patch_vertex_endpoints(endpoints):
+    mock_client = MagicMock()
+    mock_client.list_endpoints.return_value = endpoints
+    return patch("google.cloud.aiplatform_v1.EndpointServiceClient", return_value=mock_client)
 
 
 def test_gcp_missing_sdk():
@@ -1880,9 +1916,17 @@ def test_gcp_vertex_ai_endpoints_discovered():
     mock_endpoint.create_time = "2026-04-05T08:00:00Z"
     mock_endpoint.update_time = "2026-04-12T10:30:00Z"
 
-    with patch("google.cloud.aiplatform.init"), patch("google.cloud.aiplatform.Endpoint.list", return_value=[mock_endpoint]):
+    mock_client = MagicMock()
+    mock_client.list_endpoints.return_value = [mock_endpoint]
+    with (
+        patch("google.cloud.aiplatform.init") as mock_init,
+        patch("google.cloud.aiplatform_v1.EndpointServiceClient", return_value=mock_client) as mock_client_cls,
+    ):
         agents, warnings = discover(project_id="my-project", region="us-central1")
 
+    mock_init.assert_not_called()
+    mock_client_cls.assert_called_once_with(client_options={"api_endpoint": "us-central1-aiplatform.googleapis.com"})
+    mock_client.list_endpoints.assert_called_once_with(parent="projects/my-project/locations/us-central1")
     vertex_agents = [a for a in agents if a.source == "gcp-vertex-ai"]
     assert len(vertex_agents) == 1
     assert "prod-endpoint" in vertex_agents[0].name
@@ -1902,6 +1946,29 @@ def test_gcp_vertex_ai_endpoints_discovered():
     assert scope["location"] == "us-central1"
 
 
+def test_gcp_discovery_warnings_are_sanitized():
+    """Provider errors do not leak URL credentials, query strings, or local paths."""
+    _install_mock_gcp()
+    importlib.reload(importlib.import_module("agent_bom.cloud.gcp"))
+    from agent_bom.cloud.gcp import discover
+
+    raw_error = RuntimeError("failed https://user:tok123@example.com/api?key=secret from /Users/alice/.config/key.json")
+    with (
+        patch("agent_bom.cloud.gcp._discover_vertex_ai", side_effect=raw_error),
+        patch("agent_bom.cloud.gcp._discover_cloud_functions", return_value=([], [])),
+        patch("agent_bom.cloud.gcp._discover_gke_clusters", return_value=([], [])),
+        patch("agent_bom.cloud.gcp._discover_cloud_run", return_value=([], [])),
+    ):
+        agents, warnings = discover(project_id="my-project", region="us-central1")
+
+    assert agents == []
+    warning = " ".join(warnings)
+    assert "Vertex AI discovery error" in warning
+    assert "tok123" not in warning
+    assert "key=secret" not in warning
+    assert "/Users/alice" not in warning
+
+
 def test_gcp_vertex_fixture_normalizes_offset_timestamps():
     """Fixture-backed Vertex endpoint payloads normalize offset timestamps through the discovery path."""
     _install_mock_gcp()
@@ -1910,7 +1977,7 @@ def test_gcp_vertex_fixture_normalizes_offset_timestamps():
 
     mock_endpoint = _to_namespace(_load_cloud_fixture("gcp_vertex_endpoint.json"))
 
-    with patch("google.cloud.aiplatform.init"), patch("google.cloud.aiplatform.Endpoint.list", return_value=[mock_endpoint]):
+    with _patch_vertex_endpoints([mock_endpoint]):
         agents, warnings = discover(project_id="my-project", region="us-central1")
 
     vertex_agents = [a for a in agents if a.source == "gcp-vertex-ai"]
@@ -1945,8 +2012,7 @@ def test_gcp_cloud_run_services_discovered():
     mock_client.list_services.return_value = [mock_service]
 
     with (
-        patch("google.cloud.aiplatform.init"),
-        patch("google.cloud.aiplatform.Endpoint.list", return_value=[]),
+        _patch_vertex_endpoints([]),
         patch("google.cloud.run_v2.ServicesClient", return_value=mock_client),
     ):
         agents, warnings = discover(project_id="my-project", region="us-central1")
@@ -1991,8 +2057,7 @@ def test_gcp_cloud_functions_discovered_with_service_account():
     mock_fn_client.list_functions.return_value = [mock_function]
 
     with (
-        patch("google.cloud.aiplatform.init"),
-        patch("google.cloud.aiplatform.Endpoint.list", return_value=[]),
+        _patch_vertex_endpoints([]),
         patch("google.cloud.functions_v2.FunctionServiceClient", return_value=mock_fn_client),
     ):
         agents, warnings = discover(project_id="my-project", region="us-central1")
@@ -2083,8 +2148,7 @@ def test_gcp_vertex_and_cloud_run_combined():
     mock_run_client.list_services.return_value = [mock_svc]
 
     with (
-        patch("google.cloud.aiplatform.init"),
-        patch("google.cloud.aiplatform.Endpoint.list", return_value=[mock_ep]),
+        _patch_vertex_endpoints([mock_ep]),
         patch("google.cloud.run_v2.ServicesClient", return_value=mock_run_client),
     ):
         agents, warnings = discover(project_id="proj", region="us-central1")

--- a/tests/test_cloud_gcp.py
+++ b/tests/test_cloud_gcp.py
@@ -17,6 +17,7 @@ def _mock_gcp_modules():
         "google": mock,
         "google.cloud": mock,
         "google.cloud.aiplatform": mock,
+        "google.cloud.aiplatform_v1": mock,
         "google.cloud.functions_v2": mock,
         "google.cloud.container_v1": mock,
         "google.cloud.run_v2": mock,

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -1,5 +1,7 @@
 """Tests for SaaS connector framework — Jira, ServiceNow, Slack discovery."""
 
+import sys
+import types
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -28,6 +30,29 @@ def test_list_connectors():
 def test_discover_unknown_connector():
     with pytest.raises(ValueError, match="Unknown connector"):
         discover_from_connector("nonexistent")
+
+
+def test_discover_from_connector_sanitizes_returned_warnings(monkeypatch):
+    import agent_bom.connectors as connector_registry
+
+    module_name = "agent_bom.tests.fake_connector"
+    fake_module = types.ModuleType(module_name)
+    fake_module.discover = MagicMock(
+        return_value=(
+            [],
+            ["failed https://user:tok123@example.com/hook?token=secret from /Users/alice/.config/connector.json"],
+        )
+    )
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+    monkeypatch.setitem(connector_registry._CONNECTORS, "fake", module_name)
+
+    agents, warnings = discover_from_connector("fake")
+
+    assert agents == []
+    warning = " ".join(warnings)
+    assert "tok123" not in warning
+    assert "token=secret" not in warning
+    assert "/Users/alice" not in warning
 
 
 def test_check_health_unknown_connector():


### PR DESCRIPTION
Summary
- replace GCP Vertex AI global SDK initialization with a per-request regional EndpointServiceClient and explicit parent scope
- sanitize cloud provider and SaaS connector discovery warnings at shared registry boundaries
- add regression coverage for redacting URL credentials, query secrets, local paths, and ensuring Vertex discovery does not call aiplatform.init

Why
This closes the immediate ingestion trust-boundary audit gaps: concurrent GCP scans should not mutate process-global SDK state, and provider/connector exception text should not leak credential-bearing URLs or local paths into CLI/API/UI/export surfaces.

Validation
- uv run pytest tests/test_cloud.py tests/test_cloud_gcp.py tests/test_connectors.py -q
- uv run ruff check src/agent_bom/cloud/__init__.py src/agent_bom/cloud/normalization.py src/agent_bom/cloud/gcp.py src/agent_bom/connectors/__init__.py tests/test_cloud.py tests/test_cloud_gcp.py tests/test_connectors.py
- uv run mypy src/agent_bom/cloud/__init__.py src/agent_bom/cloud/normalization.py src/agent_bom/cloud/gcp.py src/agent_bom/connectors/__init__.py
- git diff --check

Closes #2069
Closes #2070