### PR TITLE
feat: preserve asset discovery provenance

### DIFF
--- a/config/schemas/inventory.schema.json
+++ b/config/schemas/inventory.schema.json
@@ -6,6 +6,46 @@
 
   "$defs": {
 
+    "DiscoveryProvenance": {
+      "title": "Discovery Provenance",
+      "description": "Low-risk provenance for how an asset was observed. Values are sanitized before persistence/export.",
+      "type": "object",
+      "required": ["source_type"],
+      "properties": {
+        "source_type": {
+          "type": "string",
+          "enum": [
+            "direct_cloud_pull",
+            "operator_pushed_inventory",
+            "skill_invoked_pull",
+            "local_discovery",
+            "registry_fallback",
+            "sbom_ingest",
+            "external_scan",
+            "filesystem_scan",
+            "image_scan",
+            "unknown"
+          ]
+        },
+        "observed_via": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "source": { "type": "string" },
+        "collector": { "type": "string" },
+        "provider": { "type": "string" },
+        "service": { "type": "string" },
+        "resource_type": { "type": "string" },
+        "resource_id": { "type": "string" },
+        "resource_name": { "type": "string" },
+        "location": { "type": "string" },
+        "confidence": { "type": "string" },
+        "resolved_from_registry": { "type": "boolean" },
+        "version_source": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+
     "Tool": {
       "title": "MCP Tool",
       "description": "A tool exposed by an MCP server. Needed for blast radius: maps a vulnerability to the attacker capabilities it unlocks.",
@@ -69,6 +109,10 @@
             "purl": {
               "type": "string",
               "description": "Package URL (purl) for unambiguous identification. If provided, overrides name/version/ecosystem for scanning."
+            },
+            "discovery_provenance": {
+              "$ref": "#/$defs/DiscoveryProvenance",
+              "description": "How this package was observed or resolved."
             }
           },
           "additionalProperties": false
@@ -156,6 +200,11 @@
           "type": "array",
           "items": { "$ref": "#/$defs/SecurityIntelligenceEntry" },
           "description": "Structured MCP intelligence matches that explain block/review/warn decisions."
+        },
+
+        "discovery_provenance": {
+          "$ref": "#/$defs/DiscoveryProvenance",
+          "description": "How this server definition was observed."
         }
       },
       "additionalProperties": false
@@ -250,6 +299,11 @@
           "type": "array",
           "items": { "$ref": "#/$defs/MCPServer" },
           "description": "MCP servers this agent connects to. Each server's packages are scanned independently, then correlated back to this agent for blast radius."
+        },
+
+        "discovery_provenance": {
+          "$ref": "#/$defs/DiscoveryProvenance",
+          "description": "How this agent asset was observed."
         }
       },
       "additionalProperties": false
@@ -276,6 +330,11 @@
       "type": "string",
       "format": "date-time",
       "description": "ISO 8601 timestamp when this inventory was generated"
