### PR TITLE
fix: restore container CVE severity mapping

### DIFF
--- a/src/agent_bom/db/lookup.py
+++ b/src/agent_bom/db/lookup.py
@@ -34,6 +34,7 @@ class LocalVuln:
     severity: str
     cvss_score: Optional[float]
     fixed_version: Optional[str]
+    cvss_vector: Optional[str] = None
     epss_probability: Optional[float] = None
     epss_percentile: Optional[float] = None
     is_kev: bool = False
@@ -139,7 +140,8 @@ def lookup_package(
         rows = conn.execute(
             """
             SELECT
-                v.id, v.summary, v.severity, v.cvss_score, v.fixed_version, v.cwe_ids, COALESCE(v.aliases, '') AS aliases, v.source,
+                v.id, v.summary, v.severity, v.cvss_score, v.cvss_vector, v.fixed_version, v.cwe_ids,
+                COALESCE(v.aliases, '') AS aliases, v.source,
                 v.published, v.modified,
                 a.ecosystem, a.package_name, a.introduced, a.fixed, a.last_affected,
                 e.probability AS epss_prob, e.percentile AS epss_pct,
@@ -170,6 +172,7 @@ def lookup_package(
                     summary=row["summary"],
                     severity=row["severity"],
                     cvss_score=row["cvss_score"],
+                    cvss_vector=row["cvss_vector"],
                     fixed_version=row["fixed_version"] or row["fixed"],
                     epss_probability=epss_prob,
                     epss_percentile=epss_pct,
@@ -347,7 +350,8 @@ def lookup_packages_batch(
             # placeholders is only "(?, ?)" repeated — no user data in the SQL string.
             query = f"""
                 SELECT
-                    v.id, v.summary, v.severity, v.cvss_score, v.fixed_version, v.cwe_ids, COALESCE(v.aliases, '') AS aliases, v.source,
+                    v.id, v.summary, v.severity, v.cvss_score, v.cvss_vector, v.fixed_version, v.cwe_ids,
+                    COALESCE(v.aliases, '') AS aliases, v.source,
                     v.published, v.modified,
                     a.ecosystem, a.package_name, a.introduced, a.fixed, a.last_affected,
                     e.probability AS epss_prob, e.percentile AS epss_pct,
@@ -389,6 +393,7 @@ def lookup_packages_batch(
                         summary=row["summary"],
                         severity=row["severity"],
                         cvss_score=row["cvss_score"],
+                        cvss_vector=row["cvss_vector"],
                         fixed_version=row["fixed_version"] or row["fixed"],
                         epss_probability=epss_prob,
                         epss_percentile=epss_pct,

--- a/src/agent_bom/db/sync.py
+++ b/src/agent_bom/db/sync.py
@@ -27,8 +27,10 @@ import sqlite3
 import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 from urllib.parse import urljoin, urlparse
+
+from agent_bom.scanners.risk import parse_cvss_vector
 
 _logger = logging.getLogger(__name__)
 
@@ -158,6 +160,52 @@ def _cvss_to_severity(score: Optional[float]) -> str:
     return "unknown"
 
 
+def _normalize_sync_cvss_score(value: Any) -> Optional[float]:
+    """Extract a 0-10 CVSS score from numeric fields or vector strings."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        score = float(value)
+        return score if 0.0 <= score <= 10.0 else None
+    if isinstance(value, str):
+        try:
+            score = float(value)
+            return score if 0.0 <= score <= 10.0 else None
+        except ValueError:
+            return parse_cvss_vector(value)
+    if isinstance(value, dict):
+        for key in ("score", "baseScore", "base_score", "cvss", "vector", "vectorString"):
+            nested_score = _normalize_sync_cvss_score(value.get(key))
+            if nested_score is not None:
+                return nested_score
+    if isinstance(value, list):
+        scores = [_normalize_sync_cvss_score(item) for item in value]
+        valid_scores = [score for score in scores if score is not None]
+        if valid_scores:
+            return max(valid_scores)
+    return None
+
+
+def _normalize_sync_severity_label(value: Any) -> Optional[str]:
+    """Normalize distro/vendor severity labels to DB severity strings."""
+    if value is None:
+        return None
+    label = str(value).strip().replace("-", "_").replace(" ", "_").upper()
+    mapping = {
+        "CRITICAL": "critical",
+        "HIGH": "high",
+        "IMPORTANT": "high",
+        "MODERATE": "medium",
+        "MEDIUM": "medium",
+        "LOW": "low",
+        "MINOR": "low",
+        "NEGLIGIBLE": "low",
+        "UNIMPORTANT": "low",
+        "NONE": "none",
+    }
+    return mapping.get(label)
+
+
 def _now_utc() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -190,39 +238,30 @@ def _parse_osv_entry(data: dict) -> Optional[tuple[dict, list[dict]]]:
     for sev in data.get("severity", []):
         sev_type = sev.get("type", "")
         sev_score = sev.get("score", "")
-        if sev_type in ("CVSS_V3", "CVSS_V4") and sev_score:
+        if sev_type in ("CVSS_V3", "CVSS_V3_1", "CVSS_V4") and sev_score:
             cvss_vector = sev_score
-            # Extract base score from CVSS vector string (e.g. "CVSS:3.1/AV:N/AC:L/...")
             if cvss_score is None:
-                import re
-
-                m = re.search(r"/AV:[NALP]/AC:[LH]", sev_score)
-                if m and sev_score.startswith("CVSS:"):
-                    # Parse base score from vector using cvss lib or approximate
-                    _parts = sev_score.split("/")
-                    # Simple heuristic: count High-impact metrics
-                    _high = sum(1 for p in _parts if p.endswith(":H") or p.endswith(":N") and "UI" in p)
-                    # For accuracy, prefer database_specific score below
+                cvss_score = _normalize_sync_cvss_score(sev_score)
 
     # Pull from database_specific (most reliable source for severity + score)
     db_specific = data.get("database_specific", {})
     if isinstance(db_specific, dict):
         # Severity string (CRITICAL, HIGH, etc.)
-        raw_sev = db_specific.get("severity", "")
-        if isinstance(raw_sev, str) and raw_sev.upper() in ("CRITICAL", "HIGH", "MEDIUM", "LOW"):
-            db_severity = raw_sev.upper()
+        db_severity = _normalize_sync_severity_label(db_specific.get("severity"))
 
-        # Numeric CVSS score
-        raw_cvss = db_specific.get("cvss") or db_specific.get("cvss_score")
-        if raw_cvss is not None:
-            try:
-                cvss_score = float(raw_cvss)
-            except (ValueError, TypeError):
-                pass
+        # Numeric CVSS score or CVSS vector, depending on source.
+        for key in ("cvss", "cvss_score", "cvss_v3", "severity_vectors"):
+            raw_cvss = db_specific.get(key)
+            parsed_score = _normalize_sync_cvss_score(raw_cvss)
+            if parsed_score is not None:
+                cvss_score = parsed_score
+                if cvss_vector is None and isinstance(raw_cvss, str) and raw_cvss.startswith("CVSS:"):
+                    cvss_vector = raw_cvss
+                break
 
     # Determine severity: prefer database_specific string, then derive from CVSS
     if db_severity:
-        severity = db_severity.lower()
+        severity = db_severity
     elif cvss_score is not None:
         severity = _cvss_to_severity(cvss_score)
     else:
@@ -732,13 +771,10 @@ def _ingest_ghsa_advisory(
     cvss_vector: Optional[str] = None
     cvss_obj = advisory.get("cvss") or {}
     if cvss_obj:
-        raw_score = cvss_obj.get("score")
-        if raw_score is not None:
-            try:
-                cvss_score = float(raw_score)
-            except (TypeError, ValueError):
-                pass
         cvss_vector = cvss_obj.get("vector_string")
+        cvss_score = _normalize_sync_cvss_score(cvss_obj.get("score"))
+        if cvss_score is None:
+            cvss_score = _normalize_sync_cvss_score(cvss_vector)
 
     # If CVSS score present but severity not, derive it
     if severity == "unknown" and cvss_score is not None:

--- a/src/agent_bom/image.py
+++ b/src/agent_bom/image.py
@@ -36,6 +36,7 @@ from typing import Optional
 
 from agent_bom.models import Package, PermissionProfile, Severity, Vulnerability
 from agent_bom.sbom import parse_cyclonedx
+from agent_bom.scanners.risk import cvss_to_severity, severity_from_label
 from agent_bom.security import validate_image_ref
 
 _logger = logging.getLogger(__name__)
@@ -161,12 +162,6 @@ def _scan_with_grype(
         if not vuln_id:
             continue
 
-        raw_sev = vuln_data.get("severity", "unknown").upper()
-        try:
-            severity = Severity[raw_sev]
-        except KeyError:
-            severity = Severity.NONE
-
         # Extract CVSS score from Grype's cvss array
         cvss_score: Optional[float] = None
         for cvss in vuln_data.get("cvss", []):
@@ -175,6 +170,9 @@ def _scan_with_grype(
             if score is not None:
                 cvss_score = float(score)
                 break
+        severity = severity_from_label(vuln_data.get("severity"))
+        if severity == Severity.UNKNOWN and cvss_score is not None:
+            severity = cvss_to_severity(cvss_score)
 
         # Fixed version
         fix_info = vuln_data.get("fix", {})

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -68,6 +68,7 @@ from agent_bom.scanners.risk import (
     cvss_to_severity,
     parse_cvss_vector,
     parse_osv_severity,
+    severity_from_label,
 )
 from agent_bom.scanners.state import (
     _bump_scan_perf,
@@ -503,14 +504,15 @@ def _local_vuln_to_vulnerability(lv: "Any") -> Vulnerability:
 
     Canonicalizes ID to CVE when available (prefer CVE-xxxx over GHSA/PYSEC).
     """
-    sev_map = {
-        "critical": Severity.CRITICAL,
-        "high": Severity.HIGH,
-        "medium": Severity.MEDIUM,
-        "low": Severity.LOW,
-    }
-    severity = sev_map.get((lv.severity or "").lower(), Severity.UNKNOWN)
+    severity = severity_from_label(getattr(lv, "severity", None))
     severity_source = None
+    cvss_score = getattr(lv, "cvss_score", None)
+    cvss_vector = getattr(lv, "cvss_vector", None)
+    if cvss_score is None and isinstance(cvss_vector, str) and cvss_vector:
+        cvss_score = parse_cvss_vector(cvss_vector)
+    if severity == Severity.UNKNOWN and cvss_score is not None:
+        severity = cvss_to_severity(cvss_score)
+        severity_source = "cvss"
 
     # Canonicalize: prefer CVE ID over GHSA/PYSEC for consistency with Trivy/NVD
     raw_id = lv.id
@@ -539,7 +541,7 @@ def _local_vuln_to_vulnerability(lv: "Any") -> Vulnerability:
         summary=lv.summary or "No description available",
         severity=severity,
         severity_source=severity_source,
-        cvss_score=lv.cvss_score,
+        cvss_score=cvss_score,
         fixed_version=lv.fixed_version if _is_valid_fix_version(lv.fixed_version or "") else None,
         epss_score=lv.epss_probability,
         epss_percentile=lv.epss_percentile,

--- a/src/agent_bom/scanners/risk.py
+++ b/src/agent_bom/scanners/risk.py
@@ -8,13 +8,33 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Optional, cast
+from typing import Any, Optional, cast
 
 from agent_bom.models import Severity
 
 _logger = logging.getLogger(__name__)
 
 _OSV_MEDIUM_FALLBACK_PREFIXES = ("OSV-", "PYSEC-", "RUSTSEC-", "GO-", "MAL-", "GSD-")
+_SEVERITY_LABELS = {
+    "CRITICAL": Severity.CRITICAL,
+    "HIGH": Severity.HIGH,
+    "IMPORTANT": Severity.HIGH,
+    "MODERATE": Severity.MEDIUM,
+    "MEDIUM": Severity.MEDIUM,
+    "LOW": Severity.LOW,
+    "MINOR": Severity.LOW,
+    "NEGLIGIBLE": Severity.LOW,
+    "UNIMPORTANT": Severity.LOW,
+    "NONE": Severity.NONE,
+}
+
+
+def severity_from_label(raw: Any) -> Severity:
+    """Normalize scanner/vendor severity labels without inflating unknown data."""
+    if raw is None:
+        return Severity.UNKNOWN
+    normalized = str(raw).strip().replace("-", "_").replace(" ", "_").upper()
+    return _SEVERITY_LABELS.get(normalized, Severity.UNKNOWN)
 
 
 def advisory_id_severity_fallback(advisory_id: str) -> tuple[Severity, Optional[str]]:
@@ -150,6 +170,43 @@ def parse_cvss_vector(vector: str) -> Optional[float]:
         return None
 
 
+def _normalize_cvss_score(value: Any) -> Optional[float]:
+    """Extract a 0-10 CVSS score from common OSV/vendor record shapes."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        score = float(value)
+        return score if 0.0 <= score <= 10.0 else None
+    if isinstance(value, str):
+        try:
+            score = float(value)
+            return score if 0.0 <= score <= 10.0 else None
+        except ValueError:
+            computed = parse_cvss_vector(value)
+            return computed if computed is not None and 0.0 <= computed <= 10.0 else None
+    if isinstance(value, dict):
+        for key in ("score", "baseScore", "base_score", "cvss", "vector", "vectorString"):
+            nested_score = _normalize_cvss_score(value.get(key))
+            if nested_score is not None:
+                return nested_score
+    if isinstance(value, list):
+        scores = [_normalize_cvss_score(item) for item in value]
+        valid_scores = [score for score in scores if score is not None]
+        if valid_scores:
+            return max(valid_scores)
+    return None
+
+
+def _first_vendor_severity(*blocks: Any) -> tuple[Severity, Optional[str]]:
+    for source, block in blocks:
+        if not isinstance(block, dict):
+            continue
+        severity = severity_from_label(block.get("severity"))
+        if severity != Severity.UNKNOWN:
+            return severity, source
+    return Severity.UNKNOWN, None
+
+
 def parse_osv_severity(vuln_data: dict) -> tuple[Severity, Optional[float], Optional[str]]:
     """Extract severity, CVSS score, and severity source from OSV data."""
     cvss_score = None
@@ -158,30 +215,42 @@ def parse_osv_severity(vuln_data: dict) -> tuple[Severity, Optional[float], Opti
 
     for sev in vuln_data.get("severity", []):
         if sev.get("type") in ("CVSS_V3", "CVSS_V3_1", "CVSS_V4"):
-            score_str = sev.get("score", "")
-            try:
-                parsed = float(score_str)
-                if 0.0 <= parsed <= 10.0:
-                    cvss_score = parsed
-            except ValueError:
-                computed = parse_cvss_vector(score_str)
-                if computed is not None and 0.0 <= computed <= 10.0:
-                    cvss_score = computed
+            score = _normalize_cvss_score(sev.get("score"))
+            if score is not None:
+                cvss_score = score
 
     db_specific = vuln_data.get("database_specific", {})
-    if "severity" in db_specific:
-        sev_str = db_specific["severity"].upper()
-        severity_map = {
-            "CRITICAL": Severity.CRITICAL,
-            "HIGH": Severity.HIGH,
-            "MODERATE": Severity.MEDIUM,
-            "MEDIUM": Severity.MEDIUM,
-            "LOW": Severity.LOW,
-        }
-        resolved = severity_map.get(sev_str, Severity.UNKNOWN)
-        if resolved != Severity.UNKNOWN:
-            severity = resolved
-            severity_source = "osv_database"
+    severity, severity_source = _first_vendor_severity(("osv_database", db_specific))
+
+    if cvss_score is None and isinstance(db_specific, dict):
+        for key in ("cvss", "cvss_score", "cvss_v3", "severity_vectors"):
+            score = _normalize_cvss_score(db_specific.get(key))
+            if score is not None:
+                cvss_score = score
+                break
+
+    if cvss_score is None:
+        score = _normalize_cvss_score(vuln_data.get("severity_vectors"))
+        if score is not None:
+            cvss_score = score
+
+    if cvss_score is None:
+        for affected in vuln_data.get("affected", []):
+            if not isinstance(affected, dict):
+                continue
+            for block_name in ("database_specific", "ecosystem_specific"):
+                block = affected.get(block_name)
+                if not isinstance(block, dict):
+                    continue
+                for key in ("cvss", "cvss_score", "cvss_v3", "severity_vectors"):
+                    score = _normalize_cvss_score(block.get(key))
+                    if score is not None:
+                        cvss_score = score
+                        break
+                if cvss_score is not None:
+                    break
+            if cvss_score is not None:
+                break
 
     if cvss_score is not None:
         severity = cvss_to_severity(cvss_score)
@@ -189,19 +258,18 @@ def parse_osv_severity(vuln_data: dict) -> tuple[Severity, Optional[float], Opti
 
     if severity == Severity.UNKNOWN:
         eco_specific = vuln_data.get("ecosystem_specific", {})
-        if isinstance(eco_specific, dict) and "severity" in eco_specific:
-            sev_str = str(eco_specific["severity"]).upper()
-            severity_map = {
-                "CRITICAL": Severity.CRITICAL,
-                "HIGH": Severity.HIGH,
-                "MODERATE": Severity.MEDIUM,
-                "MEDIUM": Severity.MEDIUM,
-                "LOW": Severity.LOW,
-            }
-            resolved = severity_map.get(sev_str, severity)
-            if resolved != Severity.UNKNOWN:
-                severity = resolved
-                severity_source = "osv_ecosystem"
+        severity, severity_source = _first_vendor_severity(("osv_ecosystem", eco_specific))
+
+    if severity == Severity.UNKNOWN:
+        for affected in vuln_data.get("affected", []):
+            if not isinstance(affected, dict):
+                continue
+            severity, severity_source = _first_vendor_severity(
+                ("osv_affected_database", affected.get("database_specific")),
+                ("osv_affected_ecosystem", affected.get("ecosystem_specific")),
+            )
+            if severity != Severity.UNKNOWN:
+                break
 
     if severity == Severity.UNKNOWN:
         advisory_id = str(vuln_data.get("id", "")).upper()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2354,6 +2354,7 @@ def test_grype_scan_mock(monkeypatch, tmp_path):
     assert len(pkgs[0].vulnerabilities) == 1
     vuln = pkgs[0].vulnerabilities[0]
     assert vuln.id == "CVE-2023-32681"
+    assert vuln.severity == Severity.MEDIUM
     assert vuln.cvss_score == 6.1
     assert vuln.fixed_version == "2.31.0"
 

--- a/tests/test_local_db_scan.py
+++ b/tests/test_local_db_scan.py
@@ -29,6 +29,7 @@ def _make_local_vuln(vuln_id: str = "CVE-2024-1111", severity: str = "high", cvs
     lv.summary = f"Test vuln {vuln_id}"
     lv.severity = severity
     lv.cvss_score = cvss
+    lv.cvss_vector = None
     lv.fixed_version = "2.32.0"
     lv.epss_probability = 0.12
     lv.epss_percentile = 0.75
@@ -60,6 +61,17 @@ def test_local_vuln_to_vulnerability_unknown_severity():
     lv = _make_local_vuln(severity="", cvss=None)
     v = _local_vuln_to_vulnerability(lv)
     assert v.severity == Severity.UNKNOWN  # unknown severity must not silently inflate to MEDIUM
+
+
+def test_local_vuln_to_vulnerability_derives_severity_from_cvss_vector():
+    from agent_bom.scanners import _local_vuln_to_vulnerability
+
+    lv = _make_local_vuln(vuln_id="DEBIAN-CVE-2014-6271", severity="unknown", cvss=None)
+    lv.cvss_vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    v = _local_vuln_to_vulnerability(lv)
+    assert v.severity == Severity.CRITICAL
+    assert v.severity_source == "cvss"
+    assert v.cvss_score == 9.8
 
 
 def test_local_vuln_to_vulnerability_osv_id_without_score_uses_medium_fallback():

--- a/tests/test_local_vuln_db.py
+++ b/tests/test_local_vuln_db.py
@@ -687,6 +687,37 @@ def test_parse_osv_entry_with_cvss_severity_type():
     assert vuln_row["cvss_vector"] is not None
 
 
+def test_parse_osv_entry_derives_cvss_score_from_vector():
+    data = {
+        "id": "DEBIAN-CVE-2014-6271",
+        "summary": "CVSS vector test",
+        "published": "2024-01-01T00:00:00Z",
+        "modified": "2024-01-02T00:00:00Z",
+        "severity": [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}],
+        "affected": [],
+    }
+    result = _parse_osv_entry(data)
+    assert result is not None
+    vuln_row, _ = result
+    assert vuln_row["cvss_score"] == pytest.approx(9.8)
+    assert vuln_row["severity"] == "critical"
+
+
+def test_parse_osv_entry_normalizes_debian_important_severity():
+    data = {
+        "id": "DEBIAN-CVE-2024-0001",
+        "summary": "Debian important advisory",
+        "published": "2024-01-01T00:00:00Z",
+        "modified": "2024-01-02T00:00:00Z",
+        "database_specific": {"severity": "important"},
+        "affected": [],
+    }
+    result = _parse_osv_entry(data)
+    assert result is not None
+    vuln_row, _ = result
+    assert vuln_row["severity"] == "high"
+
+
 def test_parse_alpine_secfix_tokens_splits_compound_entries():
     assert _parse_alpine_secfix_tokens("CVE-2022-42333 CVE-2022-43334 XSA-428") == [
         "CVE-2022-42333",

--- a/tests/test_scanners.py
+++ b/tests/test_scanners.py
@@ -219,6 +219,38 @@ def test_parse_osv_severity_moderate():
     assert sev == Severity.MEDIUM
 
 
+def test_parse_osv_severity_debian_affected_vendor_severity():
+    vuln = {
+        "id": "DEBIAN-CVE-2024-0001",
+        "affected": [
+            {
+                "package": {"ecosystem": "Debian:12", "name": "openssl"},
+                "database_specific": {"severity": "important"},
+            }
+        ],
+    }
+    sev, score, sev_src = parse_osv_severity(vuln)
+    assert sev == Severity.HIGH
+    assert score is None
+    assert sev_src == "osv_affected_database"
+
+
+def test_parse_osv_severity_affected_cvss_vector():
+    vuln = {
+        "id": "DEBIAN-CVE-2024-0002",
+        "affected": [
+            {
+                "package": {"ecosystem": "Debian:12", "name": "bash"},
+                "ecosystem_specific": {"severity_vectors": ["CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"]},
+            }
+        ],
+    }
+    sev, score, sev_src = parse_osv_severity(vuln)
+    assert sev == Severity.CRITICAL
+    assert score is not None
+    assert sev_src == "cvss"
+
+
 def test_parse_osv_severity_no_data():
     sev, score, _sev_src = parse_osv_severity({})
     assert sev == Severity.UNKNOWN  # no data must not inflate to MEDIUM


### PR DESCRIPTION
Summary
- carry CVSS vectors through local vulnerability DB lookup so offline/container scans can derive severity from stored vectors
- normalize vendor severity labels such as Debian important/moderate without inflating missing data
- teach DB sync and Grype parsing to parse CVSS vector/string score shapes consistently

Validation
- uv run pytest -q tests/test_local_db_scan.py tests/test_local_vuln_db.py tests/test_scanners.py tests/test_external_scanners.py tests/test_core.py::test_grype_scan_mock tests/test_core.py::test_local_vuln_conversion_preserves_publish_dates
- uv run ruff check src/agent_bom/db/lookup.py src/agent_bom/scanners/__init__.py src/agent_bom/db/sync.py src/agent_bom/scanners/risk.py src/agent_bom/image.py tests/test_local_db_scan.py tests/test_local_vuln_db.py tests/test_scanners.py tests/test_core.py
- git diff --check
- uv run agent-bom image nginx:1.21 -f json -o <tmp> --quiet -> 2257 findings; severity distribution: 190 critical, 566 high, 589 medium, 88 low, 824 unknown (previously 2257 unknown)
