### PR TITLE
feat(graph): typed schema codegen — Python Pydantic → TypeScript single source of truth (#2255)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,48 @@ jobs:
           cd ui
           npm run headers:check
 
+      - name: Set up Python for graph schema codegen
+        uses: ./.github/actions/setup-python
+        with:
+          python-version: '3.11'
+
+      - name: Install API dependencies for graph schema codegen
+        run: uv sync --frozen --extra dev --extra api
+
+      - name: Graph schema codegen — Python ↔ TypeScript drift gate
+        # Source of truth: agent_bom.graph.types (#2255).
+        # Boots the API on a fresh port, regenerates ui/lib/graph-schema
+        # .generated.ts, and fails the build if the checked-in copy drifts.
+        # The error message tells the dev to run the codegen locally.
+        run: |
+          set -euo pipefail
+          uv run uvicorn agent_bom.api.server:app \
+            --host 127.0.0.1 --port 8422 --log-level warning \
+            > /tmp/codegen-api.log 2>&1 &
+          API_PID=$!
+          trap 'kill "$API_PID" 2>/dev/null || true' EXIT
+          for _ in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:8422/health >/dev/null 2>&1; then
+              break
+            fi
+            sleep 0.5
+          done
+          if ! curl -fsS http://127.0.0.1:8422/health >/dev/null 2>&1; then
+            echo "::error::API never became ready on 127.0.0.1:8422 — cannot run graph-schema codegen drift gate"
+            tail -n 50 /tmp/codegen-api.log || true
+            exit 1
+          fi
+          cd ui
+          AGENT_BOM_GRAPH_SCHEMA_URL=http://127.0.0.1:8422/v1/graph/schema \
+            npm run codegen:graph-schema
+          if ! git diff --exit-code lib/graph-schema.generated.ts; then
+            echo ""
+            echo "::error::ui/lib/graph-schema.generated.ts is out of date relative to /v1/graph/schema."
+            echo "Run \`cd ui && npm run codegen:graph-schema\` locally and commit the result."
+            echo "Issue: https://github.com/msaad00/agent-bom/issues/2255"
+            exit 1
+          fi
+
       - name: UI tests
         run: |
           cd ui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           if printf '%s\n' "$changed" | grep -Eq '^(src/agent_bom/api/postgres_|src/agent_bom/api/storage_schema\.py|tests/test_postgres_|\.github/workflows/ci\.yml$)'; then
             postgres=true
           fi
-          if printf '%s\n' "$changed" | grep -Eq '^(ui/|action\.yml|contracts/|src/agent_bom/api/(routes/|models\.py|server\.py)|src/agent_bom/models\.py|\.github/workflows/ci\.yml$)'; then
+          if printf '%s\n' "$changed" | grep -Eq '^(ui/|action\.yml|contracts/|src/agent_bom/(api/(routes/|models\.py|server\.py)|graph/|context_graph\.py|graph_schema\.py)|src/agent_bom/models\.py|\.github/workflows/ci\.yml$)'; then
             ui=true
           fi
           echo "action=${action}" >> "$GITHUB_OUTPUT"

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -11,6 +11,7 @@ Endpoints:
   GET  /v1/graph/node/{id}      — single node detail with edges + impact
   GET  /v1/graph/snapshots      — list persisted scan snapshots
   GET  /v1/graph/legend         — entity + relationship legends
+  GET  /v1/graph/schema         — canonical entity/edge taxonomy (codegen source)
   POST /v1/graph/presets        — save a filter preset
   GET  /v1/graph/presets        — list saved presets
   DEL  /v1/graph/presets/{name} — delete a preset
@@ -706,6 +707,70 @@ async def get_graph_legend() -> dict:
     return {
         "entities": [{"key": e.key, "label": e.label, "color": e.color, "shape": e.shape} for e in ENTITY_LEGEND],
         "relationships": [{"key": r.key, "label": r.label, "color": r.color} for r in RELATIONSHIP_LEGEND],
+    }
+
+
+# Map canonical "shape" hint → icon hint that the TS lineage-nodes module
+# understands.  Keeping the mapping server-side means the TypeScript codegen
+# stays a thin renderer; adding a new icon in lucide just means changing the
+# server map and re-running the codegen.
+_SHAPE_TO_ICON: dict[str, str] = {
+    "circle": "circle",
+    "diamond": "diamond",
+    "square": "square",
+    "triangle": "triangle",
+}
+
+
+@router.get("/v1/graph/schema", tags=["graph"])
+async def get_graph_schema() -> dict:
+    """Canonical graph entity/edge taxonomy — single source of truth.
+
+    Drives the TypeScript codegen at ``ui/scripts/codegen-graph-schema.mjs``,
+    which materialises ``ui/lib/graph-schema.generated.ts``.  CI fails the
+    build when the checked-in generated file drifts from what this endpoint
+    would emit, so adding a new ``EntityType`` or ``RelationshipType`` in
+    Python automatically forces a regen + commit on the UI side.
+    """
+    from agent_bom.graph import ENTITY_LEGEND, RELATIONSHIP_LEGEND
+    from agent_bom.graph.types import EntityType, RelationshipType
+
+    legend_entities = {entry.key: entry for entry in ENTITY_LEGEND}
+    legend_relationships = {entry.key: entry for entry in RELATIONSHIP_LEGEND}
+
+    node_kinds = []
+    for entity in EntityType:
+        legend = legend_entities.get(entity.value)
+        label = legend.label if legend else entity.value.replace("_", " ").title()
+        color = legend.color if legend else "#6b7280"
+        shape = legend.shape if legend else "circle"
+        node_kinds.append(
+            {
+                "key": entity.value,
+                "label": label,
+                "color": color,
+                "shape": shape,
+                "icon": _SHAPE_TO_ICON.get(shape, "circle"),
+            }
+        )
+
+    edge_kinds = []
+    for rel in RelationshipType:
+        legend = legend_relationships.get(rel.value)
+        label = legend.label if legend else rel.value.replace("_", " ").title()
+        color = legend.color if legend else "#6b7280"
+        edge_kinds.append(
+            {
+                "key": rel.value,
+                "label": label,
+                "color": color,
+            }
+        )
+
+    return {
+        "version": 1,
+        "node_kinds": sorted(node_kinds, key=lambda d: d["key"]),
+        "edge_kinds": sorted(edge_kinds, key=lambda d: d["key"]),
     }
 
 

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -722,6 +722,185 @@ _SHAPE_TO_ICON: dict[str, str] = {
 }
 
 
+_RELATIONSHIP_SCHEMA_META: dict[str, dict[str, object]] = {
+    RelationshipType.HOSTS.value: {
+        "category": "inventory",
+        "direction": "directed",
+        "source_types": [EntityType.PROVIDER.value, EntityType.ENVIRONMENT.value, EntityType.FLEET.value],
+        "target_types": [EntityType.AGENT.value, EntityType.SERVER.value],
+        "traversable": True,
+    },
+    RelationshipType.USES.value: {
+        "category": "inventory",
+        "direction": "directed",
+        "source_types": [EntityType.AGENT.value],
+        "target_types": [EntityType.SERVER.value],
+        "traversable": True,
+    },
+    RelationshipType.DEPENDS_ON.value: {
+        "category": "inventory",
+        "direction": "directed",
+        "source_types": [EntityType.SERVER.value, EntityType.CONTAINER.value],
+        "target_types": [EntityType.PACKAGE.value],
+        "traversable": True,
+    },
+    RelationshipType.PROVIDES_TOOL.value: {
+        "category": "inventory",
+        "direction": "directed",
+        "source_types": [EntityType.SERVER.value],
+        "target_types": [EntityType.TOOL.value],
+        "traversable": True,
+    },
+    RelationshipType.EXPOSES_CRED.value: {
+        "category": "inventory",
+        "direction": "directed",
+        "source_types": [EntityType.SERVER.value, EntityType.AGENT.value],
+        "target_types": [EntityType.CREDENTIAL.value],
+        "traversable": True,
+    },
+    RelationshipType.REACHES_TOOL.value: {
+        "category": "inventory",
+        "direction": "directed",
+        "source_types": [EntityType.CREDENTIAL.value, EntityType.AGENT.value],
+        "target_types": [EntityType.TOOL.value],
+        "traversable": True,
+    },
+    RelationshipType.SERVES_MODEL.value: {
+        "category": "inventory",
+        "direction": "directed",
+        "source_types": [EntityType.SERVER.value],
+        "target_types": [EntityType.MODEL.value],
+        "traversable": True,
+    },
+    RelationshipType.CONTAINS.value: {
+        "category": "inventory",
+        "direction": "directed",
+        "source_types": [EntityType.CONTAINER.value, EntityType.CLUSTER.value, EntityType.FLEET.value],
+        "target_types": [EntityType.PACKAGE.value, EntityType.SERVER.value, EntityType.CONTAINER.value],
+        "traversable": True,
+    },
+    RelationshipType.AFFECTS.value: {
+        "category": "vulnerability",
+        "direction": "directed",
+        "source_types": [EntityType.VULNERABILITY.value, EntityType.MISCONFIGURATION.value],
+        "target_types": [EntityType.PACKAGE.value, EntityType.SERVER.value, EntityType.CONTAINER.value],
+        "traversable": True,
+    },
+    RelationshipType.VULNERABLE_TO.value: {
+        "category": "vulnerability",
+        "direction": "directed",
+        "source_types": [EntityType.PACKAGE.value, EntityType.SERVER.value, EntityType.CONTAINER.value],
+        "target_types": [EntityType.VULNERABILITY.value],
+        "traversable": True,
+    },
+    RelationshipType.EXPLOITABLE_VIA.value: {
+        "category": "vulnerability",
+        "direction": "directed",
+        "source_types": [EntityType.VULNERABILITY.value, EntityType.MISCONFIGURATION.value],
+        "target_types": [EntityType.TOOL.value, EntityType.CREDENTIAL.value],
+        "traversable": True,
+    },
+    RelationshipType.REMEDIATES.value: {
+        "category": "vulnerability",
+        "direction": "directed",
+        "source_types": [EntityType.PACKAGE.value],
+        "target_types": [EntityType.VULNERABILITY.value, EntityType.MISCONFIGURATION.value],
+        "traversable": False,
+    },
+    RelationshipType.TRIGGERS.value: {
+        "category": "vulnerability",
+        "direction": "directed",
+        "source_types": [EntityType.VULNERABILITY.value],
+        "target_types": [EntityType.MISCONFIGURATION.value],
+        "traversable": True,
+    },
+    RelationshipType.SHARES_SERVER.value: {
+        "category": "lateral_movement",
+        "direction": "bidirectional",
+        "source_types": [EntityType.AGENT.value],
+        "target_types": [EntityType.AGENT.value],
+        "traversable": True,
+    },
+    RelationshipType.SHARES_CRED.value: {
+        "category": "lateral_movement",
+        "direction": "bidirectional",
+        "source_types": [EntityType.AGENT.value],
+        "target_types": [EntityType.AGENT.value],
+        "traversable": True,
+    },
+    RelationshipType.LATERAL_PATH.value: {
+        "category": "lateral_movement",
+        "direction": "directed",
+        "source_types": [EntityType.AGENT.value],
+        "target_types": [EntityType.AGENT.value],
+        "traversable": True,
+    },
+    RelationshipType.MANAGES.value: {
+        "category": "governance",
+        "direction": "directed",
+        "source_types": [EntityType.USER.value, EntityType.GROUP.value, EntityType.SERVICE_ACCOUNT.value],
+        "target_types": [EntityType.AGENT.value, EntityType.FLEET.value, EntityType.ENVIRONMENT.value],
+        "traversable": True,
+    },
+    RelationshipType.OWNS.value: {
+        "category": "governance",
+        "direction": "directed",
+        "source_types": [EntityType.USER.value, EntityType.GROUP.value, EntityType.SERVICE_ACCOUNT.value],
+        "target_types": [EntityType.ENVIRONMENT.value, EntityType.CLOUD_RESOURCE.value, EntityType.AGENT.value],
+        "traversable": True,
+    },
+    RelationshipType.PART_OF.value: {
+        "category": "governance",
+        "direction": "directed",
+        "source_types": [EntityType.AGENT.value, EntityType.SERVER.value, EntityType.CONTAINER.value],
+        "target_types": [EntityType.FLEET.value, EntityType.CLUSTER.value, EntityType.ENVIRONMENT.value],
+        "traversable": True,
+    },
+    RelationshipType.MEMBER_OF.value: {
+        "category": "governance",
+        "direction": "directed",
+        "source_types": [EntityType.USER.value, EntityType.SERVICE_ACCOUNT.value, EntityType.AGENT.value],
+        "target_types": [EntityType.GROUP.value, EntityType.AGENT.value, EntityType.FLEET.value],
+        "traversable": True,
+    },
+    RelationshipType.INVOKED.value: {
+        "category": "runtime",
+        "direction": "directed",
+        "source_types": [EntityType.AGENT.value],
+        "target_types": [EntityType.TOOL.value],
+        "traversable": True,
+    },
+    RelationshipType.ACCESSED.value: {
+        "category": "runtime",
+        "direction": "directed",
+        "source_types": [EntityType.TOOL.value],
+        "target_types": [EntityType.CLOUD_RESOURCE.value, EntityType.DATASET.value, EntityType.CREDENTIAL.value],
+        "traversable": True,
+    },
+    RelationshipType.DELEGATED_TO.value: {
+        "category": "runtime",
+        "direction": "directed",
+        "source_types": [EntityType.AGENT.value],
+        "target_types": [EntityType.AGENT.value],
+        "traversable": True,
+    },
+    RelationshipType.CORRELATES_WITH.value: {
+        "category": "correlation",
+        "direction": "bidirectional",
+        "source_types": [EntityType.AGENT.value, EntityType.SERVER.value],
+        "target_types": [EntityType.AGENT.value, EntityType.SERVER.value],
+        "traversable": True,
+    },
+    RelationshipType.POSSIBLY_CORRELATES_WITH.value: {
+        "category": "correlation",
+        "direction": "bidirectional",
+        "source_types": [EntityType.AGENT.value, EntityType.SERVER.value],
+        "target_types": [EntityType.AGENT.value, EntityType.SERVER.value],
+        "traversable": False,
+    },
+}
+
+
 @router.get("/v1/graph/schema", tags=["graph"])
 async def get_graph_schema() -> dict:
     """Canonical graph entity/edge taxonomy — single source of truth.
@@ -732,7 +911,7 @@ async def get_graph_schema() -> dict:
     would emit, so adding a new ``EntityType`` or ``RelationshipType`` in
     Python automatically forces a regen + commit on the UI side.
     """
-    from agent_bom.graph import ENTITY_LEGEND, RELATIONSHIP_LEGEND
+    from agent_bom.graph import ENTITY_LEGEND, ENTITY_OCSF_MAP, RELATIONSHIP_LEGEND
     from agent_bom.graph.types import EntityType, RelationshipType
 
     legend_entities = {entry.key: entry for entry in ENTITY_LEGEND}
@@ -751,6 +930,8 @@ async def get_graph_schema() -> dict:
                 "color": color,
                 "shape": shape,
                 "icon": _SHAPE_TO_ICON.get(shape, "circle"),
+                "category_uid": ENTITY_OCSF_MAP.get(entity.value, {}).get("category_uid", 0),
+                "class_uid": ENTITY_OCSF_MAP.get(entity.value, {}).get("class_uid", 0),
             }
         )
 
