### PR TITLE
fix(graph): backfill empty tenant rows

### DIFF
--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -23,13 +23,18 @@ from agent_bom.graph import AttackPath, EntityType, NodeDimensions, NodeStatus, 
 _CREATE_PRESET_TABLE_SQLITE = """\
 CREATE TABLE IF NOT EXISTS graph_filter_presets (
     name TEXT NOT NULL,
-    tenant_id TEXT DEFAULT '',
+    tenant_id TEXT NOT NULL DEFAULT 'default',
     description TEXT DEFAULT '',
     filters TEXT NOT NULL,
     created_at TEXT NOT NULL,
     PRIMARY KEY (name, tenant_id)
 )
 """
+
+_API_GRAPH_TENANT_TABLE_KEYS: dict[str, tuple[str, ...]] = {
+    "graph_filter_presets": ("name",),
+    "graph_node_search": ("node_id", "scan_id"),
+}
 
 _CREATE_SEARCH_TABLE_SQLITE = """\
 CREATE VIRTUAL TABLE IF NOT EXISTS graph_node_search
@@ -266,6 +271,7 @@ class SQLiteGraphStore:
         sqlite_graph_store._init_db(conn)
         conn.execute(_CREATE_PRESET_TABLE_SQLITE)
         conn.execute(_CREATE_SEARCH_TABLE_SQLITE)
+        sqlite_graph_store._backfill_empty_tenant_ids(conn, _API_GRAPH_TENANT_TABLE_KEYS)
         conn.commit()
         return conn
 
@@ -277,6 +283,7 @@ class SQLiteGraphStore:
         sqlite_graph_store._init_db(conn)
         conn.execute(_CREATE_PRESET_TABLE_SQLITE)
         conn.execute(_CREATE_SEARCH_TABLE_SQLITE)
+        sqlite_graph_store._backfill_empty_tenant_ids(conn, _API_GRAPH_TENANT_TABLE_KEYS)
         conn.commit()
         return conn
 
@@ -317,6 +324,7 @@ class SQLiteGraphStore:
         return clause, params
 
     def _refresh_snapshot_search_index(self, conn: sqlite3.Connection, *, tenant_id: str, scan_id: str) -> None:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn.execute("DELETE FROM graph_node_search WHERE tenant_id = ? AND scan_id = ?", (tenant_id, scan_id))
         rows = conn.execute(
             """
@@ -351,6 +359,7 @@ class SQLiteGraphStore:
 
     def delete_tenant(self, *, tenant_id: str = "") -> int:
         """Delete graph rows for one tenant and return the number of rows removed."""
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_rw_conn()
         try:
             total = 0
@@ -473,6 +482,7 @@ class SQLiteGraphStore:
         scan_id: str = "",
         node_ids: set[str],
     ) -> list[UnifiedNode]:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         if not node_ids:
             return []
         conn = self._open_ro_conn()
@@ -516,6 +526,7 @@ class SQLiteGraphStore:
         dynamic_only: bool,
         include_roots: bool,
     ) -> tuple[str, str, set[str], dict[str, int], dict[tuple[str, str, str], UnifiedEdge], dict[str, str], list[str], bool]:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         effective_scan_id, created_at = sqlite_graph_store._resolve_snapshot(conn, tenant_id=tenant_id, scan_id=scan_id)
         if not effective_scan_id:
             return scan_id, "", set(), {}, {}, {}, [], False
@@ -762,6 +773,7 @@ class SQLiteGraphStore:
         scan_id: str = "",
         source_ids: set[str],
     ) -> list[AttackPath]:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         if not source_ids:
             return []
         conn = self._open_ro_conn()
@@ -806,6 +818,7 @@ class SQLiteGraphStore:
         offset: int = 0,
         limit: int = 100,
     ) -> tuple[str, str, list[AttackPath], int]:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_ro_conn()
         if conn is None:
             return scan_id, "", [], 0
@@ -857,6 +870,7 @@ class SQLiteGraphStore:
         scan_id: str = "",
         node_id: str,
     ) -> dict[str, Any] | None:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_ro_conn()
         if conn is None:
             return None
@@ -917,6 +931,7 @@ class SQLiteGraphStore:
         scan_id: str = "",
         framework: str = "",
     ) -> dict[str, Any]:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_ro_conn()
         if conn is None:
             return {
@@ -993,6 +1008,7 @@ class SQLiteGraphStore:
             conn.close()
 
     def latest_snapshot_id(self, *, tenant_id: str = "") -> str:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_ro_conn()
         if conn is None:
             return ""
@@ -1002,6 +1018,7 @@ class SQLiteGraphStore:
             conn.close()
 
     def previous_snapshot_id(self, *, tenant_id: str = "", before_scan_id: str = "") -> str:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_ro_conn()
         if conn is None:
             return ""
@@ -1016,6 +1033,7 @@ class SQLiteGraphStore:
             conn.execute(_CREATE_SEARCH_TABLE_SQLITE)
             sqlite_graph_store.save_graph(conn, graph)
             self._refresh_snapshot_search_index(conn, tenant_id=graph.tenant_id, scan_id=graph.scan_id)
+            sqlite_graph_store._backfill_empty_tenant_ids(conn, _API_GRAPH_TENANT_TABLE_KEYS)
             conn.commit()
 
     def load_graph(
@@ -1026,6 +1044,7 @@ class SQLiteGraphStore:
         entity_types: set[str] | None = None,
         min_severity_rank: int = 0,
     ) -> UnifiedGraph:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_ro_conn()
         if conn is None:
             return UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id)
