### PR TITLE
feat(iac): DCM fullstack wiring + IAM-to-agent graph edges

### DIFF
--- a/src/agent_bom/context_graph.py
+++ b/src/agent_bom/context_graph.py
@@ -60,6 +60,7 @@ class NodeKind(str, Enum):
     CREDENTIAL = "credential"
     TOOL = "tool"
     VULNERABILITY = "vulnerability"
+    IAM_ROLE = "iam_role"  # Cloud IAM role / workload identity attached to an agent
 
 
 class EdgeKind(str, Enum):
@@ -69,6 +70,7 @@ class EdgeKind(str, Enum):
     VULNERABLE_TO = "vulnerable_to"  # server → vulnerability
     SHARES_SERVER = "shares_server"  # agent ↔ agent
     SHARES_CREDENTIAL = "shares_credential"  # agent ↔ agent
+    ATTACHED_TO = "attached_to"  # iam_role → agent (workload identity correlation)
 
 
 # ── Data structures (backward-compat) ────────────────────────────────────
@@ -187,6 +189,36 @@ def build_context_graph(
                 },
             )
         )
+
+        # Wire IAM role / cloud principal → agent edge when cloud providers
+        # have recorded workload identity in agent metadata.
+        cloud_principal = (agent_dict.get("metadata") or {}).get("cloud_principal")
+        if cloud_principal and isinstance(cloud_principal, dict):
+            principal_id = cloud_principal.get("principal_id") or cloud_principal.get("principal_name", "")
+            if principal_id:
+                role_id = f"iam_role:{principal_id}"
+                if role_id not in graph.nodes:
+                    graph.add_node(
+                        GraphNode(
+                            id=role_id,
+                            kind=NodeKind.IAM_ROLE,
+                            label=principal_id,
+                            metadata={
+                                "principal_type": cloud_principal.get("principal_type", ""),
+                                "provider": cloud_principal.get("provider", ""),
+                                "service": cloud_principal.get("service", ""),
+                            },
+                        )
+                    )
+                graph.add_edge(
+                    GraphEdge(
+                        source=role_id,
+                        target=agent_id,
+                        kind=EdgeKind.ATTACHED_TO,
+                        weight=2.0,
+                        metadata={"principal_type": cloud_principal.get("principal_type", "")},
+                    )
+                )
 
         for srv_dict in agent_dict.get("mcp_servers", []):
             srv_name = srv_dict.get("name", "unknown")

--- a/src/agent_bom/iac/atlas_mapping.py
+++ b/src/agent_bom/iac/atlas_mapping.py
@@ -87,6 +87,19 @@ IAC_ATLAS_MAP: dict[str, list[str]] = {
     "K8S-AI-001": ["AML.T0007", "AML.T0010"],
     # K8s PV / PVC mounting an open training dataset volume.
     "K8S-AI-002": ["AML.T0035", "AML.T0036"],
+    # ── Snowflake DCM — AI-data relevant rules ─────────────────────────────
+    # DCM-001: MANAGE GRANTS — lets recipient read/delegate on any Snowflake
+    # object including Cortex models, Snowpark stages, and ML feature stores.
+    "DCM-001": ["AML.T0007", "AML.T0036"],
+    # DCM-005: SPCS SERVICE without network policy — SPCS hosts AI inference
+    # containers; an unrestricted service is a discoverable inference endpoint.
+    "DCM-005": ["AML.T0010", "AML.T0010.003"],
+    # DCM-006: GRANT ACCOUNTADMIN/SECURITYADMIN — account-level admin provides
+    # full read access to every Snowflake ML registry and artifact store.
+    "DCM-006": ["AML.T0007", "AML.T0010"],
+    # DCM-008: Privilege to PUBLIC — exposes Snowflake tables/stages/models to
+    # every account user, enabling AI artifact discovery and collection.
+    "DCM-008": ["AML.T0007", "AML.T0035"],
 }
 
 # ─── Resource-type prefix fallback ─────────────────────────────────────────

--- a/src/agent_bom/iac/attack_mapping.py
+++ b/src/agent_bom/iac/attack_mapping.py
@@ -116,6 +116,15 @@ IAC_ATTACK_MAP: dict[str, list[str]] = {
     "HELM-005": ["T1552.001"],  # Secrets in values
     "HELM-006": ["T1562.001"],  # No health checks
     "HELM-007": ["T1190"],  # Service exposed without policy
+    # ── Snowflake DCM ───────────────────────────────────────────────────────
+    "DCM-001": ["T1098", "T1078.004"],  # MANAGE GRANTS → Account Manipulation + Cloud Accounts
+    "DCM-002": ["T1190"],  # NETWORK POLICY 0.0.0.0/0 → Exploit Public-Facing Application
+    "DCM-003": ["T1098", "T1078"],  # GRANT ALL → Account Manipulation + Valid Accounts
+    "DCM-004": ["T1496"],  # TASK without timeout → Resource Hijacking (unbounded credit burn)
+    "DCM-005": ["T1190", "T1133"],  # SERVICE without policy → Public App + External Remote Services
+    "DCM-006": ["T1078.004", "T1098"],  # GRANT ACCOUNTADMIN/SECURITYADMIN → Cloud Accounts + Account Manip.
+    "DCM-007": ["T1078", "T1530"],  # USAGE on DATABASE → Valid Accounts + Data from Cloud Storage
+    "DCM-008": ["T1078", "T1530"],  # Privilege to PUBLIC → Valid Accounts + Data from Cloud Storage
 }
 
 

