### PR TITLE
graph: align release labels and defaults

### DIFF
--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -190,9 +190,9 @@ Attack paths and exposure:
 
 ![agent-bom dashboard attack paths and exposure](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-paths-live.png)
 
-Focused graph:
+Agent mesh graph:
 
-![agent-bom focused graph](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/mesh-live.png)
+![agent-bom agent mesh graph](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/mesh-live.png)
 
 ## Tags
 

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -83,9 +83,9 @@ helm upgrade --install agent-bom deploy/helm/agent-bom \
 
 ![agent-bom dashboard overview](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-live.png)
 
-### Focused graph
+### Agent mesh graph
 
-![agent-bom focused graph](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/mesh-live.png)
+![agent-bom agent mesh graph](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/mesh-live.png)
 
 ## What it scans
 

--- a/README.md
+++ b/README.md
@@ -175,9 +175,13 @@ Risk, reach, fix version, and framework context in one review table — operator
 
 Agent-centered shared-infrastructure graph — selected agents, their MCP servers, tools, packages, credentials, and findings. The same evidence model renders in dark and light themes.
 
-| Dark theme | Light theme |
-|---|---|
-| ![agent-bom agent mesh dark theme](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/mesh-dark-live.png) | ![agent-bom agent mesh light theme](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/mesh-light-live.png) |
+**Dark theme**
+
+![agent-bom agent mesh dark theme](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/mesh-dark-live.png)
+
+**Light theme**
+
+![agent-bom agent mesh light theme](https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/mesh-light-live.png)
 
 </details>
 

--- a/docs/graph/CONTRACT.md
+++ b/docs/graph/CONTRACT.md
@@ -86,8 +86,8 @@ The graph renderer ships deterministic focused and expanded modes. Operators can
 
 | Mode / size | Default behaviour | Why |
 |---|---|---|
-| Focused default | 3-hop neighbourhood, 250-node page size, sibling fan-outs of 5+ collapsed into expandable cluster pills. | Starts every investigation readable, even on the 244-node self-scan. |
-| Expanded mode | 6-hop neighbourhood, 1000-node page size, sibling fan-outs of 20+ collapsed. | Lets operators widen context deliberately without losing the map. |
+| Relevant paths default | 2-hop neighbourhood, 50-node page size, high-severity vulnerable scope, sibling fan-outs of 5+ collapsed into expandable cluster pills. | Starts every investigation readable, even on dense self-scans. |
+| Expanded mode | 3-hop neighbourhood, 250-node page size, sibling fan-outs of 20+ collapsed. | Lets operators widen context deliberately without turning the first view into a whole-tenant canvas. |
 | Zoomed out | Level-of-detail renderer swaps detail cards for summary cards and cluster bubbles below the zoom thresholds. | Dense snapshots stay navigable instead of turning into unreadable labels. |
 | Large snapshots | Snapshot selector, search, filters, pagination, and graph query endpoints bound the visible canvas. | Large tenants navigate by scope, not by rendering the whole tenant in one frame. |
 

--- a/docs/graph/SECURITY_GRAPH_EPIC_PROOF.md
+++ b/docs/graph/SECURITY_GRAPH_EPIC_PROOF.md
@@ -43,7 +43,7 @@ Readability is split into deterministic controls:
 - Zoom levels resolve to `cluster`, `summary`, or `detail` bands in `ui/lib/lod-renderer.ts`.
 - Low-zoom cluster rendering only activates when aggregation materially reduces node count, avoiding unlabeled dot fields.
 - Sibling fan-outs render as cluster pills in `ui/components/lineage-nodes.tsx`.
-- Focused graph filters default to bounded depth/hops through `GraphFilterOptions` and `lineage-filter`.
+- Relevant paths filters default to bounded hop depth and visible layers through `GraphFilterOptions` and `lineage-filter`.
 
 `ui/tests/lod-renderer.test.ts` pins the zoom thresholds and the aggregation fallback.
 

