### PR TITLE
ci: deploy docs on push by default

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
           path: site
 
   deploy:
-    if: ${{ inputs.deploy }}
+    if: ${{ github.event_name != 'workflow_call' || inputs.deploy }}
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
## Summary
- deploy GitHub Pages for normal push/manual docs workflow runs by default
- keep workflow_call callers able to opt out with deploy: false

## Why
GitHub Pages is still serving an April 19 deployment even though the docs build workflow has succeeded more recently. The deploy job was guarded by inputs.deploy, which is only defined for reusable workflow calls and can evaluate false for regular push-triggered docs runs.

## Validation
- uv tool run --from mkdocs==1.6.1 --with mkdocs-material==9.7.5 --with mkdocstrings==1.0.3 --with mkdocstrings-python==2.0.3 mkdocs build --strict --site-dir /tmp/agent-bom-pages-site
- parsed .github/workflows/docs.yml with PyYAML and asserted the deploy guard
- git diff --check