### PR TITLE
fix: align proxy sandbox containment claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,13 @@ The dashboard UI under `ui/` is TypeScript / Next.js / React 19 — that's the o
 
 ## Trust & transparency
 
-agent-bom is a **read-only scanner**. It never writes configs, never executes MCP servers, never stores credential values. No telemetry. No analytics. Releases are [Sigstore-signed](docs/PERMISSIONS.md) with SLSA provenance and self-published SBOMs.
+The scanner path is **read-only**: `agent-bom agents`, `fs`, `check`, and
+related scan commands never write configs, never execute MCP servers, and never
+store credential values. Runtime commands are separate: `agent-bom proxy` and
+`agent-bom gateway` intentionally sit in live traffic so they can audit or
+enforce policy on selected MCP paths. No telemetry. No analytics. Releases are
+[Sigstore-signed](docs/PERMISSIONS.md) with SLSA provenance and self-published
+SBOMs.
 
 | When | What's sent | Where | Opt out |
 |---|---|---|---|
@@ -499,7 +505,18 @@ to check token permissions, fork PR behavior, report paths, and upload category.
 **Hosted gateway/proxy review**
 
 ```bash
-agent-bom proxy --log audit.jsonl --block-undeclared -- npx @modelcontextprotocol/server-filesystem /workspace
+# Audit and policy for one stdio MCP path, without process containment.
+agent-bom proxy --no-isolate --log audit.jsonl --block-undeclared -- npx @modelcontextprotocol/server-filesystem /workspace
+
+# Add process containment for stdio MCPs by providing a Docker/Podman image
+# that contains the server runtime, and replace the digest with your image digest.
+agent-bom proxy \
+  --sandbox-image ghcr.io/your-org/mcp-runtime:node20@sha256:<64-hex-digest> \
+  --sandbox-image-pin-policy enforce \
+  --sandbox-mount "$PWD:/workspace:ro" \
+  --log audit.jsonl \
+  --block-undeclared \
+  -- npx @modelcontextprotocol/server-filesystem /workspace
 
 agent-bom gateway serve \
   --from-control-plane https://agent-bom.example.com \
@@ -509,8 +526,9 @@ agent-bom gateway serve \
 
 Artifact: local proxy audit JSONL for stdio MCP traffic, gateway policy
 decisions for shared remote MCP traffic, and control-plane evidence when those
-surfaces are connected. Next step: run the runtime evidence pack before claiming
-gateway/proxy release sign-off.
+surfaces are connected. Gateway policy governs remote MCP traffic; it does not
+containerize the upstream server. Next step: run the runtime evidence pack before
+claiming gateway/proxy release sign-off.
 
 MCP and skills setup is documented in the client guides, not in repo-local
 assistant launch files: [Claude](docs/CLAUDE_INTEGRATION.md),

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -161,7 +161,7 @@ The proxy supports two operational modes:
 All tool calls are allowed through. Every invocation is recorded in the JSONL audit log with full metadata (tool name, truncated arguments, timestamp). Use this mode to build a baseline of normal behavior before enabling enforcement.
 
 ```bash
-agent-bom proxy --log audit.jsonl -- npx @mcp/server-filesystem /workspace
+agent-bom proxy --no-isolate --log audit.jsonl -- npx @mcp/server-filesystem /workspace
 ```
 
 For Claude Desktop, Claude Code, and Cortex JSON configs, you can auto-wrap eligible stdio servers:
@@ -180,6 +180,7 @@ Add `--block-undeclared` and/or `--policy policy.json` to actively block tool ca
 
 ```bash
 agent-bom proxy \
+  --no-isolate \
   --log audit.jsonl \
   --policy policy.json \
   --block-undeclared \
@@ -215,7 +216,7 @@ Use the `agent-bom watch` command alongside the proxy to route alerts to Slack, 
 
 ```bash
 # In one terminal: run the proxy
-agent-bom proxy --log audit.jsonl -- npx @mcp/server-filesystem /workspace
+agent-bom proxy --no-isolate --log audit.jsonl -- npx @mcp/server-filesystem /workspace
 
 # In another terminal: watch the audit log and send alerts
 agent-bom watch --webhook https://hooks.slack.com/services/T.../B.../xxx --log alerts.jsonl
@@ -480,7 +481,7 @@ kubectl apply -f deploy/k8s/sidecar-example.yaml
 The proxy exposes Prometheus-compatible metrics on port 8422 (configurable via `--metrics-port`):
 
 ```bash
