### PR TITLE
docs: align discovery envelope contract

### DIFF
--- a/docs/DISCOVERY_ENVELOPE.md
+++ b/docs/DISCOVERY_ENVELOPE.md
@@ -1,9 +1,15 @@
 # Discovery envelope (`#2083`)
 
-The **discovery envelope** is the per-run trust contract attached to every
-`Agent` that agent-bom discovers. It records *what the scan actually did*
-this run: the scan mode, the explicit scope, the IAM/API permissions
-exercised, and whether sensitive values were redacted or never collected.
+The **discovery envelope** is the per-run trust contract attached to
+provider-backed `Agent` records when the provider supports the contract. It
+records *what the scan actually did* this run: the scan mode, the explicit
+scope, the IAM/API permissions exercised, and whether sensitive values were
+redacted or never collected.
+
+The field is intentionally optional. Generic local discovery paths and older
+persisted records can still return an `Agent` without `discovery_envelope`.
+Consumers should display the envelope when present and avoid treating a missing
+envelope as proof that discovery was unsafe.
 
 This is distinct from `discovery_provenance` (sanitized record of *where the
 asset came from*). Both can coexist on the same `Agent`:
@@ -67,9 +73,9 @@ forward-compatible producer doesn't crash an older consumer.
 
 ## Producers
 
-Every cloud / SaaS / local provider populates the envelope at the end of
-its `discover()` and attaches it to every returned `Agent` via
-`attach_envelope_to_agents(...)`. As of PR B the wired set is:
+Supported cloud / SaaS / local providers populate the envelope at the end of
+`discover()` and attach it to returned `Agent` records via
+`attach_envelope_to_agents(...)`. The current wired set is:
 
 | Provider | `scan_mode` |
 |---|---|
@@ -78,6 +84,10 @@ its `discover()` and attaches it to every returned `Agent` via
 | `azure` | `cloud_read_only` |
 | `coreweave` | `cloud_read_only` |
 | `nebius` | `cloud_read_only` |
+| `lambda_labs` | `cloud_read_only` |
+| `runpod` | `cloud_read_only` |
+| `vastai` | `cloud_read_only` |
+| `crusoe` | `cloud_read_only` |
 | `snowflake` | `saas_read_only` |
 | `databricks` | `saas_read_only` |
 | `mlflow_provider` | `saas_read_only` |
@@ -86,10 +96,12 @@ its `discover()` and attaches it to every returned `Agent` via
 | `openai_provider` | `saas_read_only` |
 | `ollama` | `local_only` |
 
