### PR TITLE
Fix ready PR auto-refresh loop

### DIFF
--- a/.github/workflows/auto-retrigger-stranded.yml
+++ b/.github/workflows/auto-retrigger-stranded.yml
@@ -1,42 +1,57 @@
 name: Auto-Retrigger Stranded PRs
 
-# Permanent fix for the recurring "PR frozen after Update branch" pattern.
+# Permanent fix for the recurring "approved PR frozen behind main" and
+# "PR frozen after Update branch" patterns.
 #
-# When auto-merge or the "Update branch" button advances a PR's head SHA,
-# the resulting commit is authored by GITHUB_TOKEN. GitHub Actions
-# intentionally does NOT trigger pull_request workflows from
-# GITHUB_TOKEN-authored events (anti-loop guard), so the PR ends up with
-# zero check-runs on the current head and stays mergeable_state=blocked
-# forever. Background: docs/operations/CI_RUNBOOK.md.
+# Branch protection requires PR heads to include current main. When main moves,
+# approved auto-merge PRs can sit behind base until someone clicks Update
+# branch. If that update is performed by automation, the resulting commit can be
+# authored by GITHUB_TOKEN; GitHub Actions intentionally does NOT trigger
+# pull_request workflows from GITHUB_TOKEN-authored events (anti-loop guard), so
+# the PR can then end up with missing or stale check-runs on the current head.
+# Background: docs/operations/CI_RUNBOOK.md.
 #
-# This workflow polls regularly (or on demand), finds PRs whose current head
-# SHA is missing or has a stale required check, and runs
-# scripts/retrigger_stranded_pr.sh (close + reopen) which fires the
-# pull_request workflows from scratch.
+# This workflow polls regularly, runs immediately after main advances, and can
+# be dispatched on demand. It first refreshes same-repo auto-merge PRs that are
+# behind main, then retriggers any PR whose current head SHA is missing or has a
+# stale required check.
 #
 # Triggered from a workflow (not GITHUB_TOKEN's push), the close/reopen
 # events are properly recorded and our pull_request hooks fire on the
 # new head SHA — exactly the result a manual retrigger gives.
 
 on:
+  push:
+    branches: [main]
   schedule:
     # GitHub-hosted schedules are best-effort and can be delayed during busy
     # windows. Odd-minute slots avoid the most contended top-of-hour queue.
-    - cron: "3,18,33,48 * * * *"
+    - cron: "3,8,13,18,23,28,33,38,43,48,53,58 * * * *"
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "Optional PR number to retrigger immediately"
+        description: "Optional PR number to refresh/retrigger immediately"
         required: false
         type: string
       min_age_minutes:
-        description: "Minimum PR age before scheduled scans retrigger"
+        description: "Minimum PR age before scheduled scans refresh/retrigger"
         required: false
-        default: "6"
+        default: "3"
         type: string
+      require_auto_merge:
+        description: "Only refresh PRs with auto-merge enabled"
+        required: false
+        default: true
+        type: boolean
+      refresh_ready_prs:
+        description: "Refresh approved auto-merge PRs that are behind main"
+        required: false
+        default: true
+        type: boolean
 
 permissions:
-  contents: read
+  contents: write
+  issues: write
   pull-requests: write
 
 concurrency:
@@ -58,10 +73,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REQUIRED_CHECK: "Lint and Type Check"
-          MIN_AGE_MINUTES: ${{ inputs.min_age_minutes || '6' }}
+          MIN_AGE_MINUTES: ${{ inputs.min_age_minutes || '3' }}
           PR_NUMBER: ${{ inputs.pr_number || '' }}
+          REQUIRE_AUTO_MERGE: ${{ github.event_name != 'workflow_dispatch' || inputs.require_auto_merge }}
+          REFRESH_READY_PRS: ${{ github.event_name != 'workflow_dispatch' || inputs.refresh_ready_prs }}
         run: |
           set -euo pipefail
+          if [ "${REFRESH_READY_PRS}" = "true" ]; then
+            scripts/refresh_ready_prs.sh
+          fi
+
           if [ -n "${PR_NUMBER}" ]; then
             echo "Manual retrigger requested for PR #${PR_NUMBER}."
             scripts/retrigger_stranded_pr.sh "${PR_NUMBER}"

--- a/docs/operations/CI_RUNBOOK.md
+++ b/docs/operations/CI_RUNBOOK.md
@@ -5,6 +5,53 @@ stuck, a workflow fails unexpectedly, or you need to retrigger checks.
 
 ---
 
