### PR TITLE
cli: tighten release output contracts

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,14 @@
+# CLI Reference
+
+The canonical command reference lives in
+[site-docs/reference/cli.md](../site-docs/reference/cli.md).
+
+## Release Contracts
+
+- `agent-bom agents -f json -o -` writes JSON to stdout for automation.
+- `agent-bom agents -f <format> -o <path>` validates output suffixes and
+  appends the canonical suffix when `<path>` has no extension.
+- JSON reports include `posture_scorecard` and root `posture_grade`.
+- `agent-bom profiles ...` manages named contexts in
+  `~/.agent-bom/config.toml`; unknown profiles fail with the available profile
+  list.

--- a/src/agent_bom/cli/_profiles.py
+++ b/src/agent_bom/cli/_profiles.py
@@ -62,6 +62,20 @@ def _profiles(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return profiles
 
 
+def _available_profiles_message(profiles: dict[str, dict[str, Any]]) -> str:
+    if not profiles:
+        return "No profiles are configured."
+    return f"Available profiles: {', '.join(sorted(profiles))}."
+
+
+def _missing_profile_message(name: str, path: Path, profiles: dict[str, dict[str, Any]]) -> str:
+    return (
+        f"Profile {name!r} was not found in {path}. "
+        f"{_available_profiles_message(profiles)} "
+        "Run `agent-bom profiles list` to inspect configured profiles."
+    )
+
+
 def _reject_inline_secrets(name: str, profile: dict[str, Any]) -> None:
     for key in profile:
         key_lower = str(key).lower()
@@ -94,9 +108,7 @@ def load_active_profile(explicit: str | None = None) -> tuple[str | None, dict[s
         return None, {}
     profiles = _profiles(data)
     if name not in profiles:
-        raise click.ClickException(
-            f"Profile {name!r} was not found in {default_config_path()}. Run `agent-bom profiles list` to inspect configured profiles."
-        )
+        raise click.ClickException(_missing_profile_message(name, default_config_path(), profiles))
     return name, profiles[name]
 
 
@@ -225,8 +237,9 @@ def set_current_profile(path: Path, name: str) -> None:
     if not _PROFILE_NAME_RE.match(name):
         raise click.ClickException(f"Invalid profile name: {name!r}")
     data = load_profiles_config(path)
-    if name not in _profiles(data):
-        raise click.ClickException(f"Profile {name!r} was not found in {path}.")
+    profiles = _profiles(data)
+    if name not in profiles:
+        raise click.ClickException(_missing_profile_message(name, path, profiles))
     text = path.read_text()
     line = f'current_profile = "{name}"'
     if re.search(r"(?m)^current_profile\s*=", text):
@@ -283,7 +296,7 @@ def profiles_show_cmd(name: str | None) -> None:
         raise click.ClickException("No profile selected. Pass NAME or set current_profile.")
     profiles = _profiles(data)
     if resolved not in profiles:
-        raise click.ClickException(f"Profile {resolved!r} was not found in {default_config_path()}.")
+        raise click.ClickException(_missing_profile_message(resolved, default_config_path(), profiles))
     click.echo(f"[{resolved}]")
     for key, value in sorted(profiles[resolved].items()):
         if str(key).endswith("_env"):

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -1218,6 +1218,7 @@ def to_json(report: AIBOMReport) -> dict:
 
     scorecard = compute_posture_scorecard(report)
     result["posture_scorecard"] = scorecard.to_dict()
+    result["posture_grade"] = scorecard.grade
     result["credential_risk_ranking"] = compute_credential_risk_ranking(report)
     result["incident_correlation"] = compute_incident_correlation(report)
 

--- a/tests/test_cli_profiles.py
+++ b/tests/test_cli_profiles.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import click
+import pytest
 from click.testing import CliRunner
 
 from agent_bom.cli import main
@@ -27,6 +28,28 @@ push_api_key_env = "AGENT_BOM_PUSH_TOKEN_PROD"
 
     assert name == "prod"
     assert profile["tenant_id"] == "team-a"
+
+
+def test_missing_active_profile_lists_available_profiles(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+[profiles.dev]
+tenant_id = "default"
+
+[profiles.prod]
+tenant_id = "team-a"
+"""
+    )
+    monkeypatch.setenv("AGENT_BOM_CONFIG", str(config_path))
+    monkeypatch.setenv("AGENT_BOM_PROFILE", "missing")
+
+    with pytest.raises(click.ClickException) as excinfo:
+        load_active_profile()
+
+    message = str(excinfo.value)
+    assert "Profile 'missing' was not found" in message
+    assert "Available profiles: dev, prod" in message
 
 
 def test_scan_profile_defaults_do_not_override_explicit_cli_flags(monkeypatch, tmp_path):
@@ -167,3 +190,23 @@ format = "json"
     assert show_result.exit_code == 0
     assert "[prod]" in show_result.output
     assert "tenant_id = team-a" in show_result.output
+
+
+def test_profiles_use_missing_profile_lists_available(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+[profiles.dev]
+tenant_id = "default"
+
+[profiles.prod]
+tenant_id = "team-a"
+"""
+    )
+    monkeypatch.setenv("AGENT_BOM_CONFIG", str(config_path))
+
+    result = CliRunner().invoke(main, ["profiles", "use", "missing"])
+
+    assert result.exit_code != 0
+    assert "Profile 'missing' was not found" in result.output
+    assert "Available profiles: dev, prod" in result.output

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -535,6 +535,7 @@ def test_json_output_structure(sample_report):
     assert data["inventory_snapshot"]["schema_version"] == "1"
     assert data["summary"]["total_vulnerabilities"] == 1
     assert data["ai_bom_version"] == sample_report.tool_version
+    assert data["posture_grade"] == data["posture_scorecard"]["grade"]
 
 
 def test_json_output_includes_canonical_publish_dates(sample_report):


### PR DESCRIPTION
Summary
- expose root posture_grade beside posture_scorecard for automation consumers
- make missing profile errors list configured profile names for faster recovery
- restore docs/cli.md as a stable CLI reference entry point

Validation
- uv run pytest -q tests/test_cli_profiles.py tests/test_core.py::test_json_output_structure
- uv run ruff check src/agent_bom/cli/_profiles.py src/agent_bom/output/json_fmt.py tests/test_cli_profiles.py tests/test_core.py
- uv run mypy src/agent_bom/cli/_profiles.py src/agent_bom/output/json_fmt.py
- git diff --check