### PR TITLE
feat: add cloud discovery and ingest skills

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -297,4 +297,8 @@ jobs:
           _publish_skill "integrations/openclaw/registry"   "agent-bom-registry"   false "agent-bom registry"
           _publish_skill "integrations/openclaw/runtime"    "agent-bom-runtime"    false "agent-bom runtime"
           _publish_skill "integrations/openclaw/discover-aws" "agent-bom-discover-aws" false "agent-bom discover aws"
+          _publish_skill "integrations/openclaw/discover-azure" "agent-bom-discover-azure" false "agent-bom discover azure"
+          _publish_skill "integrations/openclaw/discover-gcp" "agent-bom-discover-gcp" false "agent-bom discover gcp"
+          _publish_skill "integrations/openclaw/discover-snowflake" "agent-bom-discover-snowflake" false "agent-bom discover snowflake"
+          _publish_skill "integrations/openclaw/ingest" "agent-bom-ingest" false "agent-bom ingest"
           _publish_skill "integrations/openclaw/vulnerability-intel" "agent-bom-vulnerability-intel" false "agent-bom vulnerability intel"

--- a/docs/CONTRIBUTING_SKILLS.md
+++ b/docs/CONTRIBUTING_SKILLS.md
@@ -60,6 +60,26 @@ Reviewers should reject bundled skills that:
 - emit inventory, SBOM, SARIF, or policy artifacts without schema validation
 - drop `discovery_provenance`, `permissions_used`, or redaction state
 
+## Framework dogfooding
+
+Bundled skills that cite OWASP Agentic Top 10, OWASP MCP Top 10, AISVS, or
+MAESTRO must include concrete behavior that satisfies the cited framework. Do
+not cite a framework as decoration.
+
+- A1 Tool Poisoning: validate schemas before trusting inventory or tool claims.
+- A2 Rug Pulls: pin the skill version to the package release and verify
+  package provenance before execution.
+- A3 Credential Theft: route all credential-bearing fields through the
+  redaction contract and never print raw values.
+- A4 Excessive Permissions: enumerate minimum read-only permissions and stop
+  when the operator cannot provide them.
+- A7 Identity Spoofing: preserve `discovery_provenance` and `permissions_used`
+  on pushed inventory.
+- A9 Misaligned Behaviors: write-capable skills must use
+  `autonomous_invocation: never`.
+- A10 Lifecycle Risks: update skill versions with the release and keep
+  verification commands current.
+
 ## Remediation skills
 
 Write-capable remediation skills have a higher bar than read-only discovery or

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -8,6 +8,10 @@ Published skills:
 - `agent-bom-compliance`
 - `agent-bom-runtime`
 - `agent-bom-discover-aws`
+- `agent-bom-discover-azure`
+- `agent-bom-discover-gcp`
+- `agent-bom-discover-snowflake`
+- `agent-bom-ingest`
 - `agent-bom-vulnerability-intel`
 
 These are the only skills pushed by release automation. They are:
@@ -29,4 +33,8 @@ When updating versions for release, update only the published skill frontmatter 
 - [`compliance/SKILL.md`](compliance/SKILL.md)
 - [`runtime/SKILL.md`](runtime/SKILL.md)
 - [`discover-aws/SKILL.md`](discover-aws/SKILL.md)
