### PR TITLE
test: guard runtime evidence pack

### DIFF
--- a/docs/release/runtime-evidence-v0.86.3.md
+++ b/docs/release/runtime-evidence-v0.86.3.md
@@ -10,6 +10,12 @@ uv run python scripts/generate_runtime_evidence_pack.py \
   --output docs/release/runtime-evidence-v0.86.3.json
 ```
 
+Release guard:
+
+```bash
+uv run pytest -q tests/test_runtime_evidence_pack.py
+```
+
 This evidence pack covers:
 
 - gateway `/healthz`

--- a/tests/test_runtime_evidence_pack.py
+++ b/tests/test_runtime_evidence_pack.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from scripts.generate_runtime_evidence_pack import generate
+
+
+def test_runtime_evidence_pack_covers_release_gate_without_docker() -> None:
+    evidence = generate(include_docker=False)
+
+    assert evidence["schema"] == "agent-bom-runtime-release-evidence/v1"
+
+    gateway = evidence["gateway"]
+    assert gateway["healthz"] == {
+        "status_code": 200,
+        "status": "ok",
+        "incoming_token_required": True,
+        "upstreams": ["jira"],
+        "policy_source_kind": "inline",
+    }
+    assert gateway["bearer_auth"]["missing_token_status_code"] == 401
+    assert gateway["bearer_auth"]["valid_token_forwarded_status_code"] == 200
+    assert gateway["policy_block"]["status_code"] == 200
+    assert gateway["policy_block"]["jsonrpc_error_code"] == -32001
+    assert gateway["policy_block"]["audit_actions"] == [
+        "gateway.policy_blocked",
+        "gateway.tool_call",
+    ]
+    assert gateway["upstream_auth"] == {
+        "bearer_header_resolved_from_env": True,
+        "traceparent_forwarded": True,
+    }
+    assert gateway["metrics"]["status_code"] == 200
+    assert any('outcome="blocked"' in line for line in gateway["metrics"]["relay_lines"])
+    assert any('outcome="forwarded"' in line for line in gateway["metrics"]["relay_lines"])
+    assert gateway["gateway_limit"]["supported_upstream_transport"] == ("streamable-http request/response JSON-RPC over HTTP POST")
+    assert "stdio relay" in gateway["gateway_limit"]["not_supported_in_gateway"]
+
+    proxy_sandbox = evidence["proxy_sandbox"]
+    assert proxy_sandbox["sandbox_command_prefix"][:2] == [
+        proxy_sandbox["sandbox_evidence"]["runtime"],
+        "run",
+    ]
+    assert proxy_sandbox["sandbox_evidence"]["enabled"] is True
+    assert proxy_sandbox["sandbox_evidence"]["read_only_rootfs"] is True
+    assert proxy_sandbox["sandbox_evidence"]["egress_policy"] == "deny"
+    assert proxy_sandbox["sandbox_evidence"]["drop_capabilities"] is True
+    assert proxy_sandbox["sandbox_evidence"]["no_new_privileges"] is True
+    assert proxy_sandbox["sandbox_evidence"]["image_pin_policy"] == "enforce"
+    assert proxy_sandbox["sandbox_evidence"]["image_pinned"] is True
+    assert proxy_sandbox["audit_chain"] == {
+        "records_written": 2,
+        "verified": 2,
+        "tampered": 0,
+        "first_record_hash_present": True,
+        "second_prev_hash_matches_first": True,
+    }
+
+    assert evidence["docker_runtime_proxy_smoke"] == {
+        "ran": False,
+        "reason": "pass --docker-smoke to build and run the runtime proxy image",
+        "expected_image": "agent-bom-runtime-evidence:0.86.3",
+    }


### PR DESCRIPTION
Summary
- add a release guard for the runtime evidence pack generator
- assert gateway health, bearer auth, policy block audit, relay metrics, upstream auth, gateway transport limits, proxy sandbox posture, and audit hash-chain verification
- document the targeted pytest command next to the runtime evidence regeneration command

Validation
- uv run pytest -q tests/test_runtime_evidence_pack.py
- uv run ruff check tests/test_runtime_evidence_pack.py scripts/generate_runtime_evidence_pack.py
- git diff --check