### PR TITLE
Clarify API extra dependency diagnostics

### DIFF
--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -72,6 +72,19 @@ _DASHBOARD_CSP_META_RE = re.compile(
 
 # ─── Dependency check ─────────────────────────────────────────────────────────
 
+
+def _api_extra_import_error_message(exc: ImportError) -> str:
+    missing = getattr(exc, "name", None)
+    missing_line = f"\nMissing import: {missing!r}" if missing else ""
+    return (
+        "agent-bom API could not import its runtime dependencies."
+        f"{missing_line}\n"
+        "Install with:  pip install 'agent-bom[api]'\n"
+        "If those packages are already installed, verify that `agent-bom api` is running in the same Python "
+        "environment that contains fastapi, uvicorn, sse-starlette, pydantic, and starlette."
+    )
+
+
 try:
     from fastapi import FastAPI
     from fastapi.middleware.cors import CORSMiddleware
@@ -79,7 +92,7 @@ try:
     from pydantic import BaseModel  # noqa: F401 — presence check for [api] extra
     from starlette.middleware import Middleware
 except ImportError as exc:  # pragma: no cover
-    raise ImportError("agent-bom API requires extra dependencies.\nInstall with:  pip install 'agent-bom[api]'") from exc
+    raise ImportError(_api_extra_import_error_message(exc)) from exc
 
 # ─── App ──────────────────────────────────────────────────────────────────────
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2181,6 +2181,20 @@ def test_api_import():
     assert app.title == "agent-bom API"
 
 
+def test_api_extra_import_error_message_names_missing_runtime_dependency():
+    """API import diagnostics should distinguish missing modules from install metadata drift."""
+    pytest.importorskip("fastapi", reason="fastapi not installed")
+    from agent_bom.api.server import _api_extra_import_error_message
+
+    message = _api_extra_import_error_message(ModuleNotFoundError("No module named 'sse_starlette'", name="sse_starlette"))
+
+    assert "sse_starlette" in message
+    assert "pip install 'agent-bom[api]'" in message
+    assert "same Python environment" in message
+    assert "fastapi" in message
+    assert "uvicorn" in message
+
+
 def test_api_health_endpoint():
     """GET /health returns {status: ok}."""
     pytest.importorskip("fastapi", reason="fastapi not installed")


### PR DESCRIPTION
Summary
- replace the generic API import-block error with diagnostics that name the missing import
- add guidance for same-Python-environment drift when fastapi/uvicorn/starlette appear installed elsewhere
- add regression coverage for the error message

Root Cause
The API server import block collapsed every ImportError into a generic "install agent-bom[api]" message. In environments where packages were present but the CLI used a different Python environment, that looked like an over-strict extras check instead of a runtime import mismatch.

Validation
- uv run pytest -q tests/test_core.py::test_api_extra_import_error_message_names_missing_runtime_dependency tests/test_core.py::test_api_import --tb=short
- uv run ruff check src/agent_bom/api/server.py tests/test_core.py
- pre-commit hooks during commit passed

Closes the P3 API extras-detection confusion item from the readiness backlog.