+- [`discover-azure/SKILL.md`](discover-azure/SKILL.md)
+- [`discover-gcp/SKILL.md`](discover-gcp/SKILL.md)
+- [`discover-snowflake/SKILL.md`](discover-snowflake/SKILL.md)
+- [`ingest/SKILL.md`](ingest/SKILL.md)
 - [`vulnerability-intel/SKILL.md`](vulnerability-intel/SKILL.md)

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -232,11 +232,16 @@ agent-bom where             # show all discovery paths
 }
 ```
 
-## Sub-Skills (10)
+## Sub-Skills (15)
 
 | Sub-Skill | Purpose | Triggers |
 |-----------|---------|---------|
 | [discover](discover/SKILL.md) | Find agents, MCP servers, configurations | "find agents", "what's configured", "mcp inventory" |
+| [discover-aws](discover-aws/SKILL.md) | Scope-zero AWS operator-pull inventory | "discover AWS agents", "Bedrock inventory", "AWS MCP inventory" |
+| [discover-azure](discover-azure/SKILL.md) | Scope-zero Azure operator-pull inventory | "discover Azure AI", "Azure MCP inventory" |
+| [discover-gcp](discover-gcp/SKILL.md) | Scope-zero GCP operator-pull inventory | "discover Vertex AI", "GCP MCP inventory" |
+| [discover-snowflake](discover-snowflake/SKILL.md) | Scope-zero Snowflake/Cortex operator-pull inventory | "discover Snowflake AI", "Cortex inventory" |
+| [ingest](ingest/SKILL.md) | Validate and scan operator-pushed inventory | "ingest inventory", "scan pushed inventory" |
 | [scan](scan/SKILL.md) | CVE scanning, image scanning, SBOM, provenance | "check package", "scan image", "verify", "blast radius" |
 | [scan-infra](scan-infra/SKILL.md) | IaC, cloud config, secrets scanning | "check terraform", "scan kubernetes", "find secrets" |
 | [enforce](enforce/SKILL.md) | Runtime policy enforcement, MCP proxy | "block risky calls", "apply policy", "proxy" |

--- a/integrations/openclaw/discover-azure/SKILL.md
+++ b/integrations/openclaw/discover-azure/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: agent-bom-discover-azure
+description: >-
+  Discover Azure-hosted AI agent and MCP-relevant assets from the operator's
+  environment, emit canonical agent-bom inventory JSON, and scan it without
+  giving agent-bom long-lived Azure credentials. Use when a user asks to
+  inventory Azure OpenAI, Container Apps, AKS, Functions, ML, or agentic Azure
+  infrastructure as canonical inventory.
+version: 0.83.4
+license: Apache-2.0
+compatibility: >-
+  Requires Python 3.11+, agent-bom installed from this repository or PyPI, and
+  operator-controlled Azure read-only credentials from Azure CLI, workload
+  identity, managed identity, or service principal.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/agent-bom
+  source: https://github.com/msaad00/agent-bom
+  pypi: https://pypi.org/project/agent-bom/
+  openclaw:
+    requires:
+      bins:
+        - python
+      env: []
+      credentials: azure-read-only
+    credential_policy: "Use the operator's existing Azure identity chain. Prefer Azure CLI, workload identity, managed identity, or short-lived service principal credentials. Do not ask users to paste client secrets. Do not print credential values."
+    optional_env:
+      - AZURE_SUBSCRIPTION_ID
+      - AZURE_TENANT_ID
+      - AZURE_CLIENT_ID
+      - AZURE_CLIENT_SECRET
+      - AZURE_AUTHORITY_HOST
+    optional_bins:
+      - az
+    emoji: "search"
+    homepage: https://github.com/msaad00/agent-bom
+    source: https://github.com/msaad00/agent-bom
+    license: Apache-2.0
+    os:
+      - darwin
+      - linux
+      - windows
+    credential_handling: "Credentials stay in the operator environment. The skill invokes Azure SDK discovery locally and writes canonical inventory JSON with source_type=skill_invoked_pull. agent-bom receives sanitized inventory only when the operator explicitly scans or pushes that inventory."
+    data_flow: "Operator Azure subscription -> read-only Azure SDK calls -> canonical inventory JSON -> optional local agent-bom inventory scan. No agent-bom-hosted service is required. Credential-like values are redacted before persistence/export."
+    file_reads:
+      - "~/.azure/azureProfile.json"
+      - "~/.azure/config"
+      - "~/.azure/msal_token_cache.json"
+    file_writes:
+      - "operator-selected inventory JSON output path"
+    network_endpoints:
+      - url: "https://login.microsoftonline.com"
+        purpose: "Azure identity token exchange when the selected credential flow needs it"
+        auth: true
+      - url: "https://management.azure.com"
+        purpose: "Azure Resource Manager and service inventory"
+        auth: true
+      - url: "https://*.cognitiveservices.azure.com"
+        purpose: "Azure AI and OpenAI service metadata where available"
+        auth: true
+    telemetry: false
+    persistence: false
+    privilege_escalation: false
+    always: false
+    autonomous_invocation: restricted
+---
+
+# agent-bom-discover-azure
+
+Use this skill to collect Azure AI and workload inventory as schema-valid
+agent-bom inventory. Default to discover-only: write JSON to an
+operator-selected path and stop.
+
+## Guardrails
+
+- Use only operator-approved Azure subscriptions and read-only identities.
+- Do not request or display raw `AZURE_CLIENT_SECRET`, access tokens, or
+  connection strings.
+- Do not modify Azure resources. This workflow is discovery-only.
+- Write inventory only to a path the operator chose.
+- Treat AI-generated prose as non-authoritative; schema-validated inventory JSON
+  is the evidence.
+
+## Workflow
+
+```bash
+python examples/operator_pull/azure_inventory_adapter.py \
+  --subscription-id "$AZURE_SUBSCRIPTION_ID" \
+  --source azure-skill-invoked \
+  --discovery-method skill_invoked_pull \
+  --output azure-inventory.json
+```
+
+Scan only when the operator asks for findings:
+
+```bash
+agent-bom agents --inventory azure-inventory.json --format json --output agent-bom-azure-findings.json
+```
+
+## Evidence Contract
+
+The emitted inventory carries `discovery_provenance.source_type:
+skill_invoked_pull`, `observed_via: skill_invoked_pull, azure_sdk`, sanitized
+`metadata.permissions_used`, and redacted credential material. If schema
+validation fails, stop and fix the inventory instead of scanning a best-effort
+summary.

--- a/integrations/openclaw/discover-gcp/SKILL.md
+++ b/integrations/openclaw/discover-gcp/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: agent-bom-discover-gcp
+description: >-
+  Discover GCP-hosted AI agent and MCP-relevant assets from the operator's
+  environment, emit canonical agent-bom inventory JSON, and scan it without
+  giving agent-bom long-lived GCP credentials. Use when a user asks to
+  inventory Vertex AI, Cloud Run, Cloud Functions, GKE, or agentic GCP
+  infrastructure as canonical inventory.
+version: 0.83.4
+license: Apache-2.0
+compatibility: >-
+  Requires Python 3.11+, agent-bom installed from this repository or PyPI, and
+  operator-controlled GCP read-only credentials from ADC, workload identity, or
+  a scoped service account.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/agent-bom
+  source: https://github.com/msaad00/agent-bom
+  pypi: https://pypi.org/project/agent-bom/
+  openclaw:
+    requires:
+      bins:
+        - python
+      env: []
+      credentials: gcp-read-only
+    credential_policy: "Use the operator's existing Application Default Credentials, workload identity, or short-lived service account credentials. Do not ask users to paste service account JSON into chat. Do not print credential values."
+    optional_env:
+      - GOOGLE_APPLICATION_CREDENTIALS
+      - GOOGLE_CLOUD_PROJECT
+      - CLOUDSDK_CONFIG
+    optional_bins:
+      - gcloud
+    emoji: "search"
+    homepage: https://github.com/msaad00/agent-bom
+    source: https://github.com/msaad00/agent-bom
+    license: Apache-2.0
+    os:
+      - darwin
+      - linux
+      - windows
+    credential_handling: "Credentials stay in the operator environment. The skill invokes GCP SDK discovery locally and writes canonical inventory JSON with source_type=skill_invoked_pull. agent-bom receives sanitized inventory only when the operator explicitly scans or pushes that inventory."
+    data_flow: "Operator GCP project -> read-only Google API calls -> canonical inventory JSON -> optional local agent-bom inventory scan. No agent-bom-hosted service is required. Credential-like values are redacted before persistence/export."
+    file_reads:
+      - "~/.config/gcloud/configurations/config_default"
+      - "~/.config/gcloud/application_default_credentials.json"
+      - "~/.config/gcloud/credentials.db"
+      - "operator-selected service account JSON when GOOGLE_APPLICATION_CREDENTIALS is set"
+    file_writes:
+      - "operator-selected inventory JSON output path"
+    network_endpoints:
+      - url: "https://cloudresourcemanager.googleapis.com"
+        purpose: "Project and resource inventory"
+        auth: true
+      - url: "https://aiplatform.googleapis.com"
+        purpose: "Vertex AI inventory"
+        auth: true
+      - url: "https://run.googleapis.com"
+        purpose: "Cloud Run inventory"
+        auth: true
+      - url: "https://cloudfunctions.googleapis.com"
+        purpose: "Cloud Functions inventory"
+        auth: true
+      - url: "https://container.googleapis.com"
+        purpose: "GKE inventory"
+        auth: true
+    telemetry: false
+    persistence: false
+    privilege_escalation: false
+    always: false
+    autonomous_invocation: restricted
+---
+
+# agent-bom-discover-gcp
+
+Use this skill to collect GCP AI and workload inventory as schema-valid
+agent-bom inventory. Default to discover-only: write JSON to an
+operator-selected path and stop.
+
+## Guardrails
+
+- Use only operator-approved projects and read-only credentials.
+- Do not request or display service account private keys, OAuth refresh tokens,
+  or bearer tokens.
+- Do not modify GCP resources. This workflow is discovery-only.
+- Write inventory only to a path the operator chose.
+- Treat AI-generated prose as non-authoritative; schema-validated inventory JSON
+  is the evidence.
+
+## Workflow
+
+```bash
+python examples/operator_pull/gcp_inventory_adapter.py \
+  --project "$GOOGLE_CLOUD_PROJECT" \
+  --region us-central1 \
+  --source gcp-skill-invoked \
+  --discovery-method skill_invoked_pull \
+  --output gcp-inventory.json
+```
+
+Scan only when the operator asks for findings:
+
+```bash
+agent-bom agents --inventory gcp-inventory.json --format json --output agent-bom-gcp-findings.json
+```
+
+## Evidence Contract
+
+The emitted inventory carries `discovery_provenance.source_type:
+skill_invoked_pull`, `observed_via: skill_invoked_pull, gcp_sdk`, sanitized
+`metadata.permissions_used`, and redacted credential material. If schema
+validation fails, stop and fix the inventory instead of scanning a best-effort
+summary.

--- a/integrations/openclaw/discover-snowflake/SKILL.md
+++ b/integrations/openclaw/discover-snowflake/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: agent-bom-discover-snowflake
+description: >-
+  Discover Snowflake Cortex, Snowpark, notebook, Streamlit, MCP, and
+  AI-observability assets from the operator's environment, emit canonical
+  agent-bom inventory JSON, and scan it without giving agent-bom long-lived
+  Snowflake credentials. Use when a user asks to inventory Snowflake AI or
+  Cortex infrastructure as canonical inventory.
+version: 0.83.4
+license: Apache-2.0
+compatibility: >-
+  Requires Python 3.11+, agent-bom installed with the snowflake extra, and
+  operator-controlled Snowflake read-only credentials. Prefer SSO, OAuth, or
+  key-pair auth over passwords.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/agent-bom
+  source: https://github.com/msaad00/agent-bom
+  pypi: https://pypi.org/project/agent-bom/
+  openclaw:
+    requires:
+      bins:
+        - python
+      env: []
+      credentials: snowflake-read-only
+    credential_policy: "Use the operator's existing Snowflake SSO, OAuth, or key-pair auth context. Prefer SNOWFLAKE_PRIVATE_KEY_PATH or SNOWFLAKE_AUTHENTICATOR over SNOWFLAKE_PASSWORD. Do not ask users to paste passwords, private keys, or OAuth tokens into chat."
+    optional_env:
+      - SNOWFLAKE_ACCOUNT
+      - SNOWFLAKE_USER
+      - SNOWFLAKE_AUTHENTICATOR
+      - SNOWFLAKE_PRIVATE_KEY_PATH
+      - SNOWFLAKE_PRIVATE_KEY_PASSPHRASE
+      - SNOWFLAKE_TOKEN
+      - SNOWFLAKE_WAREHOUSE
+      - SNOWFLAKE_DATABASE
+      - SNOWFLAKE_SCHEMA
+      - SNOWFLAKE_ROLE
+    optional_bins:
+      - snow
+      - snowsql
+    emoji: "search"
+    homepage: https://github.com/msaad00/agent-bom
+    source: https://github.com/msaad00/agent-bom
+    license: Apache-2.0
+    os:
+      - darwin
+      - linux
+      - windows
+    credential_handling: "Credentials stay in the operator environment. The skill invokes Snowflake discovery locally and writes canonical inventory JSON with source_type=skill_invoked_pull. agent-bom receives sanitized inventory only when the operator explicitly scans or pushes that inventory."
+    data_flow: "Operator Snowflake account -> read-only Snowflake queries/API calls -> canonical inventory JSON -> optional local agent-bom inventory scan. No agent-bom-hosted service is required. Credential-like values are redacted before persistence/export."
+    file_reads:
+      - "~/.snowflake/connections.toml"
+      - "~/.snowflake/config.toml"
+      - "operator-selected private key path when SNOWFLAKE_PRIVATE_KEY_PATH is set"
+    file_writes:
+      - "operator-selected inventory JSON output path"
+    network_endpoints:
+      - url: "https://{account}.snowflakecomputing.com"
+        purpose: "Snowflake inventory, Cortex, query history, and AI observability discovery"
+        auth: true
+      - url: "https://*.snowflakecomputing.com"
+        purpose: "Snowflake regional and organization account endpoints selected by the operator"
+        auth: true
+    telemetry: false
+    persistence: false
+    privilege_escalation: false
+    always: false
+    autonomous_invocation: restricted
+---
+
+# agent-bom-discover-snowflake
+
+Use this skill to collect Snowflake AI and workload inventory as schema-valid
+agent-bom inventory. Default to discover-only: write JSON to an
+operator-selected path and stop.
+
+## Guardrails
+
+- Use only operator-approved Snowflake accounts, warehouses, databases, and
+  read-only roles.
+- Prefer SSO, OAuth, or key-pair auth. Do not request or display
+  `SNOWFLAKE_PASSWORD`, private key contents, passphrases, or OAuth tokens.
+- Do not modify Snowflake resources. This workflow is discovery-only.
+- Write inventory only to a path the operator chose.
+- Treat AI-generated prose as non-authoritative; schema-validated inventory JSON
+  is the evidence.
+
+## Workflow
+
+```bash
+python examples/operator_pull/snowflake_inventory_adapter.py \
+  --account "$SNOWFLAKE_ACCOUNT" \
+  --user "$SNOWFLAKE_USER" \
+  --authenticator snowflake_jwt \
+  --source snowflake-skill-invoked \
+  --discovery-method skill_invoked_pull \
+  --output snowflake-inventory.json
+```
+
+Scan only when the operator asks for findings:
+
+```bash
+agent-bom agents --inventory snowflake-inventory.json --format json --output agent-bom-snowflake-findings.json
+```
+
+## Evidence Contract
+
+The emitted inventory carries `discovery_provenance.source_type:
+skill_invoked_pull`, `observed_via: skill_invoked_pull, snowflake_sdk`,
+sanitized `metadata.permissions_used`, and redacted credential material. If
+schema validation fails, stop and fix the inventory instead of scanning a
+best-effort summary.

--- a/integrations/openclaw/ingest/SKILL.md
+++ b/integrations/openclaw/ingest/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: agent-bom-ingest
+description: >-
+  Validate and ingest operator-pushed agent-bom inventory JSON from AWS, Azure,
+  GCP, Snowflake, CMDB, or endpoint collectors. Use when a user has canonical
+  inventory JSON and wants local findings, graph, policy, provenance, or
+  auditor-ready exports without giving agent-bom direct cloud credentials.
+version: 0.83.4
+license: Apache-2.0
+compatibility: >-
+  Requires Python 3.11+ and agent-bom 0.83.4+. Inventory must conform to the
+  packaged inventory.schema.json contract.
+metadata:
+  author: msaad00
+  homepage: https://github.com/msaad00/agent-bom
+  source: https://github.com/msaad00/agent-bom
+  pypi: https://pypi.org/project/agent-bom/
+  openclaw:
+    requires:
+      bins:
+        - agent-bom
+      env: []
+      credentials: none
+    credential_policy: "No cloud credentials are required. Optional control-plane push uses an operator-provided agent-bom API token; never ask users to paste that token into chat and never print it."
+    optional_env:
+      - AGENT_BOM_API_KEY
+      - AGENT_BOM_PUSH_URL
+    optional_bins: []
+    emoji: "inbox"
+    homepage: https://github.com/msaad00/agent-bom
+    source: https://github.com/msaad00/agent-bom
+    license: Apache-2.0
+    os:
+      - darwin
+      - linux
+      - windows
+    credential_handling: "Inventory is schema-validated before it is trusted. Env var values, URL credentials, launch arguments, discovery_provenance, permissions_used, and security intelligence pass through the sanitizer/redaction contract before display/export."
+    data_flow: "Operator-generated inventory JSON -> packaged inventory.schema.json validation -> local agent-bom scan/graph/export. Optional push to an operator-owned control plane goes only to the URL the operator provided."
+    file_reads:
+      - "operator-selected inventory JSON file"
+      - "packaged agent_bom/data/inventory.schema.json"
+    file_writes:
+      - "operator-selected JSON/SARIF/HTML/Markdown export path"
+    network_endpoints:
+      - url: "operator-provided AGENT_BOM_PUSH_URL"
+        purpose: "Optional push into the operator-owned agent-bom control plane"
+        auth: true
+        optional: true
+      - url: "https://api.osv.dev/v1"
+        purpose: "Optional package vulnerability lookup during local scan"
+        auth: false
+        optional: true
+      - url: "https://api.github.com/advisories"
+        purpose: "Optional GitHub Advisory enrichment during local scan"
+        auth: false
+        optional: true
+    telemetry: false
+    persistence: false
+    privilege_escalation: false
+    always: false
+    autonomous_invocation: restricted
+---
+
+# agent-bom-ingest
+
+Use this skill when the operator already produced canonical inventory JSON with
+an operator-pull adapter, endpoint collector, CMDB export, or AI-agent workflow.
+The default path is local validation plus local scan/export.
+
+## Guardrails
+
+- Validate inventory with the packaged schema before treating it as evidence.
+- Require `discovery_provenance` and `permissions_used` where the source claims
+  cloud/operator-pushed discovery.
+- Require a trustworthy `discovery_provenance.source_type` such as
+  `operator_pushed_inventory` or `skill_invoked_pull`; do not infer it from
+  prose.
+- Do not invent provenance, permissions, cloud scopes, or credential posture.
+- Do not push to a control plane unless the operator provides the destination
+  URL and auth method explicitly.
+- Do not print raw tokens, URL credentials, private keys, or env var values.
+
+## Workflow
+
+Validate first:
+
+```bash
+agent-bom inventory validate inventory.json
+```
+
+Scan locally:
+
+```bash
+agent-bom agents --inventory inventory.json --format json --output agent-bom-findings.json
+```
+
+Choose output by consumer:
+
+- SARIF for CI/code-scanning gates
+- JSON for graph, API, and automation
+- HTML or Markdown for human review
+- CycloneDX/SPDX for SBOM consumers
+
+## Evidence Contract
+
+Valid inventory preserves `discovery_provenance`, `permissions_used`,
+`cloud_origin`, redaction state, package identity, server identity, tools, and
+security intelligence. If the inventory is malformed or missing required trust
+fields, stop and ask the operator to regenerate it rather than scanning a
+best-effort summary.

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -187,6 +187,27 @@ scan()
 verify(package="agent-bom")
 ```
 
