### PR TITLE
security: fix PR gate SARIF action contract

### DIFF
--- a/.github/workflows/pr-security-gate.yml
+++ b/.github/workflows/pr-security-gate.yml
@@ -151,40 +151,49 @@ jobs:
       - name: Install agent-bom + dev extras
         run: uv sync --frozen --extra dev
 
-      - name: Self-scan fixture SBOM for regressions
+      - name: Self-scan current agent-bom dependencies
         id: self_scan
         run: |
-          # Scan once; capture SARIF + JSON so downstream steps can read both.
-          # `|| true` because fixture SBOMs intentionally contain CVEs — we
-          # want the report, not a hard failure on the fixture's baseline.
-          uv run agent-bom sbom tests/fixtures/test-sbom.cdx.json -f sarif -o self-scan.sarif || true
-          uv run agent-bom sbom tests/fixtures/test-sbom.cdx.json -f json -o self-scan.json || true
+          set +e
+          uv run agent-bom scan --self-scan \
+            --format sarif \
+            -o self-scan.sarif \
+            --fail-on-severity high \
+            --exclude-unfixable \
+            --quiet
+          SCAN_EXIT=$?
+          set -e
 
-          # If the scan produced neither artifact, surface a minimal SARIF so
-          # the upload step has something valid to hand to code-scanning and
-          # operators still see the scan ran.
           if [ ! -s self-scan.sarif ]; then
