### PR TITLE
feat(snowflake): Native App Phase 3 — SPCS Next.js UI + service roles

### DIFF
--- a/deploy/snowflake/native-app/manifest.yml
+++ b/deploy/snowflake/native-app/manifest.yml
@@ -14,6 +14,16 @@ artifacts:
   container_services:
     images:
       - /db/schema/agent_bom_repo/agent-bom:latest
+      - /db/schema/agent_bom_repo/agent-bom-ui:latest
+  service_roles:
+    - name: api
+      comment: >-
+        Grants USAGE on the FastAPI backend service endpoint (port 8422).
+        Assign to roles that need programmatic access to the agent-bom REST API.
+    - name: ui
+      comment: >-
+        Grants USAGE on the Next.js dashboard service endpoint (port 3000).
+        Assign to roles that need browser-based access to the agent-bom UI.
 
 privileges:
   - CREATE COMPUTE POOL:

--- a/deploy/snowflake/native-app/manifest.yml
+++ b/deploy/snowflake/native-app/manifest.yml
@@ -10,7 +10,9 @@ version:
 
 artifacts:
   setup_script: scripts/setup.sql
-  default_streamlit: streamlit/dashboard.py
+  default_web_endpoint:
+    service: core.agent_bom_api
+    endpoint: ui
   container_services:
     images:
       - /db/schema/agent_bom_repo/agent-bom:latest

--- a/deploy/snowflake/native-app/scripts/setup.sql
+++ b/deploy/snowflake/native-app/scripts/setup.sql
@@ -189,9 +189,10 @@ CREATE STREAMLIT IF NOT EXISTS core.dashboard
     MAIN_FILE = 'dashboard.py';
 GRANT USAGE ON STREAMLIT core.dashboard TO APPLICATION ROLE app_user;
 
--- 6. Services (agent-bom API + UI in Snowpark Container Services)
+-- 6. Services (Phase 3: API + UI both defined in service-spec.yaml)
 -- Note: compute pool must be created by the consumer and granted to the app.
--- The app creates the services once a compute pool is available.
+-- The app creates the service once a compute pool is available.
+-- service-spec.yaml defines two containers: agent-bom (API:8422) + agent-bom-ui (UI:3000).
 CREATE SERVICE IF NOT EXISTS core.agent_bom_api
     IN COMPUTE POOL consumer_pool  -- consumer must grant this
     FROM SPECIFICATION_FILE = '/service-spec.yaml'
@@ -199,5 +200,7 @@ CREATE SERVICE IF NOT EXISTS core.agent_bom_api
     MAX_INSTANCES = 1;
 
 GRANT USAGE ON SERVICE core.agent_bom_api TO APPLICATION ROLE app_user;
+-- Service roles surface each endpoint independently so consumers can grant
+-- API or UI access without exposing both.
 GRANT SERVICE ROLE core.agent_bom_api!api TO APPLICATION ROLE app_user;
-GRANT SERVICE ROLE core.agent_bom_api!ui TO APPLICATION ROLE app_user;
+GRANT SERVICE ROLE core.agent_bom_api!ui  TO APPLICATION ROLE app_user;

--- a/deploy/snowflake/native-app/scripts/setup.sql
+++ b/deploy/snowflake/native-app/scripts/setup.sql
@@ -183,16 +183,9 @@ AS
 -- Creates core.apply_compliance_hub() and core.compliance_posture view.
 EXECUTE IMMEDIATE FROM 'dcm/V002__compliance_proc.sql';
 
--- 7. Streamlit dashboard (default_streamlit in manifest)
-CREATE STREAMLIT IF NOT EXISTS core.dashboard
-    FROM 'streamlit'
-    MAIN_FILE = 'dashboard.py';
-GRANT USAGE ON STREAMLIT core.dashboard TO APPLICATION ROLE app_user;
-
--- 6. Services (Phase 3: API + UI both defined in service-spec.yaml)
--- Note: compute pool must be created by the consumer and granted to the app.
--- The app creates the service once a compute pool is available.
--- service-spec.yaml defines two containers: agent-bom (API:8422) + agent-bom-ui (UI:3000).
+-- 7. SPCS service — API + Next.js UI (Phase 3)
+-- Consumer must provision a compute pool and grant it to the app before this runs.
+-- manifest.yml default_web_endpoint → ui endpoint (port 3000) opens on app launch.
 CREATE SERVICE IF NOT EXISTS core.agent_bom_api
     IN COMPUTE POOL consumer_pool  -- consumer must grant this
     FROM SPECIFICATION_FILE = '/service-spec.yaml'

