### PR TITLE
[codex] fix compliance data hotfixes

### DIFF
--- a/src/agent_bom/compliance_utils.py
+++ b/src/agent_bom/compliance_utils.py
@@ -29,6 +29,7 @@ _FIELD_TO_VULN_KEY: dict[str, str] = {
     "cmmc_tags": "cmmc",
     "nist_800_53_tags": "nist_800_53",
     "fedramp_tags": "fedramp",
+    "pci_dss_tags": "pci_dss",
 }
 
 

--- a/src/agent_bom/enrichment.py
+++ b/src/agent_bom/enrichment.py
@@ -121,6 +121,60 @@ def _save_enrichment_cache() -> None:
             _logger.warning("Failed to persist %s enrichment cache to disk", name)
 
 
+def _cached_epss_scores(cve_ids: list[str], *, allow_stale: bool = False) -> dict[str, dict]:
+    """Return EPSS entries already present in the local cache."""
+    if not cve_ids:
+        return {}
+    _load_enrichment_cache()
+    raw_cache = dict(_epss_file_cache)
+    if allow_stale:
+        cache_file = _ENRICHMENT_CACHE_DIR / "epss_cache.json"
+        if cache_file.exists():
+            try:
+                raw = json.loads(cache_file.read_text())
+                if isinstance(raw, dict):
+                    raw_cache.update({k: v for k, v in raw.items() if isinstance(v, dict)})
+            except (OSError, json.JSONDecodeError, ValueError) as exc:
+                _logger.warning("Failed to load EPSS disk cache: %s", exc)
+    max_age_secs = 30 * 86400
+    now = time.time()
+    scores: dict[str, dict] = {}
+    for cve_id in cve_ids:
+        cached = raw_cache.get(cve_id)
+        if not isinstance(cached, dict):
+            continue
+        cached_at = cached.get("_cached_at", 0)
+        if allow_stale or now - cached_at < max_age_secs:
+            scores[cve_id] = {k: v for k, v in cached.items() if k != "_cached_at"}
+            record_enrichment_source("epss", "cache")
+    return scores
+
+
+def _cached_kev_catalog(*, allow_stale: bool = False) -> dict:
+    """Return the persisted KEV catalog without making network requests."""
+    global _kev_cache, _kev_cache_time
+    if _kev_cache and _kev_cache_time:
+        age = datetime.now(timezone.utc) - _kev_cache_time
+        if allow_stale or age.total_seconds() < _KEV_CACHE_TTL_SECONDS:
+            record_enrichment_source("cisa_kev", "cache")
+            return _kev_cache
+
+    if not _KEV_CACHE_FILE.exists():
+        return {}
+    try:
+        disk_data = json.loads(_KEV_CACHE_FILE.read_text())
+        cached_at = disk_data.get("_cached_at", 0)
+        data = disk_data.get("data") or {}
+        if data and (allow_stale or (time.time() - cached_at) < _KEV_CACHE_TTL_SECONDS):
+            _kev_cache = data
+            _kev_cache_time = datetime.fromtimestamp(cached_at, tz=timezone.utc)
+            record_enrichment_source("cisa_kev", "cache")
+            return data
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        _logger.warning("Failed to load KEV disk cache: %s", exc)
+    return {}
+
+
 async def fetch_nvd_data(cve_id: str, client: httpx.AsyncClient, api_key: Optional[str] = None) -> Optional[dict]:
     """Fetch CVE data from NVD API (with persistent file cache).
 
@@ -203,19 +257,9 @@ async def fetch_epss_scores(cve_ids: list[str], client: httpx.AsyncClient) -> di
     scores: dict[str, dict] = {}
     uncached: list[str] = []
 
-    # Check persistent cache first — reject entries older than 30 days
-    _max_age_secs = 30 * 86400  # 30 days
-    now = time.time()
+    scores.update(_cached_epss_scores(cve_ids))
     for cve_id in cve_ids:
-        if cve_id in _epss_file_cache:
-            cached = _epss_file_cache[cve_id]
-            cached_at = cached.get("_cached_at", 0)
-            if now - cached_at < _max_age_secs:
-                scores[cve_id] = {k: v for k, v in cached.items() if k != "_cached_at"}
-                record_enrichment_source("epss", "cache")
-            else:
-                uncached.append(cve_id)  # Stale — refetch
-        else:
+        if cve_id not in scores:
             uncached.append(cve_id)
 
     if not uncached:
@@ -299,17 +343,9 @@ async def fetch_cisa_kev_catalog(client: httpx.AsyncClient) -> dict:
             return _kev_cache
 
     # Try loading from disk cache if in-memory cache is stale
-    if not _kev_cache and _KEV_CACHE_FILE.exists():
-        try:
-            disk_data = json.loads(_KEV_CACHE_FILE.read_text())
-            cached_at = disk_data.get("_cached_at", 0)
-            if (time.time() - cached_at) < _KEV_CACHE_TTL_SECONDS:
-                _kev_cache = disk_data.get("data") or {}
-                _kev_cache_time = datetime.fromtimestamp(cached_at, tz=timezone.utc)
-                record_enrichment_source("cisa_kev", "cache")
-                return _kev_cache  # type: ignore[return-value]  # dict from disk cache
-        except (OSError, json.JSONDecodeError, ValueError) as exc:
-            _logger.warning("Failed to load KEV disk cache: %s", exc)
+    disk_cache = _cached_kev_catalog()
+    if disk_cache:
+        return disk_cache
 
     response = await request_with_retry(client, "GET", CISA_KEV_URL)
 
@@ -412,6 +448,7 @@ async def enrich_vulnerabilities(
     enable_nvd: bool = True,
     enable_epss: bool = True,
     enable_kev: bool = True,
+    offline: bool = False,
 ) -> int:
     """Enrich vulnerabilities with NVD, EPSS, and CISA KEV data.
 
