### PR TITLE
fix: add graph exploitable via edges

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -81,14 +81,14 @@ Used for unified findings outside the SCA / blast-radius path
 The unified graph projects the canonical model into a node/edge form
 used for blast-radius traversal, dashboards, and OCSF export.
 
-### Entity types (14)
+### Entity types (18)
 
 `AGENT`, `SERVER`, `PACKAGE`, `TOOL`, `MODEL`, `DATASET`, `CONTAINER`,
 `CLOUD_RESOURCE`, `VULNERABILITY`, `MISCONFIGURATION`, `CREDENTIAL`,
 `USER`, `GROUP`, `SERVICE_ACCOUNT`, `PROVIDER`, `ENVIRONMENT`, `FLEET`,
 `CLUSTER`.
 
-### Relationship types (20+)
+### Relationship types (24)
 
 | Group | Relationships | Direction |
 |---|---|---|
@@ -97,6 +97,12 @@ used for blast-radius traversal, dashboards, and OCSF export.
 | Lateral movement | `SHARES_SERVER`, `SHARES_CRED`, `LATERAL_PATH` | symmetric |
 | Ownership | `MANAGES`, `OWNS`, `PART_OF`, `MEMBER_OF` | hierarchical |
 | Runtime | `INVOKED`, `ACCESSED`, `DELEGATED_TO` | source → target, time-stamped |
+
+`EXPLOITABLE_VIA` is a capability-impact edge from a vulnerability to a
+tool when the affected package is connected to the MCP server that provides
+that tool. Because package-to-function call stacks are not always observable,
+the edge evidence records `mapping_method` and `confidence`; conservative
+server-scope mappings must not be presented as exact function-level proof.
 
 ### Canonical class → graph node mapping
 

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -21,6 +21,7 @@ from agent_bom.graph.severity import SEVERITY_RISK_SCORE
 from agent_bom.graph.types import EntityType, RelationshipType
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.package_utils import canonical_package_key, normalize_package_name
+from agent_bom.risk_analyzer import ToolCapability, classify_tool
 from agent_bom.security import sanitize_security_warnings, sanitize_text, sanitize_url
 
 try:
@@ -72,6 +73,9 @@ def build_unified_graph_from_report(
     server_name_to_agent_servers: dict[str, dict[str, str]] = defaultdict(dict)
     agent_to_server_ids: dict[str, set[str]] = defaultdict(set)
     agent_config_path_to_id: dict[str, str] = {}
+    server_to_tool_ids: dict[str, list[str]] = defaultdict(list)
+    package_id_to_servers: dict[str, list[str]] = defaultdict(list)
+    pending_exploitable_edges: list[tuple[str, str, str, dict[str, Any], str]] = []
 
     # ── Agents → Servers → Packages → Tools → Credentials ───────────
     for agent_dict in agents_data:
@@ -239,17 +243,29 @@ def build_unified_graph_from_report(
                         evidence=package_evidence,
                     )
                 )
+                package_id_to_servers[pkg_id].append(srv_id)
                 pkg_key = _package_graph_key(pkg_name, pkg_version, ecosystem, pkg_dict.get("purl"))
                 pkg_key_to_servers[pkg_key].append(srv_id)
 
                 # ── Package-level vulnerabilities ──
                 for vuln_dict in pkg_dict.get("vulnerabilities", []):
-                    _add_vuln_node(graph, vuln_dict, pkg_id, data_source_tag, package_evidence)
+                    vuln_node_id = _add_vuln_node(graph, vuln_dict, pkg_id, data_source_tag, package_evidence)
+                    if vuln_node_id:
+                        pending_exploitable_edges.append(
+                            (
+                                vuln_node_id,
+                                srv_id,
+                                pkg_id,
+                                package_evidence,
+                                str(vuln_dict.get("severity", "") or "").lower(),
+                            )
+                        )
 
             # ── Tools ──
             for tool_dict in srv_dict.get("tools", []):
                 tool_name = tool_dict.get("name", "unknown")
                 tool_id = f"tool:{srv_id}:{tool_name}"
