### PR TITLE
add canonical IDs across reports and graph

### DIFF
--- a/docs/canonical-ids.md
+++ b/docs/canonical-ids.md
@@ -1,0 +1,36 @@
+# Canonical IDs
+
+Agent BOM emits deterministic canonical IDs so repeat scans can join the same
+entities, findings, and graph relationships without replacing existing readable
+IDs or source-specific identifiers.
+
+## Contract
+
+- Canonical IDs are UUID v5 values in Agent BOM's fixed namespace.
+- Inputs are normalized by lowercasing and trimming string parts. Structured
+  parts such as tool schemas are serialized as sorted JSON before hashing.
+- Existing `id` and `stable_id` fields remain backward-compatible. New
+  consumers should prefer `canonical_id` when diffing scans, joining graph
+  nodes, or linking findings over time.
+- Source IDs stay as provenance in `source_ids` where available. They are not
+  silently discarded when a canonical ID exists.
+
+## Entity Rules
+
+| Entity | Canonical input |
+|---|---|
+| Agent | agent type + name; graph fleet agents use source or endpoint ID when provided |
+| MCP server | registry ID when available, otherwise server name + launch command |
+| MCP tool | tool name + sorted input schema |
+| MCP resource | resource URI + MIME type |
+| MCP prompt | prompt name + sorted argument descriptors |
+| Package | normalized ecosystem + package name + version, with valid PURL input authoritative |
+| Finding | affected asset canonical ID + vulnerability or finding key + package qualifiers |
+| Graph node | node `stable_id`/`canonical_id` when supplied, otherwise entity type + graph node ID |
+| Graph edge | relationship + source graph ID + target graph ID |
+
+## Compatibility Notes
+
+Graph node IDs such as `agent:claude-desktop` and `pkg:npm:express@4.18.0`
+remain readable and stable for existing API/UI consumers. `canonical_id` is an
+additional join key for scan history, deduplication, and saved investigations.

--- a/src/agent_bom/canonical_ids.py
+++ b/src/agent_bom/canonical_ids.py
@@ -1,0 +1,85 @@
+"""Deterministic canonical identity helpers for scan and graph entities."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from agent_bom.package_utils import canonical_package_key
+
+AGENT_BOM_ID_NAMESPACE = uuid.UUID("7f3e4b2a-9c1d-5f8e-a0b4-12c3d4e5f6a7")
+CANONICAL_ID_SCHEMA_VERSION = "1"
+
+
+def _part_to_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, Mapping):
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return json.dumps(list(value), sort_keys=True, separators=(",", ":"), default=str)
+    return str(value)
+
+
+def canonical_fingerprint(*parts: Any) -> str:
+    """Return the normalized fingerprint material used for canonical IDs."""
+    return ":".join(text.lower().strip() for text in (_part_to_text(part) for part in parts) if text)
+
+
+def canonical_id(*parts: Any) -> str:
+    """Return a deterministic UUID v5 for normalized content parts."""
+    return str(uuid.uuid5(AGENT_BOM_ID_NAMESPACE, canonical_fingerprint(*parts)))
+
+
+def source_ids(**values: Any) -> dict[str, str]:
+    """Return source identifiers as provenance without empty values."""
+    result: dict[str, str] = {}
+    for key, value in values.items():
+        if value in (None, "", [], {}):
+            continue
+        result[str(key)] = _part_to_text(value)
+    return result
+
+
+def canonical_package_id(name: str, version: str, ecosystem: str, purl: str | None = None) -> str:
+    return canonical_id("package", canonical_package_key(name, version, ecosystem, purl))
+
+
+def canonical_agent_id(agent_type: str, name: str, *, source_id: str = "") -> str:
+    source = (source_id or "").strip()
+    if source:
+        return canonical_id("agent", agent_type, source)
+    return canonical_id("agent", agent_type, name)
+
+
+def canonical_mcp_server_id(name: str, command: str = "", *, registry_id: str | None = None) -> str:
+    identifier = registry_id or f"{name}:{command}"
+    return canonical_id("mcp_server", identifier)
+
+
+def canonical_mcp_tool_id(name: str, input_schema: Mapping[str, Any] | None = None) -> str:
+    schema = json.dumps(input_schema or {}, sort_keys=True, separators=(",", ":"))
+    return canonical_id("mcp_tool", name, schema)
+
+
+def canonical_mcp_resource_id(uri: str, mime_type: str | None = None) -> str:
+    return canonical_id("mcp_resource", uri, mime_type or "")
+
+
+def canonical_mcp_prompt_id(name: str, arguments: Sequence[Mapping[str, Any]] | None = None) -> str:
+    args = json.dumps(list(arguments or []), sort_keys=True, separators=(",", ":"))
+    return canonical_id("mcp_prompt", name, args)
+
+
+def canonical_finding_id(asset_canonical_id: str, finding_key: str, *qualifiers: Any) -> str:
+    return canonical_id(asset_canonical_id, finding_key, *qualifiers)
+
+
+def canonical_graph_node_id(entity_type: str, graph_id: str) -> str:
+    return canonical_id("graph_node", entity_type, graph_id)
+
+
+def canonical_graph_edge_id(source: str, target: str, relationship: str) -> str:
+    return canonical_id("graph_edge", relationship, source, target)

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -7,14 +7,12 @@ Later phases will add cloud CIS, proxy alerts, SAST, and skill findings.
 from __future__ import annotations
 
 import re
-import uuid
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional
 
-# Stable namespace for agent-bom deterministic UUIDs
-# Using a fixed UUID so IDs are reproducible across machines and versions
-_AGENT_BOM_NS = uuid.UUID("7f3e4b2a-9c1d-5f8e-a0b4-12c3d4e5f6a7")
+from agent_bom.canonical_ids import canonical_finding_id, canonical_id, source_ids
+
 FINDING_SCHEMA_VERSION = "1"
 
 
@@ -24,8 +22,7 @@ def _stable_id(*parts: str) -> str:
     Same inputs always produce the same UUID. Use this for asset IDs
     and finding IDs so the same entity is tracked consistently across scans.
     """
