### PR TITLE
docs(graph): add best-in-class epic closure proof

### DIFF
--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -86,12 +86,23 @@ fixed-verified, accepted-risk, and false-positive states. It is intentionally
 not a claim of customer-wide real-world false-positive or false-negative rates;
 those require a published external corpus.
 
+## Inspect graph epic proof
+
+Graph release claims are backed by the closure artifact in
+[`docs/graph/WIZ_CLASS_GRAPH_PROOF.md`](graph/WIZ_CLASS_GRAPH_PROOF.md):
+
+```bash
+python scripts/check_graph_epic_proof.py
+pytest tests/test_graph_schema_ui_parity.py tests/test_graph_edge_counts.py tests/test_graph_visual_snapshot.py tests/test_effective_reach.py tests/test_evidence_policy.py
+```
+
 ## What this proves
 
 - the distribution artifacts were signed by GitHub Actions OIDC via Sigstore
 - the build provenance is available as SLSA attestations
 - the release includes a self-SBOM that can be inspected or rescanned later
 - scanner accuracy claims are backed by a versioned local evidence artifact
+- graph readability/trust claims are linked to deterministic, checked-in proof
 
 This is the release trust baseline. Runtime trust, container attestations, and
 registry-specific provenance still live in their own workflows and docs.

--- a/docs/graph/WIZ_CLASS_GRAPH_PROOF.md
+++ b/docs/graph/WIZ_CLASS_GRAPH_PROOF.md
@@ -1,0 +1,117 @@
+# Wiz-Class Graph Epic Closure Proof
+
+This proof is the closure artifact for #2254. It records what is now guaranteed by the repo, where the deterministic evidence lives, and what remains outside the current guarantee.
+
+## GitHub issue state
+
+Verified on 2026-05-05 with `gh issue view`:
+
+| Issue | State | Closed at | Proof surface |
+|---|---:|---|---|
+| #2255 typed schema codegen | CLOSED | 2026-05-05T01:51:44Z | Python graph enums in `src/agent_bom/graph/types.py`; generated UI schema in `ui/lib/graph-schema.generated.ts`; parity guard in `tests/test_graph_schema_ui_parity.py` |
+| #2256 per-graph layouts | CLOSED | 2026-05-05T02:00:30Z | Layout hooks under `ui/lib/use-*-layout.ts`; dispatcher in `ui/lib/use-graph-layout.ts`; guard in `ui/tests/use-graph-layout.test.tsx` |
+| #2257 LOD, aggregation, focus | CLOSED | 2026-05-05T03:46:51Z | LOD resolver in `ui/lib/lod-renderer.ts`; sibling cluster pills in `ui/components/lineage-nodes.tsx`; focused defaults in `ui/components/lineage-filter.tsx`; guards in `ui/tests/lod-renderer.test.ts` |
+| #2258 filter algebra | CLOSED | 2026-05-05T03:34:46Z | Constraint propagation in `ui/lib/filter-algebra.ts`; guard in `ui/tests/filter-algebra.test.ts` |
+| #2259 accuracy guards | CLOSED | 2026-05-05T03:25:33Z | Round-trip, edge-count, and graph payload snapshot guards in `tests/test_graph_roundtrip.py`, `tests/test_graph_edge_counts.py`, and `tests/test_graph_visual_snapshot.py` |
+| #2260 graph contract docs | CLOSED | 2026-05-05T01:08:20Z | Operator/auditor contract in `docs/graph/CONTRACT.md` |
+| #2261 two-bucket evidence | CLOSED | 2026-05-05T04:58:33Z | Redaction policy in `src/agent_bom/evidence/policy.py`; persistence-path guard in `tests/test_evidence_policy.py` |
+| #2262 effective reach | CLOSED | 2026-05-05T04:58:33Z | Scoring in `src/agent_bom/effective_reach.py`; snapshots in `tests/fixtures/effective_reach_snapshots.json`; guard in `tests/test_effective_reach.py` |
+
+## Current guarantees
+
+### Schema codegen
+
+The Python graph schema is the source of truth for entity types, relationship types, layouts, semantic layers, severities, and default graph filters. UI schema drift is guarded by `tests/test_graph_schema_ui_parity.py`, which compares the checked-in TypeScript schema against Python enums and defaults.
+
+### Layouts
+
+The graph layout dispatcher resolves UI aliases and canonical `GraphLayout` enum values to deterministic layout hooks:
+
+| Surface | Default layout proof |
+|---|---|
+| Mesh/topology aliases | `topology` and `spawn-tree` resolve to Dagre directions in `ui/lib/use-graph-layout.ts` |
+| Security graph | Force layout is a first-class dispatcher target |
+| Lineage graph | `dagre-lr` is a first-class dispatcher target |
+| Scan pipeline DAG | Sankey is a first-class dispatcher target |
+
+`ui/tests/use-graph-layout.test.tsx` pins alias resolution and verifies radial, Dagre, Dagre-LR aliasing, and Sankey selection without a browser.
+
+### LOD, aggregation, and focus
+
+Readability is split into deterministic controls:
+
+- Zoom levels resolve to `cluster`, `summary`, or `detail` bands in `ui/lib/lod-renderer.ts`.
+- Low-zoom cluster rendering only activates when aggregation materially reduces node count, avoiding unlabeled dot fields.
+- Sibling fan-outs render as cluster pills in `ui/components/lineage-nodes.tsx`.
+- Focused graph filters default to bounded depth/hops through `GraphFilterOptions` and `lineage-filter`.
+
+`ui/tests/lod-renderer.test.ts` pins the zoom thresholds and the aggregation fallback.
+
+### Filter algebra
+
+Filters are not independent toggles. `ui/lib/filter-algebra.ts` applies severity, layer, agent, runtime mode, and relationship scope as a propagated constraint system, then returns valid next values for each filter dimension. `ui/tests/filter-algebra.test.ts` exercises the behavior on a synthetic graph with distinguishable inventory, attack, and runtime edges.
+
+### Accuracy guards
+
+The graph has three deterministic accuracy gates:
+
+- Round-trip inventory subset guard: graph build must preserve structural inventory entities.
+- Edge-count guard: `tests/fixtures/graph_edge_counts.json` pins the trimmed self-scan fixture with a 5% tolerance.
+- Payload snapshot guard: `tests/fixtures/graph-snapshots/security-graph.json` pins graph payload schema, node IDs, edge triples, node-kind distribution, and edge-kind distribution.
+
+Current checked-in payload snapshot:
+
+- Schema: `agent-bom.graph-snapshot/v1`
+- Nodes: 11
+- Edges: 10
+- Node kinds: `agent=1`, `server=8`, `vulnerability=2`
+- Edge kinds: `uses=8`, `vulnerable_to=2`
+
+This is intentionally a pure graph-payload guard. It catches dropped nodes, dropped edges, renamed kinds, swapped labels, and distribution drift without requiring Playwright, a live backend, or a browser.
+
+### Two-bucket evidence
+
+Evidence is classified before durable persistence:
+
+- `safe_to_store`: package versions, lockfile source, exposed tool names, declared scopes, command names, hostnames, env var names, client/agent IDs, timestamps, status codes, trace IDs, severity and advisory metadata, and effective-reach fields.
+- `replay_only`: raw prompts, tool inputs/outputs, full paths, full URLs, command args, request/response bodies, stdout/stderr, workspace content, and unknown keys.
+
+`tests/test_evidence_policy.py` verifies classification, recursive redaction, persistence-path redaction, replay TTL cleanup, capture-replay opt-in, and badge state.
+
+### Effective reach
+
+Effective reach is a first-class graph signal and edge-adjacent rendering input. `tests/test_effective_reach.py` pins the core scenarios:
+
+- Low reach: vulnerable package behind read-only search tool, no credential exposure, `green`, composite `27.4`.
+- High reach: same class of package behind `run_shell`, visible `AWS_*`/GitHub env names, two reachable agents, `pulsing-red`, composite `100.0`.
+
+The snapshot fixture records reachable agents, tools, credential names, CVSS, EPSS, KEV status, tool capability, credential visibility, breadth, band, and composite.
+
+### Layout dispatcher
+
+The merged dispatcher (#2292) is part of this closure proof because it removes per-surface layout drift. `resolveGraphLayoutKind()` maps canonical layout enum values and UI aliases to one concrete hook surface: `force`, `radial`, `dagre`, `dagre-lr`, or `sankey`.
+
+## Honest limits
+
+These limits do not block #2254 closure, but they define what this proof does not claim:
+
+- The Python graph-payload snapshot is not a screenshot or pixel-diff test. It is stronger for graph-data regressions and intentionally does not prove CSS, canvas, or React Flow rendering.
+- The checked-in self-scan fixture for accuracy gates is trimmed to 11 nodes and 10 edges. The epic's larger 244-node / 302-edge readability target is covered by deterministic UI algorithms and child issue closure, not by a live browser proof in this PR.
+- Static graph edges are reachability and correlation claims, not causality claims. Runtime causality still requires proxy/gateway traces.
+- Cross-cluster federation, cross-cloud trust relationships, multi-region asset stitching, and non-MCP agent collaboration remain out of contract per `docs/graph/CONTRACT.md`.
+
+## Closure verdict
+
+The proof is sufficient to close #2254: every child issue #2255-#2262 is closed, each acceptance area has a deterministic repo-backed proof surface, and the remaining limits are explicitly documented as non-blocking boundaries rather than missing child work.
+
+Suggested PR body line:
+
+```text
+Closes #2254.
+```
+
+Validation command for this artifact:
+
+```bash
+python scripts/check_graph_epic_proof.py
+```

--- a/scripts/check_graph_epic_proof.py
+++ b/scripts/check_graph_epic_proof.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Pure checks for the #2254 graph epic closure proof.
+
+This script intentionally does not require a browser, backend, GitHub token, or
+network access. It verifies that the closure document points at checked-in proof
+surfaces and that the deterministic graph/effective-reach fixtures still carry
+the values claimed by the proof.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PROOF = ROOT / "docs" / "graph" / "WIZ_CLASS_GRAPH_PROOF.md"
+EDGE_COUNTS = ROOT / "tests" / "fixtures" / "graph_edge_counts.json"
+GRAPH_SNAPSHOT = ROOT / "tests" / "fixtures" / "graph-snapshots" / "security-graph.json"
+EFFECTIVE_REACH = ROOT / "tests" / "fixtures" / "effective_reach_snapshots.json"
+
+REQUIRED_FILES = [
+    PROOF,
+    ROOT / "docs" / "graph" / "CONTRACT.md",
+    ROOT / "src" / "agent_bom" / "graph" / "types.py",
+    ROOT / "src" / "agent_bom" / "effective_reach.py",
+    ROOT / "src" / "agent_bom" / "evidence" / "policy.py",
+    ROOT / "ui" / "lib" / "graph-schema.generated.ts",
+    ROOT / "ui" / "lib" / "use-graph-layout.ts",
+    ROOT / "ui" / "lib" / "filter-algebra.ts",
+    ROOT / "ui" / "lib" / "lod-renderer.ts",
+    ROOT / "ui" / "components" / "lineage-nodes.tsx",
+    ROOT / "tests" / "test_graph_schema_ui_parity.py",
+    ROOT / "tests" / "test_graph_edge_counts.py",
+    ROOT / "tests" / "test_graph_visual_snapshot.py",
+    ROOT / "tests" / "test_evidence_policy.py",
+    ROOT / "tests" / "test_effective_reach.py",
+    ROOT / "ui" / "tests" / "use-graph-layout.test.tsx",
+    ROOT / "ui" / "tests" / "lod-renderer.test.ts",
+    ROOT / "ui" / "tests" / "filter-algebra.test.ts",
+]
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _assert(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def check_required_files() -> None:
+    missing = [str(path.relative_to(ROOT)) for path in REQUIRED_FILES if not path.exists()]
+    _assert(not missing, "Missing graph proof surfaces: " + ", ".join(missing))
+
+
+def check_proof_doc() -> None:
+    text = PROOF.read_text(encoding="utf-8")
+    for issue in range(2254, 2263):
+        _assert(f"#{issue}" in text, f"Proof doc must reference #{issue}")
+    for phrase in (
+        "Schema codegen",
+        "Layouts",
+        "LOD, aggregation, and focus",
+        "Filter algebra",
+        "Accuracy guards",
+        "Two-bucket evidence",
+        "Effective reach",
+        "Layout dispatcher",
+        "Honest limits",
+        "Closes #2254",
+    ):
+        _assert(phrase in text, f"Proof doc missing section/phrase: {phrase}")
+
+
+def check_graph_fixtures() -> None:
+    edge_counts = _load_json(EDGE_COUNTS)
+    snapshot = _load_json(GRAPH_SNAPSHOT)
+
+    _assert(edge_counts["_meta"]["tolerance_pct"] == 5, "Edge-count tolerance must stay at 5%")
+    _assert(snapshot["schema"] == "agent-bom.graph-snapshot/v1", "Unexpected graph snapshot schema")
+    _assert(snapshot["node_count"] == 11, "Proof doc expects 11 snapshot nodes")
+    _assert(snapshot["edge_count"] == 10, "Proof doc expects 10 snapshot edges")
+    _assert(snapshot["node_kind_counts"] == edge_counts["node_counts"], "Node kind counts drifted from edge baseline")
+    _assert(snapshot["edge_kind_counts"] == edge_counts["edge_counts"], "Edge kind counts drifted from edge baseline")
+
+
+def check_effective_reach_fixture() -> None:
+    reach = _load_json(EFFECTIVE_REACH)
+    low = reach["low_reach"]
+    high = reach["high_reach"]
+
+    _assert(low["band"] == "green", "Low-reach fixture must stay green")
+    _assert(low["composite"] == 27.4, "Low-reach composite drifted")
+    _assert(low["reachable_tools"] == ["search_documents"], "Low-reach tool set drifted")
+    _assert(high["band"] == "pulsing-red", "High-reach fixture must stay pulsing-red")
+    _assert(high["composite"] == 100.0, "High-reach composite drifted")
+    _assert(high["agent_breadth"] == 2, "High-reach breadth drifted")
+    _assert("run_shell" in high["reachable_tools"], "High-reach fixture must include run_shell")
+    _assert("AWS_ACCESS_KEY_ID" in high["reachable_creds"], "High-reach fixture must include AWS visibility")
+
+
+def main() -> None:
+    check_required_files()
+    check_proof_doc()
+    check_graph_fixtures()
+    check_effective_reach_fixture()
+    print("graph epic proof checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes #2254.

Adds a deterministic closure proof for the best-in-class graph quality epic:

- records every child issue #2255-#2262 and its checked-in proof surface
- documents the current guarantees for schema codegen, layouts, LOD/aggregation/focus, filter algebra, accuracy guards, two-bucket evidence, effective reach, and the central layout dispatcher
- adds `scripts/check_graph_epic_proof.py` so the closure artifact can be verified without a browser, backend, GitHub token, or network access
- links the proof from `docs/RELEASE_VERIFICATION.md`

## Why

The graph epic had a lot of real implementation work spread across PRs. This gives the release a single audited artifact that says what is guaranteed, where the evidence lives, and what remains outside the current guarantee.

## Validation

- `python scripts/check_graph_epic_proof.py` -> graph epic proof checks passed
- `PYTHONPATH=src uv run pytest tests/test_graph_schema_ui_parity.py tests/test_graph_edge_counts.py tests/test_graph_visual_snapshot.py tests/test_effective_reach.py tests/test_evidence_policy.py -q` -> 55 passed
- pre-commit on committed files -> passed
