### PR TITLE
fix(ui+output): splash-kind sweep + occurrence-vs-unique package count

### DIFF
--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -618,6 +618,7 @@ def to_json(report: AIBOMReport) -> dict:
             "total_agents": report.total_agents,
             "total_mcp_servers": report.total_servers,
             "total_packages": report.total_packages,
+            "unique_packages": len(inventory_snapshot.get("packages", [])),
             "total_vulnerabilities": report.total_vulnerabilities,
             "critical_findings": len(report.critical_vulns),
         },

--- a/tests/test_dashboard_splash_kind_lock_in.py
+++ b/tests/test_dashboard_splash_kind_lock_in.py
@@ -1,0 +1,86 @@
+"""Lock-in matrix for the dashboard splash-kind sweep (#2199).
+
+PR #2196 introduced `kind: "network" | "auth" | "forbidden"` on
+`ApiOfflineState` so the splash matches the actual cause of the API
+failure (auth/forbidden/network) instead of always reading as "Cannot
+connect to the agent-bom API".
+
+This matrix walks every Next.js page that imports `ApiOfflineState` and
+asserts:
+
+1. The page imports `ApiAuthError` and/or `ApiForbiddenError` from
+   `@/lib/api-errors` so it can classify thrown errors.
+2. The page passes `kind={...}` to `ApiOfflineState` (not just `title` /
+   `detail`), so the splash gets the right copy on 401/403.
+
+A new dashboard page that mounts the splash without classification fails
+this matrix on PR — the error message names the exact file + remediation
+so the fix is self-explanatory.
+
+This complements the runtime test of `ApiOfflineState` itself; the
+lock-in here is *every page that mounts the splash* must classify, not
+just two of them.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_APP = ROOT / "ui" / "app"
+
+_OFFLINE_STATE_IMPORT = re.compile(r"from\s+['\"]@/components/api-offline-state['\"]")
+_KIND_PROP = re.compile(r"<ApiOfflineState[^/>]*\bkind\s*=", re.DOTALL)
+_API_ERRORS_IMPORT = re.compile(r"from\s+['\"]@/lib/api-errors['\"]")
+
+
+def _ui_pages_using_offline_state() -> list[Path]:
+    """Return every Next.js page that imports ApiOfflineState."""
+    pages: list[Path] = []
+    for path in UI_APP.rglob("page.tsx"):
+        text = path.read_text(encoding="utf-8")
+        if _OFFLINE_STATE_IMPORT.search(text):
+            pages.append(path)
+    return sorted(pages)
+
+
+def test_at_least_two_pages_use_the_splash() -> None:
+    """Sanity check the discovery walk -- the platform always has multiple
+    pages mounting the splash, so a regex regression that found zero pages
+    would silently let everything pass."""
+    pages = _ui_pages_using_offline_state()
+    assert len(pages) >= 2, f"Found {len(pages)} pages importing ApiOfflineState; expected >= 2. The discovery regex may be broken."
+
+
+def test_every_page_using_offline_state_classifies_error_kind() -> None:
+    """Every dashboard page that mounts the splash must classify error kind.
+
+    Pre-#2199 only `app/page.tsx` and `app/security-graph/page.tsx` did
+    this; PR #2199 extends it to compliance + vulns. New pages that mount
+    the splash without classification fail here at PR time.
+    """
+    failures: list[str] = []
+    for path in _ui_pages_using_offline_state():
+        text = path.read_text(encoding="utf-8")
+        rel = str(path.relative_to(ROOT))
+
+        if not _API_ERRORS_IMPORT.search(text):
+            failures.append(
+                f"{rel}: imports `ApiOfflineState` but not `ApiAuthError` / "
+                "`ApiForbiddenError` from `@/lib/api-errors`. Pages that mount "
+                "the splash must classify thrown errors so 401/403 doesn't "
+                "show as 'Cannot connect to the agent-bom API'."
+            )
+            continue
+
+        if not _KIND_PROP.search(text):
+            failures.append(
+                f"{rel}: renders <ApiOfflineState> without a `kind={{...}}` "
+                "prop. Pass `kind={errorKind}` so 401 -> 'Sign in', 403 -> "
+                "'Access denied', and only true network failures show the "
+                "'Cannot connect' splash."
+            )
+            continue
+
+    assert not failures, "Dashboard splash-kind drift detected (#2199 lock-in):\n  " + "\n  ".join(failures)

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -353,6 +353,32 @@ def test_json_includes_ai_bom_entities():
     assert data["ai_bom_entities"]["summary"]["agents"] == 1
 
 
+def test_json_summary_distinguishes_total_vs_unique_packages():
+    """Same package on two servers counts twice in `total_packages` (occurrences)
+    but once in `unique_packages` (deduped by stable_id), matching
+    `inventory_snapshot.packages` and `ai_bom_entities.packages`.
+
+    v0.84.6 audit flagged operators reading `total_packages` and finding
+    fewer entries in `inventory_snapshot.packages` than expected. Surfacing
+    `unique_packages` makes the occurrence-vs-unique split self-documenting
+    so the asymmetry can't read as a bug.
+    """
+    pkg = _make_pkg(name="lodash", version="4.17.20")
+    pkg_other = _make_pkg(name="lodash", version="4.17.20")
+    agent = _make_agent(
+        servers=[
+            _make_server(name="srv-a", packages=[pkg]),
+            _make_server(name="srv-b", packages=[pkg_other]),
+        ]
+    )
+    data = to_json(_make_report(agents=[agent]))
+
+    assert data["summary"]["total_packages"] == 2, "occurrence count across servers"
+    assert data["summary"]["unique_packages"] == 1, "deduped by stable_id"
+    assert len(data["inventory_snapshot"]["packages"]) == data["summary"]["unique_packages"]
+    assert len(data["ai_bom_entities"]["packages"]) == data["summary"]["unique_packages"]
+
+
 # ── Markdown ─────────────────────────────────────────────────────────────────
 
 

--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -42,6 +42,13 @@ import Link from "next/link";
 import { ComplianceHeatmap } from "@/components/compliance-heatmap";
 import { ComplianceMatrix } from "@/components/compliance-matrix";
 import { ApiOfflineState } from "@/components/api-offline-state";
+import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
+
+function _classifyApiErrorKind(err: unknown): "network" | "auth" | "forbidden" {
+  if (err instanceof ApiAuthError) return "auth";
+  if (err instanceof ApiForbiddenError) return "forbidden";
+  return "network";
+}
 
 // ─── Status helpers ──────────────────────────────────────────────────────────
 
@@ -373,6 +380,10 @@ function CompliancePageContent() {
   const [mitreCatalog, setMitreCatalog] = useState<FrameworkCatalogMetadata | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // Per #2199 splash-kind sweep: classify API errors so the splash matches
+  // the actual cause (auth/forbidden/network) instead of always reading as
+  // "Cannot connect to the agent-bom API".
+  const [errorKind, setErrorKind] = useState<"network" | "auth" | "forbidden">("network");
   const [viewMode, setViewMode] = useState<"detail" | "heatmap" | "matrix">("detail");
   const [controlQuery, setControlQuery] = useState(queryParam);
   const [statusFilter, setStatusFilter] = useState<"all" | "pass" | "warning" | "fail">("all");
@@ -387,7 +398,9 @@ function CompliancePageContent() {
         if (complianceResult.status === "fulfilled") {
           setData(complianceResult.value);
         } else {
-          setError(complianceResult.reason?.message ?? "Failed to load compliance view");
+          const reason = complianceResult.reason;
+          setError(reason?.message ?? "Failed to load compliance view");
+          setErrorKind(_classifyApiErrorKind(reason));
         }
         if (catalogResult.status === "fulfilled") {
           setMitreCatalog(catalogResult.value.frameworks?.mitre_attack ?? null);
@@ -405,10 +418,12 @@ function CompliancePageContent() {
   }
 
   if (error) {
+    const fallbackTitle = errorKind === "network" ? "Compliance view needs the agent-bom API" : undefined;
     return (
       <ApiOfflineState
-        title="Compliance view needs the agent-bom API"
+        title={fallbackTitle}
         detail={error}
+        kind={errorKind}
       />
     );
   }

--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -5,6 +5,13 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { api, Vulnerability, ScanJob, ScanResult, severityColor, severityDot, JobListItem, RemediationItem } from "@/lib/api";
 import { ApiOfflineState } from "@/components/api-offline-state";
+import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
+
+function _classifyApiErrorKind(err: unknown): "network" | "auth" | "forbidden" {
+  if (err instanceof ApiAuthError) return "auth";
+  if (err instanceof ApiForbiddenError) return "forbidden";
+  return "network";
+}
 import { Bug, Download, ExternalLink, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Layers, Loader2, Package, Server, ShieldOff, Radar, FileSearch, ShieldAlert } from "lucide-react";
 
 function downloadJson(data: unknown, filename: string) {
@@ -180,6 +187,9 @@ function VulnsPage() {
   const [loading, setLoading] = useState(true);
   const [detailLoading, setDetailLoading] = useState(false);
   const [error, setError] = useState("");
+  // Per #2199 splash-kind sweep: track auth/forbidden/network so the splash
+  // matches the actual cause instead of always reading as a connect failure.
+  const [errorKind, setErrorKind] = useState<"network" | "auth" | "forbidden">("network");
   const [scope, setScope] = useState<ScanScope>("latest");
   const [filter, setFilter] = useState<SeverityFilter>(
     paramSeverity && ["critical", "high", "medium", "low"].includes(paramSeverity)
@@ -313,6 +323,7 @@ function VulnsPage() {
         setJobs(doneJobs);
       } catch (e: unknown) {
         setError(e instanceof Error ? e.message : "Failed to load");
+        setErrorKind(_classifyApiErrorKind(e));
       } finally {
         setLoading(false);
       }
@@ -341,6 +352,7 @@ function VulnsPage() {
         }
       } catch (e: unknown) {
         setError(e instanceof Error ? e.message : "Failed to load");
+        setErrorKind(_classifyApiErrorKind(e));
       } finally {
         setDetailLoading(false);
       }
@@ -479,8 +491,9 @@ function VulnsPage() {
       )}
       {!loading && error && (
         <ApiOfflineState
-          title="Findings need the agent-bom API"
+          title={errorKind === "network" ? "Findings need the agent-bom API" : undefined}
           detail={error}
+          kind={errorKind}
         />
       )}
 


### PR DESCRIPTION
## Summary

Closes the two outstanding v0.84.6 / v0.85.0 audit observations:

1. **Splash-kind sweep** — extends #2196 from 2 pages (dashboard root + security-graph) to **every** Next.js page that mounts \`ApiOfflineState\`. Compliance and vulns pages now classify thrown errors via \`ApiAuthError\` / \`ApiForbiddenError\` and pass \`kind={errorKind}\`, so 401 reads "Sign in", 403 reads "Access denied", and the legacy "Cannot connect to the agent-bom API" copy shows only for true network failures.

2. **Occurrence-vs-unique package count** — JSON output now surfaces both \`summary.total_packages\` (occurrences across servers) and \`summary.unique_packages\` (deduped by stable_id). Real scans of this repo show \`total_packages: 849\` vs \`inventory_snapshot.packages\` len 829 — same package shared across two servers. The asymmetry is now self-documenting in the schema instead of reading as a bug.

## Lock-in

\`tests/test_dashboard_splash_kind_lock_in.py\` walks every \`page.tsx\` that imports \`ApiOfflineState\` and asserts both the \`@/lib/api-errors\` import and the \`kind={...}\` prop are present. New pages that mount the splash without classification fail at PR time with a self-explanatory error naming the file + remediation.

\`tests/test_output_formats.py::test_json_summary_distinguishes_total_vs_unique_packages\` locks in the occurrence-vs-unique split with a fixture that puts the same package on two servers.

## Test plan

- [x] \`pytest tests/test_output_formats.py tests/test_dashboard_splash_kind_lock_in.py\` — 33 passed
- [x] \`npx tsc --noEmit\` — clean
- [x] Real scan against this repo confirmed \`total_packages: 849\`, \`unique_packages: 829\`, \`inventory_snapshot.packages\` len 829 — all aligned
- [ ] Boot the dashboard with \`AGENT_BOM_API_KEY\` set to a wrong value, hit /compliance and /vulns, confirm splash reads "Sign in" not "Cannot connect"