### PR TITLE
docs: align blast-radius example direction

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -17,7 +17,7 @@ better-sqlite3@9.0.0  (npm package)
  Fix: upgrade better-sqlite3 → 11.7.0
 ```
 
-Blast radius is the core idea: `package -> vulnerability finding -> MCP server -> agent -> credentials -> tools`.
+Blast radius is the core idea: `package -> vulnerability finding -> MCP server (tools + credential env names) -> connected agents`.
 
 Scan local agent configs, MCP servers, instruction files, lockfiles, containers, cloud posture, GPU surfaces, and runtime evidence.
 
@@ -99,7 +99,7 @@ helm upgrade --install agent-bom deploy/helm/agent-bom \
 
 ## Key features
 
-- **Blast radius mapping** — package → vulnerability finding → MCP server → agent → credentials → tools
+- **Blast radius mapping** — package → vulnerability finding → MCP server (tools + credential env names) → connected agents
 - **CWE-aware impact** — RCE shows credential exposure, DoS does not
 - **Portable outputs** — SARIF, CycloneDX, SPDX, HTML, graph, JSON, ZIP evidence bundles, and more
 - **MCP server mode** — expose `agent-bom` capabilities directly to MCP clients like Claude, Cursor, Windsurf, and Cortex CoCo / Cortex Code

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -7,17 +7,17 @@
 Start with the demo, then choose the entrypoint that matches your first job: repo scan, image scan, cloud posture, fix plan, dashboard, or runtime review.
 
 ```text
-CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
-  |── better-sqlite3@9.0.0  (npm)
-       |── sqlite-mcp  (MCP Server · unverified · root)
-            |── Cursor IDE  (Agent · 4 servers · 12 tools)
-            |── ANTHROPIC_KEY, DB_URL, AWS_SECRET  (Credentials exposed)
-            |── query_db, read_file, write_file, run_shell  (Tools at risk)
+better-sqlite3@9.0.0  (npm package)
+  |── CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
+  |── sqlite-mcp  (MCP Server · unverified · root)
+       |── Cursor IDE  (Agent · 4 servers · 12 tools)
+       |── ANTHROPIC_KEY, DB_URL, AWS_SECRET  (Credential env names visible)
+       |── query_db, read_file, write_file, run_shell  (Tools at risk)
 
  Fix: upgrade better-sqlite3 → 11.7.0
 ```
 
-Blast radius is the core idea: `CVE -> package -> MCP server -> agent -> credentials -> tools`.
+Blast radius is the core idea: `package -> vulnerability finding -> MCP server -> agent -> credentials -> tools`.
 
 Scan local agent configs, MCP servers, instruction files, lockfiles, containers, cloud posture, GPU surfaces, and runtime evidence.
 
@@ -99,7 +99,7 @@ helm upgrade --install agent-bom deploy/helm/agent-bom \
 
 ## Key features
 
-- **Blast radius mapping** — CVE → package → MCP server → agent → credentials → tools
+- **Blast radius mapping** — package → vulnerability finding → MCP server → agent → credentials → tools
 - **CWE-aware impact** — RCE shows credential exposure, DoS does not
 - **Portable outputs** — SARIF, CycloneDX, SPDX, HTML, graph, JSON, ZIP evidence bundles, and more
 - **MCP server mode** — expose `agent-bom` capabilities directly to MCP clients like Claude, Cursor, Windsurf, and Cortex CoCo / Cortex Code

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/blast-radius-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/blast-radius-light.svg" alt="agent-bom blast-radius drilldown — package → CVE → MCP server → agent → credentials → tools" width="900" />
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/blast-radius-light.svg" alt="agent-bom blast-radius drilldown — package → CVE → MCP server (tools + credential env names) → connected agents" width="900" />
   </picture>
 </p>
 
@@ -36,7 +36,7 @@ better-sqlite3@9.0.0  (npm package)
  Fix: upgrade better-sqlite3 → 11.7.0
 ```
 
