### PR TITLE
docs: add Snowflake POV deployment path

### DIFF
--- a/deploy/helm/agent-bom/examples/README.md
+++ b/deploy/helm/agent-bom/examples/README.md
@@ -10,6 +10,7 @@ product split.
 |---|---|---|
 | `sqlite-pilot` | `eks-control-plane-sqlite-pilot-values.yaml` | Single-node packaged demo or short-lived pilot where Postgres is not ready yet |
 | `focused-pilot` | `eks-mcp-pilot-values.yaml` | Narrow EKS pilot with control plane, scanner, and tightened ingress |
+| `byo-postgres` | `byo-postgres-values.yaml` | Overlay for operator-owned Postgres-compatible databases, including Snowflake Postgres candidates |
 | `production` | `eks-production-values.yaml` | Postgres-backed production EKS rollout with autoscaling, backup, and ExternalSecrets |
 | `eks-vanilla` | `eks-vanilla-values.yaml` | Postgres-backed production EKS rollout with ALB, IRSA, Kubernetes Secrets, and no service mesh / ESO / cert-manager requirement |
 | `mesh-hardening` | `eks-istio-kyverno-values.yaml` | Overlay for Istio mTLS/authz and Kyverno policy-controller packaging |
@@ -64,6 +65,11 @@ python scripts/install_helm_profile.py production \
   profiles consume an operator-managed database through
   `AGENT_BOM_POSTGRES_URL`, either from External Secrets Operator
   (`production`) or a Kubernetes Secret (`eks-vanilla`).
+- Use `byo-postgres-values.yaml` as an overlay when the platform team provides
+  a Postgres-compatible database such as RDS/Aurora Postgres, Cloud SQL for
+  PostgreSQL, Azure Database for PostgreSQL, Supabase, Crunchy/EDB, or
+  Snowflake Postgres. Treat new providers as smoke-test required until API,
+  graph, fleet, policy, audit, and backup/restore posture are verified.
 - For Kubernetes Secrets without External Secrets Operator, start from
   `postgres-secret.example.yaml`, create the real secret out-of-band, and keep
   the credential out of values files and git.

--- a/deploy/helm/agent-bom/examples/byo-postgres-values.yaml
+++ b/deploy/helm/agent-bom/examples/byo-postgres-values.yaml
@@ -1,0 +1,54 @@
+# BYO Postgres overlay for operator-owned control-plane databases.
+#
+# Use this with a base profile such as `focused-pilot`, `eks-vanilla`, or
+# `production` when the database is provisioned outside the chart. The database
+# can be RDS/Aurora Postgres, Cloud SQL for PostgreSQL, Azure Database for
+# PostgreSQL, Supabase, Crunchy/EDB, Snowflake Postgres, or another
+# PostgreSQL-compatible service that exposes a standard connection string to the
+# agent-bom API pods.
+#
+# Required Kubernetes Secret shape:
+#
+#   apiVersion: v1
+#   kind: Secret
+#   metadata:
+#     name: agent-bom-control-plane-db
+#     namespace: agent-bom
+#   type: Opaque
+#   stringData:
+#     AGENT_BOM_POSTGRES_URL: postgresql://agent_bom:REDACTED@postgres.example:5432/agent_bom?sslmode=require
+#
+# Snowflake Postgres note:
+#   Treat Snowflake Postgres as a BYO Postgres candidate when it is reachable
+#   from the cluster and the connection string works with the standard Postgres
+#   driver. Keep it in "candidate / smoke-test required" status until migrations,
+#   API startup, graph writes, fleet sync, policy, audit, and backup/restore
+#   posture have been validated in the target account and region.
+
+controlPlane:
+  enabled: true
+  api:
+    env:
+      - name: AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT
+        value: "1"
+      - name: AGENT_BOM_REQUIRE_SHARED_SCIM_STORE
+        value: "1"
+      - name: AGENT_BOM_REQUIRE_AUDIT_HMAC
+        value: "1"
+      - name: AGENT_BOM_POSTGRES_POOL_MIN_SIZE
+        value: "5"
+      - name: AGENT_BOM_POSTGRES_POOL_MAX_SIZE
+        value: "20"
+      - name: AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECONDS
+        value: "5"
+      - name: AGENT_BOM_POSTGRES_STATEMENT_TIMEOUT_MS
+        value: "15000"
+    envFrom:
+      - secretRef:
+          name: agent-bom-control-plane-db
+
+  # Managed Postgres services usually own PITR/backups. Keep the packaged
+  # pg_dump CronJob disabled unless your database team explicitly wants
+  # agent-bom to produce an additional logical backup artifact.
+  backup:
+    enabled: false

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -506,6 +506,7 @@ YAML.
 - [When To Use Proxy vs Gateway vs Fleet](proxy-vs-gateway-vs-fleet.md)
 - [Focused EKS MCP Pilot](eks-mcp-pilot.md)
 - [Packaged API + UI Control Plane](control-plane-helm.md)
