### PR TITLE
ci: stabilize dependabot lockfile normalization

### DIFF
--- a/.github/workflows/dependabot-ui-lockfile-normalize.yml
+++ b/.github/workflows/dependabot-ui-lockfile-normalize.yml
@@ -9,6 +9,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: dependabot-ui-lockfile-normalize-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   normalize-ui-lockfile:
     if: >-
@@ -73,6 +77,7 @@ jobs:
         # URL and full refspec.
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
         run: |
@@ -92,4 +97,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add ui/package-lock.json
           git commit -m "chore(ui): normalize package-lock under pinned npm"
-          git push "https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}.git" "HEAD:refs/heads/${HEAD_REF}"
+          git push \
+            --force-with-lease="refs/heads/${HEAD_REF}:${HEAD_SHA}" \
+            "https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}.git" \
+            "HEAD:refs/heads/${HEAD_REF}"


### PR DESCRIPTION
## Summary
- serialize Dependabot UI lockfile normalization runs per PR
- push normalized lockfile commits with a strict force-with-lease against the PR head SHA
- keep the pull_request_target trust model: checkout base code only, copy only manifest files, and do not run PR-defined npm scripts

## Why
The normalizer currently commits from the trusted base checkout and then tries a regular push to the Dependabot branch. When the branch already contains the Dependabot commit or another normalization attempt, the push is non-fast-forward and the check fails even when the lockfile can be normalized safely.

## Validation
- parsed .github/workflows/dependabot-ui-lockfile-normalize.yml with PyYAML
- asserted HEAD_SHA is passed to the commit step and the force-with-lease refspec is present
- git diff --check

Refs #2096