### PR TITLE
feat(graph): centralize layout dispatch

### DIFF
--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -26,7 +26,7 @@ import {
   ChevronRight,
 } from "lucide-react";
 import { api, type JobListItem, type ScanJob } from "@/lib/api";
-import { useDagreLayout } from "@/lib/use-dagre-layout";
+import { useGraphLayout } from "@/lib/use-graph-layout";
 import {
   lineageNodeTypes,
   type LineageNodeData,
@@ -305,12 +305,13 @@ export default function ContextPage() {
     return { rawNodes: nodes, rawEdges: edges };
   }, [graphData, selectedAgent]);
 
-  const { nodes: layoutNodes, edges: layoutEdges } = useDagreLayout(rawNodes, rawEdges, {
-    direction: "LR",
-    nodeWidth: 200,
-    nodeHeight: 70,
-    rankSep: 140,
-    nodeSep: 25,
+  const { nodes: layoutNodes, edges: layoutEdges } = useGraphLayout("dagre-lr", rawNodes, rawEdges, {
+    dagreLr: {
+      nodeWidth: 200,
+      nodeHeight: 70,
+      rankSep: 140,
+      nodeSep: 25,
+    },
   });
 
   // Search highlighting

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -39,7 +39,7 @@ import {
   type LineageNodeData,
   type LineageNodeType,
 } from "@/components/lineage-nodes";
-import { useForceLayout } from "@/lib/use-force-layout";
+import { useGraphLayout } from "@/lib/use-graph-layout";
 import { effectiveLodBandForGraph, useLodBand } from "@/lib/lod-renderer";
 import {
   aggregateSiblings,
@@ -823,10 +823,12 @@ function GraphPageInner() {
     setHoveredNodeId(null);
   }, [graphIdentityKey]);
 
-  const { nodes: layoutNodes, edges: layoutEdges } = useForceLayout(aggregated.nodes, aggregated.edges, {
-    idealEdgeLength: filters.agentName ? 168 : 196,
-    nodeRepulsion: filters.agentName ? 3600 : 4400,
-    preservePinnedPositions: true,
+  const { nodes: layoutNodes, edges: layoutEdges } = useGraphLayout("force", aggregated.nodes, aggregated.edges, {
+    force: {
+      idealEdgeLength: filters.agentName ? 168 : 196,
+      nodeRepulsion: filters.agentName ? 3600 : 4400,
+      preservePinnedPositions: true,
+    },
   });
 
   // Focus mode (#2257). The "active" focus is whichever the operator

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -12,8 +12,7 @@ import {
 import "@xyflow/react/dist/style.css";
 import { ShieldAlert, Loader2, AlertTriangle, Search, SlidersHorizontal, Network, GitBranch, Orbit } from "lucide-react";
 import { api, type JobListItem, type ScanJob } from "@/lib/api";
-import { useDagreLayout } from "@/lib/use-dagre-layout";
-import { useRadialLayout } from "@/lib/use-radial-layout";
+import { useGraphLayout } from "@/lib/use-graph-layout";
 import { lineageNodeTypes, type LineageNodeData } from "@/components/lineage-nodes";
 import { LineageDetailPanel } from "@/components/lineage-detail";
 import { MeshStats } from "@/components/mesh-stats";
@@ -299,19 +298,18 @@ export default function MeshPage() {
     return { rawNodes: nodes, rawEdges: edges, stats };
   }, [activeResult, nodeFilter, severityFilter, selectedAgents, vulnerableOnly]);
 
-  const { nodes: layoutNodes, edges: layoutEdges } = useRadialLayout(rawNodes, rawEdges, {
-    baseRadius: 240,
-    ringSpacing: 220,
+  const { nodes: visibleNodes, edges: visibleEdges } = useGraphLayout(layoutMode, rawNodes, rawEdges, {
+    radial: {
+      baseRadius: 240,
+      ringSpacing: 220,
+    },
+    dagre: {
+      nodeWidth: 200,
+      nodeHeight: 70,
+      rankSep: 140,
+      nodeSep: 25,
+    },
   });
-  const { nodes: dagreNodes, edges: dagreEdges } = useDagreLayout(rawNodes, rawEdges, {
-    direction: layoutMode === "spawn-tree" ? "TB" : "LR",
-    nodeWidth: 200,
-    nodeHeight: 70,
-    rankSep: 140,
-    nodeSep: 25,
-  });
-  const visibleNodes = layoutMode === "radial" ? layoutNodes : dagreNodes;
-  const visibleEdges = layoutMode === "radial" ? layoutEdges : dagreEdges;
 
   // Search highlighting
   const searchMatches = useMemo(

--- a/ui/components/scan-mesh.tsx
+++ b/ui/components/scan-mesh.tsx
@@ -6,7 +6,7 @@ import {
   ReactFlow, Background, Controls, MiniMap, type Node, type Edge,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { useDagreLayout } from "@/lib/use-dagre-layout";
+import { useGraphLayout } from "@/lib/use-graph-layout";
 import { ArrowLeft, Loader2, AlertTriangle } from "lucide-react";
 import { api, type ScanJob } from "@/lib/api";
 import { lineageNodeTypes, type LineageNodeData } from "@/components/lineage-nodes";
@@ -38,12 +38,13 @@ export function ScanMeshView({ id }: { id: string }) {
     return { rawNodes: nodes, rawEdges: edges, stats };
   }, [job]);
 
-  const { nodes: layoutNodes, edges: layoutEdges } = useDagreLayout(rawNodes, rawEdges, {
-    direction: "LR",
-    nodeWidth: 200,
-    nodeHeight: 70,
-    rankSep: 140,
-    nodeSep: 25,
+  const { nodes: layoutNodes, edges: layoutEdges } = useGraphLayout("dagre-lr", rawNodes, rawEdges, {
+    dagreLr: {
+      nodeWidth: 200,
+      nodeHeight: 70,
+      rankSep: 140,
+      nodeSep: 25,
+    },
   });
 
   const connectedIds = useMemo(() => (hoveredNodeId ? getConnectedIds(hoveredNodeId, layoutEdges) : null), [hoveredNodeId, layoutEdges]);

--- a/ui/components/scan-pipeline.tsx
+++ b/ui/components/scan-pipeline.tsx
@@ -29,7 +29,7 @@ import {
   Clock,
   SkipForward,
 } from "lucide-react";
-import { useSankeyLayout } from "@/lib/use-sankey-layout";
+import { useGraphLayout } from "@/lib/use-graph-layout";
 import type { StepEvent, StepStatus } from "@/lib/api";
 import { PIPELINE_STEPS } from "@/lib/api";
 
@@ -237,11 +237,13 @@ function ScanPipelineInner({ steps, className }: ScanPipelineProps) {
     return { rawNodes, rawEdges };
   }, [steps]);
 
-  const { nodes, edges } = useSankeyLayout(rawNodes, rawEdges, {
-    nodeWidth: 190,
-    nodeHeight: 90,
-    columnGap: 50,
-    rowGap: 20,
+  const { nodes, edges } = useGraphLayout("sankey", rawNodes, rawEdges, {
+    sankey: {
+      nodeWidth: 190,
+      nodeHeight: 90,
+      columnGap: 50,
+      rowGap: 20,
+    },
   });
 
   return (

--- a/ui/lib/use-graph-layout.ts
+++ b/ui/lib/use-graph-layout.ts
@@ -1,0 +1,137 @@
+"use client";
+
+import { useMemo } from "react";
+import { type Edge, type Node } from "@xyflow/react";
+
+import { GraphLayout } from "@/lib/graph-schema";
+import { type LayoutOptions } from "@/lib/dagre-layout";
+import { type DagreLrOptions, useDagreLrLayout } from "@/lib/use-dagre-lr";
+import { type ForceLayoutOptions, useForceLayout } from "@/lib/use-force-layout";
+import { type RadialLayoutOptions, useRadialLayout } from "@/lib/use-radial-layout";
+import { type SankeyLayoutOptions, useSankeyLayout } from "@/lib/use-sankey-layout";
+import { useDagreLayout } from "@/lib/use-dagre-layout";
+
+const EMPTY_NODES: Node[] = [];
+const EMPTY_EDGES: Edge[] = [];
+
+export type GraphLayoutKind =
+  | GraphLayout
+  | "force"
+  | "radial"
+  | "dagre"
+  | "sankey"
+  | "dagre-lr"
+  | "dagre_lr"
+  | "lr"
+  | "topology"
+  | "spawn-tree"
+  | "spawn_tree";
+
+export type ResolvedGraphLayoutKind =
+  | "force"
+  | "radial"
+  | "dagre"
+  | "dagre-lr"
+  | "sankey";
+
+export interface GraphLayoutOptions {
+  force?: ForceLayoutOptions;
+  radial?: RadialLayoutOptions;
+  dagre?: LayoutOptions;
+  dagreLr?: DagreLrOptions;
+  sankey?: SankeyLayoutOptions;
+}
+
+export interface GraphLayoutState {
+  nodes: Node[];
+  edges: Edge[];
+  pending: boolean;
+  seed?: number;
+  kind: ResolvedGraphLayoutKind;
+}
+
+export function resolveGraphLayoutKind(kind: GraphLayoutKind): ResolvedGraphLayoutKind {
+  switch (kind) {
+    case GraphLayout.FORCE:
+    case "force":
+      return "force";
+    case GraphLayout.RADIAL:
+    case "radial":
+      return "radial";
+    case GraphLayout.SANKEY:
+    case "sankey":
+      return "sankey";
+    case GraphLayout.DAGRE:
+    case "dagre":
+    case GraphLayout.HIERARCHICAL:
+    case GraphLayout.GRID:
+    case "topology":
+    case "spawn-tree":
+    case "spawn_tree":
+      return "dagre";
+    case "dagre-lr":
+    case "dagre_lr":
+    case "lr":
+      return "dagre-lr";
+  }
+}
+
+export function useGraphLayout(
+  kind: GraphLayoutKind,
+  nodes: Node[],
+  edges: Edge[],
+  options: GraphLayoutOptions = {},
+): GraphLayoutState {
+  const resolvedKind = resolveGraphLayoutKind(kind);
+  const dagreOptions = useMemo<LayoutOptions>(() => {
+    const requested = options.dagre ?? {};
+    if (requested.direction !== undefined) return requested;
+    if (kind === "spawn-tree" || kind === "spawn_tree") {
+      return { ...requested, direction: "TB" };
+    }
+    if (kind === "topology") {
+      return { ...requested, direction: "LR" };
+    }
+    return requested;
+  }, [kind, options.dagre]);
+  const force = useForceLayout(
+    resolvedKind === "force" ? nodes : EMPTY_NODES,
+    resolvedKind === "force" ? edges : EMPTY_EDGES,
+    options.force,
+  );
+  const radial = useRadialLayout(
+    resolvedKind === "radial" ? nodes : EMPTY_NODES,
+    resolvedKind === "radial" ? edges : EMPTY_EDGES,
+    options.radial,
+  );
+  const dagre = useDagreLayout(
+    resolvedKind === "dagre" ? nodes : EMPTY_NODES,
+    resolvedKind === "dagre" ? edges : EMPTY_EDGES,
+    dagreOptions,
+  );
+  const dagreLr = useDagreLrLayout(
+    resolvedKind === "dagre-lr" ? nodes : EMPTY_NODES,
+    resolvedKind === "dagre-lr" ? edges : EMPTY_EDGES,
+    options.dagreLr,
+  );
+  const sankey = useSankeyLayout(
+    resolvedKind === "sankey" ? nodes : EMPTY_NODES,
+    resolvedKind === "sankey" ? edges : EMPTY_EDGES,
+    options.sankey,
+  );
+
+  return useMemo(() => {
+    switch (resolvedKind) {
+      case "force":
+        return { ...force, kind: resolvedKind };
+      case "radial":
+        return { ...radial, kind: resolvedKind };
+      case "dagre":
+        return { ...dagre, kind: resolvedKind };
+      case "dagre-lr":
+        return { ...dagreLr, kind: resolvedKind };
+      case "sankey":
+        return { ...sankey, kind: resolvedKind };
+    }
+  }, [dagre, dagreLr, force, radial, resolvedKind, sankey]);
+}

--- a/ui/tests/use-graph-layout.test.tsx
+++ b/ui/tests/use-graph-layout.test.tsx
@@ -1,0 +1,109 @@
+import { renderHook } from "@testing-library/react";
+import { Position, type Edge, type Node } from "@xyflow/react";
+import { describe, expect, it } from "vitest";
+
+import { GraphLayout } from "@/lib/graph-schema";
+import { resolveGraphLayoutKind, useGraphLayout } from "@/lib/use-graph-layout";
+
+const nodes: Node[] = [
+  {
+    id: "agent:a",
+    position: { x: 0, y: 0 },
+    data: { entityType: "agent" },
+  },
+  {
+    id: "server:b",
+    position: { x: 0, y: 0 },
+    data: { entityType: "server" },
+  },
+  {
+    id: "package:c",
+    position: { x: 0, y: 0 },
+    data: { entityType: "package" },
+  },
+];
+
+const edges: Edge[] = [
+  { id: "a-b", source: "agent:a", target: "server:b" },
+  { id: "b-c", source: "server:b", target: "package:c" },
+];
+
+describe("graph layout dispatcher", () => {
+  it("resolves GraphLayout values and UI aliases to concrete layout hooks", () => {
+    expect(resolveGraphLayoutKind(GraphLayout.FORCE)).toBe("force");
+    expect(resolveGraphLayoutKind(GraphLayout.RADIAL)).toBe("radial");
+    expect(resolveGraphLayoutKind(GraphLayout.DAGRE)).toBe("dagre");
+    expect(resolveGraphLayoutKind(GraphLayout.HIERARCHICAL)).toBe("dagre");
+    expect(resolveGraphLayoutKind("dagre-lr")).toBe("dagre-lr");
+    expect(resolveGraphLayoutKind("topology")).toBe("dagre");
+    expect(resolveGraphLayoutKind("spawn-tree")).toBe("dagre");
+    expect(resolveGraphLayoutKind(GraphLayout.SANKEY)).toBe("sankey");
+  });
+
+  it("selects radial layout and forwards radial options", () => {
+    const { result } = renderHook(() =>
+      useGraphLayout("radial", nodes, edges, {
+        radial: {
+          baseRadius: 111,
+          ringSpacing: 222,
+        },
+      }),
+    );
+
+    expect(result.current.kind).toBe("radial");
+    expect(result.current.pending).toBe(false);
+    expect(result.current.nodes.find((node) => node.id === "agent:a")?.position).toEqual({
+      x: 0,
+      y: 0,
+    });
+    const serverPosition = result.current.nodes.find((node) => node.id === "server:b")!.position;
+    expect(Math.round(Math.hypot(serverPosition.x, serverPosition.y))).toBe(111);
+    expect(result.current.edges).toBe(edges);
+  });
+
+  it("maps mesh topology aliases to the existing Dagre directions", () => {
+    const { result: topology } = renderHook(() =>
+      useGraphLayout("topology", nodes, edges, {
+        dagre: {
+          nodeWidth: 100,
+          nodeHeight: 50,
+          rankSep: 100,
+          nodeSep: 20,
+        },
+      }),
+    );
+    const { result: spawnTree } = renderHook(() =>
+      useGraphLayout("spawn-tree", nodes, edges, {
+        dagre: {
+          nodeWidth: 100,
+          nodeHeight: 50,
+          rankSep: 100,
+          nodeSep: 20,
+        },
+      }),
+    );
+
+    expect(topology.current.kind).toBe("dagre");
+    expect(topology.current.nodes[0]!.sourcePosition).toBe(Position.Right);
+    expect(topology.current.nodes[0]!.targetPosition).toBe(Position.Left);
+    expect(spawnTree.current.kind).toBe("dagre");
+    expect(spawnTree.current.nodes[0]!.sourcePosition).toBe(Position.Bottom);
+    expect(spawnTree.current.nodes[0]!.targetPosition).toBe(Position.Top);
+  });
+
+  it("selects sankey layout and forwards sankey spacing options", () => {
+    const { result } = renderHook(() =>
+      useGraphLayout("sankey", nodes, edges, {
+        sankey: {
+          nodeWidth: 80,
+          columnGap: 20,
+          nodeHeight: 40,
+          rowGap: 10,
+        },
+      }),
+    );
+
+    expect(result.current.kind).toBe("sankey");
+    expect(result.current.nodes.map((node) => node.position.x)).toEqual([0, 100, 200]);
+  });
+});


### PR DESCRIPTION
## Summary

Centralizes graph layout selection behind one dispatcher hook so graph surfaces no longer import force/radial/dagre/sankey hooks directly.

- adds `useGraphLayout()` with typed layout aliases and per-layout options
- migrates `/graph`, `/mesh`, `/context`, scan mesh, and scan pipeline callsites
- keeps existing concrete layout implementations unchanged
- adds dispatcher unit coverage for alias resolution and option forwarding

## Why

This closes the remaining graph architecture audit item: layout behavior was scattered across pages, which made it easy for graph surfaces to drift from the shared schema and from each other. A central dispatcher gives us one place to route new layouts and page modes while preserving the current force, radial, dagre, dagre-LR, and Sankey behavior.

## Validation

- `cd ui && npm run typecheck`
- `cd ui && npm run lint`
- `cd ui && npm run test:run` -> 28 files / 187 tests passed
- `cd ui && npm run build`
- `git diff --check`
