### PR TITLE
feat: fix-first security graph cockpit

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -24,6 +24,7 @@ import logging
 import os
 import time
 from typing import Literal, Optional
+from urllib.parse import quote
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
@@ -134,6 +135,224 @@ def _validate_entity_type_list(values: list[str]) -> list[str]:
     if invalid:
         raise HTTPException(status_code=422, detail=f"Unsupported graph entity type: {invalid[0]}")
     return cleaned
+
+
+def _node_labels_for_types(graph: UnifiedGraph, path_hops: list[str], entity_types: set[EntityType]) -> list[str]:
+    labels: list[str] = []
+    seen: set[str] = set()
+    for hop in path_hops:
+        node = graph.nodes.get(hop)
+        if not node or node.entity_type not in entity_types:
+            continue
+        label = node.label or node.id
+        key = label.lower()
+        if key in seen:
+            continue
+        labels.append(label)
+        seen.add(key)
+    return labels
+
+
+def _finding_ids_for_path(graph: UnifiedGraph, path_hops: list[str], vuln_ids: list[str]) -> list[str]:
+    ids: list[str] = []
+    seen: set[str] = set()
+    for value in vuln_ids:
+        cleaned = value.strip()
+        if cleaned and cleaned not in seen:
+            ids.append(cleaned)
+            seen.add(cleaned)
+    for hop in path_hops:
+        node = graph.nodes.get(hop)
+        if not node or node.entity_type not in {EntityType.VULNERABILITY, EntityType.MISCONFIGURATION}:
+            continue
+        label = node.label or node.id
+        if label not in seen:
+            ids.append(label)
+            seen.add(label)
+    return ids
+
+
+def _first_href_for_agent(agent: str) -> str:
+    return f"/agents?name={quote(agent)}"
+
+
+def _risk_reasons_for_path(graph: UnifiedGraph, path) -> list[dict[str, str]]:
+    reasons: list[dict[str, str]] = []
+    if path.composite_risk >= 90:
+        reasons.append(
+            {
+                "kind": "critical_reach",
+                "label": "Critical reach",
+                "detail": "Composite risk is at or above the release-blocking threshold.",
+            }
+        )
+    elif path.composite_risk >= 70:
+        reasons.append(
+            {
+                "kind": "high_reach",
+                "label": "High reach",
+                "detail": "Composite risk is high enough to prioritize before broad topology review.",
+            }
+        )
+    if path.credential_exposure:
+        reasons.append(
+            {
+                "kind": "credential_exposure",
+                "label": "Credential exposure",
+                "detail": f"{len(path.credential_exposure)} credential signal(s) sit on this path.",
+            }
+        )
+    if path.tool_exposure:
+        dangerous_tools = [
+            tool
+            for tool in path.tool_exposure
+            if any(keyword in tool.lower() for keyword in ("shell", "exec", "run", "command", "subprocess", "filesystem"))
+        ]
+        reasons.append(
+            {
+                "kind": "tool_reach",
+                "label": "Tool reach",
+                "detail": (
+                    f"{len(dangerous_tools)} execution/file-capable tool(s) are reachable."
+                    if dangerous_tools
+                    else f"{len(path.tool_exposure)} tool(s) are reachable from the affected agent/server."
+                ),
+            }
+        )
+    finding_ids = _finding_ids_for_path(graph, path.hops, path.vuln_ids)
+    if finding_ids:
+        reasons.append(
+            {
+                "kind": "finding",
+                "label": "Finding in chain",
+                "detail": f"{len(finding_ids)} vulnerability or misconfiguration finding(s) anchor this path.",
+            }
+        )
+    if not reasons:
+        reasons.append(
+            {
+                "kind": "topology",
+                "label": "Connected exposure",
+                "detail": "The graph found a connected exposure path that should be reviewed before full expansion.",
+            }
+        )
+    return reasons[:4]
+
+
+def _next_actions_for_path(graph: UnifiedGraph, path) -> list[dict[str, str]]:
+    findings = _finding_ids_for_path(graph, path.hops, path.vuln_ids)
+    agents = _node_labels_for_types(
+        graph,
+        path.hops,
+        {EntityType.AGENT, EntityType.USER, EntityType.GROUP, EntityType.SERVICE_ACCOUNT},
+    )
+    actions: list[dict[str, str]] = []
+    if findings:
+        actions.append(
+            {
+                "title": "Validate lead finding",
+                "detail": "Open the first finding and confirm the root cause before expanding the graph.",
+                "href": f"/findings?cve={quote(findings[0])}",
+            }
+        )
+    if agents:
+        actions.append(
+            {
+                "title": "Inspect exposed identity",
+                "detail": "Review the agent, user, or service account that can trigger this path.",
+                "href": _first_href_for_agent(agents[0]),
+            }
+        )
+    if path.credential_exposure:
+        actions.append(
+            {
+                "title": "Contain credentials",
+                "detail": "Rotate, scope, or remove exposed credentials before widening blast-radius analysis.",
+                "href": "/mesh",
+            }
+        )
+    elif path.tool_exposure:
+        actions.append(
+            {
+                "title": "Review reachable tools",
+                "detail": "Check whether the tool permissions turn this finding into a real incident path.",
+                "href": "/mesh",
+            }
+        )
+    actions.append(
+        {
+            "title": "Expand topology",
+            "detail": "Open the full lineage graph only when neighboring context is needed.",
+            "href": "/graph",
+        }
+    )
+    return actions[:4]
+
+
+def _fix_first_card_for_path(graph: UnifiedGraph, path, rank: int) -> dict:
+    findings = _finding_ids_for_path(graph, path.hops, path.vuln_ids)
+    agents = _node_labels_for_types(
+        graph,
+        path.hops,
+        {EntityType.AGENT, EntityType.USER, EntityType.GROUP, EntityType.SERVICE_ACCOUNT},
+    )
+    servers = _node_labels_for_types(graph, path.hops, {EntityType.SERVER, EntityType.CONTAINER, EntityType.CLOUD_RESOURCE})
+    packages = _node_labels_for_types(graph, path.hops, {EntityType.PACKAGE})
+    sequence = [graph.nodes[hop].label for hop in path.hops if hop in graph.nodes]
+    title_parts = [findings[0] if findings else "Exposure path"]
+    if agents:
+        title_parts.append(f"via {agents[0]}")
+    if path.tool_exposure:
+        title_parts.append(f"with {path.tool_exposure[0]}")
+    return {
+        "id": f"{path.source}::{path.target}::{'->'.join(path.hops)}",
+        "rank": rank,
+        "title": " ".join(title_parts),
+        "summary": path.summary or "Review this path before opening the full topology graph.",
+        "attack_path": path.to_dict(),
+        "sequence_labels": sequence,
+        "risk_reasons": _risk_reasons_for_path(graph, path),
+        "next_actions": _next_actions_for_path(graph, path),
+        "affected": {
+            "agents": agents,
+            "servers": servers,
+            "packages": packages,
+            "findings": findings,
+            "credentials": list(path.credential_exposure),
+            "tools": list(path.tool_exposure),
+        },
+    }
+
+
+def _path_matches_focus(graph: UnifiedGraph, path, *, cve: str, package: str, agent: str) -> bool:
+    def norm(value: str) -> str:
+        return value.strip().lower()
+
+    cve_n = norm(cve)
+    package_n = norm(package)
+    agent_n = norm(agent)
+    if not cve_n and not package_n and not agent_n:
+        return True
+    labels = {norm(graph.nodes[hop].label) for hop in path.hops if hop in graph.nodes}
+    finding_ids = {norm(value) for value in _finding_ids_for_path(graph, path.hops, path.vuln_ids)}
+    if cve_n and cve_n not in labels and cve_n not in finding_ids:
+        return False
+    if package_n:
+        package_labels = {norm(label) for label in _node_labels_for_types(graph, path.hops, {EntityType.PACKAGE})}
+        if package_n not in package_labels:
+            return False
+    if agent_n:
+        agent_labels = {
+            norm(label)
+            for label in _node_labels_for_types(
+                graph,
+                path.hops,
+                {EntityType.AGENT, EntityType.USER, EntityType.GROUP, EntityType.SERVICE_ACCOUNT},
+            )
+        }
+        if agent_n not in agent_labels:
+            return False
+    return True
 
 
 def _bounded_env_int(name: str, default: int, *, minimum: int, maximum: int) -> int:
