### PR TITLE
feat: clarify product paths and monorepo scanning

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,149 @@
+# Agent Guidelines for agent-bom
+
+This is the root operating guide for agent contributors working in this repo.
+Keep it concise and route deep implementation details to the owning docs,
+tests, or package directories.
+
+`agent-bom` is an open security scanner and self-hosted control plane for
+AI-era infrastructure. The product must prove value across local scans, CI
+evidence, fleet inventory, graph-backed findings, MCP/runtime enforcement, and
+customer-controlled deployments.
+
+## Operating Contract
+
+Every material change should satisfy four lenses:
+
+| Lens | Question | Evidence expected |
+|---|---|---|
+| Product manager | Is the first run obvious, useful, and honest? | Clear command, visible artifact, no inflated claims, next step documented |
+| Sales engineer | Can this be proven live in a buyer environment? | CLI/Docker/API/Helm/runtime smoke evidence or a specific reason it was not run |
+| Account executive | Is the buyer/problem/value clear? | Framing tied to AI/MCP supply-chain risk, self-hosted adoption, and governance evidence |
+| Software/security engineer | Is it safe, accurate, scalable, and operable? | Tests, strict validation, auth/tenant/audit behavior, failure mode, and rollback notes |
+
+Do not present roadmap work as shipped product. If a claim is user-visible, tie
+it to code, tests, screenshots, docs, or live command output.
+
+## Project Structure
+
+```text
+agent-bom/
+├─ src/agent_bom/              # Python package: CLI, scanners, API, MCP, runtime, graph
+├─ ui/                         # Next.js dashboard
+├─ deploy/helm/agent-bom/      # Kubernetes and Helm control-plane/runtime chart
+├─ integrations/               # MCP registries, OpenClaw/Cortex/Docker integration assets
+├─ docs/                       # repo docs, security evidence, architecture, skills
+├─ site-docs/                  # published documentation site
+├─ tests/                      # Python regression and contract tests
+├─ sdks/typescript/            # TypeScript SDK surface
+└─ .github/workflows/          # CI, release, dependency, and security automation
+```
+
+High-signal entry points:
+
+- CLI scan path: `src/agent_bom/cli/agents/__init__.py`
+- scanner driver metadata: `src/agent_bom/scanner_drivers.py`
+- API app and routes: `src/agent_bom/api/server.py`, `src/agent_bom/api/routes/`
+- graph persistence/API: `src/agent_bom/db/graph_store.py`, `src/agent_bom/api/routes/graph.py`
+- MCP tools/server: `src/agent_bom/mcp_server.py`, `src/agent_bom/mcp_tools/`
+- runtime proxy/gateway: `src/agent_bom/proxy_server.py`, `src/agent_bom/gateway_server.py`
+- dashboard: `ui/app/`, `ui/components/`, `ui/lib/`
+- deployment chart: `deploy/helm/agent-bom/templates/`
+
+## Product Lanes
+
+Use this framing when editing public docs, UI copy, release notes, demos, or
+examples:
+
+1. **Scan locally** — CLI, Docker, and GitHub Action produce findings, SARIF,
+   SBOMs, HTML reports, and graph exports.
+2. **Send evidence to a control plane** — fleet sync, REST API, Helm/EKS, and
+   the browser UI centralize inventory, graph state, compliance, audit, and
+   governance.
+3. **Enforce runtime behavior** — MCP server mode, proxy/gateway, and Shield
+   SDK turn the same model into assistant and tool-call controls.
+
+These lanes are one product and one evidence model. They do not weaken the
+self-hosted story: production control planes run in the customer's own cloud,
+VPC, Kubernetes cluster, database, identity, and audit boundary.
+
+## Integration Bar
+
+Integrations are distribution surfaces, not footnotes. For integration work,
+document the first command, credential boundary, artifact, and next step.
+
+Important integration families:
+
+- MCP/coding agents: Claude, Cursor, Windsurf, VS Code, Cortex Code, OpenAI
+  Codex CLI, and other MCP clients.
+- Skills/registries: OpenClaw skills, Cortex Code skill, MCP Registry,
+  Smithery, Glama, Docker MCP registry.
+- Developer workflow: CLI, Docker, GitHub Action, SARIF, SBOM, pre-install
+  `check`, PR comments, and CI gates.
+- Cloud and AI infra: AWS, Azure, GCP, Snowflake, Databricks, CoreWeave,
+  Nebius, Hugging Face, OpenAI, W&B, MLflow, Ollama.
+- Runtime and app frameworks: MCP proxy/gateway, Shield SDK, Anthropic/OpenAI
+  SDK patterns, LangChain, CrewAI.
+- Governance and observability: Postgres/Supabase, ClickHouse, Snowflake paths,
+  OTEL, SIEM/export hooks, compliance bundles.
+
+## Core Commands
+
+```bash
+uv run pytest -q
+uv run ruff check src tests
+uv run mypy src/agent_bom
+uv run agent-bom agents --demo --offline
+
+cd ui
+npm run verify:toolchain
+npm run typecheck
+npm test -- --run
+npm run build
+```
+
+Run narrower checks when the change is narrow, but list exactly what you ran in
+the PR body.
+
+Minimum verification matrix:
+
+| Change scope | Minimum verification |
+|---|---|
+| CLI/scanner behavior | targeted `tests/test_cli*` or scanner tests plus one real `agent-bom agents` smoke |
+| API routes/models | targeted API tests plus schema/codegen check when contracts change |
+| graph persistence/API/UI | graph API tests plus a live or fixture graph with non-empty nodes and edges |
+| runtime proxy/gateway | targeted runtime tests plus a live JSON-RPC smoke when feasible |
+| Helm/deploy | `helm template` for affected profiles plus YAML lint where available |
+| UI | `npm run verify:toolchain`, typecheck, tests; browser/screenshot review for visible changes |
+| docs/positioning only | stale-command search and `git diff --check`; do not claim untested capabilities |
+| dependency/toolchain | package-specific install, lockfile/toolchain verification, and affected tests |
+
+## Repo Rules
+
+- Keep changes scoped. Do not mix dependency bumps, product docs, UI changes,
+  and scanner behavior unless one is required by the other.
+- Preserve signed commits and avoid synthetic GitHub update-branch churn; use
+  local rebase plus `--force-with-lease` when a PR branch must be refreshed.
+- Do not edit generated artifacts unless the owning generation command is run
+  and documented.
+- For bug fixes, add or update a regression test that fails without the fix.
+- For user-visible dashboard or graph changes, verify readability in light and
+  dark themes and avoid dense unreadable canvases as the first view.
+- For auth, tenant, audit, firewall, gateway, and proxy changes, document
+  fail-open/fail-closed behavior explicitly.
+- For docs, avoid vague capability lists. Prefer "first command -> artifact ->
+  next step."
+
+## Release Readiness
+
+Before a release readiness claim, check:
+
+- latest `main` CI state and open release-blocker issues
+- PyPI/install smoke or local wheel smoke, depending on release stage
+- Docker/Helm smoke for the advertised deployment path
+- API `/health` and `/docs` behavior under the intended auth mode
+- MCP tool listing and strict-argument behavior
+- graph/finding links with real scan data, not only synthetic fixtures
+- runtime proxy/gateway smoke when runtime is part of the release narrative
+- README, Docker Hub README, docs site, version surfaces, and changelog alignment
+
+If a check cannot be run, say so directly and keep the claim narrower.

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,29 @@
+# Shared Agent Setup
+
+This directory is the repo-owned source of truth for assistant and agent
+behavior in agent-bom.
+
+Use `.agents/` for configuration and guidance that should apply across tools.
+Do not put durable shared guidance only in `.claude/`, `.cursor/`, `.vscode/`,
+or another provider-specific directory.
+
+## Layout
+
+- `AGENTS.md`: canonical shared root instructions.
+- `config.json`: shared bootstrap and MCP configuration for tool-specific shims.
+- `skills/`: shared, tool-neutral implementation guidance for recurring
+  workflows.
+
+The repo root `AGENTS.md` is a discovery shim that points to
+`.agents/AGENTS.md`, so tools can find the guide without duplicating it.
+
+## When To Edit
+
+Edit `.agents/AGENTS.md` when the standing engineering or product operating
+contract changes.
+
+Edit `.agents/config.json` when you need to change shared bootstrap commands,
+default development commands, or repo-owned MCP servers.
+
+Do not hand-edit generated provider files once generation exists. Edit the
+canonical files in `.agents/` and regenerate the shims.

