### PR TITLE
ui: make graph surfaces more readable

### DIFF
--- a/src/agent_bom/cli/_grouped_help.py
+++ b/src/agent_bom/cli/_grouped_help.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
+from difflib import get_close_matches
 
 import click
 
@@ -63,6 +64,26 @@ class GroupedGroup(click.Group):
     def __init__(self, *args, command_categories=None, **kwargs):
         super().__init__(*args, **kwargs)
         self._command_categories = command_categories or COMMAND_CATEGORIES
+
+    def resolve_command(self, ctx: click.Context, args: list[str]):
+        try:
+            return super().resolve_command(ctx, args)
+        except click.UsageError as exc:
+            if args:
+                suggestion = self._suggest_command(ctx, args[0])
+                if suggestion and "No such command" in exc.message:
+                    exc.message = f"{exc.message}\n\nDid you mean '{suggestion}'?"
+            raise
+
+    def _suggest_command(self, ctx: click.Context, command_name: str) -> str | None:
+        visible_commands = []
+        for name in self.list_commands(ctx):
+            command = self.get_command(ctx, name)
+            if command is None:
+                continue
+            visible_commands.append(name)
+        matches = get_close_matches(command_name, visible_commands, n=1, cutoff=0.62)
+        return matches[0] if matches else None
 
     def format_commands(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         # Collect all available commands

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -25,6 +25,14 @@ class TestAgentBom:
         assert "Core readiness" not in r.output
         assert "Navigation tips:" in r.output
 
+    def test_unknown_command_suggests_nearest_command(self):
+        from agent_bom.cli import main
+
+        r = CliRunner().invoke(main, ["scna"])
+        assert r.exit_code != 0
+        assert "No such command 'scna'" in r.output
+        assert "Did you mean 'scan'?" in r.output
+
     def test_version(self):
         from agent_bom.cli import main
 

--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -48,6 +48,7 @@ import {
   BACKGROUND_GAP,
   legendItemsForVisibleNodes,
   minimapNodeColor,
+  readableGraphEdges,
 } from "@/lib/graph-utils";
 import { FullscreenButton, GraphLegend } from "@/components/graph-chrome";
 import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
@@ -351,15 +352,11 @@ export default function ContextPage() {
   const displayEdges = useMemo(() => {
     const activeSet =
       searchMatches && searchMatches.size > 0 ? searchMatches : connectedIds;
-    if (!activeSet) return layoutEdges;
-    return layoutEdges?.map((e) => ({
-      ...e,
-      style: {
-        ...e.style,
-        opacity:
-          activeSet.has(e.source) && activeSet.has(e.target) ? 1 : 0.12,
-      },
-    }));
+    return readableGraphEdges(layoutEdges, activeSet, {
+      baseOpacity: 0.32,
+      highSignalOpacity: 0.56,
+      inactiveOpacity: 0.06,
+    });
   }, [layoutEdges, connectedIds, searchMatches]);
 
   const legendItems = useMemo(() => {

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -65,6 +65,7 @@ import {
   MINIMAP_CLASS,
   MINIMAP_MASK,
   minimapNodeColor,
+  readableGraphEdges,
 } from "@/lib/graph-utils";
 import {
   api,
@@ -824,11 +825,18 @@ function GraphPageInner() {
     setHoveredNodeId(null);
   }, [graphIdentityKey]);
 
-  const { nodes: layoutNodes, edges: layoutEdges } = useGraphLayout("force", aggregated.nodes, aggregated.edges, {
+  const graphLayoutKind = filters.agentName || filters.vulnOnly || selectedAttackPath ? "dagre-lr" : "force";
+  const { nodes: layoutNodes, edges: layoutEdges } = useGraphLayout(graphLayoutKind, aggregated.nodes, aggregated.edges, {
     force: {
       idealEdgeLength: filters.agentName ? 168 : 196,
       nodeRepulsion: filters.agentName ? 3600 : 4400,
       preservePinnedPositions: true,
+    },
+    dagreLr: {
+      nodeWidth: 230,
+      nodeHeight: 84,
+      rankSep: filters.agentName ? 160 : 190,
+      nodeSep: filters.agentName ? 44 : 58,
     },
   });
 
@@ -951,15 +959,12 @@ function GraphPageInner() {
         };
       });
     }
-    if (!localNeighborhoodIds) return layoutEdges;
-    return layoutEdges.map((edge) => ({
-      ...edge,
-      style: {
-        ...edge.style,
-        opacity: localNeighborhoodIds.has(edge.source) && localNeighborhoodIds.has(edge.target) ? 1 : 0.12,
-      },
-    }));
-  }, [layoutEdges, localNeighborhoodIds, attackPathEdgeKeys]);
+    return readableGraphEdges(layoutEdges, localNeighborhoodIds, {
+      baseOpacity: graphLayoutKind === "dagre-lr" ? 0.34 : 0.26,
+      highSignalOpacity: graphLayoutKind === "dagre-lr" ? 0.6 : 0.48,
+      inactiveOpacity: 0.06,
+    });
+  }, [layoutEdges, localNeighborhoodIds, attackPathEdgeKeys, graphLayoutKind]);
 
   const legendItems = useMemo(
     () => legendItemsForVisibleGraph(displayNodes, displayEdges),

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -51,6 +51,7 @@ import {
   BACKGROUND_GAP,
   legendItemsForVisibleGraph,
   minimapNodeColor,
+  readableGraphEdges,
 } from "@/lib/graph-utils";
 import { FullscreenButton, GraphLegend } from "@/components/graph-chrome";
 import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
@@ -301,7 +302,7 @@ function MeshCaptureView({
           <div>
             <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-700">Agent mesh</p>
             <h1 className="mt-2 text-3xl font-semibold tracking-normal text-slate-950">
-              Readable AI supply-chain path, scoped to the riskiest agent
+              AI supply-chain path, scoped to the riskiest agent
             </h1>
             <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
               The mesh starts with a bounded path view so teams can see which agent, MCP servers, packages, tools, and findings are driving risk before opening the full graph canvas.
@@ -508,14 +509,11 @@ export default function MeshPage() {
     const { nodes, edges, stats } = buildMeshGraph(activeResult, nodeFilter, severityFilter, {
       selectedAgents,
       vulnerableOnly,
-      ...(captureMode
-        ? {
-            maxCredentialNodesPerServer: 2,
-            maxToolNodesPerServer: 2,
-            maxVulnerablePackagesPerServer: 3,
-            maxVulnerabilitiesPerPackage: 1,
-          }
-        : {}),
+      maxCredentialNodesPerServer: 2,
+      maxToolNodesPerServer: 2,
+      maxVulnerablePackagesPerServer: 3,
+      maxCleanPackagesPerServer: vulnerableOnly ? 0 : 1,
+      maxVulnerabilitiesPerPackage: 1,
     });
     return { rawNodes: nodes, rawEdges: edges, stats };
   }, [activeResult, captureMode, nodeFilter, severityFilter, selectedAgents, vulnerableOnly]);
@@ -526,10 +524,10 @@ export default function MeshPage() {
       ringSpacing: 220,
     },
     dagre: {
-      nodeWidth: 200,
-      nodeHeight: 70,
-      rankSep: 95,
-      nodeSep: 18,
+      nodeWidth: 230,
+      nodeHeight: 84,
+      rankSep: 140,
+      nodeSep: 34,
     },
   });
 
