### PR TITLE
feat: expose discovery permissions used

### DIFF
--- a/src/agent_bom/cloud/__init__.py
+++ b/src/agent_bom/cloud/__init__.py
@@ -40,12 +40,64 @@ _PROVIDER_REGISTRY: dict[str, CloudProviderRegistration] = {}
 _PROVIDER_REGISTRY_WARNINGS: list[str] = []
 _PROVIDER_REGISTRY_LOADED = False
 
+_PROVIDER_PERMISSIONS_USED: dict[str, tuple[str, ...]] = {
+    "aws": (
+        "sts:GetCallerIdentity",
+        "bedrock:GetAgent",
+        "bedrock:ListAgentActionGroups",
+        "bedrock:ListAgents",
+        "ec2:DescribeInstances",
+        "ecs:DescribeServices",
+        "ecs:DescribeTaskDefinition",
+        "ecs:ListClusters",
+        "ecs:ListServices",
+        "eks:DescribeCluster",
+        "eks:ListClusters",
+        "lambda:GetFunctionConfiguration",
+        "lambda:GetLayerVersion",
+        "lambda:ListFunctions",
+        "sagemaker:DescribeEndpoint",
+        "sagemaker:DescribeEndpointConfig",
+        "sagemaker:ListEndpoints",
+        "states:DescribeStateMachine",
+        "states:ListStateMachines",
+    ),
+    "azure": (
+        "Microsoft.CognitiveServices/accounts/read",
+        "Microsoft.ContainerService/managedClusters/read",
+        "Microsoft.MachineLearningServices/workspaces/onlineEndpoints/read",
+        "Microsoft.Resources/subscriptions/resourceGroups/read",
+        "Microsoft.Web/sites/read",
+    ),
+    "gcp": (
+        "aiplatform.endpoints.list",
+        "aiplatform.models.list",
+        "container.clusters.list",
+        "run.services.list",
+        "storage.buckets.list",
+    ),
+    "coreweave": ("coreweave:read",),
+    "databricks": (
+        "databricks:clusters:read",
+        "databricks:model-serving:read",
+        "databricks:workspace:read",
+    ),
+    "huggingface": ("huggingface:models:read", "huggingface:spaces:read"),
+    "mlflow": ("mlflow:experiments:read", "mlflow:models:read", "mlflow:runs:read"),
+    "nebius": ("nebius:read",),
+    "ollama": (),
+    "openai": ("openai:assistants:read", "openai:models:read", "openai:responses:read"),
+    "snowflake": ("snowflake:show:read", "snowflake:account_usage:read"),
+    "wandb": ("wandb:artifacts:read", "wandb:runs:read"),
+}
+
 
 def _provider_capabilities(name: str) -> ExtensionCapabilities:
     scan_modes = ("runtime_probe",) if name == "ollama" else ("direct_cloud_pull",)
     return ExtensionCapabilities(
         scan_modes=scan_modes,
         required_scopes=(f"{name}:read",),
+        permissions_used=_PROVIDER_PERMISSIONS_USED.get(name, (f"{name}:read",)),
         outbound_destinations=(name,),
         data_boundary="agentless_read_only",
         network_access=name != "ollama",
@@ -129,6 +181,7 @@ def _capabilities_payload(capabilities: ExtensionCapabilities) -> dict[str, Any]
     return {
         "scan_modes": list(capabilities.scan_modes),
         "required_scopes": list(capabilities.required_scopes),
+        "permissions_used": list(capabilities.permissions_used),
         "outbound_destinations": list(capabilities.outbound_destinations),
         # Alias for operator-facing API consumers. Keep the extension field name
         # above for SDK compatibility, but expose this wording in the contract.

--- a/src/agent_bom/extensions.py
+++ b/src/agent_bom/extensions.py
@@ -19,6 +19,7 @@ class ExtensionCapabilities:
 
     scan_modes: tuple[str, ...] = ("inventory",)
     required_scopes: tuple[str, ...] = ()
+    permissions_used: tuple[str, ...] = ()
     outbound_destinations: tuple[str, ...] = ()
     data_boundary: str = "agentless_read_only"
     writes: bool = False

--- a/tests/test_discovery_provider_contract.py
+++ b/tests/test_discovery_provider_contract.py
@@ -36,6 +36,8 @@ def test_provider_contracts_describe_builtin_boundaries_without_loading_sdks() -
     assert providers["aws"]["module"] == "agent_bom.cloud.aws"
     assert providers["aws"]["capabilities"]["scan_modes"] == ["direct_cloud_pull"]
     assert providers["aws"]["capabilities"]["required_scopes"] == ["aws:read"]
+    assert "sts:GetCallerIdentity" in providers["aws"]["capabilities"]["permissions_used"]
+    assert "bedrock:ListAgents" in providers["aws"]["capabilities"]["permissions_used"]
     assert providers["aws"]["capabilities"]["network_destinations"] == ["aws"]
     assert providers["aws"]["capabilities"]["writes"] is False
     assert providers["aws"]["trust_contract"]["read_only"] is True
@@ -55,6 +57,7 @@ def test_provider_contracts_preserve_scope_zero_plugin_modes() -> None:
             capabilities=ExtensionCapabilities(
                 scan_modes=("operator_pushed_inventory", "skill_invoked_pull"),
                 required_scopes=("cmdb.inventory.read",),
+                permissions_used=("cmdb.assets.read",),
                 outbound_destinations=(),
                 data_boundary="agentless_read_only",
                 network_access=False,
@@ -67,6 +70,7 @@ def test_provider_contracts_preserve_scope_zero_plugin_modes() -> None:
     providers = {provider["name"]: provider for provider in cloud_registry.provider_contracts()["providers"]}
 
     assert providers["customer-cmdb"]["capabilities"]["scan_modes"] == ["operator_pushed_inventory", "skill_invoked_pull"]
+    assert providers["customer-cmdb"]["capabilities"]["permissions_used"] == ["cmdb.assets.read"]
     assert providers["customer-cmdb"]["trust_contract"]["supports_scope_zero"] is True
     assert providers["customer-cmdb"]["trust_contract"]["data_residency"] == "operator_environment"
 
@@ -84,3 +88,4 @@ def test_discovery_provider_contract_api_response_is_operator_readable() -> None
     assert aws["capabilities"]["data_boundary"] == "agentless_read_only"
     assert aws["trust_contract"]["scope_control"] == "operator_supplied_scopes"
     assert "aws:read" in aws["capabilities"]["required_scopes"]
+    assert all(":" in permission for permission in aws["capabilities"]["permissions_used"])


### PR DESCRIPTION
Summary

- add `permissions_used` to extension capability declarations
- publish built-in provider permission manifests through `/v1/discovery/providers`
- keep plugin/entry-point provider contracts compatible while allowing external providers to declare their own read permissions
- add regression coverage for built-in, API, and plugin provider contract output

Why

Teams evaluating direct cloud pull need an operator-readable least-privilege contract: what scan mode is used, what network destinations are contacted, and what read permissions the provider expects to exercise. This keeps the trust story concrete without changing ingestion behavior, persistence, credentials, or scan execution.

Validation

- uv run pytest tests/test_discovery_provider_contract.py tests/test_entrypoint_registries.py tests/test_data_boundaries.py tests/test_control_plane_contracts.py -q
- uv run ruff check src/agent_bom/extensions.py src/agent_bom/cloud/__init__.py tests/test_discovery_provider_contract.py
- uv run mypy src/agent_bom/extensions.py src/agent_bom/cloud/__init__.py
- git diff --check origin/main...HEAD

Refs #2089
