### PR TITLE
fix(release): close auth skills and SARIF audit gaps

### DIFF
--- a/src/agent_bom/api/auth.py
+++ b/src/agent_bom/api/auth.py
@@ -336,13 +336,30 @@ def create_api_key(
     and should be given to the user. Only the scrypt-derived hash is stored.
     """
     raw_key = f"abom_{secrets.token_urlsafe(32)}"
+    return raw_key, create_api_key_record(
+        raw_key,
+        name=name,
+        role=role,
+        expires_at=expires_at,
+        scopes=scopes,
+        tenant_id=tenant_id,
+    )
+
+
+def create_api_key_record(
+    raw_key: str,
+    name: str,
+    role: Role,
+    expires_at: str | None = None,
+    scopes: list[str] | None = None,
+    tenant_id: str = "default",
+) -> ApiKey:
+    """Create a stored API key record for an operator-supplied raw key."""
     salt = os.urandom(16)
     key_hash = _derive_key(raw_key, salt)
-    key_id = secrets.token_hex(8)
-
     normalized_expiry = normalize_api_key_expiry(expires_at)
-    api_key = ApiKey(
-        key_id=key_id,
+    return ApiKey(
+        key_id=secrets.token_hex(8),
         key_hash=key_hash,
         key_salt=salt.hex(),
         key_prefix=raw_key[:12],
@@ -352,7 +369,6 @@ def create_api_key(
         scopes=scopes or [],
         tenant_id=tenant_id,
     )
-    return raw_key, api_key
 
 
 def verify_api_key(raw_key: str, stored_keys: list[ApiKey]) -> ApiKey | None:

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -21,7 +21,7 @@ from typing import Any, cast
 from agent_bom import __version__
 from agent_bom.api import stores as _stores
 from agent_bom.api.audit_log import get_audit_log
-from agent_bom.api.auth import get_key_store
+from agent_bom.api.auth import Role, create_api_key_record, get_key_store
 from agent_bom.api.middleware import (
     APIKeyMiddleware,
     MaxBodySizeMiddleware,
@@ -468,6 +468,47 @@ _cors_env = os.environ.get("CORS_ORIGINS")
 _cors_origins: list[str] = [o.strip() for o in _cors_env.split(",") if o.strip()] if _cors_env else _default_origins
 _api_key: str | None = None
 _rate_limit_rpm: int = 60
+_env_api_keys_seeded = False
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _parse_cors_origins_from_env(default: list[str]) -> tuple[list[str], bool]:
+    raw = os.environ.get("CORS_ORIGINS", "").strip()
+    if not raw:
+        return default, False
+    origins = [origin.strip() for origin in raw.split(",") if origin.strip()]
+    return origins or default, "*" in origins
+
+
+def _seed_api_key_store_from_env() -> bool:
+    """Seed RBAC keys from AGENT_BOM_API_KEYS for direct ASGI imports."""
+    global _env_api_keys_seeded
+
+    configured = os.environ.get("AGENT_BOM_API_KEYS", "").strip()
+    if not configured:
+        return False
+    if _env_api_keys_seeded:
+        return get_key_store().has_keys()
+
+    store = get_key_store()
+    for idx, item in enumerate(configured.split(","), start=1):
+        raw_item = item.strip()
+        if not raw_item:
+            continue
+        raw_key, sep, role_value = raw_item.partition(":")
+        if not sep or not raw_key.strip() or not role_value.strip():
+            raise RuntimeError("AGENT_BOM_API_KEYS entries must use '<raw-key>:<admin|analyst|viewer>' format")
+        try:
+            role = Role(role_value.strip().lower())
+        except ValueError as exc:
+            raise RuntimeError(f"Invalid AGENT_BOM_API_KEYS role {role_value!r}; expected admin, analyst, or viewer") from exc
+        store.add(create_api_key_record(raw_key.strip(), f"env:{role.value}:{idx}", role))
+
+    _env_api_keys_seeded = True
+    return store.has_keys()
 
 
 def _apply_cors_middleware(origins: list[str]) -> None:
@@ -521,15 +562,17 @@ def configure_api(
     _api_key = api_key
     _rate_limit_rpm = rate_limit_rpm
 
+    env_key_store_configured = _seed_api_key_store_from_env()
+
     from agent_bom.api.oidc import oidc_enabled_from_env
     from agent_bom.api.scim import scim_enabled_from_env
 
     oidc_enabled = oidc_enabled_from_env()
     scim_enabled = scim_enabled_from_env()
     trusted_proxy_enabled = os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH", "").strip().lower() in {"1", "true", "yes", "on"}
-    auth_required = bool(api_key or oidc_enabled or trusted_proxy_enabled or scim_enabled)
+    auth_required = bool(api_key or env_key_store_configured or oidc_enabled or trusted_proxy_enabled or scim_enabled)
     configure_auth_runtime(
-        api_key_configured=bool(api_key),
+        api_key_configured=bool(api_key or env_key_store_configured),
         oidc_enabled=oidc_enabled,
         trusted_proxy_enabled=trusted_proxy_enabled,
         scim_enabled=scim_enabled,
@@ -553,6 +596,34 @@ def configure_api(
     _replace_middleware(MaxBodySizeMiddleware)
     if app.middleware_stack is not None:
         app.middleware_stack = app.build_middleware_stack()
+
+
+def configure_api_from_env() -> None:
+    """Configure API hardening for direct ASGI imports such as raw uvicorn."""
+    api_key = os.environ.get("AGENT_BOM_API_KEY") or None
+    has_api_keys = bool(os.environ.get("AGENT_BOM_API_KEYS", "").strip())
+    auth_env_present = any(
+        (
+            api_key,
+            has_api_keys,
+            os.environ.get("AGENT_BOM_OIDC_ISSUER"),
+            _env_truthy("AGENT_BOM_TRUST_PROXY_AUTH"),
+            os.environ.get("AGENT_BOM_SCIM_BEARER_TOKEN"),
+        )
+    )
+    if not auth_env_present:
+        return
+
+    origins, allow_all = _parse_cors_origins_from_env(_default_origins)
+    configure_api(
+        cors_origins=origins,
+        cors_allow_all=allow_all,
+        api_key=api_key,
+        rate_limit_rpm=60,
+    )
+
+
+configure_api_from_env()
 
 
 # ─── Scan Pipeline (extracted to api/pipeline.py) ────────────────────────────

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -58,7 +58,7 @@ def _enforce_auth_defaults(command: str, host: str, api_key: str | None, allow_i
     """
     if _is_loopback_host(host):
         return
-    has_api_key = bool(api_key)
+    has_api_key = bool(api_key or os.environ.get("AGENT_BOM_API_KEYS", "").strip())
     has_oidc = _oidc_enabled()
     has_scim = _scim_bearer_enabled()
     if has_api_key or has_oidc or has_scim:
@@ -82,7 +82,7 @@ def _enforce_auth_defaults(command: str, host: str, api_key: str | None, allow_i
         return
     raise click.ClickException(
         f"Refusing to expose `{command}` on non-loopback host {host!r} without authentication. "
-        "Set --api-key / AGENT_BOM_API_KEY, configure AGENT_BOM_OIDC_ISSUER / "
+        "Set --api-key / AGENT_BOM_API_KEY, configure AGENT_BOM_API_KEYS, configure AGENT_BOM_OIDC_ISSUER / "
         "AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON, set AGENT_BOM_SCIM_BEARER_TOKEN, "
         "or pass --allow-insecure-no-auth to override."
     )
@@ -184,7 +184,7 @@ def _auth_summary(
     mcp_remote: bool = False,
 ) -> str:
     """Return a user-facing summary for the active auth mode."""
-    if api_key:
+    if api_key or os.environ.get("AGENT_BOM_API_KEYS", "").strip():
         return "API key required (Bearer / X-API-Key)"
     if bearer_token:
         return "Bearer token required"

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -38,6 +38,29 @@ _SECURITY_SEVERITY_SCORE = {
     Severity.UNKNOWN: "0.0",
 }
 
+_FRAMEWORK_TAXONOMY_META: dict[str, tuple[str, str, str]] = {
+    "owasp_tags": (
+        "owasp-llm-top10",
+        "OWASP Top 10 for Large Language Model Applications",
+        "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
+    ),
+    "atlas_tags": ("mitre-atlas", "MITRE ATLAS", "https://atlas.mitre.org/"),
+    "attack_tags": ("mitre-attack", "MITRE ATT&CK", "https://attack.mitre.org/"),
+    "nist_ai_rmf_tags": ("nist-ai-rmf", "NIST AI Risk Management Framework", "https://www.nist.gov/itl/ai-risk-management-framework"),
+    "owasp_mcp_tags": ("owasp-mcp", "OWASP MCP Security", "https://owasp.org/"),
+    "owasp_agentic_tags": ("owasp-agentic", "OWASP Agentic AI Security", "https://owasp.org/"),
+    "eu_ai_act_tags": ("eu-ai-act", "EU AI Act", "https://artificialintelligenceact.eu/"),
+    "nist_csf_tags": ("nist-csf", "NIST Cybersecurity Framework", "https://www.nist.gov/cyberframework"),
+    "iso_27001_tags": ("iso-27001", "ISO/IEC 27001", "https://www.iso.org/standard/27001"),
+    "soc2_tags": (
+        "soc2",
+        "SOC 2 Trust Services Criteria",
+        "https://www.aicpa-cima.com/resources/landing/system-and-organization-controls-soc-suite-of-services",
+    ),
+    "cis_tags": ("cis-controls", "CIS Controls", "https://www.cisecurity.org/controls"),
+    "cmmc_tags": ("cmmc", "Cybersecurity Maturity Model Certification", "https://dodcio.defense.gov/CMMC/"),
+}
+
 
 def _to_relative_path(path: str) -> str:
     """Convert an absolute path to a relative path suitable for SARIF.
@@ -81,6 +104,36 @@ def _sanitize_sarif_text(field_name: str, value: Any, *, fallback: str = "") -> 
     if redacted is None:
         return fallback
     return str(redacted)
+
+
+def _build_run_taxonomies(results: list[dict]) -> list[dict]:
+    """Build SARIF run-level taxonomies from per-result framework tags."""
+    tags_by_property: dict[str, set[str]] = {key: set() for key in _FRAMEWORK_TAXONOMY_META}
+    for result in results:
+        properties = result.get("properties") or {}
+        if not isinstance(properties, dict):
+            continue
+        for property_name in tags_by_property:
+            raw_tags = properties.get(property_name) or []
+            if isinstance(raw_tags, str):
+                raw_tags = [raw_tags]
+            if isinstance(raw_tags, list):
+                tags_by_property[property_name].update(str(tag) for tag in raw_tags if str(tag).strip())
+
+    taxonomies: list[dict] = []
+    for property_name, tags in tags_by_property.items():
+        if not tags:
+            continue
+        name, full_name, uri = _FRAMEWORK_TAXONOMY_META[property_name]
+        taxonomies.append(
+            {
+                "name": name,
+                "fullName": full_name,
+                "informationUri": uri,
+                "taxa": [{"id": tag, "name": tag} for tag in sorted(tags)],
+            }
+        )
+    return taxonomies
 
 
 def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
@@ -521,23 +574,26 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
                 }
             )
 
+    taxonomies = _build_run_taxonomies(results)
+    run: dict = {
+        "tool": {
+            "driver": {
+                "name": "agent-bom",
+                "version": report.tool_version,
+                "informationUri": "https://github.com/msaad00/agent-bom",
+                "rules": rules,
+            }
+        },
+        "results": results,
+        **({"automationDetails": {"id": f"agent-bom/{report.scan_id}"}} if report.scan_id else {}),
+    }
+    if taxonomies:
+        run["taxonomies"] = taxonomies
+
     return {
         "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
         "version": "2.1.0",
-        "runs": [
-            {
-                "tool": {
-                    "driver": {
-                        "name": "agent-bom",
-                        "version": report.tool_version,
-                        "informationUri": "https://github.com/msaad00/agent-bom",
-                        "rules": rules,
-                    }
-                },
-                "results": results,
-                **({"automationDetails": {"id": f"agent-bom/{report.scan_id}"}} if report.scan_id else {}),
-            }
-        ],
+        "runs": [run],
     }
 
 

--- a/src/agent_bom/skills_service.py
+++ b/src/agent_bom/skills_service.py
@@ -284,7 +284,7 @@ def _review_to_status(report: SkillFileReport) -> ThreatIntelStatus:
     verdict = report.trust.review_verdict.value
     if verdict == "trusted":
         return ThreatIntelStatus.CLEAN
-    if verdict == "blocked":
+    if verdict in {"blocked", "high_risk"}:
         return ThreatIntelStatus.MALICIOUS
     return ThreatIntelStatus.SUSPICIOUS
 

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -11,7 +11,7 @@ import pytest
 from fastapi import Response
 from starlette.testclient import TestClient
 
-from agent_bom.api.auth import KeyStore, Role, create_api_key, get_key_store, set_key_store
+from agent_bom.api.auth import KeyStore, Role, create_api_key, create_api_key_record, get_key_store, set_key_store
 from agent_bom.api.browser_session import (
     CSRF_COOKIE_NAME,
     CSRF_HEADER_NAME,
@@ -28,6 +28,7 @@ from agent_bom.api.server import (
     RateLimitMiddleware,
     app,
     configure_api,
+    configure_api_from_env,
 )
 
 
@@ -42,6 +43,56 @@ def test_health_no_auth():
     client = TestClient(app)
     resp = client.get("/health")
     assert resp.status_code == 200
+
+
+def test_direct_asgi_import_configures_static_api_key_from_env(monkeypatch):
+    """Raw uvicorn imports must honor AGENT_BOM_API_KEY without the CLI wrapper."""
+    raw_key = "raw-uvicorn-static-key"
+    monkeypatch.setenv("AGENT_BOM_API_KEY", raw_key)
+    configure_api_from_env()
+    try:
+        client = TestClient(app)
+        assert client.get("/v1/auth/policy").status_code == 401
+        assert client.get("/v1/auth/policy", headers={"Authorization": f"Bearer {raw_key}"}).status_code == 200
+    finally:
+        monkeypatch.delenv("AGENT_BOM_API_KEY", raising=False)
+        configure_api(api_key=None)
+
+
+def test_direct_asgi_import_configures_rbac_api_keys_from_env(monkeypatch):
+    """AGENT_BOM_API_KEYS should fail closed and preserve per-key roles."""
+    raw_admin = "raw-uvicorn-admin-key"
+    raw_viewer = "raw-uvicorn-viewer-key"
+    original_store = get_key_store()
+    set_key_store(KeyStore())
+    monkeypatch.setattr("agent_bom.api.server._env_api_keys_seeded", False)
+    monkeypatch.setenv("AGENT_BOM_API_KEYS", f"{raw_admin}:admin,{raw_viewer}:viewer")
+    configure_api_from_env()
+    try:
+        client = TestClient(app)
+        assert client.get("/v1/auth/policy").status_code == 401
+        assert client.get("/v1/auth/policy", headers={"Authorization": f"Bearer {raw_admin}"}).status_code == 200
+        denied = client.post("/v1/auth/keys", json={"name": "new", "role": "viewer"}, headers={"Authorization": f"Bearer {raw_viewer}"})
+        assert denied.status_code == 403
+        allowed = client.post("/v1/auth/keys", json={"name": "new", "role": "viewer"}, headers={"Authorization": f"Bearer {raw_admin}"})
+        assert allowed.status_code == 201
+    finally:
+        monkeypatch.delenv("AGENT_BOM_API_KEYS", raising=False)
+        set_key_store(original_store)
+        monkeypatch.setattr("agent_bom.api.server._env_api_keys_seeded", False)
+        configure_api(api_key=None)
+
+
+def test_create_api_key_record_verifies_operator_supplied_key():
+    """Operator-supplied env keys must be stored as hashes, not raw material."""
+    raw_key = "operator-provided-api-key"
+    store = KeyStore()
+    record = create_api_key_record(raw_key, "env:admin:1", Role.ADMIN)
+    store.add(record)
+
+    assert record.key_hash != raw_key
+    assert store.verify(raw_key) == record
+    assert store.verify("wrong") is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_exploit_likelihood.py
+++ b/tests/test_exploit_likelihood.py
@@ -97,6 +97,22 @@ def test_sarif_embeds_exploit_likelihood_on_rule_and_result():
     assert result["properties"]["exploit_likelihood"] == "actively_exploited"
 
 
+def test_sarif_embeds_run_level_framework_taxonomies():
+    from agent_bom.models import AIBOMReport
+
+    br = _br(_vuln())
+    br.owasp_tags = ["LLM05"]
+    br.atlas_tags = ["AML.T0010"]
+    sarif = to_sarif(AIBOMReport(blast_radii=[br], tool_version="0.86.0"))
+
+    taxonomies = sarif["runs"][0]["taxonomies"]
+    taxonomy_names = {taxonomy["name"] for taxonomy in taxonomies}
+    assert {"owasp-llm-top10", "mitre-atlas"}.issubset(taxonomy_names)
+    taxa_by_name = {taxonomy["name"]: {taxon["id"] for taxon in taxonomy["taxa"]} for taxonomy in taxonomies}
+    assert "LLM05" in taxa_by_name["owasp-llm-top10"]
+    assert "AML.T0010" in taxa_by_name["mitre-atlas"]
+
+
 # ── HTML propagation ────────────────────────────────────────────────────
 
 

--- a/tests/test_skills_service.py
+++ b/tests/test_skills_service.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 from agent_bom.skill_bundles import build_skill_bundle
-from agent_bom.skills_service import rescan_skill_catalog, scan_skill_targets
+from agent_bom.skill_intel import ThreatIntelStatus
+from agent_bom.skills_service import _review_to_status, rescan_skill_catalog, scan_skill_targets
 
 
 def test_scan_skill_targets_records_catalog_and_intel(tmp_path):
@@ -50,6 +52,13 @@ def test_scan_skill_targets_records_catalog_and_intel(tmp_path):
     assert payload["schema_version"] == "1"
     assert payload["report_type"] == "skills_scan"
     assert payload["generated_at"].endswith("Z")
+
+
+def test_high_risk_local_skill_review_counts_as_malicious_status():
+    """Local high-risk verdicts should not drift from malicious summary counts."""
+    report = SimpleNamespace(threat_intel=None, trust=SimpleNamespace(review_verdict=SimpleNamespace(value="high_risk")))
+
+    assert _review_to_status(report) == ThreatIntelStatus.MALICIOUS
 
 
 def test_scan_skill_targets_redacts_server_args_in_output(tmp_path):


### PR DESCRIPTION
## Summary

Closes the release-audit gaps that were validated against current `main`:

- hardens direct ASGI/raw-uvicorn imports by honoring `AGENT_BOM_API_KEY` and `AGENT_BOM_API_KEYS` without relying on the `agent-bom api` CLI wrapper
- stores operator-supplied RBAC keys as hashed `ApiKey` records and preserves admin/analyst/viewer authorization semantics
- aligns local high-risk skills verdicts with `malicious_status_files` so the scan summary no longer reports contradictory counters
- emits SARIF run-level framework taxonomies from per-result OWASP/ATLAS/etc. tags, while keeping existing per-result properties

## Why

The CLI and Helm entrypoints were already safe, but `uvicorn agent_bom.api.server:app` skipped `configure_api()` and could silently run unauthenticated even with API key env vars set. The skills and SARIF changes close two P2 release-audit findings around summary correctness and downstream code-scanning metadata.

## Validation

- `PYTHONPATH=src uv run ruff check src/agent_bom/api/auth.py src/agent_bom/api/server.py src/agent_bom/cli/_server.py src/agent_bom/output/sarif.py src/agent_bom/skills_service.py tests/test_api_hardening.py tests/test_exploit_likelihood.py tests/test_skills_service.py`
- `PYTHONPATH=src uv run pytest tests/test_api_hardening.py tests/test_exploit_likelihood.py tests/test_skills_service.py -q` -> 75 passed, 4 warnings
- `PYTHONPATH=src uv run mypy src/agent_bom/api/auth.py src/agent_bom/api/server.py src/agent_bom/cli/_server.py src/agent_bom/output/sarif.py src/agent_bom/skills_service.py`
- pre-commit on committed files -> passed
