### PR TITLE
feat: add AWS discovery skill

### DIFF
--- a/examples/operator_pull/README.md
+++ b/examples/operator_pull/README.md
@@ -16,6 +16,12 @@ unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE
 agent-bom agents --inventory aws-inventory.json --format json
 ```
 
+For AI-agent mediated discovery, use the bundled
+`integrations/openclaw/discover-aws/SKILL.md` workflow. It invokes the same
+adapter with `--source aws-skill-invoked --discovery-method skill_invoked_pull`
+so downstream findings preserve that the AWS API call happened inside the
+operator's agent environment, not inside agent-bom.
+
 The adapter keeps useful scan context such as package PURLs, cloud metadata,
 and declared AWS read permissions, while recursively redacting sensitive
 metadata and environment values before writing the inventory file.

--- a/examples/operator_pull/aws_inventory_adapter.py
+++ b/examples/operator_pull/aws_inventory_adapter.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from agent_bom.asset_provenance import sanitize_discovery_provenance
 from agent_bom.cloud import provider_contracts
 from agent_bom.cloud.aws import discover
 from agent_bom.inventory import _validate_inventory_payload
@@ -32,6 +33,7 @@ from agent_bom.security import (
 _SCHEMA_AGENT_TYPES = frozenset({"claude-desktop", "claude-code", "cursor", "windsurf", "cline", "custom"})
 _SCHEMA_TRANSPORTS = frozenset({"stdio", "sse", "streamable-http"})
 _SCHEMA_ECOSYSTEMS = frozenset({"npm", "pypi", "go", "cargo", "maven", "nuget", "hex", "pub", "unknown"})
+_DISCOVERY_METHODS = frozenset({"operator_pushed_inventory", "skill_invoked_pull"})
 
 
 def build_inventory(
@@ -40,16 +42,46 @@ def build_inventory(
     source: str = "aws-operator-pull",
     generated_at: str | None = None,
     permissions_used: list[str] | None = None,
+    discovery_method: str = "operator_pushed_inventory",
+    collector: str = "examples/operator_pull/aws_inventory_adapter.py",
 ) -> dict[str, Any]:
     """Build an inventory.schema.json-compatible payload from AWS agents."""
     permissions = permissions_used if permissions_used is not None else _aws_permissions_used()
+    provenance = _default_discovery_provenance(
+        source=source,
+        discovery_method=discovery_method,
+        collector=collector,
+    )
     payload = {
         "schema_version": "1",
         "source": source,
         "generated_at": generated_at or datetime.now(timezone.utc).isoformat(),
-        "agents": [_agent_to_inventory(agent, permissions_used=permissions) for agent in agents],
+        "discovery_provenance": provenance,
+        "agents": [
+            _agent_to_inventory(
+                agent,
+                permissions_used=permissions,
+                inherited_provenance=provenance,
+            )
+            for agent in agents
+        ],
     }
     return _validate_inventory_payload(payload)
+
+
+def _default_discovery_provenance(*, source: str, discovery_method: str, collector: str) -> dict[str, Any]:
+    if discovery_method not in _DISCOVERY_METHODS:
+        raise ValueError(f"Unsupported discovery method: {discovery_method}")
+    return sanitize_discovery_provenance(
+        {
+            "source_type": discovery_method,
+            "observed_via": [discovery_method, "aws_sdk"],
+            "source": source,
+            "collector": collector,
+            "provider": "aws",
+            "confidence": "high",
+        }
+    ) or {"source_type": discovery_method}
 
 
 def _aws_permissions_used() -> list[str]:
@@ -57,7 +89,7 @@ def _aws_permissions_used() -> list[str]:
         providers = provider_contracts().get("providers", [])
     except Exception:  # noqa: BLE001
         return []
-    aws_provider = next((provider for provider in providers if provider.get("name") == "aws"), {})
+    aws_provider: dict[str, Any] = next((provider for provider in providers if provider.get("name") == "aws"), {})
     capabilities = aws_provider.get("capabilities", {})
     permissions = capabilities.get("permissions_used", [])
     if not isinstance(permissions, list):
@@ -65,8 +97,14 @@ def _aws_permissions_used() -> list[str]:
     return [str(permission) for permission in permissions]
 
 
-def _agent_to_inventory(agent: Agent, *, permissions_used: list[str]) -> dict[str, Any]:
+def _agent_to_inventory(
+    agent: Agent,
+    *,
+    permissions_used: list[str],
+    inherited_provenance: dict[str, Any],
+) -> dict[str, Any]:
     metadata = _metadata_with_permissions(agent.metadata, permissions_used)
+    provenance = _asset_provenance(getattr(agent, "discovery_provenance", None), metadata, inherited_provenance)
     agent_type = getattr(agent.agent_type, "value", str(agent.agent_type))
     if agent_type not in _SCHEMA_AGENT_TYPES:
         agent_type = "custom"
@@ -75,7 +113,8 @@ def _agent_to_inventory(agent: Agent, *, permissions_used: list[str]) -> dict[st
         "agent_type": agent_type,
         "config_path": sanitize_text(agent.config_path, max_len=1000) if agent.config_path else "",
         "source": sanitize_text(agent.source or "aws-operator-pull", max_len=200),
-        "mcp_servers": [_server_to_inventory(server) for server in agent.mcp_servers],
+        "mcp_servers": [_server_to_inventory(server, inherited_provenance=provenance) for server in agent.mcp_servers],
+        "discovery_provenance": provenance,
     }
     if agent.version:
         payload["version"] = sanitize_text(agent.version, max_len=100)
@@ -97,10 +136,11 @@ def _metadata_with_permissions(metadata: dict[str, Any], permissions_used: list[
     return sanitized
 
 
-def _server_to_inventory(server: MCPServer) -> dict[str, Any]:
+def _server_to_inventory(server: MCPServer, *, inherited_provenance: dict[str, Any]) -> dict[str, Any]:
     transport = getattr(server.transport, "value", str(server.transport or "stdio"))
     if transport not in _SCHEMA_TRANSPORTS:
         transport = "stdio"
+    provenance = sanitize_discovery_provenance(getattr(server, "discovery_provenance", None), defaults=inherited_provenance)
     payload: dict[str, Any] = {
         "name": sanitize_text(server.name, max_len=300),
         "command": sanitize_text(server.command, max_len=300),
@@ -108,7 +148,13 @@ def _server_to_inventory(server: MCPServer) -> dict[str, Any]:
         "transport": transport,
         "env": sanitize_env_vars(dict(server.env or {})),
         "tools": [_tool_to_inventory(tool) for tool in server.tools],
-        "packages": [_package_to_inventory(package) for package in server.packages],
+        "packages": [
+            _package_to_inventory(
+                package,
+                inherited_provenance=provenance or inherited_provenance,
+            )
+            for package in server.packages
+        ],
         "security_blocked": bool(getattr(server, "security_blocked", False)),
         "security_warnings": sanitize_security_warnings(list(getattr(server, "security_warnings", []) or [])),
         "security_intelligence": [
@@ -116,6 +162,7 @@ def _server_to_inventory(server: MCPServer) -> dict[str, Any]:
             for item in (getattr(server, "security_intelligence", []) or [])
             if isinstance(item, dict)
         ],
+        "discovery_provenance": provenance,
     }
     if server.url:
         payload["url"] = sanitize_url(str(server.url))
@@ -139,7 +186,7 @@ def _tool_to_inventory(tool: MCPTool) -> dict[str, Any]:
     return payload
 
 
-def _package_to_inventory(package: Package) -> dict[str, Any]:
+def _package_to_inventory(package: Package, *, inherited_provenance: dict[str, Any] | None = None) -> dict[str, Any]:
     payload = {
         "name": sanitize_text(package.name, max_len=300),
         "version": sanitize_text(package.version or "unknown", max_len=120) or "unknown",
@@ -149,7 +196,31 @@ def _package_to_inventory(package: Package) -> dict[str, Any]:
         payload["ecosystem"] = ecosystem
     if package.purl:
         payload["purl"] = sanitize_text(package.purl, max_len=500)
+    provenance = sanitize_discovery_provenance(getattr(package, "discovery_provenance", None), defaults=inherited_provenance)
+    if provenance:
+        payload["discovery_provenance"] = provenance
     return payload
+
+
+def _asset_provenance(
+    explicit: Any,
+    metadata: dict[str, Any],
+    inherited_provenance: dict[str, Any],
+) -> dict[str, Any]:
+    defaults = dict(inherited_provenance)
+    cloud_origin = metadata.get("cloud_origin")
+    if isinstance(cloud_origin, dict):
+        defaults.update(
+            {
+                "provider": cloud_origin.get("provider") or defaults.get("provider"),
+                "service": cloud_origin.get("service"),
+                "resource_type": cloud_origin.get("resource_type"),
+                "resource_id": cloud_origin.get("resource_id"),
+                "resource_name": cloud_origin.get("resource_name"),
+                "location": cloud_origin.get("location"),
+            }
+        )
+    return sanitize_discovery_provenance(explicit, defaults=defaults) or inherited_provenance
 
 
 def _parse_key_value(items: list[str]) -> dict[str, str]:
@@ -170,6 +241,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--region", help="AWS region to scan. Defaults to the active AWS SDK region.")
     parser.add_argument("--profile", help="AWS profile name. Uses the default credential chain when omitted.")
     parser.add_argument("--output", "-o", default="-", help="Output path, or '-' for stdout.")
+    parser.add_argument("--source", default="aws-operator-pull", help="Inventory source label.")
+    parser.add_argument(
+        "--discovery-method",
+        choices=sorted(_DISCOVERY_METHODS),
+        default="operator_pushed_inventory",
+        help="How this inventory was collected before agent-bom ingestion.",
+    )
     parser.add_argument("--compact", action="store_true", help="Emit compact JSON.")
     parser.add_argument("--include-ecs", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--include-sagemaker", action=argparse.BooleanOptionalAction, default=False)
@@ -199,7 +277,11 @@ def main(argv: list[str] | None = None) -> int:
     for warning in sanitize_security_warnings(warnings):
         sys.stderr.write(f"warning: {warning}\n")
 
-    payload = build_inventory(agents)
+    payload = build_inventory(
+        agents,
+        source=args.source,
+        discovery_method=args.discovery_method,
+    )
     text = json.dumps(payload, indent=None if args.compact else 2, sort_keys=True) + "\n"
     if args.output == "-":
         sys.stdout.write(text)

--- a/integrations/openclaw/discover-aws/SKILL.md
+++ b/integrations/openclaw/discover-aws/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: agent-bom-discover-aws
+description: >-
+  Discover AWS-hosted AI agent and MCP-relevant assets from the operator's
+  environment, emit canonical agent-bom inventory JSON, and scan it without
+  giving agent-bom long-lived cloud credentials. Use when a user asks to
+  inventory AWS Bedrock, ECS, SageMaker, Lambda, EKS, Step Functions, EC2, or
+  agentic AWS infrastructure for agent-bom.
+version: 0.82.3
+license: Apache-2.0
+compatibility: >-
+  Requires Python 3.11+, agent-bom installed from this repository or PyPI, and
+  operator-controlled AWS credentials from AWS SSO, WebIdentity, or STS. Prefer
+  short-lived credentials and read-only IAM policy scope.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/agent-bom
+  source: https://github.com/msaad00/agent-bom
+  pypi: https://pypi.org/project/agent-bom/
+  openclaw:
+    requires:
+      bins:
+        - python
+      env: []
+      credentials: aws-read-only
+    credential_policy: "Use the operator's existing AWS SDK credential chain. Prefer AWS SSO, WebIdentity, or STS assumed-role credentials. Do not ask users to paste access keys. Do not print credential values."
+    optional_env:
+      - AWS_PROFILE
+      - AWS_REGION
+      - AWS_DEFAULT_REGION
+    optional_bins: []
+    emoji: "\U0001F50E"
+    homepage: https://github.com/msaad00/agent-bom
+    source: https://github.com/msaad00/agent-bom
+    license: Apache-2.0
+    os:
+      - darwin
+      - linux
+      - windows
+    credential_handling: "Credentials stay in the operator environment. The skill invokes the AWS SDK locally and writes canonical inventory JSON with source_type=skill_invoked_pull. agent-bom receives sanitized inventory, not raw cloud credentials."
+    data_flow: "Operator AWS account -> read-only AWS SDK calls -> canonical inventory JSON -> agent-bom inventory scan. No agent-bom-hosted service is required. Values matching credential patterns are redacted before persistence/export."
+    file_reads: []
+    file_writes:
+      - "operator-selected inventory JSON output path"
+    network_endpoints:
+      - url: "https://sts.amazonaws.com"
+        purpose: "Caller identity and assumed-role context"
+        auth: true
+      - url: "https://bedrock-agent.{region}.amazonaws.com"
+        purpose: "Bedrock agent inventory"
+        auth: true
+      - url: "https://ecs.{region}.amazonaws.com"
+        purpose: "ECS workload inventory when enabled"
+        auth: true
+      - url: "https://sagemaker.{region}.amazonaws.com"
+        purpose: "SageMaker inventory when enabled"
+        auth: true
+      - url: "https://lambda.{region}.amazonaws.com"
+        purpose: "Lambda inventory when enabled"
+        auth: true
+      - url: "https://eks.{region}.amazonaws.com"
+        purpose: "EKS inventory when enabled"
+        auth: true
+      - url: "https://states.{region}.amazonaws.com"
+        purpose: "Step Functions inventory when enabled"
+        auth: true
+      - url: "https://ec2.{region}.amazonaws.com"
+        purpose: "EC2 inventory when enabled"
+        auth: true
+    telemetry: false
+    persistence: false
+    privilege_escalation: false
+    always: false
+    autonomous_invocation: restricted
+---
+
+# agent-bom-discover-aws
+
+Use this skill to collect AWS AI and workload inventory from the operator's
+environment and feed it to `agent-bom` as canonical inventory.
+
+## Guardrails
+
+- Use only operator-approved AWS profiles, roles, or short-lived STS sessions.
+- Prefer read-only IAM actions listed by `agent-bom trust` or
+  `/v1/discovery/providers`.
+- Do not request or display raw `AWS_ACCESS_KEY_ID`,
+  `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, or bearer tokens.
+- Do not modify AWS resources. This workflow is discovery-only.
+- Write inventory only to a path the operator chose.
+- Treat AI-generated prose as non-authoritative; only the schema-validated
+  inventory JSON is evidence.
+
+## Workflow
+
+1. Confirm the AWS account/region/profile and intended services.
+2. Generate inventory with the repository adapter:
+
+```bash
+python examples/operator_pull/aws_inventory_adapter.py \
+  --region us-east-1 \
+  --profile readonly-audit \
+  --source aws-skill-invoked \
+  --discovery-method skill_invoked_pull \
+  --output aws-inventory.json
+```
+
+3. Scan the generated inventory:
+
+```bash
+agent-bom agents --inventory aws-inventory.json
+```
+
+4. For CI or offline review, export JSON:
+
+```bash
+agent-bom agents --inventory aws-inventory.json --format json --output agent-bom-aws-findings.json
+```
+
+## Optional Service Flags
+
+Start narrow, then expand deliberately:
+
+```bash
+python examples/operator_pull/aws_inventory_adapter.py \
+  --region us-east-1 \
+  --profile readonly-audit \
+  --source aws-skill-invoked \
+  --discovery-method skill_invoked_pull \
+  --include-ecs \
+  --include-lambda \
+  --include-eks \
+  --output aws-inventory.json
+```
+
+Use `--no-include-ecs` or similar flags to disable default services when an
+operator wants a smaller scope.
+
+## Evidence Contract
+
+The inventory emitted by this skill uses:
+
+- `source: aws-skill-invoked`
+- `discovery_provenance.source_type: skill_invoked_pull`
+- `discovery_provenance.observed_via: skill_invoked_pull, aws_sdk`
+- sanitized `metadata.permissions_used`
+- sanitized `cloud_origin`, `cloud_principal`, lifecycle fields, packages, and
+  MCP server launch metadata
+
+If schema validation fails, stop and fix the inventory instead of scanning a
+best-effort or prose summary.