@@ -440,21 +477,28 @@ async def enrich_vulnerabilities(
         # ── Parallel enrichment: EPSS + KEV + NVD run concurrently ──
         # EPSS and KEV are single-call fetches. NVD needs CWE pre-check
         # (local, no network) then batched fetch. All three are independent.
-        console.print("  [cyan]→[/cyan] Fetching EPSS + KEV + NVD in parallel...")
+        if offline:
+            console.print("  [cyan]→[/cyan] Joining EPSS + KEV from local offline caches...")
+        else:
+            console.print("  [cyan]→[/cyan] Fetching EPSS + KEV + NVD in parallel...")
 
         async def _fetch_epss() -> dict:
             if not enable_epss:
                 return {}
+            if offline:
+                return _cached_epss_scores(cve_ids, allow_stale=True)
             data = await fetch_epss_scores(cve_ids, client)
             return data or {}
 
         async def _fetch_kev() -> dict:
             if not enable_kev:
                 return {}
+            if offline:
+                return _cached_kev_catalog(allow_stale=True)
             return await fetch_cisa_kev_catalog(client)
 
         async def _fetch_nvd() -> tuple[dict[str, dict], int, int]:
-            if not enable_nvd or not cve_ids:
+            if offline or not enable_nvd or not cve_ids:
                 return {}, 0, 0
             # Build set of CVE IDs that already have CWE data (local check)
             cves_with_cwes: set[str] = set()
@@ -608,6 +652,7 @@ def enrich_vulnerabilities_sync(
     enable_nvd: bool = True,
     enable_epss: bool = True,
     enable_kev: bool = True,
+    offline: bool = False,
 ) -> int:
     """Synchronous wrapper for enrich_vulnerabilities."""
     return asyncio.run(
@@ -617,5 +662,6 @@ def enrich_vulnerabilities_sync(
             enable_nvd,
             enable_epss,
             enable_kev,
+            offline,
         )
     )

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -81,6 +81,7 @@ class ControlTag:
     version: Optional[str] = None
     confidence: Optional[float] = None
     source: Optional[str] = None
+    via: Optional[str] = None
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -89,6 +90,7 @@ class ControlTag:
             "version": self.version,
             "confidence": self.confidence,
             "source": self.source,
+            "via": self.via,
         }
 
     @classmethod
@@ -101,6 +103,7 @@ class ControlTag:
             except ValueError:
                 confidence = None
         raw_source = payload.get("source") or payload.get("via")
+        raw_via = payload.get("via")
 
         return cls(
             framework=str(payload.get("framework") or ""),
@@ -108,6 +111,7 @@ class ControlTag:
             version=str(payload["version"]) if payload.get("version") is not None else None,
             confidence=confidence,
             source=str(raw_source) if raw_source else None,
+            via=str(raw_via) if raw_via else None,
         )
 
 
@@ -124,7 +128,30 @@ LEGACY_CONTROL_FIELDS: tuple[tuple[str, str], ...] = (
     ("iso_27001_tags", "iso_27001"),
     ("soc2_tags", "soc2"),
     ("cis_tags", "cis"),
+    ("cmmc_tags", "cmmc"),
+    ("nist_800_53_tags", "nist_800_53"),
+    ("fedramp_tags", "fedramp"),
+    ("pci_dss_tags", "pci_dss"),
 )
+
+_LEGACY_CONTROL_VERSION_BY_FRAMEWORK: dict[str, str] = {
+    "generic": "legacy",
+    "owasp_llm": "2025",
+    "mitre_atlas": "bundled",
+    "mitre_attack": "enterprise-bundled",
+    "nist_ai_rmf": "1.0",
+    "owasp_mcp": "2025",
+    "owasp_agentic": "2026",
+    "eu_ai_act": "2024",
+    "nist_csf": "2.0",
+    "iso_27001": "2022",
+    "soc2": "2017",
+    "cis": "v8",
+    "cmmc": "2.0",
+    "nist_800_53": "rev5",
+    "fedramp": "moderate",
+    "pci_dss": "4.0",
+}
 
 
 def _dedupe_control_tags(tags: list[ControlTag]) -> list[ControlTag]:
@@ -209,6 +236,10 @@ class Finding:
     iso_27001_tags: list[str] = field(default_factory=list)
     soc2_tags: list[str] = field(default_factory=list)
     cis_tags: list[str] = field(default_factory=list)
+    cmmc_tags: list[str] = field(default_factory=list)
+    nist_800_53_tags: list[str] = field(default_factory=list)
+    fedramp_tags: list[str] = field(default_factory=list)
+    pci_dss_tags: list[str] = field(default_factory=list)
 
     # Graph / correlation
     related_findings: list[str] = field(default_factory=list)  # IDs of related findings
