### PR TITLE
fix: skip nameless AISVS distributions

### DIFF
--- a/src/agent_bom/cloud/aisvs_benchmark.py
+++ b/src/agent_bom/cloud/aisvs_benchmark.py
@@ -452,7 +452,14 @@ def _check_ai_7_1() -> CISCheckResult:
             }
         )
 
-        installed = {dist.metadata["Name"].lower() for dist in importlib.metadata.distributions()}
+        installed = set()
+        for dist in importlib.metadata.distributions():
+            try:
+                package_name = dist.metadata["Name"]
+            except KeyError:
+                continue
+            if package_name:
+                installed.add(package_name.lower())
         found_malicious = installed & {p.lower() for p in malicious_ml_packages}
 
         if found_malicious:

--- a/tests/test_aisvs_benchmark.py
+++ b/tests/test_aisvs_benchmark.py
@@ -310,6 +310,24 @@ def test_check_ai_7_1_clean_environment():
     assert result.status == CheckStatus.PASS
 
 
+def test_check_ai_7_1_skips_distributions_without_name_metadata():
+    import importlib.metadata as _meta
+
+    class NamelessDist:
+        @property
+        def metadata(self):
+            return {}
+
+    class NamedDist:
+        @property
+        def metadata(self):
+            return {"Name": "torch"}
+
+    with patch.object(_meta, "distributions", return_value=[NamelessDist(), NamedDist()]):
+        result = _check_ai_7_1()
+    assert result.status == CheckStatus.PASS
+
+
 # ---------------------------------------------------------------------------
 # run_benchmark
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary
- make the AISVS malicious-package check skip installed distributions that do not expose `Name` metadata
- add a regression test covering nameless distribution metadata alongside a normal package

Why
- Python 3.13+ warns that `dist.metadata["Name"]` can fail for malformed or partial distributions
- the check should ignore nameless distributions instead of turning the AISVS run into an error

Validation
- `uv run pytest -q tests/test_aisvs_benchmark.py::test_check_ai_7_1_skips_distributions_without_name_metadata tests/test_aisvs_benchmark.py::test_check_ai_7_1_detects_malicious_package tests/test_aisvs_benchmark.py::test_check_ai_7_1_clean_environment`
- `uv run ruff check src/agent_bom/cloud/aisvs_benchmark.py tests/test_aisvs_benchmark.py`
- `uv run mypy src/agent_bom/cloud/aisvs_benchmark.py`
- `git diff --check`
