### PR TITLE
fix output formatter metadata parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
   `agent-bom-report.json`). The profile default is now applied only when the
   caller value is empty, preserving wrapper-command behavior while still
   honoring profile defaults for bare `agent-bom agents` invocations.
+- **Auditor export parity** - CSV, Markdown, and SPDX outputs now preserve
+  severity provenance, EPSS percentile, KEV dates, CWE IDs, and framework
+  compliance tags instead of dropping enrichment metadata outside JSON/SARIF.
 
 ---
 

--- a/src/agent_bom/compliance_utils.py
+++ b/src/agent_bom/compliance_utils.py
@@ -62,3 +62,12 @@ def apply_effective_blast_radius_tags(br: BlastRadius) -> BlastRadius:
     for field, tags in effective_blast_radius_tags(br).items():
         setattr(br, field, tags)
     return br
+
+
+def framework_qualified_blast_radius_tags(br: BlastRadius) -> list[str]:
+    """Return merged tags as stable framework:control strings."""
+    tags: list[str] = []
+    for field, values in effective_blast_radius_tags(br).items():
+        framework = _FIELD_TO_VULN_KEY.get(field, field.removesuffix("_tags"))
+        tags.extend(f"{framework}:{value}" for value in values)
+    return tags

--- a/src/agent_bom/output/csv_fmt.py
+++ b/src/agent_bom/output/csv_fmt.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import csv
 import io
 
+from agent_bom.compliance_utils import framework_qualified_blast_radius_tags
 from agent_bom.models import AIBOMReport, BlastRadius
 
 _COLUMNS = [
@@ -28,6 +29,11 @@ _COLUMNS = [
     "affected_servers",
     "exposed_credentials",
     "summary",
+    "severity_source",
+    "epss_percentile",
+    "kev_date_added",
+    "kev_due_date",
+    "compliance_tags",
 ]
 
 
@@ -62,10 +68,20 @@ def to_csv(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) ->
                 "affected_servers": ";".join(s.name for s in br.affected_servers),
                 "exposed_credentials": str(len(br.exposed_credentials)),
                 "summary": v.summary or "",
+                "severity_source": v.severity_source or "",
+                "epss_percentile": f"{v.epss_percentile:.4f}" if v.epss_percentile is not None else "",
+                "kev_date_added": v.kev_date_added or "",
+                "kev_due_date": v.kev_due_date or "",
+                "compliance_tags": _compliance_tags_cell(br),
             }
         )
 
     return buf.getvalue()
+
+
+def _compliance_tags_cell(br: BlastRadius) -> str:
+    """Return framework-qualified tags for one spreadsheet cell."""
+    return ";".join(framework_qualified_blast_radius_tags(br))
 
 
 def export_csv(report: AIBOMReport, output_path: str, blast_radii: list[BlastRadius] | None = None) -> None:

--- a/src/agent_bom/output/markdown.py
+++ b/src/agent_bom/output/markdown.py
@@ -5,6 +5,7 @@ Produces a self-contained Markdown report with summary table and detailed findin
 
 from __future__ import annotations
 
+from agent_bom.compliance_utils import framework_qualified_blast_radius_tags
 from agent_bom.finding import Finding, FindingType
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
 
@@ -85,16 +86,24 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
     if brs:
         lines.append("## Findings")
         lines.append("")
-        lines.append("| Severity | CVE | Package | Version | Fix | CVSS | Agents |")
-        lines.append("|----------|-----|---------|---------|-----|------|--------|")
+        lines.append("| Severity | CVE | Package | Version | Fix | CVSS | EPSS | KEV | CWE | Tags | Source | Agents |")
+        lines.append("|----------|-----|---------|---------|-----|------|------|-----|-----|------|--------|--------|")
 
         for br in sorted(brs, key=lambda b: _sev_order(b.vulnerability.severity)):
             v = br.vulnerability
             sev_badge = _severity_badge(v.severity)
             cvss = f"{v.cvss_score}" if v.cvss_score is not None else "-"
