### PR TITLE
feat: add scanner driver registry

### DIFF
--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -17,6 +17,7 @@
 | `verify` | Verify package integrity / provenance or self-verify `agent-bom` |
 | `secrets` | Scan a directory for hardcoded secrets and PII |
 | `code` | Analyze source code for AI components, prompts, guardrails, and tools |
+| `scanners` | List scanner driver capabilities, inputs, outputs, and failure semantics |
 
 ### Runtime
 

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -532,6 +532,23 @@ async def create_scan(request: Request, body: ScanRequest) -> ScanJob:
     )
 
 
+@router.get("/v1/scan/drivers", tags=["scan"])
+async def list_scan_drivers(include_planned: bool = True) -> dict:
+    """List scanner driver contracts and orchestration semantics."""
+
+    from agent_bom.scanners.registry import (
+        list_registered_scanners,
+        scanner_registry_summary,
+        scanner_registry_warnings,
+    )
+
+    return {
+        "drivers": [registration.to_dict() for registration in list_registered_scanners(include_planned=include_planned)],
+        "summary": scanner_registry_summary(),
+        "warnings": scanner_registry_warnings(),
+    }
+
+
 @router.get("/v1/scan/{job_id}", response_model=ScanJob, tags=["scan"])
 async def get_scan(request: Request, job_id: str) -> ScanJob:
     """Fetch scan status and full results."""

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -280,6 +280,7 @@ main.commands["mcp-server"] = _mcp_server_hidden
 # Focused scan commands — `agent-bom image`, `agent-bom fs`, etc.
 # ---------------------------------------------------------------------------
 from agent_bom.cli._focused_commands import code_cmd, fs_cmd, iac_cmd, image_cmd, sbom_cmd, secrets_cmd  # noqa: E402
+from agent_bom.cli._scanner_registry import scanners_cmd  # noqa: E402
 
 main.add_command(image_cmd)
 main.add_command(fs_cmd)
@@ -287,6 +288,7 @@ main.add_command(iac_cmd)
 main.add_command(sbom_cmd)
 main.add_command(secrets_cmd)
 main.add_command(code_cmd)
+main.add_command(scanners_cmd)
 
 # ---------------------------------------------------------------------------
 # Skills command group — `agent-bom skills [scan|verify]`

