### PR TITLE
cli: make runtime watch visible

### DIFF
--- a/site-docs/deployment/runtime-monitoring.md
+++ b/site-docs/deployment/runtime-monitoring.md
@@ -44,7 +44,7 @@ The `watch` command supports webhook alerts to:
 - Custom webhook URLs
 
 ```bash
-agent-bom watch --webhook-url https://hooks.slack.com/... --watch-interval 60
+agent-bom watch --webhook https://hooks.slack.com/... --interval 60
 ```
 
 ## Operator guides

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -24,6 +24,7 @@
 | Command | Description |
 |---------|-------------|
 | `proxy` | Run an MCP server through the agent-bom security proxy |
+| `watch` | Watch MCP client configuration files for drift and alert on new risks |
 | `audit` | View and analyze a proxy audit JSONL log |
 | `audit-drain-dlq` | Replay or inspect proxy audit dead-letter queue entries |
 

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -213,13 +213,13 @@ runtime_group.add_command(protect_cmd, "protect")
 runtime_group.add_command(watch_cmd, "watch")
 runtime_group.commands["configure"].hidden = True
 runtime_group.commands["protect"].hidden = True
-runtime_group.commands["watch"].hidden = True
 main.add_command(runtime_group)
 main.commands["runtime"].hidden = True  # Use proxy/audit directly
 
 # Top-level shortcuts for primary runtime commands
 main.add_command(proxy_cmd, "proxy")
 main.add_command(proxy_bootstrap_cmd, "proxy-bootstrap")
+main.add_command(watch_cmd, "watch")
 main.add_command(audit_replay_cmd, "audit")
 main.add_command(audit_drain_dlq_cmd, "audit-drain-dlq")
 

--- a/src/agent_bom/cli/_grouped_help.py
+++ b/src/agent_bom/cli/_grouped_help.py
@@ -17,7 +17,7 @@ COMMAND_CATEGORIES: OrderedDict[str, list[str]] = OrderedDict(
         ),
         (
             "Runtime",
-            ["proxy", "audit"],
+            ["proxy", "watch", "audit"],
         ),
         (
             "MCP",

--- a/src/agent_bom/cli/_runtime.py
+++ b/src/agent_bom/cli/_runtime.py
@@ -851,9 +851,10 @@ def watch_cmd(webhook, alert_log, interval):
 
     \b
     Usage:
+      agent-bom watch
+      agent-bom watch --webhook https://hooks.slack.com/services/...
+      agent-bom watch --log alerts.jsonl
       agent-bom runtime watch
-      agent-bom runtime watch --webhook https://hooks.slack.com/services/...
-      agent-bom runtime watch --log alerts.jsonl
     """
     from agent_bom.watch import (
         AlertSink,

--- a/src/agent_bom/cli/_runtime_group.py
+++ b/src/agent_bom/cli/_runtime_group.py
@@ -23,10 +23,10 @@ def runtime_group(ctx: click.Context) -> None:
     Subcommands:
       proxy       Run MCP server through security proxy
       audit       View and analyze proxy audit log
+      watch       Watch MCP configs for drift and alert
 
     Hidden compatibility commands:
       protect     Runtime protection engine (8 behavioral detectors)
-      watch       Watch MCP configs for drift and alert
       configure   Auto-configure proxy for discovered servers
     """
     if ctx.invoked_subcommand is None:

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -75,12 +75,24 @@ class TestAgentBom:
         r = CliRunner().invoke(main, ["check", "--help"])
         assert r.exit_code == 0
 
+    def test_watch_is_visible_runtime_workflow(self):
+        from agent_bom.cli import main
+
+        help_result = CliRunner().invoke(main, ["--help"])
+        assert help_result.exit_code == 0
+        assert "watch" in help_result.output
+
+        watch_result = CliRunner().invoke(main, ["watch", "--help"])
+        assert watch_result.exit_code == 0
+        assert "Watch MCP configs" in watch_result.output
+
     def test_backward_compat_runtime_group(self):
         from agent_bom.cli import main
 
         r = CliRunner().invoke(main, ["runtime", "--help"])
         assert r.exit_code == 0
         assert "proxy" in r.output
+        assert "watch" in r.output
 
     def test_backward_compat_cloud_group(self):
         from agent_bom.cli import main

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -139,6 +139,20 @@ def test_watch_cli_help():
     from agent_bom.cli import main
 
     runner = CliRunner()
+    result = runner.invoke(main, ["watch", "--help"])
+
+    assert result.exit_code == 0
+    assert "Watch MCP configs" in result.output
+    assert "agent-bom watch --log alerts.jsonl" in result.output
+
+
+def test_runtime_watch_remains_available():
+    """``agent-bom runtime watch`` remains available for existing operators."""
+    from click.testing import CliRunner
+
+    from agent_bom.cli import main
+
+    runner = CliRunner()
     result = runner.invoke(main, ["runtime", "watch", "--help"])
 
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- expose `agent-bom watch` as a visible runtime workflow
- keep `agent-bom runtime watch` available for existing operators
- update CLI reference and runtime monitoring docs to use the actual watch flags
- add regression coverage for visible root help and runtime compatibility

Closes #2430.

## Validation
- `uv run pytest -q tests/test_watch.py::test_watch_cli_help tests/test_watch.py::test_runtime_watch_remains_available tests/test_cli_entry_points.py::TestAgentBom::test_watch_is_visible_runtime_workflow tests/test_cli_entry_points.py::TestAgentBom::test_backward_compat_runtime_group tests/test_public_docs_cli_alignment.py`
- `uv run ruff check src/agent_bom/cli tests/test_watch.py tests/test_cli_entry_points.py`
- `git diff --check`
- `uv run agent-bom --help`
- `uv run agent-bom watch --help`

Note: `uv` warned about stale local `.venv` dist-info directories missing `RECORD`, but the checks completed successfully.
