### PR TITLE
feat(discovery): envelope API surface + dashboard card

### DIFF
--- a/docs/DISCOVERY_ENVELOPE.md
+++ b/docs/DISCOVERY_ENVELOPE.md
@@ -107,11 +107,37 @@ The envelope is stored on `Agent.discovery_envelope` as a plain dict so the
 model stays JSON-friendly without dragging the dataclass into the import
 path. Consumers can re-hydrate via `DiscoveryEnvelope.from_dict(...)`.
 
+## API + UI surface (PR C)
+
+The envelope rides through the existing `/v1/agents` + `/v1/agents/{name}`
+endpoints — `_serialize_agent` calls `asdict(agent)` and the envelope is a
+plain dict on the dataclass, so no shape transformation is needed.
+TypeScript types in `ui/lib/api-types.ts` carry the canonical
+`DiscoveryEnvelope` interface.
+
+The agents page renders a `DiscoveryEnvelopeCard` on each agent's expanded
+detail view (mounted only when the envelope is present). The card shows:
+
+- a clear data-residency note ("scan ran inside your environment with
+  read-only roles, no findings are sent to agent-bom") so operators
+  understand the trust posture without reading docs,
+- `scan_mode` + `redaction_status` chips,
+- the `discovery_scope` list as compact mono-styled tags,
+- the `permissions_used` list collapsed by default with a `<details>`
+  summary showing the count,
+- the `captured_at` timestamp + envelope version in the footer.
+
+Visual style mirrors the existing `DiscoveryProvenanceTags` block (same
+border-radius, same chip pattern) but in emerald to distinguish "trust
+contract for this scan" from "where this asset came from" (the sky-blue
+provenance card).
+
 ## Roadmap
 
-- **PR A (this PR)** — schema + Agent model field + AWS producer + tests.
-- PR B — connector + endpoint parity (Snowflake, Databricks, GCP, Azure,
-  vector DBs, MLflow, W&B, …) all populate the envelope.
-- PR C — UI surface on the agent / source detail view; `/v1/agents` and
-  `/v1/discovery/providers` API responses include the envelope.
-- PR D — cross-provider redaction + least-privilege test matrix.
+- **PR A (merged)** — schema + Agent model field + AWS producer + tests.
+- **PR B (merging)** — provider parity: every cloud / SaaS / local provider
+  populates the envelope.
+- **PR C (this PR)** — API + UI surface; envelope visible in the dashboard.
+- **PR D** — cross-provider redaction + least-privilege test matrix
+  verifying every provider's `permissions_used` actually matches the API
+  calls it issues.

--- a/tests/test_discovery_envelope.py
+++ b/tests/test_discovery_envelope.py
@@ -254,3 +254,48 @@ def test_provider_imports_envelope_and_attach_helper(module_path, expected_mode)
         f"{module_path} must reference DiscoveryEnvelope or attach_envelope_to_agents"
     )
     assert f"ScanMode.{expected_mode.name}" in src, f"{module_path} should use ScanMode.{expected_mode.name}"
+
+
+# ─── PR C: API surface ─────────────────────────────────────────────────
+
+
+def test_serialize_agent_includes_envelope_in_api_payload() -> None:
+    """The /v1/agents API serialiser is `_serialize_agent`, which calls
+    `asdict(agent)`. The envelope is a plain dict on the dataclass so it
+    flows through automatically -- this test guards against a future
+    refactor that drops it.
+    """
+    from agent_bom.api.routes.discovery import _serialize_agent
+
+    envelope = DiscoveryEnvelope(
+        scan_mode=ScanMode.CLOUD_READ_ONLY,
+        discovery_scope=("aws:account/123",),
+        permissions_used=("ec2:DescribeInstances",),
+        redaction_status=RedactionStatus.CENTRAL_SANITIZER_APPLIED,
+    )
+    agent = Agent(
+        name="bedrock-agent-1",
+        agent_type=AgentType.CUSTOM,
+        config_path="arn:aws:bedrock:...",
+        source="aws-bedrock",
+        discovery_envelope=envelope.to_dict(),
+    )
+    payload = _serialize_agent(agent)
+    assert "discovery_envelope" in payload
+    assert payload["discovery_envelope"]["scan_mode"] == "cloud_read_only"
+    assert payload["discovery_envelope"]["envelope_version"] == ENVELOPE_SCHEMA_VERSION
+    assert payload["discovery_envelope"]["permissions_used"] == ["ec2:DescribeInstances"]
+
+
+def test_serialize_agent_legacy_record_envelope_is_none() -> None:
+    """Legacy Agent records (created before #2083) carry no envelope; the
+    API surface reports `None` rather than fabricating one."""
+    from agent_bom.api.routes.discovery import _serialize_agent
+
+    agent = Agent(
+        name="legacy",
+        agent_type=AgentType.CLAUDE_DESKTOP,
+        config_path="/tmp/legacy",
+    )
+    payload = _serialize_agent(agent)
+    assert payload.get("discovery_envelope") is None

