### PR TITLE
fix CLI P1 polish gaps

### DIFF
--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -174,7 +174,10 @@ main.commands["policy-templates"] = _policy_templates_hidden
 from agent_bom.cli._policy_group import policy_group  # noqa: E402
 
 policy_group.add_command(policy_template, "template")
-policy_group.add_command(policy_template, "templates")
+_policy_templates_group_hidden = _copy.copy(policy_template)
+_policy_templates_group_hidden.deprecated = "Use `agent-bom policy template`."
+_policy_templates_group_hidden.name = "templates"
+policy_group.add_command(_policy_templates_group_hidden, "templates")
 policy_group.add_command(apply_command, "apply")
 policy_group.add_command(guard_cmd, "check")  # guard → policy check
 main.add_command(policy_group)

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -175,7 +175,7 @@ from agent_bom.cli._policy_group import policy_group  # noqa: E402
 
 policy_group.add_command(policy_template, "template")
 _policy_templates_group_hidden = _copy.copy(policy_template)
-_policy_templates_group_hidden.deprecated = "Use `agent-bom policy template`."
+setattr(_policy_templates_group_hidden, "deprecated", "Use `agent-bom policy template`.")
 _policy_templates_group_hidden.name = "templates"
 policy_group.add_command(_policy_templates_group_hidden, "templates")
 policy_group.add_command(apply_command, "apply")

--- a/src/agent_bom/cli/_inventory.py
+++ b/src/agent_bom/cli/_inventory.py
@@ -27,8 +27,19 @@ from agent_bom.parsers import extract_packages
 @click.option("--transitive", is_flag=True, help="Resolve transitive dependencies for npx/uvx packages")
 @click.option("--max-depth", type=int, default=3, help="Maximum depth for transitive dependency resolution")
 @click.option("--quiet", "-q", is_flag=True, help="Suppress all output except results")
-@click.option("--json", "as_json", is_flag=True, help="Output inventory and completeness telemetry as JSON")
-def inventory(config: Optional[str], project: Optional[str], transitive: bool, max_depth: int, quiet: bool, as_json: bool):
+@click.option("-f", "--format", "output_format", type=click.Choice(["console", "json"]), default="console", show_default=True)
+@click.option("--json", "as_json", is_flag=True, help="Deprecated alias for `--format json`.")
+@click.pass_context
+def inventory(
+    ctx: click.Context,
+    config: Optional[str],
+    project: Optional[str],
+    transitive: bool,
+    max_depth: int,
+    quiet: bool,
+    output_format: str,
+    as_json: bool,
+):
     """Show discovered agents and MCP servers (no vulnerability scan)."""
     con = _make_console(quiet=quiet)
 