@@ -254,7 +285,16 @@ class Finding:
             values = getattr(self, field_name)
             for value in values:
                 if value:
-                    tags.append(ControlTag(framework=framework, control=str(value), source=f"legacy:{field_name}"))
+                    tags.append(
+                        ControlTag(
+                            framework=framework,
+                            control=str(value),
+                            version=_LEGACY_CONTROL_VERSION_BY_FRAMEWORK.get(framework, "legacy"),
+                            confidence=0.75,
+                            source=f"legacy:{field_name}",
+                            via=field_name,
+                        )
+                    )
         return tags
 
     def normalized_controls(self) -> list[ControlTag]:
@@ -278,6 +318,10 @@ class Finding:
             + self.iso_27001_tags
             + self.soc2_tags
             + self.cis_tags
+            + self.cmmc_tags
+            + self.nist_800_53_tags
+            + self.fedramp_tags
+            + self.pci_dss_tags
             + [tag.control for tag in self.normalized_controls()]
         ):
             if tag not in seen:
@@ -330,6 +374,10 @@ class Finding:
             "iso_27001_tags": self.iso_27001_tags,
             "soc2_tags": self.soc2_tags,
             "cis_tags": self.cis_tags,
+            "cmmc_tags": self.cmmc_tags,
+            "nist_800_53_tags": self.nist_800_53_tags,
+            "fedramp_tags": self.fedramp_tags,
+            "pci_dss_tags": self.pci_dss_tags,
             "related_findings": self.related_findings,
             "evidence": self.evidence,
             "risk_score": self.risk_score,
@@ -547,6 +595,10 @@ def blast_radius_to_finding(br: object) -> "Finding":
         iso_27001_tags=list(br.iso_27001_tags),
         soc2_tags=list(br.soc2_tags),
         cis_tags=list(br.cis_tags),
+        cmmc_tags=list(getattr(br, "cmmc_tags", [])),
+        nist_800_53_tags=list(getattr(br, "nist_800_53_tags", [])),
+        fedramp_tags=list(getattr(br, "fedramp_tags", [])),
+        pci_dss_tags=list(getattr(br, "pci_dss_tags", [])),
         evidence=evidence,
         risk_score=br.risk_score,
     )

--- a/src/agent_bom/mitre_attack.py
+++ b/src/agent_bom/mitre_attack.py
@@ -128,6 +128,19 @@ _CHECK_KEYWORD_TACTICS: list[tuple[tuple[str, ...], list[str]]] = [
     (("encryption", "kms", "tls", "ssl", "crypto"), ["credential-access"]),
 ]
 
+_BROAD_TACTIC_FALLBACK_LIMIT = 3
+_PREFERRED_TACTIC_TECHNIQUES: dict[str, tuple[str, ...]] = {
+    "initial-access": ("T1190", "T1195", "T1078"),
+    "credential-access": ("T1552", "T1556", "T1110"),
+    "execution": ("T1059", "T1204", "T1129"),
+    "command-and-control": ("T1090", "T1105", "T1071"),
+    "collection": ("T1005", "T1530", "T1119"),
+    "exfiltration": ("T1041", "T1048", "T1537"),
+    "defense-evasion": ("T1562", "T1027", "T1036"),
+    "privilege-escalation": ("T1548", "T1068", "T1134"),
+    "impact": ("T1499", "T1485", "T1565"),
+}
+
 
 def _techniques_for_tactics(tactic_phases: list[str]) -> list[str]:
     """Return technique IDs from the catalog that belong to any of the given tactic phases."""
@@ -138,6 +151,27 @@ def _techniques_for_tactics(tactic_phases: list[str]) -> list[str]:
     for tid, meta in all_techniques.items():
         if any(t in tactic_phases for t in meta.get("tactics", [])):
             result.append(tid)
+    return result
+
+
+def _bounded_techniques_for_tactics(tactic_phases: list[str]) -> list[str]:
+    """Return a small representative set for broad context-only tactic signals."""
+    from agent_bom.mitre_fetch import get_techniques
+
+    all_techniques = get_techniques()
+    result: list[str] = []
+    seen: set[str] = set()
+    for tactic in sorted(set(tactic_phases)):
+        preferred = [
+            tid
+            for tid in _PREFERRED_TACTIC_TECHNIQUES.get(tactic, ())
+            if tid in all_techniques and tactic in all_techniques[tid].get("tactics", [])
+        ]
+        fallback = sorted(tid for tid, meta in all_techniques.items() if tid not in preferred and tactic in meta.get("tactics", []))
+        for tid in [*preferred, *fallback][:_BROAD_TACTIC_FALLBACK_LIMIT]:
+            if tid not in seen:
+                seen.add(tid)
+                result.append(tid)
     return result
 
 
@@ -292,8 +326,9 @@ def tag_blast_radius(br: BlastRadius) -> list[str]:
     if is_high and not mapped_from_cwe:
         tactic_phases.add("initial-access")
 
