### PR TITLE
Fix CLI policy help and incomplete-scan posture

### DIFF
--- a/src/agent_bom/cli/_policy_group.py
+++ b/src/agent_bom/cli/_policy_group.py
@@ -2,9 +2,10 @@
 
 Usage::
 
-    agent-bom policy check report.json   # evaluate report against policy
-    agent-bom policy template            # generate starter policy file
-    agent-bom policy apply <scan.json>   # apply remediation fixes
+    agent-bom agents --policy policy.json     # evaluate scan results against policy
+    agent-bom policy check pip flask 2.0.0    # pre-install package guard
+    agent-bom policy template                 # generate starter policy file
+    agent-bom policy apply <scan.json>        # apply remediation fixes
 """
 
 from __future__ import annotations
@@ -15,13 +16,17 @@ import click
 @click.group("policy", invoke_without_command=True)
 @click.pass_context
 def policy_group(ctx: click.Context) -> None:
-    """Policy management — checks, templates, and remediation.
+    """Policy management — install guards, templates, and remediation.
 
     \b
     Subcommands:
-      check       Evaluate a report against policy rules
+      check       Pre-install package guard for pip/npm/npx packages
       template    Generate a starter policy file with common rules
       apply       Apply remediation fixes from scan result JSON
+
+    \b
+    Report policy gates run through:
+      agent-bom agents --policy PATH
     """
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -152,6 +152,10 @@ def _exit_incomplete_scan_with_partial_summary(
         blast_radii=[],
         findings=blocklist_findings_for_agents(agents),
         scan_sources=["agent_discovery"],
+        scan_performance_data={
+            "coverage_state": "incomplete",
+            "coverage_reason": str(exc),
+        },
     )
     ctx.con.print(f"  [yellow]⚠[/yellow] {exc}")
     if output_format == "console" and not output and not quiet:

--- a/src/agent_bom/output/compact.py
+++ b/src/agent_bom/output/compact.py
@@ -97,8 +97,12 @@ def print_compact_summary(report: AIBOMReport) -> None:
         sev_counts[str(finding.severity).upper()] += 1
 
     scorecard = compute_posture_scorecard(report)
+    coverage = report.scan_performance_data or {}
+    coverage_incomplete = coverage.get("coverage_state") == "incomplete"
     high_risk_policy_count = sev_counts.get("CRITICAL", 0) + sev_counts.get("HIGH", 0)
     scorecard_summary = scorecard.summary
+    if coverage_incomplete:
+        scorecard_summary = "scan coverage incomplete"
     if high_risk_policy_count and not active_findings:
         scorecard_summary = f"{high_risk_policy_count} high-risk policy/security finding(s) present"
     preferred_driver_order = [
@@ -124,7 +128,10 @@ def print_compact_summary(report: AIBOMReport) -> None:
             if len(weak_dimensions) >= 2:
                 break
 
-    if report.total_vulnerabilities == 0 and not policy_findings:
+    if coverage_incomplete:
+        posture = "[bold black on yellow] PARTIAL COVERAGE [/bold black on yellow]"
+        border_style = "yellow"
+    elif report.total_vulnerabilities == 0 and not policy_findings:
         posture = "[bold white on green] CLEAN [/bold white on green]"
         border_style = "green"
     else:

--- a/src/agent_bom/output/console_render.py
+++ b/src/agent_bom/output/console_render.py
@@ -217,6 +217,9 @@ def print_posture_summary(report: AIBOMReport) -> None:
     """Print a high-level security posture summary with ecosystem and credential aggregation."""
     from collections import Counter
 
+    coverage = report.scan_performance_data or {}
+    coverage_incomplete = coverage.get("coverage_state") == "incomplete"
+
     # Aggregate agent status counts
     configured = sum(1 for a in report.agents if a.status == AgentStatus.CONFIGURED)
     not_configured = sum(1 for a in report.agents if a.status == AgentStatus.INSTALLED_NOT_CONFIGURED)
@@ -259,7 +262,10 @@ def print_posture_summary(report: AIBOMReport) -> None:
             sev_counts[br.vulnerability.severity.value.upper()] += 1
 
     # Posture headline
-    if report.total_vulnerabilities == 0:
+    if coverage_incomplete:
+        posture = "[bold yellow]PARTIAL COVERAGE[/bold yellow]"
+        border_style = "yellow"
+    elif report.total_vulnerabilities == 0:
         posture = "[bold green]CLEAN[/bold green]"
         border_style = "green"
     elif sev_counts.get("CRITICAL", 0) > 0:
@@ -280,6 +286,9 @@ def print_posture_summary(report: AIBOMReport) -> None:
     # Build the panel content
     lines: list[str] = []
     lines.append(f"  [bold]SECURITY POSTURE:[/bold]  {posture}")
+    if coverage_incomplete:
+        reason = str(coverage.get("coverage_reason") or "scan coverage incomplete")
+        lines.append(f"  [yellow]Coverage[/yellow]          {reason}")
     lines.append("")
 
     # Agent summary

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -294,6 +294,15 @@ class TestNoDuplication:
         check_cmd = policy.get_command(None, "check") if policy else None
         assert check_cmd is not None
 
+    def test_policy_group_help_describes_check_as_install_guard(self):
+        from agent_bom.cli import main
+
+        r = CliRunner().invoke(main, ["policy", "--help"])
+
+        assert r.exit_code == 0
+        assert "Pre-install package guard" in r.output
+        assert "agent-bom agents --policy PATH" in r.output
+
     def test_aws_cmd_is_same_object(self):
         """aws_cmd registered on both cloud module and cloud_group must be the same object."""
         from agent_bom.cli._cloud_group import aws_cmd as group_aws

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -362,6 +362,8 @@ def test_scan_incomplete_offline_scan_exits_two(monkeypatch):
     assert result.exit_code == 2
     assert "populated local vulnerability DB" in result.output
     assert "SECURITY POSTURE" in result.output
+    assert "PARTIAL COVERAGE" in result.output
+    assert "CLEAN" not in result.output
     assert "Agents" in result.output
 
 


### PR DESCRIPTION
## Summary

Closes #2130.
Closes #2129.

- Correct `agent-bom policy --help` so `policy check` is described as the pre-install package guard, not a report-policy evaluator.
- Point report policy gates to the actual supported flow: `agent-bom agents --policy PATH`.
- Mark incomplete scan reports with explicit coverage metadata.
- Render incomplete/offline coverage as `PARTIAL COVERAGE` instead of `CLEAN` in compact and verbose posture summaries.


## Validation

- `uv run pytest tests/test_cli_entry_points.py::TestNoDuplication::test_policy_group_help_describes_check_as_install_guard tests/test_cli_entry_points.py::TestNoDuplication::test_policy_check_is_guard`
- `uv run pytest tests/test_cli_scan.py::test_scan_incomplete_offline_scan_exits_two`
- `uv run pytest tests/test_cli_entry_points.py tests/test_cli_scan.py tests/test_output_summary.py tests/test_compact_output.py`
- `uv run ruff check src/agent_bom/cli/_policy_group.py src/agent_bom/cli/agents/__init__.py src/agent_bom/output/console_render.py src/agent_bom/output/compact.py tests/test_cli_entry_points.py tests/test_cli_scan.py`
- `git diff --check`