### PR TITLE
feat(snowflake): package phase 4 native app dry run

### DIFF
--- a/.github/workflows/release-snowflake.yml
+++ b/.github/workflows/release-snowflake.yml
@@ -1,0 +1,122 @@
+name: release-snowflake
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Optional Snowflake Native App version label, for example v0_86_0. Defaults to pyproject.toml.
+        required: false
+        default: ""
+        type: string
+      release_channel:
+        description: Snowflake release channel to target after dry-run review
+        required: true
+        default: private_preview
+        type: choice
+        options:
+          - private_preview
+          - public_preview
+          - general
+      dry_run:
+        description: Validate and package only; do not call Snowflake
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-snowflake-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  package:
+    name: Validate Native App package
+    runs-on: ubuntu-latest
+    outputs:
+      package_version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install validation dependencies
+        run: python -m pip install pyyaml
+
+      - name: Resolve package version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          from pathlib import Path
+          import os
+          import tomllib
+
+          supplied = os.environ.get("INPUT_VERSION", "").strip()
+          if supplied:
+              version = supplied
+          else:
+              project = tomllib.loads(Path("pyproject.toml").read_text())["project"]
+              version = "v" + str(project["version"]).replace(".", "_")
+          print(f"version={version}")
+          PY
+
+      - name: Validate manifest and service specs
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import yaml
+
+          root = Path("deploy/snowflake/native-app")
+          yaml.safe_load((root / "manifest.yml").read_text())
+          for spec in sorted((root / "service-specs").glob("*.yaml")):
+              data = yaml.safe_load(spec.read_text())
+              assert data.get("spec", {}).get("containers"), f"{spec} has no containers"
+          PY
+
+      - name: Build Snowflake Native App artifact
+        run: |
+          mkdir -p dist
+          tar -czf "dist/agent-bom-snowflake-${{ steps.version.outputs.version }}.tgz" \
+            -C deploy/snowflake/native-app .
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: agent-bom-snowflake-${{ steps.version.outputs.version }}
+          path: dist/agent-bom-snowflake-${{ steps.version.outputs.version }}.tgz
+          if-no-files-found: error
+
+  publish:
+    name: Publish release lane
+    runs-on: ubuntu-latest
+    needs: package
+    if: ${{ inputs.dry_run == false }}
+    environment: snowflake-marketplace
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: agent-bom-snowflake-${{ needs.package.outputs.package_version }}
+          path: dist
+
+      - name: Require Snowflake publisher configuration
+        env:
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+          SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
+          SNOWFLAKE_PRIVATE_KEY: ${{ secrets.SNOWFLAKE_PRIVATE_KEY }}
+          SNOWFLAKE_APPLICATION_PACKAGE: ${{ vars.SNOWFLAKE_APPLICATION_PACKAGE }}
+        run: |
+          test -n "$SNOWFLAKE_ACCOUNT"
+          test -n "$SNOWFLAKE_USER"
+          test -n "$SNOWFLAKE_PRIVATE_KEY"
+          test -n "$SNOWFLAKE_APPLICATION_PACKAGE"
+
+      - name: Stop before live publish
+        run: |
+          echo "Snowflake CLI publish is intentionally gated until Marketplace listing approval."
+          echo "Artifact: dist/agent-bom-snowflake-${{ needs.package.outputs.package_version }}.tgz"
+          echo "Target channel: ${{ inputs.release_channel }}"
+          exit 1

--- a/.github/workflows/release-snowflake.yml
+++ b/.github/workflows/release-snowflake.yml
@@ -34,6 +34,7 @@ jobs:
   package:
     name: Validate Native App package
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     outputs:
       package_version: ${{ steps.version.outputs.version }}
     steps:
@@ -93,6 +94,7 @@ jobs:
   publish:
     name: Publish release lane
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: package
     if: ${{ inputs.dry_run == false }}
     environment: snowflake-marketplace

--- a/deploy/snowflake/native-app/manifest.yml
+++ b/deploy/snowflake/native-app/manifest.yml
@@ -17,6 +17,8 @@ artifacts:
     images:
       - /db/schema/agent_bom_repo/agent-bom:latest
       - /db/schema/agent_bom_repo/agent-bom-ui:latest
+      - /db/schema/agent_bom_repo/agent-bom-scanner:latest
+      - /db/schema/agent_bom_repo/agent-bom-mcp-runtime:latest
   service_roles:
     - name: api
       comment: >-
@@ -26,6 +28,16 @@ artifacts:
       comment: >-
         Grants USAGE on the Next.js dashboard service endpoint (port 3000).
         Assign to roles that need browser-based access to the agent-bom UI.
+    - name: scanner
+      comment: >-
+        Grants USAGE on the opt-in scanner service endpoint (port 8424).
+        Assign only after core.enable_scanner_service() has created the
+        service in the consumer account.
+    - name: mcp_runtime
+      comment: >-
+        Grants USAGE on the optional MCP runtime service endpoint (port 8423).
+        Assign only after core.enable_mcp_runtime_service() has created the
+        bearer-token protected runtime service.
 
 privileges:
   - CREATE COMPUTE POOL:
@@ -54,6 +66,18 @@ configuration:
   retention_days:
     type: NUMBER
     default: 90
+  enable_scanner_service:
+    type: BOOLEAN
+    default: false
+  enable_mcp_runtime_service:
+    type: BOOLEAN
+    default: false
+  scanner_service_name:
+    type: STRING
+    default: core.agent_bom_scanner
+  mcp_runtime_service_name:
+    type: STRING
+    default: core.agent_bom_mcp_runtime
 
 references:
   - cloud_asset_tables:

