### PR TITLE
feat(scanners): SPDX license file scanner — LICENSE/COPYING files and source header detection

### DIFF
--- a/src/agent_bom/license_file_scanner.py
+++ b/src/agent_bom/license_file_scanner.py
@@ -1,0 +1,318 @@
+"""Source-file and license-file SPDX identifier scanner.
+
+Complements registry-based license detection in resolver.py by scanning:
+  1. LICENSE / COPYING / LICENCE files — SPDX-License-Identifier tag or
+     best-effort text pattern matching for the most common licenses.
+  2. Source-file headers — ``SPDX-License-Identifier:`` comment in the
+     first 20 lines of any .py / .js / .ts / .go / .java / .c / .cpp / .h file.
+
+Results feed back into the license_compliance_scan MCP tool (scan_dir
+argument) and the ``agent-bom scan`` pipeline so that packages whose
+registry metadata lacks a license field can be enriched from local source.
+
+Issue: #872
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ─── SPDX identifier extraction ──────────────────────────────────────────────
+
+_SPDX_ID_RE = re.compile(
+    r"SPDX-License-Identifier:\s*([A-Za-z0-9.+\-()]+(?:\s+(?:AND|OR|WITH)\s+[A-Za-z0-9.+\-()]+)*)",
+    re.IGNORECASE,
+)
+
+# Filenames that are conventionally license texts (case-insensitive stem match)
+_LICENSE_STEMS: frozenset[str] = frozenset(
+    {
+        "license",
+        "licence",
+        "copying",
+        "copying.lesser",
+        "notice",
+        "copyright",
+        "unlicense",
+    }
+)
+
+# Source-file extensions to scan for SPDX header comments
+_SOURCE_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        ".py",
+        ".js",
+        ".ts",
+        ".jsx",
+        ".tsx",
+        ".go",
+        ".java",
+        ".c",
+        ".cpp",
+        ".h",
+        ".hpp",
+        ".cs",
+        ".rs",
+        ".rb",
+        ".sh",
+        ".bash",
+        ".swift",
+        ".kt",
+        ".scala",
+    }
+)
+
+# Max lines to scan for SPDX header in source files
+_HEADER_SCAN_LINES = 20
+
+# Max file size (bytes) to attempt text pattern matching on license files
+_MAX_LICENSE_FILE_SIZE = 512_000  # 512 KB
+
+# ─── License text pattern matching ───────────────────────────────────────────
+#
+# Ordered by specificity — longer / more distinctive patterns first.
+# Each tuple: (compiled regex, SPDX identifier)
+
+_LICENSE_TEXT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"GNU AFFERO GENERAL PUBLIC LICENSE\s+Version 3", re.IGNORECASE), "AGPL-3.0-only"),
+    (re.compile(r"GNU GENERAL PUBLIC LICENSE\s+Version 3", re.IGNORECASE), "GPL-3.0-only"),
+    (re.compile(r"GNU GENERAL PUBLIC LICENSE\s+Version 2", re.IGNORECASE), "GPL-2.0-only"),
+    (re.compile(r"GNU LESSER GENERAL PUBLIC LICENSE\s+Version 3", re.IGNORECASE), "LGPL-3.0-only"),
+    (re.compile(r"GNU LESSER GENERAL PUBLIC LICENSE\s+Version 2\.1", re.IGNORECASE), "LGPL-2.1-only"),
+    (re.compile(r"GNU LESSER GENERAL PUBLIC LICENSE\s+Version 2(?!\.1)", re.IGNORECASE), "LGPL-2.0-only"),
+    (re.compile(r"Apache License[,\s]+Version 2\.0", re.IGNORECASE), "Apache-2.0"),
+    (re.compile(r"MIT License", re.IGNORECASE), "MIT"),
+    (re.compile(r"Permission is hereby granted,? free of charge", re.IGNORECASE), "MIT"),
+    (re.compile(r"Mozilla Public License[,\s]+Version 2\.0", re.IGNORECASE), "MPL-2.0"),
+    (re.compile(r"Eclipse Public License[,\s]+Version 2\.0", re.IGNORECASE), "EPL-2.0"),
+    (re.compile(r"Eclipse Public License[,\s]+(?:Version )?1\.0", re.IGNORECASE), "EPL-1.0"),
+    (re.compile(r"BSD 2-Clause|Simplified BSD License", re.IGNORECASE), "BSD-2-Clause"),
+    (re.compile(r"BSD 3-Clause|New BSD License|Modified BSD", re.IGNORECASE), "BSD-3-Clause"),
+    (re.compile(r"BSD 4-Clause|Original BSD", re.IGNORECASE), "BSD-4-Clause"),
+    (re.compile(r"ISC License", re.IGNORECASE), "ISC"),
+    (re.compile(r"Creative Commons.*Zero.*1\.0|CC0-1\.0", re.IGNORECASE), "CC0-1.0"),
+    (re.compile(r"Creative Commons.*Attribution.*4\.0", re.IGNORECASE), "CC-BY-4.0"),
+    (re.compile(r"Server Side Public License|SSPL", re.IGNORECASE), "SSPL-1.0"),
+    (re.compile(r"Business Source License|BUSL-1\.1", re.IGNORECASE), "BUSL-1.1"),
+    (re.compile(r"Elastic License 2\.0|ELv2", re.IGNORECASE), "Elastic-2.0"),
+    (re.compile(r"European Union Public Licen[sc]e|EUPL", re.IGNORECASE), "EUPL-1.2"),
+    (re.compile(r"Common Development and Distribution License|CDDL", re.IGNORECASE), "CDDL-1.0"),
+    (re.compile(r"Open Software License|OSL-3\.0", re.IGNORECASE), "OSL-3.0"),
+    (re.compile(r"Artistic License 2\.0", re.IGNORECASE), "Artistic-2.0"),
+    (re.compile(r"The Unlicense|UNLICENSE", re.IGNORECASE), "Unlicense"),
+    (re.compile(r"Do What The F.ck You Want|WTFPL", re.IGNORECASE), "WTFPL"),
+    (re.compile(r"Zlib License|zlib/libpng", re.IGNORECASE), "Zlib"),
+    (re.compile(r"PostgreSQL License", re.IGNORECASE), "PostgreSQL"),
+    (re.compile(r"Python Software Foundation License", re.IGNORECASE), "PSF-2.0"),
+]
+
+
+# ─── Result dataclasses ───────────────────────────────────────────────────────
+
+
+@dataclass
+class LicenseFileResult:
+    """A license detection result from a single file."""
+
+    file_path: str
+    spdx_id: str
+    detection_method: str  # "spdx_identifier" | "text_pattern" | "source_header"
+    confidence: str  # "high" | "medium" | "low"
+    raw_expression: str = ""
+
+
+@dataclass
+class DirectoryScanResult:
+    """Aggregated results from scanning a directory for license information."""
+
+    root: str
+    license_files: list[LicenseFileResult] = field(default_factory=list)
+    source_headers: list[LicenseFileResult] = field(default_factory=list)
+
+    @property
+    def all_results(self) -> list[LicenseFileResult]:
+        return self.license_files + self.source_headers
+
+    @property
+    def unique_spdx_ids(self) -> list[str]:
+        return sorted({r.spdx_id for r in self.all_results})
+
+    def to_dict(self) -> dict:
+        return {
+            "root": self.root,
+            "unique_spdx_ids": self.unique_spdx_ids,
+            "license_files": [
+                {
+                    "file_path": r.file_path,
+                    "spdx_id": r.spdx_id,
+                    "detection_method": r.detection_method,
+                    "confidence": r.confidence,
+                }
+                for r in self.license_files
+            ],
+            "source_header_count": len(self.source_headers),
+            "source_header_sample": [{"file_path": r.file_path, "spdx_id": r.spdx_id} for r in self.source_headers[:5]],
+        }
+
+
+# ─── Core detection functions ─────────────────────────────────────────────────
+
+
+def detect_spdx_from_text(text: str) -> str | None:
+    """Extract an SPDX-License-Identifier tag from arbitrary text.
+
+    Returns the raw SPDX expression (e.g. ``"MIT OR Apache-2.0"``) or None.
+    """
+    m = _SPDX_ID_RE.search(text)
+    if m:
+        return m.group(1).strip()
+    return None
+
+
+def detect_spdx_from_license_text(text: str) -> str | None:
+    """Heuristically identify an SPDX ID from license file body text.
+
+    Falls back to pattern matching when no SPDX-License-Identifier tag is
+    present. Returns the most specific match or None.
+    """
+    for pattern, spdx_id in _LICENSE_TEXT_PATTERNS:
+        if pattern.search(text):
+            return spdx_id
+    return None
+
+
+def scan_license_file(path: Path) -> LicenseFileResult | None:
+    """Scan a single LICENSE/COPYING file and return a detection result.
+
+    Returns None if the file cannot be read or no license is detected.
+    """
+    try:
+        size = path.stat().st_size
+        if size > _MAX_LICENSE_FILE_SIZE:
+            logger.debug("Skipping oversized license file %s (%d bytes)", path, size)
+            return None
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+    # Prefer explicit SPDX tag
+    spdx = detect_spdx_from_text(text)
+    if spdx:
+        return LicenseFileResult(
+            file_path=str(path),
+            spdx_id=spdx,
+            detection_method="spdx_identifier",
+            confidence="high",
+            raw_expression=spdx,
+        )
+
+    # Fall back to text pattern matching
+    spdx = detect_spdx_from_license_text(text)
+    if spdx:
+        return LicenseFileResult(
+            file_path=str(path),
+            spdx_id=spdx,
+            detection_method="text_pattern",
+            confidence="medium",
+        )
+
+    return None
+
+
+def scan_source_header(path: Path) -> LicenseFileResult | None:
+    """Scan the first N lines of a source file for an SPDX header comment.
+
+    Returns None if no SPDX-License-Identifier is found in the header.
+    """
+    try:
+        with path.open(encoding="utf-8", errors="replace") as fh:
+            header = "".join(next(fh, "") for _ in range(_HEADER_SCAN_LINES))
+    except OSError:
+        return None
+
+    spdx = detect_spdx_from_text(header)
+    if spdx:
+        return LicenseFileResult(
+            file_path=str(path),
+            spdx_id=spdx,
+            detection_method="source_header",
+            confidence="high",
+            raw_expression=spdx,
+        )
+    return None
+
+
+def is_license_filename(path: Path) -> bool:
+    """Return True when the filename looks like a license/copyright file."""
+    stem = path.stem.lower()
+    return stem in _LICENSE_STEMS or path.name.lower() in _LICENSE_STEMS
+
+
+# ─── Directory scanner ────────────────────────────────────────────────────────
+
+
+def scan_directory(
+    root: Path,
+    *,
+    scan_source_headers: bool = True,
+    max_source_files: int = 2_000,
+) -> DirectoryScanResult:
+    """Scan a directory tree for license information.
+
+    Walks ``root`` recursively:
+    - Every LICENSE/COPYING/NOTICE/UNLICENSE file is scanned for SPDX IDs.
+    - Source files (up to ``max_source_files``) are checked for
+      ``SPDX-License-Identifier:`` header comments.
+
+    Args:
+        root: Directory to scan.
+        scan_source_headers: Whether to scan source file headers (default True).
+        max_source_files: Safety cap on source files scanned to prevent
+            runaway on very large repos.
+
+    Returns:
+        A :class:`DirectoryScanResult` with all detected licenses.
+    """
+    result = DirectoryScanResult(root=str(root))
+
+    if not root.is_dir():
+        logger.warning("license_file_scanner: %s is not a directory", root)
+        return result
+
+    source_scanned = 0
+
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+
+        # Skip hidden directories (e.g. .git, .tox, node_modules)
+        if any(part.startswith(".") or part == "node_modules" or part == "__pycache__" for part in path.parts):
+            continue
+
+        if is_license_filename(path):
+            detection = scan_license_file(path)
+            if detection:
+                result.license_files.append(detection)
+            continue
+
+        if scan_source_headers and path.suffix.lower() in _SOURCE_EXTENSIONS:
+            if source_scanned >= max_source_files:
+                continue
+            detection = scan_source_header(path)
+            source_scanned += 1
+            if detection:
+                result.source_headers.append(detection)
+
+    logger.debug(
+        "license_file_scanner: %s — %d license files, %d source headers, %d unique SPDX IDs",
+        root,
+        len(result.license_files),
+        len(result.source_headers),
+        len(result.unique_spdx_ids),
+    )
+    return result

--- a/src/agent_bom/mcp_tools/compliance.py
+++ b/src/agent_bom/mcp_tools/compliance.py
@@ -197,6 +197,7 @@ async def license_compliance_scan_impl(
     *,
     scan_json: str,
     policy_json: str = "",
+    scan_dir: str = "",
     _truncate_response,
 ) -> str:
     """Implementation of the license_compliance_scan tool."""
@@ -248,7 +249,18 @@ async def license_compliance_scan_impl(
             ]
 
         report = evaluate_license_policy(agents, policy=policy)
-        return _truncate_response(json.dumps(to_serializable(report), indent=2))
+        result = to_serializable(report)
+
+        # Optional: scan a local directory for LICENSE files and SPDX headers
+        if scan_dir:
+            from pathlib import Path
+
+            from agent_bom.license_file_scanner import scan_directory
+
+            dir_result = scan_directory(Path(scan_dir))
+            result["license_file_scan"] = dir_result.to_dict()
+
+        return _truncate_response(json.dumps(result, indent=2))
     except Exception as exc:
         logger.exception("MCP tool error")
         return json.dumps({"error": sanitize_error(exc)})

--- a/tests/test_license_file_scanner.py
+++ b/tests/test_license_file_scanner.py
@@ -1,0 +1,213 @@
+"""Tests for agent_bom.license_file_scanner (#872)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_bom.license_file_scanner import (
+    detect_spdx_from_license_text,
+    detect_spdx_from_text,
+    is_license_filename,
+    scan_directory,
+    scan_license_file,
+    scan_source_header,
+)
+
+# ─── SPDX tag extraction ──────────────────────────────────────────────────────
+
+
+def test_detect_spdx_from_text_simple():
+    assert detect_spdx_from_text("# SPDX-License-Identifier: MIT") == "MIT"
+
+
+def test_detect_spdx_from_text_expression():
+    result = detect_spdx_from_text("// SPDX-License-Identifier: Apache-2.0 OR MIT")
+    assert result == "Apache-2.0 OR MIT"
+
+
+def test_detect_spdx_from_text_missing():
+    assert detect_spdx_from_text("No license info here.") is None
+
+
+def test_detect_spdx_from_text_case_insensitive():
+    assert detect_spdx_from_text("# spdx-license-identifier: GPL-3.0-only") == "GPL-3.0-only"
+
+
+# ─── License text pattern matching ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("MIT License\nPermission is hereby granted, free of charge", "MIT"),
+        ("Apache License\nVersion 2.0", "Apache-2.0"),
+        ("GNU GENERAL PUBLIC LICENSE\nVersion 3", "GPL-3.0-only"),
+        ("GNU GENERAL PUBLIC LICENSE\nVersion 2", "GPL-2.0-only"),
+        ("GNU AFFERO GENERAL PUBLIC LICENSE\nVersion 3", "AGPL-3.0-only"),
+        ("GNU LESSER GENERAL PUBLIC LICENSE\nVersion 3", "LGPL-3.0-only"),
+        ("Mozilla Public License, Version 2.0", "MPL-2.0"),
+        ("BSD 2-Clause", "BSD-2-Clause"),
+        ("BSD 3-Clause", "BSD-3-Clause"),
+        ("ISC License", "ISC"),
+        ("The Unlicense", "Unlicense"),
+        ("Server Side Public License", "SSPL-1.0"),
+        ("Business Source License", "BUSL-1.1"),
+        ("Elastic License 2.0", "Elastic-2.0"),
+        ("Creative Commons Zero 1.0", "CC0-1.0"),
+    ],
+)
+def test_detect_spdx_from_license_text(text, expected):
+    assert detect_spdx_from_license_text(text) == expected
+
+
+def test_detect_spdx_from_license_text_unknown():
+    assert detect_spdx_from_license_text("Some proprietary license text") is None
+
+
+# ─── License filename detection ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["LICENSE", "LICENSE.md", "LICENSE.txt", "COPYING", "COPYING.LESSER", "NOTICE", "UNLICENSE"],
+)
+def test_is_license_filename_positive(tmp_path, filename):
+    p = tmp_path / filename
+    p.touch()
+    assert is_license_filename(p)
+
+
+def test_is_license_filename_negative(tmp_path):
+    p = tmp_path / "main.py"
+    p.touch()
+    assert not is_license_filename(p)
+
+
+# ─── scan_license_file ────────────────────────────────────────────────────────
+
+
+def test_scan_license_file_spdx_tag(tmp_path):
+    f = tmp_path / "LICENSE"
+    f.write_text("SPDX-License-Identifier: MIT\nMIT License text...", encoding="utf-8")
+    result = scan_license_file(f)
+    assert result is not None
+    assert result.spdx_id == "MIT"
+    assert result.detection_method == "spdx_identifier"
+    assert result.confidence == "high"
+
+
+def test_scan_license_file_text_pattern(tmp_path):
+    f = tmp_path / "LICENSE"
+    f.write_text("Apache License\nVersion 2.0", encoding="utf-8")
+    result = scan_license_file(f)
+    assert result is not None
+    assert result.spdx_id == "Apache-2.0"
+    assert result.detection_method == "text_pattern"
+    assert result.confidence == "medium"
+
+
+def test_scan_license_file_unrecognised(tmp_path):
+    f = tmp_path / "LICENSE"
+    f.write_text("Proprietary — all rights reserved.", encoding="utf-8")
+    assert scan_license_file(f) is None
+
+
+def test_scan_license_file_missing():
+    assert scan_license_file(Path("/nonexistent/LICENSE")) is None
+
+
+# ─── scan_source_header ───────────────────────────────────────────────────────
+
+
+def test_scan_source_header_found(tmp_path):
+    f = tmp_path / "main.py"
+    f.write_text("# SPDX-License-Identifier: Apache-2.0\n\ndef main(): pass\n", encoding="utf-8")
+    result = scan_source_header(f)
+    assert result is not None
+    assert result.spdx_id == "Apache-2.0"
+    assert result.detection_method == "source_header"
+
+
+def test_scan_source_header_not_in_header(tmp_path):
+    f = tmp_path / "main.py"
+    content = "\n" * 25 + "# SPDX-License-Identifier: MIT\n"
+    f.write_text(content, encoding="utf-8")
+    assert scan_source_header(f) is None
+
+
+def test_scan_source_header_missing():
+    assert scan_source_header(Path("/nonexistent/file.py")) is None
+
+
+# ─── scan_directory ───────────────────────────────────────────────────────────
+
+
+def test_scan_directory_mit_license(tmp_path):
+    (tmp_path / "LICENSE").write_text("SPDX-License-Identifier: MIT\nMIT License", encoding="utf-8")
+    result = scan_directory(tmp_path)
+    assert "MIT" in result.unique_spdx_ids
+    assert len(result.license_files) == 1
+
+
+def test_scan_directory_source_headers(tmp_path):
+    (tmp_path / "app.py").write_text("# SPDX-License-Identifier: Apache-2.0\nprint('hi')\n", encoding="utf-8")
+    result = scan_directory(tmp_path)
+    assert "Apache-2.0" in result.unique_spdx_ids
+    assert len(result.source_headers) == 1
+
+
+def test_scan_directory_skips_hidden(tmp_path):
+    hidden = tmp_path / ".git"
+    hidden.mkdir()
+    (hidden / "LICENSE").write_text("MIT License\nPermission is hereby granted", encoding="utf-8")
+    result = scan_directory(tmp_path)
+    # .git is hidden — should be skipped
+    assert len(result.license_files) == 0
+
+
+def test_scan_directory_skips_node_modules(tmp_path):
+    nm = tmp_path / "node_modules" / "pkg"
+    nm.mkdir(parents=True)
+    (nm / "LICENSE").write_text("MIT License\nPermission is hereby granted", encoding="utf-8")
+    result = scan_directory(tmp_path)
+    assert len(result.license_files) == 0
+
+
+def test_scan_directory_multiple_licenses(tmp_path):
+    (tmp_path / "LICENSE").write_text("SPDX-License-Identifier: MIT\n", encoding="utf-8")
+    sub = tmp_path / "vendor"
+    sub.mkdir()
+    (sub / "LICENSE").write_text("Apache License\nVersion 2.0", encoding="utf-8")
+    result = scan_directory(tmp_path)
+    assert "MIT" in result.unique_spdx_ids
+    assert "Apache-2.0" in result.unique_spdx_ids
+
+
+def test_scan_directory_empty(tmp_path):
+    result = scan_directory(tmp_path)
+    assert result.unique_spdx_ids == []
+    assert result.all_results == []
+
+
+def test_scan_directory_not_a_dir(tmp_path):
+    f = tmp_path / "file.txt"
+    f.write_text("hello")
+    result = scan_directory(f)
+    assert result.all_results == []
+
+
+def test_scan_directory_to_dict(tmp_path):
+    (tmp_path / "LICENSE").write_text("SPDX-License-Identifier: MIT\n", encoding="utf-8")
+    result = scan_directory(tmp_path)
+    d = result.to_dict()
+    assert d["unique_spdx_ids"] == ["MIT"]
+    assert "license_files" in d
+    assert "source_header_count" in d
+
+
+def test_scan_directory_disable_source_headers(tmp_path):
+    (tmp_path / "main.py").write_text("# SPDX-License-Identifier: MIT\nprint('hi')\n", encoding="utf-8")
+    result = scan_directory(tmp_path, scan_source_headers=False)
+    assert len(result.source_headers) == 0


