### PR TITLE
Fix graph API serialization readiness

### DIFF
--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -1290,8 +1290,7 @@ class SQLiteGraphStore:
                 SELECT source_id, target_id, relationship, direction, weight, traversable, first_seen, last_seen, evidence, activity_id
                 FROM graph_edges
                 WHERE tenant_id = ? AND scan_id = ?
-                  AND source_id IN ({placeholders})
-                  AND target_id IN ({placeholders})
+                  AND (source_id IN ({placeholders}) OR target_id IN ({placeholders}))
                 """,  # nosec B608 - placeholders are generated solely from "?" markers
                 [tenant_id, effective_scan_id, *node_ids, *node_ids],
             ).fetchall()

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -993,18 +993,38 @@ class PostgresGraphStore:
 
     def diff_snapshots(self, scan_id_old: str, scan_id_new: str, *, tenant_id: str = "") -> dict[str, Any]:
         tenant_id = normalize_graph_tenant_id(tenant_id)
+
+        def node_metadata(row) -> dict[str, Any]:
+            return {
+                "id": row[0],
+                "entity_type": row[1],
+                "label": row[2],
+                "status": row[3] or "",
+                "severity": row[4] or "",
+                "severity_id": int(row[5] or 0),
+                "risk_score": float(row[6] or 0.0),
+            }
+
         with _tenant_connection(self._pool) as conn:
             old_nodes = {
-                row[0]: {"severity": row[1], "risk_score": row[2]}
+                row[0]: node_metadata(row)
                 for row in conn.execute(
-                    "SELECT id, severity, risk_score FROM graph_nodes WHERE scan_id = %s AND tenant_id = %s",
+                    """
+                    SELECT id, entity_type, label, status, severity, severity_id, risk_score
+                    FROM graph_nodes
+                    WHERE scan_id = %s AND tenant_id = %s
+                    """,
                     (scan_id_old, tenant_id),
                 ).fetchall()
             }
             new_nodes = {
-                row[0]: {"severity": row[1], "risk_score": row[2]}
+                row[0]: node_metadata(row)
                 for row in conn.execute(
-                    "SELECT id, severity, risk_score FROM graph_nodes WHERE scan_id = %s AND tenant_id = %s",
+                    """
+                    SELECT id, entity_type, label, status, severity, severity_id, risk_score
+                    FROM graph_nodes
+                    WHERE scan_id = %s AND tenant_id = %s
+                    """,
                     (scan_id_new, tenant_id),
                 ).fetchall()
             }
@@ -1024,8 +1044,8 @@ class PostgresGraphStore:
                 ).fetchall()
             }
             return {
-                "nodes_added": sorted(new_ids - old_ids),
-                "nodes_removed": sorted(old_ids - new_ids),
+                "nodes_added": [new_nodes[nid] for nid in sorted(new_ids - old_ids)],
+                "nodes_removed": [old_nodes[nid] for nid in sorted(old_ids - new_ids)],
                 "nodes_changed": sorted(nid for nid in (old_ids & new_ids) if old_nodes[nid] != new_nodes[nid]),
                 "edges_added": sorted(new_edges - old_edges),
                 "edges_removed": sorted(old_edges - new_edges),
@@ -1258,8 +1278,7 @@ class PostgresGraphStore:
                 SELECT source_id, target_id, relationship, direction, weight, traversable, first_seen, last_seen, evidence, activity_id
                 FROM graph_edges
                 WHERE tenant_id = %s AND scan_id = %s
-                  AND source_id IN ({placeholders})
-                  AND target_id IN ({placeholders})
+                  AND (source_id IN ({placeholders}) OR target_id IN ({placeholders}))
                 """,  # nosec B608 - placeholders are generated solely from "%s" markers
                 [tenant_id, effective_scan_id, *node_ids, *node_ids],
             ).fetchall()

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -130,6 +130,12 @@ def _parse_relationship_filter(raw: str | None) -> set[RelationshipType]:
     return parsed
 
 
+def _coalesce_alias(primary: str | None, alias: str | None, *, primary_name: str, alias_name: str) -> str:
+    if primary and alias and primary != alias:
+        raise HTTPException(status_code=422, detail=f"Conflicting query parameters: {primary_name} and {alias_name}")
+    return primary or alias or ""
+
+
 def _validate_relationship_list(values: list[str]) -> set[RelationshipType] | None:
     if not values:
         return None
