### PR TITLE
fix(pii): never reveal any matched chars; trust-contract PCI/SSN/IBAN/passport

### DIFF
--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -178,7 +178,7 @@ agent-bom serve --port 8422 --persist jobs.db
 - `GET /v1/fleet/list` — view all discovered agents across the org
 - `GET /v1/fleet/stats` — fleet-wide trust scores and posture
 - `POST /v1/fleet/sync` — ingest endpoint scan results
-- `GET /v1/compliance` — 14-framework compliance posture plus AISVS benchmark summary
+- `GET /v1/compliance` — 15-framework compliance posture plus AISVS benchmark summary
 - `GET /v1/compliance/aisvs` — latest tenant-scoped OWASP AISVS benchmark result
 
 Fleet trust scoring is advisory and evidence-backed. The score combines registry verification, active vulnerability posture, credential hygiene, permission profile, configuration quality, discovery provenance, package provenance attestation, runtime drift evidence, and inventory freshness. API responses include factor breakdowns plus evidence references so operators can explain why an agent is trusted or risky instead of treating the score as an opaque compliance certification.

--- a/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
+++ b/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
@@ -167,7 +167,7 @@ Central policy management at [`/v1/gateway/policies`](../src/agent_bom/api/route
 
 - **HMAC-chained audit log** — [`api/audit_log.py`](../src/agent_bom/api/audit_log.py). Every entry signs the previous entry's signature; tampering with any row invalidates the chain from that point forward.
 - **Ed25519-signed evidence bundles** — [`api/compliance_signing.py`](../src/agent_bom/api/compliance_signing.py). Auditor fetches the public key from [`/v1/compliance/verification-key`](../src/agent_bom/api/routes/compliance.py) once, pins it, verifies every bundle offline. Cookbook: [COMPLIANCE_SIGNING.md](COMPLIANCE_SIGNING.md).
-- **14 tag-mapped compliance frameworks plus AISVS** — OWASP LLM Top 10, OWASP MCP Top 10, OWASP Agentic Top 10, MITRE ATLAS, NIST AI RMF, NIST CSF 2.0, NIST 800-53, FedRAMP, ISO 27001, SOC 2, CIS Controls v8, CMMC, EU AI Act, and PCI DSS are mapped to findings inline. OWASP AISVS is exposed as a benchmark result with per-check evidence.
+- **15 tag-mapped compliance frameworks plus AISVS** — OWASP LLM Top 10, OWASP MCP Top 10, OWASP Agentic Top 10, MITRE ATLAS, MITRE ATT&CK Enterprise, NIST AI RMF, NIST CSF 2.0, NIST 800-53, FedRAMP, ISO 27001, SOC 2, CIS Controls v8, CMMC, EU AI Act, and PCI DSS are mapped to findings inline. OWASP AISVS is exposed as a benchmark result with per-check evidence.
 - **Tenant isolation on every export** — evidence bundle only carries scans + audit events from the authed tenant. Cross-tenant tests: [`tests/test_api_cross_tenant_matrix.py`](../tests/test_api_cross_tenant_matrix.py), [`tests/test_cross_tenant_leakage.py`](../tests/test_cross_tenant_leakage.py).
 
 ### 2.8 Scale: "Will this hold up at 50k packages and a 5k-agent fleet?"

--- a/docs/MCP_ERROR_CODES.md
+++ b/docs/MCP_ERROR_CODES.md
@@ -98,7 +98,7 @@ matrix records what each surface exposes and why.
 | Run a scan | `POST /v1/scan` | `scan` | Same scan pipeline. |
 | Look up CVE blast radius | `GET /v1/findings/{cve}` | `blast_radius` | MCP returns the same shape. |
 | Query the MCP server registry | `GET /v1/registry/servers` | `registry_lookup`, `marketplace_check`, `fleet_scan` | Registry is read-only on both. |
-| Compliance posture | `GET /v1/compliance/{framework}` / `GET /v1/compliance/aisvs` | `compliance` | 14 tag-mapped frameworks plus AISVS benchmark evidence (curated subsets — see [ARCHITECTURE.md § Coverage per framework](./ARCHITECTURE.md#coverage-per-framework)), both surfaces. |
+| Compliance posture | `GET /v1/compliance/{framework}` / `GET /v1/compliance/aisvs` | `compliance` | 15 tag-mapped frameworks plus AISVS benchmark evidence (curated subsets — see [ARCHITECTURE.md § Coverage per framework](./ARCHITECTURE.md#coverage-per-framework)), both surfaces. |
 | SBOM generation | `POST /v1/sbom` | `generate_sbom` | CycloneDX + SPDX on both. |
 | Policy evaluation | `POST /v1/gateway/evaluate` | `policy_check` | Same `check_policy` evaluator. |
 

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -164,7 +164,7 @@ agent-bom agents --enforce    # + static tool poisoning analysis
 agent-bom agents --gpu-scan   # + GPU containers, CUDA versions, DCGM exposure
 ```
 
-Outputs: blast radius tree, compliance mapping (14 tag-mapped frameworks plus AISVS benchmark evidence — curated control subsets, see [ARCHITECTURE.md § Coverage per framework](./ARCHITECTURE.md#coverage-per-framework)), posture score, SARIF/CycloneDX/SPDX/HTML.
+Outputs: blast radius tree, compliance mapping (15 tag-mapped frameworks plus AISVS benchmark evidence — curated control subsets, see [ARCHITECTURE.md § Coverage per framework](./ARCHITECTURE.md#coverage-per-framework)), posture score, SARIF/CycloneDX/SPDX/HTML.
 
 ### 4.2 Proxy mode
 

--- a/docs/PERFORMANCE_BENCHMARKS.md
+++ b/docs/PERFORMANCE_BENCHMARKS.md
@@ -81,7 +81,7 @@ each carrying a variable number of evidence entries.
 **Scaling:** linear in canonical-JSON size — serialisation dominates
 over HMAC-SHA256 itself.
 
-**Implication:** a realistic 14-framework report (≈220 controls total
+**Implication:** a realistic 15-framework report (≈220 controls total
 across frameworks, up to ~10 evidence entries each) signs in **under 5
 ms** end-to-end. Ed25519 adds ~0.2 ms on top.
 

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -142,7 +142,7 @@ If engaging a third-party auditor, the recommended scope:
 
 ### Compliance Framework Mapping
 
-agent-bom **maps findings TO compliance controls** across 14 tag-mapped frameworks and exposes AISVS as a benchmark:
+agent-bom **maps findings TO compliance controls** across 15 tag-mapped frameworks and exposes AISVS as a benchmark:
 
 OWASP LLM Top 10, OWASP MCP Top 10, OWASP Agentic Top 10,
 EU AI Act, NIST AI RMF, NIST CSF, NIST 800-53 Rev 5, FedRAMP Moderate,

--- a/src/agent_bom/parsers/dataset_pii_scanner.py
+++ b/src/agent_bom/parsers/dataset_pii_scanner.py
@@ -207,11 +207,17 @@ class DirectoryPiiResult:
 
 
 def _redact(value: str, pii_type: str) -> str:
-    """Return a safe redacted representation for display."""
-    s = str(value)
-    if len(s) <= 4:
-        return f"[{pii_type}:***]"
-    return f"[{pii_type}:{s[:2]}***{s[-2:]}]"
+    """Return a safe redacted representation for display.
+
+    The contract is **never reveal any digits / characters of the matched value** —
+    not even prefix/suffix snippets. PCI DSS § 3.4.1 prohibits storing readable
+    PAN; partial SSN exposes identity-linkable digits; partial IBAN / passport /
+    NHS / Medicare leaks the same. Findings carry only the type and severity;
+    the file path, row index, and column already give the operator everything
+    needed to locate the cell — they don't need our preview, and any preview
+    becomes a downstream leak vector (JSON output → DB → audit log → dashboard).
+    """
+    return f"[{pii_type}:REDACTED]"
 
 
 def _scan_cell(value: str, row_idx: int, col: str, file_path: str) -> list[PiiFinding]:

--- a/tests/test_dataset_pii_scanner.py
+++ b/tests/test_dataset_pii_scanner.py
@@ -20,15 +20,34 @@ from agent_bom.parsers.dataset_pii_scanner import (
 # ─── _redact ─────────────────────────────────────────────────────────────────
 
 
-def test_redact_short():
-    assert "[ssn:***]" == _redact("123", "ssn")
-
-
-def test_redact_long():
-    r = _redact("john@example.com", "email")
-    assert r.startswith("[email:jo")
-    assert r.endswith("om]")
-    assert "john@example" not in r
+def test_redact_never_reveals_any_characters():
+    """Trust contract: redaction must NEVER reveal any chars of the matched
+    value. PCI DSS § 3.4.1 prohibits storing readable PAN; partial SSN /
+    IBAN / passport / NHS leaks identity-linkable data. The finding's
+    file_path + row_index + column already locate the cell — no preview
+    needed. Any preview becomes a downstream leak vector (JSON → DB →
+    audit log → dashboard)."""
+    # Short value
+    assert _redact("123", "ssn") == "[ssn:REDACTED]"
+    # Credit card — must not leak any digits
+    cc = "4532123456789012"
+    r = _redact(cc, "credit_card")
+    assert r == "[credit_card:REDACTED]"
+    for digit in cc:
+        assert digit not in r, f"redaction leaked digit {digit!r}: {r!r}"
+    # SSN — must not leak any digits
+    ssn = "123-45-6789"
+    r = _redact(ssn, "ssn")
+    assert r == "[ssn:REDACTED]"
+    for ch in "1234567890":
+        assert ch not in r
+    # Email — full value must not appear
+    email = "john@example.com"
+    r = _redact(email, "email")
+    assert r == "[email:REDACTED]"
+    assert "john" not in r
+    assert "example" not in r
+    assert "@" not in r
 
 
 # ─── _scan_cell ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Pre-tag user concern flagged hard: "pci we gotta be careful n clear with evidence n redaction not reading etc for pci pii all of it / and the creds also n leak."

Audit confirmed `dataset_pii_scanner._redact()` returned `[<type>:XX***YY]` — first-2 + last-2 chars of the matched value. For **credit cards, SSN, IBAN, passport, NHS numbers** that's still a leak:
- PCI DSS § 3.4.1 prohibits storing readable PAN.
- Partial SSN (last 4) is identity-linkable on its own; partial IBAN reveals country + bank.
- The `sample` field flows through `JSON output → DB (compliance hub store) → audit log → dashboard`, multiplying every leak point.

Also confirmed clean (no fix needed):
- `secret_scanner.py` already uses `[CREDENTIAL_REDACTED]` / `[SECRET_REDACTED]` / `[PII_REDACTED]` placeholders — never the matched bytes (line 236, 251, 267).
- `compliance_coverage.py:262-273` PCI DSS scope is honest: `"Requirements 2/3/4/5/6/7/8/10/11/12 for vulnerable-package and evidence risk"` — no claim of scanning cardholder data.

## Fix

**`src/agent_bom/parsers/dataset_pii_scanner.py`**
- `_redact()` returns `[<pii_type>:REDACTED]` always — no character preview, no length-conditional branch.
- Docstring spells out the trust contract explicitly so future edits don't reintroduce the snippet.

**`tests/test_dataset_pii_scanner.py`**
- New regression test `test_redact_never_reveals_any_characters` locks the contract on `credit_card` / `ssn` / `email`: **no digit, no char from the matched value may appear in the redacted output**. Fails loudly if anyone re-introduces a preview.

## Surface alignment (final 14→15 sweep missed by #2238)

The drift agent missed several "14 tag-mapped" claims because they were buried in operator-facing docs:
- `docs/ENTERPRISE_SECURITY_PLAYBOOK.md:170` — "14 tag-mapped" → "15", ATT&CK Enterprise added to the prose list.
- `docs/MCP_ERROR_CODES.md`, `docs/MCP_SECURITY_MODEL.md`, `docs/SECURITY_ARCHITECTURE.md` — "14 tag-mapped frameworks" → "15".
- `docs/PERFORMANCE_BENCHMARKS.md:84` — "14-framework report" → "15".
- `docs/ENTERPRISE_DEPLOYMENT.md:181` — "14-framework compliance posture" → "15".

## Verification

- [x] `pytest tests/test_dataset_pii_scanner.py tests/test_compliance_coverage.py` → 37 passed
- [x] pre-commit (ruff/format/mypy/bandit/env-var-drift) → green
- [x] `grep -rnE "14 tag-mapped|14-framework|all 14 framework" docs/ site-docs/ README.md | grep -v archive` → empty (only historical CHANGELOG entries remain, intentionally)

## Why this gates the v0.86.0 tag

Shipping a "PII/PHI scanner" or "PCI DSS framework" surface that leaks any digits of credit cards / SSN in its findings would be a customer-visible trust-contract failure on day one — the exact concern the user flagged. The leak path was real (JSON → DB → audit log → dashboard), so a hotfix after tag would be much more expensive than blocking the tag.

## Test plan

- [ ] CI green
- [ ] After merge: tag `v0.86.0` on main