### PR TITLE
fix(scanners): apply OSV severity fallback to local cache

### DIFF
--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -50,7 +50,13 @@ from agent_bom.scanners.osv import enrich_results_if_needed as _enrich_results_i
 from agent_bom.scanners.osv import is_valid_fix_version as _is_valid_fix_version
 from agent_bom.scanners.osv import package_lookup_names as _package_lookup_names
 from agent_bom.scanners.osv import parse_fixed_version, query_osv_batch_impl
-from agent_bom.scanners.risk import _parse_cvss4_vector, cvss_to_severity, parse_cvss_vector, parse_osv_severity
+from agent_bom.scanners.risk import (
+    _parse_cvss4_vector,
+    advisory_id_severity_fallback,
+    cvss_to_severity,
+    parse_cvss_vector,
+    parse_osv_severity,
+)
 from agent_bom.scanners.state import (
     _bump_scan_perf,
     _get_api_semaphore,
@@ -492,6 +498,7 @@ def _local_vuln_to_vulnerability(lv: "Any") -> Vulnerability:
         "low": Severity.LOW,
     }
     severity = sev_map.get((lv.severity or "").lower(), Severity.UNKNOWN)
+    severity_source = None
 
     # Canonicalize: prefer CVE ID over GHSA/PYSEC for consistency with Trivy/NVD
     raw_id = lv.id
@@ -505,12 +512,21 @@ def _local_vuln_to_vulnerability(lv: "Any") -> Vulnerability:
         canonical_id = raw_id
         all_aliases = [a for a in aliases if a != canonical_id]
 
