### PR TITLE
ui: tighten graph viewport framing

### DIFF
--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -49,6 +49,7 @@ import {
   minimapNodeColor,
   readableGraphEdges,
 } from "@/lib/graph-utils";
+import { graphFitViewOptions, shouldShowGraphMiniMap } from "@/lib/graph-viewport";
 import { FullscreenButton, GraphLegend } from "@/components/graph-chrome";
 import { GraphEmptyState, GraphPanelSkeleton } from "@/components/graph-state-panels";
 import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
@@ -367,6 +368,27 @@ export default function ContextPage() {
     return legendItemsForVisibleNodes(displayNodes, extras);
   }, [displayEdges, displayNodes]);
 
+  const viewportOptions = useMemo(
+    () =>
+      graphFitViewOptions({
+        nodeCount: displayNodes.length,
+        edgeCount: displayEdges.length,
+        selectedNode: Boolean(selectedNode),
+        mode: "context",
+      }),
+    [displayEdges.length, displayNodes.length, selectedNode],
+  );
+  const showMiniMap = useMemo(
+    () =>
+      shouldShowGraphMiniMap({
+        nodeCount: displayNodes.length,
+        edgeCount: displayEdges.length,
+        selectedNode: Boolean(selectedNode),
+        mode: "context",
+      }),
+    [displayEdges.length, displayNodes.length, selectedNode],
+  );
+
   const onNodeClick = useCallback((_event: React.MouseEvent, node: Node) => {
     setSelectedNode(node.data as LineageNodeData);
     setHoveredNodeId(null);
@@ -520,7 +542,7 @@ export default function ContextPage() {
               edges={displayEdges}
               nodeTypes={lineageNodeTypes}
               fitView
-              fitViewOptions={{ padding: 0.18, maxZoom: 1.05 }}
+              fitViewOptions={viewportOptions}
               minZoom={0.16}
               maxZoom={2.5}
               onlyRenderVisibleElements
@@ -536,12 +558,14 @@ export default function ContextPage() {
             >
               <Background color={BACKGROUND_COLOR} gap={BACKGROUND_GAP} />
               <Controls className={CONTROLS_CLASS} />
-              <MiniMap
-                nodeColor={minimapNodeColor}
-                className={MINIMAP_CLASS}
-                bgColor={MINIMAP_BG}
-                maskColor={MINIMAP_MASK}
-              />
+              {showMiniMap && (
+                <MiniMap
+                  nodeColor={minimapNodeColor}
+                  className={MINIMAP_CLASS}
+                  bgColor={MINIMAP_BG}
+                  maskColor={MINIMAP_MASK}
+                />
+              )}
             </ReactFlow>
           )}
 

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -70,6 +70,7 @@ import {
   minimapNodeColor,
   readableGraphEdges,
 } from "@/lib/graph-utils";
+import { graphFitViewOptions, shouldShowGraphMiniMap } from "@/lib/graph-viewport";
 import {
   prettifyReachabilityType,
   summarizeReachability,
@@ -1021,6 +1022,26 @@ function GraphPageInner() {
     () => legendItemsForVisibleGraph(displayNodes, displayEdges),
     [displayEdges, displayNodes],
   );
+  const viewportOptions = useMemo(
+    () =>
+      graphFitViewOptions({
+        nodeCount: displayNodes.length,
+        edgeCount: displayEdges.length,
+        selectedNode: Boolean(selectedNode),
+        mode: "lineage",
+      }),
+    [displayEdges.length, displayNodes.length, selectedNode],
+  );
+  const showMiniMap = useMemo(
+    () =>
+      shouldShowGraphMiniMap({
+        nodeCount: displayNodes.length,
+        edgeCount: displayEdges.length,
+        selectedNode: Boolean(selectedNode),
+        mode: "lineage",
+      }),
+    [displayEdges.length, displayNodes.length, selectedNode],
+  );
 
   const hasContextualGraph = useMemo(
     () => displayNodes.some((node) => {
@@ -1749,7 +1770,7 @@ function GraphPageInner() {
               edges={displayEdges}
               nodeTypes={lineageNodeTypesAdaptive}
               fitView
-              fitViewOptions={{ padding: 0.18, maxZoom: 1.05 }}
+              fitViewOptions={viewportOptions}
               minZoom={0.16}
               maxZoom={2.5}
               zoomOnScroll={false}
@@ -1775,12 +1796,14 @@ function GraphPageInner() {
             >
               <Background color={BACKGROUND_COLOR} gap={BACKGROUND_GAP} />
               <Controls className={CONTROLS_CLASS} />
-              <MiniMap
-                nodeColor={minimapNodeColor}
-                className={MINIMAP_CLASS}
-                bgColor={MINIMAP_BG}
-                maskColor={MINIMAP_MASK}
-              />
+              {showMiniMap && (
+                <MiniMap
+                  nodeColor={minimapNodeColor}
+                  className={MINIMAP_CLASS}
+                  bgColor={MINIMAP_BG}
+                  maskColor={MINIMAP_MASK}
+                />
+              )}
               {/* Dock legend on the canvas itself so node-color -> entity-type
                   is one glance away. */}
               <Panel position="top-right" className="!m-2">

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -46,6 +46,7 @@ import {
   minimapNodeColor,
   readableGraphEdges,
 } from "@/lib/graph-utils";
+import { graphFitViewOptions, shouldShowGraphMiniMap } from "@/lib/graph-viewport";
 import { FullscreenButton, GraphLegend } from "@/components/graph-chrome";
 import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
@@ -375,6 +376,26 @@ export default function MeshPage() {
     () => legendItemsForVisibleGraph(displayNodes, displayEdges),
     [displayEdges, displayNodes],
   );
+  const viewportOptions = useMemo(
+    () =>
+      graphFitViewOptions({
+        nodeCount: displayNodes.length,
+        edgeCount: displayEdges.length,
+        selectedNode: Boolean(selectedNode),
+        mode: "mesh",
+      }),
+    [displayEdges.length, displayNodes.length, selectedNode],
+  );
+  const showMiniMap = useMemo(
+    () =>
+      shouldShowGraphMiniMap({
+        nodeCount: displayNodes.length,
+        edgeCount: displayEdges.length,
+        selectedNode: Boolean(selectedNode),
+        mode: "mesh",
+      }),
+    [displayEdges.length, displayNodes.length, selectedNode],
+  );
 
   const onNodeClick = useCallback((_event: React.MouseEvent, node: Node) => {
     setSelectedNode(node.data as LineageNodeData);
@@ -503,7 +524,7 @@ export default function MeshPage() {
           edges={displayEdges}
           nodeTypes={lineageNodeTypes}
           fitView
-          fitViewOptions={{ padding: 0.08, maxZoom: 1.45 }}
+          fitViewOptions={viewportOptions}
           minZoom={0.16}
           maxZoom={2.5}
           zoomOnScroll={false}
@@ -519,12 +540,14 @@ export default function MeshPage() {
         >
           <Background color={BACKGROUND_COLOR} gap={BACKGROUND_GAP} />
           <Controls className={CONTROLS_CLASS} />
-          <MiniMap
-            nodeColor={minimapNodeColor}
-            className={MINIMAP_CLASS}
-            bgColor={MINIMAP_BG}
-            maskColor={MINIMAP_MASK}
-          />
+          {showMiniMap && (
+            <MiniMap
+              nodeColor={minimapNodeColor}
+              className={MINIMAP_CLASS}
+              bgColor={MINIMAP_BG}
+              maskColor={MINIMAP_MASK}
+            />
+          )}
         </ReactFlow>
 
         {selectedNode && (

--- a/ui/lib/graph-viewport.ts
+++ b/ui/lib/graph-viewport.ts
@@ -1,0 +1,78 @@
+export type GraphViewportMode = "lineage" | "mesh" | "context";
+
+export type GraphViewportInput = {
+  nodeCount: number;
+  edgeCount?: number;
+  selectedNode?: boolean;
+  mode?: GraphViewportMode;
+};
+
+export type GraphFitViewOptions = {
+  padding: number;
+  maxZoom: number;
+  duration: number;
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizedCount(value: number | undefined): number {
+  return Math.max(0, Math.floor(Number.isFinite(value) ? value ?? 0 : 0));
+}
+
+export function graphFitViewOptions(input: GraphViewportInput): GraphFitViewOptions {
+  const nodeCount = normalizedCount(input.nodeCount);
+  const edgeCount = normalizedCount(input.edgeCount);
+  const selectedBoost = input.selectedNode ? 0.1 : 0;
+
+  let padding = 0.16;
+  let maxZoom = 1.05;
+
+  if (nodeCount <= 0) {
+    padding = 0.18;
+    maxZoom = 1;
+  } else if (nodeCount <= 6) {
+    padding = 0.08;
+    maxZoom = 1.72;
+  } else if (nodeCount <= 16) {
+    padding = 0.1;
+    maxZoom = 1.48;
+  } else if (nodeCount <= 32) {
+    padding = 0.12;
+    maxZoom = 1.28;
+  } else if (nodeCount <= 80) {
+    padding = 0.16;
+    maxZoom = 1.08;
+  } else {
+    padding = 0.2;
+    maxZoom = 0.92;
+  }
+
+  const density = nodeCount > 0 ? edgeCount / nodeCount : 0;
+  if (density > 3.5) {
+    maxZoom -= 0.12;
+    padding += 0.02;
+  }
+
+  if (input.mode === "mesh") {
+    maxZoom -= 0.06;
+  } else if (input.mode === "context") {
+    maxZoom -= 0.04;
+  }
+
+  return {
+    padding: clamp(padding, 0.08, 0.24),
+    maxZoom: clamp(maxZoom + selectedBoost, 0.82, 1.82),
+    duration: 240,
+  };
+}
+
+export function shouldShowGraphMiniMap(input: GraphViewportInput): boolean {
+  const nodeCount = normalizedCount(input.nodeCount);
+  const edgeCount = normalizedCount(input.edgeCount);
+  if (nodeCount <= 0) return false;
+  if (input.selectedNode && nodeCount <= 28) return false;
+  if (nodeCount <= 18 && edgeCount <= 36) return false;
+  return true;
+}

--- a/ui/tests/graph-viewport.test.ts
+++ b/ui/tests/graph-viewport.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { graphFitViewOptions, shouldShowGraphMiniMap } from "@/lib/graph-viewport";
+
+describe("graph viewport framing", () => {
+  it("zooms small operator-scoped graphs instead of leaving empty canvas", () => {
+    const small = graphFitViewOptions({ nodeCount: 6, edgeCount: 5, mode: "lineage" });
+    const dense = graphFitViewOptions({ nodeCount: 120, edgeCount: 520, mode: "lineage" });
+
+    expect(small.maxZoom).toBeGreaterThan(1.6);
+    expect(small.padding).toBeLessThan(0.1);
+    expect(dense.maxZoom).toBeLessThan(1);
+    expect(dense.padding).toBeGreaterThan(0.18);
+  });
+
+  it("keeps selected-node investigations tighter than the same unfocused graph", () => {
+    const unfocused = graphFitViewOptions({ nodeCount: 12, edgeCount: 14, mode: "context" });
+    const selected = graphFitViewOptions({
+      nodeCount: 12,
+      edgeCount: 14,
+      selectedNode: true,
+      mode: "context",
+    });
+
+    expect(selected.maxZoom).toBeGreaterThan(unfocused.maxZoom);
+  });
+
+  it("hides the minimap for readable focused captures and keeps it for dense topology", () => {
+    expect(shouldShowGraphMiniMap({ nodeCount: 10, edgeCount: 12 })).toBe(false);
+    expect(shouldShowGraphMiniMap({ nodeCount: 24, edgeCount: 40, selectedNode: true })).toBe(false);
+    expect(shouldShowGraphMiniMap({ nodeCount: 90, edgeCount: 160 })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add shared viewport heuristics for graph canvases so small operator-scoped graphs fit closer instead of floating in empty canvas
- hide minimaps on focused/small graph views where they obscure evidence, while preserving them for dense topology
- apply the shared framing to the full graph, agent mesh, and context map surfaces

## Validation
- `cd ui && npm test -- --run tests/graph-viewport.test.ts tests/graph-utils.test.ts tests/graph-reachability.test.ts tests/mesh-graph.test.ts`
- `cd ui && npm run typecheck`
- `cd ui && npm run lint`
- `git diff --check`