### PR TITLE
Score external scanner advisory confidence

### DIFF
--- a/src/agent_bom/parsers/external_scanners.py
+++ b/src/agent_bom/parsers/external_scanners.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from agent_bom.models import Package, Severity, Vulnerability
+from agent_bom.models import Package, Severity, Vulnerability, compute_confidence
 
 logger = logging.getLogger(__name__)
 
@@ -173,6 +173,7 @@ def parse_trivy_json(data: dict[str, Any]) -> list[Package]:
                 cwe_ids=_cwe_ids(vuln.get("CweIDs")),
                 advisory_sources=[advisory_source] if advisory_source else [],
             )
+            vuln_obj.confidence = compute_confidence(vuln_obj)
             # Avoid duplicate vuln IDs on the same package
             existing_ids = {v.id for v in pkg.vulnerabilities}
             if vuln_obj.id not in existing_ids:
@@ -248,6 +249,7 @@ def parse_grype_json(data: dict[str, Any]) -> list[Package]:
             cwe_ids=_cwe_ids(vuln_data.get("cwes")),
             advisory_sources=[advisory_source] if advisory_source else [],
         )
+        vuln_obj.confidence = compute_confidence(vuln_obj)
         existing_ids = {v.id for v in pkg.vulnerabilities}
         if vuln_obj.id not in existing_ids:
             pkg.vulnerabilities.append(vuln_obj)

--- a/tests/test_external_scanners.py
+++ b/tests/test_external_scanners.py
@@ -160,6 +160,13 @@ def test_parse_trivy_fixed_version():
     assert packages[0].vulnerabilities[0].fixed_version == "2.31.0"
 
 
+def test_parse_trivy_confidence_uses_preserved_fields():
+    packages = parse_trivy_json(TRIVY_BASIC)
+    vuln = packages[0].vulnerabilities[0]
+
+    assert vuln.confidence == pytest.approx(0.35)
+
+
 def test_parse_trivy_empty_results():
     packages = parse_trivy_json(TRIVY_EMPTY)
     assert packages == []
@@ -233,6 +240,7 @@ def test_parse_trivy_preserves_advisory_metadata():
     assert vuln.published_at == "2024-01-02T03:04:05Z"
     assert vuln.modified_at == "2024-01-03T03:04:05Z"
     assert vuln.advisory_sources == ["ghsa"]
+    assert vuln.confidence == pytest.approx(0.30)
 
 
 # ── Grype tests ────────────────────────────────────────────────────────────
@@ -271,6 +279,13 @@ def test_parse_grype_empty_matches():
 def test_parse_grype_cvss_score():
     packages = parse_grype_json(GRYPE_BASIC)
     assert packages[0].vulnerabilities[0].cvss_score == 8.1
+
+
+def test_parse_grype_confidence_uses_preserved_fields():
+    packages = parse_grype_json(GRYPE_BASIC)
+    vuln = packages[0].vulnerabilities[0]
+
+    assert vuln.confidence == pytest.approx(0.35)
 
 
 def test_parse_grype_unfixed_no_fixed_version():
@@ -331,6 +346,7 @@ def test_parse_grype_preserves_advisory_metadata():
     assert vuln.published_at == "2024-02-02T00:00:00Z"
     assert vuln.modified_at == "2024-02-03T00:00:00Z"
     assert vuln.advisory_sources == ["github:language:python"]
+    assert vuln.confidence == pytest.approx(0.30)
 
 
 # ── Syft tests ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #2076.

- Compute canonical vulnerability confidence for Trivy and Grype imported findings after preserving scanner advisory metadata.
- Add regression coverage that confidence uses CVSS/fix metadata and preserved severity/CWE metadata.

## Validation

- `uv run pytest tests/test_external_scanners.py tests/test_confidence.py`
- `uv run ruff check src/agent_bom/parsers/external_scanners.py tests/test_external_scanners.py`
- `git diff --check`