-Blast radius is the core idea: `package -> vulnerability finding -> MCP server -> agent -> credentials -> tools`. You can search by CVE, package, server, or agent, but the evidence graph keeps the vulnerable package instance as the source of the reachable exposure path. CWE-aware impact keeps a DoS from being reported like credential compromise.
+Blast radius is the core idea: `package -> vulnerability finding -> MCP server (tools + credential env names) -> connected agents`. You can search by CVE, package, server, tool, credential name, or agent, but the evidence graph keeps the vulnerable package instance as the source of the reachable exposure path. CWE-aware impact keeps a DoS from being reported like credential compromise.
 
 ## Try the demo
 

--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@
 </p>
 
 ```text
-CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
-  |── better-sqlite3@9.0.0  (npm)
-       |── sqlite-mcp  (MCP Server · unverified · root)
-            |── Cursor IDE  (Agent · 4 servers · 12 tools)
-            |── ANTHROPIC_KEY, DB_URL, AWS_SECRET  (Credentials exposed)
-            |── query_db, read_file, write_file, run_shell  (Tools at risk)
+better-sqlite3@9.0.0  (npm package)
+  |── CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
+  |── sqlite-mcp  (MCP Server · unverified · root)
+       |── Cursor IDE  (Agent · 4 servers · 12 tools)
+       |── ANTHROPIC_KEY, DB_URL, AWS_SECRET  (Credential env names visible)
+       |── query_db, read_file, write_file, run_shell  (Tools at risk)
 
  Fix: upgrade better-sqlite3 → 11.7.0
 ```
 
-Blast radius is the core idea: `CVE -> package -> MCP server -> agent -> credentials -> tools`. CWE-aware impact keeps a DoS from being reported like credential compromise.
+Blast radius is the core idea: `package -> vulnerability finding -> MCP server -> agent -> credentials -> tools`. You can search by CVE, package, server, or agent, but the evidence graph keeps the vulnerable package instance as the source of the reachable exposure path. CWE-aware impact keeps a DoS from being reported like credential compromise.
 
 ## Try the demo
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,7 +62,7 @@ graph TB
         Discovery["Discovery\n29 first-class clients"]
         Parser["Package Parser\n15 ecosystems"]
         Scanner["CVE Scanner\nOSV + NVD + GHSA"]
-        Blast["Blast Radius\nCVE → package → server → credential → tool"]
+        Blast["Blast Radius\npackage → finding → server → credential → tool"]
         IaC["IaC Engine\n138 rules"]
         CIS["CIS Benchmarks\nAWS / Azure / GCP"]
     end
@@ -116,7 +116,7 @@ sequenceDiagram
     Enrichment-->>CLI: Enriched vulnerabilities
 
     CLI->>BlastRadius: Vulns + topology
-    BlastRadius->>BlastRadius: CVE → package → server → agent → creds → tools
+    BlastRadius->>BlastRadius: package → finding → server → agent → creds → tools
     BlastRadius->>BlastRadius: Tag 15 frameworks + attach AISVS benchmark
     BlastRadius-->>CLI: Scored + tagged findings
 

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -34,7 +34,7 @@ single source of truth that every other surface serializes from.
 | `PermissionProfile` | What an MCP server can touch | `can_read_files`, `can_write_files`, `can_execute_commands`, `network_access`, `requires_credentials` |
 | `MCPServer` | One discovered server | `name`, `command`, `transport`, `surface`, `packages`, `tools`, `resources`, `permissions`, `verified`, `runs_as_root`, `env` |
 | `Agent` | One discovered agent | `name`, `agent_type`, `source`, `mcp_servers`, `config_path`, `version`, `metadata` |
