### PR TITLE
fix: trim Docker Hub short description to fit 100-char API limit

### DIFF
--- a/.github/workflows/refresh-latest-container.yml
+++ b/.github/workflows/refresh-latest-container.yml
@@ -114,7 +114,7 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           set -euo pipefail
-          SHORT_DESCRIPTION="Open security scanner for AI supply chain and infrastructure: agents, MCP, containers, cloud, GPU, and runtime."
+          SHORT_DESCRIPTION="Open security scanner for AI supply chain and infrastructure: agents, MCP, cloud, GPU, runtime."
           TOKEN=$(curl -sf -X POST "https://hub.docker.com/v2/users/login" \
             -H "Content-Type: application/json" \
             -d "{\"username\":\"${DOCKERHUB_USERNAME}\",\"password\":\"${DOCKERHUB_TOKEN}\"}" \


### PR DESCRIPTION
## Root cause

The `refresh-latest-container.yml` workflow was sending a **111-character** string in the `description` field of the Docker Hub PATCH request. Docker Hub enforces a **100-character maximum** on that field and returns `HTTP 400` when it is exceeded — which is the error seen in CI.

The `release.yml` workflow was unaffected because it already uses the shorter 95-character variant.

## Change

| Workflow | Before (111 chars) | After (95 chars) |
|---|---|---|
| `refresh-latest-container.yml` | `…agents, MCP, containers, cloud, GPU, and runtime.` | `…agents, MCP, cloud, GPU, runtime.` |

Aligns with the string already used in `release.yml`.

## Test plan

- [ ] Merge → workflow reruns → "Sync Docker Hub README" step returns HTTP 200