--- a/deploy/snowflake/native-app/scripts/setup.sql
+++ b/deploy/snowflake/native-app/scripts/setup.sql
@@ -61,6 +61,18 @@ INSERT INTO core.app_config (key, value)
     SELECT 'retention_days', PARSE_JSON('90')
     WHERE NOT EXISTS (SELECT 1 FROM core.app_config WHERE key = 'retention_days');
 
+INSERT INTO core.app_config (key, value)
+    SELECT 'enable_scanner_service', PARSE_JSON('false')
+    WHERE NOT EXISTS (SELECT 1 FROM core.app_config WHERE key = 'enable_scanner_service');
+
+INSERT INTO core.app_config (key, value)
+    SELECT 'enable_mcp_runtime_service', PARSE_JSON('false')
+    WHERE NOT EXISTS (SELECT 1 FROM core.app_config WHERE key = 'enable_mcp_runtime_service');
+
+INSERT INTO core.app_config (key, value)
+    SELECT 'advisory_egress_enabled', PARSE_JSON('false')
+    WHERE NOT EXISTS (SELECT 1 FROM core.app_config WHERE key = 'advisory_egress_enabled');
+
 -- 3c. Governance findings table
 CREATE TABLE IF NOT EXISTS core.governance_findings (
     finding_id VARCHAR PRIMARY KEY,
@@ -172,7 +184,38 @@ END;
 
 GRANT USAGE ON PROCEDURE core.trigger_scan() TO APPLICATION ROLE app_user;
 
--- 10. Auto-scan scheduled task (consumer starts with ALTER TASK ... RESUME)
+-- 10. Customer post-install health check.
+-- This is intentionally read-only and surfaces the service toggles that matter
+-- during Marketplace/private-preview validation.
+CREATE OR REPLACE PROCEDURE core.health_check()
+    RETURNS VARIANT
+    LANGUAGE SQL
+AS
+BEGIN
+    RETURN OBJECT_CONSTRUCT(
+        'status', 'ok',
+        'api_service', 'core.agent_bom_api',
+        'scanner_service_enabled', (
+            SELECT COALESCE(value::BOOLEAN, FALSE)
+            FROM core.app_config
+            WHERE key = 'enable_scanner_service'
+        ),
+        'mcp_runtime_service_enabled', (
+            SELECT COALESCE(value::BOOLEAN, FALSE)
+            FROM core.app_config
+            WHERE key = 'enable_mcp_runtime_service'
+        ),
+        'advisory_egress_enabled', (
+            SELECT COALESCE(value::BOOLEAN, FALSE)
+            FROM core.app_config
+            WHERE key = 'advisory_egress_enabled'
+        )
+    );
+END;
+
+GRANT USAGE ON PROCEDURE core.health_check() TO APPLICATION ROLE app_user;
+
+-- 11. Auto-scan scheduled task (consumer starts with ALTER TASK ... RESUME)
 CREATE OR REPLACE TASK core.auto_scan_task
     WAREHOUSE = 'COMPUTE_WH'
     SCHEDULE = 'USING CRON 0 */6 * * * UTC'
@@ -183,7 +226,7 @@ AS
 -- Creates core.apply_compliance_hub() and core.compliance_posture view.
 EXECUTE IMMEDIATE FROM 'dcm/V002__compliance_proc.sql';
 
--- 7. SPCS service — API + Next.js UI (Phase 3)
+-- 12. SPCS service — API + Next.js UI (Phase 3)
 -- Consumer must provision a compute pool and grant it to the app before this runs.
 -- manifest.yml default_web_endpoint → ui endpoint (port 3000) opens on app launch.
 CREATE SERVICE IF NOT EXISTS core.agent_bom_api
@@ -197,3 +240,64 @@ GRANT USAGE ON SERVICE core.agent_bom_api TO APPLICATION ROLE app_user;
 -- API or UI access without exposing both.
 GRANT SERVICE ROLE core.agent_bom_api!api TO APPLICATION ROLE app_user;
 GRANT SERVICE ROLE core.agent_bom_api!ui  TO APPLICATION ROLE app_user;
+
+-- 13. Phase 4 opt-in SPCS scanner service
+-- Egress is not available to this container unless the customer binds all
+-- advisory-feed EAI references and explicitly calls this procedure.
+CREATE OR REPLACE PROCEDURE core.enable_scanner_service()
+    RETURNS VARCHAR
+    LANGUAGE SQL
+AS
+BEGIN
+    CREATE SERVICE IF NOT EXISTS core.agent_bom_scanner
+        IN COMPUTE POOL consumer_pool
+        FROM SPECIFICATION_FILE = '/service-specs/scanner-service.yaml'
+        EXTERNAL_ACCESS_INTEGRATIONS = (
+            reference('osv_dev'),
+            reference('cisa_kev'),
+            reference('first_epss'),
+            reference('github_ghsa')
+        )
+        MIN_INSTANCES = 1
+        MAX_INSTANCES = 1
+        AUTO_RESUME = FALSE;
+
+    GRANT USAGE ON SERVICE core.agent_bom_scanner TO APPLICATION ROLE app_user;
+    GRANT SERVICE ROLE core.agent_bom_scanner!scanner TO APPLICATION ROLE app_user;
+
+    CALL core.set_config('enable_scanner_service', PARSE_JSON('true'));
+    CALL core.set_config('advisory_egress_enabled', PARSE_JSON('true'));
+    RETURN 'Scanner service created. Resume explicitly with ALTER SERVICE core.agent_bom_scanner RESUME.';
+END;
+
+GRANT USAGE ON PROCEDURE core.enable_scanner_service() TO APPLICATION ROLE app_user;
+
+-- 14. Phase 4 optional MCP runtime service
+-- The runtime is default-off and requires a caller-provided bearer token.
+-- No advisory-feed EAI is attached here; this service has Snowflake-only
+-- networking unless a future procedure deliberately adds bounded egress.
+CREATE OR REPLACE PROCEDURE core.enable_mcp_runtime_service(mcp_bearer_token VARCHAR)
+    RETURNS VARCHAR
+    LANGUAGE SQL
+AS
+BEGIN
+    IF (mcp_bearer_token IS NULL OR LENGTH(TRIM(mcp_bearer_token)) < 32) THEN
+        RETURN 'MCP runtime not created: provide a bearer token with at least 32 characters.';
+    END IF;
+
+    CREATE SERVICE IF NOT EXISTS core.agent_bom_mcp_runtime
+        IN COMPUTE POOL consumer_pool
+        FROM SPECIFICATION_TEMPLATE_FILE = '/service-specs/mcp-runtime-service.yaml'
+        USING (mcp_bearer_token => :mcp_bearer_token)
+        MIN_INSTANCES = 1
+        MAX_INSTANCES = 1
+        AUTO_RESUME = FALSE;
+
+    GRANT USAGE ON SERVICE core.agent_bom_mcp_runtime TO APPLICATION ROLE app_user;
+    GRANT SERVICE ROLE core.agent_bom_mcp_runtime!mcp_runtime TO APPLICATION ROLE app_user;
+
+    CALL core.set_config('enable_mcp_runtime_service', PARSE_JSON('true'));
+    RETURN 'MCP runtime service created. Resume explicitly with ALTER SERVICE core.agent_bom_mcp_runtime RESUME.';
+END;
+
+GRANT USAGE ON PROCEDURE core.enable_mcp_runtime_service(VARCHAR) TO APPLICATION ROLE app_user;

--- a/deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml
+++ b/deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml
@@ -1,0 +1,37 @@
+spec:
+  containers:
+    - name: agent-bom-mcp-runtime
+      image: /db/schema/agent_bom_repo/agent-bom-mcp-runtime:latest
+      env:
+        SNOWFLAKE_ACCOUNT: "{{ snowflake_account }}"
+        SNOWFLAKE_DATABASE: "{{ database }}"
+        SNOWFLAKE_SCHEMA: "{{ schema }}"
+        AGENT_BOM_SNOWFLAKE_NATIVE_APP: "1"
+        AGENT_BOM_MCP_MODE: "1"
+        AGENT_BOM_MCP_BEARER_TOKEN: "{{ mcp_bearer_token }}"
+        AGENT_BOM_LOG_LEVEL: "INFO"
+      command:
+        - agent-bom
+        - mcp
+        - server
+        - --transport
+        - streamable-http
+        - --host
+        - "0.0.0.0"
+        - --port
+        - "8423"
+      readinessProbe:
+        port: 8423
+        path: /health
+      resources:
+        requests:
+          memory: 256M
+          cpu: 0.25
+        limits:
+          memory: 1G
+          cpu: 1
+
+  endpoints:
+    - name: mcp_runtime
+      port: 8423
+      public: false

--- a/deploy/snowflake/native-app/service-specs/scanner-service.yaml
+++ b/deploy/snowflake/native-app/service-specs/scanner-service.yaml
@@ -1,0 +1,47 @@
+spec:
+  containers:
+    - name: agent-bom-scanner
+      image: /db/schema/agent_bom_repo/agent-bom-scanner:latest
+      env:
+        SNOWFLAKE_ACCOUNT: "{{ snowflake_account }}"
+        SNOWFLAKE_DATABASE: "{{ database }}"
+        SNOWFLAKE_SCHEMA: "{{ schema }}"
+        SNOWFLAKE_AUTHENTICATOR: snowflake_jwt
+        AGENT_BOM_STORE_BACKEND: snowflake
+        AGENT_BOM_SNOWFLAKE_NATIVE_APP: "1"
+        AGENT_BOM_ENABLE_ADVISORY_EGRESS: "1"
+        AGENT_BOM_MCP_MODE: "0"
+        AGENT_BOM_LOG_LEVEL: "INFO"
+      command:
+        - agent-bom
+        - agents
+        - --snowflake
+        - --snowflake-authenticator
+        - snowflake_jwt
+        - --format
+        - json
+        - --output
+        - /tmp/agent-bom/snowflake-scan.json
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp/agent-bom
+      readinessProbe:
+        port: 8424
+        path: /health
+      resources:
+        requests:
+          memory: 512M
+          cpu: 0.5
+        limits:
+          memory: 2G
+          cpu: 2
+
+  volumes:
+    - name: tmp
+      source: local
+      size: 1Gi
+
+  endpoints:
+    - name: scanner
+      port: 8424
+      public: false

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,6 @@ Graph docs:
 - `graph/CONTRACT.md` — graph coverage, accuracy guarantees, scaling
   boundaries, non-promises, and known gaps
 - `graph/SECURITY_GRAPH_UX_RUBRIC.md` — review rubric for
-  Wiz/Orca/CrowdStrike-style graph usability and actionability
+  fix-first security graph usability and actionability
 
 Archived or historical writeups live under [`docs/archive`](archive/README.md).

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -89,7 +89,7 @@ those require a published external corpus.
 ## Inspect graph epic proof
 
 Graph release claims are backed by the closure artifact in
-[`docs/graph/WIZ_CLASS_GRAPH_PROOF.md`](graph/WIZ_CLASS_GRAPH_PROOF.md):
+[`docs/graph/SECURITY_GRAPH_EPIC_PROOF.md`](graph/SECURITY_GRAPH_EPIC_PROOF.md):
 
 ```bash
 python scripts/check_graph_epic_proof.py

--- a/docs/graph/SECURITY_GRAPH_EPIC_PROOF.md
+++ b/docs/graph/SECURITY_GRAPH_EPIC_PROOF.md
@@ -1,4 +1,4 @@
-# Wiz-Class Graph Epic Closure Proof
+# Best-In-Class Graph Epic Closure Proof
 
 This proof is the closure artifact for #2254. It records what is now guaranteed by the repo, where the deterministic evidence lives, and what remains outside the current guarantee.
 

--- a/docs/graph/SECURITY_GRAPH_UX_RUBRIC.md
+++ b/docs/graph/SECURITY_GRAPH_UX_RUBRIC.md
@@ -5,9 +5,8 @@ standard. Use it when changing `/graph`, `/security-graph`, `/mesh`,
 graph APIs, screenshots, or graph documentation.
 
 The target is a security-operator graph, not a generic node canvas. It should
-feel closer to the investigation workflows in products such as Wiz, Orca, and
-CrowdStrike: start with what to fix, explain why it matters, show the path to
-the impacted asset, and let the operator expand context only when needed.
+start with what to fix, explain why it matters, show the path to the impacted
+asset, and let the operator expand context only when needed.
 
 ## North Star
 

--- a/docs/snowflake-native-app/INSTALL.md
+++ b/docs/snowflake-native-app/INSTALL.md
@@ -9,6 +9,7 @@ Run the entire agent-bom AI-supply-chain security stack inside your own Snowflak
 - **Wiz-shaped dashboard** — Next.js with React Flow graph viz, hosted on Snowpark Container Services inside your account
 - **Audit log** with HMAC chain, OCSF-shaped events, customer-owned (we cannot read it)
 - **Zero data egress by default** — only customer-approved advisory feeds (OSV / KEV / EPSS / GHSA) reach outbound
+- **Opt-in Phase 4 services** — scanner and MCP runtime service specs are packaged, but neither starts until you call the enable procedures
 
 ## Prerequisites
 
@@ -72,7 +73,40 @@ agent-bom needs OSV / KEV / EPSS / GHSA to enrich findings with vulnerability me
 
 If you want fully air-gapped (no outbound network at all): leave all four EAIs OFF. agent-bom still scans + classifies; CVE enrichment is just less complete.
 
-## 5 — (Recommended) Set a network policy
+The packaged scanner service is also off by default. To run the SPCS scanner
+with advisory enrichment, bind all four EAI references first, then opt in:
+
+```sql
+CALL agent_bom.core.enable_scanner_service();
+ALTER SERVICE agent_bom.core.agent_bom_scanner RESUME;
+```
+
+The scanner service attaches only these EAIs:
+
+- `osv_dev`
+- `cisa_kev`
+- `first_epss`
+- `github_ghsa`
+
+If any EAI is unbound, service creation should fail before outbound access is
+available.
+
+## 5 — (Optional) Enable the MCP runtime service
+
+The MCP runtime service is packaged for customers that want read-only agent-bom
+MCP tools available inside the Native App boundary. It is not created during
+install, has no advisory-feed EAI attached, and requires an operator-provided
+bearer token.
+
+```sql
+CALL agent_bom.core.enable_mcp_runtime_service('<32+ character bearer token>');
+ALTER SERVICE agent_bom.core.agent_bom_mcp_runtime RESUME;
+```
+
+Store the bearer token in your own secret manager or Snowflake secret workflow.
+Do not hard-code it in the app package or worksheet history.
+
+## 6 — (Recommended) Set a network policy
 
 Restrict where the dashboard can be reached from. Templates in [`network_policies.sql`](../../deploy/snowflake/native-app/scripts/network_policies.sql):
 
@@ -82,7 +116,7 @@ Restrict where the dashboard can be reached from. Templates in [`network_policie
 ALTER APPLICATION agent_bom SET CONFIGURATION network_policy_name = 'AGENT_BOM_SOC_DEFAULT';
 ```
 
-## 6 — (Optional) Set up a service user with key-pair auth
+## 7 — (Optional) Set up a service user with key-pair auth
 
 If you want to push scan data into the app from CI/CD or external orchestration, create a dedicated service user with key-pair auth. Template: [`auth_keypair_setup.sql`](../../deploy/snowflake/native-app/scripts/auth_keypair_setup.sql).
 
@@ -101,7 +135,7 @@ export SNOWFLAKE_ACCOUNT=<your_account>
 agent-bom snowflake test-connection
 ```
 
-## 7 — Trigger your first scan
+## 8 — Trigger your first scan
 
 ```sql
 -- Manual scan
@@ -111,7 +145,7 @@ CALL agent_bom.core.trigger_scan();
 ALTER TASK agent_bom.core.auto_scan_task RESUME;
 ```
 
-## 8 — Open the dashboard
+## 9 — Open the dashboard
 
 The dashboard URL is exposed via the Native App's service endpoint. From Snowsight:
 
@@ -122,6 +156,11 @@ The dashboard URL is exposed via the Native App's service endpoint. From Snowsig
 ## What to verify after install
 
 ```sql
+-- Confirm the app installed and Phase 4 services remain default-off
+CALL agent_bom.core.health_check();
+-- Expected: status=ok, scanner_service_enabled=false,
+-- mcp_runtime_service_enabled=false, advisory_egress_enabled=false
+
 -- Confirm zero account-level grants leaked through
 USE ROLE agent_bom.app_user;
 SHOW GRANTS TO APPLICATION ROLE agent_bom.app_user;
@@ -131,6 +170,9 @@ SHOW GRANTS ON DATABASE YOUR_DB;  -- should show NO grants to APPLICATION agent_
 
 -- Confirm EAI scope (only the four advisory feeds)
 SHOW EXTERNAL ACCESS INTEGRATIONS LIKE 'AGENT_BOM_%';
+
+-- Confirm no scanner egress until explicit opt-in
+SHOW SERVICES LIKE 'AGENT_BOM_SCANNER' IN SCHEMA agent_bom.core;
 ```
 
 ## Uninstall
@@ -147,4 +189,5 @@ This removes the app's compute pool, services, schemas, and all data agent-bom c
 - [Identity and naming contract](../IDENTITY_AND_NAMING_CONTRACT.md) — what's fixed vs customer-controlled
 - [Policy precedence](../POLICY_PRECEDENCE.md) — firewall / gateway / proxy / CLI layering
 - [Runtime reference](../RUNTIME_REFERENCE.md) — five runtime surfaces map
+- [Marketplace release lane](MARKETPLACE.md) — dry-run packaging and listing proof
 - Native App epic: [#2214](https://github.com/msaad00/agent-bom/issues/2214)

--- a/docs/snowflake-native-app/INSTALL.md
+++ b/docs/snowflake-native-app/INSTALL.md
@@ -6,7 +6,7 @@ Run the entire agent-bom AI-supply-chain security stack inside your own Snowflak
 
 - **15-framework compliance posture** — SOC 2, ISO 27001, FedRAMP, EU AI Act, NIST AI RMF, NIST CSF, OWASP LLM/MCP/Agentic, MITRE ATLAS, CIS Controls, CMMC, NIST 800-53, PCI DSS — automatically classifying findings from your existing scanner outputs
 - **Inventory + blast radius** across structured cloud asset tables, semi-structured event JSON, and unstructured stages (notebooks, IaC, model artifacts, prompt corpora)
-- **Wiz-shaped dashboard** — Next.js with React Flow graph viz, hosted on Snowpark Container Services inside your account
+- **Fix-first security dashboard** — Next.js with React Flow graph viz, hosted on Snowpark Container Services inside your account
 - **Audit log** with HMAC chain, OCSF-shaped events, customer-owned (we cannot read it)
 - **Zero data egress by default** — only customer-approved advisory feeds (OSV / KEV / EPSS / GHSA) reach outbound
 - **Opt-in Phase 4 services** — scanner and MCP runtime service specs are packaged, but neither starts until you call the enable procedures

--- a/docs/snowflake-native-app/MARKETPLACE.md
+++ b/docs/snowflake-native-app/MARKETPLACE.md
@@ -1,0 +1,78 @@
+# Snowflake Marketplace release lane
+
+This is the provider-side checklist for publishing agent-bom as a Snowflake
+Native App. It is intentionally dry-run first: the GitHub Actions lane packages
+the app and validates the manifest, but live publish remains blocked until the
+Marketplace listing has been reviewed and explicit Snowflake publisher secrets
+are configured.
+
+## Listing draft
+
+| Field | Draft value |
+|---|---|
+| Listing name | agent-bom - AI Supply Chain Security |
+| Category | Security and Governance |
+| Delivery method | Snowflake Native App with Snowpark Container Services |
+| Data boundary | Customer account only; no customer data leaves Snowflake |
+| Default egress | Off |
+| Optional egress | OSV.dev, CISA KEV, FIRST EPSS, GitHub Advisory Database |
+| Runtime services | API/UI by default; scanner and MCP runtime are opt-in |
+
+## Required proof before publish
+
+- Manifest review proves references are customer-bound and read-only.
+- Service specs validate as YAML and declare internal-only endpoints.
+- Advisory egress is attached only to `core.enable_scanner_service()`.
+- MCP runtime is not created during install and requires a caller-supplied
+  bearer token.
+- The release workflow is manually dispatched and defaults to `dry_run: true`.
+- If no version input is supplied, the workflow derives the Snowflake package
+  label from `pyproject.toml` (`0.86.0` -> `v0_86_0`) so package labels do not
+  drift from the release version.
+- Live publish requires the protected `snowflake-marketplace` environment plus
+  `SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_USER`, `SNOWFLAKE_PRIVATE_KEY`, and
+  `SNOWFLAKE_APPLICATION_PACKAGE`.
+
+## Manual dry run
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import yaml
+
+root = Path("deploy/snowflake/native-app")
+yaml.safe_load((root / "manifest.yml").read_text())
+for spec in sorted((root / "service-specs").glob("*.yaml")):
+    data = yaml.safe_load(spec.read_text())
+    assert data.get("spec", {}).get("containers"), spec
+PY
+
+mkdir -p dist
+tar -czf dist/agent-bom-snowflake-v0_86_0.tgz -C deploy/snowflake/native-app .
+```
+
+## Customer smoke checklist
+
+Run this checklist in a private-preview account before requesting Marketplace
+review:
+
+```sql
+CALL agent_bom.core.health_check();
+SHOW SERVICES IN APPLICATION agent_bom;
+SHOW EXTERNAL ACCESS INTEGRATIONS LIKE 'AGENT_BOM_%';
+```
+
+Expected state after install:
+
+- `core.agent_bom_api` exists and exposes the UI endpoint.
+- `core.agent_bom_scanner` does not run until
+  `core.enable_scanner_service()` is called.
+- `core.agent_bom_mcp_runtime` does not run until
+  `core.enable_mcp_runtime_service('<token>')` is called.
+- Advisory-feed EAIs remain disabled/unbound until the customer explicitly
+  approves OSV, CISA KEV, FIRST EPSS, and GHSA.
+
+## Live publish status
+
+Not enabled in this PR. The workflow stops before calling Snowflake when
+`dry_run` is false, so no Marketplace channel can be mutated by accident.

--- a/scripts/check_graph_epic_proof.py
+++ b/scripts/check_graph_epic_proof.py
@@ -13,7 +13,7 @@ import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-PROOF = ROOT / "docs" / "graph" / "WIZ_CLASS_GRAPH_PROOF.md"
+PROOF = ROOT / "docs" / "graph" / "SECURITY_GRAPH_EPIC_PROOF.md"
 EDGE_COUNTS = ROOT / "tests" / "fixtures" / "graph_edge_counts.json"
 GRAPH_SNAPSHOT = ROOT / "tests" / "fixtures" / "graph-snapshots" / "security-graph.json"
 EFFECTIVE_REACH = ROOT / "tests" / "fixtures" / "effective_reach_snapshots.json"

--- a/site-docs/deployment/snowflake-backend.md
+++ b/site-docs/deployment/snowflake-backend.md
@@ -199,8 +199,10 @@ applies here. Snowflake-specific signals worth alerting on:
   graph, and the full HMAC-chained `audit_log` are not yet on
   `SnowflakeStore`. Run Postgres alongside for these.
 - The scanner CronJob still runs in-cluster; it does not run inside
-  Snowpark. Cortex / Snowpark-native discovery is a separate capability
-  ([`src/agent_bom/cloud/snowflake.py`](https://github.com/msaad00/agent-bom/blob/main/src/agent_bom/cloud/snowflake.py)).
+  Snowpark for the Helm deployment mode. The Native App package now includes
+  an opt-in SPCS scanner service spec for customers who want scanner execution
+  inside Snowflake; it is default-off and attaches advisory-feed EAIs only when
+  `core.enable_scanner_service()` is called.
 - Time Travel + Fail-safe provide durability, but configure a retention
   window that matches your compliance retention policy.
 

--- a/site-docs/deployment/snowflake-pov.md
+++ b/site-docs/deployment/snowflake-pov.md
@@ -18,6 +18,12 @@ The POV does not include automatic patching or draft PR remediation. Today
 agent-bom produces remediation plans and evidence that can be routed into an
 existing Dependabot, Renovate, Jira, or AppSec workflow.
 
+For Native App evaluations, the packaged SPCS scanner and MCP runtime service
+specs are opt-in. API/UI install first; scanner egress to OSV, CISA KEV, FIRST
+EPSS, and GHSA is enabled only after the customer binds the EAI references and
+calls `core.enable_scanner_service()`. The MCP runtime service is also
+default-off and requires a caller-provided bearer token.
+
 ## Database options
 
 agent-bom needs a transactional Postgres-compatible control-plane database for

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -779,7 +779,7 @@ async def get_fix_first_graph_view(
 
     This endpoint is intentionally more product-shaped than `/v1/graph`: it
     ranks persisted attack paths and attaches the operator context needed for
-    a Wiz/Orca-style remediation cockpit. The full topology remains available
+    a fix-first remediation cockpit. The full topology remains available
     through `/v1/graph`; this view answers "what should I inspect first?"
     """
 

--- a/src/agent_bom/fleet_scan.py
+++ b/src/agent_bom/fleet_scan.py
@@ -1,6 +1,6 @@
 """Fleet scan — batch registry lookup + risk scoring for MCP server inventories.
 
-Accepts a list of MCP server names (e.g. from CrowdStrike, SIEM, CSV export)
+Accepts a list of MCP server names (e.g. from EDR, SIEM, CSV export)
 and returns per-server risk assessments using the local registry.
 
 Every field is traceable to a source:
@@ -148,7 +148,7 @@ def fleet_scan(
     """Scan a list of MCP server names against the registry.
 
     Args:
-        server_names: List of server names (e.g. from CrowdStrike endpoint data,
+        server_names: List of server names (e.g. from endpoint security data,
             CSV export, SIEM query). Can include npm-style scoped packages
             (@org/name), plain names, or command names.
         registry: Optional pre-loaded registry dict. Loaded from disk if None.

--- a/src/agent_bom/mcp_server_operator_tools.py
+++ b/src/agent_bom/mcp_server_operator_tools.py
@@ -326,7 +326,7 @@ def register_operator_tools(
     ) -> str:
         """Batch-scan a list of MCP server names against the security metadata registry.
 
-        Designed for fleet inventory data (CrowdStrike, SIEM, CSV exports) where
+        Designed for fleet inventory data (EDR, SIEM, CSV exports) where
         you have server names but not versions. Returns per-server risk assessment
         with registry match status, risk category, tools, credentials, known CVEs,
         and a verdict (known-high-risk, known-medium, known-low, unknown-unvetted).

--- a/src/agent_bom/output/ocsf.py
+++ b/src/agent_bom/output/ocsf.py
@@ -1,7 +1,7 @@
 """OCSF v1.1 audit log format for agent-bom runtime alerts.
 
 Converts runtime alerts to Open Cybersecurity Schema Framework (OCSF) v1.1
-format for enterprise SIEM integration (Splunk, CrowdStrike, Elastic, etc.).
+format for enterprise SIEM and detection-platform integration.
 
 OCSF event class: Security Finding (2001)
 Category: Findings (2)

--- a/tests/test_snowflake_native_app.py
+++ b/tests/test_snowflake_native_app.py
@@ -21,6 +21,8 @@ NATIVE_APP_DIR = Path(__file__).resolve().parents[1] / "deploy" / "snowflake" / 
 MANIFEST_PATH = NATIVE_APP_DIR / "manifest.yml"
 SETUP_SQL_PATH = NATIVE_APP_DIR / "scripts" / "setup.sql"
 DCM_DIR = NATIVE_APP_DIR / "dcm"
+SERVICE_SPECS_DIR = NATIVE_APP_DIR / "service-specs"
+RELEASE_WORKFLOW_PATH = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release-snowflake.yml"
 
 
 @pytest.fixture(scope="module")
@@ -31,6 +33,11 @@ def manifest() -> dict:
 @pytest.fixture(scope="module")
 def setup_sql() -> str:
     return SETUP_SQL_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def service_specs() -> dict[str, dict]:
+    return {path.name: yaml.safe_load(path.read_text(encoding="utf-8")) for path in SERVICE_SPECS_DIR.glob("*.yaml")}
 
 
 # ─── Customer-approved references contract ──────────────────────────────────
@@ -88,6 +95,14 @@ def test_manifest_declares_advisory_feed_eais(manifest: dict):
     assert not missing, f"manifest missing required EAIs: {missing}"
 
 
+def test_advisory_feed_eais_are_default_off(manifest: dict):
+    """Phase 4 scanner enrichment must stay opt-in. A future manifest change
+    that enables outbound vulnerability feeds during install is a regression."""
+    for eai in manifest.get("external_access_integrations", []):
+        name, body = next(iter(eai.items()))
+        assert body.get("enabled") is False, f"EAI {name!r} must be disabled by default"
+
+
 def test_no_eai_egresses_to_unexpected_destinations(manifest: dict):
     """Every EAI's egress destination list must match a known advisory feed.
     A future PR adding a fifth destination would surface here so we can
@@ -141,6 +156,79 @@ def test_setup_sql_grants_only_target_application_role(setup_sql: str):
         assert phrase not in setup_sql.upper(), f"setup.sql contains {phrase!r} — grants must only target APPLICATION ROLE app_user"
 
 
+# ─── Phase 4 service contract ───────────────────────────────────────────────
+
+
+def test_manifest_declares_phase4_services_default_off(manifest: dict):
+    config = manifest.get("configuration", {})
+    assert config["enable_scanner_service"]["default"] is False
+    assert config["enable_mcp_runtime_service"]["default"] is False
+
+    images = set(manifest.get("artifacts", {}).get("container_services", {}).get("images", []))
+    assert "/db/schema/agent_bom_repo/agent-bom-scanner:latest" in images
+    assert "/db/schema/agent_bom_repo/agent-bom-mcp-runtime:latest" in images
+
+
+def test_phase4_service_specs_are_packaged_and_internal(service_specs: dict[str, dict]):
+    expected = {"scanner-service.yaml", "mcp-runtime-service.yaml"}
+    assert expected <= set(service_specs)
+
+    for spec_name in expected:
+        spec = service_specs[spec_name]["spec"]
+        assert spec.get("containers"), f"{spec_name} must declare at least one container"
+        for endpoint in spec.get("endpoints", []):
+            assert endpoint.get("public") is False, f"{spec_name}:{endpoint.get('name')} must be internal-only"
+
+
+def test_scanner_service_spec_uses_scanner_entrypoint_and_not_mcp_runtime(service_specs: dict[str, dict]):
+    scanner = service_specs["scanner-service.yaml"]["spec"]["containers"][0]
+    assert scanner["name"] == "agent-bom-scanner"
+    assert scanner["env"]["AGENT_BOM_MCP_MODE"] == "0"
+    assert scanner["env"]["AGENT_BOM_ENABLE_ADVISORY_EGRESS"] == "1"
+    assert scanner["command"][:4] == ["agent-bom", "agents", "--snowflake", "--snowflake-authenticator"]
+
+
+def test_mcp_runtime_spec_requires_bearer_token_and_has_no_advisory_egress(service_specs: dict[str, dict]):
+    runtime = service_specs["mcp-runtime-service.yaml"]["spec"]["containers"][0]
+    assert runtime["name"] == "agent-bom-mcp-runtime"
+    assert runtime["env"]["AGENT_BOM_MCP_MODE"] == "1"
+    assert runtime["env"]["AGENT_BOM_MCP_BEARER_TOKEN"] == "{{ mcp_bearer_token }}"
+    assert "AGENT_BOM_ENABLE_ADVISORY_EGRESS" not in runtime["env"]
+    assert runtime["command"][:4] == ["agent-bom", "mcp", "server", "--transport"]
+
+
+def test_setup_sql_only_creates_phase4_services_from_opt_in_procedures(setup_sql: str):
+    upper = setup_sql.upper()
+    assert "CREATE OR REPLACE PROCEDURE CORE.ENABLE_SCANNER_SERVICE()" in upper
+    assert "CREATE OR REPLACE PROCEDURE CORE.ENABLE_MCP_RUNTIME_SERVICE(MCP_BEARER_TOKEN VARCHAR)" in upper
+    assert "CORE.AGENT_BOM_SCANNER" in upper
+    assert "CORE.AGENT_BOM_MCP_RUNTIME" in upper
+    assert "LENGTH(TRIM(MCP_BEARER_TOKEN)) < 32" in upper
+
+
+def test_setup_sql_exposes_customer_health_check(setup_sql: str):
+    upper = setup_sql.upper()
+    assert "CREATE OR REPLACE PROCEDURE CORE.HEALTH_CHECK()" in upper
+    assert "'SCANNER_SERVICE_ENABLED'" in upper
+    assert "'MCP_RUNTIME_SERVICE_ENABLED'" in upper
+    assert "'ADVISORY_EGRESS_ENABLED'" in upper
+    assert "GRANT USAGE ON PROCEDURE CORE.HEALTH_CHECK()" in upper
+
+
+def test_scanner_service_creation_is_eai_gated(setup_sql: str):
+    scanner_section = setup_sql.split("CREATE OR REPLACE PROCEDURE core.enable_scanner_service()", 1)[1].split(
+        "CREATE OR REPLACE PROCEDURE core.enable_mcp_runtime_service", 1
+    )[0]
+    assert "EXTERNAL_ACCESS_INTEGRATIONS" in scanner_section
+    for eai_name in ("osv_dev", "cisa_kev", "first_epss", "github_ghsa"):
+        assert f"reference('{eai_name}')" in scanner_section
+
+
+def test_mcp_runtime_service_creation_has_no_eai_clause(setup_sql: str):
+    mcp_section = setup_sql.split("CREATE OR REPLACE PROCEDURE core.enable_mcp_runtime_service", 1)[1]
+    assert "EXTERNAL_ACCESS_INTEGRATIONS" not in mcp_section
+
+
 # ─── DCM project contract ──────────────────────────────────────────────────
 
 
@@ -169,3 +257,12 @@ def test_dcm_v001_no_write_grants_on_customer_data():
     # against a customer-named DB would be a privilege escalation.
     assert "GRANT INSERT ON TABLE" not in v001 or "core." in v001
     assert "YOUR_DB." not in v001
+
+
+def test_release_workflow_derives_version_from_pyproject_when_unset():
+    workflow = RELEASE_WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "required: false" in workflow
+    assert 'project = tomllib.loads(Path("pyproject.toml").read_text())["project"]' in workflow
+    assert 'version = "v" + str(project["version"]).replace(".", "_")' in workflow
+    assert "package_version: ${{ steps.version.outputs.version }}" in workflow
+    assert "inputs.version" not in workflow.split("Build Snowflake Native App artifact", 1)[1]


### PR DESCRIPTION
## Summary

Advances #2213, #2214, and #1366.

Packages the Snowflake Native App Phase 4 dry-run lane and opt-in runtime services:

- adds scanner and MCP runtime Snowpark Container Services specs
- wires manifest artifacts/service roles and setup procedures for default-off scanner + default-off MCP runtime
- gates scanner egress behind the four advisory-feed EAI references only
- adds a `core.health_check()` post-install validation procedure
- adds a `release-snowflake` workflow that validates YAML, packages the app, derives the package label from `pyproject.toml` when omitted, sets explicit job timeouts, and intentionally stops before live publish
- adds Marketplace and install docs for dry-run release proof and customer smoke checks
- extends Native App contract tests across service specs, opt-in procedures, EAI gating, health check, and version derivation
- replaces public competitor-comparison wording with vendor-neutral security graph language

## Scope note

This is Marketplace dry-run readiness, not production Marketplace launch. Live publish, signed Snowflake registry image pushes, customer private-preview evidence, and real Snowflake account EAI traffic tests remain process/live-environment work.

## Validation

- `PYTHONPATH=src uv run pytest tests/test_snowflake_native_app.py tests/test_snowflake_backend_contract.py tests/test_snowflake_pov_docs.py -q` -> 24 passed
- `python scripts/check_graph_epic_proof.py` -> graph epic proof checks passed
- `PYTHONPATH=src uv run pytest tests/test_snowflake_native_app.py tests/test_snowflake_backend_contract.py tests/test_snowflake_pov_docs.py tests/test_graph_schema_ui_parity.py tests/test_graph_edge_counts.py tests/test_graph_visual_snapshot.py tests/test_effective_reach.py tests/test_evidence_policy.py -q` -> 79 passed
- YAML parse check for `.github/workflows/release-snowflake.yml`, `manifest.yml`, and both service specs
- `PYTHONPATH=src uv run ruff check src/agent_bom/api/routes/graph.py src/agent_bom/fleet_scan.py src/agent_bom/mcp_server_operator_tools.py src/agent_bom/output/ocsf.py scripts/check_graph_epic_proof.py`
- `git diff --check`
- public wording scan excluding literal registry package identity returned no matches
