### PR TITLE
chore: prepare v0.85.0 release

### DIFF
--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom
-        run: uv tool install agent-bom==0.84.6  # pinned — bump on each release
+        run: uv tool install agent-bom==0.85.0  # pinned — bump on each release
 
       - name: Scan changed MCP configs
         id: scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.85.0] – 2026-05-02
+
+Two new product surfaces (inter-agent firewall + per-run discovery envelope) plus four audit-driven defect fixes from the v0.84.6 hands-on review.
+
+### Added
+- **Inter-agent firewall** — tenant-scoped policy engine for agent → agent delegation. Pairwise + role-tag rules with `allow` / `deny` / `warn-only` decisions, dry-run mode for safe rollouts, hot-reloadable policy file. Decisions emit through the existing `/v1/proxy/audit` HMAC-chained audit relay. CLI: `agent-bom firewall validate / list / check`. Runtime card on the gateway dashboard tab. Issue #982 closed by #2188 / #2189 / #2190 / #2191.
+- **Per-run discovery envelope** (#2083) — every discovered Agent now carries a trust contract recording the actual scan mode, explicit scope, IAM/API permissions exercised, and redaction posture for that run. Locked enums (`scan_mode`, `redaction_status`), schema-versioned (`envelope_version: 1`), surfaced through the existing `/v1/agents` API and a new `DiscoveryEnvelopeCard` on agent detail with a data-residency note. Wired on AWS, GCP, Azure, CoreWeave, Nebius, Snowflake, Databricks, MLflow, W&B, HuggingFace, OpenAI, and Ollama. Cross-provider least-privilege + redaction lock-in matrix tests every catalog entry against an explicit read-only verb allowlist (`Get` / `List` / `Describe` / `Search` / `Read` / `Select` / `View` / `Retrieve` / `Show` / `Fetch` / `Scan` / `watch` / `GET` / `HEAD` / `OPTIONS`). Issue #2083 closed by #2192 / #2193 / #2194 / #2195.
+- **Diagrams alignment** — engine-internals and compliance SVGs realigned to canonical product counts (15 ecosystems, 14 + AISVS frameworks, 29 MCP clients, 36 MCP server tools, 26 output formats, 419 test files); OpenClaw / ClawHub framed as distribution surfaces in `integrations/openclaw/README.md`. Issue #2150 closed by #2187.
+
+### Fixed
+- **SCIM DELETE removes users from default listing** (P1 IdP-blocker, audit #2196) — `deactivate_user` flips `active=False` and bulk `list_users` now excludes deactivated users, matching Okta/Azure AD deprovisioning expectations. Precise lookups by `userName` / `externalId` / `id` keep finding deactivated users so admins can verify the deactivation landed; `?filter=active eq <bool>` is the new admin-audit primitive. Re-creating a deprovisioned `userName` still 409s.
+- **`--allow-insecure-no-auth` no longer silently overridden by SCIM bearer** (P2 audit #2196) — `_enforce_auth_defaults` recognises `AGENT_BOM_SCIM_BEARER_TOKEN` as a valid auth path. When the flag is set together with any auth method, a yellow warning to stderr names the active method instead of pretending the flag disabled auth.
+- **Dashboard "Cannot connect" splash distinguishes auth from network errors** (P2 audit #2196) — `ApiOfflineState` takes a `kind: "network" | "auth" | "forbidden"` prop; pages classify thrown errors via `ApiAuthError` / `ApiForbiddenError`. Auth/forbidden cases get distinct copy ("Sign in to view the dashboard" / "This account doesn't have access").
+- **`POST /v1/auth/keys/{id}/rotate` accepts empty body** (P3 audit #2196) — body now optional; defaults applied silently for missing or `{}` payloads.
+- **Strict MCP tool argument contract** (P1 audit #2197) — every registered tool's JSON schema now sets `additionalProperties: false`, and a runtime guard at the tool-manager call boundary rejects calls with unknown argument keys before FastMCP's Pydantic validation silently drops them. Pre-fix, AI agents passing typo args (`Version` capital, `frob`, etc.) got false-clean verdicts on the pre-install gate.
+- **Skill trust verdict split into provenance + content axes** (P1 audit #2197) — `TrustAssessmentResult` now carries `provenance_verdict` (signed? install metadata complete? source URL?) and `content_verdict` (behavioural risk signals from the audit) alongside the legacy `verdict`. Pre-fix, three legitimate cybersecurity playbooks were marked `malicious` purely because they were unsigned and lacked a frontmatter `source:` URL despite zero detected risk signals (~80% false-positive rate on real security skill trees).
+- **`--self-scan` walks every venv distribution** (P2 audit #2197) — `_build_self_scan_inventory` now uses `importlib.metadata.distributions()` so transitive deps appear in the inventory. Pre-fix, only ~23 declared deps were scanned vs ~66 actually installed.
+- **Proxy stderr sandbox warning is single-emission** (P3 audit #2197) — the duplicated `sys.stderr.write(warning)` is dropped; `logger.warning(warning)` is the single source. The structured `mcp_execution_posture` audit event still carries the same posture detail in machine-readable form.
+
+### Documentation
+- New `docs/AGENT_FIREWALL.md` — schema reference, gateway integration, proxy fast-path, dashboard overlay, 4-PR roadmap.
+- New `docs/DISCOVERY_ENVELOPE.md` — schema reference, locked vocabulary, producers table, API + UI surface, lock-in matrix.
+
+---
+
 ## [0.84.6] – 2026-05-02
 
 ### Added
@@ -1036,7 +1061,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
-[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.84.6...HEAD
+[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.85.0...HEAD
+[0.85.0]: https://github.com/msaad00/agent-bom/compare/v0.84.6...v0.85.0
 [0.84.6]: https://github.com/msaad00/agent-bom/compare/v0.84.5...v0.84.6
 [0.84.5]: https://github.com/msaad00/agent-bom/compare/v0.84.4...v0.84.5
 [0.84.4]: https://github.com/msaad00/agent-bom/compare/v0.84.3...v0.84.4

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -188,7 +188,7 @@ Focused graph:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `0.84.6` | Current stable version (pinned) |
+| `0.85.0` | Current stable version (pinned) |
 
 Published images:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.3-alpine3.23@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510
 
-ARG VERSION=0.84.6
+ARG VERSION=0.85.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ for the full split-vs-single-image guidance.
 |------|----------|
 | CLI (`agent-bom agents`) | local audit + project scan |
 | Endpoint fleet (`--push-url …/v1/fleet/sync`) | employee laptops pushing into self-hosted fleet |
-| GitHub Action (`uses: msaad00/agent-bom@v0.84.6`) | CI/CD + SARIF |
+| GitHub Action (`uses: msaad00/agent-bom@v0.85.0`) | CI/CD + SARIF |
 | Docker (`agentbom/agent-bom`) | isolated scans, API jobs, and non-browser self-hosted entrypoints |
 | Browser UI image (`agentbom/agent-bom-ui`) | the dashboard image paired with the same self-hosted control plane |
 | Kubernetes / Helm (`helm install agent-bom deploy/helm/agent-bom`) | self-hosted API + dashboard, scheduled discovery |
@@ -404,7 +404,7 @@ References: [PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md) · [PRODUCT_METRICS.md](do
 <summary><b>CI/CD in 60 seconds</b></summary>
 
 ```yaml
-- uses: msaad00/agent-bom@v0.84.6
+- uses: msaad00/agent-bom@v0.85.0
   with:
     scan-type: scan
     severity-threshold: high

--- a/deploy/docker-compose.fullstack.yml
+++ b/deploy/docker-compose.fullstack.yml
@@ -27,7 +27,7 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
-    image: agentbom/agent-bom:0.84.6
+    image: agentbom/agent-bom:0.85.0
     container_name: agent-bom-api
     restart: unless-stopped
     command: api --host 0.0.0.0 --port 8422 --allow-insecure-no-auth
@@ -74,7 +74,7 @@ services:
       args:
         # Baked into the Next.js build — must match the publicly reachable API URL
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8422}
-    image: agentbom/agent-bom-ui:0.84.6
+    image: agentbom/agent-bom-ui:0.85.0
     container_name: agent-bom-ui
     restart: unless-stopped
     ports:

--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -18,7 +18,7 @@
 
 services:
   api:
-    image: agentbom/agent-bom:0.84.6
+    image: agentbom/agent-bom:0.85.0
     container_name: agent-bom-pilot-api
     restart: unless-stopped
     command: >
@@ -45,7 +45,7 @@ services:
       start_period: 10s
 
   ui:
-    image: agentbom/agent-bom-ui:0.84.6
+    image: agentbom/agent-bom-ui:0.85.0
     container_name: agent-bom-pilot-ui
     restart: unless-stopped
     environment:

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -112,7 +112,7 @@ services:
       dockerfile: Dockerfile
       args:
         NEXT_PUBLIC_API_URL: http://localhost:8422
-    image: agentbom/agent-bom-ui:0.84.6
+    image: agentbom/agent-bom-ui:0.85.0
     container_name: agent-bom-ui
     ports:
       - "3000:3000"

--- a/deploy/docker-compose.runtime.yml
+++ b/deploy/docker-compose.runtime.yml
@@ -31,7 +31,7 @@ services:
     build:
       context: ..
       dockerfile: deploy/docker/Dockerfile.runtime
-    image: agentbom/agent-bom:0.84.6
+    image: agentbom/agent-bom:0.85.0
     container_name: agent-bom-runtime-proxy
     depends_on:
       - mcp-server

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -27,7 +27,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.84.6
+ARG VERSION=0.85.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -17,7 +17,7 @@ WORKDIR /app
 COPY pyproject.toml README.md PYPI_README.md LICENSE ./
 COPY src/ ./src/
 
-ARG VERSION=0.84.6
+ARG VERSION=0.85.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
@@ -40,7 +40,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[runtime]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.84.6
+ARG VERSION=0.85.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.snowpark
+++ b/deploy/docker/Dockerfile.snowpark
@@ -26,7 +26,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11.12-slim@sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c
 
-ARG VERSION=0.84.6
+ARG VERSION=0.85.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -41,7 +41,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.84.6
+ARG VERSION=0.85.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: agent-bom
 description: Open security scanner and graph for AI supply chain and infrastructure — discover agents and MCP, map blast radius, and inspect runtime.
-version: 0.84.6
-appVersion: "0.84.6"
+version: 0.85.0
+appVersion: "0.85.0"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -5,17 +5,17 @@
 
 image:
   repository: agentbom/agent-bom
-  tag: "0.84.6"
+  tag: "0.85.0"
   pullPolicy: IfNotPresent
 
 uiImage:
   repository: agentbom/agent-bom-ui
-  tag: "0.84.6"
+  tag: "0.85.0"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom
-  tag: "0.84.6"
+  tag: "0.85.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -38,7 +38,7 @@ tests:
   includeUi: true
   image:
     repository: agentbom/agent-bom
-    tag: "0.84.6"
+    tag: "0.85.0"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deploy/k8s/daemonset.yaml
+++ b/deploy/k8s/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: agent-bom
       containers:
         - name: monitor
-          image: agentbom/agent-bom:0.84.6
+          image: agentbom/agent-bom:0.85.0
           command: ["agent-bom"]
           args:
             - "protect"

--- a/deploy/k8s/proxy-sidecar-pilot.yaml
+++ b/deploy/k8s/proxy-sidecar-pilot.yaml
@@ -109,7 +109,7 @@ spec:
               cpu: "500m"
 
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.84.6
+          image: agentbom/agent-bom:0.85.0
           args:
             - "--policy"
             - "/etc/agent-bom/policy.json"

--- a/deploy/k8s/sidecar-example.yaml
+++ b/deploy/k8s/sidecar-example.yaml
@@ -40,7 +40,7 @@ spec:
 
         # agent-bom proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.84.6
+          image: agentbom/agent-bom:0.85.0
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -135,7 +135,7 @@ agent-bom agents --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.84.6
+- uses: msaad00/agent-bom@v0.85.0
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -72,7 +72,7 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # GitHub Actions
-- uses: msaad00/agent-bom@v0.84.6
+- uses: msaad00/agent-bom@v0.85.0
   with:
     scan-type: agents        # auto-detect MCP configs + deps
     severity-threshold: high # fail PR on HIGH+ CVEs
@@ -90,21 +90,21 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # Container image gate
-- uses: msaad00/agent-bom@v0.84.6
+- uses: msaad00/agent-bom@v0.85.0
   with:
     scan-type: image
     scan-ref: ghcr.io/acme/agent-runtime:sha-abcdef
     severity-threshold: critical
 
 # IaC gate
-- uses: msaad00/agent-bom@v0.84.6
+- uses: msaad00/agent-bom@v0.85.0
   with:
     scan-type: iac
     iac: Dockerfile,k8s/,infra/main.tf
     severity-threshold: high
 
 # Air-gapped or fully cached CI
-- uses: msaad00/agent-bom@v0.84.6
+- uses: msaad00/agent-bom@v0.85.0
   with:
     auto-update-db: false
     enrich: false
@@ -470,7 +470,7 @@ AmazonEC2ReadOnlyAccess
 docker run --rm \
   -v ~/.config:/home/abom/.config:ro \
   -v $(pwd):/workspace:ro \
-  agentbom/agent-bom:0.84.6 agents --format json
+  agentbom/agent-bom:0.85.0 agents --format json
 ```
 
 Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base image.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -242,7 +242,7 @@ blast_radius        — blast radius for a specific CVE
 ### CI/CD (GitHub Action)
 
 ```yaml
-- uses: msaad00/agent-bom@v0.84.6
+- uses: msaad00/agent-bom@v0.85.0
   with:
     format: sarif
     upload-sarif: 'true'

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,6 +1,6 @@
 {
   "generated_on": "2026-04-30",
-  "version": "0.84.6",
+  "version": "0.85.0",
   "metrics": [
     {
       "name": "MCP tools",

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -6,7 +6,7 @@ This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
 - Generated on: `2026-04-30`
-- Version: `0.84.6`
+- Version: `0.85.0`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -97,7 +97,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN" --no-browser
 clawhub publish integrations/openclaw/scan \
   --slug agent-bom-scan --name "agent-bom scan" \
-  --version "0.84.6"
+  --version "0.85.0"
 ```
 
 Release automation uses the same official `clawhub` CLI flow, not a custom
@@ -150,8 +150,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.84.6
-git push origin v0.84.6
+git tag v0.85.0
+git push origin v0.85.0
 ```
 
 This triggers:

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -13,7 +13,7 @@ For each tagged GitHub Release, expect:
 ## Download release assets
 
 ```bash
-TAG=v0.84.6
+TAG=v0.85.0
 VERSION="${TAG#v}"
 mkdir -p /tmp/agent-bom-release && cd /tmp/agent-bom-release
 gh release download "$TAG" --repo msaad00/agent-bom

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -33,7 +33,7 @@ The proxy interposes on the stdio channel between an MCP client (Claude Desktop,
 Use the published main runtime image:
 
 ```bash
-docker pull agentbom/agent-bom:0.84.6
+docker pull agentbom/agent-bom:0.85.0
 ```
 
 If you need to rebuild locally from the checked-out repo, you can still use
@@ -45,7 +45,7 @@ Run as a wrapper around any MCP server:
 ```bash
 docker run --rm \
   -v $(pwd)/audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.84.6 \
+  agentbom/agent-bom:0.85.0 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace
@@ -94,7 +94,7 @@ spec:
 
         # agent-bom runtime proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.84.6
+          image: agentbom/agent-bom:0.85.0
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"
@@ -334,7 +334,7 @@ Use the runtime container directly from Claude Desktop:
         "run", "--rm", "-i",
         "-v", "./workspace:/workspace",
         "-v", "./audit-logs:/var/log/agent-bom",
-        "agentbom/agent-bom:0.84.6",
+        "agentbom/agent-bom:0.85.0",
         "--log", "/var/log/agent-bom/audit.jsonl",
         "--block-undeclared",
         "--",

--- a/docs/archive/WINDOWS_CONTAINERS.md
+++ b/docs/archive/WINDOWS_CONTAINERS.md
@@ -113,7 +113,7 @@ container inspection. Windows Server environments should use:
 
 1. **Python CLI** -- `pip install agent-bom` works on Windows natively
 2. **Docker Desktop** -- run the Linux container images on Windows via WSL 2
-3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.84.6`) which
+3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.85.0`) which
    runs on Linux runners
 
 ---

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,4 +1,4 @@
-# agent-bom v0.84.6 blast-radius demo
+# agent-bom v0.85.0 blast-radius demo
 # Shows: blast radius → package gate
 
 Output docs/images/demo-latest.gif

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
-  "version": "0.84.6",
+  "version": "0.85.0",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
   "title": "agent-bom",
-  "version": "0.84.6",
+  "version": "0.85.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.84.6",
+      "version": "0.85.0",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   security checks. Use when the user mentions vulnerability scanning,
   MCP server trust, compliance, SBOM generation, CIS benchmarks, blast
   radius, or AI supply chain risk.
-version: 0.84.6
+version: 0.85.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -25,7 +25,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.84.6
+    docker: ghcr.io/msaad00/agent-bom:0.85.0
   openclaw:
     requires:
       bins: []
@@ -412,6 +412,6 @@ provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.84.6`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.85.0`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Analyze blast radius, attack paths, and threat landscape across your AI
   infrastructure. Use when: "blast radius", "threat intel", "risk score",
   "attack path", "lateral movement", "context graph", "who can reach what".
-version: 0.84.6
+version: 0.85.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.84.6
+    docker: ghcr.io/msaad00/agent-bom:0.85.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Generate SBOMs and compliance reports. Use when:
   "compliance report", "NIST", "SOC 2", "ISO 27001", "OWASP", "EU AI Act",
   "AISVS", "generate SBOM", "policy check".
-version: 0.84.6
+version: 0.85.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. OWASP/NIST/EU AI Act/MITRE
@@ -23,7 +23,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.84.6
+    docker: ghcr.io/msaad00/agent-bom:0.85.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/discover-aws/SKILL.md
+++ b/integrations/openclaw/discover-aws/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   inventory AWS Bedrock, ECS, SageMaker, Lambda, EKS, Step Functions, EC2, or
   agentic AWS infrastructure as canonical inventory. Passing that inventory
   to agent-bom is optional and operator-chosen.
-version: 0.84.6
+version: 0.85.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-azure/SKILL.md
+++ b/integrations/openclaw/discover-azure/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   giving agent-bom long-lived Azure credentials. Use when a user asks to
   inventory Azure OpenAI, Container Apps, AKS, Functions, ML, or agentic Azure
   infrastructure as canonical inventory.
-version: 0.84.6
+version: 0.85.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-gcp/SKILL.md
+++ b/integrations/openclaw/discover-gcp/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   giving agent-bom long-lived GCP credentials. Use when a user asks to
   inventory Vertex AI, Cloud Run, Cloud Functions, GKE, or agentic GCP
   infrastructure as canonical inventory.
-version: 0.84.6
+version: 0.85.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-snowflake/SKILL.md
+++ b/integrations/openclaw/discover-snowflake/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   agent-bom inventory JSON, and scan it without giving agent-bom long-lived
   Snowflake credentials. Use when a user asks to inventory Snowflake AI or
   Cortex infrastructure as canonical inventory.
-version: 0.84.6
+version: 0.85.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed with the snowflake extra, and

--- a/integrations/openclaw/discover/SKILL.md
+++ b/integrations/openclaw/discover/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Discover AI agents, MCP servers, and configurations on this machine or
   environment. Use when: "find agents", "what's configured", "doctor",
   "what MCP servers", "show me what's installed", "mcp inventory".
-version: 0.84.6
+version: 0.85.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.84.6
+    docker: ghcr.io/msaad00/agent-bom:0.85.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Enforce security policies on MCP tool calls and block dangerous operations at
   runtime. Use when: "block risky calls", "apply policy", "proxy",
   "runtime protection", "policy enforcement", "intercept MCP calls".
-version: 0.84.6
+version: 0.85.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.84.6
+    docker: ghcr.io/msaad00/agent-bom:0.85.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/ingest/SKILL.md
+++ b/integrations/openclaw/ingest/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   GCP, Snowflake, CMDB, or endpoint collectors. Use when a user has canonical
   inventory JSON and wants local findings, graph, policy, provenance, or
   auditor-ready exports without giving agent-bom direct cloud credentials.
-version: 0.84.6
+version: 0.85.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+ and agent-bom 0.84.4+. Inventory must conform to the

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Monitor agent fleet, track trust scores, and manage lifecycle states. Use
   when: "fleet", "watch agents", "runtime status", "trust scores",
   "fleet sync", "agent lifecycle", "serve dashboard".
-version: 0.84.6
+version: 0.85.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.84.6
+    docker: ghcr.io/msaad00/agent-bom:0.85.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.84.6
+version: 0.85.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.84.6
+version: 0.85.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Scan infrastructure-as-code, cloud configurations, and find secrets. Use when:
   "check terraform", "scan kubernetes", "IaC", "find secrets",
   "scan dockerfile", "cloud security", "misconfigurations".
-version: 0.84.6
+version: 0.85.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.84.6
+    docker: ghcr.io/msaad00/agent-bom:0.85.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   KEV), container images, provenance, filesystems, and SBOMs. Use
   when: "check package", "scan image", "verify", "is this safe",
   "scan dependencies", "CVE lookup", "blast radius".
-version: 0.84.6
+version: 0.85.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Native container image
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.84.6
+    docker: ghcr.io/msaad00/agent-bom:0.85.0
   openclaw:
     requires:
       bins: []
@@ -237,6 +237,6 @@ agent-bom agents
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.84.6`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.85.0`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Diagnose issues, check prerequisites, and validate configurations. Use when:
   "doctor", "debug", "why failing", "validate config", "check prerequisites",
   "something is broken", "db status", "fix my setup".
-version: 0.84.6
+version: 0.85.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.84.6
+    docker: ghcr.io/msaad00/agent-bom:0.85.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/vulnerability-intel/SKILL.md
+++ b/integrations/openclaw/vulnerability-intel/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   with explicit data-boundary choices. Use when a user asks for CVE lookup,
   advisory intelligence, exploitability context, fix versions, GHSA/OSV/NVD
   enrichment, or package vulnerability triage.
-version: 0.84.6
+version: 0.85.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+ and agent-bom installed from this repository or PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.84.6"
+version = "0.85.0"
 description = "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius."
 readme = "PYPI_README.md"
 license = "Apache-2.0"

--- a/site-docs/deployment/airgapped-image-bundle.md
+++ b/site-docs/deployment/airgapped-image-bundle.md
@@ -12,7 +12,7 @@ From an internet-connected build host:
 
 ```bash
 scripts/release/build-airgap-image-bundle.sh \
-  --version 0.84.6 \
+  --version 0.85.0 \
   --platform linux/amd64 \
   --output-dir dist/airgap
 ```
@@ -33,8 +33,8 @@ machine.
 ## Import On The Disconnected Host
 
 ```bash
-tar -xzf agent-bom-airgap-0.84.6-linux_amd64.tar.gz
-cd agent-bom-airgap-0.84.6-linux_amd64
+tar -xzf agent-bom-airgap-0.85.0-linux_amd64.tar.gz
+cd agent-bom-airgap-0.85.0-linux_amd64
 ./load-images.sh
 ```
 
@@ -43,7 +43,7 @@ The loader verifies archive checksums before running `docker load`.
 ## Push To An Internal Registry
 
 ```bash
-VERSION=0.84.6
+VERSION=0.85.0
 REGISTRY=registry.internal.example.com/security
 
 docker tag "agentbom/agent-bom:${VERSION}" "${REGISTRY}/agent-bom:${VERSION}"
@@ -58,13 +58,13 @@ Then point Helm at the internal registry:
 ```yaml
 image:
   repository: registry.internal.example.com/security/agent-bom
-  tag: "0.84.6"
+  tag: "0.85.0"
 
 controlPlane:
   ui:
     image:
       repository: registry.internal.example.com/security/agent-bom-ui
-      tag: "0.84.6"
+      tag: "0.85.0"
 ```
 
 ## GitHub Actions Bundle Job

--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -342,8 +342,8 @@ through a managed tap instead of direct package upload.
 
 ```bash
 python3 scripts/render_homebrew_formula.py \
-  --version 0.84.6 \
-  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.84.6.tar.gz \
+  --version 0.85.0 \
+  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.85.0.tar.gz \
   --sha256 <release-sha256>
 ```
 

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -171,7 +171,7 @@ Install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.84.6 \
+  --version 0.85.0 \
   -n agent-bom --create-namespace \
   -f values.agent-bom.yaml
 ```
@@ -207,7 +207,7 @@ Then install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.84.6 \
+  --version 0.85.0 \
   -n agent-bom --create-namespace \
   -f deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
 ```

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -92,10 +92,10 @@ docker run --rm \
 ## Runtime proxy sidecar
 
 ```bash
-docker pull agentbom/agent-bom:0.84.6
+docker pull agentbom/agent-bom:0.85.0
 docker run --rm -i \
   -v ./audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.84.6 \
+  agentbom/agent-bom:0.85.0 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace

--- a/site-docs/features/policy.md
+++ b/site-docs/features/policy.md
@@ -49,7 +49,7 @@ agent-bom proxy --policy policy.json --block-undeclared -- ...
 
 ```yaml
 - name: Security gate
-  uses: msaad00/agent-bom@v0.84.6
+  uses: msaad00/agent-bom@v0.85.0
   with:
     policy: policy.json
     fail-on-violation: true

--- a/site-docs/reference/remediate-output.md
+++ b/site-docs/reference/remediate-output.md
@@ -27,7 +27,7 @@ agent-bom remediate -p . --format json --server-group --output plan.json
 
 ```json
 {
-  "version": "0.84.6",
+  "version": "0.85.0",
   "generated_at": "2026-04-21T12:00:00+00:00",
   "remediation_plan": [],
   "summary": {

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.84.6"
+    __version__ = "0.85.0"
 
 # Cross-check against pyproject.toml for dev installs where the editable
 # install metadata may be stale (i.e. version bumped but not re-installed).

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -245,8 +245,8 @@ async def test_check_pypi_provenance_uses_file_scoped_integrity_api():
     metadata_response.status_code = 200
     metadata_response.json.return_value = {
         "urls": [
-            {"filename": "agent_bom-0.84.6-py3-none-any.whl"},
-            {"filename": "agent_bom-0.84.6.tar.gz"},
+            {"filename": "agent_bom-0.85.0-py3-none-any.whl"},
+            {"filename": "agent_bom-0.85.0.tar.gz"},
         ]
     }
     wheel_response = MagicMock()
@@ -262,23 +262,23 @@ async def test_check_pypi_provenance_uses_file_scoped_integrity_api():
         "agent_bom.integrity.request_with_retry",
         side_effect=[metadata_response, wheel_response, sdist_response],
     ) as request:
-        result = await check_pypi_provenance("agent-bom", "0.84.6", mock_client)
+        result = await check_pypi_provenance("agent-bom", "0.85.0", mock_client)
 
     assert result == {
         "has_provenance": True,
         "status": "verified",
         "attestation_count": 2,
-        "files": ["agent_bom-0.84.6-py3-none-any.whl", "agent_bom-0.84.6.tar.gz"],
+        "files": ["agent_bom-0.85.0-py3-none-any.whl", "agent_bom-0.85.0.tar.gz"],
         "attestations_by_file": {
-            "agent_bom-0.84.6-py3-none-any.whl": 1,
-            "agent_bom-0.84.6.tar.gz": 1,
+            "agent_bom-0.85.0-py3-none-any.whl": 1,
+            "agent_bom-0.85.0.tar.gz": 1,
         },
     }
     requested_urls = [call.args[2] for call in request.call_args_list]
     assert requested_urls == [
-        "https://pypi.org/pypi/agent-bom/0.84.6/json",
-        "https://pypi.org/integrity/agent-bom/0.84.6/agent_bom-0.84.6-py3-none-any.whl/provenance",
-        "https://pypi.org/integrity/agent-bom/0.84.6/agent_bom-0.84.6.tar.gz/provenance",
+        "https://pypi.org/pypi/agent-bom/0.85.0/json",
+        "https://pypi.org/integrity/agent-bom/0.85.0/agent_bom-0.85.0-py3-none-any.whl/provenance",
+        "https://pypi.org/integrity/agent-bom/0.85.0/agent_bom-0.85.0.tar.gz/provenance",
     ]
 
 
@@ -468,7 +468,7 @@ def test_verify_partial_provenance_fails_verdict():
         "has_provenance": False,
         "status": "partial",
         "attestation_count": 1,
-        "missing_files": ["agent_bom-0.84.6.tar.gz"],
+        "missing_files": ["agent_bom-0.85.0.tar.gz"],
     }
 
     result = _run_verify_with_mocks(["verify", "--json"], record, integrity, partial_provenance, pypi_meta)

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.84.6",
+  "version": "0.85.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.84.6",
+      "version": "0.85.0",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
         "@tanstack/react-table": "^8.21.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.84.6",
+  "version": "0.85.0",
   "private": true,
   "packageManager": "npm@10.9.7",
   "engines": {

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/lib/api', () => ({
       scan_sources: [],
       scan_count: 0,
     }),
-    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.84.6' }),
+    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.85.0' }),
   },
 }))
 

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ overrides = [{ name = "python-dotenv", specifier = ">=1.2.2" }]
 
 [[package]]
 name = "agent-bom"
-version = "0.84.6"
+version = "0.85.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
v0.85.0 bundles two new product surfaces (inter-agent firewall + per-run discovery envelope) and the four audit-driven fixes from the v0.84.6 hands-on review.

## Summary
- bump package, UI, Helm, Docker, K8s, registry, OpenClaw skill, and documentation refs to v0.85.0
- add the v0.85.0 changelog entry covering #2187-#2197
- refresh `uv.lock` and `ui/package-lock.json`

## Highlights since v0.84.6

### Inter-agent firewall (#982 closed by #2188 / #2189 / #2190 / #2191)
- Tenant-scoped policy engine for agent → agent delegation: `allow` / `deny` / `warn-only`.
- Hot-reloadable policy file, `dry_run` mode for safe rollouts, audit fan-out via the existing `/v1/proxy/audit` HMAC-chained relay.
- `agent-bom firewall validate / list / check` CLI.
- Runtime card on the gateway dashboard tab.

### Per-run discovery envelope (#2083 closed by #2192 / #2193 / #2194 / #2195)
- Trust contract on every discovered Agent: `scan_mode`, `discovery_scope`, `permissions_used`, `redaction_status`.
- Locked enums + schema versioning + 4-PR foundation → 12 providers → API/UI surface → least-privilege lock-in matrix.
- Verb-level allowlist machine-enforces the read-only contract: any future PR adding a write verb (`s3:PutObject`, `compute.instances.delete`) fails CI immediately.

### v0.84.6 audit fixes (#2196 + #2197)
**Platform (composite 8.4):**
- SCIM DELETE removes users from default listing (P1, IdP-blocking)
- `--allow-insecure-no-auth` + SCIM bearer interplay (P2, warning emitted)
- Dashboard splash distinguishes auth from network errors (P2)
- `/rotate` accepts empty body (P3)

**MCP + Skills (composite 8.6):**
- Strict MCP tool argument contract — no more silent typo-arg drops (P1)
- Skill trust verdict split into `provenance_verdict` + `content_verdict` (P1)
- `--self-scan` walks every venv distribution, not just declared deps (P2)
- Proxy stderr sandbox warning is single-emission (P3)

### Diagrams alignment (#2187 closed #2150)
- Engine-internals + compliance SVGs realigned to canonical product counts.
- OpenClaw / ClawHub framed as distribution surfaces.

## Validation
- `python scripts/check_release_consistency.py` ✅
- `python scripts/check-counts.py` ✅
- `python scripts/bump-version.py 0.85.0 --check` ✅
- `pytest tests/test_verify.py tests/test_firewall.py tests/test_discovery_envelope.py tests/test_mcp_strict_args.py tests/test_self_scan.py tests/test_api_scim_lifecycle.py -q` → **103 passed**

## Release plan
- merge → tag `v0.85.0` → push tag → release workflow handles PyPI / Docker Hub / Helm OCI / Sigstore / SLSA / SBOM / GH Release.