### PR TITLE
fix: emit shell completion scripts and persist CLI scans to local analytics

### DIFF
--- a/src/agent_bom/cli/_inventory.py
+++ b/src/agent_bom/cli/_inventory.py
@@ -293,15 +293,22 @@ def completions_cmd(shell: str):
     Permanent setup (zsh):
       agent-bom completions zsh >> ~/.zshrc
     """
-    import os as _os
-    import subprocess as _sp
-
-    env = {**_os.environ, "_AGENT_BOM_COMPLETE": f"{shell}_source"}
+    # Use Click's completion API directly so the script is generated from
+    # the in-process command tree. The previous implementation shelled out to
+    # `agent-bom` via subprocess, which silently emitted an empty script when
+    # the binary was not on PATH (breaking `eval "$(agent-bom completions zsh)"`).
     try:
-        result = _sp.run(["agent-bom"], env=env, capture_output=True, text=True)
-        click.echo(result.stdout, nl=False)
+        from click.shell_completion import get_completion_class
+
+        from agent_bom.cli import main as _root_cli
+
+        completion_cls = get_completion_class(shell)
+        if completion_cls is None:
+            raise RuntimeError(f"Click does not support completion for shell {shell!r}")
+        comp = completion_cls(_root_cli, {}, "agent-bom", "_AGENT_BOM_COMPLETE")
+        click.echo(comp.source(), nl=False)
     except Exception:  # noqa: BLE001
-        # Fallback: print activation instructions
+        # Fallback: print activation instructions so the user can wire it up by hand.
         if shell == "bash":
             click.echo('eval "$(_AGENT_BOM_COMPLETE=bash_source agent-bom)"')
         elif shell == "zsh":

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -2323,6 +2323,18 @@ def scan(
         return
 
     # Step 6: Save report to history + asset tracking
+    # Mirror every CLI scan to the local analytics store so `agent-bom report query`
+    # sees CLI-tier scans (not only --save'd or API-tier writes). Best-effort: a
+    # write failure must never fail the scan.
+    try:
+        import logging as _logging
+
+        from agent_bom.db.local_analytics import record_scan_report_best_effort
+
+        record_scan_report_best_effort(current_report_json, source="cli")
+    except Exception as _local_analytics_exc:  # noqa: BLE001
+        _logging.getLogger(__name__).debug("Local analytics mirror failed: %s", _local_analytics_exc, exc_info=True)
+
     if save_report:
         from agent_bom.history import save_report as _save
 

--- a/tests/test_cli_completions.py
+++ b/tests/test_cli_completions.py
@@ -1,0 +1,61 @@
+"""Regression tests for `agent-bom completions {bash,zsh,fish}`.
+
+These guard against the v0.86.5 regression where the command shelled out to
+`agent-bom` via subprocess and silently emitted zero bytes when the binary was
+not on PATH — breaking the documented `eval "$(agent-bom completions zsh)"`
+setup path. The fix uses Click's in-process completion API so script generation
+no longer depends on PATH.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from agent_bom.cli._inventory import completions_cmd
+
+
+def _invoke(shell: str) -> str:
+    runner = CliRunner()
+    result = runner.invoke(completions_cmd, [shell])
+    assert result.exit_code == 0, result.output
+    return result.output
+
+
+def test_completions_zsh_emits_nonempty_script():
+    output = _invoke("zsh")
+    assert len(output) > 0, "zsh completion script must not be empty"
+    assert "#compdef agent-bom" in output
+    assert "_AGENT_BOM_COMPLETE=zsh_complete" in output
+
+
+def test_completions_bash_emits_nonempty_script(tmp_path: Path):
+    output = _invoke("bash")
+    assert len(output) > 0, "bash completion script must not be empty"
+    assert "_AGENT_BOM_COMPLETE=bash_complete" in output
+
+    # bash -n syntax-checks the generated script. If bash is available, run it.
+    bash = shutil.which("bash")
+    if bash:
+        script = tmp_path / "completions.bash"
+        script.write_text(output)
+        proc = subprocess.run([bash, "-n", str(script)], capture_output=True, text=True)
+        assert proc.returncode == 0, f"bash -n failed: {proc.stderr}"
+
+
+def test_completions_fish_emits_nonempty_script():
+    output = _invoke("fish")
+    assert len(output) > 0, "fish completion script must not be empty"
+    assert "_AGENT_BOM_COMPLETE=fish_complete" in output
+
+
+def test_completions_zsh_independent_of_path(monkeypatch):
+    """The script must be generated in-process so it works even when the
+    `agent-bom` binary is not on PATH (pipx, --user, unactivated venv)."""
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    output = _invoke("zsh")
+    assert "#compdef agent-bom" in output
+    assert len(output) >= 1000

--- a/tests/test_cli_inventory.py
+++ b/tests/test_cli_inventory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from importlib import resources
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
@@ -280,17 +280,17 @@ def test_discovery_completeness_counts_parse_errors(tmp_path):
 
 def test_completions_bash():
     runner = CliRunner()
