### PR TITLE
fix check agent mode envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - **Auditor export parity** - CSV, Markdown, and SPDX outputs now preserve
   severity provenance, EPSS percentile, KEV dates, CWE IDs, and framework
   compliance tags instead of dropping enrichment metadata outside JSON/SARIF.
+- **`agent-bom check --agent-mode` emitted Rich console tables** - pre-install
+  package checks now honor global agent mode and return the stable JSON
+  envelope instead of mixing human tables into automation output.
 
 ---
 

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -118,6 +118,19 @@ def main(ctx: click.Context, profile: str | None, agent_mode: bool):
         import os as _os
 
         _os.environ["AGENT_BOM_PROFILE"] = profile
+    if agent_mode:
+        import os as _os
+
+        previous_agent_mode = _os.environ.get(AGENT_MODE_ENV_VAR)
+        _os.environ[AGENT_MODE_ENV_VAR] = "1"
+
+        def _restore_agent_mode_env() -> None:
+            if previous_agent_mode is None:
+                _os.environ.pop(AGENT_MODE_ENV_VAR, None)
+            else:
+                _os.environ[AGENT_MODE_ENV_VAR] = previous_agent_mode
+
+        ctx.call_on_close(_restore_agent_mode_env)
     if ctx.invoked_subcommand is None:
         _print_startup_banner()
 

--- a/src/agent_bom/cli/_agent_mode.py
+++ b/src/agent_bom/cli/_agent_mode.py
@@ -160,6 +160,44 @@ def success_envelope(
     }
 
 
