### PR TITLE
fix: render unified findings in human reports

### DIFF
--- a/src/agent_bom/output/html.py
+++ b/src/agent_bom/output/html.py
@@ -430,7 +430,8 @@ def _policy_findings_section(findings: list["Finding"]) -> str:
         description_html = f'<br><span style="color:#94a3b8">{_esc(description)}</span>' if description else ""
         remediation_html = _esc(remediation) if remediation else '<span style="color:#334155">&mdash;</span>'
         rows.append(
-            "<tr>"
+            f'<tr data-severity="{sev}" data-type="{_esc(finding.finding_type.value)}" '
+            f'data-source="{_esc(finding.source.value)}" data-asset-type="{_esc(finding.asset.asset_type)}">'
             f"<td>{_sev_badge(sev)}</td>"
             f'<td><code style="color:#c4b5fd;font-size:.75rem">{_esc(finding.finding_type.value)}</code></td>'
             f'<td><strong style="color:#e2e8f0">{_esc(asset_label)}</strong>'
@@ -445,6 +446,39 @@ def _policy_findings_section(findings: list["Finding"]) -> str:
 
     headers = ["Severity", "Type", "Asset", "Finding", "Source", "Evidence", "Remediation"]
     header_html = "".join(f'<th data-col="{i}">{h} <span class="sort-arrow"></span></th>' for i, h in enumerate(headers))
+    severity_filters = "".join(
+        f'<label style="display:flex;align-items:center;gap:4px;font-size:.78rem;color:{color};cursor:pointer">'
+        f'<input type="checkbox" class="policy-sev-filter" value="{sev}" checked> {label}</label>'
+        for sev, label, color in (
+            ("critical", "Critical", "#fca5a5"),
+            ("high", "High", "#fb923c"),
+            ("medium", "Medium", "#fbbf24"),
+            ("low", "Low", "#94a3b8"),
+            ("unknown", "Unknown", "#94a3b8"),
+        )
+    )
+    finding_types = sorted({finding.finding_type.value for finding in findings})
+    type_options = "".join(f'<option value="{_esc(ftype)}">{_esc(ftype)}</option>' for ftype in finding_types)
+    asset_types = sorted({finding.asset.asset_type for finding in findings if finding.asset.asset_type})
+    asset_options = "".join(f'<option value="{_esc(asset_type)}">{_esc(asset_type)}</option>' for asset_type in asset_types)
+    filter_bar = (
+        '<div class="policy-filter-bar" style="display:flex;flex-wrap:wrap;gap:12px;align-items:center;'
+        'margin-bottom:14px;padding:12px 16px;background:#0f172a;border-radius:8px;border:1px solid #1e293b">'
+        '<span style="font-size:.72rem;color:#64748b;text-transform:uppercase;letter-spacing:.06em;font-weight:700">Filter:</span>'
+        f"{severity_filters}"
+        '<span style="width:1px;height:18px;background:#334155"></span>'
+        '<select id="policyTypeFilter" style="padding:6px 10px;background:#1e293b;border:1px solid #334155;border-radius:6px;'
+        'color:#e2e8f0;font-size:.78rem;outline:none"><option value="">All types</option>'
+        f"{type_options}</select>"
+        '<select id="policyAssetFilter" style="padding:6px 10px;background:#1e293b;border:1px solid #334155;border-radius:6px;'
+        'color:#e2e8f0;font-size:.78rem;outline:none"><option value="">All assets</option>'
+        f"{asset_options}</select>"
+        '<input type="text" id="policySearch" placeholder="Search policy findings&hellip;" '
+        'style="padding:6px 10px;background:#1e293b;border:1px solid #334155;border-radius:6px;'
+        'color:#e2e8f0;font-size:.78rem;width:220px;outline:none">'
+        '<span id="policyVisibleCount" style="margin-left:auto;font-size:.72rem;color:#64748b"></span>'
+        "</div>"
+    )
     return (
         f'<section id="policyfindings">'
         f'<div class="sec-title">&#x1f6e1;&#xfe0f; Policy &amp; Security Findings'
@@ -454,7 +488,8 @@ def _policy_findings_section(findings: list["Finding"]) -> str:
         f"Unified non-CVE findings from scanners, policy checks, runtime controls, and MCP intelligence. "
         f"These are the same findings emitted in JSON and SARIF."
         f"</div>"
-        f'<div class="table-wrap"><table class="data-table sortable">'
+        f"{filter_bar}"
+        f'<div class="table-wrap"><table class="data-table sortable" id="policyFindingsTable">'
         f"<thead><tr>{header_html}</tr></thead>"
         f"<tbody>{''.join(rows)}</tbody></table></div>"
         f"</div></section>"
@@ -1385,7 +1420,7 @@ def to_html(report: "AIBOMReport", blast_radii: list["BlastRadius"] | None = Non
     /* PRINT */
     @media print{{
       body{{background:#fff;color:#1e293b;font-size:12px}}
-      .sidebar,.graph-controls,.graph-filter-bar,.vuln-filter-bar,.toggle-btn,.inv-search,.print-btn,.node-sidebar,.sidebar-toggle{{display:none!important}}
+      .sidebar,.graph-controls,.graph-filter-bar,.vuln-filter-bar,.policy-filter-bar,.toggle-btn,.inv-search,.print-btn,.node-sidebar,.sidebar-toggle{{display:none!important}}
       .container{{margin-left:0;max-width:100%;padding:10px}}
       footer{{margin-left:0}}
       section{{page-break-inside:avoid;margin-bottom:20px}}
@@ -2351,6 +2386,44 @@ def to_html(report: "AIBOMReport", blast_radii: list["BlastRadius"] | None = Non
   if (kevToggle) kevToggle.addEventListener('change', filterVulnTable);
   var vulnSearchInput = document.getElementById('vulnSearch');
   if (vulnSearchInput) vulnSearchInput.addEventListener('input', filterVulnTable);
+
+  // Unified policy/security finding filtering
+  function filterPolicyFindingsTable() {{
+    var table = document.getElementById('policyFindingsTable');
+    if (!table) return;
+    var rows = table.querySelectorAll('tbody tr');
+    var checkedSevs = Array.from(document.querySelectorAll('.policy-sev-filter:checked')).map(function(c) {{ return c.value; }});
+    var typeFilter = (document.getElementById('policyTypeFilter') || {{}}).value || '';
+    var assetFilter = (document.getElementById('policyAssetFilter') || {{}}).value || '';
+    var q = (document.getElementById('policySearch') || {{}}).value || '';
+    q = q.toLowerCase();
+    var visible = 0;
+    rows.forEach(function(row) {{
+      var sev = row.getAttribute('data-severity') || '';
+      var type = row.getAttribute('data-type') || '';
+      var assetType = row.getAttribute('data-asset-type') || '';
+      var text = row.textContent.toLowerCase();
+      var show = true;
+      if (checkedSevs.indexOf(sev) === -1) show = false;
+      if (typeFilter && type !== typeFilter) show = false;
+      if (assetFilter && assetType !== assetFilter) show = false;
+      if (q && text.indexOf(q) === -1) show = false;
+      row.style.display = show ? '' : 'none';
+      if (show) visible++;
+    }});
+    var count = document.getElementById('policyVisibleCount');
+    if (count) count.textContent = visible + ' of ' + rows.length + ' shown';
+  }}
+  document.querySelectorAll('.policy-sev-filter').forEach(function(cb) {{
+    cb.addEventListener('change', filterPolicyFindingsTable);
+  }});
+  var policyTypeFilter = document.getElementById('policyTypeFilter');
+  if (policyTypeFilter) policyTypeFilter.addEventListener('change', filterPolicyFindingsTable);
+  var policyAssetFilter = document.getElementById('policyAssetFilter');
+  if (policyAssetFilter) policyAssetFilter.addEventListener('change', filterPolicyFindingsTable);
+  var policySearchInput = document.getElementById('policySearch');
+  if (policySearchInput) policySearchInput.addEventListener('input', filterPolicyFindingsTable);
+  filterPolicyFindingsTable();
 
   // Cytoscape: CVE Attack Flow graph
   var cyAtkContainer = document.getElementById('cyAttack');

--- a/src/agent_bom/output/html.py
+++ b/src/agent_bom/output/html.py
@@ -21,9 +21,11 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from agent_bom.finding import FindingType
 from agent_bom.security import sanitize_launch_command, sanitize_path_label
 
 if TYPE_CHECKING:
+    from agent_bom.finding import Finding
     from agent_bom.models import AIBOMReport, BlastRadius
 
 
@@ -148,8 +150,9 @@ def _warn_gate_banner(report: "AIBOMReport") -> str:
     )
 
 
-def _summary_cards(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> str:
+def _summary_cards(report: "AIBOMReport", blast_radii: list["BlastRadius"], policy_findings: list["Finding"]) -> str:
     crit = sum(1 for br in blast_radii if br.vulnerability.severity.value == "critical")
+    policy_crit = sum(1 for finding in policy_findings if str(finding.severity).lower() == "critical")
     total_vulns = len(blast_radii)
     cred_servers = sum(1 for a in report.agents for s in a.mcp_servers if s.has_credentials)
     kev_count = sum(1 for br in blast_radii if br.vulnerability.is_kev)
@@ -172,8 +175,17 @@ def _summary_cards(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> s
                 card("&#x1f916;", str(report.total_agents), "Agents", "#60a5fa", f"{report.total_servers} servers"),
                 card("&#x1f4e6;", str(report.total_packages), "Packages", "#38bdf8", "direct + transitive"),
                 card("&#x26a0;&#xfe0f;", str(total_vulns), "Vulnerabilities", "#f87171" if total_vulns else "#34d399", "across all agents"),
+                card(
+                    "&#x1f6e1;&#xfe0f;",
+                    str(len(policy_findings)),
+                    "Policy Findings",
+                    "#f87171" if policy_findings else "#34d399",
+                    "non-CVE controls",
+                ),
                 card("&#x1f511;", str(cred_servers), "Servers w/ Creds", "#fbbf24" if cred_servers else "#34d399", "credential exposure"),
-                card("&#x1f6a8;", str(crit), "Critical", "#ef4444" if crit else "#34d399", "needs immediate fix"),
+                card(
+                    "&#x1f6a8;", str(crit + policy_crit), "Critical", "#ef4444" if crit or policy_crit else "#34d399", "needs immediate fix"
+                ),
                 card("&#x1f9a0;", str(kev_count), "CISA KEV", "#a855f7" if kev_count else "#34d399", "actively exploited"),
             ]
         )
@@ -387,6 +399,66 @@ def _remediation_list(blast_radii: list["BlastRadius"]) -> str:
         )
         nf_html = '<div style="margin-top:20px"><div class="subsection-label">No Fix Available</div>' + nf_rows + "</div>"
     return "".join(items) + nf_html
+
+
+def _non_cve_findings(report: "AIBOMReport") -> list["Finding"]:
+    """Return unified findings not already represented in the CVE tables."""
+    return [finding for finding in report.to_findings() if finding.finding_type != FindingType.CVE]
+
+
+def _policy_findings_section(findings: list["Finding"]) -> str:
+    """Render unified non-CVE findings with asset, source, and evidence context."""
+    if not findings:
+        return ""
+
+    rows = []
+    for finding in sorted(findings, key=lambda f: _SEV_ORDER.get(str(f.severity).lower(), -1), reverse=True):
+        sev = str(finding.severity or "unknown").lower()
+        title = finding.title or finding.description or finding.finding_type.value
+        asset_label = finding.asset.name or finding.asset.identifier or "unknown asset"
+        location = (
+            f'<br><code style="color:#64748b;font-size:.72rem">{_esc(finding.asset.location)}</code>' if finding.asset.location else ""
+        )
+        description = finding.description or finding.remediation_guidance or ""
+        evidence_items = [f"{_esc(key)}={_esc(value)}" for key, value in finding.evidence.items() if value not in (None, "", [], {})][:4]
+        evidence = (
+            "<br>".join(f'<code style="color:#94a3b8;font-size:.72rem">{item}</code>' for item in evidence_items)
+            if evidence_items
+            else '<span style="color:#334155">&mdash;</span>'
+        )
+        remediation = finding.remediation_guidance or ""
+        description_html = f'<br><span style="color:#94a3b8">{_esc(description)}</span>' if description else ""
+        remediation_html = _esc(remediation) if remediation else '<span style="color:#334155">&mdash;</span>'
+        rows.append(
+            "<tr>"
+            f"<td>{_sev_badge(sev)}</td>"
+            f'<td><code style="color:#c4b5fd;font-size:.75rem">{_esc(finding.finding_type.value)}</code></td>'
+            f'<td><strong style="color:#e2e8f0">{_esc(asset_label)}</strong>'
+            f'<br><span style="color:#64748b;font-size:.72rem">{_esc(finding.asset.asset_type)}</span>{location}</td>'
+            f'<td style="font-size:.82rem;color:#cbd5e1;max-width:260px"><strong>{_esc(title)}</strong>'
+            f"{description_html}</td>"
+            f'<td><code style="color:#94a3b8;font-size:.75rem">{_esc(finding.source.value)}</code></td>'
+            f'<td style="font-size:.75rem;color:#94a3b8;max-width:220px">{evidence}</td>'
+            f'<td style="font-size:.75rem;color:#4ade80;max-width:220px">{remediation_html}</td>'
+            "</tr>"
+        )
+
+    headers = ["Severity", "Type", "Asset", "Finding", "Source", "Evidence", "Remediation"]
+    header_html = "".join(f'<th data-col="{i}">{h} <span class="sort-arrow"></span></th>' for i, h in enumerate(headers))
+    return (
+        f'<section id="policyfindings">'
+        f'<div class="sec-title">&#x1f6e1;&#xfe0f; Policy &amp; Security Findings'
+        f'<sup style="font-size:.7rem;color:#475569;margin-left:6px">{len(findings)}</sup></div>'
+        f'<div class="panel">'
+        f'<div class="hint-box">'
+        f"Unified non-CVE findings from scanners, policy checks, runtime controls, and MCP intelligence. "
+        f"These are the same findings emitted in JSON and SARIF."
+        f"</div>"
+        f'<div class="table-wrap"><table class="data-table sortable">'
+        f"<thead><tr>{header_html}</tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody></table></div>"
+        f"</div></section>"
+    )
 
 
 def _skill_audit_section(report: "AIBOMReport") -> str:
@@ -1062,17 +1134,20 @@ def _compliance_section(blast_radii: list["BlastRadius"]) -> str:
 
 def to_html(report: "AIBOMReport", blast_radii: list["BlastRadius"] | None = None) -> str:
     blast_radii = blast_radii or []
+    policy_findings = _non_cve_findings(report)
     generated = report.generated_at.strftime("%Y-%m-%d %H:%M:%S UTC")
     elements_json = _cytoscape_elements(report, blast_radii)
     attack_flow_json = _attack_flow_elements(blast_radii)
     chart_data_json = _chart_data(blast_radii)
     crit = sum(1 for br in blast_radii if br.vulnerability.severity.value == "critical")
+    policy_crit = sum(1 for finding in policy_findings if str(finding.severity).lower() == "critical")
+    policy_high = sum(1 for finding in policy_findings if str(finding.severity).lower() == "high")
     total_vulns = len(blast_radii)
 
-    if crit:
+    if crit or policy_crit:
         status_color, status_label = "#dc2626", "CRITICAL FINDINGS"
-    elif total_vulns:
-        status_color, status_label = "#d97706", "VULNERABILITIES FOUND"
+    elif total_vulns or policy_high or policy_findings:
+        status_color, status_label = "#d97706", "SECURITY FINDINGS"
     else:
         status_color, status_label = "#16a34a", "CLEAN"
 
@@ -1098,6 +1173,7 @@ def to_html(report: "AIBOMReport", blast_radii: list["BlastRadius"] | None = Non
             f'<div class="panel">{_remediation_list(blast_radii)}</div>'
             f"</section>"
         )
+    policy_section = _policy_findings_section(policy_findings)
 
     # Compliance section
     compliance_html = _compliance_section(blast_radii)
@@ -1361,6 +1437,7 @@ def to_html(report: "AIBOMReport", blast_radii: list["BlastRadius"] | None = Non
     <div class="sidebar-group-label">Security</div>
     {'<a href="#attackflow" class="sidebar-link"><span class="link-icon">&#x26a1;</span> Attack Flow</a>' if blast_radii else ""}
     {f'<a href="#vulns" class="sidebar-link"><span class="link-icon">&#x1f41b;</span> Vulnerabilities <span class="link-badge" style="background:#7f1d1d;color:#fca5a5">{len(blast_radii)}</span></a>' if blast_radii else ""}
+    {f'<a href="#policyfindings" class="sidebar-link"><span class="link-icon">&#x1f6e1;&#xfe0f;</span> Policy Findings <span class="link-badge" style="background:#78350f;color:#fcd34d">{len(policy_findings)}</span></a>' if policy_findings else ""}
     {'<a href="#blast" class="sidebar-link"><span class="link-icon">&#x1f4a5;</span> Blast Radius</a>' if blast_radii else ""}
     {'<a href="#remediation" class="sidebar-link"><span class="link-icon">&#x1f527;</span> Remediation</a>' if blast_radii else ""}
   </div>
@@ -1406,7 +1483,7 @@ def to_html(report: "AIBOMReport", blast_radii: list["BlastRadius"] | None = Non
   <!-- Summary stat cards -->
   <section id="summary">
     <div class="sec-title">Summary</div>
-    {_summary_cards(report, blast_radii)}
+    {_summary_cards(report, blast_radii, policy_findings)}
   </section>
 
   <!-- Charts row -->
@@ -1490,6 +1567,7 @@ def to_html(report: "AIBOMReport", blast_radii: list["BlastRadius"] | None = Non
   {_attack_flow_section(blast_radii)}
 
   <!-- Vuln / Blast / Remediation -->
+  {policy_section}
   {vuln_sections}
 
   <!-- Compliance posture -->

--- a/src/agent_bom/output/markdown.py
+++ b/src/agent_bom/output/markdown.py
@@ -5,12 +5,14 @@ Produces a self-contained Markdown report with summary table and detailed findin
 
 from __future__ import annotations
 
+from agent_bom.finding import Finding, FindingType
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
 
 
 def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> str:
     """Convert an AIBOMReport to Markdown string."""
     brs = blast_radii or report.blast_radii
+    policy_findings = _non_cve_findings(report)
     lines: list[str] = []
 
     # Header
@@ -30,31 +32,71 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
     lines.append(f"| MCP servers | {report.total_servers} |")
     lines.append(f"| Packages scanned | {report.total_packages} |")
     lines.append(f"| Vulnerabilities | {len(brs)} |")
+    lines.append(f"| Policy/security findings | {len(policy_findings)} |")
     lines.append(f"| Critical | {sev_counts.get('critical', 0)} |")
     lines.append(f"| High | {sev_counts.get('high', 0)} |")
     lines.append(f"| Medium | {sev_counts.get('medium', 0)} |")
     lines.append(f"| Low | {sev_counts.get('low', 0)} |")
     lines.append("")
 
-    if not brs:
+    if not brs and not policy_findings:
         lines.append("No vulnerabilities found.")
         return "\n".join(lines) + "\n"
 
+    if policy_findings:
+        lines.append("## Policy & Security Findings")
+        lines.append("")
+        lines.append("| Severity | Type | Asset | Finding | Source |")
+        lines.append("|----------|------|-------|---------|--------|")
+        for finding in sorted(policy_findings, key=lambda f: _finding_sev_order(f.severity)):
+            asset = _md_cell(finding.asset.name or finding.asset.identifier or "-")
+            location = f"<br>`{finding.asset.location}`" if finding.asset.location else ""
+            title = _md_cell(finding.title or finding.description or finding.finding_type.value)
+            source = finding.source.value
+            lines.append(
+                f"| {_severity_text(finding.severity)} | `{finding.finding_type.value}` | {asset}{location} | {title} | `{source}` |"
+            )
+        lines.append("")
+
+        high_policy_findings = [f for f in policy_findings if f.severity.lower() in {"critical", "high"}]
+        if high_policy_findings:
+            lines.append("## High-Risk Policy Findings")
+            lines.append("")
+            for finding in high_policy_findings:
+                title = finding.title or finding.finding_type.value
+                lines.append(f"### {title}")
+                lines.append("")
+                lines.append(f"- **Severity**: {finding.severity.upper()}")
+                lines.append(f"- **Type**: {finding.finding_type.value}")
+                lines.append(f"- **Asset**: {finding.asset.name}")
+                if finding.asset.location:
+                    lines.append(f"- **Location**: `{finding.asset.location}`")
+                if finding.description:
+                    lines.append(f"- **Description**: {finding.description}")
+                if finding.remediation_guidance:
+                    lines.append(f"- **Remediation**: {finding.remediation_guidance}")
+                if finding.evidence:
+                    evidence = ", ".join(f"{key}={value}" for key, value in finding.evidence.items() if value is not None)
+                    if evidence:
+                        lines.append(f"- **Evidence**: {evidence}")
+                lines.append("")
+
     # Findings table
-    lines.append("## Findings")
-    lines.append("")
-    lines.append("| Severity | CVE | Package | Version | Fix | CVSS | Agents |")
-    lines.append("|----------|-----|---------|---------|-----|------|--------|")
+    if brs:
+        lines.append("## Findings")
+        lines.append("")
+        lines.append("| Severity | CVE | Package | Version | Fix | CVSS | Agents |")
+        lines.append("|----------|-----|---------|---------|-----|------|--------|")
 
-    for br in sorted(brs, key=lambda b: _sev_order(b.vulnerability.severity)):
-        v = br.vulnerability
-        sev_badge = _severity_badge(v.severity)
-        cvss = f"{v.cvss_score}" if v.cvss_score is not None else "-"
-        fix = v.fixed_version or "-"
-        agents = str(len(br.affected_agents))
-        lines.append(f"| {sev_badge} | {v.id} | {br.package.name} | {br.package.version or '-'} | {fix} | {cvss} | {agents} |")
+        for br in sorted(brs, key=lambda b: _sev_order(b.vulnerability.severity)):
+            v = br.vulnerability
+            sev_badge = _severity_badge(v.severity)
+            cvss = f"{v.cvss_score}" if v.cvss_score is not None else "-"
+            fix = v.fixed_version or "-"
+            agents = str(len(br.affected_agents))
+            lines.append(f"| {sev_badge} | {v.id} | {br.package.name} | {br.package.version or '-'} | {fix} | {cvss} | {agents} |")
 
-    lines.append("")
+        lines.append("")
 
     # Critical/High details
     critical_high = [br for br in brs if br.vulnerability.severity in (Severity.CRITICAL, Severity.HIGH)]
@@ -108,13 +150,33 @@ def _severity_counts(brs: list[BlastRadius]) -> dict[str, int]:
     return counts
 
 
+def _non_cve_findings(report: AIBOMReport) -> list[Finding]:
+    """Return unified findings that do not already appear in the CVE table."""
+    return [finding for finding in report.to_findings() if finding.finding_type != FindingType.CVE]
+
+
 _SEV_ORDER = {Severity.CRITICAL: 0, Severity.HIGH: 1, Severity.MEDIUM: 2, Severity.LOW: 3, Severity.UNKNOWN: 4, Severity.NONE: 5}
+_FINDING_SEV_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3, "unknown": 4, "none": 5}
 
 
 def _sev_order(sev: Severity) -> int:
     return _SEV_ORDER.get(sev, 99)
 
 
+def _finding_sev_order(sev: str) -> int:
+    return _FINDING_SEV_ORDER.get(sev.lower(), 99)
+
+
 def _severity_badge(sev: Severity) -> str:
     """Return a text badge for severity."""
     return f"**{sev.value.upper()}**"
+
+
+def _severity_text(sev: str) -> str:
+    """Return a text badge for string severities from unified findings."""
+    return f"**{sev.upper()}**"
+
+
+def _md_cell(value: object) -> str:
+    """Escape Markdown table separators without hiding human-readable context."""
+    return str(value).replace("|", "\\|")

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -7,6 +7,7 @@ import io
 import xml.etree.ElementTree as ET
 from datetime import datetime
 
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType
 from agent_bom.models import (
     Agent,
     AgentStatus,
@@ -20,6 +21,7 @@ from agent_bom.models import (
     Vulnerability,
 )
 from agent_bom.output import to_csv, to_json, to_junit, to_markdown
+from agent_bom.output.html import to_html
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -130,6 +132,39 @@ def _report_with_vulns() -> tuple[AIBOMReport, list[BlastRadius]]:
     ]
     report = _make_report(agents=[agent], blast_radii=brs)
     return report, brs
+
+
+def _report_with_policy_finding() -> AIBOMReport:
+    """Report with a unified non-CVE finding and no vulnerable packages."""
+    report = _make_report(agents=[_make_agent(servers=[_make_server()])])
+    report.findings = [
+        Finding(
+            finding_type=FindingType.MCP_BLOCKLIST,
+            source=FindingSource.MCP_SCAN,
+            asset=Asset(name="credential-stealer", asset_type="mcp_server", location="/tmp/mcp.json"),
+            severity="high",
+            title="Suspicious credential exfiltration MCP server",
+            description="Matched the MCP intelligence blocklist.",
+            remediation_guidance="Remove this server or replace it with a trusted MCP server.",
+            evidence={"match_type": "pattern", "confidence": "suspicious"},
+        ),
+        Finding(
+            finding_type=FindingType.CIS_FAIL,
+            source=FindingSource.CLOUD_CIS,
+            asset=Asset(
+                name="snowflake-cortex-service",
+                asset_type="cloud_resource",
+                identifier="snowflake://acct/cortex/svc",
+                location="snowflake:us-west-2",
+            ),
+            severity="medium",
+            title="Cloud AI service missing hardened policy",
+            description="Snowflake Cortex service policy needs review.",
+            remediation_guidance="Review provider contract and tighten the service policy.",
+            evidence={"scan_mode": "operator_pushed_inventory", "permissions_used": "read-only"},
+        ),
+    ]
+    return report
 
 
 # ── JUnit XML ────────────────────────────────────────────────────────────────
@@ -364,3 +399,32 @@ class TestMarkdown:
         report = _make_report()
         md = to_markdown(report)
         assert "0.70.6" in md
+
+    def test_unified_non_cve_findings_are_rendered(self):
+        report = _report_with_policy_finding()
+        md = to_markdown(report)
+
+        assert "## Policy & Security Findings" in md
+        assert "MCP_BLOCKLIST" in md
+        assert "CIS_FAIL" in md
+        assert "credential-stealer" in md
+        assert "snowflake-cortex-service" in md
+        assert "Suspicious credential exfiltration MCP server" in md
+        assert "No vulnerabilities found" not in md
+
+
+def test_html_renders_unified_non_cve_findings_with_asset_context():
+    report = _report_with_policy_finding()
+    html = to_html(report, [])
+
+    assert "SECURITY FINDINGS" in html
+    assert "Policy &amp; Security Findings" in html
+    assert "MCP_BLOCKLIST" in html
+    assert "CIS_FAIL" in html
+    assert "credential-stealer" in html
+    assert "snowflake-cortex-service" in html
+    assert "cloud_resource" in html
+    assert "operator_pushed_inventory" in html
+    assert "/tmp/mcp.json" in html
+    assert "Matched the MCP intelligence blocklist." in html
+    assert "Unified non-CVE findings" in html

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -419,6 +419,12 @@ def test_html_renders_unified_non_cve_findings_with_asset_context():
 
     assert "SECURITY FINDINGS" in html
     assert "Policy &amp; Security Findings" in html
+    assert 'id="policyFindingsTable"' in html
+    assert 'class="policy-sev-filter"' in html
+    assert 'id="policyTypeFilter"' in html
+    assert 'id="policyAssetFilter"' in html
+    assert 'id="policySearch"' in html
+    assert "filterPolicyFindingsTable" in html
     assert "MCP_BLOCKLIST" in html
     assert "CIS_FAIL" in html
     assert "credential-stealer" in html


### PR DESCRIPTION
## Summary
- render unified non-CVE findings in Markdown reports instead of hiding them behind a CVE-only path
- add an HTML Policy & Security Findings section with severity, finding type, asset, source, evidence, and remediation context
- make HTML status cards/status badge data-aware so non-CVE findings do not render as CLEAN

Closes #2133.

## Validation
- uv run pytest tests/test_output_formats.py
- uv run ruff check src/agent_bom/output/html.py src/agent_bom/output/markdown.py tests/test_output_formats.py
- uv run ruff format --check src/agent_bom/output/html.py src/agent_bom/output/markdown.py tests/test_output_formats.py
- pre-commit hooks: ruff, ruff-format, mypy, bandit

## Signature
- commit 9f4a77580e1faaae7507ecb19c3e06777cc7197c is signed and verified locally
