### PR TITLE
Fix v0.84.0 audit defects

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
           path: site
 
   deploy:
-    if: ${{ inputs.deploy != false }}
+    if: ${{ github.event_name != 'workflow_call' || inputs.deploy != false }}
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -828,7 +828,9 @@ jobs:
 
   github-release:
     name: Create GitHub Release
-    needs: [pypi-publish, docker-publish, docker-publish-ui, published-image-self-scan, sign, provenance, sbom, helm-publish]
+    # Keep the post-publish image self-scan running, but do not let a slow
+    # registry scan delay minting the GitHub Release after artifacts are out.
+    needs: [pypi-publish, docker-publish, docker-publish-ui, sign, provenance, sbom, helm-publish]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -88,6 +88,24 @@ MANAGED_VERSION_REFS: list[tuple[Path, re.Pattern[str], str]] = [
         re.compile(r"\| `([0-9]+\.[0-9]+\.[0-9]+)` \| Current stable version \(pinned\) \|"),
         "Docker Hub stable tag",
     ),
+    (
+        ROOT / "site-docs" / "deployment" / "airgapped-image-bundle.md",
+        re.compile(
+            r"(?:--version |agent-bom-airgap-|VERSION=|tag:\s*\"|agent-bom-ui:\")"
+            r"([0-9]+\.[0-9]+\.[0-9]+)"
+        ),
+        "air-gapped bundle release example",
+    ),
+    (
+        ROOT / "site-docs" / "deployment" / "aws-company-rollout.md",
+        re.compile(r"(?:--version |refs/tags/v)([0-9]+\.[0-9]+\.[0-9]+)"),
+        "AWS company rollout release example",
+    ),
+    (
+        ROOT / "site-docs" / "reference" / "remediate-output.md",
+        re.compile(r'"version":\s*"([0-9]+\.[0-9]+\.[0-9]+)"'),
+        "remediate output example version",
+    ),
 ]
 MANAGED_ACTION_REFS: list[Path] = [
     ROOT / "README.md",

--- a/site-docs/deployment/airgapped-image-bundle.md
+++ b/site-docs/deployment/airgapped-image-bundle.md
@@ -12,7 +12,7 @@ From an internet-connected build host:
 
 ```bash
 scripts/release/build-airgap-image-bundle.sh \
-  --version 0.83.1 \
+  --version 0.84.0 \
   --platform linux/amd64 \
   --output-dir dist/airgap
 ```
@@ -33,8 +33,8 @@ machine.
 ## Import On The Disconnected Host
 
 ```bash
-tar -xzf agent-bom-airgap-0.83.1-linux_amd64.tar.gz
-cd agent-bom-airgap-0.83.1-linux_amd64
+tar -xzf agent-bom-airgap-0.84.0-linux_amd64.tar.gz
+cd agent-bom-airgap-0.84.0-linux_amd64
 ./load-images.sh
 ```
 
@@ -43,7 +43,7 @@ The loader verifies archive checksums before running `docker load`.
 ## Push To An Internal Registry
 
 ```bash
-VERSION=0.83.1
+VERSION=0.84.0
 REGISTRY=registry.internal.example.com/security
 
 docker tag "agentbom/agent-bom:${VERSION}" "${REGISTRY}/agent-bom:${VERSION}"
@@ -58,13 +58,13 @@ Then point Helm at the internal registry:
 ```yaml
 image:
   repository: registry.internal.example.com/security/agent-bom
-  tag: "0.83.1"
+  tag: "0.84.0"
 
 controlPlane:
   ui:
     image:
       repository: registry.internal.example.com/security/agent-bom-ui
-      tag: "0.83.1"
+      tag: "0.84.0"
 ```
 
 ## GitHub Actions Bundle Job

--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -342,8 +342,8 @@ through a managed tap instead of direct package upload.
 
 ```bash
 python3 scripts/render_homebrew_formula.py \
-  --version 0.83.1 \
-  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.83.1.tar.gz \
+  --version 0.84.0 \
+  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.84.0.tar.gz \
   --sha256 <release-sha256>
 ```
 

--- a/site-docs/reference/remediate-output.md
+++ b/site-docs/reference/remediate-output.md
@@ -27,7 +27,7 @@ agent-bom remediate -p . --format json --server-group --output plan.json
 
 ```json
 {
-  "version": "0.83.1",
+  "version": "0.84.0",
   "generated_at": "2026-04-21T12:00:00+00:00",
   "remediation_plan": [],
   "summary": {

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -299,8 +299,9 @@ def _gateway_requires_auth(settings: GatewaySettings) -> bool:
         return True
     try:
         return get_key_store().has_keys()
-    except Exception:
-        return False
+    except Exception as exc:
+        logger.warning("Gateway key store status unavailable: %s", _sanitize_for_log(exc))
+        return True
 
 
 def _role_allows_gateway_relay(role: object) -> bool:
@@ -330,18 +331,23 @@ def _authenticate_gateway_request(request: Request, settings: GatewaySettings) -
 
     try:
         store = get_key_store()
-        if store.has_keys():
-            api_key = store.verify(raw_token) if raw_token else None
-            if api_key is None:
-                raise HTTPException(status_code=401, detail="gateway authentication required")
-            allowed, reason = _api_key_allows_gateway_relay(api_key)
-            if not allowed:
-                raise HTTPException(status_code=403, detail=reason)
-            return api_key.tenant_id or "default", "api_key"
-    except HTTPException:
-        raise
+        has_keys = store.has_keys()
     except Exception as exc:
-        logger.warning("Gateway key verification unavailable: %s", _sanitize_for_log(exc))
+        logger.warning("Gateway key store unavailable: %s", _sanitize_for_log(exc))
+        raise HTTPException(status_code=503, detail="gateway authentication unavailable") from exc
+
+    if has_keys:
+        try:
+            api_key = store.verify(raw_token) if raw_token else None
+        except Exception as exc:
+            logger.warning("Gateway key verification unavailable: %s", _sanitize_for_log(exc))
+            raise HTTPException(status_code=503, detail="gateway authentication unavailable") from exc
+        if api_key is None:
+            raise HTTPException(status_code=401, detail="gateway authentication required")
+        allowed, reason = _api_key_allows_gateway_relay(api_key)
+        if not allowed:
+            raise HTTPException(status_code=403, detail=reason)
+        return api_key.tenant_id or "default", "api_key"
 
     return "default", "none"
 

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -1476,8 +1476,9 @@ def _agent_identity_scope(agent_dict: dict[str, Any]) -> str:
 def _agent_node_id(agent_name: Any, source_id: str = "") -> str:
     """Build an agent graph ID without collapsing same-name fleet endpoints."""
     name = str(agent_name or "unknown").strip() or "unknown"
-    if source_id:
-        return f"agent:{source_id}:{name}"
+    source = _clean_graph_part(source_id).replace(":", "%3A")
+    if source:
+        return f"agent:{source}:{name}"
     return f"agent:{name}"
 
 

--- a/src/agent_bom/scanners/ghsa_advisory.py
+++ b/src/agent_bom/scanners/ghsa_advisory.py
@@ -295,6 +295,11 @@ async def check_github_advisories(
         queryable = queryable[:max_packages]
 
     logger.info("GHSA advisory check for %d packages", len(queryable))
+    github_token_available = bool(_github_token())
+    if not github_token_available:
+        logger.warning(
+            "GITHUB_TOKEN/GH_TOKEN is not set; GHSA advisory enrichment will fail fast on GitHub rate limits instead of pausing."
+        )
 
     # Build a reverse lookup: all packages sharing the same name+ecosystem
     pkg_groups: dict[str, list[Package]] = {}
@@ -312,7 +317,7 @@ async def check_github_advisories(
     try:
         async with create_client(timeout=15.0) as client:
             rate_limit_backoff = _GHSA_RATE_LIMIT_BACKOFF
-            if len(queryable) == 1 and not _github_token():
+            if not github_token_available:
                 rate_limit_backoff = _GHSA_SINGLE_PACKAGE_RATE_LIMIT_BACKOFF
             tasks = [_fetch_advisories_for_package(p, client, semaphore, rate_limit_backoff=rate_limit_backoff) for p in queryable]
             results = await asyncio.gather(*tasks, return_exceptions=True)

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -374,6 +374,35 @@ def test_relay_accepts_control_plane_api_key_and_applies_tenant(monkeypatch) -> 
     assert audit_events[-1]["tenant_id"] == "tenant-alpha"
 
 
+def test_relay_fails_closed_when_api_key_store_verification_errors(monkeypatch) -> None:
+    upstream_calls: list[dict[str, Any]] = []
+
+    async def fake_caller(upstream, message, extra_headers):
+        upstream_calls.append(message)
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    class _FakeKeyStore:
+        def has_keys(self) -> bool:
+            return True
+
+        def verify(self, raw_key: str):
+            raise RuntimeError("key store unavailable")
+
+    monkeypatch.setattr("agent_bom.gateway_server.get_key_store", lambda: _FakeKeyStore())
+
+    settings = GatewaySettings(registry=_simple_registry(), policy={}, upstream_caller=fake_caller)
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post(
+        "/mcp/filesystem",
+        headers={"X-API-Key": "tenant-alpha-key"},
+        json=_json_rpc("tools/call", name="read_file", arguments={"path": "/tmp/x"}),
+    )
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "gateway authentication unavailable"
+    assert upstream_calls == []
+
+
 def test_relay_rejects_viewer_api_key_before_forwarding(monkeypatch) -> None:
     upstream_calls: list[dict[str, Any]] = []
 

--- a/tests/test_ghsa_advisory.py
+++ b/tests/test_ghsa_advisory.py
@@ -237,11 +237,11 @@ def test_single_package_without_github_token_uses_fail_fast_rate_limit_backoff(m
     assert mock_fetch.await_args.kwargs["rate_limit_backoff"] == _GHSA_SINGLE_PACKAGE_RATE_LIMIT_BACKOFF
 
 
-def test_multi_package_scan_preserves_ghsa_rate_limit_backoff(monkeypatch):
+def test_multi_package_without_github_token_uses_fail_fast_rate_limit_backoff(monkeypatch):
     import asyncio
     from unittest.mock import AsyncMock, patch
 
-    from agent_bom.scanners.ghsa_advisory import _GHSA_RATE_LIMIT_BACKOFF, check_github_advisories
+    from agent_bom.scanners.ghsa_advisory import _GHSA_SINGLE_PACKAGE_RATE_LIMIT_BACKOFF, check_github_advisories
 
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("GH_TOKEN", raising=False)
@@ -260,7 +260,7 @@ def test_multi_package_scan_preserves_ghsa_rate_limit_backoff(monkeypatch):
 
     assert count == 0
     assert mock_fetch.await_count == 2
-    assert {call.kwargs["rate_limit_backoff"] for call in mock_fetch.await_args_list} == {_GHSA_RATE_LIMIT_BACKOFF}
+    assert {call.kwargs["rate_limit_backoff"] for call in mock_fetch.await_args_list} == {_GHSA_SINGLE_PACKAGE_RATE_LIMIT_BACKOFF}
 
 
 def test_advisory_filtered_by_package_name():

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -163,6 +163,23 @@ class TestBuildUnifiedGraphFromReport:
         assert g.has_edge("server:device-a:claude-desktop:team-chat-server", "pkg:npm:axios@1.4.0")
         assert g.has_edge("server:device-b:claude-desktop:team-chat-server", "pkg:npm:axios@1.4.0")
 
+    def test_agent_source_id_colons_do_not_collide_with_graph_id_segments(self):
+        report = {
+            "agents": [
+                {
+                    "name": "claude-desktop",
+                    "source_id": "device:prod",
+                    "mcp_servers": [],
+                },
+            ],
+        }
+
+        g = build_unified_graph_from_report(report)
+
+        assert "agent:device%3Aprod:claude-desktop" in g.nodes
+        assert "agent:device:prod:claude-desktop" not in g.nodes
+        assert g.nodes["agent:device%3Aprod:claude-desktop"].attributes["source_id"] == "device:prod"
+
     def test_provider_nodes_and_hosts_edges(self):
         g = build_unified_graph_from_report(_minimal_report())
         providers = g.nodes_by_type(EntityType.PROVIDER)


### PR DESCRIPTION
## Summary

Fixes the concrete v0.84.0 post-release audit findings:

- fail closed when gateway API key store status or verification fails
- prevent slow post-publish image self-scan from delaying GitHub Release creation
- cover and update stale release-version references in site docs
- make unauthenticated GHSA enrichment fail fast on rate limits instead of sleeping repeatedly
- escape graph agent source IDs so colon-bearing source IDs cannot collide
- restore normal GitHub Pages deployments while keeping release workflow docs validation non-deploying

## Root Cause

The gateway auth path treated unexpected key-store failures as equivalent to no configured keys. Release consistency checks missed several site-doc examples. GHSA enrichment used the full unauthenticated rate-limit backoff across multi-package scans. GitHub Pages deploys were skipped on normal docs workflow runs because the reusable-workflow input condition also applied to push/manual events.

## Validation

- `uv run pytest tests/test_gateway_server.py`
- `uv run pytest tests/test_graph_builder.py`
- `uv run pytest tests/test_ghsa_advisory.py`
- `uv run python scripts/check_release_consistency.py`
- `uv run ruff check src/agent_bom/gateway_server.py src/agent_bom/scanners/ghsa_advisory.py src/agent_bom/graph/builder.py tests/test_gateway_server.py tests/test_ghsa_advisory.py tests/test_graph_builder.py scripts/check_release_consistency.py`
- `uv run python -c 'import yaml; from pathlib import Path; yaml.safe_load(Path(".github/workflows/docs.yml").read_text()); yaml.safe_load(Path(".github/workflows/release.yml").read_text()); print("workflow yaml parsed")'`
- `git diff --check`
