### PR TITLE
fix canonical ID persistence alignment

### DIFF
--- a/src/agent_bom/api/fleet_store.py
+++ b/src/agent_bom/api/fleet_store.py
@@ -15,6 +15,7 @@ from typing import Any, Protocol
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+from agent_bom.canonical_ids import canonical_agent_id
 from agent_bom.platform_invariants import normalize_tenant_id, normalize_timestamp, now_utc_iso
 
 # ─── Models ──────────────────────────────────────────────────────────────────
@@ -32,6 +33,7 @@ class FleetAgent(BaseModel):
     """A managed agent in the fleet registry."""
 
     agent_id: str
+    canonical_id: str = ""
     name: str
     agent_type: str
     config_path: str = ""
@@ -73,6 +75,8 @@ class FleetAgent(BaseModel):
             self.created_at = now_utc_iso()
         if not self.updated_at:
             self.updated_at = self.created_at
+        if not self.canonical_id:
+            self.canonical_id = canonical_agent_id(self.agent_type, self.name, source_id=self.source_id)
         return self
 
 
@@ -84,6 +88,7 @@ class FleetStore(Protocol):
 
     def put(self, agent: FleetAgent) -> None: ...
     def get(self, agent_id: str, tenant_id: str | None = None) -> FleetAgent | None: ...
+    def get_by_canonical_id(self, canonical_id: str, tenant_id: str | None = None) -> FleetAgent | None: ...
     def get_by_name(self, name: str) -> FleetAgent | None: ...
     def delete(self, agent_id: str, tenant_id: str | None = None) -> bool: ...
     def list_all(self) -> list[FleetAgent]: ...
@@ -130,6 +135,16 @@ class InMemoryFleetStore:
                 return None
             return agent
 
+    def get_by_canonical_id(self, canonical_id: str, tenant_id: str | None = None) -> FleetAgent | None:
+        with self._lock:
+            for agent in self._agents.values():
+                if agent.canonical_id != canonical_id:
+                    continue
+                if tenant_id is not None and agent.tenant_id != tenant_id:
+                    continue
+                return agent
+            return None
+
     def get_by_name(self, name: str) -> FleetAgent | None:
         with self._lock:
             for a in self._agents.values():
@@ -157,6 +172,7 @@ class InMemoryFleetStore:
             return [
                 {
                     "agent_id": a.agent_id,
+                    "canonical_id": a.canonical_id,
                     "name": a.name,
                     "lifecycle_state": a.lifecycle_state,
                     "trust_score": a.trust_score,
@@ -258,6 +274,7 @@ class SQLiteFleetStore:
         self._conn.execute("""
             CREATE TABLE IF NOT EXISTS fleet_agents (
                 agent_id TEXT PRIMARY KEY,
+                canonical_id TEXT NOT NULL DEFAULT '',
                 name TEXT NOT NULL,
                 lifecycle_state TEXT NOT NULL,
                 trust_score REAL DEFAULT 0.0,
@@ -265,19 +282,33 @@ class SQLiteFleetStore:
                 data TEXT NOT NULL
             )
         """)
+        if "canonical_id" not in _table_columns(self._conn, "fleet_agents"):
+            self._conn.execute("ALTER TABLE fleet_agents ADD COLUMN canonical_id TEXT NOT NULL DEFAULT ''")
+        self._backfill_canonical_ids()
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_name ON fleet_agents(name)")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_canonical_id ON fleet_agents(canonical_id)")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_state ON fleet_agents(lifecycle_state)")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_state_trust_name ON fleet_agents(lifecycle_state, trust_score DESC, name)")
         self._conn.commit()
