### PR TITLE
ui: unify graph loading empty error states

### DIFF
--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -17,8 +17,6 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import {
-  Loader2,
-  AlertTriangle,
   Search,
   Waypoints,
   ChevronDown,
@@ -51,7 +49,7 @@ import {
 } from "@/lib/graph-utils";
 import { graphFitViewOptions, shouldShowGraphMiniMap } from "@/lib/graph-viewport";
 import { FullscreenButton, GraphLegend } from "@/components/graph-chrome";
-import { GraphEmptyState, GraphPanelSkeleton } from "@/components/graph-state-panels";
+import { GraphEmptyState, GraphPanelSkeleton, GraphRefreshOverlay } from "@/components/graph-state-panels";
 import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { isDeploymentSurfaceAvailable } from "@/lib/deployment-context";
@@ -410,21 +408,28 @@ export default function ContextPage() {
 
   if (loading || (detailLoading && !graphData)) {
     return (
-      <div className="flex items-center justify-center h-[80vh] text-zinc-400">
-        <Loader2 className="w-5 h-5 animate-spin mr-2" />
-        Loading context view...
+      <div className="h-[80vh]">
+        <GraphPanelSkeleton
+          title="Loading context graph"
+          detail="Fetching the selected scan and preparing a focused lateral-movement window."
+        />
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="flex flex-col items-center justify-center h-[80vh] text-zinc-400 gap-3">
-        <AlertTriangle className="w-8 h-8 text-amber-500" />
-        <p className="text-sm">Could not connect to agent-bom API</p>
-        <p className="text-xs text-zinc-500">
-          Make sure the API is running at localhost:8422
-        </p>
+      <div className="h-[80vh]">
+        <GraphEmptyState
+          title="Cannot load context graph"
+          detail={error || "The API did not return scan evidence for the context graph view."}
+          suggestions={[
+            "Confirm the API is reachable before reopening the context graph.",
+            "Run a fresh scan when the control plane has no completed job history.",
+            "Open the agent mesh after scan evidence is available.",
+          ]}
+          command="agent-bom serve --api"
+        />
       </div>
     );
   }
@@ -518,10 +523,7 @@ export default function ContextPage() {
         {/* Graph */}
         <div className="flex-1 relative">
           {detailLoading && graphData && (
-            <div className="absolute inset-x-0 top-0 z-10 flex items-center justify-center py-2 text-xs text-zinc-400 bg-zinc-950/70 backdrop-blur-sm">
-              <Loader2 className="w-3.5 h-3.5 animate-spin mr-2" />
-              Updating context graph...
-            </div>
+            <GraphRefreshOverlay label="Updating context graph" />
           )}
           {!graphData ? (
             <GraphPanelSkeleton

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -11,10 +11,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import {
-  Loader2,
-  AlertTriangle,
   Search,
-  ShieldAlert,
   SlidersHorizontal,
   Network,
   GitBranch,
@@ -48,6 +45,7 @@ import {
 } from "@/lib/graph-utils";
 import { graphFitViewOptions, shouldShowGraphMiniMap } from "@/lib/graph-viewport";
 import { FullscreenButton, GraphLegend } from "@/components/graph-chrome";
+import { GraphEmptyState, GraphPanelSkeleton, GraphRefreshOverlay } from "@/components/graph-state-panels";
 import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { isDeploymentSurfaceAvailable } from "@/lib/deployment-context";
@@ -415,19 +413,28 @@ export default function MeshPage() {
 
   if (loading || (detailLoading && !activeResult)) {
     return (
-      <div className="flex items-center justify-center h-[80vh] text-zinc-400">
-        <Loader2 className="w-5 h-5 animate-spin mr-2" />
-        Loading mesh view...
+      <div className="h-[80vh]">
+        <GraphPanelSkeleton
+          title="Loading agent mesh"
+          detail="Fetching completed scans and preparing the bounded agent-centered topology."
+        />
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="flex flex-col items-center justify-center h-[80vh] text-zinc-400 gap-3">
-        <AlertTriangle className="w-8 h-8 text-amber-500" />
-        <p className="text-sm">Could not connect to agent-bom API</p>
-        <p className="text-xs text-zinc-500">Make sure the API is running at localhost:8422</p>
+      <div className="h-[80vh]">
+        <GraphEmptyState
+          title="Cannot load agent mesh"
+          detail={error || "The API did not return scan evidence for the agent mesh view."}
+          suggestions={[
+            "Confirm the API is reachable before reopening the mesh view.",
+            "Run a fresh scan when the control plane has no completed job history.",
+            "Use the security graph once graph snapshots are persisted.",
+          ]}
+          command="agent-bom serve --api"
+        />
       </div>
     );
   }
@@ -437,10 +444,17 @@ export default function MeshPage() {
       return <DeploymentSurfaceRequiredState surface="mesh" counts={counts} detail={error} />;
     }
     return (
-      <div className="flex flex-col items-center justify-center h-[80vh] text-zinc-400 gap-3">
-        <ShieldAlert className="w-8 h-8 text-zinc-600" />
-        <p className="text-sm">No completed scans found</p>
-        <p className="text-xs text-zinc-500">Run a scan first to visualize the agent mesh</p>
+      <div className="h-[80vh]">
+        <GraphEmptyState
+          title="No completed scans found"
+          detail="Run a scan first so the agent mesh can show selected agents, shared MCP servers, tools, packages, credentials, and findings."
+          suggestions={[
+            "Use a demo scan for a local proof point.",
+            "Keep the first mesh view scoped to the highest-risk agent.",
+            "Open the full graph after the scan persists graph evidence.",
+          ]}
+          command="agent-bom agents --demo --offline"
+        />
       </div>
     );
   }
@@ -517,41 +531,51 @@ export default function MeshPage() {
       {/* Graph */}
       <div className="flex-1 relative">
         {detailLoading && activeResult && (
-          <div className="absolute inset-x-0 top-0 z-10 flex items-center justify-center py-2 text-xs text-zinc-400 bg-zinc-950/70 backdrop-blur-sm">
-            <Loader2 className="w-3.5 h-3.5 animate-spin mr-2" />
-            Updating mesh...
-          </div>
+          <GraphRefreshOverlay label="Updating agent mesh" />
         )}
-        <ReactFlow
-          nodes={displayNodes}
-          edges={displayEdges}
-          nodeTypes={lineageNodeTypes}
-          fitView
-          fitViewOptions={viewportOptions}
-          minZoom={0.16}
-          maxZoom={2.5}
-          zoomOnScroll={false}
-          panOnScroll={false}
-          preventScrolling={false}
-          onlyRenderVisibleElements
-          defaultEdgeOptions={{ type: "smoothstep" }}
-          proOptions={{ hideAttribution: true }}
-          onNodeClick={onNodeClick}
-          onNodeMouseEnter={onNodeMouseEnter}
-          onNodeMouseLeave={onNodeMouseLeave}
-          onPaneClick={() => { setSelectedNode(null); setHoveredNodeId(null); }}
-        >
-          <Background color={BACKGROUND_COLOR} gap={BACKGROUND_GAP} />
-          <Controls className={CONTROLS_CLASS} />
-          {showMiniMap && (
-            <MiniMap
-              nodeColor={minimapNodeColor}
-              className={MINIMAP_CLASS}
-              bgColor={MINIMAP_BG}
-              maskColor={MINIMAP_MASK}
-            />
-          )}
-        </ReactFlow>
+        {displayNodes.length === 0 ? (
+          <GraphEmptyState
+            title="No mesh relationships match this scope"
+            detail="The selected scan loaded, but the current agent, severity, or vulnerable-only filters removed the relationships needed to draw an agent mesh."
+            suggestions={[
+              "Choose another agent from the scope selector.",
+              "Lower the severity filter or disable vulnerable-only mode.",
+              "Switch to dependency flow after expanding the scope.",
+            ]}
+            command="agent-bom scan -p . -f graph"
+          />
+        ) : (
+          <ReactFlow
+            nodes={displayNodes}
+            edges={displayEdges}
+            nodeTypes={lineageNodeTypes}
+            fitView
+            fitViewOptions={viewportOptions}
+            minZoom={0.16}
+            maxZoom={2.5}
+            zoomOnScroll={false}
+            panOnScroll={false}
+            preventScrolling={false}
+            onlyRenderVisibleElements
+            defaultEdgeOptions={{ type: "smoothstep" }}
+            proOptions={{ hideAttribution: true }}
+            onNodeClick={onNodeClick}
+            onNodeMouseEnter={onNodeMouseEnter}
+            onNodeMouseLeave={onNodeMouseLeave}
+            onPaneClick={() => { setSelectedNode(null); setHoveredNodeId(null); }}
+          >
+            <Background color={BACKGROUND_COLOR} gap={BACKGROUND_GAP} />
+            <Controls className={CONTROLS_CLASS} />
+            {showMiniMap && (
+              <MiniMap
+                nodeColor={minimapNodeColor}
+                className={MINIMAP_CLASS}
+                bgColor={MINIMAP_BG}
+                maskColor={MINIMAP_MASK}
+              />
+            )}
+          </ReactFlow>
+        )}
 
         {selectedNode && (
           <LineageDetailPanel

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -23,7 +23,7 @@ function _classifyGraphErrorKind(err: unknown): "network" | "auth" | "forbidden"
 }
 import { AttackPathCard } from "@/components/attack-path-card";
 import { GraphEvidenceExportButton } from "@/components/graph-chrome";
-import { GraphEmptyState } from "@/components/graph-state-panels";
+import { GraphEmptyState, GraphPanelSkeleton } from "@/components/graph-state-panels";
 import {
   api,
   formatDate,
@@ -449,8 +449,17 @@ function SecurityGraphPageContent() {
               </div>
             ) : (
               !loadingSnapshots && (
-                <div className="mt-4 rounded-2xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-5 text-sm text-[color:var(--text-secondary)]">
-                  No persisted graph snapshots yet. Run a scan first so the security graph can build historical attack-path views.
+                <div className="mt-4">
+                  <GraphEmptyState
+                    title="No persisted graph snapshots yet"
+                    detail="Run a scan first so the security graph can build historical attack-path views from persisted graph evidence."
+                    suggestions={[
+                      "Run a local scan with graph output enabled.",
+                      "Confirm the graph persistence backend is enabled.",
+                      "Open the full graph after the first snapshot appears.",
+                    ]}
+                    command="agent-bom scan -p . -f graph"
+                  />
                 </div>
               )
             )}
@@ -502,9 +511,11 @@ function SecurityGraphPageContent() {
       </section>
 
       {loadingGraph ? (
-        <section className="rounded-3xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-8 text-center text-sm text-[color:var(--text-secondary)]">
-          <Loader2 className="mx-auto mb-3 h-6 w-6 animate-spin text-sky-400" />
-          {loadingGraphMessage}
+        <section className="rounded-3xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
+          <GraphPanelSkeleton
+            title="Loading security graph"
+            detail={loadingGraphMessage}
+          />
         </section>
       ) : graphLoadError ? (
         <section className="rounded-3xl border border-red-900/60 bg-red-950/10 p-4">


### PR DESCRIPTION
## Summary
- aligns mesh, context graph, and security graph loading/empty/error surfaces on shared graph state components
- adds scoped empty states for filtered mesh views and missing security graph snapshots
- keeps refresh messaging consistent while graph data is reloading

Closes #2455

## Validation
- `cd ui && npm run typecheck`
- `cd ui && npm test -- --run graph-state-panels`
- `cd ui && npm run lint -- app/mesh/page.tsx app/context/page.tsx app/security-graph/page.tsx`
- `git diff --check`

## Note
- `cd ui && npm run verify:toolchain` is blocked locally because this machine is on Node 25.9.0 and the UI requires `>=22 <25`.