@@ -381,6 +387,31 @@ def _rel_value(edge) -> str:
     return edge.relationship.value if hasattr(edge.relationship, "value") else str(edge.relationship)
 
 
+def _edge_relationships_for_hops(hops: list[str], edges) -> list[str]:
+    """Return relationship names for consecutive hop pairs when topology is available."""
+    if len(hops) < 2:
+        return []
+    by_pair: dict[tuple[str, str], str] = {}
+    for edge in edges:
+        rel = _rel_value(edge)
+        by_pair.setdefault((edge.source, edge.target), rel)
+        if edge.is_bidirectional:
+            by_pair.setdefault((edge.target, edge.source), rel)
+    relationships: list[str] = []
+    for source, target in zip(hops, hops[1:], strict=False):
+        relationship = by_pair.get((source, target))
+        if relationship:
+            relationships.append(relationship)
+    return relationships
+
+
+def _serialize_attack_path(path: AttackPath, edges=None) -> dict:
+    data = path.to_dict()
+    if not data.get("edges") and edges is not None:
+        data["edges"] = _edge_relationships_for_hops(path.hops, edges)
+    return data
+
+
 def _node_type_value(node) -> str:
     return node.entity_type.value if hasattr(node.entity_type, "value") else str(node.entity_type)
 
@@ -464,6 +495,7 @@ def _derived_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
                     if vulnerable_source.id != server_id:
                         hop_ids.append(vulnerable_source.id)
                     hop_ids.append(finding.id)
+                    path_edges = _edge_relationships_for_hops(hop_ids, graph.edges)
                     key = (agent_id, server_id, vulnerable_source.id, finding.id)
                     if key in seen:
                         continue
@@ -477,7 +509,7 @@ def _derived_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
                             source=agent_id,
                             target=finding.id,
                             hops=hop_ids,
