### PR TITLE
cli: enforce agent mode token budget

### DIFF
--- a/src/agent_bom/cli/_agent_mode.py
+++ b/src/agent_bom/cli/_agent_mode.py
@@ -94,6 +94,39 @@ def _truncate_report(report_json: dict[str, Any], token_budget: int) -> tuple[di
         while approx_tokens() > token_budget and isinstance(payload.get(key), list) and len(payload[key]) > 1:
             trim_list(key)
 
+    def record_removed(key: str, value: Any) -> None:
+        removed[key] = removed.get(key, 0) + (len(value) if isinstance(value, list) else 1)
+
+    for key in (
+        "ai_bom_entities",
+        "inventory_snapshot",
+        "remediation_plan",
+        "compliance_bundle",
+        "graph",
+        "lineage_graph",
+        "attack_paths",
+        "findings",
+        "blast_radius",
+        "agents",
+    ):
+        if approx_tokens() <= token_budget:
+            break
+        if key in payload:
+            record_removed(key, payload.pop(key))
+
+    if approx_tokens() > token_budget:
+        compact_keys = (
+            "schema_version",
+            "document_type",
+            "spec_version",
+            "generated_at",
+            "posture_grade",
+            "posture_scorecard",
+            "summary",
+        )
+        payload = {key: report_json[key] for key in compact_keys if key in report_json}
+        removed["payload_compacted"] = 1
+
     final_tokens = approx_tokens()
     return payload, {
         "enabled": True,
@@ -146,4 +179,4 @@ def error_envelope(*, command: str | None, message: str, exit_code: int, error_t
 
 
 def dumps_envelope(payload: dict[str, Any]) -> str:
-    return json.dumps(payload, indent=2, sort_keys=True, default=str)
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True, default=str)

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -15,6 +15,7 @@ import pytest
 from click.testing import CliRunner
 
 from agent_bom.cli import cli_main, main
+from agent_bom.cli._agent_mode import dumps_envelope, success_envelope
 from agent_bom.models import Agent, AgentType, BlastRadius, MCPServer, Package, Severity, Vulnerability
 from agent_bom.scanners import IncompleteScanError
 
@@ -129,6 +130,43 @@ def test_scan_agent_mode_token_budget_reports_truncation(monkeypatch):
     assert payload["truncated"] is True
     assert payload["truncation"]["truncated"] is True
     assert payload["truncation"]["removed"]
+
+
+def test_agent_mode_token_budget_bounds_large_envelope():
+    report = _minimal_report_json(80)
+    report.update(
+        {
+            "schema_version": "1.0",
+            "spec_version": "1.0",
+            "posture_grade": "F",
+            "summary": {"total_vulnerabilities": 80, "agents": 30, "servers": 0},
+            "agents": [{"name": f"agent-{idx}", "mcp_servers": []} for idx in range(30)],
+            "findings": [{"id": f"finding-{idx}", "details": "x" * 200} for idx in range(80)],
+            "blast_radius": [
+                {
+                    "vulnerability_id": f"CVE-2026-{idx:04d}",
+                    "severity": "high",
+                    "package": "pkg",
+                    "details": "x" * 200,
+                }
+                for idx in range(80)
+            ],
+            "inventory_snapshot": {"agents": [{"name": f"agent-{idx}"} for idx in range(30)], "details": "x" * 2000},
+            "remediation_plan": [{"id": f"fix-{idx}", "details": "x" * 200} for idx in range(80)],
+            "ai_bom_entities": {"details": "x" * 2000},
+        }
+    )
+
+    payload = success_envelope(command="agents", report_json=report, exit_code=0, token_budget=500)
+    output = dumps_envelope(payload)
+
+    assert len(output) < 500 * 10
+    assert payload["truncated"] is True
+    assert payload["truncation"]["truncated"] is True
+    assert payload["truncation"]["approx_tokens"] <= 500
+    assert payload["truncation"]["removed"]
+    assert payload["summary"]["agents"] >= 30
+    assert payload["data"]["document_type"] == "AI-BOM"
 
 
 def test_agent_mode_entry_wraps_usage_errors(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- makes `--agent-token-budget` compact the agent-mode payload after trimming large collections
- emits compact JSON envelopes so assistant callers get bounded output
- adds a synthetic oversized-envelope regression so token-budget enforcement does not depend on demo scanner behavior

## Validation
- `uv run pytest -q tests/test_cli_scan.py -k agent_mode`
- `uv run pytest -q tests/test_contract_schemas.py tests/test_cli_scan.py -k 'agent_mode or envelope'`
- `uv run ruff check src/agent_bom/cli/_agent_mode.py tests/test_cli_scan.py`
- `uv run agent-bom agents --demo --offline --no-auto-update-db --agent-mode --agent-token-budget 1500 -f json -o -`
- `git diff --check`

## Note
- `uv run mypy src/agent_bom/cli/_agent_mode.py` is currently blocked locally by an unrelated `src/agent_bom/api/routes/compliance.py` indexed-assignment error after the environment was rebuilt; the PR diff only touches the agent-mode helper and CLI scan regression tests.