--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 /**
- * Context Graph page — agent interaction graph with lateral movement analysis.
- * Shows reachability between agents, servers, credentials, tools, and
- * vulnerabilities.  Selecting an agent highlights lateral movement paths.
+ * Context Map page — static agent interaction context with lateral reachability
+ * analysis. Shows reachability between agents, servers, credentials, tools, and
+ * vulnerabilities without implying observed runtime causality.
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -461,10 +461,10 @@ export default function ContextPage() {
         <div>
           <h1 className="text-lg font-semibold text-zinc-100 flex items-center gap-2">
             <Waypoints className="w-5 h-5 text-orange-400" />
-            Context Graph
+            Context Map
           </h1>
           <p className="text-xs text-zinc-500">
-            Focused lateral-movement map for one agent scope at a time
+            Static reachability map for one agent scope at a time; runtime evidence is shown only when scans provide it.
           </p>
         </div>
         <div className="flex items-center gap-3">

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -1342,7 +1342,7 @@ function GraphPageInner() {
         <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
           <div>
             <p className="text-[10px] uppercase tracking-[0.24em] text-sky-400">Unified graph</p>
-            <h1 className="mt-1 text-lg font-semibold text-zinc-100">Security Graph</h1>
+            <h1 className="mt-1 text-lg font-semibold text-zinc-100">Lineage Graph</h1>
             <p className="text-xs text-zinc-500">
               Focused agent-to-finding graph with packages, credentials, tools, and runtime links.
             </p>
@@ -1468,7 +1468,7 @@ function GraphPageInner() {
                 ? "This scope currently resolves to findings without surrounding context. Relax filters or expand the view to recover package, server, and agent relationships."
                 : filters.agentName
                   ? `Focused on ${filters.agentName}. Expand only when you need more of the surrounding graph.`
-                  : "Relevant paths keeps the first view bounded. Use Expanded only when you need broader topology."}
+                  : "Relevant paths keeps the first view bounded by hop depth, layers, severity, and page size. Use Expanded only when you need broader topology."}
           </div>
 
           {investigationMode && (
@@ -1620,6 +1620,7 @@ function GraphPageInner() {
             <li>Node IDs are stable identifiers inside the graph model; the detail panel shows the node ID, first seen, last seen, sources, and edge counts.</li>
             <li>Pagination changes the visible canvas, not the persisted snapshot itself. Narrow the scope when the graph gets large; page when you need broader coverage.</li>
             <li>Relevant paths is for operator triage. Expanded is for topology review. Attack-path cards are the fix-first shortlist, not the whole graph.</li>
+            <li>Hop depth controls how far traversal can move from the selected agent or root. Entity layers control what kinds of nodes can render, without changing the persisted graph.</li>
           </ul>
         </details>
 

--- a/ui/e2e/lineage-graph-readability.spec.ts
+++ b/ui/e2e/lineage-graph-readability.spec.ts
@@ -84,20 +84,20 @@ function edge(source: string, target: string, relationship: string, weight = 1):
 
 function buildDenseGraph() {
   const nodes: GraphNode[] = [
-    node("agent:claude", "agent", "Claude Desktop", "high", 8.8, { agent_type: "desktop" }),
+    node("agent:desktop", "agent", "Desktop Agent", "high", 8.8, { agent_type: "desktop" }),
     node("server:filesystem", "server", "filesystem MCP", "high", 8.2, { command: "npx @modelcontextprotocol/server-filesystem" }),
-    node("server:github", "server", "github MCP", "high", 7.9, { command: "npx @modelcontextprotocol/server-github" }),
-    node("cred:github-token", "credential", "GitHub token", "high", 8.4),
+    node("server:repo", "server", "repository MCP", "high", 7.9, { command: "npx @modelcontextprotocol/server-repository" }),
+    node("cred:repo-token", "credential", "Repository token", "high", 8.4),
     node("tool:write-file", "tool", "write_file", "medium", 5.8),
   ];
   const edges: GraphEdge[] = [
-    edge("agent:claude", "server:filesystem", "uses"),
-    edge("agent:claude", "server:github", "uses"),
-    edge("server:github", "cred:github-token", "exposes_cred"),
-    edge("cred:github-token", "tool:write-file", "reaches_tool"),
+    edge("agent:desktop", "server:filesystem", "uses"),
+    edge("agent:desktop", "server:repo", "uses"),
+    edge("server:repo", "cred:repo-token", "exposes_cred"),
+    edge("cred:repo-token", "tool:write-file", "reaches_tool"),
   ];
 
-  for (const server of ["filesystem", "github"]) {
+  for (const server of ["filesystem", "repo"]) {
     const serverId = `server:${server}`;
     for (let index = 1; index <= 8; index += 1) {
       const packageId = `pkg:${server}:${index}`;
@@ -118,16 +118,16 @@ function buildDenseGraph() {
     edges,
     attack_paths: [
       {
-        source: "agent:claude",
+        source: "agent:desktop",
         target: "cve:filesystem:3",
-        hops: ["agent:claude", "server:filesystem", "pkg:filesystem:3", "cve:filesystem:3"],
+        hops: ["agent:desktop", "server:filesystem", "pkg:filesystem:3", "cve:filesystem:3"],
         edges: [
-          "agent:claude->server:filesystem:uses",
+          "agent:desktop->server:filesystem:uses",
           "server:filesystem->pkg:filesystem:3:depends_on",
           "pkg:filesystem:3->cve:filesystem:3:vulnerable_to",
         ],
         composite_risk: 9.4,
-        summary: "Claude Desktop can reach a critical vulnerable package through filesystem MCP.",
+        summary: "Desktop Agent can reach a critical vulnerable package through filesystem MCP.",
         credential_exposure: [],
         tool_exposure: ["write_file"],
         vuln_ids: ["CVE-2026-103"],
@@ -199,9 +199,9 @@ async function routeGraphPage(page: Page) {
     await route.fulfill({
       contentType: "application/json",
       body: JSON.stringify({
-        nodes_added: ["cve:filesystem:3", "cve:github:3"],
+        nodes_added: ["cve:filesystem:3", "cve:repo:3"],
         nodes_removed: [],
-        nodes_changed: ["agent:claude"],
+        nodes_changed: ["agent:desktop"],
         edges_added: [["pkg:filesystem:3", "cve:filesystem:3", "vulnerable_to"]],
         edges_removed: [],
       }),
@@ -213,20 +213,20 @@ async function routeGraphPage(page: Page) {
 }
 
 async function captureGraphScreenshot(page: Page, testInfo: TestInfo, theme: "dark" | "light") {
-  await expect(page.getByRole("heading", { name: "Security Graph" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Lineage Graph" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Relevant paths", exact: true })).toBeVisible();
   await expect(page.getByText("Attack paths", { exact: true })).toBeVisible();
   await expect(page.locator('[data-testid="cluster-pill"]').first()).toBeVisible();
   await expect(page.getByTestId("graph-compression-summary")).toContainText(/compressed|rendered/);
   await expect(page.locator("summary").filter({ hasText: "Legend" })).toBeVisible();
   await page.screenshot({
-    path: testInfo.outputPath(`security-graph-dense-${theme}.png`),
+    path: testInfo.outputPath(`lineage-graph-dense-${theme}.png`),
     fullPage: true,
   });
 }
 
 for (const theme of ["dark", "light"] as const) {
-  test(`security graph dense ${theme} view stays focused and screenshot-ready`, async ({ page }, testInfo) => {
+  test(`lineage graph dense ${theme} view stays focused and screenshot-ready`, async ({ page }, testInfo) => {
     await routeGraphPage(page);
     await page.addInitScript((selectedTheme) => {
       window.localStorage.setItem("agent-bom-theme", selectedTheme);


### PR DESCRIPTION
Summary
- makes README mesh screenshots stack vertically so graph labels are not squeezed in the release page
- renames package/container README graph copy from focused graph to Agent Mesh so public screenshots match the shipped surface
- aligns `/graph` page title with the Lineage Graph nav label
- aligns `/context` title and copy with Context Map static reachability semantics
- updates the graph contract scaling table to match shipped Relevant paths and Expanded defaults

Validation
- cd ui && npm run lint -- app/graph/graph-page-client.tsx app/context/page.tsx components/nav.tsx
- cd ui && npm run typecheck
- uv run python scripts/check_release_consistency.py
- git diff --check