+## Agentic Workflows
+
+Use tool chains, not isolated calls, when the user asks for a decision:
+
+| User intent | Recommended sequence | Output |
+|-------------|----------------------|--------|
+| "Is this MCP safe to install?" | `registry_lookup` -> `check` -> `blast_radius` when a package/version is known | concise allow/warn/block recommendation with evidence |
+| "Gate this PR" | `scan` with SARIF output and fail on high/critical findings | SARIF for code scanning plus non-zero gate result |
+| "Audit my fleet inventory" | validate inventory -> `scan`/`agents` with JSON output -> `context_graph` | findings plus graph-ready JSON |
+| "What changed since last run?" | current scan -> `diff` against prior JSON | new/resolved/persistent findings |
+| "What should I fix first?" | `scan` -> `blast_radius` -> `remediate` plan | prioritized plan only; no file writes |
+
+Pick output by consumer: SARIF for CI, JSON for automation/graph, HTML or
+Markdown for human review, CycloneDX/SPDX for SBOM consumers.
+
+For CLI gates, prefer:
+
+```bash
+agent-bom agents --format sarif --output agent-bom.sarif --fail-on-severity high
+```
+
 ## Guardrails
 
 - Show CVEs even when NVD analysis is pending or severity is `unknown` — a CVE ID is still a real finding.

