### PR TITLE
feat(compliance): hub-classify native + SARIF findings (#1044 PR B)

### DIFF
--- a/src/agent_bom/compliance_hub.py
+++ b/src/agent_bom/compliance_hub.py
@@ -19,7 +19,12 @@ asset type means adding a row here, not editing every adapter.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from agent_bom.finding import FindingSource, FindingType
+
+if TYPE_CHECKING:
+    from agent_bom.finding import Finding
 
 # ─── Framework slugs ─────────────────────────────────────────────────────────
 # Aligned with `agent_bom.compliance_coverage.TAG_MAPPED_FRAMEWORKS` slugs.
@@ -193,6 +198,34 @@ def select_frameworks(
         selected.update(_GOV_FRAMEWORKS)
 
     return [f for f in ALL_FRAMEWORKS if f in selected]
+
+
+def apply_hub_classification(finding: "Finding", *, include_gov: bool = False) -> "Finding":
+    """Populate `finding.applicable_frameworks` using the hub selection table.
+
+    Idempotent and additive: existing entries are preserved, the hub-derived
+    slugs are merged in (deduped, canonical order). Used by every finding
+    generator and ingestion adapter so a finding's framework classification
+    is consistent regardless of which entry point produced it.
+
+    Returns the same finding for fluent chaining.
+    """
+    selected = select_frameworks(
+        finding.source,
+        asset_type=finding.asset.asset_type,
+        finding_type=finding.finding_type,
+        include_gov=include_gov,
+    )
+    seen = set(finding.applicable_frameworks)
+    for slug in selected:
+        if slug not in seen:
+            finding.applicable_frameworks.append(slug)
+            seen.add(slug)
+    # Re-order to canonical so consumers can hash the list reliably.
+    finding.applicable_frameworks = [slug for slug in ALL_FRAMEWORKS if slug in seen] + [
+        slug for slug in finding.applicable_frameworks if slug not in ALL_FRAMEWORKS
+    ]
+    return finding
 
 
 def is_framework_relevant(

--- a/src/agent_bom/compliance_hub_ingest.py
+++ b/src/agent_bom/compliance_hub_ingest.py
@@ -1,0 +1,216 @@
+"""External-source ingestion for the Compliance Hub (#1044 PR B).
+
+Reads findings from external scanner outputs (SARIF today; CycloneDX,
+CSV, and JSON in PR C) and produces unified ``Finding`` objects with
+framework classification populated by ``compliance_hub.apply_hub_classification``.
+
+The contract is uniform: every external finding carries
+``FindingSource.EXTERNAL`` plus the original tool name in ``evidence``.
+The hub maps that to the union of all tag-mapped frameworks; ingestion
+adapters can refine via ``finding_type`` so downstream consumers see the
+right framework set without each adapter re-implementing the mapping.
+
+PR B ships the SARIF adapter — the most common external format for SAST,
+secret scanners, IaC scanners, and container vuln scanners. Other formats
+land in PR C alongside the API ingestion endpoint that consumes them.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from agent_bom.compliance_hub import apply_hub_classification
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType
+
+# SARIF level → severity. SARIF only defines four levels; we map none/note
+# down to "info" so they don't masquerade as low-severity bugs.
+_SARIF_LEVEL_TO_SEVERITY = {
+    "error": "high",
+    "warning": "medium",
+    "note": "info",
+    "none": "info",
+}
+
+
+def _coerce_severity(level: str | None, security_severity: float | None) -> str:
+    """Pick the best severity signal from a SARIF result.
+
+    SARIF 2.1.0 defines `level` (note/warning/error) and `properties.security-severity`
+    (CVSS-style 0–10 score). We prefer the security-severity score when present
+    because it carries more signal; otherwise fall back to the level.
+    """
+    if security_severity is not None:
+        if security_severity >= 9.0:
+            return "critical"
+        if security_severity >= 7.0:
+            return "high"
+        if security_severity >= 4.0:
+            return "medium"
+        if security_severity > 0:
+            return "low"
+        return "info"
+    return _SARIF_LEVEL_TO_SEVERITY.get((level or "warning").lower(), "medium")
+
+
+def _pick_finding_type(
+    rule_id: str | None,
+    rule_tags: list[str],
+    message: str,
+) -> FindingType:
+    """Best-effort finding-type inference from rule metadata.
+
+    Drives the hub's finding-type refinements (e.g. INJECTION pulls in AI
+    frameworks even when source is EXTERNAL). The defaults are conservative
+    — when in doubt, fall back to SAST so the hub assigns the broadest
+    enterprise framework set.
+    """
+    haystack = " ".join(filter(None, [rule_id or "", " ".join(rule_tags), message])).lower()
+    if "secret" in haystack or "credential" in haystack or "password" in haystack or "token" in haystack:
+        return FindingType.CREDENTIAL_EXPOSURE
+    if "injection" in haystack or "prompt-injection" in haystack or "sqli" in haystack or "xss" in haystack:
+        return FindingType.INJECTION
+    if "exfil" in haystack or "data-exfiltration" in haystack:
+        return FindingType.EXFILTRATION
+    if "license" in haystack:
+        return FindingType.LICENSE
+    if "cve-" in haystack or "ghsa-" in haystack:
+        return FindingType.CVE
+    if "cis-" in haystack or "benchmark" in haystack:
+        return FindingType.CIS_FAIL
+    return FindingType.SAST
+
+
+def _rule_tags(rule: dict) -> list[str]:
+    props = rule.get("properties") or {}
+    tags = props.get("tags") or []
+    return [str(t) for t in tags]
+
+
+def _result_location(result: dict) -> tuple[str, str | None]:
+    """Return (display_name, file_path) for a SARIF result.
+
+    SARIF locations carry a `physicalLocation.artifactLocation.uri`. We use
+    that as both the asset name and location so findings can be deduped by
+    file path across rules.
+    """
+    locations = result.get("locations") or []
+    if not locations:
+        return ("unknown", None)
+    physical = locations[0].get("physicalLocation") or {}
+    artifact = physical.get("artifactLocation") or {}
+    uri = artifact.get("uri")
+    if not uri:
+        return ("unknown", None)
+    region = physical.get("region") or {}
+    line = region.get("startLine")
+    name = f"{uri}:{line}" if line else uri
+    return (str(name), str(uri))
+
+
+def _build_rule_index(run: dict) -> dict[str, dict]:
+    """Index `rules[]` by id so we can fetch metadata for each result."""
+    tool = run.get("tool") or {}
+    driver = tool.get("driver") or {}
+    rules = driver.get("rules") or []
+    return {str(rule.get("id") or ""): rule for rule in rules if rule.get("id")}
+
+
+def _tool_name(run: dict) -> str:
+    tool = run.get("tool") or {}
+    driver = tool.get("driver") or {}
+    return str(driver.get("name") or "external")
+
+
+def ingest_sarif_findings(path: str | Path) -> list[Finding]:
+    """Parse a SARIF 2.1.0 file into hub-classified ``Finding`` objects.
+
+    Every finding carries ``FindingSource.EXTERNAL`` plus the originating
+    tool name (and rule id) in ``evidence``. Framework classification runs
+    through ``apply_hub_classification`` so the same matrix applies as
+    native scanners — no adapter-specific mapping table.
+
+    Returns an empty list (rather than raising) on missing or malformed
+    files so callers can ingest a directory of SARIF files without one
+    bad apple aborting the batch. The caller can detect "nothing parsed"
+    by checking the returned length.
+    """
+    sarif_path = Path(path)
+    if not sarif_path.is_file():
+        return []
+    try:
+        sarif = json.loads(sarif_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        return []
+    if not isinstance(sarif, dict):
+        return []
+
+    runs = sarif.get("runs") or []
+    findings: list[Finding] = []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        tool_name = _tool_name(run)
+        rule_index = _build_rule_index(run)
+        for result in run.get("results") or []:
+            if not isinstance(result, dict):
+                continue
+            findings.append(_sarif_result_to_finding(result, rule_index, tool_name))
+    return findings
+
+
+def _sarif_result_to_finding(result: dict, rule_index: dict[str, dict], tool_name: str) -> Finding:
+    rule_id = str(result.get("ruleId") or "")
+    rule = rule_index.get(rule_id, {})
+    rule_tags = _rule_tags(rule)
+
+    message_text = ((result.get("message") or {}).get("text") or "").strip()
+    rule_short = ((rule.get("shortDescription") or {}).get("text") or "").strip()
+    rule_full = ((rule.get("fullDescription") or {}).get("text") or "").strip()
+    description = message_text or rule_full or rule_short or rule_id
+
+    level = result.get("level")
+    properties = result.get("properties") or {}
+    sec_severity_raw = properties.get("security-severity") or (rule.get("properties") or {}).get("security-severity")
+    sec_severity: float | None
+    try:
+        sec_severity = float(sec_severity_raw) if sec_severity_raw is not None else None
+    except (TypeError, ValueError):
+        sec_severity = None
+
+    severity = _coerce_severity(level, sec_severity)
+
+    asset_name, location = _result_location(result)
+    finding_type = _pick_finding_type(rule_id, rule_tags, description)
+
+    cwe_ids = [tag.upper() for tag in rule_tags if tag.lower().startswith("cwe-")]
+
+    evidence: dict[str, Any] = {
+        "external_tool": tool_name,
+        "rule_id": rule_id,
+        "rule_tags": rule_tags,
+        "sarif_level": level,
+    }
+    if sec_severity is not None:
+        evidence["sarif_security_severity"] = sec_severity
+
+    title = rule_short or rule_id or message_text[:100] or "External finding"
+
+    finding = Finding(
+        finding_type=finding_type,
+        source=FindingSource.EXTERNAL,
+        asset=Asset(
+            name=asset_name,
+            asset_type="file" if location else "external",
+            identifier=rule_id or None,
+            location=location,
+        ),
+        severity=severity,
+        title=title,
+        description=description,
+        cwe_ids=cwe_ids,
+        cvss_score=sec_severity,
+        evidence=evidence,
+    )
+    return apply_hub_classification(finding)

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -118,6 +118,9 @@ class Finding:
 
     # Compliance mappings (same tags as BlastRadius for parity)
     compliance_tags: list[str] = field(default_factory=list)  # all framework tags combined
+    # Framework slugs that govern this finding (set by compliance_hub.apply_hub_classification).
+    # Distinct from the per-framework `*_tags` fields below, which hold control codes.
+    applicable_frameworks: list[str] = field(default_factory=list)
     owasp_tags: list[str] = field(default_factory=list)
     atlas_tags: list[str] = field(default_factory=list)
     attack_tags: list[str] = field(default_factory=list)
@@ -215,6 +218,7 @@ class Finding:
             "fixed_version": self.fixed_version,
             "remediation_guidance": self.remediation_guidance,
             "compliance_tags": self.all_compliance_tags(),
+            "applicable_frameworks": list(self.applicable_frameworks),
             "owasp_tags": self.owasp_tags,
             "atlas_tags": self.atlas_tags,
             "attack_tags": self.attack_tags,
@@ -391,7 +395,9 @@ def blast_radius_to_finding(br: object) -> "Finding":
 
     sev = vuln.severity.value if hasattr(vuln.severity, "value") else str(vuln.severity)
 
-    return Finding(
+    from agent_bom.compliance_hub import apply_hub_classification
+
+    finding = Finding(
         finding_type=FindingType.CVE,
         source=FindingSource.MCP_SCAN,
         asset=asset,
@@ -421,3 +427,4 @@ def blast_radius_to_finding(br: object) -> "Finding":
         evidence=evidence,
         risk_score=br.risk_score,
     )
+    return apply_hub_classification(finding)

--- a/src/agent_bom/mcp_blocklist.py
+++ b/src/agent_bom/mcp_blocklist.py
@@ -377,47 +377,48 @@ def flag_blocklisted_mcp_servers(agents: list[Agent], blocklist: dict[str, Any] 
 
 def blocklist_findings_for_agents(agents: list[Agent], blocklist: dict[str, Any] | None = None) -> list[Finding]:
     """Create unified findings for MCP blocklist hits and stamp server warnings."""
+    from agent_bom.compliance_hub import apply_hub_classification
+
     findings: list[Finding] = []
     for agent in agents:
         for server in agent.mcp_servers:
             for match in match_mcp_server(server, blocklist):
                 _stamp_server_match(server, match)
 
-                findings.append(
-                    Finding(
-                        finding_type=FindingType.MCP_BLOCKLIST,
-                        source=FindingSource.MCP_SCAN,
-                        asset=Asset(
-                            name=server.name,
-                            asset_type="mcp_server",
-                            identifier=server.registry_id,
-                            location=server.config_path or server.command or None,
-                        ),
-                        severity=match.severity,
-                        title=match.title,
-                        description=match.description,
-                        remediation_guidance="Remove or disable the matched MCP server until the blocklist entry is reviewed.",
-                        owasp_mcp_tags=["MCP04", "MCP07"],
-                        evidence={
-                            "agent_name": agent.name,
-                            "server_name": server.name,
-                            "server_stable_id": server.stable_id,
-                            "entry_id": match.entry_id,
-                            "match_type": match.match_type,
-                            "matched_value": match.matched_value,
-                            "blocklist_source": match.source,
-                            "confidence": match.confidence,
-                            "default_recommendation": match.default_recommendation,
-                            "source_type": match.source_type,
-                            "ecosystem": match.ecosystem,
-                            "package": match.package,
-                            "affected_versions": match.affected_versions,
-                            "first_seen": match.first_seen,
-                            "last_verified": match.last_verified,
-                            "remediation_actions": list(match.remediation_actions),
-                            "references": list(match.references),
-                        },
-                        risk_score=10.0 if match.severity == "critical" else 8.0,
-                    )
+                finding = Finding(
+                    finding_type=FindingType.MCP_BLOCKLIST,
+                    source=FindingSource.MCP_SCAN,
+                    asset=Asset(
+                        name=server.name,
+                        asset_type="mcp_server",
+                        identifier=server.registry_id,
+                        location=server.config_path or server.command or None,
+                    ),
+                    severity=match.severity,
+                    title=match.title,
+                    description=match.description,
+                    remediation_guidance="Remove or disable the matched MCP server until the blocklist entry is reviewed.",
+                    owasp_mcp_tags=["MCP04", "MCP07"],
+                    evidence={
+                        "agent_name": agent.name,
+                        "server_name": server.name,
+                        "server_stable_id": server.stable_id,
+                        "entry_id": match.entry_id,
+                        "match_type": match.match_type,
+                        "matched_value": match.matched_value,
+                        "blocklist_source": match.source,
+                        "confidence": match.confidence,
+                        "default_recommendation": match.default_recommendation,
+                        "source_type": match.source_type,
+                        "ecosystem": match.ecosystem,
+                        "package": match.package,
+                        "affected_versions": match.affected_versions,
+                        "first_seen": match.first_seen,
+                        "last_verified": match.last_verified,
+                        "remediation_actions": list(match.remediation_actions),
+                        "references": list(match.references),
+                    },
+                    risk_score=10.0 if match.severity == "critical" else 8.0,
                 )
+                findings.append(apply_hub_classification(finding))
     return findings

--- a/tests/test_compliance_hub_ingest.py
+++ b/tests/test_compliance_hub_ingest.py
@@ -1,0 +1,306 @@
+"""Tests for hub-driven finding classification + SARIF ingestion (#1044 PR B).
+
+Two contracts to lock in:
+
+1. **Native generators call the hub** — `blast_radius_to_finding` and
+   `mcp_blocklist.blocklist_findings_for_agents` produce findings whose
+   `applicable_frameworks` matches `select_frameworks(...)` for that
+   source/asset/finding-type. Any future generator that bypasses the hub
+   is a bug — the hub is the single source of truth.
+
+2. **External SARIF flows through the same hub** — a SARIF result lands
+   as a `Finding(source=EXTERNAL)` with the same framework-selection
+   semantics. CWE tags lift from rule properties; severity coerces from
+   `security-severity` (preferred) or `level` (fallback). Rule-id and
+   message text drive finding-type inference (CREDENTIAL_EXPOSURE,
+   INJECTION, etc.) so the hub's finding-type refinements kick in.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_bom.compliance_hub import (
+    FRAMEWORK_ATLAS,
+    FRAMEWORK_ISO_27001,
+    FRAMEWORK_NIST_AI_RMF,
+    FRAMEWORK_NIST_CSF,
+    FRAMEWORK_OWASP_AGENTIC,
+    FRAMEWORK_OWASP_LLM,
+    FRAMEWORK_OWASP_MCP,
+    FRAMEWORK_SOC2,
+    select_frameworks,
+)
+from agent_bom.compliance_hub_ingest import ingest_sarif_findings
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType
+from agent_bom.mcp_blocklist import blocklist_findings_for_agents
+from agent_bom.models import (
+    Agent,
+    AgentStatus,
+    AgentType,
+    BlastRadius,
+    MCPServer,
+    Package,
+    Severity,
+    TransportType,
+    Vulnerability,
+)
+
+# ─── Native-generator wiring ──────────────────────────────────────────────────
+
+
+def _make_agent_with_blocklisted_server(name: str = "claude") -> Agent:
+    server = MCPServer(
+        name="evil-mcp-server",
+        command="npx",
+        args=["evil-mcp-server"],
+        transport=TransportType.STDIO,
+        registry_id="evil-mcp-server",
+    )
+    return Agent(
+        name=name,
+        agent_type=AgentType.CLAUDE_DESKTOP,
+        config_path="/tmp/test.json",
+        mcp_servers=[server],
+        status=AgentStatus.CONFIGURED,
+    )
+
+
+def test_blocklist_findings_carry_hub_framework_classification():
+    """An MCP_BLOCKLIST finding must carry the AI framework set the hub
+    selects for source=MCP_SCAN + asset_type=mcp_server."""
+    agent = _make_agent_with_blocklisted_server()
+    blocklist = {
+        "version": "1",
+        "entries": [
+            {
+                "id": "test-entry-001",
+                "names": ["evil-mcp-server"],
+                "severity": "high",
+                "title": "Test malicious server",
+                "description": "Test entry",
+                "source": "test",
+            }
+        ],
+    }
+    findings = blocklist_findings_for_agents([agent], blocklist=blocklist)
+    assert findings, "blocklist match should produce a finding"
+
+    expected = set(
+        select_frameworks(
+            FindingSource.MCP_SCAN,
+            asset_type="mcp_server",
+            finding_type=FindingType.MCP_BLOCKLIST,
+        )
+    )
+    actual = set(findings[0].applicable_frameworks)
+    assert expected.issubset(actual), f"blocklist finding missing frameworks {sorted(expected - actual)} (got {sorted(actual)})"
+    # AI frameworks must be present (this is an MCP server finding)
+    assert FRAMEWORK_OWASP_LLM in actual
+    assert FRAMEWORK_OWASP_MCP in actual
+    assert FRAMEWORK_ATLAS in actual
+
+
+def test_blast_radius_to_finding_carries_hub_classification():
+    pkg = Package(name="left-pad", version="1.0.0", ecosystem="npm")
+    server = MCPServer(name="srv", command="npx", args=["srv"], transport=TransportType.STDIO, packages=[pkg])
+    vuln = Vulnerability(
+        id="CVE-2025-0000",
+        summary="test cve",
+        severity=Severity.HIGH,
+    )
+    br = BlastRadius(
+        package=pkg,
+        vulnerability=vuln,
+        affected_servers=[server],
+        affected_agents=[],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+
+    from agent_bom.finding import blast_radius_to_finding
+
+    finding = blast_radius_to_finding(br)
+    assert finding.source == FindingSource.MCP_SCAN
+    assert finding.asset.asset_type == "mcp_server"
+    expected = set(
+        select_frameworks(
+            FindingSource.MCP_SCAN,
+            asset_type="mcp_server",
+            finding_type=FindingType.CVE,
+        )
+    )
+    assert expected.issubset(set(finding.applicable_frameworks))
+
+
+def test_finding_to_dict_emits_applicable_frameworks():
+    """The serialised payload must surface the new field so API/UI
+    consumers can render the framework set without reaching back into
+    the hub."""
+    finding = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=Asset(name="srv", asset_type="mcp_server"),
+        severity="high",
+        applicable_frameworks=["owasp-llm", "atlas"],
+    )
+    payload = finding.to_dict()
+    assert payload["applicable_frameworks"] == ["owasp-llm", "atlas"]
+
+
+# ─── SARIF ingestion ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def sarif_with_secret_finding(tmp_path: Path) -> Path:
+    """A minimal SARIF 2.1.0 doc carrying a secret-scanner result."""
+    doc = {
+        "version": "2.1.0",
+        "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/cos02/schemas/sarif-schema-2.1.0.json",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "external-secret-scanner",
+                        "rules": [
+                            {
+                                "id": "SECRET-AWS-ACCESS-KEY",
+                                "shortDescription": {"text": "AWS access key in source"},
+                                "properties": {"tags": ["security", "secret", "CWE-798"]},
+                            }
+                        ],
+                    }
+                },
+                "results": [
+                    {
+                        "ruleId": "SECRET-AWS-ACCESS-KEY",
+                        "level": "error",
+                        "message": {"text": "Hardcoded AWS access key"},
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "artifactLocation": {"uri": "src/config.py"},
+                                    "region": {"startLine": 42},
+                                }
+                            }
+                        ],
+                        "properties": {"security-severity": "9.5"},
+                    }
+                ],
+            }
+        ],
+    }
+    target = tmp_path / "secrets.sarif"
+    target.write_text(json.dumps(doc), encoding="utf-8")
+    return target
+
+
+def test_sarif_ingest_produces_external_finding(sarif_with_secret_finding: Path):
+    findings = ingest_sarif_findings(sarif_with_secret_finding)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.source == FindingSource.EXTERNAL
+    assert f.evidence["external_tool"] == "external-secret-scanner"
+    assert f.evidence["rule_id"] == "SECRET-AWS-ACCESS-KEY"
+    assert f.severity == "critical"  # security-severity 9.5 → critical
+    assert f.cwe_ids == ["CWE-798"]
+    assert f.asset.location == "src/config.py"
+    assert f.asset.name == "src/config.py:42"
+
+
+def test_sarif_secret_finding_pulls_in_enterprise_audit_frameworks(sarif_with_secret_finding: Path):
+    """Rule id contains 'SECRET' → finding_type=CREDENTIAL_EXPOSURE → hub
+    refinement adds NIST CSF / ISO 27001 / SOC 2 even though the source
+    is EXTERNAL."""
+    findings = ingest_sarif_findings(sarif_with_secret_finding)
+    f = findings[0]
+    assert f.finding_type == FindingType.CREDENTIAL_EXPOSURE
+    for fw in (FRAMEWORK_NIST_CSF, FRAMEWORK_ISO_27001, FRAMEWORK_SOC2):
+        assert fw in f.applicable_frameworks, f"CREDENTIAL_EXPOSURE must include {fw}; got {f.applicable_frameworks}"
+
+
+def test_sarif_injection_rule_lights_up_ai_frameworks(tmp_path: Path):
+    """A SARIF result whose rule mentions 'injection' must surface AI
+    frameworks via the hub's finding-type refinement, even though the
+    source is EXTERNAL and could otherwise be anything."""
+    doc = {
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "semgrep",
+                        "rules": [
+                            {"id": "prompt-injection-detector", "shortDescription": {"text": "Prompt injection"}},
+                        ],
+                    }
+                },
+                "results": [
+                    {
+                        "ruleId": "prompt-injection-detector",
+                        "level": "error",
+                        "message": {"text": "Possible prompt injection"},
+                        "locations": [{"physicalLocation": {"artifactLocation": {"uri": "agent.py"}}}],
+                    }
+                ],
+            }
+        ],
+    }
+    sarif = tmp_path / "injection.sarif"
+    sarif.write_text(json.dumps(doc), encoding="utf-8")
+    findings = ingest_sarif_findings(sarif)
+    assert findings
+    f = findings[0]
+    assert f.finding_type == FindingType.INJECTION
+    for fw in (FRAMEWORK_OWASP_LLM, FRAMEWORK_OWASP_AGENTIC, FRAMEWORK_ATLAS, FRAMEWORK_NIST_AI_RMF):
+        assert fw in f.applicable_frameworks
+
+
+def test_sarif_severity_falls_back_to_level_when_no_security_severity(tmp_path: Path):
+    doc = {
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {"driver": {"name": "x", "rules": []}},
+                "results": [
+                    {
+                        "ruleId": "R1",
+                        "level": "warning",
+                        "message": {"text": "minor issue"},
+                        "locations": [{"physicalLocation": {"artifactLocation": {"uri": "a.py"}}}],
+                    }
+                ],
+            }
+        ],
+    }
+    sarif = tmp_path / "level.sarif"
+    sarif.write_text(json.dumps(doc), encoding="utf-8")
+    findings = ingest_sarif_findings(sarif)
+    assert findings[0].severity == "medium"  # warning → medium
+
+
+def test_sarif_missing_file_returns_empty_list(tmp_path: Path):
+    findings = ingest_sarif_findings(tmp_path / "does-not-exist.sarif")
+    assert findings == []
+
+
+def test_sarif_malformed_json_returns_empty_list_no_crash(tmp_path: Path):
+    bad = tmp_path / "bad.sarif"
+    bad.write_text("not json {", encoding="utf-8")
+    assert ingest_sarif_findings(bad) == []
+
+
+def test_sarif_zero_runs_zero_results_does_not_crash(tmp_path: Path):
+    sarif = tmp_path / "empty.sarif"
+    sarif.write_text(json.dumps({"version": "2.1.0", "runs": []}), encoding="utf-8")
+    assert ingest_sarif_findings(sarif) == []
+
+
+def test_sarif_finding_serialises_with_applicable_frameworks(sarif_with_secret_finding: Path):
+    findings = ingest_sarif_findings(sarif_with_secret_finding)
+    payload = findings[0].to_dict()
+    assert "applicable_frameworks" in payload
+    assert FRAMEWORK_NIST_CSF in payload["applicable_frameworks"]


