### PR TITLE
fix(graph): preserve semantic layers in schema codegen

### DIFF
--- a/src/agent_bom/graph/types.py
+++ b/src/agent_bom/graph/types.py
@@ -114,5 +114,6 @@ class GraphLayout(str, Enum):
     DAGRE = "dagre"
     FORCE = "force"
     RADIAL = "radial"
+    SANKEY = "sankey"
     HIERARCHICAL = "hierarchical"
     GRID = "grid"

--- a/tests/test_graph_schema_ui_parity.py
+++ b/tests/test_graph_schema_ui_parity.py
@@ -3,33 +3,42 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from agent_bom.graph import FINDING_ENTITY_TYPES, EntityType, GraphLayout, RelationshipType
+from agent_bom.graph import FINDING_ENTITY_TYPES, EntityType, GraphLayout, GraphSemanticLayer, RelationshipType
 from agent_bom.graph.container import GraphFilterOptions
 from agent_bom.graph.severity import SEVERITY_RANK, SEVERITY_RISK_SCORE, SEVERITY_TO_OCSF, OCSFSeverity
 
 ROOT = Path(__file__).resolve().parent.parent
 TS_GRAPH_SCHEMA = ROOT / "ui" / "lib" / "graph-schema.ts"
 TS_SOURCE = TS_GRAPH_SCHEMA.read_text(encoding="utf-8")
+TS_GENERATED_GRAPH_SCHEMA = ROOT / "ui" / "lib" / "graph-schema.generated.ts"
+TS_GENERATED_SOURCE = TS_GENERATED_GRAPH_SCHEMA.read_text(encoding="utf-8")
 
 
-def _block_after(marker: str, opener: str, closer: str) -> str:
-    start = TS_SOURCE.index(marker)
-    open_idx = TS_SOURCE.index(opener, start)
+def _block_after(marker: str, opener: str, closer: str, *, source: str = TS_SOURCE) -> str:
+    start = source.index(marker)
+    open_idx = source.index(opener, start)
     depth = 0
-    for idx in range(open_idx, len(TS_SOURCE)):
-        char = TS_SOURCE[idx]
+    for idx in range(open_idx, len(source)):
+        char = source[idx]
         if char == opener:
             depth += 1
         elif char == closer:
             depth -= 1
             if depth == 0:
-                return TS_SOURCE[open_idx + 1 : idx]
+                return source[open_idx + 1 : idx]
     raise AssertionError(f"Could not parse block for {marker}")
 
 
-def _ts_enum_values(name: str) -> set[str]:
-    body = _block_after(f"export enum {name}", "{", "}")
+def _ts_enum_values(name: str, *, source: str = TS_SOURCE) -> set[str]:
+    body = _block_after(f"export enum {name}", "{", "}", source=source)
     return {value for _key, value in re.findall(r"(\w+)\s*=\s*\"([^\"]+)\"", body)}
+
+
+def _ts_const_string_list(name: str, *, source: str = TS_SOURCE) -> list[str]:
+    start = source.index(f"export const {name}")
+    assignment = source.index("=", start)
+    body = _block_after("=", "[", "]", source=source[assignment:])
+    return re.findall(r"\"([^\"]+)\"", body)
 
 
 def _ts_enum_mapping(name: str) -> dict[str, int]:
@@ -93,6 +102,12 @@ def test_ui_relationship_types_match_python_graph_schema():
 
 def test_ui_graph_layouts_match_python_graph_schema():
     assert _ts_enum_values("GraphLayout") == {layout.value for layout in GraphLayout}
+
+
+def test_generated_schema_semantic_layers_match_python_graph_schema():
+    expected = [layer.value for layer in GraphSemanticLayer]
+    assert _ts_enum_values("GraphSemanticLayer", source=TS_GENERATED_SOURCE) == set(expected)
+    assert _ts_const_string_list("GRAPH_SEMANTIC_LAYERS", source=TS_GENERATED_SOURCE) == expected
 
 
 def test_ui_severity_constants_match_python_graph_schema():

--- a/ui/components/scan-pipeline.tsx
+++ b/ui/components/scan-pipeline.tsx
@@ -29,7 +29,7 @@ import {
   Clock,
   SkipForward,
 } from "lucide-react";