+    if severity == Severity.UNKNOWN:
+        for advisory_id in [str(raw_id), *(str(alias) for alias in aliases)]:
+            fallback, source = advisory_id_severity_fallback(advisory_id)
+            if fallback != Severity.UNKNOWN:
+                severity = fallback
+                severity_source = source
+                break
+
     advisory_source = getattr(lv, "source", None)
 
     return Vulnerability(
         id=canonical_id,
         summary=lv.summary or "No description available",
         severity=severity,
+        severity_source=severity_source,
         cvss_score=lv.cvss_score,
         fixed_version=lv.fixed_version if _is_valid_fix_version(lv.fixed_version or "") else None,
         epss_score=lv.epss_probability,

--- a/src/agent_bom/scanners/risk.py
+++ b/src/agent_bom/scanners/risk.py
@@ -14,6 +14,24 @@ from agent_bom.models import Severity
 
 _logger = logging.getLogger(__name__)
 
+_OSV_MEDIUM_FALLBACK_PREFIXES = ("OSV-", "PYSEC-", "RUSTSEC-", "GO-", "MAL-", "GSD-")
+
+
+def advisory_id_severity_fallback(advisory_id: str) -> tuple[Severity, Optional[str]]:
+    """Return conservative triage severity for advisory-only IDs.
+
+    Some advisory ecosystems publish IDs before CVSS/vendor severity arrives.
+    These should not stay invisible as ``unknown`` findings in operator views,
+    but only known advisory namespaces get this fallback. Arbitrary missing
+    severity still remains ``UNKNOWN``.
+    """
+    normalized = advisory_id.upper()
+    if normalized.startswith("GHSA-"):
+        return Severity.MEDIUM, "ghsa_heuristic"
+    if normalized.startswith(_OSV_MEDIUM_FALLBACK_PREFIXES):
+        return Severity.MEDIUM, "osv_heuristic"
+    return Severity.UNKNOWN, None
+
 
 def cvss_to_severity(score: Optional[float]) -> Severity:
     if score is None:
@@ -187,11 +205,9 @@ def parse_osv_severity(vuln_data: dict) -> tuple[Severity, Optional[float], Opti
 
     if severity == Severity.UNKNOWN:
         advisory_id = str(vuln_data.get("id", "")).upper()
-        if advisory_id.startswith("GHSA-"):
-            severity = Severity.MEDIUM
-            severity_source = "ghsa_heuristic"
-        elif advisory_id.startswith(("OSV-", "PYSEC-", "RUSTSEC-", "GO-", "MAL-", "GSD-")):
-            severity = Severity.MEDIUM
-            severity_source = "osv_heuristic"
+        fallback, source = advisory_id_severity_fallback(advisory_id)
+        if fallback != Severity.UNKNOWN:
+            severity = fallback
+            severity_source = source
 
     return severity, cvss_score, severity_source

--- a/tests/test_local_db_scan.py
+++ b/tests/test_local_db_scan.py
@@ -61,6 +61,25 @@ def test_local_vuln_to_vulnerability_unknown_severity():
     assert v.severity == Severity.UNKNOWN  # unknown severity must not silently inflate to MEDIUM
 
 
+def test_local_vuln_to_vulnerability_osv_id_without_score_uses_medium_fallback():
+    from agent_bom.scanners import _local_vuln_to_vulnerability
+
+    lv = _make_local_vuln(vuln_id="OSV-2022-1074", severity="", cvss=None)
+    v = _local_vuln_to_vulnerability(lv)
+    assert v.severity == Severity.MEDIUM
+    assert v.severity_source == "osv_heuristic"
+
+
+def test_local_vuln_to_vulnerability_osv_alias_without_score_uses_medium_fallback():
+    from agent_bom.scanners import _local_vuln_to_vulnerability
+
+    lv = _make_local_vuln(vuln_id="CVE-2026-0001", severity="", cvss=None)
+    lv.aliases = ["PYSEC-2026-7"]
+    v = _local_vuln_to_vulnerability(lv)
+    assert v.severity == Severity.MEDIUM
+    assert v.severity_source == "osv_heuristic"
+
+
 def test_local_vuln_to_vulnerability_kev_flag():
     from agent_bom.scanners import _local_vuln_to_vulnerability
 

--- a/tests/test_scanners.py
+++ b/tests/test_scanners.py
@@ -62,6 +62,15 @@ def test_osv_prefixed_advisory_without_score_uses_medium_fallback():
     assert sev_src == "osv_heuristic"
 
 
+def test_advisory_id_severity_fallback_keeps_unknown_ids_unknown():
+    from agent_bom.scanners.risk import advisory_id_severity_fallback
+
+    severity, sev_src = advisory_id_severity_fallback("VENDOR-2026-1")
+
+    assert severity == Severity.UNKNOWN
+    assert sev_src is None
+
+
 def test_ghsa_severity_unknown_label_not_medium():
     """GHSA advisory with unrecognized severity must return UNKNOWN, not MEDIUM."""
     from agent_bom.scanners.ghsa_advisory import _parse_ghsa_severity


### PR DESCRIPTION
Summary
- factors the advisory-id severity fallback into `advisory_id_severity_fallback()`
- applies the same GHSA/OSV/PYSEC/RUSTSEC/GO/MAL/GSD medium fallback in the local vulnerability DB conversion path
- keeps arbitrary missing local severity as UNKNOWN
- adds regressions for cached OSV IDs and aliases so local DB/offline scans match the live OSV path

Why
Claude verified #2285 closed the live OSV path, but cached local DB rows still used a plain severity-label map. That left OSV-prefixed cached findings, including the self-scan Pillow OSVs, at `unknown` despite the live parser now assigning a conservative medium triage band.

Validation
- PYTHONPATH=src uv run pytest tests/test_local_db_scan.py::test_local_vuln_to_vulnerability_unknown_severity tests/test_local_db_scan.py::test_local_vuln_to_vulnerability_osv_id_without_score_uses_medium_fallback tests/test_local_db_scan.py::test_local_vuln_to_vulnerability_osv_alias_without_score_uses_medium_fallback tests/test_scanners.py::test_osv_prefixed_advisory_without_score_uses_medium_fallback tests/test_scanners.py::test_advisory_id_severity_fallback_keeps_unknown_ids_unknown tests/test_scanners.py::test_local_db_severity_none_not_medium -q -> 6 passed
- PYTHONPATH=src uv run pytest tests/test_local_db_scan.py tests/test_scanners.py tests/test_accuracy_baseline.py -q -> 74 passed
- PYTHONPATH=src uv run ruff check src/agent_bom/scanners/__init__.py src/agent_bom/scanners/risk.py tests/test_local_db_scan.py tests/test_scanners.py -> passed
- PYTHONPATH=src uv run pre-commit run --files ... -> passed

Notes
- This does not tag or release v0.86.0.