-    with patch("subprocess.run") as mock_run:
-        mock_result = MagicMock()
-        mock_result.stdout = "# bash completion"
-        mock_run.return_value = mock_result
-        result = runner.invoke(completions_cmd, ["bash"])
-        assert result.exit_code == 0
+    result = runner.invoke(completions_cmd, ["bash"])
+    assert result.exit_code == 0
+    # In-process generation must emit a real bash completion script, not zero bytes.
+    assert len(result.output) > 0
+    assert "_AGENT_BOM_COMPLETE=bash_complete" in result.output
 
 
 def test_completions_zsh_fallback():
     runner = CliRunner()
-    with patch("subprocess.run", side_effect=Exception("fail")):
+    # If Click's completion API errors, the fallback prints activation instructions.
+    with patch("click.shell_completion.get_completion_class", side_effect=Exception("fail")):
         result = runner.invoke(completions_cmd, ["zsh"])
         assert result.exit_code == 0
         assert "zsh_source" in result.output
@@ -298,7 +298,7 @@ def test_completions_zsh_fallback():
 
 def test_completions_fish_fallback():
     runner = CliRunner()
-    with patch("subprocess.run", side_effect=Exception("fail")):
+    with patch("click.shell_completion.get_completion_class", side_effect=Exception("fail")):
         result = runner.invoke(completions_cmd, ["fish"])
         assert result.exit_code == 0
         assert "fish_source" in result.output

--- a/tests/test_local_analytics.py
+++ b/tests/test_local_analytics.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import sqlite3
 
+from click.testing import CliRunner
+
 from agent_bom.db.local_analytics import LocalAnalyticsStore
 
 
@@ -157,6 +159,57 @@ def test_history_save_dual_writes_local_analytics(monkeypatch, tmp_path):
     with sqlite3.connect(analytics_path) as conn:
         rows = conn.execute("SELECT scan_id, source, artifact_path FROM scan_runs").fetchall()
     assert rows == [("saved-scan", "cli", str(saved_path))]
+
+
+def test_cli_agents_scan_mirrors_to_local_analytics(monkeypatch, tmp_path):
+    """CLI scan completions must mirror to local-analytics regardless of --save.
+
+    Before the v0.86.6 fix, `agent-bom report query "SELECT COUNT(*) FROM scan_runs"`
+    returned 0 after a CLI scan because the mirror was only wired into
+    `history.save_report` (gated on the `--save` flag).
+    """
+    import agent_bom.db.local_analytics as local_analytics
+    from agent_bom.cli import main
+
+    db_path = tmp_path / "analytics.sqlite"
+    monkeypatch.setattr(local_analytics, "LOCAL_ANALYTICS_DB", str(db_path))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["agents", "--agent-mode", "--demo", "--no-scan", "--offline", "--no-auto-update-db"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM scan_runs").fetchone()[0]
+    assert count >= 1, "CLI scan must persist to local-analytics scan_runs"
+
+
+def test_cli_local_analytics_mirror_is_best_effort(monkeypatch, tmp_path):
+    """A mirror-write failure must never fail the scan."""
+    import agent_bom.cli.agents as agents_module
+    from agent_bom.cli import main
+
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError("simulated analytics outage")
+
+    # Patch the function as imported inside the CLI scan-completion code path.
+    monkeypatch.setattr(
+        "agent_bom.db.local_analytics.record_scan_report_best_effort",
+        _raise,
+    )
+    # Sanity: make sure we patched the symbol the CLI imports.
+    assert agents_module is not None
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["agents", "--agent-mode", "--demo", "--no-scan", "--offline", "--no-auto-update-db"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
 
 
 def test_local_analytics_store_migrates_initial_scan_id_keyed_schema(tmp_path):


### PR DESCRIPTION
## Summary
- `agent-bom completions zsh|bash|fish` now emits the Click-generated completion script
  (previously emitted zero bytes when `agent-bom` was not on PATH, silently breaking the
  documented `eval \"\$(agent-bom completions zsh)\"` setup)
- CLI scan completion now mirrors the report to the local analytics store so
  `agent-bom report query` can analyze CLI-tier scans (previously only `--save`'d or
  API-tier writes appeared in the store)
- Local-analytics mirror write is best-effort and never fails a scan

## Validation
- `uv run pytest -q tests/test_cli_completions.py tests/test_cli_inventory.py tests/test_cli_history.py tests/test_local_analytics.py` (53/53 pass)
- `uv run pytest -q` (9761 passed, 21 skipped)
- `uv run ruff check` clean on touched files
- `uv run mypy src/agent_bom/cli/_inventory.py src/agent_bom/history.py src/agent_bom/db/local_analytics.py` clean
- Hands-on: `agent-bom completions bash | bash -n -` (syntax check passes); 1189-byte zsh script emitted in-process
- Hands-on: `AGENT_BOM_LOCAL_ANALYTICS_DB=/tmp/x.sqlite agent-bom agents --demo` then `agent-bom report query "SELECT COUNT(*) FROM scan_runs"` returns 1 (was 0 before fix)
- Regression tests verified to fail on the pre-fix code path before passing on the fix