### PR TITLE
docs: clarify agent-bom owns skill contract

### DIFF
--- a/docs/CONTRIBUTING_SKILLS.md
+++ b/docs/CONTRIBUTING_SKILLS.md
@@ -4,12 +4,16 @@ Bundled skills are part of the product trust boundary. A skill must describe
 what it can read, write, call, persist, and mutate before it can ship.
 
 Use `integrations/openclaw/discover/SKILL.md` or
-`integrations/openclaw/discover-aws/SKILL.md` as the reference shape. Do not
-copy a shorter third-party skill template for bundled agent-bom skills.
+`integrations/openclaw/discover-aws/SKILL.md` as the current reference shape.
+Those files live under the OpenClaw integration directory because OpenClaw is
+one distribution channel; the trust contract belongs to agent-bom. Do not copy
+a shorter third-party skill template for bundled agent-bom skills.
 
 ## Required frontmatter
 
-Every bundled skill must declare these fields under `metadata.openclaw`:
+Every bundled agent-bom skill must declare these fields in its distribution
+metadata. For the OpenClaw package format, that metadata currently lives under
+`metadata.openclaw`:
 
 - `requires.bins`
 - `requires.env`

--- a/tests/test_bundled_skill_contract.py
+++ b/tests/test_bundled_skill_contract.py
@@ -30,8 +30,8 @@ def _bundled_skill_paths() -> list[Path]:
     return sorted(SKILL_ROOT.glob("*/SKILL.md")) + [SKILL_ROOT / "SKILL.md"]
 
 
-def test_bundled_openclaw_skills_declare_trust_boundary_contract() -> None:
-    """Bundled skills must keep the same explicit trust-boundary surface."""
+def test_bundled_agent_bom_skills_declare_trust_boundary_contract() -> None:
+    """Bundled agent-bom skills must keep the same trust-boundary surface."""
     for skill_path in _bundled_skill_paths():
         content = skill_path.read_text()
         missing = [field for field in REQUIRED_OPENCLAW_FIELDS if field not in content]


### PR DESCRIPTION
## Summary
- clarify that bundled skills are agent-bom skills and OpenClaw is only one distribution channel
- describe `metadata.openclaw` as the current OpenClaw package format, not the product-level trust boundary
- rename the guardrail contract test from OpenClaw-specific to bundled agent-bom skill-specific

Follow-up to #2138 / #2136.

## Verification
- `uv run pytest tests/test_bundled_skill_contract.py tests/test_aws_discovery_skill.py`
- signed commit verified locally with `git log -1 --show-signature`
