### PR TITLE
feat: normalize cloud origin context

### DIFF
--- a/contracts/v1/graph-export.schema.json
+++ b/contracts/v1/graph-export.schema.json
@@ -16,8 +16,14 @@
         "properties": {
           "id": { "type": "string", "minLength": 1 },
           "entity_type": { "type": "string", "minLength": 1 },
+          "kind": { "type": "string", "minLength": 1 },
           "label": { "type": "string" },
-          "risk_score": { "type": "number" }
+          "risk_score": { "type": "number" },
+          "attributes": {
+            "type": "object",
+            "description": "Optional sanitized node attributes, including cloud_origin/cloud_scope/cloud_state when available.",
+            "additionalProperties": true
+          }
         },
         "additionalProperties": true
       }

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -408,7 +408,7 @@ async def get_graph_export(request: Request, job_id: str, format: str = "json") 
         raise HTTPException(status_code=409, detail="Scan not completed yet")
 
     from agent_bom.output.graph_export import (
-        DepGraph,
+        build_graph_from_scan_data,
         to_cypher,
         to_dot,
         to_graphml,
@@ -418,40 +418,8 @@ async def get_graph_export(request: Request, job_id: str, format: str = "json") 
         to_json as graph_to_json,
     )
 
-    # Build DepGraph from scan result
-    graph = DepGraph()
     result = job.result if isinstance(job.result, dict) else {}
