### PR TITLE
fix: release-readiness graph and UI audit findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,10 +200,13 @@ flowchart LR
     classDef data fill:#0f172a,stroke:#f59e0b,color:#fef3c7
     classDef edge fill:#0f172a,stroke:#38bdf8,color:#e0f2fe
 
-    Scan["Scans + Fleet"]:::data --> API["API + UI + Postgres"]:::ctrl
-    API --> Graph["Findings + Graph + Audit"]:::data
-    API --> Gateway["Optional Gateway"]:::edge
-    API --> Proxy["Optional Proxy"]:::edge
+    Browser["Browser UI"]:::ctrl --> API["Control-plane API"]:::ctrl
+    Workers["Scans + workers"]:::data --> API
+    Fleet["Fleet sync"]:::data --> API
+    API --> Store["Postgres / SQLite"]:::data
+    API --> Graph["Findings + graph + audit"]:::data
+    Proxy["Optional proxy"]:::edge --> API
+    Gateway["Optional gateway"]:::edge --> API
 ```
 
 Deployment truth:

--- a/deploy/k8s/cronjob.yaml
+++ b/deploy/k8s/cronjob.yaml
@@ -21,7 +21,7 @@ spec:
           serviceAccountName: agent-bom
           containers:
             - name: scanner
-              image: agentbom/agent-bom:0.81.2
+              image: agentbom/agent-bom:0.86.0
               command: ["agent-bom"]
               args:
                 - "scan"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,7 +33,7 @@ graph TB
     end
 
     subgraph Shield["agent-shield — Runtime Protection"]
-        Proxy["proxy\nMCP proxy + audit"]
+        ShieldProxy["proxy\nMCP proxy + audit"]
         Protect["protect --shield\n8 detectors + deep defense"]
         Run_Cmd["run\nZero-config proxy"]
     end
@@ -68,15 +68,16 @@ graph TB
         Console["Console\nTable / verbose"]
         Formats["Formats\nJSON / SARIF / HTML / CycloneDX"]
         API["REST API + MCP\n36 tools"]
-        Proxy["Runtime Proxy\n7 inline detectors"]
+        RuntimeProxy["Runtime Proxy\n7 inline detectors"]
     end
 
     Scan & MCP_Cmd --> Discovery
-    Image_Cmd & FS_Cmd & SBOM_Cmd --> Parser
-    IAC_Cmd --> IaC
-    Cloud_Cmd --> CIS
+    Image_Cmd --> Parser
+    IaCScan --> IaC
+    AWS & Platforms --> CIS
     Check_Cmd --> Scanner
-    Run_Cmd --> Proxy
+    Run_Cmd --> RuntimeProxy
+    ShieldProxy --> RuntimeProxy
 
     Discovery --> Parser --> Scanner --> Blast
     Blast --> Console & Formats & API

--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -43,9 +43,9 @@ pre-Next.js views or from the Snowflake Streamlit compatibility surface.
 
 | Asset | Page | Required scope | Rationale |
 |---|---|---|---|
-| `dashboard-live.png` | `/dashboard?capture=1` (Risk overview) | All agents · top crop showing the gauge, posture sub-scores, score breakdown, and the start of the attack-path list | The published README should not use one tall stitched dashboard asset when two shorter frames tell the story more clearly |
-| `dashboard-paths-live.png` | `/dashboard?capture=1` (Risk overview) | All agents · mid-page crop showing the attack-path list, exposure KPI band, and the first backlog charts | Keeps the fix-first path list readable in GitHub while still proving the KPI / backlog context lives on the same page |
-| `mesh-live.png` | `/mesh` | Filter to `cursor` | Has 2 servers, 8 packages, 10+ CVEs, and richer tool + credential traversal than the smaller `claude-desktop` slice |
+| `dashboard-live.png` | `/?capture=1` (Risk overview) | All agents · top crop showing the gauge, posture sub-scores, score breakdown, and the start of the attack-path list | The published README should not use one tall stitched dashboard asset when two shorter frames tell the story more clearly |
+| `dashboard-paths-live.png` | `/?capture=1` (Risk overview) | All agents · mid-page crop showing the attack-path list, exposure KPI band, and the first backlog charts | Keeps the fix-first path list readable in GitHub while still proving the KPI / backlog context lives on the same page |
+| `mesh-live.png` | `/mesh` | Filter to the highest-signal demo agent, currently `cursor`; if another agent is used, note why in the PR | Keeps the mesh dense enough to show servers, tools, credentials, package versions, and vulnerability edges without becoming a full-tenant hairball |
 | `remediation-live.png` | `/remediation` | All frameworks tab | Shows the full prioritized fix list |
 
 ### Dashboard layout (current)

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -11,7 +11,7 @@ agent-bom is built on four security principles:
 | Principle | Implementation |
 |-----------|---------------|
 | **Read-only** | Only `List*`, `Describe*`, `Get*` APIs. Zero write calls to any target. |
-| **Agentless** | No agent installed on targets. Uses standard SDK credential chains. |
+| **Agentless cloud discovery** | Cloud and SaaS scans use read-only APIs and standard SDK credential chains. Endpoint fleet/runtime rollout is explicit and installs or schedules `agent-bom` on managed devices. |
 | **Zero-credential** | Never stores, logs, or transmits credential values. Only names (`ANTHROPIC_KEY`, never the key itself). |
 | **Least privilege** | Each cloud provider tells you the exact read-only IAM policy on access denied. |
 
@@ -50,7 +50,7 @@ Reasons that **do not** hold up:
 
 ### Practical operator guidance
 
-**Default**: pull `agentbom/agent-bom` only. The dashboard ships inside the wheel and serves at the same origin as the API. This is the right answer for single-host pilots, dev, CI, air-gapped registry mirrors, and the majority of pilots under ~500 agents.
+**Single-process default**: pull `agentbom/agent-bom` only. The dashboard ships inside the wheel and serves at the same origin as the API. This is the right answer for `agent-bom serve`, dev, CI, air-gapped registry mirrors, and API-only pilots.
 
 **Pull both** when you specifically want one of these properties:
 
@@ -59,8 +59,7 @@ Reasons that **do not** hold up:
 - the UI tier needs a **smaller attack-surface container** with no Python, no cloud SDKs, no MCP subprocess in scope (the second image is intentionally minimal)
 - a separate UI image lets your release cadence ship UI patches without re-rolling the backend image
 
-If none of those properties matter for your deployment, the second image is just bytes you don't need to pull, scan, or sign.
-| Kubernetes with shared ingress and modest scale | either is fine; the chart defaults to both for the multi-replica case |
+If none of those properties matter for your deployment, the second image is just bytes you don't need to pull, scan, or sign. The packaged Docker Compose and Helm examples still use the split API + UI shape because they model the multi-replica production layout.
 
 The Helm chart (`deploy/helm/agent-bom`) deploys both by default because the production EKS preset assumes the multi-replica case. To run API-only, set `controlPlane.ui.enabled=false` and the chart skips the UI Deployment, Service, and HPA.
 

--- a/docs/PRODUCT_INSPIRATION.md
+++ b/docs/PRODUCT_INSPIRATION.md
@@ -1,0 +1,172 @@
+# Product Inspiration Notes
+
+This file captures durable product inspiration for `agent-bom`. It is not a
+spec and should not be treated as copied source material. Use it to keep the
+product direction consistent as the graph, data model, docs, and demos evolve.
+
+## AI System Component Stack
+
+The product should model an AI system as a layered security stack, not as a
+flat list of packages or tools.
+
+Core layers:
+
+- User and application layer: web UI, desktop app, mobile app, CLI, API client,
+  IDE extension, automation job, and service account.
+- API and gateway layer: API gateway, MCP gateway, proxy, reverse proxy,
+  authorization boundary, API key, rate limit, headers, auth metadata, and
+  tenant boundary.
+- Orchestration layer: LangChain, LangGraph, CrewAI, AutoGen, custom agent
+  runtime, workflow engine, planner, router, memory manager, and execution
+  policy.
+- RAG and data layer: embeddings, vector database, chunking strategy, retriever,
+  document source, index, similarity threshold, prompt template, and data
+  classification.
+- Agent tool layer: MCP server, tool schema, function call, JSON-RPC method,
+  command permission, filesystem scope, network scope, browser capability, and
+  approval policy.
+- Tool and MCP package layer: runtime package, transitive dependency, lockfile
+  source, vulnerable package, malicious package signal, maintainer signal,
+  install script, native extension, container layer, and package provenance.
+- External integration layer: SaaS API, database connector, file system, cloud
+  account, CI system, ticketing system, source repository, A2A endpoint, and
+  business asset.
+- Inference serving layer: local inference server, hosted model endpoint,
+  Ollama, vLLM, TGI, model gateway, model router, adapter loader, and model
+  cache.
+- Model and weight layer: base model, fine tune, adapter, embedding model,
+  model card, manifest, checksum, signature, risky weight format, lineage, and
+  provenance.
+- Infrastructure layer: host, VM, container, Kubernetes workload, GPU node,
+  accelerator, chip family, bare-metal server, cloud region, subnet, IAM role,
+  storage volume, secrets manager, and telemetry pipeline.
+- Enumeration and evidence targets: HTTP header, API endpoint, MCP tool schema,
+  model behavior, error message, package manifest, lockfile, runtime trace,
+  gateway decision, proxy alert, and audit log entry.
+
+## Layer Notes
+
+At the top of the stack, users and applications interact through web
+interfaces, desktop clients, mobile apps, CLIs, APIs, IDEs, service accounts,
+and automation jobs. Those requests pass through API gateways, MCP gateways,
+reverse proxies, and policy boundaries that handle authentication, rate
+limiting, routing, tenancy, and enforcement. HTTP headers and gateway behavior
+can reveal useful backend details such as proxy software, caching strategy,
+upstream server identity, auth scheme, and routing topology.
+
+The orchestration layer coordinates how requests move through the AI system.
+Frameworks such as LangChain, LangGraph, CrewAI, AutoGen, and custom runtimes
+build prompts, manage context windows, invoke tools, route tasks, and chain
+multi-step reasoning. These frameworks have fingerprintable behaviors: error
+messages, trace shapes, retry patterns, memory conventions, prompt templates,
+tool-call envelopes, and framework-specific metadata.
+
+In practice, orchestration code often embeds the components that diagrams draw
+as separate boxes. RAG logic, tool definitions, inference client calls,
+approval policies, memory, and routing are frequently implemented inside the
+same agent runtime. The graph model should support both views: a clean product
+layer for readability and a code-true dependency view for audit accuracy.
+
+The middle tier contains the highest-value reachability surfaces. RAG pipelines
+fetch context from vector databases, document stores, and indexes before model
+generation. Even when RAG is implemented inside orchestration code, it has
+distinct enumerable parameters: embedding model, vector database, index name,
+chunking strategy, retriever settings, similarity threshold, prompt template,
+source documents, and data classification. Agent tools expose capabilities
+through MCP, JSON-RPC, function calling, shell execution, browser actions, file
+access, network reachability, and permission boundaries. External integrations
+connect agents to databases, SaaS APIs, cloud services, source repositories,
+CI systems, file systems, and other agents.
+
+The inference serving layer hosts or routes model execution. Examples include
+local servers, hosted endpoints, Ollama, vLLM, TGI, model gateways, router
+services, adapter loaders, and model caches. These surfaces expose API shapes,
+streaming behavior, tokenization quirks, response formatting, model routing
+metadata, and deployment fingerprints.
+
+The underlying model layer represents the model, adapter, embedding model, or
+fine tune that produces outputs. Model weights may be inaccessible at runtime,
+but model identity and lineage can often be inferred from model cards,
+manifests, checksums, signatures, deployment metadata, behavior, capability
+boundaries, training-data artifacts, and response patterns.
+
+The infrastructure layer sits underneath the runtime and is part of the real
+blast radius. AI systems run on hosts, VMs, containers, Kubernetes workloads,
+GPU nodes, accelerator hardware, bare-metal servers, cloud accounts, IAM
+roles, subnets, storage volumes, secrets managers, artifact registries, and
+telemetry pipelines. A graph that stops at the model or MCP server misses the
+systems operators actually need to protect.
+
+## Self-Describing Protocol Risk
+
+MCP and A2A deserve special treatment because they are designed for capability
+discovery. Unlike many opaque application layers, they advertise what they can
+do. That makes them useful to operators and attackers.
+
+MCP standardizes how AI agents discover and invoke tools. It commonly exposes
+JSON-RPC methods and tool schemas that describe available functions, inputs,
+return types, and sometimes permission assumptions. During reconnaissance,
+these schemas reveal what actions an agent can perform, what data it can
+access, and which package/runtime boundary backs the exposed tool.
+
+A2A-style agent collaboration exposes a related risk shape: capability
+discovery, task delegation, result aggregation, trust relationships, and
+cross-boundary invocation. From a graph perspective, A2A endpoints should be
+modeled as externally reachable agent relationships with explicit trust,
+tenant, identity, evidence, and data-flow edges.
+
+Product implication: self-describing protocols should not be treated as simple
+integration labels. Their schemas, methods, auth boundaries, and runtime calls
+are evidence sources. The graph should connect them to packages, tools,
+credentials, agents, users, assets, traces, and policy decisions.
+
+## Product Implications
+
+The graph should make every layer above inspectable and connected. A finding is
+only useful when the operator can see what it can reach.
+
+Graph principles:
+
+- Treat layers as first-class graph dimensions so users can filter by
+  application, gateway, orchestration, RAG, tool, package, integration,
+  inference, model, and infrastructure.
+- Show packages inside tools and MCP servers, not only the server name. The
+  useful path is often vulnerable package -> MCP server -> exposed tool ->
+  agent/client -> credential -> asset.
+- Model infrastructure underneath inference and runtime. GPU nodes, chips,
+  bare-metal hosts, Kubernetes workloads, secrets stores, and cloud IAM are part
+  of the blast radius when agents can invoke tools against real systems.
+- Preserve runtime context separately from static inventory. Static scan data
+  explains what could happen; gateway, proxy, and trace evidence explain what
+  did happen.
+- Keep evidence retention explicit. Durable evidence should stay safe to store;
+  raw prompts, tool inputs and outputs, full paths, full URLs, command args, and
+  response bodies belong in replay-only or short-TTL storage.
+- Make effective reach loud. A vulnerable package behind read-only search is
+  different from the same package behind `run_shell`, visible credential env
+  names, broad network egress, and a production agent.
+- Use layer-aware legends and relationship labels so dense graphs stay readable:
+  "runs on", "loads package", "exposes tool", "called by", "can reach", "uses
+  credential", "queries index", "serves model", "backs asset", "logged by",
+  "blocked by", and "observed in trace".
+- Support attack-path views that collapse noise by default and expand only the
+  relevant neighborhood around the selected finding, asset, agent, MCP server,
+  or credential.
+
+## Product Positioning
+
+Useful framing:
+
+`agent-bom` maps the AI system component stack and turns it into an auditable
+security graph: packages, MCP servers, agents, tools, credentials, runtime
+evidence, models, and infrastructure connected by reachability.
+
+The durable promise is not "another scanner." The product should answer:
+
+- What do we have?
+- What package, tool, model, credential, or infrastructure layer is risky?
+- Which agent or user can trigger it?
+- Which asset can it reach?
+- Was it observed at runtime?
+- What evidence can we safely retain?
+- What should be blocked, fixed, isolated, or monitored first?

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -135,13 +135,12 @@ automated base-image vulnerability issue when new actionable findings appear.
 
 ---
 
-## 6. GitHub Container Registry (GHCR)
+## 6. Docker Images
 
 Automated via `.github/workflows/publish-mcp.yml` after each release.
 
 Images published:
-- `ghcr.io/msaad00/agent-bom:{tag}` — stdio MCP server
-- `ghcr.io/msaad00/agent-bom-sse:{tag}` — SSE MCP server
+- `agentbom/agent-bom:{tag}` — CLI, API, scanner jobs, gateway, and MCP server
 
 ---
 

--- a/docs/graph/CONTRACT.md
+++ b/docs/graph/CONTRACT.md
@@ -20,12 +20,12 @@ The graph subsystem has one source of truth in code: enums in `src/agent_bom/gra
 | `tool` | `mcp_introspect.py`, `risk_analyzer.classify_mcp_tool` | One tool advertised by a server with classified capabilities (read / write / execute / network) |
 | `model` | `cloud/`, model-card scanners | One model artifact: HuggingFace ID, local path, or cloud-served endpoint |
 | `dataset` | `cloud/`, dataset discovery | One referenced dataset (cloud or local) |
