### PR TITLE
feat(cli): route scanner warnings through Rich during progress to stop spinner stacking

### DIFF
--- a/src/agent_bom/cli/_common.py
+++ b/src/agent_bom/cli/_common.py
@@ -44,6 +44,48 @@ def read_json_file_for_cli(path: str | Path, *, label: str = "JSON file") -> Any
         raise click.ClickException(f"Could not read {label.lower()} {file_path}: {exc.strerror or exc}") from exc
 
 
+import contextlib  # noqa: E402 — kept beside the helper that uses it for grep-locality
+
+
+@contextlib.contextmanager
+def rich_log_handler_during_progress(console: Console, *, logger_name: str = "agent_bom.scanners"):
+    """Route warnings from ``logger_name`` through Rich for the duration.
+
+    When a Rich ``Progress`` / ``Live`` region is active, a ``logger.warning(...)``
+    that goes through a plain stderr handler punches through the live region:
+    each warning line pushes the spinner down, the spinner redraws below it,
+    and the terminal accumulates a stack of "Scanning N packages" lines
+    instead of a single redrawing one.
+
+    Bind a ``RichHandler`` to the same ``Console`` for the duration of the
+    progress block so log records render *above* the live region without
+    breaking the redraw, then restore the original handlers on exit.
+    """
+    from rich.logging import RichHandler
+
+    target = logging.getLogger(logger_name)
+    saved_handlers = list(target.handlers)
+    saved_propagate = target.propagate
+
+    rich_h = RichHandler(
+        console=console,
+        show_time=True,
+        show_path=False,
+        markup=False,
+        rich_tracebacks=False,
+        log_time_format="%H:%M:%S",
+        omit_repeated_times=False,
+    )
+    rich_h.setLevel(logging.WARNING)
+    target.handlers = [rich_h]
+    target.propagate = False
+    try:
+        yield
+    finally:
+        target.handlers = saved_handlers
+        target.propagate = saved_propagate
+
+
 def _make_console(quiet: bool = False, output_format: str = "console", no_color: bool = False) -> Console:
     """Create a Console that routes output correctly.
 

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -1176,16 +1176,26 @@ def scan(
             if not quiet:
                 from rich.progress import BarColumn, MofNCompleteColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[bold]{task.description}[/bold]"),
-                    BarColumn(bar_width=30),
-                    MofNCompleteColumn(),
-                    TextColumn("[dim]{task.fields[phase]}[/dim]"),
-                    TimeElapsedColumn(),
-                    console=con,
-                    transient=True,
-                ) as progress:
+                from agent_bom.cli._common import rich_log_handler_during_progress
+
+                # Route ``agent_bom.scanners.*`` warnings (rate-limit retries,
+                # OSV fallbacks, etc.) through Rich for the duration of the
+                # spinner so log lines render *above* the live region instead
+                # of punching through it. Without this the terminal stacks
+                # copies of "Scanning N packages" each time a warning fires.
+                with (
+                    rich_log_handler_during_progress(con),
+                    Progress(
+                        SpinnerColumn(),
+                        TextColumn("[bold]{task.description}[/bold]"),
+                        BarColumn(bar_width=30),
+                        MofNCompleteColumn(),
+                        TextColumn("[dim]{task.fields[phase]}[/dim]"),
+                        TimeElapsedColumn(),
+                        console=con,
+                        transient=True,
+                    ) as progress,
+                ):
                     scan_task = progress.add_task(
                         f"Scanning {_unique_pkgs} packages",
                         total=4,


### PR DESCRIPTION
## Summary
Closes the visual issue where scanner warnings during a scan stack copies of the spinner line on screen.

## Repro
A real machine scan showed five copies of \`Scanning 836 packages [bar] 1/4 querying vulnerability databases...\` stacked vertically in the terminal, each separated by a \`WARNING\` log line. Cause: when a Rich \`Progress\` (spinner) is active and \`logger.warning(...)\` fires through a stderr handler, the warning line punches through the live region — the spinner gets pushed down, redraws below the warning, and the terminal accumulates a stack of progress lines.

## Fix
Add \`rich_log_handler_during_progress\` context manager in \`cli/_common.py\`. For the duration of the block it:
- Replaces the \`agent_bom.scanners\` logger handlers with a single \`RichHandler\` bound to the same \`Console\` as the Progress
- Sets \`propagate=False\` so any parent stderr handler doesn't double-emit
- Restores the original handlers/propagate on exit

\`RichHandler\` is Live-aware: it prints log records *above* the live region without breaking the spinner's redraw position.

Wrap the agents-scan Progress block in \`cli/agents/__init__.py\` with the new helper. Same Console instance is shared with the Progress so RichHandler correctly identifies the active live region.

## Behavior
- No-warning scans: zero behavior change (handler is a no-op when nothing fires).
- Warning-emitting scans (GHSA rate-limit retries, OSV fallbacks, asset tracker errors, etc.): warnings render cleanly above the spinner, spinner stays single-line and redraws in place.

## Validation
- \`ruff check\` + \`mypy\` on touched files — passed
- \`pytest tests/test_cli_scan.py tests/test_ghsa_advisory.py\` — 94 passed
- pre-commit hooks (ruff, ruff-format, mypy, bandit) — passed