### PR TITLE
fix: make proxy configure sandbox mode explicit

### DIFF
--- a/docs/MCP_CLIENT_GUIDES.md
+++ b/docs/MCP_CLIENT_GUIDES.md
@@ -93,7 +93,11 @@ args = ["proxy", "--log", "~/.agent-bom/logs/filesystem.jsonl", "--", "npx", "@m
 ## Runtime proxy notes
 
 - `agent-bom proxy` is best when the client talks to a third-party stdio server and you want runtime inspection.
-- `agent-bom proxy-configure --apply` targets JSON MCP configs and can now stamp control-plane policy/audit settings into the wrapped proxy command.
+- `agent-bom proxy-configure --apply` targets JSON MCP configs and can now
+  stamp control-plane policy/audit settings into the wrapped proxy command.
+  Generated configs include `--no-isolate` unless `--sandbox-image` is supplied,
+  so process containment is never implied without an operator-provided
+  Docker/Podman runtime image.
 - `agent-bom proxy-bootstrap --bundle-dir ./endpoint-bundle --control-plane-url https://agent-bom.example.com --push-url https://agent-bom.example.com/v1/fleet/sync` writes managed rollout artifacts for macOS/Linux and Windows without hand-editing JSON on every machine.
 - the bundle now also includes Jamf, Intune, and Kandji wrappers plus repo-shipped `.pkg` / `.msi` build scripts for IT-owned rollout
 - stdio transports have no native HTTP header channel. When a client or upstream includes W3C trace context in JSON-RPC `_meta.traceparent`, `_meta.tracestate`, or `_meta.baggage`, the proxy preserves those fields and rehydrates them onto the paired response when the upstream does not echo them back.

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -170,7 +170,10 @@ For Claude Desktop, Claude Code, and Cortex JSON configs, you can auto-wrap elig
 agent-bom proxy-configure --log-dir ~/.agent-bom/logs --detect-credentials
 ```
 
-Add `--apply` to persist the wrapped config entries.
+Add `--apply` to persist the wrapped config entries. Generated configs include
+`--no-isolate` unless you pass `--sandbox-image`; that keeps audit/policy mode
+explicit and avoids implying process containment without an operator-provided
+Docker/Podman runtime image.
 
 If you need cross-agent correlation and the broader 8-detector runtime engine, use `agent-bom runtime protect --shield` alongside or upstream of the proxy pipeline.
 

--- a/src/agent_bom/cli/_runtime.py
+++ b/src/agent_bom/cli/_runtime.py
@@ -341,6 +341,25 @@ def proxy_cmd(
 @click.option("--detect-credentials", is_flag=True, help="Enable credential leak detection in each proxy")
 @click.option("--block-undeclared", is_flag=True, help="Block undeclared tools in each proxy")
 @click.option(
+    "--sandbox-image",
+    default=None,
+    envvar="AGENT_BOM_MCP_SANDBOX_IMAGE",
+    help="Container image for generated stdio proxy configs. Omit to generate --no-isolate audit/policy configs.",
+)
+@click.option(
+    "--sandbox-image-pin-policy",
+    default=None,
+    envvar="AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY",
+    type=click.Choice(["off", "warn", "enforce"]),
+    help="Image pin policy for generated sandboxed proxy configs.",
+)
+@click.option(
+    "--sandbox-mount",
+    multiple=True,
+    metavar="HOST:CONTAINER[:ro|rw]",
+    help="Bind mount to include in generated sandboxed proxy configs.",
+)
+@click.option(
     "--control-plane-url",
     default=None,
     envvar="AGENT_BOM_API_URL",
@@ -378,6 +397,9 @@ def proxy_configure_cmd(
     secure_defaults,
     detect_credentials,
     block_undeclared,
+    sandbox_image,
+    sandbox_image_pin_policy,
+    sandbox_mount,
     control_plane_url,
     control_plane_token,
     policy_refresh_seconds,
@@ -403,11 +425,14 @@ def proxy_configure_cmd(
     - secure defaults already inject --detect-credentials and --block-undeclared
     - --log-dir for auditable JSONL logs
     - --policy for explicit allowlist/blocklist/read-only enforcement
+    - --sandbox-image for Docker/Podman process containment; without it the
+      generated config includes --no-isolate so audit/policy mode stays explicit
 
     \b
     Example:
       agent-bom proxy-configure --log-dir ~/.agent-bom/logs
       agent-bom proxy-configure --policy policy.json --log-dir ~/.agent-bom/logs --apply
+      agent-bom proxy-configure --sandbox-image ghcr.io/acme/mcp-runtime@sha256:<digest> --sandbox-image-pin-policy enforce --apply
       agent-bom proxy-configure --control-plane-url https://agent-bom.example.com --control-plane-token "$TOKEN" --apply
       agent-bom proxy-configure --no-secure-defaults --apply
     """
@@ -424,6 +449,9 @@ def proxy_configure_cmd(
         secure_defaults=secure_defaults,
         detect_credentials=detect_credentials,
         block_undeclared=block_undeclared,
+        sandbox_image=sandbox_image,
+        sandbox_image_pin_policy=sandbox_image_pin_policy,
+        sandbox_mounts=tuple(sandbox_mount),
         control_plane_url=control_plane_url,
         control_plane_token=control_plane_token,
         policy_refresh_seconds=policy_refresh_seconds,

--- a/src/agent_bom/proxy_configure.py
+++ b/src/agent_bom/proxy_configure.py
@@ -12,10 +12,10 @@ The proxied entry replaces:
 with:
 
     "command": "agent-bom",
-    "args": ["proxy", "--", "npx", "@modelcontextprotocol/server-fs", "/tmp"]
+    "args": ["proxy", "--no-isolate", "--", "npx", "@modelcontextprotocol/server-fs", "/tmp"]
 
 Optionally enriches the proxy args with --log, --policy, --detect-credentials,
-and --block-undeclared flags.
+--block-undeclared, and sandbox flags.
 """
 
 from __future__ import annotations
@@ -79,6 +79,9 @@ def auto_configure_proxies(
     control_plane_token: Optional[str] = None,
     policy_refresh_seconds: Optional[int] = None,
     audit_push_interval: Optional[int] = None,
+    sandbox_image: Optional[str] = None,
+    sandbox_image_pin_policy: Optional[str] = None,
+    sandbox_mounts: tuple[str, ...] = (),
 ) -> list[ProxyConfig]:
     """Generate proxy-wrapped configs for all eligible STDIO MCP servers.
 
@@ -96,6 +99,11 @@ def auto_configure_proxies(
             even if they are not explicitly requested by the caller.
         detect_credentials: Pass ``--detect-credentials`` to each proxy.
         block_undeclared: Pass ``--block-undeclared`` to each proxy.
+        sandbox_image: Optional Docker/Podman image for containing plain stdio
+            MCP commands. When omitted, generated configs pass ``--no-isolate``
+            so audit/policy-only configs remain runnable.
+        sandbox_image_pin_policy: Optional sandbox image pin policy.
+        sandbox_mounts: Optional sandbox bind mounts.
 
     Returns:
         List of ProxyConfig objects, one per eligible server.
@@ -133,6 +141,15 @@ def auto_configure_proxies(
 
             if secure_defaults or block_undeclared:
                 proxy_flags.append("--block-undeclared")
+
+            if sandbox_image:
+                proxy_flags += ["--sandbox-image", sandbox_image]
+                if sandbox_image_pin_policy:
+                    proxy_flags += ["--sandbox-image-pin-policy", sandbox_image_pin_policy]
+                for mount in sandbox_mounts:
+                    proxy_flags += ["--sandbox-mount", mount]
+            else:
+                proxy_flags.append("--no-isolate")
 
             proxied_args = [*proxy_flags, "--", server.command, *server.args]
 

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -300,6 +300,29 @@ def test_proxy_configure_passes_control_plane_settings():
     assert mock_auto_configure.call_args.kwargs["audit_push_interval"] == 15
 
 
+def test_proxy_configure_passes_sandbox_settings():
+    runner = CliRunner()
+    with (
+        patch("agent_bom.discovery.discover_all", return_value=[]),
+        patch("agent_bom.proxy_configure.auto_configure_proxies", return_value=[]) as mock_auto_configure,
+    ):
+        result = runner.invoke(
+            proxy_configure_cmd,
+            [
+                "--sandbox-image",
+                "ghcr.io/acme/mcp-runtime@sha256:" + "a" * 64,
+                "--sandbox-image-pin-policy",
+                "enforce",
+                "--sandbox-mount",
+                "/workspace:/workspace:ro",
+            ],
+        )
+        assert result.exit_code == 0
+    assert mock_auto_configure.call_args.kwargs["sandbox_image"].startswith("ghcr.io/acme/mcp-runtime@sha256:")
+    assert mock_auto_configure.call_args.kwargs["sandbox_image_pin_policy"] == "enforce"
+    assert mock_auto_configure.call_args.kwargs["sandbox_mounts"] == ("/workspace:/workspace:ro",)
+
+
 def test_proxy_bootstrap_writes_bundle(tmp_path):
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/test_proxy_configure.py
+++ b/tests/test_proxy_configure.py
@@ -8,6 +8,8 @@ Tests cover:
 - log_dir injects --log flag with slugified filename
 - detect_credentials injects --detect-credentials flag
 - block_undeclared injects --block-undeclared flag
+- no sandbox image injects --no-isolate so generated configs stay runnable
+- sandbox image injects sandbox flags for contained stdio proxy configs
 - ProxyConfig.as_json_entry() structure
 - apply_proxy_configs() dry_run=True returns 0, no file changes
 - apply_proxy_configs() patches mcpServers in JSON config file
@@ -68,6 +70,7 @@ def test_generates_config_for_stdio_server():
     assert "@modelcontextprotocol/server-fs" in cfg.proxied_args
     assert "--detect-credentials" in cfg.proxied_args
     assert "--block-undeclared" in cfg.proxied_args
+    assert "--no-isolate" in cfg.proxied_args
 
 
 def test_skips_sse_server():
@@ -127,6 +130,7 @@ def test_all_flags_together():
     assert "--log" in args
     assert "--detect-credentials" in args
     assert "--block-undeclared" in args
+    assert "--no-isolate" in args
 
 
 def test_control_plane_flags_injected():
@@ -158,8 +162,8 @@ def test_no_flags_minimal_proxied_args():
     agents = [_agent([server])]
     configs = auto_configure_proxies(agents, secure_defaults=False)
     cfg = configs[0]
-    # Should be: ["--", "uvx", "mcp-server-git"]
-    assert cfg.proxied_args == ["--", "uvx", "mcp-server-git"]
+    # Should be explicit audit/policy-only mode when no sandbox image is provided.
+    assert cfg.proxied_args == ["--no-isolate", "--", "uvx", "mcp-server-git"]
 
 
 def test_secure_defaults_can_be_disabled():
@@ -168,6 +172,26 @@ def test_secure_defaults_can_be_disabled():
     args = configs[0].proxied_args
     assert "--detect-credentials" not in args
     assert "--block-undeclared" not in args
+    assert "--no-isolate" in args
+
+
+def test_sandbox_flags_injected_when_image_provided():
+    agents = [_agent([_stdio()])]
+    configs = auto_configure_proxies(
+        agents,
+        sandbox_image="ghcr.io/acme/mcp-runtime@sha256:" + "a" * 64,
+        sandbox_image_pin_policy="enforce",
+        sandbox_mounts=("/workspace:/workspace:ro",),
+    )
+    args = configs[0].proxied_args
+
+    assert "--no-isolate" not in args
+    assert "--sandbox-image" in args
+    assert args[args.index("--sandbox-image") + 1].startswith("ghcr.io/acme/mcp-runtime@sha256:")
+    assert "--sandbox-image-pin-policy" in args
+    assert args[args.index("--sandbox-image-pin-policy") + 1] == "enforce"
+    assert "--sandbox-mount" in args
+    assert args[args.index("--sandbox-mount") + 1] == "/workspace:/workspace:ro"
 
 
 def test_original_command_and_args_preserved():


### PR DESCRIPTION
Summary
- make proxy-configure generated stdio configs explicit about sandbox mode
- default generated configs to --no-isolate so audit/policy-only wrappers stay runnable
- add sandbox image, image pin policy, and sandbox mount options for generated contained configs
- document that generated configs only imply process containment when an operator supplies a Docker/Podman runtime image

Validation
- uv run pytest -q tests/test_proxy_configure.py tests/test_cli_runtime.py
- uv run ruff check src/agent_bom/proxy_configure.py src/agent_bom/cli/_runtime.py tests/test_proxy_configure.py tests/test_cli_runtime.py
- uv run mkdocs build --strict
- git diff --check
- pre-commit hooks during commit