@@ -764,6 +945,16 @@ async def get_graph_schema() -> dict:
                 "key": rel.value,
                 "label": label,
                 "color": color,
+                **_RELATIONSHIP_SCHEMA_META.get(
+                    rel.value,
+                    {
+                        "category": "custom",
+                        "direction": "directed",
+                        "source_types": [],
+                        "target_types": [],
+                        "traversable": True,
+                    },
+                ),
             }
         )
 

--- a/src/agent_bom/graph/compat.py
+++ b/src/agent_bom/graph/compat.py
@@ -11,6 +11,10 @@ NODE_KIND_TO_ENTITY: dict[str, EntityType] = {
     "credential": EntityType.CREDENTIAL,
     "tool": EntityType.TOOL,
     "vulnerability": EntityType.VULNERABILITY,
+    # Legacy context_graph exposes cloud IAM / workload identities as
+    # iam_role nodes. The canonical schema models those as service
+    # accounts so identity context survives conversion to UnifiedGraph.
+    "iam_role": EntityType.SERVICE_ACCOUNT,
 }
 
 # Map old EdgeKind values → RelationshipType
@@ -21,4 +25,8 @@ EDGE_KIND_TO_RELATIONSHIP: dict[str, RelationshipType] = {
     "vulnerable_to": RelationshipType.VULNERABLE_TO,
     "shares_server": RelationshipType.SHARES_SERVER,
     "shares_credential": RelationshipType.SHARES_CRED,
+    # Legacy iam_role -> agent attachment bridges to canonical identity
+    # membership. Keeping this mapping avoids silently dropping identity
+    # edges during to_unified_graph().
+    "attached_to": RelationshipType.MEMBER_OF,
 }

