### PR TITLE
chore: prepare v0.83.4 release

### DIFF
--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom
-        run: uv tool install agent-bom==0.83.3  # pinned — bump on each release
+        run: uv tool install agent-bom==0.83.4  # pinned — bump on each release
 
       - name: Scan changed MCP configs
         id: scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.83.4] – 2026-04-30
+
+### Added
+- **Snowflake scope-zero operator-pull adapter** — Snowflake now joins AWS, Azure, and GCP as a first-class operator-pushed inventory path, letting teams collect Cortex/Snowpark/Snowflake AI inventory inside their own boundary and explicitly decide whether to hand the canonical JSON to agent-bom for findings, graph, policy, and exports.
+- **MCP registry freshness gate** — `agent-bom registry status` now reports stale/never-synced registry state with `needs_refresh` and `recommended_action`, and `--fail-on-stale` gives release, demo, and CI pipelines a hard gate for bundled MCP intelligence freshness.
+
+### Changed
+- **Pre-pilot proxy/gateway hardening** — SSE proxy policy checks now match stdio/gateway policy scope, gateway upstream handling has bounded resilience, and remote runtime HTTP mode requires explicit auth unless an operator opts into insecure local behavior.
+- **Self-hosted deployment contract** — Helm and deployment docs now state the BYO Postgres contract clearly, including the expected `AGENT_BOM_POSTGRES_URL` secret shape for production profiles.
+- **Fleet and scanner state isolation** — fleet graph nodes preserve endpoint identity for same-named agents across devices, and local database scan preference is threaded through `ScanOptions` instead of shared module state.
+
+### Fixed
+- **Discovery provenance in exports and UI** — SARIF, OCSF, CycloneDX, and dashboard trust surfaces now retain sanitized discovery provenance, permissions-used, and scan-mode context so auditor-facing outputs match JSON/API evidence.
+- **Release/readiness alignment** — README, site docs, OpenClaw skills, Glama/MCP registry manifests, Docker/Helm references, and package metadata are aligned for the v0.83.4 release surface.
+
+---
+
 ## [0.83.3] – 2026-04-30
 
 ### Fixed

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -188,7 +188,7 @@ Focused graph:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `0.83.3` | Current stable version (pinned) |
+| `0.83.4` | Current stable version (pinned) |
 
 Published images:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.3-alpine3.23@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510
 
-ARG VERSION=0.83.3
+ARG VERSION=0.83.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ for the full split-vs-single-image guidance.
 |------|----------|
 | CLI (`agent-bom agents`) | local audit + project scan |
 | Endpoint fleet (`--push-url …/v1/fleet/sync`) | employee laptops pushing into self-hosted fleet |
-| GitHub Action (`uses: msaad00/agent-bom@v0.83.3`) | CI/CD + SARIF |
+| GitHub Action (`uses: msaad00/agent-bom@v0.83.4`) | CI/CD + SARIF |
 | Docker (`agentbom/agent-bom`) | isolated scans, API jobs, and non-browser self-hosted entrypoints |
 | Browser UI image (`agentbom/agent-bom-ui`) | the dashboard image paired with the same self-hosted control plane |
 | Kubernetes / Helm (`helm install agent-bom deploy/helm/agent-bom`) | self-hosted API + dashboard, scheduled discovery |
