### PR TITLE
Fix gateway upstream transport guardrails

### DIFF
--- a/deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml
+++ b/deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml
@@ -28,6 +28,13 @@
 #                           header on every upstream request
 #   auth: oauth2_client_credentials  (roadmap — see MULTI_MCP_GATEWAY.md)
 #
+# ── Supported upstream transport ─────────────────────────────────────────────
+#   transport: streamable-http  — JSON-RPC over HTTP POST. This is the only
+#                                 upstream relay transport the gateway supports.
+#   Legacy SSE `/sse` upstream endpoints are intentionally rejected; use the
+#   upstream server's streamable-http `/mcp` endpoint, or run a per-MCP proxy
+#   for SSE.
+#
 # Replace the three examples below with your real MCP inventory.
 
 upstreams:
@@ -35,7 +42,8 @@ upstreams:
   # vendor) behind an internal ingress. The gateway injects the bearer
   # token from a Secret; the laptop never holds it.
   - name: jira
-    url: https://mcp.jira.example.com/sse
+    url: https://mcp.jira.example.com/mcp
+    transport: streamable-http
     auth: bearer
     token_env: JIRA_MCP_TOKEN
 
@@ -45,6 +53,7 @@ upstreams:
   # Snowflake's IdP automatically.
   - name: snowflake
     url: https://snowflake.example.internal/mcp/cortex
+    transport: streamable-http
     auth: oauth2_client_credentials
     oauth_token_url: https://snowflake.example.internal/oauth/token
     oauth_client_id_env: SNOWFLAKE_OAUTH_CLIENT_ID
@@ -53,7 +62,8 @@ upstreams:
 
   # EXAMPLE 3 — A remote GitHub MCP server behind an internal ingress.
   - name: github
-    url: https://mcp.github.example.com/sse
+    url: https://mcp.github.example.com/mcp
+    transport: streamable-http
     auth: bearer
     token_env: GITHUB_MCP_TOKEN
 

--- a/docs/design/MULTI_MCP_GATEWAY.md
+++ b/docs/design/MULTI_MCP_GATEWAY.md
@@ -19,7 +19,7 @@ Add a new CLI mode: `agent-bom gateway serve`.
 
 One FastAPI service that:
 
-1. Accepts MCP client connections (HTTP + SSE, Streamable HTTP transport).
+1. Accepts MCP client connections over HTTP JSON-RPC / streamable HTTP request-response.
 2. Routes each client connection to one of N configured upstream MCP servers (local or remote), keyed by server name.
 3. Applies gateway policy (from the existing `/v1/gateway/policies` store) inline, on every `tools/call`, `tools/list`, `resources/read`, `prompts/get`.
 4. Pushes every call into the existing HMAC-chained audit log via the existing `/v1/proxy/audit` contract.
@@ -27,7 +27,7 @@ One FastAPI service that:
 
 Non-goals (explicitly):
 
-- Proxying **stdio** MCPs — clients that only speak stdio still use per-MCP `agent-bom proxy` wrappers. This gateway is HTTP/SSE-only.
+- Proxying **stdio** MCPs — clients that only speak stdio still use per-MCP `agent-bom proxy` wrappers. This gateway is HTTP/streamable-http only.
 - A new transport or policy language. Re-uses `GatewayPolicy` + `check_policy` from [`src/agent_bom/gateway.py`](../../src/agent_bom/gateway.py).
 - Replacing the sidecar mode. Both modes coexist; teams pick per workload.
 
@@ -52,16 +52,24 @@ agent-bom gateway serve \
 upstreams:
   - name: jira
     url: https://snowflake.example.internal/mcp/jira
+    transport: streamable-http
     auth: oauth2_client_credentials
     scopes: ["jira.read"]
   - name: github
-    url: https://mcp.github.example.com/sse
+    url: https://mcp.github.example.com/mcp
+    transport: streamable-http
     auth: bearer
     token_env: GITHUB_MCP_TOKEN
   - name: filesystem-review-env
     url: http://review-fs.agent-bom-workloads.svc.cluster.local:8100
