### PR TITLE
Tighten audit readiness surfaces

### DIFF
--- a/deploy/k8s/cronjob.yaml
+++ b/deploy/k8s/cronjob.yaml
@@ -21,7 +21,7 @@ spec:
           serviceAccountName: agent-bom
           containers:
             - name: scanner
-              image: agentbom/agent-bom:0.86.0
+              image: agentbom/agent-bom:0.86.1
               command: ["agent-bom"]
               args:
                 - "scan"

--- a/deploy/snowflake/native-app/manifest.yml
+++ b/deploy/snowflake/native-app/manifest.yml
@@ -15,10 +15,10 @@ artifacts:
     endpoint: ui
   container_services:
     images:
-      - /db/schema/agent_bom_repo/agent-bom:v0_86_0
-      - /db/schema/agent_bom_repo/agent-bom-ui:v0_86_0
-      - /db/schema/agent_bom_repo/agent-bom-scanner:v0_86_0
-      - /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_86_0
+      - /db/schema/agent_bom_repo/agent-bom:v0_86_1
+      - /db/schema/agent_bom_repo/agent-bom-ui:v0_86_1
+      - /db/schema/agent_bom_repo/agent-bom-scanner:v0_86_1
+      - /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_86_1
   service_roles:
     - name: api
       comment: >-

--- a/deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml
+++ b/deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom-mcp-runtime
-      image: /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_86_0
+      image: /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_86_1
       env:
         SNOWFLAKE_ACCOUNT: "{{ snowflake_account }}"
         SNOWFLAKE_DATABASE: "{{ database }}"

--- a/deploy/snowflake/native-app/service-specs/scanner-service.yaml
+++ b/deploy/snowflake/native-app/service-specs/scanner-service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom-scanner
-      image: /db/schema/agent_bom_repo/agent-bom-scanner:v0_86_0
+      image: /db/schema/agent_bom_repo/agent-bom-scanner:v0_86_1
       env:
         SNOWFLAKE_ACCOUNT: "{{ snowflake_account }}"
         SNOWFLAKE_DATABASE: "{{ database }}"

