### PR TITLE
test: add release fixture coverage

### DIFF
--- a/tests/fixtures/npm-workspace-package-lock/apps/web/package-lock.json
+++ b/tests/fixtures/npm-workspace-package-lock/apps/web/package-lock.json
@@ -1,0 +1,41 @@
+{
+  "name": "workspace-web",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "workspace-web",
+      "version": "1.0.0",
+      "dependencies": {
+        "@sample/ui": "1.0.0",
+        "react": "18.2.0"
+      },
+      "devDependencies": {
+        "vite": "5.4.0"
+      }
+    },
+    "node_modules/@sample/ui": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sample/ui/-/ui-1.0.0.tgz",
+      "integrity": "sha512-fixture"
+    },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-fixture"
+    },
+    "node_modules/vite": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.0.tgz",
+      "integrity": "sha512-fixture",
+      "dev": true
+    },
+    "node_modules/rollup": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
+      "integrity": "sha512-fixture",
+      "dev": true
+    }
+  }
+}

--- a/tests/fixtures/npm-workspace-package-lock/apps/web/package.json
+++ b/tests/fixtures/npm-workspace-package-lock/apps/web/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "workspace-web",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@sample/ui": "1.0.0",
+    "react": "18.2.0"
+  },
+  "devDependencies": {
+    "vite": "5.4.0"
+  }
+}

--- a/tests/fixtures/npm-workspace-package-lock/package.json
+++ b/tests/fixtures/npm-workspace-package-lock/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "workspace-fixture",
+  "private": true,
+  "workspaces": [
+    "apps/*"
+  ]
+}