+- [Snowflake POV Deployment Runbook](snowflake-pov.md)
 - [Performance, Sizing, and Benchmarks](performance-and-sizing.md)
 - [Visual Leak Detection](visual-leak-detection.md)
 - [Worker and Scheduler Concurrency](worker-and-scheduler-concurrency.md)

--- a/site-docs/deployment/snowflake-pov.md
+++ b/site-docs/deployment/snowflake-pov.md
@@ -1,0 +1,183 @@
+# Snowflake POV deployment runbook
+
+Use this page for a Snowflake-oriented proof of value where agent-bom runs in
+the customer's infrastructure and Snowflake/Cortex inventory is collected inside
+the operator boundary.
+
+## Scope
+
+The v0.83.4 POV scope is:
+
+- self-hosted API + UI control plane
+- operator-owned Postgres-compatible control-plane database
+- Snowflake/Cortex operator-pull inventory
+- scan, findings, provenance, permissions, graph, and export review
+- optional MCP proxy/gateway enforcement for selected MCP traffic
+
+The POV does not include automatic patching or draft PR remediation. Today
+agent-bom produces remediation plans and evidence that can be routed into an
+existing Dependabot, Renovate, Jira, or AppSec workflow.
+
+## Database options
+
+agent-bom needs a transactional Postgres-compatible control-plane database for
+multi-replica API, fleet, policy, graph, and audit state. The Helm chart does
+not install a Postgres subchart.
+
+Supported deployment pattern:
+
+- provision the database with the customer's platform tooling
+- store `AGENT_BOM_POSTGRES_URL` in a Kubernetes Secret or External Secrets
+  backend
+- run agent-bom API/UI pods with the database secret mounted as environment
+- smoke-test migrations, API startup, graph writes, fleet sync, policy, audit,
+  and backup/restore posture
+
+Candidate database services include RDS/Aurora Postgres, Cloud SQL for
+PostgreSQL, Azure Database for PostgreSQL, Supabase, Crunchy/EDB, and Snowflake
+Postgres. Snowflake Postgres is a good fit for Snowflake-owned environments
+when the instance exposes a normal PostgreSQL connection string reachable from
+the agent-bom API pods. Treat it as a candidate until the smoke tests above pass
+in the target account and region.
+
+## 1. Create the database secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agent-bom-control-plane-db
+  namespace: agent-bom
+type: Opaque
+stringData:
+  AGENT_BOM_POSTGRES_URL: postgresql://agent_bom:REDACTED@postgres.example:5432/agent_bom?sslmode=require
+```
+
+Apply it out of band through the operator's secret manager, SOPS, CI secret
+store, or External Secrets. Do not commit the real URL.
+
+## 2. Deploy the control plane
+
+For a focused EKS POV with BYO Postgres:
+
+```bash
+helm upgrade --install agent-bom deploy/helm/agent-bom \
+  --namespace agent-bom --create-namespace \
+  -f deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml \
+  -f deploy/helm/agent-bom/examples/byo-postgres-values.yaml
+```
+
+For a production-shaped EKS profile:
+
+```bash
+helm upgrade --install agent-bom deploy/helm/agent-bom \
+  --namespace agent-bom --create-namespace \
+  -f deploy/helm/agent-bom/examples/eks-production-values.yaml
+```
+
+Use the Snowflake backend overlay only when the POV explicitly wants selected
+agent-bom stores backed by Snowflake warehouse tables. That is separate from
+using Snowflake Postgres as the Postgres-compatible control-plane database.
+
+## 3. Verify the control plane
+
+```bash
+kubectl -n agent-bom get pods
+kubectl -n agent-bom logs deploy/agent-bom-api --tail=100
+kubectl -n agent-bom port-forward svc/agent-bom-api 8080:8080
+
+curl -fsS http://127.0.0.1:8080/health
+curl -fsS http://127.0.0.1:8080/version
+curl -fsS http://127.0.0.1:8080/v1/discovery/providers
+curl -fsS http://127.0.0.1:8080/v1/auth/policy
+```
+
+For Postgres candidate validation, run at least one scan and confirm API logs
+show persistent graph/fleet/policy state without falling back to in-memory
+stores.
+
+## 4. Generate Snowflake operator-pull inventory
+
+Run this from the operator environment, not from the agent-bom API pod:
+
+```bash
+python examples/operator_pull/snowflake_inventory_adapter.py \
+  --account my-org-my-account \
+  --authenticator externalbrowser \
+  --database AI_PLATFORM \
+  --schema PUBLIC \
+  --output snowflake-inventory.json
+```
+
+Then remove Snowflake credential material from the scanner environment before
+handoff:
+
+```bash
+unset SNOWFLAKE_PASSWORD SNOWFLAKE_TOKEN SNOWFLAKE_PRIVATE_KEY_PATH
+```
+
+## 5. Scan the pushed inventory
+
+Local scan:
+
+```bash
+agent-bom agents \
+  --inventory snowflake-inventory.json \
+  --format json \
+  --output snowflake-agent-bom.json
+```
+
+CI/SARIF gate:
+
+```bash
+agent-bom agents \
+  --inventory snowflake-inventory.json \
+  --format sarif \
+  --output snowflake-agent-bom.sarif \
+  --fail-on-severity high
+```
+
+Review these evidence fields:
+
+- `discovery_provenance.source_type`
+- `permissions_used`
+- redacted `cloud_origin`
+- MCP server names, transports, tools, packages, and PURLs
+- graph path from package or finding to MCP server, agent, tools, and credential
+  environment variable names
+
+## 6. Optional runtime enforcement
+
+Use `agent-bom proxy` for selected local/sidecar MCP enforcement. Use
+`agent-bom gateway serve` for shared remote MCP traffic that should be governed
+from one policy/audit plane.
+
+Do not make the gateway a mandatory choke point for the whole POV. Start with a
+small set of MCP traffic where policy enforcement and audit are the evaluation
+goal.
+
+## What works today
+
+| Surface | POV status |
+|---|---|
+| CLI scan and SARIF gate | Works from packaged install |
+| API + UI control plane | Deployable with BYO Postgres |
+| Fleet and graph | Deployable for controlled POV; smoke-test in buyer env |
+| MCP proxy/gateway | Deployable for selected traffic |
+| Snowflake/Cortex inventory | Operator-pull adapter exists |
+| Provenance and permissions | JSON, UI, SARIF, OCSF, CycloneDX surfaces exist |
+| Remediation | Structured plan only |
+
+## Roadmap / do not oversell
+
+| Surface | Current state |
+|---|---|
+| Draft PR remediation | Roadmap; not part of v0.83.4 |
+| Auto-remediation | Roadmap |
+| Full Compliance Hub | Roadmap |
+| Complete IAM-to-agent traversal | Roadmap |
+| Snowflake Postgres certification | Candidate until smoke-tested |
+
+The customer-safe positioning is: agent-bom can run in the customer's
+infrastructure with customer-owned database, identity, network, and secrets. It
+does not require a hosted agent-bom control plane.

--- a/src/agent_bom/deploy_profiles.py
+++ b/src/agent_bom/deploy_profiles.py
@@ -41,6 +41,14 @@ def helm_validation_profiles(repo_root: Path) -> list[HelmValidationProfile]:
             values_files=(examples / "eks-mcp-pilot-values.yaml",),
         ),
         HelmValidationProfile(
+            name="focused-pilot-byo-postgres",
+            description="Focused EKS pilot plus operator-owned Postgres-compatible control-plane database.",
+            values_files=(
+                examples / "eks-mcp-pilot-values.yaml",
+                examples / "byo-postgres-values.yaml",
+            ),
+        ),
+        HelmValidationProfile(
             name="production",
             description="Postgres-backed production EKS defaults with autoscaling and backups.",
             values_files=(examples / "eks-production-values.yaml",),

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -274,6 +274,7 @@ def test_helm_examples_readme_is_shipped():
     assert readme.exists()
     body = readme.read_text()
     assert "focused-pilot" in body
+    assert "byo-postgres" in body
     assert "sqlite-pilot" in body
     assert "eks-vanilla" in body
     assert "gateway-runtime" in body

--- a/tests/test_deploy_profiles.py
+++ b/tests/test_deploy_profiles.py
@@ -16,6 +16,7 @@ def test_helm_validation_profiles_reference_existing_chart_assets():
     assert [profile.name for profile in profiles] == [
         "sqlite-pilot",
         "focused-pilot",
+        "focused-pilot-byo-postgres",
         "production",
         "eks-vanilla",
         "mesh-hardening",
@@ -47,6 +48,11 @@ def test_postgres_secret_example_documents_byo_postgres_contract():
 
     assert "dependencies:" not in chart.read_text()
     assert "AGENT_BOM_POSTGRES_URL" in postgres_secret.read_text()
+    byo_values = repo_root / "deploy" / "helm" / "agent-bom" / "examples" / "byo-postgres-values.yaml"
+    byo_body = byo_values.read_text()
+    assert "AGENT_BOM_POSTGRES_URL" in byo_body
+    assert "Snowflake Postgres" in byo_body
+    assert "smoke-test required" in byo_body
     docs_body = docs.read_text()
     assert "no Postgres subchart dependency" in docs_body
     assert "provision Postgres/RDS with your platform tooling" in docs_body
@@ -66,6 +72,13 @@ def test_build_helm_profile_command_uses_shipped_profile_stack():
     assert "agent-bom" in cmd
     assert "--create-namespace" in cmd
     assert str(repo_root / "deploy" / "helm" / "agent-bom" / "examples" / "eks-mcp-pilot-values.yaml") in cmd
+
+
+def test_byo_postgres_profile_layers_focused_pilot_with_database_overlay():
+    repo_root = Path(__file__).resolve().parent.parent
+    cmd = build_helm_profile_command(repo_root, "focused-pilot-byo-postgres")
+    assert str(repo_root / "deploy" / "helm" / "agent-bom" / "examples" / "eks-mcp-pilot-values.yaml") in cmd
+    assert str(repo_root / "deploy" / "helm" / "agent-bom" / "examples" / "byo-postgres-values.yaml") in cmd
 
 
 def test_install_helm_profile_script_prints_packaged_command():

--- a/tests/test_snowflake_pov_docs.py
+++ b/tests/test_snowflake_pov_docs.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_snowflake_pov_runbook_names_current_and_roadmap_surfaces() -> None:
+    body = (ROOT / "site-docs" / "deployment" / "snowflake-pov.md").read_text()
+
+    for required in (
+        "Snowflake/Cortex operator-pull inventory",
+        "Snowflake Postgres",
+        "AGENT_BOM_POSTGRES_URL",
+        "examples/operator_pull/snowflake_inventory_adapter.py",
+        "--fail-on-severity high",
+        "Draft PR remediation",
+        "Roadmap",
+        "Candidate until smoke-tested",
+    ):
+        assert required in body
+
+
+def test_snowflake_operator_pull_adapter_has_existing_smoke_coverage() -> None:
+    test_body = (ROOT / "tests" / "test_operator_pull_azure_gcp_adapters.py").read_text()
+    adapter_body = (ROOT / "examples" / "operator_pull" / "snowflake_inventory_adapter.py").read_text()
+
+    assert "test_snowflake_operator_pull_adapter_cli_writes_scope_zero_inventory" in test_body
+    assert "--discovery-method" in adapter_body
+    assert "operator_pushed_inventory" in adapter_body
+    assert "examples/operator_pull/snowflake_inventory_adapter.py" in adapter_body


### PR DESCRIPTION
## Summary
- add a Snowflake POV runbook covering self-hosted control plane, Snowflake/Cortex operator-pull inventory, scan, graph, proxy/gateway, and roadmap boundaries
- add a BYO Postgres Helm overlay for operator-owned Postgres-compatible databases, including Snowflake Postgres as a smoke-test-required candidate
- add a packaged `focused-pilot-byo-postgres` Helm profile and tests so the deployment path stays discoverable

## Verification
- `uv run pytest tests/test_deploy_profiles.py tests/test_deploy_manifests.py::test_helm_examples_readme_is_shipped tests/test_snowflake_pov_docs.py tests/test_operator_pull_azure_gcp_adapters.py::test_snowflake_operator_pull_adapter_cli_writes_scope_zero_inventory`
- `python scripts/install_helm_profile.py focused-pilot-byo-postgres --print-command`
- signed commit verified locally with `git log -1 --show-signature`
