### PR TITLE
fix security graph command center

### DIFF
--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -4,13 +4,10 @@ import Link from "next/link";
 import { Suspense, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import {
-  AlertTriangle,
   ArrowRight,
-  ExternalLink,
   GitBranch,
   Loader2,
   Route,
-  Sparkles,
 } from "lucide-react";
 
 import { ApiOfflineState } from "@/components/api-offline-state";
@@ -22,6 +19,7 @@ function _classifyGraphErrorKind(err: unknown): "network" | "auth" | "forbidden"
   return "network";
 }
 import { AttackPathCard } from "@/components/attack-path-card";
+import { ExposurePathCommandCenter } from "@/components/exposure-path-command-center";
 import { ExposurePathStrip } from "@/components/exposure-path-strip";
 import { GraphEvidenceExportButton } from "@/components/graph-chrome";
 import { GraphEmptyState, GraphPanelSkeleton } from "@/components/graph-state-panels";
@@ -36,16 +34,12 @@ import {
 } from "@/lib/api";
 import {
   attackPathKey,
-  attackPathSequenceLabels,
   buildFindingsHref,
   buildGraphInvestigationHref,
   buildSecurityGraphHref,
   investigationRootForAttackPath,
-  labelsForAttackPathType,
   matchesAttackPathFocus,
-  recommendedInteractionRiskActions,
   recommendedAttackPathActions,
-  summarizeInteractionRisks,
   moveAttackPathSelection,
   toAttackCardNodes,
   toExposurePathFromAttackPath,
@@ -261,33 +255,12 @@ function SecurityGraphPageContent() {
     [graphNodeById, selectedAttackPath, selectedFixFirstCard?.rank, selectedScanId],
   );
 
-  const selectedPathAgents = useMemo(
-    () =>
-      selectedAttackPath
-        ? labelsForAttackPathType(selectedAttackPath, graphNodeById, "agent")
-        : [],
-    [graphNodeById, selectedAttackPath],
-  );
-
-  const selectedPathSequence = useMemo(
-    () =>
-      selectedAttackPath
-        ? attackPathSequenceLabels(selectedAttackPath, graphNodeById)
-        : [],
-    [graphNodeById, selectedAttackPath],
-  );
-
   const selectedPathActions = useMemo(
     () =>
       selectedAttackPath
         ? recommendedAttackPathActions(selectedAttackPath, graphNodeById, { scanId: selectedScanId || undefined })
         : [],
     [graphNodeById, selectedAttackPath, selectedScanId],
-  );
-
-  const interactionRiskSummary = useMemo(
-    () => summarizeInteractionRisks(graphData?.interaction_risks ?? []),
-    [graphData?.interaction_risks],
   );
 
   const emptyGraphState = useMemo(() => {
@@ -377,18 +350,45 @@ function SecurityGraphPageContent() {
   }
 
   return (
-    <div className="space-y-6">
-      <section className="rounded-3xl border border-[color:var(--border-subtle)] bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.08),transparent_34%),linear-gradient(180deg,var(--surface),var(--surface-elevated))] p-6 shadow-2xl">
+    <div className="space-y-4">
+      {selectedExposurePath && (
+        <section className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+          <div className="overflow-hidden rounded-3xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)]">
+            <ExposurePathStrip path={selectedExposurePath} />
+            <div className="p-5">
+              <ExposurePathCommandCenter
+                path={selectedExposurePath}
+                actions={selectedFixFirstCard?.next_actions ?? selectedPathActions}
+              />
+            </div>
+          </div>
+          <div className="rounded-3xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5">
+            <p className="text-[10px] uppercase tracking-[0.2em] text-orange-400">Graph operating mode</p>
+            <h2 className="mt-2 text-base font-semibold text-[color:var(--foreground)]">Fix-first investigation</h2>
+            <p className="mt-2 text-sm leading-6 text-[color:var(--text-secondary)]">
+              This page starts with the highest-risk proven path. Use the queue below to change focus, or open the
+              full lineage graph when you need broader neighbor context.
+            </p>
+            <div className="mt-4 grid gap-2 text-xs">
+              <QuickStat label="Rank" value={`#${selectedExposurePath.rank ?? 1}`} />
+              <QuickStat label="Relationships" value={String(selectedExposurePath.relationships.length)} />
+              <QuickStat label="Evidence source" value={selectedExposurePath.provenance?.source ?? "graph"} />
+            </div>
+          </div>
+        </section>
+      )}
+
+      <section className="rounded-3xl border border-[color:var(--border-subtle)] bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.08),transparent_34%),linear-gradient(180deg,var(--surface),var(--surface-elevated))] p-4 shadow-2xl">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="max-w-3xl">
             <div className="inline-flex items-center gap-2 rounded-full border border-emerald-900/60 bg-emerald-950/30 px-3 py-1 text-[11px] uppercase tracking-[0.18em] text-emerald-300">
               <Route className="h-3.5 w-3.5" />
               Security graph
             </div>
-            <h1 className="mt-4 text-3xl font-semibold tracking-tight text-[color:var(--foreground)]">
+            <h1 className="mt-3 text-2xl font-semibold tracking-tight text-[color:var(--foreground)]">
               Fix-first attack paths without dropping into the full graph canvas
             </h1>
-            <p className="mt-3 max-w-2xl text-sm leading-7 text-[color:var(--text-secondary)]">
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-[color:var(--text-secondary)]">
               This view keeps the highest-risk exploit chains explicit: what finding starts the path, which assets it reaches,
               which credentials and tools stay exposed, and where to jump next for evidence or remediation.
             </p>
@@ -416,7 +416,7 @@ function SecurityGraphPageContent() {
           </div>
         </div>
 
-        <div className="mt-6 grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="mt-4 grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
           <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
@@ -643,7 +643,7 @@ function SecurityGraphPageContent() {
             </div>
 
             <div
-              className="mt-4 grid max-w-full grid-cols-1 gap-3 outline-none md:grid-cols-2 xl:grid-cols-3"
+              className="mt-4 grid max-h-[34rem] max-w-full grid-cols-1 gap-3 overflow-y-auto pr-1 outline-none md:grid-cols-2 xl:grid-cols-3"
               tabIndex={0}
               onKeyDown={handleAttackPathQueueKeyDown}
               aria-label="Attack path queue"
@@ -698,236 +698,6 @@ function SecurityGraphPageContent() {
               })}
             </div>
           </section>
-
-          {selectedAttackPath && (
-            <section className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
-              <div className="rounded-3xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5">
-                {selectedExposurePath && (
-                  <div className="-mx-5 -mt-5 mb-5 overflow-hidden rounded-t-3xl">
-                    <ExposurePathStrip path={selectedExposurePath} />
-                  </div>
-                )}
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div>
-                    <p className="text-[10px] uppercase tracking-[0.2em] text-orange-400">Selected path</p>
-                    <h2 className="mt-1 text-lg font-semibold text-[color:var(--foreground)]">
-                      {selectedFixFirstCard?.title || selectedAttackPath.summary || "Credential-aware exploit chain"}
-                    </h2>
-                    <p className="mt-2 text-sm leading-6 text-[color:var(--text-secondary)]">
-                      {selectedFixFirstCard?.summary ||
-                        "The graph already resolved this chain. Use it as the operator-facing shortlist before you branch into detailed evidence."}
-                    </p>
-                  </div>
-                  <div className="rounded-2xl border border-red-900/60 bg-red-950/20 px-4 py-3">
-                    <div className="text-[10px] uppercase tracking-[0.18em] text-red-300">Composite risk</div>
-                    <div className="mt-1 font-mono text-2xl text-red-200">{selectedAttackPath.composite_risk.toFixed(1)}</div>
-                  </div>
-                </div>
-
-                {selectedFixFirstCard && selectedFixFirstCard.risk_reasons.length > 0 && (
-                  <div className="mt-4 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
-                    <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">Why this is prioritized</div>
-                    <div className="mt-3 grid gap-3 md:grid-cols-2">
-                      {selectedFixFirstCard.risk_reasons.map((reason) => (
-                        <div key={reason.kind} className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3">
-                          <div className="text-sm font-semibold text-[color:var(--foreground)]">{reason.label}</div>
-                          <p className="mt-1 text-xs leading-5 text-[color:var(--text-tertiary)]">{reason.detail}</p>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                  <QuickStat label="Hop count" value={String(Math.max(0, selectedAttackPath.hops.length - 1))} />
-                  <QuickStat
-                    label="Credentials exposed"
-                    value={selectedAttackPath.credential_exposure.length > 0 ? String(selectedAttackPath.credential_exposure.length) : "none"}
-                    tone={selectedAttackPath.credential_exposure.length > 0 ? "amber" : "zinc"}
-                  />
-                  <QuickStat
-                    label="Tools reachable"
-                    value={selectedAttackPath.tool_exposure.length > 0 ? String(selectedAttackPath.tool_exposure.length) : "none"}
-                    tone={selectedAttackPath.tool_exposure.length > 0 ? "blue" : "zinc"}
-                  />
-                  <QuickStat
-                    label="Findings in chain"
-                    value={selectedAttackPath.vuln_ids.length > 0 ? String(selectedAttackPath.vuln_ids.length) : "none"}
-                    tone={selectedAttackPath.vuln_ids.length > 0 ? "red" : "zinc"}
-                  />
-                </div>
-
-                {selectedPathSequence.length > 0 && (
-                  <div className="mt-4 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
-                    <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">Path sequence</div>
-                    <div className="mt-3 flex flex-wrap items-center gap-2">
-                      {selectedPathSequence.map((label, index) => (
-                        <div key={`${label}-${index}`} className="flex items-center gap-2">
-                          {index > 0 && <ArrowRight className="h-3.5 w-3.5 text-[color:var(--text-tertiary)]" />}
-                          <span className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2.5 py-1 text-[11px] font-mono text-[color:var(--text-secondary)]">
-                            {label}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                <div className="mt-4 grid gap-4 lg:grid-cols-2">
-                  <TagList
-                    label="Findings"
-                    tags={selectedAttackPath.vuln_ids}
-                    emptyLabel="No linked findings"
-                    hrefForTag={(tag) => buildFindingsHref({ scanId: selectedScanId || undefined, cve: tag })}
-                  />
-                  <TagList
-                    label="Agents"
-                    tags={selectedPathAgents}
-                    emptyLabel="No agent hop resolved in this path"
-                    hrefForTag={(tag) => `/agents?name=${encodeURIComponent(tag)}`}
-                  />
-                </div>
-
-                <div className="mt-4 grid gap-4 lg:grid-cols-2">
-                  <TagList label="Credentials" tags={selectedAttackPath.credential_exposure} emptyLabel="No credential exposure" />
-                  <TagList label="Tools" tags={selectedAttackPath.tool_exposure} emptyLabel="No tool exposure" />
-                </div>
-
-                <div className="mt-4 text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
-                  Recommended next steps
-                </div>
-                <div className="mt-3 grid gap-3 lg:grid-cols-3">
-                  {(selectedFixFirstCard?.next_actions ?? selectedPathActions).map((action) => (
-                    <Link
-                      key={action.title}
-                      href={action.href}
-                      className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 transition hover:border-[color:var(--border-strong)]"
-                    >
-                      <div className="flex items-center justify-between gap-3">
-                        <div className="text-sm font-medium text-[color:var(--foreground)]">{action.title}</div>
-                        <ArrowRight className="h-4 w-4 text-emerald-300" />
-                      </div>
-                      <p className="mt-2 text-xs leading-5 text-[color:var(--text-tertiary)]">{action.detail}</p>
-                    </Link>
-                  ))}
-
-                  <Link
-                    href={fullGraphHref}
-                    className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 transition hover:border-[color:var(--border-strong)]"
-                  >
-                    <div className="flex items-center justify-between gap-3">
-                      <div className="text-sm font-medium text-[color:var(--foreground)]">Open full graph canvas</div>
-                      <GitBranch className="h-4 w-4 text-[color:var(--text-secondary)]" />
-                    </div>
-                    <p className="mt-2 text-xs leading-5 text-[color:var(--text-tertiary)]">
-                      Switch to the full lineage view when you need broader topology, filters, or neighboring assets.
-                    </p>
-                  </Link>
-                </div>
-              </div>
-
-              <div className="space-y-4">
-                <div className="rounded-3xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5">
-                  <div className="flex items-center gap-2 text-sm font-semibold text-[color:var(--foreground)]">
-                    <Sparkles className="h-4 w-4 text-sky-400" />
-                    Interaction risks
-                  </div>
-                  <p className="mt-2 text-xs leading-5 text-[color:var(--text-tertiary)]">
-                    Runtime interaction overlays show where agent behavior, tags, and control surfaces can expand blast radius.
-                  </p>
-                  {graphData?.interaction_risks?.length ? (
-                    <div className="mt-4 space-y-3">
-                      <div className="grid grid-cols-3 gap-3">
-                        <QuickStat label="Patterns" value={String(interactionRiskSummary.total)} />
-                        <QuickStat label="Agents touched" value={String(interactionRiskSummary.uniqueAgents)} tone="blue" />
-                        <QuickStat label="Highest risk" value={interactionRiskSummary.highestRisk.toFixed(1)} tone="amber" />
-                      </div>
-                      {graphData.interaction_risks.slice(0, 3).map((risk) => (
-                        <div key={`${risk.pattern}-${risk.risk_score}`} className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3">
-                          <div className="flex items-start justify-between gap-3">
-                            <div>
-                              <div className="text-sm font-medium text-[color:var(--foreground)]">{risk.pattern}</div>
-                              <p className="mt-1 text-xs leading-5 text-[color:var(--text-tertiary)]">{risk.description}</p>
-                              {risk.owasp_agentic_tag && (
-                                <div className="mt-2 inline-flex rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2 py-1 text-[10px] font-mono text-[color:var(--text-secondary)]">
-                                  {risk.owasp_agentic_tag}
-                                </div>
-                              )}
-                            </div>
-                            <span className="rounded-full border border-sky-800 bg-sky-950/40 px-2 py-1 text-[10px] font-mono text-sky-300">
-                              {risk.risk_score.toFixed(1)}
-                            </span>
-                          </div>
-                          {risk.agents.length > 0 && (
-                            <div className="mt-3 flex flex-wrap gap-2">
-                              {Array.from(new Set(risk.agents)).slice(0, 4).map((agent) => (
-                                <Link
-                                  key={agent}
-                                  href={`/agents?name=${encodeURIComponent(agent)}`}
-                                  className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2 py-1 text-[11px] text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
-                                >
-                                  {agent}
-                                </Link>
-                              ))}
-                            </div>
-                          )}
-                          {risk.owasp_agentic_tag && (
-                            <div className="mt-3 flex flex-wrap gap-2">
-                              <Link
-                                href={`/compliance?q=${encodeURIComponent(risk.owasp_agentic_tag)}`}
-                                className="rounded-full border border-emerald-900/70 bg-emerald-950/30 px-2 py-1 text-[11px] font-mono text-emerald-300 transition hover:border-emerald-700 hover:text-emerald-200"
-                              >
-                                {risk.owasp_agentic_tag}
-                              </Link>
-                            </div>
-                          )}
-                          <div className="mt-3 flex flex-wrap gap-2">
-                            {recommendedInteractionRiskActions(risk).map((action) => (
-                              <Link
-                                key={`${risk.pattern}-${action.label}`}
-                                href={action.href}
-                                className="inline-flex items-center gap-1 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2.5 py-1 text-[11px] text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
-                              >
-                                {action.label}
-                                <ArrowRight className="h-3 w-3" />
-                              </Link>
-                            ))}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  ) : (
-                    <div className="mt-4 rounded-2xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-4 text-sm text-[color:var(--text-secondary)]">
-                      No interaction risk overlays were recorded for this snapshot.
-                    </div>
-                  )}
-                </div>
-
-                <div className="rounded-3xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5">
-                  <div className="flex items-center gap-2 text-sm font-semibold text-[color:var(--foreground)]">
-                    <AlertTriangle className="h-4 w-4 text-orange-400" />
-                    Operator notes
-                  </div>
-                  <ul className="mt-4 space-y-3 text-sm leading-6 text-[color:var(--text-secondary)]">
-                    <li>Use this page when you want the fix-first shortlist, not the full topology explorer.</li>
-                    <li>Persisted snapshots keep historical paths even when later scans deactivate or remove an entity.</li>
-                    <li>Open the lineage graph when you need full neighbor context, pagination, or custom filtering.</li>
-                  </ul>
-                  <div className="mt-4 flex flex-wrap gap-2">
-                    <a
-                      href="https://osv.dev/"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-xs text-[color:var(--text-tertiary)] transition hover:text-[color:var(--text-secondary)]"
-                    >
-                      External OSV reference
-                      <ExternalLink className="h-3 w-3" />
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </section>
-          )}
         </>
       )}
     </div>
@@ -961,46 +731,6 @@ function QuickStat({
     <div className={`rounded-2xl border px-4 py-3 ${tones[tone]}`}>
       <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">{label}</div>
       <div className="mt-1 font-mono text-xl">{value}</div>
-    </div>
-  );
-}
-
-function TagList({
-  label,
-  tags,
-  emptyLabel,
-  hrefForTag,
-}: {
-  label: string;
-  tags: string[];
-  emptyLabel: string;
-  hrefForTag?: (tag: string) => string;
-}) {
-  const uniqueTags = useMemo(() => Array.from(new Set(tags.filter((tag) => tag.trim()))), [tags]);
-  return (
-    <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
-      <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">{label}</div>
-      {uniqueTags.length > 0 ? (
-        <div className="mt-3 flex flex-wrap gap-2">
-          {uniqueTags.map((tag) => (
-            hrefForTag ? (
-              <Link
-                key={tag}
-                href={hrefForTag(tag)}
-                className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2 py-1 text-[11px] font-mono text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
-              >
-                {tag}
-              </Link>
-            ) : (
-              <span key={tag} className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2 py-1 text-[11px] font-mono text-[color:var(--text-secondary)]">
-                {tag}
-              </span>
-            )
-          ))}
-        </div>
-      ) : (
-        <div className="mt-3 text-sm text-[color:var(--text-secondary)]">{emptyLabel}</div>
-      )}
     </div>
   );
 }

--- a/ui/components/exposure-path-command-center.tsx
+++ b/ui/components/exposure-path-command-center.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import Link from "next/link";
+import type { LucideIcon } from "lucide-react";
+import {
+  Bot,
+  Bug,
+  CheckCircle2,
+  Database,
+  KeyRound,
+  Package,
+  Route,
+  Server,
+  ShieldAlert,
+  Wrench,
+} from "lucide-react";
+import { pathDisplayTitle, pathFixLabel, type ExposureEntityRole, type ExposurePath } from "@/lib/exposure-path";
+
+export interface ExposurePathCommandAction {
+  title: string;
+  detail: string;
+  href: string;
+}
+
+const ROLE_META: Record<ExposureEntityRole, { label: string; icon: LucideIcon; tint: string }> = {
+  agent: { label: "Agent", icon: Bot, tint: "border-emerald-500/30 bg-emerald-500/10 text-emerald-200" },
+  server: { label: "Server", icon: Server, tint: "border-sky-500/30 bg-sky-500/10 text-sky-200" },
+  package: { label: "Package", icon: Package, tint: "border-amber-500/30 bg-amber-500/10 text-amber-200" },
+  finding: { label: "Finding", icon: Bug, tint: "border-red-500/30 bg-red-500/10 text-red-200" },
+  credential: { label: "Credential", icon: KeyRound, tint: "border-fuchsia-500/30 bg-fuchsia-500/10 text-fuchsia-200" },
+  tool: { label: "Tool", icon: Wrench, tint: "border-purple-500/30 bg-purple-500/10 text-purple-200" },
+  environment: { label: "Environment", icon: Database, tint: "border-cyan-500/30 bg-cyan-500/10 text-cyan-200" },
+  cluster: { label: "Cluster", icon: Database, tint: "border-indigo-500/30 bg-indigo-500/10 text-indigo-200" },
+  unknown: { label: "Entity", icon: ShieldAlert, tint: "border-zinc-500/30 bg-zinc-500/10 text-zinc-200" },
+};
+
+const GRAPH_ROLE_STYLE: Record<ExposureEntityRole, { fill: string; stroke: string; text: string; accent: string }> = {
+  agent: { fill: "#052e24", stroke: "#10b981", text: "#d1fae5", accent: "#34d399" },
+  server: { fill: "#082f49", stroke: "#0ea5e9", text: "#e0f2fe", accent: "#38bdf8" },
+  package: { fill: "#422006", stroke: "#f59e0b", text: "#fef3c7", accent: "#fbbf24" },
+  finding: { fill: "#450a0a", stroke: "#ef4444", text: "#fee2e2", accent: "#f87171" },
+  credential: { fill: "#3b0764", stroke: "#d946ef", text: "#fae8ff", accent: "#e879f9" },
+  tool: { fill: "#2e1065", stroke: "#a855f7", text: "#f3e8ff", accent: "#c084fc" },
+  environment: { fill: "#164e63", stroke: "#06b6d4", text: "#cffafe", accent: "#22d3ee" },
+  cluster: { fill: "#312e81", stroke: "#6366f1", text: "#e0e7ff", accent: "#818cf8" },
+  unknown: { fill: "#27272a", stroke: "#71717a", text: "#f4f4f5", accent: "#a1a1aa" },
+};
+
+export function ExposurePathCommandCenter({
+  path,
+  actions = [],
+}: {
+  path: ExposurePath;
+  actions?: ExposurePathCommandAction[] | undefined;
+}) {
+  const fixLabel = pathFixLabel(path);
+  const evidence = path.evidence;
+  const primaryAction = actions[0];
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_280px]">
+        <div>
+          <p className="text-[10px] uppercase tracking-[0.2em] text-orange-400">Command center</p>
+          <h2 className="mt-1 text-lg font-semibold text-[color:var(--foreground)]">{pathDisplayTitle(path)}</h2>
+          <p className="mt-2 max-w-4xl text-sm leading-6 text-[color:var(--text-secondary)]">
+            {path.summary ||
+              evidence?.attackVectorSummary ||
+              "Selected exposure path with the entities, relationships, and evidence needed to choose the first fix."}
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-2 text-xs">
+          <CommandMetric label="Risk" value={path.riskScore.toFixed(1)} tone="red" />
+          <CommandMetric label="Hops" value={String(Math.max(0, path.hops.length - 1))} />
+          <CommandMetric label="Agents" value={String(path.affectedAgents.length)} />
+          <CommandMetric label="Fix" value={fixLabel ?? "triage"} tone={fixLabel ? "green" : "zinc"} />
+        </div>
+      </div>
+
+      <section aria-label="Selected exposure path graph">
+        <div className="mb-2 flex items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+          <Route className="h-3.5 w-3.5" />
+          Selected path graph
+        </div>
+        <ExposurePathGraph path={path} />
+      </section>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_300px]">
+        <section aria-label="Relationship proof">
+          <div className="mb-2 text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+            Relationship proof
+          </div>
+          <div className="max-h-64 overflow-y-auto divide-y divide-[color:var(--border-subtle)] rounded-xl border border-[color:var(--border-subtle)]">
+            {path.relationships.slice(0, 5).map((relationship) => (
+              <div key={relationship.id} className="grid gap-2 px-3 py-2 text-xs md:grid-cols-[1fr_auto]">
+                <div className="min-w-0">
+                  <span className="font-mono text-[color:var(--foreground)]">{relationship.relationship}</span>
+                  <span className="ml-2 break-all text-[color:var(--text-tertiary)]">
+                    {relationship.source} → {relationship.target}
+                  </span>
+                </div>
+                <div className="flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
+                  <span>{relationship.direction ?? "directed"}</span>
+                  <span>{relationship.traversable === false ? "blocked" : "traversable"}</span>
+                  {relationship.confidence && <span>{relationship.confidence}</span>}
+                </div>
+              </div>
+            ))}
+            {path.relationships.length === 0 && (
+              <div className="px-3 py-3 text-xs text-[color:var(--text-secondary)]">No relationship evidence attached.</div>
+            )}
+          </div>
+        </section>
+
+        <aside aria-label="Evidence drawer" className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+          <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">Evidence drawer</div>
+          <EvidenceRow label="Findings" values={path.findings} />
+          <EvidenceRow label="Agents" values={path.affectedAgents} />
+          <EvidenceRow label="Servers" values={path.affectedServers} />
+          <EvidenceRow label="Tools" values={path.reachableTools} emptyLabel="none" />
+          <EvidenceRow label="Credentials" values={path.exposedCredentials} emptyLabel="none" />
+          <div className="rounded-xl border border-[color:var(--border-subtle)] px-3 py-2 text-xs">
+            <div className="flex items-center gap-2 text-[color:var(--text-secondary)]">
+              <ShieldAlert className="h-3.5 w-3.5 text-red-300" />
+              <span>CVSS {evidence?.cvssScore ?? "n/a"}</span>
+              <span>EPSS {typeof evidence?.epssScore === "number" ? evidence.epssScore.toFixed(3) : "n/a"}</span>
+              {evidence?.isKev && <span className="font-semibold text-red-300">KEV</span>}
+            </div>
+          </div>
+        </aside>
+      </div>
+
+      {primaryAction && (
+        <Link
+          href={primaryAction.href}
+          className="flex items-start gap-3 rounded-xl border border-emerald-500/25 bg-emerald-500/10 px-4 py-3 text-sm transition hover:border-emerald-400/60"
+        >
+          <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-300" />
+          <span>
+            <span className="block font-semibold text-[color:var(--foreground)]">{primaryAction.title}</span>
+            <span className="mt-1 block text-xs leading-5 text-[color:var(--text-secondary)]">{primaryAction.detail}</span>
+          </span>
+        </Link>
+      )}
+    </div>
+  );
+}
+
+function ExposurePathGraph({ path }: { path: ExposurePath }) {
+  const layout = buildPathGraphLayout(path);
+
+  return (
+    <div className="overflow-x-auto rounded-2xl border border-[color:var(--border-subtle)] bg-[#05070b]">
+      <svg
+        viewBox={`0 0 ${layout.width} ${layout.height}`}
+        role="img"
+        aria-label={`Selected exposure path graph for ${pathDisplayTitle(path)}`}
+        className="block h-auto min-w-[760px] md:min-w-0 md:w-full"
+      >
+        <defs>
+          <marker id="exposure-arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+            <path d="M0,0 L0,6 L9,3 z" fill="#94a3b8" />
+          </marker>
+          <filter id="node-shadow" x="-20%" y="-20%" width="140%" height="140%">
+            <feDropShadow dx="0" dy="10" stdDeviation="10" floodColor="#000000" floodOpacity="0.35" />
+          </filter>
+        </defs>
+
+        <rect x="0" y="0" width={layout.width} height={layout.height} fill="#05070b" />
+        <g opacity="0.18">
+          {Array.from({ length: 10 }).map((_, index) => (
+            <line key={index} x1="0" y1={34 + index * 38} x2={layout.width} y2={34 + index * 38} stroke="#334155" strokeWidth="1" />
+          ))}
+        </g>
+
+        {layout.edges.map((edge) => (
+          <path
+            key={edge.id}
+            d={edge.path}
+            fill="none"
+            stroke={edge.stroke}
+            strokeWidth="3"
+            strokeLinecap="round"
+            markerEnd="url(#exposure-arrow)"
+            opacity="0.88"
+          >
+            <title>{edge.label}</title>
+          </path>
+        ))}
+
+        {layout.relationshipLabels.map((label) => (
+          <g key={label.id} transform={`translate(${label.x} ${label.y})`}>
+            <rect x="-52" y="-11" width="104" height="22" rx="11" fill="#0f172a" stroke="#334155" />
+            <text x="0" y="4" textAnchor="middle" fill="#cbd5e1" fontSize="11" fontFamily="var(--font-mono), monospace">
+              {label.text}
+            </text>
+          </g>
+        ))}
+
+        {layout.nodes.map((node, index) => {
+          const style = GRAPH_ROLE_STYLE[node.role] ?? GRAPH_ROLE_STYLE.unknown;
+          const meta = ROLE_META[node.role] ?? ROLE_META.unknown;
+          return (
+            <g key={`${node.id}-${index}`} transform={`translate(${node.x} ${node.y})`} filter="url(#node-shadow)">
+              <rect width={layout.nodeWidth} height={layout.nodeHeight} rx="14" fill={style.fill} stroke={style.stroke} strokeWidth="2" />
+              <circle cx="18" cy="20" r="5" fill={style.accent} />
+              <text x="32" y="24" fill={style.accent} fontSize="10" fontWeight="700" letterSpacing="2" fontFamily="var(--font-mono), monospace">
+                {meta.label.toUpperCase()}
+              </text>
+              <text x="16" y="50" fill={style.text} fontSize="16" fontWeight="700" fontFamily="var(--font-sans), system-ui">
+                {truncateGraphText(node.label, 17)}
+              </text>
+              {node.severity && (
+                <text x="16" y="70" fill="#94a3b8" fontSize="11" letterSpacing="1.4" fontFamily="var(--font-mono), monospace">
+                  {String(node.severity).toUpperCase()}
+                </text>
+              )}
+              <title>{`${meta.label}: ${node.label}`}</title>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+
+function buildPathGraphLayout(path: ExposurePath) {
+  const width = 920;
+  const nodeWidth = 178;
+  const nodeHeight = 84;
+  const columns = Math.min(3, Math.max(1, path.hops.length));
+  const rows = Math.max(1, Math.ceil(path.hops.length / columns));
+  const xGap = columns > 1 ? (width - nodeWidth - 64) / (columns - 1) : 0;
+  const yGap = 138;
+  const height = 52 + rows * nodeHeight + (rows - 1) * (yGap - nodeHeight) + 36;
+  const nodes = path.hops.map((hop, index) => {
+    const row = Math.floor(index / columns);
+    const col = index % columns;
+    const visualCol = row % 2 === 0 ? col : columns - 1 - col;
+    return {
+      ...hop,
+      x: 32 + visualCol * xGap,
+      y: 38 + row * yGap,
+    };
+  });
+  const edges = nodes.slice(0, -1).map((source, index) => {
+    const target = nodes[index + 1]!;
+    const relationship = relationshipForPathStep(path, source.id, target.id, index);
+    const startX = source.x + nodeWidth;
+    const startY = source.y + nodeHeight / 2;
+    const endX = target.x;
+    const endY = target.y + nodeHeight / 2;
+    const sameRow = Math.abs(startY - endY) < 10;
+    const control = sameRow ? Math.max(48, Math.abs(endX - startX) / 2) : 70;
+    const pathD = sameRow
+      ? `M ${startX} ${startY} C ${startX + control} ${startY}, ${endX - control} ${endY}, ${endX} ${endY}`
+      : `M ${source.x + nodeWidth / 2} ${source.y + nodeHeight} C ${source.x + nodeWidth / 2} ${source.y + nodeHeight + control}, ${target.x + nodeWidth / 2} ${target.y - control}, ${target.x + nodeWidth / 2} ${target.y}`;
+    const style = GRAPH_ROLE_STYLE[target.role] ?? GRAPH_ROLE_STYLE.unknown;
+    return {
+      id: `${source.id}->${target.id}`,
+      path: pathD,
+      stroke: style.stroke,
+      label: relationship,
+      labelX: sameRow ? (startX + endX) / 2 : (source.x + target.x + nodeWidth) / 2,
+      labelY: sameRow ? startY - 16 : (source.y + target.y + nodeHeight) / 2,
+    };
+  });
+  const relationshipLabels = edges.map((edge) => ({
+    id: `${edge.id}:label`,
+    text: truncateGraphText(edge.label, 14),
+    x: edge.labelX,
+    y: edge.labelY,
+  }));
+
+  return { width, height, nodeWidth, nodeHeight, nodes, edges, relationshipLabels };
+}
+
+function relationshipForPathStep(path: ExposurePath, source: string, target: string, index: number): string {
+  const byEndpoints = path.relationships.find((relationship) => relationship.source === source && relationship.target === target);
+  if (byEndpoints) return byEndpoints.relationship;
+  return path.relationships[index]?.relationship ?? "reaches";
+}
+
+function truncateGraphText(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, Math.max(1, maxLength - 1))}…` : value;
+}
+
+function CommandMetric({ label, value, tone = "zinc" }: { label: string; value: string; tone?: "red" | "green" | "zinc" }) {
+  const toneClass =
+    tone === "red"
+      ? "border-red-500/25 bg-red-500/10 text-red-200"
+      : tone === "green"
+        ? "border-emerald-500/25 bg-emerald-500/10 text-emerald-200"
+        : "border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]";
+
+  return (
+    <div className={`rounded-xl border px-3 py-2 ${toneClass}`}>
+      <div className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">{label}</div>
+      <div className="mt-1 truncate font-mono text-sm font-semibold">{value}</div>
+    </div>
+  );
+}
+
+function EvidenceRow({
+  label,
+  values,
+  emptyLabel = "none",
+}: {
+  label: string;
+  values: string[];
+  emptyLabel?: string;
+}) {
+  return (
+    <div className="rounded-xl border border-[color:var(--border-subtle)] px-3 py-2 text-xs">
+      <div className="mb-1 text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">{label}</div>
+      <div className="flex flex-wrap gap-1.5">
+        {(values.length > 0 ? values : [emptyLabel]).slice(0, 4).map((value) => (
+          <span
+            key={`${label}-${value}`}
+            className="rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2 py-0.5 text-[color:var(--text-secondary)]"
+          >
+            {value}
+          </span>
+        ))}
+        {values.length > 4 && (
+          <span className="rounded border border-[color:var(--border-subtle)] px-2 py-0.5 text-[color:var(--text-tertiary)]">
+            +{values.length - 4}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/tests/exposure-path-command-center.test.tsx
+++ b/ui/tests/exposure-path-command-center.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ExposurePathCommandCenter } from "@/components/exposure-path-command-center";
+import type { ExposurePath } from "@/lib/exposure-path";
+
+const basePath: ExposurePath = {
+  id: "path-1",
+  label: "analyst-agent -> database -> werkzeug -> CVE-2026-0002",
+  summary: "Agent reaches a vulnerable package through the database MCP server.",
+  riskScore: 9.6,
+  severity: "critical",
+  source: { id: "agent:analyst", label: "analyst-agent", role: "agent" },
+  target: { id: "vuln:werkzeug:CVE-2026-0002", label: "CVE-2026-0002", role: "finding", severity: "critical" },
+  hops: [
+    { id: "agent:analyst", label: "analyst-agent", role: "agent" },
+    { id: "server:database", label: "database", role: "server" },
+    { id: "pkg:werkzeug", label: "werkzeug@2.2.2", role: "package", severity: "critical" },
+    { id: "vuln:werkzeug:CVE-2026-0002", label: "CVE-2026-0002", role: "finding", severity: "critical" },
+    { id: "tool:execute_sql", label: "execute_sql", role: "tool" },
+    { id: "cred:DATABASE_URL", label: "DATABASE_URL", role: "credential" },
+  ],
+  relationships: [
+    {
+      id: "agent->server",
+      source: "agent:analyst",
+      target: "server:database",
+      relationship: "uses",
+      direction: "directed",
+      traversable: true,
+      confidence: "observed",
+    },
+    {
+      id: "pkg->vuln",
+      source: "pkg:werkzeug",
+      target: "vuln:werkzeug:CVE-2026-0002",
+      relationship: "vulnerable_to",
+      direction: "directed",
+      traversable: true,
+      confidence: "scanner",
+    },
+  ],
+  nodeIds: ["agent:analyst", "server:database", "pkg:werkzeug", "vuln:werkzeug:CVE-2026-0002"],
+  edgeIds: ["agent->server", "pkg->vuln"],
+  findings: ["CVE-2026-0002"],
+  affectedAgents: ["analyst-agent"],
+  affectedServers: ["database"],
+  reachableTools: ["execute_sql"],
+  exposedCredentials: ["DATABASE_URL"],
+  dependencyContext: {
+    packageName: "werkzeug",
+    packageVersion: "2.2.2",
+    ecosystem: "pypi",
+    serverName: "database",
+  },
+  fix: {
+    label: "Upgrade werkzeug",
+    version: "2.2.3",
+  },
+  evidence: {
+    cvssScore: 9.8,
+    epssScore: 0.834,
+    isKev: true,
+    attackVectorSummary: "Database MCP server exposes SQL execution.",
+  },
+};
+
+describe("ExposurePathCommandCenter", () => {
+  it("renders the selected exposure path as a command-center investigation", () => {
+    render(
+      <ExposurePathCommandCenter
+        path={basePath}
+        actions={[{ title: "Validate the lead finding", detail: "Open CVE evidence.", href: "/findings?cve=CVE-2026-0002" }]}
+      />,
+    );
+
+    expect(screen.getByText("Command center")).toBeInTheDocument();
+    expect(screen.getByText("analyst-agent -> werkzeug@2.2.2 -> CVE-2026-0002")).toBeInTheDocument();
+    expect(screen.getByText("Selected path graph")).toBeInTheDocument();
+    expect(screen.getByText("Relationship proof")).toBeInTheDocument();
+    expect(screen.getByText("Evidence drawer")).toBeInTheDocument();
+    expect(screen.getAllByText("uses").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("vulnerable_to").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("DATABASE_URL").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("execute_sql").length).toBeGreaterThan(0);
+    expect(screen.getByText("CVSS 9.8")).toBeInTheDocument();
+    expect(screen.getByText("EPSS 0.834")).toBeInTheDocument();
+    expect(screen.getByText("KEV")).toBeInTheDocument();
+    expect(screen.getByText("Validate the lead finding")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Summary

Move `/security-graph` from a long report-style selected-path page to a compact fix-first graph command center.

What changed

- puts the selected exposure path at the top of the page instead of burying it below the snapshot summary and queue
- adds an actual selected-path graph surface with typed nodes, directional edges, relationship labels, and entity-specific colors
- keeps the command center compact by removing the duplicated legacy selected-path detail section
- keeps the attack-path queue as a bounded internal scroll area instead of extending the page indefinitely
- preserves relationship proof, evidence drawer, remediation action, rank, relationship count, and provenance around the graph
- keeps mobile readable by preserving a minimum graph width with horizontal scroll instead of shrinking the graph into unreadable text

Why

The previous graph surfaces were too report-like. This PR makes the first graph viewport explain the security path directly: what is exposed, which entities and relationships prove it, and what action to take next. It is still the focused-path renderer; the Sigma/WebGL environment renderer remains the next graph-tech PR.

Validation

- `npm test -- --run tests/exposure-path-command-center.test.tsx tests/exposure-path.test.ts tests/attack-paths.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Playwright browser smoke against `/security-graph` with mocked graph API data at 1440x1000 and 390x900; verified selected path graph renders at the top, no duplicated legacy Selected path section, and mobile graph keeps readable width
- `git diff --check origin/main...HEAD`
- commit pre-commit hooks: end-of-file, trailing whitespace, private-key, case-conflict, merge-conflict, mixed-line-ending, duplicate artifact guard

Known local environment note

- `npm run verify:toolchain` correctly fails on this workstation because local Node is `25.9.0`; the repo declares `>=22 <25`. I did not weaken the toolchain gate.
