### PR TITLE
docs: sharpen AI BOM first-run wedge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 </p>
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
-<p align="center"><b>Open security scanner and control plane for AI supply chain and runtime infrastructure — local scans, CI evidence, fleet inventory, MCP enforcement, and self-hosted governance.</b></p>
+<p align="center"><b>Open security scanner and AI BOM for the AI stack.</b></p>
 
-<p align="center"><code>agent-bom</code> follows vulnerable packages, MCP servers, tools, credentials, agents, and runtime paths so teams can prioritize the fix that removes the most reachable risk.</p>
+<p align="center"><code>agent-bom</code> inventories agents, MCP servers, tools, packages, credential environment names, cloud and runtime evidence, then maps the reachable blast radius behind each finding.</p>
 
 <p align="center">
   <a href="https://msaad00.github.io/agent-bom/">Docs</a> ·
@@ -54,7 +54,12 @@ Blast radius is the core idea: `package -> vulnerability finding -> MCP server (
 agent-bom agents --demo --offline
 ```
 
-The demo uses a curated sample so the output stays reproducible across releases. Every CVE shown is a real OSV/GHSA match against a genuinely vulnerable package version — no fabricated findings (locked in by [`tests/test_demo_inventory_accuracy.py`](tests/test_demo_inventory_accuracy.py)). For a real scan, run `agent-bom agents`, or add `-p .` to fold project manifests and lockfiles into the same result.
+The demo produces a terminal finding set and graph-ready inventory without
+touching your source tree. Every CVE shown is a real OSV/GHSA match against a
+genuinely vulnerable package version — no fabricated findings (locked in by
+[`tests/test_demo_inventory_accuracy.py`](tests/test_demo_inventory_accuracy.py)).
+For a real scan, run `agent-bom agents`, or add `-p .` to fold project
+manifests and lockfiles into the same result.
 
 Want an inspectable sample before scanning your own repo? Run the bundled
 first-run AI stack:
@@ -74,6 +79,17 @@ dashboard.
 </p>
 
 ## Quick start
+
+Start with the surface you already use. Each path produces evidence that can
+later roll into the same self-hosted control plane.
+
+| Start here | Command | First artifact |
+|---|---|---|
+| **CLI** | `agent-bom agents --demo --offline` | terminal findings + graph-ready inventory |
+| **Your repo** | `agent-bom agents -p . -f html -o agent-bom-report.html` | local HTML review, JSON/SARIF/SBOM/graph exports when requested |
+| **CI** | `uses: msaad00/agent-bom@v0.86.3` | SARIF, PR summary, optional code-scanning upload |
+| **Assistant / MCP** | `agent-bom mcp server` | read-only security tools for Claude, Cursor, Codex, Windsurf, Cortex, and other MCP clients |
+| **Self-hosted control plane** | `docker compose -f docker-compose.pilot.yml up -d` | API + dashboard in your infrastructure |
 
 ```bash
 pip install agent-bom                  # CLI
@@ -408,13 +424,13 @@ for the full split-vs-single-image guidance.
 
 ## Choose Your Path
 
-Start with one lane. Each lane feeds the same evidence model, so local scans,
-fleet inventory, graph findings, compliance evidence, and runtime decisions can
-roll up into the same self-hosted control plane when you need it.
+Start with one lane. Each lane feeds the same AI BOM evidence model, so local
+scans, fleet inventory, graph findings, compliance evidence, and runtime
+decisions can roll up into the same self-hosted control plane when you need it.
 
 ```text
 agent-bom
-├─ scan locally
+├─ generate an AI BOM locally
 │  ├─ CLI / Docker / GitHub Action
 │  └─ findings, SARIF, SBOM, HTML, graph exports
 ├─ send evidence to a control plane

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -1,13 +1,15 @@
 # Product Brief
 
-`agent-bom` is an open security scanner and self-hosted control plane for
-AI supply chain and runtime infrastructure — local scans, CI evidence, fleet
-inventory, MCP/runtime enforcement, and governance surfaces that run in the
-operator's own environment.
+`agent-bom` is an open security scanner and AI BOM for the AI stack, with a
+self-hosted control plane for teams that need fleet inventory, graph-backed
+findings, MCP/runtime enforcement, and governance evidence inside their own
+environment.
 
 It is built around a simple thesis: security and visibility for AI infrastructure should be open, transparent, and accessible, not reserved for teams with enterprise budgets.
 
