### PR TITLE
Add gateway KEDA autoscaling support

### DIFF
--- a/deploy/helm/agent-bom/examples/README.md
+++ b/deploy/helm/agent-bom/examples/README.md
@@ -12,6 +12,7 @@ product split.
 | `focused-pilot` | `eks-mcp-pilot-values.yaml` | Narrow EKS pilot with control plane, scanner, and tightened ingress |
 | `byo-postgres` | `byo-postgres-values.yaml` | Overlay for operator-owned Postgres-compatible databases, including Snowflake Postgres candidates |
 | `production` | `eks-production-values.yaml` | Postgres-backed production EKS rollout with autoscaling, backup, and ExternalSecrets |
+| `keda-autoscaling` | `eks-production-values.yaml` + `eks-keda-values.yaml` + `gateway-upstreams.example.yaml` | Production overlay with KEDA-backed API and gateway autoscaling |
 | `eks-vanilla` | `eks-vanilla-values.yaml` | Postgres-backed production EKS rollout with ALB, IRSA, Kubernetes Secrets, and no service mesh / ESO / cert-manager requirement |
 | `mesh-hardening` | `eks-istio-kyverno-values.yaml` | Overlay for Istio mTLS/authz and Kyverno policy-controller packaging |
 | `snowflake-backend` | `eks-snowflake-values.yaml` | Overlay for Snowflake governance and selected store parity, not a claim of full control-plane replacement |

--- a/deploy/helm/agent-bom/examples/eks-keda-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-keda-values.yaml
@@ -1,4 +1,4 @@
-# EKS preset — KEDA-driven autoscaling on the control-plane API tier.
+# EKS preset — KEDA-driven autoscaling on API and gateway tiers.
 #
 # Use this preset when:
 #   * Scanner traffic is bursty (queue-depth / job-completion-rate spikes)
@@ -12,9 +12,12 @@
 # What this preset does
 # ─────────────────────
 #   * Replaces the default CPU-only HPA on `agent-bom-api` with a KEDA
-#     ScaledObject driven by two Prometheus queries:
+#     ScaledObject driven by Prometheus queries:
 #       - rate-limit pressure (saturation precursor)
 #       - API p99 latency (request-servicing health)
+#       - active scan jobs (queue depth)
+#   * Enables the same KEDA path for the gateway when `gateway.enabled=true`,
+#     driven by forwarded relay rate plus relay pressure signals.
 #   * Floors at 3 replicas so a single-AZ blip cannot drop us under quorum.
 #   * Caps at 12 replicas to keep Postgres connection-pool usage bounded.
 #   * 30s poll, 5min cooldown — fast enough for scan-burst patterns,
@@ -77,3 +80,39 @@ controlPlane:
                     value: 4
                     periodSeconds: 30
                 selectPolicy: Max
+
+gateway:
+  autoscaling:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 12
+    keda:
+      enabled: true
+      pollingIntervalSeconds: 30
+      cooldownSeconds: 300
+      prometheus:
+        serverAddress: http://prometheus.monitoring.svc:9090
+        relayRateThreshold: "25"
+        pressureRateThreshold: "1"
+      fallback:
+        failureThreshold: 3
+        replicas: 3
+      advanced:
+        horizontalPodAutoscalerConfig:
+          behavior:
+            scaleDown:
+              stabilizationWindowSeconds: 300
+              policies:
+                - type: Percent
+                  value: 25
+                  periodSeconds: 60
+            scaleUp:
+              stabilizationWindowSeconds: 30
+              policies:
+                - type: Percent
+                  value: 100
+                  periodSeconds: 30
+                - type: Pods
+                  value: 4
+                  periodSeconds: 30
+              selectPolicy: Max

