### PR TITLE
Add MCP HTTP scan contract coverage

### DIFF
--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -703,7 +703,14 @@ def _run_scan_sync(job: ScanJob) -> None:
             pipeline.skip_step("enrichment", "Skipped")
             pipeline.skip_step("analysis", "Skipped")
             pipeline.skip_step("output", "No results")
-            job.result = {"agents": [], "vulnerabilities": [], "blast_radius": [], "warnings": warnings_all}
+            job.result = {
+                "status": "no_agents_found",
+                "agents": [],
+                "vulnerabilities": [],
+                "blast_radius": [],
+                "blast_radii": [],
+                "warnings": warnings_all,
+            }
             job.status = JobStatus.DONE
             job.completed_at = _now()
             return

--- a/src/agent_bom/mcp_tools/scanning.py
+++ b/src/agent_bom/mcp_tools/scanning.py
@@ -73,9 +73,14 @@ async def scan_impl(
         )
         scan_warnings = [*pre_warnings, *scan_warnings]
         if not agents:
-            result: dict[str, object] = {"status": "no_agents_found", "agents": [], "blast_radii": []}
-            if scan_warnings:
-                result["warnings"] = scan_warnings
+            result: dict[str, object] = {
+                "status": "no_agents_found",
+                "agents": [],
+                "vulnerabilities": [],
+                "blast_radius": [],
+                "blast_radii": [],
+                "warnings": scan_warnings,
+            }
             return _truncate_response(json.dumps(result))
         from agent_bom.vex import active_blast_radii
 

--- a/tests/test_mcp_http_scan_contract.py
+++ b/tests/test_mcp_http_scan_contract.py
@@ -1,0 +1,44 @@
+import json
+
+import pytest
+
+from agent_bom.api.models import ScanJob, ScanRequest
+from agent_bom.api.pipeline import _now, _run_scan_sync
+from agent_bom.mcp_tools.scanning import scan_impl
+
+
+def _truncate(value: str) -> str:
+    return value
+
+
+async def _empty_scan_pipeline(*_args, **_kwargs):
+    return [], [], [], []
+
+
+def _contract_subset(payload: dict[str, object]) -> dict[str, object]:
+    keys = {"status", "agents", "vulnerabilities", "blast_radius", "blast_radii", "warnings"}
+    return {key: payload.get(key) for key in sorted(keys)}
+
+
+@pytest.mark.asyncio
+async def test_mcp_scan_no_agent_shape_matches_http_scan(monkeypatch):
+    """Guard the shared scan response contract across MCP and HTTP surfaces."""
+    monkeypatch.setattr("agent_bom.discovery.discover_all", lambda **_kwargs: [])
+
+    job = ScanJob(
+        job_id="contract-no-agents",
+        created_at=_now(),
+        request=ScanRequest(),
+    )
+    _run_scan_sync(job)
+    assert job.result is not None
+
+    raw_mcp = await scan_impl(
+        _run_scan_pipeline=_empty_scan_pipeline,
+        _truncate_response=_truncate,
+    )
+    mcp_result = json.loads(raw_mcp)
+
+    assert _contract_subset(mcp_result) == _contract_subset(job.result)
+    assert mcp_result["blast_radius"] == mcp_result["blast_radii"] == []
+    assert job.result["blast_radius"] == job.result["blast_radii"] == []


### PR DESCRIPTION
Summary
- align no-agent scan result shape across MCP and HTTP scan surfaces
- preserve both canonical blast_radius and legacy blast_radii fields for compatibility
- add a contract test that runs both surfaces against the same no-agent input and diffs the stable response shape

Validation
- uv run pytest -q tests/test_mcp_http_scan_contract.py tests/test_mcp_server.py::test_scan_no_agents tests/test_mcp_server.py::test_scan_default_read_only_contract_does_not_refresh_db_and_uses_offline_scan --tb=short
- uv run pytest -q tests/test_mcp_http_scan_contract.py tests/test_mcp_server.py::test_scan_no_agents tests/test_api_endpoints.py::test_create_scan_returns_202 --tb=short
- uv run ruff check src/agent_bom/mcp_tools/scanning.py src/agent_bom/api/pipeline.py tests/test_mcp_http_scan_contract.py