--- a/src/agent_bom/graph/types.py
+++ b/src/agent_bom/graph/types.py
@@ -54,8 +54,8 @@ class RelationshipType(str, Enum):
     AFFECTS = "affects"  # vulnerability → package (reverse)
     VULNERABLE_TO = "vulnerable_to"  # package/server → vulnerability
     EXPLOITABLE_VIA = "exploitable_via"  # vulnerability → tool/credential
-    REMEDIATES = "remediates"  # fix_version → vulnerability
-    TRIGGERS = "triggers"  # vulnerability → toxic_combination
+    REMEDIATES = "remediates"  # package/fixed package → vulnerability
+    TRIGGERS = "triggers"  # vulnerability → misconfiguration/risk condition
 
     # ── Lateral movement (computed) ──
     SHARES_SERVER = "shares_server"  # agent ↔ agent

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -1043,3 +1043,110 @@ class TestGraphFilterOptions:
         sub = g.filtered_view(filters)
         # Only critical vuln node should pass
         assert len(sub.nodes) == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# /v1/graph/schema endpoint — codegen contract for the TypeScript dashboard
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestGraphSchemaEndpoint:
+    """Regression tests for the codegen contract introduced in #2255.
+
+    The TypeScript dashboard calls ``GET /v1/graph/schema`` to materialise
+    ``ui/lib/graph-schema.generated.ts`` at build time. CI fails the build if
+    that file drifts. These tests pin the contract on the Python side so the
+    UI never silently drops nodes of a freshly-added kind.
+    """
+
+    def _client(self):
+        from fastapi.testclient import TestClient
+
+        from agent_bom.api.server import app
+
+        return TestClient(app)
+
+    def test_schema_endpoint_returns_canonical_taxonomy(self):
+        client = self._client()
+        resp = client.get("/v1/graph/schema")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert set(body) >= {"version", "node_kinds", "edge_kinds"}
+        assert isinstance(body["version"], int) and body["version"] >= 1
+        assert isinstance(body["node_kinds"], list) and body["node_kinds"]
+        assert isinstance(body["edge_kinds"], list) and body["edge_kinds"]
+
+    def test_schema_endpoint_lists_every_python_entity_and_relationship(self):
+        from agent_bom.graph.types import EntityType, RelationshipType
+
+        client = self._client()
+        body = client.get("/v1/graph/schema").json()
+        node_keys = {entry["key"] for entry in body["node_kinds"]}
+        edge_keys = {entry["key"] for entry in body["edge_kinds"]}
+        assert node_keys == {et.value for et in EntityType}
+        assert edge_keys == {rt.value for rt in RelationshipType}
+
+    def test_schema_entries_carry_label_color_shape_icon(self):
+        client = self._client()
+        body = client.get("/v1/graph/schema").json()
+        for entry in body["node_kinds"]:
+            assert {"key", "label", "color", "shape", "icon"} <= set(entry)
+            assert entry["color"].startswith("#")
+        for entry in body["edge_kinds"]:
+            assert {"key", "label", "color"} <= set(entry)
+            assert entry["color"].startswith("#")
+
+    def test_schema_endpoint_picks_up_new_node_kind(self, monkeypatch):
+        """If a new EntityType is added in Python, the schema endpoint must
+        surface it without any code change in the route handler — that is the
+        whole point of the codegen contract: drift is impossible because the
+        endpoint reflects the Python enum literally.
+        """
+        import enum
+
+        from agent_bom.graph import container as _container
+        from agent_bom.graph import types as _types
+
+        class _ExtendedEntityType(str, enum.Enum):
+            AGENT = "agent"
+            SERVER = "server"
+            PACKAGE = "package"
+            TOOL = "tool"
+            MODEL = "model"
+            DATASET = "dataset"
+            CONTAINER = "container"
+            CLOUD_RESOURCE = "cloud_resource"
+            VULNERABILITY = "vulnerability"
+            MISCONFIGURATION = "misconfiguration"
+            CREDENTIAL = "credential"
+            USER = "user"
+            GROUP = "group"
+            SERVICE_ACCOUNT = "service_account"
+            PROVIDER = "provider"
+            ENVIRONMENT = "environment"
+            FLEET = "fleet"
+            CLUSTER = "cluster"
+            # Hypothetical new kind, e.g. for #2256+ workflow.
+            FAKE_NEW_KIND = "fake_new_kind"
+
+        monkeypatch.setattr(_types, "EntityType", _ExtendedEntityType)
+
+        # The route handler imports EntityType from agent_bom.graph.types
+        # at call time, so the monkeypatch is observed without re-importing
+        # the module.
+        client = self._client()
+        body = client.get("/v1/graph/schema").json()
+        node_keys = {entry["key"] for entry in body["node_kinds"]}
+        assert "fake_new_kind" in node_keys, (
+            "Adding a new EntityType in Python must automatically appear in "
+            "GET /v1/graph/schema. If this fails, the route handler is "
+            "hard-coding the kind list instead of reflecting the enum."
+        )
+        # Even though the new kind has no legend entry, the endpoint must
+        # synthesise sane fallback metadata so the UI codegen does not crash.
+        new_entry = next(entry for entry in body["node_kinds"] if entry["key"] == "fake_new_kind")
+        assert new_entry["label"]
+        assert new_entry["color"].startswith("#")
+        assert new_entry["shape"] in {"circle", "diamond", "square", "triangle"}
+        # Silence flake8 for the unused alias — kept for future legend tests.
+        assert _container is not None

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -778,6 +778,30 @@ class TestContextGraphBridge:
         assert ug.attack_paths[0].composite_risk == 5.0
         assert ug.attack_paths[0].credential_exposure == ["API_KEY"]
 
+    def test_to_unified_graph_preserves_legacy_iam_identity_edges(self):
+        from agent_bom.context_graph import ContextGraph, EdgeKind, GraphEdge, GraphNode, NodeKind, to_unified_graph
+        from agent_bom.graph_schema import EntityType, RelationshipType
+
+        cg = ContextGraph()
+        cg.add_node(GraphNode(id="iam_role:role-a", kind=NodeKind.IAM_ROLE, label="role-a"))
+        cg.add_node(GraphNode(id="agent:agent-a", kind=NodeKind.AGENT, label="agent-a"))
+        cg.add_edge(
+            GraphEdge(
+                source="iam_role:role-a",
+                target="agent:agent-a",
+                kind=EdgeKind.ATTACHED_TO,
+            )
+        )
+
+        ug = to_unified_graph(cg, scan_id="identity-bridge")
+
+        role = ug.nodes["iam_role:role-a"]
+        assert role.entity_type == EntityType.SERVICE_ACCOUNT
+        assert any(
+            edge.relationship == RelationshipType.MEMBER_OF and edge.source == "iam_role:role-a" and edge.target == "agent:agent-a"
+            for edge in ug.edges
+        )
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # graph_backend bridge
@@ -821,9 +845,11 @@ class TestBackwardCompat:
 
         assert _NODE_KIND_TO_ENTITY["agent"] == EntityType.AGENT
         assert _NODE_KIND_TO_ENTITY["vulnerability"] == EntityType.VULNERABILITY
+        assert _NODE_KIND_TO_ENTITY["iam_role"] == EntityType.SERVICE_ACCOUNT
         assert _EDGE_KIND_TO_RELATIONSHIP["uses"] == RelationshipType.USES
         assert _EDGE_KIND_TO_RELATIONSHIP["exposes"] == RelationshipType.EXPOSES_CRED
         assert _EDGE_KIND_TO_RELATIONSHIP["shares_credential"] == RelationshipType.SHARES_CRED
+        assert _EDGE_KIND_TO_RELATIONSHIP["attached_to"] == RelationshipType.MEMBER_OF
 
     def test_context_graph_still_exports_old_types(self):
         """Existing consumers that import NodeKind etc. from context_graph still work."""
@@ -1090,11 +1116,41 @@ class TestGraphSchemaEndpoint:
         client = self._client()
         body = client.get("/v1/graph/schema").json()
         for entry in body["node_kinds"]:
-            assert {"key", "label", "color", "shape", "icon"} <= set(entry)
+            assert {"key", "label", "color", "shape", "icon", "category_uid", "class_uid"} <= set(entry)
             assert entry["color"].startswith("#")
+            assert isinstance(entry["category_uid"], int)
+            assert isinstance(entry["class_uid"], int)
         for entry in body["edge_kinds"]:
