### PR TITLE
fix: align Snowflake EKS deployment profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add --no-cache build-base ca-certificates git linux-headers \
 COPY pyproject.toml README.md LICENSE ./
 COPY src/ ./src/
 
-RUN pip install --no-cache-dir --prefix=/install ".[api]"
+RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.3-alpine3.23@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510

--- a/deploy/helm/agent-bom/examples/eks-snowflake-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-snowflake-values.yaml
@@ -6,8 +6,8 @@
 # is explicit — see site-docs/deployment/backend-parity.md.
 #
 # Key-pair auth is required. Passwords are deprecated and emit a runtime
-# warning. Generate the private key once, store in AWS Secrets Manager (or
-# your equivalent), and mount via ExternalSecrets.
+# warning. Generate the private key once, store in Kubernetes Secrets, AWS
+# Secrets Manager + ExternalSecrets, or your equivalent.
 #
 #   openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt
 #   snowsql -a <account> -u <user> -q "ALTER USER <user> SET RSA_PUBLIC_KEY='...'"
@@ -108,12 +108,12 @@ controlPlane:
       - secretRef:
           name: agent-bom-control-plane-auth
 
-    volumeMounts:
+    extraVolumeMounts:
       - name: snowflake-key
         mountPath: /var/snowflake
         readOnly: true
 
-    volumes:
+    extraVolumes:
       - name: snowflake-key
         secret:
           secretName: agent-bom-snowflake
@@ -135,33 +135,46 @@ controlPlane:
   backup:
     enabled: false
 
+scanner:
   # Scanner CronJob still runs; pushes scan results via the API which writes to Snowflake.
-  scanCronJob:
-    enabled: true
-    schedule: "0 */6 * * *"
-    args:
-      - "agents"
-      - "--k8s-mcp"
-      - "--k8s-all-namespaces"
-      - "--introspect"
-      - "--push-url"
-      - "http://agent-bom-api.agent-bom.svc.cluster.local:8080/v1/fleet/sync"
+  enabled: true
+  schedule: "0 */6 * * *"
+  extraArgs:
+    - "--k8s-mcp"
+    - "--k8s-all-namespaces"
+    - "--introspect"
+    - "--push-url"
+    - "http://agent-bom-api.agent-bom.svc.cluster.local:8422/v1/fleet/sync"
 
-  networkPolicy:
-    enabled: true
-    restrictIngress: true
-    allowedNamespaces:
-      - agent-bom
-      - ingress-nginx
-    # Egress: the API needs to reach *.snowflakecomputing.com on 443
-    egress:
-      - to:
-          - ipBlock:
-              cidr: 0.0.0.0/0
-              except:
-                - 10.0.0.0/8
-                - 172.16.0.0/12
-                - 192.168.0.0/16
-        ports:
-          - protocol: TCP
-            port: 443
+networkPolicy:
+  enabled: true
+  restrictIngress: true
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: agent-bom
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: controller
+      ports:
+        - protocol: TCP
+          port: 8422
+        - protocol: TCP
+          port: 3000
+  # Egress: the API needs to reach *.snowflakecomputing.com on 443.
+  additionalEgress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443

--- a/site-docs/deployment/eks-mcp-pilot.md
+++ b/site-docs/deployment/eks-mcp-pilot.md
@@ -167,19 +167,26 @@ flowchart LR
   helm --> ns[(namespace: agent-bom)]
   ns --> api[API + UI + scanner CronJob]
   api --> pg[(Postgres<br/>RDS or in-cluster)]
-  api --> es[(External Secrets<br/>AWS Secrets Manager)]
+  api --> sec[(Kubernetes Secret<br/>or ExternalSecrets)]
 ```
 
 ```bash
