### PR TITLE
docs(graph): add security graph UX rubric

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,4 +18,11 @@ Canonical docs here:
 - `SUPPLY_CHAIN.md`
 - `THREAT_MODEL.md`
 
+Graph docs:
+
+- `graph/CONTRACT.md` — graph coverage, accuracy guarantees, scaling
+  boundaries, non-promises, and known gaps
+- `graph/SECURITY_GRAPH_UX_RUBRIC.md` — review rubric for
+  Wiz/Orca/CrowdStrike-style graph usability and actionability
+
 Archived or historical writeups live under [`docs/archive`](archive/README.md).

--- a/docs/SECURITY_AUTH_TENANCY_AUDIT.md
+++ b/docs/SECURITY_AUTH_TENANCY_AUDIT.md
@@ -1,7 +1,8 @@
 # Security, Auth, and Tenancy Audit
 
-> **Snapshot:** fresh pass over `main` as of 2026-04-20, after #1555–#1566
-> landed. Every rating below has a file reference — grep to verify. This
+> **Snapshot:** refreshed on 2026-05-05 after the gateway/proxy runtime,
+> visual-leak, graph-quality, and evidence-retention work landed. Every
+> rating below has a file reference — grep to verify. This
 > doc answers: "are SSO / SAML / OAuth / OIDC / multi-tenancy /
 > isolation / RBAC / least-priv / zero-trust / defense-in-depth /
 > non-repudiation / CIA / input sanitization / KMS / key rotation /
@@ -54,11 +55,21 @@ Every PR below reviewed against the on-disk code, not just the PR description. V
 - Impact: a pilot team's dashboard login goes through OIDC / SAML (their IdP enforces MFA) — so MFA is effectively present *via the IdP*. But there's no in-product MFA for API-key auth.
 - **Fix proposal:** documented today = OIDC + SAML users inherit the IdP's MFA; API keys stay machine-to-machine (operator is expected to protect API-key storage). File a docs-only issue to make this explicit in the `SECURITY_ARCHITECTURE.md`.
 
-### P1 — Screenshot / visual-capture sensitive data detection — *doesn't exist yet* (real feature gap)
+### Closed — Screenshot / visual-capture sensitive data detection now exists
 
-- `grep -rln "screenshot\|screen_capture" src/agent_bom/` returns only `parsers/skill_audit.py` (as a permission class check, not content analysis).
-- The gap you flagged: MCPs / agents that take screenshots can capture credentials, PII, customer data, internal URLs — agent-bom doesn't inspect or redact that content today.
-- **Filed as a new feature:** see issue link in the companion PR. Design sketch below in §Appendix.
+- `src/agent_bom/runtime/visual_leak_detector.py` implements the optional OCR
+  detector and redaction path for image-bearing tool responses.
+- `src/agent_bom/proxy.py` wires `--detect-visual-leaks` for proxy runtime
+  enforcement.
+- `src/agent_bom/gateway_server.py` wires visual-leak health, readiness, check,
+  and redact behavior for gateway responses.
+- `src/agent_bom/proxy_policy.py` classifies screenshot/screen-capture tool
+  names so policy can block that capability class before an upstream call.
+- `tests/test_visual_leak_detector.py` covers the visual channel.
+
+Remaining operator note: the feature is opt-in because OCR requires the
+`agent-bom[visual]` extra and a Tesseract binary on `PATH`. That is the right
+default for local-first scanning and lightweight gateway deployments.
 
 ### P2 — Password-based auth on upstream config should be explicitly banned
 
@@ -79,28 +90,30 @@ Every PR below reviewed against the on-disk code, not just the PR description. V
 - `src/agent_bom/graph/` + `context_graph.py` total ~2,850 LOC across 10 focused modules — code is good, but there's no "how this scales" doc (cardinality at 50k packages, memory growth).
 - **Fix:** extend `docs/PERFORMANCE_BENCHMARKS.md` with a graph-specific section. Small add, filed as companion issue.
 
-## Appendix: screenshot sensitive-data detection — design sketch
+## Appendix: screenshot sensitive-data detection — implemented shape
 
 **Why it matters:** any MCP that wraps a browser / screen-capture tool (Playwright-MCP, Puppeteer-MCP, plus Cursor/Claude running screen-read tools) can exfiltrate secrets, PII, and internal data through pixels that never hit the existing text-content detectors.
 
 **Where it slots into the existing architecture** (no new service):
 
