### PR TITLE
docs(diagrams): align engine-internals + compliance counts to current product state

### DIFF
--- a/docs/images/compliance-dark.svg
+++ b/docs/images/compliance-dark.svg
@@ -15,7 +15,7 @@
   <rect width="960" height="280" rx="12" fill="#09090b"/>
 
   <text x="480" y="28" text-anchor="middle" class="title">Compliance coverage</text>
-  <text x="480" y="44" text-anchor="middle" class="subtitle">11 frameworks, 300+ controls mapped automatically from scan findings</text>
+  <text x="480" y="44" text-anchor="middle" class="subtitle">14 frameworks + AISVS, 300+ controls mapped automatically from scan findings</text>
 
   <!-- ═══ ROW 1: 5 frameworks ═══ -->
 

--- a/docs/images/compliance-light.svg
+++ b/docs/images/compliance-light.svg
@@ -15,7 +15,7 @@
   <rect width="960" height="364" rx="12" fill="#ffffff" stroke="#e4e4e7" stroke-width="1"/>
 
   <text x="480" y="28" text-anchor="middle" class="title">Compliance coverage</text>
-  <text x="480" y="44" text-anchor="middle" class="subtitle">11 frameworks, 300+ controls mapped automatically from scan findings</text>
+  <text x="480" y="44" text-anchor="middle" class="subtitle">14 frameworks + AISVS, 300+ controls mapped automatically from scan findings</text>
 
   <!-- ═══ ROW 1: 5 frameworks ═══ -->
 

--- a/docs/images/engine-internals-dark.svg
+++ b/docs/images/engine-internals-dark.svg
@@ -49,7 +49,7 @@
 
   <rect x="38" y="232" width="172" height="28" rx="6" fill="#1e293b" stroke="#1e3a5f" stroke-width="0.5"/>
   <text x="50" y="250" class="mod-name">Package Parsers</text>
-  <text x="210" y="250" text-anchor="end" class="mod-sub" fill="#60a5fa">5 ecosystems</text>
+  <text x="210" y="250" text-anchor="end" class="mod-sub" fill="#60a5fa">15 ecosystems</text>
 
   <rect x="38" y="266" width="172" height="28" rx="6" fill="#1e293b" stroke="#1e3a5f" stroke-width="0.5"/>
   <text x="50" y="284" class="mod-name">SBOM + Model Ingest</text>
@@ -109,7 +109,7 @@
 
   <rect x="530" y="164" width="172" height="28" rx="6" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
   <text x="542" y="182" class="mod-name">Compliance</text>
-  <text x="702" y="182" text-anchor="end" class="mod-sub" fill="#fb7185">11 frameworks</text>
+  <text x="702" y="182" text-anchor="end" class="mod-sub" fill="#fb7185">14 + AISVS</text>
 
   <rect x="530" y="198" width="172" height="28" rx="6" fill="#2a1520" stroke="#881337" stroke-width="0.5"/>
   <text x="542" y="216" class="mod-name">Policy Engine</text>
@@ -214,7 +214,7 @@
   <!-- ═══════════════════════════════════════════════════════════════════════ -->
   <rect x="24" y="482" width="912" height="44" rx="8" fill="#111113" stroke="#1c1c1f" stroke-width="1"/>
 
-  <text x="92" y="504" text-anchor="middle" class="stat-num" fill="#3b82f6">21</text>
+  <text x="92" y="504" text-anchor="middle" class="stat-num" fill="#3b82f6">29</text>
   <text x="92" y="518" text-anchor="middle" class="stat-label">MCP clients</text>
 
   <text x="222" y="504" text-anchor="middle" class="stat-num" fill="#f59e0b">6</text>
@@ -223,15 +223,15 @@
   <text x="352" y="504" text-anchor="middle" class="stat-num" fill="#f43f5e">427+</text>
   <text x="352" y="518" text-anchor="middle" class="stat-label">registry servers</text>
 
