### PR TITLE
docs: align skill CLI examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ Container image gate, IaC gate, air-gapped CI, MCP scan, and the SARIF / SBOM ex
 }
 ```
 
-Also on [Glama](https://glama.ai/mcp/servers/@msaad00/agent-bom), [Smithery](integrations/smithery.yaml), [MCP Registry](integrations/mcp-registry/server.json), and [OpenClaw](integrations/openclaw/README.md).
+Marketplace and agentic surfaces: [Glama](https://glama.ai/mcp/servers/@msaad00/agent-bom), [OpenClaw skills](integrations/openclaw/README.md), the [Smithery manifest](integrations/smithery.yaml), and the [MCP Registry manifest](integrations/mcp-registry/server.json).
 
 <details>
 <summary><b>Install extras + output formats</b></summary>

--- a/integrations/cortex-code/SKILL.md
+++ b/integrations/cortex-code/SKILL.md
@@ -39,7 +39,7 @@ vulnerable packages to the credentials and tools they can reach.
 pipx install agent-bom
 
 # Or run directly with uvx (no install needed)
-uvx agent-bom scan
+uvx agent-bom agents
 ```
 
 ## Instructions
@@ -47,7 +47,7 @@ uvx agent-bom scan
 ### Scan the current MCP setup
 
 ```bash
-agent-bom scan
+agent-bom agents
 ```
 
 Auto-discovers all configured MCP clients (Cortex Code, Claude Desktop, Cursor, etc.),
@@ -62,21 +62,21 @@ agent-bom check <package>@<version> --ecosystem <npm|pypi|go|maven|cargo|nuget|g
 ### Map blast radius of a CVE
 
 ```bash
-agent-bom scan --enrich
+agent-bom agents --enrich
 # Then review the blast radius section in the output
 ```
 
 ### Generate SBOM
 
 ```bash
-agent-bom scan -f cyclonedx -o sbom.json
-agent-bom scan -f spdx -o sbom.spdx.json
+agent-bom agents -f cyclonedx -o sbom.json
+agent-bom agents -f spdx -o sbom.spdx.json
 ```
 
 ### Scan with GPU infrastructure detection
 
 ```bash
-agent-bom scan --gpu-scan
+agent-bom agents --gpu-scan
 ```
 
 ### Run as MCP server (for other AI tools)
@@ -101,15 +101,15 @@ When a user asks to install a new MCP server or package:
 
 ### Full security audit
 When a user asks for a security review:
-1. Run `agent-bom scan --enrich`
+1. Run `agent-bom agents --enrich`
 2. Summarize findings by severity
 3. Highlight any credential exposure
 4. Show blast radius for critical/high findings
 
 ### Compliance report
 When compliance documentation is needed:
-1. Run `agent-bom scan -f cyclonedx -o sbom.json`
-2. Run `agent-bom scan --enrich` for compliance framework mapping
+1. Run `agent-bom agents -f cyclonedx -o sbom.json`
+2. Run `agent-bom agents --enrich --compliance` for compliance framework mapping
 3. Report maps to OWASP, NIST, EU AI Act, ISO 27001, SOC 2
 
 ## Best Practices
@@ -117,7 +117,7 @@ When compliance documentation is needed:
 - Always run `agent-bom check` before adding new MCP servers to your `mcp.json`
 - Use `--enrich` for full NVD/EPSS/KEV enrichment (slower but more complete)
 - Review blast radius for any CRITICAL or HIGH findings
-- Use `agent-bom scan -f sarif` for CI/CD integration with GitHub Security tab
+- Use `agent-bom agents -f sarif` for CI/CD integration with GitHub Security tab
 - No API keys required for basic scanning (NVD_API_KEY optional for higher rate limits)
 
 ## Privacy

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -65,7 +65,8 @@ visualizes agent context graphs.
 ```bash
 pipx install agent-bom
 agent-bom agents --verbose   # blast radius detail for each agent
-agent-bom graph              # generate context graph
+agent-bom agents -f json -o scan.json
+agent-bom graph scan.json    # export graph from a saved JSON report
 ```
 
 ## When to Use
@@ -85,7 +86,8 @@ agent-bom graph              # generate context graph
 agent-bom agents --verbose
 
 # Generate context graph
