### PR TITLE
docs: add AI infrastructure coverage matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,10 @@ see value and where enterprises wire agent-bom into existing controls.
 | Runtime and app frameworks | MCP proxy/gateway, Shield SDK, Anthropic/OpenAI SDK patterns, LangChain, CrewAI | enforces policy on live tool calls and lets applications add in-process allow/block decisions |
 | Governance and observability | Postgres/Supabase, ClickHouse, Snowflake paths, OTEL, SIEM/export hooks, compliance bundles | persists evidence, trends, audit, graph state, and control mappings without requiring a hosted vendor plane |
 
+For cloud, IaC, GPU, skills, and runtime boundaries, use the
+[AI infrastructure coverage matrix](site-docs/architecture/ai-infrastructure.md#coverage-matrix)
+to pick the command and artifact before making a release or buyer-facing claim.
+
 Three copy-paste workflows cover the common agentic adoption paths:
 
 **Local developer scan**

--- a/site-docs/architecture/ai-infrastructure.md
+++ b/site-docs/architecture/ai-infrastructure.md
@@ -14,6 +14,34 @@ For the comprehensive guide, see [AI_INFRASTRUCTURE_SCANNING.md](https://github.
 | **AI observability** | LangSmith, Langfuse, Braintrust, Arize/Phoenix, Trubrics, Helicone SDK inventory |
 | **Code** | SAST via Semgrep with CWE mapping |
 
+## Coverage Matrix
+
+Use this matrix when deciding which AI infrastructure path to run first. The
+command should match the system boundary you can actually inspect.
+
+| Surface | First command | Evidence produced | Credential boundary | Current limit |
+|---|---|---|---|---|
+| Local agent and MCP inventory | `agent-bom agents -p .` | agents, MCP servers, packages, credential env-var names, findings | local filesystem and project checkout | static scan; no live tool-call causality |
+| Skills and instruction files | `agent-bom skills scan .` | instruction-file findings, referenced packages, MCP mentions, trust notes | repo-local docs and skill files | does not prove a skill is installed in every assistant |
+| Container and GPU images | `agent-bom agents --image <image>` | OS and language packages, CVEs, SBOM-ready package inventory | registry pull credentials when private images are used | image scan does not prove runtime deployment |
+| Kubernetes and GPU workloads | `agent-bom agents --k8s --namespace <ns>` | pod/workload inventory, package paths where available, GPU workload context | kubeconfig or in-cluster service account | depends on Kubernetes permissions and visible namespaces |
+| Cloud and AI platforms | provider-specific scan flags or enterprise preset | read-only cloud, warehouse, model, and AI service inventory | customer-managed provider credentials | provider coverage varies; mark partial evidence honestly |
+| IaC and repo posture | `agent-bom iac scan .` or CI action | Terraform, Kubernetes, Helm, CloudFormation, Dockerfile findings | repository checkout | planned resources are not proof of deployed state |
+| Runtime proxy or gateway | `agent-bom proxy ...` or `agent-bom gateway serve ...` | audit JSONL, policy decisions, runtime alerts, relay metrics | selected MCP traffic path and operator runtime tokens | only selected traffic is governed |
+
+## Evidence Rules
+
+- Keep scan-only evidence separate from runtime evidence. Static findings show
+  reachability and exposure; proxy, gateway, trace, or Shield evidence is
+  required for live tool-call causality.
+- Record the command, target boundary, artifact path, and credential source in
+  release notes or buyer demos.
+- Treat provider entries marked partial as explicit gaps, not as silent
+  coverage.
+- Prefer read-only credentials for cloud, warehouse, model, and registry scans.
+- Do not imply endpoint, gateway, or proxy rollout unless the runtime command
+  path was actually run.
+
 ## Cloud providers
 
 | Provider | Module | CIS Benchmark |

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -2,7 +2,9 @@
 
 **Open security scanner and graph for AI supply chain and infrastructure — discover agents and MCP, map blast radius, and inspect runtime.**
 
-Scan agents, MCP, packages, containers, Kubernetes, cloud, and GPU workloads with blast-radius context.
+Scan agents, MCP, packages, containers, Kubernetes, cloud, and GPU workloads
+with blast-radius context. For source-by-source boundaries, see the
+[AI infrastructure coverage matrix](architecture/ai-infrastructure.md#coverage-matrix).
 
 ## What it does
 


### PR DESCRIPTION
## Summary
- add a coverage matrix for local agent inventory, skills, image/GPU scans, Kubernetes, cloud/AI platforms, IaC, and runtime proxy/gateway evidence
- document the credential boundary and current limit for each surface
- link the matrix from the README and docs home page so release claims point to concrete command/artifact boundaries

## Validation
- uv run mkdocs build --strict
- git diff --check