### PR TITLE
docs: enforce bundled skill guardrail contract

### DIFF
--- a/docs/CONTRIBUTING_SKILLS.md
+++ b/docs/CONTRIBUTING_SKILLS.md
@@ -1,0 +1,74 @@
+# Contributing agent-bom skills
+
+Bundled skills are part of the product trust boundary. A skill must describe
+what it can read, write, call, persist, and mutate before it can ship.
+
+Use `integrations/openclaw/discover/SKILL.md` or
+`integrations/openclaw/discover-aws/SKILL.md` as the reference shape. Do not
+copy a shorter third-party skill template for bundled agent-bom skills.
+
+## Required frontmatter
+
+Every bundled skill must declare these fields under `metadata.openclaw`:
+
+- `requires.bins`
+- `requires.env`
+- `requires.credentials`
+- `credential_policy`
+- `credential_handling`
+- `optional_env`
+- `optional_bins`
+- `data_flow`
+- `file_reads`
+- `file_writes`
+- `network_endpoints`
+- `telemetry`
+- `persistence`
+- `privilege_escalation`
+- `autonomous_invocation`
+
+Each `network_endpoints` entry must name the endpoint, purpose, and whether
+authentication is used. Use an empty list when no network call is made.
+
+## Required body sections
+
+Every bundled skill must include:
+
+- a clear purpose and supported product surface
+- mode guidance, including the default mode
+- guardrails for what the skill may and may not do
+- privacy and data handling guidance
+- verification or provenance guidance
+- the expected output artifact and schema, when the skill emits one
+
+## Review rules
+
+Reviewers should reject bundled skills that:
+
+- ask users to paste raw cloud keys, API tokens, or session secrets into chat
+- Never print raw credential values, raw URL credentials, or launch arguments
+  with tokens
+- mutate cloud, repository, endpoint, or control-plane resources unless the
+  skill is explicitly a human-approved remediation skill
+- call private agent-bom internals when an existing CLI, API, or MCP command
+  provides the same product contract
+- treat AI prose as compliance evidence
+- emit inventory, SBOM, SARIF, or policy artifacts without schema validation
+- drop `discovery_provenance`, `permissions_used`, or redaction state
+
+## Remediation skills
+
+Write-capable remediation skills have a higher bar than read-only discovery or
+scan skills:
+
+- `autonomous_invocation` must be `never`
+- dry-run must be the default
+- every writable file type must be enumerated in `file_writes`
+- writes must stay inside the project root
+- branch creation, package manager execution, and PR opening must be explicit
+- `network_endpoints` must include GitHub and package registries used by the
+  remediation workflow
+- each apply attempt must produce an audit record
+
+Do not ship a remediation skill that describes patch or PR behavior before the
+corresponding CLI/API behavior exists and is tested.

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -27,6 +27,7 @@ metadata:
       env: []
       credentials: none
     credential_policy: "Zero credentials required. Blast radius and context graph analysis operate on local scan data. EPSS and CVE lookups send only public CVE IDs — no internal data."
+    credential_handling: "No credentials are required or collected. Do not include raw scan artifacts, config files, or credential values in advisory lookups; only public CVE identifiers may leave the machine."
     optional_env: []
     optional_bins: []
     emoji: "\U0001F4A5"

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -30,6 +30,7 @@ metadata:
       env: []
       credentials: none
     credential_policy: "Zero credentials required for OWASP/NIST/EU AI Act compliance and SBOM generation. CIS benchmark checks (AWS, Azure, GCP, Snowflake) optionally accept cloud credentials — only used locally to call cloud APIs, never transmitted elsewhere."
+    credential_handling: "Use only operator-configured cloud SDK credentials for explicitly requested CIS checks. Do not ask users to paste secrets, and never print cloud tokens, private keys, passwords, or connection strings."
     optional_env:
       - name: AWS_PROFILE
         purpose: "AWS CIS benchmark checks — uses boto3 with your local AWS profile"

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -26,6 +26,7 @@ metadata:
       env: []
       credentials: none
     credential_policy: "Zero credentials required. Policy evaluation is local. Proxy operates on local network only. Policy files are user-provided and never transmitted."
+    credential_handling: "Policy and audit files may contain credential names but must not expose credential values. Redact token-like values before logging, displaying, or exporting runtime evidence."
     optional_env: []
     optional_bins: []
     emoji: "\U0001F6AB"

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -27,6 +27,7 @@ metadata:
       env: []
       credentials: none
     credential_policy: "Zero credentials required for fleet listing and trust score tracking. Fleet sync reads local scan state. Dashboard server (agent-bom serve) runs on localhost only."
