### PR TITLE
feat: preserve reachability finding context

### DIFF
--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -6,6 +6,7 @@ Later phases will add cloud CIS, proxy alerts, SAST, and skill findings.
 
 from __future__ import annotations
 
+import re
 import uuid
 from dataclasses import dataclass, field
 from enum import Enum
@@ -231,6 +232,97 @@ class Finding:
         }
 
 
+def _package_occurrence_evidence(occurrence: object) -> dict[str, object]:
+    """Return layer/package provenance in a stable dict shape."""
+    if hasattr(occurrence, "to_dict"):
+        raw = occurrence.to_dict()
+        if isinstance(raw, dict):
+            return raw
+    return {
+        "layer_index": getattr(occurrence, "layer_index", None),
+        "layer_id": getattr(occurrence, "layer_id", None),
+        "layer_path": getattr(occurrence, "layer_path", None),
+        "package_path": getattr(occurrence, "package_path", None),
+        "created_by": getattr(occurrence, "created_by", None),
+        "dockerfile_instruction": getattr(occurrence, "dockerfile_instruction", None),
+    }
+
+
+def _evidence_payload(value: object) -> object:
+    """Normalize common model objects before recursive evidence sanitization."""
+    if isinstance(value, dict):
+        return {str(key): _evidence_payload(child) for key, child in value.items()}
+    if isinstance(value, list | tuple | set):
+        return [_evidence_payload(item) for item in value]
+    if hasattr(value, "to_dict"):
+        raw = value.to_dict()
+        if isinstance(raw, dict):
+            return _evidence_payload(raw)
+    if hasattr(value, "name"):
+        payload: dict[str, object] = {"name": getattr(value, "name", None)}
+        for attr in ("version", "ecosystem", "hop", "id", "transport", "url", "command", "args"):
+            if hasattr(value, attr):
+                payload[attr] = getattr(value, attr)
+        return payload
+    return value
+
+
+def _evidence_key_looks_sensitive(key: object | None) -> bool:
+    if key is None:
+        return False
+    from agent_bom.security import SENSITIVE_PATTERNS
+
+    return any(re.search(pattern, str(key).lower()) for pattern in SENSITIVE_PATTERNS)
+
+
+def _evidence_key_looks_like_url(key: object | None) -> bool:
+    if key is None:
+        return False
+    key_text = str(key).lower()
+    return key_text in {"url", "uri", "endpoint", "webhook"} or key_text.endswith(("_url", "_uri", "_endpoint", "_webhook"))
+
+
+def _evidence_key_looks_like_path(key: object | None) -> bool:
+    if key is None:
+        return False
+    key_text = str(key).lower()
+    return (
+        "path" in key_text
+        or key_text in {"cwd", "workspace", "dir", "directory"}
+        or key_text.endswith(("_dir", "_directory", "_cwd", "_workspace"))
+    )
+
+
+def _sanitized_evidence_value(value: object, *, key: object | None = None, depth: int = 0) -> object:
+    from agent_bom.security import sanitize_path_label, sanitize_sensitive_payload, sanitize_text, sanitize_url
+
+    if depth >= 8:
+        return "[truncated]"
+    if value is None or isinstance(value, bool | int | float):
+        return value
+    if isinstance(value, str):
+        if _evidence_key_looks_sensitive(key):
+            return "***REDACTED***"
+        if _evidence_key_looks_like_url(key):
+            return sanitize_url(value)
+        if _evidence_key_looks_like_path(key):
+            return sanitize_path_label(value)
+        return sanitize_text(value)
+    if isinstance(value, dict):
+        sanitized: dict[str, object] = {}
+        for raw_key, raw_value in value.items():
+            clean_key = sanitize_text(raw_key, max_len=200)
+            sanitized[clean_key] = _sanitized_evidence_value(raw_value, key=clean_key, depth=depth + 1)
+        return sanitized
+    if isinstance(value, list | tuple | set):
+        return [_sanitized_evidence_value(item, key=key, depth=depth + 1) for item in list(value)]
+    return sanitize_sensitive_payload(value)
+
+
+def _sanitized_evidence_field(value: object) -> object:
+    return _sanitized_evidence_value(_evidence_payload(value))
+
+
 def blast_radius_to_finding(br: object) -> "Finding":
     """Convert a BlastRadius instance to a unified Finding.
 
@@ -268,12 +360,28 @@ def blast_radius_to_finding(br: object) -> "Finding":
         "package_name": pkg.name,
         "package_version": pkg.version,
         "ecosystem": pkg.ecosystem,
+        "package_is_direct": pkg.is_direct,
+        "package_parent": pkg.parent_package,
+        "package_dependency_depth": pkg.dependency_depth,
+        "package_dependency_scope": pkg.dependency_scope,
+        "package_reachability_evidence": pkg.reachability_evidence,
         "affected_server_count": len(br.affected_servers),
         "exposed_credential_count": len(br.exposed_credentials),
         "exposed_tool_count": len(br.exposed_tools),
+        "hop_depth": getattr(br, "hop_depth", 1),
+        "delegation_chain": _sanitized_evidence_field(getattr(br, "delegation_chain", [])),
+        "transitive_agents": _sanitized_evidence_field(getattr(br, "transitive_agents", [])),
+        "transitive_servers": _sanitized_evidence_field(getattr(br, "transitive_servers", [])),
+        "transitive_packages": _sanitized_evidence_field(getattr(br, "transitive_packages", [])),
+        "transitive_credential_count": len(getattr(br, "transitive_credentials", []) or []),
+        "transitive_risk_score": getattr(br, "transitive_risk_score", 0.0),
+        "graph_reachable": getattr(br, "graph_reachable", None),
+        "graph_min_hop_distance": getattr(br, "graph_min_hop_distance", None),
+        "graph_reachable_from_agents": _sanitized_evidence_field(getattr(br, "graph_reachable_from_agents", [])),
+        "layer_attribution": _sanitized_evidence_field([_package_occurrence_evidence(occ) for occ in br.layer_attribution]),
     }
     if vuln.references:
-        evidence["references"] = vuln.references[:5]
+        evidence["references"] = _sanitized_evidence_field(vuln.references[:5])
 
     sev = vuln.severity.value if hasattr(vuln.severity, "value") else str(vuln.severity)
 

--- a/tests/test_finding.py
+++ b/tests/test_finding.py
@@ -1,5 +1,7 @@
 """Tests for the unified Finding model (issue #566, Phase 1)."""
 
+import json
+
 import pytest
 
 from agent_bom.finding import (
@@ -14,6 +16,7 @@ from agent_bom.models import (
     BlastRadius,
     MCPServer,
     Package,
+    PackageOccurrence,
     Severity,
     TransportType,
     Vulnerability,
@@ -296,6 +299,111 @@ def test_blast_radius_to_finding_evidence_has_package_info():
     assert finding.evidence["package_name"] == "requests"
     assert finding.evidence["package_version"] == "2.0.0"
     assert finding.evidence["exposed_credential_count"] == 1
+
+
+def test_blast_radius_to_finding_preserves_sanitized_reachability_evidence():
+    raw_github_token = "ghp_" + "abcdefghijklmnopqrstuvwxyz" + "1234567890"
+    raw_slack_token = "xoxb-" + "1234567890-" + "1234567890-" + "abcdefghijklmnopqrstuv"
+    br = _make_blast_radius()
+    br.hop_depth = 3
+    br.delegation_chain = [f"test-server -> {raw_slack_token} -> delegated-agent"]
+    br.transitive_agents = [
+        {
+            "name": "delegated-agent",
+            "hop": 2,
+            "token": raw_github_token,
+            "config_path": "/Users/alice/.config/agent-bom/private-agent.json",
+        }
+    ]
+    br.transitive_servers = [
+        {
+            "name": "delegated-server",
+            "url": "https://user:" + "password@example.com/mcp?token=raw",
+        }
+    ]
+    br.transitive_packages = [
+        {
+            "name": "transitive-lib",
+            "version": "1.0.0",
+            "download_url": "https://user:" + "password@registry.example.com/transitive-lib.tgz?token=raw",
+        }
+    ]
+    br.transitive_credentials = ["AWS_SECRET_ACCESS_KEY"]
+    br.transitive_risk_score = 4.2
+    br.graph_reachable = True
+    br.graph_min_hop_distance = 2
+    br.graph_reachable_from_agents = ["delegated-agent"]
+
+    finding = blast_radius_to_finding(br)
+
+    assert finding.evidence["hop_depth"] == 3
+    assert finding.evidence["delegation_chain"] == ["test-server -> <redacted> -> delegated-agent"]
+    assert finding.evidence["transitive_agents"][0]["name"] == "delegated-agent"
+    assert finding.evidence["transitive_agents"][0]["hop"] == 2
+    assert finding.evidence["transitive_agents"][0]["token"] == "***REDACTED***"
+    assert finding.evidence["transitive_agents"][0]["config_path"] == "<path:private-agent.json>"
+    assert finding.evidence["transitive_servers"][0]["name"] == "delegated-server"
+    assert finding.evidence["transitive_servers"][0]["url"] == "https://example.com/mcp"
+    assert finding.evidence["transitive_packages"][0]["name"] == "transitive-lib"
+    assert finding.evidence["transitive_packages"][0]["download_url"] == "https://registry.example.com/transitive-lib.tgz"
+    assert finding.evidence["transitive_credential_count"] == 1
+    assert finding.evidence["transitive_risk_score"] == 4.2
+    assert finding.evidence["graph_reachable"] is True
+    assert finding.evidence["graph_min_hop_distance"] == 2
+    assert finding.evidence["graph_reachable_from_agents"] == ["delegated-agent"]
+
+    serialized = json.dumps(finding.evidence, sort_keys=True)
+    assert raw_github_token not in serialized
+    assert raw_slack_token not in serialized
+    assert "user:password" not in serialized
+    assert "/Users/alice/.config/agent-bom/private-agent.json" not in serialized
+
+
+def test_report_to_findings_preserves_sanitized_layer_attribution_evidence():
+    raw_token = "ghp_" + "abcdefghijklmnopqrstuvwxyz" + "1234567890"
+    pkg = _make_package()
+    pkg.is_direct = False
+    pkg.parent_package = "top-level"
+    pkg.dependency_depth = 2
+    pkg.dependency_scope = "runtime"
+    pkg.reachability_evidence = "lockfile"
+    pkg.occurrences = [
+        PackageOccurrence(
+            layer_index=7,
+            layer_id="sha256:layer7",
+            layer_path="/var/lib/docker/overlay2/sensitive-layer",
+            package_path="/Users/alice/work/private/package-lock.json",
+            created_by=f"RUN npm config set //registry.npmjs.org/:_authToken={raw_token}",
+            dockerfile_instruction=f"RUN npm install --token={raw_token}",
+        )
+    ]
+    br = _make_blast_radius()
+    br.package = pkg
+    br.graph_reachable = False
+    report = AIBOMReport(agents=[], blast_radii=[br])
+
+    finding = report.to_findings()[0]
+
+    assert finding.evidence["package_is_direct"] is False
+    assert finding.evidence["package_parent"] == "top-level"
+    assert finding.evidence["package_dependency_depth"] == 2
+    assert finding.evidence["package_dependency_scope"] == "runtime"
+    assert finding.evidence["package_reachability_evidence"] == "lockfile"
+    assert finding.evidence["graph_reachable"] is False
+    assert finding.evidence["layer_attribution"] == [
+        {
+            "layer_index": 7,
+            "layer_id": "sha256:layer7",
+            "layer_path": "<path:sensitive-layer>",
+            "package_path": "<path:package-lock.json>",
+            "created_by": "RUN npm config set //registry.npmjs.org/:_authToken=<redacted>",
+            "dockerfile_instruction": "RUN npm install --token=<redacted>",
+        }
+    ]
+
+    serialized = json.dumps(finding.evidence, sort_keys=True)
+    assert raw_token not in serialized
+    assert "/Users/alice/work/private/package-lock.json" not in serialized
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary
- carry blast-radius reachability, delegation, transitive, graph, and layer attribution context into unified Finding evidence
- sanitize nested evidence fields before they reach JSON/API/SARIF/UI consumers through the Finding stream
- add regression coverage for AIBOMReport.to_findings and blast_radius_to_finding preserving context without leaking token-like values, credential URLs, or local paths

Why
The canonical BlastRadius model already contains useful reachability context, but consumers that walk unified findings lose that context. This keeps the unified stream honest and actionable without exposing sensitive launch or filesystem details.

Validation
- uv run pytest tests/test_finding.py -q
- uv run ruff check src/agent_bom/finding.py tests/test_finding.py
- uv run mypy src/agent_bom/finding.py
- git diff --check

Closes #2074