--- a/deploy/helm/agent-bom/templates/gateway-hpa.yaml
+++ b/deploy/helm/agent-bom/templates/gateway-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.gateway.enabled .Values.gateway.autoscaling.enabled }}
+{{- if and .Values.gateway.enabled .Values.gateway.autoscaling.enabled (not .Values.gateway.autoscaling.keda.enabled) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/deploy/helm/agent-bom/templates/gateway-keda-scaledobject.yaml
+++ b/deploy/helm/agent-bom/templates/gateway-keda-scaledobject.yaml
@@ -1,0 +1,59 @@
+{{- /*
+KEDA-driven autoscaling for the gateway tier.
+
+When ``gateway.autoscaling.keda.enabled`` is true, KEDA's ScaledObject
+takes over from the static CPU/memory HPA. The default trigger set uses
+gateway relay metrics exported by ``agent_bom.api.metrics``:
+
+* Forwarded relay rate scales out on healthy traffic growth.
+* Pressure rate scales out before clients see sustained throttling or
+  upstream-circuit saturation.
+
+Operators can replace the defaults with ``gateway.autoscaling.keda.triggers``.
+*/ -}}
+{{- if and .Values.gateway.enabled .Values.gateway.autoscaling.enabled .Values.gateway.autoscaling.keda.enabled }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "agent-bom.name" . }}-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "agent-bom.name" . }}-gateway
+  minReplicaCount: {{ .Values.gateway.autoscaling.minReplicas }}
+  maxReplicaCount: {{ .Values.gateway.autoscaling.maxReplicas }}
+  pollingInterval: {{ .Values.gateway.autoscaling.keda.pollingIntervalSeconds | default 30 }}
+  cooldownPeriod: {{ .Values.gateway.autoscaling.keda.cooldownSeconds | default 300 }}
+  fallback:
+    failureThreshold: {{ .Values.gateway.autoscaling.keda.fallback.failureThreshold | default 3 }}
+    replicas: {{ .Values.gateway.autoscaling.keda.fallback.replicas | default .Values.gateway.autoscaling.minReplicas }}
+  {{- with .Values.gateway.autoscaling.keda.advanced }}
+  advanced:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  triggers:
+    {{- $defaults := .Values.gateway.autoscaling.keda }}
+    {{- if $defaults.triggers }}
+    {{- toYaml $defaults.triggers | nindent 4 }}
+    {{- else }}
+    - type: prometheus
+      metadata:
+        serverAddress: {{ required "gateway.keda.prometheus.serverAddress is required when gateway keda.enabled is true and triggers is empty" $defaults.prometheus.serverAddress | quote }}
+        metricName: agent_bom_gateway_forwarded_relays
+        threshold: {{ $defaults.prometheus.relayRateThreshold | default "25" | quote }}
+        query: |
+          sum(rate(agent_bom_gateway_relays_total{outcome="forwarded"}[1m]))
+    - type: prometheus
+      metadata:
+        serverAddress: {{ $defaults.prometheus.serverAddress | quote }}
+        metricName: agent_bom_gateway_pressure
+        threshold: {{ $defaults.prometheus.pressureRateThreshold | default "1" | quote }}
+        query: |
+          sum(rate(agent_bom_gateway_relays_total{outcome=~"rate_limited|upstream_timeout|upstream_error|circuit_open"}[1m]))
+    {{- end }}
+{{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -147,6 +147,22 @@ gateway:
     targetCPUUtilizationPercentage: 70
     targetMemoryUtilizationPercentage: null
     behavior: {}
+    # KEDA-driven autoscaling for gateway relay traffic. When enabled, the
+    # static CPU/memory HPA is suppressed and a ScaledObject is rendered
+    # instead. KEDA generates its own internal HPA.
+    keda:
+      enabled: false
+      pollingIntervalSeconds: 30
+      cooldownSeconds: 300
+      prometheus:
+        serverAddress: ""  # e.g. http://prometheus.monitoring.svc:9090
+        relayRateThreshold: "25"       # forwarded relay requests/sec
+        pressureRateThreshold: "1"     # rate-limited/error/circuit events/sec
+      triggers: []  # set non-empty to fully replace the default Prometheus triggers
+      fallback:
+        failureThreshold: 3
+        replicas: 2
+      advanced: {}
   image:
     repository: agentbom/agent-bom
     # tag defaults to Chart.AppVersion

--- a/src/agent_bom/deploy_profiles.py
+++ b/src/agent_bom/deploy_profiles.py
@@ -54,6 +54,16 @@ def helm_validation_profiles(repo_root: Path) -> list[HelmValidationProfile]:
             values_files=(examples / "eks-production-values.yaml",),
         ),
         HelmValidationProfile(
+            name="keda-autoscaling",
+            description="Production EKS defaults with KEDA-backed API and gateway autoscaling.",
+            values_files=(
+                examples / "eks-production-values.yaml",
+                examples / "eks-keda-values.yaml",
+            ),
+            set_arguments=("gateway.enabled=true",),
+            set_file_arguments=(("gateway.upstreamsYaml", examples / "gateway-upstreams.example.yaml"),),
+        ),
+        HelmValidationProfile(
             name="eks-vanilla",
             description="Production EKS profile using ALB, IRSA, Kubernetes Secrets, and RDS/Postgres.",
             values_files=(examples / "eks-vanilla-values.yaml",),

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -248,6 +248,7 @@ def test_helm_templates_exist():
         "controlplane-ui-hpa.yaml",
         "controlplane-ui-service.yaml",
         "gateway-hpa.yaml",
+        "gateway-keda-scaledobject.yaml",
         "gateway-pdb.yaml",
         "sidecar-injector-cert.yaml",
         "sidecar-injector-deployment.yaml",
@@ -278,6 +279,7 @@ def test_helm_examples_readme_is_shipped():
     assert "sqlite-pilot" in body
     assert "eks-vanilla" in body
     assert "gateway-runtime" in body
+    assert "keda-autoscaling" in body
     assert "install_helm_profile.py" in body
 
 
@@ -475,6 +477,20 @@ def test_helm_gateway_autoscaling_defaults():
     assert autoscaling["targetCPUUtilizationPercentage"] == 70
     assert autoscaling["targetMemoryUtilizationPercentage"] is None
     assert autoscaling["behavior"] == {}
+    assert autoscaling["keda"]["enabled"] is False
+    assert autoscaling["keda"]["prometheus"]["relayRateThreshold"] == "25"
+    assert autoscaling["keda"]["prometheus"]["pressureRateThreshold"] == "1"
+
+
+def test_helm_gateway_keda_template_suppresses_static_hpa():
+    """Gateway KEDA must own autoscaling when enabled, not stack with a static HPA."""
+    hpa_template = (HELM_DIR / "templates" / "gateway-hpa.yaml").read_text()
+    scaled_object = (HELM_DIR / "templates" / "gateway-keda-scaledobject.yaml").read_text()
+
+    assert "(not .Values.gateway.autoscaling.keda.enabled)" in hpa_template
+    assert "kind: ScaledObject" in scaled_object
+    assert "agent_bom_gateway_relays_total" in scaled_object
+    assert "gateway.autoscaling.keda.triggers" in scaled_object
 
 
 def test_helm_control_plane_api_extra_volume_defaults():

--- a/tests/test_deploy_profiles.py
+++ b/tests/test_deploy_profiles.py
@@ -18,6 +18,7 @@ def test_helm_validation_profiles_reference_existing_chart_assets():
         "focused-pilot",
         "focused-pilot-byo-postgres",
         "production",
+        "keda-autoscaling",
         "eks-vanilla",
         "mesh-hardening",
         "snowflake-backend",
@@ -38,6 +39,20 @@ def test_gateway_runtime_profile_uses_shipped_upstreams_example():
     assert gateway.set_file_arguments == (
         ("gateway.upstreamsYaml", repo_root / "deploy" / "helm" / "agent-bom" / "examples" / "gateway-upstreams.example.yaml"),
     )
+
+
+def test_keda_profile_layers_production_and_keda_overlay():
+    repo_root = Path(__file__).resolve().parent.parent
+    profiles = {profile.name: profile for profile in helm_validation_profiles(repo_root)}
+    keda = profiles["keda-autoscaling"]
+    example_dir = repo_root / "deploy" / "helm" / "agent-bom" / "examples"
+
+    assert keda.values_files == (
+        example_dir / "eks-production-values.yaml",
+        example_dir / "eks-keda-values.yaml",
+    )
+    assert keda.set_arguments == ("gateway.enabled=true",)
+    assert keda.set_file_arguments == (("gateway.upstreamsYaml", example_dir / "gateway-upstreams.example.yaml"),)
 
 
 def test_postgres_secret_example_documents_byo_postgres_contract():


### PR DESCRIPTION
## Summary
- Adds a gateway `ScaledObject` template for KEDA-backed autoscaling.
- Suppresses the static gateway HPA when gateway KEDA is enabled.
- Extends the packaged KEDA profile so API and gateway autoscaling render together.

## Changed files
- `deploy/helm/agent-bom/values.yaml`
- `deploy/helm/agent-bom/templates/gateway-hpa.yaml`
- `deploy/helm/agent-bom/templates/gateway-keda-scaledobject.yaml`
- `deploy/helm/agent-bom/examples/eks-keda-values.yaml`
- `deploy/helm/agent-bom/examples/README.md`
- `src/agent_bom/deploy_profiles.py`
- `tests/test_deploy_manifests.py`
- `tests/test_deploy_profiles.py`

## Validation
- `pytest tests/test_deploy_manifests.py::test_helm_templates_exist tests/test_deploy_manifests.py::test_helm_gateway_autoscaling_defaults tests/test_deploy_manifests.py::test_helm_gateway_keda_template_suppresses_static_hpa tests/test_deploy_manifests.py::test_helm_examples_readme_is_shipped tests/test_deploy_profiles.py`
- `python scripts/validate_helm_profiles.py --profile keda-autoscaling | rg "kind: ScaledObject|name: agent-bom-gateway|agent_bom_gateway_relays_total|\+ helm template"`
- pre-commit hooks from `git commit`