@@ -403,6 +622,64 @@ async def get_graph(
             min_severity_rank=min_rank,
         ),
         "pagination": _page_meta(total, offset, limit, cursor=cursor, next_cursor=next_cursor),
+    }
+
+
+@router.get("/v1/graph/views/fix-first", tags=["graph"])
+async def get_fix_first_graph_view(
+    request: Request,
+    scan_id: Optional[str] = Query(None, description="Scan snapshot ID; latest if omitted"),
+    cve: str = Query("", description="Optional finding focus"),
+    package: str = Query("", description="Optional package focus"),
+    agent: str = Query("", description="Optional agent or identity focus"),
+    limit: int = Query(8, ge=1, le=25, description="Maximum ranked path cards to return"),
+) -> dict:
+    """Return a fix-first security graph view model.
+
+    This endpoint is intentionally more product-shaped than `/v1/graph`: it
+    ranks persisted attack paths and attaches the operator context needed for
+    a Wiz/Orca-style remediation cockpit. The full topology remains available
+    through `/v1/graph`; this view answers "what should I inspect first?"
+    """
+
+    tenant = _tenant(request)
+    graph_store = _get_graph_store_or_503()
+    requested_scan_id = scan_id or ""
+
+    if not requested_scan_id and not await _graph_store_call(graph_store.latest_snapshot_id, tenant_id=tenant):
+        raise HTTPException(status_code=503, detail="Graph snapshots not found. Run a scan first.")
+
+    graph = await _graph_store_call(
+        graph_store.load_graph,
+        scan_id=requested_scan_id,
+        tenant_id=tenant,
+    )
+    ranked_paths = sorted(
+        (path for path in graph.attack_paths if _path_matches_focus(graph, path, cve=cve, package=package, agent=agent)),
+        key=lambda path: (path.composite_risk, len(path.hops), len(path.credential_exposure), len(path.tool_exposure)),
+        reverse=True,
+    )
+    cards = [_fix_first_card_for_path(graph, path, index + 1) for index, path in enumerate(ranked_paths[:limit])]
+    covered_findings = {finding for card in cards for finding in card["affected"]["findings"]}
+    return {
+        "scan_id": graph.scan_id,
+        "tenant_id": graph.tenant_id,
+        "created_at": graph.created_at,
+        "cards": cards,
+        "summary": {
+            "total_paths": len(graph.attack_paths),
+            "matched_paths": len(ranked_paths),
+            "returned_paths": len(cards),
+            "highest_risk": cards[0]["attack_path"]["composite_risk"] if cards else 0.0,
+            "covered_findings": len(covered_findings),
+            "node_count": len(graph.nodes),
+            "edge_count": len(graph.edges),
+        },
+        "focus": {
+            "cve": cve,
+            "package": package,
+            "agent": agent,
+        },
     }
 
 

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -883,8 +883,50 @@ class TestGraphStoreBackendSelection:
         assert body["attack_paths"][0]["tool_exposure"] == ["run_shell"]
         assert any(call[0] == "latest_snapshot_id" for call in recording_graph_store.calls)
         assert any(call[0] == "page_nodes" for call in recording_graph_store.calls)
