### PR TITLE
test: add Terraform public storage fixture

### DIFF
--- a/tests/fixtures/iac/terraform/public-s3-bucket/main.tf
+++ b/tests/fixtures/iac/terraform/public-s3-bucket/main.tf
@@ -1,3 +1,6 @@
+# Intentionally vulnerable regression fixture.
+# Encryption does not make public object access safe; TF-SEC-002 must still
+# flag this bucket because acl = "public-read" exposes storage publicly.
 resource "aws_s3_bucket" "training_data" {
   bucket = "agent-bom-public-training-data"
   acl    = "public-read"

--- a/tests/fixtures/iac/terraform/public-s3-bucket/main.tf
+++ b/tests/fixtures/iac/terraform/public-s3-bucket/main.tf
@@ -1,0 +1,12 @@
+resource "aws_s3_bucket" "training_data" {
+  bucket = "agent-bom-public-training-data"
+  acl    = "public-read"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+}

--- a/tests/test_iac_terraform_security.py
+++ b/tests/test_iac_terraform_security.py
@@ -111,7 +111,7 @@ resource "aws_s3_bucket" "private" {
         assert finding.severity == "critical"
         assert finding.category == "terraform"
         assert finding.file_path.endswith("tests/fixtures/iac/terraform/public-s3-bucket/main.tf")
-        assert finding.line_number == 1
+        assert finding.line_number == 4
         assert "CIS-AWS-2.1.2" in finding.compliance
         assert "NIST-AC-3" in finding.compliance
         assert "Use private ACL" in finding.message

--- a/tests/test_iac_terraform_security.py
+++ b/tests/test_iac_terraform_security.py
@@ -8,6 +8,8 @@ import pytest
 
 from agent_bom.iac.terraform_security import scan_terraform_security
 
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
 
 @pytest.fixture()
 def tmp_tf(tmp_path: Path):
@@ -97,6 +99,22 @@ resource "aws_s3_bucket" "private" {
         findings = scan_terraform_security(tmp_tf(content))
         tf002 = [f for f in findings if f.rule_id == "TF-SEC-002"]
         assert len(tf002) == 0
+
+    def test_public_storage_fixture_records_actionable_evidence(self):
+        fixture = FIXTURES / "iac" / "terraform" / "public-s3-bucket" / "main.tf"
+
+        findings = scan_terraform_security(fixture)
+
+        tf002 = [f for f in findings if f.rule_id == "TF-SEC-002"]
+        assert len(tf002) == 1
+        finding = tf002[0]
+        assert finding.severity == "critical"
+        assert finding.category == "terraform"
+        assert finding.file_path.endswith("tests/fixtures/iac/terraform/public-s3-bucket/main.tf")
+        assert finding.line_number == 1
+        assert "CIS-AWS-2.1.2" in finding.compliance
+        assert "NIST-AC-3" in finding.compliance
+        assert "Use private ACL" in finding.message
 
 
 class TestSecurityGroupCIDR:


### PR DESCRIPTION
Summary
- add a reusable Terraform fixture with an encrypted but public-read S3 bucket
- assert TF-SEC-002 captures severity, compliance tags, source path, line number, and fix guidance
- keep the existing inline Terraform public ACL tests intact

Validation
- uv run pytest -q tests/test_iac_terraform_security.py::TestS3PublicACL::test_public_storage_fixture_records_actionable_evidence tests/test_iac_terraform_security.py::TestS3PublicACL::test_public_read tests/test_iac_terraform_security.py::TestTerraformCompliance::test_compliance_tags
- git diff --check -- tests/fixtures/iac/terraform/public-s3-bucket/main.tf tests/test_iac_terraform_security.py