### PR TITLE
cli: add interactive command shell

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ mcp-server = [
 ]
 dashboard = ["streamlit>=1.55.0", "plotly>=5.18.0", "pandas>=2.0.0"]
 snyk = []  # Uses existing httpx dependency, no additional packages needed
+interactive = ["prompt-toolkit>=3.0"]
 oidc = [
     "PyJWT>=2.8",
     "cryptography>=46.0.7",  # Buffer overflow advisory on older releases when non-contiguous buffers reach cryptography APIs

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -71,6 +71,7 @@
 | `db` | Manage the local vulnerability database |
 | `doctor` | Check environment readiness for scanning |
 | `gateway` | Multi-MCP gateway commands |
+| `interactive` | Start an interactive command shell for repeated CLI workflows |
 | `profiles` | Manage named CLI profiles for repeatable scan contexts |
 | `proxy-bootstrap` | Generate managed endpoint onboarding material |
 | `samples` | Create bundled sample inputs for demos and first runs |

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -275,6 +275,10 @@ from agent_bom.cli._profiles import profiles_group  # noqa: E402
 
 main.add_command(profiles_group)
 
+from agent_bom.cli._interactive import interactive_cmd  # noqa: E402
+
+main.add_command(interactive_cmd)
+
 # ---------------------------------------------------------------------------
 # MCP command group — `agent-bom mcp [inventory|introspect|registry|server]`
 # ---------------------------------------------------------------------------

--- a/src/agent_bom/cli/_interactive.py
+++ b/src/agent_bom/cli/_interactive.py
@@ -1,0 +1,139 @@
+"""Interactive CLI shell."""
+
+from __future__ import annotations
+
+import shlex
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+import click
+
+PROMPT = "agent-bom> "
+EXIT_COMMANDS = {"exit", "quit", ":q"}
+
+
+def _history_path() -> Path:
+    return Path("~/.agent-bom/history/interactive.history").expanduser()
+
+
+def _make_prompt_reader(history_enabled: bool) -> Callable[[str], str]:
+    try:
+        from prompt_toolkit import prompt
+        from prompt_toolkit.history import FileHistory
+    except Exception:
+        return input
+
+    history = None
+    if history_enabled:
+        path = _history_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        history = FileHistory(str(path))
+
+    def _read(prompt_text: str) -> str:
+        return prompt(prompt_text, history=history)
+
+    return _read
+
+
+def _split_command(line: str) -> list[str]:
+    try:
+        return shlex.split(line)
+    except ValueError as exc:
+        raise click.ClickException(f"Could not parse command: {exc}") from exc
+
+
+def _print_interactive_help(output: Callable[[str], None]) -> None:
+    output("Commands:")
+    output("  help                 show this help")
+    output("  history              show commands from this session")
+    output("  last                 show the last command exit code")
+    output("  exit | quit | :q     leave interactive mode")
+    output("")
+    output("Run normal commands without the program name, for example:")
+    output("  agents --demo --offline")
+    output("  profiles list")
+    output("  report history")
+
+
+def _invoke_root_command(root_command: click.Command, args: Sequence[str], output: Callable[[str], None]) -> int:
+    if args and args[0] == "interactive":
+        output("Already in interactive mode.")
+        return 0
+    try:
+        root_command.main(args=list(args), prog_name="agent-bom", standalone_mode=False)
+        return 0
+    except click.ClickException as exc:
+        exc.show()
+        return int(getattr(exc, "exit_code", 1) or 1)
+    except click.Abort:
+        output("Aborted.")
+        return 1
+    except SystemExit as exc:
+        code = exc.code
+        return code if isinstance(code, int) else 1
+
+
+def run_interactive(
+    root_command: click.Command,
+    *,
+    input_fn: Callable[[str], str] | None = None,
+    output: Callable[[str], None] = click.echo,
+    history_enabled: bool = True,
+) -> int:
+    """Run the interactive shell and return the last command exit code."""
+    read = input_fn or _make_prompt_reader(history_enabled)
+    session_history: list[str] = []
+    last_exit_code = 0
+
+    output("agent-bom interactive. Type `help` for commands, `exit` to leave.")
+
+    while True:
+        try:
+            line = read(PROMPT)
+        except EOFError:
+            output("")
+            return last_exit_code
+        except KeyboardInterrupt:
+            output("")
+            continue
+
+        line = line.strip()
+        if not line:
+            continue
+
+        try:
+            args = _split_command(line)
+        except click.ClickException as exc:
+            exc.show()
+            last_exit_code = 2
+            continue
+
+        command = args[0].lower() if args else ""
+        if command in EXIT_COMMANDS:
+            return last_exit_code
+        if command in {"help", "?"}:
+            _print_interactive_help(output)
+            continue
+        if command == "history":
+            if not session_history:
+                output("No commands run yet.")
+            else:
+                for index, item in enumerate(session_history, start=1):
+                    output(f"{index:>3}  {item}")
+            continue
+        if command == "last":
+            output(f"Last exit code: {last_exit_code}")
+            continue
+
+        session_history.append(line)
+        last_exit_code = _invoke_root_command(root_command, args, output)
+
+
+@click.command("interactive")
+@click.option("--no-history", is_flag=True, help="Disable persistent prompt history for this session.")
+def interactive_cmd(no_history: bool) -> None:
+    """Start an interactive command shell."""
+    import agent_bom.cli as cli_module
+
+    exit_code = run_interactive(cli_module.main, history_enabled=not no_history)
+    raise SystemExit(exit_code)

--- a/src/agent_bom/cli/_interactive.py
+++ b/src/agent_bom/cli/_interactive.py
@@ -51,7 +51,7 @@ def _print_interactive_help(output: Callable[[str], None]) -> None:
     output("")
     output("Run normal commands without the program name, for example:")
     output("  agents --demo --offline")
-    output("  profiles list")
+    output("  doctor")
     output("  report history")
 
 

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import click
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+from agent_bom.cli._interactive import run_interactive
+
+
+def test_interactive_meta_commands():
+    @click.group()
+    def root() -> None:
+        pass
+
+    lines = iter(["help", "history", "last", "exit"])
+    output: list[str] = []
+
+    exit_code = run_interactive(
+        root,
+        input_fn=lambda _prompt: next(lines),
+        output=output.append,
+        history_enabled=False,
+    )
+
+    assert exit_code == 0
+    assert any("Commands:" in line for line in output)
+    assert any("No commands run yet." in line for line in output)
+    assert any("Last exit code: 0" in line for line in output)
+
+
+def test_interactive_routes_normal_commands():
+    @click.group()
+    def root() -> None:
+        pass
+
+    @root.command("ok")
+    def ok_cmd() -> None:
+        click.echo("ran ok")
+
+    lines = iter(["ok", "history", "exit"])
+    output: list[str] = []
+
+    exit_code = run_interactive(
+        root,
+        input_fn=lambda _prompt: next(lines),
+        output=output.append,
+        history_enabled=False,
+    )
+
+    assert exit_code == 0
+    assert any("ok" in line for line in output)
+
+
+def test_interactive_command_is_visible_in_help():
+    result = CliRunner().invoke(main, ["--help"])
+
+    assert result.exit_code == 0
+    assert "interactive" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -145,6 +145,9 @@ graph = [
 huggingface = [
     { name = "huggingface-hub" },
 ]
+interactive = [
+    { name = "prompt-toolkit" },
+]
 mcp-server = [
     { name = "mcp" },
     { name = "smithery" },
@@ -253,6 +256,7 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'dashboard'", specifier = ">=2.0.0" },
     { name = "pillow", marker = "extra == 'visual'", specifier = ">=10.0" },
     { name = "plotly", marker = "extra == 'dashboard'", specifier = ">=5.18.0" },
+    { name = "prompt-toolkit", marker = "extra == 'interactive'", specifier = ">=3.0" },
     { name = "protobuf", marker = "extra == 'otel'", specifier = ">=6.33.5" },
     { name = "psutil", marker = "extra == 'runtime'", specifier = ">=5.9" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.1" },
@@ -286,7 +290,7 @@ requires-dist = [
     { name = "watchdog", marker = "extra == 'watch'", specifier = ">=4.0" },
     { name = "werkzeug", specifier = ">=3.1.6" },
 ]
-provides-extras = ["api", "otel", "ui", "aws", "azure", "gcp", "coreweave", "databricks", "snowflake", "nebius", "huggingface", "wandb", "openai", "ai-enrich", "graph", "pdf", "postgres", "watch", "runtime", "visual", "mcp-server", "dashboard", "snyk", "oidc", "saml", "cloud", "docs", "dev", "dev-all"]
+provides-extras = ["api", "otel", "ui", "aws", "azure", "gcp", "coreweave", "databricks", "snowflake", "nebius", "huggingface", "wandb", "openai", "ai-enrich", "graph", "pdf", "postgres", "watch", "runtime", "visual", "mcp-server", "dashboard", "snyk", "interactive", "oidc", "saml", "cloud", "docs", "dev", "dev-all"]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -3138,6 +3142,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4909,6 +4925,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
     { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
     { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- adds `agent-bom interactive` as a visible command shell for repeated CLI workflows
- supports help, session history, last exit code, and exit commands
- dispatches normal CLI commands from the prompt and prevents recursive interactive sessions
- adds an optional `interactive` extra for persistent prompt history while keeping a stdlib fallback

Closes #2460

## Validation
- `uv run pytest -q tests/test_cli_interactive.py tests/test_doctor_cli.py`
- `uv run ruff check src/agent_bom/cli/_interactive.py src/agent_bom/cli/__init__.py tests/test_cli_interactive.py`
- `uv run mypy src/agent_bom/cli/_interactive.py`
- `printf 'help\nexit\n' | uv run agent-bom interactive --no-history`
- `uv lock --check`
- `git diff --check`
