### PR TITLE
Add MCP package version provenance

### DIFF
--- a/config/schemas/inventory.schema.json
+++ b/config/schemas/inventory.schema.json
@@ -6,6 +6,45 @@
 
   "$defs": {
 
+    "VersionProvenance": {
+      "title": "Package Version Provenance",
+      "description": "Evidence for how a package version was resolved.",
+      "type": "object",
+      "properties": {
+        "declared_name": { "type": "string" },
+        "declared_version": { "type": "string" },
+        "resolved_version": { "type": "string" },
+        "version_source": {
+          "type": "string",
+          "enum": ["runtime_process", "image_sbom", "installed_package", "tool_cache", "lockfile", "command_pin", "registry_latest", "unknown"]
+        },
+        "confidence": {
+          "type": "string",
+          "enum": ["exact", "high", "medium", "low", "unknown"]
+        },
+        "observed_at": { "type": "string" },
+        "version_resolved_at": { "type": "string" },
+        "resolved_from_registry": { "type": "boolean" },
+        "floating_reference": { "type": "boolean" },
+        "floating_reference_reason": { "type": "string" },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "version_conflicts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+
     "DiscoveryProvenance": {
       "title": "Discovery Provenance",
       "description": "Low-risk provenance for how an asset was observed. Values are sanitized before persistence/export.",
@@ -41,7 +80,8 @@
         "location": { "type": "string" },
         "confidence": { "type": "string" },
         "resolved_from_registry": { "type": "boolean" },
-        "version_source": { "type": "string" }
+        "version_source": { "type": "string" },
+        "version_provenance": { "$ref": "#/$defs/VersionProvenance" }
       },
       "additionalProperties": false
     },

--- a/docs/decisions/007-mcp-package-version-provenance.md
+++ b/docs/decisions/007-mcp-package-version-provenance.md
@@ -1,0 +1,146 @@
+# ADR-007: MCP Package Version Provenance
+
+**Status:** Accepted
+**Date:** 2026-05-01
+
+## Context
+
+MCP server package scanning must distinguish proven runtime facts from inferred
+or speculative package versions. A server command such as
+`npx @modelcontextprotocol/server-github@1.2.3` gives a different level of
+evidence than `npx @modelcontextprotocol/server-github`, a lockfile, an
+installed package directory, a container SBOM, or a live registry lookup.
+
+Without explicit version provenance, downstream surfaces have to bluff:
+scanner JSON, SARIF, graph nodes, blast-radius scoring, dashboard posture, and
+workflow gates cannot tell whether a CVE is tied to the thing actually running
+or only to a best-effort registry resolution at scan time.
+
+This matters especially for MCP graphs. Packages and tools are sibling surfaces
+under an MCP server: packages carry code-level CVEs, while tools are callable
+capabilities exposed by the server. A vulnerable package can put sibling tools
+at risk through server-scope blast-radius reasoning, but the scanner must not
+claim exact tool-handler reachability unless it has implementation-level proof.
+
+## Decision
+
+Represent package version resolution as structured, validated provenance on the
+package asset and propagate it through scanner output, graph output, SARIF, API
+responses, and UI drilldowns.
+
+The package model should expose a structured provenance object rather than a
+free-form string:
+
+```json
+{
+  "declared_name": "@modelcontextprotocol/server-github",
+  "declared_version": "latest",
+  "resolved_version": "1.2.3",
+  "version_source": "registry_latest",
+  "confidence": "low",
+  "observed_at": "2026-05-01T18:58:00Z",
+  "version_resolved_at": "2026-05-01T18:58:03Z",
+  "evidence": [
+    {
+      "type": "registry",
+      "url": "https://registry.npmjs.org/@modelcontextprotocol/server-github/latest"
+    }
+  ],
+  "version_conflicts": []
+}
+```
+
+`version_source` must be one of:
+
+- `runtime_process`
+- `image_sbom`
+- `installed_package`
+- `tool_cache`
+- `lockfile`
+- `command_pin`
+- `registry_latest`
+- `unknown`
+
+`confidence` must be one of:
+
+- `exact`
+- `high`
+- `medium`
+- `low`
+- `unknown`
+
+Do not ship `registry_at_timestamp` as an active source until install-log
+ingestion exists. Historical registry reconstruction is not reliable enough by
+itself because dist-tags, yanked releases, mirrors, and caches can diverge.
+
+When multiple sources resolve the same package, use deterministic precedence:
+
+```text
+runtime_process > image_sbom > installed_package > tool_cache > lockfile >
+command_pin > registry_latest > unknown
+```
+
+Runtime and SBOM evidence win over intended state. Installed package metadata
+wins over lockfiles when scanning an actual runtime directory. Command pins win
+over registry lookup because they are user-stated intent. When sources
+disagree, preserve the chosen version and emit `version_conflicts`, for example:
+
+```json
+[
+  {"source": "command_pin", "version": "1.2.3"},
+  {"source": "installed_package", "version": "1.2.4"}
+]
+```
+
+Floating versions must preserve both intent and observation. For example,
+`npx pkg@latest` should keep `declared_version: "latest"` and set
+`resolved_version` from the actual source that resolved it. A floating version
+is itself a security posture signal.
+
+Scanner and workflow behavior:
+
+- Exact CVE matching requires `resolved_version`.
+- CVE severity remains factual and must not be rewritten by confidence.
+- Risk and posture scoring may apply confidence multipliers.
+- Fail gates should distinguish proven findings from speculative findings. By
+  default, `--fail-on-severity` should gate on sufficient confidence, while an
+  explicit speculative mode may include low-confidence registry-only findings.
+- The dashboard should expose a Coverage Confidence measure: how many servers
+  and packages are pinned, locked, installed, runtime-observed, or only
+  registry-inferred.
+
+Graph and UI behavior:
+
+- MCP server to package remains `depends_on`.
+- MCP server to tool remains `provides_tool`.
+- Package to vulnerability remains `vulnerable_to`.
+- Vulnerability to tool reachability is conservative unless the scanner has
+  implementation-level tool-handler proof.
+- UI labels must show version source and confidence near package and finding
+  drilldowns, especially for `registry_latest` and `tool_cache`.
+
+Structured evidence should be machine-readable and, when available, include
+fields such as `type`, `path`, `line`, `sha256`, `url`, `process_id`,
+`container_image`, or `sbom_ref`. Evidence should be bounded and sanitized like
+other discovery provenance.
+
+## Consequences
+
+- **Positive:** Findings become auditable: users can see whether a package
+  version came from runtime, SBOM, lockfile, cache, command pin, or registry.
+- **Positive:** Graph, SARIF, JSON, and dashboard surfaces stop overstating
+  registry-only guesses as runtime proof.
+- **Positive:** Package/tool semantics stay honest. Packages and tools are
+  siblings under a server; exact package-to-tool-handler claims require deeper
+  proof.
+- **Positive:** Floating MCP server commands become visible posture issues
+  rather than silently resolving to whatever a registry returns at scan time.
+- **Positive:** Risk scoring can account for measurement quality without
+  mutating the underlying CVE severity.
+- **Trade-off:** Provenance adds schema and UI complexity across scanner,
+  graph, API, SARIF, and dashboard contracts.
+- **Trade-off:** Some existing fields such as `version_source: "detected"` or
+  `source_type: "unknown"` need migration into the structured contract.
+- **Boundary:** This decision defines version provenance and confidence. It
+  does not implement static source-to-tool-handler attribution or sandboxed tool
+  execution. Those are separate tool-level analysis features.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -24,6 +24,7 @@ Each ADR follows this structure:
 | 004 | [Proxy-Based Runtime Enforcement](004-proxy-runtime-enforcement.md) | Accepted | 2026-03-11 |
 | 005 | [Re-Export Pattern for Backward Compatibility](005-re-export-pattern.md) | Accepted | 2026-03-11 |
 | 006 | [Unified Graph Write Batching](006-unified-graph-write-batching.md) | Accepted | 2026-04-25 |
+| 007 | [MCP Package Version Provenance](007-mcp-package-version-provenance.md) | Accepted | 2026-05-01 |
 
 ## Adding a New ADR
 

--- a/src/agent_bom/api/routes/discovery.py
+++ b/src/agent_bom/api/routes/discovery.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, HTTPException, Request
 from agent_bom.api.mcp_observation_store import MCPObservation, merge_observations
 from agent_bom.api.models import JobStatus
 from agent_bom.api.stores import _get_fleet_store, _get_mcp_observation_store, _get_store
-from agent_bom.asset_provenance import agent_discovery_provenance, package_discovery_provenance
+from agent_bom.asset_provenance import agent_discovery_provenance, package_discovery_provenance, package_version_provenance
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.security import (
     sanitize_command_args,
@@ -200,6 +200,10 @@ def _serialize_agent(
         server_payload["security_intelligence"] = _merge_security_intelligence(list(getattr(server, "security_intelligence", []) or []))
         for idx, package in enumerate(getattr(server, "packages", []) or []):
             if idx < len(server_payload.get("packages", []) or []):
+                server_payload["packages"][idx]["version_provenance"] = package_version_provenance(
+                    package,
+                    inherited=agent_provenance,
+                )
                 server_payload["packages"][idx]["discovery_provenance"] = package_discovery_provenance(
                     package,
                     inherited=agent_provenance,
@@ -632,6 +636,7 @@ async def get_agent_lifecycle(request: Request, agent_name: str) -> dict:
                             "version": pkg.get("version", ""),
                             "ecosystem": pkg.get("ecosystem", ""),
                             "vuln_count": len(vulns),
+                            "version_provenance": pkg.get("version_provenance"),
                             "discovery_provenance": pkg.get("discovery_provenance"),
                         },
                     }

--- a/src/agent_bom/asset_provenance.py
+++ b/src/agent_bom/asset_provenance.py
@@ -6,7 +6,57 @@ import re
 from dataclasses import asdict, dataclass, field, is_dataclass
 from typing import Any
 
-from agent_bom.security import sanitize_log_label
+from agent_bom.security import sanitize_log_label, sanitize_path_label, sanitize_url
+
+PACKAGE_VERSION_SOURCES = frozenset(
+    {
+        "runtime_process",
+        "image_sbom",
+        "installed_package",
+        "tool_cache",
+        "lockfile",
+        "command_pin",
+        "registry_latest",
+        "unknown",
+    }
+)
+PACKAGE_VERSION_CONFIDENCE = frozenset({"exact", "high", "medium", "low", "unknown"})
+_VERSION_SOURCE_ALIASES = {
+    "registry_fallback": "registry_latest",
+    "registry": "registry_latest",
+    "latest": "registry_latest",
+    "sbom_ingest": "image_sbom",
+    "image_scan": "image_sbom",
+    "filesystem_scan": "installed_package",
+    "node_modules": "installed_package",
+    "installed": "installed_package",
+    "cache": "tool_cache",
+    "npm_cache": "tool_cache",
+    "uv_cache": "tool_cache",
+    "manifest": "command_pin",
+    "pinned": "command_pin",
+    "pin": "command_pin",
+}
+_VERSION_SOURCE_CONFIDENCE = {
+    "runtime_process": "exact",
+    "image_sbom": "exact",
+    "installed_package": "exact",
+    "tool_cache": "high",
+    "lockfile": "exact",
+    "command_pin": "exact",
+    "registry_latest": "low",
+    "unknown": "unknown",
+}
+_VERSION_SOURCE_PRECEDENCE = {
+    "runtime_process": 80,
+    "image_sbom": 70,
+    "installed_package": 60,
+    "tool_cache": 50,
+    "lockfile": 40,
+    "command_pin": 30,
+    "registry_latest": 20,
+    "unknown": 0,
+}
 
 DISCOVERY_SOURCE_TYPES = frozenset(
     {
@@ -35,6 +85,29 @@ _STRING_FIELDS = (
     "confidence",
     "version_source",
 )
+_VERSION_PROVENANCE_STRING_FIELDS = (
+    "declared_name",
+    "declared_version",
+    "resolved_version",
+    "version_source",
+    "confidence",
+    "observed_at",
+    "version_resolved_at",
+    "legacy_version_source",
+)
+_VERSION_EVIDENCE_STRING_FIELDS = (
+    "type",
+    "path",
+    "source_file",
+    "parser",
+    "sha256",
+    "url",
+    "process_id",
+    "container_image",
+    "sbom_ref",
+    "package_path",
+)
+_VERSION_EVIDENCE_PATH_FIELDS = frozenset({"path", "source_file", "package_path"})
 _SENSITIVE_VALUE_RE = re.compile(r"(token|password|secret|api[_-]?key|credential|bearer|jwt)[^\s]*\s*[:=]", re.IGNORECASE)
 _URL_USERINFO_RE = re.compile(r"://[^/\s:@]+:[^@/\s]+@")
 
@@ -137,6 +210,94 @@ def agent_discovery_provenance(agent: Any) -> dict[str, Any] | None:
     return sanitize_discovery_provenance(explicit, defaults=defaults)
 
 
+def normalize_package_version_source(value: Any, *, resolved_from_registry: bool = False) -> str:
+    """Return the canonical package version source enum.
+
+    Legacy parser values are accepted on input so older scanners can keep
+    emitting them while downstream surfaces receive the ADR-007 contract.
+    """
+    raw = _sanitize_string(value, max_len=64).lower().replace("-", "_")
+    if not raw:
+        return "registry_latest" if resolved_from_registry else "unknown"
+    source = _VERSION_SOURCE_ALIASES.get(raw, raw)
+    if source == "detected":
+        return "registry_latest" if resolved_from_registry else "unknown"
+    if source not in PACKAGE_VERSION_SOURCES:
+        return "unknown"
+    return source
+
+
+def normalize_package_version_confidence(value: Any, *, version_source: str = "unknown") -> str:
+    """Return the canonical confidence enum for a package version source."""
+    raw = _sanitize_string(value, max_len=32).lower().replace("-", "_")
+    if raw in PACKAGE_VERSION_CONFIDENCE:
+        return raw
+    return _VERSION_SOURCE_CONFIDENCE.get(version_source, "unknown")
+
+
+def package_version_provenance(package: Any, inherited: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build structured package version provenance for scanner/API/graph use."""
+    explicit_discovery = _coerce_mapping(_field(package, "discovery_provenance"))
+    explicit = _coerce_mapping(explicit_discovery.get("version_provenance"))
+    inherited = sanitize_discovery_provenance(inherited) or {}
+
+    resolved_from_registry = bool(
+        _field(package, "resolved_from_registry", False)
+        or explicit.get("resolved_from_registry")
+        or explicit_discovery.get("resolved_from_registry")
+    )
+    legacy_version_source = explicit.get("version_source") or explicit_discovery.get("version_source") or _field(package, "version_source")
+    version_source = normalize_package_version_source(
+        explicit.get("version_source") or legacy_version_source,
+        resolved_from_registry=resolved_from_registry,
+    )
+    confidence = normalize_package_version_confidence(
+        explicit.get("confidence") or _field(package, "version_confidence"),
+        version_source=version_source,
+    )
+    resolved_version = (
+        explicit.get("resolved_version") or _field(package, "resolved_version") or _resolved_package_version(_field(package, "version"))
+    )
+    declared_version = explicit.get("declared_version") or _field(package, "declared_version")
+    if not declared_version and _field(package, "floating_reference", False):
+        declared_version = _field(package, "registry_version") or _field(package, "version")
+
+    result: dict[str, Any] = {
+        "declared_name": explicit.get("declared_name") or _field(package, "name"),
+        "declared_version": declared_version,
+        "resolved_version": resolved_version,
+        "version_source": version_source,
+        "confidence": confidence,
+        "observed_at": explicit.get("observed_at") or inherited.get("observed_at"),
+        "version_resolved_at": explicit.get("version_resolved_at") or _field(package, "version_resolved_at"),
+        "resolved_from_registry": resolved_from_registry,
+        "source_precedence": _VERSION_SOURCE_PRECEDENCE[version_source],
+    }
+    canonical_legacy_source = normalize_package_version_source(
+        legacy_version_source,
+        resolved_from_registry=resolved_from_registry,
+    )
+    if legacy_version_source and canonical_legacy_source != legacy_version_source:
+        result["legacy_version_source"] = str(legacy_version_source)
+    if _field(package, "floating_reference", False):
+        result["floating_reference"] = True
+        if _field(package, "floating_reference_reason"):
+            result["floating_reference_reason"] = _field(package, "floating_reference_reason")
+
+    evidence = _sanitize_version_evidence_list(
+        explicit.get("evidence") or _field(package, "version_evidence") or _occurrence_version_evidence(package)
+    )
+    if evidence:
+        result["evidence"] = evidence
+
+    conflicts = _sanitize_version_conflicts(explicit.get("version_conflicts") or _field(package, "version_conflicts"))
+    if conflicts:
+        result["version_conflicts"] = conflicts
+
+    sanitized = _sanitize_version_provenance(result)
+    return sanitized or {"version_source": "unknown", "confidence": "unknown", "source_precedence": 0}
+
+
 def package_discovery_provenance(package: Any, inherited: dict[str, Any] | None = None) -> dict[str, Any] | None:
     """Build sanitized Package discovery provenance from explicit/current fields."""
     explicit = getattr(package, "discovery_provenance", None)
@@ -166,7 +327,108 @@ def package_discovery_provenance(package: Any, inherited: dict[str, Any] | None 
                 "version_source": version_source,
             }
         )
-    return sanitize_discovery_provenance(explicit, defaults=defaults)
+    provenance = sanitize_discovery_provenance(explicit, defaults=defaults)
+    if not provenance:
+        provenance = {}
+    provenance["version_provenance"] = package_version_provenance(package, inherited=inherited)
+    return provenance
+
+
+def _resolved_package_version(value: Any) -> str | None:
+    text = _sanitize_string(value, max_len=128)
+    if text and text not in {"latest", "unknown", "*"}:
+        return text
+    return None
+
+
+def _sanitize_version_provenance(value: dict[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for field_name in _VERSION_PROVENANCE_STRING_FIELDS:
+        field_value = _sanitize_string(value.get(field_name), max_len=256)
+        if field_value:
+            result[field_name] = field_value
+
+    result["version_source"] = normalize_package_version_source(result.get("version_source") or value.get("version_source"))
+    result["confidence"] = normalize_package_version_confidence(result.get("confidence"), version_source=result["version_source"])
+
+    for field_name in ("resolved_from_registry", "floating_reference"):
+        if value.get(field_name) is not None:
+            result[field_name] = bool(value.get(field_name))
+
+    precedence = value.get("source_precedence")
+    if isinstance(precedence, int):
+        result["source_precedence"] = precedence
+    else:
+        result["source_precedence"] = _VERSION_SOURCE_PRECEDENCE[result["version_source"]]
+
+    evidence = _sanitize_version_evidence_list(value.get("evidence"))
+    if evidence:
+        result["evidence"] = evidence
+
+    conflicts = _sanitize_version_conflicts(value.get("version_conflicts"))
+    if conflicts:
+        result["version_conflicts"] = conflicts
+
+    return {key: val for key, val in result.items() if val not in (None, "", [])}
+
+
+def _sanitize_version_evidence_list(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, dict):
+        values = [value]
+    elif isinstance(value, (list, tuple)):
+        values = list(value)
+    else:
+        values = []
+
+    result: list[dict[str, Any]] = []
+    for entry in values:
+        raw = _coerce_mapping(entry)
+        if not raw:
+            continue
+        item: dict[str, Any] = {}
+        for field_name in _VERSION_EVIDENCE_STRING_FIELDS:
+            safe = _sanitize_string(raw.get(field_name), max_len=256)
+            if safe:
+                if field_name in _VERSION_EVIDENCE_PATH_FIELDS:
+                    safe = sanitize_path_label(safe)
+                elif field_name == "url":
+                    safe = sanitize_url(safe) or ""
+                    if not safe:
+                        continue
+                item[field_name] = safe
+        line = raw.get("line")
+        if isinstance(line, int) and line > 0:
+            item["line"] = line
+        if item:
+            result.append(item)
+    return result[:10]
+
+
+def _sanitize_version_conflicts(value: Any) -> list[dict[str, str]]:
+    if isinstance(value, dict):
+        values = [value]
+    elif isinstance(value, (list, tuple)):
+        values = list(value)
+    else:
+        values = []
+
+    result: list[dict[str, str]] = []
+    for entry in values:
+        raw = _coerce_mapping(entry)
+        source = normalize_package_version_source(raw.get("source") or raw.get("version_source"))
+        version = _sanitize_string(raw.get("version"), max_len=128)
+        if source != "unknown" and version:
+            result.append({"source": source, "version": version})
+    return result[:10]
+
+
+def _occurrence_version_evidence(package: Any) -> list[dict[str, Any]]:
+    evidence: list[dict[str, Any]] = []
+    for occurrence in getattr(package, "occurrences", []) or []:
+        raw = _coerce_mapping(occurrence)
+        if raw:
+            evidence.append(raw)
+    return evidence
 
 
 def _coerce_mapping(value: Any) -> dict[str, Any]:
@@ -179,6 +441,12 @@ def _coerce_mapping(value: Any) -> dict[str, Any]:
     if isinstance(value, dict):
         return dict(value)
     return {}
+
+
+def _field(value: Any, name: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
 
 
 def _sanitize_string(value: Any, *, max_len: int = 256) -> str:

--- a/src/agent_bom/cli/_focused_commands.py
+++ b/src/agent_bom/cli/_focused_commands.py
@@ -228,8 +228,19 @@ def sbom_cmd(
 @click.argument("path", type=click.Path(exists=True))
 @click.option("-f", "--format", "output_format", default="console", help="Output format (console or json)")
 @click.option("-o", "--output", "output_path", help="Output file path")
+@click.option("--no-color", is_flag=True, help="Disable colored output")
+@click.option("--log-json", "log_json", is_flag=True, help="Emit structured JSON logs to stderr")
+@click.option("--log-file", "log_file", type=click.Path(), default=None, help="Write JSON logs to file")
 @click.option("--quiet", "-q", is_flag=True)
-def secrets_cmd(path: str, output_format: str, output_path: Optional[str], quiet: bool) -> None:
+def secrets_cmd(
+    path: str,
+    output_format: str,
+    output_path: Optional[str],
+    no_color: bool,
+    log_json: bool,
+    log_file: Optional[str],
+    quiet: bool,
+) -> None:
     """Scan a directory for hardcoded secrets and PII.
 
     Uses 34 credential patterns + 11 PII patterns + 4 file-specific
@@ -246,11 +257,13 @@ def secrets_cmd(path: str, output_format: str, output_path: Optional[str], quiet
 
     from rich.console import Console
 
+    from agent_bom.logging_config import setup_logging
     from agent_bom.secret_scanner import scan_secrets
 
     output_format = _validate_json_or_console_format("secrets", output_format)
+    setup_logging(level="ERROR" if quiet else "INFO", json_output=log_json, log_file=log_file)
 
-    con = Console(stderr=True, quiet=quiet)
+    con = Console(stderr=True, quiet=quiet, no_color=no_color)
     result = scan_secrets(path)
 
     if output_format == "json":

--- a/src/agent_bom/cli/_skills_group.py
+++ b/src/agent_bom/cli/_skills_group.py
@@ -54,6 +54,9 @@ def skills_group(ctx: click.Context) -> None:
     help="Path to the local skills catalog (defaults to ~/.agent-bom/skills/catalog.json)",
 )
 @click.option("--verbose", "-v", is_flag=True, help="Show all findings instead of only the default top findings summary")
+@click.option("--no-color", is_flag=True, help="Disable colored output")
+@click.option("--log-json", "log_json", is_flag=True, help="Emit structured JSON logs to stderr")
+@click.option("--log-file", "log_file", type=click.Path(path_type=Path), default=None, help="Write JSON logs to file")
 @click.option("--quiet", "-q", is_flag=True, help="Suppress headings, summaries, and recommendations in console output")
 def skills_scan_cmd(
     paths: tuple[Path, ...],
@@ -63,6 +66,9 @@ def skills_scan_cmd(
     intel_source: str | None,
     catalog_path: Path | None,
     verbose: bool,
+    no_color: bool,
+    log_json: bool,
+    log_file: Path | None,
     quiet: bool,
 ) -> None:
     """Scan skill and instruction files for trust, risk, and provenance.
@@ -73,6 +79,9 @@ def skills_scan_cmd(
       agent-bom skills scan CLAUDE.md .cursor/rules
       agent-bom skills scan . --fail-on-verdict suspicious -f json
     """
+    from agent_bom.logging_config import setup_logging
+
+    setup_logging(level="ERROR" if quiet else "INFO", json_output=log_json, log_file=str(log_file) if log_file else None)
     report = scan_skill_targets(paths, intel_source=intel_source, catalog_path=catalog_path)
     payload = report.to_dict()
 
@@ -83,7 +92,7 @@ def skills_scan_cmd(
         else:
             click.echo(rendered)
     else:
-        console = Console()
+        console = Console(no_color=no_color)
         summary = payload["summary"]
 
         if not report.files:

--- a/src/agent_bom/data/inventory.schema.json
+++ b/src/agent_bom/data/inventory.schema.json
@@ -6,6 +6,45 @@
 
   "$defs": {
 
+    "VersionProvenance": {
+      "title": "Package Version Provenance",
+      "description": "Evidence for how a package version was resolved.",
+      "type": "object",
+      "properties": {
+        "declared_name": { "type": "string" },
+        "declared_version": { "type": "string" },
+        "resolved_version": { "type": "string" },
+        "version_source": {
+          "type": "string",
+          "enum": ["runtime_process", "image_sbom", "installed_package", "tool_cache", "lockfile", "command_pin", "registry_latest", "unknown"]
+        },
+        "confidence": {
+          "type": "string",
+          "enum": ["exact", "high", "medium", "low", "unknown"]
+        },
+        "observed_at": { "type": "string" },
+        "version_resolved_at": { "type": "string" },
+        "resolved_from_registry": { "type": "boolean" },
+        "floating_reference": { "type": "boolean" },
+        "floating_reference_reason": { "type": "string" },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "version_conflicts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+
     "DiscoveryProvenance": {
       "title": "Discovery Provenance",
       "description": "Low-risk provenance for how an asset was observed. Values are sanitized before persistence/export.",
@@ -41,7 +80,8 @@
         "location": { "type": "string" },
         "confidence": { "type": "string" },
         "resolved_from_registry": { "type": "boolean" },
-        "version_source": { "type": "string" }
+        "version_source": { "type": "string" },
+        "version_provenance": { "$ref": "#/$defs/VersionProvenance" }
       },
       "additionalProperties": false
     },

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -334,7 +334,7 @@ def blast_radius_to_finding(br: object) -> "Finding":
     if not isinstance(br, BlastRadius):
         raise TypeError(f"Expected BlastRadius, got {type(br)}")
 
-    from agent_bom.asset_provenance import package_discovery_provenance
+    from agent_bom.asset_provenance import package_discovery_provenance, package_version_provenance
 
     vuln = br.vulnerability
     pkg = br.package
@@ -385,6 +385,7 @@ def blast_radius_to_finding(br: object) -> "Finding":
     package_provenance = package_discovery_provenance(pkg)
     if package_provenance:
         evidence["package_discovery_provenance"] = package_provenance
+    evidence["package_version_provenance"] = package_version_provenance(pkg)
     if vuln.references:
         evidence["references"] = _sanitized_evidence_field(vuln.references[:5])
 

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -13,7 +13,7 @@ from pathlib import PurePath
 from typing import Any
 
 from agent_bom.api.tracing import get_tracer
-from agent_bom.asset_provenance import sanitize_discovery_provenance
+from agent_bom.asset_provenance import package_version_provenance, sanitize_discovery_provenance
 from agent_bom.graph.container import UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import NodeDimensions, UnifiedNode
@@ -208,6 +208,7 @@ def build_unified_graph_from_report(
                 pkg_id = _package_node_id(pkg_dict)
                 package_evidence = _package_evidence(pkg_dict, data_source_tag)
                 package_discovery_provenance = sanitize_discovery_provenance(pkg_dict.get("discovery_provenance"))
+                package_version_provenance = _package_version_provenance_from_dict(pkg_dict)
 
                 graph.add_node(
                     UnifiedNode(
@@ -226,6 +227,7 @@ def build_unified_graph_from_report(
                             "is_malicious": pkg_dict.get("is_malicious", False),
                             "stable_id": pkg_dict.get("stable_id", ""),
                             "discovery_provenance": package_discovery_provenance,
+                            "version_provenance": package_version_provenance,
                         },
                         dimensions=NodeDimensions(ecosystem=ecosystem),
                         data_sources=[data_source_tag],
@@ -1131,6 +1133,7 @@ def _package_evidence(pkg_dict: dict[str, Any], data_source_tag: str) -> dict[st
         "source_package": pkg_dict.get("source_package", ""),
         "version_source": pkg_dict.get("version_source", ""),
         "discovery_provenance": sanitize_discovery_provenance(pkg_dict.get("discovery_provenance")),
+        "version_provenance": _package_version_provenance_from_dict(pkg_dict),
         "occurrence_count": pkg_dict.get("occurrence_count", len(occurrences)),
         "occurrences": normalized_occurrences,
     }
@@ -1142,6 +1145,37 @@ def _package_evidence(pkg_dict: dict[str, Any], data_source_tag: str) -> dict[st
             if introduced.get(key) not in (None, "")
         }
     return {key: value for key, value in evidence.items() if value not in (None, "", [])}
+
+
+def _package_version_provenance_from_dict(pkg_dict: dict[str, Any]) -> dict[str, Any]:
+    explicit = pkg_dict.get("version_provenance")
+    if isinstance(explicit, dict):
+        return package_version_provenance(
+            {
+                "name": pkg_dict.get("name"),
+                "version": pkg_dict.get("version"),
+                "version_source": pkg_dict.get("version_source"),
+                "resolved_from_registry": pkg_dict.get("resolved_from_registry", False),
+                "discovery_provenance": {"version_provenance": explicit},
+            }
+        )
+    return package_version_provenance(
+        {
+            "name": pkg_dict.get("name"),
+            "version": pkg_dict.get("version"),
+            "version_source": pkg_dict.get("version_source"),
+            "resolved_from_registry": pkg_dict.get("resolved_from_registry", False),
+            "declared_version": pkg_dict.get("declared_version"),
+            "resolved_version": pkg_dict.get("resolved_version"),
+            "version_confidence": pkg_dict.get("version_confidence"),
+            "version_resolved_at": pkg_dict.get("version_resolved_at"),
+            "version_evidence": pkg_dict.get("version_evidence") or pkg_dict.get("occurrences") or [],
+            "version_conflicts": pkg_dict.get("version_conflicts") or [],
+            "floating_reference": pkg_dict.get("floating_reference", False),
+            "floating_reference_reason": pkg_dict.get("floating_reference_reason"),
+            "registry_version": pkg_dict.get("registry_version"),
+        }
+    )
 
 
 def _blast_radius_package_evidence(br_dict: dict[str, Any], data_source_tag: str) -> dict[str, Any]:

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -321,6 +321,12 @@ class Package:
     resolved_from_registry: bool = False  # True if resolved dynamically vs from lock file
     registry_version: Optional[str] = None  # Latest version from registry (for drift comparison)
     version_source: str = "detected"  # "detected" | "manifest" | "registry_fallback"
+    declared_version: Optional[str] = None  # Version/ref declared by command or manifest (may be latest/floating)
+    resolved_version: Optional[str] = None  # Exact version selected after resolution, when known
+    version_confidence: Optional[str] = None  # ADR-007 confidence enum for the resolved version
+    version_resolved_at: Optional[str] = None  # Timestamp when version was resolved
+    version_evidence: list[dict] = field(default_factory=list)  # Structured evidence for version source
+    version_conflicts: list[dict] = field(default_factory=list)  # Conflicting source/version observations
     floating_reference: bool = False  # True when the package/source ref is mutable (latest/main/no digest)
     floating_reference_reason: Optional[str] = None  # Why the ref is mutable
     is_malicious: bool = False  # True if flagged as known malicious (MAL- prefix in OSV)

--- a/src/agent_bom/output/attack_flow.py
+++ b/src/agent_bom/output/attack_flow.py
@@ -342,6 +342,8 @@ def build_attack_flow(
         if pkg_id not in seen_nodes:
             seen_nodes.add(pkg_id)
             unique_packages.add(pkg_str)
+            raw_version_provenance = br.get("package_version_provenance")
+            version_provenance: dict = raw_version_provenance if isinstance(raw_version_provenance, dict) else {}
             nodes.append(
                 {
                     "id": pkg_id,
@@ -352,6 +354,9 @@ def build_attack_flow(
                         "label": pkg_name,
                         "version": pkg_version,
                         "ecosystem": ecosystem,
+                        "version_provenance": version_provenance,
+                        "version_source": version_provenance.get("version_source"),
+                        "version_confidence": version_provenance.get("confidence"),
                     },
                 }
             )

--- a/src/agent_bom/output/cyclonedx_fmt.py
+++ b/src/agent_bom/output/cyclonedx_fmt.py
@@ -14,7 +14,12 @@ from pathlib import Path
 from uuid import uuid4
 
 from agent_bom import __version__
-from agent_bom.asset_provenance import agent_discovery_provenance, package_discovery_provenance, sanitize_discovery_provenance
+from agent_bom.asset_provenance import (
+    agent_discovery_provenance,
+    package_discovery_provenance,
+    package_version_provenance,
+    sanitize_discovery_provenance,
+)
 from agent_bom.models import AIBOMReport
 from agent_bom.security import sanitize_launch_command, sanitize_path_label
 
@@ -360,6 +365,7 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
             for pkg in server.packages:
                 pkg_ref = _sanitize_bom_ref(f"pkg-{pkg.stable_id}")
                 package_provenance = package_discovery_provenance(pkg, inherited=server_provenance)
+                version_provenance = package_version_provenance(pkg, inherited=server_provenance)
 
                 pkg_properties = [
                     {"name": "agent-bom:ecosystem", "value": pkg.ecosystem},
@@ -369,6 +375,8 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
                     {"name": "agent-bom:reachability-evidence", "value": pkg.reachability_evidence},
                     {"name": "agent-bom:resolved-from-registry", "value": str(pkg.resolved_from_registry).lower()},
                     {"name": "agent-bom:version-source", "value": pkg.version_source},
+                    {"name": "agent-bom:version-provenance-source", "value": version_provenance.get("version_source", "unknown")},
+                    {"name": "agent-bom:version-provenance-confidence", "value": version_provenance.get("confidence", "unknown")},
                     {"name": "agent-bom:floating-reference", "value": str(pkg.floating_reference).lower()},
                 ]
                 _append_discovery_provenance_properties(pkg_properties, package_provenance)

--- a/src/agent_bom/output/graph.py
+++ b/src/agent_bom/output/graph.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, TypedDict
 
+from agent_bom.asset_provenance import package_version_provenance
 from agent_bom.graph import SEVERITY_BADGE as _SEVERITY_BADGE
 from agent_bom.graph import SEVERITY_RANK as _SEVERITY_RANK
 from agent_bom.security import sanitize_launch_command, sanitize_path_label
@@ -386,6 +387,7 @@ def build_graph_elements(
                 summary_label = f"{pkg.name}\n{pkg.version}"
                 if collapse_cves and vc:
                     summary_label = f"{pkg.name}@{pkg.version}\n{vuln_summary['summaryText']} • {vc} CVEs"
+                version_provenance = package_version_provenance(pkg)
                 elements.append(
                     {
                         "data": {
@@ -401,6 +403,9 @@ def build_graph_elements(
                             ),
                             "ecosystem": pkg.ecosystem,
                             "version": pkg.version,
+                            "versionSource": version_provenance.get("version_source", "unknown"),
+                            "versionConfidence": version_provenance.get("confidence", "unknown"),
+                            "versionProvenance": json.dumps(version_provenance),
                             "vulnIds": json.dumps(vuln_ids),
                             "vulnCount": vc,
                             "maxSeverity": max_severity,
@@ -422,6 +427,7 @@ def build_graph_elements(
                             "source": sid,
                             "target": pid,
                             "type": "depends_on",
+                            "versionProvenance": json.dumps(version_provenance),
                             "maxSeverity": max_severity,
                             "vulnCount": vc,
                         }

--- a/src/agent_bom/output/graph_export.py
+++ b/src/agent_bom/output/graph_export.py
@@ -141,6 +141,32 @@ def _agent_node_attributes(agent: dict[str, Any]) -> dict[str, Any]:
     )
 
 
+def _package_node_attributes(pkg: dict[str, Any]) -> dict[str, Any]:
+    raw_version_provenance = pkg.get("version_provenance")
+    version_provenance: dict[str, Any]
+    if isinstance(raw_version_provenance, dict):
+        version_provenance = raw_version_provenance
+    else:
+        discovery = pkg.get("discovery_provenance")
+        if isinstance(discovery, dict) and isinstance(discovery.get("version_provenance"), dict):
+            version_provenance = discovery["version_provenance"]
+        else:
+            version_provenance = {}
+    version_source = version_provenance.get("version_source") or pkg.get("version_source")
+    version_confidence = version_provenance.get("confidence") or pkg.get("version_confidence")
+    return _compact_attributes(
+        {
+            "name": pkg.get("name"),
+            "version": pkg.get("version"),
+            "ecosystem": pkg.get("ecosystem"),
+            "purl": pkg.get("purl"),
+            "version_source": version_source,
+            "version_confidence": version_confidence,
+            "version_provenance": version_provenance,
+        }
+    )
+
+
 def build_graph_from_scan_data(data: dict[str, Any]) -> DepGraph:
     """Build a :class:`DepGraph` from an in-memory scan JSON report."""
     graph = DepGraph()
@@ -208,8 +234,14 @@ def build_graph_from_scan_data(data: dict[str, Any]) -> DepGraph:
                 pkg_label = f"{pkg_name}@{pkg_ver}" if pkg_ver else pkg_name
                 if dep_depth and dep_depth > 0:
                     pkg_label += f" (depth {dep_depth})"
-                graph.add_node(pkg_id, pkg_label, pkg_kind)
-                graph.add_edge(srv_id, pkg_id, "depends_on")
+                pkg_attributes = _package_node_attributes(pkg)
+                graph.add_node(pkg_id, pkg_label, pkg_kind, attributes=pkg_attributes)
+                graph.add_edge(
+                    srv_id,
+                    pkg_id,
+                    "depends_on",
+                    evidence={"version_provenance": pkg_attributes.get("version_provenance")},
+                )
 
                 for vuln in vulns:
                     vuln_id_str = vuln.get("id", "UNKNOWN")

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from agent_bom.asset_provenance import agent_discovery_provenance, package_discovery_provenance, sanitize_discovery_provenance
+from agent_bom.asset_provenance import (
+    agent_discovery_provenance,
+    package_discovery_provenance,
+    package_version_provenance,
+    sanitize_discovery_provenance,
+)
 from agent_bom.compliance_utils import effective_blast_radius_tags
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
@@ -376,6 +381,7 @@ def _build_inventory_snapshot(report: AIBOMReport) -> dict:
                         "distro_version": pkg.distro_version,
                         "floating_reference": pkg.floating_reference,
                         "floating_reference_reason": pkg.floating_reference_reason,
+                        "version_provenance": package_version_provenance(pkg, inherited=agent_provenance),
                         "discovery_provenance": package_discovery_provenance(pkg, inherited=agent_provenance),
                         "occurrence_count": len(pkg.occurrences),
                         "occurrences": [_package_occurrence_to_dict(occ) for occ in pkg.occurrences],
@@ -637,6 +643,16 @@ def to_json(report: AIBOMReport) -> dict:
                                 "reachability_evidence": pkg.reachability_evidence,
                                 "resolved_from_registry": pkg.resolved_from_registry,
                                 "version_source": pkg.version_source,
+                                "declared_version": pkg.declared_version,
+                                "resolved_version": pkg.resolved_version,
+                                "version_confidence": pkg.version_confidence,
+                                "version_resolved_at": pkg.version_resolved_at,
+                                "version_evidence": pkg.version_evidence or None,
+                                "version_conflicts": pkg.version_conflicts or None,
+                                "version_provenance": package_version_provenance(
+                                    pkg,
+                                    inherited=agent_discovery_provenance(agent),
+                                ),
                                 "discovery_provenance": package_discovery_provenance(
                                     pkg,
                                     inherited=agent_discovery_provenance(agent),
@@ -755,6 +771,7 @@ def to_json(report: AIBOMReport) -> dict:
                     _package_occurrence_to_dict(br.package.primary_occurrence) if br.package.primary_occurrence else None
                 ),
                 "package_discovery_provenance": package_discovery_provenance(br.package),
+                "package_version_provenance": package_version_provenance(br.package),
                 "is_malicious": br.package.is_malicious,
                 "malicious_reason": br.package.malicious_reason,
                 "scorecard_score": br.package.scorecard_score,

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -7,7 +7,12 @@ import json
 from pathlib import Path
 from typing import Any
 
-from agent_bom.asset_provenance import agent_discovery_provenance, package_discovery_provenance, sanitize_discovery_provenance
+from agent_bom.asset_provenance import (
+    agent_discovery_provenance,
+    package_discovery_provenance,
+    package_version_provenance,
+    sanitize_discovery_provenance,
+)
 from agent_bom.finding import FindingType
 from agent_bom.models import AIBOMReport, Severity
 from agent_bom.security import sanitize_sensitive_payload
@@ -164,6 +169,7 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
         package_provenance = package_discovery_provenance(br.package)
         if package_provenance:
             result_properties["package_discovery_provenance"] = _sanitize_sarif_property(package_provenance)
+        result_properties["package_version_provenance"] = _sanitize_sarif_property(package_version_provenance(br.package))
         agent_provenance = [
             provenance for provenance in (agent_discovery_provenance(agent) for agent in br.affected_agents[:10]) if provenance
         ]

--- a/src/agent_bom/output/spdx_fmt.py
+++ b/src/agent_bom/output/spdx_fmt.py
@@ -7,6 +7,7 @@ from datetime import timezone
 from pathlib import Path
 from typing import Any
 
+from agent_bom.asset_provenance import package_version_provenance
 from agent_bom.models import AIBOMReport
 
 
@@ -127,6 +128,21 @@ def to_spdx(report: AIBOMReport) -> dict:
                         "versionInfo": pkg.version,
                         "primaryPurpose": "LIBRARY",
                     }
+                    version_provenance = package_version_provenance(pkg)
+                    pkg_element["annotation"] = [
+                        {
+                            "type": "Annotation",
+                            "annotationType": "OTHER",
+                            "subject": pkg_id,
+                            "statement": f"agent-bom:version-provenance-source={version_provenance.get('version_source', 'unknown')}",
+                        },
+                        {
+                            "type": "Annotation",
+                            "annotationType": "OTHER",
+                            "subject": pkg_id,
+                            "statement": f"agent-bom:version-provenance-confidence={version_provenance.get('confidence', 'unknown')}",
+                        },
+                    ]
                     if pkg.purl:
                         pkg_element["externalIdentifier"] = [{"type": "PackageURL", "identifier": pkg.purl}]
                     if pkg.license_expression or pkg.license:

--- a/src/agent_bom/output/svg.py
+++ b/src/agent_bom/output/svg.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import html
 from typing import TYPE_CHECKING
 
+from agent_bom.asset_provenance import package_version_provenance
+
 if TYPE_CHECKING:
     from agent_bom.models import AIBOMReport, BlastRadius
 
@@ -145,6 +147,7 @@ def to_svg(
                         "label": f"{pkg.name}@{pkg.version}",
                         "type": "pkg_vuln" if is_vuln else "pkg_clean",
                         "ecosystem": pkg.ecosystem,
+                        "version_provenance": package_version_provenance(pkg),
                     }
                 )
                 server_to_packages.append((sid, pid))
@@ -272,10 +275,16 @@ def to_svg(
             colors = _COLORS.get(ctype, _COLORS.get(color_key, ("#333", "#f5f5f5", "#999")))
             text_color, bg_color, border_color = colors
             label = html.escape(item["label"][:28])
+            version_attrs = ""
+            version_provenance = item.get("version_provenance")
+            if isinstance(version_provenance, dict):
+                source = html.escape(str(version_provenance.get("version_source", "unknown")), quote=True)
+                confidence = html.escape(str(version_provenance.get("confidence", "unknown")), quote=True)
+                version_attrs = f' data-version-source="{source}" data-version-confidence="{confidence}"'
 
             parts.append(
                 f'<rect x="{col_x}" y="{y}" width="{_NODE_W}" height="{_NODE_H}" '
-                f'rx="{_NODE_RX}" fill="{bg_color}" stroke="{border_color}" stroke-width="1.5"/>'
+                f'rx="{_NODE_RX}" fill="{bg_color}" stroke="{border_color}" stroke-width="1.5"{version_attrs}/>'
             )
             parts.append(
                 f'<text x="{col_x + _NODE_W / 2}" y="{y + _NODE_H / 2 + 4}" '

--- a/src/agent_bom/parsers/compiled_parsers.py
+++ b/src/agent_bom/parsers/compiled_parsers.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -1236,6 +1238,83 @@ def parse_conda_packages(directory: Path) -> list[Package]:
     return unique
 
 
+def _normalize_python_dist_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _resolve_uv_cached_version(name: str) -> tuple[str, Path] | None:
+    """Return an exact package version from uv's local cache, if present."""
+    cache_root = Path(os.environ.get("UV_CACHE_DIR") or Path.home() / ".cache" / "uv")
+    if not cache_root.exists():
+        return None
+
+    wanted = _normalize_python_dist_name(name)
+    matches: list[tuple[float, str, Path]] = []
+    inspected = 0
+    for metadata_path in cache_root.glob("archive-v*/**/*.dist-info/METADATA"):
+        inspected += 1
+        if inspected > 5000:
+            break
+        try:
+            dist_info_name = metadata_path.parent.name.rsplit(".dist-info", 1)[0]
+            candidate_name = dist_info_name.rsplit("-", 1)[0]
+            if _normalize_python_dist_name(candidate_name) != wanted:
+                continue
+            metadata = metadata_path.read_text(encoding="utf-8", errors="replace")
+            version = ""
+            declared_name = ""
+            for line in metadata.splitlines():
+                if line.startswith("Name: "):
+                    declared_name = line.removeprefix("Name: ").strip()
+                elif line.startswith("Version: "):
+                    version = line.removeprefix("Version: ").strip()
+                if declared_name and version:
+                    break
+            if version and (not declared_name or _normalize_python_dist_name(declared_name) == wanted):
+                matches.append((metadata_path.stat().st_mtime, version, metadata_path))
+        except Exception as exc:
+            logger.debug("Failed to inspect uv cache package metadata at %s: %s", metadata_path, exc)
+    if not matches:
+        return None
+    _, version, path = max(matches, key=lambda item: item[0])
+    return version, path
+
+
+def _uvx_package_from_command(name: str, declared_version: str, server: MCPServer) -> Package:
+    is_floating = declared_version in {"latest", "*"}
+    cached = _resolve_uv_cached_version(name) if is_floating else None
+    version = cached[0] if cached else declared_version
+    pkg = Package(
+        name=name,
+        version=version,
+        ecosystem="pypi",
+        purl=f"pkg:pypi/{name}@{version}",
+        is_direct=True,
+    )
+    pkg.declared_version = declared_version
+    if not is_floating:
+        pkg.resolved_version = version
+        pkg.version_source = "command_pin"
+        pkg.version_confidence = "exact"
+        pkg.version_evidence = [{"type": "command_pin", "source_file": server.config_path or "", "parser": "uvx"}]
+    elif cached:
+        _, evidence_path = cached
+        pkg.resolved_version = version
+        pkg.version_source = "tool_cache"
+        pkg.version_confidence = "high"
+        pkg.version_resolved_at = datetime.now(timezone.utc).isoformat()
+        pkg.version_evidence = [{"type": "tool_cache", "path": str(evidence_path), "parser": "uvx"}]
+        pkg.floating_reference = True
+        pkg.floating_reference_reason = "uvx command omitted an explicit package version"
+    else:
+        pkg.resolved_from_registry = True
+        pkg.version_source = "registry_fallback"
+        pkg.registry_version = declared_version
+        pkg.floating_reference = True
+        pkg.floating_reference_reason = "uvx command omitted an explicit package version"
+    return pkg
+
+
 def detect_uvx_package(server: MCPServer) -> list[Package]:
     """Extract package info from uvx/uv commands."""
     packages: list[Package] = []
@@ -1250,30 +1329,14 @@ def detect_uvx_package(server: MCPServer) -> list[Package]:
             if match:
                 name = match.group(1)
                 version = match.group(2) or "latest"
-                packages.append(
-                    Package(
-                        name=name,
-                        version=version,
-                        ecosystem="pypi",
-                        purl=f"pkg:pypi/{name}@{version}",
-                        is_direct=True,
-                    )
-                )
+                packages.append(_uvx_package_from_command(name, version, server))
             break
         elif not arg.startswith("-") and arg not in ("run", "tool"):
             match = re.match(r"^([a-zA-Z0-9_.-]+)(?:==(.+))?$", arg)
             if match:
                 name = match.group(1)
                 version = match.group(2) or "latest"
-                packages.append(
-                    Package(
-                        name=name,
-                        version=version,
-                        ecosystem="pypi",
-                        purl=f"pkg:pypi/{name}@{version}",
-                        is_direct=True,
-                    )
-                )
+                packages.append(_uvx_package_from_command(name, version, server))
             break
 
     return packages

--- a/src/agent_bom/parsers/node_parsers.py
+++ b/src/agent_bom/parsers/node_parsers.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
+from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import quote
 
@@ -28,6 +30,31 @@ def _npm_purl(name: str, version: str) -> str:
         scope, _, pkg_name = name[1:].partition("/")
         return f"pkg:npm/{quote('@' + scope, safe='')}/{pkg_name}@{version}"
     return f"pkg:npm/{name}@{version}"
+
+
+def _resolve_npx_cached_version(name: str) -> tuple[str, Path] | None:
+    """Return an exact package version from npm's local npx cache, if present."""
+    cache_root = Path(os.environ.get("npm_config_cache") or Path.home() / ".npm")
+    npx_root = cache_root / "_npx"
+    if not npx_root.exists():
+        return None
+
+    matches: list[tuple[float, str, Path]] = []
+    for node_modules in list(npx_root.glob("*/node_modules"))[:200]:
+        pkg_json = node_modules.joinpath(*name.split("/"), "package.json")
+        if not pkg_json.exists():
+            continue
+        try:
+            data = read_json_limited(pkg_json)
+            version = str(data.get("version") or "").strip()
+            if version:
+                matches.append((pkg_json.stat().st_mtime, version, pkg_json))
+        except Exception as exc:
+            logger.debug("Failed to inspect npx cache package metadata at %s: %s", pkg_json, exc)
+    if not matches:
+        return None
+    _, version, path = max(matches, key=lambda item: item[0])
+    return version, path
 
 
 def parse_npm_packages(directory: Path) -> list[Package]:
@@ -334,16 +361,40 @@ def detect_npx_package(server: MCPServer) -> list[Package]:
         match = re.match(r"^(@?[a-zA-Z0-9_.-]+(?:/[a-zA-Z0-9_.-]+)?)(?:@(.+))?$", arg)
         if match:
             name = match.group(1)
-            version = match.group(2) or "latest"
-            packages.append(
-                Package(
-                    name=name,
-                    version=version,
-                    ecosystem="npm",
-                    purl=_npm_purl(name, version),
-                    is_direct=True,
-                )
+            pinned_version = match.group(2)
+            declared_version = pinned_version or "latest"
+            is_floating = declared_version in {"latest", "*"}
+            cached = _resolve_npx_cached_version(name) if is_floating else None
+            version = cached[0] if cached else declared_version
+            pkg = Package(
+                name=name,
+                version=version,
+                ecosystem="npm",
+                purl=_npm_purl(name, version),
+                is_direct=True,
             )
+            pkg.declared_version = declared_version
+            if not is_floating:
+                pkg.resolved_version = version
+                pkg.version_source = "command_pin"
+                pkg.version_confidence = "exact"
+                pkg.version_evidence = [{"type": "command_pin", "source_file": server.config_path or "", "parser": "npx"}]
+            elif cached:
+                _, evidence_path = cached
+                pkg.resolved_version = version
+                pkg.version_source = "tool_cache"
+                pkg.version_confidence = "high"
+                pkg.version_resolved_at = datetime.now(timezone.utc).isoformat()
+                pkg.version_evidence = [{"type": "tool_cache", "path": str(evidence_path), "parser": "npx"}]
+                pkg.floating_reference = True
+                pkg.floating_reference_reason = "npx command omitted an explicit package version"
+            else:
+                pkg.resolved_from_registry = True
+                pkg.version_source = "registry_fallback"
+                pkg.registry_version = declared_version
+                pkg.floating_reference = True
+                pkg.floating_reference_reason = "npx command omitted an explicit package version"
+            packages.append(pkg)
             break  # First non-flag arg is the package
 
     return packages

--- a/tests/test_asset_discovery_provenance.py
+++ b/tests/test_asset_discovery_provenance.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.pipeline import _run_scan_sync
 from agent_bom.api.routes.discovery import _serialize_agent
-from agent_bom.asset_provenance import sanitize_discovery_provenance
+from agent_bom.asset_provenance import package_version_provenance, sanitize_discovery_provenance
 from agent_bom.finding import blast_radius_to_finding
 from agent_bom.graph import EntityType
 from agent_bom.graph.builder import build_unified_graph_from_report
@@ -102,6 +102,12 @@ def test_json_surfaces_infer_and_preserve_asset_discovery_provenance() -> None:
     assert registry_provenance["source_type"] == "registry_fallback"
     assert registry_provenance["resolved_from_registry"] is True
     assert registry_provenance["version_source"] == "registry_fallback"
+    assert registry_provenance["version_provenance"]["version_source"] == "registry_latest"
+    assert registry_provenance["version_provenance"]["confidence"] == "low"
+
+    registry_version_provenance = agents["bedrock-agent"]["mcp_servers"][0]["packages"][0]["version_provenance"]
+    assert registry_version_provenance["version_source"] == "registry_latest"
+    assert registry_version_provenance["legacy_version_source"] == "registry_fallback"
 
     skill_provenance = agents["skill-files"]["mcp_servers"][0]["packages"][0]["discovery_provenance"]
     assert skill_provenance["source_type"] == "skill_invoked_pull"
@@ -109,6 +115,7 @@ def test_json_surfaces_infer_and_preserve_asset_discovery_provenance() -> None:
 
     snapshot_pkg = next(pkg for pkg in payload["inventory_snapshot"]["packages"] if pkg["name"] == "mcp-server")
     assert snapshot_pkg["discovery_provenance"]["source_type"] == "registry_fallback"
+    assert snapshot_pkg["version_provenance"]["version_source"] == "registry_latest"
 
 
 def test_api_graph_and_finding_surfaces_preserve_sanitized_provenance() -> None:
@@ -142,11 +149,42 @@ def test_api_graph_and_finding_surfaces_preserve_sanitized_provenance() -> None:
     graph = build_unified_graph_from_report(report_payload)
     package_node = graph.nodes_by_type(EntityType.PACKAGE)[0]
     assert package_node.attributes["discovery_provenance"]["source"] == "<redacted>"
+    assert package_node.attributes["version_provenance"]["version_source"] == "unknown"
     depends_edge = graph.edges_to(package_node.id)[0]
     assert depends_edge.evidence["discovery_provenance"]["source_type"] == "operator_pushed_inventory"
+    assert depends_edge.evidence["version_provenance"]["confidence"] == "unknown"
 
     finding = blast_radius_to_finding(_blast_radius(vuln, pkg, server, agent))
     assert finding.evidence["package_discovery_provenance"]["source"] == "<redacted>"
+    assert finding.evidence["package_version_provenance"]["version_source"] == "unknown"
+
+
+def test_package_version_provenance_canonicalizes_sources_and_conflicts() -> None:
+    pkg = Package(
+        name="@modelcontextprotocol/server-github",
+        version="1.2.4",
+        ecosystem="npm",
+        version_source="registry_fallback",
+        resolved_from_registry=True,
+        declared_version="latest",
+        version_conflicts=[
+            {"source": "command_pin", "version": "1.2.3"},
+            {"source": "node_modules", "version": "1.2.4"},
+        ],
+        version_evidence=[{"type": "registry", "url": "https://registry.npmjs.org/pkg/latest"}],
+    )
+
+    provenance = package_version_provenance(pkg)
+
+    assert provenance["declared_version"] == "latest"
+    assert provenance["resolved_version"] == "1.2.4"
+    assert provenance["version_source"] == "registry_latest"
+    assert provenance["confidence"] == "low"
+    assert provenance["legacy_version_source"] == "registry_fallback"
+    assert provenance["version_conflicts"] == [
+        {"source": "command_pin", "version": "1.2.3"},
+        {"source": "installed_package", "version": "1.2.4"},
+    ]
 
 
 def test_inventory_schema_accepts_discovery_provenance(tmp_path) -> None:
@@ -187,6 +225,11 @@ def test_inventory_schema_accepts_discovery_provenance(tmp_path) -> None:
                                             "source_type": "operator_pushed_inventory",
                                             "observed_via": ["operator_inventory"],
                                             "version_source": "manifest",
+                                            "version_provenance": {
+                                                "resolved_version": "0.104.0",
+                                                "version_source": "lockfile",
+                                                "confidence": "exact",
+                                            },
                                         },
                                     }
                                 ],
@@ -204,6 +247,7 @@ def test_inventory_schema_accepts_discovery_provenance(tmp_path) -> None:
     assert payload["discovery_provenance"]["collector"] == "cmdb-export"
     pkg = payload["agents"][0]["mcp_servers"][0]["packages"][0]
     assert pkg["discovery_provenance"]["version_source"] == "manifest"
+    assert pkg["discovery_provenance"]["version_provenance"]["version_source"] == "lockfile"
 
 
 def test_api_pipeline_inventory_preserves_packages_and_provenance(monkeypatch, tmp_path) -> None:

--- a/tests/test_attack_flow.py
+++ b/tests/test_attack_flow.py
@@ -79,6 +79,22 @@ def test_attack_flow_node_types():
     assert "agent" in node_types
 
 
+def test_attack_flow_package_nodes_preserve_version_provenance():
+    blast_radius = _make_blast_radius()
+    blast_radius[0]["package_version_provenance"] = {
+        "version_source": "lockfile",
+        "confidence": "exact",
+        "resolved_version": "4.18.2",
+    }
+
+    result = build_attack_flow(blast_radius, _make_agents())
+    package = next(node for node in result["nodes"] if node["data"]["nodeType"] == "package" and node["data"]["label"] == "express")
+
+    assert package["data"]["version_source"] == "lockfile"
+    assert package["data"]["version_confidence"] == "exact"
+    assert package["data"]["version_provenance"]["resolved_version"] == "4.18.2"
+
+
 def test_attack_flow_stats():
     """Stats reflect the input data."""
     result = build_attack_flow(_make_blast_radius(), _make_agents())

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -71,6 +71,22 @@ class TestAgentBom:
         r = CliRunner().invoke(main, ["mcp", "--help"])
         assert r.exit_code == 0
 
+    def test_secrets_help_has_common_output_flags(self):
+        from agent_bom.cli import main
+
+        r = CliRunner().invoke(main, ["secrets", "--help"])
+        assert r.exit_code == 0
+        for flag in ("--no-color", "--log-json", "--log-file"):
+            assert flag in r.output
+
+    def test_skills_scan_help_has_common_output_flags(self):
+        from agent_bom.cli import main
+
+        r = CliRunner().invoke(main, ["skills", "scan", "--help"])
+        assert r.exit_code == 0
+        for flag in ("--no-color", "--log-json", "--log-file"):
+            assert flag in r.output
+
 
 # ── agent-shield ─────────────────────────────────────────────────────────────
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -187,6 +187,27 @@ def test_npx_package_detection():
     assert packages[0].ecosystem == "npm"
 
 
+def test_npx_package_detection_uses_local_npx_cache(monkeypatch, tmp_path):
+    pkg_json = tmp_path / "_npx" / "abc123" / "node_modules" / "@modelcontextprotocol" / "server-filesystem" / "package.json"
+    pkg_json.parent.mkdir(parents=True)
+    pkg_json.write_text(json.dumps({"name": "@modelcontextprotocol/server-filesystem", "version": "1.2.3"}), encoding="utf-8")
+    monkeypatch.setenv("npm_config_cache", str(tmp_path))
+    server = MCPServer(
+        name="filesystem",
+        command="npx",
+        args=["@modelcontextprotocol/server-filesystem", "/tmp"],
+    )
+    from agent_bom.parsers import detect_npx_package
+
+    package = detect_npx_package(server)[0]
+
+    assert package.version == "1.2.3"
+    assert package.declared_version == "latest"
+    assert package.version_source == "tool_cache"
+    assert package.version_confidence == "high"
+    assert package.version_evidence[0]["path"] == str(pkg_json)
+
+
 def test_uvx_package_detection():
     server = MCPServer(
         name="mcp-server-fetch",
@@ -199,6 +220,27 @@ def test_uvx_package_detection():
     assert len(packages) == 1
     assert packages[0].name == "mcp-server-fetch"
     assert packages[0].ecosystem == "pypi"
+
+
+def test_uvx_package_detection_uses_local_uv_cache(monkeypatch, tmp_path):
+    metadata = tmp_path / "archive-v0" / "abc123" / "mcp_server_fetch-4.5.6.dist-info" / "METADATA"
+    metadata.parent.mkdir(parents=True)
+    metadata.write_text("Name: mcp-server-fetch\nVersion: 4.5.6\n", encoding="utf-8")
+    monkeypatch.setenv("UV_CACHE_DIR", str(tmp_path))
+    server = MCPServer(
+        name="mcp-server-fetch",
+        command="uvx",
+        args=["mcp-server-fetch"],
+    )
+    from agent_bom.parsers import detect_uvx_package
+
+    package = detect_uvx_package(server)[0]
+
+    assert package.version == "4.5.6"
+    assert package.declared_version == "latest"
+    assert package.version_source == "tool_cache"
+    assert package.version_confidence == "high"
+    assert package.version_evidence[0]["path"] == str(metadata)
 
 
 def test_docker_image_package_detection():

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -509,8 +509,13 @@ class TestBuildUnifiedGraphFromReport:
         edge = next(e for e in g.edges if e.source == "server:claude-desktop:mcp-fs" and e.target == "pkg:npm:express@4.18.0")
         assert edge.evidence["source"] == "mcp-scan"
         assert edge.evidence["purl"] == "pkg:npm/express@4.18.0"
+        assert edge.evidence["version_provenance"]["resolved_version"] == "4.18.0"
+        assert edge.evidence["version_provenance"]["version_source"] == "unknown"
         assert edge.evidence["occurrences"][0]["package_path"] == "app/package-lock.json"
         assert edge.evidence["occurrences"][0]["line"] == 42
+
+        node = g.nodes["pkg:npm:express@4.18.0"]
+        assert node.attributes["version_provenance"]["resolved_version"] == "4.18.0"
 
     def test_package_node_id_uses_canonical_identity(self):
         report = _minimal_report()

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -158,6 +158,28 @@ def test_loads_agent_server_package_nodes():
         os.unlink(path)
 
 
+def test_package_nodes_preserve_version_provenance():
+    pkg = _pkg("requests", "2.31.0", "pypi")
+    pkg["version_provenance"] = {
+        "version_source": "lockfile",
+        "confidence": "exact",
+        "resolved_version": "2.31.0",
+    }
+    data = _make_scan_json([_agent("myagent", [_server("myserver", [pkg])])])
+    path = _write_scan(data)
+    try:
+        graph = load_graph_from_scan(path)
+        payload = to_json(graph)
+        pkg_node = next(node for node in payload["nodes"] if node["kind"] == "pkg")
+        edge = next(edge for edge in payload["edges"] if edge["kind"] == "depends_on")
+
+        assert pkg_node["attributes"]["version_source"] == "lockfile"
+        assert pkg_node["attributes"]["version_confidence"] == "exact"
+        assert edge["evidence"]["version_provenance"]["resolved_version"] == "2.31.0"
+    finally:
+        os.unlink(path)
+
+
 def test_credential_to_tool_reaches_edges_export_with_evidence():
     server = _server(
         "github",

--- a/tests/test_output_cov.py
+++ b/tests/test_output_cov.py
@@ -411,6 +411,8 @@ class TestToSarif:
         assert props["package_discovery_provenance"]["source_type"] == "operator_pushed_inventory"
         assert props["package_discovery_provenance"]["source"] == "<redacted>"
         assert props["package_discovery_provenance"]["version_source"] == "manifest"
+        assert props["package_version_provenance"]["version_source"] == "command_pin"
+        assert props["package_version_provenance"]["confidence"] == "exact"
         assert props["agent_discovery_provenance"][0]["collector"] == "cmdb-export"
 
 
@@ -476,6 +478,8 @@ class TestToCyclonedx:
         assert props["agent-bom:discovery-provenance:source-type"] == "skill_invoked_pull"
         assert props["agent-bom:discovery-provenance:collector"] == "agent-bom-discover-aws"
         assert props["agent-bom:discovery-provenance:observed-via"] == '["skill_invoked_pull","aws_sdk"]'
+        assert props["agent-bom:version-provenance-source"] == "unknown"
+        assert props["agent-bom:version-provenance-confidence"] == "unknown"
 
 
 # ── to_spdx ──────────────────────────────────────────────────────────────────
@@ -486,6 +490,21 @@ class TestToSpdx:
         report = _make_report()
         spdx = to_spdx(report)
         assert spdx["spdxVersion"] == "SPDX-3.0"
+
+
+def test_spdx_package_preserves_version_provenance_annotations():
+    pkg = _make_pkg()
+    pkg.version_source = "lockfile"
+    server = _make_server(packages=[pkg])
+    agent = _make_agent(servers=[server])
+    report = _make_report(agents=[agent])
+
+    spdx = to_spdx(report)
+    pkg_element = next(element for element in spdx["elements"] if element.get("name") == pkg.name)
+    statements = {annotation["statement"] for annotation in pkg_element["annotation"]}
+
+    assert "agent-bom:version-provenance-source=lockfile" in statements
+    assert "agent-bom:version-provenance-confidence=exact" in statements
 
 
 def test_json_output_redacts_server_launch_fields():

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -460,3 +460,21 @@ def test_cytoscape_graph_includes_credential_to_tool_reachability_evidence():
     assert reaches_edges
     assert reaches_edges[0]["mapping_method"] == "server_scope_conservative"
     assert reaches_edges[0]["confidence"] == "medium"
+
+
+def test_cytoscape_package_nodes_include_version_provenance():
+    from agent_bom.output.graph import build_graph_elements
+
+    pkg = _make_pkg("axios", "1.4.0", "npm")
+    pkg.version_source = "lockfile"
+    server = _make_server("github", packages=[pkg])
+    agent = _make_agent(servers=[server])
+    report = _make_report(agents=[agent])
+    blast_radius = _make_blast_radius(pkg=pkg, agents=[agent])
+
+    elements = build_graph_elements(report, [blast_radius])
+    package = next(element["data"] for element in elements if element.get("data", {}).get("type") == "pkg_vuln")
+
+    assert package["versionSource"] == "lockfile"
+    assert package["versionConfidence"] == "exact"
+    assert '"version_source": "lockfile"' in package["versionProvenance"]

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -198,6 +198,13 @@ function stringAttribute(attributes: Record<string, unknown> | undefined, key: s
   return typeof value === "string" ? value : undefined;
 }
 
+function versionProvenanceAttribute(attributes: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = attributes?.version_provenance;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const nested = (value as Record<string, unknown>)[key];
+  return typeof nested === "string" ? nested : undefined;
+}
+
 function buildFallbackNodeData(node: UnifiedNode): LineageNodeData {
   const attributes = { ...(node.attributes ?? {}), node_id: node.id };
   return {
@@ -219,6 +226,8 @@ function buildFallbackNodeData(node: UnifiedNode): LineageNodeData {
       stringAttribute(attributes, "source"),
     version: stringAttribute(attributes, "version") || stringAttribute(attributes, "hash"),
     ecosystem: stringAttribute(attributes, "ecosystem"),
+    versionSource: versionProvenanceAttribute(attributes, "version_source") || stringAttribute(attributes, "version_source"),
+    versionConfidence: versionProvenanceAttribute(attributes, "confidence") || stringAttribute(attributes, "version_confidence"),
     command:
       stringAttribute(attributes, "command") ||
       stringAttribute(attributes, "transport") ||
@@ -260,6 +269,14 @@ function mergeNodeDetail(base: LineageNodeData, detail: GraphNodeDetailResponse)
       stringAttribute(mergedAttributes, "source"),
     version: base.version || stringAttribute(mergedAttributes, "version") || stringAttribute(mergedAttributes, "hash"),
     ecosystem: base.ecosystem || stringAttribute(mergedAttributes, "ecosystem"),
+    versionSource:
+      base.versionSource ||
+      versionProvenanceAttribute(mergedAttributes, "version_source") ||
+      stringAttribute(mergedAttributes, "version_source"),
+    versionConfidence:
+      base.versionConfidence ||
+      versionProvenanceAttribute(mergedAttributes, "confidence") ||
+      stringAttribute(mergedAttributes, "version_confidence"),
     command:
       base.command ||
       stringAttribute(mergedAttributes, "command") ||

--- a/ui/components/lineage-detail.tsx
+++ b/ui/components/lineage-detail.tsx
@@ -223,6 +223,8 @@ export function LineageDetailPanel({
           <div className="space-y-3">
             {data.ecosystem && <Row label="Ecosystem" value={data.ecosystem} />}
             {data.version && <Row label="Version" value={data.version} />}
+            {data.versionSource && <Row label="Version source" value={data.versionSource} />}
+            {data.versionConfidence && <Row label="Version confidence" value={data.versionConfidence} />}
             {(data.vulnCount ?? 0) > 0 ? (
               <Row label="Findings" value={data.vulnCount ?? 0} className="text-red-400" />
             ) : (

--- a/ui/components/lineage-nodes.tsx
+++ b/ui/components/lineage-nodes.tsx
@@ -75,6 +75,7 @@ export type LineageNodeData = {
   ecosystem?: string | undefined;
   version?: string | undefined;
   versionSource?: string | undefined;
+  versionConfidence?: string | undefined;
   registryVersion?: string | undefined;
   // Vulnerability / misconfiguration
   severity?: string | undefined;
@@ -386,6 +387,9 @@ function ServerNode({ data }: { data: LineageNodeData }) {
 
 function PackageNode({ data }: { data: LineageNodeData }) {
   const hasVulns = (data.vulnCount ?? 0) > 0;
+  const provenance = data.versionSource
+    ? `${data.versionSource}${data.versionConfidence ? ` · ${data.versionConfidence}` : ""}`
+    : "";
   return (
     <NodeCard
       data={data}
@@ -394,7 +398,11 @@ function PackageNode({ data }: { data: LineageNodeData }) {
       ringClass="ring-zinc-400"
       icon={Package}
       iconClass="text-zinc-400"
-      subtitle={data.version ? `${data.version}${data.ecosystem ? ` · ${data.ecosystem}` : ""}` : data.ecosystem}
+      subtitle={
+        data.version
+          ? `${data.version}${data.ecosystem ? ` · ${data.ecosystem}` : ""}${provenance ? ` · ${provenance}` : ""}`
+          : data.ecosystem
+      }
       footer={
         hasVulns ? (
           <div className="mt-1 text-[10px] text-red-400">

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -268,9 +268,25 @@ export interface DiscoveryProvenance {
   location?: string | undefined;
   mapping_method?: string | undefined;
   version_source?: string | undefined;
+  version_provenance?: VersionProvenance | undefined;
   confidence?: string | number | undefined;
   discovered_via?: string | undefined;
   resolved_from_registry?: boolean | undefined;
+}
+
+export interface VersionProvenance {
+  declared_name?: string | undefined;
+  declared_version?: string | undefined;
+  resolved_version?: string | undefined;
+  version_source?: string | undefined;
+  confidence?: string | undefined;
+  observed_at?: string | undefined;
+  version_resolved_at?: string | undefined;
+  resolved_from_registry?: boolean | undefined;
+  floating_reference?: boolean | undefined;
+  floating_reference_reason?: string | undefined;
+  evidence?: Record<string, unknown>[] | undefined;
+  version_conflicts?: Record<string, unknown>[] | undefined;
 }
 
 export interface SecurityIntelligenceEntry {
@@ -311,6 +327,9 @@ export interface Package {
   version: string;
   ecosystem: string;
   purl?: string | undefined;
+  version_source?: string | undefined;
+  version_confidence?: string | undefined;
+  version_provenance?: VersionProvenance | undefined;
   discovery_provenance?: DiscoveryProvenance | undefined;
   vulnerabilities?: Vulnerability[] | undefined;
 }

--- a/ui/lib/mesh-graph.ts
+++ b/ui/lib/mesh-graph.ts
@@ -4,7 +4,7 @@
  */
 
 import { type Node, type Edge, MarkerType } from "@xyflow/react";
-import type { ScanResult, MCPServer, Agent, Vulnerability } from "@/lib/api";
+import type { ScanResult, MCPServer, Agent, Vulnerability, Package as AIBOMPackage } from "@/lib/api";
 import type { LineageNodeData } from "@/components/lineage-nodes";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -54,6 +54,18 @@ export interface MeshGraphScope {
 
 const CRED_RE = /key|token|secret|password|credential|auth/i;
 
+function packageVersionSource(pkg: AIBOMPackage): string | undefined {
+  return pkg.version_provenance?.version_source || pkg.discovery_provenance?.version_provenance?.version_source || pkg.version_source;
+}
+
+function packageVersionConfidence(pkg: AIBOMPackage): string | undefined {
+  return (
+    pkg.version_provenance?.confidence ||
+    pkg.discovery_provenance?.version_provenance?.confidence ||
+    pkg.version_confidence
+  );
+}
+
 function agentSourceId(agent: Agent): string {
   const direct = typeof agent.source_id === "string" ? agent.source_id.trim() : "";
   if (direct) return direct;
@@ -92,7 +104,14 @@ function mergeServers(existing: MCPServer, incoming: MCPServer): MCPServer {
       for (const vuln of pkg.vulnerabilities ?? []) {
         vulnerabilities.set(vuln.id, vuln);
       }
-      packages.set(key, { ...current, vulnerabilities: [...vulnerabilities.values()] });
+      packages.set(key, {
+        ...current,
+        version_source: current.version_source || pkg.version_source,
+        version_confidence: current.version_confidence || pkg.version_confidence,
+        version_provenance: current.version_provenance || pkg.version_provenance,
+        discovery_provenance: current.discovery_provenance || pkg.discovery_provenance,
+        vulnerabilities: [...vulnerabilities.values()],
+      });
     } else {
       packages.set(key, pkg);
     }
@@ -539,6 +558,8 @@ export function buildMeshGraph(
             nodeType: "package",
             ecosystem: pkg.ecosystem,
             version: pkg.version,
+            versionSource: packageVersionSource(pkg),
+            versionConfidence: packageVersionConfidence(pkg),
             vulnCount,
           } satisfies LineageNodeData,
         });

--- a/ui/lib/unified-graph-flow.ts
+++ b/ui/lib/unified-graph-flow.ts
@@ -340,6 +340,8 @@ function toLineageData(
     case "package":
       data.ecosystem = stringAttr(node, "ecosystem");
       data.version = stringAttr(node, "version");
+      data.versionSource = versionProvenanceString(node, "version_source") || stringAttr(node, "version_source");
+      data.versionConfidence = versionProvenanceString(node, "confidence");
       data.vulnCount = countOutgoing(node.id, outgoing, RelationshipType.VULNERABLE_TO);
       break;
     case "vulnerability":
@@ -616,6 +618,13 @@ function mapNodeType(node: UnifiedNode): LineageNodeType | null {
 function stringAttr(node: UnifiedNode, key: string): string {
   const value = node.attributes?.[key];
   return typeof value === "string" ? value : "";
+}
+
+function versionProvenanceString(node: UnifiedNode, key: string): string {
+  const value = node.attributes?.version_provenance;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return "";
+  const nested = (value as Record<string, unknown>)[key];
+  return typeof nested === "string" ? nested : "";
 }
 
 function numberAttr(node: UnifiedNode, key: string): number | undefined {


### PR DESCRIPTION
## Summary
- add canonical MCP package version provenance with version_source/confidence enums, evidence, conflicts, and ADR documentation
- propagate version provenance through JSON/API/graph/finding/SARIF/CycloneDX/SPDX/attack-flow/SVG/UI surfaces
- resolve floating npx/uvx commands from local tool caches when available, otherwise keep registry-latest evidence low-confidence
- add missing --no-color, --log-json, and --log-file flags to secrets and skills scan

## Validation
- ruff check on touched Python files
- python -m pytest focused provenance/graph/output/CLI/parser suite: 263 passed
- npm run typecheck
- pre-commit on commit: ruff, ruff-format, mypy, bandit
- git diff --check

## Notes
- This deliberately does not claim historical registry-at-timestamp reconstruction. Floating commands are only upgraded when local cache/runtime evidence exists.