-            assert {"key", "label", "color"} <= set(entry)
+            assert {
+                "key",
+                "label",
+                "color",
+                "category",
+                "direction",
+                "source_types",
+                "target_types",
+                "traversable",
+            } <= set(entry)
             assert entry["color"].startswith("#")
+            assert entry["category"]
+            assert entry["direction"] in {"directed", "bidirectional"}
+            assert isinstance(entry["source_types"], list)
+            assert isinstance(entry["target_types"], list)
+            assert isinstance(entry["traversable"], bool)
+
+    def test_schema_relationship_metadata_uses_known_node_types(self):
+        from agent_bom.graph.types import EntityType, RelationshipType
+
+        client = self._client()
+        body = client.get("/v1/graph/schema").json()
+        valid_nodes = {entity.value for entity in EntityType}
+        for entry in body["edge_kinds"]:
+            assert set(entry["source_types"]) <= valid_nodes
+            assert set(entry["target_types"]) <= valid_nodes
+
+        edge_entries = {entry["key"]: entry for entry in body["edge_kinds"]}
+        for relationship in RelationshipType:
+            assert edge_entries[relationship.value]["category"] != "custom"
 
     def test_schema_endpoint_picks_up_new_node_kind(self, monkeypatch):
         """If a new EntityType is added in Python, the schema endpoint must

--- a/ui/lib/graph-schema.generated.ts
+++ b/ui/lib/graph-schema.generated.ts
@@ -41,6 +41,8 @@ export interface GraphNodeKindMeta {
   color: string;
   shape: string;
   icon: string;
+  category_uid: number;
+  class_uid: number;
 }
 
 export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> = {
@@ -48,109 +50,145 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "AI Agent",
     "color": "#10b981",
     "shape": "circle",
-    "icon": "circle"
+    "icon": "circle",
+    "category_uid": 5,
+    "class_uid": 4001
   },
   "cloud_resource": {
     "label": "Cloud Resource",
     "color": "#0ea5e9",
     "shape": "square",
-    "icon": "square"
+    "icon": "square",
+    "category_uid": 5,
+    "class_uid": 4001
   },
   "cluster": {
     "label": "Cluster",
     "color": "#4b5563",
     "shape": "square",
-    "icon": "square"
+    "icon": "square",
+    "category_uid": 5,
+    "class_uid": 4001
   },
   "container": {
     "label": "Container",
     "color": "#6366f1",
     "shape": "square",
-    "icon": "square"
+    "icon": "square",
+    "category_uid": 5,
+    "class_uid": 4001
   },
   "credential": {
     "label": "Credential",
     "color": "#f59e0b",
     "shape": "diamond",
-    "icon": "diamond"
+    "icon": "diamond",
+    "category_uid": 5,
+    "class_uid": 4001
   },
   "dataset": {
     "label": "Dataset",
     "color": "#06b6d4",
     "shape": "square",
-    "icon": "square"
+    "icon": "square",
+    "category_uid": 5,
+    "class_uid": 4001
   },
   "environment": {
     "label": "Environment",
     "color": "#9ca3af",
     "shape": "square",
-    "icon": "square"
+    "icon": "square",
+    "category_uid": 0,
+    "class_uid": 0
   },
   "fleet": {
     "label": "Fleet",
     "color": "#6b7280",
     "shape": "square",
-    "icon": "square"
+    "icon": "square",
+    "category_uid": 5,
+    "class_uid": 4001
   },
   "group": {
     "label": "Group",
     "color": "#0d9488",
     "shape": "circle",
-    "icon": "circle"
+    "icon": "circle",
+    "category_uid": 3,
+    "class_uid": 3001
   },
   "misconfiguration": {
     "label": "Misconfiguration",
     "color": "#f97316",
     "shape": "triangle",
-    "icon": "triangle"
+    "icon": "triangle",
+    "category_uid": 2,
+    "class_uid": 2003
   },
   "model": {
     "label": "Model",
     "color": "#8b5cf6",
     "shape": "square",
-    "icon": "square"
+    "icon": "square",
+    "category_uid": 5,
+    "class_uid": 4001
   },
   "package": {
     "label": "Package",
     "color": "#52525b",
     "shape": "square",
-    "icon": "square"
+    "icon": "square",
+    "category_uid": 5,
+    "class_uid": 4001
   },
   "provider": {
     "label": "Provider",
     "color": "#d1d5db",
     "shape": "square",
-    "icon": "square"
+    "icon": "square",
+    "category_uid": 0,
+    "class_uid": 0
   },
   "server": {
     "label": "MCP Server",
     "color": "#3b82f6",
     "shape": "circle",
-    "icon": "circle"
+    "icon": "circle",
+    "category_uid": 5,
+    "class_uid": 4001
   },
   "service_account": {
     "label": "Service Account",
     "color": "#0f766e",
     "shape": "circle",
-    "icon": "circle"
+    "icon": "circle",
+    "category_uid": 3,
+    "class_uid": 3001
   },
   "tool": {
     "label": "Tool",
     "color": "#a855f7",
     "shape": "diamond",
-    "icon": "diamond"
+    "icon": "diamond",
+    "category_uid": 5,
+    "class_uid": 4001
   },
   "user": {
     "label": "User",
     "color": "#14b8a6",
     "shape": "circle",
-    "icon": "circle"
+    "icon": "circle",
+    "category_uid": 3,
+    "class_uid": 3001
   },
   "vulnerability": {
     "label": "Vulnerability",
     "color": "#ef4444",
     "shape": "triangle",
-    "icon": "triangle"
+    "icon": "triangle",
+    "category_uid": 2,
+    "class_uid": 2001
   },
 };
 
@@ -193,108 +231,378 @@ export const GRAPH_EDGE_KINDS: readonly GraphEdgeKindKey[] = ["accessed", "affec
 export interface GraphEdgeKindMeta {
   label: string;
   color: string;
+  category: string;
+  direction: "directed" | "bidirectional";
+  source_types: readonly GraphNodeKindKey[];
+  target_types: readonly GraphNodeKindKey[];
+  traversable: boolean;
 }
 
 export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> = {
   "accessed": {
     "label": "Accessed (runtime)",
-    "color": "#3b82f6"
+    "color": "#3b82f6",
+    "category": "runtime",
+    "direction": "directed",
+    "source_types": [
+      "tool"
+    ],
+    "target_types": [
+      "cloud_resource",
+      "dataset",
+      "credential"
+    ],
+    "traversable": true
   },
   "affects": {
     "label": "Affects",
-    "color": "#dc2626"
+    "color": "#dc2626",
+    "category": "vulnerability",
+    "direction": "directed",
+    "source_types": [
+      "vulnerability",
+      "misconfiguration"
+    ],
+    "target_types": [
+      "package",
+      "server",
+      "container"
+    ],
+    "traversable": true
   },
   "contains": {
     "label": "Contains",
-    "color": "#6366f1"
+    "color": "#6366f1",
+    "category": "inventory",
+    "direction": "directed",
+    "source_types": [
+      "container",
+      "cluster",
+      "fleet"
+    ],
+    "target_types": [
+      "package",
+      "server",
+      "container"
+    ],
+    "traversable": true
   },
   "correlates_with": {
     "label": "Correlates With (cross-env)",
-    "color": "#0ea5e9"
+    "color": "#0ea5e9",
+    "category": "correlation",
+    "direction": "bidirectional",
+    "source_types": [
+      "agent",
+      "server"
+    ],
+    "target_types": [
+      "agent",
+      "server"
+    ],
+    "traversable": true
   },
   "delegated_to": {
     "label": "Delegated To (runtime)",
-    "color": "#a855f7"
+    "color": "#a855f7",
+    "category": "runtime",
+    "direction": "directed",
+    "source_types": [
+      "agent"
+    ],
+    "target_types": [
+      "agent"
+    ],
+    "traversable": true
   },
   "depends_on": {
     "label": "Depends On",
-    "color": "#52525b"
+    "color": "#52525b",
+    "category": "inventory",
+    "direction": "directed",
+    "source_types": [
+      "server",
+      "container"
+    ],
+    "target_types": [
+      "package"
+    ],
+    "traversable": true
   },
   "exploitable_via": {
     "label": "Exploitable Via",
-    "color": "#b91c1c"
+    "color": "#b91c1c",
+    "category": "vulnerability",
+    "direction": "directed",
+    "source_types": [
+      "vulnerability",
+      "misconfiguration"
+    ],
+    "target_types": [
+      "tool",
+      "credential"
+    ],
+    "traversable": true
   },
   "exposes_cred": {
     "label": "Exposes Credential",
-    "color": "#f59e0b"
+    "color": "#f59e0b",
+    "category": "inventory",
+    "direction": "directed",
+    "source_types": [
+      "server",
+      "agent"
+    ],
+    "target_types": [
+      "credential"
+    ],
+    "traversable": true
   },
   "hosts": {
     "label": "Hosts",
-    "color": "#6b7280"
+    "color": "#6b7280",
+    "category": "inventory",
+    "direction": "directed",
+    "source_types": [
+      "provider",
+      "environment",
+      "fleet"
+    ],
+    "target_types": [
+      "agent",
+      "server"
+    ],
+    "traversable": true
   },
   "invoked": {
     "label": "Invoked (runtime)",
-    "color": "#10b981"
+    "color": "#10b981",
+    "category": "runtime",
+    "direction": "directed",
+    "source_types": [
+      "agent"
+    ],
+    "target_types": [
+      "tool"
+    ],
+    "traversable": true
   },
   "lateral_path": {
     "label": "Lateral Path",
-    "color": "#ea580c"
+    "color": "#ea580c",
+    "category": "lateral_movement",
+    "direction": "directed",
+    "source_types": [
+      "agent"
+    ],
+    "target_types": [
+      "agent"
+    ],
+    "traversable": true
   },
   "manages": {
     "label": "Manages",
-    "color": "#14b8a6"
+    "color": "#14b8a6",
+    "category": "governance",
+    "direction": "directed",
+    "source_types": [
+      "user",
+      "group",
+      "service_account"
+    ],
+    "target_types": [
+      "agent",
+      "fleet",
+      "environment"
+    ],
+    "traversable": true
   },
   "member_of": {
     "label": "Member Of",
-    "color": "#4b5563"
+    "color": "#4b5563",
+    "category": "governance",
+    "direction": "directed",
+    "source_types": [
+      "user",
+      "service_account",
+      "agent"
+    ],
+    "target_types": [
+      "group",
+      "agent",
+      "fleet"
+    ],
+    "traversable": true
   },
   "owns": {
     "label": "Owns",
-    "color": "#0d9488"
+    "color": "#0d9488",
+    "category": "governance",
+    "direction": "directed",
+    "source_types": [
+      "user",
+      "group",
+      "service_account"
+    ],
+    "target_types": [
+      "environment",
+      "cloud_resource",
+      "agent"
+    ],
+    "traversable": true
   },
   "part_of": {
     "label": "Part Of",
-    "color": "#6b7280"
+    "color": "#6b7280",
+    "category": "governance",
+    "direction": "directed",
+    "source_types": [
+      "agent",
+      "server",
+      "container"
+    ],
+    "target_types": [
+      "fleet",
+      "cluster",
+      "environment"
+    ],
+    "traversable": true
   },
   "possibly_correlates_with": {
     "label": "Possibly Correlates With (low confidence)",
-    "color": "#7dd3fc"
+    "color": "#7dd3fc",
+    "category": "correlation",
+    "direction": "bidirectional",
+    "source_types": [
+      "agent",
+      "server"
+    ],
+    "target_types": [
+      "agent",
+      "server"
+    ],
+    "traversable": false
   },
   "provides_tool": {
     "label": "Provides Tool",
-    "color": "#a855f7"
+    "color": "#a855f7",
+    "category": "inventory",
+    "direction": "directed",
+    "source_types": [
+      "server"
+    ],
+    "target_types": [
+      "tool"
+    ],
+    "traversable": true
   },
   "reaches_tool": {
     "label": "Credential Reaches Tool",
-    "color": "#fbbf24"
+    "color": "#fbbf24",
+    "category": "inventory",
+    "direction": "directed",
+    "source_types": [
+      "credential",
+      "agent"
+    ],
+    "target_types": [
+      "tool"
+    ],
+    "traversable": true
   },
   "remediates": {
     "label": "Remediates",
-    "color": "#22c55e"
+    "color": "#22c55e",
+    "category": "vulnerability",
+    "direction": "directed",
+    "source_types": [
+      "package"
+    ],
+    "target_types": [
+      "vulnerability",
+      "misconfiguration"
+    ],
+    "traversable": false
   },
   "serves_model": {
     "label": "Serves Model",
-    "color": "#8b5cf6"
+    "color": "#8b5cf6",
+    "category": "inventory",
+    "direction": "directed",
+    "source_types": [
+      "server"
+    ],
+    "target_types": [
+      "model"
+    ],
+    "traversable": true
   },
   "shares_cred": {
     "label": "Shares Credential",
-    "color": "#f97316"
+    "color": "#f97316",
+    "category": "lateral_movement",
+    "direction": "bidirectional",
+    "source_types": [
+      "agent"
+    ],
+    "target_types": [
+      "agent"
+    ],
+    "traversable": true
   },
   "shares_server": {
     "label": "Shares Server",
-    "color": "#22d3ee"
+    "color": "#22d3ee",
+    "category": "lateral_movement",
+    "direction": "bidirectional",
+    "source_types": [
+      "agent"
+    ],
+    "target_types": [
+      "agent"
+    ],
+    "traversable": true
   },
   "triggers": {
     "label": "Triggers",
-    "color": "#f97316"
+    "color": "#f97316",
+    "category": "vulnerability",
+    "direction": "directed",
+    "source_types": [
+      "vulnerability"
+    ],
+    "target_types": [
+      "misconfiguration"
+    ],
+    "traversable": true
   },
   "uses": {
     "label": "Uses",
-    "color": "#10b981"
+    "color": "#10b981",
+    "category": "inventory",
+    "direction": "directed",
+    "source_types": [
+      "agent"
+    ],
+    "target_types": [
+      "server"
+    ],
+    "traversable": true
   },
   "vulnerable_to": {
     "label": "Vulnerable To",
-    "color": "#ef4444"
+    "color": "#ef4444",
+    "category": "vulnerability",
+    "direction": "directed",
+    "source_types": [
+      "package",
+      "server",
+      "container"
+    ],
+    "target_types": [
+      "vulnerability"
+    ],
+    "traversable": true
   },
 };
 

--- a/ui/lib/graph-schema.generated.ts
+++ b/ui/lib/graph-schema.generated.ts
@@ -1,0 +1,317 @@
+// AUTO-GENERATED — do not edit. Run `npm run codegen:graph-schema` to refresh.
+//
+// Source of truth: agent_bom.graph.types.EntityType + RelationshipType.
+// The Python API at GET /v1/graph/schema is the canonical taxonomy; this
+// file is materialised by ui/scripts/codegen-graph-schema.mjs and the CI
+// "UI Validate" job fails when it drifts (see #2255).
+
+export const GRAPH_SCHEMA_VERSION = 1 as const;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Node kinds (entity types)
+// ═══════════════════════════════════════════════════════════════════════════
+
+export enum GraphNodeKind {
+  AGENT = "agent",
+  CLOUD_RESOURCE = "cloud_resource",
+  CLUSTER = "cluster",
+  CONTAINER = "container",
+  CREDENTIAL = "credential",
+  DATASET = "dataset",
+  ENVIRONMENT = "environment",
+  FLEET = "fleet",
+  GROUP = "group",
+  MISCONFIGURATION = "misconfiguration",
+  MODEL = "model",
+  PACKAGE = "package",
+  PROVIDER = "provider",
+  SERVER = "server",
+  SERVICE_ACCOUNT = "service_account",
+  TOOL = "tool",
+  USER = "user",
+  VULNERABILITY = "vulnerability",
+}
+
+export type GraphNodeKindKey = "agent" | "cloud_resource" | "cluster" | "container" | "credential" | "dataset" | "environment" | "fleet" | "group" | "misconfiguration" | "model" | "package" | "provider" | "server" | "service_account" | "tool" | "user" | "vulnerability";
+
+export const GRAPH_NODE_KINDS: readonly GraphNodeKindKey[] = ["agent", "cloud_resource", "cluster", "container", "credential", "dataset", "environment", "fleet", "group", "misconfiguration", "model", "package", "provider", "server", "service_account", "tool", "user", "vulnerability"] as const;
+
+export interface GraphNodeKindMeta {
+  label: string;
+  color: string;
+  shape: string;
+  icon: string;
+}
+
+export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> = {
+  "agent": {
+    "label": "AI Agent",
+    "color": "#10b981",
+    "shape": "circle",
+    "icon": "circle"
+  },
+  "cloud_resource": {
+    "label": "Cloud Resource",
+    "color": "#0ea5e9",
+    "shape": "square",
+    "icon": "square"
+  },
+  "cluster": {
+    "label": "Cluster",
+    "color": "#4b5563",
+    "shape": "square",
+    "icon": "square"
+  },
+  "container": {
+    "label": "Container",
+    "color": "#6366f1",
+    "shape": "square",
+    "icon": "square"
+  },
+  "credential": {
+    "label": "Credential",
+    "color": "#f59e0b",
+    "shape": "diamond",
+    "icon": "diamond"
+  },
+  "dataset": {
+    "label": "Dataset",
+    "color": "#06b6d4",
+    "shape": "square",
+    "icon": "square"
+  },
+  "environment": {
+    "label": "Environment",
+    "color": "#9ca3af",
+    "shape": "square",
+    "icon": "square"
+  },
+  "fleet": {
+    "label": "Fleet",
+    "color": "#6b7280",
+    "shape": "square",
+    "icon": "square"
+  },
+  "group": {
+    "label": "Group",
+    "color": "#0d9488",
+    "shape": "circle",
+    "icon": "circle"
+  },
+  "misconfiguration": {
+    "label": "Misconfiguration",
+    "color": "#f97316",
+    "shape": "triangle",
+    "icon": "triangle"
+  },
+  "model": {
+    "label": "Model",
+    "color": "#8b5cf6",
+    "shape": "square",
+    "icon": "square"
+  },
+  "package": {
+    "label": "Package",
+    "color": "#52525b",
+    "shape": "square",
+    "icon": "square"
+  },
+  "provider": {
+    "label": "Provider",
+    "color": "#d1d5db",
+    "shape": "square",
+    "icon": "square"
+  },
+  "server": {
+    "label": "MCP Server",
+    "color": "#3b82f6",
+    "shape": "circle",
+    "icon": "circle"
+  },
+  "service_account": {
+    "label": "Service Account",
+    "color": "#0f766e",
+    "shape": "circle",
+    "icon": "circle"
+  },
+  "tool": {
+    "label": "Tool",
+    "color": "#a855f7",
+    "shape": "diamond",
+    "icon": "diamond"
+  },
+  "user": {
+    "label": "User",
+    "color": "#14b8a6",
+    "shape": "circle",
+    "icon": "circle"
+  },
+  "vulnerability": {
+    "label": "Vulnerability",
+    "color": "#ef4444",
+    "shape": "triangle",
+    "icon": "triangle"
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Edge kinds (relationship types)
+// ═══════════════════════════════════════════════════════════════════════════
+
+export enum GraphEdgeKind {
+  ACCESSED = "accessed",
+  AFFECTS = "affects",
+  CONTAINS = "contains",
+  CORRELATES_WITH = "correlates_with",
+  DELEGATED_TO = "delegated_to",
+  DEPENDS_ON = "depends_on",
+  EXPLOITABLE_VIA = "exploitable_via",
+  EXPOSES_CRED = "exposes_cred",
+  HOSTS = "hosts",
+  INVOKED = "invoked",
+  LATERAL_PATH = "lateral_path",
+  MANAGES = "manages",
+  MEMBER_OF = "member_of",
+  OWNS = "owns",
+  PART_OF = "part_of",
+  POSSIBLY_CORRELATES_WITH = "possibly_correlates_with",
+  PROVIDES_TOOL = "provides_tool",
+  REACHES_TOOL = "reaches_tool",
+  REMEDIATES = "remediates",
+  SERVES_MODEL = "serves_model",
+  SHARES_CRED = "shares_cred",
+  SHARES_SERVER = "shares_server",
+  TRIGGERS = "triggers",
+  USES = "uses",
+  VULNERABLE_TO = "vulnerable_to",
+}
+
+export type GraphEdgeKindKey = "accessed" | "affects" | "contains" | "correlates_with" | "delegated_to" | "depends_on" | "exploitable_via" | "exposes_cred" | "hosts" | "invoked" | "lateral_path" | "manages" | "member_of" | "owns" | "part_of" | "possibly_correlates_with" | "provides_tool" | "reaches_tool" | "remediates" | "serves_model" | "shares_cred" | "shares_server" | "triggers" | "uses" | "vulnerable_to";
+
+export const GRAPH_EDGE_KINDS: readonly GraphEdgeKindKey[] = ["accessed", "affects", "contains", "correlates_with", "delegated_to", "depends_on", "exploitable_via", "exposes_cred", "hosts", "invoked", "lateral_path", "manages", "member_of", "owns", "part_of", "possibly_correlates_with", "provides_tool", "reaches_tool", "remediates", "serves_model", "shares_cred", "shares_server", "triggers", "uses", "vulnerable_to"] as const;
+
+export interface GraphEdgeKindMeta {
+  label: string;
+  color: string;
+}
+
+export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> = {
+  "accessed": {
+    "label": "Accessed (runtime)",
+    "color": "#3b82f6"
+  },
+  "affects": {
+    "label": "Affects",
+    "color": "#dc2626"
+  },
+  "contains": {
+    "label": "Contains",
+    "color": "#6366f1"
+  },
+  "correlates_with": {
+    "label": "Correlates With (cross-env)",
+    "color": "#0ea5e9"
+  },
+  "delegated_to": {
+    "label": "Delegated To (runtime)",
+    "color": "#a855f7"
+  },
+  "depends_on": {
+    "label": "Depends On",
+    "color": "#52525b"
+  },
+  "exploitable_via": {
+    "label": "Exploitable Via",
+    "color": "#b91c1c"
+  },
+  "exposes_cred": {
+    "label": "Exposes Credential",
+    "color": "#f59e0b"
+  },
+  "hosts": {
+    "label": "Hosts",
+    "color": "#6b7280"
+  },
+  "invoked": {
+    "label": "Invoked (runtime)",
+    "color": "#10b981"
+  },
+  "lateral_path": {
+    "label": "Lateral Path",
+    "color": "#ea580c"
+  },
+  "manages": {
+    "label": "Manages",
+    "color": "#14b8a6"
+  },
+  "member_of": {
+    "label": "Member Of",
+    "color": "#4b5563"
+  },
+  "owns": {
+    "label": "Owns",
+    "color": "#0d9488"
+  },
+  "part_of": {
+    "label": "Part Of",
+    "color": "#6b7280"
+  },
+  "possibly_correlates_with": {
+    "label": "Possibly Correlates With (low confidence)",
+    "color": "#7dd3fc"
+  },
+  "provides_tool": {
+    "label": "Provides Tool",
+    "color": "#a855f7"
+  },
+  "reaches_tool": {
+    "label": "Credential Reaches Tool",
+    "color": "#fbbf24"
+  },
+  "remediates": {
+    "label": "Remediates",
+    "color": "#22c55e"
+  },
+  "serves_model": {
+    "label": "Serves Model",
+    "color": "#8b5cf6"
+  },
+  "shares_cred": {
+    "label": "Shares Credential",
+    "color": "#f97316"
+  },
+  "shares_server": {
+    "label": "Shares Server",
+    "color": "#22d3ee"
+  },
+  "triggers": {
+    "label": "Triggers",
+    "color": "#f97316"
+  },
+  "uses": {
+    "label": "Uses",
+    "color": "#10b981"
+  },
+  "vulnerable_to": {
+    "label": "Vulnerable To",
+    "color": "#ef4444"
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Type guards
+// ═══════════════════════════════════════════════════════════════════════════
+
+export function isGraphNodeKind(value: unknown): value is GraphNodeKindKey {
+  return (
+    typeof value === "string" &&
+    (GRAPH_NODE_KINDS as readonly string[]).includes(value)
+  );
+}
+
+export function isGraphEdgeKind(value: unknown): value is GraphEdgeKindKey {
+  return (
+    typeof value === "string" &&
+    (GRAPH_EDGE_KINDS as readonly string[]).includes(value)
+  );
+}

--- a/ui/lib/graph-schema.ts
+++ b/ui/lib/graph-schema.ts
@@ -118,10 +118,22 @@ import type {
   GraphEdgeKindKey as _GraphEdgeKindKey,
 } from "./graph-schema.generated";
 type _AssertExtends<T extends U, U> = T;
-type _NodeParity = _AssertExtends<EntityType, _GraphNodeKindKey>;
-type _EdgeParity = _AssertExtends<RelationshipType, _GraphEdgeKindKey>;
+type _EntityTypeValue = `${EntityType}`;
+type _RelationshipTypeValue = `${RelationshipType}`;
+type _NodeParity = _AssertExtends<_EntityTypeValue, _GraphNodeKindKey>;
+type _EdgeParity = _AssertExtends<_RelationshipTypeValue, _GraphEdgeKindKey>;
+type _GeneratedNodeParity = _AssertExtends<_GraphNodeKindKey, _EntityTypeValue>;
+type _GeneratedEdgeParity = _AssertExtends<
+  _GraphEdgeKindKey,
+  _RelationshipTypeValue
+>;
 // Surface the helper aliases so they aren't pruned as unused imports.
-export type _GraphSchemaParity = [_NodeParity, _EdgeParity];
+export type _GraphSchemaParity = [
+  _NodeParity,
+  _EdgeParity,
+  _GeneratedNodeParity,
+  _GeneratedEdgeParity,
+];
 
 export enum OCSFSeverity {
   UNKNOWN = 0,

--- a/ui/lib/graph-schema.ts
+++ b/ui/lib/graph-schema.ts
@@ -1,11 +1,41 @@
 /**
- * Unified Graph Schema — TypeScript mirror of Python graph_schema.py.
+ * Unified Graph Schema — TypeScript surface for the Python graph schema.
  *
- * Single source of truth for all graph types in the Next.js UI.
- * Every enum, interface, and constant here mirrors the Python module exactly.
+ * As of #2255 the canonical taxonomy (entity types + relationship types)
+ * is generated from the Python source via `npm run codegen:graph-schema`
+ * into ./graph-schema.generated.ts. This file re-exports the generated
+ * kind enums and continues to host the richer TypeScript-specific types
+ * (UnifiedNode/UnifiedEdge interfaces, OCSF mappings, severity helpers,
+ * legend data) that are not part of the cross-language contract.
  *
- * OCSF-aligned: every node carries category_uid / class_uid / type_uid.
+ * When adding a new entity / edge type:
+ *   1. Add it to agent_bom.graph.types in Python.
+ *   2. Run `cd ui && npm run codegen:graph-schema` to refresh
+ *      graph-schema.generated.ts.
+ *   3. Extend any UI-only maps in this file (ENTITY_OCSF_MAP, color
+ *      maps, etc.) to cover the new key.
  */
+
+// Re-export the codegen output so consumers can keep the
+// `from "@/lib/graph-schema"` import path while still resolving the
+// generated, drift-checked enum/union types.
+export {
+  GRAPH_SCHEMA_VERSION,
+  GraphNodeKind,
+  GraphEdgeKind,
+  GRAPH_NODE_KINDS,
+  GRAPH_EDGE_KINDS,
+  GRAPH_NODE_KIND_META,
+  GRAPH_EDGE_KIND_META,
+  isGraphNodeKind,
+  isGraphEdgeKind,
+} from "./graph-schema.generated";
+export type {
+  GraphNodeKindKey,
+  GraphEdgeKindKey,
+  GraphNodeKindMeta,
+  GraphEdgeKindMeta,
+} from "./graph-schema.generated";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Enums
@@ -77,6 +107,21 @@ export enum NodeStatus {
   VULNERABLE = "vulnerable",
   REMEDIATED = "remediated",
 }
+
+// Compile-time parity guard — fails the typecheck if the hand-rolled
+// EntityType / RelationshipType enums above drift from the generated
+// GraphNodeKind / GraphEdgeKind. The generated file is the source of
+// truth (#2255); this guard turns drift into a tsc error rather than a
+// silent runtime miss.
+import type {
+  GraphNodeKindKey as _GraphNodeKindKey,
+  GraphEdgeKindKey as _GraphEdgeKindKey,
+} from "./graph-schema.generated";
+type _AssertExtends<T extends U, U> = T;
+type _NodeParity = _AssertExtends<EntityType, _GraphNodeKindKey>;
+type _EdgeParity = _AssertExtends<RelationshipType, _GraphEdgeKindKey>;
+// Surface the helper aliases so they aren't pruned as unused imports.
+export type _GraphSchemaParity = [_NodeParity, _EdgeParity];
 
 export enum OCSFSeverity {
   UNKNOWN = 0,

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,8 @@
     "verify:toolchain": "node scripts/verify-toolchain.mjs",
     "headers:sync": "node scripts/sync-vercel-headers.mjs",
     "headers:check": "node scripts/sync-vercel-headers.mjs --check",
+    "codegen:graph-schema": "node scripts/codegen-graph-schema.mjs",
+    "codegen:graph-schema:check": "node scripts/codegen-graph-schema.mjs --check",
     "test": "vitest",
     "test:run": "vitest run"
   },

--- a/ui/scripts/codegen-graph-schema.mjs
+++ b/ui/scripts/codegen-graph-schema.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+// Generate ui/lib/graph-schema.generated.ts from the canonical Python
+// taxonomy at GET /v1/graph/schema (issue #2255).
+//
+// Why: agent_bom.graph.types.EntityType + RelationshipType is the single
+// source of truth. The TypeScript dashboard previously hand-mirrored those
+// enums in two places (ui/lib/graph-schema.ts + ui/components/lineage-
+// nodes.tsx LineageNodeType union), which silently drifted whenever a new
+// kind landed on the Python side. This script materialises the API
+// response into typed TS so drift becomes a CI failure instead of a
+// silent dropped node in the graph view.
+//
+// Usage:
+//   node scripts/codegen-graph-schema.mjs            # rewrite generated file
+//   node scripts/codegen-graph-schema.mjs --check    # exit 1 if drift
+//
+// Env:
+//   AGENT_BOM_GRAPH_SCHEMA_URL  override URL
+//                               (default http://127.0.0.1:8422/v1/graph/schema)
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const UI_ROOT = resolve(HERE, "..");
+const OUT_PATH = resolve(UI_ROOT, "lib/graph-schema.generated.ts");
+
+const DEFAULT_URL = "http://127.0.0.1:8422/v1/graph/schema";
+const URL_ENV = process.env.AGENT_BOM_GRAPH_SCHEMA_URL || DEFAULT_URL;
+
+const checkOnly = process.argv.includes("--check");
+
+function fail(msg) {
+  process.stderr.write(`error: ${msg}\n`);
+  process.exit(1);
+}
+
+function toEnumMember(key) {
+  // "cloud_resource" → "CLOUD_RESOURCE"
+  return key.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+}
+
+function jsonStringify(value) {
+  return JSON.stringify(value, null, 2);
+}
+
+async function fetchSchema() {
+  let resp;
+  try {
+    resp = await fetch(URL_ENV, { headers: { accept: "application/json" } });
+  } catch (err) {
+    fail(
+      `failed to GET ${URL_ENV}: ${err?.message ?? err}\n` +
+        `Is the API running? Try:\n` +
+        `  uv run agent-bom api --host 127.0.0.1 --port 8422 --allow-insecure-no-auth`,
+    );
+  }
+  if (!resp.ok) {
+    fail(`GET ${URL_ENV} returned ${resp.status} ${resp.statusText}`);
+  }
+  let data;
+  try {
+    data = await resp.json();
+  } catch (err) {
+    fail(`response from ${URL_ENV} was not valid JSON: ${err?.message ?? err}`);
+  }
+  if (
+    typeof data !== "object" ||
+    data === null ||
+    !Array.isArray(data.node_kinds) ||
+    !Array.isArray(data.edge_kinds)
+  ) {
+    fail(`unexpected schema shape from ${URL_ENV}: ${JSON.stringify(data).slice(0, 200)}`);
+  }
+  return data;
+}
+
+function render(schema) {
+  const nodeKinds = [...schema.node_kinds].sort((a, b) =>
+    a.key.localeCompare(b.key),
+  );
+  const edgeKinds = [...schema.edge_kinds].sort((a, b) =>
+    a.key.localeCompare(b.key),
+  );
+
+  const nodeEnum = nodeKinds
+    .map((n) => `  ${toEnumMember(n.key)} = ${JSON.stringify(n.key)},`)
+    .join("\n");
+
+  const edgeEnum = edgeKinds
+    .map((e) => `  ${toEnumMember(e.key)} = ${JSON.stringify(e.key)},`)
+    .join("\n");
+
+  const nodeUnion = nodeKinds.map((n) => JSON.stringify(n.key)).join(" | ");
+  const edgeUnion = edgeKinds.map((e) => JSON.stringify(e.key)).join(" | ");
+
+  const nodeMetadataObj = nodeKinds
+    .map(
+      (n) =>
+        `  ${JSON.stringify(n.key)}: ${jsonStringify({
+          label: n.label,
+          color: n.color,
+          shape: n.shape,
+          icon: n.icon,
+        }).replace(/\n/g, "\n  ")},`,
+    )
+    .join("\n");
+
+  const edgeMetadataObj = edgeKinds
+    .map(
+      (e) =>
+        `  ${JSON.stringify(e.key)}: ${jsonStringify({
+          label: e.label,
+          color: e.color,
+        }).replace(/\n/g, "\n  ")},`,
+    )
+    .join("\n");
+
+  const nodeKindList = nodeKinds.map((n) => JSON.stringify(n.key)).join(", ");
+  const edgeKindList = edgeKinds.map((e) => JSON.stringify(e.key)).join(", ");
+
+  return `// AUTO-GENERATED — do not edit. Run \`npm run codegen:graph-schema\` to refresh.
+//
+// Source of truth: agent_bom.graph.types.EntityType + RelationshipType.
+// The Python API at GET /v1/graph/schema is the canonical taxonomy; this
+// file is materialised by ui/scripts/codegen-graph-schema.mjs and the CI
+// "UI Validate" job fails when it drifts (see #2255).
+
+export const GRAPH_SCHEMA_VERSION = ${schema.version ?? 1} as const;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Node kinds (entity types)
+// ═══════════════════════════════════════════════════════════════════════════
+
+export enum GraphNodeKind {
+${nodeEnum}
+}
+
+export type GraphNodeKindKey = ${nodeUnion};
+
+export const GRAPH_NODE_KINDS: readonly GraphNodeKindKey[] = [${nodeKindList}] as const;
+
+export interface GraphNodeKindMeta {
+  label: string;
+  color: string;
+  shape: string;
+  icon: string;
+}
+
+export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> = {
+${nodeMetadataObj}
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Edge kinds (relationship types)
+// ═══════════════════════════════════════════════════════════════════════════
+
+export enum GraphEdgeKind {
+${edgeEnum}
+}
+
+export type GraphEdgeKindKey = ${edgeUnion};
+
+export const GRAPH_EDGE_KINDS: readonly GraphEdgeKindKey[] = [${edgeKindList}] as const;
+
+export interface GraphEdgeKindMeta {
+  label: string;
+  color: string;
+}
+
+export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> = {
+${edgeMetadataObj}
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Type guards
+// ═══════════════════════════════════════════════════════════════════════════
+
+export function isGraphNodeKind(value: unknown): value is GraphNodeKindKey {
+  return (
+    typeof value === "string" &&
+    (GRAPH_NODE_KINDS as readonly string[]).includes(value)
+  );
+}
+
+export function isGraphEdgeKind(value: unknown): value is GraphEdgeKindKey {
+  return (
+    typeof value === "string" &&
+    (GRAPH_EDGE_KINDS as readonly string[]).includes(value)
+  );
+}
+`;
+}
+
+const schema = await fetchSchema();
+const expected = render(schema);
+
+if (checkOnly) {
+  if (!existsSync(OUT_PATH)) {
+    fail(
+      `${OUT_PATH} is missing.\n` +
+        `Run \`npm run codegen:graph-schema\` and commit the result.`,
+    );
+  }
+  const current = readFileSync(OUT_PATH, "utf8");
+  if (current !== expected) {
+    process.stderr.write(
+      `error: ${OUT_PATH} is out of date relative to GET /v1/graph/schema.\n` +
+        `\n` +
+        `The Python graph taxonomy (agent_bom.graph.types) has new entries\n` +
+        `that the dashboard does not know about, so nodes of those kinds\n` +
+        `would silently disappear from the UI. Regenerate locally:\n` +
+        `\n` +
+        `  cd ui && npm run codegen:graph-schema\n` +
+        `\n` +
+        `Then commit ui/lib/graph-schema.generated.ts.\n`,
+    );
+    process.exit(1);
+  }
+  process.stdout.write(`OK: ${OUT_PATH} matches /v1/graph/schema\n`);
+  process.exit(0);
+}
+
+writeFileSync(OUT_PATH, expected);
+process.stdout.write(
+  `wrote ${OUT_PATH} (${schema.node_kinds.length} node kinds, ${schema.edge_kinds.length} edge kinds)\n`,
+);

--- a/ui/scripts/codegen-graph-schema.mjs
+++ b/ui/scripts/codegen-graph-schema.mjs
@@ -103,6 +103,8 @@ function render(schema) {
           color: n.color,
           shape: n.shape,
           icon: n.icon,
+          category_uid: n.category_uid,
+          class_uid: n.class_uid,
         }).replace(/\n/g, "\n  ")},`,
     )
     .join("\n");
@@ -113,6 +115,11 @@ function render(schema) {
         `  ${JSON.stringify(e.key)}: ${jsonStringify({
           label: e.label,
           color: e.color,
+          category: e.category,
+          direction: e.direction,
+          source_types: e.source_types,
+          target_types: e.target_types,
+          traversable: e.traversable,
         }).replace(/\n/g, "\n  ")},`,
     )
     .join("\n");
@@ -146,6 +153,8 @@ export interface GraphNodeKindMeta {
   color: string;
   shape: string;
   icon: string;
+  category_uid: number;
+  class_uid: number;
 }
 
 export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> = {
@@ -167,6 +176,11 @@ export const GRAPH_EDGE_KINDS: readonly GraphEdgeKindKey[] = [${edgeKindList}] a
 export interface GraphEdgeKindMeta {
   label: string;
   color: string;
+  category: string;
+  direction: "directed" | "bidirectional";
+  source_types: readonly GraphNodeKindKey[];
+  target_types: readonly GraphNodeKindKey[];
+  traversable: boolean;
 }
 
 export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> = {


### PR DESCRIPTION
Closes #2255.

## Why

`EntityType` / `RelationshipType` were declared in two places — `agent_bom.graph.types` (Python) and `ui/lib/graph-schema.ts` (TypeScript) — and drifted independently. Adding a new kind on the Python side silently dropped UI nodes of that kind until manual QA caught it. The fix routes the TypeScript side through codegen so drift becomes a CI failure instead of a runtime miss.

## What changed

- **`GET /v1/graph/schema`** — new FastAPI route in `src/agent_bom/api/routes/graph.py` that reflects `EntityType` + `RelationshipType` at request time, joined with `ENTITY_LEGEND` / `RELATIONSHIP_LEGEND` for label / color / shape / icon hints. Adding a new enum value is the only edit required.
- **`ui/scripts/codegen-graph-schema.mjs`** — Node script that hits the schema endpoint (URL configurable via `AGENT_BOM_GRAPH_SCHEMA_URL`) and materialises `ui/lib/graph-schema.generated.ts`: typed enums (`GraphNodeKind`, `GraphEdgeKind`), key unions, metadata records, and type guards. File header reads `AUTO-GENERATED — do not edit. Run npm run codegen:graph-schema to refresh.`
- **`ui/lib/graph-schema.ts`** — re-exports the generated kinds and adds a compile-time parity guard (`type _AssertExtends<T extends U, U>`) so `tsc` fails if the hand-rolled `EntityType` / `RelationshipType` drift away from the generated set.
- **`ui/package.json`** — `codegen:graph-schema` and `codegen:graph-schema:check` scripts.
- **CI gate** in `.github/workflows/ci.yml` "UI Validate" job: boots the API on `127.0.0.1:8422`, runs the codegen, and `git diff --exit-code` on the generated file. Drift fails with a "run `cd ui && npm run codegen:graph-schema` locally" message that links back to #2255.
- **Regression test** `tests/test_graph_schema.py::TestGraphSchemaEndpoint` (4 cases) — including a monkeypatched fake `EntityType` (`fake_new_kind`) that proves the endpoint surfaces new kinds without a route edit.

## Out of scope

Per the issue, migrating to Cartography's schema is deferred — its AWS/Azure/GCP entity shape would require significant adaptation for the AI-supply-chain entities (Agent / MCPServer / Tool / Skill).

## Verification

- `python -c "from agent_bom.api.server import app"` — clean
- `pytest tests/test_graph_schema.py` — 77 passed
- `pytest tests/test_graph_schema.py::TestGraphSchemaEndpoint` — 4 passed
- `cd ui && npm run typecheck` — clean
- `cd ui && npm run lint` — clean
- `cd ui && npm run test:run` — 150 / 150 passed
- Boot API + curl `/v1/graph/schema` — 18 node kinds, 25 edge kinds, valid JSON
- Codegen `--check` against running API — OK, no drift

## Test plan

- [ ] CI "UI Validate / Graph schema codegen" step passes on this PR
- [ ] CI fails as expected if a new `EntityType` is added without re-running the codegen
- [ ] Existing dashboard pages render unchanged (graph/security-graph)