### PR TITLE
api: type compliance summary response

### DIFF
--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -932,18 +932,19 @@ async def get_compliance_summary(request: Request) -> dict:
         "summary",
     }
     response = {key: full.get(key) for key in summary_keys if key in full}
-    response["frameworks"] = {}
+    framework_summary: dict[str, dict[str, int]] = {}
     for key, value in full.items():
         if isinstance(value, list):
             pass_count = sum(1 for item in value if item.get("status") == "pass")
             warn_count = sum(1 for item in value if item.get("status") == "warning")
             fail_count = sum(1 for item in value if item.get("status") == "fail")
-            response["frameworks"][key] = {
+            framework_summary[key] = {
                 "controls": len(value),
                 "pass": pass_count,
                 "warning": warn_count,
                 "fail": fail_count,
             }
+    response["frameworks"] = framework_summary
     return response
 
 


### PR DESCRIPTION
## Summary
- types the /v1/compliance/summary framework aggregation separately before attaching it to the response
- fixes the narrow mypy failure that surfaced while validating agent-mode release contracts
- preserves the existing route payload shape and framework counts

## Validation
- uv run mypy src/agent_bom/cli/_agent_mode.py
- uv run ruff check src/agent_bom/api/routes/compliance.py
- uv run pytest -q tests/test_api_compliance_auth.py::test_compliance_summary_does_not_route_as_framework_slug tests/test_compliance.py::test_compliance_summary_counts
- git diff --check

Part of #2487.