### PR TITLE
ui: make agent mesh readable by default

### DIFF
--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -180,7 +180,7 @@ export default function MeshPage() {
   const [selectedNode, setSelectedNode] = useState<LineageNodeData | null>(null);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [activeJob, setActiveJob] = useState<ScanJob | null>(null);
-  const [layoutMode, setLayoutMode] = useState<MeshLayoutMode>("radial");
+  const [layoutMode, setLayoutMode] = useState<MeshLayoutMode>("topology");
 
   // Filters
   const [nodeFilter, setNodeFilter] = useState<NodeTypeFilter>({
@@ -288,6 +288,7 @@ export default function MeshPage() {
     const empty: MeshStatsData = {
       totalAgents: 0, sharedServers: 0, uniqueCredentials: 0, toolOverlap: 0,
       credentialBlast: [], totalPackages: 0, totalVulnerabilities: 0,
+      omittedCredentials: 0, omittedTools: 0, omittedPackages: 0, omittedVulnerabilities: 0,
       criticalCount: 0, highCount: 0, mediumCount: 0, lowCount: 0, kevCount: 0,
     };
     if (!activeResult) return { rawNodes: [] as Node[], rawEdges: [] as Edge[], stats: empty };
@@ -306,8 +307,8 @@ export default function MeshPage() {
     dagre: {
       nodeWidth: 200,
       nodeHeight: 70,
-      rankSep: 140,
-      nodeSep: 25,
+      rankSep: 95,
+      nodeSep: 18,
     },
   });
 
@@ -409,16 +410,16 @@ export default function MeshPage() {
   }
 
   return (
-    <div className="h-[calc(100vh-3.5rem)] flex flex-col">
+    <div className="h-[calc(100vh-3.5rem)] flex flex-col bg-background text-foreground">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--border-subtle)]">
         <div>
-          <h1 className="text-lg font-semibold text-zinc-100">Agent Mesh</h1>
-          <p className="text-xs text-zinc-500">
-            Agent-centered shared infrastructure across MCP servers, packages, tools, and findings
+          <h1 className="text-lg font-semibold text-foreground">Agent Mesh</h1>
+          <p className="text-xs text-[var(--text-secondary)]">
+            Evidence-scoped path view across agents, MCP servers, tools, packages, credential references, and findings
           </p>
-          <p className="mt-1 text-[11px] text-zinc-600">
-            Default scope stays on the highest-risk agent first so the mesh is readable before you expand it.
+          <p className="mt-1 text-[11px] text-[var(--text-tertiary)]">
+            Default view ranks the highest-risk agent first and hides lower-priority nodes until you expand filters.
           </p>
         </div>
         <div className="flex items-center gap-3">
@@ -490,7 +491,7 @@ export default function MeshPage() {
           edges={displayEdges}
           nodeTypes={lineageNodeTypes}
           fitView
-          fitViewOptions={{ padding: 0.18, maxZoom: 1.05 }}
+          fitViewOptions={{ padding: 0.08, maxZoom: 1.45 }}
           minZoom={0.16}
           maxZoom={2.5}
           zoomOnScroll={false}

--- a/ui/components/lineage-nodes.tsx
+++ b/ui/components/lineage-nodes.tsx
@@ -131,7 +131,8 @@ function NodeCard({
 }: CardProps) {
   return (
     <div
-      className={`${shapeClass} border-2 px-3 py-2 min-w-[148px] max-w-[220px] shadow-lg backdrop-blur transition-opacity ${borderClass} ${bgClass} ${
+      title={data.label}
+      className={`${shapeClass} border-2 px-3 py-2 min-w-[168px] max-w-[240px] shadow-lg backdrop-blur transition-opacity ${borderClass} ${bgClass} ${
         data.dimmed ? "opacity-25" : ""
       } ${data.highlighted ? `ring-2 ${ringClass}` : ""}`}
     >
@@ -147,12 +148,12 @@ function NodeCard({
       />
       <div className="flex items-center gap-1.5 mb-0.5">
         <Icon className={`w-3.5 h-3.5 shrink-0 ${iconClass}`} />
-        <span className="text-xs font-semibold text-zinc-100 truncate">{data.label}</span>
-        <span className="ml-auto rounded border border-white/10 bg-black/20 px-1.5 py-0.5 text-[9px] uppercase tracking-[0.16em] text-zinc-500">
+        <span className="text-[13px] font-semibold leading-4 text-zinc-50 truncate">{data.label}</span>
+        <span className="ml-auto rounded border border-white/15 bg-black/25 px-1.5 py-0.5 text-[9px] uppercase tracking-[0.12em] text-zinc-300">
           {NODE_TYPE_BADGES[data.nodeType]}
         </span>
       </div>
-      {subtitle && <div className="text-[10px] text-zinc-400 truncate">{subtitle}</div>}
+      {subtitle && <div className="text-[11px] leading-4 text-zinc-300 truncate">{subtitle}</div>}
       {footer}
     </div>
   );
@@ -165,7 +166,7 @@ const NODE_TYPE_BADGES: Record<LineageNodeType, string> = {
   package: "Package",
   vulnerability: "CVE",
   misconfiguration: "Config",
-  credential: "Credential",
+  credential: "Cred ref",
   tool: "Tool",
   model: "Model",
   dataset: "Dataset",

--- a/ui/components/mesh-stats.tsx
+++ b/ui/components/mesh-stats.tsx
@@ -7,20 +7,25 @@ export type { MeshStatsData };
 
 export function MeshStats({ stats }: { stats: MeshStatsData }) {
   const totalSev = stats.criticalCount + stats.highCount + stats.mediumCount + stats.lowCount;
+  const omittedTotal =
+    stats.omittedCredentials +
+    stats.omittedTools +
+    stats.omittedPackages +
+    stats.omittedVulnerabilities;
 
   return (
-    <div className="flex items-center gap-4 px-4 py-2 border-b border-zinc-800 text-xs flex-wrap">
+    <div className="flex items-center gap-4 px-4 py-2 border-b border-[var(--border-subtle)] text-xs flex-wrap">
       <Stat icon={ShieldAlert} label="Agents" value={stats.totalAgents} color="text-emerald-400" />
       <Stat icon={Server} label="Shared Servers" value={stats.sharedServers} color="text-cyan-400" />
       <Stat icon={Package} label="Packages" value={stats.totalPackages} color="text-zinc-400" />
       <Stat icon={Bug} label="Vulns" value={stats.totalVulnerabilities} color="text-red-400" />
-      <Stat icon={KeyRound} label="Credentials" value={stats.uniqueCredentials} color="text-amber-400" />
+      <Stat icon={KeyRound} label="Credential refs" value={stats.uniqueCredentials} color="text-amber-400" />
       <Stat icon={Wrench} label="Tool Overlap" value={stats.toolOverlap} color="text-purple-400" />
 
       {/* Severity breakdown mini-bar */}
       {totalSev > 0 && (
         <div className="flex items-center gap-1.5 ml-2">
-          <span className="text-zinc-500">Severity:</span>
+          <span className="text-[var(--text-secondary)]">Severity:</span>
           <div className="flex h-2.5 rounded-full overflow-hidden w-24 bg-zinc-800">
             {stats.criticalCount > 0 && (
               <div
@@ -68,6 +73,13 @@ export function MeshStats({ stats }: { stats: MeshStatsData }) {
         </div>
       )}
 
+      {omittedTotal > 0 && (
+        <div className="flex items-center gap-1 rounded border border-[var(--border-subtle)] bg-[var(--surface-muted)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)]">
+          <span className="font-semibold text-foreground">{omittedTotal}</span>
+          <span>lower-priority nodes hidden</span>
+        </div>
+      )}
+
       {/* Credential blast */}
       {stats.credentialBlast.length > 0 && (
         <div className="ml-auto flex items-center gap-1.5 text-amber-400">
@@ -96,8 +108,8 @@ function Stat({
   return (
     <div className="flex items-center gap-1.5">
       <Icon className={`w-3.5 h-3.5 ${color}`} />
-      <span className="text-zinc-500">{label}</span>
-      <span className="font-semibold text-zinc-200">{value}</span>
+      <span className="text-[var(--text-secondary)]">{label}</span>
+      <span className="font-semibold text-foreground">{value}</span>
     </div>
   );
 }

--- a/ui/components/scan-mesh.tsx
+++ b/ui/components/scan-mesh.tsx
@@ -31,6 +31,7 @@ export function ScanMeshView({ id }: { id: string }) {
     const empty: MeshStatsData = {
       totalAgents: 0, sharedServers: 0, uniqueCredentials: 0, toolOverlap: 0,
       credentialBlast: [], totalPackages: 0, totalVulnerabilities: 0,
+      omittedCredentials: 0, omittedTools: 0, omittedPackages: 0, omittedVulnerabilities: 0,
       criticalCount: 0, highCount: 0, mediumCount: 0, lowCount: 0, kevCount: 0,
     };
     if (!job?.result) return { rawNodes: [] as Node[], rawEdges: [] as Edge[], stats: empty };

--- a/ui/lib/mesh-graph.ts
+++ b/ui/lib/mesh-graph.ts
@@ -17,6 +17,10 @@ export interface MeshStatsData {
   credentialBlast: string[];
   totalPackages: number;
   totalVulnerabilities: number;
+  omittedCredentials: number;
+  omittedTools: number;
+  omittedPackages: number;
+  omittedVulnerabilities: number;
   criticalCount: number;
   highCount: number;
   mediumCount: number;
@@ -51,6 +55,11 @@ type VulnerabilitySeverity = Vulnerability["severity"];
 export interface MeshGraphScope {
   selectedAgents?: string[] | undefined;
   vulnerableOnly?: boolean | undefined;
+  maxCredentialNodesPerServer?: number | undefined;
+  maxToolNodesPerServer?: number | undefined;
+  maxVulnerablePackagesPerServer?: number | undefined;
+  maxCleanPackagesPerServer?: number | undefined;
+  maxVulnerabilitiesPerPackage?: number | undefined;
 }
 
 // ─── Credential detection ───────────────────────────────────────────────────
@@ -283,6 +292,11 @@ export function buildMeshGraph(
   const sevFilter = severityFilter ?? "all";
   const selectedAgents = scope?.selectedAgents ?? [];
   const vulnerableOnly = scope?.vulnerableOnly ?? false;
+  const maxCredentialNodesPerServer = scope?.maxCredentialNodesPerServer ?? 4;
+  const maxToolNodesPerServer = scope?.maxToolNodesPerServer ?? 3;
+  const maxVulnerablePackagesPerServer = scope?.maxVulnerablePackagesPerServer ?? (vulnerableOnly ? 4 : 5);
+  const maxCleanPackagesPerServer = scope?.maxCleanPackagesPerServer ?? (vulnerableOnly ? 0 : 2);
+  const maxVulnerabilitiesPerPackage = scope?.maxVulnerabilitiesPerPackage ?? (vulnerableOnly ? 2 : 3);
   const scopedAgents =
     selectedAgents.length > 0
       ? result.agents.filter((agent) => selectedAgents.includes(getMeshAgentKey(agent)) || selectedAgents.includes(agent.name))
@@ -343,6 +357,10 @@ export function buildMeshGraph(
   // View stats
   let totalPackages = 0;
   let totalVulnerabilities = 0;
+  let omittedCredentials = 0;
+  let omittedTools = 0;
+  let omittedPackages = 0;
+  let omittedVulnerabilities = 0;
   let criticalCount = 0;
   let highCount = 0;
   let mediumCount = 0;
@@ -446,7 +464,9 @@ export function buildMeshGraph(
 
     // ── Credential nodes ──
     if (showCreds) {
-      for (const cred of group.credNames) {
+      const visibleCreds = [...group.credNames].sort().slice(0, maxCredentialNodesPerServer);
+      omittedCredentials += Math.max(0, group.credNames.size - visibleCreds.length);
+      for (const cred of visibleCreds) {
         const credId = `cred:${serverId}:${cred}`;
         if (!seen.has(credId)) {
           seen.add(credId);
@@ -458,7 +478,7 @@ export function buildMeshGraph(
             data: {
               label: cred,
               nodeType: "credential",
-              serverName: group.name,
+              serverName: `${group.name} · env-var reference`,
               sharedBy: credAgentMap.get(cred)?.size,
             } satisfies LineageNodeData,
           });
@@ -482,7 +502,10 @@ export function buildMeshGraph(
     // ── Tool nodes (limit 5 per server) ──
     if (showTools) {
       const allTools = group.servers.flatMap((s) => s.tools ?? []);
-      const uniqueTools = [...new Map(allTools.map((t) => [t.name, t])).values()].slice(0, 5);
+      const allUniqueTools = [...new Map(allTools.map((t) => [t.name, t])).values()]
+        .sort((left, right) => left.name.localeCompare(right.name));
+      const uniqueTools = allUniqueTools.slice(0, maxToolNodesPerServer);
+      omittedTools += Math.max(0, allUniqueTools.length - uniqueTools.length);
       for (const tool of uniqueTools) {
         const toolId = `tool:${serverId}:${tool.name}`;
         if (!seen.has(toolId)) {
@@ -554,8 +577,10 @@ export function buildMeshGraph(
         });
       const cleanPkgs = rankedPackages
         .filter((entry) => entry.matchingVulns.length === 0)
-        .slice(0, vulnerableOnly ? 0 : 2);
-      const displayPkgs = [...vulnPkgs.slice(0, vulnerableOnly ? 8 : 6), ...cleanPkgs];
+        .slice(0, maxCleanPackagesPerServer);
+      const visibleVulnPkgs = vulnPkgs.slice(0, maxVulnerablePackagesPerServer);
+      omittedPackages += Math.max(0, vulnPkgs.length - visibleVulnPkgs.length);
+      const displayPkgs = [...visibleVulnPkgs, ...cleanPkgs];
 
       for (const { pkg, serverId: packageServerId, matchingVulns } of displayPkgs) {
         const pkgId = `pkg:${packageServerId}:${pkg.ecosystem}:${pkg.name}@${pkg.version}`;
@@ -597,7 +622,9 @@ export function buildMeshGraph(
 
         // ── Vulnerability nodes ──
         if (showVulns && matchingVulns.length > 0) {
-          for (const vuln of matchingVulns.slice(0, vulnerableOnly ? 6 : 5)) {
+          const visibleVulns = matchingVulns.slice(0, maxVulnerabilitiesPerPackage);
+          omittedVulnerabilities += Math.max(0, matchingVulns.length - visibleVulns.length);
+          for (const vuln of visibleVulns) {
             const vulnId = `vuln:${pkg.name}:${vuln.id}`;
             if (seen.has(vulnId)) continue;
             seen.add(vulnId);
@@ -660,6 +687,10 @@ export function buildMeshGraph(
     credentialBlast,
     totalPackages,
     totalVulnerabilities,
+    omittedCredentials,
+    omittedTools,
+    omittedPackages,
+    omittedVulnerabilities,
     criticalCount,
     highCount,
     mediumCount,

--- a/ui/tests/mesh-graph.test.ts
+++ b/ui/tests/mesh-graph.test.ts
@@ -230,4 +230,62 @@ describe("buildMeshGraph", () => {
       .sort();
     expect(packageLabels).toEqual(["server-filesystem@1.0.0", "server-filesystem@2.0.0"]);
   });
+
+  it("caps dense findings and reports omitted nodes for readable defaults", () => {
+    const result: ScanResult = {
+      agents: [
+        {
+          name: "cursor",
+          agent_type: "desktop",
+          mcp_servers: [
+            {
+              name: "dense-server",
+              env: {
+                OPENAI_API_KEY: "",
+                ANTHROPIC_API_KEY: "",
+                AWS_SECRET_ACCESS_KEY: "",
+                GITHUB_TOKEN: "",
+                DATABASE_PASSWORD: "",
+              },
+              packages: Array.from({ length: 6 }, (_, packageIndex) => ({
+                name: `pkg-${packageIndex}`,
+                version: "1.0.0",
+                ecosystem: "npm",
+                vulnerabilities: Array.from({ length: 4 }, (_, vulnIndex) => ({
+                  id: `CVE-2026-${packageIndex}${vulnIndex}`,
+                  severity: vulnIndex === 0 ? "critical" : "high",
+                })),
+              })),
+              tools: Array.from({ length: 6 }, (_, index) => ({
+                name: `tool_${index}`,
+                description: `Tool ${index}`,
+              })),
+            },
+          ],
+        },
+      ],
+      blast_radius: [],
+    };
+
+    const { nodes, stats } = buildMeshGraph(
+      result,
+      { packages: true, vulnerabilities: true, credentials: true, tools: true },
+      "high",
+      { vulnerableOnly: true },
+    );
+
+    expect(nodes.filter((node) => node.data.nodeType === "package")).toHaveLength(4);
+    expect(nodes.filter((node) => node.data.nodeType === "vulnerability")).toHaveLength(8);
+    expect(nodes.filter((node) => node.data.nodeType === "tool")).toHaveLength(3);
+    expect(nodes.filter((node) => node.data.nodeType === "credential")).toHaveLength(4);
+    expect(stats.omittedPackages).toBe(2);
+    expect(stats.omittedVulnerabilities).toBe(8);
+    expect(stats.omittedTools).toBe(3);
+    expect(stats.omittedCredentials).toBe(1);
+    expect(
+      nodes
+        .filter((node) => node.data.nodeType === "credential")
+        .every((node) => String(node.data.serverName).includes("env-var reference")),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
Summary
- make Agent Mesh default to the scoped topology layout instead of a radial graph
- cap dense tools, credential references, vulnerable packages, and CVEs so the first view is readable
- disclose hidden lower-priority nodes and label credentials as env-var references rather than stored secret values
- improve node label contrast and light-theme header/stat readability for the mesh page

Validation
- npm run typecheck
- npm test -- --run tests/mesh-graph.test.ts tests/use-graph-layout.test.tsx
- npm run build
- live visual check against local API + bundled demo data:
  - uv run agent-bom agents --demo --offline -f json -o /tmp/agent-bom-demo-report.json
  - POST /v1/results/push to local agent-bom serve
  - Playwright screenshots reviewed at 1600x1000 dark, 1600x1000 light, and 1000x720 dark
