### PR TITLE
ui: add graph product defaults

### DIFF
--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -17,7 +17,6 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import {
-  ShieldAlert,
   Loader2,
   AlertTriangle,
   Search,
@@ -51,6 +50,7 @@ import {
   readableGraphEdges,
 } from "@/lib/graph-utils";
 import { FullscreenButton, GraphLegend } from "@/components/graph-chrome";
+import { GraphEmptyState, GraphPanelSkeleton } from "@/components/graph-state-panels";
 import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { isDeploymentSurfaceAvailable } from "@/lib/deployment-context";
@@ -409,12 +409,17 @@ export default function ContextPage() {
       return <DeploymentSurfaceRequiredState surface="context" counts={counts} detail={error} />;
     }
     return (
-      <div className="flex flex-col items-center justify-center h-[80vh] text-zinc-400 gap-3">
-        <ShieldAlert className="w-8 h-8 text-zinc-600" />
-        <p className="text-sm">No completed scans found</p>
-        <p className="text-xs text-zinc-500">
-          Run a scan first to visualize the context graph
-        </p>
+      <div className="h-[80vh]">
+        <GraphEmptyState
+          title="No completed scans found"
+          detail="Run a scan first so the context map can show agents, MCP servers, shared credentials, and lateral paths from a real snapshot."
+          suggestions={[
+            "Use a demo scan for a local proof point.",
+            "Open the Security Graph after the scan persists graph evidence.",
+            "Keep the first context view scoped to one agent before expanding.",
+          ]}
+          command="agent-bom agents --demo --offline"
+        />
       </div>
     );
   }