@@ -36,8 +47,11 @@ def inventory(config: Optional[str], project: Optional[str], transitive: bool, m
 
     _out.console = con
 
-    discovery_stdout = redirect_stdout(StringIO()) if as_json else nullcontext()
-    discovery_stderr = redirect_stderr(StringIO()) if as_json else nullcontext()
+    if as_json and ctx.parent is not None and ctx.parent.info_name == "mcp":
+        click.echo("Warning: --json is deprecated; use -f json.", err=True)
+    json_output = as_json or output_format == "json"
+    discovery_stdout = redirect_stdout(StringIO()) if json_output else nullcontext()
+    discovery_stderr = redirect_stderr(StringIO()) if json_output else nullcontext()
     inventory_source: Optional[str] = None
     with discovery_stdout, discovery_stderr:
         if config:
@@ -80,13 +94,13 @@ def inventory(config: Optional[str], project: Optional[str], transitive: bool, m
                 agents = discover_all(project_dir=project)
 
     if not agents:
-        if as_json:
+        if json_output:
             _print_inventory_json(agents, inventory_source)
             return
         con.print("\n[yellow]No MCP configurations found.[/yellow]")
         sys.exit(0)
 
-    if not as_json:
+    if not json_output:
         con.print("\n[bold blue]Extracting package dependencies...[/bold blue]\n")
         if transitive:
             con.print(f"  [cyan]Transitive resolution enabled (max depth: {max_depth})[/cyan]\n")
@@ -101,7 +115,7 @@ def inventory(config: Optional[str], project: Optional[str], transitive: bool, m
                 continue
             server.packages = extract_packages(server, resolve_transitive=transitive, max_depth=max_depth)
 
-    if as_json:
+    if json_output:
         _print_inventory_json(agents, inventory_source)
         return
 

--- a/src/agent_bom/cli/_profiles.py
+++ b/src/agent_bom/cli/_profiles.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import click
 
+from agent_bom.cli._grouped_help import SuggestingGroup
 from agent_bom.cli._tenant import TENANT_ENV_VAR
 
 CONFIG_ENV_VAR = "AGENT_BOM_CONFIG"
@@ -249,7 +250,7 @@ def set_current_profile(path: Path, name: str) -> None:
     path.write_text(text)
 
 
-@click.group("profiles")
+@click.group("profiles", cls=SuggestingGroup)
 def profiles_group() -> None:
     """Manage named CLI profiles in ~/.agent-bom/config.toml."""
 

--- a/src/agent_bom/cli/agents/_discovery.py
+++ b/src/agent_bom/cli/agents/_discovery.py
@@ -98,33 +98,37 @@ def run_local_discovery(
     **kwargs: Any,
 ) -> None:
     """Steps 1–1g4: discover agents from local sources, SBOM, images, etc."""
-    from rich.rule import Rule
-
     # Allow callers to inject discover_all (enables patch("agent_bom.cli.agents.discover_all"))
     _discover = _discover_all if _discover_all is not None else _discover_all_default
     con = ctx.con
+    preloaded_inventory_data: dict[str, Any] | None = None
+    inventory_label: str | None = None
+    if inventory:
+        if inventory == "-":
+            inventory_label = "stdin"
+        elif "agent-bom-demo-" in inventory:
+            inventory_label = "curated sample environment"
+        elif "agent-bom-self-scan" in inventory:
+            inventory_label = "self-scan"
+        else:
+            inventory_label = inventory
+        from agent_bom.inventory import load_inventory
+
+        try:
+            preloaded_inventory_data = load_inventory(inventory)
+        except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as exc:
+            raise click.BadParameter(str(exc), param_hint="--inventory") from exc
+
+    from rich.rule import Rule
+
     con.print(Rule("Discovery", style="blue"))
 
     # Step 1: Agent discovery
     if skill_only:
         ctx.agents = []  # skill-only: no agent discovery
     elif inventory:
-        if inventory == "-":
-            label = "stdin"
-        elif "agent-bom-demo-" in inventory:
-            label = "curated sample environment"
-        elif "agent-bom-self-scan" in inventory:
-            label = "self-scan"
-        else:
-            label = inventory
-        from agent_bom.inventory import load_inventory
-
-        try:
-            inventory_data = load_inventory(inventory)
-        except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as exc:
-            raise click.BadParameter(str(exc), param_hint="--inventory") from exc
-        ctx.agents = _build_agents_from_inventory(inventory_data, inventory)
-        con.print(f"\n  [green]✓[/green] {len(ctx.agents)} agent(s) from {label}")
+        ctx.agents = _build_agents_from_inventory(preloaded_inventory_data or {"agents": []}, inventory)
+        con.print(f"\n  [green]✓[/green] {len(ctx.agents)} agent(s) from {inventory_label or inventory}")
     elif no_discover:
         ctx.agents = []
     elif config_dir:

--- a/tests/test_cli_p1_polish.py
+++ b/tests/test_cli_p1_polish.py
@@ -1,0 +1,82 @@
+"""Regression tests for remaining CLI P1 audit polish."""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+
+
+def test_did_you_mean_top_level_typo() -> None:
+    result = CliRunner().invoke(main, ["scna"])
+    assert result.exit_code == 2
+    assert "Did you mean 'scan'" in result.output
+
+
+def test_did_you_mean_nested_mcp_typo() -> None:
+    result = CliRunner().invoke(main, ["mcp", "scna"])
+    assert result.exit_code == 2
+    assert "Did you mean 'scan'" in result.output
+
+
+def test_did_you_mean_nested_profiles_typo() -> None:
+    result = CliRunner().invoke(main, ["profiles", "useeee"])
+    assert result.exit_code == 2
+    assert "Did you mean 'use'" in result.output
+
+
+def test_scan_inventory_stdin_sentinel_loads_json_payload() -> None:
+    payload = '{"agents":[{"name":"stdin-agent","agent_type":"custom","mcp_servers":[]}]}'
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            main,
+            ["scan", "--inventory", "-", "--no-scan", "-f", "json"],
+            input=payload,
+        )
+        assert result.exit_code == 0, result.output
+        with open("agent-bom-report.json", encoding="utf-8") as report_file:
+            body = json.load(report_file)
+        assert body["agents"][0]["name"] == "stdin-agent"
+
+
+def test_discovery_banner_deferred_until_after_inventory_validation() -> None:
+    result = CliRunner().invoke(main, ["scan", "--inventory", "/tmp/__does_not_exist_agent_bom.json"])
+    assert result.exit_code != 0
+    assert "Discovery" not in result.output
+    assert "Inventory file not found" in result.output
+
+
+def test_policy_templates_is_deprecated_alias(tmp_path) -> None:
+    out = tmp_path / "policy.json"
+    result = CliRunner().invoke(main, ["policy", "templates", "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    assert "deprecated" in result.output.lower()
+    assert out.exists()
+
+
+def test_policy_template_singular_is_canonical(tmp_path) -> None:
+    out = tmp_path / "policy.json"
+    result = CliRunner().invoke(main, ["policy", "template", "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    assert "deprecated" not in result.output.lower()
+    assert out.exists()
+
+
+def test_mcp_inventory_format_json_flag_works(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("agent_bom.cli._inventory.discover_all", lambda **_: [])
+    result = CliRunner().invoke(main, ["mcp", "inventory", "-f", "json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert "discovery_completeness" in payload
+
+
+def test_mcp_inventory_json_alias_emits_deprecation(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("agent_bom.cli._inventory.discover_all", lambda **_: [])
+    result = CliRunner().invoke(main, ["mcp", "inventory", "--json"])
+    assert result.exit_code == 0, result.output
+    assert "deprecated" in result.output.lower()


### PR DESCRIPTION
## Summary
Close the remaining CLI P1 polish items from the v0.86.5 audit:

- nested did-you-mean coverage for top-level, `mcp`, and `profiles` command typos
- `scan --inventory -` reads piped stdin before printing the discovery banner
- missing inventory files fail before the Discovery section renders
- `policy templates` remains a deprecated compatibility alias while `policy template` is canonical
- `mcp inventory -f json` works, with `--json` kept as a deprecated alias in the MCP path

## Root Cause
Several CLI behaviors were implemented one command at a time, so nested Click groups and alias paths did not share the same command-suggestion and output-flag conventions. Inventory validation also happened after discovery rendering, which made late validation errors visually noisy.

## Validation
- `uv run pytest -q tests/test_cli_p1_polish.py tests/test_cli_inventory.py tests/test_cli_check.py`
- `uv run ruff check src/agent_bom/cli/__init__.py src/agent_bom/cli/_inventory.py src/agent_bom/cli/_profiles.py src/agent_bom/cli/agents/_discovery.py tests/test_cli_p1_polish.py`
- `git diff --check`
- commit pre-commit hooks: ruff, ruff-format, mypy, bandit, env-var drift, duplicate artifact guard