--- a/site-docs/skills/index.md
+++ b/site-docs/skills/index.md
@@ -10,6 +10,7 @@ agent-bom includes pre-built skill workflows for common security tasks.
 | [CSPM AWS](https://github.com/msaad00/agent-bom/blob/main/docs/skills/cspm-aws-benchmark.md) | `cspm-aws-benchmark.md` | AWS CIS benchmark |
 | [CSPM Azure](https://github.com/msaad00/agent-bom/blob/main/docs/skills/cspm-azure-benchmark.md) | `cspm-azure-benchmark.md` | Azure security benchmark |
 | [CSPM GCP](https://github.com/msaad00/agent-bom/blob/main/docs/skills/cspm-gcp-benchmark.md) | `cspm-gcp-benchmark.md` | GCP security benchmark |
+| [AWS Discovery Skill](https://github.com/msaad00/agent-bom/blob/main/integrations/openclaw/discover-aws/SKILL.md) | `integrations/openclaw/discover-aws/SKILL.md` | Skill-mediated AWS inventory with signed/sanitized agent-bom ingestion |
 | [Incident Response](https://github.com/msaad00/agent-bom/blob/main/docs/skills/incident-response.md) | `incident-response.md` | CVE incident investigation |
 | [MCP Server Review](https://github.com/msaad00/agent-bom/blob/main/docs/skills/mcp-server-review.md) | `mcp-server-review.md` | Pre-install MCP server trust assessment |
 | [OWASP LLM Assessment](https://github.com/msaad00/agent-bom/blob/main/docs/skills/owasp-llm-assessment.md) | `owasp-llm-assessment.md` | OWASP LLM Top 10 compliance check |

--- a/tests/test_aws_discovery_skill.py
+++ b/tests/test_aws_discovery_skill.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_bom.parsers.skill_audit import audit_skill_result
+from agent_bom.parsers.skills import parse_skill_file
+from agent_bom.parsers.trust_assessment import assess_trust
+
+SKILL_PATH = Path(__file__).resolve().parents[1] / "integrations" / "openclaw" / "discover-aws" / "SKILL.md"
+
+
+def test_aws_discovery_skill_declares_guardrailed_skill_invoked_inventory_flow() -> None:
+    result = parse_skill_file(SKILL_PATH)
+
+    assert result.metadata is not None
+    assert result.metadata.name == "agent-bom-discover-aws"
+    assert result.metadata.license == "Apache-2.0"
+    assert "python" in result.metadata.required_bins
+    assert {"darwin", "linux", "windows"}.issubset(set(result.metadata.os_support))
+
+    content = result.raw_content[str(SKILL_PATH)]
+    assert "--discovery-method skill_invoked_pull" in content
+    assert "--source aws-skill-invoked" in content
+    assert "examples/operator_pull/aws_inventory_adapter.py" in content
+    assert "Do not ask users to paste access keys" in content
+    assert "Do not modify AWS resources" in content
+    assert "agent-bom agents --inventory aws-inventory.json" in content
+
+
+def test_aws_discovery_skill_trust_assessment_stays_review_not_blocked() -> None:
+    result = parse_skill_file(SKILL_PATH)
+    audit = audit_skill_result(result)
+    trust = assess_trust(result, audit)
+
+    assert trust.review_verdict in {"trusted", "review"}
+    assert trust.review_verdict != "blocked"
+    assert not any(finding.severity == "critical" for finding in audit.findings)

--- a/tests/test_operator_pull_aws_adapter.py
+++ b/tests/test_operator_pull_aws_adapter.py
@@ -59,6 +59,8 @@ def test_aws_operator_pull_adapter_emits_valid_sanitized_inventory(tmp_path: Pat
         [agent],
         generated_at="2026-04-29T12:00:00+00:00",
         permissions_used=["sts:GetCallerIdentity", "bedrock:ListAgents"],
+        source="aws-skill-invoked",
+        discovery_method="skill_invoked_pull",
     )
     output_path = tmp_path / "aws-inventory.json"
     output_path.write_text(json.dumps(payload), encoding="utf-8")
@@ -67,9 +69,15 @@ def test_aws_operator_pull_adapter_emits_valid_sanitized_inventory(tmp_path: Pat
     rebuilt_agents = _build_agents_from_inventory(loaded, str(output_path))
 
     assert loaded["schema_version"] == "1"
+    assert loaded["source"] == "aws-skill-invoked"
+    assert loaded["discovery_provenance"]["source_type"] == "skill_invoked_pull"
+    assert loaded["discovery_provenance"]["observed_via"] == ["skill_invoked_pull", "aws_sdk"]
     assert loaded["agents"][0]["metadata"]["cloud_origin"]["scope"]["api_token"] == "***REDACTED***"
+    assert loaded["agents"][0]["discovery_provenance"]["source_type"] == "skill_invoked_pull"
+    assert loaded["agents"][0]["discovery_provenance"]["service"] == "bedrock"
     assert loaded["agents"][0]["metadata"]["permissions_used"] == ["bedrock:ListAgents", "sts:GetCallerIdentity"]
     assert loaded["agents"][0]["mcp_servers"][0]["env"]["AWS_SESSION_TOKEN"] == "***REDACTED***"
+    assert loaded["agents"][0]["mcp_servers"][0]["packages"][0]["discovery_provenance"]["source_type"] == "skill_invoked_pull"
     assert "secret-value" not in json.dumps(loaded)
     assert rebuilt_agents[0].metadata["cloud_origin"]["provider"] == "aws"
     assert rebuilt_agents[0].metadata["permissions_used"] == ["bedrock:ListAgents", "sts:GetCallerIdentity"]
@@ -91,6 +99,41 @@ def test_aws_operator_pull_adapter_cli_writes_inventory(monkeypatch, tmp_path: P
 
     loaded = load_inventory(str(output_path))
     assert loaded["agents"][0]["name"] == "aws-empty"
+    assert loaded["discovery_provenance"]["source_type"] == "operator_pushed_inventory"
+
+
+def test_aws_operator_pull_adapter_cli_marks_skill_invoked_inventory(monkeypatch, tmp_path: Path) -> None:
+    adapter = _load_adapter()
+    monkeypatch.setattr(
+        adapter,
+        "discover",
+        lambda **_kwargs: (
+            [Agent(name="aws-skill", agent_type=AgentType.CUSTOM, config_path="aws://skill", source="aws", mcp_servers=[])],
+            [],
+        ),
+    )
+    output_path = tmp_path / "inventory.json"
+
+    assert (
+        adapter.main(
+            [
+                "--region",
+                "us-east-1",
+                "--no-include-ecs",
+                "--source",
+                "aws-skill-invoked",
+                "--discovery-method",
+                "skill_invoked_pull",
+                "--output",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+
+    loaded = load_inventory(str(output_path))
+    assert loaded["source"] == "aws-skill-invoked"
+    assert loaded["agents"][0]["discovery_provenance"]["source_type"] == "skill_invoked_pull"
 
 
 def test_aws_operator_pull_adapter_keeps_container_purl_schema_valid() -> None:


### PR DESCRIPTION
## Summary
- add a bundled AWS discovery skill that invokes the existing operator-pull adapter with least-privilege/STS guardrails
- add adapter provenance switches for skill-invoked inventory so downstream findings preserve source_type=skill_invoked_pull
- document the skill from the operator-pull README and skills index
- add tests for adapter provenance, CLI flags, skill metadata, and skill trust posture

## Why
This makes the agentic discovery path real without creating a parallel collector. The operator's AI agent can invoke the AWS SDK in the operator environment, emit canonical sanitized inventory, and then agent-bom scans that inventory without holding long-lived cloud credentials.

## Validation
- uv run pytest tests/test_operator_pull_aws_adapter.py tests/test_aws_discovery_skill.py -q
- uv run ruff check examples/operator_pull/aws_inventory_adapter.py tests/test_operator_pull_aws_adapter.py tests/test_aws_discovery_skill.py
- uv run mypy examples/operator_pull/aws_inventory_adapter.py
- uv run mkdocs build --strict --site-dir /tmp/agent-bom-aws-skill-site
- git diff --check