### PR TITLE
image: resolve native Debian severity fallback

### DIFF
--- a/src/agent_bom/db/sync.py
+++ b/src/agent_bom/db/sync.py
@@ -227,6 +227,23 @@ def _normalize_sync_severity_label(value: Any) -> Optional[str]:
     return mapping.get(label)
 
 
+def _first_sync_cvss_vector(value: Any) -> Optional[str]:
+    """Return the first CVSS vector string from common OSV/vendor shapes."""
+    if isinstance(value, str) and value.startswith("CVSS:"):
+        return value
+    if isinstance(value, dict):
+        for key in ("score", "baseScore", "base_score", "cvss", "vector", "vectorString"):
+            vector = _first_sync_cvss_vector(value.get(key))
+            if vector is not None:
+                return vector
+    if isinstance(value, list):
+        for item in value:
+            vector = _first_sync_cvss_vector(item)
+            if vector is not None:
+                return vector
+    return None
+
+
 def _now_utc() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -276,9 +293,34 @@ def _parse_osv_entry(data: dict) -> Optional[tuple[dict, list[dict]]]:
             parsed_score = _normalize_sync_cvss_score(raw_cvss)
             if parsed_score is not None:
                 cvss_score = parsed_score
-                if cvss_vector is None and isinstance(raw_cvss, str) and raw_cvss.startswith("CVSS:"):
-                    cvss_vector = raw_cvss
+                if cvss_vector is None:
+                    cvss_vector = _first_sync_cvss_vector(raw_cvss)
                 break
+
+    # Debian and other distro OSV advisories often carry their vendor
+    # severity/CVSS on affected entries instead of the top-level record.
+    for aff in data.get("affected", []):
+        if not isinstance(aff, dict):
+            continue
+        for block_name in ("database_specific", "ecosystem_specific"):
+            block = aff.get(block_name)
+            if not isinstance(block, dict):
+                continue
+            if db_severity is None:
+                db_severity = _normalize_sync_severity_label(block.get("severity"))
+            if cvss_score is None:
+                for key in ("cvss", "cvss_score", "cvss_v3", "severity_vectors"):
+                    raw_cvss = block.get(key)
+                    parsed_score = _normalize_sync_cvss_score(raw_cvss)
+                    if parsed_score is not None:
+                        cvss_score = parsed_score
+                        if cvss_vector is None:
+                            cvss_vector = _first_sync_cvss_vector(raw_cvss)
+                        break
+            if db_severity is not None and cvss_score is not None:
+                break
+        if db_severity is not None and cvss_score is not None:
+            break
 
     # Determine severity: prefer database_specific string, then derive from CVSS
     if db_severity:

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -104,7 +104,7 @@ class Vulnerability:
     id: str  # CVE or OSV ID
     summary: str
     severity: Severity
-    severity_source: Optional[str] = None  # "cvss", "osv_database", "osv_ecosystem", "ghsa_heuristic"
+    severity_source: Optional[str] = None  # "cvss", "osv_database", "osv_ecosystem", "ghsa_heuristic", etc.
     confidence: float | None = None  # Data quality confidence score (0.0-1.0)
     cvss_score: Optional[float] = None
     fixed_version: Optional[str] = None

--- a/src/agent_bom/scanners/risk.py
+++ b/src/agent_bom/scanners/risk.py
@@ -15,6 +15,7 @@ from agent_bom.models import Severity
 _logger = logging.getLogger(__name__)
 
 _OSV_MEDIUM_FALLBACK_PREFIXES = ("OSV-", "PYSEC-", "RUSTSEC-", "GO-", "MAL-", "GSD-")
