### PR TITLE
ci: make MCP registry publish opt-in

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -5,6 +5,11 @@ on:
     workflows: ["Release"]
     types: [completed]
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish to the official MCP Registry. Leave false to validate server.json only."
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -39,8 +44,34 @@ jobs:
             exit 1
           fi
 
+      - name: Decide publish mode
+        id: mode
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_DISPATCH_PUBLISH: ${{ inputs.publish || false }}
+          RELEASE_PUBLISH_ENABLED: ${{ vars.MCP_REGISTRY_PUBLISH_ENABLED || 'false' }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$WORKFLOW_DISPATCH_PUBLISH" = "true" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "Manual MCP Registry publish requested."
+          elif [ "$EVENT_NAME" = "workflow_run" ] && [ "$RELEASE_PUBLISH_ENABLED" = "true" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "MCP Registry publish enabled by repository variable."
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "MCP Registry publish not enabled; validation-only run."
+          fi
+
+      - name: Skip publish until official MCP Registry registration is enabled
+        if: steps.mode.outputs.publish != 'true'
+        run: |
+          echo "server.json validation passed."
+          echo "Skipping official MCP Registry publish because MCP_REGISTRY_PUBLISH_ENABLED is not true and manual publish was not requested."
+          echo "After the repository is registered with the official MCP Registry, set repository variable MCP_REGISTRY_PUBLISH_ENABLED=true or run this workflow manually with publish=true."
+
       - name: Get GitHub OIDC token
         id: oidc
+        if: steps.mode.outputs.publish == 'true'
         run: |
           if [ -z "$ACTIONS_ID_TOKEN_REQUEST_TOKEN" ] || [ -z "$ACTIONS_ID_TOKEN_REQUEST_URL" ]; then
             echo "::error::OIDC token request not available. Ensure id-token: write permission is granted."
@@ -58,6 +89,7 @@ jobs:
 
       - name: Exchange OIDC token for Registry JWT
         id: auth
+        if: steps.mode.outputs.publish == 'true'
         run: |
           HTTP_STATUS=$(curl -s --connect-timeout 10 --max-time 30 \
             -o /tmp/auth-response.json -w "%{http_code}" \
@@ -80,6 +112,7 @@ jobs:
           echo "jwt=$JWT" >> "$GITHUB_OUTPUT"
 
       - name: Publish to MCP Registry
+        if: steps.mode.outputs.publish == 'true'
         run: |
           print_publish_error() {
             if jq -e . >/dev/null 2>&1 </tmp/publish-response.json; then


### PR DESCRIPTION
Summary

- keep official MCP Registry `server.json` validation on every release-completed workflow
- make the actual publish/auth step opt-in via repository variable `MCP_REGISTRY_PUBLISH_ENABLED=true` or manual `workflow_dispatch` input `publish=true`
- skip OIDC/JWT exchange when publish is not enabled, so unregistered registry identity does not fail `main`

Why

The `Publish to MCP Registry` workflow validated `integrations/mcp-registry/server.json` successfully, then failed at the official registry OIDC exchange with HTTP 401. That means the official MCP Registry does not yet accept this repository identity. Until registration is complete, release-triggered workflow runs should validate metadata but should not fail `main` or open release-blocker issues for an expected external registration state.

When registry publishing is intentionally enabled, HTTP 401 and publish errors still fail the workflow.

Validation

- YAML parse for `.github/workflows/publish-mcp-registry.yml`
- pre-commit hooks during commit: yaml/eof/whitespace/private-key/case-conflict/merge-conflict/mixed-line-ending

Closes #2113
