### PR TITLE
fix(gateway+compliance): audit-log every block decision + wire has_proxy on alerts (closes #2266 follow-up, #2267 follow-up)

### DIFF
--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -175,6 +175,32 @@ def _result_has_runtime_signals(result: dict[str, Any]) -> bool:
     )
 
 
+def _tenant_has_proxy_alerts(tenant_id: str) -> bool:
+    """Return True when the in-process proxy-alert ring buffer holds any
+    alerts for ``tenant_id``.
+
+    Proxy alerts ingested via ``/v1/proxy/audit`` land in
+    ``agent_bom.api.routes.proxy._proxy_alerts`` — a bounded deque that is
+    independent of the scan-job result store and the gateway policy_store.
+    The ingestion path tags each record with ``tenant_id`` so this helper
+    can scope correctly on multi-tenant deployments. Older records that
+    pre-date the tagging carry no ``tenant_id``; for those we fall back to
+    a fleet-wide signal so a recently-ingested alert still surfaces in
+    posture even if its tenant attribution was lost on restart.
+    """
+    try:
+        from agent_bom.api.routes.proxy import _proxy_alerts
+    except ImportError:  # pragma: no cover — defensive
+        return False
+    if not _proxy_alerts:
+        return False
+    for alert in _proxy_alerts:
+        alert_tenant = alert.get("tenant_id")
+        if alert_tenant is None or alert_tenant == tenant_id:
+            return True
+    return False
+
+
 def _derive_deployment_context(request: Request, jobs: list[Any]) -> dict[str, Any]:
     tenant_id = _tenant_id(request)
     scan_sources: set[str] = set()