+def command_success_envelope(
+    *,
+    command: str,
+    data: dict[str, Any],
+    exit_code: int,
+    summary: dict[str, Any],
+    confidence: dict[str, Any],
+    error_type: str | None = None,
+) -> dict[str, Any]:
+    """Wrap a non-scan command payload in the stable agent-mode envelope."""
+    payload = {
+        "schema_version": AGENT_MODE_SCHEMA_VERSION,
+        "mode": "agent",
+        "ok": exit_code == 0,
+        "command": command,
+        "exit_code": exit_code,
+        "summary": summary,
+        "confidence": confidence,
+        "truncated": False,
+        "truncation": {
+            "enabled": False,
+            "truncated": False,
+            "token_budget": None,
+            "approx_tokens": None,
+            "removed": {},
+        },
+        "data": data,
+    }
+    if exit_code != 0:
+        error = {
+            "type": error_type or "command_exit",
+            "message": str(data.get("message") or f"{command} exited with code {exit_code}"),
+        }
+        payload["error"] = error
+        payload["errors"] = [error]
+    return payload
+
+
 def error_envelope(*, command: str | None, message: str, exit_code: int, error_type: str) -> dict[str, Any]:
     """Build the stable agent-mode error envelope."""
     error = {

--- a/src/agent_bom/cli/_check.py
+++ b/src/agent_bom/cli/_check.py
@@ -6,7 +6,7 @@ import json
 import sys
 from contextlib import nullcontext
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import click
 from rich.console import Console
@@ -92,6 +92,73 @@ def _parse_package_spec(
 def _write_json_output(payload: dict, output_path: str | None) -> None:
     """Write JSON to stdout or a file."""
     text = json.dumps(payload, indent=2)
+    if output_path and output_path != "-":
+        Path(output_path).write_text(text, encoding="utf-8")
+        return
+    click.echo(text)
+
+
+def _check_severity_counts(vulnerabilities: list | None) -> dict[str, int]:
+    counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0}
+    for vuln in vulnerabilities or []:
+        if isinstance(vuln, dict):
+            severity = str(vuln.get("severity") or "unknown").lower()
+        else:
+            severity = str(getattr(getattr(vuln, "severity", None), "value", "unknown")).lower()
+        counts[severity if severity in counts else "unknown"] += 1
+    return counts
+
+
+def _check_agent_summary(payload: dict) -> dict:
+    return {
+        "agents": 0,
+        "servers": None,
+        "packages": 1 if payload.get("package") else 0,
+        "vulnerabilities": int(payload.get("vulnerability_count") or 0),
+        "findings": 0,
+        "severity_counts": _check_severity_counts(payload.get("vulnerabilities")),
+        "posture_grade": None,
+        "verdict": payload.get("verdict"),
+        "package": payload.get("package"),
+        "version": payload.get("version"),
+    }
+
+
+def _check_agent_confidence(payload: dict) -> dict:
+    vulnerabilities = payload.get("vulnerabilities") or []
+    signals = [
+        {"name": "package_version", "present": bool(payload.get("version") and payload.get("version") != "unknown")},
+        {"name": "ecosystem", "present": bool(payload.get("ecosystems"))},
+        {"name": "advisory_backing", "present": bool(vulnerabilities)},
+        {"name": "external_enrichment", "present": any(bool(item.get("advisory_sources")) for item in vulnerabilities)},
+    ]
+    present = sum(1 for signal in signals if signal["present"])
+    level = "high" if present >= 3 else "medium" if present >= 2 else "low"
+    return {"level": level, "signals": signals}
+
+
+def _write_check_output(payload: dict, output_path: str | None, *, agent_mode: bool, exit_code: int) -> None:
+    """Write package-check output in plain JSON or agent-mode envelope form."""
+    if not agent_mode:
+        _write_json_output(payload, output_path)
+        return
+
+    from agent_bom.cli._agent_mode import command_success_envelope, dumps_envelope
+
+    error_type = None
+    if exit_code == 1:
+        error_type = "unsafe_package"
+    elif exit_code == 2:
+        error_type = "incomplete_scan"
+    envelope = command_success_envelope(
+        command="check",
+        data=payload,
+        exit_code=exit_code,
+        summary=_check_agent_summary(payload),
+        confidence=_check_agent_confidence(payload),
+        error_type=error_type,
+    )
+    text = dumps_envelope(envelope)
     if output_path and output_path != "-":
         Path(output_path).write_text(text, encoding="utf-8")
         return
@@ -357,7 +424,9 @@ def _exit_model_verification(
     help="Exit 1 only when vulnerabilities at this severity or higher are found.",
 )
 @click.option("--nvd-api-key", envvar="NVD_API_KEY", default=None, help="NVD API key for higher rate limits when using --enrich.")
+@click.pass_context
 def check(
+    ctx: click.Context,
     package_spec: str,
     ecosystem: Optional[str],
     quiet: bool,
@@ -399,7 +468,12 @@ def check(
     if output_path and output_format != "json":
         raise click.ClickException("`check --output` requires `--format json`.")
 
-    structured_output = output_format == "json"
+    from agent_bom.cli._agent_mode import agent_mode_requested
+
+    parent_params = getattr(getattr(ctx, "parent", None), "params", {}) or {}
+    root_params = getattr(ctx.find_root(), "params", {}) or {}
+    agent_mode = bool(parent_params.get("agent_mode") or root_params.get("agent_mode") or agent_mode_requested())
+    structured_output = output_format == "json" or agent_mode
     console = Console(no_color=no_color, stderr=structured_output or output_path is not None)
     runtime_console = Console(stderr=True, quiet=quiet or structured_output or output_path is not None, no_color=no_color)
     _sync_runtime_consoles(runtime_console)
@@ -412,7 +486,7 @@ def check(
     if version == "unknown":
         message = f"No version specified for {name}; skipping OSV lookup."
         if structured_output:
-            _write_json_output(
+            _write_check_output(
                 _check_result_payload(
                     name=name,
                     version=version,
@@ -422,6 +496,8 @@ def check(
                     exit_code=0,
                 ),
                 output_path,
+                agent_mode=agent_mode,
+                exit_code=0,
             )
         else:
             console.print(f"[yellow]⚠ No version specified for {name} — skipping OSV lookup.[/yellow]")
@@ -458,13 +534,13 @@ def check(
             version = next((p.version for p in pkgs if p.version not in ("unknown", "latest", "")), version)
             for p in pkgs:
                 p.version = version
-            if not quiet:
+            if not quiet and not structured_output:
                 console.print(f"  [green]✓ Resolved @latest → {version}[/green]")
         else:
             eco_str = "/".join(ecosystems)
             message = f"Could not resolve latest version for {name} ({eco_str})."
             if structured_output:
-                _write_json_output(
+                _write_check_output(
                     _check_result_payload(
                         name=name,
                         version=version,
@@ -474,6 +550,8 @@ def check(
                         exit_code=0,
                     ),
                     output_path,
+                    agent_mode=agent_mode,
+                    exit_code=0,
                 )
             else:
                 console.print(f"[yellow]⚠ Could not resolve latest version for {name} ({eco_str})[/yellow]")
@@ -481,12 +559,16 @@ def check(
             sys.exit(0)
 
     eco_display = "/".join(ecosystems)
-    if not quiet:
+    if not quiet and not structured_output:
         console.print(f"\n[bold blue]🔍 Checking {name}@{version} ({eco_display})[/bold blue]\n")
 
     import asyncio
 
-    status_context = console.status("[bold]Scanning package risk...[/bold]", spinner="dots") if not quiet else nullcontext()
+    status_context: Any
+    if not quiet and not structured_output:
+        status_context = console.status("[bold]Scanning package risk...[/bold]", spinner="dots")
+    else:
+        status_context = nullcontext()
 
     with status_context:
         from agent_bom.scanners import IncompleteScanError, ScanOptions, consume_scan_warnings, scan_packages
@@ -495,7 +577,7 @@ def check(
             asyncio.run(scan_packages(pkgs, options=ScanOptions(offline=False)))
         except IncompleteScanError as exc:
             if structured_output:
-                _write_json_output(
+                _write_check_output(
                     _check_result_payload(
                         name=name,
                         version=version,
@@ -505,13 +587,15 @@ def check(
                         exit_code=2,
                     ),
                     output_path,
+                    agent_mode=agent_mode,
+                    exit_code=2,
                 )
             else:
                 console.print(f"  [yellow]⚠[/yellow] {exc}")
             sys.exit(2)
 
     scan_warnings = consume_scan_warnings()
-    if scan_warnings and not quiet:
+    if scan_warnings and not quiet and not structured_output:
         console.print(f"  [yellow]⚠[/yellow] Scan completed with {len(scan_warnings)} warning(s); results may be incomplete.")
 
     matched_pkg = next((p for p in pkgs if p.vulnerabilities), pkgs[0])
@@ -543,7 +627,7 @@ def check(
             "Best-effort matching found no vulnerabilities, but distro metadata was insufficient for a trustworthy clean verdict."
         )
         if structured_output:
-            _write_json_output(
+            _write_check_output(
                 _check_result_payload(
                     name=name,
                     version=version,
@@ -554,6 +638,8 @@ def check(
                     warnings=scan_warnings,
                 ),
                 output_path,
+                agent_mode=agent_mode,
+                exit_code=2,
             )
             sys.exit(2)
         if quiet:
@@ -568,7 +654,7 @@ def check(
 
     if not vulns:
         if structured_output:
-            _write_json_output(
+            _write_check_output(
                 _check_result_payload(
                     name=name,
                     version=version,
@@ -579,6 +665,8 @@ def check(
                     warnings=scan_warnings,
                 ),
                 output_path,
+                agent_mode=agent_mode,
+                exit_code=0,
             )
             sys.exit(0)
         if quiet:
@@ -587,7 +675,7 @@ def check(
             console.print(f"  [green]✓ No known vulnerabilities in {name}@{version}[/green]\n")
         sys.exit(0)
 
-    if not quiet:
+    if not quiet and not structured_output:
         from rich.table import Table
 
         from agent_bom.cwe_impact import classify_cwe_impact
@@ -645,7 +733,7 @@ def check(
 
     if exit_zero:
         if structured_output:
-            _write_json_output(
+            _write_check_output(
                 _check_result_payload(
                     name=name,
                     version=version,
@@ -660,6 +748,8 @@ def check(
                     fail_on_severity_count=len(_vulns_at_or_above(vulns, fail_threshold)),
                 ),
                 output_path,
+                agent_mode=agent_mode,
+                exit_code=0,
             )
             sys.exit(0)
         if quiet:
@@ -674,7 +764,7 @@ def check(
     if fail_threshold and not failing_vulns:
         message = f"{_format_vulnerability_count(len(vulns))} in {name}@{version}; none at or above {fail_threshold}."
         if structured_output:
-            _write_json_output(
+            _write_check_output(
                 _check_result_payload(
                     name=name,
                     version=version,
@@ -688,6 +778,8 @@ def check(
                     fail_on_severity_count=0,
                 ),
                 output_path,
+                agent_mode=agent_mode,
+                exit_code=0,
             )
             sys.exit(0)
         if quiet:
@@ -697,7 +789,7 @@ def check(
         sys.exit(0)
 
     if structured_output:
-        _write_json_output(
+        _write_check_output(
             _check_result_payload(
                 name=name,
                 version=version,
@@ -711,6 +803,8 @@ def check(
                 fail_on_severity_count=len(failing_vulns),
             ),
             output_path,
+            agent_mode=agent_mode,
+            exit_code=1,
         )
         sys.exit(1)
 

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from urllib.parse import urlparse
 
 from click.testing import CliRunner
@@ -351,6 +352,57 @@ def test_check_json_output_is_machine_readable(monkeypatch):
     assert payload["verdict"] == "unsafe"
     assert payload["vulnerability_count"] == 1
     assert payload["vulnerabilities"][0]["id"] == "CVE-2023-30861"
+
+
+def test_check_agent_mode_emits_machine_envelope_without_rich_table(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_AGENT_MODE", raising=False)
+    _patch_check_scan(
+        monkeypatch,
+        [
+            Vulnerability(
+                id="CVE-2023-30861",
+                summary="Session cookie disclosure",
+                severity=Severity.HIGH,
+                fixed_version="2.3.2",
+            )
+        ],
+    )
+
+    result = CliRunner().invoke(main, ["--agent-mode", "check", "flask@2.2.0", "--ecosystem", "pypi"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["schema_version"] == "1"
+    assert payload["mode"] == "agent"
+    assert payload["ok"] is False
+    assert payload["command"] == "check"
+    assert payload["exit_code"] == 1
+    assert payload["error"]["type"] == "unsafe_package"
+    assert payload["summary"]["packages"] == 1
+    assert payload["summary"]["vulnerabilities"] == 1
+    assert payload["summary"]["severity_counts"]["high"] == 1
+    assert payload["data"]["document_type"] == "PACKAGE-CHECK"
+    assert payload["data"]["vulnerabilities"][0]["id"] == "CVE-2023-30861"
+    assert "flask@2.2.0 — 1 vulnerability found" not in result.output
+    assert "┏" not in result.output
+    assert "AGENT_BOM_AGENT_MODE" not in os.environ
+
+
+def test_check_agent_mode_env_emits_clean_envelope_for_clean_package(monkeypatch):
+    _patch_check_scan(monkeypatch, [])
+
+    result = CliRunner().invoke(
+        main,
+        ["check", "django@4.1.0", "--ecosystem", "pypi"],
+        env={"AGENT_BOM_AGENT_MODE": "1"},
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["mode"] == "agent"
+    assert payload["ok"] is True
+    assert payload["data"]["verdict"] == "clean"
+    assert payload["summary"]["vulnerabilities"] == 0
 
 
 def test_check_output_requires_json_format(monkeypatch):


### PR DESCRIPTION
## Summary

Close the P0 audit gap where `agent-bom check --agent-mode` still emitted Rich console output instead of the stable machine-readable agent envelope.

- make global `--agent-mode` visible to subcommands through `AGENT_BOM_AGENT_MODE`
- wrap `agent-bom check` structured payloads in the v1 agent-mode envelope when global agent mode or `AGENT_BOM_AGENT_MODE=1` is active
- suppress Rich status/table output for check invocations in structured/agent mode
- preserve the existing `--format json` package-check payload for non-agent callers
- add regressions for unsafe and clean package checks in agent mode

## Root Cause

`check` only switched to structured output when `--format json` was passed. The global `--agent-mode` flag lived on the root Click group and was not consulted by the package-check command, so automation received human Rich tables followed by JSON-compatible behavior only when users manually added `--format json`.

## Validation

- `uv run pytest -q tests/test_cli_check.py tests/test_contract_schemas.py`
- `uv run ruff check src/agent_bom/cli/__init__.py src/agent_bom/cli/_agent_mode.py src/agent_bom/cli/_check.py tests/test_cli_check.py tests/test_contract_schemas.py`
- `uv run mypy src/agent_bom/cli/_agent_mode.py src/agent_bom/cli/_check.py --ignore-missing-imports --disable-error-code import-untyped`
- `git diff --check`
- commit hooks: ruff, ruff-format, mypy, bandit, env-var drift, duplicate artifact guard

## Release Gate Note

This is an automation-contract hotfix for the audit P0. It does not claim broader release readiness.
