### PR TITLE
test(graph): round-trip + edge-count + visual-diff accuracy guards (#2259)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,6 +500,36 @@ jobs:
             uv run pytest tests/ -q --tb=short -m "not network"
           fi
 
+      - name: Graph accuracy guards (#2259 — round-trip + edge-count + visual-diff)
+        # Surfaces a re-baseline pointer when the graph builder drifts.  The
+        # underlying tests are already executed by the previous step; this job
+        # re-runs *just* the three guard files so the CI summary names them
+        # clearly and points operators at scripts/rebaseline_graph_edges.py.
+        if: always()
+        run: |
+          set +e
+          uv run pytest \
+            tests/test_graph_roundtrip.py \
+            tests/test_graph_edge_counts.py \
+            tests/test_graph_visual_snapshot.py \
+            -v --tb=short
+          status=$?
+          if [ $status -ne 0 ]; then
+            echo ""
+            echo "=========================================================="
+            echo "Graph accuracy guards FAILED."
+            echo ""
+            echo "If this drift is intentional (graph builder changed shape),"
+            echo "regenerate the recorded fixtures and commit them:"
+            echo ""
+            echo "    Re-baseline: python scripts/rebaseline_graph_edges.py"
+            echo ""
+            echo "Otherwise this is a real regression — fix the builder."
+            echo "=========================================================="
+          fi
+          uv run python scripts/rebaseline_graph_edges.py --dry-run
+          exit $status
+
       - name: DCM scanner self-check (meta-recursive)
         # Runs agent-bom's own DCM scanner against agent-bom's own DCM migrations.
         # Proves the scanner is alive, its rules fire on real SQL, and our own

--- a/scripts/rebaseline_graph_edges.py
+++ b/scripts/rebaseline_graph_edges.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Re-baseline the graph-accuracy guard fixtures (#2259).
+
+Regenerates the recorded fixtures used by:
+
+- ``tests/test_graph_edge_counts.py``  → ``tests/fixtures/graph_edge_counts.json``
+- the visual-diff guard                 → ``tests/fixtures/graph-snapshots/security-graph.json``
+
+Source of truth is the trimmed agent-bom self-scan at
+``tests/fixtures/agent_bom_self_scan_inventory.json``.  When the upstream
+graph builder *intentionally* changes its edge or node emission, run this
+script and check the regenerated fixtures into the same PR.
+
+Usage::
+
+    # Default: rebuild both fixtures from the existing self-scan fixture.
+    python scripts/rebaseline_graph_edges.py
+
+    # Print what would change without writing files.
+    python scripts/rebaseline_graph_edges.py --dry-run
+
+    # Refresh the upstream self-scan fixture too (runs `agent-bom scan`).
+    python scripts/rebaseline_graph_edges.py --refresh-self-scan
+
+The dry-run mode is used by CI as a smoke test that this script still
+imports and executes against the current builder.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Make ``tests/`` and ``src/`` importable so we can reuse the helpers.
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
+
+from tests._graph_helpers import (  # noqa: E402
+    EDGE_COUNTS_FIXTURE,
+    GRAPH_SNAPSHOT_DIR,
+    GRAPH_SNAPSHOT_FIXTURE,
+    SELF_SCAN_FIXTURE,
+    build_graph_from_inventory,
+    edge_counts_by_kind,
+    graph_visual_snapshot,
+    load_self_scan_fixture,
+    node_counts_by_kind,
+)
+
+
+def _refresh_self_scan_fixture() -> None:
+    """Run ``agent-bom scan`` and rewrite the trimmed fixture."""
+    out_path = ROOT / ".rebaseline_scan.json"
+    print(f"  → running: agent-bom scan -p . --format json -o {out_path}")
+    subprocess.run(
+        ["agent-bom", "scan", "-p", str(ROOT), "--format", "json", "-o", str(out_path)],
+        check=True,
+    )
+    raw = json.loads(out_path.read_text())
+
+    def _trim_agent(a: dict) -> dict:
+        return {
+            "name": a.get("name"),
+            "type": a.get("type"),
+            "status": a.get("status"),
+            "metadata": a.get("metadata", {}),
+            "mcp_servers": [
+                {
+                    "name": s.get("name"),
+                    "command": s.get("command"),
+                    "transport": s.get("transport"),
+                    "env": s.get("env", {}),
+                    "packages": [],
+                    "tools": [
+                        {
+                            "name": t.get("name"),
+                            "description": (t.get("description") or "")[:200],
+                            "capabilities": t.get("capabilities", []),
+                        }
+                        for t in s.get("tools", []) or []
+                    ],
+                }
+                for s in a.get("mcp_servers", []) or []
+            ],
+        }
+
+    def _trim_br(b: dict) -> dict:
+        return {
+            "vulnerability_id": b.get("vulnerability_id"),
+            "severity": b.get("severity"),
+            "cvss_score": b.get("cvss_score"),
+            "epss_score": b.get("epss_score"),
+            "is_kev": b.get("is_kev", False),
+            "risk_score": b.get("risk_score", 0),
+            "package": b.get("package", ""),
+            "affected_agents": b.get("affected_agents", []),
+            "affected_servers": b.get("affected_servers", []),
+            "exposed_credentials": b.get("exposed_credentials", []),
+            "exposed_tools": b.get("exposed_tools", []),
+        }
+
+    trimmed = {
+        "document_type": raw.get("document_type"),
+        "spec_version": raw.get("spec_version"),
+        "agents": [_trim_agent(a) for a in raw.get("agents", []) or []],
+        "blast_radius": [_trim_br(b) for b in raw.get("blast_radius", []) or []],
+        "summary": raw.get("summary", {}),
+    }
+    SELF_SCAN_FIXTURE.write_text(json.dumps(trimmed, indent=2, sort_keys=True) + "\n")
+    out_path.unlink(missing_ok=True)
+    print(f"  → wrote {SELF_SCAN_FIXTURE}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--dry-run", action="store_true", help="Compute fixtures without writing them.")
+    parser.add_argument(
+        "--refresh-self-scan",
+        action="store_true",
+        help="Re-run agent-bom scan first to refresh the trimmed self-scan fixture.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.refresh_self_scan and not args.dry_run:
+        _refresh_self_scan_fixture()
+    elif args.refresh_self_scan and args.dry_run:
+        print("  (--refresh-self-scan ignored with --dry-run)")
+
+    print(f"  → loading inventory: {SELF_SCAN_FIXTURE}")
+    inv = load_self_scan_fixture()
+    graph = build_graph_from_inventory(inv)
+
+    edge_counts = edge_counts_by_kind(graph)
+    node_counts = node_counts_by_kind(graph)
+    snapshot = graph_visual_snapshot(graph)
+
+    edge_payload = {
+        "_meta": {
+            "fixture": SELF_SCAN_FIXTURE.name,
+            "tolerance_pct": 5,
+            "rebuild_with": "python scripts/rebaseline_graph_edges.py",
+        },
+        "node_counts": node_counts,
+        "edge_counts": edge_counts,
+    }
+
+    print("  → edge counts by kind:")
+    for kind, count in edge_counts.items():
+        print(f"      {kind:>20s}: {count}")
+    print("  → node counts by kind:")
+    for kind, count in node_counts.items():
+        print(f"      {kind:>20s}: {count}")
+    print(f"  → visual snapshot: {snapshot['node_count']} nodes, {snapshot['edge_count']} edges")
+
+    if args.dry_run:
+        print("DRY-RUN: not writing fixtures.")
+        return 0
+
+    GRAPH_SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
+    EDGE_COUNTS_FIXTURE.write_text(json.dumps(edge_payload, indent=2, sort_keys=True) + "\n")
+    GRAPH_SNAPSHOT_FIXTURE.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n")
+    print(f"  → wrote {EDGE_COUNTS_FIXTURE}")
+    print(f"  → wrote {GRAPH_SNAPSHOT_FIXTURE}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/_graph_helpers.py
+++ b/tests/_graph_helpers.py
@@ -1,0 +1,325 @@
+"""Helpers for the graph-accuracy guards (#2259).
+
+These helpers project a built ``ContextGraph`` *back* to a flat inventory shape
+so the round-trip property test can assert that the original inventory is a
+subset of the projected one (no nodes silently dropped during graph build).
+
+The projector is intentionally conservative: it reads only structural
+information that the builder *must* preserve to be useful (agent names, server
+names, tool names, credential env-var names, vulnerability IDs).  It does not
+reconstruct deep package graphs because the builder collapses package counts
+into metadata.
+
+Edge counters are exposed for guard B (edge-count regression).
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from agent_bom.constants import is_credential_key
+from agent_bom.context_graph import (
+    ContextGraph,
+    EdgeKind,
+    NodeKind,
+    build_context_graph,
+)
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+SELF_SCAN_FIXTURE = FIXTURE_DIR / "agent_bom_self_scan_inventory.json"
+EDGE_COUNTS_FIXTURE = FIXTURE_DIR / "graph_edge_counts.json"
+GRAPH_SNAPSHOT_DIR = FIXTURE_DIR / "graph-snapshots"
+GRAPH_SNAPSHOT_FIXTURE = GRAPH_SNAPSHOT_DIR / "security-graph.json"
+
+
+def load_self_scan_fixture() -> dict[str, Any]:
+    """Load the trimmed agent-bom self-scan fixture used by guards A/B/C."""
+    with SELF_SCAN_FIXTURE.open() as f:
+        return json.load(f)
+
+
+def synthetic_inventory() -> dict[str, Any]:
+    """Tiny deterministic inventory: 3 agents, 5 packages, 2 CVEs, 2 credentials.
+
+    Designed to exercise every ``EdgeKind`` produced by the builder:
+
+    - USES, PROVIDES, EXPOSES, VULNERABLE_TO
+    - SHARES_SERVER (agents A & B both use ``filesystem``)
+    - SHARES_CREDENTIAL (agents A & B both expose ``GITHUB_TOKEN``)
+    - ATTACHED_TO (agent A has a cloud_principal in metadata)
+    """
+    return {
+        "agents": [
+            {
+                "name": "agent-a",
+                "type": "claude-desktop",
+                "status": "configured",
+                "metadata": {
+                    "cloud_principal": {
+                        "principal_id": "arn:aws:iam::111:role/agent-a",
+                        "principal_type": "iam_role",
+                        "provider": "aws",
+                        "service": "iam",
+                    }
+                },
+                "mcp_servers": [
+                    {
+                        "name": "filesystem",
+                        "command": "npx",
+                        "transport": "stdio",
+                        "env": {"GITHUB_TOKEN": "***", "DEBUG": "1"},
+                        "tools": [
+                            {"name": "read_file", "description": "Read a file"},
+                            {"name": "write_file", "description": "Write a file"},
+                        ],
+                        "packages": [
+                            {"name": "langchain", "version": "0.1.0"},
+                            {"name": "openai", "version": "1.30.0"},
+                        ],
+                    }
+                ],
+            },
+            {
+                "name": "agent-b",
+                "type": "cursor",
+                "status": "configured",
+                "metadata": {},
+                "mcp_servers": [
+                    {
+                        "name": "filesystem",
+                        "command": "npx",
+                        "transport": "stdio",
+                        "env": {"GITHUB_TOKEN": "***"},
+                        "tools": [
+                            {"name": "read_file", "description": "Read a file"},
+                        ],
+                        "packages": [
+                            {"name": "langchain", "version": "0.1.0"},
+                        ],
+                    }
+                ],
+            },
+            {
+                "name": "agent-c",
+                "type": "vscode",
+                "status": "configured",
+                "metadata": {},
+                "mcp_servers": [
+                    {
+                        "name": "github",
+                        "command": "docker",
+                        "transport": "stdio",
+                        "env": {"GH_TOKEN": "***"},
+                        "tools": [
+                            {"name": "create_issue", "description": "Create an issue"},
+                        ],
+                        "packages": [
+                            {"name": "requests", "version": "2.31.0"},
+                            {"name": "pydantic", "version": "2.5.0"},
+                        ],
+                    }
+                ],
+            },
+        ],
+        "blast_radius": [
+            {
+                "vulnerability_id": "CVE-2025-0001",
+                "severity": "critical",
+                "cvss_score": 9.8,
+                "epss_score": 0.5,
+                "is_kev": False,
+                "risk_score": 9.0,
+                "package": "langchain@0.1.0",
+                "affected_agents": ["agent-a", "agent-b"],
+                "affected_servers": ["filesystem"],
+                "exposed_credentials": ["GITHUB_TOKEN"],
+                "exposed_tools": ["read_file", "write_file"],
+            },
+            {
+                "vulnerability_id": "CVE-2025-0002",
+                "severity": "high",
+                "cvss_score": 7.5,
+                "epss_score": 0.1,
+                "is_kev": False,
+                "risk_score": 6.5,
+                "package": "requests@2.31.0",
+                "affected_agents": ["agent-c"],
+                "affected_servers": ["github"],
+                "exposed_credentials": ["GH_TOKEN"],
+                "exposed_tools": ["create_issue"],
+            },
+        ],
+    }
+
+
+def build_graph_from_inventory(inv: dict[str, Any]) -> ContextGraph:
+    """Build a context graph from an inventory dict (round-trip entry point)."""
+    return build_context_graph(inv.get("agents", []), inv.get("blast_radius", []))
+
+
+# ── Inventory projection ────────────────────────────────────────────────
+
+
+def expected_inventory_sets(inv: dict[str, Any]) -> dict[str, set[str]]:
+    """Flatten an inventory dict to canonical ID-sets for subset comparison."""
+    agents: set[str] = set()
+    servers: set[str] = set()  # ``server:<agent>:<name>``
+    tools: set[str] = set()  # ``tool:server:<agent>:<server>:<name>``
+    credentials: set[str] = set()  # ``cred:<env_key>``
+    iam_roles: set[str] = set()  # ``iam_role:<principal_id>``
+    vulnerabilities: set[str] = set()  # ``vuln:<id>``
+
+    for agent in inv.get("agents", []) or []:
+        a_name = agent.get("name", "")
+        if not a_name:
+            continue
+        agents.add(f"agent:{a_name}")
+
+        principal = (agent.get("metadata") or {}).get("cloud_principal") or {}
+        if isinstance(principal, dict):
+            pid = principal.get("principal_id") or principal.get("principal_name")
+            if pid:
+                iam_roles.add(f"iam_role:{pid}")
+
+        for srv in agent.get("mcp_servers", []) or []:
+            s_name = srv.get("name", "")
+            if not s_name:
+                continue
+            srv_id = f"server:{a_name}:{s_name}"
+            servers.add(srv_id)
+            for env_key in srv.get("env") or {}:
+                if is_credential_key(env_key):
+                    credentials.add(f"cred:{env_key}")
+            for tool in srv.get("tools", []) or []:
+                t_name = tool.get("name", "")
+                if t_name:
+                    tools.add(f"tool:{srv_id}:{t_name}")
+
+    for br in inv.get("blast_radius", []) or []:
+        vid = br.get("vulnerability_id")
+        if vid:
+            vulnerabilities.add(f"vuln:{vid}")
+
+    return {
+        "agents": agents,
+        "servers": servers,
+        "tools": tools,
+        "credentials": credentials,
+        "iam_roles": iam_roles,
+        "vulnerabilities": vulnerabilities,
+    }
+
+
+def project_graph_to_inventory_sets(graph: ContextGraph) -> dict[str, set[str]]:
+    """Project a built graph back to inventory ID-sets, by node kind."""
+    out: dict[str, set[str]] = {
+        "agents": set(),
+        "servers": set(),
+        "tools": set(),
+        "credentials": set(),
+        "iam_roles": set(),
+        "vulnerabilities": set(),
+    }
+    kind_to_bucket = {
+        NodeKind.AGENT: "agents",
+        NodeKind.SERVER: "servers",
+        NodeKind.TOOL: "tools",
+        NodeKind.CREDENTIAL: "credentials",
+        NodeKind.IAM_ROLE: "iam_roles",
+        NodeKind.VULNERABILITY: "vulnerabilities",
+    }
+    for node in graph.nodes.values():
+        bucket = kind_to_bucket.get(node.kind)
+        if bucket is not None:
+            out[bucket].add(node.id)
+    return out
+
+
+# ── Edge counting (guard B) ─────────────────────────────────────────────
+
+
+def edge_counts_by_kind(graph: ContextGraph) -> dict[str, int]:
+    """Return ``{edge_kind: count}`` over a built graph (alphabetised)."""
+    counter: Counter[str] = Counter()
+    for edge in graph.edges:
+        kind = edge.kind.value if isinstance(edge.kind, EdgeKind) else str(edge.kind)
+        counter[kind] += 1
+    return dict(sorted(counter.items()))
+
+
+def node_counts_by_kind(graph: ContextGraph) -> dict[str, int]:
+    """Return ``{node_kind: count}`` over a built graph (alphabetised)."""
+    counter: Counter[str] = Counter()
+    for node in graph.nodes.values():
+        kind = node.kind.value if isinstance(node.kind, NodeKind) else str(node.kind)
+        counter[kind] += 1
+    return dict(sorted(counter.items()))
+
+
+# ── Visual snapshot helpers (guard C) ───────────────────────────────────
+
+
+def graph_visual_snapshot(graph: ContextGraph) -> dict[str, Any]:
+    """Deterministic, layout-free snapshot of the rendered security graph.
+
+    We snapshot the *graph payload* (the same node + edge set that the
+    Cytoscape renderer in ``output/graph.py`` consumes), not a literal SVG.
+    Cytoscape's force-directed layout is non-deterministic, so a pixel-level
+    SVG diff would either be flaky or require pinning random seeds in
+    third-party JS — out of scope for a Python-only CI guard.
+
+    Snapshotting the payload still catches every regression a visual diff
+    would catch *for the graph data itself*: dropped nodes, dropped edges,
+    renamed kinds, swapped labels.  Pure layout regressions (algorithm
+    changes, viewport changes) are explicitly out of scope here and tracked
+    as a Playwright follow-up in guard C option 2.
+    """
+    nodes = sorted(
+        (
+            {
+                "id": n.id,
+                "kind": n.kind.value if isinstance(n.kind, NodeKind) else str(n.kind),
+                "label": n.label,
+            }
+            for n in graph.nodes.values()
+        ),
+        key=lambda n: n["id"],
+    )
+    edges = sorted(
+        (
+            {
+                "source": e.source,
+                "target": e.target,
+                "kind": e.kind.value if isinstance(e.kind, EdgeKind) else str(e.kind),
+            }
+            for e in graph.edges
+        ),
+        key=lambda e: (e["source"], e["target"], e["kind"]),
+    )
+    return {
+        "schema": "agent-bom.graph-snapshot/v1",
+        "node_count": len(nodes),
+        "edge_count": len(edges),
+        "node_kind_counts": _node_kind_counts(nodes),
+        "edge_kind_counts": _edge_kind_counts(edges),
+        "nodes": nodes,
+        "edges": edges,
+    }
+
+
+def _node_kind_counts(nodes: Iterable[dict[str, Any]]) -> dict[str, int]:
+    counter: Counter[str] = Counter()
+    for n in nodes:
+        counter[n["kind"]] += 1
+    return dict(sorted(counter.items()))
+
+
+def _edge_kind_counts(edges: Iterable[dict[str, Any]]) -> dict[str, int]:
+    counter: Counter[str] = Counter()
+    for e in edges:
+        counter[e["kind"]] += 1
+    return dict(sorted(counter.items()))

--- a/tests/fixtures/agent_bom_self_scan_inventory.json
+++ b/tests/fixtures/agent_bom_self_scan_inventory.json
@@ -1,0 +1,122 @@
+{
+  "agents": [
+    {
+      "mcp_servers": [
+        {
+          "command": "project",
+          "env": {},
+          "name": "",
+          "packages": [],
+          "tools": [],
+          "transport": "stdio"
+        },
+        {
+          "command": "project",
+          "env": {},
+          "name": ".clusterfuzzlite",
+          "packages": [],
+          "tools": [],
+          "transport": "stdio"
+        },
+        {
+          "command": "project",
+          "env": {},
+          "name": "dashboard",
+          "packages": [],
+          "tools": [],
+          "transport": "stdio"
+        },
+        {
+          "command": "project",
+          "env": {},
+          "name": "deploy/snowflake",
+          "packages": [],
+          "tools": [],
+          "transport": "stdio"
+        },
+        {
+          "command": "project",
+          "env": {},
+          "name": "examples/first-run-ai-stack/services/browser-helper",
+          "packages": [],
+          "tools": [],
+          "transport": "stdio"
+        },
+        {
+          "command": "project",
+          "env": {},
+          "name": "examples/first-run-ai-stack/services/research-mcp",
+          "packages": [],
+          "tools": [],
+          "transport": "stdio"
+        },
+        {
+          "command": "project",
+          "env": {},
+          "name": "sdks/typescript",
+          "packages": [],
+          "tools": [],
+          "transport": "stdio"
+        },
+        {
+          "command": "project",
+          "env": {},
+          "name": "ui",
+          "packages": [],
+          "tools": [],
+          "transport": "stdio"
+        }
+      ],
+      "metadata": {},
+      "name": "project:",
+      "status": "configured",
+      "type": "custom"
+    }
+  ],
+  "blast_radius": [
+    {
+      "affected_agents": [
+        "project:"
+      ],
+      "affected_servers": [
+        ""
+      ],
+      "cvss_score": null,
+      "epss_score": null,
+      "exposed_credentials": [],
+      "exposed_tools": [],
+      "is_kev": false,
+      "package": "pillow@12.2.0",
+      "risk_score": 1.0,
+      "severity": "unknown",
+      "vulnerability_id": "OSV-2022-1074"
+    },
+    {
+      "affected_agents": [
+        "project:"
+      ],
+      "affected_servers": [
+        ""
+      ],
+      "cvss_score": null,
+      "epss_score": null,
+      "exposed_credentials": [],
+      "exposed_tools": [],
+      "is_kev": false,
+      "package": "pillow@12.2.0",
+      "risk_score": 1.0,
+      "severity": "unknown",
+      "vulnerability_id": "OSV-2022-715"
+    }
+  ],
+  "document_type": "AI-BOM",
+  "spec_version": "1.0",
+  "summary": {
+    "critical_findings": 0,
+    "total_agents": 1,
+    "total_mcp_servers": 8,
+    "total_packages": 849,
+    "total_vulnerabilities": 2,
+    "unique_packages": 829
+  }
+}

--- a/tests/fixtures/graph-snapshots/security-graph.json
+++ b/tests/fixtures/graph-snapshots/security-graph.json
@@ -1,0 +1,123 @@
+{
+  "edge_count": 10,
+  "edge_kind_counts": {
+    "uses": 8,
+    "vulnerable_to": 2
+  },
+  "edges": [
+    {
+      "kind": "uses",
+      "source": "agent:project:",
+      "target": "server:project::"
+    },
+    {
+      "kind": "uses",
+      "source": "agent:project:",
+      "target": "server:project::.clusterfuzzlite"
+    },
+    {
+      "kind": "uses",
+      "source": "agent:project:",
+      "target": "server:project::dashboard"
+    },
+    {
+      "kind": "uses",
+      "source": "agent:project:",
+      "target": "server:project::deploy/snowflake"
+    },
+    {
+      "kind": "uses",
+      "source": "agent:project:",
+      "target": "server:project::examples/first-run-ai-stack/services/browser-helper"
+    },
+    {
+      "kind": "uses",
+      "source": "agent:project:",
+      "target": "server:project::examples/first-run-ai-stack/services/research-mcp"
+    },
+    {
+      "kind": "uses",
+      "source": "agent:project:",
+      "target": "server:project::sdks/typescript"
+    },
+    {
+      "kind": "uses",
+      "source": "agent:project:",
+      "target": "server:project::ui"
+    },
+    {
+      "kind": "vulnerable_to",
+      "source": "server:project::",
+      "target": "vuln:OSV-2022-1074"
+    },
+    {
+      "kind": "vulnerable_to",
+      "source": "server:project::",
+      "target": "vuln:OSV-2022-715"
+    }
+  ],
+  "node_count": 11,
+  "node_kind_counts": {
+    "agent": 1,
+    "server": 8,
+    "vulnerability": 2
+  },
+  "nodes": [
+    {
+      "id": "agent:project:",
+      "kind": "agent",
+      "label": "project:"
+    },
+    {
+      "id": "server:project::",
+      "kind": "server",
+      "label": ""
+    },
+    {
+      "id": "server:project::.clusterfuzzlite",
+      "kind": "server",
+      "label": ".clusterfuzzlite"
+    },
+    {
+      "id": "server:project::dashboard",
+      "kind": "server",
+      "label": "dashboard"
+    },
+    {
+      "id": "server:project::deploy/snowflake",
+      "kind": "server",
+      "label": "deploy/snowflake"
+    },
+    {
+      "id": "server:project::examples/first-run-ai-stack/services/browser-helper",
+      "kind": "server",
+      "label": "examples/first-run-ai-stack/services/browser-helper"
+    },
+    {
+      "id": "server:project::examples/first-run-ai-stack/services/research-mcp",
+      "kind": "server",
+      "label": "examples/first-run-ai-stack/services/research-mcp"
+    },
+    {
+      "id": "server:project::sdks/typescript",
+      "kind": "server",
+      "label": "sdks/typescript"
+    },
+    {
+      "id": "server:project::ui",
+      "kind": "server",
+      "label": "ui"
+    },
+    {
+      "id": "vuln:OSV-2022-1074",
+      "kind": "vulnerability",
+      "label": "OSV-2022-1074"
+    },
+    {
+      "id": "vuln:OSV-2022-715",
+      "kind": "vulnerability",
+      "label": "OSV-2022-715"
+    }
+  ],
+  "schema": "agent-bom.graph-snapshot/v1"
+}

--- a/tests/fixtures/graph_edge_counts.json
+++ b/tests/fixtures/graph_edge_counts.json
@@ -1,0 +1,16 @@
+{
+  "_meta": {
+    "fixture": "agent_bom_self_scan_inventory.json",
+    "rebuild_with": "python scripts/rebaseline_graph_edges.py",
+    "tolerance_pct": 5
+  },
+  "edge_counts": {
+    "uses": 8,
+    "vulnerable_to": 2
+  },
+  "node_counts": {
+    "agent": 1,
+    "server": 8,
+    "vulnerability": 2
+  }
+}

--- a/tests/test_graph_edge_counts.py
+++ b/tests/test_graph_edge_counts.py
@@ -1,0 +1,128 @@
+"""Guard B — edge-count regression baseline (#2259).
+
+Builds the context graph from the recorded self-scan fixture and asserts each
+edge kind's count is within ±``tolerance_pct`` of the baseline at
+``tests/fixtures/graph_edge_counts.json``.
+
+When the upstream graph builder *intentionally* changes edge emission, run::
+
+    python scripts/rebaseline_graph_edges.py
+
+…and check the regenerated baseline into the same PR.
+
+The synthetic fixture is verified with exact (not tolerance-windowed)
+expectations because it's deterministically constructed in test code — any
+drift there is a real bug, not a corpus drift.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests._graph_helpers import (
+    EDGE_COUNTS_FIXTURE,
+    build_graph_from_inventory,
+    edge_counts_by_kind,
+    load_self_scan_fixture,
+    node_counts_by_kind,
+    synthetic_inventory,
+)
+
+REBASELINE_HINT = "If this drift is intentional, re-baseline with:\n    python scripts/rebaseline_graph_edges.py"
+
+
+def _within_tolerance(actual: int, baseline: int, tolerance_pct: float) -> bool:
+    """±``tolerance_pct`` around baseline, with a ±1 floor for small counts."""
+    if baseline == 0:
+        return actual == 0
+    delta_allowed = max(1, int(round(baseline * (tolerance_pct / 100.0))))
+    return abs(actual - baseline) <= delta_allowed
+
+
+@pytest.fixture(scope="module")
+def baseline() -> dict:
+    return json.loads(EDGE_COUNTS_FIXTURE.read_text())
+
+
+@pytest.fixture(scope="module")
+def actual_counts() -> dict:
+    inv = load_self_scan_fixture()
+    graph = build_graph_from_inventory(inv)
+    return {
+        "edge_counts": edge_counts_by_kind(graph),
+        "node_counts": node_counts_by_kind(graph),
+    }
+
+
+class TestEdgeCountBaseline:
+    def test_no_kind_dropped(self, baseline: dict, actual_counts: dict) -> None:
+        """Every kind in the baseline must still be emitted."""
+        baseline_kinds = set(baseline["edge_counts"].keys())
+        actual_kinds = set(actual_counts["edge_counts"].keys())
+        missing = baseline_kinds - actual_kinds
+        assert not missing, f"Edge kinds disappeared from graph build: {sorted(missing)}\n{REBASELINE_HINT}"
+
+    def test_no_unexpected_kind_appeared(self, baseline: dict, actual_counts: dict) -> None:
+        """Surface new edge kinds so they're recorded explicitly, not silently."""
+        baseline_kinds = set(baseline["edge_counts"].keys())
+        actual_kinds = set(actual_counts["edge_counts"].keys())
+        unexpected = actual_kinds - baseline_kinds
+        assert not unexpected, f"New edge kinds emitted but not baselined: {sorted(unexpected)}\n{REBASELINE_HINT}"
+
+    def test_edge_counts_within_tolerance(self, baseline: dict, actual_counts: dict) -> None:
+        tol = baseline["_meta"]["tolerance_pct"]
+        drifted = []
+        for kind, expected in baseline["edge_counts"].items():
+            got = actual_counts["edge_counts"].get(kind, 0)
+            if not _within_tolerance(got, expected, tol):
+                drifted.append(f"{kind}: expected {expected} ±{tol}%, got {got}")
+        assert not drifted, "Edge-count regression on self-scan fixture:\n  - " + "\n  - ".join(drifted) + f"\n{REBASELINE_HINT}"
+
+    def test_node_counts_within_tolerance(self, baseline: dict, actual_counts: dict) -> None:
+        tol = baseline["_meta"]["tolerance_pct"]
+        drifted = []
+        for kind, expected in baseline["node_counts"].items():
+            got = actual_counts["node_counts"].get(kind, 0)
+            if not _within_tolerance(got, expected, tol):
+                drifted.append(f"{kind}: expected {expected} ±{tol}%, got {got}")
+        assert not drifted, "Node-count regression on self-scan fixture:\n  - " + "\n  - ".join(drifted) + f"\n{REBASELINE_HINT}"
+
+
+class TestSyntheticEdgeCounts:
+    """Exact-count assertions on the synthetic fixture (no corpus drift here)."""
+
+    @pytest.fixture(scope="class")
+    def graph(self):
+        return build_graph_from_inventory(synthetic_inventory())
+
+    def test_synthetic_emits_all_expected_edge_kinds(self, graph) -> None:
+        counts = edge_counts_by_kind(graph)
+        required = {
+            "uses",
+            "exposes",
+            "provides",
+            "vulnerable_to",
+            "shares_server",
+            "shares_credential",
+            "attached_to",
+        }
+        missing = required - set(counts.keys())
+        assert not missing, f"Synthetic fixture failed to exercise edge kinds: {sorted(missing)}"
+
+    def test_synthetic_shares_server_count(self, graph) -> None:
+        counts = edge_counts_by_kind(graph)
+        # agent-a and agent-b both use ``filesystem`` → exactly one SHARES_SERVER edge.
+        assert counts["shares_server"] == 1
+
+    def test_synthetic_shares_credential_count(self, graph) -> None:
+        counts = edge_counts_by_kind(graph)
+        # GITHUB_TOKEN is exposed by both agent-a and agent-b → exactly one
+        # SHARES_CREDENTIAL edge.
+        assert counts["shares_credential"] == 1
+
+    def test_synthetic_attached_to_count(self, graph) -> None:
+        counts = edge_counts_by_kind(graph)
+        # Only agent-a has a cloud_principal.
+        assert counts["attached_to"] == 1

--- a/tests/test_graph_roundtrip.py
+++ b/tests/test_graph_roundtrip.py
@@ -1,0 +1,102 @@
+"""Guard A — round-trip property test (#2259).
+
+Builds the context graph from an inventory, projects it back to an inventory
+ID-set view, and asserts ``original ⊆ projected`` (no nodes silently dropped
+during the build step).
+
+Two fixtures:
+
+1. A tiny synthetic inventory (3 agents, 5 packages on servers, 2 CVEs,
+   2 credentials, 1 cloud principal) — exercises every ``EdgeKind`` /
+   ``NodeKind`` the builder produces.
+2. The trimmed agent-bom self-scan at
+   ``tests/fixtures/agent_bom_self_scan_inventory.json`` — exercises a
+   real-world payload shape (regenerate via
+   ``scripts/rebaseline_graph_edges.py --refresh-self-scan``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests._graph_helpers import (
+    build_graph_from_inventory,
+    expected_inventory_sets,
+    load_self_scan_fixture,
+    project_graph_to_inventory_sets,
+    synthetic_inventory,
+)
+
+
+def _assert_subset(expected: dict[str, set[str]], projected: dict[str, set[str]]) -> None:
+    """Assert every original ID survived the round-trip, per node kind."""
+    missing_per_kind: dict[str, set[str]] = {}
+    for kind, ids in expected.items():
+        missing = ids - projected.get(kind, set())
+        if missing:
+            missing_per_kind[kind] = missing
+    assert not missing_per_kind, "Round-trip lost nodes: " + "; ".join(f"{kind}={sorted(ids)}" for kind, ids in missing_per_kind.items())
+
+
+class TestRoundTripSynthetic:
+    """Tiny deterministic fixture — fails the moment any kind is silently lost."""
+
+    def test_synthetic_round_trip_subset(self) -> None:
+        inv = synthetic_inventory()
+        graph = build_graph_from_inventory(inv)
+        expected = expected_inventory_sets(inv)
+        projected = project_graph_to_inventory_sets(graph)
+        _assert_subset(expected, projected)
+
+    def test_synthetic_has_three_agents(self) -> None:
+        inv = synthetic_inventory()
+        graph = build_graph_from_inventory(inv)
+        projected = project_graph_to_inventory_sets(graph)
+        assert projected["agents"] == {"agent:agent-a", "agent:agent-b", "agent:agent-c"}
+
+    def test_synthetic_emits_iam_role_node(self) -> None:
+        """ATTACHED_TO requires an iam_role node from cloud_principal metadata."""
+        inv = synthetic_inventory()
+        graph = build_graph_from_inventory(inv)
+        projected = project_graph_to_inventory_sets(graph)
+        assert "iam_role:arn:aws:iam::111:role/agent-a" in projected["iam_roles"]
+
+    def test_synthetic_credentials_classified(self) -> None:
+        """``GITHUB_TOKEN`` and ``GH_TOKEN`` both match credential patterns."""
+        inv = synthetic_inventory()
+        graph = build_graph_from_inventory(inv)
+        projected = project_graph_to_inventory_sets(graph)
+        assert {"cred:GITHUB_TOKEN", "cred:GH_TOKEN"} <= projected["credentials"]
+
+    def test_synthetic_vulnerabilities_present(self) -> None:
+        inv = synthetic_inventory()
+        graph = build_graph_from_inventory(inv)
+        projected = project_graph_to_inventory_sets(graph)
+        assert {"vuln:CVE-2025-0001", "vuln:CVE-2025-0002"} <= projected["vulnerabilities"]
+
+
+class TestRoundTripSelfScan:
+    """Larger real-world fixture — guards against parser regressions."""
+
+    @pytest.fixture(scope="class")
+    def inventory(self) -> dict:
+        return load_self_scan_fixture()
+
+    def test_self_scan_round_trip_subset(self, inventory: dict) -> None:
+        graph = build_graph_from_inventory(inventory)
+        expected = expected_inventory_sets(inventory)
+        projected = project_graph_to_inventory_sets(graph)
+        _assert_subset(expected, projected)
+
+    def test_self_scan_yields_at_least_one_agent(self, inventory: dict) -> None:
+        graph = build_graph_from_inventory(inventory)
+        projected = project_graph_to_inventory_sets(graph)
+        assert len(projected["agents"]) >= 1, "Self-scan must include the agent-bom CLI agent"
+
+    def test_self_scan_servers_attached_to_an_agent(self, inventory: dict) -> None:
+        """Every server ID must follow the ``server:<agent>:<name>`` shape."""
+        graph = build_graph_from_inventory(inventory)
+        projected = project_graph_to_inventory_sets(graph)
+        for srv_id in projected["servers"]:
+            assert srv_id.startswith("server:"), srv_id
+            assert srv_id.count(":") >= 2, srv_id

--- a/tests/test_graph_visual_snapshot.py
+++ b/tests/test_graph_visual_snapshot.py
@@ -1,0 +1,115 @@
+"""Guard C — visual-diff snapshot of the security graph (#2259).
+
+Approach taken: Option 1 (Python-only, payload-level snapshot).
+
+Rationale
+---------
+
+The original ticket suggested either a deterministic SVG diff via Cytoscape
++ ``pixelmatch`` or a Playwright screenshot of ``/mesh``, ``/graph``, and
+``/lineage-graph``.  Both options are heavier than this guard needs:
+
+- ``--format graph-html`` writes an HTML file that ships a Cytoscape force
+  layout.  That layout is *not* deterministic across runs — it relies on a
+  random seed inside Cytoscape — so a literal SVG/PNG diff would either be
+  flaky or require pinning third-party JS.
+- The Playwright path needs the full UI stack (Postgres-backed dashboard,
+  Next.js boot, Playwright browsers in CI).  Heavy for catching graph-data
+  regressions.
+
+Instead, we snapshot the *graph payload* (nodes + edges + kinds + labels)
+that flows into the renderer.  This catches every regression a visual diff
+would catch *for graph data* (dropped nodes, dropped edges, renamed kinds,
+swapped labels).  Pure layout regressions are explicitly out of scope for
+this Python-only guard — those are tracked as a Playwright follow-up
+(option 2 in the ticket).
+
+Snapshot location: ``tests/fixtures/graph-snapshots/security-graph.json``
+Re-baseline with: ``python scripts/rebaseline_graph_edges.py``
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests._graph_helpers import (
+    GRAPH_SNAPSHOT_FIXTURE,
+    build_graph_from_inventory,
+    graph_visual_snapshot,
+    load_self_scan_fixture,
+)
+
+REBASELINE_HINT = "If the snapshot drift is intentional, re-baseline with:\n    python scripts/rebaseline_graph_edges.py"
+
+
+@pytest.fixture(scope="module")
+def baseline_snapshot() -> dict:
+    return json.loads(GRAPH_SNAPSHOT_FIXTURE.read_text())
+
+
+@pytest.fixture(scope="module")
+def actual_snapshot() -> dict:
+    inv = load_self_scan_fixture()
+    graph = build_graph_from_inventory(inv)
+    return graph_visual_snapshot(graph)
+
+
+def test_snapshot_schema_pinned(baseline_snapshot: dict) -> None:
+    assert baseline_snapshot["schema"] == "agent-bom.graph-snapshot/v1"
+
+
+def test_node_count_matches(baseline_snapshot: dict, actual_snapshot: dict) -> None:
+    assert actual_snapshot["node_count"] == baseline_snapshot["node_count"], (
+        f"Graph node count drifted: baseline {baseline_snapshot['node_count']} → actual {actual_snapshot['node_count']}\n{REBASELINE_HINT}"
+    )
+
+
+def test_edge_count_matches(baseline_snapshot: dict, actual_snapshot: dict) -> None:
+    assert actual_snapshot["edge_count"] == baseline_snapshot["edge_count"], (
+        f"Graph edge count drifted: baseline {baseline_snapshot['edge_count']} → actual {actual_snapshot['edge_count']}\n{REBASELINE_HINT}"
+    )
+
+
+def test_node_ids_match(baseline_snapshot: dict, actual_snapshot: dict) -> None:
+    baseline_ids = {n["id"] for n in baseline_snapshot["nodes"]}
+    actual_ids = {n["id"] for n in actual_snapshot["nodes"]}
+    missing = baseline_ids - actual_ids
+    extra = actual_ids - baseline_ids
+    msg_parts = []
+    if missing:
+        msg_parts.append(f"removed: {sorted(missing)}")
+    if extra:
+        msg_parts.append(f"added: {sorted(extra)}")
+    assert not msg_parts, "Visual snapshot node IDs drifted (" + "; ".join(msg_parts) + f")\n{REBASELINE_HINT}"
+
+
+def test_edge_triples_match(baseline_snapshot: dict, actual_snapshot: dict) -> None:
+    def _triples(snap: dict) -> set[tuple[str, str, str]]:
+        return {(e["source"], e["target"], e["kind"]) for e in snap["edges"]}
+
+    baseline = _triples(baseline_snapshot)
+    actual = _triples(actual_snapshot)
+    missing = baseline - actual
+    extra = actual - baseline
+    msg_parts = []
+    if missing:
+        msg_parts.append(f"removed: {sorted(missing)[:5]}")
+    if extra:
+        msg_parts.append(f"added: {sorted(extra)[:5]}")
+    assert not msg_parts, "Visual snapshot edge triples drifted (" + "; ".join(msg_parts) + f")\n{REBASELINE_HINT}"
+
+
+def test_node_kind_distribution_stable(baseline_snapshot: dict, actual_snapshot: dict) -> None:
+    assert actual_snapshot["node_kind_counts"] == baseline_snapshot["node_kind_counts"], (
+        f"Node kind distribution drifted: baseline {baseline_snapshot['node_kind_counts']} → "
+        f"actual {actual_snapshot['node_kind_counts']}\n{REBASELINE_HINT}"
+    )
+
+
+def test_edge_kind_distribution_stable(baseline_snapshot: dict, actual_snapshot: dict) -> None:
+    assert actual_snapshot["edge_kind_counts"] == baseline_snapshot["edge_kind_counts"], (
+        f"Edge kind distribution drifted: baseline {baseline_snapshot['edge_kind_counts']} → "
+        f"actual {actual_snapshot['edge_kind_counts']}\n{REBASELINE_HINT}"
+    )


### PR DESCRIPTION
Closes #2259.

Adds three independent CI guards on the agent context graph builder so a parser change can no longer silently drop edges or nodes. Guard A is a round-trip property test (`tests/test_graph_roundtrip.py`) that builds the graph from a tiny synthetic 3-agent inventory and from a trimmed agent-bom self-scan fixture, projects the graph back to inventory ID-sets, and asserts the original is a subset of the projected set. Guard B (`tests/test_graph_edge_counts.py`) reads the recorded baseline at `tests/fixtures/graph_edge_counts.json` and asserts each edge/node kind on the self-scan fixture is within +/-5% of baseline; the synthetic fixture is checked with exact expectations because it has no corpus drift. Guard C (`tests/test_graph_visual_snapshot.py`) pins the rendered graph payload at `tests/fixtures/graph-snapshots/security-graph.json` — option 1 (Python-only payload snapshot) was chosen over Cytoscape/Playwright because the HTML renderer's force layout is non-deterministic, with rationale documented in the test docstring and a Playwright pass marked as the option-2 follow-up. CI integration adds one new step to the existing `Test (Python 3.11)` job that runs the three guard files and prints a `Re-baseline:` pointer at `scripts/rebaseline_graph_edges.py` on failure, then dry-runs the rebaseline script as a smoke test.

## Test plan
- [x] `pytest tests/test_graph_roundtrip.py tests/test_graph_edge_counts.py tests/test_graph_visual_snapshot.py` — 23 passed
- [x] `python scripts/rebaseline_graph_edges.py --dry-run` — prints counts + snapshot, no writes
- [x] `pre-commit run --files <changed-files>` — clean
- [x] `python scripts/check_workflow_timeouts.py` — clean