### PR TITLE
fix: honor `agent-bom sbom -o` when a CLI profile is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Versions follow [Semantic Versioning](https://semver.org/).
   'cryptography'` after `pip install agent-bom`. The CLI also catches the
   ImportError defensively and prints a clean `pip install 'agent-bom[runtime]'`
   hint with exit code 2 instead of a traceback.
+- **`agent-bom sbom -o` (and `image -o` / `iac -o`) ignored when a CLI profile
+  is active** - sibling scan commands forward `--output` to `scan` via
+  `ctx.invoke(scan, output=...)`. Click reports the parameter source as
+  DEFAULT in that case, so `apply_scan_profile_defaults` was overriding the
+  caller's explicit path with the profile's `output =` value (e.g.
+  `agent-bom-report.json`). The profile default is now applied only when the
+  caller value is empty, preserving wrapper-command behavior while still
+  honoring profile defaults for bare `agent-bom agents` invocations.
 
 ---
 

--- a/src/agent_bom/cli/_profiles.py
+++ b/src/agent_bom/cli/_profiles.py
@@ -187,11 +187,24 @@ def apply_scan_profile_defaults(
     format_source = ctx.get_parameter_source("output_format") if ctx is not None else None
     explicit_output = output_source in {click.core.ParameterSource.COMMANDLINE, click.core.ParameterSource.ENVIRONMENT}
     explicit_format = format_source in {click.core.ParameterSource.COMMANDLINE, click.core.ParameterSource.ENVIRONMENT}
+    # When `scan` is invoked via ``ctx.invoke`` from a sibling command
+    # (`sbom`, `image`, `iac`, …), Click reports the parameter source as
+    # DEFAULT even though the caller passed an explicit value. Treat a
+    # truthy caller value as a request to honor it; otherwise fall back to
+    # the active profile default. Without this guard, a profile that pins
+    # ``output = "agent-bom-report.json"`` overrides ``agent-bom sbom -o
+    # custom.json`` because the source is DEFAULT.
+    caller_supplied_output = bool(output)
+    caller_supplied_format = bool(output_format) and output_format != "console"
 
-    profile_output = output if explicit_format and not explicit_output else profile_default(ctx, profile, "output", output, "output")
+    profile_output = (
+        output
+        if explicit_output or caller_supplied_output or (explicit_format and not explicit_output)
+        else profile_default(ctx, profile, "output", output, "output")
+    )
     profile_format = (
         output_format
-        if explicit_output and not explicit_format
+        if explicit_format or caller_supplied_format or (explicit_output and not explicit_format)
         else profile_default(ctx, profile, "output_format", output_format, "format", "output_format")
     )
 

--- a/tests/test_cli_profiles.py
+++ b/tests/test_cli_profiles.py
@@ -162,6 +162,52 @@ output = "profile.json"
     assert result.exit_code == 0, result.output
 
 
+def test_scan_profile_does_not_clobber_ctx_invoke_output(monkeypatch, tmp_path):
+    """When a sibling command (`sbom`, `image`, `iac`) calls `scan` via
+    ``ctx.invoke(..., output=...)``, Click reports the parameter source as
+    DEFAULT even though the caller passed an explicit value. The profile
+    default must not clobber the caller's value in that case — otherwise
+    ``agent-bom sbom test.spdx.json -o custom.json`` silently writes to the
+    profile-configured filename.
+    """
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+current_profile = "prod"
+
+[profiles.prod]
+format = "json"
+output = "agent-bom-report.json"
+"""
+    )
+    monkeypatch.setenv("AGENT_BOM_CONFIG", str(config_path))
+
+    @click.command()
+    @click.option("--output")
+    @click.option("--format", "output_format", default="console")
+    def _inner(output: str | None, output_format: str) -> None:
+        values = apply_scan_profile_defaults(
+            output=output,
+            output_format=output_format,
+            preset=None,
+            nvd_api_key=None,
+            push_url=None,
+            push_api_key=None,
+            clickhouse_url=None,
+        )
+        # Caller-supplied output (ctx.invoke from sbom_cmd) must win even when
+        # the click parameter source is DEFAULT.
+        assert values[:2] == ("custom.json", "json")
+
+    @click.command()
+    @click.pass_context
+    def _outer(ctx):
+        ctx.invoke(_inner, output="custom.json", output_format="json")
+
+    result = CliRunner().invoke(_outer)
+    assert result.exit_code == 0, result.output
+
+
 def test_profiles_group_lists_and_switches_current_profile(monkeypatch, tmp_path):
     config_path = tmp_path / "config.toml"
     config_path.write_text(


### PR DESCRIPTION
## Summary
Sibling scan commands (`sbom`, `image`, `iac`, ...) forward `--output` to the
main scan handler via `ctx.invoke(scan, output=...)`. Click reports the
parameter source as DEFAULT in that case, so
`apply_scan_profile_defaults` was overriding the caller's explicit path with
the profile's `output =` value whenever a profile was active.

## Reproduction prior to this change

```
cat ~/.agent-bom/config.toml
# current_profile = "default"
# [profiles.default]
# output = "agent-bom-report.json"

agent-bom sbom test.spdx.json -f json -o sbom-out.json
# ✓ JSON report: agent-bom-report.json   <- profile clobbers -o
# sbom-out.json is never written
```

After this PR, the same command writes to `sbom-out.json` as requested.

## Fix
Treat a truthy caller value (or an explicit format pair) as a request to
honor the supplied output path even when the click parameter source is
DEFAULT — that case is dominated by `ctx.invoke` from wrapper commands.
Profile defaults still fill in for bare `agent-bom agents` runs where the
flag is omitted.

## Test plan
- [x] `pytest tests/test_cli_profiles.py` (8/8 pass, including new
      `test_scan_profile_does_not_clobber_ctx_invoke_output` regression).
- [x] Manual: with `output = "agent-bom-report.json"` pinned in the active
      profile, `agent-bom sbom test.spdx.json -f json -o sbom-out.json` now
      writes `sbom-out.json` and never creates `agent-bom-report.json`.
- [ ] CI: pip-audit / unit suite.