### PR TITLE
fix: preserve fleet endpoint identity in mesh

### DIFF
--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -178,6 +178,11 @@ Use two diagrams, not one overloaded graph:
 - **Enterprise Self-Hosted Data and Runtime Flow** answers how data moves and
   where policy, auth, RBAC, tenant scope, and audit are enforced.
 
+In the diagrams below, every box prefixed with `agent-bom` is code from this
+project running in the customer's environment. The browser, IdP, cloud APIs,
+remote MCPs, and storage systems are customer-owned dependencies or optional
+destinations; they are not an agent-bom hosted control plane.
+
 ### Enterprise Self-Hosted Topology
 
 ```mermaid
@@ -185,13 +190,16 @@ flowchart LR
     classDef edge fill:#111827,stroke:#38bdf8,color:#e0f2fe
     classDef ctrl fill:#0f172a,stroke:#6366f1,color:#e0e7ff
     classDef run fill:#0f172a,stroke:#10b981,color:#d1fae5
+    classDef scan fill:#111827,stroke:#a78bfa,color:#ede9fe
     classDef data fill:#0f172a,stroke:#f59e0b,color:#fef3c7
     classDef ext fill:#0b1220,stroke:#475569,color:#cbd5e1,stroke-dasharray:3 3
 
-    Browser["Browser"]:::ext
+    Browser["Operator browser"]:::ext
     IdP["Corporate IdP"]:::ext
-    Fleet["Fleet collectors"]:::ext
-    Remote["Remote MCPs"]:::ext
+    Endpoints["Endpoints / laptops<br/>agent-bom CLI or collector"]:::ext
+    Pipelines["CI / operator-pull adapters<br/>signed inventory"]:::ext
+    Cloud["Cloud APIs<br/>read-only scopes"]:::ext
+    Remote["Remote MCP servers"]:::ext
 
     subgraph Customer["Customer VPC / EKS / self-hosted cluster"]
       direction LR
@@ -203,15 +211,15 @@ flowchart LR
 
       subgraph Control["Control plane"]
         direction TB
-        UI["Web UI"]:::ctrl
-        API["API"]:::ctrl
-        Jobs["Scan workers"]:::ctrl
+        UI["agent-bom UI<br/>dashboard"]:::ctrl
+        API["agent-bom API<br/>auth · RBAC · tenant scope"]:::ctrl
+        Jobs["agent-bom scan workers<br/>inventory · CVE · graph"]:::scan
       end
 
       subgraph Runtime["Data plane"]
         direction TB
-        Proxy["Local proxies"]:::run
-        Gateway["Gateway"]:::run
+        Proxy["agent-bom proxy<br/>local / sidecar MCP enforcement"]:::run
+        Gateway["agent-bom gateway<br/>shared remote MCP relay"]:::run
       end
 
       subgraph Stores["Customer-managed stores"]
@@ -228,10 +236,14 @@ flowchart LR
     Ingress --> UI
     Ingress --> API
     UI --> API
-    Jobs --> API
-    Fleet -->|inventory sync| API
-    Proxy -->|policy / audit| API
-    Gateway -->|policy / audit| API
+    Jobs -->|scan results| API
+    Endpoints -->|fleet sync<br/>/v1/fleet/sync| API
+    Pipelines -->|pushed inventory<br/>/v1/discovery/inventory| API
+    Jobs -->|read-only discovery| Cloud
+    Proxy -->|policy pull| API
+    Proxy -->|runtime audit events| API
+    Gateway -->|policy pull / evaluate| API
+    Gateway -->|gateway audit events| API
     Gateway -->|remote MCP traffic| Remote
     Secrets --> API
     Secrets --> Gateway
@@ -243,12 +255,16 @@ flowchart LR
 ```
 
 Truth block:
+- `agent-bom` is the UI, API, scan workers, proxy, gateway, and optional endpoint
+  CLI/collector. It is not a hidden SaaS dependency in this topology.
 - Users enter through ingress; the API remains the single control-plane authority
   for auth, RBAC, tenant scope, graph, audit, and policy.
-- Fleet sync, scan workers, and runtime surfaces all report back to the same API,
-  so inventory and enforcement stay aligned.
-- Gateway fronts shared remote MCP traffic; optional analytics and archive stores
-  stay visually secondary to Postgres, which remains the required system of record.
+- Fleet sync, pushed inventory, scan workers, and runtime surfaces report back to
+  the same API, so inventory and enforcement stay aligned.
+- Gateway fronts shared remote MCP traffic. Local proxies stay near selected
+  endpoint or workload MCP traffic.
+- Optional analytics and archive stores stay visually secondary to Postgres,
+  which remains the required system of record.
 
 ### Enterprise Self-Hosted Data and Runtime Flow
 
@@ -259,20 +275,33 @@ flowchart TD
     classDef run fill:#0f172a,stroke:#10b981,color:#d1fae5
     classDef data fill:#0f172a,stroke:#f59e0b,color:#fef3c7
 
-    Scan["Scans<br/>CLI / API / CI / UI-triggered jobs"]:::src
-    Fleet["Fleet sync<br/>endpoint pushes"]:::src
-    Proxy["Proxy runtime<br/>local / sidecar MCP traffic"]:::run
-    Gateway["Gateway runtime<br/>shared remote MCP traffic"]:::run
+    Direct["Direct scan<br/>agent-bom CLI / worker"]:::src
+    Pushed["Pushed inventory<br/>operator adapter / CI / skill"]:::src
+    Fleet["Fleet sync<br/>endpoint CLI or collector"]:::src
+    ProxyTraffic["Selected local MCP traffic"]:::src
+    RemoteTraffic["Shared remote MCP traffic"]:::src
 
-    API["API / control plane<br/>auth · RBAC · tenant scope · audit"]:::proc
-    Graph["Graph / findings / policy / remediation"]:::proc
+    Proxy["agent-bom proxy<br/>inline local enforcement"]:::run
+    Gateway["agent-bom gateway<br/>shared remote enforcement"]:::run
+
+    API["agent-bom API / control plane<br/>auth · RBAC · tenant scope"]:::proc
+    Policy["Policy service<br/>author · sign · distribute"]:::proc
+    Audit["Audit service<br/>append · redact · export"]:::proc
+    Graph["Canonical evidence<br/>inventory · findings · graph · remediation"]:::proc
     Store[("Postgres")]:::data
     Exports["OTEL / SIEM / Snowflake / ClickHouse / S3"]:::data
 
-    Scan -->|normalized findings + inventory| API
+    Direct -->|normalized inventory + findings| API
+    Pushed -->|schema-validated inventory| API
     Fleet -->|tenant-scoped inventory| API
-    Proxy -->|audit + policy evaluation| API
-    Gateway -->|audit + policy evaluation| API
+    ProxyTraffic --> Proxy
+    RemoteTraffic --> Gateway
+    Proxy -->|policy pull / decision evidence| Policy
+    Gateway -->|policy pull / decision evidence| Policy
+    Proxy -->|runtime audit events| Audit
+    Gateway -->|gateway audit events| Audit
+    Policy --> API
+    Audit --> API
     API --> Graph
     Graph --> Store
     API -->|optional export / analytics| Exports
