### PR TITLE
docs(cli): add --self-scan to agents subcommand reference

### DIFF
--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -120,7 +120,12 @@ agent-bom agents --generate-vex --vex-output vex.json
 
 # Config directory
 agent-bom agents --config-dir /path/to/configs
+
+# Self-scan (scan agent-bom's own installed dependencies)
+agent-bom agents --self-scan
 ```
+
+The `--self-scan` flag is on the `agents` subcommand (not top-level). It walks the active Python environment via `importlib.metadata.distributions()` and emits a CVE report against agent-bom's own runtime so you can audit the tool with the tool.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Closes the documentation gap from the v0.85.0 hands-on audit observation:

> \`--self-scan\` lives on the agents subcommand, not top-level.

Adds the example to \`site-docs/reference/cli.md\` plus a one-line note disambiguating placement so the next operator finds it directly.

## Audit observation status

| # | Item | Status |
|---|------|--------|
| 1 | \`firewall validate\|list\|check\` positional POLICY_FILE | ✅ docs/AGENT_FIREWALL.md already correct (\`-p\` was a transcription slip in earlier audit) |
| 2 | \`--self-scan\` placement docs | ✅ this PR |
| 3 | Empty package count data shape | ✅ closed in #2199 via \`summary.unique_packages\` |
| 4 | \`--offline\` aborts without prior \`db update\` | ✅ error already names the fix (\"Run agent-bom db update before using --offline\") |
| 5 | Audit log HMAC key warning | ✅ already explicit |

## Test plan

- [x] visual review of \`site-docs/reference/cli.md\` in the rendered output