### PR TITLE
chore: close 0.83 release audit blockers

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -296,3 +296,5 @@ jobs:
           _publish_skill "integrations/openclaw/compliance" "agent-bom-compliance" false "agent-bom compliance"
           _publish_skill "integrations/openclaw/registry"   "agent-bom-registry"   false "agent-bom registry"
           _publish_skill "integrations/openclaw/runtime"    "agent-bom-runtime"    false "agent-bom runtime"
+          _publish_skill "integrations/openclaw/discover-aws" "agent-bom-discover-aws" false "agent-bom discover aws"
+          _publish_skill "integrations/openclaw/vulnerability-intel" "agent-bom-vulnerability-intel" false "agent-bom vulnerability intel"

--- a/README.md
+++ b/README.md
@@ -391,7 +391,12 @@ Backend choices stay explicit and optional:
 - `ClickHouse` for analytics and event-scale persistence
 - `Snowflake` for warehouse-native governance and selected backend paths
 
-Run locally, in CI, in Docker, in Kubernetes, as a self-hosted API + dashboard, or as an MCP server — no mandatory hosted control plane, no mandatory cloud vendor.
+Six ways to run agent-bom — locally, in CI, self-hosted, cloud-read-only,
+pushed inventory, or through your AI agent — chosen by your security boundary,
+not ours. agent-bom holds only the credentials your chosen mode requires and
+reaches only the systems your chosen mode permits. The discovery skills work
+standalone too: use them for inventory, and route to agent-bom only when you
+want findings, graph, policy, or exports.
 
 References: [PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md) · [PRODUCT_METRICS.md](docs/PRODUCT_METRICS.md) · [ENTERPRISE.md](docs/ENTERPRISE.md) · [How agent-bom works](site-docs/architecture/how-agent-bom-works.md).
 

