### PR TITLE
Fix CLI drift and no-token GHSA guard

### DIFF
--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -121,6 +121,7 @@ so they cannot regress silently, but they are not part of this reference.
 ## Scanner Batching
 | Env var | Type | Default | Description |
 |---|---|---|---|
+| `AGENT_BOM_GHSA_UNAUTH_PACKAGE_BUDGET` | `int` | `25` | Cap unauthenticated GHSA advisory lookups so no-token scans fail fast with partial coverage instead of spending minutes on GitHub rate limits. |
 | `AGENT_BOM_SCANNER_BATCH_DELAY` | `float` | `0.5` | — |
 | `AGENT_BOM_SCANNER_BATCH_SIZE` | `int` | `1000` | OSV API max is 1000 |
 | `AGENT_BOM_SCANNER_MAX_CONCURRENT` | `int` | `10` | Used by scanners/__init__.py for OSV batch API concurrency.  10 concurrent requests with 500ms delay between batches keeps us well under OSV.dev's rate limit while still being fast for large inventories. |

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -2,27 +2,76 @@
 
 ## Commands
 
+### Scanning
+
 | Command | Description |
 |---------|-------------|
-| `agents` | Discover MCP clients + scan for vulnerabilities |
-| `check` | Check a specific package for CVEs |
+| `agents` | Discover MCP clients, extract dependencies, scan packages, and compute blast radius |
+| `skills` | Scan, verify, and rescan AI instruction files and skills |
+| `image` | Scan a container image |
+| `fs` | Scan a filesystem directory or mounted VM disk snapshot |
+| `iac` | Scan Dockerfile, Kubernetes, Terraform, CloudFormation, and live Kubernetes posture |
+| `sbom` | Ingest an existing CycloneDX or SPDX SBOM and scan it |
+| `cloud` | Scan AWS, Azure, or GCP infrastructure posture |
+| `check` | Check one package before install or approval |
 | `verify` | Verify package integrity / provenance or self-verify `agent-bom` |
-| `where` | Show MCP discovery paths checked on this machine |
-| `image` | Container image scan |
-| `fs` | Filesystem / VM scan |
-| `iac` | Infrastructure-as-code misconfigurations |
-| `mcp` | Discover, scan, and manage MCP agents |
-| `mcp server` | Start MCP server (stdio) |
-| `cloud` | Cloud posture + CIS benchmarks |
-| `runtime proxy` | Runtime MCP proxy with enforcement |
-| `runtime protect` | 7-detector anomaly engine |
-| `runtime watch` | Config file change monitoring |
+| `secrets` | Scan a directory for hardcoded secrets and PII |
+| `code` | Analyze source code for AI components, prompts, guardrails, and tools |
+
+### Runtime
+
+| Command | Description |
+|---------|-------------|
+| `proxy` | Run an MCP server through the agent-bom security proxy |
+| `audit` | View and analyze a proxy audit JSONL log |
+
+### MCP
+
+| Command | Description |
+|---------|-------------|
+| `mcp` | Discover, scan, and manage MCP agents and servers |
+| `mcp inventory` | Discover MCP agents and servers without CVE scanning |
+| `mcp scan` | Check a single MCP server package or npx/uvx spec |
+| `mcp introspect` | Connect to live servers and list tools |
+| `mcp registry` | Browse and manage the MCP server security registry |
+| `mcp server` | Start agent-bom as an MCP server over stdio |
+| `mcp where` | Show MCP discovery paths checked on this machine |
+| `mcp validate` | Validate an MCP/client inventory file |
+| `where` | Top-level shortcut for MCP discovery paths |
+
+### Reporting
+
+| Command | Description |
+|---------|-------------|
+| `graph` | Export the transitive dependency graph from a scan report |
+| `mesh` | Show lightweight agent/MCP topology without CVE scanning |
+| `report` | History, diff, analytics, dashboard, and compliance narrative workflows |
+
+### Governance And Operations
+
+| Command | Description |
+|---------|-------------|
+| `policy` | Policy templates, application, and install-guard checks |
+| `trust` | Show data access, network, auth, and storage boundaries |
+| `fleet` | Manage AI agent fleet discovery, lifecycle, and posture |
+| `serve` | Start the API server and dashboard |
+| `api` | Start the REST API server |
+| `schedule` | Manage recurring scan schedules |
 | `remediate` | Generate a prioritized remediation plan |
-| `report` | History, diff, analytics, dashboard |
-| `policy` | Templates and remediation |
-| `serve` | Start REST API server |
-| `guard` | Pre-install CVE check |
-| `registry` | Registry management (list, search, update) |
+| `teardown` | Tear down the AWS/EKS reference install owned by agent-bom |
+
+### Database And Utilities
+
+| Command | Description |
+|---------|-------------|
+| `db` | Manage the local vulnerability database |
+| `doctor` | Check environment readiness for scanning |
+| `gateway` | Multi-MCP gateway commands |
+| `proxy-bootstrap` | Generate managed endpoint onboarding material |
+| `samples` | Create bundled sample inputs for demos and first runs |
+| `sidecar-injector` | Run the TLS admission webhook for sidecar injection |
+| `upgrade` | Check for and install the latest version of agent-bom |
+| `completions` | Print a shell completion script |
 
 ## Command contracts
 

