### PR TITLE
chore: prepare v0.84.0 release

### DIFF
--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom
-        run: uv tool install agent-bom==0.83.4  # pinned — bump on each release
+        run: uv tool install agent-bom==0.84.0  # pinned — bump on each release
 
       - name: Scan changed MCP configs
         id: scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.84.0] – 2026-04-30
+
+### Added
+- **Graph capability reachability** — graph construction now emits `EXPLOITABLE_VIA` edges from affected packages/vulnerabilities to reachable MCP tool capability nodes, closing the package → MCP server → tool → agent attack-path chain for graph consumers.
+- **Cloud discovery and ingest skills** — bundled skills now cover Azure, GCP, Snowflake, and pushed-inventory ingest workflows alongside the existing AWS discovery path, with the same guardrail contract, provenance requirements, and read-only defaults.
+- **MCP server resources, prompts, and capability metadata** — the server card now advertises 36 read-only tools, 6 resources, 6 workflow prompts, and machine-readable capability classes so agents can choose the right workflow without guessing.
+
+### Changed
+- **Human reports and graph risk state** — Markdown, HTML, compact console output, and graph nodes now render unified non-CVE findings such as MCP blocklist hits with matching severity, evidence, remediation, and blocked/warning state.
+- **Snowflake and self-hosted deployment path** — Snowflake POV docs, EKS deployment profile, BYO Postgres guidance, and deployment navigation were tightened around the current operator-pull and customer-managed data-store model.
+- **MCP documentation and metrics alignment** — MCP docs, server-card descriptions, product metrics, Glama/MCP registry manifests, Docker/Helm references, OpenClaw skill metadata, and README release refs now align to the v0.84.0 surface.
+
+### Fixed
+- **Bundled skill contract enforcement** — skill guardrail metadata is now regression-tested so new skills must declare credential handling, data flow, file access, network endpoints, invocation policy, and verification posture.
+- **Posture headline calibration** — compact output no longer pairs high/critical policy findings with a misleading strong/clean posture headline.
+- **Release-surface drift** — package metadata, Helm chart/app versions, image pins, registry manifests, skill versions, and verification docs were bumped together for the v0.84.0 release.
+
+---
+
 ## [0.83.4] – 2026-04-30
 
 ### Added
