### PR TITLE
fix: validate sandbox runtime by command name

### DIFF
--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -214,6 +214,13 @@ def sandbox_posture_warning(sandbox_evidence: Mapping[str, object]) -> str | Non
     )
 
 
+def _command_name_for_validation(command: str, sandbox_evidence: Mapping[str, object]) -> str:
+    """Validate sandbox-generated container runtimes by name, not resolved path."""
+    if sandbox_evidence.get("enabled") and sandbox_evidence.get("mode") in {"wrap_command_in_image", "harden_existing_container"}:
+        return Path(command).name
+    return command
+
+
 # ─── Proxy core ──────────────────────────────────────────────────────────────
 
 
@@ -1486,7 +1493,7 @@ async def run_proxy(
         logger.warning(warning)
 
     # Validate the effective server command before spawning
-    validate_command(server_cmd[0])
+    validate_command(_command_name_for_validation(server_cmd[0], sandbox_evidence))
     if len(server_cmd) > 1:
         validate_arguments(list(server_cmd[1:]))
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -19,6 +19,7 @@ from agent_bom.proxy import (
     AuditSpilloverStore,
     ProxyMetrics,
     ReplayDetector,
+    _command_name_for_validation,
     _control_plane_headers,
     _extract_jsonrpc_trace_meta,
     _gateway_policy_cache_path,
@@ -196,6 +197,15 @@ def test_sandbox_posture_warning_is_visible_when_disabled():
     assert "--no-isolate" in warning
     assert "--sandbox" not in warning
     assert sandbox_posture_warning({"enabled": True}) is None
+
+
+def test_sandbox_generated_runtime_validates_by_basename():
+    evidence = {"enabled": True, "mode": "wrap_command_in_image"}
+    assert _command_name_for_validation("/usr/local/bin/docker", evidence) == "docker"
+
+
+def test_user_supplied_absolute_command_stays_strict():
+    assert _command_name_for_validation("/usr/local/bin/docker", {"enabled": False}) == "/usr/local/bin/docker"
 
 
 # ── extract_tool_name ────────────────────────────────────────────────────────


### PR DESCRIPTION
Summary

Fixes a live proxy sandbox regression found during Docker-backed runtime testing:

- keep strict command allowlist validation for user-supplied commands
- validate sandbox-generated container runtime paths by basename, so a resolved Docker path like /usr/local/bin/docker matches the existing docker allowlist entry
- add focused regression coverage for both sandbox-generated and user-supplied absolute command behavior

Root Cause

The proxy wraps non-container stdio MCP commands in Docker when sandbox isolation is enabled. The sandbox wrapper resolves the container runtime path through shutil.which(), then run_proxy validates the effective argv[0]. On macOS this can become /usr/local/bin/docker, but the command allowlist contains docker by command name. That made the secure default sandbox path fail closed even when Docker was installed and the docker command itself was explicitly allowed.

Validation

- uv run pytest -q tests/test_proxy.py::test_sandbox_generated_runtime_validates_by_basename tests/test_proxy.py::test_user_supplied_absolute_command_stays_strict tests/test_proxy_sandbox.py --tb=short -> 32 passed
- uv run ruff check src/agent_bom/proxy.py tests/test_proxy.py -> passed
- live Docker smoke: agent-bom proxy --sandbox-image python:3.14.3-alpine3.23 --sandbox-mount /tmp:/host-tmp:ro -- python -u /host-tmp/abom_fake_mcp_stdio.py relayed tools/list and tools/call successfully and wrote chained proxy audit records

Runtime Notes

This preserves the intended fail-closed posture: arbitrary user-supplied absolute commands still remain strict. The relaxation only applies after the proxy has generated the sandbox container runtime command itself.