-A parametric test in `tests/test_discovery_envelope.py` enforces that each
-of these providers references the canonical envelope type and uses its
-declared `ScanMode`, so a future refactor can't quietly reclass a SaaS
-provider as `cloud_read_only` (or vice versa) without the test catching it.
+Parametric tests in `tests/test_discovery_envelope.py` and
+`tests/test_discovery_envelope_lock_in.py` enforce that these providers
+reference the canonical envelope type, use their declared `ScanMode`, declare
+the expected redaction posture, and only list read-style permissions. A future
+refactor cannot quietly reclass a SaaS provider as `cloud_read_only`, skip the
+central sanitizer, or add a write permission without the tests catching it.
 
 ```python
 from agent_bom.discovery_envelope import DiscoveryEnvelope, RedactionStatus, ScanMode
@@ -118,9 +130,9 @@ TypeScript types in `ui/lib/api-types.ts` carry the canonical
 The agents page renders a `DiscoveryEnvelopeCard` on each agent's expanded
 detail view (mounted only when the envelope is present). The card shows:
 
-- a clear data-residency note ("scan ran inside your environment with
-  read-only roles, no findings are sent to agent-bom") so operators
-  understand the trust posture without reading docs,
+- a clear data-residency note explaining that provider reads run from the
+  operator's local or self-hosted deployment boundary, not from an external
+  agent-bom SaaS service,
 - `scan_mode` + `redaction_status` chips,
 - the `discovery_scope` list as compact mono-styled tags,
 - the `permissions_used` list collapsed by default with a `<details>`
@@ -156,13 +168,13 @@ verifies every module declaring `permissions_used` is also in the matrix
 table — so a new provider added in a follow-up PR-B-style change can't
 silently bypass the least-privilege check.
 
-## Roadmap
+## Merge history
 
 - **PR A (merged)** — schema + Agent model field + AWS producer + tests.
 - **PR B (merged)** — provider parity: every cloud / SaaS / local provider
   populates the envelope.
 - **PR C (merged)** — API + UI surface; envelope visible in the dashboard.
-- **PR D (this PR)** — cross-provider redaction + least-privilege lock-in
+- **PR D (merged)** — cross-provider redaction + least-privilege lock-in
   matrix.
 
-#2083 closes with PR D.
+#2083 is closed by the merged PR A-D series.

--- a/src/agent_bom/discovery_envelope.py
+++ b/src/agent_bom/discovery_envelope.py
@@ -1,4 +1,4 @@
-"""Per-run discovery envelope (#2083 PR A).
+"""Per-run discovery envelope (#2083).
 
 The envelope is the **per-run trust contract** for an Agent. It records
 *what the scan actually did* on this run: which mode it ran in, what scope
@@ -18,8 +18,9 @@ Operators running agent-bom locally, on endpoints, or inside cloud / SaaS
 infrastructure get a code-backed answer for "what did this scan do" without
 having to read the provider source.
 
-Scope (PR A): the canonical model. AWS is wired as the first producer.
-Other providers and connectors follow in subsequent PRs (#2083 series).
+Supported cloud, SaaS, and local providers attach this envelope when they
+return provider-backed Agents. Generic local discovery and older persisted
+records may not have one, so consumers must treat the field as optional.
 """
 
 from __future__ import annotations

--- a/tests/test_discovery_envelope.py
+++ b/tests/test_discovery_envelope.py
@@ -228,6 +228,10 @@ def test_attach_envelope_helper_skips_agents_with_existing_envelope() -> None:
         ("agent_bom.cloud.azure", ScanMode.CLOUD_READ_ONLY),
         ("agent_bom.cloud.coreweave", ScanMode.CLOUD_READ_ONLY),
         ("agent_bom.cloud.nebius", ScanMode.CLOUD_READ_ONLY),
+        ("agent_bom.cloud.lambda_labs", ScanMode.CLOUD_READ_ONLY),
+        ("agent_bom.cloud.runpod", ScanMode.CLOUD_READ_ONLY),
+        ("agent_bom.cloud.vastai", ScanMode.CLOUD_READ_ONLY),
+        ("agent_bom.cloud.crusoe", ScanMode.CLOUD_READ_ONLY),
         ("agent_bom.cloud.snowflake", ScanMode.SAAS_READ_ONLY),
         ("agent_bom.cloud.databricks", ScanMode.SAAS_READ_ONLY),
         ("agent_bom.cloud.mlflow_provider", ScanMode.SAAS_READ_ONLY),
@@ -238,8 +242,8 @@ def test_attach_envelope_helper_skips_agents_with_existing_envelope() -> None:
     ],
 )
 def test_provider_imports_envelope_and_attach_helper(module_path, expected_mode):
-    """Every PR-B-wired provider imports the envelope helpers + uses the
-    right ScanMode for its surface.
+    """Every envelope-wired provider imports the helpers and uses the right
+    ScanMode for its surface.
 
     Guards against regressions where a provider drops the import or quietly
     switches surfaces (e.g. SaaS reclassed as cloud_read_only).

--- a/tests/test_discovery_envelope_lock_in.py
+++ b/tests/test_discovery_envelope_lock_in.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import importlib
 import re
+from pathlib import Path
 
 import pytest
 
@@ -390,3 +391,20 @@ def test_provider_table_covers_every_wired_provider() -> None:
             assert full in declared, (
                 f"{full} declares permissions_used but is missing from the PROVIDERS table in test_discovery_envelope_lock_in.py"
             )
+
+
+def test_docs_provider_table_matches_lock_in_matrix() -> None:
+    """Keep the public provider table aligned with the enforced provider set."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    docs = (repo_root / "docs" / "DISCOVERY_ENVELOPE.md").read_text()
+    documented = {
+        match.group(1)
+        for match in re.finditer(
+            r"^\| `([^`]+)` \| `(?:cloud_read_only|saas_read_only|local_only)` \|$",
+            docs,
+            re.MULTILINE,
+        )
+    }
+    expected = {module_path.rsplit(".", 1)[-1] for module_path, _, _ in PROVIDERS}
+    assert documented == expected

--- a/ui/app/agents/page.tsx
+++ b/ui/app/agents/page.tsx
@@ -1425,7 +1425,7 @@ export default function AgentsPage() {
   );
 }
 
-// ─── Discovery envelope card (#2083 PR C) ─────────────────────────────────
+// ─── Discovery envelope card (#2083) ──────────────────────────────────────
 
 const SCAN_MODE_LABEL: Record<string, string> = {
   local_only: "local only",
@@ -1456,7 +1456,7 @@ function DiscoveryEnvelopeCard({ envelope }: { envelope: DiscoveryEnvelope }) {
         Scan trust contract
       </div>
       <p className="mb-2 text-[11px] text-emerald-200/80">
-        Scan ran inside your environment with read-only roles. No findings, inventory, or credentials are sent to agent-bom — everything stays in your deployment.
+        Scan ran from your local or self-hosted deployment boundary with read-only roles. Sensitive values are never collected or are redacted before storage.
       </p>
       <div className="mb-2 flex flex-wrap gap-1.5">
         <span className="rounded border border-emerald-800 bg-emerald-950/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-emerald-300">


### PR DESCRIPTION
## Summary
- clarify that discovery envelopes are provider-backed and optional for legacy/local records
- align the provider list with the 16-provider lock-in matrix
- add a docs/provider-table regression test so the public trust contract cannot drift behind code again
- tighten dashboard trust-copy around local/self-hosted boundaries and sensitive-value handling

## Validation
- uv run pytest -q tests/test_discovery_envelope.py tests/test_discovery_envelope_lock_in.py
- uv run ruff check src/agent_bom/discovery_envelope.py tests/test_discovery_envelope.py tests/test_discovery_envelope_lock_in.py
- uv run mkdocs build --strict
- npm run typecheck
- git diff --check