### PR TITLE
fix(scanner): close SBOM Maven and scan redaction gaps

### DIFF
--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -457,6 +457,25 @@ def _job_for_request(request: Request, job_id: str) -> ScanJob:
     return job
 
 
+def _redact_scan_result_for_response(result: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Drop replay-only fields from top-level scan findings before API return."""
+    if not isinstance(result, dict):
+        return result
+    findings = result.get("findings")
+    if not isinstance(findings, list):
+        return result
+    redacted = dict(result)
+    redacted["findings"] = redact_for_persistence(findings, EvidenceTier.SAFE_TO_STORE)
+    return redacted
+
+
+def _job_response_payload(job: ScanJob) -> ScanJob:
+    redacted_result = _redact_scan_result_for_response(job.result)
+    if redacted_result is job.result:
+        return job
+    return job.model_copy(update={"result": redacted_result})
+
+
 def enqueue_scan_job(
     *,
     tenant_id: str,
@@ -516,7 +535,7 @@ async def create_scan(request: Request, body: ScanRequest) -> ScanJob:
 @router.get("/v1/scan/{job_id}", response_model=ScanJob, tags=["scan"])
 async def get_scan(request: Request, job_id: str) -> ScanJob:
     """Fetch scan status and full results."""
-    return _job_for_request(request, job_id)
+    return _job_response_payload(_job_for_request(request, job_id))
 
 
 @router.get("/v1/scan/{job_id}/status", tags=["scan"])

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -380,11 +380,30 @@ class Package:
     @property
     def lookup_names(self) -> list[str]:
         """Candidate package names for vulnerability matching."""
-        names = [self.name]
+        names: list[str] = []
+
+        def add_name(candidate: str | None) -> None:
+            candidate = (candidate or "").strip()
+            if not candidate:
+                return
+            norm_candidate = normalize_package_name(candidate, self.ecosystem)
+            if all(normalize_package_name(existing, self.ecosystem) != norm_candidate for existing in names):
+                names.append(candidate)
+
+        add_name(self.name)
+        if self.ecosystem.lower() == "maven" and self.purl:
+            try:
+                from packageurl import PackageURL
+
+                parsed = PackageURL.from_string(self.purl)
+            except Exception:
+                parsed = None
+            if parsed is not None and (parsed.type or "").lower() == "maven" and parsed.namespace and parsed.name:
+                add_name(f"{parsed.namespace}:{parsed.name}")
         if self.source_package:
             source_name = self.source_package.strip()
             if source_name and normalize_package_name(source_name, self.ecosystem) != normalize_package_name(self.name, self.ecosystem):
-                names.append(source_name)
+                add_name(source_name)
         return names
 
     @property

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -376,6 +376,46 @@ def test_get_scan_status_omits_large_result_payload():
     assert len(status.content) < len(full.content) / 100
 
 
+def test_get_scan_redacts_result_findings_replay_only_fields():
+    """Full scan job reads must not expose replay-only text in result.findings."""
+    client, store = _fresh_client()
+    job = ScanJob(
+        job_id="job-finding-redaction",
+        tenant_id="default",
+        status=JobStatus.DONE,
+        created_at="2026-01-01T00:00:00Z",
+        completed_at="2026-01-01T00:00:13Z",
+        request=ScanRequest(),
+        result={
+            "findings": [
+                {
+                    "id": "finding-1",
+                    "title": "Unsafe package",
+                    "description": "Copied workspace details",
+                    "remediation_guidance": "Patch using local runbook",
+                    "package": "pillow",
+                    "package_version": "10.0.0",
+                    "severity": "high",
+                }
+            ],
+        },
+    )
+    store.put(job)
+
+    response = client.get("/v1/scan/job-finding-redaction")
+
+    assert response.status_code == 200
+    finding = response.json()["result"]["findings"][0]
+    assert finding == {
+        "id": "finding-1",
+        "title": "Unsafe package",
+        "package": "pillow",
+        "package_version": "10.0.0",
+        "severity": "high",
+    }
+    assert store.get("job-finding-redaction").result["findings"][0]["description"] == "Copied workspace details"
+
+
 # ---------------------------------------------------------------------------
 # 8. DELETE scan
 # ---------------------------------------------------------------------------

--- a/tests/test_local_db_scan.py
+++ b/tests/test_local_db_scan.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agent_bom.models import Package, Severity
+from agent_bom.sbom import parse_cyclonedx
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -202,6 +203,55 @@ def test_scan_packages_local_db_finds_vulns(tmp_path):
     assert count == 1
     assert len(pkg.vulnerabilities) == 1
     assert pkg.vulnerabilities[0].id == "CVE-2024-2222"
+
+
+def test_cyclonedx_maven_purl_matches_groupid_artifact_advisories(tmp_path):
+    """CycloneDX Maven purls should match local DB groupId:artifactId advisories."""
+    from agent_bom.scanners import _scan_packages_local_db
+
+    packages = parse_cyclonedx(
+        {
+            "bomFormat": "CycloneDX",
+            "components": [
+                {
+                    "type": "library",
+                    "name": "log4j-core",
+                    "version": "2.14.1",
+                    "purl": "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
+                }
+            ],
+        }
+    )
+    pkg = packages[0]
+    db_file = tmp_path / "scan.db"
+    db_file.write_text("placeholder", encoding="utf-8")
+    conn = MagicMock()
+    lv = _make_local_vuln("CVE-2021-44228", "critical", 10.0)
+    lookup_calls: list[tuple[str, str, str]] = []
+
+    def lookup_package_side_effect(_conn, ecosystem: str, name: str, version: str):
+        lookup_calls.append((ecosystem, name, version))
+        if (ecosystem, name, version) == ("maven", "org.apache.logging.log4j:log4j-core", "2.14.1"):
+            return [lv]
+        return []
+
+    def package_in_db_side_effect(_conn, ecosystem: str, name: str) -> bool:
+        return ecosystem == "maven" and name == "org.apache.logging.log4j:log4j-core"
+
+    with (
+        patch("agent_bom.db.schema.db_freshness_days", return_value=1),
+        patch("agent_bom.db.schema.DB_PATH", db_file),
+        patch("agent_bom.db.schema.open_existing_db_readonly", return_value=conn),
+        patch("agent_bom.db.lookup.package_in_db", side_effect=package_in_db_side_effect),
+        patch("agent_bom.db.lookup_package", side_effect=lookup_package_side_effect),
+    ):
+        count, covered = _scan_packages_local_db(packages)
+
+    assert pkg.lookup_names == ["log4j-core", "org.apache.logging.log4j:log4j-core"]
+    assert ("maven", "org.apache.logging.log4j:log4j-core", "2.14.1") in lookup_calls
+    assert count == 1
+    assert covered == {"maven:log4j-core@2.14.1"}
+    assert [v.id for v in pkg.vulnerabilities] == ["CVE-2021-44228"]
 
 
 def test_scan_packages_local_db_no_duplicates(tmp_path):


### PR DESCRIPTION
## Summary

- Adds Maven `namespace:artifact` lookup synthesis from package URLs so CycloneDX Maven SBOM components match the local OSV advisory cache.
- Redacts `/v1/scan/{job_id}` findings before returning persisted job results, matching the two-bucket safe-to-store policy used by `/v1/findings`.
- Adds regression coverage for both scanner audit P1s.

## Why

The scanner audit found two release-relevant gaps: Maven SBOM components lost `groupId` during vulnerability matching, and the async scan-job read path returned Tier-B finding fields that should not be persisted or exposed by default.

## Validation

- `uv run pytest tests/test_local_db_scan.py tests/test_api_endpoints.py tests/test_scanner_ecosystems.py -q`
- `uv run ruff check src/agent_bom/models.py src/agent_bom/api/routes/scan.py tests/test_local_db_scan.py tests/test_api_endpoints.py`
- `git diff --check origin/main...HEAD`
- signed commit verified with `git log -1 --show-signature`
