### PR TITLE
ci: pin uv setup tool version

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -11,6 +11,6 @@ runs:
   steps:
     - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
       with:
-        version: "0.7.12"
+        version: "0.11.10"
         python-version: ${{ inputs.python-version }}
         enable-cache: true

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -11,5 +11,6 @@ runs:
   steps:
     - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
       with:
+        version: "0.7.12"
         python-version: ${{ inputs.python-version }}
         enable-cache: true


### PR DESCRIPTION
Summary
- Pins the uv binary version used by the shared Python setup action.
- Keeps the setup action itself SHA-pinned while avoiding live latest-release lookup during CI startup.

Why
- The setup-python dependency bump surfaced a failure mode where GitHub API instability prevented uv from installing, which made later tests fail with `uv: command not found`.

Validation
- python scripts/check_workflow_timeouts.py
- git diff --check