+    credential_handling: "Fleet and dashboard views may display credential environment variable names for context, but credential values must remain redacted and must not be persisted or transmitted."
     optional_env: []
     optional_bins: []
     emoji: "\U0001F4CA"

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -27,6 +27,7 @@ metadata:
       env: []
       credentials: none
     credential_policy: "Zero credentials required. Registry data is bundled locally. No network calls needed."
+    credential_handling: "No credentials are required for bundled registry lookups. Optional enrichment tokens must stay in the operator environment and must not be printed or embedded in skill output."
     optional_env:
       - name: SNYK_TOKEN
         purpose: "Optional third-party vulnerability enrichment for code_scan (requires SNYK_TOKEN)"

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -26,6 +26,7 @@ metadata:
       env: []
       credentials: none
     credential_policy: "Zero credentials required. Optional ClickHouse URL enables analytics storage. Never auto-discovered or inferred."
+    credential_handling: "Runtime audit data may include credential environment variable names but must not include raw values. Optional analytics credentials are operator-supplied and must not be displayed or inferred."
     optional_env: []
     optional_bins:
       - kubectl

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -27,6 +27,7 @@ metadata:
       env: []
       credentials: none
     credential_policy: "Zero credentials required for IaC and secrets scanning. Cloud checks (AWS/Azure/GCP/Snowflake) optionally accept cloud credentials — only used locally to call cloud APIs, never transmitted elsewhere."
+    credential_handling: "Use local scanner redaction before reporting secrets. Optional cloud credentials stay in the operator environment and must not be printed, persisted, or forwarded."
     optional_env:
       - name: AWS_PROFILE
         purpose: "AWS CIS benchmark checks — uses boto3 with your local AWS profile"

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -26,6 +26,7 @@ metadata:
       env: []
       credentials: none
     credential_policy: "Zero credentials required. All diagnostic checks run locally against the installed environment. No data leaves the machine."
+    credential_handling: "Diagnostics may report missing credential variable names but must not read, print, or persist credential values. Redact environment-derived evidence before display."
     optional_env: []
     optional_bins: []
     emoji: "\U0001F527"

--- a/tests/test_openclaw_skill_contract.py
+++ b/tests/test_openclaw_skill_contract.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_ROOT = ROOT / "integrations" / "openclaw"
+
+
+REQUIRED_OPENCLAW_FIELDS = (
+    "requires:",
+    "bins:",
+    "env:",
+    "credentials:",
+    "credential_policy:",
+    "credential_handling:",
+    "optional_env:",
+    "optional_bins:",
+    "data_flow:",
+    "file_reads:",
+    "file_writes:",
+    "network_endpoints:",
+    "telemetry:",
+    "persistence:",
+    "privilege_escalation:",
+    "autonomous_invocation:",
+)
+
+
+def _bundled_skill_paths() -> list[Path]:
+    return sorted(SKILL_ROOT.glob("*/SKILL.md")) + [SKILL_ROOT / "SKILL.md"]
+
+
+def test_bundled_openclaw_skills_declare_trust_boundary_contract() -> None:
+    """Bundled skills must keep the same explicit trust-boundary surface."""
+    for skill_path in _bundled_skill_paths():
+        content = skill_path.read_text()
+        missing = [field for field in REQUIRED_OPENCLAW_FIELDS if field not in content]
+        assert not missing, f"{skill_path.relative_to(ROOT)} missing {missing}"
+
+
+def test_skill_contribution_contract_documents_guardrails() -> None:
+    """New skill contributors should have a reviewable guardrail contract."""
+    content = (ROOT / "docs" / "CONTRIBUTING_SKILLS.md").read_text()
+    for phrase in (
+        "credential_policy",
+        "credential_handling",
+        "data_flow",
+        "file_reads",
+        "file_writes",
+        "network_endpoints",
+        "autonomous_invocation",
+        "Never print raw credential values",
+        "Do not ship a remediation skill",
+        "corresponding CLI/API behavior exists and is tested",
+    ):
+        assert phrase in content


### PR DESCRIPTION
## Summary
- add a bundled skill contribution contract documenting required trust-boundary metadata and remediation-skill rules
- make existing OpenClaw skills declare `credential_handling` consistently
- add a regression test requiring every bundled OpenClaw skill to declare the guardrail/frontmatter contract

Closes #2136.

## Verification
- `uv run pytest tests/test_openclaw_skill_contract.py tests/test_aws_discovery_skill.py`
- signed commit verified locally with `git log -1 --show-signature`
