### PR TITLE
fix: reflect MCP intelligence in graph risk state

### DIFF
--- a/src/agent_bom/output/graph.py
+++ b/src/agent_bom/output/graph.py
@@ -97,9 +97,11 @@ def build_graph_elements(
     Node types:
       - ``provider``    — cloud source grouping (AWS, Azure, Databricks, local, etc.)
       - ``agent``       — AI agent
-      - ``server_vuln`` — MCP server with vulnerable packages
-      - ``server_cred`` — MCP server with exposed credentials
-      - ``server_clean``— MCP server, no issues
+      - ``server_vuln``    — MCP server with vulnerable packages
+      - ``server_blocked`` — MCP server blocked by MCP intelligence
+      - ``server_intel``   — MCP server with non-blocking MCP intelligence findings
+      - ``server_cred``    — MCP server with exposed credentials
+      - ``server_clean``   — MCP server, no issues
       - ``pkg_vuln``    — vulnerable package summary
       - ``cve``         — individual CVE/advisory
 
@@ -192,7 +194,18 @@ def build_graph_elements(
             vuln_count = sum(1 for p in srv.packages if (p.name, p.ecosystem) in vuln_pkg_keys)
             has_vuln = vuln_count > 0
             has_cred = srv.has_credentials
-            stype = "server_vuln" if has_vuln else ("server_cred" if has_cred else "server_clean")
+            has_blocking_intel = bool(getattr(srv, "security_blocked", False))
+            has_security_intel = bool(getattr(srv, "security_intelligence", []))
+            if has_blocking_intel:
+                stype = "server_blocked"
+            elif has_vuln:
+                stype = "server_vuln"
+            elif has_security_intel:
+                stype = "server_intel"
+            elif has_cred:
+                stype = "server_cred"
+            else:
+                stype = "server_clean"
 
             vulnerable_pkg_count = sum(1 for p in srv.packages if (p.name, p.ecosystem) in vuln_pkg_keys)
             total_pkg_vulns = 0
@@ -213,10 +226,22 @@ def build_graph_elements(
             if total_pkg_vulns:
                 pkg_badge += f" • {total_pkg_vulns} CVEs"
             server_label = f"{srv.name}\n{pkg_badge}"
-            if has_cred:
+            if has_blocking_intel:
+                server_label = "BLOCK " + server_label
+            elif has_security_intel:
+                server_label = "INTEL " + server_label
+            elif has_cred:
                 server_label = "KEY " + server_label
             elif has_vuln:
                 server_label = "RISK " + server_label
+            intelligence = list(getattr(srv, "security_intelligence", []) or [])
+            intelligence_titles = [
+                str(item.get("title") or item.get("entry_id") or "")
+                for item in intelligence
+                if isinstance(item, dict) and (item.get("title") or item.get("entry_id"))
+            ][:5]
+            intel_note = f"\nMCP intelligence: {', '.join(intelligence_titles)}" if intelligence_titles else ""
+            security_warnings = list(getattr(srv, "security_warnings", []) or [])
 
             elements.append(
                 {
@@ -224,12 +249,16 @@ def build_graph_elements(
                         "id": sid,
                         "label": server_label,
                         "type": stype,
-                        "tip": f"MCP Server: {srv.name}{pkg_note}{cinfo}",
+                        "tip": f"MCP Server: {srv.name}{pkg_note}{cinfo}{intel_note}",
                         "command": sanitize_launch_command(srv.command or "", srv.args or [], max_args=3)[:80],
                         "packageCount": len(srv.packages),
                         "vulnPackageCount": vulnerable_pkg_count,
                         "vulnCount": total_pkg_vulns,
                         "criticalCount": critical_pkg_vulns,
+                        "securityBlocked": has_blocking_intel,
+                        "securityIntelligenceCount": len(intelligence),
+                        "securityIntelligence": json.dumps(intelligence_titles),
+                        "securityWarnings": json.dumps(security_warnings[:5]),
                         "hasCredentials": has_cred,
                         "credentials": json.dumps(srv.credential_names) if srv.credential_names else "[]",
                         "toolNames": json.dumps([t.name for t in srv.tools[:10]]) if srv.tools else "[]",
@@ -244,6 +273,8 @@ def build_graph_elements(
                         "target": sid,
                         "type": "uses",
                         "credentialEdge": 1 if has_cred else 0,
+                        "securityBlocked": 1 if has_blocking_intel else 0,
+                        "securityIntelligence": 1 if has_security_intel else 0,
                     }
                 }
             )
@@ -760,6 +791,14 @@ const cy=cytoscape({{
       'background-color':'#21262d','border-color':'#6e7681','border-width':3,
       'width':'mapData(packageCount, 1, 12, 190, 250)','height':56,'opacity':0.78
     }}}},
+    {{selector:'node[type="server_blocked"]',style:{{
+      'background-color':'#4a0612','border-color':'#ff3b30','border-width':4,
+      'width':'mapData(securityIntelligenceCount, 1, 10, 210, 300)','height':60
+    }}}},
+    {{selector:'node[type="server_intel"]',style:{{
+      'background-color':'#3f2a0b','border-color':'#f59e0b','border-width':3,
+      'width':'mapData(securityIntelligenceCount, 1, 10, 200, 280)','height':58
+    }}}},
     {{selector:'node[type="server_vuln"]',style:{{
       'background-color':'#451f24','border-color':'#ff5d5d','border-width':3,
       'width':'mapData(vulnCount, 1, 40, 200, 300)','height':56
@@ -786,6 +825,8 @@ const cy=cytoscape({{
       'target-arrow-shape':'triangle','curve-style':'bezier','arrow-scale':0.8,'opacity':0.7}}}},
     {{selector:'edge[type="hosts"]',style:{{'line-color':'#4a9eff','target-arrow-color':'#4a9eff','width':2}}}},
     {{selector:'edge[type="uses"]',style:{{'line-color':'#2ea043','target-arrow-color':'#2ea043','width':2}}}},
+    {{selector:'edge[type="uses"][securityBlocked = 1]',style:{{'line-color':'#ff3b30','target-arrow-color':'#ff3b30','width':3.5}}}},
+    {{selector:'edge[type="uses"][securityIntelligence = 1]',style:{{'line-color':'#f59e0b','target-arrow-color':'#f59e0b','width':3}}}},
     {{selector:'edge[type="uses"][credentialEdge = 1]',style:{{'line-color':'#f2b84b','target-arrow-color':'#f2b84b','width':3}}}},
     {{selector:'edge[type="depends_on"]',style:{{'line-color':'#8b949e','target-arrow-color':'#8b949e','width':1.5}}}},
     {{selector:'edge[type="depends_on"][maxSeverity = "critical"]',style:{{

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -680,6 +680,59 @@ def test_graph_no_cve_nodes_when_disabled():
     assert len(cve_nodes) == 0
 
 
+def test_graph_blocklisted_server_is_not_rendered_clean():
+    """MCP intelligence should affect server risk state even without package CVEs."""
+    from agent_bom.output.graph import build_graph_elements
+
+    server = MCPServer(
+        name="credential-stealer",
+        command="npx",
+        args=["credential-stealer"],
+        security_blocked=True,
+        security_warnings=["MCP_BLOCKLIST[high/pattern]: credential-stealer"],
+        security_intelligence=[
+            {
+                "entry_id": "suspicious-credential-stealer",
+                "title": "Suspicious credential exfiltration MCP server",
+            }
+        ],
+    )
+    agent = Agent(name="claude", agent_type=AgentType.CUSTOM, config_path="/tmp/mcp.json", mcp_servers=[server])
+    report = AIBOMReport(agents=[agent])
+
+    elements = build_graph_elements(report, [])
+    server_node = next(e["data"] for e in elements if e.get("data", {}).get("id") == "s:claude:credential-stealer")
+    uses_edge = next(e["data"] for e in elements if e.get("data", {}).get("target") == "s:claude:credential-stealer")
+
+    assert server_node["type"] == "server_blocked"
+    assert server_node["securityBlocked"] is True
+    assert server_node["securityIntelligenceCount"] == 1
+    assert "BLOCK credential-stealer" in server_node["label"]
+    assert "Suspicious credential exfiltration MCP server" in server_node["tip"]
+    assert uses_edge["securityBlocked"] == 1
+
+
+def test_graph_non_blocking_mcp_intelligence_is_warned():
+    """Non-blocking MCP intelligence gets a warning state, not a clean state."""
+    from agent_bom.output.graph import build_graph_elements
+
+    server = MCPServer(
+        name="unknown-risk-server",
+        command="uvx",
+        security_intelligence=[{"entry_id": "intel-review", "title": "Review MCP server before use"}],
+    )
+    agent = Agent(name="cursor", agent_type=AgentType.CUSTOM, config_path="/tmp/mcp.json", mcp_servers=[server])
+    report = AIBOMReport(agents=[agent])
+
+    elements = build_graph_elements(report, [])
+    server_node = next(e["data"] for e in elements if e.get("data", {}).get("id") == "s:cursor:unknown-risk-server")
+
+    assert server_node["type"] == "server_intel"
+    assert server_node["securityBlocked"] is False
+    assert server_node["securityIntelligenceCount"] == 1
+    assert "INTEL unknown-risk-server" in server_node["label"]
+
+
 def test_graph_collapse_cves_into_package_summary():
     """Collapsed graph mode summarizes CVEs on the package node instead of emitting leaf nodes."""
     from agent_bom.output.graph import build_graph_elements


### PR DESCRIPTION
## Summary
- render blocklisted MCP servers as blocked graph nodes instead of clean servers
- render non-blocking MCP intelligence as a warning graph node state
- carry security intelligence and blocked-state flags onto server nodes and agent-to-server edges

Closes #2132.

## Validation
- uv run pytest tests/test_cloud.py::test_graph_blocklisted_server_is_not_rendered_clean tests/test_cloud.py::test_graph_non_blocking_mcp_intelligence_is_warned tests/test_cloud.py::test_graph_cve_nodes tests/test_cloud.py::test_graph_collapse_cves_into_package_summary
- uv run ruff check src/agent_bom/output/graph.py tests/test_cloud.py
- uv run ruff format --check src/agent_bom/output/graph.py tests/test_cloud.py
- pre-commit hooks: ruff, ruff-format, mypy, bandit

## Signature
- commit 2867a2a31c50bdd5d783b8e77eb0867ab8830b02 is signed and verified locally
