### PR TITLE
fix(version-utils): handle npm SemVer pre-release tags in version compare

### DIFF
--- a/src/agent_bom/version_utils.py
+++ b/src/agent_bom/version_utils.py
@@ -429,7 +429,56 @@ def compare_version_order(left: str, right: str, ecosystem: str) -> int | None:
         right_norm = normalize_version(right, eco)
         return (Version(left_norm) > Version(right_norm)) - (Version(left_norm) < Version(right_norm))
     except Exception:  # noqa: BLE001
-        return None
+        # PEP 440 (``packaging.Version``) rejects npm-style pre-release tags
+        # like ``13.4.20-canary.13`` / ``5.0.0-rc.1`` / ``1.0.0-beta.4`` which
+        # are valid SemVer for npm/yarn/pnpm publishes. Without a fall-back
+        # the comparator returns None, the OSV/GHSA range matcher conserva-
+        # tively marks the package as affected, and downstream emits a false
+        # positive (e.g. ``next@16.2.4`` flagged by an advisory whose fix is
+        # ``< 13.4.20-canary.13``).
+        #
+        # Retry with the pre-release suffix stripped from BOTH sides so we
+        # get a defensible numeric major.minor.patch comparison. This is
+        # technically lossy (``13.4.20-canary.X`` is a pre-release of
+        # ``13.4.20`` per SemVer 2.0), but for OSV/GHSA introduced/fixed
+        # bounds the major.minor.patch view is the safe answer: operators
+        # on a strictly higher major.minor.patch shouldn't be flagged.
+        try:
+            from packaging.version import Version
+
+            left_stripped = _strip_semver_prerelease_tag(left)
+            right_stripped = _strip_semver_prerelease_tag(right)
+            if left_stripped == left and right_stripped == right:
+                return None  # no pre-release tag — original failure stands
+            ln = normalize_version(left_stripped, eco)
+            rn = normalize_version(right_stripped, eco)
+            return (Version(ln) > Version(rn)) - (Version(ln) < Version(rn))
+        except Exception:  # noqa: BLE001
+            return None
+
+
+_SEMVER_PRERELEASE_TAG_RE = None
+
+
+def _strip_semver_prerelease_tag(version: str) -> str:
+    """Strip a SemVer pre-release suffix from a version string.
+
+    Recognised tag stems: ``canary, beta, alpha, rc, pre, dev, nightly,
+    next, snapshot, m`` (Spring milestone), ``preview``. Everything after
+    the tag (e.g. ``.13`` in ``13.4.20-canary.13``) is also discarded so
+    build-metadata and serial counters fall away. Returns the input
+    unchanged when no recognized suffix is present so the caller can
+    detect "nothing to retry" and avoid an infinite loop.
+    """
+    global _SEMVER_PRERELEASE_TAG_RE
+    if _SEMVER_PRERELEASE_TAG_RE is None:
+        import re
+
+        _SEMVER_PRERELEASE_TAG_RE = re.compile(
+            r"-(?:canary|beta|alpha|rc|pre|dev|nightly|next|snapshot|m|preview)(?:\.[A-Za-z0-9.-]+)?$",
+            re.IGNORECASE,
+        )
+    return _SEMVER_PRERELEASE_TAG_RE.sub("", version)
 
 
 @lru_cache(maxsize=65536)

--- a/tests/test_version_utils.py
+++ b/tests/test_version_utils.py
@@ -221,3 +221,38 @@ def test_version_in_range_pypi_fixed_requests_regression():
     assert version_in_range("2.33.0", None, "2.6.0", None, "pypi") is False
     assert version_in_range("2.33.0", "2.3.0", "2.31.0", None, "pypi") is False
     assert version_in_range("2.25.0", "2.3.0", "2.31.0", None, "pypi") is True
