### PR TITLE
cli: suggest nested command typos

### DIFF
--- a/src/agent_bom/cli/_cloud_group.py
+++ b/src/agent_bom/cli/_cloud_group.py
@@ -16,8 +16,10 @@ from typing import Optional
 
 import click
 
+from agent_bom.cli._grouped_help import SuggestingGroup
 
-@click.group("cloud", invoke_without_command=True)
+
+@click.group("cloud", cls=SuggestingGroup, invoke_without_command=True)
 @click.pass_context
 def cloud_group(ctx: click.Context) -> None:
     """Scan cloud infrastructure — AWS, Azure, GCP.

--- a/src/agent_bom/cli/_db.py
+++ b/src/agent_bom/cli/_db.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 import click
 
+from agent_bom.cli._grouped_help import SuggestingGroup
 
-@click.group("db")
+
+@click.group("db", cls=SuggestingGroup)
 def db_cmd() -> None:
     """Manage the local vulnerability database."""
 

--- a/src/agent_bom/cli/_firewall.py
+++ b/src/agent_bom/cli/_firewall.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import click
 
+from agent_bom.cli._grouped_help import SuggestingGroup
 from agent_bom.firewall import (
     FirewallDecision,
     FirewallPolicyError,
@@ -20,7 +21,7 @@ from agent_bom.firewall import (
 )
 
 
-@click.group("firewall", invoke_without_command=False)
+@click.group("firewall", cls=SuggestingGroup, invoke_without_command=False)
 def firewall_group() -> None:
     """Inter-agent firewall policy tooling.
 

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import click
 
 from agent_bom.cli._common import read_json_file_for_cli
+from agent_bom.cli._grouped_help import SuggestingGroup
 from agent_bom.cli._server import _is_loopback_host
 
 logger = logging.getLogger(__name__)
@@ -56,7 +57,7 @@ def _enforce_gateway_auth_defaults(host: str, bearer_token: str | None, allow_in
     )
 
 
-@click.group(help="Multi-MCP gateway commands.")
+@click.group(cls=SuggestingGroup, help="Multi-MCP gateway commands.")
 def gateway_group() -> None:
     """Entry point for gateway subcommands."""
 

--- a/src/agent_bom/cli/_grouped_help.py
+++ b/src/agent_bom/cli/_grouped_help.py
@@ -54,16 +54,8 @@ CATEGORY_DESCRIPTIONS: dict[str, str] = {
 }
 
 