-| `container` | `image_scanner.py`, `filesystem.py` | One OCI image or unpacked filesystem |
+| `container` | `image.py`, `cloud/container_sbom.py`, `filesystem.py` | One OCI image or unpacked filesystem |
 | `cloud_resource` | `cloud/aws.py`, `cloud/azure.py`, `cloud/gcp.py` | One discovered cloud asset (workload identity target, bucket, key, etc.) |
 | `vulnerability` | `scanners/__init__.py`, `enrichment.py` | One CVE / GHSA after OSV + NVD + EPSS + KEV enrichment |
 | `misconfiguration` | `iac/`, `cis/` | One IaC / CIS rule violation |
 | `credential` | `context_graph._is_credential_key` against MCP server `env` | One credential-shaped env key (no secret value stored) |
-| `user` | SCIM ingest (`scim_provisioning.py`) | One identity from the customer IdP |
+| `user` | SCIM ingest (`api/routes/scim.py`) | One identity from the customer IdP |
 | `group` | SCIM ingest | One identity group |
 | `service_account` | Cloud workload-identity discovery | One non-human principal |
 | `provider`, `environment`, `fleet`, `cluster` | Fleet sync, cloud discovery | Organisational hierarchy nodes (no security state of their own) |
@@ -44,7 +44,7 @@ The graph subsystem has one source of truth in code: enums in `src/agent_bom/gra
 | `exposes_cred` | server → credential | The server's launch env carries a credential-shaped key. | Emitted only when `_is_credential_key(env_key)` returns true; the value is never stored. |
 | `reaches_tool` | credential → tool | A credential is reachable by an executable tool on the same server. | Emitted only when both nodes share a server *and* the tool has the `execute` capability. |
 | `serves_model` | server → model | The server fronts a model endpoint. | Emitted by cloud / HuggingFace / Ollama scanners. |
-| `contains` | container → package | A container image contains this package. | Emitted by `image_scanner.py` / `filesystem.py`. |
+| `contains` | container → package | A container image contains this package. | Emitted by `image.py`, `cloud/container_sbom.py`, and `filesystem.py`. |
 | `affects` | vulnerability → package | The CVE affects this package version. | Emitted from OSV / GHSA advisory data. |
 | `vulnerable_to` | server / package → vulnerability | The server (via its packages) is exposed to this CVE. | Emitted when a CVE in `blast_radius` lists the server in `affected_servers`. |
 | `exploitable_via` | vulnerability → tool / credential | An exploitation path leads through this tool or credential. | Emitted by blast-radius propagation when a path exists. |
@@ -82,16 +82,16 @@ agent-bom's graph is a static analytical artifact derived from inventory plus ca
 
 ## 3. Scaling boundaries
 
-The graph renderer ships explicit thresholds. Operators can override per-tenant; defaults match the table below.
+The graph renderer ships deterministic focused and expanded modes. Operators can override per-tenant; defaults match the table below.
 
-| Node count `N` | Default behaviour | Why |
+| Mode / size | Default behaviour | Why |
 |---|---|---|
-| `N ≤ 30` | Full graph render — every node and every edge in the canvas. | Pilot fleets; one screen, no aggregation needed. |
-| `30 < N ≤ 100` | Focus mode default — start anchored at the highest-risk entity, expand on demand. | Mid-market scale; the canvas is still legible if the operator drives navigation. |
-| `100 < N ≤ 300` | Sibling aggregation default — agents that share the same set of servers / credentials collapse into a single sibling cluster, expandable. | Avoids the hairball problem when many agents share infrastructure. |
-| `N > 300` | Anchor required — the operator must pick an entity, and the renderer returns the 3-hop neighbourhood around it. | Beyond ~300 nodes, no force-directed layout in a browser stays interactive. Pagination + anchored neighbourhoods are how large tenants navigate. |
+| Focused default | 3-hop neighbourhood, 250-node page size, sibling fan-outs of 5+ collapsed into expandable cluster pills. | Starts every investigation readable, even on the 244-node self-scan. |
+| Expanded mode | 6-hop neighbourhood, 1000-node page size, sibling fan-outs of 20+ collapsed. | Lets operators widen context deliberately without losing the map. |
+| Zoomed out | Level-of-detail renderer swaps detail cards for summary cards and cluster bubbles below the zoom thresholds. | Dense snapshots stay navigable instead of turning into unreadable labels. |
+| Large snapshots | Snapshot selector, search, filters, pagination, and graph query endpoints bound the visible canvas. | Large tenants navigate by scope, not by rendering the whole tenant in one frame. |
 
-Operators reaching the 300-node boundary should pivot to scoped queries (`/v1/agents/mesh?anchor=…`), the blast-radius drilldown, or the snapshot + page + search workflow described in `site-docs/deployment/performance-and-sizing.md`. The graph is designed for investigation, not for "render the whole tenant in one canvas."
+Operators reaching large-snapshot scale should pivot to scoped queries, security-graph attack paths, the blast-radius drilldown, or the snapshot + page + search workflow described in `site-docs/deployment/performance-and-sizing.md`. The graph is designed for investigation, not for "render the whole tenant in one canvas."
 
 ---
 

--- a/scripts/demo/load-dashboard-demo.sh
+++ b/scripts/demo/load-dashboard-demo.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 BASE_URL="${1:-${AGENT_BOM_API_URL:-http://127.0.0.1:8422}}"
 BASE_URL="${BASE_URL%/}"
 PUSH_URL="${BASE_URL}/v1/results/push"
-DASHBOARD_URL="${BASE_URL}/dashboard"
+DASHBOARD_URL="${BASE_URL}/"
 REPORT_PATH="$(mktemp "${TMPDIR:-/tmp}/agent-bom-demo-report.XXXXXX.json")"
 
 cleanup() {
@@ -16,7 +16,7 @@ args=(
   agents
   --demo
   --offline
-  --no-update-db
+  --no-auto-update-db
   --quiet
   -f json
   -o "$REPORT_PATH"

--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -166,15 +166,16 @@ flowchart LR
     end
 
     IDE --> Proxy
+    Proxy -->|local MCP relay| MCP
     Proxy -->|policy pull + audit push| API
-    Proxy -->|runtime MCP relay| GW
     Fleet -->|/v1/fleet/sync| API
     GW --> MCP
     Jobs --> Cloud
     Jobs --> API
-    ProxySidecar --> GW
+    ProxySidecar -->|sidecar MCP relay| MCP
+    ProxySidecar -->|policy pull + audit push| API
     API --> DB
-    GW --> API
+    GW -->|policy + audit| API
     UI --> API
 ```
 

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -39,7 +39,7 @@ Compose file into production.
 ## Quick scan
 
 ```bash
-docker run --rm ghcr.io/msaad00/agent-bom:latest scan
+docker run --rm agentbom/agent-bom:latest scan
 ```
 
 ## With host config access