-| `BlastRadius` | The chain CVE → package → server → agent → credentials → tools | `vulnerability`, `package`, `affected_servers`, `affected_agents`, `exposed_credentials`, `exposed_tools`, `risk_score`, `compliance_tags`, `*_tags` (15 framework-specific tag fields) |
+| `BlastRadius` | The chain package → vulnerability finding → server → agent → credentials → tools | `vulnerability`, `package`, `affected_servers`, `affected_agents`, `exposed_credentials`, `exposed_tools`, `risk_score`, `compliance_tags`, `*_tags` (15 framework-specific tag fields) |
 | `AIBOMReport` | Top-level scan output | `scan_id`, `agents`, `blast_radius`, `summary`, `framework_catalogs`, `scan_sources`, `tenant_id` |
 
 ### Compliance tag fields on `BlastRadius`

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -34,7 +34,7 @@ single source of truth that every other surface serializes from.
 | `PermissionProfile` | What an MCP server can touch | `can_read_files`, `can_write_files`, `can_execute_commands`, `network_access`, `requires_credentials` |
 | `MCPServer` | One discovered server | `name`, `command`, `transport`, `surface`, `packages`, `tools`, `resources`, `permissions`, `verified`, `runs_as_root`, `env` |
 | `Agent` | One discovered agent | `name`, `agent_type`, `source`, `mcp_servers`, `config_path`, `version`, `metadata` |
-| `BlastRadius` | The chain package → vulnerability finding → server → agent → credentials → tools | `vulnerability`, `package`, `affected_servers`, `affected_agents`, `exposed_credentials`, `exposed_tools`, `risk_score`, `compliance_tags`, `*_tags` (15 framework-specific tag fields) |
+| `BlastRadius` | The chain package → vulnerability finding → MCP server (exposed tools + credential env names) → connected agents | `vulnerability`, `package`, `affected_servers`, `affected_agents`, `exposed_credentials`, `exposed_tools`, `risk_score`, `compliance_tags`, `*_tags` (15 framework-specific tag fields) |
 | `AIBOMReport` | Top-level scan output | `scan_id`, `agents`, `blast_radius`, `summary`, `framework_catalogs`, `scan_sources`, `tenant_id` |
 
 ### Compliance tag fields on `BlastRadius`

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -65,7 +65,7 @@ CVE-2025-XXXX (CRITICAL)
                  └── Credentials exposed: DB_URL, ANTHROPIC_API_KEY
 ```
 
-**What agent-bom does:** scans every package in every discovered server against OSV, NVD, EPSS, CISA KEV, and GHSA. Maps CVE → package → server → agent → credentials → tools (blast radius). The full contract for the security graph — entity / edge coverage, accuracy guarantees, scaling tiers, and known gaps — is in [docs/graph/CONTRACT.md](graph/CONTRACT.md).
+**What agent-bom does:** scans every package in every discovered server against OSV, NVD, EPSS, CISA KEV, and GHSA. Maps package → vulnerability finding → server → agent → credentials → tools (blast radius). The full contract for the security graph — entity / edge coverage, accuracy guarantees, scaling tiers, and known gaps — is in [docs/graph/CONTRACT.md](graph/CONTRACT.md).
 
 agent-bom also ships bundled MCP intelligence at `src/agent_bom/data/mcp-blocklist.json`
 with a machine-readable contract in `src/agent_bom/data/mcp-intelligence.schema.json`.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -65,7 +65,7 @@ CVE-2025-XXXX (CRITICAL)
                  └── Credentials exposed: DB_URL, ANTHROPIC_API_KEY
 ```
 