+    },
+
+    "discovery_provenance": {
+      "$ref": "#/$defs/DiscoveryProvenance",
+      "description": "Default provenance for assets in this inventory."
     },
 
     "agents": {

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -22,15 +22,7 @@ from typing import Any
 from agent_bom import __version__
 from agent_bom.api.models import JobStatus, ScanJob, StepStatus
 from agent_bom.api.stores import _get_analytics_store, _get_fleet_store, _get_graph_store, _get_store, _job_lock
-from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
-from agent_bom.security import (
-    sanitize_command_args,
-    sanitize_env_vars,
-    sanitize_error,
-    sanitize_security_warnings,
-    sanitize_text,
-    sanitize_url,
-)
+from agent_bom.security import sanitize_error
 
 _logger = logging.getLogger(__name__)
 
@@ -319,44 +311,14 @@ def _run_scan_sync(job: ScanJob) -> None:
 
         if req.inventory:
             pipeline.update_step("discovery", f"Loading inventory: {req.inventory}")
-            import json as _json
-
-            from agent_bom.models import Agent, AgentType, MCPServer, TransportType
+            from agent_bom.cli._common import _build_agents_from_inventory
+            from agent_bom.inventory import load_inventory
 
             try:
-                with open(req.inventory) as _f:
-                    inv_data = _json.load(_f)
-            except (_json.JSONDecodeError, OSError) as parse_err:
+                inv_data = load_inventory(req.inventory)
+            except (OSError, RuntimeError, ValueError) as parse_err:
                 raise RuntimeError(f"Failed to load inventory file: {parse_err}") from parse_err
-            for agent_data in inv_data.get("agents", []):
-                servers = []
-                for s in agent_data.get("mcp_servers", []):
-                    servers.append(
-                        MCPServer(
-                            name=s.get("name", "unknown"),
-                            command=sanitize_text(s.get("command", ""), max_len=200),
-                            args=sanitize_command_args(list(s.get("args", []) or [])),
-                            env=sanitize_env_vars(dict(s.get("env", {}) or {})),
-                            transport=TransportType(s.get("transport", "stdio")),
-                            url=sanitize_url(str(s.get("url") or "")) if s.get("url") else None,
-                            config_path=s.get("config_path"),
-                            security_blocked=bool(s.get("security_blocked", False)),
-                            security_warnings=sanitize_security_warnings(list(s.get("security_warnings", []) or [])),
-                            security_intelligence=[
-                                sanitize_security_intelligence_entry(item)
-                                for item in (s.get("security_intelligence", []) or [])
-                                if isinstance(item, dict)
-                            ],
-                        )
-                    )
-                agents.append(
-                    Agent(
-                        name=agent_data.get("name", "unknown"),
-                        agent_type=AgentType.CUSTOM,
-                        config_path=req.inventory,
-                        mcp_servers=servers,
-                    )
-                )
+            agents.extend(_build_agents_from_inventory(inv_data, req.inventory))
 
         for image_ref in req.images:
             pipeline.update_step("discovery", f"Scanning image: {image_ref}")

--- a/src/agent_bom/api/routes/discovery.py
+++ b/src/agent_bom/api/routes/discovery.py
@@ -18,6 +18,7 @@ from fastapi import APIRouter, HTTPException, Request
 from agent_bom.api.mcp_observation_store import MCPObservation, merge_observations
 from agent_bom.api.models import JobStatus
 from agent_bom.api.stores import _get_fleet_store, _get_mcp_observation_store, _get_store
+from agent_bom.asset_provenance import agent_discovery_provenance, package_discovery_provenance
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.security import (
     sanitize_command_args,
@@ -165,6 +166,8 @@ def _serialize_agent(
     observation_index: dict[str, MCPObservation] | None = None,
 ) -> dict:
     payload = asdict(agent)
+    agent_provenance = agent_discovery_provenance(agent)
+    payload["discovery_provenance"] = agent_provenance
     payload["mcp_servers"] = []
     for server in agent.mcp_servers:
         server_payload = asdict(server)
@@ -195,6 +198,12 @@ def _serialize_agent(
         server_payload.setdefault("config_path", getattr(server, "config_path", None))
         server_payload["security_warnings"] = sanitize_security_warnings(list(getattr(server, "security_warnings", []) or []))
         server_payload["security_intelligence"] = _merge_security_intelligence(list(getattr(server, "security_intelligence", []) or []))
+        for idx, package in enumerate(getattr(server, "packages", []) or []):
+            if idx < len(server_payload.get("packages", []) or []):
+                server_payload["packages"][idx]["discovery_provenance"] = package_discovery_provenance(
+                    package,
+                    inherited=agent_provenance,
+                )
         observation_id, legacy_observation_id = _observation_ids(agent, server)
         stored_observation = (observation_index or {}).get(observation_id)
         if stored_observation is None and legacy_observation_id:
@@ -619,6 +628,7 @@ async def get_agent_lifecycle(request: Request, agent_name: str) -> dict:
                             "version": pkg.get("version", ""),
                             "ecosystem": pkg.get("ecosystem", ""),
                             "vuln_count": len(vulns),
+                            "discovery_provenance": pkg.get("discovery_provenance"),
                         },
                     }
                 )

