### PR TITLE
Fix first-run sample target alias

### DIFF
--- a/src/agent_bom/cli/_samples.py
+++ b/src/agent_bom/cli/_samples.py
@@ -16,8 +16,10 @@ def samples_group() -> None:
 
 @samples_group.command("first-run")
 @click.option(
+    "--target",
     "--output",
     "-o",
+    "output",
     type=click.Path(file_okay=False, path_type=Path),
     default=Path("agent-bom-first-run"),
     show_default=True,

--- a/tests/test_first_run_sample.py
+++ b/tests/test_first_run_sample.py
@@ -80,3 +80,12 @@ def test_samples_first_run_cli_writes_next_command(tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert "agent-bom agents --inventory" in result.output
     assert (target / "inventory.json").exists()
+
+
+def test_samples_first_run_cli_accepts_target_alias(tmp_path: Path) -> None:
+    target = tmp_path / "sample"
+    result = CliRunner().invoke(main, ["samples", "first-run", "--target", str(target)])
+
+    assert result.exit_code == 0
+    assert "agent-bom agents --inventory" in result.output
+    assert (target / "inventory.json").exists()


### PR DESCRIPTION
Summary
- accept `--target` as an alias for `agent-bom samples first-run --output`
- keep the existing `--output/-o` flags compatible
- add a regression test for the user-facing `--target` onboarding path

Root Cause
The first-run sample command exposed `--output`, while some onboarding and audit notes referred to `--target`. That made the first-run CLI feel inconsistent even though both names describe the destination directory.

Validation
- `uv run pytest -q tests/test_first_run_sample.py --tb=short` -> 7 passed
- `uv run ruff check src/agent_bom/cli/_samples.py tests/test_first_run_sample.py` -> passed
- pre-commit hooks during commit passed where applicable

Closes the P3 first-run flag inconsistency from the readiness audit.
