### PR TITLE
add SARIF upload troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,9 @@ Cortex, Cursor, Windsurf, or another MCP client.
 Artifact: `agent-bom-results.sarif`, optional pull-request summary, and GitHub
 code-scanning evidence. Next step: add `iac`, `ai-inventory`, `gpu-scan`, or
 skills checks only for the surfaces the repository actually owns.
+If the action runs but Code Scanning stays empty, use the
+[SARIF upload troubleshooting guide](docs/GITHUB_ACTION_SARIF_TROUBLESHOOTING.md)
+to check token permissions, fork PR behavior, report paths, and upload category.
 
 **Hosted gateway/proxy review**
 
@@ -536,6 +539,8 @@ References: [PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md) · [PRODUCT_METRICS.md](do
 ```
 
 Container image gate, IaC gate, air-gapped CI, MCP scan, and the SARIF / SBOM examples are documented in [site-docs/getting-started/quickstart.md](site-docs/getting-started/quickstart.md).
+SARIF upload failures are usually GitHub token or repository-setting issues;
+see [GitHub Action SARIF troubleshooting](docs/GITHUB_ACTION_SARIF_TROUBLESHOOTING.md).
 
 </details>
 

--- a/docs/GITHUB_ACTION_SARIF_TROUBLESHOOTING.md
+++ b/docs/GITHUB_ACTION_SARIF_TROUBLESHOOTING.md
@@ -1,0 +1,86 @@
+# GitHub Action SARIF Troubleshooting
+
+Use this when `agent-bom` runs in GitHub Actions but findings do not appear in
+GitHub Code Scanning.
+
+## Minimal working shape
+
+```yaml
+name: agent-bom
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: msaad00/agent-bom@v0.86.3
+        with:
+          scan-type: agents
+          format: sarif
+          upload-sarif: true
+          pr-comment: true
+```
+
+`security-events: write` is required for SARIF upload. Without it,
+`github/codeql-action/upload-sarif` cannot write code-scanning alerts even when
+the SARIF file exists.
+
+## Common failure modes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Action passes but no Code Scanning alert appears | Workflow lacks `security-events: write`. | Add job or workflow permissions with `security-events: write`. |
+| SARIF upload is skipped | `format` is not `sarif`, or no SARIF file was generated. | Set `format: sarif` and check the action log for the report path. |
+| `Resource not accessible by integration` | Pull request comes from a fork or the token lacks upload permission. | Run SARIF upload on `push` to a trusted branch, or keep fork PRs as artifact/PR-comment only. |
+| Upload fails with path errors | The configured SARIF path does not match the generated report path. | Use the action output path, or keep the default `agent-bom-results.sarif`. |
+| Alerts overwrite another scanner category | Multiple uploads share the same category. | Give each scanner a stable unique category when using manual `upload-sarif`. |
+| Private repository shows no code scanning view | Code scanning may be unavailable for the plan or repository settings. | Check repository Security settings and GitHub Advanced Security availability. |
+
+## Debug checklist
+
+1. Confirm the workflow has `contents: read` and `security-events: write`.
+2. Confirm `format: sarif` and `upload-sarif: true` are both set.
+3. Confirm the action log says a SARIF file was produced.
+4. Confirm the run is from a trusted branch when uploading SARIF.
+5. Download the workflow artifact or generated report and validate it locally:
+
+   ```bash
+   jq -e '.version == "2.1.0" and (.runs | length > 0)' agent-bom-results.sarif
+   ```
+
+6. If upload still fails, keep the SARIF artifact and PR comment enabled so the
+   security review still has evidence while token or repository settings are
+   fixed.
+
+## Manual upload fallback
+
+When using `agent-bom` only to generate SARIF and uploading manually, keep the
+same permission boundary:
+
+```yaml
+permissions:
+  contents: read
+  security-events: write
+
+steps:
+  - uses: actions/checkout@v4
+  - run: pipx run agent-bom agents -p . -f sarif -o agent-bom-results.sarif
+  - uses: github/codeql-action/upload-sarif@v4
+    if: always() && hashFiles('agent-bom-results.sarif') != ''
+    with:
+      sarif_file: agent-bom-results.sarif
+      category: agent-bom
+```
+
+For fork PRs, prefer uploading the SARIF as a workflow artifact and reviewing
+the PR comment until a trusted branch run can publish Code Scanning results.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -252,6 +252,11 @@ blast_radius        — blast radius for a specific CVE
     ignore-file: .agent-bom-ignore.yaml
 ```
 
+If findings are generated but do not appear in GitHub Code Scanning, check
+[`GITHUB_ACTION_SARIF_TROUBLESHOOTING.md`](GITHUB_ACTION_SARIF_TROUBLESHOOTING.md)
+for the required `security-events: write` permission, fork PR limitations,
+SARIF path checks, and category guidance.
+
 ### Local developer workflow
 
 ```bash

--- a/site-docs/getting-started/quickstart.md
+++ b/site-docs/getting-started/quickstart.md
@@ -96,3 +96,7 @@ agent-bom agents -f csv      # CSV export
 agent-bom check requests@2.33.0 -e pypi -f json   # single-package JSON verdict
 agent-bom report history -f json                  # saved scan metadata for CI
 ```
+
+If a GitHub Action produces SARIF but no Code Scanning alert appears, check the
+[SARIF upload troubleshooting guide](https://github.com/msaad00/agent-bom/blob/main/docs/GITHUB_ACTION_SARIF_TROUBLESHOOTING.md)
+for token permissions, fork PR behavior, report paths, and category settings.


### PR DESCRIPTION
## Summary
- add a GitHub Action SARIF troubleshooting guide
- document required `security-events: write`, fork PR limitations, SARIF path checks, categories, and manual upload fallback
- link the guide from README, MCP security model, and quickstart docs

Closes #2369.

## Validation
- uv run python scripts/check_release_consistency.py
- git diff --check
- pre-commit during commit: whitespace, private key, case conflict, merge conflict, mixed line ending gates