### PR TITLE
fix: calibrate compact posture for policy findings

### DIFF
--- a/src/agent_bom/output/compact.py
+++ b/src/agent_bom/output/compact.py
@@ -97,6 +97,10 @@ def print_compact_summary(report: AIBOMReport) -> None:
         sev_counts[str(finding.severity).upper()] += 1
 
     scorecard = compute_posture_scorecard(report)
+    high_risk_policy_count = sev_counts.get("CRITICAL", 0) + sev_counts.get("HIGH", 0)
+    scorecard_summary = scorecard.summary
+    if high_risk_policy_count and not active_findings:
+        scorecard_summary = f"{high_risk_policy_count} high-risk policy/security finding(s) present"
     preferred_driver_order = [
         "credential_hygiene",
         "vulnerability_posture",
@@ -160,7 +164,7 @@ def print_compact_summary(report: AIBOMReport) -> None:
 
     lines = [
         f"  [bold]POSTURE GRADE:[/bold]  {_posture_grade_badge(scorecard.grade)} "
-        f"[bold]{scorecard.score:.1f}/100[/bold]  [dim]{scorecard.summary}[/dim]",
+        f"[bold]{scorecard.score:.1f}/100[/bold]  [dim]{scorecard_summary}[/dim]",
         f"  [bold]SECURITY POSTURE:[/bold]  {posture}",
         "",
         f"  Agents  [bold]{report.total_agents}[/bold]    "

--- a/tests/test_compact_output.py
+++ b/tests/test_compact_output.py
@@ -142,6 +142,8 @@ def test_compact_summary_includes_non_cve_findings():
     assert "CLEAN" not in output
     assert "HIGH" in output
     assert "Findings" in output
+    assert "high-risk policy/security finding" in output
+    assert "Strong security posture" not in output
 
 
 def test_compact_summary_credentials():


### PR DESCRIPTION
## Summary
- prevent the compact console summary from pairing high/critical non-CVE findings with a generic strong-posture headline
- keep posture scorecard output intact, but use a specific policy/security finding summary when MCP blocklist or other unified findings drive the risk
- add regression coverage for high MCP_BLOCKLIST findings

Closes #2131.

## Validation
- uv run pytest tests/test_compact_output.py::test_compact_summary_includes_non_cve_findings tests/test_compact_output.py::test_compact_summary_clean tests/test_compact_output.py::test_compact_summary_with_vulns
- uv run ruff check src/agent_bom/output/compact.py tests/test_compact_output.py
- uv run ruff format --check src/agent_bom/output/compact.py tests/test_compact_output.py
- pre-commit hooks: ruff, ruff-format, mypy, bandit

## Signature
- commit 84068e3e8b7995563b4103ee43d4b499927604f3 is signed and verified locally