@@ -1041,6 +1060,7 @@ class SQLiteGraphStore:
             conn.close()
 
     def diff_snapshots(self, scan_id_old: str, scan_id_new: str, *, tenant_id: str = "") -> dict[str, Any]:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_ro_conn()
         if conn is None:
             return {
@@ -1056,6 +1076,7 @@ class SQLiteGraphStore:
             conn.close()
 
     def list_snapshots(self, *, tenant_id: str = "", limit: int = 50) -> list[dict[str, Any]]:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_ro_conn()
         if conn is None:
             return []
@@ -1072,6 +1093,7 @@ class SQLiteGraphStore:
         entity_types: set[str] | None = None,
         min_severity_rank: int = 0,
     ) -> dict[str, Any]:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_ro_conn()
         if conn is None:
             return {
@@ -1177,6 +1199,7 @@ class SQLiteGraphStore:
         offset: int = 0,
         limit: int = 500,
     ) -> tuple[str, str, list[UnifiedNode], int, str | None]:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_ro_conn()
         if conn is None:
             return scan_id, "", [], 0, None
@@ -1245,6 +1268,7 @@ class SQLiteGraphStore:
         scan_id: str = "",
         node_ids: set[str],
     ) -> list[Any]:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         if not node_ids:
             return []
         conn = self._open_ro_conn()
@@ -1299,6 +1323,7 @@ class SQLiteGraphStore:
         offset: int = 0,
         limit: int = 50,
     ) -> tuple[list[UnifiedNode], int, str | None]:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_ro_conn()
         if conn is None:
             return [], 0, None
@@ -1409,6 +1434,7 @@ class SQLiteGraphStore:
             conn.close()
 
     def save_preset(self, *, tenant_id: str, name: str, description: str, filters: dict[str, Any], created_at: str) -> None:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_rw_conn()
         try:
             conn.execute(
@@ -1420,6 +1446,7 @@ class SQLiteGraphStore:
             conn.close()
 
     def list_presets(self, *, tenant_id: str) -> list[dict[str, Any]]:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_ro_conn()
         if conn is None:
             return []
@@ -1441,6 +1468,7 @@ class SQLiteGraphStore:
             conn.close()
 
     def delete_preset(self, *, tenant_id: str, name: str) -> bool:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_rw_conn()
         try:
             cursor = conn.execute(

--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -280,11 +280,17 @@ class SQLiteGraphStore:
             return None
         conn = sqlite3.connect(str(self._db_path), timeout=10)
         conn.row_factory = sqlite3.Row
-        sqlite_graph_store._init_db(conn)
-        conn.execute(_CREATE_PRESET_TABLE_SQLITE)
-        conn.execute(_CREATE_SEARCH_TABLE_SQLITE)
-        sqlite_graph_store._backfill_empty_tenant_ids(conn, _API_GRAPH_TENANT_TABLE_KEYS)
-        conn.commit()
+        sqlite_graph_store._init_db(conn, backfill_legacy_tenants=False)
+        try:
+            conn.execute(_CREATE_PRESET_TABLE_SQLITE)
+            conn.execute(_CREATE_SEARCH_TABLE_SQLITE)
+            sqlite_graph_store._backfill_empty_tenant_ids(conn)
+            sqlite_graph_store._backfill_empty_tenant_ids(conn, _API_GRAPH_TENANT_TABLE_KEYS)
+            conn.commit()
+        except sqlite3.OperationalError as exc:
+            if "locked" not in str(exc).lower():
+                raise
+            conn.rollback()
         return conn
 
     @staticmethod

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -11,12 +11,22 @@ from typing import Any, Iterable, Iterator, Sequence
 from agent_bom.api.graph_store import _escape_like_query, _node_search_text, decode_graph_cursor, encode_graph_cursor
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
 from agent_bom.config import POSTGRES_GRAPH_SEARCH_TIMEOUT_MS, POSTGRES_STATEMENT_TIMEOUT_MS
+from agent_bom.db.graph_store import DEFAULT_GRAPH_TENANT_ID, normalize_graph_tenant_id
 from agent_bom.graph import EntityType
 
 from .postgres_common import _ensure_tenant_rls, _get_pool, _tenant_connection
 
 _ALLOWED_ENTITY_TYPES = {entity_type.value for entity_type in EntityType}
 _DEFAULT_GRAPH_WRITE_BATCH_SIZE = 1000
+_GRAPH_TENANT_TABLE_KEYS: dict[str, tuple[str, ...]] = {
+    "graph_nodes": ("id", "scan_id"),
+    "graph_edges": ("source_id", "target_id", "relationship", "scan_id"),
+    "graph_snapshots": ("scan_id",),
+    "attack_paths": ("source_node", "target_node", "scan_id"),
+    "interaction_risks": ("pattern", "agents", "scan_id"),
+    "graph_filter_presets": ("name",),
+    "graph_node_search": ("node_id", "scan_id"),
+}
 
 
 def _graph_write_batch_size() -> int:
@@ -85,6 +95,28 @@ def _assert_allowed_entity_types(entity_types: set[str] | None) -> None:
     invalid = sorted(entity_types - _ALLOWED_ENTITY_TYPES)
     if invalid:
         raise ValueError(f"Unsupported graph entity type: {invalid[0]}")
+
+
+def _backfill_empty_tenant_ids(conn) -> None:
+    for table, key_columns in _GRAPH_TENANT_TABLE_KEYS.items():
+        key_match = " AND ".join(f"existing.{column} = legacy.{column}" for column in key_columns)
+        conn.execute(
+            f"""
+            DELETE FROM {table} legacy
+            WHERE legacy.tenant_id = ''
+              AND EXISTS (
+                SELECT 1
+                FROM {table} existing
+                WHERE existing.tenant_id = %s
+                  AND {key_match}
+              )
+            """,  # nosec B608 - table/key names are static internal schema metadata
+            (DEFAULT_GRAPH_TENANT_ID,),
+        )
+        conn.execute(
+            f"UPDATE {table} SET tenant_id = %s WHERE tenant_id = ''",  # nosec B608 - table names are static internal schema metadata
+            (DEFAULT_GRAPH_TENANT_ID,),
+        )
 
 
 class PostgresGraphStore:
@@ -246,6 +278,7 @@ class PostgresGraphStore:
                 ON graph_node_search(tenant_id, scan_id, severity)
                 """
             )
+            _backfill_empty_tenant_ids(conn)
             try:
                 conn.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
                 conn.execute(
@@ -267,6 +300,7 @@ class PostgresGraphStore:
             conn.commit()
 
     def latest_snapshot_id(self, *, tenant_id: str = "") -> str:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         with _tenant_connection(self._pool) as conn:
             row = conn.execute(
                 """
@@ -304,6 +338,7 @@ class PostgresGraphStore:
         )
 
     def previous_snapshot_id(self, *, tenant_id: str = "", before_scan_id: str = "") -> str:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         if not before_scan_id:
             return ""
         with _tenant_connection(self._pool) as conn:
@@ -327,6 +362,7 @@ class PostgresGraphStore:
 
     def delete_tenant(self, *, tenant_id: str = "") -> int:
         """Delete graph rows for one tenant and return the number of rows removed."""
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         total = 0
         with _tenant_connection(self._pool) as conn:
             for table in (
@@ -347,7 +383,7 @@ class PostgresGraphStore:
         from agent_bom.graph import RelationshipType
 
         scan = graph.scan_id or ""
-        tenant = graph.tenant_id or "default"
+        tenant = normalize_graph_tenant_id(graph.tenant_id)
         now = graph.created_at or datetime.now(timezone.utc).isoformat()
         batch_size = _graph_write_batch_size()
 
@@ -570,6 +606,7 @@ class PostgresGraphStore:
         entity_types: set[str] | None = None,
         min_severity_rank: int = 0,
     ):
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         _assert_allowed_entity_types(entity_types)
         from agent_bom.graph import (
             SEVERITY_RANK,
@@ -686,6 +723,7 @@ class PostgresGraphStore:
         scan_id: str = "",
         node_ids: set[str],
     ) -> list[Any]:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         if not node_ids:
             return []
         effective_scan_id = scan_id or self.latest_snapshot_id(tenant_id=tenant_id)
@@ -715,6 +753,7 @@ class PostgresGraphStore:
         max_depth: int = 4,
         traversable_only: bool = True,
     ) -> tuple[list[list[str]], set[str]]:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
         if not graph.has_node(source):
             return [], set()
