### PR TITLE
feat(graph): compose security graph investigation handoff

### DIFF
--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -52,7 +52,12 @@ import {
   RelationshipType,
   type UnifiedNode,
 } from "@/lib/graph-schema";
-import { attackPathKey, toAttackCardNodes } from "@/lib/attack-paths";
+import {
+  attackPathKey,
+  decodeGraphInvestigationParams,
+  toAttackCardNodes,
+  type GraphInvestigationRequest,
+} from "@/lib/attack-paths";
 import {
   BACKGROUND_COLOR,
   BACKGROUND_GAP,
@@ -509,6 +514,11 @@ function GraphPageInner() {
         ""
       : "",
   );
+  const requestedInvestigationRef = useRef<GraphInvestigationRequest | null>(
+    typeof window !== "undefined"
+      ? decodeGraphInvestigationParams(new URLSearchParams(window.location.search))
+      : null,
+  );
   const firstScanSelectionRef = useRef(true);
 
   useEffect(() => {
@@ -582,7 +592,7 @@ function GraphPageInner() {
       return;
     }
 
-    if (investigationMode) return;
+    if (investigationMode || requestedInvestigationRef.current) return;
 
     if (serverEntityTypes.length === 0) {
       setGraphData(emptyGraphResponse(selectedScanId));
@@ -746,12 +756,23 @@ function GraphPageInner() {
     if (typeof window === "undefined") return;
     const nextParams = encodeFiltersToParams(filters);
     if (selectedScanId) nextParams.set("scan", selectedScanId);
+    const shareableInvestigation = investigationMode ?? requestedInvestigationRef.current;
+    if (shareableInvestigation) {
+      nextParams.set("investigate", "1");
+      nextParams.set("root", shareableInvestigation.rootId);
+      if (
+        shareableInvestigation.rootLabel &&
+        shareableInvestigation.rootLabel !== shareableInvestigation.rootId
+      ) {
+        nextParams.set("q", shareableInvestigation.rootLabel);
+      }
+    }
     const next = nextParams.toString();
     const current = searchParams?.toString() ?? "";
     if (next === current) return;
     const url = next ? `${pathname}?${next}` : pathname;
     router.replace(url, { scroll: false });
-  }, [filters, pathname, router, searchParams, selectedScanId]);
+  }, [filters, investigationMode, pathname, router, searchParams, selectedScanId]);
 
   // Constraint propagation — recompute valid values whenever graph or
   // filters change. Cheap on focused snapshots, BFS-bounded on expanded.
@@ -1019,26 +1040,34 @@ function GraphPageInner() {
     }
   }, [filters.severity, searchQuery, selectedScanId, serverEntityTypes]);
 
