### PR TITLE
fix: align CI runtime toolchains

### DIFF
--- a/.github/actions/setup-ui/action.yml
+++ b/.github/actions/setup-ui/action.yml
@@ -1,0 +1,47 @@
+name: Setup UI toolchain
+description: Install the repository's canonical Node.js and npm versions for UI workflows
+
+inputs:
+  node-version:
+    description: Node.js major/version to install
+    default: "24"
+  npm-version:
+    description: Exact npm version declared by ui/package.json packageManager
+    default: "10.9.7"
+  working-directory:
+    description: Directory containing the UI package.json
+    default: "ui"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Pin npm
+      shell: bash
+      run: |
+        set -euo pipefail
+        npm install -g "npm@${{ inputs.npm-version }}"
+        actual="$(npm --version)"
+        if [ "${actual}" != "${{ inputs.npm-version }}" ]; then
+          echo "::error::Expected npm ${{ inputs.npm-version }}, got ${actual}"
+          exit 1
+        fi
+
+    - name: Verify UI package manager declaration
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+        node -e '
+          const fs = require("fs");
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          const expected = "npm@${{ inputs.npm-version }}";
+          if (pkg.packageManager !== expected) {
+            console.error(`::error::ui/package.json packageManager must be ${expected}; found ${pkg.packageManager}`);
+            process.exit(1);
+          }
+        '

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,13 @@ updates:
       - "dependencies"
       - "docker"
     open-pull-requests-limit: 5
+    ignore:
+      # ui/package.json and ui/Dockerfile intentionally pin the supported UI
+      # runtime to Node 24 LTS (`engines.node`: >=22 <25). Dependabot should
+      # not keep opening Node 25/26 base-image PRs that CI is designed to
+      # reject.
+      - dependency-name: "node"
+        versions: [">=25"]
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -43,6 +50,16 @@ updates:
       - "dependencies"
       - "javascript"
     open-pull-requests-limit: 5
+    groups:
+      next-stack:
+        patterns:
+          - "next"
+          - "eslint-config-next"
+          - "@next/eslint-plugin-next"
+      react-stack:
+        patterns:
+          - "react"
+          - "react-dom"
 
   - package-ecosystem: "npm"
     directory: "/sdks/typescript"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,10 +121,8 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '24'
+      - name: Set up UI toolchain
+        uses: ./.github/actions/setup-ui
 
       - name: Install dependencies
         run: uv sync --frozen --extra dev
@@ -280,10 +278,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '24'
+      - name: Set up UI toolchain
+        uses: ./.github/actions/setup-ui
 
       - name: Install UI dependencies
         run: |
