### PR TITLE
[codex] fix release-readiness graph, proxy, and docs audit blockers

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,9 @@
 # Architecture
 
-Five products, one package. System overview, scan pipeline, blast radius, compliance, and integration.
+One `agent-bom` product, multiple operational surfaces. The package exposes
+CLI entry points, API/UI, MCP server mode, runtime proxy/gateway, cloud posture,
+IaC scanning, fleet, graph, reporting, and compliance workflows over the same
+core evidence model.
 
 ---
 
@@ -16,40 +19,40 @@ Operational consequences:
 
 ---
 
-## 1. System Overview — 5 Products
+## 1. System Overview — Product Surfaces
 
 ```
-pip install agent-bom    → 5 CLI entry points, shared core engine
+pip install agent-bom    → shared core engine plus focused CLI entry points
 ```
 
 ```mermaid
 graph TB
-    subgraph BOM["agent-bom — BOM + Scanning"]
-        Scan["scan\nFull 12-step pipeline"]
+    subgraph ScanSurface["Scan surface"]
+        Scan["agents\nDiscovery + scan pipeline"]
         Check_Cmd["check\nPre-install CVE gate"]
         Image_Cmd["image / fs / sbom\nContainer + filesystem"]
         Graph_Cmd["graph\nGraphML / Neo4j / DOT"]
         MCP_Cmd["mcp\ninventory / introspect / registry"]
     end
 
-    subgraph Shield["agent-shield — Runtime Protection"]
+    subgraph RuntimeSurface["Runtime surface"]
         ShieldProxy["proxy\nMCP proxy + audit"]
         Protect["protect --shield\n8 detectors + deep defense"]
         Run_Cmd["run\nZero-config proxy"]
     end
 
-    subgraph Cloud["agent-cloud — Cloud Posture"]
+    subgraph CloudSurface["Cloud posture surface"]
         AWS["aws / azure / gcp\nCIS benchmarks"]
         Platforms["snowflake / databricks\nhuggingface / ollama"]
         Posture["posture\nCross-cloud summary"]
     end
 
-    subgraph IAC["agent-iac — IaC Security"]
+    subgraph IACSurface["IaC surface"]
         IaCScan["scan\n138 rules × 5 formats"]
         Policy["policy\ntemplate / apply"]
     end
 
-    subgraph Claw["agent-claw — Fleet Governance"]
+    subgraph OpsSurface["Fleet + control-plane surface"]
         Fleet["fleet\nsync / list / stats"]
         Serve["serve / api\nDashboard + REST"]
         Report["report\nhistory / analytics"]
@@ -59,7 +62,7 @@ graph TB
         Discovery["Discovery\n29 first-class clients"]
         Parser["Package Parser\n15 ecosystems"]
         Scanner["CVE Scanner\nOSV + NVD + GHSA"]
-        Blast["Blast Radius\nCVE → agent → credentials → tools"]
+        Blast["Blast Radius\nCVE → package → server → credential → tool"]
         IaC["IaC Engine\n138 rules"]
         CIS["CIS Benchmarks\nAWS / Azure / GCP"]
     end
@@ -140,10 +143,12 @@ graph LR
     TOOL["query_db · read_file\nwrite_file · run_shell"]
 
     CVE -->|affects| PKG
-    PKG -->|dependency of| SRV
-    SRV -->|used by| AGT1 & AGT2
-    AGT1 & AGT2 -->|exposes| CRED
-    AGT1 & AGT2 -->|reaches| TOOL
+    SRV -->|depends_on| PKG
+    SRV -->|vulnerable_to| CVE
+    AGT1 & AGT2 -->|uses| SRV
+    SRV -->|exposes_cred| CRED
+    SRV -->|provides_tool| TOOL
+    CRED -->|reaches_tool| TOOL
 
     style CVE fill:#dc2626,color:#fff
     style PKG fill:#ea580c,color:#fff

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,18 +1,22 @@
 # Deployment & Scalability Architecture
 
-## 🎯 Overview
+## Overview
 
-agent-bom is designed to scale from local CLI usage to enterprise-wide AI infrastructure scanning. This document explains deployment patterns, containerization, CI/CD integration, and cloud-native architectures.
+agent-bom is one product with multiple deployable surfaces: local CLI, CI
+scanner, container image, self-hosted API/UI, fleet sync, proxy, gateway, MCP
+server mode, and Snowflake-specific compatibility views. This document covers
+the maintained deployment shapes. For the canonical chooser, start with
+[`site-docs/deployment/overview.md`](../site-docs/deployment/overview.md).
 
 ---
 
-## 🏗️ Architecture Overview
+## Architecture Overview
 
 ### How agent-bom Works
 
 ```
 ┌─────────────────────────────────────────┐
-│  agent-bom (AI-BOM Generator + Scanner) │
+│  agent-bom (AI supply-chain scanner)    │
 │  ├─ Discovers MCP/AI agent configs      │
 │  ├─ Extracts packages (+ transitive)    │
 │  ├─ Scans for vulnerabilities (OSV)     │
@@ -39,7 +43,7 @@ That keeps auth, tenant isolation, auditability, and request throttling consiste
 
 ---
 
-## 📦 Deployment Patterns
+## Deployment Patterns
 
 ### 1. Local CLI (Current)
 
@@ -75,7 +79,7 @@ WORKDIR /workspace
 
 # Default command
 ENTRYPOINT ["agent-bom"]
-CMD ["scan", "--help"]
+CMD ["agents", "--help"]
 ```
 
 #### Usage
@@ -88,14 +92,14 @@ docker build -t agent-bom:latest .
 docker run --rm \
   -v $(pwd):/workspace \
   -v ~/.config:/home/abom/.config:ro \
-  agent-bom:latest scan --enrich --output /workspace/report.json
+  agent-bom:latest agents --enrich --output /workspace/report.json
 
 # Scan with environment variables
 docker run --rm \
   -e NVD_API_KEY=your-key \
   -e SNOWFLAKE_ACCOUNT=myaccount \
   -v $(pwd):/workspace \
-  agent-bom:latest scan --enrich
+  agent-bom:latest agents --enrich
 ```
 
 **Pros**: Portable, reproducible, version-locked
@@ -232,7 +236,7 @@ spec:
           - name: agent-bom
             image: agent-bom:latest
             args:
-              - scan
+              - agents
               - --enrich
               - --format
               - json
@@ -269,93 +273,6 @@ spec:
 **Cons**: Kubernetes expertise required
 
 For the maintained Helm chart in `deploy/helm/agent-bom/`, the runtime monitor DaemonSet now includes liveness, readiness, and startup probes by default when enabled, can optionally expose a Prometheus Operator `ServiceMonitor` for `/metrics`, can optionally create an `Ingress` and `PodDisruptionBudget` for the monitor service, and ships with an explicit `NetworkPolicy` egress baseline for DNS plus outbound web traffic instead of `allow-all` egress.
-
----
-
-### 5. AWS Lambda / Cloud Functions (Serverless)
-
-**Use case**: Event-driven scanning, API endpoints
-
-#### Lambda Handler
-
-```python
-import json
-import tempfile
-import os
-from agent_bom.cli import main
-
-def lambda_handler(event, context):
-    """
-    Trigger agent-bom agents from Lambda.
-    Event payload:
-    {
-        "snowflake_account": "myaccount",
-        "enrich": true,
-        "output_bucket": "s3://mybucket/ai-bom/"
-    }
-    """
-
-    # Parse event
-    snowflake_account = event.get('snowflake_account')
-    enrich = event.get('enrich', True)
-    output_bucket = event.get('output_bucket')
-
-    # Run scan
-    with tempfile.TemporaryDirectory() as tmpdir:
-        output_file = os.path.join(tmpdir, 'ai-bom.json')
-
-        # Build CLI args
-        args = ['scan', '--format', 'json', '--output', output_file]
-        if enrich:
-            args.append('--enrich')
-        if snowflake_account:
-            args.extend(['--snowflake-account', snowflake_account])
-
-        # Execute scan
-        main(args)
-
-        # Upload to S3
-        with open(output_file) as f:
-            report = json.load(f)
-
-        # TODO: Upload to S3 using boto3
-
-        return {
-            'statusCode': 200,
-            'body': json.dumps({
-                'message': 'Scan complete',
-                'vulnerabilities': len(report.get('blast_radii', []))
-            })
-        }
-```
-
-#### SAM Template
-
-```yaml
-AWSTemplateFormatVersion: '2010-09-09'
-Transform: AWS::Serverless-2016-10-31
-
-Resources:
-  AgentBomFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      FunctionName: agent-bom-scanner
-      Runtime: python3.11
-      Handler: lambda_function.lambda_handler
-      Timeout: 300
-      MemorySize: 1024
-      Environment:
-        Variables:
-          NVD_API_KEY: !Ref NVDApiKey
-      Events:
-        Schedule:
-          Type: Schedule
-          Properties:
-            Schedule: rate(6 hours)
-```
-
-**Pros**: No infrastructure management, auto-scaling
-**Cons**: 15-minute timeout, cold start latency
 
 ---
 
@@ -430,48 +347,11 @@ Additional env vars: `SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_USER`, `SNOWFLAKE_DATABASE`
 
 ## 🌐 Remote Scanning Architectures
 
-### Scanning VMs and Remote Systems
-
-#### 1. SSH-Based Remote Scanning
-
-```python
-# Future: agent-bom/remote_scanner.py
-
-import paramiko
-import tempfile
-
-def scan_remote_vm(hostname, username, key_path):
-    """Scan MCP configs on a remote VM via SSH."""
-
-    ssh = paramiko.SSHClient()
-    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    ssh.connect(hostname, username=username, key_filename=key_path)
-
-    # Copy MCP configs to temp dir
-    with tempfile.TemporaryDirectory() as tmpdir:
-        sftp = ssh.open_sftp()
-        sftp.get('~/.config/claude-desktop/config.json',
-                 f'{tmpdir}/config.json')
-        sftp.close()
-
-        # Scan locally
-        from agent_bom.cli import main
-        main(['scan', '--config-dir', tmpdir])
-
-    ssh.close()
-```
-
-**Usage**:
-```bash
-agent-bom agents --remote ssh://user@vm.example.com --key ~/.ssh/id_rsa
-```
-
-#### 2. Agent-Based Cloud Scanning
+### Fleet and endpoint scanning
 
 ```
 ┌──────────────────────────────────────────┐
-│  Central Management Console              │
-│  (agent-bom server)                      │
+│  agent-bom API + UI                      │
 └───────────────┬──────────────────────────┘
                 │ HTTPS API
         ┌───────┴────────┬────────────┐
@@ -484,19 +364,12 @@ agent-bom agents --remote ssh://user@vm.example.com --key ~/.ssh/id_rsa
     └───────┘      └───────┘    └───────┘
 ```
 
-**Agent responsibilities**:
-- Discover local MCP configs
-- Extract packages
-- Send inventory to central server
-- Receive scan results
+Use `agent-bom fleet`, `agent-bom proxy-bootstrap`, or pushed fleet ingest for
+managed endpoint rollout. There is no shipped `agent-bom agents --remote ssh://`
+mode; use SSH or device-management tooling only as an external transport for
+running the normal CLI or onboarding bundle on the endpoint.
 
