### PR TITLE
fix: harden signed PR refresh automation

### DIFF
--- a/.github/workflows/auto-retrigger-stranded.yml
+++ b/.github/workflows/auto-retrigger-stranded.yml
@@ -72,7 +72,8 @@ jobs:
       - name: Find and retrigger stranded PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REQUIRED_CHECK: "Lint and Type Check"
+          AUTOMATION_SSH_SIGNING_KEY: ${{ secrets.AUTOMATION_SSH_SIGNING_KEY }}
+          REQUIRED_CHECKS: "Lint and Type Check,Test (Python 3.11),Test (Python 3.13),Build Package,Security Scan,CodeQL,Test (Python 3.14)"
           MIN_AGE_MINUTES: ${{ inputs.min_age_minutes || '3' }}
           PR_NUMBER: ${{ inputs.pr_number || '' }}
           REQUIRE_AUTO_MERGE: ${{ github.event_name != 'workflow_dispatch' || inputs.require_auto_merge }}

--- a/.github/workflows/dependabot-ui-lockfile-normalize.yml
+++ b/.github/workflows/dependabot-ui-lockfile-normalize.yml
@@ -77,6 +77,7 @@ jobs:
         # pushes back to the same-repo Dependabot branch with an explicit token
         # URL and full refspec.
         env:
