### PR TITLE
fix: make runtime evidence docker-optional

### DIFF
--- a/scripts/generate_runtime_evidence_pack.py
+++ b/scripts/generate_runtime_evidence_pack.py
@@ -159,6 +159,7 @@ def _proxy_sandbox_evidence() -> dict[str, Any]:
     command, sandbox_evidence = build_sandboxed_command(
         ["python", "-c", "print('ok')"],
         SandboxConfig(enabled=True, runtime="docker", image=pinned_image, image_pin_policy="enforce"),
+        resolve_runtime=False,
     )
 
     with tempfile.TemporaryDirectory() as tmp:

--- a/src/agent_bom/proxy_sandbox.py
+++ b/src/agent_bom/proxy_sandbox.py
@@ -248,11 +248,18 @@ def resolve_container_runtime(runtime: SandboxRuntime) -> str:
     raise RuntimeError("MCP sandbox isolation requires Docker or Podman on PATH")
 
 
-def build_sandboxed_command(server_cmd: list[str], config: SandboxConfig) -> tuple[list[str], dict[str, object]]:
+def build_sandboxed_command(
+    server_cmd: list[str],
+    config: SandboxConfig,
+    *,
+    resolve_runtime: bool = True,
+) -> tuple[list[str], dict[str, object]]:
     """Return the command used to run the MCP server under container isolation."""
     if not config.enabled:
         return server_cmd, config.evidence()
-    runtime = resolve_container_runtime(config.runtime)
+    runtime = resolve_container_runtime(config.runtime) if resolve_runtime else config.runtime
+    if runtime == "auto":
+        runtime = "docker"
     docker_args = _sandbox_docker_args(config)
 
     if _is_container_run(server_cmd):


### PR DESCRIPTION
Summary
- keep runtime evidence generation runnable when Docker is not installed
- add an offline planning mode for sandbox command construction while preserving runtime resolution by default
- fixes the Alpine/musl failure seen after #2389 and #2390 merged

Validation
- uv run pytest -q tests/test_runtime_evidence_pack.py tests/test_proxy_sandbox.py
- uv run ruff check src/agent_bom/proxy_sandbox.py scripts/generate_runtime_evidence_pack.py tests/test_runtime_evidence_pack.py tests/test_proxy_sandbox.py
- git diff --check