@@ -947,7 +966,13 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
-[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.82.1...HEAD
+[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.84.0...HEAD
+[0.84.0]: https://github.com/msaad00/agent-bom/compare/v0.83.4...v0.84.0
+[0.83.4]: https://github.com/msaad00/agent-bom/compare/v0.83.3...v0.83.4
+[0.83.3]: https://github.com/msaad00/agent-bom/compare/v0.83.2...v0.83.3
+[0.83.2]: https://github.com/msaad00/agent-bom/compare/v0.83.1...v0.83.2
+[0.83.1]: https://github.com/msaad00/agent-bom/compare/v0.83.0...v0.83.1
+[0.83.0]: https://github.com/msaad00/agent-bom/compare/v0.82.1...v0.83.0
 [0.82.1]: https://github.com/msaad00/agent-bom/compare/v0.82.0...v0.82.1
 [0.82.0]: https://github.com/msaad00/agent-bom/compare/v0.81.3...v0.82.0
 [0.76.4]: https://github.com/msaad00/agent-bom/compare/v0.76.2...v0.76.4

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -188,7 +188,7 @@ Focused graph:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `0.83.4` | Current stable version (pinned) |
+| `0.84.0` | Current stable version (pinned) |
 
 Published images:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.3-alpine3.23@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510
 
-ARG VERSION=0.83.4
+ARG VERSION=0.84.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ for the full split-vs-single-image guidance.
 |------|----------|
 | CLI (`agent-bom agents`) | local audit + project scan |
 | Endpoint fleet (`--push-url …/v1/fleet/sync`) | employee laptops pushing into self-hosted fleet |
-| GitHub Action (`uses: msaad00/agent-bom@v0.83.4`) | CI/CD + SARIF |
+| GitHub Action (`uses: msaad00/agent-bom@v0.84.0`) | CI/CD + SARIF |
 | Docker (`agentbom/agent-bom`) | isolated scans, API jobs, and non-browser self-hosted entrypoints |
 | Browser UI image (`agentbom/agent-bom-ui`) | the dashboard image paired with the same self-hosted control plane |
 | Kubernetes / Helm (`helm install agent-bom deploy/helm/agent-bom`) | self-hosted API + dashboard, scheduled discovery |
@@ -404,7 +404,7 @@ References: [PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md) · [PRODUCT_METRICS.md](do
 <summary><b>CI/CD in 60 seconds</b></summary>
 
 ```yaml
-- uses: msaad00/agent-bom@v0.83.4
+- uses: msaad00/agent-bom@v0.84.0
   with:
     scan-type: scan
     severity-threshold: high

--- a/deploy/docker-compose.fullstack.yml
+++ b/deploy/docker-compose.fullstack.yml
@@ -27,7 +27,7 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
-    image: agentbom/agent-bom:0.83.4
+    image: agentbom/agent-bom:0.84.0
     container_name: agent-bom-api
     restart: unless-stopped
     command: api --host 0.0.0.0 --port 8422 --allow-insecure-no-auth
@@ -74,7 +74,7 @@ services:
       args:
         # Baked into the Next.js build — must match the publicly reachable API URL
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8422}
-    image: agentbom/agent-bom-ui:0.83.4
+    image: agentbom/agent-bom-ui:0.84.0
     container_name: agent-bom-ui
     restart: unless-stopped
     ports:

--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -18,7 +18,7 @@
 
 services:
   api:
-    image: agentbom/agent-bom:0.83.4
+    image: agentbom/agent-bom:0.84.0
     container_name: agent-bom-pilot-api
     restart: unless-stopped
     command: >
@@ -45,7 +45,7 @@ services:
       start_period: 10s
 
   ui:
-    image: agentbom/agent-bom-ui:0.83.4
+    image: agentbom/agent-bom-ui:0.84.0
     container_name: agent-bom-pilot-ui
     restart: unless-stopped
     environment:

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -112,7 +112,7 @@ services:
       dockerfile: Dockerfile
       args:
         NEXT_PUBLIC_API_URL: http://localhost:8422
-    image: agentbom/agent-bom-ui:0.83.4
+    image: agentbom/agent-bom-ui:0.84.0
     container_name: agent-bom-ui
     ports:
       - "3000:3000"

--- a/deploy/docker-compose.runtime.yml
+++ b/deploy/docker-compose.runtime.yml
@@ -31,7 +31,7 @@ services:
     build:
       context: ..
       dockerfile: deploy/docker/Dockerfile.runtime
-    image: agentbom/agent-bom:0.83.4
+    image: agentbom/agent-bom:0.84.0
     container_name: agent-bom-runtime-proxy
     depends_on:
       - mcp-server

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -27,7 +27,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.83.4
+ARG VERSION=0.84.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -17,7 +17,7 @@ WORKDIR /app
 COPY pyproject.toml README.md LICENSE ./
 COPY src/ ./src/
 
-ARG VERSION=0.83.4
+ARG VERSION=0.84.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
@@ -40,7 +40,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[runtime]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.83.4
+ARG VERSION=0.84.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.snowpark
+++ b/deploy/docker/Dockerfile.snowpark
@@ -26,7 +26,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11.12-slim@sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c
 
-ARG VERSION=0.83.4
+ARG VERSION=0.84.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -41,7 +41,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.83.4
+ARG VERSION=0.84.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: agent-bom
 description: Open security scanner and graph for AI supply chain and infrastructure — discover agents and MCP, map blast radius, and inspect runtime.
-version: 0.83.4
-appVersion: "0.83.4"
+version: 0.84.0
+appVersion: "0.84.0"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -5,17 +5,17 @@
 
 image:
   repository: agentbom/agent-bom
-  tag: "0.83.4"
+  tag: "0.84.0"
   pullPolicy: IfNotPresent
 
 uiImage:
   repository: agentbom/agent-bom-ui
-  tag: "0.83.4"
+  tag: "0.84.0"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom
-  tag: "0.83.4"
+  tag: "0.84.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -38,7 +38,7 @@ tests:
   includeUi: true
   image:
     repository: agentbom/agent-bom
-    tag: "0.83.4"
+    tag: "0.84.0"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deploy/k8s/daemonset.yaml
+++ b/deploy/k8s/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: agent-bom
       containers:
         - name: monitor
-          image: agentbom/agent-bom:0.83.4
+          image: agentbom/agent-bom:0.84.0
           command: ["agent-bom"]
           args:
             - "protect"

--- a/deploy/k8s/proxy-sidecar-pilot.yaml
+++ b/deploy/k8s/proxy-sidecar-pilot.yaml
@@ -109,7 +109,7 @@ spec:
               cpu: "500m"
 
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.83.4
+          image: agentbom/agent-bom:0.84.0
           args:
             - "--policy"
             - "/etc/agent-bom/policy.json"

--- a/deploy/k8s/sidecar-example.yaml
+++ b/deploy/k8s/sidecar-example.yaml
@@ -40,7 +40,7 @@ spec:
 
         # agent-bom proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.83.4
+          image: agentbom/agent-bom:0.84.0
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -135,7 +135,7 @@ agent-bom agents --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.83.4
+- uses: msaad00/agent-bom@v0.84.0
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -72,7 +72,7 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # GitHub Actions
-- uses: msaad00/agent-bom@v0.83.4
+- uses: msaad00/agent-bom@v0.84.0
   with:
     scan-type: agents        # auto-detect MCP configs + deps
     severity-threshold: high # fail PR on HIGH+ CVEs
@@ -90,21 +90,21 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # Container image gate
-- uses: msaad00/agent-bom@v0.83.4
+- uses: msaad00/agent-bom@v0.84.0
   with:
     scan-type: image
     scan-ref: ghcr.io/acme/agent-runtime:sha-abcdef
     severity-threshold: critical
 
 # IaC gate
-- uses: msaad00/agent-bom@v0.83.4
+- uses: msaad00/agent-bom@v0.84.0
   with:
     scan-type: iac
     iac: Dockerfile,k8s/,infra/main.tf
     severity-threshold: high
 
 # Air-gapped or fully cached CI
-- uses: msaad00/agent-bom@v0.83.4
+- uses: msaad00/agent-bom@v0.84.0
   with:
     auto-update-db: false
     enrich: false
@@ -468,7 +468,7 @@ AmazonEC2ReadOnlyAccess
 docker run --rm \
   -v ~/.config:/home/abom/.config:ro \
   -v $(pwd):/workspace:ro \
-  agentbom/agent-bom:0.83.4 agents --format json
+  agentbom/agent-bom:0.84.0 agents --format json
 ```
 
 Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base image.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -242,7 +242,7 @@ blast_radius        — blast radius for a specific CVE
 ### CI/CD (GitHub Action)
 
 ```yaml
-- uses: msaad00/agent-bom@v0.83.4
+- uses: msaad00/agent-bom@v0.84.0
   with:
     format: sarif
     upload-sarif: 'true'

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,18 +1,24 @@
 {
-  "generated_on": "2026-04-28",
-  "version": "0.83.4",
+  "generated_on": "2026-04-30",
+  "version": "0.84.0",
   "metrics": [
     {
       "name": "MCP tools",
-      "value": 9,
-      "source": "src/agent_bom/mcp_server.py",
-      "notes": "Counted from @mcp.tool decorators."
+      "value": 36,
+      "source": "src/agent_bom/mcp_server_metadata.py",
+      "notes": "Counted from the advertised server-card tools."
     },
     {
       "name": "MCP resources",
-      "value": 0,
-      "source": "src/agent_bom/mcp_server.py",
-      "notes": "Counted from @mcp.resource decorators."
+      "value": 6,
+      "source": "src/agent_bom/mcp_server_metadata.py",
+      "notes": "Counted from the advertised server-card resources."
+    },
+    {
+      "name": "MCP prompts",
+      "value": 6,
+      "source": "src/agent_bom/mcp_server_metadata.py",
+      "notes": "Counted from the advertised server-card workflow prompts."
     },
     {
       "name": "GitHub workflow files",
@@ -22,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 394,
+      "value": 414,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
@@ -40,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 409,
+      "value": 421,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },
@@ -53,7 +59,7 @@
     {
       "name": "Compliance surfaces",
       "value": 15,
-      "source": "src/agent_bom/api/routes/compliance.py",
+      "source": "src/agent_bom/compliance_coverage.py",
       "notes": "14 tag-mapped frameworks plus the OWASP AISVS benchmark surface."
     },
     {

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,20 +5,21 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-04-28`
-- Version: `0.83.4`
+- Generated on: `2026-04-30`
+- Version: `0.84.0`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |
-| MCP tools | 9 | `src/agent_bom/mcp_server.py` | Counted from @mcp.tool decorators. |
-| MCP resources | 0 | `src/agent_bom/mcp_server.py` | Counted from @mcp.resource decorators. |
+| MCP tools | 36 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
+| MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
+| MCP prompts | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 35 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 394 | `tests/` | Counts files matching test_*.py. |
+| Test files | 414 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 18 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 23 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 409 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 421 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
-| Compliance surfaces | 15 | `src/agent_bom/api/routes/compliance.py` | 14 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
+| Compliance surfaces | 15 | `src/agent_bom/compliance_coverage.py` | 14 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |
 | Runtime protection engine detectors | 8 | `src/agent_bom/runtime/protection.py` | Broader protection engine used outside the lighter proxy-only path. |
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -97,7 +97,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN" --no-browser
 clawhub publish integrations/openclaw/scan \
   --slug agent-bom-scan --name "agent-bom scan" \
-  --version "0.83.4"
+  --version "0.84.0"
 ```
 
 Release automation uses the same official `clawhub` CLI flow, not a custom
@@ -150,8 +150,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.83.4
-git push origin v0.83.4
+git tag v0.84.0
+git push origin v0.84.0
 ```
 
 This triggers:

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -13,7 +13,7 @@ For each tagged GitHub Release, expect:
 ## Download release assets
 
 ```bash
-TAG=v0.83.4
+TAG=v0.84.0
 VERSION="${TAG#v}"
 mkdir -p /tmp/agent-bom-release && cd /tmp/agent-bom-release
 gh release download "$TAG" --repo msaad00/agent-bom

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -33,7 +33,7 @@ The proxy interposes on the stdio channel between an MCP client (Claude Desktop,
 Use the published main runtime image:
 
 ```bash
-docker pull agentbom/agent-bom:0.83.4
+docker pull agentbom/agent-bom:0.84.0
 ```
 
 If you need to rebuild locally from the checked-out repo, you can still use
@@ -45,7 +45,7 @@ Run as a wrapper around any MCP server:
 ```bash
 docker run --rm \
   -v $(pwd)/audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.83.4 \
+  agentbom/agent-bom:0.84.0 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace
@@ -94,7 +94,7 @@ spec:
 
         # agent-bom runtime proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.83.4
+          image: agentbom/agent-bom:0.84.0
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"
@@ -334,7 +334,7 @@ Use the runtime container directly from Claude Desktop:
         "run", "--rm", "-i",
         "-v", "./workspace:/workspace",
         "-v", "./audit-logs:/var/log/agent-bom",
-        "agentbom/agent-bom:0.83.4",
+        "agentbom/agent-bom:0.84.0",
         "--log", "/var/log/agent-bom/audit.jsonl",
         "--block-undeclared",
         "--",

--- a/docs/archive/WINDOWS_CONTAINERS.md
+++ b/docs/archive/WINDOWS_CONTAINERS.md
@@ -113,7 +113,7 @@ container inspection. Windows Server environments should use:
 
 1. **Python CLI** -- `pip install agent-bom` works on Windows natively
 2. **Docker Desktop** -- run the Linux container images on Windows via WSL 2
-3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.83.4`) which
+3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.84.0`) which
    runs on Linux runners
 
 ---

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,4 +1,4 @@
-# agent-bom v0.83.4 blast-radius demo
+# agent-bom v0.84.0 blast-radius demo
 # Shows: blast radius → package gate
 
 Output docs/images/demo-latest.gif

--- a/integrations/docker-mcp-registry/tools.json
+++ b/integrations/docker-mcp-registry/tools.json
@@ -98,19 +98,19 @@
     "arguments": []
   },
   {
-    "name": "inventory",
-    "description": "List all discovered MCP configurations and servers without running a CVE scan.",
-    "arguments": [
-      {"name": "project_path", "type": "string", "desc": "Directory to scan (default: auto-detect)"},
-      {"name": "output_format", "type": "string", "desc": "Output format: json, table"}
-    ]
-  },
-  {
     "name": "tool_risk_assessment",
     "description": "Score live-introspected MCP tool capabilities and server risk — classifies tools as READ/WRITE/EXECUTE/NETWORK/FILE_ACCESS and flags dangerous capability combinations.",
     "arguments": [
       {"name": "config_path", "type": "string", "desc": "Path to MCP client config directory (default: auto-discover)"},
       {"name": "timeout", "type": "number", "desc": "Per-server introspection timeout in seconds (default: 10.0)"}
+    ]
+  },
+  {
+    "name": "inventory",
+    "description": "List all discovered MCP configurations and servers without running a CVE scan.",
+    "arguments": [
+      {"name": "project_path", "type": "string", "desc": "Directory to scan (default: auto-detect)"},
+      {"name": "output_format", "type": "string", "desc": "Output format: json, table"}
     ]
   },
   {

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
-  "version": "0.83.4",
+  "version": "0.84.0",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
   "title": "agent-bom",
-  "version": "0.83.4",
+  "version": "0.84.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.83.4",
+      "version": "0.84.0",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   security checks. Use when the user mentions vulnerability scanning,
   MCP server trust, compliance, SBOM generation, CIS benchmarks, blast
   radius, or AI supply chain risk.
-version: 0.83.4
+version: 0.84.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -25,7 +25,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.4
+    docker: ghcr.io/msaad00/agent-bom:0.84.0
   openclaw:
     requires:
       bins: []
@@ -412,6 +412,6 @@ provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.83.4`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.84.0`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Analyze blast radius, attack paths, and threat landscape across your AI
   infrastructure. Use when: "blast radius", "threat intel", "risk score",
   "attack path", "lateral movement", "context graph", "who can reach what".
-version: 0.83.4
+version: 0.84.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.4
+    docker: ghcr.io/msaad00/agent-bom:0.84.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Generate SBOMs and compliance reports. Use when:
   "compliance report", "NIST", "SOC 2", "ISO 27001", "OWASP", "EU AI Act",
   "AISVS", "generate SBOM", "policy check".
-version: 0.83.4
+version: 0.84.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. OWASP/NIST/EU AI Act/MITRE
@@ -23,7 +23,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.4
+    docker: ghcr.io/msaad00/agent-bom:0.84.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/discover-aws/SKILL.md
+++ b/integrations/openclaw/discover-aws/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   inventory AWS Bedrock, ECS, SageMaker, Lambda, EKS, Step Functions, EC2, or
   agentic AWS infrastructure as canonical inventory. Passing that inventory
   to agent-bom is optional and operator-chosen.
-version: 0.83.4
+version: 0.84.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-azure/SKILL.md
+++ b/integrations/openclaw/discover-azure/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   giving agent-bom long-lived Azure credentials. Use when a user asks to
   inventory Azure OpenAI, Container Apps, AKS, Functions, ML, or agentic Azure
   infrastructure as canonical inventory.
-version: 0.83.4
+version: 0.84.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-gcp/SKILL.md
+++ b/integrations/openclaw/discover-gcp/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   giving agent-bom long-lived GCP credentials. Use when a user asks to
   inventory Vertex AI, Cloud Run, Cloud Functions, GKE, or agentic GCP
   infrastructure as canonical inventory.
-version: 0.83.4
+version: 0.84.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-snowflake/SKILL.md
+++ b/integrations/openclaw/discover-snowflake/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   agent-bom inventory JSON, and scan it without giving agent-bom long-lived
   Snowflake credentials. Use when a user asks to inventory Snowflake AI or
   Cortex infrastructure as canonical inventory.
-version: 0.83.4
+version: 0.84.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed with the snowflake extra, and

--- a/integrations/openclaw/discover/SKILL.md
+++ b/integrations/openclaw/discover/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Discover AI agents, MCP servers, and configurations on this machine or
   environment. Use when: "find agents", "what's configured", "doctor",
   "what MCP servers", "show me what's installed", "mcp inventory".
-version: 0.83.4
+version: 0.84.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.4
+    docker: ghcr.io/msaad00/agent-bom:0.84.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Enforce security policies on MCP tool calls and block dangerous operations at
   runtime. Use when: "block risky calls", "apply policy", "proxy",
   "runtime protection", "policy enforcement", "intercept MCP calls".
-version: 0.83.4
+version: 0.84.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.4
+    docker: ghcr.io/msaad00/agent-bom:0.84.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/ingest/SKILL.md
+++ b/integrations/openclaw/ingest/SKILL.md
@@ -5,10 +5,10 @@ description: >-
   GCP, Snowflake, CMDB, or endpoint collectors. Use when a user has canonical
   inventory JSON and wants local findings, graph, policy, provenance, or
   auditor-ready exports without giving agent-bom direct cloud credentials.
-version: 0.83.4
+version: 0.84.0
 license: Apache-2.0
 compatibility: >-
-  Requires Python 3.11+ and agent-bom 0.83.4+. Inventory must conform to the
+  Requires Python 3.11+ and agent-bom 0.84.0+. Inventory must conform to the
   packaged inventory.schema.json contract.
 metadata:
   author: msaad00

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Monitor agent fleet, track trust scores, and manage lifecycle states. Use
   when: "fleet", "watch agents", "runtime status", "trust scores",
   "fleet sync", "agent lifecycle", "serve dashboard".
-version: 0.83.4
+version: 0.84.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.4
+    docker: ghcr.io/msaad00/agent-bom:0.84.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.83.4
+version: 0.84.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.83.4
+version: 0.84.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Scan infrastructure-as-code, cloud configurations, and find secrets. Use when:
   "check terraform", "scan kubernetes", "IaC", "find secrets",
   "scan dockerfile", "cloud security", "misconfigurations".
-version: 0.83.4
+version: 0.84.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.4
+    docker: ghcr.io/msaad00/agent-bom:0.84.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   KEV), container images, provenance, filesystems, and SBOMs. Use
   when: "check package", "scan image", "verify", "is this safe",
   "scan dependencies", "CVE lookup", "blast radius".
-version: 0.83.4
+version: 0.84.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Native container image
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.4
+    docker: ghcr.io/msaad00/agent-bom:0.84.0
   openclaw:
     requires:
       bins: []
@@ -237,6 +237,6 @@ agent-bom agents
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.83.4`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.84.0`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Diagnose issues, check prerequisites, and validate configurations. Use when:
   "doctor", "debug", "why failing", "validate config", "check prerequisites",
   "something is broken", "db status", "fix my setup".
-version: 0.83.4
+version: 0.84.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.83.4
+    docker: ghcr.io/msaad00/agent-bom:0.84.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/vulnerability-intel/SKILL.md
+++ b/integrations/openclaw/vulnerability-intel/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   with explicit data-boundary choices. Use when a user asks for CVE lookup,
   advisory intelligence, exploitability context, fix versions, GHSA/OSV/NVD
   enrichment, or package vulnerability triage.
-version: 0.83.4
+version: 0.84.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+ and agent-bom installed from this repository or PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.83.4"
+version = "0.84.0"
 description = "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius."
 readme = "PYPI_README.md"
 license = "Apache-2.0"

--- a/scripts/check-counts.py
+++ b/scripts/check-counts.py
@@ -7,6 +7,7 @@ Exit 0 = all consistent. Exit 1 = drift detected.
 
 from __future__ import annotations
 
+import ast
 import re
 import sys
 from pathlib import Path
@@ -44,15 +45,42 @@ def _check(label: str, expected: str, files: list[str], pattern: str, exclude_pa
 
 # ── Source of truth: count from actual code ────────────────────────────────
 
-# MCP tools: count @mcp.tool decorators
-mcp_server = ROOT / "src/agent_bom/mcp_server.py"
-mcp_tool_count = mcp_server.read_text().count("@mcp.tool") if mcp_server.exists() else 0
+# MCP tools: count the advertised server card. The implementation is split
+# across modules, but this is the surface MCP clients and registries consume.
+metadata = ROOT / "src/agent_bom/mcp_server_metadata.py"
+if metadata.exists():
+    module = ast.parse(metadata.read_text())
+    mcp_tool_count = 0
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "_SERVER_CARD_TOOLS" for target in node.targets):
+            continue
+        value = ast.literal_eval(node.value)
+        mcp_tool_count = len(value) if isinstance(value, list) else 0
+        break
+else:
+    mcp_tool_count = 0
 
-# Runtime detectors: count class definitions in detectors.py
-detectors = ROOT / "src/agent_bom/runtime/detectors.py"
+# Runtime detectors: count the broader protection engine imports. The lighter
+# proxy path intentionally uses fewer inline detectors and is documented
+# separately in PRODUCT_METRICS.
+protection = ROOT / "src/agent_bom/runtime/protection.py"
 detector_classes = (
-    len(re.findall(r"^class \w+(?:Detector|Analyzer|Inspector|Correlator)\b", detectors.read_text(), re.MULTILINE))
-    if detectors.exists()
+    len(
+        [
+            line
+            for line in re.search(
+                r"from agent_bom\.runtime\.detectors import \((.*?)\)\n",
+                protection.read_text(),
+                re.DOTALL,
+            )
+            .group(1)
+            .splitlines()
+            if line.strip()
+        ]
+    )
+    if protection.exists()
     else 0
 )
 
@@ -89,8 +117,6 @@ SURFACES = [
     "README.md",
     "DOCKER_HUB_README.md",
     "docs/ARCHITECTURE.md",
-    "docs/archive/STRATEGIC_AUDIT_2026_03.md",
-    "docs/archive/AUDIT.md",
     "pyproject.toml",
     "action.yml",
 ]
@@ -99,7 +125,13 @@ SURFACES = [
 _check("MCP tools", str(mcp_tool_count), SURFACES, r"\d+ MCP (?:server )?tools")
 
 # Check detector count
-_check("Detectors", str(detector_classes), SURFACES, r"\d+ (?:behavioral )?detectors", exclude_pattern=r"17 behavioral")
+_check(
+    "Detectors",
+    str(detector_classes),
+    SURFACES,
+    r"\d+ (?:behavioral )?detectors",
+    exclude_pattern=r"17 behavioral|7 detectors.*8 detectors",
+)
 
 # Check dashboard pages
 _check("Pages", str(pages), SURFACES, r"\d+-page")

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import ast
+import json
 import re
 import sys
 from pathlib import Path
@@ -10,6 +12,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 README = ROOT / "README.md"
 PYPI_README = ROOT / "PYPI_README.md"
+CHANGELOG = ROOT / "CHANGELOG.md"
 DEMO_TAPE = ROOT / "docs" / "demo.tape"
 DEMO_LATEST = ROOT / "docs" / "images" / "demo-latest.gif"
 GLAMA_SERVER = ROOT / "integrations" / "glama" / "server.json"
@@ -25,6 +28,80 @@ MANAGED_IMAGE_REFS: list[tuple[Path, re.Pattern[str]]] = [
     (ROOT / "site-docs" / "deployment" / "docker.md", re.compile(r"agentbom/agent-bom:([0-9]+\.[0-9]+\.[0-9]+)")),
     (ROOT / "docs" / "RUNTIME_MONITORING.md", re.compile(r"agentbom/agent-bom:([0-9]+\.[0-9]+\.[0-9]+)")),
 ]
+MANAGED_VERSION_REFS: list[tuple[Path, re.Pattern[str], str]] = [
+    (
+        ROOT / "src" / "agent_bom" / "__init__.py",
+        re.compile(r'__version__\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"'),
+        "__version__",
+    ),
+    (ROOT / "uv.lock", re.compile(r'name = "agent-bom"\nversion = "([0-9]+\.[0-9]+\.[0-9]+)"'), "uv.lock package version"),
+    (ROOT / "ui" / "package.json", re.compile(r'"version":\s*"([0-9]+\.[0-9]+\.[0-9]+)"'), "UI package version"),
+    (
+        ROOT / "deploy" / "helm" / "agent-bom" / "values.yaml",
+        re.compile(r'tag:\s*"([0-9]+\.[0-9]+\.[0-9]+)"'),
+        "Helm values image tag",
+    ),
+    (
+        ROOT / "deploy" / "docker" / "Dockerfile.runtime",
+        re.compile(r"^ARG VERSION=([0-9]+\.[0-9]+\.[0-9]+)$", re.M),
+        "runtime Dockerfile ARG",
+    ),
+    (
+        ROOT / "deploy" / "docker" / "Dockerfile.sse",
+        re.compile(r"^ARG VERSION=([0-9]+\.[0-9]+\.[0-9]+)$", re.M),
+        "SSE Dockerfile ARG",
+    ),
+    (
+        ROOT / "deploy" / "docker" / "Dockerfile.mcp",
+        re.compile(r"^ARG VERSION=([0-9]+\.[0-9]+\.[0-9]+)$", re.M),
+        "MCP Dockerfile ARG",
+    ),
+    (
+        ROOT / "deploy" / "docker" / "Dockerfile.snowpark",
+        re.compile(r"^ARG VERSION=([0-9]+\.[0-9]+\.[0-9]+)$", re.M),
+        "Snowpark Dockerfile ARG",
+    ),
+    (
+        ROOT / "deploy" / "k8s" / "sidecar-example.yaml",
+        re.compile(r"agentbom/agent-bom:([0-9]+\.[0-9]+\.[0-9]+)"),
+        "K8s sidecar image",
+    ),
+    (
+        ROOT / "deploy" / "k8s" / "proxy-sidecar-pilot.yaml",
+        re.compile(r"agentbom/agent-bom:([0-9]+\.[0-9]+\.[0-9]+)"),
+        "K8s proxy sidecar image",
+    ),
+    (
+        ROOT / "integrations" / "mcp-registry" / "server.json",
+        re.compile(r'"version":\s*"([0-9]+\.[0-9]+\.[0-9]+)"'),
+        "MCP Registry manifest version",
+    ),
+    (ROOT / "integrations" / "glama" / "server.json", re.compile(r'"version":\s*"([0-9]+\.[0-9]+\.[0-9]+)"'), "Glama manifest version"),
+    (ROOT / "docs" / "RELEASE_VERIFICATION.md", re.compile(r"^TAG=v([0-9]+\.[0-9]+\.[0-9]+)$", re.M), "release verification tag"),
+    (
+        ROOT / "docs" / "PUBLISHING.md",
+        re.compile(r"(?:--version \"|git tag v|git push origin v)([0-9]+\.[0-9]+\.[0-9]+)"),
+        "publishing example version",
+    ),
+    (
+        ROOT / "DOCKER_HUB_README.md",
+        re.compile(r"\| `([0-9]+\.[0-9]+\.[0-9]+)` \| Current stable version \(pinned\) \|"),
+        "Docker Hub stable tag",
+    ),
+]
+MANAGED_ACTION_REFS: list[Path] = [
+    ROOT / "README.md",
+    ROOT / "docs" / "AI_INFRASTRUCTURE_SCANNING.md",
+    ROOT / "docs" / "ENTERPRISE_DEPLOYMENT.md",
+    ROOT / "docs" / "MCP_SECURITY_MODEL.md",
+    ROOT / "site-docs" / "features" / "policy.md",
+]
+MCP_COUNT_DOCS: list[Path] = [
+    ROOT / "README.md",
+    ROOT / "docs" / "MCP_SERVER.md",
+    ROOT / "site-docs" / "getting-started" / "mcp-server.md",
+]
+DOCKER_MCP_TOOLS = ROOT / "integrations" / "docker-mcp-registry" / "tools.json"
 
 
 def _load_version() -> str:
@@ -48,11 +125,44 @@ def _fail(message: str) -> None:
     raise SystemExit(1)
 
 
+def _server_card_list(variable_name: str) -> list[dict[str, object]]:
+    metadata = ROOT / "src" / "agent_bom" / "mcp_server_metadata.py"
+    module = ast.parse(metadata.read_text())
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == variable_name for target in node.targets):
+            continue
+        value = ast.literal_eval(node.value)
+        if isinstance(value, list):
+            return value
+    _fail(f"{metadata.relative_to(ROOT)} is missing {variable_name}")
+
+
+def _server_card_catalog() -> tuple[list[str], list[str], list[str]]:
+    tools = [str(tool["name"]) for tool in _server_card_list("_SERVER_CARD_TOOLS")]
+    resources = [str(resource["uri"]) for resource in _server_card_list("_SERVER_CARD_RESOURCES")]
+    prompts = [str(prompt["name"]) for prompt in _server_card_list("_SERVER_CARD_PROMPTS")]
+    return tools, resources, prompts
+
+
+def _assert_versions(path: Path, pattern: re.Pattern[str], expected: str, label: str) -> None:
+    if not path.exists():
+        _fail(f"{path.relative_to(ROOT)} is missing from release surface")
+    text = path.read_text()
+    versions = {match.group(1) for match in pattern.finditer(text)}
+    if not versions:
+        _fail(f"{path.relative_to(ROOT)} has no managed {label}")
+    if versions != {expected}:
+        _fail(f"{path.relative_to(ROOT)} has stale {label}: {sorted(versions)} != {expected}")
+
+
 def main() -> int:
     version = _load_version()
     description = _load_description()
     readme = README.read_text()
     pypi_readme = PYPI_README.read_text()
+    changelog = CHANGELOG.read_text()
     demo_tape = DEMO_TAPE.read_text()
 
     required_github_markers = [
@@ -137,6 +247,11 @@ def main() -> int:
         if marker in description:
             _fail(f"pyproject.toml description contains stale storefront phrase: {marker}")
 
+    if f"## [{version}]" not in changelog:
+        _fail(f"CHANGELOG.md must include a {version} release entry before tagging")
+    if f"[Unreleased]: https://github.com/msaad00/agent-bom/compare/v{version}...HEAD" not in changelog:
+        _fail(f"CHANGELOG.md Unreleased compare link must start at v{version}")
+
     leaked_patterns = [
         r"/Users/[^/\s]+",
         r"[A-Za-z]:\\Users\\[^\\\s]+",
@@ -167,6 +282,47 @@ def main() -> int:
         versions = {match.group(1) for match in pattern.finditer(text)}
         if versions and versions != {version}:
             _fail(f"{path.relative_to(ROOT)} contains stale managed image version(s): {sorted(versions)} != {version}")
+    for path, pattern, label in MANAGED_VERSION_REFS:
+        _assert_versions(path, pattern, version, label)
+    ui_lock = json.loads((ROOT / "ui" / "package-lock.json").read_text())
+    ui_lock_versions = {ui_lock.get("version"), ui_lock.get("packages", {}).get("", {}).get("version")}
+    if ui_lock_versions != {version}:
+        _fail(f"ui/package-lock.json has stale root package version(s): {sorted(ui_lock_versions)} != {version}")
+    for skill in sorted((ROOT / "integrations" / "openclaw").rglob("SKILL.md")):
+        _assert_versions(skill, re.compile(r"^version:\s*([0-9]+\.[0-9]+\.[0-9]+)$", re.M), version, "OpenClaw skill frontmatter version")
+        text = skill.read_text()
+        docker_versions = set(re.findall(r"ghcr\.io/msaad00/agent-bom:([0-9]+\.[0-9]+\.[0-9]+)", text))
+        verify_versions = set(re.findall(r"agent-bom verify agent-bom@([0-9]+\.[0-9]+\.[0-9]+)", text))
+        if docker_versions and docker_versions != {version}:
+            _fail(f"{skill.relative_to(ROOT)} has stale OpenClaw Docker pin(s): {sorted(docker_versions)} != {version}")
+        if verify_versions and verify_versions != {version}:
+            _fail(f"{skill.relative_to(ROOT)} has stale OpenClaw verify pin(s): {sorted(verify_versions)} != {version}")
+    for path in MANAGED_ACTION_REFS:
+        text = path.read_text()
+        action_versions = set(re.findall(r"msaad00/agent-bom@v([0-9]+\.[0-9]+\.[0-9]+)", text))
+        if action_versions and action_versions != {version}:
+            _fail(f"{path.relative_to(ROOT)} has stale GitHub Action ref(s): {sorted(action_versions)} != {version}")
+
+    tool_names, resource_uris, prompt_names = _server_card_catalog()
+    tools = len(tool_names)
+    resources = len(resource_uris)
+    prompts = len(prompt_names)
+    if (tools, resources, prompts) != (36, 6, 6):
+        _fail(f"MCP server card count changed unexpectedly: tools={tools}, resources={resources}, prompts={prompts}")
+    docker_mcp_tool_names = [str(tool["name"]) for tool in json.loads(DOCKER_MCP_TOOLS.read_text())]
+    if docker_mcp_tool_names != tool_names:
+        missing = sorted(set(tool_names) - set(docker_mcp_tool_names))
+        extra = sorted(set(docker_mcp_tool_names) - set(tool_names))
+        _fail(f"integrations/docker-mcp-registry/tools.json is out of sync with MCP server-card tools: missing={missing}, extra={extra}")
+    for path in MCP_COUNT_DOCS:
+        text = path.read_text()
+        readme_count_phrase = f"{tools} read-only security tools, {resources} resources, and {prompts} workflow prompts"
+        if path.name == "README.md" and readme_count_phrase not in text:
+            _fail("README.md must advertise current MCP tool/resource/prompt counts")
+        if path.name == "MCP_SERVER.md" and f"Tool Categories ({tools} tools)" not in text:
+            _fail("docs/MCP_SERVER.md must advertise current MCP tool count")
+        if path.name == "mcp-server.md" and f"{resources} resources and {prompts} workflow prompts" not in text:
+            _fail("site-docs/getting-started/mcp-server.md must advertise current MCP resource/prompt counts")
 
     helm_chart = ROOT / "deploy" / "helm" / "agent-bom" / "Chart.yaml"
     helm_text = helm_chart.read_text()

--- a/scripts/product_metrics_snapshot.py
+++ b/scripts/product_metrics_snapshot.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import re
 from datetime import date
@@ -34,11 +35,28 @@ def _count_python_modules() -> int:
 
 
 def _count_mcp_tools() -> int:
-    return (ROOT / "src" / "agent_bom" / "mcp_server.py").read_text().count("@mcp.tool")
+    return _count_server_card_entries("_SERVER_CARD_TOOLS")
 
 
 def _count_mcp_resources() -> int:
-    return (ROOT / "src" / "agent_bom" / "mcp_server.py").read_text().count("@mcp.resource")
+    return _count_server_card_entries("_SERVER_CARD_RESOURCES")
+
+
+def _count_mcp_prompts() -> int:
+    return _count_server_card_entries("_SERVER_CARD_PROMPTS")
+
+
+def _count_server_card_entries(variable_name: str) -> int:
+    content = (ROOT / "src" / "agent_bom" / "mcp_server_metadata.py").read_text()
+    module = ast.parse(content)
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == variable_name for target in node.targets):
+            continue
+        value = ast.literal_eval(node.value)
+        return len(value) if isinstance(value, list) else 0
+    return 0
 
 
 def _count_package_ecosystems() -> int:
@@ -50,12 +68,16 @@ def _count_package_ecosystems() -> int:
 
 
 def _count_compliance_frameworks() -> int:
-    content = (ROOT / "src" / "agent_bom" / "api" / "routes" / "compliance.py").read_text()
-    match = re.search(r"all_frameworks\s*=\s*\[(.*?)\]", content, re.DOTALL)
-    if not match:
-        return 0
-    entries = [line.strip().rstrip(",") for line in match.group(1).splitlines() if line.strip()]
-    return len(entries)
+    content = (ROOT / "src" / "agent_bom" / "compliance_coverage.py").read_text()
+    module = ast.parse(content)
+    for node in module.body:
+        if isinstance(node, ast.Assign):
+            if not any(isinstance(target, ast.Name) and target.id == "TAG_MAPPED_FRAMEWORKS" for target in node.targets):
+                continue
+            return len(node.value.elts) if isinstance(node.value, ast.Tuple) else 0
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.target.id == "TAG_MAPPED_FRAMEWORKS":
+            return len(node.value.elts) if isinstance(node.value, ast.Tuple) else 0
+    return 0
 
 
 def _count_compliance_surfaces() -> int:
@@ -96,14 +118,20 @@ def build_snapshot() -> dict[str, object]:
             {
                 "name": "MCP tools",
                 "value": _count_mcp_tools(),
-                "source": "src/agent_bom/mcp_server.py",
-                "notes": "Counted from @mcp.tool decorators.",
+                "source": "src/agent_bom/mcp_server_metadata.py",
+                "notes": "Counted from the advertised server-card tools.",
             },
             {
                 "name": "MCP resources",
                 "value": _count_mcp_resources(),
-                "source": "src/agent_bom/mcp_server.py",
-                "notes": "Counted from @mcp.resource decorators.",
+                "source": "src/agent_bom/mcp_server_metadata.py",
+                "notes": "Counted from the advertised server-card resources.",
+            },
+            {
+                "name": "MCP prompts",
+                "value": _count_mcp_prompts(),
+                "source": "src/agent_bom/mcp_server_metadata.py",
+                "notes": "Counted from the advertised server-card workflow prompts.",
             },
             {
                 "name": "GitHub workflow files",
@@ -144,7 +172,7 @@ def build_snapshot() -> dict[str, object]:
             {
                 "name": "Compliance surfaces",
                 "value": _count_compliance_surfaces(),
-                "source": "src/agent_bom/api/routes/compliance.py",
+                "source": "src/agent_bom/compliance_coverage.py",
                 "notes": "14 tag-mapped frameworks plus the OWASP AISVS benchmark surface.",
             },
             {

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -171,7 +171,7 @@ Install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.83.4 \
+  --version 0.84.0 \
   -n agent-bom --create-namespace \
   -f values.agent-bom.yaml
 ```
@@ -207,7 +207,7 @@ Then install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.83.4 \
+  --version 0.84.0 \
   -n agent-bom --create-namespace \
   -f deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
 ```

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -92,10 +92,10 @@ docker run --rm \
 ## Runtime proxy sidecar
 
 ```bash
-docker pull agentbom/agent-bom:0.83.4
+docker pull agentbom/agent-bom:0.84.0
 docker run --rm -i \
   -v ./audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.83.4 \
+  agentbom/agent-bom:0.84.0 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace

--- a/site-docs/deployment/snowflake-pov.md
+++ b/site-docs/deployment/snowflake-pov.md
@@ -6,7 +6,7 @@ the operator boundary.
 
 ## Scope
 
-The v0.83.4 POV scope is:
+The v0.84.0 POV scope is:
 
 - self-hosted API + UI control plane
 - operator-owned Postgres-compatible control-plane database
@@ -172,7 +172,7 @@ goal.
 
 | Surface | Current state |
 |---|---|
-| Draft PR remediation | Roadmap; not part of v0.83.4 |
+| Draft PR remediation | Roadmap; not part of v0.84.0 |
 | Auto-remediation | Roadmap |
 | Full Compliance Hub | Roadmap |
 | Complete IAM-to-agent traversal | Roadmap |

--- a/site-docs/features/policy.md
+++ b/site-docs/features/policy.md
@@ -49,7 +49,7 @@ agent-bom proxy --policy policy.json --block-undeclared -- ...
 
 ```yaml
 - name: Security gate
-  uses: msaad00/agent-bom@v0.83.4
+  uses: msaad00/agent-bom@v0.84.0
   with:
     policy: policy.json
     fail-on-violation: true

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.83.4"
+    __version__ = "0.84.0"
 
 # Cross-check against pyproject.toml for dev installs where the editable
 # install metadata may be stale (i.e. version bumped but not re-installed).

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.83.4",
+  "version": "0.84.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.83.4",
+      "version": "0.84.0",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
         "@tanstack/react-table": "^8.21.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.83.4",
+  "version": "0.84.0",
   "private": true,
   "packageManager": "npm@10.9.7",
   "engines": {

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/lib/api', () => ({
       scan_sources: [],
       scan_count: 0,
     }),
-    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.83.4' }),
+    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.84.0' }),
   },
 }))
 

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ overrides = [{ name = "python-dotenv", specifier = ">=1.2.2" }]
 
 [[package]]
 name = "agent-bom"
-version = "0.83.4"
+version = "0.84.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- bump package, UI, Helm, Docker, K8s, registry, OpenClaw skill, and documentation refs to v0.84.0
- add the v0.84.0 changelog entry for graph reachability, MCP resources/prompts, cloud/ingest skills, and Snowflake/self-hosted hardening
- strengthen release drift checks for lockfiles, image pins, skill metadata, registry manifests, changelog, MCP docs, and Docker MCP tool catalog alignment

## Validation
- python scripts/check_release_consistency.py
- python scripts/check-counts.py
- python scripts/bump-version.py 0.84.0 --check
- uv run ruff check scripts/check_release_consistency.py scripts/check-counts.py scripts/product_metrics_snapshot.py
- PYTHONPATH=src uv run pytest tests/test_mcp_server.py tests/test_deployment.py tests/test_bundled_skill_contract.py tests/test_stats_alignment.py tests/test_public_docs_cli_alignment.py -q
- PYTHONPATH=src uv run python server-card smoke: 36 tools / 6 resources / 6 prompts
- uv run mkdocs build --strict
- git diff --check

Commit is signed and GitHub reports verification reason: valid.