### PR TITLE
ci: honor docs deploy input

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
           path: site
 
   deploy:
-    if: ${{ github.event_name != 'workflow_call' || inputs.deploy }}
+    if: ${{ inputs.deploy != false }}
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
Summary

- make the reusable docs workflow honor `inputs.deploy: false`
- keep direct docs workflow runs deploying by default because an unset input is not `false`

Why

The v0.83.0 release workflow calls `docs.yml` with `deploy: false`, but the reusable workflow checked `github.event_name`. In reusable workflows that value still reflects the caller event, so the release tag push incorrectly ran the Pages deploy job and failed the release DAG.

Validation

- `uv run python - <<'PY' ... yaml.safe_load(...) ... PY`
- `git diff --check`