@@ -281,8 +310,10 @@ flowchart TD
 Truth block:
 - Auth, RBAC, tenant resolution, and audit happen in the control plane, not in
   the browser.
-- Scans and fleet establish inventory first; proxy and gateway add runtime
-  enforcement and runtime evidence where deployed.
+- Scans, pushed inventory, and fleet establish inventory first; proxy and
+  gateway add runtime enforcement and runtime evidence only where deployed.
+- Policy and audit are separate responsibilities: policy decides and distributes;
+  audit records what happened after redaction.
 
 ## Best Self-Hosted Path
 

--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -278,8 +278,17 @@ async def sync_fleet(request: Request, body: PushPayload | None = None):
 
     if body and body.agents:
         payload_agents = body.agents
-        existing_by_name = {agent.name: agent for agent in store.list_by_tenant(tenant_id)}
-        new_names = {str(agent.get("name", "unknown-agent")) for agent in payload_agents} - set(existing_by_name)
+        existing_agents = store.list_by_tenant(tenant_id)
+        existing_by_identity = {(agent.source_id or source_id or "server-discovery", agent.name): agent for agent in existing_agents}
+        existing_by_legacy_name = {agent.name: agent for agent in existing_agents if not agent.source_id}
+        incoming_keys = {
+            (
+                str(agent.get("source_id") or source_id or "server-discovery"),
+                str(agent.get("name", "unknown-agent")),
+            )
+            for agent in payload_agents
+        }
+        new_identities = incoming_keys - set(existing_by_identity)
 
         # Hold the per-tenant quota guard across the (check + insert
         # loop) pair so concurrent fleet-sync POSTs serialise per
@@ -288,15 +297,16 @@ async def sync_fleet(request: Request, body: PushPayload | None = None):
         # `num_replicas` (audit-5 P1 fleet race fix).
         with tenant_quota_guard(
             tenant_id,
-            lambda: enforce_fleet_agents_quota(tenant_id, attempted=len(new_names)),
+            lambda: enforce_fleet_agents_quota(tenant_id, attempted=len(new_identities)),
         ):
             for payload_agent in payload_agents:
                 name = payload_agent.get("name", "unknown-agent")
-                existing = existing_by_name.get(name)
+                payload_source_id = str(payload_agent.get("source_id") or source_id or "server-discovery")
+                identity_key = (payload_source_id, str(name))
+                existing = existing_by_identity.get(identity_key) or existing_by_legacy_name.get(str(name))
                 server_count, pkg_count, cred_count, vuln_count = _payload_counts(payload_agent)
                 score = float(payload_agent.get("trust_score", 0.0) or 0.0)
                 factors = dict(payload_agent.get("trust_factors", {}) or {})
-                payload_source_id = str(payload_agent.get("source_id") or source_id or "")
                 payload_enrollment_name = str(payload_agent.get("enrollment_name") or "")
                 payload_mdm_provider = str(payload_agent.get("mdm_provider") or "")
                 payload_owner = payload_agent.get("owner")

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -159,7 +159,7 @@ def serve_cmd(
         )
         sys.exit(2)
 
