### PR TITLE
docs: add LLM key exposure drill

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,9 @@ see value and where enterprises wire agent-bom into existing controls.
 For cloud, IaC, GPU, skills, and runtime boundaries, use the
 [AI infrastructure coverage matrix](site-docs/architecture/ai-infrastructure.md#coverage-matrix)
 to pick the command and artifact before making a release or buyer-facing claim.
+If an AI-provider key may have leaked, use the
+[LLM key exposure drill](site-docs/deployment/llm-key-exposure-drill.md) to
+map agent, MCP, CI, cloud, and runtime rotation scope.
 
 Three copy-paste workflows cover the common agentic adoption paths:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
       - Operations Reference:
           - Packaged API + UI Control Plane: deployment/control-plane-helm.md
           - Postgres Provisioning Workflow: deployment/postgres-provisioning.md
+          - LLM Key Exposure Drill: deployment/llm-key-exposure-drill.md
           - Backup and Restore Runbook: deployment/backup-restore.md
           - Air-Gapped Image Bundle: deployment/airgapped-image-bundle.md
           - Performance, Sizing, and Benchmarks: deployment/performance-and-sizing.md

--- a/site-docs/deployment/llm-key-exposure-drill.md
+++ b/site-docs/deployment/llm-key-exposure-drill.md
@@ -1,0 +1,65 @@
+# LLM Key Exposure Drill
+
+Use this runbook when an AI assistant, copied shell command, MCP server, or
+developer workstation may have exposed OpenAI, Anthropic, Bedrock, Vertex AI,
+Azure OpenAI, or other LLM credentials.
+
+The goal is not to prove the breach from agent-bom alone. The goal is to map
+where keys are referenced, which agents and MCP servers can reach them, which
+runtime paths could have moved them, and what evidence should drive rotation.
+
+## First 30 Minutes
+
+| Step | Command | Artifact | Decision |
+|---|---|---|---|
+| Inventory local agent/MCP exposure | `agent-bom agents -p . -f json -o agent-bom-agents.json` | agents, MCP servers, packages, exposed credential env-var names | Which local configs reference AI provider credentials? |
+| Scan instruction files | `agent-bom skills scan . -f json -o agent-bom-skills.json` | risky instructions, command execution patterns, credential references | Did repo instructions encourage unsafe command execution or secret access? |
+| Export review packet | `agent-bom agents -p . -f html -o agent-bom-llm-key-review.html` | human-readable blast-radius packet | Which teams need to review and rotate first? |
+| Preserve runtime evidence if present | collect proxy/gateway audit JSONL and trace IDs | audit decisions, tool calls, relay metadata | Was this a live tool-call path or a static exposure path? |
+
+Do not wait for perfect attribution before rotating active production keys. Use
+agent-bom to reduce the unknowns: owner, environment, agent, MCP server, tool,
+package, and workload reachability.
+
+## Rotation Scope Checklist
+
+| Scope | What to check | Evidence source |
+|---|---|---|
+| Developer laptops | Claude/Cursor/Windsurf/Codex/Cortex config, MCP server env names, shell profiles | `agent-bom agents`, endpoint fleet sync |
+| CI/CD | repository secrets, Actions variables, SARIF upload token permissions, build logs | GitHub audit, `agent-bom-results.sarif`, CI artifacts |
+| Runtime MCP paths | stdio proxy audit, gateway relay, policy decisions, undeclared tool blocks | proxy/gateway JSONL, control-plane runtime evidence |
+| Cloud and model platforms | Bedrock/Vertex/Azure/OpenAI/Anthropic key owners, IAM role scope, model invoke permissions | provider console, cloud inventory scans |
+| Applications | LangChain, CrewAI, OpenAI/Anthropic SDK usage, Shield decisions | AI inventory scan, application logs |
+| Warehouses and observability | Snowflake, Databricks, W&B, MLflow, Langfuse/LangSmith references | read-only provider inventory, config review |
+
+## What Agent-BOM Can Prove
+
+- Which MCP clients, servers, package dependencies, tools, and credential
+  environment variable names are visible in scanned configs.
+- Which instruction files contain risky command, credential, exfiltration, or
+  trust-bypass patterns.
+- Which vulnerable packages sit inside the same MCP server or agent path as an
+  LLM credential reference.
+- Which runtime proxy or gateway path emitted an audit event, block, or alert.
+- Which evidence is safe durable Tier-A metadata versus replay-only content.
+
+## What It Does Not Prove Alone
+
+- That an attacker actually used a leaked key.
+- That every laptop, CI job, or production workload was scanned.
+- That a static graph edge is runtime causality.
+- That provider-side logs were retained or complete.
+
+Pair agent-bom evidence with provider audit logs, endpoint telemetry, SIEM
+events, and key-usage billing records before making incident-scope claims.
+
+## Follow-Up Controls
+
+- Move long-lived provider keys into short-lived workload identity wherever the
+  provider supports it.
+- Put local stdio MCP servers that touch files, shell, network, or secrets
+  behind `agent-bom proxy` when runtime evidence matters.
+- Use gateway policy for shared remote MCPs and central tenant audit.
+- Keep SARIF and HTML packets attached to the incident record.
+- Add the rotation owner, timestamp, and verification command to the release or
+  incident notes.

--- a/site-docs/security.md
+++ b/site-docs/security.md
@@ -27,6 +27,8 @@ Across all modes, agent-bom never stores credential values — only their names 
 
 For the product-wide local, endpoint, cloud, API/UI, and proxy data boundary,
 see [Data Access Boundaries and Operator Control](deployment/data-access-boundaries.md).
+For incident response when LLM provider keys may have been exposed, use the
+[LLM Key Exposure Drill](deployment/llm-key-exposure-drill.md).
 
 ## Release trust and dependency controls
 


### PR DESCRIPTION
## Summary
- add a runbook for suspected OpenAI, Anthropic, Bedrock, Vertex AI, Azure OpenAI, and other LLM key exposure scenarios
- map the first 30 minutes of agent-bom commands to concrete artifacts and rotation decisions
- document what agent-bom can prove versus what still needs provider, endpoint, SIEM, and billing evidence

## Validation
- uv run mkdocs build --strict
- git diff --check