### PR TITLE
cli: align output paths with format

### DIFF
--- a/src/agent_bom/cli/_profiles.py
+++ b/src/agent_bom/cli/_profiles.py
@@ -170,9 +170,21 @@ def apply_scan_profile_defaults(
         return output, output_format, preset, nvd_api_key, push_url, push_api_key, clickhouse_url
     apply_profile_environment(profile)
     ctx = click.get_current_context(silent=True)
+    output_source = ctx.get_parameter_source("output") if ctx is not None else None
+    format_source = ctx.get_parameter_source("output_format") if ctx is not None else None
+    explicit_output = output_source in {click.core.ParameterSource.COMMANDLINE, click.core.ParameterSource.ENVIRONMENT}
+    explicit_format = format_source in {click.core.ParameterSource.COMMANDLINE, click.core.ParameterSource.ENVIRONMENT}
+
+    profile_output = output if explicit_format and not explicit_output else profile_default(ctx, profile, "output", output, "output")
+    profile_format = (
+        output_format
+        if explicit_output and not explicit_format
+        else profile_default(ctx, profile, "output_format", output_format, "format", "output_format")
+    )
+
     return (
-        profile_default(ctx, profile, "output", output, "output"),
-        profile_default(ctx, profile, "output_format", output_format, "format", "output_format"),
+        profile_output,
+        profile_format,
         profile_default(ctx, profile, "preset", preset, "preset"),
         profile_env_default(ctx, profile, "nvd_api_key", nvd_api_key, "nvd_api_key_env"),
         profile_default(ctx, profile, "push_url", push_url, "push_url"),

--- a/src/agent_bom/cli/agents/_output.py
+++ b/src/agent_bom/cli/agents/_output.py
@@ -51,6 +51,50 @@ from agent_bom.output import (
     to_spdx,
 )
 
+_FORMAT_OUTPUT_RULES: dict[str, tuple[str, tuple[str, ...]]] = {
+    "json": ("agent-bom-report.json", (".json",)),
+    "cyclonedx": ("agent-bom.cdx.json", (".cdx.json", ".json")),
+    "sarif": ("agent-bom.sarif", (".sarif", ".sarif.json")),
+    "spdx": ("agent-bom.spdx.json", (".spdx.json", ".json")),
+    "junit": ("agent-bom-results.xml", (".xml",)),
+    "csv": ("agent-bom-results.csv", (".csv",)),
+    "markdown": ("agent-bom-report.md", (".md", ".markdown")),
+    "html": ("agent-bom-report.html", (".html", ".htm")),
+    "pdf": ("agent-bom-report.pdf", (".pdf",)),
+    "prometheus": ("agent-bom-metrics.prom", (".prom", ".txt")),
+    "graph": ("agent-bom-graph.json", (".json",)),
+    "mermaid": ("agent-bom-diagram.mmd", (".mmd", ".md")),
+    "svg": ("agent-bom-supply-chain.svg", (".svg",)),
+    "graph-html": ("agent-bom-graph.html", (".html", ".htm")),
+    "badge": ("agent-bom-badge.json", (".json",)),
+    "plain": ("agent-bom-report.txt", (".txt", ".text", ".log")),
+    "text": ("agent-bom-report.txt", (".txt", ".text", ".log")),
+}
+
+
+def _resolve_output_path(output: Any, output_format: str) -> str:
+    """Return an output path whose suffix matches the selected format."""
+    default_name, allowed_suffixes = _FORMAT_OUTPUT_RULES[output_format]
+    if not output:
+        return default_name
+
+    raw_path = str(output)
+    lower_path = raw_path.lower()
+    if any(lower_path.endswith(suffix) for suffix in allowed_suffixes):
+        return raw_path
+
+    path = Path(raw_path)
+    if not path.suffix:
+        default_suffix = "".join(Path(default_name).suffixes)
+        return f"{raw_path}{default_suffix}"
+
+    suffix_list = ", ".join(allowed_suffixes)
+    click.echo(
+        f"--format {output_format} cannot write to '{raw_path}' because the file extension does not match. Use one of: {suffix_list}.",
+        err=True,
+    )
+    raise SystemExit(2)
+
 
 def render_output(
     ctx: ScanContext,
@@ -206,37 +250,37 @@ def render_output(
     elif output_format in ("text", "plain") and not output:
         _print_text(report, blast_radii)
     elif output_format == "json":
-        out_path = output or "agent-bom-report.json"
+        out_path = _resolve_output_path(output, output_format)
         export_json(report, out_path)
         con.print(f"\n  [green]✓[/green] JSON report: {out_path}")
     elif output_format == "cyclonedx":
-        out_path = output or "agent-bom.cdx.json"
+        out_path = _resolve_output_path(output, output_format)
         export_cyclonedx(report, out_path)
         con.print(f"\n  [green]✓[/green] CycloneDX BOM: {out_path}")
     elif output_format == "sarif":
-        out_path = output or "agent-bom.sarif"
+        out_path = _resolve_output_path(output, output_format)
         export_sarif(report, out_path, exclude_unfixable=exclude_unfixable)
         con.print(f"\n  [green]✓[/green] SARIF report: {out_path}")
         if not quiet:
             con.print("  [dim]SARIF includes enrichment context when available: CVSS/CWE, EPSS, and CISA KEV.[/dim]")
     elif output_format == "spdx":
-        out_path = output or "agent-bom.spdx.json"
+        out_path = _resolve_output_path(output, output_format)
         export_spdx(report, out_path)
         con.print(f"\n  [green]✓[/green] SPDX 3.0 BOM: {out_path}")
     elif output_format == "junit":
-        out_path = output or "agent-bom-results.xml"
+        out_path = _resolve_output_path(output, output_format)
         export_junit(report, out_path, blast_radii)
         con.print(f"\n  [green]✓[/green] JUnit XML: {out_path}")
     elif output_format == "csv":
-        out_path = output or "agent-bom-results.csv"
+        out_path = _resolve_output_path(output, output_format)
         export_csv(report, out_path, blast_radii)
         con.print(f"\n  [green]✓[/green] CSV report: {out_path}")
     elif output_format == "markdown":
-        out_path = output or "agent-bom-report.md"
+        out_path = _resolve_output_path(output, output_format)
         export_markdown(report, out_path, blast_radii)
         con.print(f"\n  [green]✓[/green] Markdown report: {out_path}")
     elif output_format == "html":
-        out_path = output or "agent-bom-report.html"
+        out_path = _resolve_output_path(output, output_format)
         export_html(report, out_path, blast_radii)
         con.print(f"\n  [green]✓[/green] HTML report: {out_path}")
         if open_report:
@@ -247,24 +291,24 @@ def render_output(
         else:
             con.print(f"  [dim]Open with:[/dim] open {out_path}")
     elif output_format == "pdf":
-        out_path = output or "agent-bom-report.pdf"
+        out_path = _resolve_output_path(output, output_format)
         export_pdf(report, out_path, blast_radii)
         con.print(f"\n  [green]✓[/green] PDF report: {out_path}")
     elif output_format == "prometheus":
-        out_path = output or "agent-bom-metrics.prom"
+        out_path = _resolve_output_path(output, output_format)
         export_prometheus(report, out_path, blast_radii)
         con.print(f"\n  [green]✓[/green] Prometheus metrics: {out_path}")
         con.print("  [dim]Scrape with node_exporter textfile or push via --push-gateway[/dim]")
     elif output_format == "graph":
         from agent_bom.output.graph import build_graph_elements
 
-        out_path = output or "agent-bom-graph.json"
+        out_path = _resolve_output_path(output, output_format)
         elements = build_graph_elements(report, blast_radii)
         Path(out_path).write_text(json.dumps({"elements": elements, "format": "cytoscape"}, indent=2))
         con.print(f"\n  [green]✓[/green] Graph JSON: {out_path}")
         con.print("  [dim]Cytoscape.js-compatible element list — open with Cytoscape desktop or any JS graph library[/dim]")
     elif output_format == "mermaid":
-        out_path = output or "agent-bom-diagram.mmd"
+        out_path = _resolve_output_path(output, output_format)
         if mermaid_mode == "attack-flow":
             from agent_bom.output.mermaid import to_mermaid
 
@@ -282,14 +326,14 @@ def render_output(
     elif output_format == "svg":
         from agent_bom.output.svg import export_svg
 
-        out_path = output or "agent-bom-supply-chain.svg"
+        out_path = _resolve_output_path(output, output_format)
         export_svg(report, blast_radii, out_path)
         con.print(f"\n  [green]✓[/green] SVG diagram: {out_path}")
         con.print("  [dim]Open in any browser or image viewer[/dim]")
     elif output_format == "graph-html":
         from agent_bom.output.graph import export_graph_html
 
-        out_path = output or "agent-bom-graph.html"
+        out_path = _resolve_output_path(output, output_format)
         export_graph_html(report, blast_radii, out_path)
         con.print(f"\n  [green]✓[/green] Interactive graph: {out_path}")
         if open_report:
@@ -300,13 +344,14 @@ def render_output(
         else:
             con.print(f"  [dim]Open with:[/dim] open {out_path}")
     elif output_format == "badge":
-        out_path = output or "agent-bom-badge.json"
+        out_path = _resolve_output_path(output, output_format)
         export_badge(report, out_path)
         con.print(f"\n  [green]✓[/green] Badge JSON: {out_path}")
         con.print("  [dim]Use with: https://img.shields.io/endpoint?url=<public-url-to-badge-json>[/dim]")
     elif output_format in ("text", "plain") and output:
-        Path(output).write_text(_format_text(report, blast_radii))
-        con.print(f"\n  [green]✓[/green] Plain text report: {output}")
+        out_path = _resolve_output_path(output, output_format)
+        Path(out_path).write_text(_format_text(report, blast_radii))
+        con.print(f"\n  [green]✓[/green] Plain text report: {out_path}")
     elif output:
         if output.endswith(".cdx.json"):
             export_cyclonedx(report, output)

--- a/tests/test_cli_profiles.py
+++ b/tests/test_cli_profiles.py
@@ -73,6 +73,72 @@ push_api_key_env = "AGENT_BOM_PUSH_TOKEN_PROD"
     assert result.exit_code == 0, result.output
 
 
+def test_scan_profile_output_does_not_shadow_explicit_format(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+current_profile = "prod"
+
+[profiles.prod]
+format = "json"
+output = "profile.json"
+"""
+    )
+    monkeypatch.setenv("AGENT_BOM_CONFIG", str(config_path))
+
+    @click.command()
+    @click.option("--output")
+    @click.option("--format", "output_format", default="console")
+    def _profile_default_test(output: str | None, output_format: str) -> None:
+        values = apply_scan_profile_defaults(
+            output=output,
+            output_format=output_format,
+            preset=None,
+            nvd_api_key=None,
+            push_url=None,
+            push_api_key=None,
+            clickhouse_url=None,
+        )
+        assert values[:2] == (None, "sarif")
+
+    result = CliRunner().invoke(_profile_default_test, ["--format", "sarif"])
+
+    assert result.exit_code == 0, result.output
+
+
+def test_scan_profile_format_does_not_shadow_explicit_output(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+current_profile = "prod"
+
+[profiles.prod]
+format = "json"
+output = "profile.json"
+"""
+    )
+    monkeypatch.setenv("AGENT_BOM_CONFIG", str(config_path))
+
+    @click.command()
+    @click.option("--output")
+    @click.option("--format", "output_format", default="console")
+    def _profile_default_test(output: str | None, output_format: str) -> None:
+        values = apply_scan_profile_defaults(
+            output=output,
+            output_format=output_format,
+            preset=None,
+            nvd_api_key=None,
+            push_url=None,
+            push_api_key=None,
+            clickhouse_url=None,
+        )
+        assert values[:2] == ("report.sarif", "console")
+
+    result = CliRunner().invoke(_profile_default_test, ["--output", "report.sarif"])
+
+    assert result.exit_code == 0, result.output
+
+
 def test_profiles_group_lists_and_switches_current_profile(monkeypatch, tmp_path):
     config_path = tmp_path / "config.toml"
     config_path.write_text(

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -221,6 +221,38 @@ def test_scan_output_to_file(tmp_path):
     assert result.exit_code == 0
 
 
+def test_scan_output_appends_format_extension_for_extensionless_path(tmp_path):
+    """Explicit formats should create artifacts with the expected suffix."""
+    out = tmp_path / "scan-report"
+    expected = tmp_path / "scan-report.sarif"
+    with (
+        patch("agent_bom.cli.agents.scan_agents_sync", return_value=([], [])),
+        patch("agent_bom.cli.agents.resolve_all_versions_sync", return_value=[]),
+    ):
+        result = _run(["scan", "--demo", "--format", "sarif", "--output", str(out), "--no-scan"])
+
+    assert result.exit_code == 0, result.output
+    assert expected.exists()
+    assert not out.exists()
+    assert "SARIF report:" in result.output
+    assert "scan-report.sarif" in result.output
+
+
+def test_scan_output_rejects_mismatched_format_extension(tmp_path):
+    """A selected format should not silently write to a misleading file name."""
+    out = tmp_path / "scan-report.json"
+    with (
+        patch("agent_bom.cli.agents.scan_agents_sync", return_value=([], [])),
+        patch("agent_bom.cli.agents.resolve_all_versions_sync", return_value=[]),
+    ):
+        result = _run(["scan", "--demo", "--format", "sarif", "--output", str(out), "--no-scan"])
+
+    assert result.exit_code == 2
+    assert "--format sarif cannot write" in result.output
+    assert ".sarif" in result.output
+    assert not out.exists()
+
+
 def test_scan_reproducible_pins_report_and_inventory_timestamps(tmp_path):
     inventory = tmp_path / "inventory.json"
     inventory.write_text(


### PR DESCRIPTION
## Summary
- appends the canonical file extension when scan output is extensionless and `--format` is explicit
- rejects misleading output suffixes such as `--format sarif --output report.json` instead of writing the wrong artifact shape silently
- keeps profile defaults from crossing explicit output/format choices, so a profile JSON output path does not override an explicit SARIF/PDF/etc. format

## Validation
- AGENT_BOM_CONFIG=/tmp/agent-bom-no-profile.toml uv run pytest -q tests/test_cli_scan.py tests/test_self_scan.py tests/test_prompt_scanner.py tests/test_browser_extensions.py tests/test_cli_profiles.py
- uv run ruff check src/agent_bom/cli/agents/_output.py src/agent_bom/cli/_profiles.py tests/test_cli_scan.py tests/test_cli_profiles.py
- uv run mypy src/agent_bom/cli/agents/_output.py src/agent_bom/cli/_profiles.py
- git diff --check
