### PR TITLE
perf: parallelize AWS provider discovery

### DIFF
--- a/src/agent_bom/cloud/aws.py
+++ b/src/agent_bom/cloud/aws.py
@@ -15,6 +15,8 @@ import json
 import logging
 import os
 import zipfile
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from email.parser import Parser as EmailParser
 from pathlib import Path
 from typing import Any
@@ -33,6 +35,8 @@ from .normalization import (
 )
 
 logger = logging.getLogger(__name__)
+
+_MAX_AWS_DISCOVERY_WORKERS = 4
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -79,103 +83,144 @@ def discover(
     resolved_region = session.region_name or os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
     account_id = _resolve_account_id(session)
 
+    discovery_jobs: list[tuple[str, Callable[[], tuple[list[Agent], list[str], list[dict[str, str] | str]]]]] = []
+
+    def _new_discovery_session() -> Any:
+        return boto3.Session(**session_kwargs)
+
     # ── Bedrock Agents ────────────────────────────────────────────────────
-    try:
-        bedrock_agents, bedrock_warnings = _discover_bedrock(session, resolved_region, account_id=account_id)
-        agents.extend(bedrock_agents)
-        warnings.extend(bedrock_warnings)
-    except NoCredentialsError:
-        warnings.append("AWS credentials not found. Configure via env vars, ~/.aws/credentials, IAM role, or SSO.")
-        return agents, warnings
-    except ClientError as exc:
-        code = exc.response["Error"]["Code"]
-        if code in ("AccessDeniedException", "UnauthorizedAccess"):
-            warnings.append("Access denied for bedrock-agent:ListAgents. Attach the BedrockAgentReadOnly or AmazonBedrockReadOnly policy.")
-        else:
-            warnings.append(f"AWS Bedrock API error: {exc}")
+    def _bedrock_job() -> tuple[list[Agent], list[str], list[dict[str, str] | str]]:
+        bedrock_agents, bedrock_warnings = _discover_bedrock(
+            _new_discovery_session(),
+            resolved_region,
+            account_id=account_id,
+        )
+        return bedrock_agents, bedrock_warnings, []
+
+    discovery_jobs.append(("bedrock", _bedrock_job))
 
     # ── ECS Tasks ─────────────────────────────────────────────────────────
     if include_ecs:
-        try:
-            ecs_refs, ecs_warns = _discover_ecs_images(session, resolved_region)
-            ecs_image_refs.extend(ecs_refs)
-            warnings.extend(ecs_warns)
-        except ClientError as exc:
-            code = exc.response["Error"]["Code"]
-            if code in ("AccessDeniedException", "UnauthorizedAccess"):
-                warnings.append("Access denied for ECS APIs. Attach AmazonECSReadOnlyAccess policy.")
-            else:
-                warnings.append(f"AWS ECS API error: {exc}")
+
+        def _ecs_job() -> tuple[list[Agent], list[str], list[dict[str, str] | str]]:
+            ecs_refs, ecs_warns = _discover_ecs_images(_new_discovery_session(), resolved_region)
+            return [], ecs_warns, list(ecs_refs)
+
+        discovery_jobs.append(("ecs", _ecs_job))
 
     # ── SageMaker Endpoints ───────────────────────────────────────────────
     if include_sagemaker:
-        try:
-            sm_agents, sm_warns = _discover_sagemaker(session, resolved_region, account_id=account_id)
-            agents.extend(sm_agents)
-            warnings.extend(sm_warns)
-        except ClientError as exc:
-            code = exc.response["Error"]["Code"]
-            if code in ("AccessDeniedException", "UnauthorizedAccess"):
-                warnings.append("Access denied for SageMaker APIs. Attach AmazonSageMakerReadOnly policy.")
-            else:
-                warnings.append(f"AWS SageMaker API error: {exc}")
+
+        def _sagemaker_job() -> tuple[list[Agent], list[str], list[dict[str, str] | str]]:
+            sm_agents, sm_warns = _discover_sagemaker(
+                _new_discovery_session(),
+                resolved_region,
+                account_id=account_id,
+            )
+            return sm_agents, sm_warns, []
+
+        discovery_jobs.append(("sagemaker", _sagemaker_job))
 
     # ── Lambda Functions (direct discovery) ────────────────────────────────
     if include_lambda:
-        try:
-            lambda_agents, lambda_warns = _discover_lambda_functions(session, resolved_region, warnings, account_id=account_id)
-            agents.extend(lambda_agents)
-            warnings.extend(lambda_warns)
-        except ClientError as exc:
-            code = exc.response["Error"]["Code"]
-            if code in ("AccessDeniedException", "UnauthorizedAccess"):
-                warnings.append("Access denied for Lambda APIs. Attach AWSLambda_ReadOnlyAccess policy.")
-            else:
-                warnings.append(f"AWS Lambda API error: {exc}")
+
+        def _lambda_job() -> tuple[list[Agent], list[str], list[dict[str, str] | str]]:
+            lambda_parent_warnings: list[str] = []
+            lambda_agents, lambda_warns = _discover_lambda_functions(
+                _new_discovery_session(),
+                resolved_region,
+                lambda_parent_warnings,
+                account_id=account_id,
+            )
+            return lambda_agents, [*lambda_parent_warnings, *lambda_warns], []
+
+        discovery_jobs.append(("lambda", _lambda_job))
 
     # ── EKS Clusters ───────────────────────────────────────────────────────
     if include_eks:
-        try:
-            eks_agents, eks_warns = _discover_eks_images(session, resolved_region, account_id=account_id)
-            agents.extend(eks_agents)
-            warnings.extend(eks_warns)
-        except ClientError as exc:
-            code = exc.response["Error"]["Code"]
-            if code in ("AccessDeniedException", "UnauthorizedAccess"):
-                warnings.append("Access denied for EKS APIs. Attach AmazonEKSReadOnlyAccess policy.")
-            else:
-                warnings.append(f"AWS EKS API error: {exc}")
+
+        def _eks_job() -> tuple[list[Agent], list[str], list[dict[str, str] | str]]:
+            eks_agents, eks_warns = _discover_eks_images(
+                _new_discovery_session(),
+                resolved_region,
+                account_id=account_id,
+            )
+            return eks_agents, eks_warns, []
+
+        discovery_jobs.append(("eks", _eks_job))
 
     # ── Step Functions ─────────────────────────────────────────────────────
     if include_step_functions:
-        try:
-            sfn_agents, sfn_warns = _discover_step_functions(session, resolved_region, warnings, account_id=account_id)
-            agents.extend(sfn_agents)
-            warnings.extend(sfn_warns)
-        except ClientError as exc:
-            code = exc.response["Error"]["Code"]
-            if code in ("AccessDeniedException", "UnauthorizedAccess"):
-                warnings.append("Access denied for Step Functions APIs. Attach AWSStepFunctionsReadOnlyAccess policy.")
-            else:
-                warnings.append(f"AWS Step Functions API error: {exc}")
+
+        def _sfn_job() -> tuple[list[Agent], list[str], list[dict[str, str] | str]]:
+            sfn_parent_warnings: list[str] = []
+            sfn_agents, sfn_warns = _discover_step_functions(
+                _new_discovery_session(),
+                resolved_region,
+                sfn_parent_warnings,
+                account_id=account_id,
+            )
+            return sfn_agents, [*sfn_parent_warnings, *sfn_warns], []
+
+        discovery_jobs.append(("step-functions", _sfn_job))
 
     # ── EC2 Instances (tag-filtered) ───────────────────────────────────────
     if include_ec2:
-        try:
+
+        def _ec2_job() -> tuple[list[Agent], list[str], list[dict[str, str] | str]]:
             ec2_agents, ec2_warns = _discover_ec2_instances(
-                session,
+                _new_discovery_session(),
                 resolved_region,
                 ec2_tag_filter or {},
                 account_id=account_id,
             )
-            agents.extend(ec2_agents)
-            warnings.extend(ec2_warns)
-        except ClientError as exc:
-            code = exc.response["Error"]["Code"]
-            if code in ("AccessDeniedException", "UnauthorizedAccess"):
-                warnings.append("Access denied for EC2 APIs. Attach AmazonEC2ReadOnlyAccess policy.")
-            else:
-                warnings.append(f"AWS EC2 API error: {exc}")
+            return ec2_agents, ec2_warns, []
+
+        discovery_jobs.append(("ec2", _ec2_job))
+
+    access_denied_warnings = {
+        "bedrock": "Access denied for bedrock-agent:ListAgents. Attach the BedrockAgentReadOnly or AmazonBedrockReadOnly policy.",
+        "ecs": "Access denied for ECS APIs. Attach AmazonECSReadOnlyAccess policy.",
+        "sagemaker": "Access denied for SageMaker APIs. Attach AmazonSageMakerReadOnly policy.",
+        "lambda": "Access denied for Lambda APIs. Attach AWSLambda_ReadOnlyAccess policy.",
+        "eks": "Access denied for EKS APIs. Attach AmazonEKSReadOnlyAccess policy.",
+        "step-functions": "Access denied for Step Functions APIs. Attach AWSStepFunctionsReadOnlyAccess policy.",
+        "ec2": "Access denied for EC2 APIs. Attach AmazonEC2ReadOnlyAccess policy.",
+    }
+    api_error_labels = {
+        "bedrock": "AWS Bedrock API error",
+        "ecs": "AWS ECS API error",
+        "sagemaker": "AWS SageMaker API error",
+        "lambda": "AWS Lambda API error",
+        "eks": "AWS EKS API error",
+        "step-functions": "AWS Step Functions API error",
+        "ec2": "AWS EC2 API error",
+    }
+
+    if discovery_jobs:
+        with ThreadPoolExecutor(max_workers=min(_MAX_AWS_DISCOVERY_WORKERS, len(discovery_jobs))) as executor:
+            futures_by_service = {service: executor.submit(job) for service, job in discovery_jobs}
+
+            for service, _job in discovery_jobs:
+                future = futures_by_service[service]
+                try:
+                    service_agents, service_warnings, service_ecs_refs = future.result()
+                except NoCredentialsError:
+                    if service == "bedrock":
+                        warnings.append("AWS credentials not found. Configure via env vars, ~/.aws/credentials, IAM role, or SSO.")
+                        return agents, warnings
+                    raise
+                except ClientError as exc:
+                    code = exc.response["Error"]["Code"]
+                    if code in ("AccessDeniedException", "UnauthorizedAccess"):
+                        warnings.append(access_denied_warnings[service])
+                    else:
+                        warnings.append(f"{api_error_labels[service]}: {exc}")
+                    continue
+
+                agents.extend(service_agents)
+                warnings.extend(service_warnings)
+                ecs_image_refs.extend(service_ecs_refs)
 
     # ── ECS images as agents ──────────────────────────────────────────────
     for ecs_ref in ecs_image_refs:

--- a/tests/test_cloud_aws.py
+++ b/tests/test_cloud_aws.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import sys
+from threading import Event
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from agent_bom.cloud.base import CloudDiscoveryError
+from agent_bom.models import Agent, AgentType
 
 
 def _mock_boto3():
@@ -17,6 +19,10 @@ def _mock_boto3():
     mock_boto3 = MagicMock()
     mock_boto3.Session.return_value = mock_session
     return mock_boto3, mock_session
+
+
+def _agent(name: str, source: str) -> Agent:
+    return Agent(name=name, agent_type=AgentType.CUSTOM, config_path=f"aws://{name}", source=source)
 
 
 # ---------------------------------------------------------------------------
@@ -306,3 +312,112 @@ def test_discover_with_region_and_profile():
 
         agents, warnings = aws.discover(region="eu-west-1", profile="prod", include_ecs=False)
         mock_boto3.Session.assert_called_with(region_name="eu-west-1", profile_name="prod")
+
+
+def test_discover_calls_all_enabled_aws_services_and_preserves_results_and_warnings():
+    """Parallel service discovery should preserve the previous aggregation contract."""
+    mock_boto3, mock_session = _mock_boto3()
+    mock_botocore = MagicMock()
+    mock_botocore.exceptions.ClientError = type("ClientError", (Exception,), {})
+    mock_botocore.exceptions.NoCredentialsError = type("NoCredentialsError", (Exception,), {})
+
+    mock_sts = MagicMock()
+    mock_sts.get_caller_identity.return_value = {"Account": "123456789012"}
+    mock_session.client.return_value = mock_sts
+
+    def lambda_discovery(_session, _region, parent_warnings, *, account_id=None):
+        parent_warnings.append("lambda-package-warning")
+        return [_agent(f"lambda:{account_id}", "aws-lambda")], ["lambda-warning"]
+
+    def sfn_discovery(_session, _region, parent_warnings, *, account_id=None):
+        parent_warnings.append("sfn-package-warning")
+        return [_agent(f"sfn:{account_id}", "aws-step-functions")], ["sfn-warning"]
+
+    with (
+        patch.dict(sys.modules, {"boto3": mock_boto3, "botocore": mock_botocore, "botocore.exceptions": mock_botocore.exceptions}),
+        patch("agent_bom.cloud.aws._discover_bedrock", return_value=([_agent("bedrock", "aws-bedrock")], ["bedrock-warning"])) as bedrock,
+        patch(
+            "agent_bom.cloud.aws._discover_ecs_images",
+            return_value=([{"image": "repo/app:1", "container_name": "app"}], ["ecs-warning"]),
+        ) as ecs,
+        patch(
+            "agent_bom.cloud.aws._discover_sagemaker",
+            return_value=([_agent("sagemaker", "aws-sagemaker")], ["sagemaker-warning"]),
+        ) as sagemaker,
+        patch("agent_bom.cloud.aws._discover_lambda_functions", side_effect=lambda_discovery) as lambda_functions,
+        patch("agent_bom.cloud.aws._discover_eks_images", return_value=([_agent("eks", "aws-eks")], ["eks-warning"])) as eks,
+        patch("agent_bom.cloud.aws._discover_step_functions", side_effect=sfn_discovery) as step_functions,
+        patch("agent_bom.cloud.aws._discover_ec2_instances", return_value=([_agent("ec2", "aws-ec2")], ["ec2-warning"])) as ec2,
+    ):
+        from agent_bom.cloud import aws
+
+        agents, warnings = aws.discover(
+            region="us-east-1",
+            include_ecs=True,
+            include_sagemaker=True,
+            include_lambda=True,
+            include_eks=True,
+            include_step_functions=True,
+            include_ec2=True,
+            ec2_tag_filter={"Agent": "true"},
+        )
+
+    bedrock.assert_called_once_with(mock_session, "us-east-1", account_id="123456789012")
+    ecs.assert_called_once_with(mock_session, "us-east-1")
+    sagemaker.assert_called_once_with(mock_session, "us-east-1", account_id="123456789012")
+    lambda_functions.assert_called_once()
+    eks.assert_called_once_with(mock_session, "us-east-1", account_id="123456789012")
+    step_functions.assert_called_once()
+    ec2.assert_called_once_with(mock_session, "us-east-1", {"Agent": "true"}, account_id="123456789012")
+
+    assert [agent.source for agent in agents] == [
+        "aws-bedrock",
+        "aws-sagemaker",
+        "aws-lambda",
+        "aws-eks",
+        "aws-step-functions",
+        "aws-ec2",
+        "aws-ecs",
+    ]
+    assert warnings == [
+        "bedrock-warning",
+        "ecs-warning",
+        "sagemaker-warning",
+        "lambda-package-warning",
+        "lambda-warning",
+        "eks-warning",
+        "sfn-package-warning",
+        "sfn-warning",
+        "ec2-warning",
+    ]
+
+
+def test_discover_submits_aws_service_discovery_before_waiting_for_ordered_results():
+    """A slow first service should not block later services from starting."""
+    mock_boto3, mock_session = _mock_boto3()
+    mock_botocore = MagicMock()
+    mock_botocore.exceptions.ClientError = type("ClientError", (Exception,), {})
+    mock_botocore.exceptions.NoCredentialsError = type("NoCredentialsError", (Exception,), {})
+    mock_session.client.return_value.get_caller_identity.return_value = {"Account": "123456789012"}
+
+    ecs_started = Event()
+
+    def bedrock_discovery(_session, _region, *, account_id=None):
+        assert ecs_started.wait(timeout=2)
+        return [_agent(f"bedrock:{account_id}", "aws-bedrock")], []
+
+    def ecs_discovery(_session, _region):
+        ecs_started.set()
+        return [], []
+
+    with (
+        patch.dict(sys.modules, {"boto3": mock_boto3, "botocore": mock_botocore, "botocore.exceptions": mock_botocore.exceptions}),
+        patch("agent_bom.cloud.aws._discover_bedrock", side_effect=bedrock_discovery),
+        patch("agent_bom.cloud.aws._discover_ecs_images", side_effect=ecs_discovery),
+    ):
+        from agent_bom.cloud import aws
+
+        agents, warnings = aws.discover(region="us-east-1", include_ecs=True)
+
+    assert warnings == []
+    assert [agent.source for agent in agents] == ["aws-bedrock"]


### PR DESCRIPTION
Summary

- run enabled AWS service discovery jobs through a bounded 4-worker executor instead of serial top-level service calls
- keep each worker on its own boto3 session and preserve deterministic result/warning aggregation order
- isolate Lambda and Step Functions parent warning buffers so parallel jobs do not share mutable warning state
- add regression coverage proving all enabled services run, ordered aggregation is preserved, and a slow first service does not block later services from starting

Why

AWS discovery covered the right services, but busy accounts could spend most of their scan time waiting on independent read-only APIs in sequence. This keeps the same read-only discovery behavior while reducing wall-clock latency for multi-service accounts.

Validation

- `pytest tests/test_cloud_aws.py -q` -> 11 passed
- `ruff check src/agent_bom/cloud/aws.py tests/test_cloud_aws.py`
- `mypy src/agent_bom/cloud/aws.py tests/test_cloud_aws.py`
- `git diff --check`

Refs #2085
