### PR TITLE
fix: final 14→15 framework drift in MCP server help + compliance route docstring

### DIFF
--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -1,7 +1,7 @@
 """Compliance and posture API routes.
 
 Endpoints:
-    GET  /v1/compliance                      14-framework compliance posture + AISVS benchmark
+    GET  /v1/compliance                      15-framework compliance posture + AISVS benchmark
     GET  /v1/compliance/aisvs                OWASP AISVS benchmark posture
     GET  /v1/compliance/narrative            full compliance narrative (all frameworks)
     GET  /v1/compliance/narrative/{framework} single-framework narrative
@@ -1509,9 +1509,10 @@ async def get_hub_posture(request: Request) -> dict:
 
     # Native sources: count blast radii from completed scan jobs as a
     # proxy for "native finding count per framework" using their tag fields.
-    # Driven by TAG_MAPPED_FRAMEWORKS so all 14 frameworks (owasp-llm, owasp-mcp,
-    # owasp-agentic, atlas, nist, nist-csf, nist-800-53, fedramp, eu-ai-act,
-    # iso-27001, soc2, cis, cmmc, pci-dss) aggregate consistently. Slug→field
+    # Driven by TAG_MAPPED_FRAMEWORKS so all 15 frameworks (owasp-llm, owasp-mcp,
+    # owasp-agentic, atlas, attack, nist, nist-csf, nist-800-53, fedramp,
+    # eu-ai-act, iso-27001, soc2, cis, cmmc, pci-dss) aggregate consistently.
+    # Slug→field
     # is NOT a pure replace (e.g. nist → nist_ai_rmf_tags), so we read the
     # canonical mapping straight off the metadata.
     slug_to_tag_field: tuple[tuple[str, str], ...] = tuple((metadata.slug, metadata.tag_field) for metadata in TAG_MAPPED_FRAMEWORKS)

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -681,7 +681,7 @@ def mcp_server_cmd(
       policy_check           Evaluate policy rules against scan findings
       registry_lookup        Query MCP server security metadata registry
       generate_sbom          Generate CycloneDX or SPDX SBOM
-      compliance             14-framework compliance posture
+      compliance             15-framework compliance posture
       remediate              Generate actionable remediation plan
       skill_scan             Scan instruction files for trust, provenance, and findings
       skill_verify           Verify Sigstore provenance for instruction files


### PR DESCRIPTION
Three remaining "14 framework" string drifts caught by the post-merge fresh audit on \`d1128bda\`. The earlier 14→15 sweep missed these because they live in **source comments / help text** rather than docs files:

## Changes

\`src/agent_bom/cli/_server.py:684\`
MCP server help banner advertised \`14-framework compliance posture\` — this is what customers see when they invoke the agent-bom MCP server metadata. Bump to 15.

\`src/agent_bom/api/routes/compliance.py:4\`
Module docstring lists routes including \`14-framework compliance posture + AISVS benchmark\` — also surfaces via the auto-generated OpenAPI tag descriptions on \`/docs\`. Bump to 15.

\`src/agent_bom/api/routes/compliance.py:1512\`
Inline comment claimed \`all 15 frameworks\` but the comma-separated list right after only had 14 entries (missing \`attack\`). Added \`attack\` to the list so the prose matches the actual \`TAG_MAPPED_FRAMEWORKS\` tuple driving the loop below.

## Why this matters for v0.86.0

The MCP server help text is a **customer-facing surface** — when a Snowflake / enterprise reviewer runs \`agent-bom mcp-server\` and sees \`14-framework compliance posture\`, the count contradicts every other surface (README, SVGs, dashboard, CHANGELOG) that the prior sweep aligned at 15. Three more lines, same release, no runtime behaviour change.

## Verification

- [x] \`grep -rnE "all 14 framework|14-framework|14 tag-mapped" src/ docs/ site-docs/ README.md | grep -v archive\` → empty
- [x] \`agent_bom.api.routes.compliance\` import clean
- [x] pre-commit (ruff/format/mypy/bandit/env-var-drift) green
- [ ] CI green