### PR TITLE
cli: preserve focused iac output paths

### DIFF
--- a/src/agent_bom/cli/_focused_commands.py
+++ b/src/agent_bom/cli/_focused_commands.py
@@ -190,6 +190,7 @@ def iac_cmd(
         iac_paths=paths,
         no_scan=True,  # IaC command: skip CVE scanning, package extraction, MCP agent discovery
         _iac_only=True,  # Internal: triggers IaC fast path (skip all discovery)
+        _apply_profile_defaults=False,  # Focused IaC flags are already resolved; scan profiles must not rewrite them.
         output_format=output_format,
         output=output_path,
         fail_on_severity=effective_fail_on_severity,

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -406,6 +406,7 @@ def scan(
     posture: bool = False,
     _iac_only: bool = False,
     _image_only: bool = False,
+    _apply_profile_defaults: bool = True,
     k8s_live: bool = False,
     k8s_live_namespace: str = "default",
     k8s_live_all_namespaces: bool = False,
@@ -436,23 +437,24 @@ def scan(
 
     agent_mode = agent_mode or agent_mode_requested()
 
-    (
-        output,
-        output_format,
-        preset,
-        nvd_api_key,
-        push_url,
-        push_api_key,
-        clickhouse_url,
-    ) = apply_scan_profile_defaults(
-        output=output,
-        output_format=output_format,
-        preset=preset,
-        nvd_api_key=nvd_api_key,
-        push_url=push_url,
-        push_api_key=push_api_key,
-        clickhouse_url=clickhouse_url,
-    )
+    if _apply_profile_defaults:
+        (
+            output,
+            output_format,
+            preset,
+            nvd_api_key,
+            push_url,
+            push_api_key,
+            clickhouse_url,
+        ) = apply_scan_profile_defaults(
+            output=output,
+            output_format=output_format,
+            preset=preset,
+            nvd_api_key=nvd_api_key,
+            push_url=push_url,
+            push_api_key=push_api_key,
+            clickhouse_url=clickhouse_url,
+        )
 
     if agent_token_budget < 0:
         raise click.ClickException("--agent-token-budget must be greater than or equal to 0.")

--- a/tests/test_focused_security_gates.py
+++ b/tests/test_focused_security_gates.py
@@ -84,7 +84,21 @@ def test_iac_command_exits_one_for_high_findings_by_default(tmp_path: Path):
     assert "1 finding" in " ".join(result.output.split())
 
 
-def test_iac_command_json_exits_one_for_high_findings_by_default(tmp_path: Path):
+def test_iac_command_json_exits_one_for_high_findings_by_default(monkeypatch, tmp_path: Path):
+    profile_config = tmp_path / "config.toml"
+    profile_output = tmp_path / "profile-report.json"
+    profile_config.write_text(
+        f"""
+current_profile = "prod"
+
+[profiles.prod]
+format = "json"
+output = "{profile_output}"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENT_BOM_CONFIG", str(profile_config))
+
     finding = IaCFinding(
         rule_id="TF-TEST",
         severity="high",
@@ -101,6 +115,7 @@ def test_iac_command_json_exits_one_for_high_findings_by_default(tmp_path: Path)
 
     assert result.exit_code == 1
     assert '"rule_id": "TF-TEST"' in result.output
+    assert not profile_output.exists()
 
 
 def test_iac_command_exits_zero_when_clean(tmp_path: Path):

--- a/tests/test_pr_gate_sarif_action_contract.py
+++ b/tests/test_pr_gate_sarif_action_contract.py
@@ -54,13 +54,27 @@ def test_focused_secrets_and_code_reject_sarif_format(tmp_path: Path) -> None:
     assert not (tmp_path / "code.sarif").exists()
 
 
-def test_iac_sarif_output_path_writes_valid_sarif(tmp_path: Path) -> None:
+def test_iac_sarif_output_path_writes_valid_sarif(monkeypatch, tmp_path: Path) -> None:
     (tmp_path / "Dockerfile").write_text("FROM python:latest\nUSER root\n", encoding="utf-8")
     output = tmp_path / "iac-results.sarif"
+    profile_output = tmp_path / "profile-report.json"
+    profile_config = tmp_path / "config.toml"
+    profile_config.write_text(
+        f"""
+current_profile = "prod"
+
+[profiles.prod]
+format = "json"
+output = "{profile_output}"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENT_BOM_CONFIG", str(profile_config))
 
     result = CliRunner().invoke(main, ["iac", str(tmp_path), "-f", "sarif", "-o", str(output), "--quiet"])
 
     assert result.exit_code == 0, result.output
+    assert not profile_output.exists()
     data = json.loads(output.read_text(encoding="utf-8"))
     assert data["version"] == "2.1.0"
     assert data["runs"][0]["tool"]["driver"]["name"] == "agent-bom"


### PR DESCRIPTION
Summary
- prevents scan profile defaults from rewriting focused `agent-bom iac` `-f/-o` values
- keeps predictable SARIF file writes for PR gate workflows
- keeps JSON IaC findings on stdout even when a profile config sets another output path

Validation
- `uv run pytest -q tests/test_focused_security_gates.py::test_iac_command_json_exits_one_for_high_findings_by_default tests/test_pr_gate_sarif_action_contract.py::test_iac_sarif_output_path_writes_valid_sarif`
- `uv run ruff check src/agent_bom/cli/_focused_commands.py src/agent_bom/cli/agents/__init__.py tests/test_focused_security_gates.py tests/test_pr_gate_sarif_action_contract.py`
- `git diff --check -- src/agent_bom/cli/_focused_commands.py src/agent_bom/cli/agents/__init__.py tests/test_focused_security_gates.py tests/test_pr_gate_sarif_action_contract.py`