--- a/ui/app/agents/page.tsx
+++ b/ui/app/agents/page.tsx
@@ -9,6 +9,7 @@ import {
   Agent,
   isConfigured,
   type AgentDetailResponse,
+  type DiscoveryEnvelope,
   type DiscoveryProvenance,
   type AgentLifecycleResponse,
   type AttackFlowNodeData,
@@ -455,6 +456,9 @@ function AgentsList() {
                       )}
                     </div>
                   </div>
+                ) : null}
+                {agent.discovery_envelope ? (
+                  <DiscoveryEnvelopeCard envelope={agent.discovery_envelope} />
                 ) : null}
                 {agent.mcp_servers?.map((srv, j) => (
                   <div key={j} className="bg-zinc-800 border border-zinc-700 rounded-lg p-3">
@@ -1418,5 +1422,81 @@ export default function AgentsPage() {
     <Suspense fallback={<div className="flex items-center justify-center min-h-screen"><Loader2 className="w-8 h-8 animate-spin text-zinc-500" /></div>}>
       <AgentsRouter />
     </Suspense>
+  );
+}
+
+// ─── Discovery envelope card (#2083 PR C) ─────────────────────────────────
+
+const SCAN_MODE_LABEL: Record<string, string> = {
+  local_only: "local only",
+  cloud_read_only: "cloud read-only",
+  saas_read_only: "SaaS read-only",
+  runtime_probe: "runtime probe",
+  container_local: "container (local)",
+  endpoint_push: "endpoint push",
+};
+
+const REDACTION_LABEL: Record<string, string> = {
+  never_collected: "never collected",
+  redacted_in_place: "redacted in place",
+  central_sanitizer_applied: "central sanitizer",
+  not_applicable: "n/a",
+};
+
+function DiscoveryEnvelopeCard({ envelope }: { envelope: DiscoveryEnvelope }) {
+  const captured = envelope.captured_at
+    ? new Date(envelope.captured_at).toLocaleString()
+    : null;
+  const mode = SCAN_MODE_LABEL[envelope.scan_mode] ?? envelope.scan_mode;
+  const redaction = REDACTION_LABEL[envelope.redaction_status] ?? envelope.redaction_status;
+  return (
+    <div className="rounded-lg border border-emerald-900/60 bg-emerald-950/20 p-3">
+      <div className="mb-2 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-300">
+        <Shield className="h-3.5 w-3.5" />
+        Scan trust contract
+      </div>
+      <p className="mb-2 text-[11px] text-emerald-200/80">
+        Scan ran inside your environment with read-only roles. No findings, inventory, or credentials are sent to agent-bom — everything stays in your deployment.
+      </p>
+      <div className="mb-2 flex flex-wrap gap-1.5">
+        <span className="rounded border border-emerald-800 bg-emerald-950/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-emerald-300">
+          {mode}
+        </span>
+        <span className="rounded border border-zinc-700 bg-zinc-900/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-zinc-300">
+          redaction: {redaction}
+        </span>
+      </div>
+      {envelope.discovery_scope.length > 0 && (
+        <div className="mt-2 text-[11px] text-zinc-400">
+          <div className="mb-1 text-[10px] uppercase tracking-[0.14em] text-zinc-500">Scope</div>
+          <div className="flex flex-wrap gap-1.5">
+            {envelope.discovery_scope.map((s) => (
+              <span key={s} className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-0.5 font-mono text-zinc-300">
+                {s}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+      {envelope.permissions_used.length > 0 && (
+        <details className="mt-2 text-[11px] text-zinc-400">
+          <summary className="cursor-pointer text-[10px] uppercase tracking-[0.14em] text-zinc-500 hover:text-zinc-300">
+            Permissions used ({envelope.permissions_used.length})
+          </summary>
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {envelope.permissions_used.map((p) => (
+              <span key={p} className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-0.5 font-mono text-zinc-300">
+                {p}
+              </span>
+            ))}
+          </div>
+        </details>
+      )}
+      {captured && (
+        <div className="mt-2 text-[10px] text-zinc-500">
+          Captured {captured} · envelope v{envelope.envelope_version}
+        </div>
+      )}
+    </div>
   );
 }

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -230,8 +230,21 @@ export interface Agent {
   last_seen?: string | undefined;
   metadata?: Record<string, unknown> | undefined;
   discovery_provenance?: DiscoveryProvenance | undefined;
+  // Per-run discovery envelope (#2083). Trust contract for the scan run that
+  // produced this Agent record: scan_mode, discovery_scope, permissions_used,
+  // redaction_status. Optional because legacy records pre-envelope don't carry it.
+  discovery_envelope?: DiscoveryEnvelope | null | undefined;
   mcp_servers: MCPServer[];
   automation_settings?: string[] | undefined;
+}
+
+export interface DiscoveryEnvelope {
+  envelope_version: number;
+  scan_mode: string;
+  discovery_scope: string[];
+  permissions_used: string[];
+  redaction_status: string;
+  captured_at: string;
 }
 
 export interface MCPServer {

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -105,6 +105,7 @@ export type {
   MCPServer,
   MCPProvenance,
   DiscoveryProvenance,
+  DiscoveryEnvelope,
   Package,
   Vulnerability,
   BlastRadius,


### PR DESCRIPTION
PR C of the #2083 series — surface phase. Surfaces the per-run discovery envelope through the existing `/v1/agents` API + a new dashboard card on the agent detail view.

## What lands here

| Layer | Change |
|---|---|
| Backend test | `_serialize_agent` already flows the envelope through `asdict()` — added two tests to pin the contract end-to-end (envelope preserved + legacy records report null, never fabricated). |
| TS types (`ui/lib/api-types.ts`) | New `DiscoveryEnvelope` interface + `Agent.discovery_envelope?` field, re-exported from `@/lib/api`. |
| UI card (`ui/app/agents/page.tsx`) | New `DiscoveryEnvelopeCard` mounted on each agent's expanded detail view when the envelope is present. |
| Docs (`docs/DISCOVERY_ENVELOPE.md`) | New "API + UI surface" section + roadmap update. |

## What the card shows

The envelope card leads with a **data-residency note** that calls out the agent-bom trust posture explicitly:

> Scan ran inside your environment with read-only roles. No findings, inventory, or credentials are sent to agent-bom — everything stays in your deployment.

This is the trust differentiator vs. legacy SaaS scanners (Snyk / Wiz / Orca / etc. that ship findings to a vendor multi-tenant cloud). Buried-in-docs trust claims don't survive procurement; surfacing it on every scan card does.

Below the note:
- `scan_mode` chip (with friendly labels — `cloud_read_only` → "cloud read-only", `saas_read_only` → "SaaS read-only", etc.)
- `redaction_status` chip
- `discovery_scope` list as compact mono tags
- `permissions_used` list collapsed in `<details>` (the audit shows the action count up front, click to expand)
- `captured_at` timestamp + envelope version footer

Visual style mirrors `DiscoveryProvenanceTags` but in emerald to distinguish "trust contract for this scan" from "where this asset came from" (sky-blue provenance card).

## Validation
- `pytest tests/test_discovery_envelope.py` → **14 passed**
- `tsc --noEmit` (UI) clean
- `ruff check` clean

## Stacking

Branched from main (post PR A merge). Independent of PR B (#2193) — different file scopes, no expected conflict.

## Roadmap

- ✅ PR A (#2192 merged) — schema + Agent field + AWS producer
- 🔄 PR B (#2193 merging) — 11 more providers populate the envelope
- ✅ PR C (this PR) — API + UI surface
- PR D — cross-provider redaction + least-privilege test matrix locking the contract