### PR TITLE
ci: harden stranded PR retrigger

### DIFF
--- a/.github/workflows/auto-retrigger-stranded.yml
+++ b/.github/workflows/auto-retrigger-stranded.yml
@@ -9,9 +9,10 @@ name: Auto-Retrigger Stranded PRs
 # zero check-runs on the current head and stays mergeable_state=blocked
 # forever. Background: docs/operations/CI_RUNBOOK.md.
 #
-# This workflow polls every 5 minutes (or on demand), finds PRs whose
-# current head SHA has no check-runs, and runs scripts/retrigger_stranded_pr.sh
-# (close + reopen) which fires the pull_request workflows from scratch.
+# This workflow polls regularly (or on demand), finds PRs whose current head
+# SHA is missing or has a stale required check, and runs
+# scripts/retrigger_stranded_pr.sh (close + reopen) which fires the
+# pull_request workflows from scratch.
 #
 # Triggered from a workflow (not GITHUB_TOKEN's push), the close/reopen
 # events are properly recorded and our pull_request hooks fire on the
@@ -19,8 +20,20 @@ name: Auto-Retrigger Stranded PRs
 
 on:
   schedule:
-    - cron: "*/5 * * * *"   # every 5 minutes
+    # GitHub-hosted schedules are best-effort and can be delayed during busy
+    # windows. Odd-minute slots avoid the most contended top-of-hour queue.
+    - cron: "3,18,33,48 * * * *"
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Optional PR number to retrigger immediately"
+        required: false
+        type: string
+      min_age_minutes:
+        description: "Minimum PR age before scheduled scans retrigger"
+        required: false
+        default: "6"
+        type: string
 
 permissions:
   contents: read
@@ -45,13 +58,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REQUIRED_CHECK: "Lint and Type Check"
-          # Skip PRs younger than this — give pull_request workflows a
-          # chance to start before we declare them stranded. The retrigger
-          # script also no-ops when the required check is already present,
-          # but skipping young PRs keeps the workflow log readable.
-          MIN_AGE_MINUTES: "10"
+          MIN_AGE_MINUTES: ${{ inputs.min_age_minutes || '6' }}
+          PR_NUMBER: ${{ inputs.pr_number || '' }}
         run: |
           set -euo pipefail
+          if [ -n "${PR_NUMBER}" ]; then
+            echo "Manual retrigger requested for PR #${PR_NUMBER}."
+            scripts/retrigger_stranded_pr.sh "${PR_NUMBER}"
+            exit 0
+          fi
+
           echo "Listing open PRs…"
           mapfile -t PRS < <(
             gh pr list \
@@ -62,7 +78,7 @@ jobs:
           )
 
           NOW_EPOCH="$(date -u +%s)"
-          STRANDED=0
+          CHECKED=0
           RETRIGGERED=0
 
           for line in "${PRS[@]}"; do
@@ -74,19 +90,7 @@ jobs:
               continue
             fi
 
-            HITS="$(
-              gh api "repos/${{ github.repository }}/commits/${SHA}/check-runs" \
-                --jq "[.check_runs[] | select(.name == \"${REQUIRED_CHECK}\")] | length"
-            )"
-
-            if [ "$HITS" -gt 0 ]; then
-              echo "PR #${PR}: ${HITS} '${REQUIRED_CHECK}' run(s) on head ${SHA:0:8} — healthy."
-              continue
-            fi
-
-            STRANDED=$(( STRANDED + 1 ))
-            echo "PR #${PR}: 0 '${REQUIRED_CHECK}' runs on head ${SHA:0:8} — stranded."
-
+            CHECKED=$(( CHECKED + 1 ))
             if [ -x scripts/retrigger_stranded_pr.sh ]; then
               if scripts/retrigger_stranded_pr.sh "$PR"; then
                 RETRIGGERED=$(( RETRIGGERED + 1 ))
@@ -99,4 +103,4 @@ jobs:
           done
 
           echo
-          echo "Summary: ${STRANDED} stranded PR(s), ${RETRIGGERED} retriggered."
+          echo "Summary: ${CHECKED} eligible PR(s) checked, ${RETRIGGERED} retrigger command(s) completed."

--- a/scripts/retrigger_stranded_pr.sh
+++ b/scripts/retrigger_stranded_pr.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 # Retrigger required CI on a PR whose head SHA was advanced by a
 # GITHUB_TOKEN-authored push (auto-merge "Update branch", merge bots).
-# Such pushes do not fire `pull_request` workflows, so the PR sits in
-# `mergeable_state: blocked` with zero check runs on the current head.
+# Such pushes do not fire `pull_request` workflows, so the PR can sit in
+# `mergeable_state: blocked` with missing or cancelled required checks on
+# the current head.
 #
 # This script:
 #   1. Reads the PR's current head SHA.
