### PR TITLE
feat(graph): global attack path queue

### DIFF
--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -215,6 +215,15 @@ class GraphStoreProtocol(Protocol):
         source_ids: set[str],
     ) -> list[AttackPath]: ...
 
+    def attack_paths(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        offset: int = 0,
+        limit: int = 100,
+    ) -> tuple[str, str, list[AttackPath], int]: ...
+
     def node_context(
         self,
         *,
@@ -786,6 +795,58 @@ class SQLiteGraphStore:
                 )
                 for row in rows
             ]
+        finally:
+            conn.close()
+
+    def attack_paths(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        offset: int = 0,
+        limit: int = 100,
+    ) -> tuple[str, str, list[AttackPath], int]:
+        conn = self._open_ro_conn()
+        if conn is None:
+            return scan_id, "", [], 0
+        try:
+            effective_scan_id, created_at = sqlite_graph_store._resolve_snapshot(conn, tenant_id=tenant_id, scan_id=scan_id)
+            if not effective_scan_id:
+                return scan_id, "", [], 0
+            total = conn.execute(
+                "SELECT COUNT(*) FROM attack_paths WHERE tenant_id = ? AND scan_id = ?",
+                (tenant_id, effective_scan_id),
+            ).fetchone()[0]
+            rows = conn.execute(
+                """
+                SELECT source_node, target_node, path_nodes, path_edges, composite_risk,
+                       summary, credential_exposure, tool_exposure, vuln_ids
+                FROM attack_paths
+                WHERE tenant_id = ? AND scan_id = ?
+                ORDER BY composite_risk DESC, source_node ASC, target_node ASC
+                LIMIT ? OFFSET ?
+                """,
+                (tenant_id, effective_scan_id, limit, offset),
+            ).fetchall()
+            return (
+                effective_scan_id,
+                created_at,
+                [
+                    AttackPath(
+                        source=row["source_node"],
+                        target=row["target_node"],
+                        hops=json.loads(row["path_nodes"]),
+                        edges=json.loads(row["path_edges"]),
+                        composite_risk=row["composite_risk"],
+                        summary=row["summary"] or "",
+                        credential_exposure=json.loads(row["credential_exposure"]),
+                        tool_exposure=json.loads(row["tool_exposure"]),
+                        vuln_ids=json.loads(row["vuln_ids"]),
+                    )
+                    for row in rows
+                ],
+                int(total or 0),
+            )
         finally:
             conn.close()
 

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -814,6 +814,61 @@ class PostgresGraphStore:
             for row in rows
         ]
 
