### PR TITLE
ui: tighten graph capture framing

### DIFF
--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -48,9 +48,9 @@ before replacing any published product image.
 |---|---|---|---|
 | `dashboard-live.png` | `/?capture=1` (Risk overview) | All agents · top crop showing the gauge, posture sub-scores, score breakdown, and the start of the attack-path list | The published README should not use one tall stitched dashboard asset when two shorter frames tell the story more clearly |
 | `dashboard-paths-live.png` | `/?capture=1` (Risk overview) | All agents · mid-page crop showing the attack-path list, exposure KPI band, and the first backlog charts | Keeps the fix-first path list readable in GitHub while still proving the KPI / backlog context lives on the same page |
-| `mesh-live.png` | `/mesh` | Capture the full light-theme agent mesh graph across selected agents, MCP servers, tools, packages, credentials, and findings | Preserves the graph-backed product surface; do not replace this with a summary card or slide view |
-| `mesh-dark-live.png` | `/mesh` | Capture the same real product graph in dark theme | Proves theme parity without using a docs-only route |
-| `mesh-light-live.png` | `/mesh` | Capture the same real product graph in light theme | Keeps dependency paths and finding edges readable in GitHub docs |
+| `mesh-live.png` | `/mesh?capture=1` | Capture the full light-theme agent mesh graph across selected agents, MCP servers, tools, packages, credentials, and findings | Preserves the graph-backed product surface; capture mode tightens graph framing and hides minimap controls |
+| `mesh-dark-live.png` | `/mesh?capture=1` | Capture the same real product graph in dark theme | Proves theme parity without using a docs-only route |
+| `mesh-light-live.png` | `/mesh?capture=1` | Capture the same real product graph in light theme | Keeps dependency paths and finding edges readable in GitHub docs |
 | `remediation-live.png` | `/remediation` | All frameworks tab | Shows the full prioritized fix list |
 
 ### Dashboard layout (current)
@@ -72,9 +72,10 @@ The `cursor` agent in `src/agent_bom/demo.py` is the best mesh hero shot in
 the current demo inventory — it brings the filesystem and database servers,
 multiple tools, reachable packages, and the densest CVE cluster
 (`pillow@9.0.0`, `cryptography@39.0.0`, `werkzeug@2.2.2`). Capturing under
-an unscoped or lower-signal agent risks a flatter graph. Use `/mesh` for the
-full product graph in both dark and light themes. Do not publish a docs-only
-slide or card view in place of the graph screenshot.
+an unscoped or lower-signal agent risks a flatter graph. Use
+`/mesh?capture=1` for the full product graph in both dark and light themes so
+the graph is framed for README-scale evidence. Do not publish a docs-only slide
+or card view in place of the graph screenshot.
 
 ## Accuracy guardrail
 

--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -376,8 +376,9 @@ export default function ContextPage() {
         edgeCount: displayEdges.length,
         selectedNode: Boolean(selectedNode),
         mode: "context",
+        captureMode,
       }),
