### PR TITLE
feat: add vulnerability intelligence skill

### DIFF
--- a/integrations/openclaw/vulnerability-intel/SKILL.md
+++ b/integrations/openclaw/vulnerability-intel/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: agent-bom-vulnerability-intel
+description: >-
+  Use agent-bom to check package, SBOM, inventory, and agent dependency
+  exposure against OSV, GitHub Security Advisories, NVD, EPSS, and CISA KEV
+  with explicit data-boundary choices. Use when a user asks for CVE lookup,
+  advisory intelligence, exploitability context, fix versions, GHSA/OSV/NVD
+  enrichment, or package vulnerability triage.
+version: 0.82.3
+license: Apache-2.0
+compatibility: >-
+  Requires Python 3.11+ and agent-bom installed from this repository or PyPI.
+  No credentials are required for basic public advisory lookups. Optional
+  NVD_API_KEY and GITHUB_TOKEN values only raise provider rate limits.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/agent-bom
+  source: https://github.com/msaad00/agent-bom
+  pypi: https://pypi.org/project/agent-bom/
+  openclaw:
+    requires:
+      bins:
+        - agent-bom
+      env: []
+      credentials: none
+    credential_policy: "Do not ask users to paste credentials. Optional NVD_API_KEY and GITHUB_TOKEN values may be present in the operator environment for rate limits, but their values must never be displayed, logged, or copied into prompts."
+    optional_env:
+      - NVD_API_KEY
+      - GITHUB_TOKEN
+    optional_bins: []
+    emoji: "\U0001F6E1"
+    homepage: https://github.com/msaad00/agent-bom
+    source: https://github.com/msaad00/agent-bom
+    license: Apache-2.0
+    os:
+      - darwin
+      - linux
+      - windows
+    credential_handling: "No cloud or source-control credentials are needed. Advisory API tokens stay in the operator environment and are used only by agent-bom's existing advisory clients; do not echo or persist token values."
+    data_flow: "Default package checks send package names, versions, ecosystems, PURLs, and CVE/advisory IDs to public advisory databases. Source code, raw config files, secrets, env values, and full scan reports are not sent to advisory providers. Use offline/cache-approved mode when private package names are sensitive."
+    file_reads:
+      - "operator-provided inventory JSON"
+      - "operator-provided CycloneDX/SPDX SBOM files"
+      - "local agent configuration paths only when the operator chooses a local scan"
+    file_writes:
+      - "operator-selected JSON/SARIF/report output path"
+    network_endpoints:
+      - url: "https://api.osv.dev/v1"
+        purpose: "OSV package vulnerability lookup"
+        auth: false
+      - url: "https://api.github.com/advisories"
+        purpose: "GitHub Security Advisories lookup; optional token only raises rate limits"
+        auth: false
+      - url: "https://services.nvd.nist.gov/rest/json/cves/2.0"
+        purpose: "NVD CVSS, CWE, and publication metadata enrichment"
+        auth: false
+      - url: "https://api.first.org/data/v1/epss"
+        purpose: "EPSS exploit probability enrichment"
+        auth: false
+      - url: "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+        purpose: "CISA Known Exploited Vulnerabilities enrichment"
+        auth: false
+    telemetry: false
+    persistence: false
+    privilege_escalation: false
+    always: false
+    autonomous_invocation: restricted
+---
+
+# agent-bom-vulnerability-intel
+
+Use this skill to answer vulnerability-intelligence questions through
+agent-bom's existing scanners and canonical evidence model. Do not create
+one-off OSV, GHSA, NVD, EPSS, or KEV clients in the agent session; route through
+agent-bom so advisory provenance, aliases, severity gates, cache behavior,
+redaction, and output schemas stay consistent.
+
+## Modes
+
+Start with the smallest mode that answers the user:
+
+| Mode | Use When | Data Boundary |
+|------|----------|---------------|
+| `explain-only` | User wants to know what would be queried | No advisory calls |
+| `check-package` | User names one package/version/ecosystem | Only that package identifier is queried |
+| `scan-local` | User wants findings from local agents or a local inventory file | Local parse first; advisory calls use package identifiers only |
+| `offline-review` | Private package names cannot leave the environment | Use local/cache-approved data only; disclose reduced coverage |
+| `export` | User wants PR gate, SARIF, JSON, or audit evidence | Write only to an operator-selected path |
+
+## Guardrails
+
+- Ask before scanning a broad filesystem path or local agent configs.
+- Do not paste or reveal `NVD_API_KEY`, `GITHUB_TOKEN`, package-registry
+  credentials, cloud credentials, or env values.
+- Do not send full source files, lockfiles, config contents, secrets, or scan
+  reports to advisory providers. agent-bom extracts package identifiers first.
+- Treat unknown or unresolvable versions as coverage gaps, not clean results.
+- Preserve advisory provenance. Do not collapse OSV, GHSA, NVD, EPSS, and KEV
+  into a single unlabelled severity.
+- Do not modify dependencies or install fixes unless the user explicitly asks
+  for a remediation workflow.
+
+## Workflows
+
+### Explain the Boundary
+
+When the user asks "what leaves my environment?", answer before running:
+
+```text
+This lookup sends package identifiers (name, version, ecosystem/PURL) and CVE
+IDs to public advisory databases. It does not send source code, raw configs,
+secrets, env values, credentials, or full scan reports. Use offline-review if
+private package names are sensitive.
+```
+
+### Check One Package
+
+```bash
+agent-bom check flask==2.0.0 --ecosystem pypi
+```
+
+Use this for quick triage and fix-version checks. If the package name belongs
+to a private registry or internal project, use `explain-only` first and let the
+operator decide whether the identifier may be queried externally.
+
+### Scan a Canonical Inventory
+
+```bash
+agent-bom agents --inventory inventory.json --format json --output findings.json
+```
+
+Use this after an operator-pull adapter or discovery skill emits canonical
+inventory. The inventory can stop at the file boundary; scanning is an explicit
+operator handoff.
+
+### Export for a PR Gate
+
+```bash
+agent-bom agents --inventory inventory.json --format sarif --output agent-bom.sarif
+```
+
+Use SARIF only when the user wants GitHub code-scanning or AppSec PR-gate
+evidence. Keep JSON for local analysis and audit trails.
+
+### Offline Review
+
+If external advisory calls are not allowed, run with the project's offline or
+cache-approved mode and say clearly that coverage depends on the locally
+available vulnerability database. Do not call a clean offline result equivalent
+to a fresh OSV/GHSA/NVD lookup.
+
+## Output Rules
+
+- Show CVE/GHSA/PYSEC aliases together when available.
+- Include severity source, fix version, EPSS, KEV status, CWE, and advisory
+  source chain when present.
+- Separate "no vulnerabilities found" from "not enough data to evaluate."
+- Keep raw credentials and credential-bearing URLs out of output, logs, prompts,
+  SARIF locations, and exported reports.

