### PR TITLE
fix: preserve discovery provenance in exports

### DIFF
--- a/src/agent_bom/output/cyclonedx_fmt.py
+++ b/src/agent_bom/output/cyclonedx_fmt.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from uuid import uuid4
 
 from agent_bom import __version__
+from agent_bom.asset_provenance import agent_discovery_provenance, package_discovery_provenance, sanitize_discovery_provenance
 from agent_bom.models import AIBOMReport
 from agent_bom.security import sanitize_launch_command, sanitize_path_label
 
@@ -25,6 +26,25 @@ def _sanitize_bom_ref(raw: str) -> str:
     Replace invalid characters (``@``, ``/``, spaces, etc.) with ``-``.
     """
     return re.sub(r"[^a-zA-Z0-9._-]", "-", raw)
+
+
+def _append_discovery_provenance_properties(properties: list[dict], provenance: dict | None) -> None:
+    """Append sanitized discovery provenance as CycloneDX component properties."""
+    if not provenance:
+        return
+    for key, value in sorted(provenance.items()):
+        if isinstance(value, (dict, list)):
+            prop_value = json.dumps(value, sort_keys=True, separators=(",", ":"))
+        elif isinstance(value, bool):
+            prop_value = str(value).lower()
+        else:
+            prop_value = str(value)
+        properties.append(
+            {
+                "name": f"agent-bom:discovery-provenance:{key.replace('_', '-')}",
+                "value": prop_value,
+            }
+        )
 
 
 # ── ML BOM extension builders ────────────────────────────────────────────────
@@ -277,6 +297,13 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
     for agent in report.agents:
         agent_ref = _sanitize_bom_ref(f"agent-{agent.stable_id}")
         agent_deps = []
+        agent_provenance = agent_discovery_provenance(agent)
+        agent_properties = [
+            {"name": "agent-bom:type", "value": "ai-agent"},
+            {"name": "agent-bom:config-path", "value": sanitize_path_label(agent.config_path) if agent.config_path else ""},
+            {"name": "agent-bom:status", "value": agent.status.value},
+        ]
+        _append_discovery_provenance_properties(agent_properties, agent_provenance)
 
         components.append(
             {
@@ -285,23 +312,21 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
                 "name": agent.name,
                 "version": agent.version or "unknown",
                 "description": f"AI Agent ({agent.agent_type.value})",
-                "properties": [
-                    {"name": "agent-bom:type", "value": "ai-agent"},
-                    {"name": "agent-bom:config-path", "value": sanitize_path_label(agent.config_path) if agent.config_path else ""},
-                    {"name": "agent-bom:status", "value": agent.status.value},
-                ],
+                "properties": agent_properties,
             }
         )
 
         for server in agent.mcp_servers:
             server_ref = _sanitize_bom_ref(f"mcp-server-{server.stable_id}")
             server_deps = []
+            server_provenance = sanitize_discovery_provenance(getattr(server, "discovery_provenance", None), defaults=agent_provenance)
 
             server_props = [
                 {"name": "agent-bom:type", "value": "mcp-server"},
                 {"name": "agent-bom:command", "value": sanitize_launch_command(server.command, server.args)},
                 {"name": "agent-bom:transport", "value": server.transport.value},
             ]
+            _append_discovery_provenance_properties(server_props, server_provenance)
             if server.has_credentials:
                 server_props.append({"name": "agent-bom:has-credentials", "value": "true"})
             if server.tools:
@@ -334,6 +359,7 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
 
             for pkg in server.packages:
                 pkg_ref = _sanitize_bom_ref(f"pkg-{pkg.stable_id}")
+                package_provenance = package_discovery_provenance(pkg, inherited=server_provenance)
 
                 pkg_properties = [
                     {"name": "agent-bom:ecosystem", "value": pkg.ecosystem},
@@ -345,6 +371,7 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
                     {"name": "agent-bom:version-source", "value": pkg.version_source},
                     {"name": "agent-bom:floating-reference", "value": str(pkg.floating_reference).lower()},
                 ]
+                _append_discovery_provenance_properties(pkg_properties, package_provenance)
                 if pkg.floating_reference_reason:
                     pkg_properties.append({"name": "agent-bom:floating-reference-reason", "value": pkg.floating_reference_reason})
                 if pkg.parent_package:

--- a/src/agent_bom/output/ocsf.py
+++ b/src/agent_bom/output/ocsf.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 import time
 from typing import Any
 
+from agent_bom.asset_provenance import sanitize_discovery_provenance
 from agent_bom.graph import SEVERITY_TO_OCSF as _SEVERITY_MAP
+from agent_bom.security import sanitize_sensitive_payload
 
 # Detector → OCSF analytic type mapping
 _ANALYTIC_TYPE: dict[str, str] = {
@@ -47,6 +49,15 @@ def alert_to_ocsf(alert: dict, product_version: str = "") -> dict[str, Any]:
     severity = alert.get("severity", "info").lower()
     detector = alert.get("detector", "unknown")
     details = alert.get("details", {})
+    safe_details: dict[str, Any] = {}
+    if isinstance(details, dict):
+        sanitized = sanitize_sensitive_payload(details, max_str_len=1000)
+        if isinstance(sanitized, dict):
+            safe_details = sanitized
+    if isinstance(details, dict) and "discovery_provenance" in details:
+        safe_provenance = sanitize_discovery_provenance(details.get("discovery_provenance"))
+        if safe_provenance:
+            safe_details["discovery_provenance"] = safe_provenance
 
     return {
         # OCSF metadata
@@ -78,8 +89,8 @@ def alert_to_ocsf(alert: dict, product_version: str = "") -> dict[str, Any]:
         "resources": [
             {
                 "type": "Other",
-                "name": details.get("tool", "unknown"),
-                "data": {k: v for k, v in details.items() if k not in ("tool",) and isinstance(v, (str, int, float, bool))},
+                "name": details.get("tool", "unknown") if isinstance(details, dict) else "unknown",
+                "data": {k: v for k, v in safe_details.items() if k != "tool"},
             }
         ],
         # Product metadata

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from agent_bom.asset_provenance import agent_discovery_provenance, package_discovery_provenance, sanitize_discovery_provenance
 from agent_bom.finding import FindingType
 from agent_bom.models import AIBOMReport, Severity
 from agent_bom.security import sanitize_sensitive_payload
@@ -160,6 +161,23 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
             "attack_vector_summary": getattr(br, "attack_vector_summary", None),
             "reachability": br.reachability,
         }
+        package_provenance = package_discovery_provenance(br.package)
+        if package_provenance:
+            result_properties["package_discovery_provenance"] = _sanitize_sarif_property(package_provenance)
+        agent_provenance = [
+            provenance for provenance in (agent_discovery_provenance(agent) for agent in br.affected_agents[:10]) if provenance
+        ]
+        if agent_provenance:
+            result_properties["agent_discovery_provenance"] = _sanitize_sarif_property(agent_provenance)
+        server_provenance = [
+            provenance
+            for provenance in (
+                sanitize_discovery_provenance(getattr(server, "discovery_provenance", None)) for server in br.affected_servers[:10]
+            )
+            if provenance
+        ]
+        if server_provenance:
+            result_properties["server_discovery_provenance"] = _sanitize_sarif_property(server_provenance)
         if (
             br.owasp_tags
             or br.atlas_tags

--- a/tests/test_output_cov.py
+++ b/tests/test_output_cov.py
@@ -38,6 +38,7 @@ from agent_bom.output import (
     to_sarif,
     to_spdx,
 )
+from agent_bom.output.ocsf import alert_to_ocsf
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -377,6 +378,30 @@ class TestToSarif:
         sarif = to_sarif(report)
         assert len(sarif["runs"][0]["results"]) >= 1
 
+    def test_cve_result_preserves_sanitized_discovery_provenance(self):
+        pkg = _make_pkg()
+        pkg.discovery_provenance = {
+            "source_type": "operator_pushed_inventory",
+            "source": "pipeline:token=secret",
+            "collector": "cmdb-export",
+            "version_source": "manifest",
+        }
+        agent = _make_agent()
+        agent.discovery_provenance = {
+            "source_type": "operator_pushed_inventory",
+            "collector": "cmdb-export",
+        }
+        br = _make_blast_radius(pkg=pkg, agents=[agent])
+        report = _make_report(agents=[agent], blast_radii=[br])
+
+        sarif = to_sarif(report)
+        props = sarif["runs"][0]["results"][0]["properties"]
+
+        assert props["package_discovery_provenance"]["source_type"] == "operator_pushed_inventory"
+        assert props["package_discovery_provenance"]["source"] == "<redacted>"
+        assert props["package_discovery_provenance"]["version_source"] == "manifest"
+        assert props["agent_discovery_provenance"][0]["collector"] == "cmdb-export"
+
 
 # ── to_cyclonedx ─────────────────────────────────────────────────────────────
 
@@ -412,6 +437,34 @@ class TestToCyclonedx:
         server_component = next(component for component in cdx["components"] if component["name"] == server.name)
         command_prop = next(prop for prop in server_component["properties"] if prop["name"] == "agent-bom:command")
         assert command_prop["value"] == "npx server --token <redacted>"
+
+    def test_cyclonedx_components_preserve_discovery_provenance_properties(self):
+        pkg = _make_pkg()
+        pkg.discovery_provenance = {
+            "source_type": "skill_invoked_pull",
+            "observed_via": ["skill_invoked_pull", "aws_sdk"],
+            "collector": "agent-bom-discover-aws",
+            "version_source": "detected",
+        }
+        server = _make_server(packages=[pkg])
+        server.discovery_provenance = {
+            "source_type": "skill_invoked_pull",
+            "provider": "aws",
+            "service": "bedrock",
+        }
+        agent = _make_agent(servers=[server])
+        agent.discovery_provenance = {
+            "source_type": "skill_invoked_pull",
+            "collector": "agent-bom-discover-aws",
+        }
+
+        cdx = to_cyclonedx(_make_report(agents=[agent]))
+        pkg_component = next(component for component in cdx["components"] if component["name"] == pkg.name)
+        props = {prop["name"]: prop["value"] for prop in pkg_component["properties"]}
+
+        assert props["agent-bom:discovery-provenance:source-type"] == "skill_invoked_pull"
+        assert props["agent-bom:discovery-provenance:collector"] == "agent-bom-discover-aws"
+        assert props["agent-bom:discovery-provenance:observed-via"] == '["skill_invoked_pull","aws_sdk"]'
 
 
 # ── to_spdx ──────────────────────────────────────────────────────────────────
@@ -1187,6 +1240,27 @@ def test_to_sarif_emits_unified_non_cve_findings():
 
     assert "finding/MCP_BLOCKLIST" in rule_ids
     assert "mcp.json" in uris
+
+
+def test_output_ocsf_preserves_nested_sanitized_details():
+    event = alert_to_ocsf(
+        {
+            "severity": "high",
+            "detector": "argument_analyzer",
+            "message": "suspicious resource read",
+            "details": {
+                "tool": "resources/read",
+                "discovery_provenance": {
+                    "source_type": "operator_pushed_inventory",
+                    "source": "pipeline:token=secret",
+                },
+            },
+        }
+    )
+
+    data = event["resources"][0]["data"]
+    assert data["discovery_provenance"]["source_type"] == "operator_pushed_inventory"
+    assert "secret" not in str(data)
 
 
 def test_to_sarif_normalizes_iac_and_ai_inventory_paths():


### PR DESCRIPTION
Summary

- add sanitized discovery provenance to primary CVE SARIF result properties
- add sanitized discovery provenance properties to CycloneDX agent, MCP server, and package components
- preserve nested sanitized runtime alert details in OCSF output instead of dropping non-scalar provenance context
- add regression coverage for SARIF, CycloneDX, and OCSF provenance preservation

Why

Discovery provenance was already present in JSON/API/graph/finding surfaces, but some export consumers could lose the source contract. AppSec and SBOM consumers should be able to tell whether a finding came from direct cloud pull, operator-pushed inventory, skill-invoked pull, registry fallback, or local discovery without falling back to raw JSON.

Validation

- uv run pytest tests/test_output_cov.py tests/test_asset_discovery_provenance.py -q
- uv run ruff check src/agent_bom/output/sarif.py src/agent_bom/output/cyclonedx_fmt.py src/agent_bom/output/ocsf.py tests/test_output_cov.py
- uv run mypy src/agent_bom/output/sarif.py src/agent_bom/output/cyclonedx_fmt.py src/agent_bom/output/ocsf.py
- git diff --check
