### PR TITLE
feat: add AWS operator pull inventory adapter

### DIFF
--- a/config/schemas/inventory.schema.json
+++ b/config/schemas/inventory.schema.json
@@ -234,6 +234,12 @@
           "description": "Where this inventory entry came from (e.g. 'local', 'snowflake', 'aws-bedrock', 'gcp-vertex', 'openai'). Used for traceability in reports."
         },
 
+        "metadata": {
+          "type": "object",
+          "description": "Sanitized provider-specific metadata such as cloud_origin, cloud_state, cloud_scope, cloud_principal, and permissions_used. Credential values must be redacted before submission.",
+          "additionalProperties": true
+        },
+
         "discovered_at": {
           "type": "string",
           "format": "date-time",

--- a/examples/operator_pull/README.md
+++ b/examples/operator_pull/README.md
@@ -1,0 +1,21 @@
+# AWS Operator-Pull Inventory Adapter
+
+This reference adapter runs in the operator's environment with the operator's
+own ephemeral or tightly scoped AWS credentials. It emits canonical
+`agent-bom` inventory JSON locally, so a later `agent-bom` scan can run from a
+file without receiving raw cloud credentials.
+
+```bash
+python examples/operator_pull/aws_inventory_adapter.py \
+  --region us-east-1 \
+  --include-lambda \
+  --include-eks \
+  --output aws-inventory.json
+
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE
+agent-bom agents --inventory aws-inventory.json --format json
+```
+
+The adapter keeps useful scan context such as package PURLs, cloud metadata,
+and declared AWS read permissions, while recursively redacting sensitive
+metadata and environment values before writing the inventory file.

--- a/examples/operator_pull/aws_inventory_adapter.py
+++ b/examples/operator_pull/aws_inventory_adapter.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Emit canonical agent-bom inventory from AWS inside the operator boundary.
+
+This adapter is meant for customer-controlled CI or automation. It uses the
+standard AWS credential chain in that environment, writes canonical inventory
+JSON to stdout or a chosen file, and never sends cloud credentials to agent-bom.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from agent_bom.cloud import provider_contracts
+from agent_bom.cloud.aws import discover
+from agent_bom.inventory import _validate_inventory_payload
+from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
+from agent_bom.models import Agent, MCPServer, MCPTool, Package
+from agent_bom.security import (
+    sanitize_command_args,
+    sanitize_env_vars,
+    sanitize_security_warnings,
+    sanitize_sensitive_payload,
+    sanitize_text,
+    sanitize_url,
+)
+
+_SCHEMA_AGENT_TYPES = frozenset({"claude-desktop", "claude-code", "cursor", "windsurf", "cline", "custom"})
+_SCHEMA_TRANSPORTS = frozenset({"stdio", "sse", "streamable-http"})
+_SCHEMA_ECOSYSTEMS = frozenset({"npm", "pypi", "go", "cargo", "maven", "nuget", "hex", "pub", "unknown"})
+
+
+def build_inventory(
+    agents: list[Agent],
+    *,
+    source: str = "aws-operator-pull",
+    generated_at: str | None = None,
+    permissions_used: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build an inventory.schema.json-compatible payload from AWS agents."""
+    permissions = permissions_used if permissions_used is not None else _aws_permissions_used()
+    payload = {
+        "schema_version": "1",
+        "source": source,
+        "generated_at": generated_at or datetime.now(timezone.utc).isoformat(),
+        "agents": [_agent_to_inventory(agent, permissions_used=permissions) for agent in agents],
+    }
+    return _validate_inventory_payload(payload)
+
+
+def _aws_permissions_used() -> list[str]:
+    try:
+        providers = provider_contracts().get("providers", [])
+    except Exception:  # noqa: BLE001
+        return []
+    aws_provider = next((provider for provider in providers if provider.get("name") == "aws"), {})
+    capabilities = aws_provider.get("capabilities", {})
+    permissions = capabilities.get("permissions_used", [])
+    if not isinstance(permissions, list):
+        return []
+    return [str(permission) for permission in permissions]
+
+
+def _agent_to_inventory(agent: Agent, *, permissions_used: list[str]) -> dict[str, Any]:
+    metadata = _metadata_with_permissions(agent.metadata, permissions_used)
+    agent_type = getattr(agent.agent_type, "value", str(agent.agent_type))
+    if agent_type not in _SCHEMA_AGENT_TYPES:
+        agent_type = "custom"
+    payload: dict[str, Any] = {
+        "name": sanitize_text(agent.name, max_len=300),
+        "agent_type": agent_type,
+        "config_path": sanitize_text(agent.config_path, max_len=1000) if agent.config_path else "",
+        "source": sanitize_text(agent.source or "aws-operator-pull", max_len=200),
+        "mcp_servers": [_server_to_inventory(server) for server in agent.mcp_servers],
+    }
+    if agent.version:
+        payload["version"] = sanitize_text(agent.version, max_len=100)
+    if metadata:
+        payload["metadata"] = metadata
+    if agent.discovered_at:
+        payload["discovered_at"] = agent.discovered_at
+    if agent.last_seen:
+        payload["last_seen"] = agent.last_seen
+    return payload
+
+
+def _metadata_with_permissions(metadata: dict[str, Any], permissions_used: list[str]) -> dict[str, Any]:
+    sanitized = sanitize_sensitive_payload(metadata or {})
+    if not isinstance(sanitized, dict):
+        sanitized = {}
+    if permissions_used:
+        sanitized["permissions_used"] = sorted(set(permissions_used))
+    return sanitized
+
+
+def _server_to_inventory(server: MCPServer) -> dict[str, Any]:
+    transport = getattr(server.transport, "value", str(server.transport or "stdio"))
+    if transport not in _SCHEMA_TRANSPORTS:
+        transport = "stdio"
+    payload: dict[str, Any] = {
+        "name": sanitize_text(server.name, max_len=300),
+        "command": sanitize_text(server.command, max_len=300),
+        "args": sanitize_command_args(list(server.args or [])),
+        "transport": transport,
+        "env": sanitize_env_vars(dict(server.env or {})),
+        "tools": [_tool_to_inventory(tool) for tool in server.tools],
+        "packages": [_package_to_inventory(package) for package in server.packages],
+        "security_blocked": bool(getattr(server, "security_blocked", False)),
+        "security_warnings": sanitize_security_warnings(list(getattr(server, "security_warnings", []) or [])),
+        "security_intelligence": [
+            sanitize_security_intelligence_entry(item)
+            for item in (getattr(server, "security_intelligence", []) or [])
+            if isinstance(item, dict)
+        ],
+    }
+    if server.url:
+        payload["url"] = sanitize_url(str(server.url))
+    if server.mcp_version:
+        payload["mcp_version"] = sanitize_text(server.mcp_version, max_len=80)
+    if server.working_dir:
+        payload["working_dir"] = sanitize_text(server.working_dir, max_len=1000)
+    if server.config_path:
+        payload["config_path"] = sanitize_text(server.config_path, max_len=1000)
+    return {key: value for key, value in payload.items() if value not in (None, "", [], {})}
+
+
+def _tool_to_inventory(tool: MCPTool) -> dict[str, Any]:
+    payload: dict[str, Any] = {"name": sanitize_text(tool.name, max_len=300)}
+    if tool.description:
+        payload["description"] = sanitize_text(tool.description, max_len=1000)
+    if tool.input_schema:
+        sanitized_schema = sanitize_sensitive_payload(tool.input_schema)
+        if isinstance(sanitized_schema, dict):
+            payload["input_schema"] = sanitized_schema
+    return payload
+
+
+def _package_to_inventory(package: Package) -> dict[str, Any]:
+    payload = {
+        "name": sanitize_text(package.name, max_len=300),
+        "version": sanitize_text(package.version or "unknown", max_len=120) or "unknown",
+    }
+    ecosystem = sanitize_text(package.ecosystem or "unknown", max_len=60) or "unknown"
+    if ecosystem in _SCHEMA_ECOSYSTEMS:
+        payload["ecosystem"] = ecosystem
+    if package.purl:
+        payload["purl"] = sanitize_text(package.purl, max_len=500)
+    return payload
+
+
+def _parse_key_value(items: list[str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for item in items:
+        if "=" not in item:
+            raise SystemExit(f"Expected KEY=VALUE, got: {item}")
+        key, value = item.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise SystemExit(f"Expected non-empty key in: {item}")
+        result[key] = value.strip()
+    return result
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Emit AWS discovery as canonical agent-bom inventory JSON.")
+    parser.add_argument("--region", help="AWS region to scan. Defaults to the active AWS SDK region.")
+    parser.add_argument("--profile", help="AWS profile name. Uses the default credential chain when omitted.")
+    parser.add_argument("--output", "-o", default="-", help="Output path, or '-' for stdout.")
+    parser.add_argument("--compact", action="store_true", help="Emit compact JSON.")
+    parser.add_argument("--include-ecs", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--include-sagemaker", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument("--include-lambda", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument("--include-eks", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument("--include-step-functions", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument("--include-ec2", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument("--ec2-tag", action="append", default=[], metavar="KEY=VALUE", help="Optional EC2 tag filter. Repeatable.")
+    parser.add_argument("--tag", action="append", default=[], metavar="KEY=VALUE", help="Optional provider tag filter. Repeatable.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    agents, warnings = discover(
+        region=args.region,
+        profile=args.profile,
+        include_ecs=args.include_ecs,
+        include_sagemaker=args.include_sagemaker,
+        include_lambda=args.include_lambda,
+        include_eks=args.include_eks,
+        include_step_functions=args.include_step_functions,
+        include_ec2=args.include_ec2,
+        ec2_tag_filter=_parse_key_value(args.ec2_tag),
+        tag_filter=_parse_key_value(args.tag),
+    )
+    for warning in sanitize_security_warnings(warnings):
+        sys.stderr.write(f"warning: {warning}\n")
+
+    payload = build_inventory(agents)
+    text = json.dumps(payload, indent=None if args.compact else 2, sort_keys=True) + "\n"
+    if args.output == "-":
+        sys.stdout.write(text)
+    else:
+        Path(args.output).write_text(text, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent_bom/cli/_common.py
+++ b/src/agent_bom/cli/_common.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from rich.console import Console
 
 from agent_bom import __version__
-from agent_bom.security import sanitize_env_vars
+from agent_bom.security import sanitize_env_vars, sanitize_sensitive_payload
 
 logger = logging.getLogger(__name__)
 
@@ -118,6 +118,11 @@ def _build_agents_from_inventory(inventory_data: dict, source_path: str) -> list
             )
             mcp_servers.append(server)
 
+        sanitized_metadata = {}
+        if isinstance(agent_data.get("metadata"), dict):
+            metadata_payload = sanitize_sensitive_payload(agent_data.get("metadata", {}))
+            sanitized_metadata = metadata_payload if isinstance(metadata_payload, dict) else {}
+
         agent = Agent(
             name=agent_data.get("name", "unknown"),
             agent_type=AgentType(agent_data.get("agent_type", agent_data.get("type", "custom"))),
@@ -125,6 +130,7 @@ def _build_agents_from_inventory(inventory_data: dict, source_path: str) -> list
             mcp_servers=mcp_servers,
             version=agent_data.get("version"),
             source=agent_data.get("source", inventory_data.get("source")),
+            metadata=sanitized_metadata,
             discovered_at=agent_data.get("discovered_at") or agent_data.get("first_seen") or "",
             last_seen=agent_data.get("last_seen") or agent_data.get("last_seen_at"),
         )

--- a/tests/test_operator_pull_aws_adapter.py
+++ b/tests/test_operator_pull_aws_adapter.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+from agent_bom.cli._common import _build_agents_from_inventory
+from agent_bom.inventory import load_inventory
+from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
+
+ADAPTER_PATH = Path(__file__).resolve().parents[1] / "examples" / "operator_pull" / "aws_inventory_adapter.py"
+
+
+def _load_adapter():
+    spec = importlib.util.spec_from_file_location("aws_inventory_adapter", ADAPTER_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_aws_operator_pull_adapter_emits_valid_sanitized_inventory(tmp_path: Path) -> None:
+    adapter = _load_adapter()
+    agent = Agent(
+        name="bedrock-agent",
+        agent_type=AgentType.CUSTOM,
+        config_path="arn:aws:bedrock:us-east-1:123456789012:agent/AGENT123",
+        source="aws-bedrock",
+        metadata={
+            "cloud_origin": {
+                "provider": "aws",
+                "service": "bedrock",
+                "resource_type": "agent",
+                "resource_id": "arn:aws:bedrock:us-east-1:123456789012:agent/AGENT123",
+                "scope": {"account_id": "123456789012", "api_token": "should-not-survive"},
+            },
+            "cloud_principal": {"principal_arn": "arn:aws:sts::123456789012:assumed-role/ReadOnly/session"},
+        },
+        mcp_servers=[
+            MCPServer(
+                name="bedrock-runtime",
+                command="npx",
+                args=["-y", "@modelcontextprotocol/server-fetch@1.0.0", "--api-key", "secret-value"],
+                env={"AWS_SESSION_TOKEN": "raw-token"},
+                transport=TransportType.STDIO,
+                packages=[
+                    Package(
+                        name="@modelcontextprotocol/server-fetch",
+                        version="1.0.0",
+                        ecosystem="npm",
+                        purl="pkg:npm/%40modelcontextprotocol/server-fetch@1.0.0",
+                    )
+                ],
+            )
+        ],
+    )
+
+    payload = adapter.build_inventory(
+        [agent],
+        generated_at="2026-04-29T12:00:00+00:00",
+        permissions_used=["sts:GetCallerIdentity", "bedrock:ListAgents"],
+    )
+    output_path = tmp_path / "aws-inventory.json"
+    output_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = load_inventory(str(output_path))
+    rebuilt_agents = _build_agents_from_inventory(loaded, str(output_path))
+
+    assert loaded["schema_version"] == "1"
+    assert loaded["agents"][0]["metadata"]["cloud_origin"]["scope"]["api_token"] == "***REDACTED***"
+    assert loaded["agents"][0]["metadata"]["permissions_used"] == ["bedrock:ListAgents", "sts:GetCallerIdentity"]
+    assert loaded["agents"][0]["mcp_servers"][0]["env"]["AWS_SESSION_TOKEN"] == "***REDACTED***"
+    assert "secret-value" not in json.dumps(loaded)
+    assert rebuilt_agents[0].metadata["cloud_origin"]["provider"] == "aws"
+    assert rebuilt_agents[0].metadata["permissions_used"] == ["bedrock:ListAgents", "sts:GetCallerIdentity"]
+
+
+def test_aws_operator_pull_adapter_cli_writes_inventory(monkeypatch, tmp_path: Path) -> None:
+    adapter = _load_adapter()
+    monkeypatch.setattr(
+        adapter,
+        "discover",
+        lambda **_kwargs: (
+            [Agent(name="aws-empty", agent_type=AgentType.CUSTOM, config_path="aws://empty", source="aws", mcp_servers=[])],
+            ["Access denied for token=secret"],
+        ),
+    )
+    output_path = tmp_path / "inventory.json"
+
+    assert adapter.main(["--region", "us-east-1", "--no-include-ecs", "--output", str(output_path)]) == 0
+
+    loaded = load_inventory(str(output_path))
+    assert loaded["agents"][0]["name"] == "aws-empty"
+
+
+def test_aws_operator_pull_adapter_keeps_container_purl_schema_valid() -> None:
+    adapter = _load_adapter()
+    package = Package(
+        name="123456789012.dkr.ecr.us-east-1.amazonaws.com/model-api",
+        version="2026-04",
+        ecosystem="container-image",
+        purl="pkg:docker/123456789012.dkr.ecr.us-east-1.amazonaws.com/model-api@2026-04",
+    )
+
+    payload = adapter._package_to_inventory(package)
+
+    assert payload == {
+        "name": "123456789012.dkr.ecr.us-east-1.amazonaws.com/model-api",
+        "version": "2026-04",
+        "purl": "pkg:docker/123456789012.dkr.ecr.us-east-1.amazonaws.com/model-api@2026-04",
+    }
+
+
+def test_aws_permissions_used_reads_provider_contract_shape() -> None:
+    adapter = _load_adapter()
+
+    permissions = adapter._aws_permissions_used()
+
+    assert "sts:GetCallerIdentity" in permissions
+    assert "bedrock:ListAgents" in permissions


### PR DESCRIPTION
Summary
- add a reference AWS operator-pull adapter that runs inside the customer's pipeline and emits canonical agent-bom inventory JSON locally
- allow inventory agents to carry sanitized provider metadata so operator-pushed cloud assets keep cloud_origin, cloud_principal, cloud_state, and permissions_used context through CLI ingestion
- recursively redact sensitive metadata and launch/env fields before writing or ingesting the inventory file
- document the scope-zero workflow where AWS credentials are unset before the agent-bom scan step

Why
This gives regulated teams a deployment mode where agent-bom does not need raw cloud credentials: their existing CI or automation performs the read-only AWS discovery with scoped ephemeral credentials, writes a schema-validated inventory file, and agent-bom scans that file. The adapter preserves useful cloud context and declared read permissions without storing credential values.

Validation
- uv run pytest tests/test_operator_pull_aws_adapter.py tests/test_cli_inventory.py::test_validate_valid_file tests/test_cli_inventory.py::test_inventory_schema_path_points_to_repo_schema -q
- uv run ruff check examples/operator_pull/aws_inventory_adapter.py tests/test_operator_pull_aws_adapter.py src/agent_bom/cli/_common.py
- uv run mypy examples/operator_pull/aws_inventory_adapter.py src/agent_bom/cli/_common.py
- python -m json.tool config/schemas/inventory.schema.json >/tmp/operator-aws-inventory-schema.json.checked
- git diff --check

Refs #2092
