### PR TITLE
feat: expose discovery provider contracts

### DIFF
--- a/src/agent_bom/api/routes/discovery.py
+++ b/src/agent_bom/api/routes/discovery.py
@@ -394,6 +394,15 @@ async def list_agents(request: Request) -> dict:
         raise HTTPException(status_code=500, detail=sanitize_error(exc)) from exc
 
 
+@router.get("/v1/discovery/providers", tags=["discovery"])
+async def list_discovery_providers() -> dict:
+    """Return registered discovery provider capability and trust contracts."""
+
+    from agent_bom.cloud import provider_contracts
+
+    return provider_contracts()
+
+
 @router.get("/v1/agents/{agent_name}", tags=["discovery"])
 async def get_agent_detail(request: Request, agent_name: str) -> dict:
     """Get detailed view of a single agent with cross-referenced scan data."""

--- a/src/agent_bom/cloud/__init__.py
+++ b/src/agent_bom/cloud/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import importlib
 from typing import Any
 
-from agent_bom.extensions import ExtensionCapabilities, iter_entry_point_registrations
+from agent_bom.extensions import ExtensionCapabilities, entrypoint_extensions_enabled, iter_entry_point_registrations
 from agent_bom.models import Agent
 
 from .base import CloudDiscoveryError, CloudProviderRegistration
@@ -42,8 +42,9 @@ _PROVIDER_REGISTRY_LOADED = False
 
 
 def _provider_capabilities(name: str) -> ExtensionCapabilities:
