### PR TITLE
data: align local analytics with unified findings

### DIFF
--- a/src/agent_bom/db/local_analytics.py
+++ b/src/agent_bom/db/local_analytics.py
@@ -10,13 +10,14 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
 from agent_bom.config import LOCAL_ANALYTICS_DB
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 DEFAULT_LOCAL_ANALYTICS_PATH = Path.home() / ".agent-bom" / "local-analytics.sqlite"
 
 
@@ -43,6 +44,22 @@ class LocalAnalyticsStore:
         return conn
 
     def _init_schema(self, conn: sqlite3.Connection) -> None:
+        if _table_exists(conn, "scan_runs") and "run_id" not in _table_columns(conn, "scan_runs"):
+            self._migrate_v1_schema(conn)
+        self._create_schema(conn)
+        conn.execute(
+            """
+            INSERT INTO local_schema_meta(component, version, applied_at)
+            VALUES ('local_analytics', ?, ?)
+            ON CONFLICT(component) DO UPDATE SET
+                version = excluded.version,
+                applied_at = excluded.applied_at
+            """,
+            (SCHEMA_VERSION, _now_iso()),
+        )
+        conn.commit()
+
+    def _create_schema(self, conn: sqlite3.Connection) -> None:
         conn.executescript(
             """
             CREATE TABLE IF NOT EXISTS local_schema_meta (
@@ -52,7 +69,8 @@ class LocalAnalyticsStore:
             );
 
             CREATE TABLE IF NOT EXISTS scan_runs (
-                scan_id TEXT PRIMARY KEY,
+                run_id TEXT PRIMARY KEY,
+                scan_id TEXT NOT NULL,
                 generated_at TEXT NOT NULL,
                 recorded_at TEXT NOT NULL,
                 tenant_id TEXT NOT NULL DEFAULT 'default',
@@ -66,6 +84,7 @@ class LocalAnalyticsStore:
             );
 
             CREATE TABLE IF NOT EXISTS scan_findings (
+                run_id TEXT NOT NULL,
                 scan_id TEXT NOT NULL,
                 finding_key TEXT NOT NULL,
                 vulnerability_id TEXT NOT NULL,
@@ -75,13 +94,20 @@ class LocalAnalyticsStore:
                 ecosystem TEXT NOT NULL,
                 severity TEXT NOT NULL,
                 risk_score REAL NOT NULL DEFAULT 0,
+                schema_version TEXT NOT NULL DEFAULT '',
+                finding_type TEXT NOT NULL DEFAULT '',
+                source TEXT NOT NULL DEFAULT '',
+                title TEXT NOT NULL DEFAULT '',
+                asset_json TEXT NOT NULL DEFAULT '{}',
+                raw_json TEXT NOT NULL DEFAULT '{}',
                 affected_agents_json TEXT NOT NULL DEFAULT '[]',
                 affected_servers_json TEXT NOT NULL DEFAULT '[]',
-                PRIMARY KEY (scan_id, finding_key),
-                FOREIGN KEY (scan_id) REFERENCES scan_runs(scan_id) ON DELETE CASCADE
+                PRIMARY KEY (run_id, finding_key),
+                FOREIGN KEY (run_id) REFERENCES scan_runs(run_id) ON DELETE CASCADE
             );
 
             CREATE TABLE IF NOT EXISTS scan_packages (
+                run_id TEXT NOT NULL,
                 scan_id TEXT NOT NULL,
                 agent_name TEXT NOT NULL,
                 server_name TEXT NOT NULL,
@@ -89,26 +115,61 @@ class LocalAnalyticsStore:
                 package_version TEXT NOT NULL,
                 ecosystem TEXT NOT NULL,
                 purl TEXT,
-                PRIMARY KEY (scan_id, agent_name, server_name, package_name, package_version, ecosystem),
-                FOREIGN KEY (scan_id) REFERENCES scan_runs(scan_id) ON DELETE CASCADE
+                PRIMARY KEY (run_id, agent_name, server_name, package_name, package_version, ecosystem),
+                FOREIGN KEY (run_id) REFERENCES scan_runs(run_id) ON DELETE CASCADE
             );
 
             CREATE INDEX IF NOT EXISTS idx_scan_runs_generated_at ON scan_runs(generated_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_scan_runs_scan_id ON scan_runs(scan_id);
             CREATE INDEX IF NOT EXISTS idx_scan_findings_severity ON scan_findings(severity);
+            CREATE INDEX IF NOT EXISTS idx_scan_findings_source ON scan_findings(source);
+            CREATE INDEX IF NOT EXISTS idx_scan_findings_type ON scan_findings(finding_type);
             CREATE INDEX IF NOT EXISTS idx_scan_packages_name ON scan_packages(package_name);
+            """
+        )
+
+    def _migrate_v1_schema(self, conn: sqlite3.Connection) -> None:
+        """Move the initial artifact-keyed mirror into run-keyed tables."""
+        conn.execute("PRAGMA foreign_keys=OFF")
+        conn.execute("ALTER TABLE scan_runs RENAME TO scan_runs_v1")
+        conn.execute("ALTER TABLE scan_findings RENAME TO scan_findings_v1")
+        conn.execute("ALTER TABLE scan_packages RENAME TO scan_packages_v1")
+        self._create_schema(conn)
+        conn.execute(
+            """
+            INSERT INTO scan_runs(
+                run_id, scan_id, generated_at, recorded_at, tenant_id, source, artifact_path,
+                total_agents, total_packages, total_vulnerabilities, critical_findings, high_findings
+            )
+            SELECT scan_id, scan_id, generated_at, recorded_at, tenant_id, source, artifact_path,
+                   total_agents, total_packages, total_vulnerabilities, critical_findings, high_findings
+            FROM scan_runs_v1
             """
         )
         conn.execute(
             """
-            INSERT INTO local_schema_meta(component, version, applied_at)
-            VALUES ('local_analytics', ?, ?)
-            ON CONFLICT(component) DO UPDATE SET
-                version = excluded.version,
-                applied_at = excluded.applied_at
-            """,
-            (SCHEMA_VERSION, _now_iso()),
+            INSERT INTO scan_findings(
+                run_id, scan_id, finding_key, vulnerability_id, package_name, package_version,
+                package_ref, ecosystem, severity, risk_score, affected_agents_json, affected_servers_json
+            )
+            SELECT scan_id, scan_id, finding_key, vulnerability_id, package_name, package_version,
+                   package_ref, ecosystem, severity, risk_score, affected_agents_json, affected_servers_json
+            FROM scan_findings_v1
+            """
         )
-        conn.commit()
+        conn.execute(
+            """
+            INSERT INTO scan_packages(
+                run_id, scan_id, agent_name, server_name, package_name, package_version, ecosystem, purl
+            )
+            SELECT scan_id, scan_id, agent_name, server_name, package_name, package_version, ecosystem, purl
+            FROM scan_packages_v1
+            """
+        )
+        conn.execute("DROP TABLE scan_findings_v1")
+        conn.execute("DROP TABLE scan_packages_v1")
+        conn.execute("DROP TABLE scan_runs_v1")
+        conn.execute("PRAGMA foreign_keys=ON")
 
     def record_scan_report(
         self,
@@ -125,6 +186,8 @@ class LocalAnalyticsStore:
             scan_id = f"local-{generated_key}"
 
         generated_at = str(report_json.get("generated_at") or report_json.get("scan_timestamp") or _now_iso())
+        recorded_at = _now_iso()
+        run_id = _run_id(report_json)
         raw_summary = report_json.get("summary")
         summary: dict[str, Any] = raw_summary if isinstance(raw_summary, dict) else {}
         findings = list(_iter_findings(report_json))
@@ -134,11 +197,12 @@ class LocalAnalyticsStore:
             conn.execute(
                 """
                 INSERT INTO scan_runs(
-                    scan_id, generated_at, recorded_at, tenant_id, source, artifact_path,
+                    run_id, scan_id, generated_at, recorded_at, tenant_id, source, artifact_path,
                     total_agents, total_packages, total_vulnerabilities, critical_findings, high_findings
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(scan_id) DO UPDATE SET
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(run_id) DO UPDATE SET
+                    scan_id = excluded.scan_id,
                     generated_at = excluded.generated_at,
                     recorded_at = excluded.recorded_at,
                     tenant_id = excluded.tenant_id,
@@ -151,9 +215,10 @@ class LocalAnalyticsStore:
                     high_findings = excluded.high_findings
                 """,
                 (
+                    run_id,
                     scan_id,
                     generated_at,
-                    _now_iso(),
+                    recorded_at,
                     tenant_id or "default",
                     source,
                     str(artifact_path) if artifact_path is not None else None,
@@ -161,30 +226,31 @@ class LocalAnalyticsStore:
                     _int(summary.get("total_packages")),
                     _int(summary.get("total_vulnerabilities")),
                     _int(summary.get("critical_findings")),
-                    sum(1 for item in findings if str(item.get("severity") or "").lower() == "high"),
+                    sum(1 for item in findings if _finding_severity(item) == "high"),
                 ),
             )
-            conn.execute("DELETE FROM scan_findings WHERE scan_id = ?", (scan_id,))
-            conn.execute("DELETE FROM scan_packages WHERE scan_id = ?", (scan_id,))
+            conn.execute("DELETE FROM scan_findings WHERE run_id = ?", (run_id,))
+            conn.execute("DELETE FROM scan_packages WHERE run_id = ?", (run_id,))
             conn.executemany(
                 """
                 INSERT INTO scan_findings(
-                    scan_id, finding_key, vulnerability_id, package_name, package_version,
+                    run_id, scan_id, finding_key, vulnerability_id, package_name, package_version,
                     package_ref, ecosystem, severity, risk_score,
+                    schema_version, finding_type, source, title, asset_json, raw_json,
                     affected_agents_json, affected_servers_json
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                [_finding_row(scan_id, finding) for finding in findings],
+                [_finding_row(run_id, scan_id, finding) for finding in findings],
             )
             conn.executemany(
                 """
                 INSERT INTO scan_packages(
-                    scan_id, agent_name, server_name, package_name, package_version, ecosystem, purl
+                    run_id, scan_id, agent_name, server_name, package_name, package_version, ecosystem, purl
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                [_package_row(scan_id, package_row) for package_row in package_rows],
+                [_package_row(run_id, scan_id, package_row) for package_row in package_rows],
             )
             conn.commit()
         return scan_id
@@ -194,7 +260,7 @@ class LocalAnalyticsStore:
         with self._connect() as conn:
             rows = conn.execute(
                 """
-                SELECT scan_id, generated_at, recorded_at, tenant_id, source, artifact_path,
+                SELECT run_id, scan_id, generated_at, recorded_at, tenant_id, source, artifact_path,
                        total_agents, total_packages, total_vulnerabilities,
                        critical_findings, high_findings
                 FROM scan_runs
@@ -235,6 +301,13 @@ def record_scan_report_best_effort(
 
 
 def _iter_findings(report_json: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    findings = report_json.get("findings")
+    if isinstance(findings, list):
+        for item in findings:
+            if isinstance(item, dict):
+                yield item
+        return
+
     blast_radius = report_json.get("blast_radius") or report_json.get("blast_radii") or []
     if isinstance(blast_radius, list):
         for item in blast_radius:
@@ -269,14 +342,16 @@ def _iter_packages(report_json: dict[str, Any]) -> Iterable[dict[str, Any]]:
                     }
 
 
-def _finding_row(scan_id: str, finding: dict[str, Any]) -> tuple[Any, ...]:
-    vulnerability_id = str(finding.get("vulnerability_id") or finding.get("id") or "")
+def _finding_row(run_id: str, scan_id: str, finding: dict[str, Any]) -> tuple[Any, ...]:
+    asset = finding.get("asset") if isinstance(finding.get("asset"), dict) else {}
+    vulnerability_id = _vulnerability_id_from_finding(finding)
     package_ref = str(finding.get("package") or "")
     package_name = str(finding.get("package_name") or _package_name_from_ref(package_ref))
     package_version = str(finding.get("package_version") or _package_version_from_ref(package_ref))
     ecosystem = str(finding.get("ecosystem") or "")
-    finding_key = "|".join((vulnerability_id, package_ref, ecosystem))
+    finding_key = _finding_key(finding, vulnerability_id, package_ref, ecosystem)
     return (
+        run_id,
         scan_id,
         finding_key,
         vulnerability_id,
@@ -284,15 +359,22 @@ def _finding_row(scan_id: str, finding: dict[str, Any]) -> tuple[Any, ...]:
         package_version,
         package_ref,
         ecosystem,
-        str(finding.get("severity") or "unknown").lower(),
+        _finding_severity(finding),
         _float(finding.get("risk_score")),
+        str(finding.get("schema_version") or ""),
+        str(finding.get("finding_type") or ""),
+        str(finding.get("source") or ""),
+        str(finding.get("title") or ""),
+        json.dumps(asset, sort_keys=True),
+        json.dumps(finding, sort_keys=True, default=str),
         json.dumps(list(finding.get("affected_agents") or []), sort_keys=True),
         json.dumps(list(finding.get("affected_servers") or []), sort_keys=True),
     )
 
 
-def _package_row(scan_id: str, package: dict[str, Any]) -> tuple[Any, ...]:
+def _package_row(run_id: str, scan_id: str, package: dict[str, Any]) -> tuple[Any, ...]:
     return (
+        run_id,
         scan_id,
         str(package.get("agent_name") or ""),
         str(package.get("server_name") or ""),
@@ -301,6 +383,46 @@ def _package_row(scan_id: str, package: dict[str, Any]) -> tuple[Any, ...]:
         str(package.get("ecosystem") or ""),
         package.get("purl"),
     )
+
+
+def _run_id(report_json: dict[str, Any]) -> str:
+    scan_run = report_json.get("scan_run")
+    if isinstance(scan_run, dict):
+        raw = str(scan_run.get("run_id") or "").strip()
+        if raw:
+            return raw
+    return f"local-run-{uuid.uuid4()}"
+
+
+def _finding_key(finding: dict[str, Any], vulnerability_id: str, package_ref: str, ecosystem: str) -> str:
+    raw = str(finding.get("id") or finding.get("stable_id") or "").strip()
+    if raw:
+        return raw
+    parts = [
+        vulnerability_id,
+        package_ref,
+        ecosystem,
+        str(finding.get("finding_type") or ""),
+        str(finding.get("source") or ""),
+        str(finding.get("title") or ""),
+    ]
+    joined = "|".join(part for part in parts if part)
+    return joined or str(uuid.uuid5(uuid.NAMESPACE_URL, json.dumps(finding, sort_keys=True, default=str)))
+
+
+def _vulnerability_id_from_finding(finding: dict[str, Any]) -> str:
+    raw = str(finding.get("vulnerability_id") or finding.get("cve_id") or "").strip()
+    if raw:
+        return raw
+    raw_id = str(finding.get("id") or "").strip()
+    upper_id = raw_id.upper()
+    if upper_id.startswith(("CVE-", "GHSA-", "DEBIAN-CVE-", "ALAS-", "RUSTSEC-")):
+        return raw_id
+    return ""
+
+
+def _finding_severity(finding: dict[str, Any]) -> str:
+    return str(finding.get("effective_severity") or finding.get("severity") or "unknown").lower()
 
 
 def _package_name_from_ref(package_ref: str) -> str:
@@ -331,3 +453,12 @@ def _float(value: Any) -> float:
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?", (table,)).fetchone()
+    return row is not None
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {str(row["name"]) for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}

--- a/tests/test_local_analytics.py
+++ b/tests/test_local_analytics.py
@@ -70,6 +70,7 @@ def test_local_analytics_store_records_scan_summary_findings_and_packages(tmp_pa
 
     assert scan_id == "scan-1"
     runs = store.list_scan_runs()
+    assert runs[0]["run_id"].startswith("local-run-")
     assert runs[0]["scan_id"] == "scan-1"
     assert runs[0]["total_packages"] == 2
     assert runs[0]["critical_findings"] == 1
@@ -82,7 +83,7 @@ def test_local_analytics_store_records_scan_summary_findings_and_packages(tmp_pa
     assert package_rows == [{"package_name": "fastapi"}, {"package_name": "uvicorn"}]
 
 
-def test_local_analytics_store_upserts_scan_without_changing_existing_json_artifact(tmp_path):
+def test_local_analytics_store_records_repeated_artifact_as_distinct_runs(tmp_path):
     report = _report()
     store = LocalAnalyticsStore(tmp_path / "local.sqlite")
 
@@ -98,8 +99,48 @@ def test_local_analytics_store_upserts_scan_without_changing_existing_json_artif
     )
     store.record_scan_report(report, source="cli")
 
-    assert store.query("SELECT total_vulnerabilities FROM scan_runs WHERE scan_id = ?", ("scan-1",)) == [{"total_vulnerabilities": 3}]
-    assert store.query("SELECT COUNT(*) AS count FROM scan_findings WHERE scan_id = ?", ("scan-1",)) == [{"count": 3}]
+    runs = store.query("SELECT run_id, total_vulnerabilities FROM scan_runs WHERE scan_id = ? ORDER BY rowid", ("scan-1",))
+    assert [row["total_vulnerabilities"] for row in runs] == [2, 3]
+    assert len({row["run_id"] for row in runs}) == 2
+    assert store.query("SELECT COUNT(*) AS count FROM scan_findings WHERE scan_id = ?", ("scan-1",)) == [{"count": 5}]
+
+
+def test_local_analytics_store_records_unified_non_cve_findings(tmp_path):
+    store = LocalAnalyticsStore(tmp_path / "local.sqlite")
+    report = _report()
+    report.pop("blast_radius")
+    report["findings"] = [
+        {
+            "schema_version": "1",
+            "id": "prompt-risk-1",
+            "finding_type": "PROMPT_SECURITY",
+            "source": "PROMPT_SCAN",
+            "asset": {
+                "name": "system.prompt",
+                "asset_type": "prompt_template",
+                "identifier": "prompts/system.prompt",
+            },
+            "severity": "high",
+            "title": "Prompt injection pattern",
+            "description": "Prompt contains override language.",
+        }
+    ]
+
+    store.record_scan_report(report, source="cli")
+
+    rows = store.query(
+        """
+        SELECT finding_key, vulnerability_id, finding_type, source, schema_version, title, asset_json
+        FROM scan_findings
+        """
+    )
+    assert rows[0]["finding_key"] == "prompt-risk-1"
+    assert rows[0]["vulnerability_id"] == ""
+    assert rows[0]["finding_type"] == "PROMPT_SECURITY"
+    assert rows[0]["source"] == "PROMPT_SCAN"
+    assert rows[0]["schema_version"] == "1"
+    assert rows[0]["title"] == "Prompt injection pattern"
+    assert '"asset_type": "prompt_template"' in rows[0]["asset_json"]
 
 
 def test_history_save_dual_writes_local_analytics(monkeypatch, tmp_path):
@@ -116,3 +157,68 @@ def test_history_save_dual_writes_local_analytics(monkeypatch, tmp_path):
     with sqlite3.connect(analytics_path) as conn:
         rows = conn.execute("SELECT scan_id, source, artifact_path FROM scan_runs").fetchall()
     assert rows == [("saved-scan", "cli", str(saved_path))]
+
+
+def test_local_analytics_store_migrates_initial_scan_id_keyed_schema(tmp_path):
+    db_path = tmp_path / "local.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE scan_runs (
+                scan_id TEXT PRIMARY KEY,
+                generated_at TEXT NOT NULL,
+                recorded_at TEXT NOT NULL,
+                tenant_id TEXT NOT NULL DEFAULT 'default',
+                source TEXT NOT NULL,
+                artifact_path TEXT,
+                total_agents INTEGER NOT NULL DEFAULT 0,
+                total_packages INTEGER NOT NULL DEFAULT 0,
+                total_vulnerabilities INTEGER NOT NULL DEFAULT 0,
+                critical_findings INTEGER NOT NULL DEFAULT 0,
+                high_findings INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE scan_findings (
+                scan_id TEXT NOT NULL,
+                finding_key TEXT NOT NULL,
+                vulnerability_id TEXT NOT NULL,
+                package_name TEXT NOT NULL,
+                package_version TEXT NOT NULL,
+                package_ref TEXT NOT NULL,
+                ecosystem TEXT NOT NULL,
+                severity TEXT NOT NULL,
+                risk_score REAL NOT NULL DEFAULT 0,
+                affected_agents_json TEXT NOT NULL DEFAULT '[]',
+                affected_servers_json TEXT NOT NULL DEFAULT '[]',
+                PRIMARY KEY (scan_id, finding_key)
+            );
+            CREATE TABLE scan_packages (
+                scan_id TEXT NOT NULL,
+                agent_name TEXT NOT NULL,
+                server_name TEXT NOT NULL,
+                package_name TEXT NOT NULL,
+                package_version TEXT NOT NULL,
+                ecosystem TEXT NOT NULL,
+                purl TEXT,
+                PRIMARY KEY (scan_id, agent_name, server_name, package_name, package_version, ecosystem)
+            );
+            INSERT INTO scan_runs(scan_id, generated_at, recorded_at, source)
+            VALUES ('legacy-scan', '2026-05-10T16:00:00+00:00', '2026-05-10T16:01:00+00:00', 'cli');
+            INSERT INTO scan_findings(
+                scan_id, finding_key, vulnerability_id, package_name, package_version,
+                package_ref, ecosystem, severity, risk_score
+            )
+            VALUES ('legacy-scan', 'CVE-2026-0001|pkg|pypi', 'CVE-2026-0001', 'pkg', '1.0', 'pkg@1.0', 'pypi', 'high', 7.1);
+            INSERT INTO scan_packages(scan_id, agent_name, server_name, package_name, package_version, ecosystem)
+            VALUES ('legacy-scan', 'agent', 'server', 'pkg', '1.0', 'pypi');
+            """
+        )
+
+    store = LocalAnalyticsStore(db_path)
+
+    assert store.list_scan_runs()[0]["run_id"] == "legacy-scan"
+    assert store.query("SELECT run_id, scan_id, source FROM scan_findings") == [
+        {"run_id": "legacy-scan", "scan_id": "legacy-scan", "source": ""}
+    ]
+    assert store.query("SELECT run_id, scan_id, package_name FROM scan_packages") == [
+        {"run_id": "legacy-scan", "scan_id": "legacy-scan", "package_name": "pkg"}
+    ]


### PR DESCRIPTION
## Summary
- record unified findings[] in the local analytics mirror and fall back to blast_radius for older reports
- add queryable finding metadata for schema_version, finding_type, source, title, asset, and raw payload
- separate local run_id from content-derived scan_id so repeated local scans remain distinct runs
- migrate the initial scan_id-keyed local schema forward

Closes #2453.

## Validation
- uv run pytest -q tests/test_local_analytics.py
- uv run ruff check src/agent_bom/db/local_analytics.py tests/test_local_analytics.py
- uv run mypy src/agent_bom/db/local_analytics.py
- git diff --check