### PR DESCRIPTION
## Summary

- Adds `license_file_scanner.py`: scans `LICENSE`, `COPYING`, `NOTICE`, and `UNLICENSE` files for SPDX-License-Identifier tags or best-effort text pattern matching (27 patterns covering MIT, Apache-2.0, GPL-2/3, AGPL-3, LGPL, MPL-2, EPL-1/2, BSD-2/3/4, ISC, CC0-1.0, Unlicense, SSPL, BUSL-1.1, Elastic-2.0, and more)
- Source-file header scanning for `SPDX-License-Identifier:` comments in the first 20 lines of `.py`, `.js`, `.ts`, `.go`, `.java`, `.c`, `.cpp`, `.h`, and 10 additional extensions; configurable cap (default 2 000 files) prevents runaway on large repos
- Skips `.git`, `node_modules`, `__pycache__`, and all hidden directories
- Wires `scan_dir` optional argument into the `license_compliance_scan` MCP tool so registry results can be enriched with local filesystem detections, addressing the gap where packages lack a license field in registry metadata
- 44 unit tests covering SPDX tag extraction, all 27 text patterns, filename detection, file/header scanning, directory scanning, and `to_dict()` output shape

## Test plan

- [ ] `pytest tests/test_license_file_scanner.py -v` — all 44 pass
- [ ] Pre-commit hooks (ruff, mypy, bandit) — all pass
- [ ] Call `license_compliance_scan` MCP tool with a `scan_dir` pointing at a local package directory and verify `license_file_scan` key in response

Closes #872