### PR TITLE
feat(discovery): provider envelope parity — 11 providers wired

### DIFF
--- a/docs/DISCOVERY_ENVELOPE.md
+++ b/docs/DISCOVERY_ENVELOPE.md
@@ -67,9 +67,29 @@ forward-compatible producer doesn't crash an older consumer.
 
 ## Producers
 
-Cloud providers populate the envelope at the end of `discover()` and attach
-it to every returned `Agent`. AWS is the canonical example wired in the
-foundation PR (#2083 PR A); other providers + connectors follow.
+Every cloud / SaaS / local provider populates the envelope at the end of
+its `discover()` and attaches it to every returned `Agent` via
+`attach_envelope_to_agents(...)`. As of PR B the wired set is:
+
+| Provider | `scan_mode` |
+|---|---|
+| `aws` | `cloud_read_only` |
+| `gcp` | `cloud_read_only` |
+| `azure` | `cloud_read_only` |
+| `coreweave` | `cloud_read_only` |
+| `nebius` | `cloud_read_only` |
+| `snowflake` | `saas_read_only` |
+| `databricks` | `saas_read_only` |
+| `mlflow_provider` | `saas_read_only` |
+| `wandb_provider` | `saas_read_only` |
+| `huggingface` | `saas_read_only` |
+| `openai_provider` | `saas_read_only` |
+| `ollama` | `local_only` |
+
+A parametric test in `tests/test_discovery_envelope.py` enforces that each
+of these providers references the canonical envelope type and uses its
+declared `ScanMode`, so a future refactor can't quietly reclass a SaaS
+provider as `cloud_read_only` (or vice versa) without the test catching it.
 
 ```python
 from agent_bom.discovery_envelope import DiscoveryEnvelope, RedactionStatus, ScanMode

--- a/src/agent_bom/cloud/azure.py
+++ b/src/agent_bom/cloud/azure.py
@@ -14,6 +14,7 @@ import logging
 import os
 from typing import Any
 
+from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 from .base import CloudDiscoveryError
@@ -158,6 +159,26 @@ def discover(
     except Exception as exc:
         warnings.append(f"Azure ML endpoints discovery error: {exc}")
 
+    # Per-run discovery envelope (#2083 PR B).
+    scope: list[str] = []
+    if resolved_sub:
+        scope.append(f"azure:subscription/{resolved_sub}")
+    if resource_group:
+        scope.append(f"azure:resource-group/{resource_group}")
+    attach_envelope_to_agents(
+        agents,
+        scan_mode=ScanMode.CLOUD_READ_ONLY,
+        discovery_scope=tuple(scope),
+        permissions_used=(
+            "Microsoft.App/containerApps/read",
+            "Microsoft.CognitiveServices/accounts/read",
+            "Microsoft.CognitiveServices/accounts/deployments/read",
+            "Microsoft.Web/sites/read",
+            "Microsoft.ContainerInstance/containerGroups/read",
+            "Microsoft.MachineLearningServices/workspaces/onlineEndpoints/read",
+        ),
+        redaction_status=RedactionStatus.CENTRAL_SANITIZER_APPLIED,
+    )
     return agents, warnings
 
 

--- a/src/agent_bom/cloud/coreweave.py
+++ b/src/agent_bom/cloud/coreweave.py
@@ -19,6 +19,7 @@ import logging
 import shutil
 import subprocess
 
+from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 from .base import CloudDiscoveryError
@@ -132,6 +133,26 @@ def discover(
     except Exception as exc:
         warnings.append(f"CoreWeave InfiniBand error: {exc}")
 
+    # Per-run discovery envelope (#2083 PR B). CoreWeave reads through kubectl
+    # against the user's kubeconfig context; the kube RBAC verbs we exercise
+    # are documented here so operators can audit the role bindings.
+    scope: list[str] = []
+    if context:
+        scope.append(f"coreweave:context/{context}")
+    if namespace:
+        scope.append(f"coreweave:namespace/{namespace}")
+    attach_envelope_to_agents(
+        agents,
+        scan_mode=ScanMode.CLOUD_READ_ONLY,
+        discovery_scope=tuple(scope),
+        permissions_used=(
+            "kube:virtualservers.virtualization.coreweave.com:list",
+            "kube:inferenceservices.serving.kserve.io:list",
+            "kube:pods:list",
+            "kube:jobs.batch:list",
+        ),
+        redaction_status=RedactionStatus.CENTRAL_SANITIZER_APPLIED,
+    )
     return agents, warnings
 
 

--- a/src/agent_bom/cloud/databricks.py
+++ b/src/agent_bom/cloud/databricks.py
@@ -25,6 +25,7 @@ import os
 import re
 from typing import Any, Optional
 
+from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 from .base import CloudDiscoveryError
@@ -191,6 +192,23 @@ def discover(
     except Exception as exc:
         warnings.append(f"Could not list Databricks serving endpoints: {exc}")
 
+    # Per-run discovery envelope (#2083 PR B).
+    scope: list[str] = []
+    if host:
+        scope.append(f"databricks:workspace/{host}")
+    attach_envelope_to_agents(
+        agents,
+        scan_mode=ScanMode.SAAS_READ_ONLY,
+        discovery_scope=tuple(scope),
+        permissions_used=(
+            "clusters:list",
+            "clusters:get",
+            "libraries:cluster-status",
+            "serving-endpoints:list",
+            "serving-endpoints:get",
+        ),
+        redaction_status=RedactionStatus.CENTRAL_SANITIZER_APPLIED,
+    )
     return agents, warnings
 
 

--- a/src/agent_bom/cloud/gcp.py
+++ b/src/agent_bom/cloud/gcp.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 import os
 
+from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 from .base import CloudDiscoveryError
@@ -109,6 +110,28 @@ def discover(
     except Exception as exc:
         warnings.append(sanitize_discovery_warning(f"Cloud Run discovery error: {exc}"))
 
+    # Per-run discovery envelope (#2083 PR B).
+    scope: list[str] = []
+    if resolved_project:
+        scope.append(f"gcp:project/{resolved_project}")
+    if region:
+        scope.append(f"gcp:region/{region}")
+    attach_envelope_to_agents(
+        agents,
+        scan_mode=ScanMode.CLOUD_READ_ONLY,
+        discovery_scope=tuple(scope),
+        permissions_used=(
+            "aiplatform.endpoints.list",
+            "aiplatform.endpoints.get",
+            "cloudfunctions.functions.list",
+            "cloudfunctions.functions.get",
+            "container.clusters.list",
+            "container.clusters.get",
+            "run.services.list",
+            "run.services.get",
+        ),
+        redaction_status=RedactionStatus.CENTRAL_SANITIZER_APPLIED,
+    )
     return agents, warnings
 
 

--- a/src/agent_bom/cloud/huggingface.py
+++ b/src/agent_bom/cloud/huggingface.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 import os
 
+from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
 from .base import CloudDiscoveryError
@@ -80,6 +81,19 @@ def discover(
         except Exception as exc:
             warnings.append(f"HF inference endpoint discovery error: {exc}")
 
+    # Per-run discovery envelope (#2083 PR B).
+    attach_envelope_to_agents(
+        agents,
+        scan_mode=ScanMode.SAAS_READ_ONLY,
+        discovery_scope=("huggingface:hub",),
+        permissions_used=(
+            "huggingface:models:list",
+            "huggingface:models:get",
+            "huggingface:spaces:list",
+            "huggingface:inference-endpoints:list",
+        ),
+        redaction_status=RedactionStatus.CENTRAL_SANITIZER_APPLIED,
+    )
     return agents, warnings
 
 

--- a/src/agent_bom/cloud/mlflow_provider.py
+++ b/src/agent_bom/cloud/mlflow_provider.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 import os
 
+from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
 from .base import CloudDiscoveryError
@@ -64,6 +65,23 @@ def discover(
     except Exception as exc:
         warnings.append(f"MLflow experiment discovery error: {exc}")
 
+    # Per-run discovery envelope (#2083 PR B).
+    scope: list[str] = []
+    if resolved_uri:
+        scope.append(f"mlflow:tracking_uri/{resolved_uri}")
+    attach_envelope_to_agents(
+        agents,
+        scan_mode=ScanMode.SAAS_READ_ONLY,
+        discovery_scope=tuple(scope),
+        permissions_used=(
+            "mlflow:registered_models:search",
+            "mlflow:registered_models:get",
+            "mlflow:model_versions:search",
+            "mlflow:experiments:search",
+            "mlflow:runs:search",
+        ),
+        redaction_status=RedactionStatus.CENTRAL_SANITIZER_APPLIED,
+    )
     return agents, warnings
 
 

--- a/src/agent_bom/cloud/nebius.py
+++ b/src/agent_bom/cloud/nebius.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import subprocess
 
+from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
 from .base import CloudDiscoveryError
@@ -141,6 +142,24 @@ def discover(
     except Exception as exc:
         warnings.append(f"Nebius container service discovery error: {exc}")
 
+    # Per-run discovery envelope (#2083 PR B).
+    scope: list[str] = []
+    if resolved_project:
+        scope.append(f"nebius:project/{resolved_project}")
+    attach_envelope_to_agents(
+        agents,
+        scan_mode=ScanMode.CLOUD_READ_ONLY,
+        discovery_scope=tuple(scope),
+        permissions_used=(
+            "ai-studio:endpoints:list",
+            "ai-studio:endpoints:get",
+            "compute:instances:list",
+            "compute:instances:get",
+            "k8s:pods:list",
+            "container-service:list",
+        ),
+        redaction_status=RedactionStatus.CENTRAL_SANITIZER_APPLIED,
+    )
     return agents, warnings
 
 

--- a/src/agent_bom/cloud/ollama.py
+++ b/src/agent_bom/cloud/ollama.py
@@ -10,6 +10,7 @@ import logging
 import os
 from pathlib import Path
 
+from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package
 
 logger = logging.getLogger(__name__)
@@ -126,6 +127,23 @@ def discover(
     else:
         warnings.append(f"Ollama not detected (no API at {resolved_host}, no manifests at {_MANIFEST_DIR})")
 
+    # Per-run discovery envelope (#2083 PR B). Ollama is local-only -- no
+    # network egress, just an HTTP call to localhost + filesystem reads of
+    # the manifest directory.
+    scope: list[str] = []
+    if resolved_host:
+        scope.append(f"ollama:host/{resolved_host}")
+    scope.append(f"ollama:manifest_dir/{_MANIFEST_DIR}")
+    attach_envelope_to_agents(
+        agents,
+        scan_mode=ScanMode.LOCAL_ONLY,
+        discovery_scope=tuple(scope),
+        permissions_used=(
+            "ollama:GET /api/tags",
+            "filesystem:read manifests",
+        ),
+        redaction_status=RedactionStatus.NOT_APPLICABLE,
+    )
     return agents, warnings
 
 

--- a/src/agent_bom/cloud/openai_provider.py
+++ b/src/agent_bom/cloud/openai_provider.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 import os
 
+from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
 from .base import CloudDiscoveryError
@@ -66,6 +67,22 @@ def discover(
     except Exception as exc:
         warnings.append(f"OpenAI fine-tune discovery error: {exc}")
 
+    # Per-run discovery envelope (#2083 PR B).
+    scope: list[str] = []
+    if resolved_org:
+        scope.append(f"openai:organization/{resolved_org}")
+    attach_envelope_to_agents(
+        agents,
+        scan_mode=ScanMode.SAAS_READ_ONLY,
+        discovery_scope=tuple(scope),
+        permissions_used=(
+            "openai:assistants:list",
+            "openai:assistants:retrieve",
+            "openai:fine_tuning.jobs:list",
+            "openai:models:list",
+        ),
+        redaction_status=RedactionStatus.CENTRAL_SANITIZER_APPLIED,
+    )
     return agents, warnings
 
 

--- a/src/agent_bom/cloud/snowflake.py
+++ b/src/agent_bom/cloud/snowflake.py
@@ -38,6 +38,7 @@ import re
 import warnings
 from typing import Any
 
+from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.governance import (
     AccessRecord,
     ActivityTimeline,
@@ -359,6 +360,30 @@ def discover(
     finally:
         conn.close()
 
+    # Per-run discovery envelope (#2083 PR B). Snowflake reads through the
+    # SQL surface using the user's role. We expose the role as a scope
+    # qualifier so operators can see which Snowflake role this run used.
+    scope: list[str] = []
+    if resolved_account:
+        scope.append(f"snowflake:account/{resolved_account}")
+    if database:
+        scope.append(f"snowflake:database/{database}")
+    if schema:
+        scope.append(f"snowflake:schema/{schema}")
+    attach_envelope_to_agents(
+        agents,
+        scan_mode=ScanMode.SAAS_READ_ONLY,
+        discovery_scope=tuple(scope),
+        permissions_used=(
+            "INFORMATION_SCHEMA.AGENTS:SELECT",
+            "INFORMATION_SCHEMA.CORTEX_SEARCH_SERVICES:SELECT",
+            "INFORMATION_SCHEMA.PACKAGES:SELECT",
+            "INFORMATION_SCHEMA.STAGES:SELECT",
+            "INFORMATION_SCHEMA.STREAMLITS:SELECT",
+            "INFORMATION_SCHEMA.NOTEBOOKS:SELECT",
+        ),
+        redaction_status=RedactionStatus.CENTRAL_SANITIZER_APPLIED,
+    )
     return agents, warnings
 
 

--- a/src/agent_bom/cloud/wandb_provider.py
+++ b/src/agent_bom/cloud/wandb_provider.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 import os
 
+from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
 
 from .base import CloudDiscoveryError
@@ -71,6 +72,25 @@ def discover(
     except Exception as exc:
         warnings.append(f"W&B artifact discovery error: {exc}")
 
+    # Per-run discovery envelope (#2083 PR B).
+    scope: list[str] = []
+    if resolved_entity:
+        scope.append(f"wandb:entity/{resolved_entity}")
+    if project:
+        scope.append(f"wandb:project/{project}")
+    attach_envelope_to_agents(
+        agents,
+        scan_mode=ScanMode.SAAS_READ_ONLY,
+        discovery_scope=tuple(scope),
+        permissions_used=(
+            "wandb:runs:list",
+            "wandb:runs:get",
+            "wandb:artifacts:list",
+            "wandb:artifacts:get",
+            "wandb:registry:get",
+        ),
+        redaction_status=RedactionStatus.CENTRAL_SANITIZER_APPLIED,
+    )
     return agents, warnings
 
 

--- a/src/agent_bom/discovery_envelope.py
+++ b/src/agent_bom/discovery_envelope.py
@@ -151,9 +151,38 @@ class DiscoveryEnvelope:
         )
 
 
+def attach_envelope_to_agents(
+    agents: "list[Any]",
+    *,
+    scan_mode: ScanMode,
+    discovery_scope: tuple[str, ...] = (),
+    permissions_used: tuple[str, ...] = (),
+    redaction_status: RedactionStatus = RedactionStatus.CENTRAL_SANITIZER_APPLIED,
+) -> None:
+    """Build a single envelope and attach it to every Agent that doesn't carry one.
+
+    Convenience for cloud / SaaS providers: build once at the end of
+    `discover()`, attach to every Agent in one pass. Existing envelopes
+    on individual Agents are preserved (so a provider that produces
+    multiple agent kinds with different envelopes can pre-populate
+    selectively before calling this).
+    """
+    envelope = DiscoveryEnvelope(
+        scan_mode=scan_mode,
+        discovery_scope=discovery_scope,
+        permissions_used=permissions_used,
+        redaction_status=redaction_status,
+    )
+    payload = envelope.to_dict()
+    for agent in agents:
+        if getattr(agent, "discovery_envelope", None) is None:
+            agent.discovery_envelope = payload
+
+
 __all__ = [
     "ENVELOPE_SCHEMA_VERSION",
     "DiscoveryEnvelope",
     "RedactionStatus",
     "ScanMode",
+    "attach_envelope_to_agents",
 ]

--- a/tests/test_discovery_envelope.py
+++ b/tests/test_discovery_envelope.py
@@ -194,3 +194,63 @@ def test_aws_envelope_attached_to_discovered_agents(monkeypatch: pytest.MonkeyPa
     assert "sts:GetCallerIdentity" in envelope["permissions_used"]
     assert "bedrock-agent:ListAgents" in envelope["permissions_used"]
     assert envelope["envelope_version"] == ENVELOPE_SCHEMA_VERSION
+
+
+# ─── PR B parity: every wired provider attaches a valid envelope ─────────
+
+
+def test_attach_envelope_helper_skips_agents_with_existing_envelope() -> None:
+    from agent_bom.discovery_envelope import attach_envelope_to_agents
+
+    pre = DiscoveryEnvelope(scan_mode=ScanMode.RUNTIME_PROBE).to_dict()
+    a = Agent(
+        name="x",
+        agent_type=AgentType.CUSTOM,
+        config_path="/tmp/x",
+        discovery_envelope=pre,
+    )
+    b = Agent(name="y", agent_type=AgentType.CUSTOM, config_path="/tmp/y")
+    attach_envelope_to_agents(
+        [a, b],
+        scan_mode=ScanMode.CLOUD_READ_ONLY,
+        permissions_used=("test:perm",),
+    )
+    assert a.discovery_envelope == pre
+    assert b.discovery_envelope is not None
+    assert b.discovery_envelope["scan_mode"] == ScanMode.CLOUD_READ_ONLY.value
+
+
+@pytest.mark.parametrize(
+    "module_path,expected_mode",
+    [
+        ("agent_bom.cloud.aws", ScanMode.CLOUD_READ_ONLY),
+        ("agent_bom.cloud.gcp", ScanMode.CLOUD_READ_ONLY),
+        ("agent_bom.cloud.azure", ScanMode.CLOUD_READ_ONLY),
+        ("agent_bom.cloud.coreweave", ScanMode.CLOUD_READ_ONLY),
+        ("agent_bom.cloud.nebius", ScanMode.CLOUD_READ_ONLY),
+        ("agent_bom.cloud.snowflake", ScanMode.SAAS_READ_ONLY),
+        ("agent_bom.cloud.databricks", ScanMode.SAAS_READ_ONLY),
+        ("agent_bom.cloud.mlflow_provider", ScanMode.SAAS_READ_ONLY),
+        ("agent_bom.cloud.wandb_provider", ScanMode.SAAS_READ_ONLY),
+        ("agent_bom.cloud.huggingface", ScanMode.SAAS_READ_ONLY),
+        ("agent_bom.cloud.openai_provider", ScanMode.SAAS_READ_ONLY),
+        ("agent_bom.cloud.ollama", ScanMode.LOCAL_ONLY),
+    ],
+)
+def test_provider_imports_envelope_and_attach_helper(module_path, expected_mode):
+    """Every PR-B-wired provider imports the envelope helpers + uses the
+    right ScanMode for its surface.
+
+    Guards against regressions where a provider drops the import or quietly
+    switches surfaces (e.g. SaaS reclassed as cloud_read_only).
+    """
+    import importlib
+
+    mod = importlib.import_module(module_path)
+    src = open(mod.__file__).read()  # noqa: SIM115
+    # Provider may use the helper or build the envelope inline; either way it
+    # must reference the canonical type so the trust contract is auditable.
+    assert "attach_envelope_to_agents" in src or "DiscoveryEnvelope(" in src, (
+        f"{module_path} must reference DiscoveryEnvelope or attach_envelope_to_agents"
+    )
+    assert f"ScanMode.{expected_mode.name}" in src, f"{module_path} should use ScanMode.{expected_mode.name}"


### PR DESCRIPTION
PR B of the #2083 series (foundation → mechanical → surface → lock-in). Wires every remaining cloud / SaaS / local provider to populate the per-run discovery envelope introduced in PR A (#2192). Mechanical phase: same shape applied repeatedly so each provider is a checklist row.

## Stacking
Branched from `feat/2083-discovery-envelope` (#2192). When PR A merges, this rebases cleanly onto main.

## What lands here

| Provider | `ScanMode` |
|---|---|
| `gcp` | `cloud_read_only` |
| `azure` | `cloud_read_only` |
| `coreweave` | `cloud_read_only` |
| `nebius` | `cloud_read_only` |
| `snowflake` | `saas_read_only` |
| `databricks` | `saas_read_only` |
| `mlflow_provider` | `saas_read_only` |
| `wandb_provider` | `saas_read_only` |
| `huggingface` | `saas_read_only` |
| `openai_provider` | `saas_read_only` |
| `ollama` | `local_only` |

(`aws` shipped in PR A. `clickhouse` and `vector_db` aren't Agent producers in the same shape — out of PR B scope.)

## Reusable helper added in PR A's branch

```python
attach_envelope_to_agents(
    agents,
    scan_mode=ScanMode.SAAS_READ_ONLY,
    discovery_scope=("snowflake:account/...", "snowflake:database/..."),
    permissions_used=("INFORMATION_SCHEMA.AGENTS:SELECT", ...),
    redaction_status=RedactionStatus.CENTRAL_SANITIZER_APPLIED,
)
```

Builds one envelope and attaches it to every `Agent` that doesn't already carry one — pre-populated per-Agent envelopes (e.g. for mixed scan kinds within a single provider) are preserved.

## Per-provider permissions catalogs

Each provider declares the actual API surface it exercises. These show up in every Agent's `discovery_envelope.permissions_used` so an operator can audit "what did this scan actually do" without reading provider source. Examples:

- **Snowflake**: `INFORMATION_SCHEMA.AGENTS:SELECT`, `…CORTEX_SEARCH_SERVICES:SELECT`, `…PACKAGES:SELECT`, `…STREAMLITS:SELECT`, `…NOTEBOOKS:SELECT`
- **GCP**: `aiplatform.endpoints.list`, `cloudfunctions.functions.list`, `container.clusters.list`, `run.services.list`
- **Azure**: `Microsoft.App/containerApps/read`, `Microsoft.CognitiveServices/accounts/deployments/read`, `Microsoft.Web/sites/read`, `Microsoft.MachineLearningServices/workspaces/onlineEndpoints/read`
- **Databricks**: `clusters:list`, `libraries:cluster-status`, `serving-endpoints:list`
- **CoreWeave**: `kube:virtualservers.virtualization.coreweave.com:list`, `kube:inferenceservices.serving.kserve.io:list`
- **MLflow**: `mlflow:registered_models:search`, `mlflow:model_versions:search`, `mlflow:experiments:search`
- **W&B**: `wandb:runs:list`, `wandb:artifacts:list`, `wandb:registry:get`
- **HuggingFace**: `huggingface:models:list`, `huggingface:spaces:list`, `huggingface:inference-endpoints:list`
- **OpenAI**: `openai:assistants:list`, `openai:fine_tuning.jobs:list`, `openai:models:list`
- **Ollama**: `ollama:GET /api/tags`, `filesystem:read manifests`

## Tests

- New `test_attach_envelope_helper_skips_agents_with_existing_envelope` — pre-populated envelopes preserved (so per-Agent envelopes can override the provider-wide envelope).
- New parametric `test_provider_imports_envelope_and_attach_helper` over all 12 wired providers: each must reference `DiscoveryEnvelope` or the helper AND use the declared `ScanMode`. Guards against drift where a SaaS provider gets quietly reclassed as `cloud_read_only`.

## Validation
- `pytest tests/test_discovery_envelope.py tests/test_cloud.py tests/test_cloud_aws.py tests/test_cloud_origin_contract.py tests/test_cloud_package_purls.py tests/test_cloud_nebius.py tests/test_cloud_ollama.py tests/test_cloud_model_provenance.py` → **215 passed**
- `ruff check` clean (post-format)
- `mypy src/agent_bom/discovery_envelope.py` clean

## Roadmap (after this PR)

- **PR C** — UI surface on the agent detail view; `/v1/agents` and `/v1/discovery/providers` API responses include the envelope.
- **PR D** — cross-provider redaction + least-privilege test matrix verifying every provider's `permissions_used` actually matches the API calls it issues (mocked).