### PR TITLE
fix: make demo remediation output trustworthy

### DIFF
--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -893,13 +893,14 @@ def scan(
                         con.print(f"    [yellow]⚠ {server.name}: blocked — {warnings}[/yellow]")
                     continue
                 pre_populated = list(server.packages)
-                if self_scan and pre_populated:
+                if (self_scan or demo) and pre_populated:
                     server.packages = pre_populated
                     total_packages += len(server.packages)
                     if verbose and server.packages:
+                        inventory_label = "demo inventory" if demo else "self-scan inventory"
                         con.print(
                             f"  [green]✓[/green] {server.name}: {len(server.packages)} package(s) "
-                            f"({server.packages[0].ecosystem}) [dim](self-scan inventory)[/dim]"
+                            f"({server.packages[0].ecosystem}) [dim]({inventory_label})[/dim]"
                         )
                     continue
                 _smithery_tok = smithery_token if smithery_flag else None

--- a/src/agent_bom/output/compact.py
+++ b/src/agent_bom/output/compact.py
@@ -65,6 +65,27 @@ def _compact_detail(text: str, limit: int = 88) -> str:
     return clean[: limit - 1].rstrip() + "…"
 
 
+def _forward_fix_version(br: object) -> str | None:
+    """Return a fix version only when it is a forward upgrade for this package."""
+    fixed = getattr(getattr(br, "vulnerability", None), "fixed_version", None)
+    if not fixed:
+        return None
+    package = getattr(br, "package", None)
+    current = str(getattr(package, "version", "") or "")
+    if current in ("", "unknown", "latest"):
+        return str(fixed)
+    ecosystem = str(getattr(package, "ecosystem", "") or "")
+    try:
+        from agent_bom.version_utils import compare_version_order
+
+        order = compare_version_order(current, str(fixed), ecosystem)
+    except Exception:  # noqa: BLE001
+        order = None
+    if order is not None and order >= 0:
+        return None
+    return str(fixed)
+
+
 def _agent_display_name(agent) -> str:
     """Return a human-readable agent label for compact tables."""
     name = str(getattr(agent, "name", "") or "").strip()
@@ -344,9 +365,9 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
     priority = [br for br in active_findings if br.is_actionable]
     rest_count = len(active_findings) - len(priority)
     if fixable_only:
-        priority = [br for br in priority if br.vulnerability.fixed_version]
+        priority = [br for br in priority if _forward_fix_version(br)]
     if not priority:
-        display_list = [br for br in active_findings if br.vulnerability.fixed_version] if fixable_only else active_findings
+        display_list = [br for br in active_findings if _forward_fix_version(br)] if fixable_only else active_findings
     else:
         display_list = priority
     shown = display_list[:limit]
@@ -385,7 +406,8 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
     table.add_column("Fix", ratio=1)
 
     for br in shown:
-        fix = f"[green]{br.vulnerability.fixed_version}[/green]" if br.vulnerability.fixed_version else "[dim]no fix[/dim]"
+        forward_fix = _forward_fix_version(br)
+        fix = f"[green]{forward_fix}[/green]" if forward_fix else "[dim]no fix[/dim]"
         # Exploit-likelihood (issue #486) — KEV wins; elevated EPSS-only
         # levels still surface a muted hint so the operator knows why
         # the row is flagged even when it's not in CISA KEV.
@@ -471,8 +493,9 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
             console.print(f"\n  [{style}]{br.vulnerability.id}[/{style}] · {pkg_ref} · [{style}]{sev_label}[/{style}]")
             if summary:
                 console.print(f"  {summary}")
-            if br.vulnerability.fixed_version:
-                console.print(f"  Fix: [green]upgrade to ≥ {br.vulnerability.fixed_version}[/green]")
+            forward_fix = _forward_fix_version(br)
+            if forward_fix:
+                console.print(f"  Fix: [green]upgrade to ≥ {forward_fix}[/green]")
             if has_blast_context and (br.affected_agents or br.exposed_credentials):
                 agent_str = ", ".join(a.name for a in br.affected_agents[:3])
                 cred_str = ", ".join(br.exposed_credentials[:3])
@@ -488,7 +511,7 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
 
     # Status bar
     console.print()
-    fixable = sum(1 for br in report.blast_radii if br.vulnerability.fixed_version)
+    fixable = sum(1 for br in report.blast_radii if _forward_fix_version(br))
     kev_count = sum(1 for br in report.blast_radii if br.vulnerability.is_kev)
     unknown_sev = sum(1 for br in report.blast_radii if br.vulnerability.severity == Severity.NONE)
     hints = ["[dim]--verbose[/dim] full details", "[dim]-f html[/dim] interactive report"]

--- a/src/agent_bom/output/console_render.py
+++ b/src/agent_bom/output/console_render.py
@@ -1142,7 +1142,7 @@ def build_remediation_plan(blast_radii: list[BlastRadius]) -> list[dict]:
             if is_prerelease_version(fv, br.package.ecosystem):
                 g["suppressed_prerelease_fixes"].add(fv)
             elif compare_versions(br.package.version, fv, br.package.ecosystem):
-                if g["fix"] is None or compare_versions(fv, g["fix"], br.package.ecosystem):
+                if g["fix"] is None or compare_versions(g["fix"], fv, br.package.ecosystem):
                     g["fix"] = fv
         g["vulns"].append(br.vulnerability.id)
         for a in br.affected_agents:

--- a/tests/test_cli_polish.py
+++ b/tests/test_cli_polish.py
@@ -16,6 +16,7 @@ from agent_bom.models import (
     Severity,
     Vulnerability,
 )
+from agent_bom.output.compact import _forward_fix_version
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -108,6 +109,24 @@ def test_fixable_only_all_fixed_shows_all():
     actionable = [br for br in brs if br.is_actionable]
     filtered = [br for br in actionable if br.vulnerability.fixed_version]
     assert len(filtered) == 2
+
+
+def test_forward_fix_version_hides_non_forward_advisory_fix():
+    br = _make_blast_radius(
+        pkg=_make_pkg(name="pillow", version="9.0.0", ecosystem="pypi"),
+        vuln=_make_vuln("CVE-2023-4863", Severity.HIGH, "0.1.8"),
+    )
+
+    assert _forward_fix_version(br) is None
+
+
+def test_forward_fix_version_keeps_forward_advisory_fix():
+    br = _make_blast_radius(
+        pkg=_make_pkg(name="pillow", version="9.0.0", ecosystem="pypi"),
+        vuln=_make_vuln("CVE-2023-50447", Severity.CRITICAL, "10.2.0"),
+    )
+
+    assert _forward_fix_version(br) == "10.2.0"
 
 
 # ── Phase 6b: CI detection ────────────────────────────────────────────────────

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -403,6 +403,27 @@ def test_demo_scan_hides_synthetic_project_temp_path():
     assert "Scanning 1 path(s) for IaC misconfigurations" not in result.output
 
 
+def test_demo_scan_preserves_curated_inventory_without_registry_fallback(monkeypatch):
+    captured: dict[str, int] = {}
+
+    def _extract_packages(*args, **kwargs):
+        raise AssertionError("demo mode should not add registry fallback packages")
+
+    def _scan_agents_sync(agents, *args, **kwargs):
+        captured["packages"] = sum(len(server.packages) for agent in agents for server in agent.mcp_servers)
+        return []
+
+    monkeypatch.setattr("agent_bom.cli.agents.extract_packages", _extract_packages)
+    monkeypatch.setattr("agent_bom.cli.agents.scan_agents_sync", _scan_agents_sync)
+
+    result = _run(["scan", "--demo", "--offline", "--no-auto-update-db"])
+
+    assert result.exit_code == 0
+    assert captured["packages"] == 12
+    assert "12 packages" in result.output
+    assert "PARTIAL COVERAGE" not in result.output
+
+
 def test_scan_format_sarif(tmp_path):
     """--format sarif should produce a SARIF file."""
     out = tmp_path / "results.sarif"

--- a/tests/test_output_cov.py
+++ b/tests/test_output_cov.py
@@ -818,6 +818,20 @@ def test_build_remediation_plan_no_downgrade():
     assert plan[0]["fix"] == "3.2.14"
 
 
+def test_build_remediation_plan_chooses_highest_forward_fix():
+    """Grouped remediation should not recommend a lower fix when a higher fix is needed."""
+    pkg = Package(name="pillow", version="9.0.0", ecosystem="pypi", vulnerabilities=[])
+    lower = Vulnerability(id="CVE-2026-0001", severity=Severity.HIGH, summary="Pillow issue", fixed_version="9.0.1")
+    higher = Vulnerability(id="CVE-2026-0002", severity=Severity.CRITICAL, summary="Pillow issue", fixed_version="10.2.0")
+    br1 = BlastRadius(vulnerability=lower, package=pkg, affected_agents=[], affected_servers=[], exposed_credentials=[], exposed_tools=[])
+    br2 = BlastRadius(vulnerability=higher, package=pkg, affected_agents=[], affected_servers=[], exposed_credentials=[], exposed_tools=[])
+
+    plan = build_remediation_plan([br1, br2])
+
+    assert len(plan) == 1
+    assert plan[0]["fix"] == "10.2.0"
+
+
 def test_build_remediation_plan_skips_prerelease_downgrade_for_npm():
     """npm canary/pre-release branches should not be emitted as a downgrade fix."""
     pkg = Package(name="next", version="16.2.1", ecosystem="npm", vulnerabilities=[])


### PR DESCRIPTION
Summary

Closes #2350.

Tightens the first-run demo and remediation output so the first command proves value cleanly:

- preserve the curated demo inventory instead of adding MCP registry fallback packages during demo mode
- keep `agent-bom agents --demo --offline` deterministic and free of partial-coverage noise when the local DB is populated
- fix grouped remediation version selection so the highest forward package fix wins
- suppress non-forward advisory fix versions in compact finding tables/details, avoiding output like `pillow@9.0.0 -> 0.1.8`

Root Cause

The demo inventory is intentionally pinned, but package extraction still ran registry fallback for pre-populated demo servers. That added a registry-derived MCP package not covered by the offline vulnerability DB, causing the public first-run command to exit with partial coverage.

Separately, grouped remediation compared candidate fixes in the wrong direction when choosing between multiple forward fixes for the same package. Compact finding output also displayed advisory-level fixed versions without checking that they were a forward upgrade for the scanned package version.

Validation

- uv run pytest -q tests/test_cli_scan.py::test_demo_scan_preserves_curated_inventory_without_registry_fallback tests/test_output_cov.py::test_build_remediation_plan_chooses_highest_forward_fix tests/test_cli_polish.py::test_forward_fix_version_hides_non_forward_advisory_fix tests/test_cli_polish.py::test_forward_fix_version_keeps_forward_advisory_fix tests/test_demo_inventory_accuracy.py --tb=short -> 6 passed
- uv run ruff check src/agent_bom/cli/agents/__init__.py src/agent_bom/output/console_render.py src/agent_bom/output/compact.py tests/test_cli_scan.py tests/test_output_cov.py tests/test_cli_polish.py -> passed
- live: uv run agent-bom agents --demo --offline -> exit 0, 12 curated packages, 57 offline findings, no PARTIAL COVERAGE
- live: Fix First now recommends pillow 9.0.0 -> 10.3.0 and suppresses the non-forward Pillow 0.1.8 advisory display
