### PR TITLE
ui: tighten release graph evidence views

### DIFF
--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -512,7 +512,7 @@ export default function ContextPage() {
           </div>
 
           <FullscreenButton />
-          <GraphLegend items={legendItems} defaultOpen={captureMode} />
+          <GraphLegend items={legendItems} />
         </div>
       </div>
 

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -507,7 +507,7 @@ export default function MeshPage() {
             ))}
           </select>
           <FullscreenButton />
-          <GraphLegend items={legendItems} defaultOpen={captureMode} />
+          <GraphLegend items={legendItems} />
         </div>
       </div>
 

--- a/ui/components/charts.tsx
+++ b/ui/components/charts.tsx
@@ -22,7 +22,7 @@ import {
   RadialBar,
 } from "recharts";
 import type { Agent, BlastRadius } from "@/lib/api";
-import { blastPriority } from "@/lib/insights-risk";
+import { buildBlastRadiusSummary } from "@/lib/insights-risk";
 
 // ─── Shared ──────────────────────────────────────────────────────────────────
 
@@ -417,30 +417,34 @@ interface RadialPoint {
   name: string;
   value: number;
   score: number;
+  vulnerabilityCount: number;
+  agentCount: number;
+  serverCount: number;
   fill: string;
 }
 
 export function BlastRadiusRadial({ data }: { data: BlastRadius[] }) {
-  const top = [...data]
-    .sort((a, b) => blastPriority(b) - blastPriority(a))
-    .slice(0, 8);
+  const top = buildBlastRadiusSummary(data, 8);
 
   if (top.length === 0) return null;
 
-  const maxScore = Math.max(...top.map(blastPriority), 1);
+  const maxScore = Math.max(...top.map((entry) => entry.score), 1);
 
-  const radialData: RadialPoint[] = top?.map((br) => {
-    const sev = br.severity?.toLowerCase() ?? "low";
-    const score = blastPriority(br);
+  const radialData: RadialPoint[] = top?.map((entry) => {
+    const sev = entry.severity?.toLowerCase() ?? "low";
+    const score = entry.score;
     const fill =
       sev === "critical" ? "#ef4444"
       : sev === "high" ? "#f97316"
       : sev === "medium" ? "#eab308"
       : "#3b82f6";
     return {
-      name: br.package ?? br.vulnerability_id,
+      name: entry.name,
       value: Math.round((score / maxScore) * 100),
       score,
+      vulnerabilityCount: entry.vulnerability_count,
+      agentCount: entry.agent_count,
+      serverCount: entry.server_count,
       fill,
     };
   });
@@ -449,7 +453,7 @@ export function BlastRadiusRadial({ data }: { data: BlastRadius[] }) {
     <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5 shadow-lg shadow-zinc-950/50">
       <h3 className="text-sm font-semibold text-zinc-300 mb-1">Blast Radius</h3>
       <p className="text-[10px] text-zinc-600 mb-2">
-        Top reachable or vulnerable packages by relative priority
+        Top reachable packages by highest priority, grouped by package
       </p>
       <div className="h-64">
         <ResponsiveContainer width="100%" height="100%">
@@ -480,6 +484,14 @@ export function BlastRadiusRadial({ data }: { data: BlastRadius[] }) {
                   >
                     <div className="font-mono text-zinc-300 mb-1 truncate max-w-[160px]">{d.name}</div>
                     <div className="flex justify-between gap-4">
+                      <span className="text-zinc-500">Findings</span>
+                      <span className="font-mono text-zinc-300">{d.vulnerabilityCount}</span>
+                    </div>
+                    <div className="flex justify-between gap-4">
+                      <span className="text-zinc-500">Agents</span>
+                      <span className="font-mono text-zinc-300">{d.agentCount || "n/a"}</span>
+                    </div>
+                    <div className="flex justify-between gap-4">
                       <span className="text-zinc-500">Priority</span>
                       <span className="font-mono" style={{ color: d.fill }}>{d.score.toFixed(1)}</span>
                     </div>
@@ -499,6 +511,7 @@ export function BlastRadiusRadial({ data }: { data: BlastRadius[] }) {
           <div key={d.name} className="flex items-center gap-2 text-[10px]">
             <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: d.fill }} />
             <span className="text-zinc-400 font-mono truncate flex-1">{d.name}</span>
+            <span className="text-zinc-600 font-mono">{d.vulnerabilityCount} findings</span>
             <span className="text-zinc-600 font-mono">{d.score.toFixed(0)}</span>
           </div>
         ))}

--- a/ui/lib/graph-viewport.ts
+++ b/ui/lib/graph-viewport.ts
@@ -63,13 +63,13 @@ export function graphFitViewOptions(input: GraphViewportInput): GraphFitViewOpti
   }
 
   if (input.captureMode) {
-    padding -= input.mode === "mesh" ? 0.04 : 0.02;
-    maxZoom += input.mode === "mesh" ? 0.18 : 0.1;
+    padding -= input.mode === "mesh" ? 0.06 : 0.02;
+    maxZoom += input.mode === "mesh" ? 0.44 : 0.1;
   }
 
   return {
     padding: clamp(padding, 0.08, 0.24),
-    maxZoom: clamp(maxZoom + selectedBoost, 0.82, 1.82),
+    maxZoom: clamp(maxZoom + selectedBoost, 0.82, 2.25),
     duration: input.captureMode ? 0 : 240,
   };
 }

