### PR TITLE
ci: pin uv setup tool version

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -11,5 +11,6 @@ runs:
   steps:
     - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
       with:
+        version: "0.11.10"
         python-version: ${{ inputs.python-version }}
         enable-cache: true


### PR DESCRIPTION
Summary
- Pins the uv binary version used by the shared Python setup action.
- Keeps the setup-uv action itself pinned by immutable SHA.
- Avoids resolving the latest uv release during CI setup.

Why
- CI jobs were failing when the release lookup for the latest uv binary returned a transient GitHub service error.
- Pinning the tool version makes Python setup deterministic across workflow lanes.

Validation
- python scripts/check_workflow_timeouts.py
- git diff --check
- commit hooks passed: yaml, file hygiene, private-key detection, merge-conflict check, ruff/mypy/bandit no-file skips, env-var drift no-file skip

Supersedes
- #2312