### PR TITLE
fix: add ingest-only inventory boundary

### DIFF
--- a/docs/FIRST_RUN.md
+++ b/docs/FIRST_RUN.md
@@ -142,3 +142,6 @@ agent-bom agents -p .
 
 Add `--inventory <file>` when you already have agent/server inventory from a
 fleet collector, SIEM export, or manually curated source of truth.
+Add `--inventory-only` when that file is the complete evidence boundary and
+you do not want project, cwd, skill, model, dataset, or secret auto-discovery
+merged into the result.

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -187,7 +187,8 @@ Users can restrict or bypass auto-discovery entirely:
 | Flag | Effect |
 |------|--------|
 | `--dry-run` | Shows exactly which files, APIs, and data would be accessed, then exits without reading anything |
-| `--inventory <file>` | Scans only the agents/packages defined in a JSON inventory file — skips all config discovery |
+| `--inventory <file>` | Reads agents/packages from a JSON inventory file |
+| `--inventory-only` / `--no-discover` | Uses only explicit input artifacts and suppresses ambient project, cwd, skill, model, dataset, and secret discovery |
 | `--project <dir>` | Restricts discovery to MCP configs in a specific project directory (does not include machine-wide configs) |
 | `--config-dir <dir>` | Reads MCP configs from a single custom directory only |
 | `--no-skill` | Disables skill/instruction file scanning |

--- a/site-docs/deployment/data-access-boundaries.md
+++ b/site-docs/deployment/data-access-boundaries.md
@@ -95,7 +95,8 @@ Operators can narrow or disable major data paths:
 | Control | Effect |
 |---|---|
 | `agent-bom agents --dry-run` | preview planned file/API access before scanning |
-| `--inventory <file>` | scan only the provided inventory |
+| `--inventory <file>` | read agents/packages from a provided inventory |
+| `--inventory-only` / `--no-discover` | use only explicit input artifacts; suppress ambient project, cwd, skill, model, dataset, and secret discovery |
 | `--project <dir>` | restrict project-oriented discovery to the requested directory |
 | `--config-dir <dir>` | read MCP configs from one operator-selected directory |
 | `--no-scan` | inventory only; skip vulnerability lookups |
@@ -151,7 +152,7 @@ to escalate access.
 For endpoint teams, the safe rollout model is explicit and inspectable:
 
 - use MDM or an endpoint manager to run a known command
-- start with `--dry-run`, `--no-scan`, or inventory-only modes when piloting
+- start with `--dry-run`, `--no-scan`, or `--inventory-only` modes when piloting
 - scope project scans to managed developer workspaces or approved paths
 - avoid collecting unrelated home-directory content
 - push only the inventory and evidence classes the operator chooses

--- a/src/agent_bom/cli/_inventory.py
+++ b/src/agent_bom/cli/_inventory.py
@@ -163,7 +163,7 @@ def validate(inventory_file: str):
         total_servers = sum(len(a.get("mcp_servers", [])) for a in agents)
         total_packages = sum(len(s.get("packages", [])) for a in agents for s in a.get("mcp_servers", []))
         console.print(f"\n  [green]✓ Valid[/green] — {len(agents)} agent(s), {total_servers} server(s), {total_packages} package(s)")
