### PR TITLE
test(snowflake): allow pinned action updates

### DIFF
--- a/.github/workflows/release-snowflake.yml
+++ b/.github/workflows/release-snowflake.yml
@@ -38,10 +38,8 @@ jobs:
     outputs:
       package_version: ${{ steps.version.outputs.version }}
     steps:
-      # actions/checkout@v4
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      # actions/setup-python@v5
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
@@ -97,7 +95,6 @@ jobs:
           tar -czf "dist/agent-bom-snowflake-${{ steps.version.outputs.version }}.tgz" \
             -C deploy/snowflake/native-app .
 
-      # actions/upload-artifact@v4
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: agent-bom-snowflake-${{ steps.version.outputs.version }}
@@ -112,7 +109,6 @@ jobs:
     if: ${{ inputs.dry_run == false }}
     environment: snowflake-marketplace
     steps:
-      # actions/download-artifact@v4
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: agent-bom-snowflake-${{ needs.package.outputs.package_version }}

--- a/tests/test_snowflake_native_app.py
+++ b/tests/test_snowflake_native_app.py
@@ -12,6 +12,7 @@ PR can't quietly weaken the read-only contract.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -283,13 +284,20 @@ def test_release_workflow_derives_version_from_pyproject_when_unset():
 
 def test_release_workflow_pins_actions_and_rejects_latest_native_app_images():
     workflow = RELEASE_WORKFLOW_PATH.read_text(encoding="utf-8")
-    assert "actions/checkout@v4" in workflow
-    assert "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" in workflow
-    assert "actions/setup-python@v5" in workflow
-    assert "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065" in workflow
-    assert "actions/upload-artifact@v4" in workflow
-    assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" in workflow
-    assert "actions/download-artifact@v4" in workflow
-    assert "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093" in workflow
+    action_refs = dict(
+        re.findall(
+            r"^\s*-\s*uses:\s*(actions/(?:checkout|setup-python|upload-artifact|download-artifact))@([0-9a-f]{40})\s*$",
+            workflow,
+            flags=re.MULTILINE,
+        )
+    )
+    assert action_refs.keys() == {
+        "actions/checkout",
+        "actions/setup-python",
+        "actions/upload-artifact",
+        "actions/download-artifact",
+    }
+    assert not re.search(r"^\s*-\s*uses:\s*actions/[^@\s]+@(?:v\d+|latest)\s*$", workflow, flags=re.MULTILINE)
+    assert not re.search(r"#\s*actions/[^@\s]+@v\d+", workflow)
     assert 'assert ":latest" not in text' in workflow
     assert 'assert f":{version}" in text' in workflow


### PR DESCRIPTION
Summary
- Keeps the Snowflake Native App release workflow pinned to full action SHAs.
- Removes stale major-version comments that made Dependabot action bumps fail the pinning contract.
- Updates the test to reject mutable action refs generically instead of hard-coding one historical SHA forever.

Why
- Unblocks the pending GitHub Actions dependency bumps while preserving the security requirement that release-lane actions are SHA-pinned.

Validation
- uv run pytest tests/test_snowflake_native_app.py::test_release_workflow_pins_actions_and_rejects_latest_native_app_images -q
- ruff check tests/test_snowflake_native_app.py
- git diff --check