--- a/config/schemas/inventory.schema.json
+++ b/config/schemas/inventory.schema.json
@@ -238,7 +238,7 @@
           "items": { "type": "string" }
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
 
     "Agent": {

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -1,6 +1,6 @@
 # MCP Server — Streamable HTTP transport for remote clients.
 #
-# Exposes agent-bom's 32 MCP tools over streamable HTTP so that Smithery, Claude
+# Exposes agent-bom's 36 MCP tools over streamable HTTP so that Smithery, Claude
 # Desktop (remote mode), and any other MCP client can connect via public URL.
 #
 # Build:   docker build -f deploy/docker/Dockerfile.sse -t agent-bom-sse .

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -22,10 +22,12 @@ agent-bom reads only what you explicitly ask it to scan:
 
 ---
 
-## Auto-Discovery Config Paths (exhaustive list)
+## Auto-Discovery Config Paths
 
-**Auto-discovery** reads these specific config paths only. No directory traversal,
-no glob patterns, no recursive walks. If a file does not exist, it is silently skipped.
+**Auto-discovery** reads known client and project paths for supported agent
+surfaces. Most entries are fixed file paths; some supported clients use bounded
+project or profile globs so teams can find the same configs their tools load.
+If a file does not exist, it is silently skipped.
 
 ### Global config files
 
@@ -58,9 +60,13 @@ no glob patterns, no recursive walks. If a file does not exist, it is silently s
 - `compose.yml`
 - `compose.yaml`
 
-**Total**: 27 specific file paths. No other files are ever read during auto-discovery.
+The exact path set changes as supported clients are added. Use
+`agent-bom where --json` or `agent-bom where --dry-run` to preview the paths
+that would be read on a given machine before any scan runs.
 
-Use `--dry-run` to preview exactly which paths would be read before any scan runs.
+Default discovery stays scoped to known agent, MCP, Docker Compose, JetBrains,
+and project config surfaces; arbitrary filesystem crawling is not part of
+auto-discovery.
 
 ---
 
@@ -98,11 +104,11 @@ Credential values are **never** read, stored, logged, or transmitted. Only names
 - **Never write** to any config file, lock file, or project file
 - **Never execute** MCP servers or agent processes
 - **Never store** credential values — only env var _names_ appear in reports
-- **Never transmit** your file contents, project structure, or inventory to external services
+- **Never transmit** your file contents, project structure, or inventory to external services unless you explicitly enable a push, export, or integration destination; pushed payloads are sanitized before transmission
 - **Never cache** any personal data to disk (scan history is opt-in via `--save`)
 - **Never require** authentication tokens or API keys (NVD key is optional for rate limits only)
-- **Never access** arbitrary files — only the 27 enumerated paths above
-- **Never traverse** directories or use glob patterns during auto-discovery
+- **Never access** arbitrary files outside the supported discovery surfaces you choose to scan
+- **Never perform** broad recursive filesystem crawls during auto-discovery
 - **Never run** background processes, daemons, cron jobs, or system services
 
 ---

--- a/docs/images/scan-pipeline-dark.svg
+++ b/docs/images/scan-pipeline-dark.svg
@@ -13,7 +13,7 @@
   <rect width="960" height="420" rx="12" fill="#09090b"/>
 
   <text x="480" y="28" text-anchor="middle" class="title">Scan pipeline</text>
-  <text x="480" y="44" text-anchor="middle" class="subtitle">5 stages, left to right. No source code or credential values leave your machine. External calls are limited to package metadata, version lookups, and CVE enrichment.</text>
+  <text x="480" y="44" text-anchor="middle" class="subtitle">5 operator stages over 6 tracked steps: discover, extract, scan, enrich, analyze, output. Source code and credential values stay local.</text>
 
   <!-- ═══ STEP 1: DISCOVER ═══ -->
   <rect x="20" y="64" width="160" height="304" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>

--- a/docs/images/scan-pipeline-light.svg
+++ b/docs/images/scan-pipeline-light.svg
@@ -13,7 +13,7 @@
   <rect width="960" height="420" rx="12" fill="#ffffff" stroke="#e4e4e7" stroke-width="1"/>
 
   <text x="480" y="28" text-anchor="middle" class="title">Scan pipeline</text>
-  <text x="480" y="44" text-anchor="middle" class="subtitle">5 stages, left to right. No source code or credential values leave your machine. External calls are limited to package metadata, version lookups, and CVE enrichment.</text>
+  <text x="480" y="44" text-anchor="middle" class="subtitle">5 operator stages over 6 tracked steps: discover, extract, scan, enrich, analyze, output. Source code and credential values stay local.</text>
 
   <!-- ═══ STEP 1: DISCOVER ═══ -->
   <rect x="20" y="64" width="160" height="304" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>

--- a/examples/operator_pull/README.md
+++ b/examples/operator_pull/README.md
@@ -48,10 +48,15 @@ agent-bom agents --inventory gcp-inventory.json --format json
 ## Skill-Mediated Handoff
 
 For AI-agent mediated discovery, use the bundled
-`integrations/openclaw/discover-aws/SKILL.md` workflow. It invokes the same
-adapter with `--source aws-skill-invoked --discovery-method skill_invoked_pull`
-so downstream findings preserve that the AWS API call happened inside the
-operator's agent environment, not inside agent-bom.
+`integrations/openclaw/discover-aws/SKILL.md` workflow. The skill is
+discover-only by default: it invokes the same adapter with
+`--source aws-skill-invoked --discovery-method skill_invoked_pull`, writes
+canonical inventory JSON, and stops. Scanning or pushing that inventory into an
+agent-bom workflow is a separate operator-approved handoff.
+
+That keeps the discovery primitive useful on its own. Teams can inspect the
+JSON, archive it, route it to a CMDB, or pass it to `agent-bom agents
+--inventory ...` only when they want findings, graph, policy, and exports.
 
 The adapters keep useful scan context such as package PURLs, cloud metadata,
 and declared read permissions, while recursively redacting sensitive

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -7,6 +7,8 @@ Published skills:
 - `agent-bom-registry`
 - `agent-bom-compliance`
 - `agent-bom-runtime`
+- `agent-bom-discover-aws`
+- `agent-bom-vulnerability-intel`
 
 These are the only skills pushed by release automation. They are:
 - focused enough for individual and team use
@@ -26,3 +28,5 @@ When updating versions for release, update only the published skill frontmatter 
 - [`registry/SKILL.md`](registry/SKILL.md)
 - [`compliance/SKILL.md`](compliance/SKILL.md)
 - [`runtime/SKILL.md`](runtime/SKILL.md)
+- [`discover-aws/SKILL.md`](discover-aws/SKILL.md)
+- [`vulnerability-intel/SKILL.md`](vulnerability-intel/SKILL.md)

--- a/integrations/openclaw/discover-aws/SKILL.md
+++ b/integrations/openclaw/discover-aws/SKILL.md
@@ -5,7 +5,8 @@ description: >-
   environment, emit canonical agent-bom inventory JSON, and scan it without
   giving agent-bom long-lived cloud credentials. Use when a user asks to
   inventory AWS Bedrock, ECS, SageMaker, Lambda, EKS, Step Functions, EC2, or
-  agentic AWS infrastructure for agent-bom.
+  agentic AWS infrastructure as canonical inventory. Passing that inventory
+  to agent-bom is optional and operator-chosen.
 version: 0.83.0
 license: Apache-2.0
 compatibility: >-
@@ -37,7 +38,7 @@ metadata:
       - darwin
       - linux
       - windows
-    credential_handling: "Credentials stay in the operator environment. The skill invokes the AWS SDK locally and writes canonical inventory JSON with source_type=skill_invoked_pull. agent-bom receives sanitized inventory, not raw cloud credentials."
+    credential_handling: "Credentials stay in the operator environment. The skill invokes the AWS SDK locally and writes canonical inventory JSON with source_type=skill_invoked_pull. agent-bom receives sanitized inventory only when the operator explicitly scans or pushes that inventory."
     data_flow: "Operator AWS account -> read-only AWS SDK calls -> canonical inventory JSON -> agent-bom inventory scan. No agent-bom-hosted service is required. Values matching credential patterns are redacted before persistence/export."
     file_reads: []
     file_writes:
@@ -77,7 +78,10 @@ metadata:
 # agent-bom-discover-aws
 
 Use this skill to collect AWS AI and workload inventory from the operator's
-environment and feed it to `agent-bom` as canonical inventory.
+environment as canonical inventory. The skill is discover-only by default:
+write schema-valid JSON to an operator-selected path and stop. Run
+`agent-bom` only when the operator explicitly wants findings, graph, policy,
+or exports from that inventory.
 
 ## Guardrails
 
@@ -91,10 +95,20 @@ environment and feed it to `agent-bom` as canonical inventory.
 - Treat AI-generated prose as non-authoritative; only the schema-validated
   inventory JSON is evidence.
 
+## Modes
+
+| Mode | What happens | Data boundary |
+|------|--------------|---------------|
+| `discover-only` | Emit canonical inventory JSON and stop | No agent-bom scan or API handoff |
+| `scan-local` | Run `agent-bom agents --inventory ...` on the generated file | Local handoff into the scanner |
+| `export` | Write JSON/SARIF or another operator-selected output | Local output only unless the operator routes it elsewhere |
+
+Use `discover-only` unless the operator asks for scan results or an export.
+
 ## Workflow
 
 1. Confirm the AWS account/region/profile and intended services.
-2. Generate inventory with the repository adapter:
+2. Generate inventory with the repository adapter and stop:
 
 ```bash
 python examples/operator_pull/aws_inventory_adapter.py \
@@ -105,13 +119,13 @@ python examples/operator_pull/aws_inventory_adapter.py \
   --output aws-inventory.json
 ```
 
-3. Scan the generated inventory:
+3. If the operator asks for findings, scan the generated inventory locally:
 
 ```bash
 agent-bom agents --inventory aws-inventory.json
 ```
 
-4. For CI or offline review, export JSON:
+4. If the operator asks for an export, write it to an operator-selected path:
 
 ```bash
 agent-bom agents --inventory aws-inventory.json --format json --output agent-bom-aws-findings.json
@@ -149,3 +163,8 @@ The inventory emitted by this skill uses:
 
 If schema validation fails, stop and fix the inventory instead of scanning a
 best-effort or prose summary.
+
+The skill does not push inventory to an API by default. Any push, scan, or
+managed control-plane handoff must be a separate operator-approved handoff
+command with the destination URL, auth method, and retained evidence classes
+made explicit.

--- a/site-docs/architecture/agentic-skills-architecture.md
+++ b/site-docs/architecture/agentic-skills-architecture.md
@@ -8,6 +8,11 @@ The design goal is simple: let teams ask an AI agent to perform security work
 while keeping collection, normalization, scanning, persistence, and export
 inside the same audited `agent-bom` boundaries.
 
+Skills are standalone workflow surfaces, not hidden ingestion. A discovery
+skill may stop after producing canonical inventory JSON. Data enters an
+`agent-bom` scan, API, or control plane only when the operator explicitly
+chooses a handoff mode.
+
 ## Layer Model
 
 ```mermaid
@@ -59,6 +64,19 @@ Skills should map to product capabilities, not to one-off scripts.
 
 ## Data Flow Patterns
 
+### Skill Modes
+
+| Mode | Default? | What happens |
+|------|----------|--------------|
+| `explain-only` | Optional | Describe required permissions, network destinations, and data boundaries before doing work |
+| `discover-only` | Yes for discovery skills | Emit canonical inventory or another schema-valid artifact and stop |
+| `scan-local` | Operator-selected | Hand an artifact to the local CLI for findings, graph, policy, and exports |
+| `push-ingest` | Operator-selected | Send an authenticated, sanitized payload to a configured agent-bom API endpoint |
+| `export` | Operator-selected | Write JSON, SARIF, SBOM, or evidence to an operator-selected path |
+
+No skill should default to pushing data into a control plane or scanning broad
+local/cloud scope. The operator chooses the mode at invocation time.
+
 ### Direct Product Invocation
 
 ```mermaid
@@ -96,8 +114,9 @@ sequenceDiagram
     Skill->>Cloud: Read-only API calls using operator credentials
     Cloud-->>Skill: Asset metadata
     Skill->>Inventory: Emit schema-valid sanitized JSON
-    Skill->>AB: agent-bom agents --inventory inventory.json
-    AB-->>Agent: Findings, graph, and provenance
+    Skill-->>User: inventory.json
+    User->>AB: Optional explicit handoff
+    AB-->>Agent: Findings, graph, and provenance when requested
 ```
 
 Use this when a team wants the AI agent to collect data without giving

--- a/site-docs/architecture/overview.md
+++ b/site-docs/architecture/overview.md
@@ -46,13 +46,13 @@ graph LR
 | Protection | `src/agent_bom/runtime/` | 7-detector anomaly engine |
 | Enforcement | `src/agent_bom/enforcement.py` | Tool poisoning detection |
 | Security | `src/agent_bom/security.py` | Path validation, credential redaction |
-| MCP Server | `src/agent_bom/mcp_server.py` | 32-tool FastMCP server |
+| MCP Server | `src/agent_bom/mcp_server.py` | 36-tool FastMCP server |
 | API | `src/agent_bom/api/` | REST API (FastAPI) |
-| Output | `src/agent_bom/output/` | HTML, Prometheus, Mermaid, SVG, STIX |
+| Output | `src/agent_bom/output/` | JSON, SARIF, CycloneDX, SPDX, OCSF, HTML, Prometheus, Mermaid, SVG |
 
 ## Security boundaries
 
-- All scanning is local-first — zero outbound calls except public vuln databases
+- All scanning is local-first; outbound calls are limited to explicitly enabled enrichment, cloud/read-only discovery, push/export, or operator-configured integrations
 - Config file env var values are always redacted before output
 - Path validation restricts file access to user home directory
 - No telemetry, no analytics, no tracking

--- a/site-docs/deployment/airgapped-image-bundle.md
+++ b/site-docs/deployment/airgapped-image-bundle.md
@@ -12,7 +12,7 @@ From an internet-connected build host:
 
 ```bash
 scripts/release/build-airgap-image-bundle.sh \
-  --version 0.82.0 \
+  --version 0.83.0 \
   --platform linux/amd64 \
   --output-dir dist/airgap
 ```
@@ -33,8 +33,8 @@ machine.
 ## Import On The Disconnected Host
 
 ```bash
-tar -xzf agent-bom-airgap-0.82.0-linux_amd64.tar.gz
-cd agent-bom-airgap-0.82.0-linux_amd64
+tar -xzf agent-bom-airgap-0.83.0-linux_amd64.tar.gz
+cd agent-bom-airgap-0.83.0-linux_amd64
 ./load-images.sh
 ```
 
@@ -43,7 +43,7 @@ The loader verifies archive checksums before running `docker load`.
 ## Push To An Internal Registry
 
 ```bash
-VERSION=0.82.0
+VERSION=0.83.0
 REGISTRY=registry.internal.example.com/security
 
 docker tag "agentbom/agent-bom:${VERSION}" "${REGISTRY}/agent-bom:${VERSION}"
@@ -58,13 +58,13 @@ Then point Helm at the internal registry:
 ```yaml
 image:
   repository: registry.internal.example.com/security/agent-bom
-  tag: "0.82.0"
+  tag: "0.83.0"
 
 controlPlane:
   ui:
     image:
       repository: registry.internal.example.com/security/agent-bom-ui
-      tag: "0.82.0"
+      tag: "0.83.0"
 ```
 
 ## GitHub Actions Bundle Job

--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -342,8 +342,8 @@ through a managed tap instead of direct package upload.
 
 ```bash
 python3 scripts/render_homebrew_formula.py \
-  --version 0.81.0 \
-  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.81.0.tar.gz \
+  --version 0.83.0 \
+  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.83.0.tar.gz \
   --sha256 <release-sha256>
 ```
 

--- a/site-docs/reference/remediate-output.md
+++ b/site-docs/reference/remediate-output.md
@@ -27,7 +27,7 @@ agent-bom remediate -p . --format json --server-group --output plan.json
 
 ```json
 {
-  "version": "0.81.0",
+  "version": "0.83.0",
   "generated_at": "2026-04-21T12:00:00+00:00",
   "remediation_plan": [],
   "summary": {

--- a/site-docs/skills/index.md
+++ b/site-docs/skills/index.md
@@ -15,7 +15,8 @@ for the layered model, subagent delegation rules, and OSV/GHSA guardrails.
 | [CSPM AWS](https://github.com/msaad00/agent-bom/blob/main/docs/skills/cspm-aws-benchmark.md) | `cspm-aws-benchmark.md` | AWS CIS benchmark |
 | [CSPM Azure](https://github.com/msaad00/agent-bom/blob/main/docs/skills/cspm-azure-benchmark.md) | `cspm-azure-benchmark.md` | Azure security benchmark |
 | [CSPM GCP](https://github.com/msaad00/agent-bom/blob/main/docs/skills/cspm-gcp-benchmark.md) | `cspm-gcp-benchmark.md` | GCP security benchmark |
-| [AWS Discovery Skill](https://github.com/msaad00/agent-bom/blob/main/integrations/openclaw/discover-aws/SKILL.md) | `integrations/openclaw/discover-aws/SKILL.md` | Skill-mediated AWS inventory with signed/sanitized agent-bom ingestion |
+| [AWS Discovery Skill](https://github.com/msaad00/agent-bom/blob/main/integrations/openclaw/discover-aws/SKILL.md) | `integrations/openclaw/discover-aws/SKILL.md` | Standalone AWS inventory discovery with optional agent-bom handoff |
+| [Vulnerability Intelligence Skill](https://github.com/msaad00/agent-bom/blob/main/integrations/openclaw/vulnerability-intel/SKILL.md) | `integrations/openclaw/vulnerability-intel/SKILL.md` | Guardrailed OSV/GHSA/NVD/EPSS/KEV advisory lookup through agent-bom evidence paths |
 | [Incident Response](https://github.com/msaad00/agent-bom/blob/main/docs/skills/incident-response.md) | `incident-response.md` | CVE incident investigation |
 | [MCP Server Review](https://github.com/msaad00/agent-bom/blob/main/docs/skills/mcp-server-review.md) | `mcp-server-review.md` | Pre-install MCP server trust assessment |
 | [OWASP LLM Assessment](https://github.com/msaad00/agent-bom/blob/main/docs/skills/owasp-llm-assessment.md) | `owasp-llm-assessment.md` | OWASP LLM Top 10 compliance check |

--- a/src/agent_bom/api/routes/discovery.py
+++ b/src/agent_bom/api/routes/discovery.py
@@ -337,7 +337,11 @@ def _persist_agent_observations(
             credential_env_vars=credential_names,
             security_blocked=bool(getattr(server, "security_blocked", False)),
             security_warnings=sanitize_security_warnings(list(getattr(server, "security_warnings", []) or [])),
-            security_intelligence=list(getattr(server, "security_intelligence", []) or []),
+            security_intelligence=[
+                sanitize_security_intelligence_entry(item)
+                for item in (getattr(server, "security_intelligence", []) or [])
+                if isinstance(item, dict)
+            ],
             observed_via=observed_via,
             observed_scopes=observed_scopes,
             scan_sources=scan_history["scan_sources"],

--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -20,6 +20,7 @@ from agent_bom.api.mcp_observation_store import MCPObservation, merge_observatio
 from agent_bom.api.models import FleetAgentUpdate, PushPayload, StateUpdate
 from agent_bom.api.stores import _get_fleet_store, _get_idempotency_store, _get_mcp_observation_store
 from agent_bom.api.tenant_quota import enforce_fleet_agents_quota, tenant_quota_guard
+from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.security import sanitize_command_args, sanitize_security_warnings, sanitize_text, sanitize_url
 
 router = APIRouter()
@@ -229,7 +230,11 @@ def _persist_payload_observations(tenant_id: str, agent: dict, *, last_discovery
             credential_env_vars=credential_names,
             security_blocked=bool(server.get("security_blocked", False)),
             security_warnings=sanitize_security_warnings(list(server.get("security_warnings", []) or [])),
-            security_intelligence=list(server.get("security_intelligence", []) or []),
+            security_intelligence=[
+                sanitize_security_intelligence_entry(item)
+                for item in (server.get("security_intelligence", []) or [])
+                if isinstance(item, dict)
+            ],
             observed_via=["fleet_sync"],
             observed_scopes=["endpoint"],
             scan_sources=[],

--- a/src/agent_bom/cli/_common.py
+++ b/src/agent_bom/cli/_common.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from rich.console import Console
 
 from agent_bom import __version__
+from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.security import sanitize_env_vars, sanitize_sensitive_payload
 
 logger = logging.getLogger(__name__)
@@ -145,7 +146,11 @@ def _build_agents_from_inventory(inventory_data: dict, source_path: str) -> list
                 mcp_version=server_data.get("mcp_version"),
                 security_blocked=bool(server_data.get("security_blocked", False)),
                 security_warnings=list(server_data.get("security_warnings", []) or []),
-                security_intelligence=list(server_data.get("security_intelligence", []) or []),
+                security_intelligence=[
+                    sanitize_security_intelligence_entry(item)
+                    for item in (server_data.get("security_intelligence", []) or [])
+                    if isinstance(item, dict)
+                ],
                 discovery_provenance=package_provenance,
                 tools=tools,
                 packages=packages,

--- a/src/agent_bom/cloud/__init__.py
+++ b/src/agent_bom/cloud/__init__.py
@@ -93,7 +93,13 @@ _PROVIDER_PERMISSIONS_USED: dict[str, tuple[str, ...]] = {
 
 
 def _provider_capabilities(name: str) -> ExtensionCapabilities:
-    scan_modes = ("runtime_probe",) if name == "ollama" else ("direct_cloud_pull",)
+    scan_modes: tuple[str, ...]
+    if name == "ollama":
+        scan_modes = ("runtime_probe",)
+    elif name in {"aws", "azure", "gcp"}:
+        scan_modes = ("direct_cloud_pull", "operator_pushed_inventory", "skill_invoked_pull")
+    else:
+        scan_modes = ("direct_cloud_pull",)
     return ExtensionCapabilities(
         scan_modes=scan_modes,
         required_scopes=(f"{name}:read",),

--- a/src/agent_bom/mcp_blocklist.py
+++ b/src/agent_bom/mcp_blocklist.py
@@ -17,13 +17,29 @@ from urllib.parse import urlsplit, urlunsplit
 
 from agent_bom.finding import Asset, Finding, FindingSource, FindingType
 from agent_bom.models import Agent, MCPServer
-from agent_bom.security import sanitize_command_args
+from agent_bom.security import sanitize_command_args, sanitize_sensitive_payload, sanitize_text
 
 logger = logging.getLogger(__name__)
 
 _CONFIDENCE_LEVELS = {"confirmed_malicious", "suspicious", "heuristic"}
 _RECOMMENDATIONS = {"block", "warn", "review"}
 _SOURCE_TYPES = {"security_advisory", "vendor_statement", "community_report", "package_registry", "heuristic"}
+_INTELLIGENCE_STRING_FIELDS = {
+    "entry_id",
+    "title",
+    "severity",
+    "confidence",
+    "default_recommendation",
+    "source_type",
+    "source",
+    "match_type",
+    "matched_value",
+    "ecosystem",
+    "package",
+    "affected_versions",
+    "first_seen",
+    "last_verified",
+}
 
 
 @dataclass(frozen=True)
@@ -145,16 +161,36 @@ def _safe_match_value(value: str) -> str:
 
 def sanitize_security_intelligence_entry(entry: dict[str, object]) -> dict[str, object]:
     """Sanitize externally surfaced MCP intelligence evidence."""
-    sanitized = dict(entry)
-    if "matched_value" in sanitized:
-        sanitized["matched_value"] = _safe_match_value(str(sanitized.get("matched_value") or ""))
-    references = sanitized.get("references")
+    sanitized: dict[str, object] = {}
+    for field_name in _INTELLIGENCE_STRING_FIELDS:
+        if field_name not in entry:
+            continue
+        value = entry.get(field_name)
+        if field_name == "matched_value":
+            sanitized[field_name] = _safe_match_value(str(value or ""))
+        else:
+            safe_value = sanitize_sensitive_payload(value, key=field_name, max_str_len=500)
+            sanitized[field_name] = sanitize_text(safe_value, max_len=500) if safe_value is not None else ""
+
+    references = entry.get("references")
     if isinstance(references, list):
         sanitized["references"] = _safe_references(references)
     elif isinstance(references, tuple):
         sanitized["references"] = _safe_references(list(references))
     else:
         sanitized["references"] = []
+
+    actions = entry.get("remediation_actions")
+    if isinstance(actions, (list, tuple)):
+        sanitized["remediation_actions"] = [
+            sanitize_text(sanitize_sensitive_payload(action, key="remediation_action"), max_len=500)
+            for action in actions
+            if action is not None
+        ][:10]
+    elif "remediation_actions" in entry:
+        safe_action = sanitize_sensitive_payload(actions, key="remediation_action")
+        sanitized["remediation_actions"] = [sanitize_text(safe_action, max_len=500)] if safe_action else []
+
     return sanitized
 
 

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from agent_bom.asset_provenance import agent_discovery_provenance, package_discovery_provenance, sanitize_discovery_provenance
 from agent_bom.compliance_utils import effective_blast_radius_tags
+from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
 from agent_bom.security import sanitize_command_args, sanitize_path_label, sanitize_security_warnings, sanitize_text, sanitize_url
 
@@ -565,7 +566,11 @@ def to_json(report: AIBOMReport) -> dict:
                         "credential_env_vars": server.credential_names,
                         "security_blocked": server.security_blocked,
                         "security_warnings": sanitize_security_warnings(server.security_warnings),
-                        "security_intelligence": server.security_intelligence,
+                        "security_intelligence": [
+                            sanitize_security_intelligence_entry(item)
+                            for item in (server.security_intelligence or [])
+                            if isinstance(item, dict)
+                        ],
                         "discovery_sources": server.discovery_sources,
                         "discovery_provenance": sanitize_discovery_provenance(
                             server.discovery_provenance,

--- a/src/agent_bom/security.py
+++ b/src/agent_bom/security.py
@@ -400,6 +400,29 @@ def _looks_like_path_value(value: str) -> bool:
     return value.startswith("/") or value.startswith("~/") or bool(re.match(r"^[A-Za-z]:[\\/]", value))
 
 
+_CLOUD_IDENTITY_KEYS = {
+    "account_id",
+    "arn",
+    "cloud_principal",
+    "endpoint_id",
+    "location",
+    "principal_arn",
+    "project_id",
+    "region",
+    "resource_group",
+    "resource_id",
+    "resource_name",
+    "service",
+    "subscription_id",
+    "tenant_id",
+}
+
+
+def _key_looks_like_cloud_identity(key: object) -> bool:
+    key_text = str(key or "").strip().lower().replace("-", "_")
+    return key_text in _CLOUD_IDENTITY_KEYS or key_text.endswith("_arn") or key_text.endswith("_resource_id")
+
+
 def sanitize_path_label(value: object) -> str:
     """Return a non-revealing label for local filesystem paths."""
     text = sanitize_log_label(value, max_len=1000)
@@ -421,6 +444,10 @@ def sanitize_sensitive_payload(value: object, *, key: object | None = None, max_
             return "***REDACTED***"
         if key is not None and _key_looks_like_url(key):
             return sanitize_url(value)
+        if key is not None and _key_looks_like_cloud_identity(key):
+            if _looks_sensitive_value(value):
+                return "***REDACTED***"
+            return sanitize_text(value, max_len=max_str_len)
         if "://" in value:
             return sanitize_text(value, max_len=max_str_len)
         if key is not None and _key_looks_like_path(key) and _looks_like_path_value(value):

--- a/tests/test_aws_discovery_skill.py
+++ b/tests/test_aws_discovery_skill.py
@@ -24,6 +24,9 @@ def test_aws_discovery_skill_declares_guardrailed_skill_invoked_inventory_flow()
     assert "examples/operator_pull/aws_inventory_adapter.py" in content
     assert "Do not ask users to paste access keys" in content
     assert "Do not modify AWS resources" in content
+    assert "discover-only by default" in content
+    assert "The skill does not push inventory to an API by default" in content
+    assert "separate operator-approved handoff" in content
     assert "agent-bom agents --inventory aws-inventory.json" in content
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3518,7 +3518,7 @@ def test_openclaw_registry_skill_minimal_surface():
 
 
 def test_openclaw_skills_all_tools_covered():
-    """Core 32 MCP tools should be covered in the consolidated skill."""
+    """Core MCP tools should be covered in the consolidated skill."""
     from pathlib import Path
 
     p = Path(__file__).parent.parent / "integrations" / "openclaw" / "SKILL.md"

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -244,6 +244,8 @@ def test_publish_registries_workflow_requires_public_smithery_surface_and_curate
     assert "integrations/openclaw/compliance" in workflow
     assert "integrations/openclaw/registry" in workflow
     assert "integrations/openclaw/runtime" in workflow
+    assert "integrations/openclaw/discover-aws" in workflow
+    assert "integrations/openclaw/vulnerability-intel" in workflow
     assert '_publish_skill "integrations/openclaw" "agent-bom"' not in workflow
 
 

--- a/tests/test_discovery_provider_contract.py
+++ b/tests/test_discovery_provider_contract.py
@@ -34,14 +34,21 @@ def test_provider_contracts_describe_builtin_boundaries_without_loading_sdks() -
     assert payload["provider_count"] >= 12
     assert "aws" in providers
     assert providers["aws"]["module"] == "agent_bom.cloud.aws"
-    assert providers["aws"]["capabilities"]["scan_modes"] == ["direct_cloud_pull"]
+    assert providers["aws"]["capabilities"]["scan_modes"] == [
+        "direct_cloud_pull",
+        "operator_pushed_inventory",
+        "skill_invoked_pull",
+    ]
     assert providers["aws"]["capabilities"]["required_scopes"] == ["aws:read"]
     assert "sts:GetCallerIdentity" in providers["aws"]["capabilities"]["permissions_used"]
     assert "bedrock:ListAgents" in providers["aws"]["capabilities"]["permissions_used"]
     assert providers["aws"]["capabilities"]["network_destinations"] == ["aws"]
     assert providers["aws"]["capabilities"]["writes"] is False
     assert providers["aws"]["trust_contract"]["read_only"] is True
+    assert providers["aws"]["trust_contract"]["supports_scope_zero"] is True
     assert providers["aws"]["trust_contract"]["redaction_status"] == "central_sanitizer_applied"
+    assert providers["azure"]["trust_contract"]["supports_scope_zero"] is True
+    assert providers["gcp"]["trust_contract"]["supports_scope_zero"] is True
     assert providers["ollama"]["capabilities"]["scan_modes"] == ["runtime_probe"]
     assert providers["ollama"]["capabilities"]["network_access"] is False
 

--- a/tests/test_mcp_blocklist.py
+++ b/tests/test_mcp_blocklist.py
@@ -1,7 +1,13 @@
 import json
 from pathlib import Path
 
-from agent_bom.mcp_blocklist import blocklist_findings_for_agents, flag_blocklisted_mcp_servers, load_mcp_blocklist, match_mcp_server
+from agent_bom.mcp_blocklist import (
+    blocklist_findings_for_agents,
+    flag_blocklisted_mcp_servers,
+    load_mcp_blocklist,
+    match_mcp_server,
+    sanitize_security_intelligence_entry,
+)
 from agent_bom.models import Agent, AgentType, AIBOMReport, MCPServer, Package
 from agent_bom.output import to_json
 from agent_bom.output.sarif import to_sarif
@@ -162,6 +168,31 @@ def test_match_values_are_redacted_before_output() -> None:
         assert raw_token not in payload
         assert "user:pass" not in payload
         assert "token=secret" not in payload
+
+
+def test_security_intelligence_sanitizer_drops_unknown_secret_fields() -> None:
+    raw_token = "ghp_" + "B" * 36
+
+    safe = sanitize_security_intelligence_entry(
+        {
+            "entry_id": "intel-a",
+            "title": "Suspicious MCP",
+            "matched_value": f"npx suspicious --token {raw_token}",
+            "source": "community",
+            "references": ["https://example.com/advisory#fragment", "javascript:alert(1)"],
+            "remediation_actions": [f"remove token={raw_token}", "disable the server"],
+            "debug_token": raw_token,
+            "nested": {"authorization": raw_token},
+        }
+    )
+
+    serialized = json.dumps(safe)
+    assert "debug_token" not in safe
+    assert "nested" not in safe
+    assert raw_token not in serialized
+    assert safe["matched_value"] == "npx suspicious --token <redacted>"
+    assert safe["references"] == ["https://example.com/advisory"]
+    assert safe["remediation_actions"][0] == "***REDACTED***"
 
 
 def test_sarif_output_includes_mcp_blocklist_findings() -> None:

--- a/tests/test_operator_pull_azure_gcp_adapters.py
+++ b/tests/test_operator_pull_azure_gcp_adapters.py
@@ -33,7 +33,10 @@ def test_azure_operator_pull_adapter_cli_writes_sanitized_inventory(monkeypatch,
                 "provider": "azure",
                 "service": "machine-learning",
                 "resource_type": "endpoint",
-                "resource_id": "endpoint-1",
+                "resource_id": (
+                    "/subscriptions/sub-123/resourceGroups/rg/providers/"
+                    "Microsoft.MachineLearningServices/workspaces/ws/onlineEndpoints/endpoint-1"
+                ),
                 "scope": {"subscription_id": "sub-123", "api_token": "should-not-survive"},
             }
         },
@@ -77,6 +80,8 @@ def test_azure_operator_pull_adapter_cli_writes_sanitized_inventory(monkeypatch,
     assert loaded["source"] == "azure-operator-pull"
     assert loaded["discovery_provenance"]["source_type"] == "operator_pushed_inventory"
     assert loaded["discovery_provenance"]["observed_via"] == ["operator_pushed_inventory", "azure_sdk"]
+    assert loaded["agents"][0]["metadata"]["cloud_origin"]["resource_id"].startswith("/subscriptions/sub-123/")
+    assert loaded["agents"][0]["discovery_provenance"]["resource_id"].startswith("/subscriptions/sub-123/")
     assert loaded["agents"][0]["metadata"]["cloud_origin"]["scope"]["api_token"] == "***REDACTED***"
     assert loaded["agents"][0]["metadata"]["permissions_used"]
     assert loaded["agents"][0]["mcp_servers"][0]["env"]["AZURE_OPENAI_API_KEY"] == "***REDACTED***"


### PR DESCRIPTION
## Summary

- sanitize MCP security intelligence at all pushed-inventory, fleet/API persistence, and JSON export boundaries with a strict schema/field allowlist
- preserve cloud resource identities through redaction so Azure/GCP/AWS operator-pull provenance remains useful while credential-like values stay redacted
- expose scope-zero scan modes for AWS/Azure/GCP provider contracts and keep the new discovery/vulnerability skills in the curated ClawHub publish set
- align README, trust docs, architecture docs, scan-pipeline visuals, version examples, and skill docs with the current 0.83 product surface

## Why

This closes the release audit blockers found after the 0.83 release prep merge. The release claims around standalone skills, optional agent-bom handoff, scope-zero ingestion, sanitized evidence, provider contracts, and public docs now match the implementation before tagging.

## Validation

- uv run pytest tests/test_mcp_blocklist.py tests/test_operator_pull_azure_gcp_adapters.py tests/test_discovery_provider_contract.py tests/test_api_agent_detail.py tests/test_mcp_observation_store.py tests/test_aws_discovery_skill.py tests/test_vulnerability_intel_skill.py tests/test_operator_pull_aws_adapter.py tests/test_deployment.py::test_publish_registries_workflow_requires_public_smithery_surface_and_curated_clawhub_set -q
- uv run ruff check touched Python files and tests
- uv run mypy touched source files
- python -m json.tool config/schemas/inventory.schema.json
- python scripts/check_release_consistency.py
- python scripts/bump-version.py 0.83.0 --check
- python scripts/check_product_surface_contract.py
- uv run python scripts/generate_v1_schemas.py --check
- python sdks/shared/generate-patterns.py --check
- uv run mkdocs build --strict --site-dir /tmp/agent-bom-release-audit-site
- git diff --check