### PR TITLE
cli: hide runtime watch compatibility alias

### DIFF
--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -199,7 +199,8 @@ from agent_bom.cli._runtime import (  # noqa: E402
 )
 
 # ---------------------------------------------------------------------------
-# Runtime command group — `agent-bom runtime [proxy|protect|watch|audit|configure]`
+# Runtime command group — hidden compatibility namespace.
+# Prefer top-level commands: `agent-bom proxy`, `agent-bom watch`, `agent-bom audit`.
 # ---------------------------------------------------------------------------
 from agent_bom.cli._runtime_group import runtime_group  # noqa: E402
 
@@ -210,11 +211,14 @@ runtime_group.add_command(proxy_bootstrap_cmd, "bootstrap")
 # Deprecated — hidden but still work for backward compat
 runtime_group.add_command(proxy_configure_cmd, "configure")
 runtime_group.add_command(protect_cmd, "protect")
-runtime_group.add_command(watch_cmd, "watch")
+_runtime_watch_hidden = _copy.copy(watch_cmd)
+_runtime_watch_hidden.hidden = True
+_runtime_watch_hidden.name = "watch"
+runtime_group.add_command(_runtime_watch_hidden, "watch")
 runtime_group.commands["configure"].hidden = True
 runtime_group.commands["protect"].hidden = True
 main.add_command(runtime_group)
-main.commands["runtime"].hidden = True  # Use proxy/audit directly
+main.commands["runtime"].hidden = True  # Use proxy/watch/audit directly
 
 # Top-level shortcuts for primary runtime commands
 main.add_command(proxy_cmd, "proxy")

--- a/src/agent_bom/cli/_runtime_group.py
+++ b/src/agent_bom/cli/_runtime_group.py
@@ -23,7 +23,6 @@ def runtime_group(ctx: click.Context) -> None:
     Subcommands:
       proxy       Run MCP server through security proxy
       audit       View and analyze proxy audit log
-      watch       Watch MCP configs for drift and alert
 
     Hidden compatibility commands:
       protect     Runtime protection engine (8 behavioral detectors)

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -92,7 +92,11 @@ class TestAgentBom:
         r = CliRunner().invoke(main, ["runtime", "--help"])
         assert r.exit_code == 0
         assert "proxy" in r.output
-        assert "watch" in r.output
+        assert "watch" not in r.output
+
+        watch_result = CliRunner().invoke(main, ["runtime", "watch", "--help"])
+        assert watch_result.exit_code == 0
+        assert "Watch MCP configs" in watch_result.output
 
     def test_backward_compat_cloud_group(self):
         from agent_bom.cli import main


### PR DESCRIPTION
## Summary
- keep `agent-bom watch` as the visible and documented command
- keep `agent-bom runtime watch` working as a hidden compatibility alias
- update CLI tests so runtime help does not advertise the compatibility path

Follow-up to #2437.

## Validation
- `uv run pytest -q tests/test_watch.py::test_watch_cli_help tests/test_watch.py::test_runtime_watch_remains_available tests/test_cli_entry_points.py::TestAgentBom::test_watch_is_visible_runtime_workflow tests/test_cli_entry_points.py::TestAgentBom::test_backward_compat_runtime_group`
- `uv run ruff check src/agent_bom/cli/__init__.py src/agent_bom/cli/_runtime_group.py tests/test_cli_entry_points.py tests/test_watch.py`
- `git diff --check`