--- a/ui/lib/insights-risk.ts
+++ b/ui/lib/insights-risk.ts
@@ -142,3 +142,61 @@ export function buildEpssVsCvss(blasts: BlastRadius[]): EpssVsCvssPoint[] {
     return severityDelta || b.blast - a.blast;
   });
 }
+
+export interface BlastRadiusSummary {
+  name: string;
+  score: number;
+  severity: string;
+  vulnerability_count: number;
+  agent_count: number;
+  server_count: number;
+}
+
+export function buildBlastRadiusSummary(blasts: BlastRadius[], limit = 8): BlastRadiusSummary[] {
+  const grouped = new Map<
+    string,
+    {
+      score: number;
+      severity: string;
+      vulnerabilities: Set<string>;
+      agents: Set<string>;
+      servers: Set<string>;
+    }
+  >();
+
+  for (const blast of blasts) {
+    const name = blast.package ?? blast.vulnerability_id;
+    const entry = grouped.get(name) ?? {
+      score: 0,
+      severity: "low",
+      vulnerabilities: new Set<string>(),
+      agents: new Set<string>(),
+      servers: new Set<string>(),
+    };
+    const severity = normalizeSeverity(blast.severity);
+    if ((SEVERITY_RANK[severity] ?? 0) > (SEVERITY_RANK[entry.severity] ?? 0)) {
+      entry.severity = severity;
+    }
+    entry.score = Math.max(entry.score, blastPriority(blast));
+    entry.vulnerabilities.add(blast.vulnerability_id);
+    for (const agent of blast.affected_agents ?? []) {
+      entry.agents.add(agent);
+    }
+    for (const server of blast.affected_servers ?? []) {
+      entry.servers.add(server);
+    }
+    grouped.set(name, entry);
+  }
+
+  return [...grouped.entries()]
+    .map(([name, entry]) => ({
+      name,
+      score: entry.score,
+      severity: entry.severity,
+      vulnerability_count: entry.vulnerabilities.size,
+      agent_count: entry.agents.size,
+      server_count: entry.servers.size,
+    }))
+    .sort((left, right) => right.score - left.score || right.vulnerability_count - left.vulnerability_count || left.name.localeCompare(right.name))
+    .slice(0, limit);
+}

--- a/ui/tests/insights-risk.test.ts
+++ b/ui/tests/insights-risk.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Agent, BlastRadius, ScanResult } from "@/lib/api";
-import { blastPriority, buildDerivedBlastRadius, buildEpssVsCvss, buildPipelineStats, effectiveBlastRadius } from "@/lib/insights-risk";
+import { blastPriority, buildBlastRadiusSummary, buildDerivedBlastRadius, buildEpssVsCvss, buildPipelineStats, effectiveBlastRadius } from "@/lib/insights-risk";
 
 const agents = [
   {
@@ -73,5 +73,43 @@ describe("insights risk helpers", () => {
 
     expect(blastPriority(blast)).toBe(85);
     expect(buildEpssVsCvss([{ ...blast, cvss_score: 8.1, epss_score: 0.2 }])[0]!.blast).toBe(85);
+  });
+
+  it("groups blast radius summary by package so charts do not repeat one package per CVE", () => {
+    const rows = [
+      {
+        vulnerability_id: "CVE-2022-0001",
+        package: "pillow",
+        severity: "critical",
+        affected_agents: ["desktop-agent"],
+        affected_servers: ["filesystem"],
+        exposed_credentials: [],
+        reachable_tools: [],
+        risk_score: 10,
+        blast_score: 100,
+      },
+      {
+        vulnerability_id: "CVE-2023-0002",
+        package: "pillow",
+        severity: "high",
+        affected_agents: ["desktop-agent"],
+        affected_servers: ["filesystem"],
+        exposed_credentials: [],
+        reachable_tools: [],
+        risk_score: 8,
+        blast_score: 80,
+      },
+    ] as BlastRadius[];
+
+    expect(buildBlastRadiusSummary(rows)).toEqual([
+      expect.objectContaining({
+        name: "pillow",
+        severity: "critical",
+        vulnerability_count: 2,
+        agent_count: 1,
+        server_count: 1,
+        score: 100,
+      }),
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- keeps mesh/context graph legends closed during capture so nodes and edges stay visible
- tightens capture-mode graph fit for mesh views without changing normal interactive framing
- groups dependency blast-radius chart rows by package so the panel does not repeat one package per CVE

## Validation
- NODE24_DIR="$(dirname "$(npx -y -p node@24.11.1 node -p 'process.execPath')")"; PATH="$NODE24_DIR:$PATH"; cd ui && npm test -- --run tests/graph-viewport.test.ts tests/use-capture-mode.test.tsx tests/insights-risk.test.ts
- NODE24_DIR="$(dirname "$(npx -y -p node@24.11.1 node -p 'process.execPath')")"; PATH="$NODE24_DIR:$PATH"; cd ui && npm run typecheck
- NODE24_DIR="$(dirname "$(npx -y -p node@24.11.1 node -p 'process.execPath')")"; PATH="$NODE24_DIR:$PATH"; cd ui && npm run verify:toolchain
- bash scripts/build-ui.sh with Node 24.11.1 on PATH
- uv run python scripts/check_release_consistency.py
- git diff --check
- live capture smoke against agent-bom serve with sanitized demo payload for /mesh, /security-graph, /graph, and /insights