### PR TITLE
fix: close two P3 audit items — SAST test fixture leak + container parser host:port

### DIFF
--- a/src/agent_bom/cloud/container_sbom.py
+++ b/src/agent_bom/cloud/container_sbom.py
@@ -94,6 +94,8 @@ def _parse_image_ref(image_ref: str) -> tuple[str, str, str, str]:
         "ubuntu:22.04"                     → ("docker.io", "library", "ubuntu", "22.04")
         "nvcr.io/nvidia/cuda:12.3"        → ("nvcr.io", "nvidia", "cuda", "12.3")
         "ghcr.io/huggingface/tgi:latest"  → ("ghcr.io", "huggingface", "tgi", "latest")
+        "host:5000/img:tag"                → ("host:5000", "library", "img", "tag")
+        "localhost:5000/myimg"             → ("localhost:5000", "library", "myimg", "latest")
     """
     tag = "latest"
     last_part = image_ref.rsplit("/", 1)[-1]
@@ -101,11 +103,23 @@ def _parse_image_ref(image_ref: str) -> tuple[str, str, str, str]:
         image_ref, tag = image_ref.rsplit(":", 1)
 
     parts = image_ref.split("/")
-    if len(parts) >= 3 and ("." in parts[0] or ":" in parts[0]):
-        # Custom registry: nvcr.io/nvidia/cuda, ghcr.io/huggingface/tgi
+
+    def _looks_like_registry(s: str) -> bool:
+        # Docker / OCI convention: a registry hostname is the first slash-segment
+        # and is distinguished from a Docker Hub org by containing a `.` (FQDN) or
+        # a `:` (port) — the conservative rule the docker CLI itself uses.
+        return "." in s or ":" in s
+
+    if len(parts) >= 3 and _looks_like_registry(parts[0]):
+        # Custom registry, full path: nvcr.io/nvidia/cuda, ghcr.io/huggingface/tgi
         registry = parts[0]
         org = parts[1]
         repo = "/".join(parts[2:])
+    elif len(parts) == 2 and _looks_like_registry(parts[0]):
+        # Custom registry, no org: host:5000/img, localhost:5000/myimg, registry.io/img
+        registry = parts[0]
+        org = "library"
+        repo = parts[1]
     elif len(parts) == 2:
         # Docker Hub user image: pytorch/pytorch
         registry = "docker.io"

--- a/tests/test_container_sbom.py
+++ b/tests/test_container_sbom.py
@@ -49,6 +49,10 @@ def _clear_scan_cache():
         ("nvidia/cuda:11.8-cudnn8", "docker.io", "nvidia", "cuda", "11.8-cudnn8"),
         ("rocm/pytorch:latest", "docker.io", "rocm", "pytorch", "latest"),
         ("vllm/vllm-openai:v0.4.0", "docker.io", "vllm", "vllm-openai", "v0.4.0"),
+        # Self-hosted registry with port (audit P3 — was misclassified as docker.io org)
+        ("host:5000/img:tag", "host:5000", "library", "img", "tag"),
+        ("localhost:5000/myimg", "localhost:5000", "library", "myimg", "latest"),
+        ("registry.io:443/org/img:1.0", "registry.io:443", "org", "img", "1.0"),
     ],
 )
 def test_parse_image_ref(image_ref, registry, org, repo, tag):

--- a/tests/test_sast.py
+++ b/tests/test_sast.py
@@ -374,6 +374,11 @@ def test_scan_code_default_uses_local_rules_and_auto(monkeypatch, tmp_path):
     """default config should prefer local rule bundles and still include Semgrep auto."""
     monkeypatch.setattr("agent_bom.sast.shutil.which", lambda _: "/usr/bin/semgrep")
     monkeypatch.setattr("agent_bom.sast._get_semgrep_version", lambda: "1.50.0")
+    # Pin Path.home() to a clean tmp directory so the dev's real ~/.semgrep
+    # config (if any) doesn't get auto-discovered and flip the assertion.
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr("agent_bom.sast.Path.home", lambda: fake_home)
     rules_dir = tmp_path / ".agent-bom" / "sast-rules"
     rules_dir.mkdir(parents=True)
     (rules_dir / "custom.yaml").write_text("rules: []", encoding="utf-8")


### PR DESCRIPTION
## Summary

Closes the only two carry-over P3 items from the v0.86.0 pre-tag audit. Neither is tag-blocking (already deferred per audit) but both are small, isolated, and regression-tested. Lands as v0.86.1 cleanup.

### P3 — \`test_sast.py\` brittle on dev machines with \`~/.semgrep/\`

`test_scan_code_default_uses_local_rules_and_auto` asserted:
```python
assert sast_result.config_used == f"{rules_dir.resolve()},auto"
```
But `_discover_local_sast_configs` (sast.py:165) walks both `scan_root` AND `Path.home()` looking for `.semgrep` / `.semgrep.yaml` / `.semgrep.yml`. Any dev with semgrep rules installed gets `{rules_dir.resolve()},/Users/.../.semgrep,auto` — assertion fails. CI runners don't have `~/.semgrep` so CI passed.

**Fix:** monkeypatch `Path.home()` to a clean tmp directory (consistent with sibling test at line 404).

### P3 — \`_parse_image_ref\` mishandles self-hosted registries with ports

`_parse_image_ref("host:5000/img:tag")` returned `("docker.io", "host:5000", "img", "tag")` — a Docker Hub org named `"host:5000"` doesn't exist. Same bug for `localhost:5000/myimg`. Edge case (RunPod / Vast.ai discovery uses Docker Hub today) but worth fixing while it's small.

**Fix:** when a 2-segment ref's first segment contains a `.` (FQDN) or `:` (port), classify as `registry/repo` with implicit `"library"` org — the same convention `docker` CLI uses.

**Regression cases added** to the parametrized test:
| ref | registry | org | repo | tag |
|---|---|---|---|---|
| `host:5000/img:tag` | `host:5000` | `library` | `img` | `tag` |
| `localhost:5000/myimg` | `localhost:5000` | `library` | `myimg` | `latest` |
| `registry.io:443/org/img:1.0` | `registry.io:443` | `org` | `img` | `1.0` |

## Verification

- [x] `pytest tests/test_sast.py tests/test_container_sbom.py` → **67 passed**
- [x] pre-commit (ruff/format/mypy/bandit/env-var-drift) → green

## Test plan

- [ ] CI green
- [ ] Bundle into v0.86.1 along with any post-v0.86.0 hotfixes