-**What agent-bom does:** scans every package in every discovered server against OSV, NVD, EPSS, CISA KEV, and GHSA. Maps package → vulnerability finding → server → agent → credentials → tools (blast radius). The full contract for the security graph — entity / edge coverage, accuracy guarantees, scaling tiers, and known gaps — is in [docs/graph/CONTRACT.md](graph/CONTRACT.md).
+**What agent-bom does:** scans every package in every discovered server against OSV, NVD, EPSS, CISA KEV, and GHSA. Maps package → vulnerability finding → MCP server (exposed tools + credential env names) → connected agents (blast radius). The full contract for the security graph — entity / edge coverage, accuracy guarantees, scaling tiers, and known gaps — is in [docs/graph/CONTRACT.md](graph/CONTRACT.md).
 
 agent-bom also ships bundled MCP intelligence at `src/agent_bom/data/mcp-blocklist.json`
 with a machine-readable contract in `src/agent_bom/data/mcp-intelligence.schema.json`.

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -161,7 +161,7 @@ agent-bom proxy-bootstrap \
 |----------|-------|-------------|
 | **Scan** | `scan`, `code_scan`, `vector_db_scan`, `gpu_infra_scan`, `ai_inventory_scan` | Discover agents, scan packages, code, vector stores, GPU infra, and AI usage |
 | **Check** | `check`, `verify`, `marketplace_check`, `license_compliance_scan` | Pre-install CVE gate, integrity verification, marketplace trust, and license policy |
-| **Blast Radius** | `blast_radius` | Map package → vulnerability finding → MCP server → agent → credentials → tools |
+| **Blast Radius** | `blast_radius` | Map package → vulnerability finding → MCP server (tools + credential env names) → connected agents |
 | **Registry** | `registry_lookup`, `inventory`, `where`, `fleet_scan` | Query the MCP registry, inspect discovery paths, and summarize fleet inventories |
 | **Compliance** | `compliance`, `cis_benchmark`, `aisvs_benchmark` | Run OWASP, NIST, MITRE ATLAS, CIS, and AISVS-aligned posture checks |
 | **Policy** | `policy_check`, `remediate` | Evaluate policies and generate guided remediation plans |

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -161,7 +161,7 @@ agent-bom proxy-bootstrap \
 |----------|-------|-------------|
 | **Scan** | `scan`, `code_scan`, `vector_db_scan`, `gpu_infra_scan`, `ai_inventory_scan` | Discover agents, scan packages, code, vector stores, GPU infra, and AI usage |
 | **Check** | `check`, `verify`, `marketplace_check`, `license_compliance_scan` | Pre-install CVE gate, integrity verification, marketplace trust, and license policy |
-| **Blast Radius** | `blast_radius` | Map CVE → package → MCP server → agent → credentials → tools |
+| **Blast Radius** | `blast_radius` | Map package → vulnerability finding → MCP server → agent → credentials → tools |
 | **Registry** | `registry_lookup`, `inventory`, `where`, `fleet_scan` | Query the MCP registry, inspect discovery paths, and summarize fleet inventories |
 | **Compliance** | `compliance`, `cis_benchmark`, `aisvs_benchmark` | Run OWASP, NIST, MITRE ATLAS, CIS, and AISVS-aligned posture checks |
 | **Policy** | `policy_check`, `remediate` | Evaluate policies and generate guided remediation plans |

--- a/docs/archive/AUDIT.md
+++ b/docs/archive/AUDIT.md
@@ -40,7 +40,7 @@ OpenSSF Scorecard (enrichment)       maintainer quality signal
 ```
 
 **CVSS parsing**: v3.1 and v4.0 implemented from spec, not from a library.
-**Blast radius**: package → vulnerability finding → servers → agents → tools → credentials → risk score.
+**Blast radius**: package → vulnerability finding → MCP servers (tools + credential env names) → connected agents → risk score.
 **Risk score formula**: base_severity + agent_reach + cred_exposure + tool_count + AI_boost + KEV_boost + EPSS_boost + scorecard_boost (all configurable via env vars).
 **Compliance tagging**: 14 frameworks on every blast radius — OWASP LLM, OWASP MCP, OWASP Agentic, ATLAS, NIST AI RMF, EU AI Act, NIST CSF, ISO 27001, SOC 2, CIS Controls, CMMC.
 **Toxic combos**: 8 patterns — CRED_BLAST, KEV_WITH_CREDS, EXECUTE_EXPLOIT, MULTI_AGENT_CVE, TRANSITIVE_CRITICAL, LATERAL_CHAIN, CACHE_POISON, CROSS_AGENT_POISON.
@@ -266,7 +266,7 @@ Enrichment (optional, --enrich flag)
         |
         v
 Blast Radius Analysis (agent-bom's core intelligence)
-├── package → vulnerability finding → server → agent reachability graph
+├── package → vulnerability finding → MCP server reachability graph
 ├── Tool exposure: what tools are reachable through the vulnerable path
 ├── Credential exposure: what secrets are at risk
 ├── Risk score: CVSS + reach + AI context + KEV + EPSS + Scorecard

--- a/docs/archive/AUDIT.md
+++ b/docs/archive/AUDIT.md
@@ -40,7 +40,7 @@ OpenSSF Scorecard (enrichment)       maintainer quality signal
 ```
 
 **CVSS parsing**: v3.1 and v4.0 implemented from spec, not from a library.
