### PR TITLE
fix(docs): close v0.85.0 multi-persona audit P1 items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Two new product surfaces (inter-agent firewall + per-run discovery envelope) plu
 - **Severity closer rendered empty on Python 3.13** — `Severity(str, Enum)` `str()` semantics changed; the closer now reads `Severity.value` so the breakdown renders content on every supported Python (#2185).
 - **npm SemVer pre-release tag handling** — `compare_version_order` now strips `-canary.N`, `-beta.N`, `-rc.N`, etc. before PEP 440 parsing so npm pre-releases no longer fall through to the conservative "affected" verdict (e.g. CVE-2023-46298 false positive on `next@16.2.4-canary.13`) (#2182).
 - **Stacked progress lines under interleaved log warnings** — scanner warnings now flow through Rich during the progress block, so spinners stop double-rendering when GHSA/OSV emit warnings mid-scan (#2183).
-- **OSV-first GHSA UX** — the "GITHUB_TOKEN not set" / "limited to N unauthenticated lookups" notes are now informational only and no longer surface as scan warnings; OSV mirrors GHSA within ~24h, so the unauthenticated path is fine for typical use (matches Trivy/Grype defaults) (#2181).
+- **OSV-first GHSA UX** — the "GITHUB_TOKEN not set" / "limited to N unauthenticated lookups" notes are now informational only and no longer surface as scan warnings; OSV mirrors GHSA within ~24h, so the unauthenticated path is the default for typical use and a `GITHUB_TOKEN` is only needed for fresh-CVE turnaround under 24h (#2181).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,14 @@ Advanced/manual path from a checked-out repo:
 ```bash
 helm upgrade --install agent-bom deploy/helm/agent-bom \
   --namespace agent-bom --create-namespace \
+  --set controlPlane.enabled=true \
   -f deploy/helm/agent-bom/examples/eks-production-values.yaml
 ```
+
+> **Note:** `controlPlane.enabled` defaults to `false` (scanner-only render). The
+> API, dashboard, gateway, proxy, firewall, and Postgres only deploy when
+> `controlPlane.enabled=true`. The bundled example values files set this for
+> you; if you build your own values file, set the flag explicitly.
 
 After the first scan:
 

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -1,3 +1,22 @@
+# ───────────────────────────────────────────────────────────────────────────
+# IMPORTANT: `controlPlane.enabled` defaults to `false` (scanner-only render).
+#
+# The default render ships ONLY the CLI scanner Job + supporting RBAC. The API,
+# dashboard, gateway, proxy, firewall, MCP server, and Postgres are all gated
+# behind `controlPlane.enabled=true`. EKS / GKE / AKS users that want the full
+# platform — running scans, browsing findings in the UI, hitting the REST API,
+# enforcing runtime policy — must set:
+#
+#     helm install agent-bom agent-bom/agent-bom \
+#       --set controlPlane.enabled=true
+#
+# Without that flag a `helm install` succeeds quietly and only the scanner
+# pieces are deployed. See the `controlPlane:` block below (around line 257)
+# for the full set of subcomponents this flag toggles on, and the chart
+# README at deploy/helm/agent-bom/README.md (or the project README's
+# "Helm / Kubernetes" section) for the complete quick-start.
+# ───────────────────────────────────────────────────────────────────────────
+#
 # For the canonical AGENT_BOM_* env-var reference (auto-generated from
 # src/agent_bom/config.py), see docs/operations/ENV_VARS.md. CI fails if a
 # new AGENT_BOM_* env var is referenced in src/ without being declared in

--- a/src/agent_bom/constants.py
+++ b/src/agent_bom/constants.py
@@ -601,6 +601,7 @@ COMPLIANCE_FRAMEWORKS: tuple[tuple[str, str], ...] = (
     ("cmmc", "CMMC 2.0"),
     ("nist_800_53", "NIST 800-53 Rev 5"),
     ("fedramp", "FedRAMP Moderate"),
+    ("pci_dss", "PCI DSS"),
 )
 
 COMPLIANCE_FRAMEWORK_COUNT: int = len(COMPLIANCE_FRAMEWORKS)


### PR DESCRIPTION
## Summary

Closes three P1 items from the v0.85.0 multi-persona audit.

- **Compliance framework drift** — `src/agent_bom/compliance_hub.py:ALL_FRAMEWORKS` and `compliance_coverage.py:TAG_MAPPED_FRAMEWORKS` register PCI DSS as a tag-mapped framework, but `src/agent_bom/constants.py:COMPLIANCE_FRAMEWORKS` (the single-source-of-truth registry called out in the file's own docstring) omitted it. The README's compliance claim already names PCI DSS, so the registry was the lagging surface. Add `("pci_dss", "PCI DSS")` so all three sources line up and `COMPLIANCE_FRAMEWORK_COUNT` becomes 15.
- **Competitor scrub in CHANGELOG.md** — the v0.84.7 entry for #2181 contained a parenthetical comparison to third-party tool defaults. CHANGELOG entries ship verbatim into GitHub Release notes, so rewrite the line to describe the OSV-first behaviour on its own merits (CVEs land in OSV within ~24h; `GITHUB_TOKEN` is only needed for sub-24h freshness) without naming other tools. Grepped the rest of `CHANGELOG.md` — no other competitor mentions.
- **Helm `controlPlane.enabled` callout** — `deploy/helm/agent-bom/values.yaml` defaults to `controlPlane.enabled=false` (scanner-only render). Operators who run `helm install` without the flag get a quiet success and only the CronJob scanner — no API, no dashboard, no Postgres. Add a top-of-file callout block in `values.yaml` explaining the gating and listing the components it toggles, plus a matching note in the project README's Helm quick-start with the `--set controlPlane.enabled=true` flag spelled out.

## Test plan

- [x] `pytest tests/test_compliance_hub_cross_format.py` — 11 passed (cross-format invariants still hold after the constants change).
- [x] Pre-commit hook chain (ruff, ruff-format, mypy, bandit, env-var drift gate) — all green.
- [x] Verified `COMPLIANCE_FRAMEWORK_COUNT == 15` post-change and that `pci_dss` is the only added entry; `attack` (MITRE ATT&CK Enterprise, blast-radius tagger, separate from ATLAS) is preserved.
- [ ] CI to confirm Helm chart lint + UI typecheck stay green.