### PR TITLE
feat(compliance): durable hub store backends (#1044 follow-up)

### DIFF
--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -1,34 +1,63 @@
-"""Tenant-scoped in-memory store for hub-ingested findings (#1044 PR C).
+"""Tenant-scoped store for hub-ingested findings (#1044 PR C + persistence).
 
-Persists external compliance findings (SARIF / CycloneDX / CSV / JSON
-imports) alongside native scan results so dashboard / API aggregations
-can render unified posture.
+Three backends share the same Protocol so callers (`api/routes/compliance.py`)
+don't care which is wired:
 
-In-memory for now — durable persistence (Postgres / ClickHouse) lands
-in a follow-up. The store is single-process; multi-replica deployments
-should treat ingested findings as ephemeral until persistence ships.
+- ``InMemoryComplianceHubStore`` — process-local; ephemeral; the test default.
+- ``SQLiteComplianceHubStore`` — single-node persistence behind
+  ``AGENT_BOM_DB``. Survives restarts; not safe for multi-replica.
+- ``PostgresComplianceHubStore`` — multi-replica; required behind
+  ``AGENT_BOM_POSTGRES_URL`` for clustered self-hosted deployments.
+
+Selection happens in ``stores.get_compliance_hub_store()``. Same env-var
+pattern as the SCIM lifecycle store, so an operator who's already
+configured Postgres for SCIM gets durable hub findings for free.
+
+Schema is denormalised on the framework slugs: a CSV column
+``applicable_frameworks_csv`` lets posture aggregation filter at the SQL
+layer instead of decoding every payload. Each finding is also tagged
+with ``ingested_at`` so future expiry / TTL work has a key.
 """
 
 from __future__ import annotations
 
+import json
+import sqlite3
 import threading
-from typing import Any
+from typing import Any, Protocol
 
 
-class ComplianceHubStore:
-    """Tenant-scoped append-only ledger of hub-ingested findings.
+class ComplianceHubStore(Protocol):
+    """Append-only ledger of hub-ingested findings, scoped per tenant."""
 
-    Each finding is stored as its serialised dict (Finding.to_dict()) so
-    the API can return the canonical payload without re-serialising on
-    every read.
-    """
+    def add(self, tenant_id: str, findings: list[dict[str, Any]]) -> int:
+        """Append findings for a tenant. Returns the new total count."""
+        ...
+
+    def list(self, tenant_id: str) -> list[dict[str, Any]]:
+        """Return every finding for a tenant in ingest order (oldest first)."""
+        ...
+
+    def count(self, tenant_id: str) -> int:
+        """Return the count of findings for a tenant."""
+        ...
+
+    def clear(self, tenant_id: str) -> int:
+        """Remove all findings for a tenant. Returns the number removed."""
+        ...
+
+
+# ─── In-memory backend ──────────────────────────────────────────────────────
+
+
+class InMemoryComplianceHubStore:
+    """Process-local store. Ephemeral; tests + single-node demos only."""
 
     def __init__(self) -> None:
         self._by_tenant: dict[str, list[dict[str, Any]]] = {}
         self._lock = threading.Lock()
 
     def add(self, tenant_id: str, findings: list[dict[str, Any]]) -> int:
-        """Append findings for a tenant. Returns the new total count."""
         with self._lock:
             bucket = self._by_tenant.setdefault(tenant_id, [])
             bucket.extend(findings)
@@ -49,18 +78,165 @@ class ComplianceHubStore:
             return removed
 
 
+# ─── SQLite backend ─────────────────────────────────────────────────────────
+
+# Default name surfaced in the openapi description; set when AGENT_BOM_DB is wired.
+_SCHEMA_KEY = "compliance_hub"
+
+
+def _frameworks_csv(payload: dict[str, Any]) -> str:
+    """Denormalise the framework slug list into a sortable CSV column."""
+    slugs = payload.get("applicable_frameworks") or []
+    if not isinstance(slugs, list):
+        return ""
+    return ",".join(str(s) for s in slugs if s)
+
+
+def _now_utc_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class SQLiteComplianceHubStore:
+    """SQLite-backed hub store for single-node persistence.
+
+    NOT safe for multi-replica API deployments: SQLite's WAL is local to
+    the file. Use ``PostgresComplianceHubStore`` when more than one API
+    pod must share findings.
+    """
+
+    def __init__(self, db_path: str = "agent_bom.db") -> None:
+        self._db_path = db_path
+        self._local = threading.local()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        if not hasattr(self._local, "conn") or self._local.conn is None:
+            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            self._local.conn.execute("PRAGMA journal_mode=WAL")
+        conn: sqlite3.Connection = self._local.conn
+        return conn
+
+    def _init_db(self) -> None:
+        from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
+        ensure_sqlite_schema_version(self._conn, _SCHEMA_KEY)
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS compliance_hub_findings (
+                tenant_id TEXT NOT NULL,
+                finding_id TEXT NOT NULL,
+                ingested_at TEXT NOT NULL,
+                source TEXT NOT NULL,
+                applicable_frameworks_csv TEXT NOT NULL DEFAULT '',
+                payload TEXT NOT NULL,
+                ordinal INTEGER NOT NULL,
+                PRIMARY KEY (tenant_id, finding_id, ordinal)
+            )
+            """
+        )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_order ON compliance_hub_findings(tenant_id, ordinal)")
+        self._conn.commit()
+
+    def _next_ordinal(self, tenant_id: str) -> int:
+        row = self._conn.execute(
+            "SELECT COALESCE(MAX(ordinal), 0) FROM compliance_hub_findings WHERE tenant_id = ?",
+            (tenant_id,),
+        ).fetchone()
+        return int(row[0]) + 1 if row else 1
+
+    def add(self, tenant_id: str, findings: list[dict[str, Any]]) -> int:
+        if not findings:
+            return self.count(tenant_id)
+        now = _now_utc_iso()
+        next_ord = self._next_ordinal(tenant_id)
+        rows = []
+        for offset, payload in enumerate(findings):
+            rows.append(
+                (
+                    tenant_id,
+                    str(payload.get("id") or f"hub-{next_ord + offset}"),
+                    now,
+                    str(payload.get("source") or ""),
+                    _frameworks_csv(payload),
+                    json.dumps(payload, sort_keys=True),
+                    next_ord + offset,
+                )
+            )
+        self._conn.executemany(
+            """
+            INSERT OR REPLACE INTO compliance_hub_findings
+                (tenant_id, finding_id, ingested_at, source, applicable_frameworks_csv, payload, ordinal)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+        self._conn.commit()
+        return self.count(tenant_id)
+
+    def list(self, tenant_id: str) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            "SELECT payload FROM compliance_hub_findings WHERE tenant_id = ? ORDER BY ordinal ASC",
+            (tenant_id,),
+        ).fetchall()
+        return [json.loads(row[0]) for row in rows]
+
+    def count(self, tenant_id: str) -> int:
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM compliance_hub_findings WHERE tenant_id = ?",
+            (tenant_id,),
+        ).fetchone()
+        return int(row[0]) if row else 0
+
+    def clear(self, tenant_id: str) -> int:
+        cur = self._conn.execute(
+            "DELETE FROM compliance_hub_findings WHERE tenant_id = ?",
+            (tenant_id,),
+        )
+        self._conn.commit()
+        return cur.rowcount or 0
+
+
+# ─── Module-level access (set/reset wired in stores.py) ──────────────────────
+
+
 _HUB_STORE: ComplianceHubStore | None = None
 
 
 def get_compliance_hub_store() -> ComplianceHubStore:
-    """Return the process-wide hub store, lazily constructed."""
+    """Return the active hub store, lazily picking the configured backend.
+
+    Resolution order:
+      1. ``AGENT_BOM_POSTGRES_URL`` -> Postgres (multi-replica safe)
+      2. ``AGENT_BOM_DB`` -> SQLite (single-node persistent)
+      3. neither -> in-memory (ephemeral)
+    """
+    import os
+
     global _HUB_STORE
-    if _HUB_STORE is None:
-        _HUB_STORE = ComplianceHubStore()
+    if _HUB_STORE is not None:
+        return _HUB_STORE
+
+    if os.environ.get("AGENT_BOM_POSTGRES_URL"):
+        from agent_bom.api.postgres_compliance_hub import PostgresComplianceHubStore
+
+        _HUB_STORE = PostgresComplianceHubStore()
+    elif os.environ.get("AGENT_BOM_DB"):
+        _HUB_STORE = SQLiteComplianceHubStore(os.environ["AGENT_BOM_DB"])
+    else:
+        _HUB_STORE = InMemoryComplianceHubStore()
     return _HUB_STORE
 
 
+def set_compliance_hub_store(store: ComplianceHubStore | None) -> None:
+    """Override the hub store. Used by tests to inject a clean backend."""
+    global _HUB_STORE
+    _HUB_STORE = store
+
+
 def reset_compliance_hub_store() -> None:
-    """Reset the store — for tests only."""
+    """Reset to lazy-init. Used by tests; never call from production code."""
     global _HUB_STORE
     _HUB_STORE = None

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -1,0 +1,98 @@
+"""Postgres-backed Compliance Hub store for clustered deployments.
+
+Mirrors ``SQLiteComplianceHubStore`` but uses the same connection pool +
+tenant-RLS pattern as ``PostgresSCIMStore``. Selected when
+``AGENT_BOM_POSTGRES_URL`` is set so a clustered API deployment can
+share ingested findings across replicas.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent_bom.api.compliance_hub_store import _frameworks_csv, _now_utc_iso
+from agent_bom.api.postgres_common import _ensure_tenant_rls, _get_pool, _tenant_connection
+from agent_bom.api.storage_schema import ensure_postgres_schema_version
+
+
+class PostgresComplianceHubStore:
+    """Shared hub store backing multi-replica self-hosted deployments."""
+
+    def __init__(self, pool=None) -> None:
+        self._pool = pool or _get_pool()
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "compliance_hub")
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS compliance_hub_findings (
+                    tenant_id TEXT NOT NULL,
+                    finding_id TEXT NOT NULL,
+                    ingested_at TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    applicable_frameworks_csv TEXT NOT NULL DEFAULT '',
+                    payload JSONB NOT NULL,
+                    ordinal BIGSERIAL NOT NULL,
+                    PRIMARY KEY (tenant_id, finding_id, ordinal)
+                )
+                """
+            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_order ON compliance_hub_findings(tenant_id, ordinal)")
+            _ensure_tenant_rls(conn, "compliance_hub_findings", "tenant_id")
+            conn.commit()
+
+    def add(self, tenant_id: str, findings: list[dict[str, Any]]) -> int:
+        if not findings:
+            return self.count(tenant_id)
+        now = _now_utc_iso()
+        with _tenant_connection(self._pool) as conn:
+            for payload in findings:
+                conn.execute(
+                    """
+                    INSERT INTO compliance_hub_findings
+                        (tenant_id, finding_id, ingested_at, source, applicable_frameworks_csv, payload)
+                    VALUES (%s, %s, %s, %s, %s, %s::jsonb)
+                    """,
+                    (
+                        tenant_id,
+                        str(payload.get("id") or f"hub-{now}-{id(payload)}"),
+                        now,
+                        str(payload.get("source") or ""),
+                        _frameworks_csv(payload),
+                        json.dumps(payload, sort_keys=True),
+                    ),
+                )
+            conn.commit()
+        return self.count(tenant_id)
+
+    def list(self, tenant_id: str) -> list[dict[str, Any]]:
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                "SELECT payload FROM compliance_hub_findings WHERE tenant_id = %s ORDER BY ordinal ASC",
+                (tenant_id,),
+            ).fetchall()
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            raw = row[0]
+            out.append(raw if isinstance(raw, dict) else json.loads(raw))
+        return out
+
+    def count(self, tenant_id: str) -> int:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM compliance_hub_findings WHERE tenant_id = %s",
+                (tenant_id,),
+            ).fetchone()
+        return int(row[0]) if row else 0
+
+    def clear(self, tenant_id: str) -> int:
+        with _tenant_connection(self._pool) as conn:
+            cur = conn.execute(
+                "DELETE FROM compliance_hub_findings WHERE tenant_id = %s",
+                (tenant_id,),
+            )
+            conn.commit()
+        return cur.rowcount or 0

--- a/tests/test_compliance_hub_api.py
+++ b/tests/test_compliance_hub_api.py
@@ -238,3 +238,122 @@ def test_clear_requires_write_permission():
     reader.headers.update(proxy_headers(role="viewer", tenant="tenant-alpha"))
     resp = reader.delete("/v1/compliance/hub/findings")
     assert resp.status_code in (401, 403), f"viewer should be denied (got {resp.status_code})"
+
+
+# ─── SQLite backend ──────────────────────────────────────────────────────────
+
+
+def test_sqlite_backend_persists_across_store_instances(tmp_path):
+    """Findings written through one SQLiteComplianceHubStore must be
+    readable from a fresh instance pointing at the same file. This is
+    the single-node persistence contract: API restart -> findings still
+    visible. In-memory backend would fail this test."""
+    from agent_bom.api.compliance_hub_store import (
+        SQLiteComplianceHubStore,
+        set_compliance_hub_store,
+    )
+
+    db = tmp_path / "hub.db"
+    store_a = SQLiteComplianceHubStore(str(db))
+    set_compliance_hub_store(store_a)
+
+    client = _client(tenant="tenant-alpha")
+    client.post(
+        "/v1/compliance/ingest",
+        json={"format": "sarif", "content": json.dumps(_sarif_doc())},
+    )
+    assert client.get("/v1/compliance/hub/findings").json()["total"] == 1
+
+    # Rebind to a fresh store instance with the same db path -> data persists.
+    store_b = SQLiteComplianceHubStore(str(db))
+    set_compliance_hub_store(store_b)
+
+    after_restart = client.get("/v1/compliance/hub/findings").json()
+    assert after_restart["total"] == 1, "SQLite persistence contract: findings must survive a store restart"
+
+
+def test_sqlite_backend_keeps_tenant_data_separate(tmp_path):
+    from agent_bom.api.compliance_hub_store import (
+        SQLiteComplianceHubStore,
+        set_compliance_hub_store,
+    )
+
+    set_compliance_hub_store(SQLiteComplianceHubStore(str(tmp_path / "x.db")))
+
+    a = _client(tenant="tenant-alpha")
+    b = _client(tenant="tenant-beta")
+    a.post("/v1/compliance/ingest", json={"format": "sarif", "content": json.dumps(_sarif_doc())})
+
+    assert a.get("/v1/compliance/hub/findings").json()["total"] == 1
+    assert b.get("/v1/compliance/hub/findings").json()["total"] == 0
+
+
+def test_sqlite_backend_clear_only_affects_caller_tenant(tmp_path):
+    from agent_bom.api.compliance_hub_store import (
+        SQLiteComplianceHubStore,
+        set_compliance_hub_store,
+    )
+
+    set_compliance_hub_store(SQLiteComplianceHubStore(str(tmp_path / "y.db")))
+
+    a = _client(tenant="tenant-alpha")
+    b = _client(tenant="tenant-beta")
+    a.post("/v1/compliance/ingest", json={"format": "sarif", "content": json.dumps(_sarif_doc())})
+    b.post("/v1/compliance/ingest", json={"format": "sarif", "content": json.dumps(_sarif_doc())})
+
+    a.delete("/v1/compliance/hub/findings")
+    assert a.get("/v1/compliance/hub/findings").json()["total"] == 0
+    assert b.get("/v1/compliance/hub/findings").json()["total"] == 1
+
+
+def test_sqlite_backend_preserves_ingest_order(tmp_path):
+    """`list` returns oldest-first; the SQLite ordinal column drives
+    that contract. Pagination + UI rendering both depend on it."""
+    from agent_bom.api.compliance_hub_store import (
+        SQLiteComplianceHubStore,
+        set_compliance_hub_store,
+    )
+
+    set_compliance_hub_store(SQLiteComplianceHubStore(str(tmp_path / "ord.db")))
+    client = _client()
+    for i in range(5):
+        csv = f"Title,Severity\nrow-{i},low\n"
+        client.post("/v1/compliance/ingest", json={"format": "csv", "content": csv})
+
+    titles = [f["title"] for f in client.get("/v1/compliance/hub/findings").json()["findings"]]
+    assert titles == [f"row-{i}" for i in range(5)]
+
+
+def test_sqlite_backend_denormalises_framework_csv_for_aggregation(tmp_path):
+    """The schema stores `applicable_frameworks_csv` so SQL-layer
+    posture aggregation can filter without parsing JSON. This test
+    asserts the column is populated for every row, which the column
+    NOT NULL constraint partly guarantees but the actual contents are
+    what aggregation will read."""
+    import sqlite3
+
+    from agent_bom.api.compliance_hub_store import (
+        SQLiteComplianceHubStore,
+        set_compliance_hub_store,
+    )
+
+    db = tmp_path / "csv.db"
+    set_compliance_hub_store(SQLiteComplianceHubStore(str(db)))
+
+    client = _client()
+    client.post(
+        "/v1/compliance/ingest",
+        json={"format": "sarif", "content": json.dumps(_sarif_doc())},
+    )
+
+    direct = sqlite3.connect(str(db))
+    rows = direct.execute(
+        "SELECT applicable_frameworks_csv FROM compliance_hub_findings WHERE tenant_id = ?",
+        ("tenant-alpha",),
+    ).fetchall()
+    direct.close()
+    assert rows, "expected at least one row"
+    csv_value = rows[0][0]
+    # SECRET rule -> CREDENTIAL_EXPOSURE -> SOC 2 / ISO / NIST CSF must be in csv
+    for slug in ("soc2", "iso-27001", "nist-csf"):
+        assert slug in csv_value, f"{slug} missing from denormalised csv: {csv_value!r}"


### PR DESCRIPTION
## Summary

Closes the storage caveat called out in #2203 (PR C) — the Compliance Hub store gains SQLite + Postgres persistence behind the same env-var pattern as SCIM lifecycle storage.

## Backend selection

\`get_compliance_hub_store()\` resolves in order:

| Env var | Backend | Suitability |
|---|---|---|
| \`AGENT_BOM_POSTGRES_URL\` | PostgresComplianceHubStore | Multi-replica safe; uses the existing pool + tenant RLS pattern from PostgresSCIMStore |
| \`AGENT_BOM_DB\` | SQLiteComplianceHubStore | Single-node; survives API restart; **not safe** for >1 replica |
| neither | InMemoryComplianceHubStore | Ephemeral — tests + dev/demo |

\`ComplianceHubStore\` is now a Protocol; route handlers don't care which backend is wired.

## Schema (both SQLite + Postgres)

\`\`\`sql
CREATE TABLE compliance_hub_findings (
    tenant_id TEXT NOT NULL,
    finding_id TEXT NOT NULL,
    ingested_at TEXT NOT NULL,
    source TEXT NOT NULL,
    applicable_frameworks_csv TEXT NOT NULL DEFAULT '',
    payload <TEXT|JSONB> NOT NULL,
    ordinal <INTEGER|BIGSERIAL> NOT NULL,
    PRIMARY KEY (tenant_id, finding_id, ordinal)
);
CREATE INDEX idx_hub_findings_tenant_order ON compliance_hub_findings(tenant_id, ordinal);
\`\`\`

\`applicable_frameworks_csv\` is denormalised on the framework slugs so posture aggregation can filter at the SQL layer without parsing JSON. \`ingested_at\` is the hook for future TTL/expiry. Postgres adds row-level security via the existing \`_ensure_tenant_rls\` helper.

## Migration

**Zero.** The in-memory store had no durable state to carry forward — operators restart pointing at \`AGENT_BOM_DB\` or \`AGENT_BOM_POSTGRES_URL\` and findings start persisting from the next ingest.

## Lock-in

5 new SQLite-backend tests in \`tests/test_compliance_hub_api.py\`:

- \`test_sqlite_backend_persists_across_store_instances\` — the actual restart-survival contract: rebind to a fresh store on the same path → findings still listed
- \`test_sqlite_backend_keeps_tenant_data_separate\` — tenant isolation at the storage layer
- \`test_sqlite_backend_clear_only_affects_caller_tenant\` — DELETE doesn't bleed across tenants
- \`test_sqlite_backend_preserves_ingest_order\` — ordinal column drives oldest-first listing for pagination
- \`test_sqlite_backend_denormalises_framework_csv_for_aggregation\` — denormalised csv column populated for every row

Existing 13 in-memory tests still pass — the Protocol abstraction is transparent to the route layer.

## Test plan

- [x] \`pytest tests/test_compliance_hub_api.py\` — 18 passed (13 existing + 5 SQLite)
- [x] \`pytest tests/test_compliance_hub*.py\` — 78 passed across the full hub suite
- [ ] Manual Postgres smoke under \`AGENT_BOM_POSTGRES_URL\` — deferred until next deploy lane refresh; the schema mirrors PostgresSCIMStore which is already exercised