-1. **Detector module** — `src/agent_bom/runtime/visual_leak_detector.py` (new) following the existing pattern of `CredentialLeakDetector` in [`runtime/detectors.py`](../src/agent_bom/runtime/detectors.py). Takes a tool response that contains an image (MCP protocol uses `content: [{"type": "image", "data": "<base64>"}]`).
-2. **OCR + pattern match** — run the image through `pytesseract` (optional dep) → feed extracted text into the same `CREDENTIAL_PATTERNS` + `_PII_PATTERNS` that already guard text responses.
-3. **Redact-in-place** — replace pixel regions matching the OCR boxes with a black rectangle before the response is forwarded to the agent. Return an `Alert(detector="visual_leak", severity=CRITICAL|HIGH)`.
-4. **Policy rule** — new `block_screen_captures: true` gateway rule that refuses `tools/call` on tools whose `class` is `screen_capture` entirely. Policy engine in [`proxy_policy.py`](../src/agent_bom/proxy_policy.py) already has the capability-class dispatch; add `screen_capture` to the tool classifier in [`runtime/detectors.py _classify_tool_classes`](../src/agent_bom/runtime/detectors.py).
-5. **Audit trail** — visual-leak hits land in the same HMAC-chained audit log as text-leak hits; `record_gateway_relay(upstream, "blocked")` and an `action: gateway.visual_leak_blocked` audit event.
-
-**Ship path:** new dep `agent-bom[visual]` that pulls `pytesseract` + `Pillow`, opt-in because OCR is CPU-heavy. Sidecar + gateway both call the detector when they receive an image-bearing tool response. CI tests use a synthetic PNG rendered with the PIL `ImageDraw` drawing of fake API keys + real redaction assertion.
-
-File size estimate: ~300 LOC core + 150 LOC tests.
+1. **Detector module** — [`runtime/visual_leak_detector.py`](../src/agent_bom/runtime/visual_leak_detector.py) follows the existing runtime-detector pattern and accepts image-bearing MCP content blocks.
+2. **OCR + pattern match** — when `agent-bom[visual]` and Tesseract are
+   available, the detector extracts text and applies credential/PII patterns to
+   the visual channel.
+3. **Redact-in-place** — matching image regions are redacted before the
+   response is forwarded.
+4. **Policy boundary** — [`proxy_policy.py`](../src/agent_bom/proxy_policy.py)
+   classifies screenshot and screen-capture tools so operators can block the
+   tool class at the gateway/proxy boundary.
+5. **Audit trail** — visual-leak alerts flow through the same runtime audit
+   path as text detector alerts, with the durable evidence-retention policy
+   keeping replay-only payloads out of long-lived analytics.
 
 ## What I recommend next (queued)
 
 1. Close out this audit with doc merge + follow-up issues filed (done in this PR).
-2. Ship the screenshot-redaction feature as a scoped PR (~1 day of focused work).
-3. Add the graph-scalability benchmark entry to `PERFORMANCE_BENCHMARKS.md` (~1 hour).
-4. Resume #1522 phases 2–4 for the remaining monoliths (though most landed in #1561, #1564, #1565, #1566 — only `cli/agents/__init__.py` remains large).
+2. Add the graph-scalability benchmark entry to `PERFORMANCE_BENCHMARKS.md` (~1 hour).
+3. Resume #1522 phases 2–4 for the remaining monoliths (though most landed in #1561, #1564, #1565, #1566 — only `cli/agents/__init__.py` remains large).
 
 ## How I verified every claim
 
@@ -111,5 +124,5 @@ grep -rn "def require_\|def _authorize" src/agent_bom/rbac.py
 grep -rn "rotation_policy\|def rotate_key" src/agent_bom/api/routes/
 grep -rn "tenant_id" src/agent_bom/api/postgres/ src/agent_bom/api/snowflake_store.py
 grep -rn "SSE-KMS\|kmsKeyId\|Ed25519" deploy/helm/agent-bom/ src/agent_bom/api/
