### PR TITLE
fix: package inventory schema in release wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -580,6 +580,13 @@ jobs:
 
       - name: Install build deps (Alpine)
         run: |
+          for attempt in 1 2 3; do
+            if apk add --no-cache bash gcc musl-dev libffi-dev openssl-dev git curl; then
+              exit 0
+            fi
+            echo "apk add failed on attempt ${attempt}; retrying after transient package-index/network failure..."
+            sleep $((attempt * 5))
+          done
           apk add --no-cache bash gcc musl-dev libffi-dev openssl-dev git curl
 
       - name: Install uv
@@ -686,6 +693,21 @@ jobs:
         run: |
           uv run --with build==1.4.0 python -m build
           uvx twine==6.2.0 check dist/*
+          python - <<'PY'
+          from pathlib import Path
+          from zipfile import ZipFile
+
+          wheel = next(Path("dist").glob("agent_bom-*.whl"))
+          required = {
+              "agent_bom/data/inventory.schema.json",
+              "agent_bom/data/mcp-intelligence.schema.json",
+          }
+          with ZipFile(wheel) as archive:
+              names = set(archive.namelist())
+          missing = sorted(required - names)
+          if missing:
+              raise SystemExit(f"wheel is missing required package data: {', '.join(missing)}")
+          PY
 
       - name: Upload package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom
-        run: uv tool install agent-bom==0.83.2  # pinned — bump on each release
+        run: uv tool install agent-bom==0.83.3  # pinned — bump on each release
 
       - name: Scan changed MCP configs
         id: scan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,23 @@ jobs:
         run: rm -rf dist/ && uv run --with build==1.4.0 python -m build
 
       - name: Verify package
-        run: uvx twine==6.2.0 check dist/*
+        run: |
+          uvx twine==6.2.0 check dist/*
+          python - <<'PY'
+          from pathlib import Path
+          from zipfile import ZipFile
+
+          wheel = next(Path("dist").glob("agent_bom-*.whl"))
+          required = {
+              "agent_bom/data/inventory.schema.json",
+              "agent_bom/data/mcp-intelligence.schema.json",
+          }
+          with ZipFile(wheel) as archive:
+              names = set(archive.namelist())
+          missing = sorted(required - names)
+          if missing:
+              raise SystemExit(f"wheel is missing required package data: {', '.join(missing)}")
+          PY
 
       - name: Upload dist artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.83.3] – 2026-04-30
+
+### Fixed
+- **Wheel inventory schema packaging** — `inventory.schema.json` now ships inside the installed `agent_bom` package, so PyPI users can run `agent-bom agents --inventory ...`, operator-pull adapters, and skill-mediated inventory flows without a source checkout.
+- **Inventory error exits** — missing inventory schema errors are now surfaced as explicit `--inventory` parameter failures with exit code 2 instead of falling through generic CLI handling.
+- **Interactive GHSA checks** — unauthenticated single-package GHSA rate-limit responses now fail fast instead of pausing for the fleet-scan backoff window, while multi-package scans preserve the bounded retry behavior.
+
+### CI
+- **Wheel content guard** — PR and release package builds now fail if required JSON schema package data is missing from the wheel.
+
+---
+
 ## [0.83.2] – 2026-04-30
 
 ### Fixed

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -188,7 +188,7 @@ Focused graph:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `0.83.2` | Current stable version (pinned) |
+| `0.83.3` | Current stable version (pinned) |
 
 Published images:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.3-alpine3.23@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510
 
-ARG VERSION=0.83.2
+ARG VERSION=0.83.3
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ for the full split-vs-single-image guidance.
 |------|----------|
 | CLI (`agent-bom agents`) | local audit + project scan |
 | Endpoint fleet (`--push-url …/v1/fleet/sync`) | employee laptops pushing into self-hosted fleet |
-| GitHub Action (`uses: msaad00/agent-bom@v0.83.2`) | CI/CD + SARIF |
+| GitHub Action (`uses: msaad00/agent-bom@v0.83.3`) | CI/CD + SARIF |
 | Docker (`agentbom/agent-bom`) | isolated scans, API jobs, and non-browser self-hosted entrypoints |
 | Browser UI image (`agentbom/agent-bom-ui`) | the dashboard image paired with the same self-hosted control plane |
 | Kubernetes / Helm (`helm install agent-bom deploy/helm/agent-bom`) | self-hosted API + dashboard, scheduled discovery |
@@ -404,7 +404,7 @@ References: [PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md) · [PRODUCT_METRICS.md](do
 <summary><b>CI/CD in 60 seconds</b></summary>
 
 ```yaml
-- uses: msaad00/agent-bom@v0.83.2
+- uses: msaad00/agent-bom@v0.83.3
   with:
     scan-type: scan
     severity-threshold: high

--- a/deploy/docker-compose.fullstack.yml
+++ b/deploy/docker-compose.fullstack.yml
@@ -27,7 +27,7 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
-    image: agentbom/agent-bom:0.83.2
+    image: agentbom/agent-bom:0.83.3
     container_name: agent-bom-api
     restart: unless-stopped
     command: api --host 0.0.0.0 --port 8422 --allow-insecure-no-auth
@@ -74,7 +74,7 @@ services:
       args:
         # Baked into the Next.js build — must match the publicly reachable API URL
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8422}
-    image: agentbom/agent-bom-ui:0.83.2
+    image: agentbom/agent-bom-ui:0.83.3
     container_name: agent-bom-ui
     restart: unless-stopped
     ports:

--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -18,7 +18,7 @@
 
 services:
   api:
-    image: agentbom/agent-bom:0.83.2
+    image: agentbom/agent-bom:0.83.3
     container_name: agent-bom-pilot-api
     restart: unless-stopped
     command: >
@@ -45,7 +45,7 @@ services:
       start_period: 10s
 
   ui:
-    image: agentbom/agent-bom-ui:0.83.2
+    image: agentbom/agent-bom-ui:0.83.3
     container_name: agent-bom-pilot-ui
     restart: unless-stopped
     environment:

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -112,7 +112,7 @@ services:
       dockerfile: Dockerfile
       args:
         NEXT_PUBLIC_API_URL: http://localhost:8422
-    image: agentbom/agent-bom-ui:0.83.2
+    image: agentbom/agent-bom-ui:0.83.3
     container_name: agent-bom-ui
     ports:
       - "3000:3000"

--- a/deploy/docker-compose.runtime.yml
+++ b/deploy/docker-compose.runtime.yml
@@ -31,7 +31,7 @@ services:
     build:
       context: ..
       dockerfile: deploy/docker/Dockerfile.runtime
-    image: agentbom/agent-bom:0.83.2
+    image: agentbom/agent-bom:0.83.3
     container_name: agent-bom-runtime-proxy
     depends_on:
       - mcp-server

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -27,7 +27,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.83.2
+ARG VERSION=0.83.3
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -17,7 +17,7 @@ WORKDIR /app
 COPY pyproject.toml README.md LICENSE ./
 COPY src/ ./src/
 
-ARG VERSION=0.83.2
+ARG VERSION=0.83.3
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
@@ -40,7 +40,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[runtime]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.83.2
+ARG VERSION=0.83.3
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.snowpark
+++ b/deploy/docker/Dockerfile.snowpark
@@ -26,7 +26,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11.12-slim@sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c
 
-ARG VERSION=0.83.2
+ARG VERSION=0.83.3
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -41,7 +41,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.83.2
+ARG VERSION=0.83.3
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: agent-bom
 description: Open security scanner and graph for AI supply chain and infrastructure — discover agents and MCP, map blast radius, and inspect runtime.
-version: 0.83.2
-appVersion: "0.83.2"
+version: 0.83.3
+appVersion: "0.83.3"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -5,17 +5,17 @@
 
 image:
   repository: agentbom/agent-bom
-  tag: "0.83.2"
+  tag: "0.83.3"
   pullPolicy: IfNotPresent
 
 uiImage:
   repository: agentbom/agent-bom-ui
-  tag: "0.83.2"
+  tag: "0.83.3"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom
-  tag: "0.83.2"
+  tag: "0.83.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -38,7 +38,7 @@ tests:
   includeUi: true
   image:
     repository: agentbom/agent-bom
-    tag: "0.83.2"
+    tag: "0.83.3"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deploy/k8s/daemonset.yaml
+++ b/deploy/k8s/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: agent-bom
       containers:
         - name: monitor
-          image: agentbom/agent-bom:0.83.2
+          image: agentbom/agent-bom:0.83.3
           command: ["agent-bom"]
           args:
             - "protect"

--- a/deploy/k8s/proxy-sidecar-pilot.yaml
+++ b/deploy/k8s/proxy-sidecar-pilot.yaml
@@ -109,7 +109,7 @@ spec:
               cpu: "500m"
 
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.83.2
+          image: agentbom/agent-bom:0.83.3
           args:
             - "--policy"
             - "/etc/agent-bom/policy.json"

--- a/deploy/k8s/sidecar-example.yaml
+++ b/deploy/k8s/sidecar-example.yaml
@@ -40,7 +40,7 @@ spec:
 
         # agent-bom proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.83.2
+          image: agentbom/agent-bom:0.83.3
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -135,7 +135,7 @@ agent-bom agents --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.83.2
+- uses: msaad00/agent-bom@v0.83.3
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -72,7 +72,7 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # GitHub Actions
-- uses: msaad00/agent-bom@v0.83.2
+- uses: msaad00/agent-bom@v0.83.3
   with:
     scan-type: agents        # auto-detect MCP configs + deps
     severity-threshold: high # fail PR on HIGH+ CVEs
@@ -90,21 +90,21 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # Container image gate
-- uses: msaad00/agent-bom@v0.83.2
+- uses: msaad00/agent-bom@v0.83.3
   with:
     scan-type: image
     scan-ref: ghcr.io/acme/agent-runtime:sha-abcdef
     severity-threshold: critical
 
 # IaC gate
-- uses: msaad00/agent-bom@v0.83.2
+- uses: msaad00/agent-bom@v0.83.3
   with:
     scan-type: iac
     iac: Dockerfile,k8s/,infra/main.tf
     severity-threshold: high
 
 # Air-gapped or fully cached CI
-- uses: msaad00/agent-bom@v0.83.2
+- uses: msaad00/agent-bom@v0.83.3
   with:
     auto-update-db: false
     enrich: false
@@ -468,7 +468,7 @@ AmazonEC2ReadOnlyAccess
 docker run --rm \
   -v ~/.config:/home/abom/.config:ro \
   -v $(pwd):/workspace:ro \
-  agentbom/agent-bom:0.83.2 agents --format json
+  agentbom/agent-bom:0.83.3 agents --format json
 ```
 
 Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base image.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -242,7 +242,7 @@ blast_radius        — blast radius for a specific CVE
 ### CI/CD (GitHub Action)
 
 ```yaml
-- uses: msaad00/agent-bom@v0.83.2
+- uses: msaad00/agent-bom@v0.83.3
   with:
     format: sarif
     upload-sarif: 'true'

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,6 +1,6 @@
 {
   "generated_on": "2026-04-28",
-  "version": "0.83.2",
+  "version": "0.83.3",
   "metrics": [
     {
       "name": "MCP tools",

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -6,7 +6,7 @@ This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
 - Generated on: `2026-04-28`
-- Version: `0.83.2`
+- Version: `0.83.3`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -97,7 +97,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN" --no-browser
 clawhub publish integrations/openclaw/scan \
   --slug agent-bom-scan --name "agent-bom scan" \
-  --version "0.83.2"
+  --version "0.83.3"
 ```
 
 Release automation uses the same official `clawhub` CLI flow, not a custom
@@ -150,8 +150,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.83.2
-git push origin v0.83.2
+git tag v0.83.3
+git push origin v0.83.3
 ```
 
 This triggers:

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -13,7 +13,7 @@ For each tagged GitHub Release, expect:
 ## Download release assets
 
 ```bash
-TAG=v0.83.2
+TAG=v0.83.3
 VERSION="${TAG#v}"
 mkdir -p /tmp/agent-bom-release && cd /tmp/agent-bom-release
 gh release download "$TAG" --repo msaad00/agent-bom

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -33,7 +33,7 @@ The proxy interposes on the stdio channel between an MCP client (Claude Desktop,
 Use the published main runtime image:
 
 ```bash
-docker pull agentbom/agent-bom:0.83.2
+docker pull agentbom/agent-bom:0.83.3
 ```
 
 If you need to rebuild locally from the checked-out repo, you can still use
@@ -45,7 +45,7 @@ Run as a wrapper around any MCP server:
 ```bash
 docker run --rm \
   -v $(pwd)/audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.83.2 \
+  agentbom/agent-bom:0.83.3 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace
@@ -94,7 +94,7 @@ spec:
 
         # agent-bom runtime proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.83.2
+          image: agentbom/agent-bom:0.83.3
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"
@@ -334,7 +334,7 @@ Use the runtime container directly from Claude Desktop:
         "run", "--rm", "-i",
         "-v", "./workspace:/workspace",
         "-v", "./audit-logs:/var/log/agent-bom",
-        "agentbom/agent-bom:0.83.2",
+        "agentbom/agent-bom:0.83.3",
         "--log", "/var/log/agent-bom/audit.jsonl",
         "--block-undeclared",
         "--",

--- a/docs/archive/WINDOWS_CONTAINERS.md
+++ b/docs/archive/WINDOWS_CONTAINERS.md
@@ -113,7 +113,7 @@ container inspection. Windows Server environments should use:
 
 1. **Python CLI** -- `pip install agent-bom` works on Windows natively
 2. **Docker Desktop** -- run the Linux container images on Windows via WSL 2
-3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.83.2`) which
+3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.83.3`) which
    runs on Linux runners
 
 ---

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,4 +1,4 @@
-# agent-bom v0.83.2 blast-radius demo
+# agent-bom v0.83.3 blast-radius demo
 # Shows: blast radius → package gate
 
 Output docs/images/demo-latest.gif

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
-  "version": "0.83.2",
+  "version": "0.83.3",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
   "title": "agent-bom",
-  "version": "0.83.2",
+  "version": "0.83.3",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.83.2",
+      "version": "0.83.3",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   security checks. Use when the user mentions vulnerability scanning,
   MCP server trust, compliance, SBOM generation, CIS benchmarks, blast
   radius, or AI supply chain risk.
-version: 0.83.2
+version: 0.83.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -25,7 +25,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.2
+    docker: ghcr.io/msaad00/agent-bom:0.83.3
   openclaw:
     requires:
       bins: []
@@ -407,6 +407,6 @@ provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.83.2`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.83.3`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Analyze blast radius, attack paths, and threat landscape across your AI
   infrastructure. Use when: "blast radius", "threat intel", "risk score",
   "attack path", "lateral movement", "context graph", "who can reach what".
-version: 0.83.2
+version: 0.83.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.2
+    docker: ghcr.io/msaad00/agent-bom:0.83.3
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Generate SBOMs and compliance reports. Use when:
   "compliance report", "NIST", "SOC 2", "ISO 27001", "OWASP", "EU AI Act",
   "AISVS", "generate SBOM", "policy check".
-version: 0.83.2
+version: 0.83.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. OWASP/NIST/EU AI Act/MITRE
@@ -23,7 +23,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.2
+    docker: ghcr.io/msaad00/agent-bom:0.83.3
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/discover-aws/SKILL.md
+++ b/integrations/openclaw/discover-aws/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   inventory AWS Bedrock, ECS, SageMaker, Lambda, EKS, Step Functions, EC2, or
   agentic AWS infrastructure as canonical inventory. Passing that inventory
   to agent-bom is optional and operator-chosen.
-version: 0.83.2
+version: 0.83.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover/SKILL.md
+++ b/integrations/openclaw/discover/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Discover AI agents, MCP servers, and configurations on this machine or
   environment. Use when: "find agents", "what's configured", "doctor",
   "what MCP servers", "show me what's installed", "mcp inventory".
-version: 0.83.2
+version: 0.83.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.2
+    docker: ghcr.io/msaad00/agent-bom:0.83.3
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Enforce security policies on MCP tool calls and block dangerous operations at
   runtime. Use when: "block risky calls", "apply policy", "proxy",
   "runtime protection", "policy enforcement", "intercept MCP calls".
-version: 0.83.2
+version: 0.83.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.2
+    docker: ghcr.io/msaad00/agent-bom:0.83.3
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Monitor agent fleet, track trust scores, and manage lifecycle states. Use
   when: "fleet", "watch agents", "runtime status", "trust scores",
   "fleet sync", "agent lifecycle", "serve dashboard".
-version: 0.83.2
+version: 0.83.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.2
+    docker: ghcr.io/msaad00/agent-bom:0.83.3
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.83.2
+version: 0.83.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.83.2
+version: 0.83.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Scan infrastructure-as-code, cloud configurations, and find secrets. Use when:
   "check terraform", "scan kubernetes", "IaC", "find secrets",
   "scan dockerfile", "cloud security", "misconfigurations".
-version: 0.83.2
+version: 0.83.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.2
+    docker: ghcr.io/msaad00/agent-bom:0.83.3
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   KEV), container images, provenance, filesystems, and SBOMs. Use
   when: "check package", "scan image", "verify", "is this safe",
   "scan dependencies", "CVE lookup", "blast radius".
-version: 0.83.2
+version: 0.83.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Native container image
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.2
+    docker: ghcr.io/msaad00/agent-bom:0.83.3
   openclaw:
     requires:
       bins: []
@@ -216,6 +216,6 @@ agent-bom agents
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.83.2`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.83.3`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Diagnose issues, check prerequisites, and validate configurations. Use when:
   "doctor", "debug", "why failing", "validate config", "check prerequisites",
   "something is broken", "db status", "fix my setup".
-version: 0.83.2
+version: 0.83.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.2
+    docker: ghcr.io/msaad00/agent-bom:0.83.3
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/vulnerability-intel/SKILL.md
+++ b/integrations/openclaw/vulnerability-intel/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   with explicit data-boundary choices. Use when a user asks for CVE lookup,
   advisory intelligence, exploitability context, fix versions, GHSA/OSV/NVD
   enrichment, or package vulnerability triage.
-version: 0.83.2
+version: 0.83.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+ and agent-bom installed from this repository or PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.83.2"
+version = "0.83.3"
 description = "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius."
 readme = "PYPI_README.md"
 license = "Apache-2.0"

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -171,7 +171,7 @@ Install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.83.2 \
+  --version 0.83.3 \
   -n agent-bom --create-namespace \
   -f values.agent-bom.yaml
 ```
@@ -207,7 +207,7 @@ Then install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.83.2 \
+  --version 0.83.3 \
   -n agent-bom --create-namespace \
   -f deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
 ```

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -92,10 +92,10 @@ docker run --rm \
 ## Runtime proxy sidecar
 
 ```bash
-docker pull agentbom/agent-bom:0.83.2
+docker pull agentbom/agent-bom:0.83.3
 docker run --rm -i \
   -v ./audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.83.2 \
+  agentbom/agent-bom:0.83.3 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace

--- a/site-docs/features/policy.md
+++ b/site-docs/features/policy.md
@@ -49,7 +49,7 @@ agent-bom proxy --policy policy.json --block-undeclared -- ...
 
 ```yaml
 - name: Security gate
-  uses: msaad00/agent-bom@v0.83.2
+  uses: msaad00/agent-bom@v0.83.3
   with:
     policy: policy.json
     fail-on-violation: true

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.83.2"
+    __version__ = "0.83.3"
 
 # Cross-check against pyproject.toml for dev installs where the editable
 # install metadata may be stale (i.e. version bumped but not re-installed).

--- a/src/agent_bom/cli/agents/_discovery.py
+++ b/src/agent_bom/cli/agents/_discovery.py
@@ -119,7 +119,7 @@ def run_local_discovery(
 
         try:
             inventory_data = load_inventory(inventory)
-        except (OSError, ValueError, json.JSONDecodeError) as exc:
+        except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as exc:
             raise click.BadParameter(str(exc), param_hint="--inventory") from exc
         ctx.agents = _build_agents_from_inventory(inventory_data, inventory)
         con.print(f"\n  [green]✓[/green] {len(ctx.agents)} agent(s) from {label}")

--- a/src/agent_bom/data/inventory.schema.json
+++ b/src/agent_bom/data/inventory.schema.json
@@ -1,0 +1,354 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-bom.github.io/schemas/inventory/v1",
+  "title": "agent-bom Inventory Schema v1",
+  "description": "Standard format for submitting AI agent and MCP server inventory to agent-bom for vulnerability scanning, blast radius analysis, and supply chain reporting.",
+
+  "$defs": {
+
+    "DiscoveryProvenance": {
+      "title": "Discovery Provenance",
+      "description": "Low-risk provenance for how an asset was observed. Values are sanitized before persistence/export.",
+      "type": "object",
+      "required": ["source_type"],
+      "properties": {
+        "source_type": {
+          "type": "string",
+          "enum": [
+            "direct_cloud_pull",
+            "operator_pushed_inventory",
+            "skill_invoked_pull",
+            "local_discovery",
+            "registry_fallback",
+            "sbom_ingest",
+            "external_scan",
+            "filesystem_scan",
+            "image_scan",
+            "unknown"
+          ]
+        },
+        "observed_via": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "source": { "type": "string" },
+        "collector": { "type": "string" },
+        "provider": { "type": "string" },
+        "service": { "type": "string" },
+        "resource_type": { "type": "string" },
+        "resource_id": { "type": "string" },
+        "resource_name": { "type": "string" },
+        "location": { "type": "string" },
+        "confidence": { "type": "string" },
+        "resolved_from_registry": { "type": "boolean" },
+        "version_source": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+
+    "Tool": {
+      "title": "MCP Tool",
+      "description": "A tool exposed by an MCP server. Needed for blast radius: maps a vulnerability to the attacker capabilities it unlocks.",
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1,
+          "description": "Tool name shorthand"
+        },
+        {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Tool name as advertised by the MCP server"
+            },
+            "description": {
+              "type": "string",
+              "description": "What this tool does"
+            },
+            "input_schema": {
+              "type": "object",
+              "description": "JSON Schema describing the tool's parameters"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+
+    "Package": {
+      "title": "Package",
+      "description": "A software package. name + version + ecosystem are the minimum needed for OSV.dev vulnerability lookup.",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^.+@.+$",
+          "description": "Shorthand: 'name@version' (ecosystem inferred from server command)"
+        },
+        {
+          "type": "object",
+          "required": ["name", "version"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Package name as it appears in the registry"
+            },
+            "version": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Exact version string (e.g. '4.18.2'). Use 'unknown' only if version is truly unavailable — scanning will be skipped."
+            },
+            "ecosystem": {
+              "type": "string",
+              "enum": ["npm", "pypi", "go", "cargo", "maven", "nuget", "hex", "pub", "unknown"],
+              "description": "Package registry. If omitted, agent-bom infers from server command (npx→npm, uvx→pypi, etc.)"
+            },
+            "purl": {
+              "type": "string",
+              "description": "Package URL (purl) for unambiguous identification. If provided, overrides name/version/ecosystem for scanning."
+            },
+            "discovery_provenance": {
+              "$ref": "#/$defs/DiscoveryProvenance",
+              "description": "How this package was observed or resolved."
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+
+    "MCPServer": {
+      "title": "MCP Server",
+      "description": "An MCP server definition. The packages[] array drives vulnerability scanning. env drives credential detection. tools drives blast radius.",
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Server identifier (matches 'name' in mcpServers config blocks)"
+        },
+
+        "command": {
+          "type": "string",
+          "description": "Local: executable command (npx, uvx, python, node, docker). Not needed for cloud/API-managed servers."
+        },
+        "args": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Arguments to the command. For npx/uvx, first arg is typically the package name agent-bom extracts automatically."
+        },
+        "transport": {
+          "type": "string",
+          "enum": ["stdio", "sse", "streamable-http"],
+          "default": "stdio",
+          "description": "Connection transport. 'stdio' for local process, 'sse'/'streamable-http' for remote."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Server endpoint URL (for SSE or streamable-http transport)"
+        },
+        "mcp_version": {
+          "type": "string",
+          "description": "MCP protocol version the server implements (e.g. '2024-11-05', '1.0'). Used for protocol compatibility tracking."
+        },
+        "working_dir": {
+          "type": "string",
+          "description": "Working directory for the server process. Used to locate lock files (package-lock.json, requirements.txt, go.sum, Cargo.lock) when packages[] is not provided."
+        },
+
+        "env": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Environment variables passed to the server. Keys matching credential patterns (API_KEY, TOKEN, PASSWORD, SECRET, etc.) are flagged as exposed credentials in blast radius analysis. Values are never logged or transmitted — only key names are used."
+        },
+
+        "tools": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Tool" },
+          "description": "Tools this server exposes. Used for blast radius: 'if this package is compromised, what tools can an attacker reach?' If empty, blast radius reports tool count as unknown."
+        },
+
+        "packages": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Package" },
+          "description": "Software packages this server depends on. These are what get scanned for CVEs. If empty and command/working_dir are set, agent-bom discovers packages from local lock files automatically."
+        },
+
+        "config_path": {
+          "type": "string",
+          "description": "Where this server's config lives. Can be a file path, Snowflake object path, AWS ARN, etc. Used in SARIF output to point findings to the right location."
+        },
+
+        "security_blocked": {
+          "type": "boolean",
+          "description": "True when local discovery or MCP intelligence policy marked this server as blocked."
+        },
+
+        "security_warnings": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Human-readable security warnings attached during discovery or policy evaluation."
+        },
+
+        "security_intelligence": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/SecurityIntelligenceEntry" },
+          "description": "Structured MCP intelligence matches that explain block/review/warn decisions."
+        },
+
+        "discovery_provenance": {
+          "$ref": "#/$defs/DiscoveryProvenance",
+          "description": "How this server definition was observed."
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "SecurityIntelligenceEntry": {
+      "title": "Security Intelligence Entry",
+      "type": "object",
+      "required": ["entry_id", "title", "confidence", "default_recommendation"],
+      "properties": {
+        "entry_id": { "type": "string" },
+        "title": { "type": "string" },
+        "severity": { "type": "string" },
+        "confidence": { "type": "string" },
+        "default_recommendation": { "type": "string" },
+        "source_type": { "type": "string" },
+        "source": { "type": "string" },
+        "match_type": { "type": "string" },
+        "matched_value": { "type": "string" },
+        "ecosystem": { "type": "string" },
+        "package": { "type": "string" },
+        "affected_versions": { "type": "string" },
+        "first_seen": { "type": "string" },
+        "last_verified": { "type": "string" },
+        "references": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "remediation_actions": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "Agent": {
+      "title": "Agent",
+      "description": "An AI agent that connects to MCP servers. All vulnerability findings are traced back to the agent level for blast radius reporting.",
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Agent identifier (human-readable, used in reports)"
+        },
+
+        "agent_type": {
+          "type": "string",
+          "enum": [
+            "claude-desktop",
+            "claude-code",
+            "cursor",
+            "windsurf",
+            "cline",
+            "custom"
+          ],
+          "default": "custom",
+          "description": "Which AI client this agent runs in. 'custom' for anything not listed."
+        },
+
+        "version": {
+          "type": "string",
+          "description": "Agent version string (e.g. '2.0', 'v1.3.1')"
+        },
+
+        "config_path": {
+          "type": "string",
+          "description": "Where this agent's config lives. File path for local agents, ARN/URI/DB path for cloud. Used in SARIF output for finding locations."
+        },
+
+        "source": {
+          "type": "string",
+          "description": "Where this inventory entry came from (e.g. 'local', 'snowflake', 'aws-bedrock', 'gcp-vertex', 'openai'). Used for traceability in reports."
+        },
+
+        "metadata": {
+          "type": "object",
+          "description": "Sanitized provider-specific metadata such as cloud_origin, cloud_state, cloud_scope, cloud_principal, and permissions_used. Credential values must be redacted before submission.",
+          "additionalProperties": true
+        },
+
+        "discovered_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp when this agent was first discovered in the source inventory."
+        },
+
+        "last_seen": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp when this agent was most recently observed in the source inventory."
+        },
+
+        "mcp_servers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/MCPServer" },
+          "description": "MCP servers this agent connects to. Each server's packages are scanned independently, then correlated back to this agent for blast radius."
+        },
+
+        "discovery_provenance": {
+          "$ref": "#/$defs/DiscoveryProvenance",
+          "description": "How this agent asset was observed."
+        }
+      },
+      "additionalProperties": false
+    }
+
+  },
+
+  "type": "object",
+  "required": ["agents"],
+  "properties": {
+
+    "schema_version": {
+      "type": "string",
+      "const": "1",
+      "description": "agent-bom inventory schema version. Always '1' for this schema."
+    },
+
+    "source": {
+      "type": "string",
+      "description": "Where this entire inventory file came from (e.g. 'snowflake-cortex', 'aws-bedrock', 'gcp-vertex'). Applied as default to all agents; overridden by per-agent source."
+    },
+
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp when this inventory was generated"
+    },
+
+    "discovery_provenance": {
+      "$ref": "#/$defs/DiscoveryProvenance",
+      "description": "Default provenance for assets in this inventory."
+    },
+
+    "agents": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/Agent" },
+      "description": "List of agents to scan"
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/agent_bom/inventory.py
+++ b/src/agent_bom/inventory.py
@@ -57,9 +57,10 @@ _ECOSYSTEM_ALIASES = {
 
 
 def _inventory_schema_path() -> Path | None:
-    """Return the checked-in inventory schema path."""
+    """Return the inventory schema path from source or installed package data."""
     candidate_paths = [
         Path(__file__).parent.parent.parent / "config" / "schemas" / "inventory.schema.json",
+        Path(__file__).parent / "data" / "inventory.schema.json",
         Path(__file__).parent.parent.parent / "schemas" / "inventory.schema.json",
     ]
     for candidate in candidate_paths:
@@ -72,6 +73,10 @@ def _inventory_schema_path() -> Path | None:
         package_root = Path(str(importlib.resources.files("agent_bom")))
     except Exception:
         return None
+
+    package_schema = Path(str(importlib.resources.files("agent_bom").joinpath("data", "inventory.schema.json")))
+    if package_schema.exists():
+        return package_schema
 
     fallback_paths = [
         package_root / ".." / ".." / "config" / "schemas" / "inventory.schema.json",

--- a/src/agent_bom/scanners/ghsa_advisory.py
+++ b/src/agent_bom/scanners/ghsa_advisory.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 _GITHUB_ADVISORY_API = "https://api.github.com/advisories"
 _GHSA_PER_PAGE = 100
 _GHSA_RATE_LIMIT_BACKOFF = 60.0
+_GHSA_SINGLE_PACKAGE_RATE_LIMIT_BACKOFF = 0.0
 
 # Map internal ecosystem names to GitHub Advisory API ecosystem values
 _ECOSYSTEM_MAP: dict[str, str] = {
@@ -45,9 +46,13 @@ class GHSARateLimitError(RuntimeError):
         self.retry_after = retry_after
 
 
+def _github_token() -> str:
+    return os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN") or ""
+
+
 def _ghsa_headers() -> dict[str, str]:
     headers = {"Accept": "application/vnd.github+json"}
-    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    token = _github_token()
     if token:
         headers["Authorization"] = f"Bearer {token}"
     return headers
@@ -306,7 +311,10 @@ async def check_github_advisories(
 
     try:
         async with create_client(timeout=15.0) as client:
-            tasks = [_fetch_advisories_for_package(p, client, semaphore) for p in queryable]
+            rate_limit_backoff = _GHSA_RATE_LIMIT_BACKOFF
+            if len(queryable) == 1 and not _github_token():
+                rate_limit_backoff = _GHSA_SINGLE_PACKAGE_RATE_LIMIT_BACKOFF
+            tasks = [_fetch_advisories_for_package(p, client, semaphore, rate_limit_backoff=rate_limit_backoff) for p in queryable]
             results = await asyncio.gather(*tasks, return_exceptions=True)
 
             for i, result in enumerate(results):

--- a/tests/test_cli_inventory.py
+++ b/tests/test_cli_inventory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from importlib import resources
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
@@ -168,6 +169,13 @@ def test_inventory_schema_path_points_to_repo_schema():
     assert schema_path is not None
     assert schema_path.name == "inventory.schema.json"
     assert "config/schemas" in schema_path.as_posix()
+
+
+def test_inventory_schema_is_packaged_with_agent_bom_data():
+    schema = resources.files("agent_bom").joinpath("data", "inventory.schema.json")
+    assert schema.is_file()
+    payload = json.loads(schema.read_text(encoding="utf-8"))
+    assert payload["$id"].endswith("/schemas/inventory/v1")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -197,6 +197,18 @@ def test_scan_bad_inventory_json_exits_two(tmp_path):
     assert "Expecting property name" in result.output
 
 
+def test_scan_missing_inventory_schema_exits_two(tmp_path):
+    inventory = tmp_path / "inventory.json"
+    inventory.write_text('{"agents": []}', encoding="utf-8")
+
+    with patch("agent_bom.inventory.load_inventory", side_effect=RuntimeError("Inventory schema file not found")):
+        result = _run(["scan", "--inventory", str(inventory), "--no-scan"])
+
+    assert result.exit_code == 2
+    assert "Invalid value for --inventory" in result.output
+    assert "Inventory schema file not found" in result.output
+
+
 def test_scan_preset_ci_flag():
     """--preset ci should be accepted without error."""
     with patch("agent_bom.cli.agents.discover_all", return_value=[]):

--- a/tests/test_ghsa_advisory.py
+++ b/tests/test_ghsa_advisory.py
@@ -180,6 +180,89 @@ def test_fetch_advisories_retries_once_on_rate_limit():
     sleep.assert_awaited_once_with(0.01)
 
 
+def test_fetch_advisories_can_fail_fast_on_rate_limit():
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    import pytest
+
+    from agent_bom.scanners.ghsa_advisory import GHSARateLimitError, _fetch_advisories_for_package
+
+    limited = MagicMock()
+    limited.status_code = 429
+    limited.headers = {"Retry-After": "60"}
+    pkg = Package(name="express", version="4.17.1", ecosystem="npm")
+
+    async def run():
+        with (
+            patch("agent_bom.scanners.ghsa_advisory.request_with_retry", new_callable=AsyncMock) as request,
+            patch("agent_bom.scanners.ghsa_advisory.asyncio.sleep", new_callable=AsyncMock) as sleep,
+        ):
+            request.return_value = limited
+            with pytest.raises(GHSARateLimitError):
+                await _fetch_advisories_for_package(
+                    pkg,
+                    MagicMock(),
+                    asyncio.Semaphore(1),
+                    rate_limit_backoff=0.0,
+                )
+            return request, sleep
+
+    request, sleep = asyncio.run(run())
+
+    assert request.await_count == 1
+    sleep.assert_not_awaited()
+
+
+def test_single_package_without_github_token_uses_fail_fast_rate_limit_backoff(monkeypatch):
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    from agent_bom.scanners.ghsa_advisory import _GHSA_SINGLE_PACKAGE_RATE_LIMIT_BACKOFF, check_github_advisories
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    pkg = Package(name="express", version="4.17.1", ecosystem="npm")
+
+    async def run():
+        with patch("agent_bom.scanners.ghsa_advisory._fetch_advisories_for_package", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = []
+            count = await check_github_advisories([pkg])
+            return count, mock_fetch
+
+    count, mock_fetch = asyncio.run(run())
+
+    assert count == 0
+    assert mock_fetch.await_count == 1
+    assert mock_fetch.await_args.kwargs["rate_limit_backoff"] == _GHSA_SINGLE_PACKAGE_RATE_LIMIT_BACKOFF
+
+
+def test_multi_package_scan_preserves_ghsa_rate_limit_backoff(monkeypatch):
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    from agent_bom.scanners.ghsa_advisory import _GHSA_RATE_LIMIT_BACKOFF, check_github_advisories
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    packages = [
+        Package(name="express", version="4.17.1", ecosystem="npm"),
+        Package(name="lodash", version="4.17.20", ecosystem="npm"),
+    ]
+
+    async def run():
+        with patch("agent_bom.scanners.ghsa_advisory._fetch_advisories_for_package", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = []
+            count = await check_github_advisories(packages)
+            return count, mock_fetch
+
+    count, mock_fetch = asyncio.run(run())
+
+    assert count == 0
+    assert mock_fetch.await_count == 2
+    assert {call.kwargs["rate_limit_backoff"] for call in mock_fetch.await_args_list} == {_GHSA_RATE_LIMIT_BACKOFF}
+
+
 def test_advisory_filtered_by_package_name():
     """Advisories for different packages are filtered out (substring match fix).
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.83.2",
+  "version": "0.83.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.83.2",
+      "version": "0.83.3",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
         "@tanstack/react-table": "^8.21.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.83.2",
+  "version": "0.83.3",
   "private": true,
   "packageManager": "npm@10.9.7",
   "engines": {

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/lib/api', () => ({
       scan_sources: [],
       scan_count: 0,
     }),
-    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.83.2' }),
+    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.83.3' }),
   },
 }))
 

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ overrides = [{ name = "python-dotenv", specifier = ">=1.2.2" }]
 
 [[package]]
 name = "agent-bom"
-version = "0.83.2"
+version = "0.83.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Summary

- package `inventory.schema.json` inside `agent_bom/data` so installed wheels can validate pushed/operator/skill inventories without a source checkout
- load the packaged schema as the fallback path and treat schema-loading failures as explicit `--inventory` parameter errors with exit code 2
- add wheel-content guards to PR and release package builds so required JSON schemas cannot be omitted from future wheels
- bump release surfaces to 0.83.3 and document the hotfix
- fail fast on unauthenticated single-package GHSA rate-limit responses while preserving the existing bounded fleet-scan backoff

Why

v0.83.2 shipped with `config/schemas/inventory.schema.json` outside the Python package. Editable installs worked, but PyPI wheel users hit `Inventory schema file not found` for `agent-bom agents --inventory ...`, which breaks the scope-zero/operator-pull and skill-mediated discovery story. This hotfix validates the actual wheel artifact before publish and adds the installed-wheel replay that caught the bug.

Validation

- `pytest tests/test_cli_inventory.py::test_inventory_schema_is_packaged_with_agent_bom_data tests/test_cli_inventory.py::test_inventory_schema_path_points_to_repo_schema tests/test_cli_scan.py::test_scan_bad_inventory_json_exits_two tests/test_cli_scan.py::test_scan_missing_inventory_schema_exits_two tests/test_ghsa_advisory.py::test_fetch_advisories_can_fail_fast_on_rate_limit tests/test_ghsa_advisory.py::test_single_package_without_github_token_uses_fail_fast_rate_limit_backoff tests/test_ghsa_advisory.py::test_multi_package_scan_preserves_ghsa_rate_limit_backoff -q`
- `pytest tests/test_ghsa_advisory.py tests/test_cli_inventory.py tests/test_cli_scan.py -q` -> 106 passed
- `ruff check src/agent_bom/inventory.py src/agent_bom/cli/agents/_discovery.py src/agent_bom/scanners/ghsa_advisory.py tests/test_cli_inventory.py tests/test_cli_scan.py tests/test_ghsa_advisory.py`
- `mypy src/agent_bom/inventory.py src/agent_bom/cli/agents/_discovery.py src/agent_bom/scanners/ghsa_advisory.py`
- `uv run --with build==1.4.0 python -m build`
- `uvx twine==6.2.0 check dist/*`
- wheel inspection confirmed `agent_bom/data/inventory.schema.json` and `agent_bom/data/mcp-intelligence.schema.json` are present
- fresh venv installed `dist/agent_bom-0.83.3-py3-none-any.whl`; `agent-bom --version` reports 0.83.3
- installed-wheel replay: `agent-bom samples first-run` then `agent-bom agents --inventory agent-bom-first-run/inventory.json --offline --format json -o first-run-scan.json --quiet` exits 0 and does not print schema errors
- installed-wheel synthetic blocklist replay exits 1 with one critical `MCP_BLOCKLIST` finding and does not leak the fake token
- `python scripts/bump-version.py 0.83.3 --check`
- `python scripts/check_release_consistency.py`
- `git diff --check`

Also verified #2114 after merge: manual `Publish to MCP Registry` workflow run succeeded in validation-only mode and closed #2113.