-  <text x="482" y="504" text-anchor="middle" class="stat-num" fill="#f43f5e">14</text>
-  <text x="482" y="518" text-anchor="middle" class="stat-label">compliance frameworks</text>
+  <text x="482" y="504" text-anchor="middle" class="stat-num" fill="#f43f5e">15</text>
+  <text x="482" y="518" text-anchor="middle" class="stat-label">compliance surfaces</text>
 
-  <text x="612" y="504" text-anchor="middle" class="stat-num" fill="#10b981">12</text>
+  <text x="612" y="504" text-anchor="middle" class="stat-num" fill="#10b981">26</text>
   <text x="612" y="518" text-anchor="middle" class="stat-label">output formats</text>
 
-  <text x="742" y="504" text-anchor="middle" class="stat-num" fill="#a78bfa">30</text>
+  <text x="742" y="504" text-anchor="middle" class="stat-num" fill="#a78bfa">36</text>
   <text x="742" y="518" text-anchor="middle" class="stat-label">MCP server tools</text>
 
-  <text x="872" y="504" text-anchor="middle" class="stat-num" fill="#71717a">4,400+</text>
-  <text x="872" y="518" text-anchor="middle" class="stat-label">tests</text>
+  <text x="872" y="504" text-anchor="middle" class="stat-num" fill="#71717a">419</text>
+  <text x="872" y="518" text-anchor="middle" class="stat-label">test files</text>
 </svg>

--- a/docs/images/engine-internals-light.svg
+++ b/docs/images/engine-internals-light.svg
@@ -49,7 +49,7 @@
 
   <rect x="38" y="232" width="172" height="28" rx="6" fill="#eff6ff" stroke="#bfdbfe" stroke-width="0.5"/>
   <text x="50" y="250" class="mod-name">Package Parsers</text>
-  <text x="210" y="250" text-anchor="end" class="mod-sub" fill="#2563eb">5 ecosystems</text>
+  <text x="210" y="250" text-anchor="end" class="mod-sub" fill="#2563eb">15 ecosystems</text>
 
   <rect x="38" y="266" width="172" height="28" rx="6" fill="#eff6ff" stroke="#bfdbfe" stroke-width="0.5"/>
   <text x="50" y="284" class="mod-name">SBOM + Model Ingest</text>
@@ -109,7 +109,7 @@
 
   <rect x="530" y="164" width="172" height="28" rx="6" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
   <text x="542" y="182" class="mod-name">Compliance</text>
-  <text x="702" y="182" text-anchor="end" class="mod-sub" fill="#e11d48">11 frameworks</text>
+  <text x="702" y="182" text-anchor="end" class="mod-sub" fill="#e11d48">14 + AISVS</text>
 
   <rect x="530" y="198" width="172" height="28" rx="6" fill="#fff1f2" stroke="#fecdd3" stroke-width="0.5"/>
   <text x="542" y="216" class="mod-name">Policy Engine</text>
@@ -214,7 +214,7 @@
   <!-- ═══════════════════════════════════════════════════════════════════════ -->
   <rect x="24" y="482" width="912" height="44" rx="8" fill="#f4f4f5" stroke="#e4e4e7" stroke-width="1"/>
 
-  <text x="92" y="504" text-anchor="middle" class="stat-num" fill="#2563eb">21</text>
+  <text x="92" y="504" text-anchor="middle" class="stat-num" fill="#2563eb">29</text>
   <text x="92" y="518" text-anchor="middle" class="stat-label">MCP clients</text>
 
   <text x="222" y="504" text-anchor="middle" class="stat-num" fill="#d97706">6</text>
@@ -223,15 +223,15 @@
   <text x="352" y="504" text-anchor="middle" class="stat-num" fill="#e11d48">427+</text>
   <text x="352" y="518" text-anchor="middle" class="stat-label">registry servers</text>
 
-  <text x="482" y="504" text-anchor="middle" class="stat-num" fill="#e11d48">14</text>
-  <text x="482" y="518" text-anchor="middle" class="stat-label">compliance frameworks</text>
+  <text x="482" y="504" text-anchor="middle" class="stat-num" fill="#e11d48">15</text>
+  <text x="482" y="518" text-anchor="middle" class="stat-label">compliance surfaces</text>
 
