### PR TITLE
ci: bound post-merge SAST self scan

### DIFF
--- a/.github/workflows/post-merge-self-scan.yml
+++ b/.github/workflows/post-merge-self-scan.yml
@@ -207,19 +207,19 @@ jobs:
       - name: Install agent-bom (from source)
         run: uv sync --extra dev
 
-      - name: Run SAST scan on source code (--code)
+      - name: Run bounded source code analysis
         id: sast_scan
-        timeout-minutes: 40
+        timeout-minutes: 15
         run: |
           set +e
           mkdir -p sarif
-          uv run agent-bom scan \
-            --code src/agent_bom \
-            --sast-config p/python \
-            --format sarif \
-            -o sarif/self-sast.sarif \
-            --quiet
-          echo "sast_exit=$?" >> "$GITHUB_OUTPUT"
+          uv run agent-bom code src/agent_bom --format json -o sarif/self-sast.json --quiet
+          scan_exit=$?
+          if [ "$scan_exit" -eq 0 ]; then
+            uv run python scripts/code_scan_json_to_sarif.py sarif/self-sast.json sarif/self-sast.sarif
+          fi
+          echo "sast_exit=$scan_exit" >> "$GITHUB_OUTPUT"
+          exit "$scan_exit"
 
       - name: Upload SAST SARIF
         if: always() && hashFiles('sarif/self-sast.sarif') != ''