--- a/docs/schemas/v1/ScanJob.json
+++ b/docs/schemas/v1/ScanJob.json
@@ -12,6 +12,7 @@
       "type": "string"
     },
     "ScanRequest": {
+      "additionalProperties": false,
       "description": "Options accepted by POST /v1/scan \u2014 mirrors agent-bom scan CLI flags.",
       "properties": {
         "agent_projects": {

--- a/docs/schemas/v1/ScanRequest.json
+++ b/docs/schemas/v1/ScanRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "description": "Options accepted by POST /v1/scan \u2014 mirrors agent-bom scan CLI flags.",
   "properties": {
     "agent_projects": {

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -51,6 +51,8 @@ class _BoundedProgress(list[str]):
 class ScanRequest(BaseModel):
     """Options accepted by POST /v1/scan — mirrors agent-bom scan CLI flags."""
 
+    model_config = ConfigDict(extra="forbid")
+
     inventory: str | None = None
     """Path to agents.json inventory file."""
 

--- a/src/agent_bom/api/routes/sources.py
+++ b/src/agent_bom/api/routes/sources.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Request
+from pydantic import ValidationError
 
 from agent_bom.api.audit_log import log_action
 from agent_bom.api.models import (
@@ -78,6 +79,7 @@ def _request_for_source(source: SourceRecord) -> ScanRequest:
         connector_name = source.connector_name or str(config.get("connector_name") or "").strip()
         if not connector_name:
             raise HTTPException(status_code=409, detail="Connector-backed sources require connector_name to run")
+        config.pop("connector_name", None)
         config.setdefault("connectors", [connector_name])
 
     if source.kind in (SourceKind.INGEST_FLEET_SYNC, SourceKind.INGEST_TRACE_PUSH, SourceKind.INGEST_RESULT_PUSH):
@@ -86,7 +88,10 @@ def _request_for_source(source: SourceRecord) -> ScanRequest:
     if source.kind in (SourceKind.RUNTIME_PROXY, SourceKind.RUNTIME_GATEWAY):
         raise HTTPException(status_code=409, detail="Runtime sources are audited by proxy/gateway traffic, not by direct scan jobs")
 
-    return ScanRequest.model_validate(config)
+    try:
+        return ScanRequest.model_validate(config)
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=exc.errors()) from exc
 
 
 @router.post("/v1/sources", tags=["sources"], status_code=201)

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -308,6 +308,17 @@ def test_create_scan_with_options():
     assert body["request"]["format"] == "cyclonedx"
 
 
+def test_create_scan_rejects_unknown_fields():
+    """POST /v1/scan rejects typoed request fields instead of dropping them."""
+    client, _ = _fresh_client()
+    resp = client.post("/v1/scan", json={"project_path": "."})
+
+    assert resp.status_code == 422
+    body = resp.json()
+    assert "project_path" in str(body)
+    assert "extra_forbidden" in str(body)
+
+
 # ---------------------------------------------------------------------------
 # 6. GET scan — not found
 # ---------------------------------------------------------------------------

--- a/tests/test_api_sources.py
+++ b/tests/test_api_sources.py
@@ -225,6 +225,26 @@ def test_running_source_queues_source_linked_job(source_client: TestClient, monk
     assert jobs_body["jobs"][0]["source_id"] == source_id
 
 
+def test_source_run_rejects_unknown_scan_request_fields(source_client: TestClient) -> None:
+    created = source_client.post(
+        "/v1/sources",
+        headers=ANALYST_HEADERS,
+        json={
+            "display_name": "Typoed repo source",
+            "kind": "scan.repo",
+            "config": {"scan_request": {"project_path": "."}},
+        },
+    )
+    source_id = created.json()["source_id"]
+
+    resp = source_client.post(f"/v1/sources/{source_id}/run", headers=ANALYST_HEADERS)
+
+    assert resp.status_code == 422
+    body = resp.json()
+    assert "project_path" in str(body)
+    assert "extra_forbidden" in str(body)
+
+
 def test_push_and_runtime_sources_reject_run_now(source_client: TestClient) -> None:
     for kind in ("ingest.trace_push", "runtime.gateway"):
         created = source_client.post(

--- a/tests/test_snowflake_native_app.py
+++ b/tests/test_snowflake_native_app.py
@@ -24,7 +24,16 @@ SETUP_SQL_PATH = NATIVE_APP_DIR / "scripts" / "setup.sql"
 DCM_DIR = NATIVE_APP_DIR / "dcm"
 SERVICE_SPECS_DIR = NATIVE_APP_DIR / "service-specs"
 RELEASE_WORKFLOW_PATH = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release-snowflake.yml"
-SNOWFLAKE_PACKAGE_IMAGE_TAG = "v0_86_0"
+PYPROJECT_PATH = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+def _snowflake_image_tag_from_pyproject() -> str:
+    match = re.search(r'^version\s*=\s*"([^"]+)"', PYPROJECT_PATH.read_text(encoding="utf-8"), re.MULTILINE)
+    assert match, "pyproject.toml must declare the package version"
+    return "v" + match.group(1).replace(".", "_")
+
+
+SNOWFLAKE_PACKAGE_IMAGE_TAG = _snowflake_image_tag_from_pyproject()
 
 
 @pytest.fixture(scope="module")

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -33,9 +33,7 @@ import {
   type FilterState,
 } from "@/components/lineage-filter";
 import {
-  lineageNodeTypes,
-  lineageNodeTypesCluster,
-  lineageNodeTypesSummary,
+  lineageNodeTypesAdaptive,
   type LineageNodeData,
   type LineageNodeType,
 } from "@/components/lineage-nodes";
@@ -867,6 +865,17 @@ function GraphPageInner() {
       .filter(Boolean)
       .join(" ") || "";
 
+  // Levels-of-detail (#2257). Hook reads `viewport.zoom` from the
+  // xyflow store provided by the wrapping `<ReactFlowProvider>` and
+  // returns "cluster" | "summary" | "detail". The chosen render band
+  // keeps dense graphs readable without changing node positions or data.
+  const lodBand = useLodBand();
+  const effectiveLodBand = effectiveLodBandForGraph(lodBand, {
+    sourceNodeCount: flow.nodes.length,
+    renderedNodeCount: aggregated.nodes.length,
+    clusterCount: aggregated.clusters.size,
+  });
+
   const displayNodes = useMemo(() => {
     if (attackPathNodeIds) {
       return layoutNodes.map((node) => {
@@ -876,13 +885,22 @@ function GraphPageInner() {
           className: composeFocusClass(node.className, inPath, !inPath),
           data: {
             ...node.data,
+            renderBand: effectiveLodBand,
             dimmed: !inPath,
             highlighted: inPath,
           },
         };
       });
     }
-    if (!localNeighborhoodIds) return layoutNodes;
+    if (!localNeighborhoodIds) {
+      return layoutNodes.map((node) => ({
+        ...node,
+        data: {
+          ...node.data,
+          renderBand: effectiveLodBand,
+        },
+      }));
+    }
     return layoutNodes.map((node) => {
       const isFocused = node.id === activeFocusId;
       const isConnected = localNeighborhoodIds.has(node.id);
@@ -892,12 +910,13 @@ function GraphPageInner() {
         className: composeFocusClass(node.className, isFocused, dimmed),
         data: {
           ...node.data,
+          renderBand: effectiveLodBand,
           dimmed,
           highlighted: isConnected,
         },
       };
     });
-  }, [layoutNodes, localNeighborhoodIds, attackPathNodeIds, activeFocusId]);
+  }, [layoutNodes, localNeighborhoodIds, attackPathNodeIds, activeFocusId, effectiveLodBand]);
 
   const displayEdges = useMemo(() => {
     if (attackPathEdgeKeys) {
@@ -990,23 +1009,6 @@ function GraphPageInner() {
   const onNodeMouseLeave = useCallback(() => {
     setHoveredNodeId(null);
   }, []);
-
-  // Levels-of-detail (#2257). Hook reads `viewport.zoom` from the
-  // xyflow store provided by the wrapping `<ReactFlowProvider>` and
-  // returns "cluster" | "summary" | "detail". The chosen registry
-  // swaps node renderers without touching node positions or data.
-  const lodBand = useLodBand();
-  const effectiveLodBand = effectiveLodBandForGraph(lodBand, {
-    sourceNodeCount: flow.nodes.length,
-    renderedNodeCount: aggregated.nodes.length,
-    clusterCount: aggregated.clusters.size,
-  });
-  const nodeTypesForBand =
-    effectiveLodBand === "cluster"
-      ? lineageNodeTypesCluster
-      : effectiveLodBand === "summary"
-        ? lineageNodeTypesSummary
-        : lineageNodeTypes;
 
   const selectFindingCard = useCallback((id: string, data: LineageNodeData) => {
     setSelectedNode({
@@ -1567,6 +1569,7 @@ function GraphPageInner() {
             <GraphFindingsFallback
               nodes={findingNodes}
               onSelect={selectFindingCard}
+              scanId={selectedScanId || undefined}
               onExpandScope={() =>
                 setFilters(createExpandedGraphFilters(filters.agentName ?? flow.agentNames[0] ?? null))
               }
@@ -1575,7 +1578,7 @@ function GraphPageInner() {
             <ReactFlow
               nodes={displayNodes}
               edges={displayEdges}
-              nodeTypes={nodeTypesForBand}
+              nodeTypes={lineageNodeTypesAdaptive}
               fitView
               fitViewOptions={{ padding: 0.18, maxZoom: 1.05 }}
               minZoom={0.16}

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 
 import { ApiOfflineState } from "@/components/api-offline-state";
-import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
+import { ApiAuthError, ApiForbiddenError, userFacingApiErrorMessage } from "@/lib/api-errors";
 
 function _classifyGraphErrorKind(err: unknown): "network" | "auth" | "forbidden" {
   if (err instanceof ApiAuthError) return "auth";
@@ -35,6 +35,7 @@ import {
 import {
   attackPathKey,
   attackPathSequenceLabels,
+  buildFindingsHref,
   buildGraphInvestigationHref,
   buildSecurityGraphHref,
   investigationRootForAttackPath,
@@ -100,7 +101,7 @@ function SecurityGraphPageContent() {
         setGraphLoadError(null);
       } catch (error) {
         if (cancelled) return;
-        setApiError(error instanceof Error ? error.message : "Failed to load graph snapshots");
+        setApiError(userFacingApiErrorMessage(error, "Failed to load graph snapshots"));
         setApiErrorKind(_classifyGraphErrorKind(error));
         setSnapshots([]);
         setGraphData(null);
@@ -153,7 +154,7 @@ function SecurityGraphPageContent() {
         if (cancelled) return;
         setGraphData(null);
         setFixFirstView(null);
-        setGraphLoadError(error instanceof Error ? error.message : "Failed to load security graph");
+        setGraphLoadError(userFacingApiErrorMessage(error, "Failed to load security graph"));
         setApiErrorKind(_classifyGraphErrorKind(error));
       } finally {
         if (!cancelled) setLoadingGraph(false);
@@ -261,9 +262,9 @@ function SecurityGraphPageContent() {
   const selectedPathActions = useMemo(
     () =>
       selectedAttackPath
-        ? recommendedAttackPathActions(selectedAttackPath, graphNodeById)
+        ? recommendedAttackPathActions(selectedAttackPath, graphNodeById, { scanId: selectedScanId || undefined })
         : [],
-    [graphNodeById, selectedAttackPath],
+    [graphNodeById, selectedAttackPath, selectedScanId],
   );
 
   const interactionRiskSummary = useMemo(
@@ -537,7 +538,7 @@ function SecurityGraphPageContent() {
               <GitBranch className="h-3.5 w-3.5" />
             </Link>
             <Link
-              href="/findings"
+              href={buildFindingsHref({ scanId: selectedScanId || undefined })}
               className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-1.5 text-xs text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
             >
               Review findings
@@ -583,7 +584,7 @@ function SecurityGraphPageContent() {
                     <GitBranch className="h-3 w-3" />
                   </Link>
                   <Link
-                    href="/findings"
+                    href={buildFindingsHref({ scanId: selectedScanId || undefined })}
                     className="inline-flex items-center gap-1 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-1 text-[11px] text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
                   >
                     Findings
@@ -736,7 +737,7 @@ function SecurityGraphPageContent() {
                     label="Findings"
                     tags={selectedAttackPath.vuln_ids}
                     emptyLabel="No linked findings"
-                    hrefForTag={(tag) => `/findings?cve=${encodeURIComponent(tag)}`}
+                    hrefForTag={(tag) => buildFindingsHref({ scanId: selectedScanId || undefined, cve: tag })}
                   />
                   <TagList
                     label="Agents"
@@ -818,7 +819,7 @@ function SecurityGraphPageContent() {
                           </div>
                           {risk.agents.length > 0 && (
                             <div className="mt-3 flex flex-wrap gap-2">
-                              {risk.agents.slice(0, 4).map((agent) => (
+                              {Array.from(new Set(risk.agents)).slice(0, 4).map((agent) => (
                                 <Link
                                   key={agent}
                                   href={`/agents?name=${encodeURIComponent(agent)}`}
@@ -934,12 +935,13 @@ function TagList({
   emptyLabel: string;
   hrefForTag?: (tag: string) => string;
 }) {
+  const uniqueTags = useMemo(() => Array.from(new Set(tags.filter((tag) => tag.trim()))), [tags]);
   return (
     <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
       <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">{label}</div>
-      {tags.length > 0 ? (
+      {uniqueTags.length > 0 ? (
         <div className="mt-3 flex flex-wrap gap-2">
-          {tags.map((tag) => (
+          {uniqueTags.map((tag) => (
             hrefForTag ? (
               <Link
                 key={tag}

--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -3,16 +3,16 @@
 import { Fragment, Suspense, useCallback, useEffect, useState, useMemo, type ReactNode } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { api, Vulnerability, ScanJob, ScanResult, severityColor, severityDot, JobListItem, RemediationItem } from "@/lib/api";
+import { api, Vulnerability, ScanJob, ScanResult, severityColor, severityDot, JobListItem, RemediationItem, type UnifiedGraphResponse } from "@/lib/api";
 import { ApiOfflineState } from "@/components/api-offline-state";
 import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
+import { Bug, Download, ExternalLink, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Layers, Loader2, Package, Server, ShieldOff, Radar, FileSearch, ShieldAlert } from "lucide-react";
 
 function _classifyApiErrorKind(err: unknown): "network" | "auth" | "forbidden" {
   if (err instanceof ApiAuthError) return "auth";
   if (err instanceof ApiForbiddenError) return "forbidden";
   return "network";
 }
-import { Bug, Download, ExternalLink, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Layers, Loader2, Package, Server, ShieldOff, Radar, FileSearch, ShieldAlert } from "lucide-react";
 
 function downloadJson(data: unknown, filename: string) {
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
@@ -134,6 +134,90 @@ function mergeRemediationItems(existing: RemediationSummary[], incoming: Remedia
   return Array.from(merged.values());
 }
 
+type GraphNode = UnifiedGraphResponse["nodes"][number];
+
+function graphNodeKind(node: GraphNode): string {
+  return String(node.entity_type).toLowerCase();
+}
+
+function attrString(node: GraphNode, key: string): string | undefined {
+  const value = node.attributes?.[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function attrNumber(node: GraphNode, key: string): number | undefined {
+  const value = node.attributes?.[key];
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function normalizedSeverity(value: string | undefined): Vulnerability["severity"] {
+  const normalized = (value ?? "").toLowerCase();
+  return normalized === "critical" || normalized === "high" || normalized === "medium" || normalized === "low" || normalized === "none"
+    ? normalized
+    : "none";
+}
+
+function collectGraphVulns(graph: UnifiedGraphResponse): EnrichedVuln[] {
+  const nodeById = new Map(graph.nodes.map((node) => [node.id, node]));
+  const packagesByFinding = new Map<string, Set<string>>();
+  const agentsByFinding = new Map<string, Set<string>>();
+
+  for (const edge of graph.edges) {
+    const source = nodeById.get(edge.source);
+    const target = nodeById.get(edge.target);
+    if (!source || !target) continue;
+    const sourceKind = graphNodeKind(source);
+    const targetKind = graphNodeKind(target);
+    const finding = sourceKind === "vulnerability" ? source : targetKind === "vulnerability" ? target : null;
+    const other = finding?.id === source.id ? target : source;
+    if (!finding || !other) continue;
+    const otherKind = graphNodeKind(other);
+    if (otherKind === "package") {
+      const values = packagesByFinding.get(finding.id) ?? new Set<string>();
+      values.add(other.label);
+      packagesByFinding.set(finding.id, values);
+    } else if (otherKind === "agent") {
+      const values = agentsByFinding.get(finding.id) ?? new Set<string>();
+      values.add(other.label);
+      agentsByFinding.set(finding.id, values);
+    }
+  }
+
+  return graph.nodes
+    .filter((node) => graphNodeKind(node) === "vulnerability")
+    .map((node): EnrichedVuln => ({
+      id: node.label,
+      severity: normalizedSeverity(node.severity),
+      summary: attrString(node, "summary") ?? attrString(node, "description"),
+      description: attrString(node, "description") ?? attrString(node, "summary"),
+      references: [],
+      advisory_sources: [],
+      aliases: [],
+      cvss_score: attrNumber(node, "cvss_score") ?? attrNumber(node, "cvss"),
+      epss_score: attrNumber(node, "epss_score") ?? attrNumber(node, "epss"),
+      is_kev: Boolean(node.attributes?.is_kev ?? node.attributes?.cisa_kev),
+      cisa_kev: Boolean(node.attributes?.cisa_kev ?? node.attributes?.is_kev),
+      fixed_version: attrString(node, "fixed_version"),
+      packages: Array.from(packagesByFinding.get(node.id) ?? []),
+      agents: Array.from(agentsByFinding.get(node.id) ?? []),
+      sources: node.data_sources.length > 0 ? node.data_sources : [`graph:${graph.scan_id.slice(0, 8)}`],
+      affected_servers: [],
+      exposed_credentials: [],
+      reachable_tools: [],
+      attack_vector_summary: attrString(node, "attack_vector_summary"),
+      impact_category: attrString(node, "impact_category"),
+      risk_score: node.risk_score,
+      remediation_items: [],
+      graph_reachable: null,
+      graph_min_hop_distance: null,
+    }));
+}
+
 function SortButton({
   label,
   field,
@@ -181,6 +265,7 @@ function VulnsPage() {
   const paramSeverity = searchParams.get("severity");
   const paramCve = searchParams.get("cve");
   const paramAgent = searchParams.get("agent");
+  const paramScan = searchParams.get("scan") ?? searchParams.get("scan_id");
 
   const [jobs, setJobs] = useState<JobListItem[]>([]);
   const [vulns, setVulns] = useState<EnrichedVuln[]>([]);
@@ -334,6 +419,31 @@ function VulnsPage() {
   useEffect(() => {
     async function loadDetails() {
       if (loading) return;
+      if (paramScan) {
+        setDetailLoading(true);
+        setError("");
+        try {
+          const graph = await api.getGraph({ scanId: paramScan, limit: 2500 });
+          setVulns(collectGraphVulns(graph));
+        } catch (graphError) {
+          try {
+            const selectedJob = await api.getScan(paramScan);
+            setVulns(collectVulns([selectedJob]));
+          } catch (jobError) {
+            setError(
+              jobError instanceof Error
+                ? jobError.message
+                : graphError instanceof Error
+                  ? graphError.message
+                  : "Failed to load selected scan",
+            );
+            setErrorKind(_classifyApiErrorKind(jobError));
+          }
+        } finally {
+          setDetailLoading(false);
+        }
+        return;
+      }
       if (jobs.length === 0) {
         setVulns([]);
         setDetailLoading(false);
@@ -359,7 +469,7 @@ function VulnsPage() {
     }
 
     void loadDetails();
-  }, [jobs, scope, loading, collectVulns]);
+  }, [jobs, scope, loading, collectVulns, paramScan]);
 
   function handleSort(field: SortKey) {
     if (sortKey === field) {
@@ -460,7 +570,9 @@ function VulnsPage() {
           <h1 className="text-2xl font-semibold tracking-tight">Findings</h1>
           <p className="text-zinc-400 text-sm mt-1">
             {scope === "latest"
-              ? `${vulns.length} vulnerability findings from the latest completed scan.`
+              ? paramScan
+                ? `${vulns.length} vulnerability findings from scan ${paramScan.slice(0, 8)}.`
+                : `${vulns.length} vulnerability findings from the latest completed scan.`
               : `${vulns.length} vulnerability findings aggregated across all completed scans.`}{" "}
             This surface is vulnerability-first today and will expand to broader finding types over time. CVSS and EPSS appear only when the underlying advisory includes them.
           </p>

--- a/ui/components/api-offline-state.tsx
+++ b/ui/components/api-offline-state.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { AlertTriangle, FileText, PlayCircle, Server } from "lucide-react";
 
 import type { ScanResult } from "@/lib/api";
+import { userFacingApiErrorMessage } from "@/lib/api-errors";
 import { getDisplayApiUrl } from "@/lib/runtime-config";
 import { checkFileSize, validateScanReport } from "@/lib/validators";
 
@@ -36,6 +37,7 @@ export function ApiOfflineState({
   const [importError, setImportError] = useState<string | null>(null);
   const apiUrl = getDisplayApiUrl();
   const resolvedTitle = title ?? KIND_TITLES[kind];
+  const resolvedDetail = detail ? userFacingApiErrorMessage(detail, "The API request failed.") : null;
 
   const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -95,9 +97,9 @@ export function ApiOfflineState({
               tab that fits your current role.
             </p>
           )}
-          {detail ? (
+          {resolvedDetail ? (
             <p className="mt-3 text-xs text-zinc-500">
-              Current error: <span className="font-mono text-zinc-400">{detail}</span>
+              Current error: <span className="font-mono text-zinc-400">{resolvedDetail}</span>
             </p>
           ) : null}
         </div>

--- a/ui/components/auth-gate.tsx
+++ b/ui/components/auth-gate.tsx
@@ -5,6 +5,7 @@ import { KeyRound, Loader2, Lock, ShieldCheck } from "lucide-react";
 
 import { useAuthState } from "@/components/auth-provider";
 import { api } from "@/lib/api";
+import { userFacingApiErrorMessage } from "@/lib/api-errors";
 import { clearSessionApiKey } from "@/lib/auth";
 
 function isAuthFailure(message: string): boolean {
@@ -63,11 +64,16 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
               onSubmit={async (event) => {
                 event.preventDefault();
                 setFormError(null);
+                const trimmedApiKey = apiKey.trim();
+                if (!trimmedApiKey) {
+                  setFormError("Enter an API key before unlocking the dashboard.");
+                  return;
+                }
                 try {
-                  await api.createAuthSession(apiKey);
+                  await api.createAuthSession(trimmedApiKey);
                   clearSessionApiKey();
                 } catch (nextError) {
-                  const message = nextError instanceof Error ? nextError.message : "Failed to create browser session";
+                  const message = userFacingApiErrorMessage(nextError, "Failed to create browser session");
                   if (message.includes("404") || message.includes("405")) {
                     clearSessionApiKey();
                     setFormError("Browser session endpoint unavailable; update the API before using browser API-key exchange.");
@@ -105,7 +111,8 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
               <div className="mt-4 flex gap-3">
                 <button
                   type="submit"
-                  className="rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-zinc-950 transition hover:bg-emerald-400"
+                  disabled={!apiKey.trim()}
+                  className="rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-zinc-950 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-zinc-800 disabled:text-zinc-500"
                 >
                   Unlock dashboard
                 </button>
@@ -132,7 +139,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
 
           {error ? (
             <div className="mt-5 rounded-2xl border border-red-900/50 bg-red-950/20 px-4 py-3 text-sm text-red-300">
-              {error}
+              {userFacingApiErrorMessage(error, "Failed to load auth session")}
             </div>
           ) : null}
           {formError ? (
@@ -148,7 +155,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-10">
       <div className="max-w-xl rounded-2xl border border-red-900/50 bg-red-950/20 p-6 text-sm text-red-300">
-        {error}
+        {userFacingApiErrorMessage(error, "Failed to load auth session")}
       </div>
     </div>
   );

--- a/ui/components/auth-provider.tsx
+++ b/ui/components/auth-provider.tsx
@@ -3,6 +3,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 
 import { api, type AuthMeResponse } from "@/lib/api";
+import { userFacingApiErrorMessage } from "@/lib/api-errors";
 
 interface AuthContextValue {
   session: AuthMeResponse | null;
@@ -35,7 +36,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setSession(next);
     } catch (nextError) {
       setSession(null);
-      setError(nextError instanceof Error ? nextError.message : "Failed to load auth session");
+      setError(userFacingApiErrorMessage(nextError, "Failed to load auth session"));
     } finally {
       setLoading(false);
     }

--- a/ui/components/graph-state-panels.tsx
+++ b/ui/components/graph-state-panels.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { ExternalLink, Route, SearchX } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { buildFindingsHref } from "@/lib/attack-paths";
 import { getOsvVulnerabilityUrl } from "@/lib/vulnerabilities";
 import type { LineageNodeData } from "./lineage-nodes";
 
@@ -120,9 +121,11 @@ export function GraphFindingsFallback({
   nodes,
   onSelect,
   onExpandScope,
+  scanId,
 }: {
   nodes: Array<{ id: string; data: LineageNodeData }>;
   onSelect: (id: string, data: LineageNodeData) => void;
+  scanId?: string | undefined;
   // Optional: when provided, a "Show full graph" button replaces the dead
   // "relax the scope to recover the graph" prose with an actual click target
   // that swaps the active filters to the expanded preset. The graph page
@@ -162,11 +165,11 @@ export function GraphFindingsFallback({
       </div>
 
       {shouldVirtualize ? (
-        <VirtualizedFindingList nodes={nodes} onSelect={onSelect} />
+        <VirtualizedFindingList nodes={nodes} onSelect={onSelect} scanId={scanId} />
       ) : (
         <div className="grid flex-1 gap-3 overflow-y-auto p-4 lg:grid-cols-2">
           {nodes.map(({ id, data }) => (
-            <FindingCard key={id} id={id} data={data} onSelect={onSelect} />
+            <FindingCard key={id} id={id} data={data} onSelect={onSelect} scanId={scanId} />
           ))}
         </div>
       )}
@@ -177,9 +180,11 @@ export function GraphFindingsFallback({
 function VirtualizedFindingList({
   nodes,
   onSelect,
+  scanId,
 }: {
   nodes: Array<{ id: string; data: LineageNodeData }>;
   onSelect: (id: string, data: LineageNodeData) => void;
+  scanId?: string | undefined;
 }) {
   const scrollerRef = useRef<HTMLDivElement | null>(null);
   const [scrollTop, setScrollTop] = useState(0);
@@ -227,7 +232,7 @@ function VirtualizedFindingList({
         >
           {visibleNodes.map(({ id, data }) => (
             <div key={id} style={{ minHeight: FINDING_ROW_HEIGHT - 12 }}>
-              <FindingCard id={id} data={data} onSelect={onSelect} />
+              <FindingCard id={id} data={data} onSelect={onSelect} scanId={scanId} />
             </div>
           ))}
         </div>
@@ -240,10 +245,12 @@ function FindingCard({
   id,
   data,
   onSelect,
+  scanId,
 }: {
   id: string;
   data: LineageNodeData;
   onSelect: (id: string, data: LineageNodeData) => void;
+  scanId?: string | undefined;
 }) {
   const severity = data.severity?.toUpperCase() ?? "UNKNOWN";
   const cvss = typeof data.cvssScore === "number" ? data.cvssScore.toFixed(1) : "N/A";
@@ -292,7 +299,7 @@ function FindingCard({
 
       <div className="mt-4 flex flex-wrap gap-2">
         <Link
-          href={`/findings?cve=${encodeURIComponent(data.label)}`}
+          href={buildFindingsHref({ scanId, cve: data.label })}
           className="inline-flex items-center gap-1 rounded-lg border border-emerald-800 bg-emerald-950/40 px-3 py-1.5 text-xs font-medium text-emerald-300 transition-colors hover:bg-emerald-950/70"
         >
           <Route className="h-3 w-3" />

--- a/ui/components/lineage-nodes.tsx
+++ b/ui/components/lineage-nodes.tsx
@@ -99,6 +99,7 @@ export type LineageNodeData = {
   evidenceTier?: "safe_to_store" | "replay_only" | undefined;
   evidenceCaptureReplay?: boolean | undefined;
   evidenceNotAfter?: string | undefined;
+  renderBand?: "detail" | "summary" | "cluster" | undefined;
 };
 
 type CardProps = {
@@ -134,8 +135,16 @@ function NodeCard({
         data.dimmed ? "opacity-25" : ""
       } ${data.highlighted ? `ring-2 ${ringClass}` : ""}`}
     >
-      {target && <Handle type="target" position={Position.Left} className="!w-2 !h-2 !bg-current" />}
-      {source && <Handle type="source" position={Position.Right} className="!w-2 !h-2 !bg-current" />}
+      <Handle
+        type="target"
+        position={Position.Left}
+        className={`!w-2 !h-2 !bg-current ${target ? "" : "!opacity-0"}`}
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        className={`!w-2 !h-2 !bg-current ${source ? "" : "!opacity-0"}`}
+      />
       <div className="flex items-center gap-1.5 mb-0.5">
         <Icon className={`w-3.5 h-3.5 shrink-0 ${iconClass}`} />
         <span className="text-xs font-semibold text-zinc-100 truncate">{data.label}</span>
@@ -747,6 +756,58 @@ const CLUSTER_BUBBLE_COLORS: Record<LineageNodeType, string> = {
   container: "#6366f1",
   cloudResource: "#0ea5e9",
   misconfiguration: "#f97316",
+};
+
+const DETAIL_RENDERERS: Record<LineageNodeType, ComponentType<{ data: LineageNodeData }>> = {
+  provider: ProviderNode,
+  agent: AgentNode,
+  user: UserNode,
+  group: GroupNode,
+  serviceAccount: ServiceAccountNode,
+  environment: EnvironmentNode,
+  fleet: FleetNode,
+  cluster: ClusterNode,
+  server: ServerNode,
+  sharedServer: SharedServerNode,
+  package: PackageNode,
+  vulnerability: VulnNode,
+  misconfiguration: MisconfigNode,
+  credential: CredentialNode,
+  tool: ToolNode,
+  model: ModelNode,
+  dataset: DatasetNode,
+  container: ContainerNode,
+  cloudResource: CloudResourceNode,
+};
+
+function AdaptiveLineageNode({ data }: { data: LineageNodeData }) {
+  if (data.renderBand === "cluster") return <ClusterBubbleNode data={data} />;
+  if (data.renderBand === "summary") return <SummaryNode data={data} />;
+  const Renderer = DETAIL_RENDERERS[data.nodeType] ?? SummaryNode;
+  return <Renderer data={data} />;
+}
+
+export const lineageNodeTypesAdaptive = {
+  providerNode: AdaptiveLineageNode,
+  agentNode: AdaptiveLineageNode,
+  userNode: AdaptiveLineageNode,
+  groupNode: AdaptiveLineageNode,
+  serviceAccountNode: AdaptiveLineageNode,
+  environmentNode: AdaptiveLineageNode,
+  fleetNode: AdaptiveLineageNode,
+  clusterNode: AdaptiveLineageNode,
+  serverNode: AdaptiveLineageNode,
+  packageNode: AdaptiveLineageNode,
+  vulnNode: AdaptiveLineageNode,
+  misconfigNode: AdaptiveLineageNode,
+  credentialNode: AdaptiveLineageNode,
+  toolNode: AdaptiveLineageNode,
+  modelNode: AdaptiveLineageNode,
+  datasetNode: AdaptiveLineageNode,
+  containerNode: AdaptiveLineageNode,
+  cloudResourceNode: AdaptiveLineageNode,
+  sharedServerNode: AdaptiveLineageNode,
+  clusterPillNode: ClusterPillNode,
 };
 
 /**

--- a/ui/lib/api-errors.ts
+++ b/ui/lib/api-errors.ts
@@ -121,6 +121,21 @@ export class ApiNetworkError extends ApiError {
   }
 }
 
+export function userFacingApiErrorMessage(err: unknown, fallback: string): string {
+  const message = err instanceof Error ? err.message : typeof err === "string" ? err : "";
+  const normalized = message.toLowerCase();
+  if (
+    normalized.includes("the string did not match the expected pattern") ||
+    normalized.includes("xmlhttprequest") ||
+    normalized.includes("failed to execute 'setrequestheader'") ||
+    normalized.includes("invalid character in header content")
+  ) {
+    return "Sign in with a valid API key before opening protected control-plane views.";
+  }
+  if (!message.trim()) return fallback;
+  return message;
+}
+
 export function classifyApiResponse(
   res: Response,
   parsedBody: unknown,

--- a/ui/lib/attack-paths.ts
+++ b/ui/lib/attack-paths.ts
@@ -112,6 +112,14 @@ export function buildSecurityGraphHref(focus: AttackPathFocus): string {
   return query ? `/security-graph?${query}` : "/security-graph";
 }
 
+export function buildFindingsHref(focus: Pick<AttackPathFocus, "cve" | "scanId">): string {
+  const params = new URLSearchParams();
+  if (focus.scanId) params.set("scan", focus.scanId);
+  if (focus.cve) params.set("cve", focus.cve);
+  const query = params.toString();
+  return query ? `/findings?${query}` : "/findings";
+}
+
 export function buildGraphInvestigationHref(
   request: GraphInvestigationRequest & Pick<AttackPathFocus, "scanId" | "agentName">,
 ): string {
@@ -209,6 +217,7 @@ export function investigationRootForAttackPath(
 export function recommendedAttackPathActions(
   path: AttackPath,
   nodeById: Map<string, UnifiedNode>,
+  focus: Pick<AttackPathFocus, "scanId"> = {},
 ): AttackPathAction[] {
   const actions: AttackPathAction[] = [];
   const leadingFinding = path.vuln_ids[0];
@@ -218,7 +227,7 @@ export function recommendedAttackPathActions(
     actions.push({
       title: "Validate the lead finding",
       detail: "Open the primary CVE evidence first so the exploit chain has a confirmed root cause.",
-      href: `/findings?cve=${encodeURIComponent(leadingFinding)}`,
+      href: buildFindingsHref({ scanId: focus.scanId, cve: leadingFinding }),
     });
   }
 

--- a/ui/lib/unified-graph-flow.ts
+++ b/ui/lib/unified-graph-flow.ts
@@ -186,10 +186,14 @@ export function buildUnifiedFlowGraph(
   const incoming = buildAdjacency(graph.edges, "target");
   const undirected = buildUndirectedAdjacency(graph.edges);
 
-  const agentNames = graph.nodes
-    .filter((node) => node.entity_type === EntityType.AGENT)
-    .map((node) => node.label)
-    .sort((a, b) => a.localeCompare(b));
+  const agentNames = Array.from(
+    new Set(
+      graph.nodes
+        .filter((node) => node.entity_type === EntityType.AGENT)
+        .map((node) => node.label)
+        .filter((label) => label.trim()),
+    ),
+  ).sort((a, b) => a.localeCompare(b));
 
   const visibleIds = deriveVisibleNodeIds(graph, filters, undirected);
 

--- a/ui/scripts/codegen-graph-schema.mjs
+++ b/ui/scripts/codegen-graph-schema.mjs
@@ -17,6 +17,8 @@
 // Env:
 //   AGENT_BOM_GRAPH_SCHEMA_URL  override URL
 //                               (default http://127.0.0.1:8422/v1/graph/schema)
+//   AGENT_BOM_GRAPH_SCHEMA_API_KEY, AGENT_BOM_CODEGEN_API_KEY, or AGENT_BOM_API_KEY
+//                               bearer token for auth-on API instances
 
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -28,6 +30,11 @@ const OUT_PATH = resolve(UI_ROOT, "lib/graph-schema.generated.ts");
 
 const DEFAULT_URL = "http://127.0.0.1:8422/v1/graph/schema";
 const URL_ENV = process.env.AGENT_BOM_GRAPH_SCHEMA_URL || DEFAULT_URL;
+const API_KEY_ENV =
+  process.env.AGENT_BOM_GRAPH_SCHEMA_API_KEY ||
+  process.env.AGENT_BOM_CODEGEN_API_KEY ||
+  process.env.AGENT_BOM_API_KEY ||
+  "";
 
 const checkOnly = process.argv.includes("--check");
 
@@ -45,10 +52,17 @@ function jsonStringify(value) {
   return JSON.stringify(value, null, 2);
 }
 
+function schemaRequestHeaders() {
+  return {
+    accept: "application/json",
+    ...(API_KEY_ENV.trim() ? { Authorization: `Bearer ${API_KEY_ENV.trim()}` } : {}),
+  };
+}
+
 async function fetchSchema() {
   let resp;
   try {
-    resp = await fetch(URL_ENV, { headers: { accept: "application/json" } });
+    resp = await fetch(URL_ENV, { headers: schemaRequestHeaders() });
   } catch (err) {
     fail(
       `failed to GET ${URL_ENV}: ${err?.message ?? err}\n` +
@@ -57,7 +71,11 @@ async function fetchSchema() {
     );
   }
   if (!resp.ok) {
-    fail(`GET ${URL_ENV} returned ${resp.status} ${resp.statusText}`);
+    const authHint =
+      resp.status === 401 || resp.status === 403
+        ? "\nSet AGENT_BOM_GRAPH_SCHEMA_API_KEY, AGENT_BOM_CODEGEN_API_KEY, or AGENT_BOM_API_KEY for auth-on API instances."
+        : "";
+    fail(`GET ${URL_ENV} returned ${resp.status} ${resp.statusText}${authHint}`);
   }
   let data;
   try {

--- a/ui/tests/api-errors.test.ts
+++ b/ui/tests/api-errors.test.ts
@@ -15,6 +15,7 @@ import {
   ApiServerError,
   ApiValidationError,
   classifyApiResponse,
+  userFacingApiErrorMessage,
 } from "../lib/api-errors";
 
 function _resp(status: number, body: unknown, extraHeaders: Record<string, string> = {}): Response {
@@ -87,5 +88,12 @@ describe("classifyApiResponse", () => {
     expect(err.status).toBe(0);
     expect(err.statusText).toBe("network_error");
     expect((err as { cause?: unknown }).cause).toBe(cause);
+  });
+
+  it("maps raw browser header exceptions to a user-facing auth message", () => {
+    const err = new Error("The string did not match the expected pattern.");
+    expect(userFacingApiErrorMessage(err, "fallback")).toBe(
+      "Sign in with a valid API key before opening protected control-plane views.",
+    );
   });
 });

--- a/ui/tests/auth-gate.test.tsx
+++ b/ui/tests/auth-gate.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, afterEach } from "vitest";
 
 import { AuthGate } from "@/components/auth-gate";
@@ -66,5 +66,28 @@ describe("AuthGate", () => {
 
     await waitFor(() => expect(screen.getByText("Control-plane authentication required")).toBeInTheDocument());
     expect(screen.getByLabelText("API key")).toHaveValue("");
+  });
+
+  it("keeps the browser session submit disabled until an API key is entered", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      json: () => Promise.resolve({ detail: "Unauthorized — invalid API key" }),
+    }) as typeof fetch;
+
+    render(
+      <AuthProvider>
+        <AuthGate>
+          <div>protected surface</div>
+        </AuthGate>
+      </AuthProvider>,
+    );
+
+    const unlock = await screen.findByRole("button", { name: "Unlock dashboard" });
+    expect(unlock).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("API key"), { target: { value: "abk_test" } });
+    expect(unlock).toBeEnabled();
   });
 });


### PR DESCRIPTION
## Summary

This PR tightens the live audit findings from the dashboard/API readiness pass:

- reject unknown `POST /v1/scan` fields instead of silently dropping bad request keys
- apply the same strict scan validation to source-triggered scans
- refresh generated v1 schemas for the stricter `ScanRequest` contract
- replace raw browser/Auth header exceptions with a user-facing sign-in message
- block empty API-key unlock attempts in the dashboard
- preserve scan/CVE context from Security Graph and Lineage Graph into Findings links
- hydrate `/findings?scan=...` from graph snapshots when job detail is unavailable
- stabilize React Flow node types and handles so dense graphs do not produce runtime warnings
- dedupe graph agent filters and repeated security graph tags/chips
- add an API-key knob to graph schema codegen for auth-on instances
- bump Snowflake Native App and K8s image references to v0.86.1

## Root Cause

The audit found a few product-surface mismatches: scan requests were lenient while MCP tool args were strict, graph findings links lost snapshot context, protected graph views could surface raw DOM exceptions before auth, and generated/deployment surfaces had small release/auth drift.

## Validation

- `uv run pytest -q tests/test_api_endpoints.py tests/test_api_sources.py` -> 39 passed
- `PYTHONPATH=src uv run python scripts/generate_v1_schemas.py --check` -> passed
- `npm run typecheck` -> passed
- `npm run lint` -> passed
- `npm test -- --run` -> 28 files / 189 tests passed
- `npm run build` -> passed
- pre-commit hooks during commit: yaml/json/toml/eof/whitespace/private-key/conflict/line-ending/ruff/ruff-format/mypy/bandit/env-var drift passed where applicable
- Playwright live browser pass against local API/dashboard:
  - selected CVE rendered from `/findings?scan=...&cve=...`
  - no empty findings state
  - no failed/4xx requests
  - no console warnings/errors
  - dark/light graph screenshots captured locally

## Live Audit Notes

The fix-first Security Graph now behaves as the primary analyst queue. The full Lineage Graph remains the broader topology explorer: stable, filterable, and readable in both themes, but intentionally denser than the fix-first path view.