-        assert any(call[0] == "attack_paths_for_sources" for call in recording_graph_store.calls)
-        assert not any(call[0] == "load_graph" for call in recording_graph_store.calls)
+
+    def test_fix_first_graph_view_returns_ranked_operator_cards(self, recording_graph_store):
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:a:fs", entity_type=EntityType.SERVER, label="mcp-fs"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="pkg:npm:express", entity_type=EntityType.PACKAGE, label="express"))
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="vuln:cve",
+                entity_type=EntityType.VULNERABILITY,
+                label="CVE-2026-1",
+                severity="critical",
+                risk_score=9.8,
+            )
+        )
+        recording_graph_store.graph.attack_paths.append(
+            AttackPath(
+                source="agent:a",
+                target="vuln:cve",
+                hops=["agent:a", "server:a:fs", "pkg:npm:express", "vuln:cve"],
+                edges=["uses", "depends_on", "vulnerable_to"],
+                composite_risk=94.0,
+                summary="agent-a reaches shell-capable MCP server before CVE-2026-1",
+                credential_exposure=["AWS_SECRET_ACCESS_KEY"],
+                tool_exposure=["run_shell"],
+                vuln_ids=["CVE-2026-1"],
+            )
+        )
+        client = TestClient(app)
+
+        response = client.get("/v1/graph/views/fix-first", params={"scan_id": "store-scan", "cve": "CVE-2026-1"})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["summary"]["matched_paths"] == 1
+        assert body["cards"][0]["rank"] == 1
+        assert body["cards"][0]["title"].startswith("CVE-2026-1 via agent-a")
+        assert body["cards"][0]["affected"]["agents"] == ["agent-a"]
+        assert body["cards"][0]["affected"]["packages"] == ["express"]
+        assert {reason["kind"] for reason in body["cards"][0]["risk_reasons"]} >= {
+            "critical_reach",
+            "credential_exposure",
+            "tool_reach",
+        }
+        assert body["cards"][0]["next_actions"][0]["href"] == "/findings?cve=CVE-2026-1"
+        assert any(call[0] == "load_graph" for call in recording_graph_store.calls)
 
     def test_graph_overview_filtered_page_stays_store_backed(self, recording_graph_store):
         recording_graph_store.graph.add_node(

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -23,10 +23,11 @@ function _classifyGraphErrorKind(err: unknown): "network" | "auth" | "forbidden"
 }
 import { AttackPathCard } from "@/components/attack-path-card";
 import { GraphEmptyState } from "@/components/graph-state-panels";