--- a/src/agent_bom/cli/_focused_commands.py
+++ b/src/agent_bom/cli/_focused_commands.py
@@ -177,7 +177,7 @@ def iac_cmd(
 
 
 @click.command("sbom")
-@click.argument("path")
+@click.argument("path", type=click.Path(exists=True, dir_okay=False, readable=True))
 @click.option("--name", "sbom_name", help="Label for the SBOM resource")
 @click.option("-f", "--format", "output_format", default="console", help="Output format")
 @click.option("-o", "--output", "output_path", help="Output file path")

--- a/src/agent_bom/cli/_mcp_group.py
+++ b/src/agent_bom/cli/_mcp_group.py
@@ -52,6 +52,9 @@ def mcp_scan_cmd(server_spec: str, ecosystem: str | None, quiet: bool, no_color:
     """Check a single MCP server package or npx/uvx spec before adding it."""
     from agent_bom.cli._check import check
 
+    if not server_spec.strip():
+        raise click.UsageError("MCP server package spec cannot be empty.")
+
     callback = check.callback
     if callback is None:
         raise click.ClickException("check command is unavailable")

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -183,6 +183,9 @@ CLOUD_DISCOVERY_TIMEOUT = _float("AGENT_BOM_CLOUD_DISCOVERY_TIMEOUT", 45.0)
 SCANNER_MAX_CONCURRENT = _int("AGENT_BOM_SCANNER_MAX_CONCURRENT", 10)
 SCANNER_BATCH_DELAY = _float("AGENT_BOM_SCANNER_BATCH_DELAY", 0.5)
 SCANNER_BATCH_SIZE = _int("AGENT_BOM_SCANNER_BATCH_SIZE", 1000)  # OSV API max is 1000
+# Cap unauthenticated GHSA advisory lookups so no-token scans fail fast
+# with partial coverage instead of spending minutes on GitHub rate limits.
+GHSA_UNAUTH_PACKAGE_BUDGET = _int("AGENT_BOM_GHSA_UNAUTH_PACKAGE_BUDGET", 25)
 
 
 # ── Scan Cache ────────────────────────────────────────────────────────────────

--- a/src/agent_bom/scanners/ghsa_advisory.py
+++ b/src/agent_bom/scanners/ghsa_advisory.py
@@ -14,6 +14,7 @@ import time
 
 import httpx
 
+from agent_bom.config import GHSA_UNAUTH_PACKAGE_BUDGET as _CONFIG_GHSA_UNAUTH_PACKAGE_BUDGET
 from agent_bom.enrichment_posture import record_enrichment_source
 from agent_bom.http_client import create_client, request_with_retry
 from agent_bom.models import Package, Severity, Vulnerability
@@ -48,6 +49,10 @@ class GHSARateLimitError(RuntimeError):
 
 def _github_token() -> str:
     return os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN") or ""
+
+
+def _unauthenticated_package_budget() -> int:
+    return max(0, int(_CONFIG_GHSA_UNAUTH_PACKAGE_BUDGET))
 
 
 def _ghsa_headers() -> dict[str, str]:
@@ -294,12 +299,30 @@ async def check_github_advisories(
     if max_packages is not None:
         queryable = queryable[:max_packages]
 
-    logger.info("GHSA advisory check for %d packages", len(queryable))
     github_token_available = bool(_github_token())
     if not github_token_available:
+        if max_packages is None:
+            unauth_budget = _unauthenticated_package_budget()
+            if len(queryable) > unauth_budget:
+                skipped = len(queryable) - unauth_budget
+                queryable = queryable[:unauth_budget]
+                from agent_bom.scanners.state import record_scan_warning
+
+                warning = (
+                    "GHSA advisory enrichment limited to "
+                    f"{unauth_budget} unauthenticated package lookup(s); skipped {skipped}. "
+                    "Set GITHUB_TOKEN or GH_TOKEN for full GHSA coverage."
+                )
+                logger.warning(warning)
+                record_scan_warning(warning)
         logger.warning(
             "GITHUB_TOKEN/GH_TOKEN is not set; GHSA advisory enrichment will fail fast on GitHub rate limits instead of pausing."
         )
+    if not queryable:
+        record_enrichment_source("ghsa", "failure", error="unauthenticated package budget disabled GHSA lookups")
+        return 0
+
+    logger.info("GHSA advisory check for %d packages", len(queryable))
 
     # Build a reverse lookup: all packages sharing the same name+ecosystem
     pkg_groups: dict[str, list[Package]] = {}

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -140,6 +140,20 @@ def test_mcp_scan_delegates_to_package_check(monkeypatch):
     assert "No known vulnerabilities" in result.output
 
 
+def test_mcp_scan_empty_spec_is_usage_error():
+    result = CliRunner().invoke(main, ["mcp", "scan", ""])
+
+    assert result.exit_code == 2
+    assert "cannot be empty" in result.output
+
+
+def test_sbom_missing_file_is_usage_error():
+    result = CliRunner().invoke(main, ["sbom", "/missing.json"])
+
+    assert result.exit_code == 2
+    assert "does not exist" in result.output
+
+
 def test_check_quiet_suppresses_scan_chatter(monkeypatch):
     async def _scan_packages(pkgs, **_kwargs):
         import agent_bom.scanners as scanners

--- a/tests/test_ghsa_advisory.py
+++ b/tests/test_ghsa_advisory.py
@@ -263,6 +263,39 @@ def test_multi_package_without_github_token_uses_fail_fast_rate_limit_backoff(mo
     assert {call.kwargs["rate_limit_backoff"] for call in mock_fetch.await_args_list} == {_GHSA_SINGLE_PACKAGE_RATE_LIMIT_BACKOFF}
 
 
+def test_without_github_token_applies_package_budget(monkeypatch):
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    from agent_bom.scanners.ghsa_advisory import _GHSA_SINGLE_PACKAGE_RATE_LIMIT_BACKOFF, check_github_advisories
+    from agent_bom.scanners.state import consume_scan_warnings, reset_scan_warnings
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setattr("agent_bom.scanners.ghsa_advisory._CONFIG_GHSA_UNAUTH_PACKAGE_BUDGET", 2)
+    reset_scan_warnings()
+    packages = [
+        Package(name="express", version="4.17.1", ecosystem="npm"),
+        Package(name="lodash", version="4.17.20", ecosystem="npm"),
+        Package(name="requests", version="2.31.0", ecosystem="pypi"),
+    ]
+
+    async def run():
+        with patch("agent_bom.scanners.ghsa_advisory._fetch_advisories_for_package", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = []
+            count = await check_github_advisories(packages)
+            return count, mock_fetch
+
+    count, mock_fetch = asyncio.run(run())
+
+    assert count == 0
+    assert mock_fetch.await_count == 2
+    assert {call.args[0].name for call in mock_fetch.await_args_list} == {"express", "lodash"}
+    assert {call.kwargs["rate_limit_backoff"] for call in mock_fetch.await_args_list} == {_GHSA_SINGLE_PACKAGE_RATE_LIMIT_BACKOFF}
+    warnings = consume_scan_warnings()
+    assert any("GHSA advisory enrichment limited to 2 unauthenticated package lookup(s); skipped 1" in item for item in warnings)
+
+
 def test_advisory_filtered_by_package_name():
     """Advisories for different packages are filtered out (substring match fix).
 

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -58,6 +58,15 @@ def test_documented_primary_commands_are_real_cli_surfaces() -> None:
         assert result.exit_code == 0, f"agent-bom {' '.join(command)} failed:\n{result.output}"
 
 
+def test_cli_reference_lists_all_visible_root_commands() -> None:
+    cli_reference = (ROOT / "site-docs" / "reference" / "cli.md").read_text(encoding="utf-8")
+    visible_commands = sorted(name for name, command in main.commands.items() if not getattr(command, "hidden", False))
+
+    missing = [name for name in visible_commands if f"| `{name}` |" not in cli_reference]
+
+    assert missing == []
+
+
 def test_public_docs_do_not_overclaim_smithery_catalog_liveness() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     smithery_doc = (ROOT / "site-docs" / "integrations" / "smithery.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- cap unauthenticated GHSA advisory enrichment and emit a scan warning with the GITHUB_TOKEN/GH_TOKEN remediation path
- make empty `mcp scan` input and missing `sbom` files usage errors with exit code 2
- refresh the CLI reference for the grouped 30+ command surface and add a docs-alignment test so future visible root commands cannot silently drift from docs

## Why
The v0.84.0 hands-on audit found CLI docs drift and a few exit-code contract mismatches. The no-token GHSA path is now fast-fail/capped so API/dashboard scans do not get dominated by GitHub advisory rate limits when no token is configured.

## Validation
- `uv run pytest tests/test_ghsa_advisory.py tests/test_cli_check.py tests/test_public_docs_cli_alignment.py tests/test_cli_exit_contract_docs.py -q`
- `uv run ruff check src/agent_bom/scanners/ghsa_advisory.py src/agent_bom/cli/_mcp_group.py src/agent_bom/cli/_focused_commands.py tests/test_ghsa_advisory.py tests/test_cli_check.py tests/test_public_docs_cli_alignment.py`
- `git diff --check`