-    # Resolve tactic phases to catalog techniques
-    for tech in _techniques_for_tactics(list(tactic_phases)):
+    # Resolve broad context signals to a bounded representative set. Direct
+    # CWE->ATT&CK mappings above remain per-finding and are not tactic-expanded.
+    for tech in _bounded_techniques_for_tactics(list(tactic_phases)):
         techniques.add(tech)
 
     return sorted(techniques)

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -783,6 +783,7 @@ class BlastRadius:
     cmmc_tags: list[str] = field(default_factory=list)  # CMMC 2.0 Level 2, e.g. ["RA.L2-3.11.2"]
     nist_800_53_tags: list[str] = field(default_factory=list)  # NIST 800-53 Rev 5, e.g. ["RA-5", "SI-2"]
     fedramp_tags: list[str] = field(default_factory=list)  # FedRAMP Moderate baseline, e.g. ["RA-5"]
+    pci_dss_tags: list[str] = field(default_factory=list)  # PCI DSS v4.0, e.g. ["Req-6.3"]
     ai_summary: Optional[str] = None  # LLM-generated contextual risk narrative
     suppressed: bool = False  # True when a tenant suppression/feedback rule covers this finding
     suppression_id: Optional[str] = None

--- a/src/agent_bom/output/compliance_narrative.py
+++ b/src/agent_bom/output/compliance_narrative.py
@@ -8,15 +8,19 @@ remediation-compliance bridges.
 Supported frameworks (slug → display name):
     owasp-llm         OWASP Top 10 for LLM
     owasp-mcp         OWASP MCP Top 10
-    atlas             MITRE ATLAS
-    nist              NIST AI RMF
     owasp-agentic     OWASP Agentic Top 10
+    nist-800-53       NIST SP 800-53
+    fedramp           FedRAMP Moderate
+    atlas             MITRE ATLAS
+    attack            MITRE ATT&CK Enterprise
+    nist              NIST AI RMF
     eu-ai-act         EU AI Act
     nist-csf          NIST CSF 2.0
     iso-27001         ISO 27001:2022
     soc2              SOC 2 TSC
     cis               CIS Controls v8
     cmmc              CMMC 2.0
+    pci-dss           PCI DSS v4.0
 """
 
 from __future__ import annotations
@@ -31,53 +35,48 @@ if TYPE_CHECKING:
 # ─── Catalogue lookups ────────────────────────────────────────────────────────
 # Imported lazily where needed to keep top-level import cost low.
 
+_DISPLAY_NAME_OVERRIDES: dict[str, str] = {
+    "owasp-llm": "OWASP Top 10 for LLM",
+    "owasp-mcp": "OWASP MCP Top 10",
+    "owasp-agentic": "OWASP Agentic Top 10",
+    "nist": "NIST AI RMF",
+    "nist-csf": "NIST CSF 2.0",
+    "nist-800-53": "NIST 800-53",
+    "fedramp": "FedRAMP",
+    "atlas": "MITRE ATLAS",
+    "attack": "MITRE ATT&CK",
+    "iso-27001": "ISO 27001:2022",
+    "soc2": "SOC 2 TSC",
+    "cis": "CIS Controls v8",
+    "cmmc": "CMMC 2.0",
+}
+
 
 def _get_catalog(slug: str) -> tuple[dict[str, str], str, str]:
     """Return (catalog_dict, tag_field_on_blast_radius, display_name) for a framework slug."""
-    from agent_bom.atlas import ATLAS_TECHNIQUES
-    from agent_bom.cis_controls import CIS_CONTROLS
-    from agent_bom.cmmc import CMMC_PRACTICES
-    from agent_bom.eu_ai_act import EU_AI_ACT
-    from agent_bom.iso_27001 import ISO_27001
-    from agent_bom.nist_ai_rmf import NIST_AI_RMF
-    from agent_bom.nist_csf import NIST_CSF
-    from agent_bom.owasp import OWASP_LLM_TOP10
-    from agent_bom.owasp_agentic import OWASP_AGENTIC_TOP10
-    from agent_bom.owasp_mcp import OWASP_MCP_TOP10
-    from agent_bom.soc2 import SOC2_TSC
+    from agent_bom.compliance_coverage import TAG_MAPPED_FRAMEWORKS
 
-    framework_map: dict[str, tuple[dict[str, str], str, str]] = {
-        "owasp-llm": (OWASP_LLM_TOP10, "owasp_tags", "OWASP Top 10 for LLM"),
-        "owasp-mcp": (OWASP_MCP_TOP10, "owasp_mcp_tags", "OWASP MCP Top 10"),
-        "atlas": (ATLAS_TECHNIQUES, "atlas_tags", "MITRE ATLAS"),
-        "nist": (NIST_AI_RMF, "nist_ai_rmf_tags", "NIST AI RMF"),
-        "owasp-agentic": (OWASP_AGENTIC_TOP10, "owasp_agentic_tags", "OWASP Agentic Top 10"),
-        "eu-ai-act": (EU_AI_ACT, "eu_ai_act_tags", "EU AI Act"),
-        "nist-csf": (NIST_CSF, "nist_csf_tags", "NIST CSF 2.0"),
-        "iso-27001": (ISO_27001, "iso_27001_tags", "ISO 27001:2022"),
-        "soc2": (SOC2_TSC, "soc2_tags", "SOC 2 TSC"),
-        "cis": (CIS_CONTROLS, "cis_tags", "CIS Controls v8"),
-        "cmmc": (CMMC_PRACTICES, "cmmc_tags", "CMMC 2.0"),
-    }
+    framework_map: dict[str, tuple[dict[str, str], str, str]] = {}
+    for metadata in TAG_MAPPED_FRAMEWORKS:
+        catalog = dict(metadata.catalog)
+        if metadata.slug == "attack":
+            from agent_bom.mitre_attack import get_attack_techniques
+
+            catalog = get_attack_techniques()
+        framework_map[metadata.slug] = (catalog, metadata.tag_field, _DISPLAY_NAME_OVERRIDES.get(metadata.slug, metadata.report_label))
     entry = framework_map.get(slug)
     if entry is None:
         raise ValueError(f"Unknown framework '{slug}'. Supported: {', '.join(framework_map.keys())}")
     return entry
 
 
-ALL_FRAMEWORK_SLUGS: list[str] = [
-    "owasp-llm",
-    "owasp-mcp",
-    "atlas",
-    "nist",
-    "owasp-agentic",
-    "eu-ai-act",
-    "nist-csf",
-    "iso-27001",
-    "soc2",
-    "cis",
-    "cmmc",
-]
+def _all_framework_slugs() -> list[str]:
+    from agent_bom.compliance_coverage import TAG_MAPPED_FRAMEWORKS
+
+    return [metadata.slug for metadata in TAG_MAPPED_FRAMEWORKS]
+
+
+ALL_FRAMEWORK_SLUGS: list[str] = _all_framework_slugs()
 
 
 # ─── Dataclasses ─────────────────────────────────────────────────────────────
@@ -384,56 +383,11 @@ def _build_remediation_impact(
     Groups blast radius entries by (package, current_version, fix_version),
     collects all framework control codes triggered, and generates a narrative.
     """
