### PR TITLE
fix: isolate scanner options per scan

### DIFF
--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -561,13 +561,13 @@ def _run_scan_sync(job: ScanJob) -> None:
         # ── Scanning phase ──
         pipeline.start_step("scanning", f"Scanning {total_pkgs} packages via OSV.dev...")
         try:
-            blast_radii = scan_agents_sync(agents, enable_enrichment=req.enrich)
+            blast_radii = scan_agents_sync(agents, enable_enrichment=req.enrich, offline=False)
         except Exception as scan_exc:  # noqa: BLE001
             # Log but don't crash — return what we have with warning
             _logger.warning("Scan phase error (retrying without enrichment): %s", scan_exc)
             pipeline.update_step("scanning", f"Scan error: {sanitize_error(scan_exc)} — retrying without enrichment")
             try:
-                blast_radii = scan_agents_sync(agents, enable_enrichment=False)
+                blast_radii = scan_agents_sync(agents, enable_enrichment=False, offline=False)
             except Exception as retry_exc:  # noqa: BLE001
                 _logger.error("Scan retry also failed: %s", retry_exc)
                 blast_radii = []

--- a/src/agent_bom/cli/_check.py
+++ b/src/agent_bom/cli/_check.py
@@ -435,10 +435,10 @@ def check(
     status_context = console.status("[bold]Scanning package risk...[/bold]", spinner="dots") if not quiet else nullcontext()
 
     with status_context:
-        from agent_bom.scanners import IncompleteScanError, consume_scan_warnings, scan_packages
+        from agent_bom.scanners import IncompleteScanError, ScanOptions, consume_scan_warnings, scan_packages
 
         try:
-            asyncio.run(scan_packages(pkgs))
+            asyncio.run(scan_packages(pkgs, options=ScanOptions(offline=False)))
         except IncompleteScanError as exc:
             if structured_output:
                 _write_json_output(

--- a/src/agent_bom/cli/_scan_runner.py
+++ b/src/agent_bom/cli/_scan_runner.py
@@ -192,6 +192,7 @@ def run_default_scan(cfg: ScanConfig, con: "Console") -> ScanResult:
                 blast_radius_depth=cfg.blast_radius_depth,
                 compliance_enabled=compliance,
                 resolve_transitive=cfg.resolve_transitive,
+                offline=cfg.offline,
             )
         except IncompleteScanError as exc:
             con.print(f"  [yellow]Warning:[/yellow] {exc}")

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -1094,6 +1094,7 @@ def scan(
                             compliance_enabled=compliance,
                             resolve_transitive=transitive,
                             show_scan_banner=False,
+                            offline=offline,
                         )
                     except IncompleteScanError as exc:
                         con.print(f"  [yellow]⚠[/yellow] {exc}")
@@ -1109,6 +1110,7 @@ def scan(
                         blast_radius_depth=blast_radius_depth,
                         compliance_enabled=compliance,
                         resolve_transitive=transitive,
+                        offline=offline,
                     )
                 except IncompleteScanError as exc:
                     con.print(f"  [yellow]⚠[/yellow] {exc}")

--- a/src/agent_bom/guard.py
+++ b/src/agent_bom/guard.py
@@ -129,11 +129,11 @@ def _extract_npm_packages(args: list[str]) -> list[str]:
 
 async def _check_package(name: str, ecosystem: str) -> dict:
     """Check a single package for vulnerabilities using existing scanner."""
-    from agent_bom.scanners import scan_packages
+    from agent_bom.scanners import ScanOptions, scan_packages
 
     pkg_entry = type("Pkg", (), {"name": name, "version": "latest", "ecosystem": ecosystem, "vulnerabilities": []})()
     try:
-        await scan_packages([pkg_entry])
+        await scan_packages([pkg_entry], options=ScanOptions(offline=False))
     except Exception as e:
         logger.warning("Failed to scan %s: %s", name, e)
         return {"name": name, "ecosystem": ecosystem, "error": str(e), "vulns": [], "blocked": False}

--- a/src/agent_bom/mcp_server_scan.py
+++ b/src/agent_bom/mcp_server_scan.py
@@ -34,7 +34,7 @@ async def run_scan_pipeline(
     from agent_bom.discovery import discover_all
     from agent_bom.models import Agent, AgentType, MCPServer, TransportType
     from agent_bom.parsers import extract_packages
-    from agent_bom.scanners import scan_agents, scan_agents_with_enrichment
+    from agent_bom.scanners import ScanOptions, scan_agents, scan_agents_with_enrichment
 
     warnings: list[str] = []
     scan_sources: list[str] = []
@@ -137,7 +137,7 @@ async def run_scan_pipeline(
                 server.packages = extract_packages(server)
 
     if enrich:
-        blast_radii = await scan_agents_with_enrichment(agents)
+        blast_radii = await scan_agents_with_enrichment(agents, options=ScanOptions(offline=False))
     else:
-        blast_radii = await scan_agents(agents)
+        blast_radii = await scan_agents(agents, options=ScanOptions(offline=False))
     return agents, blast_radii, warnings, scan_sources

--- a/src/agent_bom/mcp_tools/scanning.py
+++ b/src/agent_bom/mcp_tools/scanning.py
@@ -190,7 +190,7 @@ async def check_impl(
     try:
         from agent_bom.models import Package as Pkg
         from agent_bom.parsers.os_parsers import enrich_os_package_context
-        from agent_bom.scanners import scan_packages
+        from agent_bom.scanners import ScanOptions, scan_packages
 
         # Parse name@version
         spec = package.strip()
@@ -238,7 +238,7 @@ async def check_impl(
                     }
                 )
 
-        await scan_packages([pkg])
+        await scan_packages([pkg], options=ScanOptions(offline=False))
 
         if not pkg.vulnerabilities and eco in {"deb", "apk", "rpm"} and not os_context_complete:
             return json.dumps(

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import threading
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 from rich.console import Console
@@ -74,6 +75,35 @@ _logger = logging.getLogger(__name__)
 offline_mode: bool = False
 _scan_cache_init_lock = threading.Lock()
 _SCAN_CACHE_UNAVAILABLE = object()
+
+
+@dataclass(frozen=True)
+class ScanOptions:
+    """Immutable per-scan scanner controls.
+
+    The legacy module-level setters remain for CLI compatibility, but request
+    handlers and concurrent scan callers should pass explicit options so tenant
+    policy cannot bleed through shared module state.
+    """
+
+    offline: bool = False
+    compliance_enabled: bool = False
+    resolve_transitive: bool = False
+
+
+def default_scan_options(
+    *,
+    compliance_enabled: bool = False,
+    resolve_transitive: bool = False,
+    offline: bool | None = None,
+) -> ScanOptions:
+    """Build per-scan options while preserving legacy offline defaults."""
+
+    return ScanOptions(
+        offline=offline_mode if offline is None else offline,
+        compliance_enabled=compliance_enabled,
+        resolve_transitive=resolve_transitive,
+    )
 
 
 class IncompleteScanError(RuntimeError):
@@ -658,8 +688,16 @@ def _scan_packages_local_db_batch(
     return total
 
 
-async def scan_packages(packages: list[Package], *, resolve_transitive: bool = False) -> int:
+async def scan_packages(
+    packages: list[Package],
+    *,
+    resolve_transitive: bool = False,
+    options: ScanOptions | None = None,
+) -> int:
     """Scan a list of packages for vulnerabilities. Returns count of vulns found."""
+    scan_options = options or default_scan_options(resolve_transitive=resolve_transitive)
+    scan_offline = scan_options.offline
+    scan_resolve_transitive = scan_options.resolve_transitive
     # Deduplicate packages across discovery sources before scanning.
     # Prevents redundant OSV API calls when the same package is discovered
     # from multiple sources (local, K8s, cloud).
@@ -758,7 +796,7 @@ async def scan_packages(packages: list[Package], *, resolve_transitive: bool = F
     # Only hit npm/PyPI registries for packages we couldn't resolve locally.
     # In offline mode, skip all registry calls entirely.
     still_unresolved = [p for p in packages if p.version in ("latest", "unknown", "") and p.ecosystem.lower() in ("npm", "pypi", "conda")]
-    if still_unresolved and not offline_mode:
+    if still_unresolved and not scan_offline:
         try:
             from agent_bom.resolver import resolve_all_versions
 
@@ -773,11 +811,11 @@ async def scan_packages(packages: list[Package], *, resolve_transitive: bool = F
             _logger.warning("Version resolution failed for %d package(s): %s", len(still_unresolved), exc)
             console.print(f"  [yellow]⚠[/yellow] Version resolution skipped: {exc}")
             record_scan_warning("version resolution failed for one or more packages")
-    elif still_unresolved and offline_mode:
+    elif still_unresolved and scan_offline:
         _logger.info("Offline mode: skipping registry version resolution for %d package(s)", len(still_unresolved))
 
     # ── Transitive dependency resolution (npm / PyPI / Go) ───────────────────
-    if resolve_transitive and not offline_mode:
+    if scan_resolve_transitive and not scan_offline:
         transitive_ecosystems = {"npm", "pypi", "go"}
         eligible = [p for p in packages if p.ecosystem.lower() in transitive_ecosystems]
         if eligible:
@@ -835,12 +873,12 @@ async def scan_packages(packages: list[Package], *, resolve_transitive: bool = F
 
     osv_targets = [p for p in scannable if _db_key(p) not in db_covered]
 
-    if offline_mode or (prefer_local_db and not osv_targets):
-        if offline_mode and not db_covered:
+    if scan_offline or (prefer_local_db and not osv_targets):
+        if scan_offline and not db_covered:
             raise IncompleteScanError(
                 "Offline mode requires a populated local vulnerability DB. Run `agent-bom db update` before using `--offline`."
             )
-        if osv_targets and offline_mode:
+        if osv_targets and scan_offline:
             _logger.info("Offline mode: skipping OSV API for %d package(s) not in local DB", len(osv_targets))
             skipped_names = ", ".join(f"{pkg.name}@{pkg.version}" for pkg in osv_targets[:5])
             suffix = f" (+{len(osv_targets) - 5} more)" if len(osv_targets) > 5 else ""
@@ -893,7 +931,7 @@ async def scan_packages(packages: list[Package], *, resolve_transitive: bool = F
         for p in scannable
         if p.name.lower().replace("-", "_") in _AI_FRAMEWORK_PACKAGES or p.name.lower().replace("-", "") in _AI_FRAMEWORK_PACKAGES
     ]
-    if nvidia_packages and not offline_mode:
+    if nvidia_packages and not scan_offline:
         try:
             from agent_bom.scanners.nvidia_advisory import check_nvidia_advisories
 
@@ -907,7 +945,7 @@ async def scan_packages(packages: list[Package], *, resolve_transitive: bool = F
             record_scan_warning("NVIDIA advisory enrichment skipped")
 
     # Supplemental: check GitHub Security Advisories for all packages
-    if scannable and not offline_mode:
+    if scannable and not scan_offline:
         try:
             from agent_bom.scanners.ghsa_advisory import check_github_advisories
 
@@ -956,10 +994,13 @@ async def scan_agents(
     compliance_enabled: bool = False,
     resolve_transitive: bool = False,
     show_scan_banner: bool = True,
+    options: ScanOptions | None = None,
 ) -> list[BlastRadius]:
     """Scan all agents' MCP server packages for vulnerabilities."""
-    global compliance_mode  # noqa: PLW0603
-    compliance_mode = compliance_enabled
+    scan_options = options or default_scan_options(
+        compliance_enabled=compliance_enabled,
+        resolve_transitive=resolve_transitive,
+    )
     if show_scan_banner:
         console.print("\n[bold blue]🛡️  Scanning for vulnerabilities...[/bold blue]\n")
 
@@ -993,7 +1034,7 @@ async def scan_agents(
     if show_scan_banner:
         console.print(f"  Scanning {len(unique_packages)} unique packages across {len(agents)} agent(s)...")
 
-    total_vulns = await scan_packages(unique_packages, resolve_transitive=resolve_transitive)
+    total_vulns = await scan_packages(unique_packages, options=scan_options)
 
     # Propagate vulnerabilities back to all instances
     vuln_map = {}
@@ -1135,7 +1176,7 @@ async def scan_agents(
             br.calculate_risk_score()
             # Context-aware tagging remains opt-in for explicit compliance
             # views, but effective framework tags are always materialized.
-            if compliance_enabled:
+            if scan_options.compliance_enabled:
                 br.owasp_tags = tag_blast_radius(br)
                 br.atlas_tags = tag_atlas_techniques(br)
                 br.attack_tags = tag_attack_techniques(br)
@@ -1178,13 +1219,16 @@ async def scan_agents_with_enrichment(
     enable_enrichment: bool = True,
     compliance_enabled: bool = False,
     show_scan_banner: bool = True,
+    options: ScanOptions | None = None,
 ) -> list[BlastRadius]:
     """Scan agents and enrich vulnerabilities with NVD/EPSS/KEV data."""
+    scan_options = options or default_scan_options(compliance_enabled=compliance_enabled)
     # First, do normal OSV scan
     blast_radii = await scan_agents(
         agents,
-        compliance_enabled=compliance_enabled,
+        compliance_enabled=scan_options.compliance_enabled,
         show_scan_banner=show_scan_banner,
+        options=scan_options,
     )
 
     # Then enrich with external data
@@ -1254,25 +1298,34 @@ def scan_agents_sync(
     compliance_enabled: bool = False,
     resolve_transitive: bool = False,
     show_scan_banner: bool = True,
+    offline: bool | None = None,
+    options: ScanOptions | None = None,
 ) -> list[BlastRadius]:
     """Synchronous wrapper for scan_agents."""
+    scan_options = options or default_scan_options(
+        compliance_enabled=compliance_enabled,
+        resolve_transitive=resolve_transitive,
+        offline=offline,
+    )
     if enable_enrichment:
         blast_radii = asyncio.run(
             scan_agents_with_enrichment(
                 agents,
                 nvd_api_key,
                 enable_enrichment,
-                compliance_enabled=compliance_enabled,
+                compliance_enabled=scan_options.compliance_enabled,
                 show_scan_banner=show_scan_banner,
+                options=scan_options,
             )
         )
     else:
         blast_radii = asyncio.run(
             scan_agents(
                 agents,
-                compliance_enabled=compliance_enabled,
-                resolve_transitive=resolve_transitive,
+                compliance_enabled=scan_options.compliance_enabled,
+                resolve_transitive=scan_options.resolve_transitive,
                 show_scan_banner=show_scan_banner,
+                options=scan_options,
             )
         )
     if blast_radius_depth > 1:

--- a/tests/test_api_pipeline_image_contract.py
+++ b/tests/test_api_pipeline_image_contract.py
@@ -28,7 +28,7 @@ def test_api_pipeline_image_scan_uses_container_surface(monkeypatch):
         "agent_bom.image.scan_image",
         lambda image_ref: ([Package(name="openssl", version="3.0.16", ecosystem="deb")], "native"),
     )
-    monkeypatch.setattr("agent_bom.scanners.scan_agents_sync", lambda agents, enable_enrichment=False: [])
+    monkeypatch.setattr("agent_bom.scanners.scan_agents_sync", lambda agents, enable_enrichment=False, **kwargs: [])
 
     _run_scan_sync(job)
 
@@ -94,7 +94,8 @@ def test_api_pipeline_persists_clickhouse_analytics(monkeypatch):
         lambda image_ref: ([Package(name="openssl", version="3.0.16", ecosystem="deb")], "native"),
     )
 
-    def _fake_scan(agents, enable_enrichment=False):
+    def _fake_scan(agents, enable_enrichment=False, **kwargs):
+        assert kwargs.get("offline") is False
         agent = agents[0]
         server = agent.mcp_servers[0]
         pkg = server.packages[0]
@@ -181,7 +182,7 @@ def test_api_pipeline_persists_unified_graph_snapshot(monkeypatch):
         "agent_bom.image.scan_image",
         lambda image_ref: ([Package(name="openssl", version="3.0.16", ecosystem="deb")], "native"),
     )
-    monkeypatch.setattr("agent_bom.scanners.scan_agents_sync", lambda agents, enable_enrichment=False: [])
+    monkeypatch.setattr("agent_bom.scanners.scan_agents_sync", lambda agents, enable_enrichment=False, **kwargs: [])
 
     _run_scan_sync(job)
 

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -11,7 +11,7 @@ from agent_bom.scanners import IncompleteScanError
 
 
 def _patch_check_scan(monkeypatch, vulns):
-    async def _scan_packages(pkgs):
+    async def _scan_packages(pkgs, **_kwargs):
         for pkg in pkgs:
             pkg.vulnerabilities = list(vulns)
 
@@ -67,7 +67,7 @@ def test_check_exit_zero_reports_without_failing(monkeypatch):
 
 
 def test_check_incomplete_offline_scan_exits_two(monkeypatch):
-    async def _scan_packages(_pkgs):
+    async def _scan_packages(_pkgs, **_kwargs):
         raise IncompleteScanError("Offline mode requires a populated local vulnerability DB.")
 
     monkeypatch.setattr("agent_bom.scanners.scan_packages", _scan_packages)
@@ -99,7 +99,7 @@ def test_check_uses_version_aware_ecosystem_resolution(monkeypatch):
             return _DummyResponse(200, {"versions": {"0.0.1": {}}})
         return None
 
-    async def _scan_packages(pkgs):
+    async def _scan_packages(pkgs, **_kwargs):
         for pkg in pkgs:
             seen_ecosystems.append(pkg.ecosystem)
             pkg.vulnerabilities = []
@@ -141,7 +141,7 @@ def test_mcp_scan_delegates_to_package_check(monkeypatch):
 
 
 def test_check_quiet_suppresses_scan_chatter(monkeypatch):
-    async def _scan_packages(pkgs):
+    async def _scan_packages(pkgs, **_kwargs):
         import agent_bom.scanners as scanners
 
         scanners.console.print("scanner noise that should stay hidden")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3262,7 +3262,7 @@ def test_scan_agents_populates_intrinsic_framework_tags_without_compliance_flag(
     from agent_bom.models import Agent, AgentType, MCPServer, Package, Severity, Vulnerability
     from agent_bom.scanners import scan_agents_sync
 
-    async def _seeded_scan(packages, resolve_transitive=False):
+    async def _seeded_scan(packages, resolve_transitive=False, **_kwargs):
         return sum(len(pkg.vulnerabilities) for pkg in packages)
 
     monkeypatch.setattr("agent_bom.scanners.scan_packages", _seeded_scan)

--- a/tests/test_mcp_check_impl.py
+++ b/tests/test_mcp_check_impl.py
@@ -26,7 +26,7 @@ async def test_check_impl_requires_explicit_os_package_version():
 
 @pytest.mark.asyncio
 async def test_check_impl_uses_full_scan_pipeline():
-    async def fake_scan(packages: list[Package]):
+    async def fake_scan(packages: list[Package], **_kwargs):
         packages[0].vulnerabilities.append(Vulnerability(id="CVE-2026-TEST", summary="test", severity=Severity.HIGH))
 
     with patch("agent_bom.scanners.scan_packages", side_effect=fake_scan):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -190,7 +190,7 @@ def test_check_scoped_npm_package(mock_scan):
     """Check parses scoped npm package correctly."""
     from agent_bom.mcp_server import create_mcp_server
 
-    async def _fake_scan(pkgs):
+    async def _fake_scan(pkgs, **_kwargs):
         return None
 
     mock_scan.side_effect = _fake_scan

--- a/tests/test_scan_options.py
+++ b/tests/test_scan_options.py
@@ -1,0 +1,84 @@
+"""Regression tests for per-scan scanner option isolation."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+import agent_bom.scanners as scanners
+from agent_bom.models import Agent, AgentType, MCPServer, Package
+from agent_bom.scanners import IncompleteScanError, ScanOptions, scan_agents, scan_agents_sync, scan_packages
+
+
+def _agent(name: str = "agent", package: Package | None = None) -> Agent:
+    pkg = package or Package(name="requests", version="2.28.0", ecosystem="pypi")
+    return Agent(
+        name=name,
+        agent_type=AgentType.CUSTOM,
+        config_path=f"/tmp/{name}.json",
+        mcp_servers=[MCPServer(name=f"{name}-server", packages=[pkg])],
+    )
+
+
+def test_scan_packages_explicit_offline_option_ignores_global_online_state(monkeypatch):
+    """Offline fail-closed behavior must be per scan, not read from a global."""
+    monkeypatch.setattr(scanners, "offline_mode", False)
+    pkg = Package(name="requests", version="2.28.0", ecosystem="pypi")
+
+    with (
+        patch("agent_bom.scanners._scan_packages_local_db", return_value=(0, set())),
+        patch("agent_bom.scanners.query_osv_batch") as mock_osv,
+    ):
+        with pytest.raises(IncompleteScanError, match="populated local vulnerability DB"):
+            asyncio.run(scan_packages([pkg], options=ScanOptions(offline=True)))
+
+    mock_osv.assert_not_called()
+
+
+def test_scan_agents_threads_independent_options_to_package_scan(monkeypatch):
+    """Concurrent scans must carry their own options into package scanning."""
+    seen: list[tuple[bool, bool]] = []
+
+    async def _scan_packages(_packages, *, resolve_transitive=False, options=None):
+        assert options is not None
+        seen.append((options.offline, options.compliance_enabled))
+        await asyncio.sleep(0)
+        return 0
+
+    monkeypatch.setattr(scanners, "scan_packages", _scan_packages)
+
+    async def _run() -> None:
+        await asyncio.gather(
+            scan_agents(
+                [_agent("offline")],
+                options=ScanOptions(offline=True, compliance_enabled=True),
+                show_scan_banner=False,
+            ),
+            scan_agents(
+                [_agent("online")],
+                options=ScanOptions(offline=False, compliance_enabled=False),
+                show_scan_banner=False,
+            ),
+        )
+
+    asyncio.run(_run())
+
+    assert sorted(seen) == [(False, False), (True, True)]
+
+
+def test_scan_agents_sync_does_not_mutate_legacy_compliance_global(monkeypatch):
+    """The legacy compliance global must not become request-scoped state."""
+    monkeypatch.setattr(scanners, "compliance_mode", False)
+
+    async def _scan_packages(_packages, *, resolve_transitive=False, options=None):
+        assert options is not None
+        assert options.compliance_enabled is True
+        return 0
+
+    monkeypatch.setattr(scanners, "scan_packages", _scan_packages)
+
+    scan_agents_sync([_agent("compliance")], compliance_enabled=True, show_scan_banner=False)
+
+    assert scanners.compliance_mode is False


### PR DESCRIPTION
Summary

- add immutable per-scan `ScanOptions` and thread it through package, agent, enriched, and sync scanner paths
- stop mutating `compliance_mode` during scans and use request-local options for compliance tagging
- pass explicit online/offline scan intent from CLI, API, guard, MCP tool, and MCP server scan surfaces so stale process globals cannot contaminate unrelated scans
- add regression tests proving explicit offline options fail closed without touching OSV and concurrent scans preserve independent option values

Why

The scanner had legacy module-level `offline_mode` and `compliance_mode` state. `offline_mode` is still needed as a compatibility setter for CLI transport enforcement, but long-running API/CLI scans should not depend on mutable process-global state. This isolates scan policy per invocation and closes the multi-tenant correctness risk without changing the existing public scan signatures.

Validation

- `uv run pytest tests/test_scan_options.py tests/test_local_db_scan.py::test_scan_packages_offline_requires_local_db tests/test_local_db_scan.py::test_scan_packages_offline_partial_db_raises -q` -> 5 passed
- `uv run pytest tests/test_cli_check.py tests/test_scan_options.py -q` -> 14 passed
- `uv run pytest tests/test_scanner_robustness.py tests/test_scanner_ecosystems.py tests/test_local_db_scan.py tests/test_cli_check.py tests/test_scan_options.py -q` -> 78 passed
- `uv run ruff check src/agent_bom/scanners/__init__.py src/agent_bom/cli/_scan_runner.py src/agent_bom/cli/agents/__init__.py src/agent_bom/api/pipeline.py src/agent_bom/cli/_check.py src/agent_bom/guard.py src/agent_bom/mcp_tools/scanning.py src/agent_bom/mcp_server_scan.py tests/test_scan_options.py tests/test_cli_check.py`
- `uv run mypy src/agent_bom/scanners/__init__.py src/agent_bom/cli/_scan_runner.py src/agent_bom/cli/agents/__init__.py src/agent_bom/api/pipeline.py src/agent_bom/cli/_check.py src/agent_bom/guard.py src/agent_bom/mcp_tools/scanning.py src/agent_bom/mcp_server_scan.py`
- `git diff --check`
