### PR TITLE
fix(security): align runtime audit persistence with evidence tiers

### DIFF
--- a/src/agent_bom/api/routes/gateway.py
+++ b/src/agent_bom/api/routes/gateway.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from agent_bom.api.policy_store import GatewayPolicy
 
 router = APIRouter()
+_REPLAY_ONLY_ARGUMENT_VALUE = "[replay-only]"
 
 
 def _dep(permission: str) -> Any:
@@ -41,6 +42,28 @@ def _policy_collection_etag(policies: list["GatewayPolicy"]) -> str:
     payload = json.dumps([p.model_dump() for p in policies], sort_keys=True, separators=(",", ":"))
     digest = hashlib.sha256(payload.encode()).hexdigest()
     return f'"{digest}"'
+
+
+def _build_arguments_preview(arguments: dict[str, Any]) -> dict[str, Any]:
+    """Build a bounded tier-A preview of gateway arguments."""
+    from agent_bom.evidence import EvidenceTier, classify_field, redact_for_persistence
+    from agent_bom.security import sanitize_sensitive_payload
+
+    sanitized = sanitize_sensitive_payload(arguments)
+    if not isinstance(sanitized, dict):
+        return {}
+
+    preview: dict[str, Any] = {}
+    for key, value in list(sanitized.items())[:32]:
+        key_text = str(key)
+        if classify_field(key_text) is not EvidenceTier.SAFE_TO_STORE:
+            preview[key_text] = _REPLAY_ONLY_ARGUMENT_VALUE
+            continue
+        safe_value = redact_for_persistence({key_text: value}, EvidenceTier.SAFE_TO_STORE).get(key_text)
+        if isinstance(safe_value, str) and len(safe_value) > 256:
+            safe_value = safe_value[:256] + "…"
+        preview[key_text] = safe_value
+    return preview
 
 
 @router.get("/v1/gateway/policies", tags=["gateway"], dependencies=[_dep("policy_read")])
@@ -208,7 +231,6 @@ async def evaluate_gateway(body: EvaluateRequest, request: Request):
 
     from agent_bom.api.policy_store import PolicyAuditEntry
     from agent_bom.gateway import evaluate_gateway_policies_detail
-    from agent_bom.security import sanitize_sensitive_payload
 
     tenant_id = getattr(request.state, "tenant_id", "default")
     store = _get_policy_store()
@@ -237,17 +259,9 @@ async def evaluate_gateway(body: EvaluateRequest, request: Request):
         action_taken = "blocked"
         log_reason = reason
 
-    # Build a redacted arguments preview — never store full secret material in
-    # the audit row. Keys are kept; values are truncated and have credentials
-    # masked by the existing sanitizer.
-    sanitized_args = sanitize_sensitive_payload(body.arguments)
-    args_preview: dict[str, Any] = sanitized_args if isinstance(sanitized_args, dict) else {}
-    if len(args_preview) > 32:
-        # cap to keep audit-row size bounded
-        args_preview = dict(list(args_preview.items())[:32])
-    for k, v in list(args_preview.items()):
-        if isinstance(v, str) and len(v) > 256:
-            args_preview[k] = v[:256] + "…"
+    # Keep argument names for incident reconstruction, but only persist values
+    # that the two-bucket evidence policy marks safe to store indefinitely.
+    args_preview = _build_arguments_preview(body.arguments)
 
     request_id = getattr(request.state, "request_id", "") or ""
     trace_id = getattr(request.state, "trace_id", "") or ""

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 from agent_bom.api.models import ProxyAuditIngestRequest
 from agent_bom.api.stores import _get_idempotency_store
+from agent_bom.evidence import EvidenceTier, redact_for_persistence
 from agent_bom.security import sanitize_sensitive_payload
 
 router = APIRouter()
@@ -100,21 +101,24 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         except Exception:  # noqa: BLE001 — store is best-effort, never block ingest
             pass
         analytics_events.append(
-            {
-                "event_id": enriched.get("event_id", ""),
-                "event_timestamp": enriched.get("timestamp") or enriched.get("ts"),
-                "tenant_id": tenant_id,
-                "event_type": enriched.get("event_type", enriched.get("type", "runtime_alert")),
-                "detector": enriched.get("detector", ""),
-                "severity": enriched.get("severity", "INFO"),
-                "tool_name": enriched.get("tool_name", enriched.get("tool", "")),
-                "message": enriched.get("message", ""),
-                "agent_name": enriched.get("agent_name", ""),
-                "session_id": enriched.get("session_id", ""),
-                "trace_id": enriched.get("trace_id", ""),
-                "request_id": enriched.get("request_id", ""),
-                "source_id": enriched.get("source_id", ""),
-            }
+            redact_for_persistence(
+                {
+                    "event_id": enriched.get("event_id", ""),
+                    "event_timestamp": enriched.get("timestamp") or enriched.get("ts"),
+                    "tenant_id": tenant_id,
+                    "event_type": enriched.get("event_type", enriched.get("type", "runtime_alert")),
+                    "detector": enriched.get("detector", ""),
+                    "severity": enriched.get("severity", "INFO"),
+                    "tool_name": enriched.get("tool_name", enriched.get("tool", "")),
+                    "message": enriched.get("message", ""),
+                    "agent_name": enriched.get("agent_name", ""),
+                    "session_id": enriched.get("session_id", ""),
+                    "trace_id": enriched.get("trace_id", ""),
+                    "request_id": enriched.get("request_id", ""),
+                    "source_id": enriched.get("source_id", ""),
+                },
+                EvidenceTier.SAFE_TO_STORE,
+            )
         )
 
     if body.summary:

