### PR TITLE
chore: add contributor funnel templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_confusion.yml
+++ b/.github/ISSUE_TEMPLATE/docs_confusion.yml
@@ -1,0 +1,42 @@
+name: Docs Confusion
+description: Report unclear, stale, or conflicting documentation.
+labels: ["documentation", "area/docs"]
+body:
+  - type: input
+    id: page
+    attributes:
+      label: Page or section
+      description: Link to the README, docs page, or heading that caused confusion.
+      placeholder: "https://github.com/msaad00/agent-bom/blob/main/README.md#..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: confusion
+    attributes:
+      label: What was confusing?
+      description: Describe what you tried and where the docs sent you off track.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should the docs say?
+      description: Include the command, artifact, next step, or wording that would have helped.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - First run / quickstart
+        - CLI output or finding interpretation
+        - Docker or GitHub Action
+        - API / dashboard / Helm
+        - Runtime proxy / gateway / MCP
+        - Skills / integrations
+        - Release or version surface
+        - Other
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/inaccurate_finding.yml
+++ b/.github/ISSUE_TEMPLATE/inaccurate_finding.yml
@@ -1,0 +1,63 @@
+name: Inaccurate Finding
+description: Report a false positive, false negative, or misleading remediation.
+labels: ["bug", "area/scanning"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for public accuracy reports only. Do not include secrets, private source code, private package names, or customer data.
+
+  - type: input
+    id: version
+    attributes:
+      label: agent-bom version
+      description: Run `agent-bom --version`.
+      placeholder: "e.g. 0.86.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: finding-type
+    attributes:
+      label: Finding type
+      options:
+        - False positive
+        - False negative
+        - Wrong severity or advisory mapping
+        - Misleading remediation
+        - Missing blast-radius or context
+        - Other accuracy issue
+    validations:
+      required: true
+
+  - type: textarea
+    id: command
+    attributes:
+      label: Command and sanitized output
+      description: Include the exact command and the smallest redacted output that shows the issue.
+      render: shell
+      placeholder: |
+        agent-bom agents -p . -f json -o report.json
+        # paste the relevant sanitized finding here
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+      description: What should agent-bom have reported instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Link to public advisory, package metadata, lockfile snippet, SBOM excerpt, or scanner output that supports the correction.
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Python version, install method, and whether the scan used `--offline`, `--enrich`, an SBOM, or a registry.

--- a/.github/ISSUE_TEMPLATE/integration_request.yml
+++ b/.github/ISSUE_TEMPLATE/integration_request.yml
@@ -1,0 +1,50 @@
+name: Integration Request
+description: Request support for an MCP client, agent workflow, registry, cloud, CI, or security tool.
+labels: ["enhancement", "area/dx"]
+body:
+  - type: input
+    id: integration
+    attributes:
+      label: Integration target
+      placeholder: "e.g. Cursor MCP config, GitLab SARIF, Databricks workspace, W&B registry"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: family
+    attributes:
+      label: Integration family
+      options:
+        - MCP client or coding agent
+        - Skill or registry
+        - CI/CD or developer workflow
+        - Cloud or AI infrastructure
+        - Runtime or app framework
+        - Governance or observability
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: first-command
+    attributes:
+      label: First command or API flow
+      description: What command, config path, API call, webhook, or deployment step should agent-bom support first?
+      placeholder: "agent-bom agents --config-dir ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: artifact
+    attributes:
+      label: Expected artifact
+      description: What should be produced, blocked, uploaded, or displayed?
+      placeholder: "SARIF, SBOM, graph JSON, audit JSONL, fleet sync payload, dashboard view..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: boundary
+    attributes:
+      label: Credential and data boundary
+      description: Note required tokens, tenant/workspace scope, customer-cloud boundary, and any data that must stay local.

--- a/.github/ISSUE_TEMPLATE/runtime_proxy_bug.yml
+++ b/.github/ISSUE_TEMPLATE/runtime_proxy_bug.yml
@@ -1,0 +1,57 @@
+name: Runtime / Proxy Bug
+description: Report a proxy, gateway, Shield SDK, MCP server, or runtime audit issue.
+labels: ["bug", "area/runtime"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: agent-bom version
+      description: Run `agent-bom --version`.
+      placeholder: "e.g. 0.86.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Runtime surface
+      options:
+        - MCP server
+        - Proxy
+        - Gateway
+        - Shield SDK
+        - Runtime detector
+        - Audit log / metrics
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: command
+    attributes:
+      label: Command or deployment snippet
+      description: Include sanitized CLI flags, Helm values, Docker command, or SDK snippet.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Say whether the behavior should fail closed, fail open, audit only, or block.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior and logs
+      description: Paste sanitized JSON-RPC responses, audit JSONL records, metrics, or stack traces.
+      render: shell
+
+  - type: textarea
+    id: policy
+    attributes:
+      label: Policy, tenant, and auth context
+      description: Note policy files, tenant headers, bearer auth mode, sandbox mode, and upstream transport.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,14 +29,13 @@ The best ways to help:
 ```bash
 git clone https://github.com/msaad00/agent-bom.git
 cd agent-bom
-python3 -m venv venv && source venv/bin/activate   # Windows: venv\Scripts\activate
-pip install -e ".[dev-all]"
-pre-commit install                                  # wires ruff + ruff-format hooks
-pytest tests/ -x -q                                # must be green before you start
+uv sync --extra dev-all
+uv run pre-commit install                          # wires ruff + ruff-format hooks
+uv run pytest tests/ -x -q                         # must be green before you start
 ```
 
 That's it. `agent-bom agents` now runs from your local checkout.
-Use `.[dev]` only for a lighter core workflow; `.[dev-all]` is the supported full-suite contributor setup.
+Use `uv sync --extra dev` only for a lighter core workflow; `dev-all` is the supported full-suite contributor setup.
 
 ---
 
@@ -83,9 +82,9 @@ that should be applied alongside this contributor guide.
 git checkout -b feat/your-feature   # or fix/your-fix
 
 # Make your changes, then run:
-ruff check src/ --fix               # lint + autofix
-ruff format src/                    # formatting
-pytest tests/ -x -q                 # full suite must stay green
+uv run ruff check src tests --fix   # lint + autofix
+uv run ruff format src tests        # formatting
+uv run pytest tests/ -x -q          # full suite must stay green
 
 # Pre-commit hooks do this automatically on commit
 git add -p                          # stage intentionally
@@ -136,9 +135,9 @@ git push --force-with-lease origin your-branch
 ## Tests
 
 ```bash
-pytest tests/ -x -q                 # all tests, stop on first fail
-pytest tests/ -k "scanner" -v       # run matching tests only
-pytest tests/test_core.py -v        # specific file
+uv run pytest tests/ -x -q          # all tests, stop on first fail
+uv run pytest tests/ -k "scanner" -v
+uv run pytest tests/test_core.py -v
 ```
 
 **Rules:**
@@ -198,8 +197,8 @@ This keeps update history readable for operators and makes package maintenance l
 ## Submitting a PR
 
 1. **Branch from main** and name it `feat/`, `fix/`, `docs/`, or `chore/`.
-2. **All tests pass:** `pytest tests/ -x -q`
-3. **Lint clean:** `ruff check src/ && ruff format --check src/`
+2. **All tests pass:** `uv run pytest tests/ -x -q`
+3. **Lint clean:** `uv run ruff check src tests && uv run ruff format --check src tests`
 4. **PR description:** one-sentence summary, what changed, how to test it. If the PR resolves a GitHub issue, include `Closes #<issue-number>` in the PR body — GitHub will auto-close the issue when the PR merges.
 5. **One review required** — a maintainer will review within a few days.
 

--- a/docs/CLI_DEBUG_GUIDE.md
+++ b/docs/CLI_DEBUG_GUIDE.md
@@ -36,6 +36,12 @@ agent-bom agents --quiet --no-scan
 - Use `agent-bom agents -f sarif -o results.sarif` for file output.
 - Use `agent-bom agents -f sarif -o -` when you need SARIF JSON on stdout.
 
+If a finding looks inaccurate, open an
+[Inaccurate Finding](https://github.com/msaad00/agent-bom/issues/new?template=inaccurate_finding.yml)
+report with the exact command, agent-bom version, sanitized finding JSON/SARIF
+snippet, and public advisory or package evidence. Do not include secrets,
+private source code, private package names, or customer data in public issues.
+
 ## Verification flows
 
 ```bash
@@ -59,9 +65,9 @@ agent-bom verify @modelcontextprotocol/server-filesystem@2025.1.14 -e npm
 ## Contributor setup
 
 ```bash
-pip install -e ".[dev-all]"
-pytest tests/ -x -q
+uv sync --extra dev-all
+uv run pytest tests/ -x -q
 ```
 
-- `.[dev-all]` is the supported full-suite contributor environment.
+- `dev-all` is the supported full-suite contributor environment.
 - The `graph` extra includes the numeric dependencies required for PageRank and centrality tests.

--- a/site-docs/contributing.md
+++ b/site-docs/contributing.md
@@ -12,18 +12,14 @@ Please read and follow our [Code of Conduct](https://github.com/msaad00/agent-bo
 git clone https://github.com/msaad00/agent-bom.git
 cd agent-bom
 
-# Create virtual environment
-python3 -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
-
-# Install in development mode
-pip install -e ".[dev]"
+uv sync --extra dev-all
+uv run agent-bom --version
 ```
 
 ## Running Tests
 
 ```bash
-pytest tests/ -v
+uv run pytest tests/ -x -q
 ```
 
 ## Code Style
@@ -31,8 +27,8 @@ pytest tests/ -v
 We use `ruff` for linting:
 
 ```bash
-ruff check src/
-ruff format src/
+uv run ruff check src tests
+uv run ruff format --check src tests
 ```
 
 ## Areas to Contribute
@@ -47,8 +43,8 @@ ruff format src/
 
 1. Fork the repo and create your branch from `main`
 2. Add tests for any new functionality
-3. Ensure all tests pass: `pytest tests/ -x -q`
-4. Ensure linting passes: `ruff check src/`
+3. Ensure all tests pass: `uv run pytest tests/ -x -q`
+4. Ensure linting passes: `uv run ruff check src tests`
 5. Update the README if needed
 6. Submit your PR with a clear description
 

--- a/site-docs/reference/cli-debug.md
+++ b/site-docs/reference/cli-debug.md
@@ -23,6 +23,10 @@ agent-bom agents -f sarif -o -
 - `--quiet` suppresses scan chatter and retry noise for scripting.
 - `--log-level debug` with `--log-file` is the quickest way to capture a reproducible issue.
 - `-o -` is the stdout form for machine-readable exports.
+- If a finding looks inaccurate, open an
+  [Inaccurate Finding](https://github.com/msaad00/agent-bom/issues/new?template=inaccurate_finding.yml)
+  report with the exact command, agent-bom version, sanitized finding JSON/SARIF snippet,
+  and public advisory or package evidence.
 
 ## Command contracts
 

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -135,6 +135,13 @@ The `--self-scan` flag is on the `agents` subcommand (not top-level). It walks t
 
 See [CLI Debug Guide](cli-debug.md) for quiet/logging behavior, stdout vs file output, discovery triage, and package verification workflows.
 
+Use the
+[Inaccurate Finding](https://github.com/msaad00/agent-bom/issues/new?template=inaccurate_finding.yml)
+template for false positives, false negatives, wrong severity/advisory mapping,
+or misleading remediation. Include sanitized JSON/SARIF output and public
+evidence; do not post secrets, private source code, private package names, or
+customer data.
+
 For the JSON contract behind `agent-bom remediate`, see [`remediate` Output
 Contract](remediate-output.md).
 


### PR DESCRIPTION
## Summary
- add issue forms for inaccurate findings, docs confusion, integration requests, and runtime/proxy bugs
- refresh root and site contributing docs to use the current `uv run` contributor commands
- add a visible inaccurate-finding reporting path from CLI output/debug docs

Closes #2355 after the 10 seeded good-first issues are created and linked in the issue thread.

## Validation
- `uv run python - <<'PY' ... yaml.safe_load(...) ... PY`
- `uv run ruff check scripts/generate_runtime_evidence_pack.py src/agent_bom/runtime_smoke_mcp.py`
- `git diff --check`
- commit hooks: yaml/json/toml/eof/whitespace/private-key/case/merge/mixed-line, ruff, ruff-format, mypy, bandit, env-var reference drift
