### PR TITLE
docs: clarify Helm Postgres deployment contract

### DIFF
--- a/deploy/helm/agent-bom/examples/README.md
+++ b/deploy/helm/agent-bom/examples/README.md
@@ -60,6 +60,13 @@ python scripts/install_helm_profile.py production \
 
 ## Operator guidance
 
+- The chart intentionally does not install a Postgres subchart. Production
+  profiles consume an operator-managed database through
+  `AGENT_BOM_POSTGRES_URL`, either from External Secrets Operator
+  (`production`) or a Kubernetes Secret (`eks-vanilla`).
+- For Kubernetes Secrets without External Secrets Operator, start from
+  `postgres-secret.example.yaml`, create the real secret out-of-band, and keep
+  the credential out of values files and git.
 - Start with `focused-pilot` for the narrow customer EKS story.
 - Use `sqlite-pilot` only for demos or single-node packaged pilots.
 - Move to `eks-vanilla` when you run EKS with ALB, IRSA, RDS/Postgres, and

--- a/deploy/helm/agent-bom/examples/postgres-secret.example.yaml
+++ b/deploy/helm/agent-bom/examples/postgres-secret.example.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agent-bom-control-plane-db
+  namespace: agent-bom
+type: Opaque
+stringData:
+  # Replace with your operator-provisioned Postgres/RDS endpoint.
+  # Keep this file as an example only; create the real Secret from your
+  # platform secret manager, External Secrets Operator, SOPS, or CI secret
+  # store so the credential is not committed.
+  AGENT_BOM_POSTGRES_URL: postgresql://agent_bom:REPLACE_ME_PASSWORD@REPLACE_ME_POSTGRES_HOST:5432/agent_bom

--- a/deploy/helm/agent-bom/templates/NOTES.txt
+++ b/deploy/helm/agent-bom/templates/NOTES.txt
@@ -1,5 +1,11 @@
 Enterprise pilot notes:
 
+- The chart does not provision Postgres. Production profiles expect an
+  operator-managed Postgres/RDS database exposed through
+  `AGENT_BOM_POSTGRES_URL`; see
+  `deploy/helm/agent-bom/examples/postgres-secret.example.yaml` for the
+  Kubernetes Secret shape and `site-docs/deployment/postgres-provisioning.md`
+  for the ownership contract.
 - Set `AGENT_BOM_AUDIT_HMAC_KEY` in the control-plane secret.
 - Set `AGENT_BOM_REQUIRE_AUDIT_HMAC=1` to fail closed if the key is missing.
 - Use Postgres for the pilot control plane; SQLite is not the multi-replica path.

--- a/site-docs/deployment/postgres-provisioning.md
+++ b/site-docs/deployment/postgres-provisioning.md
@@ -82,6 +82,28 @@ That split is deliberate:
 - destroy/cleanup ownership stays clearer
 - the product can deploy into an existing EKS platform cleanly
 
+The packaged Helm chart therefore has no Postgres subchart dependency. The
+production contract is:
+
+1. provision Postgres/RDS with your platform tooling
+2. run the packaged Postgres migrations
+3. expose the connection string to the API and backup jobs as
+   `AGENT_BOM_POSTGRES_URL`
+4. install the Helm profile
+
+For clusters without External Secrets Operator, use the shipped Secret shape as
+a starting point:
+
+```bash
+cp deploy/helm/agent-bom/examples/postgres-secret.example.yaml /tmp/agent-bom-postgres-secret.yaml
+# edit /tmp/agent-bom-postgres-secret.yaml or render it from your secret manager
+kubectl apply -f /tmp/agent-bom-postgres-secret.yaml
+```
+
+For clusters with External Secrets Operator, use the `production` profile and
+replace the `REPLACE_ME_*` remote references in
+`deploy/helm/agent-bom/examples/eks-production-values.yaml`.
+
 ## Request-to-database tenant flow
 
 For Postgres-backed deployments, a successful authenticated request does this:

--- a/tests/test_deploy_profiles.py
+++ b/tests/test_deploy_profiles.py
@@ -39,6 +39,19 @@ def test_gateway_runtime_profile_uses_shipped_upstreams_example():
     )
 
 
+def test_postgres_secret_example_documents_byo_postgres_contract():
+    repo_root = Path(__file__).resolve().parent.parent
+    chart = repo_root / "deploy" / "helm" / "agent-bom" / "Chart.yaml"
+    postgres_secret = repo_root / "deploy" / "helm" / "agent-bom" / "examples" / "postgres-secret.example.yaml"
+    docs = repo_root / "site-docs" / "deployment" / "postgres-provisioning.md"
+
+    assert "dependencies:" not in chart.read_text()
+    assert "AGENT_BOM_POSTGRES_URL" in postgres_secret.read_text()
+    docs_body = docs.read_text()
+    assert "no Postgres subchart dependency" in docs_body
+    assert "provision Postgres/RDS with your platform tooling" in docs_body
+
+
 def test_build_helm_profile_command_uses_shipped_profile_stack():
     repo_root = Path(__file__).resolve().parent.parent
     cmd = build_helm_profile_command(repo_root, "focused-pilot")


### PR DESCRIPTION
## Summary

- document the Helm/Postgres ownership contract explicitly: the chart consumes operator-managed Postgres, it does not provision a database subchart
- add a `postgres-secret.example.yaml` showing the Kubernetes Secret shape for `AGENT_BOM_POSTGRES_URL`
- tighten Helm NOTES and the deployment docs so pilot operators know which secrets must exist before installing production profiles
- add regression coverage so the BYO Postgres contract remains visible in chart examples/docs

## Why

The Snowflake/enterprise POV needs deployment clarity. Operators should not wonder whether Helm creates Postgres or whether they need RDS/platform-owned Postgres first. This keeps production ownership explicit while preserving the SQLite pilot profile for short demos.

## Validation

- `uv run pytest tests/test_deploy_profiles.py -q`
- `python scripts/validate_helm_profiles.py --list`
- `uv run ruff check src/agent_bom/deploy_profiles.py tests/test_deploy_profiles.py`
- `git diff --check`

Note: local Helm rendering was not run because `helm` is not installed in this environment; CI Helm Profile Validate covers that path.
