### PR TITLE
docs: lock release positioning tagline

### DIFF
--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -1,6 +1,6 @@
 # agent-bom
 
-**Open security scanner and control plane for AI-era infrastructure — local scans, CI evidence, fleet inventory, MCP/runtime enforcement, and self-hosted governance.**
+**Open security scanner and self-hosted control plane for AI-era infrastructure.**
 
 Every CVE in your AI stack is a credential leak waiting to happen. `agent-bom`
 follows the chain end-to-end and tells you which fix collapses it first.

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -2,7 +2,7 @@
 
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
-**Open security scanner for AI supply chain and runtime infrastructure — agents, MCP servers, packages, containers, cloud, GPU, and enforcement paths.**
+**Open security scanner and self-hosted control plane for AI-era infrastructure.**
 
 Start with the demo, then choose the entrypoint that matches your first job: repo scan, image scan, cloud posture, fix plan, dashboard, or runtime review.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p>
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
-<p align="center"><b>Open security scanner and AI BOM for the AI stack.</b></p>
+<p align="center"><b>Open security scanner and self-hosted control plane for AI-era infrastructure.</b></p>
 
 <p align="center"><code>agent-bom</code> inventories agents, MCP servers, tools, packages, credential environment names, cloud and runtime evidence, then maps the reachable blast radius behind each finding.</p>
 

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -180,7 +180,7 @@ This is the right path because it improves product trust without diluting the MC
 
 Good external phrasing:
 
-- Open security scanner and AI BOM for the AI stack
+- Open security scanner and self-hosted control plane for AI-era infrastructure.
 - Generate a reachability-backed AI BOM across agents, MCP, packages, credentials, cloud, and runtime
 - Context-aware security for agents, MCP, runtime, and AI supply chain and infrastructure
 - Blast radius from package risk to agents, credentials, tools, and runtime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-bom"
 version = "0.86.3"
-description = "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius."
+description = "Open security scanner and self-hosted control plane for AI-era infrastructure."
 readme = "PYPI_README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -8,6 +8,7 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import NoReturn
 
 ROOT = Path(__file__).resolve().parent.parent
 README = ROOT / "README.md"
@@ -18,9 +19,18 @@ DEMO_LATEST = ROOT / "docs" / "images" / "demo-latest.gif"
 PRODUCT_SCREENSHOTS = ROOT / "docs" / "images" / "product-screenshots.json"
 GLAMA_SERVER = ROOT / "integrations" / "glama" / "server.json"
 DOCKER_README = ROOT / "DOCKER_HUB_README.md"
+SITE_INDEX = ROOT / "site-docs" / "index.md"
 TOP_DOCKERFILE = ROOT / "Dockerfile"
 PYPROJECT = ROOT / "pyproject.toml"
 MCP_REGISTRY = ROOT / "src" / "agent_bom" / "mcp_registry.json"
