### PR TITLE
Runtime sandbox isolation defaults to opt-out

### DIFF
--- a/src/agent_bom/cli/_runtime.py
+++ b/src/agent_bom/cli/_runtime.py
@@ -67,7 +67,7 @@ from agent_bom.cli._common import OPTIONAL_PORT_RANGE, PORT_RANGE
 )
 @click.option(
     "--isolate/--no-isolate",
-    default=False,
+    default=True,
     envvar="AGENT_BOM_MCP_SANDBOX",
     help="Run the stdio MCP server through a hardened Docker/Podman container.",
 )

--- a/src/agent_bom/cli/run.py
+++ b/src/agent_bom/cli/run.py
@@ -159,7 +159,7 @@ def _resolve_server_command(server: str) -> list[str]:
 )
 @click.option(
     "--isolate/--no-isolate",
-    default=False,
+    default=True,
     envvar="AGENT_BOM_MCP_SANDBOX",
     help="Run the MCP server through a hardened Docker/Podman container.",
 )

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -209,8 +209,8 @@ def sandbox_posture_warning(sandbox_evidence: Mapping[str, object]) -> str | Non
         return None
     return (
         "agent-bom proxy warning: sandbox isolation is disabled; the MCP server "
-        "runs as the current host user. Set AGENT_BOM_MCP_SANDBOX=1 or pass "
-        "--isolate to run the server in a restricted container."
+        "runs as the current host user. Remove --no-isolate or set "
+        "AGENT_BOM_MCP_SANDBOX=1 to run the server in a restricted container."
     )
 
 

--- a/src/agent_bom/proxy_sandbox.py
+++ b/src/agent_bom/proxy_sandbox.py
@@ -17,6 +17,8 @@ _DEFAULT_SANDBOX_MEMORY = "512m"
 _DEFAULT_SANDBOX_PIDS_LIMIT = 256
 _DEFAULT_SANDBOX_TMPFS_SIZE = "64m"
 _DEFAULT_SANDBOX_TIMEOUT_SECONDS = 300
+_SANDBOX_ENABLE_VALUES = {"1", "true", "yes", "on", "container", "isolate"}
+_SANDBOX_DISABLE_VALUES = {"0", "false", "no", "off", "disabled", "none"}
 
 _SENSITIVE_EXACT_MOUNT_SOURCES = (Path("/"),)
 
@@ -61,7 +63,7 @@ class SandboxMount:
 class SandboxConfig:
     """Process isolation posture for a proxied MCP server."""
 
-    enabled: bool = False
+    enabled: bool = True
     runtime: SandboxRuntime = "auto"
     image: str | None = None
     image_pin_policy: SandboxImagePinPolicy = "warn"