### PR DESCRIPTION
## Summary

PR B of the 4-PR Compliance Hub series ([#1044](https://github.com/msaad00/agent-bom/issues/1044)). Mechanical wiring: the framework-selection engine from [PR A (#2200)](https://github.com/msaad00/agent-bom/pull/2200) now sits behind every finding, native or external.

## What lands

**Finding model gains \`applicable_frameworks: list[str]\`** — framework slugs from the hub. Distinct from the per-framework \`*_tags\` fields, which hold control codes. Slugs answer "which frameworks govern this finding"; codes answer "which controls within each framework".

**Native generators now call the hub:**
- \`blast_radius_to_finding()\` — CVE findings carry the AI framework set
- \`mcp_blocklist.blocklist_findings_for_agents()\` — blocklist hits same

**SARIF ingestion** (\`compliance_hub_ingest.ingest_sarif_findings\`):
- accepts SARIF 2.1.0 from any tool (Semgrep, Gitleaks, Trivy, custom)
- maps results to \`Finding(source=EXTERNAL)\` with file:line asset
- prefers \`properties.security-severity\` (CVSS-style 0–10) over \`level\` for severity
- infers \`finding_type\` from rule id / tags / message (CREDENTIAL_EXPOSURE, INJECTION, EXFILTRATION, LICENSE, CVE, CIS_FAIL, fallback SAST)
- finding-type drives hub refinements:
  - a \`SECRET-*\` rule lights up SOC 2 / ISO 27001 / NIST CSF
  - a \`prompt-injection-*\` rule lights up the AI framework set even though source is EXTERNAL
- CWE tags lift from \`rule.properties.tags\`
- malformed / missing files return \`[]\` instead of raising — batch ingestion of a directory survives one bad file

## Lock-in

11 new tests in \`tests/test_compliance_hub_ingest.py\`:

- **Native-generator contract** — \`blast_radius_to_finding\` and blocklist findings carry \`applicable_frameworks\` matching \`select_frameworks(...)\` for their source/asset/finding-type.
- **SARIF ingestion** — severity coercion (security-severity preferred over level), finding-type inference for secrets/injection, CWE lifting, asset URI parsing.
- **Hub refinements through SARIF** — secret-scanner SARIF pulls in enterprise audit frameworks; injection-scanner SARIF pulls in AI frameworks. Same hub, same answer.
- **Resilience** — missing file, malformed JSON, zero-runs all return \`[]\` cleanly.
- **Serialization** — \`Finding.to_dict()\` emits \`applicable_frameworks\` so API/UI consumers don't reach back into the hub.

## Roadmap (the 4-PR series)

- ✅ PR A (#2200) — selection engine + matrix
- **PR B (this PR)** — Finding wiring + SARIF adapter
- PR C — CycloneDX / CSV / JSON adapters + \`POST /v1/compliance/ingest\` + \`GET /v1/compliance/hub/posture\` + dashboard \`/compliance\` aggregate view
- PR D — cross-format invariants (same finding ingested via SARIF, CycloneDX, CSV must land on identical framework sets)

## Test plan

- [x] \`pytest tests/test_compliance_hub.py tests/test_compliance_hub_ingest.py\` — 34 passed
- [x] \`pytest tests/test_output_formats.py\` — 31 passed (no regression on Finding serialization)
- [x] mypy / ruff clean via pre-commit