--- a/src/agent_bom/iac/dcm.py
+++ b/src/agent_bom/iac/dcm.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from agent_bom.iac.models import IaCFinding
+from agent_bom.iac.models import IaCFinding, IaCResourceType
 
 # ─── DCM project shape detection ─────────────────────────────────────────────
 
@@ -143,6 +143,17 @@ _RULE_PATTERNS: list[tuple[str, str, str, str, str, list[str]]] = [
     ),
 ]
 
+_RULE_RESOURCE_TYPE: dict[str, IaCResourceType] = {
+    "DCM-001": IaCResourceType.DCM_GRANT,
+    "DCM-002": IaCResourceType.DCM_NETWORK_POLICY,
+    "DCM-003": IaCResourceType.DCM_GRANT,
+    "DCM-004": IaCResourceType.DCM_TASK,
+    "DCM-005": IaCResourceType.DCM_SERVICE,
+    "DCM-006": IaCResourceType.DCM_GRANT,
+    "DCM-007": IaCResourceType.DCM_GRANT,
+    "DCM-008": IaCResourceType.DCM_GRANT,
+}
+
 _REMEDIATION_BY_RULE: dict[str, str] = {
     "DCM-001": "Drop MANAGE GRANTS; use SECURITYADMIN or ROLE-OWNERSHIP.",
     "DCM-002": "Replace 0.0.0.0/0 with VPN / bastion CIDRs in ALLOWED_IP_LIST.",
@@ -198,6 +209,7 @@ def scan_dcm_migration(path: Path) -> list[IaCFinding]:
                     category="dcm",
                     compliance=list(compliance),
                     remediation=_REMEDIATION_BY_RULE.get(rule_id, ""),
+                    resource_type=_RULE_RESOURCE_TYPE.get(rule_id),
                 )
             )
 

--- a/src/agent_bom/iac/models.py
+++ b/src/agent_bom/iac/models.py
@@ -3,6 +3,34 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
+
+
+class IaCResourceType(str, Enum):
+    """First-class IaC resource types surfaced by agent-bom scanners."""
+
+    # Terraform
+    TF_RESOURCE = "tf_resource"
+    # Kubernetes
+    K8S_POD = "k8s_pod"
+    K8S_DEPLOYMENT = "k8s_deployment"
+    K8S_SERVICE = "k8s_service"
+    K8S_ROLE = "k8s_role"
+    K8S_CLUSTER_ROLE = "k8s_cluster_role"
+    K8S_NETWORK_POLICY = "k8s_network_policy"
+    # Dockerfile
+    DOCKERFILE = "dockerfile"
+    # CloudFormation
+    CFN_RESOURCE = "cfn_resource"
+    # Helm
+    HELM_RESOURCE = "helm_resource"
+    # Snowflake DCM (Database Change Management)
+    DCM_ROLE = "dcm_role"
+    DCM_NETWORK_POLICY = "dcm_network_policy"
+    DCM_TABLE = "dcm_table"
+    DCM_GRANT = "dcm_grant"
+    DCM_TASK = "dcm_task"
+    DCM_SERVICE = "dcm_service"
 
 
 @dataclass
@@ -15,11 +43,12 @@ class IaCFinding:
     message: str  # Detailed explanation with fix guidance
     file_path: str  # Relative path to the file
     line_number: int  # Line where the issue was found
-    category: str  # "dockerfile", "kubernetes", "terraform"
+    category: str  # "dockerfile", "kubernetes", "terraform", "dcm"
     compliance: list[str] = field(default_factory=list)  # e.g. ["CIS-5.1", "NIST-CM-6"]
     attack_techniques: list[str] = field(default_factory=list)  # MITRE ATT&CK IDs, e.g. ["T1552.001"]
     atlas_techniques: list[str] = field(default_factory=list)  # MITRE ATLAS IDs, e.g. ["AML.T0010"]
     remediation: str = ""  # Fix guidance
+    resource_type: IaCResourceType | None = None  # Structured resource type for graph/compliance wiring
 
 
 @dataclass