-                            edges=[],
+                            edges=path_edges,
                             composite_risk=round(min(100.0, risk), 2),
                             summary=(
                                 "Derived from graph topology: vulnerable package/server is reachable from an agent "
@@ -652,6 +684,7 @@ def _filtered_query_graph(
 async def get_graph(
     request: Request,
     scan_id: Optional[str] = Query(None, description="Filter by scan ID"),
+    scan: Optional[str] = Query(None, description="Alias for scan_id"),
     entity_types: Optional[str] = Query(None, description="Comma-separated entity types"),
     min_severity: Optional[str] = Query(None, description="Minimum severity (critical/high/medium/low)"),
     relationships: Optional[str] = Query(None, description="Comma-separated relationship types"),
@@ -671,7 +704,7 @@ async def get_graph(
 
     tenant = _tenant(request)
     graph_store = _get_graph_store_or_503()
-    requested_scan_id = scan_id or ""
+    requested_scan_id = _coalesce_alias(scan_id, scan, primary_name="scan_id", alias_name="scan")
 
     if not requested_scan_id and not await _graph_store_call(graph_store.latest_snapshot_id, tenant_id=tenant):
         raise HTTPException(status_code=503, detail="Graph snapshots not found. Run a scan first.")
@@ -704,7 +737,11 @@ async def get_graph(
         paged_nodes, pagination = _paginate(all_nodes, offset, limit)
         paged_ids = {n.id for n in paged_nodes}
         paged_edges = [e for e in graph.edges if e.source in paged_ids and e.target in paged_ids]
-        attack_paths = [p.to_dict() for p in _derived_attack_paths(graph) if p.hops and all(hop in paged_ids for hop in p.hops)]
+        attack_paths = [
+            _serialize_attack_path(p, graph.edges)
+            for p in _derived_attack_paths(graph)
+            if p.hops and all(hop in paged_ids for hop in p.hops)
+        ]
         interaction_risks = [
             r.to_dict() for r in graph.interaction_risks if r.agents and all(f"agent:{agent_name}" in paged_ids for agent_name in r.agents)
         ]
@@ -753,7 +790,7 @@ async def get_graph(
         "created_at": created_at,
         "nodes": [n.to_dict() for n in paged_nodes],
         "edges": [e.to_dict() for e in paged_edges],
-        "attack_paths": [path.to_dict() for path in source_attack_paths],
+        "attack_paths": [_serialize_attack_path(path, paged_edges) for path in source_attack_paths],
         "interaction_risks": [],
         "stats": await _graph_store_call(
             graph_store.snapshot_stats,
@@ -875,6 +912,12 @@ async def get_graph_attack_paths(
         tenant_id=tenant,
         node_ids=hop_ids,
     )
+    path_edges = await _graph_store_call(
+        graph_store.edges_for_node_ids,
+        scan_id=effective_scan_id,
+        tenant_id=tenant,
+        node_ids=hop_ids,
+    )
     stats = await _graph_store_call(
         graph_store.snapshot_stats,
         scan_id=effective_scan_id,
@@ -891,8 +934,8 @@ async def get_graph_attack_paths(
         "tenant_id": tenant,
         "created_at": created_at,
         "nodes": [node.to_dict() for node in nodes],
-        "edges": [],
-        "attack_paths": [path.to_dict() for path in paths],
+        "edges": [edge.to_dict() for edge in path_edges],
+        "attack_paths": [_serialize_attack_path(path, path_edges) for path in paths],
         "interaction_risks": [],
         "stats": stats,
         "pagination": _page_meta(total, offset, limit),
@@ -902,41 +945,56 @@ async def get_graph_attack_paths(
 @router.get("/v1/graph/paths", tags=["graph"])
 async def get_graph_paths(
     request: Request,
-    source: str = Query(..., description="Source node ID (e.g. agent:claude-desktop)"),
+    source_id: Optional[str] = Query(None, description="Source node ID (e.g. agent:claude-desktop)"),
+    source: Optional[str] = Query(None, include_in_schema=False),
     scan_id: Optional[str] = Query(None, description="Scan ID"),
+    scan: Optional[str] = Query(None, include_in_schema=False),
     max_depth: int = Query(4, ge=1, le=10, description="Maximum BFS depth"),
     offset: int = Query(0, ge=0, description="Pagination offset"),
     limit: int = Query(100, ge=1, le=1000, description="Max paths"),
 ) -> dict:
     """Find all attack paths from a source node via BFS."""
     graph_store = _get_graph_store_or_503()
-    source_nodes = await _graph_store_call(graph_store.nodes_by_ids, scan_id=scan_id or "", tenant_id=_tenant(request), node_ids={source})
+    source_node_id = _coalesce_alias(source_id, source, primary_name="source_id", alias_name="source")
+    if not source_node_id:
+        raise HTTPException(status_code=422, detail="Missing required query parameter: source_id")
+    requested_scan_id = _coalesce_alias(scan_id, scan, primary_name="scan_id", alias_name="scan")
+    tenant = _tenant(request)
+    source_nodes = await _graph_store_call(graph_store.nodes_by_ids, scan_id=requested_scan_id, tenant_id=tenant, node_ids={source_node_id})
     if not source_nodes:
-        raise HTTPException(status_code=404, detail=f"Node '{source}' not found in graph")
+        raise HTTPException(status_code=404, detail=f"Node '{source_node_id}' not found in graph")
 
     all_paths, reachable = await _graph_store_call(
         graph_store.bfs_paths,
-        scan_id=scan_id or "",
-        tenant_id=_tenant(request),
-        source=source,
+        scan_id=requested_scan_id,
+        tenant_id=tenant,
+        source=source_node_id,
         max_depth=max_depth,
         traversable_only=True,
     )
     paged_paths, pagination = _paginate(all_paths, offset, limit)
     attack_paths = await _graph_store_call(
         graph_store.attack_paths_for_sources,
-        scan_id=scan_id or "",
-        tenant_id=_tenant(request),
-        source_ids={source},
+        scan_id=requested_scan_id,
+        tenant_id=tenant,
+        source_ids={source_node_id},
+    )
+    path_node_ids = {source_node_id, *reachable}
+    path_edges = await _graph_store_call(
+        graph_store.edges_for_node_ids,
+        scan_id=requested_scan_id,
+        tenant_id=tenant,
+        node_ids=path_node_ids,
     )
 
     return {
-        "source": source,
+        "source": source_node_id,
+        "source_id": source_node_id,
         "max_depth": max_depth,
         "reachable_count": len(reachable),
         "reachable_nodes": sorted(reachable),
         "paths": [{"target": p[-1], "hops": p, "depth": len(p) - 1} for p in paged_paths],
-        "attack_paths": [ap.to_dict() for ap in attack_paths if ap.source == source],
+        "attack_paths": [_serialize_attack_path(ap, path_edges) for ap in attack_paths if ap.source == source_node_id],
         "pagination": pagination,
     }
 
@@ -1126,7 +1184,9 @@ async def query_graph(request: Request, body: GraphQueryRequest) -> dict:
             source_ids=set(body.roots),
         )
         attack_paths = [
-            ap.to_dict() for ap in root_attack_paths if ap.source in body.roots and all(hop in filtered_graph.nodes for hop in ap.hops)
+            _serialize_attack_path(ap, filtered_graph.edges)
+            for ap in root_attack_paths
+            if ap.source in body.roots and all(hop in filtered_graph.nodes for hop in ap.hops)
         ]
 
     return {

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -600,19 +600,39 @@ def diff_snapshots(
 ) -> dict[str, Any]:
     """Compute the diff between two scan snapshots."""
     tenant_id = normalize_graph_tenant_id(tenant_id)
+
+    def node_metadata(row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "id": row["id"],
+            "entity_type": row["entity_type"],
+            "label": row["label"],
+            "severity": row["severity"] or "",
+            "severity_id": int(row["severity_id"] or 0),
+            "risk_score": float(row["risk_score"] or 0.0),
+            "status": row["status"] or "",
+        }
+
     old_nodes: dict[str, dict] = {}
     for row in conn.execute(
-        "SELECT id, severity, risk_score FROM graph_nodes WHERE scan_id = ? AND tenant_id = ?",
+        """
+        SELECT id, entity_type, label, status, severity, severity_id, risk_score
+        FROM graph_nodes
+        WHERE scan_id = ? AND tenant_id = ?
+        """,
         (scan_id_old, tenant_id),
     ):
-        old_nodes[row["id"]] = {"severity": row["severity"], "risk_score": row["risk_score"]}
+        old_nodes[row["id"]] = node_metadata(row)
 
     new_nodes: dict[str, dict] = {}
     for row in conn.execute(
-        "SELECT id, severity, risk_score FROM graph_nodes WHERE scan_id = ? AND tenant_id = ?",
+        """
+        SELECT id, entity_type, label, status, severity, severity_id, risk_score
+        FROM graph_nodes
+        WHERE scan_id = ? AND tenant_id = ?
+        """,
         (scan_id_new, tenant_id),
     ):
-        new_nodes[row["id"]] = {"severity": row["severity"], "risk_score": row["risk_score"]}
+        new_nodes[row["id"]] = node_metadata(row)
 
     old_ids, new_ids = set(old_nodes), set(new_nodes)
 
@@ -631,8 +651,8 @@ def diff_snapshots(
         new_edges.add((row["source_id"], row["target_id"], row["relationship"]))
 
     return {
-        "nodes_added": sorted(new_ids - old_ids),
-        "nodes_removed": sorted(old_ids - new_ids),
+        "nodes_added": [new_nodes[nid] for nid in sorted(new_ids - old_ids)],
+        "nodes_removed": [old_nodes[nid] for nid in sorted(old_ids - new_ids)],
         "nodes_changed": sorted(nid for nid in (old_ids & new_ids) if old_nodes[nid] != new_nodes[nid]),
         "edges_added": sorted(new_edges - old_edges),
         "edges_removed": sorted(old_edges - new_edges),

--- a/src/agent_bom/graph/edge.py
+++ b/src/agent_bom/graph/edge.py
@@ -57,6 +57,8 @@ class UnifiedEdge:
             "id": self.id,
             "source": self.source,
             "target": self.target,
+            "source_id": self.source,
+            "target_id": self.target,
             "relationship": self.relationship.value if isinstance(self.relationship, RelationshipType) else self.relationship,
             "direction": self.direction,
             "weight": self.weight,

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -348,8 +348,10 @@ class TestGraphEndpointLogic:
         save_graph(graph_db, g2)
 
         diff = diff_snapshots(graph_db, "s1", "s2")
-        assert "agent:new" in diff["nodes_added"]
-        assert "agent:b" in diff["nodes_removed"]
+        assert diff["nodes_added"][0]["id"] == "agent:new"
+        assert diff["nodes_added"][0]["entity_type"] == "agent"
+        assert diff["nodes_added"][0]["label"] == "new-agent"
+        assert {node["id"] for node in diff["nodes_removed"]} >= {"agent:b"}
 
     def test_bfs_from_persisted_graph(self, graph_db):
         _build_persisted_graph(graph_db)
@@ -701,6 +703,23 @@ class TestGraphEndpointLogic:
         assert sourced[0].summary == path.summary
         assert sourced[0].tool_exposure == ["run_shell"]
 
+    def test_sqlite_graph_store_edges_for_node_ids_returns_incident_edges(self, tmp_path):
+        store = SQLiteGraphStore(tmp_path / "graph.db")
+        graph = UnifiedGraph(scan_id="incident-edge-scan", tenant_id="default")
+        graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        graph.add_node(UnifiedNode(id="tool:t", entity_type=EntityType.TOOL, label="tool-t"))
+        graph.add_edge(UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES))
+        graph.add_edge(UnifiedEdge(source="server:s", target="tool:t", relationship=RelationshipType.PROVIDES_TOOL))
+        store.save_graph(graph)
+
+        edges = store.edges_for_node_ids(tenant_id="default", scan_id="incident-edge-scan", node_ids={"agent:a", "tool:t"})
+
+        assert {(edge.source, edge.target) for edge in edges} == {
+            ("agent:a", "server:s"),
+            ("server:s", "tool:t"),
+        }
+
     def test_sqlite_graph_store_node_context_preserves_bidirectional_neighbors(self, tmp_path):
         store = SQLiteGraphStore(tmp_path / "graph.db")
         graph = UnifiedGraph(scan_id="node-context-scan", tenant_id="default")
@@ -883,7 +902,7 @@ class _RecordingGraphStore:
 
     def edges_for_node_ids(self, *, tenant_id: str = "", scan_id: str = "", node_ids: set[str]):
         self.calls.append(("edges_for_node_ids", tenant_id, scan_id, tuple(sorted(node_ids))))
-        return [edge for edge in self.graph.edges if edge.source in node_ids and edge.target in node_ids]
+        return [edge for edge in self.graph.edges if edge.source in node_ids or edge.target in node_ids]
 
     def search_nodes(
         self,
@@ -1232,6 +1251,12 @@ class TestGraphStoreBackendSelection:
         assert queue["pagination"]["total"] == 1
         assert queue["stats"]["attack_path_count"] == 1
         assert queue["attack_paths"][0]["hops"] == ["agent:a", "server:a:fs", "pkg:npm:form-data", "vuln:cve"]
+        assert queue["attack_paths"][0]["edges"] == ["uses", "depends_on", "vulnerable_to"]
+        assert {(edge["source_id"], edge["target_id"]) for edge in queue["edges"]} >= {
+            ("agent:a", "server:a:fs"),
+            ("server:a:fs", "pkg:npm:form-data"),
+            ("pkg:npm:form-data", "vuln:cve"),
+        }
 
     def test_graph_overview_filtered_page_stays_store_backed(self, recording_graph_store):
         recording_graph_store.graph.add_node(
@@ -1256,6 +1281,23 @@ class TestGraphStoreBackendSelection:
         assert helper_calls.count("edges_for_node_ids") == 1
         assert helper_calls.count("snapshot_stats") == 1
         assert "load_graph" not in helper_calls
+
+    def test_graph_overview_accepts_scan_alias_and_returns_incident_edges(self, recording_graph_store):
+        recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
+        recording_graph_store.graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        recording_graph_store.graph.add_edge(UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES))
+        client = TestClient(app)
+
+        response = client.get("/v1/graph", params={"scan": "store-scan", "limit": 1})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["scan_id"] == "store-scan"
+        assert len(body["nodes"]) == 1
+        assert body["edges"][0]["source_id"] == "agent:a"
+        assert body["edges"][0]["target_id"] == "server:s"
+        assert ("page_nodes", "default", "store-scan", None, 0, None, 0, 1) in recording_graph_store.calls
 
     def test_graph_overview_rejects_unknown_entity_type(self, recording_graph_store):
         client = TestClient(app)
@@ -1496,6 +1538,26 @@ class TestGraphStoreBackendSelection:
         assert any(call[0] == "bfs_paths" for call in recording_graph_store.calls)
         assert not any(call[0] == "load_graph" for call in recording_graph_store.calls)
 
+    def test_graph_paths_prefers_source_id_parameter_in_schema(self, recording_graph_store):
+        recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
+        recording_graph_store.graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES, traversable=True)
+        )
+        client = TestClient(app)
+
+        response = client.get("/v1/graph/paths", params={"source_id": "agent:a", "scan": "store-scan"})
+
+        assert response.status_code == 200
+        assert response.json()["source_id"] == "agent:a"
+        assert ("bfs_paths", "default", "store-scan", "agent:a", 4, True) in recording_graph_store.calls
+        parameter_names = {
+            param["name"] for param in app.openapi()["paths"]["/v1/graph/paths"]["get"]["parameters"] if param["in"] == "query"
+        }
+        assert "source_id" in parameter_names
+        assert "source" not in parameter_names
+
     def test_graph_impact_uses_store_native_traversal(self, recording_graph_store):
         recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
         recording_graph_store.graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
@@ -1665,6 +1727,8 @@ class TestGraphStoreBackendSelection:
         body = response.json()
         assert body["node"]["id"] == "server:s"
         assert body["sources"] == ["agent:a"]
+        assert body["edges_in"][0]["source_id"] == "agent:a"
+        assert body["edges_in"][0]["target_id"] == "server:s"
         assert any(call[0] == "node_context" for call in recording_graph_store.calls)
         assert not any(call[0] == "load_graph" for call in recording_graph_store.calls)
 

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -615,8 +615,8 @@ class TestGraphStore:
         save_graph(db, g2)
 
         diff = diff_snapshots(db, "s1", "s2")
-        assert "agent:b" in diff["nodes_added"]
-        assert "server:a" in diff["nodes_removed"]
+        assert {node["id"] for node in diff["nodes_added"]} == {"agent:b"}
+        assert {node["id"] for node in diff["nodes_removed"]} == {"server:a"}
         assert len(diff["edges_added"]) >= 1
         assert len(diff["edges_removed"]) >= 1
 
@@ -1045,10 +1045,8 @@ class TestRegressionPerScanHistory:
         save_graph(db, g2)
 
         diff = diff_snapshots(db, "s1", "s2")
-        assert "agent:c" in diff["nodes_added"]
-        assert "agent:b" in diff["nodes_removed"]
-        assert "agent:a" not in diff["nodes_added"]
-        assert "agent:a" not in diff["nodes_removed"]
+        assert {node["id"] for node in diff["nodes_added"]} == {"agent:c"}
+        assert {node["id"] for node in diff["nodes_removed"]} == {"agent:b"}
 
 
 class TestGraphFilterOptions:


### PR DESCRIPTION
Summary
- preserve graph page context by co-loading incident edges for returned nodes
- hydrate attack-path edge arrays from hop topology when persisted rows do not carry edge lists
- include path edges in `/v1/graph/attack-paths` response edges
- serialize `source_id`/`target_id` aliases alongside `source`/`target` for node edge details
- return graph diff node entries with metadata dictionaries instead of bare strings
- align `/v1/graph/paths` with `source_id`/`target_id` parameters while keeping legacy hidden aliases compatible
- support `scan` as a `scan_id` alias and reject conflicting scan aliases

Root Cause
The graph store had enough relationship data, but several API serializers were narrowing or dropping it at response time: page edges were limited to both endpoints inside the page, attack-path rows could omit edge arrays, node-detail edge aliases were missing, and diff/path response contracts had drifted from schema/user expectations.

Validation
- `uv run pytest -q tests/test_graph_api.py tests/test_graph_schema.py --tb=short` -> 139 passed
- `uv run pytest -q tests/test_postgres_store.py --tb=short` -> 75 passed
- `uv run ruff check src/agent_bom/api/routes/graph.py src/agent_bom/api/graph_store.py src/agent_bom/api/postgres_graph.py src/agent_bom/db/graph_store.py src/agent_bom/graph/edge.py tests/test_graph_api.py tests/test_graph_schema.py` -> passed
- pre-commit hooks during commit passed where applicable

Closes the graph serialization readiness cluster from the live audit.