--- a/src/agent_bom/evidence/policy.py
+++ b/src/agent_bom/evidence/policy.py
@@ -59,6 +59,9 @@ TIER_A_FIELDS: frozenset[str] = frozenset(
         "scope",
         "scopes",
         "command_name",
+        "event_id",
+        "event_type",
+        "event_timestamp",
         # Host / network identifiers
         "hostname",
         "host",
@@ -69,6 +72,8 @@ TIER_A_FIELDS: frozenset[str] = frozenset(
         # Identity / agent identifiers
         "client_id",
         "agent_id",
+        "agent_name",
+        "source_id",
         "tenant_id",
         "session_id",
         "actor_id",

--- a/tests/test_api_proxy_scorecard.py
+++ b/tests/test_api_proxy_scorecard.py
@@ -284,7 +284,15 @@ async def test_proxy_audit_ingest_records_analytics_with_session_trace_context(m
     payload = ProxyAuditIngestRequest(
         source_id="laptop-1",
         session_id="sess-1",
-        alerts=[{"type": "runtime_alert", "detector": "credential_leak", "severity": "critical", "message": "AWS key"}],
+        alerts=[
+            {
+                "type": "runtime_alert",
+                "detector": "credential_leak",
+                "severity": "critical",
+                "message": "AWS key copied from /Users/alice/prod",
+                "details": {"prompt": "raw user prompt", "url": "https://example.com?token=secret"},
+            }
+        ],
     )
     resp = await proxy_mod.ingest_proxy_audit(request, payload)
     assert resp["ingested"] is True
@@ -293,6 +301,8 @@ async def test_proxy_audit_ingest_records_analytics_with_session_trace_context(m
     assert analytics.events[0]["source_id"] == "laptop-1"
     assert analytics.events[0]["request_id"] == "req-1"
     assert analytics.events[0]["trace_id"] == "0123456789abcdef0123456789abcdef"
+    assert "message" not in analytics.events[0]
+    assert "details" not in analytics.events[0]
 
     proxy_mod._proxy_alerts.clear()
     proxy_mod._proxy_metrics = None

--- a/tests/test_gateway_audit.py
+++ b/tests/test_gateway_audit.py
@@ -101,7 +101,7 @@ def test_evaluate_block_writes_audit_entry() -> None:
     assert entry["tool_name"] == "shell.exec"
     assert entry["action_taken"] == "blocked"
     assert "shell.exec" in entry["reason"]
-    assert entry["arguments_preview"] == {"cmd": "ls"}
+    assert entry["arguments_preview"] == {"cmd": "[replay-only]"}
     assert entry["timestamp"]
     assert entry["tenant_id"] == "default"
 
@@ -185,10 +185,11 @@ def test_evaluate_redacts_oversized_argument_values() -> None:
         json={
             "agent_name": "agent-a",
             "tool_name": "shell.exec",
-            "arguments": {"payload": long_value},
+            "arguments": {"command_name": long_value, "path": "/Users/alice/prod/secrets.txt"},
         },
     )
     entry = client.get("/v1/gateway/audit").json()["entries"][0]
-    preview = entry["arguments_preview"]["payload"]
+    preview = entry["arguments_preview"]["command_name"]
     assert len(preview) <= 257  # 256 chars + ellipsis
     assert preview.endswith("…")
+    assert entry["arguments_preview"]["path"] == "[replay-only]"


### PR DESCRIPTION
## Summary

Tightens durable runtime/gateway audit persistence to honor the two-bucket evidence policy.

- proxy audit analytics now runs through `redact_for_persistence(... SAFE_TO_STORE)`
- raw alert `message` and nested `details` no longer land in durable analytics
- extends tier-A whitelist with operational IDs needed for audit correlation: `event_id`, `event_type`, `event_timestamp`, `agent_name`, `source_id`
- gateway policy audit previews keep argument names but replace replay-only values (`cmd`, `path`, URL, prompts, raw bodies, unknown fields) with `[replay-only]`
- safe argument values still cap at 256 chars and previews are bounded to 32 keys

## Why this matters

Reddit feedback / product direction: safe-to-store evidence must stay useful without becoming a secret store. Durable audit should retain identity, status, timing, trace IDs, tool names, and field names; raw prompts, paths, URLs, command args, bodies, and workspace content belong only in short-TTL replay.

## Validation

- `uv run pytest tests/test_gateway_audit.py tests/test_api_proxy_scorecard.py tests/test_evidence_policy.py -q` -> 52 passed
- `uv run pytest tests/test_proxy.py tests/test_proxy_policy.py tests/test_proxy_cov.py tests/test_compliance.py::test_posture_has_proxy_flips_on_proxy_alert_ingest -q` -> 164 passed
- `uv run ruff check src/agent_bom/api/routes/proxy.py src/agent_bom/api/routes/gateway.py src/agent_bom/evidence/policy.py tests/test_gateway_audit.py tests/test_api_proxy_scorecard.py` -> passed
- pre-commit -> ruff, ruff-format, mypy, bandit, env-var drift passed
