### PR TITLE
feat(firewall): inter-agent firewall foundation — schema, loader, evaluator, CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,12 @@ jobs:
         # declared in config.py nor explicitly allowlisted.
         run: uv run python scripts/generate_env_var_reference.py --check
 
+      - name: CLI reference alignment (fast preflight)
+        # Mirrors tests/test_public_docs_cli_alignment.py but runs in Lint so a
+        # new CLI root command missing a site-docs/reference/cli.md row fails
+        # in ~1 min instead of burning 6-8 min on the Test matrix.
+        run: uv run python scripts/check_cli_reference_alignment.py
+
   ui:
     name: UI Validate
     runs-on: ubuntu-latest

--- a/docs/AGENT_FIREWALL.md
+++ b/docs/AGENT_FIREWALL.md
@@ -1,0 +1,114 @@
+# Inter-agent firewall
+
+The agent-bom inter-agent firewall is a tenant-scoped policy engine that controls
+which agents are allowed to delegate to which other agents through the MCP runtime
+plane. It exists so a compromised or untrusted agent cannot move laterally through
+delegation chains.
+
+This page documents the policy schema and CLI tooling. Enforcement is layered:
+
+- **proxy** sits in the existing MCP detector chain and applies a local fast-path
+  decision against a cached policy.
+- **gateway** is the central authority — it loads the policy file, hot-reloads
+  on change, and emits decisions to the existing `/v1/proxy/audit` HMAC-chained
+  audit relay.
+
+## Policy file format
+
+```json
+{
+  "version": 1,
+  "tenant_id": "acme",
+  "enforcement_mode": "enforce",
+  "default_decision": "allow",
+  "rules": [
+    {
+      "source": "cursor",
+      "target": "snowflake-cli",
+      "decision": "deny",
+      "description": "Cursor must not delegate directly to the Snowflake CLI"
+    },
+    {
+      "source": "role:trusted-orchestrator",
+      "target": "role:data-plane",
+      "decision": "allow"
+    },
+    {
+      "source": "role:untrusted",
+      "target": "*",
+      "decision": "deny"
+    }
+  ]
+}
+```
+
+### Fields
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `version` | int | `1` | Schema version. Only `1` accepted today. |
+| `tenant_id` | string \| null | `null` | When set, the gateway applies this policy only to the named tenant. |
+| `enforcement_mode` | `"enforce" \| "dry_run"` | `"enforce"` | In `dry_run`, every `deny` decision is downgraded to `warn` so operators can preview impact. |
+| `default_decision` | `"allow" \| "deny" \| "warn"` | `"allow"` | Applied when no rule matches the source/target pair. |
+| `rules` | list | `[]` | See below. |
+
+### Rule format
+
+| Field | Type | Notes |
+|---|---|---|
+| `source` | string | Agent name (`cursor`), wildcard (`*`), or role tag (`role:trusted`). |
+| `target` | string | Same as `source`. |
+| `decision` | `"allow" \| "deny" \| "warn"` | What to do on match. `warn` audits without blocking. |
+| `description` | string | Free-form note shown by `agent-bom firewall list`. |
+
+### Pattern matching
+
+- Plain names use `fnmatch` (so `snowflake-*` matches `snowflake-cli`).
+- `role:<tag>` matches when the agent carries that role tag (also `fnmatch`-globbed).
+- `*` alone matches everything.
+
+### Precedence
+
+When more than one rule matches:
+
+1. **Most-specific rule wins.** Concrete agent names beat role tags beat wildcards.
+2. **DENY beats WARN beats ALLOW** at the same specificity (conservative default).
+
+When no rule matches, `default_decision` applies.
+
+### Dry-run mode
+
+Set `enforcement_mode: "dry_run"` to preview a policy. Every `deny` decision is
+downgraded to `warn` so the gateway audits but never blocks. This matches the rest
+of the platform's "audit before enforce" pattern.
+
+## CLI
+
+```bash
+# Validate schema
+agent-bom firewall validate ./firewall.json
+
+# List rules
+agent-bom firewall list ./firewall.json
+agent-bom firewall list ./firewall.json --json
+
+# Test a pair
+agent-bom firewall check ./firewall.json cursor snowflake-cli
+agent-bom firewall check ./firewall.json cursor snowflake-cli \
+    --source-role trusted-orchestrator
+```
+
+## Roadmap
+
+This is PR 1 of a four-PR series implementing #982:
+
+1. **Foundation** (this PR) — schema, loader, evaluator, CLI, tests.
+2. **Gateway evaluator** — gateway loads the policy, evaluates on each agent→agent
+   path, emits decisions to `/v1/proxy/audit`.
+3. **Proxy fast-path** — proxy detector consults the cached policy; gateway
+   remains authoritative for refreshes.
+4. **Dashboard runtime overlay** — per-pair decision counter, recent denials,
+   policy hot-reload status on the runtime tab.
+
+Capability-keyed rules (`agent_a may invoke tool X via agent_b`) are deliberately
+deferred to a v2 once pairwise + role tags prove out in production.

