### PR TITLE
Fix Dependabot lockfile normalize loop

### DIFF
--- a/.github/workflows/dependabot-ui-lockfile-normalize.yml
+++ b/.github/workflows/dependabot-ui-lockfile-normalize.yml
@@ -67,6 +67,7 @@ jobs:
         # trusting the PR's `scripts` block.
         run: |
           cd ui
+          cp package-lock.json /tmp/ui-package-lock.from-pr.json
           npm install --package-lock-only --ignore-scripts
 
       - name: Commit normalized lockfile
@@ -81,7 +82,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          if git diff --quiet -- ui/package-lock.json; then
+          if cmp -s /tmp/ui-package-lock.from-pr.json ui/package-lock.json; then
             echo "No normalized lockfile changes to commit."
             exit 0
           fi


### PR DESCRIPTION
Summary
- compare the normalized UI lockfile against the PR-supplied lockfile instead of the trusted base branch index
- prevent the normalize workflow from committing a fresh no-op normalization commit on every reopen/synchronize

Why
#2164 kept moving to a new head SHA after every retrigger because the workflow always saw the expected Dependabot lockfile diff relative to main as a change to commit. That detached checks from the current PR head repeatedly.

Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dependabot-ui-lockfile-normalize.yml"); puts "workflow parses"'
- git diff --check