### PR TITLE
docs(deploy): consolidate paved paths + reference pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,17 @@ The recommended motion is simple:
 
 That keeps the day-1 path easy while still giving you a full runtime story later.
 
-Two diagrams explain the self-hosted shape without collapsing into one overloaded chart:
+Start with the deployment chooser — it is the canonical entry point and links into
+every paved path:
 
-- [Enterprise Self-Hosted Topology](site-docs/deployment/overview.md#enterprise-self-hosted-topology)
-- [Enterprise Self-Hosted Data and Runtime Flow](site-docs/deployment/overview.md#enterprise-self-hosted-data-and-runtime-flow)
+- **[Deployment Overview (chooser)](site-docs/deployment/overview.md)**
+
+Three single-concern diagrams in that overview explain the self-hosted shape
+without collapsing into one overloaded chart:
+
+- [Topology — Who Runs What, Where](site-docs/deployment/overview.md#enterprise-self-hosted-diagrams)
+- [Auth + Ingress Flow](site-docs/deployment/overview.md#auth-ingress-flow)
+- [Inventory & Runtime Evidence Flow](site-docs/deployment/overview.md#inventory-runtime-evidence-flow)
 
 ```mermaid
 %%{init: {"theme":"base","themeVariables":{"primaryColor":"#0f172a","primaryBorderColor":"#6366f1","primaryTextColor":"#e0e7ff","lineColor":"#64748b"}}}%%

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
           - Backup and Restore Runbook: deployment/backup-restore.md
           - Air-Gapped Image Bundle: deployment/airgapped-image-bundle.md
           - Performance, Sizing, and Benchmarks: deployment/performance-and-sizing.md
+          - Scaling SLOs and Autoscaling: deployment/scaling-slo.md
           - Worker and Scheduler Concurrency: deployment/worker-and-scheduler-concurrency.md
           - SIEM Integration: deployment/siem-integration.md
           - Grafana Dashboard: deployment/grafana.md

--- a/site-docs/deployment/airgapped-image-bundle.md
+++ b/site-docs/deployment/airgapped-image-bundle.md
@@ -1,5 +1,9 @@
 # Air-Gapped Image Bundle
 
+> **You do not need to read this unless** you are shipping `agent-bom`
+> images into a disconnected registry or cluster. The connected pilot and
+> production paths are in [Deployment Overview](overview.md).
+
 Use this workflow when a customer must import release images into a disconnected
 registry or cluster. The bundle contains the API/runtime image, the UI image,
 checksums, and a loader script. Bundles are platform-specific; produce one for

--- a/site-docs/deployment/audit-and-compliance-verification.md
+++ b/site-docs/deployment/audit-and-compliance-verification.md
@@ -1,5 +1,10 @@
 # Audit Chain vs Compliance Signing
 
+> **You do not need to read this unless** an auditor is asking
+> "is this evidence tamper-proof?" or you are integrating audit-log
+> verification into a compliance pipeline. For day-1 deployment choices
+> use [Deployment Overview](overview.md).
+
 `agent-bom` has **two different integrity mechanisms** that solve different
 problems.
 

--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -13,15 +13,19 @@ For the concrete runtime gateway discovery path after fleet and cluster scans
 have populated remote MCPs, see [Gateway Auto-Discovery From the Control
 Plane](gateway-auto-discovery.md).
 
-`agent-bom` stays one product with two deployable images:
+> **You do not need to read this unless** you are documenting an
+> opinionated AWS / EKS rollout for a platform team — covering Postgres,
+> IRSA, backup bucket, auth secrets, Helm release, fleet onboarding, and
+> gateway / proxy patterns under one ownership story.
+>
+> If you still need to pick a path, start with [Deployment
+> Overview](overview.md) and use [Deploy In Your Own AWS /
+> EKS](own-infra-eks.md) for the paved production rollout.
 
-- `agentbom/agent-bom` for scanner, API, jobs, proxy, gateway, and workers
-- `agentbom/agent-bom-ui` for the browser dashboard
-
-Use [Deployment Overview](overview.md) first if you still need to choose a
-path. Use [Deploy In Your Own AWS / EKS Infrastructure](own-infra-eks.md) for
-the paved production rollout. This page is the deeper AWS reference once that
-decision is already made.
+The two-image product split (`agentbom/agent-bom` plus
+`agentbom/agent-bom-ui`) and the runtime-surface defaults are documented in
+[Deployment Overview](overview.md#product-surfaces). This page is the deeper
+AWS-specific reference once that decision is already made.
 
 ## Reference Entry Points
 
@@ -129,17 +133,13 @@ This is the clean ownership model:
 
 ## Product Surfaces In A Company EKS Rollout
 
-These are the product surfaces a real enterprise rollout usually cares about:
-
-- **control plane**: API, UI, auth, graph, findings, remediation, audit, policy
-- **scan and discovery**: repos, images, IaC, MCP configs, skills, cluster and cloud surfaces
-- **fleet**: endpoint and collector inventory pushed into the control plane
-- **gateway**: shared remote MCP traffic, policy, and audit in the cluster
-- **proxy**: laptop or sidecar runtime enforcement where inline MCP inspection is needed
-
-`gateway` and `proxy` are core features of the product. In practice they are
-deployed selectively by workload and traffic path, not to every process in the
-environment on day 1.
+The five product surfaces an enterprise AWS rollout cares about (control
+plane, scan and discovery, fleet, gateway, proxy) are described in
+[Deployment Overview — Product Surfaces](overview.md#product-surfaces) and
+the "When to use" decision lives in
+[Proxy vs Gateway vs Fleet](proxy-vs-gateway-vs-fleet.md). In a real EKS
+rollout `gateway` and `proxy` are deployed selectively by workload and
+traffic path, not to every process on day 1.
 
 ## Runtime Flow For Fleet, Proxy, And Gateway
 

--- a/site-docs/deployment/backend-and-security-lakes.md
+++ b/site-docs/deployment/backend-and-security-lakes.md
@@ -1,5 +1,10 @@
 # Backend and Security-Lake Strategy
 
+> **You do not need to read this unless** you are reasoning about how
+> Postgres, ClickHouse, Snowflake, S3, and (future) Databricks fit
+> together as a tiered store strategy. For the per-API capability
+> matrix use [Backend Parity](backend-parity.md).
+
 `agent-bom` is one product, but not every backend does the same job.
 
 The backend strategy should stay simple:

--- a/site-docs/deployment/backend-parity.md
+++ b/site-docs/deployment/backend-parity.md
@@ -1,5 +1,10 @@
 # Backend Parity Matrix
 
+> **You do not need to read this unless** you are choosing between
+> SQLite, Postgres / Supabase, ClickHouse, and Snowflake — or verifying
+> exactly which API surfaces are wired against each backend today.
+> Most deployments should use Postgres (the documented default).
+
 `agent-bom` does not treat every backend as interchangeable.
 
 The product contract is:

--- a/site-docs/deployment/backup-restore.md
+++ b/site-docs/deployment/backup-restore.md
@@ -1,5 +1,10 @@
 # Backup And Restore Runbook
 
+> **You do not need to read this unless** you are operating the packaged
+> Postgres backup CronJob (`controlPlane.backup.enabled=true`) or
+> rehearsing a restore. Snowflake-native deployments use the warehouse
+> durability and recovery model instead and do not need this page.
+
 This runbook covers the packaged Postgres backup path for self-hosted control
 planes. It applies when `controlPlane.backup.enabled=true` in the Helm chart.
 Snowflake-native deployments use the warehouse durability and recovery model

--- a/site-docs/deployment/control-plane-data-model.md
+++ b/site-docs/deployment/control-plane-data-model.md
@@ -1,5 +1,10 @@
 # Control-Plane Data Model and Store Parity
 
+> **You do not need to read this unless** you are answering an auditor
+> on which entity lives in which table on which backend, or designing
+> a new connector / store adapter. For the day-1 backend choice use
+> [Backend Parity](backend-parity.md).
+
 This is the operator and auditor view of the `agent-bom` control-plane
 data model.
 

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -1,12 +1,12 @@
 # Packaged API + UI Control Plane
 
+> **You do not need to read this unless** you are installing or
+> customising the agent-bom Helm chart directly (instead of going through
+> the reference installer in [Deployment Overview](overview.md)).
+
 `agent-bom` now ships a Helm-packaged control plane for teams that want the API
 and dashboard inside their own Kubernetes environment instead of running custom
 Deployment manifests by hand.
-
-If you still need to choose a path, start with [Deployment Overview](overview.md).
-Use this page after you already know you want the chart itself, either through
-the reference installer or your own Helm layering.
 
 This is the right path when you want:
 

--- a/site-docs/deployment/customer-data-and-support-boundary.md
+++ b/site-docs/deployment/customer-data-and-support-boundary.md
@@ -1,5 +1,11 @@
 # Customer Data and Support Boundary
 
+> **You do not need to read this unless** procurement / security is
+> reviewing the self-hosted trust boundary, or you are answering
+> "can the agent-bom maintainers see our data?" For the related
+> least-privilege contract see
+> [Data Access Boundaries](data-access-boundaries.md).
+
 This page defines the default self-hosted trust boundary for `agent-bom`.
 
 The short version:

--- a/site-docs/deployment/data-access-boundaries.md
+++ b/site-docs/deployment/data-access-boundaries.md
@@ -1,5 +1,10 @@
 # Data Access Boundaries and Operator Control
 
+> **You do not need to read this unless** you are answering "what can
+> agent-bom read?" / "where does the data stay?" / "which controls
+> disable each path?" For the maintainer-access boundary see
+> [Customer Data and Support Boundary](customer-data-and-support-boundary.md).
+
 `agent-bom` is designed to answer a narrow security question: where are AI
 agents, MCP servers, tool paths, packages, credentials references, and related
 runtime risks exposed?

--- a/site-docs/deployment/data-retention.md
+++ b/site-docs/deployment/data-retention.md
@@ -1,5 +1,10 @@
 # Data Retention by Class
 
+> **You do not need to read this unless** you are tuning retention for a
+> compliance or cost target — or trying to decide whether to add ClickHouse
+> / S3 alongside the Postgres control plane. Default deployments work
+> without changing retention settings.
+
 `agent-bom` should not feel like "whatever the backend keeps." Retention is a
 product contract.
 

--- a/site-docs/deployment/deployment-modes-and-alignment.md
+++ b/site-docs/deployment/deployment-modes-and-alignment.md
@@ -1,5 +1,13 @@
 # Deployment Modes and Alignment
 
+> **You do not need to read this unless** you are aligning packaging,
+> docs, UX, and release wording across the product (the
+> `local` / `fleet` / `cluster` / `hybrid` modes, the `#1520`
+> deployment-mode-aware navigation track, or the `agent-bom` vs
+> `agent-bom-ui` image story). For "what should I deploy?" use
+> [Deployment Overview](overview.md). For runtime choice use
+> [Proxy vs Gateway vs Fleet](proxy-vs-gateway-vs-fleet.md).
+
 Use this page when the question is not "can `agent-bom` do this?" but "how do
 we package, deploy, explain, and scale it without making the product feel more
 complicated than it is?"
@@ -32,19 +40,12 @@ The honest auth and runtime gaps that still matter are:
 
 ## One Product, Two Images
 
-Keep the image model simple and stable:
-
-| Product concept | Deployable image | Purpose |
-|---|---|---|
-| **agent-bom API / runtime image** | `agentbom/agent-bom` | CLI, API, scanner jobs, gateway, proxy, MCP server |
-| **agent-bom UI companion image** | `agentbom/agent-bom-ui` | Browser UI for the self-hosted control plane |
-
-This is the correct split:
-
-- Python runtime surfaces and the Node UI have different patch cadence, scaling, and blast radius
-- separate images are cleaner and safer in customer EKS
-- the mistake is not having two images
-- the mistake is presenting them like two products
+The two-image split (`agentbom/agent-bom` runtime + `agentbom/agent-bom-ui`
+companion) is documented as canonical in
+[Deployment Overview — Product Surfaces](overview.md#product-surfaces).
+Same image taxonomy across CLI, API, jobs, gateway, proxy, MCP server, and
+the browser UI; the mistake to avoid is presenting the two images like two
+separate products.
 
 Use this wording everywhere:
 
@@ -81,15 +82,12 @@ This is the clean customer-facing deployment story:
 
 ### What the customer actually deploys
 
-| Layer | Runs in customer infra | Why it exists |
-|---|---|---|
-| **UI** | browser-facing deployment | review, trigger, schedule, export |
-| **API / control plane** | FastAPI service | auth, RBAC, tenant scope, orchestration, graph, audit, policy |
-| **scanner jobs** | CronJobs, CI runners, one-off jobs | repo, image, IaC, MCP, cloud, and cluster scanning |
-| **fleet ingest** | endpoint or collector pushes | workstation and collector inventory without a mandatory daemon product |
-| **proxy** | sidecar or laptop wrapper | local enforcement near MCP traffic |
-| **gateway** | shared relay and policy surface | central runtime control where shared relay is useful |
-| **stores** | Postgres required, ClickHouse optional, Snowflake optional | transactional state, analytics, governance-oriented backends |
+The per-surface ownership (UI, API, scanner jobs, fleet ingest, proxy,
+gateway, stores) is described in [Deployment Overview — Product
+Surfaces](overview.md#product-surfaces) and the
+[Self-Hosted Product Architecture](../architecture/self-hosted-product-architecture.md)
+page. Do not re-document it here; this section exists to anchor the alignment
+matrix below.
 
 ### Response to the three practical concerns
 

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -1,16 +1,14 @@
 # Docker Deployment
 
-Use this page for containerized entrypoints. `agent-bom` is one product with
-two deployable images:
+> **You do not need to read this unless** you are running `agent-bom`
+> directly through Docker (compose, ad hoc `docker run`, or the SSE/runtime
+> Dockerfiles). For the production rollout path, start with
+> [Deployment Overview](overview.md) and follow the paved path it recommends.
 
-If you still need to choose a deployment path, start with
-[Deployment Overview](overview.md). This page is Docker-specific reference
-material after that decision, not the primary production rollout guide.
-
-- `agentbom/agent-bom` = the main runtime image for CLI scans, the API,
-  scanner jobs, gateway, MCP server mode, and other non-browser entrypoints
-- `agentbom/agent-bom-ui` = the standalone browser UI image used when the
-  self-hosted control plane runs the UI separately from the API
+Use this page for containerized entrypoints. The product split (one
+`agentbom/agent-bom` runtime image plus the `agentbom/agent-bom-ui` browser
+image) is documented in [Deployment Overview](overview.md#product-surfaces);
+this page only covers Docker-specific commands and image variants.
 
 Pilot on one workstation:
 

--- a/site-docs/deployment/enterprise-auth-and-tenancy.md
+++ b/site-docs/deployment/enterprise-auth-and-tenancy.md
@@ -1,5 +1,9 @@
 # Enterprise Auth and Tenant Isolation
 
+> **You do not need to read this unless** you are wiring SSO, SCIM,
+> trusted reverse-proxy identity, or tenant propagation on a
+> self-hosted deployment. Default API-key auth works without this page.
+
 This page is the operator-facing contract for how `agent-bom` handles:
 
 - API keys

--- a/site-docs/deployment/enterprise-pilot.md
+++ b/site-docs/deployment/enterprise-pilot.md
@@ -1,5 +1,10 @@
 # Enterprise MCP / Endpoint Pilot
 
+> **You do not need to read this unless** you are scoping an
+> open-source pilot that combines endpoint fleet, server-side MCP
+> visibility, gateway policy, and selected proxy enforcement. For the
+> paved production paths use [Deployment Overview](overview.md).
+
 This is the canonical `agent-bom` pilot shape for a company that wants one
 open-source control plane for:
 

--- a/site-docs/deployment/gateway-auto-discovery.md
+++ b/site-docs/deployment/gateway-auto-discovery.md
@@ -1,5 +1,11 @@
 # Gateway Auto-Discovery From the Control Plane
 
+> **You do not need to read this unless** you are bringing up a gateway
+> after fleet / scan data already populated remote MCPs in the control
+> plane and want to skip a hand-edited `upstreams.yaml`. For the choice
+> of runtime surface use
+> [Proxy vs Gateway vs Fleet](proxy-vs-gateway-vs-fleet.md).
+
 `agent-bom gateway serve --from-control-plane` lets the gateway load remote MCP
 upstreams directly from fleet and scan data already stored in the control plane.
 

--- a/site-docs/deployment/grafana.md
+++ b/site-docs/deployment/grafana.md
@@ -1,5 +1,8 @@
 # Grafana Dashboard
 
+> **You do not need to read this unless** you already run Grafana and
+> want the shipped agent-bom dashboard for API + proxy Prometheus metrics.
+
 `agent-bom` ships a pre-built Grafana dashboard for visualizing Prometheus
 metrics from the API and proxy.
 

--- a/site-docs/deployment/kubernetes.md
+++ b/site-docs/deployment/kubernetes.md
@@ -1,8 +1,11 @@
 # Kubernetes Deployment
 
-If you still need to choose a rollout path, start with
-[Deployment Overview](overview.md). This page is Kubernetes reference material
-for teams that already know they want raw manifests or direct chart controls.
+> **You do not need to read this unless** you are working with the raw
+> `deploy/k8s/` manifests, the optional sidecar-injection webhook, or
+> low-level Helm value tuning. The paved EKS rollout paths are
+> [Vanilla EKS Quickstart](eks-vanilla-quickstart.md) and
+> [Your Own AWS / EKS](own-infra-eks.md); the chart contract lives in
+> [Packaged API + UI Control Plane](control-plane-helm.md).
 
 ## Pre-built manifests
 

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -271,14 +271,6 @@ For the default self-hosted data-ownership and support-sharing boundary, see
 | **Gateway runtime** | shared remote MCP client | remote MCP + control-plane audit/policy | central remote MCP traffic plane |
 | **Analytics / archive** | control plane | ClickHouse, S3, SIEM, OTEL | optional longer retention, analytics, and exports |
 
-This is the product split to keep in mind:
-
-- **UI** drives workflows and review
-- **API** owns auth, RBAC, graph, audit, and policy
-- **workers** do scans and normalization
-- **fleet** persists endpoint inventory
-- **proxy and gateway** are runtime surfaces deployed where they fit
-
 By default, the control plane, job results, fleet inventory, graph snapshots,
 remediation output, and proxy audit data stay inside the customer's
 infrastructure. External egress only happens when the operator explicitly enables
@@ -288,45 +280,6 @@ webhooks.
 That same self-hosted boundary also means `agent-bom` maintainers do not get
 silent access to tenant data. For the full operator-facing contract, see
 [Customer Data and Support Boundary](customer-data-and-support-boundary.md).
-
-## Which Service Does What
-
-| Surface | Deploy it when | What it owns | What it is not |
-|---|---|---|---|
-| **Scan** | you need discovery, CVE analysis, Kubernetes inventory, CI gates, or scheduled audits | package, container, IaC, MCP, cloud, and cluster scanning | a live enforcement layer |
-| **Fleet** | you want laptops, workstations, or other collectors to persist inventory into one control plane | endpoint and collector push into `/v1/fleet/sync`, review in `/fleet` | an always-on endpoint agent or MDM product |
-| **Proxy / runtime** | you need inline MCP inspection or policy enforcement on live tool traffic | `agent-bom proxy`, audit push, selected blocks/warns, local or sidecar enforcement | a generic shared network gateway for every workload |
-| **Gateway** | you want central policy authoring and optional shared remote MCP traffic | `/gateway`, `/v1/gateway/policies`, policy pull for proxies, `agent-bom gateway serve` | a replacement for the proxy itself |
-| **API + UI** | you want one operator control plane | findings, graph, remediation, fleet review, audit, policy management | a hosted vendor control plane |
-| **MCP server** | you want `agent-bom` exposed as tools to assistants or remote clients | `agent-bom mcp server` tool surface | the same thing as the runtime proxy |
-
-## Hosted product checklist
-
-For the packaged product to feel end to end, the UI should drive the control
-plane instead of collecting data itself.
-
-| Operator action in UI | Backend/API owner | Data actually comes from |
-|---|---|---|
-| Create a scan job | `POST /v1/scan` | worker jobs that scan repos, images, IaC, MCP configs, or cloud targets |
-| Poll progress / stream status | `GET /v1/scan/{job_id}`, `GET /v1/scan/{job_id}/stream`, `GET /v1/jobs` | control-plane job state |
-| Export graph / licenses / VEX / reports | `GET /v1/scan/{job_id}/graph-export`, `/licenses`, `/vex`, `/skill-audit`; `GET /v1/compliance/{framework}/report` | normalized findings and graph state already stored in the control plane |
-| Schedule recurring collection | `POST /v1/schedules`, `GET /v1/schedules`, `PUT /v1/schedules/{id}/toggle`, `DELETE /v1/schedules/{id}` | scheduled worker execution |
-| Review fleet and endpoint inventory | `GET /v1/fleet`, `GET /v1/fleet/stats`, `GET /v1/fleet/{agent_id}` | endpoint or collector pushes to `POST /v1/fleet/sync` |
-| Review traces and pushed results | `POST /v1/traces`, `POST /v1/results/push`, `GET /v1/activity`, `GET /v1/governance` | OTLP, event collectors, or customer-owned push paths |
-| Manage runtime policy | `GET/POST/PUT/DELETE /v1/gateway/policies`, `POST /v1/gateway/evaluate` | proxy and gateway policy pull/evaluation |
-| Review runtime audit and health | `GET /v1/proxy/status`, `GET /v1/proxy/alerts`, `GET /v1/gateway/audit`, `GET /v1/gateway/stats` | `agent-bom proxy` and gateway audit push to `/v1/proxy/audit` |
-| Manage auth, keys, and audit export | `/v1/auth/*`, `/v1/audit*`, `/v1/exceptions*` | control-plane auth, RBAC, audit, and policy state |
-| Review graph, findings, posture, and compliance | `/v1/graph*`, `/v1/assets*`, `/v1/compliance*`, `/v1/posture*`, `/v1/governance*` | canonical entities, findings, events, and graph state in the control plane |
-
-That is the intended split:
-
-- `UI` = configure, trigger, schedule, review, export
-- `API / control plane` = auth, RBAC, tenant scope, orchestration, graph, persistence, audit, policy
-- `workers / connectors` = do the privileged read or collection work
-- `proxy / gateway` = enforce and audit runtime MCP traffic
-
-For the concrete backend and UI rollout plan behind this split, see [Hosted
-Product Control-Plane Spec](../architecture/hosted-product-spec.md).
 
 ## Approved intake paths today
 
@@ -413,41 +366,13 @@ YAML.
 
 ![agent-bom remediation view](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/remediation-live.png)
 
-## Start Here
+## Where to go next
 
-- [AWS Company Rollout](aws-company-rollout.md)
-- [Your Own AWS / EKS](own-infra-eks.md)
-- [Enterprise MCP / Endpoint Pilot](enterprise-pilot.md)
-- [Endpoint Fleet](endpoint-fleet.md)
-- [When To Use Proxy vs Gateway vs Fleet](proxy-vs-gateway-vs-fleet.md)
-- [Focused EKS MCP Pilot](eks-mcp-pilot.md)
-- [Packaged API + UI Control Plane](control-plane-helm.md)
-- [Snowflake POV Deployment Runbook](snowflake-pov.md)
-- [Performance, Sizing, and Benchmarks](performance-and-sizing.md)
-- [Visual Leak Detection](visual-leak-detection.md)
-- [Worker and Scheduler Concurrency](worker-and-scheduler-concurrency.md)
-- [Gateway Auto-Discovery From the Control Plane](gateway-auto-discovery.md)
-- [Backend Parity](backend-parity.md)
+The chooser table at the top of this page is the canonical entry. After that:
 
-## Hosting and Storage Boundaries
+- runtime surface decision lives in [When To Use Proxy vs Gateway vs Fleet](proxy-vs-gateway-vs-fleet.md)
+- backend choice (Postgres / ClickHouse / Snowflake) is documented in [Backend Parity Matrix](backend-parity.md) and [Backend and Security-Lake Strategy](backend-and-security-lakes.md)
+- the deeper data-model and store mapping is in [Control-Plane Data Model and Store Parity](control-plane-data-model.md)
+- the API + UI control-plane image and operator split is in [Packaged API + UI Control Plane](control-plane-helm.md) and [Hosted Product Control-Plane Spec](../architecture/hosted-product-spec.md)
 
-`agent-bom` is deployable in multiple honest ways:
-
-- **Local laptop / workstation**: CLI or `agent-bom serve` with SQLite
-- **Self-hosted VM / container**: `agent-bom api` or `agent-bom serve` behind
-  your ingress and auth
-- **Docker Compose / container platforms**: packaged API, proxy, or MCP server
-- **Kubernetes / Helm**: control plane, scanner, optional runtime monitor, and
-  operator surfaces
-- **Postgres / Supabase**: primary transactional backend
-- **ClickHouse**: analytics add-on
-- **Snowflake**: warehouse-native governance surface with explicit parity
-  limits, not the default full hosting contract
-
-Default guidance:
-
-- **Postgres** is the normal self-hosted control-plane answer
-- **ClickHouse** is the first analytics add-on when event volume grows
-- **Snowflake** is an explicit advanced path, not the default production recommendation
-
-For the detailed backend matrix, see [Backend Parity Matrix](backend-parity.md).
+Everything else in the deployment section is reference material — open it only when your platform team needs that specific detail.

--- a/site-docs/deployment/performance-and-sizing.md
+++ b/site-docs/deployment/performance-and-sizing.md
@@ -1,5 +1,10 @@
 # Performance, Sizing, and Benchmarks
 
+> **You do not need to read this unless** you are sizing nodes / replicas
+> / autoscaling for a real EKS rollout, or validating the shipped
+> benchmark harness against your own load. Defaults from the paved
+> installers fit pilot and small-team workloads without tuning.
+
 This guide is the operator-facing follow-up to the packaged Helm control plane
 and enterprise pilot docs. It does not promise fixed throughput numbers the
 repo has not published. It gives a defensible starting point for sizing,

--- a/site-docs/deployment/postgres-provisioning.md
+++ b/site-docs/deployment/postgres-provisioning.md
@@ -1,5 +1,11 @@
 # Postgres Provisioning Workflow
 
+> **You do not need to read this unless** your platform team is
+> provisioning Postgres outside of the reference installer (e.g. with
+> custom Terraform, an existing RDS, or a non-default user/role layout).
+> The paved-path installers in [Deployment Overview](overview.md) handle
+> this for you.
+
 This page documents the Postgres contract for self-hosted `agent-bom`
 operators.
 

--- a/site-docs/deployment/runtime-monitoring.md
+++ b/site-docs/deployment/runtime-monitoring.md
@@ -1,5 +1,10 @@
 # Runtime Monitoring
 
+> **You do not need to read this unless** you are deploying the runtime
+> proxy / DaemonSet monitor and want the detector list and alert routing.
+> For the choice between proxy / gateway / fleet, start with
+> [Proxy vs Gateway vs Fleet](proxy-vs-gateway-vs-fleet.md).
+
 For the full runtime monitoring deployment guide, see the [dedicated doc](https://github.com/msaad00/agent-bom/blob/main/docs/RUNTIME_MONITORING.md).
 
 ## Overview

--- a/site-docs/deployment/runtime-operations.md
+++ b/site-docs/deployment/runtime-operations.md
@@ -1,5 +1,11 @@
 # Runtime Operations
 
+> **You do not need to read this unless** you are rotating the proxy
+> policy-bundle Ed25519 signing key or renewing the cert-manager-backed
+> sidecar webhook chain. The default rollout in
+> [Deployment Overview](overview.md) does not require these tasks on
+> day 1.
+
 Use this page for the small but important operator tasks that sit between
 "feature shipped" and "production stayed healthy":
 

--- a/site-docs/deployment/scaling-slo.md
+++ b/site-docs/deployment/scaling-slo.md
@@ -1,5 +1,11 @@
 # Scaling SLOs and KEDA-driven autoscaling
 
+> **You do not need to read this unless** you are running KEDA-backed
+> autoscaling, validating the shipped per-tier SLOs, or signing off
+> production sizing for the EKS reference deployment. For default
+> sizing guidance use [Performance, Sizing, and
+> Benchmarks](performance-and-sizing.md).
+
 This page publishes the per-tier scaling SLOs agent-bom commits to under the
 documented EKS reference deployment, and explains the autoscaling primitives
 the chart ships with so you can validate them against your own load.

--- a/site-docs/deployment/siem-integration.md
+++ b/site-docs/deployment/siem-integration.md
@@ -1,5 +1,10 @@
 # SIEM Integration
 
+> **You do not need to read this unless** you are wiring `agent-bom`
+> events into a SIEM or security lake (Splunk, Elastic, Snowflake,
+> generic OCSF). The product runs end-to-end without OCSF; this page is
+> the boundary contract.
+
 Agent BOM can push events downstream in two formats:
 
 - `raw`: the canonical `agent-bom` event shape

--- a/site-docs/deployment/snowflake-backend.md
+++ b/site-docs/deployment/snowflake-backend.md
@@ -1,5 +1,11 @@
 # Snowflake-native backend
 
+> **You do not need to read this unless** your organization has decided
+> to govern control-plane data in Snowflake. The default self-hosted
+> path uses Postgres — see [Deployment Overview](overview.md) and
+> [Backend Parity](backend-parity.md). For a Snowflake POV, start with
+> [Snowflake POV](snowflake-pov.md).
+
 `agent-bom` runs against Snowflake as the primary store for scan jobs,
 fleet agents, schedules, gateway policies, vulnerability exceptions, and the policy audit trail. Use this
 mode when your organisation already governs data in Snowflake and you

--- a/site-docs/deployment/terraform-aws-baseline.md
+++ b/site-docs/deployment/terraform-aws-baseline.md
@@ -1,5 +1,11 @@
 # Terraform AWS Baseline
 
+> **You do not need to read this unless** your platform team owns the
+> AWS pieces around `agent-bom` (RDS, IRSA, S3 backup bucket, Secrets
+> Manager) directly through Terraform instead of through the reference
+> installer. For the paved AWS rollout use
+> [Your Own AWS / EKS](own-infra-eks.md).
+
 Use this page when the question is not "how do I deploy the chart?" but
 "who owns the AWS pieces around the chart, and how do I destroy them cleanly?"
 

--- a/site-docs/deployment/visual-leak-detection.md
+++ b/site-docs/deployment/visual-leak-detection.md
@@ -1,5 +1,9 @@
 # Visual Leak Detection
 
+> **You do not need to read this unless** you are turning on OCR-based
+> response inspection for screenshot / image-heavy MCP tools. It is
+> opt-in because of the OCR dependency and CPU cost.
+
 The visual leak detector is the OCR-backed response safety layer for screenshot
 and image-heavy MCP tools. It is intentionally opt-in because it adds OCR
 dependencies and CPU cost to the runtime path.

--- a/site-docs/deployment/worker-and-scheduler-concurrency.md
+++ b/site-docs/deployment/worker-and-scheduler-concurrency.md
@@ -1,5 +1,10 @@
 # Worker and Scheduler Concurrency
 
+> **You do not need to read this unless** you are debugging job queue
+> behavior, tuning concurrency for high-volume scans, or making a
+> deliberate choice between API-triggered scans, recurring schedules, and
+> packaged CronJobs.
+
 `agent-bom` uses a few different execution models at once:
 
 - API-triggered ad hoc scans

--- a/src/agent_bom/cloud/container_sbom.py
+++ b/src/agent_bom/cloud/container_sbom.py
@@ -94,6 +94,8 @@ def _parse_image_ref(image_ref: str) -> tuple[str, str, str, str]:
         "ubuntu:22.04"                     → ("docker.io", "library", "ubuntu", "22.04")
         "nvcr.io/nvidia/cuda:12.3"        → ("nvcr.io", "nvidia", "cuda", "12.3")
         "ghcr.io/huggingface/tgi:latest"  → ("ghcr.io", "huggingface", "tgi", "latest")
+        "host:5000/img:tag"                → ("host:5000", "library", "img", "tag")
+        "localhost:5000/myimg"             → ("localhost:5000", "library", "myimg", "latest")
     """
     tag = "latest"
     last_part = image_ref.rsplit("/", 1)[-1]
@@ -101,11 +103,23 @@ def _parse_image_ref(image_ref: str) -> tuple[str, str, str, str]:
         image_ref, tag = image_ref.rsplit(":", 1)
 
     parts = image_ref.split("/")
-    if len(parts) >= 3 and ("." in parts[0] or ":" in parts[0]):
-        # Custom registry: nvcr.io/nvidia/cuda, ghcr.io/huggingface/tgi
+
+    def _looks_like_registry(s: str) -> bool:
+        # Docker / OCI convention: a registry hostname is the first slash-segment
+        # and is distinguished from a Docker Hub org by containing a `.` (FQDN) or
+        # a `:` (port) — the conservative rule the docker CLI itself uses.
+        return "." in s or ":" in s
+
+    if len(parts) >= 3 and _looks_like_registry(parts[0]):
+        # Custom registry, full path: nvcr.io/nvidia/cuda, ghcr.io/huggingface/tgi
         registry = parts[0]
         org = parts[1]
         repo = "/".join(parts[2:])
+    elif len(parts) == 2 and _looks_like_registry(parts[0]):
+        # Custom registry, no org: host:5000/img, localhost:5000/myimg, registry.io/img
+        registry = parts[0]
+        org = "library"
+        repo = parts[1]
     elif len(parts) == 2:
         # Docker Hub user image: pytorch/pytorch
         registry = "docker.io"

--- a/tests/test_container_sbom.py
+++ b/tests/test_container_sbom.py
@@ -49,6 +49,10 @@ def _clear_scan_cache():
         ("nvidia/cuda:11.8-cudnn8", "docker.io", "nvidia", "cuda", "11.8-cudnn8"),
         ("rocm/pytorch:latest", "docker.io", "rocm", "pytorch", "latest"),
         ("vllm/vllm-openai:v0.4.0", "docker.io", "vllm", "vllm-openai", "v0.4.0"),
+        # Self-hosted registry with port (audit P3 — was misclassified as docker.io org)
+        ("host:5000/img:tag", "host:5000", "library", "img", "tag"),
+        ("localhost:5000/myimg", "localhost:5000", "library", "myimg", "latest"),
+        ("registry.io:443/org/img:1.0", "registry.io:443", "org", "img", "1.0"),
     ],
 )
 def test_parse_image_ref(image_ref, registry, org, repo, tag):

--- a/tests/test_sast.py
+++ b/tests/test_sast.py
@@ -374,6 +374,11 @@ def test_scan_code_default_uses_local_rules_and_auto(monkeypatch, tmp_path):
     """default config should prefer local rule bundles and still include Semgrep auto."""
     monkeypatch.setattr("agent_bom.sast.shutil.which", lambda _: "/usr/bin/semgrep")
     monkeypatch.setattr("agent_bom.sast._get_semgrep_version", lambda: "1.50.0")
+    # Pin Path.home() to a clean tmp directory so the dev's real ~/.semgrep
+    # config (if any) doesn't get auto-discovered and flip the assertion.
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr("agent_bom.sast.Path.home", lambda: fake_home)
     rules_dir = tmp_path / ".agent-bom" / "sast-rules"
     rules_dir.mkdir(parents=True)
     (rules_dir / "custom.yaml").write_text("rules: []", encoding="utf-8")


### PR DESCRIPTION
Closes #2154.

Surgical doc-prose consolidation following the diagram-split work in #2238 / #2239. Deployment docs now have one canonical home for each duplicated product-surface explanation, every reference page carries a skip callout, and the chooser table at the top of `overview.md` is the canonical entry point.

## What was consolidated

| Duplicated prose | Old homes | New canonical home |
|---|---|---|
| Two-image split (`agentbom/agent-bom` + `agentbom/agent-bom-ui`) | overview, docker, aws-company-rollout, deployment-modes-and-alignment | `deployment/overview.md#product-surfaces` |
| Per-surface ownership (Scan / Fleet / Proxy / Gateway / API+UI / MCP) | overview "Which Service Does What", deployment-modes-and-alignment "What the customer actually deploys", aws-company-rollout "Product Surfaces In A Company EKS Rollout" | `deployment/overview.md#product-surfaces` (table) and `architecture/self-hosted-product-architecture.md` |
| UI vs API vs workers vs proxy/gateway split bullets | overview "How the surfaces connect" tail, deployment-modes-and-alignment "One Product, Two Images" tail | `architecture/self-hosted-product-architecture.md` |
| `Hosted product checklist` (UI route -> API endpoint table) | `deployment/overview.md` | `architecture/hosted-product-spec.md` |
| `Start Here` link wall + `Hosting and Storage Boundaries` tail | `deployment/overview.md` | replaced by short "Where to go next" pointing to the runtime / backend / data-model / control-plane reference pages |
| Runtime surface decision (proxy vs gateway vs fleet) | aws-company-rollout, kubernetes, control-plane-helm preambles | `deployment/proxy-vs-gateway-vs-fleet.md` |

## "You do not need to read this unless..." callouts added

Every reference page now opens with a `> **You do not need to read this unless** ...` blockquote so casual readers can skip cleanly:

`airgapped-image-bundle`, `audit-and-compliance-verification`, `backup-restore`, `backend-and-security-lakes`, `backend-parity`, `control-plane-data-model`, `control-plane-helm`, `customer-data-and-support-boundary`, `data-access-boundaries`, `data-retention`, `deployment-modes-and-alignment`, `docker`, `enterprise-auth-and-tenancy`, `enterprise-pilot`, `gateway-auto-discovery`, `grafana`, `kubernetes`, `performance-and-sizing`, `postgres-provisioning`, `runtime-monitoring`, `runtime-operations`, `scaling-slo`, `siem-integration`, `snowflake-backend`, `terraform-aws-baseline`, `visual-leak-detection`, `worker-and-scheduler-concurrency`.

Paved-path pages (`overview`, `docker`, `eks-vanilla-quickstart`, `own-infra-eks`, `eks-mcp-pilot`, `snowflake-pov`, `proxy-vs-gateway-vs-fleet`, `endpoint-fleet`) intentionally do not carry the skip callout — they are the destinations users should land on.

## Nav and README

- `mkdocs.yml`: previously orphan `deployment/scaling-slo.md` added to **Operations Reference**. The 5-bucket nav (**Paved Paths**, **Runtime and Fleet**, **Enterprise Controls**, **Operations Reference**, **Specialized Reference**) is unchanged.
- `README.md`: deployment block now links to the chooser (`site-docs/deployment/overview.md`) first, replacing the broken `#enterprise-self-hosted-topology` / `#enterprise-self-hosted-data-and-runtime-flow` anchors that were superseded by the three single-concern diagrams in #2238 (Topology / Auth + Ingress / Inventory & Runtime Evidence).

## Constraint compliance

- diagram source for `overview.md` and `aws-company-rollout.md` topology / auth / data-flow blocks untouched (#2238 / #2239)
- canonical truth blocks under each diagram untouched
- no operator-detail pages deleted; only duplicated prose collapsed into "short summary + link"
- `README.md` edits scoped to the deployment-link block called out by the issue (no broader sweep)

## MkDocs strict build

`uv run mkdocs build --strict` passes cleanly: no warnings, no broken anchors, no orphan nav entries. The MkDocs 2.0-incompatibility warning that mkdocs-material prints unconditionally is unrelated to the doc changes here.

```
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: site
INFO    -  Documentation built in 2.29 seconds
```

## Test plan

- [ ] `uv run mkdocs build --strict` exits 0
- [ ] `deployment/overview.md` chooser table at the top still names every paved-path destination from nav
- [ ] every reference page in nav buckets **Enterprise Controls / Operations Reference / Specialized Reference** opens with a `> **You do not need to read this unless ...**` callout
- [ ] `README.md` "Enterprise self-hosted deployment" block now links to `site-docs/deployment/overview.md` first
- [ ] `scaling-slo.md` shows under **Operations Reference** in the rendered nav