+                capabilities, capability_source = _tool_capabilities(tool_dict)
                 graph.add_node(
                     UnifiedNode(
                         id=tool_id,
@@ -261,12 +277,17 @@ def build_unified_graph_from_report(
                             "fingerprint": tool_dict.get("fingerprint", ""),
                             "risk_score": tool_dict.get("risk_score", 0),
                             "schema_findings": tool_dict.get("schema_findings", []),
+                            "schema_rule_findings": tool_dict.get("schema_rule_findings", []),
+                            "declared_capabilities": tool_dict.get("declared_capabilities", []),
+                            "capabilities": capabilities,
+                            "capability_source": capability_source,
                             "server": srv_id,
                             "agent": agent_name,
                         },
                         data_sources=[data_source_tag],
                     )
                 )
+                server_to_tool_ids[srv_id].append(tool_id)
                 graph.add_edge(
                     UnifiedEdge(
                         source=srv_id,
@@ -301,6 +322,18 @@ def build_unified_graph_from_report(
                     )
                 )
                 cred_to_agents[env_key].append(agent_id)
+
+    for vuln_node_id, srv_id, pkg_id, package_evidence, severity in pending_exploitable_edges:
+        _add_exploitable_via_edges(
+            graph,
+            server_to_tool_ids=server_to_tool_ids,
+            vuln_node_id=vuln_node_id,
+            server_id=srv_id,
+            package_id=pkg_id,
+            evidence=package_evidence,
+            severity=severity,
+            data_source=data_source_tag,
+        )
 
     # ── Blast radius vulnerabilities ─────────────────────────────────
     for br_dict in blast_data:
@@ -350,7 +383,7 @@ def build_unified_graph_from_report(
 
         # Link affected servers → vulnerability using indexed lookups instead
         # of an agent×server cross-product scan.
-        for srv_id in _resolve_affected_server_ids(
+        affected_server_ids = _resolve_affected_server_ids(
             br_dict,
             pkg_name=pkg_name,
             pkg_version=pkg_version,
@@ -358,7 +391,8 @@ def build_unified_graph_from_report(
             pkg_key_to_servers=pkg_key_to_servers,
             server_name_to_agent_servers=server_name_to_agent_servers,
             agent_to_server_ids=agent_to_server_ids,
-        ):
+        )
+        for srv_id in affected_server_ids:
             graph.add_edge(
                 UnifiedEdge(
                     source=srv_id,
@@ -368,6 +402,27 @@ def build_unified_graph_from_report(
                     evidence=_blast_radius_package_evidence(br_dict, data_source_tag),
                 )
             )
+
+        for srv_id in affected_server_ids:
+            pkg_ids = _resolve_affected_package_ids(
+                br_dict,
+                server_id=srv_id,
+                pkg_name=pkg_name,
+                pkg_version=pkg_version,
+                ecosystem=ecosystem,
+                package_id_to_servers=package_id_to_servers,
+            )
+            for pkg_id in pkg_ids:
+                _add_exploitable_via_edges(
+                    graph,
+                    server_to_tool_ids=server_to_tool_ids,
+                    vuln_node_id=vuln_node_id,
+                    server_id=srv_id,
+                    package_id=pkg_id,
+                    evidence=_blast_radius_package_evidence(br_dict, data_source_tag),
+                    severity=severity,
+                    data_source=data_source_tag,
+                )
 
     # ── Shared server edges (agent ↔ agent) ──────────────────────────
     for srv_name, agent_names in server_to_agents.items():
@@ -771,17 +826,143 @@ def build_unified_graph_from_report(
     return graph
 
 
+def _tool_capabilities(tool_dict: dict[str, Any]) -> tuple[list[str], str]:
+    """Return normalized tool capability facets and their evidence source."""
+    declared_values = tool_dict.get("capabilities") or tool_dict.get("declared_capabilities") or []
+    if isinstance(declared_values, list):
+        declared = sorted(
+            {
+                capability.value
+                for raw in declared_values
+                if isinstance(raw, str) and (capability := _normalize_tool_capability(raw)) is not None
+            }
+        )
+        if declared:
+            return declared, "declared"
+
+    capabilities = {capability.value for capability in classify_tool(str(tool_dict.get("name", "")), str(tool_dict.get("description", "")))}
+    schema_findings = tool_dict.get("schema_findings", [])
+    if isinstance(schema_findings, list):
+        for finding in schema_findings:
+            low = str(finding).lower()
+            if "network-egress" in low or "url" in low:
+                capabilities.add(ToolCapability.NETWORK.value)
+            if "shell-execution" in low or "command" in low:
+                capabilities.add(ToolCapability.EXECUTE.value)
+            if "filesystem" in low or "path" in low:
+                capabilities.add(ToolCapability.READ.value)
+    return sorted(capabilities), "classified"
+
+
+def _normalize_tool_capability(value: str) -> ToolCapability | None:
+    normalized = value.strip().lower().replace("-", "_").replace(" ", "_")
+    aliases = {
+        "readonly": "read",
+        "read_only": "read",
+        "destructive": "delete",
+        "exec": "execute",
+        "execution": "execute",
+        "network_egress": "network",
+        "egress": "network",
+        "credential": "auth",
+        "credentials": "auth",
+        "administrative": "admin",
+    }
+    normalized = aliases.get(normalized, normalized)
+    try:
+        return ToolCapability(normalized)
+    except ValueError:
+        return None
+
+
+def _resolve_affected_package_ids(
+    br_dict: dict[str, Any],
+    *,
+    server_id: str,
+    pkg_name: str,
+    pkg_version: str,
+    ecosystem: str,
+    package_id_to_servers: dict[str, list[str]],
+) -> list[str]:
+    """Return package nodes on a specific server that can safely drive capability-impact edges."""
+    if not pkg_name:
+        return []
+    pkg_id = _package_node_id_from_parts(pkg_name, pkg_version, ecosystem, br_dict.get("package_purl") or br_dict.get("purl"))
+    if server_id not in package_id_to_servers.get(pkg_id, []):
+        return []
+    evidence = _blast_radius_package_evidence(br_dict, "")
+    if not _has_mappable_package_version(evidence):
+        return []
+    return [pkg_id]
+
+
+def _add_exploitable_via_edges(
+    graph: UnifiedGraph,
+    *,
+    server_to_tool_ids: dict[str, list[str]],
+    vuln_node_id: str,
+    server_id: str,
+    package_id: str,
+    evidence: dict[str, Any],
+    severity: str,
+    data_source: str,
+) -> None:
+    """Link a vulnerability to impacted tool capabilities with conservative evidence.
+
+    The graph usually knows that an MCP server depends on a vulnerable package
+    and exposes tools, but not the exact function-level package-to-tool call
+    stack. These edges therefore carry a conservative mapping method instead
+    of pretending to prove exact exploit reachability.
+    """
+    if not _has_mappable_package_version(evidence):
+        return
+    for tool_id in server_to_tool_ids.get(server_id, []):
+        tool = graph.get_node(tool_id)
+        if tool is None:
+            continue
+        capabilities = [str(cap) for cap in tool.attributes.get("capabilities", []) if str(cap)]
+        if not capabilities:
+            continue
+        graph.add_edge(
+            UnifiedEdge(
+                source=vuln_node_id,
+                target=tool_id,
+                relationship=RelationshipType.EXPLOITABLE_VIA,
+                weight=SEVERITY_RISK_SCORE.get(severity, 1.0),
+                evidence={
+                    "source": data_source,
+                    "server": server_id,
+                    "package_node": package_id,
+                    "package": evidence.get("package") or evidence.get("package_name", ""),
+                    "version": evidence.get("version") or evidence.get("package_version", ""),
+                    "ecosystem": evidence.get("ecosystem", ""),
+                    "purl": evidence.get("purl", ""),
+                    "mapping_method": "server_scope_conservative",
+                    "confidence": "medium",
+                    "capabilities": capabilities,
+                    "capability_source": tool.attributes.get("capability_source", ""),
+                    "discovery_provenance": evidence.get("discovery_provenance", {}),
+                },
+            )
+        )
+
+
+def _has_mappable_package_version(evidence: dict[str, Any]) -> bool:
+    version = str(evidence.get("version") or evidence.get("package_version") or "").strip().lower()
+    return bool(version and version not in {"unknown", "latest", "*", "main", "master"})
+
+
 def _add_vuln_node(
     graph: UnifiedGraph,
     vuln_dict: dict[str, Any],
     pkg_id: str,
     data_source: str,
     package_evidence: dict[str, Any] | None = None,
-) -> None:
+) -> str | None:
     """Add a vulnerability node and link it to its package."""
     vuln_id_str = vuln_dict.get("id", "")
     if not vuln_id_str:
-        return
+        return None
     severity = vuln_dict.get("severity", "").lower()
     vuln_node_id = f"vuln:{vuln_id_str}"
 
@@ -810,6 +991,7 @@ def _add_vuln_node(
             evidence=package_evidence or {"source": data_source},
         )
     )
+    return vuln_node_id
 
 
 def _normalize_server_name(raw: Any) -> str:

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -367,6 +367,15 @@ class TestBuildUnifiedGraphFromReport:
         assert "read_file" in names
         assert "write_file" in names
 
+    def test_tool_nodes_include_capability_facets(self):
+        g = build_unified_graph_from_report(_minimal_report())
+        read_tool = g.nodes["tool:server:claude-desktop:mcp-fs:read_file"]
+        write_tool = g.nodes["tool:server:claude-desktop:mcp-fs:write_file"]
+
+        assert "read" in read_tool.attributes["capabilities"]
+        assert "write" in write_tool.attributes["capabilities"]
+        assert read_tool.attributes["capability_source"] == "classified"
+
     def test_credential_nodes(self):
         g = build_unified_graph_from_report(_minimal_report())
         creds = g.nodes_by_type(EntityType.CREDENTIAL)
@@ -388,6 +397,45 @@ class TestBuildUnifiedGraphFromReport:
         pkg_id = "pkg:npm:express@4.18.0"
         vuln_id = "vuln:CVE-2024-1234"
         assert g.has_edge(pkg_id, vuln_id)
+
+    def test_vulnerability_to_tool_exploitable_via_edges(self):
+        g = build_unified_graph_from_report(_minimal_report())
+        vuln_id = "vuln:CVE-2024-1234"
+        read_tool_id = "tool:server:claude-desktop:mcp-fs:read_file"
+        write_tool_id = "tool:server:claude-desktop:mcp-fs:write_file"
+
+        assert g.has_edge(vuln_id, read_tool_id)
+        assert g.has_edge(vuln_id, write_tool_id)
+        edge = next(
+            edge
+            for edge in g.edges
+            if edge.source == vuln_id and edge.target == write_tool_id and edge.relationship == RelationshipType.EXPLOITABLE_VIA
+        )
+        assert edge.evidence["mapping_method"] == "server_scope_conservative"
+        assert edge.evidence["confidence"] == "medium"
+        assert edge.evidence["package_node"] == "pkg:npm:express@4.18.0"
+        assert "write" in edge.evidence["capabilities"]
+
+    def test_exploitable_via_does_not_cross_same_named_servers(self):
+        report = _minimal_report()
+        report["agents"][1]["mcp_servers"][0]["tools"] = [{"name": "delete_repo", "description": "Delete a repository"}]
+
+        g = build_unified_graph_from_report(report)
+
+        assert g.has_edge("vuln:CVE-2024-1234", "tool:server:claude-desktop:mcp-fs:read_file")
+        assert not g.has_edge("vuln:CVE-2024-1234", "tool:server:cursor:mcp-fs:delete_repo")
+
+    def test_unknown_package_version_does_not_emit_exploitable_via(self):
+        report = _minimal_report()
+        package = report["agents"][0]["mcp_servers"][0]["packages"][0]
+        package["version"] = "unknown"
+        report["blast_radius"][0]["package_version"] = "unknown"
+
+        g = build_unified_graph_from_report(report)
+
+        assert g.has_edge("pkg:npm:express@unknown", "vuln:CVE-2024-1234")
+        exploit_edges = [edge for edge in g.edges if edge.relationship == RelationshipType.EXPLOITABLE_VIA]
+        assert exploit_edges == []
 
     def test_server_to_package_edge(self):
         g = build_unified_graph_from_report(_minimal_report())


### PR DESCRIPTION
## Summary

- add capability facets to graph `TOOL` nodes using declared capabilities first, then existing tool classifier/schema findings
- emit conservative `EXPLOITABLE_VIA` edges from vulnerabilities to impacted MCP tools when the affected package is present on the same server
- include edge evidence for package, server, mapping method, confidence, capability source, and provenance
- update the data model docs so entity/relationship counts and `EXPLOITABLE_VIA` semantics match implementation

Closes #2144.

## Notes

This intentionally uses `mapping_method: server_scope_conservative` and `confidence: medium`. The graph proves the vulnerable package powers the MCP server that exposes the tool, but it does not overclaim exact function-level package-to-tool reachability.

## Validation

- `uv run pytest tests/test_graph_builder.py -q`
- `uv run pytest tests/test_graph_api.py tests/test_blast_reachability_surfacing.py -q`
- `uv run ruff check src/agent_bom/graph/builder.py tests/test_graph_builder.py`
- `uv run ruff format --check src/agent_bom/graph/builder.py tests/test_graph_builder.py`
- `python -m py_compile src/agent_bom/graph/builder.py`