@@ -519,11 +515,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.11', '3.13', '3.14']
-        include:
-          - python-version: '3.14'
-            experimental: true
-    # 3.14 is pre-release — failures are allowed but still reported
-    continue-on-error: ${{ matrix.experimental == true }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -685,7 +676,7 @@ jobs:
       contents: read
     needs: [changes]
     container:
-      image: python:3.12-alpine@sha256:7747d47f92cfca63a6e2b50275e23dba8407c30d8ae929a88ddd49a5d3f2d331
+      image: python:3.14.3-alpine3.23@sha256:faee120f7885a06fcc9677922331391fa690d911c020abb9e8025ff3d908e510
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -707,7 +698,7 @@ jobs:
 
       - name: Install project dependencies
         run: |
-          uv sync --frozen --extra dev --extra api --extra mcp-server
+          uv sync --frozen --extra dev --extra api --extra mcp-server --extra snowflake
 
       - name: Run tests (musl)
         run: |

--- a/.github/workflows/dependabot-ui-lockfile-normalize.yml
+++ b/.github/workflows/dependabot-ui-lockfile-normalize.yml
@@ -38,10 +38,8 @@ jobs:
           # resolution in a later step.
           persist-credentials: false
 
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '24'
+      - name: Set up UI toolchain
+        uses: ./.github/actions/setup-ui
 
       - name: Copy Dependabot UI manifests
         env:

--- a/.github/workflows/main-ui-smoke.yml
+++ b/.github/workflows/main-ui-smoke.yml
@@ -39,10 +39,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '24'
+      - name: Set up UI toolchain
+        uses: ./.github/actions/setup-ui
 
       - name: Install UI deps
         run: |

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -7095,6 +7095,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/ui/scripts/verify-toolchain.mjs
+++ b/ui/scripts/verify-toolchain.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 
 const root = process.cwd();
 const packageJson = JSON.parse(
@@ -30,6 +31,7 @@ const reactDomDeclared = packageJson.dependencies?.["react-dom"];
 const nodeEngines = packageJson.engines?.node;
 const packageManager = packageJson.packageManager;
 const expectedPackageManager = "npm@10.9.7";
+const expectedNpmVersion = expectedPackageManager.split("@").at(-1);
 
 if (!nextDeclared || !eslintConfigNextDeclared || !eslintDeclared || !nodeEngines || !packageManager) {
   fail("UI toolchain contract is incomplete: next, eslint-config-next, eslint, engines.node, and packageManager must all be declared.");
@@ -37,6 +39,17 @@ if (!nextDeclared || !eslintConfigNextDeclared || !eslintDeclared || !nodeEngine
 
 if (packageManager !== expectedPackageManager) {
   fail(`UI packageManager must stay pinned to ${expectedPackageManager}; found ${packageManager}.`);
+}
+
+let actualNpmVersion = "";
+try {
+  actualNpmVersion = execFileSync("npm", ["--version"], { encoding: "utf8" }).trim();
+} catch (error) {
+  fail(`Could not execute npm --version: ${error instanceof Error ? error.message : String(error)}`);
+}
+
+if (actualNpmVersion !== expectedNpmVersion) {
+  fail(`UI workflows must run npm ${expectedNpmVersion}; found npm ${actualNpmVersion}.`);
 }
 
 if (normalizeVersionRange(nextDeclared) !== normalizeVersionRange(eslintConfigNextDeclared)) {
@@ -82,5 +95,5 @@ if (!Number.isInteger(nodeMajor) || nodeMajor < 22 || nodeMajor > 24) {
 }
 
 console.log(
-  `UI toolchain contract verified: next ${nextInstalled}, eslint-config-next ${eslintConfigNextInstalled}, eslint ${eslintInstalled}, node ${process.versions.node}, package manager ${packageManager}.`,
+  `UI toolchain contract verified: next ${nextInstalled}, eslint-config-next ${eslintConfigNextInstalled}, eslint ${eslintInstalled}, node ${process.versions.node}, npm ${actualNpmVersion}, package manager ${packageManager}.`,
 );


### PR DESCRIPTION
Summary
- add a shared `.github/actions/setup-ui` action that installs Node 24 plus exact npm 10.9.7 before UI jobs run
- use the shared UI setup in CI UI/security paths, Dependabot UI lockfile normalization, and main UI smoke
- make `ui/scripts/verify-toolchain.mjs` assert the actual `npm --version`, not just the declared `packageManager`
- commit the npm 10.9.7-normalized UI lockfile output
- make Python 3.14 a required matrix leg instead of an allowed failure
- align Alpine/musl CI with the production Docker runtime image (`python:3.14.3-alpine3.23`) and install the production `snowflake` extra in that smoke
- prevent Dependabot from opening unsupported Node 25/26 UI Docker PRs while the UI engine range is `<25`
- group Next/ESLint and React/React-DOM Dependabot bumps so version-coupled UI packages move together

Root Cause
The repo declared a UI package manager pin and shipped a Python 3.14 Alpine runtime, but CI still used the runner's bundled npm and allowed Python 3.14 failures. Alpine coverage also tested Python 3.12 rather than the production 3.14 Alpine base. Dependabot was also allowed to open unsupported Node major PRs and split version-coupled UI packages into separate PRs.

Validation
- parsed `.github/dependabot.yml`, `.github/actions/setup-ui/action.yml`, `.github/workflows/ci.yml`, `.github/workflows/dependabot-ui-lockfile-normalize.yml`, and `.github/workflows/main-ui-smoke.yml` with PyYAML
- `python scripts/check_workflow_timeouts.py`
- `cd ui && npm run lock:normalize` is stable under npm 10.9.7
- `npm run verify:toolchain` locally fails as intended on this workstation's Node v25 drift; CI now installs Node 24/npm 10.9.7 before running it
- verified commit signature with `git verify-commit HEAD`
- pre-commit during commit: yaml/json/eof/whitespace/private-key/conflict/line-ending/env-var drift passed
