### PR TITLE
fix shared exposure path command center

### DIFF
--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -22,6 +22,7 @@ function _classifyGraphErrorKind(err: unknown): "network" | "auth" | "forbidden"
   return "network";
 }
 import { AttackPathCard } from "@/components/attack-path-card";
+import { ExposurePathStrip } from "@/components/exposure-path-strip";
 import { GraphEvidenceExportButton } from "@/components/graph-chrome";
 import { GraphEmptyState, GraphPanelSkeleton } from "@/components/graph-state-panels";
 import {
@@ -47,6 +48,7 @@ import {
   summarizeInteractionRisks,
   moveAttackPathSelection,
   toAttackCardNodes,
+  toExposurePathFromAttackPath,
 } from "@/lib/attack-paths";
 import { useCaptureMode } from "@/lib/use-capture-mode";
 
@@ -247,6 +249,16 @@ function SecurityGraphPageContent() {
   const selectedFixFirstCard = useMemo(
     () => (selectedAttackPath ? cardByPathKey.get(attackPathKey(selectedAttackPath)) ?? null : null),
     [cardByPathKey, selectedAttackPath],
+  );
+  const selectedExposurePath = useMemo(
+    () =>
+      selectedAttackPath
+        ? toExposurePathFromAttackPath(selectedAttackPath, graphNodeById, {
+            scanId: selectedScanId || undefined,
+            rank: selectedFixFirstCard?.rank,
+          })
+        : null,
+    [graphNodeById, selectedAttackPath, selectedFixFirstCard?.rank, selectedScanId],
   );
 
   const selectedPathAgents = useMemo(
@@ -690,6 +702,11 @@ function SecurityGraphPageContent() {
           {selectedAttackPath && (
             <section className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
               <div className="rounded-3xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5">
+                {selectedExposurePath && (
+                  <div className="-mx-5 -mt-5 mb-5 overflow-hidden rounded-t-3xl">
+                    <ExposurePathStrip path={selectedExposurePath} />
+                  </div>
+                )}
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div>
                     <p className="text-[10px] uppercase tracking-[0.2em] text-orange-400">Selected path</p>

--- a/ui/components/exposure-path-strip.tsx
+++ b/ui/components/exposure-path-strip.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Crosshair, KeyRound, Route, ShieldAlert, Wrench } from "lucide-react";
+import { pathDisplayTitle, pathFixLabel, type ExposurePath } from "@/lib/exposure-path";
+
+export function ExposurePathStrip({
+  path,
+  active = false,
+  actionLabel,
+  onAction,
+}: {
+  path: ExposurePath;
+  active?: boolean;
+  actionLabel?: string | undefined;
+  onAction?: (() => void) | undefined;
+}) {
+  const fixLabel = pathFixLabel(path);
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 border-b border-[var(--border-subtle)] bg-red-950/20 px-4 py-2.5 text-xs">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <span className="inline-flex items-center gap-1 rounded border border-red-500/40 bg-red-500/10 px-2 py-1 font-semibold uppercase text-red-200">
+          <Crosshair className="h-3.5 w-3.5" />
+          Top exposed path
+        </span>
+        <span className="rounded bg-red-500/15 px-2 py-0.5 font-mono text-[11px] uppercase text-red-200">
+          {path.severity}
+        </span>
+        <span className="min-w-0 truncate text-[var(--text-secondary)]" title={path.label}>
+          {pathDisplayTitle(path)}
+        </span>
+      </div>
+      <div className="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-secondary)]">
+        <Metric icon={ShieldAlert} label="risk" value={Math.round(path.riskScore * 10) / 10} />
+        <Metric icon={Route} label="hops" value={Math.max(0, path.hops.length - 1)} />
+        <Metric label="agents" value={path.affectedAgents.length} />
+        {path.reachableTools.length > 0 && <Metric icon={Wrench} label="tools" value={path.reachableTools.length} />}
+        {path.exposedCredentials.length > 0 && (
+          <Metric icon={KeyRound} label="creds" value={path.exposedCredentials.length} />
+        )}
+        {fixLabel && (
+          <span>
+            fix <b className="text-emerald-300">{fixLabel}</b>
+          </span>
+        )}
+        {onAction && actionLabel && (
+          <button
+            type="button"
+            onClick={onAction}
+            className="rounded border border-red-500/30 px-2 py-1 text-red-200 transition hover:border-red-400 hover:bg-red-500/10"
+          >
+            {active ? "Show all" : actionLabel}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Metric({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon?: typeof ShieldAlert | undefined;
+  label: string;
+  value: string | number;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      {Icon && <Icon className="h-3 w-3" />}
+      {label} <b className="text-foreground">{value}</b>
+    </span>
+  );
+}

--- a/ui/components/mesh-stats.tsx
+++ b/ui/components/mesh-stats.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Crosshair, Server, KeyRound, Wrench, ShieldAlert, Package, Bug, AlertTriangle } from "lucide-react";
+import { Server, KeyRound, Wrench, ShieldAlert, Package, Bug, AlertTriangle } from "lucide-react";
+import { ExposurePathStrip } from "@/components/exposure-path-strip";
 import type { MeshStatsData } from "@/lib/mesh-graph";
 
 export type { MeshStatsData };
@@ -24,52 +25,12 @@ export function MeshStats({
   return (
     <div className="border-b border-[var(--border-subtle)]">
       {stats.topExposurePath && (
-        <div className="flex flex-wrap items-center gap-3 border-b border-[var(--border-subtle)] bg-red-950/20 px-4 py-2.5 text-xs">
-          <div className="flex min-w-0 flex-1 items-center gap-3">
-            <span className="inline-flex items-center gap-1 rounded border border-red-500/40 bg-red-500/10 px-2 py-1 font-semibold uppercase text-red-200">
-              <Crosshair className="h-3.5 w-3.5" />
-              Top exposed path
-            </span>
-            <span className="rounded bg-red-500/15 px-2 py-0.5 font-mono text-[11px] uppercase text-red-200">
-              {stats.topExposurePath.severity}
-            </span>
-            <span className="min-w-0 truncate text-[var(--text-secondary)]" title={stats.topExposurePath.label}>
-              {stats.topExposurePath.label}
-            </span>
-          </div>
-          <div className="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-secondary)]">
-            <span>
-              risk <b className="text-foreground">{Math.round(stats.topExposurePath.riskScore * 10) / 10}</b>
-            </span>
-            <span>
-              agents <b className="text-foreground">{stats.topExposurePath.affectedAgents.length}</b>
-            </span>
-            {stats.topExposurePath.reachableTools.length > 0 && (
-              <span>
-                tools <b className="text-foreground">{stats.topExposurePath.reachableTools.length}</b>
-              </span>
-            )}
-            {stats.topExposurePath.exposedCredentials.length > 0 && (
-              <span>
-                creds <b className="text-foreground">{stats.topExposurePath.exposedCredentials.length}</b>
-              </span>
-            )}
-            {stats.topExposurePath.fixedVersion && (
-              <span>
-                fix <b className="text-emerald-300">{stats.topExposurePath.fixedVersion}</b>
-              </span>
-            )}
-            {onTogglePathFocus && (
-              <button
-                type="button"
-                onClick={onTogglePathFocus}
-                className="rounded border border-red-500/30 px-2 py-1 text-red-200 transition hover:border-red-400 hover:bg-red-500/10"
-              >
-                {pathFocusActive ? "Show all" : "Focus path"}
-              </button>
-            )}
-          </div>
-        </div>
+        <ExposurePathStrip
+          path={stats.topExposurePath}
+          active={pathFocusActive}
+          actionLabel="Focus path"
+          onAction={onTogglePathFocus}
+        />
       )}
 
       <div className="flex items-center gap-4 px-4 py-2 text-xs flex-wrap">

--- a/ui/lib/attack-paths.ts
+++ b/ui/lib/attack-paths.ts
@@ -1,4 +1,13 @@
 import { EntityType, type AttackPath, type UnifiedNode } from "./graph-schema";
+import {
+  normalizeExposureSeverity,
+  uniqueExposureValues,
+  type ExposureEntityRef,
+  type ExposureEntityRole,
+  type ExposurePath,
+  type ExposureRelationshipRef,
+  exposureSeverityRank,
+} from "./exposure-path";
 
 export type AttackPathCardNode = {
   type: "cve" | "package" | "server" | "agent" | "credential";
@@ -93,6 +102,120 @@ export function toAttackCardNodes(path: AttackPath, nodeById: Map<string, Unifie
     });
   }
   return nodes;
+}
+
+function exposureRoleForEntityType(entityType: string): ExposureEntityRole {
+  switch (entityType) {
+    case EntityType.VULNERABILITY:
+    case EntityType.MISCONFIGURATION:
+      return "finding";
+    case EntityType.PACKAGE:
+      return "package";
+    case EntityType.SERVER:
+    case EntityType.CONTAINER:
+    case EntityType.CLOUD_RESOURCE:
+      return "server";
+    case EntityType.AGENT:
+    case EntityType.USER:
+    case EntityType.GROUP:
+    case EntityType.SERVICE_ACCOUNT:
+      return "agent";
+    case EntityType.CREDENTIAL:
+      return "credential";
+    case EntityType.TOOL:
+      return "tool";
+    case EntityType.ENVIRONMENT:
+      return "environment";
+    default:
+      return "unknown";
+  }
+}
+
+function exposureRefFromUnifiedNode(node: UnifiedNode): ExposureEntityRef {
+  return {
+    id: node.id,
+    label: node.label,
+    role: exposureRoleForEntityType(String(node.entity_type)),
+    severity: node.severity,
+    riskScore: node.risk_score,
+  };
+}
+
+function fallbackExposureRef(id: string, role: ExposureEntityRole): ExposureEntityRef {
+  return {
+    id,
+    label: id,
+    role,
+  };
+}
+
+function highestNodeSeverity(hops: ExposureEntityRef[], fallback: string): string {
+  return hops.reduce(
+    (highest, hop) => (exposureSeverityRank(hop.severity) > exposureSeverityRank(highest) ? String(hop.severity) : highest),
+    fallback,
+  );
+}
+
+export function toExposurePathFromAttackPath(
+  path: AttackPath,
+  nodeById: Map<string, UnifiedNode>,
+  options: { rank?: number | undefined; scanId?: string | undefined } = {},
+): ExposurePath {
+  const hops = path.hops.map((hop) => {
+    const node = nodeById.get(hop);
+    return node ? exposureRefFromUnifiedNode(node) : fallbackExposureRef(hop, "unknown");
+  });
+  const source = nodeById.get(path.source)
+    ? exposureRefFromUnifiedNode(nodeById.get(path.source)!)
+    : hops[0] ?? fallbackExposureRef(path.source, "unknown");
+  const target = nodeById.get(path.target)
+    ? exposureRefFromUnifiedNode(nodeById.get(path.target)!)
+    : hops[hops.length - 1] ?? fallbackExposureRef(path.target, "unknown");
+  const relationships: ExposureRelationshipRef[] = path.edges.map((edgeId, index) => ({
+    id: edgeId,
+    source: path.hops[index] ?? source.id,
+    target: path.hops[index + 1] ?? target.id,
+    relationship: edgeId.includes(":") ? edgeId.split(":")[0] ?? "related" : "related",
+    direction: "directed",
+    traversable: true,
+  }));
+  const packages = hops.filter((hop) => hop.role === "package");
+  const servers = hops.filter((hop) => hop.role === "server");
+  const affectedAgents = uniqueExposureValues(labelsForAttackPathType(path, nodeById, "agent"));
+  const exposedCredentials = uniqueExposureValues(path.credential_exposure);
+  const reachableTools = uniqueExposureValues(path.tool_exposure);
+
+  return {
+    id: attackPathKey(path),
+    rank: options.rank,
+    label: path.summary || `${source.label} -> ${target.label}`,
+    summary: path.summary,
+    riskScore: path.composite_risk,
+    severity: normalizeExposureSeverity(highestNodeSeverity(hops, path.composite_risk >= 9 ? "critical" : "high")),
+    source,
+    target,
+    hops,
+    relationships,
+    nodeIds: path.hops,
+    edgeIds: path.edges,
+    findings: uniqueExposureValues(path.vuln_ids),
+    affectedAgents,
+    affectedServers: uniqueExposureValues(servers.map((server) => server.label)),
+    reachableTools,
+    exposedCredentials,
+    dependencyContext: {
+      packageName: packages[0]?.label,
+      serverName: servers[0]?.label,
+    },
+    evidence: {
+      isKev: hops.some((hop) => String(hop.label).toLowerCase().includes("kev")),
+      source: "graph_attack_path",
+    },
+    provenance: {
+      source: "graph_attack_path",
+      scanId: options.scanId,
+    },
+  };
 }
 
 export function attackPathSequenceLabels(path: AttackPath, nodeById: Map<string, UnifiedNode>): string[] {

--- a/ui/lib/exposure-path.ts
+++ b/ui/lib/exposure-path.ts
@@ -1,0 +1,147 @@
+export type ExposureSeverity = "critical" | "high" | "medium" | "low" | "none" | string;
+
+export type ExposureEntityRole =
+  | "agent"
+  | "server"
+  | "package"
+  | "finding"
+  | "credential"
+  | "tool"
+  | "environment"
+  | "cluster"
+  | "unknown";
+
+export interface ExposureEntityRef {
+  id: string;
+  label: string;
+  role: ExposureEntityRole;
+  severity?: ExposureSeverity | undefined;
+  riskScore?: number | undefined;
+}
+
+export interface ExposureRelationshipRef {
+  id: string;
+  source: string;
+  target: string;
+  relationship: string;
+  direction?: "directed" | "bidirectional" | undefined;
+  traversable?: boolean | undefined;
+  confidence?: string | undefined;
+  evidenceCount?: number | undefined;
+}
+
+export interface ExposureDependencyContext {
+  packageName?: string | undefined;
+  packageVersion?: string | undefined;
+  ecosystem?: string | undefined;
+  serverName?: string | undefined;
+}
+
+export interface ExposureFixTarget {
+  label: string;
+  version?: string | undefined;
+  href?: string | undefined;
+}
+
+export interface ExposureEvidenceSummary {
+  cvssScore?: number | undefined;
+  epssScore?: number | undefined;
+  isKev?: boolean | undefined;
+  impactCategory?: string | undefined;
+  attackVectorSummary?: string | undefined;
+  source?: string | undefined;
+}
+
+export interface ExposurePath {
+  id: string;
+  rank?: number | undefined;
+  label: string;
+  summary?: string | undefined;
+  riskScore: number;
+  severity: ExposureSeverity;
+  source: ExposureEntityRef;
+  target: ExposureEntityRef;
+  hops: ExposureEntityRef[];
+  relationships: ExposureRelationshipRef[];
+  nodeIds: string[];
+  edgeIds: string[];
+  findings: string[];
+  affectedAgents: string[];
+  affectedServers: string[];
+  reachableTools: string[];
+  exposedCredentials: string[];
+  dependencyContext?: ExposureDependencyContext | undefined;
+  fix?: ExposureFixTarget | undefined;
+  evidence?: ExposureEvidenceSummary | undefined;
+  provenance?: {
+    source: string;
+    scanId?: string | undefined;
+  } | undefined;
+  timestamps?: {
+    firstSeen?: string | undefined;
+    lastSeen?: string | undefined;
+  } | undefined;
+}
+
+const SEVERITY_RANK: Record<string, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+  none: 0,
+};
+
+export function exposureSeverityRank(severity: ExposureSeverity | undefined): number {
+  return SEVERITY_RANK[String(severity ?? "none").toLowerCase()] ?? 0;
+}
+
+export function normalizeExposureSeverity(severity: ExposureSeverity | undefined): ExposureSeverity {
+  const normalized = String(severity ?? "none").toLowerCase();
+  return normalized in SEVERITY_RANK ? normalized : severity ?? "none";
+}
+
+export function uniqueExposureValues(values: (string | undefined | null)[]): string[] {
+  return [...new Set(values.map((value) => value?.trim()).filter((value): value is string => Boolean(value)))];
+}
+
+export function exposurePathKey(path: ExposurePath): string {
+  return path.id || `${path.source.id}::${path.target.id}::${path.nodeIds.join("->")}`;
+}
+
+export function compareExposurePaths(left: ExposurePath, right: ExposurePath): number {
+  const riskDiff = right.riskScore - left.riskScore;
+  if (riskDiff !== 0) return riskDiff;
+  const severityDiff = exposureSeverityRank(right.severity) - exposureSeverityRank(left.severity);
+  if (severityDiff !== 0) return severityDiff;
+  const kevDiff = Number(Boolean(right.evidence?.isKev)) - Number(Boolean(left.evidence?.isKev));
+  if (kevDiff !== 0) return kevDiff;
+  const blastDiff = right.affectedAgents.length - left.affectedAgents.length;
+  if (blastDiff !== 0) return blastDiff;
+  return pathDisplayTitle(left).localeCompare(pathDisplayTitle(right));
+}
+
+export function highestExposureSeverity(paths: ExposurePath[]): ExposureSeverity {
+  return paths.reduce<ExposureSeverity>(
+    (highest, path) => (exposureSeverityRank(path.severity) > exposureSeverityRank(highest) ? path.severity : highest),
+    "none",
+  );
+}
+
+export function pathDisplayTitle(path: ExposurePath): string {
+  const finding = path.findings[0] || path.target.label;
+  const dependency = path.dependencyContext?.packageName
+    ? `${path.dependencyContext.packageName}${path.dependencyContext.packageVersion ? `@${path.dependencyContext.packageVersion}` : ""}`
+    : "";
+  const agent = path.affectedAgents[0] || path.source.label;
+  return [agent, dependency, finding].filter(Boolean).join(" -> ") || path.label;
+}
+
+export function pathFixLabel(path: ExposurePath): string | undefined {
+  if (path.fix?.version) return path.fix.version;
+  if (path.fix?.label) return path.fix.label;
+  return undefined;
+}
+
+export function pathSequenceLabels(path: ExposurePath): string[] {
+  return path.hops.map((hop) => hop.label);
+}

--- a/ui/lib/mesh-graph.ts
+++ b/ui/lib/mesh-graph.ts
@@ -6,6 +6,12 @@
 import { type Node, type Edge, MarkerType } from "@xyflow/react";
 import type { ScanResult, MCPServer, Agent, Vulnerability, Package as AIBOMPackage } from "@/lib/api";
 import type { LineageNodeData } from "@/components/lineage-nodes";
+import {
+  uniqueExposureValues,
+  type ExposureEntityRef,
+  type ExposurePath,
+  type ExposureRelationshipRef,
+} from "@/lib/exposure-path";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -29,7 +35,7 @@ export interface MeshStatsData {
   topExposurePath?: MeshExposurePath | undefined;
 }
 
-export interface MeshExposurePath {
+export interface MeshExposurePath extends ExposurePath {
   label: string;
   vulnerabilityId: string;
   severity: VulnerabilitySeverity;
@@ -286,7 +292,7 @@ function compareVulnerabilities(left: Vulnerability, right: Vulnerability): numb
 }
 
 function uniqueStrings(values: (string | undefined)[]): string[] {
-  return [...new Set(values.filter((value): value is string => Boolean(value)))];
+  return uniqueExposureValues(values);
 }
 
 function blastRiskScore(vuln: Vulnerability, blast: ScanResult["blast_radius"][number] | undefined): number {
@@ -752,7 +758,94 @@ export function buildMeshGraph(
             ]);
             const affectedAgents = pathAgentKeys.map((agentKey) => group.agentLabels.get(agentKey) ?? agentKey);
             const riskScore = blastRiskScore(vuln, br);
+            const agentRefs: ExposureEntityRef[] = pathAgentKeys.map((agentKey) => ({
+              id: meshAgentNodeId(agentKey),
+              label: group.agentLabels.get(agentKey) ?? agentKey,
+              role: "agent",
+            }));
+            const serverRef: ExposureEntityRef = {
+              id: serverId,
+              label: group.name,
+              role: "server",
+            };
+            const packageRef: ExposureEntityRef = {
+              id: pkgId,
+              label: `${pkg.name}@${pkg.version}`,
+              role: "package",
+              severity: vuln.severity,
+            };
+            const vulnRef: ExposureEntityRef = {
+              id: vulnId,
+              label: vuln.id,
+              role: "finding",
+              severity: vuln.severity,
+              riskScore,
+            };
+            const toolRefs: ExposureEntityRef[] = reachableTools.slice(0, 2).map((tool) => ({
+              id: `tool:${serverId}:${tool}`,
+              label: tool,
+              role: "tool" as const,
+            })).filter((ref) => seen.has(ref.id));
+            const credentialRefs: ExposureEntityRef[] = exposedCredentials.slice(0, 2).map((credential) => ({
+              id: `cred:${serverId}:${credential}`,
+              label: credential,
+              role: "credential" as const,
+            }));
+            const relationships: ExposureRelationshipRef[] = [
+              ...pathAgentKeys.map((agentKey) => ({
+                id: `${meshAgentNodeId(agentKey)}->${serverId}`,
+                source: meshAgentNodeId(agentKey),
+                target: serverId,
+                relationship: "uses",
+                direction: "directed" as const,
+                traversable: true,
+                confidence: "observed",
+                evidenceCount: 1,
+              })),
+              {
+                id: `${serverId}->${pkgId}`,
+                source: serverId,
+                target: pkgId,
+                relationship: "depends_on",
+                direction: "directed",
+                traversable: true,
+                confidence: packageVersionConfidence(pkg) || "observed",
+                evidenceCount: 1,
+              },
+              {
+                id: `${pkgId}->${vulnId}`,
+                source: pkgId,
+                target: vulnId,
+                relationship: "vulnerable_to",
+                direction: "directed",
+                traversable: true,
+                confidence: "scanner",
+                evidenceCount: 1,
+              },
+              ...toolRefs.map((tool) => ({
+                id: `${serverId}->${tool.id}`,
+                source: serverId,
+                target: tool.id,
+                relationship: "provides_tool",
+                direction: "directed" as const,
+                traversable: true,
+                confidence: "observed",
+                evidenceCount: 1,
+              })),
+              ...credentialRefs.map((credential) => ({
+                id: `${serverId}->${credential.id}`,
+                source: serverId,
+                target: credential.id,
+                relationship: "exposes_cred",
+                direction: "directed" as const,
+                traversable: true,
+                confidence: "redacted_reference",
+                evidenceCount: 1,
+              })),
+            ];
+            const exposureHops = [...agentRefs, serverRef, packageRef, vulnRef, ...toolRefs, ...credentialRefs];
             topExposurePath = betterExposurePath(topExposurePath, {
+              id: `mesh:${vuln.id}:${pkg.ecosystem}:${pkg.name}@${pkg.version}:${serverId}`,
               label: `${affectedAgents.slice(0, 2).join(", ")} -> ${group.name} -> ${pkg.name}@${pkg.version} -> ${vuln.id}`,
               vulnerabilityId: vuln.id,
               severity: vuln.severity,
@@ -771,8 +864,36 @@ export function buildMeshGraph(
               fixedVersion: vuln.fixed_version,
               impactCategory: br?.impact_category,
               attackVectorSummary: br?.attack_vector_summary,
+              source: agentRefs[0] ?? serverRef,
+              target: vulnRef,
+              hops: exposureHops,
+              relationships,
               nodeIds: pathNodeIds,
               edgeIds: pathEdgeIds,
+              findings: [vuln.id],
+              dependencyContext: {
+                packageName: pkg.name,
+                packageVersion: pkg.version,
+                ecosystem: pkg.ecosystem,
+                serverName: group.name,
+              },
+              fix: vuln.fixed_version
+                ? {
+                    label: `Upgrade ${pkg.name}`,
+                    version: vuln.fixed_version,
+                  }
+                : undefined,
+              evidence: {
+                cvssScore: vuln.cvss_score,
+                epssScore: vuln.epss_score,
+                isKev: Boolean(vuln.cisa_kev || vuln.is_kev),
+                impactCategory: br?.impact_category,
+                attackVectorSummary: br?.attack_vector_summary,
+                source: "scan_blast_radius",
+              },
+              provenance: {
+                source: "mesh_scan_result",
+              },
             });
           }
         }

--- a/ui/tests/attack-paths.test.ts
+++ b/ui/tests/attack-paths.test.ts
@@ -15,6 +15,7 @@ import {
   recommendedAttackPathActions,
   summarizeInteractionRisks,
   toAttackCardNodes,
+  toExposurePathFromAttackPath,
 } from "@/lib/attack-paths";
 import { EntityType, type AttackPath, type UnifiedNode } from "@/lib/graph-schema";
 
@@ -236,6 +237,37 @@ describe("attack path helpers", () => {
     expect(investigationRootForAttackPath(path, nodes, { packageName: "flask" })?.id).toBe("pkg-1");
     expect(investigationRootForAttackPath(path, nodes, { agentName: "Claude Desktop" })?.id).toBe("agent-1");
     expect(investigationRootForAttackPath(path, nodes, {})?.id).toBe("cve-1");
+  });
+
+  it("adapts persisted attack paths into the shared exposure path contract", () => {
+    const path: AttackPath = {
+      source: "cve-1",
+      target: "agent-1",
+      hops: ["cve-1", "pkg-1", "server-1", "agent-1"],
+      edges: ["edge:cve-pkg", "edge:pkg-server", "edge:server-agent"],
+      composite_risk: 9.4,
+      summary: "CVE reaches an agent through a shared server",
+      credential_exposure: ["DATABASE_URL"],
+      tool_exposure: ["execute_sql"],
+      vuln_ids: ["CVE-2026-0002"],
+    };
+    const nodes = new Map<string, UnifiedNode>([
+      ["cve-1", graphNode("cve-1", EntityType.VULNERABILITY, "CVE-2026-0002")],
+      ["pkg-1", graphNode("pkg-1", EntityType.PACKAGE, "werkzeug")],
+      ["server-1", graphNode("server-1", EntityType.SERVER, "database")],
+      ["agent-1", graphNode("agent-1", EntityType.AGENT, "analyst-agent")],
+    ]);
+
+    const exposure = toExposurePathFromAttackPath(path, nodes, { rank: 1, scanId: "scan-1" });
+
+    expect(exposure.rank).toBe(1);
+    expect(exposure.riskScore).toBe(9.4);
+    expect(exposure.findings).toEqual(["CVE-2026-0002"]);
+    expect(exposure.dependencyContext).toMatchObject({ packageName: "werkzeug", serverName: "database" });
+    expect(exposure.affectedAgents).toEqual(["analyst-agent"]);
+    expect(exposure.reachableTools).toEqual(["execute_sql"]);
+    expect(exposure.exposedCredentials).toEqual(["DATABASE_URL"]);
+    expect(exposure.provenance).toEqual({ source: "graph_attack_path", scanId: "scan-1" });
   });
 
   it("matches a focused attack path by cve, package, and agent labels", () => {

--- a/ui/tests/exposure-path.test.ts
+++ b/ui/tests/exposure-path.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { compareExposurePaths, pathDisplayTitle, pathFixLabel, type ExposurePath } from "@/lib/exposure-path";
+
+function path(overrides: Partial<ExposurePath>): ExposurePath {
+  return {
+    id: "path-1",
+    label: "Agent -> package -> CVE",
+    riskScore: 8,
+    severity: "high",
+    source: { id: "agent-1", label: "analyst-agent", role: "agent" },
+    target: { id: "cve-1", label: "CVE-2026-0001", role: "finding" },
+    hops: [
+      { id: "agent-1", label: "analyst-agent", role: "agent" },
+      { id: "pkg-1", label: "werkzeug@2.2.2", role: "package" },
+      { id: "cve-1", label: "CVE-2026-0001", role: "finding" },
+    ],
+    relationships: [],
+    nodeIds: ["agent-1", "pkg-1", "cve-1"],
+    edgeIds: [],
+    findings: ["CVE-2026-0001"],
+    affectedAgents: ["analyst-agent"],
+    affectedServers: ["database"],
+    reachableTools: ["execute_sql"],
+    exposedCredentials: [],
+    dependencyContext: {
+      packageName: "werkzeug",
+      packageVersion: "2.2.2",
+      ecosystem: "pypi",
+      serverName: "database",
+    },
+    ...overrides,
+  };
+}
+
+describe("ExposurePath", () => {
+  it("renders a security-first display title from shared path fields", () => {
+    expect(pathDisplayTitle(path({}))).toBe("analyst-agent -> werkzeug@2.2.2 -> CVE-2026-0001");
+  });
+
+  it("prefers fix versions for compact remediation labels", () => {
+    expect(pathFixLabel(path({ fix: { label: "Upgrade werkzeug", version: "2.2.3" } }))).toBe("2.2.3");
+    expect(pathFixLabel(path({ fix: { label: "Rotate credential" } }))).toBe("Rotate credential");
+  });
+
+  it("ranks by risk, then severity, then KEV, then affected agents", () => {
+    const criticalKev = path({ id: "critical-kev", riskScore: 9, severity: "critical", evidence: { isKev: true } });
+    const highWide = path({
+      id: "high-wide",
+      riskScore: 9,
+      severity: "high",
+      affectedAgents: ["analyst-agent", "cursor"],
+    });
+    const medium = path({ id: "medium", riskScore: 7, severity: "medium" });
+
+    expect([medium, highWide, criticalKev].sort(compareExposurePaths).map((item) => item.id)).toEqual([
+      "critical-kev",
+      "high-wide",
+      "medium",
+    ]);
+  });
+});

--- a/ui/tests/mesh-graph.test.ts
+++ b/ui/tests/mesh-graph.test.ts
@@ -86,6 +86,13 @@ describe("buildMeshGraph", () => {
 
     expect(stats.totalAgents).toBe(2);
     expect(stats.topExposurePath?.vulnerabilityId).toBe("CVE-2026-0001");
+    expect(stats.topExposurePath?.findings).toEqual(["CVE-2026-0001"]);
+    expect(stats.topExposurePath?.dependencyContext).toMatchObject({
+      packageName: "server-filesystem",
+      packageVersion: "1.0.0",
+      ecosystem: "npm",
+      serverName: "filesystem",
+    });
     expect(stats.topExposurePath?.nodeIds).toEqual(
       expect.arrayContaining([
         "agent:claude-desktop",
@@ -174,6 +181,13 @@ describe("buildMeshGraph", () => {
     expect(stats.topExposurePath?.vulnerabilityId).toBe("CVE-2023-25577");
     expect(stats.topExposurePath?.riskScore).toBe(96);
     expect(stats.topExposurePath?.fixedVersion).toBe("2.2.3");
+    expect(stats.topExposurePath?.fix).toEqual({
+      label: "Upgrade werkzeug",
+      version: "2.2.3",
+    });
+    expect(stats.topExposurePath?.relationships.map((edge) => edge.relationship)).toEqual(
+      expect.arrayContaining(["uses", "depends_on", "vulnerable_to", "provides_tool", "exposes_cred"]),
+    );
     expect(stats.topExposurePath?.impactCategory).toBe("code-execution");
     expect(stats.topExposurePath?.nodeIds).toEqual(
       expect.arrayContaining([


### PR DESCRIPTION
Summary

Start the graph upgrade implementation with the shared exposure-path contract that the graph/data review called out as PR 1.

What changed

- add `ExposurePath` as the frontend investigation contract for path rank, risk, source/target entities, hops, relationships, findings, affected agents/servers, reachable tools, exposed credentials, dependency context, fix target, evidence, and provenance
- add helpers for path ranking, security-first titles, fix labels, severity ordering, and stable value normalization
- adapt persisted graph `AttackPath` records into `ExposurePath` so `/security-graph` can use the same investigation shape as mesh/blast-radius paths
- extend mesh top-exposure paths to carry the shared contract while preserving the existing mesh aliases used by current views/tests
- replace the duplicated mesh top-path banner with a shared `ExposurePathStrip` component and render it on the selected `/security-graph` path panel
- preserve credential exposure evidence in the shared path even when the credential was not visible as a rendered mesh node

Why

The graph UI needs one security command language before the renderer migration. This makes attack paths, dependency/mesh exposure, evidence, and fixes flow through the same model so the next PR can redesign the command-center graph and the following PR can add Sigma/WebGL without inventing another data shape.

Validation

- `npm test -- --run tests/exposure-path.test.ts tests/attack-paths.test.ts tests/mesh-graph.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check origin/main...HEAD`
- commit pre-commit hooks: end-of-file, trailing whitespace, private-key, case-conflict, merge-conflict, mixed-line-ending, duplicate artifact guard

Known local environment note

- `npm run verify:toolchain` correctly fails on this workstation because local Node is `25.9.0`; the repo declares `>=22 <25`. I did not weaken the toolchain gate.
