### PR TITLE
fix: v0.84.6 MCP audit — strict tool args, self-scan venv walk, skill verdict split, dedupe sandbox warning

### DIFF
--- a/src/agent_bom/cli/agents/_self_scan.py
+++ b/src/agent_bom/cli/agents/_self_scan.py
@@ -6,28 +6,34 @@ import importlib.metadata as metadata
 
 
 def _build_self_scan_inventory() -> dict[str, list[dict[str, object]]]:
-    """Build a deterministic self-scan inventory for the installed package."""
+    """Build a self-scan inventory of every package installed in the venv.
+
+    Pre-#2197 the scan walked only `agent-bom`'s declared `requires` (top
+    level deps from pyproject.toml). The audit caught this: a fresh venv
+    install of `agent-bom` carries ~23 declared deps but ~66 actual
+    distributions once transitive deps resolve. CVEs in transitive deps
+    were therefore invisible to `--self-scan`. We now walk
+    `importlib.metadata.distributions()` so the self-scan reflects the
+    real attack surface.
+    """
     pkgs: list[dict[str, str]] = []
     seen: set[tuple[str, str, str]] = set()
 
-    dist = metadata.distribution("agent-bom")
-    for req_str in dist.requires or []:
-        name = req_str.split(";")[0].split("[")[0].strip()
-        for op in (">=", "<=", "==", "!=", "~=", ">", "<"):
-            if op in name:
-                name = name[: name.index(op)].strip()
-                break
-        if not name:
+    for dist in metadata.distributions():
+        name = (dist.metadata["Name"] or "").strip()
+        version = (dist.version or "").strip()
+        if not name or not version:
             continue
-        try:
-            version = metadata.version(name)
-        except metadata.PackageNotFoundError:
+        # Skip agent-bom itself -- it's the running tool, not a dep.
+        if name.lower() == "agent-bom":
             continue
         key = (name.lower(), version, "pypi")
         if key in seen:
             continue
         seen.add(key)
         pkgs.append({"name": name, "version": version, "ecosystem": "pypi"})