-**Blast radius**: CVE → packages → servers → agents → tools → credentials → risk score.
+**Blast radius**: package → vulnerability finding → servers → agents → tools → credentials → risk score.
 **Risk score formula**: base_severity + agent_reach + cred_exposure + tool_count + AI_boost + KEV_boost + EPSS_boost + scorecard_boost (all configurable via env vars).
 **Compliance tagging**: 14 frameworks on every blast radius — OWASP LLM, OWASP MCP, OWASP Agentic, ATLAS, NIST AI RMF, EU AI Act, NIST CSF, ISO 27001, SOC 2, CIS Controls, CMMC.
 **Toxic combos**: 8 patterns — CRED_BLAST, KEV_WITH_CREDS, EXECUTE_EXPLOIT, MULTI_AGENT_CVE, TRANSITIVE_CRITICAL, LATERAL_CHAIN, CACHE_POISON, CROSS_AGENT_POISON.
@@ -266,7 +266,7 @@ Enrichment (optional, --enrich flag)
         |
         v
 Blast Radius Analysis (agent-bom's core intelligence)
-├── CVE → package → server → agent reachability graph
+├── package → vulnerability finding → server → agent reachability graph
 ├── Tool exposure: what tools are reachable through the vulnerable path
 ├── Credential exposure: what secrets are at risk
 ├── Risk score: CVSS + reach + AI context + KEV + EPSS + Scorecard

--- a/docs/archive/STRATEGIC_AUDIT_2026_03.md
+++ b/docs/archive/STRATEGIC_AUDIT_2026_03.md
@@ -4,7 +4,7 @@
 
 ## Table of Contents
 
-1. [Competitive Landscape](#1-competitive-landscape)
+1. [Market Landscape](#1-market-landscape)
 2. [agent-bom Capability Audit](#2-agent-bom-capability-audit)
 3. [Differentiators & Uniqueness](#3-differentiators--uniqueness)
 4. [Snowflake Coco / Cortex Code Integration](#4-snowflake-coco--cortex-code-integration)
@@ -14,20 +14,17 @@
 
 ---
 
-## 1. Competitive Landscape
+## 1. Market Landscape
 
-### Direct Competitors (AI Agent Security Scanners)
+### Adjacent AI Agent Security Scanners
 
-| Tool | Vendor | GitHub Stars | Focus | Key Capabilities | Gaps vs agent-bom |
-|------|--------|-------------|-------|-------------------|-------------------|
-| **agent-scan** | Snyk | ~1.7k | MCP + Skills | 15+ risk types, auto-discovery (Claude/Cursor/Gemini/Windsurf), prompt injection, tool poisoning, tool shadowing, toxic flows, rug pull, background monitoring, Snyk Evo integration | No CVE scanning, no blast radius, no SBOM, no runtime proxy, no cloud scanning, no compliance mapping, no enrichment pipeline |
-| **skill-scanner** | Cisco AI Defense | ~900 | Skill files | Static analysis of SKILL.md files, comprehensive but CLI-only, requires Python 3.10+ and 3 API keys | No MCP scanning, no runtime, no CVE/vuln scanning, no cloud, heavy setup |
-| **SkillCheck** | Repello AI | N/A (SaaS) | Browser-based | Prompt injection, policy violations, payload delivery, severity score /100, zero setup | Browser-only, no CLI, no MCP scanning, no CVE, no runtime |
-| **mcp-scan** | Invariant Labs | ~3k+ | MCP servers | Tool poisoning, prompt injection, cross-origin escalation, WhitelistGuard | No CVE scanning, no skills, no cloud, no compliance |
-| **MCP Scan** | Enkrypt AI | N/A (SaaS) | MCP assessment | Security assessment of MCP servers | Limited scope |
-| **GuardFive** | GuardFive | N/A (SaaS) | MCP security | Tool poisoning, credential theft detection, enterprise features | SaaS-only, limited public info |
-| **Proximity** | Open source | ~500 | MCP scanning | Open-source MCP security scanner | Narrower scope |
-| **mcp-guard** | SaravanaGuhan | <100 | MCP servers | Comprehensive MCP server scanning | Small project, limited maintenance |
+| Category | Focus | Typical Capabilities | Gaps vs agent-bom |
+|----------|-------|----------------------|-------------------|
+| MCP and skill behavior scanners | MCP servers + instruction files | Prompt injection, tool poisoning, tool shadowing, toxic flows, background monitoring | No CVE scanning, no blast radius, no SBOM, no runtime proxy, no cloud scanning, no compliance mapping, no enrichment pipeline |
+| Skill-file static analyzers | SKILL.md and local instruction files | Static policy checks, provenance checks, suspicious instruction detection | No MCP scanning, no runtime, no CVE/vuln scanning, no cloud, heavy setup |
+| Browser-based agent security tools | Prompt and policy assessment | Prompt injection, policy violations, payload delivery, severity score /100 | Browser-only, no CLI, no MCP scanning, no CVE, no runtime |
+| MCP server assessment tools | MCP tool schemas and server config | Tool poisoning, prompt injection, cross-origin escalation, allow/deny policies | No CVE scanning, no skills, no cloud, no compliance |
+| Open-source MCP scanners | MCP servers | MCP server configuration and tool-surface checks | Narrower scope |
 
 ### Indirect Competitors
 
@@ -40,12 +37,12 @@
 
 ### Key Insight
 
-**No single competitor covers what agent-bom covers.** The market is fragmented:
+**The market is fragmented across adjacent categories.**
 - Agent security scanners: skill/MCP *behavioral* scanning (prompt injection, poisoning) — no CVEs
 - External CVE scanner CLIs: CVE scanning — no AI agent awareness
 - Cloud posture platforms: cloud posture — no MCP, no agent runtime
 
-**agent-bom is the only tool that combines:** CVE scanning + AI agent discovery + MCP tool security + blast radius + runtime proxy + compliance mapping + cloud scanning + enrichment pipeline + SBOM + VEX + policy engine. This is the core differentiator.
+**agent-bom combines:** CVE scanning + AI agent discovery + MCP tool security + blast radius + runtime proxy + compliance mapping + cloud scanning + enrichment pipeline + SBOM + VEX + policy engine. This is the core differentiator.
 
 ---
 
@@ -236,7 +233,7 @@ Claude Desktop, Claude Code, Cursor, Windsurf, Cline, Continue, Zed, VS Code Cop
 | SBOM/VEX | ✅ | ❌ | ❌ | ❌ | ✅ (SBOM) | ✅ (SBOM) |
 | MCP server (AI tool) | ✅ (23) | ❌ | ❌ | ❌ | ❌ | ❌ |
 | GPU/AI compute | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| SIEM integration | ✅ | Via Snyk | ❌ | ❌ | ❌ | ❌ |
+| SIEM integration | ✅ | Available in some adjacent tools | ❌ | ❌ | ❌ | ❌ |
 | Browser extensions | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | OTel trace analysis | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Policy engine | ✅ (17) | ❌ | ❌ | ❌ | ❌ | ✅ (Rego) |
@@ -400,14 +397,14 @@ OpenAI launched **Frontier** on Feb 5, 2026 — an enterprise platform for build
 | **P3** | RAG poisoning detection in vector stores | Medium | Extend vector DB scanning |
 | **P3** | MCP OAuth 2.1 auth verification | Medium | As MCP auth standardizes |
 
-### 6.2 Competitive Responses Needed
+### 6.2 Adjacent Capability Responses Needed
 
-| Competitor Move | Our Response |
-|-----------------|-------------|
-| Snyk agent-scan: background monitoring + Snyk Evo dashboard | agent-bom watch + SIEM push already covers this; consider adding `--daemon` mode |
-| Cisco skill-scanner: deep static analysis | Our SKILL.md scanning already does 17 patterns + typosquat; add Cisco's API-key-gated patterns if publicly documented |
-| Repello SkillCheck: zero-setup browser scanner | Consider a hosted web UI for quick scans (lower priority — our CLI/MCP/Action coverage is stronger) |
-| mcp-scan: WhitelistGuard | Our policy engine can do this — document `allowed_tools` policy condition |
+| Adjacent market move | agent-bom response |
+|----------------------|--------------------|
+| Background monitoring + hosted dashboard | `agent-bom watch` + SIEM push already covers this; consider adding `--daemon` mode |
+| Deeper static analysis for skill files | SKILL.md scanning already covers 17 patterns + typosquat; add more publicly documented patterns as they mature |
+| Zero-setup browser scanner | Consider a hosted web UI for quick scans (lower priority — CLI/MCP/Action coverage is stronger) |
+| Allow-list guardrails for MCP tools | The policy engine can do this — document the `allowed_tools` policy condition |
 
 ### 6.3 Scalability Assessment
 
@@ -469,4 +466,4 @@ Potentially patentable novel methods:
 4. **Engage Renxu** — he can champion internal adoption at Snowflake
 5. **Position clearly**: "agent-bom is the only security scanner that covers the full AI agent stack — from CVEs to MCP tools to runtime enforcement to compliance"
 
-The competitive landscape is fragmented. Snyk has brand recognition but narrow scope. Cisco has static analysis but no runtime. Nobody else has the depth we have. The window to establish agent-bom as the definitive AI infrastructure security scanner is now.
+The market landscape is fragmented across package scanning, MCP assessment, skill-file auditing, runtime control, and cloud posture. The window to establish agent-bom as a comprehensive AI infrastructure security scanner is now.

--- a/docs/images/blast-radius-dark.svg
+++ b/docs/images/blast-radius-dark.svg
@@ -27,7 +27,7 @@
 
   <!-- Title -->
   <text x="480" y="30" text-anchor="middle" class="title">Attack-path drilldown from one vulnerable package</text>
-  <text x="480" y="46" text-anchor="middle" class="subtitle">The graph follows package → vulnerability → server → agent → credentials → tools so remediation can be fix-first, not guess-first</text>
+  <text x="480" y="46" text-anchor="middle" class="subtitle">The graph follows package → vulnerability → MCP server (tools + credential env names) → connected agents so remediation can be fix-first, not guess-first</text>
 
   <!-- ═══════════════════════════════════════════════════════════════════════ -->
   <!-- EDGES (drawn first so nodes sit on top)                                -->

--- a/docs/images/blast-radius-light.svg
+++ b/docs/images/blast-radius-light.svg
@@ -27,7 +27,7 @@
 
   <!-- Title -->
   <text x="480" y="30" text-anchor="middle" class="title">Attack-path drilldown from one vulnerable package</text>
-  <text x="480" y="46" text-anchor="middle" class="subtitle">The graph follows package → vulnerability → server → agent → credentials → tools so remediation can be fix-first, not guess-first</text>
+  <text x="480" y="46" text-anchor="middle" class="subtitle">The graph follows package → vulnerability → MCP server (tools + credential env names) → connected agents so remediation can be fix-first, not guess-first</text>
 
   <!-- EDGES -->
   <line x1="148" y1="218" x2="186" y2="218" stroke="#ef4444" stroke-width="2" opacity="0.4" marker-end="url(#arrow-red)"/>

--- a/site-docs/features/blast-radius.md
+++ b/site-docs/features/blast-radius.md
@@ -5,7 +5,7 @@ Maps the full impact chain from a CVE to the business assets at risk.
 ## How it works
 
 ```
-CVE → Package → MCP Server → Agent → Credentials + Tools
+Package → Vulnerability Finding → MCP Server → Agent → Credentials + Tools
 ```
 
 For each vulnerability found, agent-bom traces:

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -37,7 +37,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 |---|---|
 | **Discovery** | Auto-detect 29 first-class MCP client types plus dynamic/project surfaces |
 | **CVE scanning** | OSV + NVD CVSS v4 + EPSS + CISA KEV + GHSA |
-| **Blast radius** | Map CVE impact: package → server → agent → credentials → tools |
+| **Blast radius** | Map CVE impact: package → vulnerability finding → MCP server (tools + credential env names) → connected agents |
 | **Registry** | 427+ MCP server security metadata entries |
 | **Compliance** | OWASP LLM/Agentic/MCP Top 10, MITRE ATLAS, EU AI Act, NIST AI RMF, CIS |
 | **Runtime proxy** | Policy enforcement, credential leak detection, audit logging |

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -7,17 +7,17 @@ Scan agents, MCP, packages, containers, Kubernetes, cloud, and GPU workloads wit
 ## What it does
 
 ```
-CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
-  └─ better-sqlite3@9.0.0  (npm)
-       └─ sqlite-mcp  (MCP Server · unverified)
-            ├─ Cursor IDE  (Agent · 4 servers · 12 tools)
-            ├─ ANTHROPIC_KEY, DB_URL, AWS_SECRET  (Credentials exposed)
-            └─ query_db, read_file, write_file  (Tools at risk)
+better-sqlite3@9.0.0  (npm package)
+  ├─ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
+  └─ sqlite-mcp  (MCP Server · unverified)
+       ├─ Cursor IDE  (Agent · 4 servers · 12 tools)
+       ├─ ANTHROPIC_KEY, DB_URL, AWS_SECRET  (Credential env names visible)
+       └─ query_db, read_file, write_file  (Tools at risk)
 
  Fix: upgrade better-sqlite3 → 11.7.0
 ```
 
-Package risk is only the start. agent-bom maps what it can reach across MCP servers, agents, credentials, tools, and runtime context.
+Package risk is only the start. agent-bom maps the reachable path from a vulnerable package instance to MCP servers, agents, credential names, tools, and runtime context.
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

- Updates README, PyPI README, and site landing-page blast-radius examples so they start from the vulnerable package instance.
- Keeps the vulnerability finding attached to the package before showing reachable MCP server, agent, credential-name, and tool context.
- Aligns core docs and site docs on `package -> vulnerability finding -> server -> agent -> credentials -> tools` wording.
- Rewrites archived competitive-positioning language into neutral market-category wording.

## Why

The previous example started with the CVE and then nested the package under it. That could imply the CVE owns the package, while Agent-Bom models the discovered package instance and attaches vulnerability findings to it before expanding reachability.

## Validation

- `git diff --check`
- `rg -n "CVE -> package|CVE → package|CVE-2025-1234\\s+\\(" README.md PYPI_README.md site-docs docs --glob '!node_modules'`
- `rg -n -i "\\b(wiz|orca|crowdstrike)\\b|wiz-class|wiz-shaped" README.md PYPI_README.md site-docs docs --glob '!node_modules'` returned no matches
- Commit hooks passed