+    transport: streamable-http
     auth: none
 ```
+
+The upstream transport field defaults to `streamable-http`. `http` and `https`
+are accepted as legacy aliases. `sse` and URLs whose path ends in `/sse` are
+rejected at gateway config load because the relay POSTs JSON-RPC and does not
+maintain a persistent SSE upstream client.
 
 ### Client config
 
@@ -72,7 +80,7 @@ Laptop editors point at **one** URL for every MCP, using the gateway's server-ro
 {
   "mcpServers": {
     "gateway": {
-      "transport": "sse",
+      "transport": "http",
       "url": "https://agent-bom-gateway.example.com/mcp/{server-name}",
       "headers": { "Authorization": "Bearer ${AGENT_BOM_USER_TOKEN}" }
     }
@@ -102,7 +110,7 @@ flowchart LR
     fs["Filesystem MCP in EKS"]
   end
 
-  Laptops -- SSE / Streamable HTTP --> gw
+  Laptops -- Streamable HTTP --> gw
   gw -. pull every 30s .- policy
   gw -. push every 10s .- audit
   gw -. scrape .- metrics
@@ -127,7 +135,7 @@ flowchart LR
 
 Net new code:
 
-- `src/agent_bom/gateway_server.py` — the FastAPI app, upstream registry, per-connection SSE relay
+- `src/agent_bom/gateway_server.py` — the FastAPI app, upstream registry, HTTP JSON-RPC relay
 - `src/agent_bom/cli/gateway.py` — `agent-bom gateway serve` entry point
 - `src/agent_bom/gateway_upstreams.py` — upstream config loader + auth injector
 - `tests/test_gateway_server.py` — real upstream + real policy + TestClient integration
@@ -147,17 +155,18 @@ Net new code:
 |---|---|---|
 | p50 added latency per `tools/call` | < 15 ms | existing proxy benchmarks |
 | p99 added latency | < 60 ms | |
-| Concurrent clients per pod | 500 SSE connections | FastAPI + uvloop |
+| Concurrent clients per pod | 500 request-response clients | FastAPI + uvloop |
 | Policy refresh staleness | < 45 s (30 s pull + 15 s slack) | `policy_refresh_seconds` |
 | Audit push queue backlog | alerts at > 10k events | `AuditDeliveryController` DLQ |
 
-Horizontal scale via HPA; session affinity needed on ingress (SSE is long-lived).
+Horizontal scale via HPA; no upstream SSE stickiness is required because the
+gateway relay is streamable-http request/response only.
 
 ## Rollout plan
 
 1. **Day 1 (merge of this doc):** design published; pilot team can read the target architecture.
 2. **Day 2–3:** extract policy-fetch + audit-push helpers from `run_proxy` into shared modules. Land with existing proxy still working (regression guard).
-3. **Day 4–5:** `agent-bom gateway serve` MVP — HTTP/SSE, 1 upstream, policy + audit + metrics wired.
+3. **Day 4–5:** `agent-bom gateway serve` MVP — streamable HTTP, 1 upstream, policy + audit + metrics wired.
 4. **Day 6:** N upstreams, per-upstream auth injection, upstream config hot-reload.
 5. **Day 7:** Helm chart `gateway` Deployment + HPA + NetworkPolicy + PrometheusRule + Grafana panel.
 6. **Day 8:** pilot team installs, points editors at the gateway URL, validates policy enforcement on a SaaS MCP (Jira or GitHub) and a Snowflake-hosted MCP (Cortex function).
@@ -168,4 +177,4 @@ Every stage is behind a flag until the gateway-serve tests and the pilot team si
 
 - **Upstream auth refresh**: OAuth2 client-credentials token rotation schedule. Day-1 answer: per-upstream auth policy in the config; background refresher with 80% jitter.
 - **Client authentication**: do we require a per-user token (OIDC), a per-tenant API key, or both? Day-1 answer: per-user OIDC for laptop traffic, per-service API key for machine-to-machine.
-- **Snowflake-hosted MCP specifics**: Snowflake MCPs today expose HTTP/SSE endpoints via Cortex functions or container services, authenticated against the Snowflake IdP. We assume stock MCP over HTTPS and support OAuth2 client-credentials at the gateway — the `snowflake` example in `gateway-upstreams.example.yaml` is the shape.
+- **Snowflake-hosted MCP specifics**: Snowflake MCPs should expose streamable HTTP endpoints via Cortex functions or container services, authenticated against the Snowflake IdP. We assume stock MCP over HTTPS and support OAuth2 client-credentials at the gateway — the `snowflake` example in `gateway-upstreams.example.yaml` is the shape. Legacy SSE upstream endpoints are not supported by this gateway relay.

--- a/site-docs/deployment/gateway-auto-discovery.md
+++ b/site-docs/deployment/gateway-auto-discovery.md
@@ -29,8 +29,10 @@ That endpoint aggregates tenant-scoped remote MCP servers already surfaced by:
 
 Important boundaries:
 
-- only remote `http` / `https` / `sse` upstreams are returned
+- only remote streamable HTTP upstreams are returned
 - `stdio` MCPs are intentionally excluded
+- legacy SSE `/sse` upstreams are intentionally excluded because the gateway
+  POSTs JSON-RPC upstream and does not run a persistent SSE upstream client
 - discovered upstreams always come back with `auth: "none"`
 - credentials stay in Secrets and are overlaid locally through `--upstreams`
 
@@ -40,7 +42,7 @@ You need:
 
 1. a control plane with discovered MCP servers for the tenant
 2. a gateway bearer token or API key that can read the discovery endpoint
-3. remote MCPs that actually expose HTTP/SSE transport
+3. remote MCPs that expose streamable HTTP transport
 
 ## Minimal worked example
 
@@ -70,7 +72,8 @@ Example overlay:
 ```yaml
 upstreams:
   - name: github
