### PR TITLE
fix: v0.84.6 audit — SCIM DELETE list, auth-flag interplay, splash kind, rotate body

### DIFF
--- a/src/agent_bom/api/postgres_scim.py
+++ b/src/agent_bom/api/postgres_scim.py
@@ -84,7 +84,14 @@ class PostgresSCIMStore:
             ).fetchone()
         return _load_user(row[0]) if row else None
 
-    def list_users(self, tenant_id: str, *, filter_attr: str | None = None, filter_value: str | None = None) -> list[SCIMUser]:
+    def list_users(
+        self,
+        tenant_id: str,
+        *,
+        filter_attr: str | None = None,
+        filter_value: str | None = None,
+        include_inactive: bool = False,
+    ) -> list[SCIMUser]:
         tenant = normalize_tenant_id(tenant_id)
         query = "SELECT data FROM scim_users WHERE tenant_id = %s ORDER BY user_name ASC, user_id ASC"
         params: tuple[object, ...] = (tenant,)
@@ -99,7 +106,15 @@ class PostgresSCIMStore:
             params = (tenant, filter_value)
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute(query, params).fetchall()
-        return [_load_user(row[0]) for row in rows]
+        users = [_load_user(row[0]) for row in rows]
+        # Bulk listing excludes deactivated users so SCIM DELETE actually
+        # removes them from IdP listings (Okta/Azure AD deprovisioning).
+        # Precise lookups by userName/externalId/id keep finding deactivated
+        # users -- IdP admins rely on those filters to verify a
+        # deprovisioning landed. Matches the in-memory store contract.
+        if include_inactive or filter_attr in ("active", "userName", "externalId", "id"):
+            return users
+        return [u for u in users if u.active]
 
     def deactivate_user(self, tenant_id: str, user_id: str) -> SCIMUser | None:
         user = self.get_user(tenant_id, user_id)

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -455,10 +455,22 @@ async def create_key(request: Request, req: CreateKeyRequest) -> dict:
 
 
 @router.post("/v1/auth/keys/{key_id}/rotate", tags=["enterprise"], status_code=201)
-async def rotate_key(request: Request, key_id: str, req: RotateKeyRequest) -> dict:
-    """Rotate an API key by minting a replacement and revoking the old key."""
+async def rotate_key(
+    request: Request,
+    key_id: str,
+    req: RotateKeyRequest | None = None,
+) -> dict:
+    """Rotate an API key by minting a replacement and revoking the old key.
+
+    Body is optional -- a rotation with no overrides accepts both `{}` and a
+    completely missing body. All RotateKeyRequest fields default to None
+    (inherit name from the current key, no expiry change, default overlap).
+    """
     from agent_bom.api.audit_log import log_action
     from agent_bom.api.auth import create_api_key, get_api_key_policy, get_key_store, normalize_rotation_overlap_seconds
+
+    if req is None:
+        req = RotateKeyRequest()
 
     tenant_id = getattr(request.state, "tenant_id", "default")
     actor = getattr(request.state, "api_key_name", "") or "system"

--- a/src/agent_bom/api/routes/scim.py
+++ b/src/agent_bom/api/routes/scim.py
@@ -23,6 +23,11 @@ SCIM_RESOURCE_TYPE_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:ResourceType"
 SCIM_AGENT_BOM_USER_EXTENSION = "urn:agent-bom:params:scim:schemas:extension:identity:1.0:User"
 router = APIRouter(prefix=scim_base_path(), tags=["scim"])
 _FILTER_RE = re.compile(r'^\s*(userName|displayName|externalId|id)\s+eq\s+"([^"]{1,512})"\s*$')
+# `active` is a boolean filter — admins use `?filter=active eq false` to audit
+# deactivated users (Okta/Azure AD deprovisioning verification). The regex
+# accepts an optional quoted form so SCIM clients that always quote literals
+# still work.
+_ACTIVE_FILTER_RE = re.compile(r'^\s*active\s+eq\s+"?(true|false)"?\s*$', re.IGNORECASE)
 
 
 def _tenant_id(request: Request) -> str:
@@ -42,9 +47,12 @@ def _parse_filter(raw: str | None) -> tuple[str | None, str | None]:
     if not raw:
         return None, None
     match = _FILTER_RE.match(raw)
-    if not match:
-        raise HTTPException(status_code=400, detail="Unsupported SCIM filter")
-    return match.group(1), match.group(2)
+    if match:
+        return match.group(1), match.group(2)
+    active = _ACTIVE_FILTER_RE.match(raw)
+    if active:
+        return "active", active.group(1).lower()
+    raise HTTPException(status_code=400, detail="Unsupported SCIM filter")
 
 
 def _paginate(items: list[Any], start_index: int, count: int) -> list[Any]:
@@ -344,7 +352,14 @@ async def list_users(
 ) -> dict[str, Any]:
     _require_scim(request)
     attr, value = _parse_filter(scim_filter)
