### PR TITLE
feat(compliance): hub ingest API + dashboard surface (#1044 PR C)

### DIFF
--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -1,0 +1,66 @@
+"""Tenant-scoped in-memory store for hub-ingested findings (#1044 PR C).
+
+Persists external compliance findings (SARIF / CycloneDX / CSV / JSON
+imports) alongside native scan results so dashboard / API aggregations
+can render unified posture.
+
+In-memory for now — durable persistence (Postgres / ClickHouse) lands
+in a follow-up. The store is single-process; multi-replica deployments
+should treat ingested findings as ephemeral until persistence ships.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+
+class ComplianceHubStore:
+    """Tenant-scoped append-only ledger of hub-ingested findings.
+
+    Each finding is stored as its serialised dict (Finding.to_dict()) so
+    the API can return the canonical payload without re-serialising on
+    every read.
+    """
+
+    def __init__(self) -> None:
+        self._by_tenant: dict[str, list[dict[str, Any]]] = {}
+        self._lock = threading.Lock()
+
+    def add(self, tenant_id: str, findings: list[dict[str, Any]]) -> int:
+        """Append findings for a tenant. Returns the new total count."""
+        with self._lock:
+            bucket = self._by_tenant.setdefault(tenant_id, [])
+            bucket.extend(findings)
+            return len(bucket)
+
+    def list(self, tenant_id: str) -> list[dict[str, Any]]:
+        with self._lock:
+            return list(self._by_tenant.get(tenant_id, []))
+
+    def count(self, tenant_id: str) -> int:
+        with self._lock:
+            return len(self._by_tenant.get(tenant_id, []))
+
+    def clear(self, tenant_id: str) -> int:
+        with self._lock:
+            removed = len(self._by_tenant.get(tenant_id, []))
+            self._by_tenant[tenant_id] = []
+            return removed
+
+
+_HUB_STORE: ComplianceHubStore | None = None
+
+
+def get_compliance_hub_store() -> ComplianceHubStore:
+    """Return the process-wide hub store, lazily constructed."""
+    global _HUB_STORE
+    if _HUB_STORE is None:
+        _HUB_STORE = ComplianceHubStore()
+    return _HUB_STORE
+
+
+def reset_compliance_hub_store() -> None:
+    """Reset the store — for tests only."""
+    global _HUB_STORE
+    _HUB_STORE = None

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -1393,3 +1393,180 @@ async def get_incident_correlation(request: Request) -> dict:
 
     incidents = latest_result.get("incident_correlation", [])
     return {"incidents": incidents, "count": len(incidents)}
+
+
+# ─── Compliance Hub (#1044 PR C) ──────────────────────────────────────────────
+
+
+_HUB_VALID_FORMATS = ("sarif", "cyclonedx", "csv", "json")
+
+
+@router.post(
+    "/v1/compliance/ingest",
+    tags=["compliance"],
+    status_code=201,
+    dependencies=[_dep("scan")],
+)
+async def ingest_compliance_findings(request: Request) -> dict:
+    """Ingest external findings (SARIF / CycloneDX / CSV / JSON).
+
+    Body:
+        {"format": "sarif" | "cyclonedx" | "csv" | "json",
+         "content": "<file body as a string>"}
+
+    The content is parsed via the matching adapter in
+    ``compliance_hub_ingest``; every produced finding is hub-classified
+    and appended to the tenant's hub store. Returns the per-framework
+    framework-hit breakdown so the caller can verify classification ran.
+    """
+    import tempfile
+    from pathlib import Path
+
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+    from agent_bom.compliance_hub_ingest import ingest_findings
+
+    body = await request.json()
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="Body must be a JSON object")
+    fmt = (body.get("format") or "").lower()
+    if fmt not in _HUB_VALID_FORMATS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"format must be one of {list(_HUB_VALID_FORMATS)}",
+        )
+    content = body.get("content")
+    if not isinstance(content, str) or not content.strip():
+        raise HTTPException(status_code=400, detail="content (string) is required")
+
+    suffix = ".csv" if fmt == "csv" else ".json"
+    with tempfile.NamedTemporaryFile(mode="w", suffix=suffix, delete=False, encoding="utf-8") as tmp:
+        tmp.write(content)
+        tmp_path = Path(tmp.name)
+
+    try:
+        findings = ingest_findings(tmp_path, fmt=fmt)
+    finally:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+    if not findings:
+        raise HTTPException(
+            status_code=422,
+            detail=f"No findings parsed from {fmt} content. Check the format matches the body shape (e.g. SARIF runs[].results[]).",
+        )
+
+    payloads = [f.to_dict() for f in findings]
+    tenant_id = _tenant_id(request)
+    store = get_compliance_hub_store()
+    new_total = store.add(tenant_id, payloads)
+
+    framework_counts: dict[str, int] = {}
+    for payload in payloads:
+        for slug in payload.get("applicable_frameworks") or []:
+            framework_counts[slug] = framework_counts.get(slug, 0) + 1
+
+    return {
+        "ingested": len(payloads),
+        "tenant_total": new_total,
+        "format": fmt,
+        "framework_hits": dict(sorted(framework_counts.items())),
+    }
+
+
+@router.get("/v1/compliance/hub/findings", tags=["compliance"])
+async def list_hub_findings(request: Request, limit: int = 200, offset: int = 0) -> dict:
+    """List hub-ingested findings for the current tenant."""
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+
+    findings = get_compliance_hub_store().list(_tenant_id(request))
+    limit = max(1, min(limit, 1000))
+    offset = max(0, offset)
+    page = findings[offset : offset + limit]
+    return {
+        "findings": page,
+        "count": len(page),
+        "total": len(findings),
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+@router.get("/v1/compliance/hub/posture", tags=["compliance"])
+async def get_hub_posture(request: Request) -> dict:
+    """Aggregate compliance posture across native scans + hub-ingested findings.
+
+    Returns per-framework counts, severity breakdown, and source mix
+    (native vs external) so the dashboard /compliance page can render a
+    single posture story across every entry point.
+    """
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+
+    tenant_id = _tenant_id(request)
+    hub_findings = get_compliance_hub_store().list(tenant_id)
+
+    # Native sources: count blast radii from completed scan jobs as a
+    # proxy for "native finding count per framework" using their tag fields.
+    native_framework_counts: dict[str, int] = {}
+    native_total = 0
+    for job in _tenant_jobs(request):
+        if job.status != JobStatus.DONE or not job.result:
+            continue
+        for br in job.result.get("blast_radius", []) or []:
+            native_total += 1
+            for slug, field in (
+                ("owasp-llm", "owasp_tags"),
+                ("atlas", "atlas_tags"),
+                ("nist", "nist_ai_rmf_tags"),
+                ("owasp-mcp", "owasp_mcp_tags"),
+                ("owasp-agentic", "owasp_agentic_tags"),
+                ("eu-ai-act", "eu_ai_act_tags"),
+                ("nist-csf", "nist_csf_tags"),
+                ("iso-27001", "iso_27001_tags"),
+                ("soc2", "soc2_tags"),
+                ("cis", "cis_tags"),
+            ):
+                if br.get(field):
+                    native_framework_counts[slug] = native_framework_counts.get(slug, 0) + 1
+
+    hub_framework_counts: dict[str, int] = {}
+    hub_severity_counts: dict[str, int] = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}
+    for f in hub_findings:
+        sev = (f.get("severity") or "unknown").lower()
+        hub_severity_counts[sev] = hub_severity_counts.get(sev, 0) + 1
+        for slug in f.get("applicable_frameworks") or []:
+            hub_framework_counts[slug] = hub_framework_counts.get(slug, 0) + 1
+
+    combined: dict[str, int] = {}
+    for slug, count in native_framework_counts.items():
+        combined[slug] = combined.get(slug, 0) + count
+    for slug, count in hub_framework_counts.items():
+        combined[slug] = combined.get(slug, 0) + count
+
+    return {
+        "totals": {
+            "native": native_total,
+            "hub": len(hub_findings),
+            "combined": native_total + len(hub_findings),
+        },
+        "framework_counts": {
+            "native": dict(sorted(native_framework_counts.items())),
+            "hub": dict(sorted(hub_framework_counts.items())),
+            "combined": dict(sorted(combined.items())),
+        },
+        "hub_severity_breakdown": hub_severity_counts,
+    }
+
+
+@router.delete("/v1/compliance/hub/findings", tags=["compliance"], dependencies=[_dep("policy_write")])
+async def clear_hub_findings(request: Request) -> dict:
+    """Clear all hub-ingested findings for the current tenant.
+
+    Useful when a tenant wants to re-import a clean batch (e.g. after
+    a scanner-version upgrade). Native scan results are not affected.
+    """
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+
+    removed = get_compliance_hub_store().clear(_tenant_id(request))
+    return {"removed": removed}

--- a/src/agent_bom/compliance_hub_ingest.py
+++ b/src/agent_bom/compliance_hub_ingest.py
@@ -1,25 +1,29 @@
-"""External-source ingestion for the Compliance Hub (#1044 PR B).
+"""External-source ingestion for the Compliance Hub (#1044 PR B + C).
 
-Reads findings from external scanner outputs (SARIF today; CycloneDX,
-CSV, and JSON in PR C) and produces unified ``Finding`` objects with
-framework classification populated by ``compliance_hub.apply_hub_classification``.
+Reads findings from external scanner outputs and produces unified
+``Finding`` objects with framework classification populated by
+``compliance_hub.apply_hub_classification``.
+
+Supported formats:
+- SARIF 2.1.0 (PR B) — Semgrep, Gitleaks, Trivy, custom SAST
+- CycloneDX vulnerabilities[] (PR C) — Syft+Grype, Trivy, Snyk SBOMs
+- Generic CSV (PR C) — column-mapped row → Finding
+- Generic JSON (PR C) — list-of-finding-shaped dicts
 
 The contract is uniform: every external finding carries
 ``FindingSource.EXTERNAL`` plus the original tool name in ``evidence``.
-The hub maps that to the union of all tag-mapped frameworks; ingestion
-adapters can refine via ``finding_type`` so downstream consumers see the
-right framework set without each adapter re-implementing the mapping.
-
-PR B ships the SARIF adapter — the most common external format for SAST,
-secret scanners, IaC scanners, and container vuln scanners. Other formats
-land in PR C alongside the API ingestion endpoint that consumes them.
+Ingestion adapters refine via ``finding_type`` so downstream consumers
+see the right framework set without each adapter re-implementing the
+mapping.
 """
 
 from __future__ import annotations
 
+import csv
+import io
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 from agent_bom.compliance_hub import apply_hub_classification
 from agent_bom.finding import Asset, Finding, FindingSource, FindingType
@@ -214,3 +218,317 @@ def _sarif_result_to_finding(result: dict, rule_index: dict[str, dict], tool_nam
         evidence=evidence,
     )
     return apply_hub_classification(finding)
+
+
+# ─── CycloneDX vulnerabilities[] ────────────────────────────────────────────
+
+
+_CYCLONEDX_SEVERITY_VALUES = {"critical", "high", "medium", "low", "info", "none", "unknown"}
+
+
+def _cyclonedx_severity(vuln: dict) -> tuple[str, float | None]:
+    """Pick severity + cvss score from a CycloneDX vulnerability entry.
+
+    CycloneDX `ratings[]` carries `severity` (string) and `score`
+    (CVSS-style float). Take the first rating with a recognised severity;
+    if score is set, surface it as cvss_score for downstream risk math.
+    """
+    severity = "unknown"
+    cvss_score: float | None = None
+    for rating in vuln.get("ratings") or []:
+        if not isinstance(rating, dict):
+            continue
+        sev_raw = str(rating.get("severity") or "").lower()
+        if sev_raw in _CYCLONEDX_SEVERITY_VALUES:
+            severity = sev_raw
+        score = rating.get("score")
+        if score is not None:
+            try:
+                cvss_score = float(score)
+            except (TypeError, ValueError):
+                pass
+        if severity != "unknown":
+            break
+    return severity, cvss_score
+
+
+def _cyclonedx_affected_purl(vuln: dict, components: dict[str, dict]) -> str | None:
+    """Resolve `affects[].ref` -> bom-ref -> component purl."""
+    for affect in vuln.get("affects") or []:
+        if not isinstance(affect, dict):
+            continue
+        ref = str(affect.get("ref") or "")
+        comp = components.get(ref)
+        if comp is None:
+            continue
+        purl = comp.get("purl")
+        if purl:
+            return str(purl)
+        name = comp.get("name") or ""
+        version = comp.get("version") or ""
+        if name:
+            return f"{name}@{version}" if version else name
+    return None
+
+
+def ingest_cyclonedx_vulnerabilities(path: str | Path) -> list[Finding]:
+    """Parse CycloneDX vulnerabilities[] into hub-classified Finding objects.
+
+    Maps to ``FindingSource.SBOM`` (not EXTERNAL): CycloneDX vuln data
+    comes from a known supply-chain context, so the hub's SBOM baseline
+    (NIST CSF / SOC 2 / PCI DSS) applies cleanly. CVE finding-type
+    refinement isn't a hub addition — CVEs already pull SBOM frameworks
+    by source.
+    """
+    sbom_path = Path(path)
+    if not sbom_path.is_file():
+        return []
+    try:
+        sbom = json.loads(sbom_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        return []
+    if not isinstance(sbom, dict):
+        return []
+
+    components_by_ref: dict[str, dict] = {}
+    for comp in sbom.get("components") or []:
+        if isinstance(comp, dict):
+            ref = comp.get("bom-ref")
+            if ref:
+                components_by_ref[str(ref)] = comp
+
+    findings: list[Finding] = []
+    for vuln in sbom.get("vulnerabilities") or []:
+        if not isinstance(vuln, dict):
+            continue
+        vuln_id = str(vuln.get("id") or "").strip()
+        if not vuln_id:
+            continue
+        summary = str(vuln.get("description") or vuln.get("detail") or "")
+        severity, cvss = _cyclonedx_severity(vuln)
+        purl = _cyclonedx_affected_purl(vuln, components_by_ref)
+
+        asset_name = purl or vuln_id
+        finding = Finding(
+            finding_type=FindingType.CVE,
+            source=FindingSource.SBOM,
+            asset=Asset(
+                name=asset_name,
+                asset_type="package",
+                identifier=purl,
+            ),
+            severity=severity,
+            title=f"{vuln_id}: {asset_name}",
+            description=summary,
+            cve_id=vuln_id,
+            cvss_score=cvss,
+            evidence={
+                "external_format": "cyclonedx",
+                "vuln_id": vuln_id,
+            },
+        )
+        findings.append(apply_hub_classification(finding))
+
+    return findings
+
+
+# ─── Generic CSV ─────────────────────────────────────────────────────────────
+
+
+# Default header → field mapping. Callers can override per file.
+_CSV_DEFAULT_MAPPING = {
+    "title": ("title", "rule", "rule_id", "name", "summary"),
+    "severity": ("severity", "level", "priority"),
+    "description": ("description", "message", "detail"),
+    "asset_name": ("file", "path", "asset", "resource", "location", "target"),
+    "cve_id": ("cve", "cve_id", "cwe", "id", "vuln_id"),
+}
+
+
+def _resolve_csv_field(row: dict[str, str], candidates: tuple[str, ...]) -> str:
+    for key in candidates:
+        for header in row:
+            if header.lower().replace(" ", "_") == key:
+                value = row[header]
+                if value:
+                    return str(value).strip()
+    return ""
+
+
+def _normalise_csv_severity(value: str) -> str:
+    lowered = value.lower().strip()
+    if lowered in ("critical", "crit"):
+        return "critical"
+    if lowered in ("high", "h"):
+        return "high"
+    if lowered in ("medium", "med", "moderate", "m"):
+        return "medium"
+    if lowered in ("low", "l"):
+        return "low"
+    if lowered in ("info", "informational", "note"):
+        return "info"
+    return lowered or "unknown"
+
+
+def ingest_csv_findings(path: str | Path) -> list[Finding]:
+    """Parse a generic CSV of findings into Finding objects.
+
+    Headers are matched case-insensitively against ``_CSV_DEFAULT_MAPPING``.
+    Rows missing both title and CVE id are skipped — there's nothing
+    actionable to render.
+    """
+    csv_path = Path(path)
+    if not csv_path.is_file():
+        return []
+    try:
+        text = csv_path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+
+    findings: list[Finding] = []
+    reader = csv.DictReader(io.StringIO(text))
+    for row in reader:
+        if not row:
+            continue
+        title = _resolve_csv_field(row, _CSV_DEFAULT_MAPPING["title"])
+        cve_id = _resolve_csv_field(row, _CSV_DEFAULT_MAPPING["cve_id"])
+        if not title and not cve_id:
+            continue
+        severity = _normalise_csv_severity(_resolve_csv_field(row, _CSV_DEFAULT_MAPPING["severity"]))
+        description = _resolve_csv_field(row, _CSV_DEFAULT_MAPPING["description"])
+        asset_name = _resolve_csv_field(row, _CSV_DEFAULT_MAPPING["asset_name"]) or title or cve_id
+
+        finding_type = FindingType.CVE if cve_id and cve_id.upper().startswith(("CVE-", "GHSA-")) else FindingType.SAST
+        asset_type = "package" if finding_type == FindingType.CVE else "file"
+
+        finding = Finding(
+            finding_type=finding_type,
+            source=FindingSource.EXTERNAL,
+            asset=Asset(name=asset_name, asset_type=asset_type, location=asset_name if asset_type == "file" else None),
+            severity=severity,
+            title=title or cve_id,
+            description=description,
+            cve_id=cve_id or None,
+            evidence={
+                "external_format": "csv",
+                "row_keys": sorted(row.keys()),
+            },
+        )
+        findings.append(apply_hub_classification(finding))
+    return findings
+
+
+# ─── Generic JSON list ───────────────────────────────────────────────────────
+
+
+_JSON_FINDING_KEYS = ("title", "severity", "description", "cve_id", "asset_name", "asset_type", "finding_type")
+
+
+def ingest_json_findings(path: str | Path) -> list[Finding]:
+    """Parse a generic JSON list of finding-shaped dicts into Findings.
+
+    Accepts either a top-level list of dicts or a dict with a "findings" key
+    holding the list. Each dict can carry any subset of: title, severity,
+    description, cve_id, asset_name, asset_type, finding_type, location,
+    evidence. Unknown keys are passed through into evidence so nothing
+    is lost.
+    """
+    json_path = Path(path)
+    if not json_path.is_file():
+        return []
+    try:
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        return []
+    if isinstance(data, dict):
+        rows: Iterable[Any] = data.get("findings") or []
+    elif isinstance(data, list):
+        rows = data
+    else:
+        return []
+
+    findings: list[Finding] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        title = str(row.get("title") or row.get("name") or row.get("rule_id") or "").strip()
+        cve_id = str(row.get("cve_id") or row.get("cve") or "").strip() or None
+        if not title and not cve_id:
+            continue
+        severity = _normalise_csv_severity(str(row.get("severity") or row.get("level") or ""))
+        description = str(row.get("description") or row.get("message") or "")
+        asset_name = str(row.get("asset_name") or row.get("file") or row.get("location") or "") or title or (cve_id or "")
+        asset_type_raw = str(row.get("asset_type") or "").strip().lower()
+        if asset_type_raw not in {"file", "package", "mcp_server", "agent", "tool", "container", "cloud_resource", "skill", "external"}:
+            asset_type_raw = "package" if cve_id else "external"
+
+        ft_raw = str(row.get("finding_type") or "").strip().upper()
+        try:
+            finding_type = FindingType(ft_raw) if ft_raw else (FindingType.CVE if cve_id else FindingType.SAST)
+        except ValueError:
+            finding_type = FindingType.CVE if cve_id else FindingType.SAST
+
+        evidence: dict[str, Any] = {"external_format": "json"}
+        passthrough = {k: v for k, v in row.items() if k not in _JSON_FINDING_KEYS and k not in {"location", "evidence"}}
+        if passthrough:
+            evidence["passthrough"] = passthrough
+        if isinstance(row.get("evidence"), dict):
+            evidence.update(row["evidence"])
+
+        finding = Finding(
+            finding_type=finding_type,
+            source=FindingSource.EXTERNAL,
+            asset=Asset(
+                name=asset_name,
+                asset_type=asset_type_raw,
+                location=str(row.get("location") or "") or None,
+            ),
+            severity=severity,
+            title=title or (cve_id or "External finding"),
+            description=description,
+            cve_id=cve_id,
+            evidence=evidence,
+        )
+        findings.append(apply_hub_classification(finding))
+    return findings
+
+
+# ─── Format dispatch ─────────────────────────────────────────────────────────
+
+
+def ingest_findings(path: str | Path, *, fmt: str | None = None) -> list[Finding]:
+    """Ingest findings from a file, auto-detecting format from extension.
+
+    ``fmt`` overrides extension detection: "sarif", "cyclonedx", "csv", "json".
+    """
+    p = Path(path)
+    chosen = (fmt or "").lower()
+    if not chosen:
+        suffix = p.suffix.lower().lstrip(".")
+        if suffix == "sarif":
+            chosen = "sarif"
+        elif suffix == "csv":
+            chosen = "csv"
+        elif suffix == "json":
+            try:
+                head = p.read_text(encoding="utf-8")[:512]
+            except (UnicodeDecodeError, OSError):
+                return []
+            if '"$schema"' in head and "sarif" in head.lower():
+                chosen = "sarif"
+            elif '"bomFormat"' in head or '"specVersion"' in head:
+                chosen = "cyclonedx"
+            else:
+                chosen = "json"
+        else:
+            return []
+
+    if chosen == "sarif":
+        return ingest_sarif_findings(p)
+    if chosen == "cyclonedx":
+        return ingest_cyclonedx_vulnerabilities(p)
+    if chosen == "csv":
+        return ingest_csv_findings(p)
+    if chosen == "json":
+        return ingest_json_findings(p)
+    return []

--- a/tests/test_compliance_hub_api.py
+++ b/tests/test_compliance_hub_api.py
@@ -1,0 +1,240 @@
+"""Tests for the Compliance Hub API endpoints (#1044 PR C).
+
+Covers:
+- POST /v1/compliance/ingest (SARIF / CycloneDX / CSV / JSON)
+- GET /v1/compliance/hub/findings
+- GET /v1/compliance/hub/posture
+- DELETE /v1/compliance/hub/findings
+- Tenant isolation: tenant A's hub findings must never appear for tenant B
+
+The store is process-wide and in-memory (PR C scope), so tests reset it
+between cases to avoid cross-test bleed.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.compliance_hub_store import reset_compliance_hub_store
+from agent_bom.api.server import app
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+
+
+@pytest.fixture(autouse=True)
+def _reset_store():
+    reset_compliance_hub_store()
+    yield
+    reset_compliance_hub_store()
+
+
+def _client(tenant: str = "tenant-alpha", role: str = "admin") -> TestClient:
+    client = TestClient(app)
+    client.headers.update(proxy_headers(role=role, tenant=tenant))
+    return client
+
+
+def _sarif_doc() -> dict:
+    return {
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "external-secrets",
+                        "rules": [
+                            {
+                                "id": "SECRET-AWS-ACCESS-KEY",
+                                "shortDescription": {"text": "AWS access key"},
+                                "properties": {"tags": ["secret", "CWE-798"]},
+                            }
+                        ],
+                    }
+                },
+                "results": [
+                    {
+                        "ruleId": "SECRET-AWS-ACCESS-KEY",
+                        "level": "error",
+                        "message": {"text": "Hardcoded AWS access key"},
+                        "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/cfg.py"}}}],
+                        "properties": {"security-severity": "9.5"},
+                    }
+                ],
+            }
+        ],
+    }
+
+
+# ─── POST /v1/compliance/ingest ──────────────────────────────────────────────
+
+
+def test_ingest_sarif_returns_count_plus_framework_breakdown():
+    resp = _client().post(
+        "/v1/compliance/ingest",
+        json={"format": "sarif", "content": json.dumps(_sarif_doc())},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["ingested"] == 1
+    assert body["tenant_total"] == 1
+    assert body["format"] == "sarif"
+    # SECRET rule -> CREDENTIAL_EXPOSURE -> hub adds enterprise audit frameworks
+    assert "soc2" in body["framework_hits"]
+    assert "iso-27001" in body["framework_hits"]
+    assert "nist-csf" in body["framework_hits"]
+
+
+def test_ingest_invalid_format_returns_400():
+    resp = _client().post(
+        "/v1/compliance/ingest",
+        json={"format": "xml", "content": "<x/>"},
+    )
+    assert resp.status_code == 400
+
+
+def test_ingest_empty_content_returns_400():
+    resp = _client().post(
+        "/v1/compliance/ingest",
+        json={"format": "sarif", "content": ""},
+    )
+    assert resp.status_code == 400
+
+
+def test_ingest_unparseable_sarif_returns_422():
+    resp = _client().post(
+        "/v1/compliance/ingest",
+        json={"format": "sarif", "content": json.dumps({"version": "2.1.0", "runs": []})},
+    )
+    assert resp.status_code == 422
+
+
+def test_ingest_csv_classifies_cve_rows():
+    csv = "Title,Severity,CVE\nlodash CVE,High,CVE-2021-23337\n"
+    resp = _client().post(
+        "/v1/compliance/ingest",
+        json={"format": "csv", "content": csv},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["ingested"] == 1
+
+
+# ─── GET /v1/compliance/hub/findings ─────────────────────────────────────────
+
+
+def test_list_hub_findings_returns_what_we_ingested():
+    client = _client()
+    client.post(
+        "/v1/compliance/ingest",
+        json={"format": "sarif", "content": json.dumps(_sarif_doc())},
+    )
+    resp = client.get("/v1/compliance/hub/findings")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["count"] == 1
+    assert body["findings"][0]["source"] == "EXTERNAL"
+
+
+def test_list_hub_findings_pagination():
+    client = _client()
+    csv_rows = "Title,Severity\n" + "\n".join(f"row-{i},low" for i in range(50))
+    client.post("/v1/compliance/ingest", json={"format": "csv", "content": csv_rows})
+
+    resp = client.get("/v1/compliance/hub/findings?limit=10&offset=20")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["count"] == 10
+    assert body["total"] == 50
+    assert body["offset"] == 20
+
+
+# ─── Tenant isolation ────────────────────────────────────────────────────────
+
+
+def test_hub_findings_are_tenant_scoped():
+    """Tenant A's ingest must not appear under tenant B's hub findings."""
+    a = _client(tenant="tenant-alpha")
+    b = _client(tenant="tenant-beta")
+
+    a.post("/v1/compliance/ingest", json={"format": "sarif", "content": json.dumps(_sarif_doc())})
+
+    a_list = a.get("/v1/compliance/hub/findings").json()
+    b_list = b.get("/v1/compliance/hub/findings").json()
+
+    assert a_list["total"] == 1
+    assert b_list["total"] == 0
+
+
+# ─── GET /v1/compliance/hub/posture ──────────────────────────────────────────
+
+
+def test_hub_posture_aggregates_hub_findings_per_framework():
+    client = _client()
+    client.post(
+        "/v1/compliance/ingest",
+        json={"format": "sarif", "content": json.dumps(_sarif_doc())},
+    )
+
+    resp = client.get("/v1/compliance/hub/posture")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["totals"]["hub"] == 1
+    assert body["totals"]["combined"] >= 1
+    # SECRET rule -> CREDENTIAL_EXPOSURE adds SOC 2
+    assert body["framework_counts"]["hub"].get("soc2", 0) >= 1
+    assert body["hub_severity_breakdown"]["critical"] == 1
+
+
+def test_hub_posture_with_no_findings_returns_zeros():
+    body = _client().get("/v1/compliance/hub/posture").json()
+    assert body["totals"]["hub"] == 0
+    assert body["framework_counts"]["hub"] == {}
+
+
+# ─── DELETE /v1/compliance/hub/findings ──────────────────────────────────────
+
+
+def test_clear_hub_findings_resets_store_for_tenant():
+    client = _client()
+    client.post(
+        "/v1/compliance/ingest",
+        json={"format": "sarif", "content": json.dumps(_sarif_doc())},
+    )
+    delete = client.delete("/v1/compliance/hub/findings")
+    assert delete.status_code == 200
+    assert delete.json()["removed"] == 1
+
+    after = client.get("/v1/compliance/hub/findings").json()
+    assert after["total"] == 0
+
+
+def test_clear_hub_findings_does_not_affect_other_tenant():
+    a = _client(tenant="tenant-alpha")
+    b = _client(tenant="tenant-beta")
+    a.post("/v1/compliance/ingest", json={"format": "sarif", "content": json.dumps(_sarif_doc())})
+    b.post("/v1/compliance/ingest", json={"format": "sarif", "content": json.dumps(_sarif_doc())})
+
+    a.delete("/v1/compliance/hub/findings")
+
+    assert a.get("/v1/compliance/hub/findings").json()["total"] == 0
+    assert b.get("/v1/compliance/hub/findings").json()["total"] == 1
+
+
+def test_clear_requires_write_permission():
+    """Read-only role cannot clear the hub store."""
+    reader = TestClient(app)
+    reader.headers.update(proxy_headers(role="viewer", tenant="tenant-alpha"))
+    resp = reader.delete("/v1/compliance/hub/findings")
+    assert resp.status_code in (401, 403), f"viewer should be denied (got {resp.status_code})"

--- a/tests/test_compliance_hub_ingest.py
+++ b/tests/test_compliance_hub_ingest.py
@@ -31,10 +31,17 @@ from agent_bom.compliance_hub import (
     FRAMEWORK_OWASP_AGENTIC,
     FRAMEWORK_OWASP_LLM,
     FRAMEWORK_OWASP_MCP,
+    FRAMEWORK_PCI_DSS,
     FRAMEWORK_SOC2,
     select_frameworks,
 )
-from agent_bom.compliance_hub_ingest import ingest_sarif_findings
+from agent_bom.compliance_hub_ingest import (
+    ingest_csv_findings,
+    ingest_cyclonedx_vulnerabilities,
+    ingest_findings,
+    ingest_json_findings,
+    ingest_sarif_findings,
+)
 from agent_bom.finding import Asset, Finding, FindingSource, FindingType
 from agent_bom.mcp_blocklist import blocklist_findings_for_agents
 from agent_bom.models import (
@@ -304,3 +311,215 @@ def test_sarif_finding_serialises_with_applicable_frameworks(sarif_with_secret_f
     payload = findings[0].to_dict()
     assert "applicable_frameworks" in payload
     assert FRAMEWORK_NIST_CSF in payload["applicable_frameworks"]
+
+
+# ─── CycloneDX ingestion ─────────────────────────────────────────────────────
+
+
+def test_cyclonedx_vulns_become_sbom_findings(tmp_path: Path):
+    """CycloneDX vuln entries -> Finding(source=SBOM) so the hub assigns
+    NIST CSF / SOC 2 / PCI DSS — the supply-chain framework triplet."""
+    sbom = {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.5",
+        "components": [
+            {
+                "bom-ref": "pkg:npm/lodash@4.17.20",
+                "name": "lodash",
+                "version": "4.17.20",
+                "purl": "pkg:npm/lodash@4.17.20",
+            }
+        ],
+        "vulnerabilities": [
+            {
+                "id": "CVE-2021-23337",
+                "description": "Command injection",
+                "ratings": [{"severity": "high", "score": 7.2}],
+                "affects": [{"ref": "pkg:npm/lodash@4.17.20"}],
+            }
+        ],
+    }
+    target = tmp_path / "vulns.cdx.json"
+    target.write_text(json.dumps(sbom), encoding="utf-8")
+    findings = ingest_cyclonedx_vulnerabilities(target)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.source == FindingSource.SBOM
+    assert f.cve_id == "CVE-2021-23337"
+    assert f.severity == "high"
+    assert f.cvss_score == 7.2
+    assert f.asset.identifier == "pkg:npm/lodash@4.17.20"
+    for fw in (FRAMEWORK_NIST_CSF, FRAMEWORK_SOC2, FRAMEWORK_PCI_DSS):
+        assert fw in f.applicable_frameworks
+
+
+def test_cyclonedx_missing_file_returns_empty_list(tmp_path: Path):
+    assert ingest_cyclonedx_vulnerabilities(tmp_path / "no.json") == []
+
+
+def test_cyclonedx_no_vulnerabilities_section_returns_empty(tmp_path: Path):
+    sbom = {"bomFormat": "CycloneDX", "specVersion": "1.5", "components": []}
+    target = tmp_path / "empty.cdx.json"
+    target.write_text(json.dumps(sbom), encoding="utf-8")
+    assert ingest_cyclonedx_vulnerabilities(target) == []
+
+
+# ─── CSV ingestion ───────────────────────────────────────────────────────────
+
+
+def test_csv_findings_with_cve_classified_as_supply_chain(tmp_path: Path):
+    """Row with a CVE id -> CVE finding, EXTERNAL source. EXTERNAL pulls
+    every framework, but the asset_type=package keeps things sensible."""
+    target = tmp_path / "vulns.csv"
+    target.write_text(
+        "Title,Severity,Description,File,CVE\n"
+        "lodash CVE,High,Command injection,node_modules/lodash,CVE-2021-23337\n"
+        "no-cve,medium,no cve here,src/app.py,\n",
+        encoding="utf-8",
+    )
+    findings = ingest_csv_findings(target)
+    assert len(findings) == 2
+    cve_finding = next(f for f in findings if f.cve_id)
+    assert cve_finding.cve_id == "CVE-2021-23337"
+    assert cve_finding.finding_type == FindingType.CVE
+    assert cve_finding.severity == "high"
+    sast_finding = next(f for f in findings if not f.cve_id)
+    assert sast_finding.finding_type == FindingType.SAST
+    assert sast_finding.asset.location == "src/app.py"
+
+
+def test_csv_skips_rows_with_no_title_or_cve(tmp_path: Path):
+    target = tmp_path / "sparse.csv"
+    target.write_text("Title,Severity\n,low\nValid,medium\n", encoding="utf-8")
+    findings = ingest_csv_findings(target)
+    assert len(findings) == 1
+    assert findings[0].title == "Valid"
+
+
+def test_csv_severity_normalisation(tmp_path: Path):
+    target = tmp_path / "sevs.csv"
+    target.write_text(
+        "Title,Severity\nA,Crit\nB,Moderate\nC,Informational\n",
+        encoding="utf-8",
+    )
+    findings = ingest_csv_findings(target)
+    sevs = [f.severity for f in findings]
+    assert sevs == ["critical", "medium", "info"]
+
+
+# ─── Generic JSON ingestion ──────────────────────────────────────────────────
+
+
+def test_json_list_of_findings(tmp_path: Path):
+    payload = [
+        {
+            "title": "Hardcoded API key",
+            "severity": "critical",
+            "asset_name": "src/api.py",
+            "asset_type": "file",
+            "finding_type": "CREDENTIAL_EXPOSURE",
+            "location": "src/api.py:12",
+        },
+        {
+            "cve_id": "CVE-2024-1234",
+            "severity": "high",
+            "asset_name": "left-pad",
+            "asset_type": "package",
+        },
+    ]
+    target = tmp_path / "findings.json"
+    target.write_text(json.dumps(payload), encoding="utf-8")
+    findings = ingest_json_findings(target)
+    assert len(findings) == 2
+
+    cred = next(f for f in findings if f.finding_type == FindingType.CREDENTIAL_EXPOSURE)
+    assert cred.severity == "critical"
+    assert cred.asset.location == "src/api.py:12"
+    # CREDENTIAL_EXPOSURE refinement -> enterprise audit frameworks
+    assert FRAMEWORK_ISO_27001 in cred.applicable_frameworks
+    assert FRAMEWORK_SOC2 in cred.applicable_frameworks
+
+
+def test_json_findings_dict_with_findings_key(tmp_path: Path):
+    target = tmp_path / "wrapped.json"
+    target.write_text(
+        json.dumps({"findings": [{"title": "X", "severity": "low"}]}),
+        encoding="utf-8",
+    )
+    findings = ingest_json_findings(target)
+    assert len(findings) == 1
+    assert findings[0].title == "X"
+
+
+def test_json_findings_passes_through_unknown_keys_into_evidence(tmp_path: Path):
+    target = tmp_path / "extra.json"
+    target.write_text(
+        json.dumps([{"title": "X", "severity": "low", "custom_field": "preserve_me"}]),
+        encoding="utf-8",
+    )
+    findings = ingest_json_findings(target)
+    assert findings[0].evidence.get("passthrough", {}).get("custom_field") == "preserve_me"
+
+
+def test_json_findings_skips_non_dict_rows(tmp_path: Path):
+    target = tmp_path / "mixed.json"
+    target.write_text(json.dumps(["not-a-dict", {"title": "real", "severity": "low"}]), encoding="utf-8")
+    findings = ingest_json_findings(target)
+    assert len(findings) == 1
+
+
+# ─── Format dispatch ─────────────────────────────────────────────────────────
+
+
+def test_dispatch_detects_sarif_by_schema_url(sarif_with_secret_finding: Path):
+    findings = ingest_findings(sarif_with_secret_finding)
+    assert len(findings) == 1
+    assert findings[0].source == FindingSource.EXTERNAL
+
+
+def test_dispatch_detects_cyclonedx_by_bomformat(tmp_path: Path):
+    sbom = {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.5",
+        "components": [
+            {
+                "bom-ref": "pkg:pypi/torch@2.3.0",
+                "name": "torch",
+                "version": "2.3.0",
+                "purl": "pkg:pypi/torch@2.3.0",
+            }
+        ],
+        "vulnerabilities": [
+            {
+                "id": "CVE-2024-X",
+                "description": "x",
+                "ratings": [{"severity": "medium"}],
+                "affects": [{"ref": "pkg:pypi/torch@2.3.0"}],
+            }
+        ],
+    }
+    target = tmp_path / "sbom.json"  # extension .json, not .cdx.json
+    target.write_text(json.dumps(sbom), encoding="utf-8")
+    findings = ingest_findings(target)
+    assert len(findings) == 1
+    assert findings[0].source == FindingSource.SBOM
+
+
+def test_dispatch_csv_by_extension(tmp_path: Path):
+    target = tmp_path / "x.csv"
+    target.write_text("Title,Severity\nA,low\n", encoding="utf-8")
+    findings = ingest_findings(target)
+    assert len(findings) == 1
+
+
+def test_dispatch_unknown_extension_returns_empty(tmp_path: Path):
+    target = tmp_path / "x.txt"
+    target.write_text("nope", encoding="utf-8")
+    assert ingest_findings(target) == []
+
+
+def test_dispatch_explicit_fmt_overrides_extension(tmp_path: Path):
+    target = tmp_path / "renamed.txt"
+    target.write_text("Title,Severity\nA,low\n", encoding="utf-8")
+    findings = ingest_findings(target, fmt="csv")
+    assert len(findings) == 1

--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -7,6 +7,7 @@ import {
   ComplianceResponse,
   ComplianceControl,
   FrameworkCatalogMetadata,
+  HubPostureResponse,
   OWASP_LLM_TOP10,
   OWASP_MCP_TOP10,
   OWASP_AGENTIC_TOP10,
@@ -378,6 +379,7 @@ function CompliancePageContent() {
   const queryParam = searchParams.get("q") ?? "";
   const [data, setData] = useState<ComplianceResponse | null>(null);
   const [mitreCatalog, setMitreCatalog] = useState<FrameworkCatalogMetadata | null>(null);
+  const [hubPosture, setHubPosture] = useState<HubPostureResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   // Per #2199 splash-kind sweep: classify API errors so the splash matches
@@ -393,8 +395,12 @@ function CompliancePageContent() {
   }, [queryParam]);
 
   useEffect(() => {
-    void Promise.allSettled([api.getCompliance(), api.getFrameworkCatalogs()])
-      .then(([complianceResult, catalogResult]) => {
+    void Promise.allSettled([
+      api.getCompliance(),
+      api.getFrameworkCatalogs(),
+      api.getHubPosture(),
+    ])
+      .then(([complianceResult, catalogResult, hubResult]) => {
         if (complianceResult.status === "fulfilled") {
           setData(complianceResult.value);
         } else {
@@ -404,6 +410,10 @@ function CompliancePageContent() {
         }
         if (catalogResult.status === "fulfilled") {
           setMitreCatalog(catalogResult.value.frameworks?.mitre_attack ?? null);
+        }
+        // Hub posture is best-effort: a missing endpoint shouldn't blank the page
+        if (hubResult.status === "fulfilled") {
+          setHubPosture(hubResult.value);
         }
       })
       .finally(() => setLoading(false));
@@ -561,6 +571,37 @@ function CompliancePageContent() {
             </div>
           </div>
         </div>
+
+        {/* Compliance Hub aggregate (#1044) — surfaces external ingest counts
+            alongside the native posture so the page tells one unified story. */}
+        {hubPosture && hubPosture.totals.combined > 0 ? (
+          <div className="mt-6 rounded-xl border border-emerald-900/40 bg-emerald-950/20 p-4">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+              <div className="space-y-1">
+                <div className="text-xs uppercase tracking-[0.24em] text-emerald-400">Compliance Hub</div>
+                <div className="text-sm text-zinc-200">
+                  {hubPosture.totals.combined.toLocaleString()} finding{hubPosture.totals.combined !== 1 ? "s" : ""} across all sources
+                  {hubPosture.totals.hub > 0 ? (
+                    <>
+                      {" "}<span className="text-emerald-400">({hubPosture.totals.hub.toLocaleString()} ingested external)</span>
+                    </>
+                  ) : null}
+                </div>
+                <div className="text-xs text-zinc-500">
+                  Native: {hubPosture.totals.native.toLocaleString()} · Hub-ingested: {hubPosture.totals.hub.toLocaleString()}
+                  {Object.keys(hubPosture.framework_counts.combined).length > 0 ? (
+                    <> · Frameworks lit: {Object.keys(hubPosture.framework_counts.combined).length}</>
+                  ) : null}
+                </div>
+              </div>
+              <div className="text-xs text-zinc-500 lg:max-w-sm">
+                Import SARIF / CycloneDX / CSV / JSON via{" "}
+                <code className="rounded bg-zinc-900 px-1.5 py-0.5 text-zinc-300">POST /v1/compliance/ingest</code>{" "}
+                — every external finding is auto-mapped to the same framework set as native scans.
+              </div>
+            </div>
+          </div>
+        ) : null}
 
         {/* Framework mini-cards */}
         {mitreCatalog ? (

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1723,3 +1723,19 @@ export interface AuditIntegrityResponse {
   tampered: number;
   checked: number;
 }
+
+// ─── Compliance Hub (#1044) ─────────────────────────────────────────────────
+
+export interface HubPostureResponse {
+  totals: {
+    native: number;
+    hub: number;
+    combined: number;
+  };
+  framework_counts: {
+    native: Record<string, number>;
+    hub: Record<string, number>;
+    combined: Record<string, number>;
+  };
+  hub_severity_breakdown: Record<string, number>;
+}

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -74,7 +74,8 @@ import type {
   ProxyAlertsResponse,
   AuditEntry,
   AuditLogResponse,
-  AuditIntegrityResponse
+  AuditIntegrityResponse,
+  HubPostureResponse
 } from "./api-types";
 export type {
   JobStatus,
@@ -201,7 +202,8 @@ export type {
   ProxyAlertsResponse,
   AuditEntry,
   AuditLogResponse,
-  AuditIntegrityResponse
+  AuditIntegrityResponse,
+  HubPostureResponse
 } from "./api-types";
 
 // ── Scan Pipeline Step Types ────────────────────────────────────────────────
@@ -563,6 +565,9 @@ export const api = {
   /** Single-framework compliance narrative */
   getComplianceNarrativeByFramework: (framework: string) =>
     get<ComplianceNarrativeResponse>(`/v1/compliance/narrative/${encodeURIComponent(framework)}`),
+
+  /** Compliance Hub: aggregate posture across native + ingested findings (#1044) */
+  getHubPosture: () => get<HubPostureResponse>("/v1/compliance/hub/posture"),
 
   /** Fleet management */
   listFleet: (filters?: {


### PR DESCRIPTION
## Summary

PR C of the 4-PR Compliance Hub series ([#1044](https://github.com/msaad00/agent-bom/issues/1044)). Surface PR — turns the engine from PR A (#2200) and the wiring from PR B (#2201) into a product feature.

## Adapters (\`compliance_hub_ingest.py\`)

| Format | Source tag | Hub classification |
|---|---|---|
| SARIF (PR B) | EXTERNAL | finding-type-aware; SECRET-* → SOC 2 / ISO / NIST CSF; injection → AI frameworks |
| **CycloneDX vulnerabilities[]** | SBOM | NIST CSF + SOC 2 + PCI DSS via supply-chain baseline |
| **CSV** | EXTERNAL | CVE-shaped rows classified as CVE; everything else SAST; severity normalised across vendor variants |
| **JSON** (list of dicts) | EXTERNAL | Asset type / finding type passed through; unknown keys preserved in \`evidence.passthrough\` |

\`ingest_findings(path, fmt=...)\` dispatches by extension; for \`.json\` it sniffs content (\`bomFormat\` → CycloneDX, \`$schema\` matching SARIF → SARIF, otherwise generic JSON).

## API endpoints

| Method + path | Perm | Behaviour |
|---|---|---|
| \`POST /v1/compliance/ingest\` | \`scan\` (admin + analyst) | Body \`{format, content}\`; parses, hub-classifies, appends to tenant store; returns \`{ingested, tenant_total, framework_hits}\` |
| \`GET /v1/compliance/hub/findings\` | \`read\` | Paginated listing, tenant-scoped |
| \`GET /v1/compliance/hub/posture\` | \`read\` | Aggregate \`{native, hub, combined}\` totals + per-framework counts + hub severity breakdown |
| \`DELETE /v1/compliance/hub/findings\` | \`policy_write\` (admin only) | Resets the tenant's hub store; native scan results untouched |

## Dashboard

\`/compliance\` page renders a hub aggregate banner above the existing framework mini-cards when \`totals.combined > 0\`. Shows native vs hub split, frameworks-lit count, and a one-line CLI hint pointing at \`POST /v1/compliance/ingest\`. Banner hides cleanly on empty-state pages so first-run UX is unchanged.

## Storage caveat

\`ComplianceHubStore\` is **in-memory** for PR C scope — single-process, thread-safe append + pagination. Durable persistence (Postgres / ClickHouse) is a follow-up. Multi-replica deployments should treat ingested findings as ephemeral until persistence ships.

## Lock-in

- 13 API tests: ingest happy paths per format, 400 / 422 error contracts, list + pagination, posture aggregation, clear, tenant isolation, viewer can't clear
- 15 new adapter tests: CycloneDX vulnerabilities + supply-chain framework set, CSV severity normalisation + CVE classification, JSON passthrough preservation, format dispatch by extension + content sniffing
- Tenant isolation contract: tenant A's ingest must not appear in tenant B's listing or posture

## Roadmap

- ✅ PR A (#2200) — selection engine + matrix
- ✅ PR B (#2201) — Finding wiring + SARIF adapter
- **PR C (this PR)** — CycloneDX/CSV/JSON adapters + ingest API + dashboard
- PR D — cross-format invariants (same logical finding ingested via SARIF, CycloneDX, CSV must land on identical framework sets)

## Test plan

- [x] \`pytest tests/test_compliance_hub.py tests/test_compliance_hub_ingest.py tests/test_compliance_hub_api.py\` — 62 passed
- [x] \`npx tsc --noEmit\` — clean
- [ ] Boot the dashboard, \`POST /v1/compliance/ingest\` a SARIF file, confirm the hub aggregate banner appears on /compliance with the right counts