-    from agent_bom.atlas import ATLAS_TECHNIQUES
-    from agent_bom.cis_controls import CIS_CONTROLS
-    from agent_bom.cmmc import CMMC_PRACTICES
-    from agent_bom.eu_ai_act import EU_AI_ACT
-    from agent_bom.iso_27001 import ISO_27001
-    from agent_bom.nist_ai_rmf import NIST_AI_RMF
-    from agent_bom.nist_csf import NIST_CSF
-    from agent_bom.owasp import OWASP_LLM_TOP10
-    from agent_bom.owasp_agentic import OWASP_AGENTIC_TOP10
-    from agent_bom.owasp_mcp import OWASP_MCP_TOP10
-    from agent_bom.soc2 import SOC2_TSC
+    from agent_bom.compliance_coverage import TAG_MAPPED_FRAMEWORKS
 
-    # Map control code → framework display name for narrative generation
-    control_to_framework: dict[str, str] = {}
-    for code in OWASP_LLM_TOP10:
-        control_to_framework[code] = "OWASP Top 10 for LLM"
-    for code in OWASP_MCP_TOP10:
-        control_to_framework[code] = "OWASP MCP Top 10"
-    for code in ATLAS_TECHNIQUES:
-        control_to_framework[code] = "MITRE ATLAS"
-    for code in NIST_AI_RMF:
-        control_to_framework[code] = "NIST AI RMF"
-    for code in OWASP_AGENTIC_TOP10:
-        control_to_framework[code] = "OWASP Agentic Top 10"
-    for code in EU_AI_ACT:
-        control_to_framework[code] = "EU AI Act"
-    for code in NIST_CSF:
-        control_to_framework[code] = "NIST CSF 2.0"
-    for code in ISO_27001:
-        control_to_framework[code] = "ISO 27001:2022"
-    for code in SOC2_TSC:
-        control_to_framework[code] = "SOC 2 TSC"
-    for code in CIS_CONTROLS:
-        control_to_framework[code] = "CIS Controls v8"
-    for code in CMMC_PRACTICES:
-        control_to_framework[code] = "CMMC 2.0"
-
-    tag_fields = [
-        "owasp_tags",
-        "owasp_mcp_tags",
-        "atlas_tags",
-        "nist_ai_rmf_tags",
-        "owasp_agentic_tags",
-        "eu_ai_act_tags",
-        "nist_csf_tags",
-        "iso_27001_tags",
-        "soc2_tags",
-        "cis_tags",
-        "cmmc_tags",
-    ]
+    field_to_framework = {
+        metadata.tag_field: _DISPLAY_NAME_OVERRIDES.get(metadata.slug, metadata.report_label) for metadata in TAG_MAPPED_FRAMEWORKS
+    }
 
     # Group: key = (pkg_name_version, fix_version)
     # value = {controls: set, frameworks: set}
@@ -460,12 +414,10 @@ def _build_remediation_impact(
                 "frameworks": set(),
             }
 
-        for tag_field in tag_fields:
+        for tag_field, framework_label in field_to_framework.items():
             for tag in br.get(tag_field, []):
                 groups[key]["controls"].add(tag)
-                fw = control_to_framework.get(tag)
-                if fw:
-                    groups[key]["frameworks"].add(fw)
+                groups[key]["frameworks"].add(framework_label)
 
     impacts: list[RemediationImpact] = []
     for _key, data in groups.items():
