### PR TITLE
docs: align Snowflake release examples with 0.86.3

### DIFF
--- a/.github/workflows/release-snowflake.yml
+++ b/.github/workflows/release-snowflake.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Optional Snowflake Native App version label, for example v0_86_0. Defaults to pyproject.toml.
+        description: Optional Snowflake Native App version label, for example v0_86_3. Defaults to pyproject.toml.
         required: false
         default: ""
         type: string

--- a/docs/snowflake-native-app/MARKETPLACE.md
+++ b/docs/snowflake-native-app/MARKETPLACE.md
@@ -27,7 +27,7 @@ are configured.
   bearer token.
 - The release workflow is manually dispatched and defaults to `dry_run: true`.
 - If no version input is supplied, the workflow derives the Snowflake package
-  label from `pyproject.toml` (`0.86.0` -> `v0_86_0`) so package labels do not
+  label from `pyproject.toml` (`0.86.3` -> `v0_86_3`) so package labels do not
   drift from the release version.
 - Live publish requires the protected `snowflake-marketplace` environment plus
   `SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_USER`, `SNOWFLAKE_PRIVATE_KEY`, and
@@ -48,7 +48,7 @@ for spec in sorted((root / "service-specs").glob("*.yaml")):
 PY
 
 mkdir -p dist
-tar -czf dist/agent-bom-snowflake-v0_86_0.tgz -C deploy/snowflake/native-app .
+tar -czf dist/agent-bom-snowflake-v0_86_3.tgz -C deploy/snowflake/native-app .
 ```
 
 ## Customer smoke checklist


### PR DESCRIPTION
## Summary
- update stale Snowflake Native App marketplace examples from `v0_86_0` to `v0_86_3`
- update the manual release workflow input example to match the current 0.86.3 release-prep version
- leave the real workflow behavior unchanged: it still derives the package label from `pyproject.toml` when no version input is supplied

## Validation
- `git diff --check -- .github/workflows/release-snowflake.yml docs/snowflake-native-app/MARKETPLACE.md`
- `python - <<'PY' ...` Snowflake manifest/service-spec YAML validation
