### PR TITLE
fix(compliance): include native scan findings in hub list

### DIFF
--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -1438,6 +1438,56 @@ async def get_incident_correlation(request: Request) -> dict:
 _HUB_VALID_FORMATS = ("sarif", "cyclonedx", "csv", "json")
 
 
+def _native_hub_findings(request: Request) -> list[dict[str, Any]]:
+    """Return native scan findings in the compliance-hub list shape.
+
+    The hub posture endpoint already aggregates native scans and external
+    ingests together. This keeps the list endpoint aligned with that contract
+    so operators can drill into both sides of the combined posture count.
+    """
+    from agent_bom.api.routes.scan import _iter_scan_findings
+    from agent_bom.compliance_coverage import TAG_MAPPED_FRAMEWORKS
+    from agent_bom.compliance_hub import select_frameworks
+    from agent_bom.finding import FindingSource, FindingType
+
+    slug_to_tag_field: tuple[tuple[str, str], ...] = tuple((metadata.slug, metadata.tag_field) for metadata in TAG_MAPPED_FRAMEWORKS)
+    rows: list[dict[str, Any]] = []
+    for job in _tenant_jobs(request):
+        if job.status != JobStatus.DONE or not job.result:
+            continue
+        for row in _iter_scan_findings(job):
+            package_name = str(row.get("package") or row.get("package_name") or "")
+            vulnerability_id = str(row.get("vulnerability_id") or row.get("cve_id") or row.get("id") or "")
+            has_mcp_context = bool(row.get("affected_agents") or row.get("affected_servers"))
+            source = FindingSource.MCP_SCAN if has_mcp_context else FindingSource.SBOM
+            asset_type = "mcp_server" if has_mcp_context else "package"
+            frameworks = [slug for slug, field in slug_to_tag_field if row.get(field)]
+            if not frameworks:
+                frameworks = select_frameworks(source, asset_type=asset_type, finding_type=FindingType.CVE)
+            payload = {
+                **row,
+                "id": row.get("id") or f"{job.job_id}:{vulnerability_id}:{package_name}",
+                "title": row.get("title") or f"{vulnerability_id or 'Vulnerability'} in {package_name or 'native scan asset'}",
+                "finding_type": FindingType.CVE.value,
+                "source": source.value,
+                "origin": "native_scan",
+                "asset": {
+                    "name": package_name or vulnerability_id or "native scan asset",
+                    "asset_type": asset_type,
+                    "identifier": f"pkg:{package_name}" if package_name else None,
+                    "location": None,
+                    "stable_id": None,
+                },
+                "scan_id": job.job_id,
+                "applicable_frameworks": frameworks,
+                "effective_severity": row.get("severity", "unknown"),
+            }
+            clean = redact_for_persistence(payload, EvidenceTier.SAFE_TO_STORE)
+            if isinstance(clean, dict):
+                rows.append(clean)
+    return rows
+
+
 @router.post(
     "/v1/compliance/ingest",
     tags=["compliance"],
@@ -1514,10 +1564,14 @@ async def ingest_compliance_findings(request: Request) -> dict:
 
 @router.get("/v1/compliance/hub/findings", tags=["compliance"])
 async def list_hub_findings(request: Request, limit: int = 200, offset: int = 0) -> dict:
-    """List hub-ingested findings for the current tenant."""
+    """List compliance-hub findings for the current tenant.
+
+    Includes durable external ingests plus native scan findings projected into
+    the same shape so the list endpoint matches `/hub/posture` totals.
+    """
     from agent_bom.api.compliance_hub_store import get_compliance_hub_store
 
-    findings = get_compliance_hub_store().list(_tenant_id(request))
+    findings = get_compliance_hub_store().list(_tenant_id(request)) + _native_hub_findings(request)
     limit = max(1, min(limit, 1000))
     offset = max(0, offset)
     page = findings[offset : offset + limit]

--- a/src/agent_bom/evidence/policy.py
+++ b/src/agent_bom/evidence/policy.py
@@ -125,6 +125,7 @@ TIER_A_FIELDS: frozenset[str] = frozenset(
         "applicable_frameworks_csv",
         "control_id",
         "source",
+        "origin",
         "source_type",
         "observed_via",
         "collector",

--- a/tests/test_compliance_hub_api.py
+++ b/tests/test_compliance_hub_api.py
@@ -34,9 +34,14 @@ def teardown_module() -> None:
 
 @pytest.fixture(autouse=True)
 def _reset_store():
+    from agent_bom.api.server import set_job_store
+    from agent_bom.api.store import InMemoryJobStore
+
     reset_compliance_hub_store()
+    set_job_store(InMemoryJobStore())
     yield
     reset_compliance_hub_store()
+    set_job_store(InMemoryJobStore())
 
 
 def _client(tenant: str = "tenant-alpha", role: str = "admin") -> TestClient:
@@ -158,6 +163,52 @@ def test_list_hub_findings_pagination():
     assert body["count"] == 10
     assert body["total"] == 50
     assert body["offset"] == 20
+
+
+def test_list_hub_findings_includes_native_scan_findings():
+    """Native scans and external ingests must compose in the hub list.
+
+    `/v1/compliance/hub/posture` already counts native scan findings. The list
+    endpoint should expose the same native rows so operators can drill into the
+    combined compliance posture instead of seeing only external imports.
+    """
+    from agent_bom.api.server import ScanJob, ScanRequest, set_job_store
+    from agent_bom.api.store import InMemoryJobStore
+    from agent_bom.api.stores import _get_store
+
+    set_job_store(InMemoryJobStore())
+    job = ScanJob(
+        job_id="native-hub-job",
+        tenant_id="tenant-alpha",
+        created_at="2026-05-05T10:00:00Z",
+        request=ScanRequest(),
+    )
+    job.status = JobStatus.DONE
+    job.completed_at = "2026-05-05T10:01:00Z"
+    job.result = {
+        "findings": [
+            {
+                "id": "CVE-2026-12345",
+                "vulnerability_id": "CVE-2026-12345",
+                "package": "demo-package",
+                "severity": "high",
+                "affected_agents": ["claude-desktop"],
+                "affected_servers": ["filesystem"],
+            }
+        ]
+    }
+    _get_store().put(job)
+
+    body = _client().get("/v1/compliance/hub/findings").json()
+
+    assert body["total"] == 1
+    native = body["findings"][0]
+    assert native["origin"] == "native_scan"
+    assert native["source"] == "MCP_SCAN"
+    assert native["scan_id"] == "native-hub-job"
+    assert native["applicable_frameworks"]
+
+    set_job_store(InMemoryJobStore())
 
 
 # ─── Tenant isolation ────────────────────────────────────────────────────────


### PR DESCRIPTION
Summary
- projects native scan findings into the `/v1/compliance/hub/findings` read model
- keeps external ingests durable in the hub store while adding `origin: native_scan` virtual rows for completed native scans
- preserves Tier-A redaction on the native projection and allows the safe `origin` discriminator
- resets the job store in compliance-hub API tests to prevent native scan bleed between cases

Why
The audit found `/v1/compliance/hub/posture` aggregated native scans, but `/v1/compliance/hub/findings` only returned externally ingested findings. That made the count actionable in aggregate but not drillable in the list UI.

Validation
- PYTHONPATH=src uv run pytest tests/test_compliance_hub_api.py::test_list_hub_findings_includes_native_scan_findings tests/test_compliance_hub_api.py::test_list_hub_findings_returns_what_we_ingested tests/test_compliance_hub_api.py::test_hub_posture_native_counts_aggregate_all_15_frameworks tests/test_evidence_policy.py::test_compliance_hub_drops_tier_b_fields -q -> 4 passed
- PYTHONPATH=src uv run pytest tests/test_compliance_hub_api.py tests/test_compliance_hub.py tests/test_compliance_hub_ingest.py tests/test_compliance_hub_cross_format.py tests/test_evidence_policy.py -q -> 104 passed
- PYTHONPATH=src uv run ruff check src/agent_bom/api/routes/compliance.py src/agent_bom/evidence/policy.py tests/test_compliance_hub_api.py -> passed
- PYTHONPATH=src uv run pre-commit run --files ... -> passed

Notes
- This does not change delete semantics: DELETE /v1/compliance/hub/findings clears external ingests only; native rows disappear when the underlying scan job is gone.
- This does not tag or release v0.86.0.