-    for agent in result.get("agents", []):
-        agent_name = agent.get("name", "unknown")
-        source = agent.get("source") or "local"
-        src_id = f"provider:{source}"
-        graph.add_node(src_id, source, "provider")
-        a_id = f"agent:{agent_name}"
-        graph.add_node(a_id, agent_name, "agent")
-        graph.add_edge(src_id, a_id, "hosts")
-        for srv in agent.get("mcp_servers", []):
-            srv_name = srv.get("name", "unknown")
-            s_id = f"server:{agent_name}/{srv_name}"
-            if srv.get("security_blocked"):
-                srv_kind = "server_blocked"
-            elif srv.get("security_intelligence"):
-                srv_kind = "server_intel"
-            else:
-                srv_kind = "server_cred" if srv.get("has_credentials") else "server"
-            graph.add_node(s_id, srv_name, srv_kind)
-            graph.add_edge(a_id, s_id, "uses")
-            for pkg in srv.get("packages", []):
-                p_name = pkg.get("name", "?")
-                p_ver = pkg.get("version", "")
-                p_eco = pkg.get("ecosystem", "")
-                vulns = pkg.get("vulnerabilities", [])
-                p_id = f"pkg:{p_eco}/{p_name}@{p_ver}"
-                graph.add_node(p_id, f"{p_name}@{p_ver}" if p_ver else p_name, "pkg_vuln" if vulns else "pkg")
-                graph.add_edge(s_id, p_id, "depends_on")
-                for v in vulns:
-                    v_id = f"cve:{v.get('id', '?')}"
-                    graph.add_node(v_id, v.get("id", "?"), "cve", v.get("severity", "").lower())
-                    graph.add_edge(p_id, v_id, "affects")
+    graph = build_graph_from_scan_data(result)
 
     _formats = {
         "dot": lambda g: PlainTextResponse(to_dot(g), media_type="text/vnd.graphviz"),

--- a/src/agent_bom/cloud/aws.py
+++ b/src/agent_bom/cloud/aws.py
@@ -77,10 +77,11 @@ def discover(
 
     session = boto3.Session(**session_kwargs)
     resolved_region = session.region_name or os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+    account_id = _resolve_account_id(session)
 
     # ── Bedrock Agents ────────────────────────────────────────────────────
     try:
-        bedrock_agents, bedrock_warnings = _discover_bedrock(session, resolved_region)
+        bedrock_agents, bedrock_warnings = _discover_bedrock(session, resolved_region, account_id=account_id)
         agents.extend(bedrock_agents)
         warnings.extend(bedrock_warnings)
     except NoCredentialsError:
@@ -109,7 +110,7 @@ def discover(
     # ── SageMaker Endpoints ───────────────────────────────────────────────
     if include_sagemaker:
         try:
-            sm_agents, sm_warns = _discover_sagemaker(session, resolved_region)
+            sm_agents, sm_warns = _discover_sagemaker(session, resolved_region, account_id=account_id)
             agents.extend(sm_agents)
             warnings.extend(sm_warns)
         except ClientError as exc:
@@ -122,7 +123,7 @@ def discover(
     # ── Lambda Functions (direct discovery) ────────────────────────────────
     if include_lambda:
         try:
-            lambda_agents, lambda_warns = _discover_lambda_functions(session, resolved_region, warnings)
+            lambda_agents, lambda_warns = _discover_lambda_functions(session, resolved_region, warnings, account_id=account_id)
             agents.extend(lambda_agents)
             warnings.extend(lambda_warns)
         except ClientError as exc:
@@ -135,7 +136,7 @@ def discover(
     # ── EKS Clusters ───────────────────────────────────────────────────────
     if include_eks:
         try:
-            eks_agents, eks_warns = _discover_eks_images(session, resolved_region)
+            eks_agents, eks_warns = _discover_eks_images(session, resolved_region, account_id=account_id)
             agents.extend(eks_agents)
             warnings.extend(eks_warns)
         except ClientError as exc:
@@ -148,7 +149,7 @@ def discover(
     # ── Step Functions ─────────────────────────────────────────────────────
     if include_step_functions:
         try:
-            sfn_agents, sfn_warns = _discover_step_functions(session, resolved_region, warnings)
+            sfn_agents, sfn_warns = _discover_step_functions(session, resolved_region, warnings, account_id=account_id)
             agents.extend(sfn_agents)
             warnings.extend(sfn_warns)
         except ClientError as exc:
@@ -161,7 +162,12 @@ def discover(
     # ── EC2 Instances (tag-filtered) ───────────────────────────────────────
     if include_ec2:
         try:
-            ec2_agents, ec2_warns = _discover_ec2_instances(session, resolved_region, ec2_tag_filter or {})
+            ec2_agents, ec2_warns = _discover_ec2_instances(
+                session,
+                resolved_region,
+                ec2_tag_filter or {},
+                account_id=account_id,
+            )
             agents.extend(ec2_agents)
             warnings.extend(ec2_warns)
         except ClientError as exc:
@@ -216,6 +222,7 @@ def discover(
                     resource_id=f"{task_arn}/{container_name}" if task_arn else img_ref,
                     resource_name=container_name or img_ref.split("/")[-1],
                     location=resolved_region,
+                    account_id=account_id,
                     raw_identity={
                         "cluster_arn": cluster_arn,
                         "task_arn": task_arn,
@@ -230,12 +237,27 @@ def discover(
     return agents, warnings
 
 
+def _resolve_account_id(session: Any) -> str | None:
+    """Resolve the AWS account once for normalized origin scope.
+
+    STS can be unavailable or explicitly denied in least-privilege audit roles;
+    inventory discovery should continue and simply omit account scope.
+    """
+    try:
+        identity = session.client("sts").get_caller_identity()
+    except Exception as exc:
+        logger.debug("Could not resolve AWS account ID via STS: %s", exc)
+        return None
+    account_id = str(identity.get("Account", "")).strip()
+    return account_id or None
+
+
 # ---------------------------------------------------------------------------
 # Bedrock discovery
 # ---------------------------------------------------------------------------
 
 
-def _discover_bedrock(session: Any, region: str) -> tuple[list[Agent], list[str]]:
+def _discover_bedrock(session: Any, region: str, *, account_id: str | None = None) -> tuple[list[Agent], list[str]]:
     """Discover Bedrock agents and their action groups."""
     client = session.client("bedrock-agent", region_name=region)
     agents: list[Agent] = []
@@ -254,8 +276,6 @@ def _discover_bedrock(session: Any, region: str) -> tuple[list[Agent], list[str]
                 resource_type="agent",
                 raw_state=agent_status,
             )
-            if lifecycle_state is None:
-                continue
 
             try:
                 detail = client.get_agent(agentId=agent_id)["agent"]
@@ -284,22 +304,24 @@ def _discover_bedrock(session: Any, region: str) -> tuple[list[Agent], list[str]
                         resource_id=agent_arn,
                         resource_name=agent_name,
                         location=region,
+                        account_id=account_id,
                         raw_identity={
                             "agentId": agent_id,
                             "agentArn": agent_arn,
                             "agentName": agent_name,
                         },
                     ),
-                    "cloud_state": build_cloud_state(
-                        provider="aws",
-                        service="bedrock",
-                        resource_type="agent",
-                        lifecycle_state=lifecycle_state,
-                        raw_state=agent_status,
-                        state_source="agentStatus",
-                    ),
                 },
             )
+            if lifecycle_state:
+                agent.metadata["cloud_state"] = build_cloud_state(
+                    provider="aws",
+                    service="bedrock",
+                    resource_type="agent",
+                    lifecycle_state=lifecycle_state,
+                    raw_state=agent_status,
+                    state_source="agentStatus",
+                )
             agents.append(agent)
 
     return agents, warnings
@@ -581,7 +603,7 @@ def _discover_ecs_images(session: Any, region: str) -> tuple[list[dict[str, str]
 # ---------------------------------------------------------------------------
 
 
-def _discover_sagemaker(session: Any, region: str) -> tuple[list[Agent], list[str]]:
+def _discover_sagemaker(session: Any, region: str, *, account_id: str | None = None) -> tuple[list[Agent], list[str]]:
     """Discover SageMaker endpoints and their container images."""
     sm = session.client("sagemaker", region_name=region)
     agents: list[Agent] = []
@@ -647,6 +669,7 @@ def _discover_sagemaker(session: Any, region: str) -> tuple[list[Agent], list[st
                                 resource_id=ep_desc.get("EndpointArn", ep_name),
                                 resource_name=ep_name,
                                 location=region,
+                                account_id=account_id,
                                 raw_identity={"endpoint": ep_name, "model": model_name, "image": image},
                             )
                         },
@@ -701,6 +724,8 @@ def _discover_lambda_functions(
     session: Any,
     region: str,
     parent_warnings: list[str],
+    *,
+    account_id: str | None = None,
 ) -> tuple[list[Agent], list[str]]:
     """Discover standalone Lambda functions (not just Bedrock action group Lambdas).
 
@@ -748,6 +773,7 @@ def _discover_lambda_functions(
                         resource_id=func_arn,
                         resource_name=func_name,
                         location=region,
+                        account_id=account_id,
                         raw_identity={"function_name": func_name, "function_arn": func_arn, "runtime": runtime},
                     )
                 },
@@ -785,6 +811,8 @@ def _discover_lambda_functions(
 def _discover_eks_images(
     session: Any,
     region: str,
+    *,
+    account_id: str | None = None,
 ) -> tuple[list[Agent], list[str]]:
     """Discover EKS clusters and reuse k8s.discover_images() for pod scanning.
 
@@ -843,6 +871,7 @@ def _discover_eks_images(
                             resource_id=f"{cluster_name}/{pod_name}/{container_name}",
                             resource_name=pod_name,
                             location=region,
+                            account_id=account_id,
                             raw_identity={
                                 "cluster": cluster_name,
                                 "pod": pod_name,
@@ -872,6 +901,8 @@ def _discover_step_functions(
     session: Any,
     region: str,
     parent_warnings: list[str],
+    *,
+    account_id: str | None = None,
 ) -> tuple[list[Agent], list[str]]:
     """Discover Step Functions state machines and extract referenced service ARNs.
 
@@ -949,6 +980,7 @@ def _discover_step_functions(
                         resource_id=sm_arn,
                         resource_name=sm_name,
                         location=region,
+                        account_id=account_id,
                         raw_identity={"state_machine_arn": sm_arn, "name": sm_name},
                     )
                 },
@@ -1017,6 +1049,8 @@ def _discover_ec2_instances(
     session: Any,
     region: str,
     tag_filter: dict[str, str],
+    *,
+    account_id: str | None = None,
 ) -> tuple[list[Agent], list[str]]:
     """Discover EC2 instances matching tag filters.
 
@@ -1072,6 +1106,7 @@ def _discover_ec2_instances(
                                 resource_id=instance_id,
                                 resource_name=name,
                                 location=region,
+                                account_id=account_id,
                                 raw_identity={"instance_id": instance_id, "instance_type": instance_type, "ami_id": ami_id},
                             )
                         },

--- a/src/agent_bom/cloud/aws.py
+++ b/src/agent_bom/cloud/aws.py
@@ -24,7 +24,9 @@ from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, Tran
 from .base import CloudDiscoveryError
 from .normalization import (
     build_cloud_origin,
+    build_cloud_principal,
     build_cloud_state,
+    build_cloud_timestamps,
     build_package_purl,
     normalize_cloud_lifecycle_state,
     parse_container_image_package,
@@ -65,7 +67,7 @@ def discover(
 
     agents: list[Agent] = []
     warnings: list[str] = []
-    ecs_image_refs: list[str] = []
+    ecs_image_refs: list[dict[str, str] | str] = []
 
     session_kwargs: dict[str, Any] = {}
     if region:
@@ -170,11 +172,23 @@ def discover(
                 warnings.append(f"AWS EC2 API error: {exc}")
 
     # ── ECS images as agents ──────────────────────────────────────────────
-    for img_ref in ecs_image_refs:
+    for ecs_ref in ecs_image_refs:
+        if isinstance(ecs_ref, dict):
+            img_ref = ecs_ref.get("image", "")
+            cluster_arn = ecs_ref.get("cluster_arn", "")
+            task_arn = ecs_ref.get("task_arn", "")
+            container_name = ecs_ref.get("container_name", img_ref)
+        else:
+            img_ref = ecs_ref
+            cluster_arn = ""
+            task_arn = ""
+            container_name = img_ref
+        if not img_ref:
+            continue
         ecs_agent = Agent(
             name=f"ecs-image:{img_ref}",
             agent_type=AgentType.CUSTOM,
-            config_path=f"ecs://{img_ref}",
+            config_path=task_arn or f"ecs://{img_ref}",
             source="aws-ecs",
             mcp_servers=[
                 MCPServer(
@@ -199,10 +213,15 @@ def discover(
                     provider="aws",
                     service="ecs",
                     resource_type="container-image",
-                    resource_id=img_ref,
-                    resource_name=img_ref.split("/")[-1],
+                    resource_id=f"{task_arn}/{container_name}" if task_arn else img_ref,
+                    resource_name=container_name or img_ref.split("/")[-1],
                     location=resolved_region,
-                    raw_identity={"image": img_ref},
+                    raw_identity={
+                        "cluster_arn": cluster_arn,
+                        "task_arn": task_arn,
+                        "container_name": container_name,
+                        "image": img_ref,
+                    },
                 )
             },
         )
@@ -508,10 +527,10 @@ def _parse_node_packages_from_zip(zf: zipfile.ZipFile) -> list[Package]:
 # ---------------------------------------------------------------------------
 
 
-def _discover_ecs_images(session: Any, region: str) -> tuple[list[str], list[str]]:
+def _discover_ecs_images(session: Any, region: str) -> tuple[list[dict[str, str]], list[str]]:
     """Discover container image refs from running ECS tasks."""
     ecs = session.client("ecs", region_name=region)
-    image_refs: list[str] = []
+    image_refs: list[dict[str, str]] = []
     warnings: list[str] = []
     seen: set[str] = set()
 
@@ -537,11 +556,20 @@ def _discover_ecs_images(session: Any, region: str) -> tuple[list[str], list[str
                 batch = task_arns[i : i + 100]
                 tasks = ecs.describe_tasks(cluster=cluster_arn, tasks=batch).get("tasks", [])
                 for task in tasks:
+                    task_arn = task.get("taskArn", "")
                     for container in task.get("containers", []):
                         image = container.get("image", "")
+                        container_name = container.get("name", "") or image
                         if image and image not in seen:
                             seen.add(image)
-                            image_refs.append(image)
+                            image_refs.append(
+                                {
+                                    "cluster_arn": cluster_arn,
+                                    "task_arn": task_arn,
+                                    "container_name": container_name,
+                                    "image": image,
+                                }
+                            )
         except Exception as exc:
             warnings.append(f"Could not list tasks in ECS cluster {cluster_arn}: {exc}")
 
@@ -584,6 +612,7 @@ def _discover_sagemaker(session: Any, region: str) -> tuple[list[Agent], list[st
                 model_desc = sm.describe_model(ModelName=model_name)
                 container = model_desc.get("PrimaryContainer", {})
                 image = container.get("Image", "")
+                execution_role = model_desc.get("ExecutionRoleArn", "")
 
                 if image:
                     image_parts = parse_container_image_package(image)
@@ -610,7 +639,40 @@ def _discover_sagemaker(session: Any, region: str) -> tuple[list[Agent], list[st
                         config_path=ep_desc.get("EndpointArn", f"sagemaker://{ep_name}"),
                         source="aws-sagemaker",
                         mcp_servers=[server],
+                        metadata={
+                            "cloud_origin": build_cloud_origin(
+                                provider="aws",
+                                service="sagemaker",
+                                resource_type="endpoint",
+                                resource_id=ep_desc.get("EndpointArn", ep_name),
+                                resource_name=ep_name,
+                                location=region,
+                                raw_identity={"endpoint": ep_name, "model": model_name, "image": image},
+                            )
+                        },
                     )
+                    cloud_timestamps = build_cloud_timestamps(
+                        provider="aws",
+                        service="sagemaker",
+                        resource_type="endpoint",
+                        created_at=ep_desc.get("CreationTime"),
+                        updated_at=ep_desc.get("LastModifiedTime"),
+                        created_source="CreationTime",
+                        updated_source="LastModifiedTime",
+                    )
+                    if cloud_timestamps:
+                        agent.metadata["cloud_timestamps"] = cloud_timestamps
+                    cloud_principal = build_cloud_principal(
+                        provider="aws",
+                        service="sagemaker",
+                        resource_type="endpoint",
+                        principal_type="iam-role",
+                        principal_id=execution_role or None,
+                        source_field="Model.ExecutionRoleArn",
+                        raw_identity={"execution_role_arn": execution_role},
+                    )
+                    if cloud_principal:
+                        agent.metadata["cloud_principal"] = cloud_principal
                     agents.append(agent)
 
         except Exception as exc:
@@ -655,6 +717,7 @@ def _discover_lambda_functions(
             func_name = func.get("FunctionName", "unknown")
             func_arn = func.get("FunctionArn", "")
             runtime = func.get("Runtime", "")
+            role_arn = func.get("Role", "")
 
             if runtime not in _AI_RUNTIMES:
                 continue
@@ -677,7 +740,38 @@ def _discover_lambda_functions(
                 source="aws-lambda",
                 version=runtime,
                 mcp_servers=[server],
+                metadata={
+                    "cloud_origin": build_cloud_origin(
+                        provider="aws",
+                        service="lambda",
+                        resource_type="function",
+                        resource_id=func_arn,
+                        resource_name=func_name,
+                        location=region,
+                        raw_identity={"function_name": func_name, "function_arn": func_arn, "runtime": runtime},
+                    )
+                },
             )
+            cloud_timestamps = build_cloud_timestamps(
+                provider="aws",
+                service="lambda",
+                resource_type="function",
+                updated_at=func.get("LastModified"),
+                updated_source="LastModified",
+            )
+            if cloud_timestamps:
+                agent.metadata["cloud_timestamps"] = cloud_timestamps
+            cloud_principal = build_cloud_principal(
+                provider="aws",
+                service="lambda",
+                resource_type="function",
+                principal_type="iam-role",
+                principal_id=role_arn or None,
+                source_field="Role",
+                raw_identity={"role_arn": role_arn},
+            )
+            if cloud_principal:
+                agent.metadata["cloud_principal"] = cloud_principal
             agents.append(agent)
 
     return agents, warnings
@@ -741,6 +835,22 @@ def _discover_eks_images(
                     config_path=f"eks://{cluster_name}/{pod_name}",
                     source="aws-eks",
                     mcp_servers=[server],
+                    metadata={
+                        "cloud_origin": build_cloud_origin(
+                            provider="aws",
+                            service="eks",
+                            resource_type="pod-image",
+                            resource_id=f"{cluster_name}/{pod_name}/{container_name}",
+                            resource_name=pod_name,
+                            location=region,
+                            raw_identity={
+                                "cluster": cluster_name,
+                                "pod": pod_name,
+                                "container": container_name,
+                                "image": image_ref,
+                            },
+                        )
+                    },
                 )
                 agents.append(agent)
 
@@ -782,6 +892,7 @@ def _discover_step_functions(
                 detail = sfn_client.describe_state_machine(stateMachineArn=sm_arn)
                 definition_str = detail.get("definition", "{}")
                 definition = json.loads(definition_str)
+                role_arn = detail.get("roleArn", "")
             except Exception as exc:
                 warnings.append(f"Could not describe Step Function {sm_name}: {exc}")
                 continue
@@ -830,7 +941,39 @@ def _discover_step_functions(
                 config_path=sm_arn,
                 source="aws-step-functions",
                 mcp_servers=servers,
+                metadata={
+                    "cloud_origin": build_cloud_origin(
+                        provider="aws",
+                        service="step-functions",
+                        resource_type="state-machine",
+                        resource_id=sm_arn,
+                        resource_name=sm_name,
+                        location=region,
+                        raw_identity={"state_machine_arn": sm_arn, "name": sm_name},
+                    )
+                },
             )
+            cloud_timestamps = build_cloud_timestamps(
+                provider="aws",
+                service="step-functions",
+                resource_type="state-machine",
+                created_at=sm.get("creationDate") or detail.get("creationDate"),
+                updated_source=None,
+                created_source="creationDate",
+            )
+            if cloud_timestamps:
+                agent.metadata["cloud_timestamps"] = cloud_timestamps
+            cloud_principal = build_cloud_principal(
+                provider="aws",
+                service="step-functions",
+                resource_type="state-machine",
+                principal_type="iam-role",
+                principal_id=role_arn or None,
+                source_field="roleArn",
+                raw_identity={"role_arn": role_arn},
+            )
+            if cloud_principal:
+                agent.metadata["cloud_principal"] = cloud_principal
             agents.append(agent)
 
     return agents, warnings
@@ -903,6 +1046,7 @@ def _discover_ec2_instances(
                     instance_id = instance.get("InstanceId", "unknown")
                     instance_type = instance.get("InstanceType", "")
                     ami_id = instance.get("ImageId", "")
+                    launch_time = instance.get("LaunchTime")
 
                     tags = {t["Key"]: t["Value"] for t in instance.get("Tags", [])}
                     name = tags.get("Name", instance_id)
@@ -920,7 +1064,27 @@ def _discover_ec2_instances(
                         source="aws-ec2",
                         version=f"{instance_type} ({ami_id})",
                         mcp_servers=[server],
+                        metadata={
+                            "cloud_origin": build_cloud_origin(
+                                provider="aws",
+                                service="ec2",
+                                resource_type="instance",
+                                resource_id=instance_id,
+                                resource_name=name,
+                                location=region,
+                                raw_identity={"instance_id": instance_id, "instance_type": instance_type, "ami_id": ami_id},
+                            )
+                        },
                     )
+                    cloud_timestamps = build_cloud_timestamps(
+                        provider="aws",
+                        service="ec2",
+                        resource_type="instance",
+                        created_at=launch_time,
+                        created_source="LaunchTime",
+                    )
+                    if cloud_timestamps:
+                        agent.metadata["cloud_timestamps"] = cloud_timestamps
                     agents.append(agent)
 
     except Exception as exc:

--- a/src/agent_bom/cloud/azure.py
+++ b/src/agent_bom/cloud/azure.py
@@ -432,6 +432,21 @@ def _discover_openai_deployments(
                             ),
                         },
                     )
+                    cloud_scope = build_cloud_scope(
+                        provider="azure",
+                        service="openai",
+                        resource_type="deployment",
+                        scope_type="account",
+                        scope_id=account_id,
+                        scope_name=account_name,
+                        parent_scope_type="resource-group",
+                        parent_scope_id=rg_name,
+                        parent_scope_name=rg_name,
+                        location=account_location or None,
+                        source_fields=["account.id", "account.location", "deployment.id"],
+                    )
+                    if cloud_scope:
+                        agent.metadata["cloud_scope"] = cloud_scope
                     agents.append(agent)
             except Exception as exc:
                 warnings.append(f"Could not list deployments for OpenAI account {account_name}: {exc}")
@@ -595,6 +610,8 @@ def _discover_container_instances(
         for group in client.container_groups.list():
             group_name = group.name or "unknown"
             group_id = group.id or f"azure://aci/{group_name}"
+            group_location = getattr(group, "location", "") or ""
+            rg_name = _extract_azure_resource_group(group_id)
             containers = getattr(group, "containers", []) or []
 
             for container in containers:
@@ -623,11 +640,26 @@ def _discover_container_instances(
                             resource_type="container",
                             resource_id=f"{group_id}/{container_name}",
                             resource_name=container_name,
+                            location=group_location or None,
                             subscription_id=subscription_id,
                             raw_identity={"group_id": group_id, "group_name": group_name, "container": container_name, "image": image},
                         ),
                     },
                 )
+                cloud_scope = build_cloud_scope(
+                    provider="azure",
+                    service="container-instances",
+                    resource_type="container",
+                    scope_type="resource-group",
+                    scope_id=rg_name,
+                    scope_name=rg_name or None,
+                    parent_scope_type="subscription",
+                    parent_scope_id=subscription_id,
+                    location=group_location or None,
+                    source_fields=["id", "location"],
+                )
+                if cloud_scope:
+                    agent.metadata["cloud_scope"] = cloud_scope
                 agents.append(agent)
 
     except Exception as exc:
@@ -671,6 +703,7 @@ def _discover_ml_endpoints(
                 for endpoint in client.online_endpoints.list(rg_name, ws_name):
                     ep_name = endpoint.name or "unknown"
                     ep_id = endpoint.id or f"azure://ml/{ws_name}/{ep_name}"
+                    endpoint_location = getattr(endpoint, "location", "") or getattr(ws, "location", "") or ""
                     properties = getattr(endpoint, "properties", None)
                     scoring_uri = getattr(properties, "scoring_uri", "") if properties else ""
 
@@ -714,11 +747,27 @@ def _discover_ml_endpoints(
                                 resource_type="online-endpoint",
                                 resource_id=ep_id,
                                 resource_name=ep_name,
+                                location=endpoint_location or None,
                                 subscription_id=subscription_id,
                                 raw_identity={"id": ep_id, "workspace": ws_name, "name": ep_name},
                             ),
                         },
                     )
+                    cloud_scope = build_cloud_scope(
+                        provider="azure",
+                        service="machine-learning",
+                        resource_type="online-endpoint",
+                        scope_type="workspace",
+                        scope_id=ws_id or ws_name,
+                        scope_name=ws_name,
+                        parent_scope_type="resource-group",
+                        parent_scope_id=rg_name,
+                        parent_scope_name=rg_name,
+                        location=endpoint_location or None,
+                        source_fields=["workspace.id", "endpoint.id", "endpoint.location"],
+                    )
+                    if cloud_scope:
+                        agent.metadata["cloud_scope"] = cloud_scope
                     agents.append(agent)
 
             except Exception as exc:

--- a/src/agent_bom/cloud/azure.py
+++ b/src/agent_bom/cloud/azure.py
@@ -529,7 +529,20 @@ def _discover_azure_functions(
                 config_path=app_id,
                 source="azure-functions",
                 mcp_servers=[server],
-                metadata={"runtime": runtime_stack, "location": location},
+                metadata={
+                    "runtime": runtime_stack,
+                    "location": location,
+                    "cloud_origin": build_cloud_origin(
+                        provider="azure",
+                        service="functions",
+                        resource_type="function-app",
+                        resource_id=app_id,
+                        resource_name=app_name,
+                        location=location or None,
+                        subscription_id=subscription_id,
+                        raw_identity={"id": app_id, "name": app_name, "runtime": runtime_stack},
+                    ),
+                },
             )
             cloud_scope = build_cloud_scope(
                 provider="azure",
@@ -602,7 +615,18 @@ def _discover_container_instances(
                     config_path=group_id,
                     source="azure-container-instances",
                     mcp_servers=[server],
-                    metadata={"image": image},
+                    metadata={
+                        "image": image,
+                        "cloud_origin": build_cloud_origin(
+                            provider="azure",
+                            service="container-instances",
+                            resource_type="container",
+                            resource_id=f"{group_id}/{container_name}",
+                            resource_name=container_name,
+                            subscription_id=subscription_id,
+                            raw_identity={"group_id": group_id, "group_name": group_name, "container": container_name, "image": image},
+                        ),
+                    },
                 )
                 agents.append(agent)
 
@@ -684,6 +708,15 @@ def _discover_ml_endpoints(
                         metadata={
                             "workspace": ws_name,
                             "deployments": deploy_meta,
+                            "cloud_origin": build_cloud_origin(
+                                provider="azure",
+                                service="machine-learning",
+                                resource_type="online-endpoint",
+                                resource_id=ep_id,
+                                resource_name=ep_name,
+                                subscription_id=subscription_id,
+                                raw_identity={"id": ep_id, "workspace": ws_name, "name": ep_name},
+                            ),
                         },
                     )
                     agents.append(agent)

--- a/src/agent_bom/cloud/coreweave.py
+++ b/src/agent_bom/cloud/coreweave.py
@@ -22,7 +22,7 @@ import subprocess
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 from .base import CloudDiscoveryError
-from .normalization import build_package_purl, parse_container_image_package
+from .normalization import build_cloud_origin, build_package_purl, parse_container_image_package
 
 logger = logging.getLogger(__name__)
 
@@ -185,6 +185,15 @@ def _discover_virtual_servers(
                 "gpu_count": gpu_count,
                 "region": region,
                 "kind": "VirtualServer",
+                "cloud_origin": build_cloud_origin(
+                    provider="coreweave",
+                    service="kubernetes",
+                    resource_type="virtual-server",
+                    resource_id=f"{ns}/{name}",
+                    resource_name=name,
+                    location=region or None,
+                    raw_identity={"namespace": ns, "name": name, "kind": "VirtualServer"},
+                ),
             },
         )
         agents.append(agent)
@@ -264,6 +273,14 @@ def _discover_inference_services(
             "runtime": runtime,
             "serving_url": serving_url,
             "kind": "InferenceService",
+            "cloud_origin": build_cloud_origin(
+                provider="coreweave",
+                service="kubernetes",
+                resource_type="inference-service",
+                resource_id=f"{ns}/{name}",
+                resource_name=name,
+                raw_identity={"namespace": ns, "name": name, "kind": "InferenceService", "image": runtime_image},
+            ),
         }
         if is_nim:
             metadata["is_nim"] = True
@@ -352,6 +369,14 @@ def _discover_gpu_pods(
                 "gpu_count": gpu_count,
                 "image": image_ref,
                 "kind": "Pod",
+                "cloud_origin": build_cloud_origin(
+                    provider="coreweave",
+                    service="kubernetes",
+                    resource_type="gpu-pod",
+                    resource_id=f"{pod_ns}/{pod_name}",
+                    resource_name=pod_name,
+                    raw_identity={"namespace": pod_ns, "pod": pod_name, "image": image_ref},
+                ),
             }
             if is_nim:
                 metadata["is_nim"] = True
@@ -444,6 +469,14 @@ def _discover_infiniband_jobs(
                     "gpu_count": int(gpu_limits) if gpu_limits != "0" else 0,
                     "image": image_ref,
                     "kind": "Pod",
+                    "cloud_origin": build_cloud_origin(
+                        provider="coreweave",
+                        service="kubernetes",
+                        resource_type="training-pod",
+                        resource_id=f"{pod_ns}/{pod_name}",
+                        resource_name=pod_name,
+                        raw_identity={"namespace": pod_ns, "pod": pod_name, "image": image_ref},
+                    ),
                 },
             )
             agents.append(agent)

--- a/src/agent_bom/cloud/databricks.py
+++ b/src/agent_bom/cloud/databricks.py
@@ -28,7 +28,7 @@ from typing import Any, Optional
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 from .base import CloudDiscoveryError
-from .normalization import build_cloud_state, build_package_purl, normalize_cloud_lifecycle_state
+from .normalization import build_cloud_origin, build_cloud_state, build_package_purl, normalize_cloud_lifecycle_state
 
 logger = logging.getLogger(__name__)
 
@@ -115,6 +115,14 @@ def discover(
             source="databricks",
             mcp_servers=[server],
             metadata={
+                "cloud_origin": build_cloud_origin(
+                    provider="databricks",
+                    service="clusters",
+                    resource_type="cluster",
+                    resource_id=cluster_id,
+                    resource_name=cluster_name,
+                    raw_identity={"cluster_id": cluster_id, "cluster_name": cluster_name},
+                ),
                 "cloud_state": build_cloud_state(
                     provider="databricks",
                     service="clusters",
@@ -122,7 +130,7 @@ def discover(
                     lifecycle_state=lifecycle_state,
                     raw_state=state_str,
                     state_source="cluster.state",
-                )
+                ),
             },
         )
         agents.append(agent)
@@ -158,6 +166,14 @@ def discover(
                 source="databricks",
                 mcp_servers=[server],
                 metadata={
+                    "cloud_origin": build_cloud_origin(
+                        provider="databricks",
+                        service="model-serving",
+                        resource_type="serving-endpoint",
+                        resource_id=ep_name,
+                        resource_name=ep_name,
+                        raw_identity={"name": ep_name},
+                    ),
                     "cloud_state": build_cloud_state(
                         provider="databricks",
                         service="model-serving",
@@ -165,7 +181,7 @@ def discover(
                         lifecycle_state=lifecycle_state,
                         raw_state=state_str,
                         state_source="state.ready",
-                    )
+                    ),
                 },
             )
             agents.append(agent)

--- a/src/agent_bom/cloud/gcp.py
+++ b/src/agent_bom/cloud/gcp.py
@@ -319,6 +319,16 @@ def _discover_cloud_functions(
                     "runtime": runtime,
                     "entry_point": entry_point,
                     "source_uri": source_uri,
+                    "cloud_origin": build_cloud_origin(
+                        provider="gcp",
+                        service="cloud-functions",
+                        resource_type="function",
+                        resource_id=fn_resource,
+                        resource_name=fn_name,
+                        location=region,
+                        project_id=project_id,
+                        raw_identity={"name": fn_resource, "display_name": fn_name, "runtime": runtime},
+                    ),
                 },
             )
             cloud_scope = build_cloud_scope(
@@ -439,6 +449,16 @@ def _discover_gke_clusters(
                     "region": cluster_location,
                     "cluster_version": cluster_version,
                     "node_pools": node_pool_info,
+                    "cloud_origin": build_cloud_origin(
+                        provider="gcp",
+                        service="gke",
+                        resource_type="cluster",
+                        resource_id=cluster_self_link or f"projects/{project_id}/locations/{cluster_location}/clusters/{cluster_name}",
+                        resource_name=cluster_name,
+                        location=cluster_location,
+                        project_id=project_id,
+                        raw_identity={"name": cluster_name, "self_link": cluster_self_link, "version": cluster_version},
+                    ),
                 },
             )
             agents.append(agent)

--- a/src/agent_bom/cloud/huggingface.py
+++ b/src/agent_bom/cloud/huggingface.py
@@ -15,6 +15,7 @@ import os
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
 from .base import CloudDiscoveryError
+from .normalization import build_cloud_origin
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ def discover(
     agents: list[Agent] = []
     warnings: list[str] = []
 
-    resolved_token = token or os.environ.get("HF_TOKEN", "")
+    resolved_token = token or os.environ.get("HF_TOKEN") or ""
 
     author = organization or username
     if not author and not resolved_token:
@@ -127,6 +128,14 @@ def _discover_models(
 
         # Parse model card metadata (YAML frontmatter)
         card_meta = _parse_model_card(model)
+        card_meta["cloud_origin"] = build_cloud_origin(
+            provider="huggingface",
+            service="hub",
+            resource_type="model",
+            resource_id=model_id,
+            resource_name=model_id,
+            raw_identity={"id": model_id, "library_name": library, "pipeline_tag": pipeline_tag},
+        )
 
         agent = Agent(
             name=f"hf-model:{model_id}",
@@ -186,6 +195,16 @@ def _discover_spaces(
             source="huggingface-space",
             version=sdk or None,
             mcp_servers=[server],
+            metadata={
+                "cloud_origin": build_cloud_origin(
+                    provider="huggingface",
+                    service="spaces",
+                    resource_type="space",
+                    resource_id=space_id,
+                    resource_name=space_id,
+                    raw_identity={"id": space_id, "sdk": sdk},
+                )
+            },
         )
         agents.append(agent)
 
@@ -229,6 +248,16 @@ def _discover_inference_endpoints(
             source="huggingface-endpoint",
             version=str(status),
             mcp_servers=[server],
+            metadata={
+                "cloud_origin": build_cloud_origin(
+                    provider="huggingface",
+                    service="inference-endpoints",
+                    resource_type="endpoint",
+                    resource_id=ep_name,
+                    resource_name=ep_name,
+                    raw_identity={"name": ep_name, "status": status, "framework": framework},
+                )
+            },
         )
         agents.append(agent)
 

--- a/src/agent_bom/cloud/mlflow_provider.py
+++ b/src/agent_bom/cloud/mlflow_provider.py
@@ -15,7 +15,7 @@ import os
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
 from .base import CloudDiscoveryError
-from .normalization import build_package_purl
+from .normalization import build_cloud_origin, build_package_purl
 
 logger = logging.getLogger(__name__)
 
@@ -149,6 +149,16 @@ def _discover_registered_models(
                 source="mlflow-model",
                 version=f"v{model_version}" + (f" ({model_stage})" if model_stage else ""),
                 mcp_servers=[server],
+                metadata={
+                    "cloud_origin": build_cloud_origin(
+                        provider="mlflow",
+                        service="model-registry",
+                        resource_type="model",
+                        resource_id=model_name,
+                        resource_name=model_name,
+                        raw_identity={"tracking_uri": tracking_uri, "name": model_name},
+                    )
+                },
             )
             agents.append(agent)
 
@@ -221,6 +231,16 @@ def _discover_experiments(
                 source="mlflow-experiment",
                 version=exp_id,
                 mcp_servers=[server],
+                metadata={
+                    "cloud_origin": build_cloud_origin(
+                        provider="mlflow",
+                        service="tracking",
+                        resource_type="experiment",
+                        resource_id=exp_id,
+                        resource_name=exp_name,
+                        raw_identity={"tracking_uri": tracking_uri, "experiment_id": exp_id, "name": exp_name},
+                    )
+                },
             )
             agents.append(agent)
 

--- a/src/agent_bom/cloud/nebius.py
+++ b/src/agent_bom/cloud/nebius.py
@@ -19,7 +19,7 @@ import subprocess
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
 from .base import CloudDiscoveryError
-from .normalization import build_package_purl, parse_container_image_package
+from .normalization import build_cloud_origin, build_package_purl, parse_container_image_package
 
 logger = logging.getLogger(__name__)
 
@@ -205,6 +205,17 @@ def _discover_ai_studio(
                 source="nebius-ai-studio",
                 version=f"{status} (v{model_version})",
                 mcp_servers=[server],
+                metadata={
+                    "cloud_origin": build_cloud_origin(
+                        provider="nebius",
+                        service="ai-studio",
+                        resource_type="model",
+                        resource_id=model_id,
+                        resource_name=model_name,
+                        project_id=project_id,
+                        raw_identity={"id": model_id, "name": model_name, "status": status, "version": model_version},
+                    )
+                },
             )
             agents.append(agent)
 
@@ -300,7 +311,20 @@ def _discover_gpu_instances(
                 source="nebius-gpu",
                 version=status,
                 mcp_servers=[server],
-                metadata={"gpu_count": gpu_count, "gpu_type": gpu_type, "ai_workload": is_ai_workload},
+                metadata={
+                    "gpu_count": gpu_count,
+                    "gpu_type": gpu_type,
+                    "ai_workload": is_ai_workload,
+                    "cloud_origin": build_cloud_origin(
+                        provider="nebius",
+                        service="compute",
+                        resource_type="gpu-instance",
+                        resource_id=inst_id,
+                        resource_name=inst_name,
+                        project_id=project_id,
+                        raw_identity={"id": inst_id, "name": inst_name, "platform_id": platform_id, "status": status},
+                    ),
+                },
             )
             agents.append(agent)
 
@@ -403,7 +427,19 @@ def _discover_k8s_gpu_pods(
                         source="nebius-k8s-gpu",
                         version=f"gpu-request:{gpu_request or gpu_limit}",
                         mcp_servers=[server],
-                        metadata={"image": image_ref, "container": container_name},
+                        metadata={
+                            "image": image_ref,
+                            "container": container_name,
+                            "cloud_origin": build_cloud_origin(
+                                provider="nebius",
+                                service="kubernetes",
+                                resource_type="gpu-pod",
+                                resource_id=f"{pod_ns}/{pod_name}",
+                                resource_name=pod_name,
+                                project_id=project_id,
+                                raw_identity={"namespace": pod_ns, "pod": pod_name, "container": container_name, "image": image_ref},
+                            ),
+                        },
                     )
                     agents.append(agent)
 
@@ -460,6 +496,17 @@ def _discover_container_services(
                 config_path=f"nebius://{project_id}/containers/{svc_id}",
                 source="nebius-container",
                 mcp_servers=[server],
+                metadata={
+                    "cloud_origin": build_cloud_origin(
+                        provider="nebius",
+                        service="containers",
+                        resource_type="container",
+                        resource_id=svc_id,
+                        resource_name=svc_name,
+                        project_id=project_id,
+                        raw_identity={"id": svc_id, "name": svc_name, "image": image},
+                    )
+                },
             )
             agents.append(agent)
 

--- a/src/agent_bom/cloud/normalization.py
+++ b/src/agent_bom/cloud/normalization.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from agent_bom.package_utils import normalize_package_ecosystem
-from agent_bom.security import sanitize_error, sanitize_text
+from agent_bom.security import sanitize_error, sanitize_sensitive_payload, sanitize_text
 
 _UNKNOWN_PACKAGE_VERSIONS = {"", "unknown", "detected", "0.0"}
 _CLOUD_PURL_TYPE_ALIASES = {
@@ -152,9 +152,14 @@ def build_cloud_origin(
     if scope:
         envelope["scope"] = scope
     if raw_identity:
-        envelope["raw_identity"] = {
-            key: value for key, value in raw_identity.items() if isinstance(value, (str, int, float, bool)) and value not in ("", None)
-        }
+        sanitized_identity: dict[str, Any] = {}
+        for key, value in raw_identity.items():
+            if isinstance(value, (str, int, float, bool)) and value not in ("", None):
+                sanitized_value = sanitize_sensitive_payload(value, key=key, max_str_len=200)
+                if sanitized_value not in ("", None):
+                    sanitized_identity[str(key)] = sanitized_value
+        if sanitized_identity:
+            envelope["raw_identity"] = sanitized_identity
     return envelope
 
 
@@ -298,9 +303,14 @@ def build_cloud_principal(
     if source_field:
         envelope["source_field"] = source_field
     if raw_identity:
-        envelope["raw_identity"] = {
-            key: value for key, value in raw_identity.items() if isinstance(value, (str, int, float, bool)) and value not in ("", None)
-        }
+        sanitized_identity: dict[str, Any] = {}
+        for key, value in raw_identity.items():
+            if isinstance(value, (str, int, float, bool)) and value not in ("", None):
+                sanitized_value = sanitize_sensitive_payload(value, key=key, max_str_len=200)
+                if sanitized_value not in ("", None):
+                    sanitized_identity[str(key)] = sanitized_value
+        if sanitized_identity:
+            envelope["raw_identity"] = sanitized_identity
     return envelope
 
 

--- a/src/agent_bom/cloud/openai_provider.py
+++ b/src/agent_bom/cloud/openai_provider.py
@@ -15,6 +15,7 @@ import os
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
 from .base import CloudDiscoveryError
+from .normalization import build_cloud_origin
 
 logger = logging.getLogger(__name__)
 
@@ -152,6 +153,17 @@ def _discover_assistants(
                     source="openai-assistant",
                     version=model,
                     mcp_servers=[server],
+                    metadata={
+                        "cloud_origin": build_cloud_origin(
+                            provider="openai",
+                            service="assistants",
+                            resource_type="assistant",
+                            resource_id=asst_id,
+                            resource_name=asst_name,
+                            account_id=organization or None,
+                            raw_identity={"id": asst_id, "name": asst_name, "model": model},
+                        )
+                    },
                 )
                 agents.append(agent)
 
@@ -230,6 +242,23 @@ def _discover_fine_tunes(
                     source="openai-fine-tune",
                     version=f"{status} (base: {model})",
                     mcp_servers=[server],
+                    metadata={
+                        "cloud_origin": build_cloud_origin(
+                            provider="openai",
+                            service="fine-tuning",
+                            resource_type="job",
+                            resource_id=job_id,
+                            resource_name=fine_tuned_model,
+                            account_id=organization or None,
+                            raw_identity={
+                                "id": job_id,
+                                "model": model,
+                                "fine_tuned_model": fine_tuned_model,
+                                "status": status,
+                                "training_file": training_file,
+                            },
+                        )
+                    },
                 )
                 agents.append(agent)
 

--- a/src/agent_bom/cloud/snowflake.py
+++ b/src/agent_bom/cloud/snowflake.py
@@ -55,7 +55,7 @@ from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, Tran
 from agent_bom.security import sanitize_error
 
 from .base import CloudDiscoveryError
-from .normalization import build_package_purl
+from .normalization import build_cloud_origin, build_package_purl
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +65,33 @@ def _env_or_value(value: str | None, env_var: str, default: str = "") -> str:
     if value is not None:
         return value
     return os.environ.get(env_var) or default
+
+
+def _snowflake_cloud_origin(
+    *,
+    account: str,
+    service: str,
+    resource_type: str,
+    resource_id: str,
+    resource_name: str,
+    database: str = "",
+    schema: str = "",
+) -> dict[str, Any]:
+    raw_identity = {
+        "account": account,
+        "database": database,
+        "schema": schema,
+        "name": resource_name,
+    }
+    return build_cloud_origin(
+        provider="snowflake",
+        service=service,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        resource_name=resource_name,
+        account_id=account,
+        raw_identity=raw_identity,
+    )
 
 
 def _resolve_snowflake_auth(
@@ -277,6 +304,15 @@ def discover(
                     config_path=f"snowflake://{resolved_account}/custom-tools",
                     source="snowflake-tools",
                     mcp_servers=[tool_server],
+                    metadata={
+                        "cloud_origin": _snowflake_cloud_origin(
+                            account=resolved_account,
+                            service="custom-tools",
+                            resource_type="tool-collection",
+                            resource_id=f"{resolved_account}/custom-tools",
+                            resource_name="custom-tools",
+                        )
+                    },
                 )
             )
 
@@ -298,6 +334,15 @@ def discover(
                 config_path=f"snowflake://{resolved_account}",
                 source="snowflake",
                 mcp_servers=[server],
+                metadata={
+                    "cloud_origin": _snowflake_cloud_origin(
+                        account=resolved_account,
+                        service="snowpark",
+                        resource_type="package-environment",
+                        resource_id=resolved_account,
+                        resource_name=resolved_account,
+                    )
+                },
             )
             agents.append(agent)
 
@@ -359,6 +404,17 @@ def _discover_cortex_services(
                 config_path=config_path,
                 source="snowflake-cortex",
                 mcp_servers=[server],
+                metadata={
+                    "cloud_origin": _snowflake_cloud_origin(
+                        account=account,
+                        service="cortex-search",
+                        resource_type="service",
+                        resource_id=config_path,
+                        resource_name=service_name,
+                        database=svc_database,
+                        schema=svc_schema,
+                    )
+                },
             )
             agents.append(agent)
 
@@ -587,6 +643,15 @@ def _discover_snowflake_notebooks(
                     "schema": nb_schema,
                     "owner": nb_owner,
                     "comment": nb_comment,
+                    "cloud_origin": _snowflake_cloud_origin(
+                        account=account,
+                        service="notebooks",
+                        resource_type="notebook",
+                        resource_id=f"{account}/{nb_db}/{nb_schema}/{nb_name}",
+                        resource_name=nb_name,
+                        database=nb_db,
+                        schema=nb_schema,
+                    ),
                 },
                 mcp_servers=[server],
             )
@@ -660,6 +725,17 @@ def _discover_cortex_agents(
                 config_path=config_path,
                 source="snowflake-cortex-agent",
                 mcp_servers=[server],
+                metadata={
+                    "cloud_origin": _snowflake_cloud_origin(
+                        account=account,
+                        service="cortex-agents",
+                        resource_type="agent",
+                        resource_id=config_path,
+                        resource_name=agent_name,
+                        database=db_name,
+                        schema=schema_name,
+                    )
+                },
             )
             agents.append(agent)
 
@@ -714,6 +790,17 @@ def _discover_mcp_servers(
                 config_path=config_path,
                 source="snowflake-mcp",
                 mcp_servers=[mcp_server],
+                metadata={
+                    "cloud_origin": _snowflake_cloud_origin(
+                        account=account,
+                        service="mcp",
+                        resource_type="server",
+                        resource_id=config_path,
+                        resource_name=server_name,
+                        database=db_name,
+                        schema=schema_name,
+                    )
+                },
             )
             agents.append(agent)
 
@@ -829,6 +916,15 @@ def _discover_from_query_history(
                 config_path=f"snowflake://{account}/query-history/{obj_name}",
                 source=source,
                 mcp_servers=[server],
+                metadata={
+                    "cloud_origin": _snowflake_cloud_origin(
+                        account=account,
+                        service="query-history",
+                        resource_type=obj_type,
+                        resource_id=f"{account}/query-history/{obj_name}",
+                        resource_name=obj_name,
+                    )
+                },
             )
             agents.append(agent)
 

--- a/src/agent_bom/cloud/wandb_provider.py
+++ b/src/agent_bom/cloud/wandb_provider.py
@@ -15,7 +15,7 @@ import os
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 from .base import CloudDiscoveryError
-from .normalization import build_package_purl
+from .normalization import build_cloud_origin, build_package_purl
 
 logger = logging.getLogger(__name__)
 
@@ -139,6 +139,18 @@ def _run_to_agent(run, entity: str, project: str | None) -> Agent | None:
         source="wandb-run",
         version=run_id[:8],
         mcp_servers=[server],
+        metadata={
+            "cloud_origin": build_cloud_origin(
+                provider="wandb",
+                service="runs",
+                resource_type="run",
+                resource_id=str(run_id),
+                resource_name=str(run_name),
+                account_id=entity,
+                project_id=project or None,
+                raw_identity={"id": run_id, "name": run_name, "entity": entity, "project": project or ""},
+            )
+        },
     )
 
 
@@ -186,6 +198,18 @@ def _discover_artifacts(
                         source=f"wandb-{art_type}",
                         version=str(art_version),
                         mcp_servers=[server],
+                        metadata={
+                            "cloud_origin": build_cloud_origin(
+                                provider="wandb",
+                                service="artifacts",
+                                resource_type=art_type,
+                                resource_id=art_name,
+                                resource_name=art_name,
+                                account_id=entity,
+                                project_id=project,
+                                raw_identity={"name": art_name, "version": art_version, "entity": entity, "project": project},
+                            )
+                        },
                     )
                     agents.append(agent)
             except (ValueError, KeyError, AttributeError) as exc:

--- a/src/agent_bom/output/graph_export.py
+++ b/src/agent_bom/output/graph_export.py
@@ -24,19 +24,27 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from typing import Union
+from typing import Any, Union
 
 # ── Internal graph representation ──────────────────────────────────────────────
 
 
 class _Node:
-    __slots__ = ("id", "label", "kind", "severity")
+    __slots__ = ("id", "label", "kind", "severity", "attributes")
 
-    def __init__(self, node_id: str, label: str, kind: str, severity: str = "") -> None:
+    def __init__(
+        self,
+        node_id: str,
+        label: str,
+        kind: str,
+        severity: str = "",
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
         self.id = node_id
         self.label = label
         self.kind = kind
         self.severity = severity
+        self.attributes = attributes or {}
 
 
 class _Edge:
@@ -56,9 +64,11 @@ class DepGraph:
         self._edges: list[_Edge] = []
         self._edge_set: set[tuple[str, str]] = set()
 
-    def add_node(self, node_id: str, label: str, kind: str, severity: str = "") -> None:
+    def add_node(self, node_id: str, label: str, kind: str, severity: str = "", attributes: dict[str, Any] | None = None) -> None:
         if node_id not in self._nodes:
-            self._nodes[node_id] = _Node(node_id, label, kind, severity)
+            self._nodes[node_id] = _Node(node_id, label, kind, severity, _compact_attributes(attributes))
+        elif attributes:
+            self._nodes[node_id].attributes.update(_compact_attributes(attributes))
 
     def add_edge(self, source: str, target: str, kind: str) -> None:
         key = (source, target)
@@ -84,35 +94,41 @@ class DepGraph:
 # ── Load from scan JSON ─────────────────────────────────────────────────────────
 
 
-def load_graph_from_scan(scan_path: Union[str, Path]) -> DepGraph:
-    """Build a :class:`DepGraph` from a saved JSON scan report.
+def _compact_attributes(attributes: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(attributes, dict):
+        return {}
+    return {key: value for key, value in attributes.items() if value not in (None, "", [], {})}
 
-    Args:
-        scan_path: Path to a JSON file produced by ``agent-bom scan --format json``.
 
-    Returns:
-        Populated :class:`DepGraph` with agent, server, package, and CVE nodes.
+def _agent_node_attributes(agent: dict[str, Any]) -> dict[str, Any]:
+    raw_metadata = agent.get("metadata")
+    metadata: dict[str, Any] = raw_metadata if isinstance(raw_metadata, dict) else {}
+    return _compact_attributes(
+        {
+            "source": agent.get("source"),
+            "status": agent.get("status"),
+            "discovered_at": agent.get("discovered_at"),
+            "last_seen": agent.get("last_seen"),
+            "cloud_origin": metadata.get("cloud_origin"),
+            "cloud_scope": metadata.get("cloud_scope"),
+            "cloud_state": metadata.get("cloud_state"),
+            "cloud_principal": metadata.get("cloud_principal"),
+        }
+    )
 
-    Raises:
-        ValueError: If the file is not a valid agent-bom JSON report.
-        FileNotFoundError: If the path does not exist.
-    """
-    path = Path(scan_path)
-    data = json.loads(path.read_text())
 
-    if data.get("document_type") != "AI-BOM":
-        raise ValueError(f"{scan_path} does not appear to be an agent-bom JSON report (missing 'document_type: AI-BOM')")
-
+def build_graph_from_scan_data(data: dict[str, Any]) -> DepGraph:
+    """Build a :class:`DepGraph` from an in-memory scan JSON report."""
     graph = DepGraph()
 
     for agent in data.get("agents", []):
         agent_name = agent.get("name", "unknown-agent")
         source = agent.get("source") or "local"
         source_id = f"provider:{source}"
-        graph.add_node(source_id, source, "provider")
+        graph.add_node(source_id, source, "provider", attributes={"provider": source})
 
         agent_id = f"agent:{agent_name}"
-        graph.add_node(agent_id, agent_name, "agent")
+        graph.add_node(agent_id, agent_name, "agent", attributes=_agent_node_attributes(agent))
         graph.add_edge(source_id, agent_id, "hosts")
 
         for server in agent.get("mcp_servers", []):
@@ -153,6 +169,28 @@ def load_graph_from_scan(scan_path: Union[str, Path]) -> DepGraph:
                     graph.add_edge(pkg_id, cve_id, "affects")
 
     return graph
+
+
+def load_graph_from_scan(scan_path: Union[str, Path]) -> DepGraph:
+    """Build a :class:`DepGraph` from a saved JSON scan report.
+
+    Args:
+        scan_path: Path to a JSON file produced by ``agent-bom scan --format json``.
+
+    Returns:
+        Populated :class:`DepGraph` with agent, server, package, and CVE nodes.
+
+    Raises:
+        ValueError: If the file is not a valid agent-bom JSON report.
+        FileNotFoundError: If the path does not exist.
+    """
+    path = Path(scan_path)
+    data = json.loads(path.read_text())
+
+    if data.get("document_type") != "AI-BOM":
+        raise ValueError(f"{scan_path} does not appear to be an agent-bom JSON report (missing 'document_type: AI-BOM')")
+
+    return build_graph_from_scan_data(data)
 
 
 # ── Export formats ──────────────────────────────────────────────────────────────
@@ -299,7 +337,16 @@ def to_json(graph: DepGraph) -> dict:
         Dict with ``nodes``, ``edges``, and ``stats`` keys.
     """
     return {
-        "nodes": [{"id": n.id, "label": n.label, "kind": n.kind, "severity": n.severity} for n in graph.nodes],
+        "nodes": [
+            {
+                "id": n.id,
+                "label": n.label,
+                "kind": n.kind,
+                "severity": n.severity,
+                "attributes": n.attributes,
+            }
+            for n in graph.nodes
+        ],
         "edges": [{"source": e.source, "target": e.target, "kind": e.kind} for e in graph.edges],
         "stats": {
             "node_count": graph.node_count(),
@@ -338,6 +385,7 @@ _GRAPHML_KEYS = [
     ("has_credentials", "node", "boolean", "MCP server exposes credentials"),
     ("is_vulnerable", "node", "boolean", "Package has known vulnerabilities"),
     ("is_transitive", "node", "boolean", "Transitive (indirect) dependency"),
+    ("attributes_json", "node", "string", "Additional AIBOM node attributes as compact JSON"),
     ("relationship", "edge", "string", "AIBOM relationship type"),
 ]
 
@@ -388,6 +436,8 @@ def to_graphml(graph: DepGraph) -> str:
         lines.append(f'      <data key="has_credentials">{"true" if node.kind == "server_cred" else "false"}</data>')
         lines.append(f'      <data key="is_vulnerable">{"true" if node.kind == "pkg_vuln" else "false"}</data>')
         lines.append(f'      <data key="is_transitive">{"true" if node.kind == "pkg_transitive" else "false"}</data>')
+        if node.attributes:
+            lines.append(f'      <data key="attributes_json">{_xml_escape(json.dumps(node.attributes, sort_keys=True))}</data>')
         lines.append("    </node>")
 
     # Edges
@@ -453,6 +503,9 @@ def to_cypher(graph: DepGraph) -> str:
             props.append("is_vulnerable: true")
         if node.kind == "pkg_transitive":
             props.append("is_transitive: true")
+        if node.attributes:
+            attrs_json = _cypher_str(json.dumps(node.attributes, sort_keys=True))
+            props.append(f"attributes_json: '{attrs_json}'")
 
         props_str = ", ".join(props)
         lines.append(f"MERGE (:{label} {{{props_str}}});")

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -306,7 +306,12 @@ def test_aws_ecs_images_collected():
     ecs_task_pag.paginate.return_value = [{"taskArns": ["arn:aws:ecs:us-east-1:123:task/prod/abc"]}]
     mock_ecs.get_paginator.side_effect = lambda op: {"list_clusters": ecs_cluster_pag, "list_tasks": ecs_task_pag}[op]
     mock_ecs.describe_tasks.return_value = {
-        "tasks": [{"containers": [{"image": "123456.dkr.ecr.us-east-1.amazonaws.com/ml-model:latest"}]}]
+        "tasks": [
+            {
+                "taskArn": "arn:aws:ecs:us-east-1:123:task/prod/abc",
+                "containers": [{"name": "model", "image": "123456.dkr.ecr.us-east-1.amazonaws.com/ml-model:latest"}],
+            }
+        ]
     }
     mock_session.client.side_effect = lambda svc, **kw: {"bedrock-agent": mock_bedrock, "ecs": mock_ecs}[svc]
 
@@ -319,6 +324,12 @@ def test_aws_ecs_images_collected():
     ecs_agents = [a for a in agents if a.source == "aws-ecs"]
     assert len(ecs_agents) == 1
     assert "ml-model" in ecs_agents[0].name
+    origin = ecs_agents[0].metadata["cloud_origin"]
+    assert origin["provider"] == "aws"
+    assert origin["service"] == "ecs"
+    assert origin["resource_type"] == "container-image"
+    assert origin["raw_identity"]["task_arn"] == "arn:aws:ecs:us-east-1:123:task/prod/abc"
+    assert origin["raw_identity"]["container_name"] == "model"
 
 
 # ─── Databricks Provider Tests ───────────────────────────────────────────────
@@ -371,6 +382,11 @@ def test_databricks_cluster_packages():
     assert "openai" in pkg_names
     assert all(p.ecosystem == "pypi" for p in server.packages)
     assert agents[0].source == "databricks"
+    origin = agents[0].metadata["cloud_origin"]
+    assert origin["provider"] == "databricks"
+    assert origin["service"] == "clusters"
+    assert origin["resource_type"] == "cluster"
+    assert origin["resource_id"] == "cluster-123"
     state = agents[0].metadata["cloud_state"]
     assert state["provider"] == "databricks"
     assert state["service"] == "clusters"
@@ -427,6 +443,10 @@ def test_databricks_serving_endpoint_state_normalized():
     assert warnings == []
     assert len(agents) == 1
     assert agents[0].name == "databricks-serving:prod-endpoint"
+    origin = agents[0].metadata["cloud_origin"]
+    assert origin["provider"] == "databricks"
+    assert origin["service"] == "model-serving"
+    assert origin["resource_type"] == "serving-endpoint"
     state = agents[0].metadata["cloud_state"]
     assert state["provider"] == "databricks"
     assert state["service"] == "model-serving"
@@ -799,6 +819,10 @@ def test_snowflake_cortex_agents_discovered():
     assert len(agents) == 1
     assert agents[0].source == "snowflake-cortex-agent"
     assert "My AI Agent" in agents[0].name
+    origin = agents[0].metadata["cloud_origin"]
+    assert origin["provider"] == "snowflake"
+    assert origin["service"] == "cortex-agents"
+    assert origin["resource_type"] == "agent"
 
 
 def test_snowflake_mcp_servers_discovered():
@@ -825,6 +849,10 @@ def test_snowflake_mcp_servers_discovered():
     assert len(agents) == 1
     assert agents[0].source == "snowflake-mcp"
     assert "my-mcp-server" in agents[0].name
+    origin = agents[0].metadata["cloud_origin"]
+    assert origin["provider"] == "snowflake"
+    assert origin["service"] == "mcp"
+    assert origin["resource_type"] == "server"
 
 
 def test_snowflake_query_history_parsing():
@@ -975,6 +1003,10 @@ def test_aws_lambda_direct_discovery():
     assert len(lambda_agents) == 1
     assert "ai-inference" in lambda_agents[0].name
     assert lambda_agents[0].version == "python3.12"
+    origin = lambda_agents[0].metadata["cloud_origin"]
+    assert origin["provider"] == "aws"
+    assert origin["service"] == "lambda"
+    assert origin["resource_type"] == "function"
 
 
 def test_aws_step_functions_parsing():
@@ -1071,6 +1103,10 @@ def test_aws_ec2_tag_discovery():
     assert agents[0].source == "aws-ec2"
     assert "gpu-training" in agents[0].name
     assert "p4d.24xlarge" in agents[0].version
+    origin = agents[0].metadata["cloud_origin"]
+    assert origin["provider"] == "aws"
+    assert origin["service"] == "ec2"
+    assert origin["resource_type"] == "instance"
 
 
 def test_aws_eks_reuses_k8s():
@@ -1095,6 +1131,10 @@ def test_aws_eks_reuses_k8s():
     eks_agents = [a for a in agents if a.source == "aws-eks"]
     assert len(eks_agents) == 1
     assert "my-eks-cluster" in eks_agents[0].name
+    origin = eks_agents[0].metadata["cloud_origin"]
+    assert origin["provider"] == "aws"
+    assert origin["service"] == "eks"
+    assert origin["resource_type"] == "pod-image"
     mock_discover.assert_called_once_with(all_namespaces=True, context="my-eks-cluster")
 
 
@@ -1136,6 +1176,10 @@ def test_nebius_ai_studio_discovery():
     ai_agents = [a for a in agents if a.source == "nebius-ai-studio"]
     assert len(ai_agents) == 2
     assert "llama-3-70b" in ai_agents[0].name
+    origin = ai_agents[0].metadata["cloud_origin"]
+    assert origin["provider"] == "nebius"
+    assert origin["service"] == "ai-studio"
+    assert origin["resource_type"] == "model"
 
 
 def test_nebius_gpu_instance_discovery():
@@ -1180,6 +1224,10 @@ def test_nebius_gpu_instance_discovery():
     assert len(gpu_agents) == 1
     assert "training-node" in gpu_agents[0].name
     assert gpu_agents[0].metadata["ai_workload"] is True
+    origin = gpu_agents[0].metadata["cloud_origin"]
+    assert origin["provider"] == "nebius"
+    assert origin["service"] == "compute"
+    assert origin["resource_type"] == "gpu-instance"
 
 
 # ─── CLI Deep Flag Tests ────────────────────────────────────────────────────
@@ -1250,6 +1298,9 @@ def test_hf_models_discovered():
     model_agents = [a for a in agents if a.source == "huggingface-model"]
     assert len(model_agents) == 1
     assert "my-bert-model" in model_agents[0].name
+    origin = model_agents[0].metadata["cloud_origin"]
+    assert origin["provider"] == "huggingface"
+    assert origin["resource_type"] == "model"
     # Framework packages extracted
     pkgs = model_agents[0].mcp_servers[0].packages
     pkg_names = {p.name for p in pkgs}
@@ -1278,6 +1329,9 @@ def test_hf_spaces_discovered():
     space_agents = [a for a in agents if a.source == "huggingface-space"]
     assert len(space_agents) == 1
     assert "gradio-app" in space_agents[0].name
+    origin = space_agents[0].metadata["cloud_origin"]
+    assert origin["provider"] == "huggingface"
+    assert origin["resource_type"] == "space"
     pkgs = space_agents[0].mcp_servers[0].packages
     assert any(p.name == "gradio" for p in pkgs)
 
@@ -1471,6 +1525,9 @@ def test_openai_assistants_discovered():
     assert len(asst_agents) == 1
     assert "Research Assistant" in asst_agents[0].name
     assert asst_agents[0].version == "gpt-4o"
+    origin = asst_agents[0].metadata["cloud_origin"]
+    assert origin["provider"] == "openai"
+    assert origin["resource_type"] == "assistant"
 
     # Tools mapped
     tools = asst_agents[0].mcp_servers[0].tools
@@ -1512,6 +1569,9 @@ def test_openai_fine_tunes_discovered():
     assert len(ft_agents) == 1
     assert "ft:gpt-4o-mini" in ft_agents[0].name
     assert "succeeded" in ft_agents[0].version
+    origin = ft_agents[0].metadata["cloud_origin"]
+    assert origin["provider"] == "openai"
+    assert origin["resource_type"] == "job"
 
 
 # ─── Azure Provider Tests ─────────────────────────────────────────────────
@@ -1627,6 +1687,7 @@ def test_azure_container_apps_discovered():
     origin = ca_agents[0].metadata["cloud_origin"]
     assert origin["provider"] == "azure"
     assert origin["service"] == "container-apps"
+    assert origin["resource_type"] == "container-app"
     assert origin["scope"]["subscription_id"] == "sub-123"
     timestamps = ca_agents[0].metadata["cloud_timestamps"]
     assert timestamps["created_at"] == "2026-04-10T14:30:00Z"
@@ -1935,6 +1996,7 @@ def test_gcp_vertex_ai_endpoints_discovered():
     origin = vertex_agents[0].metadata["cloud_origin"]
     assert origin["provider"] == "gcp"
     assert origin["service"] == "vertex-ai"
+    assert origin["resource_type"] == "endpoint"
     assert origin["scope"]["project_id"] == "my-project"
     timestamps = vertex_agents[0].metadata["cloud_timestamps"]
     assert timestamps["created_at"] == "2026-04-05T08:00:00Z"

--- a/tests/test_cloud_aws.py
+++ b/tests/test_cloud_aws.py
@@ -110,6 +110,139 @@ def test_discover_with_bedrock_agent():
         assert "bedrock:MyAgent" in agents[0].name
 
 
+def test_discover_persists_sts_account_scope_on_aws_origins():
+    """Representative AWS assets carry normalized account scope from STS."""
+    mock_boto3, mock_session = _mock_boto3()
+    mock_botocore = MagicMock()
+    mock_botocore.exceptions.ClientError = type("ClientError", (Exception,), {})
+    mock_botocore.exceptions.NoCredentialsError = type("NoCredentialsError", (Exception,), {})
+
+    mock_sts = MagicMock()
+    mock_sts.get_caller_identity.return_value = {"Account": "123456789012"}
+
+    mock_bedrock = MagicMock()
+    agents_paginator = MagicMock()
+    agents_paginator.paginate.return_value = [
+        {"agentSummaries": [{"agentId": "agent-1", "agentName": "SupportAgent", "agentStatus": "PREPARED"}]}
+    ]
+    action_groups_paginator = MagicMock()
+    action_groups_paginator.paginate.return_value = [{"actionGroupSummaries": []}]
+    mock_bedrock.get_paginator.side_effect = lambda op: {
+        "list_agents": agents_paginator,
+        "list_agent_action_groups": action_groups_paginator,
+    }[op]
+    mock_bedrock.get_agent.return_value = {
+        "agent": {
+            "agentArn": "arn:aws:bedrock:us-east-1:123456789012:agent/agent-1",
+            "foundationModel": "anthropic.claude-3-sonnet",
+        }
+    }
+
+    mock_ecs = MagicMock()
+    clusters_paginator = MagicMock()
+    clusters_paginator.paginate.return_value = [{"clusterArns": ["arn:aws:ecs:us-east-1:123456789012:cluster/prod"]}]
+    tasks_paginator = MagicMock()
+    tasks_paginator.paginate.return_value = [{"taskArns": ["arn:aws:ecs:us-east-1:123456789012:task/prod/task-1"]}]
+    mock_ecs.get_paginator.side_effect = lambda op: {"list_clusters": clusters_paginator, "list_tasks": tasks_paginator}[op]
+    mock_ecs.describe_tasks.return_value = {
+        "tasks": [
+            {
+                "taskArn": "arn:aws:ecs:us-east-1:123456789012:task/prod/task-1",
+                "containers": [{"name": "model-api", "image": "123456789012.dkr.ecr.us-east-1.amazonaws.com/model-api:2026-04"}],
+            }
+        ]
+    }
+
+    mock_session.client.side_effect = lambda service, **_kwargs: {
+        "sts": mock_sts,
+        "bedrock-agent": mock_bedrock,
+        "ecs": mock_ecs,
+    }[service]
+
+    with patch.dict(sys.modules, {"boto3": mock_boto3, "botocore": mock_botocore, "botocore.exceptions": mock_botocore.exceptions}):
+        from agent_bom.cloud import aws
+
+        agents, warnings = aws.discover(region="us-east-1", include_ecs=True)
+
+    assert not warnings
+    origins = {agent.source: agent.metadata["cloud_origin"] for agent in agents}
+    assert origins["aws-bedrock"]["scope"]["account_id"] == "123456789012"
+    assert origins["aws-bedrock"]["resource_id"] == "arn:aws:bedrock:us-east-1:123456789012:agent/agent-1"
+    assert origins["aws-ecs"]["scope"]["account_id"] == "123456789012"
+    assert origins["aws-ecs"]["raw_identity"]["cluster_arn"] == "arn:aws:ecs:us-east-1:123456789012:cluster/prod"
+
+
+def test_discover_continues_when_sts_account_resolution_is_denied():
+    """Denied STS permissions omit account scope without blocking discovery."""
+    mock_boto3, mock_session = _mock_boto3()
+    mock_botocore = MagicMock()
+    mock_botocore.exceptions.ClientError = type("ClientError", (Exception,), {})
+    mock_botocore.exceptions.NoCredentialsError = type("NoCredentialsError", (Exception,), {})
+
+    mock_sts = MagicMock()
+    mock_sts.get_caller_identity.side_effect = RuntimeError("AccessDenied")
+
+    mock_bedrock = MagicMock()
+    agents_paginator = MagicMock()
+    agents_paginator.paginate.return_value = [
+        {"agentSummaries": [{"agentId": "agent-1", "agentName": "SupportAgent", "agentStatus": "PREPARED"}]}
+    ]
+    action_groups_paginator = MagicMock()
+    action_groups_paginator.paginate.return_value = [{"actionGroupSummaries": []}]
+    mock_bedrock.get_paginator.side_effect = lambda op: {
+        "list_agents": agents_paginator,
+        "list_agent_action_groups": action_groups_paginator,
+    }[op]
+    mock_bedrock.get_agent.return_value = {
+        "agent": {
+            "agentArn": "arn:aws:bedrock:us-east-1:123456789012:agent/agent-1",
+            "foundationModel": "anthropic.claude-3-sonnet",
+        }
+    }
+    mock_session.client.side_effect = lambda service, **_kwargs: {"sts": mock_sts, "bedrock-agent": mock_bedrock}[service]
+
+    with patch.dict(sys.modules, {"boto3": mock_boto3, "botocore": mock_botocore, "botocore.exceptions": mock_botocore.exceptions}):
+        from agent_bom.cloud import aws
+
+        agents, warnings = aws.discover(region="us-east-1", include_ecs=False)
+
+    assert warnings == []
+    assert len(agents) == 1
+    assert "scope" not in agents[0].metadata["cloud_origin"]
+
+
+def test_bedrock_unknown_lifecycle_keeps_origin_without_cloud_state():
+    """Unverified lifecycle values do not drop the resource or invent state."""
+    from agent_bom.cloud.aws import _discover_bedrock
+
+    mock_session = MagicMock()
+    mock_bedrock = MagicMock()
+    agents_paginator = MagicMock()
+    agents_paginator.paginate.return_value = [
+        {"agentSummaries": [{"agentId": "agent-1", "agentName": "SupportAgent", "agentStatus": "CREATING"}]}
+    ]
+    action_groups_paginator = MagicMock()
+    action_groups_paginator.paginate.return_value = [{"actionGroupSummaries": []}]
+    mock_bedrock.get_paginator.side_effect = lambda op: {
+        "list_agents": agents_paginator,
+        "list_agent_action_groups": action_groups_paginator,
+    }[op]
+    mock_bedrock.get_agent.return_value = {
+        "agent": {
+            "agentArn": "arn:aws:bedrock:us-east-1:123456789012:agent/agent-1",
+            "foundationModel": "anthropic.claude-3-sonnet",
+        }
+    }
+    mock_session.client.return_value = mock_bedrock
+
+    agents, warnings = _discover_bedrock(mock_session, "us-east-1", account_id="123456789012")
+
+    assert warnings == []
+    assert len(agents) == 1
+    assert agents[0].metadata["cloud_origin"]["scope"]["account_id"] == "123456789012"
+    assert "cloud_state" not in agents[0].metadata
+
+
 def test_discover_no_credentials():
     """When credentials are missing, should add warning and return."""
     mock_boto3, mock_session = _mock_boto3()

--- a/tests/test_cloud_azure.py
+++ b/tests/test_cloud_azure.py
@@ -11,6 +11,7 @@ from agent_bom.cloud.azure import (
     _discover_azure_functions,
     _discover_container_apps,
     _discover_container_instances,
+    _discover_ml_endpoints,
     _discover_openai_deployments,
     discover,
 )
@@ -222,7 +223,12 @@ def test_container_instances_found():
 
     mock_sdk = MagicMock()
     container = SimpleNamespace(name="web", image="nginx:latest")
-    group = SimpleNamespace(name="group1", id="grp-id", containers=[container])
+    group = SimpleNamespace(
+        name="group1",
+        id="/subscriptions/sub/resourceGroups/rg-aci/providers/Microsoft.ContainerInstance/containerGroups/group1",
+        location="eastus",
+        containers=[container],
+    )
 
     mock_client = MagicMock()
     mock_client.container_groups.list.return_value = [group]
@@ -231,6 +237,13 @@ def test_container_instances_found():
     with patch.dict(sys.modules, {"azure.mgmt.containerinstance": mock_sdk}):
         agents, warnings = _discover_container_instances(MagicMock(), "sub")
         assert len(agents) == 1
+        origin = agents[0].metadata["cloud_origin"]
+        assert origin["scope"]["subscription_id"] == "sub"
+        assert origin["resource_id"].endswith("/containerGroups/group1/web")
+        scope = agents[0].metadata["cloud_scope"]
+        assert scope["scope_type"] == "resource-group"
+        assert scope["scope_id"] == "rg-aci"
+        assert scope["parent_scope"] == {"type": "subscription", "id": "sub"}
 
 
 # ---------------------------------------------------------------------------
@@ -261,6 +274,7 @@ def test_openai_found():
         name="myoai",
         kind="OpenAI",
         id="/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.CognitiveServices/accounts/myoai",
+        location="eastus",
     )
     model = SimpleNamespace(name="gpt-4", version="0613")
     sku = SimpleNamespace(name="Standard")
@@ -269,7 +283,7 @@ def test_openai_found():
         name="gpt-4-deploy",
         properties=props,
         sku=sku,
-        id="deploy-id",
+        id="/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.CognitiveServices/accounts/myoai/deployments/gpt-4-deploy",
     )
 
     mock_client = MagicMock()
@@ -281,3 +295,59 @@ def test_openai_found():
         agents, warnings = _discover_openai_deployments(MagicMock(), "sub")
         assert len(agents) == 1
         assert "gpt-4" in agents[0].name
+        origin = agents[0].metadata["cloud_origin"]
+        assert origin["scope"]["subscription_id"] == "sub"
+        assert origin["resource_name"] == "gpt-4-deploy"
+        scope = agents[0].metadata["cloud_scope"]
+        assert scope["scope_type"] == "account"
+        assert scope["scope_id"] == "/subscriptions/sub/resourceGroups/rg1/providers/Microsoft.CognitiveServices/accounts/myoai"
+        assert scope["scope_name"] == "myoai"
+        assert scope["parent_scope"] == {"type": "resource-group", "id": "rg1", "name": "rg1"}
+        assert scope["location"] == "eastus"
+
+
+# ---------------------------------------------------------------------------
+# _discover_ml_endpoints
+# ---------------------------------------------------------------------------
+
+
+def test_ml_endpoint_scope_persists_workspace_context():
+    import sys
+
+    mock_sdk = MagicMock()
+    workspace = SimpleNamespace(
+        name="ml-ws",
+        id="/subscriptions/sub/resourceGroups/rg-ml/providers/Microsoft.MachineLearningServices/workspaces/ml-ws",
+        location="westus2",
+    )
+    endpoint = SimpleNamespace(
+        name="prod-endpoint",
+        id="/subscriptions/sub/resourceGroups/rg-ml/providers/Microsoft.MachineLearningServices/workspaces/ml-ws/onlineEndpoints/prod-endpoint",
+        location="westus2",
+        properties=SimpleNamespace(scoring_uri="https://prod-endpoint.westus2.inference.ml.azure.com/score"),
+    )
+    deployment = SimpleNamespace(
+        name="blue",
+        properties=SimpleNamespace(model="azureml://registries/models/fraud-detector/versions/7", instance_type="Standard_DS3_v2"),
+    )
+
+    mock_client = MagicMock()
+    mock_client.workspaces.list_by_subscription.return_value = [workspace]
+    mock_client.online_endpoints.list.return_value = [endpoint]
+    mock_client.online_deployments.list.return_value = [deployment]
+    mock_sdk.MachineLearningServicesMgmtClient.return_value = mock_client
+
+    with patch.dict(sys.modules, {"azure.mgmt.machinelearningservices": mock_sdk}):
+        agents, warnings = _discover_ml_endpoints(MagicMock(), "sub")
+
+    assert warnings == []
+    assert len(agents) == 1
+    origin = agents[0].metadata["cloud_origin"]
+    assert origin["scope"]["subscription_id"] == "sub"
+    assert origin["resource_id"] == endpoint.id
+    scope = agents[0].metadata["cloud_scope"]
+    assert scope["scope_type"] == "workspace"
+    assert scope["scope_id"] == workspace.id
+    assert scope["scope_name"] == "ml-ws"
+    assert scope["parent_scope"] == {"type": "resource-group", "id": "rg-ml", "name": "rg-ml"}
+    assert scope["location"] == "westus2"

--- a/tests/test_cloud_origin_contract.py
+++ b/tests/test_cloud_origin_contract.py
@@ -1,0 +1,94 @@
+"""Contract tests for normalized cloud-origin provider metadata."""
+
+from __future__ import annotations
+
+from agent_bom.cloud import _PROVIDERS
+from agent_bom.cloud.normalization import build_cloud_origin
+from agent_bom.graph.builder import build_unified_graph_from_report
+from agent_bom.graph.types import EntityType
+from agent_bom.models import Agent, AgentType, AIBOMReport
+from agent_bom.output.json_fmt import to_json
+
+LOCAL_ONLY_PROVIDERS = {
+    "ollama": "Discovers a local Ollama daemon; no external cloud/SaaS resource identity exists.",
+}
+
+MOCKED_CLOUD_ORIGIN_PROVIDERS = {
+    "aws",
+    "azure",
+    "coreweave",
+    "databricks",
+    "gcp",
+    "huggingface",
+    "mlflow",
+    "nebius",
+    "openai",
+    "snowflake",
+    "wandb",
+}
+
+
+def test_registered_provider_cloud_origin_contract_is_documented() -> None:
+    """Every registered provider has a representative cloud_origin test or is local-only."""
+    assert MOCKED_CLOUD_ORIGIN_PROVIDERS | set(LOCAL_ONLY_PROVIDERS) == set(_PROVIDERS)
+    assert not (MOCKED_CLOUD_ORIGIN_PROVIDERS & set(LOCAL_ONLY_PROVIDERS))
+    assert all(reason for reason in LOCAL_ONLY_PROVIDERS.values())
+
+
+def test_cloud_origin_raw_identity_sanitizes_secret_shaped_values() -> None:
+    origin = build_cloud_origin(
+        provider="openai",
+        service="assistants",
+        resource_type="assistant",
+        resource_id="asst_123",
+        resource_name="assistant",
+        raw_identity={
+            "id": "asst_123",
+            "api_key": "sk-secret-value",
+            "endpoint_url": "https://token:secret@example.test/path?apikey=secret",
+            "empty": "",
+            "nested": {"not": "included"},
+        },
+    )
+
+    assert origin["raw_identity"]["id"] == "asst_123"
+    assert origin["raw_identity"]["api_key"] == "***REDACTED***"
+    assert origin["raw_identity"]["endpoint_url"] == "https://example.test/path"
+    assert "empty" not in origin["raw_identity"]
+    assert "nested" not in origin["raw_identity"]
+
+
+def test_cloud_origin_survives_json_and_graph_workflow() -> None:
+    """Cloud context stays available beyond provider discovery."""
+    agent = Agent(
+        name="aws-bedrock:agent-123",
+        agent_type=AgentType.CUSTOM,
+        config_path="arn:aws:bedrock:us-east-1:123456789012:agent/agent-123",
+        source="aws-bedrock",
+        metadata={
+            "cloud_origin": build_cloud_origin(
+                provider="aws",
+                service="bedrock",
+                resource_type="agent",
+                resource_id="arn:aws:bedrock:us-east-1:123456789012:agent/agent-123",
+                resource_name="support-agent",
+                location="us-east-1",
+                account_id="123456789012",
+                raw_identity={"agent_id": "agent-123", "agent_name": "support-agent"},
+            )
+        },
+    )
+    report_json = to_json(AIBOMReport(agents=[agent]))
+
+    json_origin = report_json["agents"][0]["metadata"]["cloud_origin"]
+    assert json_origin["provider"] == "aws"
+    assert json_origin["service"] == "bedrock"
+    assert json_origin["resource_type"] == "agent"
+    assert json_origin["scope"]["account_id"] == "123456789012"
+
+    graph = build_unified_graph_from_report(report_json)
+    resource_nodes = [node for node in graph.nodes_by_type(EntityType.CLOUD_RESOURCE) if node.attributes.get("cloud_origin") == json_origin]
+    assert len(resource_nodes) == 1
+    assert resource_nodes[0].dimensions.cloud_provider == "aws"
+    assert resource_nodes[0].dimensions.surface == "bedrock"
+    assert resource_nodes[0].attributes["cloud_service"] == "bedrock"

--- a/tests/test_cloud_providers_cov.py
+++ b/tests/test_cloud_providers_cov.py
@@ -58,6 +58,9 @@ class TestWandbDiscover:
             agents, warnings = wandb_provider.discover(api_key="test-key", entity="testuser", project="testproj")
             assert len(agents) >= 1
             assert agents[0].name == "wandb-run:test-run"
+            origin = agents[0].metadata["cloud_origin"]
+            assert origin["provider"] == "wandb"
+            assert origin["resource_type"] == "run"
 
     def test_discover_runs_without_project(self):
         mock_wandb = MagicMock()
@@ -99,6 +102,9 @@ class TestWandbDiscover:
             agents, warnings = wandb_provider.discover(api_key="test-key", entity="testuser", project="testproj")
             art_agents = [a for a in agents if "wandb-model:" in a.name or "wandb-dataset:" in a.name]
             assert len(art_agents) >= 1
+            origin = art_agents[0].metadata["cloud_origin"]
+            assert origin["provider"] == "wandb"
+            assert origin["resource_type"] in {"model", "dataset"}
 
     def test_run_discovery_exception(self):
         mock_wandb = MagicMock()
@@ -238,6 +244,9 @@ class TestMlflowDiscover:
             agents, warnings = mlflow_provider.discover(tracking_uri="http://localhost:5000")
             model_agents = [a for a in agents if "mlflow-model:" in a.name]
             assert len(model_agents) >= 1
+            origin = model_agents[0].metadata["cloud_origin"]
+            assert origin["provider"] == "mlflow"
+            assert origin["resource_type"] == "model"
 
     def test_discover_experiments(self):
         mock_mlflow = MagicMock()
@@ -266,6 +275,9 @@ class TestMlflowDiscover:
             agents, warnings = mlflow_provider.discover(tracking_uri="http://localhost:5000")
             exp_agents = [a for a in agents if "mlflow-exp:" in a.name]
             assert len(exp_agents) >= 1
+            origin = exp_agents[0].metadata["cloud_origin"]
+            assert origin["provider"] == "mlflow"
+            assert origin["resource_type"] == "experiment"
 
     def test_model_discovery_exception(self):
         mock_mlflow = MagicMock()
@@ -395,6 +407,9 @@ class TestOpenAIDiscover:
             asst_agents = [a for a in agents if "openai-asst:" in a.name]
             assert len(asst_agents) >= 1
             assert asst_agents[0].name == "openai-asst:Test Assistant"
+            origin = asst_agents[0].metadata["cloud_origin"]
+            assert origin["provider"] == "openai"
+            assert origin["resource_type"] == "assistant"
 
     def test_discover_fine_tunes(self):
         mock_openai = MagicMock()
@@ -425,6 +440,9 @@ class TestOpenAIDiscover:
             agents, warnings = openai_provider.discover(api_key="sk-test")
             ft_agents = [a for a in agents if "openai-ft:" in a.name]
             assert len(ft_agents) >= 1
+            origin = ft_agents[0].metadata["cloud_origin"]
+            assert origin["provider"] == "openai"
+            assert origin["resource_type"] == "job"
 
     def test_assistant_discovery_exception(self):
         mock_openai = MagicMock()

--- a/tests/test_coreweave.py
+++ b/tests/test_coreweave.py
@@ -102,6 +102,10 @@ def test_virtualserver_discovery():
         assert agent.metadata["gpu_type"] == "NVIDIA_H100_SXM"
         assert agent.metadata["gpu_count"] == 8
         assert agent.metadata["region"] == "LAS1"
+        origin = agent.metadata["cloud_origin"]
+        assert origin["provider"] == "coreweave"
+        assert origin["service"] == "kubernetes"
+        assert origin["resource_type"] == "virtual-server"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -155,6 +159,10 @@ def test_inferenceservice_discovery():
         assert "llama-70b" in agent.name
         assert agent.metadata["runtime"] == "vllm"
         assert agent.metadata["serving_url"] == "https://llama-70b.inference.coreweave.cloud"
+        origin = agent.metadata["cloud_origin"]
+        assert origin["provider"] == "coreweave"
+        assert origin["service"] == "kubernetes"
+        assert origin["resource_type"] == "inference-service"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -266,6 +274,10 @@ def test_infiniband_training_detection():
         assert agent.metadata["infiniband"] is True
         assert agent.metadata["gpu_count"] == 8
         assert agent.source == "coreweave-training"
+        origin = agent.metadata["cloud_origin"]
+        assert origin["provider"] == "coreweave"
+        assert origin["service"] == "kubernetes"
+        assert origin["resource_type"] == "training-pod"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -94,6 +94,28 @@ def _agent(name: str, servers: list | None = None, source: str = "local") -> dic
     }
 
 
+def _cloud_agent(name: str = "bedrock-agent") -> dict:
+    agent = _agent(name, [], source="aws")
+    agent.update(
+        {
+            "discovered_at": "2026-04-28T10:00:00Z",
+            "last_seen": "2026-04-28T11:00:00Z",
+            "metadata": {
+                "cloud_origin": {
+                    "provider": "aws",
+                    "service": "bedrock",
+                    "resource_type": "agent",
+                    "resource_id": "agent-123",
+                    "location": "us-east-1",
+                    "scope": {"account_id": "123456789012"},
+                },
+                "cloud_state": {"lifecycle_state": "ready", "raw_state": "PREPARED"},
+            },
+        }
+    )
+    return agent
+
+
 def _write_scan(data: dict) -> str:
     f = tempfile.NamedTemporaryFile(suffix=".json", mode="w", delete=False)
     json.dump(data, f)
@@ -319,6 +341,24 @@ def test_to_json_node_has_required_fields():
             assert "id" in node
             assert "label" in node
             assert "kind" in node
+    finally:
+        os.unlink(path)
+
+
+def test_to_json_preserves_cloud_context_attributes():
+    data = _make_scan_json([_cloud_agent()])
+    path = _write_scan(data)
+    try:
+        graph = load_graph_from_scan(path)
+        result = to_json(graph)
+        agent_node = next(node for node in result["nodes"] if node["id"] == "agent:bedrock-agent")
+        attrs = agent_node["attributes"]
+        assert attrs["cloud_origin"]["provider"] == "aws"
+        assert attrs["cloud_origin"]["service"] == "bedrock"
+        assert attrs["cloud_origin"]["scope"]["account_id"] == "123456789012"
+        assert attrs["cloud_state"]["lifecycle_state"] == "ready"
+        assert attrs["discovered_at"] == "2026-04-28T10:00:00Z"
+        assert attrs["last_seen"] == "2026-04-28T11:00:00Z"
     finally:
         os.unlink(path)
 


### PR DESCRIPTION
Summary
- add service/resource-type-aware cloud_origin envelopes across AWS, Azure, GCP, Databricks, Snowflake, CoreWeave, Nebius, Hugging Face, OpenAI, W&B, and MLflow assets
- preserve provider-specific context for VMs/instances, clusters, container workloads, Bedrock/Vertex/assistant/model assets, SaaS runs/artifacts, and data platform resources instead of flattening everything into a generic cloud label
- keep backward-compatible metadata while adding cloud_state, cloud_principal, cloud_timestamps, and sanitized raw_identity where available
- add provider contract tests and a JSON-to-graph preservation test so cloud context survives discovery into canonical workflow surfaces

Why
Operators need exact asset context for policy, RBAC, UI filtering, graph lineage, remediation ownership, and auditability. A cloud asset should carry provider, service, resource type, ID/name, location, and scope wherever the provider exposes it.

Validation
- uv run pytest tests/test_cloud_origin_contract.py tests/test_cloud.py tests/test_cloud_providers_cov.py tests/test_coreweave.py tests/test_cloud_aws.py tests/test_graph_builder.py::TestBuildUnifiedGraphFromReport::test_cloud_origin_metadata_becomes_lineage_nodes -q
- uv run ruff check src/agent_bom/cloud tests/test_cloud_origin_contract.py tests/test_cloud.py tests/test_cloud_providers_cov.py tests/test_coreweave.py tests/test_cloud_aws.py
- uv run mypy targeted cloud provider modules
- git diff --check

Closes #2071