+    def attack_paths(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        offset: int = 0,
+        limit: int = 100,
+    ) -> tuple[str, str, list[Any], int]:
+        effective_scan_id = scan_id or self.latest_snapshot_id(tenant_id=tenant_id)
+        if not effective_scan_id:
+            return scan_id, "", [], 0
+
+        with _tenant_connection(self._pool) as conn:
+            snapshot_row = conn.execute(
+                "SELECT created_at FROM graph_snapshots WHERE tenant_id = %s AND scan_id = %s",
+                (tenant_id, effective_scan_id),
+            ).fetchone()
+            total_row = conn.execute(
+                "SELECT COUNT(*) FROM attack_paths WHERE tenant_id = %s AND scan_id = %s",
+                (tenant_id, effective_scan_id),
+            ).fetchone()
+            rows = conn.execute(
+                """
+                SELECT source_node, target_node, path_nodes, path_edges, composite_risk,
+                       summary, credential_exposure, tool_exposure, vuln_ids
+                FROM attack_paths
+                WHERE tenant_id = %s AND scan_id = %s
+                ORDER BY composite_risk DESC, source_node ASC, target_node ASC
+                LIMIT %s OFFSET %s
+                """,
+                (tenant_id, effective_scan_id, limit, offset),
+            ).fetchall()
+
+        from agent_bom.graph import AttackPath
+
+        return (
+            effective_scan_id,
+            str(snapshot_row[0]) if snapshot_row else "",
+            [
+                AttackPath(
+                    source=row[0],
+                    target=row[1],
+                    hops=json.loads(row[2]),
+                    edges=json.loads(row[3]),
+                    composite_risk=row[4],
+                    summary=row[5] or "",
+                    credential_exposure=json.loads(row[6]),
+                    tool_exposure=json.loads(row[7]),
+                    vuln_ids=json.loads(row[8]),
+                )
+                for row in rows
+            ],
+            int((total_row[0] if total_row else 0) or 0),
+        )
+
     def node_context(
         self,
         *,

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -3,6 +3,7 @@
 Endpoints:
   GET  /v1/graph                — load unified graph (filtered, paginated)
   GET  /v1/graph/diff           — diff between two scan snapshots
+  GET  /v1/graph/attack-paths   — global risk-sorted attack path queue
   GET  /v1/graph/paths          — attack paths from a source node
   GET  /v1/graph/impact         — blast radius of a node (reverse BFS)
   GET  /v1/graph/search         — full-text graph search
@@ -706,6 +707,53 @@ async def get_graph_diff(
 ) -> dict:
     """Diff two scan snapshots — nodes/edges added, removed, changed."""
     return await _graph_store_call(_get_graph_store_or_503().diff_snapshots, old, new, tenant_id=_tenant(request))
+
+
+@router.get("/v1/graph/attack-paths", tags=["graph"])
+async def get_graph_attack_paths(
+    request: Request,
+    scan_id: Optional[str] = Query(None, description="Scan ID"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+    limit: int = Query(100, ge=1, le=1000, description="Max attack paths"),
+) -> dict:
+    """Return the global attack-path queue independent of node pagination.
+
+    `/v1/graph` intentionally windows nodes and therefore cannot be the source
+    of truth for fix-first triage. This endpoint ranks persisted paths across
+    the whole snapshot and hydrates only the hop nodes needed to render the
+    selected queue page.
+    """
+    tenant = _tenant(request)
+    graph_store = _get_graph_store_or_503()
+    effective_scan_id, created_at, paths, total = await _graph_store_call(
+        graph_store.attack_paths,
+        scan_id=scan_id or "",
+        tenant_id=tenant,
+        offset=offset,
+        limit=limit,
+    )
+    hop_ids = {hop for path in paths for hop in path.hops}
+    nodes = await _graph_store_call(
+        graph_store.nodes_by_ids,
+        scan_id=effective_scan_id,
+        tenant_id=tenant,
+        node_ids=hop_ids,
+    )
+    return {
+        "scan_id": effective_scan_id,
+        "tenant_id": tenant,
+        "created_at": created_at,
+        "nodes": [node.to_dict() for node in nodes],
+        "edges": [],
+        "attack_paths": [path.to_dict() for path in paths],
+        "interaction_risks": [],
+        "stats": await _graph_store_call(
+            graph_store.snapshot_stats,
+            scan_id=effective_scan_id,
+            tenant_id=tenant,
+        ),
+        "pagination": _page_meta(total, offset, limit),
+    }
 
 
 @router.get("/v1/graph/paths", tags=["graph"])

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -414,6 +414,17 @@ class TestGraphEndpointLogic:
         assert attack_paths[0].summary == ""
         assert attack_paths[0].tool_exposure == []
 
+        effective_scan_id, created_at, global_paths, total = store.attack_paths(
+            tenant_id="default",
+            scan_id="attack-path-scan",
+            offset=0,
+            limit=10,
+        )
+        assert effective_scan_id == "attack-path-scan"
+        assert created_at
+        assert total == 1
+        assert global_paths[0].target == "vuln:cve"
+
     def test_sqlite_graph_store_attack_paths_round_trip_summary_and_tools(self, tmp_path):
         store = SQLiteGraphStore(tmp_path / "graph.db")
         graph = UnifiedGraph(scan_id="attack-path-fields", tenant_id="default")
@@ -779,6 +790,11 @@ class _RecordingGraphStore:
         self.calls.append(("attack_paths_for_sources", tenant_id, scan_id, tuple(sorted(source_ids))))
         return [ap for ap in self.graph.attack_paths if ap.source in source_ids]
 
+    def attack_paths(self, *, tenant_id: str = "", scan_id: str = "", offset: int = 0, limit: int = 100):
+        self.calls.append(("attack_paths", tenant_id, scan_id, offset, limit))
+        paths = sorted(self.graph.attack_paths, key=lambda path: (-path.composite_risk, path.source, path.target))
+        return self.graph.scan_id, self.graph.created_at, paths[offset : offset + limit], len(paths)
+
     def node_context(self, *, tenant_id: str = "", scan_id: str = "", node_id: str):
         self.calls.append(("node_context", tenant_id, scan_id, node_id))
         node = self.graph.get_node(node_id)
@@ -959,6 +975,32 @@ class TestGraphStoreBackendSelection:
 
         assert response.status_code == 422
         assert "Unsupported graph entity type" in response.json()["detail"]
+
+    def test_global_attack_paths_are_not_limited_to_node_page(self, recording_graph_store):
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="vuln:cve", entity_type=EntityType.VULNERABILITY, label="CVE-2026-1"))
+        recording_graph_store.graph.attack_paths.append(
+            AttackPath(
+                source="agent:a",
+                target="vuln:cve",
+                hops=["agent:a", "server:s", "vuln:cve"],
+                edges=["uses", "vulnerable_to"],
+                composite_risk=9.8,
+                summary="agent-a reaches CVE-2026-1 outside the current node page",
+                tool_exposure=["run_shell"],
+            )
+        )
+        client = TestClient(app)
+
+        response = client.get("/v1/graph/attack-paths", params={"limit": 1})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["attack_paths"][0]["summary"] == "agent-a reaches CVE-2026-1 outside the current node page"
+        assert {node["id"] for node in body["nodes"]} == {"agent:a", "server:s", "vuln:cve"}
+        assert body["pagination"]["total"] == 1
+        assert any(call[0] == "attack_paths" for call in recording_graph_store.calls)
+        assert any(call[0] == "nodes_by_ids" for call in recording_graph_store.calls)
 
     def test_graph_presets_use_pluggable_store(self, recording_graph_store):
         client = TestClient(app)

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -44,22 +44,6 @@ import {
   moveAttackPathSelection,
   toAttackCardNodes,
 } from "@/lib/attack-paths";