@@ -648,8 +600,8 @@ def generate_compliance_narrative(
         report: The AIBOMReport to analyse.
         framework: Optional framework slug to generate a single-framework
             narrative.  When None (default), all frameworks are included.
-            Supported slugs: owasp-llm, owasp-mcp, atlas, nist, owasp-agentic,
-            eu-ai-act, nist-csf, iso-27001, soc2, cis, cmmc.
+            Supported slugs are the tag-mapped slugs in
+            agent_bom.compliance_coverage.TAG_MAPPED_FRAMEWORKS.
 
     Returns:
         A ComplianceNarrative dataclass suitable for JSON serialisation.
@@ -686,6 +638,10 @@ def generate_compliance_narrative(
                 "soc2_tags": br.soc2_tags,
                 "cis_tags": br.cis_tags,
                 "cmmc_tags": br.cmmc_tags,
+                "attack_tags": getattr(br, "attack_tags", []),
+                "nist_800_53_tags": getattr(br, "nist_800_53_tags", []),
+                "fedramp_tags": getattr(br, "fedramp_tags", []),
+                "pci_dss_tags": getattr(br, "pci_dss_tags", []),
             }
         )
 

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -59,6 +59,9 @@ _FRAMEWORK_TAXONOMY_META: dict[str, tuple[str, str, str]] = {
     ),
     "cis_tags": ("cis-controls", "CIS Controls", "https://www.cisecurity.org/controls"),
     "cmmc_tags": ("cmmc", "Cybersecurity Maturity Model Certification", "https://dodcio.defense.gov/CMMC/"),
+    "nist_800_53_tags": ("nist-800-53", "NIST SP 800-53", "https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final"),
+    "fedramp_tags": ("fedramp", "FedRAMP", "https://www.fedramp.gov/"),
+    "pci_dss_tags": ("pci-dss", "PCI DSS", "https://www.pcisecuritystandards.org/"),
 }
 
 
@@ -134,6 +137,28 @@ def _build_run_taxonomies(results: list[dict]) -> list[dict]:
             }
         )
     return taxonomies
+
+
+def _framework_taxa_references(properties: dict[str, Any]) -> list[dict]:
+    """Build result-level SARIF taxa references for declared framework taxonomies."""
+    refs: list[dict] = []
+    seen: set[tuple[str, str]] = set()
+    for property_name, (taxonomy_name, _full_name, _uri) in _FRAMEWORK_TAXONOMY_META.items():
+        raw_tags = properties.get(property_name) or []
+        if isinstance(raw_tags, str):
+            raw_tags = [raw_tags]
+        if not isinstance(raw_tags, list):
+            continue
+        for raw_tag in raw_tags:
+            tag = str(raw_tag).strip()
+            if not tag:
+                continue
+            key = (taxonomy_name, tag)
+            if key in seen:
+                continue
+            seen.add(key)
+            refs.append({"id": tag, "toolComponent": {"name": taxonomy_name}})
+    return refs
 
 
 def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
@@ -259,6 +284,7 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
         if (
             br.owasp_tags
             or br.atlas_tags
+            or getattr(br, "attack_tags", [])
             or br.nist_ai_rmf_tags
             or br.owasp_mcp_tags
             or br.owasp_agentic_tags
@@ -268,6 +294,9 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
             or br.soc2_tags
             or br.cis_tags
             or br.cmmc_tags
+            or getattr(br, "nist_800_53_tags", [])
+            or getattr(br, "fedramp_tags", [])
+            or getattr(br, "pci_dss_tags", [])
         ):
             result_properties.update(
                 {
@@ -283,9 +312,15 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
                     "soc2_tags": br.soc2_tags,
                     "cis_tags": br.cis_tags,
                     "cmmc_tags": br.cmmc_tags,
+                    "nist_800_53_tags": getattr(br, "nist_800_53_tags", []),
+                    "fedramp_tags": getattr(br, "fedramp_tags", []),
+                    "pci_dss_tags": getattr(br, "pci_dss_tags", []),
                 }
             )
         result["properties"] = result_properties
+        taxa_refs = _framework_taxa_references(result_properties)
+        if taxa_refs:
+            result["taxa"] = taxa_refs
         results.append(result)
 
     # Unified non-CVE findings, including MCP intelligence/blocklist matches.

--- a/tests/test_compliance_narrative.py
+++ b/tests/test_compliance_narrative.py
@@ -408,18 +408,38 @@ def test_multi_framework_tags_affect_multiple_frameworks():
 
 
 def test_all_framework_slugs_covered():
-    """Ensure ALL_FRAMEWORK_SLUGS matches the expected set of 14 frameworks."""
+    """Ensure ALL_FRAMEWORK_SLUGS matches the tag-mapped compliance framework set."""
     expected = {
         "owasp-llm",
         "owasp-mcp",
-        "atlas",
-        "nist",
         "owasp-agentic",
-        "eu-ai-act",
+        "nist",
         "nist-csf",
+        "nist-800-53",
+        "fedramp",
+        "atlas",
+        "attack",
+        "eu-ai-act",
         "iso-27001",
         "soc2",
         "cis",
         "cmmc",
+        "pci-dss",
     }
     assert set(ALL_FRAMEWORK_SLUGS) == expected