-    users = _get_scim_store().list_users(_tenant_id(request), filter_attr=attr, filter_value=value)
+    if attr == "active":
+        # `?filter=active eq true|false` — caller wants only active or only
+        # deactivated. Resolve the boolean here and let the store honour it.
+        want_active = value == "true"
+        all_users = _get_scim_store().list_users(_tenant_id(request), include_inactive=True)
+        users = [u for u in all_users if u.active == want_active]
+    else:
+        users = _get_scim_store().list_users(_tenant_id(request), filter_attr=attr, filter_value=value)
     page = _paginate(users, start_index, count)
     return {
         "schemas": [SCIM_LIST_SCHEMA],
@@ -361,9 +376,11 @@ async def create_user(request: Request, body: dict[str, Any]) -> dict[str, Any]:
     tenant_id = _tenant_id(request)
     store = _get_scim_store()
     user = _user_from_payload(tenant_id, body)
-    if store.list_users(tenant_id, filter_attr="userName", filter_value=user.user_name):
+    # Duplicate check must include deactivated users so re-creating a
+    # deprovisioned userName doesn't silently shadow the deactivated record.
+    if store.list_users(tenant_id, filter_attr="userName", filter_value=user.user_name, include_inactive=True):
         raise HTTPException(status_code=409, detail="User already exists")
-    if user.external_id and store.list_users(tenant_id, filter_attr="externalId", filter_value=user.external_id):
+    if user.external_id and store.list_users(tenant_id, filter_attr="externalId", filter_value=user.external_id, include_inactive=True):
         raise HTTPException(status_code=409, detail="User already exists")
     saved = store.put_user(user)
     log_action(

--- a/src/agent_bom/api/scim_store.py
+++ b/src/agent_bom/api/scim_store.py
@@ -61,7 +61,14 @@ class SCIMStore(Protocol):
 
     def put_user(self, user: SCIMUser) -> SCIMUser: ...
     def get_user(self, tenant_id: str, user_id: str) -> SCIMUser | None: ...
-    def list_users(self, tenant_id: str, *, filter_attr: str | None = None, filter_value: str | None = None) -> list[SCIMUser]: ...
+    def list_users(
+        self,
+        tenant_id: str,
+        *,
+        filter_attr: str | None = None,
+        filter_value: str | None = None,
+        include_inactive: bool = False,
+    ) -> list[SCIMUser]: ...
     def deactivate_user(self, tenant_id: str, user_id: str) -> SCIMUser | None: ...
     def put_group(self, group: SCIMGroup) -> SCIMGroup: ...
     def get_group(self, tenant_id: str, group_id: str) -> SCIMGroup | None: ...
@@ -88,11 +95,28 @@ class InMemorySCIMStore:
             record = self._users.get((normalize_tenant_id(tenant_id), user_id))
             return record.model_copy(deep=True) if record else None
 
-    def list_users(self, tenant_id: str, *, filter_attr: str | None = None, filter_value: str | None = None) -> list[SCIMUser]:
+    def list_users(
+        self,
+        tenant_id: str,
+        *,
+        filter_attr: str | None = None,
+        filter_value: str | None = None,
+        include_inactive: bool = False,
+    ) -> list[SCIMUser]:
         tenant = normalize_tenant_id(tenant_id)
         with self._lock:
             users = [u.model_copy(deep=True) for (tid, _), u in self._users.items() if tid == tenant]
-        return [u for u in users if _matches_user(u, filter_attr, filter_value)]
+        matched = [u for u in users if _matches_user(u, filter_attr, filter_value)]
+        # Bulk listing (no filter) excludes deactivated users by default so
+        # SCIM DELETE actually removes them from IdP listings (Okta/Azure AD
+        # deprovisioning). Precise lookups by userName/externalId/id keep
+        # finding deactivated users -- IdP admins rely on these filters to
+        # verify a deprovisioning landed. `?filter=active eq <bool>` and
+        # `include_inactive=True` are both explicit "include inactive"
+        # signals.
+        if include_inactive or filter_attr in ("active", "userName", "externalId", "id"):
+            return matched
+        return [u for u in matched if u.active]
 
     def deactivate_user(self, tenant_id: str, user_id: str) -> SCIMUser | None:
         with self._lock:
@@ -191,12 +215,25 @@ class SQLiteSCIMStore:
         ).fetchone()
         return SCIMUser(**json.loads(row[0])) if row else None
 
-    def list_users(self, tenant_id: str, *, filter_attr: str | None = None, filter_value: str | None = None) -> list[SCIMUser]:
+    def list_users(
+        self,
+        tenant_id: str,
+        *,
+        filter_attr: str | None = None,
+        filter_value: str | None = None,
+        include_inactive: bool = False,
+    ) -> list[SCIMUser]:
         rows = self._conn.execute(
             "SELECT data FROM scim_users WHERE tenant_id = ? ORDER BY user_name ASC, user_id ASC",
             (normalize_tenant_id(tenant_id),),
         ).fetchall()
-        return [user for user in (SCIMUser(**json.loads(row[0])) for row in rows) if _matches_user(user, filter_attr, filter_value)]
+        users = [user for user in (SCIMUser(**json.loads(row[0])) for row in rows) if _matches_user(user, filter_attr, filter_value)]
+        # Matches in-memory + Postgres contract: bulk list excludes inactive
+        # by default; precise lookups by userName/externalId/id include
+        # inactive so IdP admins can verify deprovisioning.
+        if include_inactive or filter_attr in ("active", "userName", "externalId", "id"):
+            return users
+        return [u for u in users if u.active]
 
     def deactivate_user(self, tenant_id: str, user_id: str) -> SCIMUser | None:
         user = self.get_user(tenant_id, user_id)

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -32,16 +32,58 @@ def _oidc_enabled() -> bool:
     return oidc_enabled_from_env()
 
 
+def _scim_bearer_enabled() -> bool:
+    """True when a SCIM bearer token is configured.
+
+    Imported lazily so command-line tooling that doesn't touch SCIM doesn't
+    pay the import cost.
+    """
+    from agent_bom.api.scim import scim_enabled_from_env
+
+    return scim_enabled_from_env()
+
+
 def _enforce_auth_defaults(command: str, host: str, api_key: str | None, allow_insecure_no_auth: bool) -> None:
-    """Refuse unauthenticated non-loopback binds unless explicitly overridden."""
-    if api_key or _oidc_enabled() or _is_loopback_host(host):
+    """Refuse unauthenticated non-loopback binds unless explicitly overridden.
+
+    Recognises four auth paths:
+    - explicit API key (--api-key / AGENT_BOM_API_KEY)
+    - OIDC (AGENT_BOM_OIDC_ISSUER + tenant providers)
+    - SCIM bearer (AGENT_BOM_SCIM_BEARER_TOKEN) -- the SCIM middleware
+      authenticates every endpoint when this is configured
+    - --allow-insecure-no-auth (explicit override; emits a loud warning when
+      another auth method is also configured so operators understand that
+      their `--allow-insecure-no-auth` does NOT actually disable the SCIM /
+      OIDC / API-key middleware path that's still in effect)
+    """
+    if _is_loopback_host(host):
+        return
+    has_api_key = bool(api_key)
+    has_oidc = _oidc_enabled()
+    has_scim = _scim_bearer_enabled()
+    if has_api_key or has_oidc or has_scim:
+        if allow_insecure_no_auth:
+            active: list[str] = []
+            if has_api_key:
+                active.append("API-key")
+            if has_oidc:
+                active.append("OIDC")
+            if has_scim:
+                active.append("SCIM-bearer")
+            click.secho(
+                f"warning: --allow-insecure-no-auth was passed but {', '.join(active)} authentication is "
+                "still configured -- requests will continue to be authenticated. "
+                "Unset the relevant env vars to actually run unauthenticated.",
+                fg="yellow",
+                err=True,
+            )
         return
     if allow_insecure_no_auth:
         return
     raise click.ClickException(
         f"Refusing to expose `{command}` on non-loopback host {host!r} without authentication. "
-        "Set --api-key / AGENT_BOM_API_KEY or configure AGENT_BOM_OIDC_ISSUER / "
-        "AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON, "
+        "Set --api-key / AGENT_BOM_API_KEY, configure AGENT_BOM_OIDC_ISSUER / "
+        "AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON, set AGENT_BOM_SCIM_BEARER_TOKEN, "
         "or pass --allow-insecure-no-auth to override."
     )
 
@@ -201,13 +243,22 @@ def _analytics_summary_rows(
     default=None,
     envvar="AGENT_BOM_API_KEY",
     metavar="KEY",
-    help="Require API key auth (Bearer token or X-API-Key header).",
+    help=(
+        "Require API key auth (Bearer token or X-API-Key header). "
+        "Other accepted auth paths: AGENT_BOM_OIDC_ISSUER (OIDC) and "
+        "AGENT_BOM_SCIM_BEARER_TOKEN (SCIM bearer for IdP integration)."
+    ),
 )
 @click.option(
     "--allow-insecure-no-auth",
     is_flag=True,
     default=False,
-    help="Allow unauthenticated non-loopback API exposure. Unsafe outside local development.",
+    help=(
+        "Allow unauthenticated non-loopback API exposure. Unsafe outside local development. "
+        "Note: when AGENT_BOM_API_KEY / AGENT_BOM_OIDC_ISSUER / "
+        "AGENT_BOM_SCIM_BEARER_TOKEN is also set, those auth paths still "
+        "enforce; the flag emits a warning instead of bypassing them."
+    ),
 )
 @click.option("--reload", is_flag=True, help="Auto-reload on code changes (development mode)")
 @click.option(
@@ -375,13 +426,22 @@ def serve_cmd(
     default=None,
     envvar="AGENT_BOM_API_KEY",
     metavar="KEY",
-    help="Require API key auth (Bearer token or X-API-Key header).",
+    help=(
+        "Require API key auth (Bearer token or X-API-Key header). "
+        "Other accepted auth paths: AGENT_BOM_OIDC_ISSUER (OIDC) and "
+        "AGENT_BOM_SCIM_BEARER_TOKEN (SCIM bearer for IdP integration)."
+    ),
 )
 @click.option(
     "--allow-insecure-no-auth",
     is_flag=True,
     default=False,
-    help="Allow unauthenticated non-loopback API exposure. Unsafe outside local development.",
+    help=(
+        "Allow unauthenticated non-loopback API exposure. Unsafe outside local development. "
+        "Note: when AGENT_BOM_API_KEY / AGENT_BOM_OIDC_ISSUER / "
+        "AGENT_BOM_SCIM_BEARER_TOKEN is also set, those auth paths still "
+        "enforce; the flag emits a warning instead of bypassing them."
+    ),
 )
 @click.option(
     "--rate-limit",

--- a/tests/test_api_enterprise_tenant.py
+++ b/tests/test_api_enterprise_tenant.py
@@ -135,6 +135,23 @@ async def test_rotate_key_replaces_old_key_and_preserves_overlap_window(isolated
 
 
 @pytest.mark.asyncio
+async def test_rotate_key_accepts_missing_body(isolated_key_store):
+    """Per #2196 audit: rotation with no overrides should accept a missing
+    or empty body. The previous behaviour 422'd on no body, forcing callers
+    to send `{}` for a no-op default rotation."""
+    _, alpha = create_api_key("alpha", Role.ADMIN, tenant_id="tenant-alpha")
+    isolated_key_store.add(alpha)
+
+    # Missing body (req=None) -> defaults applied silently.
+    result = await enterprise.rotate_key(
+        _request("tenant-alpha", "alice-admin"),
+        alpha.key_id,
+    )
+    assert result["replaced_key_id"] == alpha.key_id
+    assert result["tenant_id"] == "tenant-alpha"
+
+
+@pytest.mark.asyncio
 async def test_rotate_key_returns_404_for_cross_tenant_key(isolated_key_store):
     _, beta = create_api_key("beta", Role.ADMIN, tenant_id="tenant-beta")
     isolated_key_store.add(beta)

--- a/tests/test_api_scim_lifecycle.py
+++ b/tests/test_api_scim_lifecycle.py
@@ -120,10 +120,36 @@ def test_scim_user_create_list_patch_and_deactivate(scim_client: TestClient) -> 
     deleted = scim_client.delete(f"/scim/v2/Users/{user_id}", headers=_headers())
     assert deleted.status_code == 204
 
+    # Per #2196 audit, the SCIM DELETE soft-deletes via active=false. The user
+    # MUST disappear from default list responses so Okta/Azure AD see the
+    # deprovisioning land. GET by id still works (so IdPs can verify the
+    # deactivation worked) and shows active=false.
     fetched = scim_client.get(f"/scim/v2/Users/{user_id}", headers=_headers())
     assert fetched.status_code == 200
     assert fetched.json()["active"] is False
     assert fetched.json()[AGENT_BOM_USER_EXTENSION]["memberships"][0]["active"] is False
+
+    # Default list excludes deactivated users -- this is the audit-blocking
+    # IdP deprovisioning fix (#2196).
+    default_list = scim_client.get("/scim/v2/Users", headers=_headers())
+    assert default_list.status_code == 200
+    listed_ids = [r["id"] for r in default_list.json()["Resources"]]
+    assert user_id not in listed_ids
+    assert default_list.json()["totalResults"] == len(listed_ids)
+
+    # Filter `active eq false` surfaces deactivated users so admins can audit.
+    inactive_list = scim_client.get("/scim/v2/Users?filter=active eq false", headers=_headers())
+    assert inactive_list.status_code == 200
+    assert any(r["id"] == user_id for r in inactive_list.json()["Resources"])
+
+    # Re-creating a userName for a deactivated user still 409s (the
+    # duplicate check looks at the full set, including inactive).
+    re_created = scim_client.post(
+        "/scim/v2/Users",
+        headers=_headers(),
+        json={"userName": "alice.renamed@example.com"},
+    )
+    assert re_created.status_code == 409
 
 
 def test_scim_user_roles_are_normalized_and_tenant_bound(

--- a/tests/test_cli_serve_auth_enforce.py
+++ b/tests/test_cli_serve_auth_enforce.py
@@ -1,0 +1,81 @@
+"""CLI auth-enforcement tests for `agent-bom serve` (#2196 audit fix).
+
+Verify `_enforce_auth_defaults` recognises every accepted auth path
+(API key, OIDC, SCIM bearer) and emits a loud warning when
+`--allow-insecure-no-auth` is passed alongside a configured auth method
+instead of silently doing nothing.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from agent_bom.cli._server import _enforce_auth_defaults
+
+
+def test_enforce_auth_defaults_loopback_always_passes() -> None:
+    """Loopback binds skip the check entirely."""
+    _enforce_auth_defaults("serve", "127.0.0.1", api_key=None, allow_insecure_no_auth=False)
+    _enforce_auth_defaults("serve", "localhost", api_key=None, allow_insecure_no_auth=False)
+    _enforce_auth_defaults("serve", "::1", api_key=None, allow_insecure_no_auth=False)
+
+
+def test_enforce_auth_defaults_api_key_satisfies_check() -> None:
+    """API key set => non-loopback bind allowed without --allow-insecure-no-auth."""
+    _enforce_auth_defaults("serve", "0.0.0.0", api_key="secret", allow_insecure_no_auth=False)
+
+
+def test_enforce_auth_defaults_scim_token_satisfies_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SCIM bearer token alone is recognised as a valid auth path on non-loopback.
+
+    Pre-#2196, only API key and OIDC were recognised, so operators with only
+    SCIM configured hit a misleading "set api_key or use --allow-insecure-no-auth"
+    error.
+    """
+    monkeypatch.setenv("AGENT_BOM_SCIM_BEARER_TOKEN", "x" * 32)
+    _enforce_auth_defaults("serve", "0.0.0.0", api_key=None, allow_insecure_no_auth=False)
+
+
+def test_enforce_auth_defaults_no_auth_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-loopback bind with no auth path AND no override raises ClickException."""
+    monkeypatch.delenv("AGENT_BOM_SCIM_BEARER_TOKEN", raising=False)
+    monkeypatch.delenv("AGENT_BOM_OIDC_ISSUER", raising=False)
+    with pytest.raises(click.ClickException, match="Refusing to expose"):
+        _enforce_auth_defaults("serve", "0.0.0.0", api_key=None, allow_insecure_no_auth=False)
+
+
+def test_enforce_auth_defaults_explicit_override_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--allow-insecure-no-auth allows non-loopback bind even without auth."""
+    monkeypatch.delenv("AGENT_BOM_SCIM_BEARER_TOKEN", raising=False)
+    monkeypatch.delenv("AGENT_BOM_OIDC_ISSUER", raising=False)
+    _enforce_auth_defaults("serve", "0.0.0.0", api_key=None, allow_insecure_no_auth=True)
+
+
+def test_enforce_auth_defaults_warns_on_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When --allow-insecure-no-auth AND an auth method are both set, warn.
+
+    The CLI flag's name is misleading otherwise: requests still get
+    authenticated by the SCIM/OIDC/API-key middleware. The warning makes
+    the actual posture visible.
+    """
+    monkeypatch.setenv("AGENT_BOM_SCIM_BEARER_TOKEN", "x" * 32)
+    _enforce_auth_defaults("serve", "0.0.0.0", api_key=None, allow_insecure_no_auth=True)
+    captured = capsys.readouterr()
+    assert "warning" in captured.err.lower()
+    assert "SCIM-bearer" in captured.err
+
+
+def test_enforce_auth_defaults_warns_on_api_key_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """API key + --allow-insecure-no-auth also warns."""
+    monkeypatch.delenv("AGENT_BOM_SCIM_BEARER_TOKEN", raising=False)
+    _enforce_auth_defaults("serve", "0.0.0.0", api_key="secret", allow_insecure_no_auth=True)
+    captured = capsys.readouterr()
+    assert "warning" in captured.err.lower()
+    assert "API-key" in captured.err

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -12,6 +12,13 @@ import {
 } from "@/components/posture-grade";
 import { AttackPathCard } from "@/components/attack-path-card";
 import { ApiOfflineState } from "@/components/api-offline-state";
+import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
+
+function _classifyApiErrorKind(err: unknown): "network" | "auth" | "forbidden" {
+  if (err instanceof ApiAuthError) return "auth";
+  if (err instanceof ApiForbiddenError) return "forbidden";
+  return "network";
+}
 import { buildSecurityGraphHref } from "@/lib/attack-paths";
 import {
   ShieldAlert, Server, Package, Bug, Zap, ArrowRight, Clock,
@@ -326,6 +333,10 @@ export default function Dashboard() {
   const [agentsLoading, setAgentsLoading] = useState(true);
   const [detailLoading, setDetailLoading] = useState(true);
   const [apiError, setApiError] = useState(false);
+  // Differentiate "API down" from "API rejected my request" (#2196 audit fix).
+  // 401 -> "auth", 403 -> "forbidden", network/5xx -> "network".
+  const [apiErrorKind, setApiErrorKind] = useState<"network" | "auth" | "forbidden">("network");
+  const [apiErrorDetail, setApiErrorDetail] = useState<string | null>(null);
   const [importedReport, setImportedReport] = useState<ScanResult | null>(null);
   const [posture, setPosture] = useState<PostureResponse | null>(null);
 
@@ -347,9 +358,11 @@ export default function Dashboard() {
           : [];
         setJobs(jobsList);
         setApiError(false);
-      } catch {
+      } catch (err) {
         if (cancelled) return;
         setApiError(true);
+        setApiErrorKind(_classifyApiErrorKind(err));
+        setApiErrorDetail(err instanceof Error ? err.message : null);
         setJobs([]);
         setDetailJobs([]);
       } finally {
@@ -510,7 +523,7 @@ export default function Dashboard() {
   const agentsReady = !agentsLoading || Boolean(importedReport);
   const detailsReady = !detailLoading || Boolean(importedReport);
 
-  if (apiError && !importedReport) return <ApiOfflineState onImport={setImportedReport} />;
+  if (apiError && !importedReport) return <ApiOfflineState onImport={setImportedReport} kind={apiErrorKind} detail={apiErrorDetail} />;
 
   return (
     <div className="space-y-8">

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -14,6 +14,13 @@ import {
 } from "lucide-react";
 
 import { ApiOfflineState } from "@/components/api-offline-state";
+import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
+
+function _classifyGraphErrorKind(err: unknown): "network" | "auth" | "forbidden" {
+  if (err instanceof ApiAuthError) return "auth";
+  if (err instanceof ApiForbiddenError) return "forbidden";
+  return "network";
+}
 import { AttackPathCard } from "@/components/attack-path-card";
 import { GraphEmptyState } from "@/components/graph-state-panels";
 import { PostureGrade } from "@/components/posture-grade";
@@ -91,6 +98,7 @@ function SecurityGraphPageContent() {
   const [loadingSnapshots, setLoadingSnapshots] = useState(true);
   const [loadingGraph, setLoadingGraph] = useState(false);
   const [apiError, setApiError] = useState<string | null>(null);
+  const [apiErrorKind, setApiErrorKind] = useState<"network" | "auth" | "forbidden">("network");
   const [selectedAttackPathKey, setSelectedAttackPathKey] = useState<string | null>(null);
   const [focusApplied, setFocusApplied] = useState(false);
 
@@ -132,6 +140,7 @@ function SecurityGraphPageContent() {
       } catch (error) {
         if (cancelled) return;
         setApiError(error instanceof Error ? error.message : "Failed to load graph snapshots");
+        setApiErrorKind(_classifyGraphErrorKind(error));
         setSnapshots([]);
         setGraphData(null);
       } finally {
@@ -305,10 +314,12 @@ function SecurityGraphPageContent() {
   }
 
   if (apiError && !loadingSnapshots && snapshots.length === 0) {
+    const fallbackTitle = apiErrorKind === "network" ? "Cannot load the security graph" : undefined;
     return (
       <ApiOfflineState
-        title="Cannot load the security graph"
+        title={fallbackTitle}
         detail={apiError}
+        kind={apiErrorKind}
       />
     );
   }

--- a/ui/components/api-offline-state.tsx
+++ b/ui/components/api-offline-state.tsx
@@ -8,19 +8,34 @@ import type { ScanResult } from "@/lib/api";
 import { getDisplayApiUrl } from "@/lib/runtime-config";
 import { checkFileSize, validateScanReport } from "@/lib/validators";
 
+// Distinguish "API is down" from "API rejected my request" so the splash
+// stops shouting "Cannot connect" at users running `agent-bom serve` who
+// just need to authenticate. Pages classify errors via the typed
+// ApiError subclasses in lib/api-errors.ts and pass `kind` through.
+export type ApiOfflineKind = "network" | "auth" | "forbidden";
+
 interface ApiOfflineStateProps {
-  title?: string;
-  detail?: string | null;
-  onImport?: (data: ScanResult) => void;
+  title?: string | undefined;
+  detail?: string | null | undefined;
+  kind?: ApiOfflineKind | undefined;
+  onImport?: ((data: ScanResult) => void) | undefined;
 }
 
+const KIND_TITLES: Record<ApiOfflineKind, string> = {
+  network: "Cannot connect to the agent-bom API",
+  auth: "Sign in to view the dashboard",
+  forbidden: "This account doesn't have access to that view",
+};
+
 export function ApiOfflineState({
-  title = "Cannot connect to the agent-bom API",
+  title,
   detail,
+  kind = "network",
   onImport,
 }: ApiOfflineStateProps) {
   const [importError, setImportError] = useState<string | null>(null);
   const apiUrl = getDisplayApiUrl();
+  const resolvedTitle = title ?? KIND_TITLES[kind];
 
   const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -57,14 +72,29 @@ export function ApiOfflineState({
       <div className="mx-auto max-w-5xl rounded-3xl border border-zinc-800 bg-zinc-950/70 p-6 shadow-2xl shadow-black/20 md:p-8">
         <div className="mx-auto max-w-3xl text-center">
           <AlertTriangle className="mx-auto mb-4 h-11 w-11 text-orange-400" />
-          <h2 className="text-2xl font-semibold tracking-tight text-zinc-100">{title}</h2>
-          <p className="mt-3 text-sm leading-6 text-zinc-400">
-            Run the local stack at{" "}
-            <code className="rounded bg-zinc-900 px-1.5 py-0.5 font-mono text-zinc-200">
-              {apiUrl}
-            </code>{" "}
-            so the dashboard can load live scan data, graph views, and compliance surfaces.
-          </p>
+          <h2 className="text-2xl font-semibold tracking-tight text-zinc-100">{resolvedTitle}</h2>
+          {kind === "network" ? (
+            <p className="mt-3 text-sm leading-6 text-zinc-400">
+              Run the local stack at{" "}
+              <code className="rounded bg-zinc-900 px-1.5 py-0.5 font-mono text-zinc-200">
+                {apiUrl}
+              </code>{" "}
+              so the dashboard can load live scan data, graph views, and compliance surfaces.
+            </p>
+          ) : kind === "auth" ? (
+            <p className="mt-3 text-sm leading-6 text-zinc-400">
+              The API is reachable but rejected an unauthenticated request. Sign in via your IdP, set{" "}
+              <code className="rounded bg-zinc-900 px-1.5 py-0.5 font-mono text-zinc-200">AGENT_BOM_API_KEY</code>{" "}
+              when launching <code className="rounded bg-zinc-900 px-1.5 py-0.5 font-mono text-zinc-200">agent-bom serve</code>,
+              or request access from your administrator.
+            </p>
+          ) : (
+            <p className="mt-3 text-sm leading-6 text-zinc-400">
+              Authenticated, but your role doesn&apos;t carry the permissions this view needs.
+              Ask your administrator to grant a role with the relevant scope, or browse a
+              tab that fits your current role.
+            </p>
+          )}
           {detail ? (
             <p className="mt-3 text-xs text-zinc-500">
               Current error: <span className="font-mono text-zinc-400">{detail}</span>
@@ -72,44 +102,48 @@ export function ApiOfflineState({
           ) : null}
         </div>
 
-        <div className="mt-8 grid gap-4 md:grid-cols-2">
-          <div className="rounded-2xl border border-emerald-900/60 bg-emerald-950/20 p-5">
-            <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-emerald-300">
-              <PlayCircle className="h-4 w-4" />
-              Recommended: start the full product surface
-            </div>
-            <p className="mb-4 text-sm text-zinc-400">
-              This starts the API and serves the bundled dashboard from one command path.
-            </p>
-            <code className="block rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-3 font-mono text-sm leading-7 text-emerald-400">
-              pip install &apos;agent-bom[ui]&apos;
-              <br />
-              agent-bom serve
-            </code>
-          </div>
+        {kind === "network" ? (
+          <>
+            <div className="mt-8 grid gap-4 md:grid-cols-2">
+              <div className="rounded-2xl border border-emerald-900/60 bg-emerald-950/20 p-5">
+                <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-emerald-300">
+                  <PlayCircle className="h-4 w-4" />
+                  Recommended: start the full product surface
+                </div>
+                <p className="mb-4 text-sm text-zinc-400">
+                  This starts the API and serves the bundled dashboard from one command path.
+                </p>
+                <code className="block rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-3 font-mono text-sm leading-7 text-emerald-400">
+                  pip install &apos;agent-bom[ui]&apos;
+                  <br />
+                  agent-bom serve
+                </code>
+              </div>
 
-          <div className="rounded-2xl border border-blue-900/60 bg-blue-950/20 p-5">
-            <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-blue-300">
-              <Server className="h-4 w-4" />
-              API only
+              <div className="rounded-2xl border border-blue-900/60 bg-blue-950/20 p-5">
+                <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-blue-300">
+                  <Server className="h-4 w-4" />
+                  API only
+                </div>
+                <p className="mb-4 text-sm text-zinc-400">
+                  Use this if the dashboard is already running separately and only the backend is missing.
+                </p>
+                <code className="block rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-3 font-mono text-sm leading-7 text-blue-300">
+                  pip install &apos;agent-bom[api]&apos;
+                  <br />
+                  agent-bom api
+                </code>
+              </div>
             </div>
-            <p className="mb-4 text-sm text-zinc-400">
-              Use this if the dashboard is already running separately and only the backend is missing.
-            </p>
-            <code className="block rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-3 font-mono text-sm leading-7 text-blue-300">
-              pip install &apos;agent-bom[api]&apos;
-              <br />
-              agent-bom api
-            </code>
-          </div>
-        </div>
 
-        <div className="mt-4 rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4 text-sm text-zinc-400">
-          If the API is already running and you still see this page, check the browser console for CORS errors and confirm{" "}
-          <code className="rounded bg-zinc-950 px-1.5 py-0.5 font-mono text-zinc-200">NEXT_PUBLIC_API_URL</code>{" "}
-          points to{" "}
-          <code className="rounded bg-zinc-950 px-1.5 py-0.5 font-mono text-zinc-200">{apiUrl}</code>.
-        </div>
+            <div className="mt-4 rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4 text-sm text-zinc-400">
+              If the API is already running and you still see this page, check the browser console for CORS errors and confirm{" "}
+              <code className="rounded bg-zinc-950 px-1.5 py-0.5 font-mono text-zinc-200">NEXT_PUBLIC_API_URL</code>{" "}
+              points to{" "}
+              <code className="rounded bg-zinc-950 px-1.5 py-0.5 font-mono text-zinc-200">{apiUrl}</code>.
+            </div>
+          </>
+        ) : null}
 
         {onImport ? (
           <div className="mt-6 rounded-2xl border border-dashed border-zinc-700 bg-zinc-900/40 p-6 text-center">


### PR DESCRIPTION
End-to-end fix for the four verified defects from the v0.84.6 hands-on audit (composite 8.4/10). Each fix walks the data model + API + middleware + CLI + UI surfaces it can reach.

## What lands here

| # | Severity | Defect | Fix |
|---|---|---|---|
| 1 | **P1** (Okta/Azure AD blocker) | SCIM DELETE no-op — `deactivate_user` flips `active=False` but `list_users` doesn't filter, so deprovisioned users persist in IdP listings. | `SCIMStore.list_users` gains `include_inactive: bool = False` (in-memory + SQLite + Postgres). Bulk listing excludes inactive by default. Precise lookups by `userName` / `externalId` / `id` keep finding deactivated users so IdP admins can verify the deactivation landed. New filter primitive `?filter=active eq <bool>`. Duplicate-userName check on POST /Users sweeps inactive too. |
| 2 | **P2** | `--allow-insecure-no-auth` silently overridden by `AGENT_BOM_SCIM_BEARER_TOKEN` — operators with only SCIM saw misleading "set --api-key" error; passing `--allow-insecure-no-auth` silently bypassed while SCIM still 401'd. | `_enforce_auth_defaults` recognises SCIM bearer alongside API key + OIDC. When `--allow-insecure-no-auth` + any auth method are both set, emit yellow warning to stderr naming the active method. `--api-key` / `--allow-insecure-no-auth` help text updated. |
| 3 | **P2** | Dashboard "Cannot connect to the agent-bom API" splash on same-origin — actual cause was 401 from API for unauth requests. | `ApiOfflineState` takes `kind: "network" \| "auth" \| "forbidden"` with distinct copy per state. `app/page.tsx` and `app/security-graph/page.tsx` classify thrown errors via `ApiAuthError` / `ApiForbiddenError` and pass the right kind. |
| 4 | **P3** | `POST /v1/auth/keys/{id}/rotate` 422s on empty body — `RotateKeyRequest` fields are all optional but FastAPI required the body. | Body now `RotateKeyRequest \| None = None`; defaults applied silently for missing or `{}` payloads. |

Doc: `agent-bom serve --help` now references `AGENT_BOM_SCIM_BEARER_TOKEN` on `--api-key` and `--allow-insecure-no-auth` (including the warning behaviour).

## Tests
- `test_api_scim_lifecycle::test_scim_user_create_list_patch_and_deactivate` extended: post-DELETE bulk list excludes the user, `?filter=active eq false` surfaces it, re-POST of the deprovisioned userName 409s.
- `test_api_enterprise_tenant::test_rotate_key_accepts_missing_body` new.
- `tests/test_cli_serve_auth_enforce.py` new (7 cases).

## Validation
- `pytest tests/test_api_scim_lifecycle.py tests/test_api_enterprise_tenant.py tests/test_api_auth_boundary.py tests/test_api_compliance_auth.py tests/test_cli_serve_auth_enforce.py` → **63 passed**
- `tsc --noEmit` (UI) clean
- `ruff check` + `mypy` clean

## False positives that didn't need a fix
- `tenant-acme` → `default` canonicalization (per `feedback_canonicalize_over_reject` platform invariant).
- `raw_key` parser miss (audit-script bug, not API contract).

## What's next
- v0.85.0 will bundle this patch with firewall (#982) + envelope (#2083) — both merged on main but not yet released.
- MCP + skills audit (composite 8.6/10) coming as a separate PR with 4 more defects.