--- a/.agents/config.json
+++ b/.agents/config.json
@@ -1,0 +1,28 @@
+{
+  "shared": {
+    "setupScript": "uv sync --all-extras && cd ui && npm ci",
+    "devCommand": "agent-bom serve --port 8422",
+    "devTerminalDescription": "agent-bom API/control-plane development server"
+  },
+  "mcpServers": {
+    "agent-bom-local": {
+      "transport": "stdio",
+      "command": "agent-bom",
+      "args": ["mcp", "server"]
+    }
+  },
+  "claude": {
+    "settings": {}
+  },
+  "cursor": {
+    "environment": {
+      "agentCanUpdateSnapshot": false
+    }
+  },
+  "codex": {
+    "environment": {
+      "version": 1,
+      "name": "agent-bom"
+    }
+  }
+}

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,14 @@
+# Shared Agent Skills
+
+Put durable, reusable repo guidance here when a workflow deserves more detail
+than the root agent guide.
+
+Good candidates:
+
+- runtime proxy/gateway release validation
+- graph readability and graph API correctness checks
+- scanner driver implementation patterns
+- dependency and CI refresh playbooks
+- product positioning and first-run evidence review
+
+Do not use this directory for one-off task notes.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,6 +24,9 @@ body:
         - pip
         - Docker
         - GitHub Action
+        - MCP client / coding agent
+        - Self-hosted API / dashboard
+        - Kubernetes / Helm
         - From source
     validations:
       required: true
@@ -74,3 +77,9 @@ body:
     attributes:
       label: Python version
       placeholder: "e.g. 3.12.4"
+
+  - type: textarea
+    id: contribution-interest
+    attributes:
+      label: Are you interested in contributing a fix?
+      description: Optional. If yes, say whether you want guidance on a code, docs, integration, or test change.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -42,6 +42,7 @@ body:
         - Dashboard / UI
         - Compliance / policy
         - Cloud providers
+        - Integrations / skills / MCP clients
         - Container / K8s scanning
         - SBOM / output formats
         - Runtime (proxy / protect / watch)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.agents/AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,14 @@
 
 agent-bom has 7,000+ monthly installs. Every contribution directly improves security for real AI agent deployments. This guide gets you from zero to merged PR.
 
