### PR TITLE
fix(ci): use msaad00 noreply email so SSH-signed automation commits verify

### DIFF
--- a/.github/workflows/mcp-registry-sync.yml
+++ b/.github/workflows/mcp-registry-sync.yml
@@ -302,7 +302,7 @@ jobs:
           eval "$(ssh-agent -s)"
           ssh-add "$HOME/.ssh/automation_signing_key"
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "34316639+msaad00@users.noreply.github.com"
           git config gpg.format ssh
           git config user.signingkey "$HOME/.ssh/automation_signing_key.pub"
           git config commit.gpgsign true

--- a/.github/workflows/uv-lock-upgrade.yml
+++ b/.github/workflows/uv-lock-upgrade.yml
@@ -62,7 +62,7 @@ jobs:
           pubkey_path="$RUNNER_TEMP/automation_signing_key.pub"
           ssh-keygen -y -f <(printf '%s\n' "$AUTOMATION_SSH_SIGNING_KEY") > "$pubkey_path"
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "34316639+msaad00@users.noreply.github.com"
           git config gpg.format ssh
           git config user.signingkey "$pubkey_path"
           git config commit.gpgsign true


### PR DESCRIPTION
## Why \`#2249\` / \`#2250\` show "Unverified · unknown_key"

The signing PAIR is correctly set up:
- Private key sits in repo secret \`AUTOMATION_SSH_SIGNING_KEY\`.
- Public key is registered on **msaad00**'s GitHub account as a "signing" key.

But the commits the workflow produces set:

\`\`\`
user.email = "github-actions[bot]@users.noreply.github.com"
\`\`\`

That email is **not** on the msaad00 account. GitHub looks at the email on the commit, finds no GitHub user with that email + the matching key on file, and renders the badge as **Unverified · unknown_key** — even though the SSH signature is cryptographically valid.

## Fix (1 line per workflow)

Swap the commit email to msaad00's noreply form (which **is** on the account that holds the signing key):

\`\`\`diff
- git config user.email "github-actions[bot]@users.noreply.github.com"
+ git config user.email "34316639+msaad00@users.noreply.github.com"
\`\`\`

\`user.name\` stays as \`github-actions[bot]\` — bot attribution remains visible in the commit author column, only the email changes.

## After this lands

- Next scheduled / \`workflow_dispatch\` run produces commits authored as **github-actions[bot] <34316639+msaad00@users.noreply.github.com>** with the green **Verified** badge.
- Branch protection rules that require verified commits will accept automation PRs.
- Audit trail unchanged — the workflow that opened the PR is still recorded.

## Existing #2249 / #2250

They keep the old unverified commits. After this PR lands, re-run both workflows via \`workflow_dispatch\` — fresh PRs with verified signatures will appear, then close the old ones.

## Test plan

- [x] Both YAML files parse via \`yaml.safe_load\`
- [ ] CI green
- [ ] After merge: \`gh workflow run "Weekly uv.lock Upgrade" --ref main\` and \`gh workflow run "MCP Registry Sync" --ref main\`; verify the resulting commits show \`verified=true\` via \`gh api .../commits --jq '.[].commit.verification'\`