+CANONICAL_TAGLINE = "Open security scanner and self-hosted control plane for AI-era infrastructure."
+CANONICAL_TAGLINE_SURFACES: list[Path] = [
+    README,
+    PYPI_README,
+    DOCKER_README,
+    SITE_INDEX,
+    ROOT / "docs" / "PRODUCT_BRIEF.md",
+]
 MANAGED_IMAGE_REFS: list[tuple[Path, re.Pattern[str]]] = [
     (ROOT / "deploy" / "docker-compose.pilot.yml", re.compile(r"agentbom/agent-bom(?:-ui)?:([0-9]+\.[0-9]+\.[0-9]+)")),
     (ROOT / "deploy" / "docker-compose.runtime.yml", re.compile(r"agentbom/agent-bom(?:-ui)?:([0-9]+\.[0-9]+\.[0-9]+)")),
@@ -140,7 +150,7 @@ def _load_description() -> str:
     return match.group(1)
 
 
-def _fail(message: str) -> None:
+def _fail(message: str) -> NoReturn:
     print(f"ERROR: {message}", file=sys.stderr)
     raise SystemExit(1)
 
@@ -185,6 +195,14 @@ def _assert_versions(path: Path, pattern: re.Pattern[str], expected: str, label:
         _fail(f"{path.relative_to(ROOT)} has no managed {label}")
     if versions != {expected}:
         _fail(f"{path.relative_to(ROOT)} has stale {label}: {sorted(versions)} != {expected}")
+
+
+def _assert_canonical_tagline(description: str) -> None:
+    if description != CANONICAL_TAGLINE:
+        _fail(f"pyproject.toml description must match the canonical tagline: {CANONICAL_TAGLINE!r}")
+    for path in CANONICAL_TAGLINE_SURFACES:
+        if CANONICAL_TAGLINE not in path.read_text():
+            _fail(f"{path.relative_to(ROOT)} is missing the canonical tagline: {CANONICAL_TAGLINE!r}")
 
 
 def _assert_product_screenshots_current(expected_version: str) -> None:
@@ -232,6 +250,8 @@ def main() -> int:
     pypi_readme = PYPI_README.read_text()
     changelog = CHANGELOG.read_text()
     demo_tape = DEMO_TAPE.read_text()
+
+    _assert_canonical_tagline(description)
 
     required_github_markers = [
         "img.shields.io/github/actions/workflow/status",
@@ -334,8 +354,8 @@ def main() -> int:
             if file.suffix.lower() in {".gif", ".png", ".jpg", ".jpeg", ".svg", ".ico"}:
                 continue
             text = file.read_text(errors="ignore")
-            for pattern in leaked_patterns:
-                if re.search(pattern, text):
+            for leaked_pattern in leaked_patterns:
+                if re.search(leaked_pattern, text):
                     _fail(f"personal/local path leak found in {file.relative_to(ROOT)}")
 
     if f"agent-bom v{version}" not in demo_tape:
@@ -348,13 +368,13 @@ def main() -> int:
         _fail(f"DOCKER_HUB_README.md must mark {version} as the current stable version")
     if f"ARG VERSION={version}" not in TOP_DOCKERFILE.read_text():
         _fail(f"Dockerfile ARG VERSION must be {version}")
-    for path, pattern in MANAGED_IMAGE_REFS:
+    for path, image_pattern in MANAGED_IMAGE_REFS:
         text = path.read_text()
-        versions = {match.group(1) for match in pattern.finditer(text)}
+        versions = {match.group(1) for match in image_pattern.finditer(text)}
         if versions and versions != {version}:
             _fail(f"{path.relative_to(ROOT)} contains stale managed image version(s): {sorted(versions)} != {version}")
-    for path, pattern, label in MANAGED_VERSION_REFS:
-        _assert_versions(path, pattern, version, label)
+    for path, version_pattern, label in MANAGED_VERSION_REFS:
+        _assert_versions(path, version_pattern, version, label)
     ui_lock = json.loads((ROOT / "ui" / "package-lock.json").read_text())
     ui_lock_versions = {ui_lock.get("version"), ui_lock.get("packages", {}).get("", {}).get("version")}
     if ui_lock_versions != {version}:

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -1,6 +1,6 @@
 # agent-bom
 
-**Open security scanner and AI BOM for the AI stack.**
+**Open security scanner and self-hosted control plane for AI-era infrastructure.**
 
 Inventory agents, MCP servers, tools, packages, credential environment names,
 cloud and runtime evidence, then map the reachable blast radius behind each


### PR DESCRIPTION
Summary
- align README, PyPI README, Docker Hub README, docs home, product brief, and package metadata on one public tagline
- add a release consistency guard so the tagline cannot drift before tagging
- tighten script typing while adding the new guard

Validation
- uv run python scripts/check_release_consistency.py
- uv run ruff check scripts/check_release_consistency.py
- uv run mypy scripts/check_release_consistency.py
- uv lock --check
- git diff --check