### PR TITLE
fix: polish release blocker UX

### DIFF
--- a/examples/operator_pull/adapter_bootstrap.py
+++ b/examples/operator_pull/adapter_bootstrap.py
@@ -1,0 +1,28 @@
+"""Bootstrap helpers for operator-pull adapter scripts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def add_repo_src_to_path(script_file: str) -> None:
+    """Allow adapters to run from a source checkout before package install."""
+    script_path = Path(script_file).resolve()
+    adapter_dir = script_path.parent
+    repo_src = script_path.parents[2] / "src"
+    for path in (adapter_dir, repo_src):
+        if path.exists() and str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+
+
+def exit_for_missing_agent_bom(exc: ModuleNotFoundError) -> None:
+    """Convert missing agent-bom imports into an actionable non-zero CLI error."""
+    missing = exc.name or ""
+    if missing == "agent_bom" or missing.startswith("agent_bom."):
+        sys.stderr.write(
+            "error: agent-bom is required to run this adapter. "
+            "Run it from a source checkout or install with `pip install agent-bom`.\n"
+        )
+        raise SystemExit(2) from None
+    raise exc

--- a/examples/operator_pull/aws_inventory_adapter.py
+++ b/examples/operator_pull/aws_inventory_adapter.py
@@ -15,20 +15,31 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from agent_bom.asset_provenance import sanitize_discovery_provenance
-from agent_bom.cloud import provider_contracts
-from agent_bom.cloud.aws import discover
-from agent_bom.inventory import _validate_inventory_payload
-from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
-from agent_bom.models import Agent, MCPServer, MCPTool, Package
-from agent_bom.security import (
-    sanitize_command_args,
-    sanitize_env_vars,
-    sanitize_security_warnings,
-    sanitize_sensitive_payload,
-    sanitize_text,
-    sanitize_url,
-)
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from adapter_bootstrap import add_repo_src_to_path, exit_for_missing_agent_bom  # noqa: E402
+
+add_repo_src_to_path(__file__)
+
+try:
+    from agent_bom.asset_provenance import sanitize_discovery_provenance
+    from agent_bom.cloud import provider_contracts
+    from agent_bom.cloud.aws import discover
+    from agent_bom.inventory import _validate_inventory_payload
+    from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
+    from agent_bom.models import Agent, MCPServer, MCPTool, Package
+    from agent_bom.security import (
+        sanitize_command_args,
+        sanitize_env_vars,
+        sanitize_error,
+        sanitize_security_warnings,
+        sanitize_sensitive_payload,
+        sanitize_text,
+        sanitize_url,
+    )
+except ModuleNotFoundError as exc:
+    exit_for_missing_agent_bom(exc)
 
 _SCHEMA_AGENT_TYPES = frozenset({"claude-desktop", "claude-code", "cursor", "windsurf", "cline", "custom"})
 _SCHEMA_TRANSPORTS = frozenset({"stdio", "sse", "streamable-http"})
@@ -187,7 +198,7 @@ def _tool_to_inventory(tool: MCPTool) -> dict[str, Any]:
 
 
 def _package_to_inventory(package: Package, *, inherited_provenance: dict[str, Any] | None = None) -> dict[str, Any]:
-    payload = {
+    payload: dict[str, Any] = {
         "name": sanitize_text(package.name, max_len=300),
         "version": sanitize_text(package.version or "unknown", max_len=120) or "unknown",
     }
@@ -262,18 +273,23 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    agents, warnings = discover(
-        region=args.region,
-        profile=args.profile,
-        include_ecs=args.include_ecs,
-        include_sagemaker=args.include_sagemaker,
-        include_lambda=args.include_lambda,
-        include_eks=args.include_eks,
-        include_step_functions=args.include_step_functions,
-        include_ec2=args.include_ec2,
-        ec2_tag_filter=_parse_key_value(args.ec2_tag),
-        tag_filter=_parse_key_value(args.tag),
-    )
+    try:
+        agents, warnings = discover(
+            region=args.region,
+            profile=args.profile,
+            include_ecs=args.include_ecs,
+            include_sagemaker=args.include_sagemaker,
+            include_lambda=args.include_lambda,
+            include_eks=args.include_eks,
+            include_step_functions=args.include_step_functions,
+            include_ec2=args.include_ec2,
+            ec2_tag_filter=_parse_key_value(args.ec2_tag),
+            tag_filter=_parse_key_value(args.tag),
+        )
+    except Exception as exc:  # noqa: BLE001
+        safe_error = sanitize_error(exc) or exc.__class__.__name__
+        sys.stderr.write(f"error: AWS discovery failed: {safe_error}\n")
+        return 2
     for warning in sanitize_security_warnings(warnings):
         sys.stderr.write(f"warning: {warning}\n")
 

--- a/examples/operator_pull/azure_inventory_adapter.py
+++ b/examples/operator_pull/azure_inventory_adapter.py
@@ -11,10 +11,17 @@ from pathlib import Path
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from adapter_bootstrap import add_repo_src_to_path, exit_for_missing_agent_bom  # noqa: E402
+
+add_repo_src_to_path(__file__)
+
 from inventory_writer import DISCOVERY_METHODS, build_inventory_payload  # noqa: E402
 
-from agent_bom.cloud.azure import discover  # noqa: E402
-from agent_bom.security import sanitize_security_warnings  # noqa: E402
+try:
+    from agent_bom.cloud.azure import discover  # noqa: E402
+    from agent_bom.security import sanitize_error, sanitize_security_warnings  # noqa: E402
+except ModuleNotFoundError as exc:
+    exit_for_missing_agent_bom(exc)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -35,10 +42,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    agents, warnings = discover(
-        subscription_id=args.subscription_id,
-        resource_group=args.resource_group,
-    )
+    try:
+        agents, warnings = discover(
+            subscription_id=args.subscription_id,
+            resource_group=args.resource_group,
+        )
+    except Exception as exc:  # noqa: BLE001
+        safe_error = sanitize_error(exc) or exc.__class__.__name__
+        sys.stderr.write(f"error: Azure discovery failed: {safe_error}\n")
+        return 2
     for warning in sanitize_security_warnings(warnings):
         sys.stderr.write(f"warning: {warning}\n")
 

--- a/examples/operator_pull/gcp_inventory_adapter.py
+++ b/examples/operator_pull/gcp_inventory_adapter.py
@@ -11,10 +11,17 @@ from pathlib import Path
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from adapter_bootstrap import add_repo_src_to_path, exit_for_missing_agent_bom  # noqa: E402
+
+add_repo_src_to_path(__file__)
+
 from inventory_writer import DISCOVERY_METHODS, build_inventory_payload  # noqa: E402
 
-from agent_bom.cloud.gcp import discover  # noqa: E402
-from agent_bom.security import sanitize_security_warnings  # noqa: E402
+try:
+    from agent_bom.cloud.gcp import discover  # noqa: E402
+    from agent_bom.security import sanitize_error, sanitize_security_warnings  # noqa: E402
+except ModuleNotFoundError as exc:
+    exit_for_missing_agent_bom(exc)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -35,10 +42,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    agents, warnings = discover(
-        project_id=args.project_id,
-        region=args.region,
-    )
+    try:
+        agents, warnings = discover(
+            project_id=args.project_id,
+            region=args.region,
+        )
+    except Exception as exc:  # noqa: BLE001
+        safe_error = sanitize_error(exc) or exc.__class__.__name__
+        sys.stderr.write(f"error: GCP discovery failed: {safe_error}\n")
+        return 2
     for warning in sanitize_security_warnings(warnings):
         sys.stderr.write(f"warning: {warning}\n")
 

--- a/examples/operator_pull/inventory_writer.py
+++ b/examples/operator_pull/inventory_writer.py
@@ -170,7 +170,7 @@ def _tool_to_inventory(tool: MCPTool) -> dict[str, Any]:
 
 
 def _package_to_inventory(package: Package, *, inherited_provenance: dict[str, Any] | None = None) -> dict[str, Any]:
-    payload = {
+    payload: dict[str, Any] = {
         "name": sanitize_text(package.name, max_len=300),
         "version": sanitize_text(package.version or "unknown", max_len=120) or "unknown",
     }

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -121,11 +121,75 @@ def _expand_docker_mcp_packages(
     return [pkg for pkg in discovered if str(getattr(pkg, "ecosystem", "")).lower() != "docker"] + expanded, failures
 
 
+def _exit_incomplete_scan_with_partial_summary(
+    ctx: ScanContext,
+    *,
+    agents: list[Any],
+    exc: IncompleteScanError,
+    output: Any,
+    output_format: str,
+    no_tree: bool,
+    quiet: bool,
+    no_color: bool,
+    open_report: bool,
+    compliance_export: Any,
+    mermaid_mode: str,
+    push_gateway: Any,
+    otel_endpoint: Any,
+    baseline: Any,
+    delta_mode: bool,
+    verbose: bool,
+    exclude_unfixable: bool,
+    fixable_only: bool,
+    posture: bool,
+) -> None:
+    """Render discovered inventory before exiting an incomplete scan."""
+    from agent_bom.mcp_blocklist import blocklist_findings_for_agents
+
+    ctx.blast_radii = []
+    ctx.report = AIBOMReport(
+        agents=agents,
+        blast_radii=[],
+        findings=blocklist_findings_for_agents(agents),
+        scan_sources=["agent_discovery"],
+    )
+    ctx.con.print(f"  [yellow]⚠[/yellow] {exc}")
+    if output_format == "console" and not output and not quiet:
+        render_output(
+            ctx,
+            output=output,
+            output_format=output_format,
+            no_tree=no_tree,
+            quiet=quiet,
+            no_color=no_color,
+            open_report=open_report,
+            compliance_export=compliance_export,
+            mermaid_mode=mermaid_mode,
+            push_gateway=push_gateway,
+            otel_endpoint=otel_endpoint,
+            baseline=baseline,
+            delta_mode=delta_mode,
+            verbose=verbose,
+            exclude_unfixable=exclude_unfixable,
+            fixable_only=fixable_only,
+        )
+        if posture:
+            render_posture_summary(agents, [])
+    raise SystemExit(2)
+
+
 def _reset_offline_mode() -> None:
     """Restore process-global network mode after an offline CLI invocation."""
     from agent_bom.scanners import set_offline_mode
 
     set_offline_mode(False)
+
+
+def _output_format_was_explicit() -> bool:
+    ctx = click.get_current_context(silent=True)
+    if ctx is None:
+        return False
+    return ctx.get_parameter_source("output_format") is click.core.ParameterSource.COMMANDLINE
 
 
 @click.command()
@@ -408,6 +472,13 @@ def scan(
     con = _make_console(quiet=quiet or is_stdout, output_format=output_format, no_color=no_color)
     runtime_console = Console(stderr=True, quiet=quiet or is_stdout, no_color=no_color)
     _sync_runtime_consoles(runtime_console)
+
+    if output and output != "-" and output_format == "console" and _output_format_was_explicit():
+        click.echo(
+            "Error: --format console renders to the terminal only; use --format plain, markdown, or json with --output.",
+            err=True,
+        )
+        raise SystemExit(2)
 
     # Also set the output module's console so print_summary etc. route correctly
     import agent_bom.output as _out
@@ -1097,8 +1168,27 @@ def scan(
                             offline=offline,
                         )
                     except IncompleteScanError as exc:
-                        con.print(f"  [yellow]⚠[/yellow] {exc}")
-                        sys.exit(2)
+                        _exit_incomplete_scan_with_partial_summary(
+                            ctx,
+                            agents=agents,
+                            exc=exc,
+                            output=output,
+                            output_format=output_format,
+                            no_tree=no_tree,
+                            quiet=quiet,
+                            no_color=no_color,
+                            open_report=open_report,
+                            compliance_export=compliance_export,
+                            mermaid_mode=mermaid_mode,
+                            push_gateway=push_gateway,
+                            otel_endpoint=otel_endpoint,
+                            baseline=baseline,
+                            delta_mode=delta_mode,
+                            verbose=verbose,
+                            exclude_unfixable=exclude_unfixable,
+                            fixable_only=fixable_only,
+                            posture=posture,
+                        )
                     progress.update(scan_task, completed=3, phase="building blast radius analysis")
                     progress.update(scan_task, completed=4, phase="done")
             else:
@@ -1113,8 +1203,27 @@ def scan(
                         offline=offline,
                     )
                 except IncompleteScanError as exc:
-                    con.print(f"  [yellow]⚠[/yellow] {exc}")
-                    sys.exit(2)
+                    _exit_incomplete_scan_with_partial_summary(
+                        ctx,
+                        agents=agents,
+                        exc=exc,
+                        output=output,
+                        output_format=output_format,
+                        no_tree=no_tree,
+                        quiet=quiet,
+                        no_color=no_color,
+                        open_report=open_report,
+                        compliance_export=compliance_export,
+                        mermaid_mode=mermaid_mode,
+                        push_gateway=push_gateway,
+                        otel_endpoint=otel_endpoint,
+                        baseline=baseline,
+                        delta_mode=delta_mode,
+                        verbose=verbose,
+                        exclude_unfixable=exclude_unfixable,
+                        fixable_only=fixable_only,
+                        posture=posture,
+                    )
             scan_warnings = consume_scan_warnings()
             if scan_warnings:
                 con.print(f"  [yellow]⚠[/yellow] Scan completed with {len(scan_warnings)} warning(s); results may be incomplete.")

--- a/src/agent_bom/security.py
+++ b/src/agent_bom/security.py
@@ -731,6 +731,12 @@ def sanitize_error(exc: Exception | str, generic: bool = False) -> str:
     msg = str(exc)
     # Strip URLs first (before path regex matches the path portion)
     msg = re.sub(r"https?://[^\s\"']+", "<url>", msg)
+    # Strip inline credential assignments commonly included in SDK error strings.
+    msg = re.sub(
+        r"(?i)\b(token|secret|password|passwd|api[_-]?key|access[_-]?key|session[_-]?token)\s*=\s*[^\s,;]+",
+        lambda match: f"{match.group(1)}=<redacted>",
+        msg,
+    )
     # Strip absolute file paths
     msg = re.sub(r"(/[^\s:\"']+)+", "<path>", msg)
     return msg[:200] if len(msg) > 200 else msg

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -128,6 +128,16 @@ def test_scan_format_console_no_output_file():
     assert result.exit_code == 0
 
 
+def test_scan_format_console_with_output_gives_actionable_error(tmp_path):
+    """--format console is terminal-only; file output should suggest useful formats."""
+    out = tmp_path / "abom-out.console"
+    with patch("agent_bom.cli.agents.discover_all", return_value=[]):
+        result = _run(["scan", "--format", "console", "--output", str(out), "--no-scan"])
+    assert result.exit_code == 2
+    assert "console renders to the terminal only" in result.output
+    assert "--format plain" in result.output
+
+
 def test_scan_quiet_flag():
     with patch("agent_bom.cli.agents.discover_all", return_value=[]):
         result = _run(["scan", "--quiet", "--no-scan"])
@@ -339,6 +349,8 @@ def test_scan_incomplete_offline_scan_exits_two(monkeypatch):
 
     assert result.exit_code == 2
     assert "populated local vulnerability DB" in result.output
+    assert "SECURITY POSTURE" in result.output
+    assert "Agents" in result.output
 
 
 def test_scan_expands_local_docker_mcp_image():

--- a/tests/test_operator_pull_aws_adapter.py
+++ b/tests/test_operator_pull_aws_adapter.py
@@ -102,6 +102,23 @@ def test_aws_operator_pull_adapter_cli_writes_inventory(monkeypatch, tmp_path: P
     assert loaded["discovery_provenance"]["source_type"] == "operator_pushed_inventory"
 
 
+def test_aws_operator_pull_adapter_cli_returns_nonzero_without_traceback(monkeypatch, tmp_path: Path, capsys) -> None:
+    adapter = _load_adapter()
+
+    def _fail_discover(**_kwargs):
+        raise RuntimeError("credential token=secret failed")
+
+    monkeypatch.setattr(adapter, "discover", _fail_discover)
+
+    rc = adapter.main(["--region", "us-east-1", "--no-include-ecs", "--output", str(tmp_path / "inventory.json")])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "error: AWS discovery failed:" in captured.err
+    assert "Traceback" not in captured.err
+    assert "secret" not in captured.err
+
+
 def test_aws_operator_pull_adapter_cli_marks_skill_invoked_inventory(monkeypatch, tmp_path: Path) -> None:
     adapter = _load_adapter()
     monkeypatch.setattr(


### PR DESCRIPTION
Summary

- render a partial offline scan summary before exiting 2 so demos show discovered agents/posture instead of looking frozen
- make `--format console --output ...` fail early with an explicit terminal-only message and suggested file formats
- let operator-pull adapters run from a source checkout, convert missing `agent_bom` imports into actionable exit 2 errors, and sanitize cloud discovery exception text before stderr
- keep the provider contract scope-zero finding out of this PR because it was already closed by #2105 and is covered by the provider contract tests

Why

This closes the three release-audit P1s before tagging v0.83.0: offline-mode UX, standalone adapter failure handling, and the confusing console-to-file error. The changes are intentionally small and keep the release trust boundary intact: adapters do not print tracebacks or raw credential-shaped error values, and console-only output is rejected before any early-return path can bypass the guard.

Validation

- `uv run pytest tests/test_cli_scan.py::test_scan_incomplete_offline_scan_exits_two tests/test_cli_scan.py::test_scan_format_console_with_output_gives_actionable_error tests/test_operator_pull_aws_adapter.py tests/test_operator_pull_azure_gcp_adapters.py tests/test_discovery_provider_contract.py -q`
- `uv run ruff check examples/operator_pull/adapter_bootstrap.py examples/operator_pull/aws_inventory_adapter.py examples/operator_pull/azure_inventory_adapter.py examples/operator_pull/gcp_inventory_adapter.py examples/operator_pull/inventory_writer.py src/agent_bom/security.py src/agent_bom/cli/agents/__init__.py src/agent_bom/cli/agents/_output.py tests/test_cli_scan.py tests/test_operator_pull_aws_adapter.py`
- `uv run mypy examples/operator_pull/adapter_bootstrap.py examples/operator_pull/aws_inventory_adapter.py examples/operator_pull/azure_inventory_adapter.py examples/operator_pull/gcp_inventory_adapter.py examples/operator_pull/inventory_writer.py src/agent_bom/security.py src/agent_bom/cli/agents/__init__.py src/agent_bom/cli/agents/_output.py`
- `python -m py_compile examples/operator_pull/adapter_bootstrap.py examples/operator_pull/aws_inventory_adapter.py examples/operator_pull/azure_inventory_adapter.py examples/operator_pull/gcp_inventory_adapter.py examples/operator_pull/inventory_writer.py`
- `git diff --check`