+
+
+def test_same_control_id_does_not_bleed_between_frameworks():
+    br = _make_blast_radius(vuln=_make_vuln(severity=Severity.HIGH), owasp_tags=[])
+    br.owasp_tags = []
+    br.nist_800_53_tags = ["RA-5"]
+    br.fedramp_tags = []
+    report = _make_report(blast_radii=[br])
+
+    result = generate_compliance_narrative(report)
+    status_by_slug = {fn.slug: fn.status for fn in result.framework_narratives}
+
+    assert status_by_slug["nist-800-53"] == "failing"
+    assert status_by_slug["fedramp"] == "passing"
+    assert result.remediation_impact
+    assert result.remediation_impact[0].frameworks_impacted == ["NIST 800-53"]

--- a/tests/test_enrichment_cache.py
+++ b/tests/test_enrichment_cache.py
@@ -8,6 +8,7 @@ import time
 import pytest
 
 import agent_bom.enrichment as enrichment
+from agent_bom.models import Severity, Vulnerability
 
 
 @pytest.fixture(autouse=True)
@@ -17,6 +18,9 @@ def _reset_enrichment_cache(tmp_path, monkeypatch):
     monkeypatch.setattr(enrichment, "_nvd_file_cache", {})
     monkeypatch.setattr(enrichment, "_epss_file_cache", {})
     monkeypatch.setattr(enrichment, "_enrichment_cache_loaded", False)
+    monkeypatch.setattr(enrichment, "_KEV_CACHE_FILE", tmp_path / "kev_cache.json")
+    monkeypatch.setattr(enrichment, "_kev_cache", None)
+    monkeypatch.setattr(enrichment, "_kev_cache_time", None)
 
 
 class TestNVDCache:
@@ -102,3 +106,49 @@ class TestSaveCacheIdempotent:
         enrichment._nvd_file_cache["CVE-X"] = {"_cached_at": time.time()}
         enrichment._save_enrichment_cache()
         assert (sub / "nvd_cache.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_offline_enrichment_joins_epss_and_kev_caches(tmp_path, monkeypatch):
+    now = time.time()
+    (tmp_path / "epss_cache.json").write_text(
+        json.dumps(
+            {
+                "CVE-2025-9999": {
+                    "score": 0.81,
+                    "percentile": 96.0,
+                    "date": "2026-05-10",
+                    "_cached_at": now - 999_999,
+                }
+            }
+        )
+    )
+    (tmp_path / "kev_cache.json").write_text(
+        json.dumps(
+            {
+                "_cached_at": now - 999_999,
+                "data": {
+                    "CVE-2025-9999": {
+                        "date_added": "2026-05-01",
+                        "due_date": "2026-05-22",
+                    }
+                },
+            }
+        )
+    )
+
+    async def _no_network(*_args, **_kwargs):
+        raise AssertionError("offline cache join must not perform network requests")
+
+    monkeypatch.setattr(enrichment, "request_with_retry", _no_network)
+
+    vuln = Vulnerability(id="CVE-2025-9999", summary="cached", severity=Severity.HIGH)
+    enriched = await enrichment.enrich_vulnerabilities([vuln], offline=True)
+
+    assert enriched == 1
+    assert vuln.epss_score == 0.81
+    assert vuln.epss_percentile == 96.0
+    assert vuln.exploitability == "HIGH"
+    assert vuln.is_kev is True
+    assert vuln.kev_date_added == "2026-05-01"
+    assert vuln.kev_due_date == "2026-05-22"

--- a/tests/test_exploit_likelihood.py
+++ b/tests/test_exploit_likelihood.py
@@ -111,6 +111,9 @@ def test_sarif_embeds_run_level_framework_taxonomies():
     taxa_by_name = {taxonomy["name"]: {taxon["id"] for taxon in taxonomy["taxa"]} for taxonomy in taxonomies}
     assert "LLM05" in taxa_by_name["owasp-llm-top10"]
     assert "AML.T0010" in taxa_by_name["mitre-atlas"]
+    result_taxa = sarif["runs"][0]["results"][0]["taxa"]
+    assert {"id": "LLM05", "toolComponent": {"name": "owasp-llm-top10"}} in result_taxa
+    assert {"id": "AML.T0010", "toolComponent": {"name": "mitre-atlas"}} in result_taxa
 
 
 # ── HTML propagation ────────────────────────────────────────────────────

--- a/tests/test_finding.py
+++ b/tests/test_finding.py
@@ -246,16 +246,18 @@ def test_finding_normalizes_legacy_control_tags():
         {
             "framework": "owasp_llm",
             "control": "LLM05",
-            "version": None,
-            "confidence": None,
+            "version": "2025",
+            "confidence": 0.75,
             "source": "legacy:owasp_tags",
+            "via": "owasp_tags",
         },
         {
             "framework": "soc2",
             "control": "CC7.1",
-            "version": None,
-            "confidence": None,
+            "version": "2017",
+            "confidence": 0.75,
             "source": "legacy:soc2_tags",
+            "via": "soc2_tags",
         },
     ]
     assert payload["owasp_tags"] == ["LLM05"]
@@ -282,13 +284,15 @@ def test_finding_deduplicates_explicit_and_legacy_controls():
             "version": "2025",
             "confidence": 0.9,
             "source": "hub",
