### PR TITLE
fix: install Alpine C++ build toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -683,13 +683,13 @@ jobs:
       - name: Install build deps (Alpine)
         run: |
           for attempt in 1 2 3; do
-            if apk add --no-cache bash gcc musl-dev libffi-dev openssl-dev git curl; then
+            if apk add --no-cache bash gcc g++ musl-dev libffi-dev openssl-dev git curl; then
               exit 0
             fi
             echo "apk add failed on attempt ${attempt}; retrying after transient package-index/network failure..."
             sleep $((attempt * 5))
           done
-          apk add --no-cache bash gcc musl-dev libffi-dev openssl-dev git curl
+          apk add --no-cache bash gcc g++ musl-dev libffi-dev openssl-dev git curl
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0


### PR DESCRIPTION
Summary
- add g++ to the Alpine/musl CI build dependencies
- fix Snowflake connector nanoarrow C++ extension builds on Python 3.14 Alpine

Root Cause
- The Alpine lane installs gcc but not g++; latest Snowflake connector dependency builds `snowflake.connector.nanoarrow_arrow_iterator` from C++ sources on musl/Python 3.14 and fails with `error: command 'g++' failed: No such file or directory`.\n\nValidation\n- python YAML parse for `.github/workflows/ci.yml` -> passed\n- pre-commit hooks during commit -> yaml/eof/whitespace/private-key/conflict/line-ending passed\n- commit signature verified locally with `git log --show-signature -1`\n- Docker Alpine reproduction not run locally because Docker daemon is not available\n\nCloses #2347.