### PR TITLE
feat: add Azure and GCP operator pull adapters

### DIFF
--- a/examples/operator_pull/README.md
+++ b/examples/operator_pull/README.md
@@ -1,9 +1,16 @@
-# AWS Operator-Pull Inventory Adapter
+# Operator-Pull Inventory Adapters
 
-This reference adapter runs in the operator's environment with the operator's
-own ephemeral or tightly scoped AWS credentials. It emits canonical
-`agent-bom` inventory JSON locally, so a later `agent-bom` scan can run from a
-file without receiving raw cloud credentials.
+These reference adapters run in the operator's environment with the operator's
+own ephemeral or tightly scoped cloud credentials. They emit canonical
+`agent-bom` inventory JSON locally. That is useful by itself: the operator can
+inspect, archive, or route the JSON to an internal CMDB without running an
+agent-bom scan.
+
+Passing the inventory to agent-bom is an explicit handoff. Use `agent-bom agents
+--inventory ...` only when you want agent-bom findings, graph, policy, and
+exports from the discovered assets.
+
+## AWS
 
 ```bash
 python examples/operator_pull/aws_inventory_adapter.py \
@@ -16,12 +23,36 @@ unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE
 agent-bom agents --inventory aws-inventory.json --format json
 ```
 
+## Azure
+
+```bash
+python examples/operator_pull/azure_inventory_adapter.py \
+  --subscription-id 00000000-0000-0000-0000-000000000000 \
+  --resource-group ai-platform \
+  --output azure-inventory.json
+
+agent-bom agents --inventory azure-inventory.json --format json
+```
+
+## GCP
+
+```bash
+python examples/operator_pull/gcp_inventory_adapter.py \
+  --project my-gcp-project \
+  --region us-central1 \
+  --output gcp-inventory.json
+
+agent-bom agents --inventory gcp-inventory.json --format json
+```
+
+## Skill-Mediated Handoff
+
 For AI-agent mediated discovery, use the bundled
 `integrations/openclaw/discover-aws/SKILL.md` workflow. It invokes the same
 adapter with `--source aws-skill-invoked --discovery-method skill_invoked_pull`
 so downstream findings preserve that the AWS API call happened inside the
 operator's agent environment, not inside agent-bom.
 
-The adapter keeps useful scan context such as package PURLs, cloud metadata,
-and declared AWS read permissions, while recursively redacting sensitive
+The adapters keep useful scan context such as package PURLs, cloud metadata,
+and declared read permissions, while recursively redacting sensitive
 metadata and environment values before writing the inventory file.