@@ -570,14 +568,11 @@ export default function MeshPage() {
 
   const displayEdges = useMemo(() => {
     const activeSet = searchMatches && searchMatches.size > 0 ? searchMatches : connectedIds;
-    if (!activeSet) return visibleEdges;
-    return visibleEdges?.map((e) => ({
-      ...e,
-      style: {
-        ...e.style,
-        opacity: activeSet.has(e.source) && activeSet.has(e.target) ? 1 : 0.12,
-      },
-    }));
+    return readableGraphEdges(visibleEdges, activeSet, {
+      baseOpacity: 0.3,
+      highSignalOpacity: 0.58,
+      inactiveOpacity: 0.06,
+    });
   }, [visibleEdges, connectedIds, searchMatches]);
 
   const legendItems = useMemo(
@@ -650,8 +645,8 @@ export default function MeshPage() {
         <div className="flex items-center gap-3">
           <div className="flex items-center overflow-hidden rounded-lg border border-zinc-700 bg-zinc-800">
             {[
-              { key: "radial" as const, label: "Radial", icon: Orbit },
-              { key: "topology" as const, label: "Topology", icon: Network },
+              { key: "radial" as const, label: "Risk Map", icon: Orbit },
+              { key: "topology" as const, label: "Dependency Flow", icon: Network },
               { key: "spawn-tree" as const, label: "Spawn Tree", icon: GitBranch },
             ].map(({ key, label, icon: Icon }) => (
               <button

--- a/ui/components/lineage-nodes.tsx
+++ b/ui/components/lineage-nodes.tsx
@@ -132,7 +132,7 @@ function NodeCard({
   return (
     <div
       title={data.label}
-      className={`${shapeClass} border-2 px-3 py-2 min-w-[168px] max-w-[240px] shadow-lg backdrop-blur transition-opacity ${borderClass} ${bgClass} ${
+      className={`${shapeClass} border-2 px-3.5 py-2.5 min-w-[188px] max-w-[280px] shadow-xl backdrop-blur transition-opacity ${borderClass} ${bgClass} ${
         data.dimmed ? "opacity-25" : ""
       } ${data.highlighted ? `ring-2 ${ringClass}` : ""}`}
     >
@@ -146,14 +146,14 @@ function NodeCard({
         position={Position.Right}
         className={`!w-2 !h-2 !bg-current ${source ? "" : "!opacity-0"}`}
       />
-      <div className="flex items-center gap-1.5 mb-0.5">
-        <Icon className={`w-3.5 h-3.5 shrink-0 ${iconClass}`} />
-        <span className="text-[13px] font-semibold leading-4 text-zinc-50 truncate">{data.label}</span>
-        <span className="ml-auto rounded border border-white/15 bg-black/25 px-1.5 py-0.5 text-[9px] uppercase tracking-[0.12em] text-zinc-300">
+      <div className="flex items-center gap-2 mb-1">
+        <Icon className={`w-4 h-4 shrink-0 ${iconClass}`} />
+        <span className="text-sm font-semibold leading-5 text-zinc-950 dark:text-zinc-50 truncate">{data.label}</span>
+        <span className="ml-auto rounded border border-black/10 bg-white/70 px-1.5 py-0.5 text-[10px] uppercase tracking-[0.1em] text-zinc-600 dark:border-white/15 dark:bg-black/25 dark:text-zinc-200">
           {NODE_TYPE_BADGES[data.nodeType]}
         </span>
       </div>
-      {subtitle && <div className="text-[11px] leading-4 text-zinc-300 truncate">{subtitle}</div>}
+      {subtitle && <div className="text-xs leading-4 text-zinc-700 dark:text-zinc-200/90 truncate">{subtitle}</div>}
       {footer}
     </div>
   );
@@ -186,15 +186,15 @@ function AgentNode({ data }: { data: LineageNodeData }) {
   return (
     <NodeCard
       data={data}
-      borderClass={notConfigured ? "border-yellow-600 border-dashed" : "border-emerald-600"}
-      bgClass={notConfigured ? "bg-yellow-950/80" : "bg-emerald-950/80"}
+      borderClass={notConfigured ? "border-yellow-500 border-dashed" : "border-emerald-500 dark:border-emerald-600"}
+      bgClass={notConfigured ? "bg-yellow-50 dark:bg-yellow-950/80" : "bg-emerald-50 dark:bg-emerald-950/80"}
       ringClass="ring-emerald-400"
       icon={ShieldAlert}
-      iconClass="text-emerald-400"
+      iconClass="text-emerald-600 dark:text-emerald-400"
       target={false}
       subtitle={data.agentType}
       footer={
-        <div className="flex gap-2 mt-1 text-[10px] text-zinc-500">
+        <div className="flex gap-2 mt-1 text-[10px] text-zinc-600 dark:text-zinc-500">
           {data.serverCount !== undefined && <span>{data.serverCount} srv</span>}
           {data.packageCount !== undefined && <span>{data.packageCount} pkg</span>}
           {(data.vulnCount ?? 0) > 0 && <span className="text-red-400">{data.vulnCount} finding</span>}
@@ -208,15 +208,15 @@ function ProviderNode({ data }: { data: LineageNodeData }) {
   return (
     <NodeCard
       data={data}
-      borderClass="border-zinc-600"
-      bgClass="bg-zinc-900/90"
+      borderClass="border-zinc-300 dark:border-zinc-600"
+      bgClass="bg-white dark:bg-zinc-900/90"
       ringClass="ring-zinc-400"
       icon={Building2}
-      iconClass="text-zinc-400"
+      iconClass="text-zinc-600 dark:text-zinc-400"
       target={false}
       footer={
         data.agentCount !== undefined ? (
-          <div className="mt-1 text-[10px] text-zinc-500">{data.agentCount} agents</div>
+          <div className="mt-1 text-[10px] text-zinc-600 dark:text-zinc-500">{data.agentCount} agents</div>
         ) : undefined
       }
     />
@@ -257,11 +257,11 @@ function UserNode({ data }: { data: LineageNodeData }) {
   return (
     <IdentityNode
       data={data}
-      borderClass="border-emerald-700"
-      bgClass="bg-emerald-950/60"
+      borderClass="border-emerald-400 dark:border-emerald-700"
+      bgClass="bg-emerald-50 dark:bg-emerald-950/60"
       ringClass="ring-emerald-400"
       icon={ShieldAlert}
-      iconClass="text-emerald-300"
+      iconClass="text-emerald-600 dark:text-emerald-300"
       subtitle={data.description}
     />
   );
@@ -271,11 +271,11 @@ function GroupNode({ data }: { data: LineageNodeData }) {
   return (
     <IdentityNode
       data={data}
-      borderClass="border-fuchsia-700"
-      bgClass="bg-fuchsia-950/55"
+      borderClass="border-fuchsia-400 dark:border-fuchsia-700"
+      bgClass="bg-fuchsia-50 dark:bg-fuchsia-950/55"
       ringClass="ring-fuchsia-400"
       icon={Building2}
-      iconClass="text-fuchsia-300"
+      iconClass="text-fuchsia-600 dark:text-fuchsia-300"
       subtitle={data.description}
     />
   );
@@ -285,11 +285,11 @@ function ServiceAccountNode({ data }: { data: LineageNodeData }) {
   return (
     <IdentityNode
       data={data}
-      borderClass="border-amber-700"
-      bgClass="bg-amber-950/55"
+      borderClass="border-amber-400 dark:border-amber-700"
+      bgClass="bg-amber-50 dark:bg-amber-950/55"
       ringClass="ring-amber-400"
       icon={KeyRound}
-      iconClass="text-amber-300"
+      iconClass="text-amber-600 dark:text-amber-300"
       subtitle={data.description}
     />
   );
@@ -320,7 +320,7 @@ function StructureNode({
       iconClass={iconClass}
       subtitle={data.description}
       footer={
-        <div className="flex gap-2 mt-1 text-[10px] text-zinc-500">
+        <div className="flex gap-2 mt-1 text-[10px] text-zinc-600 dark:text-zinc-500">
           {data.agentCount !== undefined && <span>{data.agentCount} agents</span>}
           {data.serverCount !== undefined && <span>{data.serverCount} servers</span>}
         </div>
@@ -333,11 +333,11 @@ function EnvironmentNode({ data }: { data: LineageNodeData }) {
   return (
     <StructureNode
       data={data}
-      borderClass="border-teal-700"
-      bgClass="bg-teal-950/55"
+      borderClass="border-teal-400 dark:border-teal-700"
+      bgClass="bg-teal-50 dark:bg-teal-950/55"
       ringClass="ring-teal-400"
       icon={Cloud}
-      iconClass="text-teal-300"
+      iconClass="text-teal-600 dark:text-teal-300"
     />
   );
 }
@@ -346,11 +346,11 @@ function FleetNode({ data }: { data: LineageNodeData }) {
   return (
     <StructureNode
       data={data}
-      borderClass="border-cyan-700"
-      bgClass="bg-cyan-950/55"
+      borderClass="border-cyan-400 dark:border-cyan-700"
+      bgClass="bg-cyan-50 dark:bg-cyan-950/55"
       ringClass="ring-cyan-400"
       icon={Building2}
-      iconClass="text-cyan-300"
+      iconClass="text-cyan-600 dark:text-cyan-300"
     />
   );
 }
@@ -359,11 +359,11 @@ function ClusterNode({ data }: { data: LineageNodeData }) {
   return (
     <StructureNode
       data={data}
-      borderClass="border-sky-700"
-      bgClass="bg-sky-950/55"
+      borderClass="border-sky-400 dark:border-sky-700"
+      bgClass="bg-sky-50 dark:bg-sky-950/55"
       ringClass="ring-sky-400"
       icon={Server}
-      iconClass="text-sky-300"
+      iconClass="text-sky-600 dark:text-sky-300"
     />
   );
 }
@@ -372,11 +372,11 @@ function ServerNode({ data }: { data: LineageNodeData }) {
   return (
     <NodeCard
       data={data}
-      borderClass="border-blue-600"
-      bgClass="bg-blue-950/80"
+      borderClass="border-blue-500 dark:border-blue-600"
+      bgClass="bg-blue-50 dark:bg-blue-950/80"
       ringClass="ring-blue-400"
       icon={Server}
-      iconClass="text-blue-400"
+      iconClass="text-blue-600 dark:text-blue-400"
       subtitle={data.command}
       footer={
         <div className="flex gap-2 mt-1">
@@ -409,11 +409,11 @@ function PackageNode({ data }: { data: LineageNodeData }) {
   return (
     <NodeCard
       data={data}
-      borderClass={hasVulns ? "border-red-600/60" : "border-zinc-600"}
-      bgClass={hasVulns ? "bg-red-950/40" : "bg-zinc-900/80"}
+      borderClass={hasVulns ? "border-red-400 dark:border-red-600/60" : "border-zinc-300 dark:border-zinc-600"}
+      bgClass={hasVulns ? "bg-red-50 dark:bg-red-950/40" : "bg-white dark:bg-zinc-900/80"}
       ringClass="ring-zinc-400"
       icon={Package}
-      iconClass="text-zinc-400"
+      iconClass="text-zinc-600 dark:text-zinc-400"
       subtitle={
         data.version
           ? `${data.version}${data.ecosystem ? ` · ${data.ecosystem}` : ""}${provenance ? ` · ${provenance}` : ""}`
@@ -482,15 +482,15 @@ function VulnNode({ data }: { data: LineageNodeData }) {
     sev === "medium" ? "border-yellow-500" :
     "border-blue-500";
   const bgClass =
-    sev === "critical" ? "bg-red-950/80" :
-    sev === "high" ? "bg-orange-950/80" :
-    sev === "medium" ? "bg-yellow-950/80" :
-    "bg-blue-950/80";
+    sev === "critical" ? "bg-red-100 dark:bg-red-950/80" :
+    sev === "high" ? "bg-orange-100 dark:bg-orange-950/80" :
+    sev === "medium" ? "bg-yellow-100 dark:bg-yellow-950/80" :
+    "bg-blue-100 dark:bg-blue-950/80";
   return <FindingNode data={data} accentClass="text-red-300" borderClass={borderClass} bgClass={bgClass} />;
 }
 
 function MisconfigNode({ data }: { data: LineageNodeData }) {
-  return <FindingNode data={data} accentClass="text-orange-300" borderClass="border-orange-500" bgClass="bg-orange-950/75" />;
+  return <FindingNode data={data} accentClass="text-orange-600 dark:text-orange-300" borderClass="border-orange-500" bgClass="bg-orange-100 dark:bg-orange-950/75" />;
 }
 
 function CredentialNode({ data }: { data: LineageNodeData }) {
@@ -498,11 +498,11 @@ function CredentialNode({ data }: { data: LineageNodeData }) {
     <NodeCard
       data={data}
       borderClass="border-amber-500 border-dashed"
-      bgClass="bg-amber-950/60"
+      bgClass="bg-amber-50 dark:bg-amber-950/60"
       ringClass="ring-amber-400"
       shapeClass="rounded-2xl"
       icon={KeyRound}
-      iconClass="text-amber-400"
+      iconClass="text-amber-600 dark:text-amber-400"
       source={false}
       subtitle={data.serverName}
     />
@@ -513,12 +513,12 @@ function ToolNode({ data }: { data: LineageNodeData }) {
   return (
     <NodeCard
       data={data}
-      borderClass="border-purple-600"
-      bgClass="bg-purple-950/60"
+      borderClass="border-purple-500 dark:border-purple-600"
+      bgClass="bg-purple-50 dark:bg-purple-950/60"
       ringClass="ring-purple-400"
       shapeClass="rounded-2xl"
       icon={Wrench}
-      iconClass="text-purple-400"
+      iconClass="text-purple-600 dark:text-purple-400"
       source={false}
       subtitle={data.description}
     />
@@ -529,11 +529,11 @@ function ModelNode({ data }: { data: LineageNodeData }) {
   return (
     <NodeCard
       data={data}
-      borderClass="border-violet-600"
-      bgClass="bg-violet-950/70"
+      borderClass="border-violet-500 dark:border-violet-600"
+      bgClass="bg-violet-50 dark:bg-violet-950/70"
       ringClass="ring-violet-400"
       icon={Brain}
-      iconClass="text-violet-300"
+      iconClass="text-violet-600 dark:text-violet-300"
       subtitle={data.description}
     />
   );
@@ -543,11 +543,11 @@ function DatasetNode({ data }: { data: LineageNodeData }) {
   return (
     <NodeCard
       data={data}
-      borderClass="border-cyan-600"
-      bgClass="bg-cyan-950/70"
+      borderClass="border-cyan-500 dark:border-cyan-600"
+      bgClass="bg-cyan-50 dark:bg-cyan-950/70"
       ringClass="ring-cyan-400"
       icon={Database}
-      iconClass="text-cyan-300"
+      iconClass="text-cyan-600 dark:text-cyan-300"
       subtitle={data.description}
     />
   );
@@ -557,11 +557,11 @@ function ContainerNode({ data }: { data: LineageNodeData }) {
   return (
     <NodeCard
       data={data}
-      borderClass="border-indigo-600"
-      bgClass="bg-indigo-950/70"
+      borderClass="border-indigo-500 dark:border-indigo-600"
+      bgClass="bg-indigo-50 dark:bg-indigo-950/70"
       ringClass="ring-indigo-400"
       icon={Box}
-      iconClass="text-indigo-300"
+      iconClass="text-indigo-600 dark:text-indigo-300"
       subtitle={data.description}
     />
   );
@@ -571,11 +571,11 @@ function CloudResourceNode({ data }: { data: LineageNodeData }) {
   return (
     <NodeCard
       data={data}
-      borderClass="border-sky-600"
-      bgClass="bg-sky-950/70"
+      borderClass="border-sky-500 dark:border-sky-600"
+      bgClass="bg-sky-50 dark:bg-sky-950/70"
       ringClass="ring-sky-400"
       icon={Cloud}
-      iconClass="text-sky-300"
+      iconClass="text-sky-600 dark:text-sky-300"
       subtitle={data.description}
     />
   );
@@ -647,21 +647,21 @@ function SharedServerNode({ data }: { data: LineageNodeData }) {
     <NodeCard
       data={data}
       borderClass="border-cyan-400"
-      bgClass="bg-cyan-950/80"
+      bgClass="bg-cyan-50 dark:bg-cyan-950/80"
       ringClass="ring-cyan-300"
       shapeClass="rounded-[18px]"
       icon={Server}
-      iconClass="text-cyan-300"
+      iconClass="text-cyan-600 dark:text-cyan-300"
       subtitle={data.command}
       footer={
         <div className="flex gap-2 mt-1">
           {data.sharedBy && (
-            <span className="text-[10px] px-1.5 py-0.5 rounded bg-cyan-900/60 text-cyan-300 border border-cyan-700 font-mono">
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-cyan-100 text-cyan-700 border border-cyan-300 font-mono dark:bg-cyan-900/60 dark:text-cyan-300 dark:border-cyan-700">
               Shared by {data.sharedBy}
             </span>
           )}
           {data.packageCount !== undefined && data.packageCount > 0 && (
-            <span className="flex items-center gap-0.5 text-[10px] text-zinc-300">
+            <span className="flex items-center gap-0.5 text-[10px] text-zinc-600 dark:text-zinc-300">
               <Package className="w-2.5 h-2.5" /> {data.packageCount}
             </span>
           )}
@@ -682,12 +682,12 @@ function SummaryNode({ data }: { data: LineageNodeData }) {
   const sev = (data.severity ?? "").toLowerCase();
   const accent =
     sev === "critical"
-      ? "border-red-500 bg-red-950/70 text-red-200"
+      ? "border-red-500 bg-red-100 text-red-950 dark:bg-red-950/70 dark:text-red-200"
       : sev === "high"
-        ? "border-orange-500 bg-orange-950/60 text-orange-200"
+        ? "border-orange-500 bg-orange-100 text-orange-950 dark:bg-orange-950/60 dark:text-orange-200"
         : sev === "medium"
-          ? "border-yellow-500 bg-yellow-950/55 text-yellow-200"
-          : "border-zinc-700 bg-zinc-900/80 text-zinc-200";
+          ? "border-yellow-500 bg-yellow-100 text-yellow-950 dark:bg-yellow-950/55 dark:text-yellow-200"
+          : "border-zinc-300 bg-white text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900/80 dark:text-zinc-200";
   const vulnCount = data.vulnCount ?? 0;
   return (
     <div
@@ -701,7 +701,7 @@ function SummaryNode({ data }: { data: LineageNodeData }) {
       <div className="flex items-center gap-1">
         <span className="text-[10px] font-medium truncate">{data.label}</span>
         {vulnCount > 0 && (
-          <span className="ml-auto rounded bg-black/40 px-1 text-[9px] font-mono">
+          <span className="ml-auto rounded bg-white/70 px-1 text-[9px] font-mono dark:bg-black/40">
             {vulnCount}
           </span>
         )}

--- a/ui/components/scan-mesh.tsx
+++ b/ui/components/scan-mesh.tsx
@@ -13,7 +13,7 @@ import { lineageNodeTypes, type LineageNodeData } from "@/components/lineage-nod
 import { LineageDetailPanel } from "@/components/lineage-detail";
 import { MeshStats } from "@/components/mesh-stats";
 import { buildMeshGraph, getConnectedIds, type MeshStatsData } from "@/lib/mesh-graph";
-import { CONTROLS_CLASS, MINIMAP_CLASS, BACKGROUND_COLOR, BACKGROUND_GAP, legendItemsForVisibleNodes, minimapNodeColor } from "@/lib/graph-utils";
+import { CONTROLS_CLASS, MINIMAP_CLASS, BACKGROUND_COLOR, BACKGROUND_GAP, legendItemsForVisibleNodes, minimapNodeColor, readableGraphEdges } from "@/lib/graph-utils";
 import { GraphLegend } from "@/components/graph-chrome";
 
 export function ScanMeshView({ id }: { id: string }) {
@@ -56,8 +56,11 @@ export function ScanMeshView({ id }: { id: string }) {
   }, [layoutNodes, connectedIds]);
 
   const displayEdges = useMemo(() => {
-    if (!connectedIds) return layoutEdges;
-    return layoutEdges?.map((e) => ({ ...e, style: { ...e.style, opacity: connectedIds.has(e.source) && connectedIds.has(e.target) ? 1 : 0.12 } }));
+    return readableGraphEdges(layoutEdges, connectedIds, {
+      baseOpacity: 0.3,
+      highSignalOpacity: 0.58,
+      inactiveOpacity: 0.06,
+    });
   }, [layoutEdges, connectedIds]);
 
   const legendItems = useMemo(() => legendItemsForVisibleNodes(displayNodes), [displayNodes]);

--- a/ui/lib/graph-utils.ts
+++ b/ui/lib/graph-utils.ts
@@ -4,6 +4,7 @@
  */
 
 import type { LineageNodeData, LineageNodeType } from "@/components/lineage-nodes";
+import type { Edge } from "@xyflow/react";
 import {
   GRAPH_NODE_KIND_META,
   type GraphNodeKindKey,
@@ -257,6 +258,64 @@ export const STANDARD_LEGEND: LegendItem[] = [
   { label: "Cred", color: "#f59e0b", kind: "node", shape: "dot" },
   { label: "Tool", color: "#a855f7", kind: "node", shape: "pill" },
 ];
+
+const HIGH_SIGNAL_RELATIONSHIPS = new Set([
+  "vulnerable_to",
+  "exposes_cred",
+  "shares_cred",
+  "lateral_path",
+  "exploitable_via",
+  "accessed",
+  "invoked",
+]);
+
+function numericStrokeWidth(edge: Edge, fallback = 1.4): number {
+  const width = edge.style?.strokeWidth;
+  return typeof width === "number" && Number.isFinite(width) ? width : fallback;
+}
+
+function edgeRelationship(edge: Edge): string {
+  const relationship = (edge.data as { relationship?: unknown } | undefined)?.relationship;
+  return typeof relationship === "string" ? relationship : "";
+}
+
+export function readableGraphEdges(
+  edges: Edge[],
+  activeNodeIds?: Set<string> | null,
+  options: {
+    baseOpacity?: number;
+    highSignalOpacity?: number;
+    inactiveOpacity?: number;
+    activeOpacity?: number;
+    quietAnimation?: boolean;
+  } = {},
+): Edge[] {
+  const {
+    baseOpacity = 0.32,
+    highSignalOpacity = 0.54,
+    inactiveOpacity = 0.08,
+    activeOpacity = 0.96,
+    quietAnimation = true,
+  } = options;
+
+  return edges.map((edge): Edge => {
+    const relationship = edgeRelationship(edge);
+    const highSignal = HIGH_SIGNAL_RELATIONSHIPS.has(relationship);
+    const active = activeNodeIds ? activeNodeIds.has(edge.source) && activeNodeIds.has(edge.target) : false;
+    const opacity = activeNodeIds ? (active ? activeOpacity : inactiveOpacity) : highSignal ? highSignalOpacity : baseOpacity;
+    const width = numericStrokeWidth(edge);
+
+    return {
+      ...edge,
+      animated: quietAnimation ? Boolean(activeNodeIds && active && edge.animated) : Boolean(edge.animated),
+      style: {
+        ...edge.style,
+        opacity,
+        strokeWidth: active ? Math.max(width, 2.6) : Math.max(Math.min(width, highSignal ? 2 : 1.5), 1),
+      },
+    };
+  });
+}
 
 export const MESH_LEGEND: LegendItem[] = [
   { label: "Agent", color: "#10b981", kind: "node", shape: "dot" },

--- a/ui/tests/graph-utils.test.ts
+++ b/ui/tests/graph-utils.test.ts
@@ -6,6 +6,7 @@ import {
   legendItemsForVisibleNodes,
   minimapNodeColor,
   NODE_COLOR_MAP,
+  readableGraphEdges,
 } from "@/lib/graph-utils";
 
 describe("graph utility metadata", () => {
@@ -45,5 +46,34 @@ describe("graph utility metadata", () => {
         shape: "square",
       },
     ]);
+  });
+
+  it("de-emphasizes dense default edges and restores contrast for focused paths", () => {
+    const edges = readableGraphEdges([
+      {
+        id: "a-b",
+        source: "a",
+        target: "b",
+        data: { relationship: "uses" },
+        style: { strokeWidth: 3 },
+        animated: true,
+      },
+      {
+        id: "b-c",
+        source: "b",
+        target: "c",
+        data: { relationship: "vulnerable_to" },
+        style: { strokeWidth: 2 },
+      },
+    ]);
+
+    expect(edges[0]!.animated).toBe(false);
+    expect(edges[0]!.style?.opacity).toBeLessThan(edges[1]!.style?.opacity as number);
+    expect(edges[0]!.style?.strokeWidth).toBeLessThanOrEqual(1.5);
+
+    const focused = readableGraphEdges(edges, new Set(["b", "c"]));
+    expect(focused[0]!.style?.opacity).toBeLessThan(0.1);
+    expect(focused[1]!.style?.opacity).toBeGreaterThan(0.9);
+    expect(focused[1]!.style?.strokeWidth).toBeGreaterThanOrEqual(2.6);
   });
 });


### PR DESCRIPTION
## Summary

This PR patches the product surfaces behind the graph screenshots instead of replacing images.

- Adds shared readable edge styling for graph canvases so dense graphs quiet low-signal edges by default and restore contrast on hover/search/focus.
- Applies the shared edge behavior to Agent Mesh, scan-level Mesh, full Lineage Graph, and Context Graph.
- Tightens Agent Mesh first-view caps so the default path stays scoped to the highest-risk agent while filters still unlock broader graph exploration.
- Increases graph node card size and text contrast for better scanability.
- Adds CLI typo suggestions for unknown top-level commands, e.g. `agent-bom scna` now suggests `scan`.

## Why

The prior demo screenshot made the graph look like a dense canvas rather than an operator-grade security view. The fix needs to live in the actual graph rendering behavior: readable defaults, clear focus behavior, stronger node legibility, and a CLI that feels less brittle.

## Validation

- `uv run pytest tests/test_cli_entry_points.py::TestAgentBom::test_unknown_command_suggests_nearest_command -q`
- `uv run ruff check src/agent_bom/cli/_grouped_help.py tests/test_cli_entry_points.py`
- `cd ui && npm test -- --run tests/graph-utils.test.ts`
- `cd ui && npm run typecheck`
- `cd ui && npm run build`
- `git diff --check`