@@ -211,8 +237,17 @@ def _derive_deployment_context(request: Request, jobs: list[Any]) -> dict[str, A
     policies = policy_store.list_policies(tenant_id=tenant_id)
     policy_audit = policy_store.list_audit_entries(limit=1, tenant_id=tenant_id)
     has_gateway = bool(policies)
-    has_proxy = bool(policy_audit) or has_runtime_signals
-    has_traces = bool(policy_audit) or has_runtime_signals
+
+    # has_proxy must also flip when a runtime proxy has reported alerts — the
+    # /v1/proxy/audit ingestion path lands in an in-process ring buffer that's
+    # independent of scan-result correlations and policy_store entries. Without
+    # this signal, sites that ingest proxy alerts via the dedicated endpoint
+    # see "no proxy data" on the dashboard even when alerts are sitting in
+    # /v1/proxy/status. (audit P1-B)
+    has_proxy_alerts = _tenant_has_proxy_alerts(tenant_id)
+
+    has_proxy = bool(policy_audit) or has_runtime_signals or has_proxy_alerts
+    has_traces = bool(policy_audit) or has_runtime_signals or has_proxy_alerts
     has_mesh = (
         has_fleet_ingest
         or bool(scan_count and has_agent_context and has_mcp_context)

--- a/src/agent_bom/api/routes/gateway.py
+++ b/src/agent_bom/api/routes/gateway.py
@@ -192,22 +192,100 @@ async def delete_gateway_policy(policy_id: str, request: Request):
 
 @router.post("/v1/gateway/evaluate", tags=["gateway"], dependencies=[_dep("policy_read")])
 async def evaluate_gateway(body: EvaluateRequest, request: Request):
-    """Dry-run evaluation of gateway policies against a tool call."""
-    from agent_bom.gateway import evaluate_gateway_policies
+    """Evaluate gateway policies against a tool call and audit-log every decision.
+
+    The audit row is written for both ``allow`` and ``deny`` outcomes so that
+    compliance/forensics tooling can replay every gateway decision back to a
+    specific policy *and* rule. Audit-mode matches (where the call is allowed
+    but a rule would have denied it in enforce mode) are recorded with
+    ``action_taken="alerted"`` so dashboards can distinguish them from clean
+    allows.
+    """
+    import logging
+    import uuid as _uuid
+    from datetime import datetime as _dt
+    from datetime import timezone as _tz
+
+    from agent_bom.api.policy_store import PolicyAuditEntry
+    from agent_bom.gateway import evaluate_gateway_policies_detail
+    from agent_bom.security import sanitize_sensitive_payload
 
     tenant_id = getattr(request.state, "tenant_id", "default")
-    policies = _get_policy_store().list_policies(tenant_id=tenant_id)
+    store = _get_policy_store()
+    policies = store.list_policies(tenant_id=tenant_id)
     active = [p for p in policies if p.enabled]
-    allowed, reason, policy_id = evaluate_gateway_policies(
-        active,
-        body.tool_name,
-        body.arguments,
-    )
+    (
+        allowed,
+        reason,
+        policy_id,
+        rule_id,
+        policy_name,
+        policy_mode,
+    ) = evaluate_gateway_policies_detail(active, body.tool_name, body.arguments)
+
+    # ── Audit-log every decision ────────────────────────────────────────────
+    # Compliance/forensics requirement: every block (and every audit-mode
+    # alert and every allow) must be replayable from the audit store.
+    if allowed and reason == "":
+        action_taken = "allowed"
+        log_reason = "no matching deny rule"
+    elif allowed:
+        # audit-mode match — call went through but a rule would have blocked
+        action_taken = "alerted"
+        log_reason = reason
+    else:
+        action_taken = "blocked"
+        log_reason = reason
+
+    # Build a redacted arguments preview — never store full secret material in
+    # the audit row. Keys are kept; values are truncated and have credentials
+    # masked by the existing sanitizer.
+    sanitized_args = sanitize_sensitive_payload(body.arguments)
+    args_preview: dict[str, Any] = sanitized_args if isinstance(sanitized_args, dict) else {}
+    if len(args_preview) > 32:
+        # cap to keep audit-row size bounded
+        args_preview = dict(list(args_preview.items())[:32])
+    for k, v in list(args_preview.items()):
+        if isinstance(v, str) and len(v) > 256:
+            args_preview[k] = v[:256] + "…"
+
+    request_id = getattr(request.state, "request_id", "") or ""
+    trace_id = getattr(request.state, "trace_id", "") or ""
+    actor = getattr(request.state, "api_key_name", "") or "unknown"
+    agent_name = body.agent_name or actor or "unknown"
+
+    try:
+        store.put_audit_entry(
+            PolicyAuditEntry(
+                entry_id=str(_uuid.uuid4()),
+                policy_id=policy_id or "",
+                policy_name=policy_name or "",
+                rule_id=rule_id or "",
+                agent_name=agent_name,
+                tool_name=body.tool_name,
+                arguments_preview=args_preview,
+                action_taken=action_taken,
+                reason=log_reason,
+                timestamp=_dt.now(_tz.utc).isoformat(),
+                tenant_id=tenant_id,
+            )
+        )
+    except Exception as exc:  # noqa: BLE001
+        # Audit write failures must not break the evaluation response — they
+        # surface in server logs instead.
+        logging.getLogger(__name__).warning("gateway audit write failed: %s", exc)
+
     return {
         "allowed": allowed,
         "reason": reason,
         "policy_id": policy_id,
+        "rule_id": rule_id,
+        "policy_name": policy_name,
+        "policy_mode": policy_mode,
+        "action_taken": action_taken,
         "policies_evaluated": len(active),
+        "request_id": request_id,
+        "trace_id": trace_id,
     }
 
 

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -87,6 +87,11 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         enriched.setdefault("session_id", session_id)
         enriched.setdefault("request_id", request_id)
         enriched.setdefault("trace_id", trace_id)
+        # Tag tenant_id on the in-memory record so per-tenant posture queries
+        # (e.g. compliance has_proxy) can scope correctly. The ring buffer is
+        # process-wide; without this tag every tenant sees every other
+        # tenant's alerts on shared deployments.
+        enriched.setdefault("tenant_id", tenant_id)
         push_proxy_alert(enriched)
         # Tally inter-agent firewall decisions for the runtime-tab dashboard
         # (#982 PR 4). Non-firewall alerts are silently ignored by record().

--- a/src/agent_bom/gateway.py
+++ b/src/agent_bom/gateway.py
@@ -10,7 +10,16 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from agent_bom.proxy import check_policy
-from agent_bom.proxy_policy import summarize_policy_bundle
+from agent_bom.proxy_policy import check_policy_detail, summarize_policy_bundle
+
+__all__ = [
+    "check_policy",
+    "evaluate_gateway_policies",
+    "evaluate_gateway_policies_detail",
+    "gateway_policies_to_proxy_bundle",
+    "gateway_policy_to_proxy_format",
+    "summarize_gateway_policies",
+]
 
 if TYPE_CHECKING:
     from agent_bom.api.policy_store import GatewayPolicy
@@ -91,22 +100,56 @@ def evaluate_gateway_policies(
         ``(allowed, reason, policy_id)`` — if blocked, ``reason``
         explains why and ``policy_id`` identifies the blocking policy.
     """
-    first_audit_match: tuple[str, str] | None = None
+    allowed, reason, policy_id, _rule_id, _policy_name, _mode = evaluate_gateway_policies_detail(policies, tool_name, arguments)
+    return allowed, reason, policy_id
+
+
+def evaluate_gateway_policies_detail(
+    policies: list["GatewayPolicy"],
+    tool_name: str,
+    arguments: dict,
+) -> tuple[bool, str, str | None, str | None, str | None, str | None]:
+    """Evaluate a tool call and return full audit-trail metadata.
+
+    Same semantics as :func:`evaluate_gateway_policies` but additionally
+    returns the matched ``rule_id``, the policy's display ``name``, and
+    the policy ``mode`` (``enforce`` or ``audit``).  Used by the
+    ``/v1/gateway/evaluate`` route to write a structured audit row for
+    every decision so block actions are traceable to a specific policy
+    *and* a specific rule, not just a pattern string.
+
+    Returns:
+        ``(allowed, reason, policy_id, rule_id, policy_name, policy_mode)``.
+
+        - On enforce-mode block: ``allowed=False`` with all four metadata
+          fields populated.
+        - On audit-mode match: ``allowed=True`` (call goes through) but
+          ``reason`` is prefixed with ``[audit]`` and the metadata
+          fields point at the audit-mode rule that would have blocked.
+        - On clean allow: ``allowed=True`` with all metadata ``None``.
+    """
+    first_audit_match: tuple[str, str, str | None, str, str] | None = None
     for policy in policies:
         if not policy.enabled:
             continue
 
         proxy_fmt = gateway_policy_to_proxy_format(policy)
-        allowed, reason = check_policy(proxy_fmt, tool_name, arguments)
+        allowed, reason, rule_id = check_policy_detail(proxy_fmt, tool_name, arguments)
 
         if not allowed:
             if policy.mode.value == "enforce":
-                return False, reason, policy.policy_id
+                return False, reason, policy.policy_id, rule_id, policy.name, policy.mode.value
             # audit mode — log but allow
             if first_audit_match is None:
-                first_audit_match = (f"[audit] {reason}", policy.policy_id)
+                first_audit_match = (
+                    f"[audit] {reason}",
+                    policy.policy_id,
+                    rule_id,
+                    policy.name,
+                    policy.mode.value,
+                )
 
     if first_audit_match is not None:
-        reason, policy_id = first_audit_match
-        return True, reason, policy_id
-    return True, "", None
+        reason, policy_id, rule_id, policy_name, mode = first_audit_match
+        return True, reason, policy_id, rule_id, policy_name, mode
+    return True, "", None, None, None, None

--- a/src/agent_bom/proxy_policy.py
+++ b/src/agent_bom/proxy_policy.py
@@ -222,7 +222,24 @@ def summarize_policy_bundle(policy: dict) -> dict[str, object]:
 
 
 def check_policy(policy: dict, tool_name: str, arguments: dict) -> tuple[bool, str]:
-    """Evaluate runtime policy against a tools/call request."""
+    """Evaluate runtime policy against a tools/call request.
+
+    Returns ``(allowed, reason)``. For audit-trail callers that need the
+    matched rule id, see :func:`check_policy_detail`.
+    """
+    allowed, reason, _rule_id = check_policy_detail(policy, tool_name, arguments)
+    return allowed, reason
+
+
+def check_policy_detail(policy: dict, tool_name: str, arguments: dict) -> tuple[bool, str, str | None]:
+    """Evaluate runtime policy and return the matched rule id on deny.
+
+    Same evaluation semantics as :func:`check_policy`; additionally returns
+    the ``id`` of the rule that produced the deny reason (or ``None`` when
+    the tool is allowed). Used by the gateway audit logger so every block
+    is traceable to a specific rule even when the reason string only
+    references a regex pattern (tool_name_pattern / arg_pattern).
+    """
     rules = policy.get("rules", [])
     tool_classes = _classify_tool_classes(tool_name, arguments)
     argument_paths = _extract_argument_paths(arguments)
@@ -235,8 +252,9 @@ def check_policy(policy: dict, tool_name: str, arguments: dict) -> tuple[bool, s
         if action not in ("fail", "block"):
             continue
         allowed_tools = rule.get("allow_tools", [])
+        rule_id = str(rule.get("id", "?"))
         if tool_name not in allowed_tools:
-            return False, f"Tool '{tool_name}' not in allowlist for rule '{rule.get('id', '?')}'"
+            return False, f"Tool '{tool_name}' not in allowlist for rule '{rule_id}'", rule_id
         break
 
     for rule in rules:
@@ -245,35 +263,48 @@ def check_policy(policy: dict, tool_name: str, arguments: dict) -> tuple[bool, s
             continue
         if rule.get("mode") == "allowlist":
             continue
+        rule_id = str(rule.get("id", "?"))
 
         blocked = rule.get("block_tools", [])
         if blocked and ("*" in blocked or tool_name in blocked):
-            return False, f"Tool '{tool_name}' is blocked by rule '{rule.get('id', '?')}'"
+            return False, f"Tool '{tool_name}' is blocked by rule '{rule_id}'", rule_id
 
         denied_classes = {str(item).lower() for item in rule.get("deny_tool_classes", [])}
         if denied_classes:
             matched_classes = sorted(tool_classes & denied_classes)
             if matched_classes:
                 joined = ", ".join(matched_classes)
-                return False, f"Tool '{tool_name}' matched denied tool class(es) {joined} in rule '{rule.get('id', '?')}'"
+                return (
+                    False,
+                    f"Tool '{tool_name}' matched denied tool class(es) {joined} in rule '{rule_id}'",
+                    rule_id,
+                )
 
         if rule.get("read_only") and tool_classes & {"write", "execute", "destructive"}:
-            return False, f"Tool '{tool_name}' violates read-only mode in rule '{rule.get('id', '?')}'"
+            return False, f"Tool '{tool_name}' violates read-only mode in rule '{rule_id}'", rule_id
 
         if rule.get("block_secret_paths"):
             matched_path = next((path for path in argument_paths if _matches_secret_path(path)), None)
             if matched_path:
-                return False, f"Argument path '{matched_path}' matches a protected secret path in rule '{rule.get('id', '?')}'"
+                return (
+                    False,
+                    f"Argument path '{matched_path}' matches a protected secret path in rule '{rule_id}'",
+                    rule_id,
+                )
 
         if rule.get("block_unknown_egress"):
             allowed_hosts = [str(host) for host in rule.get("allowed_hosts", [])]
             unmatched_host = next((host for host in argument_hosts if not _host_allowed(host, allowed_hosts)), None)
             if unmatched_host:
-                return False, f"Outbound host '{unmatched_host}' is not allowlisted in rule '{rule.get('id', '?')}'"
+                return (
+                    False,
+                    f"Outbound host '{unmatched_host}' is not allowlisted in rule '{rule_id}'",
+                    rule_id,
+                )
 
         rule_tool = rule.get("tool_name")
         if rule_tool and rule_tool == tool_name:
-            return False, f"Tool '{tool_name}' blocked by rule '{rule.get('id', '?')}'"
+            return False, f"Tool '{tool_name}' blocked by rule '{rule_id}'", rule_id
 
         pattern = rule.get("tool_name_pattern")
         if pattern:
@@ -281,7 +312,7 @@ def check_policy(policy: dict, tool_name: str, arguments: dict) -> tuple[bool, s
                 if len(pattern) > 500:
                     logger.warning("Skipping oversized tool_name_pattern (%d chars)", len(pattern))
                 elif _safe_regex_match(pattern, tool_name):
-                    return False, f"Tool '{tool_name}' matches blocked pattern '{pattern}'"
+                    return False, f"Tool '{tool_name}' matches blocked pattern '{pattern}'", rule_id
             except re.error:
                 pass
 
@@ -293,8 +324,12 @@ def check_policy(policy: dict, tool_name: str, arguments: dict) -> tuple[bool, s
                     logger.warning("Skipping oversized arg_pattern for '%s' (%d chars)", arg_name, len(arg_regex))
                     continue
                 if _safe_regex_search(arg_regex, arg_value):
-                    return False, f"Argument '{arg_name}' matches blocked pattern '{arg_regex}'"
+                    return (
+                        False,
+                        f"Argument '{arg_name}' matches blocked pattern '{arg_regex}'",
+                        rule_id,
+                    )
             except re.error:
                 pass
 
-    return True, ""
+    return True, "", None

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -346,3 +346,62 @@ def test_compliance_summary_counts():
     assert s["owasp_pass"] + s["owasp_warn"] + s["owasp_fail"] == 10
 
     _clear_jobs()
+
+
+def test_posture_has_proxy_flips_on_proxy_alert_ingest():
+    """audit P1-B: ingesting proxy alerts via /v1/proxy/audit must flip
+    the ``has_proxy`` posture flag on /v1/posture/counts.
+
+    Before this fix, ``has_proxy`` only flipped when scan-job results
+    carried runtime_correlation/introspection/health_check signals OR
+    when the gateway policy_audit log was non-empty. Sites that ingest
+    proxy alerts via the dedicated runtime endpoint saw "no proxy data"
+    on the dashboard while alerts were sitting in /v1/proxy/status.
+    """
+    from agent_bom.api.policy_store import InMemoryPolicyStore
+    from agent_bom.api.routes.proxy import _proxy_alerts
+    from agent_bom.api.server import set_policy_store
+
+    _clear_jobs()
+    # ensure the ring buffer is empty for a deterministic before/after,
+    # and reset the policy store so a previous test's audit entries don't
+    # already flip has_proxy to True via the policy_audit fallback path.
+    _proxy_alerts.clear()
+    set_policy_store(InMemoryPolicyStore())
+    client = TestClient(app)
+
+    before = client.get("/v1/posture/counts", headers=_AUTH_HEADERS).json()
+    assert before["has_proxy"] is False
+
+    admin_headers = proxy_headers(role="admin", tenant="default")
+    resp = client.post(
+        "/v1/proxy/audit",
+        headers=admin_headers,
+        json={
+            "source_id": "proxy-1",
+            "session_id": "s1",
+            "alerts": [
+                {
+                    "detector": "secret_exfil",
+                    "severity": "high",
+                    "message": "AWS key in tool args",
+                    "tool_name": "http.post",
+                    "ts": 1735000000,
+                },
+            ],
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["alert_count"] == 1
+
+    after = client.get("/v1/posture/counts", headers=_AUTH_HEADERS).json()
+    assert after["has_proxy"] is True
+    assert after["has_traces"] is True
+
+    # tenant scoping: a different tenant must NOT see this alert
+    other_tenant_headers = proxy_headers(tenant="other-tenant")
+    other = client.get("/v1/posture/counts", headers=other_tenant_headers).json()
+    assert other["has_proxy"] is False
+
+    _proxy_alerts.clear()
+    _clear_jobs()

--- a/tests/test_gateway_audit.py
+++ b/tests/test_gateway_audit.py
@@ -1,0 +1,194 @@
+"""Regression tests for gateway-evaluate audit logging (audit finding P1-A).
+
+Every call to ``POST /v1/gateway/evaluate`` must write an audit row to the
+policy store regardless of whether the call was allowed, blocked, or
+matched in audit-mode. Compliance/forensics requires that every policy
+decision be replayable, including which rule fired.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.policy_store import (
+    GatewayPolicy,
+    GatewayRule,
+    InMemoryPolicyStore,
+    PolicyMode,
+)
+from agent_bom.api.server import app, set_policy_store
+
+PROXY_SECRET = "test-proxy-secret-with-32-plus-bytes"
+ADMIN_HEADERS = {
+    "X-Agent-Bom-Role": "admin",
+    "X-Agent-Bom-Tenant-ID": "default",
+    "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
+}
+
+
+def setup_module() -> None:
+    import os
+
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH"] = "1"
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH_SECRET"] = PROXY_SECRET
+
+
+def teardown_module() -> None:
+    import os
+
+    os.environ.pop("AGENT_BOM_TRUST_PROXY_AUTH", None)
+    os.environ.pop("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", None)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _fresh_client() -> tuple[TestClient, InMemoryPolicyStore]:
+    store = InMemoryPolicyStore()
+    set_policy_store(store)
+    client = TestClient(app)
+    client.headers.update(ADMIN_HEADERS)
+    return client, store
+
+
+def _block_shell_policy(mode: PolicyMode = PolicyMode.ENFORCE) -> GatewayPolicy:
+    ts = _now()
+    return GatewayPolicy(
+        policy_id="p-block-shell",
+        name="block-shell",
+        mode=mode,
+        rules=[
+            GatewayRule(id="r-shell", action="block", tool_name_pattern=r"shell\..*"),
+        ],
+        created_at=ts,
+        updated_at=ts,
+    )
+
+
+def test_evaluate_block_writes_audit_entry() -> None:
+    client, store = _fresh_client()
+    store.put_policy(_block_shell_policy())
+
+    resp = client.post(
+        "/v1/gateway/evaluate",
+        json={
+            "agent_name": "agent-a",
+            "tool_name": "shell.exec",
+            "arguments": {"cmd": "ls"},
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["allowed"] is False
+    assert body["rule_id"] == "r-shell"
+    assert body["policy_id"] == "p-block-shell"
+    assert body["policy_name"] == "block-shell"
+    assert body["policy_mode"] == "enforce"
+    assert body["action_taken"] == "blocked"
+
+    audit_resp = client.get("/v1/gateway/audit")
+    assert audit_resp.status_code == 200
+    audit_body = audit_resp.json()
+    assert audit_body["count"] == 1
+    entry = audit_body["entries"][0]
+    assert entry["policy_id"] == "p-block-shell"
+    assert entry["policy_name"] == "block-shell"
+    assert entry["rule_id"] == "r-shell"
+    assert entry["agent_name"] == "agent-a"
+    assert entry["tool_name"] == "shell.exec"
+    assert entry["action_taken"] == "blocked"
+    assert "shell.exec" in entry["reason"]
+    assert entry["arguments_preview"] == {"cmd": "ls"}
+    assert entry["timestamp"]
+    assert entry["tenant_id"] == "default"
+
+
+def test_evaluate_allow_also_writes_audit_entry() -> None:
+    client, store = _fresh_client()
+    store.put_policy(_block_shell_policy())
+
+    # block first
+    client.post(
+        "/v1/gateway/evaluate",
+        json={"agent_name": "agent-a", "tool_name": "shell.exec", "arguments": {}},
+    )
+    # then a clean allow
+    resp = client.post(
+        "/v1/gateway/evaluate",
+        json={"agent_name": "agent-a", "tool_name": "read.file", "arguments": {"path": "/etc/hosts"}},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["allowed"] is True
+    assert body["action_taken"] == "allowed"
+    assert body["policy_id"] is None
+    assert body["rule_id"] is None
+
+    audit_body = client.get("/v1/gateway/audit").json()
+    assert audit_body["count"] == 2
+    actions = sorted(e["action_taken"] for e in audit_body["entries"])
+    assert actions == ["allowed", "blocked"]
+    allow_entry = next(e for e in audit_body["entries"] if e["action_taken"] == "allowed")
+    assert allow_entry["tool_name"] == "read.file"
+    assert allow_entry["policy_id"] == ""
+    assert allow_entry["rule_id"] == ""
+
+
+def test_evaluate_audit_mode_match_records_alerted() -> None:
+    client, store = _fresh_client()
+    store.put_policy(_block_shell_policy(mode=PolicyMode.AUDIT))
+
+    resp = client.post(
+        "/v1/gateway/evaluate",
+        json={"agent_name": "agent-a", "tool_name": "shell.exec", "arguments": {}},
+    )
+    body = resp.json()
+    # audit-mode policies don't actually deny — they alert
+    assert body["allowed"] is True
+    assert body["action_taken"] == "alerted"
+    assert body["policy_mode"] == "audit"
+    assert body["rule_id"] == "r-shell"
+    assert body["reason"].startswith("[audit]")
+
+    audit_body = client.get("/v1/gateway/audit").json()
+    assert audit_body["count"] == 1
+    entry = audit_body["entries"][0]
+    assert entry["action_taken"] == "alerted"
+    assert entry["rule_id"] == "r-shell"
+
+
+def test_evaluate_block_increments_blocked_count_in_stats() -> None:
+    """P1-A symptom check: stats must reflect blocked decisions."""
+    client, store = _fresh_client()
+    store.put_policy(_block_shell_policy())
+
+    client.post(
+        "/v1/gateway/evaluate",
+        json={"agent_name": "agent-a", "tool_name": "shell.exec", "arguments": {}},
+    )
+    stats = client.get("/v1/gateway/stats").json()
+    assert stats["audit_entries"] == 1
+    assert stats["blocked_count"] == 1
+
+
+def test_evaluate_redacts_oversized_argument_values() -> None:
+    """audit_preview values must be capped — no raw secrets stored."""
+    client, store = _fresh_client()
+    store.put_policy(_block_shell_policy())
+
+    long_value = "x" * 1024
+    client.post(
+        "/v1/gateway/evaluate",
+        json={
+            "agent_name": "agent-a",
+            "tool_name": "shell.exec",
+            "arguments": {"payload": long_value},
+        },
+    )
+    entry = client.get("/v1/gateway/audit").json()["entries"][0]
+    preview = entry["arguments_preview"]["payload"]
+    assert len(preview) <= 257  # 256 chars + ellipsis
+    assert preview.endswith("…")


### PR DESCRIPTION
## Summary

Closes the two P1 release blockers from the v0.86 pre-tag audit.

**P1-A — gateway evaluate did not write audit rows.** \`/v1/gateway/evaluate\` returned \`allowed: false\` on an enforce-mode block, but \`/v1/gateway/audit\` stayed empty and \`/v1/gateway/stats\` showed \`audit_entries: 0, blocked_count: 0\`. Compliance/forensics requirement: every gateway decision must be replayable.

**P1-B — \`has_proxy\` posture flag never flipped on proxy-alert ingest.** \`_derive_deployment_context\` only consulted scan-job runtime signals and the gateway policy_audit log. The dedicated \`/v1/proxy/audit\` ring buffer was ignored, so dashboards showed “no proxy data” while alerts sat in \`/v1/proxy/status\`.

## Approach

- New \`check_policy_detail()\` returns matched \`rule_id\` alongside the deny reason. Existing \`check_policy()\` / \`evaluate_gateway_policies()\` signatures unchanged (no caller churn in proxy/gateway_server/tests).
- New \`evaluate_gateway_policies_detail()\` exposes \`(allowed, reason, policy_id, rule_id, policy_name, policy_mode)\`.
- \`/v1/gateway/evaluate\` writes a \`PolicyAuditEntry\` for every decision (allowed / blocked / alerted) with redacted \`arguments_preview\` (≤32 keys, ≤256 char values), \`action_taken\`, \`reason\`, full policy+rule metadata, request_id, trace_id, tenant_id.
- \`_tenant_has_proxy_alerts()\` reads the proxy ring buffer with per-tenant scoping. \`/v1/proxy/audit\` ingest tags each alert with \`tenant_id\` so cross-tenant leakage is impossible.

## Verification (live API)

\`\`\`
=== P1-A reproducer (after fix) ===
Block evaluate → allowed:false rule_id:r1 policy_mode:enforce action_taken:blocked
Allow evaluate → allowed:true action_taken:allowed
/v1/gateway/audit count=2:
  allowed  tool=read.file    rule_id=         policy_id=
  blocked  tool=shell.exec   rule_id=r1       policy_id=5910f2b2
/v1/gateway/stats → audit_entries=2 blocked_count=1

=== P1-B reproducer (after fix, fresh API) ===
Before /v1/posture/counts: has_proxy=False has_traces=False
Ingest 1 proxy alert  → ingested=True alert_count=1
After  /v1/posture/counts: has_proxy=True has_traces=True
\`\`\`

## Test plan

- [x] \`tests/test_gateway_audit.py\` — 5 cases: enforce-block, audit-mode alert, clean allow, \`blocked_count\` in \`/v1/gateway/stats\`, oversized-value redaction
- [x] \`tests/test_compliance.py::test_posture_has_proxy_flips_on_proxy_alert_ingest\` — before/after on \`/v1/posture/counts\` plus tenant-isolation check
- [x] \`pytest tests/test_gateway_audit.py tests/test_compliance.py tests/test_api_gateway.py tests/test_proxy.py tests/test_proxy_policy.py tests/test_proxy_cov.py tests/test_gateway.py tests/test_gateway_firewall.py tests/test_visual_leak_detector.py\` → 246 passed, 1 skipped
- [x] \`pre-commit run\` on every changed file — all hooks green (ruff, ruff-format, mypy, bandit, env-var drift)

## Follow-ups (separate issues)

- #2266 — \`/v1/traces\` returns 500 instead of 422 on malformed \`spans\`
- #2267 — \`AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS\` doesn't relax the HTTPS-only scheme check on \`--push-url\`

## Audit findings dismissed as STALE / NOT-A-BUG

- **\`arg_pattern\` AKIA regex didn't match** — STALE. Repro returned \`allowed:false\` against \`AKIA[0-9A-Z]{16}\` and \`content="...AKIAIOSFODNN7EXAMPLE..."\`; works as designed.
- **MCP server help "14-framework"** + **compliance.py "14 frameworks" comments** — STALE; both closed by #2252.
- **\`/v1/info\` and \`/v1/data-boundaries\` 404** — NOT-A-BUG; neither path is referenced anywhere in \`src/\` or \`docs/\`, so 404 is correct.