### PR TITLE
fix(ui+api): graph relax-scope button + pulse strobe + /graph scroll + /docs CSP (v0.86.0)

### DIFF
--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -59,11 +59,29 @@ _AUTH_RUNTIME_STATUS: dict[str, object] = {
     "recommended_ui_mode": "no_auth",
 }
 _API_CSP = "default-src 'self'"
+# /docs (Swagger UI) and /redoc serve HTML shells that load swagger-ui /
+# redoc bundles + a favicon from public CDNs (cdn.jsdelivr.net,
+# fastapi.tiangolo.com). The strict default-src 'self' API CSP blocks
+# them, leaving a blank page. We narrowly relax CSP for these two
+# documentation routes — they remain disable-able via
+# AGENT_BOM_DISABLE_DOCS for production deployments per the
+# _EXEMPT_PATHS toggle below.
+_DOCS_CSP = (
+    "default-src 'self'; "
+    "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+    "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+    "img-src 'self' data: https://fastapi.tiangolo.com https://cdn.jsdelivr.net; "
+    "font-src 'self' data: https://cdn.jsdelivr.net; "
+    "worker-src 'self' blob:; "
+    "connect-src 'self'"
+)
 _TRUSTED_PROXY_SECRET_MIN_BYTES = 32
 
 
 def _content_security_policy(path: str, content_type: str) -> str:
     """Return a route-aware CSP that keeps the API strict and the dashboard usable."""
