### PR TITLE
fix(docs): align compliance SVG cards with COMPLIANCE_FRAMEWORKS

### DIFF
--- a/docs/images/compliance-dark.svg
+++ b/docs/images/compliance-dark.svg
@@ -15,7 +15,7 @@
   <rect width="960" height="280" rx="12" fill="#09090b"/>
 
   <text x="480" y="28" text-anchor="middle" class="title">Compliance coverage</text>
-  <text x="480" y="44" text-anchor="middle" class="subtitle">14 frameworks + AISVS, 300+ controls mapped automatically from scan findings</text>
+  <text x="480" y="44" text-anchor="middle" class="subtitle">14 frameworks, 300+ controls mapped automatically from scan findings</text>
 
   <!-- ═══ ROW 1: 5 frameworks ═══ -->
 
@@ -102,10 +102,10 @@
   <text x="600" y="210" class="fw-count" fill="#f43f5e">10</text>
   <text x="628" y="210" class="fw-label">controls</text>
 
-  <!-- CIS Benchmarks -->
+  <!-- CIS Controls v8 -->
   <rect x="772" y="148" width="168" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="788" y="168" class="fw-name">CIS Benchmarks</text>
-  <text x="788" y="180" class="fw-code">AWS v3.0, Snowflake v1.0</text>
+  <text x="788" y="168" class="fw-name">CIS Controls v8</text>
+  <text x="788" y="180" class="fw-code">18 critical security controls</text>
   <rect x="788" y="188" width="136" height="4" rx="2" class="bar-bg"/>
   <rect x="788" y="188" width="136" height="4" rx="2" fill="#34d399"/>
   <text x="788" y="210" class="fw-count" fill="#34d399">200+</text>

--- a/docs/images/compliance-light.svg
+++ b/docs/images/compliance-light.svg
@@ -15,7 +15,7 @@
   <rect width="960" height="364" rx="12" fill="#ffffff" stroke="#e4e4e7" stroke-width="1"/>
 
   <text x="480" y="28" text-anchor="middle" class="title">Compliance coverage</text>
-  <text x="480" y="44" text-anchor="middle" class="subtitle">14 frameworks + AISVS, 300+ controls mapped automatically from scan findings</text>
+  <text x="480" y="44" text-anchor="middle" class="subtitle">14 frameworks, 300+ controls mapped automatically from scan findings</text>
 
   <!-- ═══ ROW 1: 5 frameworks ═══ -->
 
@@ -102,10 +102,10 @@
   <text x="600" y="210" class="fw-count" fill="#f43f5e">10</text>
   <text x="628" y="210" class="fw-label">controls</text>
 
-  <!-- CIS Benchmarks -->
+  <!-- CIS Controls v8 -->
   <rect x="772" y="148" width="168" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="788" y="168" class="fw-name">CIS Benchmarks</text>
-  <text x="788" y="180" class="fw-code">AWS v3.0, Snowflake v1.0</text>
+  <text x="788" y="168" class="fw-name">CIS Controls v8</text>
+  <text x="788" y="180" class="fw-code">18 critical security controls</text>
   <rect x="788" y="188" width="136" height="4" rx="2" class="bar-bg"/>
   <rect x="788" y="188" width="136" height="4" rx="2" fill="#34d399"/>
   <text x="788" y="210" class="fw-count" fill="#34d399">200+</text>
@@ -140,14 +140,14 @@
   <text x="412" y="294" class="fw-count" fill="#0ea5e9">3</text>
   <text x="432" y="294" class="fw-label">baselines</text>
 
-  <!-- AISVS -->
+  <!-- MITRE ATT&CK Enterprise -->
   <rect x="584" y="232" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="600" y="252" class="fw-name">AISVS v1.0</text>
-  <text x="600" y="264" class="fw-code">AI security verification standard</text>
+  <text x="600" y="252" class="fw-name">MITRE ATT&amp;CK</text>
+  <text x="600" y="264" class="fw-code">Enterprise adversary techniques</text>
   <rect x="600" y="272" width="144" height="4" rx="2" class="bar-bg"/>
   <rect x="600" y="272" width="108" height="4" rx="2" fill="#f59e0b"/>
-  <text x="600" y="294" class="fw-count" fill="#f59e0b">12</text>
-  <text x="628" y="294" class="fw-label">checks</text>
+  <text x="600" y="294" class="fw-count" fill="#f59e0b">200+</text>
+  <text x="640" y="294" class="fw-label">techniques</text>
 
   <!-- ═══ SUMMARY BAR ═══ -->
   <rect x="20" y="320" width="920" height="32" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>


### PR DESCRIPTION
Found by the v0.85.0 repo-duplication audit follow-up. The compliance SVG diagrams (\`docs/images/compliance-{light,dark}.svg\`) drifted from the canonical framework list in \`src/agent_bom/constants.py\` (\`COMPLIANCE_FRAMEWORKS\`).

## Drifts fixed

| Drift | Before | After |
|---|---|---|
| Subtitle | "14 frameworks + AISVS, 300+ controls..." | "14 frameworks, 300+ controls..." |
| Row 2 / col 5 | "CIS Benchmarks" / "AWS v3.0, Snowflake v1.0" | "CIS Controls v8" / "18 critical security controls" |
| Row 3 / col 4 (light only) | "AISVS v1.0" | "MITRE ATT&CK" / "Enterprise adversary techniques" |

**Why:** \`COMPLIANCE_FRAMEWORKS\` declares slug \`cis\` with label \`CIS Controls v8\` — \`CIS Benchmarks\` is the cloud-CIS rulesets surfaced separately under \`/v1/cis\`, not a tag-mapped framework. \`AISVS\` is a benchmark, not one of the 14 tag-mapped frameworks (it has its own surface in \`compliance_coverage.py\`). \`MITRE ATT&CK Enterprise\` (slug \`attack\`) was in the canonical list but missing from the diagram entirely.

## Known structural mismatch (out of scope)

The dark variant renders only 10 of 14 cards (no row 3) and the abbreviated summary text says "13 frameworks". That's a structural rendering issue, not a text fix — flagging in this PR's commit message for whoever owns the asset to address next time the SVG is regenerated.

## Test plan

- [x] Visually compared SVG card text to \`constants.py:589 COMPLIANCE_FRAMEWORKS\`
- [ ] Render the SVG and confirm "MITRE ATT&CK" doesn't visually clash with neighbouring cards (the ampersand is HTML-encoded \`&amp;\`)