### PR TITLE
fix: tighten scorecard permissions and positioning

### DIFF
--- a/.github/workflows/cflite-pr.yml
+++ b/.github/workflows/cflite-pr.yml
@@ -32,7 +32,6 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
-      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -55,7 +54,6 @@ jobs:
     needs: Build
     permissions:
       contents: read
-      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -2,22 +2,22 @@
 
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
-**Open security scanner for AI supply chain — agents, MCP servers, packages, containers, cloud, GPU, and runtime.**
+**Open security scanner for AI supply chain and runtime infrastructure — agents, MCP servers, packages, containers, cloud, GPU, and enforcement paths.**
 
 Start with the demo, then choose the entrypoint that matches your first job: repo scan, image scan, cloud posture, fix plan, dashboard, or runtime review.
 
 ```text
 better-sqlite3@9.0.0  (npm package)
-  |── CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
+  |── OSV/GHSA finding  (critical · advisory-backed)
   |── sqlite-mcp  (MCP Server · unverified · root)
        |── Cursor IDE  (Agent · 4 servers · 12 tools)
        |── ANTHROPIC_KEY, DB_URL, AWS_SECRET  (Credential env names visible)
-       |── query_db, read_file, write_file, run_shell  (Tools at risk)
+       |── query_db, read_file, write_file, run_shell  (Reachable tools)
 
  Fix: upgrade better-sqlite3 → 11.7.0
 ```
 
-Blast radius is the core idea: `package -> vulnerability finding -> MCP server (tools + credential env names) -> connected agents`.
+Blast radius is the core idea: `package -> vulnerability finding -> MCP server (tools + credential env names) -> connected agents`. This schematic explains the model; emitted findings are backed by the configured advisory sources.
 
 Scan local agent configs, MCP servers, instruction files, lockfiles, containers, cloud posture, GPU surfaces, and runtime evidence.
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 </p>
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
-<p align="center"><b>Open security scanner and control plane for AI-era infrastructure — local scans, CI evidence, fleet inventory, MCP/runtime enforcement, and self-hosted governance.</b></p>
+<p align="center"><b>Open security scanner and control plane for AI supply chain and runtime infrastructure — local scans, CI evidence, fleet inventory, MCP enforcement, and self-hosted governance.</b></p>
 
-<p align="center">Every CVE in your AI stack is a credential leak waiting to happen. <code>agent-bom</code> follows the chain end-to-end and tells you exactly which fix collapses it.</p>
+<p align="center"><code>agent-bom</code> follows vulnerable packages, MCP servers, tools, credentials, agents, and runtime paths so teams can prioritize the fix that removes the most reachable risk.</p>
 
 <p align="center">
   <a href="https://msaad00.github.io/agent-bom/">Docs</a> ·
@@ -37,16 +37,16 @@
 
 ```text
 better-sqlite3@9.0.0  (npm package)
-  |── CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
+  |── OSV/GHSA finding  (critical · advisory-backed)
   |── sqlite-mcp  (MCP Server · unverified · root)
        |── Cursor IDE  (Agent · 4 servers · 12 tools)
        |── ANTHROPIC_KEY, DB_URL, AWS_SECRET  (Credential env names visible)
-       |── query_db, read_file, write_file, run_shell  (Tools at risk)
+       |── query_db, read_file, write_file, run_shell  (Reachable tools)
 
  Fix: upgrade better-sqlite3 → 11.7.0
 ```
 
-Blast radius is the core idea: `package -> vulnerability finding -> MCP server (tools + credential env names) -> connected agents`. You can search by CVE, package, server, tool, credential name, or agent, but the evidence graph keeps the vulnerable package instance as the source of the reachable exposure path. CWE-aware impact keeps a DoS from being reported like credential compromise.
+Blast radius is the core idea: `package -> vulnerability finding -> MCP server (tools + credential env names) -> connected agents`. You can search by CVE, package, server, tool, credential name, or agent, but the evidence graph keeps the vulnerable package instance as the source of the reachable exposure path. CWE-aware impact keeps a DoS from being reported like credential compromise. The image above is a schematic; the bundled demo findings are backed by real OSV/GHSA advisories.
 
 ## Try the demo
 
