### PR TITLE
feat(graph): semantic layer metadata and grouped legend

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -30,7 +30,7 @@ from pydantic import BaseModel, Field
 
 from agent_bom.api.stores import _get_graph_store
 from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
-from agent_bom.graph import SEVERITY_RANK, EntityType, GraphFilterOptions, RelationshipType, UnifiedGraph
+from agent_bom.graph import SEVERITY_RANK, EntityType, GraphFilterOptions, GraphSemanticLayer, RelationshipType, UnifiedGraph
 from agent_bom.security import sanitize_error
 
 logger = logging.getLogger(__name__)
@@ -47,6 +47,21 @@ _GRAPH_QUERY_DEFAULT_BUDGET = {
     "max_nodes": 1000,
     "max_edges": 10_000,
     "timeout_ms": 2500,
+}
+
+_SEMANTIC_LAYER_LABELS = {
+    GraphSemanticLayer.USER.value: "User",
+    GraphSemanticLayer.IDENTITY.value: "Identity",
+    GraphSemanticLayer.APP.value: "Application",
+    GraphSemanticLayer.API_GATEWAY.value: "API / Gateway",
+    GraphSemanticLayer.ORCHESTRATION.value: "Orchestration",
+    GraphSemanticLayer.MCP_SERVER.value: "MCP Server",
+    GraphSemanticLayer.TOOL.value: "Tool",
+    GraphSemanticLayer.PACKAGE.value: "Package",
+    GraphSemanticLayer.RUNTIME_EVIDENCE.value: "Runtime Evidence",
+    GraphSemanticLayer.ASSET.value: "Asset",
+    GraphSemanticLayer.INFRA.value: "Infrastructure",
+    GraphSemanticLayer.FINDING.value: "Finding",
 }
 
 
@@ -734,7 +749,7 @@ async def get_graph_legend() -> dict:
     from agent_bom.graph import ENTITY_LEGEND, RELATIONSHIP_LEGEND
 
     return {
-        "entities": [{"key": e.key, "label": e.label, "color": e.color, "shape": e.shape} for e in ENTITY_LEGEND],
+        "entities": [{"key": e.key, "label": e.label, "color": e.color, "shape": e.shape, "layer": e.layer} for e in ENTITY_LEGEND],
         "relationships": [{"key": r.key, "label": r.label, "color": r.color} for r in RELATIONSHIP_LEGEND],
     }
 
@@ -952,12 +967,14 @@ async def get_graph_schema() -> dict:
         label = legend.label if legend else entity.value.replace("_", " ").title()
         color = legend.color if legend else "#6b7280"
         shape = legend.shape if legend else "circle"