-import { PostureGrade } from "@/components/posture-grade";
 import {
   api,
   formatDate,
+  type FixFirstGraphViewResponse,
+  type FixFirstPathCard,
   type GraphSnapshot,
   type PostureResponse,
   type UnifiedGraphResponse,
@@ -94,6 +95,7 @@ function SecurityGraphPageContent() {
   const [snapshots, setSnapshots] = useState<GraphSnapshot[]>([]);
   const [selectedScanId, setSelectedScanId] = useState("");
   const [graphData, setGraphData] = useState<UnifiedGraphResponse | null>(null);
+  const [fixFirstView, setFixFirstView] = useState<FixFirstGraphViewResponse | null>(null);
   const [posture, setPosture] = useState<PostureResponse | null>(null);
   const [loadingSnapshots, setLoadingSnapshots] = useState(true);
   const [loadingGraph, setLoadingGraph] = useState(false);
@@ -157,6 +159,7 @@ function SecurityGraphPageContent() {
   useEffect(() => {
     if (!selectedScanId) {
       setGraphData(null);
+      setFixFirstView(null);
       setSelectedAttackPathKey(null);
       return;
     }
@@ -166,18 +169,29 @@ function SecurityGraphPageContent() {
     async function loadGraph() {
       setLoadingGraph(true);
       try {
-        const graph = await api.getGraph({
-          scanId: selectedScanId,
-          entityTypes: ATTACK_PATH_ENTITY_TYPES,
-          maxDepth: 6,
-          limit: 1200,
-        });
+        const [graph, view] = await Promise.all([
+          api.getGraph({
+            scanId: selectedScanId,
+            entityTypes: ATTACK_PATH_ENTITY_TYPES,
+            maxDepth: 6,
+            limit: 1200,
+          }),
+          api.getFixFirstGraphView({
+            scanId: selectedScanId,
+            cve: focus.cve || undefined,
+            packageName: focus.packageName || undefined,
+            agentName: focus.agentName || undefined,
+            limit: 12,
+          }),
+        ]);
         if (cancelled) return;
         setGraphData(graph);
+        setFixFirstView(view);
         setApiError(null);
       } catch (error) {
         if (cancelled) return;
         setGraphData(emptyGraphResponse(selectedScanId));
+        setFixFirstView(null);
         setApiError(error instanceof Error ? error.message : "Failed to load security graph");
       } finally {
         if (!cancelled) setLoadingGraph(false);
@@ -188,7 +202,7 @@ function SecurityGraphPageContent() {
     return () => {
       cancelled = true;
     };
-  }, [selectedScanId]);
+  }, [focus.agentName, focus.cve, focus.packageName, selectedScanId]);
 
   const selectedSnapshot = useMemo(
     () => snapshots.find((snapshot) => snapshot.scan_id === selectedScanId) ?? null,
@@ -200,12 +214,24 @@ function SecurityGraphPageContent() {
     [graphData?.nodes],
   );
 
+  const fixFirstCards = useMemo(() => fixFirstView?.cards ?? [], [fixFirstView?.cards]);
+
+  const cardByPathKey = useMemo(() => {
+    const next = new Map<string, FixFirstPathCard>();
+    for (const card of fixFirstCards) {
+      next.set(attackPathKey(card.attack_path), card);
+    }
+    return next;
+  }, [fixFirstCards]);
+
   const attackPaths = useMemo(
     () =>
-      [...(graphData?.attack_paths ?? [])].sort(
-        (left, right) => right.composite_risk - left.composite_risk,
-      ),
-    [graphData?.attack_paths],
+      fixFirstCards.length > 0
+        ? fixFirstCards.map((card) => card.attack_path)
+        : [...(graphData?.attack_paths ?? [])].sort(
+            (left, right) => right.composite_risk - left.composite_risk,
+          ),
+    [fixFirstCards, graphData?.attack_paths],
   );
 
   const hasFocusContext = Boolean(focus.cve || focus.packageName || focus.agentName);
@@ -229,6 +255,11 @@ function SecurityGraphPageContent() {
         ? attackPaths.find((path) => attackPathKey(path) === selectedAttackPathKey) ?? null
         : attackPaths[0] ?? null,
     [attackPaths, selectedAttackPathKey],
+  );
+
+  const selectedFixFirstCard = useMemo(
+    () => (selectedAttackPath ? cardByPathKey.get(attackPathKey(selectedAttackPath)) ?? null : null),
+    [cardByPathKey, selectedAttackPath],
   );
 
   const selectedPathAgents = useMemo(
@@ -369,7 +400,7 @@ function SecurityGraphPageContent() {
           </div>
         </div>
 
-        <div className="mt-6 grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="mt-6 grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
           <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
@@ -419,18 +450,43 @@ function SecurityGraphPageContent() {
                 </div>
               )
             )}
+
+            {fixFirstView && (
+              <div className="mt-4 grid gap-3 border-t border-[color:var(--border-subtle)] pt-4 sm:grid-cols-3">
+                <QuickStat label="Matched paths" value={String(fixFirstView.summary.matched_paths)} tone="blue" />
+                <QuickStat label="Covered findings" value={String(fixFirstView.summary.covered_findings)} tone="amber" />
+                <QuickStat label="Highest risk" value={fixFirstView.summary.highest_risk.toFixed(1)} tone="red" />
+              </div>
+            )}
           </div>
 
           <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
             <p className="text-[10px] uppercase tracking-[0.2em] text-[color:var(--text-tertiary)]">Current pressure</p>
             {posture ? (
-              <div className="mt-3">
-                <PostureGrade
-                  grade={posture.grade}
-                  score={posture.score}
-                  dimensions={posture.dimensions}
-                  drilldown
-                />
+              <div className="mt-4">
+                <div className="flex items-end justify-between gap-4">
+                  <div>
+                    <div className="font-mono text-5xl font-semibold text-red-300">{posture.grade}</div>
+                    <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">{posture.summary}</p>
+                  </div>
+                  <div className="text-right">
+                    <div className="font-mono text-2xl text-[color:var(--foreground)]">{posture.score}</div>
+                    <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">score</div>
+                  </div>
+                </div>
+                <div className="mt-4 h-2 overflow-hidden rounded-full bg-[color:var(--surface-muted)]">
+                  <div
+                    className="h-full rounded-full bg-gradient-to-r from-red-500 via-amber-400 to-emerald-400"
+                    style={{ width: `${Math.max(0, Math.min(100, posture.score))}%` }}
+                  />
+                </div>
+                <Link
+                  href="/insights"
+                  className="mt-4 inline-flex items-center gap-2 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-1.5 text-xs text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
+                >
+                  Open posture details
+                  <ArrowRight className="h-3.5 w-3.5" />
+                </Link>
               </div>
             ) : (
               <div className="mt-4 rounded-2xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-5 text-sm text-[color:var(--text-secondary)]">
@@ -486,10 +542,10 @@ function SecurityGraphPageContent() {
               <div>
                 <p className="text-[10px] uppercase tracking-[0.2em] text-orange-400">Attack path queue</p>
                 <h2 className="mt-1 text-lg font-semibold text-[color:var(--foreground)]">
-                  {attackPaths.length} high-signal path{attackPaths.length !== 1 ? "s" : ""} in the selected snapshot
+                  {attackPaths.length} ranked fix-first path{attackPaths.length !== 1 ? "s" : ""} in the selected snapshot
                 </h2>
                 <p className="mt-1 text-sm text-[color:var(--text-tertiary)]">
-                  Focus one exploit chain at a time, then jump into the full graph only when you need broader topology.
+                  Ranked by composite risk and operator context so the first screen starts with what to validate, contain, or expand.
                 </p>
                 <p className="mt-2 text-xs text-[color:var(--text-tertiary)]">
                   Keyboard: focus this queue and use ← / → to step through paths.
@@ -539,19 +595,48 @@ function SecurityGraphPageContent() {
             >
               {attackPaths.slice(0, 8).map((path) => {
                 const key = attackPathKey(path);
+                const card = cardByPathKey.get(key);
                 const pathNodes = toAttackCardNodes(path, graphNodeById);
                 if (pathNodes.length === 0) return null;
                 const active = selectedAttackPath ? attackPathKey(selectedAttackPath) === key : false;
                 return (
                   <div
                     key={key}
-                    className={`min-w-[360px] rounded-2xl transition ${active ? "ring-2 ring-orange-400/70 ring-offset-2 ring-offset-zinc-950" : ""}`}
+                    className={`min-w-[380px] rounded-2xl border bg-[color:var(--surface-elevated)] p-3 transition ${
+                      active
+                        ? "border-orange-400/70 ring-2 ring-orange-400/70 ring-offset-2 ring-offset-zinc-950"
+                        : "border-[color:var(--border-subtle)]"
+                    }`}
                   >
+                    {card && (
+                      <div className="mb-3 flex items-start justify-between gap-3">
+                        <div>
+                          <div className="text-[10px] uppercase tracking-[0.18em] text-orange-300">#{card.rank} fix first</div>
+                          <div className="mt-1 text-sm font-semibold leading-5 text-[color:var(--foreground)]">{card.title}</div>
+                        </div>
+                        <div className="rounded-full border border-red-900/60 bg-red-950/30 px-2 py-1 font-mono text-[11px] text-red-200">
+                          {card.attack_path.composite_risk.toFixed(1)}
+                        </div>
+                      </div>
+                    )}
                     <AttackPathCard
                       nodes={pathNodes}
                       riskScore={path.composite_risk}
                       onClick={() => setSelectedAttackPathKey(key)}
                     />
+                    {card && card.risk_reasons.length > 0 && (
+                      <div className="mt-3 flex flex-wrap gap-1.5">
+                        {card.risk_reasons.slice(0, 3).map((reason) => (
+                          <span
+                            key={`${card.id}-${reason.kind}`}
+                            title={reason.detail}
+                            className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2 py-1 text-[10px] text-[color:var(--text-secondary)]"
+                          >
+                            {reason.label}
+                          </span>
+                        ))}
+                      </div>
+                    )}
                   </div>
                 );
               })}
@@ -565,10 +650,11 @@ function SecurityGraphPageContent() {
                   <div>
                     <p className="text-[10px] uppercase tracking-[0.2em] text-orange-400">Selected path</p>
                     <h2 className="mt-1 text-lg font-semibold text-[color:var(--foreground)]">
-                      {selectedAttackPath.summary || "Credential-aware exploit chain"}
+                      {selectedFixFirstCard?.title || selectedAttackPath.summary || "Credential-aware exploit chain"}
                     </h2>
                     <p className="mt-2 text-sm leading-6 text-[color:var(--text-secondary)]">
-                      The graph already resolved this chain. Use it as the operator-facing shortlist before you branch into detailed evidence.
+                      {selectedFixFirstCard?.summary ||
+                        "The graph already resolved this chain. Use it as the operator-facing shortlist before you branch into detailed evidence."}
                     </p>
                   </div>
                   <div className="rounded-2xl border border-red-900/60 bg-red-950/20 px-4 py-3">
@@ -576,6 +662,20 @@ function SecurityGraphPageContent() {
                     <div className="mt-1 font-mono text-2xl text-red-200">{selectedAttackPath.composite_risk.toFixed(1)}</div>
                   </div>
                 </div>
+
+                {selectedFixFirstCard && selectedFixFirstCard.risk_reasons.length > 0 && (
+                  <div className="mt-4 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+                    <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">Why this is prioritized</div>
+                    <div className="mt-3 grid gap-3 md:grid-cols-2">
+                      {selectedFixFirstCard.risk_reasons.map((reason) => (
+                        <div key={reason.kind} className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3">
+                          <div className="text-sm font-semibold text-[color:var(--foreground)]">{reason.label}</div>
+                          <p className="mt-1 text-xs leading-5 text-[color:var(--text-tertiary)]">{reason.detail}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
 
                 <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
                   <QuickStat label="Hop count" value={String(Math.max(0, selectedAttackPath.hops.length - 1))} />
@@ -636,7 +736,7 @@ function SecurityGraphPageContent() {
                   Recommended next steps
                 </div>
                 <div className="mt-3 grid gap-3 lg:grid-cols-3">
-                  {selectedPathActions.map((action) => (
+                  {(selectedFixFirstCard?.next_actions ?? selectedPathActions).map((action) => (
                     <Link
                       key={action.title}
                       href={action.href}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1,6 +1,6 @@
 /** Shared API response and request contracts. */
 
-import type { UnifiedEdge, UnifiedGraphData, UnifiedNode } from "./graph-schema";
+import type { AttackPath, UnifiedEdge, UnifiedGraphData, UnifiedNode } from "./graph-schema";
 
 export type JobStatus = "pending" | "running" | "done" | "failed" | "cancelled";
 
@@ -97,6 +97,58 @@ export interface GraphSnapshot {
 
 export interface UnifiedGraphResponse extends UnifiedGraphData {
   pagination: GraphPagination;
+}
+
+export interface FixFirstRiskReason {
+  kind: string;
+  label: string;
+  detail: string;
+}
+
+export interface FixFirstAction {
+  title: string;
+  detail: string;
+  href: string;
+}
+
+export interface FixFirstPathCard {
+  id: string;
+  rank: number;
+  title: string;
+  summary: string;
+  attack_path: AttackPath;
+  sequence_labels: string[];
+  risk_reasons: FixFirstRiskReason[];
+  next_actions: FixFirstAction[];
+  affected: {
+    agents: string[];
+    servers: string[];
+    packages: string[];
+    findings: string[];
+    credentials: string[];
+    tools: string[];
+  };
+}
+
+export interface FixFirstGraphViewResponse {
+  scan_id: string;
+  tenant_id: string;
+  created_at: string;
+  cards: FixFirstPathCard[];
+  summary: {
+    total_paths: number;
+    matched_paths: number;
+    returned_paths: number;
+    highest_risk: number;
+    covered_findings: number;
+    node_count: number;
+    edge_count: number;
+  };
+  focus: {
+    cve: string;
+    package: string;
+    agent: string;
+  };
 }
 
 export interface GraphImpactResponse {

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   ScanJobStatus,
   GraphSnapshot,
   UnifiedGraphResponse,
+  FixFirstGraphViewResponse,
   GraphNodeDetailResponse,
   GraphSearchResponse,
   GraphAgentsResponse,
@@ -91,6 +92,8 @@ export type {
   GraphPagination,
   GraphSnapshot,
   UnifiedGraphResponse,
+  FixFirstGraphViewResponse,
+  FixFirstPathCard,
   GraphImpactResponse,
   GraphNodeDetailResponse,
   GraphSearchResponse,
@@ -488,6 +491,24 @@ export const api = {
     if (filters?.limit != null) params.set("limit", String(filters.limit));
     const qs = params.toString();
     return get<UnifiedGraphResponse>(`/v1/graph${qs ? `?${qs}` : ""}`);
+  },
+
+  /** Load the ranked fix-first security graph view model */
+  getFixFirstGraphView: (filters?: {
+    scanId?: string | undefined;
+    cve?: string | undefined;
+    packageName?: string | undefined;
+    agentName?: string | undefined;
+    limit?: number | undefined;
+  }) => {
+    const params = new URLSearchParams();
+    if (filters?.scanId) params.set("scan_id", filters.scanId);
+    if (filters?.cve) params.set("cve", filters.cve);
+    if (filters?.packageName) params.set("package", filters.packageName);
+    if (filters?.agentName) params.set("agent", filters.agentName);
+    if (filters?.limit != null) params.set("limit", String(filters.limit));
+    const qs = params.toString();
+    return get<FixFirstGraphViewResponse>(`/v1/graph/views/fix-first${qs ? `?${qs}` : ""}`);
   },
 
   /** Search graph nodes within a snapshot */


### PR DESCRIPTION
## Summary

Moves `/security-graph` from a raw graph explorer toward a fix-first security cockpit in the style of Wiz / Orca / CrowdStrike exposure workflows.

- adds `/v1/graph/views/fix-first`, a backend view model that ranks attack paths and returns operator-ready cards
- exposes affected agents, servers, packages, findings, credentials, and tools per path
- explains prioritization with first-class risk reasons: critical reach, credential exposure, tool reach, KEV, EPSS, and path depth
- adds recommended next actions with deep links into findings, agent graph focus, SBOM, and runtime evidence
- wires the frontend to fetch the snapshot and fix-first view together so the first viewport shows the queue, not only the canvas
- replaces the tall posture grade panel with compact pressure stats so the attack queue appears earlier

## Why this matters

The graph quality work made large graphs readable. This PR makes them actionable: an operator can answer `what should I fix first?`, `why is this path prioritized?`, and `what evidence backs it?` without interpreting every node and edge manually.

## Validation

- `uv run pytest tests/test_graph_api.py -q` -> 48 passed
- `npm run test:run` -> 24 files / 174 tests passed
- `npm run typecheck` -> passed
- `npm run lint` -> passed
- `uv run ruff check src/agent_bom/api/routes/graph.py tests/test_graph_api.py` -> passed
- `git diff --check` -> passed
- local API + Next UI smoke with Playwright against `/security-graph?scan=...&agent=cursor`

## Local screenshot

Saved for review on the workstation:

`/Users/mohamedsaad/Desktop/agent-bom-e2e-screens/security-graph-fix-first.png`