--- a/examples/operator_pull/azure_inventory_adapter.py
+++ b/examples/operator_pull/azure_inventory_adapter.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Emit canonical agent-bom inventory from Azure inside the operator boundary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from inventory_writer import DISCOVERY_METHODS, build_inventory_payload  # noqa: E402
+
+from agent_bom.cloud.azure import discover  # noqa: E402
+from agent_bom.security import sanitize_security_warnings  # noqa: E402
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Emit Azure discovery as canonical agent-bom inventory JSON.")
+    parser.add_argument("--subscription-id", help="Azure subscription ID. Defaults to AZURE_SUBSCRIPTION_ID.")
+    parser.add_argument("--resource-group", help="Optional Azure resource group scope.")
+    parser.add_argument("--output", "-o", default="-", help="Output path, or '-' for stdout.")
+    parser.add_argument("--compact", action="store_true", help="Emit compact JSON.")
+    parser.add_argument("--source", default="azure-operator-pull", help="Inventory source label.")
+    parser.add_argument(
+        "--discovery-method",
+        choices=sorted(DISCOVERY_METHODS),
+        default="operator_pushed_inventory",
+        help="How this inventory was collected before agent-bom ingestion.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    agents, warnings = discover(
+        subscription_id=args.subscription_id,
+        resource_group=args.resource_group,
+    )
+    for warning in sanitize_security_warnings(warnings):
+        sys.stderr.write(f"warning: {warning}\n")
+
+    payload = build_inventory_payload(
+        agents,
+        provider_name="azure",
+        source=args.source,
+        collector="examples/operator_pull/azure_inventory_adapter.py",
+        discovery_method=args.discovery_method,
+    )
+    text = json.dumps(payload, indent=None if args.compact else 2, sort_keys=True) + "\n"
+    if args.output == "-":
+        sys.stdout.write(text)
+    else:
+        Path(args.output).write_text(text, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/operator_pull/gcp_inventory_adapter.py
+++ b/examples/operator_pull/gcp_inventory_adapter.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Emit canonical agent-bom inventory from GCP inside the operator boundary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from inventory_writer import DISCOVERY_METHODS, build_inventory_payload  # noqa: E402
+
+from agent_bom.cloud.gcp import discover  # noqa: E402
+from agent_bom.security import sanitize_security_warnings  # noqa: E402
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Emit GCP discovery as canonical agent-bom inventory JSON.")
+    parser.add_argument("--project", "--project-id", dest="project_id", help="GCP project ID. Defaults to GOOGLE_CLOUD_PROJECT.")
+    parser.add_argument("--region", default="us-central1", help="GCP region to scan.")
+    parser.add_argument("--output", "-o", default="-", help="Output path, or '-' for stdout.")
+    parser.add_argument("--compact", action="store_true", help="Emit compact JSON.")
+    parser.add_argument("--source", default="gcp-operator-pull", help="Inventory source label.")
+    parser.add_argument(
+        "--discovery-method",
+        choices=sorted(DISCOVERY_METHODS),
+        default="operator_pushed_inventory",
+        help="How this inventory was collected before agent-bom ingestion.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    agents, warnings = discover(
+        project_id=args.project_id,
+        region=args.region,
+    )
+    for warning in sanitize_security_warnings(warnings):
+        sys.stderr.write(f"warning: {warning}\n")
+
+    payload = build_inventory_payload(
+        agents,
+        provider_name="gcp",
+        source=args.source,
+        collector="examples/operator_pull/gcp_inventory_adapter.py",
+        discovery_method=args.discovery_method,
+    )
+    text = json.dumps(payload, indent=None if args.compact else 2, sort_keys=True) + "\n"
+    if args.output == "-":
+        sys.stdout.write(text)
+    else:
+        Path(args.output).write_text(text, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/operator_pull/inventory_writer.py
+++ b/examples/operator_pull/inventory_writer.py
@@ -1,0 +1,206 @@
+"""Shared canonical inventory writer for operator-pull adapters."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from agent_bom.asset_provenance import sanitize_discovery_provenance
+from agent_bom.cloud import provider_contracts
+from agent_bom.inventory import _validate_inventory_payload
+from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
+from agent_bom.models import Agent, MCPServer, MCPTool, Package
+from agent_bom.security import (
+    sanitize_command_args,
+    sanitize_env_vars,
+    sanitize_security_warnings,
+    sanitize_sensitive_payload,
+    sanitize_text,
+    sanitize_url,
+)
+
+SCHEMA_AGENT_TYPES = frozenset({"claude-desktop", "claude-code", "cursor", "windsurf", "cline", "custom"})
+SCHEMA_TRANSPORTS = frozenset({"stdio", "sse", "streamable-http"})
+SCHEMA_ECOSYSTEMS = frozenset({"npm", "pypi", "go", "cargo", "maven", "nuget", "hex", "pub", "unknown"})
+DISCOVERY_METHODS = frozenset({"operator_pushed_inventory", "skill_invoked_pull"})
+
+
+def provider_permissions_used(provider_name: str) -> list[str]:
+    """Read declared provider permissions from the discovery contract."""
+    try:
+        providers = provider_contracts().get("providers", [])
+    except Exception:  # noqa: BLE001
+        return []
+    provider: dict[str, Any] = next((item for item in providers if item.get("name") == provider_name), {})
+    capabilities = provider.get("capabilities", {})
+    permissions = capabilities.get("permissions_used", [])
+    if not isinstance(permissions, list):
+        return []
+    return [str(permission) for permission in permissions]
+
+
+def build_inventory_payload(
+    agents: list[Agent],
+    *,
+    provider_name: str,
+    source: str,
+    collector: str,
+    generated_at: str | None = None,
+    permissions_used: list[str] | None = None,
+    discovery_method: str = "operator_pushed_inventory",
+) -> dict[str, Any]:
+    """Build an inventory.schema.json-compatible payload from cloud agents."""
+    if discovery_method not in DISCOVERY_METHODS:
+        raise ValueError(f"Unsupported discovery method: {discovery_method}")
+    permissions = permissions_used if permissions_used is not None else provider_permissions_used(provider_name)
+    provenance = sanitize_discovery_provenance(
+        {
+            "source_type": discovery_method,
+            "observed_via": [discovery_method, f"{provider_name}_sdk"],
+            "source": source,
+            "collector": collector,
+            "provider": provider_name,
+            "confidence": "high",
+        }
+    ) or {"source_type": discovery_method}
+    payload = {
+        "schema_version": "1",
+        "source": source,
+        "generated_at": generated_at or datetime.now(timezone.utc).isoformat(),
+        "discovery_provenance": provenance,
+        "agents": [
+            _agent_to_inventory(
+                agent,
+                permissions_used=permissions,
+                inherited_provenance=provenance,
+            )
+            for agent in agents
+        ],
+    }
+    return _validate_inventory_payload(payload)
+
+
+def _agent_to_inventory(
+    agent: Agent,
+    *,
+    permissions_used: list[str],
+    inherited_provenance: dict[str, Any],
+) -> dict[str, Any]:
+    metadata = _metadata_with_permissions(agent.metadata, permissions_used)
+    provenance = _asset_provenance(getattr(agent, "discovery_provenance", None), metadata, inherited_provenance)
+    agent_type = getattr(agent.agent_type, "value", str(agent.agent_type))
+    if agent_type not in SCHEMA_AGENT_TYPES:
+        agent_type = "custom"
+    payload: dict[str, Any] = {
+        "name": sanitize_text(agent.name, max_len=300),
+        "agent_type": agent_type,
+        "config_path": sanitize_text(agent.config_path, max_len=1000) if agent.config_path else "",
+        "source": sanitize_text(agent.source or inherited_provenance.get("source") or "operator-pull", max_len=200),
+        "mcp_servers": [_server_to_inventory(server, inherited_provenance=provenance) for server in agent.mcp_servers],
+        "discovery_provenance": provenance,
+    }
+    if agent.version:
+        payload["version"] = sanitize_text(agent.version, max_len=100)
+    if metadata:
+        payload["metadata"] = metadata
+    if agent.discovered_at:
+        payload["discovered_at"] = agent.discovered_at
+    if agent.last_seen:
+        payload["last_seen"] = agent.last_seen
+    return payload
+
+
+def _metadata_with_permissions(metadata: dict[str, Any], permissions_used: list[str]) -> dict[str, Any]:
+    sanitized = sanitize_sensitive_payload(metadata or {})
+    if not isinstance(sanitized, dict):
+        sanitized = {}
+    if permissions_used:
+        sanitized["permissions_used"] = sorted(set(permissions_used))
+    return sanitized
+
+
+def _server_to_inventory(server: MCPServer, *, inherited_provenance: dict[str, Any]) -> dict[str, Any]:
+    transport = getattr(server.transport, "value", str(server.transport or "stdio"))
+    if transport not in SCHEMA_TRANSPORTS:
+        transport = "stdio"
+    provenance = sanitize_discovery_provenance(getattr(server, "discovery_provenance", None), defaults=inherited_provenance)
+    payload: dict[str, Any] = {
+        "name": sanitize_text(server.name, max_len=300),
+        "command": sanitize_text(server.command, max_len=300),
+        "args": sanitize_command_args(list(server.args or [])),
+        "transport": transport,
+        "env": sanitize_env_vars(dict(server.env or {})),
+        "tools": [_tool_to_inventory(tool) for tool in server.tools],
+        "packages": [
+            _package_to_inventory(
+                package,
+                inherited_provenance=provenance or inherited_provenance,
+            )
+            for package in server.packages
+        ],
+        "security_blocked": bool(getattr(server, "security_blocked", False)),
+        "security_warnings": sanitize_security_warnings(list(getattr(server, "security_warnings", []) or [])),
+        "security_intelligence": [
+            sanitize_security_intelligence_entry(item)
+            for item in (getattr(server, "security_intelligence", []) or [])
+            if isinstance(item, dict)
+        ],
+        "discovery_provenance": provenance,
+    }
+    if server.url:
+        payload["url"] = sanitize_url(str(server.url))
+    if server.mcp_version:
+        payload["mcp_version"] = sanitize_text(server.mcp_version, max_len=80)
+    if server.working_dir:
+        payload["working_dir"] = sanitize_text(server.working_dir, max_len=1000)
+    if server.config_path:
+        payload["config_path"] = sanitize_text(server.config_path, max_len=1000)
+    return {key: value for key, value in payload.items() if value not in (None, "", [], {})}
+
+
+def _tool_to_inventory(tool: MCPTool) -> dict[str, Any]:
+    payload: dict[str, Any] = {"name": sanitize_text(tool.name, max_len=300)}
+    if tool.description:
+        payload["description"] = sanitize_text(tool.description, max_len=1000)
+    if tool.input_schema:
+        sanitized_schema = sanitize_sensitive_payload(tool.input_schema)
+        if isinstance(sanitized_schema, dict):
+            payload["input_schema"] = sanitized_schema
+    return payload
+
+
+def _package_to_inventory(package: Package, *, inherited_provenance: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload = {
+        "name": sanitize_text(package.name, max_len=300),
+        "version": sanitize_text(package.version or "unknown", max_len=120) or "unknown",
+    }
+    ecosystem = sanitize_text(package.ecosystem or "unknown", max_len=60) or "unknown"
+    if ecosystem in SCHEMA_ECOSYSTEMS:
+        payload["ecosystem"] = ecosystem
+    if package.purl:
+        payload["purl"] = sanitize_text(package.purl, max_len=500)
+    provenance = sanitize_discovery_provenance(getattr(package, "discovery_provenance", None), defaults=inherited_provenance)
+    if provenance:
+        payload["discovery_provenance"] = provenance
+    return payload
+
+
+def _asset_provenance(
+    explicit: Any,
+    metadata: dict[str, Any],
+    inherited_provenance: dict[str, Any],
+) -> dict[str, Any]:
+    defaults = dict(inherited_provenance)
+    cloud_origin = metadata.get("cloud_origin")
+    if isinstance(cloud_origin, dict):
+        defaults.update(
+            {
+                "provider": cloud_origin.get("provider") or defaults.get("provider"),
+                "service": cloud_origin.get("service"),
+                "resource_type": cloud_origin.get("resource_type"),
+                "resource_id": cloud_origin.get("resource_id"),
+                "resource_name": cloud_origin.get("resource_name"),
+                "location": cloud_origin.get("location"),
+            }
+        )
+    return sanitize_discovery_provenance(explicit, defaults=defaults) or inherited_provenance

--- a/tests/test_operator_pull_azure_gcp_adapters.py
+++ b/tests/test_operator_pull_azure_gcp_adapters.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+from agent_bom.inventory import load_inventory
+from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
+
+ROOT = Path(__file__).resolve().parents[1]
+AZURE_ADAPTER_PATH = ROOT / "examples" / "operator_pull" / "azure_inventory_adapter.py"
+GCP_ADAPTER_PATH = ROOT / "examples" / "operator_pull" / "gcp_inventory_adapter.py"
+WRITER_PATH = ROOT / "examples" / "operator_pull" / "inventory_writer.py"
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_azure_operator_pull_adapter_cli_writes_sanitized_inventory(monkeypatch, tmp_path: Path) -> None:
+    adapter = _load_module(AZURE_ADAPTER_PATH, "azure_inventory_adapter")
+    agent = Agent(
+        name="azure-ai-endpoint",
+        agent_type=AgentType.CUSTOM,
+        config_path="/subscriptions/sub-123/resourceGroups/rg/providers/Microsoft.MachineLearningServices/workspaces/ws",
+        source="azure",
+        metadata={
+            "cloud_origin": {
+                "provider": "azure",
+                "service": "machine-learning",
+                "resource_type": "endpoint",
+                "resource_id": "endpoint-1",
+                "scope": {"subscription_id": "sub-123", "api_token": "should-not-survive"},
+            }
+        },
+        mcp_servers=[
+            MCPServer(
+                name="azure-openai",
+                command="npx",
+                args=["-y", "server", "--api-key", "raw-token"],
+                env={"AZURE_OPENAI_API_KEY": "raw-token"},
+                transport=TransportType.STDIO,
+                packages=[
+                    Package(
+                        name="@azure/openai",
+                        version="1.0.0",
+                        ecosystem="npm",
+                        purl="pkg:npm/%40azure/openai@1.0.0",
+                    )
+                ],
+            )
+        ],
+    )
+    monkeypatch.setattr(adapter, "discover", lambda **_kwargs: ([agent], ["warning has token=secret"]))
+    output_path = tmp_path / "azure-inventory.json"
+
+    assert (
+        adapter.main(
+            [
+                "--subscription-id",
+                "sub-123",
+                "--resource-group",
+                "rg",
+                "--output",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+
+    loaded = load_inventory(str(output_path))
+    serialized = json.dumps(loaded)
+    assert loaded["source"] == "azure-operator-pull"
+    assert loaded["discovery_provenance"]["source_type"] == "operator_pushed_inventory"
+    assert loaded["discovery_provenance"]["observed_via"] == ["operator_pushed_inventory", "azure_sdk"]
+    assert loaded["agents"][0]["metadata"]["cloud_origin"]["scope"]["api_token"] == "***REDACTED***"
+    assert loaded["agents"][0]["metadata"]["permissions_used"]
+    assert loaded["agents"][0]["mcp_servers"][0]["env"]["AZURE_OPENAI_API_KEY"] == "***REDACTED***"
+    assert "raw-token" not in serialized
+    assert "should-not-survive" not in serialized
+
+
+def test_gcp_operator_pull_adapter_cli_marks_skill_invoked_inventory(monkeypatch, tmp_path: Path) -> None:
+    adapter = _load_module(GCP_ADAPTER_PATH, "gcp_inventory_adapter")
+    agent = Agent(
+        name="vertex-endpoint",
+        agent_type=AgentType.CUSTOM,
+        config_path="projects/demo/locations/us-central1/endpoints/endpoint-1",
+        source="gcp",
+        metadata={
+            "cloud_origin": {
+                "provider": "gcp",
+                "service": "vertex-ai",
+                "resource_type": "endpoint",
+                "resource_id": "endpoint-1",
+                "location": "us-central1",
+            },
+            "service_account_token": "hidden-token",
+        },
+        mcp_servers=[],
+    )
+    monkeypatch.setattr(adapter, "discover", lambda **_kwargs: ([agent], []))
+    output_path = tmp_path / "gcp-inventory.json"
+
+    assert (
+        adapter.main(
+            [
+                "--project",
+                "demo",
+                "--region",
+                "us-central1",
+                "--source",
+                "gcp-skill-invoked",
+                "--discovery-method",
+                "skill_invoked_pull",
+                "--output",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+
+    loaded = load_inventory(str(output_path))
+    serialized = json.dumps(loaded)
+    assert loaded["source"] == "gcp-skill-invoked"
+    assert loaded["discovery_provenance"]["source_type"] == "skill_invoked_pull"
+    assert loaded["discovery_provenance"]["observed_via"] == ["skill_invoked_pull", "gcp_sdk"]
+    assert loaded["agents"][0]["discovery_provenance"]["provider"] == "gcp"
+    assert loaded["agents"][0]["metadata"]["permissions_used"]
+    assert "hidden-token" not in serialized
+
+
+def test_operator_pull_inventory_writer_keeps_container_purl_schema_valid() -> None:
+    writer = _load_module(WRITER_PATH, "inventory_writer")
+    package = Package(
+        name="gcr.io/demo/model-api",
+        version="2026-04",
+        ecosystem="container-image",
+        purl="pkg:docker/gcr.io/demo/model-api@2026-04",
+    )
+
+    payload = writer._package_to_inventory(package)
+
+    assert payload == {
+        "name": "gcr.io/demo/model-api",
+        "version": "2026-04",
+        "purl": "pkg:docker/gcr.io/demo/model-api@2026-04",
+    }
+
+
+def test_provider_permissions_used_reads_azure_and_gcp_contracts() -> None:
+    writer = _load_module(WRITER_PATH, "inventory_writer")
+
+    azure_permissions = writer.provider_permissions_used("azure")
+    gcp_permissions = writer.provider_permissions_used("gcp")
+
+    assert azure_permissions
+    assert gcp_permissions
+    assert all(":" in permission or "." in permission for permission in azure_permissions + gcp_permissions)


### PR DESCRIPTION
Summary

- add Azure and GCP operator-pull inventory adapters that emit canonical inventory JSON from inside the operator boundary
- share sanitized inventory writing for operator-pull adapters, including discovery provenance, provider permissions_used, package PURLs, lifecycle fields, MCP launch metadata redaction, and schema validation
- document discover-only as the default handoff: the adapters write local inventory first, and operators opt into a later agent-bom scan only when they want findings/graph/policy output

Why

This extends the scope-zero discovery story beyond AWS. Teams can use their own ephemeral cloud credentials in their own CI/agent environment, produce canonical inventory, and decide whether that data stops at the file boundary or is handed to agent-bom for scanning.

Validation

- uv run pytest tests/test_operator_pull_aws_adapter.py tests/test_operator_pull_azure_gcp_adapters.py -q
- uv run ruff check examples/operator_pull tests/test_operator_pull_azure_gcp_adapters.py
- uv run mypy examples/operator_pull/inventory_writer.py examples/operator_pull/azure_inventory_adapter.py examples/operator_pull/gcp_inventory_adapter.py
- git diff --check

Refs #2094
