### PR TITLE
fix: harden gateway upstream resilience

### DIFF
--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -16,12 +16,12 @@ MVP scope:
     no new policy engine).
   * Audit events emitted via a caller-supplied sink; in-cluster deploys
     point it at ``/v1/proxy/audit``.
-  * Per-upstream static header / bearer auth injection from
+  * Pooled upstream HTTP relay with per-upstream circuit breakers.
+  * Per-upstream static header / bearer / OAuth2 auth injection from
     ``UpstreamRegistry``.
 
 Non-goals for MVP (see design doc):
   * stdio upstreams (per-MCP ``agent-bom proxy`` wrapper still handles these)
-  * OAuth2 client-credentials token refresh
   * SSE long-poll / Streamable HTTP streaming
 """
 
@@ -100,6 +100,112 @@ class GatewaySettings:
     require_shared_rate_limit: bool = False
     policy_path: Path | None = None
     policy_reload_interval_seconds: int = 0
+    upstream_failure_threshold: int = 3
+    upstream_circuit_cooldown_seconds: float = 30.0
+    upstream_http_timeout_seconds: float = 30.0
+    upstream_http_max_connections: int = 100
+    upstream_http_max_keepalive_connections: int = 20
+
+
+class GatewayCircuitOpenError(RuntimeError):
+    """Raised when an upstream circuit is open and calls should fail fast."""
+
+    def __init__(self, upstream_name: str, retry_after_seconds: float) -> None:
+        self.upstream_name = upstream_name
+        self.retry_after_seconds = max(1.0, retry_after_seconds)
+        super().__init__(f"upstream {upstream_name!r} circuit open; retry after {int(self.retry_after_seconds)}s")
+
+
+@dataclass
+class _CircuitState:
+    failures: int = 0
+    opened_until: float = 0.0
+
+
+class GatewayCircuitBreaker:
+    """Small per-upstream circuit breaker for gateway relay calls."""
+
+    def __init__(self, *, failure_threshold: int, cooldown_seconds: float) -> None:
+        self.failure_threshold = max(1, failure_threshold)
+        self.cooldown_seconds = max(1.0, cooldown_seconds)
+        self._states: dict[str, _CircuitState] = {}
+        self._lock = asyncio.Lock()
+
+    async def before_call(self, key: str, upstream_name: str) -> None:
+        now = time.monotonic()
+        async with self._lock:
+            state = self._states.get(key)
+            if state is None or state.opened_until <= 0:
+                return
+            if state.opened_until > now:
+                raise GatewayCircuitOpenError(upstream_name, state.opened_until - now)
+            # Half-open: allow one trial request and reset on success/failure path.
+            state.opened_until = 0.0
+
+    async def record_success(self, key: str) -> None:
+        async with self._lock:
+            self._states.pop(key, None)
+
+    async def record_failure(self, key: str) -> None:
+        now = time.monotonic()
+        async with self._lock:
+            state = self._states.setdefault(key, _CircuitState())
+            state.failures += 1
+            if state.failures >= self.failure_threshold:
+                state.opened_until = now + self.cooldown_seconds
+
+
+class GatewayUpstreamRelay:
+    """Lifecycle-managed upstream relay with connection pooling and breakers."""
+
+    def __init__(self, settings: GatewaySettings) -> None:
+        self._timeout_seconds = max(1.0, settings.upstream_http_timeout_seconds)
+        self._max_connections = max(1, settings.upstream_http_max_connections)
+        self._max_keepalive_connections = max(1, settings.upstream_http_max_keepalive_connections)
+        self._client: Any | None = None
+        self._client_lock = asyncio.Lock()
+        self._breaker = GatewayCircuitBreaker(
+            failure_threshold=settings.upstream_failure_threshold,
+            cooldown_seconds=settings.upstream_circuit_cooldown_seconds,
+        )
+
+    async def aclose(self) -> None:
+        async with self._client_lock:
+            if self._client is not None:
+                await self._client.aclose()
+                self._client = None
+
+    async def _client_for_call(self) -> Any:
+        if self._client is not None:
+            return self._client
+        async with self._client_lock:
+            if self._client is None:
+                import httpx
+
+                self._client = httpx.AsyncClient(
+                    timeout=httpx.Timeout(self._timeout_seconds),
+                    limits=httpx.Limits(
+                        max_connections=self._max_connections,
+                        max_keepalive_connections=self._max_keepalive_connections,
+                    ),
+                )
+            return self._client
+
+    async def __call__(
+        self,
+        upstream: UpstreamConfig,
+        message: dict[str, Any],
+        extra_headers: dict[str, str],
+    ) -> dict[str, Any]:
+        circuit_key = _upstream_circuit_key(upstream)
+        await self._breaker.before_call(circuit_key, upstream.name)
+        try:
+            response = await _post_upstream_jsonrpc(upstream, message, extra_headers, client=await self._client_for_call())
+        except Exception:
+            await self._breaker.record_failure(circuit_key)
+            raise
+        await self._breaker.record_success(circuit_key)
+        return response
 
 
 def _load_policy_file(policy_path: Path) -> dict[str, Any]:
@@ -281,18 +387,32 @@ async def _default_upstream_caller(
     """
     import httpx
 
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        return await _post_upstream_jsonrpc(upstream, message, extra_headers, client=client)
+
+
+def _upstream_circuit_key(upstream: UpstreamConfig) -> str:
+    return f"{upstream.tenant_id or 'global'}:{upstream.name}:{upstream.url}"
+
+
+async def _post_upstream_jsonrpc(
+    upstream: UpstreamConfig,
+    message: dict[str, Any],
+    extra_headers: dict[str, str],
+    *,
+    client: Any,
+) -> dict[str, Any]:
     auth_headers = await upstream.resolve_auth_headers()
     headers = {"Content-Type": "application/json", **auth_headers, **extra_headers}
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        response = await client.post(upstream.url, json=message, headers=headers)
-        response.raise_for_status()
-        if len(response.content) > _MAX_GATEWAY_MESSAGE_BYTES:
-            raise ValueError(f"upstream response exceeded {_MAX_GATEWAY_MESSAGE_BYTES} bytes")
-        if response.headers.get("content-type", "").startswith("application/json"):
-            return response.json()
-        # Some upstreams return text/event-stream; MVP treats non-JSON as an opaque
-        # body wrapped in a success envelope so policy + audit still fire.
-        return {"jsonrpc": "2.0", "id": message.get("id"), "result": {"raw": response.text}}
+    response = await client.post(upstream.url, json=message, headers=headers)
+    response.raise_for_status()
+    if len(response.content) > _MAX_GATEWAY_MESSAGE_BYTES:
+        raise ValueError(f"upstream response exceeded {_MAX_GATEWAY_MESSAGE_BYTES} bytes")
+    if response.headers.get("content-type", "").startswith("application/json"):
+        return response.json()
+    # Some upstreams return text/event-stream; MVP treats non-JSON as an opaque
+    # body wrapped in a success envelope so policy + audit still fire.
+    return {"jsonrpc": "2.0", "id": message.get("id"), "result": {"raw": response.text}}
 
 
 def build_control_plane_audit_sink(
@@ -339,7 +459,9 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
 
         require_visual_leak_runtime()
 
-    upstream_caller = settings.upstream_caller or _default_upstream_caller
+    managed_upstream_relay = GatewayUpstreamRelay(settings) if settings.upstream_caller is None else None
+    upstream_caller = settings.upstream_caller or managed_upstream_relay
+    assert upstream_caller is not None
     rate_limit_store = _build_gateway_rate_limit_store(settings)
     policy_state: dict[str, Any] = {
         "policy": dict(settings.policy),
@@ -393,6 +515,8 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                     reload_task = asyncio.create_task(_policy_reload_loop())
             yield
         finally:
+            if managed_upstream_relay is not None:
+                await managed_upstream_relay.aclose()
             if reload_task is not None:
                 reload_task.cancel()
                 try:
@@ -420,6 +544,14 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             "status": "ok",
             "upstreams": settings.registry.names(),
             "auth": {"incoming_token_required": _gateway_requires_auth(settings)},
+            "upstream_runtime": {
+                "pooled_http_client": managed_upstream_relay is not None,
+                "circuit_breaker_enabled": managed_upstream_relay is not None,
+                "failure_threshold": settings.upstream_failure_threshold,
+                "cooldown_seconds": settings.upstream_circuit_cooldown_seconds,
+                "max_connections": settings.upstream_http_max_connections,
+                "max_keepalive_connections": settings.upstream_http_max_keepalive_connections,
+            },
             "rate_limit_runtime": _gateway_rate_limit_runtime_status(settings),
             "policy_runtime": policy_runtime,
         }
@@ -583,6 +715,25 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                     if trace_meta["baggage"]:
                         span.set_attribute("agent_bom.gateway.baggage_present", True)
                 upstream_response = await upstream_caller(upstream, forwarded_message, extra_headers)
+        except GatewayCircuitOpenError as exc:
+            logger.warning("gateway upstream circuit open for %s", upstream.name)
+            record_gateway_relay(upstream.name, "circuit_open")
+            retry_after_header = str(int(exc.retry_after_seconds))
+            if settings.audit_sink is not None:
+                await settings.audit_sink(
+                    {
+                        "action": "gateway.upstream_circuit_open",
+                        "upstream": upstream.name,
+                        "tenant_id": tenant_id,
+                        "reason": "circuit_open",
+                        "retry_after_seconds": int(exc.retry_after_seconds),
+                    }
+                )
+            raise HTTPException(
+                status_code=503,
+                detail="upstream circuit open",
+                headers={"Retry-After": retry_after_header},
+            ) from exc
         except asyncio.TimeoutError as exc:
             logger.warning("gateway upstream call timed out for %s", upstream.name)
             record_gateway_relay(upstream.name, "upstream_timeout")

--- a/src/agent_bom/gateway_upstreams.py
+++ b/src/agent_bom/gateway_upstreams.py
@@ -13,6 +13,7 @@ ConfigMap or Secret. Reload = redeploy.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import threading
@@ -38,6 +39,8 @@ SUPPORTED_AUTH_MODES: tuple[str, ...] = ("none", "bearer", "oauth2_client_creden
 # IdP with the same credentials share a token.
 _oauth_cache_lock = threading.Lock()
 _oauth_cache: dict[tuple[str, str, tuple[str, ...]], tuple[str, float]] = {}
+_oauth_singleflight_lock = threading.Lock()
+_oauth_singleflight_locks: dict[tuple[str, str, tuple[str, ...]], asyncio.Lock] = {}
 
 
 def _cached_oauth_token(key: tuple[str, str, tuple[str, ...]]) -> str | None:
@@ -56,10 +59,21 @@ def _store_oauth_token(key: tuple[str, str, tuple[str, ...]], token: str, expire
         _oauth_cache[key] = (token, time.time() + max(30, expires_in))
 
 
+def _oauth_singleflight_for(key: tuple[str, str, tuple[str, ...]]) -> asyncio.Lock:
+    with _oauth_singleflight_lock:
+        lock = _oauth_singleflight_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            _oauth_singleflight_locks[key] = lock
+        return lock
+
+
 def reset_oauth_cache_for_tests() -> None:
     """Drop the process-wide OAuth2 token cache — test-only entry point."""
     with _oauth_cache_lock:
         _oauth_cache.clear()
+    with _oauth_singleflight_lock:
+        _oauth_singleflight_locks.clear()
 
 
 @dataclass(frozen=True)
@@ -143,6 +157,19 @@ class UpstreamConfig:
         if cached is not None:
             return cached
 
+        async with _oauth_singleflight_for(cache_key):
+            cached = _cached_oauth_token(cache_key)
+            if cached is not None:
+                return cached
+            return await self._fetch_and_store_oauth2_token(cache_key, self.oauth_token_url, client_id, client_secret)
+
+    async def _fetch_and_store_oauth2_token(
+        self,
+        cache_key: tuple[str, str, tuple[str, ...]],
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+    ) -> str:
         import httpx
 
         form: dict[str, str] = {
@@ -155,7 +182,7 @@ class UpstreamConfig:
 
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.post(
-                self.oauth_token_url,
+                token_url,
                 data=form,
                 headers={"Accept": "application/json"},
             )

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -26,7 +26,7 @@ from starlette.testclient import TestClient
 
 from agent_bom.api.auth import Role
 from agent_bom.api.tracing import parse_traceparent
-from agent_bom.gateway_server import GatewaySettings, create_gateway_app
+from agent_bom.gateway_server import GatewaySettings, GatewayUpstreamRelay, create_gateway_app
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
 
 
@@ -70,6 +70,14 @@ def test_healthz_lists_configured_upstreams() -> None:
         "status": "ok",
         "upstreams": ["filesystem", "jira"],
         "auth": {"incoming_token_required": False},
+        "upstream_runtime": {
+            "pooled_http_client": True,
+            "circuit_breaker_enabled": True,
+            "failure_threshold": 3,
+            "cooldown_seconds": 30.0,
+            "max_connections": 100,
+            "max_keepalive_connections": 20,
+        },
         "rate_limit_runtime": {
             "enabled": False,
             "limit_per_tenant_per_minute": 0,
@@ -854,6 +862,86 @@ def test_relay_upstream_timeout_surfaces_as_502_and_is_audited() -> None:
             "tenant_id": "default",
             "error": "timeout",
             "reason": "timeout",
+        }
+    ]
+
+
+def test_managed_upstream_relay_opens_circuit_after_repeated_failures() -> None:
+    class _FailingResponse:
+        content = b'{"error":"boom"}'
+        headers = {"content-type": "application/json"}
+
+        def raise_for_status(self) -> None:
+            raise RuntimeError("upstream down")
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.posts = 0
+
+        async def post(self, *_args, **_kwargs):
+            self.posts += 1
+            return _FailingResponse()
+
+        async def aclose(self) -> None:
+            pass
+
+    async def _exercise() -> int:
+        relay = GatewayUpstreamRelay(
+            GatewaySettings(
+                registry=_simple_registry(),
+                policy={},
+                upstream_failure_threshold=2,
+                upstream_circuit_cooldown_seconds=30,
+            )
+        )
+        fake_client = _FakeClient()
+        relay._client = fake_client
+        upstream = UpstreamConfig(name="filesystem", url="http://fs.local:8100")
+        message = _json_rpc("tools/call", name="read_file", arguments={"path": "/tmp/a"})
+
+        for _ in range(2):
+            try:
+                await relay(upstream, message, {})
+            except RuntimeError:
+                pass
+        try:
+            await relay(upstream, message, {})
+        except Exception as exc:  # noqa: BLE001
+            assert "circuit open" in str(exc)
+        return fake_client.posts
+
+    assert asyncio.run(_exercise()) == 2
+
+
+def test_relay_returns_503_when_managed_circuit_is_open() -> None:
+    async def circuit_open_caller(upstream, message, extra_headers):
+        from agent_bom.gateway_server import GatewayCircuitOpenError
+
+        raise GatewayCircuitOpenError(upstream.name, 12)
+
+    audit_events: list[dict[str, Any]] = []
+
+    async def audit_sink(event):
+        audit_events.append(event)
+
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={},
+        upstream_caller=circuit_open_caller,
+        audit_sink=audit_sink,
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_json_rpc("tools/call", name="read_file", arguments={"path": "/tmp/x"}))
+    assert resp.status_code == 503
+    assert resp.headers["retry-after"] == "12"
+    assert resp.json()["detail"] == "upstream circuit open"
+    assert audit_events == [
+        {
+            "action": "gateway.upstream_circuit_open",
+            "upstream": "filesystem",
+            "tenant_id": "default",
+            "reason": "circuit_open",
+            "retry_after_seconds": 12,
         }
     ]
 

--- a/tests/test_gateway_upstreams.py
+++ b/tests/test_gateway_upstreams.py
@@ -332,6 +332,69 @@ def test_oauth2_fetches_token_and_caches(tmp_path: Path, monkeypatch: pytest.Mon
     assert fetch_count["n"] == 1, "token must be cached across resolve calls within expiry"
 
 
+def test_oauth2_concurrent_cache_miss_uses_singleflight(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Concurrent first callers should share one IdP token request."""
+    import asyncio
+
+    import httpx
+
+    from agent_bom.gateway_upstreams import reset_oauth_cache_for_tests
+
+    reset_oauth_cache_for_tests()
+
+    fetch_count = {"n": 0}
+
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> dict:
+            return {"access_token": "oauth-tok-singleflight", "expires_in": 3600, "token_type": "Bearer"}
+
+    class _FakeAsyncClient:
+        def __init__(self, *_, **__):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+        async def post(self, *_args, **_kwargs):
+            fetch_count["n"] += 1
+            await asyncio.sleep(0.01)
+            return _FakeResponse()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+    monkeypatch.setenv("SF_CLIENT_ID", "cid")
+    monkeypatch.setenv("SF_CLIENT_SECRET", "csec")
+
+    path = _write_yaml(
+        tmp_path,
+        """
+        upstreams:
+          - name: jira-snowflake
+            url: https://snowflake.example.com/mcp/jira
+            auth: oauth2_client_credentials
+            oauth_token_url: https://snowflake.example.com/oauth/token
+            oauth_client_id_env: SF_CLIENT_ID
+            oauth_client_secret_env: SF_CLIENT_SECRET
+            scopes: ["jira.read", "jira.write"]
+        """,
+    )
+    registry = UpstreamRegistry.from_yaml(path)
+    upstream = registry.get("jira-snowflake")
+    assert upstream is not None
+
+    async def _resolve_many() -> list[dict[str, str]]:
+        return await asyncio.gather(*(upstream.resolve_auth_headers() for _ in range(8)))
+
+    headers = asyncio.run(_resolve_many())
+    assert {h["Authorization"] for h in headers} == {"Bearer oauth-tok-singleflight"}
+    assert fetch_count["n"] == 1
+
+
 def test_oauth2_missing_env_vars_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     import asyncio
 


### PR DESCRIPTION
## Summary

- add a lifecycle-managed pooled HTTP relay for gateway upstream requests instead of constructing a fresh `httpx.AsyncClient` per request
- add a per-upstream circuit breaker that fails fast with `503` + `Retry-After` after repeated upstream failures
- add OAuth2 client-credentials singleflight so concurrent first callers share one token fetch instead of stampeding the IdP
- expose upstream relay posture in `/healthz` so operators can see pooling and breaker settings during POVs

## Why

This closes the remaining high-concurrency gateway fragility from the pilot audit. A slow or failing MCP upstream should not degrade every gateway caller, and OAuth cache misses should not fan out into duplicate IdP requests during fleet startup.

## Validation

- `pytest tests/test_gateway_server.py tests/test_gateway_upstreams.py tests/test_gateway_upstream_discovery_route.py tests/test_gateway_auth_tenant_e2e.py tests/test_control_plane_contracts.py::test_control_plane_contract_scan_graph_policy_audit_flow tests/test_proxy.py tests/test_proxy_policy.py tests/test_api_proxy_scorecard.py -q` -> 192 passed
- `ruff check src/agent_bom/gateway_server.py src/agent_bom/gateway_upstreams.py tests/test_gateway_server.py tests/test_gateway_upstreams.py`
- `mypy src/agent_bom/gateway_server.py src/agent_bom/gateway_upstreams.py`
- `git diff --check`
- pre-commit hooks during commit: whitespace/eof/private-key/case-conflict/merge-conflict/mixed-line-ending/ruff/ruff-format/mypy/bandit