-**Central server responsibilities**:
-- Aggregate packages from all agents
-- Batch query OSV/NVD/EPSS/KEV
-- Calculate global blast radius
-- Provide web UI for results
-
-#### 3. API-Based Cloud Scanning
+### API-Based Cloud Scanning
 
 ```python
 # Scan Snowflake Cortex via API (uses SSO by default)
@@ -629,9 +502,8 @@ export SNOWFLAKE_PRIVATE_KEY_PATH=~/.ssh/snowflake_key.p8
 
 agent-bom agents --enrich
 
-# Or use secret managers
-agent-bom agents --secret-provider aws-secrets-manager \
-               --secret-id prod/agent-bom/nvd-key
+# In Kubernetes, mount keys through Secrets, External Secrets, or IRSA-backed
+# secret managers and expose only the required environment variables.
 ```
 
 ### 2. Network Isolation
@@ -659,61 +531,24 @@ spec:
 
 ### 3. RBAC and Audit Logging
 
-```python
-# Future: agent-bom with audit logging
-
-import logging
-logging.basicConfig(filename='/var/log/agent-bom/audit.log')
-
-def scan_with_audit(user, target):
-    logging.info(f"User {user} initiated scan of {target}")
-    result = scan(target)
-    logging.info(f"Scan complete: {len(result.vulnerabilities)} vulns found")
-    return result
-```
+Use the self-hosted API for authenticated operator workflows. The API enforces
+API-key/OIDC/SAML auth, RBAC, tenant propagation, rate limiting, and audit
+logging; proxy and gateway runtime events are posted back to the same audit
+surface.
 
 ---
 
-## 📈 Performance Benchmarks
+## 📈 Performance and Scale Evidence
 
-| Scale | Local CLI | Docker | Kubernetes | Lambda |
-|-------|-----------|--------|------------|--------|
-| 1 MCP server | 5s | 8s | 15s | 20s |
-| 10 MCP servers | 30s | 35s | 40s | 60s |
-| 100 packages | 2m | 2m 15s | 2m 30s | 4m |
-| 1,000 packages (batched) | 15m | 16m | 12m (parallel) | N/A |
+Use the measured performance docs instead of release-plan estimates:
 
-**Note**: With NVD API key, enrichment adds ~10% overhead. Without key, adds 5-10x overhead due to rate limiting.
+- [`docs/PERFORMANCE_BENCHMARKS.md`](PERFORMANCE_BENCHMARKS.md)
+- [`docs/perf/`](perf/)
+- [`site-docs/deployment/performance-and-sizing.md`](../site-docs/deployment/performance-and-sizing.md)
 
----
-
-## 🚀 Next Steps for Production
-
-### Phase 1: Containerization (Week 1)
-- [ ] Create Dockerfile
-- [ ] Publish to Docker Hub / GHCR
-- [ ] Test in CI/CD pipelines
-
-### Phase 2: Cloud Provider APIs (Week 2-3)
-- [ ] Implement Snowflake Cortex scanning
-- [ ] Implement AWS Bedrock scanning
-- [ ] Implement Azure OpenAI scanning
-
-### Phase 3: Remote Scanning (Week 4)
-- [ ] SSH-based remote scanning
-- [ ] Agent-based architecture (PoC)
-- [ ] API server for centralized management
-
-### Phase 4: Scale Testing (Week 5)
-- [ ] Benchmark 1,000+ package scans
-- [ ] Implement caching layer
-- [ ] Optimize batch processing
-
-### Phase 5: Enterprise Features (Later)
-- [ ] Web UI dashboard
-- [ ] SIEM/SOAR integrations
-- [ ] Multi-tenancy support
-- [ ] Historical trending
+For large API deployments, configure Postgres-backed stores so scan jobs, fleet
+state, schedules, API keys, audit, graph, and rate limiting survive API replica
+rotation and stay tenant-scoped.
 
 ---
 
@@ -739,8 +574,8 @@ agent-bom scales from local CLI to enterprise infrastructure by:
 
 1. **Containerization**: Docker images for portability
 2. **CI/CD Integration**: GitHub Actions, GitLab CI, Jenkins
-3. **Cloud-Native**: Kubernetes CronJobs, serverless functions
-4. **Remote Scanning**: SSH, agents, cloud APIs
+3. **Cloud-Native**: Kubernetes CronJobs and Helm-managed control-plane deployments
+4. **Remote Inventory**: fleet sync, pushed ingest, and cloud APIs
 5. **Performance**: Caching, batching, parallelization
 
 agent-bom can be deployed anywhere — CLI, Docker, CI/CD, Kubernetes, Snowflake, or as an MCP server — specialized for AI agent infrastructure security.

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -127,7 +127,7 @@ If engaging a third-party auditor, the recommended scope:
 
 ## Graph guarantees
 
-agent-bom builds a context graph from inventory and canonical advisory feeds (CISA KEV, OSV, NVD, EPSS, MITRE) to model lateral movement across MCP agents, servers, credentials, and tools. The graph is deterministic, round-trip-clean against the source inventory, and tenant-scoped at the database layer via Postgres row-level security. It does not use ML inference, does not encode causality without runtime traces from the proxy / gateway, and does not update in real time without those runtimes in the path.
+agent-bom builds a context graph from inventory and canonical advisory feeds (CISA KEV, OSV, NVD, EPSS, MITRE) to model reachability across MCP agents, servers, credentials, and tools. Static edges use the contract names: `agent -> server` (`uses`), `server -> credential` (`exposes_cred`), `server -> tool` (`provides_tool`), and `credential -> tool` (`reaches_tool`). The graph is deterministic, round-trip-clean against the source inventory, and tenant-scoped at the database layer via Postgres row-level security. It does not use ML inference, does not encode causality without runtime traces from the proxy / gateway, and does not update in real time without those runtimes in the path.
 
 The full contract — entity and edge enums, accuracy guarantees, scaling tiers, re-baseline procedure, and known coverage gaps — is in [docs/graph/CONTRACT.md](graph/CONTRACT.md).
 
@@ -136,8 +136,10 @@ The full contract — entity and edge enums, accuracy guarantees, scaling tiers,
 ### What agent-bom IS
 
 - A **local CLI tool** that scans your infrastructure
+- A **self-hosted API + UI** for operator workflows, graph, audit, remediation, and policy
 - An **MCP server** that exposes scan tools to AI agents
 - A **runtime proxy** that monitors MCP traffic
+- A **gateway and fleet surface** for shared remote MCP policy and endpoint inventory
 - **Apache 2.0 licensed** open source software
 
 ### What agent-bom IS NOT

--- a/docs/SECURITY_AUTH_TENANCY_AUDIT.md
+++ b/docs/SECURITY_AUTH_TENANCY_AUDIT.md
@@ -12,50 +12,49 @@
 
 | Dimension | Score | Evidence |
 |---|:-:|---|
