### PR TITLE
data: version scan output schemas

### DIFF
--- a/contracts/v1/examples/scan-report.minimal.json
+++ b/contracts/v1/examples/scan-report.minimal.json
@@ -1,9 +1,15 @@
 {
+  "schema_version": "1.0",
   "document_type": "AI-BOM",
   "spec_version": "1.0",
   "scan_id": "scan-demo-001",
   "ai_bom_version": "0.82.0",
   "generated_at": "2026-04-25T00:00:00Z",
+  "scan_run": {
+    "schema_version": "1",
+    "scan_id": "scan-demo-001",
+    "generated_at": "2026-04-25T00:00:00Z"
+  },
   "scan_sources": ["demo"],
   "summary": {
     "total_agents": 1,

--- a/contracts/v1/scan-report.schema.json
+++ b/contracts/v1/scan-report.schema.json
@@ -3,8 +3,9 @@
   "$id": "https://agent-bom.dev/contracts/v1/scan-report.schema.json",
   "title": "agent-bom scan report v1",
   "type": "object",
-  "required": ["document_type", "spec_version", "scan_id", "generated_at", "summary", "agents"],
+  "required": ["schema_version", "document_type", "spec_version", "scan_id", "generated_at", "summary", "agents"],
   "properties": {
+    "schema_version": { "type": "string", "pattern": "^1(\\.\\d+)?$" },
     "document_type": { "const": "AI-BOM" },
     "spec_version": { "type": "string", "pattern": "^1(\\.\\d+)?$" },
     "scan_id": { "type": "string", "minLength": 1 },
@@ -53,8 +54,46 @@
         "additionalProperties": true
       }
     },
-    "blast_radius": { "type": "array" },
-    "inventory_snapshot": { "type": "object" }
+    "scan_run": {
+      "type": "object",
+      "required": ["schema_version", "scan_id", "generated_at"],
+      "properties": {
+        "schema_version": { "type": "string", "pattern": "^1(\\.\\d+)?$" },
+        "scan_id": { "type": "string" },
+        "generated_at": { "type": "string", "format": "date-time" }
+      },
+      "additionalProperties": true
+    },
+    "blast_radius": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["schema_version"],
+        "properties": {
+          "schema_version": { "type": "string", "pattern": "^1(\\.\\d+)?$" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["schema_version"],
+        "properties": {
+          "schema_version": { "type": "string", "pattern": "^1(\\.\\d+)?$" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "inventory_snapshot": {
+      "type": "object",
+      "required": ["schema_version"],
+      "properties": {
+        "schema_version": { "type": "string", "pattern": "^1(\\.\\d+)?$" }
+      },
+      "additionalProperties": true
+    }
   },
   "additionalProperties": true
 }

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -15,6 +15,7 @@ from typing import Optional
 # Stable namespace for agent-bom deterministic UUIDs
 # Using a fixed UUID so IDs are reproducible across machines and versions
 _AGENT_BOM_NS = uuid.UUID("7f3e4b2a-9c1d-5f8e-a0b4-12c3d4e5f6a7")
+FINDING_SCHEMA_VERSION = "1"
 
 
 def _stable_id(*parts: str) -> str:
@@ -291,6 +292,7 @@ class Finding:
     def to_dict(self) -> dict:
         """Return a JSON-serializable finding payload."""
         return {
+            "schema_version": FINDING_SCHEMA_VERSION,
             "id": self.id,
             "finding_type": self.finding_type.value,
             "source": self.source.value,

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -13,6 +13,7 @@ from agent_bom.asset_provenance import (
     sanitize_discovery_provenance,
 )
 from agent_bom.compliance_utils import effective_blast_radius_tags
+from agent_bom.finding import FINDING_SCHEMA_VERSION
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
 from agent_bom.security import (
@@ -23,6 +24,11 @@ from agent_bom.security import (
     sanitize_text,
     sanitize_url,
 )
+
+SCAN_REPORT_SCHEMA_VERSION = "1.0"
+SCAN_RUN_SCHEMA_VERSION = "1"
+BLAST_RADIUS_SCHEMA_VERSION = "1"
+INVENTORY_SNAPSHOT_SCHEMA_VERSION = "1"
 
 
 def _severity_state(severity: Severity) -> str:
@@ -82,6 +88,7 @@ def _prompt_scan_findings(prompt_scan: dict) -> list[dict[str, object]]:
         severity = str(item.get("severity") or "unknown").lower()
         findings.append(
             {
+                "schema_version": FINDING_SCHEMA_VERSION,
                 "id": _stable_report_finding_id("prompt_scan", source_file, line_number, title, item.get("matched_text")),
                 "finding_type": "PROMPT_SECURITY",
                 "source": "PROMPT_SCAN",
@@ -118,6 +125,7 @@ def _browser_extension_findings(browser_extensions: dict) -> list[dict[str, obje
         severity = str(item.get("risk_level") or "unknown").lower()
         findings.append(
             {
+                "schema_version": FINDING_SCHEMA_VERSION,
                 "id": _stable_report_finding_id("browser_extension", browser, extension_id, item.get("version")),
                 "finding_type": "BROWSER_EXTENSION_RISK",
                 "source": "BROWSER_EXTENSION_SCAN",
@@ -670,7 +678,7 @@ def _build_inventory_snapshot(report: AIBOMReport) -> dict:
         )
 
     return {
-        "schema_version": "1",
+        "schema_version": INVENTORY_SNAPSHOT_SCHEMA_VERSION,
         "generated_at": report.generated_at.isoformat(),
         "agents": agents,
     }
@@ -785,11 +793,18 @@ def to_json(report: AIBOMReport) -> dict:
 
     all_packages = [pkg for agent in report.agents for server in agent.mcp_servers for pkg in server.packages]
     result = {
+        "schema_version": SCAN_REPORT_SCHEMA_VERSION,
         "document_type": "AI-BOM",
-        "spec_version": "1.0",
+        "spec_version": SCAN_REPORT_SCHEMA_VERSION,
         "scan_id": report.scan_id,
         "ai_bom_version": report.tool_version,
         "generated_at": report.generated_at.isoformat(),
+        "scan_run": {
+            "schema_version": SCAN_RUN_SCHEMA_VERSION,
+            "scan_id": report.scan_id,
+            "generated_at": report.generated_at.isoformat(),
+            "source_count": len(report.scan_sources),
+        },
         "scan_sources": report.scan_sources,
         "has_mcp_context": report.has_mcp_context,
         "has_agent_context": report.has_agent_context,
@@ -1003,6 +1018,7 @@ def to_json(report: AIBOMReport) -> dict:
         ],
         "blast_radius": [
             {
+                "schema_version": BLAST_RADIUS_SCHEMA_VERSION,
                 **({"package_name": br.package.name, "package_version": br.package.version, "package_stable_id": br.package.stable_id}),
                 **effective_blast_radius_tags(br),
                 "risk_score": br.risk_score,

--- a/tests/test_contract_schemas.py
+++ b/tests/test_contract_schemas.py
@@ -63,6 +63,58 @@ def test_scan_report_serializer_matches_contract_schema() -> None:
     assert agent_payload["type"] == "claude-desktop"
 
 
+def test_scan_report_helper_findings_match_contract_schema() -> None:
+    """Prompt and browser helper findings must stay inside the v1 finding contract."""
+    report = AIBOMReport(
+        generated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        scan_id="scan-contract-helper-findings",
+        tool_version="0.81.3",
+        prompt_scan_data={
+            "files_scanned": 1,
+            "prompt_files": ["system.prompt"],
+            "findings": [
+                {
+                    "source_file": "system.prompt",
+                    "line_number": 1,
+                    "title": "Prompt injection pattern",
+                    "category": "prompt_injection",
+                    "severity": "high",
+                    "detail": "Prompt contains override language.",
+                    "matched_text": "ignore previous instructions",
+                    "recommendation": "Remove override instructions from the prompt.",
+                }
+            ],
+            "passed": False,
+        },
+        browser_extensions={
+            "extensions": [
+                {
+                    "id": "risk-ext",
+                    "name": "Risk Extension",
+                    "version": "1.0.0",
+                    "browser": "chrome",
+                    "permissions": ["debugger"],
+                    "host_permissions": ["<all_urls>"],
+                    "risk_level": "critical",
+                    "risk_reasons": ["Critical permission: debugger"],
+                    "path": "/tmp/risk-ext",
+                }
+            ],
+            "total": 1,
+            "critical_count": 1,
+            "high_count": 0,
+        },
+    )
+
+    payload = to_json(report)
+    jsonschema.validate(payload, _load(CONTRACTS / "scan-report.schema.json"))
+
+    helper_sources = {"PROMPT_SCAN", "BROWSER_EXTENSION_SCAN"}
+    helper_findings = [finding for finding in payload["findings"] if finding.get("source") in helper_sources]
+    assert {finding["source"] for finding in helper_findings} == helper_sources
+    assert all(finding["schema_version"] == "1" for finding in helper_findings)
+
+
 def test_scan_report_contract_accepts_agent_type_without_legacy_type() -> None:
     payload = _load(CONTRACTS / "examples" / "scan-report.minimal.json")
     payload["agents"][0].pop("type")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -525,8 +525,14 @@ def test_sarif_exclude_unfixable():
 
 def test_json_output_structure(sample_report):
     data = to_json(sample_report)
+    assert data["schema_version"] == "1.0"
+    assert data["scan_run"]["schema_version"] == "1"
+    assert data["scan_run"]["scan_id"] == sample_report.scan_id
     assert "agents" in data
     assert "blast_radius" in data
+    assert data["blast_radius"][0]["schema_version"] == "1"
+    assert data["findings"][0]["schema_version"] == "1"
+    assert data["inventory_snapshot"]["schema_version"] == "1"
     assert data["summary"]["total_vulnerabilities"] == 1
     assert data["ai_bom_version"] == sample_report.tool_version
 


### PR DESCRIPTION
## Summary
- add explicit schema versions to scan reports, scan-run metadata, blast-radius rows, and unified findings
- keep inventory snapshots on the shared schema-version constant
- update the v1 scan-report contract and minimal example for the new markers

Closes #2449.

## Validation
- `uv run pytest -q tests/test_contract_schemas.py tests/test_core.py::test_json_output_structure tests/test_output_formats.py::test_json_inventory_snapshot_round_trips_through_inventory_schema`
- `uv run ruff check src/agent_bom/output/json_fmt.py src/agent_bom/finding.py tests/test_core.py`
- `uv run mypy src/agent_bom/output/json_fmt.py src/agent_bom/finding.py`
- `git diff --check`
