### PR TITLE
Fix graph export and malformed input follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.84.1] – 2026-05-01
+
+### Fixed
+- **Graph export parity** — CLI Cytoscape, Graph HTML, Mermaid, GraphML, Cypher, and API graph paths now surface conservative credential → tool `reaches_tool` evidence consistently.
+- **CLI error contracts** — listener ports now reject privileged or invalid values before socket bind, and malformed inventory, VEX, policy, and ignore files fail loudly with actionable parser messages instead of raw tracebacks or silent skips.
+- **Delta gate artifact consistency** — delta-mode filtering now happens before report rendering so JSON/SARIF artifacts and CI exit gates reflect the same new-only finding set.
+- **UI E2E production parity** — Playwright now runs against a staged standalone bundle that mirrors the container runtime, preventing hydration checks from passing only in dev mode.
+
+---
+
 ## [0.84.0] – 2026-04-30
 
 ### Added

--- a/src/agent_bom/cli/_analysis.py
+++ b/src/agent_bom/cli/_analysis.py
@@ -470,8 +470,8 @@ def introspect_cmd(server_command, server_url, timeout, introspect_all, baseline
     baseline: dict[str, list[str]] = {}
     if baseline_path:
         try:
-            baseline = _json.loads(Path(baseline_path).read_text())
-        except Exception as e:  # noqa: BLE001
+            baseline = read_json_file_for_cli(baseline_path, label="baseline file")
+        except click.ClickException as e:
             con.print(f"[yellow]Warning: could not load baseline: {e}[/yellow]")
 
     # Introspect

--- a/src/agent_bom/cli/_common.py
+++ b/src/agent_bom/cli/_common.py
@@ -29,6 +29,7 @@ BANNER = r"""
 
 SEVERITY_ORDER = {"critical": 4, "high": 3, "medium": 2, "low": 1, "none": 0, "unknown": -1}
 PORT_RANGE = click.IntRange(1, 65535)
+LISTEN_PORT_RANGE = click.IntRange(1024, 65535)
 OPTIONAL_PORT_RANGE = click.IntRange(0, 65535)
 
 

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 
 import click
 
-from agent_bom.cli._common import PORT_RANGE
+from agent_bom.cli._common import LISTEN_PORT_RANGE
 
 
 def _is_loopback_host(host: str) -> bool:
@@ -193,7 +193,7 @@ def _analytics_summary_rows(
     show_default=True,
     help="Host to bind to (non-loopback requires --api-key / OIDC or --allow-insecure-no-auth).",
 )
-@click.option("--port", default=8422, show_default=True, type=PORT_RANGE, help="API server port")
+@click.option("--port", default=8422, show_default=True, type=LISTEN_PORT_RANGE, help="API server port")
 @click.option("--persist", default=None, metavar="DB_PATH", help="Enable persistent job storage via SQLite (e.g. --persist jobs.db).")
 @click.option("--cors-allow-all", is_flag=True, default=False, help="Allow all CORS origins (dev mode).")
 @click.option(
@@ -365,7 +365,7 @@ def serve_cmd(
     show_default=True,
     help="Host to bind to (non-loopback requires --api-key / OIDC or --allow-insecure-no-auth).",
 )
-@click.option("--port", default=8422, show_default=True, type=PORT_RANGE, help="Port to listen on")
+@click.option("--port", default=8422, show_default=True, type=LISTEN_PORT_RANGE, help="Port to listen on")
 @click.option("--reload", is_flag=True, help="Auto-reload on code changes (development mode)")
 @click.option("--workers", default=1, show_default=True, help="Number of worker processes")
 @click.option("--cors-origins", default=None, metavar="ORIGINS", help="Comma-separated CORS origins (default: localhost:3000).")
@@ -582,7 +582,7 @@ def api_cmd(
     show_default=True,
     help="MCP transport protocol.",
 )
-@click.option("--port", default=8423, show_default=True, type=PORT_RANGE, help="Port for HTTP/SSE transport.")
+@click.option("--port", default=8423, show_default=True, type=LISTEN_PORT_RANGE, help="Port for HTTP/SSE transport.")
 @click.option("--host", default="127.0.0.1", show_default=True, help="Host for HTTP/SSE transport.")
 @click.option(
     "--bearer-token",

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -489,6 +489,36 @@ def scan(
 
     _out.console = con
 
+    _validated_ignore_entries: list[dict[str, Any]] | None = None
+    if policy:
+        from agent_bom.policy import load_policy as _load_policy_for_validation
+
+        try:
+            _load_policy_for_validation(policy)
+        except (FileNotFoundError, ValueError) as exc:
+            raise click.ClickException(f"Policy error: {exc}") from exc
+    if ignore_file:
+        from agent_bom.ignores import load_ignore_file as _load_ignore_file_for_validation
+
+        try:
+            _validated_ignore_entries = _load_ignore_file_for_validation(ignore_file)
+        except ValueError as exc:
+            raise click.ClickException(str(exc)) from exc
+    if vex_path:
+        from agent_bom.vex import load_vex as _load_vex_for_validation
+
+        try:
+            _load_vex_for_validation(vex_path)
+        except ValueError as exc:
+            raise click.ClickException(str(exc)) from exc
+    if baseline:
+        from agent_bom.scan_delta import load_baseline as _load_baseline_for_validation
+
+        try:
+            _load_baseline_for_validation(baseline)
+        except (FileNotFoundError, ValueError) as exc:
+            raise click.ClickException(f"Baseline error: {exc}") from exc
+
     if demo:
         con.print("\n[bold yellow]Demo mode[/bold yellow] — curated agent + MCP sample with known-vulnerable packages.\n")
 
@@ -2025,7 +2055,10 @@ def scan(
     # Apply ignore/allowlist file (.agent-bom-ignore.yaml or --ignore-file)
     from agent_bom.ignores import apply_ignores, load_ignore_file
 
-    _ignore_entries = load_ignore_file(ignore_file)
+    try:
+        _ignore_entries = _validated_ignore_entries if _validated_ignore_entries is not None else load_ignore_file(ignore_file)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
     if _ignore_entries:
         blast_radii, _suppressed = apply_ignores(blast_radii, _ignore_entries)
         if _suppressed and not quiet:
@@ -2052,6 +2085,62 @@ def scan(
     # Attach blast_radii and report to context for downstream phases
     ctx.blast_radii = blast_radii
     ctx.report = report
+
+    current_report_json = to_json(report)
+
+    # Step 4h: Delta mode must run before rendering so JSON/SARIF artifacts
+    # and CI exit gates both reflect the same new-only finding set.
+    if delta_mode:
+        from agent_bom.scan_delta import compute_delta, load_baseline
+
+        _baseline_path = baseline
+        if not _baseline_path:
+            from agent_bom.scan_delta import _DEFAULT_BASELINE_PATH
+
+            if _DEFAULT_BASELINE_PATH.exists():
+                _baseline_path = str(_DEFAULT_BASELINE_PATH)
+            else:
+                logger.warning(
+                    "Delta mode requested but no --baseline file specified and no auto-baseline found at %s. Skipping delta filter.",
+                    _DEFAULT_BASELINE_PATH,
+                )
+
+        if _baseline_path:
+            try:
+                _baseline_data = load_baseline(_baseline_path)
+                _delta_result = compute_delta(current_report_json, _baseline_data)
+                _delta_result.baseline_path = _baseline_path
+                ctx.delta_result = _delta_result
+                report.delta_data = {
+                    "enabled": True,
+                    "new_count": _delta_result.new_count,
+                    "pre_existing_count": _delta_result.pre_existing_count,
+                    "baseline_path": _baseline_path,
+                }
+
+                _new_keys = {(d.get("vulnerability_id", "").upper(), d.get("package", "")) for d in _delta_result.new_items}
+                blast_radii = [
+                    br for br in blast_radii if (br.vulnerability.id.upper(), f"{br.package.name}@{br.package.version}") in _new_keys
+                ]
+                report.blast_radii = blast_radii
+                if report.findings:
+                    from agent_bom.finding import FindingType
+
+                    _new_cve_ids = {d.get("vulnerability_id", "").upper() for d in _delta_result.new_items}
+                    report.findings = [
+                        finding
+                        for finding in report.findings
+                        if finding.finding_type != FindingType.CVE or str(finding.cve_id or "").upper() in _new_cve_ids
+                    ]
+                ctx.blast_radii = blast_radii
+                current_report_json = to_json(report)
+
+                if not quiet:
+                    from rich.console import Console as _Console
+
+                    _Console().print(f"\n[bold]Delta:[/bold] {_delta_result.summary_line()} (baseline: {_baseline_path})\n")
+            except (FileNotFoundError, ValueError) as exc:
+                logger.warning("Delta baseline error: %s — skipping delta filter", exc)
 
     # Step 5: Output
     _step_t0 = _time.monotonic()
@@ -2082,7 +2171,6 @@ def scan(
         return
 
     # Step 6: Save report to history + asset tracking
-    current_report_json = to_json(report)
     if save_report:
         from agent_bom.history import save_report as _save
 
@@ -2112,43 +2200,12 @@ def scan(
 
     # Step 7: Diff against baseline
     if baseline:
-        from agent_bom.history import diff_reports, load_report
+        from agent_bom.history import diff_reports
+        from agent_bom.scan_delta import load_baseline
 
-        baseline_data = load_report(Path(baseline))
+        baseline_data = load_baseline(Path(baseline))
         diff = diff_reports(baseline_data, current_report_json)
         print_diff(diff)
-
-    # Step 7a: Delta mode — exit code based on new findings only
-    if delta_mode:
-        from agent_bom.scan_delta import compute_delta, load_baseline
-
-        _baseline_path = baseline
-        if not _baseline_path:
-            from agent_bom.scan_delta import _DEFAULT_BASELINE_PATH
-
-            if _DEFAULT_BASELINE_PATH.exists():
-                _baseline_path = str(_DEFAULT_BASELINE_PATH)
-            else:
-                logger.warning(
-                    "Delta mode requested but no --baseline file specified and no auto-baseline found at %s. Skipping delta filter.",
-                    _DEFAULT_BASELINE_PATH,
-                )
-
-        if _baseline_path:
-            try:
-                _baseline_data = load_baseline(_baseline_path)
-                _delta_result = compute_delta(current_report_json, _baseline_data)
-                _delta_result.baseline_path = _baseline_path
-                ctx.delta_result = _delta_result
-                if not quiet:
-                    from rich.console import Console as _Console
-
-                    _Console().print(f"\n[bold]Delta:[/bold] {_delta_result.summary_line()} (baseline: {_baseline_path})\n")
-                from agent_bom.scan_delta import apply_delta_to_scan
-
-                current_report_json = apply_delta_to_scan(current_report_json, _delta_result)
-            except (FileNotFoundError, ValueError) as exc:
-                logger.warning("Delta baseline error: %s — skipping delta filter", exc)
 
     ctx.step_timings["output"] = _time.monotonic() - _step_t0
 

--- a/src/agent_bom/ignores.py
+++ b/src/agent_bom/ignores.py
@@ -68,16 +68,15 @@ def load_ignore_file(path: str | Path | None = None) -> list[dict[str, Any]]:
     try:
         with target.open() as fh:
             data = yaml.safe_load(fh) or {}
-    except (OSError, yaml.YAMLError) as exc:
-        logger.warning("agent-bom-ignore: failed to parse %s: %s", target, exc)
-        return []
+    except OSError as exc:
+        raise ValueError(f"Could not read ignore file {target}: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Invalid YAML in ignore file {target}: {exc}") from exc
     if not isinstance(data, dict):
-        logger.warning("agent-bom-ignore: expected mapping at top level — skipping file")
-        return []
+        raise ValueError(f"Ignore file {target} must be a YAML mapping with an 'ignores' list")
     entries = data.get("ignores", [])
     if not isinstance(entries, list):
-        logger.warning("agent-bom-ignore: 'ignores' must be a list — skipping file")
-        return []
+        raise ValueError(f"Ignore file {target} field 'ignores' must be a list")
     return entries
 
 
@@ -89,11 +88,11 @@ def _parse_minimal_yaml(path: Path) -> list[dict[str, Any]]:
         if text.strip().startswith("{") or text.strip().startswith("["):
             data = json.loads(text)
             return data.get("ignores", data) if isinstance(data, dict) else data
-    except (OSError, json.JSONDecodeError) as exc:
-        logger.warning("agent-bom-ignore: failed to parse %s without PyYAML: %s", path, exc)
-        pass
-    logger.warning("agent-bom-ignore: PyYAML not installed and file is not JSON — ignore file skipped. Install PyYAML: pip install pyyaml")
-    return []
+    except OSError as exc:
+        raise ValueError(f"Could not read ignore file {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in ignore file {path}: line {exc.lineno}, column {exc.colno}: {exc.msg}") from exc
+    raise ValueError("PyYAML is required for YAML ignore files: pip install pyyaml")
 
 
 def _entry_is_expired(entry: dict[str, Any]) -> bool:

--- a/src/agent_bom/inventory.py
+++ b/src/agent_bom/inventory.py
@@ -166,7 +166,10 @@ def _load_from_stdin() -> dict:
 
     fmt = _detect_format(content)
     if fmt == "json":
-        return _validate_inventory_payload(json.loads(content))
+        try:
+            return _validate_inventory_payload(json.loads(content))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Inventory JSON error in stdin: line {exc.lineno}, column {exc.colno}: {exc.msg}") from exc
 
     return _load_csv_inventory(io.StringIO(content))
 
@@ -181,7 +184,11 @@ def _detect_format(content: str) -> str:
 
 def _load_json_inventory(fp: io.TextIOBase) -> dict:  # type: ignore[override]
     """Parse JSON inventory from a file-like object."""
-    return _validate_inventory_payload(json.load(fp))
+    try:
+        return _validate_inventory_payload(json.load(fp))
+    except json.JSONDecodeError as exc:
+        source = getattr(fp, "name", "inventory file")
+        raise ValueError(f"Inventory JSON error in {source}: line {exc.lineno}, column {exc.colno}: {exc.msg}") from exc
 
 
 def _load_csv_inventory(fp: io.TextIOBase) -> dict:  # type: ignore[override]

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -973,6 +973,7 @@ class AIBOMReport:
     gpu_infra_data: Optional[dict] = None  # Serialized GPU/AI compute infra scan results
     iac_findings_data: Optional[dict] = None  # Serialized IaC misconfiguration findings (set by CLI)
     runtime_correlation: Optional[dict] = None  # Runtime ↔ scan correlation (proxy audit vs CVE findings)
+    delta_data: Optional[dict] = None  # Baseline/delta comparison metadata for CI gate outputs
     scan_performance_data: Optional[dict] = None  # Cache coverage / scan latency metadata
     training_pipelines: Optional[dict] = None  # Serialized TrainingPipelineScanResult
     dataset_cards: Optional[dict] = None  # Serialized DatasetScanResult

--- a/src/agent_bom/output/graph.py
+++ b/src/agent_bom/output/graph.py
@@ -102,12 +102,17 @@ def build_graph_elements(
       - ``server_intel``   — MCP server with non-blocking MCP intelligence findings
       - ``server_cred``    — MCP server with exposed credentials
       - ``server_clean``   — MCP server, no issues
+      - ``credential``  — credential reference exposed by an MCP server
+      - ``tool``        — MCP tool reachable through a server
       - ``pkg_vuln``    — vulnerable package summary
       - ``cve``         — individual CVE/advisory
 
     Edge types (in ``data.type``):
       - ``hosts``       — provider → agent
       - ``uses``        — agent → server
+      - ``exposes_cred`` — server → credential
+      - ``provides_tool`` — server → tool
+      - ``reaches_tool`` — credential → tool
       - ``depends_on``  — server → package
       - ``affects``     — package → CVE
     """
@@ -278,6 +283,72 @@ def build_graph_elements(
                     }
                 }
             )
