### PR TITLE
image: derive Debian CVE severity from related CVE

### DIFF
--- a/src/agent_bom/image.py
+++ b/src/agent_bom/image.py
@@ -97,6 +97,45 @@ def _build_scanner_env(
     return env
 
 
+def _cvss_score_from_grype_vulnerability(vuln_data: dict) -> Optional[float]:
+    for cvss in vuln_data.get("cvss", []):
+        metrics = cvss.get("metrics", {})
+        score = metrics.get("baseScore")
+        if score is not None:
+            return float(score)
+    return None
+
+
+def _severity_from_grype_vulnerability(vuln_data: dict, cvss_score: Optional[float]) -> Severity:
+    severity = severity_from_label(vuln_data.get("severity"))
+    if severity == Severity.UNKNOWN and cvss_score is not None:
+        return cvss_to_severity(cvss_score)
+    return severity
+
+
+def _related_grype_vulnerabilities(match: dict, vuln_data: dict) -> list[dict]:
+    related: list[dict] = []
+    for source in (match.get("relatedVulnerabilities"), vuln_data.get("relatedVulnerabilities")):
+        if isinstance(source, list):
+            related.extend(item for item in source if isinstance(item, dict))
+    return related
+
+
+def _debian_related_cve_fallback(match: dict, vuln_data: dict) -> tuple[Optional[Severity], Optional[float]]:
+    vuln_id = str(vuln_data.get("id") or "")
+    if not vuln_id.startswith("DEBIAN-CVE-"):
+        return None, None
+    for related in _related_grype_vulnerabilities(match, vuln_data):
+        related_id = str(related.get("id") or "")
+        if not related_id.startswith("CVE-"):
+            continue
+        related_score = _cvss_score_from_grype_vulnerability(related)
+        related_severity = _severity_from_grype_vulnerability(related, related_score)
+        if related_severity != Severity.UNKNOWN or related_score is not None:
+            return related_severity, related_score
+    return None, None
+
+
 def _scan_with_grype(
     image_ref: str,
     registry_user: Optional[str] = None,
@@ -162,17 +201,15 @@ def _scan_with_grype(
         if not vuln_id:
             continue
 
-        # Extract CVSS score from Grype's cvss array
-        cvss_score: Optional[float] = None
-        for cvss in vuln_data.get("cvss", []):
-            metrics = cvss.get("metrics", {})
-            score = metrics.get("baseScore")
-            if score is not None:
-                cvss_score = float(score)
-                break
-        severity = severity_from_label(vuln_data.get("severity"))
-        if severity == Severity.UNKNOWN and cvss_score is not None:
-            severity = cvss_to_severity(cvss_score)
+        # Extract CVSS score from Grype's cvss array.
+        cvss_score = _cvss_score_from_grype_vulnerability(vuln_data)
+        severity = _severity_from_grype_vulnerability(vuln_data, cvss_score)
+        if severity == Severity.UNKNOWN and cvss_score is None:
+            fallback_severity, fallback_score = _debian_related_cve_fallback(match, vuln_data)
+            if fallback_score is not None:
+                cvss_score = fallback_score
+            if fallback_severity is not None:
+                severity = fallback_severity
 
         # Fixed version
         fix_info = vuln_data.get("fix", {})

--- a/tests/test_image_auth.py
+++ b/tests/test_image_auth.py
@@ -19,6 +19,7 @@ from agent_bom.image import (
     detect_multi_arch,
     scan_image,
 )
+from agent_bom.models import Severity
 from agent_bom.security import SecurityError
 
 # ─── _build_scanner_env ─────────────────────────────────────────────────────
@@ -142,6 +143,47 @@ def test_external_scanner_helpers_validate_image_ref():
         assert False, "Expected SecurityError"
     except SecurityError as exc:
         assert "Invalid image reference" in str(exc)
+
+
+def test_grype_debian_cve_uses_related_canonical_cve_score(monkeypatch):
+    """Debian advisories without scores inherit severity from related CVE data."""
+    grype_payload = {
+        "matches": [
+            {
+                "artifact": {"type": "deb", "name": "bash", "version": "5.2"},
+                "vulnerability": {
+                    "id": "DEBIAN-CVE-2014-6271",
+                    "severity": "Unknown",
+                    "description": "Debian advisory without a direct score",
+                    "cvss": [],
+                },
+                "relatedVulnerabilities": [
+                    {
+                        "id": "CVE-2014-6271",
+                        "severity": "Unknown",
+                        "cvss": [{"metrics": {"baseScore": 9.8}}],
+                    }
+                ],
+            }
+        ]
+    }
+
+    def fake_run(cmd, **kwargs):
+        class R:
+            returncode = 0
+            stdout = json.dumps(grype_payload)
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    packages = _scan_with_grype("debian:bookworm")
+
+    vuln = packages[0].vulnerabilities[0]
+    assert vuln.id == "DEBIAN-CVE-2014-6271"
+    assert vuln.cvss_score == 9.8
+    assert vuln.severity == Severity.CRITICAL
 
 
 def test_external_scanner_helpers_validate_platform():


### PR DESCRIPTION
Summary
- derive missing DEBIAN-CVE severity and CVSS from related canonical CVE records in Grype output
- keep the original distro advisory ID while using the related CVE score for severity classification
- add regression coverage for a Debian advisory with no direct score

Validation
- uv run pytest -q tests/test_image_auth.py
- uv run ruff check src/agent_bom/image.py tests/test_image_auth.py
- uv run mypy src/agent_bom/image.py
- git diff --check