### PR TITLE
perf: bucket cross environment correlation

### DIFF
--- a/src/agent_bom/cross_env_correlation.py
+++ b/src/agent_bom/cross_env_correlation.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Iterable, Mapping, TypeAlias, Union
+from typing import Any, Iterable, Mapping, TypeAlias, TypeVar, Union
 
 from agent_bom.models import Agent
 
@@ -40,6 +40,7 @@ from agent_bom.models import Agent
 # we normalize both shapes through `_AgentView` instead of forcing one
 # canonical type on every caller.
 AgentLike: TypeAlias = Union[Agent, Mapping[str, Any]]
+_CloudT = TypeVar("_CloudT")
 
 # ---------------------------------------------------------------------------
 # Strict-bar requirement: at least this many of the strong signals (account,
@@ -331,16 +332,43 @@ def _match_bedrock(
     )
 
 
+def _add_candidate(index: dict[str, list[_CloudT]], key: str | None, cloud: _CloudT) -> None:
+    """Add a cloud asset to a signal index when the signal is usable."""
+    if key:
+        index.setdefault(key, []).append(cloud)
+
+
+def _iter_indexed_candidates(index: dict[str, list[_CloudT]], keys: Iterable[str]) -> list[_CloudT]:
+    """Return unique cloud assets that share at least one strong signal.
+
+    The matchers still apply their strict scoring after this prefilter. This
+    only removes pairs that cannot possibly match because none of their
+    provider identity signals intersect.
+    """
+    candidates: list[_CloudT] = []
+    seen: set[int] = set()
+    for key in keys:
+        for cloud in index.get(key, []):
+            marker = id(cloud)
+            if marker in seen:
+                continue
+            seen.add(marker)
+            candidates.append(cloud)
+    return candidates
+
+
 def correlate_bedrock(agents: Iterable[AgentLike]) -> list[CorrelationMatch]:
     """Match local agents to cloud-discovered Bedrock agents."""
     local_evidence: list[_LocalAwsEvidence] = []
-    cloud_bedrock: list[_CloudBedrockAgent] = []
+    cloud_index: dict[str, list[_CloudBedrockAgent]] = {}
 
     for agent in agents:
         view = _normalize(agent)
         cloud = _extract_cloud_bedrock_agent(view)
         if cloud is not None:
-            cloud_bedrock.append(cloud)
+            _add_candidate(cloud_index, cloud.account_id, cloud)
+            _add_candidate(cloud_index, cloud.region, cloud)
+            _add_candidate(cloud_index, cloud.model_id, cloud)
             continue
         local = _extract_local_aws_evidence(view)
         if local is not None:
@@ -348,7 +376,8 @@ def correlate_bedrock(agents: Iterable[AgentLike]) -> list[CorrelationMatch]:
 
     matches: list[CorrelationMatch] = []
     for local in local_evidence:
-        for cloud in cloud_bedrock:
+        candidate_keys = (*local.account_ids, *local.regions, *local.model_ids)
+        for cloud in _iter_indexed_candidates(cloud_index, candidate_keys):
             match = _match_bedrock(local, cloud)
             if match is not None:
                 matches.append(match)