-agent-bom graph
+agent-bom agents -f json -o scan.json
+agent-bom graph scan.json
 ```
 
 ## Tools

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -111,8 +111,8 @@ Run AISVS v1.0 and CIS benchmark checks.
 
 ```bash
 pipx install agent-bom
-agent-bom agents -f compliance-export  # run agents scan with compliance export
-agent-bom generate-sbom                # generate CycloneDX SBOM
+agent-bom agents --compliance --compliance-export nist-ai-rmf
+agent-bom agents -f cyclonedx -o sbom.json
 ```
 
 ## When to Use

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -113,6 +113,7 @@ agent-bom iac infra/         # scan Terraform/CloudFormation/K8s
 agent-bom cloud aws          # AWS CIS benchmark
 agent-bom cloud azure        # Azure CIS benchmark
 agent-bom cloud gcp          # GCP CIS benchmark
+agent-bom agents --snowflake --snowflake-cis-benchmark
 agent-bom secrets .          # find secrets in current directory
 ```
 
@@ -136,7 +137,7 @@ agent-bom iac infra/
 agent-bom cloud aws
 agent-bom cloud azure
 agent-bom cloud gcp
-agent-bom cloud snowflake
+agent-bom agents --snowflake --snowflake-cis-benchmark
 
 # Find secrets in files
 agent-bom secrets .

--- a/site-docs/architecture/agentic-skills-architecture.md
+++ b/site-docs/architecture/agentic-skills-architecture.md
@@ -131,7 +131,7 @@ flowchart LR
     SA2["Subagent: advisory analysis"]
     SA3["Subagent: PR/SARIF gate"]
     Contract["Signed or schema-validated artifact"]
-    AB["agent-bom scan"]
+    AB["agent-bom agents / sbom / image"]
 
     Lead --> SA1
     Lead --> SA2

--- a/site-docs/features/blast-radius.md
+++ b/site-docs/features/blast-radius.md
@@ -20,7 +20,7 @@ For each vulnerability found, agent-bom traces:
 
 ```bash
 # CLI
-agent-bom scan   # blast radius is included in scan output
+agent-bom agents   # blast radius is included in scan output
 
 # MCP tool
 blast_radius(cve_id="CVE-2024-21538")

--- a/site-docs/features/compliance.md
+++ b/site-docs/features/compliance.md
@@ -35,23 +35,20 @@ the scan hot path does not fetch MITRE or other framework data at runtime.
 
 ```bash
 # Single framework
-agent-bom scan --compliance owasp-llm
+agent-bom agents --compliance
 
-# Multiple frameworks
-agent-bom scan --compliance owasp-llm,eu-ai-act
-
-# All frameworks
-agent-bom scan --compliance all
+# Compliance evidence export
+agent-bom agents --compliance --compliance-export nist-ai-rmf
 ```
 
 ## CIS Benchmarks (cloud)
 
 ```bash
 # AWS CIS Foundations v3.0
-agent-bom cis-benchmark --provider aws
+agent-bom cloud aws --cis
 
 # Snowflake CIS v1.0
-agent-bom cis-benchmark --provider snowflake
+agent-bom agents --snowflake --snowflake-cis-benchmark
 ```
 
 Requires cloud credentials (AWS_PROFILE or SNOWFLAKE_ACCOUNT/USER/PASSWORD).

--- a/site-docs/features/policy.md
+++ b/site-docs/features/policy.md
@@ -36,7 +36,7 @@ Declarative policy-as-code for security gates and enforcement.
 
 ```bash
 # CLI — evaluate scan results against policy
-agent-bom scan --policy policy.json
+agent-bom agents --policy policy.json
 
 # MCP tool
 policy_check(policy_file="policy.json")

--- a/site-docs/features/sbom.md
+++ b/site-docs/features/sbom.md
@@ -13,8 +13,8 @@ Generate Software Bills of Materials in industry-standard formats.
 
 ```bash
 # CLI
-agent-bom scan --sbom cyclonedx -o sbom.json
-agent-bom scan --sbom spdx -o sbom.spdx.json
+agent-bom agents -f cyclonedx -o sbom.json
+agent-bom agents -f spdx -o sbom.spdx.json
 
 # MCP tool
 generate_sbom(format="cyclonedx")
@@ -25,7 +25,7 @@ generate_sbom(format="cyclonedx")
 agent-bom can also ingest existing SBOMs for analysis:
 
 ```bash
