### PR TITLE
test: guard Finder duplicate artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,15 @@ docs/CAPTURE [0-9].md
 docs/images/* [0-9].png
 docs/images/* [0-9].gif
 docs/images/* [0-9].svg
+docs/**/* [0-9].md
+site-docs/**/* [0-9].md
 src/agent_bom/**/* [0-9].py
 tests/**/* [0-9].py
+ui/**/* [0-9].js
+ui/**/* [0-9].jsx
+ui/**/* [0-9].json
+ui/**/* [0-9].md
+ui/**/* [0-9].ts
+ui/**/* [0-9].tsx
 deploy/helm/agent-bom/**/* [0-9].yaml
 .github/workflows/* [0-9].yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,9 @@ repos:
         language: system
         pass_filenames: false
         files: ^(src/agent_bom/.*\.py|src/agent_bom/config\.py|scripts/env_var_allowlist\.txt|docs/operations/ENV_VARS\.md)$
+      - id: duplicate-artifact-guard
+        name: Finder duplicate artifact guard
+        entry: python3 scripts/check_duplicate_artifacts.py
+        language: system
+        pass_filenames: false
+        files: ^(src/|tests/|docs/|site-docs/|ui/|contracts/|deploy/|\.github/workflows/)

--- a/scripts/check_duplicate_artifacts.py
+++ b/scripts/check_duplicate_artifacts.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Fail when Finder-style duplicate artifacts are tracked.
+"""Fail when Finder-style duplicate artifacts are present.
 
 macOS Finder copies such as ``foo 2.py`` and duplicated directories such as
 ``contracts/v1 2`` are easy to miss in reviews but can be included in source
-distributions and release archives. This guard checks tracked paths only, so
-local virtualenvs, node_modules, and generated build output do not create noise.
+distributions and release archives. CI checks tracked paths. Local operators can
+use ``--working-tree`` to catch untracked copies that would still be collected by
+tools such as pytest.
 """
 
 from __future__ import annotations
@@ -19,11 +20,31 @@ _DUPLICATE_COMPONENT_RE = re.compile(r"^.+ [2-9](?:\.[^.\\/]+)?$")
 _IGNORED_PREFIXES = (
     ".git/",
     ".venv/",
+    "venv/",
+    "dist/",
+    "build/",
     "node_modules/",
+    ".mypy_cache/",
+    ".pytest_cache/",
+    ".ruff_cache/",
     "ui/node_modules/",
+    "ui/.next/",
     "ui/out/",
     "site/",
 )
+_IGNORED_DIR_NAMES = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    "node_modules",
+    "site",
+    "venv",
+}
 
 
 def _tracked_paths() -> list[str]:
@@ -35,6 +56,20 @@ def _tracked_paths() -> list[str]:
         text=False,
     )
     return [part.decode("utf-8", errors="replace") for part in result.stdout.split(b"\0") if part]
+
+
+def _working_tree_paths(root: Path) -> list[str]:
+    paths: list[str] = []
+    for path in root.rglob("*"):
+        try:
+            relative = path.relative_to(root)
+        except ValueError:
+            continue
+        parts = relative.parts
+        if any(part in _IGNORED_DIR_NAMES for part in parts):
+            continue
+        paths.append(relative.as_posix())
+    return paths
 
 
 def _load_paths(path: Path) -> list[str]:
@@ -62,15 +97,27 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         help="Optional newline-delimited path list for tests; defaults to git ls-files.",
     )
+    parser.add_argument(
+        "--working-tree",
+        action="store_true",
+        help="Scan the local working tree, including untracked files, while skipping build/cache directories.",
+    )
     args = parser.parse_args(argv)
 
-    paths = _load_paths(args.paths_file) if args.paths_file else _tracked_paths()
+    if args.paths_file:
+        paths = _load_paths(args.paths_file)
+    elif args.working_tree:
+        paths = _working_tree_paths(Path.cwd())
+    else:
+        paths = _tracked_paths()
     duplicates = find_duplicate_artifacts(paths)
     if not duplicates:
-        print("No tracked Finder-style duplicate artifacts found.")
+        scope = "working-tree" if args.working_tree else "tracked"
+        print(f"No {scope} Finder-style duplicate artifacts found.")
         return 0
 
-    print("Tracked Finder-style duplicate artifacts found:", file=sys.stderr)
+    scope = "Working-tree" if args.working_tree else "Tracked"
+    print(f"{scope} Finder-style duplicate artifacts found:", file=sys.stderr)
     for path in duplicates:
         print(f"- {path}", file=sys.stderr)
     print(

--- a/tests/test_duplicate_artifact_guard.py
+++ b/tests/test_duplicate_artifact_guard.py
@@ -40,3 +40,22 @@ def test_duplicate_artifact_guard_cli_returns_failure_for_duplicates(tmp_path: P
     assert main(["--paths-file", str(paths)]) == 1
     captured = capsys.readouterr()
     assert "model_advisories 2.py" in captured.err
+
+
+def test_duplicate_artifact_guard_working_tree_mode_detects_untracked_copies(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    duplicate = tmp_path / "ui" / "components" / "command-palette 2.tsx"
+    duplicate.parent.mkdir(parents=True)
+    duplicate.write_text("export {}\n", encoding="utf-8")
+    ignored = tmp_path / "node_modules" / "package 2" / "index.js"
+    ignored.parent.mkdir(parents=True)
+    ignored.write_text("", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["--working-tree"]) == 1
+    captured = capsys.readouterr()
+    assert "ui/components/command-palette 2.tsx" in captured.err
+    assert "node_modules/package 2/index.js" not in captured.err


### PR DESCRIPTION
Summary
- extend the duplicate-artifact guard with a local working-tree scan mode for Finder-style copies
- expand ignore coverage for UI and docs duplicate filenames
- run the tracked duplicate guard from pre-commit so merge/release artifacts are caught earlier

Validation
- uv run pytest -q tests/test_duplicate_artifact_guard.py
- python3 scripts/check_duplicate_artifacts.py
- uv run ruff check scripts/check_duplicate_artifacts.py tests/test_duplicate_artifact_guard.py
- git diff --check