### PR TITLE
fix: load project inventory for mcp inventory

### DIFF
--- a/src/agent_bom/cli/_inventory.py
+++ b/src/agent_bom/cli/_inventory.py
@@ -12,7 +12,7 @@ from typing import Optional
 import click
 from rich.console import Console
 
-from agent_bom.cli._common import _make_console, read_json_file_for_cli
+from agent_bom.cli._common import _build_agents_from_inventory, _make_console, read_json_file_for_cli
 from agent_bom.discovery import discover_all
 from agent_bom.inventory import _inventory_schema_path, _inventory_validator
 from agent_bom.mcp_blocklist import flag_blocklisted_mcp_servers
@@ -38,9 +38,11 @@ def inventory(config: Optional[str], project: Optional[str], transitive: bool, m
 
     discovery_stdout = redirect_stdout(StringIO()) if as_json else nullcontext()
     discovery_stderr = redirect_stderr(StringIO()) if as_json else nullcontext()
+    inventory_source: Optional[str] = None
     with discovery_stdout, discovery_stderr:
         if config:
             config_path = Path(config)
+            inventory_source = str(config_path)
             try:
                 config_data = read_json_file_for_cli(config_path, label="MCP config")
                 from agent_bom.discovery import parse_mcp_config
@@ -64,11 +66,22 @@ def inventory(config: Optional[str], project: Optional[str], transitive: bool, m
             except Exception as e:
                 raise click.ClickException(f"Error parsing MCP config {config_path}: {e}") from e
         else:
-            agents = discover_all(project_dir=project)
+            project_inventory = _project_inventory_path(project)
+            if project_inventory is not None:
+                inventory_source = str(project_inventory)
+                from agent_bom.inventory import load_inventory
+
+                try:
+                    inventory_data = load_inventory(str(project_inventory))
+                except (OSError, ValueError) as exc:
+                    raise click.ClickException(f"Error loading project inventory {project_inventory}: {exc}") from exc
+                agents = _build_agents_from_inventory(inventory_data, str(project_inventory))
+            else:
+                agents = discover_all(project_dir=project)
 
     if not agents:
         if as_json:
-            _print_inventory_json(agents, config)
+            _print_inventory_json(agents, inventory_source)
             return
         con.print("\n[yellow]No MCP configurations found.[/yellow]")
         sys.exit(0)
@@ -84,15 +97,27 @@ def inventory(config: Optional[str], project: Optional[str], transitive: bool, m
         for server in agent.mcp_servers:
             if server.security_blocked:
                 continue  # Don't extract from security-blocked servers
+            if server.packages:
+                continue
             server.packages = extract_packages(server, resolve_transitive=transitive, max_depth=max_depth)
 
     if as_json:
-        _print_inventory_json(agents, config)
+        _print_inventory_json(agents, inventory_source)
         return
 
     report = AIBOMReport(agents=agents)
     print_summary(report)
     print_agent_tree(report)
+
+
+def _project_inventory_path(project: Optional[str]) -> Path | None:
+    if not project:
+        return None
+    project_path = Path(project)
+    if not project_path.is_dir():
+        return None
+    inventory_path = project_path / "inventory.json"
+    return inventory_path if inventory_path.is_file() else None
 
 
 def _print_inventory_json(agents, config: Optional[str]) -> None:

--- a/tests/test_cli_inventory.py
+++ b/tests/test_cli_inventory.py
@@ -76,6 +76,53 @@ def test_inventory_json_with_config_reports_completeness(tmp_path):
         assert completeness["sources"][0]["status"] == "present"
 
 
+def test_inventory_prefers_project_inventory_json(tmp_path):
+    runner = CliRunner()
+    project_inventory = {
+        "schema_version": "1",
+        "generated_at": "2026-05-09T00:00:00Z",
+        "agents": [
+            {
+                "name": "operator-agent",
+                "agent_type": "custom",
+                "mcp_servers": [
+                    {
+                        "name": "declared-server",
+                        "command": "npx",
+                        "args": ["-y", "@modelcontextprotocol/server-filesystem"],
+                        "packages": [{"name": "left-pad", "version": "1.3.0", "ecosystem": "npm"}],
+                    }
+                ],
+            }
+        ],
+    }
+    (tmp_path / "inventory.json").write_text(json.dumps(project_inventory), encoding="utf-8")
+    (tmp_path / ".cursor").mkdir()
+    (tmp_path / ".cursor" / "mcp.json").write_text(
+        json.dumps({"mcpServers": {"runtime-only": {"command": "node", "args": ["server.js"]}}}),
+        encoding="utf-8",
+    )
+
+    with (
+        patch("agent_bom.cli._inventory.discover_all") as mock_discover,
+        patch("agent_bom.cli._inventory.extract_packages") as mock_extract,
+    ):
+        result = runner.invoke(inventory, ["-p", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0
+    mock_discover.assert_not_called()
+    mock_extract.assert_not_called()
+    data = json.loads(result.output)
+    assert data["summary"]["total_agents"] == 1
+    assert data["summary"]["total_mcp_servers"] == 1
+    assert data["summary"]["total_packages"] == 1
+    assert data["agents"][0]["name"] == "operator-agent"
+    server = data["agents"][0]["mcp_servers"][0]
+    assert server["name"] == "declared-server"
+    assert server["packages"][0]["name"] == "left-pad"
+    assert data["discovery_completeness"]["sources"][0]["expanded"].endswith("inventory.json")
+
+
 def test_inventory_with_bad_config(tmp_path):
     runner = CliRunner()
     config_file = tmp_path / "bad.json"


### PR DESCRIPTION
Summary
- make `agent-bom mcp inventory -p <project>` prefer `<project>/inventory.json` when present
- preserve packages declared by operator-pushed inventory instead of replacing them with runtime package extraction
- add a regression test that proves project inventory wins over local MCP config discovery for this command

Why
- the first-run sample and operator-pull flows generate `inventory.json`, but `mcp inventory -p` previously ignored that richer evidence and fell back to MCP config discovery only
- this caused declared agents/packages to disappear from MCP inventory output, weakening AI-BOM and control-plane handoff evidence

Validation
- `uv run pytest -q tests/test_cli_inventory.py::test_inventory_prefers_project_inventory_json tests/test_cli_inventory.py::test_inventory_json_with_config_reports_completeness tests/test_cli_inventory.py::test_inventory_with_agents`
- `uv run ruff check src/agent_bom/cli/_inventory.py tests/test_cli_inventory.py`
- `git diff --check`
- live smoke: `uv run agent-bom samples first-run --output /tmp/agent-bom-mcp-inventory-check` then `uv run agent-bom mcp inventory -p /tmp/agent-bom-mcp-inventory-check --json` returned 2 agents, 3 servers, 5 packages, source `inventory.json`
