### PR TITLE
graph: align context schema and traversal budgets

### DIFF
--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -575,10 +575,6 @@ class SQLiteGraphStore:
                 dynamic_only=dynamic_only,
             ):
                 edge = self._edge_from_row(row)
-                edge_count += 1
-                if edge_count > max_edges:
-                    truncated = True
-                    break
                 candidates: list[str] = []
                 if direction in {"forward", "both"}:
                     if edge.source == current:
@@ -592,6 +588,11 @@ class SQLiteGraphStore:
                         candidates.append(edge.target)
                 if not candidates:
                     continue
+
+                edge_count += 1
+                if edge_count > max_edges:
+                    truncated = True
+                    break
 
                 rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship)
                 traversed_edges.setdefault((edge.source, edge.target, rel), edge)

--- a/src/agent_bom/context_graph.py
+++ b/src/agent_bom/context_graph.py
@@ -746,6 +746,7 @@ def to_serializable(
             {
                 "id": n.id,
                 "kind": n.kind.value,
+                "entity_type": (_NODE_KIND_TO_ENTITY.get(n.kind.value, EntityType.SERVER)).value,
                 "label": n.label,
                 "metadata": n.metadata,
             }
@@ -756,6 +757,7 @@ def to_serializable(
                 "source": e.source,
                 "target": e.target,
                 "kind": e.kind.value,
+                "relationship": (_EDGE_KIND_TO_RELATIONSHIP.get(e.kind.value) or e.kind).value,
                 "weight": e.weight,
                 "metadata": e.metadata,
             }

--- a/tests/test_context_graph.py
+++ b/tests/test_context_graph.py
@@ -524,6 +524,8 @@ class TestAPIContextGraph:
         assert "nodes" in data
         assert "stats" in data
         assert data["stats"]["agent_count"] == 2
+        assert {node["entity_type"] for node in data["nodes"]} >= {"agent", "server"}
+        assert {edge["relationship"] for edge in data["edges"]} >= {"uses", "shares_server"}
 
     def test_api_agent_filter(self):
         """GET /v1/scan/{id}/context-graph?agent=a1 filters lateral paths."""

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -727,6 +727,31 @@ class TestGraphEndpointLogic:
         assert sourced[0].summary == path.summary
         assert sourced[0].tool_exposure == ["run_shell"]
 
+    def test_sqlite_graph_store_edge_budget_counts_only_traversed_direction(self, tmp_path):
+        store = SQLiteGraphStore(tmp_path / "graph.db")
+        graph = UnifiedGraph(scan_id="budget-scan", tenant_id="default")
+        graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        graph.add_node(UnifiedNode(id="tool:t", entity_type=EntityType.TOOL, label="tool-t"))
+        for index in range(3):
+            graph.add_node(UnifiedNode(id=f"agent:in-{index}", entity_type=EntityType.AGENT, label=f"in-{index}"))
+            graph.add_edge(UnifiedEdge(source=f"agent:in-{index}", target="server:s", relationship=RelationshipType.USES))
+        graph.add_edge(UnifiedEdge(source="server:s", target="tool:t", relationship=RelationshipType.PROVIDES_TOOL))
+        store.save_graph(graph)
+
+        subgraph, depth_by_node, truncated = store.traverse_subgraph(
+            roots=["server:s"],
+            direction="forward",
+            max_depth=1,
+            max_edges=1,
+        )
+
+        assert truncated is False
+        assert set(subgraph.nodes) == {"server:s", "tool:t"}
+        assert [(edge.source, edge.target, edge.relationship) for edge in subgraph.edges] == [
+            ("server:s", "tool:t", RelationshipType.PROVIDES_TOOL)
+        ]
+        assert depth_by_node["tool:t"] == 1
+
     def test_sqlite_graph_store_edges_for_node_ids_returns_incident_edges(self, tmp_path):
         store = SQLiteGraphStore(tmp_path / "graph.db")
         graph = UnifiedGraph(scan_id="incident-edge-scan", tenant_id="default")

--- a/ui/lib/context-graph.ts
+++ b/ui/lib/context-graph.ts
@@ -11,7 +11,8 @@ import { readReachBreakdown, readReachScore, reachEdgeWidth, reachStrokeColor } 
 
 export interface ContextGraphNode {
   id: string;
-  kind: "agent" | "server" | "credential" | "tool" | "vulnerability";
+  kind: "agent" | "server" | "credential" | "tool" | "vulnerability" | "iam_role";
+  entity_type?: string;
   label: string;
   metadata: Record<string, unknown>;
 }
@@ -20,6 +21,7 @@ export interface ContextGraphEdge {
   source: string;
   target: string;
   kind: string;
+  relationship?: string;
   weight: number;
   metadata: Record<string, unknown>;
 }
@@ -72,6 +74,8 @@ const KIND_TO_NODE_TYPE: Record<string, LineageNodeType> = {
   credential: "credential",
   tool: "tool",
   vulnerability: "vulnerability",
+  iam_role: "serviceAccount",
+  service_account: "serviceAccount",
 };
 
 // ─── Edge colors ─────────────────────────────────────────────────────────────
@@ -79,10 +83,14 @@ const KIND_TO_NODE_TYPE: Record<string, LineageNodeType> = {
 const EDGE_COLORS: Record<string, string> = {
   uses: "#10b981",          // emerald  agent→server
   exposes: "#f59e0b",       // amber    server→credential
+  exposes_cred: "#f59e0b",  // amber    server→credential
   provides: "#a855f7",      // purple   server→tool
+  provides_tool: "#a855f7", // purple   server→tool
   vulnerable_to: "#ef4444", // red      server→vulnerability
   shares_server: "#22d3ee", // cyan     agent↔agent
   shares_credential: "#f97316", // orange agent↔agent
+  shares_cred: "#f97316",   // orange   agent↔agent
+  member_of: "#60a5fa",     // blue     identity→agent
 };
 
 // ─── Builder ─────────────────────────────────────────────────────────────────
@@ -125,7 +133,8 @@ export function buildContextFlowGraph(
   // Shared server IDs
   const sharedServerNames = new Set<string>();
   for (const e of data.edges) {
-    if (e.kind === "shares_server") {
+    const relationship = e.relationship ?? e.kind;
+    if (relationship === "shares_server") {
       const srv = (e.metadata?.server as string) ?? "";
       if (srv) sharedServerNames.add(srv);
     }
@@ -134,7 +143,8 @@ export function buildContextFlowGraph(
   const nodes: Node[] = data.nodes
     .filter((node) => visibleIds.has(node.id))
     .map((n) => {
-    let nodeType = KIND_TO_NODE_TYPE[n.kind] ?? "server";
+    const graphKind = n.entity_type ?? n.kind;
+    let nodeType = KIND_TO_NODE_TYPE[graphKind] ?? "server";
     if (n.kind === "server" && sharedServerNames.has(n.label)) {
       nodeType = "sharedServer";
     }
@@ -169,7 +179,8 @@ export function buildContextFlowGraph(
     .filter((edge) => visibleIds.has(edge.source) && visibleIds.has(edge.target))
     .map((e, i) => {
     const isOnPath = pathEdgePairs.has(`${e.source}→${e.target}`);
-    const baseColor = EDGE_COLORS[e.kind] ?? "#52525b";
+    const relationship = e.relationship ?? e.kind;
+    const baseColor = EDGE_COLORS[relationship] ?? "#52525b";
     const reachScore = readReachScore(e.metadata?.effective_reach_score);
     const reachColor = reachStrokeColor(reachScore);
     const strokeColor = isOnPath ? "#f97316" : reachColor ?? baseColor;
@@ -192,9 +203,9 @@ export function buildContextFlowGraph(
           width: 12,
           height: 12,
         },
-        label: e.kind === "shares_server"
+        label: relationship === "shares_server"
           ? `shared: ${(e.metadata?.server as string) ?? ""}`
-          : e.kind === "shares_credential"
+          : relationship === "shares_credential" || relationship === "shares_cred"
           ? `shared: ${(e.metadata?.credential as string) ?? ""}`
           : undefined,
         labelStyle: { fontSize: 9, fill: "#71717a" },

--- a/ui/tests/context-graph.test.ts
+++ b/ui/tests/context-graph.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { buildContextFlowGraph, type ContextGraphData } from "@/lib/context-graph";
+
+describe("buildContextFlowGraph", () => {
+  it("prefers canonical entity and relationship fields when present", () => {
+    const data: ContextGraphData = {
+      nodes: [
+        {
+          id: "iam_role:prod",
+          kind: "iam_role",
+          entity_type: "service_account",
+          label: "prod-role",
+          metadata: {},
+        },
+        {
+          id: "agent:desktop",
+          kind: "agent",
+          entity_type: "agent",
+          label: "desktop",
+          metadata: {},
+        },
+      ],
+      edges: [
+        {
+          source: "iam_role:prod",
+          target: "agent:desktop",
+          kind: "attached_to",
+          relationship: "member_of",
+          weight: 1,
+          metadata: {},
+        },
+      ],
+      lateral_paths: [],
+      interaction_risks: [],
+      stats: {
+        total_nodes: 2,
+        total_edges: 1,
+        agent_count: 1,
+        shared_server_count: 0,
+        shared_credential_count: 0,
+        lateral_path_count: 0,
+        max_lateral_depth: 0,
+        highest_path_risk: 0,
+        interaction_risk_count: 0,
+      },
+    };
+
+    const graph = buildContextFlowGraph(data);
+
+    expect(graph.nodes.find((node) => node.id === "iam_role:prod")?.type).toBe("serviceAccount");
+    expect(graph.edges[0]?.style?.stroke).toBe("#60a5fa");
+  });
+});


### PR DESCRIPTION
Summary
- adds canonical `entity_type` and `relationship` fields to Context Map API payloads while preserving legacy `kind` fields
- teaches the Context Map UI to prefer canonical graph fields for service accounts and relationship colors
- fixes SQLite graph traversal budgets so incoming-only incident edges do not consume a forward traversal edge budget
- adds Python and UI regressions for both behaviors

Validation
- uv run pytest -q tests/test_graph_api.py tests/test_context_graph.py
- cd ui && npm test -- --run tests/context-graph.test.ts
- uv run ruff check src/agent_bom/api/graph_store.py src/agent_bom/context_graph.py tests/test_graph_api.py tests/test_context_graph.py
- cd ui && npm run lint -- lib/context-graph.ts tests/context-graph.test.ts
- cd ui && npm run typecheck
- git diff --check