### PR TITLE
fix: add compliance summary and probe aliases

### DIFF
--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -660,7 +660,11 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         {
             "/",
             "/health",
+            "/healthz",
+            "/livez",
+            "/ping",
             "/readyz",
+            "/status",
             "/version",
             "/docs",
             "/redoc",
@@ -674,7 +678,11 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         else {
             "/",
             "/health",
+            "/healthz",
+            "/livez",
+            "/ping",
             "/readyz",
+            "/status",
             "/version",
             "/v1/auth/session",
             "/v1/auth/saml/metadata",

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -2,6 +2,7 @@
 
 Endpoints:
     GET  /v1/compliance                      15-framework compliance posture + AISVS benchmark
+    GET  /v1/compliance/summary              aggregate compliance summary
     GET  /v1/compliance/aisvs                OWASP AISVS benchmark posture
     GET  /v1/compliance/narrative            full compliance narrative (all frameworks)
     GET  /v1/compliance/narrative/{framework} single-framework narrative
@@ -910,6 +911,40 @@ async def get_compliance_verification_key(request: Request) -> dict:
 async def get_aisvs_compliance(request: Request) -> dict:
     """Return the latest tenant-scoped OWASP AISVS benchmark result from completed scans."""
     return _latest_aisvs_benchmark_from_jobs(_tenant_jobs(request))
+
+
+@router.get("/v1/compliance/summary", tags=["compliance"])
+async def get_compliance_summary(request: Request) -> dict:
+    """Return aggregate compliance score and per-framework status counts.
+
+    Keep this literal route above /v1/compliance/{framework}; otherwise FastAPI
+    correctly treats "summary" as a framework slug.
+    """
+    full = await get_compliance(request)
+    summary_keys = {
+        "overall_score",
+        "overall_status",
+        "scan_count",
+        "latest_scan",
+        "has_mcp_context",
+        "has_agent_context",
+        "scan_sources",
+        "summary",
+    }
+    response = {key: full.get(key) for key in summary_keys if key in full}
+    response["frameworks"] = {}
+    for key, value in full.items():
+        if isinstance(value, list):
+            pass_count = sum(1 for item in value if item.get("status") == "pass")
+            warn_count = sum(1 for item in value if item.get("status") == "warning")
+            fail_count = sum(1 for item in value if item.get("status") == "fail")
+            response["frameworks"][key] = {
+                "controls": len(value),
+                "pass": pass_count,
+                "warning": warn_count,
+                "fail": fail_count,
+            }
+    return response
 
 
 @router.get("/v1/compliance/{framework}", tags=["compliance"])

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -798,6 +798,12 @@ async def health() -> HealthResponse:
     )
 
 
+@app.get("/healthz", response_model=HealthResponse, tags=["meta"])
+async def healthz() -> HealthResponse:
+    """Kubernetes-style liveness probe alias for /health."""
+    return await health()
+
+
 @app.get("/version", response_model=VersionInfo, tags=["meta"])
 async def version() -> VersionInfo:
     """Version information."""
@@ -815,6 +821,24 @@ async def readiness() -> JSONResponse:
     if _shutting_down:
         return JSONResponse(status_code=503, content={"status": "draining"})
     return JSONResponse(status_code=200, content={"status": "ready"})
+
+
+@app.get("/livez", response_model=HealthResponse, tags=["meta"])
+async def liveness() -> HealthResponse:
+    """Kubernetes-style liveness probe alias for /health."""
+    return await health()
+
+
+@app.get("/ping", tags=["meta"])
+async def ping() -> dict[str, str]:
+    """Minimal ping endpoint for load balancers and smoke checks."""
+    return {"status": "ok"}
+
+
+@app.get("/status", response_model=HealthResponse, tags=["meta"])
+async def status() -> HealthResponse:
+    """Operator status alias for the health payload."""
+    return await health()
 
 
 # ── Dashboard static file serving ────────────────────────────────────────────

--- a/tests/test_api_compliance_auth.py
+++ b/tests/test_api_compliance_auth.py
@@ -101,6 +101,17 @@ def test_aisvs_compliance_accepts_trusted_proxy_headers() -> None:
     assert body["representation"] == "benchmark"
 
 
+def test_compliance_summary_does_not_route_as_framework_slug() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/compliance/summary", headers=_proxy_headers())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "overall_score" in body
+    assert "summary" in body
+    assert "frameworks" in body
+    assert "owasp_llm_top10" in body["frameworks"]
+
+
 def test_compliance_export_end_to_end_returns_real_evidence() -> None:
     """Full stack: seed a real ScanJob, hit the FastAPI route, verify evidence wires.
 

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -45,6 +45,21 @@ def test_health_no_auth():
     assert resp.status_code == 200
 
 
+def test_kubernetes_probe_aliases_no_auth():
+    """Kubernetes-style probe aliases should be reachable without credentials."""
+    client = TestClient(app)
+    expected_statuses = {
+        "/healthz": "ok",
+        "/livez": "ok",
+        "/ping": "ok",
+        "/status": "ok",
+    }
+    for path, status in expected_statuses.items():
+        resp = client.get(path)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == status
+
+
 def test_direct_asgi_import_configures_static_api_key_from_env(monkeypatch):
     """Raw uvicorn imports must honor AGENT_BOM_API_KEY without the CLI wrapper."""
     raw_key = "raw-uvicorn-static-key"
@@ -214,6 +229,30 @@ def test_api_key_middleware_blocks_without_key():
     client = TestClient(test_app)
     resp = client.get("/v1/test")
     assert resp.status_code == 401
+
+
+def test_api_key_middleware_exempts_probe_aliases_without_key():
+    """Auth middleware must not block configured liveness/status aliases."""
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    async def dummy(request):
+        return StarletteJSONResponse({"ok": True})
+
+    test_app = Starlette(
+        routes=[
+            Route("/healthz", dummy),
+            Route("/livez", dummy),
+            Route("/ping", dummy),
+            Route("/status", dummy),
+        ]
+    )
+    test_app.add_middleware(APIKeyMiddleware, api_key="test-key-123")
+
+    client = TestClient(test_app)
+    for path in ("/healthz", "/livez", "/ping", "/status"):
+        assert client.get(path).status_code == 200
 
 
 def test_api_key_middleware_exempts_cors_preflight():


### PR DESCRIPTION
## Summary
- add a literal `/v1/compliance/summary` route before the dynamic framework route so summary requests no longer resolve as an unknown framework slug
- add Kubernetes/load-balancer friendly probe aliases: `/healthz`, `/livez`, `/ping`, and `/status`
- exempt those probe aliases from API-key middleware so auth-enabled deployments can use them for liveness/status checks
- add regression coverage for the route collision and probe auth behavior

## Validation
- `uv run pytest -q tests/test_api_compliance_auth.py::test_compliance_summary_does_not_route_as_framework_slug tests/test_api_hardening.py::test_kubernetes_probe_aliases_no_auth tests/test_api_hardening.py::test_api_key_middleware_exempts_probe_aliases_without_key tests/test_api_hardening.py::test_api_key_middleware_blocks_without_key`
- pre-commit hooks on commit: ruff, ruff-format, mypy, bandit
