### PR TITLE
Polish clean scan output before patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - **Graph export parity** — CLI Cytoscape, Graph HTML, Mermaid, GraphML, Cypher, and API graph paths now surface conservative credential → tool `reaches_tool` evidence consistently.
 - **Dashboard scan polling** — the scan detail UI now polls a lightweight status endpoint during async scans and fetches the full result only once at completion, avoiding repeated multi-MB `/v1/scan/{id}` payloads.
 - **CLI error contracts** — listener ports now reject privileged or invalid values before socket bind, and malformed inventory, VEX, policy, and ignore files fail loudly with actionable parser messages instead of raw tracebacks or silent skips.
+- **Pre-release output polish** — clean scans now describe config-posture gaps without contradicting `SECURITY POSTURE: CLEAN`, project-scoped agents render with human-readable labels, and CSV inventory ingestion logs skipped empty package rows.
 - **Delta gate artifact consistency** — delta-mode filtering now happens before report rendering so JSON/SARIF artifacts and CI exit gates reflect the same new-only finding set.
 - **UI E2E production parity** — Playwright now runs against a staged standalone bundle that mirrors the container runtime, preventing hydration checks from passing only in dev mode.
 

--- a/src/agent_bom/inventory.py
+++ b/src/agent_bom/inventory.py
@@ -226,6 +226,7 @@ def _load_csv_inventory(fp: io.TextIOBase) -> dict:  # type: ignore[override]
 
     # Build inventory structure
     agents_by_name: dict[str, dict] = {}
+    skipped_empty_identity_rows = 0
     for (agent_name, server_name), rows in groups.items():
         packages = []
         env: dict[str, str] = {}
@@ -234,6 +235,7 @@ def _load_csv_inventory(fp: io.TextIOBase) -> dict:  # type: ignore[override]
             version = (row.get(col_version) or "").strip()
             ecosystem = _normalize_inventory_ecosystem((row.get(col_ecosystem) or "").strip())
             if not name or not version:
