### PR TITLE
fix graph command center proof

### DIFF
--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -191,6 +191,7 @@ export default function MeshPage() {
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [activeJob, setActiveJob] = useState<ScanJob | null>(null);
   const [layoutMode, setLayoutMode] = useState<MeshLayoutMode>("topology");
+  const [pathFocusEnabled, setPathFocusEnabled] = useState(true);
 
   // Filters
   const [nodeFilter, setNodeFilter] = useState<NodeTypeFilter>({
@@ -349,6 +350,11 @@ export default function MeshPage() {
     [hoveredNodeId, visibleEdges]
   );
 
+  const pathFocusIds = useMemo(() => {
+    if (!pathFocusEnabled || !stats.topExposurePath || searchQuery || hoveredNodeId) return null;
+    return new Set(stats.topExposurePath.nodeIds);
+  }, [hoveredNodeId, pathFocusEnabled, searchQuery, stats.topExposurePath]);
+
   const displayNodes = useMemo(() => {
     if (searchMatches && searchMatches.size > 0) {
       return visibleNodes?.map((n) => ({
@@ -356,22 +362,28 @@ export default function MeshPage() {
         data: { ...n.data, dimmed: !searchMatches.has(n.id), highlighted: searchMatches.has(n.id) },
       }));
     }
+    if (pathFocusIds) {
+      return visibleNodes?.map((n) => ({
+        ...n,
+        data: { ...n.data, dimmed: !pathFocusIds.has(n.id), highlighted: pathFocusIds.has(n.id) },
+      }));
+    }
     if (!connectedIds) return visibleNodes;
     return visibleNodes?.map((n) => ({
       ...n,
       data: { ...n.data, dimmed: !connectedIds.has(n.id), highlighted: connectedIds.has(n.id) },
     }));
-  }, [visibleNodes, connectedIds, searchMatches]);
+  }, [visibleNodes, connectedIds, searchMatches, pathFocusIds]);
 
   const displayEdges = useMemo(() => {
-    const activeSet = searchMatches && searchMatches.size > 0 ? searchMatches : connectedIds;
+    const activeSet = searchMatches && searchMatches.size > 0 ? searchMatches : connectedIds ?? pathFocusIds;
     return readableGraphEdges(visibleEdges, activeSet, {
       baseOpacity: 0.3,
       highSignalOpacity: 0.58,
       inactiveOpacity: 0.06,
       captureMode,
     });
-  }, [visibleEdges, connectedIds, searchMatches, captureMode]);
+  }, [visibleEdges, connectedIds, searchMatches, pathFocusIds, captureMode]);
 
   const legendItems = useMemo(
     () => legendItemsForVisibleGraph(displayNodes, displayEdges),
@@ -512,7 +524,11 @@ export default function MeshPage() {
       </div>
 
       {/* Stats bar */}
-      <MeshStats stats={stats} />
+      <MeshStats
+        stats={stats}
+        pathFocusActive={Boolean(pathFocusIds)}
+        onTogglePathFocus={stats.topExposurePath ? () => setPathFocusEnabled((current) => !current) : undefined}
+      />
 
       {/* Filter toolbar */}
       <MeshToolbar

--- a/ui/components/mesh-stats.tsx
+++ b/ui/components/mesh-stats.tsx
@@ -1,11 +1,19 @@
 "use client";
 
-import { Server, KeyRound, Wrench, ShieldAlert, Package, Bug, AlertTriangle } from "lucide-react";
+import { Crosshair, Server, KeyRound, Wrench, ShieldAlert, Package, Bug, AlertTriangle } from "lucide-react";
 import type { MeshStatsData } from "@/lib/mesh-graph";
 
 export type { MeshStatsData };
 
-export function MeshStats({ stats }: { stats: MeshStatsData }) {
+export function MeshStats({
+  stats,
+  pathFocusActive = false,
+  onTogglePathFocus,
+}: {
+  stats: MeshStatsData;
+  pathFocusActive?: boolean;
+  onTogglePathFocus?: (() => void) | undefined;
+}) {
   const totalSev = stats.criticalCount + stats.highCount + stats.mediumCount + stats.lowCount;
   const omittedTotal =
     stats.omittedCredentials +
@@ -14,82 +22,133 @@ export function MeshStats({ stats }: { stats: MeshStatsData }) {
     stats.omittedVulnerabilities;
 
   return (
-    <div className="flex items-center gap-4 px-4 py-2 border-b border-[var(--border-subtle)] text-xs flex-wrap">
-      <Stat icon={ShieldAlert} label="Agents" value={stats.totalAgents} color="text-emerald-400" />
-      <Stat icon={Server} label="Shared Servers" value={stats.sharedServers} color="text-cyan-400" />
-      <Stat icon={Package} label="Packages" value={stats.totalPackages} color="text-zinc-400" />
-      <Stat icon={Bug} label="Vulns" value={stats.totalVulnerabilities} color="text-red-400" />
-      <Stat icon={KeyRound} label="Credential refs" value={stats.uniqueCredentials} color="text-amber-400" />
-      <Stat icon={Wrench} label="Tool Overlap" value={stats.toolOverlap} color="text-purple-400" />
-
-      {/* Severity breakdown mini-bar */}
-      {totalSev > 0 && (
-        <div className="flex items-center gap-1.5 ml-2">
-          <span className="text-[var(--text-secondary)]">Severity:</span>
-          <div className="flex h-2.5 rounded-full overflow-hidden w-24 bg-zinc-800">
-            {stats.criticalCount > 0 && (
-              <div
-                className="bg-red-500 h-full"
-                style={{ width: `${(stats.criticalCount / totalSev) * 100}%` }}
-                title={`${stats.criticalCount} critical`}
-              />
+    <div className="border-b border-[var(--border-subtle)]">
+      {stats.topExposurePath && (
+        <div className="flex flex-wrap items-center gap-3 border-b border-[var(--border-subtle)] bg-red-950/20 px-4 py-2.5 text-xs">
+          <div className="flex min-w-0 flex-1 items-center gap-3">
+            <span className="inline-flex items-center gap-1 rounded border border-red-500/40 bg-red-500/10 px-2 py-1 font-semibold uppercase text-red-200">
+              <Crosshair className="h-3.5 w-3.5" />
+              Top exposed path
+            </span>
+            <span className="rounded bg-red-500/15 px-2 py-0.5 font-mono text-[11px] uppercase text-red-200">
+              {stats.topExposurePath.severity}
+            </span>
+            <span className="min-w-0 truncate text-[var(--text-secondary)]" title={stats.topExposurePath.label}>
+              {stats.topExposurePath.label}
+            </span>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-secondary)]">
+            <span>
+              risk <b className="text-foreground">{Math.round(stats.topExposurePath.riskScore * 10) / 10}</b>
+            </span>
+            <span>
+              agents <b className="text-foreground">{stats.topExposurePath.affectedAgents.length}</b>
+            </span>
+            {stats.topExposurePath.reachableTools.length > 0 && (
+              <span>
+                tools <b className="text-foreground">{stats.topExposurePath.reachableTools.length}</b>
+              </span>
             )}
-            {stats.highCount > 0 && (
-              <div
-                className="bg-orange-500 h-full"
-                style={{ width: `${(stats.highCount / totalSev) * 100}%` }}
-                title={`${stats.highCount} high`}
-              />
+            {stats.topExposurePath.exposedCredentials.length > 0 && (
+              <span>
+                creds <b className="text-foreground">{stats.topExposurePath.exposedCredentials.length}</b>
+              </span>
             )}
-            {stats.mediumCount > 0 && (
-              <div
-                className="bg-yellow-500 h-full"
-                style={{ width: `${(stats.mediumCount / totalSev) * 100}%` }}
-                title={`${stats.mediumCount} medium`}
-              />
+            {stats.topExposurePath.fixedVersion && (
+              <span>
+                fix <b className="text-emerald-300">{stats.topExposurePath.fixedVersion}</b>
+              </span>
             )}
-            {stats.lowCount > 0 && (
-              <div
-                className="bg-blue-500 h-full"
-                style={{ width: `${(stats.lowCount / totalSev) * 100}%` }}
-                title={`${stats.lowCount} low`}
-              />
+            {onTogglePathFocus && (
+              <button
+                type="button"
+                onClick={onTogglePathFocus}
+                className="rounded border border-red-500/30 px-2 py-1 text-red-200 transition hover:border-red-400 hover:bg-red-500/10"
+              >
+                {pathFocusActive ? "Show all" : "Focus path"}
+              </button>
             )}
           </div>
-          {stats.criticalCount > 0 && (
-            <span className="text-red-400 font-semibold">{stats.criticalCount}C</span>
-          )}
-          {stats.highCount > 0 && (
-            <span className="text-orange-400 font-semibold">{stats.highCount}H</span>
-          )}
         </div>
       )}
 
-      {/* KEV badge */}
-      {stats.kevCount > 0 && (
-        <div className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-red-900/60 border border-red-700">
-          <AlertTriangle className="w-3 h-3 text-red-400" />
-          <span className="text-red-300 font-mono text-[10px]">{stats.kevCount} KEV</span>
-        </div>
-      )}
+      <div className="flex items-center gap-4 px-4 py-2 text-xs flex-wrap">
+        <Stat icon={ShieldAlert} label="Agents" value={stats.totalAgents} color="text-emerald-400" />
+        <Stat icon={Server} label="Shared Servers" value={stats.sharedServers} color="text-cyan-400" />
+        <Stat icon={Package} label="Packages" value={stats.totalPackages} color="text-zinc-400" />
+        <Stat icon={Bug} label="Vulns" value={stats.totalVulnerabilities} color="text-red-400" />
+        <Stat icon={KeyRound} label="Credential refs" value={stats.uniqueCredentials} color="text-amber-400" />
+        <Stat icon={Wrench} label="Tool Overlap" value={stats.toolOverlap} color="text-purple-400" />
 
-      {omittedTotal > 0 && (
-        <div className="flex items-center gap-1 rounded border border-[var(--border-subtle)] bg-[var(--surface-muted)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)]">
-          <span className="font-semibold text-foreground">{omittedTotal}</span>
-          <span>lower-priority nodes hidden</span>
-        </div>
-      )}
+        {/* Severity breakdown mini-bar */}
+        {totalSev > 0 && (
+          <div className="flex items-center gap-1.5 ml-2">
+            <span className="text-[var(--text-secondary)]">Severity:</span>
+            <div className="flex h-2.5 rounded-full overflow-hidden w-24 bg-zinc-800">
+              {stats.criticalCount > 0 && (
+                <div
+                  className="bg-red-500 h-full"
+                  style={{ width: `${(stats.criticalCount / totalSev) * 100}%` }}
+                  title={`${stats.criticalCount} critical`}
+                />
+              )}
+              {stats.highCount > 0 && (
+                <div
+                  className="bg-orange-500 h-full"
+                  style={{ width: `${(stats.highCount / totalSev) * 100}%` }}
+                  title={`${stats.highCount} high`}
+                />
+              )}
+              {stats.mediumCount > 0 && (
+                <div
+                  className="bg-yellow-500 h-full"
+                  style={{ width: `${(stats.mediumCount / totalSev) * 100}%` }}
+                  title={`${stats.mediumCount} medium`}
+                />
+              )}
+              {stats.lowCount > 0 && (
+                <div
+                  className="bg-blue-500 h-full"
+                  style={{ width: `${(stats.lowCount / totalSev) * 100}%` }}
+                  title={`${stats.lowCount} low`}
+                />
+              )}
+            </div>
+            {stats.criticalCount > 0 && (
+              <span className="text-red-400 font-semibold">{stats.criticalCount}C</span>
+            )}
+            {stats.highCount > 0 && (
+              <span className="text-orange-400 font-semibold">{stats.highCount}H</span>
+            )}
+          </div>
+        )}
 
-      {/* Credential blast */}
-      {stats.credentialBlast.length > 0 && (
-        <div className="ml-auto flex items-center gap-1.5 text-amber-400">
-          <KeyRound className="w-3 h-3" />
-          <span className="text-[10px]">
-            {stats.credentialBlast.slice(0, 2).join(", ")}
-            {stats.credentialBlast.length > 2 && ` +${stats.credentialBlast.length - 2}`}
-          </span>
-        </div>
-      )}
+        {/* KEV badge */}
+        {stats.kevCount > 0 && (
+          <div className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-red-900/60 border border-red-700">
+            <AlertTriangle className="w-3 h-3 text-red-400" />
+            <span className="text-red-300 font-mono text-[10px]">{stats.kevCount} KEV</span>
+          </div>
+        )}
+
+        {omittedTotal > 0 && (
+          <div className="flex items-center gap-1 rounded border border-[var(--border-subtle)] bg-[var(--surface-muted)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)]">
+            <span className="font-semibold text-foreground">{omittedTotal}</span>
+            <span>lower-priority nodes hidden</span>
+          </div>
+        )}
+
+        {/* Credential blast */}
+        {stats.credentialBlast.length > 0 && (
+          <div className="ml-auto flex items-center gap-1.5 text-amber-400">
+            <KeyRound className="w-3 h-3" />
+            <span className="text-[10px]">
+              {stats.credentialBlast.slice(0, 2).join(", ")}
+              {stats.credentialBlast.length > 2 && ` +${stats.credentialBlast.length - 2}`}
+            </span>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/ui/components/scan-mesh.tsx
+++ b/ui/components/scan-mesh.tsx
@@ -22,6 +22,7 @@ export function ScanMeshView({ id }: { id: string }) {
   const [error, setError] = useState<string | null>(null);
   const [selectedNode, setSelectedNode] = useState<LineageNodeData | null>(null);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+  const [pathFocusEnabled, setPathFocusEnabled] = useState(true);
 
   useEffect(() => {
     api.getScan(id).then(setJob).catch((e) => setError(e.message)).finally(() => setLoading(false));
@@ -49,19 +50,29 @@ export function ScanMeshView({ id }: { id: string }) {
   });
 
   const connectedIds = useMemo(() => (hoveredNodeId ? getConnectedIds(hoveredNodeId, layoutEdges) : null), [hoveredNodeId, layoutEdges]);
+  const pathFocusIds = useMemo(() => {
+    if (!pathFocusEnabled || !stats.topExposurePath || hoveredNodeId) return null;
+    return new Set(stats.topExposurePath.nodeIds);
+  }, [hoveredNodeId, pathFocusEnabled, stats.topExposurePath]);
 
   const displayNodes = useMemo(() => {
+    if (pathFocusIds) {
+      return layoutNodes?.map((n) => ({
+        ...n,
+        data: { ...n.data, dimmed: !pathFocusIds.has(n.id), highlighted: pathFocusIds.has(n.id) },
+      }));
+    }
     if (!connectedIds) return layoutNodes;
     return layoutNodes?.map((n) => ({ ...n, data: { ...n.data, dimmed: !connectedIds.has(n.id), highlighted: connectedIds.has(n.id) } }));
-  }, [layoutNodes, connectedIds]);
+  }, [layoutNodes, connectedIds, pathFocusIds]);
 
   const displayEdges = useMemo(() => {
-    return readableGraphEdges(layoutEdges, connectedIds, {
+    return readableGraphEdges(layoutEdges, connectedIds ?? pathFocusIds, {
       baseOpacity: 0.3,
       highSignalOpacity: 0.58,
       inactiveOpacity: 0.06,
     });
-  }, [layoutEdges, connectedIds]);
+  }, [layoutEdges, connectedIds, pathFocusIds]);
 
   const legendItems = useMemo(() => legendItemsForVisibleNodes(displayNodes), [displayNodes]);
 
@@ -93,7 +104,11 @@ export function ScanMeshView({ id }: { id: string }) {
         </div>
         <GraphLegend items={legendItems} />
       </div>
-      <MeshStats stats={stats} />
+      <MeshStats
+        stats={stats}
+        pathFocusActive={Boolean(pathFocusIds)}
+        onTogglePathFocus={stats.topExposurePath ? () => setPathFocusEnabled((current) => !current) : undefined}
+      />
       <div className="flex-1 relative">
         <ReactFlow
           nodes={displayNodes} edges={displayEdges} nodeTypes={lineageNodeTypes}

--- a/ui/lib/mesh-graph.ts
+++ b/ui/lib/mesh-graph.ts
@@ -26,6 +26,30 @@ export interface MeshStatsData {
   mediumCount: number;
   lowCount: number;
   kevCount: number;
+  topExposurePath?: MeshExposurePath | undefined;
+}
+
+export interface MeshExposurePath {
+  label: string;
+  vulnerabilityId: string;
+  severity: VulnerabilitySeverity;
+  packageName: string;
+  packageVersion: string;
+  ecosystem: string;
+  serverName: string;
+  affectedAgents: string[];
+  affectedServers: string[];
+  exposedCredentials: string[];
+  reachableTools: string[];
+  riskScore: number;
+  cvssScore?: number | undefined;
+  epssScore?: number | undefined;
+  isKev: boolean;
+  fixedVersion?: string | undefined;
+  impactCategory?: string | undefined;
+  attackVectorSummary?: string | undefined;
+  nodeIds: string[];
+  edgeIds: string[];
 }
 
 export interface ServerGroup {
@@ -261,6 +285,31 @@ function compareVulnerabilities(left: Vulnerability, right: Vulnerability): numb
   return (right.epss_score ?? 0) - (left.epss_score ?? 0);
 }
 
+function uniqueStrings(values: (string | undefined)[]): string[] {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))];
+}
+
+function blastRiskScore(vuln: Vulnerability, blast: ScanResult["blast_radius"][number] | undefined): number {
+  const direct = blast?.risk_score ?? blast?.blast_score;
+  if (typeof direct === "number" && Number.isFinite(direct)) return direct;
+  const severityBase = severityWeight(vuln.severity) * 20;
+  const cvssBoost = typeof vuln.cvss_score === "number" ? vuln.cvss_score : 0;
+  const epssBoost = typeof vuln.epss_score === "number" ? vuln.epss_score * 10 : 0;
+  const kevBoost = vuln.cisa_kev || vuln.is_kev ? 12 : 0;
+  return Math.round((severityBase + cvssBoost + epssBoost + kevBoost) * 10) / 10;
+}
+
+function betterExposurePath(left: MeshExposurePath | undefined, right: MeshExposurePath): MeshExposurePath {
+  if (!left) return right;
+  if (right.riskScore !== left.riskScore) return right.riskScore > left.riskScore ? right : left;
+  const severityDiff = severityWeight(right.severity) - severityWeight(left.severity);
+  if (severityDiff !== 0) return severityDiff > 0 ? right : left;
+  if (right.affectedAgents.length !== left.affectedAgents.length) {
+    return right.affectedAgents.length > left.affectedAgents.length ? right : left;
+  }
+  return right.vulnerabilityId.localeCompare(left.vulnerabilityId) < 0 ? right : left;
+}
+
 function normalizeSeverity(severity: string | undefined): VulnerabilitySeverity {
   const normalized = String(severity ?? "none").toLowerCase();
   if (normalized === "critical" || normalized === "high" || normalized === "medium" || normalized === "low") {
@@ -366,6 +415,7 @@ export function buildMeshGraph(
   let mediumCount = 0;
   let lowCount = 0;
   let kevCount = 0;
+  let topExposurePath: MeshExposurePath | undefined;
 
   // ── Agent nodes ──
   for (const agent of activeAgents) {
@@ -673,6 +723,57 @@ export function buildMeshGraph(
                 color: sevColor(vuln.severity),
               },
             });
+
+            const affectedAgentKeys = [...group.agents].filter((agentKey) => {
+              const affected = br?.affected_agents ?? [];
+              if (affected.length === 0) return true;
+              const label = group.agentLabels.get(agentKey) ?? "";
+              return affected.includes(agentKey) || affected.includes(agentKey.split("@")[0] ?? agentKey) || affected.includes(label);
+            });
+            const pathAgentKeys = affectedAgentKeys.length > 0 ? affectedAgentKeys : [...group.agents].slice(0, 1);
+            const pathAgentIds = pathAgentKeys.map(meshAgentNodeId);
+            const reachableTools = uniqueStrings([...(br?.reachable_tools ?? []), ...(br?.exposed_tools ?? [])]);
+            const exposedCredentials = uniqueStrings(br?.exposed_credentials ?? []);
+            const toolNodeIds = reachableTools
+              .slice(0, 2)
+              .map((tool) => `tool:${serverId}:${tool}`)
+              .filter((nodeId) => seen.has(nodeId));
+            const credentialNodeIds = exposedCredentials
+              .slice(0, 2)
+              .map((credential) => `cred:${serverId}:${credential}`)
+              .filter((nodeId) => seen.has(nodeId));
+            const pathNodeIds = uniqueStrings([...pathAgentIds, serverId, pkgId, vulnId, ...toolNodeIds, ...credentialNodeIds]);
+            const pathEdgeIds = uniqueStrings([
+              ...pathAgentKeys.map((agentKey) => `${meshAgentNodeId(agentKey)}->${serverId}`),
+              `${serverId}->${pkgId}`,
+              `${pkgId}->${vulnId}`,
+              ...toolNodeIds.map((nodeId) => `${serverId}->${nodeId}`),
+              ...credentialNodeIds.map((nodeId) => `${serverId}->${nodeId}`),
+            ]);
+            const affectedAgents = pathAgentKeys.map((agentKey) => group.agentLabels.get(agentKey) ?? agentKey);
+            const riskScore = blastRiskScore(vuln, br);
+            topExposurePath = betterExposurePath(topExposurePath, {
+              label: `${affectedAgents.slice(0, 2).join(", ")} -> ${group.name} -> ${pkg.name}@${pkg.version} -> ${vuln.id}`,
+              vulnerabilityId: vuln.id,
+              severity: vuln.severity,
+              packageName: pkg.name,
+              packageVersion: pkg.version,
+              ecosystem: pkg.ecosystem,
+              serverName: group.name,
+              affectedAgents,
+              affectedServers: br?.affected_servers?.length ? br.affected_servers : [group.name],
+              exposedCredentials,
+              reachableTools,
+              riskScore,
+              cvssScore: vuln.cvss_score,
+              epssScore: vuln.epss_score,
+              isKev: Boolean(vuln.cisa_kev || vuln.is_kev),
+              fixedVersion: vuln.fixed_version,
+              impactCategory: br?.impact_category,
+              attackVectorSummary: br?.attack_vector_summary,
+              nodeIds: pathNodeIds,
+              edgeIds: pathEdgeIds,
+            });
           }
         }
       }
@@ -696,6 +797,7 @@ export function buildMeshGraph(
     mediumCount,
     lowCount,
     kevCount,
+    topExposurePath,
   };
 
   return { nodes, edges, stats };

--- a/ui/tests/mesh-graph.test.ts
+++ b/ui/tests/mesh-graph.test.ts
@@ -85,12 +85,104 @@ describe("buildMeshGraph", () => {
     );
 
     expect(stats.totalAgents).toBe(2);
+    expect(stats.topExposurePath?.vulnerabilityId).toBe("CVE-2026-0001");
+    expect(stats.topExposurePath?.nodeIds).toEqual(
+      expect.arrayContaining([
+        "agent:claude-desktop",
+        "agent:cursor",
+        "server:filesystem::",
+        "pkg:server:filesystem:::npm:server-filesystem@1.0.0",
+        "vuln:server-filesystem:CVE-2026-0001",
+      ]),
+    );
+    expect(stats.topExposurePath?.reachableTools).toEqual(["read_file"]);
     expect(nodes.filter((node) => node.id === "agent:cursor")).toHaveLength(1);
     expect(nodes.some((node) => node.id === "agent:claude-desktop")).toBe(true);
     expect(nodes.some((node) => node.id === "agent:cursor")).toBe(true);
     expect(nodes.some((node) => node.id === "agent:zed")).toBe(false);
     expect(edges.some((edge) => edge.id === "agent:claude-desktop->server:filesystem::")).toBe(true);
     expect(edges.some((edge) => edge.id === "agent:cursor->server:filesystem::")).toBe(true);
+  });
+
+  it("ranks the mesh command path by blast score, severity, and blast radius evidence", () => {
+    const result: ScanResult = {
+      agents: [
+        {
+          name: "analyst-agent",
+          agent_type: "desktop",
+          mcp_servers: [
+            {
+              name: "database",
+              packages: [
+                {
+                  name: "pillow",
+                  version: "9.0.0",
+                  ecosystem: "pypi",
+                  vulnerabilities: [{ id: "CVE-2022-22817", severity: "high", fixed_version: "9.0.1" }],
+                },
+                {
+                  name: "werkzeug",
+                  version: "2.2.2",
+                  ecosystem: "pypi",
+                  vulnerabilities: [{ id: "CVE-2023-25577", severity: "critical", fixed_version: "2.2.3" }],
+                },
+              ],
+              tools: [
+                { name: "read_file", description: "Read a file" },
+                { name: "execute_sql", description: "Run SQL" },
+              ],
+              env: {
+                DATABASE_URL: "redacted",
+              },
+            },
+          ],
+        },
+      ],
+      blast_radius: [
+        {
+          vulnerability_id: "CVE-2022-22817",
+          severity: "high",
+          package: "pillow",
+          affected_agents: ["analyst-agent"],
+          affected_servers: ["database"],
+          exposed_credentials: [],
+          reachable_tools: ["read_file"],
+          blast_score: 45,
+        },
+        {
+          vulnerability_id: "CVE-2023-25577",
+          severity: "critical",
+          package: "werkzeug",
+          affected_agents: ["analyst-agent"],
+          affected_servers: ["database"],
+          exposed_credentials: ["DATABASE_URL"],
+          reachable_tools: ["execute_sql"],
+          blast_score: 96,
+          impact_category: "code-execution",
+          attack_vector_summary: "Agent can reach database server package and SQL tool.",
+        },
+      ],
+    };
+
+    const { stats } = buildMeshGraph(
+      result,
+      { packages: true, vulnerabilities: true, credentials: true, tools: true },
+      "high",
+      { vulnerableOnly: true, maxVulnerabilitiesPerPackage: 1 },
+    );
+
+    expect(stats.topExposurePath?.vulnerabilityId).toBe("CVE-2023-25577");
+    expect(stats.topExposurePath?.riskScore).toBe(96);
+    expect(stats.topExposurePath?.fixedVersion).toBe("2.2.3");
+    expect(stats.topExposurePath?.impactCategory).toBe("code-execution");
+    expect(stats.topExposurePath?.nodeIds).toEqual(
+      expect.arrayContaining([
+        "agent:analyst-agent",
+        "server:database::",
+        "pkg:server:database:::pypi:werkzeug@2.2.2",
+        "vuln:werkzeug:CVE-2023-25577",
+      ]),
+    );
   });
 
   it("respects selected agent scope without dropping the shared server edge", () => {


### PR DESCRIPTION
Summary
- make the mesh graph compute a top exposed path from scan + blast-radius evidence instead of presenting only a generic topology canvas
- add a reusable MeshExposurePath contract with vulnerability, package, server, affected agents, reachable tools, exposed credentials, fixed version, risk score, and graph node/edge ids
- show an operator-facing “Top exposed path” strip above /mesh and scan mesh with risk, affected-agent count, tool/credential reach, and fix target
- default-focus the top path in the graph so the first view highlights the exposed nodes and edges while keeping search/hover interactions intact
- add regression coverage for path ranking by blast score, severity, and blast-radius evidence

Root Cause
The graph surfaces had strong raw ingredients — inventory, dependency review, blast radius, lineage, mesh, and attack paths — but /mesh still opened as a node canvas. That made public screenshots and first-run usage look weaker than security-vendor-grade graph products because the first screen did not answer: what is exposed, why does it matter, what reaches it, and what fixes it.

Validation
- npm test -- --run tests/mesh-graph.test.ts tests/graph-utils.test.ts tests/use-graph-layout.test.tsx tests/graph-viewport.test.ts
- npm run typecheck
- npm run lint
- git diff --check origin/main...HEAD

Environment note
- npm run verify:toolchain was not run to completion on this machine because the repo correctly rejects local Node 25.9.0; ui/package.json requires >=22 <25.

Next PRs
- renderer scale: add WebGL/Cytoscape/Cosmograph-style large-graph fallback for 5k+ visible nodes
- graph semantics: cluster by environment/tenant/server, add dependency-chain summaries, and route Security Graph/Lineage/Mesh through one shared investigation model
- executive view: live exposure KPIs and top-N paths instead of static report-style graph entry