--- a/tests/test_vulnerability_intel_skill.py
+++ b/tests/test_vulnerability_intel_skill.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_bom.parsers.skill_audit import audit_skill_result
+from agent_bom.parsers.skills import parse_skill_file
+from agent_bom.parsers.trust_assessment import assess_trust
+
+SKILL_PATH = Path(__file__).resolve().parents[1] / "integrations" / "openclaw" / "vulnerability-intel" / "SKILL.md"
+
+
+def test_vulnerability_intel_skill_declares_guardrailed_advisory_flow() -> None:
+    result = parse_skill_file(SKILL_PATH)
+
+    assert result.metadata is not None
+    assert result.metadata.name == "agent-bom-vulnerability-intel"
+    assert result.metadata.license == "Apache-2.0"
+    assert "agent-bom" in result.metadata.required_bins
+    assert {"darwin", "linux", "windows"}.issubset(set(result.metadata.os_support))
+
+    content = result.raw_content[str(SKILL_PATH)]
+    assert "https://api.osv.dev/v1" in content
+    assert "https://api.github.com/advisories" in content
+    assert "https://services.nvd.nist.gov/rest/json/cves/2.0" in content
+    assert "https://api.first.org/data/v1/epss" in content
+    assert "known_exploited_vulnerabilities.json" in content
+    assert "one-off OSV, GHSA, NVD, EPSS, or KEV clients" in content
+    assert "The inventory can stop at the file boundary" in content
+
+
+def test_vulnerability_intel_skill_makes_external_lookup_and_offline_boundaries_explicit() -> None:
+    result = parse_skill_file(SKILL_PATH)
+    content = result.raw_content[str(SKILL_PATH)]
+
+    assert "No advisory calls" in content
+    assert "Only that package identifier is queried" in content
+    assert "Use local/cache-approved data only" in content
+    assert "Do not send full source files, lockfiles, config contents, secrets" in content
+    assert "advisory providers" in content
+    assert "clean offline result" in content
+    assert "fresh OSV/GHSA/NVD lookup" in content
+
+
+def test_vulnerability_intel_skill_trust_assessment_stays_review_not_blocked() -> None:
+    result = parse_skill_file(SKILL_PATH)
+    audit = audit_skill_result(result)
+    trust = assess_trust(result, audit)
+
+    assert trust.review_verdict in {"trusted", "review"}
+    assert trust.review_verdict != "blocked"
+    assert not any(finding.severity == "critical" for finding in audit.findings)


### PR DESCRIPTION
Summary

- add a focused vulnerability-intelligence skill for OSV, GitHub Security Advisories, NVD, EPSS, and CISA KEV triage through existing agent-bom surfaces
- define explicit modes: explain-only, check-package, scan-local, offline-review, and export
- document advisory data boundaries: package identifiers and CVE/advisory IDs may be queried, while source, secrets, raw configs, credentials, and full reports are not sent to advisory providers
- add parser/audit/trust regression coverage for the skill guardrails

Why

This gives AI-agent users a secure, scoped way to ask vulnerability-intelligence questions without creating one-off advisory clients or bypassing agent-bom's provenance, cache, severity, alias, redaction, and output contracts. It also keeps data handoff explicit: a user can explain, check, scan locally, export, or stay offline based on their boundary.

Validation

- uv run pytest tests/test_vulnerability_intel_skill.py -q
- uv run ruff check tests/test_vulnerability_intel_skill.py
- git diff --check

Refs #2100