-agent-bom scan --sbom-input existing-sbom.json
+agent-bom sbom existing-sbom.json
 ```
 
 Supports CycloneDX 1.x and SPDX 2.x/3.0 JSON inputs.
@@ -34,8 +34,8 @@ Supports CycloneDX 1.x and SPDX 2.x/3.0 JSON inputs.
 
 ```bash
 # Apply VEX to suppress known non-exploitable findings
-agent-bom scan --vex vex-document.json
+agent-bom agents --vex vex-document.json
 
 # Generate VEX from scan results
-agent-bom scan --generate-vex --vex-output vex.json
+agent-bom agents --generate-vex --vex-output vex.json
 ```

--- a/site-docs/features/scanning.md
+++ b/site-docs/features/scanning.md
@@ -52,7 +52,7 @@ Config files are parsed for server definitions. Environment variable **values** 
 ## Container image scanning
 
 ```bash
-agent-bom scan --image python:3.12-slim
+agent-bom image python:3.12-slim
 ```
 
 Uses agent-bom's native image scanning pipeline to enumerate OS and language packages within container images.

--- a/site-docs/getting-started/install.md
+++ b/site-docs/getting-started/install.md
@@ -42,7 +42,7 @@ pip install -e ".[dev]"
 
 ```bash
 agent-bom --version
-agent-bom scan --help
+agent-bom agents --help
 ```
 
 ## Requirements

--- a/site-docs/integrations/smithery.md
+++ b/site-docs/integrations/smithery.md
@@ -1,8 +1,15 @@
-# Smithery Integration
+# Smithery Manifest
 
-agent-bom is published in the [Smithery](https://smithery.ai) MCP catalog. This page
-documents the field-naming convention used by Smithery's session config and how those
-values map to the environment variables the agent-bom MCP server actually reads.
+agent-bom ships a Smithery-compatible manifest at `integrations/smithery.yaml`.
+This page documents the field-naming convention used by Smithery's session config
+and how those values map to the environment variables the agent-bom MCP server
+actually reads.
+
+The manifest and release workflow are ready for Smithery publication, but the
+public catalog entry is only considered live after the Smithery release workflow
+successfully publishes against a public unauthenticated MCP endpoint. Until then,
+use Glama, OpenClaw, local `uvx agent-bom mcp server`, or your own Railway/Docker
+deployment as the active MCP surfaces.
 
 ## Why two naming conventions exist
 

--- a/site-docs/reference/exit-codes.md
+++ b/site-docs/reference/exit-codes.md
@@ -19,7 +19,7 @@ automation can distinguish caller mistakes from control-plane outages.
 | `3`   | (reserved)          | Reserved for "policy gate failed" — declared so future policy commands have a stable code to use.              | Not yet emitted.                                                           |
 | `4`   | (reserved)          | Reserved for "auth required" / "auth invalid" on commands that talk to an authenticated control plane.        | Not yet emitted.                                                           |
 | `5`   | (reserved)          | Reserved for "remote control-plane error" (5xx response from the API).                                         | Not yet emitted.                                                           |
-| `130` | interrupted         | Process received `SIGINT` (`Ctrl-C`) — POSIX convention, kept for shell idiom compatibility.                  | Long-running `agent-bom proxy` / `agent-bom serve` / `agent-bom scan`.      |
+| `130` | interrupted         | Process received `SIGINT` (`Ctrl-C`) — POSIX convention, kept for shell idiom compatibility.                  | Long-running `agent-bom proxy` / `agent-bom serve` / `agent-bom agents`.    |
 | `*`   | subprocess passthrough | When agent-bom shells out (e.g. native scanner binaries), the child's non-zero exit code is propagated.    | `agent-bom shield`, `agent-bom run` proxy invocations.                     |
 
 The unreserved codes (`0`, `1`, `2`, `130`) are stable today. Codes `3`, `4`, `5` are
@@ -69,7 +69,7 @@ care about families, not individual semantics.
 Until reserved codes (`3`/`4`/`5`) are emitted, the safe shell idiom is:
 
 ```bash