-#   2. Checks whether the canonical required check ("Lint and Type Check")
-#      has run against that SHA.
-#   3. If not, closes + reopens the PR — the `reopened` action fires
-#      `pull_request` workflows again from scratch.
+#   2. Checks whether the canonical required check ("Lint and Type Check") is
+#      attached to that SHA and is either pending/running/successful.
+#   3. If missing or terminally stale, closes + reopens the PR — the
+#      `reopened` action fires `pull_request` workflows again from scratch.
 #
 # Usage:
 #   scripts/retrigger_stranded_pr.sh <PR_NUMBER>
@@ -33,18 +34,44 @@ if [ -z "${HEAD_SHA}" ]; then
   exit 1
 fi
 
-CHECK_HITS="$(
+CHECK_STATE="$(
   gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
-    --jq "[.check_runs[] | select(.name == \"${REQUIRED_CHECK}\")] | length"
+    --jq "[
+      .check_runs[]
+      | select(.name == \"${REQUIRED_CHECK}\")
+      | {status, conclusion}
+    ]"
 )"
 
-if [ "${CHECK_HITS}" -gt 0 ]; then
-  echo "PR #${PR}: head ${HEAD_SHA} already has '${REQUIRED_CHECK}' (count=${CHECK_HITS}). No retrigger needed."
+CHECK_HITS="$(jq 'length' <<< "${CHECK_STATE}")"
+ACTIVE_HITS="$(jq '[.[] | select(.status != "completed")] | length' <<< "${CHECK_STATE}")"
+SUCCESS_HITS="$(jq '[.[] | select(.conclusion == "success")] | length' <<< "${CHECK_STATE}")"
+STALE_HITS="$(jq '[.[] | select(.conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "startup_failure" or .conclusion == "stale" or .conclusion == "skipped")] | length' <<< "${CHECK_STATE}")"
+FAILED_HITS="$(jq '[.[] | select(.conclusion == "failure")] | length' <<< "${CHECK_STATE}")"
+
+if [ "${ACTIVE_HITS}" -gt 0 ]; then
+  echo "PR #${PR}: '${REQUIRED_CHECK}' is already active on head ${HEAD_SHA}. No retrigger needed."
   exit 0
 fi
 
-echo "PR #${PR}: head ${HEAD_SHA} has 0 '${REQUIRED_CHECK}' runs. Closing + reopening to retrigger required workflows."
-gh pr close "${PR}" --comment "auto-retrigger: required CI did not fire on head ${HEAD_SHA} (likely a GITHUB_TOKEN-authored 'Update branch' merge). Reopening to re-run checks."
+if [ "${SUCCESS_HITS}" -gt 0 ]; then
+  echo "PR #${PR}: head ${HEAD_SHA} already has successful '${REQUIRED_CHECK}'. No retrigger needed."
+  exit 0
+fi
+
+if [ "${FAILED_HITS}" -gt 0 ] && [ "${STALE_HITS}" -eq 0 ]; then
+  echo "PR #${PR}: '${REQUIRED_CHECK}' failed on head ${HEAD_SHA}. Not retriggering a real failure."
+  exit 0
+fi
+
+if [ "${CHECK_HITS}" -eq 0 ]; then
+  reason="required CI did not attach"
+else
+  reason="required CI is terminally stale (${STALE_HITS}/${CHECK_HITS} stale runs)"
+fi
+
+echo "PR #${PR}: ${reason} for '${REQUIRED_CHECK}' on head ${HEAD_SHA}. Closing + reopening to retrigger required workflows."
+gh pr close "${PR}" --comment "auto-retrigger: ${reason} for '${REQUIRED_CHECK}' on head ${HEAD_SHA} (likely a GITHUB_TOKEN-authored 'Update branch' merge or cancelled required context). Reopening to re-run checks."
 
 # `gh pr close` returns before GitHub has propagated the state change to
 # the PR resource. Reopening too soon races: the reopen API call lands


### PR DESCRIPTION
Summary

- treat missing, cancelled, timed-out, startup-failed, stale, or skipped required check runs as stranded instead of only checking whether a run exists
- leave real failed required checks alone so actual CI failures are not hidden by close/reopen churn
- add a manual workflow_dispatch PR-number path for the stranded-PR healer
- move the scheduled poll to odd-minute slots and reduce the age gate so it is more useful during active PR work

Why

GitHub-token-authored update-branch merges can leave PRs blocked when pull_request workflows do not attach to the new head SHA. The repo already had a healer, but it only detected zero check runs and the scheduled runs are best-effort. This makes the mitigation more precise and easier to invoke without changing the main CI jobs.

Validation

- scripts/retrigger_stranded_pr.sh 2088
- python YAML parse for .github/workflows/auto-retrigger-stranded.yml
- bash -n scripts/retrigger_stranded_pr.sh
- git diff --check
