### PR TITLE
feat: add extension entrypoint registries

### DIFF
--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -71,6 +71,11 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_ENRICHMENT_MAX_CACHE` | `int` | `10000` | — |
 | `AGENT_BOM_ENRICHMENT_TTL` | `int` | `604800` | Used by enrichment.py for persistent NVD + EPSS disk cache.  7-day TTL balances freshness vs. API rate limits.  10,000 entries covers most enterprise scans without unbounded disk/memory growth. |
 
+## Extension Loading
+| Env var | Type | Default | Description |
+|---|---|---|---|
+| `AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS` | `bool` | `False` | Disabled by default so third-party provider/connector/parser entry points never execute unless an operator explicitly opts in. |
+
 ## HTTP Client
 | Env var | Type | Default | Description |
 |---|---|---|---|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,15 @@ agent-cloud = "agent_bom.cli.cloud:cloud_main"
 agent-iac = "agent_bom.cli.iac:iac_main"
 agent-claw = "agent_bom.cli.claw:claw_main"
 
+[project.entry-points."agent_bom.cloud_providers"]
+agent_bom_builtin = "agent_bom.cloud:builtin_provider_registrations"
+
+[project.entry-points."agent_bom.connectors"]
+agent_bom_builtin = "agent_bom.connectors:builtin_connector_registrations"
+
+[project.entry-points."agent_bom.inventory_parsers"]
+agent_bom_builtin = "agent_bom.parsers:builtin_inventory_parser_registrations"
+
 [project.urls]
 Homepage = "https://github.com/msaad00/agent-bom"
 Repository = "https://github.com/msaad00/agent-bom"

--- a/scripts/generate_env_var_reference.py
+++ b/scripts/generate_env_var_reference.py
@@ -39,7 +39,7 @@ DOC_FILE = ROOT / "docs" / "operations" / "ENV_VARS.md"
 ALLOWLIST_FILE = ROOT / "scripts" / "env_var_allowlist.txt"
 
 # Helpers in config.py that wrap os.environ.get() with a typed default.
-_CONFIG_HELPERS = {"_float", "_int", "_str"}
+_CONFIG_HELPERS = {"_bool", "_float", "_int", "_str"}
 
 ENV_VAR_LITERAL = re.compile(r'"(AGENT_BOM_[A-Z][A-Z0-9_]*)"')
 
@@ -146,7 +146,7 @@ def _parse_config(path: Path) -> list[EnvVar]:
             if not value.args or not isinstance(value.args[0], ast.Constant) or not isinstance(value.args[0].value, str):
                 continue
             env_key = value.args[0].value
-            type_label = {"_float": "float", "_int": "int", "_str": "str"}[value.func.id]
+            type_label = {"_bool": "bool", "_float": "float", "_int": "int", "_str": "str"}[value.func.id]
             default_repr = ast.unparse(value.args[1]).strip() if len(value.args) >= 2 and value.args[1] is not None else ""
         elif isinstance(value, ast.Call) and _is_environ_get(value) and value.args and isinstance(value.args[0], ast.Constant):
             arg = value.args[0].value

--- a/src/agent_bom/cloud/__init__.py
+++ b/src/agent_bom/cloud/__init__.py
@@ -10,11 +10,16 @@ from __future__ import annotations
 import importlib
 from typing import Any
 
+from agent_bom.extensions import ExtensionCapabilities, iter_entry_point_registrations
 from agent_bom.models import Agent
 
-from .base import CloudDiscoveryError
+from .base import CloudDiscoveryError, CloudProviderRegistration
 from .normalization import sanitize_discovery_warnings
 
+_ENTRY_POINT_GROUP = "agent_bom.cloud_providers"
+
+# Backward-compatible module lookup surface. Keep this mutable for tests,
+# integrations, and stats checks that read the old registry directly.
 _PROVIDERS: dict[str, str] = {
     "aws": "agent_bom.cloud.aws",
     "azure": "agent_bom.cloud.azure",
@@ -30,6 +35,102 @@ _PROVIDERS: dict[str, str] = {
     "ollama": "agent_bom.cloud.ollama",
 }
 
+_BUILTIN_PROVIDERS: dict[str, str] = dict(_PROVIDERS)
+_PROVIDER_REGISTRY: dict[str, CloudProviderRegistration] = {}
+_PROVIDER_REGISTRY_WARNINGS: list[str] = []
+_PROVIDER_REGISTRY_LOADED = False
+
+
+def _provider_capabilities(name: str) -> ExtensionCapabilities:
+    return ExtensionCapabilities(
+        scan_modes=("inventory",),
+        required_scopes=(f"{name}:read",),
+        outbound_destinations=(name,),
+        data_boundary="agentless_read_only",
+        network_access=name != "ollama",
+    )
+
+
+def _registration_for_provider(name: str, module: str, *, source: str = "builtin") -> CloudProviderRegistration:
+    return CloudProviderRegistration(
+        name=name,
+        module=module,
+        capabilities=_provider_capabilities(name),
+        source=source,
+    )
+
+
+def builtin_provider_registrations() -> list[CloudProviderRegistration]:
+    """Return built-in cloud provider registrations."""
+
+    return [_registration_for_provider(name, module) for name, module in _BUILTIN_PROVIDERS.items()]
+
+
+def _coerce_provider_registration(value: Any, entry_point_name: str) -> CloudProviderRegistration:
+    if isinstance(value, CloudProviderRegistration):
+        return value
+    name = str(getattr(value, "name", entry_point_name)).strip()
+    module = str(getattr(value, "module", "")).strip()
+    if not name or not module:
+        raise ValueError("cloud provider registration must declare name and module")
+    capabilities = getattr(value, "capabilities", ExtensionCapabilities())
+    if not isinstance(capabilities, ExtensionCapabilities):
+        capabilities = ExtensionCapabilities()
+    return CloudProviderRegistration(
+        name=name,
+        module=module,
+        capabilities=capabilities,
+        source=str(getattr(value, "source", "entry_point")),
+        discover_attr=str(getattr(value, "discover_attr", "discover")),
+    )
+
+
+def register_provider(registration: CloudProviderRegistration) -> None:
+    """Register a cloud provider for discovery lookup."""
+
+    _PROVIDER_REGISTRY[registration.name] = registration
+    _PROVIDERS[registration.name] = registration.module
+
+
+def _ensure_provider_registry_loaded() -> None:
+    global _PROVIDER_REGISTRY_LOADED
+    if _PROVIDER_REGISTRY_LOADED:
+        return
+    for registration in builtin_provider_registrations():
+        register_provider(registration)
+    for registration in iter_entry_point_registrations(
+        group=_ENTRY_POINT_GROUP,
+        coerce=_coerce_provider_registration,
+        warnings=_PROVIDER_REGISTRY_WARNINGS,
+    ):
+        register_provider(registration)
+    _PROVIDER_REGISTRY_LOADED = True
+
+
+def list_registered_providers() -> list[CloudProviderRegistration]:
+    """Return registered cloud providers with capability declarations."""
+
+    _ensure_provider_registry_loaded()
+    registrations = dict(_PROVIDER_REGISTRY)
+    for name, module in _PROVIDERS.items():
+        registrations.setdefault(name, _registration_for_provider(name, module, source="legacy"))
+    return [registrations[name] for name in sorted(registrations)]
+
+
+def provider_registry_warnings() -> list[str]:
+    """Return sanitized non-fatal registry loading warnings."""
+
+    _ensure_provider_registry_loaded()
+    return list(_PROVIDER_REGISTRY_WARNINGS)
+
+
+def _reset_provider_registry_for_tests() -> None:
+    _PROVIDER_REGISTRY.clear()
+    _PROVIDER_REGISTRY_WARNINGS.clear()
+    _PROVIDERS.clear()
+    global _PROVIDER_REGISTRY_LOADED
+    _PROVIDER_REGISTRY_LOADED = False
+
 
 def discover_from_provider(
     provider: str,
@@ -44,10 +145,13 @@ def discover_from_provider(
         ValueError: if *provider* is not a known provider name.
         CloudDiscoveryError: if the provider SDK is not installed or API fails.
     """
+    _ensure_provider_registry_loaded()
     if provider not in _PROVIDERS:
         raise ValueError(f"Unknown cloud provider '{provider}'. Available: {', '.join(sorted(_PROVIDERS))}")
+    registration = _PROVIDER_REGISTRY.get(provider)
     mod = importlib.import_module(_PROVIDERS[provider])
-    agents, warnings = mod.discover(**kwargs)
+    discover_attr = registration.discover_attr if registration else "discover"
+    agents, warnings = getattr(mod, discover_attr)(**kwargs)
     return agents, sanitize_discovery_warnings(warnings)
 
 
@@ -62,6 +166,7 @@ def discover_governance(
     Returns:
         GovernanceReport with findings and raw data.
     """
+    _ensure_provider_registry_loaded()
     if provider != "snowflake":
         raise ValueError(f"Governance discovery not supported for '{provider}'.")
     mod = importlib.import_module(_PROVIDERS["snowflake"])
@@ -79,6 +184,7 @@ def discover_activity(
     Returns:
         ActivityTimeline with query history and observability events.
     """
+    _ensure_provider_registry_loaded()
     if provider != "snowflake":
         raise ValueError(f"Activity discovery not supported for '{provider}'.")
     mod = importlib.import_module(_PROVIDERS["snowflake"])
@@ -90,4 +196,8 @@ __all__ = [
     "discover_from_provider",
     "discover_governance",
     "discover_activity",
+    "list_registered_providers",
+    "provider_registry_warnings",
+    "register_provider",
+    "builtin_provider_registrations",
 ]

--- a/src/agent_bom/cloud/base.py
+++ b/src/agent_bom/cloud/base.py
@@ -2,6 +2,27 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from agent_bom.extensions import ExtensionCapabilities, RegistryEntry
+from agent_bom.models import Agent
+
 
 class CloudDiscoveryError(Exception):
     """Raised when a cloud provider SDK is missing or an API call fails."""
+
+
+@dataclass(frozen=True)
+class CloudProviderRegistration(RegistryEntry):
+    """Registry metadata for a cloud provider discovery implementation."""
+
+
+class CloudProvider(Protocol):
+    """Protocol implemented by cloud provider discovery extensions."""
+
+    name: str
+    capabilities: ExtensionCapabilities
+
+    def discover(self, **kwargs: Any) -> tuple[list[Agent], list[str]]:
+        """Discover cloud inventory and return user-safe warnings."""

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -35,9 +35,24 @@ def _int(env_key: str, default: int) -> int:
         return default
 
 
+def _bool(env_key: str, default: bool) -> bool:
+    """Read a boolean from *env_key*, falling back to *default*."""
+    raw = os.environ.get(env_key)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _str(env_key: str, default: str) -> str:
     """Read a string from *env_key*, falling back to *default*."""
     return os.environ.get(env_key, default)
+
+
+# ── Extension Loading ─────────────────────────────────────────────────────
+# Disabled by default so third-party provider/connector/parser entry points
+# never execute unless an operator explicitly opts in.
+
+ENABLE_EXTENSION_ENTRYPOINTS = _bool("AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS", False)
 
 
 # ── EPSS Thresholds ─────────────────────────────────────────────────────────

--- a/src/agent_bom/connectors/__init__.py
+++ b/src/agent_bom/connectors/__init__.py
@@ -12,15 +12,116 @@ import importlib
 from typing import Any
 
 from agent_bom.cloud.normalization import sanitize_discovery_warnings
+from agent_bom.extensions import ExtensionCapabilities, iter_entry_point_registrations
 from agent_bom.models import Agent
 
-from .base import ConnectorError, ConnectorStatus
+from .base import ConnectorError, ConnectorRegistration, ConnectorStatus
 
+_ENTRY_POINT_GROUP = "agent_bom.connectors"
+
+# Backward-compatible module lookup surface.
 _CONNECTORS: dict[str, str] = {
     "jira": "agent_bom.connectors.jira_connector",
     "servicenow": "agent_bom.connectors.servicenow_connector",
     "slack": "agent_bom.connectors.slack_connector",
 }
+
+_BUILTIN_CONNECTORS: dict[str, str] = dict(_CONNECTORS)
+_CONNECTOR_REGISTRY: dict[str, ConnectorRegistration] = {}
+_CONNECTOR_REGISTRY_WARNINGS: list[str] = []
+_CONNECTOR_REGISTRY_LOADED = False
+
+
+def _connector_capabilities(name: str) -> ExtensionCapabilities:
+    return ExtensionCapabilities(
+        scan_modes=("inventory",),
+        required_scopes=(f"{name}:read",),
+        outbound_destinations=(name,),
+        data_boundary="agentless_read_only",
+        network_access=True,
+    )
+
+
+def _registration_for_connector(name: str, module: str, *, source: str = "builtin") -> ConnectorRegistration:
+    return ConnectorRegistration(
+        name=name,
+        module=module,
+        capabilities=_connector_capabilities(name),
+        source=source,
+    )
+
+
+def builtin_connector_registrations() -> list[ConnectorRegistration]:
+    """Return built-in SaaS connector registrations."""
+
+    return [_registration_for_connector(name, module) for name, module in _BUILTIN_CONNECTORS.items()]
+
+
+def _coerce_connector_registration(value: Any, entry_point_name: str) -> ConnectorRegistration:
+    if isinstance(value, ConnectorRegistration):
+        return value
+    name = str(getattr(value, "name", entry_point_name)).strip()
+    module = str(getattr(value, "module", "")).strip()
+    if not name or not module:
+        raise ValueError("connector registration must declare name and module")
+    capabilities = getattr(value, "capabilities", ExtensionCapabilities())
+    if not isinstance(capabilities, ExtensionCapabilities):
+        capabilities = ExtensionCapabilities()
+    return ConnectorRegistration(
+        name=name,
+        module=module,
+        capabilities=capabilities,
+        source=str(getattr(value, "source", "entry_point")),
+        discover_attr=str(getattr(value, "discover_attr", "discover")),
+        health_attr=str(getattr(value, "health_attr", "health_check")),
+    )
+
+
+def register_connector(registration: ConnectorRegistration) -> None:
+    """Register a SaaS connector for discovery lookup."""
+
+    _CONNECTOR_REGISTRY[registration.name] = registration
+    _CONNECTORS[registration.name] = registration.module
+
+
+def _ensure_connector_registry_loaded() -> None:
+    global _CONNECTOR_REGISTRY_LOADED
+    if _CONNECTOR_REGISTRY_LOADED:
+        return
+    for registration in builtin_connector_registrations():
+        register_connector(registration)
+    for registration in iter_entry_point_registrations(
+        group=_ENTRY_POINT_GROUP,
+        coerce=_coerce_connector_registration,
+        warnings=_CONNECTOR_REGISTRY_WARNINGS,
+    ):
+        register_connector(registration)
+    _CONNECTOR_REGISTRY_LOADED = True
+
+
+def list_registered_connectors() -> list[ConnectorRegistration]:
+    """Return registered connectors with capability declarations."""
+
+    _ensure_connector_registry_loaded()
+    registrations = dict(_CONNECTOR_REGISTRY)
+    for name, module in _CONNECTORS.items():
+        registrations.setdefault(name, _registration_for_connector(name, module, source="legacy"))
+    return [registrations[name] for name in sorted(registrations)]
+
+
+def connector_registry_warnings() -> list[str]:
+    """Return sanitized non-fatal registry loading warnings."""
+
+    _ensure_connector_registry_loaded()
+    return list(_CONNECTOR_REGISTRY_WARNINGS)
+
+
+def _reset_connector_registry_for_tests() -> None:
+    _CONNECTOR_REGISTRY.clear()
+    _CONNECTOR_REGISTRY_WARNINGS.clear()
+    _CONNECTORS.clear()
+    global _CONNECTOR_REGISTRY_LOADED
+    _CONNECTOR_REGISTRY_LOADED = False
 
 
 def discover_from_connector(
@@ -36,10 +137,13 @@ def discover_from_connector(
         ValueError: if *connector* is not a known connector name.
         ConnectorError: if the connector API call fails.
     """
+    _ensure_connector_registry_loaded()
     if connector not in _CONNECTORS:
         raise ValueError(f"Unknown connector '{connector}'. Available: {', '.join(sorted(_CONNECTORS))}")
+    registration = _CONNECTOR_REGISTRY.get(connector)
     mod = importlib.import_module(_CONNECTORS[connector])
-    agents, warnings = mod.discover(**kwargs)
+    discover_attr = registration.discover_attr if registration else "discover"
+    agents, warnings = getattr(mod, discover_attr)(**kwargs)
     return agents, sanitize_discovery_warnings(warnings)
 
 
@@ -48,12 +152,30 @@ def check_connector_health(
     **kwargs: Any,
 ) -> ConnectorStatus:
     """Check if a connector can authenticate and reach its API."""
+    _ensure_connector_registry_loaded()
     if connector not in _CONNECTORS:
         raise ValueError(f"Unknown connector '{connector}'.")
+    registration = _CONNECTOR_REGISTRY.get(connector)
     mod = importlib.import_module(_CONNECTORS[connector])
-    return mod.health_check(**kwargs)
+    health_attr = registration.health_attr if registration else "health_check"
+    return getattr(mod, health_attr)(**kwargs)
 
 
 def list_connectors() -> list[str]:
     """Return sorted list of available connector names."""
+    _ensure_connector_registry_loaded()
     return sorted(_CONNECTORS.keys())
+
+
+__all__ = [
+    "ConnectorError",
+    "ConnectorRegistration",
+    "ConnectorStatus",
+    "check_connector_health",
+    "discover_from_connector",
+    "list_connectors",
+    "list_registered_connectors",
+    "connector_registry_warnings",
+    "register_connector",
+    "builtin_connector_registrations",
+]

--- a/src/agent_bom/connectors/base.py
+++ b/src/agent_bom/connectors/base.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Any, Protocol
+
+from agent_bom.extensions import ExtensionCapabilities, RegistryEntry
+from agent_bom.models import Agent
 
 
 class ConnectorError(Exception):
@@ -32,3 +36,23 @@ class ConnectorStatus:
     message: str = ""
     api_version: str = ""
     details: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ConnectorRegistration(RegistryEntry):
+    """Registry metadata for a SaaS connector implementation."""
+
+    health_attr: str = "health_check"
+
+
+class Connector(Protocol):
+    """Protocol implemented by SaaS connector discovery extensions."""
+
+    name: str
+    capabilities: ExtensionCapabilities
+
+    def discover(self, **kwargs: Any) -> tuple[list[Agent], list[str]]:
+        """Discover connector inventory and return user-safe warnings."""
+
+    def health_check(self, **kwargs: Any) -> ConnectorStatus:
+        """Check connector health."""

--- a/src/agent_bom/extensions.py
+++ b/src/agent_bom/extensions.py
@@ -1,0 +1,106 @@
+"""Shared extension registry primitives."""
+
+from __future__ import annotations
+
+import importlib.metadata as metadata
+import os
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from typing import Any, TypeVar
+
+from agent_bom.security import sanitize_error, sanitize_text
+
+ENTRYPOINTS_ENABLED_ENV = "AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS"
+
+
+@dataclass(frozen=True)
+class ExtensionCapabilities:
+    """Declared capabilities and boundaries for an extension."""
+
+    scan_modes: tuple[str, ...] = ("inventory",)
+    required_scopes: tuple[str, ...] = ()
+    outbound_destinations: tuple[str, ...] = ()
+    data_boundary: str = "agentless_read_only"
+    writes: bool = False
+    network_access: bool = False
+    guarantees: tuple[str, ...] = ("read_only",)
+
+
+@dataclass(frozen=True)
+class RegistryEntry:
+    """Common registry metadata for provider, connector, and parser extensions."""
+
+    name: str
+    module: str
+    capabilities: ExtensionCapabilities = field(default_factory=ExtensionCapabilities)
+    source: str = "builtin"
+    discover_attr: str = "discover"
+
+
+T = TypeVar("T")
+
+
+def entrypoint_extensions_enabled() -> bool:
+    """Return True when third-party entry-point loading is explicitly enabled."""
+
+    value = os.getenv(ENTRYPOINTS_ENABLED_ENV, "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def sanitize_registry_warning(value: object, *, max_len: int = 500) -> str:
+    """Sanitize a registry loading diagnostic before it leaves the boundary."""
+
+    return sanitize_text(sanitize_error(str(value)), max_len=max_len)
+
+
+def _entry_points_for_group(group: str) -> Iterable[Any]:
+    entry_points = metadata.entry_points()
+    if hasattr(entry_points, "select"):
+        return entry_points.select(group=group)
+    return entry_points.get(group, ())
+
+
+def _registration_payload(loaded: Any) -> Any:
+    if isinstance(loaded, RegistryEntry):
+        return loaded
+    if hasattr(loaded, "name") and hasattr(loaded, "module"):
+        return loaded
+    if callable(loaded):
+        return loaded()
+    return loaded
+
+
+def iter_entry_point_registrations(
+    *,
+    group: str,
+    coerce: Callable[[Any, str], T],
+    warnings: list[str],
+) -> list[T]:
+    """Load extension registrations from a Python entry-point group.
+
+    Third-party loading is opt-in via ``AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS``.
+    Failures are collected as sanitized warnings so built-ins remain usable.
+    """
+
+    if not entrypoint_extensions_enabled():
+        return []
+
+    try:
+        entry_points = list(_entry_points_for_group(group))
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(sanitize_registry_warning(f"Could not enumerate entry points for {group}: {exc}"))
+        return []
+
+    registrations: list[T] = []
+    for entry_point in entry_points:
+        entry_point_name = sanitize_text(getattr(entry_point, "name", "unknown"), max_len=120)
+        try:
+            loaded = entry_point.load()
+            payload = _registration_payload(loaded)
+            if isinstance(payload, Iterable) and not isinstance(payload, (str, bytes, RegistryEntry)):
+                registrations.extend(coerce(item, entry_point_name) for item in payload)
+            else:
+                registrations.append(coerce(payload, entry_point_name))
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(sanitize_registry_warning(f"Could not load entry point {entry_point_name} from {group}: {exc}"))
+    return registrations

--- a/src/agent_bom/parsers/__init__.py
+++ b/src/agent_bom/parsers/__init__.py
@@ -8,12 +8,14 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 from urllib.parse import quote
 
 from rich.console import Console
 
+from agent_bom.extensions import ExtensionCapabilities, iter_entry_point_registrations
 from agent_bom.models import MCPServer, Package
+from agent_bom.parsers.base import InventoryParserRegistration
 
 # Re-export Go/Maven/Cargo/Gradle/conda/uvx parsers for backward compatibility
 from agent_bom.parsers.compiled_parsers import (  # noqa: F401
@@ -63,6 +65,137 @@ from agent_bom.parsers.python_parsers import (  # noqa: F401
 # Re-export Ruby, PHP, and Swift parsers
 from agent_bom.parsers.ruby_parsers import parse_ruby_packages  # noqa: F401
 from agent_bom.parsers.swift_parsers import parse_swift_packages  # noqa: F401
+
+_ENTRY_POINT_GROUP = "agent_bom.inventory_parsers"
+
+
+_BUILTIN_INVENTORY_PARSERS: dict[str, tuple[str, str, tuple[str, ...]]] = {
+    "npm": ("agent_bom.parsers.node_parsers", "parse_npm_packages", ("package.json", "package-lock.json")),
+    "yarn": ("agent_bom.parsers.node_parsers", "parse_yarn_lock", ("yarn.lock",)),
+    "pnpm": ("agent_bom.parsers.node_parsers", "parse_pnpm_lock", ("pnpm-lock.yaml",)),
+    "bun": ("agent_bom.parsers.node_parsers", "parse_bun_packages", ("bun.lockb", "bun.lock")),
+    "pip": ("agent_bom.parsers.python_parsers", "parse_pip_packages", ("requirements.txt", "pyproject.toml", "poetry.lock", "uv.lock")),
+    "pip_compile": ("agent_bom.parsers.python_parsers", "parse_pip_compile_inputs", ("requirements.in",)),
+    "conda_environment": ("agent_bom.parsers.python_parsers", "parse_conda_environment", ("environment.yml", "environment.yaml")),
+    "conda": ("agent_bom.parsers.compiled_parsers", "parse_conda_packages", ("conda-meta",)),
+    "go": ("agent_bom.parsers.compiled_parsers", "parse_go_packages", ("go.mod", "go.sum")),
+    "cargo": ("agent_bom.parsers.compiled_parsers", "parse_cargo_packages", ("Cargo.toml", "Cargo.lock")),
+    "maven": ("agent_bom.parsers.compiled_parsers", "parse_maven_packages", ("pom.xml",)),
+    "gradle": ("agent_bom.parsers.compiled_parsers", "parse_gradle_packages", ("build.gradle", "build.gradle.kts")),
+    "nuget": ("agent_bom.parsers.dotnet_parsers", "parse_nuget_packages", ("*.csproj", "packages.lock.json")),
+    "ruby": ("agent_bom.parsers.ruby_parsers", "parse_ruby_packages", ("Gemfile", "Gemfile.lock")),
+    "php": ("agent_bom.parsers.php_parsers", "parse_php_packages", ("composer.json", "composer.lock")),
+    "swift": ("agent_bom.parsers.swift_parsers", "parse_swift_packages", ("Package.swift", "Package.resolved")),
+    "apk": ("agent_bom.parsers.os_parsers", "parse_apk_packages", ("lib/apk/db/installed",)),
+    "dpkg": ("agent_bom.parsers.os_parsers", "parse_dpkg_packages", ("var/lib/dpkg/status",)),
+    "rpm": ("agent_bom.parsers.os_parsers", "parse_rpm_packages", ("var/lib/rpm",)),
+}
+
+_INVENTORY_PARSER_REGISTRY: dict[str, InventoryParserRegistration] = {}
+_INVENTORY_PARSER_REGISTRY_WARNINGS: list[str] = []
+_INVENTORY_PARSER_REGISTRY_LOADED = False
+
+
+def _parser_capabilities() -> ExtensionCapabilities:
+    return ExtensionCapabilities(
+        scan_modes=("inventory",),
+        required_scopes=("local_project_read",),
+        outbound_destinations=(),
+        data_boundary="local_manifest_read_only",
+        network_access=False,
+        guarantees=("read_only", "local_files_only"),
+    )
+
+
+def _registration_for_inventory_parser(
+    name: str,
+    module: str,
+    parse_attr: str,
+    manifest_names: tuple[str, ...],
+    *,
+    source: str = "builtin",
+) -> InventoryParserRegistration:
+    return InventoryParserRegistration(
+        name=name,
+        module=module,
+        capabilities=_parser_capabilities(),
+        source=source,
+        parse_attr=parse_attr,
+        manifest_names=manifest_names,
+    )
+
+
+def builtin_inventory_parser_registrations() -> list[InventoryParserRegistration]:
+    """Return built-in package inventory parser registrations."""
+
+    return [
+        _registration_for_inventory_parser(name, module, parse_attr, manifest_names)
+        for name, (module, parse_attr, manifest_names) in _BUILTIN_INVENTORY_PARSERS.items()
+    ]
+
+
+def _coerce_inventory_parser_registration(value: Any, entry_point_name: str) -> InventoryParserRegistration:
+    if isinstance(value, InventoryParserRegistration):
+        return value
+    name = str(getattr(value, "name", entry_point_name)).strip()
+    module = str(getattr(value, "module", "")).strip()
+    if not name or not module:
+        raise ValueError("inventory parser registration must declare name and module")
+    capabilities = getattr(value, "capabilities", ExtensionCapabilities())
+    if not isinstance(capabilities, ExtensionCapabilities):
+        capabilities = ExtensionCapabilities()
+    return InventoryParserRegistration(
+        name=name,
+        module=module,
+        capabilities=capabilities,
+        source=str(getattr(value, "source", "entry_point")),
+        discover_attr=str(getattr(value, "discover_attr", "discover")),
+        parse_attr=str(getattr(value, "parse_attr", "parse")),
+        manifest_names=tuple(str(item) for item in getattr(value, "manifest_names", ())),
+    )
+
+
+def register_inventory_parser(registration: InventoryParserRegistration) -> None:
+    """Register an inventory parser with capability metadata."""
+
+    _INVENTORY_PARSER_REGISTRY[registration.name] = registration
+
+
+def _ensure_inventory_parser_registry_loaded() -> None:
+    global _INVENTORY_PARSER_REGISTRY_LOADED
+    if _INVENTORY_PARSER_REGISTRY_LOADED:
+        return
+    for registration in builtin_inventory_parser_registrations():
+        register_inventory_parser(registration)
+    for registration in iter_entry_point_registrations(
+        group=_ENTRY_POINT_GROUP,
+        coerce=_coerce_inventory_parser_registration,
+        warnings=_INVENTORY_PARSER_REGISTRY_WARNINGS,
+    ):
+        register_inventory_parser(registration)
+    _INVENTORY_PARSER_REGISTRY_LOADED = True
+
+
+def list_registered_inventory_parsers() -> list[InventoryParserRegistration]:
+    """Return registered inventory parsers with capability declarations."""
+
+    _ensure_inventory_parser_registry_loaded()
+    return [_INVENTORY_PARSER_REGISTRY[name] for name in sorted(_INVENTORY_PARSER_REGISTRY)]
+
+
+def inventory_parser_registry_warnings() -> list[str]:
+    """Return sanitized non-fatal registry loading warnings."""
+
+    _ensure_inventory_parser_registry_loaded()
+    return list(_INVENTORY_PARSER_REGISTRY_WARNINGS)
+
+
+def _reset_inventory_parser_registry_for_tests() -> None:
+    _INVENTORY_PARSER_REGISTRY.clear()
+    _INVENTORY_PARSER_REGISTRY_WARNINGS.clear()
+    global _INVENTORY_PARSER_REGISTRY_LOADED
+    _INVENTORY_PARSER_REGISTRY_LOADED = False
+
 
 # Path to bundled MCP registry (parsers/ is a subdir of agent_bom/)
 _REGISTRY_PATH = Path(__file__).parent.parent / "mcp_registry.json"

--- a/src/agent_bom/parsers/base.py
+++ b/src/agent_bom/parsers/base.py
@@ -1,0 +1,30 @@
+"""Shared base types for inventory parser modules."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from agent_bom.extensions import ExtensionCapabilities, RegistryEntry
+from agent_bom.models import MCPServer, Package
+
+
+@dataclass(frozen=True)
+class InventoryParserRegistration(RegistryEntry):
+    """Registry metadata for an inventory parser implementation."""
+
+    parse_attr: str = "parse"
+    manifest_names: tuple[str, ...] = ()
+
+
+class InventoryParser(Protocol):
+    """Protocol implemented by package inventory parser extensions."""
+
+    name: str
+    capabilities: ExtensionCapabilities
+    manifest_names: Sequence[str]
+
+    def parse(self, root: Path, server: MCPServer | None = None) -> list[Package]:
+        """Parse packages from an inventory root."""

--- a/tests/test_entrypoint_registries.py
+++ b/tests/test_entrypoint_registries.py
@@ -1,0 +1,208 @@
+"""Tests for provider, connector, and parser entry-point registries."""
+
+from __future__ import annotations
+
+import sys
+import types
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from agent_bom.extensions import ENTRYPOINTS_ENABLED_ENV, ExtensionCapabilities
+
+
+class FakeEntryPoint:
+    def __init__(self, name: str, loader: Callable[[], Any]) -> None:
+        self.name = name
+        self._loader = loader
+
+    def load(self) -> Any:
+        return self._loader()
+
+
+class FakeEntryPoints(list):
+    def select(self, *, group: str) -> list[FakeEntryPoint]:
+        return [entry_point for entry_point in self if getattr(entry_point, "group", group) == group]
+
+
+def _patch_entry_points(monkeypatch, entries_by_group: dict[str, list[FakeEntryPoint]]) -> None:
+    entries = FakeEntryPoints()
+    for group, group_entries in entries_by_group.items():
+        for entry_point in group_entries:
+            entry_point.group = group
+            entries.append(entry_point)
+
+    monkeypatch.setattr("agent_bom.extensions.metadata.entry_points", lambda: entries)
+
+
+def _reset_registries() -> None:
+    import agent_bom.cloud as cloud_registry
+    import agent_bom.connectors as connector_registry
+    import agent_bom.parsers as parser_registry
+
+    cloud_registry._reset_provider_registry_for_tests()
+    connector_registry._reset_connector_registry_for_tests()
+    parser_registry._reset_inventory_parser_registry_for_tests()
+
+
+def _load_builtin_registries() -> None:
+    import agent_bom.cloud as cloud_registry
+    import agent_bom.connectors as connector_registry
+    import agent_bom.parsers as parser_registry
+
+    cloud_registry.list_registered_providers()
+    connector_registry.list_registered_connectors()
+    parser_registry.list_registered_inventory_parsers()
+
+
+@pytest.fixture(autouse=True)
+def reset_registry_state(monkeypatch):
+    monkeypatch.delenv(ENTRYPOINTS_ENABLED_ENV, raising=False)
+    _reset_registries()
+    yield
+    monkeypatch.delenv(ENTRYPOINTS_ENABLED_ENV, raising=False)
+    _reset_registries()
+    _load_builtin_registries()
+
+
+def test_built_in_registries_are_available_by_default(monkeypatch):
+    monkeypatch.delenv(ENTRYPOINTS_ENABLED_ENV, raising=False)
+    _reset_registries()
+
+    import agent_bom.cloud as cloud_registry
+    import agent_bom.connectors as connector_registry
+    import agent_bom.parsers as parser_registry
+
+    providers = {registration.name: registration for registration in cloud_registry.list_registered_providers()}
+    connectors = {registration.name: registration for registration in connector_registry.list_registered_connectors()}
+    parsers = {registration.name: registration for registration in parser_registry.list_registered_inventory_parsers()}
+
+    assert providers["aws"].module == "agent_bom.cloud.aws"
+    assert providers["ollama"].capabilities.writes is False
+    assert cloud_registry._PROVIDERS["gcp"] == "agent_bom.cloud.gcp"
+
+    assert connector_registry.list_connectors() == ["jira", "servicenow", "slack"]
+    assert connectors["slack"].capabilities.data_boundary == "agentless_read_only"
+
+    assert {"npm", "pip", "go", "maven", "ruby", "swift"} <= set(parsers)
+    assert parsers["npm"].parse_attr == "parse_npm_packages"
+    assert parsers["npm"].capabilities.network_access is False
+
+
+def test_opt_in_fake_cloud_provider_entry_point_loads_and_sanitizes(monkeypatch):
+    monkeypatch.setenv(ENTRYPOINTS_ENABLED_ENV, "true")
+    _reset_registries()
+
+    import agent_bom.cloud as cloud_registry
+    from agent_bom.cloud.base import CloudProviderRegistration
+
+    module_name = "agent_bom.tests.fake_entrypoint_cloud"
+    fake_module = types.ModuleType(module_name)
+    fake_module.discover = lambda **_: (
+        [],
+        ["failed https://user:tok123@example.com/api?key=secret from /Users/alice/.config/provider.json"],
+    )
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    registration = CloudProviderRegistration(
+        name="acme",
+        module=module_name,
+        capabilities=ExtensionCapabilities(
+            scan_modes=("inventory",),
+            required_scopes=("acme.inventory.read",),
+            outbound_destinations=("api.acme.example",),
+            data_boundary="agentless_read_only",
+            network_access=True,
+        ),
+        source="entry_point",
+    )
+    _patch_entry_points(
+        monkeypatch,
+        {"agent_bom.cloud_providers": [FakeEntryPoint("acme", lambda: lambda: registration)]},
+    )
+
+    providers = {entry.name: entry for entry in cloud_registry.list_registered_providers()}
+    assert providers["acme"].source == "entry_point"
+    assert cloud_registry._PROVIDERS["acme"] == module_name
+
+    agents, warnings = cloud_registry.discover_from_provider("acme")
+    assert agents == []
+    warning = " ".join(warnings)
+    assert "tok123" not in warning
+    assert "key=secret" not in warning
+    assert "/Users/alice" not in warning
+
+
+def test_entry_point_failures_are_sanitized_and_do_not_hide_builtins(monkeypatch):
+    monkeypatch.setenv(ENTRYPOINTS_ENABLED_ENV, "1")
+    _reset_registries()
+
+    import agent_bom.cloud as cloud_registry
+
+    def fail_load() -> Any:
+        raise RuntimeError("boom https://user:tok123@example.com/api?key=secret from /Users/alice/.config/plugin.json")
+
+    _patch_entry_points(
+        monkeypatch,
+        {"agent_bom.cloud_providers": [FakeEntryPoint("bad-provider", fail_load)]},
+    )
+
+    providers = {entry.name for entry in cloud_registry.list_registered_providers()}
+    warnings = " ".join(cloud_registry.provider_registry_warnings())
+
+    assert "aws" in providers
+    assert "ollama" in providers
+    assert "bad-provider" in warnings
+    assert "tok123" not in warnings
+    assert "key=secret" not in warnings
+    assert "/Users/alice" not in warnings
+
+
+def test_fake_connector_and_parser_entry_points_load_when_enabled(monkeypatch):
+    monkeypatch.setenv(ENTRYPOINTS_ENABLED_ENV, "yes")
+    _reset_registries()
+
+    import agent_bom.connectors as connector_registry
+    import agent_bom.parsers as parser_registry
+    from agent_bom.connectors.base import ConnectorRegistration
+    from agent_bom.parsers.base import InventoryParserRegistration
+
+    connector_registration = ConnectorRegistration(
+        name="pagerduty",
+        module="agent_bom.tests.fake_pagerduty_connector",
+        capabilities=ExtensionCapabilities(
+            required_scopes=("pagerduty.read",),
+            outbound_destinations=("api.pagerduty.com",),
+            network_access=True,
+        ),
+        source="entry_point",
+    )
+    parser_registration = InventoryParserRegistration(
+        name="custom-lock",
+        module="agent_bom.tests.fake_lock_parser",
+        capabilities=ExtensionCapabilities(
+            required_scopes=("local_project_read",),
+            outbound_destinations=(),
+            data_boundary="local_manifest_read_only",
+            network_access=False,
+        ),
+        parse_attr="parse_custom_lock",
+        manifest_names=("custom.lock",),
+        source="entry_point",
+    )
+    _patch_entry_points(
+        monkeypatch,
+        {
+            "agent_bom.connectors": [FakeEntryPoint("pagerduty", lambda: lambda: connector_registration)],
+            "agent_bom.inventory_parsers": [FakeEntryPoint("custom-lock", lambda: lambda: parser_registration)],
+        },
+    )
+
+    connectors = {entry.name: entry for entry in connector_registry.list_registered_connectors()}
+    parsers = {entry.name: entry for entry in parser_registry.list_registered_inventory_parsers()}
+
+    assert connectors["pagerduty"].source == "entry_point"
+    assert "jira" in connectors
+    assert parsers["custom-lock"].manifest_names == ("custom.lock",)
+    assert "pip" in parsers


### PR DESCRIPTION
Summary

- add shared extension registry primitives with explicit opt-in entry-point loading via `AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS`
- add CloudProvider, Connector, and InventoryParser registration/protocol foundations
- preserve legacy built-in provider, connector, parser behavior and module lookup surfaces
- keep built-ins available when entry-point loading is disabled or when a plugin entry point fails
- sanitize registry loading failures before exposing warnings
- declare project entry-point groups for cloud providers, connectors, and inventory parsers

Why

This is the first safe slice for #2077 and the foundation for #794/#795. It gives plugins and SDK-built integrations a registry boundary without making third-party code load by default, and without weakening the product trust contract around read-only, scoped, sanitized discovery.

Validation

- `uv run pytest tests/test_entrypoint_registries.py tests/test_connectors.py tests/test_cloud.py tests/test_parser_interop.py tests/test_bun_nuget_pipcompile_parsers.py tests/test_registry_resolution.py tests/test_stats_alignment.py -q` -> 211 passed
- `uv run ruff check pyproject.toml src/agent_bom/extensions.py src/agent_bom/cloud/base.py src/agent_bom/cloud/__init__.py src/agent_bom/connectors/base.py src/agent_bom/connectors/__init__.py src/agent_bom/parsers/base.py src/agent_bom/parsers/__init__.py tests/test_entrypoint_registries.py`
- `uv run mypy src/agent_bom/extensions.py src/agent_bom/cloud/base.py src/agent_bom/cloud/__init__.py src/agent_bom/connectors/base.py src/agent_bom/connectors/__init__.py src/agent_bom/parsers/base.py src/agent_bom/parsers/__init__.py`
- `git diff --check`

Closes #2077
Refs #794
Refs #795
