### PR TITLE
fix CLI runtime audit gates

### DIFF
--- a/src/agent_bom/cli/_check.py
+++ b/src/agent_bom/cli/_check.py
@@ -154,6 +154,8 @@ def _check_result_payload(
     vulnerabilities: list | None = None,
     warnings: list[str] | None = None,
     exit_zero: bool = False,
+    fail_on_severity: str | None = None,
+    fail_on_severity_count: int | None = None,
 ) -> dict:
     """Build machine-readable check output."""
     serialized_vulns = []
@@ -188,6 +190,8 @@ def _check_result_payload(
         "message": message,
         "exit_code": exit_code,
         "exit_zero": exit_zero,
+        "fail_on_severity": fail_on_severity,
+        "fail_on_severity_count": fail_on_severity_count,
         "vulnerability_count": len(serialized_vulns),
         "scan_warnings": warnings or [],
         "vulnerabilities": serialized_vulns,
@@ -196,6 +200,16 @@ def _check_result_payload(
 
 def _format_vulnerability_count(count: int) -> str:
     return f"{count} vulnerability found" if count == 1 else f"{count} vulnerabilities found"
+
+
+_CHECK_SEVERITY_RANK = {"none": 0, "unknown": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
+
+
+def _vulns_at_or_above(vulnerabilities: list, threshold: str | None) -> list:
+    if not threshold:
+        return list(vulnerabilities)
+    threshold_rank = _CHECK_SEVERITY_RANK[threshold.lower()]
+    return [vuln for vuln in vulnerabilities if _CHECK_SEVERITY_RANK.get(str(vuln.severity.value).lower(), 0) >= threshold_rank]
 
 
 def _resolve_check_ecosystems(name: str, version: str, ecosystem: Optional[str], detected_eco: str) -> list[str]:
@@ -333,6 +347,12 @@ def _exit_model_verification(
     help="Exit 0 even when vulnerabilities are found (useful for exploratory or parallel checks)",
 )
 @click.option("--enrich", is_flag=True, help="Add NVD CVSS, EPSS, and CISA KEV enrichment to matched vulnerabilities.")
+@click.option(
+    "--fail-on-severity",
+    type=click.Choice(["critical", "high", "medium", "low"], case_sensitive=False),
+    default=None,
+    help="Exit 1 only when vulnerabilities at this severity or higher are found.",
+)
 @click.option("--nvd-api-key", envvar="NVD_API_KEY", default=None, help="NVD API key for higher rate limits when using --enrich.")
 def check(
     package_spec: str,
@@ -343,6 +363,7 @@ def check(
     output_path: str | None,
     exit_zero: bool,
     enrich: bool,
+    fail_on_severity: str | None,
     nvd_api_key: str | None,
 ):
     """Check a package for known vulnerabilities before installing.
@@ -370,6 +391,7 @@ def check(
       (or `agent-bom scan`) with `--format/--output`.
       Use --exit-zero for exploratory or parallel workflows where findings
       should be reported without failing the command.
+      Use --fail-on-severity to make CI fail only at the selected threshold.
     """
     if output_path and output_format != "json":
         raise click.ClickException("`check --output` requires `--format json`.")
@@ -491,6 +513,7 @@ def check(
 
     matched_pkg = next((p for p in pkgs if p.vulnerabilities), pkgs[0])
     vulns = matched_pkg.vulnerabilities
+    fail_threshold = fail_on_severity.lower() if fail_on_severity else None
 
     if enrich and any(pkg.vulnerabilities for pkg in pkgs):
         from agent_bom.enrichment import enrich_vulnerabilities
@@ -630,6 +653,8 @@ def check(
                     vulnerabilities=vulns,
                     warnings=scan_warnings,
                     exit_zero=True,
+                    fail_on_severity=fail_threshold,
+                    fail_on_severity_count=len(_vulns_at_or_above(vulns, fail_threshold)),
                 ),
                 output_path,
             )
@@ -640,6 +665,32 @@ def check(
             console.print(
                 f"  [yellow]⚠ {_format_vulnerability_count(len(vulns))} — reported without failing due to --exit-zero.[/yellow]\n"
             )
+        sys.exit(0)
+
+    failing_vulns = _vulns_at_or_above(vulns, fail_threshold)
+    if fail_threshold and not failing_vulns:
+        message = f"{_format_vulnerability_count(len(vulns))} in {name}@{version}; none at or above {fail_threshold}."
+        if structured_output:
+            _write_json_output(
+                _check_result_payload(
+                    name=name,
+                    version=version,
+                    ecosystems=ecosystems,
+                    verdict="unsafe",
+                    message=message,
+                    exit_code=0,
+                    vulnerabilities=vulns,
+                    warnings=scan_warnings,
+                    fail_on_severity=fail_threshold,
+                    fail_on_severity_count=0,
+                ),
+                output_path,
+            )
+            sys.exit(0)
+        if quiet:
+            click.echo(f"{name}@{version}: {_format_vulnerability_count(len(vulns))} (below {fail_threshold})")
+        else:
+            console.print(f"  [yellow]⚠ {message}[/yellow]\n")
         sys.exit(0)
 
     if structured_output:
@@ -653,6 +704,8 @@ def check(
                 exit_code=1,
                 vulnerabilities=vulns,
                 warnings=scan_warnings,
+                fail_on_severity=fail_threshold,
+                fail_on_severity_count=len(failing_vulns),
             ),
             output_path,
         )

--- a/src/agent_bom/cli/_entry.py
+++ b/src/agent_bom/cli/_entry.py
@@ -44,6 +44,7 @@ def make_entry_point(
 
         # Resolve the group — supports both direct reference and lazy callable
         _group = group() if callable(group) and not isinstance(group, click.Group) else group
+        _normalize_agent_mode_argv()
 
         try:
             _group(standalone_mode=not agent_mode_requested())
@@ -95,3 +96,19 @@ def _command_name() -> str | None:
         if not arg.startswith("-"):
             return arg
     return None
+
+
+def _normalize_agent_mode_argv() -> None:
+    """Accept --agent-mode before or after the subcommand.
+
+    Click only parses global options before the subcommand. Assistant callers
+    commonly append flags after the command (`agent-bom agents --agent-mode`),
+    so normalize that spelling into the existing env-backed global contract
+    before Click sees argv.
+    """
+    args = sys.argv[1:]
+    if "--agent-mode" not in args:
+        return
+    if args[:1] == ["--agent-mode"]:
+        return
+    sys.argv[:] = [sys.argv[0], "--agent-mode", *(arg for arg in args if arg != "--agent-mode")]

--- a/src/agent_bom/cli/_mcp_group.py
+++ b/src/agent_bom/cli/_mcp_group.py
@@ -69,5 +69,6 @@ def mcp_scan_cmd(server_spec: str, ecosystem: str | None, quiet: bool, no_color:
         output_path=None,
         exit_zero=exit_zero,
         enrich=False,
+        fail_on_severity=None,
         nvd_api_key=None,
     )

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -2292,6 +2292,14 @@ def scan(
             except (FileNotFoundError, ValueError) as exc:
                 logger.warning("Delta baseline error: %s — skipping delta filter", exc)
 
+    if not save_report:
+        try:
+            from agent_bom.db.local_analytics import record_scan_report_best_effort
+
+            record_scan_report_best_effort(current_report_json, source="cli")
+        except Exception as exc:  # pragma: no cover - best-effort analytics must never break scans
+            logger.debug("Local analytics persistence failed: %s", exc, exc_info=True)
+
     # Step 5: Output
     _step_t0 = _time.monotonic()
     _posture_console_only = posture and output_format == "console" and not output
@@ -2361,7 +2369,6 @@ def scan(
             tracker.close()
         except Exception as exc:
             logger.debug("Asset tracking failed: %s", exc, exc_info=True)
-
     # Step 7: Diff against baseline
     if baseline:
         from agent_bom.history import diff_reports

--- a/src/agent_bom/proxy_audit.py
+++ b/src/agent_bom/proxy_audit.py
@@ -628,8 +628,8 @@ def compute_payload_hash(payload: dict) -> str:
 
 
 def compute_response_hmac(payload: dict, key: str) -> str:
-    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
-    return hmac.new(key.encode("utf-8"), canonical.encode("utf-8"), hashlib.sha256).hexdigest()
+    payload_sha256 = compute_payload_hash(payload)
+    return hmac.new(key.encode("utf-8"), payload_sha256.encode("utf-8"), hashlib.sha256).hexdigest()
 
 
 def _record_digest(record: dict) -> str:

--- a/tests/test_audit_replay.py
+++ b/tests/test_audit_replay.py
@@ -97,6 +97,7 @@ RESPONSE_HMAC = {
     "ts": "2026-03-09T10:00:01.100000+00:00",
     "type": "response_hmac",
     "id": 1,
+    "response_sha256": "abc123",
     "hmac_sha256": "a" * 64,
 }
 
@@ -560,6 +561,19 @@ def test_display_json_with_summary(capsys):
     assert code == 0
     out = json.loads(capsys.readouterr().out)
     assert out["summary"]["total_tool_calls"] == 5
+
+
+def test_display_json_fails_on_hmac_mismatch(capsys):
+    log = AuditLog(
+        tool_calls=[ToolCallEntry(ts="", tool="t", policy="allowed", reason="", agent_id="", args={}, payload_sha256="abc", message_id=1)],
+        hmac_entries=[ResponseHMACEntry(ts="", message_id=1, response_sha256="abc", hmac_sha256="0" * 64)],
+    )
+
+    code = display_json(log, hmac_verification=verify_hmac_entries(log, "secret"))
+
+    assert code == 2
+    out = json.loads(capsys.readouterr().out)
+    assert out["hmac_verification"]["failed"] == 1
 
 
 def test_display_rich_empty():

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -139,6 +139,54 @@ def test_check_exit_zero_reports_without_failing(monkeypatch):
     assert "reported without failing due to --exit-zero" in result.output
 
 
+def test_check_fail_on_severity_exits_zero_when_findings_below_threshold(monkeypatch):
+    _patch_check_scan(
+        monkeypatch,
+        [
+            Vulnerability(
+                id="CVE-2026-0001",
+                summary="Moderate issue",
+                severity=Severity.MEDIUM,
+                fixed_version="2.0.0",
+            )
+        ],
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["check", "demo@1.0.0", "--ecosystem", "pypi", "--fail-on-severity", "high", "--format", "json", "--quiet"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["fail_on_severity"] == "high"
+    assert payload["fail_on_severity_count"] == 0
+
+
+def test_check_fail_on_severity_exits_one_when_threshold_matches(monkeypatch):
+    _patch_check_scan(
+        monkeypatch,
+        [
+            Vulnerability(
+                id="CVE-2026-0002",
+                summary="Critical issue",
+                severity=Severity.CRITICAL,
+                fixed_version="2.0.0",
+            )
+        ],
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["check", "demo@1.0.0", "--ecosystem", "pypi", "--fail-on-severity", "high", "--format", "json", "--quiet"],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["fail_on_severity"] == "high"
+    assert payload["fail_on_severity_count"] == 1
+
+
 def test_check_incomplete_offline_scan_exits_two(monkeypatch):
     async def _scan_packages(_pkgs, **_kwargs):
         raise IncompleteScanError("Offline mode requires a populated local vulnerability DB.")

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -185,6 +185,19 @@ def test_agent_mode_entry_wraps_usage_errors(monkeypatch, capsys):
     assert payload["errors"][0]["type"] == "usage"
 
 
+def test_agent_mode_entry_accepts_late_flag(monkeypatch, capsys):
+    monkeypatch.delenv("AGENT_BOM_AGENT_MODE", raising=False)
+    monkeypatch.setattr(sys, "argv", ["agent-bom", "not-a-command", "--agent-mode"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main()
+
+    assert excinfo.value.code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "agent"
+    assert payload["ok"] is False
+
+
 def test_scan_external_scan_invalid_json_exits_nonzero(tmp_path):
     inventory = {
         "schema_version": "1",
@@ -246,6 +259,24 @@ def test_scan_no_scan_flag():
     with patch("agent_bom.cli.agents.discover_all", return_value=[]):
         result = _run(["scan", "--no-scan"])
     assert result.exit_code == 0
+
+
+def test_scan_records_local_analytics_without_save():
+    calls = []
+
+    def _record(report_json, **kwargs):
+        calls.append((report_json, kwargs))
+        return "local-scan"
+
+    with (
+        patch("agent_bom.cli.agents.discover_all", return_value=[]),
+        patch("agent_bom.db.local_analytics.record_scan_report_best_effort", side_effect=_record),
+    ):
+        result = _run(["scan", "--demo", "--no-scan", "--quiet"])
+
+    assert result.exit_code == 0
+    assert calls
+    assert calls[0][1]["source"] == "cli"
 
 
 def test_scan_empty_state_shows_real_client_paths(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes the CLI/runtime hotfix slice from the v0.86.5 audit:

- make `agent-bom audit --verify-hmac --json` actually verify HMAC entries and fail nonzero on mismatch
- require a signing key for `--verify-hmac` instead of silently no-oping
- align response HMAC signing with the verifier by signing the stored payload SHA-256 and writing that hash to audit logs
- make blocked audit entries fail the rich/`--blocked-only` CI gate even without a summary record
- make `agent-bom completions bash|zsh|fish` emit a non-empty fallback when the nested console-script completion call fails
- add `agent-bom check --fail-on-severity` for thresholded pre-install CI gates
- accept `--agent-mode` after subcommands by normalizing it before Click parses argv
- persist completed CLI scans into the local analytics mirror when `--save` is not used; `--save` keeps its existing history dual-write path

## Root Cause

Several CLI paths were wired as presentation features but not as reliable automation gates: JSON audit output skipped HMAC verification, completions trusted an empty failed subprocess, `check` only supported all-or-nothing failing, and local analytics persistence was tied to saved history artifacts instead of completed CLI scan reports.

## Validation

- `env -u AGENT_BOM_AGENT_MODE uv run pytest -q tests/test_cli_inventory.py tests/test_cli_check.py tests/test_audit_replay.py tests/test_cli_scan.py -q`
- `uv run ruff check src/agent_bom/audit_replay.py src/agent_bom/cli/_check.py src/agent_bom/cli/_entry.py src/agent_bom/cli/_inventory.py src/agent_bom/cli/_mcp_group.py src/agent_bom/cli/agents/__init__.py src/agent_bom/proxy.py src/agent_bom/proxy_audit.py tests/test_audit_replay.py tests/test_cli_check.py tests/test_cli_inventory.py tests/test_cli_scan.py`
- `git diff --check`
- commit pre-commit hooks: ruff, ruff-format, mypy, bandit, env-var drift, duplicate artifact guard