--- a/tests/test_context_graph.py
+++ b/tests/test_context_graph.py
@@ -555,3 +555,61 @@ class TestAPIContextGraph:
         # Lateral paths should only originate from a1
         for p in data["lateral_paths"]:
             assert p["source"] == "agent:a1"
+
+
+# ─── IAM role → agent edges (#980) ───────────────────────────────────────────
+
+
+class TestIamRoleAgentEdges:
+    """IAM_ROLE nodes and ATTACHED_TO edges from cloud_principal metadata."""
+
+    def _agent_with_principal(self, name: str, principal_id: str, principal_type: str = "role") -> dict:
+        return {
+            "name": name,
+            "type": "cloud",
+            "status": "active",
+            "mcp_servers": [],
+            "metadata": {
+                "cloud_principal": {
+                    "principal_id": principal_id,
+                    "principal_name": principal_id,
+                    "principal_type": principal_type,
+                    "provider": "aws",
+                    "service": "lambda",
+                }
+            },
+        }
+
+    def test_iam_role_node_created(self):
+        agent = self._agent_with_principal("fn1", "arn:aws:iam::123:role/MyRole")
+        graph = build_context_graph([agent], [])
+        role_id = "iam_role:arn:aws:iam::123:role/MyRole"
+        assert role_id in graph.nodes
+        assert graph.nodes[role_id].kind.value == "iam_role"
+
+    def test_attached_to_edge_created(self):
+        agent = self._agent_with_principal("fn1", "arn:aws:iam::123:role/MyRole")
+        graph = build_context_graph([agent], [])
+        role_id = "iam_role:arn:aws:iam::123:role/MyRole"
+        agent_id = "agent:fn1"
+        attached = [e for e in graph.edges if e.source == role_id and e.target == agent_id]
+        assert attached, "Expected ATTACHED_TO edge from IAM role to agent"
+        assert attached[0].kind.value == "attached_to"
+
+    def test_no_principal_no_iam_node(self):
+        agent = {"name": "plain", "type": "mcp", "status": "active", "mcp_servers": [], "metadata": {}}
+        graph = build_context_graph([agent], [])
+        iam_nodes = [n for n in graph.nodes.values() if n.kind.value == "iam_role"]
+        assert iam_nodes == []
+
+    def test_shared_role_single_node(self):
+        """Two agents with the same IAM role share one IAM_ROLE node."""
+        role_arn = "arn:aws:iam::123:role/SharedRole"
+        a1 = self._agent_with_principal("fn1", role_arn)
+        a2 = self._agent_with_principal("fn2", role_arn)
+        graph = build_context_graph([a1, a2], [])
+        iam_nodes = [n for n in graph.nodes.values() if n.kind.value == "iam_role"]
+        assert len(iam_nodes) == 1
+        # Both agents have an ATTACHED_TO edge from the shared role
+        attached = [e for e in graph.edges if e.kind.value == "attached_to"]
+        assert len(attached) == 2

--- a/tests/test_iac_dcm.py
+++ b/tests/test_iac_dcm.py
@@ -193,3 +193,72 @@ def test_scan_iac_directory_does_not_treat_dcm_as_kubernetes(tmp_path):
     # — the absence of a wrong-category classification is the assertion.
     for f_ in findings:
         assert f_.category == "dcm" or f_.category != "kubernetes", f"DCM file misclassified as {f_.category}: {f_.rule_id}"
