### PR TITLE
superseded: pipeline DAG event artifact

### DIFF
--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -45,7 +45,7 @@
 |---------|-------------|
 | `graph` | Export the transitive dependency graph from a scan report |
 | `mesh` | Show lightweight agent/MCP topology without CVE scanning |
-| `report` | History, diff, analytics, dashboard, and compliance narrative workflows |
+| `report` | History, diff, pipeline-event artifacts, analytics, dashboard, and compliance narrative workflows |
 
 ### Governance And Operations
 
@@ -78,6 +78,7 @@
 
 - `check` supports terminal output by default plus `--format json` for machine-readable pre-install verdicts.
 - `report history` and `report diff` support `--format json` for CI and automation.
+- `report pipeline-events <scan-job.json>` exports structured scan progress as JSONL for DAG/dashboard consumers.
 - `remediate` supports `--format json` as the machine-readable remediation contract.
 - Use `agent-bom agents -f <format> -o <path>` for SARIF, HTML, SBOM, and richer environment exports.
 - Use `agent-bom agents -f sarif -o -` when you need SARIF on stdout for piping.
@@ -94,6 +95,7 @@ agent-bom agents -f json|html|sarif|csv|cyclonedx|spdx
 agent-bom agents -o report.json
 agent-bom check requests@2.33.0 -e pypi -f json -o check.json
 agent-bom report diff before.json after.json -f json -o diff.json
+agent-bom report pipeline-events scan-job.json -o pipeline-events.jsonl
 
 # Compliance
 agent-bom agents --compliance owasp-llm,eu-ai-act,all

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 
 import ctypes
 import gc
+import json
 import logging
 import sys
 import threading
 import uuid
+from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from enum import Enum
@@ -120,6 +122,18 @@ def _release_scan_memory() -> None:
 # ─── Constants ───────────────────────────────────────────────────────────────
 
 PIPELINE_STEPS = ["discovery", "extraction", "scanning", "enrichment", "analysis", "output"]