+
+            tool_ids: list[tuple[str, str]] = []
+            for tool in srv.tools:
+                tool_id = f"tool:{agent.name}:{srv.name}:{tool.name}"
+                tool_ids.append((tool.name, tool_id))
+                elements.append(
+                    {
+                        "data": {
+                            "id": tool_id,
+                            "label": tool.name,
+                            "type": "tool",
+                            "tip": f"MCP Tool: {tool.name}\nServer: {srv.name}",
+                            "server": sid,
+                            "searchText": " ".join([tool.name, srv.name, agent.name]).lower(),
+                        }
+                    }
+                )
+                elements.append(
+                    {
+                        "data": {
+                            "source": sid,
+                            "target": tool_id,
+                            "type": "provides_tool",
+                        }
+                    }
+                )
+
+            for cred in srv.credential_names:
+                cred_id = f"cred:{agent.name}:{srv.name}:{cred}"
+                elements.append(
+                    {
+                        "data": {
+                            "id": cred_id,
+                            "label": cred,
+                            "type": "credential",
+                            "tip": f"Credential: {cred}\nServer: {srv.name}",
+                            "server": sid,
+                            "searchText": " ".join([cred, srv.name, agent.name]).lower(),
+                        }
+                    }
+                )
+                elements.append(
+                    {
+                        "data": {
+                            "source": sid,
+                            "target": cred_id,
+                            "type": "exposes_cred",
+                        }
+                    }
+                )
+                for tool_name, tool_id in tool_ids:
+                    elements.append(
+                        {
+                            "data": {
+                                "source": cred_id,
+                                "target": tool_id,
+                                "type": "reaches_tool",
+                                "relationship": "reaches_tool",
+                                "server": sid,
+                                "credential_env_var": cred,
+                                "tool": tool_name,
+                                "mapping_method": "server_scope_conservative",
+                                "confidence": "medium",
+                            }
+                        }
+                    )
 
             # ── Package nodes (vulnerable only) ───────────────────────
             seen_pkg_ids: set[str] = set()
