### PR TITLE
fix: isolate local db scan preference

### DIFF
--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -505,6 +505,7 @@ def scan(
             con.print("[dim]Offline mode — local vulnerability DB only[/dim]")
 
     # ── Auto-offline: use local DB if synced recently (saves ~10s network) ──
+    prefer_local_db = False
     if not offline and not no_scan:
         try:
             import os
@@ -515,9 +516,7 @@ def scan(
             if DB_PATH.exists():
                 _age_days = (time.time() - os.path.getmtime(DB_PATH)) / 86400
                 if _age_days <= 1:
-                    import agent_bom.scanners as _scanners_auto
-
-                    _scanners_auto.prefer_local_db = True
+                    prefer_local_db = True
                     logger.debug("Local DB is %.1f day(s) old — preferring local DB over network", _age_days)
         except Exception:
             pass  # DB not available, will use network
@@ -1166,6 +1165,7 @@ def scan(
                             resolve_transitive=transitive,
                             show_scan_banner=False,
                             offline=offline,
+                            prefer_local_db=prefer_local_db,
                         )
                     except IncompleteScanError as exc:
                         _exit_incomplete_scan_with_partial_summary(
@@ -1201,6 +1201,7 @@ def scan(
                         compliance_enabled=compliance,
                         resolve_transitive=transitive,
                         offline=offline,
+                        prefer_local_db=prefer_local_db,
                     )
                 except IncompleteScanError as exc:
                     _exit_incomplete_scan_with_partial_summary(

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -89,12 +89,14 @@ class ScanOptions:
     offline: bool = False
     compliance_enabled: bool = False
     resolve_transitive: bool = False
+    prefer_local_db: bool = False
 
 
 def default_scan_options(
     *,
     compliance_enabled: bool = False,
     resolve_transitive: bool = False,
+    prefer_local_db: bool | None = None,
     offline: bool | None = None,
 ) -> ScanOptions:
     """Build per-scan options while preserving legacy offline defaults."""
@@ -103,6 +105,7 @@ def default_scan_options(
         offline=offline_mode if offline is None else offline,
         compliance_enabled=compliance_enabled,
         resolve_transitive=resolve_transitive,
+        prefer_local_db=prefer_local_db if prefer_local_db is not None else globals().get("prefer_local_db", False),
     )
 
 
@@ -120,12 +123,14 @@ def set_offline_mode(value: bool) -> None:
 
 
 # When True, prefer local DB results and only fall back to OSV API for
-# packages not found in the DB. Set automatically when DB is <24h old.
+# packages not found in the DB. Legacy compatibility only; concurrent callers
+# should pass ScanOptions(prefer_local_db=...) instead of mutating this.
 prefer_local_db: bool = False
 
 # CVE-level framework tags are always computed so structured outputs stay
 # truthful by default. The CLI --compliance flag still controls whether
 # context-heavy compliance views are rendered explicitly.
+# Legacy compatibility only; per-scan behavior is ScanOptions.compliance_enabled.
 compliance_mode: bool = False
 
 # Map ecosystem names to OSV ecosystem identifiers
@@ -698,6 +703,7 @@ async def scan_packages(
     scan_options = options or default_scan_options(resolve_transitive=resolve_transitive)
     scan_offline = scan_options.offline
     scan_resolve_transitive = scan_options.resolve_transitive
+    scan_prefer_local_db = scan_options.prefer_local_db
     # Deduplicate packages across discovery sources before scanning.
     # Prevents redundant OSV API calls when the same package is discovered
     # from multiple sources (local, K8s, cloud).
@@ -873,7 +879,7 @@ async def scan_packages(
 
     osv_targets = [p for p in scannable if _db_key(p) not in db_covered]
 
-    if scan_offline or (prefer_local_db and not osv_targets):
+    if scan_offline or (scan_prefer_local_db and not osv_targets):
         if scan_offline and not db_covered:
             raise IncompleteScanError(
                 "Offline mode requires a populated local vulnerability DB. Run `agent-bom db update` before using `--offline`."
@@ -888,7 +894,7 @@ async def scan_packages(
                 f"{skipped_names}{suffix}. Run `agent-bom db update` before using `--offline`."
             )
         results = {}
-    elif prefer_local_db and osv_targets:
+    elif scan_prefer_local_db and osv_targets:
         # DB is fresh — only query OSV for packages genuinely missing from DB
         _logger.debug("Local DB preferred: querying OSV for %d uncovered package(s) only", len(osv_targets))
         results = await query_osv_batch(osv_targets)
@@ -1299,12 +1305,14 @@ def scan_agents_sync(
     resolve_transitive: bool = False,
     show_scan_banner: bool = True,
     offline: bool | None = None,
+    prefer_local_db: bool | None = None,
     options: ScanOptions | None = None,
 ) -> list[BlastRadius]:
     """Synchronous wrapper for scan_agents."""
     scan_options = options or default_scan_options(
         compliance_enabled=compliance_enabled,
         resolve_transitive=resolve_transitive,
+        prefer_local_db=prefer_local_db,
         offline=offline,
     )
     if enable_enrichment:

--- a/tests/test_scan_options.py
+++ b/tests/test_scan_options.py
@@ -82,3 +82,21 @@ def test_scan_agents_sync_does_not_mutate_legacy_compliance_global(monkeypatch):
     scan_agents_sync([_agent("compliance")], compliance_enabled=True, show_scan_banner=False)
 
     assert scanners.compliance_mode is False
+
+
+def test_scan_agents_sync_threads_prefer_local_db_as_scan_option(monkeypatch):
+    """Fresh-local-DB preference must be carried per scan, not via module state."""
+    monkeypatch.setattr(scanners, "prefer_local_db", False)
+    seen: list[bool] = []
+
+    async def _scan_packages(_packages, *, resolve_transitive=False, options=None):
+        assert options is not None
+        seen.append(options.prefer_local_db)
+        return 0
+
+    monkeypatch.setattr(scanners, "scan_packages", _scan_packages)
+
+    scan_agents_sync([_agent("local-db")], prefer_local_db=True, show_scan_banner=False)
+
+    assert seen == [True]
+    assert scanners.prefer_local_db is False


### PR DESCRIPTION
Summary

- add prefer_local_db to immutable ScanOptions
- pass the CLI fresh-local-DB preference through scan_agents_sync instead of mutating agent_bom.scanners.prefer_local_db
- keep legacy globals as compatibility fallbacks while documenting that concurrent callers should use explicit ScanOptions
- add regression coverage proving prefer_local_db is scoped to the scan call and does not alter module state

Why

The scanner already moved offline/compliance/transitive controls into ScanOptions for tenant isolation. prefer_local_db was still being toggled as module state from the CLI auto-local-DB path, which leaves another avoidable cross-request bleed risk in long-lived processes.

Validation

- uv run pytest tests/test_scan_options.py tests/test_cli_scan.py::test_scan_offline_mode_does_not_leak_after_cli_invocation -q
- uv run ruff check src/agent_bom/scanners/__init__.py src/agent_bom/cli/agents/__init__.py tests/test_scan_options.py
- uv run mypy src/agent_bom/scanners/__init__.py src/agent_bom/cli/agents/__init__.py
- git diff --check