-agent-bom proxy --metrics-port 8422 --log audit.jsonl -- npx @mcp/server-filesystem /workspace
+agent-bom proxy --no-isolate --metrics-port 8422 --log audit.jsonl -- npx @mcp/server-filesystem /workspace
 ```
 
 ### Metrics endpoint

--- a/site-docs/deployment/llm-key-exposure-drill.md
+++ b/site-docs/deployment/llm-key-exposure-drill.md
@@ -59,7 +59,16 @@ events, and key-usage billing records before making incident-scope claims.
   provider supports it.
 - Put local stdio MCP servers that touch files, shell, network, or secrets
   behind `agent-bom proxy` when runtime evidence matters.
+- Treat proxy containment as a separate setting from proxy audit. `agent-bom
+  proxy --no-isolate` gives audit and policy evidence without process
+  containment. Container isolation applies to stdio MCP servers when Docker or
+  Podman is available and the proxy is given a sandbox image with
+  `--sandbox-image` or `AGENT_BOM_MCP_SANDBOX_IMAGE`; production deployments
+  should also set `--sandbox-image-pin-policy enforce`.
 - Use gateway policy for shared remote MCPs and central tenant audit.
+- Do not claim the gateway containerizes remote MCP upstreams. It centralizes
+  auth, tenancy, routing, policy decisions, relay metrics, and audit evidence;
+  upstream runtime containment remains in the upstream workload or sidecar.
 - Keep SARIF and HTML packets attached to the incident record.
 - Add the rotation owner, timestamp, and verification command to the release or
   incident notes.

--- a/site-docs/deployment/runtime-monitoring.md
+++ b/site-docs/deployment/runtime-monitoring.md
@@ -21,7 +21,7 @@ The runtime proxy (`agent-bom proxy`) intercepts MCP JSON-RPC messages between c
 
 | Mode | Command | Use case |
 |------|---------|----------|
-| Local sidecar | `agent-bom proxy -- npx server` | Dev/testing |
+| Local sidecar | `agent-bom proxy --no-isolate -- npx server` | Dev/testing audit and policy without process containment |
 | Docker sidecar | See [Docker](docker.md) | Production |
 | K8s sidecar | See [Kubernetes](kubernetes.md) | Fleet |
 | Optional node-wide monitor | Helm `monitor.enabled=true` | Broad runtime coverage only when a team explicitly accepts a DaemonSet |

--- a/site-docs/features/runtime-proxy.md
+++ b/site-docs/features/runtime-proxy.md
@@ -34,12 +34,16 @@ MCP Server (filesystem, postgres, etc.)
 ## Usage
 
 ```bash
-# Basic audit logging
-agent-bom proxy --log audit.jsonl \
+# Basic audit and policy for one stdio server, without process containment.
+agent-bom proxy --no-isolate --log audit.jsonl \
   -- npx @modelcontextprotocol/server-filesystem /workspace
 
-# Recommended hardened proxy
+# Process-contained stdio proxy. The sandbox image must contain the server
+# runtime, such as Node for npx-based MCP servers.
 agent-bom proxy \
+  --sandbox-image ghcr.io/your-org/mcp-runtime:node20@sha256:<64-hex-digest> \
+  --sandbox-image-pin-policy enforce \
+  --sandbox-mount "$PWD:/workspace:ro" \
   --policy policy.json \
   --log audit.jsonl \
   --detect-credentials \
@@ -53,6 +57,21 @@ Recommended minimum hardening for developer workstations:
 - `--detect-credentials` to inspect responses for leaked secrets
 - `--block-undeclared` to stop tools that were never declared in `tools/list`
 - `--policy` when you want explicit allowlist/blocklist/read-only enforcement
+- `--sandbox-image` plus `--sandbox-image-pin-policy enforce` when you want
+  Docker/Podman process containment for stdio MCP servers
+
+Important containment limits:
+
+- `--no-isolate` is audit and policy only; it does not contain the MCP server
+  process.
+- `--isolate` is the default for stdio proxy mode. For plain commands such as
+  `npx ...`, isolation requires `--sandbox-image` or
+  `AGENT_BOM_MCP_SANDBOX_IMAGE`.
+- Existing `docker run ...` or `podman run ...` server commands can be hardened
+  directly by the proxy; conflicting weaker flags such as host networking are
+  stripped before launch.
+- `--url` SSE/HTTP proxy mode and the shared gateway govern remote MCP traffic
+  but do not containerize the upstream server.
 
 ## Audit JSONL example
 
