### PR TITLE
feat(cli): startup banner, findings header label, severity-breakdown closer, OSV-first GHSA UX

### DIFF
--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -37,13 +37,44 @@ from agent_bom.cli._grouped_help import GroupedGroup  # noqa: E402 — needed be
 from agent_bom.discovery import discover_all  # noqa: F401
 
 
-@click.group(cls=GroupedGroup, context_settings={"help_option_names": ["-h", "--help"]})
+def _print_startup_banner() -> None:
+    """Render the ``agent-bom`` no-args startup banner.
+
+    Mirrors the spirit of Claude Code / Snowflake Cortex CLI splash output:
+    a small product mark, the trust-chain tagline, three quick-start hints,
+    and a docs link. Compact (≤ 12 lines) so it never pushes prior output
+    off-screen on standard terminals.
+    """
+    from rich.console import Console
+
+    con = Console()
+    con.print()
+    con.print(f"    [bold cyan]⛨[/bold cyan]  [bold]agent-bom[/bold] [dim]·[/dim] [dim]v{__version__}[/dim]")
+    con.print()
+    con.print("    Open security scanner for AI infrastructure.")
+    con.print("    [dim]agent → MCP server → packages → CVEs → blast radius[/dim]")
+    con.print()
+    con.print("    [bold]Quick start[/bold]")
+    con.print("    [cyan]▶[/cyan] [bold]agent-bom agents[/bold]              discover + scan local agents and MCP servers")
+    con.print("    [cyan]▶[/cyan] [bold]agent-bom samples first-run[/bold]   write an inspectable sample AI stack")
+    con.print("    [cyan]▶[/cyan] [bold]agent-bom -h[/bold]                  full command catalog (grouped)")
+    con.print()
+    con.print("    [dim]Docs:[/dim]  [link=https://github.com/msaad00/agent-bom]https://github.com/msaad00/agent-bom[/link]")
+    con.print()
+
+
+@click.group(
+    cls=GroupedGroup,
+    context_settings={"help_option_names": ["-h", "--help"]},
+    invoke_without_command=True,
+)
 @click.version_option(
     version=__version__,
     prog_name="agent-bom",
     message=(f"agent-bom {__version__}\nPython {sys.version.split()[0]} · {sys.platform}\nDocs:  https://github.com/msaad00/agent-bom"),
 )
-def main():
+@click.pass_context
+def main(ctx: click.Context):
     """agent-bom — Security scanner for AI infrastructure.
 
     \b
@@ -70,7 +101,8 @@ def main():
     \b
     Docs:  https://github.com/msaad00/agent-bom
     """
