### PR TITLE
ui: add reusable scan progress stream hook

### DIFF
--- a/ui/components/scan-result.tsx
+++ b/ui/components/scan-result.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { api, type ScanJob, type ScanJobStatus, type ScanResult, type BlastRadius, type RemediationItem, type GraphExportFormat, formatDate, OWASP_LLM_TOP10, MITRE_ATLAS, severityColor } from "@/lib/api";
-import type { StepEvent, SSEEvent } from "@/lib/api";
+import { useScanStream } from "@/lib/use-scan-stream";
 import { ScanPipeline } from "@/components/scan-pipeline";
 import { SeverityBadge } from "@/components/severity-badge";
 import {
@@ -13,88 +13,67 @@ import {
 
 // ─── Scan Result View ───────────────────────────────────────────────────────
 
+function mergeScanStatus(prev: ScanJob | null, status: ScanJobStatus): ScanJob {
+  return {
+    job_id: status.job_id,
+    tenant_id: status.tenant_id ?? prev?.tenant_id,
+    status: status.status,
+    created_at: status.created_at,
+    completed_at: status.completed_at ?? prev?.completed_at,
+    request: status.request ?? prev?.request ?? {},
+    progress: prev?.progress ?? [],
+    result: prev?.result,
+    error: status.error ?? prev?.error,
+  };
+}
+
 export function ScanResultView({ id }: { id: string }) {
   const [job, setJob] = useState<ScanJob | null>(null);
-  const [messages, setMessages] = useState<string[]>([]);
-  const [streaming, setStreaming] = useState(true);
-  const [pipelineSteps, setPipelineSteps] = useState<Map<string, StepEvent>>(new Map());
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState("");
   const logRef = useRef<HTMLDivElement>(null);
   const fetchedResultRef = useRef(false);
   const fetchingResultRef = useRef(false);
+  const activeJobIdRef = useRef(id);
+
+  const fetchFullResultOnce = useCallback(async () => {
+    if (fetchedResultRef.current || fetchingResultRef.current) return;
+    fetchingResultRef.current = true;
+    try {
+      const fullJob = await api.getScan(id);
+      if (activeJobIdRef.current === id) {
+        setJob(fullJob);
+        fetchedResultRef.current = true;
+      }
+    } finally {
+      fetchingResultRef.current = false;
+    }
+  }, [id]);
+
+  const refreshStatus = useCallback(async () => {
+    const status = await api.getScanStatus(id);
+    if (activeJobIdRef.current !== id) return;
+    setJob((prev) => mergeScanStatus(prev, status));
+    if (status.status === "done" || status.status === "failed" || status.status === "cancelled") {
+      await fetchFullResultOnce();
+    }
+  }, [fetchFullResultOnce, id]);
 
   useEffect(() => {
-    let cancelled = false;
-
-    function mergeStatus(prev: ScanJob | null, status: ScanJobStatus): ScanJob {
-      return {
-        job_id: status.job_id,
-        tenant_id: status.tenant_id ?? prev?.tenant_id,
-        status: status.status,
-        created_at: status.created_at,
-        completed_at: status.completed_at ?? prev?.completed_at,
-        request: status.request ?? prev?.request ?? {},
-        progress: prev?.progress ?? [],
-        result: prev?.result,
-        error: status.error ?? prev?.error,
-      };
-    }
-
-    async function fetchFullResultOnce() {
-      if (fetchedResultRef.current || fetchingResultRef.current) return;
-      fetchingResultRef.current = true;
-      try {
-        const fullJob = await api.getScan(id);
-        if (!cancelled) {
-          setJob(fullJob);
-          fetchedResultRef.current = true;
-        }
-      } finally {
-        fetchingResultRef.current = false;
-      }
-    }
-
-    async function refreshStatus() {
-      const status = await api.getScanStatus(id);
-      if (cancelled) return;
-      setJob((prev) => mergeStatus(prev, status));
-      if (status.status === "done" || status.status === "failed" || status.status === "cancelled") {
-        await fetchFullResultOnce();
-      }
-    }
-
+    activeJobIdRef.current = id;
     fetchedResultRef.current = false;
     fetchingResultRef.current = false;
     refreshStatus().catch(() => {});
+  }, [id, refreshStatus]);
 
-    const cleanup = api.streamScan(
-      id,
-      (data: SSEEvent) => {
-        if (data.type === "step") {
-          const step = data as StepEvent;
-          setPipelineSteps((prev) => {
-            const next = new Map(prev);
-            next.set(step.step_id, step);
-            return next;
-          });
-          setMessages((m) => [...m, step.message]);
-        } else if (data.type === "progress") {
-          const d = data as { message?: string };
-          if (d.message) setMessages((m) => [...m, d.message!]);
-        }
-        refreshStatus().catch(() => {});
-      },
-      () => {
-        setStreaming(false);
-        refreshStatus().catch(() => {});
-      }
-    );
-    return () => {
-      cancelled = true;
-      cleanup();
-    };
-  }, [id]);
+  const handleStreamUpdate = useCallback(() => {
+    refreshStatus().catch(() => {});
+  }, [refreshStatus]);
+
+  const { messages, pipelineSteps, streaming } = useScanStream(id, {
+    onDone: handleStreamUpdate,
+    onEvent: handleStreamUpdate,
+  });
 
   useEffect(() => {
     if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;

--- a/ui/lib/use-scan-stream.ts
+++ b/ui/lib/use-scan-stream.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { api, type SSEEvent, type StepEvent } from "@/lib/api";
+
+export interface UseScanStreamOptions {
+  enabled?: boolean;
+  onEvent?: (event: SSEEvent) => void;
+  onDone?: () => void;
+}
+
+export interface UseScanStreamState {
+  streaming: boolean;
+  messages: string[];
+  pipelineSteps: Map<string, StepEvent>;
+  lastEvent: SSEEvent | null;
+}
+
+export function useScanStream(jobId: string, options: UseScanStreamOptions = {}): UseScanStreamState {
+  const { enabled = true, onDone, onEvent } = options;
+  const [streaming, setStreaming] = useState(false);
+  const [messages, setMessages] = useState<string[]>([]);
+  const [pipelineSteps, setPipelineSteps] = useState<Map<string, StepEvent>>(new Map());
+  const [lastEvent, setLastEvent] = useState<SSEEvent | null>(null);
+
+  useEffect(() => {
+    setMessages([]);
+    setPipelineSteps(new Map());
+    setLastEvent(null);
+
+    if (!jobId || !enabled) {
+      setStreaming(false);
+      return undefined;
+    }
+
+    let closed = false;
+    setStreaming(true);
+
+    const cleanup = api.streamScan(
+      jobId,
+      (event) => {
+        if (closed) return;
+        setLastEvent(event);
+        if (event.type === "step") {
+          const step = event as StepEvent;
+          setPipelineSteps((prev) => {
+            const next = new Map(prev);
+            next.set(step.step_id, step);
+            return next;
+          });
+          setMessages((prev) => [...prev, step.message]);
+        } else if (event.type === "progress" && event.message) {
+          setMessages((prev) => [...prev, event.message]);
+        }
+        onEvent?.(event);
+      },
+      () => {
+        if (closed) return;
+        setStreaming(false);
+        onDone?.();
+      }
+    );
+
+    return () => {
+      closed = true;
+      cleanup();
+    };
+  }, [enabled, jobId, onDone, onEvent]);
+
+  return { streaming, messages, pipelineSteps, lastEvent };
+}

--- a/ui/tests/use-scan-stream.test.tsx
+++ b/ui/tests/use-scan-stream.test.tsx
@@ -1,0 +1,63 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { api, type SSEEvent } from "@/lib/api";
+import { useScanStream } from "@/lib/use-scan-stream";
+
+describe("useScanStream", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("collects progress and step events from the scan stream", () => {
+    let emit: ((event: SSEEvent) => void) | undefined;
+    let finish: (() => void) | undefined;
+    const cleanup = vi.fn();
+    const streamSpy = vi.spyOn(api, "streamScan").mockImplementation((_jobId, onMessage, onDone) => {
+      emit = onMessage;
+      finish = onDone;
+      return cleanup;
+    });
+
+    const { result, unmount } = renderHook(() => useScanStream("job-123"));
+
+    expect(streamSpy).toHaveBeenCalledWith("job-123", expect.any(Function), expect.any(Function));
+    expect(result.current.streaming).toBe(true);
+
+    act(() => {
+      emit?.({ type: "progress", message: "discovering local configs" });
+    });
+
+    expect(result.current.messages).toEqual(["discovering local configs"]);
+
+    act(() => {
+      emit?.({
+        type: "step",
+        step_id: "scanning",
+        status: "running",
+        message: "scanning 12 packages",
+        progress_pct: 45,
+      });
+    });
+
+    expect(result.current.messages).toEqual(["discovering local configs", "scanning 12 packages"]);
+    expect(result.current.pipelineSteps.get("scanning")?.progress_pct).toBe(45);
+
+    act(() => {
+      finish?.();
+    });
+
+    expect(result.current.streaming).toBe(false);
+
+    unmount();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not connect when disabled", () => {
+    const streamSpy = vi.spyOn(api, "streamScan").mockImplementation(() => vi.fn());
+
+    const { result } = renderHook(() => useScanStream("job-123", { enabled: false }));
+
+    expect(streamSpy).not.toHaveBeenCalled();
+    expect(result.current.streaming).toBe(false);
+  });
+});


### PR DESCRIPTION
Summary
- extracts scan SSE handling into a reusable `useScanStream` hook
- keeps scan progress messages and step state in one tested stream consumer
- updates the scan result page to hydrate status/final results from the shared hook instead of inline EventSource wiring

Why
- the backend already exposes `/v1/scan/{job_id}/stream`; the UI path needed a reusable, tested client-side contract so scan progress remains visible without manual refresh
- this closes the release-track SSE UI gap without adding a duplicate backend feature

Validation
- cd ui && npm test -- --run tests/use-scan-stream.test.tsx
- cd ui && npm run typecheck
- cd ui && npm run lint -- components/scan-result.tsx lib/use-scan-stream.ts tests/use-scan-stream.test.tsx
- git diff --check