-    url: https://mcp.github.example.com/sse
+    url: https://mcp.github.example.com/mcp
+    transport: streamable-http
     auth: bearer
     token_env: GITHUB_MCP_TOKEN
 ```
@@ -95,7 +98,7 @@ Expected response shape:
     {
       "name": "jira",
       "url": "https://mcp.example.internal/jira",
-      "transport": "sse",
+      "transport": "streamable-http",
       "auth": "none",
       "source_agents": ["mac-laptop-1", "windows-laptop-3"]
     }

--- a/src/agent_bom/api/routes/gateway.py
+++ b/src/agent_bom/api/routes/gateway.py
@@ -25,6 +25,7 @@ from fastapi.responses import JSONResponse, Response
 
 from agent_bom.api.models import EvaluateRequest, JobStatus, PolicyCreate, PolicyUpdate
 from agent_bom.api.stores import _get_policy_store, _get_store
+from agent_bom.gateway_upstreams import is_gateway_compatible_upstream_transport
 from agent_bom.rbac import require_authenticated_permission
 
 if TYPE_CHECKING:
@@ -331,9 +332,11 @@ async def discovered_upstreams(request: Request) -> dict:
 
     Aggregates every MCP server surfaced by the fleet-scan path (pushed
     via ``/v1/fleet/sync`` or returned from in-cluster scans) that has a
-    real HTTP(S) URL — i.e. something a multi-MCP gateway can actually
-    front. stdio servers are excluded because they only make sense as a
-    per-workload sidecar / wrapper (``agent-bom proxy -- <cmd>``).
+    streamable HTTP URL — i.e. something this multi-MCP gateway can
+    relay with JSON-RPC-over-HTTP POST. stdio servers are excluded because
+    they only make sense as a per-workload sidecar / wrapper
+    (``agent-bom proxy -- <cmd>``); legacy SSE endpoints are excluded
+    because the gateway does not maintain persistent upstream SSE clients.
 
     Response shape matches the ``upstreams.yaml`` the gateway consumes,
     so a gateway pod can pull this endpoint at startup and every N
@@ -348,7 +351,7 @@ async def discovered_upstreams(request: Request) -> dict:
           "tenant_id": "...",
           "source": "fleet_scan_aggregate",
           "upstreams": [
-            {"name": "jira", "url": "https://...", "transport": "sse",
+            {"name": "jira", "url": "https://...", "transport": "streamable-http",
              "auth": "none", "source_agents": ["agent-a", ...]},
             ...
           ]
@@ -378,20 +381,22 @@ async def discovered_upstreams(request: Request) -> dict:
             agent_name = agent.get("name") or agent.get("agent_name") or ""
             for server in agent.get("servers") or []:
                 url = server.get("url") or ""
-                if not url.startswith(("http://", "https://")):
-                    # Skip stdio MCPs — they're per-workload sidecar territory.
-                    continue
                 name = server.get("name") or ""
                 if not name:
                     continue
                 transport = server.get("transport") or "http"
+                if not is_gateway_compatible_upstream_transport(transport, url):
+                    # Skip stdio and SSE MCPs. The gateway upstream relay is
+                    # streamable-http only; SSE requires a persistent upstream
+                    # event client that this relay intentionally does not run.
+                    continue
                 key = (name, url)
                 record = by_key.setdefault(
                     key,
                     {
                         "name": name,
                         "url": url,
-                        "transport": transport,
+                        "transport": "streamable-http",
                         "auth": "none",
                         "source_agents": [],
                     },

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -81,7 +81,7 @@ def gateway_group() -> None:
     help=(
         "Pull auto-discovered upstreams from this agent-bom control plane URL "
         "(hits /v1/gateway/upstreams/discovered). Fleet scans surface remote "
-        "HTTP/SSE MCPs into this endpoint — the gateway registers whatever the "
+        "streamable HTTP MCPs into this endpoint — the gateway registers whatever the "
         "fleet has discovered, so pilot teams don't start from a blank YAML."
     ),
 )

--- a/src/agent_bom/gateway_upstreams.py
+++ b/src/agent_bom/gateway_upstreams.py
@@ -21,6 +21,7 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 import yaml
 
@@ -32,6 +33,8 @@ class UpstreamConfigError(ValueError):
 
 
 SUPPORTED_AUTH_MODES: tuple[str, ...] = ("none", "bearer", "oauth2_client_credentials")
+SUPPORTED_UPSTREAM_TRANSPORTS: tuple[str, ...] = ("streamable-http",)
+_STREAMABLE_HTTP_ALIASES: frozenset[str] = frozenset({"http", "https", "streamable-http"})
 
 
 # Process-wide cache for OAuth2 client-credentials access tokens. Keyed by
@@ -85,7 +88,12 @@ class UpstreamConfig:
     name:
         Stable identifier used in request routing (``/mcp/{name}``).
     url:
-        Base URL of the upstream MCP server. Must be HTTPS in production.
+        Streamable HTTP JSON-RPC endpoint of the upstream MCP server. Must be
+        HTTPS in production. Legacy SSE ``/sse`` event endpoints are not
+        supported by the gateway relay.
+    transport:
+        Upstream transport. The gateway currently supports only
+        ``streamable-http``; ``http``/``https`` are accepted as legacy aliases.
     auth:
         One of ``SUPPORTED_AUTH_MODES`` — ``none``, ``bearer``, or
         ``oauth2_client_credentials``.
@@ -104,6 +112,7 @@ class UpstreamConfig:
 
     name: str
     url: str
+    transport: str = "streamable-http"
     tenant_id: str | None = None
     auth: str = "none"
     token_env: str | None = None
@@ -112,6 +121,15 @@ class UpstreamConfig:
     oauth_client_secret_env: str | None = None
     oauth_scopes: tuple[str, ...] = ()
     headers: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        transport = normalize_gateway_upstream_transport(
+            self.transport,
+            url=self.url,
+            source="upstream config",
+            name=self.name,
+        )
+        object.__setattr__(self, "transport", transport)
 
     def resolved_static_headers(self) -> dict[str, str]:
         """Return the per-upstream static headers with bearer tokens resolved from env.
@@ -345,6 +363,50 @@ def fetch_discovered_upstreams(
     return response.json()
 
 
+def _is_sse_endpoint_url(url: str) -> bool:
+    path = urlsplit(url).path.rstrip("/")
+    return bool(path) and path.rsplit("/", 1)[-1].lower() == "sse"
+
+
+def normalize_gateway_upstream_transport(
+    raw_transport: Any,
+    *,
+    url: str,
+    source: str,
+    name: str,
+) -> str:
+    """Normalize and validate gateway upstream transport declarations."""
+    raw_value = getattr(raw_transport, "value", raw_transport)
+    transport = "streamable-http" if raw_value is None else str(raw_value).strip().lower()
+    if transport in _STREAMABLE_HTTP_ALIASES:
+        if _is_sse_endpoint_url(url):
+            raise UpstreamConfigError(
+                f"{source}: upstream {name!r} points at SSE endpoint {url!r}; "
+                "gateway upstream relay supports streamable-http JSON-RPC endpoints only. "
+                "Use the upstream's streamable-http /mcp endpoint, or run a per-MCP proxy for SSE."
+            )
+        return "streamable-http"
+    if transport == "sse":
+        raise UpstreamConfigError(
+            f"{source}: upstream {name!r} uses transport='sse'; gateway upstream relay supports "
+            "streamable-http JSON-RPC endpoints only and does not maintain persistent SSE upstream clients."
+        )
+    raise UpstreamConfigError(
+        f"{source}: upstream {name!r} has unsupported transport={transport!r} — supported: {', '.join(SUPPORTED_UPSTREAM_TRANSPORTS)}"
+    )
+
+
+def is_gateway_compatible_upstream_transport(transport: Any, url: str) -> bool:
+    """Return True when a discovered remote MCP can be relayed by the gateway."""
+    if not isinstance(url, str) or not url.startswith(("http://", "https://")):
+        return False
+    try:
+        normalize_gateway_upstream_transport(transport, url=url, source="gateway discovery", name="upstream")
+    except UpstreamConfigError:
+        return False
+    return True
+
+
 def _parse_upstream(raw: Any, *, source: str, default_tenant_id: str | None = None) -> UpstreamConfig:
     if not isinstance(raw, dict):
         raise UpstreamConfigError(f"{source}: every upstream entry must be a mapping, got {type(raw).__name__}")
@@ -356,6 +418,14 @@ def _parse_upstream(raw: Any, *, source: str, default_tenant_id: str | None = No
     url = raw.get("url")
     if not isinstance(url, str) or not url.startswith(("http://", "https://")):
         raise UpstreamConfigError(f"{source}: upstream {name!r} requires an http(s) 'url'")
+    url = url.rstrip("/")
+
+    transport = normalize_gateway_upstream_transport(
+        raw.get("transport"),
+        url=url,
+        source=source,
+        name=name,
+    )
 
     auth = raw.get("auth", "none")
     if auth not in SUPPORTED_AUTH_MODES:
@@ -377,7 +447,8 @@ def _parse_upstream(raw: Any, *, source: str, default_tenant_id: str | None = No
 
     return UpstreamConfig(
         name=name,
-        url=url.rstrip("/"),
+        url=url,
+        transport=transport,
         tenant_id=tenant_id,
         auth=auth,
         token_env=raw.get("token_env"),

--- a/tests/test_gateway_auth_tenant_e2e.py
+++ b/tests/test_gateway_auth_tenant_e2e.py
@@ -90,7 +90,7 @@ def pilot_fleet():
         store,
         "tenant-alpha",
         servers=[
-            {"name": "jira", "url": "https://mcp.jira.example.com/sse", "transport": "sse"},
+            {"name": "jira", "url": "https://mcp.jira.example.com/mcp", "transport": "streamable-http"},
             {"name": "internal", "url": "http://mcp.internal.svc.cluster.local:8100", "transport": "http"},
         ],
     )
@@ -149,7 +149,7 @@ def test_full_pilot_flow_auth_tenant_discovery_relay_policy_audit_metrics(pilot_
             [
                 UpstreamConfig(
                     name="jira",
-                    url="https://mcp.jira.example.com/sse",
+                    url="https://mcp.jira.example.com/mcp",
                     auth="bearer",
                     token_env="JIRA_MCP_TOKEN",
                 )

--- a/tests/test_gateway_upstream_discovery_route.py
+++ b/tests/test_gateway_upstream_discovery_route.py
@@ -3,10 +3,10 @@
 The gateway auto-discovery path — pilot teams don't hand-author a blank
 upstreams.yaml; they let fleet scans surface remote MCPs and the gateway
 pulls them from this endpoint. This test seeds real ScanJob results
-with mixed local (stdio) + remote (HTTP/SSE) MCPs and verifies that:
+with mixed local (stdio) + remote MCPs and verifies that:
 
-- Only HTTP/SSE servers come back (stdio excluded — those are per-MCP
-  sidecar territory).
+- Only streamable HTTP servers come back (stdio and SSE excluded — those
+  are per-MCP sidecar/proxy territory).
 - Each discovered upstream reports the agents that surfaced it.
 - Tenant scoping holds — tenant-alpha never sees tenant-beta's
   discoveries.
@@ -69,7 +69,7 @@ def fleet_seeded():
         "tenant-alpha",
         agent_name="mac-laptop-1",
         servers=[
-            {"name": "jira", "url": "https://snowflake.example.internal/mcp/jira", "transport": "sse"},
+            {"name": "jira", "url": "https://snowflake.example.internal/mcp/jira", "transport": "streamable-http"},
             {"name": "filesystem", "url": None, "transport": "stdio"},  # stdio — excluded
         ],
     )
@@ -78,8 +78,8 @@ def fleet_seeded():
         "tenant-alpha",
         agent_name="windows-laptop-3",
         servers=[
-            {"name": "jira", "url": "https://snowflake.example.internal/mcp/jira", "transport": "sse"},
-            {"name": "github", "url": "https://mcp.github.example.com/sse", "transport": "sse"},
+            {"name": "jira", "url": "https://snowflake.example.internal/mcp/jira", "transport": "streamable-http"},
+            {"name": "github", "url": "https://mcp.github.example.com/mcp", "transport": "http"},
         ],
     )
 
@@ -117,6 +117,7 @@ def test_discovered_upstreams_returns_remote_mcps_only(fleet_seeded) -> None:
     assert sorted(names) == ["github", "jira"]  # filesystem (stdio) excluded
     for u in body["upstreams"]:
         assert u["url"].startswith(("http://", "https://"))
+        assert u["transport"] == "streamable-http"
         assert u["auth"] == "none"
 
 
@@ -154,7 +155,7 @@ def test_discovered_upstreams_reports_name_collisions_and_renames(monkeypatch: p
         store,
         "tenant-alpha",
         agent_name="team-a-laptop",
-        servers=[{"name": "jira", "url": "https://mcp.jira.example.com/sse", "transport": "sse"}],
+        servers=[{"name": "jira", "url": "https://mcp.jira.example.com/mcp", "transport": "http"}],
     )
     _seed_scan_with_servers(
         store,
@@ -199,6 +200,28 @@ def test_discovered_upstreams_returns_empty_when_fleet_has_no_remote_mcps() -> N
     set_job_store(store)
     try:
         resp = _client_for("tenant-stdio-only").get("/v1/gateway/upstreams/discovered")
+        assert resp.status_code == 200
+        assert resp.json()["upstreams"] == []
+    finally:
+        _stores._store = prev
+
+
+def test_discovered_upstreams_excludes_sse_endpoints() -> None:
+    """SSE upstreams would 405 on POST; discovery must not feed them to the gateway."""
+    store = InMemoryJobStore()
+    _seed_scan_with_servers(
+        store,
+        "tenant-sse-only",
+        agent_name="laptop",
+        servers=[
+            {"name": "legacy-sse", "url": "https://mcp.example.com/sse", "transport": "sse"},
+            {"name": "sse-path", "url": "https://mcp.example.com/sse", "transport": "http"},
+        ],
+    )
+    prev = _stores._store
+    set_job_store(store)
+    try:
+        resp = _client_for("tenant-sse-only").get("/v1/gateway/upstreams/discovered")
         assert resp.status_code == 200
         assert resp.json()["upstreams"] == []
     finally:

--- a/tests/test_gateway_upstreams.py
+++ b/tests/test_gateway_upstreams.py
@@ -11,6 +11,7 @@ from agent_bom.gateway_upstreams import (
     UpstreamConfigError,
     UpstreamRegistry,
 )
+from agent_bom.models import TransportType
 
 
 def _write_yaml(tmp_path: Path, content: str) -> Path:
@@ -44,7 +45,7 @@ def test_from_yaml_multiple_upstreams_routable_by_name(tmp_path: Path) -> None:
           - name: jira
             url: https://snowflake.example.internal/mcp/jira
           - name: github
-            url: https://mcp.github.example.com/sse
+            url: https://mcp.github.example.com/mcp
             auth: bearer
             token_env: GITHUB_MCP_TOKEN
         """,
@@ -62,7 +63,7 @@ def test_bearer_auth_resolves_token_from_env(tmp_path: Path, monkeypatch: pytest
         """
         upstreams:
           - name: github
-            url: https://mcp.github.example.com/sse
+            url: https://mcp.github.example.com/mcp
             auth: bearer
             token_env: GITHUB_MCP_TOKEN
         """,
@@ -81,7 +82,7 @@ def test_bearer_auth_missing_token_env_raises(tmp_path: Path, monkeypatch: pytes
         """
         upstreams:
           - name: github
-            url: https://mcp.github.example.com/sse
+            url: https://mcp.github.example.com/mcp
             auth: bearer
             token_env: MISSING_TOKEN_VAR
         """,
@@ -140,13 +141,66 @@ def test_unsupported_auth_rejected(tmp_path: Path) -> None:
         UpstreamRegistry.from_yaml(path)
 
 
+def test_sse_transport_rejected_with_clear_gateway_error(tmp_path: Path) -> None:
+    path = _write_yaml(
+        tmp_path,
+        """
+        upstreams:
+          - name: legacy-sse
+            url: https://mcp.example.com/sse
+            transport: sse
+        """,
+    )
+    with pytest.raises(UpstreamConfigError, match="streamable-http JSON-RPC endpoints only"):
+        UpstreamRegistry.from_yaml(path)
+
+
+def test_sse_endpoint_path_rejected_even_without_transport_field(tmp_path: Path) -> None:
+    path = _write_yaml(
+        tmp_path,
+        """
+        upstreams:
+          - name: legacy-sse
+            url: https://mcp.example.com/sse
+        """,
+    )
+    with pytest.raises(UpstreamConfigError, match="points at SSE endpoint"):
+        UpstreamRegistry.from_yaml(path)
+
+
+def test_direct_upstream_config_rejects_sse_endpoint_before_relay() -> None:
+    with pytest.raises(UpstreamConfigError, match="points at SSE endpoint"):
+        UpstreamConfig(name="legacy-sse", url="https://mcp.example.com/sse")
+
+
+def test_http_transport_alias_normalizes_to_streamable_http(tmp_path: Path) -> None:
+    path = _write_yaml(
+        tmp_path,
+        """
+        upstreams:
+          - name: github
+            url: https://mcp.github.example.com/mcp
+            transport: http
+        """,
+    )
+    registry = UpstreamRegistry.from_yaml(path)
+    upstream = registry.get("github")
+    assert upstream is not None
+    assert upstream.transport == "streamable-http"
+
+
+def test_transport_enum_normalizes_to_streamable_http() -> None:
+    upstream = UpstreamConfig(name="github", url="https://mcp.github.example.com/mcp", transport=TransportType.STREAMABLE_HTTP)
+    assert upstream.transport == "streamable-http"
+
+
 def test_static_headers_resolved_alongside_bearer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     path = _write_yaml(
         tmp_path,
         """
         upstreams:
           - name: github
-            url: https://mcp.github.example.com/sse
+            url: https://mcp.github.example.com/mcp
             auth: bearer
             token_env: GH_TOKEN
             headers:
@@ -171,12 +225,13 @@ def test_from_discovery_response_builds_registry_with_none_auth() -> None:
         "source": "fleet_scan_aggregate",
         "upstreams": [
             {"name": "jira", "url": "https://snowflake.example.internal/mcp/jira", "auth": "none"},
-            {"name": "github", "url": "https://mcp.github.example.com/sse", "auth": "none"},
+            {"name": "github", "url": "https://mcp.github.example.com/mcp", "transport": "streamable-http", "auth": "none"},
         ],
     }
     registry = UpstreamRegistry.from_discovery_response(payload)
     assert registry.names() == ["github", "jira"]
     assert registry.get("jira").auth == "none"  # type: ignore[union-attr]
+    assert registry.get("github").transport == "streamable-http"  # type: ignore[union-attr]
     # Discovery doesn't know bearer tokens — operator overlays them
     assert registry.get("jira").token_env is None  # type: ignore[union-attr]
 


### PR DESCRIPTION
Summary
- fail closed when gateway upstream config points at legacy SSE transport or `/sse` endpoints
- normalize `http`/`https` upstream transport aliases to `streamable-http`
- filter SSE discoveries out of `/v1/gateway/upstreams/discovered` so the gateway does not register endpoints that would 405 on JSON-RPC POST
- refresh gateway docs, Helm example config, and auto-discovery docs to describe streamable HTTP upstream-only behavior

Root Cause
The gateway upstream relay is request/response JSON-RPC over HTTP POST. Legacy MCP SSE endpoints expose a server-sent event stream and do not accept POST on `/sse`, so registering those endpoints led to runtime `405 Method Not Allowed` upstream failures instead of an operator-facing configuration error.

Validation
- `uv run pytest -q tests/test_gateway_upstreams.py tests/test_gateway_upstream_discovery_route.py tests/test_gateway_auth_tenant_e2e.py tests/test_gateway_server.py --tb=short` -> 73 passed
- `uv run pytest -q tests/test_control_plane_contracts.py tests/test_api_gateway.py --tb=short` -> 26 passed
- `uv run ruff check src/agent_bom/gateway_upstreams.py src/agent_bom/api/routes/gateway.py src/agent_bom/cli/_gateway.py tests/test_gateway_upstreams.py tests/test_gateway_upstream_discovery_route.py tests/test_gateway_auth_tenant_e2e.py` -> passed
- pre-commit hooks during commit passed where applicable

Closes the gateway SSE upstream relay readiness finding.