@@ -735,6 +774,7 @@ class PostgresGraphStore:
         node_id: str,
         max_depth: int = 4,
     ) -> dict[str, Any] | None:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
         if not graph.has_node(node_id):
             return None
@@ -757,6 +797,7 @@ class PostgresGraphStore:
         dynamic_only: bool = False,
         include_roots: bool = True,
     ) -> tuple[Any, dict[str, int], bool]:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
         return graph.traverse_subgraph(
             roots,
@@ -779,6 +820,7 @@ class PostgresGraphStore:
         scan_id: str = "",
         source_ids: set[str],
     ) -> list[Any]:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         if not source_ids:
             return []
         effective_scan_id = scan_id or self.latest_snapshot_id(tenant_id=tenant_id)
@@ -822,6 +864,7 @@ class PostgresGraphStore:
         offset: int = 0,
         limit: int = 100,
     ) -> tuple[str, str, list[Any], int]:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         effective_scan_id = scan_id or self.latest_snapshot_id(tenant_id=tenant_id)
         if not effective_scan_id:
             return scan_id, "", [], 0
@@ -876,6 +919,7 @@ class PostgresGraphStore:
         scan_id: str = "",
         node_id: str,
     ) -> dict[str, Any] | None:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
         node = graph.get_node(node_id)
         if not node:
@@ -896,6 +940,7 @@ class PostgresGraphStore:
         scan_id: str = "",
         framework: str = "",
     ) -> dict[str, Any]:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         from collections import defaultdict
 
         graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
