### PR TITLE
docs: make compliance graphic readable

### DIFF
--- a/docs/images/compliance-dark.svg
+++ b/docs/images/compliance-dark.svg
@@ -9,7 +9,7 @@
     .card { fill: #18181b; stroke: #3f3f46; stroke-width: 1.2; }
     .name { font-size: 15px; font-weight: 750; fill: #f4f4f5; }
     .scope { font-size: 11px; font-weight: 600; fill: #a1a1aa; }
-    .count { font-size: 28px; font-weight: 800; }
+    .count { font-size: 22px; font-weight: 800; }
     .unit { font-size: 11px; font-weight: 700; fill: #a1a1aa; }
     .bar-bg { fill: #27272a; }
     .summary { fill: #18181b; stroke: #3f3f46; stroke-width: 1.2; }
@@ -27,100 +27,100 @@
   <rect x="48" y="124" width="320" height="88" rx="10" class="card"/>
   <text x="72" y="154" class="name">OWASP LLM Top 10</text>
   <text x="72" y="175" class="scope">Prompt injection, data poisoning, supply chain</text>
-  <rect x="72" y="188" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="72" y="188" width="272" height="6" rx="3" fill="#3b82f6"/>
-  <text x="72" y="204" class="count" fill="#3b82f6">10</text>
-  <text x="120" y="203" class="unit">controls</text>
+  <rect x="72" y="204" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="72" y="204" width="272" height="6" rx="3" fill="#3b82f6"/>
+  <text x="72" y="202" class="count" fill="#3b82f6">10</text>
+  <text x="116" y="201" class="unit">controls</text>
 
   <rect x="400" y="124" width="320" height="88" rx="10" class="card"/>
   <text x="424" y="154" class="name">OWASP MCP Top 10</text>
   <text x="424" y="175" class="scope">Tool poisoning, auth bypass, rug pull risk</text>
-  <rect x="424" y="188" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="424" y="188" width="272" height="6" rx="3" fill="#3b82f6"/>
-  <text x="424" y="204" class="count" fill="#3b82f6">10</text>
-  <text x="472" y="203" class="unit">controls</text>
+  <rect x="424" y="204" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="424" y="204" width="272" height="6" rx="3" fill="#3b82f6"/>
+  <text x="424" y="202" class="count" fill="#3b82f6">10</text>
+  <text x="468" y="201" class="unit">controls</text>
 
   <rect x="752" y="124" width="320" height="88" rx="10" class="card"/>
   <text x="776" y="154" class="name">OWASP Agentic Top 10</text>
   <text x="776" y="175" class="scope">Excessive agency, unsafe output, autonomy risk</text>
-  <rect x="776" y="188" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="776" y="188" width="272" height="6" rx="3" fill="#3b82f6"/>
-  <text x="776" y="204" class="count" fill="#3b82f6">10</text>
-  <text x="824" y="203" class="unit">controls</text>
+  <rect x="776" y="204" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="776" y="204" width="272" height="6" rx="3" fill="#3b82f6"/>
+  <text x="776" y="202" class="count" fill="#3b82f6">10</text>
+  <text x="820" y="201" class="unit">controls</text>
 
   <rect x="48" y="236" width="320" height="88" rx="10" class="card"/>
   <text x="72" y="266" class="name">MITRE ATLAS</text>
   <text x="72" y="287" class="scope">Adversarial machine learning tactics</text>
-  <rect x="72" y="300" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="72" y="300" width="208" height="6" rx="3" fill="#f59e0b"/>
-  <text x="72" y="316" class="count" fill="#f59e0b">14</text>
-  <text x="120" y="315" class="unit">techniques</text>
+  <rect x="72" y="316" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="72" y="316" width="208" height="6" rx="3" fill="#f59e0b"/>
+  <text x="72" y="314" class="count" fill="#f59e0b">14</text>
+  <text x="116" y="313" class="unit">techniques</text>
 
   <rect x="400" y="236" width="320" height="88" rx="10" class="card"/>
   <text x="424" y="266" class="name">NIST AI RMF</text>
   <text x="424" y="287" class="scope">Govern, map, measure, and manage</text>
-  <rect x="424" y="300" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="424" y="300" width="214" height="6" rx="3" fill="#10b981"/>
-  <text x="424" y="316" class="count" fill="#10b981">19</text>
-  <text x="472" y="315" class="unit">subcategories</text>
+  <rect x="424" y="316" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="424" y="316" width="214" height="6" rx="3" fill="#10b981"/>
+  <text x="424" y="314" class="count" fill="#10b981">19</text>
+  <text x="468" y="313" class="unit">subcategories</text>
 
   <rect x="752" y="236" width="320" height="88" rx="10" class="card"/>
   <text x="776" y="266" class="name">EU AI Act</text>
   <text x="776" y="287" class="scope">Risk management and human oversight</text>
-  <rect x="776" y="300" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="776" y="300" width="164" height="6" rx="3" fill="#a78bfa"/>
-  <text x="776" y="316" class="count" fill="#a78bfa">12</text>
-  <text x="824" y="315" class="unit">articles</text>
+  <rect x="776" y="316" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="776" y="316" width="164" height="6" rx="3" fill="#a78bfa"/>
+  <text x="776" y="314" class="count" fill="#a78bfa">12</text>
+  <text x="820" y="313" class="unit">articles</text>
 
   <text x="48" y="366" class="section">ENTERPRISE CONTROL FRAMEWORKS</text>
 
   <rect x="48" y="386" width="320" height="88" rx="10" class="card"/>
   <text x="72" y="416" class="name">NIST CSF 2.0</text>
   <text x="72" y="437" class="scope">Identify, protect, detect, respond, recover</text>
-  <rect x="72" y="450" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="72" y="450" width="215" height="6" rx="3" fill="#10b981"/>
-  <text x="72" y="466" class="count" fill="#10b981">23</text>
-  <text x="120" y="465" class="unit">subcategories</text>
+  <rect x="72" y="466" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="72" y="466" width="215" height="6" rx="3" fill="#10b981"/>
+  <text x="72" y="464" class="count" fill="#10b981">23</text>
+  <text x="116" y="463" class="unit">subcategories</text>
 
   <rect x="400" y="386" width="320" height="88" rx="10" class="card"/>
   <text x="424" y="416" class="name">NIST 800-53 Rev. 5</text>
   <text x="424" y="437" class="scope">Federal information system controls</text>
-  <rect x="424" y="450" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="424" y="450" width="218" height="6" rx="3" fill="#10b981"/>
-  <text x="424" y="466" class="count" fill="#10b981">29</text>
-  <text x="472" y="465" class="unit">controls</text>
+  <rect x="424" y="466" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="424" y="466" width="218" height="6" rx="3" fill="#10b981"/>
+  <text x="424" y="464" class="count" fill="#10b981">29</text>
+  <text x="468" y="463" class="unit">controls</text>
 
   <rect x="752" y="386" width="320" height="88" rx="10" class="card"/>
   <text x="776" y="416" class="name">FedRAMP</text>
   <text x="776" y="437" class="scope">Low, Moderate, and High baselines</text>
-  <rect x="776" y="450" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="776" y="450" width="126" height="6" rx="3" fill="#0ea5e9"/>
-  <text x="776" y="466" class="count" fill="#0ea5e9">3</text>
-  <text x="808" y="465" class="unit">baselines</text>
+  <rect x="776" y="466" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="776" y="466" width="126" height="6" rx="3" fill="#0ea5e9"/>
+  <text x="776" y="464" class="count" fill="#0ea5e9">3</text>
+  <text x="804" y="463" class="unit">baselines</text>
 
   <rect x="48" y="498" width="320" height="88" rx="10" class="card"/>
   <text x="72" y="528" class="name">ISO 27001 / SOC 2</text>
   <text x="72" y="549" class="scope">Security controls and trust criteria</text>
-  <rect x="72" y="562" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="72" y="562" width="166" height="6" rx="3" fill="#f43f5e"/>
-  <text x="72" y="578" class="count" fill="#f43f5e">18</text>
-  <text x="120" y="577" class="unit">mapped controls</text>
+  <rect x="72" y="578" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="72" y="578" width="166" height="6" rx="3" fill="#f43f5e"/>
+  <text x="72" y="576" class="count" fill="#f43f5e">18</text>
+  <text x="116" y="575" class="unit">mapped controls</text>
 
   <rect x="400" y="498" width="320" height="88" rx="10" class="card"/>
   <text x="424" y="528" class="name">CIS Controls v8 / CMMC 2.0</text>
   <text x="424" y="549" class="scope">Hardening checks and contractor practices</text>
-  <rect x="424" y="562" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="424" y="562" width="256" height="6" rx="3" fill="#34d399"/>
-  <text x="424" y="578" class="count" fill="#34d399">217+</text>
-  <text x="492" y="577" class="unit">checks + practices</text>
+  <rect x="424" y="578" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="424" y="578" width="256" height="6" rx="3" fill="#34d399"/>
+  <text x="424" y="576" class="count" fill="#34d399">217+</text>
+  <text x="484" y="575" class="unit">checks + practices</text>
 
   <rect x="752" y="498" width="320" height="88" rx="10" class="card"/>
   <text x="776" y="528" class="name">MITRE ATT&amp;CK / PCI DSS</text>
   <text x="776" y="549" class="scope">Technique mapping and payment-card controls</text>
-  <rect x="776" y="562" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="776" y="562" width="238" height="6" rx="3" fill="#fb7185"/>
-  <text x="776" y="578" class="count" fill="#fb7185">600+</text>
-  <text x="858" y="577" class="unit">techniques + requirements</text>
+  <rect x="776" y="578" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="776" y="578" width="238" height="6" rx="3" fill="#fb7185"/>
+  <text x="776" y="576" class="count" fill="#fb7185">600+</text>
+  <text x="846" y="575" class="unit">techniques + requirements</text>
 
   <rect x="48" y="620" width="1024" height="46" rx="10" class="summary"/>
   <text x="96" y="651" class="summary-num" fill="#3b82f6">15</text>

--- a/docs/images/compliance-dark.svg
+++ b/docs/images/compliance-dark.svg
@@ -1,181 +1,138 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 364" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 690" fill="none" role="img" aria-labelledby="title desc">
+  <title id="title">agent-bom compliance coverage</title>
+  <desc id="desc">Readable compliance mapping summary across fifteen AI and security frameworks.</desc>
   <style>
     text { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; }
-    .title { font-size: 16px; font-weight: 700; fill: #f4f4f5; }
-    .subtitle { font-size: 10.5px; font-weight: 400; fill: #52525b; }
-    .fw-name { font-size: 10px; font-weight: 700; fill: #e4e4e7; }
-    .fw-code { font-size: 8px; font-weight: 600; fill: #71717a; }
-    .fw-count { font-size: 18px; font-weight: 800; }
-    .fw-label { font-size: 8px; font-weight: 500; fill: #71717a; }
+    .title { font-size: 24px; font-weight: 750; fill: #f8fafc; }
+    .subtitle { font-size: 14px; font-weight: 500; fill: #a1a1aa; }
+    .section { font-size: 11px; font-weight: 700; letter-spacing: .08em; fill: #71717a; }
+    .card { fill: #18181b; stroke: #3f3f46; stroke-width: 1.2; }
+    .name { font-size: 15px; font-weight: 750; fill: #f4f4f5; }
+    .scope { font-size: 11px; font-weight: 600; fill: #a1a1aa; }
+    .count { font-size: 28px; font-weight: 800; }
+    .unit { font-size: 11px; font-weight: 700; fill: #a1a1aa; }
     .bar-bg { fill: #27272a; }
-    .summary-num { font-size: 22px; font-weight: 800; }
-    .summary-label { font-size: 9px; font-weight: 500; fill: #71717a; }
+    .summary { fill: #18181b; stroke: #3f3f46; stroke-width: 1.2; }
+    .summary-num { font-size: 28px; font-weight: 850; }
+    .summary-label { font-size: 12px; font-weight: 700; fill: #a1a1aa; }
+    .note { font-size: 11px; font-weight: 600; fill: #71717a; }
   </style>
 
-  <rect width="960" height="364" rx="12" fill="#09090b"/>
+  <rect width="1120" height="690" rx="18" fill="#09090b"/>
 
-  <text x="480" y="28" text-anchor="middle" class="title">Compliance coverage</text>
-  <text x="480" y="44" text-anchor="middle" class="subtitle">15 frameworks, 300+ controls mapped automatically from scan findings</text>
+  <text x="560" y="44" text-anchor="middle" class="title">Compliance coverage</text>
+  <text x="560" y="68" text-anchor="middle" class="subtitle">Curated AI, MCP, cloud, and enterprise control mappings from scan findings</text>
+  <text x="48" y="104" class="section">AI AND AGENT SECURITY</text>
 
-  <!-- ═══ ROW 1: 5 frameworks ═══ -->
+  <rect x="48" y="124" width="320" height="88" rx="10" class="card"/>
+  <text x="72" y="154" class="name">OWASP LLM Top 10</text>
+  <text x="72" y="175" class="scope">Prompt injection, data poisoning, supply chain</text>
+  <rect x="72" y="188" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="72" y="188" width="272" height="6" rx="3" fill="#3b82f6"/>
+  <text x="72" y="204" class="count" fill="#3b82f6">10</text>
+  <text x="120" y="203" class="unit">controls</text>
 
-  <!-- OWASP LLM Top 10 -->
-  <rect x="20" y="64" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="36" y="84" class="fw-name">OWASP LLM Top 10</text>
-  <text x="36" y="96" class="fw-code">Prompt injection, data poisoning, supply chain</text>
-  <rect x="36" y="104" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="36" y="104" width="144" height="4" rx="2" fill="#3b82f6"/>
-  <text x="36" y="126" class="fw-count" fill="#3b82f6">10</text>
-  <text x="64" y="126" class="fw-label">controls</text>
+  <rect x="400" y="124" width="320" height="88" rx="10" class="card"/>
+  <text x="424" y="154" class="name">OWASP MCP Top 10</text>
+  <text x="424" y="175" class="scope">Tool poisoning, auth bypass, rug pull risk</text>
+  <rect x="424" y="188" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="424" y="188" width="272" height="6" rx="3" fill="#3b82f6"/>
+  <text x="424" y="204" class="count" fill="#3b82f6">10</text>
+  <text x="472" y="203" class="unit">controls</text>
 
-  <!-- OWASP MCP Top 10 -->
-  <rect x="208" y="64" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="224" y="84" class="fw-name">OWASP MCP Top 10</text>
-  <text x="224" y="96" class="fw-code">Tool poisoning, auth bypass, rug pull</text>
-  <rect x="224" y="104" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="224" y="104" width="144" height="4" rx="2" fill="#3b82f6"/>
-  <text x="224" y="126" class="fw-count" fill="#3b82f6">10</text>
-  <text x="252" y="126" class="fw-label">controls</text>
+  <rect x="752" y="124" width="320" height="88" rx="10" class="card"/>
+  <text x="776" y="154" class="name">OWASP Agentic Top 10</text>
+  <text x="776" y="175" class="scope">Excessive agency, unsafe output, autonomy risk</text>
+  <rect x="776" y="188" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="776" y="188" width="272" height="6" rx="3" fill="#3b82f6"/>
+  <text x="776" y="204" class="count" fill="#3b82f6">10</text>
+  <text x="824" y="203" class="unit">controls</text>
 
-  <!-- OWASP Agentic Top 10 -->
-  <rect x="396" y="64" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="412" y="84" class="fw-name">OWASP Agentic Top 10</text>
-  <text x="412" y="96" class="fw-code">Excessive agency, insecure output</text>
-  <rect x="412" y="104" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="412" y="104" width="144" height="4" rx="2" fill="#3b82f6"/>
-  <text x="412" y="126" class="fw-count" fill="#3b82f6">10</text>
-  <text x="440" y="126" class="fw-label">controls</text>
+  <rect x="48" y="236" width="320" height="88" rx="10" class="card"/>
+  <text x="72" y="266" class="name">MITRE ATLAS</text>
+  <text x="72" y="287" class="scope">Adversarial machine learning tactics</text>
+  <rect x="72" y="300" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="72" y="300" width="208" height="6" rx="3" fill="#f59e0b"/>
+  <text x="72" y="316" class="count" fill="#f59e0b">14</text>
+  <text x="120" y="315" class="unit">techniques</text>
 
-  <!-- MITRE ATLAS -->
-  <rect x="584" y="64" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="600" y="84" class="fw-name">MITRE ATLAS</text>
-  <text x="600" y="96" class="fw-code">Adversarial ML tactics + techniques</text>
-  <rect x="600" y="104" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="600" y="104" width="108" height="4" rx="2" fill="#f59e0b"/>
-  <text x="600" y="126" class="fw-count" fill="#f59e0b">14</text>
-  <text x="628" y="126" class="fw-label">techniques</text>
+  <rect x="400" y="236" width="320" height="88" rx="10" class="card"/>
+  <text x="424" y="266" class="name">NIST AI RMF</text>
+  <text x="424" y="287" class="scope">Govern, map, measure, and manage</text>
+  <rect x="424" y="300" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="424" y="300" width="214" height="6" rx="3" fill="#10b981"/>
+  <text x="424" y="316" class="count" fill="#10b981">19</text>
+  <text x="472" y="315" class="unit">subcategories</text>
 
-  <!-- NIST AI RMF -->
-  <rect x="772" y="64" width="168" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="788" y="84" class="fw-name">NIST AI RMF</text>
-  <text x="788" y="96" class="fw-code">Govern, map, measure, manage</text>
-  <rect x="788" y="104" width="136" height="4" rx="2" class="bar-bg"/>
-  <rect x="788" y="104" width="102" height="4" rx="2" fill="#10b981"/>
-  <text x="788" y="126" class="fw-count" fill="#10b981">19</text>
-  <text x="816" y="126" class="fw-label">subcategories</text>
+  <rect x="752" y="236" width="320" height="88" rx="10" class="card"/>
+  <text x="776" y="266" class="name">EU AI Act</text>
+  <text x="776" y="287" class="scope">Risk management and human oversight</text>
+  <rect x="776" y="300" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="776" y="300" width="164" height="6" rx="3" fill="#a78bfa"/>
+  <text x="776" y="316" class="count" fill="#a78bfa">12</text>
+  <text x="824" y="315" class="unit">articles</text>
 
-  <!-- ═══ ROW 2: 5 frameworks ═══ -->
+  <text x="48" y="366" class="section">ENTERPRISE CONTROL FRAMEWORKS</text>
 
-  <!-- NIST CSF -->
-  <rect x="20" y="148" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="36" y="168" class="fw-name">NIST CSF 2.0</text>
-  <text x="36" y="180" class="fw-code">Identify, protect, detect, respond</text>
-  <rect x="36" y="188" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="36" y="188" width="108" height="4" rx="2" fill="#10b981"/>
-  <text x="36" y="210" class="fw-count" fill="#10b981">23</text>
-  <text x="64" y="210" class="fw-label">subcategories</text>
+  <rect x="48" y="386" width="320" height="88" rx="10" class="card"/>
+  <text x="72" y="416" class="name">NIST CSF 2.0</text>
+  <text x="72" y="437" class="scope">Identify, protect, detect, respond, recover</text>
+  <rect x="72" y="450" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="72" y="450" width="215" height="6" rx="3" fill="#10b981"/>
+  <text x="72" y="466" class="count" fill="#10b981">23</text>
+  <text x="120" y="465" class="unit">subcategories</text>
 
-  <!-- EU AI Act -->
-  <rect x="208" y="148" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="224" y="168" class="fw-name">EU AI Act</text>
-  <text x="224" y="180" class="fw-code">Risk management, transparency, oversight</text>
-  <rect x="224" y="188" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="224" y="188" width="86" height="4" rx="2" fill="#a78bfa"/>
-  <text x="224" y="210" class="fw-count" fill="#a78bfa">12</text>
-  <text x="252" y="210" class="fw-label">articles</text>
+  <rect x="400" y="386" width="320" height="88" rx="10" class="card"/>
+  <text x="424" y="416" class="name">NIST 800-53 Rev. 5</text>
+  <text x="424" y="437" class="scope">Federal information system controls</text>
+  <rect x="424" y="450" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="424" y="450" width="218" height="6" rx="3" fill="#10b981"/>
+  <text x="424" y="466" class="count" fill="#10b981">29</text>
+  <text x="472" y="465" class="unit">controls</text>
 
-  <!-- SOC 2 -->
-  <rect x="396" y="148" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="412" y="168" class="fw-name">SOC 2</text>
-  <text x="412" y="180" class="fw-code">Trust service criteria</text>
-  <rect x="412" y="188" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="412" y="188" width="72" height="4" rx="2" fill="#f43f5e"/>
-  <text x="412" y="210" class="fw-count" fill="#f43f5e">8</text>
-  <text x="432" y="210" class="fw-label">criteria</text>
+  <rect x="752" y="386" width="320" height="88" rx="10" class="card"/>
+  <text x="776" y="416" class="name">FedRAMP</text>
+  <text x="776" y="437" class="scope">Low, Moderate, and High baselines</text>
+  <rect x="776" y="450" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="776" y="450" width="126" height="6" rx="3" fill="#0ea5e9"/>
+  <text x="776" y="466" class="count" fill="#0ea5e9">3</text>
+  <text x="808" y="465" class="unit">baselines</text>
 
-  <!-- ISO 27001 -->
-  <rect x="584" y="148" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="600" y="168" class="fw-name">ISO 27001</text>
-  <text x="600" y="180" class="fw-code">Information security controls</text>
-  <rect x="600" y="188" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="600" y="188" width="86" height="4" rx="2" fill="#f43f5e"/>
-  <text x="600" y="210" class="fw-count" fill="#f43f5e">10</text>
-  <text x="628" y="210" class="fw-label">controls</text>
+  <rect x="48" y="498" width="320" height="88" rx="10" class="card"/>
+  <text x="72" y="528" class="name">ISO 27001 / SOC 2</text>
+  <text x="72" y="549" class="scope">Security controls and trust criteria</text>
+  <rect x="72" y="562" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="72" y="562" width="166" height="6" rx="3" fill="#f43f5e"/>
+  <text x="72" y="578" class="count" fill="#f43f5e">18</text>
+  <text x="120" y="577" class="unit">mapped controls</text>
 
-  <!-- CIS Controls v8 -->
-  <rect x="772" y="148" width="168" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="788" y="168" class="fw-name">CIS Controls v8</text>
-  <text x="788" y="180" class="fw-code">18 critical security controls</text>
-  <rect x="788" y="188" width="136" height="4" rx="2" class="bar-bg"/>
-  <rect x="788" y="188" width="136" height="4" rx="2" fill="#34d399"/>
-  <text x="788" y="210" class="fw-count" fill="#34d399">200+</text>
-  <text x="828" y="210" class="fw-label">checks</text>
+  <rect x="400" y="498" width="320" height="88" rx="10" class="card"/>
+  <text x="424" y="528" class="name">CIS Controls v8 / CMMC 2.0</text>
+  <text x="424" y="549" class="scope">Hardening checks and contractor practices</text>
+  <rect x="424" y="562" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="424" y="562" width="256" height="6" rx="3" fill="#34d399"/>
+  <text x="424" y="578" class="count" fill="#34d399">217+</text>
+  <text x="492" y="577" class="unit">checks + practices</text>
 
-  <!-- ═══ ROW 3: 5 frameworks ═══ -->
+  <rect x="752" y="498" width="320" height="88" rx="10" class="card"/>
+  <text x="776" y="528" class="name">MITRE ATT&amp;CK / PCI DSS</text>
+  <text x="776" y="549" class="scope">Technique mapping and payment-card controls</text>
+  <rect x="776" y="562" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="776" y="562" width="238" height="6" rx="3" fill="#fb7185"/>
+  <text x="776" y="578" class="count" fill="#fb7185">600+</text>
+  <text x="858" y="577" class="unit">techniques + requirements</text>
 
-  <!-- CMMC 2.0 -->
-  <rect x="20" y="232" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="36" y="252" class="fw-name">CMMC 2.0</text>
-  <text x="36" y="264" class="fw-code">DoD contractor cybersecurity maturity</text>
-  <rect x="36" y="272" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="36" y="272" width="86" height="4" rx="2" fill="#6366f1"/>
-  <text x="36" y="294" class="fw-count" fill="#6366f1">17</text>
-  <text x="64" y="294" class="fw-label">practices</text>
-
-  <!-- NIST 800-53 -->
-  <rect x="208" y="232" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="224" y="252" class="fw-name">NIST 800-53 Rev 5</text>
-  <text x="224" y="264" class="fw-code">Federal information system controls</text>
-  <rect x="224" y="272" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="224" y="272" width="108" height="4" rx="2" fill="#10b981"/>
-  <text x="224" y="294" class="fw-count" fill="#10b981">29</text>
-  <text x="252" y="294" class="fw-label">controls</text>
-
-  <!-- FedRAMP -->
-  <rect x="396" y="232" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="412" y="252" class="fw-name">FedRAMP</text>
-  <text x="412" y="264" class="fw-code">Low / Moderate / High baselines</text>
-  <rect x="412" y="272" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="412" y="272" width="72" height="4" rx="2" fill="#0ea5e9"/>
-  <text x="412" y="294" class="fw-count" fill="#0ea5e9">3</text>
-  <text x="432" y="294" class="fw-label">baselines</text>
-
-  <!-- MITRE ATT&CK Enterprise -->
-  <rect x="584" y="232" width="176" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="600" y="252" class="fw-name">MITRE ATT&amp;CK Enterprise</text>
-  <text x="600" y="264" class="fw-code">Adversary techniques (CWE→CAPEC→ATT&amp;CK)</text>
-  <rect x="600" y="272" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="600" y="272" width="128" height="4" rx="2" fill="#fb7185"/>
-  <text x="600" y="294" class="fw-count" fill="#fb7185">~600</text>
-  <text x="640" y="294" class="fw-label">techniques</text>
-
-  <!-- PCI DSS v4.0 -->
-  <rect x="772" y="232" width="168" height="72" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="788" y="252" class="fw-name">PCI DSS v4.0</text>
-  <text x="788" y="264" class="fw-code">Payment-card data security requirements</text>
-  <rect x="788" y="272" width="136" height="4" rx="2" class="bar-bg"/>
-  <rect x="788" y="272" width="100" height="4" rx="2" fill="#f472b6"/>
-  <text x="788" y="294" class="fw-count" fill="#f472b6">12</text>
-  <text x="816" y="294" class="fw-label">requirements</text>
-
-  <!-- ═══ SUMMARY BAR ═══ -->
-  <rect x="20" y="320" width="920" height="32" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-
-  <text x="80" y="342" text-anchor="middle" class="summary-num" fill="#3b82f6">15</text>
-  <text x="126" y="342" class="summary-label">frameworks</text>
-
-  <rect x="186" y="328" width="1" height="16" fill="#27272a"/>
-
-  <text x="230" y="342" text-anchor="middle" class="summary-num" fill="#10b981">300+</text>
-  <text x="276" y="342" class="summary-label">controls mapped</text>
-
-  <rect x="370" y="328" width="1" height="16" fill="#27272a"/>
-
-  <text x="420" y="342" text-anchor="middle" class="summary-num" fill="#f59e0b">3</text>
-  <text x="442" y="342" class="summary-label">OWASP standards (LLM + MCP + Agentic)</text>
-
-  <rect x="660" y="328" width="1" height="16" fill="#27272a"/>
-
-  <text x="710" y="342" text-anchor="middle" class="summary-num" fill="#a78bfa">auto</text>
-  <text x="756" y="342" class="summary-label">mapped from scan findings — no manual config</text>
+  <rect x="48" y="620" width="1024" height="46" rx="10" class="summary"/>
+  <text x="96" y="651" class="summary-num" fill="#3b82f6">15</text>
+  <text x="150" y="648" class="summary-label">frameworks</text>
+  <rect x="286" y="632" width="1" height="22" fill="#3f3f46"/>
+  <text x="326" y="651" class="summary-num" fill="#10b981">300+</text>
+  <text x="422" y="648" class="summary-label">mapped controls</text>
+  <rect x="594" y="632" width="1" height="22" fill="#3f3f46"/>
+  <text x="632" y="651" class="summary-num" fill="#f59e0b">3</text>
+  <text x="670" y="648" class="summary-label">OWASP standards</text>
+  <rect x="820" y="632" width="1" height="22" fill="#3f3f46"/>
+  <text x="858" y="651" class="summary-num" fill="#a78bfa">auto</text>
+  <text x="930" y="648" class="summary-label">from scan evidence</text>
+  <text x="560" y="681" text-anchor="middle" class="note">Curated subsets focused on AI, MCP, and agent risk; not full-framework catalogs.</text>
 </svg>

--- a/docs/images/compliance-light.svg
+++ b/docs/images/compliance-light.svg
@@ -9,7 +9,7 @@
     .card { fill: #fafafa; stroke: #d4d4d8; stroke-width: 1.2; }
     .name { font-size: 15px; font-weight: 750; fill: #27272a; }
     .scope { font-size: 11px; font-weight: 600; fill: #71717a; }
-    .count { font-size: 28px; font-weight: 800; }
+    .count { font-size: 22px; font-weight: 800; }
     .unit { font-size: 11px; font-weight: 700; fill: #71717a; }
     .bar-bg { fill: #e4e4e7; }
     .summary { fill: #fafafa; stroke: #d4d4d8; stroke-width: 1.2; }
@@ -27,100 +27,100 @@
   <rect x="48" y="124" width="320" height="88" rx="10" class="card"/>
   <text x="72" y="154" class="name">OWASP LLM Top 10</text>
   <text x="72" y="175" class="scope">Prompt injection, data poisoning, supply chain</text>
-  <rect x="72" y="188" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="72" y="188" width="272" height="6" rx="3" fill="#3b82f6"/>
-  <text x="72" y="204" class="count" fill="#2563eb">10</text>
-  <text x="120" y="203" class="unit">controls</text>
+  <rect x="72" y="204" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="72" y="204" width="272" height="6" rx="3" fill="#3b82f6"/>
+  <text x="72" y="202" class="count" fill="#2563eb">10</text>
+  <text x="116" y="201" class="unit">controls</text>
 
   <rect x="400" y="124" width="320" height="88" rx="10" class="card"/>
   <text x="424" y="154" class="name">OWASP MCP Top 10</text>
   <text x="424" y="175" class="scope">Tool poisoning, auth bypass, rug pull risk</text>
-  <rect x="424" y="188" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="424" y="188" width="272" height="6" rx="3" fill="#3b82f6"/>
-  <text x="424" y="204" class="count" fill="#2563eb">10</text>
-  <text x="472" y="203" class="unit">controls</text>
+  <rect x="424" y="204" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="424" y="204" width="272" height="6" rx="3" fill="#3b82f6"/>
+  <text x="424" y="202" class="count" fill="#2563eb">10</text>
+  <text x="468" y="201" class="unit">controls</text>
 
   <rect x="752" y="124" width="320" height="88" rx="10" class="card"/>
   <text x="776" y="154" class="name">OWASP Agentic Top 10</text>
   <text x="776" y="175" class="scope">Excessive agency, unsafe output, autonomy risk</text>
-  <rect x="776" y="188" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="776" y="188" width="272" height="6" rx="3" fill="#3b82f6"/>
-  <text x="776" y="204" class="count" fill="#2563eb">10</text>
-  <text x="824" y="203" class="unit">controls</text>
+  <rect x="776" y="204" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="776" y="204" width="272" height="6" rx="3" fill="#3b82f6"/>
+  <text x="776" y="202" class="count" fill="#2563eb">10</text>
+  <text x="820" y="201" class="unit">controls</text>
 
   <rect x="48" y="236" width="320" height="88" rx="10" class="card"/>
   <text x="72" y="266" class="name">MITRE ATLAS</text>
   <text x="72" y="287" class="scope">Adversarial machine learning tactics</text>
-  <rect x="72" y="300" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="72" y="300" width="208" height="6" rx="3" fill="#f59e0b"/>
-  <text x="72" y="316" class="count" fill="#d97706">14</text>
-  <text x="120" y="315" class="unit">techniques</text>
+  <rect x="72" y="316" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="72" y="316" width="208" height="6" rx="3" fill="#f59e0b"/>
+  <text x="72" y="314" class="count" fill="#d97706">14</text>
+  <text x="116" y="313" class="unit">techniques</text>
 
   <rect x="400" y="236" width="320" height="88" rx="10" class="card"/>
   <text x="424" y="266" class="name">NIST AI RMF</text>
   <text x="424" y="287" class="scope">Govern, map, measure, and manage</text>
-  <rect x="424" y="300" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="424" y="300" width="214" height="6" rx="3" fill="#10b981"/>
-  <text x="424" y="316" class="count" fill="#059669">19</text>
-  <text x="472" y="315" class="unit">subcategories</text>
+  <rect x="424" y="316" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="424" y="316" width="214" height="6" rx="3" fill="#10b981"/>
+  <text x="424" y="314" class="count" fill="#059669">19</text>
+  <text x="468" y="313" class="unit">subcategories</text>
 
   <rect x="752" y="236" width="320" height="88" rx="10" class="card"/>
   <text x="776" y="266" class="name">EU AI Act</text>
   <text x="776" y="287" class="scope">Risk management and human oversight</text>
-  <rect x="776" y="300" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="776" y="300" width="164" height="6" rx="3" fill="#a78bfa"/>
-  <text x="776" y="316" class="count" fill="#7c3aed">12</text>
-  <text x="824" y="315" class="unit">articles</text>
+  <rect x="776" y="316" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="776" y="316" width="164" height="6" rx="3" fill="#a78bfa"/>
+  <text x="776" y="314" class="count" fill="#7c3aed">12</text>
+  <text x="820" y="313" class="unit">articles</text>
 
   <text x="48" y="366" class="section">ENTERPRISE CONTROL FRAMEWORKS</text>
 
   <rect x="48" y="386" width="320" height="88" rx="10" class="card"/>
   <text x="72" y="416" class="name">NIST CSF 2.0</text>
   <text x="72" y="437" class="scope">Identify, protect, detect, respond, recover</text>
-  <rect x="72" y="450" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="72" y="450" width="215" height="6" rx="3" fill="#10b981"/>
-  <text x="72" y="466" class="count" fill="#059669">23</text>
-  <text x="120" y="465" class="unit">subcategories</text>
+  <rect x="72" y="466" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="72" y="466" width="215" height="6" rx="3" fill="#10b981"/>
+  <text x="72" y="464" class="count" fill="#059669">23</text>
+  <text x="116" y="463" class="unit">subcategories</text>
 
   <rect x="400" y="386" width="320" height="88" rx="10" class="card"/>
   <text x="424" y="416" class="name">NIST 800-53 Rev. 5</text>
   <text x="424" y="437" class="scope">Federal information system controls</text>
-  <rect x="424" y="450" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="424" y="450" width="218" height="6" rx="3" fill="#10b981"/>
-  <text x="424" y="466" class="count" fill="#059669">29</text>
-  <text x="472" y="465" class="unit">controls</text>
+  <rect x="424" y="466" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="424" y="466" width="218" height="6" rx="3" fill="#10b981"/>
+  <text x="424" y="464" class="count" fill="#059669">29</text>
+  <text x="468" y="463" class="unit">controls</text>
 
   <rect x="752" y="386" width="320" height="88" rx="10" class="card"/>
   <text x="776" y="416" class="name">FedRAMP</text>
   <text x="776" y="437" class="scope">Low, Moderate, and High baselines</text>
-  <rect x="776" y="450" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="776" y="450" width="126" height="6" rx="3" fill="#0ea5e9"/>
-  <text x="776" y="466" class="count" fill="#0284c7">3</text>
-  <text x="808" y="465" class="unit">baselines</text>
+  <rect x="776" y="466" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="776" y="466" width="126" height="6" rx="3" fill="#0ea5e9"/>
+  <text x="776" y="464" class="count" fill="#0284c7">3</text>
+  <text x="804" y="463" class="unit">baselines</text>
 
   <rect x="48" y="498" width="320" height="88" rx="10" class="card"/>
   <text x="72" y="528" class="name">ISO 27001 / SOC 2</text>
   <text x="72" y="549" class="scope">Security controls and trust criteria</text>
-  <rect x="72" y="562" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="72" y="562" width="166" height="6" rx="3" fill="#f43f5e"/>
-  <text x="72" y="578" class="count" fill="#e11d48">18</text>
-  <text x="120" y="577" class="unit">mapped controls</text>
+  <rect x="72" y="578" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="72" y="578" width="166" height="6" rx="3" fill="#f43f5e"/>
+  <text x="72" y="576" class="count" fill="#e11d48">18</text>
+  <text x="116" y="575" class="unit">mapped controls</text>
 
   <rect x="400" y="498" width="320" height="88" rx="10" class="card"/>
   <text x="424" y="528" class="name">CIS Controls v8 / CMMC 2.0</text>
   <text x="424" y="549" class="scope">Hardening checks and contractor practices</text>
-  <rect x="424" y="562" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="424" y="562" width="256" height="6" rx="3" fill="#34d399"/>
-  <text x="424" y="578" class="count" fill="#059669">217+</text>
-  <text x="492" y="577" class="unit">checks + practices</text>
+  <rect x="424" y="578" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="424" y="578" width="256" height="6" rx="3" fill="#34d399"/>
+  <text x="424" y="576" class="count" fill="#059669">217+</text>
+  <text x="484" y="575" class="unit">checks + practices</text>
 
   <rect x="752" y="498" width="320" height="88" rx="10" class="card"/>
   <text x="776" y="528" class="name">MITRE ATT&amp;CK / PCI DSS</text>
   <text x="776" y="549" class="scope">Technique mapping and payment-card controls</text>
-  <rect x="776" y="562" width="272" height="6" rx="3" class="bar-bg"/>
-  <rect x="776" y="562" width="238" height="6" rx="3" fill="#fb7185"/>
-  <text x="776" y="578" class="count" fill="#be123c">600+</text>
-  <text x="858" y="577" class="unit">techniques + requirements</text>
+  <rect x="776" y="578" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="776" y="578" width="238" height="6" rx="3" fill="#fb7185"/>
+  <text x="776" y="576" class="count" fill="#be123c">600+</text>
+  <text x="846" y="575" class="unit">techniques + requirements</text>
 
   <rect x="48" y="620" width="1024" height="46" rx="10" class="summary"/>
   <text x="96" y="651" class="summary-num" fill="#2563eb">15</text>

--- a/docs/images/compliance-light.svg
+++ b/docs/images/compliance-light.svg
@@ -1,181 +1,138 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 364" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 690" fill="none" role="img" aria-labelledby="title desc">
+  <title id="title">agent-bom compliance coverage</title>
+  <desc id="desc">Readable compliance mapping summary across fifteen AI and security frameworks.</desc>
   <style>
     text { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; }
-    .title { font-size: 16px; font-weight: 700; fill: #18181b; }
-    .subtitle { font-size: 10.5px; font-weight: 400; fill: #a1a1aa; }
-    .fw-name { font-size: 10px; font-weight: 700; fill: #27272a; }
-    .fw-code { font-size: 8px; font-weight: 600; fill: #a1a1aa; }
-    .fw-count { font-size: 18px; font-weight: 800; }
-    .fw-label { font-size: 8px; font-weight: 500; fill: #a1a1aa; }
+    .title { font-size: 24px; font-weight: 750; fill: #18181b; }
+    .subtitle { font-size: 14px; font-weight: 500; fill: #52525b; }
+    .section { font-size: 11px; font-weight: 700; letter-spacing: .08em; fill: #71717a; }
+    .card { fill: #fafafa; stroke: #d4d4d8; stroke-width: 1.2; }
+    .name { font-size: 15px; font-weight: 750; fill: #27272a; }
+    .scope { font-size: 11px; font-weight: 600; fill: #71717a; }
+    .count { font-size: 28px; font-weight: 800; }
+    .unit { font-size: 11px; font-weight: 700; fill: #71717a; }
     .bar-bg { fill: #e4e4e7; }
-    .summary-num { font-size: 22px; font-weight: 800; }
-    .summary-label { font-size: 9px; font-weight: 500; fill: #a1a1aa; }
+    .summary { fill: #fafafa; stroke: #d4d4d8; stroke-width: 1.2; }
+    .summary-num { font-size: 28px; font-weight: 850; }
+    .summary-label { font-size: 12px; font-weight: 700; fill: #71717a; }
+    .note { font-size: 11px; font-weight: 600; fill: #71717a; }
   </style>
 
-  <rect width="960" height="364" rx="12" fill="#ffffff" stroke="#e4e4e7" stroke-width="1"/>
+  <rect width="1120" height="690" rx="18" fill="#ffffff" stroke="#e4e4e7" stroke-width="1"/>
 
-  <text x="480" y="28" text-anchor="middle" class="title">Compliance coverage</text>
-  <text x="480" y="44" text-anchor="middle" class="subtitle">15 frameworks, 300+ controls mapped automatically from scan findings</text>
+  <text x="560" y="44" text-anchor="middle" class="title">Compliance coverage</text>
+  <text x="560" y="68" text-anchor="middle" class="subtitle">Curated AI, MCP, cloud, and enterprise control mappings from scan findings</text>
+  <text x="48" y="104" class="section">AI AND AGENT SECURITY</text>
 
-  <!-- ═══ ROW 1: 5 frameworks ═══ -->
+  <rect x="48" y="124" width="320" height="88" rx="10" class="card"/>
+  <text x="72" y="154" class="name">OWASP LLM Top 10</text>
+  <text x="72" y="175" class="scope">Prompt injection, data poisoning, supply chain</text>
+  <rect x="72" y="188" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="72" y="188" width="272" height="6" rx="3" fill="#3b82f6"/>
+  <text x="72" y="204" class="count" fill="#2563eb">10</text>
+  <text x="120" y="203" class="unit">controls</text>
 
-  <!-- OWASP LLM Top 10 -->
-  <rect x="20" y="64" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="36" y="84" class="fw-name">OWASP LLM Top 10</text>
-  <text x="36" y="96" class="fw-code">Prompt injection, data poisoning, supply chain</text>
-  <rect x="36" y="104" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="36" y="104" width="144" height="4" rx="2" fill="#3b82f6"/>
-  <text x="36" y="126" class="fw-count" fill="#3b82f6">10</text>
-  <text x="64" y="126" class="fw-label">controls</text>
+  <rect x="400" y="124" width="320" height="88" rx="10" class="card"/>
+  <text x="424" y="154" class="name">OWASP MCP Top 10</text>
+  <text x="424" y="175" class="scope">Tool poisoning, auth bypass, rug pull risk</text>
+  <rect x="424" y="188" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="424" y="188" width="272" height="6" rx="3" fill="#3b82f6"/>
+  <text x="424" y="204" class="count" fill="#2563eb">10</text>
+  <text x="472" y="203" class="unit">controls</text>
 
-  <!-- OWASP MCP Top 10 -->
-  <rect x="208" y="64" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="224" y="84" class="fw-name">OWASP MCP Top 10</text>
-  <text x="224" y="96" class="fw-code">Tool poisoning, auth bypass, rug pull</text>
-  <rect x="224" y="104" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="224" y="104" width="144" height="4" rx="2" fill="#3b82f6"/>
-  <text x="224" y="126" class="fw-count" fill="#3b82f6">10</text>
-  <text x="252" y="126" class="fw-label">controls</text>
+  <rect x="752" y="124" width="320" height="88" rx="10" class="card"/>
+  <text x="776" y="154" class="name">OWASP Agentic Top 10</text>
+  <text x="776" y="175" class="scope">Excessive agency, unsafe output, autonomy risk</text>
+  <rect x="776" y="188" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="776" y="188" width="272" height="6" rx="3" fill="#3b82f6"/>
+  <text x="776" y="204" class="count" fill="#2563eb">10</text>
+  <text x="824" y="203" class="unit">controls</text>
 
-  <!-- OWASP Agentic Top 10 -->
-  <rect x="396" y="64" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="412" y="84" class="fw-name">OWASP Agentic Top 10</text>
-  <text x="412" y="96" class="fw-code">Excessive agency, insecure output</text>
-  <rect x="412" y="104" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="412" y="104" width="144" height="4" rx="2" fill="#3b82f6"/>
-  <text x="412" y="126" class="fw-count" fill="#3b82f6">10</text>
-  <text x="440" y="126" class="fw-label">controls</text>
+  <rect x="48" y="236" width="320" height="88" rx="10" class="card"/>
+  <text x="72" y="266" class="name">MITRE ATLAS</text>
+  <text x="72" y="287" class="scope">Adversarial machine learning tactics</text>
+  <rect x="72" y="300" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="72" y="300" width="208" height="6" rx="3" fill="#f59e0b"/>
+  <text x="72" y="316" class="count" fill="#d97706">14</text>
+  <text x="120" y="315" class="unit">techniques</text>
 
-  <!-- MITRE ATLAS -->
-  <rect x="584" y="64" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="600" y="84" class="fw-name">MITRE ATLAS</text>
-  <text x="600" y="96" class="fw-code">Adversarial ML tactics + techniques</text>
-  <rect x="600" y="104" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="600" y="104" width="108" height="4" rx="2" fill="#f59e0b"/>
-  <text x="600" y="126" class="fw-count" fill="#f59e0b">14</text>
-  <text x="628" y="126" class="fw-label">techniques</text>
+  <rect x="400" y="236" width="320" height="88" rx="10" class="card"/>
+  <text x="424" y="266" class="name">NIST AI RMF</text>
+  <text x="424" y="287" class="scope">Govern, map, measure, and manage</text>
+  <rect x="424" y="300" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="424" y="300" width="214" height="6" rx="3" fill="#10b981"/>
+  <text x="424" y="316" class="count" fill="#059669">19</text>
+  <text x="472" y="315" class="unit">subcategories</text>
 
-  <!-- NIST AI RMF -->
-  <rect x="772" y="64" width="168" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="788" y="84" class="fw-name">NIST AI RMF</text>
-  <text x="788" y="96" class="fw-code">Govern, map, measure, manage</text>
-  <rect x="788" y="104" width="136" height="4" rx="2" class="bar-bg"/>
-  <rect x="788" y="104" width="102" height="4" rx="2" fill="#10b981"/>
-  <text x="788" y="126" class="fw-count" fill="#10b981">19</text>
-  <text x="816" y="126" class="fw-label">subcategories</text>
+  <rect x="752" y="236" width="320" height="88" rx="10" class="card"/>
+  <text x="776" y="266" class="name">EU AI Act</text>
+  <text x="776" y="287" class="scope">Risk management and human oversight</text>
+  <rect x="776" y="300" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="776" y="300" width="164" height="6" rx="3" fill="#a78bfa"/>
+  <text x="776" y="316" class="count" fill="#7c3aed">12</text>
+  <text x="824" y="315" class="unit">articles</text>
 
-  <!-- ═══ ROW 2: 5 frameworks ═══ -->
+  <text x="48" y="366" class="section">ENTERPRISE CONTROL FRAMEWORKS</text>
 
-  <!-- NIST CSF -->
-  <rect x="20" y="148" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="36" y="168" class="fw-name">NIST CSF 2.0</text>
-  <text x="36" y="180" class="fw-code">Identify, protect, detect, respond</text>
-  <rect x="36" y="188" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="36" y="188" width="108" height="4" rx="2" fill="#10b981"/>
-  <text x="36" y="210" class="fw-count" fill="#10b981">23</text>
-  <text x="64" y="210" class="fw-label">subcategories</text>
+  <rect x="48" y="386" width="320" height="88" rx="10" class="card"/>
+  <text x="72" y="416" class="name">NIST CSF 2.0</text>
+  <text x="72" y="437" class="scope">Identify, protect, detect, respond, recover</text>
+  <rect x="72" y="450" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="72" y="450" width="215" height="6" rx="3" fill="#10b981"/>
+  <text x="72" y="466" class="count" fill="#059669">23</text>
+  <text x="120" y="465" class="unit">subcategories</text>
 
-  <!-- EU AI Act -->
-  <rect x="208" y="148" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="224" y="168" class="fw-name">EU AI Act</text>
-  <text x="224" y="180" class="fw-code">Risk management, transparency, oversight</text>
-  <rect x="224" y="188" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="224" y="188" width="86" height="4" rx="2" fill="#a78bfa"/>
-  <text x="224" y="210" class="fw-count" fill="#a78bfa">12</text>
-  <text x="252" y="210" class="fw-label">articles</text>
+  <rect x="400" y="386" width="320" height="88" rx="10" class="card"/>
+  <text x="424" y="416" class="name">NIST 800-53 Rev. 5</text>
+  <text x="424" y="437" class="scope">Federal information system controls</text>
+  <rect x="424" y="450" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="424" y="450" width="218" height="6" rx="3" fill="#10b981"/>
+  <text x="424" y="466" class="count" fill="#059669">29</text>
+  <text x="472" y="465" class="unit">controls</text>
 
-  <!-- SOC 2 -->
-  <rect x="396" y="148" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="412" y="168" class="fw-name">SOC 2</text>
-  <text x="412" y="180" class="fw-code">Trust service criteria</text>
-  <rect x="412" y="188" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="412" y="188" width="72" height="4" rx="2" fill="#f43f5e"/>
-  <text x="412" y="210" class="fw-count" fill="#f43f5e">8</text>
-  <text x="432" y="210" class="fw-label">criteria</text>
+  <rect x="752" y="386" width="320" height="88" rx="10" class="card"/>
+  <text x="776" y="416" class="name">FedRAMP</text>
+  <text x="776" y="437" class="scope">Low, Moderate, and High baselines</text>
+  <rect x="776" y="450" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="776" y="450" width="126" height="6" rx="3" fill="#0ea5e9"/>
+  <text x="776" y="466" class="count" fill="#0284c7">3</text>
+  <text x="808" y="465" class="unit">baselines</text>
 
-  <!-- ISO 27001 -->
-  <rect x="584" y="148" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="600" y="168" class="fw-name">ISO 27001</text>
-  <text x="600" y="180" class="fw-code">Information security controls</text>
-  <rect x="600" y="188" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="600" y="188" width="86" height="4" rx="2" fill="#f43f5e"/>
-  <text x="600" y="210" class="fw-count" fill="#f43f5e">10</text>
-  <text x="628" y="210" class="fw-label">controls</text>
+  <rect x="48" y="498" width="320" height="88" rx="10" class="card"/>
+  <text x="72" y="528" class="name">ISO 27001 / SOC 2</text>
+  <text x="72" y="549" class="scope">Security controls and trust criteria</text>
+  <rect x="72" y="562" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="72" y="562" width="166" height="6" rx="3" fill="#f43f5e"/>
+  <text x="72" y="578" class="count" fill="#e11d48">18</text>
+  <text x="120" y="577" class="unit">mapped controls</text>
 
-  <!-- CIS Controls v8 -->
-  <rect x="772" y="148" width="168" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="788" y="168" class="fw-name">CIS Controls v8</text>
-  <text x="788" y="180" class="fw-code">18 critical security controls</text>
-  <rect x="788" y="188" width="136" height="4" rx="2" class="bar-bg"/>
-  <rect x="788" y="188" width="136" height="4" rx="2" fill="#34d399"/>
-  <text x="788" y="210" class="fw-count" fill="#34d399">200+</text>
-  <text x="828" y="210" class="fw-label">checks</text>
+  <rect x="400" y="498" width="320" height="88" rx="10" class="card"/>
+  <text x="424" y="528" class="name">CIS Controls v8 / CMMC 2.0</text>
+  <text x="424" y="549" class="scope">Hardening checks and contractor practices</text>
+  <rect x="424" y="562" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="424" y="562" width="256" height="6" rx="3" fill="#34d399"/>
+  <text x="424" y="578" class="count" fill="#059669">217+</text>
+  <text x="492" y="577" class="unit">checks + practices</text>
 
-  <!-- ═══ ROW 3: 4 frameworks ═══ -->
+  <rect x="752" y="498" width="320" height="88" rx="10" class="card"/>
+  <text x="776" y="528" class="name">MITRE ATT&amp;CK / PCI DSS</text>
+  <text x="776" y="549" class="scope">Technique mapping and payment-card controls</text>
+  <rect x="776" y="562" width="272" height="6" rx="3" class="bar-bg"/>
+  <rect x="776" y="562" width="238" height="6" rx="3" fill="#fb7185"/>
+  <text x="776" y="578" class="count" fill="#be123c">600+</text>
+  <text x="858" y="577" class="unit">techniques + requirements</text>
 
-  <!-- CMMC 2.0 -->
-  <rect x="20" y="232" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="36" y="252" class="fw-name">CMMC 2.0</text>
-  <text x="36" y="264" class="fw-code">DoD contractor cybersecurity maturity</text>
-  <rect x="36" y="272" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="36" y="272" width="86" height="4" rx="2" fill="#6366f1"/>
-  <text x="36" y="294" class="fw-count" fill="#6366f1">17</text>
-  <text x="64" y="294" class="fw-label">practices</text>
-
-  <!-- NIST 800-53 -->
-  <rect x="208" y="232" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="224" y="252" class="fw-name">NIST 800-53 Rev 5</text>
-  <text x="224" y="264" class="fw-code">Federal information system controls</text>
-  <rect x="224" y="272" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="224" y="272" width="108" height="4" rx="2" fill="#10b981"/>
-  <text x="224" y="294" class="fw-count" fill="#10b981">29</text>
-  <text x="252" y="294" class="fw-label">controls</text>
-
-  <!-- FedRAMP -->
-  <rect x="396" y="232" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="412" y="252" class="fw-name">FedRAMP</text>
-  <text x="412" y="264" class="fw-code">Low / Moderate / High baselines</text>
-  <rect x="412" y="272" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="412" y="272" width="72" height="4" rx="2" fill="#0ea5e9"/>
-  <text x="412" y="294" class="fw-count" fill="#0ea5e9">3</text>
-  <text x="432" y="294" class="fw-label">baselines</text>
-
-  <!-- MITRE ATT&CK Enterprise -->
-  <rect x="584" y="232" width="176" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="600" y="252" class="fw-name">MITRE ATT&amp;CK Enterprise</text>
-  <text x="600" y="264" class="fw-code">Adversary techniques (CWE→CAPEC→ATT&amp;CK)</text>
-  <rect x="600" y="272" width="144" height="4" rx="2" class="bar-bg"/>
-  <rect x="600" y="272" width="128" height="4" rx="2" fill="#9f1239"/>
-  <text x="600" y="294" class="fw-count" fill="#9f1239">~600</text>
-  <text x="640" y="294" class="fw-label">techniques</text>
-
-  <!-- PCI DSS v4.0 -->
-  <rect x="772" y="232" width="168" height="72" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="788" y="252" class="fw-name">PCI DSS v4.0</text>
-  <text x="788" y="264" class="fw-code">Payment-card data security requirements</text>
-  <rect x="788" y="272" width="136" height="4" rx="2" class="bar-bg"/>
-  <rect x="788" y="272" width="100" height="4" rx="2" fill="#ec4899"/>
-  <text x="788" y="294" class="fw-count" fill="#ec4899">12</text>
-  <text x="816" y="294" class="fw-label">requirements</text>
-
-  <!-- ═══ SUMMARY BAR ═══ -->
-  <rect x="20" y="320" width="920" height="32" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-
-  <text x="80" y="342" text-anchor="middle" class="summary-num" fill="#3b82f6">15</text>
-  <text x="126" y="342" class="summary-label">frameworks</text>
-
-  <rect x="186" y="328" width="1" height="16" fill="#e4e4e7"/>
-
-  <text x="230" y="342" text-anchor="middle" class="summary-num" fill="#10b981">300+</text>
-  <text x="276" y="342" class="summary-label">controls mapped</text>
-
-  <rect x="370" y="328" width="1" height="16" fill="#e4e4e7"/>
-
-  <text x="420" y="342" text-anchor="middle" class="summary-num" fill="#f59e0b">3</text>
-  <text x="442" y="342" class="summary-label">OWASP standards (LLM + MCP + Agentic)</text>
-
-  <rect x="660" y="328" width="1" height="16" fill="#e4e4e7"/>
-
-  <text x="710" y="342" text-anchor="middle" class="summary-num" fill="#a78bfa">auto</text>
-  <text x="756" y="342" class="summary-label">mapped from scan findings — no manual config</text>
+  <rect x="48" y="620" width="1024" height="46" rx="10" class="summary"/>
+  <text x="96" y="651" class="summary-num" fill="#2563eb">15</text>
+  <text x="150" y="648" class="summary-label">frameworks</text>
+  <rect x="286" y="632" width="1" height="22" fill="#d4d4d8"/>
+  <text x="326" y="651" class="summary-num" fill="#059669">300+</text>
+  <text x="422" y="648" class="summary-label">mapped controls</text>
+  <rect x="594" y="632" width="1" height="22" fill="#d4d4d8"/>
+  <text x="632" y="651" class="summary-num" fill="#d97706">3</text>
+  <text x="670" y="648" class="summary-label">OWASP standards</text>
+  <rect x="820" y="632" width="1" height="22" fill="#d4d4d8"/>
+  <text x="858" y="651" class="summary-num" fill="#7c3aed">auto</text>
+  <text x="930" y="648" class="summary-label">from scan evidence</text>
+  <text x="560" y="681" text-anchor="middle" class="note">Curated subsets focused on AI, MCP, and agent risk; not full-framework catalogs.</text>
 </svg>


### PR DESCRIPTION
Summary
- replace the cramped compliance README SVGs with wider, sectioned layouts for light and dark mode
- prevent framework labels, counts, and summary text from overflowing their containers
- keep the honest scope note visible inside the graphic

Validation
- xmllint --noout docs/images/compliance-dark.svg docs/images/compliance-light.svg
- git diff --check