+_DISTRO_MEDIUM_FALLBACK_PREFIXES = ("DEBIAN-CVE-",)
 _SEVERITY_LABELS = {
     "CRITICAL": Severity.CRITICAL,
     "HIGH": Severity.HIGH,
@@ -50,6 +51,8 @@ def advisory_id_severity_fallback(advisory_id: str) -> tuple[Severity, Optional[
         return Severity.MEDIUM, "ghsa_heuristic"
     if normalized.startswith(_OSV_MEDIUM_FALLBACK_PREFIXES):
         return Severity.MEDIUM, "osv_heuristic"
+    if normalized.startswith(_DISTRO_MEDIUM_FALLBACK_PREFIXES):
+        return Severity.MEDIUM, "distro_advisory_heuristic"
     return Severity.UNKNOWN, None
 
 

--- a/tests/test_local_db_scan.py
+++ b/tests/test_local_db_scan.py
@@ -93,6 +93,15 @@ def test_local_vuln_to_vulnerability_osv_alias_without_score_uses_medium_fallbac
     assert v.severity_source == "osv_heuristic"
 
 
+def test_local_vuln_to_vulnerability_debian_id_without_score_uses_medium_fallback():
+    from agent_bom.scanners import _local_vuln_to_vulnerability
+
+    lv = _make_local_vuln(vuln_id="DEBIAN-CVE-2026-0001", severity="", cvss=None)
+    v = _local_vuln_to_vulnerability(lv)
+    assert v.severity == Severity.MEDIUM
+    assert v.severity_source == "distro_advisory_heuristic"
+
+
 def test_local_vuln_to_vulnerability_kev_flag():
     from agent_bom.scanners import _local_vuln_to_vulnerability
 

--- a/tests/test_local_vuln_db.py
+++ b/tests/test_local_vuln_db.py
@@ -718,6 +718,49 @@ def test_parse_osv_entry_normalizes_debian_important_severity():
     assert vuln_row["severity"] == "high"
 
 
+def test_parse_osv_entry_uses_debian_affected_vendor_severity():
+    data = {
+        "id": "DEBIAN-CVE-2024-0002",
+        "summary": "Debian affected-level severity",
+        "published": "2024-01-01T00:00:00Z",
+        "modified": "2024-01-02T00:00:00Z",
+        "affected": [
+            {
+                "package": {"ecosystem": "Debian:12", "name": "openssl"},
+                "database_specific": {"severity": "important"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "3.0.11-1~deb12u2"}]}],
+            }
+        ],
+    }
+    result = _parse_osv_entry(data)
+    assert result is not None
+    vuln_row, affected_rows = result
+    assert vuln_row["severity"] == "high"
+    assert affected_rows[0]["ecosystem"] == "debian:12"
+
+
+def test_parse_osv_entry_uses_debian_affected_cvss_vector():
+    data = {
+        "id": "DEBIAN-CVE-2024-0003",
+        "summary": "Debian affected-level CVSS",
+        "published": "2024-01-01T00:00:00Z",
+        "modified": "2024-01-02T00:00:00Z",
+        "affected": [
+            {
+                "package": {"ecosystem": "Debian:12", "name": "bash"},
+                "ecosystem_specific": {"severity_vectors": ["CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"]},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}]}],
+            }
+        ],
+    }
+    result = _parse_osv_entry(data)
+    assert result is not None
+    vuln_row, _ = result
+    assert vuln_row["severity"] == "critical"
+    assert vuln_row["cvss_score"] == pytest.approx(9.8)
+    assert vuln_row["cvss_vector"] == "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+
+
 def test_parse_alpine_secfix_tokens_splits_compound_entries():
     assert _parse_alpine_secfix_tokens("CVE-2022-42333 CVE-2022-43334 XSA-428") == [
         "CVE-2022-42333",

--- a/tests/test_scanners.py
+++ b/tests/test_scanners.py
@@ -71,6 +71,15 @@ def test_advisory_id_severity_fallback_keeps_unknown_ids_unknown():
     assert sev_src is None
 
 
+def test_debian_advisory_without_score_uses_medium_fallback():
+    """Debian advisories without CVSS still need a visible triage band."""
+    vuln = {"id": "DEBIAN-CVE-2026-0001", "summary": "distro advisory without score"}
+    severity, score, sev_src = parse_osv_severity(vuln)
+    assert severity == Severity.MEDIUM
+    assert score is None
+    assert sev_src == "distro_advisory_heuristic"
+
+
 def test_ghsa_severity_unknown_label_not_medium():
     """GHSA advisory with unrecognized severity must return UNKNOWN, not MEDIUM."""
     from agent_bom.scanners.ghsa_advisory import _parse_ghsa_severity


### PR DESCRIPTION
Summary
- preserve affected-level Debian vendor severity and CVSS vectors during local vulnerability DB sync
- add a transparent Debian advisory fallback after CVSS and vendor severity are unavailable so native image findings do not stay hidden as unknown
- cover OSV parsing, local DB conversion, and image/native scanner regression paths with focused tests

Root cause
- The external scanner fallback handled related CVE records, but native image scans use the local vulnerability DB path. Some Debian advisories carry severity/CVSS on affected entries or have advisory IDs without scores, so they remained unknown in native image output.

Validation
- uv run pytest -q tests/test_scanners.py tests/test_local_db_scan.py tests/test_local_vuln_db.py tests/test_cwe_enrichment.py tests/test_image_auth.py
- uv run ruff check src/agent_bom/scanners/risk.py src/agent_bom/db/sync.py src/agent_bom/models.py tests/test_scanners.py tests/test_local_db_scan.py tests/test_local_vuln_db.py
- uv run mypy src/agent_bom/scanners/risk.py src/agent_bom/db/sync.py src/agent_bom/models.py
- git diff --check