### PR TITLE
feat(compliance): hub framework-selection foundation (#1044 PR A)

### DIFF
--- a/src/agent_bom/compliance_hub.py
+++ b/src/agent_bom/compliance_hub.py
@@ -1,0 +1,216 @@
+"""Compliance Hub — context-aware framework selection (#1044 PR A).
+
+The hub answers a single question that every ingestion path needs to make
+the same way: *given a finding, which compliance frameworks apply?*
+
+Without this, every adapter (SARIF, CycloneDX, native scanner, external
+imports) re-implements the mapping ad hoc — leading to the same finding
+landing under different framework sets depending on which entry point
+loaded it. The hub centralises the selection table from issue #1044 so
+the answer is one function call regardless of source.
+
+This is PR A (foundation): pure mapping engine + test matrix. PR B wires
+the engine into ingestion adapters; PR C exposes hub aggregation
+endpoints + dashboard surface; PR D locks in cross-format invariants.
+
+The table below is the source of truth. Adding a new finding source or
+asset type means adding a row here, not editing every adapter.
+"""
+
+from __future__ import annotations
+
+from agent_bom.finding import FindingSource, FindingType
+
+# ─── Framework slugs ─────────────────────────────────────────────────────────
+# Aligned with `agent_bom.compliance_coverage.TAG_MAPPED_FRAMEWORKS` slugs.
+# Keep this list in sync — the slug is what flows through the API surface.
+
+FRAMEWORK_OWASP_LLM = "owasp-llm"
+FRAMEWORK_OWASP_MCP = "owasp-mcp"
+FRAMEWORK_OWASP_AGENTIC = "owasp-agentic"
+FRAMEWORK_ATLAS = "atlas"
+FRAMEWORK_NIST_AI_RMF = "nist"
+FRAMEWORK_NIST_CSF = "nist-csf"
+FRAMEWORK_NIST_800_53 = "nist-800-53"
+FRAMEWORK_FEDRAMP = "fedramp"
+FRAMEWORK_EU_AI_ACT = "eu-ai-act"
+FRAMEWORK_ISO_27001 = "iso-27001"
+FRAMEWORK_SOC2 = "soc2"
+FRAMEWORK_CIS = "cis"
+FRAMEWORK_CMMC = "cmmc"
+FRAMEWORK_PCI_DSS = "pci-dss"
+
+ALL_FRAMEWORKS: tuple[str, ...] = (
+    FRAMEWORK_OWASP_LLM,
+    FRAMEWORK_OWASP_MCP,
+    FRAMEWORK_OWASP_AGENTIC,
+    FRAMEWORK_ATLAS,
+    FRAMEWORK_NIST_AI_RMF,
+    FRAMEWORK_NIST_CSF,
+    FRAMEWORK_NIST_800_53,
+    FRAMEWORK_FEDRAMP,
+    FRAMEWORK_EU_AI_ACT,
+    FRAMEWORK_ISO_27001,
+    FRAMEWORK_SOC2,
+    FRAMEWORK_CIS,
+    FRAMEWORK_CMMC,
+    FRAMEWORK_PCI_DSS,
+)
+
+
+_AI_FRAMEWORKS: tuple[str, ...] = (
+    FRAMEWORK_OWASP_LLM,
+    FRAMEWORK_OWASP_MCP,
+    FRAMEWORK_OWASP_AGENTIC,
+    FRAMEWORK_ATLAS,
+    FRAMEWORK_NIST_AI_RMF,
+    FRAMEWORK_EU_AI_ACT,
+)
+
+_ENTERPRISE_FRAMEWORKS: tuple[str, ...] = (
+    FRAMEWORK_NIST_CSF,
+    FRAMEWORK_ISO_27001,
+    FRAMEWORK_SOC2,
+)
+
+_GOV_FRAMEWORKS: tuple[str, ...] = (
+    FRAMEWORK_NIST_800_53,
+    FRAMEWORK_FEDRAMP,
+    FRAMEWORK_CMMC,
+)
+
+_CONTAINER_FRAMEWORKS: tuple[str, ...] = (
+    FRAMEWORK_CIS,
+    FRAMEWORK_NIST_CSF,
+    FRAMEWORK_PCI_DSS,
+    FRAMEWORK_SOC2,
+)
+
+_CLOUD_POSTURE_FRAMEWORKS: tuple[str, ...] = (
+    FRAMEWORK_CIS,
+    FRAMEWORK_SOC2,
+    FRAMEWORK_ISO_27001,
+    FRAMEWORK_NIST_800_53,
+)
+
+
+# ─── Source → framework selection table (the source of truth) ───────────────
+# Issue #1044 specifies this mapping. Each source carries a baseline list of
+# frameworks that always apply; asset type and finding type can refine.
+
+_SOURCE_BASELINE: dict[FindingSource, tuple[str, ...]] = {
+    FindingSource.MCP_SCAN: _AI_FRAMEWORKS,
+    FindingSource.SKILL: _AI_FRAMEWORKS,
+    FindingSource.PROXY: (
+        FRAMEWORK_OWASP_LLM,
+        FRAMEWORK_OWASP_AGENTIC,
+        FRAMEWORK_ATLAS,
+    ),
+    FindingSource.BROWSER_EXT: (
+        FRAMEWORK_OWASP_LLM,
+        FRAMEWORK_ATLAS,
+    ),
+    FindingSource.CONTAINER: _CONTAINER_FRAMEWORKS,
+    FindingSource.CLOUD_CIS: _CLOUD_POSTURE_FRAMEWORKS,
+    FindingSource.SBOM: (
+        FRAMEWORK_NIST_CSF,
+        FRAMEWORK_SOC2,
+        FRAMEWORK_PCI_DSS,
+    ),
+    FindingSource.SAST: (
+        FRAMEWORK_NIST_CSF,
+        FRAMEWORK_SOC2,
+        FRAMEWORK_PCI_DSS,
+    ),
+    FindingSource.FILESYSTEM: (
+        FRAMEWORK_CIS,
+        FRAMEWORK_SOC2,
+    ),
+    FindingSource.EXTERNAL: ALL_FRAMEWORKS,
+}
+
+
+# Asset-type refinements: when the source baseline is broad, asset shape
+# narrows it. These are *additive* — they don't shrink the baseline.
+_ASSET_TYPE_ADDITIONS: dict[str, tuple[str, ...]] = {
+    "mcp_server": _AI_FRAMEWORKS,
+    "agent": _AI_FRAMEWORKS,
+    "tool": _AI_FRAMEWORKS,
+    "skill": _AI_FRAMEWORKS,
+    "container": _CONTAINER_FRAMEWORKS,
+    "cloud_resource": _CLOUD_POSTURE_FRAMEWORKS,
+    "iac_resource": (FRAMEWORK_CIS, FRAMEWORK_NIST_800_53, FRAMEWORK_FEDRAMP),
+}
+
+
+# Finding-type refinements: a CREDENTIAL_EXPOSURE on any source pulls in
+# enterprise auditing frameworks; LICENSE pulls in supply-chain governance.
+_FINDING_TYPE_ADDITIONS: dict[FindingType, tuple[str, ...]] = {
+    FindingType.CREDENTIAL_EXPOSURE: _ENTERPRISE_FRAMEWORKS,
+    FindingType.LICENSE: (FRAMEWORK_NIST_CSF, FRAMEWORK_SOC2),
+    FindingType.INJECTION: _AI_FRAMEWORKS,
+    FindingType.EXFILTRATION: _AI_FRAMEWORKS + (FRAMEWORK_SOC2,),
+    FindingType.CIS_FAIL: (FRAMEWORK_CIS,),
+}
+
+
+def select_frameworks(
+    source: FindingSource,
+    asset_type: str | None = None,
+    finding_type: FindingType | None = None,
+    *,
+    include_gov: bool = False,
+) -> list[str]:
+    """Return the list of framework slugs that apply to a finding context.
+
+    Args:
+        source: Which scanner / ingestion path produced the finding.
+        asset_type: The Asset.asset_type (e.g. "mcp_server", "container",
+            "cloud_resource", "package", "agent"). Optional but recommended.
+        finding_type: The FindingType (e.g. CREDENTIAL_EXPOSURE, INJECTION).
+            Adds finding-shape-specific frameworks on top of the source
+            baseline.
+        include_gov: When True, layer FedRAMP / NIST 800-53 / CMMC on top.
+            Off by default because most tenants don't operate under those
+            programs; the dashboard / API can opt in per tenant.
+
+    Returns:
+        Deduplicated list of framework slugs in stable order, drawn from
+        ALL_FRAMEWORKS so callers can match against
+        compliance_coverage.TAG_MAPPED_FRAMEWORKS.
+    """
+    selected: set[str] = set()
+
+    selected.update(_SOURCE_BASELINE.get(source, ()))
+
+    if asset_type:
+        selected.update(_ASSET_TYPE_ADDITIONS.get(asset_type, ()))
+
+    if finding_type:
+        selected.update(_FINDING_TYPE_ADDITIONS.get(finding_type, ()))
+
+    if include_gov:
+        selected.update(_GOV_FRAMEWORKS)
+
+    return [f for f in ALL_FRAMEWORKS if f in selected]
+
+
+def is_framework_relevant(
+    framework_slug: str,
+    source: FindingSource,
+    asset_type: str | None = None,
+    finding_type: FindingType | None = None,
+    *,
+    include_gov: bool = False,
+) -> bool:
+    """Return True if `framework_slug` applies to this finding context.
+
+    Convenience wrapper for filtering — equivalent to checking membership
+    in `select_frameworks(...)` but cheaper for single-framework checks.
+    """
+    return framework_slug in select_frameworks(
+        source,
+        asset_type,
+        finding_type,
+        include_gov=include_gov,
+    )

--- a/tests/test_compliance_hub.py
+++ b/tests/test_compliance_hub.py
@@ -1,0 +1,227 @@
+"""Compliance Hub framework-selection matrix (#1044 PR A).
+
+This test file is the executable version of the table in issue #1044:
+each (FindingSource, asset_type, finding_type) row maps to an expected
+set of frameworks that apply. If a future PR adds a new source or
+re-classifies an existing one, these tests force the change to be
+deliberate — the matrix is the contract.
+
+Two-way invariants we lock in here:
+
+1. **Inclusion** — for every documented (source × asset) pairing, the
+   expected frameworks must be selected.
+2. **Exclusion** — the AI-side frameworks (OWASP LLM / MCP / Agentic /
+   ATLAS / NIST AI RMF / EU AI Act) must NOT show up on pure-cloud or
+   pure-container findings, and vice versa. Scope discipline matters
+   because compliance auditors will read the dashboard literally.
+
+The hub is meant to be the *only* place that answers "which frameworks
+apply to this finding"; ingestion paths in PR B will call into it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.compliance_coverage import TAG_MAPPED_FRAMEWORKS
+from agent_bom.compliance_hub import (
+    FRAMEWORK_ATLAS,
+    FRAMEWORK_CIS,
+    FRAMEWORK_CMMC,
+    FRAMEWORK_EU_AI_ACT,
+    FRAMEWORK_FEDRAMP,
+    FRAMEWORK_ISO_27001,
+    FRAMEWORK_NIST_800_53,
+    FRAMEWORK_NIST_AI_RMF,
+    FRAMEWORK_NIST_CSF,
+    FRAMEWORK_OWASP_AGENTIC,
+    FRAMEWORK_OWASP_LLM,
+    FRAMEWORK_OWASP_MCP,
+    FRAMEWORK_PCI_DSS,
+    FRAMEWORK_SOC2,
+    is_framework_relevant,
+    select_frameworks,
+)
+from agent_bom.finding import FindingSource, FindingType
+
+_AI_FRAMEWORK_SET = {
+    FRAMEWORK_OWASP_LLM,
+    FRAMEWORK_OWASP_MCP,
+    FRAMEWORK_OWASP_AGENTIC,
+    FRAMEWORK_ATLAS,
+    FRAMEWORK_NIST_AI_RMF,
+    FRAMEWORK_EU_AI_ACT,
+}
+
+
+# ─── Table from #1044 — each row is one source × asset → expected frameworks ──
+
+
+@pytest.mark.parametrize(
+    "source,asset_type,expected_subset",
+    [
+        # AI / agent / MCP findings → all six AI frameworks
+        (FindingSource.MCP_SCAN, "agent", _AI_FRAMEWORK_SET),
+        (FindingSource.MCP_SCAN, "mcp_server", _AI_FRAMEWORK_SET),
+        (FindingSource.MCP_SCAN, "tool", _AI_FRAMEWORK_SET),
+        (FindingSource.SKILL, "skill", _AI_FRAMEWORK_SET),
+        # Runtime proxy → AI frameworks (LLM + Agentic + ATLAS minimum)
+        (FindingSource.PROXY, None, {FRAMEWORK_OWASP_LLM, FRAMEWORK_OWASP_AGENTIC, FRAMEWORK_ATLAS}),
+        # Browser extension → LLM + ATLAS
+        (FindingSource.BROWSER_EXT, None, {FRAMEWORK_OWASP_LLM, FRAMEWORK_ATLAS}),
+        # Container image → CIS + NIST CSF + PCI + SOC2
+        (
+            FindingSource.CONTAINER,
+            "container",
+            {FRAMEWORK_CIS, FRAMEWORK_NIST_CSF, FRAMEWORK_PCI_DSS, FRAMEWORK_SOC2},
+        ),
+        # Cloud CIS posture → CIS + SOC2 + ISO + NIST 800-53
+        (
+            FindingSource.CLOUD_CIS,
+            "cloud_resource",
+            {FRAMEWORK_CIS, FRAMEWORK_SOC2, FRAMEWORK_ISO_27001, FRAMEWORK_NIST_800_53},
+        ),
+        # SBOM / supply chain → NIST CSF + SOC2 + PCI
+        (FindingSource.SBOM, "package", {FRAMEWORK_NIST_CSF, FRAMEWORK_SOC2, FRAMEWORK_PCI_DSS}),
+        # SAST / code → NIST CSF + SOC2 + PCI
+        (FindingSource.SAST, None, {FRAMEWORK_NIST_CSF, FRAMEWORK_SOC2, FRAMEWORK_PCI_DSS}),
+        # Filesystem → CIS + SOC2
+        (FindingSource.FILESYSTEM, None, {FRAMEWORK_CIS, FRAMEWORK_SOC2}),
+    ],
+)
+def test_source_baseline_includes_expected_frameworks(source: FindingSource, asset_type: str | None, expected_subset: set[str]) -> None:
+    selected = set(select_frameworks(source, asset_type=asset_type))
+    missing = expected_subset - selected
+    assert not missing, (
+        f"source={source.value} asset_type={asset_type!r} should select "
+        f"{sorted(expected_subset)}; missing {sorted(missing)} from {sorted(selected)}"
+    )
+
+
+# ─── Scope discipline — AI frameworks must not leak onto pure-infra findings ──
+
+
+@pytest.mark.parametrize(
+    "source,asset_type,banned",
+    [
+        # Container/cloud findings must NOT carry AI framework tags
+        (FindingSource.CONTAINER, "container", _AI_FRAMEWORK_SET),
+        (FindingSource.CLOUD_CIS, "cloud_resource", _AI_FRAMEWORK_SET),
+        (FindingSource.FILESYSTEM, None, _AI_FRAMEWORK_SET),
+    ],
+)
+def test_ai_frameworks_do_not_leak_to_infra_findings(source: FindingSource, asset_type: str | None, banned: set[str]) -> None:
+    selected = set(select_frameworks(source, asset_type=asset_type))
+    leaked = banned & selected
+    assert not leaked, (
+        f"source={source.value} asset_type={asset_type!r} must not select AI frameworks {sorted(banned)}; leaked: {sorted(leaked)}"
+    )
+
+
+# ─── Finding-type refinements — same source, different finding shape ──────────
+
+
+def test_credential_exposure_pulls_in_enterprise_audit_frameworks() -> None:
+    """A leaked credential is a SOC 2 / ISO 27001 / NIST CSF event no
+    matter where it surfaced. The hub must add those even when the source
+    baseline wouldn't."""
+    selected = set(
+        select_frameworks(
+            FindingSource.MCP_SCAN,
+            asset_type="mcp_server",
+            finding_type=FindingType.CREDENTIAL_EXPOSURE,
+        )
+    )
+    for framework in (FRAMEWORK_NIST_CSF, FRAMEWORK_ISO_27001, FRAMEWORK_SOC2):
+        assert framework in selected, f"CREDENTIAL_EXPOSURE on MCP_SCAN must include {framework}; got {sorted(selected)}"
+
+
+def test_injection_finding_pulls_in_ai_frameworks_even_from_neutral_source() -> None:
+    """An INJECTION finding ingested via SAST/EXTERNAL must still light up
+    the AI framework set — the finding shape, not the source, drives the
+    classification here."""
+    selected = set(
+        select_frameworks(
+            FindingSource.SAST,
+            finding_type=FindingType.INJECTION,
+        )
+    )
+    for framework in _AI_FRAMEWORK_SET:
+        assert framework in selected, f"INJECTION must surface {framework} regardless of source; got {sorted(selected)}"
+
+
+def test_cis_fail_pulls_in_cis_even_when_source_does_not() -> None:
+    selected = set(select_frameworks(FindingSource.SAST, finding_type=FindingType.CIS_FAIL))
+    assert FRAMEWORK_CIS in selected
+
+
+# ─── External imports — auto-detect / catch-all ─────────────────────────────
+
+
+def test_external_source_selects_every_framework() -> None:
+    """SARIF / CycloneDX / CSV imports may carry findings whose source
+    can't be inferred. The hub returns every framework so the importer
+    can prune based on actual finding metadata in PR B."""
+    selected = set(select_frameworks(FindingSource.EXTERNAL))
+    expected = {meta.slug for meta in TAG_MAPPED_FRAMEWORKS} - {"aisvs"}  # benchmark slug, not tag-mapped
+    missing = expected - selected
+    assert not missing, f"EXTERNAL must offer every tag-mapped framework; missing {sorted(missing)}"
+
+
+# ─── Government overlay — opt-in ─────────────────────────────────────────────
+
+
+def test_gov_overlay_off_by_default() -> None:
+    selected = set(select_frameworks(FindingSource.CLOUD_CIS, asset_type="cloud_resource"))
+    assert FRAMEWORK_FEDRAMP not in selected
+    assert FRAMEWORK_CMMC not in selected
+
+
+def test_gov_overlay_on_demand() -> None:
+    selected = set(
+        select_frameworks(
+            FindingSource.CLOUD_CIS,
+            asset_type="cloud_resource",
+            include_gov=True,
+        )
+    )
+    assert FRAMEWORK_FEDRAMP in selected
+    assert FRAMEWORK_CMMC in selected
+    assert FRAMEWORK_NIST_800_53 in selected
+
+
+# ─── Stable ordering — the hub must return frameworks in canonical order ─────
+
+
+def test_select_frameworks_returns_stable_canonical_order() -> None:
+    """Two calls with the same inputs return the same list. This matters
+    for downstream consumers that hash / cache the framework set."""
+    a = select_frameworks(FindingSource.MCP_SCAN, asset_type="mcp_server")
+    b = select_frameworks(FindingSource.MCP_SCAN, asset_type="mcp_server")
+    assert a == b, "select_frameworks must be deterministic"
+
+
+def test_is_framework_relevant_matches_select_frameworks() -> None:
+    """The convenience wrapper must agree with the full selector."""
+    selected = select_frameworks(FindingSource.MCP_SCAN, asset_type="mcp_server")
+    for slug in selected:
+        assert is_framework_relevant(slug, FindingSource.MCP_SCAN, asset_type="mcp_server")
+    assert not is_framework_relevant(FRAMEWORK_PCI_DSS, FindingSource.MCP_SCAN, asset_type="mcp_server")
+
+
+# ─── Slug parity — every selectable slug must exist in the coverage catalog ──
+
+
+def test_every_selected_slug_resolves_in_compliance_coverage() -> None:
+    """If select_frameworks returns a slug, the dashboard / report API
+    must be able to render it. This catches drift where the hub references
+    a framework that isn't in TAG_MAPPED_FRAMEWORKS."""
+    coverage_slugs = {meta.slug for meta in TAG_MAPPED_FRAMEWORKS}
+    # Walk every plausible source and asset combination
+    for source in FindingSource:
+        for asset_type in (None, "mcp_server", "agent", "tool", "container", "cloud_resource", "package"):
+            for slug in select_frameworks(source, asset_type=asset_type, include_gov=True):
+                assert slug in coverage_slugs, (
+                    f"Hub returned slug {slug!r} for source={source.value} / asset={asset_type!r} "
+                    f"but it isn't registered in compliance_coverage.TAG_MAPPED_FRAMEWORKS"
+                )


### PR DESCRIPTION
## Summary

PR A of the 4-PR Compliance Hub series ([#1044](https://github.com/msaad00/agent-bom/issues/1044)). Foundation only — pure mapping engine plus a parametric test matrix that locks in the selection table from the issue.

The hub centralises the question every ingestion path needs to answer the same way: **given a finding, which compliance frameworks apply?** Without this, SARIF / CycloneDX / native-scanner / external imports each re-implement the mapping ad hoc and the same finding lands under different framework sets depending on which entry point loaded it.

## Selection table (#1044)

| Finding source | Frameworks |
|---|---|
| \`MCP_SCAN\` / \`SKILL\` / \`PROXY\` / \`BROWSER_EXT\` | OWASP LLM, MCP, Agentic, ATLAS, NIST AI RMF, EU AI Act |
| \`CONTAINER\` | CIS, NIST CSF, PCI DSS, SOC 2 |
| \`CLOUD_CIS\` | CIS, SOC 2, ISO 27001, NIST 800-53 |
| \`SBOM\` / \`SAST\` | NIST CSF, SOC 2, PCI DSS |
| \`FILESYSTEM\` | CIS, SOC 2 |
| \`EXTERNAL\` | All (PR B will prune from finding metadata) |

Asset type and finding type **refine** the source baseline:
- \`CREDENTIAL_EXPOSURE\` on any source pulls in enterprise audit frameworks (NIST CSF / ISO / SOC 2)
- \`INJECTION\` ingested via SAST still lights up the AI set
- \`include_gov=True\` opts a tenant into FedRAMP / NIST 800-53 / CMMC

## Lock-in

23 parametric tests in \`tests/test_compliance_hub.py\` walk the table:

- **Inclusion** — every documented (source, asset) pairing selects its expected frameworks.
- **Exclusion** — AI frameworks must NOT leak onto container / cloud / filesystem findings (and vice versa). Auditors read the dashboard literally.
- **Slug parity** — every slug returned by \`select_frameworks\` must resolve in \`compliance_coverage.TAG_MAPPED_FRAMEWORKS\`. Catches drift where the hub references a framework the dashboard can't render.
- **Determinism** — same inputs → same ordered list (downstream consumers cache framework sets).

## Roadmap (the 4-PR series)

- **PR A (this PR)** — selection engine + matrix. **Pure foundation, no behaviour change.**
- PR B — wire the engine into ingestion adapters (SARIF, CycloneDX, CSV, JSON), populate \`Finding\` framework tag fields via the hub.
- PR C — \`POST /v1/compliance/ingest\`, \`GET /v1/compliance/hub/posture\`, \`GET /v1/compliance/hub/export/{framework}\`, dashboard \`/compliance\` page reads aggregate.
- PR D — cross-format invariants matrix (same finding ingested via SARIF, CycloneDX, CSV must land on identical framework set).

## Test plan

- [x] \`pytest tests/test_compliance_hub.py -v\` — 23 passed
- [x] No public surface change yet — nothing to manually exercise. PR B will plug the engine into ingestion paths.