### PR TITLE
fix API gateway data audit gaps

### DIFF
--- a/scripts/generate_runtime_evidence_pack.py
+++ b/scripts/generate_runtime_evidence_pack.py
@@ -115,7 +115,7 @@ def _gateway_evidence() -> dict[str, Any]:
                 "params": {"name": "query_issues", "arguments": {"jql": "project = AGENTBOM"}},
             },
         )
-        metrics = client.get("/metrics")
+        metrics = client.get("/metrics", headers={"Authorization": f"Bearer {GATEWAY_TOKEN}"})
 
     os.environ.pop(UPSTREAM_TOKEN_ENV, None)
     metric_lines = [line for line in metrics.text.splitlines() if "agent_bom_gateway_relays_total" in line]

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -1661,3 +1661,127 @@ class MaxBodySizeMiddleware(BaseHTTPMiddleware):
             request._receive = _receive  # type: ignore[attr-defined]
 
         return await call_next(request)
+
+
+# ─── P1-18 v0.86.5 audit: structured error envelope ───────────────────────────
+
+# Map HTTP status codes to stable string codes that downstream consumers can
+# pin on without parsing free-form messages. The mapping is intentionally
+# narrow — every API error funnels through one of these buckets, with anything
+# else falling back to ``INTERNAL_ERROR``.
+_ERROR_CODE_BY_STATUS = {
+    400: "BAD_REQUEST",
+    401: "AUTH_FAILED",
+    403: "FORBIDDEN",
+    404: "NOT_FOUND",
+    405: "METHOD_NOT_ALLOWED",
+    409: "CONFLICT",
+    413: "PAYLOAD_TOO_LARGE",
+    415: "UNSUPPORTED_MEDIA_TYPE",
+    422: "VALIDATION_ERROR",
+    429: "RATE_LIMITED",
+    500: "INTERNAL_ERROR",
+    503: "SERVICE_UNAVAILABLE",
+}
+
+
+def _error_code_for_status(status_code: int) -> str:
+    return _ERROR_CODE_BY_STATUS.get(status_code, "INTERNAL_ERROR")
+
+
+def _error_message_for(status_code: int, detail: object) -> str:
+    """Best-effort short human message derived from the FastAPI detail."""
+    if isinstance(detail, str) and detail.strip():
+        return detail
+    if isinstance(detail, list) and detail:
+        # RequestValidationError serializes to a list of field-level errors;
+        # collapse the first message so the envelope still has a human field.
+        first = detail[0]
+        if isinstance(first, dict):
+            msg = first.get("msg")
+            if isinstance(msg, str) and msg.strip():
+                return msg
+    if isinstance(detail, dict):
+        msg = detail.get("message") or detail.get("msg")
+        if isinstance(msg, str) and msg.strip():
+            return msg
+    return {
+        400: "Bad request",
+        401: "Authentication required",
+        403: "Forbidden",
+        404: "Not found",
+        409: "Conflict",
+        413: "Payload too large",
+        422: "Validation error",
+        429: "Rate limited",
+        500: "Internal error",
+        503: "Service unavailable",
+    }.get(status_code, "Request failed")
+
+
+def _build_error_envelope(
+    *,
+    status_code: int,
+    detail: object,
+    correlation_id: str,
+    headers: dict[str, str] | None = None,
+) -> JSONResponse:
+    payload = {
+        "error": {
+            "code": _error_code_for_status(status_code),
+            "message": _error_message_for(status_code, detail),
+            "correlation_id": correlation_id,
+            # Preserve the original FastAPI detail payload for backward
+            # compatibility — existing UIs that displayed `detail` still work
+            # while new clients can read `error.code` / `error.message`.
+            "details": detail,
+        },
+        # Top-level alias kept so callers that grew up on
+        # ``{"detail": "..."}`` still parse. New code should read ``error``.
+        "detail": detail,
+    }
+    response_headers = dict(headers or {})
+    response_headers.setdefault("X-Request-ID", correlation_id)
+    return JSONResponse(status_code=status_code, content=payload, headers=response_headers)
+
+
+def install_error_envelope(application: object) -> None:
+    """Register FastAPI exception handlers that emit the v1 error envelope.
+
+    The envelope is ``{error: {code, message, correlation_id, details}}`` and
+    is also surfaced as a top-level ``detail`` field for backward compatibility
+    with the historical FastAPI shape.
+    """
+    from fastapi import HTTPException
+    from fastapi.exceptions import RequestValidationError
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    def _correlation_id(request: StarletteRequest) -> str:
+        return getattr(request.state, "request_id", "") or request.headers.get("x-request-id") or str(uuid.uuid4())
+
+    async def http_exception_handler(request: StarletteRequest, exc: HTTPException):
+        return _build_error_envelope(
+            status_code=exc.status_code,
+            detail=exc.detail,
+            correlation_id=_correlation_id(request),
+            headers=getattr(exc, "headers", None),
+        )
+
+    async def starlette_http_exception_handler(request: StarletteRequest, exc: StarletteHTTPException):
+        return _build_error_envelope(
+            status_code=exc.status_code,
+            detail=exc.detail,
+            correlation_id=_correlation_id(request),
+            headers=getattr(exc, "headers", None),
+        )
+
+    async def validation_exception_handler(request: StarletteRequest, exc: RequestValidationError):
+        return _build_error_envelope(
+            status_code=422,
+            detail=exc.errors(),
+            correlation_id=_correlation_id(request),
+        )
+
+    application.add_exception_handler(HTTPException, http_exception_handler)  # type: ignore[attr-defined]
+    application.add_exception_handler(StarletteHTTPException, starlette_http_exception_handler)  # type: ignore[attr-defined]
+    application.add_exception_handler(RequestValidationError, validation_exception_handler)  # type: ignore[attr-defined]

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -534,7 +534,8 @@ async def list_keys(request: Request) -> dict:
 
     tenant_id = getattr(request.state, "tenant_id", "default")
     keys = get_key_store().list_keys(tenant_id=tenant_id)
