### PR TITLE
fix: gate SSE proxy policy methods

### DIFF
--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -728,7 +728,8 @@ async def _proxy_sse_server(
                 line_str = line.decode("utf-8", errors="replace")
                 msg = parse_jsonrpc(line_str)
 
-                if not msg or not is_tools_call(msg):
+                policy_subject = policy_subject_from_message(msg) if msg else None
+                if not msg or not policy_subject:
                     # Non-tool-call messages (initialize, notifications, etc.) — pass through
                     try:
                         fwd = await client.post(
@@ -743,9 +744,9 @@ async def _proxy_sse_server(
                         logger.debug("SSE proxy: pass-through failed: %s", exc)
                     continue
 
-                tool_name = extract_tool_name(msg) or "unknown"
+                tool_name, arguments = policy_subject
+                is_tool_call = is_tools_call(msg)
                 request_trace_meta = _extract_jsonrpc_trace_meta(msg)
-                arguments = extract_tool_arguments(msg)
                 msg_id = msg.get("id")
                 p_hash = compute_payload_hash(msg)
                 agent_id, identity_block_reason = check_identity(msg, policy)
@@ -787,7 +788,7 @@ async def _proxy_sse_server(
                     sys.stdout.buffer.flush()
                     continue
 
-                if block_undeclared and declared_tools and tool_name not in declared_tools:
+                if is_tool_call and block_undeclared and declared_tools and tool_name not in declared_tools:
                     reason = f"Tool '{tool_name}' not in declared tools/list"
                     if log_file:
                         log_tool_call(
@@ -881,13 +882,18 @@ async def _proxy_sse_server(
                         tenant_id=control_plane_tenant_id,
                     )  # type: ignore[arg-type]
 
-                # Forward tool call to remote SSE/HTTP server
+                # Forward the gated JSON-RPC request to the remote SSE/HTTP
+                # server. Tool calls use the compatibility /tools/call path;
+                # resources/prompts/sampling/extension methods retain their
+                # original method and go through the generic /message path.
                 call_counter += 1
                 try:
-                    span_cm = _PROXY_TRACER.start_as_current_span("proxy.sse_tools_call") if _PROXY_TRACER else nullcontext()
+                    span_name = "proxy.sse_tools_call" if is_tool_call else "proxy.sse_gated_message"
+                    span_cm = _PROXY_TRACER.start_as_current_span(span_name) if _PROXY_TRACER else nullcontext()
                     with span_cm as span:
                         if span is not None:
-                            span.set_attribute("agent_bom.proxy.tool_name", tool_name)
+                            span.set_attribute("agent_bom.proxy.subject", tool_name)
+                            span.set_attribute("agent_bom.proxy.method", msg.get("method", "unknown"))
                             span.set_attribute("agent_bom.proxy.call_counter", call_counter)
                         forwarded_message = _inject_jsonrpc_trace_meta(
                             msg,
@@ -895,8 +901,9 @@ async def _proxy_sse_server(
                             tracestate=request_trace_meta.get("tracestate"),
                             baggage=request_trace_meta.get("baggage"),
                         )
+                        forward_path = "/tools/call" if is_tool_call else "/message"
                         resp = await client.post(
-                            url.rstrip("/") + "/tools/call",
+                            url.rstrip("/") + forward_path,
                             json=forwarded_message,
                             timeout=30,
                             headers=_proxy_request_headers(

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -924,6 +924,97 @@ def test_proxy_sse_server_uses_httpx(tmp_path):
     assert exit_code == 0
 
 
+def test_proxy_sse_policy_blocks_gated_resource_reads(tmp_path, monkeypatch):
+    """SSE policy enforcement covers resources/read, not only tools/call."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from agent_bom.proxy import _proxy_sse_server
+
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(
+        json.dumps({"rules": [{"id": "no-resource-read", "action": "block", "block_tools": ["resources/read"]}]}),
+        encoding="utf-8",
+    )
+
+    tools_response = MagicMock()
+    tools_response.raise_for_status = MagicMock()
+    tools_response.json.return_value = {"jsonrpc": "2.0", "id": 1, "result": {"tools": []}}
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.post = AsyncMock(return_value=tools_response)
+
+    resource_read = {
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "resources/read",
+        "params": {"uri": "file:///etc/passwd"},
+    }
+    monkeypatch.setattr(proxy_mod, "create_async_stdin_reader", AsyncMock(return_value=object()))
+    monkeypatch.setattr(
+        proxy_mod,
+        "read_async_stdin_line",
+        AsyncMock(side_effect=[(json.dumps(resource_read) + "\n").encode(), b""]),
+    )
+
+    stdout = type("Stdout", (), {"buffer": io.BytesIO()})()
+    monkeypatch.setattr(proxy_mod.sys, "stdout", stdout)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        exit_code = asyncio.run(_proxy_sse_server(url="http://localhost:3000", policy_path=str(policy_path)))
+
+    assert exit_code == 0
+    assert mock_client.post.await_count == 1  # tools/list only; blocked before /message
+    written = stdout.buffer.getvalue().decode()
+    assert "no-resource-read" in written
+    assert "resources/read" in written
+
+
+def test_proxy_sse_forwards_allowed_gated_messages_to_message_endpoint(monkeypatch):
+    """Non-tool gated JSON-RPC methods keep their method and use /message."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from agent_bom.proxy import _proxy_sse_server
+
+    tools_response = MagicMock()
+    tools_response.raise_for_status = MagicMock()
+    tools_response.json.return_value = {"jsonrpc": "2.0", "id": 1, "result": {"tools": []}}
+
+    message_response = MagicMock()
+    message_response.raise_for_status = MagicMock()
+    message_response.json.return_value = {"jsonrpc": "2.0", "id": 8, "result": {"contents": []}}
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.post = AsyncMock(side_effect=[tools_response, message_response])
+
+    prompts_get = {
+        "jsonrpc": "2.0",
+        "id": 8,
+        "method": "prompts/get",
+        "params": {"name": "demo"},
+    }
+    monkeypatch.setattr(proxy_mod, "create_async_stdin_reader", AsyncMock(return_value=object()))
+    monkeypatch.setattr(
+        proxy_mod,
+        "read_async_stdin_line",
+        AsyncMock(side_effect=[(json.dumps(prompts_get) + "\n").encode(), b""]),
+    )
+
+    stdout = type("Stdout", (), {"buffer": io.BytesIO()})()
+    monkeypatch.setattr(proxy_mod.sys, "stdout", stdout)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        exit_code = asyncio.run(_proxy_sse_server(url="http://localhost:3000/"))
+
+    assert exit_code == 0
+    assert mock_client.post.await_args_list[1].args[0] == "http://localhost:3000/message"
+    assert mock_client.post.await_args_list[1].kwargs["json"]["method"] == "prompts/get"
+    assert "contents" in stdout.buffer.getvalue().decode()
+
+
 def test_response_hmac_canonical_key_order():
     """HMAC is the same regardless of dict key insertion order."""
     msg_a = {"b": 2, "a": 1}


### PR DESCRIPTION
Summary

- gate SSE proxy JSON-RPC policy subjects with the same helper already used by stdio proxy and gateway
- cover resources/read, prompts/get, sampling/createMessage, and mcp_extension/* on SSE transport instead of passing them through unchecked
- preserve correct upstream routing: tools/call still goes to /tools/call, non-tool gated methods go to /message with their original method intact
- add regression coverage for blocked resources/read and allowed prompts/get SSE paths

Why

#2116 expanded policy coverage for stdio proxy and gateway, but the SSE proxy loop still treated only tools/call as policy-enforced. That left prompt/resource/sampling methods as a claim-vs-implementation gap for HTTP/SSE MCP deployments.

Validation

- uv run pytest tests/test_proxy.py tests/test_gateway_server.py::test_relay_blocks_resource_prompt_sampling_methods_by_policy -q
- uv run ruff check src/agent_bom/proxy.py tests/test_proxy.py
- uv run mypy src/agent_bom/proxy.py
- git diff --check