-    fingerprint = ":".join(p.lower().strip() for p in parts if p)
-    return str(uuid.uuid5(_AGENT_BOM_NS, fingerprint))
+    return canonical_id(*parts)
 
 
 def stable_id(*parts: str) -> str:
@@ -187,6 +184,16 @@ class Asset:
         identifier = self.identifier or f"{self.name}:{self.location or ''}"
         return _stable_id(self.asset_type, identifier)
 
+    @property
+    def canonical_id(self) -> str:
+        """Canonical alias for stable_id used by reports and graph joins."""
+        return self.stable_id
+
+    @property
+    def source_ids(self) -> dict[str, str]:
+        """Original source identifiers retained as provenance."""
+        return source_ids(identifier=self.identifier, location=self.location)
+
 
 @dataclass
 class Finding:
@@ -271,12 +278,17 @@ class Finding:
                 pkg_part = purl.split("/")[-1] if "/" in purl else purl
                 if "@" in pkg_part:
                     pkg_name, pkg_version = pkg_part.rsplit("@", 1)
-            self.id = _stable_id(
+            self.id = canonical_finding_id(
                 self.asset.stable_id,
                 cve_part,
                 pkg_name,
                 pkg_version,
             )
+
+    @property
+    def canonical_id(self) -> str:
+        """Canonical alias for id used by report and graph consumers."""
+        return self.id
 
     def _legacy_control_tags(self) -> list[ControlTag]:
         """Return normalized controls derived from legacy tag arrays."""
@@ -338,6 +350,7 @@ class Finding:
         return {
             "schema_version": FINDING_SCHEMA_VERSION,
             "id": self.id,
+            "canonical_id": self.canonical_id,
             "finding_type": self.finding_type.value,
             "source": self.source.value,
             "asset": {
@@ -346,6 +359,8 @@ class Finding:
                 "identifier": self.asset.identifier,
                 "location": self.asset.location,
                 "stable_id": self.asset.stable_id,
+                "canonical_id": self.asset.canonical_id,
+                "source_ids": self.asset.source_ids,
             },
             "severity": self.severity,
             "effective_severity": self.effective_severity(),

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from agent_bom.api.tracing import get_tracer
 from agent_bom.asset_provenance import package_version_provenance, sanitize_discovery_provenance
+from agent_bom.canonical_ids import canonical_agent_id, canonical_graph_node_id, source_ids
 from agent_bom.graph.container import UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import NodeDimensions, UnifiedNode
@@ -96,7 +97,10 @@ def build_unified_graph_from_report(
                 id=provider_id,
                 entity_type=EntityType.PROVIDER,
                 label=provider_name,
-                attributes={"provider": provider_name},
+                attributes={
+                    "provider": provider_name,
+                    "canonical_id": canonical_graph_node_id(EntityType.PROVIDER.value, provider_id),
+                },
                 data_sources=[data_source_tag],
             )
         )
@@ -110,6 +114,13 @@ def build_unified_graph_from_report(
                 last_seen=str(agent_dict.get("last_seen") or agent_dict.get("discovered_at") or ""),
                 attributes={
                     "agent_type": agent_type,
+                    "canonical_id": agent_dict.get("canonical_id")
+                    or (
+                        canonical_agent_id(agent_type, agent_name, source_id=agent_scope)
+                        if agent_scope
+                        else agent_dict.get("stable_id") or canonical_agent_id(agent_type, agent_name)
+                    ),
+                    "source_ids": source_ids(source_id=agent_scope, stable_id=agent_dict.get("stable_id")),
                     "status": agent_dict.get("status", ""),
                     "stable_id": agent_dict.get("stable_id", ""),
                     "config_path": agent_dict.get("config_path", ""),
@@ -178,6 +189,10 @@ def build_unified_graph_from_report(
                         ],
                         "security_intelligence_count": len(srv_dict.get("security_intelligence", []) or []),
                         "agent": agent_name,
+                        "canonical_id": srv_dict.get("canonical_id")
+                        or srv_dict.get("stable_id")
+                        or canonical_graph_node_id(EntityType.SERVER.value, srv_id),
+                        "source_ids": source_ids(stable_id=srv_dict.get("stable_id"), registry_id=srv_dict.get("registry_id")),
                         "stable_id": srv_dict.get("stable_id", ""),
                         "fingerprint": srv_dict.get("fingerprint", ""),
                     },
@@ -219,6 +234,10 @@ def build_unified_graph_from_report(
                             "version": pkg_version,
                             "ecosystem": ecosystem,
                             "purl": pkg_dict.get("purl", ""),
+                            "canonical_id": pkg_dict.get("canonical_id")
+                            or pkg_dict.get("stable_id")
+                            or canonical_graph_node_id(EntityType.PACKAGE.value, pkg_id),
+                            "source_ids": source_ids(stable_id=pkg_dict.get("stable_id"), purl=pkg_dict.get("purl")),
                             "is_direct": pkg_dict.get("is_direct", True),
                             "parent_package": pkg_dict.get("parent_package", ""),
                             "dependency_depth": pkg_dict.get("dependency_depth", 0),
@@ -277,6 +296,10 @@ def build_unified_graph_from_report(
                         label=tool_name,
                         attributes={
                             "description": tool_dict.get("description", ""),
+                            "canonical_id": tool_dict.get("canonical_id")
+                            or tool_dict.get("stable_id")
+                            or canonical_graph_node_id(EntityType.TOOL.value, tool_id),
+                            "source_ids": source_ids(stable_id=tool_dict.get("stable_id")),
                             "stable_id": tool_dict.get("stable_id", ""),
                             "fingerprint": tool_dict.get("fingerprint", ""),
                             "risk_score": tool_dict.get("risk_score", 0),
@@ -313,7 +336,11 @@ def build_unified_graph_from_report(
                         id=cred_id,
                         entity_type=EntityType.CREDENTIAL,
                         label=env_key,
-                        attributes={"servers": [srv_id]},
+                        attributes={
+                            "canonical_id": canonical_graph_node_id(EntityType.CREDENTIAL.value, cred_id),
+                            "source_ids": source_ids(env_key=env_key),
+                            "servers": [srv_id],
+                        },
                         data_sources=[data_source_tag],
                     )
                 )
@@ -374,6 +401,8 @@ def build_unified_graph_from_report(
                 severity=severity,
                 risk_score=br_dict.get("risk_score", 0),
                 attributes={
+                    "canonical_id": canonical_graph_node_id(EntityType.VULNERABILITY.value, vuln_node_id),
+                    "source_ids": source_ids(vulnerability_id=vuln_id_str),
                     "cvss_score": br_dict.get("cvss_score"),
                     "epss_score": br_dict.get("epss_score"),
                     "is_kev": br_dict.get("is_kev", False),
@@ -992,6 +1021,8 @@ def _add_vuln_node(
             label=vuln_id_str,
             severity=severity,
             attributes={
+                "canonical_id": canonical_graph_node_id(EntityType.VULNERABILITY.value, vuln_node_id),
+                "source_ids": source_ids(vulnerability_id=vuln_id_str),
                 "cvss_score": vuln_dict.get("cvss_score"),
                 "epss_score": vuln_dict.get("epss_score"),
                 "is_kev": vuln_dict.get("is_kev", False),

--- a/src/agent_bom/graph/edge.py
+++ b/src/agent_bom/graph/edge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from agent_bom.canonical_ids import canonical_graph_edge_id
 from agent_bom.graph.types import RelationshipType
 from agent_bom.graph.util import _now_iso
 
@@ -52,9 +53,16 @@ class UnifiedEdge:
         rel = self.relationship.value if isinstance(self.relationship, RelationshipType) else self.relationship
         return f"{rel}:{self.source}:{self.target}"
 
+    @property
+    def canonical_id(self) -> str:
+        """Stable edge identity for scan-history joins without changing edge.id."""
+        rel = self.relationship.value if isinstance(self.relationship, RelationshipType) else str(self.relationship)
+        return canonical_graph_edge_id(self.source, self.target, rel)
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "id": self.id,
+            "canonical_id": self.canonical_id,
             "source": self.source,
             "target": self.target,
             "source_id": self.source,

--- a/src/agent_bom/graph/node.py
+++ b/src/agent_bom/graph/node.py
@@ -7,6 +7,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
+from agent_bom.canonical_ids import canonical_graph_node_id
 from agent_bom.graph.ocsf import ENTITY_OCSF_MAP
 from agent_bom.graph.severity import (
     OCSF_SEVERITY_NAMES,
@@ -120,9 +121,19 @@ class UnifiedNode:
         if not self.last_seen:
             self.last_seen = self.first_seen
 
+    @property
+    def canonical_id(self) -> str:
+        """Stable identity used for cross-scan joins without changing graph IDs."""
+        candidate = self.attributes.get("canonical_id") or self.attributes.get("stable_id")
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate
+        entity_type = self.entity_type.value if isinstance(self.entity_type, EntityType) else str(self.entity_type)
+        return canonical_graph_node_id(entity_type, self.id)
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "id": self.id,
+            "canonical_id": self.canonical_id,
             "entity_type": self.entity_type.value if isinstance(self.entity_type, EntityType) else self.entity_type,
             "label": self.label,
             "category_uid": self.category_uid,
@@ -143,6 +154,9 @@ class UnifiedNode:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> UnifiedNode:
         dims = data.get("dimensions", {})
+        attributes = dict(data.get("attributes", {}))
+        if data.get("canonical_id") and not attributes.get("canonical_id"):
+            attributes["canonical_id"] = data["canonical_id"]
         return cls(
             id=data["id"],
             entity_type=EntityType(data["entity_type"]),
@@ -156,7 +170,7 @@ class UnifiedNode:
             severity_id=data.get("severity_id", OCSFSeverity.UNKNOWN),
             first_seen=data.get("first_seen", ""),
             last_seen=data.get("last_seen", ""),
-            attributes=data.get("attributes", {}),
+            attributes=attributes,
             compliance_tags=data.get("compliance_tags", []),
             data_sources=data.get("data_sources", []),
             dimensions=NodeDimensions.from_dict(dims) if isinstance(dims, dict) else NodeDimensions(),

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -12,12 +12,19 @@ if TYPE_CHECKING:
     from agent_bom.finding import Finding
 
 from agent_bom.advisory_sources import merge_advisory_sources
-from agent_bom.package_utils import (
-    canonical_package_key,
-    normalize_package_name,
+from agent_bom.canonical_ids import (
+    canonical_agent_id,
+    canonical_mcp_prompt_id,
+    canonical_mcp_resource_id,
+    canonical_mcp_server_id,
+    canonical_mcp_tool_id,
+    canonical_package_id,
 )
 from agent_bom.package_utils import (
     host_matches_domain as _host_matches_domain,
+)
+from agent_bom.package_utils import (
+    normalize_package_name,
 )
 from agent_bom.package_utils import parse_debian_source_name as parse_debian_source_name  # noqa: F401
 from agent_bom.package_utils import (
@@ -371,11 +378,12 @@ class Package:
         Same ecosystem/name/version (or purl when available) always produces
         the same ID across scans — enables first-seen/last-seen tracking.
         """
-        import uuid as _uuid
+        return canonical_package_id(self.name, self.version, self.ecosystem, self.purl)
 
-        _ns = _uuid.UUID("7f3e4b2a-9c1d-5f8e-a0b4-12c3d4e5f6a7")
-        fingerprint = f"package:{canonical_package_key(self.name, self.version, self.ecosystem, self.purl)}"
-        return str(_uuid.uuid5(_ns, fingerprint))
+    @property
+    def canonical_id(self) -> str:
+        """Canonical alias for stable_id used by report and graph consumers."""
+        return self.stable_id
 
     @property
     def lookup_names(self) -> list[str]:
@@ -449,12 +457,12 @@ class MCPTool:
     @property
     def stable_id(self) -> str:
         """Deterministic ID for this MCP tool."""
-        import uuid as _uuid
+        return canonical_mcp_tool_id(self.name, self.input_schema)
 
-        _ns = _uuid.UUID("7f3e4b2a-9c1d-5f8e-a0b4-12c3d4e5f6a7")
-        schema = json.dumps(self.input_schema or {}, sort_keys=True, separators=(",", ":"))
-        fingerprint = f"mcp_tool:{self.name.lower().strip()}:{schema}"
-        return str(_uuid.uuid5(_ns, fingerprint))
+    @property
+    def canonical_id(self) -> str:
+        """Canonical alias for stable_id used by report and graph consumers."""
+        return self.stable_id
 
     @property
     def fingerprint(self) -> str:
@@ -489,11 +497,12 @@ class MCPResource:
     @property
     def stable_id(self) -> str:
         """Deterministic ID for this MCP resource."""
-        import uuid as _uuid
+        return canonical_mcp_resource_id(self.uri, self.mime_type)
 
-        _ns = _uuid.UUID("7f3e4b2a-9c1d-5f8e-a0b4-12c3d4e5f6a7")
-        fingerprint = f"mcp_resource:{self.uri.lower().strip()}:{(self.mime_type or '').lower().strip()}"
-        return str(_uuid.uuid5(_ns, fingerprint))
+    @property
+    def canonical_id(self) -> str:
+        """Canonical alias for stable_id used by report and graph consumers."""
+        return self.stable_id
 
     @property
     def fingerprint(self) -> str:
@@ -525,12 +534,12 @@ class MCPPrompt:
     @property
     def stable_id(self) -> str:
         """Deterministic ID for this MCP prompt descriptor."""
-        import uuid as _uuid
+        return canonical_mcp_prompt_id(self.name, self.arguments)
 
-        _ns = _uuid.UUID("7f3e4b2a-9c1d-5f8e-a0b4-12c3d4e5f6a7")
-        args = json.dumps(self.arguments, sort_keys=True, separators=(",", ":"))
-        fingerprint = f"mcp_prompt:{self.name.lower().strip()}:{args}"
-        return str(_uuid.uuid5(_ns, fingerprint))
+    @property
+    def canonical_id(self) -> str:
+        """Canonical alias for stable_id used by report and graph consumers."""
+        return self.stable_id
 
     @property
     def fingerprint(self) -> str:
@@ -614,12 +623,12 @@ class MCPServer:
         Uses registry_id when available (most stable identifier), otherwise
         falls back to name+command so the same server is always the same ID.
         """
-        import uuid as _uuid
+        return canonical_mcp_server_id(self.name, self.command, registry_id=self.registry_id)
 
-        _ns = _uuid.UUID("7f3e4b2a-9c1d-5f8e-a0b4-12c3d4e5f6a7")
-        identifier = self.registry_id or f"{self.name}:{self.command}"
-        fingerprint = f"mcp_server:{identifier.lower().strip()}"
-        return str(_uuid.uuid5(_ns, fingerprint))
+    @property
+    def canonical_id(self) -> str:
+        """Canonical alias for stable_id used by report and graph consumers."""
+        return self.stable_id
 
     @property
     def auth_mode(self) -> str:
@@ -734,11 +743,12 @@ class Agent:
         Canonical identity: agent_type + name. Same agent configuration
         always resolves to the same ID across scans.
         """
-        import uuid as _uuid
+        return canonical_agent_id(self.agent_type.value, self.name)
 
-        _ns = _uuid.UUID("7f3e4b2a-9c1d-5f8e-a0b4-12c3d4e5f6a7")
-        fingerprint = f"agent:{self.agent_type.value}:{self.name.lower().strip()}"
-        return str(_uuid.uuid5(_ns, fingerprint))
+    @property
+    def canonical_id(self) -> str:
+        """Canonical alias for stable_id used by report and graph consumers."""
+        return self.stable_id
 
     @property
     def total_packages(self) -> int:

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -90,6 +90,7 @@ def _prompt_scan_findings(prompt_scan: dict) -> list[dict[str, object]]:
             {
                 "schema_version": FINDING_SCHEMA_VERSION,
                 "id": _stable_report_finding_id("prompt_scan", source_file, line_number, title, item.get("matched_text")),
+                "canonical_id": _stable_report_finding_id("prompt_scan", source_file, line_number, title, item.get("matched_text")),
                 "finding_type": "PROMPT_SECURITY",
                 "source": "PROMPT_SCAN",
                 "asset": {
@@ -98,6 +99,7 @@ def _prompt_scan_findings(prompt_scan: dict) -> list[dict[str, object]]:
                     "identifier": source_file or None,
                     "location": source_file or None,
                     "stable_id": _stable_report_finding_id("prompt_asset", source_file),
+                    "canonical_id": _stable_report_finding_id("prompt_asset", source_file),
                 },
                 "severity": severity,
                 "effective_severity": severity,
@@ -127,6 +129,7 @@ def _browser_extension_findings(browser_extensions: dict) -> list[dict[str, obje
             {
                 "schema_version": FINDING_SCHEMA_VERSION,
                 "id": _stable_report_finding_id("browser_extension", browser, extension_id, item.get("version")),
+                "canonical_id": _stable_report_finding_id("browser_extension", browser, extension_id, item.get("version")),
                 "finding_type": "BROWSER_EXTENSION_RISK",
                 "source": "BROWSER_EXTENSION_SCAN",
                 "asset": {
@@ -135,6 +138,7 @@ def _browser_extension_findings(browser_extensions: dict) -> list[dict[str, obje
                     "identifier": extension_id,
                     "location": item.get("path"),
                     "stable_id": _stable_report_finding_id("browser_extension_asset", browser, extension_id),
+                    "canonical_id": _stable_report_finding_id("browser_extension_asset", browser, extension_id),
                 },
                 "severity": severity,
                 "effective_severity": severity,
@@ -381,6 +385,7 @@ def _build_ai_bom_entities_snapshot(report: AIBOMReport) -> dict:
         agents.append(
             {
                 "id": agent.stable_id,
+                "canonical_id": agent.canonical_id,
                 "name": agent.name,
                 "agent_type": agent.agent_type.value,
                 "type": agent.agent_type.value,
@@ -398,6 +403,7 @@ def _build_ai_bom_entities_snapshot(report: AIBOMReport) -> dict:
             if server.stable_id not in servers:
                 servers[server.stable_id] = {
                     "id": server.stable_id,
+                    "canonical_id": server.canonical_id,
                     "name": server.name,
                     "surface": server.surface.value,
                     "fingerprint": server.fingerprint,
@@ -420,6 +426,7 @@ def _build_ai_bom_entities_snapshot(report: AIBOMReport) -> dict:
                 if tool.stable_id not in tools:
                     tools[tool.stable_id] = {
                         "id": tool.stable_id,
+                        "canonical_id": tool.canonical_id,
                         "name": tool.name,
                         "fingerprint": tool.fingerprint,
                         "description": tool.description,
@@ -437,6 +444,7 @@ def _build_ai_bom_entities_snapshot(report: AIBOMReport) -> dict:
                 if resource.stable_id not in resources:
                     resources[resource.stable_id] = {
                         "id": resource.stable_id,
+                        "canonical_id": resource.canonical_id,
                         "uri": resource.uri,
                         "name": resource.name,
                         "fingerprint": resource.fingerprint,
@@ -452,6 +460,7 @@ def _build_ai_bom_entities_snapshot(report: AIBOMReport) -> dict:
                 if prompt.stable_id not in prompts:
                     prompts[prompt.stable_id] = {
                         "id": prompt.stable_id,
+                        "canonical_id": prompt.canonical_id,
                         "name": prompt.name,
                         "fingerprint": prompt.fingerprint,
                         "description": prompt.description,
@@ -467,6 +476,7 @@ def _build_ai_bom_entities_snapshot(report: AIBOMReport) -> dict:
                 if pkg.stable_id not in packages:
                     packages[pkg.stable_id] = {
                         "id": pkg.stable_id,
+                        "canonical_id": pkg.canonical_id,
                         "name": pkg.name,
                         "version": pkg.version,
                         "ecosystem": pkg.ecosystem,
@@ -828,6 +838,7 @@ def to_json(report: AIBOMReport) -> dict:
             {
                 "name": agent.name,
                 "stable_id": agent.stable_id,
+                "canonical_id": agent.canonical_id,
                 "agent_type": agent.agent_type.value,
                 "type": agent.agent_type.value,
                 "config_path": sanitize_path_label(agent.config_path) if agent.config_path else "",
@@ -842,6 +853,7 @@ def to_json(report: AIBOMReport) -> dict:
                     {
                         "name": server.name,
                         "stable_id": server.stable_id,
+                        "canonical_id": server.canonical_id,
                         "surface": server.surface.value,
                         "fingerprint": server.fingerprint,
                         "command": server.command,
@@ -868,6 +880,7 @@ def to_json(report: AIBOMReport) -> dict:
                             {
                                 "name": t.name,
                                 "stable_id": t.stable_id,
+                                "canonical_id": t.canonical_id,
                                 "fingerprint": t.fingerprint,
                                 "description": t.description,
                                 "discovery_source": t.discovery_source,
@@ -882,6 +895,7 @@ def to_json(report: AIBOMReport) -> dict:
                             {
                                 "uri": r.uri,
                                 "stable_id": r.stable_id,
+                                "canonical_id": r.canonical_id,
                                 "fingerprint": r.fingerprint,
                                 "name": r.name,
                                 "description": r.description,
@@ -895,6 +909,7 @@ def to_json(report: AIBOMReport) -> dict:
                             {
                                 "name": p.name,
                                 "stable_id": p.stable_id,
+                                "canonical_id": p.canonical_id,
                                 "fingerprint": p.fingerprint,
                                 "description": p.description,
                                 "arguments": p.arguments,
@@ -907,6 +922,7 @@ def to_json(report: AIBOMReport) -> dict:
                             {
                                 "name": pkg.name,
                                 "stable_id": pkg.stable_id,
+                                "canonical_id": pkg.canonical_id,
                                 "version": pkg.version,
                                 "ecosystem": pkg.ecosystem,
                                 "purl": pkg.purl,
@@ -1020,6 +1036,7 @@ def to_json(report: AIBOMReport) -> dict:
             {
                 "schema_version": BLAST_RADIUS_SCHEMA_VERSION,
                 **({"package_name": br.package.name, "package_version": br.package.version, "package_stable_id": br.package.stable_id}),
+                "package_canonical_id": br.package.canonical_id,
                 **effective_blast_radius_tags(br),
                 "risk_score": br.risk_score,
                 "reachability": br.reachability,

--- a/tests/test_aibom_e2e.py
+++ b/tests/test_aibom_e2e.py
@@ -250,6 +250,21 @@ class TestAIBOMDocument:
         assert result["summary"]["total_agents"] == 2
         assert result["summary"]["total_vulnerabilities"] >= 2
 
+    def test_report_surfaces_canonical_ids_alongside_stable_ids(self):
+        report = _make_full_report()
+        result = to_json(report)
+
+        agent = result["agents"][0]
+        server = agent["mcp_servers"][0]
+        package = server["packages"][0]
+        finding = result["findings"][0]
+
+        assert agent["canonical_id"] == agent["stable_id"]
+        assert server["canonical_id"] == server["stable_id"]
+        assert package["canonical_id"] == package["stable_id"]
+        assert finding["canonical_id"] == finding["id"]
+        assert finding["asset"]["canonical_id"] == finding["asset"]["stable_id"]
+
     def test_mcp_context_detected(self):
         report = _make_full_report()
         assert report.has_mcp_context is True

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -121,6 +121,7 @@ class TestBuildUnifiedGraphFromReport:
                     "name": "claude-desktop",
                     "type": "claude-desktop",
                     "source_id": "device-a",
+                    "stable_id": "legacy-agent-stable-id",
                     "enrollment_name": "eng-laptop-a",
                     "owner": "alice",
                     "mcp_servers": [
@@ -137,6 +138,7 @@ class TestBuildUnifiedGraphFromReport:
                     "name": "claude-desktop",
                     "type": "claude-desktop",
                     "source_id": "device-b",
+                    "stable_id": "legacy-agent-stable-id",
                     "enrollment_name": "eng-laptop-b",
                     "owner": "bob",
                     "mcp_servers": [
@@ -156,6 +158,7 @@ class TestBuildUnifiedGraphFromReport:
 
         assert "agent:device-a:claude-desktop" in g.nodes
         assert "agent:device-b:claude-desktop" in g.nodes
+        assert g.nodes["agent:device-a:claude-desktop"].canonical_id != g.nodes["agent:device-b:claude-desktop"].canonical_id
         assert g.nodes["agent:device-a:claude-desktop"].attributes["source_id"] == "device-a"
         assert g.nodes["agent:device-b:claude-desktop"].attributes["owner"] == "bob"
         assert g.has_edge("agent:device-a:claude-desktop", "server:device-a:claude-desktop:team-chat-server")
@@ -179,6 +182,7 @@ class TestBuildUnifiedGraphFromReport:
         assert "agent:device%3Aprod:claude-desktop" in g.nodes
         assert "agent:device:prod:claude-desktop" not in g.nodes
         assert g.nodes["agent:device%3Aprod:claude-desktop"].attributes["source_id"] == "device:prod"
+        assert g.nodes["agent:device%3Aprod:claude-desktop"].attributes["source_ids"]["source_id"] == "device:prod"
 
     def test_provider_nodes_and_hosts_edges(self):
         g = build_unified_graph_from_report(_minimal_report())
@@ -530,7 +534,18 @@ class TestBuildUnifiedGraphFromReport:
         g = build_unified_graph_from_report(report)
 
         assert "pkg:pypi:torch-audio@1.0.0" in g.nodes
+        assert g.nodes["pkg:pypi:torch-audio@1.0.0"].to_dict()["canonical_id"]
         assert g.has_edge("pkg:pypi:torch-audio@1.0.0", "vuln:CVE-2024-1234")
+
+    def test_graph_nodes_and_edges_emit_canonical_ids_without_replacing_readable_ids(self):
+        g = build_unified_graph_from_report(_minimal_report())
+        agent = g.nodes["agent:claude-desktop"]
+        edge = next(e for e in g.edges if e.source == "agent:claude-desktop" and e.target == "server:claude-desktop:mcp-fs")
+
+        assert agent.to_dict()["id"] == "agent:claude-desktop"
+        assert agent.to_dict()["canonical_id"] == agent.canonical_id
+        assert edge.to_dict()["id"] == "uses:agent:claude-desktop:server:claude-desktop:mcp-fs"
+        assert edge.to_dict()["canonical_id"] == edge.canonical_id
 
     def test_agent_to_server_edge(self):
         g = build_unified_graph_from_report(_minimal_report())

--- a/tests/test_stable_ids.py
+++ b/tests/test_stable_ids.py
@@ -1,7 +1,7 @@
 """Tests for deterministic UUID v5 stable IDs on assets and findings (issue: stable IDs)."""
 
 from agent_bom.finding import Asset, Finding, FindingSource, FindingType, stable_id
-from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
+from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
 # ---------------------------------------------------------------------------
 # Finding determinism
@@ -94,6 +94,7 @@ def test_asset_stable_id_is_deterministic():
     a1 = Asset(name="requests", asset_type="package", identifier="pkg:pypi/requests@2.0.0")
     a2 = Asset(name="requests", asset_type="package", identifier="pkg:pypi/requests@2.0.0")
     assert a1.stable_id == a2.stable_id
+    assert a1.canonical_id == a1.stable_id
     assert len(a1.stable_id) == 36
 
 
@@ -137,6 +138,16 @@ def test_package_stable_id_uses_canonical_package_identity():
     p_dot = Package(name="Torch.Audio", version="1.0.0", ecosystem="PyPI", purl="pkg:pypi/Torch.Audio@1.0.0")
 
     assert p_hyphen.stable_id == p_under.stable_id == p_dot.stable_id
+    assert p_hyphen.canonical_id == p_hyphen.stable_id
+
+
+def test_tool_canonical_id_ignores_schema_key_order():
+    """Non-semantic JSON schema key order must not split tool identity."""
+    t1 = MCPTool(name="search", description="Search", input_schema={"b": 2, "a": {"z": True, "m": False}})
+    t2 = MCPTool(name="search", description="Search docs", input_schema={"a": {"m": False, "z": True}, "b": 2})
+
+    assert t1.stable_id == t2.stable_id
+    assert t1.canonical_id == t1.stable_id
 
 
 # ---------------------------------------------------------------------------
@@ -169,6 +180,15 @@ def test_mcpserver_stable_id_uses_registry_id_when_available():
     assert s_with_registry.stable_id != s_without_registry.stable_id
 
 
+def test_mcpserver_canonical_id_survives_registry_rename():
+    """Registry IDs are authoritative so display-name changes do not split history."""
+    s1 = MCPServer(name="filesystem", command="npx @modelcontextprotocol/server-filesystem", registry_id="modelcontextprotocol/filesystem")
+    s2 = MCPServer(name="File System", command="uvx filesystem-server", registry_id="modelcontextprotocol/filesystem")
+
+    assert s1.stable_id == s2.stable_id
+    assert s1.canonical_id == s1.stable_id
+
+
 # ---------------------------------------------------------------------------
 # Agent stable_id
 # ---------------------------------------------------------------------------
@@ -179,6 +199,7 @@ def test_agent_stable_id_deterministic():
     a1 = Agent(name="Claude Desktop", agent_type=AgentType.CLAUDE_DESKTOP, config_path="/path/a")
     a2 = Agent(name="Claude Desktop", agent_type=AgentType.CLAUDE_DESKTOP, config_path="/path/b")
     assert a1.stable_id == a2.stable_id
+    assert a1.canonical_id == a1.stable_id
     assert len(a1.stable_id) == 36
 
 


### PR DESCRIPTION
## Summary
- closes #2489 with a bounded canonical-ID contract for core scan entities, findings, graph nodes, and graph edges
- centralizes deterministic UUID v5 ID helpers while preserving existing `id` and `stable_id` fields for backward compatibility
- emits `canonical_id`/`source_ids` in JSON report and graph serialization, with docs and regression tests for repeat-scan joins and source conflicts

## Validation
- `uv run pytest -q tests/test_stable_ids.py tests/test_graph_builder.py tests/test_aibom_e2e.py tests/test_finding.py tests/test_graph_roundtrip.py tests/test_graph_schema.py`
- `uv run ruff check src/agent_bom/canonical_ids.py src/agent_bom/finding.py src/agent_bom/models.py src/agent_bom/graph/node.py src/agent_bom/graph/edge.py src/agent_bom/graph/builder.py src/agent_bom/output/json_fmt.py tests/test_stable_ids.py tests/test_graph_builder.py tests/test_aibom_e2e.py`
- `uv run mypy src/agent_bom/canonical_ids.py src/agent_bom/finding.py src/agent_bom/models.py src/agent_bom/graph/node.py src/agent_bom/graph/edge.py src/agent_bom/graph/builder.py src/agent_bom/output/json_fmt.py`
- `git diff --check`
- `PYTHONPATH=src uv run agent-bom agents --demo --offline`

## Notes
- Bare `uv run agent-bom agents --demo --offline` failed in this fresh worktree before application import with `ModuleNotFoundError: No module named agent_bom`; the same smoke passed with `PYTHONPATH=src`.
- Deferred: database migration/backfill and time-versioned edge history belong to separate graph-history work.