### PR TITLE
security: require verified agent identity tokens

### DIFF
--- a/src/agent_bom/agent_identity.py
+++ b/src/agent_bom/agent_identity.py
@@ -8,7 +8,9 @@ Two supported token formats:
 - **JWT** (three base64url parts): payload decoded, ``sub`` claim used as
   ``agent_id``.  When ``jwks_uri`` is set in policy, the signature is
   cryptographically verified (RS256/ES256/RS384/ES384).  Expiry (``exp``) is
-  always checked.  The ``none`` algorithm is always rejected.
+  always checked.  The ``none`` algorithm is always rejected.  Enforced
+  identity mode requires JWT verification; unsigned JWTs are only accepted in
+  non-blocking audit mode.
 - **Opaque token**: looked up in ``policy.agent_tokens`` dict
   (``{token: agent_id}``).
 
@@ -241,12 +243,15 @@ def resolve_agent_id(token: str, policy: dict) -> tuple[str, str | None]:
             except (TypeError, ValueError):
                 return ANONYMOUS, "Invalid JWT exp claim"
 
-        # Cryptographic signature verification when JWKS is configured
+        # Cryptographic signature verification when JWKS is configured. In
+        # enforced mode, a JWT without verification policy is not an identity.
         jwks_uri = _resolve_jwks_uri(policy)
         if jwks_uri:
             verified, sig_err = _verify_jwt_signature(token, jwks_uri)
             if not verified:
                 return ANONYMOUS, f"JWT signature invalid: {sig_err}"
+        elif policy.get("require_agent_identity"):
+            return ANONYMOUS, "JWT signature verification required: configure jwks_uri or oidc_issuer"
 
         agent_id = claims.get("sub") or claims.get("agent_id") or claims.get("name")
         if not agent_id or not isinstance(agent_id, str):

--- a/tests/test_agent_identity.py
+++ b/tests/test_agent_identity.py
@@ -187,13 +187,14 @@ def test_check_identity_valid_jwt_passes():
     assert block is None
 
 
-def test_check_identity_valid_jwt_required_passes():
+def test_check_identity_unsigned_jwt_required_blocks_without_verification_policy():
     token = _make_jwt({"sub": "agent-diana"})
     msg = _msg_with_identity(token)
     policy = {"require_agent_identity": True}
     agent_id, block = check_identity(msg, policy)
-    assert agent_id == "agent-diana"
-    assert block is None
+    assert agent_id == ANONYMOUS
+    assert block is not None
+    assert "signature verification required" in block
 
 
 def test_check_identity_expired_jwt_required_blocks():

--- a/tests/test_jwks_identity.py
+++ b/tests/test_jwks_identity.py
@@ -202,8 +202,8 @@ def test_check_identity_jwks_required_blocks_on_no_jwks_key():
     assert block is not None
 
 
-def test_check_identity_no_jwks_configured_passes_as_before():
-    """Without jwks_uri, identity check passes for well-formed JWT — no regression."""
+def test_check_identity_no_jwks_configured_audit_mode_passes_as_before():
+    """Without jwks_uri, non-enforcing audit mode still resolves a well-formed JWT."""
 
     def _msg(token):
         return {
@@ -215,3 +215,19 @@ def test_check_identity_no_jwks_configured_passes_as_before():
     agent_id, block = check_identity(_msg(token), {})
     assert agent_id == "agent-ok"
     assert block is None
+
+
+def test_check_identity_required_jwt_without_verification_policy_blocks():
+    """Enforced identity mode must not trust an unsigned JWT identity claim."""
+
+    def _msg(token):
+        return {
+            "method": "tools/call",
+            "params": {"name": "x", "arguments": {}, "_meta": {"agent_identity": token}},
+        }
+
+    token = _make_jwt({"sub": "agent-claimed"})
+    agent_id, block = check_identity(_msg(token), {"require_agent_identity": True})
+    assert agent_id == ANONYMOUS
+    assert block is not None
+    assert "signature verification required" in block


### PR DESCRIPTION
Summary
- fail closed when require_agent_identity=true receives a JWT without jwks_uri or oidc_issuer verification policy
- keep non-enforcing audit mode compatible with well-formed JWT identity extraction
- add regression coverage for unsigned JWTs in enforced identity mode

Validation
- uv run pytest -q tests/test_agent_identity.py tests/test_jwks_identity.py
- uv run ruff check src/agent_bom/agent_identity.py tests/test_agent_identity.py tests/test_jwks_identity.py
- git diff --check