### PR TITLE
Bump release surfaces to v0.84.4

### DIFF
--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom
-        run: uv tool install agent-bom==0.84.3  # pinned — bump on each release
+        run: uv tool install agent-bom==0.84.4  # pinned — bump on each release
 
       - name: Scan changed MCP configs
         id: scan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,16 +133,27 @@ jobs:
         run: |
           set -euo pipefail
           if ! uv run agent-bom registry status --stale-after-days 14 --fail-on-stale --format json; then
-            echo "::error::Bundled MCP registry freshness is stale or invalid. Run 'uv run agent-bom registry sync-all --max-pages 10', review and commit src/agent_bom/mcp_registry.json, then retag the release."
+            echo "::error::Bundled MCP registry freshness is stale or invalid. Refresh the committed registry in a pre-release PR, review src/agent_bom/mcp_registry.json, then retag the release."
             exit 1
           fi
 
-      - name: Verify MCP registry sync is committed
+      - name: Verify MCP registry serialization is stable
         run: |
           set -euo pipefail
-          uv run agent-bom registry sync-all --max-pages 10
+          uv run python - <<'PY'
+          import json
+          from pathlib import Path
+
+          from agent_bom.mcp_registry_text import dumps_registry_json
+
+          path = Path("src/agent_bom/mcp_registry.json")
+          current = path.read_text(encoding="utf-8")
+          normalized = dumps_registry_json(json.loads(current))
+          if normalized != current:
+              path.write_text(normalized, encoding="utf-8")
+          PY
           if ! git diff --quiet -- src/agent_bom/mcp_registry.json; then
-            echo "::error::Bundled MCP registry changed during release sync. Run 'uv run agent-bom registry sync-all --max-pages 10', review and commit src/agent_bom/mcp_registry.json, then retag the release."
+            echo "::error::Bundled MCP registry serialization is not stable. Run the registry formatter locally, review and commit src/agent_bom/mcp_registry.json, then retag the release."
             git diff --stat -- src/agent_bom/mcp_registry.json
             git diff -- src/agent_bom/mcp_registry.json | head -200 || true
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.84.4] – 2026-05-01
+
+### Fixed
+- **Deterministic release registry gate** — tag workflows now verify committed registry freshness and local JSON serialization stability without running live registry syncs against moving external catalogs.
+- **Patch release alignment** — bumped release surfaces from the failed `v0.84.3` tag to `v0.84.4` after the registry gate proved the live-sync check was nondeterministic.
+
+---
+
 ## [0.84.3] – 2026-05-01
 
 ### Fixed