@@ -554,13 +583,15 @@ def _match_azure_openai(
 def correlate_azure_openai(agents: Iterable[AgentLike]) -> list[CorrelationMatch]:
     """Match local agents to cloud-discovered Azure OpenAI deployments."""
     local_evidence: list[_LocalAzureOpenAIEvidence] = []
-    cloud_deployments: list[_CloudAzureOpenAIDeployment] = []
+    cloud_index: dict[str, list[_CloudAzureOpenAIDeployment]] = {}
 
     for agent in agents:
         view = _normalize(agent)
         cloud = _extract_cloud_azure_openai_deployment(view)
         if cloud is not None:
-            cloud_deployments.append(cloud)
+            _add_candidate(cloud_index, cloud.subscription_id, cloud)
+            _add_candidate(cloud_index, cloud.account_name, cloud)
+            _add_candidate(cloud_index, cloud.deployment_name, cloud)
             continue
         local = _extract_local_azure_openai_evidence(view)
         if local is not None:
@@ -568,7 +599,8 @@ def correlate_azure_openai(agents: Iterable[AgentLike]) -> list[CorrelationMatch
 
     matches: list[CorrelationMatch] = []
     for local in local_evidence:
-        for cloud in cloud_deployments:
+        candidate_keys = (*local.subscription_ids, *local.account_names, *local.deployment_names)
+        for cloud in _iter_indexed_candidates(cloud_index, candidate_keys):
             match = _match_azure_openai(local, cloud)
             if match is not None:
                 matches.append(match)
@@ -785,13 +817,15 @@ def _match_gcp_vertex(
 def correlate_gcp_vertex(agents: Iterable[AgentLike]) -> list[CorrelationMatch]:
     """Match local agents to cloud-discovered GCP Vertex AI endpoints."""
     local_evidence: list[_LocalGcpVertexEvidence] = []
-    cloud_endpoints: list[_CloudGcpVertexEndpoint] = []
+    cloud_index: dict[str, list[_CloudGcpVertexEndpoint]] = {}
 
     for agent in agents:
         view = _normalize(agent)
         cloud = _extract_cloud_gcp_vertex_endpoint(view)
         if cloud is not None:
-            cloud_endpoints.append(cloud)
+            _add_candidate(cloud_index, cloud.project_id, cloud)
+            _add_candidate(cloud_index, cloud.location, cloud)
+            _add_candidate(cloud_index, cloud.endpoint_id, cloud)
             continue
         local = _extract_local_gcp_vertex_evidence(view)
         if local is not None:
@@ -799,7 +833,8 @@ def correlate_gcp_vertex(agents: Iterable[AgentLike]) -> list[CorrelationMatch]:
 
     matches: list[CorrelationMatch] = []
     for local in local_evidence:
-        for cloud in cloud_endpoints:
+        candidate_keys = (*local.project_ids, *local.locations, *local.endpoint_ids)
+        for cloud in _iter_indexed_candidates(cloud_index, candidate_keys):
             match = _match_gcp_vertex(local, cloud)
             if match is not None:
                 matches.append(match)

--- a/tests/test_cross_env_correlation.py
+++ b/tests/test_cross_env_correlation.py
@@ -109,6 +109,21 @@ def test_only_model_id_matches_is_low_confidence() -> None:
     assert "Partial match" in match.rationale
 
 
+def test_bedrock_scope_bucket_does_not_drop_model_only_cross_account_candidate() -> None:
+    local = _local_agent(account_id="999988887777", region="eu-west-1")
+    unrelated = _cloud_bedrock_agent(
+        name="bedrock:unrelated",
+        arn="arn:aws:bedrock:ap-southeast-2:222233334444:agent/OTHER",
+        account_id="222233334444",
+        region="ap-southeast-2",
+        model_id=_OTHER_MODEL,
+    )
+
+    matches = correlate_bedrock([local, unrelated, _cloud_bedrock_agent()])
+
+    assert [(match.cloud_agent_name, match.matched_signals) for match in matches] == [("bedrock:prod-agent", ("model_id",))]
+
+
 def test_account_and_region_without_model_is_low_confidence() -> None:
     # The local agent declares the right AWS scope but does not name the
     # specific model — still a low-confidence candidate, not a strong match.
@@ -335,6 +350,26 @@ def test_azure_only_deployment_matches_is_low_confidence() -> None:
     assert matches[0].matched_signals == ("deployment_name",)
 
 
+def test_azure_subscription_bucket_does_not_drop_deployment_only_cross_subscription_candidate() -> None:
+    local = _local_azure_agent(
+        subscription_id="99999999-8888-7777-6666-555555555555",
+        endpoint_url="https://other-account.openai.azure.com/",
+    )
+    unrelated = _cloud_azure_openai_deployment(
+        name="azure-openai:unrelated/other",
+        subscription_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        account_name="unrelated-openai",
+        deployment_name="other",
+        resource_id="/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/rg/providers/Microsoft.CognitiveServices/accounts/unrelated-openai/deployments/other",
+    )
+
+    matches = correlate_azure_openai([local, unrelated, _cloud_azure_openai_deployment()])
+
+    assert [(match.cloud_agent_name, match.matched_signals) for match in matches] == [
+        (f"azure-openai:{_AZURE_ACCOUNT}/{_AZURE_DEPLOYMENT}", ("deployment_name",))
+    ]
+
+
 def test_azure_subscription_and_account_without_deployment_is_low_confidence() -> None:
     local = _local_azure_agent(deployment=None)
 
@@ -514,6 +549,22 @@ def test_gcp_only_endpoint_id_matches_is_low_confidence() -> None:
     assert len(matches) == 1
     assert matches[0].confidence is CorrelationConfidence.LOW
     assert matches[0].matched_signals == ("endpoint_id",)
+
+
+def test_gcp_project_bucket_does_not_drop_endpoint_only_cross_project_candidate() -> None:
+    local = _local_gcp_agent(project_id="other-project", location="europe-west4")
+    unrelated = _cloud_gcp_vertex_endpoint(
+        name="vertex-ai:unrelated",
+        resource_name="projects/unrelated-prod/locations/asia-east1/endpoints/987654321",
+        project_id="unrelated-prod",
+        location="asia-east1",
+    )
+
+    matches = correlate_gcp_vertex([local, unrelated, _cloud_gcp_vertex_endpoint()])
+
+    assert [(match.cloud_agent_name, match.matched_signals) for match in matches] == [
+        ("vertex-ai:gemini-prod-endpoint", ("endpoint_id",))
+    ]
 
 
 def test_gcp_endpoint_resource_path_in_env_supplies_all_three_signals() -> None:


### PR DESCRIPTION
Summary
- replace all-pairs cross-environment matching with provider-specific candidate indexes
- index AWS by account/region/model, Azure by subscription/account/deployment, and GCP by project/location/endpoint
- keep the strict matcher behavior unchanged after candidate selection
- add regression coverage proving low-confidence cross-scope candidates are not dropped by the bucket prefilter

Why
Fleet scans with many local agents and cloud assets should not compare every local evidence row against every cloud runtime when no identity signals intersect. The prefilter removes impossible pairs while preserving the existing accuracy contract: full triplets remain high-confidence and partial signal matches remain visible as low-confidence candidates.

Validation
- uv run pytest tests/test_cross_env_correlation.py -q
- uv run ruff check src/agent_bom/cross_env_correlation.py tests/test_cross_env_correlation.py
- uv run mypy src/agent_bom/cross_env_correlation.py
- git diff --check