+
+    def _backfill_canonical_ids(self) -> None:
+        rows = self._conn.execute("SELECT agent_id, data FROM fleet_agents WHERE canonical_id = ''").fetchall()
+        for agent_id, raw in rows:
+            agent = FleetAgent.model_validate_json(raw)
+            self._conn.execute(
+                "UPDATE fleet_agents SET canonical_id = ?, data = ? WHERE agent_id = ?",
+                (agent.canonical_id, agent.model_dump_json(), agent_id),
+            )
 
     def put(self, agent: FleetAgent) -> None:
         normalized = FleetAgent.model_validate(agent.model_dump())
         self._conn.execute(
             """INSERT OR REPLACE INTO fleet_agents
-               (agent_id, name, lifecycle_state, trust_score, updated_at, data)
-               VALUES (?, ?, ?, ?, ?, ?)""",
+               (agent_id, canonical_id, name, lifecycle_state, trust_score, updated_at, data)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
             (
                 normalized.agent_id,
+                normalized.canonical_id,
                 normalized.name,
                 normalized.lifecycle_state.value,
                 normalized.trust_score,
@@ -294,6 +325,19 @@ class SQLiteFleetStore:
             row = self._conn.execute(
                 "SELECT data FROM fleet_agents WHERE agent_id = ? AND json_extract(data, '$.tenant_id') = ?",
                 (agent_id, tenant_id),
+            ).fetchone()
+        if row is None:
+            return None
+        agent: FleetAgent = FleetAgent.model_validate_json(row[0])
+        return agent
+
+    def get_by_canonical_id(self, canonical_id: str, tenant_id: str | None = None) -> FleetAgent | None:
+        if tenant_id is None:
+            row = self._conn.execute("SELECT data FROM fleet_agents WHERE canonical_id = ?", (canonical_id,)).fetchone()
+        else:
+            row = self._conn.execute(
+                "SELECT data FROM fleet_agents WHERE canonical_id = ? AND json_extract(data, '$.tenant_id') = ?",
+                (canonical_id, tenant_id),
             ).fetchone()
         if row is None:
             return None
@@ -324,15 +368,16 @@ class SQLiteFleetStore:
 
     def list_summary(self) -> list[dict[str, Any]]:
         rows = self._conn.execute(
-            "SELECT agent_id, name, lifecycle_state, trust_score, updated_at FROM fleet_agents ORDER BY name"
+            "SELECT agent_id, canonical_id, name, lifecycle_state, trust_score, updated_at FROM fleet_agents ORDER BY name"
         ).fetchall()
         return [
             {
                 "agent_id": r[0],
-                "name": r[1],
-                "lifecycle_state": r[2],
-                "trust_score": r[3],
-                "updated_at": r[4],
+                "canonical_id": r[1],
+                "name": r[2],
+                "lifecycle_state": r[3],
+                "trust_score": r[4],
+                "updated_at": r[5],
             }
             for r in rows
         ]
@@ -404,19 +449,24 @@ class SQLiteFleetStore:
             return 0
         self._conn.executemany(
             """INSERT OR REPLACE INTO fleet_agents
-               (agent_id, name, lifecycle_state, trust_score, updated_at, data)
-               VALUES (?, ?, ?, ?, ?, ?)""",
+               (agent_id, canonical_id, name, lifecycle_state, trust_score, updated_at, data)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
             [
                 (
-                    a.agent_id,
-                    a.name,
-                    a.lifecycle_state.value,
-                    a.trust_score,
-                    a.updated_at,
-                    a.model_dump_json(),
+                    normalized.agent_id,
+                    normalized.canonical_id,
+                    normalized.name,
+                    normalized.lifecycle_state.value,
+                    normalized.trust_score,
+                    normalized.updated_at,
+                    normalized.model_dump_json(),
                 )
-                for a in agents
+                for normalized in (FleetAgent.model_validate(agent.model_dump()) for agent in agents)
             ],
         )
         self._conn.commit()
         return len(agents)
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}  # nosec B608 - table is static

--- a/src/agent_bom/api/mcp_observation_store.py
+++ b/src/agent_bom/api/mcp_observation_store.py
@@ -6,9 +6,10 @@ import sqlite3
 import threading
 from typing import Protocol
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+from agent_bom.canonical_ids import canonical_mcp_server_id
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.platform_invariants import normalize_tenant_id, normalize_timestamp, now_utc_iso
 from agent_bom.security import sanitize_command_args, sanitize_security_warnings, sanitize_text, sanitize_url
@@ -18,6 +19,7 @@ class MCPObservation(BaseModel):
     tenant_id: str = "default"
     observation_id: str
     server_stable_id: str
+    server_canonical_id: str = ""
     server_fingerprint: str = ""
     server_name: str
     agent_name: str = ""
@@ -87,6 +89,12 @@ class MCPObservation(BaseModel):
     def _sanitize_command(cls, value: object) -> str:
         return sanitize_text(value, max_len=200)
 
+    @model_validator(mode="after")
+    def _apply_canonical_id(self) -> MCPObservation:
+        if not self.server_canonical_id:
+            self.server_canonical_id = self.server_stable_id or canonical_mcp_server_id(self.server_name, self.command)
+        return self
+
 
 def _pick_timestamp(*values: str | None, prefer: str) -> str | None:
     candidates = [value for value in values if value]
@@ -119,6 +127,7 @@ def merge_observations(existing: MCPObservation | None, incoming: MCPObservation
         tenant_id=incoming.tenant_id,
         observation_id=incoming.observation_id,
         server_stable_id=incoming.server_stable_id or existing.server_stable_id,
+        server_canonical_id=incoming.server_canonical_id or existing.server_canonical_id,
         server_fingerprint=incoming.server_fingerprint or existing.server_fingerprint,
         server_name=incoming.server_name or existing.server_name,
         agent_name=incoming.agent_name or existing.agent_name,
@@ -151,6 +160,7 @@ def merge_observations(existing: MCPObservation | None, incoming: MCPObservation
 class MCPObservationStore(Protocol):
     def put(self, observation: MCPObservation) -> None: ...
     def get(self, tenant_id: str, observation_id: str) -> MCPObservation | None: ...
+    def get_by_server_canonical_id(self, tenant_id: str, server_canonical_id: str) -> MCPObservation | None: ...
     def list_by_tenant(self, tenant_id: str) -> list[MCPObservation]: ...
 
 
@@ -167,6 +177,13 @@ class InMemoryMCPObservationStore:
     def get(self, tenant_id: str, observation_id: str) -> MCPObservation | None:
         with self._lock:
             return self._rows.get((tenant_id, observation_id))
+
+    def get_by_server_canonical_id(self, tenant_id: str, server_canonical_id: str) -> MCPObservation | None:
+        with self._lock:
+            for (row_tenant, _), row in self._rows.items():
+                if row_tenant == tenant_id and row.server_canonical_id == server_canonical_id:
+                    return row
+            return None
 
     def list_by_tenant(self, tenant_id: str) -> list[MCPObservation]:
         with self._lock:
@@ -197,24 +214,41 @@ class SQLiteMCPObservationStore:
             CREATE TABLE IF NOT EXISTS mcp_observations (
                 tenant_id TEXT NOT NULL,
                 observation_id TEXT NOT NULL,
+                server_canonical_id TEXT NOT NULL DEFAULT '',
                 server_name TEXT NOT NULL,
                 updated_at TEXT NOT NULL,
                 data TEXT NOT NULL,
                 PRIMARY KEY (tenant_id, observation_id)
             )
         """)
+        if "server_canonical_id" not in _table_columns(self._conn, "mcp_observations"):
+            self._conn.execute("ALTER TABLE mcp_observations ADD COLUMN server_canonical_id TEXT NOT NULL DEFAULT ''")
+        self._backfill_server_canonical_ids()
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_mcp_observations_tenant_server ON mcp_observations(tenant_id, server_name)")
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_mcp_observations_tenant_canonical ON mcp_observations(tenant_id, server_canonical_id)"
+        )
         self._conn.commit()
+
+    def _backfill_server_canonical_ids(self) -> None:
+        rows = self._conn.execute("SELECT tenant_id, observation_id, data FROM mcp_observations WHERE server_canonical_id = ''").fetchall()
+        for tenant_id, observation_id, raw in rows:
+            observation = MCPObservation.model_validate_json(raw)
+            self._conn.execute(
+                "UPDATE mcp_observations SET server_canonical_id = ?, data = ? WHERE tenant_id = ? AND observation_id = ?",
+                (observation.server_canonical_id, observation.model_dump_json(), tenant_id, observation_id),
+            )
 
     def put(self, observation: MCPObservation) -> None:
         normalized = MCPObservation.model_validate(observation.model_dump())
         self._conn.execute(
             """INSERT OR REPLACE INTO mcp_observations
-               (tenant_id, observation_id, server_name, updated_at, data)
-               VALUES (?, ?, ?, ?, ?)""",
+               (tenant_id, observation_id, server_canonical_id, server_name, updated_at, data)
+               VALUES (?, ?, ?, ?, ?, ?)""",
             (
                 normalized.tenant_id,
                 normalized.observation_id,
+                normalized.server_canonical_id,
                 normalized.server_name,
                 normalized.updated_at,
                 normalized.model_dump_json(),
@@ -232,9 +266,23 @@ class SQLiteMCPObservationStore:
         obs: MCPObservation = MCPObservation.model_validate_json(row[0])
         return obs
 
+    def get_by_server_canonical_id(self, tenant_id: str, server_canonical_id: str) -> MCPObservation | None:
+        row = self._conn.execute(
+            "SELECT data FROM mcp_observations WHERE tenant_id = ? AND server_canonical_id = ? ORDER BY updated_at DESC LIMIT 1",
+            (tenant_id, server_canonical_id),
+        ).fetchone()
+        if row is None:
+            return None
+        obs: MCPObservation = MCPObservation.model_validate_json(row[0])
+        return obs
+
     def list_by_tenant(self, tenant_id: str) -> list[MCPObservation]:
         rows = self._conn.execute(
             "SELECT data FROM mcp_observations WHERE tenant_id = ? ORDER BY server_name, updated_at DESC",
             (tenant_id,),
         ).fetchall()
         return [MCPObservation.model_validate_json(row[0]) for row in rows]
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}  # nosec B608 - table is static

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -407,6 +407,7 @@ def _sync_scan_agents_to_fleet(agents: list, tenant_id: str = "default") -> None
         else:
             fleet_agent = FleetAgent(
                 agent_id=str(uuid.uuid4()),
+                canonical_id=getattr(agent, "canonical_id", "") or "",
                 name=agent.name,
                 agent_type=agent.agent_type.value if hasattr(agent.agent_type, "value") else str(agent.agent_type),
                 config_path=agent.config_path or "",

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -407,7 +407,7 @@ def _sync_scan_agents_to_fleet(agents: list, tenant_id: str = "default") -> None
         else:
             fleet_agent = FleetAgent(
                 agent_id=str(uuid.uuid4()),
-                canonical_id=getattr(agent, "canonical_id", "") or "",
+                canonical_id=_optional_str(getattr(agent, "canonical_id", "")),
                 name=agent.name,
                 agent_type=agent.agent_type.value if hasattr(agent.agent_type, "value") else str(agent.agent_type),
                 config_path=agent.config_path or "",
@@ -427,6 +427,10 @@ def _sync_scan_agents_to_fleet(agents: list, tenant_id: str = "default") -> None
 
     if to_upsert:
         store.batch_put(to_upsert)
+
+
+def _optional_str(value: object) -> str:
+    return value if isinstance(value, str) else ""
 
 
 # ─── Scan Pipeline Runner ───────────────────────────────────────────────────

--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -385,6 +385,7 @@ class PostgresFleetStore:
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS fleet_agents (
                     agent_id TEXT PRIMARY KEY,
+                    canonical_id TEXT NOT NULL DEFAULT '',
                     name TEXT NOT NULL,
                     lifecycle_state TEXT NOT NULL,
                     trust_score REAL DEFAULT 0.0,
@@ -393,7 +394,9 @@ class PostgresFleetStore:
                     data JSONB NOT NULL
                 )
             """)
+            conn.execute("ALTER TABLE fleet_agents ADD COLUMN IF NOT EXISTS canonical_id TEXT NOT NULL DEFAULT ''")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_name ON fleet_agents(name)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_canonical_id ON fleet_agents(canonical_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_state ON fleet_agents(lifecycle_state)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_tenant ON fleet_agents(tenant_id)")
             conn.execute(
@@ -415,16 +418,26 @@ class PostgresFleetStore:
         data = agent.model_dump_json()
         with _tenant_connection(self._pool) as conn:
             conn.execute(
-                """INSERT INTO fleet_agents (agent_id, name, lifecycle_state, trust_score, tenant_id, updated_at, data)
-                   VALUES (%s, %s, %s, %s, %s, %s, %s)
+                """INSERT INTO fleet_agents (agent_id, canonical_id, name, lifecycle_state, trust_score, tenant_id, updated_at, data)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
                    ON CONFLICT (agent_id) DO UPDATE SET
+                     canonical_id = EXCLUDED.canonical_id,
                      name = EXCLUDED.name,
                      lifecycle_state = EXCLUDED.lifecycle_state,
                      trust_score = EXCLUDED.trust_score,
                      tenant_id = EXCLUDED.tenant_id,
                      updated_at = EXCLUDED.updated_at,
                      data = EXCLUDED.data""",
-                (agent.agent_id, agent.name, agent.lifecycle_state.value, agent.trust_score, agent.tenant_id, agent.updated_at, data),
+                (
+                    agent.agent_id,
+                    agent.canonical_id,
+                    agent.name,
+                    agent.lifecycle_state.value,
+                    agent.trust_score,
+                    agent.tenant_id,
+                    agent.updated_at,
+                    data,
+                ),
             )
             conn.commit()
 
@@ -438,6 +451,22 @@ class PostgresFleetStore:
                 row = conn.execute(
                     "SELECT data FROM fleet_agents WHERE agent_id = %s AND tenant_id = %s",
                     (agent_id, tenant_id),
+                ).fetchone()
+            if row is None:
+                return None
+            raw = row[0] if isinstance(row[0], str) else json.dumps(row[0])
+            return FleetAgent.model_validate_json(raw)
+
+    def get_by_canonical_id(self, canonical_id: str, tenant_id: str | None = None):
+        from .fleet_store import FleetAgent
+
+        with _tenant_connection(self._pool) as conn:
+            if tenant_id is None:
+                row = conn.execute("SELECT data FROM fleet_agents WHERE canonical_id = %s", (canonical_id,)).fetchone()
+            else:
+                row = conn.execute(
+                    "SELECT data FROM fleet_agents WHERE canonical_id = %s AND tenant_id = %s",
+                    (canonical_id, tenant_id),
                 ).fetchone()
             if row is None:
                 return None
@@ -475,8 +504,10 @@ class PostgresFleetStore:
 
     def list_summary(self) -> list[dict]:
         with _tenant_connection(self._pool) as conn:
-            rows = conn.execute("SELECT agent_id, name, lifecycle_state, trust_score FROM fleet_agents ORDER BY name").fetchall()
-            return [{"agent_id": r[0], "name": r[1], "lifecycle_state": r[2], "trust_score": r[3]} for r in rows]
+            rows = conn.execute(
+                "SELECT agent_id, canonical_id, name, lifecycle_state, trust_score FROM fleet_agents ORDER BY name"
+            ).fetchall()
+            return [{"agent_id": r[0], "canonical_id": r[1], "name": r[2], "lifecycle_state": r[3], "trust_score": r[4]} for r in rows]
 
     def list_by_tenant(self, tenant_id: str) -> list:
         from .fleet_store import FleetAgent

--- a/src/agent_bom/api/snowflake_store.py
+++ b/src/agent_bom/api/snowflake_store.py
@@ -214,6 +214,7 @@ class SnowflakeFleetStore:
             cur.execute("""
                 CREATE TABLE IF NOT EXISTS fleet_agents (
                     agent_id VARCHAR PRIMARY KEY,
+                    canonical_id VARCHAR NOT NULL DEFAULT '',
                     name VARCHAR NOT NULL,
                     lifecycle_state VARCHAR NOT NULL,
                     trust_score FLOAT DEFAULT 0.0,
@@ -222,6 +223,7 @@ class SnowflakeFleetStore:
                     data VARIANT NOT NULL
                 )
             """)
+            cur.execute("ALTER TABLE fleet_agents ADD COLUMN IF NOT EXISTS canonical_id VARCHAR NOT NULL DEFAULT ''")
             cur.execute("ALTER TABLE fleet_agents ADD COLUMN IF NOT EXISTS tenant_id VARCHAR NOT NULL DEFAULT 'default'")
 
     def put(self, agent: FleetAgent) -> None:
@@ -230,13 +232,14 @@ class SnowflakeFleetStore:
                 """MERGE INTO fleet_agents t USING (SELECT %s AS agent_id) s
                    ON t.agent_id = s.agent_id
                    WHEN MATCHED THEN UPDATE SET
-                     name = %s, lifecycle_state = %s, trust_score = %s,
+                     canonical_id = %s, name = %s, lifecycle_state = %s, trust_score = %s,
                      updated_at = %s, tenant_id = %s, data = PARSE_JSON(%s)
                    WHEN NOT MATCHED THEN INSERT
-                     (agent_id, name, lifecycle_state, trust_score, updated_at, tenant_id, data)
-                     VALUES (%s, %s, %s, %s, %s, %s, PARSE_JSON(%s))""",
+                     (agent_id, canonical_id, name, lifecycle_state, trust_score, updated_at, tenant_id, data)
+                     VALUES (%s, %s, %s, %s, %s, %s, %s, PARSE_JSON(%s))""",
                 (
                     agent.agent_id,
+                    agent.canonical_id,
                     agent.name,
                     agent.lifecycle_state.value,
                     agent.trust_score,
@@ -244,6 +247,7 @@ class SnowflakeFleetStore:
                     agent.tenant_id,
                     agent.model_dump_json(),
                     agent.agent_id,
+                    agent.canonical_id,
                     agent.name,
                     agent.lifecycle_state.value,
                     agent.trust_score,
@@ -260,6 +264,21 @@ class SnowflakeFleetStore:
                 cur.execute("SELECT data FROM fleet_agents WHERE agent_id = %s", (agent_id,))
             else:
                 cur.execute("SELECT data FROM fleet_agents WHERE agent_id = %s AND tenant_id = %s", (agent_id, tenant_id))
+            row = cur.fetchone()
+            if row is None:
+                return None
+            return FleetAgent.model_validate_json(row[0] if isinstance(row[0], str) else json.dumps(row[0]))
+
+    def get_by_canonical_id(self, canonical_id: str, tenant_id: str | None = None) -> FleetAgent | None:
+        with self._connect() as conn:
+            cur = conn.cursor()
+            if tenant_id is None:
+                cur.execute("SELECT data FROM fleet_agents WHERE canonical_id = %s", (canonical_id,))
+            else:
+                cur.execute(
+                    "SELECT data FROM fleet_agents WHERE canonical_id = %s AND tenant_id = %s",
+                    (canonical_id, tenant_id),
+                )
             row = cur.fetchone()
             if row is None:
                 return None
@@ -292,14 +311,15 @@ class SnowflakeFleetStore:
     def list_summary(self) -> list[dict]:
         with self._connect() as conn:
             cur = conn.cursor()
-            cur.execute("SELECT agent_id, name, lifecycle_state, trust_score, updated_at FROM fleet_agents ORDER BY name")
+            cur.execute("SELECT agent_id, canonical_id, name, lifecycle_state, trust_score, updated_at FROM fleet_agents ORDER BY name")
             return [
                 {
                     "agent_id": r[0],
-                    "name": r[1],
-                    "lifecycle_state": r[2],
-                    "trust_score": r[3],
-                    "updated_at": str(r[4]) if r[4] else None,
+                    "canonical_id": r[1],
+                    "name": r[2],
+                    "lifecycle_state": r[3],
+                    "trust_score": r[4],
+                    "updated_at": str(r[5]) if r[5] else None,
                 }
                 for r in cur.fetchall()
             ]
@@ -346,12 +366,13 @@ class SnowflakeFleetStore:
             params: list = []
             for agent in batch:
                 source_parts.append(
-                    "SELECT %s AS agent_id, %s AS name, %s AS lifecycle_state, "
+                    "SELECT %s AS agent_id, %s AS canonical_id, %s AS name, %s AS lifecycle_state, "
                     "%s AS trust_score, %s AS updated_at, %s AS tenant_id, PARSE_JSON(%s) AS data"
                 )
                 params.extend(
                     [
                         agent.agent_id,
+                        agent.canonical_id,
                         agent.name,
                         agent.lifecycle_state.value,
                         agent.trust_score,
@@ -366,11 +387,11 @@ class SnowflakeFleetStore:
                 f"MERGE INTO fleet_agents t USING ({source_sql}) s "  # nosec B608
                 "ON t.agent_id = s.agent_id "
                 "WHEN MATCHED THEN UPDATE SET "
-                "  name = s.name, lifecycle_state = s.lifecycle_state, "
+                "  canonical_id = s.canonical_id, name = s.name, lifecycle_state = s.lifecycle_state, "
                 "  trust_score = s.trust_score, updated_at = s.updated_at, tenant_id = s.tenant_id, data = s.data "
                 "WHEN NOT MATCHED THEN INSERT "
-                "  (agent_id, name, lifecycle_state, trust_score, updated_at, tenant_id, data) "
-                "  VALUES (s.agent_id, s.name, s.lifecycle_state, s.trust_score, "
+                "  (agent_id, canonical_id, name, lifecycle_state, trust_score, updated_at, tenant_id, data) "
+                "  VALUES (s.agent_id, s.canonical_id, s.name, s.lifecycle_state, s.trust_score, "
                 "          s.updated_at, s.tenant_id, s.data)"
             )
 

--- a/src/agent_bom/db/local_analytics.py
+++ b/src/agent_bom/db/local_analytics.py
@@ -15,9 +15,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
+from agent_bom.canonical_ids import canonical_package_id
 from agent_bom.config import LOCAL_ANALYTICS_DB
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 DEFAULT_LOCAL_ANALYTICS_PATH = Path.home() / ".agent-bom" / "local-analytics.sqlite"
 
 
@@ -47,6 +48,7 @@ class LocalAnalyticsStore:
         if _table_exists(conn, "scan_runs") and "run_id" not in _table_columns(conn, "scan_runs"):
             self._migrate_v1_schema(conn)
         self._create_schema(conn)
+        self._migrate_canonical_columns(conn)
         conn.execute(
             """
             INSERT INTO local_schema_meta(component, version, applied_at)
@@ -100,6 +102,8 @@ class LocalAnalyticsStore:
                 title TEXT NOT NULL DEFAULT '',
                 asset_json TEXT NOT NULL DEFAULT '{}',
                 raw_json TEXT NOT NULL DEFAULT '{}',
+                canonical_id TEXT NOT NULL DEFAULT '',
+                asset_canonical_id TEXT NOT NULL DEFAULT '',
                 affected_agents_json TEXT NOT NULL DEFAULT '[]',
                 affected_servers_json TEXT NOT NULL DEFAULT '[]',
                 PRIMARY KEY (run_id, finding_key),
@@ -115,6 +119,7 @@ class LocalAnalyticsStore:
                 package_version TEXT NOT NULL,
                 ecosystem TEXT NOT NULL,
                 purl TEXT,
+                package_canonical_id TEXT NOT NULL DEFAULT '',
                 PRIMARY KEY (run_id, agent_name, server_name, package_name, package_version, ecosystem),
                 FOREIGN KEY (run_id) REFERENCES scan_runs(run_id) ON DELETE CASCADE
             );
@@ -125,6 +130,23 @@ class LocalAnalyticsStore:
             CREATE INDEX IF NOT EXISTS idx_scan_findings_source ON scan_findings(source);
             CREATE INDEX IF NOT EXISTS idx_scan_findings_type ON scan_findings(finding_type);
             CREATE INDEX IF NOT EXISTS idx_scan_packages_name ON scan_packages(package_name);
+            """
+        )
+
+    def _migrate_canonical_columns(self, conn: sqlite3.Connection) -> None:
+        finding_columns = _table_columns(conn, "scan_findings") if _table_exists(conn, "scan_findings") else set()
+        package_columns = _table_columns(conn, "scan_packages") if _table_exists(conn, "scan_packages") else set()
+        if "canonical_id" not in finding_columns:
+            conn.execute("ALTER TABLE scan_findings ADD COLUMN canonical_id TEXT NOT NULL DEFAULT ''")
+        if "asset_canonical_id" not in finding_columns:
+            conn.execute("ALTER TABLE scan_findings ADD COLUMN asset_canonical_id TEXT NOT NULL DEFAULT ''")
+        if "package_canonical_id" not in package_columns:
+            conn.execute("ALTER TABLE scan_packages ADD COLUMN package_canonical_id TEXT NOT NULL DEFAULT ''")
+        conn.executescript(
+            """
+            CREATE INDEX IF NOT EXISTS idx_scan_findings_canonical_id ON scan_findings(canonical_id);
+            CREATE INDEX IF NOT EXISTS idx_scan_findings_asset_canonical_id ON scan_findings(asset_canonical_id);
+            CREATE INDEX IF NOT EXISTS idx_scan_packages_canonical_id ON scan_packages(package_canonical_id);
             """
         )
 
@@ -237,18 +259,19 @@ class LocalAnalyticsStore:
                     run_id, scan_id, finding_key, vulnerability_id, package_name, package_version,
                     package_ref, ecosystem, severity, risk_score,
                     schema_version, finding_type, source, title, asset_json, raw_json,
-                    affected_agents_json, affected_servers_json
+                    canonical_id, asset_canonical_id, affected_agents_json, affected_servers_json
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 [_finding_row(run_id, scan_id, finding) for finding in findings],
             )
             conn.executemany(
                 """
                 INSERT INTO scan_packages(
-                    run_id, scan_id, agent_name, server_name, package_name, package_version, ecosystem, purl
+                    run_id, scan_id, agent_name, server_name, package_name, package_version, ecosystem, purl,
+                    package_canonical_id
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 [_package_row(run_id, scan_id, package_row) for package_row in package_rows],
             )
@@ -343,7 +366,8 @@ def _iter_packages(report_json: dict[str, Any]) -> Iterable[dict[str, Any]]:
 
 
 def _finding_row(run_id: str, scan_id: str, finding: dict[str, Any]) -> tuple[Any, ...]:
-    asset = finding.get("asset") if isinstance(finding.get("asset"), dict) else {}
+    raw_asset = finding.get("asset")
+    asset: dict[str, Any] = raw_asset if isinstance(raw_asset, dict) else {}
     vulnerability_id = _vulnerability_id_from_finding(finding)
     package_ref = str(finding.get("package") or "")
     package_name = str(finding.get("package_name") or _package_name_from_ref(package_ref))
@@ -367,21 +391,28 @@ def _finding_row(run_id: str, scan_id: str, finding: dict[str, Any]) -> tuple[An
         str(finding.get("title") or ""),
         json.dumps(asset, sort_keys=True),
         json.dumps(finding, sort_keys=True, default=str),
+        str(finding.get("canonical_id") or ""),
+        str(asset.get("canonical_id") or ""),
         json.dumps(list(finding.get("affected_agents") or []), sort_keys=True),
         json.dumps(list(finding.get("affected_servers") or []), sort_keys=True),
     )
 
 
 def _package_row(run_id: str, scan_id: str, package: dict[str, Any]) -> tuple[Any, ...]:
+    package_name = str(package.get("name") or "")
+    package_version = str(package.get("version") or "")
+    ecosystem = str(package.get("ecosystem") or "")
+    purl = package.get("purl")
     return (
         run_id,
         scan_id,
         str(package.get("agent_name") or ""),
         str(package.get("server_name") or ""),
-        str(package.get("name") or ""),
-        str(package.get("version") or ""),
-        str(package.get("ecosystem") or ""),
-        package.get("purl"),
+        package_name,
+        package_version,
+        ecosystem,
+        purl,
+        str(package.get("canonical_id") or canonical_package_id(package_name, package_version, ecosystem, str(purl or "") or None)),
     )
 
 

--- a/tests/test_fleet_tenant.py
+++ b/tests/test_fleet_tenant.py
@@ -11,6 +11,7 @@ from agent_bom.api.fleet_store import (
     InMemoryFleetStore,
     SQLiteFleetStore,
 )
+from agent_bom.canonical_ids import canonical_agent_id
 
 
 def _make_agent(agent_id: str, name: str, tenant_id: str = "default") -> FleetAgent:
@@ -43,6 +44,22 @@ def test_fleet_agent_tenant_serialization():
     data = agent.model_dump_json()
     restored = FleetAgent.model_validate_json(data)
     assert restored.tenant_id == "team-a"
+
+
+def test_fleet_agent_derives_canonical_id():
+    agent = _make_agent("a1", "Desktop Agent", tenant_id="team-a")
+    assert agent.canonical_id == canonical_agent_id("claude_desktop", "Desktop Agent")
+
+
+def test_fleet_agent_canonical_id_prefers_source_id():
+    agent = FleetAgent(
+        agent_id="a1",
+        name="Renamed Agent",
+        agent_type="cursor",
+        source_id="device-123",
+        updated_at="2026-01-01T00:00:00Z",
+    )
+    assert agent.canonical_id == canonical_agent_id("cursor", "Renamed Agent", source_id="device-123")
 
 
 # ─── InMemoryFleetStore ──────────────────────────────────────────────────────
@@ -82,6 +99,17 @@ def test_in_memory_list_tenants():
 def test_in_memory_list_tenants_empty():
     store = InMemoryFleetStore()
     assert store.list_tenants() == []
+
+
+def test_in_memory_get_by_canonical_id_is_tenant_scoped():
+    store = InMemoryFleetStore()
+    team_a = _make_agent("a1", "agent1", "team-a")
+    team_b = _make_agent("a2", "agent1", "team-b")
+    store.put(team_a)
+    store.put(team_b)
+
+    assert store.get_by_canonical_id(team_a.canonical_id, tenant_id="team-a").agent_id == "a1"
+    assert store.get_by_canonical_id(team_a.canonical_id, tenant_id="team-missing") is None
 
 
 # ─── SQLiteFleetStore ────────────────────────────────────────────────────────
@@ -139,6 +167,18 @@ def test_sqlite_batch_put_preserves_tenant(sqlite_store):
     sqlite_store.batch_put(agents)
     assert sqlite_store.list_by_tenant("team-a")[0].tenant_id == "team-a"
     assert sqlite_store.list_by_tenant("team-b")[0].tenant_id == "team-b"
+
+
+def test_sqlite_get_by_canonical_id(sqlite_store):
+    agent = _make_agent("a1", "agent1", "team-a")
+    sqlite_store.put(agent)
+
+    stored = sqlite_store.get_by_canonical_id(agent.canonical_id, tenant_id="team-a")
+
+    assert stored is not None
+    assert stored.agent_id == "a1"
+    assert sqlite_store.get_by_canonical_id(agent.canonical_id, tenant_id="team-b") is None
+    assert sqlite_store.list_summary()[0]["canonical_id"] == agent.canonical_id
 
 
 # ─── Cross-tenant isolation ──────────────────────────────────────────────────

--- a/tests/test_local_analytics.py
+++ b/tests/test_local_analytics.py
@@ -4,6 +4,7 @@ import sqlite3
 
 from click.testing import CliRunner
 
+from agent_bom.canonical_ids import canonical_package_id
 from agent_bom.db.local_analytics import LocalAnalyticsStore
 
 
@@ -43,10 +44,12 @@ def _report(scan_id: str = "scan-1") -> dict:
         "blast_radius": [
             {
                 "vulnerability_id": "CVE-2026-0001",
+                "canonical_id": "finding-canonical-1",
                 "package": "fastapi@0.115.0",
                 "package_name": "fastapi",
                 "package_version": "0.115.0",
                 "ecosystem": "pypi",
+                "asset": {"name": "fastapi", "canonical_id": "asset-canonical-1"},
                 "severity": "critical",
                 "risk_score": 9.4,
                 "affected_agents": ["desktop-agent"],
@@ -83,6 +86,24 @@ def test_local_analytics_store_records_scan_summary_findings_and_packages(tmp_pa
 
     package_rows = store.query("SELECT package_name FROM scan_packages ORDER BY package_name")
     assert package_rows == [{"package_name": "fastapi"}, {"package_name": "uvicorn"}]
+
+    canonical_finding_rows = store.query(
+        "SELECT canonical_id, asset_canonical_id FROM scan_findings WHERE vulnerability_id = ?",
+        ("CVE-2026-0001",),
+    )
+    assert canonical_finding_rows == [{"canonical_id": "finding-canonical-1", "asset_canonical_id": "asset-canonical-1"}]
+
+    canonical_package_rows = store.query("SELECT package_name, package_canonical_id FROM scan_packages ORDER BY package_name")
+    assert canonical_package_rows == [
+        {
+            "package_name": "fastapi",
+            "package_canonical_id": canonical_package_id("fastapi", "0.115.0", "pypi", "pkg:pypi/fastapi@0.115.0"),
+        },
+        {
+            "package_name": "uvicorn",
+            "package_canonical_id": canonical_package_id("uvicorn", "0.32.0", "pypi"),
+        },
+    ]
 
 
 def test_local_analytics_store_records_repeated_artifact_as_distinct_runs(tmp_path):
@@ -275,3 +296,65 @@ def test_local_analytics_store_migrates_initial_scan_id_keyed_schema(tmp_path):
     assert store.query("SELECT run_id, scan_id, package_name FROM scan_packages") == [
         {"run_id": "legacy-scan", "scan_id": "legacy-scan", "package_name": "pkg"}
     ]
+
+
+def test_local_analytics_store_migrates_v2_canonical_columns(tmp_path):
+    db_path = tmp_path / "local.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE scan_runs (
+                run_id TEXT PRIMARY KEY,
+                scan_id TEXT NOT NULL,
+                generated_at TEXT NOT NULL,
+                recorded_at TEXT NOT NULL,
+                tenant_id TEXT NOT NULL DEFAULT 'default',
+                source TEXT NOT NULL,
+                artifact_path TEXT,
+                total_agents INTEGER NOT NULL DEFAULT 0,
+                total_packages INTEGER NOT NULL DEFAULT 0,
+                total_vulnerabilities INTEGER NOT NULL DEFAULT 0,
+                critical_findings INTEGER NOT NULL DEFAULT 0,
+                high_findings INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE scan_findings (
+                run_id TEXT NOT NULL,
+                scan_id TEXT NOT NULL,
+                finding_key TEXT NOT NULL,
+                vulnerability_id TEXT NOT NULL,
+                package_name TEXT NOT NULL,
+                package_version TEXT NOT NULL,
+                package_ref TEXT NOT NULL,
+                ecosystem TEXT NOT NULL,
+                severity TEXT NOT NULL,
+                risk_score REAL NOT NULL DEFAULT 0,
+                schema_version TEXT NOT NULL DEFAULT '',
+                finding_type TEXT NOT NULL DEFAULT '',
+                source TEXT NOT NULL DEFAULT '',
+                title TEXT NOT NULL DEFAULT '',
+                asset_json TEXT NOT NULL DEFAULT '{}',
+                raw_json TEXT NOT NULL DEFAULT '{}',
+                affected_agents_json TEXT NOT NULL DEFAULT '[]',
+                affected_servers_json TEXT NOT NULL DEFAULT '[]',
+                PRIMARY KEY (run_id, finding_key)
+            );
+            CREATE TABLE scan_packages (
+                run_id TEXT NOT NULL,
+                scan_id TEXT NOT NULL,
+                agent_name TEXT NOT NULL,
+                server_name TEXT NOT NULL,
+                package_name TEXT NOT NULL,
+                package_version TEXT NOT NULL,
+                ecosystem TEXT NOT NULL,
+                purl TEXT,
+                PRIMARY KEY (run_id, agent_name, server_name, package_name, package_version, ecosystem)
+            );
+            """
+        )
+
+    store = LocalAnalyticsStore(db_path)
+
+    finding_columns = {row["name"] for row in store.query("SELECT name FROM pragma_table_info('scan_findings')")}
+    package_columns = {row["name"] for row in store.query("SELECT name FROM pragma_table_info('scan_packages')")}
+    assert {"canonical_id", "asset_canonical_id"} <= finding_columns
+    assert "package_canonical_id" in package_columns

--- a/tests/test_mcp_observation_store.py
+++ b/tests/test_mcp_observation_store.py
@@ -13,6 +13,7 @@ from agent_bom.api.mcp_observation_store import (
     SQLiteMCPObservationStore,
     merge_observations,
 )
+from agent_bom.canonical_ids import canonical_mcp_server_id
 
 
 def _make_observation(**overrides) -> MCPObservation:
@@ -43,6 +44,19 @@ def test_observation_normalizes_tenant_and_timestamps() -> None:
     assert observation.last_synced == "2026-04-23T15:06:00Z"
 
 
+def test_observation_derives_server_canonical_id_from_stable_id() -> None:
+    observation = _make_observation(server_stable_id="stable-server-1")
+    assert observation.server_canonical_id == "stable-server-1"
+
+
+def test_observation_derives_server_canonical_id_from_server_identity_without_stable_id() -> None:
+    observation = _make_observation(server_stable_id="", server_name="Filesystem", command="npx @modelcontextprotocol/server-filesystem")
+    assert observation.server_canonical_id == canonical_mcp_server_id(
+        "Filesystem",
+        "npx @modelcontextprotocol/server-filesystem",
+    )
+
+
 def test_merge_rejects_tenant_mismatch() -> None:
     existing = _make_observation(tenant_id="tenant-a")
     incoming = _make_observation(tenant_id="tenant-b")
@@ -67,6 +81,15 @@ def test_merge_preserves_blocked_state_and_structured_intelligence() -> None:
 
     assert merged.security_blocked is True
     assert [item["entry_id"] for item in merged.security_intelligence] == ["intel-a", "intel-b"]
+
+
+def test_merge_retains_server_canonical_id() -> None:
+    existing = _make_observation(server_canonical_id="server-canonical-1")
+    incoming = _make_observation(server_canonical_id="server-canonical-1")
+
+    merged = merge_observations(existing, incoming)
+
+    assert merged.server_canonical_id == "server-canonical-1"
 
 
 def test_observation_sanitizes_security_intelligence() -> None:
@@ -102,6 +125,18 @@ def test_inmemory_store_revalidates_observation_before_write() -> None:
     assert stored.last_seen == "2026-04-23T11:05:00Z"
 
 
+def test_inmemory_store_get_by_server_canonical_id() -> None:
+    store = InMemoryMCPObservationStore()
+    observation = _make_observation()
+    store.put(observation)
+
+    stored = store.get_by_server_canonical_id("tenant-a", observation.server_canonical_id)
+
+    assert stored is not None
+    assert stored.observation_id == "obs-1"
+    assert store.get_by_server_canonical_id("tenant-b", observation.server_canonical_id) is None
+
+
 def test_sqlite_store_revalidates_observation_before_write() -> None:
     store, path = _sqlite_store()
     try:
@@ -111,5 +146,20 @@ def test_sqlite_store_revalidates_observation_before_write() -> None:
         assert stored is not None
         assert stored.tenant_id == "tenant-a"
         assert stored.updated_at == "2026-04-23T12:00:00Z"
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_sqlite_store_get_by_server_canonical_id() -> None:
+    store, path = _sqlite_store()
+    try:
+        observation = _make_observation()
+        store.put(observation)
+
+        stored = store.get_by_server_canonical_id("tenant-a", observation.server_canonical_id)
+
+        assert stored is not None
+        assert stored.observation_id == "obs-1"
+        assert store.get_by_server_canonical_id("tenant-b", observation.server_canonical_id) is None
     finally:
         path.unlink(missing_ok=True)

--- a/tests/test_medium_hardening.py
+++ b/tests/test_medium_hardening.py
@@ -448,6 +448,7 @@ def test_sync_uses_batch_put():
     mock_store.batch_put.assert_called_once()
     call_args = mock_store.batch_put.call_args[0][0]
     assert len(call_args) == 3
+    assert all(isinstance(agent.canonical_id, str) for agent in call_args)
 
 
 def test_sync_batch_put_with_existing():
@@ -489,6 +490,7 @@ def test_sync_batch_put_with_existing():
     mock_store.batch_put.assert_called_once()
     call_args = mock_store.batch_put.call_args[0][0]
     assert len(call_args) == 2
+    assert all(isinstance(agent.canonical_id, str) for agent in call_args)
     # No individual put calls
     mock_store.put.assert_not_called()
 

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -195,9 +195,9 @@ class MockConnection:
             elif "from scan_jobs" in sql_lower and "job_id, team_id, status, created_at, completed_at, triggered_by" in sql_lower:
                 rows = list(self._store.get("scan_jobs", {}).values())
                 cursor.rows = [(r[0], r[1], r[2], r[3], r[4], (r[5] if len(r) > 6 else None)) for r in rows]
-            elif "from fleet_agents" in sql_lower and "agent_id, name, lifecycle_state, trust_score" in sql_lower:
+            elif "from fleet_agents" in sql_lower and "agent_id, canonical_id, name, lifecycle_state, trust_score" in sql_lower:
                 rows = list(self._store.get("fleet_agents", {}).values())
-                cursor.rows = [(r[0], r[1], r[2], r[3]) for r in rows]
+                cursor.rows = [(r[0], r[1], r[2], r[3], r[4]) for r in rows]
             elif "from graph_nodes" in sql_lower and "id, entity_type, label" in sql_lower:
                 rows = list(self._store.get("graph_nodes", {}).values())
                 if params:
@@ -454,6 +454,7 @@ def test_fleet_store_put_get(mock_pool):
     # Set up mock data for retrieval
     mock_pool._conn._store.setdefault("fleet_agents", {})["a-1"] = (
         "a-1",
+        agent.canonical_id,
         "test-agent",
         "discovered",
         0.0,
@@ -466,6 +467,36 @@ def test_fleet_store_put_get(mock_pool):
     assert retrieved is not None
     assert retrieved.agent_id == "a-1"
     assert retrieved.name == "test-agent"
+    assert retrieved.canonical_id == agent.canonical_id
+
+
+def test_fleet_store_get_by_canonical_id(mock_pool):
+    from agent_bom.api.fleet_store import FleetAgent, FleetLifecycleState
+    from agent_bom.api.postgres_store import PostgresFleetStore
+
+    store = PostgresFleetStore(pool=mock_pool)
+    agent = FleetAgent(
+        agent_id="a-1",
+        name="test-agent",
+        agent_type="claude_desktop",
+        lifecycle_state=FleetLifecycleState.DISCOVERED,
+        updated_at="2026-01-01T00:00:00Z",
+    )
+    mock_pool._conn._store.setdefault("fleet_agents", {})[agent.canonical_id] = (
+        "a-1",
+        agent.canonical_id,
+        "test-agent",
+        "discovered",
+        0.0,
+        "default",
+        "2026-01-01T00:00:00Z",
+        agent.model_dump_json(),
+    )
+
+    retrieved = store.get_by_canonical_id(agent.canonical_id)
+
+    assert retrieved is not None
+    assert retrieved.agent_id == "a-1"
 
 
 def test_fleet_store_get_nonexistent(mock_pool):
@@ -489,7 +520,8 @@ def test_fleet_store_get_by_name(mock_pool):
     )
 
     mock_pool._conn._store.setdefault("fleet_agents", {})["test-agent"] = (
-        "test-agent",
+        "a-1",
+        agent.canonical_id,
         "test-agent",
         "approved",
         0.0,
@@ -519,11 +551,24 @@ def test_fleet_store_list_all(mock_pool):
 
 
 def test_fleet_store_list_summary(mock_pool):
+    from agent_bom.api.fleet_store import FleetAgent
     from agent_bom.api.postgres_store import PostgresFleetStore
 
     store = PostgresFleetStore(pool=mock_pool)
+    agent = FleetAgent(agent_id="a-1", name="summary-agent", agent_type="cursor", updated_at="2026-01-01T00:00:00Z")
+    mock_pool._conn._store.setdefault("fleet_agents", {})["a-1"] = (
+        "a-1",
+        agent.canonical_id,
+        "summary-agent",
+        "discovered",
+        0.7,
+        "default",
+        "2026-01-01T00:00:00Z",
+        agent.model_dump_json(),
+    )
     result = store.list_summary()
     assert isinstance(result, list)
+    assert result[0]["canonical_id"] == agent.canonical_id
 
 
 def test_fleet_store_list_by_tenant(mock_pool):
@@ -550,6 +595,7 @@ def test_fleet_store_update_state(mock_pool):
     # Mock existing agent
     mock_pool._conn._store.setdefault("fleet_agents", {})["a-1"] = (
         "a-1",
+        "agent-canonical-1",
         "test",
         "discovered",
         0.0,

--- a/tests/test_snowflake_stores.py
+++ b/tests/test_snowflake_stores.py
@@ -348,7 +348,13 @@ class TestSnowflakeFleetStore:
 
         SnowflakeFleetStore(SF_PARAMS)
         calls = [str(c) for c in conn.cursor().execute.call_args_list]
-        assert any("CREATE TABLE IF NOT EXISTS fleet_agents" in c and "tenant_id VARCHAR NOT NULL DEFAULT 'default'" in c for c in calls)
+        assert any(
+            "CREATE TABLE IF NOT EXISTS fleet_agents" in c
+            and "canonical_id VARCHAR NOT NULL DEFAULT ''" in c
+            and "tenant_id VARCHAR NOT NULL DEFAULT 'default'" in c
+            for c in calls
+        )
+        assert any("ALTER TABLE fleet_agents ADD COLUMN IF NOT EXISTS canonical_id" in c for c in calls)
         assert any("ALTER TABLE fleet_agents ADD COLUMN IF NOT EXISTS tenant_id" in c for c in calls)
 
     @patch("agent_bom.api.snowflake_store._sf_connect")
@@ -361,6 +367,7 @@ class TestSnowflakeFleetStore:
         calls = conn.cursor().execute.call_args_list
         merge_call = [c for c in calls if "MERGE INTO fleet_agents" in str(c)]
         assert len(merge_call) > 0
+        assert any(agent.canonical_id in str(c) for c in merge_call)
         assert any(agent.tenant_id in str(c) for c in merge_call)
 
     @patch("agent_bom.api.snowflake_store._sf_connect")
@@ -396,6 +403,19 @@ class TestSnowflakeFleetStore:
         assert result.name == "test-agent"
 
     @patch("agent_bom.api.snowflake_store._sf_connect")
+    def test_get_by_canonical_id(self, mock_connect):
+        agent = self._make_agent()
+        cur = _mock_cursor(fetchone_val=(agent.model_dump_json(),))
+        conn = _mock_connection(cursor=cur)
+        mock_connect.return_value = conn
+        store = self._make_store()
+        result = store.get_by_canonical_id(agent.canonical_id, tenant_id="tenant-alpha")
+        assert result is not None
+        assert result.agent_id == "a1"
+        sql = str(conn.cursor().execute.call_args_list[-1])
+        assert "WHERE canonical_id = %s AND tenant_id = %s" in sql
+
+    @patch("agent_bom.api.snowflake_store._sf_connect")
     def test_delete(self, mock_connect):
         cur = _mock_cursor(rowcount=1)
         conn = _mock_connection(cursor=cur)
@@ -420,7 +440,7 @@ class TestSnowflakeFleetStore:
     def test_list_summary(self, mock_connect):
         cur = _mock_cursor(
             fetchall_val=[
-                ("a1", "agent-a", "discovered", 0.8, "2025-01-01T00:00:00Z"),
+                ("a1", "agent-canonical-1", "agent-a", "discovered", 0.8, "2025-01-01T00:00:00Z"),
             ]
         )
         conn = _mock_connection(cursor=cur)
@@ -429,6 +449,7 @@ class TestSnowflakeFleetStore:
         result = store.list_summary()
         assert len(result) == 1
         assert result[0]["agent_id"] == "a1"
+        assert result[0]["canonical_id"] == "agent-canonical-1"
         assert result[0]["trust_score"] == 0.8
 
     @patch("agent_bom.api.snowflake_store._sf_connect")


### PR DESCRIPTION
## Summary

Align canonical IDs across the persistence surfaces that were still storing only local row IDs after the report and graph canonical-ID work landed.

- add `canonical_id` to fleet agents across in-memory, SQLite, Postgres, and Snowflake stores, including indexed lookup helpers
- add `server_canonical_id` to MCP observations so connector observations can be correlated by stable server identity
- add canonical finding, asset, and package columns to the local analytics mirror used by CLI/API evidence queries
- backfill SQLite rows from existing JSON payloads without changing existing primary keys
- preserve the current readable IDs while making canonical IDs queryable for DB joins, connector sync, and graph/finding correlation

## Root Cause

The previous canonical-ID work surfaced stable IDs in report and graph payloads, but persistence stores still indexed primarily by local IDs such as `agent_id`, `observation_id`, and package row keys. That left connector, analytics, and DB paths unable to reliably join the same logical entity across scans or storage backends.

## Validation

- `uv run pytest -q tests/test_fleet_store.py tests/test_fleet_batch.py tests/test_fleet_tenant.py tests/test_mcp_observation_store.py tests/test_local_analytics.py tests/test_postgres_store.py tests/test_snowflake_stores.py`
- `uv run ruff check src/agent_bom/api/fleet_store.py src/agent_bom/api/mcp_observation_store.py src/agent_bom/api/pipeline.py src/agent_bom/api/postgres_store.py src/agent_bom/api/snowflake_store.py src/agent_bom/db/local_analytics.py tests/test_fleet_tenant.py tests/test_local_analytics.py tests/test_mcp_observation_store.py tests/test_postgres_store.py tests/test_snowflake_stores.py`
- `uv run mypy src/ --ignore-missing-imports --disable-error-code import-untyped`
- `git diff --check`
- commit hooks: ruff, ruff-format, mypy, bandit, env-var drift, duplicate artifact guard

## Release Gate Note

This should remain draft until the pending Claude release audit is reviewed. It is a data-contract hardening PR, not a release-readiness claim.
