### PR TITLE
Fix graph schema initialization race

### DIFF
--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -225,7 +225,7 @@ def _init_db(conn: sqlite3.Connection, *, backfill_legacy_tenants: bool = True) 
     row = conn.execute("SELECT version FROM graph_schema_version ORDER BY version DESC LIMIT 1").fetchone()
     if row is None:
         conn.execute(
-            "INSERT INTO graph_schema_version (version) VALUES (?)",
+            "INSERT OR IGNORE INTO graph_schema_version (version) VALUES (?)",
             (_GRAPH_SCHEMA_VERSION,),
         )
     existing_columns = {row["name"] for row in conn.execute("PRAGMA table_info(attack_paths)").fetchall()}

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -507,6 +507,30 @@ class TestGraphEndpointLogic:
         assert defaults["graph_filter_presets"] == "'default'"
         assert search_tenant["dflt_value"] is None
 
+    def test_sqlite_graph_schema_version_insert_tolerates_concurrent_initializer(self, tmp_path):
+        conn = sqlite3.connect(tmp_path / "schema-race.db")
+        conn.row_factory = sqlite3.Row
+        try:
+            conn.execute("CREATE TABLE graph_schema_version (version INTEGER PRIMARY KEY)")
+            conn.execute(
+                """
+                CREATE TRIGGER concurrent_schema_initializer
+                BEFORE INSERT ON graph_schema_version
+                WHEN NOT EXISTS (SELECT 1 FROM graph_schema_version WHERE version = NEW.version)
+                BEGIN
+                  INSERT INTO graph_schema_version (version) VALUES (NEW.version);
+                END
+                """
+            )
+
+            _init_db(conn)
+
+            rows = conn.execute("SELECT version FROM graph_schema_version").fetchall()
+        finally:
+            conn.close()
+
+        assert len(rows) == 1
+
     def test_sqlite_graph_store_search_applies_slice_filters(self, tmp_path):
         store = SQLiteGraphStore(tmp_path / "graph.db")
         graph = UnifiedGraph(scan_id="search-scan", tenant_id="default")


### PR DESCRIPTION
## Summary

Fixes the main-branch CI regression where SQLite graph persistence can fail during schema initialization:

- make the `graph_schema_version` marker insert idempotent with `INSERT OR IGNORE`
- add a regression test that simulates a competing initializer inserting the same schema version between the empty read and our insert

## Root Cause

The CI failure in #2317 showed graph persistence failing before the tenant-isolation assertion:

- `UNIQUE constraint failed: graph_schema_version.version`
- followed by pushed-result graph persistence failing with `database is locked`

`_init_db()` performed a read-then-insert for the schema marker. If another connection initialized the same SQLite DB in the small window between those operations, the second insert could raise a unique constraint failure and poison the graph persistence path.

## Validation

- `uv run pytest -q tests/test_graph_api.py::TestGraphEndpointLogic::test_sqlite_graph_schema_version_insert_tolerates_concurrent_initializer tests/test_api_tenant_isolation.py::test_receive_push_normalizes_report_contract_and_persists_graph --tb=short` -> 2 passed
- `uv run pytest -q tests/test_graph_api.py tests/test_api_tenant_isolation.py --tb=short` -> 83 passed, 1 existing runtime warning
- `uv run ruff check src/agent_bom/db/graph_store.py tests/test_graph_api.py` -> passed
- `uv run mypy src/agent_bom/db/graph_store.py` -> passed
- pre-commit hooks during commit passed where applicable

Closes #2317.