+            "via": None,
         },
         {
             "framework": "mitre_atlas",
             "control": "AML.T0010",
-            "version": None,
-            "confidence": None,
+            "version": "bundled",
+            "confidence": 0.75,
             "source": "legacy:atlas_tags",
+            "via": "atlas_tags",
         },
     ]
     assert "LLM05" in finding.all_compliance_tags()
@@ -298,7 +302,7 @@ def test_finding_deduplicates_explicit_and_legacy_controls():
 def test_control_tag_from_dict_accepts_via_alias():
     tag = ControlTag.from_dict({"framework": "nist_csf", "control": "ID.RA-01", "via": "legacy"})
 
-    assert tag == ControlTag(framework="nist_csf", control="ID.RA-01", source="legacy")
+    assert tag == ControlTag(framework="nist_csf", control="ID.RA-01", source="legacy", via="legacy")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mitre_attack.py
+++ b/tests/test_mitre_attack.py
@@ -41,6 +41,7 @@ _MOCK_TECHNIQUES: dict[str, dict] = {
     # Execution
     "T1059": {"name": "Command and Scripting Interpreter", "tactics": ["execution"], "description": "", "platforms": []},
     "T1059.004": {"name": "Unix Shell", "tactics": ["execution"], "description": "", "platforms": []},
+    "T1203": {"name": "Exploitation for Client Execution", "tactics": ["execution"], "description": "", "platforms": []},
     # Initial Access
     "T1078": {
         "name": "Valid Accounts",
@@ -52,6 +53,7 @@ _MOCK_TECHNIQUES: dict[str, dict] = {
     "T1195": {"name": "Supply Chain Compromise", "tactics": ["initial-access"], "description": "", "platforms": []},
     "T1195.002": {"name": "Compromise Software Supply Chain", "tactics": ["initial-access"], "description": "", "platforms": []},
     # Credential Access
+    "T1003.001": {"name": "LSASS Memory", "tactics": ["credential-access"], "description": "", "platforms": []},
     "T1552": {"name": "Unsecured Credentials", "tactics": ["credential-access"], "description": "", "platforms": []},
     "T1556": {
         "name": "Modify Authentication Process",
@@ -63,6 +65,7 @@ _MOCK_TECHNIQUES: dict[str, dict] = {
     "T1562": {"name": "Impair Defenses", "tactics": ["defense-evasion"], "description": "", "platforms": []},
     "T1562.008": {"name": "Disable Cloud Logs", "tactics": ["defense-evasion"], "description": "", "platforms": []},
     # Collection / Exfiltration
+    "T1040": {"name": "Network Sniffing", "tactics": ["credential-access", "collection"], "description": "", "platforms": []},
     "T1530": {"name": "Data from Cloud Storage", "tactics": ["collection"], "description": "", "platforms": []},
     "T1537": {"name": "Transfer Data to Cloud Account", "tactics": ["exfiltration"], "description": "", "platforms": []},
     # Privilege Escalation
@@ -91,6 +94,7 @@ _MOCK_CWE_TO_ATTACK: dict[str, list[str]] = {
     "CWE-502": ["T1059", "T1190"],
     "CWE-400": ["T1499"],
     "CWE-494": ["T1195.002"],
+    "CWE-787": ["T1203"],
 }
 
 
@@ -359,6 +363,16 @@ def test_high_severity_without_direct_cwe_mapping_falls_back_to_initial_access()
     with _mock_catalog():
         tags = tag_blast_radius(_br(cwe_ids=["CWE-99999"], severity=Severity.HIGH))
     assert len(tags) > 0
+
+
+def test_heap_overflow_cwe_does_not_broadcast_unrelated_attack_tactics():
+    with _mock_catalog():
+        tags = tag_blast_radius(_br(cwe_ids=["CWE-787"], severity=Severity.CRITICAL, tools=[], creds=[]))
+
+    assert "T1203" in tags
+    assert "T1003.001" not in tags
+    assert "T1059.004" not in tags
+    assert "T1040" not in tags
 
 
 # ─── tag_blast_radius — context-based signals ─────────────────────────────────


### PR DESCRIPTION
## Summary
- bound MITRE ATT&CK blast-radius tactic fallback while preserving direct CWE mappings
- add legacy ControlTag provenance, offline EPSS/KEV cache joins, and SARIF result taxa references
- align compliance narrative slugs with tag-mapped frameworks and prevent same-control cross-framework bleed

## Validation
- uv run pytest -q tests/test_mitre_attack.py tests/test_finding.py tests/test_enrichment_cache.py tests/test_exploit_likelihood.py tests/test_compliance_narrative.py
- uv run ruff check src/agent_bom/mitre_attack.py src/agent_bom/finding.py src/agent_bom/models.py src/agent_bom/compliance_utils.py src/agent_bom/enrichment.py src/agent_bom/output/sarif.py src/agent_bom/output/compliance_narrative.py tests/test_mitre_attack.py tests/test_finding.py tests/test_enrichment_cache.py tests/test_exploit_likelihood.py tests/test_compliance_narrative.py
- pre-commit hooks during commit: ruff, ruff-format, mypy, bandit, env-var reference drift, Finder duplicate artifact guard