-    from agent_bom.gateway_server import GatewaySettings, create_gateway_app
+    from agent_bom.gateway_server import GatewaySettings, build_control_plane_audit_sink, create_gateway_app
     from agent_bom.gateway_upstreams import (
         UpstreamConfigError,
         UpstreamRegistry,
@@ -213,10 +213,12 @@ def serve_cmd(
         except RuntimeError as exc:
             raise click.ClickException(str(exc)) from exc
 
+    audit_sink = build_control_plane_audit_sink(control_plane_url, control_plane_token, source_id="gateway") if control_plane_url else None
+
     settings = GatewaySettings(
         registry=registry,
         policy=policy,
-        audit_sink=None,
+        audit_sink=audit_sink,
         bearer_token=bearer_token,
         enable_visual_leak_detection=detect_visual_leaks,
         require_visual_leak_detection_ready=detect_visual_leaks and not allow_visual_leak_best_effort,

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -10,8 +10,8 @@ Design doc: docs/design/MULTI_MCP_GATEWAY.md.
 MVP scope:
   * Request/response relay over HTTP (POST). Streamable-HTTP transport
     with bidirectional streaming is a v2 addition — the MVP handles
-    the dominant case (``tools/call``, ``tools/list``) where the client
-    expects one response per request.
+    the dominant request/response case where the client expects one
+    response per request.
   * Policy evaluation via ``agent_bom.proxy.check_policy`` (reused —
     no new policy engine).
   * Audit events emitted via a caller-supplied sink; in-cluster deploys
@@ -33,6 +33,7 @@ import logging
 import os
 import threading
 import time
+import uuid
 from contextlib import asynccontextmanager, nullcontext
 from dataclasses import dataclass
 from pathlib import Path
@@ -41,16 +42,18 @@ from typing import Any, Awaitable, Callable
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, Response
 
-from agent_bom.api.auth import get_key_store
+from agent_bom.api.auth import Role, get_key_store
 from agent_bom.api.metrics import record_gateway_relay, record_rate_limit_hit
 from agent_bom.api.middleware import InMemoryRateLimitStore, PostgresRateLimitStore
 from agent_bom.api.tracing import get_tracer, inject_trace_headers, make_request_trace
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
-from agent_bom.proxy import check_policy, is_tools_call, parse_jsonrpc
+from agent_bom.proxy import check_policy, is_tools_call, parse_jsonrpc, policy_subject_from_message
 from agent_bom.proxy_policy import summarize_policy_bundle
 
 logger = logging.getLogger(__name__)
 _GATEWAY_TRACER = get_tracer("agent_bom.gateway")
+_MAX_GATEWAY_MESSAGE_BYTES = 2 * 1024 * 1024
+_GATEWAY_RELAY_SCOPE = "gateway:relay"
 
 AuditSink = Callable[[dict[str, Any]], Awaitable[None]]
 UpstreamCaller = Callable[[UpstreamConfig, dict[str, Any], dict[str, str]], Awaitable[dict[str, Any]]]
@@ -194,6 +197,24 @@ def _gateway_requires_auth(settings: GatewaySettings) -> bool:
         return False
 
 
+def _role_allows_gateway_relay(role: object) -> bool:
+    try:
+        normalized = role if isinstance(role, Role) else Role(str(role).lower())
+    except ValueError:
+        return False
+    return normalized in {Role.ADMIN, Role.ANALYST}
+
+
+def _api_key_allows_gateway_relay(api_key: Any) -> tuple[bool, str]:
+    if not _role_allows_gateway_relay(getattr(api_key, "role", None)):
+        role_value = getattr(getattr(api_key, "role", None), "value", getattr(api_key, "role", "unknown"))
+        return False, f"gateway relay requires analyst role or higher; key has {role_value}"
+    has_scope = getattr(api_key, "has_scope", None)
+    if callable(has_scope) and not has_scope(_GATEWAY_RELAY_SCOPE):
+        return False, f"gateway relay requires {_GATEWAY_RELAY_SCOPE} scope"
+    return True, ""
+
+
 def _authenticate_gateway_request(request: Request, settings: GatewaySettings) -> tuple[str, str]:
     raw_token = _extract_request_token(request)
     if settings.bearer_token:
@@ -207,6 +228,9 @@ def _authenticate_gateway_request(request: Request, settings: GatewaySettings) -
             api_key = store.verify(raw_token) if raw_token else None
             if api_key is None:
                 raise HTTPException(status_code=401, detail="gateway authentication required")
+            allowed, reason = _api_key_allows_gateway_relay(api_key)
+            if not allowed:
+                raise HTTPException(status_code=403, detail=reason)
             return api_key.tenant_id or "default", "api_key"
     except HTTPException:
         raise
@@ -262,11 +286,46 @@ async def _default_upstream_caller(
     async with httpx.AsyncClient(timeout=30.0) as client:
         response = await client.post(upstream.url, json=message, headers=headers)
         response.raise_for_status()
+        if len(response.content) > _MAX_GATEWAY_MESSAGE_BYTES:
+            raise ValueError(f"upstream response exceeded {_MAX_GATEWAY_MESSAGE_BYTES} bytes")
         if response.headers.get("content-type", "").startswith("application/json"):
             return response.json()
         # Some upstreams return text/event-stream; MVP treats non-JSON as an opaque
         # body wrapped in a success envelope so policy + audit still fire.
         return {"jsonrpc": "2.0", "id": message.get("id"), "result": {"raw": response.text}}
+
+
+def build_control_plane_audit_sink(
+    base_url: str,
+    token: str | None,
+    *,
+    source_id: str = "gateway",
+    session_id: str | None = None,
+) -> AuditSink:
+    """Build an audit sink that forwards gateway runtime events to the API."""
+    audit_url = base_url.rstrip("/") + "/v1/proxy/audit"
+    active_session_id = session_id or str(uuid.uuid4())
+
+    async def _sink(event: dict[str, Any]) -> None:
+        import httpx
+
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        payload = {
+            "source_id": source_id,
+            "session_id": active_session_id,
+            "idempotency_key": event.get("event_id") or str(uuid.uuid4()),
+            "alerts": [event],
+        }
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(connect=5.0, read=10.0, write=10.0, pool=5.0)) as client:
+                response = await client.post(audit_url, json=payload, headers=headers)
+                response.raise_for_status()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Gateway audit push failed: %s", _sanitize_for_log(exc))
+
+    return _sink
 
 
 def create_gateway_app(settings: GatewaySettings) -> FastAPI:
@@ -399,8 +458,20 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         if upstream is None:
             raise HTTPException(status_code=404, detail=f"unknown upstream {server_name!r}")
 
+        content_length = request.headers.get("content-length")
+        if content_length:
+            try:
+                if int(content_length) > _MAX_GATEWAY_MESSAGE_BYTES:
+                    raise HTTPException(status_code=413, detail="gateway request exceeds maximum JSON-RPC message size")
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail="invalid Content-Length header") from exc
+
+        raw_body = await request.body()
+        if len(raw_body) > _MAX_GATEWAY_MESSAGE_BYTES:
+            raise HTTPException(status_code=413, detail="gateway request exceeds maximum JSON-RPC message size")
+
         try:
-            body = await request.json()
+            body = json.loads(raw_body)
         except Exception as exc:  # noqa: BLE001
             raise HTTPException(status_code=400, detail=f"body is not valid JSON: {exc}") from exc
 
@@ -448,19 +519,19 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                     },
                 )
 
-        if is_tools_call(message):
-            params = message.get("params", {}) or {}
-            tool_name = params.get("name", "")
-            arguments = params.get("arguments", {}) or {}
+        policy_subject = policy_subject_from_message(message)
+        if policy_subject:
+            tool_name, arguments = policy_subject
             async with policy_lock:
                 current_policy = dict(policy_state["policy"])
             allowed, reason = check_policy(current_policy, tool_name, arguments)
             if not allowed:
                 record_gateway_relay(upstream.name, "blocked")
                 audit_event: dict[str, Any] = {
-                    "action": "gateway.tool_call_blocked",
+                    "action": "gateway.policy_blocked",
                     "upstream": upstream.name,
                     "tenant_id": tenant_id,
+                    "method": message.get("method"),
                     "tool": tool_name,
                     "reason": reason,
                 }
@@ -610,6 +681,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
 # Re-export the parser for easier test authoring / CLI glue.
 __all__ = [
     "GatewaySettings",
+    "build_control_plane_audit_sink",
     "create_gateway_app",
     "parse_jsonrpc",
 ]

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -127,6 +127,30 @@ def is_tools_call(msg: dict) -> bool:
     return msg.get("method") == "tools/call"
 
 
+_POLICY_GATED_METHODS = {
+    "prompts/get",
+    "resources/read",
+    "sampling/createMessage",
+}
+
+
+def policy_subject_from_message(msg: dict) -> tuple[str, dict] | None:
+    """Return the policy subject and arguments for gated JSON-RPC methods."""
+    if is_tools_call(msg):
+        return extract_tool_name(msg) or "unknown", extract_tool_arguments(msg)
+
+    method = msg.get("method")
+    if not isinstance(method, str):
+        return None
+    if method not in _POLICY_GATED_METHODS and not method.startswith("mcp_extension/"):
+        return None
+
+    params = msg.get("params", {})
+    if isinstance(params, dict):
+        return method, params
+    return method, {"params": params}
+
+
 def is_tools_list_response(msg: dict, request_id: Optional[int | str] = None) -> bool:
     """Check if a JSON-RPC message is a tools/list response."""
     if "result" not in msg:
@@ -166,6 +190,17 @@ def make_error_response(request_id: int | str | None, code: int, message: str) -
             "message": message,
         },
     }
+
+
+def sandbox_posture_warning(sandbox_evidence: Mapping[str, object]) -> str | None:
+    """Return an operator-visible warning when proxy isolation is not active."""
+    if sandbox_evidence.get("enabled"):
+        return None
+    return (
+        "agent-bom proxy warning: sandbox isolation is disabled; the MCP server "
+        "runs as the current host user. Set AGENT_BOM_MCP_SANDBOX=1 or pass "
+        "--sandbox to run the server in a restricted container."
+    )
 
 
 # ─── Proxy core ──────────────────────────────────────────────────────────────
