### PR TITLE
cli: add local analytics query

### DIFF
--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -48,7 +48,7 @@
 |---------|-------------|
 | `graph` | Export the transitive dependency graph from a scan report |
 | `mesh` | Show lightweight agent/MCP topology without CVE scanning |
-| `report` | History, diff, pipeline-event artifacts, analytics, dashboard, and compliance narrative workflows |
+| `report` | History, diff, pipeline-event artifacts, local queries, analytics, dashboard, and compliance narrative workflows |
 
 ### Governance And Operations
 
@@ -84,6 +84,7 @@
 - `check` supports terminal output by default plus `--format json` for machine-readable pre-install verdicts.
 - `report history` and `report diff` support `--format json` for CI and automation.
 - `report pipeline-events <scan-job.json>` exports structured scan progress as JSONL for DAG/dashboard consumers.
+- `report query "SELECT ..."` runs read-only SQL against the local scan analytics store.
 - `remediate` supports `--format json` as the machine-readable remediation contract.
 - Use `agent-bom agents -f <format> -o <path>` for SARIF, HTML, SBOM, and richer environment exports.
 - Use `agent-bom agents -f sarif -o -` when you need SARIF on stdout for piping.
@@ -101,6 +102,7 @@ agent-bom agents -o report.json
 agent-bom check requests@2.33.0 -e pypi -f json -o check.json
 agent-bom report diff before.json after.json -f json -o diff.json
 agent-bom report pipeline-events scan-job.json -o pipeline-events.jsonl
+agent-bom report query "SELECT severity, COUNT(*) AS count FROM scan_findings GROUP BY severity" --format json
 
 # Compliance
 agent-bom agents --compliance owasp-llm,eu-ai-act,all

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -250,15 +250,16 @@ main.add_command(mesh_cmd, "mesh")
 # introspect is under `mcp introspect` — no top-level duplicate
 
 # ---------------------------------------------------------------------------
-# Report command group — `agent-bom report [history|diff|rescan|analytics|dashboard]`
+# Report command group — `agent-bom report [history|diff|rescan|query|analytics|dashboard]`
 # ---------------------------------------------------------------------------
-from agent_bom.cli._report_group import pipeline_events_cmd, report_group  # noqa: E402
+from agent_bom.cli._report_group import local_query_cmd, pipeline_events_cmd, report_group  # noqa: E402
 
 report_group.add_command(history_cmd, "history")
 report_group.add_command(diff_cmd, "diff")
 report_group.add_command(rescan_command, "rescan")
 report_group.add_command(compliance_narrative_cmd, "compliance-narrative")
 report_group.add_command(pipeline_events_cmd, "pipeline-events")
+report_group.add_command(local_query_cmd, "query")
 report_group.add_command(analytics_cmd, "analytics")
 report_group.add_command(dashboard_cmd, "dashboard")
 main.add_command(report_group)

--- a/src/agent_bom/cli/_report_group.py
+++ b/src/agent_bom/cli/_report_group.py
@@ -6,6 +6,7 @@ Usage::
     agent-bom report diff <a> <b>        # diff two scan reports or SBOMs
     agent-bom report rescan              # re-scan to verify remediation
     agent-bom report compliance-narrative report.json
+    agent-bom report query "SELECT ..."  # query the local scan analytics store
     agent-bom report analytics           # query vulnerability trends
     agent-bom serve                      # launch bundled API + Next.js dashboard
     agent-bom report dashboard           # legacy Streamlit compatibility dashboard
@@ -15,6 +16,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import click
 
@@ -33,6 +35,7 @@ def report_group(ctx: click.Context) -> None:
       rescan      Re-scan vulnerable packages to verify remediation
       compliance-narrative  Generate auditor-facing compliance narrative from a saved scan report
       pipeline-events  Export scan pipeline DAG events as JSONL