-grep -rn "screenshot\|screen_capture" src/agent_bom/  # single match = gap
+grep -rn "screenshot\|screen_capture\|visual_leak" src/agent_bom/
 ```

--- a/docs/graph/SECURITY_GRAPH_UX_RUBRIC.md
+++ b/docs/graph/SECURITY_GRAPH_UX_RUBRIC.md
@@ -1,0 +1,104 @@
+# Security Graph UX Rubric
+
+This rubric turns the product direction for `agent-bom` into a reviewable
+standard. Use it when changing `/graph`, `/security-graph`, `/mesh`,
+graph APIs, screenshots, or graph documentation.
+
+The target is a security-operator graph, not a generic node canvas. It should
+feel closer to the investigation workflows in products such as Wiz, Orca, and
+CrowdStrike: start with what to fix, explain why it matters, show the path to
+the impacted asset, and let the operator expand context only when needed.
+
+## North Star
+
+The graph should answer six questions without requiring the user to manually
+decode a dense canvas:
+
+1. What risky thing exists?
+2. Which agent, user, service account, or workflow can trigger it?
+3. Which MCP server, tool, package, model, dataset, or infrastructure layer is
+   on the path?
+4. What asset, credential, endpoint, tenant, or environment can it reach?
+5. Was the path observed at runtime, statically inferred, or both?
+6. What should be blocked, patched, isolated, monitored, or reviewed first?
+
+## Product Maturity Targets
+
+| Target | Minimum bar | Best-in-class bar |
+|---|---|---|
+| Default view | Opens below the operator's cognitive limit with clustering, focus, and search. | Opens on a fix-first queue with the most actionable path selected and the graph scoped around it. |
+| Prioritisation | Severity is visible on nodes and findings. | Effective reach combines vulnerability severity, exploitability, known exploitation, tool capability, credential visibility, runtime evidence, agent breadth, and asset criticality. |
+| Path readability | Edges have labels and the legend explains node types. | Paths are sentence-readable: vulnerable package -> MCP server -> tool -> agent/user -> credential/asset, with each hop's evidence tier visible. |
+| Scale | Large snapshots use pagination, LOD, aggregation, and filters. | Large tenants navigate by saved scope, entity search, ranked attack paths, and expansion from one selected path rather than whole-tenant rendering. |
+| Evidence | Node detail shows source metadata. | Every claim is marked as static scan, gateway/proxy runtime, imported evidence, or replay-only evidence, with retention tier shown. |
+| Remediation | Findings link to generic fix guidance. | The UI shows the lowest-cost choke point: patch package, disable tool, rotate credential, narrow scope, block gateway rule, or isolate asset. |
+| Safety | Redaction exists in backend policies. | Durable views only show safe-to-store evidence; replay-only fields are named but not persisted or displayed raw. |
+
+## Required Graph Layers
+
+Treat these as semantic layers even when the underlying code represents them
+with existing entity types.
+
+| Layer | Examples | Why it matters |
+|---|---|---|
+| User/application | human user, desktop app, IDE, CLI, API client, service account | Shows who or what can trigger the path. |
+| Gateway/runtime boundary | API gateway, MCP gateway, proxy, policy decision, audit log, trace ID | Separates static possibility from runtime enforcement and observation. |
+| Orchestration | agent, LangChain/LangGraph/CrewAI/AutoGen/custom runtime, planner, router | Explains how prompts, tools, memory, and delegation are coordinated. |
+| RAG/data | vector DB, retriever, index, embedding model, source document, dataset | Shows sensitive context and data-flow reachability. |
+| MCP/tool | MCP server, tool schema, command class, filesystem scope, network scope | This is the core agent attack surface. |
+| Package/supply chain | package, transitive dependency, lockfile, container layer, malicious signal | Connects CVEs and provenance to exposed capability. |
+| Model/inference | model, adapter, inference server, model gateway, cache | Captures model serving risk and provenance. |
+| Infrastructure/asset | Kubernetes workload, host, GPU node, accelerator, cloud account, IAM role, endpoint, business asset | Shows what the agent path can actually impact. |
+| Finding/governance | CVE, misconfiguration, policy violation, compliance control, owner | Turns the path into a fix queue and audit trail. |
+
+## Interaction Rules
+
+- The first screen must not be a whole-tenant hairball. It should open on a
+  focused view, ranked path, or selected entity neighborhood.
+- Relationship labels should be verbs an operator can read aloud: `uses`,
+  `loads package`, `exposes tool`, `can reach`, `uses credential`, `invoked`,
+  `blocked by`, `observed in trace`, `owns`, `part of`.
+- Graph filters must reduce the visible graph and the available filter choices
+  together. Selecting `severity=critical` should not leave impossible agent,
+  layer, or relationship options active.
+- Cluster pills must preserve context. Never collapse a multi-parent child if
+  that would hide another path.
+- Hover focus is for inspection; pinned focus is for investigation. Hover must
+  not override a pinned node or selected attack path.
+- Node detail should always show stable ID, type, semantic layer, evidence
+  source, first/last seen where available, incoming/outgoing counts, and the
+  next action.
+
+## Review Checklist
+
+Every graph or graph-adjacent PR should answer:
+
+- Does the change make the default view more actionable or just add more
+  objects to the canvas?
+- Can an operator explain the selected path in one sentence?
+- Are static, runtime, imported, and replay-only evidence clearly separated?
+- Does the UI remain readable at the agent-bom self-scan size and at 1,000+
+  nodes through filtering, pagination, or aggregation?
+- Are backend enum/schema changes reflected in generated TypeScript and tests?
+- Are screenshots and docs updated only when they reflect the packaged Next.js
+  product, not an older prototype surface?
+
+## Immediate Enhancement Backlog
+
+1. **Fix-first graph cockpit.** Keep `/security-graph` centered on ranked
+   attack paths and remediation choke points, with the canvas scoped to the
+   selected path.
+2. **Semantic layer legend.** Group node types by layer so the legend reads
+   like an AI-system stack instead of a flat enum dump.
+3. **Runtime evidence overlay.** Distinguish static reachability, observed
+   invocation, blocked policy decision, replay-only trace, and safe-to-store
+   evidence.
+4. **Asset-criticality weighting.** Add environment, tenant, business asset,
+   and owner criticality to effective reach so the same CVE is ranked
+   differently in dev vs production.
+5. **Remediation choke-point cards.** For each path, suggest the cheapest
+   fix that breaks the most reachability: patch, disable tool, rotate
+   credential, narrow egress, enforce gateway policy, or isolate workload.
+6. **Screenshot refresh gate.** After graph UI changes land, refresh live
+   product screenshots from the packaged Next.js dashboard and avoid replacing
+   them with hand-built or stale prototype views.

--- a/site-docs/architecture/overview.md
+++ b/site-docs/architecture/overview.md
@@ -6,6 +6,9 @@ For the data-model contract between native `agent-bom` objects and optional OCSF
 
 For the end-to-end intake story across direct scans, read-only integrations, pushed ingest, and imported artifacts, see [Data Ingestion and Security](data-ingestion-and-security.md).
 
+For the operator model behind attack paths, reachability, runtime evidence, and
+large graph readability, see [Security Graph Model](security-graph-model.md).
+
 For the shortest operator-facing explanation of inputs, engine, outputs, deployment models, and product surfaces, see [How Agent-BOM Works](how-agent-bom-works.md).
 
 For the next-phase hosted product plan that maps UI actions to control-plane

--- a/site-docs/architecture/security-graph-model.md
+++ b/site-docs/architecture/security-graph-model.md
@@ -84,6 +84,9 @@ operator jobs:
    Let operators collapse many exposed paths with one change instead of chasing
    every finding separately.
 
+For the product and review rubric behind these jobs, see
+[`docs/graph/SECURITY_GRAPH_UX_RUBRIC.md`](https://github.com/msaad00/agent-bom/blob/main/docs/graph/SECURITY_GRAPH_UX_RUBRIC.md).
+
 ## Reading the graph in the UI
 
 The UI exposes three layers of interpretation:


### PR DESCRIPTION
## Summary

Adds a concrete review rubric for making the Agent-Bom graph feel like an operator-grade security graph instead of a generic node canvas.

- defines the north-star questions the graph must answer
- sets best-in-class targets for fix-first triage, reachability, scale, evidence, and remediation
- names semantic graph layers across users, gateways, orchestration, MCP/tools, packages, model/inference, infrastructure, assets, and governance
- links the rubric from the docs index and security graph model
- refreshes the stale security/auth audit section that still said visual leak detection did not exist, now pointing to the implemented detector/proxy/gateway wiring

## Validation

- `uv run python scripts/check_release_consistency.py` -> passed
- `git diff --check` -> passed
- pre-commit -> docs hooks passed