### PR TITLE
api: bound release safety controls

### DIFF
--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -1275,13 +1275,35 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                 reset_current_tenant(tenant_token)
 
 
+DEFAULT_SCAN_RATE_LIMIT_RPM = 600
+DEFAULT_READ_RATE_LIMIT_RPM = DEFAULT_SCAN_RATE_LIMIT_RPM * 5
+MAX_RATE_LIMIT_RPM = 60_000
+
+
+def _validate_rate_limit(name: str, value: int, *, max_rpm: int) -> int:
+    try:
+        rpm = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if rpm < 1:
+        raise ValueError(f"{name} must be at least 1")
+    if rpm > max_rpm:
+        raise ValueError(f"{name} must be <= {max_rpm}")
+    return rpm
+
+
 class RateLimitMiddleware(BaseHTTPMiddleware):
     """Tenant-aware sliding window rate limiter with bounded memory."""
 
-    def __init__(self, app: ASGIApp, scan_rpm: int = 60, read_rpm: int = 300):
+    def __init__(
+        self,
+        app: ASGIApp,
+        scan_rpm: int = DEFAULT_SCAN_RATE_LIMIT_RPM,
+        read_rpm: int = DEFAULT_READ_RATE_LIMIT_RPM,
+    ):
         super().__init__(app)
-        self._scan_rpm = scan_rpm
-        self._read_rpm = read_rpm
+        self._scan_rpm = _validate_rate_limit("scan_rpm", scan_rpm, max_rpm=MAX_RATE_LIMIT_RPM)
+        self._read_rpm = _validate_rate_limit("read_rpm", read_rpm, max_rpm=MAX_RATE_LIMIT_RPM * 5)
         self._window = 60
         self._store = self._build_store()
 

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -876,8 +876,8 @@ async def list_audit_entries(
     action: str | None = None,
     resource: str | None = None,
     since: str | None = None,
-    limit: int = 100,
-    offset: int = 0,
+    limit: Annotated[int, Query(ge=1, le=1000)] = 100,
+    offset: Annotated[int, Query(ge=0)] = 0,
 ) -> dict:
     """List audit log entries with optional filters."""
     from agent_bom.api.audit_log import get_audit_log