+## Ready PRs blocked behind `main`
+
+### Symptom
+
+A PR is approved, auto-merge is enabled, and all current checks are green, but
+GitHub still says **This branch is out-of-date with the base branch** or
+**branch update already in progress**. This becomes common when several small
+readiness PRs are stacked behind a strict `main` branch protection rule.
+
+### Root cause
+
+`main` advanced after the PR checks started. Branch protection has
+`required_status_checks.strict = true`, so GitHub requires the PR head to
+include the latest `main` before it can merge. Clicking **Update branch** fixes
+the base mismatch, but the resulting synthetic merge commit can produce stale
+or canceled check state.
+
+### Permanent fix: auto-refresh ready PRs
+
+`.github/workflows/auto-retrigger-stranded.yml` now runs on every push to
+`main`, on a 5-minute schedule, and on manual dispatch. It first runs:
+
+```sh
+scripts/refresh_ready_prs.sh
+```
+
+The script only refreshes same-repo, non-draft PRs targeting `main`. By default
+it further limits writes to PRs with auto-merge already enabled, so exploratory
+branches are left alone. After updating a PR branch, it runs the stranded-check
+retrigger below so required checks attach to the new head.
+
+Manual one-shot refresh:
+
+```sh
+PR_NUMBER=<PR_NUMBER> scripts/refresh_ready_prs.sh
+```
+
+Dry-run inspection:
+
+```sh
+DRY_RUN=true scripts/refresh_ready_prs.sh
+```
+
+If the workflow reports "branch update already in progress", leave it alone; the
+next scheduled run will verify whether the head advanced and retrigger checks if
+needed.
+
 ## Stranded PRs (zero check runs on the current head SHA)
 
 ### Symptom
@@ -47,15 +94,16 @@ run on any PR.
 ### Permanent fix: scheduled auto-retrigger (recommended, already on)
 
 `.github/workflows/auto-retrigger-stranded.yml` runs `scripts/retrigger_stranded_pr.sh`
-against every open PR whose current head SHA has zero `Lint and Type Check`
-runs. Cron is `*/5 * * * *`, plus `workflow_dispatch` for on-demand. Once
-this workflow is on the default branch, stranded PRs unstrand themselves
-within five minutes — no operator action required.
+against every open PR whose current head SHA has zero or stale
+`Lint and Type Check` runs. It runs after `main` advances, every five minutes,
+and through `workflow_dispatch` for on-demand. Once this workflow is on the
+default branch, stranded PRs unstrand themselves within five minutes — no
+operator action required.
 
 Operator-side troubleshooting if a strand persists past ~10 minutes:
 
 - Did the workflow itself run? `gh run list --workflow=auto-retrigger-stranded.yml --limit 5`
-- Was the PR younger than `MIN_AGE_MINUTES` (10 min)? It's intentionally
+- Was the PR younger than `MIN_AGE_MINUTES` (3 min by default)? It's intentionally
   skipped to give the initial `pull_request` workflow a chance to start.
 - Did `gh api commits/{sha}/check-runs` return zero, or is there a
   different check name now? Update `REQUIRED_CHECK` in the workflow if
@@ -63,7 +111,7 @@ Operator-side troubleshooting if a strand persists past ~10 minutes:
 
 ### Permanent fix alternatives (settings change required)
 
-The auto-retrigger workflow above is the cheapest path. The following
+The auto-refresh/retrigger workflow above is the cheapest path. The following
 alternatives still apply if you prefer settings-level fixes; pick one.
 
 | Option | Where | Tradeoff |

--- a/scripts/enable_merge_queue.sh
+++ b/scripts/enable_merge_queue.sh
@@ -11,10 +11,11 @@
 #
 # For the recurring stranded-CI pain that motivated wanting merge queue,
 # `.github/workflows/auto-retrigger-stranded.yml` is the practical fix:
-# it polls open PRs every 5 minutes and runs scripts/retrigger_stranded_pr.sh
-# against any whose current head SHA has zero check-runs. That neutralises
-# the GITHUB_TOKEN-authored-merge anti-loop guard without needing
-# repo-settings changes.
+# it runs after main advances, polls open PRs every 5 minutes, refreshes
+# ready auto-merge PRs that are behind main, and runs
+# scripts/retrigger_stranded_pr.sh against any whose current head SHA has zero
+# or stale check-runs. That neutralises both strict-branch staleness and the
+# GITHUB_TOKEN-authored-merge anti-loop guard without needing settings changes.
 #
 # Usage:
 #   scripts/enable_merge_queue.sh         # print steps
@@ -60,8 +61,9 @@ Verify with:
 
   scripts/enable_merge_queue.sh --check
 
-Until the toggle is on, the practical fix for stranded PRs is the
-scheduled workflow at .github/workflows/auto-retrigger-stranded.yml,
-which auto-runs scripts/retrigger_stranded_pr.sh every 5 minutes. No
-operator action needed once it's on the default branch.
+Until the toggle is on, the practical fix for stale/stranded PRs is the
+workflow at .github/workflows/auto-retrigger-stranded.yml, which refreshes
+ready auto-merge PRs after main advances and auto-runs
+scripts/retrigger_stranded_pr.sh every 5 minutes. No operator action needed
+once it's on the default branch.
 EOF

