### PR TITLE
ui: add shared page state panels

### DIFF
--- a/ui/app/agents/page.tsx
+++ b/ui/app/agents/page.tsx
@@ -55,6 +55,7 @@ import {
   X,
 } from "lucide-react";
 import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
+import { PageEmptyState, PageErrorState, PageLoadingState } from "@/components/states/page-state";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { isDeploymentSurfaceAvailable } from "@/lib/deployment-context";
 
@@ -311,12 +312,24 @@ function AgentsList() {
       )}
 
       {loading && (
-        <div className="flex items-center justify-center py-20 text-zinc-400">
-          <Loader2 className="h-6 w-6 animate-spin mr-2" />
-          Discovering agents...
-        </div>
+        <PageLoadingState
+          title="Discovering agents"
+          detail="Loading configured agents, MCP servers, packages, credentials, and inventory metadata from the API."
+          data-testid="agents-loading-state"
+        />
       )}
-      {error && <p className="text-red-400 text-sm">{error}</p>}
+      {error && (
+        <PageErrorState
+          title="Could not load agents"
+          detail={error}
+          suggestions={[
+            "Confirm the API is reachable for this dashboard session.",
+            "Run a local discovery scan if this is a first-run environment.",
+            "Use the scan page to generate a fresh inventory artifact.",
+          ]}
+          command="agent-bom agents --demo --offline"
+        />
+      )}
 
       {/* Summary stats bar */}
       {!loading && agents.length > 0 && (
@@ -360,17 +373,23 @@ function AgentsList() {
         </div>
       )}
 
-      {!loading && agents.length === 0 &&
+      {!loading && !error && agents.length === 0 &&
         (counts && !isDeploymentSurfaceAvailable("agents", counts) ? (
           <DeploymentSurfaceRequiredState surface="agents" counts={counts} detail={error || null} />
         ) : (
-          <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
-            <Server className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
-            <p className="text-zinc-500 text-sm">No agents discovered locally.</p>
-            <p className="text-zinc-600 text-xs mt-1">
-              Install Claude Desktop, Cursor, or Windsurf and configure MCP servers.
-            </p>
-          </div>
+          <PageEmptyState
+            title="No agents discovered yet"
+            detail="Run discovery against this workspace or load a demo scan to populate configured agents, MCP servers, packages, and credentials."
+            icon={Server}
+            suggestions={[
+              "Start with the offline demo if you need a reproducible sample.",
+              "Run a local scan from the same environment where MCP clients are configured.",
+              "Open the mesh view after discovery to inspect agent and server relationships.",
+            ]}
+            command="agent-bom agents --demo --offline"
+            action={{ label: "Open scan", href: "/scan" }}
+            data-testid="agents-empty-state"
+          />
         ))}
 
       {/* Configured agents — row-virtualized for large estates */}
@@ -540,9 +559,15 @@ function AgentsList() {
         </div>
       </div>
       {!loading && filteredConfigured.length === 0 && configured.length > 0 && (
-        <div className="rounded-xl border border-dashed border-zinc-800 py-12 text-center">
-          <p className="text-sm text-zinc-500">No configured agents match the current search.</p>
-        </div>
+        <PageEmptyState
+          title="No configured agents match"
+          detail="The current search filtered out every configured agent in this inventory."
+          icon={Search}
+          suggestions={[
+            "Clear the search to return to the full configured list.",
+            "Search by exact agent name, source, or agent type.",
+          ]}
+        />
       )}
 
       {/* Installed but not configured — virtualized for parity with the configured list */}

--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -34,16 +34,15 @@ import {
   Server,
   ChevronDown,
   ChevronRight,
-  Loader2,
   Scan,
   Grid3X3,
   List,
   Search,
 } from "lucide-react";
-import Link from "next/link";
 import { ComplianceHeatmap } from "@/components/compliance-heatmap";
 import { ComplianceMatrix } from "@/components/compliance-matrix";
 import { ApiOfflineState } from "@/components/api-offline-state";
+import { PageEmptyState, PageLoadingState } from "@/components/states/page-state";
 import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
 
 function _classifyApiErrorKind(err: unknown): "network" | "auth" | "forbidden" {
@@ -424,9 +423,11 @@ function CompliancePageContent() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-[60vh]">
-        <Loader2 className="w-6 h-6 text-zinc-500 animate-spin" />
-      </div>
+      <PageLoadingState
+        title="Loading compliance posture"
+        detail="Fetching framework coverage, catalog metadata, and hub posture evidence from the API."
+        data-testid="compliance-loading-state"
+      />
     );
   }
 
@@ -914,22 +915,19 @@ function CompliancePageContent() {
 
       {/* ── Empty state ───────────────────────────────────────────────── */}
       {data.scan_count === 0 && (
-        <div className="text-center py-12 space-y-4">
-          <Scan className="w-12 h-12 text-zinc-600 mx-auto" />
-          <h3 className="text-lg font-medium text-zinc-300">No scans yet</h3>
-          <p className="text-sm text-zinc-500 max-w-md mx-auto">
-            Run a scan to populate the compliance posture dashboard.
-            Compliance scores are computed from OWASP, ATLAS, and NIST
-            framework tags on your blast radius findings.
-          </p>
-          <Link
-            href="/scan"
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white text-sm font-medium transition-colors"
-          >
-            <Scan className="w-4 h-4" />
-            Start a Scan
-          </Link>
-        </div>
+        <PageEmptyState
+          title="No compliance scans yet"
+          detail="Run a scan to populate framework coverage, control status, affected packages, and governance evidence."
+          icon={Scan}
+          suggestions={[
+            "Start with a local scan to generate compliance-tagged findings.",
+            "Open findings after the scan to verify the evidence behind failed controls.",
+            "Use the matrix view once multiple frameworks have populated control coverage.",
+          ]}
+          command="agent-bom agents --demo --offline"
+          action={{ label: "Start a scan", href: "/scan" }}
+          data-testid="compliance-empty-state"
+        />
       )}
     </div>
   );
@@ -939,10 +937,10 @@ export default function CompliancePage() {
   return (
     <Suspense
       fallback={
-        <div className="flex items-center justify-center py-20 text-zinc-400">
-          <Loader2 className="mr-2 h-6 w-6 animate-spin" />
-          Loading compliance posture...
-        </div>
+        <PageLoadingState
+          title="Loading compliance posture"
+          detail="Preparing framework controls and scan-derived posture summaries."
+        />
       }
     >
       <CompliancePageContent />

--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { api, Vulnerability, ScanJob, ScanResult, severityColor, severityDot, JobListItem, RemediationItem, type UnifiedGraphResponse } from "@/lib/api";
 import { ApiOfflineState } from "@/components/api-offline-state";
+import { PageEmptyState, PageLoadingState } from "@/components/states/page-state";
 import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
 import { Bug, Download, ExternalLink, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Layers, Loader2, Package, Server, ShieldOff, Radar, FileSearch, ShieldAlert } from "lucide-react";
 
@@ -250,10 +251,10 @@ function SortButton({
 export default function VulnsPageWrapper() {
   return (
     <Suspense fallback={
-      <div className="flex items-center justify-center py-20 text-zinc-400">
-        <Loader2 className="h-6 w-6 animate-spin mr-2" />
-        Loading vulnerabilities...
-      </div>
+      <PageLoadingState
+        title="Loading findings"
+        detail="Preparing scan summaries and vulnerability evidence for the findings view."
+      />
     }>
       <VulnsPage />
     </Suspense>
@@ -590,16 +591,17 @@ function VulnsPage() {
       </div>
 
       {loading && (
-        <div className="flex items-center justify-center py-20 text-zinc-400">
-          <Loader2 className="h-6 w-6 animate-spin mr-2" />
-          Loading scan summaries...
-        </div>
+        <PageLoadingState
+          title="Loading scan summaries"
+          detail="Fetching completed scan jobs before loading vulnerability and graph-backed finding evidence."
+          data-testid="findings-loading-state"
+        />
       )}
       {!loading && detailLoading && vulns.length === 0 && (
-        <div className="flex items-center justify-center py-20 text-zinc-400">
-          <Loader2 className="h-6 w-6 animate-spin mr-2" />
-          {scope === "latest" ? "Loading latest scan..." : "Aggregating completed scans..."}
-        </div>
+        <PageLoadingState
+          title={scope === "latest" ? "Loading latest scan" : "Aggregating completed scans"}
+          detail="Resolving vulnerability records, affected packages, agents, reachability, and remediation links."
+        />
       )}
       {!loading && error && (
         <ApiOfflineState
@@ -610,13 +612,19 @@ function VulnsPage() {
       )}
 
       {!loading && !error && vulns.length === 0 && (
-          <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
-          <Bug className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
-          <p className="text-zinc-500 text-sm">No findings found.</p>
-          <p className="text-zinc-600 text-xs mt-1">
-            Run a scan with enrichment enabled to see CVE-backed findings here.
-          </p>
-        </div>
+        <PageEmptyState
+          title="No findings found"
+          detail="Run a scan with vulnerability enrichment enabled to populate CVE-backed findings, affected packages, agents, and remediation evidence."
+          icon={Bug}
+          suggestions={[
+            "Start with the offline demo if you want predictable sample data.",
+            "Run a project scan with graph output to connect findings to packages and agents.",
+            "Use all completed scans when you need aggregate evidence across jobs.",
+          ]}
+          command="agent-bom agents --demo --offline"
+          action={{ label: "Open scan", href: "/scan" }}
+          data-testid="findings-empty-state"
+        />
       )}
 
       {!error && vulns.length > 0 && (

--- a/ui/components/graph-state-panels.tsx
+++ b/ui/components/graph-state-panels.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import Link from "next/link";
-import { ExternalLink, Route, SearchX } from "lucide-react";
+import { ExternalLink, Route } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { buildFindingsHref } from "@/lib/attack-paths";
 import { getOsvVulnerabilityUrl } from "@/lib/vulnerabilities";
+import { PageEmptyState, PageLoadingState } from "@/components/states/page-state";
 import type { LineageNodeData } from "./lineage-nodes";
 
 const FINDINGS_VIRTUALIZE_THRESHOLD = 80;
@@ -39,33 +40,12 @@ export function GraphEmptyState({
   command?: string | undefined;
 }) {
   return (
-    <div className="flex h-full items-center justify-center">
-      <div className="max-w-xl rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-6 text-left shadow-lg">
-        <div className="flex items-start gap-3">
-          <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2">
-            <SearchX className="h-5 w-5 text-[color:var(--text-secondary)]" />
-          </div>
-          <div>
-            <h3 className="text-base font-semibold text-[color:var(--foreground)]">{title}</h3>
-            <p className="mt-2 text-sm leading-6 text-[color:var(--text-secondary)]">{detail}</p>
-          </div>
-        </div>
-        <ul className="mt-4 space-y-2 text-sm text-[color:var(--text-secondary)]">
-          {suggestions.map((suggestion) => (
-            <li key={suggestion} className="flex items-start gap-2">
-              <span className="mt-1 h-1.5 w-1.5 rounded-full bg-[color:var(--text-tertiary)]" />
-              <span>{suggestion}</span>
-            </li>
-          ))}
-        </ul>
-        {command ? (
-          <div className="mt-4 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2">
-            <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">First command</div>
-            <code className="mt-1 block overflow-x-auto whitespace-nowrap text-xs text-[color:var(--foreground)]">{command}</code>
-          </div>
-        ) : null}
-      </div>
-    </div>
+    <PageEmptyState
+      title={title}
+      detail={detail}
+      suggestions={suggestions}
+      command={command}
+    />
   );
 }
 
@@ -77,23 +57,7 @@ export function GraphPanelSkeleton({
   detail?: string;
 }) {
   return (
-    <div className="flex h-full items-center justify-center p-6" data-testid="graph-panel-skeleton">
-      <div className="w-full max-w-4xl rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <div className="h-3 w-28 animate-pulse rounded-full bg-[color:var(--surface-elevated)]" />
-            <h3 className="mt-3 text-base font-semibold text-[color:var(--foreground)]">{title}</h3>
-            <p className="mt-2 max-w-xl text-sm leading-6 text-[color:var(--text-secondary)]">{detail}</p>
-          </div>
-          <div className="h-10 w-24 animate-pulse rounded-xl bg-[color:var(--surface-elevated)]" />
-        </div>
-        <div className="mt-6 grid gap-4 md:grid-cols-3">
-          <SkeletonColumn bars={4} />
-          <SkeletonColumn bars={5} />
-          <SkeletonColumn bars={4} />
-        </div>
-      </div>
-    </div>
+    <PageLoadingState title={title} detail={detail} data-testid="graph-panel-skeleton" />
   );
 }
 
@@ -104,23 +68,6 @@ export function GraphRefreshOverlay({ label = "Refreshing graph window" }: { lab
       data-testid="graph-refresh-overlay"
     >
       {label}
-    </div>
-  );
-}
-
-function SkeletonColumn({ bars }: { bars: number }) {
-  return (
-    <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-4">
-      <div className="h-4 w-24 animate-pulse rounded-full bg-[color:var(--surface-elevated)]" />
-      <div className="mt-4 space-y-3">
-        {Array.from({ length: bars }, (_, index) => (
-          <div
-            key={index}
-            className="h-3 animate-pulse rounded-full bg-[color:var(--surface-elevated)]"
-            style={{ width: `${92 - index * 11}%` }}
-          />
-        ))}
-      </div>
     </div>
   );
 }

--- a/ui/components/states/page-state.tsx
+++ b/ui/components/states/page-state.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import Link from "next/link";
+import type { ElementType, ReactNode } from "react";
+import { AlertTriangle, Loader2, SearchX } from "lucide-react";
+
+type PageStateAction = {
+  label: string;
+  href?: string | undefined;
+  onClick?: (() => void) | undefined;
+};
+
+type PageStateProps = {
+  title: string;
+  detail: string;
+  icon?: ElementType | undefined;
+  suggestions?: string[] | undefined;
+  command?: string | undefined;
+  action?: PageStateAction | undefined;
+  tone?: "neutral" | "warning" | "danger" | "success" | undefined;
+  children?: ReactNode;
+  "data-testid"?: string | undefined;
+};
+
+const TONE_CLASS: Record<NonNullable<PageStateProps["tone"]>, string> = {
+  neutral: "border-[color:var(--border-subtle)] bg-[color:var(--surface)] text-[color:var(--text-secondary)]",
+  warning: "border-amber-500/25 bg-amber-500/10 text-amber-100",
+  danger: "border-red-500/25 bg-red-500/10 text-red-100",
+  success: "border-emerald-500/25 bg-emerald-500/10 text-emerald-100",
+};
+
+export function PageState({
+  title,
+  detail,
+  icon: Icon = SearchX,
+  suggestions = [],
+  command,
+  action,
+  tone = "neutral",
+  children,
+  "data-testid": testId,
+}: PageStateProps) {
+  return (
+    <div className="flex min-h-[18rem] items-center justify-center px-4 py-10" data-testid={testId}>
+      <div className={`w-full max-w-2xl rounded-2xl border p-6 shadow-lg ${TONE_CLASS[tone]}`}>
+        <div className="flex items-start gap-3">
+          <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2">
+            <Icon className="h-5 w-5 text-[color:var(--text-secondary)]" />
+          </div>
+          <div className="min-w-0">
+            <h3 className="text-base font-semibold text-[color:var(--foreground)]">{title}</h3>
+            <p className="mt-2 text-sm leading-6 text-[color:var(--text-secondary)]">{detail}</p>
+          </div>
+        </div>
+
+        {suggestions.length > 0 ? (
+          <ul className="mt-4 space-y-2 text-sm text-[color:var(--text-secondary)]">
+            {suggestions.map((suggestion) => (
+              <li key={suggestion} className="flex items-start gap-2">
+                <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[color:var(--text-tertiary)]" />
+                <span>{suggestion}</span>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
+        {command ? (
+          <div className="mt-4 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2">
+            <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">First command</div>
+            <code className="mt-1 block overflow-x-auto whitespace-nowrap text-xs text-[color:var(--foreground)]">{command}</code>
+          </div>
+        ) : null}
+
+        {children}
+
+        {action ? (
+          <div className="mt-5">
+            {action.href ? (
+              <Link
+                href={action.href}
+                className="inline-flex items-center justify-center rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm font-medium text-emerald-200 transition hover:border-emerald-400 hover:bg-emerald-500/20"
+              >
+                {action.label}
+              </Link>
+            ) : (
+              <button
+                type="button"
+                onClick={action.onClick}
+                className="inline-flex items-center justify-center rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm font-medium text-emerald-200 transition hover:border-emerald-400 hover:bg-emerald-500/20"
+              >
+                {action.label}
+              </button>
+            )}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function PageEmptyState(props: Omit<PageStateProps, "tone">) {
+  return <PageState {...props} tone="neutral" />;
+}
+
+export function PageErrorState(props: Omit<PageStateProps, "tone" | "icon"> & { icon?: ElementType | undefined }) {
+  return <PageState {...props} icon={props.icon ?? AlertTriangle} tone="danger" />;
+}
+
+export function PageLoadingState({
+  title,
+  detail,
+  "data-testid": testId,
+}: {
+  title: string;
+  detail: string;
+  "data-testid"?: string | undefined;
+}) {
+  return (
+    <div className="flex min-h-[18rem] items-center justify-center px-4 py-10" data-testid={testId}>
+      <div className="w-full max-w-3xl rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg">
+        <div className="flex items-start gap-3">
+          <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2">
+            <Loader2 className="h-5 w-5 animate-spin text-[color:var(--text-secondary)]" />
+          </div>
+          <div>
+            <h3 className="text-base font-semibold text-[color:var(--foreground)]">{title}</h3>
+            <p className="mt-2 text-sm leading-6 text-[color:var(--text-secondary)]">{detail}</p>
+          </div>
+        </div>
+        <div className="mt-6 grid gap-4 md:grid-cols-3">
+          {[0, 1, 2].map((column) => (
+            <div key={column} className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-4">
+              <div className="h-4 w-24 animate-pulse rounded-full bg-[color:var(--surface-elevated)]" />
+              <div className="mt-4 space-y-3">
+                {[0, 1, 2, 3].map((row) => (
+                  <div
+                    key={row}
+                    className="h-3 animate-pulse rounded-full bg-[color:var(--surface-elevated)]"
+                    style={{ width: `${92 - row * 13 - column * 4}%` }}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/tests/page-state.test.tsx
+++ b/ui/tests/page-state.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { PageEmptyState, PageErrorState, PageLoadingState } from "@/components/states/page-state";
+
+describe("page state components", () => {
+  it("renders empty state guidance with a first command and action", () => {
+    render(
+      <PageEmptyState
+        title="No findings found"
+        detail="Run a scan to populate this view."
+        suggestions={["Use the demo for sample data.", "Open scan for a real run."]}
+        command="agent-bom agents --demo --offline"
+        action={{ label: "Open scan", href: "/scan" }}
+      />,
+    );
+
+    expect(screen.getByText("No findings found")).toBeInTheDocument();
+    expect(screen.getByText("agent-bom agents --demo --offline")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open scan" })).toHaveAttribute("href", "/scan");
+  });
+
+  it("renders error and loading states with stable test ids", () => {
+    render(
+      <>
+        <PageErrorState title="Could not load agents" detail="API unavailable" data-testid="error-state" />
+        <PageLoadingState title="Loading compliance posture" detail="Fetching controls." data-testid="loading-state" />
+      </>,
+    );
+
+    expect(screen.getByTestId("error-state")).toHaveTextContent("Could not load agents");
+    expect(screen.getByTestId("loading-state")).toHaveTextContent("Loading compliance posture");
+  });
+});


### PR DESCRIPTION
## Summary
- add shared page loading, empty, and error state components
- reuse the shared states from graph panels instead of keeping graph-only copies
- apply the pattern to the first batch: agents, findings, and compliance, with next-action guidance and first commands

Closes #2433.

## Validation
- `cd ui && npm test -- --run tests/page-state.test.tsx tests/graph-state-panels.test.tsx`
- `cd ui && npm run typecheck`
- `cd ui && npm run lint`
- `git diff --check`

Note: local Node is v25.9.0 while the UI package declares `>=22 <25`; the focused checks still completed successfully.