+
+
+# ─── IaCResourceType wiring ───────────────────────────────────────────────────
+
+from agent_bom.iac.models import IaCResourceType  # noqa: E402
+
+
+def test_dcm_findings_carry_resource_type(tmp_path):
+    """Every DCM finding must carry an IaCResourceType value so graph/compliance wiring works."""
+    dcm_dir = tmp_path / "dcm"
+    dcm_dir.mkdir()
+    # DCM-001 → DCM_GRANT; DCM-002 → DCM_NETWORK_POLICY; DCM-004 → DCM_TASK; DCM-005 → DCM_SERVICE
+    sql = (
+        "GRANT MANAGE GRANTS ON ACCOUNT TO ROLE x;\n"
+        "CREATE NETWORK POLICY p ALLOWED_IP_LIST=('0.0.0.0/0');\n"
+        "CREATE TASK t AS BEGIN RETURN 1; END;\n"
+        "CREATE SERVICE s IN COMPUTE POOL c AS spec='...';\n"
+    )
+    (dcm_dir / "V001__setup.sql").write_text(sql, encoding="utf-8")
+    findings = scan_iac_directory(tmp_path)
+    dcm = [f for f in findings if f.category == "dcm"]
+    assert dcm, "Expected DCM findings"
+    for f in dcm:
+        assert f.resource_type is not None, f"{f.rule_id} missing resource_type"
+        assert isinstance(f.resource_type, IaCResourceType)
+
+
+def test_dcm_grant_rules_have_dcm_grant_type(tmp_path):
+    """DCM-001/003/006/007/008 are all GRANT-class — resource_type must be DCM_GRANT."""
+    dcm_dir = tmp_path / "dcm"
+    dcm_dir.mkdir()
+    (dcm_dir / "V001__grants.sql").write_text(
+        "GRANT MANAGE GRANTS ON ACCOUNT TO ROLE x;\n",
+        encoding="utf-8",
+    )
+    findings = scan_iac_directory(tmp_path)
+    dcm001 = [f for f in findings if f.rule_id == "DCM-001"]
+    assert dcm001, "DCM-001 not triggered"
+    assert dcm001[0].resource_type == IaCResourceType.DCM_GRANT
+
+
+def test_dcm_attack_techniques_populated(tmp_path):
+    """DCM findings must have ATT&CK techniques enriched via attack_mapping."""
+    dcm_dir = tmp_path / "dcm"
+    dcm_dir.mkdir()
+    (dcm_dir / "V001__priv.sql").write_text(
+        "GRANT MANAGE GRANTS ON ACCOUNT TO ROLE x;\n",
+        encoding="utf-8",
+    )
+    findings = scan_iac_directory(tmp_path)
+    dcm001 = [f for f in findings if f.rule_id == "DCM-001"]
+    assert dcm001
+    assert dcm001[0].attack_techniques, "DCM-001 missing ATT&CK techniques"
+    assert "T1098" in dcm001[0].attack_techniques
+
+
+def test_dcm_atlas_techniques_populated(tmp_path):
+    """DCM-001 and DCM-005/006/008 must have ATLAS techniques (AI-data relevance)."""
+    dcm_dir = tmp_path / "dcm"
+    dcm_dir.mkdir()
+    (dcm_dir / "V001__priv.sql").write_text(
+        "GRANT MANAGE GRANTS ON ACCOUNT TO ROLE x;\n",
+        encoding="utf-8",
+    )
+    findings = scan_iac_directory(tmp_path)
+    dcm001 = [f for f in findings if f.rule_id == "DCM-001"]
+    assert dcm001
+    assert dcm001[0].atlas_techniques, "DCM-001 missing ATLAS techniques"
+    assert "AML.T0007" in dcm001[0].atlas_techniques


### PR DESCRIPTION
## Summary

Closes #2218 and #980.

**DCM as first-class IaC type (#2218):**
- `IaCResourceType` enum added to `iac/models.py` with DCM values (`DCM_ROLE`, `DCM_NETWORK_POLICY`, `DCM_TABLE`, `DCM_GRANT`, `DCM_TASK`, `DCM_SERVICE`) and variants for all other IaC providers
- `IaCFinding` gains an optional `resource_type: IaCResourceType | None` field — zero breaking change to existing scanners
- `iac/attack_mapping.py`: DCM-001..008 mapped to ATT&CK (T1098/T1078.004 privilege escalation, T1190/T1133 network exposure, T1496 resource hijacking, T1530 data access)
- `iac/atlas_mapping.py`: DCM-001 (MANAGE GRANTS), DCM-005 (SPCS service), DCM-006 (ACCOUNTADMIN grant), DCM-008 (PUBLIC role) mapped to ATLAS AML.T0007/T0010/T0035/T0036 — SPCS hosts AI inference; MANAGE GRANTS unlocks Cortex/Snowpark ML registry access
- `iac/dcm.py`: `_RULE_RESOURCE_TYPE` map wires resource_type onto every DCM finding
- The existing `__init__.py` post-scan enrichment loop already calls `get_attack_techniques()` and `get_atlas_techniques()` — DCM findings auto-enrich with no additional wiring

**IAM-to-agent correlation (#980):**
- `context_graph.py`: `NodeKind.IAM_ROLE` + `EdgeKind.ATTACHED_TO` added
- `build_context_graph()` reads `cloud_principal` from agent metadata (already populated by AWS/GCP/Azure providers via `build_cloud_principal()`) and creates `IAM_ROLE` nodes + `ATTACHED_TO` edges
- Shared roles (multiple agents with the same execution identity) produce a single `IAM_ROLE` node with multiple outbound edges — blast-radius analysis can now trace "which other agents share this role"

## Test plan

- [ ] `python -m pytest tests/test_iac_dcm.py` — resource_type on findings, ATT&CK/ATLAS enrichment
- [ ] `python -m pytest tests/test_context_graph.py` — IAM_ROLE node created, ATTACHED_TO edge wired, shared-role single-node dedup, no-principal no-node
- [ ] `python -m pytest tests/test_iac_attack_mapping.py` (if exists) — DCM entries present