@@ -404,7 +404,7 @@ References: [PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md) · [PRODUCT_METRICS.md](do
 <summary><b>CI/CD in 60 seconds</b></summary>
 
 ```yaml
-- uses: msaad00/agent-bom@v0.83.3
+- uses: msaad00/agent-bom@v0.83.4
   with:
     scan-type: scan
     severity-threshold: high

--- a/deploy/docker-compose.fullstack.yml
+++ b/deploy/docker-compose.fullstack.yml
@@ -27,7 +27,7 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
-    image: agentbom/agent-bom:0.83.3
+    image: agentbom/agent-bom:0.83.4
     container_name: agent-bom-api
     restart: unless-stopped
     command: api --host 0.0.0.0 --port 8422 --allow-insecure-no-auth
@@ -74,7 +74,7 @@ services:
       args:
         # Baked into the Next.js build — must match the publicly reachable API URL
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8422}
-    image: agentbom/agent-bom-ui:0.83.3
+    image: agentbom/agent-bom-ui:0.83.4
     container_name: agent-bom-ui
     restart: unless-stopped
     ports:

--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -18,7 +18,7 @@
 
 services:
   api:
-    image: agentbom/agent-bom:0.83.3
+    image: agentbom/agent-bom:0.83.4
     container_name: agent-bom-pilot-api
     restart: unless-stopped
     command: >
@@ -45,7 +45,7 @@ services:
       start_period: 10s
 
   ui:
-    image: agentbom/agent-bom-ui:0.83.3
+    image: agentbom/agent-bom-ui:0.83.4
     container_name: agent-bom-pilot-ui
     restart: unless-stopped
     environment:

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -112,7 +112,7 @@ services:
       dockerfile: Dockerfile
       args:
         NEXT_PUBLIC_API_URL: http://localhost:8422
-    image: agentbom/agent-bom-ui:0.83.3
+    image: agentbom/agent-bom-ui:0.83.4
     container_name: agent-bom-ui
     ports:
       - "3000:3000"

--- a/deploy/docker-compose.runtime.yml
+++ b/deploy/docker-compose.runtime.yml
@@ -31,7 +31,7 @@ services:
     build:
       context: ..
       dockerfile: deploy/docker/Dockerfile.runtime
-    image: agentbom/agent-bom:0.83.3
+    image: agentbom/agent-bom:0.83.4
     container_name: agent-bom-runtime-proxy
     depends_on:
       - mcp-server

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -27,7 +27,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.83.3
+ARG VERSION=0.83.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -17,7 +17,7 @@ WORKDIR /app
 COPY pyproject.toml README.md LICENSE ./
 COPY src/ ./src/
 
-ARG VERSION=0.83.3
+ARG VERSION=0.83.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
@@ -40,7 +40,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[runtime]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.83.3
+ARG VERSION=0.83.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.snowpark
+++ b/deploy/docker/Dockerfile.snowpark
@@ -26,7 +26,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11.12-slim@sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c
 
-ARG VERSION=0.83.3
+ARG VERSION=0.83.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -41,7 +41,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.83.3
+ARG VERSION=0.83.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: agent-bom
 description: Open security scanner and graph for AI supply chain and infrastructure — discover agents and MCP, map blast radius, and inspect runtime.
-version: 0.83.3
-appVersion: "0.83.3"
+version: 0.83.4
+appVersion: "0.83.4"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -5,17 +5,17 @@
 
 image:
   repository: agentbom/agent-bom
-  tag: "0.83.3"
+  tag: "0.83.4"
   pullPolicy: IfNotPresent
 
 uiImage:
   repository: agentbom/agent-bom-ui
-  tag: "0.83.3"
+  tag: "0.83.4"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom
-  tag: "0.83.3"
+  tag: "0.83.4"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -38,7 +38,7 @@ tests:
   includeUi: true
   image:
     repository: agentbom/agent-bom
-    tag: "0.83.3"
+    tag: "0.83.4"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deploy/k8s/daemonset.yaml
+++ b/deploy/k8s/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: agent-bom
       containers:
         - name: monitor
-          image: agentbom/agent-bom:0.83.3
+          image: agentbom/agent-bom:0.83.4
           command: ["agent-bom"]
           args:
             - "protect"

--- a/deploy/k8s/proxy-sidecar-pilot.yaml
+++ b/deploy/k8s/proxy-sidecar-pilot.yaml
@@ -109,7 +109,7 @@ spec:
               cpu: "500m"
 
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.83.3
+          image: agentbom/agent-bom:0.83.4
           args:
             - "--policy"
             - "/etc/agent-bom/policy.json"

--- a/deploy/k8s/sidecar-example.yaml
+++ b/deploy/k8s/sidecar-example.yaml
@@ -40,7 +40,7 @@ spec:
 
         # agent-bom proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.83.3
+          image: agentbom/agent-bom:0.83.4
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -135,7 +135,7 @@ agent-bom agents --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.83.3
+- uses: msaad00/agent-bom@v0.83.4
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -72,7 +72,7 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # GitHub Actions
-- uses: msaad00/agent-bom@v0.83.3
+- uses: msaad00/agent-bom@v0.83.4
   with:
     scan-type: agents        # auto-detect MCP configs + deps
     severity-threshold: high # fail PR on HIGH+ CVEs
@@ -90,21 +90,21 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # Container image gate
-- uses: msaad00/agent-bom@v0.83.3
+- uses: msaad00/agent-bom@v0.83.4
   with:
     scan-type: image
     scan-ref: ghcr.io/acme/agent-runtime:sha-abcdef
     severity-threshold: critical
 
 # IaC gate
-- uses: msaad00/agent-bom@v0.83.3
+- uses: msaad00/agent-bom@v0.83.4
   with:
     scan-type: iac
     iac: Dockerfile,k8s/,infra/main.tf
     severity-threshold: high
 
 # Air-gapped or fully cached CI
-- uses: msaad00/agent-bom@v0.83.3
+- uses: msaad00/agent-bom@v0.83.4
   with:
     auto-update-db: false
     enrich: false
@@ -468,7 +468,7 @@ AmazonEC2ReadOnlyAccess
 docker run --rm \
   -v ~/.config:/home/abom/.config:ro \
   -v $(pwd):/workspace:ro \
-  agentbom/agent-bom:0.83.3 agents --format json
+  agentbom/agent-bom:0.83.4 agents --format json
 ```
 
 Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base image.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -242,7 +242,7 @@ blast_radius        — blast radius for a specific CVE
 ### CI/CD (GitHub Action)
 
 ```yaml
-- uses: msaad00/agent-bom@v0.83.3
+- uses: msaad00/agent-bom@v0.83.4
   with:
     format: sarif
     upload-sarif: 'true'

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,6 +1,6 @@
 {
   "generated_on": "2026-04-28",
-  "version": "0.83.3",
+  "version": "0.83.4",
   "metrics": [
     {
       "name": "MCP tools",

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -6,7 +6,7 @@ This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
 - Generated on: `2026-04-28`
-- Version: `0.83.3`
+- Version: `0.83.4`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -97,7 +97,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN" --no-browser
 clawhub publish integrations/openclaw/scan \
   --slug agent-bom-scan --name "agent-bom scan" \
-  --version "0.83.3"
+  --version "0.83.4"
 ```
 
 Release automation uses the same official `clawhub` CLI flow, not a custom
@@ -150,8 +150,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.83.3
-git push origin v0.83.3
+git tag v0.83.4
+git push origin v0.83.4
 ```
 
 This triggers:

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -13,7 +13,7 @@ For each tagged GitHub Release, expect:
 ## Download release assets
 
 ```bash
-TAG=v0.83.3
+TAG=v0.83.4
 VERSION="${TAG#v}"
 mkdir -p /tmp/agent-bom-release && cd /tmp/agent-bom-release
 gh release download "$TAG" --repo msaad00/agent-bom

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -33,7 +33,7 @@ The proxy interposes on the stdio channel between an MCP client (Claude Desktop,
 Use the published main runtime image:
 
 ```bash
-docker pull agentbom/agent-bom:0.83.3
+docker pull agentbom/agent-bom:0.83.4
 ```
 
 If you need to rebuild locally from the checked-out repo, you can still use
@@ -45,7 +45,7 @@ Run as a wrapper around any MCP server:
 ```bash
 docker run --rm \
   -v $(pwd)/audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.83.3 \
+  agentbom/agent-bom:0.83.4 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace
@@ -94,7 +94,7 @@ spec:
 
         # agent-bom runtime proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.83.3
+          image: agentbom/agent-bom:0.83.4
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"
@@ -334,7 +334,7 @@ Use the runtime container directly from Claude Desktop:
         "run", "--rm", "-i",
         "-v", "./workspace:/workspace",
         "-v", "./audit-logs:/var/log/agent-bom",
-        "agentbom/agent-bom:0.83.3",
+        "agentbom/agent-bom:0.83.4",
         "--log", "/var/log/agent-bom/audit.jsonl",
         "--block-undeclared",
         "--",

--- a/docs/archive/WINDOWS_CONTAINERS.md
+++ b/docs/archive/WINDOWS_CONTAINERS.md
@@ -113,7 +113,7 @@ container inspection. Windows Server environments should use:
 
 1. **Python CLI** -- `pip install agent-bom` works on Windows natively
 2. **Docker Desktop** -- run the Linux container images on Windows via WSL 2
-3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.83.3`) which
+3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.83.4`) which
    runs on Linux runners
 
 ---

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,4 +1,4 @@
-# agent-bom v0.83.3 blast-radius demo
+# agent-bom v0.83.4 blast-radius demo
 # Shows: blast radius → package gate
 
 Output docs/images/demo-latest.gif

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
-  "version": "0.83.3",
+  "version": "0.83.4",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
   "title": "agent-bom",
-  "version": "0.83.3",
+  "version": "0.83.4",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.83.3",
+      "version": "0.83.4",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   security checks. Use when the user mentions vulnerability scanning,
   MCP server trust, compliance, SBOM generation, CIS benchmarks, blast
   radius, or AI supply chain risk.
-version: 0.83.3
+version: 0.83.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -25,7 +25,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.3
+    docker: ghcr.io/msaad00/agent-bom:0.83.4
   openclaw:
     requires:
       bins: []
@@ -407,6 +407,6 @@ provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.83.3`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.83.4`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Analyze blast radius, attack paths, and threat landscape across your AI
   infrastructure. Use when: "blast radius", "threat intel", "risk score",
   "attack path", "lateral movement", "context graph", "who can reach what".
-version: 0.83.3
+version: 0.83.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.3
+    docker: ghcr.io/msaad00/agent-bom:0.83.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Generate SBOMs and compliance reports. Use when:
   "compliance report", "NIST", "SOC 2", "ISO 27001", "OWASP", "EU AI Act",
   "AISVS", "generate SBOM", "policy check".
-version: 0.83.3
+version: 0.83.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. OWASP/NIST/EU AI Act/MITRE
@@ -23,7 +23,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.3
+    docker: ghcr.io/msaad00/agent-bom:0.83.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/discover-aws/SKILL.md
+++ b/integrations/openclaw/discover-aws/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   inventory AWS Bedrock, ECS, SageMaker, Lambda, EKS, Step Functions, EC2, or
   agentic AWS infrastructure as canonical inventory. Passing that inventory
   to agent-bom is optional and operator-chosen.
-version: 0.83.3
+version: 0.83.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover/SKILL.md
+++ b/integrations/openclaw/discover/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Discover AI agents, MCP servers, and configurations on this machine or
   environment. Use when: "find agents", "what's configured", "doctor",
   "what MCP servers", "show me what's installed", "mcp inventory".
-version: 0.83.3
+version: 0.83.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.3
+    docker: ghcr.io/msaad00/agent-bom:0.83.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Enforce security policies on MCP tool calls and block dangerous operations at
   runtime. Use when: "block risky calls", "apply policy", "proxy",
   "runtime protection", "policy enforcement", "intercept MCP calls".
-version: 0.83.3
+version: 0.83.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.3
+    docker: ghcr.io/msaad00/agent-bom:0.83.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Monitor agent fleet, track trust scores, and manage lifecycle states. Use
   when: "fleet", "watch agents", "runtime status", "trust scores",
   "fleet sync", "agent lifecycle", "serve dashboard".
-version: 0.83.3
+version: 0.83.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.3
+    docker: ghcr.io/msaad00/agent-bom:0.83.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.83.3
+version: 0.83.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.83.3
+version: 0.83.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Scan infrastructure-as-code, cloud configurations, and find secrets. Use when:
   "check terraform", "scan kubernetes", "IaC", "find secrets",
   "scan dockerfile", "cloud security", "misconfigurations".
-version: 0.83.3
+version: 0.83.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.3
+    docker: ghcr.io/msaad00/agent-bom:0.83.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   KEV), container images, provenance, filesystems, and SBOMs. Use
   when: "check package", "scan image", "verify", "is this safe",
   "scan dependencies", "CVE lookup", "blast radius".
-version: 0.83.3
+version: 0.83.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Native container image
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.3
+    docker: ghcr.io/msaad00/agent-bom:0.83.4
   openclaw:
     requires:
       bins: []
@@ -216,6 +216,6 @@ agent-bom agents
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.83.3`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.83.4`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Diagnose issues, check prerequisites, and validate configurations. Use when:
   "doctor", "debug", "why failing", "validate config", "check prerequisites",
   "something is broken", "db status", "fix my setup".
-version: 0.83.3
+version: 0.83.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.3
+    docker: ghcr.io/msaad00/agent-bom:0.83.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/vulnerability-intel/SKILL.md
+++ b/integrations/openclaw/vulnerability-intel/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   with explicit data-boundary choices. Use when a user asks for CVE lookup,
   advisory intelligence, exploitability context, fix versions, GHSA/OSV/NVD
   enrichment, or package vulnerability triage.
-version: 0.83.3
+version: 0.83.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+ and agent-bom installed from this repository or PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.83.3"
+version = "0.83.4"
 description = "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius."
 readme = "PYPI_README.md"
 license = "Apache-2.0"

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -171,7 +171,7 @@ Install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.83.3 \
+  --version 0.83.4 \
   -n agent-bom --create-namespace \
   -f values.agent-bom.yaml
 ```
@@ -207,7 +207,7 @@ Then install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.83.3 \
+  --version 0.83.4 \
   -n agent-bom --create-namespace \
   -f deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
 ```

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -92,10 +92,10 @@ docker run --rm \
 ## Runtime proxy sidecar
 
 ```bash
-docker pull agentbom/agent-bom:0.83.3
+docker pull agentbom/agent-bom:0.83.4
 docker run --rm -i \
   -v ./audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.83.3 \
+  agentbom/agent-bom:0.83.4 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace

--- a/site-docs/features/policy.md
+++ b/site-docs/features/policy.md
@@ -49,7 +49,7 @@ agent-bom proxy --policy policy.json --block-undeclared -- ...
 
 ```yaml
 - name: Security gate
-  uses: msaad00/agent-bom@v0.83.3
+  uses: msaad00/agent-bom@v0.83.4
   with:
     policy: policy.json
     fail-on-violation: true

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.83.3"
+    __version__ = "0.83.4"
 
 # Cross-check against pyproject.toml for dev installs where the editable
 # install metadata may be stale (i.e. version bumped but not re-installed).

--- a/src/agent_bom/data/mcp-blocklist.json
+++ b/src/agent_bom/data/mcp-blocklist.json
@@ -150,7 +150,7 @@
       "match_type": "pattern",
       "patterns": [
         "(^|[-_./@])credential[-_]?stealer($|[-_./])",
-        "(^|[-_./@])secret[-_]?exfil(trate|tration)?($|[-_./])",
+        "(^|[-_./@])secret[-_]?exfil(trate|tration|trator)?($|[-_./])",
         "(^|[-_./@])token[-_]?grabber($|[-_./])"
       ],
       "severity": "high",

--- a/tests/test_mcp_blocklist.py
+++ b/tests/test_mcp_blocklist.py
@@ -259,6 +259,18 @@ def test_bundled_blocklist_matches_curated_malicious_mcp_packages() -> None:
         assert match.match_type == "pattern"
 
 
+def test_bundled_blocklist_matches_suspicious_exfiltration_names() -> None:
+    blocklist = load_mcp_blocklist()
+    cases = ["credential-stealer", "secret-exfiltrator", "token-grabber"]
+
+    for name in cases:
+        matches = match_mcp_server(MCPServer(name=name, command="npx", args=["-y", name]), blocklist)
+        match = next(match for match in matches if match.entry_id == "suspicious-credential-exfiltration-name")
+
+        assert match.severity == "high"
+        assert match.match_type == "pattern"
+
+
 def test_bundled_blocklist_keeps_version_specific_mcp_package_pinned() -> None:
     blocklist = load_mcp_blocklist()
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.83.3",
+  "version": "0.83.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.83.3",
+      "version": "0.83.4",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
         "@tanstack/react-table": "^8.21.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.83.3",
+  "version": "0.83.4",
   "private": true,
   "packageManager": "npm@10.9.7",
   "engines": {

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/lib/api', () => ({
       scan_sources: [],
       scan_count: 0,
     }),
-    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.83.3' }),
+    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.83.4' }),
   },
 }))
 

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ overrides = [{ name = "python-dotenv", specifier = ">=1.2.2" }]
 
 [[package]]
 name = "agent-bom"
-version = "0.83.3"
+version = "0.83.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- bump package, Docker, Helm, UI, skill, Glama, MCP registry, and docs references to 0.83.4
- add the v0.83.4 changelog entry covering pre-pilot hardening, Snowflake operator-pull, registry freshness, runtime auth, and scanner-state isolation
- keep release surfaces aligned before cutting the signed v0.83.4 tag

## Validation

- python scripts/bump-version.py 0.83.4 --check
- python scripts/check_release_consistency.py
- uv build
- fresh venv install of dist/agent_bom-0.83.4-py3-none-any.whl[api]
- fresh wheel smoke: agent-bom --version, doctor, samples first-run, agents --inventory -> JSON, registry status fields
- uv run pytest tests/test_public_docs_cli_alignment.py tests/test_registry.py tests/test_protect.py tests/test_scan_options.py tests/test_output_cov.py tests/test_gateway_server.py tests/test_gateway_upstreams.py tests/test_graph_builder.py tests/test_operator_pull_azure_gcp_adapters.py tests/test_deploy_profiles.py -q
- npm --prefix ui run test:run -- tests/nav.test.tsx
- git diff --check

Commit signature verified by GitHub: 97ee197b.