@@ -139,7 +139,7 @@ They are captured from the packaged Next.js dashboard served by `agent-bom serve
 
 ### Dashboard — Risk overview
 
-The landing page is the **Risk overview**: a letter-grade gauge, the four headline counters (actively exploited · credentials exposed · reachable tools · top attack-path risk), the security-posture grade with sub-scores (policy + controls, open evidence, packages + CVEs, reach + exposure, MCP configuration), and the score breakdown for each driver.
+The landing page is the **Risk overview**: a letter-grade gauge, the four headline counters (actively exploited · credential scopes reachable · reachable tools · top attack-path risk), the security-posture grade with sub-scores (policy + controls, open evidence, packages + CVEs, reach + exposure, MCP configuration), and the score breakdown for each driver.
 
 ![agent-bom dashboard overview](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-live.png)
 

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -1,9 +1,9 @@
 # Product Brief
 
 `agent-bom` is an open security scanner and self-hosted control plane for
-AI-era infrastructure — local scans, CI evidence, fleet inventory, MCP/runtime
-enforcement, and governance surfaces that run in the operator's own
-environment.
+AI supply chain and runtime infrastructure — local scans, CI evidence, fleet
+inventory, MCP/runtime enforcement, and governance surfaces that run in the
+operator's own environment.
 
 It is built around a simple thesis: security and visibility for AI infrastructure should be open, transparent, and accessible, not reserved for teams with enterprise budgets.
 

--- a/docs/images/blast-radius-dark.svg
+++ b/docs/images/blast-radius-dark.svg
@@ -89,8 +89,8 @@
   <rect x="186" y="186" width="130" height="64" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
   <rect x="186" y="186" width="4" height="64" rx="2" fill="#ef4444"/>
   <text x="206" y="204" class="node-type" fill="#ef4444">CVE</text>
-  <text x="206" y="220" class="node-label" fill="#fca5a5">CVE-2025-1234</text>
-  <text x="206" y="236" class="node-detail">Critical 9.8 · CISA KEV</text>
+  <text x="206" y="220" class="node-label" fill="#fca5a5">OSV/GHSA finding</text>
+  <text x="206" y="236" class="node-detail">Critical · advisory-backed</text>
 
   <!-- ═══════════════════════════════════════════════════════════════════════ -->
   <!-- NODE: Server A (sqlite-mcp)                                             -->
@@ -176,7 +176,7 @@
   <!-- Dangerous tool highlighted -->
   <rect x="732" y="278" width="100" height="24" rx="6" fill="#2d1215" stroke="#ef4444" stroke-width="1.5"/>
   <text x="782" y="294" text-anchor="middle" class="tool-label" fill="#fca5a5">run_shell</text>
-  <text x="845" y="294" font-size="8" font-weight="700" fill="#ef4444" font-family="system-ui, sans-serif">RCE RISK</text>
+  <text x="845" y="294" font-size="8" font-weight="700" fill="#ef4444" font-family="system-ui, sans-serif">EXECUTION TOOL</text>
 
   <!-- ═══════════════════════════════════════════════════════════════════════ -->
   <!-- SHARED PATH HIGHLIGHT (the "aha" moment)                                -->
@@ -209,7 +209,7 @@
   <rect x="380" y="424" width="1" height="48" rx="0.5" fill="#27272a"/>
 
   <text x="440" y="440" text-anchor="middle" class="impact-num" fill="#ef4444">1</text>
-  <text x="440" y="458" text-anchor="middle" class="impact-label">RCE-capable</text>
+  <text x="440" y="458" text-anchor="middle" class="impact-label">exec-capable</text>
   <text x="440" y="472" text-anchor="middle" class="impact-label">tool exposed</text>
 
   <!-- Fix recommendation -->

--- a/docs/images/blast-radius-light.svg
+++ b/docs/images/blast-radius-light.svg
@@ -61,8 +61,8 @@
   <rect x="186" y="186" width="130" height="64" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
   <rect x="186" y="186" width="4" height="64" rx="2" fill="#ef4444"/>
   <text x="206" y="204" class="node-type" fill="#dc2626">CVE</text>
-  <text x="206" y="220" class="node-label" fill="#991b1b">CVE-2025-1234</text>
-  <text x="206" y="236" class="node-detail">Critical 9.8 · CISA KEV</text>
+  <text x="206" y="220" class="node-label" fill="#991b1b">OSV/GHSA finding</text>
+  <text x="206" y="236" class="node-detail">Critical · advisory-backed</text>
 
   <!-- NODE: Server A -->
   <rect x="372" y="110" width="140" height="64" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
@@ -132,7 +132,7 @@
 
   <rect x="732" y="278" width="100" height="24" rx="6" fill="#fef2f2" stroke="#ef4444" stroke-width="1.5"/>
   <text x="782" y="294" text-anchor="middle" class="tool-label" fill="#dc2626">run_shell</text>
-  <text x="845" y="294" font-size="8" font-weight="700" fill="#dc2626" font-family="system-ui, sans-serif">RCE RISK</text>
+  <text x="845" y="294" font-size="8" font-weight="700" fill="#dc2626" font-family="system-ui, sans-serif">EXECUTION TOOL</text>
 
   <!-- SHARED PATH HIGHLIGHT -->
   <rect x="540" y="186" width="170" height="76" rx="12" stroke="#ef4444" stroke-width="1" stroke-dasharray="4 3" stroke-opacity="0.2" fill="none"/>
@@ -160,7 +160,7 @@
   <rect x="380" y="424" width="1" height="48" rx="0.5" fill="#e4e4e7"/>
 
   <text x="440" y="440" text-anchor="middle" class="impact-num" fill="#ef4444">1</text>
-  <text x="440" y="458" text-anchor="middle" class="impact-label">RCE-capable</text>
+  <text x="440" y="458" text-anchor="middle" class="impact-label">exec-capable</text>
   <text x="440" y="472" text-anchor="middle" class="impact-label">tool exposed</text>
 
   <rect x="520" y="420" width="404" height="58" rx="8" fill="#ecfdf5" stroke="#a7f3d0" stroke-width="1"/>

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -8,7 +8,7 @@ Scan agents, MCP, packages, containers, Kubernetes, cloud, and GPU workloads wit
 
 ```
 better-sqlite3@9.0.0  (npm package)