-import { useDagreLayout } from "@/lib/use-dagre-layout";
+import { useSankeyLayout } from "@/lib/use-sankey-layout";
 import type { StepEvent, StepStatus } from "@/lib/api";
 import { PIPELINE_STEPS } from "@/lib/api";
 
@@ -237,12 +237,11 @@ function ScanPipelineInner({ steps, className }: ScanPipelineProps) {
     return { rawNodes, rawEdges };
   }, [steps]);
 
-  const { nodes, edges } = useDagreLayout(rawNodes, rawEdges, {
-    direction: "LR",
+  const { nodes, edges } = useSankeyLayout(rawNodes, rawEdges, {
     nodeWidth: 190,
     nodeHeight: 90,
-    rankSep: 50,
-    nodeSep: 20,
+    columnGap: 50,
+    rowGap: 20,
   });
 
   return (

--- a/ui/lib/graph-schema.generated.ts
+++ b/ui/lib/graph-schema.generated.ts
@@ -8,6 +8,72 @@
 export const GRAPH_SCHEMA_VERSION = 1 as const;
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Semantic layers
+// ═══════════════════════════════════════════════════════════════════════════
+
+export enum GraphSemanticLayer {
+  USER = "user",
+  IDENTITY = "identity",
+  APP = "app",
+  API_GATEWAY = "api_gateway",
+  ORCHESTRATION = "orchestration",
+  MCP_SERVER = "mcp_server",
+  TOOL = "tool",
+  PACKAGE = "package",
+  RUNTIME_EVIDENCE = "runtime_evidence",
+  ASSET = "asset",
+  INFRA = "infra",
+  FINDING = "finding",
+}
+
+export type GraphSemanticLayerKey = "user" | "identity" | "app" | "api_gateway" | "orchestration" | "mcp_server" | "tool" | "package" | "runtime_evidence" | "asset" | "infra" | "finding";
+
+export const GRAPH_SEMANTIC_LAYERS: readonly GraphSemanticLayerKey[] = ["user", "identity", "app", "api_gateway", "orchestration", "mcp_server", "tool", "package", "runtime_evidence", "asset", "infra", "finding"] as const;
+
+export interface GraphSemanticLayerMeta {
+  label: string;
+}
+
+export const GRAPH_SEMANTIC_LAYER_META: Record<GraphSemanticLayerKey, GraphSemanticLayerMeta> = {
+  "user": {
+    "label": "User"
+  },
+  "identity": {
+    "label": "Identity"
+  },
+  "app": {
+    "label": "Application"
+  },
+  "api_gateway": {
+    "label": "API / Gateway"
+  },
+  "orchestration": {
+    "label": "Orchestration"
+  },
+  "mcp_server": {
+    "label": "MCP Server"
+  },
+  "tool": {
+    "label": "Tool"
+  },
+  "package": {
+    "label": "Package"
+  },
+  "runtime_evidence": {
+    "label": "Runtime Evidence"
+  },
+  "asset": {
+    "label": "Asset"
+  },
+  "infra": {
+    "label": "Infrastructure"
+  },
+  "finding": {
+    "label": "Finding"
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Node kinds (entity types)
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -40,7 +106,7 @@ export interface GraphNodeKindMeta {
   label: string;
   color: string;
   shape: string;
-  layer: string;
+  layer: GraphSemanticLayerKey;
   icon: string;
   category_uid: number;
   class_uid: number;

--- a/ui/lib/graph-schema.ts
+++ b/ui/lib/graph-schema.ts
@@ -502,6 +502,7 @@ export enum GraphLayout {
   DAGRE = "dagre",
   FORCE = "force",
   RADIAL = "radial",
+  SANKEY = "sankey",
   HIERARCHICAL = "hierarchical",
   GRID = "grid",
 }

--- a/ui/lib/use-sankey-layout.ts
+++ b/ui/lib/use-sankey-layout.ts
@@ -19,9 +19,8 @@
  * same `seed` field as the other layouts so visual-diff CI can key
  * snapshots uniformly (#2259).
  *
- * Wiring: this layout has no dashboard surface yet — it is pre-built so
- * the pipeline-DAG view (#2257 follow-up) can adopt it without further
- * library work.
+ * Wiring: used by the live scan-pipeline DAG so execution stages read as a
+ * directional flow instead of a generic topology graph.
  */
 
 "use client";

--- a/ui/scripts/codegen-graph-schema.mjs
+++ b/ui/scripts/codegen-graph-schema.mjs
@@ -68,6 +68,7 @@ async function fetchSchema() {
   if (
     typeof data !== "object" ||
     data === null ||
+    !Array.isArray(data.semantic_layers) ||
     !Array.isArray(data.node_kinds) ||
     !Array.isArray(data.edge_kinds)
   ) {
@@ -77,6 +78,7 @@ async function fetchSchema() {
 }
 
 function render(schema) {
+  const semanticLayers = [...schema.semantic_layers];
   const nodeKinds = [...schema.node_kinds].sort((a, b) =>
     a.key.localeCompare(b.key),
   );
@@ -94,6 +96,22 @@ function render(schema) {
 
   const nodeUnion = nodeKinds.map((n) => JSON.stringify(n.key)).join(" | ");
   const edgeUnion = edgeKinds.map((e) => JSON.stringify(e.key)).join(" | ");
+  const semanticLayerUnion = semanticLayers.map((layer) => JSON.stringify(layer.key)).join(" | ");
+
+  const semanticLayerEnum = semanticLayers
+    .map((layer) => `  ${toEnumMember(layer.key)} = ${JSON.stringify(layer.key)},`)
+    .join("\n");
+
+  const semanticLayerList = semanticLayers.map((layer) => JSON.stringify(layer.key)).join(", ");
+
+  const semanticLayerMetadataObj = semanticLayers
+    .map(
+      (layer) =>
+        `  ${JSON.stringify(layer.key)}: ${jsonStringify({
+          label: layer.label,
+        }).replace(/\n/g, "\n  ")},`,
+    )
+    .join("\n");
 
   const nodeMetadataObj = nodeKinds
     .map(
@@ -138,6 +156,26 @@ function render(schema) {
 export const GRAPH_SCHEMA_VERSION = ${schema.version ?? 1} as const;
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Semantic layers
+// ═══════════════════════════════════════════════════════════════════════════
+
+export enum GraphSemanticLayer {
+${semanticLayerEnum}
+}
+
+export type GraphSemanticLayerKey = ${semanticLayerUnion};
+
+export const GRAPH_SEMANTIC_LAYERS: readonly GraphSemanticLayerKey[] = [${semanticLayerList}] as const;
+
+export interface GraphSemanticLayerMeta {
+  label: string;
+}
+
+export const GRAPH_SEMANTIC_LAYER_META: Record<GraphSemanticLayerKey, GraphSemanticLayerMeta> = {
+${semanticLayerMetadataObj}
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Node kinds (entity types)
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -153,7 +191,7 @@ export interface GraphNodeKindMeta {
   label: string;
   color: string;
   shape: string;
-  layer: string;
+  layer: GraphSemanticLayerKey;
   icon: string;
   category_uid: number;
   class_uid: number;


### PR DESCRIPTION
Summary
- generates semantic layer enum/list/meta from /v1/graph/schema instead of dropping semantic_layers
- adds a parity regression so generated TS layers match the Python GraphSemanticLayer order
- adds sankey to the canonical GraphLayout enum and wires the live scan pipeline to use the existing Sankey layout helper

Why
The audit found graph composition drift: /v1/graph/schema returned semantic_layers but #2255 codegen silently discarded them, and the Sankey helper was dead code while the canonical layout enum only exposed 3 of the 4 claimed graph layouts.

Validation
- PYTHONPATH=src uv run pytest tests/test_graph_schema_ui_parity.py tests/test_graph_schema.py::TestGraphSchemaEndpoint::test_schema_endpoint_returns_canonical_taxonomy tests/test_graph_schema.py::TestGraphSchemaEndpoint::test_schema_entries_carry_label_color_shape_icon -q -> 9 passed
- cd ui && npm run codegen:graph-schema:check -> passed
- cd ui && npm run typecheck -> passed
- cd ui && npm run lint -> passed
- cd ui && npm run test:run -> 26 files / 177 tests passed
- PYTHONPATH=src uv run pre-commit run --files ... -> passed

Notes
- This is graph schema/layout composition only; it does not tag or release v0.86.0.
