### PR TITLE
data: add local scan analytics store

### DIFF
--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -88,6 +88,11 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_HTTP_MAX_BACKOFF` | `float` | `30.0` | — |
 | `AGENT_BOM_HTTP_MAX_RETRIES` | `int` | `3` | Used by http_client.create_client() and request_with_retry().  Defaults: 3 retries with 1s initial backoff (doubles each retry, capped at 30s).  30s per-request timeout covers most external APIs; NVD can be slow so operators may raise this. |
 
+## Local Analytics
+| Env var | Type | Default | Description |
+|---|---|---|---|
+| `AGENT_BOM_LOCAL_ANALYTICS_DB` | `str` | `''` | Optional path override for the local scan analytics SQL mirror. Empty string means use ~/.agent-bom/local-analytics.sqlite. |
+
 ## MCP Server Limits
 | Env var | Type | Default | Description |
 |---|---|---|---|

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -877,6 +877,20 @@ def _run_scan_sync(job: ScanJob) -> None:
                 _logger.warning("Asset tracker persistence failed: %s", asset_exc)
                 with lock:
                     job.progress.append(f"Asset tracker skipped: {sanitize_error(asset_exc)}")
+
+            try:
+                from agent_bom.db.local_analytics import record_scan_report_best_effort
+
+                recorded_scan_id = record_scan_report_best_effort(
+                    report_json,
+                    source="api",
+                    tenant_id=str(getattr(job, "tenant_id", None) or "default"),
+                )
+                if recorded_scan_id:
+                    with lock:
+                        job.progress.append(f"Local analytics synced scan {recorded_scan_id}")
+            except Exception as local_analytics_exc:  # noqa: BLE001
+                _logger.debug("Local analytics persistence skipped: %s", local_analytics_exc)
         else:
             with lock:
                 job.progress.append("Result side-effect persistence skipped by request")

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -198,6 +198,13 @@ GHSA_UNAUTH_PACKAGE_BUDGET = _int("AGENT_BOM_GHSA_UNAUTH_PACKAGE_BUDGET", 25)
 SCAN_CACHE_MAX_ENTRIES = _int("AGENT_BOM_SCAN_CACHE_MAX_ENTRIES", 100_000)
 
 
+# ── Local Analytics ─────────────────────────────────────────────────────────
+# Optional path override for the local scan analytics SQL mirror. Empty string
+# means use ~/.agent-bom/local-analytics.sqlite.
+
+LOCAL_ANALYTICS_DB = _str("AGENT_BOM_LOCAL_ANALYTICS_DB", "")
+
+
 # ── AI Enrichment ─────────────────────────────────────────────────────────
 # Used by ai_enrich.py for LLM-powered risk narratives.
 #

--- a/src/agent_bom/db/local_analytics.py
+++ b/src/agent_bom/db/local_analytics.py
@@ -1,0 +1,333 @@
+"""Local scan analytics store.
+
+The history JSON files remain the durable artifact of record. This module keeps
+an adjacent queryable mirror of scan runs, findings, and packages so local
+reporting can read small normalized tables instead of repeatedly loading every
+history JSON file.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from agent_bom.config import LOCAL_ANALYTICS_DB
+
+SCHEMA_VERSION = 1
+DEFAULT_LOCAL_ANALYTICS_PATH = Path.home() / ".agent-bom" / "local-analytics.sqlite"
+
+
+def local_analytics_path() -> Path:
+    """Return the configured local analytics database path."""
+    if LOCAL_ANALYTICS_DB:
+        return Path(LOCAL_ANALYTICS_DB).expanduser()
+    return DEFAULT_LOCAL_ANALYTICS_PATH
+
+
+class LocalAnalyticsStore:
+    """Small local SQL mirror of scan history."""
+
+    def __init__(self, db_path: str | Path | None = None) -> None:
+        self.db_path = Path(db_path).expanduser() if db_path is not None else local_analytics_path()
+
+    def _connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        self._init_schema(conn)
+        return conn
+
+    def _init_schema(self, conn: sqlite3.Connection) -> None:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS local_schema_meta (
+                component TEXT PRIMARY KEY,
+                version INTEGER NOT NULL,
+                applied_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS scan_runs (
+                scan_id TEXT PRIMARY KEY,
+                generated_at TEXT NOT NULL,
+                recorded_at TEXT NOT NULL,
+                tenant_id TEXT NOT NULL DEFAULT 'default',
+                source TEXT NOT NULL,
+                artifact_path TEXT,
+                total_agents INTEGER NOT NULL DEFAULT 0,
+                total_packages INTEGER NOT NULL DEFAULT 0,
+                total_vulnerabilities INTEGER NOT NULL DEFAULT 0,
+                critical_findings INTEGER NOT NULL DEFAULT 0,
+                high_findings INTEGER NOT NULL DEFAULT 0
+            );
+
+            CREATE TABLE IF NOT EXISTS scan_findings (
+                scan_id TEXT NOT NULL,
+                finding_key TEXT NOT NULL,
+                vulnerability_id TEXT NOT NULL,
+                package_name TEXT NOT NULL,
+                package_version TEXT NOT NULL,
+                package_ref TEXT NOT NULL,
+                ecosystem TEXT NOT NULL,
+                severity TEXT NOT NULL,
+                risk_score REAL NOT NULL DEFAULT 0,
+                affected_agents_json TEXT NOT NULL DEFAULT '[]',
+                affected_servers_json TEXT NOT NULL DEFAULT '[]',
+                PRIMARY KEY (scan_id, finding_key),
+                FOREIGN KEY (scan_id) REFERENCES scan_runs(scan_id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS scan_packages (
+                scan_id TEXT NOT NULL,
+                agent_name TEXT NOT NULL,
+                server_name TEXT NOT NULL,
+                package_name TEXT NOT NULL,
+                package_version TEXT NOT NULL,
+                ecosystem TEXT NOT NULL,
+                purl TEXT,
+                PRIMARY KEY (scan_id, agent_name, server_name, package_name, package_version, ecosystem),
+                FOREIGN KEY (scan_id) REFERENCES scan_runs(scan_id) ON DELETE CASCADE
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_scan_runs_generated_at ON scan_runs(generated_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_scan_findings_severity ON scan_findings(severity);
+            CREATE INDEX IF NOT EXISTS idx_scan_packages_name ON scan_packages(package_name);
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO local_schema_meta(component, version, applied_at)
+            VALUES ('local_analytics', ?, ?)
+            ON CONFLICT(component) DO UPDATE SET
+                version = excluded.version,
+                applied_at = excluded.applied_at
+            """,
+            (SCHEMA_VERSION, _now_iso()),
+        )
+        conn.commit()
+
+    def record_scan_report(
+        self,
+        report_json: dict[str, Any],
+        *,
+        source: str,
+        tenant_id: str = "default",
+        artifact_path: str | Path | None = None,
+    ) -> str:
+        """Upsert one scan report into normalized local tables."""
+        scan_id = str(report_json.get("scan_id") or "").strip()
+        if not scan_id:
+            generated_key = str(report_json.get("generated_at") or _now_iso()).replace(":", "").replace("-", "")
+            scan_id = f"local-{generated_key}"
+
+        generated_at = str(report_json.get("generated_at") or report_json.get("scan_timestamp") or _now_iso())
+        raw_summary = report_json.get("summary")
+        summary: dict[str, Any] = raw_summary if isinstance(raw_summary, dict) else {}
+        findings = list(_iter_findings(report_json))
+        package_rows = list(_iter_packages(report_json))
+
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO scan_runs(
+                    scan_id, generated_at, recorded_at, tenant_id, source, artifact_path,
+                    total_agents, total_packages, total_vulnerabilities, critical_findings, high_findings
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(scan_id) DO UPDATE SET
+                    generated_at = excluded.generated_at,
+                    recorded_at = excluded.recorded_at,
+                    tenant_id = excluded.tenant_id,
+                    source = excluded.source,
+                    artifact_path = excluded.artifact_path,
+                    total_agents = excluded.total_agents,
+                    total_packages = excluded.total_packages,
+                    total_vulnerabilities = excluded.total_vulnerabilities,
+                    critical_findings = excluded.critical_findings,
+                    high_findings = excluded.high_findings
+                """,
+                (
+                    scan_id,
+                    generated_at,
+                    _now_iso(),
+                    tenant_id or "default",
+                    source,
+                    str(artifact_path) if artifact_path is not None else None,
+                    _int(summary.get("total_agents")),
+                    _int(summary.get("total_packages")),
+                    _int(summary.get("total_vulnerabilities")),
+                    _int(summary.get("critical_findings")),
+                    sum(1 for item in findings if str(item.get("severity") or "").lower() == "high"),
+                ),
+            )
+            conn.execute("DELETE FROM scan_findings WHERE scan_id = ?", (scan_id,))
+            conn.execute("DELETE FROM scan_packages WHERE scan_id = ?", (scan_id,))
+            conn.executemany(
+                """
+                INSERT INTO scan_findings(
+                    scan_id, finding_key, vulnerability_id, package_name, package_version,
+                    package_ref, ecosystem, severity, risk_score,
+                    affected_agents_json, affected_servers_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [_finding_row(scan_id, finding) for finding in findings],
+            )
+            conn.executemany(
+                """
+                INSERT INTO scan_packages(
+                    scan_id, agent_name, server_name, package_name, package_version, ecosystem, purl
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                [_package_row(scan_id, package_row) for package_row in package_rows],
+            )
+            conn.commit()
+        return scan_id
+
+    def list_scan_runs(self, *, limit: int = 20) -> list[dict[str, Any]]:
+        """Return recent scan runs newest first."""
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT scan_id, generated_at, recorded_at, tenant_id, source, artifact_path,
+                       total_agents, total_packages, total_vulnerabilities,
+                       critical_findings, high_findings
+                FROM scan_runs
+                ORDER BY generated_at DESC
+                LIMIT ?
+                """,
+                (max(1, int(limit)),),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def query(self, sql: str, params: Iterable[Any] = ()) -> list[dict[str, Any]]:
+        """Run a read query against the local analytics store."""
+        if not sql.lstrip().lower().startswith("select"):
+            raise ValueError("local analytics queries are read-only")
+        with self._connect() as conn:
+            rows = conn.execute(sql, tuple(params)).fetchall()
+        return [dict(row) for row in rows]
+
+
+def record_scan_report_best_effort(
+    report_json: dict[str, Any],
+    *,
+    source: str,
+    tenant_id: str = "default",
+    artifact_path: str | Path | None = None,
+    db_path: str | Path | None = None,
+) -> str | None:
+    """Record a scan locally without allowing analytics to break scan output."""
+    try:
+        return LocalAnalyticsStore(db_path).record_scan_report(
+            report_json,
+            source=source,
+            tenant_id=tenant_id,
+            artifact_path=artifact_path,
+        )
+    except Exception:
+        return None
+
+
+def _iter_findings(report_json: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    blast_radius = report_json.get("blast_radius") or report_json.get("blast_radii") or []
+    if isinstance(blast_radius, list):
+        for item in blast_radius:
+            if isinstance(item, dict):
+                yield item
+
+
+def _iter_packages(report_json: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    agents = report_json.get("agents") or []
+    if not isinstance(agents, list):
+        return
+    for agent in agents:
+        if not isinstance(agent, dict):
+            continue
+        agent_name = str(agent.get("name") or "")
+        servers = agent.get("mcp_servers") or []
+        if not isinstance(servers, list):
+            continue
+        for server in servers:
+            if not isinstance(server, dict):
+                continue
+            server_name = str(server.get("name") or "")
+            packages = server.get("packages") or []
+            if not isinstance(packages, list):
+                continue
+            for package in packages:
+                if isinstance(package, dict):
+                    yield {
+                        "agent_name": agent_name,
+                        "server_name": server_name,
+                        **package,
+                    }
+
+
+def _finding_row(scan_id: str, finding: dict[str, Any]) -> tuple[Any, ...]:
+    vulnerability_id = str(finding.get("vulnerability_id") or finding.get("id") or "")
+    package_ref = str(finding.get("package") or "")
+    package_name = str(finding.get("package_name") or _package_name_from_ref(package_ref))
+    package_version = str(finding.get("package_version") or _package_version_from_ref(package_ref))
+    ecosystem = str(finding.get("ecosystem") or "")
+    finding_key = "|".join((vulnerability_id, package_ref, ecosystem))
+    return (
+        scan_id,
+        finding_key,
+        vulnerability_id,
+        package_name,
+        package_version,
+        package_ref,
+        ecosystem,
+        str(finding.get("severity") or "unknown").lower(),
+        _float(finding.get("risk_score")),
+        json.dumps(list(finding.get("affected_agents") or []), sort_keys=True),
+        json.dumps(list(finding.get("affected_servers") or []), sort_keys=True),
+    )
+
+
+def _package_row(scan_id: str, package: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        scan_id,
+        str(package.get("agent_name") or ""),
+        str(package.get("server_name") or ""),
+        str(package.get("name") or ""),
+        str(package.get("version") or ""),
+        str(package.get("ecosystem") or ""),
+        package.get("purl"),
+    )
+
+
+def _package_name_from_ref(package_ref: str) -> str:
+    if "@" not in package_ref:
+        return package_ref
+    return package_ref.rsplit("@", 1)[0]
+
+
+def _package_version_from_ref(package_ref: str) -> str:
+    if "@" not in package_ref:
+        return ""
+    return package_ref.rsplit("@", 1)[1]
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/src/agent_bom/history.py
+++ b/src/agent_bom/history.py
@@ -30,6 +30,12 @@ def save_report(report_json: dict, label: Optional[str] = None) -> Path:
     stem = f"{ts}-{label}" if label else ts
     path = history_dir() / f"{stem}.json"
     path.write_text(json.dumps(report_json, indent=2))
+    try:
+        from agent_bom.db.local_analytics import record_scan_report_best_effort
+
+        record_scan_report_best_effort(report_json, source="cli", artifact_path=path)
+    except Exception:
+        pass
     return path
 
 

--- a/tests/test_local_analytics.py
+++ b/tests/test_local_analytics.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import sqlite3
+
+from agent_bom.db.local_analytics import LocalAnalyticsStore
+
+
+def _report(scan_id: str = "scan-1") -> dict:
+    return {
+        "scan_id": scan_id,
+        "generated_at": "2026-05-10T16:00:00+00:00",
+        "summary": {
+            "total_agents": 1,
+            "total_packages": 2,
+            "total_vulnerabilities": 2,
+            "critical_findings": 1,
+        },
+        "agents": [
+            {
+                "name": "desktop-agent",
+                "mcp_servers": [
+                    {
+                        "name": "filesystem",
+                        "packages": [
+                            {
+                                "name": "fastapi",
+                                "version": "0.115.0",
+                                "ecosystem": "pypi",
+                                "purl": "pkg:pypi/fastapi@0.115.0",
+                            },
+                            {
+                                "name": "uvicorn",
+                                "version": "0.32.0",
+                                "ecosystem": "pypi",
+                            },
+                        ],
+                    }
+                ],
+            }
+        ],
+        "blast_radius": [
+            {
+                "vulnerability_id": "CVE-2026-0001",
+                "package": "fastapi@0.115.0",
+                "package_name": "fastapi",
+                "package_version": "0.115.0",
+                "ecosystem": "pypi",
+                "severity": "critical",
+                "risk_score": 9.4,
+                "affected_agents": ["desktop-agent"],
+                "affected_servers": ["filesystem"],
+            },
+            {
+                "vulnerability_id": "CVE-2026-0002",
+                "package": "uvicorn@0.32.0",
+                "ecosystem": "pypi",
+                "severity": "high",
+                "risk_score": 7.2,
+                "affected_agents": ["desktop-agent"],
+                "affected_servers": ["filesystem"],
+            },
+        ],
+    }
+
+
+def test_local_analytics_store_records_scan_summary_findings_and_packages(tmp_path):
+    store = LocalAnalyticsStore(tmp_path / "local.sqlite")
+
+    scan_id = store.record_scan_report(_report(), source="cli", artifact_path=tmp_path / "scan.json")
+
+    assert scan_id == "scan-1"
+    runs = store.list_scan_runs()
+    assert runs[0]["scan_id"] == "scan-1"
+    assert runs[0]["total_packages"] == 2
+    assert runs[0]["critical_findings"] == 1
+    assert runs[0]["high_findings"] == 1
+
+    severity_rows = store.query("SELECT severity, COUNT(*) AS count FROM scan_findings GROUP BY severity ORDER BY severity")
+    assert severity_rows == [{"severity": "critical", "count": 1}, {"severity": "high", "count": 1}]
+
+    package_rows = store.query("SELECT package_name FROM scan_packages ORDER BY package_name")
+    assert package_rows == [{"package_name": "fastapi"}, {"package_name": "uvicorn"}]
+
+
+def test_local_analytics_store_upserts_scan_without_changing_existing_json_artifact(tmp_path):
+    report = _report()
+    store = LocalAnalyticsStore(tmp_path / "local.sqlite")
+
+    store.record_scan_report(report, source="cli")
+    report["summary"]["total_vulnerabilities"] = 3
+    report["blast_radius"].append(
+        {
+            "vulnerability_id": "CVE-2026-0003",
+            "package": "fastapi@0.115.0",
+            "ecosystem": "pypi",
+            "severity": "medium",
+        }
+    )
+    store.record_scan_report(report, source="cli")
+
+    assert store.query("SELECT total_vulnerabilities FROM scan_runs WHERE scan_id = ?", ("scan-1",)) == [{"total_vulnerabilities": 3}]
+    assert store.query("SELECT COUNT(*) AS count FROM scan_findings WHERE scan_id = ?", ("scan-1",)) == [{"count": 3}]
+
+
+def test_history_save_dual_writes_local_analytics(monkeypatch, tmp_path):
+    import agent_bom.db.local_analytics as local_analytics
+    import agent_bom.history as history
+
+    analytics_path = tmp_path / "analytics.sqlite"
+    monkeypatch.setattr(history, "HISTORY_DIR", tmp_path / "history")
+    monkeypatch.setattr(local_analytics, "LOCAL_ANALYTICS_DB", str(analytics_path))
+
+    saved_path = history.save_report(_report("saved-scan"))
+
+    assert saved_path.exists()
+    with sqlite3.connect(analytics_path) as conn:
+        rows = conn.execute("SELECT scan_id, source, artifact_path FROM scan_runs").fetchall()
+    assert rows == [("saved-scan", "cli", str(saved_path))]


### PR DESCRIPTION
## Summary
- add a local analytics SQL mirror for scan runs, findings, and packages
- dual-write saved CLI history reports and completed API scans without changing the JSON history artifact
- document `AGENT_BOM_LOCAL_ANALYTICS_DB` and add targeted write/query regression tests

Closes #2434.

## Validation
- `uv run pytest -q tests/test_local_analytics.py`
- `uv run ruff check src/agent_bom/db/local_analytics.py src/agent_bom/history.py src/agent_bom/api/pipeline.py src/agent_bom/config.py tests/test_local_analytics.py`
- `uv run mypy src/agent_bom/db/local_analytics.py`
- `git diff --check`