--- a/scripts/refresh_ready_prs.sh
+++ b/scripts/refresh_ready_prs.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Keep approved auto-merge PRs moving when `main` advances.
+#
+# Branch protection requires PR branches to be up to date with `main`. GitHub's
+# auto-merge does not always refresh queued PRs promptly, and the UI "Update
+# branch" path can leave canceled or missing checks. This script updates stale
+# same-repo PR heads and then invokes the stranded-check retrigger so required
+# checks attach to the new head.
+#
+# Usage:
+#   scripts/refresh_ready_prs.sh
+#   PR_NUMBER=2321 scripts/refresh_ready_prs.sh
+#   DRY_RUN=true scripts/refresh_ready_prs.sh
+
+set -euo pipefail
+
+REPO="${GH_REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+BASE_BRANCH="${BASE_BRANCH:-main}"
+PR_NUMBER="${PR_NUMBER:-}"
+MIN_AGE_MINUTES="${MIN_AGE_MINUTES:-3}"
+REQUIRE_AUTO_MERGE="${REQUIRE_AUTO_MERGE:-true}"
+DRY_RUN="${DRY_RUN:-false}"
+REQUIRED_CHECK="${REQUIRED_CHECK:-Lint and Type Check}"
+MAX_POLLS="${MAX_POLLS:-12}"
+POLL_SECONDS="${POLL_SECONDS:-5}"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh is required" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+now_epoch() {
+  date -u +%s
+}
+
+date_epoch() {
+  local value="$1"
+  date -u -d "$value" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$value" +%s
+}
+
+list_prs() {
+  if [ -n "${PR_NUMBER}" ]; then
+    printf '%s\n' "${PR_NUMBER}"
+    return
+  fi
+
+  gh pr list \
+    --repo "${REPO}" \
+    --state open \
+    --base "${BASE_BRANCH}" \
+    --limit 100 \
+    --json number,isDraft \
+    --jq '.[] | select(.isDraft == false) | .number'
+}
+
+base_sha() {
+  gh api "repos/${REPO}/git/ref/heads/${BASE_BRANCH}" --jq .object.sha
+}
+
+commits_missing_from_head() {
+  local head_sha="$1"
+  local base_sha="$2"
+  gh api "repos/${REPO}/compare/${head_sha}...${base_sha}" --jq .ahead_by
+}
+
+poll_head_change() {
+  local pr="$1"
+  local old_sha="$2"
+  local attempt
+  local new_sha
+
+  for ((attempt = 1; attempt <= MAX_POLLS; attempt++)); do
+    new_sha="$(gh api "repos/${REPO}/pulls/${pr}" --jq .head.sha)"
+    if [ "${new_sha}" != "${old_sha}" ]; then
+      printf '%s\n' "${new_sha}"
+      return 0
+    fi
+    sleep "${POLL_SECONDS}"
+  done
+
+  printf '%s\n' "${old_sha}"
+}
+
+refresh_pr() {
+  local pr="$1"
+  local info
+  local is_draft base_ref head_owner updated_at age_seconds auto_merge review head_sha head_ref
+  local repo_owner missing output updated_sha now updated_epoch
+
+  info="$(gh pr view "${pr}" \
+    --repo "${REPO}" \
+    --json number,isDraft,baseRefName,headRefName,headRefOid,headRepositoryOwner,updatedAt,reviewDecision,autoMergeRequest,url)"
+
+  is_draft="$(jq -r '.isDraft' <<< "${info}")"
+  base_ref="$(jq -r '.baseRefName' <<< "${info}")"
+  head_owner="$(jq -r '.headRepositoryOwner.login' <<< "${info}")"
+  updated_at="$(jq -r '.updatedAt' <<< "${info}")"
+  auto_merge="$(jq -r '.autoMergeRequest != null' <<< "${info}")"
+  review="$(jq -r '.reviewDecision' <<< "${info}")"
+  head_sha="$(jq -r '.headRefOid' <<< "${info}")"
+  head_ref="$(jq -r '.headRefName' <<< "${info}")"
+  repo_owner="${REPO%%/*}"
+
+  if [ "${is_draft}" = "true" ]; then
+    echo "PR #${pr}: draft, skipping."
+    return 0
+  fi
+
+  if [ "${base_ref}" != "${BASE_BRANCH}" ]; then
+    echo "PR #${pr}: targets ${base_ref}, not ${BASE_BRANCH}; skipping."
+    return 0
+  fi
+
+  if [ "${head_owner}" != "${repo_owner}" ]; then
+    echo "PR #${pr}: fork-owned branch (${head_owner}/${head_ref}), skipping."
+    return 0
+  fi
+
+  if [ "${REQUIRE_AUTO_MERGE}" = "true" ] && [ "${auto_merge}" != "true" ]; then
+    echo "PR #${pr}: auto-merge not enabled, skipping."
+    return 0
+  fi
+
+  now="$(now_epoch)"
+  updated_epoch="$(date_epoch "${updated_at}")"
+  age_seconds=$((now - updated_epoch))
+  if [ "${age_seconds}" -lt $((60 * MIN_AGE_MINUTES)) ]; then
+    echo "PR #${pr}: updated ${age_seconds}s ago, skipping until it settles."
+    return 0
+  fi
+
+  missing="$(commits_missing_from_head "${head_sha}" "$(base_sha)")"
+  if [ "${missing}" -eq 0 ]; then
+    echo "PR #${pr}: already contains current ${BASE_BRANCH}; checking for stranded CI."
+    REQUIRED_CHECK="${REQUIRED_CHECK}" scripts/retrigger_stranded_pr.sh "${pr}"
+    return 0
+  fi
+
+  echo "PR #${pr}: ${missing} ${BASE_BRANCH} commit(s) missing; refreshing ${head_ref}."
+  if [ "${DRY_RUN}" = "true" ]; then
+    echo "PR #${pr}: dry-run, would run gh pr update-branch."
+    return 0
+  fi
+
+  if output="$(gh pr update-branch "${pr}" --repo "${REPO}" 2>&1)"; then
+    printf '%s\n' "${output}"
+  else
+    if grep -qi "update.*already.*progress" <<< "${output}"; then
+      echo "PR #${pr}: branch update already in progress; next run will verify CI."
+      return 0
+    fi
+    printf '%s\n' "${output}" >&2
+    return 1
+  fi
+
+  updated_sha="$(poll_head_change "${pr}" "${head_sha}")"
+  if [ "${updated_sha}" = "${head_sha}" ]; then
+    echo "PR #${pr}: head did not advance after update request; next run will retry."
+    return 0
+  fi
+
+  echo "PR #${pr}: head advanced ${head_sha} -> ${updated_sha}; ensuring required checks attach."
+  REQUIRED_CHECK="${REQUIRED_CHECK}" scripts/retrigger_stranded_pr.sh "${pr}"
+
+  if [ "${review}" != "APPROVED" ]; then
+    echo "PR #${pr}: refreshed, but review decision is ${review}; auto-merge will wait for review."
+  fi
+}
+
+checked=0
+refreshed=0
+
+while IFS= read -r pr; do
+  [ -n "${pr}" ] || continue
+  checked=$((checked + 1))
+  if refresh_pr "${pr}"; then
+    refreshed=$((refreshed + 1))
+  else
+    echo "PR #${pr}: refresh failed, continuing." >&2
+  fi
+done < <(list_prs)
+
+echo
+echo "Summary: ${checked} PR(s) inspected, ${refreshed} completed without fatal errors."

