### PR TITLE
feat: normalize cloud package PURLs

### DIFF
--- a/src/agent_bom/cloud/aws.py
+++ b/src/agent_bom/cloud/aws.py
@@ -22,7 +22,13 @@ from typing import Any
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
 from .base import CloudDiscoveryError
-from .normalization import build_cloud_origin, build_cloud_state, normalize_cloud_lifecycle_state
+from .normalization import (
+    build_cloud_origin,
+    build_cloud_state,
+    build_package_purl,
+    normalize_cloud_lifecycle_state,
+    parse_container_image_package,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -176,6 +182,16 @@ def discover(
                     command="docker",
                     args=["run", img_ref],
                     transport=TransportType.STDIO,
+                    packages=[
+                        Package(
+                            name=parts[0],
+                            version=parts[1],
+                            ecosystem="container-image",
+                            purl=build_package_purl(ecosystem="container-image", name=parts[0], version=parts[1]),
+                        )
+                        for parts in [parse_container_image_package(img_ref)]
+                        if parts
+                    ],
                 )
             ],
             metadata={
@@ -450,6 +466,7 @@ def _parse_python_packages_from_zip(zf: zipfile.ZipFile) -> list[Package]:
                             name=pkg_name,
                             version=pkg_version,
                             ecosystem="pypi",
+                            purl=build_package_purl(ecosystem="pypi", name=pkg_name, version=pkg_version),
                         )
                     )
             except Exception:
@@ -477,6 +494,7 @@ def _parse_node_packages_from_zip(zf: zipfile.ZipFile) -> list[Package]:
                             name=pkg_name,
                             version=pkg_version,
                             ecosystem="npm",
+                            purl=build_package_purl(ecosystem="npm", name=pkg_name, version=pkg_version),
                         )
                     )
             except Exception:
@@ -568,12 +586,23 @@ def _discover_sagemaker(session: Any, region: str) -> tuple[list[Agent], list[st
                 image = container.get("Image", "")
 
                 if image:
+                    image_parts = parse_container_image_package(image)
                     server = MCPServer(
                         name=f"sagemaker-model:{model_name}",
                         command="docker",
                         args=["run", image],
                         transport=TransportType.STDIO,
                         env={"AWS_REGION": region},
+                        packages=[
+                            Package(
+                                name=image_parts[0],
+                                version=image_parts[1],
+                                ecosystem="container-image",
+                                purl=build_package_purl(ecosystem="container-image", name=image_parts[0], version=image_parts[1]),
+                            )
+                        ]
+                        if image_parts
+                        else [],
                     )
                     agent = Agent(
                         name=f"sagemaker:{ep_name}",
@@ -689,11 +718,22 @@ def _discover_eks_images(
         try:
             image_records = discover_images(all_namespaces=True, context=cluster_name)
             for image_ref, pod_name, container_name in image_records:
+                image_parts = parse_container_image_package(image_ref)
                 server = MCPServer(
                     name=image_ref,
                     command="docker",
                     args=["run", image_ref],
                     transport=TransportType.STDIO,
+                    packages=[
+                        Package(
+                            name=image_parts[0],
+                            version=image_parts[1],
+                            ecosystem="container-image",
+                            purl=build_package_purl(ecosystem="container-image", name=image_parts[0], version=image_parts[1]),
+                        )
+                    ]
+                    if image_parts
+                    else [],
                 )
                 agent = Agent(
                     name=f"eks:{cluster_name}/{pod_name}/{container_name}",

--- a/src/agent_bom/cloud/azure.py
+++ b/src/agent_bom/cloud/azure.py
@@ -17,7 +17,7 @@ from typing import Any
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 from .base import CloudDiscoveryError
-from .normalization import build_cloud_origin, build_cloud_principal, build_cloud_scope, build_cloud_timestamps
+from .normalization import build_cloud_origin, build_cloud_principal, build_cloud_scope, build_cloud_timestamps, build_package_purl
 
 logger = logging.getLogger(__name__)
 
@@ -509,6 +509,7 @@ def _discover_azure_functions(
                                 name=rt_name,
                                 version=rt_ver,
                                 ecosystem="azure-runtime",
+                                purl=build_package_purl(ecosystem="azure-runtime", name=rt_name, version=rt_ver),
                             )
                         )
                 except Exception as exc:

--- a/src/agent_bom/cloud/coreweave.py
+++ b/src/agent_bom/cloud/coreweave.py
@@ -22,6 +22,7 @@ import subprocess
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 from .base import CloudDiscoveryError
+from .normalization import build_package_purl, parse_container_image_package
 
 logger = logging.getLogger(__name__)
 
@@ -241,9 +242,16 @@ def _discover_inference_services(
 
         packages: list[Package] = []
         if runtime_image:
-            img_name = runtime_image.split("/")[-1].split(":")[0]
-            img_version = runtime_image.split(":")[-1] if ":" in runtime_image else "latest"
-            packages.append(Package(name=img_name, version=img_version, ecosystem="container-image"))
+            image_parts = parse_container_image_package(runtime_image)
+            if image_parts:
+                packages.append(
+                    Package(
+                        name=image_parts[0],
+                        version=image_parts[1],
+                        ecosystem="container-image",
+                        purl=build_package_purl(ecosystem="container-image", name=image_parts[0], version=image_parts[1]),
+                    )
+                )
 
         server = MCPServer(
             name=f"coreweave-inference:{ns}/{name}",
@@ -318,10 +326,19 @@ def _discover_gpu_pods(
             if is_nim:
                 nim_model = image_ref.removeprefix(_NIM_IMAGE_PREFIX).split(":")[0]
 
-            img_name = image_ref.split("/")[-1].split(":")[0]
-            img_version = image_ref.split(":")[-1] if ":" in image_ref else "latest"
-
-            packages = [Package(name=img_name, version=img_version, ecosystem="container-image")]
+            image_parts = parse_container_image_package(image_ref)
+            packages = (
+                [
+                    Package(
+                        name=image_parts[0],
+                        version=image_parts[1],
+                        ecosystem="container-image",
+                        purl=build_package_purl(ecosystem="container-image", name=image_parts[0], version=image_parts[1]),
+                    )
+                ]
+                if image_parts
+                else []
+            )
 
             server = MCPServer(
                 name=f"coreweave-gpu-pod:{pod_ns}/{pod_name}",
@@ -397,9 +414,16 @@ def _discover_infiniband_jobs(
 
             packages: list[Package] = []
             if image_ref:
-                img_name = image_ref.split("/")[-1].split(":")[0]
-                img_version = image_ref.split(":")[-1] if ":" in image_ref else "latest"
-                packages.append(Package(name=img_name, version=img_version, ecosystem="container-image"))
+                image_parts = parse_container_image_package(image_ref)
+                if image_parts:
+                    packages.append(
+                        Package(
+                            name=image_parts[0],
+                            version=image_parts[1],
+                            ecosystem="container-image",
+                            purl=build_package_purl(ecosystem="container-image", name=image_parts[0], version=image_parts[1]),
+                        )
+                    )
 
             server = MCPServer(
                 name=f"coreweave-training:{pod_ns}/{pod_name}",

--- a/src/agent_bom/cloud/databricks.py
+++ b/src/agent_bom/cloud/databricks.py
@@ -28,7 +28,7 @@ from typing import Any, Optional
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 from .base import CloudDiscoveryError
-from .normalization import build_cloud_state, normalize_cloud_lifecycle_state
+from .normalization import build_cloud_state, build_package_purl, normalize_cloud_lifecycle_state
 
 logger = logging.getLogger(__name__)
 
@@ -239,7 +239,7 @@ def _parse_pypi_spec(spec: str) -> Optional[Package]:
     version = match.group(2) or "unknown"
     # Clean version — take first version if comma-separated
     version = version.split(",")[0].strip()
-    return Package(name=name, version=version, ecosystem="pypi")
+    return Package(name=name, version=version, ecosystem="pypi", purl=build_package_purl(ecosystem="pypi", name=name, version=version))
 
 
 def _parse_maven_coords(coords: str) -> Optional[Package]:
@@ -250,9 +250,16 @@ def _parse_maven_coords(coords: str) -> Optional[Package]:
     if len(parts) >= 3:
         group_artifact = f"{parts[0]}:{parts[1]}"
         version = parts[2]
-        return Package(name=group_artifact, version=version, ecosystem="maven")
+        return Package(
+            name=group_artifact,
+            version=version,
+            ecosystem="maven",
+            purl=build_package_purl(ecosystem="maven", name=group_artifact, version=version),
+        )
     if len(parts) == 2:
-        return Package(name=parts[0], version=parts[1], ecosystem="maven")
+        return Package(
+            name=parts[0], version=parts[1], ecosystem="maven", purl=build_package_purl(ecosystem="maven", name=parts[0], version=parts[1])
+        )
     return None
 
 
@@ -265,5 +272,10 @@ def _parse_jar_path(path: str) -> Optional[Package]:
     # Try pattern: name-version
     match = re.match(r"^(.+?)-(\d+\..+)$", filename)
     if match:
-        return Package(name=match.group(1), version=match.group(2), ecosystem="maven")
+        return Package(
+            name=match.group(1),
+            version=match.group(2),
+            ecosystem="maven",
+            purl=build_package_purl(ecosystem="maven", name=match.group(1), version=match.group(2)),
+        )
     return Package(name=filename, version="unknown", ecosystem="maven")

--- a/src/agent_bom/cloud/gcp.py
+++ b/src/agent_bom/cloud/gcp.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import logging
 import os
 
-from agent_bom.models import Agent, AgentType, MCPServer, TransportType
+from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 from .base import CloudDiscoveryError
 from .normalization import (
@@ -21,6 +21,8 @@ from .normalization import (
     build_cloud_principal,
     build_cloud_scope,
     build_cloud_timestamps,
+    build_package_purl,
+    parse_container_image_package,
     sanitize_discovery_warning,
 )
 
@@ -487,12 +489,23 @@ def _discover_cloud_run(
             for container in template.containers:
                 image = container.image or ""
                 if image:
+                    image_parts = parse_container_image_package(image)
                     service_account = getattr(template, "service_account", "") or ""
                     server = MCPServer(
                         name=f"cloud-run:{svc_name}",
                         command="docker",
                         args=["run", image],
                         transport=TransportType.STDIO,
+                        packages=[
+                            Package(
+                                name=image_parts[0],
+                                version=image_parts[1],
+                                ecosystem="container-image",
+                                purl=build_package_purl(ecosystem="container-image", name=image_parts[0], version=image_parts[1]),
+                            )
+                        ]
+                        if image_parts
+                        else [],
                     )
                     agent = Agent(
                         name=f"cloud-run:{svc_name}",

--- a/src/agent_bom/cloud/gpu_infra.py
+++ b/src/agent_bom/cloud/gpu_infra.py
@@ -29,6 +29,7 @@ import subprocess
 from dataclasses import dataclass, field
 from typing import Any
 
+from agent_bom.cloud.normalization import build_package_purl
 from agent_bom.http_client import create_client, request_with_retry
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
@@ -617,9 +618,23 @@ def gpu_infra_to_agents(report: GpuInfraReport) -> list[Agent]:
         # Build package list from CUDA/cuDNN versions
         packages: list[Package] = []
         if c.cuda_version:
-            packages.append(Package(name="cuda-toolkit", version=c.cuda_version, ecosystem="container"))
+            packages.append(
+                Package(
+                    name="cuda-toolkit",
+                    version=c.cuda_version,
+                    ecosystem="container",
+                    purl=build_package_purl(ecosystem="container", name="cuda-toolkit", version=c.cuda_version),
+                )
+            )
         if c.cudnn_version:
-            packages.append(Package(name="cudnn", version=c.cudnn_version, ecosystem="container"))
+            packages.append(
+                Package(
+                    name="cudnn",
+                    version=c.cudnn_version,
+                    ecosystem="container",
+                    purl=build_package_purl(ecosystem="container", name="cudnn", version=c.cudnn_version),
+                )
+            )
 
         server = MCPServer(
             name=c.image,

--- a/src/agent_bom/cloud/mlflow_provider.py
+++ b/src/agent_bom/cloud/mlflow_provider.py
@@ -15,6 +15,7 @@ import os
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
 from .base import CloudDiscoveryError
+from .normalization import build_package_purl
 
 logger = logging.getLogger(__name__)
 
@@ -304,7 +305,15 @@ def _parse_requirements_txt(content: str) -> list[Package]:
             if sep in line:
                 name, version = line.split(sep, 1)
                 name = name.split("[")[0].strip()
-                packages.append(Package(name=name, version=version.strip(), ecosystem="pypi"))
+                clean_version = version.strip()
+                packages.append(
+                    Package(
+                        name=name,
+                        version=clean_version,
+                        ecosystem="pypi",
+                        purl=build_package_purl(ecosystem="pypi", name=name, version=clean_version),
+                    )
+                )
                 break
         else:
             name = line.split("[")[0].strip()
@@ -333,7 +342,15 @@ def _parse_conda_yaml(content: str) -> list[Package]:
                         if sep in pip_dep:
                             name, version = pip_dep.split(sep, 1)
                             name = name.split("[")[0].strip()
-                            packages.append(Package(name=name, version=version.strip(), ecosystem="pypi"))
+                            clean_version = version.strip()
+                            packages.append(
+                                Package(
+                                    name=name,
+                                    version=clean_version,
+                                    ecosystem="pypi",
+                                    purl=build_package_purl(ecosystem="pypi", name=name, version=clean_version),
+                                )
+                            )
                             break
                     else:
                         name = pip_dep.split("[")[0].strip()

--- a/src/agent_bom/cloud/nebius.py
+++ b/src/agent_bom/cloud/nebius.py
@@ -19,6 +19,7 @@ import subprocess
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
 from .base import CloudDiscoveryError
+from .normalization import build_package_purl, parse_container_image_package
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +185,7 @@ def _discover_ai_studio(
                     name=model_name,
                     version=str(model_version),
                     ecosystem="nebius-ai-studio",
+                    purl=build_package_purl(ecosystem="nebius-ai-studio", name=model_name, version=str(model_version)),
                 )
             ]
 
@@ -275,6 +277,11 @@ def _discover_gpu_instances(
                         name=boot_disk.get("image_name", image_id),
                         version="detected",
                         ecosystem="nebius-compute-image",
+                        purl=build_package_purl(
+                            ecosystem="nebius-compute-image",
+                            name=boot_disk.get("image_name", image_id),
+                            version="detected",
+                        ),
                     )
                 )
 
@@ -367,13 +374,19 @@ def _discover_k8s_gpu_pods(
                         continue
                     seen_images.add(image_ref)
 
-                    packages = [
-                        Package(
-                            name=image_ref.split("/")[-1].split(":")[0],
-                            version=image_ref.split(":")[-1] if ":" in image_ref else "latest",
-                            ecosystem="container-image",
-                        )
-                    ]
+                    image_parts = parse_container_image_package(image_ref)
+                    packages = (
+                        [
+                            Package(
+                                name=image_parts[0],
+                                version=image_parts[1],
+                                ecosystem="container-image",
+                                purl=build_package_purl(ecosystem="container-image", name=image_parts[0], version=image_parts[1]),
+                            )
+                        ]
+                        if image_parts
+                        else []
+                    )
 
                     server = MCPServer(
                         name=f"nebius-k8s-gpu:{pod_ns}/{pod_name}/{container_name}",

--- a/src/agent_bom/cloud/normalization.py
+++ b/src/agent_bom/cloud/normalization.py
@@ -5,7 +5,16 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
+from agent_bom.package_utils import normalize_package_ecosystem
 from agent_bom.security import sanitize_error, sanitize_text
+
+_UNKNOWN_PACKAGE_VERSIONS = {"", "unknown", "detected", "0.0"}
+_CLOUD_PURL_TYPE_ALIASES = {
+    "azure-runtime": "generic",
+    "container": "generic",
+    "container-image": "docker",
+    "nebius-ai-studio": "generic",
+}
 
 _LIFECYCLE_STATE_MAPS: dict[tuple[str, str, str], dict[str, str]] = {
     ("aws", "bedrock", "agent"): {
@@ -23,6 +32,65 @@ _LIFECYCLE_STATE_MAPS: dict[tuple[str, str, str], dict[str, str]] = {
         "NOT_READY": "not-ready",
     },
 }
+
+
+def build_package_purl(*, ecosystem: str, name: str, version: str | None) -> str | None:
+    """Return a normalized PURL for cloud-discovered packages when versioned.
+
+    Cloud APIs often expose inferred dependencies with ``unknown`` or
+    provider-specific placeholders. Those are intentionally left without a PURL
+    so downstream matching does not treat a guess as a stable package identity.
+    """
+    normalized_ecosystem = normalize_package_ecosystem(ecosystem)
+    purl_type = _CLOUD_PURL_TYPE_ALIASES.get(normalized_ecosystem, normalized_ecosystem)
+    package_name = (name or "").strip()
+    package_version = str(version or "").strip()
+    if not normalized_ecosystem or not package_name or package_version.lower() in _UNKNOWN_PACKAGE_VERSIONS:
+        return None
+
+    namespace: str | None = None
+    purl_name = package_name
+    if normalized_ecosystem == "maven":
+        if ":" in package_name:
+            namespace, purl_name = package_name.split(":", 1)
+        elif "/" in package_name:
+            namespace, purl_name = package_name.rsplit("/", 1)
+    elif normalized_ecosystem == "npm" and package_name.startswith("@") and "/" in package_name:
+        namespace, purl_name = package_name.split("/", 1)
+    elif purl_type == "docker" and "/" in package_name:
+        namespace, purl_name = package_name.rsplit("/", 1)
+
+    try:
+        from packageurl import PackageURL
+
+        return PackageURL(
+            type=purl_type,
+            namespace=namespace or None,
+            name=purl_name,
+            version=package_version,
+        ).to_string()
+    except Exception:
+        return None
+
+
+def parse_container_image_package(image_ref: str) -> tuple[str, str] | None:
+    """Return ``(repository, tag_or_digest_or_latest)`` from an image reference."""
+    image = (image_ref or "").strip()
+    if not image:
+        return None
+    if "@sha256:" in image:
+        name, digest = image.split("@", 1)
+        return (name, digest) if name and digest else None
+    leaf = image.rsplit("/", 1)[-1]
+    if not leaf:
+        return None
+    if ":" in leaf:
+        name, version = image.rsplit(":", 1)
+    else:
+        name, version = image, "latest"
+    if not name:
+        return None
+    return name, version
 
 
 def normalize_cloud_lifecycle_state(

--- a/src/agent_bom/cloud/snowflake.py
+++ b/src/agent_bom/cloud/snowflake.py
@@ -55,6 +55,7 @@ from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, Tran
 from agent_bom.security import sanitize_error
 
 from .base import CloudDiscoveryError
+from .normalization import build_package_purl
 
 logger = logging.getLogger(__name__)
 
@@ -388,7 +389,11 @@ def _discover_snowpark_packages(
             version = str(row[1])
             if name.lower() not in seen:
                 seen.add(name.lower())
-                packages.append(Package(name=name, version=version, ecosystem="pypi"))
+                packages.append(
+                    Package(
+                        name=name, version=version, ecosystem="pypi", purl=build_package_purl(ecosystem="pypi", name=name, version=version)
+                    )
+                )
 
     except Exception as exc:
         # INFORMATION_SCHEMA.PACKAGES may not exist or may not be accessible
@@ -524,7 +529,14 @@ def _discover_snowflake_notebooks(
                             parts = pkg_spec.split("==") if "==" in pkg_spec else pkg_spec.split("=")
                             pkg_name = parts[0].strip()
                             pkg_version = parts[1].strip() if len(parts) > 1 else "unknown"
-                            packages.append(Package(name=pkg_name, version=pkg_version, ecosystem="pypi"))
+                            packages.append(
+                                Package(
+                                    name=pkg_name,
+                                    version=pkg_version,
+                                    ecosystem="pypi",
+                                    purl=build_package_purl(ecosystem="pypi", name=pkg_name, version=pkg_version),
+                                )
+                            )
                             # Flag AI/ML packages as tools for visibility
                             if pkg_name.lower().replace("-", "_") in _ai_ml_packages:
                                 tools.append(

--- a/src/agent_bom/cloud/wandb_provider.py
+++ b/src/agent_bom/cloud/wandb_provider.py
@@ -15,6 +15,7 @@ import os
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 from .base import CloudDiscoveryError
+from .normalization import build_package_purl
 
 logger = logging.getLogger(__name__)
 
@@ -228,7 +229,14 @@ def _extract_packages_from_metadata(
                 name = item.get("name", "")
                 version = item.get("version", "unknown")
                 if name and name not in seen:
-                    packages.append(Package(name=name, version=version, ecosystem="pypi"))
+                    packages.append(
+                        Package(
+                            name=name,
+                            version=version,
+                            ecosystem="pypi",
+                            purl=build_package_purl(ecosystem="pypi", name=name, version=version),
+                        )
+                    )
                     seen.add(name)
 
     # Check common config keys for framework hints
@@ -252,7 +260,14 @@ def _parse_requirement(req: str) -> Package | None:
             # Strip extras: package[extra]==1.0 → package
             if "[" in name:
                 name = name.split("[")[0]
-            return Package(name=name.strip(), version=version.strip(), ecosystem="pypi")
+            clean_name = name.strip()
+            clean_version = version.strip()
+            return Package(
+                name=clean_name,
+                version=clean_version,
+                ecosystem="pypi",
+                purl=build_package_purl(ecosystem="pypi", name=clean_name, version=clean_version),
+            )
 
     # No version specifier
     name = req.split("[")[0].strip() if "[" in req else req.strip()

--- a/tests/test_cloud_package_purls.py
+++ b/tests/test_cloud_package_purls.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import io
+import sys
+import types
+import zipfile
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def test_cloud_package_purl_encodes_scoped_npm_and_skips_unknown() -> None:
+    from agent_bom.cloud.normalization import build_package_purl
+
+    assert build_package_purl(ecosystem="npm", name="@types/node", version="22.0.0") == "pkg:npm/%40types/node@22.0.0"
+    assert build_package_purl(ecosystem="container-image", name="gcr.io/acme/app/worker", version="v1.2.3") == (
+        "pkg:docker/gcr.io/acme/app/worker@v1.2.3"
+    )
+    assert build_package_purl(ecosystem="azure-runtime", name="python", version="3.11") == "pkg:generic/python@3.11"
+    assert build_package_purl(ecosystem="pypi", name="requests", version="unknown") is None
+    assert build_package_purl(ecosystem="azure-runtime", name="python", version="0.0") is None
+
+
+def test_aws_zip_package_parsers_emit_purls() -> None:
+    from agent_bom.cloud.aws import _parse_node_packages_from_zip, _parse_python_packages_from_zip
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("python/Requests_OAuthlib-1.3.0.dist-info/METADATA", "Name: Requests_OAuthlib\nVersion: 1.3.0\n")
+        zf.writestr("nodejs/node_modules/@types/node/package.json", '{"name": "@types/node", "version": "22.0.0"}')
+
+    buf.seek(0)
+    with zipfile.ZipFile(buf) as zf:
+        pypi_pkg = _parse_python_packages_from_zip(zf)[0]
+        npm_pkg = _parse_node_packages_from_zip(zf)[0]
+
+    assert pypi_pkg.purl == "pkg:pypi/requests-oauthlib@1.3.0"
+    assert npm_pkg.purl == "pkg:npm/%40types/node@22.0.0"
+
+
+def test_azure_function_runtime_package_has_purl() -> None:
+    from agent_bom.cloud.azure import _discover_azure_functions
+
+    app = SimpleNamespace(
+        name="fn",
+        id="/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Web/sites/fn",
+        kind="functionapp,linux",
+        location="eastus",
+    )
+    config = SimpleNamespace(linux_fx_version="PYTHON|3.11")
+    web_apps = SimpleNamespace(list=lambda: [app], get_configuration=lambda _rg, _app: config)
+    client = SimpleNamespace(web_apps=web_apps)
+
+    azure_web = types.ModuleType("azure.mgmt.web")
+    setattr(azure_web, "WebSiteManagementClient", lambda _credential, _subscription_id: client)
+
+    with patch.dict(
+        sys.modules, {"azure": types.ModuleType("azure"), "azure.mgmt": types.ModuleType("azure.mgmt"), "azure.mgmt.web": azure_web}
+    ):
+        agents, warnings = _discover_azure_functions(object(), "sub")
+
+    assert warnings == []
+    pkg = agents[0].mcp_servers[0].packages[0]
+    assert pkg.purl == "pkg:generic/python@3.11"
+
+
+def test_gcp_cloud_run_container_package_has_purl() -> None:
+    from agent_bom.cloud.gcp import _discover_cloud_run
+
+    container = SimpleNamespace(image="us-docker.pkg.dev/acme/app/worker:v1.2.3")
+    template = SimpleNamespace(containers=[container], service_account="worker@acme.iam.gserviceaccount.com")
+    service = SimpleNamespace(name="projects/acme/locations/us-central1/services/worker", template=template)
+    client = SimpleNamespace(list_services=lambda parent: [service])
+
+    run_v2 = types.ModuleType("google.cloud.run_v2")
+    setattr(run_v2, "ServicesClient", lambda: client)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "google": types.ModuleType("google"),
+            "google.cloud": types.ModuleType("google.cloud"),
+            "google.cloud.run_v2": run_v2,
+        },
+    ):
+        agents, warnings = _discover_cloud_run("acme", "us-central1")
+
+    assert warnings == []
+    pkg = agents[0].mcp_servers[0].packages[0]
+    assert pkg.name == "us-docker.pkg.dev/acme/app/worker"
+    assert pkg.purl == "pkg:docker/us-docker.pkg.dev/acme/app/worker@v1.2.3"
+
+
+def test_databricks_library_parsers_emit_purls_only_for_known_versions() -> None:
+    from agent_bom.cloud.databricks import _parse_jar_path, _parse_maven_coords, _parse_pypi_spec
+
+    assert _parse_pypi_spec("Requests_OAuthlib==1.3.0").purl == "pkg:pypi/requests-oauthlib@1.3.0"  # type: ignore[union-attr]
+    assert _parse_maven_coords("com.google.guava:guava:32.1.3-jre").purl == "pkg:maven/com.google.guava/guava@32.1.3-jre"  # type: ignore[union-attr]
+    assert _parse_jar_path("/dbfs/jars/spark-nlp_2.12-5.3.2.jar").purl == "pkg:maven/spark-nlp_2.12@5.3.2"  # type: ignore[union-attr]
+    assert _parse_pypi_spec("langchain").purl is None  # type: ignore[union-attr]
+
+
+def test_cloud_ml_package_parsers_emit_purls_for_pinned_versions() -> None:
+    from agent_bom.cloud.mlflow_provider import _parse_requirements_txt
+    from agent_bom.cloud.wandb_provider import _parse_requirement
+
+    wandb_pkg = _parse_requirement("transformers[torch]==4.39.0")
+    mlflow_pkg = _parse_requirements_txt("scikit-learn==1.4.1\npandas\n")
+
+    assert wandb_pkg is not None
+    assert wandb_pkg.purl == "pkg:pypi/transformers@4.39.0"
+    assert [pkg.purl for pkg in mlflow_pkg] == ["pkg:pypi/scikit-learn@1.4.1", None]


### PR DESCRIPTION
Summary
- add shared cloud package PURL helpers with valid PURL type mapping for PyPI, npm, Maven, Docker/container images, and generic provider-native artifacts
- populate PURLs for version-known cloud-discovered packages across AWS, Azure, GCP, Databricks, CoreWeave, Nebius, GPU infra, W&B, MLflow, and Snowflake
- preserve honesty by skipping PURLs for unknown/detected placeholder versions instead of emitting guessed identities
- add cloud package PURL regression tests, including Docker repository preservation and scoped npm encoding

Why
Cloud-discovered packages should carry the same canonical package identity quality as parser-discovered packages so SBOM, JSON/API, graph, SARIF, and downstream policy workflows can correlate them accurately.

Validation
- uv run pytest tests/test_cloud_package_purls.py -q
- uv run pytest tests/test_cloud.py tests/test_cloud_package_purls.py -q
- uv run ruff check touched cloud files and tests/test_cloud_package_purls.py
- uv run mypy touched cloud source files
- git diff --check

Closes #2072