-    [displayEdges.length, displayNodes.length, selectedNode],
+    [captureMode, displayEdges.length, displayNodes.length, selectedNode],
   );
   const showMiniMap = useMemo(
     () =>
@@ -543,6 +544,7 @@ export default function ContextPage() {
             />
           ) : (
             <ReactFlow
+              key={captureMode ? "context-capture" : "context-interactive"}
               nodes={displayNodes}
               edges={displayEdges}
               nodeTypes={lineageNodeTypes}

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -1032,8 +1032,9 @@ function GraphPageInner() {
         edgeCount: displayEdges.length,
         selectedNode: Boolean(selectedNode),
         mode: "lineage",
+        captureMode,
       }),
-    [displayEdges.length, displayNodes.length, selectedNode],
+    [captureMode, displayEdges.length, displayNodes.length, selectedNode],
   );
   const showMiniMap = useMemo(
     () =>
@@ -1774,6 +1775,7 @@ function GraphPageInner() {
             />
           ) : (
             <ReactFlow
+              key={captureMode ? "lineage-capture" : "lineage-interactive"}
               nodes={displayNodes}
               edges={displayEdges}
               nodeTypes={lineageNodeTypesAdaptive}

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -384,8 +384,9 @@ export default function MeshPage() {
         edgeCount: displayEdges.length,
         selectedNode: Boolean(selectedNode),
         mode: "mesh",
+        captureMode,
       }),
-    [displayEdges.length, displayNodes.length, selectedNode],
+    [captureMode, displayEdges.length, displayNodes.length, selectedNode],
   );
   const showMiniMap = useMemo(
     () =>
@@ -546,6 +547,7 @@ export default function MeshPage() {
           />
         ) : (
           <ReactFlow
+            key={captureMode ? "mesh-capture" : "mesh-interactive"}
             nodes={displayNodes}
             edges={displayEdges}
             nodeTypes={lineageNodeTypes}
@@ -565,7 +567,7 @@ export default function MeshPage() {
             onPaneClick={() => { setSelectedNode(null); setHoveredNodeId(null); }}
           >
             <Background color={BACKGROUND_COLOR} gap={BACKGROUND_GAP} />
-            <Controls className={CONTROLS_CLASS} />
+            {!captureMode && <Controls className={CONTROLS_CLASS} />}
             {showMiniMap && (
               <MiniMap
                 nodeColor={minimapNodeColor}

--- a/ui/lib/graph-viewport.ts
+++ b/ui/lib/graph-viewport.ts
@@ -5,6 +5,7 @@ export type GraphViewportInput = {
   edgeCount?: number;
   selectedNode?: boolean;
   mode?: GraphViewportMode;
+  captureMode?: boolean;
 };
 
 export type GraphFitViewOptions = {
@@ -61,10 +62,15 @@ export function graphFitViewOptions(input: GraphViewportInput): GraphFitViewOpti
     maxZoom -= 0.04;
   }
 
+  if (input.captureMode) {
+    padding -= input.mode === "mesh" ? 0.04 : 0.02;
+    maxZoom += input.mode === "mesh" ? 0.18 : 0.1;
+  }
+
   return {
     padding: clamp(padding, 0.08, 0.24),
     maxZoom: clamp(maxZoom + selectedBoost, 0.82, 1.82),
-    duration: 240,
+    duration: input.captureMode ? 0 : 240,
   };
 }
 

--- a/ui/lib/use-capture-mode.ts
+++ b/ui/lib/use-capture-mode.ts
@@ -6,12 +6,16 @@ export function isCaptureModeSearch(search: string): boolean {
   return new URLSearchParams(search).get("capture") === "1";
 }
 
+function readCaptureModeFromLocation(): boolean {
+  if (typeof window === "undefined") return false;
+  return isCaptureModeSearch(window.location.search);
+}
+
 export function useCaptureMode(): boolean {
-  const [captureMode, setCaptureMode] = useState(false);
+  const [captureMode, setCaptureMode] = useState(readCaptureModeFromLocation);
 
   useEffect(() => {
-    const update = () => setCaptureMode(isCaptureModeSearch(window.location.search));
-    update();
+    const update = () => setCaptureMode(readCaptureModeFromLocation());
     window.addEventListener("popstate", update);
     return () => window.removeEventListener("popstate", update);
   }, []);

--- a/ui/tests/graph-viewport.test.ts
+++ b/ui/tests/graph-viewport.test.ts
@@ -30,4 +30,13 @@ describe("graph viewport framing", () => {
     expect(shouldShowGraphMiniMap({ nodeCount: 24, edgeCount: 40, selectedNode: true })).toBe(false);
     expect(shouldShowGraphMiniMap({ nodeCount: 90, edgeCount: 160 })).toBe(true);
   });
+
+  it("tightens capture-mode framing for published mesh screenshots", () => {
+    const interactive = graphFitViewOptions({ nodeCount: 18, edgeCount: 24, mode: "mesh" });
+    const capture = graphFitViewOptions({ nodeCount: 18, edgeCount: 24, mode: "mesh", captureMode: true });
+
+    expect(capture.maxZoom).toBeGreaterThan(interactive.maxZoom);
+    expect(capture.padding).toBeLessThan(interactive.padding);
+    expect(capture.duration).toBe(0);
+  });
 });

--- a/ui/tests/use-capture-mode.test.tsx
+++ b/ui/tests/use-capture-mode.test.tsx
@@ -1,0 +1,47 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { graphFitViewOptions } from "@/lib/graph-viewport";
+import { isCaptureModeSearch, useCaptureMode } from "@/lib/use-capture-mode";
+
+describe("useCaptureMode", () => {
+  it("parses capture query strings", () => {
+    expect(isCaptureModeSearch("?capture=1")).toBe(true);
+    expect(isCaptureModeSearch("?capture=0")).toBe(false);
+    expect(isCaptureModeSearch("")).toBe(false);
+  });
+
+  it("reads capture mode synchronously on first render", () => {
+    window.history.replaceState({}, "", "/mesh?capture=1");
+
+    const { result } = renderHook(() => useCaptureMode());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("tracks browser navigation changes", () => {
+    window.history.replaceState({}, "", "/mesh?capture=1");
+    const { result } = renderHook(() => useCaptureMode());
+
+    act(() => {
+      window.history.pushState({}, "", "/mesh");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("drives capture-ready graph fit options from the initial URL", () => {
+    window.history.replaceState({}, "", "/mesh?capture=1");
+
+    const { result } = renderHook(() => {
+      const captureMode = useCaptureMode();
+      return graphFitViewOptions({ nodeCount: 18, edgeCount: 24, mode: "mesh", captureMode });
+    });
+
+    expect(result.current.duration).toBe(0);
+    expect(result.current.maxZoom).toBeGreaterThan(
+      graphFitViewOptions({ nodeCount: 18, edgeCount: 24, mode: "mesh" }).maxZoom,
+    );
+  });
+});


### PR DESCRIPTION
Summary
- makes graph capture mode use tighter deterministic fit-view framing
- passes capture mode through lineage, context, and mesh graph viewports
- hides React Flow controls on the mesh capture route so published screenshots stay focused on the real graph
- updates the capture protocol to use the real `/mesh?capture=1` product route for mesh screenshots

Notes
- no screenshot asset was added or promoted in this PR
- the next screenshot refresh should recapture the real mesh graph from `/mesh?capture=1` after this lands

Validation
- cd ui && npm test -- --run tests/graph-viewport.test.ts
- cd ui && npm run typecheck
- cd ui && npm run lint -- app/mesh/page.tsx app/graph/graph-page-client.tsx app/context/page.tsx lib/graph-viewport.ts tests/graph-viewport.test.ts
- uv run python scripts/check_release_consistency.py
- git diff --check