### PR TITLE
Harden post-0.84.5 scan contracts

### DIFF
--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -434,8 +434,10 @@ python scripts/install_helm_profile.py --list
 ### 4. Cloud Infrastructure — agentless discovery
 
 ```bash
-# Scan all cloud providers in one command
-agent-bom cloud aws,azure,gcp
+# Scan configured providers individually
+agent-bom cloud aws
+agent-bom cloud azure
+agent-bom cloud gcp
 
 # With CIS benchmarks
 agent-bom cloud aws --cis

--- a/docs/schemas/v1/ScanJob.json
+++ b/docs/schemas/v1/ScanJob.json
@@ -21,12 +21,34 @@
           "title": "Agent Projects",
           "type": "array"
         },
+        "auto_update_db": {
+          "default": false,
+          "title": "Auto Update Db",
+          "type": "boolean"
+        },
         "connectors": {
           "items": {
             "type": "string"
           },
           "title": "Connectors",
           "type": "array"
+        },
+        "db_sources": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Db Sources"
+        },
+        "dry_run": {
+          "default": false,
+          "title": "Dry Run",
+          "type": "boolean"
         },
         "dynamic_discovery": {
           "default": false,
@@ -135,6 +157,16 @@
           ],
           "default": null,
           "title": "Min Severity"
+        },
+        "no_scan": {
+          "default": false,
+          "title": "No Scan",
+          "type": "boolean"
+        },
+        "offline": {
+          "default": false,
+          "title": "Offline",
+          "type": "boolean"
         },
         "sbom": {
           "anyOf": [

--- a/docs/schemas/v1/ScanRequest.json
+++ b/docs/schemas/v1/ScanRequest.json
@@ -8,12 +8,34 @@
       "title": "Agent Projects",
       "type": "array"
     },
+    "auto_update_db": {
+      "default": false,
+      "title": "Auto Update Db",
+      "type": "boolean"
+    },
     "connectors": {
       "items": {
         "type": "string"
       },
       "title": "Connectors",
       "type": "array"
+    },
+    "db_sources": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Db Sources"
+    },
+    "dry_run": {
+      "default": false,
+      "title": "Dry Run",
+      "type": "boolean"
     },
     "dynamic_discovery": {
       "default": false,
@@ -122,6 +144,16 @@
       ],
       "default": null,
       "title": "Min Severity"
+    },
+    "no_scan": {
+      "default": false,
+      "title": "No Scan",
+      "type": "boolean"
+    },
+    "offline": {
+      "default": false,
+      "title": "Offline",
+      "type": "boolean"
     },
     "sbom": {
       "anyOf": [

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -62,6 +62,21 @@ class ScanRequest(BaseModel):
     enrich: bool = False
     """Enrich with NVD CVSS, EPSS, and CISA KEV data."""
 
+    offline: bool = False
+    """Use the local vulnerability DB only; do not perform network vulnerability lookups."""
+
+    dry_run: bool = False
+    """Validate and preview the scan request without discovery, vulnerability scanning, or result side effects."""
+
+    no_scan: bool = False
+    """Run discovery and package extraction only; skip vulnerability scanning and result side effects."""
+
+    auto_update_db: bool = False
+    """Explicitly refresh the local vulnerability DB before scanning when stale."""
+
+    db_sources: str | None = None
+    """Comma-separated vulnerability DB sources to refresh when auto_update_db is enabled."""
+
     connectors: list[str] = Field(default_factory=list)
     """SaaS connectors to discover from (e.g. ['jira', 'servicenow', 'slack'])."""
 

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -287,6 +287,7 @@ def _run_scan_sync(job: ScanJob) -> None:
         req = job.request
         agents = []
         warnings_all: list[str] = []
+        side_effects_enabled = not (req.dry_run or req.no_scan)
 
         # ── Path validation (prevent path traversal via API) ──
         path_fields = (
@@ -300,6 +301,53 @@ def _run_scan_sync(job: ScanJob) -> None:
         )
         for p in path_fields:
             validate_path(p, must_exist=True)
+
+        if req.dry_run:
+            pipeline.start_step("discovery", "Dry run: validating scan request")
+            pipeline.complete_step("discovery", "Dry run request validated")
+            pipeline.skip_step("extraction", "Dry run")
+            pipeline.skip_step("scanning", "Dry run")
+            pipeline.skip_step("enrichment", "Dry run")
+            pipeline.skip_step("analysis", "Dry run")
+            pipeline.skip_step("output", "Dry run completed without side effects")
+            with lock:
+                job.result = {
+                    "dry_run": True,
+                    "scan_skipped": True,
+                    "offline": req.offline,
+                    "no_scan": req.no_scan,
+                    "side_effects": "skipped",
+                    "would_scan": {
+                        "inventory": bool(req.inventory),
+                        "images": list(req.images),
+                        "kubernetes": req.k8s,
+                        "terraform_dirs": list(req.tf_dirs),
+                        "github_actions": bool(req.gha_path),
+                        "agent_projects": list(req.agent_projects),
+                        "jupyter_dirs": list(req.jupyter_dirs),
+                        "sbom": bool(req.sbom),
+                        "connectors": list(req.connectors),
+                        "filesystem_paths": list(req.filesystem_paths),
+                        "dynamic_discovery": req.dynamic_discovery,
+                    },
+                    "warnings": [],
+                }
+                job.status = JobStatus.DONE
+                job.completed_at = _now()
+            return
+
+        if req.auto_update_db and not req.offline and not req.no_scan:
+            try:
+                from agent_bom.db.schema import db_freshness_days
+                from agent_bom.db.sync import sync_db
+
+                source_list = [s.strip() for s in req.db_sources.split(",") if s.strip()] if req.db_sources else None
+                freshness = db_freshness_days()
+                if freshness is None or freshness > 7 or source_list:
+                    sync_db(sources=source_list)
+            except Exception as db_exc:  # noqa: BLE001
+                _logger.warning("API auto DB refresh failed: %s", sanitize_error(db_exc))
+                warnings_all.append(f"Auto DB refresh skipped: {sanitize_error(db_exc)}")
 
         # ── Discovery phase ──
         pipeline.start_step("discovery", "Discovering local MCP configurations...")
@@ -521,30 +569,64 @@ def _run_scan_sync(job: ScanJob) -> None:
         pipeline.complete_step("extraction", f"Extracted {total_pkgs} packages", {"packages": total_pkgs})
 
         # ── Scanning phase ──
-        scan_message = (
-            f"Scanning {total_pkgs} packages via OSV.dev with vulnerability enrichment..."
-            if req.enrich
-            else f"Scanning {total_pkgs} packages via OSV.dev..."
-        )
-        pipeline.start_step("scanning", scan_message)
-        try:
-            blast_radii = scan_agents_sync(agents, enable_enrichment=req.enrich, offline=False)
-        except Exception as scan_exc:  # noqa: BLE001
-            # Log but don't crash — return what we have with warning
-            _logger.warning("Scan phase error (retrying without enrichment): %s", scan_exc)
-            pipeline.update_step("scanning", f"Scan error: {sanitize_error(scan_exc)} — retrying without enrichment")
+        blast_radii = []
+        effective_enrich = bool(req.enrich and not req.offline)
+        if req.no_scan:
+            pipeline.skip_step("scanning", "Vulnerability scanning skipped by request")
+            warnings_all.append("Vulnerability scanning skipped by request")
+        else:
+            if req.offline:
+                scan_message = f"Scanning {total_pkgs} packages against the local vulnerability DB only..."
+            else:
+                scan_message = (
+                    f"Scanning {total_pkgs} packages via OSV.dev with vulnerability enrichment..."
+                    if effective_enrich
+                    else f"Scanning {total_pkgs} packages via OSV.dev..."
+                )
+            pipeline.start_step("scanning", scan_message)
             try:
-                blast_radii = scan_agents_sync(agents, enable_enrichment=False, offline=False)
-            except Exception as retry_exc:  # noqa: BLE001
-                _logger.error("Scan retry also failed: %s", retry_exc)
-                blast_radii = []
-                warnings_all.append(f"CVE scanning failed: {sanitize_error(retry_exc)}")
-        total_vulns = sum(len(p.vulnerabilities) for a in agents for s in a.mcp_servers for p in s.packages)
-        if total_pkgs > 0 and total_vulns == 0 and not blast_radii:
-            warnings_all.append(
-                f"Scanned {total_pkgs} packages but found 0 vulnerabilities. This may indicate a network issue reaching OSV.dev."
+                blast_radii = scan_agents_sync(agents, enable_enrichment=effective_enrich, offline=req.offline)
+            except Exception as scan_exc:  # noqa: BLE001
+                if req.offline:
+                    _logger.warning("Offline scan phase error: %s", scan_exc)
+                    pipeline.update_step("scanning", f"Offline scan error: {sanitize_error(scan_exc)}")
+                    warnings_all.append(f"Offline CVE scanning failed: {sanitize_error(scan_exc)}")
+                    blast_radii = []
+                else:
+                    # Log but don't crash — return what we have with warning
+                    _logger.warning("Scan phase error (retrying without enrichment): %s", scan_exc)
+                    pipeline.update_step("scanning", f"Scan error: {sanitize_error(scan_exc)} — retrying without enrichment")
+                    try:
+                        blast_radii = scan_agents_sync(agents, enable_enrichment=False, offline=False)
+                    except Exception as retry_exc:  # noqa: BLE001
+                        _logger.error("Scan retry also failed: %s", retry_exc)
+                        blast_radii = []
+                        warnings_all.append(f"CVE scanning failed: {sanitize_error(retry_exc)}")
+            total_vulns = sum(len(p.vulnerabilities) for a in agents for s in a.mcp_servers for p in s.packages)
+            if total_pkgs > 0 and total_vulns == 0 and not blast_radii and not req.offline:
+                warnings_all.append(
+                    f"Scanned {total_pkgs} packages but found 0 vulnerabilities. This may indicate a network issue reaching OSV.dev."
+                )
+            pipeline.complete_step("scanning", f"Found {total_vulns} vulnerabilities", {"vulnerabilities": total_vulns})
+
+        if req.no_scan:
+            total_vulns = 0
+        elif req.offline and req.enrich:
+            warnings_all.append("Enrichment skipped because offline mode was requested")
+
+        if req.no_scan:
+            pipeline.skip_step("enrichment", "Vulnerability scanning skipped")
+        elif effective_enrich:
+            # Enrichment is executed inside scan_agents_sync, alongside the
+            # vulnerability query. Emit a terminal event only so SSE timing does
+            # not claim a separate enrichment phase ran after scanning.
+            pipeline.complete_step(
+                "enrichment",
+                "Enrichment completed during scanning",
+                {"executed_in_step": "scanning"},
             )
-        pipeline.complete_step("scanning", f"Found {total_vulns} vulnerabilities", {"vulnerabilities": total_vulns})
+        else:
+            pipeline.skip_step("enrichment", "Enrichment not requested")
 
         # ── Severity filtering (post-scan) ──
         if req.min_severity:
@@ -556,25 +638,16 @@ def _run_scan_sync(job: ScanJob) -> None:
             from agent_bom.api.stores import _get_exception_store
             from agent_bom.suppression_rules import apply_tenant_suppression_rules
 
-            suppression = apply_tenant_suppression_rules(blast_radii, _get_exception_store(), tenant_id=job.tenant_id or "default")
+            suppression = (
+                {"suppressed": 0}
+                if req.no_scan
+                else apply_tenant_suppression_rules(blast_radii, _get_exception_store(), tenant_id=job.tenant_id or "default")
+            )
             if suppression["suppressed"]:
                 warnings_all.append(f"{suppression['suppressed']} finding(s) suppressed by tenant feedback/rules")
         except Exception as exc:  # noqa: BLE001
             _logger.warning("Tenant suppression-rule evaluation skipped: %s", sanitize_error(exc))
             warnings_all.append("Tenant suppression-rule evaluation skipped")
-
-        # ── Enrichment phase ──
-        if req.enrich:
-            # Enrichment is executed inside scan_agents_sync, alongside the
-            # vulnerability query. Emit a terminal event only so SSE timing does
-            # not claim a separate enrichment phase ran after scanning.
-            pipeline.complete_step(
-                "enrichment",
-                "Enrichment completed during scanning",
-                {"executed_in_step": "scanning"},
-            )
-        else:
-            pipeline.skip_step("enrichment", "Enrichment not requested")
 
         # ── Analysis phase ──
         pipeline.start_step("analysis", "Computing blast radius...")
@@ -610,68 +683,74 @@ def _run_scan_sync(job: ScanJob) -> None:
             job.result = report_json
             job.status = JobStatus.DONE
 
-        try:
-            pipeline.update_step("output", "Persisting unified graph...")
-            _persist_graph_snapshot(job, report_json, lock=lock)
-        except Exception as graph_exc:  # noqa: BLE001
-            _logger.warning("Unified graph persistence failed: %s", graph_exc)
-            with lock:
-                job.progress.append(f"Graph persistence skipped: {sanitize_error(graph_exc)}")
+        if side_effects_enabled:
+            try:
+                pipeline.update_step("output", "Persisting unified graph...")
+                _persist_graph_snapshot(job, report_json, lock=lock)
+            except Exception as graph_exc:  # noqa: BLE001
+                _logger.warning("Unified graph persistence failed: %s", graph_exc)
+                with lock:
+                    job.progress.append(f"Graph persistence skipped: {sanitize_error(graph_exc)}")
 
-        try:
-            from agent_bom.asset_tracker import AssetTracker
+            try:
+                from agent_bom.asset_tracker import AssetTracker
 
-            tracker = AssetTracker(tenant_id=str(getattr(job, "tenant_id", None) or "default"))
-            asset_diff = tracker.record_scan(report_json)
-            tracker.close()
+                tracker = AssetTracker(tenant_id=str(getattr(job, "tenant_id", None) or "default"))
+                asset_diff = tracker.record_scan(report_json)
+                tracker.close()
+                with lock:
+                    job.progress.append(
+                        "Asset tracker synced "
+                        f"(new={asset_diff['summary']['new_count']}, "
+                        f"resolved={asset_diff['summary']['resolved_count']}, "
+                        f"open={asset_diff['summary']['total_open']})"
+                    )
+            except Exception as asset_exc:  # noqa: BLE001
+                _logger.warning("Asset tracker persistence failed: %s", asset_exc)
+                with lock:
+                    job.progress.append(f"Asset tracker skipped: {sanitize_error(asset_exc)}")
+        else:
             with lock:
-                job.progress.append(
-                    "Asset tracker synced "
-                    f"(new={asset_diff['summary']['new_count']}, "
-                    f"resolved={asset_diff['summary']['resolved_count']}, "
-                    f"open={asset_diff['summary']['total_open']})"
-                )
-        except Exception as asset_exc:  # noqa: BLE001
-            _logger.warning("Asset tracker persistence failed: %s", asset_exc)
-            with lock:
-                job.progress.append(f"Asset tracker skipped: {sanitize_error(asset_exc)}")
+                job.progress.append("Result side-effect persistence skipped by request")
 
         pipeline.complete_step("output", "Report ready")
 
         # Auto-sync discovered agents to fleet registry
-        try:
-            _sync_scan_agents_to_fleet(agents, tenant_id=str(getattr(job, "tenant_id", None) or "default"))
-        except Exception as fleet_exc:  # noqa: BLE001
-            with lock:
-                job.progress.append(f"Fleet sync skipped: {fleet_exc}")
+        if side_effects_enabled:
+            try:
+                _sync_scan_agents_to_fleet(agents, tenant_id=str(getattr(job, "tenant_id", None) or "default"))
+            except Exception as fleet_exc:  # noqa: BLE001
+                with lock:
+                    job.progress.append(f"Fleet sync skipped: {fleet_exc}")
 
-        try:
-            from agent_bom.analytics_contract import build_scan_analytics_payload
+        if side_effects_enabled:
+            try:
+                from agent_bom.analytics_contract import build_scan_analytics_payload
 
-            analytics_store = _get_analytics_store()
-            analytics = build_scan_analytics_payload(report, report_json=report_json, scan_id=job.job_id, source="api")
-            # Plumb the job's tenant through to analytics so the shared
-            # ClickHouse cluster stays segregated per tenant at row level.
-            tenant_id = str(getattr(job, "tenant_id", None) or "default")
-            for agent_name, findings in analytics.agent_findings.items():
-                analytics_store.record_scan(analytics.scan_id, agent_name, findings, tenant_id=tenant_id)
-            analytics_store.record_scan_metadata(analytics.scan_metadata, tenant_id=tenant_id)
-            for agent_name, snapshot in analytics.posture_snapshots.items():
-                analytics_store.record_posture(agent_name, snapshot, tenant_id=tenant_id)
-            for fleet_snapshot in analytics.fleet_snapshots:
-                # The analytics builder seeds tenant_id="default" so CLI scans
-                # without a request context keep working. When a real job is
-                # on the wire we override with the authed tenant so dashboards
-                # see the finding in the right column.
-                fleet_snapshot["tenant_id"] = tenant_id
-                analytics_store.record_fleet_snapshot(fleet_snapshot)
-            for control in analytics.compliance_controls:
-                analytics_store.record_compliance_control(control, tenant_id=tenant_id)
-            analytics_store.record_cis_benchmark_checks(analytics.cis_benchmark_checks, tenant_id=tenant_id)
-        except Exception as analytics_exc:  # noqa: BLE001
-            _logger.warning("API ClickHouse analytics persistence failed: %s", analytics_exc)
-            with lock:
-                job.progress.append(f"Analytics sync skipped: {sanitize_error(analytics_exc)}")
+                analytics_store = _get_analytics_store()
+                analytics = build_scan_analytics_payload(report, report_json=report_json, scan_id=job.job_id, source="api")
+                # Plumb the job's tenant through to analytics so the shared
+                # ClickHouse cluster stays segregated per tenant at row level.
+                tenant_id = str(getattr(job, "tenant_id", None) or "default")
+                for agent_name, findings in analytics.agent_findings.items():
+                    analytics_store.record_scan(analytics.scan_id, agent_name, findings, tenant_id=tenant_id)
+                analytics_store.record_scan_metadata(analytics.scan_metadata, tenant_id=tenant_id)
+                for agent_name, snapshot in analytics.posture_snapshots.items():
+                    analytics_store.record_posture(agent_name, snapshot, tenant_id=tenant_id)
+                for fleet_snapshot in analytics.fleet_snapshots:
+                    # The analytics builder seeds tenant_id="default" so CLI scans
+                    # without a request context keep working. When a real job is
+                    # on the wire we override with the authed tenant so dashboards
+                    # see the finding in the right column.
+                    fleet_snapshot["tenant_id"] = tenant_id
+                    analytics_store.record_fleet_snapshot(fleet_snapshot)
+                for control in analytics.compliance_controls:
+                    analytics_store.record_compliance_control(control, tenant_id=tenant_id)
+                analytics_store.record_cis_benchmark_checks(analytics.cis_benchmark_checks, tenant_id=tenant_id)
+            except Exception as analytics_exc:  # noqa: BLE001
+                _logger.warning("API ClickHouse analytics persistence failed: %s", analytics_exc)
+                with lock:
+                    job.progress.append(f"Analytics sync skipped: {sanitize_error(analytics_exc)}")
 
     except Exception as exc:  # noqa: BLE001
         with lock:

--- a/src/agent_bom/api/routes/schedules.py
+++ b/src/agent_bom/api/routes/schedules.py
@@ -27,12 +27,15 @@ async def create_schedule(request: Request, body: ScheduleCreate) -> dict:
     """Create a recurring scan schedule."""
     from agent_bom.api.audit_log import log_action
     from agent_bom.api.schedule_store import ScanSchedule
-    from agent_bom.api.scheduler import parse_cron_next
+    from agent_bom.api.scheduler import parse_cron_next, validate_cron_expression
 
     tenant_id = getattr(request.state, "tenant_id", "default")
     actor = getattr(request.state, "api_key_name", "") or "system"
     if body.tenant_id not in ("default", tenant_id):
         raise HTTPException(status_code=403, detail="Forbidden — tenant_id must match the authenticated tenant")
+
+    if not validate_cron_expression(body.cron_expression):
+        raise HTTPException(status_code=422, detail="Invalid cron expression")
 
     now = datetime.now(timezone.utc)
     next_run = parse_cron_next(body.cron_expression, now)

--- a/src/agent_bom/api/scheduler.py
+++ b/src/agent_bom/api/scheduler.py
@@ -14,6 +14,33 @@ logger = logging.getLogger(__name__)
 _SCHEDULER_LEADER_LOCK_ID = 4_197_042_001
 
 
+def validate_cron_expression(cron_expr: str) -> bool:
+    """Return True when a cron expression is in the scheduler's supported subset."""
+    parts = cron_expr.strip().split()
+    if len(parts) != 5:
+        return False
+
+    ranges = ((0, 59), (0, 23), (1, 31), (1, 12), (0, 7))
+    for spec, (min_val, max_val) in zip(parts, ranges, strict=True):
+        if spec == "*":
+            continue
+        if spec.startswith("*/"):
+            try:
+                step = int(spec[2:])
+            except ValueError:
+                return False
+            if step <= 0 or step > max_val:
+                return False
+            continue
+        try:
+            value = int(spec)
+        except ValueError:
+            return False
+        if value < min_val or value > max_val:
+            return False
+    return True
+
+
 def parse_cron_next(cron_expr: str, after: datetime) -> datetime | None:
     """Calculate next run time from a basic cron expression.
 
@@ -29,9 +56,9 @@ def parse_cron_next(cron_expr: str, after: datetime) -> datetime | None:
 
     Returns None if the expression cannot be parsed.
     """
-    parts = cron_expr.strip().split()
-    if len(parts) != 5:
+    if not validate_cron_expression(cron_expr):
         return None
+    parts = cron_expr.strip().split()
 
     try:
         minute_spec, hour_spec, dom_spec, month_spec, dow_spec = parts

--- a/src/agent_bom/cli/_analysis.py
+++ b/src/agent_bom/cli/_analysis.py
@@ -347,9 +347,11 @@ def mesh_cmd(scan_file: Optional[str], project_dir: Optional[str], fmt: str, out
 
 @click.command("dashboard")
 @click.option("--report", type=click.Path(exists=True), default=None, help="Path to agent-bom JSON report file.")
-@click.option("--port", default=8501, show_default=True, type=PORT_RANGE, help="Streamlit server port.")
+@click.option("--port", default=8501, show_default=True, type=PORT_RANGE, help="Legacy Streamlit server port.")
 def dashboard_cmd(report: Optional[str], port: int):
-    """Launch the interactive Streamlit dashboard.
+    """Launch the legacy Streamlit compatibility dashboard.
+
+    The bundled Next.js dashboard is served by `agent-bom serve`.
 
     \b
     Requires:  pip install 'agent-bom[dashboard]'

--- a/src/agent_bom/cli/_cloud_group.py
+++ b/src/agent_bom/cli/_cloud_group.py
@@ -74,6 +74,7 @@ def cloud_group(ctx: click.Context) -> None:
             aws_cis_benchmark="aws" in providers,
             azure_cis_benchmark="azure" in providers,
             gcp_cis_benchmark="gcp" in providers,
+            auto_update_db=False,
         )
 
 
@@ -113,6 +114,7 @@ def aws_cmd(
         aws_include_eks=include_eks,
         aws_include_ec2=include_ec2,
         aws_cis_benchmark=cis and not no_cis,
+        auto_update_db=False,
         output_format=output_format,
         output=output_path,
         quiet=quiet,
@@ -143,6 +145,7 @@ def azure_cmd(
         azure_flag=True,
         azure_subscription=subscription,
         azure_cis_benchmark=cis and not no_cis,
+        auto_update_db=False,
         output_format=output_format,
         output=output_path,
         quiet=quiet,
@@ -173,6 +176,7 @@ def gcp_cmd(
         gcp_flag=True,
         gcp_project=project,
         gcp_cis_benchmark=cis and not no_cis,
+        auto_update_db=False,
         output_format=output_format,
         output=output_path,
         quiet=quiet,

--- a/src/agent_bom/cli/_registry.py
+++ b/src/agent_bom/cli/_registry.py
@@ -25,7 +25,7 @@ def schedule_add(name: str, cron: str, config: Optional[str]):
     import uuid as _uuid
 
     from agent_bom.api.schedule_store import InMemoryScheduleStore, ScanSchedule, SQLiteScheduleStore
-    from agent_bom.api.scheduler import parse_cron_next
+    from agent_bom.api.scheduler import parse_cron_next, validate_cron_expression
 
     console = Console()
 
@@ -37,6 +37,8 @@ def schedule_add(name: str, cron: str, config: Optional[str]):
     from datetime import datetime, timezone
 
     now = datetime.now(timezone.utc)
+    if not validate_cron_expression(cron):
+        raise click.ClickException("Invalid cron expression")
     next_run = parse_cron_next(cron, now)
 
     db_path = _os.environ.get("AGENT_BOM_DB")

--- a/src/agent_bom/cli/_report_group.py
+++ b/src/agent_bom/cli/_report_group.py
@@ -1,4 +1,4 @@
-"""Report command group — history, diff, analytics, and dashboards.
+"""Report command group — history, diff, analytics, and dashboard helpers.
 
 Usage::
 
@@ -7,7 +7,8 @@ Usage::
     agent-bom report rescan              # re-scan to verify remediation
     agent-bom report compliance-narrative report.json
     agent-bom report analytics           # query vulnerability trends
-    agent-bom report dashboard           # launch interactive dashboard
+    agent-bom serve                      # launch bundled API + Next.js dashboard
+    agent-bom report dashboard           # legacy Streamlit compatibility dashboard
 """
 
 from __future__ import annotations
@@ -18,7 +19,7 @@ import click
 @click.group("report", invoke_without_command=True)
 @click.pass_context
 def report_group(ctx: click.Context) -> None:
-    """Reports — history, diff, analytics, and dashboards.
+    """Reports — history, diff, analytics, and dashboard helpers.
 
     \b
     Subcommands:
@@ -27,7 +28,7 @@ def report_group(ctx: click.Context) -> None:
       rescan      Re-scan vulnerable packages to verify remediation
       compliance-narrative  Generate auditor-facing compliance narrative from a saved scan report
       analytics   Query vulnerability trends (ClickHouse)
-      dashboard   Launch interactive Streamlit dashboard
+      dashboard   Launch legacy Streamlit compatibility dashboard; use `agent-bom serve` for the bundled Next.js UI
     """
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())

--- a/src/agent_bom/cli/agents/_discovery.py
+++ b/src/agent_bom/cli/agents/_discovery.py
@@ -159,6 +159,7 @@ def run_local_discovery(
     if (
         not skill_only
         and not scan_prompts
+        and not browser_extensions
         and not ctx.agents
         and not images
         and not k8s

--- a/src/agent_bom/cli/claw.py
+++ b/src/agent_bom/cli/claw.py
@@ -77,7 +77,7 @@ def fleet_group(ctx: click.Context) -> None:
       sync       Run discovery and sync results into fleet registry
       list       List fleet agents with filtering
       stats      Fleet-wide statistics
-      state      Update agent lifecycle state
+      reconcile-k8s  Compare Kubernetes inventory snapshots
     """
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
@@ -91,8 +91,9 @@ def fleet_sync_cmd(quiet: bool) -> None:
 
     con = Console(stderr=True, quiet=quiet)
     con.print("[dim]Fleet sync requires the API server. Start with:[/dim]")
-    con.print("  [cyan]agent-claw api[/cyan]")
+    con.print("  [cyan]agent-bom api[/cyan]")
     con.print("  [cyan]curl -X POST http://localhost:8422/v1/fleet/sync[/cyan]")
+    raise click.ClickException("fleet sync is not available as a local-only command; call the API endpoint instead")
 
 
 @click.command("list")
@@ -105,8 +106,9 @@ def fleet_list_cmd(state, environment, quiet) -> None:
 
     con = Console(stderr=True, quiet=quiet)
     con.print("[dim]Fleet list requires the API server. Start with:[/dim]")
-    con.print("  [cyan]agent-claw api[/cyan]")
+    con.print("  [cyan]agent-bom api[/cyan]")
     con.print("  [cyan]curl http://localhost:8422/v1/fleet[/cyan]")
+    raise click.ClickException("fleet list is not available as a local-only command; call the API endpoint instead")
 
 
 @click.command("stats")
@@ -117,8 +119,9 @@ def fleet_stats_cmd(quiet) -> None:
 
     con = Console(stderr=True, quiet=quiet)
     con.print("[dim]Fleet stats requires the API server. Start with:[/dim]")
-    con.print("  [cyan]agent-claw api[/cyan]")
+    con.print("  [cyan]agent-bom api[/cyan]")
     con.print("  [cyan]curl http://localhost:8422/v1/fleet/stats[/cyan]")
+    raise click.ClickException("fleet stats is not available as a local-only command; call the API endpoint instead")
 
 
 fleet_group.add_command(fleet_sync_cmd, "sync")

--- a/src/agent_bom/db/sync.py
+++ b/src/agent_bom/db/sync.py
@@ -28,6 +28,7 @@ import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
+from urllib.parse import urljoin, urlparse
 
 _logger = logging.getLogger(__name__)
 
@@ -49,7 +50,8 @@ def _validate_sync_url(url: str, param_name: str = "url") -> None:
 
 # Source URLs — all public, no auth required
 _OSV_ALL_ZIP_URL = "https://osv-vulnerabilities.storage.googleapis.com/all.zip"
-_EPSS_CSV_URL = "https://epss.cyentia.com/epss_scores-current.csv.gz"
+_EPSS_CSV_URL = "https://epss.empiricalsecurity.com/epss_scores-current.csv.gz"
+_EPSS_REDIRECT_HOSTS = {"epss.cyentia.com", "epss.empiricalsecurity.com"}
 _KEV_JSON_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
 _GHSA_REST_URL = "https://api.github.com/advisories"
 _NVD_API_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
@@ -525,6 +527,41 @@ def sync_alpine_secdb(
 # ---------------------------------------------------------------------------
 
 
+def _resolve_epss_redirect(current_url: str, location: str) -> str:
+    """Resolve an EPSS redirect without allowing arbitrary host pivots."""
+    next_url = urljoin(current_url, location)
+    _validate_sync_url(next_url, "epss redirect url")
+    current_host = (urlparse(current_url).hostname or "").lower()
+    next_host = (urlparse(next_url).hostname or "").lower()
+    allowed_hosts = set(_EPSS_REDIRECT_HOSTS)
+    if current_host:
+        allowed_hosts.add(current_host)
+    if next_host not in allowed_hosts:
+        raise ValueError(f"epss redirect url host is not allowed: {next_host!r}")
+    return next_url
+
+
+def _fetch_epss_csv_bytes(src: str) -> bytes:
+    """Fetch EPSS CSV bytes, following only expected HTTPS EPSS redirects."""
+    from agent_bom.http_client import create_sync_client, sync_request_with_retry
+
+    current_url = src
+    with create_sync_client(timeout=30) as client:
+        for _ in range(4):
+            response = sync_request_with_retry(client, "GET", current_url)
+            if response is None:
+                raise ConnectionError(f"Failed to fetch EPSS data from {current_url!r} after retries")
+            if response.status_code in {301, 302, 303, 307, 308}:
+                location = response.headers.get("location")
+                if not location:
+                    response.raise_for_status()
+                current_url = _resolve_epss_redirect(current_url, location)
+                continue
+            response.raise_for_status()
+            return response.content
+    raise RuntimeError("EPSS download exceeded redirect limit")
+
+
 def sync_epss(conn: sqlite3.Connection, url: Optional[str] = None) -> int:
     """Download and ingest the FIRST EPSS scores CSV.
 
@@ -532,14 +569,12 @@ def sync_epss(conn: sqlite3.Connection, url: Optional[str] = None) -> int:
     """
     import gzip
 
-    from agent_bom.http_client import fetch_bytes
-
     src = url or _EPSS_CSV_URL
     _validate_sync_url(src, "epss url")
     _logger.info("Downloading EPSS scores from %s …", src)
 
     try:
-        raw = fetch_bytes(src, timeout=30)
+        raw = _fetch_epss_csv_bytes(src)
     except Exception as exc:
         _logger.error("Failed to download EPSS data: %s", exc)
         raise

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -1,8 +1,9 @@
 """agent-bom MCP Server — expose security scanning as MCP tools.
 
 Start with:
-    agent-bom mcp server              # stdio (for Claude Desktop, Cursor, etc.)
-    agent-bom mcp server --sse        # SSE transport (for remote clients)
+    agent-bom mcp server                          # stdio (for Claude Desktop, Cursor, etc.)
+    agent-bom mcp server --transport sse          # SSE transport (for remote clients)
+    agent-bom mcp server --transport streamable-http
 
 Tools (36):
     scan                — Full discovery → scan → output pipeline
@@ -327,6 +328,7 @@ async def _run_scan_pipeline(
     sbom_path: Optional[str] = None,
     enrich: bool = False,
     transitive: bool = False,
+    offline: bool = False,
 ):
     """Run discovery -> extraction -> scanning and return (agents, blast_radii, warnings)."""
     return await _mcp_scan.run_scan_pipeline(
@@ -336,6 +338,7 @@ async def _run_scan_pipeline(
         sbom_path=sbom_path,
         enrich=enrich,
         transitive=transitive,
+        offline=offline,
     )
 
 
@@ -385,6 +388,10 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
         image: Annotated[str | None, Field(description="Docker image to scan (e.g. 'nginx:1.25', 'ghcr.io/org/app:v1').")] = None,
         sbom_path: Annotated[str | None, Field(description="Path to existing CycloneDX or SPDX JSON SBOM file to ingest.")] = None,
         enrich: Annotated[bool, Field(description="Enable NVD CVSS, EPSS probability, and CISA KEV enrichment.")] = False,
+        offline: Annotated[
+            bool,
+            Field(description="Use the local vulnerability DB only and skip registry, OSV, GHSA, and NVIDIA network lookups."),
+        ] = True,
         scorecard: Annotated[
             bool, Field(description="Enrich packages with OpenSSF Scorecard scores (requires resolvable GitHub repos).")
         ] = False,
@@ -404,7 +411,10 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
                 )
             ),
         ] = None,
-        auto_update_db: Annotated[bool, Field(description="Auto-refresh local vuln DB if stale (>7 days) before scanning.")] = True,
+        auto_update_db: Annotated[
+            bool,
+            Field(description="Explicitly refresh the local vuln DB if stale (>7 days) before scanning."),
+        ] = False,
         db_sources: Annotated[
             str | None,
             Field(description="Comma-separated DB sources to sync before scanning (e.g. 'nvd,ghsa,osv,epss,kev')."),
@@ -441,6 +451,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
             image=image,
             sbom_path=sbom_path,
             enrich=enrich,
+            offline=offline,
             scorecard=scorecard,
             transitive=transitive,
             verify_integrity=verify_integrity,

--- a/src/agent_bom/mcp_server_scan.py
+++ b/src/agent_bom/mcp_server_scan.py
@@ -29,6 +29,7 @@ async def run_scan_pipeline(
     sbom_path: Optional[str] = None,
     enrich: bool = False,
     transitive: bool = False,
+    offline: bool = False,
 ):
     """Run discovery -> extraction -> scanning and return agents + findings."""
     from agent_bom.discovery import discover_all
@@ -136,8 +137,8 @@ async def run_scan_pipeline(
             if not server.packages:
                 server.packages = extract_packages(server)
 
-    if enrich:
-        blast_radii = await scan_agents_with_enrichment(agents, options=ScanOptions(offline=False))
+    if enrich and not offline:
+        blast_radii = await scan_agents_with_enrichment(agents, options=ScanOptions(offline=offline))
     else:
-        blast_radii = await scan_agents(agents, options=ScanOptions(offline=False))
+        blast_radii = await scan_agents(agents, options=ScanOptions(offline=offline))
     return agents, blast_radii, warnings, scan_sources

--- a/src/agent_bom/mcp_tools/scanning.py
+++ b/src/agent_bom/mcp_tools/scanning.py
@@ -18,12 +18,13 @@ async def scan_impl(
     image: str | None = None,
     sbom_path: str | None = None,
     enrich: bool = False,
+    offline: bool = True,
     scorecard: bool = False,
     transitive: bool = False,
     verify_integrity: bool = False,
     fail_severity: str | None = None,
     warn_severity: str | None = None,
-    auto_update_db: bool = True,
+    auto_update_db: bool = False,
     db_sources: str | None = None,
     output_format: str = "json",
     policy: dict | None = None,
@@ -35,8 +36,19 @@ async def scan_impl(
         from agent_bom.models import AIBOMReport
         from agent_bom.output import to_json
 
-        # Auto-refresh stale DB before scanning
-        if auto_update_db:
+        pre_warnings: list[str] = []
+        if offline and enrich:
+            enrich = False
+            pre_warnings.append("Enrichment skipped because offline mode was requested")
+        if offline and scorecard:
+            scorecard = False
+            pre_warnings.append("OpenSSF Scorecard enrichment skipped because offline mode was requested")
+        if offline and verify_integrity:
+            verify_integrity = False
+            pre_warnings.append("Package integrity verification skipped because offline mode was requested")
+
+        # Auto-refresh stale DB before scanning only when explicitly requested.
+        if auto_update_db and not offline:
             try:
                 from agent_bom.db.schema import db_freshness_days
                 from agent_bom.db.sync import sync_db
@@ -47,6 +59,9 @@ async def scan_impl(
                     sync_db(sources=source_list)
             except Exception as exc:
                 logger.warning("Auto DB refresh failed: %s", exc)
+                pre_warnings.append(f"Auto DB refresh skipped: {sanitize_error(exc)}")
+        elif auto_update_db and offline:
+            pre_warnings.append("Auto DB refresh skipped because offline mode was requested")
 
         agents, blast_radii, scan_warnings, scan_sources = await _run_scan_pipeline(
             config_path,
@@ -54,7 +69,9 @@ async def scan_impl(
             sbom_path,
             enrich,
             transitive=transitive,
+            offline=offline,
         )
+        scan_warnings = [*pre_warnings, *scan_warnings]
         if not agents:
             result: dict[str, object] = {"status": "no_agents_found", "agents": [], "blast_radii": []}
             if scan_warnings:

--- a/src/agent_bom/skills_service.py
+++ b/src/agent_bom/skills_service.py
@@ -199,6 +199,9 @@ def _looks_like_instruction_surface(path: Path, *, allow_docs_skills: bool = Fal
     if any(parent.name == "skills" for parent in path.parents):
         return True
 
+    if any(parent.name == "prompts" for parent in path.parents):
+        return True
+
     if any(parent.name == "rules" and parent.parent.name == ".cursor" for parent in path.parents if parent.parent != parent):
         return True
 

--- a/tests/test_api_pipeline_image_contract.py
+++ b/tests/test_api_pipeline_image_contract.py
@@ -4,7 +4,7 @@ import json
 
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.pipeline import _run_scan_sync
-from agent_bom.models import BlastRadius, Package, Severity, Vulnerability
+from agent_bom.models import Agent, AgentType, BlastRadius, MCPServer, Package, Severity, TransportType, Vulnerability
 
 
 class _DummyStore:
@@ -13,6 +13,24 @@ class _DummyStore:
 
     def put(self, job: ScanJob) -> None:
         self.jobs.append(job)
+
+
+def _agent_with_package() -> Agent:
+    return Agent(
+        name="api-agent",
+        agent_type=AgentType.CUSTOM,
+        config_path="/tmp/api-agent",
+        mcp_servers=[
+            MCPServer(
+                name="api-server",
+                command="npx",
+                args=[],
+                env={},
+                transport=TransportType.STDIO,
+                packages=[Package(name="express", version="4.18.2", ecosystem="npm")],
+            )
+        ],
+    )
 
 
 def test_api_pipeline_image_scan_uses_container_surface(monkeypatch):
@@ -40,6 +58,93 @@ def test_api_pipeline_image_scan_uses_container_surface(monkeypatch):
     assert job.result["summary"]["total_agents"] == 1
     assert job.result["agents"][0]["source"] == "image"
     assert job.result["agents"][0]["mcp_servers"][0]["surface"] == "container-image"
+
+
+def test_api_pipeline_dry_run_skips_discovery_scan_and_side_effects(monkeypatch):
+    store = _DummyStore()
+    job = ScanJob(
+        job_id="dry-run-123",
+        created_at="2026-03-25T12:00:00Z",
+        request=ScanRequest(images=["agentbom/agent-bom:latest"], dry_run=True, auto_update_db=True),
+    )
+
+    def _unexpected(*_args, **_kwargs):
+        raise AssertionError("dry-run must not reach discovery, scan, DB sync, or persistence hooks")
+
+    monkeypatch.setattr("agent_bom.api.pipeline._get_store", lambda: store)
+    monkeypatch.setattr("agent_bom.discovery.discover_all", _unexpected)
+    monkeypatch.setattr("agent_bom.scanners.scan_agents_sync", _unexpected)
+    monkeypatch.setattr("agent_bom.db.sync.sync_db", _unexpected)
+    monkeypatch.setattr("agent_bom.api.pipeline._persist_graph_snapshot", _unexpected)
+    monkeypatch.setattr("agent_bom.api.pipeline._sync_scan_agents_to_fleet", _unexpected)
+    monkeypatch.setattr("agent_bom.api.pipeline._get_analytics_store", _unexpected)
+
+    _run_scan_sync(job)
+
+    assert job.status == JobStatus.DONE
+    assert job.result is not None
+    assert job.result["dry_run"] is True
+    assert job.result["side_effects"] == "skipped"
+    assert store.jobs[-1].job_id == "dry-run-123"
+
+
+def test_api_pipeline_no_scan_skips_vulnerability_scan_and_result_side_effects(monkeypatch):
+    store = _DummyStore()
+    job = ScanJob(
+        job_id="no-scan-123",
+        created_at="2026-03-25T12:00:00Z",
+        request=ScanRequest(no_scan=True, auto_update_db=True),
+    )
+
+    def _unexpected(*_args, **_kwargs):
+        raise AssertionError("no_scan must not reach vulnerability scan, DB sync, or result side-effect hooks")
+
+    monkeypatch.setattr("agent_bom.api.pipeline._get_store", lambda: store)
+    monkeypatch.setattr("agent_bom.discovery.discover_all", lambda *args, **kwargs: [_agent_with_package()])
+    monkeypatch.setattr("agent_bom.scanners.scan_agents_sync", _unexpected)
+    monkeypatch.setattr("agent_bom.db.sync.sync_db", _unexpected)
+    monkeypatch.setattr("agent_bom.api.pipeline._persist_graph_snapshot", _unexpected)
+    monkeypatch.setattr("agent_bom.api.pipeline._sync_scan_agents_to_fleet", _unexpected)
+    monkeypatch.setattr("agent_bom.api.pipeline._get_analytics_store", _unexpected)
+
+    _run_scan_sync(job)
+
+    assert job.status == JobStatus.DONE
+    assert job.result is not None
+    assert job.result["summary"]["total_agents"] == 1
+    assert job.result["summary"]["total_vulnerabilities"] == 0
+    assert "Vulnerability scanning skipped by request" in job.result["warnings"]
+
+
+def test_api_pipeline_offline_scan_never_retries_online(monkeypatch):
+    store = _DummyStore()
+    job = ScanJob(
+        job_id="offline-123",
+        created_at="2026-03-25T12:00:00Z",
+        request=ScanRequest(offline=True, enrich=True),
+    )
+    seen_offline: list[bool | None] = []
+
+    monkeypatch.setattr("agent_bom.api.pipeline._get_store", lambda: store)
+    monkeypatch.setattr("agent_bom.api.pipeline._sync_scan_agents_to_fleet", lambda _agents, tenant_id="default": None)
+    monkeypatch.setattr("agent_bom.api.pipeline._persist_graph_snapshot", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("agent_bom.discovery.discover_all", lambda *args, **kwargs: [_agent_with_package()])
+
+    def _offline_scan(_agents, enable_enrichment=False, **kwargs):
+        seen_offline.append(kwargs.get("offline"))
+        assert enable_enrichment is False
+        assert kwargs.get("offline") is True
+        raise RuntimeError("local DB missing")
+
+    monkeypatch.setattr("agent_bom.scanners.scan_agents_sync", _offline_scan)
+
+    _run_scan_sync(job)
+
+    assert job.status == JobStatus.DONE
+    assert seen_offline == [True]
+    assert job.result is not None
+    assert "Offline CVE scanning failed: local DB missing" in job.result["warnings"]
+    assert "Enrichment skipped because offline mode was requested" in job.result["warnings"]
 
 
 def test_api_pipeline_persists_clickhouse_analytics(monkeypatch):

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -269,6 +269,26 @@ async def test_schedule_create_audit_logs_authenticated_tenant(isolated_audit_lo
 
 
 @pytest.mark.asyncio
+async def test_schedule_create_rejects_invalid_cron(isolated_audit_log):
+    store = InMemoryScheduleStore()
+    set_schedule_store(store)
+
+    with pytest.raises(HTTPException) as exc:
+        await schedule_routes.create_schedule(
+            _request("tenant-alpha"),
+            ScheduleCreate(
+                name="bad-scan",
+                cron_expression="bad cron",
+                scan_config={"path": "."},
+            ),
+        )
+
+    assert exc.value.status_code == 422
+    assert store.list_all(tenant_id="tenant-alpha") == []
+    assert isolated_audit_log.list_entries() == []
+
+
+@pytest.mark.asyncio
 async def test_scan_routes_are_tenant_scoped():
     store = InMemoryJobStore()
     set_job_store(store)

--- a/tests/test_browser_extensions.py
+++ b/tests/test_browser_extensions.py
@@ -6,6 +6,9 @@ import json
 import zipfile
 from pathlib import Path
 
+from click.testing import CliRunner
+
+from agent_bom.cli import main
 from agent_bom.parsers.browser_extensions import (
     _assess_extension_risk,
     _build_extension,
@@ -242,6 +245,38 @@ def test_discover_returns_list(monkeypatch):
     result = discover_browser_extensions()
     assert isinstance(result, list)
     assert result == []
+
+
+def test_browser_extensions_cli_reports_empty_scan(monkeypatch, tmp_path):
+    """--browser-extensions should leave observable JSON even when no profiles match."""
+    monkeypatch.setattr("agent_bom.parsers.browser_extensions.discover_browser_extensions", lambda include_low_risk=False: [])
+    monkeypatch.setattr("agent_bom.cli.agents._discovery._discover_all_default", lambda *args, **kwargs: [])
+    out_file = tmp_path / "report.json"
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "scan",
+            "--browser-extensions",
+            "--project",
+            str(tmp_path),
+            "--format",
+            "json",
+            "--output",
+            str(out_file),
+            "--no-auto-update-db",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(out_file.read_text())
+    assert data["browser_extensions"] == {
+        "extensions": [],
+        "total": 0,
+        "critical_count": 0,
+        "high_count": 0,
+    }
+    assert "browser_extensions" in data["scan_sources"]
 
 
 def test_discover_filters_low_risk(monkeypatch, tmp_path):

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -39,6 +39,14 @@ class TestAgentBom:
         assert r.exit_code == 0
         assert "OpenSSF Scorecard" in r.output
 
+    def test_report_dashboard_help_points_to_serve_for_next_ui(self):
+        from agent_bom.cli import main
+
+        r = CliRunner().invoke(main, ["report", "--help"])
+        assert r.exit_code == 0
+        assert "agent-bom serve" in r.output
+        assert "legacy Streamlit compatibility" in r.output
+
     def test_scan_backward_compat(self):
         from agent_bom.cli import main
 
@@ -161,6 +169,22 @@ class TestAgentCloud:
         assert r.exit_code == 0
         assert "--project" in r.output
 
+    def test_cloud_provider_wrappers_disable_auto_db_refresh(self, monkeypatch):
+        from agent_bom.cli.cloud import cloud
+
+        seen = []
+
+        def fake_scan(**kwargs):
+            seen.append(kwargs)
+
+        monkeypatch.setattr("agent_bom.cli.agents.scan.callback", fake_scan)
+
+        for command in ("aws", "azure", "gcp"):
+            r = CliRunner().invoke(cloud, [command])
+            assert r.exit_code == 0
+
+        assert [item["auto_update_db"] for item in seen] == [False, False, False]
+
     def test_snowflake_help(self):
         from agent_bom.cli.cloud import cloud
 
@@ -270,6 +294,19 @@ class TestAgentClaw:
         assert "sync" in r.output
         assert "list" in r.output
         assert "stats" in r.output
+        assert "reconcile-k8s" in r.output
+        fleet = claw.get_command(None, "fleet")
+        assert fleet.get_command(None, "state") is None
+
+    def test_fleet_placeholder_commands_fail_closed(self):
+        from agent_bom.cli.claw import claw
+
+        for command in ("sync", "list", "stats"):
+            r = CliRunner().invoke(claw, ["fleet", command])
+            assert r.exit_code != 0
+            assert "agent-bom api" in r.output
+            assert "agent-claw api" not in r.output
+            assert "not available as a local-only command" in r.output
 
     def test_schedule_help(self):
         from agent_bom.cli.claw import claw

--- a/tests/test_cli_registry.py
+++ b/tests/test_cli_registry.py
@@ -387,6 +387,15 @@ def test_schedule_add():
         assert "Schedule created" in result.output
 
 
+def test_schedule_add_rejects_invalid_cron():
+    runner = CliRunner()
+    with patch("agent_bom.api.schedule_store.InMemoryScheduleStore") as mock_cls:
+        result = runner.invoke(schedule, ["add", "--name", "daily", "--cron", "bad cron"])
+        assert result.exit_code != 0
+        assert "Invalid cron expression" in result.output
+        mock_cls.assert_not_called()
+
+
 def test_schedule_list_empty():
     runner = CliRunner()
     with patch("agent_bom.api.schedule_store.InMemoryScheduleStore") as mock_cls:

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -22,6 +22,38 @@ def test_dockerfile_sse_exists():
     assert "EXPOSE" in content
 
 
+def test_deployment_metadata_uses_canonical_mcp_server_command():
+    """Glama, mcporter, and stdio Docker metadata should not drift to the hidden alias."""
+    glama = json.loads((ROOT / "integrations" / "glama" / "server.json").read_text())
+    mcporter = json.loads((ROOT / "config" / "mcporter.json").read_text())
+    dockerfile_mcp = (ROOT / "deploy" / "docker" / "Dockerfile.mcp").read_text()
+    glama_dockerfile = (ROOT / "integrations" / "glama" / "Dockerfile").read_text()
+
+    assert glama["command"] == "agent-bom"
+    assert glama["args"] == ["mcp", "server"]
+    assert mcporter["mcpServers"]["agent-bom"] == {
+        "command": "agent-bom",
+        "args": ["mcp", "server"],
+    }
+    assert 'ENTRYPOINT ["agent-bom", "mcp", "server"]' in dockerfile_mcp
+    assert 'ENTRYPOINT ["agent-bom", "mcp", "server"]' in glama_dockerfile
+    assert '"mcp-server"' not in glama_dockerfile
+    assert '"mcp-server"' not in dockerfile_mcp
+
+
+def test_remote_mcp_deployment_uses_canonical_streamable_http_command():
+    """Remote deployment files should invoke the canonical grouped command."""
+    remote_files = [
+        ROOT / "deploy" / "docker" / "Dockerfile.sse",
+        ROOT / "deploy" / "Procfile",
+    ]
+
+    for path in remote_files:
+        content = path.read_text()
+        assert "agent-bom mcp server --transport streamable-http" in content
+        assert "agent-bom mcp-server" not in content
+
+
 def test_railway_json_valid():
     """railway.json should be valid JSON with correct deploy config."""
     f = ROOT / "railway.json"

--- a/tests/test_first_run_sample.py
+++ b/tests/test_first_run_sample.py
@@ -10,6 +10,7 @@ from agent_bom.cli import main
 from agent_bom.inventory import load_inventory
 from agent_bom.parsers import scan_project_directory, summarize_project_inventory
 from agent_bom.samples import write_first_run_sample
+from agent_bom.skills_service import scan_skill_targets
 
 ROOT = Path(__file__).resolve().parents[1]
 SAMPLE = ROOT / "examples" / "first-run-ai-stack"
@@ -36,6 +37,14 @@ def test_first_run_project_manifests_are_scannable() -> None:
     assert summary["declaration_only_directories"] == 1
     assert summary["ecosystems"]["npm"] >= 2
     assert summary["ecosystems"]["pypi"] >= 3
+
+
+def test_first_run_prompt_is_recognized_by_skills_scan() -> None:
+    report = scan_skill_targets([SAMPLE])
+    payload = report.to_dict()
+
+    assert payload["summary"]["files_scanned"] >= 1
+    assert any(Path(file_report.path).name == "agent-system-prompt.md" for file_report in report.files)
 
 
 def test_first_run_docs_reference_real_paths() -> None:

--- a/tests/test_local_vuln_db.py
+++ b/tests/test_local_vuln_db.py
@@ -12,10 +12,12 @@ import pytest
 from agent_bom.db.lookup import VulnDB, _version_affected, lookup_package
 from agent_bom.db.schema import DB_PATH, _validated_db_path, db_stats, init_db
 from agent_bom.db.sync import (
+    _EPSS_CSV_URL,
     _ingest_alpine_secdb_payload,
     _ingest_osv_file,
     _parse_alpine_secfix_tokens,
     _parse_osv_entry,
+    _resolve_epss_redirect,
     _validate_sync_url,
     sync_alpine_secdb,
     sync_epss,
@@ -404,12 +406,29 @@ def test_sync_kev_mocked(tmp_db):
 def test_sync_epss_mocked(tmp_db):
     csv_content = b"cve,epss,percentile\nCVE-2024-1,0.95,99.5\nCVE-2024-2,0.10,50.0\n"
 
-    with patch("agent_bom.http_client.fetch_bytes", return_value=csv_content):
+    with patch("agent_bom.db.sync._fetch_epss_csv_bytes", return_value=csv_content):
         count = sync_epss(tmp_db, url="https://fake/epss.csv.gz")
 
     assert count == 2
     row = tmp_db.execute("SELECT probability FROM epss_scores WHERE cve_id='CVE-2024-1'").fetchone()
     assert row[0] == pytest.approx(0.95)
+
+
+def test_default_epss_url_uses_current_host():
+    assert _EPSS_CSV_URL == "https://epss.empiricalsecurity.com/epss_scores-current.csv.gz"
+
+
+def test_epss_redirect_allows_legacy_to_current_host():
+    redirected = _resolve_epss_redirect(
+        "https://epss.cyentia.com/epss_scores-current.csv.gz",
+        "https://epss.empiricalsecurity.com/epss_scores-current.csv.gz",
+    )
+    assert redirected == "https://epss.empiricalsecurity.com/epss_scores-current.csv.gz"
+
+
+def test_epss_redirect_rejects_unexpected_host():
+    with pytest.raises(ValueError, match="not allowed"):
+        _resolve_epss_redirect("https://epss.empiricalsecurity.com/epss_scores-current.csv.gz", "https://example.com/epss.csv.gz")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -26,8 +26,6 @@ def _run(coro):
 
 def _call_tool(server, name, args=None):
     """Call a tool and extract the text result."""
-    if name == "scan" and (args is None or "auto_update_db" not in args):
-        raise AssertionError("MCP scan unit tests must set auto_update_db explicitly to avoid live DB refresh")
     content_blocks, _meta = _run(server.call_tool(name, args or {}))
     return json.loads(content_blocks[0].text)
 
@@ -261,6 +259,46 @@ def test_scan_no_agents(mock_pipeline):
     server = create_mcp_server()
     result = _call_tool(server, "scan", {"auto_update_db": False})
     assert result["status"] == "no_agents_found"
+
+
+@patch("agent_bom.mcp_server._run_scan_pipeline")
+def test_scan_default_read_only_contract_does_not_refresh_db_and_uses_offline_scan(mock_pipeline):
+    """Default read-only scan must avoid DB refresh and online vulnerability scans."""
+    mock_pipeline.return_value = ([], [], [], [])
+
+    from agent_bom.mcp_server import create_mcp_server
+
+    def _unexpected_sync(*_args, **_kwargs):
+        raise AssertionError("default MCP scan must not refresh the vulnerability DB")
+
+    server = create_mcp_server()
+    with patch("agent_bom.db.sync.sync_db", side_effect=_unexpected_sync):
+        result = _call_tool(server, "scan")
+
+    assert result["status"] == "no_agents_found"
+    _args, kwargs = mock_pipeline.call_args
+    assert kwargs["offline"] is True
+
+
+@patch("agent_bom.mcp_server._run_scan_pipeline")
+def test_scan_online_db_refresh_requires_explicit_opt_in(mock_pipeline):
+    """Callers can opt back into the historical DB refresh + online scan behavior."""
+    mock_pipeline.return_value = ([], [], [], [])
+    sync_calls: list[object] = []
+
+    from agent_bom.mcp_server import create_mcp_server
+
+    server = create_mcp_server()
+    with (
+        patch("agent_bom.db.schema.db_freshness_days", return_value=99),
+        patch("agent_bom.db.sync.sync_db", side_effect=lambda sources=None: sync_calls.append(sources)),
+    ):
+        result = _call_tool(server, "scan", {"offline": False, "auto_update_db": True, "db_sources": "osv,ghsa"})
+
+    assert result["status"] == "no_agents_found"
+    assert sync_calls == [["osv", "ghsa"]]
+    _args, kwargs = mock_pipeline.call_args
+    assert kwargs["offline"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_schedule_store.py
+++ b/tests/test_schedule_store.py
@@ -9,7 +9,7 @@ from agent_bom.api.schedule_store import (
     ScanSchedule,
     SQLiteScheduleStore,
 )
-from agent_bom.api.scheduler import parse_cron_next
+from agent_bom.api.scheduler import parse_cron_next, validate_cron_expression
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -193,6 +193,13 @@ class TestParseCronNext:
         after = datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
         result = parse_cron_next("*/0 * * * *", after)
         assert result is None
+
+    def test_validation_rejects_invalid_ignored_fields(self):
+        assert validate_cron_expression("0 0 bad * *") is False
+        assert parse_cron_next("0 0 bad * *", datetime(2025, 1, 1, tzinfo=timezone.utc)) is None
+
+    def test_validation_accepts_basic_five_field_cron(self):
+        assert validate_cron_expression("0 0 * * *") is True
 
 
 # ─── scheduler_loop ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- harden post-0.84.5 scan contracts: API dry-run/no-scan/offline controls, explicit API DB refresh opt-in, and MCP scan defaults that stay read-only/offline unless callers opt into online refresh
- close post-merge audit findings: EPSS official host/redirect handling, invalid cron rejection in CLI/API, fleet CLI fail-closed behavior, cloud wrappers avoiding pre-auth DB refresh, browser-extension observable output, first-run prompt recognition, and dashboard/help/docs drift
- add Glama/deployment metadata regression coverage so marketplace/Docker metadata stays on canonical `agent-bom mcp server`

## Root Cause
- API and MCP scan paths still had online/DB-refresh assumptions even where the command/tool contract implied dry-run, no-scan, or read-only behavior
- schedule creation accepted unsupported cron strings and converted them into dead schedules
- EPSS moved hosts and the sync path did not constrain-follow official redirects
- several command/help surfaces were placeholders or stale after the 0.84.5 fix train

## Validation
- `PYTHONPATH=src uv run pytest -q --tb=short tests/test_api_pipeline_events.py tests/test_api_pipeline_image_contract.py tests/test_mcp_server.py tests/test_two_tier_severity.py tests/test_deployment.py tests/test_local_vuln_db.py tests/test_schedule_store.py tests/test_cli_registry.py tests/test_api_tenant_isolation.py tests/test_cli_entry_points.py tests/test_first_run_sample.py tests/test_browser_extensions.py tests/test_api_hardening.py tests/test_rate_limit_headers.py tests/test_integrity.py tests/test_verify.py tests/test_audit_replay.py tests/test_api_endpoints.py` — 566 passed
- `PYTHONPATH=src uv run ruff check ...` on changed files
- `PYTHONPATH=src uv run mypy ...` on changed source files
- `git diff --check`
- pre-commit on commit: ruff, ruff-format, mypy, bandit

## Notes
- no release tag was created
- real cloud/IdP/24h soak tests still require external credentials/infra and should be tracked as release sign-off/nightly workflows
