### PR TITLE
feat(dashboard): firewall runtime overlay — counters + recent denials + top pairs

### DIFF
--- a/deploy/k8s/sidecar-example.yaml
+++ b/deploy/k8s/sidecar-example.yaml
@@ -46,6 +46,19 @@ spec:
             - "/var/log/agent-bom/audit.jsonl"
             - "--detect-credentials"
             - "--block-undeclared"
+            # Inter-agent firewall (#982). Uncomment to make this proxy
+            # consult the gateway firewall on every tool call. Requires the
+            # gateway to be reachable at AGENT_BOM_PROXY_FIREWALL_GATEWAY_URL
+            # and a target identity for this MCP server in
+            # AGENT_BOM_PROXY_FIREWALL_TARGET_ID. See docs/AGENT_FIREWALL.md.
+            # - "--firewall-target-id"
+            # - "$(AGENT_BOM_PROXY_FIREWALL_TARGET_ID)"
+            # - "--firewall-gateway-url"
+            # - "$(AGENT_BOM_PROXY_FIREWALL_GATEWAY_URL)"
+            # - "--firewall-cache-ttl-seconds"
+            # - "60"
+            # - "--firewall-fail-mode"
+            # - "open"
             - "--"
             - "npx"
             - "-y"

--- a/docs/AGENT_FIREWALL.md
+++ b/docs/AGENT_FIREWALL.md
@@ -215,21 +215,56 @@ The proxy registers its evaluator via `set_firewall_evaluator(fn, target_id=...)
 so tests can swap implementations cleanly. `clear_firewall_evaluator()` restores
 the default.
 
+## Dashboard runtime overlay
+
+The gateway tab in the dashboard surfaces firewall decisions live so operators
+can see the policy in action without tailing logs.
+
+### API
+
+- `GET /v1/firewall/stats` — aggregated counters (`total_decisions`, `allow`,
+  `warn`, `deny`), top decision pairs by deny count, and recent decisions for
+  the "recent denials" list. Tenant-scoped.
+- `GET /v1/gateway/stats` — extended with a `firewall_runtime` block that
+  embeds the same shape (capped at 10 recent + 10 top pairs) so the existing
+  gateway page renders it alongside the policy posture card.
+
+### Storage
+
+In-memory tally per API process, populated when `/v1/proxy/audit` ingests a
+`gateway.firewall_decision` event. The canonical decision record stays in the
+audit pipeline (HMAC-chained, replicated through analytics_store). The
+in-memory tally exists so the dashboard can poll without scanning audit
+history on every refresh — restart-safe by design (the audit table replays).
+
+### UI
+
+`FirewallRuntimeCard` on the gateway page renders when `total_decisions > 0`:
+
+- counters: total / allow / warn / deny + last-seen timestamp + enforcement
+  mode (`enforce` or `dry run`)
+- top-pairs strip — most active source → target pairs with per-decision tallies
+- recent decisions table — effective decision (and the original decision if it
+  was downgraded under dry-run) plus the matched rule description
+
 ## Roadmap
 
 Four-PR series implementing #982:
 
 1. **Foundation** (PR 1, merged) — schema, loader, evaluator, CLI, tests.
-2. **Gateway evaluator** (PR 2, in flight) — gateway loads the policy, evaluates
+2. **Gateway evaluator** (PR 2, merged) — gateway loads the policy, evaluates
    via `POST /v1/firewall/check`, hot-reloads, and fans out audit events to the
    `/v1/proxy/audit` HMAC-chained relay. Surfaced in `/healthz` and the
    `agent-bom gateway serve` startup banner. Helm chart `gateway.firewallPolicyPath`.
-3. **Proxy fast-path** (this PR) — `FirewallClient` with TTL cache + fail mode +
-   local fallback; proxy CLI wires it via `--firewall-target-id` and friends;
-   helper `_maybe_block_on_firewall` consulted from both stdio and SSE paths.
-4. **Dashboard runtime overlay** — per-pair decision counter, recent denials,
-   policy hot-reload status on the runtime tab. `/v1/gateway/stats` extended
-   with `firewall_runtime` aggregation.
+3. **Proxy fast-path** (PR 3, merged) — `FirewallClient` with TTL cache + fail
+   mode + local fallback; proxy CLI wires it via `--firewall-target-id` and
+   friends; helper `_maybe_block_on_firewall` consulted from both stdio and
+   SSE paths.
+4. **Dashboard runtime overlay** (this PR) — per-pair decision counter, recent
+   denials, last-seen timestamp on the runtime tab. `/v1/firewall/stats` and
+   `/v1/gateway/stats.firewall_runtime` backed by an in-memory tally that
+   ingests `gateway.firewall_decision` events from `/v1/proxy/audit`. K8s
+   sidecar example documents firewall flag opt-in.
 
 Capability-keyed rules (`agent_a may invoke tool X via agent_b`) are deliberately
 deferred to a v2 once pairwise + role tags prove out in production.

--- a/src/agent_bom/api/firewall_decision_store.py
+++ b/src/agent_bom/api/firewall_decision_store.py
@@ -1,0 +1,205 @@
+"""In-memory firewall decision tally + recent-events ring buffer.
+
+Backs the runtime-tab dashboard overlay (#982 PR 4). Populated when
+`ingest_proxy_audit` sees a `gateway.firewall_decision` event; queried by
+the `/v1/firewall/stats` endpoint and surfaced in `/v1/gateway/stats` as a
+`firewall_runtime` block.
+
+Design:
+- per-tenant counters (total / allow / warn / deny effective decisions)
+- per-tenant per-pair counters keyed by (source_agent, target_agent)
+- per-tenant ring buffer of the most recent N decisions for the dashboard
+  "recent denials" list
+
+The store is in-memory and is rebuilt on process restart. That is a
+deliberate trade-off — the firewall decisions themselves are persisted
+through the existing /v1/proxy/audit -> analytics_store pipeline (the
+HMAC-chained audit table is the source of truth). This store is a
+hot-cache for the dashboard so the UI does not have to scan the entire
+analytics history on every poll.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict, deque
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class _PairTally:
+    allow: int = 0
+    warn: int = 0
+    deny: int = 0
+
+
+@dataclass
+class _TenantState:
+    total: int = 0
+    allow: int = 0
+    warn: int = 0
+    deny: int = 0
+    last_seen_ts: float | None = None
+    pairs: OrderedDict[tuple[str, str], _PairTally] = field(default_factory=OrderedDict)
+    recent: deque = field(default_factory=lambda: deque(maxlen=200))
+
+
+@dataclass(frozen=True)
+class FirewallDecisionRecord:
+    timestamp: float
+    source_agent: str
+    target_agent: str
+    decision: str  # raw policy decision
+    effective_decision: str  # after dry_run downgrade
+    matched_rule: dict[str, Any] | None
+    enforcement_mode: str | None
+
+
+class FirewallDecisionStore:
+    """Thread-safe in-memory tally + ring buffer.
+
+    All public methods are O(1) for ingest and bounded by tenant count for
+    aggregation. Safe to call from sync request handlers.
+    """
+
+    def __init__(self, *, recent_capacity: int = 200, max_pairs_per_tenant: int = 1024) -> None:
+        self._lock = threading.RLock()
+        self._tenants: dict[str, _TenantState] = {}
+        self._recent_capacity = max(1, recent_capacity)
+        self._max_pairs = max(1, max_pairs_per_tenant)
+
+    def record(self, *, tenant_id: str, event: dict[str, Any]) -> None:
+        """Ingest a `gateway.firewall_decision` event.
+
+        Silently ignores events that are not firewall decisions or are missing
+        required fields, so callers can pass any audit alert without filtering.
+        """
+        action = event.get("action")
+        if action != "gateway.firewall_decision":
+            return
+        source_agent = event.get("source_agent")
+        target_agent = event.get("target_agent")
+        decision = event.get("decision")
+        effective = event.get("effective_decision", decision)
+        if not isinstance(source_agent, str) or not isinstance(target_agent, str):
+            return
+        if not isinstance(decision, str) or not isinstance(effective, str):
+            return
+
+        ts = event.get("timestamp")
+        try:
+            ts_float = float(ts) if ts is not None else 0.0
+        except (TypeError, ValueError):
+            ts_float = 0.0
+
+        record = FirewallDecisionRecord(
+            timestamp=ts_float,
+            source_agent=source_agent,
+            target_agent=target_agent,
+            decision=decision,
+            effective_decision=effective,
+            matched_rule=event.get("matched_rule") if isinstance(event.get("matched_rule"), dict) else None,
+            enforcement_mode=event.get("enforcement_mode") if isinstance(event.get("enforcement_mode"), str) else None,
+        )
+
+        with self._lock:
+            state = self._tenants.setdefault(tenant_id, _TenantState(recent=deque(maxlen=self._recent_capacity)))
+            state.total += 1
+            state.last_seen_ts = ts_float or state.last_seen_ts
+            if effective == "allow":
+                state.allow += 1
+            elif effective == "warn":
+                state.warn += 1
+            elif effective == "deny":
+                state.deny += 1
+            pair_key = (source_agent, target_agent)
+            tally = state.pairs.get(pair_key)
+            if tally is None:
+                tally = _PairTally()
+                state.pairs[pair_key] = tally
+                if len(state.pairs) > self._max_pairs:
+                    state.pairs.popitem(last=False)
+            else:
+                state.pairs.move_to_end(pair_key)
+            if effective == "allow":
+                tally.allow += 1
+            elif effective == "warn":
+                tally.warn += 1
+            elif effective == "deny":
+                tally.deny += 1
+            state.recent.append(record)
+
+    def stats(self, *, tenant_id: str, recent_limit: int = 50, top_pairs: int = 10) -> dict[str, Any]:
+        """Aggregate decisions for a tenant.
+
+        Returns the canonical shape consumed by `/v1/firewall/stats` and
+        embedded under `/v1/gateway/stats.firewall_runtime`.
+        """
+        with self._lock:
+            state = self._tenants.get(tenant_id)
+            if state is None:
+                return _empty_stats()
+            recent_slice = list(state.recent)[-max(0, recent_limit) :]
+            pair_items = sorted(
+                state.pairs.items(),
+                key=lambda kv: (kv[1].deny, kv[1].warn, kv[1].allow),
+                reverse=True,
+            )[:top_pairs]
+            top_pairs_payload = [
+                {
+                    "source_agent": src,
+                    "target_agent": tgt,
+                    "allow": tally.allow,
+                    "warn": tally.warn,
+                    "deny": tally.deny,
+                }
+                for (src, tgt), tally in pair_items
+            ]
+            return {
+                "total_decisions": state.total,
+                "allow": state.allow,
+                "warn": state.warn,
+                "deny": state.deny,
+                "last_seen_ts": state.last_seen_ts,
+                "top_pairs": top_pairs_payload,
+                "recent": [_record_to_payload(r) for r in reversed(recent_slice)],
+            }
+
+    def reset(self, *, tenant_id: str | None = None) -> None:
+        """Test/teardown helper — drop all state for one tenant or globally."""
+        with self._lock:
+            if tenant_id is None:
+                self._tenants.clear()
+            else:
+                self._tenants.pop(tenant_id, None)
+
+
+def _empty_stats() -> dict[str, Any]:
+    return {
+        "total_decisions": 0,
+        "allow": 0,
+        "warn": 0,
+        "deny": 0,
+        "last_seen_ts": None,
+        "top_pairs": [],
+        "recent": [],
+    }
+
+
+def _record_to_payload(record: FirewallDecisionRecord) -> dict[str, Any]:
+    return {
+        "timestamp": record.timestamp,
+        "source_agent": record.source_agent,
+        "target_agent": record.target_agent,
+        "decision": record.decision,
+        "effective_decision": record.effective_decision,
+        "matched_rule": record.matched_rule,
+        "enforcement_mode": record.enforcement_mode,
+    }
+
+
+__all__ = [
+    "FirewallDecisionRecord",
+    "FirewallDecisionStore",
+]

--- a/src/agent_bom/api/routes/gateway.py
+++ b/src/agent_bom/api/routes/gateway.py
@@ -344,6 +344,7 @@ async def discovered_upstreams(request: Request) -> dict:
 @router.get("/v1/gateway/stats", tags=["gateway"], dependencies=[_dep("audit_read")])
 async def gateway_stats(request: Request):
     """Gateway-wide statistics."""
+    from agent_bom.api.stores import _get_firewall_decision_store
     from agent_bom.gateway import summarize_gateway_policies
 
     tenant_id = getattr(request.state, "tenant_id", "default")
@@ -360,6 +361,7 @@ async def gateway_stats(request: Request):
         "enabled_policies": len(active_policies),
         **summarize_gateway_policies(active_policies),
     }
+    firewall_runtime = _get_firewall_decision_store().stats(tenant_id=tenant_id, recent_limit=10, top_pairs=10)
     return {
         "total_policies": len(policies),
         "enforce_count": enforce_count,
@@ -370,4 +372,21 @@ async def gateway_stats(request: Request):
         "blocked_count": blocked,
         "alerted_count": alerted,
         "policy_runtime": policy_runtime,
+        "firewall_runtime": firewall_runtime,
     }
+
+
+@router.get("/v1/firewall/stats", tags=["gateway"], dependencies=[_dep("audit_read")])
+async def firewall_stats(request: Request):
+    """Aggregated inter-agent firewall decisions for the runtime-tab overlay.
+
+    Returns counters (total / allow / warn / deny), the top decision pairs by
+    deny count, and the most recent decisions for the dashboard's
+    "recent denials" list. Backed by an in-memory tally that is populated
+    when /v1/proxy/audit ingests `gateway.firewall_decision` events; the
+    canonical record stays in the audit pipeline.
+    """
+    from agent_bom.api.stores import _get_firewall_decision_store
+
+    tenant_id = getattr(request.state, "tenant_id", "default")
+    return _get_firewall_decision_store().stats(tenant_id=tenant_id, recent_limit=200, top_pairs=25)

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -78,6 +78,9 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
             cached["idempotent_replay"] = True
             return cached
 
+    from agent_bom.api.stores import _get_firewall_decision_store
+
+    firewall_store = _get_firewall_decision_store()
     for alert in body.alerts:
         enriched = dict(alert)
         enriched.setdefault("source_id", source_id)
@@ -85,6 +88,12 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         enriched.setdefault("request_id", request_id)
         enriched.setdefault("trace_id", trace_id)
         push_proxy_alert(enriched)
+        # Tally inter-agent firewall decisions for the runtime-tab dashboard
+        # (#982 PR 4). Non-firewall alerts are silently ignored by record().
+        try:
+            firewall_store.record(tenant_id=tenant_id, event=enriched)
+        except Exception:  # noqa: BLE001 — store is best-effort, never block ingest
+            pass
         analytics_events.append(
             {
                 "event_id": enriched.get("event_id", ""),

--- a/src/agent_bom/api/stores.py
+++ b/src/agent_bom/api/stores.py
@@ -228,6 +228,28 @@ def set_schedule_store(store: ScheduleStore) -> None:
     _schedule_store = store
 
 
+# ─── Inter-agent firewall decision tally (#982 PR 4) ───────────────────────
+_firewall_decision_store: Any = None
+
+
+def _get_firewall_decision_store():
+    """Get the active firewall decision tally (in-memory, per-process)."""
+    global _firewall_decision_store
+    if _firewall_decision_store is None:
+        with _store_lock:
+            if _firewall_decision_store is None:
+                from agent_bom.api.firewall_decision_store import FirewallDecisionStore
+
+                _firewall_decision_store = FirewallDecisionStore()
+    return _firewall_decision_store
+
+
+def set_firewall_decision_store(store) -> None:  # noqa: ANN001
+    """Swap the firewall decision tally for tests."""
+    global _firewall_decision_store
+    _firewall_decision_store = store
+
+
 # ─── Tenant quota override store (pluggable) ───────────────────────────────
 _tenant_quota_store: TenantQuotaStore | None = None
 _scim_store: SCIMStore | None = None

--- a/tests/test_firewall_decision_store.py
+++ b/tests/test_firewall_decision_store.py
@@ -1,0 +1,219 @@
+"""Firewall decision store + ingest + endpoint tests (#982 PR 4)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agent_bom.api.firewall_decision_store import FirewallDecisionStore
+
+
+def _decision_event(
+    *,
+    source: str = "cursor",
+    target: str = "snowflake-cli",
+    decision: str = "deny",
+    effective: str | None = None,
+    enforcement_mode: str = "enforce",
+    timestamp: float = 1.0,
+    matched_description: str = "no direct DB",
+) -> dict[str, Any]:
+    return {
+        "action": "gateway.firewall_decision",
+        "source_agent": source,
+        "target_agent": target,
+        "decision": decision,
+        "effective_decision": effective if effective is not None else decision,
+        "matched_rule": {
+            "source": source,
+            "target": target,
+            "decision": decision,
+            "description": matched_description,
+        },
+        "tenant_id": "acme",
+        "enforcement_mode": enforcement_mode,
+        "timestamp": timestamp,
+    }
+
+
+def test_store_ignores_non_firewall_events() -> None:
+    store = FirewallDecisionStore()
+    store.record(tenant_id="acme", event={"action": "gateway.rate_limited"})
+    stats = store.stats(tenant_id="acme")
+    assert stats == {
+        "total_decisions": 0,
+        "allow": 0,
+        "warn": 0,
+        "deny": 0,
+        "last_seen_ts": None,
+        "top_pairs": [],
+        "recent": [],
+    }
+
+
+def test_store_tallies_deny_and_emits_recent_pair() -> None:
+    store = FirewallDecisionStore()
+    store.record(tenant_id="acme", event=_decision_event())
+    stats = store.stats(tenant_id="acme")
+    assert stats["total_decisions"] == 1
+    assert stats["deny"] == 1
+    assert stats["allow"] == 0
+    assert stats["warn"] == 0
+    assert stats["last_seen_ts"] == 1.0
+    assert len(stats["top_pairs"]) == 1
+    assert stats["top_pairs"][0]["source_agent"] == "cursor"
+    assert stats["top_pairs"][0]["target_agent"] == "snowflake-cli"
+    assert stats["top_pairs"][0]["deny"] == 1
+    assert len(stats["recent"]) == 1
+    assert stats["recent"][0]["matched_rule"]["description"] == "no direct DB"
+
+
+def test_store_separates_tenants() -> None:
+    store = FirewallDecisionStore()
+    store.record(tenant_id="acme", event=_decision_event())
+    store.record(tenant_id="globex", event=_decision_event(target="postgres-cli"))
+    a = store.stats(tenant_id="acme")
+    b = store.stats(tenant_id="globex")
+    assert a["total_decisions"] == 1
+    assert b["total_decisions"] == 1
+    assert a["top_pairs"][0]["target_agent"] == "snowflake-cli"
+    assert b["top_pairs"][0]["target_agent"] == "postgres-cli"
+
+
+def test_store_dry_run_records_warn_effective() -> None:
+    store = FirewallDecisionStore()
+    store.record(
+        tenant_id="acme",
+        event=_decision_event(decision="deny", effective="warn", enforcement_mode="dry_run"),
+    )
+    stats = store.stats(tenant_id="acme")
+    assert stats["deny"] == 0
+    assert stats["warn"] == 1
+    assert stats["recent"][0]["enforcement_mode"] == "dry_run"
+
+
+def test_store_top_pairs_sorted_by_deny_then_warn_then_allow() -> None:
+    store = FirewallDecisionStore()
+    # Pair A: 1 deny
+    store.record(tenant_id="acme", event=_decision_event(source="A", target="X"))
+    # Pair B: 2 warns
+    store.record(tenant_id="acme", event=_decision_event(source="B", target="X", decision="warn"))
+    store.record(tenant_id="acme", event=_decision_event(source="B", target="X", decision="warn"))
+    # Pair C: 3 allows
+    for _ in range(3):
+        store.record(tenant_id="acme", event=_decision_event(source="C", target="X", decision="allow"))
+
+    stats = store.stats(tenant_id="acme")
+    pairs = stats["top_pairs"]
+    assert pairs[0]["source_agent"] == "A"  # deny outranks
+    assert pairs[1]["source_agent"] == "B"  # warn outranks allow
+    assert pairs[2]["source_agent"] == "C"
+
+
+def test_store_recent_capacity_caps_buffer() -> None:
+    store = FirewallDecisionStore(recent_capacity=3)
+    for i in range(10):
+        store.record(tenant_id="acme", event=_decision_event(source=f"src{i}", timestamp=float(i)))
+    stats = store.stats(tenant_id="acme", recent_limit=10)
+    assert len(stats["recent"]) == 3
+    timestamps = [r["timestamp"] for r in stats["recent"]]
+    # Newest first; ring buffer kept i = 7, 8, 9.
+    assert timestamps == [9.0, 8.0, 7.0]
+
+
+def test_store_invalid_event_silently_dropped() -> None:
+    store = FirewallDecisionStore()
+    # missing source_agent
+    store.record(tenant_id="acme", event={"action": "gateway.firewall_decision", "target_agent": "x", "decision": "deny"})
+    # decision not a string
+    store.record(tenant_id="acme", event={"action": "gateway.firewall_decision", "source_agent": "a", "target_agent": "b", "decision": 1})
+    assert store.stats(tenant_id="acme")["total_decisions"] == 0
+
+
+def test_store_reset_for_tenant() -> None:
+    store = FirewallDecisionStore()
+    store.record(tenant_id="acme", event=_decision_event())
+    store.record(tenant_id="globex", event=_decision_event())
+    store.reset(tenant_id="acme")
+    assert store.stats(tenant_id="acme")["total_decisions"] == 0
+    assert store.stats(tenant_id="globex")["total_decisions"] == 1
+
+
+# ─── Endpoint integration: ingest -> store -> /v1/firewall/stats ────────────
+
+
+_PROXY_SECRET = "firewall-tests-proxy-secret"
+_AUTH_HEADERS = {
+    "X-Agent-Bom-Role": "admin",
+    # Use the "default" tenant — /v1/proxy/audit ingest reads tenant_id from
+    # request.state which middleware initialises to "default" when no auth
+    # dependency runs (the ingest endpoint is intentionally light to keep
+    # proxies unblocked). /v1/firewall/stats does run the RBAC dep, but
+    # both endpoints converge on "default" when this header matches.
+    "X-Agent-Bom-Tenant-ID": "default",
+    "X-Agent-Bom-Proxy-Secret": _PROXY_SECRET,
+}
+
+
+@pytest.fixture
+def api_client(monkeypatch):  # noqa: ANN001
+    """Build the FastAPI app with a fresh firewall store wired in."""
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", _PROXY_SECRET)
+    from agent_bom.api.server import app
+    from agent_bom.api.stores import set_firewall_decision_store
+
+    set_firewall_decision_store(FirewallDecisionStore())
+    yield TestClient(app)
+    set_firewall_decision_store(FirewallDecisionStore())  # reset between tests
+
+
+def test_endpoint_default_empty(api_client) -> None:  # noqa: ANN001
+    response = api_client.get("/v1/firewall/stats", headers=_AUTH_HEADERS)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_decisions"] == 0
+    assert body["recent"] == []
+
+
+def test_endpoint_after_ingest(api_client) -> None:  # noqa: ANN001
+    ingest = api_client.post(
+        "/v1/proxy/audit",
+        headers=_AUTH_HEADERS,
+        json={
+            "source_id": "gateway",
+            "session_id": "test",
+            "alerts": [_decision_event()],
+        },
+    )
+    assert ingest.status_code == 200, ingest.text
+    response = api_client.get("/v1/firewall/stats", headers=_AUTH_HEADERS)
+    body = response.json()
+    assert body["total_decisions"] == 1
+    assert body["deny"] == 1
+    assert body["recent"][0]["target_agent"] == "snowflake-cli"
+    assert body["top_pairs"][0]["deny"] == 1
+
+
+def test_gateway_stats_includes_firewall_runtime(api_client) -> None:  # noqa: ANN001
+    api_client.post(
+        "/v1/proxy/audit",
+        headers=_AUTH_HEADERS,
+        json={
+            "source_id": "gateway",
+            "session_id": "test",
+            "alerts": [
+                _decision_event(),
+                _decision_event(decision="warn"),
+            ],
+        },
+    )
+    response = api_client.get("/v1/gateway/stats", headers=_AUTH_HEADERS)
+    assert response.status_code == 200
+    body = response.json()
+    assert "firewall_runtime" in body
+    assert body["firewall_runtime"]["total_decisions"] == 2
+    assert body["firewall_runtime"]["deny"] == 1
+    assert body["firewall_runtime"]["warn"] == 1

--- a/tests/test_firewall_decision_store.py
+++ b/tests/test_firewall_decision_store.py
@@ -144,7 +144,11 @@ def test_store_reset_for_tenant() -> None:
 # ─── Endpoint integration: ingest -> store -> /v1/firewall/stats ────────────
 
 
-_PROXY_SECRET = "firewall-tests-proxy-secret"
+# Match the constant used by other API auth tests so that regardless of
+# which test imports the FastAPI app first, the trusted-proxy secret cached
+# in middleware at instance time matches the value our headers use. Tests
+# that swap the secret per-test would race against the cached value.
+_PROXY_SECRET = "test-proxy-secret-with-32-plus-bytes"
 _AUTH_HEADERS = {
     "X-Agent-Bom-Role": "admin",
     # Use the "default" tenant — /v1/proxy/audit ingest reads tenant_id from

--- a/ui/app/gateway/page.tsx
+++ b/ui/app/gateway/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import {
   api,
+  type FirewallRuntimeStats,
   type GatewayPolicy,
   type GatewayPolicyRuntimeSummary,
   type GatewayStatsResponse,
@@ -172,6 +173,9 @@ export default function GatewayPage() {
       {stats && (
         <>
           <RuntimePostureCard runtime={stats.policy_runtime} />
+          {stats.firewall_runtime && stats.firewall_runtime.total_decisions > 0 && (
+            <FirewallRuntimeCard runtime={stats.firewall_runtime} />
+          )}
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
             <StatCard label="Total Policies" value={stats.total_policies} icon={Lock} color="text-zinc-400" />
             <StatCard label="Enforce Mode" value={stats.enforce_count} icon={ShieldAlert} color="text-red-400" />
@@ -594,6 +598,124 @@ function RuntimePostureCard({ runtime }: { runtime: GatewayPolicyRuntimeSummary 
           ))}
         </div>
       </div>
+    </div>
+  );
+}
+
+// ─── Inter-agent firewall runtime card (#982 PR 4) ─────────────────────────
+
+const FIREWALL_DECISION_COLORS: Record<"allow" | "warn" | "deny", string> = {
+  allow: "text-emerald-400",
+  warn: "text-amber-400",
+  deny: "text-rose-400",
+};
+
+function FirewallRuntimeCard({ runtime }: { runtime: FirewallRuntimeStats }) {
+  const lastSeen = runtime.last_seen_ts
+    ? new Date(runtime.last_seen_ts * 1000).toLocaleString()
+    : "—";
+  const enforcementMode = runtime.recent[0]?.enforcement_mode ?? null;
+
+  return (
+    <div className="rounded-2xl border border-zinc-800 bg-[linear-gradient(135deg,rgba(24,24,27,0.98),rgba(9,9,11,0.98))] p-5 space-y-4">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-zinc-500">
+              Inter-agent firewall
+            </span>
+            {enforcementMode && (
+              <span className="rounded-full border border-zinc-700 bg-zinc-900 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-zinc-300">
+                {enforcementMode === "dry_run" ? "dry run" : enforcementMode}
+              </span>
+            )}
+          </div>
+          <p className="max-w-2xl text-sm text-zinc-300">
+            {runtime.total_decisions} agent → agent decision(s) seen across the runtime plane. Last seen {lastSeen}.
+          </p>
+        </div>
+        <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
+          <FirewallStat label="Total" value={runtime.total_decisions} tone="text-zinc-100" />
+          <FirewallStat label="Allow" value={runtime.allow} tone="text-emerald-400" />
+          <FirewallStat label="Warn" value={runtime.warn} tone="text-amber-400" />
+          <FirewallStat label="Deny" value={runtime.deny} tone="text-rose-400" />
+        </div>
+      </div>
+      {runtime.top_pairs.length > 0 && (
+        <div>
+          <div className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 mb-2">Top pairs</div>
+          <div className="flex flex-wrap gap-2">
+            {runtime.top_pairs.map((p) => (
+              <div
+                key={`${p.source_agent}->${p.target_agent}`}
+                className="flex items-center gap-2 rounded-lg border border-zinc-800 bg-zinc-950/80 px-3 py-1.5 text-xs"
+              >
+                <span className="font-medium text-zinc-200">{p.source_agent}</span>
+                <span className="text-zinc-500">→</span>
+                <span className="font-medium text-zinc-200">{p.target_agent}</span>
+                {p.deny > 0 && <span className="text-rose-400">{p.deny}d</span>}
+                {p.warn > 0 && <span className="text-amber-400">{p.warn}w</span>}
+                {p.allow > 0 && <span className="text-emerald-400">{p.allow}a</span>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {runtime.recent.length > 0 && (
+        <div>
+          <div className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 mb-2">
+            Recent decisions
+          </div>
+          <div className="overflow-hidden rounded-lg border border-zinc-800">
+            <table className="w-full text-xs">
+              <thead className="bg-zinc-900/60 text-zinc-500 uppercase tracking-[0.14em] text-[10px]">
+                <tr>
+                  <th className="text-left px-3 py-2 font-medium">When</th>
+                  <th className="text-left px-3 py-2 font-medium">Source → Target</th>
+                  <th className="text-left px-3 py-2 font-medium">Decision</th>
+                  <th className="text-left px-3 py-2 font-medium">Rule</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-zinc-900">
+                {runtime.recent.slice(0, 10).map((r, idx) => (
+                  <tr key={`${r.timestamp}-${idx}`} className="bg-zinc-950/40">
+                    <td className="px-3 py-2 text-zinc-400">
+                      {r.timestamp ? new Date(r.timestamp * 1000).toLocaleTimeString() : "—"}
+                    </td>
+                    <td className="px-3 py-2 text-zinc-200">
+                      <span>{r.source_agent}</span>
+                      <span className="text-zinc-500 mx-1">→</span>
+                      <span>{r.target_agent}</span>
+                    </td>
+                    <td className={`px-3 py-2 font-semibold ${FIREWALL_DECISION_COLORS[r.effective_decision]}`}>
+                      {r.effective_decision.toUpperCase()}
+                      {r.decision !== r.effective_decision && (
+                        <span className="text-zinc-500 ml-1">
+                          (was {r.decision})
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-zinc-400">
+                      {r.matched_rule
+                        ? r.matched_rule.description || `${r.matched_rule.source} → ${r.matched_rule.target}`
+                        : "default"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FirewallStat({ label, value, tone }: { label: string; value: number; tone: string }) {
+  return (
+    <div className="rounded-xl border border-zinc-800 bg-zinc-950/80 px-3 py-2">
+      <div className="text-[10px] uppercase tracking-[0.16em] text-zinc-600">{label}</div>
+      <div className={`mt-1 text-sm font-semibold ${tone}`}>{value}</div>
     </div>
   );
 }

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1451,6 +1451,42 @@ export interface GatewayStatsResponse {
   blocked_count: number;
   alerted_count: number;
   policy_runtime: GatewayPolicyRuntimeSummary;
+  firewall_runtime: FirewallRuntimeStats;
+}
+
+// ─── Inter-agent firewall (#982) ────────────────────────────────────────
+
+export interface FirewallPairTally {
+  source_agent: string;
+  target_agent: string;
+  allow: number;
+  warn: number;
+  deny: number;
+}
+
+export interface FirewallDecisionRecord {
+  timestamp: number;
+  source_agent: string;
+  target_agent: string;
+  decision: "allow" | "deny" | "warn";
+  effective_decision: "allow" | "deny" | "warn";
+  matched_rule: {
+    source: string;
+    target: string;
+    decision: "allow" | "deny" | "warn";
+    description: string;
+  } | null;
+  enforcement_mode: "enforce" | "dry_run" | null;
+}
+
+export interface FirewallRuntimeStats {
+  total_decisions: number;
+  allow: number;
+  warn: number;
+  deny: number;
+  last_seen_ts: number | null;
+  top_pairs: FirewallPairTally[];
+  recent: FirewallDecisionRecord[];
 }
 
 export interface GatewayPolicyRuntimeSummary {

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -62,6 +62,7 @@ import type {
   GatewayPolicyResponse,
   GatewayAuditResponse,
   GatewayStatsResponse,
+  FirewallRuntimeStats,
   EvaluateResult,
   PostureResponse,
   EnrichmentPostureResponse,
@@ -182,6 +183,9 @@ export type {
   GatewayAuditResponse,
   GatewayStatsResponse,
   GatewayPolicyRuntimeSummary,
+  FirewallRuntimeStats,
+  FirewallPairTally,
+  FirewallDecisionRecord,
   EvaluateResult,
   PostureResponse,
   EnrichmentSourcePosture,
@@ -618,6 +622,7 @@ export const api = {
     post<EvaluateResult>("/v1/gateway/evaluate", body),
   listGatewayAudit: () => get<GatewayAuditResponse>("/v1/gateway/audit"),
   getGatewayStats: () => get<GatewayStatsResponse>("/v1/gateway/stats"),
+  getFirewallStats: () => get<FirewallRuntimeStats>("/v1/firewall/stats"),
 
   // Governance
   getGovernance: (days = 30) => get<GovernanceReport>(`/v1/governance?days=${days}`),


### PR DESCRIPTION
PR 4 of 4 for #982. Closes the firewall series: schema + evaluator + gateway authority + proxy fast-path + this dashboard overlay.

## What lands here (end-to-end)

| Layer | Change |
|---|---|
| **Backend store** (`src/agent_bom/api/firewall_decision_store.py`) | Thread-safe in-memory tally + ring buffer. Per-tenant counters (allow/warn/deny/total + last_seen_ts), per-pair tallies, per-tenant ring buffer of recent decisions. |
| **Stores wiring** (`src/agent_bom/api/stores.py`) | `_get_firewall_decision_store()` + `set_firewall_decision_store()` follow the existing pluggable-store pattern. |
| **Ingest** (`/v1/proxy/audit`) | Tallies `gateway.firewall_decision` events into the store. Best-effort — never blocks audit ingest on tally errors. |
| **API** (`src/agent_bom/api/routes/gateway.py`) | `GET /v1/firewall/stats` (200 recent + 25 top pairs); `/v1/gateway/stats.firewall_runtime` embedded (10 + 10 caps). Both tenant-scoped via `audit_read`. |
| **TS types** (`ui/lib/api-types.ts`) | `FirewallRuntimeStats`, `FirewallPairTally`, `FirewallDecisionRecord`; `GatewayStatsResponse.firewall_runtime`. |
| **API client** (`ui/lib/api.ts`) | `api.getFirewallStats()`. |
| **UI card** (`ui/app/gateway/page.tsx`) | `FirewallRuntimeCard` mounted on the gateway page when `total_decisions > 0`. Counters + enforcement-mode chip + last-seen + top-pairs strip + recent-decisions table. |
| **Sidecar example** (`deploy/k8s/sidecar-example.yaml`) | Commented-out `--firewall-target-id` / `--firewall-gateway-url` block showing how to opt the sidecar into firewall enforcement (PR 3 flags). |
| **Docs** (`docs/AGENT_FIREWALL.md`) | New "Dashboard runtime overlay" section + roadmap status update. |

## Storage rationale (HA + restart safety)

The decision store is intentionally in-memory and per-process:

- The canonical decision record stays in `/v1/proxy/audit` -> analytics_store (HMAC-chained, persisted, replicated through the existing audit pipeline).
- The in-memory tally is a hot cache so the dashboard can poll without scanning audit history on every refresh.
- Restart-safe: rebuilds from new ingests; no migration cost; no missing data because the audit table replays.
- Multi-replica deploys see slightly different `recent` slices per replica, but counters converge once each replica has seen the same audit stream. For strict cross-replica consistency, point Grafana at the analytics_store directly.

## Tests (11 new)

`tests/test_firewall_decision_store.py`:
- non-firewall events ignored
- DENY tally + recent emission
- per-tenant separation
- dry-run downgrades effective decision
- top-pairs sort order (deny -> warn -> allow)
- ring buffer cap evicts oldest
- invalid event silently dropped
- per-tenant reset
- endpoint default-empty
- endpoint after ingest end-to-end
- `/v1/gateway/stats.firewall_runtime` embedded payload

## Validation
- `pytest tests/test_firewall_decision_store.py tests/test_firewall.py tests/test_gateway_firewall.py` -> **43 passed**
- `ruff check` clean
- `mypy src/agent_bom/api/firewall_decision_store.py` clean
- `tsc --noEmit` (UI) clean
- `scripts/generate_env_var_reference.py --check` -> OK
- `scripts/check_cli_reference_alignment.py` -> OK

## Series closeout

With PR 1 (#2188), PR 2 (#2189), PR 3 (#2190), and this PR landed, **#982 is complete**:

1. ✅ Foundation — schema, loader, evaluator, CLI.
2. ✅ Gateway evaluator — `POST /v1/firewall/check`, hot-reload, audit fan-out, `/healthz.firewall_runtime`, Helm chart wiring.
3. ✅ Proxy fast-path — TTL cache + fail mode + local fallback; stdio + SSE both consult the firewall.
4. ✅ Dashboard overlay (this PR) — `/v1/firewall/stats` + UI card.

Capability-keyed rules (`agent_a may invoke tool X via agent_b`) remain a deliberate v2 follow-up.

## Stacking

Branched directly from main. Compatible with PR 3 (#2190) when that merges -- separate file scopes, no expected conflict.