-    return {"keys": [k.to_dict() for k in keys]}
+    # P1-16 v0.86.5 audit: schema_version on terminal list response.
+    return {"schema_version": "v1", "keys": [k.to_dict() for k in keys]}
 
 
 @router.get("/v1/auth/policy", tags=["enterprise"])
@@ -886,6 +887,8 @@ async def list_audit_entries(
     store = get_audit_log()
     entries = store.list_entries(action=action, resource=resource, since=since, limit=limit, offset=offset, tenant_id=tenant_id)
     return {
+        # P1-16 v0.86.5 audit: schema_version on terminal list response.
+        "schema_version": "v1",
         "entries": [e.to_dict() for e in entries],
         "total": store.count(action=action, tenant_id=tenant_id),
         "limit": limit,
@@ -1032,11 +1035,26 @@ async def create_exception(request: Request, req: ExceptionRequest) -> dict:
 
 
 @router.get("/v1/exceptions", tags=["enterprise"])
-async def list_exceptions(request: Request, status: str | None = None) -> dict:
+async def list_exceptions(
+    request: Request,
+    status: str | None = None,
+    # P1-17 v0.86.5 audit: cap exception pagination to keep parity with /v1/audit.
+    limit: Annotated[int, Query(ge=1, le=1000)] = 1000,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> dict:
     """List all vulnerability exceptions."""
     tenant_id = getattr(request.state, "tenant_id", "default")
-    exceptions = _get_exception_store().list_all(status=status, tenant_id=tenant_id)
-    return {"exceptions": [e.to_dict() for e in exceptions], "total": len(exceptions)}
+    all_exceptions = _get_exception_store().list_all(status=status, tenant_id=tenant_id)
+    total = len(all_exceptions)
+    page = all_exceptions[offset : offset + limit]
+    return {
+        # P1-16 v0.86.5 audit: schema_version on terminal list response.
+        "schema_version": "v1",
+        "exceptions": [e.to_dict() for e in page],
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
 
 
 @router.get("/v1/exceptions/{exception_id}", tags=["enterprise"])

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -12,8 +12,10 @@ Endpoints:
 
 from __future__ import annotations
 
-from collections import Counter, deque
+import time
+from collections import Counter, OrderedDict, deque
 from pathlib import Path as _Path
+from threading import Lock
 from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, HTTPException, Query, Request, WebSocket
@@ -44,6 +46,46 @@ _proxy_alerts: deque[dict] = deque(maxlen=1000)
 _proxy_alerts_total: int = 0
 _proxy_metrics: dict | None = None
 _proxy_metrics_by_tenant: dict[str, dict] = {}
+
+# P1-19 v0.86.5 audit: dedupe inbound proxy alerts by event_id over a 24h
+# window so a hostile or buggy proxy cannot replay credential-leak alerts and
+# inflate detector tallies. Per-(tenant_id, event_id) entries expire after
+# AUDIT_DEDUPE_WINDOW_SECONDS.
+AUDIT_DEDUPE_WINDOW_SECONDS = 24 * 60 * 60
+AUDIT_DEDUPE_MAX_ENTRIES = 50_000
+_audit_dedupe: "OrderedDict[tuple[str, str], float]" = OrderedDict()
+_audit_dedupe_lock = Lock()
+
+
+def _purge_expired_dedupe(now: float) -> None:
+    cutoff = now - AUDIT_DEDUPE_WINDOW_SECONDS
+    while _audit_dedupe:
+        key, ts = next(iter(_audit_dedupe.items()))
+        if ts >= cutoff:
+            break
+        _audit_dedupe.popitem(last=False)
+    while len(_audit_dedupe) > AUDIT_DEDUPE_MAX_ENTRIES:
+        _audit_dedupe.popitem(last=False)
+
+
+def _claim_audit_event(tenant_id: str, event_id: str) -> bool:
+    """Reserve a (tenant, event_id) pair. Returns True if new, False if replay."""
+    if not event_id:
+        return True
+    now = time.time()
+    key = (tenant_id or "default", event_id)
+    with _audit_dedupe_lock:
+        _purge_expired_dedupe(now)
+        if key in _audit_dedupe:
+            return False
+        _audit_dedupe[key] = now
+        return True
+
+
+def _reset_audit_dedupe_for_tests() -> None:
+    """Test helper to clear the dedupe table between cases."""
+    with _audit_dedupe_lock:
+        _audit_dedupe.clear()
 
 
 def push_proxy_alert(alert: dict) -> None:
@@ -102,6 +144,8 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
     from agent_bom.api.stores import _get_firewall_decision_store
 
     firewall_store = _get_firewall_decision_store()
+    duplicate_event_ids: list[str] = []
+    accepted_alerts: list[dict] = []
     for alert in body.alerts:
         enriched = dict(alert)
         enriched.setdefault("source_id", source_id)
@@ -113,6 +157,14 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         # process-wide; without this tag every tenant sees every other
         # tenant's alerts on shared deployments.
         enriched.setdefault("tenant_id", tenant_id)
+        # P1-19 v0.86.5 audit: dedupe by event_id so a buggy or hostile proxy
+        # cannot replay credential_leak alerts and inflate per-detector
+        # tallies. Empty event_id falls through to keep legacy callers working.
+        event_id = str(enriched.get("event_id") or "")
+        if event_id and not _claim_audit_event(tenant_id, event_id):
+            duplicate_event_ids.append(event_id)
+            continue
+        accepted_alerts.append(enriched)
         push_proxy_alert(enriched)
         # Tally inter-agent firewall decisions for the runtime-tab dashboard
         # (#982 PR 4). Non-firewall alerts are silently ignored by record().
@@ -156,6 +208,19 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         except Exception:
             pass
 
+    # P1-19 v0.86.5 audit: count both the alerts that crossed the wire and the
+    # runtime_alerts surfaced via summary so credential_leak detections always
+    # register, regardless of which envelope key the caller used.
+    summary_runtime_alerts = 0
+    if isinstance(body.summary, dict):
+        candidate = body.summary.get("runtime_alerts")
+        if isinstance(candidate, int):
+            summary_runtime_alerts = max(0, candidate)
+        elif isinstance(candidate, list):
+            summary_runtime_alerts = len(candidate)
+    accepted_count = len(accepted_alerts)
+    effective_alert_count = max(accepted_count, summary_runtime_alerts)
+
     log_action(
         "proxy.audit_ingested",
         actor=actor,
@@ -164,14 +229,18 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         session_id=session_id,
         request_id=request_id,
         trace_id=trace_id,
-        alert_count=len(body.alerts),
+        alert_count=effective_alert_count,
+        duplicate_alert_count=len(duplicate_event_ids),
         has_summary=body.summary is not None,
     )
     response = {
         "ingested": True,
         "source_id": source_id,
         "session_id": session_id,
-        "alert_count": len(body.alerts),
+        "alert_count": effective_alert_count,
+        "accepted_alert_count": accepted_count,
+        "duplicate_alert_count": len(duplicate_event_ids),
+        "duplicate_event_ids": duplicate_event_ids,
         "has_summary": body.summary is not None,
     }
     if body.idempotency_key:

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -31,9 +31,9 @@ import os
 import time
 import uuid
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import PlainTextResponse
 from werkzeug.security import safe_join
 
@@ -847,16 +847,16 @@ async def stream_scan(request: Request, job_id: str):
 @router.get("/v1/jobs", tags=["scan"])
 async def list_jobs(
     request: Request,
-    limit: int = 50,
-    offset: int = 0,
+    # P1-17 v0.86.5 audit: enforce limit/offset caps via Pydantic so callers
+    # cannot pass `?limit=10000` to fan out the in-memory scan-job list.
+    limit: Annotated[int, Query(ge=1, le=1000)] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
     include_details: bool = False,
 ) -> dict:
     """List all scan jobs (for the UI job history panel).
 
-    Supports pagination via ``limit`` (default 50, max 200) and ``offset``.
+    Supports pagination via ``limit`` (default 50, max 1000) and ``offset``.
     """
-    limit = max(1, min(limit, 200))
-    offset = max(0, offset)
     tenant_id = _tenant_id(request)
     store = _get_store()
     summary = store.list_summary(tenant_id=tenant_id)
@@ -883,6 +883,9 @@ async def list_jobs(
 
         enriched.append(item)
     return {
+        # P1-16 v0.86.5 audit: emit schema_version on terminal list responses
+        # so downstream consumers can pin a contract independent of API path.
+        "schema_version": "v1",
         "jobs": enriched,
         "count": len(enriched),
         "total": total,
@@ -923,8 +926,10 @@ async def list_findings(
     request: Request,
     severity: str | None = None,
     sort: str = "effective_reach",
-    limit: int = 500,
-    offset: int = 0,
+    # P1-17 v0.86.5 audit: enforce limit cap server-side instead of trusting
+    # the historical `min(limit, 1000)` clamp at use-site.
+    limit: Annotated[int, Query(ge=1, le=1000)] = 500,
+    offset: Annotated[int, Query(ge=0)] = 0,
 ) -> dict:
     """List vulnerability findings aggregated from completed scan results.
 
@@ -947,11 +952,12 @@ async def list_findings(
         sort_key = "effective_reach"
     findings.sort(key=lambda row: _finding_sort_key(row, sort_key))
 
-    limit = max(1, min(limit, 1000))
-    offset = max(0, offset)
     total = len(findings)
     page = redact_for_persistence(findings[offset : offset + limit], EvidenceTier.SAFE_TO_STORE)
     return {
+        # P1-16 v0.86.5 audit: emit schema_version so consumers can pin a
+        # contract independent of API path.
+        "schema_version": "v1",
         "findings": page,
         "count": len(page),
         "total": total,
@@ -965,8 +971,9 @@ async def list_findings(
 @router.get("/v1/inventory", tags=["scan"])
 async def list_inventory(
     request: Request,
-    limit: int = 500,
-    offset: int = 0,
+    # P1-17 v0.86.5 audit: enforce limit cap server-side via Pydantic.
+    limit: Annotated[int, Query(ge=1, le=1000)] = 500,
+    offset: Annotated[int, Query(ge=0)] = 0,
 ) -> dict:
     """List agent and package inventory aggregated from completed scan results."""
     tenant_id = _tenant_id(request)
@@ -981,8 +988,6 @@ async def list_inventory(
         jobs.append({"job_id": job.job_id, "created_at": job.created_at, "completed_at": job.completed_at or ""})
 
     packages = _inventory_packages_from_agents(agents)
-    limit = max(1, min(limit, 1000))
-    offset = max(0, offset)
     total = len(agents)
     page = agents[offset : offset + limit]
     return {

--- a/src/agent_bom/api/routes/sources.py
+++ b/src/agent_bom/api/routes/sources.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
+from typing import Annotated
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import ValidationError
 
 from agent_bom.api.audit_log import log_action
@@ -130,10 +131,26 @@ async def create_source(request: Request, body: SourceCreate) -> dict:
 
 
 @router.get("/v1/sources", tags=["sources"])
-async def list_sources(request: Request) -> dict:
+async def list_sources(
+    request: Request,
+    # P1-17 v0.86.5 audit: cap pagination so hostile callers cannot probe an
+    # entire tenant's source registry in a single request.
+    limit: Annotated[int, Query(ge=1, le=1000)] = 1000,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> dict:
     tenant_id = _tenant_id(request)
-    sources = [source.model_dump() for source in _get_source_store().list_all(tenant_id=tenant_id)]
-    return {"sources": sources, "count": len(sources)}
+    all_sources = [source.model_dump() for source in _get_source_store().list_all(tenant_id=tenant_id)]
+    total = len(all_sources)
+    page = all_sources[offset : offset + limit]
+    return {
+        # P1-16 v0.86.5 audit: schema_version on terminal list response.
+        "schema_version": "v1",
+        "sources": page,
+        "count": len(page),
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
 
 
 @router.get("/v1/sources/{source_id}", tags=["sources"])

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -31,6 +31,7 @@ from agent_bom.api.middleware import (
     RateLimitMiddleware,
     TrustHeadersMiddleware,
     configure_auth_runtime,
+    install_error_envelope,
 )
 
 # ─── Extracted modules ────────────────────────────────────────────────────────
@@ -567,6 +568,10 @@ _apply_cors_middleware(_cors_origins)
 
 
 app.add_middleware(TrustHeadersMiddleware)
+
+# P1-18 v0.86.5 audit: wrap FastAPI's bare ``{"detail": ...}`` errors in the
+# structured ``{error: {code, message, correlation_id, details}}`` envelope.
+install_error_envelope(app)
 
 
 def configure_api(

--- a/src/agent_bom/cli/_check.py
+++ b/src/agent_bom/cli/_check.py
@@ -183,6 +183,9 @@ def _check_result_payload(
         )
 
     return {
+        "schema_version": "1.0",
+        "document_type": "PACKAGE-CHECK",
+        "spec_version": "1.0",
         "package": name,
         "version": version,
         "ecosystems": ecosystems,

--- a/src/agent_bom/cli/_history.py
+++ b/src/agent_bom/cli/_history.py
@@ -13,7 +13,7 @@ import click
 from rich.console import Console
 
 from agent_bom.output import print_diff
-from agent_bom.output.compliance_narrative import ALL_FRAMEWORK_SLUGS
+from agent_bom.output.compliance_narrative import ACCEPTED_FRAMEWORK_SLUGS
 
 if TYPE_CHECKING:
     from agent_bom.models import Agent, AIBOMReport, BlastRadius
@@ -587,7 +587,7 @@ def rescan_command(baseline: str, output: Optional[str], md: Optional[str], enri
 @click.argument("scan_file", type=click.Path(exists=True))
 @click.option(
     "--framework",
-    type=click.Choice(ALL_FRAMEWORK_SLUGS),
+    type=click.Choice(ACCEPTED_FRAMEWORK_SLUGS, case_sensitive=False),
     default=None,
     help="Generate a single-framework narrative instead of the full set.",
 )

--- a/src/agent_bom/cli/agents/_preflight.py
+++ b/src/agent_bom/cli/agents/_preflight.py
@@ -277,6 +277,9 @@ def run_iac_only_scan(
 
     iac_report = AIBOMReport(agents=[], blast_radii=[])
     iac_report.iac_findings_data = {
+        "schema_version": "1.0",
+        "document_type": "IAC-FINDINGS",
+        "spec_version": "1.0",
         "total": len(all_iac_findings),
         "findings": [
             {

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -714,6 +714,14 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         event is emitted to the configured audit_sink so denies and warns
         flow into the existing /v1/proxy/audit relay.
         """
+        # P1-20 v0.86.5 audit: gateway --bearer-token (or API-key store) must
+        # gate the firewall-check endpoint, not just /mcp/{server}. Otherwise
+        # the policy evaluator is reachable unauthenticated on shared
+        # deployments and leaks every rule via the matched_rule field.
+        if _gateway_requires_auth(settings):
+            tenant_id, auth_method = _authenticate_gateway_request(request, settings)
+            request.state.tenant_id = tenant_id
+            request.state.auth_method = auth_method
         try:
             payload = await request.json()
         except json.JSONDecodeError as exc:
@@ -795,11 +803,19 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         return JSONResponse(response_payload)
 
     @app.get("/metrics")
-    async def metrics() -> Response:
+    async def metrics(request: Request) -> Response:
         # Prometheus text-exposition format must be plain text, not JSON.
         # Previous JSONResponse wrapped the body in quotes + escaped newlines,
         # which breaks every Prometheus scraper. Serve as `Response` with the
         # exposition media type so scrapers parse it.
+        #
+        # P1-20 v0.86.5 audit: scraping endpoints carry decision counters and
+        # tenant tags — gate them with the same bearer/API-key check that
+        # protects /mcp/{server} when incoming auth is configured.
+        if _gateway_requires_auth(settings):
+            tenant_id, auth_method = _authenticate_gateway_request(request, settings)
+            request.state.tenant_id = tenant_id
+            request.state.auth_method = auth_method
         from agent_bom.api.metrics import render_prometheus_lines
 
         body = "\n".join(render_prometheus_lines()) + "\n"

--- a/src/agent_bom/output/compliance_narrative.py
+++ b/src/agent_bom/output/compliance_narrative.py
@@ -77,6 +77,16 @@ def _all_framework_slugs() -> list[str]:
 
 
 ALL_FRAMEWORK_SLUGS: list[str] = _all_framework_slugs()
+FRAMEWORK_SLUG_ALIASES: dict[str, str] = {
+    "mitre-attack": "attack",
+    "mitre_attack": "attack",
+}
+ACCEPTED_FRAMEWORK_SLUGS: list[str] = [*ALL_FRAMEWORK_SLUGS, *FRAMEWORK_SLUG_ALIASES]
+
+
+def normalize_framework_slug(slug: str) -> str:
+    normalized = slug.strip().lower()
+    return FRAMEWORK_SLUG_ALIASES.get(normalized, normalized)
 
 
 # ─── Dataclasses ─────────────────────────────────────────────────────────────
@@ -611,6 +621,7 @@ def generate_compliance_narrative(
     """
     # Validate slug early so we fail fast before any computation
     if framework is not None:
+        framework = normalize_framework_slug(framework)
         _get_catalog(framework)  # raises ValueError for unknown slugs
 
     # Build a lightweight list-of-dicts from blast_radii (avoids re-importing models)

--- a/tests/test_api_data_p1_batch_v0867.py
+++ b/tests/test_api_data_p1_batch_v0867.py
@@ -1,0 +1,262 @@
+"""Regression tests for the v0.86.7 API/data P1 batch (P1-16/17/18/19/20/22/24).
+
+These tests pin down the seven defects landed in the v0.86.5 audit follow-up:
+
+* P1-16: ``schema_version`` on terminal list responses
+* P1-17: pagination ceiling enforced ``limit≤1000`` across list endpoints
+* P1-18: structured error envelope with ``code`` + ``correlation_id``
+* P1-19: ``/v1/proxy/audit`` counts runtime_alert entries + dedupes by ``event_id``
+* P1-20: gateway bearer token now gates ``/v1/firewall/check`` + ``/metrics``
+* P1-22: ``iac`` + ``check`` JSON outputs carry the schema envelope
+* P1-24: CLI compliance-narrative accepts the full framework slug set,
+  including the ``mitre-attack`` alias to ``attack``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+from starlette.testclient import TestClient
+
+from agent_bom.api import stores as _stores
+from agent_bom.api.routes import proxy as proxy_routes
+from agent_bom.api.server import app
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.stores import set_job_store
+
+
+@pytest.fixture
+def fresh_client():
+    """Return a TestClient with a clean in-memory job store + sources store."""
+    from agent_bom.api.exception_store import InMemoryExceptionStore
+    from agent_bom.api.source_store import InMemorySourceStore
+    from agent_bom.api.stores import set_exception_store, set_source_store
+
+    store = InMemoryJobStore()
+    set_job_store(store)
+    set_source_store(InMemorySourceStore())
+    set_exception_store(InMemoryExceptionStore())
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+    _stores._store = None
+    _stores._source_store = None
+    _stores._exception_store = None
+
+
+# ── P1-16: schema_version on terminal list responses ───────────────────────────
+
+
+@pytest.mark.parametrize(
+    "path,key",
+    [
+        ("/v1/findings", "schema_version"),
+        ("/v1/jobs", "schema_version"),
+        ("/v1/sources", "schema_version"),
+        ("/v1/audit", "schema_version"),
+        ("/v1/auth/keys", "schema_version"),
+    ],
+)
+def test_p1_16_schema_version_on_list_responses(fresh_client, path, key):
+    resp = fresh_client.get(path)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body.get(key) == "v1", f"{path} response missing schema_version=v1: {body}"
+
+
+# ── P1-17: pagination cap ≤1000 ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/v1/findings",
+        "/v1/jobs",
+        "/v1/sources",
+        "/v1/exceptions",
+        "/v1/inventory",
+    ],
+)
+def test_p1_17_pagination_rejects_oversize_limit(fresh_client, path):
+    """`?limit=10000` is now a 422, not silently honored."""
+    resp = fresh_client.get(f"{path}?limit=10000")
+    assert resp.status_code == 422, f"{path} did not reject limit=10000 (got {resp.status_code})"
+
+
+def test_p1_17_pagination_accepts_max_cap(fresh_client):
+    resp = fresh_client.get("/v1/findings?limit=1000")
+    assert resp.status_code == 200
+    assert resp.json()["limit"] == 1000
+
+
+# ── P1-18: structured error envelope ───────────────────────────────────────────
+
+
+def test_p1_18_error_envelope_for_not_found(fresh_client):
+    resp = fresh_client.get("/v1/jobs/nonexistent-job-id")
+    assert resp.status_code in (404, 405), resp.status_code
+    body = resp.json()
+    assert "error" in body, body
+    err = body["error"]
+    assert err["code"] in {"NOT_FOUND", "METHOD_NOT_ALLOWED"}
+    assert err["correlation_id"]
+    assert resp.headers.get("X-Request-ID") == err["correlation_id"]
+    # Backward-compat: the original FastAPI ``detail`` is still surfaced.
+    assert "detail" in body
+
+
+def test_p1_18_error_envelope_for_validation(fresh_client):
+    # limit=0 violates ge=1; FastAPI now returns the structured envelope.
+    resp = fresh_client.get("/v1/findings?limit=0")
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+    assert body["error"]["correlation_id"]
+
+
+def test_p1_18_correlation_id_round_trips(fresh_client):
+    requested = "test-corr-id-1234"
+    resp = fresh_client.get("/v1/jobs/missing-job", headers={"x-request-id": requested})
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["error"]["correlation_id"] == requested
+
+
+# ── P1-19: proxy audit counts + dedupe ─────────────────────────────────────────
+
+
+def test_p1_19_proxy_audit_dedupes_by_event_id(fresh_client):
+    proxy_routes._reset_audit_dedupe_for_tests()
+    payload = {
+        "source_id": "proxy-a",
+        "session_id": "session-1",
+        "alerts": [
+            {
+                "event_id": "evt-001",
+                "severity": "critical",
+                "detector": "credential_leak",
+                "message": "secret detected",
+            }
+        ],
+        "summary": None,
+    }
+    first = fresh_client.post("/v1/proxy/audit", json=payload)
+    assert first.status_code == 200, first.text
+    first_body = first.json()
+    assert first_body["alert_count"] == 1
+    assert first_body["accepted_alert_count"] == 1
+    assert first_body["duplicate_alert_count"] == 0
+
+    second = fresh_client.post("/v1/proxy/audit", json=payload)
+    assert second.status_code == 200
+    second_body = second.json()
+    # Replayed alert is rejected; downstream tallies must not double-count.
+    assert second_body["accepted_alert_count"] == 0
+    assert second_body["duplicate_alert_count"] == 1
+    assert "evt-001" in second_body["duplicate_event_ids"]
+
+
+def test_p1_19_proxy_audit_counts_summary_runtime_alerts(fresh_client):
+    proxy_routes._reset_audit_dedupe_for_tests()
+    payload = {
+        "source_id": "proxy-b",
+        "session_id": "session-2",
+        "alerts": [],
+        "summary": {
+            "runtime_alerts": 3,
+            "runtime_alerts_by_detector": {"credential_leak": 3},
+        },
+    }
+    resp = fresh_client.post("/v1/proxy/audit", json=payload)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["alert_count"] == 3, body
+    assert body["has_summary"] is True
+
+
+# ── P1-22: schema envelope on iac + check JSON ─────────────────────────────────
+
+
+def test_p1_22_check_json_has_schema_envelope(tmp_path):
+    from agent_bom.cli._check import _check_result_payload
+
+    payload = _check_result_payload(
+        name="left-pad",
+        version="1.3.0",
+        ecosystems=["npm"],
+        verdict="clean",
+        message="no known vulns",
+        exit_code=0,
+        vulnerabilities=[],
+        warnings=[],
+    )
+    assert payload["schema_version"] == "1.0"
+    assert payload["document_type"] == "PACKAGE-CHECK"
+    assert payload["spec_version"] == "1.0"
+
+
+def test_p1_22_iac_json_has_schema_envelope(tmp_path, monkeypatch):
+    """`agent-bom iac` JSON output carries the envelope so consumers can pin shape."""
+    from agent_bom.cli._focused_commands import iac_cmd
+
+    # Drop a single dockerfile finding-worthy file. The exact rule firing isn't
+    # important — we just need a JSON body to inspect.
+    df = tmp_path / "Dockerfile"
+    df.write_text("FROM ubuntu:latest\nUSER root\n", encoding="utf-8")
+    out = tmp_path / "iac.json"
+
+    runner = CliRunner()
+    result = runner.invoke(iac_cmd, [str(tmp_path), "-f", "json", "-o", str(out)])
+    # `iac` exits 1 when high-severity findings are present — that's still a
+    # successful run for the envelope check. Anything other than 0/1 is fatal.
+    assert result.exit_code in (0, 1), result.output
+
+    data = json.loads(out.read_text())
+    assert data["schema_version"] == "1.0"
+    assert data["document_type"] == "IAC-FINDINGS"
+    assert data["spec_version"] == "1.0"
+    assert "findings" in data
+    assert "total" in data
+
+
+# ── P1-24: compliance-narrative framework alias ────────────────────────────────
+
+
+def test_p1_24_normalize_alias_maps_mitre_attack_to_attack():
+    from agent_bom.output.compliance_narrative import (
+        ALL_FRAMEWORK_SLUGS,
+        normalize_framework_slug,
+    )
+
+    assert "attack" in ALL_FRAMEWORK_SLUGS
+    assert normalize_framework_slug("mitre-attack") == "attack"
+    assert normalize_framework_slug("MITRE-ATTACK") == "attack"
+    assert normalize_framework_slug("attack") == "attack"
+
+
+def test_p1_24_cli_compliance_narrative_accepts_mitre_attack(tmp_path):
+    from agent_bom.cli._history import compliance_narrative_cmd
+
+    scan_file = tmp_path / "scan.json"
+    scan_file.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "agents": [],
+                "blast_radii": [],
+                "scan_metadata": {"scan_id": "x", "version": "v1"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        compliance_narrative_cmd,
+        [str(scan_file), "--framework", "mitre-attack", "-f", "json"],
+    )
+    # The framework alias must be accepted; the narrative generator may still
+    # emit an empty payload when no findings exist, but it must not 2-out from
+    # click.Choice rejecting the alias.
+    assert result.exit_code == 0, result.output

--- a/tests/test_api_data_p1_batch_v0867.py
+++ b/tests/test_api_data_p1_batch_v0867.py
@@ -45,6 +45,20 @@ def fresh_client():
     _stores._exception_store = None
 
 
+@pytest.fixture(autouse=True)
+def reset_proxy_runtime_state():
+    """Keep proxy audit regressions from leaking process-global alert state."""
+    proxy_routes._reset_audit_dedupe_for_tests()
+    proxy_routes._proxy_alerts.clear()
+    proxy_routes._proxy_metrics = None
+    proxy_routes._proxy_metrics_by_tenant.clear()
+    yield
+    proxy_routes._reset_audit_dedupe_for_tests()
+    proxy_routes._proxy_alerts.clear()
+    proxy_routes._proxy_metrics = None
+    proxy_routes._proxy_metrics_by_tenant.clear()
+
+
 # ── P1-16: schema_version on terminal list responses ───────────────────────────
 
 

--- a/tests/test_control_plane_contracts.py
+++ b/tests/test_control_plane_contracts.py
@@ -272,7 +272,7 @@ def test_control_plane_contract_scan_graph_policy_audit_flow(control_plane_contr
     assert upstream_calls[0]["tenant_id"] == "tenant-alpha"
     assert upstream_calls[0]["headers"]["Authorization"] == "Bearer tenant-alpha-token"
 
-    metrics = gw.get("/metrics")
+    metrics = gw.get("/metrics", headers={"X-API-Key": "tenant-alpha-key"})
     assert metrics.status_code == 200
     assert 'agent_bom_gateway_relays_total{upstream="jira",outcome="blocked"} 1' in metrics.text
     assert 'agent_bom_gateway_relays_total{upstream="jira",outcome="forwarded"} 1' in metrics.text

--- a/tests/test_gateway_auth_tenant_e2e.py
+++ b/tests/test_gateway_auth_tenant_e2e.py
@@ -243,7 +243,9 @@ def test_full_pilot_flow_auth_tenant_discovery_relay_policy_audit_metrics(pilot_
         assert upstream_calls[0]["tool"] == "query_issues"
 
         # ── Stage 6: metrics reflect both outcomes
-        metrics_resp = gw.get("/metrics")
+        # P1-20 v0.86.5 audit: /metrics is now gated by the same bearer/API-key
+        # check that protects /mcp/{server}; reuse the tenant-alpha key.
+        metrics_resp = gw.get("/metrics", headers={"X-API-Key": "tenant-alpha-gateway-key"})
         assert metrics_resp.status_code == 200
         body_text = metrics_resp.text
         assert body_text.startswith("# HELP"), "not Prometheus exposition"

--- a/tests/test_gateway_firewall.py
+++ b/tests/test_gateway_firewall.py
@@ -272,3 +272,51 @@ def test_firewall_check_invalid_json_body() -> None:
     with TestClient(create_gateway_app(settings)) as client:
         resp = client.post("/v1/firewall/check", content=b"{not json", headers={"content-type": "application/json"})
     assert resp.status_code == 400
+
+
+# ── P1-20 v0.86.5 audit: bearer token gates /v1/firewall/check + /metrics ──────
+
+
+def test_p1_20_firewall_check_requires_bearer_when_configured() -> None:
+    settings = GatewaySettings(registry=_registry(), policy={}, bearer_token="s3cr3t")  # noqa: S106
+    with TestClient(create_gateway_app(settings)) as client:
+        # Missing auth -> 401 envelope from the gateway.
+        unauth = client.post(
+            "/v1/firewall/check",
+            json={"source_agent": "cursor", "target_agent": "claude-desktop"},
+        )
+        assert unauth.status_code == 401
+
+        # Wrong bearer -> 401.
+        bad = client.post(
+            "/v1/firewall/check",
+            json={"source_agent": "cursor", "target_agent": "claude-desktop"},
+            headers={"Authorization": "Bearer wrong"},
+        )
+        assert bad.status_code == 401
+
+        # Correct bearer -> 200.
+        ok = client.post(
+            "/v1/firewall/check",
+            json={"source_agent": "cursor", "target_agent": "claude-desktop"},
+            headers={"Authorization": "Bearer s3cr3t"},
+        )
+        assert ok.status_code == 200
+
+
+def test_p1_20_metrics_requires_bearer_when_configured() -> None:
+    settings = GatewaySettings(registry=_registry(), policy={}, bearer_token="s3cr3t")  # noqa: S106
+    with TestClient(create_gateway_app(settings)) as client:
+        unauth = client.get("/metrics")
+        assert unauth.status_code == 401
+        ok = client.get("/metrics", headers={"Authorization": "Bearer s3cr3t"})
+        assert ok.status_code == 200
+        assert ok.headers["content-type"].startswith("text/plain")
+
+
+def test_p1_20_metrics_remains_open_when_no_auth_configured() -> None:
+    """When no bearer token + no API key store, /metrics stays open (loopback)."""
+    settings = GatewaySettings(registry=_registry(), policy={})
+    with TestClient(create_gateway_app(settings)) as client:
+        resp = client.get("/metrics")
+    assert resp.status_code == 200

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -292,7 +292,7 @@ def test_list_jobs_pagination():
 
 
 def test_list_jobs_clamps_limit():
-    """Limit is clamped to max 200."""
+    """GET /v1/jobs accepts the shared 1000-row list ceiling."""
     from unittest.mock import patch
 
     from starlette.testclient import TestClient
@@ -306,7 +306,7 @@ def test_list_jobs_clamps_limit():
         client = TestClient(app)
         resp = client.get("/v1/jobs?limit=999")
         assert resp.status_code == 200
-        assert resp.json()["limit"] == 200
+        assert resp.json()["limit"] == 999
 
 
 def test_list_fleet_pagination():

--- a/tests/test_snowflake_backend_contract.py
+++ b/tests/test_snowflake_backend_contract.py
@@ -90,7 +90,13 @@ def test_supported_snowflake_routes_remain_wired(mock_connect, monkeypatch):
             assert schedules.json() == []
 
             assert exceptions.status_code == 200
-            assert exceptions.json() == {"exceptions": [], "total": 0}
+            assert exceptions.json() == {
+                "schema_version": "v1",
+                "exceptions": [],
+                "total": 0,
+                "limit": 1000,
+                "offset": 0,
+            }
     finally:
         _clear_store_globals()
 


### PR DESCRIPTION
## Summary
Fix the remaining API/gateway/data P1 audit gaps in one bounded batch:

- add `schema_version: v1` to terminal list responses for findings, jobs, audit, sources, auth keys, and exceptions
- enforce `limit <= 1000` on list-style API routes that previously accepted oversized limits
- wrap FastAPI/validation errors in `{error: {code, message, correlation_id, details}}` while preserving top-level `detail`
- make `/v1/proxy/audit` count runtime alerts from alerts or summary, and dedupe replayed `event_id`s per tenant
- gate gateway `/v1/firewall/check` and `/metrics` when bearer/API-key auth is configured
- add schema envelopes to `check` and IaC JSON outputs
- accept `mitre-attack` as a compliance narrative alias for `attack`

## Root Cause
The API and CLI surfaces grew independently: some list endpoints had no stable response contract or cap, FastAPI default errors leaked through unchanged, proxy audit ingest trusted replayed payloads, and gateway auth checks only covered MCP relay paths.

## Validation
- `uv run pytest -q tests/test_api_data_p1_batch_v0867.py tests/test_gateway_firewall.py tests/test_gateway_auth_tenant_e2e.py`
- `uv run ruff check src/agent_bom/api/middleware.py src/agent_bom/api/routes/enterprise.py src/agent_bom/api/routes/proxy.py src/agent_bom/api/routes/scan.py src/agent_bom/api/routes/sources.py src/agent_bom/api/server.py src/agent_bom/cli/_check.py src/agent_bom/cli/_history.py src/agent_bom/cli/agents/_preflight.py src/agent_bom/gateway_server.py tests/test_api_data_p1_batch_v0867.py tests/test_gateway_firewall.py tests/test_gateway_auth_tenant_e2e.py`
- `git diff --check`
- commit pre-commit hooks: ruff, ruff-format, mypy, bandit, env-var drift, duplicate artifact guard
