### PR TITLE
fix: require auth for remote runtime HTTP

### DIFF
--- a/src/agent_bom/cli/_runtime.py
+++ b/src/agent_bom/cli/_runtime.py
@@ -571,12 +571,29 @@ def proxy_bootstrap_cmd(
 @click.option("--log-json", "log_json", is_flag=True, help="Structured JSON logs")
 @click.option("--shield", is_flag=True, help="Enable deep defense mode (correlated threat scoring, escalation, kill-switch)")
 @click.option(
+    "--allow-insecure-no-auth",
+    is_flag=True,
+    help="Allow --mode http to bind non-loopback without AGENT_BOM_PROTECTION_API_KEY.",
+)
+@click.option(
     "--correlation-window",
     default=30.0,
     show_default=True,
     help="Alert correlation window in seconds (used with --shield)",
 )
-def protect_cmd(mode, port, host, detectors, alert_file, alert_webhook, log_level, log_json, shield, correlation_window):
+def protect_cmd(
+    mode,
+    port,
+    host,
+    detectors,
+    alert_file,
+    alert_webhook,
+    log_level,
+    log_json,
+    shield,
+    allow_insecure_no_auth,
+    correlation_window,
+):
     """Run the runtime protection engine as a standalone monitor.
 
     \b
@@ -619,9 +636,14 @@ def protect_cmd(mode, port, host, detectors, alert_file, alert_webhook, log_leve
         if not alert_webhook and _proj_cfg.get("alert_webhook"):
             alert_webhook = _proj_cfg["alert_webhook"]
     from agent_bom.runtime.protection import ProtectionEngine
-    from agent_bom.runtime.server import run_http_mode, run_stdin_mode
+    from agent_bom.runtime.server import enforce_runtime_http_auth_defaults, run_http_mode, run_stdin_mode
 
     setup_logging(level=log_level, json_output=log_json)
+    if mode == "http":
+        try:
+            enforce_runtime_http_auth_defaults(host, allow_insecure_no_auth=allow_insecure_no_auth)
+        except RuntimeError as exc:
+            raise click.ClickException(str(exc)) from exc
 
     # Build dispatcher with configured channels
     dispatcher = AlertDispatcher()
@@ -686,7 +708,7 @@ def protect_cmd(mode, port, host, detectors, alert_file, alert_webhook, log_leve
             loop.add_signal_handler(sig, _signal_handler)
 
         if mode == "http":
-            task = asyncio.create_task(run_http_mode(engine, host, port))
+            task = asyncio.create_task(run_http_mode(engine, host, port, allow_insecure_no_auth=allow_insecure_no_auth))
         else:
             task = asyncio.create_task(run_stdin_mode(engine))
 

--- a/src/agent_bom/runtime/server.py
+++ b/src/agent_bom/runtime/server.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import hmac
+import ipaddress
 import json
 import logging
 import os
@@ -32,6 +33,33 @@ if TYPE_CHECKING:
     from agent_bom.runtime.protection import ProtectionEngine
 
 logger = logging.getLogger(__name__)
+
+
+def _is_loopback_host(host: str) -> bool:
+    """Return True when ``host`` resolves to loopback-only access."""
+    cleaned = host.strip().lower()
+    if cleaned in {"localhost", "127.0.0.1", "::1"}:
+        return True
+    try:
+        return ipaddress.ip_address(cleaned).is_loopback
+    except ValueError:
+        return False
+
+
+def enforce_runtime_http_auth_defaults(
+    host: str,
+    *,
+    api_key: str | None = None,
+    allow_insecure_no_auth: bool = False,
+) -> None:
+    """Refuse unauthenticated non-loopback runtime HTTP binds."""
+    resolved_api_key = api_key if api_key is not None else os.environ.get("AGENT_BOM_PROTECTION_API_KEY")
+    if resolved_api_key or _is_loopback_host(host) or allow_insecure_no_auth:
+        return
+    raise RuntimeError(
+        f"Refusing to expose `runtime protect --mode http` on non-loopback host {host!r} without authentication. "
+        "Set AGENT_BOM_PROTECTION_API_KEY or pass --allow-insecure-no-auth to override."
+    )
 
 
 def _runtime_metrics_text(engine: ProtectionEngine) -> str:
@@ -157,12 +185,14 @@ async def _dispatch(engine: ProtectionEngine, data: dict) -> list[dict]:
 # ─── HTTP mode ───────────────────────────────────────────────────────────────
 
 
-async def run_http_mode(engine: ProtectionEngine, host: str, port: int) -> None:
+async def run_http_mode(engine: ProtectionEngine, host: str, port: int, *, allow_insecure_no_auth: bool = False) -> None:
     """Start an asyncio HTTP server that accepts tool call JSON via POST.
 
-    Zero trust: requires ``AGENT_BOM_PROTECTION_API_KEY`` env var when set.
+    Zero trust: requires ``AGENT_BOM_PROTECTION_API_KEY`` env var for
+    non-loopback listeners unless the operator explicitly overrides.
     Requests must include ``Authorization: Bearer <key>`` header.
     """
+    enforce_runtime_http_auth_defaults(host, allow_insecure_no_auth=allow_insecure_no_auth)
     engine.start()
 
     # 10 MB — matches proxy.py MAX_MESSAGE_SIZE

--- a/tests/test_protect.py
+++ b/tests/test_protect.py
@@ -10,7 +10,7 @@ from click.testing import CliRunner
 from agent_bom.alerts.dispatcher import AlertDispatcher
 from agent_bom.cli import main
 from agent_bom.runtime.protection import ProtectionEngine
-from agent_bom.runtime.server import _dispatch, _route_http, _runtime_metrics_text
+from agent_bom.runtime.server import _dispatch, _route_http, _runtime_metrics_text, enforce_runtime_http_auth_defaults
 
 # ─── CLI help / option tests ────────────────────────────────────────────────
 
@@ -27,6 +27,42 @@ def test_protect_help():
     assert "--alert-file" in result.output
     assert "--alert-webhook" in result.output
     assert "runtime protection" in result.output.lower()
+    assert "--allow-insecure-no-auth" in result.output
+
+
+def test_runtime_http_remote_bind_requires_auth(monkeypatch):
+    """Runtime HTTP mode should fail closed when exposed remotely without auth."""
+    monkeypatch.delenv("AGENT_BOM_PROTECTION_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="without authentication"):
+        enforce_runtime_http_auth_defaults("0.0.0.0")
+
+
+def test_runtime_http_loopback_bind_does_not_require_auth(monkeypatch):
+    """Loopback runtime HTTP mode remains convenient for local development."""
+    monkeypatch.delenv("AGENT_BOM_PROTECTION_API_KEY", raising=False)
+    enforce_runtime_http_auth_defaults("127.0.0.1")
+    enforce_runtime_http_auth_defaults("localhost")
+
+
+def test_runtime_http_remote_bind_allows_api_key(monkeypatch):
+    """Remote runtime HTTP mode is allowed when bearer auth is configured."""
+    monkeypatch.setenv("AGENT_BOM_PROTECTION_API_KEY", "secret")
+    enforce_runtime_http_auth_defaults("0.0.0.0")
+
+
+def test_runtime_http_remote_bind_allows_explicit_override(monkeypatch):
+    """Operators can still opt into unauthenticated remote binds explicitly."""
+    monkeypatch.delenv("AGENT_BOM_PROTECTION_API_KEY", raising=False)
+    enforce_runtime_http_auth_defaults("0.0.0.0", allow_insecure_no_auth=True)
+
+
+def test_runtime_protect_cli_refuses_remote_http_without_auth(monkeypatch):
+    """CLI should report a ClickException instead of starting an exposed listener."""
+    monkeypatch.delenv("AGENT_BOM_PROTECTION_API_KEY", raising=False)
+    runner = CliRunner()
+    result = runner.invoke(main, ["runtime", "protect", "--mode", "http", "--host", "0.0.0.0"])
+    assert result.exit_code != 0
+    assert "without authentication" in result.output
 
 
 # ─── _dispatch unit tests (stdin protocol) ──────────────────────────────────


### PR DESCRIPTION
Summary

- require AGENT_BOM_PROTECTION_API_KEY before runtime protect HTTP mode can bind non-loopback addresses
- keep loopback developer mode unchanged and add an explicit --allow-insecure-no-auth override for operators who intentionally accept the risk
- enforce the same posture in both the CLI path and the runtime server helper, with regression tests for auth, loopback, override, and fail-closed behavior

Why

The API server already refuses unauthenticated non-loopback binds. Runtime HTTP mode exposed the same kind of control surface but only authenticated requests when a key happened to be configured. This closes that parity gap before pilot demos of the proxy/runtime stack.

Validation

- uv run pytest tests/test_protect.py -q
- uv run ruff check src/agent_bom/runtime/server.py src/agent_bom/cli/_runtime.py tests/test_protect.py
- uv run mypy src/agent_bom/runtime/server.py src/agent_bom/cli/_runtime.py
- git diff --check
