### PR TITLE
cli: support reproducible scan timestamps

### DIFF
--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -427,6 +427,9 @@ def _job_summary_payload(job: ScanJob) -> dict[str, Any]:
 
     result = job.result if isinstance(job.result, dict) else {}
     summary = result.get("summary") if isinstance(result.get("summary"), dict) else None
+    scan_run = result.get("scan_run") if isinstance(result.get("scan_run"), dict) else None
+    generated_at = result.get("generated_at") or (scan_run or {}).get("generated_at")
+    scan_timestamp = result.get("scan_timestamp") or generated_at
     request_payload = sanitize_sensitive_payload(job.request.model_dump(exclude_defaults=True, exclude_none=True))
     return {
         "job_id": job.job_id,
@@ -436,7 +439,9 @@ def _job_summary_payload(job: ScanJob) -> dict[str, Any]:
         "completed_at": job.completed_at,
         "request": request_payload if isinstance(request_payload, dict) else {},
         "summary": summary,
-        "scan_timestamp": result.get("scan_timestamp"),
+        "scan_timestamp": scan_timestamp,
+        "generated_at": generated_at,
+        "scan_run": scan_run,
         "pushed": bool(result.get("pushed")),
         "error": job.error,
     }

--- a/src/agent_bom/api/stores.py
+++ b/src/agent_bom/api/stores.py
@@ -72,9 +72,11 @@ def _compact_terminal_job(job: ScanJob) -> ScanJob:
 
     compact_result: dict[str, Any] = {_COMPACTED_RESULT_MARKER: True}
     if isinstance(job.result, dict):
-        for key in ("summary", "scan_timestamp", "pushed"):
+        for key in ("summary", "scan_timestamp", "generated_at", "scan_run", "pushed"):
             if key in job.result:
                 compact_result[key] = job.result[key]
+        if "scan_timestamp" not in compact_result and "generated_at" in compact_result:
+            compact_result["scan_timestamp"] = compact_result["generated_at"]
     return job.model_copy(update={"result": compact_result})
 
 

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -196,6 +196,21 @@ def _output_format_was_explicit() -> bool:
     return ctx.get_parameter_source("output_format") is click.core.ParameterSource.COMMANDLINE
 
 
