### PR TITLE
Add gateway NetworkPolicy hardening

### DIFF
--- a/deploy/helm/agent-bom/templates/gateway-networkpolicy.yaml
+++ b/deploy/helm/agent-bom/templates/gateway-networkpolicy.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.gateway.enabled .Values.gateway.networkPolicy.enabled }}
+{{- $egress := .Values.gateway.networkPolicy.egress | default list }}
+{{- $additionalEgress := .Values.gateway.networkPolicy.additionalEgress | default list }}
+{{- $hasEgress := or .Values.gateway.networkPolicy.allowDns (gt (len $egress) 0) (gt (len $additionalEgress) 0) }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "agent-bom.name" . }}-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "agent-bom.name" . }}
+      app.kubernetes.io/component: gateway
+  policyTypes:
+    - Egress
+  {{- if not $hasEgress }}
+  egress: []
+  {{- else }}
+  egress:
+    {{- if .Values.gateway.networkPolicy.allowDns }}
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- with $egress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with $additionalEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -214,6 +214,16 @@ gateway:
     create: true
     name: ""
     annotations: {}
+  # Gateway-specific default-deny egress. Kubernetes NetworkPolicy cannot
+  # portably express FQDNs from upstream URLs, so operators should translate
+  # configured upstream MCPs/control-plane discovery targets into ipBlock or
+  # pod/namespace selectors here. With gateway.enabled=true this policy keeps
+  # gateway egress closed except DNS and the explicit rules below.
+  networkPolicy:
+    enabled: true
+    allowDns: true
+    egress: []
+    additionalEgress: []
   extraVolumes: []
   extraVolumeMounts: []
   resources:

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -447,6 +447,24 @@ def test_helm_gateway_service_account_defaults():
     assert gateway["allowVisualLeakBestEffort"] is False
 
 
+def test_helm_gateway_network_policy_defaults_to_explicit_egress_allowlist():
+    """Gateway pods should get a component-specific egress policy when enabled."""
+    doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
+    policy = doc["gateway"]["networkPolicy"]
+    assert policy["enabled"] is True
+    assert policy["allowDns"] is True
+    assert policy["egress"] == []
+    assert policy["additionalEgress"] == []
+
+    template = (HELM_DIR / "templates" / "gateway-networkpolicy.yaml").read_text()
+    assert "kind: NetworkPolicy" in template
+    assert "app.kubernetes.io/component: gateway" in template
+    assert ".Values.gateway.networkPolicy.enabled" in template
+    assert ".Values.gateway.networkPolicy.egress" in template
+    assert ".Values.gateway.networkPolicy.additionalEgress" in template
+    assert "egress: []" in template
+
+
 def test_helm_gateway_template_wires_control_plane_and_runtime_flags():
     """Gateway deployment should expose the CLI's deploy-time control knobs."""
     template = (HELM_DIR / "templates" / "gateway-deployment.yaml").read_text()


### PR DESCRIPTION
Summary
- add a gateway-specific NetworkPolicy rendered when gateway.enabled=true
- select only gateway pods and default-deny egress except DNS plus explicit operator-provided egress rules
- document that Kubernetes NetworkPolicy needs upstream MCP/control-plane targets translated into ipBlock or pod/namespace selectors

Validation
- uv run pytest -q tests/test_deploy_manifests.py::test_helm_gateway_network_policy_defaults_to_explicit_egress_allowlist tests/test_deploy_manifests.py::test_helm_gateway_service_account_defaults tests/test_iac_helm.py::TestAgentBomHelmChartDefaults::test_repo_templates_wire_security_contexts_and_network_policy --tb=short
- uv run ruff check tests/test_deploy_manifests.py
- helm template agent-bom deploy/helm/agent-bom --set gateway.enabled=true