-# 1. Create secrets in AWS Secrets Manager (names match ExternalSecrets in the chart)
-aws secretsmanager create-secret --name agent-bom/api-key --secret-string "$(openssl rand -hex 32)"
-aws secretsmanager create-secret --name agent-bom/audit-hmac --secret-string "$(openssl rand -hex 32)"
-aws secretsmanager create-secret --name agent-bom/postgres-url --secret-string "postgres://…"
+# 1. Create the namespace and chart-facing Kubernetes Secret.
+# eks-mcp-pilot-values.yaml references this secret through controlPlane.api.envFrom.
+kubectl create namespace agent-bom --dry-run=client -o yaml | kubectl apply -f -
+
+export API_KEY="$(openssl rand -hex 32)"
+export AUDIT_HMAC_KEY="$(openssl rand -hex 32)"
+export AGENT_BOM_POSTGRES_URL="postgresql://agent_bom:REPLACE_ME@postgres.example:5432/agent_bom?sslmode=require"
 
 # 2. Generate the Ed25519 key pair for compliance evidence signing
 openssl genpkey -algorithm ed25519 -out /tmp/evidence-priv.pem
-aws secretsmanager create-secret --name agent-bom/evidence-signing \
-  --secret-string "$(cat /tmp/evidence-priv.pem)"
+kubectl -n agent-bom create secret generic agent-bom-control-plane \
+  --from-literal=AGENT_BOM_POSTGRES_URL="$AGENT_BOM_POSTGRES_URL" \
+  --from-literal=AGENT_BOM_API_KEY="$API_KEY" \
+  --from-literal=AGENT_BOM_AUDIT_HMAC_KEY="$AUDIT_HMAC_KEY" \
+  --from-literal=AGENT_BOM_REQUIRE_AUDIT_HMAC="1" \
+  --from-file=AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM=/tmp/evidence-priv.pem
 rm /tmp/evidence-priv.pem
 
 # 3. Helm install with the focused pilot values
@@ -188,13 +195,18 @@ helm install agent-bom deploy/helm/agent-bom \
   -f deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml
 ```
 
+If your platform requires AWS Secrets Manager, enable
+`controlPlane.externalSecrets` and map those remote keys into the same
+`agent-bom-control-plane` Kubernetes Secret. The pilot values file does not
+enable ExternalSecrets by default.
+
 ### Stage 2 — Smoke test (2 min)
 
 Run the pilot verification script from any workstation with a
 `kubectl port-forward` open to the API service:
 
 ```bash