--- a/tests/test_bundled_skill_contract.py
+++ b/tests/test_bundled_skill_contract.py
@@ -52,5 +52,39 @@ def test_skill_contribution_contract_documents_guardrails() -> None:
         "Never print raw credential values",
         "Do not ship a remediation skill",
         "corresponding CLI/API behavior exists and is tested",
+        "A1 Tool Poisoning",
+        "A7 Identity Spoofing",
+    ):
+        assert phrase in content
+
+
+def test_cloud_discovery_and_inventory_ingest_skills_are_bundled() -> None:
+    """Cloud skill coverage should match the shipped operator-pull adapters."""
+    expected = {
+        "discover-aws": "aws_inventory_adapter.py",
+        "discover-azure": "azure_inventory_adapter.py",
+        "discover-gcp": "gcp_inventory_adapter.py",
+        "discover-snowflake": "snowflake_inventory_adapter.py",
+        "ingest": "inventory.schema.json",
+    }
+    for skill_name, expected_receipt in expected.items():
+        skill_path = SKILL_ROOT / skill_name / "SKILL.md"
+        assert skill_path.exists(), f"missing bundled skill: {skill_name}"
+        content = skill_path.read_text()
+        assert "source_type" in content
+        assert "discovery_provenance" in content
+        assert "permissions_used" in content
+        assert expected_receipt in content
+
+
+def test_scan_skill_documents_agentic_workflow_sequences() -> None:
+    """The scan skill should tell agents how to chain tools for CI and install-time review."""
+    content = (SKILL_ROOT / "scan" / "SKILL.md").read_text()
+    for phrase in (
+        "Agentic Workflows",
+        "registry_lookup",
+        "fail on high/critical",
+        "SARIF for CI",
+        "JSON for automation/graph",
     ):
         assert phrase in content

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -245,6 +245,10 @@ def test_publish_registries_workflow_requires_public_smithery_surface_and_curate
     assert "integrations/openclaw/registry" in workflow
     assert "integrations/openclaw/runtime" in workflow
     assert "integrations/openclaw/discover-aws" in workflow
