### PR TITLE
fix(release): SVG dedupe ATT&CK + add PCI DSS, cache container SBOM, credit #2236

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ AI-infra and supply-chain breadth release: ATLAS catalog wired through to dashbo
 - **AMD advisory scanner** — AMD PSIRT advisory ingestion + GPU driver CVE mapping + K8s GPU compound rules (#2224).
 - **AMD PSIRT live-feed fetcher** — keeps AMD advisory data fresh; falls back to a checked-in static seed if the upstream feed is unreachable (#2230).
 - **AMD/Intel driver CVE gates + Intel advisory feed + K8S-036** — per-node driver checks for both vendors plus a K8s rule (`K8S-036`) for `nvidia-device-plugin` RBAC scope (#2232).
+- **Intel i915/xe driver CVE gate** — per-node check for CVE-2023-22655 / CVE-2023-25546; reads `/sys/module/i915/version` or `/sys/module/xe/version` via `kubectl exec`, falls back to `uname -r` (#2236).
+- **NVIDIA DGX/HGX firmware + BMC advisories** — `firmware_advisory.py` ships a 6-CVE NVIDIA CSAF seed (3× H100 BMC/CLI critical/high, DGX A100 SBIOS, ConnectX-6 DoS, DGX Station A100 OOB write); per-node product mapping via GPU-model labels; surfaces through `GpuInfraReport.firmware_findings` and `risk_summary.firmware_cve_count` (#2236).
+- **Container image SBOM (RunPod / Vast.ai)** — `container_sbom.py` fetches Docker Hub registry v2 metadata (manifest digest, config labels, layer size). Emits `UNPINNED_TAG`, `NO_SBOM_ATTESTATION`, `STALE_IMAGE` (>180d), `MISSING_PROVENANCE` findings; offline-safe and graceful on token/manifest failures; per-process `lru_cache` so duplicate pods share one Docker Hub round-trip (#2236).
 - **GPU cloud provider discovery** — Lambda Labs, RunPod, Vast.ai, and Crusoe added to the cloud catalog; agents emerge with `cloud_origin.provider` set to the right vendor (#2229).
 - **Nebius InfiniBand training job discovery** — Nebius training jobs and their InfiniBand fabric scope are discovered as agents (#2231).
 - **SPDX license file scanner** — detects `LICENSE` / `COPYING` files and SPDX source-header markers across the inventory; results feed the existing license posture surface (#2234).

--- a/docs/PERFORMANCE_BENCHMARKS.md
+++ b/docs/PERFORMANCE_BENCHMARKS.md
@@ -38,8 +38,8 @@ python scripts/check_scale_evidence.py
 ### Blast-radius tag indexing — `_index_blast_radii_by_tag`
 
 The O(n × k) pass that feeds every compliance bundle. Measured across
-1k / 10k / 50k blast-radius findings each tagged under all 14
-compliance frameworks (≈14 tag fields per finding).
+1k / 10k / 50k blast-radius findings each tagged under all 15
+compliance frameworks (≈15 tag fields per finding).
 
 | Inventory size | Mean | StdDev | Throughput |
 |---:|---:|---:|---:|

--- a/docs/images/compliance-dark.svg
+++ b/docs/images/compliance-dark.svg
@@ -140,23 +140,23 @@
   <text x="412" y="294" class="fw-count" fill="#0ea5e9">3</text>
   <text x="432" y="294" class="fw-label">baselines</text>
 
-  <!-- MITRE ATT&CK -->
+  <!-- MITRE ATT&CK Enterprise -->
   <rect x="584" y="232" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="600" y="252" class="fw-name">MITRE ATT&amp;CK</text>
-  <text x="600" y="264" class="fw-code">Enterprise adversary techniques</text>
+  <text x="600" y="252" class="fw-name">MITRE ATT&amp;CK Enterprise</text>
+  <text x="600" y="264" class="fw-code">Adversary techniques (CWE→CAPEC→ATT&amp;CK)</text>
   <rect x="600" y="272" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="600" y="272" width="108" height="4" rx="2" fill="#f59e0b"/>
-  <text x="600" y="294" class="fw-count" fill="#f59e0b">200+</text>
+  <rect x="600" y="272" width="128" height="4" rx="2" fill="#fb7185"/>
+  <text x="600" y="294" class="fw-count" fill="#fb7185">~600</text>
   <text x="640" y="294" class="fw-label">techniques</text>
 
-  <!-- MITRE ATT&CK Enterprise -->
+  <!-- PCI DSS v4.0 -->
   <rect x="772" y="232" width="168" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="788" y="252" class="fw-name">MITRE ATT&amp;CK Enterprise</text>
-  <text x="788" y="264" class="fw-code">Adversary techniques (CWE→CAPEC→ATT&amp;CK)</text>
+  <text x="788" y="252" class="fw-name">PCI DSS v4.0</text>
+  <text x="788" y="264" class="fw-code">Payment-card data security requirements</text>
   <rect x="788" y="272" width="136" height="4" rx="2" class="bar-bg"/>
-  <rect x="788" y="272" width="122" height="4" rx="2" fill="#fb7185"/>
-  <text x="788" y="294" class="fw-count" fill="#fb7185">~600</text>
-  <text x="828" y="294" class="fw-label">techniques</text>
+  <rect x="788" y="272" width="100" height="4" rx="2" fill="#f472b6"/>
+  <text x="788" y="294" class="fw-count" fill="#f472b6">12</text>
+  <text x="816" y="294" class="fw-label">requirements</text>
 
   <!-- ═══ SUMMARY BAR ═══ -->
   <rect x="20" y="320" width="920" height="32" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>

--- a/docs/images/compliance-light.svg
+++ b/docs/images/compliance-light.svg
@@ -142,21 +142,21 @@
 
   <!-- MITRE ATT&CK Enterprise -->
   <rect x="584" y="232" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="600" y="252" class="fw-name">MITRE ATT&amp;CK</text>
-  <text x="600" y="264" class="fw-code">Enterprise adversary techniques</text>
+  <text x="600" y="252" class="fw-name">MITRE ATT&amp;CK Enterprise</text>
+  <text x="600" y="264" class="fw-code">Adversary techniques (CWE→CAPEC→ATT&amp;CK)</text>
   <rect x="600" y="272" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="600" y="272" width="108" height="4" rx="2" fill="#f59e0b"/>
-  <text x="600" y="294" class="fw-count" fill="#f59e0b">200+</text>
+  <rect x="600" y="272" width="128" height="4" rx="2" fill="#9f1239"/>
+  <text x="600" y="294" class="fw-count" fill="#9f1239">~600</text>
   <text x="640" y="294" class="fw-label">techniques</text>
 
-  <!-- MITRE ATT&CK Enterprise -->
+  <!-- PCI DSS v4.0 -->
   <rect x="772" y="232" width="168" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="788" y="252" class="fw-name">MITRE ATT&amp;CK Enterprise</text>
-  <text x="788" y="264" class="fw-code">Adversary techniques (CWE→CAPEC→ATT&amp;CK)</text>
+  <text x="788" y="252" class="fw-name">PCI DSS v4.0</text>
+  <text x="788" y="264" class="fw-code">Payment-card data security requirements</text>
   <rect x="788" y="272" width="136" height="4" rx="2" class="bar-bg"/>
-  <rect x="788" y="272" width="122" height="4" rx="2" fill="#9f1239"/>
-  <text x="788" y="294" class="fw-count" fill="#9f1239">~600</text>
-  <text x="828" y="294" class="fw-label">techniques</text>
+  <rect x="788" y="272" width="100" height="4" rx="2" fill="#ec4899"/>
+  <text x="788" y="294" class="fw-count" fill="#ec4899">12</text>
+  <text x="816" y="294" class="fw-label">requirements</text>
 
   <!-- ═══ SUMMARY BAR ═══ -->
   <rect x="20" y="320" width="920" height="32" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>

--- a/src/agent_bom/cloud/container_sbom.py
+++ b/src/agent_bom/cloud/container_sbom.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from functools import lru_cache
 
 logger = logging.getLogger(__name__)
 
@@ -202,12 +203,19 @@ def _check_labels(labels: dict[str, str]) -> tuple[bool, bool]:
     return sbom, prov
 
 
+@lru_cache(maxsize=512)
 def scan_container_image(image_ref: str) -> ContainerImageSbom:
     """Scan a container image reference for SBOM and provenance posture.
 
     Queries Docker Hub registry API v2 to fetch manifest and config blob
     without downloading image layers. For non-Docker Hub registries, returns
     a best-effort record with MISSING_PROVENANCE finding.
+
+    Cached per-process by ``image_ref`` so that fleets running the same
+    image across many pods (RunPod / Vast.ai discovery) only make one
+    Docker Hub round-trip per unique image, avoiding anonymous rate
+    limits (100 / 6h) and saving ~3 sequential ``requests.get`` calls per
+    duplicate. Cache size is bounded to 512 entries.
 
     Args:
         image_ref: Image reference string, e.g. ``"pytorch/pytorch:2.1.0"``.

--- a/tests/test_container_sbom.py
+++ b/tests/test_container_sbom.py
@@ -26,6 +26,15 @@ from agent_bom.cloud.container_sbom import (
     scan_container_image,
 )
 
+
+@pytest.fixture(autouse=True)
+def _clear_scan_cache():
+    """scan_container_image is process-cached (lru_cache) so duplicate
+    pods share one Docker Hub round-trip. Tests must reset between cases
+    so mocked responses don't leak across tests."""
+    scan_container_image.cache_clear()
+
+
 # ─── Unit: _parse_image_ref ───────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Pre-tag audit (post-#2238 merge) caught three real issues that #2238 missed:

### P1 — SVG fix in #2238 was wrong

The original 14-cell layout in `compliance-light.svg` had **no PCI DSS card** AND its 14th cell was already labelled "MITRE ATT&CK". My #2238 SVG sweep added a 15th cell labelled "MITRE ATT&CK Enterprise" — producing two ATT&CK cards (one labelled "MITRE ATT&CK", one "ATT&CK Enterprise") and **still no PCI DSS**. The SVGs rendered 15 cells but only 14 unique frameworks.

**Fix:**
- Rename row-3 col-4 from "MITRE ATT&CK" → "MITRE ATT&CK Enterprise" with the canonical `Adversary techniques (CWE→CAPEC→ATT&CK)` subline and `~600 techniques` count (matches `constants.py:592 ("attack", "MITRE ATT&CK Enterprise")`).
- Replace the duplicated row-3 col-5 with **PCI DSS v4.0** (12 requirements, pink `#ec4899` light / `#f472b6` dark).
- Both files now render **15 unique cards** aligned with `COMPLIANCE_FRAMEWORKS` and `TAG_MAPPED_FRAMEWORKS`.

### P1 — #2236 not credited in v0.86.0 CHANGELOG

\`#2236\` (Intel driver CVE gate, NVIDIA DGX/HGX firmware/BMC advisories, container image SBOM) merged to main *before* the v0.86.0 release tag. It ships as part of v0.86.0 but the CHANGELOG didn't credit it. Added three Added entries crediting #2236.

### P2 — Container SBOM scan unbounded HTTP fan-out

`scan_container_image()` was called once per discovered RunPod / Vast.ai pod. Each call fires 3 sequential `requests.get` to Docker Hub (token + manifest + config). A customer with 200 pods all running the same image would make ~600 HTTP calls and may hit Docker Hub's anonymous 100/6h rate limit. Air-gapped envs eat ~10s per pod on connect timeouts.

**Fix:** `@lru_cache(maxsize=512)` on `scan_container_image` — process-cached by `image_ref` so duplicate pods share one Docker Hub round-trip. Added `cache_clear()` autouse fixture in tests so mocked responses don't leak across cases.

### P2 — Stale "all 14" in PERFORMANCE_BENCHMARKS

`docs/PERFORMANCE_BENCHMARKS.md:41` still said "all 14 / ≈14 tag fields" — missed by the #2238 sweep. Bumped to "all 15 / ≈15 tag fields" to match `TAG_MAPPED_FRAMEWORKS` count.

## Verification

- [x] `xmllint --noout docs/images/compliance-{light,dark}.svg` → clean
- [x] Both SVGs now show 15 unique cells (no duplicate ATT&CK, PCI DSS present); cell labels enumerated:
  ```
  1.OWASP LLM 2.OWASP MCP 3.OWASP Agentic 4.MITRE ATLAS 5.NIST AI RMF
  6.NIST CSF 7.EU AI Act 8.SOC 2 9.ISO 27001 10.CIS Controls v8
  11.CMMC 12.NIST 800-53 13.FedRAMP 14.MITRE ATT&CK Enterprise 15.PCI DSS v4.0
  ```
- [x] `pytest tests/test_container_sbom.py tests/test_compliance_hub.py tests/test_compliance_hub_api.py tests/test_compliance_coverage.py` → **83 passed** (37 container_sbom + 46 compliance/coverage/hub)
- [x] `scripts/check_release_consistency.py` → passed
- [x] pre-commit (ruff/format/mypy/bandit/env-var-drift) → green

## Why this gates the v0.86.0 tag

The drift agent specifically called the SVG dupe + missing PCI DSS as a P1 release blocker — shipping v0.86.0 with a "15 frameworks" subtitle but only 14 unique cells, and PCI DSS missing despite the v0.86.0 PR description claiming it's there, is the exact "surface honesty" failure the user has been hammering on. The Docker Hub rate-limit blast on 200-pod fleets is a real customer hit on day one.

## Test plan

- [ ] CI green
- [ ] After merge: tag `v0.86.0` on main