### PR TITLE
docs: add AI infrastructure credential boundaries

### DIFF
--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -130,6 +130,27 @@ agent-bom agents --image <lambda-workload-image> --enrich -f json
 agent-bom agents --nebius -f json -o nebius-ai-scan.json
 ```
 
+## Credential boundaries
+
+Prefer read-only credentials. A scan sees only the cloud account, project,
+workspace, namespace, registry, or local endpoint that the provided credential
+can inspect. Treat that boundary as part of the evidence.
+
+| Surface | First command | Credential boundary | Data read | Artifact |
+|---|---|---|---|---|
+| AWS AI and GPU infrastructure | `agent-bom agents --preset enterprise --aws` | AWS profile, role, or web identity scoped to read-only inventory | account, region, EKS/ECS/Lambda/IAM/S3 and AI-service metadata visible to the role | JSON/HTML findings, graph-ready cloud inventory, optional CIS evidence |
+| Azure AI surfaces | `agent-bom agents --preset enterprise --azure` | Azure identity or service principal scoped to selected subscriptions/resource groups | Azure AI, container, identity, and resource metadata visible to the principal | JSON/HTML findings and cloud inventory |
+| GCP Vertex AI and cloud resources | `agent-bom agents --preset enterprise --gcp` | ADC or service account scoped to selected projects | Vertex AI, IAM, storage, compute, and project metadata visible to the service account | JSON/HTML findings and cloud inventory |
+| Snowflake AI Data Cloud | `agent-bom agents --preset enterprise --snowflake` | Snowflake role/user scoped by warehouse, database, schema, and account grants | Cortex, warehouse, role, object, task, stream, and query metadata visible to the role | Snowflake posture evidence and compliance-ready inventory |
+| Databricks workspaces | `agent-bom agents --preset enterprise --databricks` | Databricks host/token or configured workspace identity | workspace, cluster/job, model, secret-scope names, and notebook metadata visible to the token | workspace inventory and findings |
+| Hugging Face model and registry evidence | `agent-bom agents -p . --enrich` or provider-specific scan path | public Hub access or optional token for private model metadata | model card, repository, file, license, and provenance metadata visible to the caller | model provenance and supply-chain evidence |
+| W&B, MLflow, and observability tools | `agent-bom agents -p .` plus configured provider scan | workspace/project token scoped by the provider | experiment, run, model registry, and trace metadata visible to the token | MLOps inventory and related findings |
+| Ollama and local model runtimes | `agent-bom agents --preset enterprise --ollama` | local endpoint access on the inspected host or network boundary | local model/runtime metadata exposed by the endpoint | local model runtime inventory |
+
+Scan artifacts should record credential environment variable names, role names,
+workspace identifiers, and source paths where needed for investigation; they
+should not store provider secret values.
+
 ## CI/CD integration
 
 ### GitHub Actions — GPU image gate

--- a/site-docs/architecture/ai-infrastructure.md
+++ b/site-docs/architecture/ai-infrastructure.md
@@ -56,3 +56,26 @@ command should match the system boundary you can actually inspect.
 | Databricks | `cloud/databricks.py` | — |
 | HuggingFace | `cloud/huggingface.py` | — |
 | Ollama | `cloud/ollama.py` | — |
+
+## Credential Boundaries
+
+Use read-only credentials for provider scans. A provider scan proves only the
+account, workspace, namespace, registry, or local endpoint that credential can
+inspect; it does not prove all deployed AI systems unless those systems are in
+that boundary.
+
+| Surface | First command | Credential boundary | Data read | Artifact |
+|---|---|---|---|---|
+| AWS AI and GPU infrastructure | `agent-bom agents --preset enterprise --aws` | AWS profile, role, or web identity with read-only inventory permissions | account, region, EKS/ECS/Lambda/IAM/S3 and AI-service metadata visible to the role | JSON/HTML findings, graph-ready cloud inventory, CIS evidence when enabled |
+| Azure AI surfaces | `agent-bom agents --preset enterprise --azure` | Azure identity or service principal scoped to selected subscriptions/resource groups | Azure AI, container, identity, and resource metadata visible to the principal | JSON/HTML findings and cloud inventory |
+| GCP Vertex AI and cloud resources | `agent-bom agents --preset enterprise --gcp` | ADC or service account scoped to selected projects | Vertex AI, IAM, storage, compute, and project metadata visible to the service account | JSON/HTML findings and cloud inventory |
+| Snowflake AI Data Cloud | `agent-bom agents --preset enterprise --snowflake` | Snowflake role/user scoped by warehouse, database, schema, and account grants | Cortex, warehouse, role, object, task, stream, and query metadata visible to the role | Snowflake posture evidence and compliance-ready inventory |
+| Databricks workspaces | `agent-bom agents --preset enterprise --databricks` | Databricks host/token or configured workspace identity | workspace, cluster/job, model, secret-scope names, and notebook metadata visible to the token | workspace inventory and findings |
+| Hugging Face model and registry evidence | `agent-bom agents -p . --enrich` or provider-specific scan path | public Hub access or optional token for private model metadata | model card, repository, file, license, and provenance metadata visible to the caller | model provenance and supply-chain evidence |
+| OpenAI and hosted model providers | `agent-bom agents -p .` plus provider inventory where configured | repo-local code/config and any configured read-only provider inventory token | SDK imports, model names, endpoint references, and provider-visible metadata where supported | AI inventory, provider references, and graph-ready model/service nodes |
+| W&B, MLflow, and observability tools | `agent-bom agents -p .` plus configured provider scan | workspace/project token scoped by the provider | experiment, run, model registry, and trace metadata visible to the token | MLOps inventory and related findings |
+| Ollama and local model runtimes | `agent-bom agents --preset enterprise --ollama` | local endpoint access on the inspected host or network boundary | local model/runtime metadata exposed by the endpoint | local model runtime inventory |
+
+Credential values should not be stored in scan artifacts. Outputs may include
+credential environment variable names, role names, account identifiers,
+workspace names, and source paths needed for investigation.


### PR DESCRIPTION
Summary
- add provider-by-provider credential boundary tables for AI infrastructure scans
- document first command, credential scope, data read, and artifact per provider surface
- keep the boundary honest: scan evidence only covers what the credential can inspect and does not store provider secret values

Validation
- git diff --check -- site-docs/architecture/ai-infrastructure.md docs/AI_INFRASTRUCTURE_SCANNING.md
- uv run mkdocs build --strict