### PR TITLE
ci: harden pr retrigger automation

### DIFF
--- a/.github/workflows/auto-retrigger-stranded.yml
+++ b/.github/workflows/auto-retrigger-stranded.yml
@@ -16,9 +16,10 @@ name: Auto-Retrigger Stranded PRs
 # behind main, then retriggers any PR whose current head SHA is missing or has a
 # stale required check.
 #
-# Triggered from a workflow (not GITHUB_TOKEN's push), the close/reopen
-# events are properly recorded and our pull_request hooks fire on the
-# new head SHA — exactly the result a manual retrigger gives.
+# The refresh/retrigger token must be a dedicated GitHub App token or PAT.
+# GITHUB_TOKEN-authored pushes and close/reopen events do not recursively
+# trigger pull_request workflows, so falling back to GITHUB_TOKEN recreates the
+# frozen-PR loop this workflow is meant to break.
 
 on:
   push:
@@ -50,9 +51,8 @@ on:
         type: boolean
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 concurrency:
   group: auto-retrigger-stranded
@@ -71,7 +71,7 @@ jobs:
 
       - name: Find and retrigger stranded PRs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTOMATION_GITHUB_TOKEN }}
           AUTOMATION_SSH_SIGNING_KEY: ${{ secrets.AUTOMATION_SSH_SIGNING_KEY }}
           REQUIRED_CHECKS: "Lint and Type Check,Test (Python 3.11),Test (Python 3.13),Build Package,Security Scan,CodeQL,Test (Python 3.14)"
           MIN_AGE_MINUTES: ${{ inputs.min_age_minutes || '3' }}
@@ -80,6 +80,11 @@ jobs:
           REFRESH_READY_PRS: ${{ github.event_name != 'workflow_dispatch' || inputs.refresh_ready_prs }}
         run: |
           set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::AUTOMATION_GITHUB_TOKEN is not configured; skipping auto refresh/retrigger. GITHUB_TOKEN-authored events cannot start PR checks."
+            exit 0
+          fi
+
           if [ "${REFRESH_READY_PRS}" = "true" ]; then
             scripts/refresh_ready_prs.sh
           fi

--- a/docs/operations/CI_RUNBOOK.md
+++ b/docs/operations/CI_RUNBOOK.md
@@ -33,8 +33,10 @@ scripts/refresh_ready_prs.sh
 
 The script only refreshes same-repo, non-draft PRs targeting `main`. By default
 it further limits writes to PRs with auto-merge already enabled, so exploratory
-branches are left alone. After updating a PR branch, it runs the stranded-check
-retrigger below so required checks attach to the new head.
+branches are left alone. The workflow must use `AUTOMATION_GITHUB_TOKEN`, a
+dedicated GitHub App token or PAT with repo pull-request/write access. Do not
+fall back to `GITHUB_TOKEN` for refresh or retrigger events: GitHub suppresses
+workflows triggered by that token, which recreates the frozen-check loop.
 
 Manual one-shot refresh:
 
@@ -84,9 +86,11 @@ The script:
 1. Resolves the PR's current head SHA.
 2. Checks whether the canonical required check (`Lint and Type Check`) ran
    against that SHA via `repos/.../commits/<sha>/check-runs`.
-3. If not, closes the PR and immediately reopens it. The `pull_request
-   reopened` event always fires `pull_request` workflows, so all required
-   checks restart on the up-to-date head.
+3. If any required check is still active, exits without retriggering. Downstream
+   jobs such as package build are not created until prerequisite jobs finish.
+4. If checks are missing or stale after the run is idle, closes the PR and
+   immediately reopens it. This starts `pull_request` workflows only when the
+   token is not `GITHUB_TOKEN`.
 
 The script no-ops when the required check is already present, so it is safe to
 run on any PR.
@@ -97,12 +101,14 @@ run on any PR.
 against every open PR whose current head SHA has zero or stale
 `Lint and Type Check` runs. It runs after `main` advances, every five minutes,
 and through `workflow_dispatch` for on-demand. Once this workflow is on the
-default branch, stranded PRs unstrand themselves within five minutes — no
-operator action required.
+default branch and `AUTOMATION_GITHUB_TOKEN` is configured, stranded PRs
+unstrand themselves within five minutes — no operator action required.
 
 Operator-side troubleshooting if a strand persists past ~10 minutes:
 
 - Did the workflow itself run? `gh run list --workflow=auto-retrigger-stranded.yml --limit 5`
+- Is `AUTOMATION_GITHUB_TOKEN` configured? Without it the workflow intentionally
+  skips write actions because `GITHUB_TOKEN` cannot start required PR checks.
 - Was the PR younger than `MIN_AGE_MINUTES` (3 min by default)? It's intentionally
   skipped to give the initial `pull_request` workflow a chance to start.
 - Did `gh api commits/{sha}/check-runs` return zero, or is there a

--- a/scripts/enable_merge_queue.sh
+++ b/scripts/enable_merge_queue.sh
@@ -12,10 +12,10 @@
 # For the recurring stranded-CI pain that motivated wanting merge queue,
 # `.github/workflows/auto-retrigger-stranded.yml` is the practical fix:
 # it runs after main advances, polls open PRs every 5 minutes, refreshes
