### PR TITLE
Slim async scan polling payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - **Graph export parity** — CLI Cytoscape, Graph HTML, Mermaid, GraphML, Cypher, and API graph paths now surface conservative credential → tool `reaches_tool` evidence consistently.
+- **Dashboard scan polling** — the scan detail UI now polls a lightweight status endpoint during async scans and fetches the full result only once at completion, avoiding repeated multi-MB `/v1/scan/{id}` payloads.
 - **CLI error contracts** — listener ports now reject privileged or invalid values before socket bind, and malformed inventory, VEX, policy, and ignore files fail loudly with actionable parser messages instead of raw tracebacks or silent skips.
 - **Delta gate artifact consistency** — delta-mode filtering now happens before report rendering so JSON/SARIF artifacts and CI exit gates reflect the same new-only finding set.
 - **UI E2E production parity** — Playwright now runs against a staged standalone bundle that mirrors the container runtime, preventing hydration checks from passing only in dev mode.

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -2,7 +2,8 @@
 
 Endpoints:
     POST /v1/scan                      start a scan (async, returns job_id)
-    GET  /v1/scan/{job_id}             poll scan status + results
+    GET  /v1/scan/{job_id}             fetch scan status + full results
+    GET  /v1/scan/{job_id}/status      poll lightweight scan status
     GET  /v1/scan/{job_id}/attack-flow attack flow graph (React Flow)
     GET  /v1/scan/{job_id}/context-graph context graph with lateral movement
     GET  /v1/scan/{job_id}/graph-export graph export (json/dot/mermaid/graphml/cypher)
@@ -307,8 +308,14 @@ async def create_scan(request: Request, body: ScanRequest) -> ScanJob:
 
 @router.get("/v1/scan/{job_id}", response_model=ScanJob, tags=["scan"])
 async def get_scan(request: Request, job_id: str) -> ScanJob:
-    """Poll scan status and results."""
+    """Fetch scan status and full results."""
     return _job_for_request(request, job_id)
+
+
+@router.get("/v1/scan/{job_id}/status", tags=["scan"])
+async def get_scan_status(request: Request, job_id: str) -> dict[str, Any]:
+    """Poll lightweight scan status without serializing large result payloads."""
+    return _job_summary_payload(_job_for_request(request, job_id))
 
 
 @router.get("/v1/scan/{job_id}/attack-flow", tags=["scan"])

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -287,6 +287,45 @@ def test_get_scan_after_create():
     assert get_resp.json()["job_id"] == job_id
 
 
+def test_get_scan_status_omits_large_result_payload():
+    """Status polling should not serialize the full scan result on every tick."""
+    client, store = _fresh_client()
+    job = ScanJob(
+        job_id="job-large-result",
+        tenant_id="default",
+        status=JobStatus.DONE,
+        created_at="2026-01-01T00:00:00Z",
+        completed_at="2026-01-01T00:00:13Z",
+        request=ScanRequest(inventory="/tmp/agents.json"),
+        progress=["scan started", "scan complete"],
+        result={
+            "summary": {
+                "total_agents": 8,
+                "total_servers": 8,
+                "total_packages": 165,
+                "total_vulnerabilities": 28,
+            },
+            "agents": [{"name": "agent", "payload": "x" * 250_000}],
+            "blast_radius": [{"package": "pkg", "payload": "y" * 250_000}],
+        },
+    )
+    store.put(job)
+
+    full = client.get("/v1/scan/job-large-result")
+    status = client.get("/v1/scan/job-large-result/status")
+
+    assert full.status_code == 200
+    assert status.status_code == 200
+    body = status.json()
+    assert body["job_id"] == "job-large-result"
+    assert body["status"] == "done"
+    assert body["summary"]["total_packages"] == 165
+    assert body["request"]["inventory"] == "<path:agents.json>"
+    assert "result" not in body
+    assert "progress" not in body
+    assert len(status.content) < len(full.content) / 100
+
+
 # ---------------------------------------------------------------------------
 # 8. DELETE scan
 # ---------------------------------------------------------------------------

--- a/ui/components/scan-result.tsx
+++ b/ui/components/scan-result.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
-import { api, type ScanJob, type ScanResult, type BlastRadius, type RemediationItem, type GraphExportFormat, formatDate, OWASP_LLM_TOP10, MITRE_ATLAS, severityColor } from "@/lib/api";
+import { api, type ScanJob, type ScanJobStatus, type ScanResult, type BlastRadius, type RemediationItem, type GraphExportFormat, formatDate, OWASP_LLM_TOP10, MITRE_ATLAS, severityColor } from "@/lib/api";
 import type { StepEvent, SSEEvent } from "@/lib/api";
 import { ScanPipeline } from "@/components/scan-pipeline";
 import { SeverityBadge } from "@/components/severity-badge";
