### PR TITLE
chore(ci): refresh Snowflake release action pins

### DIFF
--- a/.github/workflows/release-snowflake.yml
+++ b/.github/workflows/release-snowflake.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.11"
 
@@ -95,7 +95,7 @@ jobs:
           tar -czf "dist/agent-bom-snowflake-${{ steps.version.outputs.version }}.tgz" \
             -C deploy/snowflake/native-app .
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: agent-bom-snowflake-${{ steps.version.outputs.version }}
           path: dist/agent-bom-snowflake-${{ steps.version.outputs.version }}.tgz
@@ -109,7 +109,7 @@ jobs:
     if: ${{ inputs.dry_run == false }}
     environment: snowflake-marketplace
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: agent-bom-snowflake-${{ needs.package.outputs.package_version }}
           path: dist


### PR DESCRIPTION
Summary
- Updates the pinned GitHub Action SHAs used by the Snowflake Native App release workflow.
- Covers setup-python, upload-artifact, and download-artifact in one signed maintenance PR.
- Keeps the workflow on immutable 40-character action refs.

Why
- The generated dependency PR commits were unsigned and cannot satisfy the repository signature policy.
- This applies the same dependency updates with a verified local signature.

Validation
- uv run pytest tests/test_snowflake_native_app.py::test_release_workflow_pins_actions_and_rejects_latest_native_app_images -q
- python scripts/check_workflow_timeouts.py
- git diff --check
- commit hooks passed: yaml, file hygiene, private-key detection, merge-conflict check, ruff/mypy/bandit no-file skips, env-var drift no-file skip

Supersedes
- #2306
- #2307
- #2308