-Package risk is only the start. `agent-bom` follows what it can reach across MCP servers, agents, credentials, tools, runtime behavior, and trust posture. That is the core product value.
+Package risk is only the start. `agent-bom` follows what it can reach across
+MCP servers, agents, credential environment names, tools, runtime behavior, and
+trust posture. That reachability-backed AI BOM is the core product value.
 
 `agent-bom` is a released OSS product with a working CLI, GitHub Action, Docker images, authenticated API and MCP deployment paths, report formats, a dashboard, and a growing enterprise-hardening track.
 
@@ -25,12 +27,13 @@ persona questions quickly:
 | Account executive | "Who buys this and why now?" | AI/MCP supply-chain risk, self-hosted deployment, evidence for governance teams |
 | Software/security engineer | "Can I trust and operate it?" | signed releases, tests, strict auth defaults, Postgres tenancy, audit chain, scoped runtime controls |
 
-Do not present the product as ten equal entry points. Present it as three
-adoption lanes that share one evidence model:
+Do not present the product as ten equal entry points. Present it as one wedge
+with three adoption lanes: generate an AI BOM for the stack, send that evidence
+to a customer-controlled plane, then enforce selected runtime paths.
 
 ```text
 agent-bom
-├─ scan locally
+├─ generate an AI BOM locally
 │  └─ CLI, Docker, GitHub Action -> findings, SARIF, SBOM, HTML, graph exports
 ├─ send evidence to a control plane
 │  └─ fleet sync, REST API, Helm/EKS, UI -> inventory, graph, compliance, governance
@@ -38,8 +41,8 @@ agent-bom
    └─ MCP server, proxy/gateway, Shield SDK -> audit, policy blocks, runtime alerts
 ```
 
-1. **Scan locally** — CLI, Docker, and GitHub Action produce findings, SARIF,
-   SBOMs, HTML reports, and graph exports.
+1. **Generate an AI BOM locally** — CLI, Docker, and GitHub Action produce
+   findings, SARIF, SBOMs, HTML reports, and graph exports.
 2. **Send evidence to a control plane** — endpoint fleet, REST API, Helm/EKS,
    and the browser UI centralize inventory, graph state, compliance, and
    governance.
@@ -175,7 +178,8 @@ This is the right path because it improves product trust without diluting the MC
 
 Good external phrasing:
 
-- Open security scanner and graph for AI supply chain and infrastructure — discover agents and MCP, map blast radius, and inspect runtime
+- Open security scanner and AI BOM for the AI stack
+- Generate a reachability-backed AI BOM across agents, MCP, packages, credentials, cloud, and runtime
 - Context-aware security for agents, MCP, runtime, and AI supply chain and infrastructure
 - Blast radius from package risk to agents, credentials, tools, and runtime
 

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -1,10 +1,11 @@
 # agent-bom
 
-**Open security scanner and graph for AI supply chain and infrastructure — discover agents and MCP, map blast radius, and inspect runtime.**
+**Open security scanner and AI BOM for the AI stack.**
 
-Scan agents, MCP, packages, containers, Kubernetes, cloud, and GPU workloads
-with blast-radius context. For source-by-source boundaries, see the
-[AI infrastructure coverage matrix](architecture/ai-infrastructure.md#coverage-matrix).
+Inventory agents, MCP servers, tools, packages, credential environment names,
+cloud and runtime evidence, then map the reachable blast radius behind each
+finding. For source-by-source boundaries, see the [AI infrastructure coverage
+matrix](architecture/ai-infrastructure.md#coverage-matrix).
 
 ## What it does
 
@@ -32,6 +33,16 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 
 [Get started](getting-started/install.md){ .md-button .md-button--primary }
 [View on GitHub](https://github.com/msaad00/agent-bom){ .md-button }
+
+## Start with one lane
+
+| Lane | First command | Artifact |
+|---|---|---|
+| **Local AI BOM** | `agent-bom agents --demo --offline` | terminal findings and graph-ready inventory |
+| **Repository scan** | `agent-bom agents -p . -f html -o agent-bom-report.html` | local HTML review plus exportable evidence |
+| **CI evidence** | `uses: msaad00/agent-bom@v0.86.3` | SARIF, pull-request summary, optional code scanning |
+| **Assistant tools** | `agent-bom mcp server` | read-only security tools for MCP clients |
+| **Self-hosted control plane** | `docker compose -f docker-compose.pilot.yml up -d` | API and dashboard in your infrastructure |
 
 ## Key capabilities
 


### PR DESCRIPTION
Summary
- sharpen the front-door wedge around agent-bom as an open security scanner and AI BOM for the AI stack
- make first-run paths explicit by lane: CLI demo, repo scan, CI, MCP tools, and self-hosted control plane
- align README, docs landing page, and product brief around the same evidence model without adding untested capability claims

Validation
- git diff --check -- README.md site-docs/index.md docs/PRODUCT_BRIEF.md
- uv run mkdocs build --strict
