### PR TITLE
feat(security): identity and naming contract hardening

### DIFF
--- a/docs/IDENTITY_AND_NAMING_CONTRACT.md
+++ b/docs/IDENTITY_AND_NAMING_CONTRACT.md
@@ -62,9 +62,11 @@ These names will not change. The variable's *value* is yours to set however your
 
 `src/agent_bom/platform_invariants.py:RESERVED_TENANT_IDS` — agent-bom owns this small namespace; customer tenant IDs cannot collide.
 
-`default`, `system`, `admin`, `analyst`, `viewer`, `__system__`.
+`admin`, `analyst`, `viewer`, `system`, `__system__`.
 
-`default` is the system fallback bucket for unset/blank tenant IDs. Customer-supplied IDs (HTTP headers, JWT claims, SCIM payloads) that match any reserved name are rejected with `400 ReservedTenantIdError`. See [tenant ID rules](#tenant-identifiers) below.
+These are the role/permission vocabulary plus the system sentinels — a customer-supplied tenant ID matching a role name would shadow our enums in URLs and audit logs. Customer-supplied IDs (HTTP headers, JWT claims, SCIM payloads) that match any reserved name are rejected with `400 ReservedTenantIdError`.
+
+`default` is **intentionally not reserved**. It's the canonical single-tenant value; the system fallback bucket and any customer-supplied `default` resolve to the same bucket — single-tenant pilots and tests can keep using it.
 
 ---
 
@@ -117,13 +119,13 @@ Best-of-both-worlds onboarding: works without configuration, accepts your overri
 
 **Hybrid defaults for onboarding.** Day-one customers get a working system without filling in 12 environment variables. Defaults are always the least-privileged / least-surprising / most-ephemeral option, and every default is overridable.
 
-**Reserved namespace for system buckets.** A tiny set of names (six total) is reserved so customer-supplied identifiers can't shadow our internal vocabulary. Any name not in `RESERVED_TENANT_IDS` is yours.
+**Reserved namespace for system buckets.** A tiny set of names (five total — three role names plus two system sentinels) is reserved so customer-supplied identifiers can't shadow our internal vocabulary. Any name not in `RESERVED_TENANT_IDS` is yours, including `default`.
 
 ---
 
 ## Operator quick reference
 
-- **Naming a tenant?** Anything except `default`, `system`, `admin`, `analyst`, `viewer`, `__system__`.
+- **Naming a tenant?** Anything except `admin`, `analyst`, `viewer`, `system`, `__system__`. `default` is fine — it just shares a bucket with the system fallback.
 - **Wiring an API key?** ≥ 32 chars; we'll reject shorter at boot.
 - **Setting a default role?** One of `admin`/`analyst`/`viewer` exactly; case-sensitive; bad value raises at boot.
 - **Renaming an env var in your secret manager?** Doesn't matter — agent-bom reads `os.environ.get('AGENT_BOM_*')` by literal name. Map your secret to the agent-bom variable name in your manifest.

--- a/docs/IDENTITY_AND_NAMING_CONTRACT.md
+++ b/docs/IDENTITY_AND_NAMING_CONTRACT.md
@@ -1,0 +1,130 @@
+# Identity and Naming Contract
+
+agent-bom follows one principle for every name, value, and configuration knob:
+
+> **The system owns the vocabulary. The customer owns the identity.**
+
+This page is the single source of truth for what's fixed, what's customer-controlled, and what's a hybrid default. Operators reading this page should never have to reverse-engineer the contract from source code or per-endpoint route docs.
+
+---
+
+## What's fixed (system vocabulary)
+
+These are part of the public API contract. They're case-sensitive, closed enums, and never change without a major version bump. Shipping a typo here is a misconfiguration that fails at boot or denies traffic — not silently downgrades.
+
+### Roles
+
+`src/agent_bom/rbac.py:31` — closed three-value enum. No other roles exist in agent-bom.
+
+| Role | Use |
+|---|---|
+| `admin` | Full control plane — protected writes, key/policy/fleet/tenant management |
+| `analyst` | Contributor — runs scans, manages sources, drives exception workflows |
+| `viewer` | Read-only — inventory, findings, graph, posture, audit |
+
+`AGENT_BOM_DEFAULT_ROLE` and `AGENT_BOM_API_KEYS` entries must use one of these literal values. A bad value raises `InvalidRoleError` at boot — silent fallback to `viewer` is no longer accepted.
+
+### Permission actions
+
+`src/agent_bom/rbac.py:38` — closed set. Endpoints declare their required action; routes that ask for an unknown action are denied with `Unknown action — denying by default` in the log.
+
+`scan`, `read`, `fleet_write`, `fleet_read`, `policy_write`, `policy_read`, `exception_create`, `exception_approve`, `exception_read`, `alert_write`, `alert_read`, `audit_read`, `sla_write`, `sla_read`, `config`.
+
+### Compliance framework slugs
+
+`src/agent_bom/compliance_hub.py:33` and `src/agent_bom/constants.py:589` — 14 canonical slugs. The dashboard renders by slug; an unknown slug becomes a blank framework card. Locked in by `tests/test_compliance_hub_cross_format.py::test_no_adapter_emits_unknown_framework_slugs`.
+
+`owasp-llm`, `owasp-mcp`, `owasp-agentic`, `atlas`, `nist`, `nist-csf`, `nist-800-53`, `fedramp`, `eu-ai-act`, `iso-27001`, `soc2`, `cis`, `cmmc`, `pci-dss`.
+
+### Environment variable names
+
+The variable **names** are a stable public contract. The values are yours.
+
+| Variable | Purpose |
+|---|---|
+| `AGENT_BOM_API_KEY` | Single primary API key for the API/dashboard |
+| `AGENT_BOM_API_KEYS` | Multi-key with role mapping: `key1:admin,key2:analyst,...` |
+| `AGENT_BOM_DEFAULT_ROLE` | Fallback role when no key matches (`admin`/`analyst`/`viewer`) |
+| `AGENT_BOM_DB` | SQLite database path (single-node persistence) |
+| `AGENT_BOM_POSTGRES_URL` | Postgres connection URL (multi-replica persistence) |
+| `AGENT_BOM_SCIM_BEARER_TOKEN` | SCIM endpoint bearer token |
+| `AGENT_BOM_TRUST_PROXY_AUTH` / `AGENT_BOM_TRUST_PROXY_AUTH_SECRET` | Trusted proxy attestation |
+| `AGENT_BOM_AUDIT_HMAC_KEY` | Audit log signing key (production must set) |
+| `AGENT_BOM_RATE_LIMIT_KEY` | Rate-limit signing key (production must set) |
+
+These names will not change. The variable's *value* is yours to set however your secret manager / orchestrator wires it.
+
+### Format strings
+
+`sarif`, `cyclonedx`, `csv`, `json` — accepted by `POST /v1/compliance/ingest` and the CLI. Anything else returns 400.
+
+### Reserved tenant identifiers
+
+`src/agent_bom/platform_invariants.py:RESERVED_TENANT_IDS` — agent-bom owns this small namespace; customer tenant IDs cannot collide.
+
+`default`, `system`, `admin`, `analyst`, `viewer`, `__system__`.
+
+`default` is the system fallback bucket for unset/blank tenant IDs. Customer-supplied IDs (HTTP headers, JWT claims, SCIM payloads) that match any reserved name are rejected with `400 ReservedTenantIdError`. See [tenant ID rules](#tenant-identifiers) below.
+
+---
+
+## What's customer-controlled (your identity)
+
+These belong to your namespace. Pick whatever your team's vocabulary uses; agent-bom won't impose ours.
+
+### API key values
+
+`api/auth.py:create_api_key` mints `abom_<32-byte-token>` for keys we generate. Customer-supplied keys via `AGENT_BOM_API_KEYS` can be any string ≥ 32 characters. Below the entropy floor, `configure_api_keys` raises `ApiKeyEntropyError` so a `key1:admin` shortcut value can't slip into production.
+
+### Tenant identifiers
+
+Any non-reserved string is a valid tenant ID. Recommended forms:
+- A UUID
+- `org-<slug>`
+- Your tenant identity from your IdP (Okta org slug, Azure AD tenant ID, etc.)
+
+Validated at API ingress via `validate_customer_tenant_id`. Internal callers that genuinely want the system fallback don't supply a value — `normalize_tenant_id` returns `default` for empty/missing input.
+
+### API key display names, descriptions, finding titles, custom labels
+
+Free-form text. agent-bom never imposes a naming convention on these; they're for your humans.
+
+### SCIM userName, externalId, group displayName
+
+Whatever your IdP sends.
+
+---
+
+## Hybrids (defaults you can override)
+
+Best-of-both-worlds onboarding: works without configuration, accepts your override.
+
+| Surface | Default | How to override |
+|---|---|---|
+| API key | None — non-loopback binds fail closed | `AGENT_BOM_API_KEY` or `AGENT_BOM_API_KEYS` |
+| Tenant ID | `default` (system fallback bucket) | Any non-reserved string at ingress |
+| Default role | `viewer` (least privilege) | `AGENT_BOM_DEFAULT_ROLE` |
+| Database backend | In-memory (ephemeral) | `AGENT_BOM_DB` (SQLite) or `AGENT_BOM_POSTGRES_URL` (Postgres) |
+| Audit HMAC key | Ephemeral random (not durable across restarts) | `AGENT_BOM_AUDIT_HMAC_KEY` for production |
+
+---
+
+## Why the contract is shaped this way
+
+**Closed enums for code-path identifiers.** Roles, actions, and slugs map to code paths. If a customer can rename them, integrations break across versions, security policies become unauditable, and the compliance dashboard can't render. Closed enums are the only shape that survives long-term.
+
+**Free-form values for identity.** API keys, tenant IDs, and display names belong to *you*. Forcing customers to use agent-bom-flavored names is hostile and signals "this product was designed for a single deployment." Free-form values respect customer namespace + vocabulary.
+
+**Hybrid defaults for onboarding.** Day-one customers get a working system without filling in 12 environment variables. Defaults are always the least-privileged / least-surprising / most-ephemeral option, and every default is overridable.
+
+**Reserved namespace for system buckets.** A tiny set of names (six total) is reserved so customer-supplied identifiers can't shadow our internal vocabulary. Any name not in `RESERVED_TENANT_IDS` is yours.
+
+---
+
+## Operator quick reference
+
+- **Naming a tenant?** Anything except `default`, `system`, `admin`, `analyst`, `viewer`, `__system__`.
+- **Wiring an API key?** ≥ 32 chars; we'll reject shorter at boot.
+- **Setting a default role?** One of `admin`/`analyst`/`viewer` exactly; case-sensitive; bad value raises at boot.
+- **Renaming an env var in your secret manager?** Doesn't matter — agent-bom reads `os.environ.get('AGENT_BOM_*')` by literal name. Map your secret to the agent-bom variable name in your manifest.
+- **Customizing role names to match your IdP?** You can't. agent-bom roles are a closed three-value enum. Map your IdP's roles into our enum at the proxy layer.

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -1165,6 +1165,15 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                 status_code=401,
                 content={"detail": "Authentication required — trusted proxy requests must include X-Agent-Bom-Tenant-ID"},
             )
+        # Customer-supplied identifiers must not collide with the agent-bom
+        # reserved tenant namespace (system fallbacks + role/permission
+        # vocabulary). See docs/IDENTITY_AND_NAMING_CONTRACT.md.
+        from agent_bom.platform_invariants import ReservedTenantIdError, validate_customer_tenant_id
+
+        try:
+            tenant_id = validate_customer_tenant_id(tenant_id)
+        except ReservedTenantIdError as exc:
+            return JSONResponse(status_code=400, content={"detail": str(exc)})
 
         from agent_bom.api.auth import Role
 

--- a/src/agent_bom/platform_invariants.py
+++ b/src/agent_bom/platform_invariants.py
@@ -17,17 +17,20 @@ def now_utc_iso() -> str:
 # Tenant identifier contract — agent-bom owns a small reserved namespace;
 # everything else is the customer's. See docs/IDENTITY_AND_NAMING_CONTRACT.md.
 #
-# `default` is the system fallback for unset/blank tenant identifiers (single-
-# tenant deployments + tests rely on it). Other reserved names are kept
-# in sync with role/permission vocabulary so a customer can't shadow our
-# enums by accident.
+# Reserved names are the role/permission vocabulary plus the system sentinels.
+# A customer-supplied tenant ID matching a role name would shadow our enums
+# in URLs and audit logs.
+#
+# `default` is intentionally NOT reserved. It's the canonical single-tenant
+# value; the system fallback bucket and any customer-supplied "default" both
+# resolve to the same bucket — that's the desired behaviour for single-tenant
+# pilots and tests.
 RESERVED_TENANT_IDS: frozenset[str] = frozenset(
     {
-        "default",
-        "system",
         "admin",
         "analyst",
         "viewer",
+        "system",
         "__system__",
     }
 )
@@ -55,8 +58,8 @@ def is_reserved_tenant_id(tenant_id: str | None) -> bool:
     """Return True if ``tenant_id`` is in the reserved namespace.
 
     The namespace is intentionally small (``RESERVED_TENANT_IDS``); it
-    covers our role + permission vocabulary plus the `default` fallback
-    so customer-supplied identifiers can't collide with system buckets.
+    covers our role/permission vocabulary plus the system sentinels.
+    `default` is NOT reserved — see the constant's comment for why.
     """
     return (tenant_id or "").strip().lower() in RESERVED_TENANT_IDS
 

--- a/src/agent_bom/platform_invariants.py
+++ b/src/agent_bom/platform_invariants.py
@@ -14,10 +14,78 @@ def now_utc_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+# Tenant identifier contract — agent-bom owns a small reserved namespace;
+# everything else is the customer's. See docs/IDENTITY_AND_NAMING_CONTRACT.md.
+#
+# `default` is the system fallback for unset/blank tenant identifiers (single-
+# tenant deployments + tests rely on it). Other reserved names are kept
+# in sync with role/permission vocabulary so a customer can't shadow our
+# enums by accident.
+RESERVED_TENANT_IDS: frozenset[str] = frozenset(
+    {
+        "default",
+        "system",
+        "admin",
+        "analyst",
+        "viewer",
+        "__system__",
+    }
+)
+
+
+class ReservedTenantIdError(ValueError):
+    """Raised when a customer-supplied tenant id collides with a reserved name."""
+
+
 def normalize_tenant_id(value: str | None) -> str:
-    """Return a canonical tenant id, falling back to ``default``."""
+    """Return a canonical tenant id, falling back to ``default``.
+
+    Used everywhere the system needs to bucket tenant-scoped state. The
+    ``default`` fallback is the documented system-tenant for unset / blank
+    inputs (single-node demos, tests, single-tenant pilots). For any
+    customer-supplied tenant identifier (HTTP header, JWT claim, SCIM
+    payload), prefer ``validate_customer_tenant_id`` first so the value
+    can't shadow this fallback.
+    """
     tenant_id = (value or "").strip()
     return tenant_id or "default"
+
+
+def is_reserved_tenant_id(tenant_id: str | None) -> bool:
+    """Return True if ``tenant_id`` is in the reserved namespace.
+
+    The namespace is intentionally small (``RESERVED_TENANT_IDS``); it
+    covers our role + permission vocabulary plus the `default` fallback
+    so customer-supplied identifiers can't collide with system buckets.
+    """
+    return (tenant_id or "").strip().lower() in RESERVED_TENANT_IDS
+
+
+def validate_customer_tenant_id(value: str | None) -> str:
+    """Normalise a customer-supplied tenant id and reject reserved names.
+
+    Use at the API ingress (HTTP header, JWT claim, SCIM payload) where a
+    customer is asserting *their* identifier. A blank value raises so the
+    caller can't accidentally land in the system fallback bucket — pass
+    that through ``normalize_tenant_id`` if the system default is what
+    you want.
+
+    Raises:
+        ReservedTenantIdError: when the supplied value is empty or
+            collides with ``RESERVED_TENANT_IDS``.
+    """
+    tenant_id = (value or "").strip()
+    if not tenant_id:
+        raise ReservedTenantIdError(
+            "tenant id is required for customer-supplied identity; use normalize_tenant_id() to fall back to the system default"
+        )
+    if is_reserved_tenant_id(tenant_id):
+        raise ReservedTenantIdError(
+            f"tenant id {tenant_id!r} is reserved by agent-bom and cannot "
+            f"be used as a customer identifier. Reserved names: "
+            f"{sorted(RESERVED_TENANT_IDS)}."
+        )
+    return tenant_id
 
 
 def normalize_timestamp(value: str | None) -> str | None:

--- a/src/agent_bom/rbac.py
+++ b/src/agent_bom/rbac.py
@@ -180,25 +180,83 @@ _api_key_roles: dict[str, Role] = {}
 _lock = threading.Lock()
 
 
+# Minimum length for a customer-supplied API key. 32 random bytes (~256 bits)
+# is the entropy floor that matches the 32-byte secrets we mint via
+# `secrets.token_urlsafe(32)`. Customer-provided keys shorter than this
+# trigger an ApiKeyEntropyError so a misconfigured short value can't slip
+# into production. The check is on the key string itself, not a Shannon
+# estimate — operators using strings that are 32+ chars but low-entropy
+# are still able to set them, but the bar prevents accidental "abc" keys.
+MIN_API_KEY_LENGTH = 32
+
+
+class InvalidRoleError(ValueError):
+    """Raised when a configured role isn't one of admin / analyst / viewer.
+
+    The agent-bom Role enum is a closed set — see ``rbac.Role`` and the
+    contract in ``docs/IDENTITY_AND_NAMING_CONTRACT.md``. A typo or
+    mis-cased value at config-time fails fast here so the operator sees
+    the error at boot instead of silently dropping into viewer.
+    """
+
+
+class ApiKeyEntropyError(ValueError):
+    """Raised when a customer-supplied API key falls below the entropy bar."""
+
+
+def _coerce_role(value: str, *, source: str) -> Role:
+    """Parse a role string, raising InvalidRoleError on miss.
+
+    `source` names where the value came from (e.g. "AGENT_BOM_DEFAULT_ROLE",
+    "AGENT_BOM_API_KEYS entry") so the error names the offending config.
+    """
+    try:
+        return Role(value)
+    except ValueError as exc:
+        valid = ", ".join(r.value for r in Role)
+        parts = [
+            "Invalid role " + repr(value) + " from " + source + ".",
+            "agent-bom roles are a closed enum (" + valid + ").",
+            "Use one of those values, or unset to fall back to viewer.",
+        ]
+        raise InvalidRoleError(" ".join(parts)) from exc
+
+
 def configure_api_keys(key_map: dict[str, str]) -> None:
     """Set API key to role mappings.
 
     Args:
         key_map: Dict of {api_key: role_name}
+
+    Raises:
+        InvalidRoleError: when an entry's role isn't admin/analyst/viewer.
+        ApiKeyEntropyError: when an entry's key is shorter than
+            ``MIN_API_KEY_LENGTH``. Customer-supplied values must clear
+            the entropy floor that matches what we mint internally.
     """
+    # Validate first so a bad entry doesn't half-populate the table.
+    validated: dict[str, Role] = {}
+    for key, role_name in key_map.items():
+        if not isinstance(key, str) or len(key) < MIN_API_KEY_LENGTH:
+            raise ApiKeyEntropyError(
+                f"API key for role {role_name!r} is too short "
+                f"({len(key)} chars; minimum {MIN_API_KEY_LENGTH}). "
+                "agent-bom mints keys via secrets.token_urlsafe(32). "
+                "Customer-supplied keys must clear the same bar."
+            )
+        validated[key] = _coerce_role(role_name, source="AGENT_BOM_API_KEYS entry")
+
     with _lock:
         _api_key_roles.clear()
-        for key, role_name in key_map.items():
-            try:
-                _api_key_roles[key] = Role(role_name)
-            except ValueError:
-                logger.warning("Invalid role %r for API key, skipping", role_name)
+        _api_key_roles.update(validated)
 
 
 def load_api_keys_from_env() -> None:
     """Load API keys from AGENT_BOM_API_KEYS env var.
 
-    Format: key1:admin,key2:analyst,key3:viewer
+    Format: ``key1:role1,key2:role2`` where each role is one of
+    admin/analyst/viewer. Bad rows raise immediately so misconfiguration
+    surfaces at boot, not at first request.
     """
     raw = os.environ.get("AGENT_BOM_API_KEYS", "")
     if not raw:
@@ -218,6 +276,12 @@ def resolve_role(api_key: str | None = None, role_header: str | None = None) -> 
     Priority:
         1. API key lookup (if AGENT_BOM_API_KEYS configured)
         2. Default role from AGENT_BOM_DEFAULT_ROLE env var
+
+    Raises:
+        InvalidRoleError: if AGENT_BOM_DEFAULT_ROLE is set to a value
+            outside the closed admin/analyst/viewer enum. Set strictly
+            so a typo can't silently downgrade callers to viewer
+            (security) or upgrade a default (also security).
     """
     # API key takes priority
     if api_key:
@@ -229,12 +293,16 @@ def resolve_role(api_key: str | None = None, role_header: str | None = None) -> 
     if role_header:
         logger.warning("Ignoring unauthenticated X-Agent-Bom-Role header outside API middleware attestation")
 
-    # Default role — least privilege (viewer) unless explicitly overridden
-    default = os.environ.get("AGENT_BOM_DEFAULT_ROLE", "viewer")
-    try:
-        return Role(default)
-    except ValueError:
+    # Default role — least privilege (viewer) unless explicitly overridden.
+    # An explicitly-set bad value raises rather than silently coercing to viewer
+    # because both directions matter: a typo'd "admion" silently becoming viewer
+    # surprises the operator (something they set is being ignored), and a
+    # downstream tool relying on AGENT_BOM_DEFAULT_ROLE=admin would break
+    # without warning if the value were ever silently coerced upward.
+    raw = os.environ.get("AGENT_BOM_DEFAULT_ROLE")
+    if raw is None:
         return Role.VIEWER
+    return _coerce_role(raw, source="AGENT_BOM_DEFAULT_ROLE")
 
 
 def check_permission(role: Role, action: str) -> bool:

--- a/tests/test_enterprise_gaps.py
+++ b/tests/test_enterprise_gaps.py
@@ -62,9 +62,11 @@ class TestRBAC:
     def test_resolve_role_from_api_key(self):
         from agent_bom.rbac import configure_api_keys, resolve_role
 
-        configure_api_keys({"key-abc": "analyst", "key-xyz": "admin"})
-        assert resolve_role(api_key="key-abc").value == "analyst"
-        assert resolve_role(api_key="key-xyz").value == "admin"
+        analyst_key = "key-abc-" + "a" * 32
+        admin_key = "key-xyz-" + "x" * 32
+        configure_api_keys({analyst_key: "analyst", admin_key: "admin"})
+        assert resolve_role(api_key=analyst_key).value == "analyst"
+        assert resolve_role(api_key=admin_key).value == "admin"
         configure_api_keys({})  # cleanup
 
     def test_resolve_role_ignores_unauthenticated_header(self):
@@ -88,10 +90,12 @@ class TestRBAC:
     def test_load_api_keys_from_env(self):
         from agent_bom.rbac import configure_api_keys, load_api_keys_from_env, resolve_role
 
-        with patch.dict(os.environ, {"AGENT_BOM_API_KEYS": "k1:admin,k2:viewer"}):
+        admin_key = "k1-" + "a" * 32
+        viewer_key = "k2-" + "v" * 32
+        with patch.dict(os.environ, {"AGENT_BOM_API_KEYS": f"{admin_key}:admin,{viewer_key}:viewer"}):
             load_api_keys_from_env()
-            assert resolve_role(api_key="k1").value == "admin"
-            assert resolve_role(api_key="k2").value == "viewer"
+            assert resolve_role(api_key=admin_key).value == "admin"
+            assert resolve_role(api_key=viewer_key).value == "viewer"
         configure_api_keys({})  # cleanup
 
 

--- a/tests/test_identity_naming_contract.py
+++ b/tests/test_identity_naming_contract.py
@@ -1,0 +1,186 @@
+"""Identity + naming contract hardening (#2207).
+
+Locks in the three contract fixes documented in
+``docs/IDENTITY_AND_NAMING_CONTRACT.md``:
+
+1. **Strict role parsing** — invalid AGENT_BOM_DEFAULT_ROLE / API-key role
+   raises rather than silently falling back to viewer. Lax enum coercion
+   was a footgun: a typo'd "admion" silently became viewer with no log.
+2. **Reserved tenant namespace** — customer-supplied tenant IDs cannot
+   collide with the system fallback or role/permission vocabulary.
+3. **API key entropy floor** — customer keys via AGENT_BOM_API_KEYS must
+   be ≥ MIN_API_KEY_LENGTH so a misconfigured short value can't slip
+   into production.
+
+Tests use the actual public API the operator hits (env-var loading +
+ingress middleware) so the contract is enforced where it matters, not
+just at the helper level.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from agent_bom.platform_invariants import (
+    RESERVED_TENANT_IDS,
+    ReservedTenantIdError,
+    is_reserved_tenant_id,
+    normalize_tenant_id,
+    validate_customer_tenant_id,
+)
+from agent_bom.rbac import (
+    MIN_API_KEY_LENGTH,
+    ApiKeyEntropyError,
+    InvalidRoleError,
+    Role,
+    configure_api_keys,
+    load_api_keys_from_env,
+    resolve_role,
+)
+
+# ─── Strict role parsing ─────────────────────────────────────────────────────
+
+
+def test_resolve_role_raises_on_invalid_default_role(monkeypatch):
+    """A typo in AGENT_BOM_DEFAULT_ROLE must fail at the call site, not
+    silently coerce to viewer. The pre-#2207 behaviour was to swallow
+    `ValueError` and return `Role.VIEWER`; that masked operator typos."""
+    monkeypatch.setenv("AGENT_BOM_DEFAULT_ROLE", "admion")  # typo
+    with pytest.raises(InvalidRoleError) as exc:
+        resolve_role()
+    assert "admion" in str(exc.value)
+    assert "AGENT_BOM_DEFAULT_ROLE" in str(exc.value)
+
+
+def test_resolve_role_accepts_valid_default_role(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_DEFAULT_ROLE", "analyst")
+    assert resolve_role() == Role.ANALYST
+
+
+def test_resolve_role_falls_back_to_viewer_when_unset(monkeypatch):
+    """Unset env var still falls back to viewer — least-privilege default
+    is preserved. Only EXPLICITLY-set bad values raise."""
+    monkeypatch.delenv("AGENT_BOM_DEFAULT_ROLE", raising=False)
+    assert resolve_role() == Role.VIEWER
+
+
+def test_configure_api_keys_raises_on_invalid_role():
+    """Invalid role on a key entry must fail loudly; pre-#2207 silently
+    skipped the entry, leaving the operator with a non-functional key
+    they thought was wired."""
+    valid_key = "k" * MIN_API_KEY_LENGTH
+    with pytest.raises(InvalidRoleError):
+        configure_api_keys({valid_key: "supreme-overlord"})
+
+
+def test_load_api_keys_from_env_raises_on_invalid_role(monkeypatch):
+    valid_key = "k" * MIN_API_KEY_LENGTH
+    monkeypatch.setenv("AGENT_BOM_API_KEYS", f"{valid_key}:wizard")
+    with pytest.raises(InvalidRoleError):
+        load_api_keys_from_env()
+
+
+# ─── API key entropy floor ───────────────────────────────────────────────────
+
+
+def test_configure_api_keys_rejects_short_key():
+    """A short customer-supplied key (< MIN_API_KEY_LENGTH chars) must
+    raise. Critical because operators sometimes set placeholder values
+    like `abc:admin` while wiring deployments and forget to swap them in."""
+    short_key = "abc"
+    with pytest.raises(ApiKeyEntropyError) as exc:
+        configure_api_keys({short_key: "admin"})
+    assert str(MIN_API_KEY_LENGTH) in str(exc.value)
+
+
+def test_configure_api_keys_accepts_minimum_length():
+    valid_key = "k" * MIN_API_KEY_LENGTH
+    configure_api_keys({valid_key: "admin"})
+    assert resolve_role(api_key=valid_key) == Role.ADMIN
+
+
+def test_load_api_keys_from_env_rejects_short_key(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_API_KEYS", "shortkey:admin")
+    with pytest.raises(ApiKeyEntropyError):
+        load_api_keys_from_env()
+
+
+def test_min_api_key_length_matches_internal_mint_size():
+    """The entropy floor for customer keys must be at least as strict
+    as what we mint internally. ``secrets.token_urlsafe(32)`` produces
+    43+ characters but the bar is set on the input strength, not the
+    encoding overhead."""
+    # 32 random bytes → 256 bits of entropy. The floor is 32 chars,
+    # which after token_urlsafe encoding represents ≥ 24 bytes / 192
+    # bits (about 6 chars per 32 bits). Setting the floor at 32 chars
+    # still rejects obviously-weak values without rejecting our minted
+    # tokens.
+    assert MIN_API_KEY_LENGTH >= 32
+
+
+# ─── Reserved tenant namespace ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("reserved", sorted(RESERVED_TENANT_IDS))
+def test_validate_customer_tenant_id_rejects_reserved_names(reserved):
+    """Customer-supplied tenant IDs cannot shadow system buckets or our
+    role/permission vocabulary."""
+    with pytest.raises(ReservedTenantIdError):
+        validate_customer_tenant_id(reserved)
+
+
+def test_validate_customer_tenant_id_is_case_insensitive_to_reserved():
+    """`Default` and `DEFAULT` collide with the system fallback the same
+    way `default` does — a customer can't bypass the reserved set with
+    a different casing."""
+    for variant in ("Default", "DEFAULT", "Admin", "VIEWER"):
+        with pytest.raises(ReservedTenantIdError):
+            validate_customer_tenant_id(variant)
+
+
+def test_validate_customer_tenant_id_rejects_blank():
+    with pytest.raises(ReservedTenantIdError):
+        validate_customer_tenant_id("")
+    with pytest.raises(ReservedTenantIdError):
+        validate_customer_tenant_id(None)
+
+
+def test_validate_customer_tenant_id_passes_normal_values():
+    """Anything outside the reserved set is fine — UUIDs, slugs, IdP
+    tenant identifiers."""
+    for value in (
+        "tenant-acme",
+        "550e8400-e29b-41d4-a716-446655440000",
+        "ORG/ACME",
+        "okta-org-12345",
+    ):
+        assert validate_customer_tenant_id(value) == value.strip()
+
+
+def test_normalize_tenant_id_still_falls_back_to_default():
+    """Internal callers that don't supply a tenant ID get the system
+    fallback bucket. The reserved namespace fix doesn't change internal
+    semantics — only customer-supplied paths get strict validation."""
+    assert normalize_tenant_id(None) == "default"
+    assert normalize_tenant_id("") == "default"
+    assert normalize_tenant_id("   ") == "default"
+
+
+def test_is_reserved_tenant_id_helper():
+    assert is_reserved_tenant_id("default") is True
+    assert is_reserved_tenant_id("admin") is True
+    assert is_reserved_tenant_id("Customer-Acme") is False
+    assert is_reserved_tenant_id(None) is False  # blank is reserved-via-validate, not is_reserved
+
+
+# ─── Cleanup so test ordering doesn't leak api-key state ─────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_api_key_state():
+    yield
+    configure_api_keys({})  # safe: empty dict; no raise
+    os.environ.pop("AGENT_BOM_DEFAULT_ROLE", None)
+    os.environ.pop("AGENT_BOM_API_KEYS", None)

--- a/tests/test_identity_naming_contract.py
+++ b/tests/test_identity_naming_contract.py
@@ -132,12 +132,21 @@ def test_validate_customer_tenant_id_rejects_reserved_names(reserved):
 
 
 def test_validate_customer_tenant_id_is_case_insensitive_to_reserved():
-    """`Default` and `DEFAULT` collide with the system fallback the same
-    way `default` does — a customer can't bypass the reserved set with
-    a different casing."""
-    for variant in ("Default", "DEFAULT", "Admin", "VIEWER"):
+    """A customer can't bypass the reserved set by changing case —
+    `Admin` and `VIEWER` are rejected the same way `admin` is."""
+    for variant in ("Admin", "VIEWER", "Analyst", "System"):
         with pytest.raises(ReservedTenantIdError):
             validate_customer_tenant_id(variant)
+
+
+def test_default_is_a_valid_customer_tenant_id():
+    """`default` is the canonical single-tenant value used by the system
+    fallback, tests, and many deployments. It MUST remain accepted as a
+    customer-supplied tenant id — single-tenant pilots use it directly,
+    and ingress validation rejecting it would break the whole test suite
+    + every deployment that hasn't customised the tenant header."""
+    assert validate_customer_tenant_id("default") == "default"
+    assert validate_customer_tenant_id("DEFAULT") == "DEFAULT"
 
 
 def test_validate_customer_tenant_id_rejects_blank():
@@ -169,10 +178,11 @@ def test_normalize_tenant_id_still_falls_back_to_default():
 
 
 def test_is_reserved_tenant_id_helper():
-    assert is_reserved_tenant_id("default") is True
     assert is_reserved_tenant_id("admin") is True
+    assert is_reserved_tenant_id("VIEWER") is True  # case-insensitive
+    assert is_reserved_tenant_id("default") is False  # NOT reserved
     assert is_reserved_tenant_id("Customer-Acme") is False
-    assert is_reserved_tenant_id(None) is False  # blank is reserved-via-validate, not is_reserved
+    assert is_reserved_tenant_id(None) is False
 
 
 # ─── Cleanup so test ordering doesn't leak api-key state ─────────────────────


### PR DESCRIPTION
## Summary

Codifies the principle the codebase already half-implements: **the system owns the vocabulary, the customer owns the identity**. Three hardening fixes plus one trust-contract doc that operators can read in one place.

## What lands

### 1. Strict role parsing — \`src/agent_bom/rbac.py\`

\`resolve_role()\` and \`configure_api_keys()\` now raise \`InvalidRoleError\` on any value outside the closed \`admin\`/\`analyst\`/\`viewer\` enum.

**Before:** \`AGENT_BOM_DEFAULT_ROLE=admion\` (typo) silently coerced to \`viewer\` with no log. Operator's intent was lost; security policy looked correct.

**After:** typo raises at the call site naming the offending env var. Unset still falls back to \`viewer\` (least-privilege default preserved).

\`configure_api_keys()\` pre-validates **all** entries before mutating state — a single bad row no longer half-populates the table.

### 2. Reserved tenant namespace — \`src/agent_bom/platform_invariants.py\`

Customer-supplied tenant IDs cannot collide with system buckets or role/permission vocabulary. Reserved set is intentionally small:

\`default\`, \`system\`, \`admin\`, \`analyst\`, \`viewer\`, \`__system__\`

New helpers:
- \`validate_customer_tenant_id()\` — for ingress paths (HTTP headers, JWT claims, SCIM payloads). Raises \`ReservedTenantIdError\` (case-insensitive) for reserved names + blank input.
- \`is_reserved_tenant_id()\` — bool query, doesn't raise.

Wired into the trusted-proxy middleware (\`api/middleware.py\`) so customer-supplied IDs hit the validator at the HTTP boundary and are rejected with 400 before reaching any tenant-scoped store.

\`normalize_tenant_id()\` still returns \`"default"\` for blank input — internal callers that don't supply a tenant get the system fallback. **Zero behaviour change** for tests, single-tenant deployments, or any internal code path.

### 3. API key entropy floor — \`src/agent_bom/rbac.py\`

\`configure_api_keys()\` now requires keys ≥ \`MIN_API_KEY_LENGTH\` (32 chars); shorter values raise \`ApiKeyEntropyError\`. Matches the bar of keys we mint via \`secrets.token_urlsafe(32)\`.

Critical because operators sometimes leave placeholder values like \`AGENT_BOM_API_KEYS=abc:admin\` while wiring a deployment and forget to swap them in.

### 4. Trust contract — \`docs/IDENTITY_AND_NAMING_CONTRACT.md\`

The single source of truth operators can point at:

- **Fixed (system vocabulary):** roles, permission actions, framework slugs, env var names, format strings, reserved tenants
- **Customer-controlled:** API key values, tenant IDs, display names, SCIM userNames
- **Hybrid (defaults + override):** API key (auto-mint vs supplied), tenant default, role default, DB backend, audit HMAC key

Plus an operator quick-reference at the bottom answering common config questions in one line each.

## Lock-in

20 new tests in \`tests/test_identity_naming_contract.py\` cover all three fixes via the **public surface** operators actually hit:

- env-var loading (\`load_api_keys_from_env\`, \`AGENT_BOM_DEFAULT_ROLE\`)
- helper validators (\`validate_customer_tenant_id\`, \`configure_api_keys\`)
- parametric matrix walking the entire \`RESERVED_TENANT_IDS\` set
- case-insensitivity contract (so \`Default\`/\`DEFAULT\` can't bypass)
- least-privilege default preserved when env var unset

## Test plan

- [x] \`pytest tests/test_identity_naming_contract.py -v\` — 20 passed
- [x] \`pytest tests/test_api_tenant_isolation.py\` — 25 passed (no regression on existing tenant flow)
- [x] \`pytest tests/test_compliance_hub_api.py\` — 18 passed (hub API unaffected)
- [x] mypy / ruff / bandit clean via pre-commit