### PR TITLE
fix(cli): use Severity.value so the scan-complete severity closer renders content

### DIFF
--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -1283,10 +1283,18 @@ def scan(
                 sev_counts: dict[str, int] = {}
                 for br in blast_radii:
                     # ``BlastRadius.severity`` lives on the wrapped Vulnerability,
-                    # not the BlastRadius dataclass itself. Severity is a
-                    # ``str, Enum`` so ``str(...)`` yields the canonical token.
+                    # not the BlastRadius dataclass itself. ``Severity(str, Enum)``
+                    # holds the canonical token in ``.value`` (e.g. "critical").
+                    # On Python 3.13 ``str(Severity.CRITICAL)`` returns
+                    # "Severity.CRITICAL" rather than "critical", so reach for
+                    # ``.value`` first and only fall through to ``str()`` for
+                    # plain-string severities (policy findings, mocks).
                     raw_sev = getattr(br.vulnerability, "severity", None) if getattr(br, "vulnerability", None) else None
-                    sev_key = (str(raw_sev).lower() if raw_sev else "unknown") or "unknown"
+                    if raw_sev is None:
+                        sev_key = "unknown"
+                    else:
+                        sev_value = getattr(raw_sev, "value", raw_sev)
+                        sev_key = str(sev_value).lower() or "unknown"
                     sev_counts[sev_key] = sev_counts.get(sev_key, 0) + 1
                 _sev_order = ["critical", "high", "medium", "low", "unknown"]
                 _sev_color = {

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -875,3 +875,30 @@ def test_compliance_export_help_lists_supported_values():
     assert result.exit_code == 0
     assert "--compliance-export" in result.output
     assert "cmmc, fedramp, nist-ai-rmf" in result.output
+
+
+def test_scan_complete_closer_renders_severity_breakdown():
+    """Regression: ``Scan complete -- N high · M medium`` must render content,
+    not just an empty trailing dash.
+
+    On Python 3.13 ``str(Severity.CRITICAL)`` returns ``'Severity.CRITICAL'``
+    rather than ``'critical'``, which previously caused the closer's
+    severity-key lookup to miss every entry in the canonical
+    ``["critical", "high", "medium", "low", "unknown"]`` order list and
+    render an empty breakdown after ``Scan complete --``.
+    """
+    result = _run(["scan", "--demo", "--no-auto-update-db"])
+
+    # The closer fires only when blast_radii is non-empty; demo provides 50+.
+    if "Scan complete" in result.output:
+        # Must NOT be the empty-breakdown form.
+        # Find the closer line and confirm it has content after the em dash.
+        for line in result.output.splitlines():
+            if "Scan complete" in line and "—" in line:
+                trailing = line.split("—", 1)[1].strip()
+                assert trailing, f"closer rendered empty breakdown: {line!r}"
+                # And the trailing content should mention at least one severity tier.
+                assert any(s in trailing.lower() for s in ("critical", "high", "medium", "low", "advisory")), (
+                    f"closer rendered no severity tier: {line!r}"
+                )
+                break


### PR DESCRIPTION
## Summary
Pre-release audit before tagging v0.84.6 caught a regression introduced in #2181's severity-coloured closer:

\`\`\`
⚠ Scan complete —      ← empty trailing breakdown!
\`\`\`

instead of the intended

\`\`\`
⚠ Scan complete — 2 critical · 19 high · 25 medium
\`\`\`

## Root cause
\`Severity(str, Enum)\` carries the canonical token in \`.value\` (\`"critical"\`, \`"high"\`, ...). On **Python 3.13** \`str(Severity.CRITICAL)\` returns the default Enum repr \`"Severity.CRITICAL"\`, **not** \`"critical"\`. Lower-casing that to \`"severity.critical"\` failed to match any entry in the canonical \`["critical", "high", "medium", "low", "unknown"]\` order list, and the join over the ordered keys produced an empty string.

## Fix
Reach for \`.value\` first via \`getattr(raw_sev, "value", raw_sev)\`. Enum values now yield the canonical token; \`str()\` fall-through covers plain-string severities (policy findings, mocks).

## Regression coverage
\`tests/test_cli_scan.py::test_scan_complete_closer_renders_severity_breakdown\` — when the closer fires, the trailing fragment after the em dash must be non-empty AND mention at least one severity tier. Locks in the contract so the bug can't slip back through tests that only assert on the leading \`"Scan complete"\` string.

## Validation
- \`PYTHONPATH=src pytest tests/test_cli_scan.py -q -m "not network"\` — 67 / 67 pass
- pre-commit hooks (ruff, ruff-format, mypy, bandit) — passed
- live: \`agent-bom agents --demo\` now renders the closer with a coloured severity breakdown

## Why this is a release blocker
v0.84.6 will ship #2181's severity closer as the user-visible closing line for every scan with findings. Shipping with the empty-breakdown regression would mean every scan looks like a half-finished log line.