### PR TITLE
chore: scrub tool-credit phrasing from regression-test docstring

### DIFF
--- a/tests/test_regression_quality.py
+++ b/tests/test_regression_quality.py
@@ -1,4 +1,4 @@
-"""Regression tests for quality issues found by Codex audits.
+"""Regression tests for quality issues caught by historical scanner audits.
 
 These tests prevent regressions on fixes that were verified at runtime.
 """


### PR DESCRIPTION
## Summary
- Replace the lone tool-credit reference in committed source (`tests/test_regression_quality.py` docstring) with neutral phrasing

## Why
The docstring read "Regression tests for quality issues found by Codex audits." This was the last tool-credit reference still in the repo after the PR-title and v0.84.5 release-body cleanup. No production behavior changes.

## Scope (what was already cleaned outside this PR)
- 35 PR titles with `[codex]` prefix renamed via `gh pr edit`
- 9 PR titles with `Codex audit / Codex polish / Codex P0/P1 / codex 9/10` phrasing renamed
- v0.84.5 GitHub Release body bullets cleaned
- `#44` retained (`Codex` there refers to the OpenAI Codex CLI as a supported MCP client product, not authorship)

## Validation
- `git grep -nE "(Codex audit|Codex polish|Codex review|by Codex|via Codex)" -- '*.py' '*.md' '*.ts' '*.tsx'` returns no matches after this change
- All other `Codex`/`codex` mentions in source/docs are legitimate product references (Codex CLI integration, `~/.codex/config.toml`, supported-client tables)