@@ -50,7 +50,7 @@ Mount your MCP client configs for auto-discovery:
 docker run --rm \
   -v "$HOME/.config:/home/abom/.config:ro" \
   -v "$HOME/Library/Application Support:/home/abom/Library/Application Support:ro" \
-  ghcr.io/msaad00/agent-bom:latest scan
+  agentbom/agent-bom:latest scan
 ```
 
 ## Self-hosted SSE server
@@ -84,7 +84,7 @@ docker run --rm \
   -e SSL_CERT_FILE=/certs/internal-ca.pem \
   -e REQUESTS_CA_BUNDLE=/certs/internal-ca.pem \
   -v ./internal-ca.pem:/certs/internal-ca.pem:ro \
-  ghcr.io/msaad00/agent-bom:latest --version
+  agentbom/agent-bom:latest --version
 ```
 
 ## Runtime proxy sidecar
@@ -103,7 +103,7 @@ docker run --rm -i \
 
 | Image | Purpose |
 |-------|---------|
-| `ghcr.io/msaad00/agent-bom:latest` | Main runtime image: CLI, API, scanner jobs, gateway, MCP server |
+| `agentbom/agent-bom:latest` | Main runtime image: CLI, API, scanner jobs, gateway, MCP server |
 | `agentbom/agent-bom-ui` | Standalone browser UI image for split control-plane deploys |
 | `deploy/docker/Dockerfile.sse` | SSE MCP server |
 | `deploy/docker/Dockerfile.runtime` | Local rebuild recipe for the runtime proxy path shipped in `agentbom/agent-bom` |

--- a/site-docs/getting-started/install.md
+++ b/site-docs/getting-started/install.md
@@ -21,13 +21,13 @@ pip install "agent-bom[all]"         # Everything
 
 ```bash
 # CLI scanning
-docker run --rm ghcr.io/msaad00/agent-bom:latest scan
+docker run --rm agentbom/agent-bom:latest scan
 
 # With host config access (for MCP client discovery)
 docker run --rm \
   -v "$HOME/.config:/home/abom/.config:ro" \
   -v "$HOME/Library/Application Support:/home/abom/Library/Application Support:ro" \
-  ghcr.io/msaad00/agent-bom:latest scan
+  agentbom/agent-bom:latest scan
 ```
 
 ## From source

--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -765,7 +765,8 @@ class SQLiteGraphStore:
             placeholders = ",".join("?" for _ in source_ids)
             rows = conn.execute(
                 f"""
-                SELECT source_node, target_node, path_nodes, path_edges, composite_risk, credential_exposure, vuln_ids
+                SELECT source_node, target_node, path_nodes, path_edges, composite_risk,
+                       summary, credential_exposure, tool_exposure, vuln_ids
                 FROM attack_paths
                 WHERE tenant_id = ? AND scan_id = ? AND source_node IN ({placeholders})
                 """,  # nosec B608 - placeholders are generated internally
@@ -778,7 +779,9 @@ class SQLiteGraphStore:
                     hops=json.loads(row["path_nodes"]),
                     edges=json.loads(row["path_edges"]),
                     composite_risk=row["composite_risk"],
+                    summary=row["summary"] or "",
                     credential_exposure=json.loads(row["credential_exposure"]),
+                    tool_exposure=json.loads(row["tool_exposure"]),
                     vuln_ids=json.loads(row["vuln_ids"]),
                 )
                 for row in rows

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -173,9 +173,11 @@ class PostgresGraphStore:
                     target_node TEXT NOT NULL,
                     hop_count INTEGER DEFAULT 0,
                     composite_risk DOUBLE PRECISION DEFAULT 0.0,
+                    summary TEXT DEFAULT '',
                     path_nodes TEXT DEFAULT '[]',
                     path_edges TEXT DEFAULT '[]',
                     credential_exposure TEXT DEFAULT '[]',
+                    tool_exposure TEXT DEFAULT '[]',
                     vuln_ids TEXT DEFAULT '[]',
                     scan_id TEXT NOT NULL,
                     tenant_id TEXT NOT NULL DEFAULT 'default',
@@ -188,6 +190,8 @@ class PostgresGraphStore:
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_pg_attack_paths_scan_risk ON attack_paths(tenant_id, scan_id, composite_risk DESC)"
             )
+            conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS summary TEXT DEFAULT ''")
+            conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS tool_exposure TEXT DEFAULT '[]'")
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS interaction_risks (
@@ -410,9 +414,11 @@ class PostgresGraphStore:
                         ap.target,
                         len(ap.hops),
                         ap.composite_risk,
+                        ap.summary,
                         json.dumps(ap.hops),
                         json.dumps(ap.edges),
                         json.dumps(ap.credential_exposure),
+                        json.dumps(ap.tool_exposure),
                         json.dumps(ap.vuln_ids),
                         scan,
                         tenant,
@@ -501,15 +507,17 @@ class PostgresGraphStore:
                 """
                 INSERT INTO attack_paths (
                     source_node, target_node, hop_count, composite_risk,
-                    path_nodes, path_edges, credential_exposure, vuln_ids,
-                    scan_id, tenant_id, computed_at
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    summary, path_nodes, path_edges, credential_exposure,
+                    tool_exposure, vuln_ids, scan_id, tenant_id, computed_at
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (source_node, target_node, scan_id, tenant_id) DO UPDATE SET
                     hop_count = EXCLUDED.hop_count,
                     composite_risk = EXCLUDED.composite_risk,
+                    summary = EXCLUDED.summary,
                     path_nodes = EXCLUDED.path_nodes,
                     path_edges = EXCLUDED.path_edges,
                     credential_exposure = EXCLUDED.credential_exposure,
+                    tool_exposure = EXCLUDED.tool_exposure,
                     vuln_ids = EXCLUDED.vuln_ids,
                     computed_at = EXCLUDED.computed_at
                 """,
@@ -630,7 +638,8 @@ class PostgresGraphStore:
 
             for row in conn.execute(
                 """
-                SELECT source_node, target_node, path_nodes, path_edges, composite_risk, credential_exposure, vuln_ids
+                SELECT source_node, target_node, path_nodes, path_edges, composite_risk,
+                       summary, credential_exposure, tool_exposure, vuln_ids
                 FROM attack_paths
                 WHERE tenant_id = %s AND scan_id = %s
                 """,
@@ -643,8 +652,10 @@ class PostgresGraphStore:
                         hops=json.loads(row[2]),
                         edges=json.loads(row[3]),
                         composite_risk=row[4],
-                        credential_exposure=json.loads(row[5]),
-                        vuln_ids=json.loads(row[6]),
+                        summary=row[5] or "",
+                        credential_exposure=json.loads(row[6]),
+                        tool_exposure=json.loads(row[7]),
+                        vuln_ids=json.loads(row[8]),
                     )
                 )
 