+def _reproducible_generated_at(enabled: bool):
+    """Return a pinned report timestamp when reproducible output is requested."""
+    import os
+    from datetime import datetime, timezone
+
+    raw_epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    if raw_epoch is None and not enabled:
+        return None
+    epoch = 0 if raw_epoch is None else raw_epoch
+    try:
+        return datetime.fromtimestamp(int(epoch), tz=timezone.utc)
+    except (OverflowError, OSError, ValueError) as exc:
+        raise click.ClickException("SOURCE_DATE_EPOCH must be an integer Unix timestamp.") from exc
+
+
 @click.command()
 @scan_options
 def scan(
@@ -373,6 +388,7 @@ def scan(
     log_json: bool,
     log_file: Optional[str],
     no_color: bool,
+    reproducible: bool,
     preset: Optional[str],
     open_report: bool,
     compliance_export: Optional[str],
@@ -1546,12 +1562,15 @@ def scan(
     _scan_fingerprint = "|".join(_pkg_fingerprints) or "empty"
     _scan_id = str(_uuid.uuid5(_scan_ns, f"scan:{_scan_fingerprint}"))
 
+    _generated_at = _reproducible_generated_at(reproducible)
+    _report_kwargs = {"generated_at": _generated_at} if _generated_at is not None else {}
     report = AIBOMReport(
         agents=agents,
         blast_radii=blast_radii,
         findings=_findings,
         scan_sources=_scan_sources,
         scan_id=_scan_id,
+        **_report_kwargs,
     )
     from agent_bom.advisory_sources import summarize_advisory_coverage
 

--- a/src/agent_bom/cli/options_sources.py
+++ b/src/agent_bom/cli/options_sources.py
@@ -192,6 +192,12 @@ def output_options(fn):
             click.option("--log-json", "log_json", is_flag=True, help="Emit structured JSON logs to stderr (for SIEM ingestion)"),
             click.option("--log-file", "log_file", type=click.Path(), default=None, help="Write JSON logs to file"),
             click.option("--no-color", is_flag=True, help="Disable colored output (useful for piping, CI logs, accessibility)"),
+            click.option(
+                "--reproducible",
+                is_flag=True,
+                default=False,
+                help="Use a stable generated_at timestamp for reproducible artifacts. SOURCE_DATE_EPOCH overrides the timestamp.",
+            ),
             click.option("--quiet", "-q", is_flag=True, help="Suppress all output except results (for scripting)"),
             click.option(
                 "--exclude-unfixable",

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -221,6 +221,74 @@ def test_scan_output_to_file(tmp_path):
     assert result.exit_code == 0
 
 
+def test_scan_reproducible_pins_report_and_inventory_timestamps(tmp_path):
+    inventory = tmp_path / "inventory.json"
+    inventory.write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "generated_at": "2026-05-09T00:00:00Z",
+                "agents": [{"name": "fixture-agent", "agent_type": "custom", "mcp_servers": []}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = tmp_path / "report.json"
+    result = _run(
+        [
+            "scan",
+            "--inventory",
+            str(inventory),
+            "--inventory-only",
+            "--no-scan",
+            "--reproducible",
+            "--format",
+            "json",
+            "--output",
+            str(out),
+        ]
+    )
+
+    assert result.exit_code == 0, result.output
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["generated_at"] == "1970-01-01T00:00:00+00:00"
+    assert report["inventory_snapshot"]["generated_at"] == "1970-01-01T00:00:00+00:00"
+
+
+def test_scan_honors_source_date_epoch_for_reproducible_outputs(tmp_path):
+    inventory = tmp_path / "inventory.json"
+    inventory.write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "generated_at": "2026-05-09T00:00:00Z",
+                "agents": [{"name": "fixture-agent", "agent_type": "custom", "mcp_servers": []}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = tmp_path / "report.json"
+    result = _run(
+        [
+            "scan",
+            "--inventory",
+            str(inventory),
+            "--inventory-only",
+            "--no-scan",
+            "--format",
+            "json",
+            "--output",
+            str(out),
+        ],
+        env={"SOURCE_DATE_EPOCH": "1700000000"},
+    )
+
+    assert result.exit_code == 0, result.output
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["generated_at"] == "2023-11-14T22:13:20+00:00"
+    assert report["inventory_snapshot"]["generated_at"] == "2023-11-14T22:13:20+00:00"
+
+
 def test_scan_unknown_output_extension_fails(tmp_path):
     out = tmp_path / "report.ocsf"
     result = _run(["scan", "--demo", "--output", str(out), "--no-scan"])

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -45,6 +45,53 @@ def test_jobs_get_missing_returns_none():
     assert _jobs_get("nonexistent") is None
 
 
+def test_compact_terminal_job_preserves_scan_timestamp_metadata():
+    from agent_bom.api.server import JobStatus, ScanJob, ScanRequest
+    from agent_bom.api.stores import _compact_terminal_job
+
+    job = ScanJob(job_id="compact-time", created_at="2025-01-01T00:00:00Z", request=ScanRequest())
+    job.status = JobStatus.DONE
+    job.result = {
+        "summary": {"total_agents": 1},
+        "generated_at": "2026-01-01T00:00:00+00:00",
+        "scan_run": {
+            "scan_id": "scan-123",
+            "generated_at": "2026-01-01T00:00:00+00:00",
+        },
+        "agents": [{"name": "large payload"}],
+    }
+
+    compact = _compact_terminal_job(job)
+
+    assert compact.result is not None
+    assert compact.result["generated_at"] == "2026-01-01T00:00:00+00:00"
+    assert compact.result["scan_timestamp"] == "2026-01-01T00:00:00+00:00"
+    assert compact.result["scan_run"]["scan_id"] == "scan-123"
+    assert "agents" not in compact.result
+
+
+def test_job_summary_payload_aliases_generated_at_to_scan_timestamp():
+    from agent_bom.api.routes.scan import _job_summary_payload
+    from agent_bom.api.server import JobStatus, ScanJob, ScanRequest
+
+    job = ScanJob(job_id="summary-time", created_at="2025-01-01T00:00:00Z", request=ScanRequest())
+    job.status = JobStatus.DONE
+    job.result = {
+        "summary": {"total_agents": 1},
+        "generated_at": "2026-01-01T00:00:00+00:00",
+        "scan_run": {
+            "scan_id": "scan-123",
+            "generated_at": "2026-01-01T00:00:00+00:00",
+        },
+    }
+
+    payload = _job_summary_payload(job)
+
+    assert payload["generated_at"] == "2026-01-01T00:00:00+00:00"
+    assert payload["scan_timestamp"] == "2026-01-01T00:00:00+00:00"
+    assert payload["scan_run"]["scan_id"] == "scan-123"
+
+
 def test_jobs_bounded_eviction():
     """When _jobs exceeds _MAX_IN_MEMORY_JOBS, oldest completed jobs are evicted."""
     from agent_bom.api import stores as _stores

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -447,10 +447,11 @@ export default function Dashboard() {
   // so all downstream useMemo aggregators work without changes.
   const effectiveJobs = useMemo<ScanJob[]>(() => {
     if (!apiError || !importedReport) return detailJobs;
+    const importedGeneratedAt = importedReport.scan_timestamp ?? importedReport.generated_at ?? new Date().toISOString();
     return [{
       job_id: "imported",
       status: "done",
-      created_at: importedReport.scan_timestamp ?? new Date().toISOString(),
+      created_at: importedGeneratedAt,
       request: {} as ScanJob["request"],
       progress: [],
       result: importedReport as unknown as Record<string, unknown>,
@@ -459,13 +460,16 @@ export default function Dashboard() {
 
   const effectiveRecentJobs = useMemo<JobListItem[]>(() => {
     if (!apiError || !importedReport) return jobs;
+    const importedGeneratedAt = importedReport.scan_timestamp ?? importedReport.generated_at ?? new Date().toISOString();
     return [{
       job_id: "imported",
       status: "done",
-      created_at: importedReport.scan_timestamp ?? new Date().toISOString(),
+      created_at: importedGeneratedAt,
       request: {},
       summary: importedReport.summary,
-      scan_timestamp: importedReport.scan_timestamp,
+      scan_timestamp: importedReport.scan_timestamp ?? importedGeneratedAt,
+      generated_at: importedReport.generated_at ?? importedGeneratedAt,
+      scan_run: importedReport.scan_run,
       pushed: false,
     }];
   }, [jobs, apiError, importedReport]);

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -71,6 +71,8 @@ export interface ScanResult {
   summary?: Summary | undefined;
   warnings?: string[] | undefined;
   scan_timestamp?: string | undefined;
+  generated_at?: string | undefined;
+  scan_run?: Record<string, unknown> | undefined;
   tool_version?: string | undefined;
   /** Context metadata — auto-detected from scan sources */
   has_mcp_context?: boolean | undefined;
@@ -1210,6 +1212,8 @@ export interface JobListItem {
   request?: ScanRequest | undefined;
   summary?: Summary | undefined;
   scan_timestamp?: string | undefined;
+  generated_at?: string | undefined;
+  scan_run?: Record<string, unknown> | undefined;
   pushed?: boolean | undefined;
   error?: string | undefined;
 }


### PR DESCRIPTION
## Summary
- add --reproducible to pin CLI scan report timestamps for stable artifacts
- honor SOURCE_DATE_EPOCH for CI and release-build timestamp control
- keep report and inventory snapshot generated_at values aligned
- preserve generated_at and scan_run in compact API job summaries, with scan_timestamp as the compatibility alias
- keep imported UI reports aligned with generated_at when scan_timestamp is absent

Closes #2451.

## Validation
- uv run pytest -q tests/test_cli_scan.py::test_scan_reproducible_pins_report_and_inventory_timestamps tests/test_cli_scan.py::test_scan_honors_source_date_epoch_for_reproducible_outputs tests/test_cli_scan.py::test_scan_output_to_file tests/test_hardening.py::test_compact_terminal_job_preserves_scan_timestamp_metadata tests/test_hardening.py::test_job_summary_payload_aliases_generated_at_to_scan_timestamp
- uv run ruff check src/agent_bom/cli/agents/__init__.py src/agent_bom/cli/options_sources.py src/agent_bom/api/stores.py src/agent_bom/api/routes/scan.py tests/test_cli_scan.py tests/test_hardening.py
- uv run mypy src/agent_bom/cli/agents/__init__.py src/agent_bom/cli/options_sources.py src/agent_bom/api/stores.py src/agent_bom/api/routes/scan.py
- git diff --check
- npm run verify:toolchain blocked locally: Node 25.9.0 is outside the repo range >=22 <25