--- a/src/agent_bom/asset_provenance.py
+++ b/src/agent_bom/asset_provenance.py
@@ -1,0 +1,214 @@
+"""Sanitized discovery provenance for canonical assets."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field, is_dataclass
+from typing import Any
+
+from agent_bom.security import sanitize_log_label
+
+DISCOVERY_SOURCE_TYPES = frozenset(
+    {
+        "direct_cloud_pull",
+        "operator_pushed_inventory",
+        "skill_invoked_pull",
+        "local_discovery",
+        "registry_fallback",
+        "sbom_ingest",
+        "external_scan",
+        "filesystem_scan",
+        "image_scan",
+        "unknown",
+    }
+)
+
+_STRING_FIELDS = (
+    "source",
+    "collector",
+    "provider",
+    "service",
+    "resource_type",
+    "resource_id",
+    "resource_name",
+    "location",
+    "confidence",
+    "version_source",
+)
+_SENSITIVE_VALUE_RE = re.compile(r"(token|password|secret|api[_-]?key|credential|bearer|jwt)[^\s]*\s*[:=]", re.IGNORECASE)
+_URL_USERINFO_RE = re.compile(r"://[^/\s:@]+:[^@/\s]+@")
+
+
+@dataclass
+class DiscoveryProvenance:
+    """Low-risk discovery provenance contract shared by Agent/Package assets."""
+
+    source_type: str
+    observed_via: list[str] = field(default_factory=list)
+    source: str | None = None
+    collector: str | None = None
+    provider: str | None = None
+    service: str | None = None
+    resource_type: str | None = None
+    resource_id: str | None = None
+    resource_name: str | None = None
+    location: str | None = None
+    confidence: str | None = None
+    resolved_from_registry: bool | None = None
+    version_source: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return sanitize_discovery_provenance(self) or {}
+
+
+def sanitize_discovery_provenance(value: Any, defaults: dict[str, Any] | None = None) -> dict[str, Any] | None:
+    """Return a bounded, JSON-safe provenance payload.
+
+    Explicit values override defaults, but all fields pass through the same
+    allowlist and string redaction before leaving the model layer.
+    """
+    raw: dict[str, Any] = {}
+    if defaults:
+        raw.update(defaults)
+    raw.update(_coerce_mapping(value))
+    if not raw:
+        return None
+
+    source_type = _sanitize_string(raw.get("source_type") or raw.get("type") or "unknown", max_len=64)
+    if source_type not in DISCOVERY_SOURCE_TYPES:
+        source_type = "unknown"
+
+    result: dict[str, Any] = {"source_type": source_type}
+    observed_via = _sanitize_string_list(raw.get("observed_via") or raw.get("sources") or [])
+    if observed_via:
+        result["observed_via"] = observed_via
+
+    for field_name in _STRING_FIELDS:
+        value = _sanitize_string(raw.get(field_name))
+        if value:
+            result[field_name] = value
+
+    for field_name in ("resolved_from_registry",):
+        if raw.get(field_name) is not None:
+            result[field_name] = bool(raw.get(field_name))
+
+    return {key: val for key, val in result.items() if val not in (None, "", [])}
+
+
+def agent_discovery_provenance(agent: Any) -> dict[str, Any] | None:
+    """Build sanitized Agent discovery provenance from explicit or inferred data."""
+    metadata = getattr(agent, "metadata", {}) or {}
+    if not isinstance(metadata, dict):
+        metadata = {}
+    explicit = getattr(agent, "discovery_provenance", None) or metadata.get("discovery_provenance")
+    source = getattr(agent, "source", None)
+    cloud_origin = metadata.get("cloud_origin")
+    defaults: dict[str, Any]
+    if isinstance(cloud_origin, dict):
+        defaults = {
+            "source_type": "direct_cloud_pull",
+            "observed_via": ["cloud_pull"],
+            "source": source,
+            "provider": cloud_origin.get("provider"),
+            "service": cloud_origin.get("service"),
+            "resource_type": cloud_origin.get("resource_type"),
+            "resource_id": cloud_origin.get("resource_id"),
+            "resource_name": cloud_origin.get("resource_name"),
+            "location": cloud_origin.get("location"),
+            "confidence": "high",
+        }
+    else:
+        source_text = str(source or "").lower()
+        if "skill" in source_text:
+            source_type = "skill_invoked_pull"
+            observed_via = ["skill_invoked_pull"]
+        elif source_text and any(token in source_text for token in ("inventory", "cmdb", "fleet")):
+            source_type = "operator_pushed_inventory"
+            observed_via = ["operator_inventory"]
+        else:
+            source_type = "local_discovery"
+            observed_via = ["local_discovery"]
+        defaults = {
+            "source_type": source_type,
+            "observed_via": observed_via,
+            "source": source,
+            "confidence": "medium" if source_type == "local_discovery" else "high",
+        }
+    return sanitize_discovery_provenance(explicit, defaults=defaults)
+
+
+def package_discovery_provenance(package: Any, inherited: dict[str, Any] | None = None) -> dict[str, Any] | None:
+    """Build sanitized Package discovery provenance from explicit/current fields."""
+    explicit = getattr(package, "discovery_provenance", None)
+    inherited = sanitize_discovery_provenance(inherited) or {}
+    defaults: dict[str, Any] = {
+        key: inherited[key]
+        for key in ("source_type", "observed_via", "source", "provider", "service", "location", "confidence")
+        if key in inherited
+    }
+    version_source = getattr(package, "version_source", None)
+    resolved_from_registry = bool(getattr(package, "resolved_from_registry", False))
+    if version_source == "registry_fallback":
+        defaults.update(
+            {
+                "source_type": "registry_fallback",
+                "observed_via": _merge_observed_via(defaults.get("observed_via"), ["registry_fallback"]),
+                "source": "bundled_registry",
+                "resolved_from_registry": True,
+                "version_source": version_source,
+                "confidence": "medium",
+            }
+        )
+    elif resolved_from_registry or version_source:
+        defaults.update(
+            {
+                "resolved_from_registry": resolved_from_registry,
+                "version_source": version_source,
+            }
+        )
+    return sanitize_discovery_provenance(explicit, defaults=defaults)
+
+
+def _coerce_mapping(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, DiscoveryProvenance):
+        return asdict(value)
+    if is_dataclass(value) and not isinstance(value, type):
+        return asdict(value)
+    if isinstance(value, dict):
+        return dict(value)
+    return {}
+
+
+def _sanitize_string(value: Any, *, max_len: int = 256) -> str:
+    if value is None or isinstance(value, (dict, list, tuple, set)):
+        return ""
+    text = sanitize_log_label(value, max_len=max_len)
+    if not text:
+        return ""
+    if _SENSITIVE_VALUE_RE.search(text) or _URL_USERINFO_RE.search(text):
+        return "<redacted>"
+    return text
+
+
+def _sanitize_string_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        values = [value]
+    elif isinstance(value, (list, tuple, set)):
+        values = list(value)
+    else:
+        values = []
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in values:
+        safe = _sanitize_string(item, max_len=96)
+        if safe and safe not in seen:
+            seen.add(safe)
+            result.append(safe)
+    return result[:10]
+
+
+def _merge_observed_via(existing: Any, extra: list[str]) -> list[str]:
+    return _sanitize_string_list([*_sanitize_string_list(existing), *extra])

--- a/src/agent_bom/cli/_common.py
+++ b/src/agent_bom/cli/_common.py
@@ -61,11 +61,29 @@ def _sync_runtime_consoles(console: Console) -> None:
 
 def _build_agents_from_inventory(inventory_data: dict, source_path: str) -> list:
     """Build Agent objects from parsed inventory dict (JSON or CSV)."""
+    from agent_bom.asset_provenance import sanitize_discovery_provenance
     from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
     agents = []
+    inventory_provenance = sanitize_discovery_provenance(
+        inventory_data.get("discovery_provenance"),
+        defaults={
+            "source_type": "operator_pushed_inventory",
+            "observed_via": ["operator_inventory"],
+            "source": inventory_data.get("source"),
+            "collector": "inventory",
+            "confidence": "high",
+        },
+    )
     for agent_data in inventory_data.get("agents", []):
         mcp_servers = []
+        agent_provenance = sanitize_discovery_provenance(
+            agent_data.get("discovery_provenance"),
+            defaults={
+                **(inventory_provenance or {}),
+                "source": agent_data.get("source", inventory_data.get("source")),
+            },
+        )
         for server_data in agent_data.get("mcp_servers", []):
             # Parse pre-populated tools (e.g. from Snowflake/cloud inventory)
             tools = []
@@ -83,13 +101,24 @@ def _build_agents_from_inventory(inventory_data: dict, source_path: str) -> list
 
             # Parse pre-known packages (e.g. from cloud asset scan)
             packages = []
+            package_provenance = sanitize_discovery_provenance(
+                server_data.get("discovery_provenance"),
+                defaults=agent_provenance,
+            )
             for pkg_data in server_data.get("packages", []):
                 if isinstance(pkg_data, str):
                     if "@" in pkg_data:
                         name, version = pkg_data.rsplit("@", 1)
                     else:
                         name, version = pkg_data, "unknown"
-                    packages.append(Package(name=name, version=version, ecosystem="unknown"))
+                    packages.append(
+                        Package(
+                            name=name,
+                            version=version,
+                            ecosystem="unknown",
+                            discovery_provenance=package_provenance,
+                        )
+                    )
                 elif isinstance(pkg_data, dict):
                     packages.append(
                         Package(
@@ -97,6 +126,10 @@ def _build_agents_from_inventory(inventory_data: dict, source_path: str) -> list
                             version=pkg_data.get("version", "unknown"),
                             ecosystem=pkg_data.get("ecosystem", "unknown"),
                             purl=pkg_data.get("purl"),
+                            discovery_provenance=sanitize_discovery_provenance(
+                                pkg_data.get("discovery_provenance"),
+                                defaults=package_provenance,
+                            ),
                         )
                     )
 
@@ -113,6 +146,7 @@ def _build_agents_from_inventory(inventory_data: dict, source_path: str) -> list
                 security_blocked=bool(server_data.get("security_blocked", False)),
                 security_warnings=list(server_data.get("security_warnings", []) or []),
                 security_intelligence=list(server_data.get("security_intelligence", []) or []),
+                discovery_provenance=package_provenance,
                 tools=tools,
                 packages=packages,
             )
@@ -127,6 +161,7 @@ def _build_agents_from_inventory(inventory_data: dict, source_path: str) -> list
             source=agent_data.get("source", inventory_data.get("source")),
             discovered_at=agent_data.get("discovered_at") or agent_data.get("first_seen") or "",
             last_seen=agent_data.get("last_seen") or agent_data.get("last_seen_at"),
+            discovery_provenance=agent_provenance,
         )
         agents.append(agent)
 

--- a/src/agent_bom/cli/agents/_discovery.py
+++ b/src/agent_bom/cli/agents/_discovery.py
@@ -744,11 +744,24 @@ def run_local_discovery(
                 if skill_result.servers:
                     from agent_bom.models import Agent, AgentType
 
+                    skill_provenance = {
+                        "source_type": "skill_invoked_pull",
+                        "observed_via": ["skill_invoked_pull"],
+                        "source": "skill-files",
+                        "collector": "skill_scanner",
+                        "confidence": "high",
+                    }
+                    for server in skill_result.servers:
+                        for pkg in getattr(server, "packages", []) or []:
+                            if getattr(pkg, "discovery_provenance", None) is None:
+                                pkg.discovery_provenance = skill_provenance
                     skill_agent = Agent(
                         name="skill-files",
                         agent_type=AgentType.CUSTOM,
                         config_path=str(skill_file_list[0]),
                         mcp_servers=skill_result.servers,
+                        source="skill-files",
+                        discovery_provenance=skill_provenance,
                     )
                     ctx.agents.append(skill_agent)
                     con.print(f"  [green]✓[/green] Found {len(skill_result.servers)} MCP server(s) in skill files")
@@ -756,12 +769,24 @@ def run_local_discovery(
                     from agent_bom.models import Agent, AgentType
                     from agent_bom.models import MCPServer as _SkillSrv
 
+                    skill_provenance = {
+                        "source_type": "skill_invoked_pull",
+                        "observed_via": ["skill_invoked_pull"],
+                        "source": "skill-files",
+                        "collector": "skill_scanner",
+                        "confidence": "high",
+                    }
+                    for pkg in skill_result.packages:
+                        if getattr(pkg, "discovery_provenance", None) is None:
+                            pkg.discovery_provenance = skill_provenance
                     skill_server = _SkillSrv(name="skill-packages", command="(from skill files)", packages=skill_result.packages)
                     skill_pkg_agent = Agent(
                         name="skill-packages",
                         agent_type=AgentType.CUSTOM,
                         config_path=", ".join(str(p) for p in skill_file_list[:3]),
                         mcp_servers=[skill_server],
+                        source="skill-files",
+                        discovery_provenance=skill_provenance,
                     )
                     ctx.agents.append(skill_pkg_agent)
                     con.print(f"  [green]✓[/green] Found {len(skill_result.packages)} package(s) referenced in skill files")

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -334,6 +334,8 @@ def blast_radius_to_finding(br: object) -> "Finding":
     if not isinstance(br, BlastRadius):
         raise TypeError(f"Expected BlastRadius, got {type(br)}")
 
+    from agent_bom.asset_provenance import package_discovery_provenance
+
     vuln = br.vulnerability
     pkg = br.package
 
@@ -380,6 +382,9 @@ def blast_radius_to_finding(br: object) -> "Finding":
         "graph_reachable_from_agents": _sanitized_evidence_field(getattr(br, "graph_reachable_from_agents", [])),
         "layer_attribution": _sanitized_evidence_field([_package_occurrence_evidence(occ) for occ in br.layer_attribution]),
     }
+    package_provenance = package_discovery_provenance(pkg)
+    if package_provenance:
+        evidence["package_discovery_provenance"] = package_provenance
     if vuln.references:
         evidence["references"] = _sanitized_evidence_field(vuln.references[:5])
 

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -13,6 +13,7 @@ from pathlib import PurePath
 from typing import Any
 
 from agent_bom.api.tracing import get_tracer
+from agent_bom.asset_provenance import sanitize_discovery_provenance
 from agent_bom.graph.container import UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import NodeDimensions, UnifiedNode
@@ -82,6 +83,7 @@ def build_unified_graph_from_report(
         agent_metadata = agent_dict.get("metadata", {})
         if not isinstance(agent_metadata, dict):
             agent_metadata = {}
+        agent_discovery_provenance = sanitize_discovery_provenance(agent_dict.get("discovery_provenance"))
 
         graph.add_node(
             UnifiedNode(
@@ -109,6 +111,7 @@ def build_unified_graph_from_report(
                     "discovered_at": agent_dict.get("discovered_at"),
                     "last_seen": agent_dict.get("last_seen"),
                     "server_count": len(agent_dict.get("mcp_servers", [])),
+                    "discovery_provenance": agent_discovery_provenance,
                     "cloud_origin": agent_metadata.get("cloud_origin"),
                     "cloud_state": agent_metadata.get("cloud_state"),
                     "cloud_scope": agent_metadata.get("cloud_scope"),
@@ -189,6 +192,7 @@ def build_unified_graph_from_report(
                 ecosystem = pkg_dict.get("ecosystem", "")
                 pkg_id = _package_node_id(pkg_dict)
                 package_evidence = _package_evidence(pkg_dict, data_source_tag)
+                package_discovery_provenance = sanitize_discovery_provenance(pkg_dict.get("discovery_provenance"))
 
                 graph.add_node(
                     UnifiedNode(
@@ -206,6 +210,7 @@ def build_unified_graph_from_report(
                             "scorecard_score": pkg_dict.get("scorecard_score"),
                             "is_malicious": pkg_dict.get("is_malicious", False),
                             "stable_id": pkg_dict.get("stable_id", ""),
+                            "discovery_provenance": package_discovery_provenance,
                         },
                         dimensions=NodeDimensions(ecosystem=ecosystem),
                         data_sources=[data_source_tag],
@@ -915,6 +920,7 @@ def _package_evidence(pkg_dict: dict[str, Any], data_source_tag: str) -> dict[st
         "stable_id": pkg_dict.get("stable_id", ""),
         "source_package": pkg_dict.get("source_package", ""),
         "version_source": pkg_dict.get("version_source", ""),
+        "discovery_provenance": sanitize_discovery_provenance(pkg_dict.get("discovery_provenance")),
         "occurrence_count": pkg_dict.get("occurrence_count", len(occurrences)),
         "occurrences": normalized_occurrences,
     }

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -356,6 +356,7 @@ class Package:
     maintainer_count: Optional[int] = None
     source_repo: Optional[str] = None
     occurrences: list[PackageOccurrence] = field(default_factory=list)  # Layer/file provenance for concrete package observations
+    discovery_provenance: Optional[dict] = None  # Sanitized discovery provenance contract for this package asset
 
     @property
     def stable_id(self) -> str:
@@ -579,6 +580,7 @@ class MCPServer:
     security_intelligence: list[dict[str, object]] = field(default_factory=list)
     surface: ServerSurface = ServerSurface.MCP
     discovery_sources: list[str] = field(default_factory=list)
+    discovery_provenance: Optional[dict] = None  # Sanitized discovery provenance contract for this server asset
 
     @property
     def stable_id(self) -> str:
@@ -684,6 +686,7 @@ class Agent:
     parent_agent: Optional[str] = None  # Parent agent name (for spawn tree / delegation)
     metadata: dict = field(default_factory=dict)  # Extra config data (permissions, hooks, etc.)
     automation_settings: list = field(default_factory=list)  # Risky automation settings (scheduled tasks, etc.)
+    discovery_provenance: Optional[dict] = None  # Sanitized discovery provenance contract for this agent asset
 
     def __post_init__(self) -> None:
         """Backfill lifecycle fields for legacy Agent construction paths."""

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from agent_bom.asset_provenance import agent_discovery_provenance, package_discovery_provenance, sanitize_discovery_provenance
 from agent_bom.compliance_utils import effective_blast_radius_tags
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
 from agent_bom.security import sanitize_command_args, sanitize_path_label, sanitize_security_warnings, sanitize_text, sanitize_url
@@ -275,6 +276,7 @@ def _build_inventory_snapshot(report: AIBOMReport) -> dict:
 
     for agent in report.agents:
         server_ids: list[str] = []
+        agent_provenance = agent_discovery_provenance(agent)
         agents.append(
             {
                 "id": agent.stable_id,
@@ -285,6 +287,7 @@ def _build_inventory_snapshot(report: AIBOMReport) -> dict:
                 "discovered_at": agent.discovered_at,
                 "last_seen": agent.last_seen,
                 "config_path": sanitize_path_label(agent.config_path) if agent.config_path else "",
+                "discovery_provenance": agent_provenance,
                 "server_ids": server_ids,
             }
         )
@@ -305,6 +308,10 @@ def _build_inventory_snapshot(report: AIBOMReport) -> dict:
                     "resource_ids": [],
                     "prompt_ids": [],
                     "package_ids": [],
+                    "discovery_provenance": sanitize_discovery_provenance(
+                        getattr(server, "discovery_provenance", None),
+                        defaults=agent_provenance,
+                    ),
                 }
             relationships.append({"from": agent.stable_id, "to": server.stable_id, "type": "uses"})
 
@@ -368,6 +375,7 @@ def _build_inventory_snapshot(report: AIBOMReport) -> dict:
                         "distro_version": pkg.distro_version,
                         "floating_reference": pkg.floating_reference,
                         "floating_reference_reason": pkg.floating_reference_reason,
+                        "discovery_provenance": package_discovery_provenance(pkg, inherited=agent_provenance),
                         "occurrence_count": len(pkg.occurrences),
                         "occurrences": [_package_occurrence_to_dict(occ) for occ in pkg.occurrences],
                         "vulnerability_count": len(pkg.vulnerabilities),
@@ -538,6 +546,7 @@ def to_json(report: AIBOMReport) -> dict:
                 "status": agent.status.value,
                 "discovered_at": agent.discovered_at,
                 "last_seen": agent.last_seen,
+                "discovery_provenance": agent_discovery_provenance(agent),
                 "metadata": agent.metadata,
                 "automation_settings": agent.automation_settings,
                 "mcp_servers": [
@@ -558,6 +567,10 @@ def to_json(report: AIBOMReport) -> dict:
                         "security_warnings": sanitize_security_warnings(server.security_warnings),
                         "security_intelligence": server.security_intelligence,
                         "discovery_sources": server.discovery_sources,
+                        "discovery_provenance": sanitize_discovery_provenance(
+                            server.discovery_provenance,
+                            defaults=agent_discovery_provenance(agent),
+                        ),
                         "tools": [
                             {
                                 "name": t.name,
@@ -619,6 +632,10 @@ def to_json(report: AIBOMReport) -> dict:
                                 "reachability_evidence": pkg.reachability_evidence,
                                 "resolved_from_registry": pkg.resolved_from_registry,
                                 "version_source": pkg.version_source,
+                                "discovery_provenance": package_discovery_provenance(
+                                    pkg,
+                                    inherited=agent_discovery_provenance(agent),
+                                ),
                                 "floating_reference": pkg.floating_reference,
                                 "floating_reference_reason": pkg.floating_reference_reason,
                                 "registry_version": pkg.registry_version,
@@ -732,6 +749,7 @@ def to_json(report: AIBOMReport) -> dict:
                 "introduced_in_layer": (
                     _package_occurrence_to_dict(br.package.primary_occurrence) if br.package.primary_occurrence else None
                 ),
+                "package_discovery_provenance": package_discovery_provenance(br.package),
                 "is_malicious": br.package.is_malicious,
                 "malicious_reason": br.package.malicious_reason,
                 "scorecard_score": br.package.scorecard_score,

--- a/tests/test_asset_discovery_provenance.py
+++ b/tests/test_asset_discovery_provenance.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+from agent_bom.api.pipeline import _run_scan_sync
+from agent_bom.api.routes.discovery import _serialize_agent
+from agent_bom.asset_provenance import sanitize_discovery_provenance
+from agent_bom.finding import blast_radius_to_finding
+from agent_bom.graph import EntityType
+from agent_bom.graph.builder import build_unified_graph_from_report
+from agent_bom.inventory import load_inventory
+from agent_bom.models import Agent, AgentType, AIBOMReport, BlastRadius, MCPServer, Package, Severity, Vulnerability
+from agent_bom.output.json_fmt import to_json
+
+
+def test_discovery_provenance_contract_is_sanitized() -> None:
+    provenance = sanitize_discovery_provenance(
+        {
+            "source_type": "skill_invoked_pull",
+            "observed_via": ["skill:api_key=secret", "skill_invoked_pull", "skill_invoked_pull"],
+            "source": "https://user:pass@example.test/path",
+            "collector": "skill_scanner\nwith-control",
+            "ignored": "not exported",
+        }
+    )
+
+    assert provenance == {
+        "source_type": "skill_invoked_pull",
+        "observed_via": ["<redacted>", "skill_invoked_pull"],
+        "source": "<redacted>",
+        "collector": "skill_scanner with-control",
+    }
+
+
+def test_json_surfaces_infer_and_preserve_asset_discovery_provenance() -> None:
+    registry_pkg = Package(
+        name="mcp-server",
+        version="unknown",
+        ecosystem="npm",
+        resolved_from_registry=True,
+        version_source="registry_fallback",
+    )
+    cloud_agent = Agent(
+        name="bedrock-agent",
+        agent_type=AgentType.CUSTOM,
+        config_path="aws://bedrock/agent-1",
+        source="aws-bedrock",
+        metadata={
+            "cloud_origin": {
+                "provider": "aws",
+                "service": "bedrock",
+                "resource_type": "agent",
+                "resource_id": "arn:aws:bedrock:us-east-1:123:agent/agent-1",
+                "resource_name": "agent-1",
+                "location": "us-east-1",
+            }
+        },
+        mcp_servers=[MCPServer(name="bedrock-runtime", packages=[registry_pkg])],
+    )
+    inventory_agent = _inventory_agent()
+    skill_agent = Agent(
+        name="skill-files",
+        agent_type=AgentType.CUSTOM,
+        config_path="SKILL.md",
+        source="skill-files",
+        mcp_servers=[
+            MCPServer(
+                name="skill-packages",
+                packages=[
+                    Package(
+                        name="langchain",
+                        version="0.1.0",
+                        ecosystem="pypi",
+                        discovery_provenance={"source": "skill:token=secret"},
+                    )
+                ],
+            )
+        ],
+    )
+    local_agent = Agent(
+        name="claude",
+        agent_type=AgentType.CLAUDE_DESKTOP,
+        config_path="/tmp/claude.json",
+        mcp_servers=[MCPServer(name="local-server", packages=[Package(name="express", version="4.18.2", ecosystem="npm")])],
+    )
+    report = AIBOMReport(
+        agents=[cloud_agent, inventory_agent, skill_agent, local_agent],
+        generated_at=datetime(2026, 4, 29, tzinfo=timezone.utc),
+    )
+
+    payload = to_json(report)
+    agents = {agent["name"]: agent for agent in payload["agents"]}
+    assert agents["bedrock-agent"]["discovery_provenance"]["source_type"] == "direct_cloud_pull"
+    assert agents["bedrock-agent"]["discovery_provenance"]["provider"] == "aws"
+    assert agents["inventory-agent"]["discovery_provenance"]["source_type"] == "operator_pushed_inventory"
+    assert agents["skill-files"]["discovery_provenance"]["source_type"] == "skill_invoked_pull"
+    assert agents["claude"]["discovery_provenance"]["source_type"] == "local_discovery"
+
+    registry_provenance = agents["bedrock-agent"]["mcp_servers"][0]["packages"][0]["discovery_provenance"]
+    assert registry_provenance["source_type"] == "registry_fallback"
+    assert registry_provenance["resolved_from_registry"] is True
+    assert registry_provenance["version_source"] == "registry_fallback"
+
+    skill_provenance = agents["skill-files"]["mcp_servers"][0]["packages"][0]["discovery_provenance"]
+    assert skill_provenance["source_type"] == "skill_invoked_pull"
+    assert skill_provenance["source"] == "<redacted>"
+
+    snapshot_pkg = next(pkg for pkg in payload["inventory_snapshot"]["packages"] if pkg["name"] == "mcp-server")
+    assert snapshot_pkg["discovery_provenance"]["source_type"] == "registry_fallback"
+
+
+def test_api_graph_and_finding_surfaces_preserve_sanitized_provenance() -> None:
+    vuln = Vulnerability(id="CVE-2026-0001", summary="test", severity=Severity.HIGH)
+    pkg = Package(
+        name="requests",
+        version="2.0.0",
+        ecosystem="pypi",
+        vulnerabilities=[vuln],
+        discovery_provenance={
+            "source_type": "operator_pushed_inventory",
+            "observed_via": ["operator_inventory"],
+            "source": "inventory:password=secret",
+        },
+    )
+    server = MCPServer(name="inventory-server", packages=[pkg])
+    agent = Agent(
+        name="inventory-agent",
+        agent_type=AgentType.CUSTOM,
+        config_path="/tmp/inventory.json",
+        source="inventory",
+        mcp_servers=[server],
+    )
+
+    api_payload = _serialize_agent(agent)
+    api_provenance = api_payload["mcp_servers"][0]["packages"][0]["discovery_provenance"]
+    assert api_provenance["source_type"] == "operator_pushed_inventory"
+    assert api_provenance["source"] == "<redacted>"
+
+    report_payload = to_json(AIBOMReport(agents=[agent], blast_radii=[_blast_radius(vuln, pkg, server, agent)]))
+    graph = build_unified_graph_from_report(report_payload)
+    package_node = graph.nodes_by_type(EntityType.PACKAGE)[0]
+    assert package_node.attributes["discovery_provenance"]["source"] == "<redacted>"
+    depends_edge = graph.edges_to(package_node.id)[0]
+    assert depends_edge.evidence["discovery_provenance"]["source_type"] == "operator_pushed_inventory"
+
+    finding = blast_radius_to_finding(_blast_radius(vuln, pkg, server, agent))
+    assert finding.evidence["package_discovery_provenance"]["source"] == "<redacted>"
+
+
+def test_inventory_schema_accepts_discovery_provenance(tmp_path) -> None:
+    inventory_path = tmp_path / "inventory.json"
+    inventory_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "source": "customer-cmdb",
+                "discovery_provenance": {
+                    "source_type": "operator_pushed_inventory",
+                    "observed_via": ["operator_inventory"],
+                    "collector": "cmdb-export",
+                },
+                "agents": [
+                    {
+                        "name": "inventory-agent",
+                        "agent_type": "custom",
+                        "discovery_provenance": {
+                            "source_type": "operator_pushed_inventory",
+                            "observed_via": ["operator_inventory"],
+                            "provider": "aws",
+                        },
+                        "mcp_servers": [
+                            {
+                                "name": "inventory-server",
+                                "discovery_provenance": {
+                                    "source_type": "operator_pushed_inventory",
+                                    "observed_via": ["operator_inventory"],
+                                    "service": "bedrock",
+                                },
+                                "packages": [
+                                    {
+                                        "name": "fastapi",
+                                        "version": "0.104.0",
+                                        "ecosystem": "pypi",
+                                        "discovery_provenance": {
+                                            "source_type": "operator_pushed_inventory",
+                                            "observed_via": ["operator_inventory"],
+                                            "version_source": "manifest",
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = load_inventory(str(inventory_path))
+
+    assert payload["discovery_provenance"]["collector"] == "cmdb-export"
+    pkg = payload["agents"][0]["mcp_servers"][0]["packages"][0]
+    assert pkg["discovery_provenance"]["version_source"] == "manifest"
+
+
+def test_api_pipeline_inventory_preserves_packages_and_provenance(monkeypatch, tmp_path) -> None:
+    class _DummyStore:
+        def __init__(self) -> None:
+            self.jobs: list[ScanJob] = []
+
+        def put(self, job: ScanJob) -> None:
+            self.jobs.append(job)
+
+    inventory_path = tmp_path / "inventory.json"
+    inventory_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "source": "customer-cmdb",
+                "agents": [
+                    {
+                        "name": "inventory-agent",
+                        "agent_type": "custom",
+                        "mcp_servers": [
+                            {
+                                "name": "inventory-server",
+                                "packages": [
+                                    {
+                                        "name": "fastapi",
+                                        "version": "0.104.0",
+                                        "ecosystem": "pypi",
+                                        "discovery_provenance": {
+                                            "source_type": "operator_pushed_inventory",
+                                            "observed_via": ["operator_inventory"],
+                                            "source": "cmdb:token=secret",
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    store = _DummyStore()
+    job = ScanJob(
+        job_id="inventory-provenance",
+        created_at="2026-04-29T12:00:00Z",
+        request=ScanRequest(inventory=str(inventory_path), enrich=False),
+    )
+
+    monkeypatch.setattr("agent_bom.api.pipeline._get_store", lambda: store)
+    monkeypatch.setattr("agent_bom.api.pipeline._sync_scan_agents_to_fleet", lambda _agents, tenant_id="default": None)
+    monkeypatch.setattr("agent_bom.discovery.discover_all", lambda *args, **kwargs: [])
+    monkeypatch.setattr("agent_bom.scanners.scan_agents_sync", lambda agents, enable_enrichment=False, **kwargs: [])
+
+    _run_scan_sync(job)
+
+    assert job.status == JobStatus.DONE
+    assert job.result is not None
+    agent = job.result["agents"][0]
+    assert agent["discovery_provenance"]["source_type"] == "operator_pushed_inventory"
+    pkg = agent["mcp_servers"][0]["packages"][0]
+    assert pkg["name"] == "fastapi"
+    assert pkg["discovery_provenance"]["source"] == "<redacted>"
+
+
+def _inventory_agent() -> Agent:
+    from agent_bom.cli._common import _build_agents_from_inventory
+
+    return _build_agents_from_inventory(
+        {
+            "source": "cmdb-inventory",
+            "agents": [
+                {
+                    "name": "inventory-agent",
+                    "agent_type": "custom",
+                    "mcp_servers": [
+                        {
+                            "name": "inventory-server",
+                            "packages": [{"name": "fastapi", "version": "0.104.0", "ecosystem": "pypi"}],
+                        }
+                    ],
+                }
+            ],
+        },
+        "/tmp/inventory.json",
+    )[0]
+
+
+def _blast_radius(vuln: Vulnerability, pkg: Package, server: MCPServer, agent: Agent) -> BlastRadius:
+    return BlastRadius(
+        vulnerability=vuln,
+        package=pkg,
+        affected_servers=[server],
+        affected_agents=[agent],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )


### PR DESCRIPTION
Summary
- add a sanitized discovery_provenance contract for Agent, MCPServer, and Package assets
- accept provenance in inventory.schema.json and preserve it through CLI/API inventory ingestion, JSON output, graph nodes/edge evidence, lifecycle APIs, and vulnerability findings
- infer provenance for direct cloud pull, operator-pushed inventory, local discovery, registry fallback, and skill-invoked discovery without exposing token-like values or URL credentials
- reuse the shared inventory loader in API scans so pushed inventory keeps packages/tools/provenance instead of being reduced to server shells

Why
This closes the visibility/discovery gap where operators could see a finding but not how the asset entered agent-bom. The data now carries source type, collector, provider/service/resource context, version source, and confidence through the canonical model and output surfaces while staying within the redaction boundary.

Validation
- uv run pytest tests/test_asset_discovery_provenance.py tests/test_api_pipeline_image_contract.py tests/test_cli_inventory.py::test_inventory_schema_path_points_to_repo_schema -q
- uv run ruff check src/agent_bom/asset_provenance.py src/agent_bom/api/pipeline.py src/agent_bom/api/routes/discovery.py src/agent_bom/cli/_common.py src/agent_bom/cli/agents/_discovery.py src/agent_bom/finding.py src/agent_bom/graph/builder.py src/agent_bom/models.py src/agent_bom/output/json_fmt.py tests/test_asset_discovery_provenance.py
- uv run mypy src/agent_bom/asset_provenance.py src/agent_bom/api/pipeline.py src/agent_bom/api/routes/discovery.py src/agent_bom/cli/_common.py src/agent_bom/cli/agents/_discovery.py src/agent_bom/finding.py src/agent_bom/graph/builder.py src/agent_bom/models.py src/agent_bom/output/json_fmt.py
- python -m json.tool config/schemas/inventory.schema.json >/tmp/inventory-schema.json.checked
- git diff --check

Refs #2092