-import { EntityType } from "@/lib/graph-schema";
-
-const ATTACK_PATH_ENTITY_TYPES = [
-  EntityType.VULNERABILITY,
-  EntityType.MISCONFIGURATION,
-  EntityType.PACKAGE,
-  EntityType.SERVER,
-  EntityType.CONTAINER,
-  EntityType.CLOUD_RESOURCE,
-  EntityType.AGENT,
-  EntityType.USER,
-  EntityType.GROUP,
-  EntityType.SERVICE_ACCOUNT,
-  EntityType.CREDENTIAL,
-  EntityType.TOOL,
-];
 
 function emptyGraphResponse(scanId: string): UnifiedGraphResponse {
   return {
@@ -170,11 +154,9 @@ function SecurityGraphPageContent() {
       setLoadingGraph(true);
       try {
         const [graph, view] = await Promise.all([
-          api.getGraph({
+          api.getGraphAttackPaths({
             scanId: selectedScanId,
-            entityTypes: ATTACK_PATH_ENTITY_TYPES,
-            maxDepth: 6,
-            limit: 1200,
+            limit: 250,
           }),
           api.getFixFirstGraphView({
             scanId: selectedScanId,

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -511,6 +511,20 @@ export const api = {
     return get<FixFirstGraphViewResponse>(`/v1/graph/views/fix-first${qs ? `?${qs}` : ""}`);
   },
 
+  /** Load the global risk-sorted attack path queue without node-page coupling */
+  getGraphAttackPaths: (filters?: {
+    scanId?: string | undefined;
+    offset?: number | undefined;
+    limit?: number | undefined;
+  }) => {
+    const params = new URLSearchParams();
+    if (filters?.scanId) params.set("scan_id", filters.scanId);
+    if (filters?.offset != null) params.set("offset", String(filters.offset));
+    if (filters?.limit != null) params.set("limit", String(filters.limit));
+    const qs = params.toString();
+    return get<UnifiedGraphResponse>(`/v1/graph/attack-paths${qs ? `?${qs}` : ""}`);
+  },
+
   /** Search graph nodes within a snapshot */
   searchGraph: (query: string, filters?: { scanId?: string; offset?: number; limit?: number }) => {
     const params = new URLSearchParams();


### PR DESCRIPTION
## Summary

Makes `/security-graph` use a real global attack-path queue instead of loading a large node page and deriving paths from whatever happened to be visible.

- adds `GET /v1/graph/attack-paths` for snapshot-wide, risk-sorted attack paths
- hydrates only the hop nodes needed to render the returned queue page
- adds SQLite and Postgres graph-store support for paginated global attack paths
- updates `/security-graph` to call the new endpoint with a bounded queue page
- keeps `/v1/graph` unchanged for canvas pagination and topology browsing

## Why this matters

Wiz/Orca/CrowdStrike-style exposure workflows do not let the top attack path disappear because it fell outside the current node page. This separates fix-first triage from whole-canvas pagination while preserving the existing graph canvas contract.

## Validation

- `uv run pytest tests/test_graph_api.py -q` -> 48 passed
- `npm run typecheck` -> passed
- `npm run lint` -> passed
- `npm run test:run` -> 24 files / 174 tests passed
- `uv run ruff check src/agent_bom/api/graph_store.py src/agent_bom/api/postgres_graph.py src/agent_bom/api/routes/graph.py tests/test_graph_api.py` -> passed
- `git diff --check` -> passed
- pre-commit -> ruff, ruff-format, mypy, bandit, env-var drift passed
