### PR TITLE
feat(graph): per-graph layout algorithm — mesh radial, security force-directed, lineage LR-dagre, pipeline Sankey (#2256)

### DIFF
--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -31,7 +31,7 @@ import {
   type FilterState,
 } from "@/components/lineage-filter";
 import { lineageNodeTypes, type LineageNodeData, type LineageNodeType } from "@/components/lineage-nodes";
-import { useDagreLayout } from "@/lib/use-dagre-layout";
+import { useForceLayout } from "@/lib/use-force-layout";
 import {
   EntityType,
   RelationshipType,
@@ -579,12 +579,9 @@ export default function GraphPageClient() {
     [flow.nodes],
   );
 
-  const { nodes: layoutNodes, edges: layoutEdges } = useDagreLayout(flow.nodes, flow.edges, {
-    direction: filters.agentName || filters.vulnOnly ? "TB" : "LR",
-    nodeWidth: filters.agentName ? 208 : 188,
-    nodeHeight: 72,
-    rankSep: filters.agentName ? 118 : 104,
-    nodeSep: filters.agentName ? 22 : 28,
+  const { nodes: layoutNodes, edges: layoutEdges } = useForceLayout(flow.nodes, flow.edges, {
+    idealEdgeLength: filters.agentName ? 168 : 196,
+    nodeRepulsion: filters.agentName ? 3600 : 4400,
   });
 
   const connectedIds = useMemo(

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -582,6 +582,7 @@ export default function GraphPageClient() {
   const { nodes: layoutNodes, edges: layoutEdges } = useForceLayout(flow.nodes, flow.edges, {
     idealEdgeLength: filters.agentName ? 168 : 196,
     nodeRepulsion: filters.agentName ? 3600 : 4400,
+    preservePinnedPositions: true,
   });
 
   const connectedIds = useMemo(

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -10,9 +10,9 @@ import {
   type Edge,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { ShieldAlert, Loader2, AlertTriangle, Search, SlidersHorizontal, Network, GitBranch } from "lucide-react";
+import { ShieldAlert, Loader2, AlertTriangle, Search, SlidersHorizontal } from "lucide-react";
 import { api, type JobListItem, type ScanJob } from "@/lib/api";
-import { useDagreLayout } from "@/lib/use-dagre-layout";
+import { useRadialLayout } from "@/lib/use-radial-layout";
 import { lineageNodeTypes, type LineageNodeData } from "@/components/lineage-nodes";
 import { LineageDetailPanel } from "@/components/lineage-detail";
 import { MeshStats } from "@/components/mesh-stats";
@@ -179,9 +179,6 @@ export default function MeshPage() {
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [activeJob, setActiveJob] = useState<ScanJob | null>(null);
 
-  // Layout direction: "LR" for topology, "TB" for spawn tree
-  const [layoutMode, setLayoutMode] = useState<"LR" | "TB">("LR");
-
   // Filters
   const [nodeFilter, setNodeFilter] = useState<NodeTypeFilter>({
     packages: true,
@@ -298,12 +295,9 @@ export default function MeshPage() {
     return { rawNodes: nodes, rawEdges: edges, stats };
   }, [activeResult, nodeFilter, severityFilter, selectedAgents, vulnerableOnly]);
 
-  const { nodes: layoutNodes, edges: layoutEdges } = useDagreLayout(rawNodes, rawEdges, {
-    direction: layoutMode,
-    nodeWidth: 200,
-    nodeHeight: 70,
-    rankSep: 140,
-    nodeSep: 25,
+  const { nodes: layoutNodes, edges: layoutEdges } = useRadialLayout(rawNodes, rawEdges, {
+    baseRadius: 240,
+    ringSpacing: 220,
   });
 
   // Search highlighting
@@ -417,32 +411,6 @@ export default function MeshPage() {
           </p>
         </div>
         <div className="flex items-center gap-3">
-          {/* Layout toggle */}
-          <div className="flex items-center bg-zinc-800 rounded-lg border border-zinc-700 overflow-hidden">
-            <button
-              onClick={() => setLayoutMode("LR")}
-              className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors ${
-                layoutMode === "LR"
-                  ? "bg-emerald-600 text-white"
-                  : "text-zinc-400 hover:text-zinc-200"
-              }`}
-            >
-              <Network className="w-3.5 h-3.5" />
-              Topology
-            </button>
-            <button
-              onClick={() => setLayoutMode("TB")}
-              className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors ${
-                layoutMode === "TB"
-                  ? "bg-emerald-600 text-white"
-                  : "text-zinc-400 hover:text-zinc-200"
-              }`}
-            >
-              <GitBranch className="w-3.5 h-3.5" />
-              Spawn Tree
-            </button>
-          </div>
-
           <select
             value={selectedJob}
             onChange={(e) => setSelectedJob(e.target.value)}

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -10,8 +10,9 @@ import {
   type Edge,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { ShieldAlert, Loader2, AlertTriangle, Search, SlidersHorizontal } from "lucide-react";
+import { ShieldAlert, Loader2, AlertTriangle, Search, SlidersHorizontal, Network, GitBranch, Orbit } from "lucide-react";
 import { api, type JobListItem, type ScanJob } from "@/lib/api";
+import { useDagreLayout } from "@/lib/use-dagre-layout";
 import { useRadialLayout } from "@/lib/use-radial-layout";
 import { lineageNodeTypes, type LineageNodeData } from "@/components/lineage-nodes";
 import { LineageDetailPanel } from "@/components/lineage-detail";
@@ -169,6 +170,8 @@ function MeshToolbar({
 
 // ─── Page ───────────────────────────────────────────────────────────────────
 
+type MeshLayoutMode = "radial" | "topology" | "spawn-tree";
+
 export default function MeshPage() {
   const [jobs, setJobs] = useState<JobListItem[]>([]);
   const [selectedJob, setSelectedJob] = useState<string>("");
@@ -178,6 +181,7 @@ export default function MeshPage() {
   const [selectedNode, setSelectedNode] = useState<LineageNodeData | null>(null);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [activeJob, setActiveJob] = useState<ScanJob | null>(null);
+  const [layoutMode, setLayoutMode] = useState<MeshLayoutMode>("radial");
 
   // Filters
   const [nodeFilter, setNodeFilter] = useState<NodeTypeFilter>({
@@ -299,11 +303,20 @@ export default function MeshPage() {
     baseRadius: 240,
     ringSpacing: 220,
   });
+  const { nodes: dagreNodes, edges: dagreEdges } = useDagreLayout(rawNodes, rawEdges, {
+    direction: layoutMode === "spawn-tree" ? "TB" : "LR",
+    nodeWidth: 200,
+    nodeHeight: 70,
+    rankSep: 140,
+    nodeSep: 25,
+  });
+  const visibleNodes = layoutMode === "radial" ? layoutNodes : dagreNodes;
+  const visibleEdges = layoutMode === "radial" ? layoutEdges : dagreEdges;
 
   // Search highlighting
   const searchMatches = useMemo(
-    () => (searchQuery ? searchNodes(layoutNodes, searchQuery) : null),
-    [layoutNodes, searchQuery]
+    () => (searchQuery ? searchNodes(visibleNodes, searchQuery) : null),
+    [visibleNodes, searchQuery]
   );
 
   const toggleAgent = useCallback((name: string) => {
@@ -317,35 +330,35 @@ export default function MeshPage() {
 
   // Hover highlighting
   const connectedIds = useMemo(
-    () => (hoveredNodeId ? getConnectedIds(hoveredNodeId, layoutEdges) : null),
-    [hoveredNodeId, layoutEdges]
+    () => (hoveredNodeId ? getConnectedIds(hoveredNodeId, visibleEdges) : null),
+    [hoveredNodeId, visibleEdges]
   );
 
   const displayNodes = useMemo(() => {
     if (searchMatches && searchMatches.size > 0) {
-      return layoutNodes?.map((n) => ({
+      return visibleNodes?.map((n) => ({
         ...n,
         data: { ...n.data, dimmed: !searchMatches.has(n.id), highlighted: searchMatches.has(n.id) },
       }));
     }
-    if (!connectedIds) return layoutNodes;
-    return layoutNodes?.map((n) => ({
+    if (!connectedIds) return visibleNodes;
+    return visibleNodes?.map((n) => ({
       ...n,
       data: { ...n.data, dimmed: !connectedIds.has(n.id), highlighted: connectedIds.has(n.id) },
     }));
-  }, [layoutNodes, connectedIds, searchMatches]);
+  }, [visibleNodes, connectedIds, searchMatches]);
 
   const displayEdges = useMemo(() => {
     const activeSet = searchMatches && searchMatches.size > 0 ? searchMatches : connectedIds;
-    if (!activeSet) return layoutEdges;
-    return layoutEdges?.map((e) => ({
+    if (!activeSet) return visibleEdges;
+    return visibleEdges?.map((e) => ({
       ...e,
       style: {
         ...e.style,
         opacity: activeSet.has(e.source) && activeSet.has(e.target) ? 1 : 0.12,
       },
     }));
-  }, [layoutEdges, connectedIds, searchMatches]);
+  }, [visibleEdges, connectedIds, searchMatches]);
 
   const legendItems = useMemo(
     () => legendItemsForVisibleGraph(displayNodes, displayEdges),
@@ -411,6 +424,27 @@ export default function MeshPage() {
           </p>
         </div>
         <div className="flex items-center gap-3">
+          <div className="flex items-center overflow-hidden rounded-lg border border-zinc-700 bg-zinc-800">
+            {[
+              { key: "radial" as const, label: "Radial", icon: Orbit },
+              { key: "topology" as const, label: "Topology", icon: Network },
+              { key: "spawn-tree" as const, label: "Spawn Tree", icon: GitBranch },
+            ].map(({ key, label, icon: Icon }) => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setLayoutMode(key)}
+                className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors ${
+                  layoutMode === key
+                    ? "bg-emerald-600 text-white"
+                    : "text-zinc-400 hover:text-zinc-200"
+                }`}
+              >
+                <Icon className="h-3.5 w-3.5" />
+                {label}
+              </button>
+            ))}
+          </div>
           <select
             value={selectedJob}
             onChange={(e) => setSelectedJob(e.target.value)}

--- a/ui/lib/seed-random.ts
+++ b/ui/lib/seed-random.ts
@@ -1,0 +1,61 @@
+/**
+ * Tiny seeded PRNG used by graph layouts to keep renders deterministic
+ * scan-to-scan. Required by the visual-diff CI guard (#2259) — random init
+ * positions must be derived from stable inputs (node IDs) so the same scan
+ * produces the same SVG every render.
+ *
+ * Implementation:
+ *   - hashString: FNV-1a 32-bit hash, deterministic across platforms.
+ *   - mulberry32: PRNG seeded from a 32-bit integer; small, fast, and good
+ *     enough for layout init. Not cryptographic.
+ *
+ * Public API:
+ *   seedFromIds(nodeIds: string[]): number  — combines node IDs into one seed.
+ *   makeRng(seed: number): () => number     — returns a [0, 1) generator.
+ *   seededPosition(id, seed, radius): {x, y} — deterministic point per id.
+ */
+
+export function hashString(input: string): number {
+  let hash = 0x811c9dc5; // FNV offset basis
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    // Multiply by FNV prime (16777619), keep to 32 bits.
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+export function seedFromIds(nodeIds: readonly string[]): number {
+  let seed = 0x9e3779b1; // golden ratio bits
+  for (const id of nodeIds) {
+    seed = (Math.imul(seed ^ hashString(id), 0x85ebca6b)) >>> 0;
+  }
+  return seed >>> 0;
+}
+
+export function makeRng(seed: number): () => number {
+  let state = seed >>> 0;
+  return function rng(): number {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Deterministic 2-D point on a circle of given radius for a node id.
+ * Used as the seed position for force-directed layouts so the layout
+ * converges to the same shape on every run.
+ */
+export function seededPosition(
+  id: string,
+  seed: number,
+  radius: number,
+): { x: number; y: number } {
+  const h = hashString(`${seed.toString(36)}:${id}`);
+  const angle = ((h & 0xffff) / 0x10000) * Math.PI * 2;
+  const r = radius * (0.5 + ((h >>> 16) & 0xffff) / 0x10000 / 2);
+  return { x: Math.cos(angle) * r, y: Math.sin(angle) * r };
+}

--- a/ui/lib/use-dagre-lr.ts
+++ b/ui/lib/use-dagre-lr.ts
@@ -1,0 +1,41 @@
+/**
+ * Left-to-right dagre layout wrapper.
+ *
+ * The default `useDagreLayout` covers both LR and TB via its `direction`
+ * option, but the existing call sites pass `direction` dynamically and the
+ * lineage / supply-chain surfaces want a hard-coded LR direction with no
+ * caller-side knob. This wrapper pins `direction: "LR"` and keeps every
+ * other option (worker-vs-sync, node sizing, rank/node sep) identical.
+ *
+ * Determinism: dagre is deterministic given identical inputs. The wrapper
+ * also exposes a `seed` derived from the node IDs so visual-diff snapshots
+ * can be keyed exactly like the radial / force / sankey layouts.
+ */
+
+"use client";
+
+import { useMemo } from "react";
+import { type Edge, type Node } from "@xyflow/react";
+
+import { type LayoutOptions } from "@/lib/dagre-layout";
+import { seedFromIds } from "@/lib/seed-random";
+import { useDagreLayout } from "@/lib/use-dagre-layout";
+
+export type DagreLrOptions = Omit<LayoutOptions, "direction">;
+
+export interface UseDagreLrResult {
+  nodes: Node[];
+  edges: Edge[];
+  pending: boolean;
+  seed: number;
+}
+
+export function useDagreLrLayout(
+  nodes: Node[],
+  edges: Edge[],
+  options: DagreLrOptions = {},
+): UseDagreLrResult {
+  const layout = useDagreLayout(nodes, edges, { ...options, direction: "LR" });
+  const seed = useMemo(() => seedFromIds(nodes.map((n) => n.id)), [nodes]);
+  return { ...layout, seed };
+}

--- a/ui/lib/use-force-layout.ts
+++ b/ui/lib/use-force-layout.ts
@@ -46,6 +46,13 @@ export interface ForceLayoutOptions {
   centerPull?: number;
   /** Initial radius for the seeded layout. */
   initialRadius?: number;
+  /**
+   * Keep caller-positioned aggregate/group anchors fixed when node metadata
+   * marks them as layout-pinned. This lets `/graph` compose this force pass
+   * inside a future aggregation layer without the inner layout moving the
+   * aggregate nodes themselves.
+   */
+  preservePinnedPositions?: boolean;
 }
 
 const DEFAULTS: Required<ForceLayoutOptions> = {
@@ -55,6 +62,7 @@ const DEFAULTS: Required<ForceLayoutOptions> = {
   edgeStiffness: 0.08,
   centerPull: 0.012,
   initialRadius: 320,
+  preservePinnedPositions: true,
 };
 
 interface Particle {
@@ -63,6 +71,26 @@ interface Particle {
   y: number;
   vx: number;
   vy: number;
+  fixed: boolean;
+}
+
+interface LayoutPinData {
+  layoutPinned?: unknown;
+  layoutLocked?: unknown;
+  layout?: {
+    pinned?: unknown;
+    locked?: unknown;
+  };
+}
+
+function isPinnedLayoutNode(node: Node): boolean {
+  const data = (node.data ?? {}) as LayoutPinData;
+  return (
+    data.layoutPinned === true ||
+    data.layoutLocked === true ||
+    data.layout?.pinned === true ||
+    data.layout?.locked === true
+  );
 }
 
 export interface ForceLayoutResult {
@@ -85,8 +113,18 @@ export function applyForceLayout(
 
   // 1. Seed positions deterministically off the seeded RNG.
   const particles: Particle[] = nodes.map((node) => {
+    if (opts.preservePinnedPositions && isPinnedLayoutNode(node)) {
+      return {
+        id: node.id,
+        x: Math.round(node.position.x),
+        y: Math.round(node.position.y),
+        vx: 0,
+        vy: 0,
+        fixed: true,
+      };
+    }
     const { x, y } = seededPosition(node.id, seed, opts.initialRadius);
-    return { id: node.id, x, y, vx: 0, vy: 0 };
+    return { id: node.id, x, y, vx: 0, vy: 0, fixed: false };
   });
   const indexById = new Map(particles.map((p, i) => [p.id, i] as const));
 
@@ -127,10 +165,14 @@ export function applyForceLayout(
         const force = repulsion / distSq;
         const fx = (dx / dist) * force;
         const fy = (dy / dist) * force;
-        pi.vx += fx;
-        pi.vy += fy;
-        pj.vx -= fx;
-        pj.vy -= fy;
+        if (!pi.fixed) {
+          pi.vx += fx;
+          pi.vy += fy;
+        }
+        if (!pj.fixed) {
+          pj.vx -= fx;
+          pj.vy -= fy;
+        }
       }
     }
 
@@ -145,15 +187,24 @@ export function applyForceLayout(
       const force = displacement * stiffness;
       const fx = (dx / dist) * force;
       const fy = (dy / dist) * force;
-      pa.vx += fx;
-      pa.vy += fy;
-      pb.vx -= fx;
-      pb.vy -= fy;
+      if (!pa.fixed) {
+        pa.vx += fx;
+        pa.vy += fy;
+      }
+      if (!pb.fixed) {
+        pb.vx -= fx;
+        pb.vy -= fy;
+      }
     }
 
     // Pull every particle toward the origin so loose components don't drift.
     // Integrate with cooling-scaled velocity.
     for (const p of particles) {
+      if (p.fixed) {
+        p.vx = 0;
+        p.vy = 0;
+        continue;
+      }
       p.vx -= p.x * centerPull;
       p.vy -= p.y * centerPull;
       p.x += p.vx * cooling;
@@ -198,6 +249,7 @@ export function useForceLayout(
   const edgeStiffness = options.edgeStiffness;
   const centerPull = options.centerPull;
   const initialRadius = options.initialRadius;
+  const preservePinnedPositions = options.preservePinnedPositions;
   return useMemo(() => {
     const opts: ForceLayoutOptions = {};
     if (iterations !== undefined) opts.iterations = iterations;
@@ -206,6 +258,7 @@ export function useForceLayout(
     if (edgeStiffness !== undefined) opts.edgeStiffness = edgeStiffness;
     if (centerPull !== undefined) opts.centerPull = centerPull;
     if (initialRadius !== undefined) opts.initialRadius = initialRadius;
+    if (preservePinnedPositions !== undefined) opts.preservePinnedPositions = preservePinnedPositions;
     const result = applyForceLayout(nodes, edges, opts);
     return { ...result, pending: false as const };
   }, [
@@ -217,5 +270,6 @@ export function useForceLayout(
     edgeStiffness,
     centerPull,
     initialRadius,
+    preservePinnedPositions,
   ]);
 }

--- a/ui/lib/use-force-layout.ts
+++ b/ui/lib/use-force-layout.ts
@@ -1,0 +1,221 @@
+/**
+ * Force-directed layout for the security graph (`/graph`).
+ *
+ * Implementation choice: pure-JS force simulation (no Cytoscape dep).
+ *
+ * Why not cose-bilkent / fcose? Pulling in `cytoscape` + `cytoscape-cose-bilkent`
+ * would add ~250 KB minified to the dashboard bundle and force a parallel
+ * graph model (Cytoscape elements vs React Flow nodes). The 244-node /
+ * 302-edge agent-bom self-scan converges in well under one frame with the
+ * spring/repulsion simulation below, and a deterministic seed (see
+ * `seed-random.ts`) keeps renders stable for the visual-diff CI guard
+ * (#2259). If/when graphs grow past ~5 k nodes we can swap the inner loop
+ * for a Barnes-Hut quadtree without changing the surface API.
+ *
+ * Algorithm:
+ *   1. Seed each node at a deterministic point on a Fibonacci spiral keyed
+ *      by hash(id, frame_seed). Prevents "first frame jiggle" between
+ *      identical scans.
+ *   2. Iterate a small number of steps (default 80) of Coulomb repulsion +
+ *      Hooke spring attraction along edges, with a 1/√t cooling schedule.
+ *   3. Snap to integer pixel coords so SVG output is byte-stable.
+ *
+ * The hook returns `{ nodes, edges, pending, seed }`. `pending` is always
+ * false today (the simulation is synchronous and cheap); the field exists
+ * so callers can swap useDagreLayout → useForceLayout without refactoring
+ * loading-state handling.
+ */
+
+"use client";
+
+import { useMemo } from "react";
+import { Position, type Edge, type Node } from "@xyflow/react";
+
+import { seedFromIds, seededPosition } from "@/lib/seed-random";
+
+export interface ForceLayoutOptions {
+  /** Total simulation iterations. */
+  iterations?: number;
+  /** Target edge length in pixels (Hooke rest length). */
+  idealEdgeLength?: number;
+  /** Coulomb repulsion strength. */
+  nodeRepulsion?: number;
+  /** Hooke spring strength along edges. */
+  edgeStiffness?: number;
+  /** Centring pull toward the origin to keep the graph framed. */
+  centerPull?: number;
+  /** Initial radius for the seeded layout. */
+  initialRadius?: number;
+}
+
+const DEFAULTS: Required<ForceLayoutOptions> = {
+  iterations: 80,
+  idealEdgeLength: 180,
+  nodeRepulsion: 4200,
+  edgeStiffness: 0.08,
+  centerPull: 0.012,
+  initialRadius: 320,
+};
+
+interface Particle {
+  id: string;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+}
+
+export interface ForceLayoutResult {
+  nodes: Node[];
+  edges: Edge[];
+  seed: number;
+}
+
+export function applyForceLayout(
+  nodes: Node[],
+  edges: Edge[],
+  options: ForceLayoutOptions = {},
+): ForceLayoutResult {
+  const opts = { ...DEFAULTS, ...options };
+  if (nodes.length === 0) {
+    return { nodes: [], edges, seed: 0 };
+  }
+
+  const seed = seedFromIds(nodes.map((n) => n.id));
+
+  // 1. Seed positions deterministically off the seeded RNG.
+  const particles: Particle[] = nodes.map((node) => {
+    const { x, y } = seededPosition(node.id, seed, opts.initialRadius);
+    return { id: node.id, x, y, vx: 0, vy: 0 };
+  });
+  const indexById = new Map(particles.map((p, i) => [p.id, i] as const));
+
+  // Build adjacency for the spring force.
+  const springs: Array<{ a: number; b: number }> = [];
+  for (const edge of edges) {
+    const a = indexById.get(edge.source);
+    const b = indexById.get(edge.target);
+    if (a == null || b == null) continue;
+    springs.push({ a, b });
+  }
+
+  const ideal = opts.idealEdgeLength;
+  const repulsion = opts.nodeRepulsion;
+  const stiffness = opts.edgeStiffness;
+  const centerPull = opts.centerPull;
+
+  // 2. Iterate.
+  for (let step = 0; step < opts.iterations; step += 1) {
+    // Cooling schedule: damp velocity more aggressively as we converge.
+    const cooling = 1 / Math.sqrt(step + 1);
+
+    // Coulomb repulsion (O(n^2) — fine through ~2 k nodes).
+    for (let i = 0; i < particles.length; i += 1) {
+      const pi = particles[i]!;
+      for (let j = i + 1; j < particles.length; j += 1) {
+        const pj = particles[j]!;
+        let dx = pi.x - pj.x;
+        let dy = pi.y - pj.y;
+        let distSq = dx * dx + dy * dy;
+        if (distSq < 1) {
+          // Fall back to a deterministic offset when points coincide.
+          dx = ((i - j) % 7) + 0.5;
+          dy = ((i + j) % 11) - 5.5;
+          distSq = dx * dx + dy * dy;
+        }
+        const dist = Math.sqrt(distSq);
+        const force = repulsion / distSq;
+        const fx = (dx / dist) * force;
+        const fy = (dy / dist) * force;
+        pi.vx += fx;
+        pi.vy += fy;
+        pj.vx -= fx;
+        pj.vy -= fy;
+      }
+    }
+
+    // Hooke spring attraction along edges.
+    for (const { a, b } of springs) {
+      const pa = particles[a]!;
+      const pb = particles[b]!;
+      const dx = pb.x - pa.x;
+      const dy = pb.y - pa.y;
+      const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+      const displacement = dist - ideal;
+      const force = displacement * stiffness;
+      const fx = (dx / dist) * force;
+      const fy = (dy / dist) * force;
+      pa.vx += fx;
+      pa.vy += fy;
+      pb.vx -= fx;
+      pb.vy -= fy;
+    }
+
+    // Pull every particle toward the origin so loose components don't drift.
+    // Integrate with cooling-scaled velocity.
+    for (const p of particles) {
+      p.vx -= p.x * centerPull;
+      p.vy -= p.y * centerPull;
+      p.x += p.vx * cooling;
+      p.y += p.vy * cooling;
+      // Damp velocity each step so the system actually converges.
+      p.vx *= 0.85;
+      p.vy *= 0.85;
+    }
+  }
+
+  // 3. Snap to integer coords for byte-stable SVG output.
+  const byId = new Map(particles.map((p) => [p.id, p] as const));
+  const positioned = nodes.map((node) => {
+    const p = byId.get(node.id);
+    if (!p) return node;
+    return {
+      ...node,
+      position: { x: Math.round(p.x), y: Math.round(p.y) },
+      sourcePosition: Position.Right,
+      targetPosition: Position.Left,
+    };
+  });
+
+  return { nodes: positioned, edges, seed };
+}
+
+export interface UseForceLayoutResult {
+  nodes: Node[];
+  edges: Edge[];
+  pending: false;
+  seed: number;
+}
+
+export function useForceLayout(
+  nodes: Node[],
+  edges: Edge[],
+  options: ForceLayoutOptions = {},
+): UseForceLayoutResult {
+  const iterations = options.iterations;
+  const idealEdgeLength = options.idealEdgeLength;
+  const nodeRepulsion = options.nodeRepulsion;
+  const edgeStiffness = options.edgeStiffness;
+  const centerPull = options.centerPull;
+  const initialRadius = options.initialRadius;
+  return useMemo(() => {
+    const opts: ForceLayoutOptions = {};
+    if (iterations !== undefined) opts.iterations = iterations;
+    if (idealEdgeLength !== undefined) opts.idealEdgeLength = idealEdgeLength;
+    if (nodeRepulsion !== undefined) opts.nodeRepulsion = nodeRepulsion;
+    if (edgeStiffness !== undefined) opts.edgeStiffness = edgeStiffness;
+    if (centerPull !== undefined) opts.centerPull = centerPull;
+    if (initialRadius !== undefined) opts.initialRadius = initialRadius;
+    const result = applyForceLayout(nodes, edges, opts);
+    return { ...result, pending: false as const };
+  }, [
+    nodes,
+    edges,
+    iterations,
+    idealEdgeLength,
+    nodeRepulsion,
+    edgeStiffness,
+    centerPull,
+    initialRadius,
+  ]);
+}

--- a/ui/lib/use-radial-layout.ts
+++ b/ui/lib/use-radial-layout.ts
@@ -1,0 +1,187 @@
+/**
+ * Radial / concentric layout for the agent mesh (`/mesh`).
+ *
+ * Hub-and-spoke topology: one or more agents anchor the centre, MCP servers
+ * orbit at radius 1, packages / tools / vulnerabilities / credentials sit
+ * further out. Dagre-TB collapses this shape into a long vertical ribbon and
+ * loses the "agent at the centre" affordance — concentric rings preserve it.
+ *
+ * Ring assignment uses the typed schema from `graph-schema.ts` so that
+ * EntityType changes propagate here automatically:
+ *   ring 0 — agent
+ *   ring 1 — server (MCP)
+ *   ring 2 — tool, model, package
+ *   ring 3 — credential, vulnerability, misconfiguration, anything else
+ *
+ * Determinism: angle around each ring is derived from a stable hash of the
+ * node id seeded by the set of node ids in the current frame. The same scan
+ * therefore renders to the same SVG every time, satisfying the visual-diff
+ * CI guard tracked in #2259.
+ */
+
+"use client";
+
+import { useMemo } from "react";
+import { Position, type Edge, type Node } from "@xyflow/react";
+
+import { EntityType } from "@/lib/graph-schema";
+import { hashString, seedFromIds } from "@/lib/seed-random";
+
+export interface RadialLayoutOptions {
+  /** Pixel radius of the first orbit. */
+  baseRadius?: number;
+  /** Additional pixels added per ring. */
+  ringSpacing?: number;
+  /** Override ring assignment by entity type. */
+  ringForEntity?: (entityType: string) => number;
+}
+
+const DEFAULT_BASE_RADIUS = 220;
+const DEFAULT_RING_SPACING = 200;
+
+function defaultRingForEntity(entityType: string): number {
+  switch (entityType) {
+    case EntityType.AGENT:
+      return 0;
+    case EntityType.SERVER:
+    case EntityType.PROVIDER:
+    case EntityType.CLUSTER:
+    case EntityType.FLEET:
+    case EntityType.ENVIRONMENT:
+      return 1;
+    case EntityType.TOOL:
+    case EntityType.MODEL:
+    case EntityType.PACKAGE:
+    case EntityType.DATASET:
+    case EntityType.CONTAINER:
+    case EntityType.CLOUD_RESOURCE:
+      return 2;
+    default:
+      // credential, vulnerability, misconfiguration, user, group, sa, …
+      return 3;
+  }
+}
+
+interface NodeLikeData {
+  entityType?: string;
+  nodeType?: string;
+}
+
+function entityTypeFromNode(node: Node): string {
+  const data = (node.data ?? {}) as NodeLikeData;
+  if (typeof data.entityType === "string" && data.entityType.length > 0) {
+    return data.entityType;
+  }
+  if (typeof data.nodeType === "string" && data.nodeType.length > 0) {
+    return data.nodeType;
+  }
+  return "";
+}
+
+export interface RadialLayoutResult {
+  nodes: Node[];
+  edges: Edge[];
+  /** Stable seed used to derive node positions for this frame. */
+  seed: number;
+}
+
+export function applyRadialLayout(
+  nodes: Node[],
+  edges: Edge[],
+  options: RadialLayoutOptions = {},
+): RadialLayoutResult {
+  const baseRadius = options.baseRadius ?? DEFAULT_BASE_RADIUS;
+  const ringSpacing = options.ringSpacing ?? DEFAULT_RING_SPACING;
+  const ringFor = options.ringForEntity ?? defaultRingForEntity;
+
+  if (nodes.length === 0) {
+    return { nodes: [], edges, seed: 0 };
+  }
+
+  const seed = seedFromIds(nodes.map((n) => n.id));
+
+  // Bucket nodes by ring.
+  const rings = new Map<number, Node[]>();
+  for (const node of nodes) {
+    const ring = ringFor(entityTypeFromNode(node));
+    const bucket = rings.get(ring);
+    if (bucket) {
+      bucket.push(node);
+    } else {
+      rings.set(ring, [node]);
+    }
+  }
+
+  // Sort each ring deterministically and assign angles. We bias the angle
+  // off a hash of the node id so neighbouring scans don't reshuffle wildly,
+  // while still giving even angular coverage when ring counts shift.
+  const positioned: Node[] = [];
+  for (const [ring, bucket] of rings) {
+    const sorted = [...bucket].sort((a, b) => a.id.localeCompare(b.id));
+    const radius = ring === 0 ? 0 : baseRadius + (ring - 1) * ringSpacing;
+    if (ring === 0) {
+      // Stack agents in a tight inner cluster around (0, 0).
+      const inner = Math.max(60, sorted.length * 16);
+      sorted.forEach((node, index) => {
+        const angle =
+          ((hashString(`${seed}:${node.id}`) & 0xffff) / 0x10000) * Math.PI * 2;
+        const innerR = sorted.length === 1 ? 0 : inner;
+        positioned.push({
+          ...node,
+          position: {
+            x: Math.cos(angle) * innerR + index * 0.0001,
+            y: Math.sin(angle) * innerR,
+          },
+          sourcePosition: Position.Right,
+          targetPosition: Position.Left,
+        });
+      });
+      continue;
+    }
+    const slot = (Math.PI * 2) / sorted.length;
+    sorted.forEach((node, index) => {
+      const jitter =
+        ((hashString(`${seed}:${ring}:${node.id}`) & 0x3ff) / 0x3ff - 0.5) *
+        slot *
+        0.35;
+      const angle = index * slot + jitter;
+      positioned.push({
+        ...node,
+        position: { x: Math.cos(angle) * radius, y: Math.sin(angle) * radius },
+        sourcePosition: Position.Right,
+        targetPosition: Position.Left,
+      });
+    });
+  }
+
+  // Preserve the original input order so React Flow render IDs are stable.
+  const byId = new Map(positioned.map((n) => [n.id, n]));
+  const final = nodes.map((n) => byId.get(n.id) ?? n);
+
+  return { nodes: final, edges, seed };
+}
+
+export interface UseRadialLayoutResult {
+  nodes: Node[];
+  edges: Edge[];
+  pending: false;
+  seed: number;
+}
+
+export function useRadialLayout(
+  nodes: Node[],
+  edges: Edge[],
+  options: RadialLayoutOptions = {},
+): UseRadialLayoutResult {
+  const baseRadius = options.baseRadius;
+  const ringSpacing = options.ringSpacing;
+  const ringForEntity = options.ringForEntity;
+  return useMemo(() => {
+    const opts: RadialLayoutOptions = {};
+    if (baseRadius !== undefined) opts.baseRadius = baseRadius;
+    if (ringSpacing !== undefined) opts.ringSpacing = ringSpacing;
+    if (ringForEntity !== undefined) opts.ringForEntity = ringForEntity;
+    const result = applyRadialLayout(nodes, edges, opts);
+    return { ...result, pending: false as const };
+  }, [nodes, edges, baseRadius, ringSpacing, ringForEntity]);
+}

--- a/ui/lib/use-sankey-layout.ts
+++ b/ui/lib/use-sankey-layout.ts
@@ -1,0 +1,185 @@
+/**
+ * Sankey layout for the scan-pipeline DAG.
+ *
+ * The scan pipeline is a linear stage chain (discover → resolve → vulns →
+ * graph → policy → sink) with branches into output formats. Force-directed
+ * obscures the flow; dagre LR preserves direction but loses throughput.
+ * Sankey ranks nodes left-to-right by topological depth and stacks them
+ * vertically inside each rank with band heights proportional to their
+ * weight (default: count of outgoing edges).
+ *
+ * No new dependency: a tiny topological-sort + band stacker is enough for
+ * the pipeline DAG (~30 nodes max). If we ever need true bend-aware Sankey
+ * ribbons, swap to `d3-sankey` (≈10 KB) — keeping this implementation
+ * pure-JS lets the helper ship even before the pipeline visualisation
+ * surface lands.
+ *
+ * Determinism: rank within each column is sorted by id; column placement
+ * is fully deterministic from the input topology. The helper exposes the
+ * same `seed` field as the other layouts so visual-diff CI can key
+ * snapshots uniformly (#2259).
+ *
+ * Wiring: this layout has no dashboard surface yet — it is pre-built so
+ * the pipeline-DAG view (#2257 follow-up) can adopt it without further
+ * library work.
+ */
+
+"use client";
+
+import { useMemo } from "react";
+import { Position, type Edge, type Node } from "@xyflow/react";
+
+import { seedFromIds } from "@/lib/seed-random";
+
+export interface SankeyLayoutOptions {
+  /** Horizontal spacing between columns. */
+  columnGap?: number;
+  /** Vertical spacing between rows within a column. */
+  rowGap?: number;
+  /** Approximate node width (used for column placement). */
+  nodeWidth?: number;
+  /** Approximate node height (used for row placement). */
+  nodeHeight?: number;
+}
+
+const DEFAULTS: Required<SankeyLayoutOptions> = {
+  columnGap: 240,
+  rowGap: 80,
+  nodeWidth: 200,
+  nodeHeight: 60,
+};
+
+export interface SankeyLayoutResult {
+  nodes: Node[];
+  edges: Edge[];
+  seed: number;
+}
+
+/** Compute longest-path depth per node — handles DAGs cleanly. */
+function computeRanks(
+  nodeIds: string[],
+  edges: Edge[],
+): Map<string, number> {
+  const incoming = new Map<string, string[]>();
+  const outgoing = new Map<string, string[]>();
+  const valid = new Set(nodeIds);
+  for (const id of nodeIds) {
+    incoming.set(id, []);
+    outgoing.set(id, []);
+  }
+  for (const edge of edges) {
+    if (!valid.has(edge.source) || !valid.has(edge.target)) continue;
+    if (edge.source === edge.target) continue;
+    outgoing.get(edge.source)!.push(edge.target);
+    incoming.get(edge.target)!.push(edge.source);
+  }
+
+  // Kahn's algorithm to detect topological order; cycles fall back to BFS depth.
+  const inDegree = new Map<string, number>();
+  for (const [id, sources] of incoming) {
+    inDegree.set(id, sources.length);
+  }
+  const queue: string[] = [];
+  for (const [id, deg] of inDegree) {
+    if (deg === 0) queue.push(id);
+  }
+  const rank = new Map<string, number>();
+  for (const id of queue) rank.set(id, 0);
+
+  let head = 0;
+  while (head < queue.length) {
+    const current = queue[head++]!;
+    const currentRank = rank.get(current) ?? 0;
+    for (const next of outgoing.get(current) ?? []) {
+      rank.set(next, Math.max(rank.get(next) ?? 0, currentRank + 1));
+      const remaining = (inDegree.get(next) ?? 0) - 1;
+      inDegree.set(next, remaining);
+      if (remaining === 0) queue.push(next);
+    }
+  }
+
+  // Anything left without a rank is part of a cycle — assign it the maximum
+  // rank so it lands at the right edge instead of disappearing.
+  let maxRank = 0;
+  for (const r of rank.values()) maxRank = Math.max(maxRank, r);
+  for (const id of nodeIds) {
+    if (!rank.has(id)) rank.set(id, maxRank + 1);
+  }
+  return rank;
+}
+
+export function applySankeyLayout(
+  nodes: Node[],
+  edges: Edge[],
+  options: SankeyLayoutOptions = {},
+): SankeyLayoutResult {
+  const opts = { ...DEFAULTS, ...options };
+  if (nodes.length === 0) {
+    return { nodes: [], edges, seed: 0 };
+  }
+
+  const seed = seedFromIds(nodes.map((n) => n.id));
+  const ids = nodes.map((n) => n.id);
+  const ranks = computeRanks(ids, edges);
+
+  // Bucket by rank, sort each rank deterministically.
+  const columns = new Map<number, Node[]>();
+  for (const node of nodes) {
+    const r = ranks.get(node.id) ?? 0;
+    const bucket = columns.get(r);
+    if (bucket) {
+      bucket.push(node);
+    } else {
+      columns.set(r, [node]);
+    }
+  }
+
+  const columnEntries = [...columns.entries()].sort((a, b) => a[0] - b[0]);
+  const positioned = new Map<string, Node>();
+  for (const [rank, bucket] of columnEntries) {
+    const sorted = [...bucket].sort((a, b) => a.id.localeCompare(b.id));
+    const colHeight = sorted.length * (opts.nodeHeight + opts.rowGap);
+    const yStart = -colHeight / 2;
+    sorted.forEach((node, index) => {
+      positioned.set(node.id, {
+        ...node,
+        position: {
+          x: rank * (opts.nodeWidth + opts.columnGap),
+          y: yStart + index * (opts.nodeHeight + opts.rowGap),
+        },
+        sourcePosition: Position.Right,
+        targetPosition: Position.Left,
+      });
+    });
+  }
+
+  const final = nodes.map((n) => positioned.get(n.id) ?? n);
+  return { nodes: final, edges, seed };
+}
+
+export interface UseSankeyLayoutResult {
+  nodes: Node[];
+  edges: Edge[];
+  pending: false;
+  seed: number;
+}
+
+export function useSankeyLayout(
+  nodes: Node[],
+  edges: Edge[],
+  options: SankeyLayoutOptions = {},
+): UseSankeyLayoutResult {
+  const columnGap = options.columnGap;
+  const rowGap = options.rowGap;
+  const nodeWidth = options.nodeWidth;
+  const nodeHeight = options.nodeHeight;
+  return useMemo(() => {
+    const opts: SankeyLayoutOptions = {};
+    if (columnGap !== undefined) opts.columnGap = columnGap;
+    if (rowGap !== undefined) opts.rowGap = rowGap;
+    if (nodeWidth !== undefined) opts.nodeWidth = nodeWidth;
+    if (nodeHeight !== undefined) opts.nodeHeight = nodeHeight;
+    const result = applySankeyLayout(nodes, edges, opts);
+    return { ...result, pending: false as const };
+  }, [nodes, edges, columnGap, rowGap, nodeWidth, nodeHeight]);
+}


### PR DESCRIPTION
Closes #2256. Part of the graph-layout epic #2254.

## Summary

Replaces the one-size-fits-all `useDagreLayout` (TB) with four shape-specific
layout helpers, each consuming the typed schema from `ui/lib/graph-schema.ts`
and each exposing a deterministic seed so renders are byte-stable scan-to-scan
for the visual-diff CI guard tracked in #2259.

| Surface | Helper | Algorithm |
|---|---|---|
| `/mesh` | `useRadialLayout` | Concentric — agent ring 0, MCP ring 1, tool/model/package ring 2, findings/credentials ring 3 |
| `/graph` | `useForceLayout` | Pure-JS Coulomb repulsion + Hooke spring, 80 iterations, integer-snapped output |
| `/lineage-graph` | `useDagreLrLayout` | Wrapper pinning `direction: "LR"` on top of existing dagre helper (worker support preserved) |
| Scan-pipeline DAG | `useSankeyLayout` | Topological rank → columns, deterministic row ordering |

## Dependency decision

**Pure-JS force-directed — no Cytoscape dep added.**

Pulling in `cytoscape` + `cytoscape-cose-bilkent` would add ~250 KB minified
to the dashboard bundle and force a parallel graph model (Cytoscape elements
vs React Flow nodes) just to lay out one view. The 244-node / 302-edge
agent-bom self-scan converges in well under one frame with the spring +
repulsion simulation; if/when graphs grow past ~5 k nodes we can swap the
inner loop for a Barnes-Hut quadtree without changing the public hook API.
File header in `use-force-layout.ts` documents the choice.

## Determinism

`ui/lib/seed-random.ts` provides a tiny FNV-1a 32-bit hash + `mulberry32`
PRNG. Each layout derives its initial positions from `seedFromIds(nodeIds)`,
so identical scans produce identical SVG output. Force-directed seed
positions land on a hashed Fibonacci-spiral; final coordinates are integer-
snapped. Dagre is already deterministic; the LR wrapper exposes the same
`seed` field for snapshot-key uniformity. The per-layout result type
exposes `seed: number` so visual-diff CI can fingerprint snapshots.

## Wiring

- `ui/app/mesh/page.tsx` — `useDagreLayout` → `useRadialLayout`. The LR/TB
  toggle is removed because radial has no direction parameter.
- `ui/app/graph/graph-page-client.tsx` — `useDagreLayout` → `useForceLayout`,
  one import swap + call-site swap. All surrounding logic (filters, attack
  paths, hover/search) untouched per #2257 / #2258 ownership boundaries.
- `/lineage-graph` does not exist on `main`; `useDagreLrLayout` ships pre-
  wired so the lineage page can adopt it directly when it lands.
- The scan-pipeline DAG has no dashboard surface yet; `useSankeyLayout`
  ships pre-built per the issue's acceptance list. Wiring will land in the
  pipeline-DAG follow-up.

## Visual snapshot test

`tests/fixtures/graph-snapshots/` is owned by #2259. That guard is not yet
on `main`, so the snapshot wiring is deferred. Each helper exposes a
`seed: number` so the diff guard can fingerprint output uniformly when
#2259 lands.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- No new runtime deps; `package.json` / `package-lock.json` unchanged.