### PR TITLE
ui: make graph capture mode readable

### DIFF
--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -55,6 +55,7 @@ import { GraphEmptyState, GraphPanelSkeleton } from "@/components/graph-state-pa
 import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { isDeploymentSurfaceAvailable } from "@/lib/deployment-context";
+import { useCaptureMode } from "@/lib/use-capture-mode";
 
 // ─── Stats Bar ──────────────────────────────────────────────────────────────
 
@@ -225,6 +226,7 @@ export default function ContextPage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [activeJob, setActiveJob] = useState<ScanJob | null>(null);
   const { counts } = useDeploymentContext();
+  const captureMode = useCaptureMode();
 
   // Load completed jobs
   useEffect(() => {
@@ -357,8 +359,9 @@ export default function ContextPage() {
       baseOpacity: 0.32,
       highSignalOpacity: 0.56,
       inactiveOpacity: 0.06,
+      captureMode,
     });
-  }, [layoutEdges, connectedIds, searchMatches]);
+  }, [layoutEdges, connectedIds, searchMatches, captureMode]);
 
   const legendItems = useMemo(() => {
     const extras =
@@ -380,13 +383,13 @@ export default function ContextPage() {
   );
   const showMiniMap = useMemo(
     () =>
-      shouldShowGraphMiniMap({
+      !captureMode && shouldShowGraphMiniMap({
         nodeCount: displayNodes.length,
         edgeCount: displayEdges.length,
         selectedNode: Boolean(selectedNode),
         mode: "context",
       }),
-    [displayEdges.length, displayNodes.length, selectedNode],
+    [captureMode, displayEdges.length, displayNodes.length, selectedNode],
   );
 
   const onNodeClick = useCallback((_event: React.MouseEvent, node: Node) => {
@@ -503,7 +506,7 @@ export default function ContextPage() {
           </div>
 
           <FullscreenButton />
-          <GraphLegend items={legendItems} />
+          <GraphLegend items={legendItems} defaultOpen={captureMode} />
         </div>
       </div>
 

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -90,6 +90,7 @@ import {
   decodeFiltersFromParams,
   encodeFiltersToParams,
 } from "@/lib/filter-algebra";
+import { useCaptureMode } from "@/lib/use-capture-mode";
 
 function PulseStyles() {
   return (
@@ -531,6 +532,7 @@ function GraphPageInner() {
       : null,
   );
   const firstScanSelectionRef = useRef(true);
+  const captureMode = useCaptureMode();
 
   useEffect(() => {
     setLoadingSnapshots(true);
@@ -980,7 +982,7 @@ function GraphPageInner() {
         const inPath = attackPathEdgeKeys.has(`${edge.source}=>${edge.target}`);
         return {
           ...edge,
-          animated: Boolean(inPath || edge.animated),
+          animated: captureMode ? false : Boolean(inPath || edge.animated),
           style: {
             ...edge.style,
             opacity: inPath ? 1 : 0.08,
@@ -999,7 +1001,7 @@ function GraphPageInner() {
           reachabilitySummary.edgeKeys.has(`${edge.target}=>${edge.source}`);
         return {
           ...edge,
-          animated: Boolean(inReach || edge.animated),
+          animated: captureMode ? false : Boolean(inReach || edge.animated),
           style: {
             ...edge.style,
             opacity: inReach ? 0.95 : 0.07,
@@ -1015,8 +1017,9 @@ function GraphPageInner() {
       baseOpacity: graphLayoutKind === "dagre-lr" ? 0.34 : 0.26,
       highSignalOpacity: graphLayoutKind === "dagre-lr" ? 0.6 : 0.48,
       inactiveOpacity: 0.06,
+      captureMode,
     });
-  }, [layoutEdges, localNeighborhoodIds, attackPathEdgeKeys, reachabilitySummary, graphLayoutKind]);
+  }, [layoutEdges, localNeighborhoodIds, attackPathEdgeKeys, reachabilitySummary, graphLayoutKind, captureMode]);
 
   const legendItems = useMemo(
     () => legendItemsForVisibleGraph(displayNodes, displayEdges),
@@ -1034,13 +1037,13 @@ function GraphPageInner() {
   );
   const showMiniMap = useMemo(
     () =>
-      shouldShowGraphMiniMap({
+      !captureMode && shouldShowGraphMiniMap({
         nodeCount: displayNodes.length,
         edgeCount: displayEdges.length,
         selectedNode: Boolean(selectedNode),
         mode: "lineage",
       }),
-    [displayEdges.length, displayNodes.length, selectedNode],
+    [captureMode, displayEdges.length, displayNodes.length, selectedNode],
   );
 
   const hasContextualGraph = useMemo(
@@ -1675,6 +1678,7 @@ function GraphPageInner() {
                     <AttackPathCard
                       nodes={pathNodes}
                       riskScore={path.composite_risk}
+                      captureMode={captureMode}
                       onClick={() => {
                         setReachabilitySummary(null);
                         setReachabilityError(null);
@@ -1807,14 +1811,14 @@ function GraphPageInner() {
               {/* Dock legend on the canvas itself so node-color -> entity-type
                   is one glance away. */}
               <Panel position="top-right" className="!m-2">
-                <details className="rounded-xl border border-zinc-800 bg-zinc-950/85 backdrop-blur p-2 group">
+                <details open={captureMode || undefined} className="rounded-xl border border-zinc-800 bg-zinc-950/85 backdrop-blur p-2 group">
                   <summary className="flex items-center gap-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden text-[10px] uppercase tracking-[0.2em] text-zinc-400">
                     <span>Legend</span>
                     <span className="text-zinc-600 group-open:hidden">▸</span>
                     <span className="text-zinc-600 hidden group-open:inline">▾</span>
                   </summary>
                   <div className="mt-2">
-                    <GraphLegend items={legendItems} embedded />
+                    <GraphLegend items={legendItems} embedded defaultOpen={captureMode} />
                   </div>
                 </details>
               </Panel>

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -51,6 +51,7 @@ import { FullscreenButton, GraphLegend } from "@/components/graph-chrome";
 import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { isDeploymentSurfaceAvailable } from "@/lib/deployment-context";
+import { useCaptureMode } from "@/lib/use-capture-mode";
 
 // ─── Filter Toolbar ─────────────────────────────────────────────────────────
 
@@ -205,6 +206,7 @@ export default function MeshPage() {
   const [selectedAgents, setSelectedAgents] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const { counts } = useDeploymentContext();
+  const captureMode = useCaptureMode();
 
   useEffect(() => {
     api
@@ -369,8 +371,9 @@ export default function MeshPage() {
       baseOpacity: 0.3,
       highSignalOpacity: 0.58,
       inactiveOpacity: 0.06,
+      captureMode,
     });
-  }, [visibleEdges, connectedIds, searchMatches]);
+  }, [visibleEdges, connectedIds, searchMatches, captureMode]);
 
   const legendItems = useMemo(
     () => legendItemsForVisibleGraph(displayNodes, displayEdges),
@@ -388,13 +391,13 @@ export default function MeshPage() {
   );
   const showMiniMap = useMemo(
     () =>
-      shouldShowGraphMiniMap({
+      !captureMode && shouldShowGraphMiniMap({
         nodeCount: displayNodes.length,
         edgeCount: displayEdges.length,
         selectedNode: Boolean(selectedNode),
         mode: "mesh",
       }),
-    [displayEdges.length, displayNodes.length, selectedNode],
+    [captureMode, displayEdges.length, displayNodes.length, selectedNode],
   );
 
   const onNodeClick = useCallback((_event: React.MouseEvent, node: Node) => {
@@ -489,7 +492,7 @@ export default function MeshPage() {
             ))}
           </select>
           <FullscreenButton />
-          <GraphLegend items={legendItems} />
+          <GraphLegend items={legendItems} defaultOpen={captureMode} />
         </div>
       </div>
 

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -47,6 +47,7 @@ import {
   moveAttackPathSelection,
   toAttackCardNodes,
 } from "@/lib/attack-paths";
+import { useCaptureMode } from "@/lib/use-capture-mode";
 
 const ATTACK_PATH_QUEUE_LIMIT = 75;
 const FIX_FIRST_CARD_LIMIT = 12;
@@ -65,6 +66,7 @@ function SecurityGraphPageContent() {
   const [apiErrorKind, setApiErrorKind] = useState<"network" | "auth" | "forbidden">("network");
   const [selectedAttackPathKey, setSelectedAttackPathKey] = useState<string | null>(null);
   const [focusApplied, setFocusApplied] = useState(false);
+  const captureMode = useCaptureMode();
 
   const focus = useMemo(
     () => ({
@@ -647,6 +649,7 @@ function SecurityGraphPageContent() {
                     <AttackPathCard
                       nodes={pathNodes}
                       riskScore={path.composite_risk}
+                      captureMode={captureMode}
                       onClick={() => setSelectedAttackPathKey(key)}
                     />
                     {card && card.risk_reasons.length > 0 && (

--- a/ui/components/attack-path-card.tsx
+++ b/ui/components/attack-path-card.tsx
@@ -15,6 +15,7 @@ interface AttackPathCardProps {
   riskScore: number;
   onClick?: () => void;
   href?: string | undefined;
+  captureMode?: boolean | undefined;
 }
 
 const NODE_META: Record<AttackPathNode["type"], { icon: LucideIcon; tint: string; ring: string }> = {
@@ -25,7 +26,7 @@ const NODE_META: Record<AttackPathNode["type"], { icon: LucideIcon; tint: string
   credential: { icon: KeyRound, tint: "text-fuchsia-300 bg-fuchsia-500/12", ring: "border-fuchsia-500/25" },
 };
 
-export function AttackPathCard({ nodes, riskScore, onClick, href }: AttackPathCardProps) {
+export function AttackPathCard({ nodes, riskScore, onClick, href, captureMode = false }: AttackPathCardProps) {
   const riskTone =
     riskScore >= 8
       ? "border-red-500/25 bg-red-500/10 text-red-200"
@@ -67,7 +68,13 @@ export function AttackPathCard({ nodes, riskScore, onClick, href }: AttackPathCa
               <div className={`flex items-center gap-2 rounded-xl border px-2.5 py-1.5 ${severityRing} ${meta.tint}`}>
                 <Icon className="h-3.5 w-3.5 shrink-0" />
                 <div className="min-w-0">
-                  <p className="max-w-[120px] truncate text-[11px] font-medium text-[color:var(--foreground)]">{node.label}</p>
+                  <p
+                    className={`text-[11px] font-medium text-[color:var(--foreground)] ${
+                      captureMode ? "max-w-[13rem] whitespace-normal break-words leading-4" : "max-w-[120px] truncate"
+                    }`}
+                  >
+                    {node.label}
+                  </p>
                   <p className="text-[9px] uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">{node.type}</p>
                 </div>
               </div>
@@ -93,7 +100,9 @@ export function AttackPathCard({ nodes, riskScore, onClick, href }: AttackPathCa
   );
 
   const className =
-    "group block w-full rounded-2xl border border-[color:var(--border-subtle)] bg-[linear-gradient(135deg,var(--surface),var(--surface-elevated))] px-4 py-3 text-left shadow-lg transition-all hover:-translate-y-0.5 hover:border-[color:var(--border-strong)] hover:shadow-xl hover:shadow-emerald-500/5";
+    `group block w-full rounded-2xl border border-[color:var(--border-subtle)] bg-[linear-gradient(135deg,var(--surface),var(--surface-elevated))] px-4 py-3 text-left shadow-lg transition-all hover:border-[color:var(--border-strong)] hover:shadow-xl hover:shadow-emerald-500/5 ${
+      captureMode ? "" : "hover:-translate-y-0.5"
+    }`;
 
   if (href && !onClick) {
     return (

--- a/ui/components/graph-chrome.tsx
+++ b/ui/components/graph-chrome.tsx
@@ -5,7 +5,7 @@
  * Used across all graph views for consistent UX.
  */
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import {
   Brain,
   Boxes,
@@ -67,12 +67,17 @@ export function GraphLegend({
   defaultOpen?: boolean;
   embedded?: boolean;
 }) {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(defaultOpen);
+
+  useEffect(() => {
+    if (defaultOpen) setOpen(true);
+  }, [defaultOpen]);
 
   if (items.length === 0) return null;
 
   const nodeItems = items.filter((item) => item.kind !== "edge");
   const edgeItems = items.filter((item) => item.kind === "edge");
+  const visible = open || defaultOpen || embedded;
 
   return (
     <div className="relative">
@@ -80,14 +85,14 @@ export function GraphLegend({
         type="button"
         onClick={() => setOpen((current) => !current)}
         className={`${embedded ? "hidden" : "flex"} items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800/80 px-2.5 py-1.5 text-xs text-zinc-300 transition-colors hover:bg-zinc-700 backdrop-blur-sm`}
-        aria-expanded={open}
-        aria-label={open ? "Hide legend" : "Show legend"}
+        aria-expanded={visible}
+        aria-label={visible ? "Hide legend" : "Show legend"}
       >
         <span className="font-medium">Legend</span>
         <span className="rounded-full bg-zinc-900 px-1.5 py-0.5 text-[10px] text-zinc-400">{items.length}</span>
-        <ChevronDown className={`h-3.5 w-3.5 transition-transform ${open ? "rotate-180" : ""}`} />
+        <ChevronDown className={`h-3.5 w-3.5 transition-transform ${visible ? "rotate-180" : ""}`} />
       </button>
-      {(open || defaultOpen || embedded) && (
+      {visible && (
         <div className={`${embedded ? "relative w-[min(30rem,calc(100vw-2rem))] shadow-none" : "absolute right-0 top-full z-20 mt-2 w-[min(30rem,calc(100vw-2rem))] shadow-2xl shadow-black/30"} max-h-[60vh] overflow-y-auto rounded-xl border border-zinc-700 bg-zinc-900/95 p-3 backdrop-blur-md`}>
           {nodeItems.length > 0 && <LayeredLegendSections items={nodeItems} />}
           {edgeItems.length > 0 && (

--- a/ui/lib/graph-utils.ts
+++ b/ui/lib/graph-utils.ts
@@ -288,6 +288,7 @@ export function readableGraphEdges(
     inactiveOpacity?: number;
     activeOpacity?: number;
     quietAnimation?: boolean;
+    captureMode?: boolean;
   } = {},
 ): Edge[] {
   const {
@@ -296,22 +297,36 @@ export function readableGraphEdges(
     inactiveOpacity = 0.08,
     activeOpacity = 0.96,
     quietAnimation = true,
+    captureMode = false,
   } = options;
 
   return edges.map((edge): Edge => {
     const relationship = edgeRelationship(edge);
     const highSignal = HIGH_SIGNAL_RELATIONSHIPS.has(relationship);
     const active = activeNodeIds ? activeNodeIds.has(edge.source) && activeNodeIds.has(edge.target) : false;
-    const opacity = activeNodeIds ? (active ? activeOpacity : inactiveOpacity) : highSignal ? highSignalOpacity : baseOpacity;
+    const captureBaseOpacity = captureMode ? Math.max(baseOpacity, 0.42) : baseOpacity;
+    const captureHighSignalOpacity = captureMode ? Math.max(highSignalOpacity, 0.68) : highSignalOpacity;
+    const captureInactiveOpacity = captureMode ? Math.max(inactiveOpacity, 0.18) : inactiveOpacity;
+    const opacity = activeNodeIds
+      ? active
+        ? activeOpacity
+        : captureInactiveOpacity
+      : highSignal
+        ? captureHighSignalOpacity
+        : captureBaseOpacity;
     const width = numericStrokeWidth(edge);
 
     return {
       ...edge,
-      animated: quietAnimation ? Boolean(activeNodeIds && active && edge.animated) : Boolean(edge.animated),
+      animated: captureMode ? false : quietAnimation ? Boolean(activeNodeIds && active && edge.animated) : Boolean(edge.animated),
       style: {
         ...edge.style,
         opacity,
-        strokeWidth: active ? Math.max(width, 2.6) : Math.max(Math.min(width, highSignal ? 2 : 1.5), 1),
+        strokeWidth: active
+          ? Math.max(width, captureMode ? 3 : 2.6)
+          : captureMode
+            ? Math.max(Math.min(width, highSignal ? 2.2 : 1.6), 1.25)
+            : Math.max(Math.min(width, highSignal ? 2 : 1.5), 1),
       },
     };
   });

--- a/ui/lib/use-capture-mode.ts
+++ b/ui/lib/use-capture-mode.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function isCaptureModeSearch(search: string): boolean {
+  return new URLSearchParams(search).get("capture") === "1";
+}
+
+export function useCaptureMode(): boolean {
+  const [captureMode, setCaptureMode] = useState(false);
+
+  useEffect(() => {
+    const update = () => setCaptureMode(isCaptureModeSearch(window.location.search));
+    update();
+    window.addEventListener("popstate", update);
+    return () => window.removeEventListener("popstate", update);
+  }, []);
+
+  return captureMode;
+}

--- a/ui/tests/graph-chrome.test.tsx
+++ b/ui/tests/graph-chrome.test.tsx
@@ -25,4 +25,20 @@ describe("GraphLegend", () => {
     expect(screen.getByText("Relationships")).toBeInTheDocument();
     expect(screen.getByText("Uses")).toBeInTheDocument();
   });
+
+  it("opens the legend by default for capture-ready graph views", () => {
+    render(
+      <GraphLegend
+        defaultOpen
+        items={[
+          { label: "Agent", color: "#10b981", layer: "orchestration", kind: "node", shape: "dot" },
+          { label: "Uses", color: "#10b981", kind: "edge", lineStyle: "solid" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /hide legend/i })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Orchestration")).toBeInTheDocument();
+    expect(screen.getByText("Relationships")).toBeInTheDocument();
+  });
 });

--- a/ui/tests/graph-utils.test.ts
+++ b/ui/tests/graph-utils.test.ts
@@ -76,4 +76,34 @@ describe("graph utility metadata", () => {
     expect(focused[1]!.style?.opacity).toBeGreaterThan(0.9);
     expect(focused[1]!.style?.strokeWidth).toBeGreaterThanOrEqual(2.6);
   });
+
+  it("uses a stable non-animated edge profile for capture mode", () => {
+    const captured = readableGraphEdges(
+      [
+        {
+          id: "a-b",
+          source: "a",
+          target: "b",
+          data: { relationship: "uses" },
+          animated: true,
+          style: { strokeWidth: 1 },
+        },
+        {
+          id: "b-c",
+          source: "b",
+          target: "c",
+          data: { relationship: "vulnerable_to" },
+          animated: true,
+          style: { strokeWidth: 1 },
+        },
+      ],
+      new Set(["b"]),
+      { inactiveOpacity: 0.04, captureMode: true },
+    );
+
+    expect(captured.every((edge) => edge.animated === false)).toBe(true);
+    expect(captured[0]!.style?.opacity).toBeGreaterThanOrEqual(0.18);
+    expect(captured[1]!.style?.opacity).toBeGreaterThanOrEqual(0.18);
+    expect(captured[1]!.style?.strokeWidth).toBeGreaterThanOrEqual(1.25);
+  });
 });


### PR DESCRIPTION
## Summary
- add a shared `?capture=1` capture mode for graph surfaces
- force legends open, hide minimaps, and disable animated edges for stable screenshot evidence
- make attack-path labels wrap instead of truncating in capture mode

Closes #2446.

## Validation
- `cd ui && npm test -- --run tests/graph-utils.test.ts tests/graph-chrome.test.tsx tests/attack-path-card.test.tsx`
- `cd ui && npm run typecheck`
- `cd ui && npm run lint`
- `git diff --check`
