### PR TITLE
Prepare v0.86.2 release

### DIFF
--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom
-        run: uv tool install agent-bom==0.86.1  # pinned — bump on each release
+        run: uv tool install agent-bom==0.86.2  # pinned — bump on each release
 
       - name: Scan changed MCP configs
         id: scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.86.2] - 2026-05-07
+
+Audit-readiness patch for the live dashboard/API release pass. This release closes the scan-contract, graph-serialization, gateway-transport, CI refresh, image tarball, API extras, MCP/HTTP contract, and gateway NetworkPolicy hardening items validated after `v0.86.1`.
+
+### Added
+- **Airgap image tarball entry point** - `agent-bom image --tar <path>` now scans local OCI/Docker tarballs without requiring a Docker daemon or registry pull path (#2327).
+- **MCP-to-HTTP scan contract coverage** - regression coverage now asserts MCP scan output shape stays aligned with the HTTP scan path for shared scan internals (#2326).
+- **Gateway component NetworkPolicy** - Helm now renders a gateway-specific default-deny egress policy with explicit DNS/upstream allowlist hooks instead of relying only on global policy coverage (#2328).
+
+### Fixed
+- **Strict scan request validation** - direct and source-triggered scan requests now reject unknown fields with 422 errors instead of silently dropping typoed inputs (#2319).
+- **Dashboard protected-view UX** - protected graph/dashboard views now turn empty API-key and browser authorization-header failures into sign-in/forbidden states instead of raw DOM exceptions (#2319).
+- **Graph API serialization readiness** - graph edges, attack paths, node detail relationships, diff metadata, and path query aliases now serialize consistently for dense graph consumers (#2323).
+- **Gateway upstream transport guardrails** - SSE upstreams are rejected with an explicit configuration error instead of being relayed through an incompatible POST path; streamable HTTP upstreams keep working (#2322).
+- **SQLite graph schema initialization race** - graph schema marker initialization is idempotent, preventing concurrent initializer failures in CI and tenant graph persistence (#2320).
+- **First-run sample flag alias** - the first-run sample CLI now accepts the documented target alias consistently (#2321).
+- **API extras diagnostics** - API startup dependency checks now report the missing import details instead of over-collapsing into a misleading extras message (#2325).
+- **Ready-PR refresh loop** - stranded approved PRs now have a safer refresh path so branch updates do not freeze behind stale checks (#2324).
+
+---
+
 ## [0.86.1] – 2026-05-06
 
 Patch release alignment after the `v0.86.0` tag failed before publish at the MCP registry serialization gate.
@@ -1119,7 +1140,8 @@ Two new product surfaces (inter-agent firewall + per-run discovery envelope) plu
 
 ---
 
-[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.86.1...HEAD
+[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.86.2...HEAD
+[0.86.2]: https://github.com/msaad00/agent-bom/compare/v0.86.1...v0.86.2
 [0.86.1]: https://github.com/msaad00/agent-bom/compare/v0.86.0...v0.86.1
 [0.86.0]: https://github.com/msaad00/agent-bom/compare/v0.85.0...v0.86.0
 [0.85.0]: https://github.com/msaad00/agent-bom/compare/v0.84.6...v0.85.0

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -188,7 +188,7 @@ Focused graph:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `0.86.1` | Current stable version (pinned) |
+| `0.86.2` | Current stable version (pinned) |
 
 Published images:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.3-alpine3.23@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510
 
-ARG VERSION=0.86.1
+ARG VERSION=0.86.2
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ for the full split-vs-single-image guidance.
 |------|----------|
 | CLI (`agent-bom agents`) | local audit + project scan |
 | Endpoint fleet (`--push-url …/v1/fleet/sync`) | employee laptops pushing into self-hosted fleet |
-| GitHub Action (`uses: msaad00/agent-bom@v0.86.1`) | CI/CD + SARIF |
+| GitHub Action (`uses: msaad00/agent-bom@v0.86.2`) | CI/CD + SARIF |
 | Docker (`agentbom/agent-bom`) | isolated scans, API jobs, and non-browser self-hosted entrypoints |
 | Browser UI image (`agentbom/agent-bom-ui`) | the dashboard image paired with the same self-hosted control plane |
 | Kubernetes / Helm (`helm install agent-bom deploy/helm/agent-bom`) | self-hosted API + dashboard, scheduled discovery |
@@ -429,7 +429,7 @@ References: [PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md) · [PRODUCT_METRICS.md](do
 <summary><b>CI/CD in 60 seconds</b></summary>
 
 ```yaml
-- uses: msaad00/agent-bom@v0.86.1
+- uses: msaad00/agent-bom@v0.86.2
   with:
     scan-type: scan
     severity-threshold: high

--- a/deploy/docker-compose.fullstack.yml
+++ b/deploy/docker-compose.fullstack.yml
@@ -27,7 +27,7 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
-    image: agentbom/agent-bom:0.86.1
+    image: agentbom/agent-bom:0.86.2
     container_name: agent-bom-api
     restart: unless-stopped
     command: api --host 0.0.0.0 --port 8422 --allow-insecure-no-auth
@@ -74,7 +74,7 @@ services:
       args:
         # Baked into the Next.js build — must match the publicly reachable API URL
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8422}
-    image: agentbom/agent-bom-ui:0.86.1
+    image: agentbom/agent-bom-ui:0.86.2
     container_name: agent-bom-ui
     restart: unless-stopped
     ports:

--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -18,7 +18,7 @@
 
 services:
   api:
-    image: agentbom/agent-bom:0.86.1
+    image: agentbom/agent-bom:0.86.2
     container_name: agent-bom-pilot-api
     restart: unless-stopped
     command: >
@@ -45,7 +45,7 @@ services:
       start_period: 10s
 
   ui:
-    image: agentbom/agent-bom-ui:0.86.1
+    image: agentbom/agent-bom-ui:0.86.2
     container_name: agent-bom-pilot-ui
     restart: unless-stopped
     environment:

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -112,7 +112,7 @@ services:
       dockerfile: Dockerfile
       args:
         NEXT_PUBLIC_API_URL: http://localhost:8422
-    image: agentbom/agent-bom-ui:0.86.1
+    image: agentbom/agent-bom-ui:0.86.2
     container_name: agent-bom-ui
     ports:
       - "3000:3000"

--- a/deploy/docker-compose.runtime.yml
+++ b/deploy/docker-compose.runtime.yml
@@ -31,7 +31,7 @@ services:
     build:
       context: ..
       dockerfile: deploy/docker/Dockerfile.runtime
-    image: agentbom/agent-bom:0.86.1
+    image: agentbom/agent-bom:0.86.2
     container_name: agent-bom-runtime-proxy
     depends_on:
       - mcp-server

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -27,7 +27,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.86.1
+ARG VERSION=0.86.2
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -17,7 +17,7 @@ WORKDIR /app
 COPY pyproject.toml README.md PYPI_README.md LICENSE ./
 COPY src/ ./src/
 
-ARG VERSION=0.86.1
+ARG VERSION=0.86.2
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
@@ -40,7 +40,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[runtime]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.86.1
+ARG VERSION=0.86.2
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.snowpark
+++ b/deploy/docker/Dockerfile.snowpark
@@ -26,7 +26,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11.12-slim@sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c
 
-ARG VERSION=0.86.1
+ARG VERSION=0.86.2
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -41,7 +41,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.86.1
+ARG VERSION=0.86.2
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: agent-bom
 description: Open security scanner and graph for AI supply chain and infrastructure — discover agents and MCP, map blast radius, and inspect runtime.
-version: 0.86.1
-appVersion: "0.86.1"
+version: 0.86.2
+appVersion: "0.86.2"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -24,17 +24,17 @@
 
 image:
   repository: agentbom/agent-bom
-  tag: "0.86.1"
+  tag: "0.86.2"
   pullPolicy: IfNotPresent
 
 uiImage:
   repository: agentbom/agent-bom-ui
-  tag: "0.86.1"
+  tag: "0.86.2"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom
-  tag: "0.86.1"
+  tag: "0.86.2"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -57,7 +57,7 @@ tests:
   includeUi: true
   image:
     repository: agentbom/agent-bom
-    tag: "0.86.1"
+    tag: "0.86.2"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deploy/k8s/cronjob.yaml
+++ b/deploy/k8s/cronjob.yaml
@@ -21,7 +21,7 @@ spec:
           serviceAccountName: agent-bom
           containers:
             - name: scanner
-              image: agentbom/agent-bom:0.86.1
+              image: agentbom/agent-bom:0.86.2
               command: ["agent-bom"]
               args:
                 - "scan"

--- a/deploy/k8s/daemonset.yaml
+++ b/deploy/k8s/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: agent-bom
       containers:
         - name: monitor
-          image: agentbom/agent-bom:0.86.1
+          image: agentbom/agent-bom:0.86.2
           command: ["agent-bom"]
           args:
             - "protect"

--- a/deploy/k8s/proxy-sidecar-pilot.yaml
+++ b/deploy/k8s/proxy-sidecar-pilot.yaml
@@ -109,7 +109,7 @@ spec:
               cpu: "500m"
 
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.86.1
+          image: agentbom/agent-bom:0.86.2
           args:
             - "--policy"
             - "/etc/agent-bom/policy.json"

--- a/deploy/k8s/sidecar-example.yaml
+++ b/deploy/k8s/sidecar-example.yaml
@@ -40,7 +40,7 @@ spec:
 
         # agent-bom proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.86.1
+          image: agentbom/agent-bom:0.86.2
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"

--- a/deploy/snowflake/native-app/manifest.yml
+++ b/deploy/snowflake/native-app/manifest.yml
@@ -15,10 +15,10 @@ artifacts:
     endpoint: ui
   container_services:
     images:
-      - /db/schema/agent_bom_repo/agent-bom:v0_86_1
-      - /db/schema/agent_bom_repo/agent-bom-ui:v0_86_1
-      - /db/schema/agent_bom_repo/agent-bom-scanner:v0_86_1
-      - /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_86_1
+      - /db/schema/agent_bom_repo/agent-bom:v0_86_2
+      - /db/schema/agent_bom_repo/agent-bom-ui:v0_86_2
+      - /db/schema/agent_bom_repo/agent-bom-scanner:v0_86_2
+      - /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_86_2
   service_roles:
     - name: api
       comment: >-

--- a/deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml
+++ b/deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom-mcp-runtime
-      image: /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_86_1
+      image: /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_86_2
       env:
         SNOWFLAKE_ACCOUNT: "{{ snowflake_account }}"
         SNOWFLAKE_DATABASE: "{{ database }}"

--- a/deploy/snowflake/native-app/service-specs/scanner-service.yaml
+++ b/deploy/snowflake/native-app/service-specs/scanner-service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom-scanner
-      image: /db/schema/agent_bom_repo/agent-bom-scanner:v0_86_1
+      image: /db/schema/agent_bom_repo/agent-bom-scanner:v0_86_2
       env:
         SNOWFLAKE_ACCOUNT: "{{ snowflake_account }}"
         SNOWFLAKE_DATABASE: "{{ database }}"

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -135,7 +135,7 @@ agent-bom agents --nebius -f json -o nebius-ai-scan.json
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.86.1
+- uses: msaad00/agent-bom@v0.86.2
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -71,7 +71,7 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # GitHub Actions
-- uses: msaad00/agent-bom@v0.86.1
+- uses: msaad00/agent-bom@v0.86.2
   with:
     scan-type: agents        # auto-detect MCP configs + deps
     severity-threshold: high # fail PR on HIGH+ CVEs
@@ -89,21 +89,21 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # Container image gate
-- uses: msaad00/agent-bom@v0.86.1
+- uses: msaad00/agent-bom@v0.86.2
   with:
     scan-type: image
     scan-ref: ghcr.io/acme/agent-runtime:sha-abcdef
     severity-threshold: critical
 
 # IaC gate
-- uses: msaad00/agent-bom@v0.86.1
+- uses: msaad00/agent-bom@v0.86.2
   with:
     scan-type: iac
     iac: Dockerfile,k8s/,infra/main.tf
     severity-threshold: high
 
 # Air-gapped or fully cached CI
-- uses: msaad00/agent-bom@v0.86.1
+- uses: msaad00/agent-bom@v0.86.2
   with:
     auto-update-db: false
     enrich: false
@@ -469,7 +469,7 @@ AmazonEC2ReadOnlyAccess
 docker run --rm \
   -v ~/.config:/home/abom/.config:ro \
   -v $(pwd):/workspace:ro \
-  agentbom/agent-bom:0.86.1 agents --format json
+  agentbom/agent-bom:0.86.2 agents --format json
 ```
 
 Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base image.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -242,7 +242,7 @@ blast_radius        — blast radius for a specific CVE
 ### CI/CD (GitHub Action)
 
 ```yaml
-- uses: msaad00/agent-bom@v0.86.1
+- uses: msaad00/agent-bom@v0.86.2
   with:
     format: sarif
     upload-sarif: 'true'

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,6 +1,6 @@
 {
   "generated_on": "2026-04-30",
-  "version": "0.86.1",
+  "version": "0.86.2",
   "metrics": [
     {
       "name": "MCP tools",

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -6,7 +6,7 @@ This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
 - Generated on: `2026-04-30`
-- Version: `0.86.1`
+- Version: `0.86.2`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -97,7 +97,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN" --no-browser
 clawhub publish integrations/openclaw/scan \
   --slug agent-bom-scan --name "agent-bom scan" \
-  --version "0.86.1"
+  --version "0.86.2"
 ```
 
 Release automation uses the same official `clawhub` CLI flow, not a custom
@@ -149,8 +149,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.86.1
-git push origin v0.86.1
+git tag v0.86.2
+git push origin v0.86.2
 ```
 
 This triggers:

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -13,7 +13,7 @@ For each tagged GitHub Release, expect:
 ## Download release assets
 
 ```bash
-TAG=v0.86.1
+TAG=v0.86.2
 VERSION="${TAG#v}"
 mkdir -p /tmp/agent-bom-release && cd /tmp/agent-bom-release
 gh release download "$TAG" --repo msaad00/agent-bom

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -33,7 +33,7 @@ The proxy interposes on the stdio channel between an MCP client (Claude Desktop,
 Use the published main runtime image:
 
 ```bash
-docker pull agentbom/agent-bom:0.86.1
+docker pull agentbom/agent-bom:0.86.2
 ```
 
 If you need to rebuild locally from the checked-out repo, you can still use
@@ -45,7 +45,7 @@ Run as a wrapper around any MCP server:
 ```bash
 docker run --rm \
   -v $(pwd)/audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.86.1 \
+  agentbom/agent-bom:0.86.2 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace
@@ -94,7 +94,7 @@ spec:
 
         # agent-bom runtime proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.86.1
+          image: agentbom/agent-bom:0.86.2
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"
@@ -334,7 +334,7 @@ Use the runtime container directly from Claude Desktop:
         "run", "--rm", "-i",
         "-v", "./workspace:/workspace",
         "-v", "./audit-logs:/var/log/agent-bom",
-        "agentbom/agent-bom:0.86.1",
+        "agentbom/agent-bom:0.86.2",
         "--log", "/var/log/agent-bom/audit.jsonl",
         "--block-undeclared",
         "--",

--- a/docs/archive/WINDOWS_CONTAINERS.md
+++ b/docs/archive/WINDOWS_CONTAINERS.md
@@ -113,7 +113,7 @@ container inspection. Windows Server environments should use:
 
 1. **Python CLI** -- `pip install agent-bom` works on Windows natively
 2. **Docker Desktop** -- run the Linux container images on Windows via WSL 2
-3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.86.1`) which
+3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.86.2`) which
    runs on Linux runners
 
 ---

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,4 +1,4 @@
-# agent-bom v0.86.1 blast-radius demo
+# agent-bom v0.86.2 blast-radius demo
 # Shows: blast radius → package gate
 
 Output docs/images/demo-latest.gif

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
-  "version": "0.86.1",
+  "version": "0.86.2",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
   "title": "agent-bom",
-  "version": "0.86.1",
+  "version": "0.86.2",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.86.1",
+      "version": "0.86.2",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   security checks. Use when the user mentions vulnerability scanning,
   MCP server trust, compliance, SBOM generation, CIS benchmarks, blast
   radius, or AI supply chain risk.
-version: 0.86.1
+version: 0.86.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -25,7 +25,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.86.1
+    docker: ghcr.io/msaad00/agent-bom:0.86.2
   openclaw:
     requires:
       bins: []
@@ -415,6 +415,6 @@ provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.86.1`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.86.2`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Analyze blast radius, attack paths, and threat landscape across your AI
   infrastructure. Use when: "blast radius", "threat intel", "risk score",
   "attack path", "lateral movement", "context graph", "who can reach what".
-version: 0.86.1
+version: 0.86.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.86.1
+    docker: ghcr.io/msaad00/agent-bom:0.86.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Generate SBOMs and compliance reports. Use when:
   "compliance report", "NIST", "SOC 2", "ISO 27001", "OWASP", "EU AI Act",
   "AISVS", "generate SBOM", "policy check".
-version: 0.86.1
+version: 0.86.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. OWASP/NIST/EU AI Act/MITRE
@@ -23,7 +23,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.86.1
+    docker: ghcr.io/msaad00/agent-bom:0.86.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/discover-aws/SKILL.md
+++ b/integrations/openclaw/discover-aws/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   inventory AWS Bedrock, ECS, SageMaker, Lambda, EKS, Step Functions, EC2, or
   agentic AWS infrastructure as canonical inventory. Passing that inventory
   to agent-bom is optional and operator-chosen.
-version: 0.86.1
+version: 0.86.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-azure/SKILL.md
+++ b/integrations/openclaw/discover-azure/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   giving agent-bom long-lived Azure credentials. Use when a user asks to
   inventory Azure OpenAI, Container Apps, AKS, Functions, ML, or agentic Azure
   infrastructure as canonical inventory.
-version: 0.86.1
+version: 0.86.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-gcp/SKILL.md
+++ b/integrations/openclaw/discover-gcp/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   giving agent-bom long-lived GCP credentials. Use when a user asks to
   inventory Vertex AI, Cloud Run, Cloud Functions, GKE, or agentic GCP
   infrastructure as canonical inventory.
-version: 0.86.1
+version: 0.86.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-snowflake/SKILL.md
+++ b/integrations/openclaw/discover-snowflake/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   agent-bom inventory JSON, and scan it without giving agent-bom long-lived
   Snowflake credentials. Use when a user asks to inventory Snowflake AI or
   Cortex infrastructure as canonical inventory.
-version: 0.86.1
+version: 0.86.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed with the snowflake extra, and

--- a/integrations/openclaw/discover/SKILL.md
+++ b/integrations/openclaw/discover/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Discover AI agents, MCP servers, and configurations on this machine or
   environment. Use when: "find agents", "what's configured", "doctor",
   "what MCP servers", "show me what's installed", "mcp inventory".
-version: 0.86.1
+version: 0.86.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.86.1
+    docker: ghcr.io/msaad00/agent-bom:0.86.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Enforce security policies on MCP tool calls and block dangerous operations at
   runtime. Use when: "block risky calls", "apply policy", "proxy",
   "runtime protection", "policy enforcement", "intercept MCP calls".
-version: 0.86.1
+version: 0.86.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.86.1
+    docker: ghcr.io/msaad00/agent-bom:0.86.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/ingest/SKILL.md
+++ b/integrations/openclaw/ingest/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   GCP, Snowflake, CMDB, or endpoint collectors. Use when a user has canonical
   inventory JSON and wants local findings, graph, policy, provenance, or
   auditor-ready exports without giving agent-bom direct cloud credentials.
-version: 0.86.1
+version: 0.86.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+ and agent-bom 0.84.4+. Inventory must conform to the

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Monitor agent fleet, track trust scores, and manage lifecycle states. Use
   when: "fleet", "watch agents", "runtime status", "trust scores",
   "fleet sync", "agent lifecycle", "serve dashboard".
-version: 0.86.1
+version: 0.86.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.86.1
+    docker: ghcr.io/msaad00/agent-bom:0.86.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.86.1
+version: 0.86.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.86.1
+version: 0.86.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Scan infrastructure-as-code, cloud configurations, and find secrets. Use when:
   "check terraform", "scan kubernetes", "IaC", "find secrets",
   "scan dockerfile", "cloud security", "misconfigurations".
-version: 0.86.1
+version: 0.86.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.86.1
+    docker: ghcr.io/msaad00/agent-bom:0.86.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   KEV), container images, provenance, filesystems, and SBOMs. Use
   when: "check package", "scan image", "verify", "is this safe",
   "scan dependencies", "CVE lookup", "blast radius".
-version: 0.86.1
+version: 0.86.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Native container image
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.86.1
+    docker: ghcr.io/msaad00/agent-bom:0.86.2
   openclaw:
     requires:
       bins: []
@@ -237,6 +237,6 @@ agent-bom agents
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.86.1`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.86.2`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Diagnose issues, check prerequisites, and validate configurations. Use when:
   "doctor", "debug", "why failing", "validate config", "check prerequisites",
   "something is broken", "db status", "fix my setup".
-version: 0.86.1
+version: 0.86.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.86.1
+    docker: ghcr.io/msaad00/agent-bom:0.86.2
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/vulnerability-intel/SKILL.md
+++ b/integrations/openclaw/vulnerability-intel/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   with explicit data-boundary choices. Use when a user asks for CVE lookup,
   advisory intelligence, exploitability context, fix versions, GHSA/OSV/NVD
   enrichment, or package vulnerability triage.
-version: 0.86.1
+version: 0.86.2
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+ and agent-bom installed from this repository or PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.86.1"
+version = "0.86.2"
 description = "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius."
 readme = "PYPI_README.md"
 license = "Apache-2.0"

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -45,6 +45,17 @@ VERSION_LOCATIONS: list[tuple[str, re.Pattern, str]] = [
     # Frontend package — UI version tracks the platform release so the docker image and
     # the Next.js build manifest agree on what version is shipping
     ("ui/package.json", re.compile(r'^(\s*"version":\s*")[^"]+(",?)', re.M), r"\g<1>{v}\g<2>"),
+    (
+        "ui/package-lock.json",
+        re.compile(r'(\A\{\n  "name": "ui",\n  "version": ")[^"]+(")', re.M),
+        r"\g<1>{v}\g<2>",
+    ),
+    (
+        "ui/package-lock.json",
+        re.compile(r'(\n    "": \{\n      "name": "ui",\n      "version": ")[^"]+(")', re.M),
+        r"\g<1>{v}\g<2>",
+    ),
+    ("uv.lock", re.compile(r'(\[\[package\]\]\nname = "agent-bom"\nversion = ")[^"]+(")', re.M), r"\g<1>{v}\g<2>"),
 ]
 
 OPENCLAW_SKILL_PATTERNS: list[tuple[str, re.Pattern, str]] = [
@@ -69,6 +80,22 @@ DOC_TEST_LOCATIONS: list[tuple[str, re.Pattern, str]] = [
     ("site-docs/deployment/control-plane-helm.md", re.compile(r"(--version\s+)\d+\.\d+\.\d+"), r"\g<1>{v}"),
     ("deploy/k8s/sidecar-example.yaml", re.compile(r"(agentbom/agent-bom:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
     ("deploy/k8s/proxy-sidecar-pilot.yaml", re.compile(r"(agentbom/agent-bom:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
+    ("deploy/k8s/cronjob.yaml", re.compile(r"(agentbom/agent-bom:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
+    (
+        "deploy/snowflake/native-app/manifest.yml",
+        re.compile(r"(:v)\d+_\d+_\d+"),
+        r"\g<1>{v_underscore}",
+    ),
+    (
+        "deploy/snowflake/native-app/service-specs/scanner-service.yaml",
+        re.compile(r"(:v)\d+_\d+_\d+"),
+        r"\g<1>{v_underscore}",
+    ),
+    (
+        "deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml",
+        re.compile(r"(:v)\d+_\d+_\d+"),
+        r"\g<1>{v_underscore}",
+    ),
     ("docs/PRODUCT_METRICS.md", re.compile(r"(- Version: `)\d+\.\d+\.\d+(`)"), r"\g<1>{v}\g<2>"),
     ("docs/PRODUCT_METRICS.json", re.compile(r'("version":\s*")\d+\.\d+\.\d+(")'), r"\g<1>{v}\g<2>"),
     ("docs/RELEASE_VERIFICATION.md", re.compile(r"^(TAG=v)\d+\.\d+\.\d+$", re.M), r"\g<1>{v}"),
@@ -113,6 +140,7 @@ def bump(new_version: str, *, dry_run: bool = False, check: bool = False) -> int
     if not re.match(r"^\d+\.\d+\.\d+$", new_version):
         print(f"ERROR: Invalid semver: {new_version}", file=sys.stderr)
         return 1
+    underscore_version = new_version.replace(".", "_")
 
     all_locations = VERSION_LOCATIONS + DOC_TEST_LOCATIONS
     for glob_pattern, pattern, template in OPENCLAW_SKILL_PATTERNS:
@@ -129,7 +157,7 @@ def bump(new_version: str, *, dry_run: bool = False, check: bool = False) -> int
             continue
 
         text = path.read_text()
-        replacement = template.format(v=new_version)
+        replacement = template.format(v=new_version, v_underscore=underscore_version)
         new_text, count = pattern.subn(replacement, text)
 
         if count == 0:

--- a/site-docs/deployment/airgapped-image-bundle.md
+++ b/site-docs/deployment/airgapped-image-bundle.md
@@ -16,7 +16,7 @@ From an internet-connected build host:
 
 ```bash
 scripts/release/build-airgap-image-bundle.sh \
-  --version 0.86.1 \
+  --version 0.86.2 \
   --platform linux/amd64 \
   --output-dir dist/airgap
 ```
@@ -37,8 +37,8 @@ machine.
 ## Import On The Disconnected Host
 
 ```bash
-tar -xzf agent-bom-airgap-0.86.1-linux_amd64.tar.gz
-cd agent-bom-airgap-0.86.1-linux_amd64
+tar -xzf agent-bom-airgap-0.86.2-linux_amd64.tar.gz
+cd agent-bom-airgap-0.86.2-linux_amd64
 ./load-images.sh
 ```
 
@@ -47,7 +47,7 @@ The loader verifies archive checksums before running `docker load`.
 ## Push To An Internal Registry
 
 ```bash
-VERSION=0.86.1
+VERSION=0.86.2
 REGISTRY=registry.internal.example.com/security
 
 docker tag "agentbom/agent-bom:${VERSION}" "${REGISTRY}/agent-bom:${VERSION}"
@@ -62,13 +62,13 @@ Then point Helm at the internal registry:
 ```yaml
 image:
   repository: registry.internal.example.com/security/agent-bom
-  tag: "0.86.1"
+  tag: "0.86.2"
 
 controlPlane:
   ui:
     image:
       repository: registry.internal.example.com/security/agent-bom-ui
-      tag: "0.86.1"
+      tag: "0.86.2"
 ```
 
 ## GitHub Actions Bundle Job

--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -332,8 +332,8 @@ through a managed tap instead of direct package upload.
 
 ```bash
 python3 scripts/render_homebrew_formula.py \
-  --version 0.86.1 \
-  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.86.1.tar.gz \
+  --version 0.86.2 \
+  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.86.2.tar.gz \
   --sha256 <release-sha256>
 ```
 

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -171,7 +171,7 @@ Install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.86.1 \
+  --version 0.86.2 \
   -n agent-bom --create-namespace \
   -f values.agent-bom.yaml
 ```
@@ -207,7 +207,7 @@ Then install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.86.1 \
+  --version 0.86.2 \
   -n agent-bom --create-namespace \
   -f deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
 ```

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -90,10 +90,10 @@ docker run --rm \
 ## Runtime proxy sidecar
 
 ```bash
-docker pull agentbom/agent-bom:0.86.1
+docker pull agentbom/agent-bom:0.86.2
 docker run --rm -i \
   -v ./audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.86.1 \
+  agentbom/agent-bom:0.86.2 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace

--- a/site-docs/features/policy.md
+++ b/site-docs/features/policy.md
@@ -49,7 +49,7 @@ agent-bom proxy --policy policy.json --block-undeclared -- ...
 
 ```yaml
 - name: Security gate
-  uses: msaad00/agent-bom@v0.86.1
+  uses: msaad00/agent-bom@v0.86.2
   with:
     policy: policy.json
     fail-on-violation: true

--- a/site-docs/reference/remediate-output.md
+++ b/site-docs/reference/remediate-output.md
@@ -27,7 +27,7 @@ agent-bom remediate -p . --format json --server-group --output plan.json
 
 ```json
 {
-  "version": "0.86.1",
+  "version": "0.86.2",
   "generated_at": "2026-04-21T12:00:00+00:00",
   "remediation_plan": [],
   "summary": {

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.86.1"
+    __version__ = "0.86.2"
 
 # Cross-check against pyproject.toml for dev installs where the editable
 # install metadata may be stale (i.e. version bumped but not re-installed).

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.86.1",
+  "version": "0.86.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.86.1",
+      "version": "0.86.2",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
         "@tanstack/react-table": "^8.21.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.86.1",
+  "version": "0.86.2",
   "private": true,
   "packageManager": "npm@10.9.7",
   "engines": {

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/lib/api', () => ({
       scan_sources: [],
       scan_count: 0,
     }),
-    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.86.1' }),
+    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.86.2' }),
   },
 }))
 

--- a/uv.lock
+++ b/uv.lock
@@ -21,7 +21,7 @@ overrides = [{ name = "python-dotenv", specifier = ">=1.2.2" }]
 
 [[package]]
 name = "agent-bom"
-version = "0.86.1"
+version = "0.86.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- bump release-managed package, Docker, Helm, UI, registry, docs, OpenClaw, Snowflake Native App, K8s cronjob, lockfile, and verification surfaces to 0.86.2
- add the 0.86.2 changelog entry for the audit-readiness patch set (#2319, #2320, #2321, #2322, #2323, #2324, #2325, #2326, #2327, #2328)
- extend scripts/bump-version.py so future release bumps also manage ui/package-lock.json, uv.lock, Snowflake Native App image refs, and deploy/k8s/cronjob.yaml

## Validation
- python scripts/bump-version.py 0.86.2 --check
- uv run python scripts/check_release_consistency.py
- PYTHONPATH=src uv run python scripts/generate_v1_schemas.py --check
- uv run pytest -q tests/test_api_endpoints.py tests/test_api_sources.py tests/test_mcp_http_scan_contract.py tests/test_gateway_upstreams.py tests/test_graph_api.py tests/test_deploy_manifests.py --tb=short -> 185 passed
- helm template agent-bom deploy/helm/agent-bom
- helm template agent-bom deploy/helm/agent-bom --set gateway.enabled=true --set-file gateway.upstreamsYaml=deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml
- uv run python scripts/check_product_surface_contract.py
- cd ui && npm ci
- cd ui && npm run typecheck
- cd ui && npm test -- --run -> 28 files / 189 tests passed
- cd ui && npm run lint
- cd ui && npm run build
- uv run ruff check scripts/bump-version.py
- git diff --check

## Notes
- Local UI validation used Node v25.9.0, which is outside the declared UI engine range >=22 <25; checks still passed after npm ci.
- Unrelated untracked duplicate docs were left untouched.