### PR TITLE
test: fix graph defaults E2E selector

### DIFF
--- a/ui/e2e/security-graph-readability.spec.ts
+++ b/ui/e2e/security-graph-readability.spec.ts
@@ -214,7 +214,7 @@ async function routeGraphPage(page: Page) {
 
 async function captureGraphScreenshot(page: Page, testInfo: TestInfo, theme: "dark" | "light") {
   await expect(page.getByRole("heading", { name: "Security Graph" })).toBeVisible();
-  await expect(page.getByText("Relevant paths", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Relevant paths", exact: true })).toBeVisible();
   await expect(page.getByText("Attack paths", { exact: true })).toBeVisible();
   await expect(page.locator('[data-testid="cluster-pill"]').first()).toBeVisible();
   await expect(page.getByTestId("graph-compression-summary")).toContainText(/compressed|rendered/);


### PR DESCRIPTION
## Summary
- fix the graph product defaults E2E selector that failed in UI Validate after #2425 merged
- target the `Relevant paths` preset by button role/name instead of broad text lookup
- keep the dense graph dark/light screenshot readiness assertions intact

Closes #2427.

## Validation
- `git diff --check`
- `cd ui && npm run typecheck`
- `cd ui && npm run test:e2e -- e2e/security-graph-readability.spec.ts`

Note: local Node is v25.9.0 while the UI package declares `>=22 <25`; the focused checks still completed after refreshing `ui/node_modules` with `npm ci`.