--- a/scripts/retrigger_stranded_pr.sh
+++ b/scripts/retrigger_stranded_pr.sh
@@ -40,8 +40,11 @@ CHECK_STATE="$(
       .check_runs[]
       | select(.name == \"${REQUIRED_CHECK}\")
       | {status, conclusion}
-    ]"
+    ]" || printf '[]'
 )"
+if [ -z "${CHECK_STATE}" ]; then
+  CHECK_STATE="[]"
+fi
 
 CHECK_HITS="$(jq 'length' <<< "${CHECK_STATE}")"
 ACTIVE_HITS="$(jq '[.[] | select(.status != "completed")] | length' <<< "${CHECK_STATE}")"


### PR DESCRIPTION
Summary
- add a repo-level ready-PR refresh script that updates same-repo auto-merge PRs when main moves
- run the refresh from the existing stranded-PR workflow on push to main, every 5 minutes, and on manual dispatch
- harden the stranded-check retrigger against transient empty check-run API responses
- update the CI runbook and merge-queue helper docs so the operator path matches the automation

Root Cause
Strict branch protection requires PR heads to include current main. The existing stranded-PR automation only handled missing/stale checks on the current head; it did not refresh approved auto-merge PRs that became out-of-date after another PR merged. That left the queue dependent on GitHub UI branch updates and repeated manual reruns.

Validation
- bash -n scripts/refresh_ready_prs.sh scripts/retrigger_stranded_pr.sh scripts/enable_merge_queue.sh
- python YAML parse for .github/workflows/auto-retrigger-stranded.yml
- DRY_RUN=true MIN_AGE_MINUTES=0 PR_NUMBER=2321 scripts/refresh_ready_prs.sh
- git diff --check
- pre-commit hooks during commit passed

Live dry-run note
Against #2321, the script detected that the branch already contained current main and verified the required Lint and Type Check context was attached, so it no-oped instead of rewriting the branch.