@@ -1233,6 +1268,10 @@ async def run_proxy(
     elif sandbox_config:
         sandbox_evidence = sandbox_config.evidence()
 
+    if warning := sandbox_posture_warning(sandbox_evidence):
+        sys.stderr.write(warning + "\n")
+        logger.warning(warning)
+
     # Validate the effective server command before spawning
     validate_command(server_cmd[0])
     if len(server_cmd) > 1:
@@ -1311,10 +1350,10 @@ async def run_proxy(
                 if msg.get("method") == "tools/list" and "id" in msg:
                     tools_list_request_ids.add(msg["id"])
 
-                # Intercept tools/call requests
-                if is_tools_call(msg):
-                    tool_name = extract_tool_name(msg) or "unknown"
-                    arguments = extract_tool_arguments(msg)
+                # Intercept policy-gated JSON-RPC requests.
+                policy_subject = policy_subject_from_message(msg)
+                if policy_subject:
+                    tool_name, arguments = policy_subject
                     msg_id = msg.get("id")
 
                     # Payload integrity: hash the full message

--- a/src/agent_bom/proxy_policy.py
+++ b/src/agent_bom/proxy_policy.py
@@ -247,7 +247,7 @@ def check_policy(policy: dict, tool_name: str, arguments: dict) -> tuple[bool, s
             continue
 
         blocked = rule.get("block_tools", [])
-        if blocked and tool_name in blocked:
+        if blocked and ("*" in blocked or tool_name in blocked):
             return False, f"Tool '{tool_name}' is blocked by rule '{rule.get('id', '?')}'"
 
         denied_classes = {str(item).lower() for item in rule.get("deny_tool_classes", [])}

--- a/tests/test_api_fleet.py
+++ b/tests/test_api_fleet.py
@@ -321,6 +321,34 @@ def test_sync_persists_endpoint_identity_metadata():
     assert agent.mdm_provider == "jamf"
 
 
+def test_sync_keeps_same_agent_name_separate_per_endpoint():
+    client, store = _fresh_client()
+    for source_id, owner in (("device-a", "alice"), ("device-b", "bob")):
+        resp = client.post(
+            "/v1/fleet/sync",
+            json={
+                "source_id": source_id,
+                "agents": [
+                    {
+                        "name": "claude-desktop",
+                        "agent_type": "claude_desktop",
+                        "source_id": source_id,
+                        "owner": owner,
+                        "trust_score": 80,
+                        "mcp_servers": [],
+                    }
+                ],
+            },
+        )
+        assert resp.status_code == 200
+
+    agents = sorted(store.list_all(), key=lambda agent: agent.source_id)
+    assert [(agent.name, agent.source_id, agent.owner) for agent in agents] == [
+        ("claude-desktop", "device-a", "alice"),
+        ("claude-desktop", "device-b", "bob"),
+    ]
+
+
 def test_sync_endpoint_push_is_idempotent():
     client, store = _fresh_client()
     payload = {

--- a/tests/test_control_plane_contracts.py
+++ b/tests/test_control_plane_contracts.py
@@ -17,6 +17,7 @@ import pytest
 from starlette.testclient import TestClient
 
 from agent_bom.api import stores as _stores
+from agent_bom.api.auth import Role
 from agent_bom.api.metrics import reset_for_tests as reset_metrics
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.pipeline import _persist_graph_snapshot
@@ -214,7 +215,16 @@ def test_control_plane_contract_scan_graph_policy_audit_flow(control_plane_contr
 
         def verify(self, raw_key: str):
             if raw_key == "tenant-alpha-key":
-                return type("ApiKey", (), {"tenant_id": "tenant-alpha"})()
+                return type(
+                    "ApiKey",
+                    (),
+                    {
+                        "tenant_id": "tenant-alpha",
+                        "role": Role.ANALYST,
+                        "scopes": ["gateway:relay"],
+                        "has_scope": lambda self, scope: scope in self.scopes,
+                    },
+                )()
             return None
 
     monkeypatch.setattr("agent_bom.gateway_server.get_key_store", lambda: _FakeKeyStore())
@@ -243,7 +253,7 @@ def test_control_plane_contract_scan_graph_policy_audit_flow(control_plane_contr
     assert blocked.status_code == 200
     assert blocked.json()["error"]["code"] == -32001
     assert upstream_calls == []
-    assert any(event["action"] == "gateway.tool_call_blocked" for event in audit_events)
+    assert any(event["action"] == "gateway.policy_blocked" for event in audit_events)
     assert audit_events[-1]["tenant_id"] == "tenant-alpha"
 
     allowed = gw.post(

--- a/tests/test_gateway_auth_tenant_e2e.py
+++ b/tests/test_gateway_auth_tenant_e2e.py
@@ -15,7 +15,7 @@ The scenario a pilot team actually walks through:
    ``jira`` on top of what discovery returned.
 5. A client calls ``POST /mcp/jira`` on the gateway with a policy-blocked
    tool name. The gateway blocks BEFORE the upstream is touched, records
-   a ``gateway.tool_call_blocked`` audit event via the sink, bumps the
+   a ``gateway.policy_blocked`` audit event via the sink, bumps the
    ``agent_bom_gateway_relays_total{outcome="blocked"}`` metric, and
    returns the JSON-RPC error envelope.
 6. A second call with an allowed tool makes it through to the (fake)
@@ -35,6 +35,7 @@ import pytest
 from starlette.testclient import TestClient
 
 from agent_bom.api import stores as _stores
+from agent_bom.api.auth import Role
 from agent_bom.api.metrics import reset_for_tests as reset_metrics
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.server import app
@@ -181,7 +182,16 @@ def test_full_pilot_flow_auth_tenant_discovery_relay_policy_audit_metrics(pilot_
 
             def verify(self, raw_key: str):
                 if raw_key == "tenant-alpha-gateway-key":
-                    return type("ApiKey", (), {"tenant_id": "tenant-alpha"})()
+                    return type(
+                        "ApiKey",
+                        (),
+                        {
+                            "tenant_id": "tenant-alpha",
+                            "role": Role.ANALYST,
+                            "scopes": ["gateway:relay"],
+                            "has_scope": lambda self, scope: scope in self.scopes,
+                        },
+                    )()
                 return None
 
         monkeypatch.setattr("agent_bom.gateway_server.get_key_store", lambda: _FakeKeyStore())
@@ -210,7 +220,7 @@ def test_full_pilot_flow_auth_tenant_discovery_relay_policy_audit_metrics(pilot_
         assert err["code"] == -32001
         assert "Blocked" in err["message"]
         assert upstream_calls == [], "blocked call reached upstream"
-        blocked_events = [e for e in audit if e["action"] == "gateway.tool_call_blocked"]
+        blocked_events = [e for e in audit if e["action"] == "gateway.policy_blocked"]
         assert len(blocked_events) == 1
         assert blocked_events[0]["upstream"] == "jira"
         assert blocked_events[0]["tool"] == "run_shell"

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -24,6 +24,7 @@ from typing import Any
 
 from starlette.testclient import TestClient
 
+from agent_bom.api.auth import Role
 from agent_bom.api.tracing import parse_traceparent
 from agent_bom.gateway_server import GatewaySettings, create_gateway_app
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
@@ -45,6 +46,16 @@ def _json_rpc(method: str, **params: Any) -> dict[str, Any]:
         "method": method,
         "params": params,
     }
+
+
+def _gateway_api_key(tenant_id: str, *, role: Role = Role.ANALYST, scopes: list[str] | None = None) -> SimpleNamespace:
+    allowed_scopes = scopes if scopes is not None else ["gateway:relay"]
+    return SimpleNamespace(
+        tenant_id=tenant_id,
+        role=role,
+        scopes=allowed_scopes,
+        has_scope=lambda required: not allowed_scopes or required in allowed_scopes or "*" in allowed_scopes,
+    )
 
 
 # ─── Happy path: relay returns upstream response verbatim ──────────────────
@@ -326,7 +337,7 @@ def test_relay_accepts_control_plane_api_key_and_applies_tenant(monkeypatch) -> 
 
         def verify(self, raw_key: str):
             if raw_key == "tenant-alpha-key":
-                return SimpleNamespace(tenant_id="tenant-alpha")
+                return _gateway_api_key("tenant-alpha")
             return None
 
     monkeypatch.setattr("agent_bom.gateway_server.get_key_store", lambda: _FakeKeyStore())
@@ -355,6 +366,71 @@ def test_relay_accepts_control_plane_api_key_and_applies_tenant(monkeypatch) -> 
     assert audit_events[-1]["tenant_id"] == "tenant-alpha"
 
 
+def test_relay_rejects_viewer_api_key_before_forwarding(monkeypatch) -> None:
+    upstream_calls: list[dict[str, Any]] = []
+
+    async def fake_caller(upstream, message, extra_headers):
+        upstream_calls.append(message)
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    class _FakeKeyStore:
+        def has_keys(self) -> bool:
+            return True
+
+        def verify(self, raw_key: str):
+            if raw_key == "viewer-key":
+                return _gateway_api_key("tenant-alpha", role=Role.VIEWER)
+            return None
+
+    monkeypatch.setattr("agent_bom.gateway_server.get_key_store", lambda: _FakeKeyStore())
+
+    settings = GatewaySettings(registry=_simple_registry(), policy={}, upstream_caller=fake_caller)
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post(
+        "/mcp/filesystem",
+        headers={"X-API-Key": "viewer-key"},
+        json=_json_rpc("tools/call", name="write_file", arguments={"path": "/tmp/x"}),
+    )
+    assert resp.status_code == 403
+    assert "requires analyst role" in resp.json()["detail"]
+    assert upstream_calls == []
+
+
+def test_relay_rejects_api_key_without_gateway_scope(monkeypatch) -> None:
+    upstream_calls: list[dict[str, Any]] = []
+
+    async def fake_caller(upstream, message, extra_headers):
+        upstream_calls.append(message)
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    class _FakeKeyStore:
+        def has_keys(self) -> bool:
+            return True
+
+        def verify(self, raw_key: str):
+            if raw_key == "analyst-no-gateway":
+                return SimpleNamespace(
+                    tenant_id="tenant-alpha",
+                    role=Role.ANALYST,
+                    scopes=["scan:read"],
+                    has_scope=lambda required: required == "scan:read",
+                )
+            return None
+
+    monkeypatch.setattr("agent_bom.gateway_server.get_key_store", lambda: _FakeKeyStore())
+
+    settings = GatewaySettings(registry=_simple_registry(), policy={}, upstream_caller=fake_caller)
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post(
+        "/mcp/filesystem",
+        headers={"X-API-Key": "analyst-no-gateway"},
+        json=_json_rpc("tools/call", name="read_file", arguments={"path": "/tmp/x"}),
+    )
+    assert resp.status_code == 403
+    assert "gateway:relay" in resp.json()["detail"]
+    assert upstream_calls == []
+
+
 def test_relay_routes_same_upstream_name_by_authenticated_tenant(monkeypatch) -> None:
     upstream_calls: list[dict[str, Any]] = []
 
@@ -368,9 +444,9 @@ def test_relay_routes_same_upstream_name_by_authenticated_tenant(monkeypatch) ->
 
         def verify(self, raw_key: str):
             if raw_key == "tenant-alpha-key":
-                return SimpleNamespace(tenant_id="tenant-alpha")
+                return _gateway_api_key("tenant-alpha")
             if raw_key == "tenant-beta-key":
-                return SimpleNamespace(tenant_id="tenant-beta")
+                return _gateway_api_key("tenant-beta")
             return None
 
     monkeypatch.setattr("agent_bom.gateway_server.get_key_store", lambda: _FakeKeyStore())
@@ -412,7 +488,7 @@ def test_relay_fails_closed_when_tenant_has_no_matching_upstream(monkeypatch) ->
 
         def verify(self, raw_key: str):
             if raw_key == "tenant-beta-key":
-                return SimpleNamespace(tenant_id="tenant-beta")
+                return _gateway_api_key("tenant-beta")
             return None
 
     monkeypatch.setattr("agent_bom.gateway_server.get_key_store", lambda: _FakeKeyStore())
@@ -441,9 +517,9 @@ def test_gateway_rate_limit_is_tenant_scoped(monkeypatch) -> None:
 
         def verify(self, raw_key: str):
             if raw_key == "tenant-alpha-key":
-                return SimpleNamespace(tenant_id="tenant-alpha")
+                return _gateway_api_key("tenant-alpha")
             if raw_key == "tenant-beta-key":
-                return SimpleNamespace(tenant_id="tenant-beta")
+                return _gateway_api_key("tenant-beta")
             return None
 
     monkeypatch.setattr("agent_bom.gateway_server.get_key_store", lambda: _FakeKeyStore())
@@ -490,7 +566,7 @@ def test_gateway_rate_limit_shared_store_holds_under_concurrency(monkeypatch) ->
 
         def verify(self, raw_key: str):
             if raw_key == "tenant-alpha-key":
-                return SimpleNamespace(tenant_id="tenant-alpha")
+                return _gateway_api_key("tenant-alpha")
             return None
 
     class _ConcurrentSharedStore:
@@ -611,7 +687,8 @@ def test_relay_blocks_tool_by_policy() -> None:
     assert upstream_calls == []
     # And the audit trail must record the block with the tool name + reason
     assert len(audit_events) == 1
-    assert audit_events[0]["action"] == "gateway.tool_call_blocked"
+    assert audit_events[0]["action"] == "gateway.policy_blocked"
+    assert audit_events[0]["method"] == "tools/call"
     assert audit_events[0]["tool"] == "run_shell"
     assert "no-shell" in (audit_events[0]["reason"] or "")
 
@@ -781,8 +858,8 @@ def test_relay_upstream_timeout_surfaces_as_502_and_is_audited() -> None:
     ]
 
 
-def test_relay_non_tool_message_bypasses_policy_and_forwards() -> None:
-    """tools/list and other non-tools/call methods must pass through without a policy check."""
+def test_relay_tools_list_bypasses_policy_and_forwards() -> None:
+    """Discovery methods pass through; executable/runtime methods are gated."""
     upstream_calls: list[dict[str, Any]] = []
 
     async def fake_caller(upstream, message, extra_headers):
@@ -798,6 +875,52 @@ def test_relay_non_tool_message_bypasses_policy_and_forwards() -> None:
     resp = client.post("/mcp/filesystem", json=_json_rpc("tools/list"))
     assert resp.status_code == 200
     assert upstream_calls and upstream_calls[0]["method"] == "tools/list"
+
+
+def test_relay_blocks_resource_prompt_sampling_methods_by_policy() -> None:
+    upstream_calls: list[dict[str, Any]] = []
+    audit_events: list[dict[str, Any]] = []
+
+    async def fake_caller(upstream, message, extra_headers):
+        upstream_calls.append(message)
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    async def audit_sink(event):
+        audit_events.append(event)
+
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={"rules": [{"id": "block-runtime", "action": "block", "block_tools": ["*"]}]},
+        upstream_caller=fake_caller,
+        audit_sink=audit_sink,
+    )
+    client = TestClient(create_gateway_app(settings))
+    for method, params in (
+        ("resources/read", {"uri": "file:///etc/passwd"}),
+        ("prompts/get", {"name": "prod-secrets"}),
+        ("sampling/createMessage", {"messages": [{"role": "user", "content": "exfiltrate"}]}),
+    ):
+        resp = client.post("/mcp/filesystem", json={**_json_rpc(method), "params": params})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["error"]["code"] == -32001
+        assert method in body["error"]["data"]["reason"]
+
+    assert upstream_calls == []
+    assert [event["method"] for event in audit_events] == ["resources/read", "prompts/get", "sampling/createMessage"]
+
+
+def test_relay_rejects_oversized_jsonrpc_request() -> None:
+    settings = GatewaySettings(registry=_simple_registry(), policy={})
+    client = TestClient(create_gateway_app(settings))
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "read_file", "arguments": {"blob": "x" * (2 * 1024 * 1024 + 1)}},
+    }
+    resp = client.post("/mcp/filesystem", json=payload)
+    assert resp.status_code == 413
 
 
 def test_visual_detector_singleton_init_is_locked(monkeypatch) -> None:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -35,6 +35,8 @@ from agent_bom.proxy import (
     is_tools_call,
     log_tool_call,
     parse_jsonrpc,
+    policy_subject_from_message,
+    sandbox_posture_warning,
 )
 from agent_bom.proxy_audit import _AUDIT_CHAIN_STATE, write_audit_record
 
@@ -142,6 +144,47 @@ def test_is_tools_call_false():
     assert is_tools_call(msg) is False
 
 
+def test_policy_subject_maps_tool_calls_to_tool_name_and_arguments():
+    msg = {
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "id": 1,
+        "params": {"name": "read_file", "arguments": {"path": "/etc/passwd"}},
+    }
+    assert policy_subject_from_message(msg) == ("read_file", {"path": "/etc/passwd"})
+
+
+def test_policy_subject_gates_resource_prompt_sampling_and_extensions():
+    assert policy_subject_from_message({"method": "resources/read", "params": {"uri": "file:///etc/passwd"}}) == (
+        "resources/read",
+        {"uri": "file:///etc/passwd"},
+    )
+    assert policy_subject_from_message({"method": "prompts/get", "params": {"name": "prod"}}) == (
+        "prompts/get",
+        {"name": "prod"},
+    )
+    assert policy_subject_from_message({"method": "sampling/createMessage", "params": {"maxTokens": 1000}}) == (
+        "sampling/createMessage",
+        {"maxTokens": 1000},
+    )
+    assert policy_subject_from_message({"method": "mcp_extension/doSensitiveThing", "params": {"scope": "admin"}}) == (
+        "mcp_extension/doSensitiveThing",
+        {"scope": "admin"},
+    )
+
+
+def test_policy_subject_leaves_discovery_methods_ungated():
+    assert policy_subject_from_message({"method": "tools/list", "params": {}}) is None
+
+
+def test_sandbox_posture_warning_is_visible_when_disabled():
+    warning = sandbox_posture_warning({"enabled": False})
+    assert warning is not None
+    assert "sandbox isolation is disabled" in warning
+    assert "AGENT_BOM_MCP_SANDBOX=1" in warning
+    assert sandbox_posture_warning({"enabled": True}) is None
+
+
 # ── extract_tool_name ────────────────────────────────────────────────────────
 
 
@@ -203,6 +246,14 @@ def test_check_policy_blocks_tool():
     assert allowed is False
     assert "exec_cmd" in reason
     assert "block-exec" in reason
+
+
+def test_check_policy_block_tools_wildcard_blocks_gated_methods():
+    policy = {"rules": [{"id": "block-all", "action": "block", "block_tools": ["*"]}]}
+    allowed, reason = check_policy(policy, "resources/read", {"uri": "file:///etc/passwd"})
+    assert allowed is False
+    assert "resources/read" in reason
+    assert "block-all" in reason
 
 
 def test_check_policy_blocks_arg_pattern():

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -19,6 +19,8 @@ import { MeshStats } from "@/components/mesh-stats";
 import {
   buildMeshGraph,
   getConnectedIds,
+  getMeshAgentKey,
+  getMeshAgentLabel,
   searchNodes,
   type NodeTypeFilter,
   type SeverityFilter,
@@ -50,7 +52,7 @@ function MeshToolbar({
   setSearchQuery,
   vulnerableOnly,
   setVulnerableOnly,
-  agentNames,
+  agentOptions,
   selectedAgents,
   toggleAgent,
 }: {
@@ -62,7 +64,7 @@ function MeshToolbar({
   setSearchQuery: (q: string) => void;
   vulnerableOnly: boolean;
   setVulnerableOnly: (next: boolean) => void;
-  agentNames: string[];
+  agentOptions: { key: string; label: string }[];
   selectedAgents: string[];
   toggleAgent: (name: string) => void;
 }) {
@@ -137,24 +139,24 @@ function MeshToolbar({
         )}
       </div>
 
-      {agentNames.length > 0 && (
+      {agentOptions.length > 0 && (
         <>
           <div className="w-px h-4 bg-zinc-700" />
           <div className="flex items-center gap-1.5 overflow-x-auto max-w-[28rem] pb-1">
-            {agentNames.map((name) => {
-              const active = selectedAgents.includes(name);
+            {agentOptions.map(({ key, label }) => {
+              const active = selectedAgents.includes(key);
               return (
                 <button
-                  key={name}
+                  key={key}
                   type="button"
-                  onClick={() => toggleAgent(name)}
+                  onClick={() => toggleAgent(key)}
                   className={`rounded-full border px-2.5 py-1 text-[11px] transition ${
                     active
                       ? "border-emerald-500/50 bg-emerald-500/10 text-emerald-200"
                       : "border-zinc-700 bg-zinc-900/70 text-zinc-500 hover:border-zinc-500 hover:text-zinc-300"
                   }`}
                 >
-                  {name}
+                  {label}
                 </button>
               );
             })}
@@ -239,15 +241,16 @@ export default function MeshPage() {
 
   const activeResult = useMemo(() => activeJob?.result ?? null, [activeJob]);
 
-  const agentNames = useMemo(
-    () =>
-      activeResult
-        ? Array.from(new Set(activeResult.agents.map((agent) => agent.name))).sort((left, right) =>
-            left.localeCompare(right),
-          )
-        : [],
-    [activeResult],
-  );
+  const agentOptions = useMemo(() => {
+    if (!activeResult) return [];
+    const options = new Map<string, string>();
+    for (const agent of activeResult.agents) {
+      options.set(getMeshAgentKey(agent), getMeshAgentLabel(agent));
+    }
+    return [...options.entries()]
+      .map(([key, label]) => ({ key, label }))
+      .sort((left, right) => left.label.localeCompare(right.label));
+  }, [activeResult]);
 
   const rankedAgentNames = useMemo(() => {
     if (!activeResult) return [];
@@ -258,13 +261,14 @@ export default function MeshPage() {
           return packageTotal + (pkg.vulnerabilities?.length ?? 0);
         }, 0);
       }, 0);
-      scoreByAgent.set(agent.name, score);
+      scoreByAgent.set(getMeshAgentKey(agent), score);
     }
-    return [...agentNames].sort((left, right) => {
+    const labelByKey = new Map(agentOptions.map((option) => [option.key, option.label]));
+    return agentOptions.map((option) => option.key).sort((left, right) => {
       const scoreDiff = (scoreByAgent.get(right) ?? 0) - (scoreByAgent.get(left) ?? 0);
-      return scoreDiff !== 0 ? scoreDiff : left.localeCompare(right);
+      return scoreDiff !== 0 ? scoreDiff : (labelByKey.get(left) ?? left).localeCompare(labelByKey.get(right) ?? right);
     });
-  }, [activeResult, agentNames]);
+  }, [activeResult, agentOptions]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -468,7 +472,7 @@ export default function MeshPage() {
         setSearchQuery={setSearchQuery}
         vulnerableOnly={vulnerableOnly}
         setVulnerableOnly={setVulnerableOnly}
-        agentNames={agentNames}
+        agentOptions={agentOptions}
         selectedAgents={selectedAgents}
         toggleAgent={toggleAgent}
       />

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -219,6 +219,12 @@ export interface Agent {
   agent_type: string;
   config_path?: string | undefined;
   source?: string | undefined;
+  source_id?: string | undefined;
+  enrollment_name?: string | undefined;
+  owner?: string | undefined;
+  environment?: string | undefined;
+  mdm_provider?: string | undefined;
+  tags?: string[] | undefined;
   status?: AgentStatus | undefined;
   discovered_at?: string | undefined;
   last_seen?: string | undefined;

--- a/ui/lib/mesh-graph.ts
+++ b/ui/lib/mesh-graph.ts
@@ -27,6 +27,7 @@ export interface MeshStatsData {
 export interface ServerGroup {
   name: string;
   agents: Set<string>;
+  agentLabels: Map<string, string>;
   servers: MCPServer[];
   totalTools: number;
   totalCreds: number;
@@ -52,6 +53,30 @@ export interface MeshGraphScope {
 // ─── Credential detection ───────────────────────────────────────────────────
 
 const CRED_RE = /key|token|secret|password|credential|auth/i;
+
+function agentSourceId(agent: Agent): string {
+  const direct = typeof agent.source_id === "string" ? agent.source_id.trim() : "";
+  if (direct) return direct;
+  const metadataSource = agent.metadata?.source_id;
+  return typeof metadataSource === "string" ? metadataSource.trim() : "";
+}
+
+export function getMeshAgentKey(agent: Agent): string {
+  const sourceId = agentSourceId(agent);
+  return sourceId ? `${agent.name}@${sourceId}` : agent.name;
+}
+
+export function getMeshAgentLabel(agent: Agent): string {
+  const sourceId = agentSourceId(agent);
+  const enrollment = typeof agent.enrollment_name === "string" ? agent.enrollment_name.trim() : "";
+  const suffix = enrollment || sourceId;
+  return suffix ? `${agent.name} · ${suffix}` : agent.name;
+}
+
+function meshAgentNodeId(agentOrKey: Agent | string): string {
+  const key = typeof agentOrKey === "string" ? agentOrKey : getMeshAgentKey(agentOrKey);
+  return `agent:${key}`;
+}
 
 function getCredKeys(server: MCPServer): string[] {
   return server.env ? Object.keys(server.env).filter((k) => CRED_RE.test(k)) : [];
@@ -92,9 +117,10 @@ function normalizeAgents(agents: Agent[]): Agent[] {
   const merged = new Map<string, Agent>();
 
   for (const agent of agents) {
-    const existing = merged.get(agent.name);
+    const key = getMeshAgentKey(agent);
+    const existing = merged.get(key);
     if (!existing) {
-      merged.set(agent.name, {
+      merged.set(key, {
         ...agent,
         mcp_servers: [...agent.mcp_servers],
       });
@@ -111,7 +137,7 @@ function normalizeAgents(agents: Agent[]): Agent[] {
       serverMap.set(key, current ? mergeServers(current, server) : server);
     }
 
-    merged.set(agent.name, {
+    merged.set(key, {
       ...existing,
       agent_type: existing.agent_type || agent.agent_type,
       status: existing.status || agent.status,
@@ -128,12 +154,15 @@ export function detectSharedServers(agents: Agent[]): Map<string, ServerGroup> {
   const groups = new Map<string, ServerGroup>();
 
   for (const agent of agents) {
+    const agentKey = getMeshAgentKey(agent);
+    const agentLabel = getMeshAgentLabel(agent);
     for (const server of agent.mcp_servers) {
       const key = server.name;
       const existing = groups.get(key);
       const creds = getCredKeys(server);
       if (existing) {
-        existing.agents.add(agent.name);
+        existing.agents.add(agentKey);
+        existing.agentLabels.set(agentKey, agentLabel);
         existing.servers.push(server);
         existing.totalTools += server.tools?.length ?? 0;
         existing.totalCreds += creds.length;
@@ -142,7 +171,8 @@ export function detectSharedServers(agents: Agent[]): Map<string, ServerGroup> {
       } else {
         groups.set(key, {
           name: server.name,
-          agents: new Set([agent.name]),
+          agents: new Set([agentKey]),
+          agentLabels: new Map([[agentKey, agentLabel]]),
           servers: [server],
           totalTools: server.tools?.length ?? 0,
           totalCreds: creds.length,
@@ -220,7 +250,7 @@ export function buildMeshGraph(
   const vulnerableOnly = scope?.vulnerableOnly ?? false;
   const scopedAgents =
     selectedAgents.length > 0
-      ? result.agents.filter((agent) => selectedAgents.includes(agent.name))
+      ? result.agents.filter((agent) => selectedAgents.includes(getMeshAgentKey(agent)) || selectedAgents.includes(agent.name))
       : result.agents;
   const normalizedAgents = normalizeAgents(scopedAgents);
   const blastByVulnId = new Map(result.blast_radius?.map((item) => [item.vulnerability_id, item]) ?? []);
@@ -268,7 +298,7 @@ export function buildMeshGraph(
     for (const server of agent.mcp_servers) {
       for (const tool of server.tools ?? []) {
         const existing = toolAgentMap.get(tool.name) ?? new Set<string>();
-        existing.add(agent.name);
+        existing.add(getMeshAgentKey(agent));
         toolAgentMap.set(tool.name, existing);
       }
     }
@@ -286,7 +316,8 @@ export function buildMeshGraph(
 
   // ── Agent nodes ──
   for (const agent of activeAgents) {
-    const agentId = `agent:${agent.name}`;
+    const agentKey = getMeshAgentKey(agent);
+    const agentId = meshAgentNodeId(agentKey);
     const visibleServers = vulnerableOnly ? agent.mcp_servers.filter(hasVisiblePackage) : agent.mcp_servers;
     const visiblePackageCount = visibleServers.reduce((sum, server) => {
       return sum + server.packages.filter((pkg) => {
@@ -312,13 +343,21 @@ export function buildMeshGraph(
       type: "agentNode",
       position: { x: 0, y: 0 },
       data: {
-        label: agent.name,
+        label: getMeshAgentLabel(agent),
         nodeType: "agent",
         agentType: agent.agent_type,
         agentStatus: agent.status,
         serverCount: visibleServers.length,
         packageCount: visiblePackageCount,
         vulnCount: totalVulns,
+        attributes: {
+          source_id: agentSourceId(agent),
+          enrollment_name: agent.enrollment_name,
+          owner: agent.owner,
+          environment: agent.environment,
+          mdm_provider: agent.mdm_provider,
+          tags: agent.tags,
+        },
       } satisfies LineageNodeData,
     });
   }
@@ -342,18 +381,18 @@ export function buildMeshGraph(
         credentialCount: group.totalCreds,
         packageCount: group.totalPackages,
         sharedBy: group.agents.size,
-        sharedAgents: [...group.agents],
+        sharedAgents: [...group.agents].map((agentKey) => group.agentLabels.get(agentKey) ?? agentKey),
       } satisfies LineageNodeData,
     });
 
     // Agent → Server edges
-    for (const agentName of group.agents) {
-      const edgeId = `agent:${agentName}->server:${name}`;
+    for (const agentKey of group.agents) {
+      const edgeId = `${meshAgentNodeId(agentKey)}->server:${name}`;
       if (!seen.has(edgeId)) {
         seen.add(edgeId);
         edges.push({
           id: edgeId,
-          source: `agent:${agentName}`,
+          source: meshAgentNodeId(agentKey),
           target: serverId,
           type: "smoothstep",
           data: { relationship: "uses" },

--- a/ui/tests/mesh-graph.test.ts
+++ b/ui/tests/mesh-graph.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { ScanResult } from "@/lib/api";
-import { buildMeshGraph } from "@/lib/mesh-graph";
+import { buildMeshGraph, getMeshAgentKey } from "@/lib/mesh-graph";
 
 const baseResult: ScanResult = {
   agents: [
@@ -104,5 +104,62 @@ describe("buildMeshGraph", () => {
     expect(nodes.some((node) => node.id === "agent:cursor")).toBe(true);
     expect(nodes.some((node) => node.id === "server:filesystem")).toBe(true);
     expect(edges.some((edge) => edge.id === "agent:cursor->server:filesystem")).toBe(true);
+  });
+
+  it("keeps same-named agents separate across fleet endpoints", () => {
+    const fleetResult: ScanResult = {
+      agents: [
+        {
+          name: "claude-desktop",
+          agent_type: "desktop",
+          source_id: "device-a",
+          enrollment_name: "alice-mac",
+          mcp_servers: [
+            {
+              name: "filesystem",
+              packages: [
+                {
+                  name: "server-filesystem",
+                  version: "1.0.0",
+                  ecosystem: "npm",
+                  vulnerabilities: [{ id: "CVE-2026-0001", severity: "critical" }],
+                },
+              ],
+              tools: [],
+            },
+          ],
+        },
+        {
+          name: "claude-desktop",
+          agent_type: "desktop",
+          source_id: "device-b",
+          enrollment_name: "bob-mac",
+          mcp_servers: [
+            {
+              name: "filesystem",
+              packages: [
+                {
+                  name: "server-filesystem",
+                  version: "1.0.0",
+                  ecosystem: "npm",
+                  vulnerabilities: [{ id: "CVE-2026-0001", severity: "critical" }],
+                },
+              ],
+              tools: [],
+            },
+          ],
+        },
+      ],
+      blast_radius: [],
+    };
+
+    const { nodes, edges } = buildMeshGraph(fleetResult, undefined, "high");
+
+    expect(getMeshAgentKey(fleetResult.agents[0]!)).toBe("claude-desktop@device-a");
+    expect(nodes.some((node) => node.id === "agent:claude-desktop@device-a")).toBe(true);
+    expect(nodes.some((node) => node.id === "agent:claude-desktop@device-b")).toBe(true);
+    expect(nodes.filter((node) => node.data.label === "claude-desktop · alice-mac")).toHaveLength(1);
+    expect(edges.some((edge) => edge.id === "agent:claude-desktop@device-a->server:filesystem")).toBe(true);
+    expect(edges.some((edge) => edge.id === "agent:claude-desktop@device-b->server:filesystem")).toBe(true);
   });
 });


### PR DESCRIPTION
Summary

- preserve endpoint `source_id` when fleet sync receives same-named agents from different devices
- make Agent Mesh node identity endpoint-aware so `claude-desktop` on separate laptops renders as separate nodes instead of collapsing by display name
- surface endpoint labels in mesh filters and node metadata while keeping legacy local scans backwards-compatible

Why

Fleet deployments can have the same AI client installed on many endpoints. Collapsing by agent name hides which device/user/MDM enrollment owns a server, credential, tool, or vulnerable package. The fleet store already accepted endpoint metadata; this wires that identity through the sync and mesh surfaces.

Validation

- `pytest tests/test_api_fleet.py::test_sync_keeps_same_agent_name_separate_per_endpoint tests/test_api_fleet.py::test_sync_accepts_endpoint_push_payload tests/test_api_fleet.py::test_sync_endpoint_push_is_idempotent -q`
- `npm --prefix ui test -- mesh-graph.test.ts --run`
- `npm --prefix ui run typecheck`
- `ruff check src/agent_bom/api/routes/fleet.py tests/test_api_fleet.py`
- `mypy src/agent_bom/api/routes/fleet.py`
- `git diff --check`
