### PR TITLE
fix: make inventory round trips idempotent

### DIFF
--- a/src/agent_bom/asset_provenance.py
+++ b/src/agent_bom/asset_provenance.py
@@ -165,6 +165,12 @@ def sanitize_discovery_provenance(value: Any, defaults: dict[str, Any] | None = 
         if raw.get(field_name) is not None:
             result[field_name] = bool(raw.get(field_name))
 
+    version_provenance = raw.get("version_provenance")
+    if isinstance(version_provenance, dict):
+        sanitized_version_provenance = _sanitize_version_provenance(version_provenance)
+        if sanitized_version_provenance:
+            result["version_provenance"] = sanitized_version_provenance
+
     return {key: val for key, val in result.items() if val not in (None, "", [])}
 
 

--- a/src/agent_bom/inventory.py
+++ b/src/agent_bom/inventory.py
@@ -106,6 +106,12 @@ def _validate_inventory_payload(data: Any) -> dict[str, Any]:
     if not isinstance(data, dict):
         raise ValueError("Inventory JSON root must be an object with an 'agents' array")
 
+    if "inventory_snapshot" in data and "document_type" in data:
+        snapshot = data.get("inventory_snapshot")
+        if not isinstance(snapshot, dict):
+            raise ValueError("Inventory snapshot in scan report must be an object")
+        data = snapshot
+
     errors = sorted(_inventory_validator().iter_errors(data), key=lambda e: list(e.path))
     if errors:
         first = errors[0]

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -671,7 +671,6 @@ def _build_inventory_snapshot(report: AIBOMReport) -> dict:
 
     return {
         "schema_version": "1",
-        "source": "agent-bom",
         "generated_at": report.generated_at.isoformat(),
         "agents": agents,
     }

--- a/src/agent_bom/security.py
+++ b/src/agent_bom/security.py
@@ -426,6 +426,8 @@ def _key_looks_like_cloud_identity(key: object) -> bool:
 def sanitize_path_label(value: object) -> str:
     """Return a non-revealing label for local filesystem paths."""
     text = sanitize_log_label(value, max_len=1000)
+    if re.fullmatch(r"<path:[^<>]+>", text):
+        return text
     basename = re.split(r"[\\/]+", text.rstrip("/\\"))[-1] if text else ""
     basename = sanitize_text(basename or "path", max_len=80)
     if not basename or _key_looks_sensitive(basename) or _looks_sensitive_value(basename):

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -298,6 +298,105 @@ def test_scan_inventory_no_discover_does_not_merge_project_or_skill_state(tmp_pa
     assert "Scanning 1 skill file" not in result.output
 
 
+def test_scan_inventory_only_round_trips_scan_report_snapshot_without_accretion(tmp_path):
+    inventory = tmp_path / "inventory.json"
+    inventory.write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "generated_at": "2026-05-09T00:00:00Z",
+                "agents": [
+                    {
+                        "name": "declared-agent",
+                        "agent_type": "custom",
+                        "config_path": "<path:mcp.json>",
+                        "mcp_servers": [
+                            {
+                                "name": "declared-server",
+                                "command": "python",
+                                "config_path": "<path:mcp.json>",
+                                "security_intelligence": [
+                                    {
+                                        "entry_id": "MCP-TEST-1",
+                                        "title": "Fixture intelligence",
+                                        "severity": "high",
+                                        "confidence": "heuristic",
+                                        "default_recommendation": "review",
+                                        "source_type": "heuristic",
+                                        "source": "fixture",
+                                        "match_type": "package",
+                                        "matched_value": "declared-server",
+                                    }
+                                ],
+                                "packages": [
+                                    {
+                                        "name": "requests",
+                                        "version": "2.31.0",
+                                        "ecosystem": "pypi",
+                                        "discovery_provenance": {
+                                            "source_type": "operator_pushed_inventory",
+                                            "version_provenance": {
+                                                "version_source": "lockfile",
+                                                "confidence": "high",
+                                                "evidence": [{"package_path": "<path:mcp.json>"}],
+                                            },
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+
+    first_result = _run(
+        [
+            "scan",
+            "--inventory",
+            str(inventory),
+            "--inventory-only",
+            "--no-scan",
+            "--format",
+            "json",
+            "--output",
+            str(first),
+        ]
+    )
+    second_result = _run(
+        [
+            "scan",
+            "--inventory",
+            str(first),
+            "--inventory-only",
+            "--no-scan",
+            "--format",
+            "json",
+            "--output",
+            str(second),
+        ]
+    )
+
+    assert first_result.exit_code == 0, first_result.output
+    assert second_result.exit_code == 0, second_result.output
+
+    first_snapshot = json.loads(first.read_text(encoding="utf-8"))["inventory_snapshot"]
+    second_snapshot = json.loads(second.read_text(encoding="utf-8"))["inventory_snapshot"]
+    first_snapshot.pop("generated_at", None)
+    second_snapshot.pop("generated_at", None)
+
+    assert first_snapshot == second_snapshot
+    server = second_snapshot["agents"][0]["mcp_servers"][0]
+    assert server["config_path"] == "<path:mcp.json>"
+    assert "collector" not in server["security_intelligence"][0]
+    evidence = server["packages"][0]["discovery_provenance"]["version_provenance"]["evidence"]
+    assert evidence == [{"package_path": "<path:mcp.json>"}]
+
+
 def test_scan_bad_ignore_file_yaml_exits_one(tmp_path):
     ignore_file = tmp_path / ".agent-bom-ignore.yaml"
     ignore_file.write_text("ignores:\n  - id: [unterminated\n", encoding="utf-8")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -16,6 +16,7 @@ from agent_bom.security import (
     sanitize_env_vars,
     sanitize_error,
     sanitize_log_label,
+    sanitize_path_label,
     sanitize_url,
     validate_arguments,
     validate_command,
@@ -215,6 +216,10 @@ def test_sanitize_command_args_redacts_secret_values_and_urls():
 
 def test_sanitize_url_strips_credentials_query_and_fragment():
     assert sanitize_url("https://user:pass@example.com/path?token=secret#frag") == "https://example.com/path"
+
+
+def test_sanitize_path_label_is_idempotent_for_existing_safe_labels():
+    assert sanitize_path_label("<path:mcp.json>") == "<path:mcp.json>"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- allow `--inventory` to accept a prior `agent-bom scan --format json` report by extracting its `inventory_snapshot`
- make sanitized `<path:...>` labels idempotent so inventory round-trips do not nest path redaction wrappers
- preserve nested package `version_provenance` during inventory ingestion and stop generated snapshots from adding a synthetic top-level source that accretes on reuse

## Validation
- `uv run pytest -q tests/test_security.py::test_sanitize_path_label_is_idempotent_for_existing_safe_labels tests/test_cli_scan.py::test_scan_inventory_only_round_trips_scan_report_snapshot_without_accretion tests/test_output_formats.py::test_json_inventory_snapshot_round_trips_through_inventory_schema`
- `uv run ruff check src/agent_bom/security.py src/agent_bom/asset_provenance.py src/agent_bom/inventory.py src/agent_bom/output/json_fmt.py tests/test_security.py tests/test_cli_scan.py`
- `git diff --check`
- commit hooks: ruff, ruff-format, mypy, bandit, env-var drift