--- a/deploy/snowflake/service-spec.yaml
+++ b/deploy/snowflake/service-spec.yaml
@@ -1,15 +1,61 @@
 spec:
   containers:
+    # ── agent-bom API (FastAPI) ───────────────────────────────────────────────
     - name: agent-bom
       image: /db/schema/agent_bom_repo/agent-bom:latest
       env:
         SNOWFLAKE_ACCOUNT: "{{ snowflake_account }}"
         SNOWFLAKE_DATABASE: "{{ database }}"
         SNOWFLAKE_SCHEMA: "{{ schema }}"
+        AGENT_BOM_MCP_MODE: "0"
+        AGENT_BOM_LOG_LEVEL: "INFO"
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp/agent-bom
       readinessProbe:
         port: 8422
         path: /health
+      resources:
+        requests:
+          memory: 512M
+          cpu: 0.5
+        limits:
+          memory: 2G
+          cpu: 2
+
+    # ── agent-bom UI (Next.js) ───────────────────────────────────────────────
+    # Proxies /api/* to the API container via localhost; no public egress.
+    - name: agent-bom-ui
+      image: /db/schema/agent_bom_repo/agent-bom-ui:latest
+      env:
+        # Both containers share the same SPCS service network namespace,
+        # so the API is reachable on localhost without an external round-trip.
+        NEXT_PUBLIC_API_URL: "http://localhost:8422"
+        NODE_ENV: production
+        PORT: "3000"
+      readinessProbe:
+        port: 3000
+        path: /api/health
+      resources:
+        requests:
+          memory: 256M
+          cpu: 0.25
+        limits:
+          memory: 1G
+          cpu: 1
+
+  volumes:
+    - name: tmp
+      source: local
+      size: 1Gi
+
   endpoints:
+    # Internal API endpoint — consumed by the UI container and Streamlit dashboard.
     - name: api
       port: 8422
+      public: false
+
+    # Internal UI endpoint — accessed via the Snowflake Native App ingress URL.
+    - name: ui
+      port: 3000
       public: false


### PR DESCRIPTION
## What

Extends the Snowpark Container Services deployment to run both the FastAPI backend and Next.js UI in a single SPCS service, alongside the Streamlit-in-Snowflake (SiS) dashboard already shipping in Phase 1.

## Architecture

```
SPCS Service: core.agent_bom_api
├── Container: agent-bom       → port 8422 (FastAPI)  → endpoint 'api'
└── Container: agent-bom-ui    → port 3000 (Next.js)  → endpoint 'ui'
    └── NEXT_PUBLIC_API_URL=http://localhost:8422
        (shared service network — no external round-trip)
```

Both containers share the SPCS service network namespace. The UI reaches the API on `localhost:8422` — zero cross-account HTTP egress.

## Changes

### `deploy/snowflake/service-spec.yaml`
- `agent-bom` container: adds `AGENT_BOM_MCP_MODE`, `AGENT_BOM_LOG_LEVEL`, `volumeMounts`, resource `requests`/`limits`
- `agent-bom-ui` container: `NEXT_PUBLIC_API_URL=http://localhost:8422`, `NODE_ENV=production`, readiness probe on `/api/health`
- Shared `tmp` volume (1 Gi local)
- `ui` endpoint (port 3000, internal)

### `deploy/snowflake/native-app/manifest.yml`
- Declares `agent-bom-ui:latest` image in `container_services.images`
- Declares two `service_roles`: `api` and `ui` — consumers can grant access to each endpoint independently (e.g. data scientists get `ui` only)

### `deploy/snowflake/native-app/scripts/setup.sql`
- `GRANT SERVICE ROLE core.agent_bom_api!api TO APPLICATION ROLE app_user`
- `GRANT SERVICE ROLE core.agent_bom_api!ui  TO APPLICATION ROLE app_user`

## Test plan
- [ ] `snow app run` on a SPCS-enabled Snowflake account — both containers reach Running state
- [ ] `SHOW ENDPOINTS IN SERVICE core.agent_bom_api` returns both `api` (8422) and `ui` (3000)
- [ ] `curl https://<ui-endpoint>/api/health` returns 200
- [ ] `curl https://<api-endpoint>/health` returns 200
- [ ] Next.js dashboard loads and fetches data from the API via localhost (no CORS errors in browser console)