-        console.print(f"\n  [dim]Scan with:[/dim] agent-bom scan --inventory {inventory_file}")
+        console.print(f"\n  [dim]Scan exact inventory with:[/dim] agent-bom scan --inventory {inventory_file} --inventory-only")
     else:
         console.print(f"\n  [red]✗ Invalid — {len(errors)} error(s):[/red]\n")
         for err in errors:

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -202,6 +202,7 @@ def scan(
     project: Optional[str],
     config_dir: Optional[str],
     inventory: Optional[str],
+    no_discover: bool,
     output: Optional[str],
     output_format: str,
     dry_run: bool,
@@ -580,6 +581,7 @@ def scan(
         emit_dry_run_plan(
             con,
             inventory=inventory,
+            no_discover=no_discover,
             project=project,
             config_dir=config_dir,
             code_paths=code_paths,
@@ -717,6 +719,7 @@ def scan(
         config_dir=config_dir,
         inventory=inventory,
         skill_only=skill_only,
+        no_discover=no_discover,
         dynamic_discovery=dynamic_discovery,
         dynamic_max_depth=dynamic_max_depth,
         include_processes=include_processes,
@@ -1770,7 +1773,7 @@ def scan(
 
     # ── Step 1i: Model binary file scan ─────────────────────────────
     # Auto-detect: if no --model-dirs given, check project dir for model files
-    if not skill_only and not model_dirs and project:
+    if not skill_only and not no_discover and not model_dirs and project:
         from pathlib import Path as _MPath
 
         _project_path = _MPath(project)
@@ -1837,7 +1840,7 @@ def scan(
 
     # ── Step 1k: Dataset card scan ──────────────────────────────────
     # Auto-detect: check project for dataset_info.json or .dvc files
-    if not skill_only and not dataset_dirs and project:
+    if not skill_only and not no_discover and not dataset_dirs and project:
         from pathlib import Path as _DPath
 
         _proj = _DPath(project)
@@ -1901,7 +1904,7 @@ def scan(
 
     # ── Step 1l: Training pipeline scan ──────────────────────────────
     # Auto-detect: check project for MLmodel, wandb-metadata.json, pipeline YAML
-    if not skill_only and not training_dirs and project:
+    if not skill_only and not no_discover and not training_dirs and project:
         from pathlib import Path as _TPath
 
         _tproj = _TPath(project)
@@ -1943,7 +1946,7 @@ def scan(
             con.print(f"  [yellow]⚠[/yellow] {w}")
 
     # ── Step 1m: AST source code analysis (auto-detect Python AI code) ──
-    if not skill_only and project and not dry_run:
+    if not skill_only and not no_discover and project and not dry_run:
         from pathlib import Path as _APath
 
         _aproj = _APath(project)
@@ -1971,7 +1974,7 @@ def scan(
                 pass  # AST analysis not available
 
     # ── Step 1n: Secret scanning (auto-detect in project) ──────────
-    if not skill_only and project and not dry_run:
+    if not skill_only and not no_discover and project and not dry_run:
         try:
             from agent_bom.secret_scanner import scan_secrets as _scan_secrets
 

--- a/src/agent_bom/cli/agents/_discovery.py
+++ b/src/agent_bom/cli/agents/_discovery.py
@@ -46,6 +46,7 @@ def run_local_discovery(
     config_dir: Any,
     inventory: Any,
     skill_only: bool,
+    no_discover: bool = False,
     dynamic_discovery: bool,
     dynamic_max_depth: int,
     include_processes: bool,
@@ -123,6 +124,8 @@ def run_local_discovery(
             raise click.BadParameter(str(exc), param_hint="--inventory") from exc
         ctx.agents = _build_agents_from_inventory(inventory_data, inventory)
         con.print(f"\n  [green]✓[/green] {len(ctx.agents)} agent(s) from {label}")
+    elif no_discover:
+        ctx.agents = []
     elif config_dir:
         con.print(f"\n[bold blue]Scanning config directory: {config_dir}...[/bold blue]\n")
         with con.status("[bold]Discovering agents and MCP servers...[/bold]", spinner="dots"):
@@ -158,6 +161,7 @@ def run_local_discovery(
     any_cloud = kwargs.get("_any_cloud", False)
     if (
         not skill_only
+        and not no_discover
         and not scan_prompts
         and not browser_extensions
         and not ctx.agents
@@ -350,7 +354,16 @@ def run_local_discovery(
     # Auto-detect: scan current directory for lockfiles and IaC (always, not just when no MCP)
     # Skip auto-detect when explicitly scanning images or an external SBOM — avoid mixing local
     # CWD packages (e.g. uv.lock transitive deps) with the targeted scan surface.
-    if not filesystem_paths and not project and not skill_only and not images and not image_tars and not sbom_file and not inventory:
+    if (
+        not no_discover
+        and not filesystem_paths
+        and not project
+        and not skill_only
+        and not images
+        and not image_tars
+        and not sbom_file
+        and not inventory
+    ):
         cwd = Path.cwd()
         _lockfile_patterns = [
             "requirements.txt",
@@ -371,7 +384,7 @@ def run_local_discovery(
             filesystem_paths = (str(cwd),)
             con.print(f"\n[bold blue]Auto-detected lockfiles in {cwd}[/bold blue]")
 
-    if not iac_paths and not skill_only and not images and not image_tars and not sbom_file and not inventory:
+    if not no_discover and not iac_paths and not skill_only and not images and not image_tars and not sbom_file and not inventory:
         cwd = Path(project) if project else Path.cwd()
         _auto_iac: list[str] = []
         for name in ["Dockerfile", "docker-compose.yml", "docker-compose.yaml"]:
@@ -415,7 +428,7 @@ def run_local_discovery(
 
             # Auto-discover MCP configs inside directory (VM snapshots, mounts)
             fs_dir = Path(fs_path)
-            if fs_dir.is_dir():
+            if fs_dir.is_dir() and not no_discover:
                 from agent_bom.discovery import discover_filesystem_mcps
 
                 fs_mcp_agents = discover_filesystem_mcps(fs_dir)
@@ -610,7 +623,7 @@ def run_local_discovery(
         }
 
     # Step 1d4: Project package scan
-    if not skill_only and project and not images and not code_paths and not sbom_file:
+    if not skill_only and not no_discover and project and not images and not code_paths and not sbom_file:
         from agent_bom.models import Agent, AgentType, MCPServer, ServerSurface, TransportType
         from agent_bom.parsers import scan_project_directory, summarize_project_inventory
 
@@ -728,12 +741,13 @@ def run_local_discovery(
                 skill_file_list.extend(discover_skill_files(p))
             else:
                 skill_file_list.append(p)
-        # Auto-discover skill files in project directory
-        search_dir = Path(project) if project else Path.cwd()
-        auto_skills = discover_skill_files(search_dir)
-        for sf in auto_skills:
-            if sf not in skill_file_list:
-                skill_file_list.append(sf)
+        if not no_discover:
+            # Auto-discover skill files in project directory
+            search_dir = Path(project) if project else Path.cwd()
+            auto_skills = discover_skill_files(search_dir)
+            for sf in auto_skills:
+                if sf not in skill_file_list:
+                    skill_file_list.append(sf)
 
         if skill_file_list:
             skill_result = scan_skill_files(skill_file_list)

--- a/src/agent_bom/cli/agents/_discovery.py
+++ b/src/agent_bom/cli/agents/_discovery.py
@@ -355,14 +355,9 @@ def run_local_discovery(
     # Skip auto-detect when explicitly scanning images or an external SBOM — avoid mixing local
     # CWD packages (e.g. uv.lock transitive deps) with the targeted scan surface.
     if (
-        not no_discover
-        and not filesystem_paths
-        and not project
-        and not skill_only
-        and not images
-        and not image_tars
-        and not sbom_file
+        not filesystem_paths
         and not inventory
+        and (not no_discover and not project and not skill_only and not images and not image_tars and not sbom_file)
     ):
         cwd = Path.cwd()
         _lockfile_patterns = [
@@ -384,7 +379,7 @@ def run_local_discovery(
             filesystem_paths = (str(cwd),)
             con.print(f"\n[bold blue]Auto-detected lockfiles in {cwd}[/bold blue]")
 
-    if not no_discover and not iac_paths and not skill_only and not images and not image_tars and not sbom_file and not inventory:
+    if not iac_paths and not inventory and (not no_discover and not skill_only and not images and not image_tars and not sbom_file):
         cwd = Path(project) if project else Path.cwd()
         _auto_iac: list[str] = []
         for name in ["Dockerfile", "docker-compose.yml", "docker-compose.yaml"]:

--- a/src/agent_bom/cli/agents/_preflight.py
+++ b/src/agent_bom/cli/agents/_preflight.py
@@ -41,6 +41,7 @@ def emit_dry_run_plan(
     con: Any,
     *,
     inventory: str | None,
+    no_discover: bool,
     project: str | None,
     config_dir: str | None,
     code_paths: tuple,
@@ -91,6 +92,8 @@ def emit_dry_run_plan(
         reads.append(f"  [green]Would read:[/green]   {project}  (agent configs)")
     if config_dir:
         reads.append(f"  [green]Would read:[/green]   {config_dir}  (config directory)")
+    if no_discover:
+        reads.append("  [dim]Ambient discovery:[/dim] disabled (--no-discover)")
     if not reads:
         for client, path in get_all_discovery_paths():
             reads.append(f"  [green]Would read:[/green]   {path}  ({client})")
@@ -117,7 +120,7 @@ def emit_dry_run_plan(
         reads.append(f"  [green]Would read:[/green]   {sp}  (skill/instruction file)")
     if no_skill:
         reads.append("  [dim]Skill scanning:[/dim]   disabled (--no-skill)")
-    elif not skill_paths:
+    elif not skill_paths and not no_discover:
         reads.append("  [green]Would discover:[/green] skill files (CLAUDE.md, .cursorrules, etc.)")
     if skill_only:
         reads.append("  [bold cyan]Mode:[/bold cyan]           skill-only (skipping agent/package/CVE scanning)")

--- a/src/agent_bom/cli/options_sources.py
+++ b/src/agent_bom/cli/options_sources.py
@@ -15,6 +15,17 @@ def input_options(fn):
             click.option("--config-dir", type=click.Path(exists=True), help="Custom agent config directory to scan"),
             click.option("--inventory", type=str, default=None, help="Inventory file (JSON or CSV). Use '-' for stdin."),
             click.option(
+                "--no-discover",
+                "--inventory-only",
+                "no_discover",
+                is_flag=True,
+                default=False,
+                help=(
+                    "Use only explicit input artifacts such as --inventory, --sbom, --external-scan, --image, "
+                    "or --filesystem; do not merge ambient project, cwd, skill, model, dataset, or secret discovery."
+                ),
+            ),
+            click.option(
                 "--sbom",
                 "sbom_file",
                 type=click.Path(exists=True),

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -71,6 +71,8 @@ def test_scan_help():
     assert result.exit_code == 0
     assert "--output" in result.output
     assert "--format" in result.output
+    assert "--no-discover" in result.output
+    assert "--inventory-only" in result.output
     assert "graph (Cytoscape.js graph JSON)" in normalized
     assert "graph (raw graph JSON)" not in normalized
 
@@ -207,6 +209,66 @@ def test_scan_bad_inventory_json_exits_two(tmp_path):
     assert result.exit_code == 2
     assert "Invalid value for --inventory" in result.output
     assert "Expecting property name" in result.output
+
+
+def test_scan_inventory_no_discover_does_not_merge_project_or_skill_state(tmp_path):
+    inventory = tmp_path / "inventory.json"
+    inventory.write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "generated_at": "2026-05-09T00:00:00Z",
+                "agents": [
+                    {
+                        "name": "declared-agent",
+                        "agent_type": "custom",
+                        "source": "operator_inventory",
+                        "mcp_servers": [
+                            {
+                                "name": "declared-server",
+                                "command": "python -m declared",
+                                "packages": [
+                                    {"name": "requests", "version": "2.31.0", "ecosystem": "pypi"},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "requirements.txt").write_text("flask==2.2.0\n", encoding="utf-8")
+    (project / "SKILL.md").write_text(
+        "---\nname: local-skill\n---\nRun with package flask==2.2.0.\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "report.json"
+
+    result = _run(
+        [
+            "scan",
+            "--inventory",
+            str(inventory),
+            "--project",
+            str(project),
+            "--no-discover",
+            "--no-scan",
+            "--format",
+            "json",
+            "--output",
+            str(out),
+        ]
+    )
+
+    assert result.exit_code == 0, result.output
+    report = json.loads(out.read_text(encoding="utf-8"))
+    agent_names = [agent["name"] for agent in report["agents"]]
+    assert agent_names == ["declared-agent"]
+    assert "Scanning project directory" not in result.output
+    assert "Scanning 1 skill file" not in result.output
 
 
 def test_scan_bad_ignore_file_yaml_exits_one(tmp_path):

--- a/tests/test_regression_quality.py
+++ b/tests/test_regression_quality.py
@@ -98,8 +98,9 @@ class TestInventoryIsolation:
         discovery_path = Path("src/agent_bom/cli/agents/_discovery.py")
         content = discovery_path.read_text()
 
-        # Both auto-detection blocks must check for inventory
-        lockfile_guard = re.search(r"if not filesystem_paths.*and not inventory", content)
+        # Both auto-detection blocks must check for inventory. Match across
+        # formatter-inserted line breaks so this guard tracks behavior, not style.
+        lockfile_guard = re.search(r"if\s*\(.*not filesystem_paths.*and not inventory", content, re.DOTALL)
         iac_guard = re.search(r"if not iac_paths.*and not inventory", content)
 
         assert lockfile_guard, "Lockfile auto-detection must check 'and not inventory'"


### PR DESCRIPTION
## Summary
- add --no-discover / --inventory-only so supplied inventory or artifact inputs can be scanned without ambient project, cwd, skill, model, dataset, or secret discovery
- guard project/package, skill auto-discovery, filesystem MCP discovery, model/dataset/training auto-detect, AST, and secret scan paths behind that boundary
- update dry-run and docs so the data boundary is visible to operators

## Validation
- uv run pytest -q tests/test_cli_scan.py::test_scan_help tests/test_cli_scan.py::test_scan_inventory_no_discover_does_not_merge_project_or_skill_state tests/test_cli_inventory.py::test_validate_valid_file
- uv run ruff check src/agent_bom/cli/options_sources.py src/agent_bom/cli/agents/__init__.py src/agent_bom/cli/agents/_discovery.py src/agent_bom/cli/agents/_preflight.py src/agent_bom/cli/_inventory.py tests/test_cli_scan.py
- git diff --check
- uv run mkdocs build --strict
- uv run agent-bom scan --inventory examples/first-run-ai-stack/inventory.json --inventory-only --dry-run

Note: mkdocs reports an unrelated untracked local duplicate file, site-docs/architecture/ai-bom-coverage 2.md; it is not part of this PR.