### PR TITLE
ui: add graph evidence export controls

### DIFF
--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -16,7 +16,7 @@ import "@xyflow/react/dist/style.css";
 import { AlertTriangle, Loader2, Route, ShieldAlert } from "lucide-react";
 
 import { AttackPathCard } from "@/components/attack-path-card";
-import { GraphLegend, FullscreenButton } from "@/components/graph-chrome";
+import { GraphEvidenceExportButton, GraphLegend, FullscreenButton } from "@/components/graph-chrome";
 import { LineageDetailPanel } from "@/components/lineage-detail";
 import {
   GraphControlGroup,
@@ -1347,6 +1347,10 @@ function GraphPageInner() {
               ))}
             </select>
 
+            <GraphEvidenceExportButton
+              scanId={selectedScanId || undefined}
+              filenamePrefix={selectedScanId ? `scan-${selectedScanId}-graph` : undefined}
+            />
             <FullscreenButton />
           </div>
         </div>

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -22,6 +22,7 @@ function _classifyGraphErrorKind(err: unknown): "network" | "auth" | "forbidden"
   return "network";
 }
 import { AttackPathCard } from "@/components/attack-path-card";
+import { GraphEvidenceExportButton } from "@/components/graph-chrome";
 import { GraphEmptyState } from "@/components/graph-state-panels";
 import {
   api,
@@ -380,6 +381,10 @@ function SecurityGraphPageContent() {
           </div>
 
           <div className="flex flex-wrap items-center gap-2">
+            <GraphEvidenceExportButton
+              scanId={selectedScanId || undefined}
+              filenamePrefix={selectedScanId ? `scan-${selectedScanId}-security-graph` : undefined}
+            />
             <Link
               href={fullGraphHref}
               className="inline-flex items-center gap-2 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-4 py-2 text-sm font-medium text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)]"

--- a/ui/components/graph-chrome.tsx
+++ b/ui/components/graph-chrome.tsx
@@ -16,6 +16,7 @@ import {
   Download,
   FolderTree,
   KeyRound,
+  Loader2,
   Maximize2,
   Minimize2,
   Server,
@@ -23,6 +24,7 @@ import {
   Wrench,
 } from "lucide-react";
 import { useReactFlow } from "@xyflow/react";
+import { api, type GraphExportFormat } from "@/lib/api";
 import type { LegendItem } from "@/lib/graph-utils";
 
 // ─── Legend Bar ──────────────────────────────────────────────────────────────
@@ -256,5 +258,74 @@ export function GraphExportButton({ filename }: { filename?: string }) {
       <Download className="w-3.5 h-3.5" />
       Export
     </button>
+  );
+}
+
+const GRAPH_EVIDENCE_FORMATS: GraphExportFormat[] = ["json", "mermaid", "graphml"];
+
+function extensionForGraphFormat(format: GraphExportFormat): string {
+  return format === "json" ? "json" : format;
+}
+
+export function GraphEvidenceExportButton({
+  scanId,
+  formats = GRAPH_EVIDENCE_FORMATS,
+  filenamePrefix,
+}: {
+  scanId?: string | undefined;
+  formats?: GraphExportFormat[];
+  filenamePrefix?: string | undefined;
+}) {
+  const [format, setFormat] = useState<GraphExportFormat>(formats[0] ?? "json");
+  const [exporting, setExporting] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleDownload = useCallback(async () => {
+    if (!scanId) return;
+    setExporting(true);
+    setError("");
+    try {
+      const blob = await api.downloadScanGraph(scanId, format);
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = `${filenamePrefix ?? `scan-${scanId}-graph`}.${extensionForGraphFormat(format)}`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to export graph evidence");
+    } finally {
+      setExporting(false);
+    }
+  }, [filenamePrefix, format, scanId]);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <select
+        aria-label="Graph evidence format"
+        value={format}
+        onChange={(event) => setFormat(event.target.value as GraphExportFormat)}
+        className="rounded-lg border border-zinc-700 bg-zinc-900/90 px-2.5 py-1.5 text-xs text-zinc-300 focus:border-sky-600 focus:outline-none"
+      >
+        {formats.map((item) => (
+          <option key={item} value={item}>
+            {item.toUpperCase()}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        onClick={() => void handleDownload()}
+        disabled={!scanId || exporting}
+        className="inline-flex items-center gap-1.5 rounded-lg border border-cyan-900/60 bg-cyan-950/30 px-2.5 py-1.5 text-xs font-medium text-cyan-200 transition-colors hover:border-cyan-800 hover:bg-cyan-950/50 disabled:cursor-not-allowed disabled:opacity-50"
+        title="Download the selected scan graph in an evidence format for review, import, or audit handoff."
+      >
+        {exporting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Download className="h-3.5 w-3.5" />}
+        Download graph evidence
+      </button>
+      {error ? <span className="text-xs text-red-300">{error}</span> : null}
+    </div>
   );
 }

--- a/ui/tests/graph-chrome.test.tsx
+++ b/ui/tests/graph-chrome.test.tsx
@@ -1,7 +1,12 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { GraphLegend } from "@/components/graph-chrome";
+import { GraphEvidenceExportButton, GraphLegend } from "@/components/graph-chrome";
+import { api } from "@/lib/api";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("GraphLegend", () => {
   it("groups entity legend rows by semantic layer and keeps relationships separate", () => {
@@ -24,5 +29,32 @@ describe("GraphLegend", () => {
     expect(screen.getByText("Findings")).toBeInTheDocument();
     expect(screen.getByText("Relationships")).toBeInTheDocument();
     expect(screen.getByText("Uses")).toBeInTheDocument();
+  });
+});
+
+describe("GraphEvidenceExportButton", () => {
+  it("downloads the selected scan graph in the chosen evidence format", async () => {
+    const downloadSpy = vi
+      .spyOn(api, "downloadScanGraph")
+      .mockResolvedValue(new Blob(["graph"], { type: "application/json" }));
+    const createObjectUrlSpy = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:graph");
+    const revokeObjectUrlSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const anchorClickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    render(<GraphEvidenceExportButton scanId="scan-123" filenamePrefix="selected-graph" />);
+
+    fireEvent.change(screen.getByLabelText("Graph evidence format"), { target: { value: "mermaid" } });
+    fireEvent.click(screen.getByRole("button", { name: /download graph evidence/i }));
+
+    await waitFor(() => expect(downloadSpy).toHaveBeenCalledWith("scan-123", "mermaid"));
+    expect(createObjectUrlSpy).toHaveBeenCalled();
+    expect(anchorClickSpy).toHaveBeenCalled();
+    expect(revokeObjectUrlSpy).toHaveBeenCalledWith("blob:graph");
+  });
+
+  it("stays disabled until a scan is selected", () => {
+    render(<GraphEvidenceExportButton />);
+
+    expect(screen.getByRole("button", { name: /download graph evidence/i })).toBeDisabled();
   });
 });


### PR DESCRIPTION
## Summary
- add a shared graph evidence export control backed by the existing scan graph export API
- mount the control in the full graph and security graph views for selected snapshots
- cover format selection, disabled state, and download behavior in graph chrome tests

## Validation
- `cd ui && npm test -- --run tests/graph-chrome.test.tsx tests/api.test.ts`
- `cd ui && npm run typecheck`
- `cd ui && npm run lint`
- `git diff --check`