+      query       Run read-only SQL against the local scan analytics store
       analytics   Query vulnerability trends (ClickHouse)
       dashboard   Launch legacy Streamlit compatibility dashboard; use `agent-bom serve` for the bundled Next.js UI
     """
@@ -63,3 +66,51 @@ def pipeline_events_cmd(scan_job_json: str, output_path: str | None) -> None:
         return
     if jsonl:
         click.echo(jsonl)
+
+
+@click.command("query")
+@click.argument("sql")
+@click.option(
+    "--db",
+    "db_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Local analytics database path. Defaults to AGENT_BOM_LOCAL_ANALYTICS_DB or ~/.agent-bom/local-analytics.sqlite.",
+)
+@click.option("--format", "output_format", type=click.Choice(["table", "json"]), default="table", show_default=True)
+def local_query_cmd(sql: str, db_path: Path | None, output_format: str) -> None:
+    """Run read-only SQL against the local scan analytics store."""
+    from agent_bom.db.local_analytics import LocalAnalyticsStore, local_analytics_path
+
+    resolved_db = db_path or local_analytics_path()
+    store = LocalAnalyticsStore(resolved_db)
+    try:
+        rows = store.query(sql)
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"Could not query local analytics store: {exc}") from exc
+
+    if output_format == "json":
+        click.echo(json.dumps({"db_path": str(resolved_db), "count": len(rows), "rows": rows}, indent=2))
+        return
+
+    _echo_rows_as_table(rows)
+
+
+def _echo_rows_as_table(rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        click.echo("No rows.")
+        return
+
+    columns = list(rows[0].keys())
+    widths = {column: max(len(column), *(len(_stringify(row.get(column))) for row in rows)) for column in columns}
+    header = "  ".join(column.ljust(widths[column]) for column in columns)
+    divider = "  ".join("-" * widths[column] for column in columns)
+    click.echo(header)
+    click.echo(divider)
+    for row in rows:
+        click.echo("  ".join(_stringify(row.get(column)).ljust(widths[column]) for column in columns))
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)

--- a/tests/test_cli_report_query.py
+++ b/tests/test_cli_report_query.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+from agent_bom.db.local_analytics import LocalAnalyticsStore
+
+
+def _scan_report() -> dict:
+    return {
+        "scan_id": "query-scan",
+        "generated_at": "2026-05-10T16:00:00+00:00",
+        "findings": [
+            {
+                "id": "finding-1",
+                "vulnerability_id": "CVE-2026-0001",
+                "package_name": "fastapi",
+                "package_version": "0.115.0",
+                "ecosystem": "pypi",
+                "severity": "high",
+                "risk_score": 8.1,
+            }
+        ],
+    }
+
+
+def test_report_query_outputs_local_analytics_rows_as_json(tmp_path):
+    db_path = tmp_path / "local.sqlite"
+    LocalAnalyticsStore(db_path).record_scan_report(_scan_report(), source="cli")
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "report",
+            "query",
+            "SELECT severity, COUNT(*) AS count FROM scan_findings GROUP BY severity",
+            "--db",
+            str(db_path),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["count"] == 1
+    assert payload["rows"] == [{"severity": "high", "count": 1}]
+
+
+def test_report_query_outputs_local_analytics_rows_as_table(tmp_path):
+    db_path = tmp_path / "local.sqlite"
+    LocalAnalyticsStore(db_path).record_scan_report(_scan_report(), source="cli")
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "report",
+            "query",
+            "SELECT package_name, severity FROM scan_findings ORDER BY package_name",
+            "--db",
+            str(db_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "package_name  severity" in result.output
+    assert "fastapi       high" in result.output
+
+
+def test_report_query_rejects_write_sql(tmp_path):
+    db_path = tmp_path / "local.sqlite"
+    LocalAnalyticsStore(db_path).record_scan_report(_scan_report(), source="cli")
+
+    result = CliRunner().invoke(
+        main,
+        ["report", "query", "DELETE FROM scan_findings", "--db", str(db_path)],
+    )
+
+    assert result.exit_code != 0
+    assert "read-only" in result.output


### PR DESCRIPTION
Summary
- adds `agent-bom report query` for read-only SQL against the local scan analytics store
- supports table and JSON output plus an explicit `--db` override for local workflow validation
- documents the command in the public CLI reference

Validation
- uv run pytest -q tests/test_cli_report_query.py tests/test_local_analytics.py
- uv run pytest -q tests/test_public_docs_cli_alignment.py tests/test_cli_entry_points.py::TestAgentBom::test_report_dashboard_help_points_to_serve_for_next_ui
- uv run ruff check src/agent_bom/cli/_report_group.py src/agent_bom/cli/__init__.py tests/test_cli_report_query.py
- uv run mypy src/agent_bom/cli/_report_group.py
- uv run agent-bom report query "SELECT 'high' AS severity, 1 AS count" --format json\n- git diff --check