-  <text x="612" y="504" text-anchor="middle" class="stat-num" fill="#059669">12</text>
+  <text x="612" y="504" text-anchor="middle" class="stat-num" fill="#059669">26</text>
   <text x="612" y="518" text-anchor="middle" class="stat-label">output formats</text>
 
-  <text x="742" y="504" text-anchor="middle" class="stat-num" fill="#7c3aed">30</text>
+  <text x="742" y="504" text-anchor="middle" class="stat-num" fill="#7c3aed">36</text>
   <text x="742" y="518" text-anchor="middle" class="stat-label">MCP server tools</text>
 
-  <text x="872" y="504" text-anchor="middle" class="stat-num" fill="#a1a1aa">4,400+</text>
-  <text x="872" y="518" text-anchor="middle" class="stat-label">tests</text>
+  <text x="872" y="504" text-anchor="middle" class="stat-num" fill="#a1a1aa">419</text>
+  <text x="872" y="518" text-anchor="middle" class="stat-label">test files</text>
 </svg>

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -1,5 +1,10 @@
 # OpenClaw / ClawHub Skill Publishing
 
+> **Ownership.** These skills are owned and maintained by `agent-bom`.
+> OpenClaw and ClawHub are distribution surfaces — they package and surface
+> agent-bom skills for installation; the implementation, version, security
+> review, and release cadence stay with agent-bom.
+
 `agent-bom` keeps the public ClawHub surface intentionally small.
 
 Published skills:


### PR DESCRIPTION
Closes #2150.

## Summary
Diagram audit (`#2150`) flagged stale counts and inconsistent claims across architecture and compliance visuals. This PR walks the SVGs back to current product state and adds the OpenClaw/ClawHub ownership framing the issue asked for.

## Changes

### `docs/images/engine-internals-{light,dark}.svg`
| Drift | Before | After | Source of truth |
|---|---|---|---|
| Package Parsers mod-sub | `5 ecosystems` | `15 ecosystems` | `src/agent_bom/ecosystems.SUPPORTED_PACKAGE_ECOSYSTEMS` |
| Compliance mod-sub | `11 frameworks` | `14 + AISVS` | `docs/PRODUCT_METRICS.json` |
| stat: MCP clients | `21` | `29` | `src/agent_bom/discovery.CONFIG_LOCATIONS` |
| stat: MCP server tools | `30` | `36` | `docs/PRODUCT_METRICS.json` + `src/agent_bom/mcp_server_metadata.py` |
| stat: output formats | `12` | `26` | `src/agent_bom/output/` module count |
| stat: compliance | `14 compliance frameworks` | `15 compliance surfaces` | `compliance_coverage` (14 frameworks + AISVS) |
| stat: tests | `4,400+ tests` | `419 test files` | `tests/test_*.py` count |

### `docs/images/compliance-{light,dark}.svg`
- subtitle: `11 frameworks, 300+ controls mapped` → `14 frameworks + AISVS, 300+ controls mapped`. The 5 / 5 / 4 row labels are framework groupings (5 + 5 + 4 = 14) and stay correct.

### `integrations/openclaw/README.md`
Adds an explicit ownership note at the top:

> **Ownership.** These skills are owned and maintained by `agent-bom`. OpenClaw and ClawHub are distribution surfaces — they package and surface agent-bom skills for installation; the implementation, version, security review, and release cadence stay with agent-bom.

## Out of scope (left for follow-up)
- Net-new self-hosted topology SVG. The canonical topology contract already lives in `site-docs/architecture/self-hosted-product-architecture.md` with a per-surface ownership table, and reads cleanly without a redrawn SVG.

## Validation
- `python3 -c "import xml.etree.ElementTree as ET; [ET.parse(p) for p in ['docs/images/engine-internals-light.svg', ...]]"` → all SVGs parse.
- Post-edit grep audit: every remaining count claim in `docs/images/*.svg` traces back to a canonical source (discovery registry, ecosystems registry, PRODUCT_METRICS, output module, mcp_server_metadata, or tests directory).
- No code paths touched.