### PR TITLE
fix(snowflake): pin native app release artifacts

### DIFF
--- a/.github/workflows/release-snowflake.yml
+++ b/.github/workflows/release-snowflake.yml
@@ -38,9 +38,11 @@ jobs:
     outputs:
       package_version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: actions/setup-python@v5
+      # actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
 
@@ -67,12 +69,22 @@ jobs:
           PY
 
       - name: Validate manifest and service specs
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
         run: |
           python - <<'PY'
           from pathlib import Path
           import yaml
+          import os
 
           root = Path("deploy/snowflake/native-app")
+          version = os.environ["PACKAGE_VERSION"]
+          documents = [root / "manifest.yml", *sorted((root / "service-specs").glob("*.yaml"))]
+          for path in documents:
+              text = path.read_text()
+              assert ":latest" not in text, f"{path} uses a mutable :latest image tag"
+              assert f":{version}" in text, f"{path} does not reference package image tag {version}"
+
           yaml.safe_load((root / "manifest.yml").read_text())
           for spec in sorted((root / "service-specs").glob("*.yaml")):
               data = yaml.safe_load(spec.read_text())
@@ -85,7 +97,8 @@ jobs:
           tar -czf "dist/agent-bom-snowflake-${{ steps.version.outputs.version }}.tgz" \
             -C deploy/snowflake/native-app .
 
-      - uses: actions/upload-artifact@v4
+      # actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: agent-bom-snowflake-${{ steps.version.outputs.version }}
           path: dist/agent-bom-snowflake-${{ steps.version.outputs.version }}.tgz
@@ -99,7 +112,8 @@ jobs:
     if: ${{ inputs.dry_run == false }}
     environment: snowflake-marketplace
     steps:
-      - uses: actions/download-artifact@v4
+      # actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: agent-bom-snowflake-${{ needs.package.outputs.package_version }}
           path: dist

--- a/deploy/snowflake/native-app/manifest.yml
+++ b/deploy/snowflake/native-app/manifest.yml
@@ -15,10 +15,10 @@ artifacts:
     endpoint: ui
   container_services:
     images:
-      - /db/schema/agent_bom_repo/agent-bom:latest
-      - /db/schema/agent_bom_repo/agent-bom-ui:latest
-      - /db/schema/agent_bom_repo/agent-bom-scanner:latest
-      - /db/schema/agent_bom_repo/agent-bom-mcp-runtime:latest
+      - /db/schema/agent_bom_repo/agent-bom:v0_86_0
+      - /db/schema/agent_bom_repo/agent-bom-ui:v0_86_0
+      - /db/schema/agent_bom_repo/agent-bom-scanner:v0_86_0
+      - /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_86_0
   service_roles:
     - name: api
       comment: >-

--- a/deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml
+++ b/deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom-mcp-runtime
-      image: /db/schema/agent_bom_repo/agent-bom-mcp-runtime:latest
+      image: /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_86_0
       env:
         SNOWFLAKE_ACCOUNT: "{{ snowflake_account }}"
         SNOWFLAKE_DATABASE: "{{ database }}"

--- a/deploy/snowflake/native-app/service-specs/scanner-service.yaml
+++ b/deploy/snowflake/native-app/service-specs/scanner-service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom-scanner
-      image: /db/schema/agent_bom_repo/agent-bom-scanner:latest
+      image: /db/schema/agent_bom_repo/agent-bom-scanner:v0_86_0
       env:
         SNOWFLAKE_ACCOUNT: "{{ snowflake_account }}"
         SNOWFLAKE_DATABASE: "{{ database }}"

--- a/tests/test_snowflake_native_app.py
+++ b/tests/test_snowflake_native_app.py
@@ -23,6 +23,7 @@ SETUP_SQL_PATH = NATIVE_APP_DIR / "scripts" / "setup.sql"
 DCM_DIR = NATIVE_APP_DIR / "dcm"
 SERVICE_SPECS_DIR = NATIVE_APP_DIR / "service-specs"
 RELEASE_WORKFLOW_PATH = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release-snowflake.yml"
+SNOWFLAKE_PACKAGE_IMAGE_TAG = "v0_86_0"
 
 
 @pytest.fixture(scope="module")
@@ -165,8 +166,20 @@ def test_manifest_declares_phase4_services_default_off(manifest: dict):
     assert config["enable_mcp_runtime_service"]["default"] is False
 
     images = set(manifest.get("artifacts", {}).get("container_services", {}).get("images", []))
-    assert "/db/schema/agent_bom_repo/agent-bom-scanner:latest" in images
-    assert "/db/schema/agent_bom_repo/agent-bom-mcp-runtime:latest" in images
+    assert f"/db/schema/agent_bom_repo/agent-bom-scanner:{SNOWFLAKE_PACKAGE_IMAGE_TAG}" in images
+    assert f"/db/schema/agent_bom_repo/agent-bom-mcp-runtime:{SNOWFLAKE_PACKAGE_IMAGE_TAG}" in images
+
+
+def test_native_app_container_images_are_release_pinned(manifest: dict, service_specs: dict[str, dict]):
+    image_refs = list(manifest.get("artifacts", {}).get("container_services", {}).get("images", []))
+    for spec in service_specs.values():
+        image_refs.extend(
+            container["image"] for container in spec.get("spec", {}).get("containers", []) if isinstance(container.get("image"), str)
+        )
+
+    assert image_refs
+    assert all(":latest" not in image for image in image_refs)
+    assert all(image.endswith(f":{SNOWFLAKE_PACKAGE_IMAGE_TAG}") for image in image_refs)
 
 
 def test_phase4_service_specs_are_packaged_and_internal(service_specs: dict[str, dict]):
@@ -266,3 +279,17 @@ def test_release_workflow_derives_version_from_pyproject_when_unset():
     assert 'version = "v" + str(project["version"]).replace(".", "_")' in workflow
     assert "package_version: ${{ steps.version.outputs.version }}" in workflow
     assert "inputs.version" not in workflow.split("Build Snowflake Native App artifact", 1)[1]
+
+
+def test_release_workflow_pins_actions_and_rejects_latest_native_app_images():
+    workflow = RELEASE_WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "actions/checkout@v4" in workflow
+    assert "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" in workflow
+    assert "actions/setup-python@v5" in workflow
+    assert "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065" in workflow
+    assert "actions/upload-artifact@v4" in workflow
+    assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" in workflow
+    assert "actions/download-artifact@v4" in workflow
+    assert "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093" in workflow
+    assert 'assert ":latest" not in text' in workflow
+    assert 'assert f":{version}" in text' in workflow


### PR DESCRIPTION
## Summary

- Pins Snowflake Native App container image references to the current package image tag instead of `:latest`.
- Pins the Snowflake release workflow actions to immutable commit SHAs while keeping readable action/version comments.
- Adds release-package validation that rejects mutable `:latest` image tags and requires the package image tag in the manifest and service specs.
- Adds static contract tests for pinned Native App images and pinned workflow actions.

## Why

The dry-run package should be reproducible for release review. Mutable action refs and `:latest` container image references make it harder to prove what artifact was validated.

## Validation

- `PYTHONPATH=src uv run pytest tests/test_snowflake_native_app.py -q`
- YAML parse check for `.github/workflows/release-snowflake.yml`, `manifest.yml`, and service specs
- `uv run ruff check tests/test_snowflake_native_app.py`
- `git diff --check`
- Commit hooks passed
