### PR TITLE
ui: expand command palette actions

### DIFF
--- a/ui/components/command-palette.tsx
+++ b/ui/components/command-palette.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import Link from "next/link";
+import type { ElementType } from "react";
+import { useEffect } from "react";
+import { Search } from "lucide-react";
+
+export interface CommandPaletteLink {
+  href: string;
+  label: string;
+  group: string;
+  icon: ElementType;
+}
+
+export interface CommandPaletteAction {
+  id: string;
+  label: string;
+  group: string;
+  icon: ElementType;
+  run: () => void;
+  keywords?: string[];
+}
+
+interface CommandPaletteProps {
+  query: string;
+  links: CommandPaletteLink[];
+  actions?: CommandPaletteAction[];
+  setQuery: (query: string) => void;
+  onClose: () => void;
+}
+
+function matchesQuery(query: string, label: string, group: string, keywords: string[] = []) {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return [label, group, ...keywords].some((value) => value.toLowerCase().includes(q));
+}
+
+export function CommandPalette({ query, links, actions = [], setQuery, onClose }: CommandPaletteProps) {
+  const filteredLinks = links.filter((link) => matchesQuery(query, link.label, link.group));
+  const filteredActions = actions.filter((action) => matchesQuery(query, action.label, action.group, action.keywords));
+  const hasResults = filteredLinks.length > 0 || filteredActions.length > 0;
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-start justify-center pt-[15vh]" role="dialog" aria-label="Command palette">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+      <div className="relative w-full max-w-lg overflow-hidden rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] shadow-2xl">
+        <div className="flex items-center gap-3 border-b border-[color:var(--border-subtle)] px-4 py-3">
+          <Search className="h-4 w-4 shrink-0 text-[color:var(--text-secondary)]" />
+          <input
+            autoFocus
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search pages and commands..."
+            className="flex-1 bg-transparent text-sm text-[color:var(--foreground)] outline-none placeholder:text-[color:var(--text-secondary)]"
+          />
+          <kbd className="rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-1.5 py-0.5 font-mono text-[10px] text-[color:var(--text-secondary)]">
+            ESC
+          </kbd>
+        </div>
+        <div className="max-h-[50vh] overflow-y-auto py-2">
+          {!hasResults ? (
+            <div className="px-4 py-8 text-center text-sm text-[color:var(--text-secondary)]">No results found</div>
+          ) : (
+            <>
+              {filteredActions.map(({ id, label, icon: Icon, group, run }) => (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => {
+                    run();
+                    onClose();
+                  }}
+                  className="flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm text-[color:var(--foreground)] transition-colors hover:bg-[color:var(--surface-elevated)]"
+                >
+                  <Icon className="h-4 w-4 shrink-0 text-[color:var(--text-secondary)]" />
+                  <span className="flex-1">{label}</span>
+                  <span className="text-[10px] uppercase tracking-wider text-[color:var(--text-tertiary)]">{group}</span>
+                </button>
+              ))}
+              {filteredLinks.map(({ href, label, icon: Icon, group }) => (
+                <Link
+                  key={href}
+                  href={href}
+                  onClick={onClose}
+                  className="flex items-center gap-3 px-4 py-2.5 text-sm text-[color:var(--foreground)] transition-colors hover:bg-[color:var(--surface-elevated)]"
+                >
+                  <Icon className="h-4 w-4 shrink-0 text-[color:var(--text-secondary)]" />
+                  <span className="flex-1">{label}</span>
+                  <span className="text-[10px] uppercase tracking-wider text-[color:var(--text-tertiary)]">{group}</span>
+                </Link>
+              ))}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
 import {
   Scan,
   Server,
@@ -28,10 +28,15 @@ import {
   Search,
   LayoutDashboard,
   Wrench,
+  RefreshCw,
+  Focus,
+  Copy,
+  SunMoon,
 } from "lucide-react";
 import { api } from "@/lib/api";
 import { useAuthState } from "@/components/auth-provider";
 import { BrandMark } from "@/components/brand-mark";
+import { CommandPalette, type CommandPaletteAction } from "@/components/command-palette";
 import { ThemeToggle } from "@/components/theme-toggle";
 import {
   deploymentModeLabel,
@@ -240,6 +245,59 @@ export function Nav() {
     })
     .filter((group) => group.visibleLinks.length > 0 || group.hiddenLinks.length > 0);
   const commandLinks = navGroups.flatMap((group) => group.visibleLinks.map((link) => ({ ...link, group: group.label })));
+  const commandActions = useMemo<CommandPaletteAction[]>(
+    () => [
+      {
+        id: "refresh-view",
+        label: "Refresh current view",
+        group: "Action",
+        icon: RefreshCw,
+        keywords: ["reload", "update"],
+        run: () => window.location.reload(),
+      },
+      {
+        id: "focus-main",
+        label: "Focus main content",
+        group: "Action",
+        icon: Focus,
+        keywords: ["skip", "content"],
+        run: () => {
+          const main = document.getElementById("main-content");
+          if (!main) return;
+          if (!main.hasAttribute("tabindex")) {
+            main.setAttribute("tabindex", "-1");
+          }
+          main.focus();
+        },
+      },
+      {
+        id: "copy-url",
+        label: "Copy current URL",
+        group: "Action",
+        icon: Copy,
+        keywords: ["share", "link"],
+        run: () => {
+          void navigator.clipboard?.writeText(window.location.href);
+        },
+      },
+      {
+        id: "toggle-theme",
+        label: "Toggle theme",
+        group: "Action",
+        icon: SunMoon,
+        keywords: ["dark", "light"],
+        run: () => {
+          const current = document.documentElement.dataset.theme === "light" ? "light" : "dark";
+          const next = current === "dark" ? "light" : "dark";
+          document.documentElement.dataset.theme = next;
+          document.documentElement.style.colorScheme = next;
+          window.localStorage.setItem("agent-bom-theme", next);
+          window.dispatchEvent(new Event("agent-bom-theme-change"));
+        },
+      },
+    ],
+    []
+  );
 
   const sidebarContent = (
     <>
@@ -523,6 +581,7 @@ export function Nav() {
         <CommandPalette
           query={searchQuery}
           links={commandLinks}
+          actions={commandActions}
           setQuery={setSearchQuery}
           onClose={() => { setSearchOpen(false); setSearchQuery(""); }}
         />
@@ -578,73 +637,6 @@ function SessionStatus({
       <p className="mt-1 text-[11px] text-[color:var(--text-secondary)]">
         {session.role_summary?.display_name ?? session.role ?? "Unknown"} · tenant {session.tenant_id}
       </p>
-    </div>
-  );
-}
-
-// ─── Command Palette ────────────────────────────────────────────────────────
-
-function CommandPalette({
-  query,
-  links,
-  setQuery,
-  onClose,
-}: {
-  query: string;
-  links: Array<NavLink & { group: string }>;
-  setQuery: (q: string) => void;
-  onClose: () => void;
-}) {
-  const filtered = query
-    ? links.filter(
-        (l) =>
-          l.label.toLowerCase().includes(query.toLowerCase()) ||
-          l.group.toLowerCase().includes(query.toLowerCase())
-      )
-    : links;
-
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [onClose]);
-
-  return (
-    <div className="fixed inset-0 z-[100] flex items-start justify-center pt-[15vh]">
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
-      <div className="relative w-full max-w-lg bg-[color:var(--surface)] border border-[color:var(--border-subtle)] rounded-xl shadow-2xl overflow-hidden">
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-[color:var(--border-subtle)]">
-          <Search className="w-4 h-4 text-[color:var(--text-secondary)] shrink-0" />
-          <input
-            autoFocus
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search pages, commands..."
-            className="flex-1 bg-transparent text-sm text-[color:var(--foreground)] placeholder:text-[color:var(--text-secondary)] outline-none"
-          />
-          <kbd className="text-[10px] font-mono bg-[color:var(--surface-elevated)] border border-[color:var(--border-subtle)] rounded px-1.5 py-0.5 text-[color:var(--text-secondary)]">ESC</kbd>
-        </div>
-        <div className="max-h-[50vh] overflow-y-auto py-2">
-          {filtered.length === 0 ? (
-            <div className="px-4 py-8 text-center text-sm text-[color:var(--text-secondary)]">No results found</div>
-          ) : (
-            filtered.map(({ href, label, icon: Icon, group }) => (
-              <Link
-                key={href}
-                href={href}
-                onClick={onClose}
-                className="flex items-center gap-3 px-4 py-2.5 text-sm text-[color:var(--foreground)] hover:bg-[color:var(--surface-elevated)] transition-colors"
-              >
-                <Icon className="w-4 h-4 text-[color:var(--text-secondary)]" />
-                <span className="flex-1">{label}</span>
-                <span className="text-[10px] text-[color:var(--text-tertiary)] uppercase tracking-wider">{group}</span>
-              </Link>
-            ))
-          )}
-        </div>
-      </div>
     </div>
   );
 }

--- a/ui/tests/command-palette.test.tsx
+++ b/ui/tests/command-palette.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+
+import { CommandPalette, type CommandPaletteAction } from "@/components/command-palette";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+function Icon() {
+  return <span aria-hidden="true" />;
+}
+
+function Harness({ actions = [], onClose = vi.fn() }: { actions?: CommandPaletteAction[]; onClose?: () => void }) {
+  const [query, setQuery] = useState("");
+  return (
+    <CommandPalette
+      query={query}
+      setQuery={setQuery}
+      onClose={onClose}
+      actions={actions}
+      links={[{ href: "/findings", label: "Findings", group: "Scan", icon: Icon }]}
+    />
+  );
+}
+
+describe("CommandPalette", () => {
+  it("shows page links and command actions", () => {
+    render(<Harness actions={[{ id: "refresh", label: "Refresh current view", group: "Action", icon: Icon, run: vi.fn() }]} />);
+
+    expect(screen.getByRole("link", { name: /findings/i })).toHaveAttribute("href", "/findings");
+    expect(screen.getByRole("button", { name: /refresh current view/i })).toBeInTheDocument();
+  });
+
+  it("filters actions by keyword", () => {
+    render(
+      <Harness
+        actions={[
+          { id: "copy", label: "Copy current URL", group: "Action", icon: Icon, keywords: ["share"], run: vi.fn() },
+        ]}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Search pages and commands..."), { target: { value: "share" } });
+
+    expect(screen.getByRole("button", { name: /copy current url/i })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /findings/i })).not.toBeInTheDocument();
+  });
+
+  it("runs an action and closes the palette", () => {
+    const run = vi.fn();
+    const onClose = vi.fn();
+    render(<Harness onClose={onClose} actions={[{ id: "focus", label: "Focus main content", group: "Action", icon: Icon, run }]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /focus main content/i }));
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Escape", () => {
+    const onClose = vi.fn();
+    render(<Harness onClose={onClose} />);
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 let mockedPathname = '/'
@@ -162,6 +162,17 @@ describe('Nav', () => {
     fireEvent.click(screen.getByRole('button', { name: /protect/i }))
     const links = screen.getAllByRole('link', { name: /audit log/i })
     expect(links.some((l) => l.getAttribute('href') === '/audit')).toBe(true)
+  })
+
+  it('opens the command palette with page links and actions', () => {
+    render(<Nav />)
+
+    fireEvent.keyDown(window, { key: 'k', metaKey: true })
+
+    const palette = screen.getByRole('dialog', { name: /command palette/i })
+    expect(palette).toBeInTheDocument()
+    expect(within(palette).getByRole('button', { name: /refresh current view/i })).toBeInTheDocument()
+    expect(within(palette).getByRole('link', { name: /dashboard/i })).toHaveAttribute('href', '/')
   })
 
   it('renders the agent-bom brand text', () => {


### PR DESCRIPTION
## Summary
- extract the navigation command palette into a reusable component
- keep page navigation search and add action commands for refresh, focus main content, copy current URL, and theme toggle
- add focused tests for filtering, selecting actions, Escape close, and opening from the nav shortcut

Closes #2431.

## Validation
- `cd ui && npm test -- --run tests/command-palette.test.tsx tests/nav.test.tsx`
- `cd ui && npm run typecheck`
- `cd ui && npm run lint`
- `git diff --check`

Note: local Node is v25.9.0 while the UI package declares `>=22 <25`; the focused checks still completed successfully.