--- a/src/agent_bom/cli/_scanner_registry.py
+++ b/src/agent_bom/cli/_scanner_registry.py
@@ -1,0 +1,64 @@
+"""Scanner driver registry CLI surfaces."""
+
+from __future__ import annotations
+
+import json
+
+import click
+from rich.table import Table
+
+from agent_bom.cli._common import _make_console
+from agent_bom.scanners.registry import list_registered_scanners, scanner_registry_summary, scanner_registry_warnings
+
+
+@click.command("scanners")
+@click.option("--include-planned/--active-only", default=True, help="Include planned scanner-driver slots.")
+@click.option("-f", "--format", "output_format", type=click.Choice(["console", "json"]), default="console", show_default=True)
+def scanners_cmd(include_planned: bool, output_format: str) -> None:
+    """List scanner drivers, capabilities, and failure semantics."""
+
+    drivers = list_registered_scanners(include_planned=include_planned)
+    summary = scanner_registry_summary()
+    warnings = scanner_registry_warnings()
+
+    if output_format == "json":
+        click.echo(
+            json.dumps(
+                {
+                    "drivers": [driver.to_dict() for driver in drivers],
+                    "summary": summary,
+                    "warnings": warnings,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return
+
+    console = _make_console()
+    table = Table(title="Scanner Driver Registry", show_lines=False)
+    table.add_column("Driver", style="bold cyan", no_wrap=True)
+    table.add_column("State", no_wrap=True)
+    table.add_column("Phase", no_wrap=True)
+    table.add_column("Failure", no_wrap=True)
+    table.add_column("Inputs")
+    table.add_column("Findings")
+    table.add_column("Summary")
+
+    for driver in drivers:
+        table.add_row(
+            driver.name,
+            driver.execution_state.value,
+            driver.phase.value,
+            driver.failure_mode.value,
+            ", ".join(driver.input_types) or "-",
+            ", ".join(driver.finding_types) or "-",
+            driver.summary,
+        )
+
+    console.print(table)
+    console.print(
+        f"[dim]total={summary['total']} active={summary['active']} passive={summary['passive']} planned={summary['planned']}[/dim]"
+    )
+    for warning in warnings:
+        console.print(f"[yellow]warning:[/yellow] {warning}")

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -50,6 +50,18 @@ from agent_bom.scanners.osv import enrich_results_if_needed as _enrich_results_i
 from agent_bom.scanners.osv import is_valid_fix_version as _is_valid_fix_version
 from agent_bom.scanners.osv import package_lookup_names as _package_lookup_names
 from agent_bom.scanners.osv import parse_fixed_version, query_osv_batch_impl
+from agent_bom.scanners.registry import (  # noqa: F401
+    ScannerExecutionState,
+    ScannerFailureMode,
+    ScannerPhase,
+    ScannerRegistration,
+    builtin_scanner_registrations,
+    get_scanner_registration,
+    list_registered_scanners,
+    register_scanner,
+    scanner_registry_summary,
+    scanner_registry_warnings,
+)
 from agent_bom.scanners.risk import (
     _parse_cvss4_vector,
     advisory_id_severity_fallback,

--- a/src/agent_bom/scanners/base.py
+++ b/src/agent_bom/scanners/base.py
@@ -1,0 +1,115 @@
+"""Shared scanner driver registry types.
+
+The first driver-registry layer is intentionally metadata-first. Existing scan
+execution remains wired through the current CLI/API pipeline, while each scanner
+declares its inputs, outputs, failure semantics, telemetry, and execution state.
+That gives product/API/UI surfaces a stable contract before individual scanner
+families are migrated behind a common run interface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Protocol
+
+from agent_bom.extensions import ExtensionCapabilities, RegistryEntry
+
+
+class ScannerPhase(str, Enum):
+    """Pipeline phase where a scanner driver contributes evidence."""
+
+    DISCOVERY = "discovery"
+    EXTRACTION = "extraction"
+    SCANNING = "scanning"
+    ENRICHMENT = "enrichment"
+    ANALYSIS = "analysis"
+    OUTPUT = "output"
+
+
+class ScannerExecutionState(str, Enum):
+    """Whether a driver is executable today or declared as a roadmap slot."""
+
+    ACTIVE = "active"
+    PASSIVE = "passive"
+    PLANNED = "planned"
+
+
+class ScannerFailureMode(str, Enum):
+    """How the orchestrator should treat driver failures."""
+
+    FAIL_CLOSED = "fail_closed"
+    WARN_AND_CONTINUE = "warn_and_continue"
+    SKIP_WHEN_UNAVAILABLE = "skip_when_unavailable"
+
+
+@dataclass(frozen=True)
+class ScannerRegistration(RegistryEntry):
+    """Registry metadata for a scanner driver implementation."""
+
+    phase: ScannerPhase = ScannerPhase.SCANNING
+    execution_state: ScannerExecutionState = ScannerExecutionState.ACTIVE
+    failure_mode: ScannerFailureMode = ScannerFailureMode.WARN_AND_CONTINUE
+    enabled_by_default: bool = True
+    run_attr: str = ""
+    input_types: tuple[str, ...] = ()
+    output_types: tuple[str, ...] = ()
+    finding_types: tuple[str, ...] = ()
+    skip_when: tuple[str, ...] = ()
+    telemetry_keys: tuple[str, ...] = ()
+    standards: tuple[str, ...] = ()
+    summary: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable API/CLI-safe representation."""
+
+        return {
+            "name": self.name,
+            "module": self.module,
+            "source": self.source,
+            "phase": self.phase.value,
+            "execution_state": self.execution_state.value,
+            "failure_mode": self.failure_mode.value,
+            "enabled_by_default": self.enabled_by_default,
+            "run_attr": self.run_attr,
+            "input_types": list(self.input_types),
+            "output_types": list(self.output_types),
+            "finding_types": list(self.finding_types),
+            "skip_when": list(self.skip_when),
+            "telemetry_keys": list(self.telemetry_keys),
+            "standards": list(self.standards),
+            "summary": self.summary,
+            "capabilities": {
+                "scan_modes": list(self.capabilities.scan_modes),
+                "required_scopes": list(self.capabilities.required_scopes),
+                "permissions_used": list(self.capabilities.permissions_used),
+                "outbound_destinations": list(self.capabilities.outbound_destinations),
+                "data_boundary": self.capabilities.data_boundary,
+                "writes": self.capabilities.writes,
+                "network_access": self.capabilities.network_access,
+                "guarantees": list(self.capabilities.guarantees),
+            },
+        }
+
+
+class ScannerDriver(Protocol):
+    """Protocol implemented by future executable scanner-driver extensions."""
+
+    name: str
+    capabilities: ExtensionCapabilities
+
+    def run(self, **kwargs: Any) -> dict[str, Any]:
+        """Run the scanner and return a serializable result payload."""
+
+
+@dataclass
+class ScannerRunTelemetry:
+    """Common telemetry envelope for future scanner-driver execution."""
+
+    scanner: str
+    status: str
+    duration_ms: float = 0.0
+    inputs_seen: int = 0
+    outputs_emitted: int = 0
+    findings_emitted: int = 0
+    warnings: list[str] = field(default_factory=list)

--- a/src/agent_bom/scanners/registry.py
+++ b/src/agent_bom/scanners/registry.py
@@ -1,0 +1,504 @@
+"""Scanner driver registry.
+
+This registry makes scanner families discoverable before every implementation
+is migrated behind one executor. It is the shared contract for CLI, API, UI,
+and future plugin drivers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_bom.extensions import ExtensionCapabilities, iter_entry_point_registrations
+from agent_bom.scanners.base import (
+    ScannerExecutionState,
+    ScannerFailureMode,
+    ScannerPhase,
+    ScannerRegistration,
+)
+
+_ENTRY_POINT_GROUP = "agent_bom.scanner_drivers"
+
+_SCANNER_REGISTRY: dict[str, ScannerRegistration] = {}
+_SCANNER_REGISTRY_WARNINGS: list[str] = []
+_SCANNER_REGISTRY_LOADED = False
+
+
+def _local_read_capabilities(
+    *,
+    scan_modes: tuple[str, ...] = ("local",),
+    guarantees: tuple[str, ...] = ("read_only",),
+) -> ExtensionCapabilities:
+    return ExtensionCapabilities(
+        scan_modes=scan_modes,
+        required_scopes=("local_project_read",),
+        outbound_destinations=(),
+        data_boundary="local_filesystem_read_only",
+        network_access=False,
+        guarantees=guarantees,
+    )
+
+
+def _network_read_capabilities(
+    *,
+    destinations: tuple[str, ...],
+    scan_modes: tuple[str, ...] = ("online",),
+    required_scopes: tuple[str, ...] = ("network_egress",),
+) -> ExtensionCapabilities:
+    return ExtensionCapabilities(
+        scan_modes=scan_modes,
+        required_scopes=required_scopes,
+        outbound_destinations=destinations,
+        data_boundary="read_only_metadata_lookup",
+        network_access=True,
+        guarantees=("read_only", "bounded_egress"),
+    )
+
+
+def _registration(
+    name: str,
+    module: str,
+    *,
+    phase: ScannerPhase,
+    run_attr: str,
+    input_types: tuple[str, ...],
+    output_types: tuple[str, ...],
+    finding_types: tuple[str, ...],
+    summary: str,
+    capabilities: ExtensionCapabilities,
+    failure_mode: ScannerFailureMode = ScannerFailureMode.WARN_AND_CONTINUE,
+    execution_state: ScannerExecutionState = ScannerExecutionState.ACTIVE,
+    enabled_by_default: bool = True,
+    skip_when: tuple[str, ...] = (),
+    telemetry_keys: tuple[str, ...] = (),
+    standards: tuple[str, ...] = (),
+    source: str = "builtin",
+) -> ScannerRegistration:
+    return ScannerRegistration(
+        name=name,
+        module=module,
+        capabilities=capabilities,
+        source=source,
+        phase=phase,
+        execution_state=execution_state,
+        failure_mode=failure_mode,
+        enabled_by_default=enabled_by_default,
+        run_attr=run_attr,
+        input_types=input_types,
+        output_types=output_types,
+        finding_types=finding_types,
+        skip_when=skip_when,
+        telemetry_keys=telemetry_keys,
+        standards=standards,
+        summary=summary,
+    )
+
+
+def builtin_scanner_registrations() -> list[ScannerRegistration]:
+    """Return built-in scanner registrations with capability metadata."""
+
+    local_read = _local_read_capabilities()
+    return [
+        _registration(
+            "sca-vulnerability",
+            "agent_bom.scanners",
+            phase=ScannerPhase.SCANNING,
+            run_attr="scan_agents_sync",
+            input_types=("agents", "packages"),
+            output_types=("blast_radii", "vulnerabilities", "findings"),
+            finding_types=("cve", "ghsa", "osv", "malicious-package", "dependency-confusion", "typosquat"),
+            summary="SCA vulnerability matching with OSV/GHSA/local DB, enrichment, KEV/EPSS, compliance, and blast radius.",
+            capabilities=_network_read_capabilities(destinations=("osv.dev", "github_advisory_database", "local_vulnerability_db")),
+            failure_mode=ScannerFailureMode.FAIL_CLOSED,
+            skip_when=("no_scan_requested", "no_packages_found"),
+            telemetry_keys=("packages_scanned", "api_batches", "cache_hits", "warnings", "duration_ms"),
+            standards=("OWASP", "NIST", "CIS", "SOC2", "EU_AI_ACT"),
+        ),
+        _registration(
+            "secret-patterns",
+            "agent_bom.secret_scanner",
+            phase=ScannerPhase.SCANNING,
+            run_attr="scan_secrets",
+            input_types=("filesystem_path", "source_file", "config_file"),
+            output_types=("secret_findings",),
+            finding_types=("credential", "pii", "hardcoded-secret"),
+            summary="Local file secret and PII pattern scanning using the shared runtime detector pattern library.",
+            capabilities=local_read,
+            failure_mode=ScannerFailureMode.WARN_AND_CONTINUE,
+            skip_when=("no_filesystem_scope", "file_too_large", "excluded_directory"),
+            telemetry_keys=("files_scanned", "findings_emitted", "warnings", "duration_ms"),
+            standards=("OWASP_LLM01", "CIS_16_4", "SOC2_CC6_1"),
+        ),
+        _registration(
+            "sast-semgrep",
+            "agent_bom.sast",
+            phase=ScannerPhase.SCANNING,
+            run_attr="scan_code",
+            input_types=("code_path", "sarif"),
+            output_types=("sast_data", "packages", "vulnerabilities"),
+            finding_types=("sast", "cwe", "owasp"),
+            summary="Semgrep/SARIF SAST normalization into the package/vulnerability model.",
+            capabilities=_local_read_capabilities(guarantees=("read_only", "local_rules_only", "remote_rules_disabled")),
+            failure_mode=ScannerFailureMode.SKIP_WHEN_UNAVAILABLE,
+            skip_when=("semgrep_missing", "no_code_scope"),
+            telemetry_keys=("files_scanned", "rules_loaded", "findings_emitted", "duration_ms"),
+            standards=("CWE", "OWASP", "SARIF"),
+        ),
+        _registration(
+            "container-image",
+            "agent_bom.image",
+            phase=ScannerPhase.DISCOVERY,
+            run_attr="scan_image",
+            input_types=("image_ref", "image_tar"),
+            output_types=("packages", "image_scan_strategy"),
+            finding_types=("container-package", "image-vulnerability-input"),
+            summary="Container image package extraction via local daemon, registry, or OCI tarball paths.",
+            capabilities=ExtensionCapabilities(
+                scan_modes=("image", "airgap"),
+                required_scopes=("image_read",),
+                permissions_used=("docker_socket_read", "registry_pull", "local_tar_read"),
+                outbound_destinations=("container_registry",),
+                data_boundary="image_metadata_and_layers_read_only",
+                network_access=True,
+                guarantees=("read_only",),
+            ),
+            failure_mode=ScannerFailureMode.WARN_AND_CONTINUE,
+            skip_when=("no_image_scope", "image_runtime_unavailable"),
+            telemetry_keys=("images_scanned", "packages_emitted", "strategy", "warnings", "duration_ms"),
+        ),
+        _registration(
+            "container-sbom-posture",
+            "agent_bom.cloud.container_sbom",
+            phase=ScannerPhase.ANALYSIS,
+            run_attr="scan_container_image",
+            input_types=("image_ref",),
+            output_types=("container_sbom_posture",),
+            finding_types=("unpinned-tag", "missing-sbom", "missing-provenance", "stale-image"),
+            summary="Read-only OCI metadata posture check for SBOM/provenance/staleness signals.",
+            capabilities=_network_read_capabilities(destinations=("docker_hub_registry_api",), scan_modes=("cloud", "container")),
+            failure_mode=ScannerFailureMode.WARN_AND_CONTINUE,
+            skip_when=("non_docker_hub_registry_metadata_only", "registry_unavailable"),
+            telemetry_keys=("images_checked", "registry_requests", "findings_emitted", "duration_ms"),
+            standards=("SLSA", "CycloneDX", "SPDX"),
+        ),
+        _registration(
+            "sbom-ingest",
+            "agent_bom.sbom",
+            phase=ScannerPhase.DISCOVERY,
+            run_attr="load_sbom",
+            input_types=("cyclonedx", "spdx", "sbom_json"),
+            output_types=("packages", "sbom_metadata"),
+            finding_types=("sbom-package",),
+            summary="SBOM ingestion for CycloneDX/SPDX documents into the shared package model.",
+            capabilities=local_read,
+            failure_mode=ScannerFailureMode.FAIL_CLOSED,
+            skip_when=("no_sbom_input",),
+            telemetry_keys=("packages_emitted", "format", "warnings", "duration_ms"),
+            standards=("CycloneDX", "SPDX"),
+        ),
+        _registration(
+            "iac-terraform",
+            "agent_bom.terraform",
+            phase=ScannerPhase.DISCOVERY,
+            run_attr="scan_terraform_dir",
+            input_types=("terraform_dir",),
+            output_types=("agents", "iac_findings"),
+            finding_types=("iac", "misconfiguration", "ai-infra"),
+            summary="Terraform AI infrastructure discovery and misconfiguration evidence.",
+            capabilities=local_read,
+            failure_mode=ScannerFailureMode.WARN_AND_CONTINUE,
+            skip_when=("no_terraform_scope",),
+            telemetry_keys=("files_scanned", "findings_emitted", "warnings", "duration_ms"),
+            standards=("MITRE_ATLAS", "CIS", "NIST"),
+        ),
+        _registration(
+            "cicd-github-actions",
+            "agent_bom.github_actions",
+            phase=ScannerPhase.DISCOVERY,
+            run_attr="scan_github_actions",
+            input_types=("github_actions_path",),
+            output_types=("agents", "workflow_findings"),
+            finding_types=("workflow-permissions", "unpinned-action", "secret-exposure", "fork-pr-risk"),
+            summary="GitHub Actions workflow inventory and CI/CD posture checks.",
+            capabilities=local_read,
+            failure_mode=ScannerFailureMode.WARN_AND_CONTINUE,
+            skip_when=("no_github_actions_scope",),
+            telemetry_keys=("workflows_scanned", "findings_emitted", "warnings", "duration_ms"),
+            standards=("SLSA", "CIS", "NIST"),
+        ),
+        _registration(
+            "dataset-card",
+            "agent_bom.parsers.dataset_cards",
+            phase=ScannerPhase.DISCOVERY,
+            run_attr="scan_dataset_directory",
+            input_types=("dataset_directory", "dataset_card"),
+            output_types=("dataset_cards",),
+            finding_types=("unlicensed-dataset", "missing-card", "unversioned-data", "remote-source"),
+            summary="Dataset-card provenance, license, and lineage scanner.",
+            capabilities=local_read,
+            failure_mode=ScannerFailureMode.WARN_AND_CONTINUE,
+            skip_when=("no_dataset_scope",),
+            telemetry_keys=("datasets_scanned", "flagged_count", "warnings", "duration_ms"),
+            standards=("EU_AI_ACT", "NIST_AI_RMF"),
+        ),
+        _registration(
+            "dataset-pii",
+            "agent_bom.parsers.dataset_pii_scanner",
+            phase=ScannerPhase.SCANNING,
+            run_attr="scan_directory_for_pii",
+            input_types=("csv", "json", "jsonl", "dataset_directory"),
+            output_types=("dataset_pii_findings",),
+            finding_types=("pii", "phi", "drivers_license", "email", "ssn"),
+            summary="Dataset row sampling scanner for PII/PHI exposure.",
+            capabilities=local_read,
+            failure_mode=ScannerFailureMode.WARN_AND_CONTINUE,
+            skip_when=("no_dataset_scope", "unsupported_file_type", "row_limit_reached"),
+            telemetry_keys=("files_scanned", "rows_scanned", "findings_emitted", "duration_ms"),
+            standards=("HIPAA", "EU_AI_ACT", "NIST_PRIVACY"),
+        ),
+        _registration(
+            "prompt-injection",
+            "agent_bom.parsers.prompt_scanner",
+            phase=ScannerPhase.SCANNING,
+            run_attr="scan_prompt_file",
+            input_types=("prompt_file", "instruction_file"),
+            output_types=("prompt_findings",),
+            finding_types=("prompt-injection", "hidden-instruction", "tool-exfiltration"),
+            summary="Prompt/instruction file scanning for injection and agentic abuse patterns.",
+            capabilities=local_read,
+            failure_mode=ScannerFailureMode.WARN_AND_CONTINUE,
+            skip_when=("no_prompt_scope", "unsupported_file_type"),
+            telemetry_keys=("files_scanned", "findings_emitted", "duration_ms"),
+            standards=("OWASP_LLM", "OWASP_AGENTIC"),
+        ),
+        _registration(
+            "license-policy",
+            "agent_bom.license_policy",
+            phase=ScannerPhase.ANALYSIS,
+            run_attr="evaluate_license_policy",
+            input_types=("agents", "packages", "license_policy"),
+            output_types=("license_report",),
+            finding_types=("license-block", "license-warning", "unknown-license"),
+            summary="SPDX license policy evaluation across discovered packages.",
+            capabilities=_local_read_capabilities(scan_modes=("analysis",)),
+            failure_mode=ScannerFailureMode.WARN_AND_CONTINUE,
+            skip_when=("no_packages_found", "license_policy_disabled"),
+            telemetry_keys=("packages_evaluated", "findings_emitted", "duration_ms"),
+            standards=("SPDX", "OpenChain"),
+        ),
+        _registration(
+            "firmware-advisory",
+            "agent_bom.scanners.firmware_advisory",
+            phase=ScannerPhase.SCANNING,
+            run_attr="scan_firmware_advisories",
+            input_types=("gpu_inventory", "firmware_inventory"),
+            output_types=("firmware_findings",),
+            finding_types=("firmware-cve", "bmc-cve", "driver-cve"),
+            summary="GPU firmware/BMC/driver advisory scanner for AI infrastructure.",
+            capabilities=_network_read_capabilities(destinations=("bundled_firmware_advisory_feed",), scan_modes=("infra", "gpu")),
+            failure_mode=ScannerFailureMode.WARN_AND_CONTINUE,
+            skip_when=("no_gpu_inventory", "advisory_feed_unavailable"),
+            telemetry_keys=("devices_scanned", "advisories_matched", "duration_ms"),
+            standards=("NVIDIA_CSAF", "CVE"),
+        ),
+        _registration(
+            "model-advisory",
+            "agent_bom.model_advisories",
+            phase=ScannerPhase.SCANNING,
+            run_attr="match_model_advisories",
+            input_types=("model_card", "model_inventory"),
+            output_types=("model_advisories",),
+            finding_types=("unsafe-model-format", "model-card-risk", "model-advisory"),
+            summary="Model-specific advisory and model-card risk matching.",
+            capabilities=_local_read_capabilities(scan_modes=("model",)),
+            failure_mode=ScannerFailureMode.WARN_AND_CONTINUE,
+            skip_when=("no_model_inventory", "feed_missing"),
+            telemetry_keys=("models_scanned", "advisories_matched", "duration_ms"),
+            standards=("NIST_AI_RMF", "EU_AI_ACT"),
+        ),
+        _registration(
+            "runtime-detectors",
+            "agent_bom.runtime.detectors",
+            phase=ScannerPhase.SCANNING,
+            run_attr="detector_pipeline",
+            input_types=("tool_call", "tool_response", "runtime_event"),
+            output_types=("runtime_findings", "policy_decisions"),
+            finding_types=("prompt-injection", "credential-leak", "rate-limit", "tool-drift", "vector-db-injection"),
+            summary="Runtime proxy detector family for agent/tool call enforcement.",
+            capabilities=ExtensionCapabilities(
+                scan_modes=("runtime", "proxy"),
+                required_scopes=("runtime_event_read",),
+                permissions_used=("tool_call_observe",),
+                outbound_destinations=(),
+                data_boundary="runtime_event_inline_redacted",
+                network_access=False,
+                guarantees=("redacted_evidence", "policy_enforced"),
+            ),
+            failure_mode=ScannerFailureMode.FAIL_CLOSED,
+            skip_when=("runtime_proxy_disabled",),
+            telemetry_keys=("events_scanned", "findings_emitted", "policy_blocks", "duration_ms"),
+            standards=("OWASP_LLM", "OWASP_MCP", "SOC2"),
+        ),
+        _registration(
+            "yara-signature",
+            "agent_bom.scanners.yara",
+            phase=ScannerPhase.SCANNING,
+            run_attr="scan_with_yara",
+            input_types=("file", "directory", "model_file", "artifact"),
+            output_types=("signature_findings",),
+            finding_types=("malware-signature", "unsafe-artifact", "model-file-indicator"),
+            summary="Reserved scanner-driver slot for local YARA-style artifact signatures; not executable in this release.",
+            capabilities=_local_read_capabilities(scan_modes=("signature",)),
+            failure_mode=ScannerFailureMode.SKIP_WHEN_UNAVAILABLE,
+            execution_state=ScannerExecutionState.PLANNED,
+            enabled_by_default=False,
+            skip_when=("driver_not_implemented", "ruleset_missing"),
+            telemetry_keys=("files_scanned", "rules_loaded", "matches", "duration_ms"),
+            standards=("YARA",),
+        ),
+        _registration(
+            "zero-day-heuristics",
+            "agent_bom.scanners.zero_day",
+            phase=ScannerPhase.ANALYSIS,
+            run_attr="score_zero_day_residual_risk",
+            input_types=("packages", "runtime_context", "exploit_signals", "graph_context"),
+            output_types=("residual_risk_scores", "prioritized_findings"),
+            finding_types=("residual-risk", "zero-day-susceptibility", "high-blast-radius-unfixed"),
+            summary="Reserved scanner-driver slot for residual/zero-day risk scoring across SCA, runtime, and graph context.",
+            capabilities=_local_read_capabilities(scan_modes=("analysis",)),
+            failure_mode=ScannerFailureMode.SKIP_WHEN_UNAVAILABLE,
+            execution_state=ScannerExecutionState.PLANNED,
+            enabled_by_default=False,
+            skip_when=("driver_not_implemented", "insufficient_context"),
+            telemetry_keys=("packages_scored", "contexts_used", "scores_emitted", "duration_ms"),
+            standards=("EPSS", "KEV", "NIST_AI_RMF"),
+        ),
+    ]
+
+
+def _coerce_scanner_registration(value: Any, entry_point_name: str) -> ScannerRegistration:
+    if isinstance(value, ScannerRegistration):
+        return value
+    name = str(getattr(value, "name", entry_point_name)).strip()
+    module = str(getattr(value, "module", "")).strip()
+    if not name or not module:
+        raise ValueError("scanner registration must declare name and module")
+    capabilities = getattr(value, "capabilities", ExtensionCapabilities())
+    if not isinstance(capabilities, ExtensionCapabilities):
+        capabilities = ExtensionCapabilities()
+    phase = getattr(value, "phase", ScannerPhase.SCANNING)
+    if not isinstance(phase, ScannerPhase):
+        phase = ScannerPhase(str(phase))
+    execution_state = getattr(value, "execution_state", ScannerExecutionState.ACTIVE)
+    if not isinstance(execution_state, ScannerExecutionState):
+        execution_state = ScannerExecutionState(str(execution_state))
+    failure_mode = getattr(value, "failure_mode", ScannerFailureMode.WARN_AND_CONTINUE)
+    if not isinstance(failure_mode, ScannerFailureMode):
+        failure_mode = ScannerFailureMode(str(failure_mode))
+    return ScannerRegistration(
+        name=name,
+        module=module,
+        capabilities=capabilities,
+        source=str(getattr(value, "source", "entry_point")),
+        phase=phase,
+        execution_state=execution_state,
+        failure_mode=failure_mode,
+        enabled_by_default=bool(getattr(value, "enabled_by_default", True)),
+        run_attr=str(getattr(value, "run_attr", "run")),
+        input_types=tuple(str(item) for item in getattr(value, "input_types", ())),
+        output_types=tuple(str(item) for item in getattr(value, "output_types", ())),
+        finding_types=tuple(str(item) for item in getattr(value, "finding_types", ())),
+        skip_when=tuple(str(item) for item in getattr(value, "skip_when", ())),
+        telemetry_keys=tuple(str(item) for item in getattr(value, "telemetry_keys", ())),
+        standards=tuple(str(item) for item in getattr(value, "standards", ())),
+        summary=str(getattr(value, "summary", "")),
+    )
+
+
+def register_scanner(registration: ScannerRegistration) -> None:
+    """Register a scanner driver with capability and execution metadata."""
+
+    if not registration.name:
+        raise ValueError("scanner registration must declare a name")
+    if registration.name in _SCANNER_REGISTRY:
+        raise ValueError(f"duplicate scanner registration: {registration.name}")
+    _SCANNER_REGISTRY[registration.name] = registration
+
+
+def _ensure_scanner_registry_loaded() -> None:
+    global _SCANNER_REGISTRY_LOADED
+    if _SCANNER_REGISTRY_LOADED:
+        return
+    for registration in builtin_scanner_registrations():
+        register_scanner(registration)
+    for registration in iter_entry_point_registrations(
+        group=_ENTRY_POINT_GROUP,
+        coerce=_coerce_scanner_registration,
+        warnings=_SCANNER_REGISTRY_WARNINGS,
+    ):
+        register_scanner(registration)
+    _SCANNER_REGISTRY_LOADED = True
+
+
+def list_registered_scanners(*, include_planned: bool = True) -> list[ScannerRegistration]:
+    """Return registered scanner drivers sorted by name."""
+
+    _ensure_scanner_registry_loaded()
+    registrations = [_SCANNER_REGISTRY[name] for name in sorted(_SCANNER_REGISTRY)]
+    if include_planned:
+        return registrations
+    return [registration for registration in registrations if registration.execution_state != ScannerExecutionState.PLANNED]
+
+
+def get_scanner_registration(name: str) -> ScannerRegistration:
+    """Return one scanner registration or raise ``KeyError``."""
+
+    _ensure_scanner_registry_loaded()
+    return _SCANNER_REGISTRY[name]
+
+
+def scanner_registry_warnings() -> list[str]:
+    """Return sanitized non-fatal registry loading warnings."""
+
+    _ensure_scanner_registry_loaded()
+    return list(_SCANNER_REGISTRY_WARNINGS)
+
+
+def scanner_registry_summary() -> dict[str, object]:
+    """Return a compact scanner registry summary for API/UI surfaces."""
+
+    registrations = list_registered_scanners(include_planned=True)
+    by_phase: dict[str, int] = {}
+    by_state: dict[str, int] = {}
+    for registration in registrations:
+        by_phase[registration.phase.value] = by_phase.get(registration.phase.value, 0) + 1
+        by_state[registration.execution_state.value] = by_state.get(registration.execution_state.value, 0) + 1
+    return {
+        "total": len(registrations),
+        "active": by_state.get(ScannerExecutionState.ACTIVE.value, 0),
+        "passive": by_state.get(ScannerExecutionState.PASSIVE.value, 0),
+        "planned": by_state.get(ScannerExecutionState.PLANNED.value, 0),
+        "by_phase": by_phase,
+        "by_state": by_state,
+    }
+
+
+def _reset_scanner_registry_for_tests() -> None:
+    _SCANNER_REGISTRY.clear()
+    _SCANNER_REGISTRY_WARNINGS.clear()
+    global _SCANNER_REGISTRY_LOADED
+    _SCANNER_REGISTRY_LOADED = False
+
+
+__all__ = [
+    "ScannerExecutionState",
+    "ScannerFailureMode",
+    "ScannerPhase",
+    "ScannerRegistration",
+    "builtin_scanner_registrations",
+    "get_scanner_registration",
+    "list_registered_scanners",
+    "register_scanner",
+    "scanner_registry_summary",
+    "scanner_registry_warnings",
+]

--- a/tests/test_scanner_driver_registry.py
+++ b/tests/test_scanner_driver_registry.py
@@ -1,0 +1,179 @@
+"""Tests for scanner driver registry contracts."""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import app
+from agent_bom.cli import main
+from agent_bom.extensions import ENTRYPOINTS_ENABLED_ENV, ExtensionCapabilities
+from agent_bom.scanners.base import ScannerExecutionState, ScannerFailureMode, ScannerPhase, ScannerRegistration
+
+
+class FakeEntryPoint:
+    def __init__(self, name: str, loader: Callable[[], Any]) -> None:
+        self.name = name
+        self._loader = loader
+
+    def load(self) -> Any:
+        return self._loader()
+
+
+class FakeEntryPoints(list):
+    def select(self, *, group: str) -> list[FakeEntryPoint]:
+        return [entry_point for entry_point in self if getattr(entry_point, "group", group) == group]
+
+
+def _patch_entry_points(monkeypatch, entries_by_group: dict[str, list[FakeEntryPoint]]) -> None:
+    entries = FakeEntryPoints()
+    for group, group_entries in entries_by_group.items():
+        for entry_point in group_entries:
+            entry_point.group = group
+            entries.append(entry_point)
+    monkeypatch.setattr("agent_bom.extensions.metadata.entry_points", lambda: entries)
+
+
+@pytest.fixture(autouse=True)
+def reset_scanner_registry(monkeypatch):
+    import agent_bom.scanners.registry as scanner_registry
+
+    monkeypatch.delenv(ENTRYPOINTS_ENABLED_ENV, raising=False)
+    scanner_registry._reset_scanner_registry_for_tests()
+    yield
+    monkeypatch.delenv(ENTRYPOINTS_ENABLED_ENV, raising=False)
+    scanner_registry._reset_scanner_registry_for_tests()
+    scanner_registry.list_registered_scanners()
+
+
+def test_builtin_scanner_registry_declares_core_scanner_families() -> None:
+    from agent_bom.scanners.registry import list_registered_scanners, scanner_registry_summary
+
+    scanners = {registration.name: registration for registration in list_registered_scanners()}
+
+    expected = {
+        "sca-vulnerability",
+        "secret-patterns",
+        "sast-semgrep",
+        "container-image",
+        "sbom-ingest",
+        "iac-terraform",
+        "cicd-github-actions",
+        "dataset-pii",
+        "prompt-injection",
+        "firmware-advisory",
+        "runtime-detectors",
+        "yara-signature",
+        "zero-day-heuristics",
+    }
+    assert expected <= set(scanners)
+    assert scanners["sca-vulnerability"].failure_mode is ScannerFailureMode.FAIL_CLOSED
+    assert scanners["sca-vulnerability"].capabilities.network_access is True
+    assert scanners["secret-patterns"].capabilities.network_access is False
+    assert scanners["sast-semgrep"].skip_when == ("semgrep_missing", "no_code_scope")
+    assert scanners["runtime-detectors"].phase is ScannerPhase.SCANNING
+    assert scanners["yara-signature"].execution_state is ScannerExecutionState.PLANNED
+    assert scanners["zero-day-heuristics"].enabled_by_default is False
+
+    summary = scanner_registry_summary()
+    assert summary["total"] == len(scanners)
+    assert summary["planned"] == 2
+    assert summary["by_phase"]["scanning"] >= 6
+
+
+def test_planned_scanners_can_be_excluded() -> None:
+    from agent_bom.scanners.registry import list_registered_scanners
+
+    active_names = {registration.name for registration in list_registered_scanners(include_planned=False)}
+
+    assert "sca-vulnerability" in active_names
+    assert "yara-signature" not in active_names
+    assert "zero-day-heuristics" not in active_names
+
+
+def test_duplicate_scanner_registration_is_rejected() -> None:
+    from agent_bom.scanners.registry import register_scanner
+
+    registration = ScannerRegistration(name="duplicate", module="agent_bom.tests.fake")
+    register_scanner(registration)
+
+    with pytest.raises(ValueError, match="duplicate scanner registration"):
+        register_scanner(registration)
+
+
+def test_entry_point_scanner_registration_loads_only_when_enabled(monkeypatch) -> None:
+    import agent_bom.scanners.registry as scanner_registry
+
+    module_name = "agent_bom.tests.fake_scanner_driver"
+    fake_module = types.ModuleType(module_name)
+    fake_module.run = lambda **_: {"ok": True}
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    registration = ScannerRegistration(
+        name="acme-secret-scanner",
+        module=module_name,
+        source="entry_point",
+        phase=ScannerPhase.SCANNING,
+        run_attr="run",
+        input_types=("filesystem_path",),
+        output_types=("secret_findings",),
+        finding_types=("credential",),
+        capabilities=ExtensionCapabilities(scan_modes=("local",), required_scopes=("local_project_read",)),
+    )
+    _patch_entry_points(
+        monkeypatch,
+        {"agent_bom.scanner_drivers": [FakeEntryPoint("acme-secret-scanner", lambda: registration)]},
+    )
+
+    scanner_registry._reset_scanner_registry_for_tests()
+    assert "acme-secret-scanner" not in {item.name for item in scanner_registry.list_registered_scanners()}
+
+    monkeypatch.setenv(ENTRYPOINTS_ENABLED_ENV, "true")
+    scanner_registry._reset_scanner_registry_for_tests()
+    scanners = {item.name: item for item in scanner_registry.list_registered_scanners()}
+
+    assert scanners["acme-secret-scanner"].source == "entry_point"
+    assert scanners["acme-secret-scanner"].input_types == ("filesystem_path",)
+
+
+def test_scan_drivers_api_endpoint_returns_contracts() -> None:
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.get("/v1/scan/drivers")
+
+    assert response.status_code == 200
+    body = response.json()
+    drivers = {driver["name"]: driver for driver in body["drivers"]}
+    assert body["summary"]["total"] == len(drivers)
+    assert drivers["sca-vulnerability"]["failure_mode"] == "fail_closed"
+    assert drivers["secret-patterns"]["capabilities"]["network_access"] is False
+    assert drivers["yara-signature"]["execution_state"] == "planned"
+
+
+def test_scan_drivers_api_can_hide_planned_slots() -> None:
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.get("/v1/scan/drivers?include_planned=false")
+
+    assert response.status_code == 200
+    names = {driver["name"] for driver in response.json()["drivers"]}
+    assert "secret-patterns" in names
+    assert "yara-signature" not in names
+
+
+def test_scanners_cli_lists_driver_contracts_as_json() -> None:
+    result = CliRunner().invoke(main, ["scanners", "--active-only", "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    body = json.loads(result.output)
+    names = {driver["name"] for driver in body["drivers"]}
+    assert "sca-vulnerability" in names
+    assert "secret-patterns" in names
+    assert "yara-signature" not in names


### PR DESCRIPTION
Summary
- add a metadata-first ScannerDriver registry contract for scanner families, including phase, execution state, failure mode, inputs, outputs, finding types, telemetry keys, standards, and capability boundaries
- register built-in scanner families for SCA, secrets, SAST, container/image, SBOM, IaC, CI/CD, datasets, prompts, license policy, firmware/model advisory, runtime detectors, plus planned YARA and zero-day residual-risk slots
- expose the registry through GET /v1/scan/drivers and a new agent-bom scanners CLI command with console/json output
- add tests for built-in contracts, extension entry-point gating, API output, planned-driver filtering, and CLI JSON output

Why
The scan stack already has specialized scanners, but orchestration and product surfaces could only infer them from CLI/API runner branches. This makes scanner capabilities explicit and independently testable before migrating execution behind a common driver interface.

Validation
- uv run pytest -q tests/test_scanner_driver_registry.py --tb=short
- uv run mypy src/agent_bom/scanners/base.py src/agent_bom/scanners/registry.py src/agent_bom/api/routes/scan.py src/agent_bom/cli/_scanner_registry.py
- uv run ruff check src/agent_bom/cli/_scanner_registry.py src/agent_bom/cli/__init__.py tests/test_scanner_driver_registry.py src/agent_bom/scanners/base.py src/agent_bom/scanners/registry.py src/agent_bom/api/routes/scan.py src/agent_bom/scanners/__init__.py
- uv run agent-bom scanners --active-only --format json
- pre-commit during commit: ruff, ruff-format, mypy, bandit, env-var drift passed