-# ready auto-merge PRs that are behind main, and runs
+# ready auto-merge PRs that are behind main with a dedicated automation token, and runs
 # scripts/retrigger_stranded_pr.sh against any whose current head SHA has zero
-# or stale check-runs. That neutralises both strict-branch staleness and the
-# GITHUB_TOKEN-authored-merge anti-loop guard without needing settings changes.
+# or stale check-runs. That neutralises strict-branch staleness without falling
+# back to GITHUB_TOKEN-authored events, which GitHub intentionally suppresses.
 #
 # Usage:
 #   scripts/enable_merge_queue.sh         # print steps
@@ -64,6 +64,6 @@ Verify with:
 Until the toggle is on, the practical fix for stale/stranded PRs is the
 workflow at .github/workflows/auto-retrigger-stranded.yml, which refreshes
 ready auto-merge PRs after main advances and auto-runs
-scripts/retrigger_stranded_pr.sh every 5 minutes. No operator action needed
-once it's on the default branch.
+scripts/retrigger_stranded_pr.sh every 5 minutes. Configure the
+AUTOMATION_GITHUB_TOKEN secret first; GITHUB_TOKEN cannot retrigger PR checks.
 EOF

--- a/scripts/refresh_ready_prs.sh
+++ b/scripts/refresh_ready_prs.sh
@@ -5,7 +5,8 @@
 # auto-merge does not always refresh queued PRs promptly, and the UI "Update
 # branch" path can leave canceled or missing checks. This script updates stale
 # same-repo PR heads and then invokes the stranded-check retrigger so required
-# checks attach to the new head.
+# checks attach to the new head. Refresh pushes must use a non-GITHUB_TOKEN
+# credential; GITHUB_TOKEN-authored pushes do not trigger pull_request checks.
 #
 # Usage:
 #   scripts/refresh_ready_prs.sh
@@ -221,8 +222,7 @@ refresh_pr() {
     return 0
   fi
 
-  echo "PR #${pr}: head advanced ${head_sha} -> ${updated_sha}; ensuring required checks attach."
-  REQUIRED_CHECKS="${REQUIRED_CHECKS}" scripts/retrigger_stranded_pr.sh "${pr}"
+  echo "PR #${pr}: head advanced ${head_sha} -> ${updated_sha}; pull_request checks should attach from the automation token push."
 
   if [ "${review}" != "APPROVED" ]; then
     echo "PR #${pr}: refreshed, but review decision is ${review}; auto-merge will wait for review."

--- a/scripts/retrigger_stranded_pr.sh
+++ b/scripts/retrigger_stranded_pr.sh
@@ -9,8 +9,11 @@
 #   1. Reads the PR's current head SHA.
 #   2. Checks whether all canonical required checks are attached to that SHA
 #      and are either pending/running/successful.
-#   3. If any are missing or terminally stale, closes + reopens the PR — the
-#      `reopened` action fires `pull_request` workflows again from scratch.
+#   3. If any required checks are still active, waits for the current run
+#      instead of retriggering while downstream jobs have not been created yet.
+#   4. If checks are missing or terminally stale after the run is idle, closes
+#      + reopens the PR. This must use a GitHub App token or PAT; GITHUB_TOKEN
+#      close/reopen events do not start pull_request workflows.
 #
 # Usage:
 #   scripts/retrigger_stranded_pr.sh <PR_NUMBER>
@@ -76,6 +79,12 @@ done
 if [ "${#failed[@]}" -gt 0 ]; then
   printf "PR #%s: required check(s) failed on head %s: %s. Not retriggering real failures.\n" \
     "${PR}" "${HEAD_SHA}" "$(IFS=', '; echo "${failed[*]}")"
+  exit 0
+fi
+
+if [ "${#active[@]}" -gt 0 ]; then
+  printf "PR #%s: required checks are active on head %s (%s active, %s successful, %s missing, %s stale). Not retriggering an in-flight run.\n" \
+    "${PR}" "${HEAD_SHA}" "${#active[@]}" "${#successful[@]}" "${#missing[@]}" "${#stale[@]}"
   exit 0
 fi
 


### PR DESCRIPTION
Summary
- require a dedicated automation token for PR refresh/retrigger writes instead of relying on GITHUB_TOKEN events that GitHub suppresses
- avoid retriggering while required checks are still active, so downstream jobs are not treated as missing before prerequisites finish
- stop immediately close/reopening after branch refresh; let automation-token pushes attach checks naturally
- update the CI runbook and merge-queue helper with the required token boundary

Validation
- bash -n scripts/retrigger_stranded_pr.sh scripts/refresh_ready_prs.sh scripts/enable_merge_queue.sh
- uv run python scripts/check_workflow_timeouts.py
- pre-commit run --files .github/workflows/auto-retrigger-stranded.yml docs/operations/CI_RUNBOOK.md scripts/enable_merge_queue.sh scripts/refresh_ready_prs.sh scripts/retrigger_stranded_pr.sh
- git diff --check