### PR TITLE
image: enrich native Debian CVE severity

### DIFF
--- a/src/agent_bom/db/sync.py
+++ b/src/agent_bom/db/sync.py
@@ -147,6 +147,8 @@ _CVSS_SEVERITY = {
     (4.0, 6.9): "medium",
     (0.1, 3.9): "low",
 }
+_CVE_ID_RE = re.compile(r"^CVE-\d{4}-\d{4,}$", re.IGNORECASE)
+_DEBIAN_CVE_ID_RE = re.compile(r"^DEBIAN-(CVE-\d{4}-\d{4,})$", re.IGNORECASE)
 
 
 def _cvss_to_severity(score: Optional[float]) -> str:
@@ -158,6 +160,25 @@ def _cvss_to_severity(score: Optional[float]) -> str:
         if lo <= score <= hi:
             return sev
     return "unknown"
+
+
+def _nvd_cve_candidates(vuln_id: str, raw_aliases: str = "") -> list[str]:
+    """Return canonical CVE IDs that NVD can resolve for a local DB row."""
+
+    candidates: list[str] = []
+
+    def add(value: Any) -> None:
+        candidate = str(value or "").strip().upper()
+        debian_match = _DEBIAN_CVE_ID_RE.match(candidate)
+        if debian_match:
+            candidate = debian_match.group(1)
+        if _CVE_ID_RE.match(candidate) and candidate not in candidates:
+            candidates.append(candidate)
+
+    add(vuln_id)
+    for alias in (raw_aliases or "").split(","):
+        add(alias)
+    return candidates
 
 
 def _normalize_sync_cvss_score(value: Any) -> Optional[float]:
@@ -976,8 +997,10 @@ def sync_nvd(
 ) -> int:
     """Enrich local DB entries missing CVSS data using the NVD API.
 
-    Queries the DB for CVEs with unknown severity, then fetches CVSS v3.1
-    data from NVD and updates the ``vulns`` table in-place.
+    Queries the DB for CVE-backed rows with unknown severity, then fetches
+    CVSS v3.1 data from NVD and updates the ``vulns`` table in-place. Distro
+    advisory rows such as ``DEBIAN-CVE-*`` are resolved through their embedded
+    or aliased canonical CVE ID so native image scans do not stay unknown.
 
     Rate limiting:
         - Without key: 5 requests / 30s (sleep 6s between requests)
@@ -1004,28 +1027,35 @@ def sync_nvd(
     # Rate limit: 5 req/30s without key → 6s between; 50 req/30s with key → 0.6s between
     sleep_seconds = 0.6 if api_key else 6.0
 
-    # Find CVEs in our DB that are missing CVSS data
+    # Find CVE-backed rows in our DB that are missing CVSS data. Some OSV
+    # distro advisories use IDs such as DEBIAN-CVE-2014-6271 but still map to
+    # the canonical CVE in aliases or in the ID suffix.
     rows = conn.execute(
         """
-        SELECT id FROM vulns
+        SELECT id, COALESCE(aliases, '') AS aliases FROM vulns
         WHERE (severity = 'unknown' OR cvss_score IS NULL)