-  ├─ CVE-2025-1234  (CRITICAL · CVSS 9.8 · CISA KEV)
+  ├─ OSV/GHSA finding  (critical · advisory-backed)
   └─ sqlite-mcp  (MCP Server · unverified)
        ├─ Cursor IDE  (Agent · 4 servers · 12 tools)
        ├─ ANTHROPIC_KEY, DB_URL, AWS_SECRET  (Credential env names visible)


### PR DESCRIPTION
## Summary

- replaces the buzzwordy AI-era tagline with concrete AI supply-chain/runtime positioning
- softens overclaiming CVE/credential copy so the README distinguishes reachability from compromise
- updates the blast-radius schematic and text to avoid synthetic CVE/KEV/RCE claims
- removes unused ClusterFuzzLite security-events write permissions from PR/batch fuzzing jobs

## Root Cause

The README headline read like broad market language, and the graph schematic implied facts that should only appear when backed by advisory/runtime evidence. OpenSSF also flagged ClusterFuzzLite jobs for security-events write even though those jobs do not upload SARIF.

## Validation

- python workflow YAML parse across .github/workflows
- PYTHONPATH=src uv run pytest -q tests/test_demo_inventory_accuracy.py --tb=short -> 2 passed
- uv run --with pip-audit pip-audit -s osv --format json --output /tmp/agent-bom-pip-audit.json -> no known vulnerabilities found
- git diff --check -> clean