-kubectl -n agent-bom port-forward svc/agent-bom-api 8080:8080 &
+kubectl -n agent-bom port-forward svc/agent-bom-api 8080:8422 &
 ./scripts/pilot-verify.sh http://localhost:8080 "$API_KEY"
 ```
 
@@ -206,7 +218,7 @@ fails fast with a non-zero exit if any check breaks:
 3. `POST /v1/fleet/sync` — endpoint fleet ingest works
 4. `POST /v1/scan` — a small demo scan runs end-to-end
 5. `GET /v1/compliance/verification-key` — Ed25519 key is exposed
-6. `GET /v1/compliance/soc2/report` — bundle comes back signed + evidence non-empty
+6. `GET /v1/compliance/owasp-llm/report` — bundle comes back signed + evidence non-empty
 7. Re-verifies the bundle signature with the public key from step 5
 
 ### Stage 3a — Multi-MCP gateway (new, HTTP/SSE upstreams — 10 min)
@@ -298,14 +310,14 @@ curl -s http://localhost:8080/v1/compliance/verification-key \
   -H "X-Agent-Bom-Role: admin" -H "X-Agent-Bom-Tenant-ID: pilot-acme" \
   | jq -r .public_key_pem > pinned-pub.pem
 
-curl -sD headers.txt -o soc2.json \
-  "http://localhost:8080/v1/compliance/soc2/report" \
+curl -sD headers.txt -o owasp-llm.json \
+  "http://localhost:8080/v1/compliance/owasp-llm/report" \
   -H "X-Agent-Bom-Role: admin" -H "X-Agent-Bom-Tenant-ID: pilot-acme"
 
 python - <<'PY'
 import json
 from cryptography.hazmat.primitives import serialization
-body = json.load(open("soc2.json"))
+body = json.load(open("owasp-llm.json"))
 pub = serialization.load_pem_public_key(open("pinned-pub.pem").read().encode())
 sig = [l.split(": ",1)[1].strip() for l in open("headers.txt") if l.lower().startswith("x-agent-bom-compliance-report-signature")][0]
 pub.verify(bytes.fromhex(sig), json.dumps(body, sort_keys=True).encode())

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -282,6 +282,12 @@ def test_dockerfiles_support_proxy_and_ca_contract():
             assert token in content, f"{dockerfile.name} missing {token}"
 
 
+def test_primary_api_image_includes_snowflake_extra_for_snowflake_backend():
+    """The default API image must contain the Snowflake connector for the Snowflake Helm profile."""
+    content = (ROOT / "Dockerfile").read_text()
+    assert 'pip install --no-cache-dir --prefix=/install ".[api,snowflake]"' in content
+
+
 def test_runtime_dockerfile_builds_from_repo_source():
     """Runtime image should install agent-bom from the checked-out source tree, not PyPI."""
     content = (ROOT / "deploy" / "docker" / "Dockerfile.runtime").read_text()
@@ -310,6 +316,40 @@ def test_compose_examples_pass_through_proxy_and_ca_env():
         content = compose_file.read_text()
         for token in required_tokens:
             assert token in content, f"{compose_file.name} missing {token}"
+
+
+def test_eks_snowflake_values_use_supported_chart_keys():
+    """Snowflake EKS profile should render with keys the Helm chart actually consumes."""
+    import yaml
+
+    values = yaml.safe_load((ROOT / "deploy" / "helm" / "agent-bom" / "examples" / "eks-snowflake-values.yaml").read_text())
+    api = values["controlPlane"]["api"]
+    assert "extraVolumeMounts" in api
+    assert "extraVolumes" in api
+    assert "volumeMounts" not in api
+    assert "volumes" not in api
+    assert api["extraVolumeMounts"][0]["mountPath"] == "/var/snowflake"
+    assert api["extraVolumes"][0]["secret"]["secretName"] == "agent-bom-snowflake"
+
+    assert "scanCronJob" not in values["controlPlane"]
+    assert values["scanner"]["enabled"] is True
+    assert "--push-url" in values["scanner"]["extraArgs"]
+    assert "http://agent-bom-api.agent-bom.svc.cluster.local:8422/v1/fleet/sync" in values["scanner"]["extraArgs"]
+
+    assert "networkPolicy" not in values["controlPlane"]
+    assert values["networkPolicy"]["enabled"] is True
+    assert values["networkPolicy"]["restrictIngress"] is True
+    assert values["networkPolicy"]["additionalEgress"][0]["ports"][0]["port"] == 443
+
+
+def test_eks_pilot_doc_matches_chart_secret_and_service_port():
+    """The pilot runbook should match the values file and the actual API service port."""
+    doc = (ROOT / "site-docs" / "deployment" / "eks-mcp-pilot.md").read_text()
+    assert "kubectl -n agent-bom create secret generic agent-bom-control-plane" in doc
+    assert "controlPlane.externalSecrets" in doc
+    assert "8080:8422" in doc
+    assert "/v1/compliance/owasp-llm/report" in doc
+    assert "/v1/compliance/soc2/report" not in doc
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- install the Snowflake extra in the default API Docker image used by the Helm chart
- align the Snowflake EKS values file with supported chart keys: extraVolumes/extraVolumeMounts, top-level scanner, top-level networkPolicy
- fix the focused EKS pilot runbook so secrets, port-forwarding, and compliance evidence endpoints match the chart and smoke script

## Validation
- uv run pytest tests/test_deployment.py -q
- uv run pytest tests/test_deploy_profiles.py tests/test_deployment.py -q
- uv run pytest tests/test_deploy_manifests.py tests/test_snowflake_backend_contract.py tests/test_snowflake_pov_docs.py -q
- uv run ruff check tests/test_deployment.py
- git diff --check

Note: helm is not installed in this local environment, so Helm rendering was validated through YAML/manifest contract tests rather than a local `helm template` run.