+The best ways to help:
+
+- Try the demo and open issues for confusing output, missing context, or weak remediation.
+- Request integrations for MCP clients, coding agents, CI systems, cloud providers, and security workflows you actually use.
+- Pick a `good first issue` or `help wanted` task and comment before starting.
+- Improve docs, screenshots, diagrams, and first-run examples when something is unclear.
+- Star, share, or recommend the project when agent-bom gives you useful evidence; community signal helps security teams trust an open tool.
+
 ## Table of contents
 
 - [Quick start (5 minutes)](#quick-start)
@@ -27,7 +35,7 @@ pre-commit install                                  # wires ruff + ruff-format h
 pytest tests/ -x -q                                # must be green before you start
 ```
 
-That's it. `agent-bom scan` now runs from your local checkout.
+That's it. `agent-bom agents` now runs from your local checkout.
 Use `.[dev]` only for a lighter core workflow; `.[dev-all]` is the supported full-suite contributor setup.
 
 ---
@@ -65,6 +73,10 @@ See [open issues labeled P1](https://github.com/msaad00/agent-bom/issues?q=is%3A
 ---
 
 ## Development workflow
+
+Start with [`AGENTS.md`](AGENTS.md) when using assistant or agent workflows in
+this repo. It captures the product, security, verification, and release lenses
+that should be applied alongside this contributor guide.
 
 ```bash
 # Create a branch

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -1,6 +1,6 @@
 # agent-bom
 
-**Open security scanner for AI supply chain — agents, MCP servers, packages, containers, cloud, GPU, and runtime.**
+**Open security scanner and control plane for AI-era infrastructure — local scans, CI evidence, fleet inventory, MCP/runtime enforcement, and self-hosted governance.**
 
 Every CVE in your AI stack is a credential leak waiting to happen. `agent-bom`
 follows the chain end-to-end and tells you which fix collapses it first.
@@ -48,6 +48,17 @@ References:
 - GitHub README: https://github.com/msaad00/agent-bom/blob/main/README.md
 - Product brief: https://github.com/msaad00/agent-bom/blob/main/docs/PRODUCT_BRIEF.md
 - Verified metrics: https://github.com/msaad00/agent-bom/blob/main/docs/PRODUCT_METRICS.md
+
+## Choose Your Path
+
+Start with one lane. The scanner, API, UI, gateway, proxy, and MCP tools all
+feed the same evidence model.
+
+| Lane | Start with | Produces |
+|------|------------|----------|
+| **Scan locally** | `docker run --rm agentbom/agent-bom:latest agents --demo` | findings, SARIF, SBOM, HTML, graph exports |
+| **Send evidence to a control plane** | `docker compose -f docker-compose.pilot.yml up -d` | fleet inventory, scan jobs, graph state, compliance exports |
+| **Enforce runtime behavior** | `agent-bom proxy` or `agent-bom mcp server` from this image | MCP tools, audit JSONL, policy blocks, runtime alerts |
 
 ## CLI And Runtime Quick Start
 

--- a/DOCKER_HUB_UI_README.md
+++ b/DOCKER_HUB_UI_README.md
@@ -1,6 +1,6 @@
 # agent-bom-ui
 
-Dashboard image for `agent-bom`.
+Dashboard image for the self-hosted `agent-bom` control plane.
 
 `agent-bom` is one product with two deployable images:
 
@@ -10,6 +10,11 @@ Dashboard image for `agent-bom`.
 This image is not a separate product and it is not meant to be the first thing a
 pilot user reasons about. Use the packaged pilot or Helm chart so both images are
 pulled for you.
+
+Use the UI when you are in the **send evidence to a control plane** lane:
+endpoint fleet sync, REST API jobs, Helm/EKS, scheduled discovery, graph state,
+findings, compliance, and governance all converge here. Local-only CLI/Docker
+scans and runtime proxy enforcement can run without the browser image.
 
 ## Run This First
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,19 @@
 </p>
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
-<p align="center"><b>Open security scanner for AI supply chain and infrastructure — agents, MCP servers, packages, containers, cloud (AWS, Azure, GCP, Snowflake, Databricks, CoreWeave, Nebius), GPU, and runtime.</b></p>
+<p align="center"><b>Open security scanner and control plane for AI-era infrastructure — local scans, CI evidence, fleet inventory, MCP/runtime enforcement, and self-hosted governance.</b></p>
 
 <p align="center">Every CVE in your AI stack is a credential leak waiting to happen. <code>agent-bom</code> follows the chain end-to-end and tells you exactly which fix collapses it.</p>
+
+<p align="center">
+  <a href="https://msaad00.github.io/agent-bom/">Docs</a> ·
+  <a href="docs/FIRST_RUN.md">Demo</a> ·
+  <a href="site-docs/deployment/overview.md">Self-host</a> ·
+  <a href="https://github.com/marketplace/actions/agent-bom">GitHub Action</a> ·
+  <a href="https://hub.docker.com/r/agentbom/agent-bom">Docker</a> ·
+  <a href="https://github.com/msaad00/agent-bom/issues/new/choose">Report Bug / Feature Request</a> ·
+  <a href="https://github.com/msaad00/agent-bom/releases">Changelog</a>
+</p>
 
 <p align="center">
   <picture>
@@ -251,7 +261,7 @@ Backend defaults:
 
 | Layer | Default | Add later only if needed |
 |---|---|---|
-| **control plane** | Postgres | Snowflake only when the published backend parity is the reason to choose it |
+| **control plane** | Postgres / Supabase | Snowflake only for published warehouse-native governance and selected store paths |
 | **analytics / archive** | none required | ClickHouse, OTEL, S3 |
 
 ## Start here by scenario
@@ -390,18 +400,58 @@ For published containers, the packaging model is:
 See [docs/ENTERPRISE_DEPLOYMENT.md § Container images — do I need both?](docs/ENTERPRISE_DEPLOYMENT.md#container-images--do-i-need-both)
 for the full split-vs-single-image guidance.
 
-| Mode | Best for |
-|------|----------|
-| CLI (`agent-bom agents`) | local audit + project scan |
-| Endpoint fleet (`--push-url …/v1/fleet/sync`) | employee laptops pushing into self-hosted fleet |
-| GitHub Action (`uses: msaad00/agent-bom@v0.86.2`) | CI/CD + SARIF |
-| Docker (`agentbom/agent-bom`) | isolated scans, API jobs, and non-browser self-hosted entrypoints |
-| Browser UI image (`agentbom/agent-bom-ui`) | the dashboard image paired with the same self-hosted control plane |
-| Kubernetes / Helm (`helm install agent-bom deploy/helm/agent-bom`) | self-hosted API + dashboard, scheduled discovery |
-| REST API (`agent-bom api`) | platform integration, self-hosted control plane |
-| MCP server (`agent-bom mcp server`) | Claude Desktop, Claude Code, Cursor, Codex, Windsurf, Cortex |
-| Runtime proxy (`agent-bom proxy`) | MCP traffic enforcement |
-| Shield SDK (`from agent_bom.shield import Shield`) | in-process protection |
+## Choose Your Path
+
+Start with one lane. The dashboard, API, gateway, proxy, and SDK are optional
+extensions around the same evidence model.
+
+```text
+agent-bom
+├─ scan locally
+│  ├─ CLI / Docker / GitHub Action
+│  └─ findings, SARIF, SBOM, HTML, graph exports
+├─ send evidence to a control plane
+│  ├─ fleet sync / REST API / Helm / dashboard
+│  └─ inventory, scan jobs, graph state, compliance, governance
+└─ enforce runtime behavior
+   ├─ MCP server / proxy / gateway / Shield SDK
+   └─ tool-call audit, policy blocks, runtime alerts
+```
+
+| Lane | Start with | Produces | Move up to |
+|------|------------|----------|------------|
+| **Scan locally** | `agent-bom agents --demo --offline`, then `agent-bom agents -p .` | terminal findings, SARIF, SBOM, HTML, graph exports | Docker or GitHub Action |
+| **Send evidence to a control plane** | `agent-bom agents --push-url https://agent-bom.example.com/v1/fleet/sync` | fleet inventory, scan jobs, graph state, compliance exports | REST API, pilot compose, Helm/EKS |
+| **Enforce runtime behavior** | `agent-bom mcp server` for assistants, `agent-bom proxy` for MCP traffic, `Shield` for in-process checks | MCP tools, audit JSONL, policy blocks, runtime alerts | gateway/proxy sidecars, Shield SDK integration |
+
+### Product Modes
+
+| Mode | Best for | First command | Primary artifact |
+|------|----------|---------------|------------------|
+| CLI (`agent-bom agents`) | local audit + project scan | `agent-bom agents -p .` | console, JSON, SARIF, SBOM, HTML |
+| Endpoint fleet (`--push-url .../v1/fleet/sync`) | employee laptops pushing into self-hosted fleet | `agent-bom agents --preset enterprise --push-url https://agent-bom.example.com/v1/fleet/sync` | fleet inventory + trust factors |
+| GitHub Action (`uses: msaad00/agent-bom@v0.86.2`) | CI/CD + SARIF | `uses: msaad00/agent-bom@v0.86.2` | `agent-bom-results.sarif` |
+| Docker (`agentbom/agent-bom`) | isolated CLI/API jobs and non-browser self-hosted entrypoints | `docker run --rm agentbom/agent-bom:0.86.2 agents --demo` | same artifacts as CLI |
+| Browser UI image (`agentbom/agent-bom-ui`) | browser dashboard paired with the same API/control plane | `docker compose -f docker-compose.pilot.yml up -d` | dashboard at `http://localhost:3000` |
+| Kubernetes / Helm | self-hosted API + dashboard, scheduled discovery | `helm upgrade --install agent-bom deploy/helm/agent-bom --set controlPlane.enabled=true` | API, UI, jobs, optional gateway/proxy |
+| REST API (`agent-bom api` / `agent-bom serve`) | platform integration and self-hosted control plane | `agent-bom serve --port 8422 --persist jobs.db` | `/docs`, `/health`, `/v1/scan`, `/v1/fleet` |
+| MCP server (`agent-bom mcp server`) | Claude Desktop, Claude Code, Cursor, Codex, Windsurf, Cortex | `agent-bom mcp server` | 36 read-only MCP security tools |
+| Runtime proxy (`agent-bom proxy`) | MCP traffic enforcement | `agent-bom proxy --log audit.jsonl --block-undeclared -- ...` | audit JSONL, metrics, policy decisions |
+| Shield SDK (`from agent_bom.shield import Shield`) | in-process protection | `from agent_bom.shield import Shield` | allow/block decisions and redacted alerts |
+
+### Integrations and Agentic Workflows
+
+Integrations are product surfaces, not extras. They decide where users first
+see value and where enterprises wire agent-bom into existing controls.
+
+| Integration surface | Examples | What agent-bom does |
+|---|---|---|
+| MCP and coding agents | Claude Desktop / Code, Cursor, Windsurf, VS Code, Cortex Code, OpenAI Codex CLI | discovers configured MCP servers, exposes 36 read-only security tools, and returns findings to the assistant workflow |
+| Skills and plugins | OpenClaw skills, Cortex Code skill, MCP Registry, Smithery, Glama, Docker MCP registry | packages repeatable scan, compliance, registry, runtime, and Snowflake discovery workflows where agent users already work |
+| CI/CD and developer workflow | GitHub Action, SARIF, pre-install `check`, Docker, local CLI | blocks unsafe packages, uploads code-scanning evidence, and keeps SBOM/remediation output scriptable |
+| Cloud, warehouse, and AI infra | AWS, Azure, GCP, Snowflake, Databricks, CoreWeave, Nebius, Hugging Face, OpenAI, W&B, MLflow, Ollama | pulls read-only inventory and posture evidence with operator-controlled credentials |
+| Runtime and app frameworks | MCP proxy/gateway, Shield SDK, Anthropic/OpenAI SDK patterns, LangChain, CrewAI | enforces policy on live tool calls and lets applications add in-process allow/block decisions |
+| Governance and observability | Postgres/Supabase, ClickHouse, Snowflake paths, OTEL, SIEM/export hooks, compliance bundles | persists evidence, trends, audit, graph state, and control mappings without requiring a hosted vendor plane |
 
 MCP and skills setup is documented in the client guides, not in repo-local
 assistant launch files: [Claude](docs/CLAUDE_INTEGRATION.md),
@@ -414,14 +464,15 @@ Backend choices stay explicit and optional:
 - `SQLite` for local and single-node use
 - `Postgres` / `Supabase` for the primary transactional control plane
 - `ClickHouse` for analytics and event-scale persistence
-- `Snowflake` for warehouse-native governance and selected backend paths
+- `Snowflake` for warehouse-native governance and selected backend paths that
+  can coexist with a Postgres-backed control plane
 
-Six ways to run agent-bom — locally, in CI, self-hosted, cloud-read-only,
-pushed inventory, or through your AI agent — chosen by your security boundary,
-not ours. agent-bom holds only the credentials your chosen mode requires and
-reaches only the systems your chosen mode permits. The discovery skills work
-standalone too: use them for inventory, and route to agent-bom only when you
-want findings, graph, policy, or exports.
+Run agent-bom locally, in CI, self-hosted, cloud-read-only, pushed inventory,
+or through your AI agent. Pick the path by security boundary: agent-bom holds
+only the credentials your chosen mode requires and reaches only the systems
+your chosen mode permits. Discovery skills work standalone too: use them for
+inventory, and route to agent-bom when you want findings, graph, policy, or
+exports.
 
 References: [PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md) · [PRODUCT_METRICS.md](docs/PRODUCT_METRICS.md) · [ENTERPRISE.md](docs/ENTERPRISE.md) · [How agent-bom works](site-docs/architecture/how-agent-bom-works.md).
 

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -174,7 +174,7 @@ agent-bom serve --port 8422 --persist jobs.db
 
 **Endpoints:**
 - `POST /v1/scan` — submit scans from any source
-- `GET /v1/fleet/list` — view all discovered agents across the org
+- `GET /v1/fleet` — view all discovered agents across the org
 - `GET /v1/fleet/stats` — fleet-wide trust scores and posture
 - `POST /v1/fleet/sync` — ingest endpoint scan results
 - `GET /v1/compliance` — 15-framework compliance posture plus AISVS benchmark summary

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -1,6 +1,9 @@
 # Product Brief
 
-`agent-bom` is an open security scanner for AI supply chain and infrastructure — agents, MCP, packages, containers, cloud, GPU, and runtime.
+`agent-bom` is an open security scanner and self-hosted control plane for
+AI-era infrastructure — local scans, CI evidence, fleet inventory, MCP/runtime
+enforcement, and governance surfaces that run in the operator's own
+environment.
 
 It is built around a simple thesis: security and visibility for AI infrastructure should be open, transparent, and accessible, not reserved for teams with enterprise budgets.
 
@@ -10,6 +13,58 @@ Package risk is only the start. `agent-bom` follows what it can reach across MCP
 
 Current repo-derived counts live in [PRODUCT_METRICS.md](PRODUCT_METRICS.md). This brief intentionally keeps volatile metrics out of the main narrative.
 
+## Positioning contract
+
+The product should converge curious users into real adoption by answering four
+persona questions quickly:
+
+| Persona | Question they need answered | Product proof |
+|---|---|---|
+| Product manager | "Is the first run valuable and obvious?" | deterministic demo, fix-first output, clear next step |
+| Sales engineer | "Can I prove this in the buyer's environment?" | CLI/Docker/Action smoke, control-plane pilot, gateway/proxy evidence |
+| Account executive | "Who buys this and why now?" | AI/MCP supply-chain risk, self-hosted deployment, evidence for governance teams |
+| Software/security engineer | "Can I trust and operate it?" | signed releases, tests, strict auth defaults, Postgres tenancy, audit chain, scoped runtime controls |
+
+Do not present the product as ten equal entry points. Present it as three
+adoption lanes that share one evidence model:
+
+```text
+agent-bom
+├─ scan locally
+│  └─ CLI, Docker, GitHub Action -> findings, SARIF, SBOM, HTML, graph exports
+├─ send evidence to a control plane
+│  └─ fleet sync, REST API, Helm/EKS, UI -> inventory, graph, compliance, governance
+└─ enforce runtime behavior
+   └─ MCP server, proxy/gateway, Shield SDK -> audit, policy blocks, runtime alerts
+```
+
+1. **Scan locally** — CLI, Docker, and GitHub Action produce findings, SARIF,
+   SBOMs, HTML reports, and graph exports.
+2. **Send evidence to a control plane** — endpoint fleet, REST API, Helm/EKS,
+   and the browser UI centralize inventory, graph state, compliance, and
+   governance.
+3. **Enforce runtime behavior** — MCP server mode, proxy/gateway, and Shield
+   SDK turn the same model into agentic workflow controls.
+
+This framing does not narrow the deployment story. It makes "deploy in your
+own cloud / infrastructure" the production form of lane 2, with runtime
+controls from lane 3 added where the customer needs inline enforcement.
+
+Integrations should be described as distribution and workflow fit, not as a
+miscellaneous compatibility list. The strongest story is:
+
+- **coding agents and MCP clients**: Claude, Cursor, Windsurf, VS Code, Cortex
+  Code, and similar clients can invoke agent-bom as a read-only security tool
+  surface.
+- **skills and registries**: OpenClaw skills, Cortex Code skill packaging, MCP
+  Registry, Smithery, Glama, and Docker MCP registry make repeatable
+  agent-bom workflows available where agent users already discover tools.
+- **developer controls**: CLI, Docker, GitHub Action, SARIF, SBOM, and
+  pre-install checks make local and CI adoption useful without the dashboard.
+- **enterprise data paths**: REST API, fleet sync, Helm/EKS, Postgres,
+  ClickHouse, Snowflake paths, OTEL, SIEM/export hooks, and compliance bundles
+  let security teams centralize evidence inside their own infrastructure.
+
 ## Deployment truth
 
 The product should be framed deployment-first:
@@ -17,6 +72,9 @@ The product should be framed deployment-first:
 - **self-hosted operator plane** in the customer's own infrastructure
 - **entry points** through CLI, GitHub Action, fleet ingest, proxy, and gateway
 - **pilot** as a narrower rollout profile of the same architecture, not a separate product shape
+- **Fortune-500 deployment readiness** as customer-controlled infrastructure,
+  explicit auth/tenant/storage choices, and evidence-backed operations, not as
+  a hosted SaaS claim
 
 That keeps the repo story aligned with the actual code: one shared graph, one
 policy model, multiple entry points, no mandatory hosted control plane.

--- a/integrations/docker-mcp-registry/readme.md
+++ b/integrations/docker-mcp-registry/readme.md
@@ -10,13 +10,13 @@ Package risk is only the start. agent-bom maps what it can reach across MCP serv
 
 ```bash
 # Scan your AI agent environment
-docker run --rm agentbom/agent-bom scan
+docker run --rm agentbom/agent-bom agents
 
 # Pre-install CVE gate
 docker run --rm agentbom/agent-bom check flask@2.0.0
 
 # Generate CycloneDX SBOM
-docker run --rm -v "$(pwd):/workspace" agentbom/agent-bom scan -p /workspace -f cyclonedx -o /workspace/sbom.json
+docker run --rm -v "$(pwd):/workspace" agentbom/agent-bom agents -p /workspace -f cyclonedx -o /workspace/sbom.json
 ```
 
 ## What it scans

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -39,7 +39,7 @@ Compose file into production.
 ## Quick scan
 
 ```bash
-docker run --rm agentbom/agent-bom:latest scan
+docker run --rm agentbom/agent-bom:latest agents --demo
 ```
 
 ## With host config access
@@ -50,7 +50,7 @@ Mount your MCP client configs for auto-discovery:
 docker run --rm \
   -v "$HOME/.config:/home/abom/.config:ro" \
   -v "$HOME/Library/Application Support:/home/abom/Library/Application Support:ro" \
-  agentbom/agent-bom:latest scan
+  agentbom/agent-bom:latest agents
 ```
 
 ## Self-hosted SSE server
@@ -87,17 +87,22 @@ docker run --rm \
   agentbom/agent-bom:latest --version
 ```
 
-## Runtime proxy sidecar
+## Runtime proxy against a remote MCP endpoint
 
 ```bash
 docker pull agentbom/agent-bom:0.86.2
 docker run --rm -i \
   -v ./audit-logs:/var/log/agent-bom \
   agentbom/agent-bom:0.86.2 \
+  proxy \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
-  -- npx -y @modelcontextprotocol/server-filesystem /workspace
+  --url http://host.docker.internal:3000
 ```
+
+For stdio MCP wrapping, prefer the repo's runtime compose example or run
+`agent-bom proxy` on the host where the target MCP command and its runtime
+(`node`, `uvx`, `python`, etc.) are installed.
 
 ## Images
 

--- a/src/agent_bom/parsers/node_parsers.py
+++ b/src/agent_bom/parsers/node_parsers.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from urllib.parse import quote
 
@@ -18,6 +19,9 @@ from agent_bom.models import MCPServer, Package
 from agent_bom.parsers.file_limits import read_json_limited, read_text_limited
 
 logger = logging.getLogger(__name__)
+
+_WORKSPACE_PROTOCOL_PREFIXES = ("workspace:", "file:", "link:", "portal:")
+_MAX_WORKSPACE_PACKAGE_JSONS = 500
 
 
 def _npm_purl(name: str, version: str) -> str:
@@ -55,6 +59,113 @@ def _resolve_npx_cached_version(name: str) -> tuple[str, Path] | None:
         return None
     _, version, path = max(matches, key=lambda item: item[0])
     return version, path
+
+
+def _coerce_workspace_patterns(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, dict):
+        packages = value.get("packages")
+        if isinstance(packages, list):
+            return [str(item).strip() for item in packages if str(item).strip()]
+    return []
+
+
+def _workspace_root_for(directory: Path) -> Path | None:
+    for candidate in (directory, *directory.parents):
+        if (candidate / "pnpm-workspace.yaml").exists():
+            return candidate
+        pkg_json = candidate / "package.json"
+        if pkg_json.exists():
+            try:
+                data = read_json_limited(pkg_json)
+            except Exception:
+                continue
+            if _coerce_workspace_patterns(data.get("workspaces")):
+                return candidate
+    return None
+
+
+@lru_cache(maxsize=128)
+def _workspace_package_versions(root: str) -> dict[str, str]:
+    workspace_root = Path(root)
+    patterns: list[str] = []
+
+    pnpm_workspace = workspace_root / "pnpm-workspace.yaml"
+    if pnpm_workspace.exists():
+        try:
+            import yaml
+
+            data = yaml.safe_load(read_text_limited(pnpm_workspace)) or {}
+            if isinstance(data, dict):
+                packages = data.get("packages")
+                if isinstance(packages, list):
+                    patterns.extend(str(item).strip() for item in packages if str(item).strip())
+        except Exception as exc:
+            logger.debug("Failed to parse pnpm workspace at %s: %s", pnpm_workspace, exc)
+
+    root_pkg_json = workspace_root / "package.json"
+    if root_pkg_json.exists():
+        try:
+            data = read_json_limited(root_pkg_json)
+            patterns.extend(_coerce_workspace_patterns(data.get("workspaces")))
+        except Exception as exc:
+            logger.debug("Failed to inspect npm workspace package.json at %s: %s", root_pkg_json, exc)
+
+    versions: dict[str, str] = {}
+    seen_dirs: set[Path] = set()
+    for pattern in dict.fromkeys(patterns):
+        if pattern.startswith("!"):
+            continue
+
+        package_jsons: list[Path] = []
+        if "**" in pattern:
+            recursive_suffix = "/**"
+            if pattern.endswith(recursive_suffix) and pattern.count("**") == 1:
+                base = workspace_root / pattern[: -len(recursive_suffix)].rstrip("/")
+                if base.is_dir():
+                    package_jsons.extend(
+                        pkg_json
+                        for pkg_json in base.rglob("package.json")
+                        if "node_modules" not in pkg_json.parts and ".git" not in pkg_json.parts
+                    )
+            else:
+                logger.debug("Skipping unsupported recursive workspace pattern %s in %s", pattern, workspace_root)
+                continue
+        else:
+            package_jsons.extend(pkg_dir / "package.json" for pkg_dir in workspace_root.glob(pattern) if pkg_dir.is_dir())
+
+        for pkg_json in package_jsons[:_MAX_WORKSPACE_PACKAGE_JSONS]:
+            pkg_dir = pkg_json.parent
+            if "node_modules" in pkg_dir.parts or ".git" in pkg_dir.parts or pkg_dir in seen_dirs:
+                continue
+            seen_dirs.add(pkg_dir)
+            if not pkg_json.exists():
+                continue
+            try:
+                data = read_json_limited(pkg_json)
+            except Exception as exc:
+                logger.debug("Failed to inspect workspace package %s: %s", pkg_json, exc)
+                continue
+            name = str(data.get("name") or "").strip()
+            version = str(data.get("version") or "").strip()
+            if name and version:
+                versions[name] = version
+    return versions
+
+
+def _resolve_workspace_dependency(directory: Path, name: str, version_spec: object) -> tuple[str, str] | None:
+    spec = str(version_spec or "").strip()
+    root = _workspace_root_for(directory)
+    if root is None:
+        return None
+    workspace_versions = _workspace_package_versions(str(root))
+    version = workspace_versions.get(name)
+    if not version:
+        return None
+    if spec.startswith(_WORKSPACE_PROTOCOL_PREFIXES) or spec in {"*", ""}:
+        return version, spec
+    return None
 
 
 def parse_npm_packages(directory: Path) -> list[Package]:
@@ -103,11 +214,30 @@ def parse_npm_packages(directory: Path) -> list[Package]:
             pkg_data = read_json_limited(directory / "package.json")
             for dep_type in ("dependencies", "devDependencies"):
                 for name, version_spec in pkg_data.get(dep_type, {}).items():
-                    version = version_spec.lstrip("^~>=< ")
-                    # Validate: must look like a semver (at least major.minor.patch)
-                    # Otherwise mark as "latest" for resolver to handle
-                    if not re.match(r"^\d+\.\d+\.\d+", version):
-                        version = "latest"
+                    declared_version = str(version_spec)
+                    workspace_resolution = _resolve_workspace_dependency(directory, name, declared_version)
+                    version_source = "manifest"
+                    resolved_version = None
+                    version_confidence = None
+                    version_evidence: list[dict] = []
+                    if workspace_resolution:
+                        version, declared_version = workspace_resolution
+                        version_source = "workspace"
+                        resolved_version = version
+                        version_confidence = "workspace_manifest"
+                        version_evidence.append(
+                            {
+                                "source": "workspace_manifest",
+                                "declared_version": declared_version,
+                                "resolved_version": version,
+                            }
+                        )
+                    else:
+                        version = declared_version.lstrip("^~>=< ")
+                        # Validate: must look like a semver (at least major.minor.patch)
+                        # Otherwise mark as "latest" for resolver to handle
+                        if not re.match(r"^\d+\.\d+\.\d+", version):
+                            version = "latest"
                     packages.append(
                         Package(
                             name=name,
@@ -115,6 +245,12 @@ def parse_npm_packages(directory: Path) -> list[Package]:
                             ecosystem="npm",
                             purl=_npm_purl(name, version),
                             is_direct=True,
+                            reachability_evidence="workspace_manifest" if workspace_resolution else "declaration_only",
+                            version_source=version_source,
+                            declared_version=declared_version,
+                            resolved_version=resolved_version,
+                            version_confidence=version_confidence,
+                            version_evidence=version_evidence,
                         )
                     )
         except (json.JSONDecodeError, KeyError) as exc:

--- a/tests/test_parser_interop.py
+++ b/tests/test_parser_interop.py
@@ -6,6 +6,7 @@ import textwrap
 
 from agent_bom.parsers import (
     parse_conda_environment,
+    parse_npm_packages,
     parse_pip_packages,
     parse_pnpm_lock,
     parse_poetry_lock,
@@ -289,6 +290,51 @@ class TestPnpmLock:
 
     def test_missing_file_returns_empty(self, tmp_path):
         assert parse_pnpm_lock(tmp_path) == []
+
+
+def test_package_json_resolves_workspace_dependencies(tmp_path):
+    (tmp_path / "pnpm-workspace.yaml").write_text(
+        textwrap.dedent("""\
+            packages:
+              - "packages/**"
+              - "web"
+        """)
+    )
+    shared = tmp_path / "packages" / "shared"
+    eslint = tmp_path / "packages" / "config-eslint"
+    web = tmp_path / "web"
+    shared.mkdir(parents=True)
+    eslint.mkdir(parents=True)
+    web.mkdir()
+    (shared / "package.json").write_text('{"name": "@langfuse/shared", "version": "1.0.0"}')
+    (eslint / "package.json").write_text('{"name": "@repo/eslint-config", "version": "0.0.0"}')
+    (web / "package.json").write_text(
+        textwrap.dedent("""\
+            {
+              "name": "web",
+              "dependencies": {
+                "@langfuse/shared": "workspace:*",
+                "next": "16.2.6"
+              },
+              "devDependencies": {
+                "@repo/eslint-config": "workspace:*",
+                "typescript": "^5.9.3"
+              }
+            }
+        """)
+    )
+
+    by_name = {pkg.name: pkg for pkg in parse_npm_packages(web)}
+
+    assert by_name["@langfuse/shared"].version == "1.0.0"
+    assert by_name["@langfuse/shared"].version_source == "workspace"
+    assert by_name["@langfuse/shared"].declared_version == "workspace:*"
+    assert by_name["@langfuse/shared"].resolved_version == "1.0.0"
+    assert by_name["@langfuse/shared"].version_confidence == "workspace_manifest"
+    assert by_name["@langfuse/shared"].reachability_evidence == "workspace_manifest"
+    assert by_name["@repo/eslint-config"].version == "0.0.0"
+    assert by_name["next"].version == "16.2.6"
+    assert by_name["typescript"].version == "5.9.3"
 
 
 # ── ECOSYSTEM_MAP includes conda ──────────────────────────────────────────────


### PR DESCRIPTION
Summary

- reframes the public README, Docker Hub READMEs, and product brief around three adoption lanes: scan locally, send evidence to a self-hosted control plane, and enforce runtime behavior
- adds a compact product tree, integration matrix, contributor funnel updates, and issue-template fields for MCP/client/self-hosted reports
- adds repo-owned shared agent guidance under .agents/ with root AGENTS.md as the discovery shim
- fixes stale public commands and endpoint references found during product-mode validation
- resolves workspace-local npm dependencies in monorepos from pnpm/npm workspace manifests instead of treating first-party packages as registry latest

Root Cause

The public docs listed many product modes as equal choices, which made the first-run and deployment story harder to understand. The Langfuse comparison also exposed a concrete scan-quality gap: workspace-local packages such as @langfuse/shared and @repo/eslint-config were inventoried but could not be resolved from public registries because agent-bom was not hydrating package.json-only workspace references from workspace manifests.

Validation

- uv run pytest -q tests/test_parser_interop.py::test_package_json_resolves_workspace_dependencies tests/test_parser_interop.py::TestPnpmLock --tb=short -> 7 passed
- uv run ruff check src/agent_bom/parsers/node_parsers.py tests/test_parser_interop.py -> passed
- python structured file check for .agents/config.json and issue templates -> passed
- git diff --check -> passed
- signed commit pre-commit hooks passed: yaml/json/eof/whitespace/private-key/conflict/line-ending/ruff/ruff-format/mypy/bandit/env-var drift
- dogfood parser check against a local Langfuse checkout: @langfuse/shared, @repo/eslint-config, @repo/typescript-config, and @langfuse/ee now resolve with version_source=workspace instead of latest

Notes

This PR does not claim the graph readability work is complete. It tightens first-run/product framing, contributor conversion, repo-agent guidance, and monorepo scan correctness.

Refs #2352.
Refs #2353.
Refs #2355.
Refs #2356.
