### PR TITLE
feat(graph): server-backed faceted search

### DIFF
--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -962,14 +962,19 @@ function GraphPageInner() {
     }
     setSearching(true);
     try {
-      const response = await api.searchGraph(query, { scanId: selectedScanId, limit: 8 });
+      const response = await api.searchGraph(query, {
+        scanId: selectedScanId,
+        entityTypes: serverEntityTypes,
+        ...(filters.severity ? { minSeverity: filters.severity } : {}),
+        limit: 16,
+      });
       setSearchResults(response.results);
     } catch {
       setSearchResults([]);
     } finally {
       setSearching(false);
     }
-  }, [searchQuery, selectedScanId]);
+  }, [filters.severity, searchQuery, selectedScanId, serverEntityTypes]);
 
   const focusSearchResult = useCallback(
     (node: UnifiedNode) => {
@@ -1150,6 +1155,9 @@ function GraphPageInner() {
 
           {searchResults.length > 0 && (
             <div className="mt-2 rounded-2xl border border-zinc-800 bg-zinc-950/90 p-2">
+              <div className="mb-2 px-1 text-[10px] uppercase tracking-[0.18em] text-zinc-500">
+                Search respects current entity scope{filters.severity ? ` and ${filters.severity}+ severity` : ""}
+              </div>
               <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
                 {searchResults.map((result) => (
                   <button

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -491,12 +491,35 @@ export const api = {
   },
 
   /** Search graph nodes within a snapshot */
-  searchGraph: (query: string, filters?: { scanId?: string; offset?: number; limit?: number }) => {
+  searchGraph: (
+    query: string,
+    filters?: {
+      scanId?: string;
+      entityTypes?: string[];
+      minSeverity?: string;
+      compliancePrefixes?: string[];
+      dataSources?: string[];
+      offset?: number;
+      limit?: number;
+      cursor?: string;
+    },
+  ) => {
     const params = new URLSearchParams();
     params.set("q", query);
     if (filters?.scanId) params.set("scan_id", filters.scanId);
+    if (filters?.entityTypes && filters.entityTypes.length > 0) {
+      params.set("entity_types", filters.entityTypes.join(","));
+    }
+    if (filters?.minSeverity) params.set("min_severity", filters.minSeverity);
+    if (filters?.compliancePrefixes && filters.compliancePrefixes.length > 0) {
+      params.set("compliance_prefixes", filters.compliancePrefixes.join(","));
+    }
+    if (filters?.dataSources && filters.dataSources.length > 0) {
+      params.set("data_sources", filters.dataSources.join(","));
+    }
     if (filters?.offset != null) params.set("offset", String(filters.offset));
     if (filters?.limit != null) params.set("limit", String(filters.limit));
+    if (filters?.cursor) params.set("cursor", filters.cursor);
     return get<GraphSearchResponse>(`/v1/graph/search?${params.toString()}`);
   },
 


### PR DESCRIPTION
## Summary

Makes graph search use the server-side filters that already exist on `/v1/graph/search`.

- expands `api.searchGraph()` to pass entity type, severity, compliance prefix, data source, offset, limit, and cursor filters
- wires the graph search box to the active entity scope and severity threshold
- increases result count from 8 to 16 so operators get a more useful shortlist without loading the whole graph
- labels the search result panel so it is clear the current graph scope affects results

## Why this matters

Large security graphs need server-backed faceted search. This is a small step toward the scalable triage drawer from the Wiz/Orca/CrowdStrike alignment audit: search should respect the current investigation scope instead of behaving like a tiny local lookup.

## Validation

- `npm run typecheck` -> passed
- `npm run lint` -> passed
- `npm run test:run` -> 24 files / 174 tests passed
- `git diff --check` -> passed
- pre-commit -> file hygiene hooks passed