+    assert "integrations/openclaw/discover-azure" in workflow
+    assert "integrations/openclaw/discover-gcp" in workflow
+    assert "integrations/openclaw/discover-snowflake" in workflow
+    assert "integrations/openclaw/ingest" in workflow
     assert "integrations/openclaw/vulnerability-intel" in workflow
     assert '_publish_skill "integrations/openclaw" "agent-bom"' not in workflow
 


### PR DESCRIPTION
## Summary
- add agent-bom-owned discover skills for Azure, GCP, and Snowflake operator-pull inventory
- add an agent-bom ingest skill for schema-validated operator-pushed inventory
- document skill guardrail dogfooding and add scan workflow recipes for CI gates, install checks, fleet inventory, diffing, and remediation planning
- publish the new curated skills through the registry workflow and guard them with skill contract tests

## Validation
- uv run pytest tests/test_bundled_skill_contract.py tests/test_deployment.py tests/test_aws_discovery_skill.py tests/test_vulnerability_intel_skill.py -q
- uv run pytest tests/test_skills_cli.py tests/test_trust_assessment.py::test_assess_trust_agent_bom_skill -q
- uv run ruff check tests/test_bundled_skill_contract.py tests/test_deployment.py
- YAML parse check for all bundled SKILL.md files
- git diff --check

Closes #2134.
Closes #2135.
Closes #2137.