### PR TITLE
feat: add Snowflake operator pull adapter

### DIFF
--- a/examples/operator_pull/README.md
+++ b/examples/operator_pull/README.md
@@ -45,6 +45,20 @@ python examples/operator_pull/gcp_inventory_adapter.py \
 agent-bom agents --inventory gcp-inventory.json --format json
 ```
 
+## Snowflake
+
+```bash
+python examples/operator_pull/snowflake_inventory_adapter.py \
+  --account my-org-my-account \
+  --authenticator externalbrowser \
+  --database AI_PLATFORM \
+  --schema PUBLIC \
+  --output snowflake-inventory.json
+
+unset SNOWFLAKE_PASSWORD SNOWFLAKE_TOKEN SNOWFLAKE_PRIVATE_KEY_PATH
+agent-bom agents --inventory snowflake-inventory.json --format json
+```
+
 ## Skill-Mediated Handoff
 
 For AI-agent mediated discovery, use the bundled

--- a/examples/operator_pull/snowflake_inventory_adapter.py
+++ b/examples/operator_pull/snowflake_inventory_adapter.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Emit canonical agent-bom inventory from Snowflake inside the operator boundary.
+
+This adapter runs with the operator's Snowflake auth context and writes
+canonical inventory JSON locally. Passing that inventory to agent-bom is an
+explicit handoff, so agent-bom does not need Snowflake credentials for the
+scan/graph/export workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from adapter_bootstrap import add_repo_src_to_path, exit_for_missing_agent_bom  # noqa: E402
+
+add_repo_src_to_path(__file__)
+
+from inventory_writer import DISCOVERY_METHODS, build_inventory_payload  # noqa: E402
+
+try:
+    from agent_bom.cloud.snowflake import discover  # noqa: E402
+    from agent_bom.security import sanitize_error, sanitize_security_warnings  # noqa: E402
+except ModuleNotFoundError as exc:
+    exit_for_missing_agent_bom(exc)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Emit Snowflake discovery as canonical agent-bom inventory JSON.")
+    parser.add_argument("--account", help="Snowflake account identifier. Defaults to SNOWFLAKE_ACCOUNT.")
+    parser.add_argument("--user", help="Snowflake user. Defaults to SNOWFLAKE_USER.")
+    parser.add_argument(
+        "--authenticator",
+        help="Snowflake authenticator such as externalbrowser, snowflake_jwt, or oauth.",
+    )
+    parser.add_argument("--database", help="Optional Snowflake database scope.")
+    parser.add_argument("--schema", help="Optional Snowflake schema scope.")
+    parser.add_argument("--output", "-o", default="-", help="Output path, or '-' for stdout.")
+    parser.add_argument("--compact", action="store_true", help="Emit compact JSON.")
+    parser.add_argument("--source", default="snowflake-operator-pull", help="Inventory source label.")
+    parser.add_argument(
+        "--discovery-method",
+        choices=sorted(DISCOVERY_METHODS),
+        default="operator_pushed_inventory",
+        help="How this inventory was collected before agent-bom ingestion.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        agents, warnings = discover(
+            account=args.account,
+            user=args.user,
+            authenticator=args.authenticator,
+            database=args.database,
+            schema=args.schema,
+        )
+    except Exception as exc:  # noqa: BLE001
+        safe_error = sanitize_error(exc) or exc.__class__.__name__
+        sys.stderr.write(f"error: Snowflake discovery failed: {safe_error}\n")
+        return 2
+    for warning in sanitize_security_warnings(warnings):
+        sys.stderr.write(f"warning: {warning}\n")
+
+    payload = build_inventory_payload(
+        agents,
+        provider_name="snowflake",
+        source=args.source,
+        collector="examples/operator_pull/snowflake_inventory_adapter.py",
+        discovery_method=args.discovery_method,
+    )
+    text = json.dumps(payload, indent=None if args.compact else 2, sort_keys=True) + "\n"
+    if args.output == "-":
+        sys.stdout.write(text)
+    else:
+        Path(args.output).write_text(text, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent_bom/cloud/__init__.py
+++ b/src/agent_bom/cloud/__init__.py
@@ -96,7 +96,7 @@ def _provider_capabilities(name: str) -> ExtensionCapabilities:
     scan_modes: tuple[str, ...]
     if name == "ollama":
         scan_modes = ("runtime_probe",)
-    elif name in {"aws", "azure", "gcp"}:
+    elif name in {"aws", "azure", "gcp", "snowflake"}:
         scan_modes = ("direct_cloud_pull", "operator_pushed_inventory", "skill_invoked_pull")
     else:
         scan_modes = ("direct_cloud_pull",)

--- a/tests/test_operator_pull_azure_gcp_adapters.py
+++ b/tests/test_operator_pull_azure_gcp_adapters.py
@@ -10,6 +10,7 @@ from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 ROOT = Path(__file__).resolve().parents[1]
 AZURE_ADAPTER_PATH = ROOT / "examples" / "operator_pull" / "azure_inventory_adapter.py"
 GCP_ADAPTER_PATH = ROOT / "examples" / "operator_pull" / "gcp_inventory_adapter.py"
+SNOWFLAKE_ADAPTER_PATH = ROOT / "examples" / "operator_pull" / "snowflake_inventory_adapter.py"
 WRITER_PATH = ROOT / "examples" / "operator_pull" / "inventory_writer.py"
 
 
@@ -139,6 +140,76 @@ def test_gcp_operator_pull_adapter_cli_marks_skill_invoked_inventory(monkeypatch
     assert "hidden-token" not in serialized
 
 
+def test_snowflake_operator_pull_adapter_cli_writes_scope_zero_inventory(monkeypatch, tmp_path: Path) -> None:
+    adapter = _load_module(SNOWFLAKE_ADAPTER_PATH, "snowflake_inventory_adapter")
+    agent = Agent(
+        name="cortex:analyst",
+        agent_type=AgentType.CUSTOM,
+        config_path="snowflake://org-acct/AI_PLATFORM/PUBLIC/analyst",
+        source="snowflake-cortex",
+        metadata={
+            "cloud_origin": {
+                "provider": "snowflake",
+                "service": "cortex-agent",
+                "resource_type": "agent",
+                "resource_id": "snowflake://org-acct/AI_PLATFORM/PUBLIC/analyst",
+                "resource_name": "analyst",
+                "raw_identity": {
+                    "account": "org-acct",
+                    "database": "AI_PLATFORM",
+                    "schema": "PUBLIC",
+                    "session_token": "raw-token",
+                },
+            }
+        },
+        mcp_servers=[
+            MCPServer(
+                name="snowflake-mcp:analytics",
+                url="https://org-acct.snowflakecomputing.com/api/v2/mcp/analytics?token=raw-token",
+                transport=TransportType.STREAMABLE_HTTP,
+                packages=[
+                    Package(
+                        name="snowflake-snowpark-python",
+                        version="1.26.0",
+                        ecosystem="pypi",
+                        purl="pkg:pypi/snowflake-snowpark-python@1.26.0",
+                    )
+                ],
+            )
+        ],
+    )
+    monkeypatch.setattr(adapter, "discover", lambda **_kwargs: ([agent], ["warning has token=secret"]))
+    output_path = tmp_path / "snowflake-inventory.json"
+
+    assert (
+        adapter.main(
+            [
+                "--account",
+                "org-acct",
+                "--authenticator",
+                "externalbrowser",
+                "--database",
+                "AI_PLATFORM",
+                "--schema",
+                "PUBLIC",
+                "--output",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+
+    loaded = load_inventory(str(output_path))
+    serialized = json.dumps(loaded)
+    assert loaded["source"] == "snowflake-operator-pull"
+    assert loaded["discovery_provenance"]["source_type"] == "operator_pushed_inventory"
+    assert loaded["discovery_provenance"]["observed_via"] == ["operator_pushed_inventory", "snowflake_sdk"]
+    assert loaded["agents"][0]["metadata"]["permissions_used"]
+    assert loaded["agents"][0]["discovery_provenance"]["provider"] == "snowflake"
+    assert loaded["agents"][0]["mcp_servers"][0]["url"] == "https://org-acct.snowflakecomputing.com/api/v2/mcp/analytics"
+    assert "raw-token" not in serialized
+
+
 def test_operator_pull_inventory_writer_keeps_container_purl_schema_valid() -> None:
     writer = _load_module(WRITER_PATH, "inventory_writer")
     package = Package(
@@ -162,7 +233,9 @@ def test_provider_permissions_used_reads_azure_and_gcp_contracts() -> None:
 
     azure_permissions = writer.provider_permissions_used("azure")
     gcp_permissions = writer.provider_permissions_used("gcp")
+    snowflake_permissions = writer.provider_permissions_used("snowflake")
 
     assert azure_permissions
     assert gcp_permissions
-    assert all(":" in permission or "." in permission for permission in azure_permissions + gcp_permissions)
+    assert snowflake_permissions
+    assert all(":" in permission or "." in permission for permission in azure_permissions + gcp_permissions + snowflake_permissions)


### PR DESCRIPTION
## Summary

- add a Snowflake operator-pull inventory adapter that emits canonical inventory JSON without requiring agent-bom to hold Snowflake credentials during scan
- mark Snowflake provider contracts as supporting `operator_pushed_inventory` and `skill_invoked_pull`, keeping `/v1/discovery/providers` aligned with the shipped adapter
- document the Snowflake scope-zero workflow next to AWS/Azure/GCP and add regression coverage for redaction, provenance, permissions_used, and schema-valid output

## Why

This closes the Snowflake-specific scope-zero gap before external sharing. A Snowflake operator can now run discovery inside their own boundary, inspect or archive the inventory locally, then explicitly hand the JSON to agent-bom only when they want findings, graph, policy, and exports.

## Validation

- `uv run pytest tests/test_operator_pull_azure_gcp_adapters.py -q`
- `uv run pytest tests/test_cloud_origin_contract.py tests/test_cloud_providers_cov.py -q`
- `uv run pytest tests/test_operator_pull_azure_gcp_adapters.py tests/test_cloud_origin_contract.py tests/test_cloud_providers_cov.py -q`
- `uv run ruff check examples/operator_pull/snowflake_inventory_adapter.py examples/operator_pull/inventory_writer.py tests/test_operator_pull_azure_gcp_adapters.py src/agent_bom/cloud/__init__.py`
- `uv run mypy src/agent_bom/cloud/__init__.py`
- `python examples/operator_pull/snowflake_inventory_adapter.py --help`
- `git diff --check`