+            epss = f"{v.epss_score:.4f}" if v.epss_score is not None else "-"
+            kev = "Yes" if v.is_kev else "-"
+            cwe = _md_cell(", ".join(v.cwe_ids) if v.cwe_ids else "-")
+            tags = _md_cell(_compliance_tags_text(br) or "-")
+            source = _md_cell(v.severity_source or "-")
             fix = v.fixed_version or "-"
             agents = str(len(br.affected_agents))
-            lines.append(f"| {sev_badge} | {v.id} | {br.package.name} | {br.package.version or '-'} | {fix} | {cvss} | {agents} |")
+            lines.append(
+                f"| {sev_badge} | {v.id} | {br.package.name} | {br.package.version or '-'} | {fix} | {cvss} | "
+                f"{epss} | {kev} | {cwe} | {tags} | {source} | {agents} |"
+            )
 
         lines.append("")
 
@@ -111,16 +120,27 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
                 lines.append(f"> {v.summary}")
                 lines.append("")
             lines.append(f"- **Severity**: {v.severity.value.upper()}")
+            if v.severity_source:
+                lines.append(f"- **Severity source**: {v.severity_source}")
             if v.cvss_score is not None:
                 lines.append(f"- **CVSS**: {v.cvss_score}")
             if v.epss_score is not None:
                 lines.append(f"- **EPSS**: {v.epss_score:.4f}")
+            if v.epss_percentile is not None:
+                lines.append(f"- **EPSS percentile**: {v.epss_percentile:.4f}")
             if v.is_kev:
                 lines.append("- **KEV**: Yes (CISA Known Exploited)")
+            if v.kev_date_added:
+                lines.append(f"- **KEV date added**: {v.kev_date_added}")
+            if v.kev_due_date:
+                lines.append(f"- **KEV due date**: {v.kev_due_date}")
             if v.fixed_version:
                 lines.append(f"- **Fix**: Upgrade to {v.fixed_version}")
             if v.cwe_ids:
                 lines.append(f"- **CWE**: {', '.join(v.cwe_ids)}")
+            compliance_tags = _compliance_tags_text(br)
+            if compliance_tags:
+                lines.append(f"- **Compliance tags**: {compliance_tags}")
             if br.affected_agents:
                 lines.append(f"- **Affected agents**: {', '.join(a.name for a in br.affected_agents)}")
             if br.exposed_credentials:
@@ -180,3 +200,8 @@ def _severity_text(sev: str) -> str:
 def _md_cell(value: object) -> str:
     """Escape Markdown table separators without hiding human-readable context."""
     return str(value).replace("|", "\\|")
+
+
+def _compliance_tags_text(br: BlastRadius) -> str:
+    """Return framework-qualified tags for compact Markdown rendering."""
+    return ", ".join(framework_qualified_blast_radius_tags(br))

--- a/src/agent_bom/output/spdx_fmt.py
+++ b/src/agent_bom/output/spdx_fmt.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from agent_bom.asset_provenance import package_version_provenance
+from agent_bom.compliance_utils import framework_qualified_blast_radius_tags
 from agent_bom.models import AIBOMReport
 
 
@@ -50,6 +51,7 @@ def to_spdx(report: AIBOMReport) -> dict:
     }
 
     pkg_ref_map: dict[str, str] = {}
+    vuln_compliance_tags = _blast_radius_compliance_tags(report)
 
     for agent in report.agents:
         agent_id = _next_id("SPDXRef-Agent")
@@ -179,6 +181,13 @@ def to_spdx(report: AIBOMReport) -> dict:
                         "description": vuln.summary or "",
                         "externalIdentifier": [{"type": "cve", "identifier": vuln.id}] if vuln.id.startswith("CVE-") else [],
                     }