--- a/scripts/check_cli_reference_alignment.py
+++ b/scripts/check_cli_reference_alignment.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Fail fast when a new CLI root command is missing from the public reference.
+
+Mirrors `tests/test_public_docs_cli_alignment.py::test_cli_reference_lists_all_visible_root_commands`
+but is invoked from the fast Lint stage of CI so the failure surfaces in ~1
+minute instead of waiting on the 6-8 minute test matrix to fail. Run via the
+project's venv so click + the rest of the CLI imports cleanly.
+
+Usage (CI):
+    uv run python scripts/check_cli_reference_alignment.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    sys.path.insert(0, str(ROOT / "src"))
+    try:
+        from agent_bom.cli import main as cli_main
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"check_cli_reference_alignment: failed to import CLI: {exc}\n"
+            "Run inside the project venv (e.g. `uv run python scripts/check_cli_reference_alignment.py`).",
+            file=sys.stderr,
+        )
+        return 2
+
+    cli_reference_path = ROOT / "site-docs" / "reference" / "cli.md"
+    if not cli_reference_path.exists():
+        print(f"check_cli_reference_alignment: missing {cli_reference_path}", file=sys.stderr)
+        return 2
+
+    cli_reference = cli_reference_path.read_text(encoding="utf-8")
+    visible_commands = sorted(name for name, command in cli_main.commands.items() if not getattr(command, "hidden", False))
+
+    missing = [name for name in visible_commands if f"| `{name}` |" not in cli_reference]
+    if missing:
+        print(
+            "check_cli_reference_alignment: site-docs/reference/cli.md is missing entries for:\n  "
+            + "\n  ".join(f"- `{name}`" for name in missing)
+            + "\n\nAdd a row of the form  | `<name>` | <one-line description> |"
+            " under the appropriate section before committing.",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -52,6 +52,7 @@
 | Command | Description |
 |---------|-------------|
 | `policy` | Policy templates, application, and install-guard checks |
+| `firewall` | Inter-agent firewall policy validate / list / check |
 | `trust` | Show data access, network, auth, and storage boundaries |
 | `fleet` | Manage AI agent fleet discovery, lifecycle, and posture |
 | `serve` | Start the API server and dashboard |

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -162,6 +162,10 @@ policy_group.add_command(apply_command, "apply")
 policy_group.add_command(guard_cmd, "check")  # guard → policy check
 main.add_command(policy_group)
 
+from agent_bom.cli._firewall import firewall_group  # noqa: E402
+
+main.add_command(firewall_group)
+
 from agent_bom.cli._server import api_cmd, mcp_server_cmd, serve_cmd  # noqa: E402
 
 main.add_command(serve_cmd, "serve")

--- a/src/agent_bom/cli/_firewall.py
+++ b/src/agent_bom/cli/_firewall.py
@@ -1,0 +1,159 @@
+"""`agent-bom firewall` CLI: validate and inspect inter-agent firewall policies.
+
+Foundation only (#982 PR 1). Enforcement at the gateway and proxy is wired up
+in subsequent PRs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from agent_bom.firewall import (
+    FirewallPolicyError,
+    evaluate,
+    load_firewall_policy_file,
+)
+
+
+@click.group("firewall", invoke_without_command=False)
+def firewall_group() -> None:
+    """Inter-agent firewall policy tooling.
+
+    \b
+    Subcommands:
+      validate    Validate a firewall policy file
+      list        List rules in a firewall policy file
+      check       Test a source → target pair against a policy
+
+    \b
+    Policy file format (JSON):
+      {
+        "version": 1,
+        "tenant_id": "acme",
+        "enforcement_mode": "enforce" | "dry_run",
+        "default_decision": "allow" | "deny" | "warn",
+        "rules": [
+          {"source": "cursor", "target": "snowflake-cli",
+           "decision": "deny", "description": "..."},
+          {"source": "role:trusted", "target": "role:data-plane", "decision": "allow"}
+        ]
+      }
+    """
+
+
+@firewall_group.command("validate")
+@click.argument("policy_file", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+def validate_cmd(policy_file: Path) -> None:
+    """Validate a firewall policy file. Exits non-zero on schema errors."""
+    try:
+        policy = load_firewall_policy_file(policy_file)
+    except FirewallPolicyError as exc:
+        click.secho(f"invalid: {exc}", fg="red", err=True)
+        raise SystemExit(2)
+    click.secho(
+        f"valid · {len(policy.rules)} rule(s) · default={policy.default_decision.value} · mode={policy.enforcement_mode.value}",
+        fg="green",
+    )
+
+
+@firewall_group.command("list")
+@click.argument("policy_file", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON instead of a human-readable table.")
+def list_cmd(policy_file: Path, as_json: bool) -> None:
+    """List rules in a firewall policy file."""
+    try:
+        policy = load_firewall_policy_file(policy_file)
+    except FirewallPolicyError as exc:
+        click.secho(f"invalid: {exc}", fg="red", err=True)
+        raise SystemExit(2)
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "version": policy.version,
+                    "tenant_id": policy.tenant_id,
+                    "enforcement_mode": policy.enforcement_mode.value,
+                    "default_decision": policy.default_decision.value,
+                    "rules": [
+                        {
+                            "source": r.source,
+                            "target": r.target,
+                            "decision": r.decision.value,
+                            "description": r.description,
+                        }
+                        for r in policy.rules
+                    ],
+                },
+                indent=2,
+            )
+        )
+        return
+
+    click.echo(
+        f"firewall · tenant={policy.tenant_id or '*'} · mode={policy.enforcement_mode.value} · default={policy.default_decision.value}"
+    )
+    if not policy.rules:
+        click.echo("(no rules)")
+        return
+    for rule in policy.rules:
+        color = {"allow": "green", "deny": "red", "warn": "yellow"}.get(rule.decision.value, "white")
+        click.echo(
+            f"  {rule.source:<24} -> {rule.target:<24}  "
+            + click.style(rule.decision.value.upper(), fg=color)
+            + (f"  · {rule.description}" if rule.description else "")
+        )
+
+
+@firewall_group.command("check")
+@click.argument("policy_file", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.argument("source")
+@click.argument("target")
+@click.option(
+    "--source-role",
+    "source_roles",
+    multiple=True,
+    help="Role tag for the source agent (repeatable).",
+)
+@click.option(
+    "--target-role",
+    "target_roles",
+    multiple=True,
+    help="Role tag for the target agent (repeatable).",
+)
+def check_cmd(
+    policy_file: Path,
+    source: str,
+    target: str,
+    source_roles: tuple[str, ...],
+    target_roles: tuple[str, ...],
+) -> None:
+    """Test a source → target pair against the policy."""
+    try:
+        policy = load_firewall_policy_file(policy_file)
+    except FirewallPolicyError as exc:
+        click.secho(f"invalid: {exc}", fg="red", err=True)
+        raise SystemExit(2)
+
+    result = evaluate(
+        policy,
+        source_agent=source,
+        target_agent=target,
+        source_roles=set(source_roles),
+        target_roles=set(target_roles),
+    )
+    color = {"allow": "green", "deny": "red", "warn": "yellow"}[result.effective_decision.value]
+    click.echo(f"{source} -> {target}: " + click.style(result.effective_decision.value.upper(), fg=color, bold=True))
+    if result.matched_rule is not None:
+        click.echo(
+            f"  matched: {result.matched_rule.source} -> {result.matched_rule.target} "
+            f"({result.matched_rule.decision.value})"
+            + (f"  · {result.matched_rule.description}" if result.matched_rule.description else "")
+        )
+    else:
+        click.echo(f"  no rule matched · default = {policy.default_decision.value}")
+    if result.decision != result.effective_decision:
+        click.echo(f"  note: dry_run mode converted {result.decision.value} -> {result.effective_decision.value}")

--- a/src/agent_bom/firewall.py
+++ b/src/agent_bom/firewall.py
@@ -1,0 +1,233 @@
+"""Inter-agent firewall policy: pairwise + role-tag rules with allow/deny/warn tiers.
+
+This module is the policy *foundation* (#982 PR 1). It defines the schema, loader,
+and evaluator. Enforcement at the gateway and proxy enforcement points is wired up
+in subsequent PRs (#982 PR 2, PR 3).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+
+class FirewallDecision(str, Enum):
+    """Per-rule decision tier."""
+
+    ALLOW = "allow"
+    DENY = "deny"
+    WARN = "warn"
+
+
+class FirewallEnforcementMode(str, Enum):
+    """Global enforcement mode controlling whether DENY actually blocks."""
+
+    ENFORCE = "enforce"
+    DRY_RUN = "dry_run"
+
+
+class FirewallPolicyError(ValueError):
+    """Raised when a firewall policy payload fails validation."""
+
+
+_ROLE_PREFIX = "role:"
+
+
+@dataclass(frozen=True)
+class FirewallRule:
+    """A single agent→agent rule.
+
+    Patterns may name a concrete agent (`cursor`) or a role tag (`role:trusted`).
+    `*` is a fnmatch wildcard.
+    """
+
+    source: str
+    target: str
+    decision: FirewallDecision
+    description: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.source.strip() or not self.target.strip():
+            raise FirewallPolicyError("firewall rule source and target must be non-empty")
+
+
+@dataclass(frozen=True)
+class AgentFirewallPolicy:
+    """A tenant-scoped firewall policy.
+
+    `default_decision` applies when no rule matches. Defaults to ALLOW so an
+    empty policy file is permissive — operators opt into deny by adding rules.
+    """
+
+    version: int = 1
+    tenant_id: str | None = None
+    enforcement_mode: FirewallEnforcementMode = FirewallEnforcementMode.ENFORCE
+    rules: tuple[FirewallRule, ...] = field(default_factory=tuple)
+    default_decision: FirewallDecision = FirewallDecision.ALLOW
+
+    def __post_init__(self) -> None:
+        if self.version != 1:
+            raise FirewallPolicyError(f"unsupported firewall policy version: {self.version}")
+
+
+@dataclass(frozen=True)
+class FirewallEvaluation:
+    """Result of evaluating a policy for a single agent→agent pair."""
+
+    decision: FirewallDecision
+    matched_rule: FirewallRule | None
+    effective_decision: FirewallDecision
+    """`decision` after applying enforcement_mode (DRY_RUN converts DENY → WARN)."""
+
+
+def _matches(pattern: str, value: str, value_roles: frozenset[str]) -> bool:
+    """Return True if `pattern` matches `value` directly or via role tag."""
+
+    if pattern.startswith(_ROLE_PREFIX):
+        role = pattern[len(_ROLE_PREFIX) :]
+        if not role:
+            return False
+        for actual_role in value_roles:
+            if fnmatch.fnmatchcase(actual_role, role):
+                return True
+        return False
+    return fnmatch.fnmatchcase(value, pattern)
+
+
+def _rule_specificity(rule: FirewallRule) -> int:
+    """Higher = more specific. Concrete names beat role tags beat wildcards."""
+
+    score = 0
+    for side in (rule.source, rule.target):
+        if "*" in side:
+            score += 0
+        elif side.startswith(_ROLE_PREFIX):
+            score += 1
+        else:
+            score += 2
+    return score
+
+
+def evaluate(
+    policy: AgentFirewallPolicy,
+    *,
+    source_agent: str,
+    target_agent: str,
+    source_roles: frozenset[str] | set[str] = frozenset(),
+    target_roles: frozenset[str] | set[str] = frozenset(),
+) -> FirewallEvaluation:
+    """Evaluate the policy for a source → target pair.
+
+    Precedence: most-specific matching rule wins. Within the same specificity,
+    DENY beats WARN beats ALLOW (conservative default).
+    """
+
+    source_roles_fs = frozenset(source_roles)
+    target_roles_fs = frozenset(target_roles)
+
+    candidates: list[FirewallRule] = []
+    for rule in policy.rules:
+        if _matches(rule.source, source_agent, source_roles_fs) and _matches(rule.target, target_agent, target_roles_fs):
+            candidates.append(rule)
+
+    if not candidates:
+        return FirewallEvaluation(
+            decision=policy.default_decision,
+            matched_rule=None,
+            effective_decision=_apply_enforcement_mode(policy.default_decision, policy.enforcement_mode),
+        )
+
+    candidates.sort(
+        key=lambda rule: (
+            -_rule_specificity(rule),
+            0 if rule.decision == FirewallDecision.DENY else (1 if rule.decision == FirewallDecision.WARN else 2),
+        )
+    )
+    winner = candidates[0]
+    return FirewallEvaluation(
+        decision=winner.decision,
+        matched_rule=winner,
+        effective_decision=_apply_enforcement_mode(winner.decision, policy.enforcement_mode),
+    )
+
+
+def _apply_enforcement_mode(decision: FirewallDecision, mode: FirewallEnforcementMode) -> FirewallDecision:
+    if mode == FirewallEnforcementMode.DRY_RUN and decision == FirewallDecision.DENY:
+        return FirewallDecision.WARN
+    return decision
+
+
+def parse_firewall_policy(payload: dict) -> AgentFirewallPolicy:
+    """Parse a JSON-decoded payload into a policy. Raises FirewallPolicyError on issues."""
+
+    if not isinstance(payload, dict):
+        raise FirewallPolicyError("firewall policy must be a JSON object")
+
+    version = payload.get("version", 1)
+    if not isinstance(version, int):
+        raise FirewallPolicyError("firewall policy 'version' must be an integer")
+
+    tenant_id = payload.get("tenant_id")
+    if tenant_id is not None and not isinstance(tenant_id, str):
+        raise FirewallPolicyError("firewall policy 'tenant_id' must be a string when set")
+
+    mode_raw = payload.get("enforcement_mode", "enforce")
+    if not isinstance(mode_raw, str):
+        raise FirewallPolicyError("firewall policy 'enforcement_mode' must be a string")
+    try:
+        mode = FirewallEnforcementMode(mode_raw)
+    except ValueError as exc:
+        raise FirewallPolicyError(f"unknown enforcement_mode: {mode_raw!r}") from exc
+
+    default_raw = payload.get("default_decision", "allow")
+    if not isinstance(default_raw, str):
+        raise FirewallPolicyError("firewall policy 'default_decision' must be a string")
+    try:
+        default_decision = FirewallDecision(default_raw)
+    except ValueError as exc:
+        raise FirewallPolicyError(f"unknown default_decision: {default_raw!r}") from exc
+
+    raw_rules = payload.get("rules", [])
+    if not isinstance(raw_rules, list):
+        raise FirewallPolicyError("firewall policy 'rules' must be a list")
+
+    rules: list[FirewallRule] = []
+    for index, raw in enumerate(raw_rules):
+        if not isinstance(raw, dict):
+            raise FirewallPolicyError(f"rule[{index}] must be an object")
+        source = raw.get("source")
+        target = raw.get("target")
+        decision_raw = raw.get("decision")
+        if not isinstance(source, str) or not isinstance(target, str):
+            raise FirewallPolicyError(f"rule[{index}] missing 'source' / 'target' string")
+        if not isinstance(decision_raw, str):
+            raise FirewallPolicyError(f"rule[{index}] missing 'decision' string")
+        try:
+            decision = FirewallDecision(decision_raw)
+        except ValueError as exc:
+            raise FirewallPolicyError(f"rule[{index}] has unknown decision: {decision_raw!r}") from exc
+        description = raw.get("description", "")
+        if not isinstance(description, str):
+            raise FirewallPolicyError(f"rule[{index}] 'description' must be a string when set")
+        rules.append(FirewallRule(source=source, target=target, decision=decision, description=description))
+
+    return AgentFirewallPolicy(
+        version=version,
+        tenant_id=tenant_id,
+        enforcement_mode=mode,
+        rules=tuple(rules),
+        default_decision=default_decision,
+    )
+
+
+def load_firewall_policy_file(path: Path) -> AgentFirewallPolicy:
+    """Load a firewall policy from a JSON file."""
+
+    try:
+        payload = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise FirewallPolicyError(f"firewall policy {path} is not valid JSON: {exc.msg}") from exc
+    return parse_firewall_policy(payload)

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -1,0 +1,224 @@
+"""Tests for the inter-agent firewall foundation (#982 PR 1)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_bom.firewall import (
+    AgentFirewallPolicy,
+    FirewallDecision,
+    FirewallEnforcementMode,
+    FirewallPolicyError,
+    FirewallRule,
+    evaluate,
+    load_firewall_policy_file,
+    parse_firewall_policy,
+)
+
+
+def test_empty_policy_default_allow():
+    policy = AgentFirewallPolicy()
+    result = evaluate(policy, source_agent="cursor", target_agent="claude-desktop")
+    assert result.decision == FirewallDecision.ALLOW
+    assert result.matched_rule is None
+
+
+def test_pairwise_deny_wins():
+    policy = AgentFirewallPolicy(rules=(FirewallRule(source="cursor", target="claude-desktop", decision=FirewallDecision.DENY),))
+    result = evaluate(policy, source_agent="cursor", target_agent="claude-desktop")
+    assert result.decision == FirewallDecision.DENY
+    assert result.matched_rule is not None
+
+
+def test_role_tag_match():
+    policy = AgentFirewallPolicy(rules=(FirewallRule(source="role:trusted", target="role:data-plane", decision=FirewallDecision.DENY),))
+    result = evaluate(
+        policy,
+        source_agent="cursor",
+        target_agent="snowflake-cli",
+        source_roles={"trusted"},
+        target_roles={"data-plane"},
+    )
+    assert result.decision == FirewallDecision.DENY
+
+
+def test_specific_rule_beats_role_rule():
+    policy = AgentFirewallPolicy(
+        rules=(
+            FirewallRule(source="role:trusted", target="role:data-plane", decision=FirewallDecision.DENY),
+            FirewallRule(source="cursor", target="snowflake-cli", decision=FirewallDecision.ALLOW),
+        )
+    )
+    result = evaluate(
+        policy,
+        source_agent="cursor",
+        target_agent="snowflake-cli",
+        source_roles={"trusted"},
+        target_roles={"data-plane"},
+    )
+    assert result.decision == FirewallDecision.ALLOW
+    assert result.matched_rule is not None
+    assert result.matched_rule.source == "cursor"
+
+
+def test_deny_beats_allow_at_same_specificity():
+    policy = AgentFirewallPolicy(
+        rules=(
+            FirewallRule(source="cursor", target="claude-desktop", decision=FirewallDecision.ALLOW),
+            FirewallRule(source="cursor", target="claude-desktop", decision=FirewallDecision.DENY),
+        )
+    )
+    result = evaluate(policy, source_agent="cursor", target_agent="claude-desktop")
+    assert result.decision == FirewallDecision.DENY
+
+
+def test_warn_only_decision_returns_warn():
+    policy = AgentFirewallPolicy(rules=(FirewallRule(source="cursor", target="claude-desktop", decision=FirewallDecision.WARN),))
+    result = evaluate(policy, source_agent="cursor", target_agent="claude-desktop")
+    assert result.decision == FirewallDecision.WARN
+    assert result.effective_decision == FirewallDecision.WARN
+
+
+def test_dry_run_mode_converts_deny_to_warn():
+    policy = AgentFirewallPolicy(
+        enforcement_mode=FirewallEnforcementMode.DRY_RUN,
+        rules=(FirewallRule(source="cursor", target="claude-desktop", decision=FirewallDecision.DENY),),
+    )
+    result = evaluate(policy, source_agent="cursor", target_agent="claude-desktop")
+    assert result.decision == FirewallDecision.DENY
+    assert result.effective_decision == FirewallDecision.WARN
+
+
+def test_dry_run_mode_keeps_allow_and_warn_unchanged():
+    policy = AgentFirewallPolicy(
+        enforcement_mode=FirewallEnforcementMode.DRY_RUN,
+        rules=(
+            FirewallRule(source="a", target="b", decision=FirewallDecision.WARN),
+            FirewallRule(source="c", target="d", decision=FirewallDecision.ALLOW),
+        ),
+    )
+    warn_result = evaluate(policy, source_agent="a", target_agent="b")
+    allow_result = evaluate(policy, source_agent="c", target_agent="d")
+    assert warn_result.effective_decision == FirewallDecision.WARN
+    assert allow_result.effective_decision == FirewallDecision.ALLOW
+
+
+def test_wildcard_pattern_matches():
+    policy = AgentFirewallPolicy(rules=(FirewallRule(source="*", target="snowflake-*", decision=FirewallDecision.DENY),))
+    result = evaluate(policy, source_agent="cursor", target_agent="snowflake-cli")
+    assert result.decision == FirewallDecision.DENY
+
+
+def test_default_decision_deny():
+    policy = AgentFirewallPolicy(default_decision=FirewallDecision.DENY)
+    result = evaluate(policy, source_agent="cursor", target_agent="claude-desktop")
+    assert result.decision == FirewallDecision.DENY
+    assert result.matched_rule is None
+
+
+def test_role_pattern_with_wildcard():
+    policy = AgentFirewallPolicy(rules=(FirewallRule(source="role:trusted-*", target="*", decision=FirewallDecision.ALLOW),))
+    result = evaluate(
+        policy,
+        source_agent="cursor",
+        target_agent="claude-desktop",
+        source_roles={"trusted-orchestrator"},
+    )
+    assert result.decision == FirewallDecision.ALLOW
+
+
+def test_parse_minimal_policy():
+    policy = parse_firewall_policy({"rules": []})
+    assert policy.version == 1
+    assert policy.default_decision == FirewallDecision.ALLOW
+    assert policy.enforcement_mode == FirewallEnforcementMode.ENFORCE
+    assert policy.rules == ()
+
+
+def test_parse_full_policy():
+    payload = {
+        "version": 1,
+        "tenant_id": "acme",
+        "enforcement_mode": "dry_run",
+        "default_decision": "deny",
+        "rules": [
+            {
+                "source": "cursor",
+                "target": "snowflake-cli",
+                "decision": "allow",
+                "description": "Cursor may delegate to Snowflake CLI",
+            },
+            {"source": "role:untrusted", "target": "*", "decision": "deny"},
+        ],
+    }
+    policy = parse_firewall_policy(payload)
+    assert policy.tenant_id == "acme"
+    assert policy.enforcement_mode == FirewallEnforcementMode.DRY_RUN
+    assert policy.default_decision == FirewallDecision.DENY
+    assert len(policy.rules) == 2
+    assert policy.rules[0].description == "Cursor may delegate to Snowflake CLI"
+
+
+def test_parse_unknown_decision_raises():
+    with pytest.raises(FirewallPolicyError, match="unknown decision"):
+        parse_firewall_policy({"rules": [{"source": "a", "target": "b", "decision": "yikes"}]})
+
+
+def test_parse_missing_source_raises():
+    with pytest.raises(FirewallPolicyError, match="missing 'source'"):
+        parse_firewall_policy({"rules": [{"target": "b", "decision": "deny"}]})
+
+
+def test_parse_unknown_enforcement_mode_raises():
+    with pytest.raises(FirewallPolicyError, match="unknown enforcement_mode"):
+        parse_firewall_policy({"enforcement_mode": "audit-only", "rules": []})
+
+
+def test_parse_unsupported_version_raises():
+    with pytest.raises(FirewallPolicyError, match="unsupported firewall policy version"):
+        parse_firewall_policy({"version": 2, "rules": []})
+
+
+def test_parse_non_dict_raises():
+    with pytest.raises(FirewallPolicyError, match="must be a JSON object"):
+        parse_firewall_policy([])  # type: ignore[arg-type]
+
+
+def test_load_file_round_trip(tmp_path: Path):
+    payload = {
+        "version": 1,
+        "rules": [{"source": "*", "target": "snowflake-*", "decision": "warn"}],
+    }
+    policy_path = tmp_path / "firewall.json"
+    policy_path.write_text(json.dumps(payload))
+    policy = load_firewall_policy_file(policy_path)
+    assert len(policy.rules) == 1
+    assert policy.rules[0].decision == FirewallDecision.WARN
+
+
+def test_load_invalid_json_raises(tmp_path: Path):
+    policy_path = tmp_path / "firewall.json"
+    policy_path.write_text("{not json")
+    with pytest.raises(FirewallPolicyError, match="not valid JSON"):
+        load_firewall_policy_file(policy_path)
+
+
+def test_empty_source_raises():
+    with pytest.raises(FirewallPolicyError, match="non-empty"):
+        FirewallRule(source="", target="b", decision=FirewallDecision.DENY)
+
+
+def test_role_only_prefix_does_not_match():
+    """`role:` (empty role) should not blanket-match anything."""
+
+    policy = AgentFirewallPolicy(rules=(FirewallRule(source="role:", target="*", decision=FirewallDecision.DENY),))
+    result = evaluate(
+        policy,
+        source_agent="cursor",
+        target_agent="claude-desktop",
+        source_roles={"trusted"},
+    )
+    assert result.decision == FirewallDecision.ALLOW


### PR DESCRIPTION
First of four PRs for #982. Foundation only — schema + loader + evaluator + CLI + tests + docs. **Zero behaviour change at the runtime plane.**

## Why this is split

The firewall is a meaningful product surface (tenant-scoped policy engine + proxy + gateway + audit + UI). Landing it as one PR would be a multi-thousand-line drop. The four-PR plan was explicitly signed off:

1. **Foundation (this PR)** — schema, loader, evaluator, CLI, tests.
2. Gateway evaluator + audit emission.
3. Proxy detector chain fast-path.
4. Runtime-tab dashboard overlay.

Capability-keyed rules (`agent_a may invoke tool X via agent_b`) are deliberately deferred to a v2.

## Schema (`src/agent_bom/firewall.py`)
- `AgentFirewallPolicy` — versioned, tenant-scoped, hot-reload-friendly. `version: 1` strict.
- `FirewallRule` — pairwise (`cursor → snowflake-cli`) or role-tagged (`role:trusted → role:data-plane`); `fnmatch` wildcards.
- `FirewallDecision` — `allow | deny | warn`. `warn` audits without blocking, matching the rest of the platform's "audit before enforce" pattern.
- `FirewallEnforcementMode` — `enforce | dry_run`. In dry-run every `deny` is downgraded to `warn` so operators can preview a policy before flipping it.
- `evaluate(...)` — most-specific rule wins; DENY beats WARN beats ALLOW at the same specificity. Returns both the matched decision and the effective decision after applying enforcement mode.

## CLI

```
agent-bom firewall validate ./firewall.json
agent-bom firewall list ./firewall.json [--json]
agent-bom firewall check ./firewall.json cursor snowflake-cli \
    --source-role trusted-orchestrator
```

## Tests

22 cases in `tests/test_firewall.py`: pairwise + role-tag matching, specificity precedence, deny-beats-allow tie-break, wildcard patterns, default-decision fallback, dry-run downgrade, schema validation errors, file loader round-trip, empty-role-prefix safety.

## Docs

`docs/AGENT_FIREWALL.md` documents the schema, precedence rules, dry-run semantics, CLI surface, and the 4-PR roadmap.

## Validation
- `pytest tests/test_firewall.py -q` → **22 passed**
- `ruff check` clean
- `mypy src/agent_bom/firewall.py` clean
- end-to-end CLI smoke (validate / list / check) verified locally

## What is NOT in this PR
- gateway never loads or consults the policy (PR 2)
- proxy never consults the policy (PR 3)
- no dashboard surface (PR 4)
- no `/v1/proxy/audit` decision emission (PR 2)

That isolation is intentional — operators can begin authoring policies immediately while PRs 2-4 land enforcement.