### PR TITLE
fix: report enrichment pipeline timing honestly

### DIFF
--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -159,7 +159,7 @@ class ScanPipeline:
         self,
         step_id: str,
         message: str,
-        stats: dict[str, int] | None = None,
+        stats: dict[str, Any] | None = None,
         progress_pct: int | None = None,
     ) -> None:
         """Update a running step with new message/stats."""
@@ -171,7 +171,7 @@ class ScanPipeline:
             event["progress_pct"] = progress_pct
         self._emit(event)
 
-    def complete_step(self, step_id: str, message: str, stats: dict[str, int] | None = None) -> None:
+    def complete_step(self, step_id: str, message: str, stats: dict[str, Any] | None = None) -> None:
         """Mark a step as done."""
         event = self._steps[step_id]
         event["status"] = StepStatus.DONE
@@ -559,7 +559,12 @@ def _run_scan_sync(job: ScanJob) -> None:
         pipeline.complete_step("extraction", f"Extracted {total_pkgs} packages", {"packages": total_pkgs})
 
         # ── Scanning phase ──
-        pipeline.start_step("scanning", f"Scanning {total_pkgs} packages via OSV.dev...")
+        scan_message = (
+            f"Scanning {total_pkgs} packages via OSV.dev with vulnerability enrichment..."
+            if req.enrich
+            else f"Scanning {total_pkgs} packages via OSV.dev..."
+        )
+        pipeline.start_step("scanning", scan_message)
         try:
             blast_radii = scan_agents_sync(agents, enable_enrichment=req.enrich, offline=False)
         except Exception as scan_exc:  # noqa: BLE001
@@ -598,9 +603,14 @@ def _run_scan_sync(job: ScanJob) -> None:
 
         # ── Enrichment phase ──
         if req.enrich:
-            pipeline.start_step("enrichment", "Enriching with NVD CVSS, EPSS, CISA KEV...")
-            # Enrichment happens inside scan_agents_sync, so just mark done
-            pipeline.complete_step("enrichment", "Enrichment complete")
+            # Enrichment is executed inside scan_agents_sync, alongside the
+            # vulnerability query. Emit a terminal event only so SSE timing does
+            # not claim a separate enrichment phase ran after scanning.
+            pipeline.complete_step(
+                "enrichment",
+                "Enrichment completed during scanning",
+                {"executed_in_step": "scanning"},
+            )
         else:
             pipeline.skip_step("enrichment", "Enrichment not requested")
 

--- a/tests/test_api_pipeline_image_contract.py
+++ b/tests/test_api_pipeline_image_contract.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.pipeline import _run_scan_sync
 from agent_bom.models import BlastRadius, Package, Severity, Vulnerability
@@ -188,3 +190,42 @@ def test_api_pipeline_persists_unified_graph_snapshot(monkeypatch):
 
     assert job.status == JobStatus.DONE
     assert persisted == [("tenant-blue", "graph-123")]
+
+
+def test_api_pipeline_reports_enrichment_as_part_of_scanning(monkeypatch):
+    store = _DummyStore()
+    job = ScanJob(
+        job_id="enrich-123",
+        tenant_id="tenant-blue",
+        created_at="2026-03-25T12:00:00Z",
+        request=ScanRequest(images=["agentbom/agent-bom:latest"], enrich=True),
+    )
+
+    monkeypatch.setattr("agent_bom.api.pipeline._get_store", lambda: store)
+    monkeypatch.setattr("agent_bom.api.pipeline._sync_scan_agents_to_fleet", lambda _agents, tenant_id="default": None)
+    monkeypatch.setattr("agent_bom.api.pipeline._persist_graph_snapshot", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("agent_bom.discovery.discover_all", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        "agent_bom.image.scan_image",
+        lambda image_ref: ([Package(name="openssl", version="3.0.16", ecosystem="deb")], "native"),
+    )
+
+    def _fake_scan(agents, enable_enrichment=False, **kwargs):
+        assert enable_enrichment is True
+        assert kwargs.get("offline") is False
+        return []
+
+    monkeypatch.setattr("agent_bom.scanners.scan_agents_sync", _fake_scan)
+
+    _run_scan_sync(job)
+
+    events = [json.loads(line) for line in job.progress if line.startswith("{")]
+    enrichment_events = [event for event in events if event["step_id"] == "enrichment"]
+    scanning_events = [event for event in events if event["step_id"] == "scanning"]
+
+    assert job.status == JobStatus.DONE
+    assert not any(event["status"] == "running" for event in enrichment_events)
+    assert enrichment_events[-1]["status"] == "done"
+    assert enrichment_events[-1]["message"] == "Enrichment completed during scanning"
+    assert enrichment_events[-1]["stats"]["executed_in_step"] == "scanning"
+    assert any("with vulnerability enrichment" in event["message"] for event in scanning_events)


### PR DESCRIPTION
Summary

- stop emitting a fake running enrichment phase after scanning has already completed
- make the scanning step message explicit when vulnerability enrichment is enabled
- emit enrichment as a terminal event with stats pointing back to the scanning step

Why

The API scan pipeline already performs vulnerability enrichment inside scan_agents_sync during the scanning phase. The SSE pipeline previously started and completed a separate enrichment step afterward, which made operator timing and progress views misleading. This keeps the six-step contract but makes the event stream honest.

Validation

- uv run pytest tests/test_api_pipeline_image_contract.py tests/test_api_pipeline_events.py -q
- uv run ruff check src/agent_bom/api/pipeline.py tests/test_api_pipeline_image_contract.py tests/test_api_pipeline_events.py
- uv run mypy src/agent_bom/api/pipeline.py
- git diff --check