@@ -78,6 +97,7 @@ backlog fields. The complete field guide lives in
       "command": "agent-bom",
       "args": [
         "proxy",
+        "--no-isolate",
         "--log", "audit.jsonl",
         "--policy", "policy.json",
         "--detect-credentials",

--- a/site-docs/reference/agentic-workflows.md
+++ b/site-docs/reference/agentic-workflows.md
@@ -11,7 +11,7 @@ plane or runtime enforcement rollout.
 | GitHub Actions | `uses: msaad00/agent-bom@v0.86.3` with SARIF upload enabled | Runs in CI with repository-scoped token permissions. Fork PR behavior depends on GitHub security policy. | `agent-bom-results.sarif`, pull-request summary, code-scanning alert category. | Branch protection, required code scanning, artifact retention. |
 | Skills and instruction files | `agent-bom skills scan .` | Reads repo-local instructions such as `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, and `skills/*.md`. | Skill trust findings, referenced package and MCP inventory, credential-env names. | Signed skills, provenance verification, registry publishing. |
 | Cloud and AI infrastructure | `agent-bom agents --preset enterprise` plus provider-specific flags only where credentials are approved. | Uses read-only provider APIs or local inventory files. Keep provider secrets in the operator boundary, not in repo docs. | Cloud, warehouse, GPU, model, dataset, and runtime package evidence. | Fleet sync, compliance exports, graph-backed findings. |
-| Runtime proxy | `agent-bom proxy --log audit.jsonl --block-undeclared -- ...` | Wraps selected local MCP traffic. Policy can block before an upstream tool receives the call. | Tier-A audit JSONL, policy decisions, runtime alerts, metrics. | Sidecar proxy, gateway policy pull, SIEM export. |
+| Runtime proxy | `agent-bom proxy --no-isolate --log audit.jsonl --block-undeclared -- ...` | Wraps selected local MCP traffic. Policy can block before an upstream tool receives the call. Container containment requires a stdio MCP path plus a configured sandbox image or an existing container command. | Tier-A audit JSONL, policy decisions, runtime alerts, metrics, and sandbox posture when isolation is enabled. | Sidecar proxy, gateway policy pull, SIEM export. |
 | Shared gateway | `agent-bom gateway serve --from-control-plane ...` | Centralizes auth, tenancy, routing, and policy for remote MCP upstreams. | Gateway health, policy evaluation, relay metrics, audit relay. | Helm/EKS gateway, tenant policies, autoscaling. |
 | Shield SDK | `from agent_bom.shield import Shield` | Enforces allow/block decisions in-process where the application already sees tool calls. | Redacted alerts and application-local decisions. | Shared policy model, proxy/gateway parity, runtime monitoring. |
 
@@ -46,7 +46,17 @@ SARIF troubleshooting guide before changing scanner behavior.
 ### Hosted Gateway Or Proxy Review
 
 ```bash
-agent-bom proxy --log audit.jsonl --block-undeclared -- npx @modelcontextprotocol/server-filesystem /workspace
+# Audit/policy only for a selected stdio MCP server.
+agent-bom proxy --no-isolate --log audit.jsonl --block-undeclared -- npx @modelcontextprotocol/server-filesystem /workspace
+
+# Add process containment by running the stdio MCP inside a pinned sandbox image.
+agent-bom proxy \
+  --sandbox-image ghcr.io/your-org/mcp-runtime:node20@sha256:<64-hex-digest> \
+  --sandbox-image-pin-policy enforce \
+  --sandbox-mount "$PWD:/workspace:ro" \
+  --log audit.jsonl \
+  --block-undeclared \
+  -- npx @modelcontextprotocol/server-filesystem /workspace
 
 agent-bom gateway serve \
   --from-control-plane https://agent-bom.example.com \
@@ -56,7 +66,8 @@ agent-bom gateway serve \
 
 Produces runtime audit and policy evidence for selected traffic. This is not a
 claim that all MCP traffic is governed; it proves the selected proxy or gateway
-path.
+path. Gateway policy governs remote MCP traffic; it does not containerize the
+upstream server.
 
 ## Guardrails
 

--- a/src/agent_bom/cli/_runtime.py
+++ b/src/agent_bom/cli/_runtime.py
@@ -224,12 +224,15 @@ def proxy_cmd(
       to the remote MCP endpoint so it can enforce policy on live traffic
 
     \b
-    Usage (stdio — subprocess):
-      agent-bom proxy -- npx @modelcontextprotocol/server-filesystem /tmp
-      agent-bom proxy --log audit.jsonl -- npx @mcp/server-github
-      agent-bom proxy --policy policy.json --detect-credentials --block-undeclared -- npx @mcp/server-postgres
-      agent-bom proxy --detect-credentials --log-only -- npx @mcp/server-github
-      agent-bom proxy --log audit.jsonl --response-sign-key $MY_SECRET -- npx @mcp/server-github
+    Usage (stdio — audit/policy without process containment):
+      agent-bom proxy --no-isolate --log audit.jsonl -- npx @mcp/server-github
+      agent-bom proxy --no-isolate --policy policy.json --detect-credentials --block-undeclared -- npx @mcp/server-postgres
+
+    \b
+    Usage (stdio — Docker/Podman containment):
+      agent-bom proxy --sandbox-image ghcr.io/acme/mcp-runtime@sha256:<digest> --log audit.jsonl -- npx @mcp/server-github
+      agent-bom proxy --sandbox-image ghcr.io/acme/mcp-runtime@sha256:<digest> \\
+        --sandbox-image-pin-policy enforce --block-undeclared -- npx @mcp/server-postgres
 
     \b
     Usage (SSE/HTTP — remote server):
@@ -280,7 +283,7 @@ def proxy_cmd(
         raise click.UsageError("Provide a server command (e.g. -- npx @mcp/server-filesystem /tmp) or --url for SSE/HTTP mode.")
 
     from agent_bom.proxy import run_proxy
-    from agent_bom.proxy_sandbox import sandbox_config_from_env
+    from agent_bom.proxy_sandbox import sandbox_config_from_env, sandbox_requires_image_for_command
 
     try:
         sandbox_config = sandbox_config_from_env(
@@ -298,6 +301,13 @@ def proxy_cmd(
         )
     except ValueError as exc:
         raise click.UsageError(str(exc)) from exc
+
+    if sandbox_requires_image_for_command(list(server_cmd), sandbox_config):
+        raise click.UsageError(
+            "MCP sandbox isolation for plain stdio commands requires --sandbox-image "
+            "or AGENT_BOM_MCP_SANDBOX_IMAGE. Use --no-isolate for audit/policy only, "
+            "or pass an existing docker/podman run command for the proxy to harden."
+        )
 
     exit_code = asyncio.run(
         run_proxy(

--- a/src/agent_bom/cli/run.py
+++ b/src/agent_bom/cli/run.py
@@ -272,7 +272,7 @@ def run_cmd(
     from agent_bom.api.proxy_replay_store import set_capture_replay
     from agent_bom.project_config import get_policy_path, load_project_config
     from agent_bom.proxy import run_proxy
-    from agent_bom.proxy_sandbox import sandbox_config_from_env
+    from agent_bom.proxy_sandbox import sandbox_config_from_env, sandbox_requires_image_for_command
 
     # Activate tier-B (replay-only) capture for this process if --capture-replay
     # is set. Without it, tier-B fields are dropped at the redaction layer.
@@ -317,6 +317,13 @@ def run_cmd(
         )
     except ValueError as exc:
         raise click.UsageError(str(exc)) from exc
+
+    if sandbox_requires_image_for_command(cmd, sandbox_config):
+        raise click.UsageError(
+            "MCP sandbox isolation for plain stdio commands requires --sandbox-image "
+            "or AGENT_BOM_MCP_SANDBOX_IMAGE. Use --no-isolate for audit/policy only, "
+            "or pass an existing docker/podman run command for the proxy to harden."
+        )
 
     # Build env for child process — no mutation of current env needed here;
     # run_proxy spawns the subprocess itself and inherits os.environ.

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -6,7 +6,8 @@ invocations, compares actual usage against declared capabilities, and
 optionally enforces security policy in real-time.
 
 Usage:
-    agent-bom proxy [--policy policy.json] [--log audit.jsonl] -- npx @mcp/server-filesystem /tmp
+    agent-bom proxy --no-isolate [--policy policy.json] [--log audit.jsonl] -- npx @mcp/server-filesystem /tmp
+    agent-bom proxy --sandbox-image ghcr.io/acme/mcp-runtime@sha256:<digest> -- npx @mcp/server-filesystem /tmp
 """
 
 from __future__ import annotations

--- a/src/agent_bom/proxy_sandbox.py
+++ b/src/agent_bom/proxy_sandbox.py
@@ -279,6 +279,17 @@ def build_sandboxed_command(server_cmd: list[str], config: SandboxConfig) -> tup
     return command, evidence
 
 
+def sandbox_requires_image_for_command(server_cmd: list[str], config: SandboxConfig) -> bool:
+    """Return true when isolated stdio execution needs a sandbox image.
+
+    Existing ``docker run`` / ``podman run`` commands already name the image
+    they execute and can be hardened directly. Plain commands such as
+    ``npx ...`` or ``python -m ...`` need an operator-provided image so the
+    proxy can run them inside Docker/Podman instead of on the host.
+    """
+    return config.enabled and not config.image and not _is_container_run(server_cmd)
+
+
 def _sandbox_docker_args(config: SandboxConfig) -> list[str]:
     args = ["--rm", "-i"]
     if config.read_only_rootfs:

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -135,7 +135,7 @@ def test_run_delegates_to_run_proxy():
     ):
         mock_asyncio_run.side_effect = _consume_coroutine_and_return()
         # CliRunner catches SystemExit — check exit_code instead
-        result = runner.invoke(run_cmd, ["uvx/mcp-server-git", "--quiet"])
+        result = runner.invoke(run_cmd, ["uvx/mcp-server-git", "--quiet", "--no-isolate"])
         assert result.exit_code == 0
         mock_asyncio_run.assert_called_once()
 
@@ -160,7 +160,7 @@ def test_run_passes_policy_to_run_proxy():
             mock_asyncio_run.side_effect = _consume_coroutine_and_return()
             result = runner.invoke(
                 run_cmd,
-                ["uvx/mcp-server-git", "--policy", policy_path, "--quiet"],
+                ["uvx/mcp-server-git", "--policy", policy_path, "--quiet", "--no-isolate"],
             )
         assert result.exit_code == 0
         mock_asyncio_run.assert_called_once()
@@ -208,6 +208,17 @@ def test_run_no_isolate_opts_out():
     mock_asyncio_run.assert_called_once()
 
 
+def test_run_plain_isolated_command_requires_sandbox_image():
+    runner = CliRunner()
+
+    with patch("agent_bom.project_config.load_project_config", return_value=None):
+        result = runner.invoke(run_cmd, ["uvx/mcp-server-git", "--quiet"])
+
+    assert result.exit_code == 2
+    assert "requires --sandbox-image" in result.output
+    assert "--no-isolate" in result.output
+
+
 def test_run_command_not_found_handled(tmp_path):
     """When asyncio.run raises FileNotFoundError the error surfaces cleanly."""
     runner = CliRunner()
@@ -216,7 +227,7 @@ def test_run_command_not_found_handled(tmp_path):
         patch("agent_bom.cli.run.asyncio.run", side_effect=_consume_coroutine_and_raise(FileNotFoundError("no such"))),
         patch("agent_bom.project_config.load_project_config", return_value=None),
     ):
-        result = runner.invoke(run_cmd, ["nonexistent-server-xyz-abc"])
+        result = runner.invoke(run_cmd, ["nonexistent-server-xyz-abc", "--no-isolate"])
     # Should exit non-zero or have an exception recorded
     assert result.exit_code != 0 or result.exception is not None
 
@@ -229,7 +240,7 @@ def test_run_quiet_flag_suppresses_stderr():
         patch("agent_bom.cli.run.asyncio.run", side_effect=_consume_coroutine_and_return()),
         patch("agent_bom.project_config.load_project_config", return_value=None),
     ):
-        result = runner.invoke(run_cmd, ["uvx/mcp-server-git", "--quiet"])
+        result = runner.invoke(run_cmd, ["uvx/mcp-server-git", "--quiet", "--no-isolate"])
     assert result.exit_code == 0
 
 

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -44,7 +44,7 @@ def test_proxy_cmd_runs_proxy(tmp_path):
         patch("agent_bom.proxy.run_proxy", new_callable=AsyncMock, return_value=0),
         patch("agent_bom.project_config.load_project_config", return_value=None),
     ):
-        result = runner.invoke(proxy_cmd, ["--", "echo", "hello"])
+        result = runner.invoke(proxy_cmd, ["--no-isolate", "--", "echo", "hello"])
         assert result.exit_code == 0
 
 
@@ -54,10 +54,20 @@ def test_proxy_cmd_sandbox_is_enabled_by_default():
         patch("agent_bom.proxy.run_proxy", new_callable=AsyncMock, return_value=0) as mock_run,
         patch("agent_bom.project_config.load_project_config", return_value=None),
     ):
-        result = runner.invoke(proxy_cmd, ["--", "echo", "hello"])
+        result = runner.invoke(proxy_cmd, ["--sandbox-image", "ghcr.io/acme/mcp-sandbox:1", "--", "echo", "hello"])
 
     assert result.exit_code == 0
     assert mock_run.await_args.kwargs["sandbox_config"].enabled is True
+
+
+def test_proxy_cmd_plain_isolated_command_requires_sandbox_image():
+    runner = CliRunner()
+    with patch("agent_bom.project_config.load_project_config", return_value=None):
+        result = runner.invoke(proxy_cmd, ["--", "echo", "hello"])
+
+    assert result.exit_code == 2
+    assert "requires --sandbox-image" in result.output
+    assert "--no-isolate" in result.output
 
 
 def test_proxy_cmd_no_isolate_opts_out():
@@ -97,7 +107,7 @@ def test_proxy_cmd_with_project_config():
         patch("agent_bom.project_config.load_project_config", return_value={"policy": "test.json"}),
         patch("agent_bom.project_config.get_policy_path", return_value=None),
     ):
-        result = runner.invoke(proxy_cmd, ["--", "echo"])
+        result = runner.invoke(proxy_cmd, ["--no-isolate", "--", "echo"])
         assert result.exit_code == 0
 
 
@@ -118,6 +128,7 @@ def test_proxy_cmd_passes_control_plane_settings():
                 "45",
                 "--audit-push-interval",
                 "15",
+                "--no-isolate",
                 "--",
                 "echo",
                 "hello",

--- a/tests/test_proxy_sandbox.py
+++ b/tests/test_proxy_sandbox.py
@@ -9,6 +9,7 @@ from agent_bom.proxy_sandbox import (
     build_sandboxed_command,
     parse_sandbox_mount,
     sandbox_config_from_env,
+    sandbox_requires_image_for_command,
 )
 
 PINNED_IMAGE = "ghcr.io/acme/mcp-sandbox:1@sha256:" + "a" * 64
@@ -259,3 +260,22 @@ def test_build_sandboxed_command_requires_image_for_plain_commands(monkeypatch):
 
     with pytest.raises(RuntimeError, match="requires --sandbox-image"):
         build_sandboxed_command(["python", "-m", "server"], SandboxConfig(enabled=True))
+
+
+def test_sandbox_requires_image_for_plain_isolated_commands():
+    assert sandbox_requires_image_for_command(["npx", "@mcp/server"], SandboxConfig(enabled=True)) is True
+    assert (
+        sandbox_requires_image_for_command(
+            ["npx", "@mcp/server"],
+            SandboxConfig(enabled=True, image=PINNED_IMAGE),
+        )
+        is False
+    )
+    assert sandbox_requires_image_for_command(["npx", "@mcp/server"], SandboxConfig(enabled=False)) is False
+    assert (
+        sandbox_requires_image_for_command(
+            ["docker", "run", "--rm", "-i", "ghcr.io/acme/server:1"],
+            SandboxConfig(enabled=True),
+        )
+        is False
+    )


### PR DESCRIPTION
Summary
- make proxy examples distinguish audit/policy-only mode from process containment
- document that stdio containment needs Docker/Podman plus a sandbox image or an existing container command
- add a CLI guard so plain isolated stdio commands fail fast with guidance instead of implying containment is configured
- clarify that gateway and remote proxy paths govern traffic but do not containerize upstream MCP servers

Validation
- uv run pytest -q tests/test_cli_runtime.py tests/test_cli_run.py tests/test_proxy_sandbox.py
- uv run ruff check src/agent_bom/proxy_sandbox.py src/agent_bom/cli/_runtime.py src/agent_bom/cli/run.py tests/test_cli_runtime.py tests/test_cli_run.py tests/test_proxy_sandbox.py
- uv run mkdocs build --strict
- git diff --check
- pre-commit hooks during commit