-| API-key auth + rotation | **9** | [`api/auth.py`](../src/agent_bom/api/auth.py), [`api/middleware.py:250`](../src/agent_bom/api/middleware.py:250) APIKeyMiddleware, [`routes/enterprise.py:106`](../src/agent_bom/api/routes/enterprise.py:106) `rotate_key` with `rotation_policy="enforced"` |
-| OIDC (Okta, Auth0, Azure AD, Google) | **9** | [`api/oidc.py:290`](../src/agent_bom/api/oidc.py:290) `OIDCConfig`, claim-based tenant resolution, audience pinning |
+| API-key auth + rotation | **9** | [`api/auth.py`](../src/agent_bom/api/auth.py), [`api/middleware.py:250`](../src/agent_bom/api/middleware.py#L250) APIKeyMiddleware, [`routes/enterprise.py:106`](../src/agent_bom/api/routes/enterprise.py#L106) `rotate_key` with `rotation_policy="enforced"` |
+| OIDC (Okta, Auth0, Azure AD, Google) | **9** | [`api/oidc.py:290`](../src/agent_bom/api/oidc.py#L290) `OIDCConfig`, claim-based tenant resolution, audience pinning |
 | SAML SSO | **8.5** | [`api/saml.py`](../src/agent_bom/api/saml.py) `SAMLConfig` + `/v1/auth/saml/metadata`; needs `[saml]` extra |
-| RBAC (admin / analyst / viewer) | **9** | [`rbac.py:137 require_permission`](../src/agent_bom/rbac.py:137), [`:160 require_authenticated_permission`](../src/agent_bom/rbac.py:160), 3 roles × 8 action classes |
-| Rate limiting (per-tenant + global) | **9** | [`api/middleware.py InMemoryRateLimitStore + PostgresRateLimitStore`](../src/agent_bom/api/middleware.py:53), `X-RateLimit-*` response headers |
+| RBAC (admin / analyst / viewer) | **9** | [`rbac.py:137 require_permission`](../src/agent_bom/rbac.py#L137), [`:160 require_authenticated_permission`](../src/agent_bom/rbac.py#L160), 3 roles × 8 action classes |
+| Rate limiting (per-tenant + global) | **9** | [`api/middleware.py InMemoryRateLimitStore + PostgresRateLimitStore`](../src/agent_bom/api/middleware.py#L53), `X-RateLimit-*` response headers |
 | Multi-tenancy: row-level isolation | **9** | Native `tenant_id` in Postgres ([#1562](https://github.com/msaad00/agent-bom/pull/1562)), ClickHouse (row-level filter tested), Snowflake ([#1567](https://github.com/msaad00/agent-bom/pull/1567) fleet native), SQLite. 3 test layers: [`test_clickhouse_tenant_isolation.py`](../tests/test_clickhouse_tenant_isolation.py), [`test_cross_tenant_leakage.py`](../tests/test_cross_tenant_leakage.py), [`test_api_cross_tenant_matrix.py`](../tests/test_api_cross_tenant_matrix.py) |
 | Audit log non-repudiation | **8.5** | HMAC-chained log ([`api/audit_log.py`](../src/agent_bom/api/audit_log.py)); Ed25519-signed compliance bundles ([`api/compliance_signing.py`](../src/agent_bom/api/compliance_signing.py), cookbook [`COMPLIANCE_SIGNING.md`](COMPLIANCE_SIGNING.md)). Tenant audit chains hardened in [#1559](https://github.com/msaad00/agent-bom/pull/1559) |
-| Secrets at rest (KMS, rotation) | **8.5** | SSE-KMS on Postgres backup ([`controlplane-backup-cronjob.yaml:78`](../deploy/helm/agent-bom/templates/controlplane-backup-cronjob.yaml:78)), External Secrets wired to Secrets Manager ([`controlplane-externalsecret.yaml`](../deploy/helm/agent-bom/templates/controlplane-externalsecret.yaml)), API-key + HMAC + Ed25519 all operator-rotated via `kubectl rollout restart` |
-| Ephemeral creds (no passwords at rest) | **8** | Bearer tokens referenced by env-var name only in upstreams.yaml ([`gateway-upstreams.example.yaml`](../deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml)); OAuth2 client-credentials token cache with early refresh ([`gateway_upstreams.py`](../src/agent_bom/gateway_upstreams.py)); Snowflake backend mandates key-pair, password fallback rejected when `AGENT_BOM_SNOWFLAKE_REQUIRE_KEYPAIR=1` ([`eks-snowflake-values.yaml`](../deploy/helm/agent-bom/examples/eks-snowflake-values.yaml)) |
+| Secrets at rest (KMS, rotation) | **8.5** | SSE-KMS on Postgres backup ([`controlplane-backup-cronjob.yaml:78`](../deploy/helm/agent-bom/templates/controlplane-backup-cronjob.yaml#L78)), External Secrets wired to Secrets Manager ([`controlplane-externalsecret.yaml`](../deploy/helm/agent-bom/templates/controlplane-externalsecret.yaml)), API-key + HMAC + Ed25519 all operator-rotated via `kubectl rollout restart` |
+| Ephemeral creds (no passwords at rest) | **8** | Bearer tokens referenced by env-var name only in upstreams.yaml ([`gateway-upstreams.example.yaml`](../deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml)); OAuth2 client-credentials token cache with early refresh ([`gateway_upstreams.py`](../src/agent_bom/gateway_upstreams.py)); Snowflake key-pair auth is the production recommendation, while `SNOWFLAKE_PASSWORD` remains a deprecated fallback with a runtime warning ([`snowflake_store.py`](../src/agent_bom/api/snowflake_store.py)) |
 | Zero-trust / mTLS / NetworkPolicy | **8** | Istio PeerAuthentication + AuthorizationPolicy templates ([`controlplane-istio-*.yaml`](../deploy/helm/agent-bom/templates/)), Kyverno policy, NetworkPolicy `restrictIngress` per example values file, Pod Security Admission `restricted` |
-| Defense in depth (middleware stack) | **9** | Body-size + read-timeout → trust-headers + W3C trace → auth → RBAC → tenant → rate limit → route → audit → store. Every layer testable in isolation. Diagrammed in README §3. |
+| Defense in depth (middleware stack) | **9** | Body-size + read-timeout → trust-headers + W3C trace → auth → RBAC → tenant → rate limit → route → audit → store. Every layer testable in isolation. |
 | SQL injection | **9** | Postgres uses psycopg parameterized queries (no f-string SQL). ClickHouse has [`_escape()`](../src/agent_bom/api/clickhouse_store.py) + numeric casts + a bandit `nosec B608` annotation reviewed. Snowflake store uses connector parameter binding. |
 | XSS | **8** | Next.js dashboard renders via React auto-escape; strict CSP on API routes ([`middleware.py:_API_CSP`](../src/agent_bom/api/middleware.py)); HTML report is static-generated without user-controllable HTML passthrough. |
 | Input validation at boundaries | **8.5** | Pydantic models on every route; path-traversal + command-injection guards in [`proxy_policy.py`](../src/agent_bom/proxy_policy.py) (`block_secret_paths`, `block_unknown_egress`); `ArgumentAnalyzer` on every tool call |
 | CIA triad | **8.5** | C: TLS at ingress + KMS at rest; I: HMAC-chain + Ed25519 signing + checksums on backup restore; A: HPA on API + gateway, backup restore CI round-trip |
-| **Overall** | **~8.7** | Above-bar on every axis above except the new-feature gaps below |
+| **Overall** | **~8.7** | Above-bar on every axis above except the documented gaps below |
 
-## Assessment of the PR stream that landed while I was out
+## Current implementation notes
 
-Every PR below reviewed against the on-disk code, not just the PR description. Verdicts:
+- Audit entry details participate in the HMAC chain, and gateway, proxy,
+  quota, and compliance audit events carry tenant context.
+- Postgres control-plane state is split across focused stores while preserving
+  public imports; job retention respects configured TTL.
+- Tenant-scoped stores filter at the query layer where supported. Snowflake
+  stores carry native tenant columns for the supported scan, fleet, schedule,
+  exception, and policy paths.
+- Analytics writes carry session and trace context so logs, metrics, and traces
+  can correlate the same request.
+- The MCP server metadata and entry point are separated from runtime wiring.
+- Python AST analysis and console rendering internals are split into focused
+  modules without changing the operator-facing command surface.
 
-| PR | Title | LOC touched | Assessment |
-|---|---|---|---|
-| [#1559](https://github.com/msaad00/agent-bom/pull/1559) | harden tenant-scoped audit chains | audit_log.py +116 / -46, plus routes | **✓ real hardening.** Audit entry `details` now participate in the HMAC chain (not just metadata); gateway/proxy/quota/compliance audit events carry tenant. Legacy chain verification preserved for old entries. |
-| [#1560](https://github.com/msaad00/agent-bom/pull/1560) | align deployment context + self-hosted rollout story | README.md, init.sql +217, DATA_MODEL +39 | **✓ docs + schema alignment.** Postgres init.sql now mirrors the alembic migrations; README self-hosted section explicit about deployment contexts. |
-| [#1561](https://github.com/msaad00/agent-bom/pull/1561) | split postgres stores + align job provenance | 5 new postgres_* modules, ~1,400 LOC moved | **✓ the right split.** `postgres_store.py` → `postgres_{common,access,audit,graph,policy}`. Public import surface stable. TTL-respecting scan-job retention is a real bug fix, not just refactor. |
-| [#1562](https://github.com/msaad00/agent-bom/pull/1562) | tenant-scoped stores query natively | schedule_store +30, snowflake_store +45 | **✓ correctness.** Broad-read-then-python-filter was a silent O(N) leak risk; every store now filters at the query layer. Snowflake got native tenant columns where it was previously defaulted to "default". |
-| [#1563](https://github.com/msaad00/agent-bom/pull/1563) | preserve session + trace context in analytics | clickhouse_store +49, routes/proxy +33 | **✓ observability correctness.** Analytics writes now carry the same session + trace context as the audit log so Grafana correlates the same request across metric/log/trace. |
-| [#1564](https://github.com/msaad00/agent-bom/pull/1564) | split mcp server metadata + entrypoint | mcp_server.py -304, metadata/entrypoint +279 | **✓ good split.** mcp_server.py now ~500 LOC of wiring; the tool metadata + entrypoint separation tracks the issue #1522 prescription. |
-| [#1565](https://github.com/msaad00/agent-bom/pull/1565) | split python ast analysis internals | ast_analyzer.py -1766, ast_python_analysis.py +1725 | **✓ huge win for reviewability.** The analyzer dispatcher (ast_analyzer.py) is now thin; the Python-specific rules live in a focused module. Exactly the split prescribed. |
-| [#1566](https://github.com/msaad00/agent-bom/pull/1566) | split output console renderers | output/__init__.py -1673, console_render.py +1660 | **✓ continues #1557's Phase 1a.** Between this and my #1557, the output monolith is effectively done. |
-| [#1567](https://github.com/msaad00/agent-bom/pull/1567) *(open)* | snowflake fleet sync tenant-native | snowflake_store, pipeline | **✓ closes the last silent tenant-default leak.** `_sync_scan_agents_to_fleet` was writing fleet agents into `default` when the job had a real tenant. This is a P0 the audit would have flagged — already fixed. |
-
-**Net verdict:** codex's stream was on the right track. The splits + the tenant-native queries + the audit-chain hardening are exactly what a pilot-readiness review would demand. No red flags, no scaffolding introduced, imports stable.
-
-## Real gaps (P0 → P2)
+## Real gaps (P1 → P2)
 
 ### P1 — MFA is a CIS benchmark check, not a product feature
 
 - `grep -rln "mfa\|MFA\|totp" src/agent_bom/` returns only `cloud/*_cis_benchmark.py` (we *check* for MFA in customers' cloud accounts) — **we don't require MFA on the dashboard / API keys ourselves**.
 - Impact: a pilot team's dashboard login goes through OIDC / SAML (their IdP enforces MFA) — so MFA is effectively present *via the IdP*. But there's no in-product MFA for API-key auth.
-- **Fix proposal:** documented today = OIDC + SAML users inherit the IdP's MFA; API keys stay machine-to-machine (operator is expected to protect API-key storage). File a docs-only issue to make this explicit in the `SECURITY_ARCHITECTURE.md`.
+- Current boundary: OIDC + SAML users inherit the IdP's MFA; API keys stay
+  machine-to-machine credentials and must be protected by the operator's secret
+  storage, rotation, and least-privilege controls.
 
-### Closed — Screenshot / visual-capture sensitive data detection now exists
+### Implemented — Screenshot / visual-capture sensitive data detection now exists
 
 - `src/agent_bom/runtime/visual_leak_detector.py` implements the optional OCR
   detector and redaction path for image-bearing tool responses.
@@ -74,12 +73,17 @@ default for local-first scanning and lightweight gateway deployments.
 ### P2 — Password-based auth on upstream config should be explicitly banned
 
 - `gateway_upstreams.py` accepts `auth: bearer` with env-var token. Operators could (mis)configure Snowflake MCP as `bearer` and put the Snowflake password in the env var.
-- **Fix:** add a linter check or a runtime warning if an upstream's `token_env` is named `*_PASSWORD*`. Small; not urgent.
+- A remaining code hardening step is to add a linter check or runtime warning when
+  an upstream's `token_env` is named `*_PASSWORD*`.
 
-### P2 — `AGENT_BOM_SNOWFLAKE_REQUIRE_KEYPAIR=1` is opt-in
+### P2 — Snowflake password fallback is deprecated, not hard-disabled in code
 
-- Default is permissive — password fallback still works unless you set the env var.
-- **Fix:** flip the default to deny-password for `0.79.0+`, with a migration note. Breaking change, but right thing to do.
+- `SNOWFLAKE_PASSWORD` still works with a deprecation warning in
+  `build_connection_params()`. The Helm Snowflake example documents key-pair
+  auth and sets `AGENT_BOM_SNOWFLAKE_REQUIRE_KEYPAIR=1`, but that flag is not
+  currently enforced by `snowflake_store.py`.
+- Hard-failing password fallback would be a code change and migration note, not
+  a documentation-only claim.
 
 ### P2 — `/metrics` endpoint is unauthenticated
 
@@ -108,12 +112,6 @@ default for local-first scanning and lightweight gateway deployments.
 5. **Audit trail** — visual-leak alerts flow through the same runtime audit
    path as text detector alerts, with the durable evidence-retention policy
    keeping replay-only payloads out of long-lived analytics.
-
-## What I recommend next (queued)
-
-1. Close out this audit with doc merge + follow-up issues filed (done in this PR).
-2. Add the graph-scalability benchmark entry to `PERFORMANCE_BENCHMARKS.md` (~1 hour).
-3. Resume #1522 phases 2–4 for the remaining monoliths (though most landed in #1561, #1564, #1565, #1566 — only `cli/agents/__init__.py` remains large).
 
 ## How I verified every claim
 

--- a/docs/VISUAL_LANGUAGE.md
+++ b/docs/VISUAL_LANGUAGE.md
@@ -1,6 +1,8 @@
 # Visual language for agent-bom docs
 
-Three media, used deliberately. Picking the right one keeps the README
+Three media, used deliberately. agent-bom is one product with multiple
+surfaces; images should show the surface being discussed without implying a
+separate product or unshipped capability. Picking the right medium keeps the README
 readable, mobile-friendly, and easy to keep in sync with code.
 
 For product screenshots, the source of truth is the packaged Next.js
@@ -22,12 +24,20 @@ Current SVG inventory:
 | File | What it shows | Where it lives in the README |
 |---|---|---|
 | `logo-{light,dark}.svg` | Brand mark | hero |
-| `blast-radius-{light,dark}.svg` | Package → CVE → MCP → agent → credentials → tools | hero, under tagline |
+| `blast-radius-{light,dark}.svg` | CVE, package, MCP server, agent, credentials, and tools in one blast-radius path | hero, under tagline |
 | `scan-pipeline-{light,dark}.svg` | 5-stage pipeline (discover → scan → analyze → report → enforce) | "How a scan moves" |
 | `engine-internals-{light,dark}.svg` | Inside the scanner | available for deeper architecture docs; not currently embedded in the README |
 | `compliance-{light,dark}.svg` | Finding → control → evidence packet | Compliance section |
-| `dashboard-live.png` `dashboard-paths-live.png` `mesh-live.png` `remediation-live.png` | Live packaged Next.js dashboard screenshots | Product views |
 | `demo-latest.gif` | Terminal demo (1.04MB after compression) | "Try the demo" |
+
+Current PNG inventory:
+
+| File | What it shows | Where it lives in the README |
+|---|---|---|
+| `dashboard-live.png` | Packaged Next.js dashboard risk overview | Product views |
+| `dashboard-paths-live.png` | Packaged Next.js attack paths and exposure view | Product views |
+| `mesh-live.png` | Agent mesh graph surface | Product views |
+| `remediation-live.png` | Fix-first remediation surface | Product views |
 
 ## Mermaid — for code-true flows that evolve
 

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -256,8 +256,8 @@ single onboarding bundle that can be:
 - assembled into `.pkg` and `.msi` installers from the same generated bundle
 - published into a Homebrew tap via the shipped formula renderer
 
-That gives you one operator story without pretending every workload needs the
-same runtime path.
+That gives you one operator story while keeping proxy, gateway, and fleet as
+separate runtime choices.
 
 For the post-install maintenance path around proxy policy-signing key rotation
 and cert-manager-backed webhook certificate renewal, see
@@ -377,6 +377,6 @@ The chooser table at the top of this page is the canonical entry. After that:
 - runtime surface decision lives in [When To Use Proxy vs Gateway vs Fleet](proxy-vs-gateway-vs-fleet.md)
 - backend choice (Postgres / ClickHouse / Snowflake) is documented in [Backend Parity Matrix](backend-parity.md) and [Backend and Security-Lake Strategy](backend-and-security-lakes.md)
 - the deeper data-model and store mapping is in [Control-Plane Data Model and Store Parity](control-plane-data-model.md)
-- the API + UI control-plane image and operator split is in [Packaged API + UI Control Plane](control-plane-helm.md) and [Hosted Product Control-Plane Spec](../architecture/hosted-product-spec.md)
+- the API + UI control-plane image and operator split is in [Packaged API + UI Control Plane](control-plane-helm.md) and [Self-Hosted Product Architecture](../architecture/self-hosted-product-architecture.md)
 
 Everything else in the deployment section is reference material — open it only when your platform team needs that specific detail.

--- a/site-docs/deployment/snowflake-backend.md
+++ b/site-docs/deployment/snowflake-backend.md
@@ -42,22 +42,9 @@ Pick Snowflake when:
 - You want to join `agent-bom` findings against other Snowflake
   governance data (user activity, cloud asset tables) without moving
   data across systems.
-- You want **one backend that covers the Snowflake-supported
-  transactional, streaming, and analytical workloads**. Snowflake now
-  ships:
-  - **Hybrid Tables** (row-oriented) for fast transactional writes to
-    the scan / fleet / policy / audit stores.
-  - **Standard columnar tables** for the analytics queries the
-    dashboard and compliance narratives run.
-  - **Snowpipe Streaming** for real-time audit / telemetry ingest
-    without a separate Kafka or ClickHouse hop.
-  - **Postgres-compatible protocol** (via the Postgres API / drivers
-    where applicable) so tooling that speaks `psycopg` can point at
-    Snowflake the same way it points at Postgres — reducing client-side
-    changes when you migrate.
-  - **Native cross-cloud replication + listings** so the control plane
-    in your EKS cluster can read/write the same Snowflake tables your
-    cloud + Cortex MCPs read, regardless of region.
+- You want selected `agent-bom` control-plane state in Snowflake:
+  scan jobs, fleet agents, schedules, gateway policies, vulnerability
+  exceptions, and gateway policy audit.
 
 Pick Postgres when you want broad API surface coverage and the fastest
 possible install, and you're comfortable adding ClickHouse only if
@@ -107,16 +94,17 @@ governance.
 
 ## Auth — zero-credential model
 
-**Key-pair auth is required** for the Snowflake backend in production
+**Key-pair auth is recommended** for the Snowflake backend in production
 ([`build_connection_params`](https://github.com/msaad00/agent-bom/blob/main/src/agent_bom/api/snowflake_store.py)).
 Passwords are deprecated and emit a runtime warning; password auth is
 intentionally not recommended because it breaks rotation and short-lived
 credential hygiene.
 
 SSO (externalbrowser) is used for interactive operator CLI; the
-control-plane API uses key-pair. Both reject the deprecated
-`SNOWFLAKE_PASSWORD` path when
-`AGENT_BOM_SNOWFLAKE_REQUIRE_KEYPAIR=1`.
+control-plane API should use key-pair. Current code still accepts the
+deprecated `SNOWFLAKE_PASSWORD` path with a warning; enforce key-pair
+operationally by omitting password secrets and mounting only
+`SNOWFLAKE_PRIVATE_KEY_PATH`.
 
 ### Generate a key pair once
 
@@ -163,7 +151,8 @@ The example file configures:
 
 - `AGENT_BOM_STORE_BACKEND=snowflake` (and equivalent for fleet / policy / audit)
 - Key-pair auth via mounted `rsa_key.p8`
-- `AGENT_BOM_SNOWFLAKE_REQUIRE_KEYPAIR=1` — hard-fail on password fallback
+- `SNOWFLAKE_PRIVATE_KEY_PATH` mounted from the `agent-bom-snowflake` Secret;
+  do not include `SNOWFLAKE_PASSWORD` in that Secret for production
 - Postgres backup CronJob disabled (Snowflake handles durability)
 - Scanner CronJob still runs, pushes scan results to `/v1/fleet/sync`
 - Egress NetworkPolicy allowing only `*.snowflakecomputing.com` on 443
@@ -208,8 +197,7 @@ applies here. Snowflake-specific signals worth alerting on:
 
 - Source registry, API-key persistence, trend,
   graph, and the full HMAC-chained `audit_log` are not yet on
-  `SnowflakeStore`. Run Postgres alongside for these, or wait for
-  parity.
+  `SnowflakeStore`. Run Postgres alongside for these.
 - The scanner CronJob still runs in-cluster; it does not run inside
   Snowpark. Cortex / Snowpark-native discovery is a separate capability
   ([`src/agent_bom/cloud/snowflake.py`](https://github.com/msaad00/agent-bom/blob/main/src/agent_bom/cloud/snowflake.py)).
@@ -221,5 +209,4 @@ applies here. Snowflake-specific signals worth alerting on:
 `Snowflake` is already a valid warehouse-native backend mode for governance,
 scan inventory, fleet state, schedules, and gateway policy paths. `Postgres` remains the
 default full control-plane answer. Use Snowflake when that warehouse-native
-shape is the goal, not because the product is pretending all backend roles are
-already identical.
+shape is the goal; do not treat it as full backend parity with Postgres.

--- a/site-docs/getting-started/install.md
+++ b/site-docs/getting-started/install.md
@@ -11,23 +11,32 @@ pipx install agent-bom
 ## With optional extras
 
 ```bash
-pip install "agent-bom[api]"         # REST API server
-pip install "agent-bom[mcp-server]"  # MCP server dependencies
-pip install "agent-bom[dashboard]"   # Streamlit dashboard
-pip install "agent-bom[all]"         # Everything
+pip install "agent-bom[api]"          # REST API server
+pip install "agent-bom[ui]"           # API plus bundled local UI support
+pip install "agent-bom[mcp-server]"   # MCP server dependencies
+pip install "agent-bom[postgres]"     # Postgres-backed control-plane state
+pip install "agent-bom[cloud]"        # AWS, Azure, GCP, Databricks, Snowflake, Nebius, HuggingFace, W&B, OpenAI
+pip install "agent-bom[visual]"       # OCR-backed visual-leak detection; also requires Tesseract on PATH
+pip install "agent-bom[dashboard]"    # Snowflake Streamlit compatibility dashboard
+pip install "agent-bom[dev-all]"      # Developer environment used by this repo
 ```
+
+Other supported extras in `pyproject.toml` include `otel`, `aws`, `azure`,
+`gcp`, `coreweave`, `databricks`, `snowflake`, `nebius`, `huggingface`,
+`wandb`, `openai`, `ai-enrich`, `graph`, `pdf`, `watch`, `runtime`, `snyk`,
+`oidc`, `saml`, `docs`, and `dev`. There is no `agent-bom[all]` extra.
 
 ## Docker
 
 ```bash
 # CLI scanning
-docker run --rm agentbom/agent-bom:latest scan
+docker run --rm agentbom/agent-bom:latest agents
 
 # With host config access (for MCP client discovery)
 docker run --rm \
   -v "$HOME/.config:/home/abom/.config:ro" \
   -v "$HOME/Library/Application Support:/home/abom/Library/Application Support:ro" \
-  agentbom/agent-bom:latest scan
+  agentbom/agent-bom:latest agents
 ```
 
 ## From source

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -149,12 +149,18 @@ def _persist_graph_snapshot(
     scan_id = report_json.get("scan_id") or job.job_id
     graph = build_unified_graph_from_report(report_json, scan_id=scan_id, tenant_id=tenant_id)
 
-    previous_graph = None
-    graph_store = _get_graph_store()
-    previous_scan_id = graph_store.latest_snapshot_id(tenant_id=tenant_id)
-    if previous_scan_id and previous_scan_id != scan_id:
-        previous_graph = graph_store.load_graph(tenant_id=tenant_id, scan_id=previous_scan_id)
-    graph_store.save_graph(graph)
+    from agent_bom.api.postgres_store import reset_current_tenant, set_current_tenant
+
+    tenant_token = set_current_tenant(tenant_id)
+    try:
+        previous_graph = None
+        graph_store = _get_graph_store()
+        previous_scan_id = graph_store.latest_snapshot_id(tenant_id=tenant_id)
+        if previous_scan_id and previous_scan_id != scan_id:
+            previous_graph = graph_store.load_graph(tenant_id=tenant_id, scan_id=previous_scan_id)
+        graph_store.save_graph(graph)
+    finally:
+        reset_current_tenant(tenant_token)
 
     alerts = compute_delta_alerts(previous_graph, graph)
     delivery = dispatch_delta_alerts(alerts, product_version=__version__) if alerts else None

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -32,7 +32,7 @@ from pydantic import BaseModel, Field
 
 from agent_bom.api.stores import _get_graph_store
 from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
-from agent_bom.graph import SEVERITY_RANK, EntityType, GraphFilterOptions, GraphSemanticLayer, RelationshipType, UnifiedGraph
+from agent_bom.graph import SEVERITY_RANK, AttackPath, EntityType, GraphFilterOptions, GraphSemanticLayer, RelationshipType, UnifiedGraph
 from agent_bom.security import sanitize_error
 
 logger = logging.getLogger(__name__)
@@ -326,6 +326,7 @@ def _fix_first_card_for_path(graph: UnifiedGraph, path, rank: int) -> dict:
         "title": " ".join(title_parts),
         "summary": path.summary or "Review this path before opening the full topology graph.",
         "attack_path": path.to_dict(),
+        "nodes": [graph.nodes[hop].to_dict() for hop in path.hops if hop in graph.nodes],
         "sequence_labels": sequence,
         "risk_reasons": _risk_reasons_for_path(graph, path),
         "next_actions": _next_actions_for_path(graph, path),
@@ -369,6 +370,130 @@ def _path_matches_focus(graph: UnifiedGraph, path, *, cve: str, package: str, ag
         if agent_n not in agent_labels:
             return False
     return True
+
+
+def _is_finding_like_node(node) -> bool:
+    entity_type = node.entity_type.value if hasattr(node.entity_type, "value") else str(node.entity_type)
+    return entity_type in {EntityType.VULNERABILITY.value, EntityType.MISCONFIGURATION.value}
+
+
+def _rel_value(edge) -> str:
+    return edge.relationship.value if hasattr(edge.relationship, "value") else str(edge.relationship)
+
+
+def _node_type_value(node) -> str:
+    return node.entity_type.value if hasattr(node.entity_type, "value") else str(node.entity_type)
+
+
+def _node_risk_100(node) -> float:
+    risk = float(getattr(node, "risk_score", 0.0) or 0.0)
+    if risk <= 10.0:
+        risk *= 10.0
+    if risk <= 0:
+        risk = float(SEVERITY_RANK.get(str(getattr(node, "severity", "") or "").lower(), 0) * 20)
+    return max(0.0, min(100.0, risk))
+
+
+def _derived_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
+    """Derive fix-first paths when a snapshot lacks materialised path rows.
+
+    Older snapshots and some stores have rich topology but no `attack_paths`
+    records. Security operators still need the obvious chain:
+    agent -> MCP server -> package/server -> vulnerability, enriched with the
+    server's credential and tool exposure. Keep this deterministic and bounded;
+    stores with first-class path rows remain the source of truth.
+    """
+    if graph.attack_paths:
+        return list(graph.attack_paths)
+
+    incoming: dict[str, list] = {}
+    outgoing: dict[str, list] = {}
+    for edge in graph.edges:
+        incoming.setdefault(edge.target, []).append(edge)
+        outgoing.setdefault(edge.source, []).append(edge)
+
+    paths: list[AttackPath] = []
+    seen: set[tuple[str, str, str, str]] = set()
+    finding_types = {EntityType.VULNERABILITY.value, EntityType.MISCONFIGURATION.value}
+
+    for finding in graph.nodes.values():
+        if _node_type_value(finding) not in finding_types:
+            continue
+        for finding_edge in incoming.get(finding.id, []):
+            if _rel_value(finding_edge) != RelationshipType.VULNERABLE_TO.value:
+                continue
+            vulnerable_source = graph.nodes.get(finding_edge.source)
+            if vulnerable_source is None:
+                continue
+
+            server_ids: list[str] = []
+            if _node_type_value(vulnerable_source) == EntityType.SERVER.value:
+                server_ids.append(vulnerable_source.id)
+            else:
+                for source_edge in incoming.get(vulnerable_source.id, []):
+                    if _rel_value(source_edge) == RelationshipType.DEPENDS_ON.value:
+                        source_parent = graph.nodes.get(source_edge.source)
+                        if source_parent is not None and _node_type_value(source_parent) == EntityType.SERVER.value:
+                            server_ids.append(source_parent.id)
+
+            for server_id in server_ids:
+                agent_ids = [
+                    edge.source
+                    for edge in incoming.get(server_id, [])
+                    if _rel_value(edge) == RelationshipType.USES.value
+                    and graph.nodes.get(edge.source) is not None
+                    and _node_type_value(graph.nodes[edge.source])
+                    in {EntityType.AGENT.value, EntityType.USER.value, EntityType.SERVICE_ACCOUNT.value}
+                ]
+                if not agent_ids:
+                    agent_ids = [server_id]
+
+                credentials = [
+                    graph.nodes[edge.target].label
+                    for edge in outgoing.get(server_id, [])
+                    if _rel_value(edge) == RelationshipType.EXPOSES_CRED.value and edge.target in graph.nodes
+                ]
+                tools = [
+                    graph.nodes[edge.target].label
+                    for edge in outgoing.get(server_id, [])
+                    if _rel_value(edge) == RelationshipType.PROVIDES_TOOL.value and edge.target in graph.nodes
+                ]
+
+                for agent_id in sorted(set(agent_ids)):
+                    hop_ids = [agent_id, server_id]
+                    if vulnerable_source.id != server_id:
+                        hop_ids.append(vulnerable_source.id)
+                    hop_ids.append(finding.id)
+                    key = (agent_id, server_id, vulnerable_source.id, finding.id)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+
+                    risk = _node_risk_100(finding)
+                    risk += min(10.0, len(credentials) * 3.0)
+                    risk += min(10.0, len(tools) * 0.75)
+                    paths.append(
+                        AttackPath(
+                            source=agent_id,
+                            target=finding.id,
+                            hops=hop_ids,
+                            edges=[],
+                            composite_risk=round(min(100.0, risk), 2),
+                            summary=(
+                                "Derived from graph topology: vulnerable package/server is reachable from an agent "
+                                "and inherits the server's credential/tool exposure."
+                            ),
+                            credential_exposure=sorted(set(credentials)),
+                            tool_exposure=sorted(set(tools)),
+                            vuln_ids=[finding.label or finding.id],
+                        )
+                    )
+
+    return sorted(
+        paths,
+        key=lambda path: (path.composite_risk, len(path.hops), len(path.credential_exposure), len(path.tool_exposure)),
+        reverse=True,
+    )
 
 
 def _bounded_env_int(name: str, default: int, *, minimum: int, maximum: int) -> int:
@@ -474,7 +599,7 @@ def _node_matches_query(
         entity_type = node.entity_type.value if hasattr(node.entity_type, "value") else str(node.entity_type)
         if entity_type not in entity_types:
             return False
-    if min_severity_rank and SEVERITY_RANK.get(node.severity.lower(), 0) < min_severity_rank:
+    if min_severity_rank and _is_finding_like_node(node) and SEVERITY_RANK.get(node.severity.lower(), 0) < min_severity_rank:
         return False
     if compliance_prefixes:
         prefixes = {tag.split("-")[0].upper() if "-" in tag else tag.upper() for tag in node.compliance_tags}
@@ -579,7 +704,7 @@ async def get_graph(
         paged_nodes, pagination = _paginate(all_nodes, offset, limit)
         paged_ids = {n.id for n in paged_nodes}
         paged_edges = [e for e in graph.edges if e.source in paged_ids and e.target in paged_ids]
-        attack_paths = [p.to_dict() for p in graph.attack_paths if p.hops and all(hop in paged_ids for hop in p.hops)]
+        attack_paths = [p.to_dict() for p in _derived_attack_paths(graph) if p.hops and all(hop in paged_ids for hop in p.hops)]
         interaction_risks = [
             r.to_dict() for r in graph.interaction_risks if r.agents and all(f"agent:{agent_name}" in paged_ids for agent_name in r.agents)
         ]
@@ -616,7 +741,7 @@ async def get_graph(
         tenant_id=tenant,
         node_ids=paged_ids,
     )
-    attack_paths = await _graph_store_call(
+    source_attack_paths = await _graph_store_call(
         graph_store.attack_paths_for_sources,
         scan_id=effective_scan_id,
         tenant_id=tenant,
@@ -628,7 +753,7 @@ async def get_graph(
         "created_at": created_at,
         "nodes": [n.to_dict() for n in paged_nodes],
         "edges": [e.to_dict() for e in paged_edges],
-        "attack_paths": [path.to_dict() for path in attack_paths],
+        "attack_paths": [path.to_dict() for path in source_attack_paths],
         "interaction_risks": [],
         "stats": await _graph_store_call(
             graph_store.snapshot_stats,
@@ -670,8 +795,9 @@ async def get_fix_first_graph_view(
         scan_id=requested_scan_id,
         tenant_id=tenant,
     )
+    available_paths = _derived_attack_paths(graph)
     ranked_paths = sorted(
-        (path for path in graph.attack_paths if _path_matches_focus(graph, path, cve=cve, package=package, agent=agent)),
+        (path for path in available_paths if _path_matches_focus(graph, path, cve=cve, package=package, agent=agent)),
         key=lambda path: (path.composite_risk, len(path.hops), len(path.credential_exposure), len(path.tool_exposure)),
         reverse=True,
     )
@@ -683,7 +809,7 @@ async def get_fix_first_graph_view(
         "created_at": graph.created_at,
         "cards": cards,
         "summary": {
-            "total_paths": len(graph.attack_paths),
+            "total_paths": len(available_paths),
             "matched_paths": len(ranked_paths),
             "returned_paths": len(cards),
             "highest_risk": cards[0]["attack_path"]["composite_risk"] if cards else 0.0,
@@ -732,6 +858,16 @@ async def get_graph_attack_paths(
         offset=offset,
         limit=limit,
     )
+    if total == 0:
+        graph = await _graph_store_call(
+            graph_store.load_graph,
+            scan_id=effective_scan_id,
+            tenant_id=tenant,
+        )
+        derived_paths = _derived_attack_paths(graph)
+        total = len(derived_paths)
+        paths = derived_paths[offset : offset + limit]
+        created_at = graph.created_at
     hop_ids = {hop for path in paths for hop in path.hops}
     nodes = await _graph_store_call(
         graph_store.nodes_by_ids,
@@ -739,6 +875,17 @@ async def get_graph_attack_paths(
         tenant_id=tenant,
         node_ids=hop_ids,
     )
+    stats = await _graph_store_call(
+        graph_store.snapshot_stats,
+        scan_id=effective_scan_id,
+        tenant_id=tenant,
+    )
+    if total and int(stats.get("attack_path_count") or 0) == 0:
+        stats = {
+            **stats,
+            "attack_path_count": total,
+            "max_attack_path_risk": max((path.composite_risk for path in paths), default=0.0),
+        }
     return {
         "scan_id": effective_scan_id,
         "tenant_id": tenant,
@@ -747,11 +894,7 @@ async def get_graph_attack_paths(
         "edges": [],
         "attack_paths": [path.to_dict() for path in paths],
         "interaction_risks": [],
-        "stats": await _graph_store_call(
-            graph_store.snapshot_stats,
-            scan_id=effective_scan_id,
-            tenant_id=tenant,
-        ),
+        "stats": stats,
         "pagination": _page_meta(total, offset, limit),
     }
 

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -43,13 +43,15 @@ router = APIRouter()
 _proxy_alerts: deque[dict] = deque(maxlen=1000)
 _proxy_alerts_total: int = 0
 _proxy_metrics: dict | None = None
+_proxy_metrics_by_tenant: dict[str, dict] = {}
 
 
 def push_proxy_alert(alert: dict) -> None:
     """Called by the proxy to record a runtime alert (in-process path)."""
     global _proxy_alerts_total
     sanitized = sanitize_sensitive_payload(alert)
-    _proxy_alerts.append(sanitized if isinstance(sanitized, dict) else {})
+    safe = redact_for_persistence(sanitized, EvidenceTier.SAFE_TO_STORE)
+    _proxy_alerts.append(safe if isinstance(safe, dict) else {})
     _proxy_alerts_total += 1
 
 
@@ -58,6 +60,24 @@ def push_proxy_metrics(metrics: dict) -> None:
     global _proxy_metrics
     sanitized = sanitize_sensitive_payload(metrics)
     _proxy_metrics = sanitized if isinstance(sanitized, dict) else {}
+    tenant_id = str(_proxy_metrics.get("tenant_id") or "default")
+    _proxy_metrics_by_tenant[tenant_id] = dict(_proxy_metrics)
+
+
+def _request_tenant_id(request: Request) -> str:
+    """Return the authenticated tenant for HTTP proxy endpoints."""
+    return str(getattr(request.state, "tenant_id", "default") or "default")
+
+
+def _alert_visible_to_tenant(alert: dict, tenant_id: str) -> bool:
+    """Scope process-wide proxy alerts to the authenticated tenant.
+
+    Historical single-user/local records may not have a tenant tag. Keep those
+    visible only to the default tenant so they do not leak into authenticated
+    customer tenants on shared deployments.
+    """
+    alert_tenant = str(alert.get("tenant_id") or "default")
+    return alert_tenant == tenant_id
 
 
 @router.post("/v1/proxy/audit", tags=["proxy"])
@@ -127,6 +147,7 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         summary.setdefault("session_id", session_id)
         summary.setdefault("request_id", request_id)
         summary.setdefault("trace_id", trace_id)
+        summary.setdefault("tenant_id", tenant_id)
         push_proxy_metrics(summary)
 
     if analytics_events:
@@ -197,7 +218,9 @@ def _read_alerts_from_log(path: _Path) -> list[dict]:
                     if record.get("type") == "runtime_alert":
                         sanitized = sanitize_sensitive_payload(record)
                         if isinstance(sanitized, dict):
-                            alerts.append(sanitized)
+                            safe = redact_for_persistence(sanitized, EvidenceTier.SAFE_TO_STORE)
+                            if isinstance(safe, dict):
+                                alerts.append(safe)
                 except (ValueError, KeyError):
                     continue
     except OSError:
@@ -205,12 +228,14 @@ def _read_alerts_from_log(path: _Path) -> list[dict]:
     return alerts
 
 
-def _load_proxy_alerts() -> list[dict]:
+def _load_proxy_alerts(tenant_id: str = "default") -> list[dict]:
     """Return in-memory alerts, or fall back to the configured audit log."""
     log_path = _get_configured_log_path()
     if log_path and not _proxy_alerts:
-        return _read_alerts_from_log(log_path)
-    return list(_proxy_alerts)
+        alerts = _read_alerts_from_log(log_path)
+    else:
+        alerts = list(_proxy_alerts)
+    return [alert for alert in alerts if _alert_visible_to_tenant(alert, tenant_id)]
 
 
 def _summarize_proxy_alerts(alerts: list[dict]) -> dict:
@@ -248,7 +273,7 @@ def _summarize_proxy_alerts(alerts: list[dict]) -> dict:
     }
 
 
-def _read_metrics_from_log(path: _Path) -> dict | None:
+def _read_metrics_from_log(path: _Path, tenant_id: str = "default") -> dict | None:
     """Read the last proxy_summary record from a JSONL audit log."""
     import json as _json
 
@@ -263,7 +288,7 @@ def _read_metrics_from_log(path: _Path) -> dict | None:
                     continue
                 try:
                     record = _json.loads(line)
-                    if record.get("type") == "proxy_summary":
+                    if record.get("type") == "proxy_summary" and _alert_visible_to_tenant(record, tenant_id):
                         last_summary = record
                 except (ValueError, KeyError):
                     continue
@@ -276,25 +301,30 @@ def _read_metrics_from_log(path: _Path) -> dict | None:
 
 
 @router.get("/v1/proxy/status", tags=["proxy"])
-async def proxy_status() -> dict:
+async def proxy_status(request: Request) -> dict:
     """Get runtime proxy metrics.
 
     Returns the latest proxy metrics summary.  Reads from the in-process
     buffer (populated by ``push_proxy_metrics``) or from the audit log
     configured via the ``AGENT_BOM_LOG`` environment variable.
     """
+    tenant_id = _request_tenant_id(request)
     metrics: dict | None = None
     if _proxy_metrics is not None:
-        metrics = dict(_proxy_metrics)
+        tenant_metrics = _proxy_metrics_by_tenant.get(tenant_id)
+        if tenant_metrics is not None:
+            metrics = dict(tenant_metrics)
+        elif _alert_visible_to_tenant(_proxy_metrics, tenant_id):
+            metrics = dict(_proxy_metrics)
     else:
         log_path = _get_configured_log_path()
         if log_path:
-            metrics = _read_metrics_from_log(log_path)
+            metrics = _read_metrics_from_log(log_path, tenant_id)
             if metrics is not None:
                 metrics = dict(metrics)
 
     if metrics is not None:
-        alert_summary = _summarize_proxy_alerts(_load_proxy_alerts())
+        alert_summary = _summarize_proxy_alerts(_load_proxy_alerts(tenant_id))
         metrics["alert_summary"] = {key: value for key, value in alert_summary.items() if key != "recent_alerts"}
         metrics["recent_alerts"] = alert_summary["recent_alerts"]
         return metrics
@@ -307,6 +337,7 @@ async def proxy_status() -> dict:
 
 @router.get("/v1/proxy/alerts", tags=["proxy"])
 async def proxy_alerts(
+    request: Request,
     severity: str | None = None,
     detector: str | None = None,
     limit: int = Query(default=100, ge=1, le=1000, description="Max alerts to return (1-1000)"),
@@ -321,7 +352,8 @@ async def proxy_alerts(
         detector: Filter by detector name.
         limit: Maximum number of alerts to return (default 100).
     """
-    alerts = _load_proxy_alerts()
+    tenant_id = _request_tenant_id(request)
+    alerts = _load_proxy_alerts(tenant_id)
 
     # Apply filters
     if severity:
@@ -455,7 +487,7 @@ async def ws_proxy_metrics(websocket: WebSocket) -> None:
 
             # Count alerts in last 60 seconds
             cutoff = now - 60
-            recent_alerts = [a for a in _proxy_alerts if a.get("ts", 0) > cutoff]
+            recent_alerts = [a for a in _proxy_alerts if a.get("ts", 0) > cutoff and _alert_visible_to_tenant(a, "default")]
 
             await websocket.send_json(
                 {
@@ -508,6 +540,8 @@ async def ws_proxy_alerts(websocket: WebSocket) -> None:
             if current > seen:
                 new_count = min(current - seen, len(_proxy_alerts))
                 for alert in list(_proxy_alerts)[-new_count:]:
+                    if not _alert_visible_to_tenant(alert, "default"):
+                        continue
                     await websocket.send_json(alert)
                 seen = current
             await asyncio.sleep(0.25)

--- a/tests/test_api_proxy_scorecard.py
+++ b/tests/test_api_proxy_scorecard.py
@@ -17,6 +17,7 @@ from agent_bom.api.server import (
     push_proxy_alert,
     push_proxy_metrics,
 )
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
 
 # ── /v1/proxy/status ───────────────────────────────────────────────────────
 
@@ -245,6 +246,115 @@ def test_proxy_alert_api_redacts_runtime_alert_details():
     assert "/Users/alice" not in encoded
     assert "prod-secrets" not in encoded
     proxy_mod._proxy_alerts.clear()
+
+
+def test_proxy_alerts_are_tenant_scoped_for_http_reads():
+    import agent_bom.api.routes.proxy as proxy_mod
+    from agent_bom.api.server import configure_api
+
+    enable_trusted_proxy_env()
+    configure_api(api_key=None)
+    proxy_mod._proxy_alerts.clear()
+    proxy_mod._proxy_metrics = None
+    try:
+        client = TestClient(app)
+        alpha_headers = proxy_headers(role="admin", tenant="tenant-alpha")
+        beta_headers = proxy_headers(role="admin", tenant="tenant-beta")
+
+        assert (
+            client.post(
+                "/v1/proxy/audit",
+                headers=alpha_headers,
+                json={
+                    "source_id": "alpha-laptop",
+                    "session_id": "alpha-session",
+                    "alerts": [{"type": "runtime_alert", "detector": "cred", "severity": "critical", "message": "alpha-only"}],
+                    "summary": {"type": "proxy_summary", "total_tool_calls": 7, "total_blocked": 1},
+                },
+            ).status_code
+            == 200
+        )
+        assert (
+            client.post(
+                "/v1/proxy/audit",
+                headers=beta_headers,
+                json={
+                    "source_id": "beta-laptop",
+                    "session_id": "beta-session",
+                    "alerts": [{"type": "runtime_alert", "detector": "arg", "severity": "high", "message": "beta-only"}],
+                    "summary": {"type": "proxy_summary", "total_tool_calls": 3, "total_blocked": 0},
+                },
+            ).status_code
+            == 200
+        )
+
+        alpha_alerts = client.get("/v1/proxy/alerts", headers=alpha_headers).json()
+        beta_alerts = client.get("/v1/proxy/alerts", headers=beta_headers).json()
+        assert alpha_alerts["count"] == 1
+        assert beta_alerts["count"] == 1
+        assert alpha_alerts["alerts"][0]["source_id"] == "alpha-laptop"
+        assert beta_alerts["alerts"][0]["source_id"] == "beta-laptop"
+        assert "beta-laptop" not in json.dumps(alpha_alerts)
+        assert "alpha-laptop" not in json.dumps(beta_alerts)
+
+        alpha_status = client.get("/v1/proxy/status", headers=alpha_headers).json()
+        beta_status = client.get("/v1/proxy/status", headers=beta_headers).json()
+        assert alpha_status["source_id"] == "alpha-laptop"
+        assert beta_status["source_id"] == "beta-laptop"
+        assert alpha_status["alert_summary"]["total_alerts"] == 1
+        assert beta_status["alert_summary"]["total_alerts"] == 1
+    finally:
+        proxy_mod._proxy_alerts.clear()
+        proxy_mod._proxy_metrics = None
+        proxy_mod._proxy_metrics_by_tenant.clear()
+        disable_trusted_proxy_env()
+        configure_api(api_key=None)
+
+
+def test_proxy_alerts_drop_tier_b_replay_only_fields():
+    import agent_bom.api.routes.proxy as proxy_mod
+
+    proxy_mod._proxy_alerts.clear()
+    proxy_mod._proxy_metrics = None
+    try:
+        payload = {
+            "source_id": "laptop-1",
+            "session_id": "sess-1",
+            "alerts": [
+                {
+                    "type": "runtime_alert",
+                    "detector": "argument_analyzer",
+                    "severity": "critical",
+                    "message": "raw prompt copied from workspace",
+                    "tool_name": "shell.exec",
+                    "details": {
+                        "prompt": "summarize /Users/alice/customer-contract.txt",
+                        "tool_output": "customer secret output",
+                        "args": ["cat", "/Users/alice/customer-contract.txt"],
+                        "url": "https://example.com/full/path?token=secret",
+                        "hostname": "mcp.internal.example",
+                        "status_code": 403,
+                    },
+                }
+            ],
+        }
+        resp = TestClient(app).post("/v1/proxy/audit", json=payload)
+        assert resp.status_code == 200
+
+        data = TestClient(app).get("/v1/proxy/alerts").json()
+        encoded = json.dumps(data)
+        assert "shell.exec" in encoded
+        assert "mcp.internal.example" in encoded
+        assert "403" in encoded
+        assert "prompt" not in encoded
+        assert "tool_output" not in encoded
+        assert "customer-contract" not in encoded
+        assert "token=secret" not in encoded
+        assert "raw prompt copied" not in encoded
+    finally:
+        proxy_mod._proxy_alerts.clear()
+        proxy_mod._proxy_metrics = None
+        proxy_mod._proxy_metrics_by_tenant.clear()
 
 
 def test_proxy_audit_ingest_is_idempotent():

--- a/tests/test_audit_round2.py
+++ b/tests/test_audit_round2.py
@@ -277,7 +277,8 @@ def test_read_alerts_from_log_with_valid_data():
         result = _read_alerts_from_log(Path(f.name))
 
     assert len(result) == 2
-    assert result[0]["message"] == "test alert"
+    assert result[0]["type"] == "runtime_alert"
+    assert "message" not in result[0]
 
 
 # ── ThreadPoolExecutor sizing ────────────────────────────────────────────────

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -934,6 +934,12 @@ class TestGraphStoreBackendSelection:
         assert body["summary"]["matched_paths"] == 1
         assert body["cards"][0]["rank"] == 1
         assert body["cards"][0]["title"].startswith("CVE-2026-1 via agent-a")
+        assert {node["id"] for node in body["cards"][0]["nodes"]} == {
+            "agent:a",
+            "server:a:fs",
+            "pkg:npm:express",
+            "vuln:cve",
+        }
         assert body["cards"][0]["affected"]["agents"] == ["agent-a"]
         assert body["cards"][0]["affected"]["packages"] == ["express"]
         assert {reason["kind"] for reason in body["cards"][0]["risk_reasons"]} >= {
@@ -943,6 +949,49 @@ class TestGraphStoreBackendSelection:
         }
         assert body["cards"][0]["next_actions"][0]["href"] == "/findings?cve=CVE-2026-1"
         assert any(call[0] == "load_graph" for call in recording_graph_store.calls)
+
+    def test_fix_first_graph_view_derives_paths_when_snapshot_has_topology_but_no_path_rows(self, recording_graph_store):
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:a:fs", entity_type=EntityType.SERVER, label="mcp-fs"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="pkg:npm:form-data", entity_type=EntityType.PACKAGE, label="form-data"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="cred:aws", entity_type=EntityType.CREDENTIAL, label="AWS_SECRET_ACCESS_KEY"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="tool:shell", entity_type=EntityType.TOOL, label="run_shell"))
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="vuln:cve",
+                entity_type=EntityType.VULNERABILITY,
+                label="CVE-2026-1",
+                severity="critical",
+                risk_score=9.8,
+            )
+        )
+        recording_graph_store.graph.add_edge(UnifiedEdge(source="agent:a", target="server:a:fs", relationship=RelationshipType.USES))
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="server:a:fs", target="pkg:npm:form-data", relationship=RelationshipType.DEPENDS_ON)
+        )
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="pkg:npm:form-data", target="vuln:cve", relationship=RelationshipType.VULNERABLE_TO)
+        )
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="server:a:fs", target="cred:aws", relationship=RelationshipType.EXPOSES_CRED)
+        )
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="server:a:fs", target="tool:shell", relationship=RelationshipType.PROVIDES_TOOL)
+        )
+        client = TestClient(app)
+
+        response = client.get("/v1/graph/views/fix-first", params={"scan_id": "store-scan"})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["summary"]["total_paths"] == 1
+        assert body["cards"][0]["affected"]["findings"] == ["CVE-2026-1"]
+        assert body["cards"][0]["affected"]["credentials"] == ["AWS_SECRET_ACCESS_KEY"]
+        assert body["cards"][0]["affected"]["tools"] == ["run_shell"]
+
+        queue = client.get("/v1/graph/attack-paths", params={"scan_id": "store-scan", "limit": 5}).json()
+        assert queue["pagination"]["total"] == 1
+        assert queue["stats"]["attack_path_count"] == 1
+        assert queue["attack_paths"][0]["hops"] == ["agent:a", "server:a:fs", "pkg:npm:form-data", "vuln:cve"]
 
     def test_graph_overview_filtered_page_stays_store_backed(self, recording_graph_store):
         recording_graph_store.graph.add_node(
@@ -1024,15 +1073,25 @@ class TestGraphStoreBackendSelection:
 
         persisted = UnifiedGraph(scan_id="job-123", tenant_id="default")
         persisted.add_node(UnifiedNode(id="agent:scan", entity_type=EntityType.AGENT, label="scan-agent"))
+        tenant_context: list[tuple[str, str]] = []
 
         monkeypatch.setattr("agent_bom.api.pipeline._get_graph_store", lambda: recording_graph_store)
         monkeypatch.setattr("agent_bom.graph.builder.build_unified_graph_from_report", lambda report_json, scan_id, tenant_id: persisted)
         monkeypatch.setattr("agent_bom.graph.webhooks.compute_delta_alerts", lambda previous, current: [])
+        monkeypatch.setattr(
+            "agent_bom.api.postgres_store.set_current_tenant",
+            lambda tenant_id: tenant_context.append(("set", tenant_id)) or "tenant-token",
+        )
+        monkeypatch.setattr(
+            "agent_bom.api.postgres_store.reset_current_tenant",
+            lambda token: tenant_context.append(("reset", token)),
+        )
 
         job = SimpleNamespace(job_id="job-123", tenant_id="default", progress=[])
         _persist_graph_snapshot(job, {"scan_id": "job-123"})
 
         assert ("save_graph", "job-123", "default") in recording_graph_store.calls
+        assert tenant_context == [("set", "default"), ("reset", "tenant-token")]
 
     def test_graph_search_uses_store_native_query(self, recording_graph_store):
         recording_graph_store.graph.add_node(UnifiedNode(id="server:a", entity_type=EntityType.SERVER, label="agent-a server"))
@@ -1277,6 +1336,57 @@ class TestGraphStoreBackendSelection:
         assert body["attack_paths"][0]["summary"] == "agent-a -> server-s -> CVE-2026-1"
         assert any(call[0] == "traverse_subgraph" for call in recording_graph_store.calls)
         assert not any(call[0] == "load_graph" for call in recording_graph_store.calls)
+
+    def test_graph_query_severity_filter_preserves_non_finding_context(self, recording_graph_store):
+        recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
+        recording_graph_store.graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="vuln:low",
+                entity_type=EntityType.VULNERABILITY,
+                label="CVE-2026-LOW",
+                severity="low",
+                severity_id=2,
+            )
+        )
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="vuln:critical",
+                entity_type=EntityType.VULNERABILITY,
+                label="CVE-2026-CRITICAL",
+                severity="critical",
+                severity_id=5,
+            )
+        )
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES, traversable=True)
+        )
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="server:s", target="vuln:low", relationship=RelationshipType.VULNERABLE_TO, traversable=True)
+        )
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="server:s", target="vuln:critical", relationship=RelationshipType.VULNERABLE_TO, traversable=True)
+        )
+        client = TestClient(app)
+
+        response = client.post(
+            "/v1/graph/query",
+            json={
+                "roots": ["agent:a"],
+                "direction": "forward",
+                "max_depth": 2,
+                "min_severity": "critical",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert {node["id"] for node in body["nodes"]} == {"agent:a", "server:s", "vuln:critical"}
+        assert {(edge["source"], edge["target"]) for edge in body["edges"]} == {
+            ("agent:a", "server:s"),
+            ("server:s", "vuln:critical"),
+        }
 
     def test_graph_get_rejects_unknown_relationship(self, recording_graph_store):
         client = TestClient(app)

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -137,7 +137,15 @@ function PulseStyles() {
   );
 }
 
-function getConnectedIds(nodeId: string, edges: Edge[]): Set<string> {
+const FOCUS_NEIGHBORHOOD_DEPTH = 2;
+const FOCUS_NEIGHBORHOOD_NODE_LIMIT = 80;
+
+function getLocalNeighborhoodIds(
+  nodeId: string,
+  edges: Edge[],
+  maxDepth = FOCUS_NEIGHBORHOOD_DEPTH,
+  maxNodes = FOCUS_NEIGHBORHOOD_NODE_LIMIT,
+): Set<string> {
   const adjacency = new Map<string, Set<string>>();
   for (const edge of edges) {
     addNeighbor(adjacency, edge.source, edge.target);
@@ -145,13 +153,15 @@ function getConnectedIds(nodeId: string, edges: Edge[]): Set<string> {
   }
 
   const visited = new Set<string>([nodeId]);
-  const queue = [nodeId];
+  const queue = [{ id: nodeId, depth: 0 }];
   while (queue.length > 0) {
     const current = queue.shift()!;
-    for (const neighbor of adjacency.get(current) ?? []) {
+    if (current.depth >= maxDepth) continue;
+    for (const neighbor of adjacency.get(current.id) ?? []) {
       if (visited.has(neighbor)) continue;
       visited.add(neighbor);
-      queue.push(neighbor);
+      if (visited.size >= maxNodes) return visited;
+      queue.push({ id: neighbor, depth: current.depth + 1 });
     }
   }
 
@@ -803,8 +813,8 @@ function GraphPageInner() {
   // survives until the operator clicks the empty pane or pins another
   // node. Hover never overrides a pin.
   const activeFocusId = pinnedFocusId ?? hoveredNodeId;
-  const connectedIds = useMemo(
-    () => (activeFocusId ? getConnectedIds(activeFocusId, layoutEdges) : null),
+  const localNeighborhoodIds = useMemo(
+    () => (activeFocusId ? getLocalNeighborhoodIds(activeFocusId, layoutEdges) : null),
     [activeFocusId, layoutEdges],
   );
 
@@ -849,10 +859,10 @@ function GraphPageInner() {
         };
       });
     }
-    if (!connectedIds) return layoutNodes;
+    if (!localNeighborhoodIds) return layoutNodes;
     return layoutNodes.map((node) => {
       const isFocused = node.id === activeFocusId;
-      const isConnected = connectedIds.has(node.id);
+      const isConnected = localNeighborhoodIds.has(node.id);
       const dimmed = !isConnected;
       return {
         ...node,
@@ -864,7 +874,7 @@ function GraphPageInner() {
         },
       };
     });
-  }, [layoutNodes, connectedIds, attackPathNodeIds, activeFocusId]);
+  }, [layoutNodes, localNeighborhoodIds, attackPathNodeIds, activeFocusId]);
 
   const displayEdges = useMemo(() => {
     if (attackPathEdgeKeys) {
@@ -884,15 +894,15 @@ function GraphPageInner() {
         };
       });
     }
-    if (!connectedIds) return layoutEdges;
+    if (!localNeighborhoodIds) return layoutEdges;
     return layoutEdges.map((edge) => ({
       ...edge,
       style: {
         ...edge.style,
-        opacity: connectedIds.has(edge.source) && connectedIds.has(edge.target) ? 1 : 0.12,
+        opacity: localNeighborhoodIds.has(edge.source) && localNeighborhoodIds.has(edge.target) ? 1 : 0.12,
       },
     }));
-  }, [layoutEdges, connectedIds, attackPathEdgeKeys]);
+  }, [layoutEdges, localNeighborhoodIds, attackPathEdgeKeys]);
 
   const legendItems = useMemo(
     () => legendItemsForVisibleGraph(displayNodes, displayEdges),
@@ -1040,7 +1050,6 @@ function GraphPageInner() {
           dynamic_only: filters.runtimeMode === "dynamic",
           include_roots: true,
           include_attack_paths: true,
-          min_severity: filters.severity ?? "",
           relationship_types: serverRelationships,
         });
         setGraphData(queryResponseToGraphResponse(response));
@@ -1058,7 +1067,7 @@ function GraphPageInner() {
         setLoadingGraph(false);
       }
     },
-    [filters.runtimeMode, filters.severity, filters.vulnOnly, flowNodeDataById, selectedScanId, serverRelationships],
+    [filters.runtimeMode, filters.vulnOnly, flowNodeDataById, selectedScanId, serverRelationships],
   );
 
   const clearInvestigationMode = useCallback(() => {
@@ -1413,7 +1422,7 @@ function GraphPageInner() {
             </div>
 
             <div className="mt-3 flex gap-3 overflow-x-auto pb-1">
-              {attackPaths.slice(0, 6).map((path) => {
+              {attackPaths.map((path) => {
                 const key = attackPathKey(path);
                 const pathNodes = toAttackCardNodes(path, graphNodeById);
                 if (pathNodes.length === 0) return null;

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -45,35 +45,6 @@ import {
   toAttackCardNodes,
 } from "@/lib/attack-paths";
 
-function emptyGraphResponse(scanId: string): UnifiedGraphResponse {
-  return {
-    scan_id: scanId,
-    tenant_id: "",
-    created_at: "",
-    nodes: [],
-    edges: [],
-    attack_paths: [],
-    interaction_risks: [],
-    stats: {
-      total_nodes: 0,
-      total_edges: 0,
-      node_types: {},
-      severity_counts: {},
-      relationship_types: {},
-      attack_path_count: 0,
-      interaction_risk_count: 0,
-      max_attack_path_risk: 0,
-      highest_interaction_risk: 0,
-    },
-    pagination: {
-      total: 0,
-      offset: 0,
-      limit: 0,
-      has_more: false,
-    },
-  };
-}
-
 function SecurityGraphPageContent() {
   const searchParams = useSearchParams();
   const [snapshots, setSnapshots] = useState<GraphSnapshot[]>([]);
@@ -84,6 +55,7 @@ function SecurityGraphPageContent() {
   const [loadingSnapshots, setLoadingSnapshots] = useState(true);
   const [loadingGraph, setLoadingGraph] = useState(false);
   const [apiError, setApiError] = useState<string | null>(null);
+  const [graphLoadError, setGraphLoadError] = useState<string | null>(null);
   const [apiErrorKind, setApiErrorKind] = useState<"network" | "auth" | "forbidden">("network");
   const [selectedAttackPathKey, setSelectedAttackPathKey] = useState<string | null>(null);
   const [focusApplied, setFocusApplied] = useState(false);
@@ -123,12 +95,15 @@ function SecurityGraphPageContent() {
             : snapshotList[0]?.scan_id ?? "";
         setSelectedScanId(initialScanId);
         setApiError(null);
+        setGraphLoadError(null);
       } catch (error) {
         if (cancelled) return;
         setApiError(error instanceof Error ? error.message : "Failed to load graph snapshots");
         setApiErrorKind(_classifyGraphErrorKind(error));
         setSnapshots([]);
         setGraphData(null);
+        setFixFirstView(null);
+        setGraphLoadError(null);
       } finally {
         if (!cancelled) setLoadingSnapshots(false);
       }
@@ -145,6 +120,7 @@ function SecurityGraphPageContent() {
       setGraphData(null);
       setFixFirstView(null);
       setSelectedAttackPathKey(null);
+      setGraphLoadError(null);
       return;
     }
 
@@ -170,11 +146,13 @@ function SecurityGraphPageContent() {
         setGraphData(graph);
         setFixFirstView(view);
         setApiError(null);
+        setGraphLoadError(null);
       } catch (error) {
         if (cancelled) return;
-        setGraphData(emptyGraphResponse(selectedScanId));
+        setGraphData(null);
         setFixFirstView(null);
-        setApiError(error instanceof Error ? error.message : "Failed to load security graph");
+        setGraphLoadError(error instanceof Error ? error.message : "Failed to load security graph");
+        setApiErrorKind(_classifyGraphErrorKind(error));
       } finally {
         if (!cancelled) setLoadingGraph(false);
       }
@@ -191,12 +169,17 @@ function SecurityGraphPageContent() {
     [snapshots, selectedScanId],
   );
 
-  const graphNodeById = useMemo(
-    () => new Map((graphData?.nodes ?? []).map((node) => [node.id, node])),
-    [graphData?.nodes],
-  );
-
   const fixFirstCards = useMemo(() => fixFirstView?.cards ?? [], [fixFirstView?.cards]);
+
+  const graphNodeById = useMemo(() => {
+    const nodes = new Map((graphData?.nodes ?? []).map((node) => [node.id, node]));
+    for (const card of fixFirstCards) {
+      for (const node of card.nodes ?? []) {
+        nodes.set(node.id, node);
+      }
+    }
+    return nodes;
+  }, [fixFirstCards, graphData?.nodes]);
 
   const cardByPathKey = useMemo(() => {
     const next = new Map<string, FixFirstPathCard>();
@@ -297,6 +280,19 @@ function SecurityGraphPageContent() {
       ],
     };
   }, [focusLabel, hasFocusContext]);
+
+  const graphErrorState = useMemo(() => {
+    const detail = graphLoadError ?? "The graph API did not return attack-path data for this snapshot.";
+    return {
+      title: "Cannot load attack paths for this snapshot",
+      detail,
+      suggestions: [
+        "Retry the graph load after confirming the API is reachable.",
+        "Open the full graph only after this error clears.",
+        "Check API logs for the rejected or failed attack-path request.",
+      ],
+    };
+  }, [graphLoadError]);
 
   const loadingGraphMessage = focusLabel
     ? `Loading attack-path candidates for ${focusLabel} from the persisted graph.`
@@ -484,6 +480,32 @@ function SecurityGraphPageContent() {
           <Loader2 className="mx-auto mb-3 h-6 w-6 animate-spin text-sky-400" />
           {loadingGraphMessage}
         </section>
+      ) : graphLoadError ? (
+        <section className="rounded-3xl border border-red-900/60 bg-red-950/10 p-4">
+          <GraphEmptyState
+            title={graphErrorState.title}
+            detail={graphErrorState.detail}
+            suggestions={graphErrorState.suggestions}
+          />
+          <div className="mt-4 flex flex-wrap gap-3 border-t border-red-900/40 pt-4">
+            <Link
+              href={fullGraphHref}
+              className="inline-flex items-center gap-2 rounded-full border border-red-900/60 bg-red-950/30 px-3 py-1.5 text-xs text-red-200 transition hover:border-red-700"
+            >
+              Retry in full graph
+              <GitBranch className="h-3.5 w-3.5" />
+            </Link>
+            {hasFocusContext && (
+              <Link
+                href={resetFocusHref}
+                className="inline-flex items-center gap-2 rounded-full border border-red-900/60 bg-red-950/30 px-3 py-1.5 text-xs text-red-200 transition hover:border-red-700"
+              >
+                Clear focus
+                <ArrowRight className="h-3.5 w-3.5" />
+              </Link>
+            )}
+          </div>
+        </section>
       ) : attackPaths.length === 0 ? (
         <section className="rounded-3xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
           <GraphEmptyState
@@ -570,12 +592,12 @@ function SecurityGraphPageContent() {
             </div>
 
             <div
-              className="mt-4 flex gap-3 overflow-x-auto pb-1 outline-none"
+              className="mt-4 grid max-w-full grid-cols-1 gap-3 outline-none md:grid-cols-2 xl:grid-cols-3"
               tabIndex={0}
               onKeyDown={handleAttackPathQueueKeyDown}
               aria-label="Attack path queue"
             >
-              {attackPaths.slice(0, 8).map((path) => {
+              {attackPaths.map((path) => {
                 const key = attackPathKey(path);
                 const card = cardByPathKey.get(key);
                 const pathNodes = toAttackCardNodes(path, graphNodeById);
@@ -584,7 +606,7 @@ function SecurityGraphPageContent() {
                 return (
                   <div
                     key={key}
-                    className={`min-w-[380px] rounded-2xl border bg-[color:var(--surface-elevated)] p-3 transition ${
+                    className={`min-w-0 rounded-2xl border bg-[color:var(--surface-elevated)] p-3 transition ${
                       active
                         ? "border-orange-400/70 ring-2 ring-orange-400/70 ring-offset-2 ring-offset-zinc-950"
                         : "border-[color:var(--border-subtle)]"

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -117,6 +117,7 @@ export interface FixFirstPathCard {
   title: string;
   summary: string;
   attack_path: AttackPath;
+  nodes?: UnifiedNode[] | undefined;
   sequence_labels: string[];
   risk_reasons: FixFirstRiskReason[];
   next_actions: FixFirstAction[];


### PR DESCRIPTION
## Summary

Release-readiness fixes from the end-to-end graph/security audit:

- make `/security-graph` and `/graph` behave like fix-first security investigation surfaces instead of page-slice browsers
- derive attack paths for persisted snapshots that have topology but no materialized `attack_paths` rows, so old self-scan data still powers the fix-first queue
- prevent proxy runtime alerts from leaking across tenants and enforce safe-to-store evidence redaction on proxy alert reads
- bind background graph persistence to the scan job tenant before Postgres/RLS-backed graph store calls
- refresh deployment/security/product docs so the README/docs story matches the current code and avoids stale rollout diagrams/claims

## Root Cause

The merged graph work improved layout and APIs, but hands-on testing found release blockers:

- historical snapshots could show `0` attack paths even though agent -> server -> package -> CVE topology existed
- `/security-graph` could widen to several thousand pixels because fixed-width attack-path cards sat in a horizontal queue
- proxy alert/status APIs read from a process-wide ring buffer without tenant filtering
- safe-to-store runtime surfaces still needed stricter Tier-B field removal
- graph persistence in worker threads relied on request-local tenant context that does not cross the executor boundary

## Validation

- `uv run pytest -q` -> `9557 passed, 23 skipped`
- `npm run build` -> passed
- `npm run typecheck` -> passed
- `npm run lint` -> passed
- `npm run test:run` -> `26 files / 177 tests passed`
- `mkdocs build --strict` -> passed
- `uv run ruff check ...` -> passed
- `git diff --check` -> passed
- pre-commit on commit -> ruff, ruff-format, mypy, bandit, env-var drift passed

## Hands-on Screenshots

Saved locally under:

`/Users/mohamedsaad/Desktop/agent-bom-audit-screenshots/`

Notable captures:

- `security-graph-desktop.png` - fix-first queue wraps cleanly at 1440px and shows 54 matched attack paths
- `security-graph-mobile.png` - mobile queue and selected-path details remain readable at 390px
- `graph-desktop.png`
- `graph-mobile.png`
- `dashboard-desktop.png`

## Notes

This does not tag or release. It is intentionally a pre-tag hardening PR.