@@ -807,6 +878,14 @@ const cy=cytoscape({{
       'background-color':'#4c3411','border-color':'#f2b84b','border-width':3,
       'width':'mapData(vulnCount, 0, 40, 200, 300)','height':56
     }}}},
+    {{selector:'node[type="credential"]',style:{{
+      'background-color':'#f2b84b','border-color':'#b45309','color':'#111827',
+      'shape':'tag','width':150,'height':42,'font-size':12
+    }}}},
+    {{selector:'node[type="tool"]',style:{{
+      'background-color':'#38bdf8','border-color':'#0369a1','color':'#082f49',
+      'shape':'roundrectangle','width':160,'height':42,'font-size':12
+    }}}},
     {{selector:'node[type="pkg_vuln"]',style:{{
       'background-color':'#3b1a1a','border-color':'#da3633',
       'width':'mapData(vulnCount, 1, 15, 180, 280)','height':58,'text-max-width':220
@@ -828,6 +907,9 @@ const cy=cytoscape({{
     {{selector:'edge[type="uses"][securityBlocked = 1]',style:{{'line-color':'#ff3b30','target-arrow-color':'#ff3b30','width':3.5}}}},
     {{selector:'edge[type="uses"][securityIntelligence = 1]',style:{{'line-color':'#f59e0b','target-arrow-color':'#f59e0b','width':3}}}},
     {{selector:'edge[type="uses"][credentialEdge = 1]',style:{{'line-color':'#f2b84b','target-arrow-color':'#f2b84b','width':3}}}},
+    {{selector:'edge[type="exposes_cred"]',style:{{'line-color':'#f2b84b','target-arrow-color':'#f2b84b','width':2}}}},
+    {{selector:'edge[type="provides_tool"]',style:{{'line-color':'#38bdf8','target-arrow-color':'#38bdf8','width':1.8}}}},
+    {{selector:'edge[type="reaches_tool"]',style:{{'line-style':'dashed','line-color':'#f59e0b','target-arrow-color':'#f59e0b','width':2}}}},
     {{selector:'edge[type="depends_on"]',style:{{'line-color':'#8b949e','target-arrow-color':'#8b949e','width':1.5}}}},
     {{selector:'edge[type="depends_on"][maxSeverity = "critical"]',style:{{
       'line-color':'#ff5d5d','target-arrow-color':'#ff5d5d','width':2.5

--- a/src/agent_bom/output/graph_export.py
+++ b/src/agent_bom/output/graph_export.py
@@ -47,12 +47,13 @@ class _Node:
 
 
 class _Edge:
-    __slots__ = ("source", "target", "kind")
+    __slots__ = ("source", "target", "kind", "evidence")
 
-    def __init__(self, source: str, target: str, kind: str) -> None:
+    def __init__(self, source: str, target: str, kind: str, evidence: dict[str, Any] | None = None) -> None:
         self.source = source
         self.target = target
         self.kind = kind
+        self.evidence = _compact_attributes(evidence)
 
 
 class DepGraph:
@@ -61,7 +62,7 @@ class DepGraph:
     def __init__(self) -> None:
         self._nodes: dict[str, _Node] = {}
         self._edges: list[_Edge] = []
-        self._edge_set: set[tuple[str, str]] = set()
+        self._edge_set: set[tuple[str, str, str]] = set()
 
     def add_node(self, node_id: str, label: str, kind: str, severity: str = "", attributes: dict[str, Any] | None = None) -> None:
         if node_id not in self._nodes:
@@ -69,11 +70,11 @@ class DepGraph:
         elif attributes:
             self._nodes[node_id].attributes.update(_compact_attributes(attributes))
 
-    def add_edge(self, source: str, target: str, kind: str) -> None:
-        key = (source, target)
+    def add_edge(self, source: str, target: str, kind: str, evidence: dict[str, Any] | None = None) -> None:
+        key = (source, target, kind)
         if key not in self._edge_set:
             self._edge_set.add(key)
-            self._edges.append(_Edge(source, target, kind))
+            self._edges.append(_Edge(source, target, kind, evidence))
 
     @property
     def nodes(self) -> list[_Node]:
@@ -97,6 +98,30 @@ def _compact_attributes(attributes: dict[str, Any] | None) -> dict[str, Any]:
     if not isinstance(attributes, dict):
         return {}
     return {key: value for key, value in attributes.items() if value not in (None, "", [], {})}
+
+
+def _credential_names_from_server(server: dict[str, Any]) -> list[str]:
+    env_vars = server.get("credential_env_vars")
+    if isinstance(env_vars, list):
+        return sorted({str(item) for item in env_vars if str(item).strip()})
+    env = server.get("env")
+    if not isinstance(env, dict):
+        return []
+    from agent_bom.constants import SENSITIVE_PATTERNS
+
+    return sorted({key for key in env if any(pattern in key.lower() for pattern in SENSITIVE_PATTERNS)})
+
+
+def _tool_names_from_server(server: dict[str, Any]) -> list[str]:
+    names: list[str] = []
+    for item in server.get("tools", []) or []:
+        if isinstance(item, dict):
+            name = item.get("name")
+        else:
+            name = item
+        if str(name or "").strip():
+            names.append(str(name))
+    return names
 
 
 def _agent_node_attributes(agent: dict[str, Any]) -> dict[str, Any]:
@@ -143,6 +168,32 @@ def build_graph_from_scan_data(data: dict[str, Any]) -> DepGraph:
             srv_id = f"server:{agent_name}/{srv_name}"
             graph.add_node(srv_id, srv_name, srv_kind)
             graph.add_edge(agent_id, srv_id, "uses")
+
+            tool_ids: list[tuple[str, str]] = []
+            for tool_name in _tool_names_from_server(server):
+                tool_id = f"tool:{agent_name}/{srv_name}/{tool_name}"
+                graph.add_node(tool_id, tool_name, "tool", attributes={"server": srv_id})
+                graph.add_edge(srv_id, tool_id, "provides_tool")
+                tool_ids.append((tool_name, tool_id))
+
+            for cred_name in _credential_names_from_server(server):
+                cred_id = f"cred:{cred_name}"
+                graph.add_node(cred_id, cred_name, "credential", attributes={"server": srv_id})
+                graph.add_edge(srv_id, cred_id, "exposes_cred")
+                for tool_name, tool_id in tool_ids:
+                    graph.add_edge(
+                        cred_id,
+                        tool_id,
+                        "reaches_tool",
+                        evidence={
+                            "source": source,
+                            "server": srv_id,
+                            "credential_env_var": cred_name,
+                            "tool": tool_name,
+                            "mapping_method": "server_scope_conservative",
+                            "confidence": "medium",
+                        },
+                    )
 
             for pkg in server.get("packages", []):
                 pkg_name = pkg.get("name", "?")
@@ -199,6 +250,8 @@ _DOT_COLORS: dict[str, str] = {
     "agent": "#2ea043",
     "server": "#6e7681",
     "server_cred": "#d29922",
+    "credential": "#f59e0b",
+    "tool": "#38bdf8",
     "pkg": "#8b949e",
     "pkg_vuln": "#f85149",
     "pkg_transitive": "#8b949e",
@@ -210,6 +263,8 @@ _DOT_SHAPES: dict[str, str] = {
     "agent": "box",
     "server": "ellipse",
     "server_cred": "ellipse",
+    "credential": "note",
+    "tool": "component",
     "pkg": "rectangle",
     "pkg_vuln": "rectangle",
     "pkg_transitive": "rectangle",
@@ -292,6 +347,8 @@ def to_mermaid(graph: DepGraph) -> str:
             "agent": "agent",
             "server": "server",
             "server_cred": "servercred",
+            "credential": "credential",
+            "tool": "tool",
             "pkg": "pkg",
             "pkg_vuln": "pkgvuln",
             "pkg_transitive": "pkgtrans",
@@ -304,6 +361,8 @@ def to_mermaid(graph: DepGraph) -> str:
         "    classDef agent fill:#2ea043,color:#fff,stroke:#16a34a",
         "    classDef server fill:#6e7681,color:#fff,stroke:#374151",
         "    classDef servercred fill:#d29922,color:#fff,stroke:#b45309",
+        "    classDef credential fill:#f59e0b,color:#111827,stroke:#b45309",
+        "    classDef tool fill:#38bdf8,color:#082f49,stroke:#0369a1",
         "    classDef pkg fill:#8b949e,color:#fff,stroke:#374151",
         "    classDef pkgvuln fill:#f85149,color:#fff,stroke:#dc2626",
         "    classDef pkgtrans fill:#8b949e,color:#ddd,stroke:#6b7280,stroke-dasharray:4 2",
@@ -351,7 +410,7 @@ def to_json(graph: DepGraph) -> dict:
             }
             for n in graph.nodes
         ],
-        "edges": [{"source": e.source, "target": e.target, "kind": e.kind} for e in graph.edges],
+        "edges": [{"source": e.source, "target": e.target, "kind": e.kind, "evidence": e.evidence} for e in graph.edges],
         "stats": {
             "node_count": graph.node_count(),
             "edge_count": graph.edge_count(),
@@ -367,6 +426,8 @@ _NEO4J_LABELS: dict[str, str] = {
     "agent": "AIAgent",
     "server": "MCPServer",
     "server_cred": "MCPServer",
+    "credential": "Credential",
+    "tool": "Tool",
     "pkg": "Package",
     "pkg_vuln": "Package",
     "pkg_transitive": "Package",
@@ -379,6 +440,9 @@ _NEO4J_REL_TYPES: dict[str, str] = {
     "uses": "USES_SERVER",
     "depends_on": "DEPENDS_ON",
     "affects": "AFFECTS",
+    "provides_tool": "PROVIDES_TOOL",
+    "exposes_cred": "EXPOSES_CRED",
+    "reaches_tool": "REACHES_TOOL",
 }
 
 # GraphML data key definitions for AIBOM attributes
@@ -391,6 +455,7 @@ _GRAPHML_KEYS = [
     ("is_transitive", "node", "boolean", "Transitive (indirect) dependency"),
     ("attributes_json", "node", "string", "Additional AIBOM node attributes as compact JSON"),
     ("relationship", "edge", "string", "AIBOM relationship type"),
+    ("evidence_json", "edge", "string", "Additional edge evidence as compact JSON"),
 ]
 
 
@@ -450,6 +515,8 @@ def to_graphml(graph: DepGraph) -> str:
         tgt = _xml_escape(edge.target)
         lines.append(f'    <edge id="e{i}" source="{src}" target="{tgt}">')
         lines.append(f'      <data key="relationship">{_xml_escape(edge.kind)}</data>')
+        if edge.evidence:
+            lines.append(f'      <data key="evidence_json">{_xml_escape(json.dumps(edge.evidence, sort_keys=True))}</data>')
         lines.append("    </edge>")
 
     lines.append("  </graph>")
@@ -483,6 +550,8 @@ def to_cypher(graph: DepGraph) -> str:
         "// ── Create constraints for idempotent import ──",
         "CREATE CONSTRAINT IF NOT EXISTS FOR (n:AIAgent) REQUIRE n.id IS UNIQUE;",
         "CREATE CONSTRAINT IF NOT EXISTS FOR (n:MCPServer) REQUIRE n.id IS UNIQUE;",
+        "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Credential) REQUIRE n.id IS UNIQUE;",
+        "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Tool) REQUIRE n.id IS UNIQUE;",
         "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Package) REQUIRE n.id IS UNIQUE;",
         "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Vulnerability) REQUIRE n.id IS UNIQUE;",
         "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Provider) REQUIRE n.id IS UNIQUE;",

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -871,6 +871,8 @@ def to_json(report: AIBOMReport) -> dict:
 
     if report.runtime_correlation:
         result["runtime_correlation"] = report.runtime_correlation
+    if report.delta_data:
+        result["delta"] = report.delta_data
     if report.scan_performance_data:
         result["scan_performance"] = report.scan_performance_data
     if report.runtime_session_graph:

--- a/src/agent_bom/output/mermaid.py
+++ b/src/agent_bom/output/mermaid.py
@@ -113,6 +113,16 @@ def to_mermaid(report: AIBOMReport, blast_radii: list[BlastRadius]) -> str:
                 edge = f'    {srv_node} -->|exposes| {tool_node}["{_sanitize_label(tool.name)}"]'
                 edges.add(edge)
 
+        # credential → tools reachable through the same affected server scope.
+        # This mirrors the conservative graph-builder mapping used by JSON,
+        # Cytoscape, GraphML, and Cypher exports.
+        for cred in br.exposed_credentials:
+            cred_node = ids.get(f"cred:{cred}")
+            for tool in br.exposed_tools:
+                tool_node = ids.get(f"tool:{tool.name}")
+                edge = f"    {cred_node} -.->|reaches_tool| {tool_node}"
+                edges.add(edge)
+
     # Add edges
     for edge in sorted(edges):
         lines.append(edge)
@@ -204,6 +214,18 @@ def to_mermaid_supply_chain(report: AIBOMReport) -> str:
             if len(srv.packages) > 5:
                 more_node = ids.get(f"more:{agent.name}:{srv.name}")
                 edges.add(f'    {srv_node} -.-> {more_node}["{len(srv.packages) - 5} more..."]')
+
+            tool_nodes: list[tuple[str, str]] = []
+            for tool in srv.tools:
+                tool_node = ids.get(f"tool:{agent.name}:{srv.name}:{tool.name}")
+                tool_nodes.append((tool.name, tool_node))
+                edges.add(f'    {srv_node} -->|provides_tool| {tool_node}["{_sanitize_label(tool.name)}"]')
+
+            for cred in srv.credential_names:
+                cred_node = ids.get(f"cred:{agent.name}:{srv.name}:{cred}")
+                edges.add(f'    {srv_node} -->|exposes_cred| {cred_node}["{_sanitize_label(cred)}"]')
+                for _tool_name, tool_node in tool_nodes:
+                    edges.add(f"    {cred_node} -.->|reaches_tool| {tool_node}")
 
     for edge in sorted(edges):
         lines.append(edge)

--- a/src/agent_bom/policy.py
+++ b/src/agent_bom/policy.py
@@ -383,6 +383,8 @@ def load_policy(path: str) -> dict:
             data = yaml.safe_load(text)
         except ImportError:
             raise ImportError("PyYAML is required for YAML policy files: pip install pyyaml")
+        except yaml.YAMLError as e:
+            raise ValueError(f"Invalid YAML in policy file: {e}") from e
     else:
         try:
             data = json.loads(text)

--- a/src/agent_bom/vex.py
+++ b/src/agent_bom/vex.py
@@ -93,8 +93,11 @@ def load_vex(path: str) -> VexDocument:
       "statements": [{"vulnerability_id": "CVE-...", "status": "..."}]
     }
     """
-    with open(path) as f:
-        data = json.load(f)
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"VEX JSON error in {path}: line {exc.lineno}, column {exc.colno}: {exc.msg}") from exc
 
     statements = []
     for stmt_data in data.get("statements", []):

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 from click.testing import CliRunner
 
 from agent_bom.cli import main
+from agent_bom.models import Agent, AgentType, BlastRadius, MCPServer, Package, Severity, Vulnerability
 from agent_bom.scanners import IncompleteScanError
 
 # ---------------------------------------------------------------------------
@@ -200,6 +201,44 @@ def test_scan_bad_inventory_json_exits_two(tmp_path):
     assert "Expecting property name" in result.output
 
 
+def test_scan_bad_ignore_file_yaml_exits_one(tmp_path):
+    ignore_file = tmp_path / ".agent-bom-ignore.yaml"
+    ignore_file.write_text("ignores:\n  - id: [unterminated\n", encoding="utf-8")
+
+    with patch("agent_bom.cli.agents.discover_all", return_value=[]):
+        result = _run(["scan", "--ignore-file", str(ignore_file), "--no-scan"])
+
+    assert result.exit_code == 1
+    assert "Invalid YAML in ignore file" in result.output
+    assert "line" in result.output
+
+
+def test_scan_bad_policy_json_exits_one_with_message(tmp_path):
+    policy = tmp_path / "policy.json"
+    policy.write_text("{bad json", encoding="utf-8")
+
+    with patch("agent_bom.cli.agents.discover_all", return_value=[]):
+        result = _run(["scan", "--policy", str(policy), "--no-scan", "--quiet"])
+
+    assert result.exit_code == 1
+    assert "Policy error" in result.output
+    assert "Invalid JSON in policy file" in result.output
+
+
+def test_scan_bad_baseline_json_exits_before_rendering(tmp_path):
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text("{bad json", encoding="utf-8")
+    output = tmp_path / "report.json"
+
+    with patch("agent_bom.cli.agents.discover_all", return_value=[]):
+        result = _run(["scan", "--baseline", str(baseline), "--no-scan", "--format", "json", "--output", str(output)])
+
+    assert result.exit_code == 1
+    assert "Baseline error" in result.output
+    assert "not valid JSON" in result.output
+    assert not output.exists()
+
+
 def test_scan_missing_inventory_schema_exits_two(tmp_path):
     inventory = tmp_path / "inventory.json"
     inventory.write_text('{"agents": []}', encoding="utf-8")
@@ -249,6 +288,74 @@ def test_scan_delta_with_baseline(tmp_path):
     with patch("agent_bom.cli.agents.discover_all", return_value=[]):
         result = _run(["scan", "--delta", "--baseline", str(baseline), "--no-scan"])
     assert result.exit_code == 0
+
+
+def test_scan_delta_filters_json_output_before_render(tmp_path):
+    old_vuln = Vulnerability(id="CVE-2026-0001", summary="old finding", severity=Severity.HIGH, fixed_version="1.0.1")
+    new_vuln = Vulnerability(id="CVE-2026-0002", summary="new finding", severity=Severity.HIGH, fixed_version="1.0.1")
+    old_pkg = Package(name="oldpkg", version="1.0.0", ecosystem="pypi", vulnerabilities=[old_vuln])
+    new_pkg = Package(name="newpkg", version="1.0.0", ecosystem="pypi", vulnerabilities=[new_vuln])
+    server = MCPServer(name="srv", command="python", packages=[old_pkg, new_pkg])
+    agent = Agent(name="agent", agent_type=AgentType.CUSTOM, config_path="agent.json", mcp_servers=[server])
+    blast_radii = [
+        BlastRadius(
+            vulnerability=old_vuln,
+            package=old_pkg,
+            affected_servers=[server],
+            affected_agents=[agent],
+            exposed_credentials=[],
+            exposed_tools=[],
+        ),
+        BlastRadius(
+            vulnerability=new_vuln,
+            package=new_pkg,
+            affected_servers=[server],
+            affected_agents=[agent],
+            exposed_credentials=[],
+            exposed_tools=[],
+        ),
+    ]
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(
+        json.dumps(
+            {
+                **_minimal_report_json(1),
+                "blast_radius": [{"vulnerability_id": "CVE-2026-0001", "package": "oldpkg@1.0.0"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "delta.json"
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with (
+        patch("agent_bom.cli.agents.discover_all", return_value=[agent]),
+        patch("agent_bom.cli.agents.extract_packages", return_value=[]),
+        patch("agent_bom.cli.agents.scan_agents_sync", return_value=blast_radii),
+        patch("agent_bom.cli.agents.resolve_all_versions_sync", return_value=[]),
+    ):
+        result = _run(
+            [
+                "scan",
+                "--project",
+                str(project),
+                "--delta",
+                "--baseline",
+                str(baseline),
+                "-f",
+                "json",
+                "-o",
+                str(output),
+                "--no-auto-update-db",
+            ]
+        )
+
+    assert result.exit_code == 0
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert data["delta"]["new_count"] == 1
+    assert data["delta"]["pre_existing_count"] == 1
+    assert [item["vulnerability_id"] for item in data["blast_radius"]] == ["CVE-2026-0002"]
 
 
 def test_scan_enrich_flag():

--- a/tests/test_cli_server.py
+++ b/tests/test_cli_server.py
@@ -57,7 +57,7 @@ def test_serve_cmd_invalid_port_is_usage_error():
 
     assert result.exit_code == 2
     assert "Invalid value for '--port'" in result.output
-    assert "1<=x<=65535" in result.output
+    assert "1024<=x<=65535" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -91,7 +91,19 @@ def test_api_cmd_invalid_port_is_usage_error():
 
     assert result.exit_code == 2
     assert "Invalid value for '--port'" in result.output
-    assert "1<=x<=65535" in result.output
+    assert "1024<=x<=65535" in result.output
+
+
+def test_api_cmd_rejects_privileged_port_before_binding():
+    runner = CliRunner()
+
+    with patch("uvicorn.run") as mock_run:
+        result = runner.invoke(api_cmd, ["--port", "80"])
+
+    assert result.exit_code == 2
+    assert "Invalid value for '--port'" in result.output
+    assert "1024<=x<=65535" in result.output
+    mock_run.assert_not_called()
 
 
 def test_api_cmd_rejects_unauthenticated_non_loopback_bind():
@@ -277,6 +289,15 @@ def test_serve_cmd_requires_clickhouse_url_for_backend():
 # ---------------------------------------------------------------------------
 # mcp_server_cmd
 # ---------------------------------------------------------------------------
+
+
+def test_mcp_server_cmd_invalid_port_is_usage_error():
+    runner = CliRunner()
+    result = runner.invoke(mcp_server_cmd, ["--port", "99999"])
+
+    assert result.exit_code == 2
+    assert "Invalid value for '--port'" in result.output
+    assert "1024<=x<=65535" in result.output
 
 
 def test_mcp_server_cmd_stdio():

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -28,6 +28,20 @@ def _created_tables(sql: str) -> set[str]:
     return {match.rsplit(".", 1)[-1] for match in re.findall(r"CREATE TABLE IF NOT EXISTS ([a-zA-Z0-9_.]+)", sql)}
 
 
+def _created_table_columns(sql: str) -> dict[str, set[str]]:
+    tables: dict[str, set[str]] = {}
+    pattern = re.compile(r"CREATE TABLE IF NOT EXISTS ([a-zA-Z0-9_.]+)\s*\((.*?)\)\s*ENGINE", re.DOTALL)
+    for table, body in pattern.findall(sql):
+        columns: set[str] = set()
+        for raw_line in body.splitlines():
+            line = raw_line.strip().rstrip(",")
+            if not line or line.startswith("--"):
+                continue
+            columns.add(line.split()[0].strip("`"))
+        tables[table.rsplit(".", 1)[-1]] = columns
+    return tables
+
+
 # ─── ClickHouseClient tests ─────────────────────────────────────────────────
 
 
@@ -203,6 +217,16 @@ class TestClickHouseClient:
         assert init_tables == runtime_tables
         assert "cis_benchmark_checks" in init_tables
         assert "control_plane_schema_versions" in init_tables
+
+    def test_supabase_init_schema_columns_match_runtime_tables(self):
+        """Supabase ClickHouse bootstrap must include every runtime column."""
+        from agent_bom.cloud.clickhouse import _TABLE_DDL
+
+        runtime_columns = _created_table_columns("\n".join(_TABLE_DDL))
+        init_sql = Path("deploy/supabase/clickhouse/init.sql").read_text(encoding="utf-8")
+        init_columns = _created_table_columns(init_sql)
+
+        assert init_columns == runtime_columns
 
 
 # ─── NullAnalyticsStore tests ───────────────────────────────────────────────

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -71,7 +71,13 @@ def _vuln(vid: str = "CVE-2024-0001", severity: str = "high") -> dict:
     return {"id": vid, "severity": severity, "summary": "A test vulnerability.", "cvss_score": 7.5}
 
 
-def _server(name: str, pkgs: list | None = None, has_creds: bool = False) -> dict:
+def _server(
+    name: str,
+    pkgs: list | None = None,
+    has_creds: bool = False,
+    tools: list[dict] | None = None,
+    credential_env_vars: list[str] | None = None,
+) -> dict:
     return {
         "name": name,
         "command": "npx",
@@ -79,6 +85,8 @@ def _server(name: str, pkgs: list | None = None, has_creds: bool = False) -> dic
         "transport": "stdio",
         "url": "",
         "has_credentials": has_creds,
+        "tools": tools or [],
+        "credential_env_vars": credential_env_vars or [],
         "packages": pkgs or [],
     }
 
@@ -146,6 +154,29 @@ def test_loads_agent_server_package_nodes():
         assert "agent" in kinds
         assert "server" in kinds
         assert "pkg" in kinds
+    finally:
+        os.unlink(path)
+
+
+def test_credential_to_tool_reaches_edges_export_with_evidence():
+    server = _server(
+        "github",
+        tools=[{"name": "create_issue"}, {"name": "delete_repo"}],
+        credential_env_vars=["GITHUB_TOKEN"],
+    )
+    data = _make_scan_json([_agent("a", [server])])
+    path = _write_scan(data)
+    try:
+        graph = load_graph_from_scan(path)
+        payload = to_json(graph)
+        edge = next(edge for edge in payload["edges"] if edge["kind"] == "reaches_tool" and edge["target"].endswith("/delete_repo"))
+
+        assert edge["source"] == "cred:GITHUB_TOKEN"
+        assert edge["evidence"]["mapping_method"] == "server_scope_conservative"
+        assert edge["evidence"]["confidence"] == "medium"
+        assert "|reaches_tool|" in to_mermaid(graph)
+        assert "REACHES_TOOL" in to_cypher(graph)
+        assert "reaches_tool" in to_graphml(graph)
     finally:
         os.unlink(path)
 

--- a/tests/test_ignores.py
+++ b/tests/test_ignores.py
@@ -50,18 +50,28 @@ def test_load_ignore_file_yaml(tmp_path):
     assert entries[0]["id"] == "CVE-2024-1111"
 
 
-def test_load_ignore_file_invalid_yaml_returns_empty(tmp_path):
+def test_load_ignore_file_invalid_yaml_raises(tmp_path):
     pytest.importorskip("yaml")
     f = tmp_path / ".agent-bom-ignore.yaml"
     f.write_text("ignores:\n  - id: [unterminated\n")
-    assert load_ignore_file(f) == []
+    with pytest.raises(ValueError, match="Invalid YAML in ignore file"):
+        load_ignore_file(f)
 
 
 def test_load_ignore_file_requires_mapping_top_level(tmp_path):
     pytest.importorskip("yaml")
     f = tmp_path / ".agent-bom-ignore.yaml"
     f.write_text("- id: CVE-2024-1111\n  reason: test\n")
-    assert load_ignore_file(f) == []
+    with pytest.raises(ValueError, match="must be a YAML mapping"):
+        load_ignore_file(f)
+
+
+def test_load_ignore_file_requires_ignores_list(tmp_path):
+    pytest.importorskip("yaml")
+    f = tmp_path / ".agent-bom-ignore.yaml"
+    f.write_text("ignores: nope\n")
+    with pytest.raises(ValueError, match="field 'ignores' must be a list"):
+        load_ignore_file(f)
 
 
 def test_load_ignore_file_default_name(tmp_path, monkeypatch):

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -8,6 +8,7 @@ from agent_bom.models import (
     AIBOMReport,
     BlastRadius,
     MCPServer,
+    MCPTool,
     Package,
     Severity,
     TransportType,
@@ -101,6 +102,43 @@ def test_mermaid_credential_exposure():
     report, brs = _make_report_and_blast_radii()
     result = to_mermaid(report, brs)
     assert "API_KEY" in result
+
+
+def test_mermaid_attack_flow_shows_credential_to_tool_reachability():
+    """Attack-flow Mermaid output carries conservative credential -> tool evidence."""
+    report, brs = _make_report_and_blast_radii()
+    brs[0].exposed_tools = [MCPTool(name="delete_repo", description="Delete repository")]
+    result = to_mermaid(report, brs)
+    assert "delete_repo" in result
+    assert "|reaches_tool|" in result
+
+
+def test_mermaid_supply_chain_shows_credential_to_tool_reachability():
+    """Supply-chain Mermaid output carries conservative credential -> tool evidence."""
+    server = MCPServer(
+        name="github",
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-github"],
+        env={"GITHUB_TOKEN": "***"},
+        transport=TransportType.STDIO,
+        tools=[
+            MCPTool(name="create_issue", description="Create issue"),
+            MCPTool(name="delete_repo", description="Delete repository"),
+        ],
+    )
+    agent = Agent(
+        name="claude-desktop",
+        agent_type=AgentType.CLAUDE_DESKTOP,
+        config_path="/tmp/config.json",
+        mcp_servers=[server],
+    )
+    result = to_mermaid_supply_chain(AIBOMReport(agents=[agent]))
+
+    assert "GITHUB_TOKEN" in result
+    assert "delete_repo" in result
+    assert "|provides_tool|" in result
+    assert "|exposes_cred|" in result
+    assert "|reaches_tool|" in result
 
 
 def test_mermaid_severity_styling():

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -15,6 +15,7 @@ from agent_bom.models import (
     AIBOMReport,
     BlastRadius,
     MCPServer,
+    MCPTool,
     Package,
     Severity,
     TransportType,
@@ -54,6 +55,8 @@ def _make_agent(
 def _make_server(
     name: str = "test-server",
     packages: list[Package] | None = None,
+    tools: list[MCPTool] | None = None,
+    env: dict[str, str] | None = None,
 ) -> MCPServer:
     return MCPServer(
         name=name,
@@ -61,7 +64,8 @@ def _make_server(
         args=[name],
         transport=TransportType.STDIO,
         packages=packages or [],
-        env={},
+        tools=tools or [],
+        env=env or {},
     )
 
 
@@ -434,3 +438,25 @@ def test_html_renders_unified_non_cve_findings_with_asset_context():
     assert "/tmp/mcp.json" in html
     assert "Matched the MCP intelligence blocklist." in html
     assert "Unified non-CVE findings" in html
+
+
+def test_cytoscape_graph_includes_credential_to_tool_reachability_evidence():
+    from agent_bom.output.graph import build_graph_elements
+
+    server = _make_server(
+        "github",
+        tools=[MCPTool(name="create_issue", description="Create issue"), MCPTool(name="delete_repo", description="Delete repo")],
+        env={"GITHUB_TOKEN": "***"},
+    )
+    report = _make_report(agents=[_make_agent(servers=[server])])
+
+    elements = build_graph_elements(report, [])
+    reaches_edges = [
+        element["data"]
+        for element in elements
+        if element.get("data", {}).get("type") == "reaches_tool" and element["data"].get("credential_env_var") == "GITHUB_TOKEN"
+    ]
+
+    assert reaches_edges
+    assert reaches_edges[0]["mapping_method"] == "server_scope_conservative"
+    assert reaches_edges[0]["confidence"] == "medium"

--- a/tests/test_policy_engine.py
+++ b/tests/test_policy_engine.py
@@ -114,6 +114,16 @@ def test_load_policy_invalid_json(tmp_path):
         load_policy(str(path))
 
 
+def test_load_policy_invalid_yaml(tmp_path):
+    """Malformed YAML raises ValueError instead of leaking a parser exception."""
+    pytest.importorskip("yaml")
+    path = tmp_path / "bad.yaml"
+    path.write_text("rules:\n  - id: [unterminated\n")
+
+    with pytest.raises(ValueError, match="Invalid YAML"):
+        load_policy(str(path))
+
+
 # ---------------------------------------------------------------------------
 # _validate_policy
 # ---------------------------------------------------------------------------

--- a/tests/test_vex.py
+++ b/tests/test_vex.py
@@ -198,6 +198,13 @@ class TestVexLoad:
         with pytest.raises(ValueError, match="Unknown VEX status"):
             load_vex(str(path))
 
+    def test_load_malformed_json_raises_cli_safe_error(self, tmp_path):
+        path = tmp_path / "vex.json"
+        path.write_text("{bad json", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="VEX JSON error.*line 1, column 2"):
+            load_vex(str(path))
+
     def test_load_unknown_justification_ignored(self, tmp_path):
         data = {
             "statements": [

--- a/ui/e2e/scan-export.spec.ts
+++ b/ui/e2e/scan-export.spec.ts
@@ -166,16 +166,20 @@ test("scan flow reaches result view and exports graph JSON", async ({ page }) =>
   await page.waitForLoadState("networkidle");
 
   const imageInput = page.getByPlaceholder("nginx:1.25 or ghcr.io/org/app:v1");
-  await expect(imageInput, "image input must be visible after hydration").toBeVisible({ timeout: 15_000 });
-  await expect(imageInput, "image input must be enabled after hydration").toBeEnabled({ timeout: 15_000 });
-
-  // If the page never hydrated, surface the captured browser errors before
-  // letting the implicit fill timeout swallow them.
-  if (consoleErrors.length > 0) {
-    throw new Error(
-      "Browser reported errors before scan flow could start (likely CSP block or hydration failure):\n" +
-        consoleErrors.map((e) => `  - ${e}`).join("\n"),
-    );
+  try {
+    await expect(imageInput, "image input must be visible after hydration").toBeVisible({ timeout: 15_000 });
+    await expect(imageInput, "image input must be enabled after hydration").toBeEnabled({ timeout: 15_000 });
+  } catch (err) {
+    // If the page never hydrated, surface the captured browser errors before
+    // letting the implicit fill timeout swallow them. Do not fail a hydrated
+    // scan page for unrelated Next.js background prefetch noise.
+    if (consoleErrors.length > 0) {
+      throw new Error(
+        "Browser reported errors before scan flow could start (likely CSP block or hydration failure):\n" +
+          consoleErrors.map((e) => `  - ${e}`).join("\n"),
+      );
+    }
+    throw err;
   }
 
   await imageInput.fill("nginx:1.25");

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -3,8 +3,11 @@ import { defineConfig, devices } from "@playwright/test";
 const PORT = 3001;
 const baseURL = `http://127.0.0.1:${PORT}`;
 const serverCommand =
-  `if test -f .next/standalone/server.js && test -f .next/standalone/.next/server/pages-manifest.json; ` +
-  `then HOSTNAME=127.0.0.1 PORT=${PORT} node .next/standalone/server.js; ` +
+  `if test -f .next/standalone/server.js; ` +
+  `then mkdir -p .next/standalone/.next && rm -rf .next/standalone/.next/static .next/standalone/public && ` +
+  `cp -R .next/static .next/standalone/.next/static && ` +
+  `if test -d public; then cp -R public .next/standalone/public; fi && ` +
+  `cd .next/standalone && HOSTNAME=127.0.0.1 PORT=${PORT} node server.js; ` +
   `else npm run dev -- --hostname 127.0.0.1 --port ${PORT}; fi`;
 
 export default defineConfig({


### PR DESCRIPTION
Summary
- surface credential -> tool reaches_tool evidence across CLI graph/Cytoscape, graph-html, Mermaid, GraphML, Cypher, and JSON graph exports
- reject privileged listener ports before socket bind for serve/api/mcp server paths
- fail fast on malformed policy, ignore, baseline, inventory, and VEX inputs with clear parser messages instead of silent skips or late generic errors
- make delta-mode report rendering match new-only CI gate behavior and add v0.84.1 changelog notes
- harden UI E2E to run against a staged standalone bundle that mirrors container runtime assets

Why
Post-merge audit of #2162 found that REACHES_TOOL existed in the unified graph but not all user-facing graph outputs, and malformed --policy / --ignore-file / --baseline inputs could be skipped or reported too late. This closes those patch-release gaps before v0.84.1.

Validation
- uv run pytest tests/test_cli_scan.py tests/test_cli_server.py tests/test_ignores.py tests/test_policy_engine.py tests/test_vex.py tests/test_graph_export.py tests/test_mermaid.py tests/test_output_formats.py tests/test_clickhouse.py -q
- npm --prefix ui run lint
- npm --prefix ui run test:run
- npm --prefix ui run test:e2e -- --reporter=line
- uv run ruff check src/agent_bom/cli/_analysis.py src/agent_bom/cli/_common.py src/agent_bom/cli/_server.py src/agent_bom/cli/agents/__init__.py src/agent_bom/ignores.py src/agent_bom/inventory.py src/agent_bom/models.py src/agent_bom/output/graph.py src/agent_bom/output/graph_export.py src/agent_bom/output/json_fmt.py src/agent_bom/output/mermaid.py src/agent_bom/policy.py src/agent_bom/vex.py tests/test_cli_scan.py tests/test_cli_server.py tests/test_clickhouse.py tests/test_graph_export.py tests/test_ignores.py tests/test_mermaid.py tests/test_output_formats.py tests/test_policy_engine.py tests/test_vex.py
- git diff --check