@@ -944,6 +989,7 @@ class PostgresGraphStore:
         }
 
     def diff_snapshots(self, scan_id_old: str, scan_id_new: str, *, tenant_id: str = "") -> dict[str, Any]:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         with _tenant_connection(self._pool) as conn:
             old_nodes = {
                 row[0]: {"severity": row[1], "risk_score": row[2]}
@@ -983,6 +1029,7 @@ class PostgresGraphStore:
             }
 
     def list_snapshots(self, *, tenant_id: str = "", limit: int = 50) -> list[dict[str, Any]]:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute(
                 """
@@ -1028,6 +1075,7 @@ class PostgresGraphStore:
         entity_types: set[str] | None = None,
         min_severity_rank: int = 0,
     ) -> dict[str, Any]:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         _assert_allowed_entity_types(entity_types)
         effective_scan_id = scan_id or self.latest_snapshot_id(tenant_id=tenant_id)
         if not effective_scan_id:
@@ -1125,6 +1173,7 @@ class PostgresGraphStore:
         offset: int = 0,
         limit: int = 500,
     ) -> tuple[str, str, list[Any], int, str | None]:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         _assert_allowed_entity_types(entity_types)
         effective_scan_id = scan_id or self.latest_snapshot_id(tenant_id=tenant_id)
         if not effective_scan_id:
@@ -1193,6 +1242,7 @@ class PostgresGraphStore:
         scan_id: str = "",
         node_ids: set[str],
     ) -> list[Any]:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         if not node_ids:
             return []
         effective_scan_id = scan_id or self.latest_snapshot_id(tenant_id=tenant_id)
@@ -1242,6 +1292,7 @@ class PostgresGraphStore:
         offset: int = 0,
         limit: int = 50,
     ):
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         _assert_allowed_entity_types(entity_types)
         effective_scan_id = scan_id or self.latest_snapshot_id(tenant_id=tenant_id)
         if not effective_scan_id:
@@ -1323,6 +1374,7 @@ class PostgresGraphStore:
             return nodes, total, next_cursor
 
     def save_preset(self, *, tenant_id: str, name: str, description: str, filters: dict[str, Any], created_at: str) -> None:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         with _tenant_connection(self._pool) as conn:
             conn.execute(
                 """
@@ -1338,6 +1390,7 @@ class PostgresGraphStore:
             conn.commit()
 
     def list_presets(self, *, tenant_id: str) -> list[dict[str, Any]]:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute(
                 "SELECT name, description, filters, created_at FROM graph_filter_presets WHERE tenant_id = %s ORDER BY name",
@@ -1354,6 +1407,7 @@ class PostgresGraphStore:
             ]
 
     def delete_preset(self, *, tenant_id: str, name: str) -> bool:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
         with _tenant_connection(self._pool) as conn:
             cursor = conn.execute(
                 "DELETE FROM graph_filter_presets WHERE name = %s AND tenant_id = %s",

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -14,7 +14,7 @@ from agent_bom.config import POSTGRES_GRAPH_SEARCH_TIMEOUT_MS, POSTGRES_STATEMEN
 from agent_bom.db.graph_store import DEFAULT_GRAPH_TENANT_ID, normalize_graph_tenant_id
 from agent_bom.graph import EntityType
 
-from .postgres_common import _ensure_tenant_rls, _get_pool, _tenant_connection
+from .postgres_common import _apply_tenant_session, _ensure_tenant_rls, _get_pool, _tenant_connection, bypass_tenant_rls
 
 _ALLOWED_ENTITY_TYPES = {entity_type.value for entity_type in EntityType}
 _DEFAULT_GRAPH_WRITE_BATCH_SIZE = 1000
@@ -278,7 +278,10 @@ class PostgresGraphStore:
                 ON graph_node_search(tenant_id, scan_id, severity)
                 """
             )
-            _backfill_empty_tenant_ids(conn)
+            with bypass_tenant_rls():
+                _apply_tenant_session(conn)
+                _backfill_empty_tenant_ids(conn)
+            _apply_tenant_session(conn)
             try:
                 conn.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
                 conn.execute(

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -216,7 +216,7 @@ def default_graph_db_path() -> Path:
     return Path.home() / ".agent-bom" / "db" / "graph.db"
 
 
-def _init_db(conn: sqlite3.Connection) -> None:
+def _init_db(conn: sqlite3.Connection, *, backfill_legacy_tenants: bool = True) -> None:
     """Ensure tables exist and schema is current."""
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA foreign_keys=ON")
@@ -233,7 +233,8 @@ def _init_db(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE attack_paths ADD COLUMN summary TEXT DEFAULT ''")
     if "tool_exposure" not in existing_columns:
         conn.execute("ALTER TABLE attack_paths ADD COLUMN tool_exposure TEXT DEFAULT '[]'")
-    _backfill_empty_tenant_ids(conn)
+    if backfill_legacy_tenants:
+        _backfill_empty_tenant_ids(conn)
     conn.commit()
 
 

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -36,8 +36,16 @@ logger = logging.getLogger(__name__)
 # Schema DDL — scan_id is part of every PK for per-scan isolation
 # ═══════════════════════════════════════════════════════════════════════════
 
+DEFAULT_GRAPH_TENANT_ID = "default"
 _GRAPH_SCHEMA_VERSION = 2
 _DEFAULT_GRAPH_WRITE_BATCH_SIZE = 1000
+_GRAPH_TENANT_TABLE_KEYS: dict[str, tuple[str, ...]] = {
+    "graph_nodes": ("id", "scan_id"),
+    "graph_edges": ("source_id", "target_id", "relationship", "scan_id"),
+    "graph_snapshots": ("scan_id",),
+    "attack_paths": ("source_node", "target_node", "scan_id"),
+    "interaction_risks": ("pattern", "agents", "scan_id"),
+}
 
 _CREATE_TABLES = """\
 -- ── Graph nodes (one row per node per scan) ──
@@ -62,7 +70,7 @@ CREATE TABLE IF NOT EXISTS graph_nodes (
     data_sources    TEXT DEFAULT '[]',
     dimensions      TEXT DEFAULT '{}',
     scan_id         TEXT NOT NULL,
-    tenant_id       TEXT DEFAULT '',
+    tenant_id       TEXT NOT NULL DEFAULT 'default',
     PRIMARY KEY (id, scan_id, tenant_id)
 );
 
@@ -85,7 +93,7 @@ CREATE TABLE IF NOT EXISTS graph_edges (
     evidence        TEXT DEFAULT '{}',
     activity_id     INTEGER DEFAULT 1,
     scan_id         TEXT NOT NULL,
-    tenant_id       TEXT DEFAULT '',
+    tenant_id       TEXT NOT NULL DEFAULT 'default',
     PRIMARY KEY (source_id, target_id, relationship, scan_id, tenant_id)
 );
 
@@ -98,7 +106,7 @@ CREATE INDEX IF NOT EXISTS idx_ge_tenant_scan ON graph_edges(tenant_id, scan_id)
 -- ── Snapshots ──
 CREATE TABLE IF NOT EXISTS graph_snapshots (
     scan_id         TEXT NOT NULL,
-    tenant_id       TEXT DEFAULT '',
+    tenant_id       TEXT NOT NULL DEFAULT 'default',
     created_at      TEXT NOT NULL,
     node_count      INTEGER DEFAULT 0,
     edge_count      INTEGER DEFAULT 0,
@@ -120,7 +128,7 @@ CREATE TABLE IF NOT EXISTS attack_paths (
     tool_exposure   TEXT DEFAULT '[]',
     vuln_ids        TEXT DEFAULT '[]',
     scan_id         TEXT NOT NULL,
-    tenant_id       TEXT DEFAULT '',
+    tenant_id       TEXT NOT NULL DEFAULT 'default',
     computed_at     TEXT NOT NULL,
     PRIMARY KEY (source_node, target_node, scan_id, tenant_id)
 );
@@ -136,7 +144,7 @@ CREATE TABLE IF NOT EXISTS interaction_risks (
     description     TEXT DEFAULT '',
     owasp_agentic_tag TEXT DEFAULT NULL,
     scan_id         TEXT NOT NULL,
-    tenant_id       TEXT DEFAULT '',
+    tenant_id       TEXT NOT NULL DEFAULT 'default',
     PRIMARY KEY (pattern, agents, scan_id, tenant_id)
 );
 
@@ -150,6 +158,48 @@ CREATE TABLE IF NOT EXISTS graph_schema_version (
 # ═══════════════════════════════════════════════════════════════════════════
 # Connection helpers
 # ═══════════════════════════════════════════════════════════════════════════
+
+
+def normalize_graph_tenant_id(tenant_id: str | None) -> str:
+    """Map legacy blank graph tenants into the canonical default bucket."""
+
+    return (tenant_id or "").strip() or DEFAULT_GRAPH_TENANT_ID
+
+
+def _backfill_empty_tenant_ids(conn: sqlite3.Connection, table_keys: dict[str, tuple[str, ...]] | None = None) -> None:
+    """Move legacy ``tenant_id = ''`` rows into the default graph tenant.
+
+    When a default-tenant row already exists for the same graph key, keep the
+    explicit default row and drop the duplicate legacy row before updating.
+    """
+
+    specs = table_keys or _GRAPH_TENANT_TABLE_KEYS
+    for table, key_columns in specs.items():
+        table_exists = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'virtual') AND name = ?",
+            (table,),
+        ).fetchone()
+        if table_exists is None:
+            continue
+        if key_columns:
+            key_match = " AND ".join(f"existing.{column} = {table}.{column}" for column in key_columns)
+            conn.execute(
+                f"""
+                DELETE FROM {table}
+                WHERE tenant_id = ''
+                  AND EXISTS (
+                    SELECT 1
+                    FROM {table} existing
+                    WHERE existing.tenant_id = ?
+                      AND {key_match}
+                  )
+                """,  # nosec B608 - table/key names are static internal schema metadata
+                (DEFAULT_GRAPH_TENANT_ID,),
+            )
+        conn.execute(
+            f"UPDATE {table} SET tenant_id = ? WHERE tenant_id = ''",  # nosec B608 - table names are static internal schema metadata
+            (DEFAULT_GRAPH_TENANT_ID,),
+        )
 
 
 def default_graph_db_path() -> Path:
@@ -183,6 +233,7 @@ def _init_db(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE attack_paths ADD COLUMN summary TEXT DEFAULT ''")
     if "tool_exposure" not in existing_columns:
         conn.execute("ALTER TABLE attack_paths ADD COLUMN tool_exposure TEXT DEFAULT '[]'")
+    _backfill_empty_tenant_ids(conn)
     conn.commit()
 
 
@@ -233,6 +284,7 @@ def open_graph_db(db_path: str | Path) -> Generator[sqlite3.Connection, None, No
 
 def latest_snapshot_id(conn: sqlite3.Connection, *, tenant_id: str = "") -> str:
     """Return the newest snapshot ID for a tenant, or ``""`` when absent."""
+    tenant_id = normalize_graph_tenant_id(tenant_id)
     row = conn.execute(
         """\
         SELECT scan_id
@@ -248,6 +300,7 @@ def latest_snapshot_id(conn: sqlite3.Connection, *, tenant_id: str = "") -> str:
 
 def previous_snapshot_id(conn: sqlite3.Connection, *, tenant_id: str = "", before_scan_id: str = "") -> str:
     """Return the snapshot immediately before ``before_scan_id`` for a tenant."""
+    tenant_id = normalize_graph_tenant_id(tenant_id)
     if not before_scan_id:
         return ""
     current = conn.execute(
@@ -276,6 +329,7 @@ def _resolve_snapshot(
     scan_id: str = "",
 ) -> tuple[str, str]:
     """Resolve the requested or latest snapshot and return ``(scan_id, created_at)``."""
+    tenant_id = normalize_graph_tenant_id(tenant_id)
     effective_scan_id = scan_id or latest_snapshot_id(conn, tenant_id=tenant_id)
     if not effective_scan_id:
         return "", ""
@@ -293,7 +347,7 @@ def _resolve_snapshot(
 
 def save_graph(conn: sqlite3.Connection, graph: UnifiedGraph) -> None:
     """Persist a UnifiedGraph as an immutable per-scan snapshot."""
-    tenant = graph.tenant_id
+    tenant = normalize_graph_tenant_id(graph.tenant_id)
     scan = graph.scan_id
     now = _now_iso()
     batch_size = _graph_write_batch_size()
@@ -438,6 +492,7 @@ def load_graph(
     min_severity_rank: int = 0,
 ) -> UnifiedGraph:
     """Load a UnifiedGraph from a specific scan snapshot."""
+    tenant_id = normalize_graph_tenant_id(tenant_id)
     effective_scan_id, created_at = _resolve_snapshot(conn, tenant_id=tenant_id, scan_id=scan_id)
     graph = UnifiedGraph(scan_id=effective_scan_id, tenant_id=tenant_id, created_at=created_at)
     if not effective_scan_id:
@@ -543,6 +598,7 @@ def diff_snapshots(
     tenant_id: str = "",
 ) -> dict[str, Any]:
     """Compute the diff between two scan snapshots."""
+    tenant_id = normalize_graph_tenant_id(tenant_id)
     old_nodes: dict[str, dict] = {}
     for row in conn.execute(
         "SELECT id, severity, risk_score FROM graph_nodes WHERE scan_id = ? AND tenant_id = ?",
@@ -589,6 +645,7 @@ def list_snapshots(
     limit: int = 50,
 ) -> list[dict[str, Any]]:
     """List recent graph snapshots ordered by creation time desc."""
+    tenant_id = normalize_graph_tenant_id(tenant_id)
     rows = conn.execute(
         """\
         SELECT scan_id, created_at, node_count, edge_count, risk_summary

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -14,7 +14,7 @@ from agent_bom.api.graph_store import SQLiteGraphStore
 from agent_bom.api.routes import graph as graph_routes
 from agent_bom.api.server import app
 from agent_bom.api.stores import set_graph_store
-from agent_bom.db.graph_store import _init_db, load_graph, save_graph
+from agent_bom.db.graph_store import DEFAULT_GRAPH_TENANT_ID, _init_db, load_graph, save_graph
 from agent_bom.graph import (
     AttackPath,
     EntityType,
@@ -73,6 +73,14 @@ def _build_persisted_graph(db, scan_id="test-scan-001"):
     )
     save_graph(db, g)
     return g
+
+
+def _sqlite_tenant_defaults(conn: sqlite3.Connection, tables: tuple[str, ...]) -> dict[str, str | None]:
+    defaults: dict[str, str | None] = {}
+    for table in tables:
+        tenant_row = next(row for row in conn.execute(f"PRAGMA table_info({table})") if row["name"] == "tenant_id")
+        defaults[table] = tenant_row["dflt_value"]
+    return defaults
 
 
 @pytest.fixture
@@ -180,6 +188,139 @@ class TestScanPipelineWiring:
         assert "agent:latest" in latest.nodes
         assert "agent:a" not in latest.nodes
 
+    def test_sqlite_graph_schema_defaults_tenant_to_default(self, graph_db):
+        defaults = _sqlite_tenant_defaults(
+            graph_db,
+            (
+                "graph_nodes",
+                "graph_edges",
+                "graph_snapshots",
+                "attack_paths",
+                "interaction_risks",
+            ),
+        )
+
+        assert defaults
+        assert all(default == "'default'" for default in defaults.values())
+
+    def test_low_level_sqlite_graph_empty_tenant_rows_are_backfilled_to_default(self, tmp_path):
+        db_path = tmp_path / "legacy-low-level-graph.db"
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            _init_db(conn)
+            conn.execute(
+                """
+                INSERT INTO graph_nodes (
+                    id, entity_type, label, first_seen, last_seen, attributes,
+                    compliance_tags, data_sources, dimensions, scan_id, tenant_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "agent:legacy",
+                    "agent",
+                    "Legacy Agent",
+                    "2026-05-01T00:00:00Z",
+                    "2026-05-01T00:00:00Z",
+                    "{}",
+                    "[]",
+                    "[]",
+                    "{}",
+                    "legacy-scan",
+                    "",
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO graph_nodes (
+                    id, entity_type, label, first_seen, last_seen, attributes,
+                    compliance_tags, data_sources, dimensions, scan_id, tenant_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "server:legacy",
+                    "server",
+                    "Legacy Server",
+                    "2026-05-01T00:00:00Z",
+                    "2026-05-01T00:00:00Z",
+                    "{}",
+                    "[]",
+                    "[]",
+                    "{}",
+                    "legacy-scan",
+                    "",
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO graph_edges (
+                    source_id, target_id, relationship, first_seen, last_seen,
+                    evidence, scan_id, tenant_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "agent:legacy",
+                    "server:legacy",
+                    "uses",
+                    "2026-05-01T00:00:00Z",
+                    "2026-05-01T00:00:00Z",
+                    "{}",
+                    "legacy-scan",
+                    "",
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO graph_snapshots (scan_id, tenant_id, created_at, node_count, edge_count, risk_summary)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                ("legacy-scan", "", "2026-05-01T00:00:00Z", 2, 1, "{}"),
+            )
+            conn.execute(
+                """
+                INSERT INTO attack_paths (
+                    source_node, target_node, hop_count, composite_risk, summary,
+                    path_nodes, path_edges, credential_exposure, tool_exposure,
+                    vuln_ids, scan_id, tenant_id, computed_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "agent:legacy",
+                    "server:legacy",
+                    1,
+                    4.2,
+                    "legacy path",
+                    '["agent:legacy", "server:legacy"]',
+                    '["uses"]',
+                    "[]",
+                    "[]",
+                    "[]",
+                    "legacy-scan",
+                    "",
+                    "2026-05-01T00:00:00Z",
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO interaction_risks (pattern, agents, risk_score, description, scan_id, tenant_id)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                ("legacy-pattern", '["agent:legacy"]', 3.5, "legacy risk", "legacy-scan", ""),
+            )
+            conn.commit()
+            _init_db(conn)
+
+            loaded = load_graph(conn, tenant_id=DEFAULT_GRAPH_TENANT_ID, scan_id="legacy-scan")
+            assert sorted(loaded.nodes) == ["agent:legacy", "server:legacy"]
+            assert [(edge.source, edge.target) for edge in loaded.edges] == [("agent:legacy", "server:legacy")]
+            assert [path.summary for path in loaded.attack_paths] == ["legacy path"]
+            assert [risk.pattern for risk in loaded.interaction_risks] == ["legacy-pattern"]
+
+            for table in ("graph_nodes", "graph_edges", "graph_snapshots", "attack_paths", "interaction_risks"):
+                assert conn.execute(f"SELECT COUNT(*) FROM {table} WHERE tenant_id = ''").fetchone()[0] == 0
+        finally:
+            conn.close()
+
 
 class TestGraphEndpointLogic:
     """Test the endpoint logic directly (no HTTP, just function calls)."""
@@ -266,6 +407,90 @@ class TestGraphEndpointLogic:
         assert total == 1
         assert [node.id for node in results] == ["server:acme:vector"]
         assert next_cursor is None
+
+    def test_sqlite_graph_store_empty_tenant_rows_query_under_default(self, tmp_path):
+        store = SQLiteGraphStore(tmp_path / "legacy-api-graph.db")
+        conn = store._open_rw_conn()
+        try:
+            conn.execute(
+                """
+                INSERT INTO graph_nodes (
+                    id, entity_type, label, first_seen, last_seen, attributes,
+                    compliance_tags, data_sources, dimensions, scan_id, tenant_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "agent:legacy-api",
+                    "agent",
+                    "Legacy API Agent",
+                    "2026-05-01T00:00:00Z",
+                    "2026-05-01T00:00:00Z",
+                    "{}",
+                    "[]",
+                    "[]",
+                    "{}",
+                    "legacy-api-scan",
+                    "",
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO graph_snapshots (scan_id, tenant_id, created_at, node_count, edge_count, risk_summary)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                ("legacy-api-scan", "", "2026-05-01T00:00:00Z", 1, 0, "{}"),
+            )
+            conn.execute(
+                """
+                INSERT INTO graph_filter_presets (name, tenant_id, description, filters, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                ("legacy-filter", "", "legacy filter", '{"entity_types":["agent"]}', "2026-05-01T00:00:00Z"),
+            )
+            conn.execute(
+                """
+                INSERT INTO graph_node_search (
+                    tenant_id, scan_id, node_id, entity_type, severity, compliance_tags, data_sources, search_text
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("", "legacy-api-scan", "agent:legacy-api", "agent", "", "", "", "legacy api agent"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        loaded = store.load_graph(tenant_id="default", scan_id="legacy-api-scan")
+        search_results, search_total, _ = store.search_nodes(
+            tenant_id="default",
+            scan_id="legacy-api-scan",
+            query="legacy",
+            limit=10,
+        )
+        presets = store.list_presets(tenant_id="default")
+
+        assert list(loaded.nodes) == ["agent:legacy-api"]
+        assert search_total == 1
+        assert [node.id for node in search_results] == ["agent:legacy-api"]
+        assert [preset["name"] for preset in presets] == ["legacy-filter"]
+
+        conn = sqlite3.connect(tmp_path / "legacy-api-graph.db")
+        try:
+            for table in ("graph_nodes", "graph_snapshots", "graph_filter_presets", "graph_node_search"):
+                assert conn.execute(f"SELECT COUNT(*) FROM {table} WHERE tenant_id = ''").fetchone()[0] == 0
+        finally:
+            conn.close()
+
+    def test_sqlite_graph_store_new_api_tables_do_not_default_to_empty_tenant(self, tmp_path):
+        store = SQLiteGraphStore(tmp_path / "schema-defaults.db")
+        conn = store._open_rw_conn()
+        try:
+            defaults = _sqlite_tenant_defaults(conn, ("graph_filter_presets",))
+            search_tenant = next(row for row in conn.execute("PRAGMA table_info(graph_node_search)") if row["name"] == "tenant_id")
+        finally:
+            conn.close()
+
+        assert defaults["graph_filter_presets"] == "'default'"
+        assert search_tenant["dflt_value"] is None
 
     def test_sqlite_graph_store_search_applies_slice_filters(self, tmp_path):
         store = SQLiteGraphStore(tmp_path / "graph.db")

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -480,6 +480,21 @@ class TestGraphEndpointLogic:
         finally:
             conn.close()
 
+    def test_sqlite_graph_store_read_path_does_not_run_legacy_backfill(self, tmp_path, monkeypatch):
+        store = SQLiteGraphStore(tmp_path / "read-path-graph.db")
+        graph = UnifiedGraph(scan_id="read-scan", tenant_id="tenant-alpha")
+        graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        store.save_graph(graph)
+
+        def fail_backfill(*_args, **_kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+        monkeypatch.setattr("agent_bom.api.graph_store.sqlite_graph_store._backfill_empty_tenant_ids", fail_backfill)
+
+        loaded = store.load_graph(tenant_id="tenant-alpha", scan_id="read-scan")
+
+        assert "agent:a" in loaded.nodes
+
     def test_sqlite_graph_store_new_api_tables_do_not_default_to_empty_tenant(self, tmp_path):
         store = SQLiteGraphStore(tmp_path / "schema-defaults.db")
         conn = store._open_rw_conn()

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1251,6 +1251,29 @@ def test_graph_store_init_backfills_empty_tenant_rows(mock_pool):
     assert expected_tables.issubset(delete_tables)
 
 
+def test_graph_store_init_backfills_empty_tenant_rows_with_rls_bypass(mock_pool):
+    from agent_bom.api.postgres_store import PostgresGraphStore
+
+    PostgresGraphStore(pool=mock_pool)
+
+    executed = mock_pool._conn.executed
+    bypass_on_index = next(
+        index for index, (sql, params) in enumerate(executed) if "set_config('app.bypass_rls'" in sql and params == ("1",)
+    )
+    first_backfill_index = next(
+        index
+        for index, (sql, _params) in enumerate(executed)
+        if "legacy.tenant_id = ''" in sql or "SET tenant_id = %s WHERE tenant_id = ''" in sql
+    )
+    bypass_off_after_backfill = any(
+        index > first_backfill_index and "set_config('app.bypass_rls'" in sql and params == ("0",)
+        for index, (sql, params) in enumerate(executed)
+    )
+
+    assert bypass_on_index < first_backfill_index
+    assert bypass_off_after_backfill
+
+
 def test_graph_store_save_graph_normalizes_empty_tenant_to_default(mock_pool):
     from agent_bom.api.postgres_store import PostgresGraphStore
     from agent_bom.graph import EntityType, UnifiedGraph, UnifiedNode

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1222,6 +1222,54 @@ def test_graph_store_init_adds_query_indexes(mock_pool):
     assert any("idx_pg_attack_paths_scan_risk" in sql for sql, _ in mock_pool._conn.executed)
 
 
+def test_graph_store_init_backfills_empty_tenant_rows(mock_pool):
+    from agent_bom.api.postgres_store import PostgresGraphStore
+
+    PostgresGraphStore(pool=mock_pool)
+
+    expected_tables = {
+        "graph_nodes",
+        "graph_edges",
+        "graph_snapshots",
+        "attack_paths",
+        "interaction_risks",
+        "graph_filter_presets",
+        "graph_node_search",
+    }
+    update_tables = {
+        sql.strip().split()[1]
+        for sql, params in mock_pool._conn.executed
+        if sql.strip().startswith("UPDATE ") and "SET tenant_id = %s WHERE tenant_id = ''" in sql and params == ("default",)
+    }
+    delete_tables = {
+        sql.strip().split()[2]
+        for sql, params in mock_pool._conn.executed
+        if sql.strip().startswith("DELETE FROM ") and "legacy.tenant_id = ''" in sql and params == ("default",)
+    }
+
+    assert expected_tables.issubset(update_tables)
+    assert expected_tables.issubset(delete_tables)
+
+
+def test_graph_store_save_graph_normalizes_empty_tenant_to_default(mock_pool):
+    from agent_bom.api.postgres_store import PostgresGraphStore
+    from agent_bom.graph import EntityType, UnifiedGraph, UnifiedNode
+
+    store = PostgresGraphStore(pool=mock_pool)
+    graph = UnifiedGraph(scan_id="scan-default")
+    graph.add_node(UnifiedNode(id="agent:default", entity_type=EntityType.AGENT, label="Default Agent"))
+
+    store.save_graph(graph)
+
+    graph_node_rows = [
+        rows for sql, rows in mock_pool._conn.executemany_calls if "INSERT INTO graph_nodes" in sql and "graph_node_search" not in sql
+    ]
+    graph_search_rows = [rows for sql, rows in mock_pool._conn.executemany_calls if "INSERT INTO graph_node_search" in sql]
+
+    assert graph_node_rows[-1][0][17] == "default"
+    assert graph_search_rows[-1][0][1] == "default"
+
+
 def test_graph_store_nodes_by_ids_uses_node_table(mock_pool, monkeypatch):
     from agent_bom.api.postgres_store import PostgresGraphStore
     from agent_bom.graph import EntityType, UnifiedGraph, UnifiedNode


### PR DESCRIPTION
## Summary

- Backfills legacy graph rows with empty tenant IDs into the default tenant bucket.
- Aligns SQLite and Postgres graph query behavior so old empty-tenant rows remain visible through the current default tenant path.
- Runs the Postgres legacy backfill under the existing trusted internal RLS-bypass session flag so existing forced-RLS installs are actually migrated.
- Keeps SQLite API read paths available when a concurrent writer locks the database during best-effort legacy backfill.
- Adds regression coverage for graph API and Postgres graph store behavior.

## Why

Closes the release-audit gap where pre-tenant graph rows could be stranded after tenant-aware graph APIs standardized on a non-empty default tenant.

## Validation

- `pytest tests/test_graph_api.py tests/test_postgres_store.py tests/test_api_tenant_isolation.py -q`
- `pytest tests/test_graph_api.py::TestGraphEndpointLogic::test_sqlite_graph_store_read_path_does_not_run_legacy_backfill tests/test_graph_api.py::TestGraphEndpointLogic::test_sqlite_graph_store_empty_tenant_rows_query_under_default tests/test_api_tenant_isolation.py::test_receive_push_normalizes_report_contract_and_persists_graph -q`
- `python -m compileall -q src/agent_bom/db/graph_store.py src/agent_bom/api/graph_store.py src/agent_bom/api/postgres_graph.py`
- `ruff check src/agent_bom/db/graph_store.py src/agent_bom/api/graph_store.py src/agent_bom/api/postgres_graph.py tests/test_graph_api.py tests/test_postgres_store.py`
- Commit hooks passed: `ruff`, `ruff-format`, `mypy`, `bandit`, env-var reference drift
