### PR TITLE
fix: use daily vuln db freshness

### DIFF
--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -505,7 +505,7 @@ def _run_scan_sync(job: ScanJob) -> None:
 
                 source_list = [s.strip() for s in req.db_sources.split(",") if s.strip()] if req.db_sources else None
                 freshness = db_freshness_days()
-                if freshness is None or freshness > 7 or source_list:
+                if freshness is None or freshness >= 1 or source_list:
                     sync_db(sources=source_list)
             except Exception as db_exc:  # noqa: BLE001
                 _logger.warning("API auto DB refresh failed: %s", sanitize_error(db_exc))

--- a/src/agent_bom/cli/_db.py
+++ b/src/agent_bom/cli/_db.py
@@ -142,10 +142,10 @@ def db_status(db_path: str | None) -> None:
         age = db_freshness_days(db_file)
         if age is None:
             freshness_msg = "[yellow]Never synced — run agent-bom db update[/yellow]"
-        elif age <= 7:
+        elif age < 1:
             freshness_msg = f"[green]Fresh ({age}d ago)[/green]"
-        elif age <= 14:
-            freshness_msg = f"[yellow]Aging ({age}d ago) — consider running db update[/yellow]"
+        elif age <= 7:
+            freshness_msg = f"[yellow]Aging ({age}d ago) — run agent-bom db update for daily security freshness[/yellow]"
         else:
             freshness_msg = f"[red]Stale ({age}d ago) — run agent-bom db update[/red]"
         con.print(f"  Freshness       : {freshness_msg}")

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -568,7 +568,7 @@ def scan(
 
         freshness = db_freshness_days()
         source_list = [s.strip() for s in db_sources.split(",")] if db_sources else None
-        if freshness is None or freshness > 7 or source_list:
+        if freshness is None or freshness >= 1 or source_list:
             if not quiet and not no_scan:
                 src_msg = f" (sources: {', '.join(source_list)})" if source_list else ""
                 con.print(f"[dim]Refreshing local vuln DB{src_msg} …[/dim]")
@@ -637,18 +637,18 @@ def scan(
                         "Falling back to OSV API (slower). "
                         "Run [bold]agent-bom db update[/bold] to build a local cache."
                     )
-            elif _db_age > 14:
+            elif _db_age > 7:
                 if not quiet:
                     con.print(
                         f"[red]⚠ Local vulnerability DB is {_db_age} days old.[/red] "
                         "Scan results may be incomplete. "
                         "Run [bold]agent-bom db update[/bold] before scanning."
                     )
-            elif _db_age > 7:
+            elif _db_age >= 1:
                 if not quiet:
                     con.print(
                         f"[yellow]⚠ Local vulnerability DB is {_db_age} days old.[/yellow] "
-                        "Consider running [bold]agent-bom db update[/bold]."
+                        "Run [bold]agent-bom db update[/bold] for daily security freshness."
                     )
         except Exception:
             pass  # Never block a scan due to freshness check failure

--- a/src/agent_bom/cli/options_sources.py
+++ b/src/agent_bom/cli/options_sources.py
@@ -272,7 +272,7 @@ def enrichment_options(fn):
                 default=True,
                 envvar="AGENT_BOM_AUTO_UPDATE_DB",
                 show_default=True,
-                help="Auto-refresh local vuln DB if stale (>7 days). --no-auto-update-db to disable.",
+                help="Auto-refresh local vuln DB when older than the daily freshness target. --no-auto-update-db to disable.",
             ),
             click.option(
                 "--db-source",

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -413,7 +413,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
         ] = None,
         auto_update_db: Annotated[
             bool,
-            Field(description="Explicitly refresh the local vuln DB if stale (>7 days) before scanning."),
+            Field(description="Explicitly refresh the local vuln DB when older than the daily freshness target before scanning."),
         ] = False,
         db_sources: Annotated[
             str | None,

--- a/src/agent_bom/mcp_tools/scanning.py
+++ b/src/agent_bom/mcp_tools/scanning.py
@@ -55,7 +55,7 @@ async def scan_impl(
 
                 freshness = db_freshness_days()
                 source_list = [s.strip() for s in db_sources.split(",")] if db_sources else None
-                if freshness is None or freshness > 7 or source_list:
+                if freshness is None or freshness >= 1 or source_list:
                     sync_db(sources=source_list)
             except Exception as exc:
                 logger.warning("Auto DB refresh failed: %s", exc)

--- a/tests/test_auto_update_db.py
+++ b/tests/test_auto_update_db.py
@@ -15,10 +15,10 @@ def _invoke(*args):
     return runner.invoke(scan, list(args), catch_exceptions=False)
 
 
-def test_auto_update_db_flag_triggers_sync_when_stale():
-    """When DB freshness is >7 days, sync_db() must be called."""
+def test_auto_update_db_flag_triggers_sync_when_aging():
+    """When DB freshness misses the daily target, sync_db() must be called."""
     with (
-        patch("agent_bom.db.schema.db_freshness_days", return_value=10) as mock_fresh,
+        patch("agent_bom.db.schema.db_freshness_days", return_value=1) as mock_fresh,
         patch("agent_bom.db.sync.sync_db") as mock_sync,
         patch("agent_bom.cli.agents.discover_all", return_value=[]),
         patch("agent_bom.cli.agents.scan_agents_sync", return_value=[]),
@@ -30,9 +30,9 @@ def test_auto_update_db_flag_triggers_sync_when_stale():
 
 
 def test_auto_update_db_skips_when_fresh():
-    """When DB freshness is <=7 days, sync_db() must NOT be called."""
+    """When DB freshness is inside the daily target, sync_db() must NOT be called."""
     with (
-        patch("agent_bom.db.schema.db_freshness_days", return_value=3) as mock_fresh,
+        patch("agent_bom.db.schema.db_freshness_days", return_value=0) as mock_fresh,
         patch("agent_bom.db.sync.sync_db") as mock_sync,
         patch("agent_bom.cli.agents.discover_all", return_value=[]),
         patch("agent_bom.cli.agents.scan_agents_sync", return_value=[]),

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -963,6 +963,30 @@ def test_db_status_freshness_stale(tmp_path):
     assert "Stale" in result.output or "20d" in result.output or "ago" in result.output
 
 
+def test_db_status_freshness_aging_at_daily_boundary(tmp_path):
+    """db status marks a one-day-old DB as aging, not fresh."""
+    from datetime import datetime, timedelta, timezone
+
+    from agent_bom.db.schema import init_db
+
+    db_file = tmp_path / "aging.db"
+    conn = init_db(db_file)
+    old_iso = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    conn.execute(
+        "INSERT OR REPLACE INTO sync_meta(source, last_synced, record_count) VALUES (?, ?, ?)",
+        ("osv", old_iso, 100),
+    )
+    conn.commit()
+    conn.close()
+
+    result = _run(["db", "status", "--path", str(db_file)])
+    assert result.exit_code == 0
+    assert "Aging" in result.output
+    assert "daily" in result.output
+    assert "freshness" in result.output
+    assert "Fresh (" not in result.output
+
+
 def test_db_status_no_sync_meta(tmp_path):
     """db status with empty sync_meta shows 'No sync data' message."""
     from agent_bom.db.schema import init_db


### PR DESCRIPTION
## Summary
- treat vulnerability DB data as fresh only inside the daily freshness target
- auto-refresh the local DB once it is at least one day old, instead of waiting a week
- keep one to seven days as an explicit aging state and more than seven days as stale
- align CLI, API pipeline, and MCP scan tool wording around the same freshness contract

## Validation
- `uv run pytest -q tests/test_auto_update_db.py tests/test_cli_scan.py::test_db_status_freshness_fresh tests/test_cli_scan.py::test_db_status_freshness_aging_at_daily_boundary tests/test_cli_scan.py::test_db_status_freshness_stale`
- `uv run ruff check src/agent_bom/cli/_db.py src/agent_bom/cli/agents/__init__.py src/agent_bom/api/pipeline.py src/agent_bom/mcp_tools/scanning.py src/agent_bom/cli/options_sources.py src/agent_bom/mcp_server.py tests/test_auto_update_db.py tests/test_cli_scan.py`
- `git diff --check`
