### PR TITLE
fix: make cryptography a core dependency so `agent-bom audit` works after pip install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **`agent-bom audit` fails on base install** - `cryptography` is now a core
+  dependency (it was previously only in `[runtime]`/`[oidc]` extras), so the
+  proxy audit log viewer no longer crashes with `No module named
+  'cryptography'` after `pip install agent-bom`. The CLI also catches the
+  ImportError defensively and prints a clean `pip install 'agent-bom[runtime]'`
+  hint with exit code 2 instead of a traceback.
+
 ---
 
 ## [0.86.5] - 2026-05-11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "tornado>=6.5.5",  # CVE-2026-31958 (multipart DoS), GHSA-78cv-mqj4-43f7 (cookie injection) — transitive via streamlit
     # NOTE: stale pyopenssl suppressions were retired after snowflake-connector-python moved to a compatible range.
     # Tracked: https://github.com/msaad00/agent-bom/issues/930
+    "cryptography>=46.0.7",  # Required by audit chain (aes-cmac-128), proxy response signing, OIDC; top-level `audit` CLI fails without it.
 ]
 
 [project.optional-dependencies]

--- a/src/agent_bom/cli/_runtime.py
+++ b/src/agent_bom/cli/_runtime.py
@@ -922,7 +922,18 @@ def audit_replay_cmd(log_path, tool, entry_type, blocked_only, alerts_only, sign
       agent-bom runtime audit audit.jsonl --verify-chain
       agent-bom runtime audit audit.jsonl --json
     """
-    from agent_bom.audit_replay import replay
+    try:
+        from agent_bom.audit_replay import replay
+    except ImportError as exc:
+        if exc.name == "cryptography":
+            click.echo(
+                "ERROR: cryptography is required for `agent-bom audit`.\n"
+                "Install it with:  pip install 'agent-bom[runtime]'  "
+                "(or: pip install cryptography)",
+                err=True,
+            )
+            sys.exit(2)
+        raise
 
     exit_code = replay(
         log_path,

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -442,6 +442,34 @@ def test_audit_replay_cmd_alerts_only(tmp_path):
     assert result.exit_code == 0
 
 
+def test_audit_replay_cmd_cryptography_missing_emits_install_hint(tmp_path, monkeypatch):
+    """If cryptography is not importable, `agent-bom audit` should surface a
+    clean `pip install 'agent-bom[runtime]'` hint and exit 2, not a traceback.
+    """
+    import builtins
+    import json
+    import sys
+
+    log_file = tmp_path / "audit.jsonl"
+    log_file.write_text(json.dumps({"type": "tools/call", "tool": "x"}) + "\n")
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "agent_bom.audit_replay":
+            raise ImportError("No module named 'cryptography'", name="cryptography")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "agent_bom.audit_replay", raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(audit_replay_cmd, [str(log_file)])
+    assert result.exit_code == 2
+    assert "cryptography" in result.output
+    assert "agent-bom[runtime]" in result.output
+
+
 def test_audit_drain_dlq_cmd_writes_json_summary_and_deletes_drained(tmp_path):
     import json
 

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,7 @@ version = "0.86.5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "cryptography" },
     { name = "cyclonedx-python-lib" },
     { name = "flask" },
     { name = "httpx" },
@@ -229,6 +230,7 @@ requires-dist = [
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.9" },
     { name = "boto3", marker = "extra == 'aws'", specifier = ">=1.34" },
     { name = "click", specifier = ">=8.0" },
+    { name = "cryptography", specifier = ">=46.0.7" },
     { name = "cryptography", marker = "extra == 'oidc'", specifier = ">=46.0.7" },
     { name = "cryptography", marker = "extra == 'runtime'", specifier = ">=46.0.7" },
     { name = "cyclonedx-python-lib", specifier = ">=11.6" },


### PR DESCRIPTION
## Summary
- Promotes `cryptography>=46.0.7` from `[runtime]`/`[oidc]` extras into the core
  dependency list. It is already load-bearing for proxy response signing, the
  aes-cmac-128 audit chain (`audit_integrity.py`), and OIDC token verification.
- Hardens the `agent-bom audit` CLI wrapper so any future `cryptography`
  ImportError surfaces as a clean `pip install 'agent-bom[runtime]'` hint with
  exit code 2, matching the UX `agent-bom api` already uses for missing
  uvicorn.
- Adds a regression test that monkey-patches the import and asserts the hint.

## Reproduction prior to this change

```
python -m venv /tmp/x && source /tmp/x/bin/activate
pip install agent-bom        # v0.86.5 from PyPI, clean venv
agent-bom audit /any/audit.jsonl
# agent-bom error: No module named 'cryptography'
# Run with --verbose for full traceback.
```

`agent-bom audit` is advertised under `--help`'s Runtime section, so users
following the documented first-run path hit this on the very first attempt to
inspect a proxy log.

## Why core, not lazy
- `audit_integrity` is imported unconditionally by `audit_replay`, proxy
  response signing, the compliance signing path, and OIDC.
- The wheel cost of cryptography is small relative to the existing dependency
  closure (`urllib3`, `httpx`, `streamlit`, etc.) and the library is already
  pulled in transitively by any non-trivial install.
- The defensive lazy-import + install hint stays in place so an unusual
  packaging path (e.g. someone manually stripping wheels) still produces an
  actionable error instead of a traceback.

## Test plan
- [x] `pytest tests/test_cli_runtime.py::test_audit_replay_cmd_cryptography_missing_emits_install_hint` (new)
- [x] `pytest tests/test_cli_runtime.py::test_audit_replay_cmd` (existing — still green)
- [x] `pytest tests/test_cli_runtime.py::test_audit_replay_cmd_blocked` (existing — still green)
- [ ] CI: pip-audit / npm-audit / unit suite
- [ ] Manual: clean venv `pip install <wheel>` + `agent-bom audit any.jsonl` should now print the audit table instead of an ImportError.