### PR TITLE
Add proxy audit DLQ drain tooling

### DIFF
--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -24,6 +24,7 @@
 |---------|-------------|
 | `proxy` | Run an MCP server through the agent-bom security proxy |
 | `audit` | View and analyze a proxy audit JSONL log |
+| `audit-drain-dlq` | Replay or inspect proxy audit dead-letter queue entries |
 
 ### MCP
 

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -189,6 +189,7 @@ main.commands["registry"].hidden = True  # Available under `mcp registry`
 
 from agent_bom.cli._runtime import (  # noqa: E402
     _NoOpDetector,
+    audit_drain_dlq_cmd,
     audit_replay_cmd,
     protect_cmd,
     proxy_bootstrap_cmd,
@@ -204,6 +205,7 @@ from agent_bom.cli._runtime_group import runtime_group  # noqa: E402
 
 runtime_group.add_command(proxy_cmd, "proxy")
 runtime_group.add_command(audit_replay_cmd, "audit")
+runtime_group.add_command(audit_drain_dlq_cmd, "drain-dlq")
 runtime_group.add_command(proxy_bootstrap_cmd, "bootstrap")
 # Deprecated — hidden but still work for backward compat
 runtime_group.add_command(proxy_configure_cmd, "configure")
@@ -219,6 +221,7 @@ main.commands["runtime"].hidden = True  # Use proxy/audit directly
 main.add_command(proxy_cmd, "proxy")
 main.add_command(proxy_bootstrap_cmd, "proxy-bootstrap")
 main.add_command(audit_replay_cmd, "audit")
+main.add_command(audit_drain_dlq_cmd, "audit-drain-dlq")
 
 from agent_bom.cli._analysis import (  # noqa: E402
     analytics_cmd,

--- a/src/agent_bom/cli/_runtime.py
+++ b/src/agent_bom/cli/_runtime.py
@@ -897,3 +897,52 @@ def audit_replay_cmd(log_path, tool, entry_type, blocked_only, alerts_only, sign
         as_json=as_json,
     )
     sys.exit(exit_code)
+
+
+@click.command("audit-drain-dlq")
+@click.argument("dlq_path", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--output",
+    "output_path",
+    required=True,
+    type=click.Path(dir_okay=False),
+    help="JSONL file to append valid DLQ records to.",
+)
+@click.option("--max-records", type=int, default=None, help="Maximum number of valid records to drain.")
+@click.option("--delete-drained", is_flag=True, help="Remove drained valid records from the DLQ after appending them.")
+@click.option("--json", "as_json", is_flag=True, help="Output machine-readable JSON summary.")
+def audit_drain_dlq_cmd(dlq_path, output_path, max_records, delete_drained, as_json):
+    """Drain valid proxy audit DLQ records into a JSONL file."""
+    import json
+    from pathlib import Path
+
+    from agent_bom.proxy_audit import drain_proxy_audit_dlq
+
+    if max_records is not None and max_records <= 0:
+        raise click.UsageError("--max-records must be greater than zero")
+
+    result = drain_proxy_audit_dlq(
+        Path(dlq_path),
+        Path(output_path),
+        max_records=max_records,
+        delete_drained=delete_drained,
+    )
+    payload = {
+        "dlq_path": str(result.dlq_path),
+        "output_path": str(result.output_path),
+        "records_written": result.records_written,
+        "invalid_lines": result.invalid_lines,
+        "remaining_lines": result.remaining_lines,
+        "deleted_drained": result.deleted_drained,
+    }
+    if as_json:
+        click.echo(json.dumps(payload, sort_keys=True))
+        return
+
+    console = Console()
+    console.print(
+        "[green]Drained[/green] "
+        f"{result.records_written} valid record(s) to {result.output_path} "
+        f"({result.invalid_lines} invalid line(s); "
+        f"{'deleted drained records' if result.deleted_drained else 'left DLQ unchanged'})."
+    )

--- a/src/agent_bom/proxy_audit.py
+++ b/src/agent_bom/proxy_audit.py
@@ -309,6 +309,90 @@ class AuditSpilloverStore:
                 handle.write(line + "\n")
 
 
+@dataclass(frozen=True)
+class AuditDlqDrainResult:
+    """Summary returned after draining proxy audit DLQ records."""
+
+    dlq_path: Path
+    output_path: Path
+    records_written: int
+    invalid_lines: int
+    remaining_lines: int
+    deleted_drained: bool
+
+
+def drain_proxy_audit_dlq(
+    dlq_path: Path,
+    output_path: Path,
+    *,
+    max_records: int | None = None,
+    delete_drained: bool = False,
+) -> AuditDlqDrainResult:
+    """Append valid proxy audit DLQ records to ``output_path``.
+
+    Invalid JSONL lines are counted and left in place when ``delete_drained``
+    is set, so operators can inspect them separately.
+    """
+    if max_records is not None and max_records <= 0:
+        raise ValueError("max_records must be greater than zero")
+
+    records_to_write: list[str] = []
+    remaining_lines: list[str] = []
+    invalid_lines = 0
+    drained = 0
+
+    with dlq_path.open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.rstrip("\n")
+            stripped = line.strip()
+            if not stripped:
+                if delete_drained:
+                    remaining_lines.append(raw_line)
+                continue
+            try:
+                payload = json.loads(stripped)
+            except json.JSONDecodeError:
+                invalid_lines += 1
+                if delete_drained:
+                    remaining_lines.append(raw_line)
+                continue
+            if not isinstance(payload, dict):
+                invalid_lines += 1
+                if delete_drained:
+                    remaining_lines.append(raw_line)
+                continue
+            if max_records is not None and drained >= max_records:
+                if delete_drained:
+                    remaining_lines.append(raw_line)
+                continue
+            records_to_write.append(json.dumps(payload, separators=(",", ":")))
+            drained += 1
+
+    if records_to_write:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("a", encoding="utf-8") as output:
+            for record in records_to_write:
+                output.write(record + "\n")
+
+    if delete_drained and drained:
+        if remaining_lines:
+            tmp_path = dlq_path.with_name(f"{dlq_path.name}.tmp")
+            with tmp_path.open("w", encoding="utf-8") as tmp:
+                tmp.writelines(remaining_lines)
+            tmp_path.replace(dlq_path)
+        else:
+            dlq_path.unlink()
+
+    return AuditDlqDrainResult(
+        dlq_path=dlq_path,
+        output_path=output_path,
+        records_written=drained,
+        invalid_lines=invalid_lines,
+        remaining_lines=len(remaining_lines) if delete_drained else 0,
+        deleted_drained=delete_drained,
+    )
+
+
 class ProxyMetricsServer:
     """Lightweight HTTP server exposing Prometheus text exposition format on /metrics."""
 

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 
 from agent_bom.cli._runtime import (
     _NoOpDetector,
+    audit_drain_dlq_cmd,
     audit_replay_cmd,
     protect_cmd,
     proxy_bootstrap_cmd,
@@ -402,3 +403,24 @@ def test_audit_replay_cmd_alerts_only(tmp_path):
     runner = CliRunner()
     result = runner.invoke(audit_replay_cmd, [str(log_file), "--alerts-only"])
     assert result.exit_code == 0
+
+
+def test_audit_drain_dlq_cmd_writes_json_summary_and_deletes_drained(tmp_path):
+    import json
+
+    dlq = tmp_path / "audit.dlq.jsonl"
+    output = tmp_path / "drained.jsonl"
+    dlq.write_text('{"event":"one"}\nnot-json\n{"event":"two"}\n', encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_drain_dlq_cmd,
+        [str(dlq), "--output", str(output), "--max-records", "1", "--delete-drained", "--json"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["records_written"] == 1
+    assert payload["invalid_lines"] == 1
+    assert output.read_text(encoding="utf-8") == '{"event":"one"}\n'
+    assert dlq.read_text(encoding="utf-8") == 'not-json\n{"event":"two"}\n'

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -39,7 +39,7 @@ from agent_bom.proxy import (
     sandbox_posture_warning,
     undeclared_tool_block_reason,
 )
-from agent_bom.proxy_audit import _AUDIT_CHAIN_STATE, write_audit_record
+from agent_bom.proxy_audit import _AUDIT_CHAIN_STATE, drain_proxy_audit_dlq, write_audit_record
 
 
 def test_proxy_message_size_budget_is_two_mib_or_less():
@@ -643,6 +643,34 @@ def test_audit_spillover_store_diverts_to_dlq_when_spillover_full(tmp_path: Path
     assert destination == "dlq"
     assert store.spillover_size_bytes() == 0
     assert store.dlq_size_bytes() > 0
+
+
+def test_drain_proxy_audit_dlq_appends_valid_records_and_preserves_invalid(tmp_path: Path):
+    dlq = tmp_path / "audit.dlq.jsonl"
+    output = tmp_path / "audit.recovered.jsonl"
+    dlq.write_text('{"event":"one"}\nnot-json\n["not", "an", "object"]\n{"event":"two"}\n', encoding="utf-8")
+
+    result = drain_proxy_audit_dlq(dlq, output, delete_drained=True)
+
+    assert result.records_written == 2
+    assert result.invalid_lines == 2
+    assert result.remaining_lines == 2
+    assert output.read_text(encoding="utf-8") == '{"event":"one"}\n{"event":"two"}\n'
+    assert dlq.read_text(encoding="utf-8") == 'not-json\n["not", "an", "object"]\n'
+
+
+def test_drain_proxy_audit_dlq_without_delete_leaves_dlq_unchanged(tmp_path: Path):
+    dlq = tmp_path / "audit.dlq.jsonl"
+    output = tmp_path / "audit.recovered.jsonl"
+    body = '{"event":"one"}\n{"event":"two"}\n'
+    dlq.write_text(body, encoding="utf-8")
+
+    result = drain_proxy_audit_dlq(dlq, output, max_records=1)
+
+    assert result.records_written == 1
+    assert result.remaining_lines == 0
+    assert output.read_text(encoding="utf-8") == '{"event":"one"}\n'
+    assert dlq.read_text(encoding="utf-8") == body
 
 
 # ── CLI proxy --help ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds a proxy audit DLQ drain helper that appends valid JSONL records to an operator-chosen file.
- Preserves malformed lines for manual inspection and only rewrites the DLQ when `--delete-drained` is explicit.
- Adds a CLI command with text and JSON summaries for operational use.

## Changed files
- `src/agent_bom/proxy_audit.py`
- `src/agent_bom/cli/_runtime.py`
- `src/agent_bom/cli/__init__.py`
- `tests/test_proxy.py`
- `tests/test_cli_runtime.py`

## Validation
- `pytest tests/test_proxy.py::test_audit_spillover_store_diverts_to_dlq_when_spillover_full tests/test_proxy.py::test_drain_proxy_audit_dlq_appends_valid_records_and_preserves_invalid tests/test_proxy.py::test_drain_proxy_audit_dlq_without_delete_leaves_dlq_unchanged tests/test_cli_runtime.py::test_audit_drain_dlq_cmd_writes_json_summary_and_deletes_drained`
- pre-commit hooks from `git commit`