+PIPELINE_DAG_EVENT_SCHEMA = "agent-bom.pipeline.dag.events.v1"
+PIPELINE_DAG_EDGES = [{"source": source, "target": target} for source, target in zip(PIPELINE_STEPS, PIPELINE_STEPS[1:], strict=False)]
+_PIPELINE_STEP_INDEX = {step_id: index for index, step_id in enumerate(PIPELINE_STEPS)}
+_PIPELINE_PREDECESSORS = {
+    step_id: [edge["source"] for edge in PIPELINE_DAG_EDGES if edge["target"] == step_id] for step_id in PIPELINE_STEPS
+}
+_PIPELINE_SUCCESSORS = {step_id: [edge["target"] for edge in PIPELINE_DAG_EDGES if edge["source"] == step_id] for step_id in PIPELINE_STEPS}
+_TERMINAL_STEP_STATUSES = {
+    StepStatus.DONE.value,
+    StepStatus.FAILED.value,
+    StepStatus.SKIPPED.value,
+}
 
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -127,6 +141,83 @@ PIPELINE_STEPS = ["discovery", "extraction", "scanning", "enrichment", "analysis
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def iter_pipeline_dag_event_records(
+    progress_lines: Iterable[str],
+    *,
+    scan_id: str,
+    tenant_id: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return dashboard-ready DAG step records from structured progress lines.
+
+    The API already emits JSON step progress records for SSE consumers. This
+    helper keeps that wire behavior intact while giving local tests, report
+    exporters, and dashboards a stable JSONL artifact shape that includes the
+    scan pipeline DAG edges needed to render progress as a graph.
+    """
+    records: list[dict[str, Any]] = []
+    for sequence, line in enumerate(progress_lines):
+        try:
+            event = json.loads(line)
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(event, dict) or event.get("type") != "step":
+            continue
+        step_id = event.get("step_id")
+        status = event.get("status")
+        if not isinstance(step_id, str) or step_id not in _PIPELINE_STEP_INDEX:
+            continue
+        if isinstance(status, StepStatus):
+            status = status.value
+        if not isinstance(status, str):
+            continue
+
+        emitted_at = event.get("completed_at") or event.get("started_at")
+        record: dict[str, Any] = {
+            "schema_version": PIPELINE_DAG_EVENT_SCHEMA,
+            "type": "pipeline_dag_step",
+            "event_id": f"{scan_id}:{sequence}:{step_id}:{status}",
+            "scan_id": scan_id,
+            "sequence": sequence,
+            "emitted_at": emitted_at if isinstance(emitted_at, str) else None,
+            "step": {
+                "id": step_id,
+                "index": _PIPELINE_STEP_INDEX[step_id],
+                "status": status,
+                "message": event.get("message") if isinstance(event.get("message"), str) else "",
+                "started_at": event.get("started_at") if isinstance(event.get("started_at"), str) else None,
+                "completed_at": event.get("completed_at") if isinstance(event.get("completed_at"), str) else None,
+                "stats": event.get("stats") if isinstance(event.get("stats"), dict) else {},
+                "sub_step": event.get("sub_step") if isinstance(event.get("sub_step"), str) else None,
+                "progress_pct": event.get("progress_pct") if isinstance(event.get("progress_pct"), int) else None,
+            },
+            "dag": {
+                "node_id": step_id,
+                "depends_on": list(_PIPELINE_PREDECESSORS[step_id]),
+                "next_steps": list(_PIPELINE_SUCCESSORS[step_id]),
+                "edges": [dict(edge) for edge in PIPELINE_DAG_EDGES],
+            },
+            "dashboard": {
+                "lane": "scan_pipeline",
+                "render": "dag_step",
+                "terminal": status in _TERMINAL_STEP_STATUSES,
+            },
+        }
+        if tenant_id:
+            record["tenant_id"] = tenant_id
+        records.append(record)
+    return records
+
+
+def pipeline_dag_events_jsonl(job: ScanJob) -> str:
+    """Serialize a scan job's structured pipeline events as JSONL."""
+    records = iter_pipeline_dag_event_records(
+        list(job.progress),
+        scan_id=job.job_id,
+        tenant_id=job.tenant_id,
+    )
+    return "\n".join(json.dumps(record, sort_keys=True) for record in records)
 
 
 def _persist_graph_snapshot(
@@ -263,11 +354,9 @@ class ScanPipeline:
 
     def _emit(self, event: dict[str, Any]) -> None:
         """Serialize step event to job.progress for SSE pickup (thread-safe)."""
-        import json as _json_mod
-
         # Convert enum values to strings for JSON serialization
         serializable = {k: (v.value if isinstance(v, Enum) else v) for k, v in event.items()}
-        line = _json_mod.dumps(serializable)
+        line = json.dumps(serializable)
         if self._lock:
             with self._lock:
                 self._job.progress.append(line)

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -628,12 +628,16 @@ configure_api_from_env()
 
 # ─── Scan Pipeline (extracted to api/pipeline.py) ────────────────────────────
 from agent_bom.api.pipeline import (  # noqa: E402
+    PIPELINE_DAG_EDGES,  # noqa: F401 — re-exported for tests/artifact consumers
+    PIPELINE_DAG_EVENT_SCHEMA,  # noqa: F401 — re-exported for tests/artifact consumers
     PIPELINE_STEPS,  # noqa: F401 — re-exported for tests
     ScanPipeline,  # noqa: F401 — re-exported for tests
     _executor,  # noqa: F401 — re-exported for tests (may be replaced on shutdown; use get_executor() for new submissions)
     _run_scan_sync,  # noqa: F401 — re-exported for backward compat
     _sync_scan_agents_to_fleet,  # noqa: F401 — re-exported for tests
     get_executor,  # noqa: F401 — re-exported for tests
+    iter_pipeline_dag_event_records,  # noqa: F401 — re-exported for tests/artifact consumers
+    pipeline_dag_events_jsonl,  # noqa: F401 — re-exported for tests/artifact consumers
 )
 
 # ─── Route modules ────────────────────────────────────────────────────────

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -235,12 +235,13 @@ main.add_command(mesh_cmd, "mesh")
 # ---------------------------------------------------------------------------
 # Report command group — `agent-bom report [history|diff|rescan|analytics|dashboard]`
 # ---------------------------------------------------------------------------
-from agent_bom.cli._report_group import report_group  # noqa: E402
+from agent_bom.cli._report_group import pipeline_events_cmd, report_group  # noqa: E402
 
 report_group.add_command(history_cmd, "history")
 report_group.add_command(diff_cmd, "diff")
 report_group.add_command(rescan_command, "rescan")
 report_group.add_command(compliance_narrative_cmd, "compliance-narrative")
+report_group.add_command(pipeline_events_cmd, "pipeline-events")
 report_group.add_command(analytics_cmd, "analytics")
 report_group.add_command(dashboard_cmd, "dashboard")
 main.add_command(report_group)

--- a/src/agent_bom/cli/_report_group.py
+++ b/src/agent_bom/cli/_report_group.py
@@ -13,6 +13,9 @@ Usage::
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import click
 
 
@@ -27,8 +30,34 @@ def report_group(ctx: click.Context) -> None:
       diff        Diff two scan reports or CycloneDX/SPDX SBOMs
       rescan      Re-scan vulnerable packages to verify remediation
       compliance-narrative  Generate auditor-facing compliance narrative from a saved scan report
+      pipeline-events  Export scan pipeline DAG events as JSONL
       analytics   Query vulnerability trends (ClickHouse)
       dashboard   Launch legacy Streamlit compatibility dashboard; use `agent-bom serve` for the bundled Next.js UI
     """
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
+
+
+@click.command("pipeline-events")
+@click.argument("scan_job_json", type=click.Path(exists=True, dir_okay=False, readable=True))
+@click.option("-o", "--output", "output_path", type=click.Path(dir_okay=False), help="Write JSONL artifact to this file")
+def pipeline_events_cmd(scan_job_json: str, output_path: str | None) -> None:
+    """Export structured scan pipeline progress as dashboard-ready JSONL."""
+    from agent_bom.api.models import ScanJob
+    from agent_bom.api.pipeline import pipeline_dag_events_jsonl
+
+    path = Path(scan_job_json)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        job = ScanJob.model_validate(payload)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not read ScanJob JSON from {path}: {exc}") from exc
+
+    jsonl = pipeline_dag_events_jsonl(job)
+    if output_path:
+        output = Path(output_path)
+        output.write_text(f"{jsonl}\n" if jsonl else "", encoding="utf-8")
+        click.echo(f"Wrote {output}")
+        return
+    if jsonl:
+        click.echo(jsonl)

--- a/tests/test_api_pipeline_events.py
+++ b/tests/test_api_pipeline_events.py
@@ -4,13 +4,20 @@ from __future__ import annotations
 
 import json
 
+from click.testing import CliRunner
+
 from agent_bom.api.server import (
+    PIPELINE_DAG_EDGES,
+    PIPELINE_DAG_EVENT_SCHEMA,
     PIPELINE_STEPS,
     ScanJob,
     ScanPipeline,
     ScanRequest,
     StepStatus,
+    iter_pipeline_dag_event_records,
+    pipeline_dag_events_jsonl,
 )
+from agent_bom.cli._report_group import pipeline_events_cmd
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -218,3 +225,87 @@ class TestSSEEventFormat:
         parsed = json.loads(job.progress[0])
         assert isinstance(parsed["status"], str)
         assert parsed["status"] == "running"
+
+
+# ---------------------------------------------------------------------------
+# Dashboard DAG event artifact
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineDagEventArtifact:
+    def test_dag_event_records_include_step_edges_for_dashboard(self):
+        job = _make_job()
+        job.tenant_id = "tenant-a"
+        pipeline = ScanPipeline(job)
+
+        pipeline.start_step("discovery", "Discovering...")
+        pipeline.complete_step("discovery", "Found 2 agents", stats={"agents": 2})
+        pipeline.start_step("extraction", "Extracting packages...")
+        pipeline.skip_step("scanning", "Vulnerability scanning skipped")
+        job.progress.append("legacy progress line")
+
+        records = iter_pipeline_dag_event_records(job.progress, scan_id=job.job_id, tenant_id=job.tenant_id)
+
+        assert len(records) == 4
+        assert all(record["schema_version"] == PIPELINE_DAG_EVENT_SCHEMA for record in records)
+        assert all(record["type"] == "pipeline_dag_step" for record in records)
+        assert all(record["scan_id"] == job.job_id for record in records)
+        assert all(record["tenant_id"] == "tenant-a" for record in records)
+
+        discovery = records[0]
+        assert discovery["step"]["id"] == "discovery"
+        assert discovery["step"]["index"] == 0
+        assert discovery["dag"]["depends_on"] == []
+        assert discovery["dag"]["next_steps"] == ["extraction"]
+        assert discovery["dag"]["edges"] == PIPELINE_DAG_EDGES
+        assert discovery["dashboard"] == {
+            "lane": "scan_pipeline",
+            "render": "dag_step",
+            "terminal": False,
+        }
+
+        scanning = records[-1]
+        assert scanning["step"]["id"] == "scanning"
+        assert scanning["step"]["status"] == "skipped"
+        assert scanning["dag"]["depends_on"] == ["extraction"]
+        assert scanning["dag"]["next_steps"] == ["enrichment"]
+        assert scanning["dashboard"]["terminal"] is True
+
+    def test_dag_event_jsonl_serializes_one_record_per_structured_step(self):
+        job = _make_job()
+        pipeline = ScanPipeline(job)
+        pipeline.start_step("analysis", "Computing blast radius...", sub_step="agent-a")
+        pipeline.update_step("analysis", "Halfway", stats={"blast_radius": 1}, progress_pct=50)
+        pipeline.complete_step("analysis", "Done", stats={"blast_radius": 2})
+        job.progress.append("plain progress")
+
+        jsonl = pipeline_dag_events_jsonl(job)
+        lines = jsonl.splitlines()
+
+        assert len(lines) == 3
+        parsed = [json.loads(line) for line in lines]
+        assert [record["sequence"] for record in parsed] == [0, 1, 2]
+        assert parsed[0]["event_id"] == "test-123:0:analysis:running"
+        assert parsed[0]["step"]["sub_step"] == "agent-a"
+        assert parsed[1]["step"]["progress_pct"] == 50
+        assert parsed[2]["step"]["stats"] == {"blast_radius": 2}
+        assert parsed[2]["dashboard"]["terminal"] is True
+
+    def test_report_cli_exports_pipeline_dag_event_jsonl(self, tmp_path):
+        job = _make_job()
+        pipeline = ScanPipeline(job)
+        pipeline.start_step("output", "Building report...")
+        pipeline.complete_step("output", "Report ready")
+
+        scan_job_path = tmp_path / "scan-job.json"
+        output_path = tmp_path / "pipeline-events.jsonl"
+        scan_job_path.write_text(json.dumps(job.model_dump(mode="json")), encoding="utf-8")
+
+        result = CliRunner().invoke(pipeline_events_cmd, [str(scan_job_path), "--output", str(output_path)])
+
+        assert result.exit_code == 0
+        assert output_path.exists()
+        records = [json.loads(line) for line in output_path.read_text(encoding="utf-8").splitlines()]
+        assert [record["step"]["status"] for record in records] == ["running", "done"]
+        assert records[0]["dag"]["depends_on"] == ["analysis"]
+        assert records[0]["dag"]["next_steps"] == []


### PR DESCRIPTION
Superseded by #2298.

This closed PR used an old branch naming convention and should not be merged. The active replacement is #2298 with the same pipeline DAG artifact scope and neutral public wording.