-  const focusSearchResult = useCallback(
-    async (node: UnifiedNode) => {
-      const fallback = flowNodeDataById.get(node.id) ?? buildFallbackNodeData(node);
-      setSelectedNode({
-        ...fallback,
-        attributes: {
-          ...(fallback.attributes ?? {}),
-          node_id: node.id,
-        },
-      });
-      setSelectedNodeId(node.id);
+  const loadRootInvestigation = useCallback(
+    async (request: GraphInvestigationRequest & { node?: UnifiedNode | undefined }) => {
+      if (!selectedScanId) return;
+
+      const fallback = request.node
+        ? flowNodeDataById.get(request.node.id) ?? buildFallbackNodeData(request.node)
+        : null;
+      if (fallback) {
+        setSelectedNode({
+          ...fallback,
+          attributes: {
+            ...(fallback.attributes ?? {}),
+            node_id: request.rootId,
+          },
+        });
+      } else {
+        setSelectedNode(null);
+      }
+      setSelectedNodeId(request.rootId);
       setPinnedFocusId(null);
-      setHoveredNodeId(node.id);
+      setHoveredNodeId(request.rootId);
       setSelectedAttackPathKey(null);
       setSearchResults([]);
-      setSearchQuery(node.label);
+      setSearchQuery(request.rootLabel ?? request.node?.label ?? request.rootId);
       setLoadingGraph(true);
       try {
         const response = await api.queryGraph({
-          roots: [node.id],
+          roots: [request.rootId],
           scan_id: selectedScanId,
           direction: "both",
           max_depth: filters.vulnOnly ? 3 : 4,
@@ -1052,10 +1081,14 @@ function GraphPageInner() {
           include_attack_paths: true,
           relationship_types: serverRelationships,
         });
+        const rootNode = response.nodes.find((node) => node.id === request.rootId) ?? request.node;
+        if (rootNode) {
+          setSelectedNode(buildFallbackNodeData(rootNode));
+        }
         setGraphData(queryResponseToGraphResponse(response));
         setInvestigationMode({
-          rootId: node.id,
-          rootLabel: node.label,
+          rootId: request.rootId,
+          rootLabel: rootNode?.label ?? request.rootLabel ?? request.rootId,
           truncated: response.truncated,
           nodeCount: response.nodes.length,
           edgeCount: response.edges.length,
@@ -1068,6 +1101,24 @@ function GraphPageInner() {
       }
     },
     [filters.runtimeMode, filters.vulnOnly, flowNodeDataById, selectedScanId, serverRelationships],
+  );
+
+  useEffect(() => {
+    const requested = requestedInvestigationRef.current;
+    if (!requested || !selectedScanId) return;
+    requestedInvestigationRef.current = null;
+    void loadRootInvestigation(requested);
+  }, [loadRootInvestigation, selectedScanId]);
+
+  const focusSearchResult = useCallback(
+    async (node: UnifiedNode) => {
+      await loadRootInvestigation({
+        rootId: node.id,
+        rootLabel: node.label,
+        node,
+      });
+    },
+    [loadRootInvestigation],
   );
 
   const clearInvestigationMode = useCallback(() => {

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -35,7 +35,9 @@ import {
 import {
   attackPathKey,
   attackPathSequenceLabels,
+  buildGraphInvestigationHref,
   buildSecurityGraphHref,
+  investigationRootForAttackPath,
   labelsForAttackPathType,
   matchesAttackPathFocus,
   recommendedInteractionRiskActions,
@@ -200,26 +202,39 @@ function SecurityGraphPageContent() {
   );
 
   const hasFocusContext = Boolean(focus.cve || focus.packageName || focus.agentName);
-  const fullGraphHref = useMemo(() => {
-    const params = new URLSearchParams();
-    if (selectedScanId) params.set("scan", selectedScanId);
-    if (focus.agentName) params.set("agent", focus.agentName);
-    if (focus.cve) params.set("q", focus.cve);
-    else if (focus.packageName) params.set("q", focus.packageName);
-    const query = params.toString();
-    return query ? `/graph?${query}` : "/graph";
-  }, [focus.agentName, focus.cve, focus.packageName, selectedScanId]);
-  const resetFocusHref = useMemo(
-    () => buildSecurityGraphHref({ scanId: selectedScanId || undefined }),
-    [selectedScanId],
-  );
-
   const selectedAttackPath = useMemo(
     () =>
       selectedAttackPathKey
         ? attackPaths.find((path) => attackPathKey(path) === selectedAttackPathKey) ?? null
         : attackPaths[0] ?? null,
     [attackPaths, selectedAttackPathKey],
+  );
+  const investigationRoot = useMemo(
+    () =>
+      selectedAttackPath
+        ? investigationRootForAttackPath(selectedAttackPath, graphNodeById, focus)
+        : null,
+    [focus, graphNodeById, selectedAttackPath],
+  );
+  const fullGraphHref = useMemo(() => {
+    if (investigationRoot) {
+      return buildGraphInvestigationHref({
+        scanId: selectedScanId || undefined,
+        agentName: focus.agentName || undefined,
+        rootId: investigationRoot.id,
+        rootLabel: investigationRoot.label,
+      });
+    }
+
+    const params = new URLSearchParams();
+    if (selectedScanId) params.set("scan", selectedScanId);
+    if (focus.agentName) params.set("agent", focus.agentName);
+    const query = params.toString();
+    return query ? `/graph?${query}` : "/graph";
+  }, [focus.agentName, investigationRoot, selectedScanId]);
+  const resetFocusHref = useMemo(
+    () => buildSecurityGraphHref({ scanId: selectedScanId || undefined }),
+    [selectedScanId],
   );
 
   const selectedFixFirstCard = useMemo(

--- a/ui/lib/attack-paths.ts
+++ b/ui/lib/attack-paths.ts
@@ -13,6 +13,11 @@ export type AttackPathFocus = {
   scanId?: string | undefined;
 };
 
+export type GraphInvestigationRequest = {
+  rootId: string;
+  rootLabel?: string | undefined;
+};
+
 export type AttackPathAction = {
   title: string;
   detail: string;
@@ -107,6 +112,35 @@ export function buildSecurityGraphHref(focus: AttackPathFocus): string {
   return query ? `/security-graph?${query}` : "/security-graph";
 }
 
+export function buildGraphInvestigationHref(
+  request: GraphInvestigationRequest & Pick<AttackPathFocus, "scanId" | "agentName">,
+): string {
+  const params = new URLSearchParams();
+  if (request.scanId) params.set("scan", request.scanId);
+  if (request.agentName) params.set("agent", request.agentName);
+  params.set("investigate", "1");
+  params.set("root", request.rootId);
+  if (request.rootLabel && request.rootLabel !== request.rootId) {
+    params.set("q", request.rootLabel);
+  }
+  return `/graph?${params.toString()}`;
+}
+
+export function decodeGraphInvestigationParams(
+  params: URLSearchParams | { get(name: string): string | null },
+): GraphInvestigationRequest | null {
+  const rootId = params.get("root") || params.get("root_id") || params.get("node");
+  if (!rootId) return null;
+
+  const investigate = params.get("investigate");
+  if (investigate && investigate !== "1" && investigate !== "true") return null;
+
+  return {
+    rootId,
+    rootLabel: params.get("q") || params.get("label") || undefined,
+  };
+}
+
 function normalizeLabel(value: string | undefined): string {
   return (value ?? "").trim().toLowerCase();
 }
@@ -133,6 +167,43 @@ export function labelsForAttackPathType(
     deduped.set(node.label, node.rawLabel);
   }
   return Array.from(deduped.values());
+}
+
+export function investigationRootForAttackPath(
+  path: AttackPath,
+  nodeById: Map<string, UnifiedNode>,
+  focus: AttackPathFocus = {},
+): UnifiedNode | null {
+  const cve = normalizeLabel(focus.cve);
+  const packageName = normalizeLabel(focus.packageName);
+  const agentName = normalizeLabel(focus.agentName);
+  const typedHops = path.hops
+    .map((hop) => nodeById.get(hop))
+    .filter((node): node is UnifiedNode => Boolean(node))
+    .map((node) => ({
+      node,
+      label: normalizeLabel(node.label),
+      type: mapAttackPathNodeType(String(node.entity_type)),
+    }));
+
+  if (cve) {
+    const focusedCve = typedHops.find(
+      (hop) => hop.type === "cve" && (hop.label === cve || path.vuln_ids.some((id) => normalizeLabel(id) === cve)),
+    );
+    if (focusedCve) return focusedCve.node;
+  }
+
+  if (packageName) {
+    const focusedPackage = typedHops.find((hop) => hop.type === "package" && hop.label === packageName);
+    if (focusedPackage) return focusedPackage.node;
+  }
+
+  if (agentName) {
+    const focusedAgent = typedHops.find((hop) => hop.type === "agent" && hop.label === agentName);
+    if (focusedAgent) return focusedAgent.node;
+  }
+
+  return nodeById.get(path.source) ?? typedHops[0]?.node ?? null;
 }
 
 export function recommendedAttackPathActions(

--- a/ui/tests/attack-paths.test.ts
+++ b/ui/tests/attack-paths.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from "vitest";
 import {
   attackPathKey,
   attackPathSequenceLabels,
+  buildGraphInvestigationHref,
   buildSecurityGraphHref,
+  decodeGraphInvestigationParams,
+  investigationRootForAttackPath,
   labelsForAttackPathType,
   mapAttackPathNodeType,
   matchesAttackPathFocus,
@@ -16,6 +19,27 @@ import {
 import { EntityType, type AttackPath, type UnifiedNode } from "@/lib/graph-schema";
 
 describe("attack path helpers", () => {
+  function graphNode(id: string, entityType: EntityType, label: string): UnifiedNode {
+    return {
+      id,
+      entity_type: entityType,
+      label,
+      category_uid: 5,
+      class_uid: 4001,
+      type_uid: 0,
+      status: "active",
+      risk_score: 6,
+      severity: "high",
+      severity_id: 4,
+      first_seen: "2026-04-14T00:00:00Z",
+      last_seen: "2026-04-14T00:00:00Z",
+      attributes: {},
+      compliance_tags: [],
+      data_sources: [],
+      dimensions: {},
+    };
+  }
+
   it("builds a stable key from source, target, and hops", () => {
     const path: AttackPath = {
       source: "pkg",
@@ -169,6 +193,49 @@ describe("attack path helpers", () => {
         agentName: "Claude Desktop",
       }),
     ).toBe("/security-graph?scan=scan-123&cve=CVE-2026-0002&package=flask&agent=Claude+Desktop");
+  });
+
+  it("builds a shareable graph investigation href", () => {
+    expect(
+      buildGraphInvestigationHref({
+        scanId: "scan-123",
+        agentName: "Claude Desktop",
+        rootId: "pkg-1",
+        rootLabel: "flask",
+      }),
+    ).toBe("/graph?scan=scan-123&agent=Claude+Desktop&investigate=1&root=pkg-1&q=flask");
+  });
+
+  it("decodes graph investigation roots from URL params", () => {
+    expect(decodeGraphInvestigationParams(new URLSearchParams("investigate=1&root=pkg-1&q=flask"))).toEqual({
+      rootId: "pkg-1",
+      rootLabel: "flask",
+    });
+    expect(decodeGraphInvestigationParams(new URLSearchParams("investigate=0&root=pkg-1"))).toBeNull();
+  });
+
+  it("chooses a concrete investigation root from the selected attack path", () => {
+    const path: AttackPath = {
+      source: "cve-1",
+      target: "agent-1",
+      hops: ["cve-1", "pkg-1", "server-1", "agent-1"],
+      edges: [],
+      composite_risk: 9.4,
+      summary: "focused path",
+      credential_exposure: [],
+      tool_exposure: [],
+      vuln_ids: ["CVE-2026-0002"],
+    };
+    const nodes = new Map<string, UnifiedNode>([
+      ["cve-1", graphNode("cve-1", EntityType.VULNERABILITY, "CVE-2026-0002")],
+      ["pkg-1", graphNode("pkg-1", EntityType.PACKAGE, "flask")],
+      ["server-1", graphNode("server-1", EntityType.SERVER, "mcp-server")],
+      ["agent-1", graphNode("agent-1", EntityType.AGENT, "Claude Desktop")],
+    ]);
+
+    expect(investigationRootForAttackPath(path, nodes, { packageName: "flask" })?.id).toBe("pkg-1");
+    expect(investigationRootForAttackPath(path, nodes, { agentName: "Claude Desktop" })?.id).toBe("agent-1");
+    expect(investigationRootForAttackPath(path, nodes, {})?.id).toBe("cve-1");
   });
 
   it("matches a focused attack path by cve, package, and agent labels", () => {


### PR DESCRIPTION
Summary
- adds a shareable /graph?investigate=1&root=<node-id> URL contract for root-centered investigation mode
- makes /security-graph choose a concrete root node from the selected attack path and link directly into bounded investigation instead of passing an ignored q parameter
- keeps investigation URLs shareable while the root-centered graph is active and reuses the same queryGraph path as search-result focus
- adds helper coverage for graph investigation URLs, URL decoding, and attack-path root selection

Why this matters
/security-graph is the fix-first cockpit; /graph is the deep investigation canvas. The handoff now preserves the selected attack path context with a node id that the graph page can actually load, matching the Wiz/Orca/CrowdStrike-style flow: triage path first, then inspect the bounded neighborhood around the selected root.

Validation
- npm run test:run -- attack-paths.test.ts -> 14 passed
- npm run typecheck -> passed
- npm run lint -> passed
- npm run test:run -> 26 files / 180 tests passed
- git diff --check -> passed
- PYTHONPATH=src uv run pre-commit run --files ui/lib/attack-paths.ts ui/app/security-graph/page.tsx ui/app/graph/graph-page-client.tsx ui/tests/attack-paths.test.ts -> passed