--- a/scripts/code_scan_json_to_sarif.py
+++ b/scripts/code_scan_json_to_sarif.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Convert ``agent-bom code --format json`` output to SARIF."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+_LEVELS = {
+    "critical": "error",
+    "high": "error",
+    "medium": "warning",
+    "low": "note",
+    "info": "none",
+}
+_SECURITY_SEVERITY = {
+    "critical": "9.0",
+    "high": "7.0",
+    "medium": "4.0",
+    "low": "1.0",
+    "info": "0.0",
+}
+_CREDENTIAL_ASSIGNMENT = re.compile(
+    r"(?i)\b(token|secret|password|passwd|api[_-]?key|access[_-]?key|session[_-]?token)\s*=\s*[^\s,;]+"
+)
+
+
+def _agent_bom_version() -> str:
+    try:
+        return importlib.metadata.version("agent-bom")
+    except importlib.metadata.PackageNotFoundError:
+        return "0.0.0"
+
+
+def _safe_text(value: object, *, max_len: int = 500) -> str:
+    text = str(value or "").replace("\x00", "").strip()
+    text = _CREDENTIAL_ASSIGNMENT.sub(lambda match: f"{match.group(1)}=<redacted>", text)
+    return text[:max_len]
+
+
+def _relative_path(value: object) -> str:
+    text = _safe_text(value, max_len=300).replace("\\", "/").lstrip("/")
+    return text or "unknown"
+
+
+def _line_number(value: object) -> int:
+    try:
+        line = int(str(value or 1))
+    except (TypeError, ValueError):
+        return 1
+    return max(line, 1)
+
+
+def _add_rule(rules: dict[str, dict[str, Any]], rule_id: str, title: str, severity: str, category: str) -> None:
+    if rule_id in rules:
+        return
+    sev = severity.lower()
+    rules[rule_id] = {
+        "id": rule_id,
+        "shortDescription": {"text": _safe_text(title, max_len=120) or rule_id},
+        "defaultConfiguration": {"level": _LEVELS.get(sev, "warning")},
+        "properties": {
+            "security-severity": _SECURITY_SEVERITY.get(sev, "4.0"),
+            "category": _safe_text(category, max_len=80),
+        },
+    }
+
+
+def _result(rule_id: str, level: str, message: str, file_path: str, line: int, fingerprint_input: str) -> dict[str, Any]:
+    return {
+        "ruleId": rule_id,
+        "level": level,
+        "kind": "fail" if level in {"error", "warning"} else "informational",
+        "message": {"text": _safe_text(message, max_len=1000)},
+        "fingerprints": {"agent-bom-code/v1": hashlib.sha256(fingerprint_input.encode("utf-8")).hexdigest()},
+        "locations": [
+            {
+                "physicalLocation": {
+                    "artifactLocation": {"uri": file_path, "uriBaseId": "%SRCROOT%"},
+                    "region": {"startLine": line, "startColumn": 1},
+                }
+            }
+        ],
+    }
+
+
+def convert(data: dict[str, Any]) -> dict[str, Any]:
+    rules: dict[str, dict[str, Any]] = {}
+    results: list[dict[str, Any]] = []
+
+    for finding in data.get("flow_findings") or []:
+        if not isinstance(finding, dict):
+            continue
+        category = _safe_text(finding.get("category") or "flow")
+        rule_id = f"agent-bom-code-flow/{category}"
+        title = _safe_text(finding.get("title") or category.replace("_", " ").title())
+        detail = _safe_text(finding.get("detail") or title, max_len=1000)
+        file_path = _relative_path(finding.get("file"))
+        line = _line_number(finding.get("line"))
+        _add_rule(rules, rule_id, title, "medium", category)
+        results.append(_result(rule_id, "warning", detail, file_path, line, f"{rule_id}:{file_path}:{line}:{detail}"))
+
+    ai_components = data.get("ai_components") or {}
+    if isinstance(ai_components, dict):
+        candidates: list[dict[str, Any]] = []
+        for key in ("components", "deprecated_models", "api_keys", "shadow_ai"):
+            values = ai_components.get(key) or []
+            if isinstance(values, list):
+                candidates.extend(item for item in values if isinstance(item, dict))
+        for component in candidates:
+            severity = _safe_text(component.get("severity") or "info").lower()
+            component_type = _safe_text(component.get("component_type") or component.get("kind") or "component")
+            if severity == "info" and component_type not in {"api_key", "deprecated_model"}:
+                continue
+            name = "[REDACTED]" if component_type == "api_key" else _safe_text(component.get("name") or component_type, max_len=120)
+            rule_id = f"agent-bom-ai-component/{component_type}"
+            title = f"{component_type.replace('_', ' ').title()}: {name}"
+            file_path = _relative_path(component.get("file_path") or component.get("file"))
+            line = _line_number(component.get("line_number") or component.get("line"))
+            level = _LEVELS.get(severity, "warning")
+            message = _safe_text(component.get("description") or title, max_len=1000)
+            _add_rule(rules, rule_id, title, severity, component_type)
+            results.append(_result(rule_id, level, message, file_path, line, f"{rule_id}:{file_path}:{line}:{name}"))
+
+    return {
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "agent-bom code",
+                        "version": _agent_bom_version(),
+                        "informationUri": "https://github.com/msaad00/agent-bom",
+                        "rules": list(rules.values()),
+                    }
+                },
+                "results": results,
+            }
+        ],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(argv or sys.argv[1:])
+    if len(args) != 2:
+        print("usage: code_scan_json_to_sarif.py INPUT.json OUTPUT.sarif", file=sys.stderr)
+        return 2
+    input_path = Path(args[0])
+    output_path = Path(args[1])
+    data = json.loads(input_path.read_text(encoding="utf-8"))
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(convert(data), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_code_scan_json_to_sarif.py
+++ b/tests/test_code_scan_json_to_sarif.py
@@ -1,0 +1,38 @@
+import json
+
+from scripts.code_scan_json_to_sarif import convert
+
+
+def test_code_scan_json_to_sarif_redacts_api_key_component_name():
+    sarif = convert(
+        {
+            "flow_findings": [
+                {
+                    "category": "sql_string_construction",
+                    "title": "SQL query is built dynamically",
+                    "detail": "query uses token=abc123 before execute",
+                    "file": "api/db.py",
+                    "line": 42,
+                }
+            ],
+            "ai_components": {
+                "api_keys": [
+                    {
+                        "component_type": "api_key",
+                        "name": "sk-test-value",
+                        "severity": "critical",
+                        "file_path": "settings.py",
+                        "line_number": 7,
+                        "description": "hardcoded api_key=secret-value",
+                    }
+                ]
+            },
+        }
+    )
+
+    encoded = json.dumps(sarif)
+    assert sarif["version"] == "2.1.0"
+    assert len(sarif["runs"][0]["results"]) == 2
+    assert "sk-test-value" not in encoded
+    assert "secret-value" not in encoded
+    assert "token=abc123" not in encoded


### PR DESCRIPTION
Summary

- replace the post-merge SAST self-scan's broad `agent-bom scan --code ...` path with the bounded `agent-bom code` source analyzer
- convert the resulting code-analysis JSON to SARIF for the existing GitHub Security upload category
- redact credential-shaped fragments while converting code findings to SARIF
- add a regression test for the converter and its redaction behavior

Why

The v0.83.0 release gate failed after #2107 because Post-Merge Self-Scan's `Self SAST scan` timed out after 40 minutes. Logs showed the broad `agent-bom scan --code src/agent_bom --format sarif` path moved through discovery, then hung until the step timeout. The post-merge gate needs a bounded, deterministic source-analysis path, not the full scan pipeline.

This keeps the same outcome for the Security tab: a SARIF upload under `agent-bom-self-sast`, now generated from the already-bounded `agent-bom code` analyzer.

Validation

- `uv run pytest tests/test_code_scan_json_to_sarif.py -q`
- `uv run ruff check scripts/code_scan_json_to_sarif.py tests/test_code_scan_json_to_sarif.py`
- `uv run mypy scripts/code_scan_json_to_sarif.py`
- `uv run python - <<'PY' ... yaml.safe_load('.github/workflows/post-merge-self-scan.yml') ... PY`
- `uv run agent-bom code src/agent_bom --format json -o /tmp/agent-bom-sast-ci/self-sast.json --quiet`
- `uv run python scripts/code_scan_json_to_sarif.py /tmp/agent-bom-sast-ci/self-sast.json /tmp/agent-bom-sast-ci/self-sast.sarif`
- `python -m json.tool /tmp/agent-bom-sast-ci/self-sast.sarif >/dev/null`
- local generated SARIF contained 7 rules / 132 results
- `python -m py_compile scripts/code_scan_json_to_sarif.py`
- `git diff --check`