+        layer = legend.layer if legend and legend.layer else GraphSemanticLayer.ASSET.value
         node_kinds.append(
             {
                 "key": entity.value,
                 "label": label,
                 "color": color,
                 "shape": shape,
+                "layer": layer,
                 "icon": _SHAPE_TO_ICON.get(shape, "circle"),
                 "category_uid": ENTITY_OCSF_MAP.get(entity.value, {}).get("category_uid", 0),
                 "class_uid": ENTITY_OCSF_MAP.get(entity.value, {}).get("class_uid", 0),
@@ -989,6 +1006,7 @@ async def get_graph_schema() -> dict:
 
     return {
         "version": 1,
+        "semantic_layers": [{"key": layer.value, "label": _SEMANTIC_LAYER_LABELS[layer.value]} for layer in GraphSemanticLayer],
         "node_kinds": sorted(node_kinds, key=lambda d: d["key"]),
         "edge_kinds": sorted(edge_kinds, key=lambda d: d["key"]),
     }

--- a/src/agent_bom/graph/__init__.py
+++ b/src/agent_bom/graph/__init__.py
@@ -37,7 +37,7 @@ from agent_bom.graph.severity import (
     severity_rank,
     severity_to_ocsf,
 )
-from agent_bom.graph.types import EntityType, GraphLayout, NodeStatus, RelationshipType
+from agent_bom.graph.types import EntityType, GraphLayout, GraphSemanticLayer, NodeStatus, RelationshipType
 from agent_bom.graph.util import _now_iso
 from agent_bom.graph.webhooks import compute_delta_alerts, dispatch_delta_alerts, format_alerts_for_siem
 
@@ -45,6 +45,7 @@ __all__ = [
     # Types
     "EntityType",
     "RelationshipType",
+    "GraphSemanticLayer",
     "NodeStatus",
     "GraphLayout",
     "OCSFSeverity",

--- a/src/agent_bom/graph/container.py
+++ b/src/agent_bom/graph/container.py
@@ -11,7 +11,7 @@ from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import UnifiedNode
 from agent_bom.graph.ocsf import FINDING_ENTITY_TYPES
 from agent_bom.graph.severity import SEVERITY_RANK
-from agent_bom.graph.types import EntityType, NodeStatus, RelationshipType
+from agent_bom.graph.types import EntityType, GraphSemanticLayer, NodeStatus, RelationshipType
 from agent_bom.graph.util import _now_iso
 
 
@@ -651,22 +651,26 @@ class UnifiedGraph:
 
     def inventory_view(self) -> UnifiedGraph:
         return self._subgraph(
-            node_filter=lambda n: n.status == NodeStatus.ACTIVE
-            and n.entity_type
-            not in (
-                EntityType.VULNERABILITY,
-                EntityType.MISCONFIGURATION,
+            node_filter=lambda n: (
+                n.status == NodeStatus.ACTIVE
+                and n.entity_type
+                not in (
+                    EntityType.VULNERABILITY,
+                    EntityType.MISCONFIGURATION,
+                )
             ),
-            edge_filter=lambda e: e.relationship
-            in (
-                RelationshipType.HOSTS,
-                RelationshipType.USES,
-                RelationshipType.DEPENDS_ON,
-                RelationshipType.PROVIDES_TOOL,
-                RelationshipType.EXPOSES_CRED,
-                RelationshipType.REACHES_TOOL,
-                RelationshipType.SERVES_MODEL,
-                RelationshipType.CONTAINS,
+            edge_filter=lambda e: (
+                e.relationship
+                in (
+                    RelationshipType.HOSTS,
+                    RelationshipType.USES,
+                    RelationshipType.DEPENDS_ON,
+                    RelationshipType.PROVIDES_TOOL,
+                    RelationshipType.EXPOSES_CRED,
+                    RelationshipType.REACHES_TOOL,
+                    RelationshipType.SERVES_MODEL,
+                    RelationshipType.CONTAINS,
+                )
             ),
         )
 
@@ -826,28 +830,31 @@ class LegendEntry:
     label: str
     color: str
     shape: str = "circle"  # circle / diamond / square / triangle
+    layer: str = ""
 
 
 # Entity legend
 ENTITY_LEGEND: list[LegendEntry] = [
-    LegendEntry(key="agent", label="AI Agent", color="#10b981", shape="circle"),
-    LegendEntry(key="server", label="MCP Server", color="#3b82f6", shape="circle"),
-    LegendEntry(key="package", label="Package", color="#52525b", shape="square"),
-    LegendEntry(key="tool", label="Tool", color="#a855f7", shape="diamond"),
-    LegendEntry(key="vulnerability", label="Vulnerability", color="#ef4444", shape="triangle"),
-    LegendEntry(key="credential", label="Credential", color="#f59e0b", shape="diamond"),
-    LegendEntry(key="misconfiguration", label="Misconfiguration", color="#f97316", shape="triangle"),
-    LegendEntry(key="model", label="Model", color="#8b5cf6", shape="square"),
-    LegendEntry(key="container", label="Container", color="#6366f1", shape="square"),
-    LegendEntry(key="cloud_resource", label="Cloud Resource", color="#0ea5e9", shape="square"),
-    LegendEntry(key="user", label="User", color="#14b8a6", shape="circle"),
-    LegendEntry(key="group", label="Group", color="#0d9488", shape="circle"),
-    LegendEntry(key="service_account", label="Service Account", color="#0f766e", shape="circle"),
-    LegendEntry(key="fleet", label="Fleet", color="#6b7280", shape="square"),
-    LegendEntry(key="cluster", label="Cluster", color="#4b5563", shape="square"),
-    LegendEntry(key="dataset", label="Dataset", color="#06b6d4", shape="square"),
-    LegendEntry(key="environment", label="Environment", color="#9ca3af", shape="square"),
-    LegendEntry(key="provider", label="Provider", color="#d1d5db", shape="square"),
+    LegendEntry(key="agent", label="AI Agent", color="#10b981", shape="circle", layer=GraphSemanticLayer.ORCHESTRATION.value),
+    LegendEntry(key="server", label="MCP Server", color="#3b82f6", shape="circle", layer=GraphSemanticLayer.MCP_SERVER.value),
+    LegendEntry(key="package", label="Package", color="#52525b", shape="square", layer=GraphSemanticLayer.PACKAGE.value),
+    LegendEntry(key="tool", label="Tool", color="#a855f7", shape="diamond", layer=GraphSemanticLayer.TOOL.value),
+    LegendEntry(key="vulnerability", label="Vulnerability", color="#ef4444", shape="triangle", layer=GraphSemanticLayer.FINDING.value),
+    LegendEntry(key="credential", label="Credential", color="#f59e0b", shape="diamond", layer=GraphSemanticLayer.IDENTITY.value),
+    LegendEntry(
+        key="misconfiguration", label="Misconfiguration", color="#f97316", shape="triangle", layer=GraphSemanticLayer.FINDING.value
+    ),
+    LegendEntry(key="model", label="Model", color="#8b5cf6", shape="square", layer=GraphSemanticLayer.ASSET.value),
+    LegendEntry(key="container", label="Container", color="#6366f1", shape="square", layer=GraphSemanticLayer.INFRA.value),
+    LegendEntry(key="cloud_resource", label="Cloud Resource", color="#0ea5e9", shape="square", layer=GraphSemanticLayer.INFRA.value),
+    LegendEntry(key="user", label="User", color="#14b8a6", shape="circle", layer=GraphSemanticLayer.USER.value),
+    LegendEntry(key="group", label="Group", color="#0d9488", shape="circle", layer=GraphSemanticLayer.IDENTITY.value),
+    LegendEntry(key="service_account", label="Service Account", color="#0f766e", shape="circle", layer=GraphSemanticLayer.IDENTITY.value),
+    LegendEntry(key="fleet", label="Fleet", color="#6b7280", shape="square", layer=GraphSemanticLayer.INFRA.value),
+    LegendEntry(key="cluster", label="Cluster", color="#4b5563", shape="square", layer=GraphSemanticLayer.INFRA.value),
+    LegendEntry(key="dataset", label="Dataset", color="#06b6d4", shape="square", layer=GraphSemanticLayer.ASSET.value),
+    LegendEntry(key="environment", label="Environment", color="#9ca3af", shape="square", layer=GraphSemanticLayer.INFRA.value),
+    LegendEntry(key="provider", label="Provider", color="#d1d5db", shape="square", layer=GraphSemanticLayer.INFRA.value),
 ]
 
 RELATIONSHIP_LEGEND: list[LegendEntry] = [

--- a/src/agent_bom/graph/types.py
+++ b/src/agent_bom/graph/types.py
@@ -37,6 +37,23 @@ class EntityType(str, Enum):
     CLUSTER = "cluster"
 
 
+class GraphSemanticLayer(str, Enum):
+    """Operator-facing AI system layers used to group graph entities."""
+
+    USER = "user"
+    IDENTITY = "identity"
+    APP = "app"
+    API_GATEWAY = "api_gateway"
+    ORCHESTRATION = "orchestration"
+    MCP_SERVER = "mcp_server"
+    TOOL = "tool"
+    PACKAGE = "package"
+    RUNTIME_EVIDENCE = "runtime_evidence"
+    ASSET = "asset"
+    INFRA = "infra"
+    FINDING = "finding"
+
+
 class RelationshipType(str, Enum):
     """Edge relationship types across all graph surfaces."""
 

--- a/src/agent_bom/graph_schema.py
+++ b/src/agent_bom/graph_schema.py
@@ -23,6 +23,7 @@ from agent_bom.graph import (
     EntityType,
     GraphFilterOptions,
     GraphLayout,
+    GraphSemanticLayer,
     InteractionRisk,
     LegendEntry,
     NodeDimensions,

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -1100,8 +1100,9 @@ class TestGraphSchemaEndpoint:
         resp = client.get("/v1/graph/schema")
         assert resp.status_code == 200
         body = resp.json()
-        assert set(body) >= {"version", "node_kinds", "edge_kinds"}
+        assert set(body) >= {"version", "semantic_layers", "node_kinds", "edge_kinds"}
         assert isinstance(body["version"], int) and body["version"] >= 1
+        assert isinstance(body["semantic_layers"], list) and body["semantic_layers"]
         assert isinstance(body["node_kinds"], list) and body["node_kinds"]
         assert isinstance(body["edge_kinds"], list) and body["edge_kinds"]
 
@@ -1118,9 +1119,11 @@ class TestGraphSchemaEndpoint:
     def test_schema_entries_carry_label_color_shape_icon(self):
         client = self._client()
         body = client.get("/v1/graph/schema").json()
+        layer_keys = {entry["key"] for entry in body["semantic_layers"]}
         for entry in body["node_kinds"]:
-            assert {"key", "label", "color", "shape", "icon", "category_uid", "class_uid"} <= set(entry)
+            assert {"key", "label", "color", "shape", "layer", "icon", "category_uid", "class_uid"} <= set(entry)
             assert entry["color"].startswith("#")
+            assert entry["layer"] in layer_keys
             assert isinstance(entry["category_uid"], int)
             assert isinstance(entry["class_uid"], int)
         for entry in body["edge_kinds"]:
@@ -1140,6 +1143,16 @@ class TestGraphSchemaEndpoint:
             assert isinstance(entry["source_types"], list)
             assert isinstance(entry["target_types"], list)
             assert isinstance(entry["traversable"], bool)
+
+    def test_every_entity_type_has_semantic_layer(self):
+        from agent_bom.graph import ENTITY_LEGEND, GraphSemanticLayer
+        from agent_bom.graph.types import EntityType
+
+        allowed_layers = {layer.value for layer in GraphSemanticLayer}
+        layer_by_entity = {entry.key: entry.layer for entry in ENTITY_LEGEND}
+        assert set(layer_by_entity) == {entity.value for entity in EntityType}
+        assert set(layer_by_entity.values()) <= allowed_layers
+        assert all(layer_by_entity.values())
 
     def test_schema_relationship_metadata_uses_known_node_types(self):
         from agent_bom.graph.types import EntityType, RelationshipType
@@ -1207,5 +1220,6 @@ class TestGraphSchemaEndpoint:
         assert new_entry["label"]
         assert new_entry["color"].startswith("#")
         assert new_entry["shape"] in {"circle", "diamond", "square", "triangle"}
+        assert new_entry["layer"] == "asset"
         # Silence flake8 for the unused alias — kept for future legend tests.
         assert _container is not None

--- a/tests/test_graph_wave1.py
+++ b/tests/test_graph_wave1.py
@@ -275,3 +275,10 @@ class TestLegends:
     def test_legend_entries_have_color(self):
         for entry in ENTITY_LEGEND + RELATIONSHIP_LEGEND:
             assert entry.color.startswith("#"), f"Bad color for {entry.key}: {entry.color}"
+
+    def test_entity_legend_entries_have_semantic_layer(self):
+        from agent_bom.graph import GraphSemanticLayer
+
+        allowed_layers = {layer.value for layer in GraphSemanticLayer}
+        for entry in ENTITY_LEGEND:
+            assert entry.layer in allowed_layers, f"Bad layer for {entry.key}: {entry.layer}"

--- a/ui/components/graph-chrome.tsx
+++ b/ui/components/graph-chrome.tsx
@@ -27,6 +27,37 @@ import type { LegendItem } from "@/lib/graph-utils";
 
 // ─── Legend Bar ──────────────────────────────────────────────────────────────
 
+const LAYER_ORDER = [
+  "user",
+  "identity",
+  "app",
+  "api_gateway",
+  "orchestration",
+  "mcp_server",
+  "tool",
+  "package",
+  "runtime_evidence",
+  "asset",
+  "infra",
+  "finding",
+] as const;
+
+const LAYER_LABELS: Record<string, string> = {
+  user: "User",
+  identity: "Identity",
+  app: "Application",
+  api_gateway: "API / Gateway",
+  orchestration: "Orchestration",
+  mcp_server: "MCP Servers",
+  tool: "Tools",
+  package: "Packages",
+  runtime_evidence: "Runtime Evidence",
+  asset: "Assets",
+  infra: "Infrastructure",
+  finding: "Findings",
+  other: "Other",
+};
+
 export function GraphLegend({
   items,
   defaultOpen = false,
@@ -58,15 +89,39 @@ export function GraphLegend({
       </button>
       {(open || defaultOpen || embedded) && (
         <div className={`${embedded ? "relative w-[min(30rem,calc(100vw-2rem))] shadow-none" : "absolute right-0 top-full z-20 mt-2 w-[min(30rem,calc(100vw-2rem))] shadow-2xl shadow-black/30"} max-h-[60vh] overflow-y-auto rounded-xl border border-zinc-700 bg-zinc-900/95 p-3 backdrop-blur-md`}>
-          {nodeItems.length > 0 && (
-            <LegendSection title="Entities" items={nodeItems} />
-          )}
+          {nodeItems.length > 0 && <LayeredLegendSections items={nodeItems} />}
           {edgeItems.length > 0 && (
             <LegendSection title="Relationships" items={edgeItems} />
           )}
         </div>
       )}
     </div>
+  );
+}
+
+function LayeredLegendSections({ items }: { items: LegendItem[] }) {
+  const grouped = new Map<string, LegendItem[]>();
+  for (const item of items) {
+    const layer = item.layer || "other";
+    const existing = grouped.get(layer);
+    if (existing) {
+      existing.push(item);
+    } else {
+      grouped.set(layer, [item]);
+    }
+  }
+
+  const orderedLayers = [
+    ...LAYER_ORDER.filter((layer) => grouped.has(layer)),
+    ...[...grouped.keys()].filter((layer) => !(LAYER_ORDER as readonly string[]).includes(layer)).sort(),
+  ];
+
+  return (
+    <>
+      {orderedLayers.map((layer) => (
+        <LegendSection key={layer} title={LAYER_LABELS[layer] ?? layer.replace(/_/g, " ")} items={grouped.get(layer) ?? []} />
+      ))}
+    </>
   );
 }
 

--- a/ui/lib/graph-schema.generated.ts
+++ b/ui/lib/graph-schema.generated.ts
@@ -40,6 +40,7 @@ export interface GraphNodeKindMeta {
   label: string;
   color: string;
   shape: string;
+  layer: string;
   icon: string;
   category_uid: number;
   class_uid: number;
@@ -50,6 +51,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "AI Agent",
     "color": "#10b981",
     "shape": "circle",
+    "layer": "orchestration",
     "icon": "circle",
     "category_uid": 5,
     "class_uid": 4001
@@ -58,6 +60,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "Cloud Resource",
     "color": "#0ea5e9",
     "shape": "square",
+    "layer": "infra",
     "icon": "square",
     "category_uid": 5,
     "class_uid": 4001
@@ -66,6 +69,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "Cluster",
     "color": "#4b5563",
     "shape": "square",
+    "layer": "infra",
     "icon": "square",
     "category_uid": 5,
     "class_uid": 4001
@@ -74,6 +78,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "Container",
     "color": "#6366f1",
     "shape": "square",
+    "layer": "infra",
     "icon": "square",
     "category_uid": 5,
     "class_uid": 4001
@@ -82,6 +87,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "Credential",
     "color": "#f59e0b",
     "shape": "diamond",
+    "layer": "identity",
     "icon": "diamond",
     "category_uid": 5,
     "class_uid": 4001
@@ -90,6 +96,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "Dataset",
     "color": "#06b6d4",
     "shape": "square",
+    "layer": "asset",
     "icon": "square",
     "category_uid": 5,
     "class_uid": 4001
@@ -98,6 +105,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "Environment",
     "color": "#9ca3af",
     "shape": "square",
+    "layer": "infra",
     "icon": "square",
     "category_uid": 0,
     "class_uid": 0
@@ -106,6 +114,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "Fleet",
     "color": "#6b7280",
     "shape": "square",
+    "layer": "infra",
     "icon": "square",
     "category_uid": 5,
     "class_uid": 4001
@@ -114,6 +123,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "Group",
     "color": "#0d9488",
     "shape": "circle",
+    "layer": "identity",
     "icon": "circle",
     "category_uid": 3,
     "class_uid": 3001
@@ -122,6 +132,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "Misconfiguration",
     "color": "#f97316",
     "shape": "triangle",
+    "layer": "finding",
     "icon": "triangle",
     "category_uid": 2,
     "class_uid": 2003
@@ -130,6 +141,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "Model",
     "color": "#8b5cf6",
     "shape": "square",
+    "layer": "asset",
     "icon": "square",
     "category_uid": 5,
     "class_uid": 4001
@@ -138,6 +150,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "Package",
     "color": "#52525b",
     "shape": "square",
+    "layer": "package",
     "icon": "square",
     "category_uid": 5,
     "class_uid": 4001
@@ -146,6 +159,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "Provider",
     "color": "#d1d5db",
     "shape": "square",
+    "layer": "infra",
     "icon": "square",
     "category_uid": 0,
     "class_uid": 0
@@ -154,6 +168,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "MCP Server",
     "color": "#3b82f6",
     "shape": "circle",
+    "layer": "mcp_server",
     "icon": "circle",
     "category_uid": 5,
     "class_uid": 4001
@@ -162,6 +177,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "Service Account",
     "color": "#0f766e",
     "shape": "circle",
+    "layer": "identity",
     "icon": "circle",
     "category_uid": 3,
     "class_uid": 3001
@@ -170,6 +186,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "Tool",
     "color": "#a855f7",
     "shape": "diamond",
+    "layer": "tool",
     "icon": "diamond",
     "category_uid": 5,
     "class_uid": 4001
@@ -178,6 +195,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "User",
     "color": "#14b8a6",
     "shape": "circle",
+    "layer": "user",
     "icon": "circle",
     "category_uid": 3,
     "class_uid": 3001
@@ -186,6 +204,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "label": "Vulnerability",
     "color": "#ef4444",
     "shape": "triangle",
+    "layer": "finding",
     "icon": "triangle",
     "category_uid": 2,
     "class_uid": 2001

--- a/ui/lib/graph-utils.ts
+++ b/ui/lib/graph-utils.ts
@@ -79,6 +79,7 @@ export const EDGE_COLORS = {
 export interface LegendItem {
   label: string;
   color: string;
+  layer?: string | undefined;
   dashed?: boolean | undefined;
   kind?: "node" | "edge" | undefined;
   lineStyle?: "solid" | "dashed" | undefined;
@@ -108,25 +109,25 @@ const NODE_TYPE_LEGEND_ORDER: LineageNodeType[] = [
 ];
 
 const NODE_TYPE_LEGEND_ITEMS: Record<LineageNodeType, LegendItem> = {
-  provider: { label: "Provider", color: "#71717a", kind: "node", shape: "dot" },
-  agent: { label: "Agent", color: "#10b981", kind: "node", shape: "dot" },
-  sharedServer: { label: "Shared", color: "#22d3ee", kind: "node", shape: "square" },
-  server: { label: "Server", color: "#3b82f6", kind: "node", shape: "square" },
-  package: { label: "Package", color: "#52525b", kind: "node", shape: "pill" },
-  model: { label: "Model", color: "#8b5cf6", kind: "node", shape: "pill" },
-  dataset: { label: "Dataset", color: "#06b6d4", kind: "node", shape: "pill" },
-  container: { label: "Container", color: "#6366f1", kind: "node", shape: "square" },
-  cloudResource: { label: "Cloud", color: "#0ea5e9", kind: "node", shape: "square" },
-  environment: { label: "Env", color: "#14b8a6", kind: "node", shape: "square" },
-  fleet: { label: "Fleet", color: "#22d3ee", kind: "node", shape: "square" },
-  cluster: { label: "Cluster", color: "#38bdf8", kind: "node", shape: "square" },
-  user: { label: "User", color: "#34d399", kind: "node", shape: "dot" },
-  group: { label: "Group", color: "#d946ef", kind: "node", shape: "pill" },
-  serviceAccount: { label: "Svc", color: "#fbbf24", kind: "node", shape: "dot" },
-  vulnerability: { label: "Vuln", color: "#ef4444", kind: "node", shape: "diamond" },
-  misconfiguration: { label: "Config", color: "#f97316", kind: "node", shape: "diamond" },
-  credential: { label: "Cred", color: "#f59e0b", kind: "node", shape: "dot" },
-  tool: { label: "Tool", color: "#a855f7", kind: "node", shape: "pill" },
+  provider: { label: "Provider", color: "#71717a", layer: "infra", kind: "node", shape: "dot" },
+  agent: { label: "Agent", color: "#10b981", layer: "orchestration", kind: "node", shape: "dot" },
+  sharedServer: { label: "Shared", color: "#22d3ee", layer: "mcp_server", kind: "node", shape: "square" },
+  server: { label: "Server", color: "#3b82f6", layer: "mcp_server", kind: "node", shape: "square" },
+  package: { label: "Package", color: "#52525b", layer: "package", kind: "node", shape: "pill" },
+  model: { label: "Model", color: "#8b5cf6", layer: "asset", kind: "node", shape: "pill" },
+  dataset: { label: "Dataset", color: "#06b6d4", layer: "asset", kind: "node", shape: "pill" },
+  container: { label: "Container", color: "#6366f1", layer: "infra", kind: "node", shape: "square" },
+  cloudResource: { label: "Cloud", color: "#0ea5e9", layer: "infra", kind: "node", shape: "square" },
+  environment: { label: "Env", color: "#14b8a6", layer: "infra", kind: "node", shape: "square" },
+  fleet: { label: "Fleet", color: "#22d3ee", layer: "infra", kind: "node", shape: "square" },
+  cluster: { label: "Cluster", color: "#38bdf8", layer: "infra", kind: "node", shape: "square" },
+  user: { label: "User", color: "#34d399", layer: "user", kind: "node", shape: "dot" },
+  group: { label: "Group", color: "#d946ef", layer: "identity", kind: "node", shape: "pill" },
+  serviceAccount: { label: "Svc", color: "#fbbf24", layer: "identity", kind: "node", shape: "dot" },
+  vulnerability: { label: "Vuln", color: "#ef4444", layer: "finding", kind: "node", shape: "diamond" },
+  misconfiguration: { label: "Config", color: "#f97316", layer: "finding", kind: "node", shape: "diamond" },
+  credential: { label: "Cred", color: "#f59e0b", layer: "identity", kind: "node", shape: "dot" },
+  tool: { label: "Tool", color: "#a855f7", layer: "tool", kind: "node", shape: "pill" },
 };
 
 const RELATIONSHIP_LEGEND_ORDER = [

--- a/ui/lib/unified-graph-flow.ts
+++ b/ui/lib/unified-graph-flow.ts
@@ -133,6 +133,28 @@ const NODE_COLORS: Record<LineageNodeType, string> = {
   misconfiguration: "#f97316",
 };
 
+const NODE_LAYERS: Record<LineageNodeType, string> = {
+  provider: "infra",
+  agent: "orchestration",
+  user: "user",
+  group: "identity",
+  serviceAccount: "identity",
+  environment: "infra",
+  fleet: "infra",
+  cluster: "infra",
+  server: "mcp_server",
+  sharedServer: "mcp_server",
+  package: "package",
+  vulnerability: "finding",
+  credential: "identity",
+  tool: "tool",
+  model: "asset",
+  dataset: "asset",
+  container: "infra",
+  cloudResource: "infra",
+  misconfiguration: "finding",
+};
+
 const FINDING_NODE_TYPES = new Set<LineageNodeType>(["vulnerability", "misconfiguration"]);
 const RUNTIME_RELATIONSHIPS = new Set<string>([
   RelationshipType.INVOKED,
@@ -475,6 +497,7 @@ function legendForNodeTypes(nodeTypes: Set<LineageNodeType>): LegendItem[] {
     .map((nodeType) => ({
       label: NODE_LABELS[nodeType],
       color: NODE_COLORS[nodeType],
+      layer: NODE_LAYERS[nodeType],
       shape: legendShapeForNodeType(nodeType),
     }));
 }

--- a/ui/scripts/codegen-graph-schema.mjs
+++ b/ui/scripts/codegen-graph-schema.mjs
@@ -102,6 +102,7 @@ function render(schema) {
           label: n.label,
           color: n.color,
           shape: n.shape,
+          layer: n.layer,
           icon: n.icon,
           category_uid: n.category_uid,
           class_uid: n.class_uid,
@@ -152,6 +153,7 @@ export interface GraphNodeKindMeta {
   label: string;
   color: string;
   shape: string;
+  layer: string;
   icon: string;
   category_uid: number;
   class_uid: number;

--- a/ui/tests/graph-chrome.test.tsx
+++ b/ui/tests/graph-chrome.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { GraphLegend } from "@/components/graph-chrome";
+
+describe("GraphLegend", () => {
+  it("groups entity legend rows by semantic layer and keeps relationships separate", () => {
+    render(
+      <GraphLegend
+        embedded
+        items={[
+          { label: "Agent", color: "#10b981", layer: "orchestration", kind: "node", shape: "dot" },
+          { label: "MCP Server", color: "#3b82f6", layer: "mcp_server", kind: "node", shape: "square" },
+          { label: "Package", color: "#52525b", layer: "package", kind: "node", shape: "pill" },
+          { label: "Vulnerability", color: "#ef4444", layer: "finding", kind: "node", shape: "diamond" },
+          { label: "Uses", color: "#10b981", kind: "edge", lineStyle: "solid" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Orchestration")).toBeInTheDocument();
+    expect(screen.getByText("MCP Servers")).toBeInTheDocument();
+    expect(screen.getByText("Packages")).toBeInTheDocument();
+    expect(screen.getByText("Findings")).toBeInTheDocument();
+    expect(screen.getByText("Relationships")).toBeInTheDocument();
+    expect(screen.getByText("Uses")).toBeInTheDocument();
+  });
+});

--- a/ui/tests/graph-layer-semantics.test.ts
+++ b/ui/tests/graph-layer-semantics.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { GraphNodeKind, GRAPH_NODE_KIND_META } from "@/lib/graph-schema";
+
+describe("graph semantic layers", () => {
+  it("maps core security graph entities to operator-facing AI system layers", () => {
+    expect(GRAPH_NODE_KIND_META[GraphNodeKind.USER].layer).toBe("user");
+    expect(GRAPH_NODE_KIND_META[GraphNodeKind.GROUP].layer).toBe("identity");
+    expect(GRAPH_NODE_KIND_META[GraphNodeKind.SERVICE_ACCOUNT].layer).toBe("identity");
+    expect(GRAPH_NODE_KIND_META[GraphNodeKind.CREDENTIAL].layer).toBe("identity");
+    expect(GRAPH_NODE_KIND_META[GraphNodeKind.AGENT].layer).toBe("orchestration");
+    expect(GRAPH_NODE_KIND_META[GraphNodeKind.SERVER].layer).toBe("mcp_server");
+    expect(GRAPH_NODE_KIND_META[GraphNodeKind.TOOL].layer).toBe("tool");
+    expect(GRAPH_NODE_KIND_META[GraphNodeKind.PACKAGE].layer).toBe("package");
+    expect(GRAPH_NODE_KIND_META[GraphNodeKind.MODEL].layer).toBe("asset");
+    expect(GRAPH_NODE_KIND_META[GraphNodeKind.DATASET].layer).toBe("asset");
+    expect(GRAPH_NODE_KIND_META[GraphNodeKind.CONTAINER].layer).toBe("infra");
+    expect(GRAPH_NODE_KIND_META[GraphNodeKind.CLOUD_RESOURCE].layer).toBe("infra");
+    expect(GRAPH_NODE_KIND_META[GraphNodeKind.VULNERABILITY].layer).toBe("finding");
+    expect(GRAPH_NODE_KIND_META[GraphNodeKind.MISCONFIGURATION].layer).toBe("finding");
+  });
+});

--- a/ui/tests/graph-schema-color-invariant.test.ts
+++ b/ui/tests/graph-schema-color-invariant.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { RELATIONSHIP_COLOR_MAP, RelationshipType } from "@/lib/graph-schema";
+import { GRAPH_NODE_KIND_META, RELATIONSHIP_COLOR_MAP, RelationshipType } from "@/lib/graph-schema";
 
 describe("RELATIONSHIP_COLOR_MAP", () => {
   it("has a color for every RelationshipType", () => {
@@ -29,6 +29,18 @@ describe("RELATIONSHIP_COLOR_MAP", () => {
     for (const [key, color] of Object.entries(RELATIONSHIP_COLOR_MAP)) {
       if (!/^#[0-9a-fA-F]{3,8}$/.test(color)) {
         bad.push(`${key}=${color}`);
+      }
+    }
+    expect(bad).toEqual([]);
+  });
+});
+
+describe("GRAPH_NODE_KIND_META", () => {
+  it("has label, color, shape, and semantic layer for every node kind", () => {
+    const bad: string[] = [];
+    for (const [key, meta] of Object.entries(GRAPH_NODE_KIND_META)) {
+      if (!meta.label || !meta.shape || !meta.layer || !/^#[0-9a-fA-F]{3,8}$/.test(meta.color)) {
+        bad.push(key);
       }
     }
     expect(bad).toEqual([]);


### PR DESCRIPTION
## Summary

Adds semantic AI-system layer metadata to the graph taxonomy and uses it to make the graph legend read like a security product surface instead of a flat entity list.

- adds `GraphSemanticLayer` with reserved layers for user, identity, app, API/gateway, orchestration, MCP server, tool, package, runtime evidence, asset, infra, and finding
- annotates every current `EntityType` legend entry with a semantic layer
- exposes `semantic_layers[]` and per-node-kind `layer` from `/v1/graph/schema`
- exposes entity `layer` from `/v1/graph/legend`
- regenerates `ui/lib/graph-schema.generated.ts` with `GraphNodeKindMeta.layer`
- groups visible graph legend rows by semantic layer while keeping relationships separate
- adds backend and UI tests for layer coverage, generated schema metadata, and legend grouping

## Why this matters

This is the low-risk foundation for the Wiz/Orca/CrowdStrike-style graph direction: operators should understand whether a node is identity, orchestration, MCP server, package, runtime evidence, infra, or finding before they interpret individual node types. No new emitted node kinds or storage changes in this PR.

## Validation

- `uv run pytest tests/test_graph_schema.py::TestGraphSchemaEndpoint tests/test_graph_wave1.py::TestLegends -q` -> 10 passed
- `uv run pytest tests/test_graph_schema.py tests/test_graph_wave1.py -q` -> 104 passed
- `uv run ruff check src/agent_bom/graph/types.py src/agent_bom/graph/container.py src/agent_bom/api/routes/graph.py tests/test_graph_schema.py tests/test_graph_wave1.py` -> passed
- `AGENT_BOM_GRAPH_SCHEMA_URL=http://127.0.0.1:8423/v1/graph/schema npm run codegen:graph-schema:check` -> passed against local API
- `npm run test:run -- graph-layer-semantics graph-chrome graph-schema-color-invariant` -> 3 files / 5 tests passed
- `npm run test:run` -> 26 files / 177 tests passed
- `npm run typecheck` -> passed
- `npm run lint` -> passed
- `git diff --check` -> passed
