### PR TITLE
fix: preserve external scanner advisory metadata

### DIFF
--- a/src/agent_bom/parsers/external_scanners.py
+++ b/src/agent_bom/parsers/external_scanners.py
@@ -54,6 +54,64 @@ def _map_severity(raw: str) -> Severity:
     return mapping.get(raw.lower(), Severity.UNKNOWN)
 
 
+def _string_list(values: Any) -> list[str]:
+    """Return non-empty string values while preserving input order."""
+    if not isinstance(values, list):
+        return []
+    return [value for value in values if isinstance(value, str) and value]
+
+
+def _cwe_ids(values: Any) -> list[str]:
+    return [value for value in _string_list(values) if value.upper().startswith("CWE-")]
+
+
+def _aliases(primary_id: str, *sources: Any) -> list[str]:
+    seen: set[str] = {primary_id}
+    aliases: list[str] = []
+    for source in sources:
+        for value in _string_list(source):
+            if value in seen:
+                continue
+            seen.add(value)
+            aliases.append(value)
+    return aliases
+
+
+def _trivy_advisory_source(vuln: dict[str, Any]) -> str | None:
+    data_source = vuln.get("DataSource") or {}
+    if isinstance(data_source, dict):
+        source_id = data_source.get("ID")
+        if isinstance(source_id, str) and source_id:
+            return source_id
+        source_name = data_source.get("Name")
+        if isinstance(source_name, str) and source_name:
+            return source_name
+    severity_source = vuln.get("SeveritySource")
+    return severity_source if isinstance(severity_source, str) and severity_source else None
+
+
+def _grype_advisory_source(vuln: dict[str, Any]) -> str | None:
+    namespace = vuln.get("namespace")
+    if isinstance(namespace, str) and namespace:
+        return namespace
+    data_source = vuln.get("dataSource")
+    return data_source if isinstance(data_source, str) and data_source else None
+
+
+def _grype_related_aliases(vuln: dict[str, Any]) -> list[str]:
+    related = vuln.get("relatedVulnerabilities") or []
+    if not isinstance(related, list):
+        return []
+    aliases: list[str] = []
+    for item in related:
+        if not isinstance(item, dict):
+            continue
+        item_id = item.get("id")
+        if isinstance(item_id, str) and item_id:
+            aliases.append(item_id)
+    return aliases
+
+
 # ── Trivy parser ─────────────────────────────────────────────────────────────
 
 
@@ -98,14 +156,22 @@ def parse_trivy_json(data: dict[str, Any]) -> list[Package]:
                     break
 
             references: list[str] = vuln.get("References") or []
+            vuln_id = vuln.get("VulnerabilityID", "")
+            advisory_source = _trivy_advisory_source(vuln)
 
             vuln_obj = Vulnerability(
-                id=vuln.get("VulnerabilityID", ""),
+                id=vuln_id,
                 summary=vuln.get("Title") or vuln.get("Description") or "",
                 severity=_map_severity(vuln.get("Severity", "")),
+                severity_source=vuln.get("SeveritySource") or None,
                 cvss_score=cvss_score,
                 fixed_version=vuln.get("FixedVersion") or None,
                 references=list(references),
+                published_at=vuln.get("PublishedDate") or None,
+                modified_at=vuln.get("LastModifiedDate") or None,
+                aliases=_aliases(vuln_id, vuln.get("VendorIDs"), vuln.get("Aliases")),
+                cwe_ids=_cwe_ids(vuln.get("CweIDs")),
+                advisory_sources=[advisory_source] if advisory_source else [],
             )
             # Avoid duplicate vuln IDs on the same package
             existing_ids = {v.id for v in pkg.vulnerabilities}
@@ -164,14 +230,23 @@ def parse_grype_json(data: dict[str, Any]) -> list[Package]:
             fixed_version = fix_versions[0] if fix_versions else None
 
         references: list[str] = vuln_data.get("urls") or []
+        vuln_id = vuln_data.get("id", "")
+        related_aliases = _grype_related_aliases(vuln_data)
+        advisory_source = _grype_advisory_source(vuln_data)
 
         vuln_obj = Vulnerability(
-            id=vuln_data.get("id", ""),
+            id=vuln_id,
             summary=vuln_data.get("description") or "",
             severity=_map_severity(vuln_data.get("severity", "")),
+            severity_source=vuln_data.get("namespace") or None,
             cvss_score=cvss_score,
             fixed_version=fixed_version,
             references=list(references),
+            published_at=vuln_data.get("publishedDate") or vuln_data.get("published") or None,
+            modified_at=vuln_data.get("modifiedDate") or vuln_data.get("modified") or None,
+            aliases=_aliases(vuln_id, vuln_data.get("aliases"), related_aliases),
+            cwe_ids=_cwe_ids(vuln_data.get("cwes")),
+            advisory_sources=[advisory_source] if advisory_source else [],
         )
         existing_ids = {v.id for v in pkg.vulnerabilities}
         if vuln_obj.id not in existing_ids:

--- a/tests/test_external_scanners.py
+++ b/tests/test_external_scanners.py
@@ -65,7 +65,7 @@ TRIVY_MULTIPLE_ECOSYSTEMS = {
     ]
 }
 
