### PR TITLE
test: guard CLI error exit codes

### DIFF
--- a/tests/test_cli_inventory.py
+++ b/tests/test_cli_inventory.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
+from agent_bom.cli import main
 from agent_bom.cli._inventory import _inventory_schema_path, completions_cmd, inventory, validate, where
 
 # ---------------------------------------------------------------------------
@@ -32,6 +33,16 @@ def test_inventory_json_no_agents_includes_completeness():
         assert data["agents"] == []
         assert data["discovery_completeness"]["path_count"] >= 1
         assert "actual_server_count" in data["discovery_completeness"]
+
+
+def test_mcp_validate_invalid_json_exits_nonzero(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{bad", encoding="utf-8")
+
+    result = CliRunner().invoke(main, ["mcp", "validate", str(bad)])
+
+    assert result.exit_code != 0
+    assert "Error:" in result.output
 
 
 def test_inventory_with_agents():

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -75,6 +75,33 @@ def test_scan_help():
     assert "graph (raw graph JSON)" not in normalized
 
 
+def test_scan_external_scan_invalid_json_exits_nonzero(tmp_path):
+    inventory = {
+        "schema_version": "1",
+        "generated_at": "2026-05-09T00:00:00Z",
+        "agents": [{"name": "fixture-agent", "agent_type": "custom", "mcp_servers": []}],
+    }
+    inventory_file = tmp_path / "inventory.json"
+    inventory_file.write_text(json.dumps(inventory), encoding="utf-8")
+    bad_external_scan = tmp_path / "bad-external-scan.json"
+    bad_external_scan.write_text("{bad", encoding="utf-8")
+
+    result = _run(
+        [
+            "scan",
+            "--inventory",
+            str(inventory_file),
+            "--external-scan",
+            str(bad_external_scan),
+            "--offline",
+            "--no-auto-update-db",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "External scan error:" in result.output
+
+
 # ---------------------------------------------------------------------------
 # scan — zero-config dry run (no network, no real discovery)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a regression test that  exits non-zero when it prints an inventory JSON error
- add a regression test that  exits non-zero for invalid external scanner JSON
- locks the pre-scan trust contract that visible CLI errors are scriptable and cannot silently pass CI

## Validation
- uv run pytest -q tests/test_cli_inventory.py::test_mcp_validate_invalid_json_exits_nonzero tests/test_cli_scan.py::test_scan_external_scan_invalid_json_exits_nonzero
- uv run ruff check tests/test_cli_inventory.py tests/test_cli_scan.py
- git diff --check