+
+    pkgs.sort(key=lambda p: (p["name"].lower(), p["version"]))
 
     return {
         "agents": [

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -784,6 +784,15 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
         tool_metrics_snapshot=_tool_metrics_snapshot,
     )
 
+    # Strict-arg contract on every registered tool (#2197 audit P1).
+    # Sets `additionalProperties: false` on the JSON Schema served via
+    # tools/list AND wraps each tool's runner so unknown arg keys raise
+    # instead of being silently dropped. Pre-fix, AI agents passing typo
+    # args (e.g. `Version` capital) got false-clean verdicts.
+    from agent_bom.mcp_strict_args import harden_tool_arguments
+
+    harden_tool_arguments(mcp)
+
     return mcp
 
 

--- a/src/agent_bom/mcp_strict_args.py
+++ b/src/agent_bom/mcp_strict_args.py
@@ -1,0 +1,89 @@
+"""Strict-args contract for MCP tools (#2197 audit fix).
+
+The audit caught a P1 silent-arg-drop defect: passing `{"package": "flask",
+"version": "2.0.0"}` to `check` returned CLEAN because the unknown `version`
+arg was silently dropped (FastMCP defaults to allowing extra properties),
+so `check` resolved `flask` -> latest -> 0 vulns. AI agents passing typo
+args (`Version` capital, `frob`, etc.) get false-clean verdicts on every
+pre-install gate.
+
+Fix: walk every registered FastMCP tool after registration and:
+
+1. Set `additionalProperties: false` on the JSON Schema served via
+   `tools/list` so MCP clients can validate locally before calling.
+2. Wrap each tool's runner so unknown argument keys raise a clear
+   `ToolError` ("Unknown argument 'Version' for tool 'check' -- accepted
+   keys: ...") instead of being silently dropped.
+
+Pydantic `model_config['extra'] = 'forbid'` cannot be retrofitted after
+model creation (Pydantic only reads it at class-build time), so the
+runtime check lives in a wrapper instead of being baked into the model.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def harden_tool_arguments(mcp: Any) -> int:
+    """Mutate every registered FastMCP tool to reject unknown arguments.
+
+    Two hardenings applied:
+
+    1. **Public schema** -- `additionalProperties: false` on every tool's
+       parameters dict so MCP clients can validate locally before sending.
+    2. **Runtime guard** -- the tool manager's `call_tool` is wrapped so
+       any call carrying an unknown argument key raises a clear `ToolError`
+       *before* FastMCP's Pydantic-backed validation silently drops it.
+
+    Pydantic `model_config['extra'] = 'forbid'` cannot be retrofitted after
+    model creation, so the guard lives at the manager call boundary
+    instead of inside the tool model.
+
+    Returns the number of tools whose schema was hardened. Idempotent.
+    """
+
+    tools = list(mcp._tool_manager._tools.values())
+    hardened = 0
+    for tool in tools:
+        params = getattr(tool, "parameters", None)
+        if isinstance(params, dict) and params.get("additionalProperties") is not False:
+            params["additionalProperties"] = False
+            hardened += 1
+
+    manager = mcp._tool_manager
+    original_call = manager.call_tool
+    if getattr(original_call, "_agent_bom_strict", False):
+        return hardened
+
+    async def _strict_call_tool(name: str, arguments: dict[str, Any], *args: Any, **kwargs: Any) -> Any:
+        tool = manager.get_tool(name)
+        if tool is not None and isinstance(arguments, dict):
+            accepted = _accepted_keys_for_tool(tool)
+            unknown = sorted(set(arguments) - accepted)
+            if unknown:
+                from mcp.server.fastmcp.exceptions import ToolError
+
+                raise ToolError(
+                    f"Unknown argument(s) for tool '{name}': {unknown}. "
+                    f"Accepted: {sorted(accepted)}. "
+                    "(These previously were silently dropped, which let AI agents "
+                    "get false-clean verdicts on typo args -- now they fail loudly.)"
+                )
+        return await original_call(name, arguments, *args, **kwargs)
+
+    _strict_call_tool._agent_bom_strict = True  # type: ignore[attr-defined]
+    manager.call_tool = _strict_call_tool  # type: ignore[method-assign]
+    return hardened
+
+
+def _accepted_keys_for_tool(tool: Any) -> frozenset[str]:
+    """Return the set of argument names the tool's signature actually accepts."""
+    params = getattr(tool, "parameters", None) or {}
+    properties = params.get("properties", {})
+    if isinstance(properties, dict):
+        return frozenset(str(k) for k in properties.keys())
+    return frozenset()
+
+
+__all__ = ["harden_tool_arguments"]

--- a/src/agent_bom/parsers/trust_assessment.py
+++ b/src/agent_bom/parsers/trust_assessment.py
@@ -82,12 +82,30 @@ class TrustCategoryResult:
 
 @dataclass
 class TrustAssessmentResult:
-    """Complete trust assessment across all 5 categories."""
+    """Complete trust assessment across all 5 categories.
+
+    The legacy single `verdict` conflated provenance signals (signed?
+    source URL?) with content risk signals (credential access? shell
+    exec? exfiltration?). Per #2197 audit, that misclassified legitimate
+    cybersecurity playbooks as `malicious` whenever they were unsigned
+    and lacked a frontmatter `source:` URL, even when the audit found
+    zero behavioural risk signals.
+
+    The result now carries TWO axes:
+
+    - `provenance_verdict` -- signed, install metadata complete, source URL?
+    - `content_verdict`    -- behavioural risk signals from the audit?
+
+    `verdict` (the union of both) and `review_verdict` are preserved so
+    pre-#2197 consumers don't break.
+    """
 
     categories: list[TrustCategoryResult] = field(default_factory=list)
     verdict: Verdict = Verdict.BENIGN
     review_verdict: ReviewVerdict = ReviewVerdict.REVIEW
     confidence: Confidence = Confidence.LOW
+    provenance_verdict: Verdict = Verdict.BENIGN
+    content_verdict: Verdict = Verdict.BENIGN
     recommendations: list[str] = field(default_factory=list)
     review_reasons: list[str] = field(default_factory=list)
     reviewer_guidance: list[str] = field(default_factory=list)
@@ -111,6 +129,10 @@ class TrustAssessmentResult:
             "verdict": self.verdict.value,
             "review_verdict": self.review_verdict.value,
             "confidence": self.confidence.value,
+            # Two-axis split (#2197 audit). `verdict` above is kept for
+            # backward compat; new consumers should prefer these axes.
+            "provenance_verdict": self.provenance_verdict.value,
+            "content_verdict": self.content_verdict.value,
             "categories": [
                 {
                     "name": c.name,
@@ -596,6 +618,45 @@ def _compute_verdict(
     return Verdict.BENIGN, Confidence.LOW
 
 
+# Per #2197 audit: split verdict into provenance + content axes.
+# `install_mechanism` is the only category that scores on metadata
+# completeness (signed? source URL? install methods declared?). Every
+# other category scores on actual behavioural risk in the skill content.
+_PROVENANCE_CATEGORY_KEYS = frozenset({"install_mechanism"})
+
+
+def _split_categories(
+    categories: list[TrustCategoryResult],
+) -> tuple[list[TrustCategoryResult], list[TrustCategoryResult]]:
+    """Partition categories into (provenance, content) axes."""
+    provenance = [c for c in categories if c.key in _PROVENANCE_CATEGORY_KEYS]
+    content = [c for c in categories if c.key not in _PROVENANCE_CATEGORY_KEYS]
+    return provenance, content
+
+
+def _compute_axis_verdict(categories: list[TrustCategoryResult]) -> Verdict:
+    """Compute a single-axis verdict (BENIGN/SUSPICIOUS/MALICIOUS).
+
+    Used independently for provenance and content axes so the trust
+    contract surfaces honestly which dimension is suspect (#2197).
+    """
+    if not categories:
+        return Verdict.BENIGN
+    fail_count = sum(1 for c in categories if c.level == TrustLevel.FAIL)
+    warn_count = sum(1 for c in categories if c.level == TrustLevel.WARN)
+    if fail_count >= 2:
+        return Verdict.MALICIOUS
+    if fail_count >= 1:
+        # On a single-axis assessment a single FAIL no longer escalates to
+        # MALICIOUS unless paired with corroborating WARNs -- that's what
+        # the audit caught (one FAIL on `install_mechanism` was scoring
+        # the whole file MALICIOUS).
+        return Verdict.SUSPICIOUS if warn_count == 0 else Verdict.MALICIOUS
+    if warn_count >= 1:
+        return Verdict.SUSPICIOUS
+    return Verdict.BENIGN
+
+
 # ── Recommendations ──────────────────────────────────────────────────────────
 
 
@@ -746,6 +807,11 @@ def assess_trust(
     ]
 
     verdict, confidence = _compute_verdict(categories)
+    # Per #2197 audit: split verdict into provenance + content so a clean
+    # skill that's just unsigned no longer reads as `malicious`.
+    provenance_categories, content_categories = _split_categories(categories)
+    provenance_verdict = _compute_axis_verdict(provenance_categories)
+    content_verdict = _compute_axis_verdict(content_categories)
     recommendations = _generate_recommendations(categories)
     review_verdict = _compute_review_verdict(verdict, categories, audit)
     review_reasons = _build_review_reasons(categories, audit)
@@ -756,6 +822,8 @@ def assess_trust(
         verdict=verdict,
         review_verdict=review_verdict,
         confidence=confidence,
+        provenance_verdict=provenance_verdict,
+        content_verdict=content_verdict,
         recommendations=recommendations,
         review_reasons=review_reasons,
         reviewer_guidance=reviewer_guidance,

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -1466,7 +1466,12 @@ async def run_proxy(
         sandbox_evidence = sandbox_config.evidence()
 
     if warning := sandbox_posture_warning(sandbox_evidence):
-        sys.stderr.write(warning + "\n")
+        # Single emission via the logger (#2197 audit P3). The previous code
+        # printed to both `sys.stderr` and `logger.warning(...)`, which
+        # duplicated the message in the operator's terminal because the
+        # default logging handler ALSO writes to stderr. The structured
+        # `mcp_execution_posture` audit event in the audit log already
+        # carries the same posture detail in machine-readable form.
         logger.warning(warning)
 
     # Validate the effective server command before spawning

--- a/tests/test_mcp_strict_args.py
+++ b/tests/test_mcp_strict_args.py
@@ -1,0 +1,91 @@
+"""MCP strict-args contract (#2197 audit P1).
+
+Pre-fix, every tool let unknown arg keys silently drop. AI agents passing
+typo args (e.g. `Version` capital) got false-clean verdicts. The fix:
+
+1. `additionalProperties: false` on every tool's JSON schema served via
+   `tools/list`, so MCP clients can validate locally.
+2. Runtime guard at the manager call boundary that rejects calls
+   carrying unknown arg keys before FastMCP's Pydantic validation
+   silently drops them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agent_bom.mcp_server import create_mcp_server
+
+
+@pytest.fixture(scope="module")
+def mcp_server():
+    return create_mcp_server()
+
+
+def test_every_tool_advertises_additional_properties_false(mcp_server) -> None:  # noqa: ANN001
+    """Every registered tool's JSON schema must reject unknown properties."""
+    tools = list(mcp_server._tool_manager._tools.values())
+    assert len(tools) >= 30, f"expected ~36 tools, got {len(tools)}"
+    leaks: list[str] = []
+    for tool in tools:
+        params = tool.parameters or {}
+        if params.get("additionalProperties") is not False:
+            leaks.append(tool.name)
+    assert not leaks, f"tools missing additionalProperties:false: {leaks}"
+
+
+def test_unknown_argument_raises_clear_error(mcp_server) -> None:  # noqa: ANN001
+    """Calling a tool with a typo arg name fails loudly instead of silently
+    dropping the arg (the audit's flask@2.0.0 false-clean repro)."""
+    from mcp.server.fastmcp.exceptions import ToolError
+
+    async def call() -> None:
+        await mcp_server._tool_manager.call_tool(
+            "check",
+            {"package": "flask", "version": "2.0.0", "ecosystem": "pypi"},
+        )
+
+    with pytest.raises(ToolError) as exc:
+        asyncio.run(call())
+    msg = str(exc.value)
+    assert "Unknown argument" in msg
+    assert "version" in msg
+    assert "check" in msg
+
+
+def test_known_arguments_pass_through(mcp_server) -> None:  # noqa: ANN001
+    """Sanity check: legitimate calls aren't blocked by the guard.
+
+    Don't actually run the tool (it would do real network work); just
+    confirm that the strict-args layer doesn't trip on the canonical
+    arg shape. We use `inventory` because it accepts an optional
+    `config_path` and runs locally.
+    """
+
+    async def call() -> object:
+        return await mcp_server._tool_manager.call_tool(
+            "inventory",
+            {"config_path": None},
+        )
+
+    # The call may succeed or fail downstream (e.g. no MCP configs found),
+    # but it should NOT raise a ToolError about unknown args.
+    from mcp.server.fastmcp.exceptions import ToolError
+
+    try:
+        asyncio.run(call())
+    except ToolError as e:
+        assert "Unknown argument" not in str(e)
+
+
+def test_harden_is_idempotent(mcp_server) -> None:  # noqa: ANN001
+    """Calling harden_tool_arguments twice doesn't double-wrap."""
+    from agent_bom.mcp_strict_args import harden_tool_arguments
+
+    # First call already happened in create_mcp_server; this is the second.
+    harden_tool_arguments(mcp_server)
+    # Verify the manager's call_tool is still our wrapper (not a wrapper of
+    # a wrapper -- the marker attribute prevents stacking).
+    assert getattr(mcp_server._tool_manager.call_tool, "_agent_bom_strict", False) is True

--- a/tests/test_self_scan.py
+++ b/tests/test_self_scan.py
@@ -54,33 +54,37 @@ class TestSelfScanInventory:
                 pass
         assert resolved >= 5, f"Expected >=5 resolved deps, got {resolved}"
 
-    def test_self_scan_inventory_deduplicates_and_hides_local_paths(self):
-        """Self-scan inventory should not duplicate packages or leak temp paths."""
+    def test_self_scan_inventory_walks_installed_distributions(self):
+        """Per #2197 audit: self-scan walks every installed distribution
+        in the venv (not just declared deps), excludes agent-bom itself,
+        and dedups duplicate (name, version, ecosystem) tuples."""
 
         class _FakeDist:
-            requires = [
-                "agent-bom>=0.75.9",
-                "Agent-Bom>=0.75.9",
-                "requests>=2.33.0",
-                "requests>=2.33.0",
-            ]
+            def __init__(self, name: str, version: str) -> None:
+                self.metadata = {"Name": name}
+                self.version = version
 
-        def _fake_version(name: str) -> str:
-            versions = {"agent-bom": "0.75.9", "Agent-Bom": "0.75.9", "requests": "2.33.0"}
-            return versions[name]
+        fake_dists = [
+            _FakeDist("agent-bom", "0.75.9"),  # excluded -- this IS the tool
+            _FakeDist("requests", "2.33.0"),
+            _FakeDist("Requests", "2.33.0"),  # case-only duplicate, dropped
+            _FakeDist("urllib3", "2.0.0"),  # transitive dep, must appear
+            _FakeDist("", "1.0.0"),  # empty name, dropped
+            _FakeDist("foo", ""),  # empty version, dropped
+        ]
 
-        with (
-            patch("importlib.metadata.distribution", return_value=_FakeDist()),
-            patch("importlib.metadata.version", side_effect=_fake_version),
-        ):
+        with patch("importlib.metadata.distributions", return_value=fake_dists):
             inventory = _build_self_scan_inventory()
 
         agent = inventory["agents"][0]
         packages = agent["mcp_servers"][0]["packages"]
         assert agent["config_path"] == "self-scan://agent-bom"
+        # Sorted by lowercased name; agent-bom self excluded; the first
+        # case-variant ("requests") wins the dedup key, so capitalised
+        # "Requests" is dropped; empty name/version entries dropped.
         assert packages == [
-            {"name": "agent-bom", "version": "0.75.9", "ecosystem": "pypi"},
             {"name": "requests", "version": "2.33.0", "ecosystem": "pypi"},
+            {"name": "urllib3", "version": "2.0.0", "ecosystem": "pypi"},
         ]
 
 


### PR DESCRIPTION
End-to-end fix for the four verified defects from the v0.84.6 MCP + Skills hands-on audit (composite 8.6/10). Pairs with #2196 (platform audit fixes); together they address every audit finding before the v0.85.0 cut.

## What lands here

| # | Severity | Defect | Fix |
|---|---|---|---|
| 1 | **P1** | Tool-arg silent drop on all 36 MCP tools — `{"package":"flask","version":"2.0.0","ecosystem":"pypi"}` returns CLEAN because `version` was silently dropped. AI agents passing typo args got false-clean verdicts on every pre-install gate. | New `agent_bom.mcp_strict_args.harden_tool_arguments(mcp)` walks every registered FastMCP tool, sets `additionalProperties: false` on the JSON Schema served via `tools/list`, AND wraps the tool manager's `call_tool` so unknown arg keys raise a clear `ToolError` *before* FastMCP's Pydantic validation silently drops them. Idempotent. |
| 2 | **P1** | Skill trust verdict conflated provenance with content risk — three legitimate cybersecurity remediation playbooks were marked `malicious` with **zero** detected risk signals, purely because they were unsigned and lacked a frontmatter `source:` URL (~80% false-positive rate on real security skill trees). | `TrustAssessmentResult` now carries two axes: `provenance_verdict` (signed? install metadata complete? source URL?) and `content_verdict` (behavioural risk signals from the audit). The legacy `verdict` is preserved for backward compat. New helper `_compute_axis_verdict` computes each axis independently; `_split_categories` partitions on `install_mechanism` (provenance) vs everything else (content). |
| 3 | **P2** | Self-scan saw declared deps only — `--self-scan` reported 23 packages while `pip list` showed 66 in the venv. CVEs in transitive deps were invisible. | `_build_self_scan_inventory` now walks `importlib.metadata.distributions()` (every installed package), excludes agent-bom itself, dedups (name, version, ecosystem) tuples, sorts by lowercased name. |
| 4 | **P3** | Proxy duplicate stderr sandbox warning — `agent-bom proxy warning: sandbox isolation is disabled` printed twice on startup as plain text. The same info IS in the structured `mcp_execution_posture` audit event. | Single emission via `logger.warning(...)`; the redundant `sys.stderr.write(warning + "\n")` is dropped (default logging handler already routes to stderr). |

## Tests

- `tests/test_mcp_strict_args.py` (new, 4 cases): every tool advertises `additionalProperties: false`; unknown arg names raise `ToolError` with a clear message; legitimate calls pass through; double-call idempotence.
- `tests/test_self_scan.py::test_self_scan_inventory_walks_installed_distributions` (rewritten): verifies the new venv-walk via mocked `importlib.metadata.distributions()` — agent-bom self excluded, case-variant dedup wins by first-seen, empty entries dropped.

## Validation
- `pytest tests/test_mcp_strict_args.py tests/test_self_scan.py tests/test_trust_assessment.py tests/test_proxy_sandbox.py tests/test_mcp_server.py tests/test_mcp_tool_rules.py` → **165 passed**
- End-to-end smoke: `await mcp._tool_manager.call_tool("check", {"package":"flask","version":"2.0.0","ecosystem":"pypi"})` → `ToolError: Unknown argument(s) for tool 'check': ['version']. Accepted: ['ecosystem', 'package']` (was: silent CLEAN verdict on flask@latest pre-fix).
- `ruff check` clean (post-format)
- `mypy` clean

## Strong wins preserved (don't regress)
The audit explicitly called out as best-in-class:
- Proxy audit log with `prev_hash` + `record_hash` tamper-evident chain
- Three credential detectors (AWS, OpenAI, Generic) firing on a single read
- `block-undeclared` rejects undeclared tools before they reach the wrapped server
- Bearer auth on remote MCP (401/406/200 paths all clean)

This PR doesn't touch any of those.

## What's next

With this PR + #2196 (platform audit fixes) merged, **v0.85.0** can ship: firewall (#982) + envelope (#2083) + both audit-fix patches in one minor release.