### PR TITLE
ci: dedupe PR dependency audit gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,22 +137,6 @@ jobs:
       - name: Bandit (Static Security Analysis)
         run: uv run bandit -r src/ --severity-level medium
 
-      - name: pip-audit (Dependency Vulnerabilities)
-        run: |
-          # Run pip-audit; if it fails, check if all vulns have no fix available.
-          # This avoids hardcoded ignores — if a fix ships, the "FIXED VERSION"
-          # column will show a version instead of "--" and this check will fail.
-          uv run --with pip-audit pip-audit --ignore-vuln CVE-2026-3219 2>&1 | tee /tmp/pip-audit.txt || {
-            # If every vuln row shows "-- " as fixed version, no fix is available upstream
-            FIXABLE=$(grep -E "^\| https://" /tmp/pip-audit.txt | grep -v "| -- " | head -5)
-            if [ -n "$FIXABLE" ]; then
-              echo "::error::pip-audit found vulnerabilities with available fixes:"
-              echo "$FIXABLE"
-              exit 1
-            fi
-            echo "::warning::pip-audit found only unfixable CVEs (no upstream fix) — passing"
-          }
-
       - name: OSV Scanner (all lockfiles)
         run: |
           OSV_SCANNER_VERSION="v2.3.3"


### PR DESCRIPTION
Summary
- remove the duplicate text-mode pip-audit step from CI/CD Pipeline / Security Scan
- keep PR Security Gate / pip-audit on PR as the authoritative JSON dependency audit gate
- leave OSV, Trivy, npm audits, Bandit, and JS supply-chain guard in Security Scan

Validation
- uv run python scripts/check_workflow_timeouts.py
- YAML parse assertion: Security Scan no longer has pip-audit; OSV and Trivy still present
- git diff --check