### PR TITLE
fix(api): CORS preflight (OPTIONS) bypasses APIKeyMiddleware — tag-blocking P1

### DIFF
--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -900,6 +900,15 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         return resolution.role, None
 
     async def dispatch(self, request: StarletteRequest, call_next):
+        # CORS preflight (OPTIONS) MUST bypass auth: browsers do not attach
+        # Authorization headers to preflights (CORS spec / Fetch §3.2.2).
+        # Rejecting them with 401 before CORSMiddleware runs blocks every
+        # cross-origin dashboard / SaaS UI / SDK from talking to the API —
+        # the actual request never fires because the preflight failed.
+        # CORSMiddleware will reply with the right Access-Control-Allow-*
+        # headers for the configured origin set.
+        if request.method == "OPTIONS":
+            return await call_next(request)
         if request.url.path in self._EXEMPT_PATHS:
             return await call_next(request)
         if self._is_dashboard_public_request(request.url.path, request.method):

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -165,6 +165,44 @@ def test_api_key_middleware_blocks_without_key():
     assert resp.status_code == 401
 
 
+def test_api_key_middleware_exempts_cors_preflight():
+    """CORS preflight (OPTIONS) MUST bypass auth.
+
+    Browsers do not attach Authorization headers to preflight requests
+    (CORS spec / Fetch §3.2.2). Rejecting OPTIONS with 401 before
+    CORSMiddleware runs blocks every cross-origin dashboard / SaaS UI
+    / SDK from talking to the API — the actual request never fires
+    because the preflight failed. The auth boundary stays enforced for
+    the real request methods (GET/POST/PUT/DELETE/PATCH).
+    """
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    async def dummy(request):
+        return StarletteJSONResponse({"ok": True})
+
+    test_app = Starlette(routes=[Route("/v1/test", dummy, methods=["GET", "OPTIONS"])])
+    test_app.add_middleware(APIKeyMiddleware, api_key="test-key-cors")
+
+    client = TestClient(test_app)
+    # Preflight without bearer — must NOT 401; CORSMiddleware (in real
+    # app stack) will then add Access-Control-Allow-* headers.
+    resp = client.options(
+        "/v1/test",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "authorization",
+        },
+    )
+    assert resp.status_code != 401, "OPTIONS preflight must bypass APIKeyMiddleware"
+    # Real request (GET) without bearer still 401 — auth boundary intact.
+    assert client.get("/v1/test").status_code == 401
+    # Real request with bearer succeeds.
+    assert client.get("/v1/test", headers={"X-API-Key": "test-key-cors"}).status_code == 200
+
+
 def test_api_key_middleware_exempts_packaged_dashboard_assets():
     """Dashboard shell assets must load before browser auth/bootstrap completes."""
     from starlette.applications import Starlette


### PR DESCRIPTION
## Summary

Tag-blocking P1 found by the pre-tag audit:

> APIKeyMiddleware.dispatch() (middleware.py:902) does not exempt OPTIONS. Browsers send preflight WITHOUT the Authorization header (by spec), so they get 401 and the actual request is never made. Same-origin dashboard works because no preflight. **Any external dashboard, SaaS UI, or cross-origin SDK currently can't talk to this API.**

Repro before fix:

```
$ curl -X OPTIONS -H "Origin: http://localhost:3000" \
       -H "Access-Control-Request-Method: GET" \
       -H "Access-Control-Request-Headers: authorization" \
       http://127.0.0.1:8489/v1/agents
HTTP/1.1 401 Unauthorized   ← CORS never sees this
```

## Fix (2 lines + test)

`src/agent_bom/api/middleware.py:902` — first line of `dispatch()` now short-circuits OPTIONS to `call_next` so CORSMiddleware downstream sees the request and replies with `Access-Control-Allow-*` headers for the configured origin set.

```python
async def dispatch(self, request, call_next):
    if request.method == "OPTIONS":
        return await call_next(request)  # let CORSMiddleware respond
    ...
```

Auth boundary **unchanged** for real request methods — GET / POST / PUT / DELETE / PATCH still 401 without a valid key.

## Verification (live on 0.86.0 main)

```
OPTIONS /v1/agents (no auth)   -> 200 + access-control-allow-{origin,headers,methods,credentials}
GET     /v1/agents (no auth)   -> 401
GET     /v1/agents (X-Api-Key) -> 200
```

## Regression test

`tests/test_api_hardening.py::test_api_key_middleware_exempts_cors_preflight` — locks in:
1. OPTIONS preflight must NOT 401
2. GET without bearer must still 401 (auth boundary intact)
3. GET with bearer succeeds

## Why this gates v0.86.0

Shipping a release where every external dashboard / SaaS UI / cross-origin SDK breaks at the CORS preflight is a customer-visible day-one regression. Same-origin dashboards (the bundled UI) are unaffected, but anyone embedding the API or building a cross-origin frontend would hit a wall.

## Out of scope (P2 audit findings, defer to v0.86.1)

- `/v1/info` and `/v1/data-boundaries` 404 — trust-contract docs reference them but they aren't routed.
- Helm should mark `AGENT_BOM_AUDIT_HMAC_KEY` as required.
- `_apply_cors_middleware` should log a warning when wildcard origin is in effect.

## Test plan

- [ ] CI green
- [ ] After merge: tag `v0.86.0` on main