@@ -494,10 +499,21 @@ export default function ContextPage() {
             </div>
           )}
           {!graphData ? (
-            <div className="flex items-center justify-center h-full text-zinc-400">
-              <Loader2 className="w-5 h-5 animate-spin mr-2" />
-              Loading context graph...
-            </div>
+            <GraphPanelSkeleton
+              title="Loading context map"
+              detail="Fetching the selected scan and preparing the focused agent-to-server context."
+            />
+          ) : displayNodes.length === 0 ? (
+            <GraphEmptyState
+              title="No context relationships match this scope"
+              detail="The selected scan loaded, but this agent scope does not have enough server, credential, or lateral path evidence to draw a context map."
+              suggestions={[
+                "Choose another agent from the scope selector.",
+                "Switch to all agents to inspect shared infrastructure.",
+                "Run a broader scan when you expect MCP server or credential relationships.",
+              ]}
+              command="agent-bom scan -p . -f graph"
+            />
           ) : (
             <ReactFlow
               nodes={displayNodes}

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -30,6 +30,9 @@ import {
   DEFAULT_FILTERS,
   createExpandedGraphFilters,
   createFocusedGraphFilters,
+  createImmediateGraphFilters,
+  graphScopeLabelForFilters,
+  graphScopePresetForFilters,
   type FilterState,
 } from "@/components/lineage-filter";
 import {
@@ -387,7 +390,7 @@ function graphErrorState(message: string): { title: string; detail: string; sugg
       detail: message,
       suggestions: [
         "Reduce depth or page size before retrying.",
-        "Switch back to Focused view for operator triage.",
+        "Switch back to Relevant paths for operator triage.",
         "Narrow the graph by agent, severity, or relationship scope.",
       ],
     };
@@ -780,10 +783,11 @@ function GraphPageInner() {
     [graphData, filters],
   );
   const validValues = filterAlgebra.validValues;
+  const activeScopePreset = graphScopePresetForFilters(filters);
 
   const handleResetFilters = useCallback(() => {
-    setFilters(DEFAULT_FILTERS);
-  }, []);
+    setFilters(createFocusedGraphFilters(flow.agentNames[0] ?? null));
+  }, [flow.agentNames]);
 
   const flowNodeDataById = useMemo(
     () => new Map(flow.nodes.map((node) => [node.id, node.data])),
@@ -1265,18 +1269,28 @@ function GraphPageInner() {
           </form>
 
           <div className="mt-3 flex flex-wrap gap-4 text-[11px]">
-            <GraphControlGroup label="View">
+            <GraphControlGroup label="Scope preset">
+              <button
+                type="button"
+                onClick={() => setFilters(createImmediateGraphFilters(filters.agentName ?? flow.agentNames[0] ?? null))}
+                className={scopeButtonClass(activeScopePreset === "immediate")}
+                title="One-hop triage around the selected agent"
+              >
+                Immediate
+              </button>
               <button
                 type="button"
                 onClick={() => setFilters(createFocusedGraphFilters(filters.agentName ?? flow.agentNames[0] ?? null))}
-                className="rounded-lg border border-sky-500/30 bg-sky-500/10 px-2.5 py-1 text-sky-200 transition hover:border-sky-400/60"
+                className={scopeButtonClass(activeScopePreset === "relevant")}
+                title="Default fix-first graph with bounded path context"
               >
-                Focused
+                Relevant paths
               </button>
               <button
                 type="button"
                 onClick={() => setFilters(createExpandedGraphFilters(null))}
-                className="rounded-lg border border-zinc-700 bg-zinc-900/80 px-2.5 py-1 text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100"
+                className={scopeButtonClass(activeScopePreset === "expanded")}
+                title="Broader topology review with lower-priority context included"
               >
                 Expanded
               </button>
@@ -1291,7 +1305,7 @@ function GraphPageInner() {
                 {filters.severity ? `${filters.severity}+` : "all severities"}
               </span>
               <span className="rounded-lg border border-zinc-800 bg-zinc-900/80 px-2.5 py-1 text-zinc-400">
-                depth {filters.maxDepth}
+                {graphScopeLabelForFilters(filters)}
               </span>
               {filters.vulnOnly && (
                 <span className="rounded-lg border border-emerald-500/20 bg-emerald-500/10 px-2.5 py-1 text-emerald-200">
@@ -1320,7 +1334,7 @@ function GraphPageInner() {
                 ? "This scope currently resolves to findings without surrounding context. Relax filters or expand the view to recover package, server, and agent relationships."
                 : filters.agentName
                   ? `Focused on ${filters.agentName}. Expand only when you need more of the surrounding graph.`
-                  : "Focused view keeps the graph scoped. Use Expanded when you need broader topology."}
+                  : "Relevant paths keeps the first view bounded. Use Expanded only when you need broader topology."}
           </div>
 
           {investigationMode && (
@@ -1459,7 +1473,7 @@ function GraphPageInner() {
             <li>Each snapshot is a persisted control-plane view of entities, edges, attack paths, and relationship counts at one capture time.</li>
             <li>Node IDs are stable identifiers inside the graph model; the detail panel shows the node ID, first seen, last seen, sources, and edge counts.</li>
             <li>Pagination changes the visible canvas, not the persisted snapshot itself. Narrow the scope when the graph gets large; page when you need broader coverage.</li>
-            <li>Focused view is for operator triage. Expanded view is for topology review. Attack-path cards are the fix-first shortlist, not the whole graph.</li>
+            <li>Relevant paths is for operator triage. Expanded is for topology review. Attack-path cards are the fix-first shortlist, not the whole graph.</li>
           </ul>
         </details>
 
@@ -1579,7 +1593,7 @@ function GraphPageInner() {
           {loadingGraph && !graphData ? (
             <GraphPanelSkeleton
               title="Loading graph window"
-              detail="Fetching the selected snapshot with the current layer, severity, depth, and relationship filters."
+              detail={`Fetching the selected snapshot with the ${graphScopeLabelForFilters(filters).toLowerCase()} scope and active layer filters.`}
             />
           ) : graphPanelError ? (
             <GraphEmptyState
@@ -1593,9 +1607,10 @@ function GraphPageInner() {
               detail="The current combination of layers, severity, agent, depth, and runtime scope filtered everything out."
               suggestions={[
                 "Drop the severity threshold or turn off vulnerable-only.",
-                "Switch from Focused to Expanded when you need broader topology.",
+                "Switch from Relevant paths to Expanded when you need broader topology.",
                 "Re-enable the package or server layers to recover the path context.",
               ]}
+              command="agent-bom agents --demo --offline"
             />
           ) : graphOnlyFindings ? (
             <GraphFindingsFallback
@@ -1699,6 +1714,12 @@ function MetricCard({
       <span className="font-mono text-zinc-100">{value}</span> {label}
     </div>
   );
+}
+
+function scopeButtonClass(active: boolean): string {
+  return active
+    ? "rounded-lg border border-sky-500/40 bg-sky-500/15 px-2.5 py-1 text-sky-100 transition hover:border-sky-400/70"
+    : "rounded-lg border border-zinc-700 bg-zinc-900/80 px-2.5 py-1 text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100";
 }
 
 function PathStat({

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -48,6 +48,9 @@ import {
   toAttackCardNodes,
 } from "@/lib/attack-paths";
 
+const ATTACK_PATH_QUEUE_LIMIT = 75;
+const FIX_FIRST_CARD_LIMIT = 12;
+
 function SecurityGraphPageContent() {
   const searchParams = useSearchParams();
   const [snapshots, setSnapshots] = useState<GraphSnapshot[]>([]);
@@ -135,14 +138,14 @@ function SecurityGraphPageContent() {
         const [graph, view] = await Promise.all([
           api.getGraphAttackPaths({
             scanId: selectedScanId,
-            limit: 250,
+            limit: ATTACK_PATH_QUEUE_LIMIT,
           }),
           api.getFixFirstGraphView({
             scanId: selectedScanId,
             cve: focus.cve || undefined,
             packageName: focus.packageName || undefined,
             agentName: focus.agentName || undefined,
-            limit: 12,
+            limit: FIX_FIRST_CARD_LIMIT,
           }),
         ]);
         if (cancelled) return;
@@ -502,6 +505,7 @@ function SecurityGraphPageContent() {
             title={graphErrorState.title}
             detail={graphErrorState.detail}
             suggestions={graphErrorState.suggestions}
+            command="agent-bom serve --api"
           />
           <div className="mt-4 flex flex-wrap gap-3 border-t border-red-900/40 pt-4">
             <Link
@@ -528,6 +532,7 @@ function SecurityGraphPageContent() {
             title={emptyGraphState.title}
             detail={emptyGraphState.detail}
             suggestions={emptyGraphState.suggestions}
+            command="agent-bom scan -p . -f graph"
           />
           <div className="mt-4 flex flex-wrap gap-3 border-t border-[color:var(--border-subtle)] pt-4">
             <Link

--- a/ui/components/graph-state-panels.tsx
+++ b/ui/components/graph-state-panels.tsx
@@ -31,10 +31,12 @@ export function GraphEmptyState({
   title,
   detail,
   suggestions,
+  command,
 }: {
   title: string;
   detail: string;
   suggestions: string[];
+  command?: string | undefined;
 }) {
   return (
     <div className="flex h-full items-center justify-center">
@@ -56,6 +58,12 @@ export function GraphEmptyState({
             </li>
           ))}
         </ul>
+        {command ? (
+          <div className="mt-4 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2">
+            <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">First command</div>
+            <code className="mt-1 block overflow-x-auto whitespace-nowrap text-xs text-[color:var(--foreground)]">{command}</code>
+          </div>
+        ) : null}
       </div>
     </div>
   );
@@ -145,7 +153,7 @@ export function GraphFindingsFallback({
             <h3 className="mt-1 text-sm font-semibold text-[color:var(--foreground)]">This filter currently resolves to findings only</h3>
             <p className="mt-1 max-w-3xl text-xs leading-5 text-[color:var(--text-secondary)]">
               You are looking at the vulnerability slice without enough surrounding package, server, or agent context to form a topology.
-              Use this list for evidence and remediation, or relax the scope to recover the graph.
+              Use this list for evidence and remediation, or switch to the expanded topology scope.
             </p>
             {onExpandScope ? (
               <button
@@ -153,8 +161,7 @@ export function GraphFindingsFallback({
                 onClick={onExpandScope}
                 className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-300 hover:bg-emerald-500/20 hover:border-emerald-400 transition-colors"
               >
-                Show full graph
-                <span className="text-[10px] text-emerald-400/70">(expand scope)</span>
+                Show expanded topology
               </button>
             ) : null}
           </div>

--- a/ui/components/lineage-filter.tsx
+++ b/ui/components/lineage-filter.tsx
@@ -61,6 +61,33 @@ export const EXPANDED_LAYER_DEFAULTS: Record<LineageNodeType, boolean> = {
   tool: true,
 };
 
+export type GraphScopePreset = "immediate" | "relevant" | "expanded";
+
+export const GRAPH_SCOPE_LABELS: Record<GraphScopePreset, string> = {
+  immediate: "Immediate",
+  relevant: "Relevant paths",
+  expanded: "Expanded",
+};
+
+export const GRAPH_SCOPE_DESCRIPTIONS: Record<GraphScopePreset, string> = {
+  immediate: "One-hop triage around a selected agent.",
+  relevant: "Default fix-first graph with bounded path context.",
+  expanded: "Broader topology review with lower-priority context included.",
+};
+
+export function createImmediateGraphFilters(agentName: string | null = null): FilterState {
+  return {
+    layers: { ...FOCUSED_LAYER_DEFAULTS },
+    severity: "high",
+    agentName,
+    vulnOnly: true,
+    runtimeMode: "all",
+    relationshipScope: "all",
+    maxDepth: 1,
+    pageSize: 25,
+  };
+}
+
 export function createFocusedGraphFilters(agentName: string | null = null): FilterState {
   return {
     layers: { ...FOCUSED_LAYER_DEFAULTS },
@@ -89,13 +116,25 @@ export function createExpandedGraphFilters(agentName: string | null = null): Fil
 
 export const DEFAULT_FILTERS: FilterState = createFocusedGraphFilters();
 
+export function graphScopePresetForFilters(filters: FilterState): GraphScopePreset {
+  if (filters.maxDepth <= 1 && filters.pageSize <= 25 && filters.vulnOnly) return "immediate";
+  if (filters.maxDepth <= 2 && filters.pageSize <= 50 && filters.vulnOnly && filters.severity === "high") {
+    return "relevant";
+  }
+  return "expanded";
+}
+
+export function graphScopeLabelForFilters(filters: FilterState): string {
+  return GRAPH_SCOPE_LABELS[graphScopePresetForFilters(filters)];
+}
+
 interface FilterPanelProps {
   filters: FilterState;
   onChange: (f: FilterState) => void;
   agentNames: string[];
   /** Constraint-propagation valid values from filter-algebra. When omitted, every value is enabled. */
   validValues?: FilterValidValues;
-  /** Click handler for the "Reset to wide" button at the panel header. */
+  /** Click handler for the reset button at the panel header. */
   onReset?: () => void;
 }
 
@@ -231,7 +270,7 @@ export function FilterPanel({ filters, onChange, agentNames, validValues, onRese
             className="flex items-center gap-1 rounded border border-zinc-800 bg-zinc-900/80 px-2 py-1 text-[10px] text-zinc-400 transition hover:border-emerald-600/40 hover:text-emerald-200"
           >
             <RotateCcw className="h-3 w-3" />
-            Reset scope
+            Reset
           </button>
         )}
       </div>
@@ -336,7 +375,7 @@ export function FilterPanel({ filters, onChange, agentNames, validValues, onRese
         title="Traversal"
         open={openSections.traversal}
         onToggle={() => toggleSection("traversal")}
-        summary={`${filters.runtimeMode === "all" ? "static + runtime" : filters.runtimeMode} · depth ${filters.maxDepth}`}
+        summary={`${filters.runtimeMode === "all" ? "static + runtime" : filters.runtimeMode} · ${graphScopeLabelForFilters(filters)}`}
       >
         <div className="space-y-2">
           <select
@@ -364,6 +403,7 @@ export function FilterPanel({ filters, onChange, agentNames, validValues, onRese
             }
             className="w-full bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-zinc-300 focus:outline-none focus:border-emerald-600"
           >
+            <option value="1">Depth 1</option>
             <option value="2">Depth 2</option>
             <option value="3">Depth 3</option>
             <option value="4">Depth 4</option>
@@ -410,6 +450,7 @@ export function FilterPanel({ filters, onChange, agentNames, validValues, onRese
           onChange={(e) => onChange({ ...filters, pageSize: Number(e.target.value) })}
           className="w-full bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-zinc-300 focus:outline-none focus:border-emerald-600"
         >
+          <option value="25">25 nodes</option>
           <option value="50">50 nodes</option>
           <option value="100">100 nodes</option>
           <option value="250">250 nodes</option>

--- a/ui/e2e/security-graph-readability.spec.ts
+++ b/ui/e2e/security-graph-readability.spec.ts
@@ -214,7 +214,7 @@ async function routeGraphPage(page: Page) {
 
 async function captureGraphScreenshot(page: Page, testInfo: TestInfo, theme: "dark" | "light") {
   await expect(page.getByRole("heading", { name: "Security Graph" })).toBeVisible();
-  await expect(page.getByText("Focused", { exact: true })).toBeVisible();
+  await expect(page.getByText("Relevant paths", { exact: true })).toBeVisible();
   await expect(page.getByText("Attack paths", { exact: true })).toBeVisible();
   await expect(page.locator('[data-testid="cluster-pill"]').first()).toBeVisible();
   await expect(page.getByTestId("graph-compression-summary")).toContainText(/compressed|rendered/);

--- a/ui/tests/graph-state-panels.test.tsx
+++ b/ui/tests/graph-state-panels.test.tsx
@@ -1,6 +1,16 @@
 import { fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
-import { GraphFindingsFallback, GraphPanelSkeleton, GraphRefreshOverlay } from '@/components/graph-state-panels'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+import { GraphEmptyState, GraphFindingsFallback, GraphPanelSkeleton, GraphRefreshOverlay } from '@/components/graph-state-panels'
 import type { LineageNodeData } from '@/components/lineage-nodes'
 
 function finding(index: number): { id: string; data: LineageNodeData } {
@@ -51,6 +61,20 @@ describe('GraphFindingsFallback', () => {
 })
 
 describe('Graph loading states', () => {
+  it('renders first command guidance in graph empty states', () => {
+    render(
+      <GraphEmptyState
+        title="No graph snapshots found"
+        detail="Run a scan first."
+        suggestions={["Use demo data."]}
+        command="agent-bom agents --demo --offline"
+      />,
+    )
+
+    expect(screen.getByText('First command')).toBeInTheDocument()
+    expect(screen.getByText('agent-bom agents --demo --offline')).toBeInTheDocument()
+  })
+
   it('renders a bounded graph panel skeleton', () => {
     render(<GraphPanelSkeleton title="Loading graph window" detail="Fetching a bounded graph window." />)
 

--- a/ui/tests/lineage-filter.test.tsx
+++ b/ui/tests/lineage-filter.test.tsx
@@ -4,6 +4,10 @@ import { describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_FILTERS,
   FilterPanel,
+  createExpandedGraphFilters,
+  createImmediateGraphFilters,
+  graphScopeLabelForFilters,
+  graphScopePresetForFilters,
   type FilterState,
 } from "@/components/lineage-filter";
 
@@ -19,6 +23,20 @@ describe("FilterPanel", () => {
     expect(DEFAULT_FILTERS.pageSize).toBe(50);
     expect(DEFAULT_FILTERS.vulnOnly).toBe(true);
     expect(DEFAULT_FILTERS.severity).toBe("high");
+    expect(graphScopePresetForFilters(DEFAULT_FILTERS)).toBe("relevant");
+    expect(graphScopeLabelForFilters(DEFAULT_FILTERS)).toBe("Relevant paths");
+  });
+
+  it("names graph scope presets by operator workflow instead of raw depth", () => {
+    const immediate = createImmediateGraphFilters("cursor");
+    const expanded = createExpandedGraphFilters();
+
+    expect(immediate.maxDepth).toBe(1);
+    expect(immediate.pageSize).toBe(25);
+    expect(graphScopeLabelForFilters(immediate)).toBe("Immediate");
+    expect(expanded.maxDepth).toBe(3);
+    expect(expanded.pageSize).toBe(250);
+    expect(graphScopeLabelForFilters(expanded)).toBe("Expanded");
   });
 
   it("windows large agent lists instead of rendering every agent option", () => {


### PR DESCRIPTION
## Summary
- add workflow-named graph scopes: Immediate, Relevant paths, and Expanded
- keep first graph views bounded while preserving expanded topology review
- add command-driven empty states for Security Graph, Lineage Graph, and Context Map
- reduce the Security Graph attack-path request budget from 250 to 75 paths

## Why
The graph surfaces were still exposing raw traversal knobs before explaining the operator workflow. This PR makes the default experience more like an enterprise security console: scoped, readable first, and explicit about how to expand when needed.

## Validation
- `cd ui && npm test -- --run tests/lineage-filter.test.tsx tests/graph-state-panels.test.tsx tests/filter-algebra.test.ts` — 19 passed
- `cd ui && npm run typecheck` — passed
- `git diff --check` — passed

## Note
- `cd ui && npm run build` could not run in this local shell because `npm run verify:toolchain` reports Node `25.9.0`; the repo requires `>=22 <25`. The failure happens before app code is compiled.
