### PR TITLE
docs: fix release diagram drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ without collapsing into one overloaded chart:
 - [Auth + Ingress Flow](site-docs/deployment/overview.md#auth-ingress-flow)
 - [Inventory & Runtime Evidence Flow](site-docs/deployment/overview.md#inventory-runtime-evidence-flow)
 
+The short README shape is:
+
 ```mermaid
 %%{init: {"theme":"base","themeVariables":{"primaryColor":"#0f172a","primaryBorderColor":"#6366f1","primaryTextColor":"#e0e7ff","lineColor":"#64748b"}}}%%
 flowchart LR

--- a/docs/VISUAL_LANGUAGE.md
+++ b/docs/VISUAL_LANGUAGE.md
@@ -10,7 +10,7 @@ deployments, but they are not the primary product visuals for README or docs.
 ## SVG — for hero visuals + dense product imagery
 
 Use when:
-- the diagram is the *story* of the section (blast-radius, scan pipeline, engine internals, compliance mapping, topology)
+- the diagram is the *story* of the section (blast-radius, scan pipeline, engine internals, compliance mapping)
 - you need typographic control, color hierarchy, or dense info per pixel
 - it does not change every PR
 
@@ -24,8 +24,7 @@ Current SVG inventory:
 | `logo-{light,dark}.svg` | Brand mark | hero |
 | `blast-radius-{light,dark}.svg` | Package → CVE → MCP → agent → credentials → tools | hero, under tagline |
 | `scan-pipeline-{light,dark}.svg` | 5-stage pipeline (discover → scan → analyze → report → enforce) | "How a scan moves" |
-| `engine-internals-{light,dark}.svg` | Inside the scanner | "How a scan moves" |
-| `topology-{light,dark}.svg` | Focused graph view (start scoped, expand) | "How a scan moves" |
+| `engine-internals-{light,dark}.svg` | Inside the scanner | available for deeper architecture docs; not currently embedded in the README |
 | `compliance-{light,dark}.svg` | Finding → control → evidence packet | Compliance section |
 | `dashboard-live.png` `dashboard-paths-live.png` `mesh-live.png` `remediation-live.png` | Live packaged Next.js dashboard screenshots | Product views |
 | `demo-latest.gif` | Terminal demo (1.04MB after compression) | "Try the demo" |

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -142,6 +142,10 @@ flowchart TB
     Platform --> Postgres
     Platform -. optional export .-> Sinks
     Runtime --> Platform
+    Endpoints --> Platform
+    IdP -. OIDC / SAML .-> Platform
+    Platform -. inventory reads .-> Cloud
+    Runtime -. MCP relay .-> Remote
 ```
 
 Truth block:


### PR DESCRIPTION
## Summary

Small release-readiness cleanup from the graph/docs audit.

- corrects `docs/VISUAL_LANGUAGE.md` so it no longer claims non-existent `topology-{light,dark}.svg` assets
- marks `engine-internals` as an available architecture asset, not a current README embed
- connects the customer-owned external nodes in the deployment topology diagram so IdP, endpoints, cloud APIs, and remote MCPs are not floating
- clarifies that the README Mermaid is a short shape, while the deployment overview owns the three detailed diagrams

## Validation

- `uv run python scripts/check_release_consistency.py` -> passed
- targeted grep for stale screenshot/asset claims -> only the corrected `engine-internals` inventory row remains
- `git diff --check` -> passed