-          AND id LIKE 'CVE-%'
+          AND (id LIKE '%CVE-%' OR aliases LIKE '%CVE-%')
         LIMIT :max_entries
         """,
         {"max_entries": max_entries},
     ).fetchall()
 
-    if not rows:
+    row_targets: list[tuple[str, str]] = []
+    for row in rows:
+        candidates = _nvd_cve_candidates(row["id"], row["aliases"])
+        if candidates:
+            row_targets.append((row["id"], candidates[0]))
+
+    if not row_targets:
         _logger.info("NVD enrichment: no CVEs missing CVSS data — nothing to do")
         _update_sync_meta(conn, "nvd", 0)
         return 0
 
-    cve_ids = [row[0] for row in rows]
-    _logger.info("NVD enrichment: fetching CVSS data for %d CVEs …", len(cve_ids))
+    _logger.info("NVD enrichment: fetching CVSS data for %d CVE-backed rows …", len(row_targets))
 
     enriched = 0
 
-    for cve_id in cve_ids:
+    for row_id, cve_id in row_targets:
         params = {"cveId": cve_id}
         if api_key:
             params["apiKey"] = api_key
@@ -1085,7 +1115,7 @@ def sync_nvd(
 
         # Merge NVD CWE IDs with any existing ones (from OSV/GHSA)
         if nvd_cwes:
-            existing_cwes_raw = conn.execute("SELECT cwe_ids FROM vulns WHERE id=?", (cve_id,)).fetchone()
+            existing_cwes_raw = conn.execute("SELECT cwe_ids FROM vulns WHERE id=?", (row_id,)).fetchone()
             existing_cwes = set((existing_cwes_raw[0] or "").split(",")) if existing_cwes_raw and existing_cwes_raw[0] else set()
             existing_cwes.discard("")
             merged = list(existing_cwes | set(nvd_cwes))
@@ -1097,17 +1127,17 @@ def sync_nvd(
             if merged_str is not None:
                 conn.execute(
                     "UPDATE vulns SET cvss_score=?, cvss_vector=?, severity=?, cwe_ids=? WHERE id=?",
-                    (cvss_score, cvss_vector, severity, merged_str, cve_id),
+                    (cvss_score, cvss_vector, severity, merged_str, row_id),
                 )
             else:
                 conn.execute(
                     "UPDATE vulns SET cvss_score=?, cvss_vector=?, severity=? WHERE id=?",
-                    (cvss_score, cvss_vector, severity, cve_id),
+                    (cvss_score, cvss_vector, severity, row_id),
                 )
         elif merged_str is not None:
             conn.execute(
                 "UPDATE vulns SET cwe_ids=? WHERE id=?",
-                (merged_str, cve_id),
+                (merged_str, row_id),
             )
         enriched += 1
 

--- a/tests/test_cwe_enrichment.py
+++ b/tests/test_cwe_enrichment.py
@@ -410,6 +410,56 @@ def test_sync_nvd_stores_cwe_ids() -> None:
     assert cwes == {"CWE-79", "CWE-89"}
 
 
+def test_sync_nvd_derives_canonical_cve_for_debian_advisory() -> None:
+    """DEBIAN-CVE rows should inherit NVD CVSS from the canonical CVE ID."""
+    conn = _make_conn()
+    _insert_vuln(conn, "DEBIAN-CVE-2014-6271", severity="unknown")
+    requested: list[str] = []
+
+    def fetch_json(url: str, *, timeout: int = 30, headers: dict | None = None):
+        from urllib.parse import parse_qs, urlparse
+
+        cve_id = parse_qs(urlparse(url).query).get("cveId", [""])[0]
+        requested.append(cve_id)
+        return json.loads(_nvd_response_with_cwes(cve_id, score=9.8, severity="CRITICAL", cwes=["CWE-78"]))
+
+    with patch("agent_bom.http_client.fetch_json", side_effect=fetch_json):
+        with patch("time.sleep"):
+            count = sync_nvd(conn, url="https://services.nvd.nist.gov/rest/json/cves/2.0", max_entries=10)
+
+    assert count == 1
+    assert requested == ["CVE-2014-6271"]
+    row = conn.execute("SELECT severity, cvss_score, cwe_ids FROM vulns WHERE id = 'DEBIAN-CVE-2014-6271'").fetchone()
+    assert row["severity"] == "critical"
+    assert row["cvss_score"] == pytest.approx(9.8)
+    assert row["cwe_ids"] == "CWE-78"
+
+
+def test_sync_nvd_uses_cve_alias_for_non_cve_advisory() -> None:
+    conn = _make_conn()
+    _insert_vuln(conn, "OSV-2026-0001", severity="unknown")
+    conn.execute("UPDATE vulns SET aliases='CVE-2026-99010' WHERE id='OSV-2026-0001'")
+    conn.commit()
+    requested: list[str] = []
+
+    def fetch_json(url: str, *, timeout: int = 30, headers: dict | None = None):
+        from urllib.parse import parse_qs, urlparse
+
+        cve_id = parse_qs(urlparse(url).query).get("cveId", [""])[0]
+        requested.append(cve_id)
+        return json.loads(_nvd_response_with_cwes(cve_id, score=7.5, severity="HIGH", cwes=[]))
+
+    with patch("agent_bom.http_client.fetch_json", side_effect=fetch_json):
+        with patch("time.sleep"):
+            count = sync_nvd(conn, url="https://services.nvd.nist.gov/rest/json/cves/2.0", max_entries=10)
+
+    assert count == 1
+    assert requested == ["CVE-2026-99010"]
+    row = conn.execute("SELECT severity, cvss_score FROM vulns WHERE id = 'OSV-2026-0001'").fetchone()
+    assert row["severity"] == "high"
+    assert row["cvss_score"] == pytest.approx(7.5)
+
+
 def test_sync_nvd_merges_cwe_ids_with_existing() -> None:
     """NVD CWE IDs should be merged with existing ones from OSV/GHSA."""
     conn = _make_conn()


### PR DESCRIPTION
Summary
- resolves local DB NVD enrichment for CVE-backed distro advisories such as DEBIAN-CVE-* instead of only primary CVE-* rows
- derives the canonical CVE from DEBIAN-CVE-* IDs or CVE aliases and writes the CVSS/severity/CWE data back to the original advisory row
- adds regressions for native Debian advisory enrichment and non-CVE advisory alias enrichment

Validation
- uv run pytest -q tests/test_cwe_enrichment.py tests/test_local_vuln_db.py tests/test_scanners.py
- uv run ruff check src/agent_bom/db/sync.py tests/test_cwe_enrichment.py
- uv run mypy src/agent_bom/db/sync.py
- git diff --check