### PR TITLE
release: enable PyPI native attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,6 +260,8 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          attestations: true
 
       - name: Verify PyPI provenance attestations
         run: |


### PR DESCRIPTION
## Summary
Enable native PyPI provenance attestations in the release publisher by passing `attestations: true` to `pypa/gh-action-pypi-publish`.

This closes the remaining supply-chain audit gap where GitHub Sigstore bundles existed, but PyPI's PEP 740 provenance surface could still report no native attestations.

## Root Cause
The release workflow already used Trusted Publishing and verified PyPI's integrity API after upload, but the publish action was not explicitly configured to emit PyPI-native attestations.

## Validation
- `git diff --check`
- pre-commit hooks from commit: YAML check, whitespace, private-key check, conflict check, duplicate artifact guard
