### PR TITLE
chore(ui): bump react stack to 19.2.6

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -14,8 +14,8 @@
         "@xyflow/react": "^12.10.2",
         "lucide-react": "^1.14.0",
         "next": "^16.2.4",
-        "react": "19.2.5",
-        "react-dom": "19.2.5",
+        "react": "19.2.6",
+        "react-dom": "19.2.6",
         "recharts": "^3.8.1"
       },
       "devDependencies": {
@@ -7095,6 +7095,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7221,24 +7222,24 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-is": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -30,8 +30,8 @@
     "@xyflow/react": "^12.10.2",
     "lucide-react": "^1.14.0",
     "next": "^16.2.4",
-    "react": "19.2.5",
-    "react-dom": "19.2.5",
+    "react": "19.2.6",
+    "react-dom": "19.2.6",
     "recharts": "^3.8.1"
   },
   "overrides": {


### PR DESCRIPTION
Summary
- replaces the split Dependabot React and React-DOM bumps with one aligned stack update
- updates both declared UI runtime dependencies to 19.2.6
- refreshes package-lock.json with npm 10.9.7 so peer dependency resolution stays consistent

Root Cause
Dependabot opened separate React and React-DOM PRs. The React-DOM-only PR fails npm resolution because react-dom@19.2.6 requires react@^19.2.6 while the root package still declares react@19.2.5. The UI toolchain contract also requires React and React-DOM to stay version-aligned.

Validation
- cd ui && npx -y -p node@24 -p npm@10.9.7 npm ci
- cd ui && npx -y -p node@24 -p npm@10.9.7 npm run verify:toolchain
- cd ui && npx -y -p node@24 -p npm@10.9.7 npm run typecheck
- cd ui && npx -y -p node@24 -p npm@10.9.7 npm test -- --run

Supersedes
- #2332
- #2333