@@ -777,7 +788,8 @@ class PostgresGraphStore:
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute(
                 f"""
-                SELECT source_node, target_node, path_nodes, path_edges, composite_risk, credential_exposure, vuln_ids
+                SELECT source_node, target_node, path_nodes, path_edges, composite_risk,
+                       summary, credential_exposure, tool_exposure, vuln_ids
                 FROM attack_paths
                 WHERE tenant_id = %s AND scan_id = %s AND source_node IN ({placeholders})
                 ORDER BY composite_risk DESC, source_node ASC, target_node ASC
@@ -794,8 +806,10 @@ class PostgresGraphStore:
                 hops=json.loads(row[2]),
                 edges=json.loads(row[3]),
                 composite_risk=row[4],
-                credential_exposure=json.loads(row[5]),
-                vuln_ids=json.loads(row[6]),
+                summary=row[5] or "",
+                credential_exposure=json.loads(row[6]),
+                tool_exposure=json.loads(row[7]),
+                vuln_ids=json.loads(row[8]),
             )
             for row in rows
         ]

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -98,6 +98,36 @@ def _parse_entity_type_filter(raw: str | None) -> set[str] | None:
     return values or None
 
 
+def _parse_relationship_filter(raw: str | None) -> set[RelationshipType]:
+    if not raw:
+        return set()
+    parsed: set[RelationshipType] = set()
+    for value in raw.split(","):
+        value = value.strip()
+        if not value:
+            continue
+        try:
+            parsed.add(RelationshipType(value))
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=f"Unsupported graph relationship type: {value}") from exc
+    return parsed
+
+
+def _validate_relationship_list(values: list[str]) -> set[RelationshipType] | None:
+    if not values:
+        return None
+    parsed: set[RelationshipType] = set()
+    for value in values:
+        cleaned = value.strip()
+        if not cleaned:
+            continue
+        try:
+            parsed.add(RelationshipType(cleaned))
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=f"Unsupported graph relationship type: {cleaned}") from exc
+    return parsed or None
+
+
 def _validate_entity_type_list(values: list[str]) -> list[str]:
     cleaned = [value.strip() for value in values if value.strip()]
     invalid = sorted(set(cleaned) - _ALLOWED_ENTITY_TYPES)
@@ -277,7 +307,7 @@ async def get_graph(
     Nodes are paginated (offset/limit). Edges are filtered to only include
     edges between returned nodes. Stats reflect the full (unpaginated) graph.
     """
-    from agent_bom.graph import SEVERITY_RANK, GraphFilterOptions, RelationshipType
+    from agent_bom.graph import SEVERITY_RANK, GraphFilterOptions
 
     tenant = _tenant(request)
     graph_store = _get_graph_store_or_503()
@@ -300,14 +330,7 @@ async def get_graph(
             entity_types=et_set,
             min_severity_rank=min_rank,
         )
-        rel_set: set[RelationshipType] = set()
-        if relationships:
-            for r in relationships.split(","):
-                r = r.strip()
-                try:
-                    rel_set.add(RelationshipType(r))
-                except ValueError:
-                    pass
+        rel_set = _parse_relationship_filter(relationships)
         filters = GraphFilterOptions(
             relationship_types=rel_set,
             static_only=static_only,
@@ -358,13 +381,19 @@ async def get_graph(
         tenant_id=tenant,
         node_ids=paged_ids,
     )
+    attack_paths = await _graph_store_call(
+        graph_store.attack_paths_for_sources,
+        scan_id=effective_scan_id,
+        tenant_id=tenant,
+        source_ids=paged_ids,
+    )
     return {
         "scan_id": effective_scan_id,
         "tenant_id": tenant,
         "created_at": created_at,
         "nodes": [n.to_dict() for n in paged_nodes],
         "edges": [e.to_dict() for e in paged_edges],
-        "attack_paths": [],
+        "attack_paths": [path.to_dict() for path in attack_paths],
         "interaction_risks": [],
         "stats": await _graph_store_call(
             graph_store.snapshot_stats,
@@ -577,7 +606,7 @@ async def query_graph(request: Request, body: GraphQueryRequest) -> dict:
     if missing_roots:
         raise HTTPException(status_code=404, detail={"message": "Root nodes not found", "missing_roots": missing_roots})
 
-    rel_types = {RelationshipType(rel) for rel in body.relationship_types} if body.relationship_types else None
+    rel_types = _validate_relationship_list(body.relationship_types)
     deadline = time.monotonic() + (body.timeout_ms / 1000)
     traversal_graph, depth_by_node, truncated = await _graph_store_call(
         graph_store.traverse_subgraph,

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -113,9 +113,11 @@ CREATE TABLE IF NOT EXISTS attack_paths (
     target_node     TEXT NOT NULL,
     hop_count       INTEGER DEFAULT 0,
     composite_risk  REAL DEFAULT 0.0,
+    summary         TEXT DEFAULT '',
     path_nodes      TEXT DEFAULT '[]',
     path_edges      TEXT DEFAULT '[]',
     credential_exposure TEXT DEFAULT '[]',
+    tool_exposure   TEXT DEFAULT '[]',
     vuln_ids        TEXT DEFAULT '[]',
     scan_id         TEXT NOT NULL,
     tenant_id       TEXT DEFAULT '',
@@ -176,6 +178,11 @@ def _init_db(conn: sqlite3.Connection) -> None:
             "INSERT INTO graph_schema_version (version) VALUES (?)",
             (_GRAPH_SCHEMA_VERSION,),
         )
+    existing_columns = {row["name"] for row in conn.execute("PRAGMA table_info(attack_paths)").fetchall()}
+    if "summary" not in existing_columns:
+        conn.execute("ALTER TABLE attack_paths ADD COLUMN summary TEXT DEFAULT ''")
+    if "tool_exposure" not in existing_columns:
+        conn.execute("ALTER TABLE attack_paths ADD COLUMN tool_exposure TEXT DEFAULT '[]'")
     conn.commit()
 
 
@@ -367,18 +374,20 @@ def save_graph(conn: sqlite3.Connection, graph: UnifiedGraph) -> None:
             """\
             INSERT OR REPLACE INTO attack_paths (
                 source_node, target_node, hop_count, composite_risk,
-                path_nodes, path_edges, credential_exposure, vuln_ids,
-                scan_id, tenant_id, computed_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                summary, path_nodes, path_edges, credential_exposure,
+                tool_exposure, vuln_ids, scan_id, tenant_id, computed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 ap.source,
                 ap.target,
                 len(ap.hops),
                 ap.composite_risk,
+                ap.summary,
                 json.dumps(ap.hops),
                 json.dumps(ap.edges),
                 json.dumps(ap.credential_exposure),
+                json.dumps(ap.tool_exposure),
                 json.dumps(ap.vuln_ids),
                 scan,
                 tenant,
@@ -498,7 +507,9 @@ def load_graph(
                 hops=json.loads(row["path_nodes"]),
                 edges=json.loads(row["path_edges"]),
                 composite_risk=row["composite_risk"],
+                summary=row["summary"] or "",
                 credential_exposure=json.loads(row["credential_exposure"]),
+                tool_exposure=json.loads(row["tool_exposure"]),
                 vuln_ids=json.loads(row["vuln_ids"]),
             )
         )

--- a/src/agent_bom/rbac.py
+++ b/src/agent_bom/rbac.py
@@ -419,6 +419,8 @@ def require_authenticated_permission(action: str) -> Callable:
         x_tenant_id: str | None = Header(None, alias="X-Agent-Bom-Tenant-ID"),
         x_proxy_secret: str | None = Header(None, alias="X-Agent-Bom-Proxy-Secret"),
     ) -> Role:
+        from agent_bom.api.middleware import get_auth_runtime_status
+
         state_role = getattr(request.state, "api_key_role", None)
         if state_role:
             try:
@@ -428,6 +430,24 @@ def require_authenticated_permission(action: str) -> Callable:
             if not getattr(request.state, "tenant_id", None):
                 request.state.tenant_id = "default"
             return _authorize(role, action)
+
+        auth_runtime = get_auth_runtime_status()
+        env_auth_configured = any(
+            os.environ.get(name, "").strip()
+            for name in (
+                "AGENT_BOM_API_KEY",
+                "AGENT_BOM_OIDC_ISSUER",
+                "AGENT_BOM_TRUST_PROXY_AUTH",
+                "AGENT_BOM_SCIM_BEARER_TOKEN",
+            )
+        )
+        proxy_identity_headers_present = bool(x_role or x_tenant_id or x_proxy_secret)
+        if not auth_runtime["auth_required"] and not env_auth_configured and not proxy_identity_headers_present:
+            request.state.api_key_name = "local-no-auth"
+            request.state.api_key_role = Role.ADMIN.value
+            request.state.tenant_id = getattr(request.state, "tenant_id", None) or "default"
+            request.state.auth_method = "no_auth"
+            return _authorize(Role.ADMIN, action)
 
         trusted_proxy_enabled = os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH", "").strip().lower() in {
             "1",

--- a/src/agent_bom/security.py
+++ b/src/agent_bom/security.py
@@ -551,8 +551,9 @@ def validate_url(url: str, *, allowed_schemes: tuple[str, ...] = ("https",), all
         "yes",
         "on",
     }
+    http_private_override = allow_private and parsed.scheme == "http" and allowed_schemes == ("https",)
 
-    if parsed.scheme not in allowed_schemes:
+    if parsed.scheme not in allowed_schemes and not http_private_override:
         if allowed_schemes == ("https",):
             raise SecurityError(f"URL must use HTTPS; got: {parsed.scheme}")
         expected = ", ".join(f"{scheme}://" for scheme in allowed_schemes)
@@ -600,6 +601,9 @@ def validate_url(url: str, *, allowed_schemes: tuple[str, ...] = ("https",), all
                 return
         except ValueError:
             continue
+
+    if http_private_override:
+        raise SecurityError("HTTP URLs are only allowed for private egress targets when AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS is enabled")
 
     # Static log — no user-controlled values to prevent both cleartext
     # credential logging and log injection (CodeQL py/clear-text-logging,

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -66,6 +66,9 @@ def _build_persisted_graph(db, scan_id="test-scan-001"):
             edges=["uses", "vulnerable_to"],
             composite_risk=9.0,
             summary="agent-a → mcp-fs → CVE-2024-1",
+            credential_exposure=["AWS_SECRET_ACCESS_KEY"],
+            tool_exposure=["run_shell"],
+            vuln_ids=["CVE-2024-1"],
         )
     )
     save_graph(db, g)
@@ -408,6 +411,44 @@ class TestGraphEndpointLogic:
 
         assert len(attack_paths) == 1
         assert attack_paths[0].target == "vuln:cve"
+        assert attack_paths[0].summary == ""
+        assert attack_paths[0].tool_exposure == []
+
+    def test_sqlite_graph_store_attack_paths_round_trip_summary_and_tools(self, tmp_path):
+        store = SQLiteGraphStore(tmp_path / "graph.db")
+        graph = UnifiedGraph(scan_id="attack-path-fields", tenant_id="default")
+        graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        graph.add_node(UnifiedNode(id="tool:shell", entity_type=EntityType.TOOL, label="run_shell"))
+        graph.add_node(UnifiedNode(id="vuln:cve", entity_type=EntityType.VULNERABILITY, label="CVE-2026-1"))
+        graph.add_edge(UnifiedEdge(source="agent:a", target="tool:shell", relationship=RelationshipType.REACHES_TOOL))
+        graph.add_edge(UnifiedEdge(source="tool:shell", target="vuln:cve", relationship=RelationshipType.VULNERABLE_TO))
+        graph.attack_paths.append(
+            AttackPath(
+                source="agent:a",
+                target="vuln:cve",
+                hops=["agent:a", "tool:shell", "vuln:cve"],
+                edges=["reaches_tool", "vulnerable_to"],
+                composite_risk=9.9,
+                summary="agent-a can reach run_shell before CVE-2026-1",
+                credential_exposure=["AWS_SECRET_ACCESS_KEY"],
+                tool_exposure=["run_shell"],
+                vuln_ids=["CVE-2026-1"],
+            )
+        )
+
+        store.save_graph(graph)
+
+        loaded = store.load_graph(tenant_id="default", scan_id="attack-path-fields")
+        assert len(loaded.attack_paths) == 1
+        path = loaded.attack_paths[0]
+        assert path.summary == "agent-a can reach run_shell before CVE-2026-1"
+        assert path.credential_exposure == ["AWS_SECRET_ACCESS_KEY"]
+        assert path.tool_exposure == ["run_shell"]
+        assert path.vuln_ids == ["CVE-2026-1"]
+
+        sourced = store.attack_paths_for_sources(tenant_id="default", scan_id="attack-path-fields", source_ids={"agent:a"})
+        assert sourced[0].summary == path.summary
+        assert sourced[0].tool_exposure == ["run_shell"]
 
     def test_sqlite_graph_store_node_context_preserves_bidirectional_neighbors(self, tmp_path):
         store = SQLiteGraphStore(tmp_path / "graph.db")
@@ -820,13 +861,29 @@ def recording_graph_store():
 
 class TestGraphStoreBackendSelection:
     def test_graph_routes_use_pluggable_store(self, recording_graph_store):
+        recording_graph_store.graph.add_node(UnifiedNode(id="vuln:cve", entity_type=EntityType.VULNERABILITY, label="CVE-2026-1"))
+        recording_graph_store.graph.attack_paths.append(
+            AttackPath(
+                source="agent:a",
+                target="vuln:cve",
+                hops=["agent:a", "vuln:cve"],
+                edges=["vulnerable_to"],
+                composite_risk=8.8,
+                summary="agent-a reaches CVE-2026-1",
+                tool_exposure=["run_shell"],
+            )
+        )
         client = TestClient(app)
 
         response = client.get("/v1/graph")
         assert response.status_code == 200
-        assert response.json()["scan_id"] == "store-scan"
+        body = response.json()
+        assert body["scan_id"] == "store-scan"
+        assert body["attack_paths"][0]["summary"] == "agent-a reaches CVE-2026-1"
+        assert body["attack_paths"][0]["tool_exposure"] == ["run_shell"]
         assert any(call[0] == "latest_snapshot_id" for call in recording_graph_store.calls)
         assert any(call[0] == "page_nodes" for call in recording_graph_store.calls)
+        assert any(call[0] == "attack_paths_for_sources" for call in recording_graph_store.calls)
         assert not any(call[0] == "load_graph" for call in recording_graph_store.calls)
 
     def test_graph_overview_filtered_page_stays_store_backed(self, recording_graph_store):
@@ -1133,8 +1190,31 @@ class TestGraphStoreBackendSelection:
             ("server:s", "vuln:CVE-2026-1"),
         }
         assert body["attack_paths"][0]["target"] == "vuln:CVE-2026-1"
+        assert body["attack_paths"][0]["summary"] == "agent-a -> server-s -> CVE-2026-1"
         assert any(call[0] == "traverse_subgraph" for call in recording_graph_store.calls)
         assert not any(call[0] == "load_graph" for call in recording_graph_store.calls)
+
+    def test_graph_get_rejects_unknown_relationship(self, recording_graph_store):
+        client = TestClient(app)
+
+        response = client.get("/v1/graph?relationships=uses,not_a_relationship")
+
+        assert response.status_code == 422
+        assert "Unsupported graph relationship type" in response.json()["detail"]
+
+    def test_graph_query_rejects_unknown_relationship(self, recording_graph_store):
+        client = TestClient(app)
+
+        response = client.post(
+            "/v1/graph/query",
+            json={
+                "roots": ["agent:a"],
+                "relationship_types": ["not_a_relationship"],
+            },
+        )
+
+        assert response.status_code == 422
+        assert "Unsupported graph relationship type" in response.json()["detail"]
 
     def test_graph_node_uses_store_native_context(self, recording_graph_store):
         recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -644,6 +644,7 @@ class TestGraphStore:
                 edges=["uses", "vulnerable_to"],
                 composite_risk=9.0,
                 summary="agent-a → mcp-fs → CVE-2024-1",
+                tool_exposure=["read_file"],
             )
         )
         save_graph(db, g)
@@ -651,6 +652,8 @@ class TestGraphStore:
         loaded = load_graph(db, scan_id="test-001")
         assert len(loaded.attack_paths) == 1
         assert loaded.attack_paths[0].composite_risk == 9.0
+        assert loaded.attack_paths[0].summary == "agent-a → mcp-fs → CVE-2024-1"
+        assert loaded.attack_paths[0].tool_exposure == ["read_file"]
 
     def test_interaction_risks_persisted(self, db):
         from agent_bom.db.graph_store import load_graph, save_graph

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -213,10 +213,10 @@ class MockConnection:
                     scan_id = params[1] if len(params) > 1 else ""
                     requested_sources = set(params[2:])
                     rows = [
-                        r for r in rows if r[9] == tenant_id and r[8] == scan_id and (not requested_sources or r[0] in requested_sources)
+                        r for r in rows if r[11] == tenant_id and r[10] == scan_id and (not requested_sources or r[0] in requested_sources)
                     ]
                 rows.sort(key=lambda r: (-float(r[3]), str(r[0]), str(r[1])))
-                cursor.rows = [(r[0], r[1], r[4], r[5], r[3], r[6], r[7]) for r in rows]
+                cursor.rows = [(r[0], r[1], r[5], r[6], r[3], r[4], r[7], r[8], r[9]) for r in rows]
             elif params:
                 for table_data in self._store.values():
                     for pk, row in table_data.items():
@@ -1309,7 +1309,9 @@ def test_graph_store_attack_paths_for_sources_uses_materialized_table(mock_pool,
             hops=["agent:a", "vuln:cve"],
             edges=["edge:1"],
             composite_risk=9.4,
+            summary="agent-a reaches CVE-2026-0001",
             credential_exposure=["API_KEY"],
+            tool_exposure=["run_shell"],
             vuln_ids=["CVE-2026-0001"],
         )
     )
@@ -1323,7 +1325,9 @@ def test_graph_store_attack_paths_for_sources_uses_materialized_table(mock_pool,
 
     assert len(paths) == 1
     assert paths[0].target == "vuln:cve"
+    assert paths[0].summary == "agent-a reaches CVE-2026-0001"
     assert paths[0].credential_exposure == ["API_KEY"]
+    assert paths[0].tool_exposure == ["run_shell"]
     select_sql = "\n".join(sql for sql, _params in mock_pool._conn.executed if "FROM attack_paths" in sql)
     assert "source_node IN" in select_sql
 

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -255,6 +255,22 @@ class TestPushResults:
         headers = call_kwargs.kwargs.get("headers", {})
         assert headers.get("Authorization") == "Bearer test-key-123"
 
+    def test_push_url_private_egress_override_allows_http_localhost(self, monkeypatch):
+        monkeypatch.setenv("AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS", "true")
+        mock_resp = AsyncMock()
+        mock_resp.status_code = 200
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("agent_bom.http_client.create_client", return_value=mock_client):
+            result = push_results("http://localhost:8422/v1/results/push", {"agents": []})
+
+        assert result is True
+        assert mock_client.post.call_args.args[0] == "http://localhost:8422/v1/results/push"
+
     def test_push_network_error(self):
         """Network errors retry up to max attempts then return False."""
         mock_client = AsyncMock()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -274,6 +274,19 @@ def test_validate_url_http():
         validate_url("http://example.com/api")
 
 
+def test_validate_url_private_egress_override_allows_http_localhost(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS", "true")
+
+    validate_url("http://localhost/api")
+
+
+def test_validate_url_private_egress_override_rejects_public_http(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS", "true")
+
+    with pytest.raises(SecurityError, match="HTTP URLs are only allowed"):
+        validate_url("http://93.184.216.34/api")
+
+
 def test_validate_url_metadata():
     with pytest.raises(SecurityError, match="metadata"):
         validate_url("https://169.254.169.254/latest/meta-data/")

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -463,6 +463,13 @@ function GraphPageInner() {
   const seededFromUrlRef = useRef<boolean>(
     typeof window !== "undefined" && new URLSearchParams(window.location.search).toString().length > 0,
   );
+  const requestedScanIdRef = useRef<string>(
+    typeof window !== "undefined"
+      ? new URLSearchParams(window.location.search).get("scan") ||
+        new URLSearchParams(window.location.search).get("scan_id") ||
+        ""
+      : "",
+  );
   const firstScanSelectionRef = useRef(true);
 
   useEffect(() => {
@@ -472,7 +479,14 @@ function GraphPageInner() {
       .then((items) => {
         setSnapshots(items);
         if (items.length > 0) {
-          setSelectedScanId((current) => current || items[0]!.scan_id);
+          setSelectedScanId((current) => {
+            if (current) return current;
+            const requested = requestedScanIdRef.current;
+            if (requested && items.some((item) => item.scan_id === requested)) {
+              return requested;
+            }
+            return items[0]!.scan_id;
+          });
         }
       })
       .catch((e) => setError(e.message))
@@ -535,6 +549,7 @@ function GraphPageInner() {
       return;
     }
 
+    let cancelled = false;
     setLoadingGraph(true);
     setSelectedNode(null);
     api
@@ -550,14 +565,21 @@ function GraphPageInner() {
         limit: filters.pageSize,
       })
       .then((result) => {
+        if (cancelled) return;
         setGraphData(result);
         setError(null);
       })
       .catch((e) => {
+        if (cancelled) return;
         setError(e.message);
         setGraphData(null);
       })
-      .finally(() => setLoadingGraph(false));
+      .finally(() => {
+        if (!cancelled) setLoadingGraph(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [
     selectedScanId,
     serverEntityTypes,
@@ -679,12 +701,14 @@ function GraphPageInner() {
   // copied address bar reproduces the view but back/forward isn't spammed.
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const next = encodeFiltersToParams(filters).toString();
+    const nextParams = encodeFiltersToParams(filters);
+    if (selectedScanId) nextParams.set("scan", selectedScanId);
+    const next = nextParams.toString();
     const current = searchParams?.toString() ?? "";
     if (next === current) return;
     const url = next ? `${pathname}?${next}` : pathname;
     router.replace(url, { scroll: false });
-  }, [filters, pathname, router, searchParams]);
+  }, [filters, pathname, router, searchParams, selectedScanId]);
 
   // Constraint propagation — recompute valid values whenever graph or
   // filters change. Cheap on focused snapshots, BFS-bounded on expanded.
@@ -1423,11 +1447,8 @@ function GraphPageInner() {
                 bgColor={MINIMAP_BG}
                 maskColor={MINIMAP_MASK}
               />
-              {/* Dock legend on the canvas itself so node-color → entity-type
-                  is one glance away instead of "scroll back up to the hero
-                  block to find which colour means agent". Wraps in a
-                  <details> so it can be collapsed when the operator wants
-                  more canvas. */}
+              {/* Dock legend on the canvas itself so node-color -> entity-type
+                  is one glance away. */}
               <Panel position="top-right" className="!m-2">
                 <details className="rounded-xl border border-zinc-800 bg-zinc-950/85 backdrop-blur p-2 group">
                   <summary className="flex items-center gap-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden text-[10px] uppercase tracking-[0.2em] text-zinc-400">
@@ -1436,7 +1457,7 @@ function GraphPageInner() {
                     <span className="text-zinc-600 hidden group-open:inline">▾</span>
                   </summary>
                   <div className="mt-2">
-                    <GraphLegend items={legendItems} />
+                    <GraphLegend items={legendItems} embedded />
                   </div>
                 </details>
               </Panel>

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -235,12 +235,24 @@ const SEVERITY_ORDER_MAP: Record<string, number> = {
   critical: 4, high: 3, medium: 2, low: 1,
 };
 
+function blastTools(blast: BlastRadius): string[] {
+  return blast.exposed_tools ?? blast.reachable_tools ?? [];
+}
+
+function blastCredentials(blast: BlastRadius): string[] {
+  return blast.exposed_credentials ?? [];
+}
+
+function blastAgents(blast: BlastRadius): string[] {
+  return blast.affected_agents ?? [];
+}
+
 function aggregateCompoundIssues(allBlast: BlastRadius[]): CompoundIssue[] {
   const issues: CompoundIssue[] = [];
 
   // 1. CISA KEV + reachable tool exposure
   const kevReachable = allBlast.filter(
-    (b) => (b.is_kev ?? b.cisa_kev) && (b.exposed_tools ?? b.reachable_tools).length > 0
+    (b) => (b.is_kev ?? b.cisa_kev) && blastTools(b).length > 0
   );
   if (kevReachable.length > 0) {
     issues.push({
@@ -257,7 +269,7 @@ function aggregateCompoundIssues(allBlast: BlastRadius[]): CompoundIssue[] {
 
   // 2. CISA KEV + credential exposure
   const kevCredential = allBlast.filter(
-    (b) => (b.is_kev ?? b.cisa_kev) && b.exposed_credentials.length > 0
+    (b) => (b.is_kev ?? b.cisa_kev) && blastCredentials(b).length > 0
   );
   if (kevCredential.length > 0) {
     issues.push({
@@ -295,8 +307,8 @@ function aggregateCompoundIssues(allBlast: BlastRadius[]): CompoundIssue[] {
   // 4. Credential exposure + reachable exec tools
   const credExec = allBlast.filter(
     (b) =>
-      b.exposed_credentials.length > 0 &&
-      (b.exposed_tools ?? b.reachable_tools).some((t) =>
+      blastCredentials(b).length > 0 &&
+      blastTools(b).some((t) =>
         ["bash", "exec", "shell", "run", "execute", "subprocess"].some((kw) =>
           t.toLowerCase().includes(kw)
         )
@@ -476,11 +488,8 @@ export default function Dashboard() {
   const scatterData = useMemo(() => aggregateEpssVsCvss(allBlast), [allBlast]);
   const compoundIssues = useMemo(() => aggregateCompoundIssues(allBlast), [allBlast]);
   const kevCount = useMemo(() => allBlast.filter((b) => (b.is_kev ?? b.cisa_kev) === true).length, [allBlast]);
-  const credentialExposureCount = useMemo(() => allBlast.filter((b) => b.exposed_credentials.length > 0).length, [allBlast]);
-  const reachableToolCount = useMemo(
-    () => new Set(allBlast.flatMap((b) => b.exposed_tools ?? b.reachable_tools ?? [])).size,
-    [allBlast]
-  );
+  const credentialExposureCount = useMemo(() => allBlast.filter((b) => blastCredentials(b).length > 0).length, [allBlast]);
+  const reachableToolCount = useMemo(() => new Set(allBlast.flatMap(blastTools)).size, [allBlast]);
 
   // Unique CVE count
   const uniqueCVEs = useMemo(() => {
@@ -627,23 +636,25 @@ export default function Dashboard() {
             {[...allBlast]
               .sort((a, b) => (b.risk_score ?? b.blast_score) - (a.risk_score ?? a.blast_score))
               .slice(0, 5)
-              .map((b) => {
+              .map((b, index) => {
                 const nodes: { type: "cve" | "package" | "server" | "agent" | "credential"; label: string; severity?: string }[] = [
                   { type: "cve", label: b.vulnerability_id, severity: b.severity?.toLowerCase() },
                 ];
                 if (b.package) nodes.push({ type: "package", label: b.package });
                 if (b.affected_servers && b.affected_servers.length > 0) nodes.push({ type: "server", label: b.affected_servers[0]! });
-                if (b.affected_agents.length > 0) nodes.push({ type: "agent", label: b.affected_agents[0]! });
-                if (b.exposed_credentials.length > 0) nodes.push({ type: "credential", label: b.exposed_credentials[0]! });
+                const agents = blastAgents(b);
+                const credentials = blastCredentials(b);
+                if (agents.length > 0) nodes.push({ type: "agent", label: agents[0]! });
+                if (credentials.length > 0) nodes.push({ type: "credential", label: credentials[0]! });
                 return (
                   <AttackPathCard
-                    key={b.vulnerability_id}
+                    key={`${b.vulnerability_id}:${b.package ?? "unknown"}:${index}`}
                     nodes={nodes}
                     riskScore={b.risk_score ?? b.blast_score / 10}
                     href={buildSecurityGraphHref({
                       cve: b.vulnerability_id,
                       packageName: b.package,
-                      agentName: b.affected_agents[0],
+                      agentName: agents[0],
                     })}
                   />
                 );
@@ -828,9 +839,9 @@ export default function Dashboard() {
             {[...allBlast]
               .sort((a, b) => (b.risk_score ?? b.blast_score) - (a.risk_score ?? a.blast_score))
               .slice(0, 5)
-              .map((b) => (
+              .map((b, index) => (
                 <BlastCard
-                  key={b.vulnerability_id}
+                  key={`${b.vulnerability_id}:${b.package ?? "unknown"}:${index}`}
                   blast={b}
                   detailHref={`/findings?cve=${b.vulnerability_id}`}
                 />
@@ -1050,11 +1061,11 @@ function BlastCard({ blast, detailHref }: { blast: BlastRadius; detailHref: stri
           </a>
         </div>
         <div className="flex flex-wrap gap-3 mt-1.5 text-xs text-zinc-500">
-          <span>{blast.affected_agents.length} agent{blast.affected_agents.length !== 1 ? "s" : ""}</span>
-          {blast.exposed_credentials.length > 0 && (
-            <span className="text-orange-400">{blast.exposed_credentials.length} credential{blast.exposed_credentials.length !== 1 ? "s" : ""}</span>
+          <span>{blastAgents(blast).length} agent{blastAgents(blast).length !== 1 ? "s" : ""}</span>
+          {blastCredentials(blast).length > 0 && (
+            <span className="text-orange-400">{blastCredentials(blast).length} credential{blastCredentials(blast).length !== 1 ? "s" : ""}</span>
           )}
-          <span>{(blast.exposed_tools ?? blast.reachable_tools).length} tool{(blast.exposed_tools ?? blast.reachable_tools).length !== 1 ? "s" : ""}</span>
+          <span>{blastTools(blast).length} tool{blastTools(blast).length !== 1 ? "s" : ""}</span>
           {(blast.is_kev ?? blast.cisa_kev) && <span className="text-red-400 font-semibold">CISA KEV</span>}
           {blast.cvss_score != null && <span>CVSS {blast.cvss_score.toFixed(1)}</span>}
           {blast.epss_score != null && <span>EPSS {(blast.epss_score * 100).toFixed(0)}%</span>}
@@ -1199,9 +1210,9 @@ function CompoundIssueCard({ issue }: { issue: CompoundIssue }) {
           {issue.description}
         </p>
         <div className="flex flex-wrap gap-1.5">
-          {issue.findings.slice(0, 4).map((f) => (
+          {issue.findings.slice(0, 4).map((f, index) => (
             <span
-              key={f.vulnerability_id}
+              key={`${issue.id}:${f.vulnerability_id}:${f.package ?? "unknown"}:${index}`}
               className={`text-[10px] font-mono rounded px-1.5 py-0.5 ${badgeColor}`}
             >
               {f.vulnerability_id}

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -209,6 +209,15 @@ function SecurityGraphPageContent() {
   );
 
   const hasFocusContext = Boolean(focus.cve || focus.packageName || focus.agentName);
+  const fullGraphHref = useMemo(() => {
+    const params = new URLSearchParams();
+    if (selectedScanId) params.set("scan", selectedScanId);
+    if (focus.agentName) params.set("agent", focus.agentName);
+    if (focus.cve) params.set("q", focus.cve);
+    else if (focus.packageName) params.set("q", focus.packageName);
+    const query = params.toString();
+    return query ? `/graph?${query}` : "/graph";
+  }, [focus.agentName, focus.cve, focus.packageName, selectedScanId]);
   const resetFocusHref = useMemo(
     () => buildSecurityGraphHref({ scanId: selectedScanId || undefined }),
     [selectedScanId],
@@ -344,7 +353,7 @@ function SecurityGraphPageContent() {
 
           <div className="flex flex-wrap items-center gap-2">
             <Link
-              href="/graph"
+              href={fullGraphHref}
               className="inline-flex items-center gap-2 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-4 py-2 text-sm font-medium text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)]"
             >
               Open full lineage graph
@@ -446,7 +455,7 @@ function SecurityGraphPageContent() {
           />
           <div className="mt-4 flex flex-wrap gap-3 border-t border-[color:var(--border-subtle)] pt-4">
             <Link
-              href="/graph"
+              href={fullGraphHref}
               className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-1.5 text-xs text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
             >
               Open full graph
@@ -492,7 +501,7 @@ function SecurityGraphPageContent() {
                 )}
                 <div className="mt-3 flex flex-wrap gap-2">
                   <Link
-                    href="/graph"
+                    href={fullGraphHref}
                     className="inline-flex items-center gap-1 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-1 text-[11px] text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
                   >
                     Full graph
@@ -642,7 +651,7 @@ function SecurityGraphPageContent() {
                   ))}
 
                   <Link
-                    href="/graph"
+                    href={fullGraphHref}
                     className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 transition hover:border-[color:var(--border-strong)]"
                   >
                     <div className="flex items-center justify-between gap-3">

--- a/ui/components/graph-chrome.tsx
+++ b/ui/components/graph-chrome.tsx
@@ -27,7 +27,15 @@ import type { LegendItem } from "@/lib/graph-utils";
 
 // ─── Legend Bar ──────────────────────────────────────────────────────────────
 
-export function GraphLegend({ items }: { items: LegendItem[] }) {
+export function GraphLegend({
+  items,
+  defaultOpen = false,
+  embedded = false,
+}: {
+  items: LegendItem[];
+  defaultOpen?: boolean;
+  embedded?: boolean;
+}) {
   const [open, setOpen] = useState(false);
 
   if (items.length === 0) return null;
@@ -40,7 +48,7 @@ export function GraphLegend({ items }: { items: LegendItem[] }) {
       <button
         type="button"
         onClick={() => setOpen((current) => !current)}
-        className="flex items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800/80 px-2.5 py-1.5 text-xs text-zinc-300 transition-colors hover:bg-zinc-700 backdrop-blur-sm"
+        className={`${embedded ? "hidden" : "flex"} items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800/80 px-2.5 py-1.5 text-xs text-zinc-300 transition-colors hover:bg-zinc-700 backdrop-blur-sm`}
         aria-expanded={open}
         aria-label={open ? "Hide legend" : "Show legend"}
       >
@@ -48,8 +56,8 @@ export function GraphLegend({ items }: { items: LegendItem[] }) {
         <span className="rounded-full bg-zinc-900 px-1.5 py-0.5 text-[10px] text-zinc-400">{items.length}</span>
         <ChevronDown className={`h-3.5 w-3.5 transition-transform ${open ? "rotate-180" : ""}`} />
       </button>
-      {open && (
-        <div className="absolute right-0 top-full z-20 mt-2 w-[min(22rem,calc(100vw-2rem))] rounded-xl border border-zinc-700 bg-zinc-900/95 p-3 shadow-2xl shadow-black/30 backdrop-blur-md">
+      {(open || defaultOpen || embedded) && (
+        <div className={`${embedded ? "relative w-[min(30rem,calc(100vw-2rem))] shadow-none" : "absolute right-0 top-full z-20 mt-2 w-[min(30rem,calc(100vw-2rem))] shadow-2xl shadow-black/30"} max-h-[60vh] overflow-y-auto rounded-xl border border-zinc-700 bg-zinc-900/95 p-3 backdrop-blur-md`}>
           {nodeItems.length > 0 && (
             <LegendSection title="Entities" items={nodeItems} />
           )}
@@ -66,12 +74,12 @@ function LegendSection({ title, items }: { title: string; items: LegendItem[] })
   return (
     <div className="first:mt-0 mt-3">
       <div className="mb-2 text-[10px] uppercase tracking-[0.18em] text-zinc-500">{title}</div>
-      <div className="grid grid-cols-2 gap-x-3 gap-y-2 text-[11px] text-zinc-300 sm:grid-cols-3">
+      <div className="grid grid-cols-1 gap-x-3 gap-y-2 text-[11px] text-zinc-300 sm:grid-cols-2">
         {items.map((item) => (
-          <span key={`${title}:${item.label}`} className="flex items-center gap-2 whitespace-nowrap">
+          <span key={`${title}:${item.label}`} className="flex min-w-0 items-center gap-2">
             <LegendMarker item={item} />
             <LegendIcon item={item} />
-            {item.label}
+            <span className="min-w-0 truncate" title={item.label}>{item.label}</span>
           </span>
         ))}
       </div>

--- a/ui/components/scan-result.tsx
+++ b/ui/components/scan-result.tsx
@@ -249,8 +249,8 @@ export function ScanResultView({ id }: { id: string }) {
           </div>
           {!collapsedSections.has("blast") && (
             <div className="space-y-3">
-              {blastRadius.sort((a, b) => b.blast_score - a.blast_score).map((b) => (
-                <BlastRadiusCard key={b.vulnerability_id} blast={b} />
+              {blastRadius.sort((a, b) => b.blast_score - a.blast_score).map((b, index) => (
+                <BlastRadiusCard key={`${b.vulnerability_id}:${b.package ?? "unknown"}:${index}`} blast={b} />
               ))}
             </div>
           )}
@@ -404,9 +404,9 @@ function BlastRadiusCard({ blast }: { blast: BlastRadius }) {
         </div>
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-        <ImpactPill icon={Zap} label="Agents affected" items={blast.affected_agents} />
-        <ImpactPill icon={Key} label="Credentials exposed" items={blast.exposed_credentials} accent="orange" />
-        <ImpactPill icon={Wrench} label="Tools reachable" items={blast.reachable_tools} />
+        <ImpactPill icon={Zap} label="Agents affected" items={blast.affected_agents ?? []} />
+        <ImpactPill icon={Key} label="Credentials exposed" items={blast.exposed_credentials ?? []} accent="orange" />
+        <ImpactPill icon={Wrench} label="Tools reachable" items={blast.reachable_tools ?? blast.exposed_tools ?? []} />
       </div>
       {((blast.owasp_tags && blast.owasp_tags.length > 0) || (blast.atlas_tags && blast.atlas_tags.length > 0)) && (
         <div className="mt-3 flex flex-wrap gap-1.5">
@@ -426,17 +426,18 @@ function BlastRadiusCard({ blast }: { blast: BlastRadius }) {
   );
 }
 
-function ImpactPill({ icon: Icon, label, items, accent }: { icon: React.ElementType; label: string; items: string[]; accent?: string }) {
-  const accentClass = accent === "orange" && items.length > 0 ? "text-orange-400" : "text-zinc-300";
+function ImpactPill({ icon: Icon, label, items, accent }: { icon: React.ElementType; label: string; items?: string[]; accent?: string }) {
+  const safeItems = items ?? [];
+  const accentClass = accent === "orange" && safeItems.length > 0 ? "text-orange-400" : "text-zinc-300";
   return (
     <div className="bg-zinc-800 rounded-lg p-3">
       <div className={`flex items-center gap-1.5 text-xs font-semibold mb-2 ${accentClass}`}>
-        <Icon className="w-3.5 h-3.5" /><span>{label} ({items.length})</span>
+        <Icon className="w-3.5 h-3.5" /><span>{label} ({safeItems.length})</span>
       </div>
-      {items.length > 0 ? (
+      {safeItems.length > 0 ? (
         <div className="space-y-1">
-          {items.slice(0, 4).map((item, i) => <p key={i} className="text-xs font-mono text-zinc-400 truncate">{item}</p>)}
-          {items.length > 4 && <p className="text-xs text-zinc-600">+{items.length - 4} more</p>}
+          {safeItems.slice(0, 4).map((item, i) => <p key={i} className="text-xs font-mono text-zinc-400 truncate">{item}</p>)}
+          {safeItems.length > 4 && <p className="text-xs text-zinc-600">+{safeItems.length - 4} more</p>}
         </div>
       ) : (
         <p className="text-xs text-zinc-600">None</p>

--- a/ui/lib/mesh-graph.ts
+++ b/ui/lib/mesh-graph.ts
@@ -25,7 +25,10 @@ export interface MeshStatsData {
 }
 
 export interface ServerGroup {
+  id: string;
   name: string;
+  command: string;
+  transport: string;
   agents: Set<string>;
   agentLabels: Map<string, string>;
   servers: MCPServer[];
@@ -88,6 +91,16 @@ export function getMeshAgentLabel(agent: Agent): string {
 function meshAgentNodeId(agentOrKey: Agent | string): string {
   const key = typeof agentOrKey === "string" ? agentOrKey : getMeshAgentKey(agentOrKey);
   return `agent:${key}`;
+}
+
+function serverIdentity(server: MCPServer): string {
+  return `${server.name}|${server.command ?? ""}|${server.transport ?? ""}`;
+}
+
+function meshServerNodeId(serverOrGroup: MCPServer | ServerGroup): string {
+  const command = "command" in serverOrGroup ? serverOrGroup.command : serverOrGroup.command ?? "";
+  const transport = "transport" in serverOrGroup ? serverOrGroup.transport : serverOrGroup.transport ?? "";
+  return `server:${serverOrGroup.name}:${command}:${transport}`;
 }
 
 function getCredKeys(server: MCPServer): string[] {
@@ -176,7 +189,7 @@ export function detectSharedServers(agents: Agent[]): Map<string, ServerGroup> {
     const agentKey = getMeshAgentKey(agent);
     const agentLabel = getMeshAgentLabel(agent);
     for (const server of agent.mcp_servers) {
-      const key = server.name;
+      const key = serverIdentity(server);
       const existing = groups.get(key);
       const creds = getCredKeys(server);
       if (existing) {
@@ -189,7 +202,10 @@ export function detectSharedServers(agents: Agent[]): Map<string, ServerGroup> {
         creds.forEach((c) => existing.credNames.add(c));
       } else {
         groups.set(key, {
+          id: key,
           name: server.name,
+          command: server.command ?? "",
+          transport: server.transport ?? "",
           agents: new Set([agentKey]),
           agentLabels: new Map([[agentKey, agentLabel]]),
           servers: [server],
@@ -382,9 +398,9 @@ export function buildMeshGraph(
   }
 
   // ── Server nodes (shared vs regular) ──
-  for (const [name, group] of serverGroups) {
+  for (const group of serverGroups.values()) {
     const isShared = group.agents.size > 1;
-    const serverId = `server:${name}`;
+    const serverId = meshServerNodeId(group);
     const firstServer = group.servers[0];
     if (!firstServer) continue;
 
@@ -393,7 +409,7 @@ export function buildMeshGraph(
       type: isShared ? "sharedServerNode" : "serverNode",
       position: { x: 0, y: 0 },
       data: {
-        label: name,
+        label: group.name,
         nodeType: isShared ? "sharedServer" : "server",
         command: firstServer.command || firstServer.transport || "",
         toolCount: group.totalTools,
@@ -406,7 +422,7 @@ export function buildMeshGraph(
 
     // Agent → Server edges
     for (const agentKey of group.agents) {
-      const edgeId = `${meshAgentNodeId(agentKey)}->server:${name}`;
+      const edgeId = `${meshAgentNodeId(agentKey)}->${serverId}`;
       if (!seen.has(edgeId)) {
         seen.add(edgeId);
         edges.push({
@@ -431,7 +447,7 @@ export function buildMeshGraph(
     // ── Credential nodes ──
     if (showCreds) {
       for (const cred of group.credNames) {
-        const credId = `cred:${name}:${cred}`;
+        const credId = `cred:${serverId}:${cred}`;
         if (!seen.has(credId)) {
           seen.add(credId);
           const multiAgent = (credAgentMap.get(cred)?.size ?? 0) > 1;
@@ -442,7 +458,7 @@ export function buildMeshGraph(
             data: {
               label: cred,
               nodeType: "credential",
-              serverName: name,
+              serverName: group.name,
               sharedBy: credAgentMap.get(cred)?.size,
             } satisfies LineageNodeData,
           });
@@ -468,7 +484,7 @@ export function buildMeshGraph(
       const allTools = group.servers.flatMap((s) => s.tools ?? []);
       const uniqueTools = [...new Map(allTools.map((t) => [t.name, t])).values()].slice(0, 5);
       for (const tool of uniqueTools) {
-        const toolId = `tool:${name}:${tool.name}`;
+        const toolId = `tool:${serverId}:${tool.name}`;
         if (!seen.has(toolId)) {
           seen.add(toolId);
           const multiAgent = (toolAgentMap.get(tool.name)?.size ?? 0) > 1;
@@ -501,12 +517,12 @@ export function buildMeshGraph(
     // ── Package nodes ──
     if (showPkgs) {
       // Collect all unique packages across server instances in this group
-      const pkgMap = new Map<string, { pkg: typeof group.servers[0]["packages"][0]; serverName: string }>();
+      const pkgMap = new Map<string, { pkg: typeof group.servers[0]["packages"][0]; serverId: string }>();
       for (const srv of group.servers) {
         for (const pkg of srv.packages) {
           const key = `${pkg.ecosystem}:${pkg.name}@${pkg.version}`;
           if (!pkgMap.has(key)) {
-            pkgMap.set(key, { pkg, serverName: name });
+            pkgMap.set(key, { pkg, serverId });
           }
         }
       }
@@ -541,8 +557,8 @@ export function buildMeshGraph(
         .slice(0, vulnerableOnly ? 0 : 2);
       const displayPkgs = [...vulnPkgs.slice(0, vulnerableOnly ? 8 : 6), ...cleanPkgs];
 
-      for (const { pkg, serverName, matchingVulns } of displayPkgs) {
-        const pkgId = `pkg:${serverName}:${pkg.ecosystem}:${pkg.name}`;
+      for (const { pkg, serverId: packageServerId, matchingVulns } of displayPkgs) {
+        const pkgId = `pkg:${packageServerId}:${pkg.ecosystem}:${pkg.name}@${pkg.version}`;
         if (seen.has(pkgId)) continue;
         seen.add(pkgId);
 
@@ -565,7 +581,7 @@ export function buildMeshGraph(
         });
         edges.push({
           id: `${serverId}->${pkgId}`,
-          source: serverId,
+          source: packageServerId,
           target: pkgId,
           type: "smoothstep",
           data: { relationship: "depends_on" },

--- a/ui/tests/mesh-graph.test.ts
+++ b/ui/tests/mesh-graph.test.ts
@@ -89,8 +89,8 @@ describe("buildMeshGraph", () => {
     expect(nodes.some((node) => node.id === "agent:claude-desktop")).toBe(true);
     expect(nodes.some((node) => node.id === "agent:cursor")).toBe(true);
     expect(nodes.some((node) => node.id === "agent:zed")).toBe(false);
-    expect(edges.some((edge) => edge.id === "agent:claude-desktop->server:filesystem")).toBe(true);
-    expect(edges.some((edge) => edge.id === "agent:cursor->server:filesystem")).toBe(true);
+    expect(edges.some((edge) => edge.id === "agent:claude-desktop->server:filesystem::")).toBe(true);
+    expect(edges.some((edge) => edge.id === "agent:cursor->server:filesystem::")).toBe(true);
   });
 
   it("respects selected agent scope without dropping the shared server edge", () => {
@@ -102,8 +102,8 @@ describe("buildMeshGraph", () => {
     );
 
     expect(nodes.some((node) => node.id === "agent:cursor")).toBe(true);
-    expect(nodes.some((node) => node.id === "server:filesystem")).toBe(true);
-    expect(edges.some((edge) => edge.id === "agent:cursor->server:filesystem")).toBe(true);
+    expect(nodes.some((node) => node.id === "server:filesystem::")).toBe(true);
+    expect(edges.some((edge) => edge.id === "agent:cursor->server:filesystem::")).toBe(true);
   });
 
   it("keeps same-named agents separate across fleet endpoints", () => {
@@ -159,7 +159,75 @@ describe("buildMeshGraph", () => {
     expect(nodes.some((node) => node.id === "agent:claude-desktop@device-a")).toBe(true);
     expect(nodes.some((node) => node.id === "agent:claude-desktop@device-b")).toBe(true);
     expect(nodes.filter((node) => node.data.label === "claude-desktop · alice-mac")).toHaveLength(1);
-    expect(edges.some((edge) => edge.id === "agent:claude-desktop@device-a->server:filesystem")).toBe(true);
-    expect(edges.some((edge) => edge.id === "agent:claude-desktop@device-b->server:filesystem")).toBe(true);
+    expect(edges.some((edge) => edge.id === "agent:claude-desktop@device-a->server:filesystem::")).toBe(true);
+    expect(edges.some((edge) => edge.id === "agent:claude-desktop@device-b->server:filesystem::")).toBe(true);
+  });
+
+  it("does not merge same-named servers with different command identity", () => {
+    const result: ScanResult = {
+      agents: [
+        {
+          name: "claude-desktop",
+          agent_type: "desktop",
+          mcp_servers: [
+            {
+              name: "filesystem",
+              command: "npx @modelcontextprotocol/server-filesystem /tmp/a",
+              packages: [],
+              tools: [{ name: "read_file", description: "Read a file" }],
+            },
+          ],
+        },
+        {
+          name: "cursor",
+          agent_type: "desktop",
+          mcp_servers: [
+            {
+              name: "filesystem",
+              command: "npx @modelcontextprotocol/server-filesystem /tmp/b",
+              packages: [],
+              tools: [{ name: "read_file", description: "Read a file" }],
+            },
+          ],
+        },
+      ],
+      blast_radius: [],
+    };
+
+    const { nodes } = buildMeshGraph(result, { packages: true, vulnerabilities: true, credentials: true, tools: true }, "all");
+
+    const serverNodes = nodes.filter((node) => node.data.nodeType === "server" || node.data.nodeType === "sharedServer");
+    expect(serverNodes).toHaveLength(2);
+    expect(serverNodes.every((node) => node.data.nodeType === "server")).toBe(true);
+  });
+
+  it("keeps package versions as distinct visible package nodes", () => {
+    const result: ScanResult = {
+      agents: [
+        {
+          name: "claude-desktop",
+          agent_type: "desktop",
+          mcp_servers: [
+            {
+              name: "filesystem",
+              packages: [
+                { name: "server-filesystem", ecosystem: "npm", version: "1.0.0", vulnerabilities: [] },
+                { name: "server-filesystem", ecosystem: "npm", version: "2.0.0", vulnerabilities: [] },
+              ],
+              tools: [],
+            },
+          ],
+        },
+      ],
+      blast_radius: [],
+    };
+
+    const { nodes } = buildMeshGraph(result, { packages: true, vulnerabilities: true, credentials: true, tools: true }, "all");
+
+    const packageLabels = nodes
+      .filter((node) => node.data.nodeType === "package")
+      .map((node) => node.data.label)
+      .sort();
+    expect(packageLabels).toEqual(["server-filesystem@1.0.0", "server-filesystem@2.0.0"]);
   });
 });


### PR DESCRIPTION
## Summary

- Fixes release-readiness issues found in the hands-on audit after the graph/evidence PR wave.
- Persists full attack-path metadata (`summary`, `tool_exposure`) in SQLite/Postgres and returns persisted paths from `/v1/graph`.
- Validates graph relationship filters with HTTP 422 instead of silently ignoring invalid values.
- Fixes private-egress URL semantics so `AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS` only relaxes HTTP for private/local targets.
- Makes explicit local no-auth mode consistent for dashboard posture routes while still rejecting spoofed proxy identity headers.
- Hardens graph UI state, scan context preservation, mesh node identity, dashboard/scan-result rendering, and graph legend readability.
- Refreshes deployment/docs drift and captures product inspiration for layered AI system security graphs.

## UI/UX audit note

The current graph surfaces are functionally stronger after this pass, but the PR intentionally records that we are not yet at Wiz/CrowdStrike-level UX. Security Graph is the most actionable surface; Lineage Graph still needs stronger view-model guidance when it collapses to finding cards; Mesh needs semantic grouping/edge bundling for scale. Follow-up product work should make the graph fix-first, context-aware, collapsible, and action-oriented by default.

## Validation

- `uv run pytest tests/ -q --tb=short -m 'not network'` -> 9537 passed, 23 skipped, 12 deselected
- `npm run test:run` -> 174 passed
- `npm run typecheck` -> passed
- `npm run lint` -> passed
- `npm run codegen:graph-schema:check` -> passed
- `git diff --check` -> passed
- Playwright browser pass across overview, security graph, lineage graph, mesh, findings, scan result -> passed

## Screenshots

Local screenshots were saved for review at:

`/Users/mohamedsaad/Desktop/agent-bom-e2e-screens`

## Release note

Do not tag/release from this branch until CI is green and the screenshot/UX findings are reviewed. This PR is opened as draft so the release gate remains explicit.