--- a/tests/fixtures/output/demo-markdown-golden.md
+++ b/tests/fixtures/output/demo-markdown-golden.md
@@ -1,0 +1,51 @@
+# agent-bom Scan Report
+
+**Generated**: 2026-01-01 12:00:00 UTC
+**Version**: agent-bom v0.70.6
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Agents discovered | 1 |
+| MCP servers | 1 |
+| Packages scanned | 1 |
+| Vulnerabilities | 4 |
+| Policy/security findings | 0 |
+| Critical | 1 |
+| High | 1 |
+| Medium | 1 |
+| Low | 1 |
+
+## Findings
+
+| Severity | CVE | Package | Version | Fix | CVSS | Agents |
+|----------|-----|---------|---------|-----|------|--------|
+| **CRITICAL** | CVE-2024-0001 | lodash | 4.17.20 | 4.17.21 | 9.8 | 1 |
+| **HIGH** | CVE-2024-0002 | requests | 2.28.0 | 2.31.0 | 7.5 | 1 |
+| **MEDIUM** | CVE-2024-0003 | express | 4.18.0 | 4.17.21 | 5.3 | 1 |
+| **LOW** | CVE-2024-0004 | debug | 4.3.0 | 4.17.21 | 2.1 | 1 |
+
+## Critical & High Findings
+
+### CVE-2024-0001 — lodash@4.17.20
+
+> Test vulnerability
+
+- **Severity**: CRITICAL
+- **CVSS**: 9.8
+- **Fix**: Upgrade to 4.17.21
+- **CWE**: CWE-1321
+- **Affected agents**: claude
+
+### CVE-2024-0002 — requests@2.28.0
+
+> Test vulnerability
+
+- **Severity**: HIGH
+- **CVSS**: 7.5
+- **Fix**: Upgrade to 2.31.0
+- **Affected agents**: claude
+
+---
+*Scanned by [agent-bom](https://github.com/msaad00/agent-bom) v0.70.6*

--- a/tests/fixtures/skills/missing-guardrail/SKILL.md
+++ b/tests/fixtures/skills/missing-guardrail/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: missing-guardrail-fixture
+description: Fixture that intentionally omits the capability guardrail contract.
+---
+
+# Missing Guardrail Fixture
+
+This fixture asks the operator to bypass guardrails before reading `.env`
+content. It intentionally omits the `capabilities` block so the scanner keeps
+reporting the missing capability declaration alongside the behavioral finding.

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -7,6 +7,7 @@ import io
 import json
 import xml.etree.ElementTree as ET
 from datetime import datetime
+from pathlib import Path
 
 from agent_bom.finding import Asset, Finding, FindingSource, FindingType
 from agent_bom.models import (
@@ -24,6 +25,8 @@ from agent_bom.models import (
 )
 from agent_bom.output import to_csv, to_json, to_junit, to_markdown
 from agent_bom.output.html import to_html
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -441,6 +444,13 @@ class TestMarkdown:
         md = to_markdown(report, brs)
         assert "4.17.21" in md
         assert "2.31.0" in md
+
+    def test_demo_markdown_export_matches_golden_fixture(self):
+        report, brs = _report_with_vulns()
+        golden = (FIXTURES / "output" / "demo-markdown-golden.md").read_text(encoding="utf-8")
+        rendered = to_markdown(report, brs).replace("  \n", "\n")
+
+        assert rendered == golden
 
     def test_footer(self):
         report, brs = _report_with_vulns()

--- a/tests/test_project_mode.py
+++ b/tests/test_project_mode.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from agent_bom.parsers import scan_project_directory, summarize_project_inventory
 from agent_bom.sbom import detect_sbom_resource_name, load_sbom
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
 
 # ── scan_project_directory ────────────────────────────────────────────────────
 
@@ -189,6 +192,30 @@ class TestScanProjectDirectory:
         assert summary["ecosystems"] == {"npm": 2}
         assert summary["directories"][0]["lockfile_files"] == ["package-lock.json"]
         assert summary["directories"][0]["advisory_evidence"] == "lockfile_backed"
+
+    def test_workspace_package_lock_fixture_keeps_nested_manifest_context(self):
+        fixture_root = FIXTURES / "npm-workspace-package-lock"
+        web_dir = fixture_root / "apps" / "web"
+
+        result = scan_project_directory(fixture_root)
+        assert web_dir in result
+
+        packages = {package.name: package for package in result[web_dir]}
+        assert packages["react"].version == "18.2.0"
+        assert packages["react"].is_direct is True
+        assert packages["@sample/ui"].version == "1.0.0"
+        assert packages["@sample/ui"].is_direct is True
+        assert packages["vite"].version == "5.4.0"
+        assert packages["vite"].is_direct is True
+        assert packages["rollup"].version == "4.24.0"
+        assert packages["rollup"].is_direct is False
+
+        summary = summarize_project_inventory(fixture_root, result)
+        directory = next(item for item in summary["directories"] if item["path"] == "apps/web")
+        assert set(directory["manifest_files"]) == {"package.json", "package-lock.json"}
+        assert directory["lockfile_files"] == ["package-lock.json"]
+        assert directory["advisory_evidence"] == "lockfile_backed"
+        assert summary["ecosystems"] == {"npm": 4}
 
     def test_summarize_project_inventory_marks_manifest_only_depth(self, tmp_path):
         (tmp_path / "requirements.txt").write_text("requests==2.31.0\nflask==3.0.0\n")

--- a/tests/test_skills_cli.py
+++ b/tests/test_skills_cli.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from click.testing import CliRunner
 
 from agent_bom.cli import main
 from agent_bom.skill_bundles import build_skill_bundle
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
 
 
 def test_skills_scan_json(tmp_path):
@@ -45,6 +48,24 @@ Environment:
     assert data["files"][0]["bundle"]["sha256"]
     assert data["files"][0]["trust"]["review_verdict"] in {"trusted", "review", "high_risk", "blocked"}
     assert "behavioral_summary" in data["files"][0]["audit"]
+
+
+def test_skills_scan_missing_guardrail_fixture_reports_contract_gap():
+    """Release fixture for skill files that omit declared capability guardrails."""
+    fixture = FIXTURES / "skills" / "missing-guardrail"
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["skills", "scan", str(fixture), "--format", "json"])
+    assert result.exit_code == 0, result.output
+
+    data = json.loads(result.output)
+    findings = data["files"][0]["audit"]["findings"]
+    categories = {finding["category"] for finding in findings}
+
+    assert data["summary"]["files_scanned"] == 1
+    assert "missing_capability_declaration" in categories
+    assert "prompt_coercion" in categories
+    assert data["files"][0]["audit"]["behavioral_summary"]["high_or_critical"] >= 1
 
 
 def test_skills_scan_json_with_catalog_and_intel(tmp_path):


### PR DESCRIPTION
Summary
- adds a missing-guardrail skill fixture that verifies capability declaration gaps are surfaced with behavioral findings
- adds an npm workspace package-lock fixture to keep nested workspace manifests and lockfile-backed advisory evidence covered
- adds a deterministic demo Markdown export golden fixture

Closes #2371
Closes #2368
Closes #2367

Validation
- uv run pytest -q tests/test_skills_cli.py::test_skills_scan_missing_guardrail_fixture_reports_contract_gap tests/test_project_mode.py::TestScanProjectDirectory::test_workspace_package_lock_fixture_keeps_nested_manifest_context tests/test_output_formats.py::TestMarkdown::test_demo_markdown_export_matches_golden_fixture
- uv run ruff check tests/test_skills_cli.py tests/test_project_mode.py tests/test_output_formats.py
- git diff --check origin/main..HEAD
- git diff --check