### PR TITLE
[codex] test dense graph readability evidence

### DIFF
--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -805,7 +805,10 @@ function GraphPageInner() {
       }),
     [flow.nodes, flow.edges, aggregationThreshold, expandedClusterIds],
   );
-
+  const aggregatedClusterNodes = useMemo(
+    () => aggregated.nodes.filter((node) => isClusterPillNode(node as Node<LineageNodeData>)),
+    [aggregated.nodes],
+  );
   const graphIdentityKey = useMemo(
     () =>
       JSON.stringify({
@@ -917,6 +920,18 @@ function GraphPageInner() {
       };
     });
   }, [layoutNodes, localNeighborhoodIds, attackPathNodeIds, activeFocusId, effectiveLodBand]);
+
+  const compressedGroupCount = aggregatedClusterNodes.length;
+  const compressedNodeCount = useMemo(
+    () =>
+      aggregatedClusterNodes.reduce((total, node) => {
+        const count = (node.data as LineageNodeData & { count?: unknown }).count;
+        return total + (typeof count === "number" && Number.isFinite(count) ? count : 0);
+      }, 0),
+    [aggregatedClusterNodes],
+  );
+  const sourceNodeCount = graphData?.nodes.length ?? flow.nodes.length;
+  const renderedNodeCount = displayNodes.length;
 
   const displayEdges = useMemo(() => {
     if (attackPathEdgeKeys) {
@@ -1279,6 +1294,18 @@ function GraphPageInner() {
                 </span>
               )}
             </GraphControlGroup>
+            {sourceNodeCount > 0 && (
+              <GraphControlGroup label="Scale">
+                <span
+                  data-testid="graph-compression-summary"
+                  className="rounded-lg border border-sky-500/20 bg-sky-500/10 px-2.5 py-1 text-sky-200"
+                >
+                  {compressedGroupCount > 0
+                    ? `compressed ${compressedGroupCount} groups / ${compressedNodeCount} nodes`
+                    : `rendered ${renderedNodeCount} / ${sourceNodeCount} nodes`}
+                </span>
+              </GraphControlGroup>
+            )}
           </div>
 
           <div className="mt-2 text-xs text-zinc-500">

--- a/ui/e2e/security-graph-readability.spec.ts
+++ b/ui/e2e/security-graph-readability.spec.ts
@@ -1,0 +1,239 @@
+import { expect, test, type Page, type TestInfo } from "@playwright/test";
+
+const scanId = "scan-dense-graph";
+const previousScanId = "scan-dense-graph-prev";
+const createdAt = "2026-05-08T16:00:00Z";
+
+type GraphNode = {
+  id: string;
+  entity_type: string;
+  label: string;
+  category_uid: number;
+  class_uid: number;
+  type_uid: number;
+  status: string;
+  risk_score: number;
+  severity: string;
+  severity_id: number;
+  first_seen: string;
+  last_seen: string;
+  attributes: Record<string, unknown>;
+  compliance_tags: string[];
+  data_sources: string[];
+  dimensions: Record<string, string>;
+};
+
+type GraphEdge = {
+  id: string;
+  source: string;
+  target: string;
+  relationship: string;
+  direction: "directed" | "bidirectional";
+  weight: number;
+  traversable: boolean;
+  first_seen: string;
+  last_seen: string;
+  evidence: Record<string, unknown>;
+  activity_id: number;
+};
+
+function node(
+  id: string,
+  entityType: string,
+  label: string,
+  severity = "none",
+  riskScore = 0,
+  attributes: Record<string, unknown> = {},
+): GraphNode {
+  const severityRank: Record<string, number> = { none: 0, low: 1, medium: 2, high: 3, critical: 4 };
+  return {
+    id,
+    entity_type: entityType,
+    label,
+    category_uid: 0,
+    class_uid: 0,
+    type_uid: 0,
+    status: "active",
+    risk_score: riskScore,
+    severity,
+    severity_id: severityRank[severity] ?? 0,
+    first_seen: createdAt,
+    last_seen: createdAt,
+    attributes,
+    compliance_tags: [],
+    data_sources: ["e2e"],
+    dimensions: {},
+  };
+}
+
+function edge(source: string, target: string, relationship: string, weight = 1): GraphEdge {
+  return {
+    id: `${source}->${target}:${relationship}`,
+    source,
+    target,
+    relationship,
+    direction: "directed",
+    weight,
+    traversable: true,
+    first_seen: createdAt,
+    last_seen: createdAt,
+    evidence: {},
+    activity_id: 1,
+  };
+}
+
+function buildDenseGraph() {
+  const nodes: GraphNode[] = [
+    node("agent:claude", "agent", "Claude Desktop", "high", 8.8, { agent_type: "desktop" }),
+    node("server:filesystem", "server", "filesystem MCP", "high", 8.2, { command: "npx @modelcontextprotocol/server-filesystem" }),
+    node("server:github", "server", "github MCP", "high", 7.9, { command: "npx @modelcontextprotocol/server-github" }),
+    node("cred:github-token", "credential", "GitHub token", "high", 8.4),
+    node("tool:write-file", "tool", "write_file", "medium", 5.8),
+  ];
+  const edges: GraphEdge[] = [
+    edge("agent:claude", "server:filesystem", "uses"),
+    edge("agent:claude", "server:github", "uses"),
+    edge("server:github", "cred:github-token", "exposes_cred"),
+    edge("cred:github-token", "tool:write-file", "reaches_tool"),
+  ];
+
+  for (const server of ["filesystem", "github"]) {
+    const serverId = `server:${server}`;
+    for (let index = 1; index <= 8; index += 1) {
+      const packageId = `pkg:${server}:${index}`;
+      const vulnId = `cve:${server}:${index}`;
+      const severity = index % 3 === 0 ? "critical" : "high";
+      nodes.push(node(packageId, "package", `${server}-package-${index}`, severity, 7 + index / 10));
+      nodes.push(node(vulnId, "vulnerability", `CVE-2026-${server === "filesystem" ? "10" : "20"}${index}`, severity, 8 + index / 10));
+      edges.push(edge(serverId, packageId, "depends_on"));
+      edges.push(edge(packageId, vulnId, "vulnerable_to", 1.5));
+    }
+  }
+
+  return {
+    scan_id: scanId,
+    tenant_id: "default",
+    created_at: createdAt,
+    nodes,
+    edges,
+    attack_paths: [
+      {
+        source: "agent:claude",
+        target: "cve:filesystem:3",
+        hops: ["agent:claude", "server:filesystem", "pkg:filesystem:3", "cve:filesystem:3"],
+        edges: [
+          "agent:claude->server:filesystem:uses",
+          "server:filesystem->pkg:filesystem:3:depends_on",
+          "pkg:filesystem:3->cve:filesystem:3:vulnerable_to",
+        ],
+        composite_risk: 9.4,
+        summary: "Claude Desktop can reach a critical vulnerable package through filesystem MCP.",
+        credential_exposure: [],
+        tool_exposure: ["write_file"],
+        vuln_ids: ["CVE-2026-103"],
+      },
+    ],
+    interaction_risks: [],
+    stats: {
+      total_nodes: nodes.length,
+      total_edges: edges.length,
+      node_types: { agent: 1, server: 2, package: 16, vulnerability: 16, credential: 1, tool: 1 },
+      severity_counts: { critical: 4, high: 17, medium: 1 },
+      relationship_types: { uses: 2, depends_on: 16, vulnerable_to: 16, exposes_cred: 1, reaches_tool: 1 },
+      attack_path_count: 1,
+      interaction_risk_count: 0,
+      max_attack_path_risk: 9.4,
+      highest_interaction_risk: 0,
+    },
+    pagination: {
+      total: nodes.length,
+      offset: 0,
+      limit: 250,
+      has_more: false,
+    },
+  };
+}
+
+async function routeGraphPage(page: Page) {
+  const graph = buildDenseGraph();
+
+  await page.route("**/health", async (route) => {
+    await route.fulfill({ contentType: "application/json", body: JSON.stringify({ status: "ok" }) });
+  });
+  await page.route("**/v1/auth/me", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        authenticated: true,
+        auth_required: false,
+        configured_modes: [],
+        recommended_ui_mode: "no_auth",
+        auth_method: null,
+        subject: null,
+        role: null,
+        role_summary: null,
+        tenant_id: "default",
+        memberships: [],
+        request_id: "req-graph-e2e",
+        trace_id: "trace-graph-e2e",
+        span_id: "span-graph-e2e",
+      }),
+    });
+  });
+  await page.route("**/v1/posture/counts", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ critical: 4, high: 17, medium: 1, low: 0, total: 22, kev: 0, compound_issues: 1 }),
+    });
+  });
+  await page.route("**/v1/graph/snapshots?limit=40", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify([
+        { scan_id: scanId, created_at: createdAt, node_count: graph.nodes.length, edge_count: graph.edges.length, risk_summary: graph.stats.severity_counts },
+        { scan_id: previousScanId, created_at: "2026-05-08T15:00:00Z", node_count: 12, edge_count: 20, risk_summary: { high: 8 } },
+      ]),
+    });
+  });
+  await page.route("**/v1/graph/diff?**", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        nodes_added: ["cve:filesystem:3", "cve:github:3"],
+        nodes_removed: [],
+        nodes_changed: ["agent:claude"],
+        edges_added: [["pkg:filesystem:3", "cve:filesystem:3", "vulnerable_to"]],
+        edges_removed: [],
+      }),
+    });
+  });
+  await page.route("**/v1/graph?**", async (route) => {
+    await route.fulfill({ contentType: "application/json", body: JSON.stringify(graph) });
+  });
+}
+
+async function captureGraphScreenshot(page: Page, testInfo: TestInfo, theme: "dark" | "light") {
+  await expect(page.getByRole("heading", { name: "Security Graph" })).toBeVisible();
+  await expect(page.getByText("Focused", { exact: true })).toBeVisible();
+  await expect(page.getByText("Attack paths", { exact: true })).toBeVisible();
+  await expect(page.locator('[data-testid="cluster-pill"]').first()).toBeVisible();
+  await expect(page.getByTestId("graph-compression-summary")).toContainText(/compressed|rendered/);
+  await expect(page.locator("summary").filter({ hasText: "Legend" })).toBeVisible();
+  await page.screenshot({
+    path: testInfo.outputPath(`security-graph-dense-${theme}.png`),
+    fullPage: true,
+  });
+}
+
+for (const theme of ["dark", "light"] as const) {
+  test(`security graph dense ${theme} view stays focused and screenshot-ready`, async ({ page }, testInfo) => {
+    await routeGraphPage(page);
+    await page.addInitScript((selectedTheme) => {
+      window.localStorage.setItem("agent-bom-theme", selectedTheme);
+    }, theme);
+
+    await page.goto("/graph");
+    await page.waitForLoadState("networkidle");
+    await captureGraphScreenshot(page, testInfo, theme);
+  });
+}


### PR DESCRIPTION
## What changed

- Adds a dense `/graph` Playwright evidence spec that mocks a high-cardinality MCP/package/CVE graph and captures dark + light screenshots.
- Asserts the release-critical graph affordances are visible: focused mode, attack-path cards, cluster pills, legend, and the scale/compression chip.
- Adds a small scale chip to the graph toolbar so operators can see whether the current graph is compressed or how many nodes are rendered from the source snapshot.

## Why

Issue #2354 is about making dense security graphs readable and action-first at scale. The implementation already had focused defaults, sibling aggregation, LOD rendering, legend/minimap, and attack-path cards; this PR adds visible scale feedback plus e2e evidence so regressions are caught before release.

Refs #2354.

## Validation

- `cd ui && npm run typecheck` ✅
- `cd ui && npm test -- --run sibling-aggregator lod-renderer` ✅
- `cd ui && npm run build` ✅
- `cd ui && npm run test:e2e -- security-graph-readability.spec.ts` ✅
- Visual review of generated dark and light dense-graph screenshots ✅
- `cd ui && npm run verify:toolchain` ⚠️ failed locally because this shell is using Node `25.9.0`; the UI declares `>=22 <25`.
