### PR TITLE
fix(ci): graceful skip when AUTOMATION_SSH_SIGNING_KEY missing

### DIFF
--- a/.github/workflows/mcp-registry-sync.yml
+++ b/.github/workflows/mcp-registry-sync.yml
@@ -280,13 +280,20 @@ jobs:
           echo "cve_count=$(cat /tmp/cve_count 2>/dev/null || echo 0)" >> "$GITHUB_OUTPUT"
 
       - name: Configure signed automation commits
+        id: signing
         if: steps.count.outputs.new_count != '0' || steps.count.outputs.toolhive_count != '0' || steps.count.outputs.version_count != '0' || steps.count.outputs.cve_count != '0'
         env:
           AUTOMATION_SSH_SIGNING_KEY: ${{ secrets.AUTOMATION_SSH_SIGNING_KEY }}
         run: |
           if [ -z "$AUTOMATION_SSH_SIGNING_KEY" ]; then
-            echo "AUTOMATION_SSH_SIGNING_KEY is required for signed automation PRs." >&2
-            exit 1
+            # Graceful skip: scheduled runs on repos without the signing
+            # secret previously hard-failed daily.  Skip the PR-create
+            # step and exit successfully so the cron stops alerting.
+            # Repos that want signed automation PRs can set the secret
+            # per docs/AUTOMATION_SIGNING.md and the next run will sign.
+            echo "AUTOMATION_SSH_SIGNING_KEY not configured — skipping PR creation."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           mkdir -p "$HOME/.ssh"
           printf '%s\n' "$AUTOMATION_SSH_SIGNING_KEY" > "$HOME/.ssh/automation_signing_key"
@@ -299,9 +306,10 @@ jobs:
           git config gpg.format ssh
           git config user.signingkey "$HOME/.ssh/automation_signing_key.pub"
           git config commit.gpgsign true
+          echo "configured=true" >> "$GITHUB_OUTPUT"
 
       - name: Create PR if registry changed
-        if: steps.count.outputs.new_count != '0' || steps.count.outputs.toolhive_count != '0' || steps.count.outputs.version_count != '0' || steps.count.outputs.cve_count != '0'
+        if: (steps.count.outputs.new_count != '0' || steps.count.outputs.toolhive_count != '0' || steps.count.outputs.version_count != '0' || steps.count.outputs.cve_count != '0') && steps.signing.outputs.configured == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           NEW_COUNT: ${{ steps.count.outputs.new_count }}

--- a/.github/workflows/uv-lock-upgrade.yml
+++ b/.github/workflows/uv-lock-upgrade.yml
@@ -42,13 +42,20 @@ jobs:
           fi
 
       - name: Configure signed automation commits
+        id: signing
         if: steps.diff.outputs.changed == 'true'
         env:
           AUTOMATION_SSH_SIGNING_KEY: ${{ secrets.AUTOMATION_SSH_SIGNING_KEY }}
         run: |
           if [ -z "$AUTOMATION_SSH_SIGNING_KEY" ]; then
-            echo "AUTOMATION_SSH_SIGNING_KEY is required for signed automation PRs." >&2
-            exit 1
+            # Graceful skip: scheduled runs on repos without the signing
+            # secret previously hard-failed daily.  Skip the PR-open step
+            # and exit successfully so the cron stops alerting.  Repos
+            # that want signed automation PRs can set the secret per
+            # docs/AUTOMATION_SIGNING.md and the next run will sign.
+            echo "AUTOMATION_SSH_SIGNING_KEY not configured — skipping PR creation."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           eval "$(ssh-agent -s)"
           ssh-add - <<< "$AUTOMATION_SSH_SIGNING_KEY"
@@ -63,9 +70,10 @@ jobs:
             echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK"
             echo "SSH_AGENT_PID=$SSH_AGENT_PID"
           } >> "$GITHUB_ENV"
+          echo "configured=true" >> "$GITHUB_OUTPUT"
 
       - name: Open PR if lockfile changed
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.diff.outputs.changed == 'true' && steps.signing.outputs.configured == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -97,7 +105,7 @@ jobs:
           fi
 
       - name: Stop signing agent
-        if: always() && steps.diff.outputs.changed == 'true'
+        if: always() && steps.diff.outputs.changed == 'true' && steps.signing.outputs.configured == 'true'
         run: |
           ssh-agent -k || true
 


### PR DESCRIPTION
## What you mentioned: "this failed in 6 am"

Two scheduled workflows hard-failed today (and every day) on \`main\` because the \`AUTOMATION_SSH_SIGNING_KEY\` secret isn't configured on this repo:

| Run | Workflow | When | Error |
|---|---|---|---|
| 25313260564 | Weekly uv.lock Upgrade | 2026-05-04T10:10Z | \`exit 1\` at signing step |
| 25314935171 | MCP Registry Sync | 2026-05-04T10:52Z | \`exit 1\` at signing step |

Both crashed at the **"Configure signed automation commits"** step before they could do anything useful. The hard-fail was correct in spirit (don't push unsigned automation PRs when signing is required) but treating the cron as broken-on-every-run created alert fatigue.

## Fix

`.github/workflows/uv-lock-upgrade.yml` and `.github/workflows/mcp-registry-sync.yml`:

- Add `id: signing` to the configure step so downstream steps can read its output.
- When the secret is missing: log `"skipping — secret not configured"`, set `configured=false`, **exit 0**.
- Gate the "Open/Create PR" step on `signing.outputs.configured == 'true'` so the workflow doesn't try `git commit -S` without a key.
- Gate the "Stop signing agent" cleanup on the same flag.

## Net behaviour

| Repo state | Before | After |
|---|---|---|
| **Secret set** | Workflow runs, opens signed PR | Unchanged — signed automation PRs continue |
| **Secret unset** | `exit 1` daily, alert fatigue | Logs skip, exits 0, no alert |

Configure the secret per `docs/AUTOMATION_SIGNING.md` to re-enable signed automation PRs — next scheduled run will sign.

## Verification

- [x] Both YAML files parse via `yaml.safe_load`
- [x] pre-commit (no linters apply to .yml)
- [ ] CI green
- [ ] Manual: trigger \`workflow_dispatch\` after merge to confirm the skip path