-class GroupedGroup(click.Group):
-    """A Click group that displays commands organized by category.
-
-    Pass ``command_categories`` to override the default category mapping.
-    Each product (agent-bom, agent-shield, etc.) provides its own categories.
-    """
-
-    def __init__(self, *args, command_categories=None, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._command_categories = command_categories or COMMAND_CATEGORIES
+class SuggestingGroup(click.Group):
+    """A Click group that suggests nearby subcommands on typos."""
 
     def resolve_command(self, ctx: click.Context, args: list[str]):
         try:
@@ -84,6 +76,18 @@ class GroupedGroup(click.Group):
             visible_commands.append(name)
         matches = get_close_matches(command_name, visible_commands, n=1, cutoff=0.62)
         return matches[0] if matches else None
+
+
+class GroupedGroup(SuggestingGroup):
+    """A Click group that displays commands organized by category.
+
+    Pass ``command_categories`` to override the default category mapping.
+    Each product (agent-bom, agent-shield, etc.) provides its own categories.
+    """
+
+    def __init__(self, *args, command_categories=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._command_categories = command_categories or COMMAND_CATEGORIES
 
     def format_commands(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         # Collect all available commands

--- a/src/agent_bom/cli/_mcp_group.py
+++ b/src/agent_bom/cli/_mcp_group.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 
 import click
 
+from agent_bom.cli._grouped_help import SuggestingGroup
 
-@click.group("mcp", invoke_without_command=True)
+
+@click.group("mcp", cls=SuggestingGroup, invoke_without_command=True)
 @click.pass_context
 def mcp_group(ctx: click.Context) -> None:
     """Discover, scan, and manage MCP agents and servers.

--- a/src/agent_bom/cli/_policy_group.py
+++ b/src/agent_bom/cli/_policy_group.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 
 import click
 
+from agent_bom.cli._grouped_help import SuggestingGroup
 
-@click.group("policy", invoke_without_command=True)
+
+@click.group("policy", cls=SuggestingGroup, invoke_without_command=True)
 @click.pass_context
 def policy_group(ctx: click.Context) -> None:
     """Policy management — install guards, templates, and remediation.

--- a/src/agent_bom/cli/_registry.py
+++ b/src/agent_bom/cli/_registry.py
@@ -10,8 +10,10 @@ from typing import Optional
 import click
 from rich.console import Console
 
+from agent_bom.cli._grouped_help import SuggestingGroup
 
-@click.group()
+
+@click.group(cls=SuggestingGroup)
 def schedule():
     """Manage recurring scan schedules."""
 
@@ -102,7 +104,7 @@ def schedule_remove(schedule_id: str):
         sys.exit(1)
 
 
-@click.group()
+@click.group(cls=SuggestingGroup)
 def registry():
     """Manage the MCP server registry."""
 

--- a/src/agent_bom/cli/_report_group.py
+++ b/src/agent_bom/cli/_report_group.py
@@ -18,8 +18,10 @@ from pathlib import Path
 
 import click
 
+from agent_bom.cli._grouped_help import SuggestingGroup
 
-@click.group("report", invoke_without_command=True)
+
+@click.group("report", cls=SuggestingGroup, invoke_without_command=True)
 @click.pass_context
 def report_group(ctx: click.Context) -> None:
     """Reports — history, diff, analytics, and dashboard helpers.

--- a/src/agent_bom/cli/_runtime_group.py
+++ b/src/agent_bom/cli/_runtime_group.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 import click
 
+from agent_bom.cli._grouped_help import SuggestingGroup
 
-@click.group("runtime", invoke_without_command=True)
+
+@click.group("runtime", cls=SuggestingGroup, invoke_without_command=True)
 @click.pass_context
 def runtime_group(ctx: click.Context) -> None:
     """Runtime enforcement — proxy and audit MCP traffic.

--- a/src/agent_bom/cli/_samples.py
+++ b/src/agent_bom/cli/_samples.py
@@ -6,10 +6,11 @@ from pathlib import Path
 
 import click
 
+from agent_bom.cli._grouped_help import SuggestingGroup
 from agent_bom.samples import write_first_run_sample
 
 
-@click.group(name="samples")
+@click.group(name="samples", cls=SuggestingGroup)
 def samples_group() -> None:
     """Create bundled sample inputs for demos and first-run scans."""
 

--- a/src/agent_bom/cli/_skills_group.py
+++ b/src/agent_bom/cli/_skills_group.py
@@ -11,6 +11,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from agent_bom.cli._grouped_help import SuggestingGroup
 from agent_bom.skills_service import rescan_skill_catalog, scan_skill_targets, verify_skill_targets
 
 _VERDICT_ORDER = {"benign": 0, "suspicious": 1, "malicious": 2}
@@ -25,7 +26,7 @@ def _display_path(path: str) -> str:
         return p.name or str(p)
 
 
-@click.group("skills", invoke_without_command=True)
+@click.group("skills", cls=SuggestingGroup, invoke_without_command=True)
 @click.pass_context
 def skills_group(ctx: click.Context) -> None:
     """Scan, verify, and rescan AI instruction files, skills, and agent prompts.

--- a/src/agent_bom/cli/claw.py
+++ b/src/agent_bom/cli/claw.py
@@ -15,7 +15,7 @@ import click
 
 from agent_bom import __version__
 from agent_bom.cli._entry import make_entry_point
-from agent_bom.cli._grouped_help import GroupedGroup
+from agent_bom.cli._grouped_help import GroupedGroup, SuggestingGroup
 
 # ── Help categories ──────────────────────────────────────────────────────────
 
@@ -67,7 +67,7 @@ def claw():
 # ── Fleet command group (new) ────────────────────────────────────────────────
 
 
-@click.group("fleet", invoke_without_command=True)
+@click.group("fleet", cls=SuggestingGroup, invoke_without_command=True)
 @click.pass_context
 def fleet_group(ctx: click.Context) -> None:
     """Manage AI agent fleet — discovery, lifecycle, trust scoring.

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -33,6 +33,14 @@ class TestAgentBom:
         assert "No such command 'scna'" in r.output
         assert "Did you mean 'scan'?" in r.output
 
+    def test_nested_unknown_command_suggests_nearest_command(self):
+        from agent_bom.cli import main
+
+        r = CliRunner().invoke(main, ["mcp", "valdte"])
+        assert r.exit_code != 0
+        assert "No such command 'valdte'" in r.output
+        assert "Did you mean 'validate'?" in r.output
+
     def test_version(self):
         from agent_bom.cli import main
 


### PR DESCRIPTION
## Summary
- split the existing top-level typo suggestion behavior into a reusable `SuggestingGroup`
- apply typo suggestions to nested command groups such as `mcp`, `policy`, `report`, `cloud`, `runtime`, `skills`, `registry`, `db`, `gateway`, `firewall`, and `samples`
- add regression coverage for `agent-bom mcp valdte` suggesting `validate`

Closes #2429.

## Validation
- `uv run pytest -q tests/test_cli_entry_points.py`
- `uv run ruff check src/agent_bom/cli tests/test_cli_entry_points.py`
- `git diff --check`
- `uv run agent-bom mcp valdte`

Note: `uv` warned about stale local `.venv` dist-info directories missing `RECORD`, but the checks completed successfully.