@@ -888,11 +888,13 @@ async def list_audit_entries(
     return {
         "entries": [e.to_dict() for e in entries],
         "total": store.count(action=action, tenant_id=tenant_id),
+        "limit": limit,
+        "offset": offset,
     }
 
 
 @router.get("/v1/audit/integrity", tags=["enterprise"])
-async def audit_integrity(request: Request, limit: int = 1000) -> dict:
+async def audit_integrity(request: Request, limit: Annotated[int, Query(ge=1, le=10_000)] = 1000) -> dict:
     """Verify HMAC integrity of audit log entries."""
     from agent_bom.api.audit_log import get_audit_log
 
@@ -907,8 +909,8 @@ async def export_audit_entries(
     action: str | None = None,
     resource: str | None = None,
     since: str | None = None,
-    limit: int = 1000,
-    offset: int = 0,
+    limit: Annotated[int, Query(ge=1, le=10_000)] = 1000,
+    offset: Annotated[int, Query(ge=0)] = 0,
     format: str = "json",
 ):
     """Export audit entries as a signed evidence packet."""

--- a/src/agent_bom/api/routes/gateway.py
+++ b/src/agent_bom/api/routes/gateway.py
@@ -23,7 +23,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, Response
 
 from agent_bom.api.models import EvaluateRequest, JobStatus, PolicyCreate, PolicyUpdate
@@ -405,7 +405,7 @@ async def list_gateway_audit(
     request: Request,
     policy_id: str | None = None,
     agent_name: str | None = None,
-    limit: int = 100,
+    limit: int = Query(100, ge=1, le=1000),
 ):
     """Query the gateway policy audit log."""
     tenant_id = getattr(request.state, "tenant_id", "default")

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -24,6 +24,8 @@ from agent_bom.api import stores as _stores
 from agent_bom.api.audit_log import get_audit_log
 from agent_bom.api.auth import Role, create_api_key_record, get_key_store
 from agent_bom.api.middleware import (
+    DEFAULT_SCAN_RATE_LIMIT_RPM,
+    MAX_RATE_LIMIT_RPM,
     APIKeyMiddleware,
     MaxBodySizeMiddleware,
     RateLimitMiddleware,
@@ -481,7 +483,8 @@ _default_origins = [
 _cors_env = os.environ.get("CORS_ORIGINS")
 _cors_origins: list[str] = [o.strip() for o in _cors_env.split(",") if o.strip()] if _cors_env else _default_origins
 _api_key: str | None = None
-_rate_limit_rpm: int = 60
+DEFAULT_RATE_LIMIT_RPM = DEFAULT_SCAN_RATE_LIMIT_RPM
+_rate_limit_rpm: int = DEFAULT_RATE_LIMIT_RPM
 _env_api_keys_seeded = False
 
 
@@ -544,6 +547,18 @@ def _replace_middleware(middleware_cls: object, /, **kwargs: object) -> None:
     app.user_middleware.insert(0, Middleware(cast(Any, middleware_cls), **kwargs))
 
 
+def _validated_rate_limit_rpm(value: int) -> int:
+    try:
+        rpm = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("rate_limit_rpm must be an integer") from exc
+    if rpm < 1:
+        raise ValueError("rate_limit_rpm must be at least 1")
+    if rpm > MAX_RATE_LIMIT_RPM:
+        raise ValueError(f"rate_limit_rpm must be <= {MAX_RATE_LIMIT_RPM}")
+    return rpm
+
+
 # CORS: defaults to localhost; configure via configure_api() before startup
 _apply_cors_middleware(_cors_origins)
 
@@ -558,13 +573,15 @@ def configure_api(
     cors_origins: list[str] | None = None,
     cors_allow_all: bool = False,
     api_key: str | None = None,
-    rate_limit_rpm: int = 60,
+    rate_limit_rpm: int = DEFAULT_RATE_LIMIT_RPM,
 ) -> None:
     """Configure API hardening before server startup.
 
     Call this before uvicorn.run() to set CORS, auth, and rate limiting.
     """
     global _cors_origins, _api_key, _rate_limit_rpm
+
+    validated_rate_limit_rpm = _validated_rate_limit_rpm(rate_limit_rpm)
 
     if cors_allow_all:
         _cors_origins = ["*"]
@@ -574,7 +591,7 @@ def configure_api(
     _apply_cors_middleware(_cors_origins)
 
     _api_key = api_key
-    _rate_limit_rpm = rate_limit_rpm
+    _rate_limit_rpm = validated_rate_limit_rpm
 
     env_key_store_configured = _seed_api_key_store_from_env()
 
@@ -602,7 +619,7 @@ def configure_api(
     # Refresh runtime-configurable middleware. _replace_middleware inserts at
     # the front; this call order keeps body-size outermost, auth before rate
     # limiting, and rate limiting able to read tenant/auth state.
-    _replace_middleware(RateLimitMiddleware, scan_rpm=rate_limit_rpm, read_rpm=rate_limit_rpm * 5)
+    _replace_middleware(RateLimitMiddleware, scan_rpm=_rate_limit_rpm, read_rpm=_rate_limit_rpm * 5)
     if auth_required:
         _replace_middleware(APIKeyMiddleware, api_key=api_key)
     else:
@@ -633,7 +650,7 @@ def configure_api_from_env() -> None:
         cors_origins=origins,
         cors_allow_all=allow_all,
         api_key=api_key,
-        rate_limit_rpm=60,
+        rate_limit_rpm=DEFAULT_RATE_LIMIT_RPM,
     )
 
 

--- a/src/agent_bom/audit_integrity.py
+++ b/src/agent_bom/audit_integrity.py
@@ -3,19 +3,42 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
+import secrets
 from typing import Any
 
 from cryptography.hazmat.primitives.ciphers import algorithms
 from cryptography.hazmat.primitives.cmac import CMAC
 
-_AUDIT_CHAIN_FALLBACK_KEY = b"agent-bom-audit-chain-v1"
+_logger = logging.getLogger(__name__)
+_AUDIT_CHAIN_EPHEMERAL_KEY: bytes | None = None
+
+
+def _env_truthy(name: str) -> bool:
+    return (os.environ.get(name) or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def audit_chain_key() -> bytes:
-    """Return the operator HMAC key, or a deterministic local fallback."""
+    """Return the operator audit-chain key.
+
+    Development runs may use a per-process ephemeral key, but production can
+    opt into fail-closed startup with AGENT_BOM_REQUIRE_AUDIT_HMAC=1.
+    """
+    global _AUDIT_CHAIN_EPHEMERAL_KEY
+
     configured = (os.environ.get("AGENT_BOM_AUDIT_HMAC_KEY") or "").strip()
-    return configured.encode("utf-8") if configured else _AUDIT_CHAIN_FALLBACK_KEY
+    if configured:
+        return configured.encode("utf-8")
+    if _env_truthy("AGENT_BOM_REQUIRE_AUDIT_HMAC"):
+        raise RuntimeError("AGENT_BOM_REQUIRE_AUDIT_HMAC is enabled but AGENT_BOM_AUDIT_HMAC_KEY is not set")
+    if _AUDIT_CHAIN_EPHEMERAL_KEY is None:
+        _AUDIT_CHAIN_EPHEMERAL_KEY = secrets.token_bytes(32)
+        _logger.warning(
+            "AGENT_BOM_AUDIT_HMAC_KEY not set — audit-chain CMAC uses an ephemeral key "
+            "(signatures will not survive process restart; set env var for production)"
+        )
+    return _AUDIT_CHAIN_EPHEMERAL_KEY
 
 
 def _audit_chain_cmac_key() -> bytes:

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -446,9 +446,9 @@ def serve_cmd(
 @click.option(
     "--rate-limit",
     "rate_limit_rpm",
-    default=60,
+    default=600,
     show_default=True,
-    type=int,
+    type=click.IntRange(1, 60_000),
     metavar="RPM",
     help="Rate limit for scan endpoints (requests/minute per IP).",
 )

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -23,6 +23,8 @@ from agent_bom.api.browser_session import (
 from agent_bom.api.middleware import InMemoryRateLimitStore
 from agent_bom.api.oidc import OIDCConfig
 from agent_bom.api.server import (
+    DEFAULT_RATE_LIMIT_RPM,
+    MAX_RATE_LIMIT_RPM,
     APIKeyMiddleware,
     MaxBodySizeMiddleware,
     RateLimitMiddleware,
@@ -212,6 +214,31 @@ def test_configure_api_refreshes_cors_policy():
     resp = client.get("/health", headers={"Origin": "http://127.0.0.1:3001"})
     assert resp.status_code == 200
     assert resp.headers.get("access-control-allow-origin") is None
+
+
+def test_configure_api_defaults_to_release_safe_rate_limit():
+    """The packaged API should not default to a tiny demo-only rate limit."""
+    configure_api(api_key=None)
+    rate_limit = next(m for m in app.user_middleware if m.cls is RateLimitMiddleware)
+    assert rate_limit.kwargs["scan_rpm"] == DEFAULT_RATE_LIMIT_RPM
+    assert rate_limit.kwargs["read_rpm"] == DEFAULT_RATE_LIMIT_RPM * 5
+
+
+@pytest.mark.parametrize("value", [0, -1, MAX_RATE_LIMIT_RPM + 1])
+def test_configure_api_rejects_invalid_rate_limit(value: int):
+    """Invalid operator-provided rate limits should fail at configuration time."""
+    with pytest.raises(ValueError):
+        configure_api(api_key=None, rate_limit_rpm=value)
+
+
+def test_rate_limit_middleware_rejects_invalid_limits():
+    """Direct middleware use should get the same bounded operator inputs."""
+    from starlette.applications import Starlette
+
+    with pytest.raises(ValueError):
+        RateLimitMiddleware(Starlette(), scan_rpm=0)
+    with pytest.raises(ValueError):
+        RateLimitMiddleware(Starlette(), read_rpm=MAX_RATE_LIMIT_RPM * 5 + 1)
 
 
 def test_api_key_middleware_blocks_without_key():
@@ -1044,6 +1071,18 @@ def test_rate_limit_middleware():
     resp = client.post("/v1/scan")
     assert resp.status_code == 429
     assert "Retry-After" in resp.headers
+
+
+def test_audit_and_gateway_limits_are_validated():
+    """High-volume audit surfaces must reject invalid limits instead of forwarding them."""
+    configure_api(api_key=None, rate_limit_rpm=1000)
+    client = TestClient(app)
+
+    assert client.get("/v1/audit?limit=0").status_code == 422
+    assert client.get("/v1/audit?limit=1001").status_code == 422
+    assert client.get("/v1/audit/integrity?limit=0").status_code == 422
+    assert client.get("/v1/audit/export?limit=10001").status_code == 422
+    assert client.get("/v1/gateway/audit?limit=1001").status_code == 422
 
 
 def test_rate_limit_middleware_uses_postgres_store_when_available(monkeypatch):

--- a/tests/test_audit_replay.py
+++ b/tests/test_audit_replay.py
@@ -6,6 +6,9 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
+
+from agent_bom import audit_integrity
 from agent_bom.audit_integrity import compute_audit_record_mac
 from agent_bom.audit_replay import (
     AlertEntry,
@@ -116,6 +119,28 @@ PROXY_SUMMARY = {
     "blocked_runtime_alerts": 0,
     "latest_runtime_alert_at": "2026-03-09T10:00:02.000000+00:00",
 }
+
+
+def test_audit_chain_key_uses_ephemeral_fallback(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_AUDIT_HMAC_KEY", raising=False)
+    monkeypatch.delenv("AGENT_BOM_REQUIRE_AUDIT_HMAC", raising=False)
+    monkeypatch.setattr(audit_integrity, "_AUDIT_CHAIN_EPHEMERAL_KEY", None)
+
+    first = audit_integrity.audit_chain_key()
+    second = audit_integrity.audit_chain_key()
+
+    assert first == second
+    assert len(first) == 32
+    assert first != b"agent-bom-audit-chain-v1"
+
+
+def test_audit_chain_key_can_fail_closed(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_AUDIT_HMAC_KEY", raising=False)
+    monkeypatch.setenv("AGENT_BOM_REQUIRE_AUDIT_HMAC", "1")
+    monkeypatch.setattr(audit_integrity, "_AUDIT_CHAIN_EPHEMERAL_KEY", None)
+
+    with pytest.raises(RuntimeError, match="AGENT_BOM_REQUIRE_AUDIT_HMAC"):
+        audit_integrity.audit_chain_key()
 
 
 # ── parse_audit_log ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- raises the packaged API scan rate-limit default to 600 RPM and keeps read traffic at 5x that budget
- validates configured API and direct middleware rate limits instead of accepting zero, negative, or unbounded values
- bounds audit and gateway audit pagination with FastAPI validation
- replaces the deterministic audit-chain fallback key with a per-process ephemeral key, plus fail-closed mode via AGENT_BOM_REQUIRE_AUDIT_HMAC=1

## Validation
- uv run pytest -q tests/test_api_hardening.py tests/test_audit_replay.py tests/test_rate_limit_headers.py tests/test_api_operator_policy.py
- uv run ruff check src/agent_bom/audit_integrity.py src/agent_bom/api/server.py src/agent_bom/api/middleware.py src/agent_bom/api/routes/enterprise.py src/agent_bom/api/routes/gateway.py src/agent_bom/cli/_server.py tests/test_api_hardening.py tests/test_audit_replay.py
- uv run mypy src/agent_bom/audit_integrity.py src/agent_bom/api/server.py src/agent_bom/api/middleware.py src/agent_bom/api/routes/enterprise.py src/agent_bom/api/routes/gateway.py src/agent_bom/cli/_server.py
- git diff --check