+                    vuln_annotations = _vulnerability_annotations(
+                        vuln,
+                        vuln_element_id,
+                        compliance_tags=vuln_compliance_tags.get(_vulnerability_key(pkg, vuln), []),
+                    )
+                    if vuln_annotations:
+                        vuln_element["annotation"] = vuln_annotations
                     if vuln.cvss_score is not None:
                         vuln_element["assessedElement"] = pkg_id
                         vuln_element["score"] = {
@@ -223,3 +232,63 @@ def export_spdx(report: AIBOMReport, output_path: str) -> None:
     """Export report as SPDX 3.0 JSON-LD file."""
     data = to_spdx(report)
     Path(output_path).write_text(json.dumps(data, indent=2))
+
+
+def _vulnerability_annotations(vuln: Any, subject: str, *, compliance_tags: list[str] | None = None) -> list[dict[str, object]]:
+    """Encode non-core vulnerability enrichments as SPDX annotations."""
+    statements: list[str] = []
+    if vuln.severity_source:
+        statements.append(f"agent-bom:severity-source={vuln.severity_source}")
+    if vuln.epss_score is not None:
+        statements.append(f"agent-bom:epss-score={vuln.epss_score:.4f}")
+    if vuln.epss_percentile is not None:
+        statements.append(f"agent-bom:epss-percentile={vuln.epss_percentile:.4f}")
+    statements.append(f"agent-bom:kev={'true' if vuln.is_kev else 'false'}")
+    if vuln.kev_date_added:
+        statements.append(f"agent-bom:kev-date-added={vuln.kev_date_added}")
+    if vuln.kev_due_date:
+        statements.append(f"agent-bom:kev-due-date={vuln.kev_due_date}")
+    for cwe_id in vuln.cwe_ids:
+        statements.append(f"agent-bom:cwe={cwe_id}")
+    for tag in [*list(compliance_tags or []), *_vulnerability_compliance_tags(vuln)]:
+        statements.append(f"agent-bom:compliance-tag={tag}")
+
+    return [
+        {
+            "type": "Annotation",
+            "annotationType": "OTHER",
+            "subject": subject,
+            "statement": statement,
+        }
+        for statement in statements
+    ]
+
+
+def _vulnerability_compliance_tags(vuln: Any) -> list[str]:
+    """Return framework-qualified vulnerability compliance tags."""
+    raw_tags = getattr(vuln, "compliance_tags", None) or {}
+    if isinstance(raw_tags, dict):
+        tags: list[str] = []
+        for framework, controls in sorted(raw_tags.items()):
+            if isinstance(controls, str):
+                controls = [controls]
+            for control in controls or []:
+                tags.append(f"{framework}:{control}")
+        return tags
+    if isinstance(raw_tags, list | tuple | set):
+        return [str(tag) for tag in raw_tags if tag]
+    return []
+
+
+def _blast_radius_compliance_tags(report: AIBOMReport) -> dict[tuple[str, str, str | None, str], list[str]]:
+    """Return framework-qualified compliance tags keyed by package vulnerability."""
+    by_vuln: dict[tuple[str, str, str | None, str], list[str]] = {}
+    for br in report.blast_radii:
+        tags = framework_qualified_blast_radius_tags(br)
+        if tags:
+            by_vuln[_vulnerability_key(br.package, br.vulnerability)] = tags
+    return by_vuln
+
+
+def _vulnerability_key(pkg: Any, vuln: Any) -> tuple[str, str, str | None, str]:
+    return (pkg.ecosystem, pkg.name, pkg.version, vuln.id)

--- a/tests/fixtures/output/demo-markdown-golden.md
+++ b/tests/fixtures/output/demo-markdown-golden.md
@@ -19,12 +19,12 @@
 
 ## Findings
 
-| Severity | CVE | Package | Version | Fix | CVSS | Agents |
-|----------|-----|---------|---------|-----|------|--------|
-| **CRITICAL** | CVE-2024-0001 | lodash | 4.17.20 | 4.17.21 | 9.8 | 1 |
-| **HIGH** | CVE-2024-0002 | requests | 2.28.0 | 2.31.0 | 7.5 | 1 |
-| **MEDIUM** | CVE-2024-0003 | express | 4.18.0 | 4.17.21 | 5.3 | 1 |
-| **LOW** | CVE-2024-0004 | debug | 4.3.0 | 4.17.21 | 2.1 | 1 |
+| Severity | CVE | Package | Version | Fix | CVSS | EPSS | KEV | CWE | Tags | Source | Agents |
+|----------|-----|---------|---------|-----|------|------|-----|-----|------|--------|--------|
+| **CRITICAL** | CVE-2024-0001 | lodash | 4.17.20 | 4.17.21 | 9.8 | - | - | CWE-1321 | - | - | 1 |
+| **HIGH** | CVE-2024-0002 | requests | 2.28.0 | 2.31.0 | 7.5 | - | - | - | - | - | 1 |
+| **MEDIUM** | CVE-2024-0003 | express | 4.18.0 | 4.17.21 | 5.3 | - | - | - | - | - | 1 |
+| **LOW** | CVE-2024-0004 | debug | 4.3.0 | 4.17.21 | 2.1 | - | - | - | - | - | 1 |
 
 ## Critical & High Findings
 

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -23,7 +23,7 @@ from agent_bom.models import (
     TransportType,
     Vulnerability,
 )
-from agent_bom.output import to_csv, to_json, to_junit, to_markdown
+from agent_bom.output import to_csv, to_json, to_junit, to_markdown, to_spdx
 from agent_bom.output.html import to_html
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
@@ -95,6 +95,23 @@ def _make_vuln(
         cvss_score=cvss_score,
         fixed_version=fixed_version,
         cwe_ids=cwe_ids or [],
+    )
+
+
+def _make_enriched_vuln() -> Vulnerability:
+    return Vulnerability(
+        id="CVE-2026-4242",
+        severity=Severity.HIGH,
+        severity_source="nvd:cvss_v3",
+        summary="Enriched vulnerability",
+        cvss_score=8.8,
+        epss_score=0.812345,
+        epss_percentile=99.1234,
+        fixed_version="2.0.0",
+        is_kev=True,
+        kev_date_added="2026-01-15",
+        kev_due_date="2026-02-05",
+        cwe_ids=["CWE-79", "CWE-352"],
     )
 
 
@@ -306,6 +323,26 @@ class TestCSV:
         assert rows[0]["published_at"] == "2026-03-21T12:00:00Z"
         assert rows[0]["modified_at"] == "2026-03-23T09:00:00Z"
 
+    def test_enrichment_and_compliance_metadata_are_appended(self):
+        br = _make_blast_radius(pkg=_make_pkg("web-lib", "1.0.0"), vuln=_make_enriched_vuln())
+        br.owasp_tags = ["LLM05"]
+        br.soc2_tags = ["CC7.1"]
+        report = _make_report(blast_radii=[br])
+
+        csv_str = to_csv(report, [br])
+        reader = csv.DictReader(io.StringIO(csv_str.lstrip("\ufeff")))
+        row = next(reader)
+
+        assert row["cwe_ids"] == "CWE-79;CWE-352"
+        assert row["epss_score"] == "0.8123"
+        assert row["is_kev"] == "yes"
+        assert row["severity_source"] == "nvd:cvss_v3"
+        assert row["epss_percentile"] == "99.1234"
+        assert row["kev_date_added"] == "2026-01-15"
+        assert row["kev_due_date"] == "2026-02-05"
+        assert "owasp_llm:LLM05" in row["compliance_tags"]
+        assert "soc2:CC7.1" in row["compliance_tags"]
+
 
 class TestJSON:
     def test_nested_package_vulnerability_count_present(self):
@@ -473,6 +510,48 @@ class TestMarkdown:
         assert "snowflake-cortex-service" in md
         assert "Suspicious credential exfiltration MCP server" in md
         assert "No vulnerabilities found" not in md
+
+    def test_findings_table_preserves_enrichment_and_compliance_metadata(self):
+        br = _make_blast_radius(pkg=_make_pkg("web-lib", "1.0.0"), vuln=_make_enriched_vuln())
+        br.owasp_tags = ["LLM05"]
+        br.soc2_tags = ["CC7.1"]
+        report = _make_report(blast_radii=[br])
+
+        md = to_markdown(report, [br])
+
+        assert "| Severity | CVE | Package | Version | Fix | CVSS | EPSS | KEV | CWE | Tags | Source | Agents |" in md
+        assert "0.8123" in md
+        assert "Yes" in md
+        assert "CWE-79, CWE-352" in md
+        assert "owasp_llm:LLM05" in md
+        assert "soc2:CC7.1" in md
+        assert "nvd:cvss_v3" in md
+        assert "- **EPSS percentile**: 99.1234" in md
+        assert "- **KEV date added**: 2026-01-15" in md
+
+
+def test_spdx_vulnerability_annotations_preserve_enrichment_and_compliance_metadata():
+    vuln = _make_enriched_vuln()
+    pkg = _make_pkg("web-lib", "1.0.0")
+    pkg.vulnerabilities = [vuln]
+    br = _make_blast_radius(pkg=pkg, vuln=vuln)
+    br.owasp_tags = ["LLM05"]
+    br.soc2_tags = ["CC7.1"]
+    report = _make_report(agents=[_make_agent(servers=[_make_server(packages=[pkg])])], blast_radii=[br])
+
+    spdx = to_spdx(report)
+    vuln_element = next(element for element in spdx["elements"] if element.get("type") == "security/Vulnerability")
+    statements = {annotation["statement"] for annotation in vuln_element["annotation"]}
+
+    assert "agent-bom:severity-source=nvd:cvss_v3" in statements
+    assert "agent-bom:epss-score=0.8123" in statements
+    assert "agent-bom:epss-percentile=99.1234" in statements
+    assert "agent-bom:kev=true" in statements
+    assert "agent-bom:kev-date-added=2026-01-15" in statements
+    assert "agent-bom:cwe=CWE-79" in statements
+    assert "agent-bom:cwe=CWE-352" in statements
+    assert "agent-bom:compliance-tag=owasp_llm:LLM05" in statements
+    assert "agent-bom:compliance-tag=soc2:CC7.1" in statements
 
 
 def test_html_renders_unified_non_cve_findings_with_asset_context():


### PR DESCRIPTION
## Summary

Close the audit gap where non-JSON/SARIF export surfaces dropped vulnerability enrichment metadata needed by auditors and downstream tooling.

- append severity provenance, EPSS percentile, KEV dates, and framework-qualified compliance tags to CSV output
- include EPSS, KEV, CWE, compliance tags, and severity source in Markdown findings and high-risk detail sections
- preserve CWE, EPSS, KEV, severity source, and compliance tags in SPDX vulnerability annotations
- expose a shared helper for stable `framework:control` tag rendering so outputs use `owasp_llm:LLM05` / `soc2:CC7.1` instead of internal field names

## Root Cause

The shared finding model carried the enrichment fields, but CSV, Markdown, and SPDX formatters serialized only the original minimal vulnerability subset. That made JSON/SARIF richer than the human/auditor export paths and caused compliance evidence drift across surfaces.

## Validation

- `uv run pytest -q tests/test_output_formats.py tests/test_compliance_narrative.py`
- `uv run ruff check src/agent_bom/compliance_utils.py src/agent_bom/output/csv_fmt.py src/agent_bom/output/markdown.py src/agent_bom/output/spdx_fmt.py tests/test_output_formats.py`
- `uv run mypy src/agent_bom/compliance_utils.py src/agent_bom/output/csv_fmt.py src/agent_bom/output/markdown.py src/agent_bom/output/spdx_fmt.py --ignore-missing-imports --disable-error-code import-untyped`
- `git diff --check`
- commit hooks: ruff, ruff-format, mypy, bandit, env-var drift, duplicate artifact guard

## Release Gate Note

This is an export-contract hardening PR from the v0.86.5 audit. It does not claim broader release readiness.
