### PR TITLE
feat(cli): verdict-led compact posture summary, full panel behind --verbose

### DIFF
--- a/src/agent_bom/cli/agents/_output.py
+++ b/src/agent_bom/cli/agents/_output.py
@@ -144,8 +144,8 @@ def render_output(
                 print_attack_flow_tree(report)
             print_threat_frameworks(report)
         else:
-            # Compact output (default)
-            print_compact_summary(report)
+            # Compact output (default) — verdict-led posture summary.
+            print_compact_summary(report, verbose=verbose)
             print_scan_performance_summary(report)
             print_compact_agents(report)
             print_compact_blast_radius(report, fixable_only=fixable_only)

--- a/src/agent_bom/output/compact.py
+++ b/src/agent_bom/output/compact.py
@@ -96,8 +96,18 @@ def _iter_cis_bundles(report: AIBOMReport):
 # ─── Compact Output (default mode) ───────────────────────────────────────────
 
 
-def print_compact_summary(report: AIBOMReport) -> None:
-    """Compact summary — posture + key metrics in ~8 lines."""
+def print_compact_summary(report: AIBOMReport, *, verbose: bool = False) -> None:
+    """Compact summary — verdict-led posture in 2-4 lines.
+
+    Default (``verbose=False``) leads with a severity-coloured one-liner
+    verdict, follows with an inventory count line, and only mentions the
+    posture grade / drivers / credentials when richer context exists,
+    pointing the operator at ``--verbose`` for that detail.
+
+    ``verbose=True`` re-renders the previous detailed panel form
+    (posture grade, weak driver dimensions, credential list, privilege
+    counts, AI inventory).
+    """
     from collections import Counter
 
     from agent_bom.finding import FindingType
@@ -186,6 +196,46 @@ def print_compact_summary(report: AIBOMReport) -> None:
     n_transitive = len(all_pkgs) - n_direct
     pkg_detail = f" ({n_direct}D/{n_transitive}T)" if n_transitive else ""
 
+    has_ai_inventory = bool(getattr(report, "ai_inventory_data", None) and (report.ai_inventory_data or {}).get("total_components", 0) > 0)
+    has_more_context = bool(weak_dimensions or cred_names or elevated or has_ai_inventory or coverage_incomplete or scorecard.score < 90)
+
+    inventory_line = (
+        f"  [bold]{report.total_agents}[/bold] agents [dim]·[/dim] "
+        f"[bold]{report.total_servers}[/bold] servers [dim]·[/dim] "
+        f"[bold]{report.total_packages}[/bold][dim]{pkg_detail}[/dim] packages"
+    )
+
+    if not verbose:
+        # Default verdict-led form: 2 lines + optional --verbose hint.
+        lines = [
+            f"  [bold]Security posture:[/bold]  {posture}",
+            inventory_line,
+        ]
+        if has_more_context:
+            hint_bits: list[str] = []
+            if scorecard.score < 100:
+                hint_bits.append(f"posture grade {_posture_grade_badge(scorecard.grade)} {scorecard.score:.0f}/100")
+            if weak_dimensions:
+                hint_bits.append(f"{len(weak_dimensions)} weak driver(s)")
+            if cred_names:
+                hint_bits.append(f"{len(cred_names)} credential(s)")
+            if elevated:
+                hint_bits.append(f"{elevated} elevated server(s)")
+            hint_text = " · ".join(hint_bits) if hint_bits else "drivers and credentials"
+            lines.append("")
+            lines.append(f"  [dim]→ Run with[/dim] [bold]--verbose[/bold] [dim]for[/dim] {hint_text}")
+
+        console.print(
+            Panel(
+                "\n".join(lines),
+                title=f"[bold]agent-bom[/bold]  v{report.tool_version}",
+                border_style=border_style,
+                padding=(0, 1),
+            )
+        )
+        return
+
+    # Verbose form: full posture detail (the previous default rendering).
     lines = [
         f"  [bold]CONFIG POSTURE GRADE:[/bold]  {_posture_grade_badge(scorecard.grade)} "
         f"[bold]{scorecard.score:.1f}/100[/bold]  [dim]{scorecard_summary}[/dim]",

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -495,10 +495,13 @@ def test_scan_incomplete_offline_scan_exits_two(monkeypatch):
 
     assert result.exit_code == 2
     assert "populated local vulnerability DB" in result.output
-    assert "SECURITY POSTURE" in result.output
+    # Verdict-led default panel labels the row "Security posture:"; the
+    # ``--verbose`` form labels it "SECURITY POSTURE:". Either is acceptable
+    # — the contract under test is that the partial-coverage state surfaces.
+    assert "Security posture" in result.output or "SECURITY POSTURE" in result.output
     assert "PARTIAL COVERAGE" in result.output
     assert "CLEAN" not in result.output
-    assert "Agents" in result.output
+    assert "agents" in result.output.lower()
 
 
 def test_scan_expands_local_docker_mcp_image():

--- a/tests/test_compact_output.py
+++ b/tests/test_compact_output.py
@@ -94,7 +94,7 @@ def _blast(vuln, pkg, agents, servers, creds=None):
 
 
 def test_compact_summary_clean():
-    """0 vulns → CLEAN posture."""
+    """0 vulns → CLEAN posture (verbose form keeps the explicit grade row)."""
     agent = _make_agent(
         servers=[
             _make_server(
@@ -105,7 +105,7 @@ def test_compact_summary_clean():
         ]
     )
     report = AIBOMReport(agents=[agent])
-    output = _capture(print_compact_summary, report)
+    output = _capture(lambda r: print_compact_summary(r, verbose=True), report)
     assert "CLEAN" in output
     assert "CONFIG POSTURE GRADE" in output
     assert "Agents" in output
@@ -113,20 +113,41 @@ def test_compact_summary_clean():
 
 
 def test_compact_summary_with_vulns():
-    """Shows severity breakdown when vulns exist."""
+    """Shows severity breakdown when vulns exist (verbose form keeps the explicit grade row)."""
     vuln = _vuln()
     pkg = Package(name="lodash", version="4.17.20", ecosystem="npm", vulnerabilities=[vuln])
     server = _make_server(packages=[pkg])
     agent = _make_agent(servers=[server])
     br = _blast(vuln, pkg, [agent], [server])
     report = AIBOMReport(agents=[agent], blast_radii=[br])
-    output = _capture(print_compact_summary, report)
+    output = _capture(lambda r: print_compact_summary(r, verbose=True), report)
     assert "CONFIG POSTURE GRADE" in output
     assert "CRIT" in output  # Badge shows " CRIT " not "CRITICAL"
     assert "Vulns" in output
 
 
 def test_compact_summary_distinguishes_clean_vulns_from_config_posture():
+    """Verbose form keeps the explicit CONFIG POSTURE GRADE / SECURITY POSTURE split."""
+    agent = _make_agent(
+        servers=[
+            _make_server(
+                packages=[
+                    Package(name="express", version="4.19.0", ecosystem="npm"),
+                ]
+            )
+        ]
+    )
+    report = AIBOMReport(agents=[agent])
+    output = _plain(_capture(lambda r: print_compact_summary(r, verbose=True), report))
+    assert "CONFIG POSTURE GRADE" in output
+    assert "No vulnerabilities found" in output
+    assert "best-practice/config posture" in output
+    assert "SECURITY POSTURE:" in output
+    assert "CLEAN" in output
+
+
+def test_compact_summary_default_is_verdict_led():
+    """Default form is verdict-led: posture + inventory, no driver/credential dump."""
     agent = _make_agent(
         servers=[
             _make_server(
@@ -138,15 +159,17 @@ def test_compact_summary_distinguishes_clean_vulns_from_config_posture():
     )
     report = AIBOMReport(agents=[agent])
     output = _plain(_capture(print_compact_summary, report))
-    assert "CONFIG POSTURE GRADE" in output
-    assert "No vulnerabilities found" in output
-    assert "best-practice/config posture" in output
-    assert "SECURITY POSTURE:" in output
+    # Detailed sections moved behind --verbose:
+    assert "CONFIG POSTURE GRADE" not in output
+    assert "Top Drivers" not in output
+    # Verdict + inventory still surface:
     assert "CLEAN" in output
+    assert "agents" in output
+    assert "packages" in output
 
 
 def test_compact_summary_includes_non_cve_findings():
-    """Policy and blocklist findings should not render as CLEAN."""
+    """Policy and blocklist findings should not render as CLEAN — verbose form keeps the rationale."""
     finding = Finding(
         finding_type=FindingType.MCP_BLOCKLIST,
         source=FindingSource.MCP_SCAN,
@@ -156,7 +179,7 @@ def test_compact_summary_includes_non_cve_findings():
     )
     report = AIBOMReport(findings=[finding])
 
-    output = _capture(print_compact_summary, report)
+    output = _capture(lambda r: print_compact_summary(r, verbose=True), report)
 
     assert "CLEAN" not in output
     assert "HIGH" in output
@@ -166,13 +189,34 @@ def test_compact_summary_includes_non_cve_findings():
     assert "Strong security posture" not in output
 
 
+def test_compact_summary_default_does_not_render_clean_for_policy_findings():
+    """Default (verdict-led) form must still surface non-CVE policy findings as non-clean."""
+    finding = Finding(
+        finding_type=FindingType.MCP_BLOCKLIST,
+        source=FindingSource.MCP_SCAN,
+        asset=Asset(name="bad-server", asset_type="mcp_server"),
+        severity="high",
+        title="Blocked MCP server",
+    )
+    report = AIBOMReport(findings=[finding])
+    output = _capture(print_compact_summary, report)
+    assert "CLEAN" not in output
+    assert "HIGH" in output
+
+
 def test_compact_summary_credentials():
-    """Shows credential names."""
+    """Verbose form lists credential names; default form just hints at the count."""
     server = _make_server(name="github", env={"GITHUB_TOKEN": "xxx"})
     agent = _make_agent(servers=[server])
     report = AIBOMReport(agents=[agent])
-    output = _capture(print_compact_summary, report)
-    assert "GITHUB_TOKEN" in output
+
+    verbose_output = _capture(lambda r: print_compact_summary(r, verbose=True), report)
+    assert "GITHUB_TOKEN" in verbose_output
+
+    default_output = _plain(_capture(print_compact_summary, report))
+    # Default form does NOT list credential names — it surfaces the count via
+    # the --verbose hint when something interesting exists in the scorecard.
+    assert "GITHUB_TOKEN" not in default_output
 
 
 def test_compact_summary_unknown_severity_is_labeled_advisory():
@@ -189,16 +233,30 @@ def test_compact_summary_unknown_severity_is_labeled_advisory():
 
 
 def test_compact_summary_shows_top_drivers_for_weak_posture():
-    """Weak posture should surface the key drivers inline."""
+    """Verbose form surfaces the key drivers inline."""
     vuln = _vuln(severity=Severity.HIGH, fixed="9.9.9")
     pkg = Package(name="pkg", version="1.0.0", ecosystem="npm", vulnerabilities=[vuln])
     server = _make_server(packages=[pkg], env={"AWS_SECRET_ACCESS_KEY": "x"})
     agent = _make_agent(servers=[server])
     br = _blast(vuln, pkg, [agent], [server], creds=["AWS_SECRET_ACCESS_KEY"])
     report = AIBOMReport(agents=[agent], blast_radii=[br])
-    output = _capture(print_compact_summary, report)
+    output = _capture(lambda r: print_compact_summary(r, verbose=True), report)
     assert "Top Drivers" in output
     assert "Credential Hygiene" in output
+
+
+def test_compact_summary_default_offers_verbose_hint_when_drivers_weak():
+    """Default form replaces inline drivers with a -> Run with --verbose hint."""
+    vuln = _vuln(severity=Severity.HIGH, fixed="9.9.9")
+    pkg = Package(name="pkg", version="1.0.0", ecosystem="npm", vulnerabilities=[vuln])
+    server = _make_server(packages=[pkg], env={"AWS_SECRET_ACCESS_KEY": "x"})
+    agent = _make_agent(servers=[server])
+    br = _blast(vuln, pkg, [agent], [server], creds=["AWS_SECRET_ACCESS_KEY"])
+    report = AIBOMReport(agents=[agent], blast_radii=[br])
+    output = _plain(_capture(print_compact_summary, report))
+    assert "Top Drivers" not in output  # moved to --verbose
+    assert "--verbose" in output  # hint surfaces
+    assert "weak driver" in output or "credential" in output  # hint mentions what's behind it
 
 
 # ── print_compact_agents ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
The default compact posture panel rendered a 5-7 line dense block with five rows: \`CONFIG POSTURE GRADE\`, \`SECURITY POSTURE\`, an inventory row, \`Top Drivers\`, and \`Credentials\`. Operators reported it was hard to scan at a glance.

Switch the default to a verdict-led 2-line layout:

\`\`\`
╭ agent-bom · v0.84.5 ────────────────────────────────╮
│  Security posture:  CLEAN  no known vulnerabilities │
│  9 agents · 9 servers · 837 packages                │
╰─────────────────────────────────────────────────────╯
\`\`\`

When the scan has richer context (weak driver dimensions, configured credentials, elevated privileges, AI inventory, sub-90 grade), append a single hint line that surfaces the counts and points at \`--verbose\`:

\`\`\`
│  → Run with --verbose for posture grade C 77/100 · 2 weak driver(s) · 5 credential(s)
\`\`\`

\`agent-bom agents --verbose\` re-renders the previous detailed panel form unchanged.

## Why
Real machine scans against this repo (837 packages, 9 agents) showed the operator scrolling past the inventory row to find the actual security verdict. \`Trivy\`/\`Grype\` lead with the verdict ("X critical, Y high") and let the operator drill in. This brings agent-bom in line.

## Behaviour matrix

| Scan state | Default (no \`--verbose\`) | \`--verbose\` |
|---|---|---|
| Clean | \`Security posture: CLEAN  no known vulnerabilities\` + inventory | full 5-row panel with \`CONFIG POSTURE GRADE\` + \`SECURITY POSTURE: CLEAN\` |
| Findings present | severity-coloured badge + inventory + (if more) hint | full 5-row panel + Top Drivers + Credentials + Privileges + AI Inventory |
| Coverage incomplete | \`PARTIAL COVERAGE\` badge + inventory + hint | same as before plus the partial-coverage rationale row |

## Test coverage
- \`tests/test_compact_output.py::test_compact_summary_default_is_verdict_led\` — pins the new default form
- \`tests/test_compact_output.py::test_compact_summary_default_does_not_render_clean_for_policy_findings\` — non-CVE findings still surface as non-clean in the default form
- \`tests/test_compact_output.py::test_compact_summary_default_offers_verbose_hint_when_drivers_weak\` — the conditional \`--verbose\` hint appears when there's something to drill into
- All four pre-existing tests that asserted the detailed form (\`test_compact_summary_clean\`, \`test_compact_summary_with_vulns\`, \`test_compact_summary_distinguishes_clean_vulns_from_config_posture\`, \`test_compact_summary_includes_non_cve_findings\`, \`test_compact_summary_credentials\`, \`test_compact_summary_shows_top_drivers_for_weak_posture\`) updated to call \`print_compact_summary(report, verbose=True)\` since they're testing the detailed-panel semantics.

## Validation
- \`ruff check\` + \`mypy\` on touched files — passed
- \`pytest tests/test_compact_output.py\` — 21 / 21 pass
- \`pytest tests/test_output_formats.py tests/test_cli_polish.py\` — 46 / 46 pass
- pre-commit hooks (ruff, ruff-format, mypy, bandit) — passed
- live: \`agent-bom agents --demo\` renders 2-line verdict + hint; \`agent-bom agents --demo --verbose\` renders the full panel