### PR TITLE
ui: derive insights blast radius

### DIFF
--- a/ui/app/insights/page.tsx
+++ b/ui/app/insights/page.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 import {
   api,
   ScanJob,
-  ScanResult,
   Agent,
   BlastRadius,
 } from "@/lib/api";
@@ -15,72 +14,12 @@ import {
   PipelineFlow,
   EpssVsCvssChart,
   VulnTrendChart,
-  type PipelineStats,
-  type EpssVsCvssPoint,
   type TrendDataPoint,
 } from "@/components/charts";
+import { buildEpssVsCvss, buildPipelineStats, effectiveBlastRadius } from "@/lib/insights-risk";
 import { BarChart3, RefreshCw, AlertTriangle } from "lucide-react";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
-
-function buildPipelineStats(result: ScanResult): PipelineStats {
-  let servers = 0;
-  let packages = 0;
-  for (const agent of result.agents) {
-    servers += agent.mcp_servers.length;
-    for (const srv of agent.mcp_servers) {
-      packages += srv.packages.length;
-    }
-  }
-
-  const blasts = result.blast_radius ?? [];
-  let critical = 0;
-  let high = 0;
-  let vulnerabilities = 0;
-  let kev = 0;
-
-  // Deduplicate vuln IDs across all packages
-  const seen = new Set<string>();
-  for (const br of blasts) {
-    if (!seen.has(br.vulnerability_id)) {
-      seen.add(br.vulnerability_id);
-      vulnerabilities++;
-      if (br.severity === "critical") critical++;
-      if (br.severity === "high") high++;
-      if (br.is_kev ?? br.cisa_kev) kev++;
-    }
-  }
-
-  return {
-    agents: result.agents.length,
-    servers,
-    packages,
-    vulnerabilities,
-    critical,
-    high,
-    kev,
-  };
-}
-
-function buildEpssVsCvss(blasts: BlastRadius[]): EpssVsCvssPoint[] {
-  const seen = new Set<string>();
-  const out: EpssVsCvssPoint[] = [];
-  for (const br of blasts) {
-    if (seen.has(br.vulnerability_id)) continue;
-    seen.add(br.vulnerability_id);
-    if (!br.cvss_score && !br.epss_score) continue;
-    out.push({
-      cve: br.vulnerability_id,
-      cvss: br.cvss_score ?? 0,
-      epss: br.epss_score ?? 0,
-      blast: br.risk_score ?? br.blast_score,
-      severity: br.severity ?? "low",
-      kev: !!(br.is_kev ?? br.cisa_kev),
-      package: br.package,
-    });
-  }
-  return out;
-}
 
 function buildTrendData(jobs: ScanJob[]): TrendDataPoint[] {
   return jobs
@@ -155,7 +94,7 @@ export default function InsightsPage() {
   const latest = latestJob;
   const result = latest?.result ?? null;
   const agents: Agent[] = result?.agents ?? [];
-  const blasts = useMemo<BlastRadius[]>(() => result?.blast_radius ?? [], [result]);
+  const blasts = useMemo<BlastRadius[]>(() => effectiveBlastRadius(result), [result]);
 
   const pipelineStats = useMemo(
     () => (result ? buildPipelineStats(result) : null),
@@ -225,21 +164,22 @@ export default function InsightsPage() {
       {/* Pipeline flow — full width */}
       {pipelineStats && <PipelineFlow stats={pipelineStats} />}
 
-      {/* Supply chain treemap — full width; click a package → /vulns */}
-      {agents.length > 0 && (
-        <div>
-          <SupplyChainTreemap
-            agents={agents}
-            onPackageClick={(pkg) => router.push(`/vulns?search=${encodeURIComponent(pkg)}`)}
-          />
-          <p className="text-[10px] text-zinc-700 mt-1 text-right">Click a package to drill down → Vulns</p>
-        </div>
-      )}
+      <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1.15fr)_minmax(340px,0.85fr)] gap-4">
+        {/* Supply chain treemap; click a package → /vulns */}
+        {agents.length > 0 && (
+          <div>
+            <SupplyChainTreemap
+              agents={agents}
+              onPackageClick={(pkg) => router.push(`/vulns?search=${encodeURIComponent(pkg)}`)}
+            />
+            <p className="text-[10px] text-zinc-700 mt-1 text-right">Click a package to drill down → Vulns</p>
+          </div>
+        )}
 
-      {/* 2-col: blast radius radial + EPSS×CVSS scatter */}
-      <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
-        {blasts.length > 0 && <BlastRadiusRadial data={blasts} />}
-        {epssVsCvss.length > 0 && <EpssVsCvssChart data={epssVsCvss} />}
+        <div className="grid gap-4">
+          {blasts.length > 0 && <BlastRadiusRadial data={blasts} />}
+          {epssVsCvss.length > 0 && <EpssVsCvssChart data={epssVsCvss} />}
+        </div>
       </div>
 
       {/* Trend (multi-scan history) — full width */}

--- a/ui/components/charts.tsx
+++ b/ui/components/charts.tsx
@@ -22,6 +22,7 @@ import {
   RadialBar,
 } from "recharts";
 import type { Agent, BlastRadius } from "@/lib/api";
+import { blastPriority } from "@/lib/insights-risk";
 
 // ─── Shared ──────────────────────────────────────────────────────────────────
 
@@ -415,20 +416,22 @@ export function SupplyChainTreemap({
 interface RadialPoint {
   name: string;
   value: number;
+  score: number;
   fill: string;
 }
 
 export function BlastRadiusRadial({ data }: { data: BlastRadius[] }) {
   const top = [...data]
-    .sort((a, b) => b.blast_score - a.blast_score)
+    .sort((a, b) => blastPriority(b) - blastPriority(a))
     .slice(0, 8);
 
   if (top.length === 0) return null;
 
-  const maxScore = top[0]!.blast_score;
+  const maxScore = Math.max(...top.map(blastPriority), 1);
 
   const radialData: RadialPoint[] = top?.map((br) => {
     const sev = br.severity?.toLowerCase() ?? "low";
+    const score = blastPriority(br);
     const fill =
       sev === "critical" ? "#ef4444"
       : sev === "high" ? "#f97316"
@@ -436,7 +439,8 @@ export function BlastRadiusRadial({ data }: { data: BlastRadius[] }) {
       : "#3b82f6";
     return {
       name: br.package ?? br.vulnerability_id,
-      value: Math.round((br.blast_score / Math.max(maxScore, 1)) * 100),
+      value: Math.round((score / maxScore) * 100),
+      score,
       fill,
     };
   });
@@ -445,7 +449,7 @@ export function BlastRadiusRadial({ data }: { data: BlastRadius[] }) {
     <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5 shadow-lg shadow-zinc-950/50">
       <h3 className="text-sm font-semibold text-zinc-300 mb-1">Blast Radius</h3>
       <p className="text-[10px] text-zinc-600 mb-2">
-        Top packages by blast score (relative %)
+        Top reachable or vulnerable packages by relative priority
       </p>
       <div className="h-64">
         <ResponsiveContainer width="100%" height="100%">
@@ -476,7 +480,11 @@ export function BlastRadiusRadial({ data }: { data: BlastRadius[] }) {
                   >
                     <div className="font-mono text-zinc-300 mb-1 truncate max-w-[160px]">{d.name}</div>
                     <div className="flex justify-between gap-4">
-                      <span className="text-zinc-500">Blast %</span>
+                      <span className="text-zinc-500">Priority</span>
+                      <span className="font-mono" style={{ color: d.fill }}>{d.score.toFixed(1)}</span>
+                    </div>
+                    <div className="flex justify-between gap-4">
+                      <span className="text-zinc-500">Relative</span>
                       <span className="font-mono" style={{ color: d.fill }}>{d.value}%</span>
                     </div>
                   </div>
@@ -491,7 +499,7 @@ export function BlastRadiusRadial({ data }: { data: BlastRadius[] }) {
           <div key={d.name} className="flex items-center gap-2 text-[10px]">
             <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: d.fill }} />
             <span className="text-zinc-400 font-mono truncate flex-1">{d.name}</span>
-            <span className="text-zinc-600 font-mono">{d.value}%</span>
+            <span className="text-zinc-600 font-mono">{d.score.toFixed(0)}</span>
           </div>
         ))}
       </div>

--- a/ui/lib/insights-risk.ts
+++ b/ui/lib/insights-risk.ts
@@ -1,0 +1,144 @@
+import type { Agent, BlastRadius, ScanResult, Vulnerability } from "@/lib/api";
+import type { EpssVsCvssPoint, PipelineStats } from "@/components/charts";
+
+const SEVERITY_RANK: Record<string, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+  none: 0,
+};
+
+const SEVERITY_SCORE: Record<string, number> = {
+  critical: 90,
+  high: 70,
+  medium: 45,
+  low: 20,
+  none: 5,
+};
+const DEFAULT_SEVERITY_SCORE = 20;
+
+function normalizeSeverity(severity: string | undefined): string {
+  const normalized = (severity ?? "low").toLowerCase();
+  return normalized === "none" ? "low" : normalized;
+}
+
+function vulnerabilityPriority(vuln: Vulnerability): number {
+  const severity = normalizeSeverity(vuln.severity);
+  const severityScore = SEVERITY_SCORE[severity] ?? DEFAULT_SEVERITY_SCORE;
+  const cvssScore = typeof vuln.cvss_score === "number" ? vuln.cvss_score * 10 : 0;
+  const epssBonus = typeof vuln.epss_score === "number" ? Math.min(15, vuln.epss_score * 15) : 0;
+  const kevBonus = vuln.is_kev ?? vuln.cisa_kev ? 10 : 0;
+  return Math.min(100, Math.max(severityScore, cvssScore) + epssBonus + kevBonus);
+}
+
+export function blastPriority(blast: BlastRadius): number {
+  const raw = typeof blast.risk_score === "number" ? blast.risk_score : blast.blast_score;
+  if (Number.isFinite(raw) && raw > 0) {
+    return raw <= 10 ? raw * 10 : raw;
+  }
+  const severityScore = SEVERITY_SCORE[normalizeSeverity(blast.severity)] ?? DEFAULT_SEVERITY_SCORE;
+  const cvssScore = typeof blast.cvss_score === "number" ? blast.cvss_score * 10 : 0;
+  const epssBonus = typeof blast.epss_score === "number" ? Math.min(15, blast.epss_score * 15) : 0;
+  const kevBonus = blast.is_kev ?? blast.cisa_kev ? 10 : 0;
+  return Math.min(100, Math.max(severityScore, cvssScore) + epssBonus + kevBonus);
+}
+
+export function buildDerivedBlastRadius(agents: Agent[]): BlastRadius[] {
+  const derived: BlastRadius[] = [];
+  for (const agent of agents) {
+    for (const server of agent.mcp_servers ?? []) {
+      for (const pkg of server.packages ?? []) {
+        for (const vuln of pkg.vulnerabilities ?? []) {
+          const score = vulnerabilityPriority(vuln);
+          derived.push({
+            vulnerability_id: vuln.id,
+            severity: normalizeSeverity(vuln.severity),
+            package: pkg.name,
+            ecosystem: pkg.ecosystem,
+            affected_agents: [agent.name],
+            affected_servers: [server.name],
+            exposed_credentials: [],
+            reachable_tools: [],
+            risk_score: score / 10,
+            blast_score: score,
+            cvss_score: vuln.cvss_score,
+            epss_score: vuln.epss_score,
+            is_kev: vuln.is_kev,
+            cisa_kev: vuln.cisa_kev,
+            fixed_version: vuln.fixed_version,
+            attack_vector_summary: "Derived from package vulnerability data because graph blast radius was not populated for this scan.",
+          });
+        }
+      }
+    }
+  }
+  return derived;
+}
+
+export function effectiveBlastRadius(result: ScanResult | null): BlastRadius[] {
+  if (!result) return [];
+  const blasts = result.blast_radius ?? [];
+  return blasts.length > 0 ? blasts : buildDerivedBlastRadius(result.agents ?? []);
+}
+
+export function buildPipelineStats(result: ScanResult): PipelineStats {
+  let servers = 0;
+  let packages = 0;
+  for (const agent of result.agents) {
+    servers += agent.mcp_servers.length;
+    for (const srv of agent.mcp_servers) {
+      packages += srv.packages.length;
+    }
+  }
+
+  const blasts = effectiveBlastRadius(result);
+  let critical = 0;
+  let high = 0;
+  let vulnerabilities = 0;
+  let kev = 0;
+
+  const seen = new Set<string>();
+  for (const br of blasts) {
+    if (seen.has(br.vulnerability_id)) continue;
+    seen.add(br.vulnerability_id);
+    vulnerabilities++;
+    const severity = normalizeSeverity(br.severity);
+    if (severity === "critical") critical++;
+    if (severity === "high") high++;
+    if (br.is_kev ?? br.cisa_kev) kev++;
+  }
+
+  return {
+    agents: result.agents.length,
+    servers,
+    packages,
+    vulnerabilities,
+    critical,
+    high,
+    kev,
+  };
+}
+
+export function buildEpssVsCvss(blasts: BlastRadius[]): EpssVsCvssPoint[] {
+  const seen = new Set<string>();
+  const out: EpssVsCvssPoint[] = [];
+  for (const br of blasts) {
+    if (seen.has(br.vulnerability_id)) continue;
+    seen.add(br.vulnerability_id);
+    if (!br.cvss_score && !br.epss_score) continue;
+    out.push({
+      cve: br.vulnerability_id,
+      cvss: br.cvss_score ?? 0,
+      epss: br.epss_score ?? 0,
+      blast: blastPriority(br),
+      severity: normalizeSeverity(br.severity),
+      kev: !!(br.is_kev ?? br.cisa_kev),
+      package: br.package,
+    });
+  }
+  return out.sort((a, b) => {
+    const severityDelta = (SEVERITY_RANK[b.severity] ?? 0) - (SEVERITY_RANK[a.severity] ?? 0);
+    return severityDelta || b.blast - a.blast;
+  });
+}

--- a/ui/tests/insights-risk.test.ts
+++ b/ui/tests/insights-risk.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type { Agent, BlastRadius, ScanResult } from "@/lib/api";
+import { blastPriority, buildDerivedBlastRadius, buildEpssVsCvss, buildPipelineStats, effectiveBlastRadius } from "@/lib/insights-risk";
+
+const agents = [
+  {
+    name: "desktop-agent",
+    mcp_servers: [
+      {
+        name: "filesystem",
+        packages: [
+          {
+            name: "pillow",
+            version: "9.0.0",
+            ecosystem: "pypi",
+            vulnerabilities: [
+              {
+                id: "CVE-2022-0001",
+                severity: "critical",
+                cvss_score: 9.8,
+                epss_score: 0.42,
+                fixed_version: "9.0.1",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+] as unknown as Agent[];
+
+describe("insights risk helpers", () => {
+  it("derives blast-radius rows from vulnerable packages when graph analysis is absent", () => {
+    const derived = buildDerivedBlastRadius(agents);
+
+    expect(derived).toHaveLength(1);
+    expect(derived[0]).toMatchObject({
+      vulnerability_id: "CVE-2022-0001",
+      severity: "critical",
+      package: "pillow",
+      affected_agents: ["desktop-agent"],
+      affected_servers: ["filesystem"],
+    });
+    expect(derived[0]!.blast_score).toBeGreaterThan(90);
+  });
+
+  it("uses derived rows for pipeline stats when scan blast radius is empty", () => {
+    const result = {
+      agents,
+      blast_radius: [],
+    } as unknown as ScanResult;
+
+    expect(effectiveBlastRadius(result)).toHaveLength(1);
+    expect(buildPipelineStats(result)).toMatchObject({
+      agents: 1,
+      servers: 1,
+      packages: 1,
+      vulnerabilities: 1,
+      critical: 1,
+    });
+  });
+
+  it("uses risk_score before blast_score so nonzero risk does not render as an empty chart", () => {
+    const blast = {
+      vulnerability_id: "CVE-2022-0002",
+      severity: "high",
+      affected_agents: ["desktop-agent"],
+      exposed_credentials: [],
+      reachable_tools: [],
+      risk_score: 8.5,
+      blast_score: 0,
+    } as BlastRadius;
+
+    expect(blastPriority(blast)).toBe(85);
+    expect(buildEpssVsCvss([{ ...blast, cvss_score: 8.1, epss_score: 0.2 }])[0]!.blast).toBe(85);
+  });
+});


### PR DESCRIPTION
Summary
- derive Insights blast-radius rows from package vulnerability evidence when graph blast rows are absent
- use risk score, then blast score, then severity/CVSS/EPSS/KEV priority so risk charts do not render empty for valid scan data
- place the supply-chain map beside risk panels on wide screens so one treemap does not dominate the first viewport

Validation
- cd ui && npm test -- --run tests/insights-risk.test.ts tests/api.test.ts
- cd ui && npm run lint -- app/insights/page.tsx components/charts.tsx lib/insights-risk.ts tests/insights-risk.test.ts
- cd ui && npm run typecheck
- git diff --check

Note
- Local Node is v25.9.0 while the UI toolchain contract is >=22 <25; the focused checks above still passed after refreshing the local UI dependency install.