-    pass
+    if ctx.invoked_subcommand is None:
+        _print_startup_banner()
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -1272,7 +1272,11 @@ def scan(
                 # line tells the operator something new.
                 sev_counts: dict[str, int] = {}
                 for br in blast_radii:
-                    sev_key = (str(br.severity).lower() if br.severity else "unknown") or "unknown"
+                    # ``BlastRadius.severity`` lives on the wrapped Vulnerability,
+                    # not the BlastRadius dataclass itself. Severity is a
+                    # ``str, Enum`` so ``str(...)`` yields the canonical token.
+                    raw_sev = getattr(br.vulnerability, "severity", None) if getattr(br, "vulnerability", None) else None
+                    sev_key = (str(raw_sev).lower() if raw_sev else "unknown") or "unknown"
                     sev_counts[sev_key] = sev_counts.get(sev_key, 0) + 1
                 _sev_order = ["critical", "high", "medium", "low", "unknown"]
                 _sev_color = {

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -1266,7 +1266,24 @@ def scan(
             if scan_warnings:
                 con.print(f"  [yellow]⚠[/yellow] Scan completed with {len(scan_warnings)} warning(s); results may be incomplete.")
             if blast_radii:
-                con.print(f"  [red]⚠[/red] Scan complete — [bold]{len(blast_radii)}[/bold] finding(s)")
+                # Don't repeat the bare finding count — the scanner already
+                # printed "Found N vulnerabilities across N finding(s)" above.
+                # Surface a severity breakdown here instead so the closer
+                # line tells the operator something new.
+                sev_counts: dict[str, int] = {}
+                for br in blast_radii:
+                    sev_key = (str(br.severity).lower() if br.severity else "unknown") or "unknown"
+                    sev_counts[sev_key] = sev_counts.get(sev_key, 0) + 1
+                _sev_order = ["critical", "high", "medium", "low", "unknown"]
+                _sev_color = {
+                    "critical": "red bold",
+                    "high": "red",
+                    "medium": "yellow",
+                    "low": "blue",
+                    "unknown": "dim",
+                }
+                _sev_str = " · ".join(f"[{_sev_color[s]}]{sev_counts[s]} {s}[/{_sev_color[s]}]" for s in _sev_order if s in sev_counts)
+                con.print(f"  [red]⚠[/red] Scan complete — {_sev_str}")
             elif offline:
                 if unresolved:
                     con.print(

--- a/src/agent_bom/output/compact.py
+++ b/src/agent_bom/output/compact.py
@@ -306,7 +306,22 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
 
     console.print()
     total = len(display_list)
-    title = f"Top Findings ({min(limit, total)} of {total})" if total > limit else f"Findings ({len(shown)})"
+    shown_n = len(shown)
+    total_active = len(active_findings)
+    if total > limit:
+        # Priority list truncated by --limit; tell the operator how many
+        # additional priority rows aren't shown.
+        suffix = ""
+        if total_active > total:
+            suffix = f" · {total_active - total} more below priority"
+        title = f"Top Findings ({min(limit, total)} of {total}{suffix})"
+    elif total_active > shown_n:
+        # Display list fits in --limit but priority filtering hid some
+        # lower-severity rows further down. Tell the operator both numbers
+        # so '+ N hidden' below the table doesn't look contradictory.
+        title = f"Findings ({shown_n} of {total_active} shown · {total_active - shown_n} hidden)"
+    else:
+        title = f"Findings ({shown_n})"
     console.print(Rule(f"[bold]{title}[/bold]", style="dim"))
 
     # Context-aware table layout

--- a/src/agent_bom/scanners/ghsa_advisory.py
+++ b/src/agent_bom/scanners/ghsa_advisory.py
@@ -301,17 +301,23 @@ async def check_github_advisories(
             if len(queryable) > unauth_budget:
                 skipped = len(queryable) - unauth_budget
                 queryable = queryable[:unauth_budget]
-                from agent_bom.scanners.state import record_scan_warning
-
-                warning = (
-                    "GHSA advisory enrichment limited to "
-                    f"{unauth_budget} unauthenticated package lookup(s); skipped {skipped}. "
-                    "Set GITHUB_TOKEN or GH_TOKEN for full GHSA coverage."
+                # OSV mirrors GHSA within ~24h, so the skipped lookups are
+                # almost always already covered by the offline OSV bundle —
+                # this is an info-level note, not a scan-quality warning.
+                # Surface only at --verbose / --log-level info, and don't
+                # record it on the scan report's warnings_all badge.
+                logger.info(
+                    "GHSA advisory enrichment limited to %d unauthenticated package lookup(s); skipped %d. "
+                    "OSV bundle (refreshed via `agent-bom db update`) already covers GHSA — set GITHUB_TOKEN "
+                    "only if you need <24h advisory freshness.",
+                    unauth_budget,
+                    skipped,
                 )
-                logger.warning(warning)
-                record_scan_warning(warning)
-        logger.warning(
-            "GITHUB_TOKEN/GH_TOKEN is not set; GHSA advisory enrichment will fail fast on GitHub rate limits instead of pausing."
+        # Same rationale as above: token absence is not a scan-quality
+        # warning when OSV already covers the same GHSA data offline.
+        logger.info(
+            "GITHUB_TOKEN/GH_TOKEN is not set; GHSA advisory live enrichment uses fail-fast budget. "
+            "OSV bundle covers GHSA already — set the token only for <24h advisory freshness."
         )
     if not queryable:
         record_enrichment_source("ghsa", "failure", error="unauthenticated package budget disabled GHSA lookups")

--- a/tests/test_ghsa_advisory.py
+++ b/tests/test_ghsa_advisory.py
@@ -262,8 +262,9 @@ def test_multi_package_without_github_token_uses_fail_fast_rate_limit_backoff(mo
     assert {call.kwargs["rate_limit_backoff"] for call in mock_fetch.await_args_list} == {_GHSA_SINGLE_PACKAGE_RATE_LIMIT_BACKOFF}
 
 
-def test_without_github_token_applies_package_budget(monkeypatch):
+def test_without_github_token_applies_package_budget(monkeypatch, caplog):
     import asyncio
+    import logging
     from unittest.mock import AsyncMock, patch
 
     from agent_bom.scanners.ghsa_advisory import _GHSA_SINGLE_PACKAGE_RATE_LIMIT_BACKOFF, check_github_advisories
@@ -282,7 +283,8 @@ def test_without_github_token_applies_package_budget(monkeypatch):
     async def run():
         with patch("agent_bom.scanners.ghsa_advisory._fetch_advisories_for_package", new_callable=AsyncMock) as mock_fetch:
             mock_fetch.return_value = []
-            count = await check_github_advisories(packages)
+            with caplog.at_level(logging.INFO, logger="agent_bom.scanners.ghsa_advisory"):
+                count = await check_github_advisories(packages)
             return count, mock_fetch
 
     count, mock_fetch = asyncio.run(run())
@@ -291,8 +293,17 @@ def test_without_github_token_applies_package_budget(monkeypatch):
     assert mock_fetch.await_count == 2
     assert {call.args[0].name for call in mock_fetch.await_args_list} == {"express", "lodash"}
     assert {call.kwargs["rate_limit_backoff"] for call in mock_fetch.await_args_list} == {_GHSA_SINGLE_PACKAGE_RATE_LIMIT_BACKOFF}
-    warnings = consume_scan_warnings()
-    assert any("GHSA advisory enrichment limited to 2 unauthenticated package lookup(s); skipped 1" in item for item in warnings)
+
+    # The token-budget hint is now an INFO-level note (so default scans don't
+    # surface it as a scan-quality warning) and is intentionally NOT recorded
+    # via record_scan_warning. It still shows under --verbose / --log-level
+    # info via the logger; assert it shows up there with the expected counts.
+    info_text = "\n".join(rec.getMessage() for rec in caplog.records if rec.name == "agent_bom.scanners.ghsa_advisory")
+    assert "GHSA advisory enrichment limited to 2 unauthenticated package lookup(s); skipped 1" in info_text
+    # And confirm it does NOT bubble into the scan_warnings bucket (the
+    # warnings_all badge users see on every scan report would otherwise
+    # mark a clean scan as "completed with warnings").
+    assert not any("unauthenticated package lookup" in item for item in consume_scan_warnings())
 
 
 def test_advisory_filtered_by_package_name():


### PR DESCRIPTION
## Summary
Polish pass on the CLI scanning and results experience driven by a real machine scan that exposed three rough edges + the GHSA "you don't have a token" warning that fired on every default scan.

1. **Startup banner on `agent-bom` (no subcommand)** — small shield mark, tagline, three quick-start hints, docs link. Mirrors the spirit of Claude Code / Snowflake Cortex CLI splash output. Compact (≤ 12 lines). `agent-bom -h` still shows the full grouped command catalog unchanged.

2. **`Findings (N)` header now disambiguates shown vs hidden** — was ambiguous when priority filtering hid lower-severity rows ("Findings (1)" with a trailing "+ 2 hidden" line forced the operator to do the subtraction). Header now renders as:
   - `Top Findings (X of Y · Z more below priority)` when `--limit` truncates the priority list
   - `Findings (X of Y shown · Z hidden)` when priority filtering hid lower-severity rows
   - `Findings (X)` when nothing is hidden

3. **Closing line shows severity breakdown instead of a duplicated count** — was `Scan complete — 3 finding(s)` repeating the bare count already printed by the scanner ("Found 3 vulnerabilities across 3 finding(s)"). Now: `Scan complete — 1 high · 2 medium`, severity-coloured. The closer tells the operator something the scanner header didn't.

4. **GHSA "GITHUB_TOKEN not set" + "limited to N unauthenticated lookups" warnings demoted from WARNING to INFO** — and removed from `record_scan_warning`, so they no longer surface as scan-quality warnings on the report's `warnings_all` badge. Rationale: the OSV bundle (refreshed via `agent-bom db update`) already mirrors GHSA within ~24h, matching how Trivy / Grype / OSV-Scanner handle the same data. Missing GitHub token is not a scan-quality concern out of the box. Notes still surface under `--verbose` / `--log-level info` for users who want the freshness hint, framed as opt-in enhancement, not a missing requirement.

## Why
A real-machine scan against this repo (837 packages, 9 agents) emitted:
- A redundant "Scan complete — 3 finding(s)" line right after "Found 3 vulnerabilities across 3 finding(s)"
- "Findings (1)" header with "+ 2 medium/low hidden" trailing line, leaving the operator to do the math
- Two `WARNING` lines about missing `GITHUB_TOKEN` that polluted progress output and added a "scan completed with warnings; results may be incomplete" badge to a clean scan
- No banner / product mark when the operator typed `agent-bom` to discover what they had

This PR fixes all four. No behavior change for scan results — only output formatting and log levels.

## Validation
- `ruff check` on touched files — passed
- pre-commit hooks (ruff, ruff-format, mypy, bandit) — all passed
- live: `agent-bom` (no args) renders banner; `agent-bom -h` unchanged
- live: default `agent-bom agents` no longer emits GHSA token warnings; `--verbose` surfaces them as info notes

## Out of scope (deferred)
- **Progress-line stacking under interleaved log warnings** — separate PR; needs proper Rich `RichHandler` + `Live` integration. Mitigated indirectly here by demoting GHSA warnings (the primary log source that interleaved with the spinner)
- **CVE-2023-46298 false positive on `next@16.2.4`** — version-range matcher investigation; will open a focused PR after digging into the OSV record vs agent-bom semver comparator
- **Posture panel readability rework** — separate UX redesign