+
+
+def test_npm_canary_prerelease_compare_avoids_false_positive():
+    """Regression: ``next@16.2.4`` must not match a fix bound of ``13.4.20-canary.13``.
+
+    PEP 440 ``packaging.Version`` rejects npm SemVer pre-release tags like
+    ``-canary.13`` / ``-rc.1`` / ``-beta.4`` as invalid. Without a pre-release
+    fall-back, ``compare_version_order`` returned ``None`` and the OSV/GHSA
+    range matcher conservatively marked the package as affected — producing
+    a false positive on ``CVE-2023-46298`` for ``next@16.2.4`` (a Next.js 16
+    install was flagged by an advisory whose fix was a Next.js 13 canary).
+    """
+    # Direct comparator: 16.2.4 is greater than 13.4.20-canary.13.
+    assert compare_version_order("16.2.4", "13.4.20-canary.13", "npm") == 1
+    assert compare_version_order("13.4.20-canary.13", "16.2.4", "npm") == -1
+
+    # Range matcher must NOT mark 16.2.4 as affected.
+    assert version_in_range("16.2.4", "0.9.9", "13.4.20-canary.13", None, "npm") is False
+
+    # But the truly vulnerable cases stay vulnerable.
+    assert version_in_range("13.4.19", "0.9.9", "13.4.20-canary.13", None, "npm") is True
+    assert version_in_range("1.0.0", "0.9.9", "13.4.20-canary.13", None, "npm") is True
+
+
+def test_npm_other_semver_prerelease_tags_compare_correctly():
+    """Other npm pre-release tag stems must round-trip the same way."""
+    # rc / beta / alpha / pre / nightly / next / snapshot — all SemVer 2.0
+    # pre-release stems that PEP 440 doesn't accept directly. The fall-back
+    # comparator strips them so a higher stable release is correctly seen as
+    # newer than a pre-release of an older line.
+    assert compare_version_order("5.0.0", "4.18.0-rc.1", "npm") == 1
+    assert compare_version_order("3.0.0", "2.0.0-beta.4", "npm") == 1
+    assert compare_version_order("2.0.0", "1.0.0-alpha.0", "npm") == 1
+    assert compare_version_order("2.0.0", "1.99.0-pre.5", "npm") == 1
+    assert compare_version_order("4.0.0", "3.5.0-nightly.20240101", "npm") == 1


### PR DESCRIPTION
## Summary
Closes the false-positive class where a package on a higher major than an advisory's fix bound was flagged as affected because the fix bound carried an npm-style pre-release suffix that PEP 440 cannot parse.

## Concrete repro

A real machine running `next@16.2.4` got flagged by `CVE-2023-46298` (Next.js missing cache-control header), whose affected range is `[0.9.9, 13.4.20-canary.13)` for `npm:next`.

Pre-fix behavior:
1. `packaging.version.Version("13.4.20-canary.13")` raises `InvalidVersion` — PEP 440 doesn't accept npm SemVer pre-release suffixes (`-tag.serial`).
2. `compare_version_order(16.2.4, 13.4.20-canary.13, npm)` caught the parse error and returned `None`.
3. The OSV/GHSA range matcher treats `None` as "unknown" and conservatively marks the package as affected (correct default for genuinely unknown comparisons, wrong here).

Result: `agent-bom check next@16.2.4 -e npm` reported `CVE-2023-46298` as affecting a Next.js 16 install, even though the fix landed in Next.js 13.

## Fix

Add a fall-back path inside `compare_version_order`: when the primary PEP 440 parse fails AND the input contains a recognised SemVer pre-release tag stem (`canary`/`beta`/`alpha`/`rc`/`pre`/`dev`/`nightly`/`next`/`snapshot`/`m`/`preview`), strip the suffix from both sides and retry the numeric `major.minor.patch` compare.

Technically lossy per SemVer 2.0 (`13.4.20-canary.X` is strictly a pre-release of `13.4.20`), but for OSV/GHSA introduced/fixed advisory bounds the `major.minor.patch` view is the correct safe answer: operators on a strictly higher `major.minor.patch` shouldn't be flagged.

## Regression coverage

- `tests/test_version_utils.py::test_npm_canary_prerelease_compare_avoids_false_positive` — direct repro of the next@16.2.4 FP plus the still-vulnerable cases (13.4.19, 1.0.0)
- `tests/test_version_utils.py::test_npm_other_semver_prerelease_tags_compare_correctly` — covers `rc`/`beta`/`alpha`/`pre`/`nightly` against higher stable releases

## Validation

- `ruff check` + `mypy` on touched files: passed
- `pytest tests/test_version_utils.py` — **44 / 44 pass** (42 existing + 2 new)
- pre-commit hooks (ruff, ruff-format, mypy, bandit): passed
- live: `agent-bom check next@16.2.4 -e npm` — no longer matches CVE-2023-46298 after this fix lands in the local DB lookup path

## Out of scope

- A separate latent bug in `normalize_version("1.0.0rc1", "pypi")` returns `1.0.0.postc1` (turns RC into POST-release) — this PR doesn't touch that path; existing tests for it pass; will open a follow-up.
- The "OSV record only has GIT range type events" issue (the upstream OSV mirror of CVE-2023-46298 has no semver ranges, only commit SHAs) — that's an upstream-data quality issue. agent-bom's local DB merges OSV + GHSA by CVE ID and ends up with the correct npm range from GHSA, so this fix is sufficient for the user-visible FP.