-TRIVY_EMPTY = {"Results": []}
+TRIVY_EMPTY: dict[str, list[object]] = {"Results": []}
 
 # ── Grype fixtures ─────────────────────────────────────────────────────────
 
@@ -103,7 +103,7 @@ GRYPE_MULTIPLE_TYPES = {
     ]
 }
 
-GRYPE_EMPTY = {"matches": []}
+GRYPE_EMPTY: dict[str, list[object]] = {"matches": []}
 
 # ── Syft fixtures ──────────────────────────────────────────────────────────
 
@@ -195,6 +195,46 @@ def test_parse_trivy_ghsa_cvss_fallback():
     assert packages[0].vulnerabilities[0].cvss_score == 5.3
 
 
+def test_parse_trivy_preserves_advisory_metadata():
+    data = {
+        "Results": [
+            {
+                "Target": "requirements.txt",
+                "Type": "pip",
+                "Vulnerabilities": [
+                    {
+                        "VulnerabilityID": "CVE-2024-11111",
+                        "PkgName": "django",
+                        "InstalledVersion": "4.2.0",
+                        "Severity": "HIGH",
+                        "SeveritySource": "ghsa",
+                        "Title": "Django advisory",
+                        "DataSource": {
+                            "ID": "ghsa",
+                            "Name": "GitHub Security Advisory pip",
+                            "URL": "https://github.com/advisories",
+                        },
+                        "VendorIDs": ["GHSA-abcd-efgh-ijkl"],
+                        "CweIDs": ["CWE-79", "CWE-352"],
+                        "PublishedDate": "2024-01-02T03:04:05Z",
+                        "LastModifiedDate": "2024-01-03T03:04:05Z",
+                    }
+                ],
+            }
+        ]
+    }
+
+    packages = parse_trivy_json(data)
+
+    vuln = packages[0].vulnerabilities[0]
+    assert vuln.cwe_ids == ["CWE-79", "CWE-352"]
+    assert vuln.aliases == ["GHSA-abcd-efgh-ijkl"]
+    assert vuln.severity_source == "ghsa"
+    assert vuln.published_at == "2024-01-02T03:04:05Z"
+    assert vuln.modified_at == "2024-01-03T03:04:05Z"
+    assert vuln.advisory_sources == ["ghsa"]
+
+
 # ── Grype tests ────────────────────────────────────────────────────────────
 
 
@@ -249,6 +289,48 @@ def test_parse_grype_unfixed_no_fixed_version():
     }
     packages = parse_grype_json(data)
     assert packages[0].vulnerabilities[0].fixed_version is None
+
+
+def test_parse_grype_preserves_advisory_metadata():
+    data = {
+        "matches": [
+            {
+                "vulnerability": {
+                    "id": "GHSA-abcd-efgh-ijkl",
+                    "severity": "High",
+                    "namespace": "github:language:python",
+                    "dataSource": "https://github.com/advisories/GHSA-abcd-efgh-ijkl",
+                    "description": "Django advisory",
+                    "cwes": ["CWE-79", "CWE-352"],
+                    "aliases": ["PYSEC-2024-1"],
+                    "relatedVulnerabilities": [
+                        {
+                            "id": "CVE-2024-22222",
+                            "namespace": "nvd:cpe",
+                            "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2024-22222",
+                        }
+                    ],
+                    "publishedDate": "2024-02-02T00:00:00Z",
+                    "modifiedDate": "2024-02-03T00:00:00Z",
+                },
+                "artifact": {
+                    "name": "django",
+                    "version": "4.2.0",
+                    "type": "python",
+                },
+            }
+        ]
+    }
+
+    packages = parse_grype_json(data)
+
+    vuln = packages[0].vulnerabilities[0]
+    assert vuln.cwe_ids == ["CWE-79", "CWE-352"]
+    assert vuln.aliases == ["PYSEC-2024-1", "CVE-2024-22222"]
+    assert vuln.severity_source == "github:language:python"
+    assert vuln.published_at == "2024-02-02T00:00:00Z"
+    assert vuln.modified_at == "2024-02-03T00:00:00Z"
+    assert vuln.advisory_sources == ["github:language:python"]
 
 
 # ── Syft tests ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Summary

- preserve CWE IDs, aliases, severity source, published/modified timestamps, and advisory provenance when ingesting Trivy JSON
- preserve the same advisory metadata when ingesting Grype JSON, including related vulnerability aliases
- add focused Trivy and Grype fixtures proving canonical `Vulnerability` objects retain provenance used by confidence scoring and downstream exports

Why

External scanner ingestion previously normalized findings into package/vulnerability objects but dropped metadata that OSV/GHSA-native discovery keeps. That made identical advisories score and render differently depending on source. This keeps the canonical model richer without changing scanner detection semantics.

Validation

- `pytest tests/test_external_scanners.py -q` -> 21 passed
- `ruff check src/agent_bom/parsers/external_scanners.py tests/test_external_scanners.py`
- `mypy src/agent_bom/parsers/external_scanners.py tests/test_external_scanners.py`
- `git diff --check`

Refs #2085