@@ -168,7 +170,7 @@ def sandbox_config_from_env(
     """Build sandbox config from CLI values and AGENT_BOM_MCP_SANDBOX_* env vars."""
     if enabled is None:
         env_enabled = os.environ.get("AGENT_BOM_MCP_SANDBOX")
-        enabled = bool(env_enabled and env_enabled.strip().lower() in {"1", "true", "yes", "on", "container"})
+        enabled = _sandbox_enabled_from_env(env_enabled)
     else:
         enabled = bool(enabled)
     requested_runtime = (runtime or os.environ.get("AGENT_BOM_MCP_SANDBOX_RUNTIME") or "auto").strip().lower()
@@ -211,6 +213,17 @@ def sandbox_config_from_env(
         tmpfs_size=requested_tmpfs_size,
         timeout_seconds=requested_timeout,
     )
+
+
+def _sandbox_enabled_from_env(value: str | None) -> bool:
+    if value is None:
+        return True
+    normalized = value.strip().lower()
+    if normalized in _SANDBOX_DISABLE_VALUES:
+        return False
+    if normalized in _SANDBOX_ENABLE_VALUES:
+        return True
+    return bool(normalized)
 
 
 def resolve_container_runtime(runtime: SandboxRuntime) -> str:

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -194,6 +194,20 @@ def test_run_passes_sandbox_config_to_run_proxy():
     mock_asyncio_run.assert_called_once()
 
 
+def test_run_no_isolate_opts_out():
+    runner = CliRunner()
+
+    with (
+        patch("agent_bom.cli.run.asyncio.run") as mock_asyncio_run,
+        patch("agent_bom.project_config.load_project_config", return_value=None),
+    ):
+        mock_asyncio_run.side_effect = _consume_coroutine_and_return()
+        result = runner.invoke(run_cmd, ["uvx/mcp-server-git", "--quiet", "--no-isolate"])
+
+    assert result.exit_code == 0
+    mock_asyncio_run.assert_called_once()
+
+
 def test_run_command_not_found_handled(tmp_path):
     """When asyncio.run raises FileNotFoundError the error surfaces cleanly."""
     runner = CliRunner()

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -47,6 +47,30 @@ def test_proxy_cmd_runs_proxy(tmp_path):
         assert result.exit_code == 0
 
 
+def test_proxy_cmd_sandbox_is_enabled_by_default():
+    runner = CliRunner()
+    with (
+        patch("agent_bom.proxy.run_proxy", new_callable=AsyncMock, return_value=0) as mock_run,
+        patch("agent_bom.project_config.load_project_config", return_value=None),
+    ):
+        result = runner.invoke(proxy_cmd, ["--", "echo", "hello"])
+
+    assert result.exit_code == 0
+    assert mock_run.await_args.kwargs["sandbox_config"].enabled is True
+
+
+def test_proxy_cmd_no_isolate_opts_out():
+    runner = CliRunner()
+    with (
+        patch("agent_bom.proxy.run_proxy", new_callable=AsyncMock, return_value=0) as mock_run,
+        patch("agent_bom.project_config.load_project_config", return_value=None),
+    ):
+        result = runner.invoke(proxy_cmd, ["--no-isolate", "--", "echo", "hello"])
+
+    assert result.exit_code == 0
+    assert mock_run.await_args.kwargs["sandbox_config"].enabled is False
+
+
 def test_proxy_cmd_invalid_metrics_port_is_usage_error():
     runner = CliRunner()
     result = runner.invoke(proxy_cmd, ["--metrics-port", "99999", "--", "echo", "hello"])

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -193,7 +193,7 @@ def test_sandbox_posture_warning_is_visible_when_disabled():
     assert warning is not None
     assert "sandbox isolation is disabled" in warning
     assert "AGENT_BOM_MCP_SANDBOX=1" in warning
-    assert "--isolate" in warning
+    assert "--no-isolate" in warning
     assert "--sandbox" not in warning
     assert sandbox_posture_warning({"enabled": True}) is None
 

--- a/tests/test_proxy_sandbox.py
+++ b/tests/test_proxy_sandbox.py
@@ -92,6 +92,23 @@ def test_sandbox_config_from_env_parses_operator_values(monkeypatch, tmp_path):
     assert config.mounts[0].target == "/workspace"
 
 
+def test_sandbox_config_defaults_to_enabled(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_MCP_SANDBOX", raising=False)
+
+    config = sandbox_config_from_env()
+
+    assert config.enabled is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "disabled", "none"])
+def test_sandbox_config_env_false_values_opt_out(monkeypatch, value):
+    monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX", value)
+
+    config = sandbox_config_from_env()
+
+    assert config.enabled is False
+
+
 def test_sandbox_config_defaults_are_bounded_and_network_none(monkeypatch):
     monkeypatch.delenv("AGENT_BOM_MCP_SANDBOX_EGRESS", raising=False)
     monkeypatch.delenv("AGENT_BOM_MCP_SANDBOX_CPUS", raising=False)


### PR DESCRIPTION
## Summary
- Enables MCP proxy sandbox isolation by default for runtime entrypoints.
- Keeps explicit opt-out through `--no-isolate` and falsey `AGENT_BOM_MCP_SANDBOX` values.
- Updates the disabled-sandbox warning and adds regression tests for default and opt-out behavior.

## Changed files
- `src/agent_bom/proxy_sandbox.py`
- `src/agent_bom/cli/_runtime.py`
- `src/agent_bom/cli/run.py`
- `src/agent_bom/proxy.py`
- `tests/test_proxy_sandbox.py`
- `tests/test_cli_runtime.py`
- `tests/test_cli_run.py`
- `tests/test_proxy.py`

## Validation
- `pytest tests/test_proxy_sandbox.py tests/test_proxy.py::test_sandbox_posture_warning_is_visible_when_disabled tests/test_cli_runtime.py::test_proxy_cmd_sandbox_is_enabled_by_default tests/test_cli_runtime.py::test_proxy_cmd_no_isolate_opts_out tests/test_cli_runtime.py::test_proxy_cmd_passes_sandbox_config tests/test_cli_run.py::test_run_passes_sandbox_config_to_run_proxy tests/test_cli_run.py::test_run_no_isolate_opts_out`
- pre-commit hooks from `git commit`