### PR TITLE
Fix release tag gates

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
           path: site
 
   deploy:
-    if: ${{ github.event_name != 'workflow_call' || inputs.deploy != false }}
+    if: ${{ github.event_name != 'workflow_call' || inputs.deploy == true }}
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/src/agent_bom/glama.py
+++ b/src/agent_bom/glama.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from agent_bom.http_client import create_client, request_with_retry
-from agent_bom.mcp_registry_text import normalize_registry_description
+from agent_bom.mcp_registry_text import dumps_registry_json, normalize_registry_description
 from agent_bom.models import Package
 
 logger = logging.getLogger(__name__)
@@ -291,7 +291,7 @@ async def sync_from_glama(
         local_data["servers"] = local_servers
         local_data["_updated"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         local_data["_total_servers"] = len(local_servers)
-        _REGISTRY_PATH.write_text(json.dumps(local_data, indent=2) + "\n")
+        _REGISTRY_PATH.write_text(dumps_registry_json(local_data), encoding="utf-8")
         logger.info("Added %d Glama servers to registry", result.added)
 
     return result

--- a/src/agent_bom/mcp_official_registry.py
+++ b/src/agent_bom/mcp_official_registry.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from agent_bom.http_client import create_client, request_with_retry
-from agent_bom.mcp_registry_text import normalize_registry_description
+from agent_bom.mcp_registry_text import dumps_registry_json, normalize_registry_description
 from agent_bom.models import MCPServer, Package
 
 logger = logging.getLogger(__name__)
@@ -299,7 +299,7 @@ async def sync_from_official_registry(
         local_data["servers"] = local_servers
         local_data["_updated"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         local_data["_mcp_registry_sync"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        _REGISTRY_PATH.write_text(json.dumps(local_data, indent=2) + "\n")
+        _REGISTRY_PATH.write_text(dumps_registry_json(local_data), encoding="utf-8")
 
     return result
 

--- a/src/agent_bom/mcp_registry.json
+++ b/src/agent_bom/mcp_registry.json
@@ -2,7 +2,7 @@
   "_comment": "agent-bom MCP Server Registry — security metadata database for known MCP servers",
   "_schema_version": "2.0",
   "_updated": "2026-05-01",
-  "_total_servers": 657,
+  "_total_servers": 658,
   "_differentiator": "Security metadata database — not just a catalog. Each entry has risk_level (category-derived), tools, credential_env_vars (heuristic-inferred) for blast radius pre-computation.",
   "_source": "https://github.com/msaad00/agent-bom/blob/main/data/mcp-registry.yaml",
   "_sources": [
@@ -12736,6 +12736,19 @@
       "source": "glama",
       "glama_id": "u9ncaux4l6",
       "glama_url": "https://glama.ai/mcp/servers/u9ncaux4l6",
+      "auto_enriched": true
+    },
+    "kushalsai-01/mcp-server-codebase-analyser": {
+      "ecosystem": "npm",
+      "package": "kushalsai-01/mcp-server-codebase-analyser",
+      "description": "Analyzes TypeScript codebases for health issues, fetches system incidents, and generates remediatio…",
+      "risk_level": "medium",
+      "tools": [],
+      "repository": "https://github.com/kushalsai-01/mcp-server-codebase-analyser",
+      "license": "MIT License",
+      "source": "glama",
+      "glama_id": "ir7wgxu3aa",
+      "glama_url": "https://glama.ai/mcp/servers/ir7wgxu3aa",
       "auto_enriched": true
     }
   },

--- a/src/agent_bom/mcp_registry_text.py
+++ b/src/agent_bom/mcp_registry_text.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 MCP_REGISTRY_DESCRIPTION_MAX_CHARS = 100
 
 
@@ -16,3 +18,8 @@ def normalize_registry_description(value: object, *, max_chars: int = MCP_REGIST
     if len(text) <= max_chars:
         return text
     return text[: max_chars - 1].rstrip() + "…"
+
+
+def dumps_registry_json(value: object) -> str:
+    """Serialize bundled registry JSON with stable Unicode-preserving output."""
+    return json.dumps(value, indent=2, ensure_ascii=False) + "\n"

--- a/src/agent_bom/registry.py
+++ b/src/agent_bom/registry.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from agent_bom.mcp_registry_text import dumps_registry_json
 from agent_bom.models import Package
 
 logger = logging.getLogger(__name__)
@@ -416,7 +417,7 @@ async def update_registry_versions(
         from datetime import datetime, timezone
 
         data["_updated"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        _REGISTRY_PATH.write_text(json.dumps(data, indent=2) + "\n")
+        _REGISTRY_PATH.write_text(dumps_registry_json(data), encoding="utf-8")
 
     return result
 
@@ -628,7 +629,7 @@ def enrich_registry_entries(dry_run: bool = False) -> EnrichResult:
         from datetime import datetime, timezone
 
         data["_updated"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        _REGISTRY_PATH.write_text(json.dumps(data, indent=2) + "\n")
+        _REGISTRY_PATH.write_text(dumps_registry_json(data), encoding="utf-8")
 
     return result
 
@@ -836,7 +837,7 @@ async def enrich_registry_with_cves(
 
         data["_cve_enriched"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         data["_updated"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        _REGISTRY_PATH.write_text(json.dumps(data, indent=2) + "\n")
+        _REGISTRY_PATH.write_text(dumps_registry_json(data), encoding="utf-8")
 
     return result
 

--- a/src/agent_bom/registry_enrichment.py
+++ b/src/agent_bom/registry_enrichment.py
@@ -25,7 +25,7 @@ from typing import Any
 
 import httpx
 
-from agent_bom.mcp_registry_text import normalize_registry_description
+from agent_bom.mcp_registry_text import dumps_registry_json, normalize_registry_description
 
 _logger = logging.getLogger(__name__)
 
@@ -302,10 +302,7 @@ def enrich_registry(
     registry["_enrichment_sources"] = ["smithery", "docker_hub", "github"]
 
     # Write back
-    _REGISTRY_PATH.write_text(
-        json.dumps(registry, indent=2, ensure_ascii=False) + "\n",
-        encoding="utf-8",
-    )
+    _REGISTRY_PATH.write_text(dumps_registry_json(registry), encoding="utf-8")
 
     stats["total"] = len(servers)
     stats["new"] = len(servers) - existing_count

--- a/src/agent_bom/smithery.py
+++ b/src/agent_bom/smithery.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from agent_bom.http_client import create_client, request_with_retry
-from agent_bom.mcp_registry_text import normalize_registry_description
+from agent_bom.mcp_registry_text import dumps_registry_json, normalize_registry_description
 from agent_bom.models import MCPServer, Package
 
 logger = logging.getLogger(__name__)
@@ -390,7 +390,7 @@ async def sync_from_smithery(
         local_data["servers"] = local_servers
         local_data["_updated"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         local_data["_smithery_sync"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        _REGISTRY_PATH.write_text(json.dumps(local_data, indent=2) + "\n")
+        _REGISTRY_PATH.write_text(dumps_registry_json(local_data), encoding="utf-8")
 
     return result
 


### PR DESCRIPTION
## Summary
- skip GitHub Pages deployment when docs.yml is called from the tag release workflow with deploy=false
- centralize bundled MCP registry JSON serialization so all registry writers preserve Unicode and avoid release-gate formatting churn
- refresh the bundled MCP registry with the latest Glama delta so sync-all is committed for v0.84.1

## Validation
- uv run pytest tests/test_registry.py tests/test_smithery.py tests/test_glama.py -q
- uv run ruff check src/agent_bom/mcp_registry_text.py src/agent_bom/mcp_official_registry.py src/agent_bom/smithery.py src/agent_bom/glama.py src/agent_bom/registry.py src/agent_bom/registry_enrichment.py tests/test_registry.py tests/test_smithery.py tests/test_glama.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docs.yml"); YAML.load_file(".github/workflows/release.yml"); puts "workflows parse"'
- git diff --check
- uv run python - <<'PY'
import json
from pathlib import Path
from agent_bom.mcp_registry_text import dumps_registry_json
p=Path('src/agent_bom/mcp_registry.json')
text=p.read_text()
data=json.loads(text)
rendered=dumps_registry_json(data)
assert rendered == text
assert '\u2026' not in rendered
assert all(len((entry.get('description') or '')) <= 100 for entry in data.get('servers', {}).values())
PY