### PR TITLE
ci: stabilize release gate time budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -838,7 +838,7 @@ jobs:
     name: Dogfood GitHub Action
     if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.action == 'true')
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       contents: read
     needs: [changes]

--- a/.github/workflows/post-merge-self-scan.yml
+++ b/.github/workflows/post-merge-self-scan.yml
@@ -23,7 +23,7 @@ jobs:
   self-sast-scan:
     name: Self SAST scan
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: read
       security-events: write  # required: SARIF upload to GitHub Security tab
@@ -89,10 +89,42 @@ jobs:
               fh.write(f"- Low: {low}\n")
           PY
 
-      - name: Print full dep scan summary (all severities, for logs)
+      - name: Print dep scan summary from SARIF (all severities, for logs)
         if: always()
         run: |
-          uv run agent-bom scan --self-scan --quiet 2>&1 | tail -20 || true
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path("sarif/self-dep.sarif")
+          if not path.exists():
+              print("No dependency SARIF was produced.")
+              raise SystemExit(0)
+
+          data = json.loads(path.read_text())
+          findings = []
+          for run in data.get("runs", []):
+              for result in run.get("results", []):
+                  props = result.get("properties", {}) or {}
+                  findings.append(
+                      {
+                          "rule": result.get("ruleId", "unknown"),
+                          "level": result.get("level", "unknown"),
+                          "severity": props.get("security-severity", "unknown"),
+                          "message": (result.get("message") or {}).get("text", ""),
+                      }
+                  )
+
+          print(f"Dependency SARIF findings: {len(findings)}")
+          for item in findings[:20]:
+              message = item["message"].replace("\n", " ")[:160]
+              print(
+                  f"- {item['rule']} level={item['level']} "
+                  f"security-severity={item['severity']} {message}"
+              )
+          if len(findings) > 20:
+              print(f"... {len(findings) - 20} additional findings omitted from log")
+          PY
 
       - name: Run SAST scan on source code (--code)
         id: sast_scan


### PR DESCRIPTION
## Summary

- stop the post-merge self-scan from re-running the full dependency scan just to print a summary; parse the SARIF already produced instead
- raise the post-merge SAST job timeout from 20 to 30 minutes so the source scan and SARIF upload have room after dependency scanning
- raise the GitHub Action dogfood timeout from 10 to 20 minutes so source installs plus skills gates do not cancel the main CI workflow

## Why

The merged 0.83.0 release prep reached main, but post-merge validation did not settle cleanly: CI/CD concluded cancelled because the dogfood action job timed out, and Post-Merge Self-Scan concluded cancelled because the source SAST step ran out of job budget after a duplicate dependency scan. This keeps the release tag from being cut from a clean main.

## Validation

- parsed `.github/workflows/post-merge-self-scan.yml` and `.github/workflows/ci.yml` with PyYAML
- `git diff --check`