-            cat > self-scan.sarif <<'EOF'
-          {"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"agent-bom","version":"0.0.0"}},"results":[]}]}
-          EOF
+            echo "::error::agent-bom self-scan did not produce self-scan.sarif"
+            exit 2
           fi
 
-          # KEV count is advisory — we surface it for the operator, never fail.
-          if [ -s self-scan.json ]; then
-            KEV_COUNT=$(python -c "
+          python3 - <<'PY'
           import json
-          try:
-              with open('self-scan.json') as f:
-                  data = json.load(f)
-              print(sum(1 for v in data.get('vulnerabilities', []) if v.get('kev')))
-          except Exception:
-              print('0')
-          ")
-            echo "Fixture SBOM reports ${KEV_COUNT} KEV-listed findings"
-            if [ "${KEV_COUNT:-0}" -gt 0 ]; then
-              echo "::warning::fixture SBOM contains ${KEV_COUNT} KEV-listed CVE(s) — investigate before merging if this is a new baseline"
-            fi
-          fi
+          from pathlib import Path
+
+          data = json.loads(Path("self-scan.sarif").read_text(encoding="utf-8"))
+          run = (data.get("runs") or [{}])[0]
+          results = run.get("results") or []
+          rules = {
+              rule.get("id"): rule
+              for rule in (run.get("tool", {}).get("driver", {}).get("rules") or [])
+          }
+          high_or_critical = []
+          kev = 0
+          for result in results:
+              props = rules.get(result.get("ruleId"), {}).get("properties", {})
+              score = float(props.get("security-severity") or 0)
+              kev += 1 if props.get("kev") else 0
+              if score >= 7.0:
+                  high_or_critical.append(result.get("ruleId", "<unknown>"))
+          print(f"agent-bom self-scan SARIF findings: total={len(results)} high_or_critical={len(high_or_critical)} kev={kev}")
+          if kev:
+              print(f"::warning::agent-bom self-scan found {kev} KEV-listed finding(s)")
+          PY
+
+          exit "$SCAN_EXIT"
 
       - name: Upload SARIF to code-scanning
         if: always() && hashFiles('self-scan.sarif') != ''

--- a/action.yml
+++ b/action.yml
@@ -214,6 +214,7 @@ runs:
         INPUT_SCAN_REF: ${{ inputs.scan-ref }}
         INPUT_FORMAT: ${{ inputs.format }}
         INPUT_OUTPUT: ${{ inputs.output }}
+        INPUT_UPLOAD_SARIF: ${{ inputs.upload-sarif }}
         INPUT_SEVERITY: ${{ inputs.severity-threshold }}
         INPUT_WARN_ON: ${{ inputs.warn-on-severity }}
         INPUT_POLICY: ${{ inputs.policy }}
@@ -256,6 +257,10 @@ runs:
               exit 1
               ;;
           esac
+        }
+        fail_unsupported_focused_mode() {
+          echo "::error::scan-type=$INPUT_SCAN_TYPE does not support SARIF upload or vulnerability gates. Use format=json or format=console with upload-sarif=false and no severity/policy gates, or use scan-type=scan/image/fs/iac/sbom."
+          exit 1
         }
         # Map scan-type to focused command
         #   scan  → agent-bom agents (full auto-detect, default)
@@ -338,6 +343,20 @@ runs:
           exit 1
         fi
 
+        if [ "$INPUT_SCAN_TYPE" = "secrets" ] || [ "$INPUT_SCAN_TYPE" = "code" ]; then
+          if [ -z "$INPUT_FORMAT" ] || [ "$INPUT_FORMAT" = "sarif" ]; then
+            fail_unsupported_focused_mode
+          fi
+          [ "$INPUT_UPLOAD_SARIF" = "true" ] && fail_unsupported_focused_mode
+          [ -n "$INPUT_SEVERITY" ] && fail_unsupported_focused_mode
+          [ -n "$INPUT_WARN_ON" ] && fail_unsupported_focused_mode
+          [ -n "$INPUT_POLICY" ] && fail_unsupported_focused_mode
+          [ "$INPUT_FAIL_ON_KEV" = "true" ] && fail_unsupported_focused_mode
+          [ "$INPUT_EXCLUDE_UNFIXABLE" = "true" ] && fail_unsupported_focused_mode
+          [ "$INPUT_GPU_SCAN" = "true" ] && fail_unsupported_focused_mode
+          [ "$INPUT_SKILL_ONLY" = "true" ] && fail_unsupported_focused_mode
+        fi
+
         # Output format
         if [ "$INPUT_FORMAT" = "sarif" ]; then
           ARGS+=(-f sarif -o "$RESULT_FILE")
@@ -351,101 +370,103 @@ runs:
         # Skills scans have their own narrower CLI surface and should not
         # inherit vulnerability-scan flags like --auto-update-db or --policy.
         if [ "$INPUT_SCAN_TYPE" != "skills" ]; then
-          # Severity gate
-          if [ -n "$INPUT_SEVERITY" ]; then
-            validate_severity_choice "$INPUT_SEVERITY" "severity-threshold"
-            ARGS+=(--fail-on-severity "$INPUT_SEVERITY")
-          fi
-
-          # Warn-on severity (non-blocking)
-          if [ -n "$INPUT_WARN_ON" ]; then
-            validate_severity_choice "$INPUT_WARN_ON" "warn-on-severity"
-            ARGS+=(--warn-on "$INPUT_WARN_ON")
-          fi
-
-          # Policy file
-          if [ -n "$INPUT_POLICY" ]; then
-            ARGS+=(--policy "$INPUT_POLICY")
-          fi
-
-          # Enrichment
-          if [ "$INPUT_ENRICH" = "true" ]; then
-            ARGS+=(--enrich)
-          fi
-
-          # Auto-update vulnerability database
-          if [ "$INPUT_AUTO_UPDATE_DB" = "true" ]; then
-            ARGS+=(--auto-update-db)
-          fi
-
-          # KEV gate
-          if [ "$INPUT_FAIL_ON_KEV" = "true" ]; then
-            ARGS+=(--fail-on-kev)
-          fi
-
-          # Docker image (skip if scan-type=image — already in command)
-          if [ -n "$INPUT_IMAGE" ] && [ "$INPUT_SCAN_TYPE" != "image" ]; then
-            ARGS+=(--image "$INPUT_IMAGE")
-          fi
-
-          # Config directory
-          if [ -n "$INPUT_CONFIG_DIR" ]; then
-            ARGS+=(--config-dir "$INPUT_CONFIG_DIR")
-          fi
-
-          # Existing SBOM (skip if scan-type=sbom — already in command)
-          if [ -n "$INPUT_SBOM" ] && [ "$INPUT_SCAN_TYPE" != "sbom" ]; then
-            ARGS+=(--sbom "$INPUT_SBOM")
-          fi
-
-          # Remediation plan
-          if [ -n "$INPUT_REMEDIATE" ]; then
-            ARGS+=(--remediate "$INPUT_REMEDIATE")
-          fi
-
-          # AI enrichment
-          if [ "$INPUT_AI_ENRICH" = "true" ]; then
-            ARGS+=(--ai-enrich)
-            if [ -n "$INPUT_AI_MODEL" ]; then
-              ARGS+=(--ai-model "$INPUT_AI_MODEL")
+          if [ "$INPUT_SCAN_TYPE" != "secrets" ] && [ "$INPUT_SCAN_TYPE" != "code" ]; then
+            # Severity gate
+            if [ -n "$INPUT_SEVERITY" ]; then
+              validate_severity_choice "$INPUT_SEVERITY" "severity-threshold"
+              ARGS+=(--fail-on-severity "$INPUT_SEVERITY")
             fi
-          fi
 
-          # Ignore file
-          if [ -n "$INPUT_IGNORE_FILE" ]; then
-            ARGS+=(--ignore-file "$INPUT_IGNORE_FILE")
-          fi
+            # Warn-on severity (non-blocking)
+            if [ -n "$INPUT_WARN_ON" ]; then
+              validate_severity_choice "$INPUT_WARN_ON" "warn-on-severity"
+              ARGS+=(--warn-on "$INPUT_WARN_ON")
+            fi
 
-          # IaC scanning paths (skip if scan-type=iac — already in command)
-          if [ -n "$INPUT_IAC" ] && [ "$INPUT_SCAN_TYPE" != "iac" ]; then
-            IFS=',' read -ra IAC_PATHS <<< "$INPUT_IAC"
-            for p in "${IAC_PATHS[@]}"; do
-              p="$(trim_arg "$p")"
-              if [ -n "$p" ]; then
-                ARGS+=(--iac "$p")
+            # Policy file
+            if [ -n "$INPUT_POLICY" ]; then
+              ARGS+=(--policy "$INPUT_POLICY")
+            fi
+
+            # Enrichment
+            if [ "$INPUT_ENRICH" = "true" ]; then
+              ARGS+=(--enrich)
+            fi
+
+            # Auto-update vulnerability database
+            if [ "$INPUT_AUTO_UPDATE_DB" = "true" ]; then
+              ARGS+=(--auto-update-db)
+            fi
+
+            # KEV gate
+            if [ "$INPUT_FAIL_ON_KEV" = "true" ]; then
+              ARGS+=(--fail-on-kev)
+            fi
+
+            # Docker image (skip if scan-type=image — already in command)
+            if [ -n "$INPUT_IMAGE" ] && [ "$INPUT_SCAN_TYPE" != "image" ]; then
+              ARGS+=(--image "$INPUT_IMAGE")
+            fi
+
+            # Config directory
+            if [ -n "$INPUT_CONFIG_DIR" ]; then
+              ARGS+=(--config-dir "$INPUT_CONFIG_DIR")
+            fi
+
+            # Existing SBOM (skip if scan-type=sbom — already in command)
+            if [ -n "$INPUT_SBOM" ] && [ "$INPUT_SCAN_TYPE" != "sbom" ]; then
+              ARGS+=(--sbom "$INPUT_SBOM")
+            fi
+
+            # Remediation plan
+            if [ -n "$INPUT_REMEDIATE" ]; then
+              ARGS+=(--remediate "$INPUT_REMEDIATE")
+            fi
+
+            # AI enrichment
+            if [ "$INPUT_AI_ENRICH" = "true" ]; then
+              ARGS+=(--ai-enrich)
+              if [ -n "$INPUT_AI_MODEL" ]; then
+                ARGS+=(--ai-model "$INPUT_AI_MODEL")
               fi
-            done
-          fi
+            fi
 
-          # AI inventory scanning paths
-          if [ -n "$INPUT_AI_INVENTORY" ]; then
-            IFS=',' read -ra AI_PATHS <<< "$INPUT_AI_INVENTORY"
-            for p in "${AI_PATHS[@]}"; do
-              p="$(trim_arg "$p")"
-              if [ -n "$p" ]; then
-                ARGS+=(--ai-inventory "$p")
-              fi
-            done
-          fi
+            # Ignore file
+            if [ -n "$INPUT_IGNORE_FILE" ]; then
+              ARGS+=(--ignore-file "$INPUT_IGNORE_FILE")
+            fi
 
-          # OS package scanning
-          if [ "$INPUT_OS_PACKAGES" = "true" ]; then
-            ARGS+=(--os-packages)
-          fi
+            # IaC scanning paths (skip if scan-type=iac — already in command)
+            if [ -n "$INPUT_IAC" ] && [ "$INPUT_SCAN_TYPE" != "iac" ]; then
+              IFS=',' read -ra IAC_PATHS <<< "$INPUT_IAC"
+              for p in "${IAC_PATHS[@]}"; do
+                p="$(trim_arg "$p")"
+                if [ -n "$p" ]; then
+                  ARGS+=(--iac "$p")
+                fi
+              done
+            fi
 
-          # Delta scanning baseline
-          if [ -n "$INPUT_BASELINE" ]; then
-            ARGS+=(--baseline "$INPUT_BASELINE" --delta-mode new-only)
+            # AI inventory scanning paths
+            if [ -n "$INPUT_AI_INVENTORY" ]; then
+              IFS=',' read -ra AI_PATHS <<< "$INPUT_AI_INVENTORY"
+              for p in "${AI_PATHS[@]}"; do
+                p="$(trim_arg "$p")"
+                if [ -n "$p" ]; then
+                  ARGS+=(--ai-inventory "$p")
+                fi
+              done
+            fi
+
+            # OS package scanning
+            if [ "$INPUT_OS_PACKAGES" = "true" ]; then
+              ARGS+=(--os-packages)
+            fi
+
+            # Delta scanning baseline
+            if [ -n "$INPUT_BASELINE" ]; then
+              ARGS+=(--baseline "$INPUT_BASELINE" --delta-mode new-only)
+            fi
           fi
         fi
 

--- a/src/agent_bom/cli/_focused_commands.py
+++ b/src/agent_bom/cli/_focused_commands.py
@@ -21,6 +21,17 @@ from typing import Optional
 import click
 
 
+def _validate_json_or_console_format(command_name: str, output_format: str) -> str:
+    """Focused intelligence commands do not emit SARIF or implement vuln gates."""
+    normalized = output_format.lower()
+    if normalized not in {"console", "json"}:
+        raise click.ClickException(
+            f"{command_name} supports only format=console or format=json; "
+            "SARIF output and vulnerability gates are not supported for this focused mode."
+        )
+    return normalized
+
+
 @click.command("image")
 @click.argument("image_ref")
 @click.option("--platform", help="Target platform (e.g. linux/amd64)")
@@ -237,6 +248,8 @@ def secrets_cmd(path: str, output_format: str, output_path: Optional[str], quiet
 
     from agent_bom.secret_scanner import scan_secrets
 
+    output_format = _validate_json_or_console_format("secrets", output_format)
+
     con = Console(stderr=True, quiet=quiet)
     result = scan_secrets(path)
 
@@ -293,6 +306,8 @@ def code_cmd(path: str, output_format: str, output_path: Optional[str], quiet: b
 
     from agent_bom.ai_components import scan_source
     from agent_bom.ast_analyzer import analyze_project
+
+    output_format = _validate_json_or_console_format("code", output_format)
 
     con = Console(stderr=True, quiet=quiet)
     result = analyze_project(path)

--- a/src/agent_bom/cli/agents/_preflight.py
+++ b/src/agent_bom/cli/agents/_preflight.py
@@ -270,7 +270,7 @@ def run_iac_only_scan(
     iac_ctx.report = iac_report
     iac_ctx.iac_findings_data = iac_report.iac_findings_data
 
-    if output_format == "json" or output:
+    if output_format == "json" or (output and output_format == "console"):
         out_data = json.dumps(iac_report.iac_findings_data, indent=2)
         if output and output != "-":
             Path(output).write_text(out_data)

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+from typing import Any
 
 from agent_bom.finding import FindingType
 from agent_bom.models import AIBOMReport, Severity
+from agent_bom.security import sanitize_sensitive_payload
 
 _SARIF_SEVERITY_MAP = {
     Severity.CRITICAL: "error",
@@ -55,6 +57,11 @@ def _to_relative_path(path: str) -> str:
             return p.name
 
     return path
+
+
+def _sanitize_sarif_property(value: Any) -> Any:
+    """Apply final defensive redaction before data leaves via SARIF."""
+    return sanitize_sensitive_payload(value, max_str_len=1000)
 
 
 def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
@@ -232,8 +239,8 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
                     "risk_score": finding.risk_score,
                     "asset_type": finding.asset.asset_type,
                     "asset_name": finding.asset.name,
-                    "evidence": finding.evidence,
-                    "remediation_guidance": finding.remediation_guidance,
+                    "evidence": _sanitize_sarif_property(finding.evidence),
+                    "remediation_guidance": _sanitize_sarif_property(finding.remediation_guidance),
                 },
             }
         )
@@ -389,8 +396,8 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
             result_props: dict = {
                 "remediation": remediation,
                 "cis_section": check.get("cis_section") or "",
-                "evidence": check.get("evidence") or "",
-                "resource_ids": check.get("resource_ids") or [],
+                "evidence": _sanitize_sarif_property(check.get("evidence") or ""),
+                "resource_ids": _sanitize_sarif_property(check.get("resource_ids") or []),
             }
             # Surface the remediation knobs flat for consumers that
             # can't (or don't want to) read nested dicts.

--- a/tests/test_pr_gate_sarif_action_contract.py
+++ b/tests/test_pr_gate_sarif_action_contract.py
@@ -1,0 +1,97 @@
+"""Regression tests for the PR gate, action, and focused SARIF contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType
+from agent_bom.models import AIBOMReport
+from agent_bom.output.sarif import to_sarif
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_pr_security_gate_uses_real_self_scan_sarif_not_fixture() -> None:
+    workflow = (ROOT / ".github/workflows/pr-security-gate.yml").read_text(encoding="utf-8")
+
+    assert "tests/fixtures/test-sbom.cdx.json" not in workflow
+    assert "|| true" not in workflow
+    assert "agent-bom scan --self-scan" in workflow
+    assert "--format sarif" in workflow
+    assert "--fail-on-severity high" in workflow
+    assert yaml.safe_load(workflow)["jobs"]["self-scan-pr"]
+
+
+def test_action_rejects_secrets_and_code_sarif_or_gate_contracts() -> None:
+    action_text = (ROOT / "action.yml").read_text(encoding="utf-8")
+    action = yaml.safe_load(action_text)
+    scan_step = next(step for step in action["runs"]["steps"] if step.get("id") == "scan")
+    run_script = scan_step["run"]
+
+    assert "INPUT_UPLOAD_SARIF" in scan_step["env"]
+    assert "fail_unsupported_focused_mode" in run_script
+    assert "scan-type=$INPUT_SCAN_TYPE does not support SARIF upload or vulnerability gates" in run_script
+    assert '[ "$INPUT_SCAN_TYPE" = "secrets" ] || [ "$INPUT_SCAN_TYPE" = "code" ]' in run_script
+    assert '[ "$INPUT_SCAN_TYPE" != "secrets" ] && [ "$INPUT_SCAN_TYPE" != "code" ]' in run_script
+
+
+def test_focused_secrets_and_code_reject_sarif_format(tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    secrets = runner.invoke(main, ["secrets", str(tmp_path), "-f", "sarif", "-o", str(tmp_path / "secrets.sarif")])
+    assert secrets.exit_code != 0
+    assert "SARIF output and vulnerability gates are not supported" in secrets.output
+    assert not (tmp_path / "secrets.sarif").exists()
+
+    code = runner.invoke(main, ["code", str(tmp_path), "-f", "sarif", "-o", str(tmp_path / "code.sarif")])
+    assert code.exit_code != 0
+    assert "SARIF output and vulnerability gates are not supported" in code.output
+    assert not (tmp_path / "code.sarif").exists()
+
+
+def test_iac_sarif_output_path_writes_valid_sarif(tmp_path: Path) -> None:
+    (tmp_path / "Dockerfile").write_text("FROM python:latest\nUSER root\n", encoding="utf-8")
+    output = tmp_path / "iac-results.sarif"
+
+    result = CliRunner().invoke(main, ["iac", str(tmp_path), "-f", "sarif", "-o", str(output), "--quiet"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert data["version"] == "2.1.0"
+    assert data["runs"][0]["tool"]["driver"]["name"] == "agent-bom"
+    assert data["runs"][0]["results"]
+    assert data["runs"][0]["results"][0]["ruleId"].startswith("iac/")
+
+
+def test_sarif_sanitizes_unified_finding_evidence_at_sink() -> None:
+    token = "sk-" + "live-" + "1234567890" + "abcdef"
+    report = AIBOMReport(
+        findings=[
+            Finding(
+                finding_type=FindingType.SAST,
+                source=FindingSource.SAST,
+                asset=Asset(name="app", asset_type="source", location="/Users/alice/prod-secrets/app.py"),
+                severity="high",
+                title="Unsafe credential flow",
+                evidence={
+                    "api_key": token,
+                    "path": "/Users/alice/prod-secrets/app.py",
+                    "url": "https://alice:secret@example.com/hook?token=secret",
+                },
+                remediation_guidance=f"Rotate {token}",
+            )
+        ]
+    )
+
+    encoded = json.dumps(to_sarif(report), sort_keys=True)
+
+    assert token not in encoded
+    assert "/Users/alice/prod-secrets" not in encoded
+    assert "alice:secret" not in encoded
+    assert "***REDACTED***" in encoded
+    assert "<path:app.py>" in encoded


### PR DESCRIPTION
Summary

- replace PR self-scan fixture SARIF with a real `agent-bom scan --self-scan` SARIF gate for current dependencies
- keep Code Scanning placeholder categories intact so existing check/category setup does not drift
- fail fast when the reusable action is asked to use unsupported SARIF upload or vulnerability gates for focused `secrets`/`code` modes
- fix focused IaC output so `-f sarif -o <path>` writes valid SARIF instead of JSON to a `.sarif` path
- defensively sanitize unified finding evidence and IaC evidence/resource properties at the SARIF sink

Why

Journey #2 found that AppSec PR users could see stale or invalid SARIF behavior: the PR gate uploaded fixture results instead of current dependency findings, the action implied SARIF/gate support for focused modes that do not produce SARIF, and focused IaC could write JSON to a SARIF path. This makes the PR gate honest and keeps the trust boundary enforced at the export sink.

Validation

- `uv run pytest tests/test_pr_gate_sarif_action_contract.py tests/test_ai_enrich.py tests/test_self_scan.py tests/test_iac_dockerfile.py -q` -> 130 passed
- `uv run ruff check src/agent_bom/cli/_focused_commands.py src/agent_bom/cli/agents/_preflight.py src/agent_bom/output/sarif.py tests/test_pr_gate_sarif_action_contract.py`
- `uv run mypy src/agent_bom/cli/_focused_commands.py src/agent_bom/cli/agents/_preflight.py src/agent_bom/output/sarif.py`
- YAML parse check for `action.yml` and `.github/workflows/pr-security-gate.yml`
- `git diff --check`

Refs #2085