-agent-bom scan ./project --output sarif > out.sarif
+agent-bom agents -p ./project --format sarif > out.sarif
 rc=$?
 case "$rc" in
   0)   echo "ok" ;;

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -1,0 +1,67 @@
+"""Public docs and bundled skills should teach commands that actually work."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLIC_CLI_DOCS = [
+    ROOT / "integrations" / "cortex-code" / "SKILL.md",
+    ROOT / "integrations" / "openclaw" / "analyze" / "SKILL.md",
+    ROOT / "integrations" / "openclaw" / "compliance" / "SKILL.md",
+    ROOT / "integrations" / "openclaw" / "scan-infra" / "SKILL.md",
+    ROOT / "site-docs" / "features" / "sbom.md",
+    ROOT / "site-docs" / "features" / "scanning.md",
+    ROOT / "site-docs" / "features" / "policy.md",
+    ROOT / "site-docs" / "features" / "compliance.md",
+    ROOT / "site-docs" / "features" / "blast-radius.md",
+    ROOT / "site-docs" / "getting-started" / "install.md",
+    ROOT / "site-docs" / "reference" / "exit-codes.md",
+    ROOT / "site-docs" / "architecture" / "agentic-skills-architecture.md",
+]
+
+
+def test_public_docs_do_not_teach_removed_cli_surfaces() -> None:
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in PUBLIC_CLI_DOCS)
+
+    removed_or_misleading = [
+        "agent-bom generate-sbom",
+        "agent-bom cloud snowflake",
+        "agent-bom cis-benchmark",
+        "agent-bom scan --sbom cyclonedx",
+        "agent-bom scan --sbom spdx",
+        "agent-bom scan --sbom-input",
+    ]
+    for command in removed_or_misleading:
+        assert command not in combined
+
+
+def test_documented_primary_commands_are_real_cli_surfaces() -> None:
+    runner = CliRunner()
+    commands = [
+        ["agents", "--help"],
+        ["image", "--help"],
+        ["sbom", "--help"],
+        ["cloud", "aws", "--help"],
+        ["graph", "--help"],
+        ["validate", "--help"],
+        ["db", "status", "--help"],
+        ["skills", "scan", "--help"],
+    ]
+
+    for command in commands:
+        result = runner.invoke(main, command)
+        assert result.exit_code == 0, f"agent-bom {' '.join(command)} failed:\n{result.output}"
+
+
+def test_public_docs_do_not_overclaim_smithery_catalog_liveness() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    smithery_doc = (ROOT / "site-docs" / "integrations" / "smithery.md").read_text(encoding="utf-8")
+
+    assert "agent-bom is published in the [Smithery]" not in smithery_doc
+    assert "Also on [Glama]" not in readme
+    assert "Smithery manifest" in readme


### PR DESCRIPTION
## Summary

- align public OpenClaw, Cortex Code, and site docs examples with the current CLI surfaces
- replace removed or misleading command examples for SBOM generation, Snowflake CIS, graph export, policy, and compliance workflows
- add a regression test that blocks these stale public-facing command examples from returning
- make Smithery docs precise: manifest/workflow exists, but public catalog liveness is not claimed until the listing is actually live

## Why

The Snowflake/enterprise POV path now depends on the docs and bundled skills being as accurate as the product surfaces. During the pre-share audit, a few public skill/docs pages still taught commands like `agent-bom generate-sbom`, `agent-bom cloud snowflake`, and SBOM generation via `--sbom`, which either do not exist or mean a different ingest workflow. Those are first-impression failures even when the underlying scanner is healthy. The same pass found that Glama is live and Railway is healthy, while the Smithery public listing currently returns 404, so the docs now describe Smithery as a manifest/publication workflow rather than an already-live catalog surface.

## Validation

- `pytest tests/test_public_docs_cli_alignment.py tests/test_cli_exit_contract_docs.py -q`
- `ruff check tests/test_public_docs_cli_alignment.py`
- `git diff --check`
- `rg -n "agent-bom (generate-sbom|cloud snowflake|cis-benchmark)|agent-bom scan --sbom (cyclonedx|spdx)|agent-bom scan --sbom-input" integrations/cortex-code integrations/openclaw site-docs -S` returns no matches