@@ -21,9 +21,52 @@ export function ScanResultView({ id }: { id: string }) {
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState("");
   const logRef = useRef<HTMLDivElement>(null);
+  const fetchedResultRef = useRef(false);
+  const fetchingResultRef = useRef(false);
 
   useEffect(() => {
-    api.getScan(id).then(setJob).catch(() => {});
+    let cancelled = false;
+
+    function mergeStatus(prev: ScanJob | null, status: ScanJobStatus): ScanJob {
+      return {
+        job_id: status.job_id,
+        tenant_id: status.tenant_id ?? prev?.tenant_id,
+        status: status.status,
+        created_at: status.created_at,
+        completed_at: status.completed_at ?? prev?.completed_at,
+        request: status.request ?? prev?.request ?? {},
+        progress: prev?.progress ?? [],
+        result: prev?.result,
+        error: status.error ?? prev?.error,
+      };
+    }
+
+    async function fetchFullResultOnce() {
+      if (fetchedResultRef.current || fetchingResultRef.current) return;
+      fetchingResultRef.current = true;
+      try {
+        const fullJob = await api.getScan(id);
+        if (!cancelled) {
+          setJob(fullJob);
+          fetchedResultRef.current = true;
+        }
+      } finally {
+        fetchingResultRef.current = false;
+      }
+    }
+
+    async function refreshStatus() {
+      const status = await api.getScanStatus(id);
+      if (cancelled) return;
+      setJob((prev) => mergeStatus(prev, status));
+      if (status.status === "done" || status.status === "failed" || status.status === "cancelled") {
+        await fetchFullResultOnce();
+      }
+    }
+
+    fetchedResultRef.current = false;
+    fetchingResultRef.current = false;
+    refreshStatus().catch(() => {});
 
     const cleanup = api.streamScan(
       id,
@@ -40,14 +83,17 @@ export function ScanResultView({ id }: { id: string }) {
           const d = data as { message?: string };
           if (d.message) setMessages((m) => [...m, d.message!]);
         }
-        api.getScan(id).then(setJob).catch(() => {});
+        refreshStatus().catch(() => {});
       },
       () => {
         setStreaming(false);
-        api.getScan(id).then(setJob).catch(() => {});
+        refreshStatus().catch(() => {});
       }
     );
-    return cleanup;
+    return () => {
+      cancelled = true;
+      cleanup();
+    };
   }, [id]);
 
   useEffect(() => {

--- a/ui/e2e/scan-export.spec.ts
+++ b/ui/e2e/scan-export.spec.ts
@@ -123,6 +123,20 @@ test("scan flow reaches result view and exports graph JSON", async ({ page }) =>
     });
   });
 
+  await page.route(`**/v1/scan/${scanJob.job_id}/status`, async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        job_id: scanJob.job_id,
+        status: scanJob.status,
+        created_at: scanJob.created_at,
+        completed_at: "2026-04-20T12:00:13Z",
+        request: scanJob.request,
+        summary: scanJob.result.summary,
+      }),
+    });
+  });
+
   await page.route(`**/v1/scan/${scanJob.job_id}/stream`, async (route) => {
     await route.fulfill({
       contentType: "text/event-stream",

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1086,6 +1086,7 @@ export interface JobListItem {
   job_id: string;
   status: JobStatus;
   created_at: string;
+  tenant_id?: string | undefined;
   completed_at?: string | undefined;
   request?: ScanRequest | undefined;
   summary?: Summary | undefined;
@@ -1093,6 +1094,8 @@ export interface JobListItem {
   pushed?: boolean | undefined;
   error?: string | undefined;
 }
+
+export type ScanJobStatus = JobListItem;
 
 export interface AgentsResponse {
   agents: Agent[];

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -9,6 +9,7 @@ import type {
   ScanRequest,
   SSEEvent,
   ScanJob,
+  ScanJobStatus,
   GraphSnapshot,
   UnifiedGraphResponse,
   GraphNodeDetailResponse,
@@ -83,6 +84,7 @@ export type {
   DoneEvent,
   SSEEvent,
   ScanJob,
+  ScanJobStatus,
   ScanResult,
   GraphPagination,
   GraphSnapshot,
@@ -383,6 +385,9 @@ export const api = {
 
   /** Poll scan status + results */
   getScan: (jobId: string) => get<ScanJob>(`/v1/scan/${jobId}`),
+
+  /** Poll scan status without loading large result payloads */
+  getScanStatus: (jobId: string) => get<ScanJobStatus>(`/v1/scan/${jobId}/status`),
 
   /** Export a completed scan graph in a graph-native format. */
   downloadScanGraph: (jobId: string, format: GraphExportFormat = "json") =>

--- a/ui/tests/api.test.ts
+++ b/ui/tests/api.test.ts
@@ -206,6 +206,37 @@ describe('api.getScan', () => {
     expect(result.result?.summary?.total_agents).toBe(2)
   })
 
+  it('polls lightweight scan status without requesting full results', async () => {
+    const payload = {
+      job_id: 'job-1',
+      status: 'running',
+      created_at: '2024-01-01T00:00:00Z',
+      request: {},
+      summary: {
+        total_agents: 2,
+        total_servers: 5,
+        total_packages: 100,
+        total_vulnerabilities: 3,
+      },
+    }
+    const fetchMock = mockFetch(payload)
+    global.fetch = fetchMock
+
+    const result = await api.getScanStatus('job-1')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/v1/scan/job-1/status",
+      expect.objectContaining({
+        credentials: "include",
+        headers: {},
+        signal: expect.any(AbortSignal),
+      }),
+    )
+    expect(result.job_id).toBe('job-1')
+    expect(result.summary?.total_packages).toBe(100)
+    expect('result' in result).toBe(false)
+  })
+
   it('preserves richer scan contract fields from the backend', async () => {
     const payload = {
       job_id: 'job-2',


### PR DESCRIPTION
Summary
- add a lightweight GET /v1/scan/{job_id}/status endpoint for async scan polling
- update the dashboard scan detail view to poll status payloads during progress and fetch the full scan result once at completion
- add API/UI regression coverage and update the 0.84.1 changelog notes

Why
The dashboard was calling GET /v1/scan/{job_id} on every SSE event. Large completed or in-progress jobs can serialize multi-MB result payloads repeatedly, which makes scans look hung and wastes bandwidth/CPU.

Validation
- uv run pytest tests/test_api_endpoints.py -q
- npm --prefix ui run test:run -- tests/api.test.ts
- npm --prefix ui run lint
- npm --prefix ui run typecheck
- uv run ruff check src/agent_bom/api/routes/scan.py tests/test_api_endpoints.py
- git diff --check