@@ -999,7 +1007,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
-[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.84.3...HEAD
+[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.84.4...HEAD
+[0.84.4]: https://github.com/msaad00/agent-bom/compare/v0.84.3...v0.84.4
 [0.84.3]: https://github.com/msaad00/agent-bom/compare/v0.84.2...v0.84.3
 [0.84.2]: https://github.com/msaad00/agent-bom/compare/v0.84.1...v0.84.2
 [0.84.1]: https://github.com/msaad00/agent-bom/compare/v0.84.0...v0.84.1

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -188,7 +188,7 @@ Focused graph:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `0.84.3` | Current stable version (pinned) |
+| `0.84.4` | Current stable version (pinned) |
 
 Published images:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.3-alpine3.23@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510
 
-ARG VERSION=0.84.3
+ARG VERSION=0.84.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ for the full split-vs-single-image guidance.
 |------|----------|
 | CLI (`agent-bom agents`) | local audit + project scan |
 | Endpoint fleet (`--push-url …/v1/fleet/sync`) | employee laptops pushing into self-hosted fleet |
-| GitHub Action (`uses: msaad00/agent-bom@v0.84.3`) | CI/CD + SARIF |
+| GitHub Action (`uses: msaad00/agent-bom@v0.84.4`) | CI/CD + SARIF |
 | Docker (`agentbom/agent-bom`) | isolated scans, API jobs, and non-browser self-hosted entrypoints |
 | Browser UI image (`agentbom/agent-bom-ui`) | the dashboard image paired with the same self-hosted control plane |
 | Kubernetes / Helm (`helm install agent-bom deploy/helm/agent-bom`) | self-hosted API + dashboard, scheduled discovery |
@@ -404,7 +404,7 @@ References: [PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md) · [PRODUCT_METRICS.md](do
 <summary><b>CI/CD in 60 seconds</b></summary>
 
 ```yaml
-- uses: msaad00/agent-bom@v0.84.3
+- uses: msaad00/agent-bom@v0.84.4
   with:
     scan-type: scan
     severity-threshold: high

--- a/deploy/docker-compose.fullstack.yml
+++ b/deploy/docker-compose.fullstack.yml
@@ -27,7 +27,7 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
-    image: agentbom/agent-bom:0.84.3
+    image: agentbom/agent-bom:0.84.4
     container_name: agent-bom-api
     restart: unless-stopped
     command: api --host 0.0.0.0 --port 8422 --allow-insecure-no-auth
@@ -74,7 +74,7 @@ services:
       args:
         # Baked into the Next.js build — must match the publicly reachable API URL
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8422}
-    image: agentbom/agent-bom-ui:0.84.3
+    image: agentbom/agent-bom-ui:0.84.4
     container_name: agent-bom-ui
     restart: unless-stopped
     ports:

--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -18,7 +18,7 @@
 
 services:
   api:
-    image: agentbom/agent-bom:0.84.3
+    image: agentbom/agent-bom:0.84.4
     container_name: agent-bom-pilot-api
     restart: unless-stopped
     command: >
@@ -45,7 +45,7 @@ services:
       start_period: 10s
 
   ui:
-    image: agentbom/agent-bom-ui:0.84.3
+    image: agentbom/agent-bom-ui:0.84.4
     container_name: agent-bom-pilot-ui
     restart: unless-stopped
     environment:

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -112,7 +112,7 @@ services:
       dockerfile: Dockerfile
       args:
         NEXT_PUBLIC_API_URL: http://localhost:8422
-    image: agentbom/agent-bom-ui:0.84.3
+    image: agentbom/agent-bom-ui:0.84.4
     container_name: agent-bom-ui
     ports:
       - "3000:3000"

--- a/deploy/docker-compose.runtime.yml
+++ b/deploy/docker-compose.runtime.yml
@@ -31,7 +31,7 @@ services:
     build:
       context: ..
       dockerfile: deploy/docker/Dockerfile.runtime
-    image: agentbom/agent-bom:0.84.3
+    image: agentbom/agent-bom:0.84.4
     container_name: agent-bom-runtime-proxy
     depends_on:
       - mcp-server

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -27,7 +27,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.84.3
+ARG VERSION=0.84.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -17,7 +17,7 @@ WORKDIR /app
 COPY pyproject.toml README.md LICENSE ./
 COPY src/ ./src/
 
-ARG VERSION=0.84.3
+ARG VERSION=0.84.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
@@ -40,7 +40,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[runtime]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.84.3
+ARG VERSION=0.84.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.snowpark
+++ b/deploy/docker/Dockerfile.snowpark
@@ -26,7 +26,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11.12-slim@sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c
 
-ARG VERSION=0.84.3
+ARG VERSION=0.84.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -41,7 +41,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.84.3
+ARG VERSION=0.84.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: agent-bom
 description: Open security scanner and graph for AI supply chain and infrastructure — discover agents and MCP, map blast radius, and inspect runtime.
-version: 0.84.3
-appVersion: "0.84.3"
+version: 0.84.4
+appVersion: "0.84.4"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -5,17 +5,17 @@
 
 image:
   repository: agentbom/agent-bom
-  tag: "0.84.3"
+  tag: "0.84.4"
   pullPolicy: IfNotPresent
 
 uiImage:
   repository: agentbom/agent-bom-ui
-  tag: "0.84.3"
+  tag: "0.84.4"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom
-  tag: "0.84.3"
+  tag: "0.84.4"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -38,7 +38,7 @@ tests:
   includeUi: true
   image:
     repository: agentbom/agent-bom
-    tag: "0.84.3"
+    tag: "0.84.4"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deploy/k8s/daemonset.yaml
+++ b/deploy/k8s/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: agent-bom
       containers:
         - name: monitor
-          image: agentbom/agent-bom:0.84.3
+          image: agentbom/agent-bom:0.84.4
           command: ["agent-bom"]
           args:
             - "protect"

--- a/deploy/k8s/proxy-sidecar-pilot.yaml
+++ b/deploy/k8s/proxy-sidecar-pilot.yaml
@@ -109,7 +109,7 @@ spec:
               cpu: "500m"
 
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.84.3
+          image: agentbom/agent-bom:0.84.4
           args:
             - "--policy"
             - "/etc/agent-bom/policy.json"

--- a/deploy/k8s/sidecar-example.yaml
+++ b/deploy/k8s/sidecar-example.yaml
@@ -40,7 +40,7 @@ spec:
 
         # agent-bom proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.84.3
+          image: agentbom/agent-bom:0.84.4
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -135,7 +135,7 @@ agent-bom agents --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.84.3
+- uses: msaad00/agent-bom@v0.84.4
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -72,7 +72,7 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # GitHub Actions
-- uses: msaad00/agent-bom@v0.84.3
+- uses: msaad00/agent-bom@v0.84.4
   with:
     scan-type: agents        # auto-detect MCP configs + deps
     severity-threshold: high # fail PR on HIGH+ CVEs
@@ -90,21 +90,21 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # Container image gate
-- uses: msaad00/agent-bom@v0.84.3
+- uses: msaad00/agent-bom@v0.84.4
   with:
     scan-type: image
     scan-ref: ghcr.io/acme/agent-runtime:sha-abcdef
     severity-threshold: critical
 
 # IaC gate
-- uses: msaad00/agent-bom@v0.84.3
+- uses: msaad00/agent-bom@v0.84.4
   with:
     scan-type: iac
     iac: Dockerfile,k8s/,infra/main.tf
     severity-threshold: high
 
 # Air-gapped or fully cached CI
-- uses: msaad00/agent-bom@v0.84.3
+- uses: msaad00/agent-bom@v0.84.4
   with:
     auto-update-db: false
     enrich: false
@@ -468,7 +468,7 @@ AmazonEC2ReadOnlyAccess
 docker run --rm \
   -v ~/.config:/home/abom/.config:ro \
   -v $(pwd):/workspace:ro \
-  agentbom/agent-bom:0.84.3 agents --format json
+  agentbom/agent-bom:0.84.4 agents --format json
 ```
 
 Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base image.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -242,7 +242,7 @@ blast_radius        — blast radius for a specific CVE
 ### CI/CD (GitHub Action)
 
 ```yaml
-- uses: msaad00/agent-bom@v0.84.3
+- uses: msaad00/agent-bom@v0.84.4
   with:
     format: sarif
     upload-sarif: 'true'

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,6 +1,6 @@
 {
   "generated_on": "2026-04-30",
-  "version": "0.84.3",
+  "version": "0.84.4",
   "metrics": [
     {
       "name": "MCP tools",

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -6,7 +6,7 @@ This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
 - Generated on: `2026-04-30`
-- Version: `0.84.3`
+- Version: `0.84.4`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -97,7 +97,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN" --no-browser
 clawhub publish integrations/openclaw/scan \
   --slug agent-bom-scan --name "agent-bom scan" \
-  --version "0.84.3"
+  --version "0.84.4"
 ```
 
 Release automation uses the same official `clawhub` CLI flow, not a custom
@@ -150,8 +150,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.84.3
-git push origin v0.84.3
+git tag v0.84.4
+git push origin v0.84.4
 ```
 
 This triggers:

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -13,7 +13,7 @@ For each tagged GitHub Release, expect:
 ## Download release assets
 
 ```bash
-TAG=v0.84.3
+TAG=v0.84.4
 VERSION="${TAG#v}"
 mkdir -p /tmp/agent-bom-release && cd /tmp/agent-bom-release
 gh release download "$TAG" --repo msaad00/agent-bom

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -33,7 +33,7 @@ The proxy interposes on the stdio channel between an MCP client (Claude Desktop,
 Use the published main runtime image:
 
 ```bash
-docker pull agentbom/agent-bom:0.84.3
+docker pull agentbom/agent-bom:0.84.4
 ```
 
 If you need to rebuild locally from the checked-out repo, you can still use
@@ -45,7 +45,7 @@ Run as a wrapper around any MCP server:
 ```bash
 docker run --rm \
   -v $(pwd)/audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.84.3 \
+  agentbom/agent-bom:0.84.4 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace
@@ -94,7 +94,7 @@ spec:
 
         # agent-bom runtime proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.84.3
+          image: agentbom/agent-bom:0.84.4
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"
@@ -334,7 +334,7 @@ Use the runtime container directly from Claude Desktop:
         "run", "--rm", "-i",
         "-v", "./workspace:/workspace",
         "-v", "./audit-logs:/var/log/agent-bom",
-        "agentbom/agent-bom:0.84.3",
+        "agentbom/agent-bom:0.84.4",
         "--log", "/var/log/agent-bom/audit.jsonl",
         "--block-undeclared",
         "--",

--- a/docs/archive/WINDOWS_CONTAINERS.md
+++ b/docs/archive/WINDOWS_CONTAINERS.md
@@ -113,7 +113,7 @@ container inspection. Windows Server environments should use:
 
 1. **Python CLI** -- `pip install agent-bom` works on Windows natively
 2. **Docker Desktop** -- run the Linux container images on Windows via WSL 2
-3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.84.3`) which
+3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.84.4`) which
    runs on Linux runners
 
 ---

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,4 +1,4 @@
-# agent-bom v0.84.3 blast-radius demo
+# agent-bom v0.84.4 blast-radius demo
 # Shows: blast radius → package gate
 
 Output docs/images/demo-latest.gif

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
-  "version": "0.84.3",
+  "version": "0.84.4",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
   "title": "agent-bom",
-  "version": "0.84.3",
+  "version": "0.84.4",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.84.3",
+      "version": "0.84.4",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   security checks. Use when the user mentions vulnerability scanning,
   MCP server trust, compliance, SBOM generation, CIS benchmarks, blast
   radius, or AI supply chain risk.
-version: 0.84.3
+version: 0.84.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -25,7 +25,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.84.3
+    docker: ghcr.io/msaad00/agent-bom:0.84.4
   openclaw:
     requires:
       bins: []
@@ -412,6 +412,6 @@ provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.84.3`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.84.4`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Analyze blast radius, attack paths, and threat landscape across your AI
   infrastructure. Use when: "blast radius", "threat intel", "risk score",
   "attack path", "lateral movement", "context graph", "who can reach what".
-version: 0.84.3
+version: 0.84.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.84.3
+    docker: ghcr.io/msaad00/agent-bom:0.84.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Generate SBOMs and compliance reports. Use when:
   "compliance report", "NIST", "SOC 2", "ISO 27001", "OWASP", "EU AI Act",
   "AISVS", "generate SBOM", "policy check".
-version: 0.84.3
+version: 0.84.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. OWASP/NIST/EU AI Act/MITRE
@@ -23,7 +23,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.84.3
+    docker: ghcr.io/msaad00/agent-bom:0.84.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/discover-aws/SKILL.md
+++ b/integrations/openclaw/discover-aws/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   inventory AWS Bedrock, ECS, SageMaker, Lambda, EKS, Step Functions, EC2, or
   agentic AWS infrastructure as canonical inventory. Passing that inventory
   to agent-bom is optional and operator-chosen.
-version: 0.84.3
+version: 0.84.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-azure/SKILL.md
+++ b/integrations/openclaw/discover-azure/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   giving agent-bom long-lived Azure credentials. Use when a user asks to
   inventory Azure OpenAI, Container Apps, AKS, Functions, ML, or agentic Azure
   infrastructure as canonical inventory.
-version: 0.84.3
+version: 0.84.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-gcp/SKILL.md
+++ b/integrations/openclaw/discover-gcp/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   giving agent-bom long-lived GCP credentials. Use when a user asks to
   inventory Vertex AI, Cloud Run, Cloud Functions, GKE, or agentic GCP
   infrastructure as canonical inventory.
-version: 0.84.3
+version: 0.84.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-snowflake/SKILL.md
+++ b/integrations/openclaw/discover-snowflake/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   agent-bom inventory JSON, and scan it without giving agent-bom long-lived
   Snowflake credentials. Use when a user asks to inventory Snowflake AI or
   Cortex infrastructure as canonical inventory.
-version: 0.84.3
+version: 0.84.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed with the snowflake extra, and

--- a/integrations/openclaw/discover/SKILL.md
+++ b/integrations/openclaw/discover/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Discover AI agents, MCP servers, and configurations on this machine or
   environment. Use when: "find agents", "what's configured", "doctor",
   "what MCP servers", "show me what's installed", "mcp inventory".
-version: 0.84.3
+version: 0.84.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.84.3
+    docker: ghcr.io/msaad00/agent-bom:0.84.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Enforce security policies on MCP tool calls and block dangerous operations at
   runtime. Use when: "block risky calls", "apply policy", "proxy",
   "runtime protection", "policy enforcement", "intercept MCP calls".
-version: 0.84.3
+version: 0.84.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.84.3
+    docker: ghcr.io/msaad00/agent-bom:0.84.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/ingest/SKILL.md
+++ b/integrations/openclaw/ingest/SKILL.md
@@ -5,10 +5,10 @@ description: >-
   GCP, Snowflake, CMDB, or endpoint collectors. Use when a user has canonical
   inventory JSON and wants local findings, graph, policy, provenance, or
   auditor-ready exports without giving agent-bom direct cloud credentials.
-version: 0.84.3
+version: 0.84.4
 license: Apache-2.0
 compatibility: >-
-  Requires Python 3.11+ and agent-bom 0.84.3+. Inventory must conform to the
+  Requires Python 3.11+ and agent-bom 0.84.4+. Inventory must conform to the
   packaged inventory.schema.json contract.
 metadata:
   author: msaad00

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Monitor agent fleet, track trust scores, and manage lifecycle states. Use
   when: "fleet", "watch agents", "runtime status", "trust scores",
   "fleet sync", "agent lifecycle", "serve dashboard".
-version: 0.84.3
+version: 0.84.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.84.3
+    docker: ghcr.io/msaad00/agent-bom:0.84.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.84.3
+version: 0.84.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.84.3
+version: 0.84.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Scan infrastructure-as-code, cloud configurations, and find secrets. Use when:
   "check terraform", "scan kubernetes", "IaC", "find secrets",
   "scan dockerfile", "cloud security", "misconfigurations".
-version: 0.84.3
+version: 0.84.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.84.3
+    docker: ghcr.io/msaad00/agent-bom:0.84.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   KEV), container images, provenance, filesystems, and SBOMs. Use
   when: "check package", "scan image", "verify", "is this safe",
   "scan dependencies", "CVE lookup", "blast radius".
-version: 0.84.3
+version: 0.84.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Native container image
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.84.3
+    docker: ghcr.io/msaad00/agent-bom:0.84.4
   openclaw:
     requires:
       bins: []
@@ -237,6 +237,6 @@ agent-bom agents
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.84.3`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.84.4`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Diagnose issues, check prerequisites, and validate configurations. Use when:
   "doctor", "debug", "why failing", "validate config", "check prerequisites",
   "something is broken", "db status", "fix my setup".
-version: 0.84.3
+version: 0.84.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.84.3
+    docker: ghcr.io/msaad00/agent-bom:0.84.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/vulnerability-intel/SKILL.md
+++ b/integrations/openclaw/vulnerability-intel/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   with explicit data-boundary choices. Use when a user asks for CVE lookup,
   advisory intelligence, exploitability context, fix versions, GHSA/OSV/NVD
   enrichment, or package vulnerability triage.
-version: 0.84.3
+version: 0.84.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+ and agent-bom installed from this repository or PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.84.3"
+version = "0.84.4"
 description = "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius."
 readme = "PYPI_README.md"
 license = "Apache-2.0"

--- a/site-docs/deployment/airgapped-image-bundle.md
+++ b/site-docs/deployment/airgapped-image-bundle.md
@@ -12,7 +12,7 @@ From an internet-connected build host:
 
 ```bash
 scripts/release/build-airgap-image-bundle.sh \
-  --version 0.84.3 \
+  --version 0.84.4 \
   --platform linux/amd64 \
   --output-dir dist/airgap
 ```
@@ -33,8 +33,8 @@ machine.
 ## Import On The Disconnected Host
 
 ```bash
-tar -xzf agent-bom-airgap-0.84.3-linux_amd64.tar.gz
-cd agent-bom-airgap-0.84.3-linux_amd64
+tar -xzf agent-bom-airgap-0.84.4-linux_amd64.tar.gz
+cd agent-bom-airgap-0.84.4-linux_amd64
 ./load-images.sh
 ```
 
@@ -43,7 +43,7 @@ The loader verifies archive checksums before running `docker load`.
 ## Push To An Internal Registry
 
 ```bash
-VERSION=0.84.3
+VERSION=0.84.4
 REGISTRY=registry.internal.example.com/security
 
 docker tag "agentbom/agent-bom:${VERSION}" "${REGISTRY}/agent-bom:${VERSION}"
@@ -58,13 +58,13 @@ Then point Helm at the internal registry:
 ```yaml
 image:
   repository: registry.internal.example.com/security/agent-bom
-  tag: "0.84.3"
+  tag: "0.84.4"
 
 controlPlane:
   ui:
     image:
       repository: registry.internal.example.com/security/agent-bom-ui
-      tag: "0.84.3"
+      tag: "0.84.4"
 ```
 
 ## GitHub Actions Bundle Job

--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -342,8 +342,8 @@ through a managed tap instead of direct package upload.
 
 ```bash
 python3 scripts/render_homebrew_formula.py \
-  --version 0.84.3 \
-  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.84.3.tar.gz \
+  --version 0.84.4 \
+  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.84.4.tar.gz \
   --sha256 <release-sha256>
 ```
 

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -171,7 +171,7 @@ Install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.84.3 \
+  --version 0.84.4 \
   -n agent-bom --create-namespace \
   -f values.agent-bom.yaml
 ```
@@ -207,7 +207,7 @@ Then install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.84.3 \
+  --version 0.84.4 \
   -n agent-bom --create-namespace \
   -f deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
 ```

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -92,10 +92,10 @@ docker run --rm \
 ## Runtime proxy sidecar
 
 ```bash
-docker pull agentbom/agent-bom:0.84.3
+docker pull agentbom/agent-bom:0.84.4
 docker run --rm -i \
   -v ./audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.84.3 \
+  agentbom/agent-bom:0.84.4 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace

--- a/site-docs/deployment/snowflake-pov.md
+++ b/site-docs/deployment/snowflake-pov.md
@@ -6,7 +6,7 @@ the operator boundary.
 
 ## Scope
 
-The v0.84.3 POV scope is:
+The v0.84.4 POV scope is:
 
 - self-hosted API + UI control plane
 - operator-owned Postgres-compatible control-plane database
@@ -172,7 +172,7 @@ goal.
 
 | Surface | Current state |
 |---|---|
-| Draft PR remediation | Roadmap; not part of v0.84.3 |
+| Draft PR remediation | Roadmap; not part of v0.84.4 |
 | Auto-remediation | Roadmap |
 | Full Compliance Hub | Roadmap |
 | Complete IAM-to-agent traversal | Roadmap |

--- a/site-docs/features/policy.md
+++ b/site-docs/features/policy.md
@@ -49,7 +49,7 @@ agent-bom proxy --policy policy.json --block-undeclared -- ...
 
 ```yaml
 - name: Security gate
-  uses: msaad00/agent-bom@v0.84.3
+  uses: msaad00/agent-bom@v0.84.4
   with:
     policy: policy.json
     fail-on-violation: true

--- a/site-docs/reference/remediate-output.md
+++ b/site-docs/reference/remediate-output.md
@@ -27,7 +27,7 @@ agent-bom remediate -p . --format json --server-group --output plan.json
 
 ```json
 {
-  "version": "0.84.3",
+  "version": "0.84.4",
   "generated_at": "2026-04-21T12:00:00+00:00",
   "remediation_plan": [],
   "summary": {

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.84.3"
+    __version__ = "0.84.4"
 
 # Cross-check against pyproject.toml for dev installs where the editable
 # install metadata may be stale (i.e. version bumped but not re-installed).

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -298,6 +298,14 @@ def test_docs_workflow_never_deploys_pages_from_release_tags():
     assert "actions/deploy-pages" in workflow
 
 
+def test_release_registry_gate_is_deterministic_without_live_sync():
+    """Tag releases should not mutate the bundled registry from live catalogs."""
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text()
+    assert "agent-bom registry status --stale-after-days 14 --fail-on-stale" in workflow
+    assert "dumps_registry_json" in workflow
+    assert "agent-bom registry sync-all" not in workflow
+
+
 def test_publish_registries_workflow_requires_public_smithery_surface_and_curated_clawhub_set():
     """Registry publishing should fail fast on auth-gated Smithery URLs and avoid omnibus ClawHub skills."""
     workflow = (ROOT / ".github" / "workflows" / "publish-registries.yml").read_text()

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.84.3",
+  "version": "0.84.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.84.3",
+      "version": "0.84.4",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
         "@tanstack/react-table": "^8.21.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.84.3",
+  "version": "0.84.4",
   "private": true,
   "packageManager": "npm@10.9.7",
   "engines": {

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/lib/api', () => ({
       scan_sources: [],
       scan_count: 0,
     }),
-    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.84.3' }),
+    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.84.4' }),
   },
 }))
 

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ overrides = [{ name = "python-dotenv", specifier = ">=1.2.2" }]
 
 [[package]]
 name = "agent-bom"
-version = "0.84.3"
+version = "0.84.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Summary
- bump all release surfaces from the failed v0.84.3 tag to v0.84.4
- remove live registry sync from the release gate to avoid racing external MCP catalog changes at tag time
- keep the release gate deterministic: check committed registry freshness and local JSON serialization stability only
- add regression coverage so release.yml cannot reintroduce registry sync-all and docs deploy remains branch-main gated

Why
The v0.84.3 tag failed because Glama added three servers between the committed registry refresh and the release workflow. Running sync-all during a tag release creates a TOCTOU race against live external catalogs. Registry refresh belongs in a pre-release PR; tag release should only verify committed state.

Artifact check
- No GitHub Releases for 0.84.1/0.84.2/0.84.3
- No PyPI releases for 0.84.1/0.84.2/0.84.3
- No Docker tags for 0.84.1/0.84.2/0.84.3

Validation
- uv run python scripts/check_release_consistency.py
- uv run pytest tests/test_deployment.py::test_docs_workflow_never_deploys_pages_from_release_tags tests/test_deployment.py::test_release_registry_gate_is_deterministic_without_live_sync tests/test_deployment.py::test_mcp_registry_entry_valid tests/test_stats_alignment.py -q
- uv run ruff check tests/test_deployment.py scripts/check_release_consistency.py src/agent_bom/__init__.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docs.yml"); YAML.load_file(".github/workflows/release.yml"); puts "workflow YAML parses"'\n- registry serializer dry-run: stable=True and git diff clean\n- git diff --check