### PR TITLE
cli: add agent mode output contract

### DIFF
--- a/contracts/v1/README.md
+++ b/contracts/v1/README.md
@@ -15,6 +15,8 @@ Compatibility policy:
 
 Published schemas:
 
+- `agent-mode-envelope.schema.json` - machine-readable CLI envelope returned
+  by `--agent-mode` for assistant and automation callers.
 - `scan-report.schema.json` - top-level AI-BOM JSON scan output.
 - `graph-export.schema.json` - graph nodes, edges, and materialized attack
   paths.

--- a/contracts/v1/agent-mode-envelope.schema.json
+++ b/contracts/v1/agent-mode-envelope.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-bom.dev/contracts/v1/agent-mode-envelope.schema.json",
+  "title": "agent-bom agent mode CLI envelope v1",
+  "type": "object",
+  "required": ["schema_version", "mode", "ok", "command", "exit_code", "truncated"],
+  "properties": {
+    "schema_version": { "type": "string", "pattern": "^1(\\.\\d+)?$" },
+    "mode": { "const": "agent" },
+    "ok": { "type": "boolean" },
+    "command": { "type": ["string", "null"] },
+    "exit_code": { "type": "integer", "minimum": 0 },
+    "summary": {
+      "type": "object",
+      "required": ["agents", "vulnerabilities", "findings", "severity_counts"],
+      "properties": {
+        "agents": { "type": "integer", "minimum": 0 },
+        "servers": { "type": ["integer", "null"], "minimum": 0 },
+        "packages": { "type": ["integer", "null"], "minimum": 0 },
+        "vulnerabilities": { "type": "integer", "minimum": 0 },
+        "findings": { "type": "integer", "minimum": 0 },
+        "severity_counts": {
+          "type": "object",
+          "required": ["critical", "high", "medium", "low", "unknown"],
+          "properties": {
+            "critical": { "type": "integer", "minimum": 0 },
+            "high": { "type": "integer", "minimum": 0 },
+            "medium": { "type": "integer", "minimum": 0 },
+            "low": { "type": "integer", "minimum": 0 },
+            "unknown": { "type": "integer", "minimum": 0 }
+          },
+          "additionalProperties": false
+        },
+        "posture_grade": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "confidence": {
+      "type": "object",
+      "required": ["level", "signals"],
+      "properties": {
+        "level": { "enum": ["low", "medium", "high"] },
+        "signals": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "present"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "present": { "type": "boolean" }
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "truncated": { "type": "boolean" },
+    "truncation": {
+      "type": "object",
+      "required": ["enabled", "truncated", "token_budget", "approx_tokens", "removed"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "truncated": { "type": "boolean" },
+        "token_budget": { "type": ["integer", "null"], "minimum": 0 },
+        "approx_tokens": { "type": ["integer", "null"], "minimum": 0 },
+        "removed": {
+          "type": "object",
+          "additionalProperties": { "type": "integer", "minimum": 0 }
+        }
+      },
+      "additionalProperties": true
+    },
+    "data": {
+      "type": "object",
+      "description": "Underlying command payload. For agent-bom agents this is the AI-BOM scan report."
+    },
+    "error": { "$ref": "#/$defs/error" },
+    "errors": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/error" }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "ok": { "const": true } }, "required": ["ok"] },
+      "then": { "required": ["summary", "confidence", "truncation", "data"] }
+    },
+    {
+      "if": { "properties": { "ok": { "const": false } }, "required": ["ok"] },
+      "then": { "required": ["error", "errors"] }
+    }
+  ],
+  "$defs": {
+    "error": {
+      "type": "object",
+      "required": ["type", "message"],
+      "properties": {
+        "type": { "type": "string", "minLength": 1 },
+        "message": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/v1/examples/agent-mode-envelope.minimal.json
+++ b/contracts/v1/examples/agent-mode-envelope.minimal.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "1",
+  "mode": "agent",
+  "ok": true,
+  "command": "agents",
+  "exit_code": 0,
+  "summary": {
+    "agents": 1,
+    "servers": 1,
+    "packages": 1,
+    "vulnerabilities": 0,
+    "findings": 0,
+    "severity_counts": {
+      "critical": 0,
+      "high": 0,
+      "medium": 0,
+      "low": 0,
+      "unknown": 0
+    },
+    "posture_grade": "A"
+  },
+  "confidence": {
+    "level": "medium",
+    "signals": [
+      { "name": "schema_version", "present": true },
+      { "name": "scan_sources", "present": true },
+      { "name": "advisory_backing", "present": false }
+    ]
+  },
+  "truncated": false,
+  "truncation": {
+    "enabled": false,
+    "truncated": false,
+    "token_budget": null,
+    "approx_tokens": null,
+    "removed": {}
+  },
+  "data": {
+    "schema_version": "1.0",
+    "document_type": "AI-BOM",
+    "spec_version": "1.0",
+    "scan_id": "scan-demo-001",
+    "generated_at": "2026-04-25T00:00:00Z",
+    "summary": {
+      "total_agents": 1,
+      "total_mcp_servers": 1,
+      "total_packages": 1,
+      "total_vulnerabilities": 0
+    },
+    "agents": []
+  }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,6 +9,8 @@ The canonical command reference lives in
 - `agent-bom agents -f <format> -o <path>` validates output suffixes and
   appends the canonical suffix when `<path>` has no extension.
 - JSON reports include `posture_scorecard` and root `posture_grade`.
+- `agent-bom agents --agent-mode` writes a stable JSON envelope for assistant
+  and automation callers.
 - `agent-bom profiles ...` manages named contexts in
   `~/.agent-bom/config.toml`; unknown profiles fail with the available profile
   list.

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -13,6 +13,8 @@
 # `# reason` comments are stripped by the loader.
 
 AGENT_BOM_AI_MODEL_ADVISORY_FEED
+# CLI machine-readable envelope toggle; read by the entrypoint before config is loaded.
+AGENT_BOM_AGENT_MODE
 AGENT_BOM_ALERT_WEBHOOK
 AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS
 AGENT_BOM_ANALYTICS_BACKEND

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -86,6 +86,7 @@
 - `report pipeline-events <scan-job.json>` exports structured scan progress as JSONL for DAG/dashboard consumers.
 - `report query "SELECT ..."` runs read-only SQL against the local scan analytics store.
 - `remediate` supports `--format json` as the machine-readable remediation contract.
+- `agents --agent-mode` emits a stable JSON envelope for assistant and automation callers. It defaults to JSON stdout, reports `ok`, `exit_code`, summary counts, confidence signals, truncation metadata, and the full scan payload under `data`.
 - Use `agent-bom agents -f <format> -o <path>` for SARIF, HTML, SBOM, and richer environment exports.
 - Use `agent-bom agents -f sarif -o -` when you need SARIF on stdout for piping.
 - `where` is available both as `agent-bom where` and `agent-bom mcp where`.
@@ -103,6 +104,10 @@ agent-bom check requests@2.33.0 -e pypi -f json -o check.json
 agent-bom report diff before.json after.json -f json -o diff.json
 agent-bom report pipeline-events scan-job.json -o pipeline-events.jsonl
 agent-bom report query "SELECT severity, COUNT(*) AS count FROM scan_findings GROUP BY severity" --format json
+
+# Assistant / automation envelope
+agent-bom agents --agent-mode
+agent-bom agents --agent-mode --agent-token-budget 4000
 
 # Compliance
 agent-bom agents --compliance owasp-llm,eu-ai-act,all

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -12,6 +12,7 @@ import sys
 import click
 
 from agent_bom import __version__
+from agent_bom.cli._agent_mode import AGENT_MODE_ENV_VAR
 from agent_bom.cli._common import (
     BANNER,  # noqa: F401 — re-export for backward compatibility
     SEVERITY_ORDER,
@@ -74,13 +75,19 @@ def _print_startup_banner() -> None:
     metavar="NAME",
     help="Use a named CLI profile from ~/.agent-bom/config.toml.",
 )
+@click.option(
+    "--agent-mode",
+    is_flag=True,
+    envvar=AGENT_MODE_ENV_VAR,
+    help="Emit stable machine-readable JSON for assistant and automation callers.",
+)
 @click.version_option(
     version=__version__,
     prog_name="agent-bom",
     message=(f"agent-bom {__version__}\nPython {sys.version.split()[0]} · {sys.platform}\nDocs:  https://github.com/msaad00/agent-bom"),
 )
 @click.pass_context
-def main(ctx: click.Context, profile: str | None):
+def main(ctx: click.Context, profile: str | None, agent_mode: bool):
     """agent-bom — Security scanner for AI infrastructure.
 
     \b

--- a/src/agent_bom/cli/_agent_mode.py
+++ b/src/agent_bom/cli/_agent_mode.py
@@ -1,0 +1,149 @@
+"""Machine-readable CLI contract for assistant and automation callers."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from copy import deepcopy
+from typing import Any
+
+AGENT_MODE_ENV_VAR = "AGENT_BOM_AGENT_MODE"
+AGENT_MODE_SCHEMA_VERSION = "1"
+
+
+def agent_mode_requested(argv: list[str] | None = None) -> bool:
+    """Return True when the current invocation requested agent mode."""
+    args = sys.argv[1:] if argv is None else argv
+    if "--agent-mode" in args:
+        return True
+    raw = os.environ.get(AGENT_MODE_ENV_VAR, "")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _severity_counts(report_json: dict[str, Any]) -> dict[str, int]:
+    counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0}
+    for item in report_json.get("blast_radius", []) or []:
+        if not isinstance(item, dict):
+            continue
+        severity = str(item.get("severity") or "unknown").lower()
+        counts[severity if severity in counts else "unknown"] += 1
+    return counts
+
+
+def _summary(report_json: dict[str, Any]) -> dict[str, Any]:
+    summary_raw = report_json.get("summary")
+    summary: dict[str, Any] = summary_raw if isinstance(summary_raw, dict) else {}
+    inventory_raw = report_json.get("inventory_snapshot")
+    inventory: dict[str, Any] = inventory_raw if isinstance(inventory_raw, dict) else {}
+    agents_raw = report_json.get("agents")
+    agents: list[Any] = agents_raw if isinstance(agents_raw, list) else []
+    blast_radius_raw = report_json.get("blast_radius")
+    blast_radius: list[Any] = blast_radius_raw if isinstance(blast_radius_raw, list) else []
+    findings_raw = report_json.get("findings")
+    findings: list[Any] = findings_raw if isinstance(findings_raw, list) else []
+    scorecard_raw = report_json.get("posture_scorecard")
+    scorecard: dict[str, Any] = scorecard_raw if isinstance(scorecard_raw, dict) else {}
+    return {
+        "agents": summary.get("agents", len(agents)),
+        "servers": summary.get("servers", inventory.get("servers")),
+        "packages": summary.get("packages", inventory.get("packages")),
+        "vulnerabilities": summary.get("total_vulnerabilities", len(blast_radius)),
+        "findings": len(findings),
+        "severity_counts": _severity_counts(report_json),
+        "posture_grade": report_json.get("posture_grade") or scorecard.get("grade"),
+    }
+
+
+def _confidence(report_json: dict[str, Any]) -> dict[str, Any]:
+    sources_raw = report_json.get("scan_sources")
+    sources: list[Any] = sources_raw if isinstance(sources_raw, list) else []
+    blast_radius_raw = report_json.get("blast_radius")
+    blast_radius: list[Any] = blast_radius_raw if isinstance(blast_radius_raw, list) else []
+    has_advisory_backing = any(isinstance(item, dict) and item.get("vulnerability_id") for item in blast_radius)
+    signals = [
+        {"name": "schema_version", "present": bool(report_json.get("schema_version"))},
+        {"name": "scan_sources", "present": bool(sources)},
+        {"name": "advisory_backing", "present": has_advisory_backing},
+    ]
+    present = sum(1 for signal in signals if signal["present"])
+    level = "high" if present >= 2 else "medium" if present == 1 else "low"
+    return {"level": level, "signals": signals}
+
+
+def _truncate_report(report_json: dict[str, Any], token_budget: int) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Trim largest report collections to fit an approximate token budget."""
+    if token_budget <= 0:
+        return report_json, {"enabled": False, "truncated": False, "token_budget": None, "approx_tokens": None, "removed": {}}
+
+    payload = deepcopy(report_json)
+    removed: dict[str, int] = {}
+
+    def approx_tokens() -> int:
+        return max(1, len(json.dumps(payload, separators=(",", ":"), default=str)) // 4)
+
+    def trim_list(key: str) -> None:
+        value = payload.get(key)
+        if not isinstance(value, list) or len(value) <= 1:
+            return
+        keep = max(1, len(value) // 2)
+        removed[key] = removed.get(key, 0) + len(value) - keep
+        payload[key] = value[:keep]
+
+    for key in ("findings", "blast_radius", "agents"):
+        while approx_tokens() > token_budget and isinstance(payload.get(key), list) and len(payload[key]) > 1:
+            trim_list(key)
+
+    final_tokens = approx_tokens()
+    return payload, {
+        "enabled": True,
+        "truncated": bool(removed),
+        "token_budget": token_budget,
+        "approx_tokens": final_tokens,
+        "removed": removed,
+    }
+
+
+def success_envelope(
+    *,
+    command: str,
+    report_json: dict[str, Any],
+    exit_code: int,
+    token_budget: int = 0,
+) -> dict[str, Any]:
+    """Wrap a scan report in the stable agent-mode success envelope."""
+    payload, truncation = _truncate_report(report_json, token_budget)
+    return {
+        "schema_version": AGENT_MODE_SCHEMA_VERSION,
+        "mode": "agent",
+        "ok": exit_code == 0,
+        "command": command,
+        "exit_code": exit_code,
+        "summary": _summary(report_json),
+        "confidence": _confidence(report_json),
+        "truncated": bool(truncation["truncated"]),
+        "truncation": truncation,
+        "data": payload,
+    }
+
+
+def error_envelope(*, command: str | None, message: str, exit_code: int, error_type: str) -> dict[str, Any]:
+    """Build the stable agent-mode error envelope."""
+    error = {
+        "type": error_type,
+        "message": message,
+    }
+    return {
+        "schema_version": AGENT_MODE_SCHEMA_VERSION,
+        "mode": "agent",
+        "ok": False,
+        "command": command,
+        "exit_code": exit_code,
+        "truncated": False,
+        "error": error,
+        "errors": [error],
+    }
+
+
+def dumps_envelope(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True, default=str)

--- a/src/agent_bom/cli/_entry.py
+++ b/src/agent_bom/cli/_entry.py
@@ -14,6 +14,7 @@ from typing import Callable
 
 import click
 
+from agent_bom.cli._agent_mode import agent_mode_requested, dumps_envelope, error_envelope
 from agent_bom.cli._common import (
     _check_for_update_bg,
     _print_update_notice,
@@ -45,15 +46,37 @@ def make_entry_point(
         _group = group() if callable(group) and not isinstance(group, click.Group) else group
 
         try:
-            _group(standalone_mode=True)
+            _group(standalone_mode=not agent_mode_requested())
         except SystemExit as exc:
             if exc.code == 0:
                 _print_update_notice(Console(stderr=True))
             raise
         except KeyboardInterrupt:
+            if agent_mode_requested():
+                click.echo(
+                    dumps_envelope(error_envelope(command=_command_name(), message="Interrupted.", exit_code=130, error_type="interrupt")),
+                    err=False,
+                )
+                sys.exit(130)
             click.echo("\nInterrupted.", err=True)
             sys.exit(130)
+        except click.ClickException as exc:
+            if agent_mode_requested():
+                click.echo(
+                    dumps_envelope(
+                        error_envelope(command=_command_name(), message=exc.format_message(), exit_code=exc.exit_code, error_type="usage")
+                    ),
+                    err=False,
+                )
+                sys.exit(exc.exit_code)
+            raise
         except Exception as exc:  # noqa: BLE001
+            if agent_mode_requested():
+                click.echo(
+                    dumps_envelope(error_envelope(command=_command_name(), message=str(exc), exit_code=1, error_type=type(exc).__name__)),
+                    err=False,
+                )
+                sys.exit(1)
             verbose = "--verbose" in sys.argv or "-v" in sys.argv
             err_console = Console(stderr=True)
             err_console.print(f"\n[bold red]{product_name} error:[/bold red] {exc}")
@@ -65,3 +88,10 @@ def make_entry_point(
 
     entry_main.__doc__ = f"Entry point for {product_name}."
     return entry_main
+
+
+def _command_name() -> str | None:
+    for arg in sys.argv[1:]:
+        if not arg.startswith("-"):
+            return arg
+    return None

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -389,6 +389,8 @@ def scan(
     log_file: Optional[str],
     no_color: bool,
     reproducible: bool,
+    agent_mode: bool,
+    agent_token_budget: int,
     preset: Optional[str],
     open_report: bool,
     compliance_export: Optional[str],
@@ -429,7 +431,10 @@ def scan(
 
     _scan_start = _time.monotonic()
 
+    from agent_bom.cli._agent_mode import agent_mode_requested
     from agent_bom.cli._profiles import apply_scan_profile_defaults
+
+    agent_mode = agent_mode or agent_mode_requested()
 
     (
         output,
@@ -448,6 +453,19 @@ def scan(
         push_api_key=push_api_key,
         clickhouse_url=clickhouse_url,
     )
+
+    if agent_token_budget < 0:
+        raise click.ClickException("--agent-token-budget must be greater than or equal to 0.")
+    if agent_mode:
+        if _output_format_was_explicit() and output_format != "json":
+            raise click.ClickException("--agent-mode requires --format json.")
+        output_format = "json"
+        click_ctx = click.get_current_context(silent=True)
+        output_source = click_ctx.get_parameter_source("output") if click_ctx is not None else None
+        explicit_output = output_source in {click.core.ParameterSource.COMMANDLINE, click.core.ParameterSource.ENVIRONMENT}
+        output = output if explicit_output and output else "-"
+        quiet = True
+        no_color = True
 
     # Configure logging — explicit --log-level overrides --verbose
     if quiet and log_level is None and not verbose and not log_json and not log_file:
@@ -2264,7 +2282,7 @@ def scan(
     # Step 5: Output
     _step_t0 = _time.monotonic()
     _posture_console_only = posture and output_format == "console" and not output
-    if not _posture_console_only:
+    if not _posture_console_only and not agent_mode:
         render_output(
             ctx,
             output=output,
@@ -2282,6 +2300,8 @@ def scan(
             verbose=verbose,
             exclude_unfixable=exclude_unfixable,
             fixable_only=fixable_only,
+            agent_mode=agent_mode,
+            agent_token_budget=agent_token_budget,
         )
 
     # ── Posture summary mode (--posture) ──────────────────────────────────────
@@ -2395,6 +2415,28 @@ def scan(
         push_api_key=push_api_key,
         quiet=quiet,
     )
+
+    if agent_mode:
+        render_output(
+            ctx,
+            output=output,
+            output_format=output_format,
+            no_tree=no_tree,
+            quiet=quiet,
+            no_color=no_color,
+            open_report=open_report,
+            compliance_export=compliance_export,
+            mermaid_mode=mermaid_mode,
+            push_gateway=push_gateway,
+            otel_endpoint=otel_endpoint,
+            baseline=baseline,
+            delta_mode=delta_mode,
+            verbose=verbose,
+            exclude_unfixable=exclude_unfixable,
+            fixable_only=fixable_only,
+            agent_mode=agent_mode,
+            agent_token_budget=agent_token_budget,
+        )
 
     if exit_code:
         sys.exit(exit_code)

--- a/src/agent_bom/cli/agents/_output.py
+++ b/src/agent_bom/cli/agents/_output.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import click
 
+from agent_bom.cli._agent_mode import dumps_envelope, success_envelope
 from agent_bom.cli.agents._context import ScanContext
 from agent_bom.models import AIBOMReport
 from agent_bom.output import (
@@ -114,6 +115,8 @@ def render_output(
     verbose: bool = False,
     exclude_unfixable: bool = False,
     fixable_only: bool = False,
+    agent_mode: bool = False,
+    agent_token_budget: int = 0,
     **kwargs: Any,
 ) -> None:
     """Step 5: render report to console/file. Also Steps 5b, 5c, 5d."""
@@ -170,6 +173,14 @@ def render_output(
         elif output_format == "graph-html":
             click.echo("Error: --format graph-html requires --output/-o (cannot write HTML to stdout)", err=True)
             sys.exit(2)
+        elif agent_mode:
+            payload = success_envelope(
+                command="agents",
+                report_json=to_json(report),
+                exit_code=ctx.exit_code,
+                token_budget=agent_token_budget,
+            )
+            sys.stdout.write(dumps_envelope(payload))
         else:
             sys.stdout.write(json.dumps(to_json(report), indent=2))
         sys.stdout.write("\n")

--- a/src/agent_bom/cli/options_sources.py
+++ b/src/agent_bom/cli/options_sources.py
@@ -200,6 +200,20 @@ def output_options(fn):
             ),
             click.option("--quiet", "-q", is_flag=True, help="Suppress all output except results (for scripting)"),
             click.option(
+                "--agent-mode",
+                is_flag=True,
+                envvar="AGENT_BOM_AGENT_MODE",
+                help="Emit stable machine-readable JSON for assistant and automation callers.",
+            ),
+            click.option(
+                "--agent-token-budget",
+                type=int,
+                default=0,
+                show_default=True,
+                metavar="TOKENS",
+                help="Approximate JSON token budget for --agent-mode output. 0 keeps the full report.",
+            ),
+            click.option(
                 "--exclude-unfixable",
                 is_flag=True,
                 default=False,

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -8,11 +8,13 @@ no network or filesystem side-effects escape the test.
 from __future__ import annotations
 
 import json
+import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
 from click.testing import CliRunner
 
-from agent_bom.cli import main
+from agent_bom.cli import cli_main, main
 from agent_bom.models import Agent, AgentType, BlastRadius, MCPServer, Package, Severity, Vulnerability
 from agent_bom.scanners import IncompleteScanError
 
@@ -76,6 +78,73 @@ def test_scan_help():
     assert "--no-follow-symlinks" in result.output
     assert "graph (Cytoscape.js graph JSON)" in normalized
     assert "graph (raw graph JSON)" not in normalized
+
+
+def test_scan_agent_mode_emits_machine_envelope(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_CONFIG", raising=False)
+    result = _run(["agents", "--agent-mode", "--demo", "--no-scan", "--offline", "--no-auto-update-db"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["schema_version"] == "1"
+    assert payload["mode"] == "agent"
+    assert payload["ok"] is True
+    assert payload["command"] == "agents"
+    assert payload["exit_code"] == 0
+    assert payload["summary"]["agents"] >= 1
+    assert payload["confidence"]["level"] in {"high", "medium", "low"}
+    assert payload["truncated"] is False
+    assert payload["truncation"]["truncated"] is False
+    assert payload["data"]["document_type"] == "AI-BOM"
+
+
+def test_scan_agent_mode_ignores_profile_output_default(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+current_profile = "prod"
+
+[profiles.prod]
+format = "json"
+output = "profile-report.json"
+"""
+    )
+    monkeypatch.setenv("AGENT_BOM_CONFIG", str(config_path))
+
+    result = _run(["agents", "--agent-mode", "--demo", "--no-scan", "--offline", "--no-auto-update-db"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["mode"] == "agent"
+
+
+def test_scan_agent_mode_token_budget_reports_truncation(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_CONFIG", raising=False)
+    result = _run(["agents", "--agent-mode", "--agent-token-budget", "200", "--demo", "--no-scan", "--offline", "--no-auto-update-db"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["truncation"]["enabled"] is True
+    assert payload["truncation"]["token_budget"] == 200
+    assert payload["truncated"] is True
+    assert payload["truncation"]["truncated"] is True
+    assert payload["truncation"]["removed"]
+
+
+def test_agent_mode_entry_wraps_usage_errors(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["agent-bom", "--agent-mode", "not-a-command"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main()
+
+    assert excinfo.value.code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "agent"
+    assert payload["ok"] is False
+    assert payload["exit_code"] == 2
+    assert payload["truncated"] is False
+    assert payload["error"]["type"] == "usage"
+    assert payload["errors"][0]["type"] == "usage"
 
 
 def test_scan_external_scan_invalid_json_exits_nonzero(tmp_path):

--- a/tests/test_contract_schemas.py
+++ b/tests/test_contract_schemas.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import jsonschema
 
+from agent_bom.cli._agent_mode import error_envelope, success_envelope
 from agent_bom.models import Agent, AgentStatus, AgentType, AIBOMReport
 from agent_bom.output import to_json
 
@@ -61,6 +62,20 @@ def test_scan_report_serializer_matches_contract_schema() -> None:
     agent_payload = payload["agents"][0]
     assert agent_payload["agent_type"] == "claude-desktop"
     assert agent_payload["type"] == "claude-desktop"
+
+
+def test_agent_mode_envelopes_match_contract_schema() -> None:
+    schema = _load(CONTRACTS / "agent-mode-envelope.schema.json")
+    report = _load(CONTRACTS / "examples" / "scan-report.minimal.json")
+
+    jsonschema.validate(
+        success_envelope(command="agents", report_json=report, exit_code=0),
+        schema,
+    )
+    jsonschema.validate(
+        error_envelope(command="agents", message="invalid command", exit_code=2, error_type="usage"),
+        schema,
+    )
 
 
 def test_scan_report_helper_findings_match_contract_schema() -> None:


### PR DESCRIPTION
Summary
- adds a global --agent-mode flag and AGENT_BOM_AGENT_MODE env toggle for machine-readable CLI envelopes
- adds token-budget truncation metadata and confidence fields for assistant/operator workflows
- locks the agent-mode envelope with a JSON Schema and example fixture
- updates CLI docs/reference and env allowlist

Notes
- clean rebuild from current main after closing #2476
- intentionally excludes CI workflow changes; CI retrigger hardening is isolated in #2478

Validation
- uv run pytest -q tests/test_cli_scan.py::test_scan_agent_mode_emits_machine_envelope tests/test_cli_scan.py::test_scan_agent_mode_token_budget_reports_truncation tests/test_cli_scan.py::test_agent_mode_entry_wraps_usage_errors tests/test_contract_schemas.py::test_contract_schemas_are_valid_draft_2020_12 tests/test_contract_schemas.py::test_contract_examples_match_their_schema tests/test_contract_schemas.py::test_agent_mode_envelopes_match_contract_schema
- uv run ruff check src/agent_bom/cli/_agent_mode.py tests/test_cli_scan.py tests/test_contract_schemas.py
- uv run python scripts/check_cli_reference_alignment.py
- pre-commit run --files contracts/v1/README.md contracts/v1/agent-mode-envelope.schema.json contracts/v1/examples/agent-mode-envelope.minimal.json docs/cli.md scripts/env_var_allowlist.txt site-docs/reference/cli.md src/agent_bom/cli/__init__.py src/agent_bom/cli/_agent_mode.py src/agent_bom/cli/_entry.py src/agent_bom/cli/agents/__init__.py src/agent_bom/cli/agents/_output.py src/agent_bom/cli/options_sources.py tests/test_cli_scan.py tests/test_contract_schemas.py
- git diff --check