### PR TITLE
cli: show partial posture on incomplete scans

### DIFF
--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -158,11 +158,13 @@ def _exit_incomplete_scan_with_partial_summary(
         },
     )
     ctx.con.print(f"  [yellow]⚠[/yellow] {exc}")
-    if output_format == "console" and not output and not quiet:
+    profile_defaulted_output = not _scan_output_target_was_explicit()
+    should_render_console_summary = (output_format == "console" and not output) or profile_defaulted_output
+    if should_render_console_summary and not quiet:
         render_output(
             ctx,
-            output=output,
-            output_format=output_format,
+            output=None,
+            output_format="console",
             no_tree=no_tree,
             quiet=quiet,
             no_color=no_color,
@@ -194,6 +196,15 @@ def _output_format_was_explicit() -> bool:
     if ctx is None:
         return False
     return ctx.get_parameter_source("output_format") is click.core.ParameterSource.COMMANDLINE
+
+
+def _scan_output_target_was_explicit() -> bool:
+    """Return true when the caller explicitly selected a machine output target."""
+    ctx = click.get_current_context(silent=True)
+    if ctx is None:
+        return False
+    explicit_sources = {click.core.ParameterSource.COMMANDLINE, click.core.ParameterSource.ENVIRONMENT}
+    return ctx.get_parameter_source("output") in explicit_sources or ctx.get_parameter_source("output_format") in explicit_sources
 
 
 def _reproducible_generated_at(enabled: bool):

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -900,7 +900,20 @@ def test_scan_save_flag(tmp_path):
     assert result.exit_code == 0
 
 
-def test_scan_incomplete_offline_scan_exits_two(monkeypatch):
+def test_scan_incomplete_offline_scan_exits_two(monkeypatch, tmp_path):
+    profile_output = tmp_path / "profile-report.json"
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        f"""
+current_profile = "local"
+
+[profiles.local]
+format = "json"
+output = "{profile_output}"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENT_BOM_CONFIG", str(config_path))
     monkeypatch.setattr("agent_bom.cli.agents.discover_all", lambda *args, **kwargs: [])
 
     def _scan_agents_sync(*args, **kwargs):
@@ -919,6 +932,7 @@ def test_scan_incomplete_offline_scan_exits_two(monkeypatch):
     assert "PARTIAL COVERAGE" in result.output
     assert "CLEAN" not in result.output
     assert "agents" in result.output.lower()
+    assert not profile_output.exists()
 
 
 def test_scan_expands_local_docker_mcp_image():


### PR DESCRIPTION
Summary
- restores the partial-coverage posture panel when an incomplete offline scan exits with code 2
- treats scan profile output defaults as implicit, so profile JSON/file defaults cannot hide the human warning path
- keeps explicit command/env output targets intact
- adds a regression test with an active profile that defaults to JSON output

Validation
- PYTHONPATH=src uv run pytest -q tests/test_cli_scan.py::test_scan_incomplete_offline_scan_exits_two
- PYTHONPATH=src uv run pytest -q tests/test_cli_scan.py tests/test_cli_profiles.py
- PYTHONPATH=src uv run ruff check src/agent_bom/cli/agents/__init__.py tests/test_cli_scan.py
- git diff --check
- commit hooks: ruff, ruff-format, mypy, bandit, env-var drift, duplicate-artifact guard