### PR TITLE
feat(discovery): per-run envelope — scan_mode + scope + permissions + redaction

### DIFF
--- a/docs/DISCOVERY_ENVELOPE.md
+++ b/docs/DISCOVERY_ENVELOPE.md
@@ -1,0 +1,97 @@
+# Discovery envelope (`#2083`)
+
+The **discovery envelope** is the per-run trust contract attached to every
+`Agent` that agent-bom discovers. It records *what the scan actually did*
+this run: the scan mode, the explicit scope, the IAM/API permissions
+exercised, and whether sensitive values were redacted or never collected.
+
+This is distinct from `discovery_provenance` (sanitized record of *where the
+asset came from*). Both can coexist on the same `Agent`:
+
+| Field | Purpose |
+|---|---|
+| `discovery_provenance` | "This Agent was pulled from AWS account 12345 via cloud_pull." |
+| `discovery_envelope`   | "This run used cloud_read_only mode, scoped to account/12345 + region/us-east-1, exercised ec2:DescribeInstances + iam:GetRole, redaction_status=central_sanitizer_applied." |
+
+## Schema
+
+```json
+{
+  "envelope_version": 1,
+  "scan_mode": "cloud_read_only",
+  "discovery_scope": [
+    "aws:account/123456789012",
+    "aws:region/us-east-1"
+  ],
+  "permissions_used": [
+    "bedrock-agent:GetAgent",
+    "bedrock-agent:ListAgents",
+    "sts:GetCallerIdentity"
+  ],
+  "redaction_status": "central_sanitizer_applied",
+  "captured_at": "2026-05-02T20:15:00.000+00:00"
+}
+```
+
+### Locked vocabulary
+
+`scan_mode` is a locked enum so the trust contract stays reliable:
+
+| Value | Meaning |
+|---|---|
+| `local_only` | No network egress, no cloud / SaaS read, no runtime probe |
+| `cloud_read_only` | Read-only API calls against a cloud provider (AWS, Azure, GCP, …) |
+| `saas_read_only` | Read-only API calls against a SaaS surface (Snowflake, Databricks, …) |
+| `runtime_probe` | Live MCP server introspection (`tools/list`, `resources/list`, …) |
+| `container_local` | Local container scan — image layers, manifests, no runtime probe |
+| `endpoint_push` | Endpoint-side discovery pushed into the API; pull-only on the server side |
+
+`redaction_status` is also locked:
+
+| Value | Meaning |
+|---|---|
+| `never_collected` | The provider deliberately never read the sensitive value |
+| `redacted_in_place` | The provider redacted the value before returning it |
+| `central_sanitizer_applied` | The shared `agent_bom.security` sanitizer scrubbed the value before storage |
+| `not_applicable` | No sensitive values were in scope this run |
+
+### Versioning
+
+`envelope_version` is strict — only `1` is accepted. New producers can bump
+it, but `DiscoveryEnvelope.from_dict()` will refuse mismatched versions so
+old consumers detect new shapes loudly instead of silently dropping data.
+
+Within a version, unknown enum values fall back to safe defaults
+(`scan_mode = local_only`, `redaction_status = not_applicable`) so a
+forward-compatible producer doesn't crash an older consumer.
+
+## Producers
+
+Cloud providers populate the envelope at the end of `discover()` and attach
+it to every returned `Agent`. AWS is the canonical example wired in the
+foundation PR (#2083 PR A); other providers + connectors follow.
+
+```python
+from agent_bom.discovery_envelope import DiscoveryEnvelope, RedactionStatus, ScanMode
+
+envelope = DiscoveryEnvelope(
+    scan_mode=ScanMode.CLOUD_READ_ONLY,
+    discovery_scope=("aws:account/12345", "aws:region/us-east-1"),
+    permissions_used=("ec2:DescribeInstances", "iam:ListRoles"),
+    redaction_status=RedactionStatus.CENTRAL_SANITIZER_APPLIED,
+)
+agent.discovery_envelope = envelope.to_dict()
+```
+
+The envelope is stored on `Agent.discovery_envelope` as a plain dict so the
+model stays JSON-friendly without dragging the dataclass into the import
+path. Consumers can re-hydrate via `DiscoveryEnvelope.from_dict(...)`.
+
+## Roadmap
+
+- **PR A (this PR)** — schema + Agent model field + AWS producer + tests.
+- PR B — connector + endpoint parity (Snowflake, Databricks, GCP, Azure,
+  vector DBs, MLflow, W&B, …) all populate the envelope.
+- PR C — UI surface on the agent / source detail view; `/v1/agents` and
+  `/v1/discovery/providers` API responses include the envelope.
+- PR D — cross-provider redaction + least-privilege test matrix.

--- a/src/agent_bom/cloud/aws.py
+++ b/src/agent_bom/cloud/aws.py
@@ -21,6 +21,7 @@ from email.parser import Parser as EmailParser
 from pathlib import Path
 from typing import Any
 
+from agent_bom.discovery_envelope import DiscoveryEnvelope, RedactionStatus, ScanMode
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
 from .base import CloudDiscoveryError
@@ -279,7 +280,110 @@ def discover(
         )
         agents.append(ecs_agent)
 
+    # ── Per-run discovery envelope (#2083) ────────────────────────────────
+    # Capture the trust contract for THIS run: the modes / scope / IAM
+    # permissions actually exercised, plus the redaction posture. The
+    # central sanitizer in `agent_bom.security` is what ultimately scrubs
+    # values before storage, so we report `central_sanitizer_applied`.
+    discovery_scope: list[str] = []
+    if account_id:
+        discovery_scope.append(f"aws:account/{account_id}")
+    if resolved_region:
+        discovery_scope.append(f"aws:region/{resolved_region}")
+    if tag_filter:
+        for k, v in sorted(tag_filter.items()):
+            discovery_scope.append(f"aws:tag/{k}={v}")
+
+    permissions_used = _aws_permissions_for_jobs(
+        include_ecs=include_ecs,
+        include_sagemaker=include_sagemaker,
+        include_lambda=include_lambda,
+        include_eks=include_eks,
+        include_step_functions=include_step_functions,
+        include_ec2=include_ec2,
+    )
+    envelope = DiscoveryEnvelope(
+        scan_mode=ScanMode.CLOUD_READ_ONLY,
+        discovery_scope=tuple(discovery_scope),
+        permissions_used=permissions_used,
+        redaction_status=RedactionStatus.CENTRAL_SANITIZER_APPLIED,
+    )
+    envelope_payload = envelope.to_dict()
+    for agent in agents:
+        if agent.discovery_envelope is None:
+            agent.discovery_envelope = envelope_payload
+
     return agents, warnings
+
+
+# IAM permissions exercised by AWS provider helpers, by job. Each entry is
+# the read-only API call list the corresponding `_discover_*` function
+# actually issues. Kept here so the per-run envelope `permissions_used`
+# field stays honest -- producers control the catalog, not external docs.
+_AWS_BEDROCK_PERMISSIONS: tuple[str, ...] = (
+    "bedrock-agent:ListAgents",
+    "bedrock-agent:GetAgent",
+    "bedrock-agent:ListAgentActionGroups",
+    "bedrock-agent:GetAgentActionGroup",
+    "bedrock-agent:ListAgentKnowledgeBases",
+)
+_AWS_ECS_PERMISSIONS: tuple[str, ...] = (
+    "ecs:ListClusters",
+    "ecs:ListTasks",
+    "ecs:DescribeTasks",
+    "ecs:DescribeTaskDefinition",
+)
+_AWS_SAGEMAKER_PERMISSIONS: tuple[str, ...] = (
+    "sagemaker:ListEndpoints",
+    "sagemaker:DescribeEndpoint",
+    "sagemaker:DescribeEndpointConfig",
+    "sagemaker:DescribeModel",
+)
+_AWS_LAMBDA_PERMISSIONS: tuple[str, ...] = (
+    "lambda:ListFunctions",
+    "lambda:GetFunction",
+)
+_AWS_EKS_PERMISSIONS: tuple[str, ...] = (
+    "eks:ListClusters",
+    "eks:DescribeCluster",
+)
+_AWS_STEP_FUNCTIONS_PERMISSIONS: tuple[str, ...] = (
+    "states:ListStateMachines",
+    "states:DescribeStateMachine",
+)
+_AWS_EC2_PERMISSIONS: tuple[str, ...] = ("ec2:DescribeInstances",)
+_AWS_BASELINE_PERMISSIONS: tuple[str, ...] = ("sts:GetCallerIdentity",)
+
+
+def _aws_permissions_for_jobs(
+    *,
+    include_ecs: bool,
+    include_sagemaker: bool,
+    include_lambda: bool,
+    include_eks: bool,
+    include_step_functions: bool,
+    include_ec2: bool,
+) -> tuple[str, ...]:
+    """Return the IAM action list this run is allowed to exercise.
+
+    Bedrock + the baseline `sts:GetCallerIdentity` are always in scope
+    because `discover()` always tries to resolve the account and list agents.
+    Other services are gated on the include_* flags.
+    """
+    perms: list[str] = list(_AWS_BASELINE_PERMISSIONS) + list(_AWS_BEDROCK_PERMISSIONS)
+    if include_ecs:
+        perms.extend(_AWS_ECS_PERMISSIONS)
+    if include_sagemaker:
+        perms.extend(_AWS_SAGEMAKER_PERMISSIONS)
+    if include_lambda:
+        perms.extend(_AWS_LAMBDA_PERMISSIONS)
+    if include_eks:
+        perms.extend(_AWS_EKS_PERMISSIONS)
+    if include_step_functions:
+        perms.extend(_AWS_STEP_FUNCTIONS_PERMISSIONS)
+    if include_ec2:
+        perms.extend(_AWS_EC2_PERMISSIONS)
+    return tuple(sorted(set(perms)))
 
 
 def _resolve_account_id(session: Any) -> str | None:

--- a/src/agent_bom/discovery_envelope.py
+++ b/src/agent_bom/discovery_envelope.py
@@ -1,0 +1,159 @@
+"""Per-run discovery envelope (#2083 PR A).
+
+The envelope is the **per-run trust contract** for an Agent. It records
+*what the scan actually did* on this run: which mode it ran in, what scope
+was requested, which IAM/API permissions were exercised, and whether
+sensitive values were redacted or never collected at all.
+
+This is distinct from `discovery_provenance` (the sanitized record of
+*where the asset came from*) — both can coexist on the same Agent:
+
+- `discovery_provenance`: "This Agent was pulled from AWS account 12345 via
+  cloud_pull observed_via=['cloud_pull']."
+- `discovery_envelope`:   "This run used cloud_read_only mode, scoped to
+  account/12345, region/us-east-1, exercised ec2:DescribeInstances and
+  iam:GetRole, redaction_status=central_sanitizer_applied."
+
+Operators running agent-bom locally, on endpoints, or inside cloud / SaaS
+infrastructure get a code-backed answer for "what did this scan do" without
+having to read the provider source.
+
+Scope (PR A): the canonical model. AWS is wired as the first producer.
+Other providers and connectors follow in subsequent PRs (#2083 series).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+ENVELOPE_SCHEMA_VERSION = 1
+
+
+class ScanMode(str, Enum):
+    """Locked enum of how the scan was executed.
+
+    A locked vocabulary keeps the trust contract reliable. New modes get
+    added here intentionally; ad hoc strings are not accepted.
+    """
+
+    LOCAL_ONLY = "local_only"
+    """No network egress, no cloud / SaaS read, no runtime probe."""
+
+    CLOUD_READ_ONLY = "cloud_read_only"
+    """Read-only API calls against a cloud provider (AWS, Azure, GCP, …)."""
+
+    SAAS_READ_ONLY = "saas_read_only"
+    """Read-only API calls against a SaaS surface (Snowflake, Databricks, …)."""
+
+    RUNTIME_PROBE = "runtime_probe"
+    """Live MCP server introspection (tools/list, resources/list, …)."""
+
+    CONTAINER_LOCAL = "container_local"
+    """Local container scan — image layers, manifests, no runtime probe."""
+
+    ENDPOINT_PUSH = "endpoint_push"
+    """Endpoint-side discovery pushed into the API; pull-only on the server side."""
+
+
+class RedactionStatus(str, Enum):
+    """Redaction posture for sensitive values seen during this run."""
+
+    NEVER_COLLECTED = "never_collected"
+    """The provider deliberately never read the sensitive value (e.g. a token)."""
+
+    REDACTED_IN_PLACE = "redacted_in_place"
+    """The provider redacted the value before returning it (e.g. last 4 of a key)."""
+
+    CENTRAL_SANITIZER_APPLIED = "central_sanitizer_applied"
+    """The shared `agent_bom.security` sanitizer scrubbed the value before storage."""
+
+    NOT_APPLICABLE = "not_applicable"
+    """No sensitive values were in scope for this run."""
+
+
+@dataclass(frozen=True)
+class DiscoveryEnvelope:
+    """Per-run trust contract attached to a discovered Agent.
+
+    All fields are intentionally simple types so the envelope round-trips
+    cleanly through JSON / SARIF / OCSF / SBOM exporters and across the
+    `/v1/agents` API surface.
+    """
+
+    envelope_version: int = ENVELOPE_SCHEMA_VERSION
+    scan_mode: ScanMode = ScanMode.LOCAL_ONLY
+    discovery_scope: tuple[str, ...] = ()
+    """Strings describing what was explicitly in scope, e.g.
+    ``("aws:account/123456789012", "aws:region/us-east-1")``."""
+
+    permissions_used: tuple[str, ...] = ()
+    """Actual IAM/API permissions exercised, e.g.
+    ``("ec2:DescribeInstances", "iam:ListRoles")``."""
+
+    redaction_status: RedactionStatus = RedactionStatus.NOT_APPLICABLE
+    captured_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable payload (canonical shape).
+
+        Tuples are flattened to lists so the wire shape matches `/v1/agents`
+        responses without a custom encoder.
+        """
+        return {
+            "envelope_version": self.envelope_version,
+            "scan_mode": self.scan_mode.value,
+            "discovery_scope": list(self.discovery_scope),
+            "permissions_used": list(self.permissions_used),
+            "redaction_status": self.redaction_status.value,
+            "captured_at": self.captured_at,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> DiscoveryEnvelope:
+        """Build an envelope from a JSON-decoded payload.
+
+        Strict on schema version (only `1` accepted today) so an envelope
+        emitted by a newer producer can be detected and routed; loose on
+        unknown enum values (falls back to LOCAL_ONLY / NOT_APPLICABLE so a
+        future producer doesn't crash old consumers).
+        """
+        if not isinstance(payload, dict):
+            raise ValueError("DiscoveryEnvelope payload must be a JSON object")
+        version = payload.get("envelope_version", ENVELOPE_SCHEMA_VERSION)
+        if version != ENVELOPE_SCHEMA_VERSION:
+            raise ValueError(f"Unsupported envelope_version: {version!r} (expected {ENVELOPE_SCHEMA_VERSION})")
+        try:
+            scan_mode = ScanMode(payload.get("scan_mode", ScanMode.LOCAL_ONLY.value))
+        except ValueError:
+            scan_mode = ScanMode.LOCAL_ONLY
+        try:
+            redaction_status = RedactionStatus(payload.get("redaction_status", RedactionStatus.NOT_APPLICABLE.value))
+        except ValueError:
+            redaction_status = RedactionStatus.NOT_APPLICABLE
+
+        scope = payload.get("discovery_scope") or ()
+        if not isinstance(scope, (list, tuple)):
+            raise ValueError("discovery_scope must be a list of strings")
+        perms = payload.get("permissions_used") or ()
+        if not isinstance(perms, (list, tuple)):
+            raise ValueError("permissions_used must be a list of strings")
+        captured_at = payload.get("captured_at") or datetime.now(timezone.utc).isoformat()
+        return cls(
+            envelope_version=version,
+            scan_mode=scan_mode,
+            discovery_scope=tuple(str(s) for s in scope),
+            permissions_used=tuple(str(p) for p in perms),
+            redaction_status=redaction_status,
+            captured_at=str(captured_at),
+        )
+
+
+__all__ = [
+    "ENVELOPE_SCHEMA_VERSION",
+    "DiscoveryEnvelope",
+    "RedactionStatus",
+    "ScanMode",
+]

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -693,6 +693,13 @@ class Agent:
     metadata: dict = field(default_factory=dict)  # Extra config data (permissions, hooks, etc.)
     automation_settings: list = field(default_factory=list)  # Risky automation settings (scheduled tasks, etc.)
     discovery_provenance: Optional[dict] = None  # Sanitized discovery provenance contract for this agent asset
+    # Per-run discovery envelope (#2083): trust contract for THIS scan run
+    # -- scan_mode, discovery_scope, permissions_used, redaction_status.
+    # Stored as a dict so the model stays JSON-friendly without dragging
+    # `discovery_envelope.DiscoveryEnvelope` into the import path; producers
+    # populate via `DiscoveryEnvelope.to_dict()` and consumers can re-hydrate
+    # via `DiscoveryEnvelope.from_dict()`.
+    discovery_envelope: Optional[dict] = None
 
     def __post_init__(self) -> None:
         """Backfill lifecycle fields for legacy Agent construction paths."""

--- a/tests/test_discovery_envelope.py
+++ b/tests/test_discovery_envelope.py
@@ -1,0 +1,196 @@
+"""Discovery envelope model + AWS provider wiring (#2083 PR A)."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime
+
+import pytest
+
+from agent_bom.discovery_envelope import (
+    ENVELOPE_SCHEMA_VERSION,
+    DiscoveryEnvelope,
+    RedactionStatus,
+    ScanMode,
+)
+from agent_bom.models import Agent, AgentType
+
+
+def test_envelope_default_shape() -> None:
+    envelope = DiscoveryEnvelope()
+    payload = envelope.to_dict()
+    assert payload["envelope_version"] == ENVELOPE_SCHEMA_VERSION
+    assert payload["scan_mode"] == ScanMode.LOCAL_ONLY.value
+    assert payload["discovery_scope"] == []
+    assert payload["permissions_used"] == []
+    assert payload["redaction_status"] == RedactionStatus.NOT_APPLICABLE.value
+    # captured_at is an ISO 8601 timestamp.
+    parsed = datetime.fromisoformat(payload["captured_at"])
+    assert parsed.tzinfo is not None
+
+
+def test_envelope_round_trip() -> None:
+    envelope = DiscoveryEnvelope(
+        scan_mode=ScanMode.CLOUD_READ_ONLY,
+        discovery_scope=("aws:account/12345", "aws:region/us-east-1"),
+        permissions_used=("ec2:DescribeInstances", "iam:ListRoles"),
+        redaction_status=RedactionStatus.CENTRAL_SANITIZER_APPLIED,
+    )
+    payload = envelope.to_dict()
+    assert isinstance(payload["discovery_scope"], list)
+    assert isinstance(payload["permissions_used"], list)
+    rebuilt = DiscoveryEnvelope.from_dict(payload)
+    assert rebuilt == envelope
+
+
+def test_envelope_from_dict_defaults_unknown_enum_values_safely() -> None:
+    payload = {
+        "envelope_version": ENVELOPE_SCHEMA_VERSION,
+        "scan_mode": "future_mode_unknown_to_us",
+        "discovery_scope": [],
+        "permissions_used": [],
+        "redaction_status": "weird_thing",
+    }
+    rebuilt = DiscoveryEnvelope.from_dict(payload)
+    # Forward-compat: unknown enum values fall back to safe defaults.
+    assert rebuilt.scan_mode == ScanMode.LOCAL_ONLY
+    assert rebuilt.redaction_status == RedactionStatus.NOT_APPLICABLE
+
+
+def test_envelope_from_dict_rejects_wrong_schema_version() -> None:
+    with pytest.raises(ValueError, match="Unsupported envelope_version"):
+        DiscoveryEnvelope.from_dict({"envelope_version": 99})
+
+
+def test_envelope_from_dict_rejects_non_object() -> None:
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        DiscoveryEnvelope.from_dict([])  # type: ignore[arg-type]
+
+
+def test_envelope_from_dict_rejects_non_list_scope() -> None:
+    with pytest.raises(ValueError, match="discovery_scope"):
+        DiscoveryEnvelope.from_dict({"discovery_scope": "not-a-list"})
+
+
+def test_envelope_from_dict_coerces_scope_and_perms_to_strings() -> None:
+    rebuilt = DiscoveryEnvelope.from_dict({"discovery_scope": [1, 2], "permissions_used": [3]})
+    assert rebuilt.discovery_scope == ("1", "2")
+    assert rebuilt.permissions_used == ("3",)
+
+
+def test_agent_model_carries_envelope() -> None:
+    """Agent dataclass round-trips the envelope dict through asdict()."""
+    envelope = DiscoveryEnvelope(scan_mode=ScanMode.RUNTIME_PROBE)
+    agent = Agent(
+        name="claude-desktop",
+        agent_type=AgentType.CLAUDE_DESKTOP,
+        config_path="/tmp/x",
+        discovery_envelope=envelope.to_dict(),
+    )
+    payload = asdict(agent)
+    assert payload["discovery_envelope"]["scan_mode"] == "runtime_probe"
+    rebuilt = DiscoveryEnvelope.from_dict(payload["discovery_envelope"])
+    assert rebuilt.scan_mode == ScanMode.RUNTIME_PROBE
+
+
+# ─── AWS provider wiring ────────────────────────────────────────────────
+
+
+def test_aws_permissions_baseline_only() -> None:
+    from agent_bom.cloud.aws import _aws_permissions_for_jobs
+
+    perms = _aws_permissions_for_jobs(
+        include_ecs=False,
+        include_sagemaker=False,
+        include_lambda=False,
+        include_eks=False,
+        include_step_functions=False,
+        include_ec2=False,
+    )
+    # Always-on: STS + Bedrock.
+    assert "sts:GetCallerIdentity" in perms
+    assert "bedrock-agent:ListAgents" in perms
+    # Gated services should not appear when their flag is off.
+    assert "ec2:DescribeInstances" not in perms
+    assert "lambda:GetFunction" not in perms
+
+
+def test_aws_permissions_include_optional_services() -> None:
+    from agent_bom.cloud.aws import _aws_permissions_for_jobs
+
+    perms = _aws_permissions_for_jobs(
+        include_ecs=True,
+        include_sagemaker=True,
+        include_lambda=True,
+        include_eks=True,
+        include_step_functions=True,
+        include_ec2=True,
+    )
+    for needle in (
+        "ecs:DescribeTasks",
+        "sagemaker:DescribeEndpoint",
+        "lambda:GetFunction",
+        "eks:DescribeCluster",
+        "states:DescribeStateMachine",
+        "ec2:DescribeInstances",
+    ):
+        assert needle in perms
+
+
+def test_aws_permissions_sorted_and_unique() -> None:
+    from agent_bom.cloud.aws import _aws_permissions_for_jobs
+
+    perms = _aws_permissions_for_jobs(
+        include_ecs=True,
+        include_sagemaker=True,
+        include_lambda=True,
+        include_eks=True,
+        include_step_functions=True,
+        include_ec2=True,
+    )
+    assert list(perms) == sorted(perms)
+    assert len(perms) == len(set(perms))
+
+
+def test_aws_envelope_attached_to_discovered_agents(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without boto3 credentials this can't run real discovery, but we can
+    verify the wiring by feeding a stub Bedrock job and asserting the
+    envelope lands on every returned Agent.
+    """
+    pytest.importorskip("boto3")
+
+    import agent_bom.cloud.aws as aws_module
+
+    # Feed a single fake Bedrock agent. ECS/SageMaker/etc. are off by default.
+    fake_agent = Agent(
+        name="bedrock-agent-1",
+        agent_type=AgentType.CUSTOM,
+        config_path="arn:aws:bedrock:...",
+        source="aws-bedrock",
+    )
+
+    def _fake_bedrock(*args, **kwargs):
+        return [fake_agent], []
+
+    def _fake_account(_session):
+        return "111111111111"
+
+    monkeypatch.setattr(aws_module, "_discover_bedrock", _fake_bedrock)
+    monkeypatch.setattr(aws_module, "_resolve_account_id", _fake_account)
+
+    class _FakeSession:
+        region_name = "us-east-1"
+
+    monkeypatch.setattr(aws_module.boto3 if hasattr(aws_module, "boto3") else __import__("boto3"), "Session", lambda **kw: _FakeSession())
+
+    agents, warnings = aws_module.discover(include_ecs=False)
+    assert len(agents) == 1
+    envelope = agents[0].discovery_envelope
+    assert envelope is not None
+    assert envelope["scan_mode"] == ScanMode.CLOUD_READ_ONLY.value
+    assert envelope["redaction_status"] == RedactionStatus.CENTRAL_SANITIZER_APPLIED.value
+    assert "aws:account/111111111111" in envelope["discovery_scope"]
+    assert "aws:region/us-east-1" in envelope["discovery_scope"]
+    assert "sts:GetCallerIdentity" in envelope["permissions_used"]
+    assert "bedrock-agent:ListAgents" in envelope["permissions_used"]
+    assert envelope["envelope_version"] == ENVELOPE_SCHEMA_VERSION


### PR DESCRIPTION
PR A of the #2083 series. Lands the canonical envelope model + `Agent.discovery_envelope` field + AWS producer wiring. Subsequent PRs cover the other providers and the UI / API surface.

User signed off on the four design decisions in [issue #2083 comment](https://github.com/msaad00/agent-bom/issues/2083) before this code:

1. ✅ Per-`Agent` envelope shape (one envelope per provider per run, not top-level on `ScanReport`).
2. ✅ Locked vocabulary for `scan_mode` (`local_only | cloud_read_only | saas_read_only | runtime_probe | container_local | endpoint_push`).
3. ✅ Fine-grained `permissions_used` (actual API calls like `ec2:DescribeInstances`, not coarse capability tags).
4. ✅ Schema versioning via `envelope_version` so future expansion can be detected.

## What is the envelope

The per-run **trust contract** attached to every discovered Agent. It records *what the scan actually did* this run: scan mode, explicit scope, IAM/API permissions exercised, and redaction posture. Distinct from `discovery_provenance` (where the asset came from); both can coexist on the same `Agent`.

| Field | Purpose |
|---|---|
| `discovery_provenance` | "Pulled from AWS account 12345 via cloud_pull." |
| `discovery_envelope`   | "This run: cloud_read_only, scope=account/12345 + region/us-east-1, exercised ec2:DescribeInstances + iam:ListRoles, redaction_status=central_sanitizer_applied." |

## What lands here

| Layer | Change |
|---|---|
| `src/agent_bom/discovery_envelope.py` (new) | `DiscoveryEnvelope` frozen dataclass + `ScanMode` + `RedactionStatus` locked enums + `to_dict()` / `from_dict()` round-trip with strict schema-version + forward-compatible enum fallback |
| `src/agent_bom/models.py` | New optional `Agent.discovery_envelope: dict \| None` field — stored as a dict so the model stays JSON-friendly without dragging the dataclass into the import path |
| `src/agent_bom/cloud/aws.py` | Builds + attaches the envelope at the end of `discover()`. New `_aws_permissions_for_jobs(...)` helper derives the IAM action list from the include_* flags. Bedrock + STS always-on; ECS / SageMaker / Lambda / EKS / Step Functions / EC2 gate on flags |
| `tests/test_discovery_envelope.py` | 12 cases: round-trip, forward-compat enum fallback, schema-version strictness, payload-shape strictness, string coercion, Agent `asdict` round-trip, AWS permission catalog invariants, end-to-end discover() attaches envelope to every Agent |
| `docs/DISCOVERY_ENVELOPE.md` | Full schema reference, locked-vocabulary tables, producer pattern, 4-PR roadmap |

## Schema (`envelope_version=1`)

```json
{
  "envelope_version": 1,
  "scan_mode": "cloud_read_only",
  "discovery_scope": ["aws:account/123456789012", "aws:region/us-east-1"],
  "permissions_used": ["bedrock-agent:GetAgent", "bedrock-agent:ListAgents", "sts:GetCallerIdentity"],
  "redaction_status": "central_sanitizer_applied",
  "captured_at": "2026-05-02T20:15:00.000+00:00"
}
```

## Validation
- `pytest tests/test_discovery_envelope.py tests/test_cloud_aws.py tests/test_cloud.py tests/test_cloud_origin_contract.py tests/test_cloud_package_purls.py` -> **134 passed**
- `ruff check` clean
- `mypy src/agent_bom/discovery_envelope.py` clean
- `scripts/generate_env_var_reference.py --check` -> OK

## Roadmap (after this PR)

- **PR B** — connector + endpoint parity. Snowflake, Databricks, GCP, Azure, vector DBs, MLflow, W&B, HuggingFace, OpenAI all populate the envelope.
- **PR C** — UI surface on agent detail view; `/v1/agents` and `/v1/discovery/providers` API responses include the envelope.
- **PR D** — cross-provider redaction + least-privilege test matrix verifying every provider's `permissions_used` actually matches the API calls it issues.