+                skipped_empty_identity_rows += 1
                 continue
             packages.append(
                 {
@@ -268,5 +270,11 @@ def _load_csv_inventory(fp: io.TextIOBase) -> dict:  # type: ignore[override]
 
     if not agents_by_name:
         raise ValueError("CSV produced no valid inventory entries (check name/version columns)")
+
+    if skipped_empty_identity_rows:
+        logger.warning(
+            "Skipped %s CSV inventory row(s) with empty package name or version",
+            skipped_empty_identity_rows,
+        )
 
     return _validate_inventory_payload({"agents": list(agents_by_name.values())})

--- a/src/agent_bom/output/compact.py
+++ b/src/agent_bom/output/compact.py
@@ -13,6 +13,8 @@ remediation plan, etc.).
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from rich.panel import Panel
 from rich.rule import Rule
 from rich.table import Table
@@ -61,6 +63,21 @@ def _compact_detail(text: str, limit: int = 88) -> str:
     if len(clean) <= limit:
         return clean
     return clean[: limit - 1].rstrip() + "…"
+
+
+def _agent_display_name(agent) -> str:
+    """Return a human-readable agent label for compact tables."""
+    name = str(getattr(agent, "name", "") or "").strip()
+    if not name.startswith("project:"):
+        return name or "unknown-agent"
+
+    config_path = str(getattr(agent, "config_path", "") or "").strip()
+    project_name = name.removeprefix("project:").strip(":") or "project"
+    if config_path:
+        path = Path(config_path)
+        if path.name and path.name != project_name:
+            return f"{path.name} ({project_name})"
+    return f"{project_name} (project)"
 
 
 def _iter_cis_bundles(report: AIBOMReport):
@@ -246,7 +263,7 @@ def print_compact_agents(report: AIBOMReport) -> None:
         vuln_style = "red" if n_vulns > 0 else "dim"
         cred_style = "yellow" if n_creds > 0 else "dim"
         table.add_row(
-            f"[bold]{a.name}[/bold]",
+            f"[bold]{_agent_display_name(a)}[/bold]",
             a.agent_type.value if hasattr(a.agent_type, "value") else str(a.agent_type),
             str(n_servers),
             str(n_pkgs),

--- a/src/agent_bom/posture.py
+++ b/src/agent_bom/posture.py
@@ -315,8 +315,17 @@ def compute_posture_scorecard(report: "AIBOMReport") -> PostureScorecard:
     total_score = round(min(100.0, max(0.0, total_score)), 1)
     grade = _score_to_grade(total_score)
 
-    # Build summary
-    if grade in ("A", "B"):
+    # Build summary. Keep vulnerability cleanliness separate from
+    # best-practice/configuration quality so clean scans do not read as
+    # contradictory when optional metadata is incomplete.
+    if total_vulns == 0:
+        if grade in ("A", "B"):
+            summary = f"No vulnerabilities found; strong best-practice/config posture ({grade}, {total_score}%)"
+        elif grade == "C":
+            summary = f"No vulnerabilities found; config/best-practice improvements recommended ({grade}, {total_score}%)"
+        else:
+            summary = f"No vulnerabilities found; config/best-practice gaps need attention ({grade}, {total_score}%)"
+    elif grade in ("A", "B"):
         summary = f"Strong best-practice/config posture ({grade}, {total_score}%)"
     elif grade == "C":
         summary = f"Moderate best-practice/config posture ({grade}, {total_score}%) — improvements recommended"

--- a/tests/test_compact_output.py
+++ b/tests/test_compact_output.py
@@ -139,6 +139,7 @@ def test_compact_summary_distinguishes_clean_vulns_from_config_posture():
     report = AIBOMReport(agents=[agent])
     output = _plain(_capture(print_compact_summary, report))
     assert "CONFIG POSTURE GRADE" in output
+    assert "No vulnerabilities found" in output
     assert "best-practice/config posture" in output
     assert "SECURITY POSTURE:" in output
     assert "CLEAN" in output
@@ -232,6 +233,23 @@ def test_compact_agents_table():
     output = _capture(print_compact_agents, report)
     assert "claude-desktop" in output
     assert "cursor" in output
+
+
+def test_compact_agents_humanizes_project_scoped_names():
+    """Project-scoped synthetic IDs should not be the primary table label."""
+    agent = _make_agent(
+        name="project:agent-bom-first-run",
+        agent_type=AgentType.CUSTOM,
+        servers=[_make_server()],
+    )
+    agent.config_path = "/tmp/agent-bom-first-run/claude-review.json"
+    report = AIBOMReport(agents=[agent])
+
+    output = _plain(_capture(print_compact_agents, report))
+
+    assert "claude-review.json" in output
+    assert "(agent-bom-first-run)" in output
+    assert "project:agent-bom-first-run" not in output
 
 
 def test_compact_agents_skips_unconfigured():

--- a/tests/test_hardening_phase2.py
+++ b/tests/test_hardening_phase2.py
@@ -418,7 +418,7 @@ class TestInventoryCSV:
         with pytest.raises(ValueError, match="empty"):
             _load_csv_inventory(io.StringIO(""))
 
-    def test_rows_with_empty_name_skipped(self):
+    def test_rows_with_empty_name_skipped(self, caplog):
         from agent_bom.inventory import _load_csv_inventory
 
         csv_data = "name,version,ecosystem\n,1.0,pypi\nfoo,2.0,pypi\n"
@@ -426,6 +426,7 @@ class TestInventoryCSV:
         pkgs = result["agents"][0]["mcp_servers"][0]["packages"]
         assert len(pkgs) == 1
         assert pkgs[0]["name"] == "foo"
+        assert "Skipped 1 CSV inventory row" in caplog.text
 
     def test_ecosystem_defaults_to_unknown(self):
         from agent_bom.inventory import _load_csv_inventory


### PR DESCRIPTION
Summary
- clarify clean-scan config posture messaging so `SECURITY POSTURE: CLEAN` is not paired with vague vulnerability-style warnings
- render project-scoped agents with human-readable compact table labels instead of raw `project:*` identifiers
- log CSV inventory rows skipped because package name or version is empty
- document the pre-release polish in the 0.84.1 changelog

Why
These are the remaining low-risk hands-on audit polish items before the patch release: reduce clean-scan wording confusion, make agent tables easier to read, and make CSV ingestion drops observable.

Validation
- uv run pytest tests/test_compact_output.py tests/test_hardening_phase2.py::TestInventoryCSV tests/test_output_cov.py::TestPrintScanPerformanceSummary tests/test_core.py::test_json_output_labels_unknown_severity_as_advisory_state -q
- uv run ruff check src/agent_bom/posture.py src/agent_bom/output/compact.py src/agent_bom/inventory.py tests/test_compact_output.py tests/test_hardening_phase2.py
- git diff --check