+          AUTOMATION_SSH_SIGNING_KEY: ${{ secrets.AUTOMATION_SSH_SIGNING_KEY }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -94,10 +95,22 @@ jobs:
               ;;
           esac
 
+          if [ -z "${AUTOMATION_SSH_SIGNING_KEY:-}" ]; then
+            echo "::error::AUTOMATION_SSH_SIGNING_KEY is required before pushing normalized lockfiles to signed-commit protected PR branches."
+            exit 1
+          fi
+
+          eval "$(ssh-agent -s)"
+          ssh-add - <<< "${AUTOMATION_SSH_SIGNING_KEY}"
+          pubkey_path="${RUNNER_TEMP}/automation_signing_key.pub"
+          ssh-keygen -y -f <(printf '%s\n' "${AUTOMATION_SSH_SIGNING_KEY}") > "${pubkey_path}"
           git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.email "34316639+msaad00@users.noreply.github.com"
+          git config gpg.format ssh
+          git config user.signingkey "${pubkey_path}"
+          git config commit.gpgsign true
           git add ui/package-lock.json
-          git commit -m "chore(ui): normalize package-lock under pinned npm"
+          git commit -S -m "chore(ui): normalize package-lock under pinned npm"
           git push \
             --force-with-lease="refs/heads/${HEAD_REF}:${HEAD_SHA}" \
             "https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}.git" \

--- a/scripts/refresh_ready_prs.sh
+++ b/scripts/refresh_ready_prs.sh
@@ -21,8 +21,12 @@ MIN_AGE_MINUTES="${MIN_AGE_MINUTES:-3}"
 REQUIRE_AUTO_MERGE="${REQUIRE_AUTO_MERGE:-true}"
 DRY_RUN="${DRY_RUN:-false}"
 REQUIRED_CHECK="${REQUIRED_CHECK:-Lint and Type Check}"
+REQUIRED_CHECKS="${REQUIRED_CHECKS:-${REQUIRED_CHECK}}"
 MAX_POLLS="${MAX_POLLS:-12}"
 POLL_SECONDS="${POLL_SECONDS:-5}"
+AUTOMATION_SSH_SIGNING_KEY="${AUTOMATION_SSH_SIGNING_KEY:-}"
+AUTOMATION_COMMIT_EMAIL="${AUTOMATION_COMMIT_EMAIL:-34316639+msaad00@users.noreply.github.com}"
+AUTOMATION_COMMIT_NAME="${AUTOMATION_COMMIT_NAME:-github-actions[bot]}"
 
 if ! command -v gh >/dev/null 2>&1; then
   echo "gh is required" >&2
@@ -66,6 +70,68 @@ commits_missing_from_head() {
   local head_sha="$1"
   local base_sha="$2"
   gh api "repos/${REPO}/compare/${head_sha}...${base_sha}" --jq .ahead_by
+}
+
+push_url() {
+  if [ -n "${GIT_PUSH_URL:-}" ]; then
+    printf '%s\n' "${GIT_PUSH_URL}"
+  elif [ -n "${GH_TOKEN:-}" ]; then
+    printf 'https://x-access-token:%s@github.com/%s.git\n' "${GH_TOKEN}" "${REPO}"
+  else
+    printf 'git@github.com:%s.git\n' "${REPO}"
+  fi
+}
+
+configure_signed_commits() {
+  local repo_dir="$1"
+  local pubkey_path
+
+  if [ -z "${AUTOMATION_SSH_SIGNING_KEY}" ]; then
+    echo "AUTOMATION_SSH_SIGNING_KEY is required to refresh protected PR branches without creating unsigned commits." >&2
+    return 1
+  fi
+
+  eval "$(ssh-agent -s)" >/dev/null
+  ssh-add - <<< "${AUTOMATION_SSH_SIGNING_KEY}" >/dev/null
+  pubkey_path="${RUNNER_TEMP:-/tmp}/automation_signing_key.pub"
+  ssh-keygen -y -f <(printf '%s\n' "${AUTOMATION_SSH_SIGNING_KEY}") > "${pubkey_path}"
+  git -C "${repo_dir}" config user.name "${AUTOMATION_COMMIT_NAME}"
+  git -C "${repo_dir}" config user.email "${AUTOMATION_COMMIT_EMAIL}"
+  git -C "${repo_dir}" config gpg.format ssh
+  git -C "${repo_dir}" config user.signingkey "${pubkey_path}"
+  git -C "${repo_dir}" config commit.gpgsign true
+}
+
+refresh_pr_with_signed_merge() {
+  local pr="$1"
+  local head_ref="$2"
+  local head_sha="$3"
+  local tmp_dir remote_url actual_head
+
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "${tmp_dir}"' RETURN
+  remote_url="$(push_url)"
+
+  git -C "${tmp_dir}" init -q
+  git -C "${tmp_dir}" remote add origin "${remote_url}"
+  git -C "${tmp_dir}" fetch --no-tags origin \
+    "refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}" \
+    "refs/heads/${head_ref}:refs/remotes/origin/${head_ref}"
+  git -C "${tmp_dir}" switch -q --detach "origin/${head_ref}"
+
+  actual_head="$(git -C "${tmp_dir}" rev-parse HEAD)"
+  if [ "${actual_head}" != "${head_sha}" ]; then
+    echo "PR #${pr}: head changed while preparing refresh (${head_sha} -> ${actual_head}); next run will retry."
+    return 0
+  fi
+
+  configure_signed_commits "${tmp_dir}"
+  git -C "${tmp_dir}" merge --no-ff -S -m "Merge branch '${BASE_BRANCH}' into ${head_ref}" "origin/${BASE_BRANCH}"
+  git -C "${tmp_dir}" verify-commit HEAD
+  git -C "${tmp_dir}" push \
+    --force-with-lease="refs/heads/${head_ref}:${head_sha}" \
+    origin \
+    "HEAD:refs/heads/${head_ref}"
 }
 
 poll_head_change() {
@@ -137,7 +203,7 @@ refresh_pr() {
   missing="$(commits_missing_from_head "${head_sha}" "$(base_sha)")"
   if [ "${missing}" -eq 0 ]; then
     echo "PR #${pr}: already contains current ${BASE_BRANCH}; checking for stranded CI."
-    REQUIRED_CHECK="${REQUIRED_CHECK}" scripts/retrigger_stranded_pr.sh "${pr}"
+    REQUIRED_CHECKS="${REQUIRED_CHECKS}" scripts/retrigger_stranded_pr.sh "${pr}"
     return 0
   fi
 
@@ -147,16 +213,7 @@ refresh_pr() {
     return 0
   fi
 
-  if output="$(gh pr update-branch "${pr}" --repo "${REPO}" 2>&1)"; then
-    printf '%s\n' "${output}"
-  else
-    if grep -qi "update.*already.*progress" <<< "${output}"; then
-      echo "PR #${pr}: branch update already in progress; next run will verify CI."
-      return 0
-    fi
-    printf '%s\n' "${output}" >&2
-    return 1
-  fi
+  refresh_pr_with_signed_merge "${pr}" "${head_ref}" "${head_sha}"
 
   updated_sha="$(poll_head_change "${pr}" "${head_sha}")"
   if [ "${updated_sha}" = "${head_sha}" ]; then
@@ -165,7 +222,7 @@ refresh_pr() {
   fi
 
   echo "PR #${pr}: head advanced ${head_sha} -> ${updated_sha}; ensuring required checks attach."
-  REQUIRED_CHECK="${REQUIRED_CHECK}" scripts/retrigger_stranded_pr.sh "${pr}"
+  REQUIRED_CHECKS="${REQUIRED_CHECKS}" scripts/retrigger_stranded_pr.sh "${pr}"
 
   if [ "${review}" != "APPROVED" ]; then
     echo "PR #${pr}: refreshed, but review decision is ${review}; auto-merge will wait for review."

--- a/scripts/retrigger_stranded_pr.sh
+++ b/scripts/retrigger_stranded_pr.sh
@@ -7,9 +7,9 @@
 #
 # This script:
 #   1. Reads the PR's current head SHA.
-#   2. Checks whether the canonical required check ("Lint and Type Check") is
-#      attached to that SHA and is either pending/running/successful.
-#   3. If missing or terminally stale, closes + reopens the PR — the
+#   2. Checks whether all canonical required checks are attached to that SHA
+#      and are either pending/running/successful.
+#   3. If any are missing or terminally stale, closes + reopens the PR — the
 #      `reopened` action fires `pull_request` workflows again from scratch.
 #
 # Usage:
@@ -26,6 +26,7 @@ fi
 
 PR="$1"
 REQUIRED_CHECK="${REQUIRED_CHECK:-Lint and Type Check}"
+REQUIRED_CHECKS="${REQUIRED_CHECKS:-${REQUIRED_CHECK}}"
 REPO="${GH_REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
 
 HEAD_SHA="$(gh api "repos/${REPO}/pulls/${PR}" --jq .head.sha)"
@@ -34,47 +35,67 @@ if [ -z "${HEAD_SHA}" ]; then
   exit 1
 fi
 
-CHECK_STATE="$(
-  gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
-    --jq "[
-      .check_runs[]
-      | select(.name == \"${REQUIRED_CHECK}\")
-      | {status, conclusion}
-    ]" || printf '[]'
+CHECK_RUNS="$(
+  gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100" --jq '.check_runs' || printf '[]'
 )"
-if [ -z "${CHECK_STATE}" ]; then
-  CHECK_STATE="[]"
+if [ -z "${CHECK_RUNS}" ]; then
+  CHECK_RUNS="[]"
 fi
 
-CHECK_HITS="$(jq 'length' <<< "${CHECK_STATE}")"
-ACTIVE_HITS="$(jq '[.[] | select(.status != "completed")] | length' <<< "${CHECK_STATE}")"
-SUCCESS_HITS="$(jq '[.[] | select(.conclusion == "success")] | length' <<< "${CHECK_STATE}")"
-STALE_HITS="$(jq '[.[] | select(.conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "startup_failure" or .conclusion == "stale" or .conclusion == "skipped")] | length' <<< "${CHECK_STATE}")"
-FAILED_HITS="$(jq '[.[] | select(.conclusion == "failure")] | length' <<< "${CHECK_STATE}")"
+IFS=',' read -r -a REQUIRED_CHECK_LIST <<< "${REQUIRED_CHECKS}"
+missing=()
+stale=()
+active=()
+successful=()
+failed=()
 
-if [ "${ACTIVE_HITS}" -gt 0 ]; then
-  echo "PR #${PR}: '${REQUIRED_CHECK}' is already active on head ${HEAD_SHA}. No retrigger needed."
+for raw_check in "${REQUIRED_CHECK_LIST[@]}"; do
+  check="$(xargs <<< "${raw_check}")"
+  [ -n "${check}" ] || continue
+
+  check_state="$(jq --arg name "${check}" '[.[] | select(.name == $name) | {status, conclusion}]' <<< "${CHECK_RUNS}")"
+  check_hits="$(jq 'length' <<< "${check_state}")"
+  active_hits="$(jq '[.[] | select(.status != "completed")] | length' <<< "${check_state}")"
+  success_hits="$(jq '[.[] | select(.conclusion == "success" or .conclusion == "neutral")] | length' <<< "${check_state}")"
+  stale_hits="$(jq '[.[] | select(.conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "startup_failure" or .conclusion == "stale" or .conclusion == "skipped")] | length' <<< "${check_state}")"
+  failed_hits="$(jq '[.[] | select(.conclusion == "failure" or .conclusion == "action_required")] | length' <<< "${check_state}")"
+
+  if [ "${active_hits}" -gt 0 ]; then
+    active+=("${check}")
+  elif [ "${success_hits}" -gt 0 ]; then
+    successful+=("${check}")
+  elif [ "${failed_hits}" -gt 0 ] && [ "${stale_hits}" -eq 0 ]; then
+    failed+=("${check}")
+  elif [ "${check_hits}" -eq 0 ]; then
+    missing+=("${check}")
+  else
+    stale+=("${check}")
+  fi
+done
+
+if [ "${#failed[@]}" -gt 0 ]; then
+  printf "PR #%s: required check(s) failed on head %s: %s. Not retriggering real failures.\n" \
+    "${PR}" "${HEAD_SHA}" "$(IFS=', '; echo "${failed[*]}")"
   exit 0
 fi
 
-if [ "${SUCCESS_HITS}" -gt 0 ]; then
-  echo "PR #${PR}: head ${HEAD_SHA} already has successful '${REQUIRED_CHECK}'. No retrigger needed."
+if [ "${#missing[@]}" -eq 0 ] && [ "${#stale[@]}" -eq 0 ]; then
+  printf "PR #%s: required checks are attached on head %s (%s successful, %s active). No retrigger needed.\n" \
+    "${PR}" "${HEAD_SHA}" "${#successful[@]}" "${#active[@]}"
   exit 0
 fi
 
-if [ "${FAILED_HITS}" -gt 0 ] && [ "${STALE_HITS}" -eq 0 ]; then
-  echo "PR #${PR}: '${REQUIRED_CHECK}' failed on head ${HEAD_SHA}. Not retriggering a real failure."
-  exit 0
+reason_parts=()
+if [ "${#missing[@]}" -gt 0 ]; then
+  reason_parts+=("missing: $(IFS=', '; echo "${missing[*]}")")
 fi
-
-if [ "${CHECK_HITS}" -eq 0 ]; then
-  reason="required CI did not attach"
-else
-  reason="required CI is terminally stale (${STALE_HITS}/${CHECK_HITS} stale runs)"
+if [ "${#stale[@]}" -gt 0 ]; then
+  reason_parts+=("stale: $(IFS=', '; echo "${stale[*]}")")
 fi
+reason="$(IFS='; '; echo "${reason_parts[*]}")"
 
-echo "PR #${PR}: ${reason} for '${REQUIRED_CHECK}' on head ${HEAD_SHA}. Closing + reopening to retrigger required workflows."
-gh pr close "${PR}" --comment "auto-retrigger: ${reason} for '${REQUIRED_CHECK}' on head ${HEAD_SHA} (likely a GITHUB_TOKEN-authored 'Update branch' merge or cancelled required context). Reopening to re-run checks."
+echo "PR #${PR}: required CI is stranded on head ${HEAD_SHA} (${reason}). Closing + reopening to retrigger required workflows."
+gh pr close "${PR}" --comment "auto-retrigger: required CI is stranded on head ${HEAD_SHA} (${reason}). Reopening to re-run checks."
 
 # `gh pr close` returns before GitHub has propagated the state change to
 # the PR resource. Reopening too soon races: the reopen API call lands


### PR DESCRIPTION
Summary
- sign Dependabot UI lockfile normalization commits with the automation SSH signing key
- fail before pushing normalized lockfiles if the signing key is missing, instead of creating an unsigned commit that branch protection cannot merge
- stop ready-PR refresh automation from using GitHub's unsigned Update Branch merge path
- refresh stale ready PRs by creating a verified signed local merge commit and pushing it with force-with-lease
- broaden stranded-check detection from one sentinel check to the full required branch-protection context list

Root Cause
Protected `main` requires signed commits and strict required checks. Automation could create new PR heads that either lacked signatures or had only one checked context considered by the retrigger script. That left PRs showing green checks but still blocked, or showing no-op retrigger behavior when Python/Security/Build/CodeQL contexts were missing.

Validation
- `bash -n scripts/refresh_ready_prs.sh scripts/retrigger_stranded_pr.sh`
- parsed `.github/workflows/auto-retrigger-stranded.yml` and `.github/workflows/dependabot-ui-lockfile-normalize.yml` with PyYAML
- verified amended commit signature with `git verify-commit HEAD`
- pre-commit during commit: yaml/eof/whitespace/private-key/conflict/line-ending/env-var drift passed
