### PR TITLE
feat: gate stale MCP registry status

### DIFF
--- a/src/agent_bom/cli/_registry.py
+++ b/src/agent_bom/cli/_registry.py
@@ -190,7 +190,8 @@ def registry_search(query, category):
 @registry.command("status")
 @click.option("--stale-after-days", type=int, default=14, show_default=True, help="Mark registry stale after this many days.")
 @click.option("--format", "-f", "fmt", type=click.Choice(["table", "json"]), default="table", help="Output format.")
-def registry_status(stale_after_days: int, fmt: str):
+@click.option("--fail-on-stale", is_flag=True, help="Exit 1 when the bundled registry is stale or has never synced.")
+def registry_status(stale_after_days: int, fmt: str, fail_on_stale: bool):
     """Show MCP registry freshness and source posture."""
     from rich.console import Console
     from rich.table import Table
@@ -201,6 +202,8 @@ def registry_status(stale_after_days: int, fmt: str):
     payload = status.to_dict()
     if fmt == "json":
         click.echo(json.dumps(payload, indent=2))
+        if fail_on_stale and status.needs_refresh:
+            raise click.exceptions.Exit(1)
         return
 
     con = Console()
@@ -220,11 +223,14 @@ def registry_status(stale_after_days: int, fmt: str):
     table.add_row("Stale after", f"{status.stale_after_days} day(s)")
     table.add_row("Servers", str(status.server_count))
     table.add_row("Sources", ", ".join(status.sources) if status.sources else "unknown")
+    table.add_row("Recommended action", status.recommended_action)
     if status.airgapped:
         table.add_row("Airgapped", "yes")
     if status.error:
         table.add_row("Error", status.error)
     con.print(table)
+    if fail_on_stale and status.needs_refresh:
+        raise click.exceptions.Exit(1)
 
 
 @registry.command("update")

--- a/src/agent_bom/registry.py
+++ b/src/agent_bom/registry.py
@@ -59,16 +59,34 @@ class RegistryFreshnessStatus:
     def is_fresh(self) -> bool:
         return self.status == "fresh"
 
+    @property
+    def needs_refresh(self) -> bool:
+        return self.status in {"stale", "never_synced"}
+
+    @property
+    def recommended_action(self) -> str:
+        if self.status == "fresh":
+            return "none"
+        if self.status == "airgapped":
+            return "verify bundled registry through your offline promotion process"
+        if self.status == "airgapped_stale":
+            return "refresh the bundled registry through your offline promotion process"
+        if self.status == "never_synced":
+            return "run agent-bom registry sync-all before relying on registry-derived evidence"
+        return "run agent-bom registry sync-all"
+
     def to_dict(self) -> dict:
         return {
             "status": self.status,
             "is_fresh": self.is_fresh,
+            "needs_refresh": self.needs_refresh,
             "last_synced_at": self.last_synced_at,
             "age_days": self.age_days,
             "stale_after_days": self.stale_after_days,
             "server_count": self.server_count,
             "sources": self.sources,
             "airgapped": self.airgapped,
+            "recommended_action": self.recommended_action,
             "error": self.error,
         }
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -276,6 +276,8 @@ def test_registry_freshness_status_stale():
 
     assert status.status == "stale"
     assert status.is_fresh is False
+    assert status.needs_refresh is True
+    assert status.recommended_action == "run agent-bom registry sync-all"
     assert status.age_days == 19
 
 
@@ -283,6 +285,7 @@ def test_registry_freshness_status_never_synced():
     status = registry_freshness_status(now=datetime(2026, 4, 25, tzinfo=timezone.utc), data={"servers": {}})
 
     assert status.status == "never_synced"
+    assert status.needs_refresh is True
     assert status.age_days is None
     assert status.error == "missing_or_invalid_last_synced_at"
 
@@ -298,6 +301,8 @@ def test_registry_freshness_status_airgapped_stale(monkeypatch):
 
     assert status.status == "airgapped_stale"
     assert status.airgapped is True
+    assert status.needs_refresh is False
+    assert "offline promotion process" in status.recommended_action
 
 
 # ── Update (mocked) ────────────────────────────────────────────────────────
@@ -436,6 +441,20 @@ def test_cli_registry_status_json():
     assert data["status"] in {"fresh", "stale", "airgapped_stale", "never_synced"}
     assert data["server_count"] >= 100
     assert "stale_after_days" in data
+    assert "needs_refresh" in data
+    assert "recommended_action" in data
+
+
+def test_cli_registry_status_fail_on_stale_exits_nonzero():
+    from click.testing import CliRunner
+
+    from agent_bom.cli import main
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["registry", "status", "--stale-after-days", "0", "--fail-on-stale", "-f", "json"])
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["needs_refresh"] is True
 
 
 # ── Dataclass construction ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- add `needs_refresh` and `recommended_action` to MCP registry freshness status output
- add `agent-bom registry status --fail-on-stale` so CI, release prep, and demos can fail fast when bundled MCP intel is stale or never synced
- keep airgapped stale registries visible without treating offline promotion as the same failure mode

## Why

Before sharing with enterprise reviewers, registry freshness needs to be operational, not just informational. Operators should be able to pin a pre-demo/release gate that catches stale MCP registry data before a buyer asks how fresh the intelligence is.

## Validation

- `uv run pytest tests/test_registry.py -q`
- `uv run ruff check src/agent_bom/registry.py src/agent_bom/cli/_registry.py tests/test_registry.py`
- `agent-bom registry status --stale-after-days 0 -f json`
- `agent-bom registry status --stale-after-days 0 --fail-on-stale -f json` exits 1