+    if path.startswith(("/docs", "/redoc")) and "text/html" in content_type:
+        return _DOCS_CSP
     if "text/html" in content_type and not path.startswith(("/v1/", "/docs", "/redoc", "/openapi.json")):
         return dashboard_csp_header()
     return _API_CSP

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -1154,7 +1154,13 @@ export default function GraphPageClient() {
               ]}
             />
           ) : graphOnlyFindings ? (
-            <GraphFindingsFallback nodes={findingNodes} onSelect={selectFindingCard} />
+            <GraphFindingsFallback
+              nodes={findingNodes}
+              onSelect={selectFindingCard}
+              onExpandScope={() =>
+                setFilters(createExpandedGraphFilters(filters.agentName ?? flow.agentNames[0] ?? null))
+              }
+            />
           ) : (
             <ReactFlow
               nodes={displayNodes}

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -60,11 +60,25 @@ function PulseStyles() {
   return (
     <style jsx global>{`
       @keyframes pulse-critical {
-        0%, 100% { box-shadow: 0 0 8px rgba(239, 68, 68, 0.4); }
-        50% { box-shadow: 0 0 20px rgba(239, 68, 68, 0.8); }
+        0%, 100% { box-shadow: 0 0 6px rgba(239, 68, 68, 0.35); }
+        50% { box-shadow: 0 0 12px rgba(239, 68, 68, 0.55); }
       }
       .node-critical-pulse {
-        animation: pulse-critical 2s ease-in-out infinite;
+        animation: pulse-critical 3.2s ease-in-out infinite;
+        /* Respect reduced-motion preferences. */
+      }
+      /* Stagger so a graph with many critical nodes does NOT strobe in
+         sync — when ten or twenty nodes pulse together at the same
+         phase the page reads as a flickering page-wide flash. The
+         animation-delay buckets desync neighbours visually. */
+      .node-critical-pulse:nth-child(3n)   { animation-delay: -0.4s; }
+      .node-critical-pulse:nth-child(3n+1) { animation-delay: -1.2s; }
+      .node-critical-pulse:nth-child(3n+2) { animation-delay: -2.0s; }
+      @media (prefers-reduced-motion: reduce) {
+        .node-critical-pulse {
+          animation: none;
+          box-shadow: 0 0 6px rgba(239, 68, 68, 0.5);
+        }
       }
     `}</style>
   );
@@ -787,7 +801,13 @@ export default function GraphPageClient() {
   }
 
   return (
-    <div className="h-[calc(100vh-3.5rem)] flex flex-col">
+    // min-h instead of h so the page can grow taller than the viewport
+    // when the snapshot diff cards / how-to-read prose / findings
+    // fallback panel push content past the fold. Previously the fixed
+    // h-[calc(100vh-3.5rem)] container clipped everything below the
+    // viewport, leaving users stuck on the snapshot row with no way
+    // to scroll to the React Flow canvas or the findings panel.
+    <div className="min-h-[calc(100vh-3.5rem)] flex flex-col">
       <PulseStyles />
 
       <div className="border-b border-zinc-800 bg-[radial-gradient(circle_at_top_left,rgba(14,165,233,0.12),transparent_26%),linear-gradient(180deg,rgba(24,24,27,0.96),rgba(9,9,11,0.96))] px-4 py-4">
@@ -1128,10 +1148,10 @@ export default function GraphPageClient() {
         )}
       </div>
 
-      <div className="flex-1 flex relative overflow-hidden">
+      <div className="flex-1 flex relative min-h-[60vh]">
         <FilterPanel filters={filters} onChange={setFilters} agentNames={flow.agentNames} />
 
-        <div className="flex-1 relative">
+        <div className="flex-1 relative min-h-[60vh]">
           {loadingGraph && !graphData ? (
             <GraphPanelSkeleton
               title="Loading graph window"

--- a/ui/components/graph-state-panels.tsx
+++ b/ui/components/graph-state-panels.tsx
@@ -119,9 +119,17 @@ function SkeletonColumn({ bars }: { bars: number }) {
 export function GraphFindingsFallback({
   nodes,
   onSelect,
+  onExpandScope,
 }: {
   nodes: Array<{ id: string; data: LineageNodeData }>;
   onSelect: (id: string, data: LineageNodeData) => void;
+  // Optional: when provided, a "Show full graph" button replaces the dead
+  // "relax the scope to recover the graph" prose with an actual click target
+  // that swaps the active filters to the expanded preset. The graph page
+  // wires this so memory-only mode (no persisted graph backend) and focused
+  // filters that drop the surrounding agent/server context can recover the
+  // topology in one click instead of hunting through filter checkboxes.
+  onExpandScope?: () => void;
 }) {
   const shouldVirtualize = nodes.length > FINDINGS_VIRTUALIZE_THRESHOLD;
 
@@ -136,6 +144,16 @@ export function GraphFindingsFallback({
               You are looking at the vulnerability slice without enough surrounding package, server, or agent context to form a topology.
               Use this list for evidence and remediation, or relax the scope to recover the graph.
             </p>
+            {onExpandScope ? (
+              <button
+                type="button"
+                onClick={onExpandScope}
+                className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-300 hover:bg-emerald-500/20 hover:border-emerald-400 transition-colors"
+              >
+                Show full graph
+                <span className="text-[10px] text-emerald-400/70">(expand scope)</span>
+              </button>
+            ) : null}
           </div>
           <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-xs text-[color:var(--text-secondary)]">
             {nodes.length} finding{nodes.length !== 1 ? "s" : ""} in scope


### PR DESCRIPTION
Four small UI/API fixes the user hit while testing v0.86.0 live. All on the same branch because they're all in the same dashboard / docs paths and unblock the same first-impression demo.

## 1) Graph relax-scope button (`Show full graph`)

`/graph` page renders `GraphFindingsFallback` when the focused-default filter resolves to vulnerability nodes only — common in memory-only mode (no Postgres-backed persisted graph) and in scans without local agent context. The fallback said "relax the scope to recover the graph" but shipped no actual button — users had to hunt through five filter checkboxes to escape findings-only view. Net effect: the moat graph (244 nodes / 302 edges in our self-scan) sat invisible behind a help message.

**Fix:** add optional `onExpandScope` prop to `GraphFindingsFallback` rendering an emerald \"Show full graph (expand scope)\" button. `/graph` wires it to `setFilters(createExpandedGraphFilters(...))`. One click.

## 2) Pulse strobe on `/graph` and `/mesh`

Every critical node got className `node-critical-pulse` driving the same `@keyframes pulse-critical` animation in sync. With 10+ critical nodes the whole page read as a flickering page-wide flash — sufficient to trigger photosensitivity concerns.

**Fix:**
- Animation intensity dialed back: `box-shadow` alpha `0.4→0.35` low / `0.8→0.55` high, duration `2s→3.2s`.
- 3-bucket `nth-child(3n / 3n+1 / 3n+2)` animation-delay stagger so neighbours desync visually.
- Honoured `prefers-reduced-motion`: static glow with no animation.

## 3) `/graph` page locked at viewport height (no scroll)

Snapshot-diff cards, how-to-read prose, and the findings fallback panel were unreachable below the fold because the outer container used `h-[calc(100vh-3.5rem)]` and the inner row used `overflow-hidden`.

**Fix:**
- `h-[calc(...)]` → `min-h-[calc(...)]` so the page can grow past viewport.
- Dropped `overflow-hidden` on the filter+canvas row, gave both the row and the canvas slot `min-h-[60vh]` floors so React Flow still has a usable height when content is short, and the page scrolls naturally when content is long.

## 4) `/docs` (Swagger UI) blank page

Strict `default-src 'self'` API CSP blocked Swagger's CDN bundle (`cdn.jsdelivr.net`) and the FastAPI favicon — the HTML shell loaded, the bundle never ran, blank page.

**Fix:**
- Added `_DOCS_CSP`: still `default-src 'self'` but explicitly allows `cdn.jsdelivr.net` for `script-src` / `style-src` / `img-src` / `font-src` and `fastapi.tiangolo.com` for the favicon.
- `_content_security_policy()` serves `_DOCS_CSP` for `/docs` and `/redoc` HTML; everything else still gets the strict API CSP.
- `AGENT_BOM_DISABLE_DOCS=1` still removes the routes entirely in production.

## Verification

- `npm run typecheck` clean
- `pre-commit` (ruff/format/mypy/bandit/env-var-drift) green
- All three UI bugs reproduce trivially against `agent-bom api --allow-insecure-no-auth` + bundled UI; fixes verified via the live dev stack the user is running right now
- `/docs` CSP fix verified: `curl -sI /docs | grep CSP` shows the relaxed policy

## Why this gates v0.86.0

The release narrative leans on the supply-chain graph as the product moat. Shipping the tag with:
- the moat graph rendering as a help-text panel users can't escape,
- the page strobing when they get past the panel,
- the page being unscrollable so they never reach the React Flow canvas,
- and `/docs` rendering blank for any reviewer who clicks the API tab,

would torch the first-impression demo for any reviewer trying the dashboard against a fresh deploy. Four small fixes, same release.