+    scan_modes = ("runtime_probe",) if name == "ollama" else ("direct_cloud_pull",)
     return ExtensionCapabilities(
-        scan_modes=("inventory",),
+        scan_modes=scan_modes,
         required_scopes=(f"{name}:read",),
         outbound_destinations=(name,),
         data_boundary="agentless_read_only",
@@ -124,6 +125,60 @@ def provider_registry_warnings() -> list[str]:
     return list(_PROVIDER_REGISTRY_WARNINGS)
 
 
+def _capabilities_payload(capabilities: ExtensionCapabilities) -> dict[str, Any]:
+    return {
+        "scan_modes": list(capabilities.scan_modes),
+        "required_scopes": list(capabilities.required_scopes),
+        "outbound_destinations": list(capabilities.outbound_destinations),
+        # Alias for operator-facing API consumers. Keep the extension field name
+        # above for SDK compatibility, but expose this wording in the contract.
+        "network_destinations": list(capabilities.outbound_destinations),
+        "data_boundary": capabilities.data_boundary,
+        "writes": capabilities.writes,
+        "network_access": capabilities.network_access,
+        "guarantees": list(capabilities.guarantees),
+    }
+
+
+def _trust_contract_payload(capabilities: ExtensionCapabilities) -> dict[str, Any]:
+    guarantees = set(capabilities.guarantees)
+    scan_modes = set(capabilities.scan_modes)
+    return {
+        "read_only": not capabilities.writes and "read_only" in guarantees,
+        "agentless": "agentless_read_only" in capabilities.data_boundary,
+        "entrypoints_opt_in": True,
+        "redaction_status": "central_sanitizer_applied",
+        "scope_control": "operator_supplied_scopes",
+        "data_residency": "operator_environment",
+        "supports_scope_zero": bool({"operator_pushed_inventory", "skill_invoked_pull"} & scan_modes),
+    }
+
+
+def provider_contracts() -> dict[str, Any]:
+    """Return provider capability contracts without importing provider SDK modules."""
+
+    providers: list[dict[str, Any]] = []
+    for registration in list_registered_providers():
+        capabilities = registration.capabilities
+        providers.append(
+            {
+                "name": registration.name,
+                "module": registration.module,
+                "source": registration.source,
+                "discover_attr": registration.discover_attr,
+                "capabilities": _capabilities_payload(capabilities),
+                "trust_contract": _trust_contract_payload(capabilities),
+            }
+        )
+    return {
+        "contract_version": "1",
+        "entrypoints_enabled": entrypoint_extensions_enabled(),
+        "provider_count": len(providers),
+        "providers": providers,
+        "warnings": provider_registry_warnings(),
+    }
+
+
 def _reset_provider_registry_for_tests() -> None:
     _PROVIDER_REGISTRY.clear()
     _PROVIDER_REGISTRY_WARNINGS.clear()
@@ -198,6 +253,7 @@ __all__ = [
     "discover_activity",
     "list_registered_providers",
     "provider_registry_warnings",
+    "provider_contracts",
     "register_provider",
     "builtin_provider_registrations",
 ]

--- a/tests/test_discovery_provider_contract.py
+++ b/tests/test_discovery_provider_contract.py
@@ -1,0 +1,86 @@
+"""Discovery provider contract API coverage."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import app
+from agent_bom.extensions import ENTRYPOINTS_ENABLED_ENV, ExtensionCapabilities
+
+
+@pytest.fixture(autouse=True)
+def reset_provider_registry(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    import agent_bom.cloud as cloud_registry
+
+    monkeypatch.delenv(ENTRYPOINTS_ENABLED_ENV, raising=False)
+    cloud_registry._reset_provider_registry_for_tests()
+    yield
+    monkeypatch.delenv(ENTRYPOINTS_ENABLED_ENV, raising=False)
+    cloud_registry._reset_provider_registry_for_tests()
+    cloud_registry.list_registered_providers()
+
+
+def test_provider_contracts_describe_builtin_boundaries_without_loading_sdks() -> None:
+    from agent_bom.cloud import provider_contracts
+
+    payload = provider_contracts()
+    providers = {provider["name"]: provider for provider in payload["providers"]}
+
+    assert payload["contract_version"] == "1"
+    assert payload["entrypoints_enabled"] is False
+    assert payload["provider_count"] >= 12
+    assert "aws" in providers
+    assert providers["aws"]["module"] == "agent_bom.cloud.aws"
+    assert providers["aws"]["capabilities"]["scan_modes"] == ["direct_cloud_pull"]
+    assert providers["aws"]["capabilities"]["required_scopes"] == ["aws:read"]
+    assert providers["aws"]["capabilities"]["network_destinations"] == ["aws"]
+    assert providers["aws"]["capabilities"]["writes"] is False
+    assert providers["aws"]["trust_contract"]["read_only"] is True
+    assert providers["aws"]["trust_contract"]["redaction_status"] == "central_sanitizer_applied"
+    assert providers["ollama"]["capabilities"]["scan_modes"] == ["runtime_probe"]
+    assert providers["ollama"]["capabilities"]["network_access"] is False
+
+
+def test_provider_contracts_preserve_scope_zero_plugin_modes() -> None:
+    import agent_bom.cloud as cloud_registry
+    from agent_bom.cloud.base import CloudProviderRegistration
+
+    cloud_registry.register_provider(
+        CloudProviderRegistration(
+            name="customer-cmdb",
+            module="customer.plugins.cmdb",
+            capabilities=ExtensionCapabilities(
+                scan_modes=("operator_pushed_inventory", "skill_invoked_pull"),
+                required_scopes=("cmdb.inventory.read",),
+                outbound_destinations=(),
+                data_boundary="agentless_read_only",
+                network_access=False,
+                guarantees=("read_only", "schema_validated"),
+            ),
+            source="entry_point",
+        )
+    )
+
+    providers = {provider["name"]: provider for provider in cloud_registry.provider_contracts()["providers"]}
+
+    assert providers["customer-cmdb"]["capabilities"]["scan_modes"] == ["operator_pushed_inventory", "skill_invoked_pull"]
+    assert providers["customer-cmdb"]["trust_contract"]["supports_scope_zero"] is True
+    assert providers["customer-cmdb"]["trust_contract"]["data_residency"] == "operator_environment"
+
+
+def test_discovery_provider_contract_api_response_is_operator_readable() -> None:
+    client = TestClient(app)
+
+    response = client.get("/v1/discovery/providers")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["entrypoints_enabled"] is False
+    assert payload["warnings"] == []
+    aws = next(provider for provider in payload["providers"] if provider["name"] == "aws")
+    assert aws["capabilities"]["data_boundary"] == "agentless_read_only"
+    assert aws["trust_contract"]["scope_control"] == "operator_supplied_scopes"
+    assert "aws:read" in aws["capabilities"]["required_scopes"]


### PR DESCRIPTION
Summary

- expose registered cloud discovery provider capability and trust contracts at /v1/discovery/providers
- serialize scan modes, scopes, network destinations, write/network behavior, guarantees, and registry warnings without importing provider SDKs
- distinguish direct cloud pull from local runtime probe and preserve scope-zero plugin modes for operator-pushed inventory / skill-invoked pull

Why

This is the first visibility/discovery slice after the entry-point registry work. Operators and auditors can now inspect what each discovery provider is allowed to do, what scopes it expects, what destinations it can reach, and which trust boundaries apply before running discovery.

Validation

- uv run pytest tests/test_discovery_provider_contract.py tests/test_entrypoint_registries.py tests/test_api_agent_detail.py -q
- uv run ruff check src/agent_bom/cloud/__init__.py src/agent_bom/api/routes/discovery.py tests/test_discovery_provider_contract.py
- uv run mypy src/agent_bom/cloud/__init__.py src/agent_bom/api/routes/discovery.py
- git diff --check

Refs #2077
Refs #794
Refs #795