### PR TITLE
add large graph overview renderer

### DIFF
--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -17,6 +17,7 @@ import { AlertTriangle, Loader2, Route, ShieldAlert } from "lucide-react";
 
 import { AttackPathCard } from "@/components/attack-path-card";
 import { GraphEvidenceExportButton, GraphLegend, FullscreenButton } from "@/components/graph-chrome";
+import { LargeGraphOverview } from "@/components/large-graph-overview";
 import { LineageDetailPanel } from "@/components/lineage-detail";
 import {
   GraphControlGroup,
@@ -85,6 +86,7 @@ import {
   type UnifiedGraphResponse,
 } from "@/lib/api";
 import { buildUnifiedFlowGraph } from "@/lib/unified-graph-flow";
+import { shouldUseLargeGraphOverview } from "@/lib/large-graph-overview";
 import {
   applyFilters,
   decodeFiltersFromParams,
@@ -906,9 +908,10 @@ function GraphPageInner() {
     clusterCount: aggregated.clusters.size,
   });
 
-  const displayNodes = useMemo(() => {
+  const lineageLayoutNodes = layoutNodes as Node<LineageNodeData>[];
+  const displayNodes = useMemo<Node<LineageNodeData>[]>(() => {
     if (attackPathNodeIds) {
-      return layoutNodes.map((node) => {
+      return lineageLayoutNodes.map((node) => {
         const inPath = attackPathNodeIds.has(node.id);
         return {
           ...node,
@@ -923,7 +926,7 @@ function GraphPageInner() {
       });
     }
     if (reachabilitySummary) {
-      return layoutNodes.map((node) => {
+      return lineageLayoutNodes.map((node) => {
         const inReach = reachabilitySummary.nodeIds.has(node.id);
         const isRoot = node.id === reachabilitySummary.rootId;
         return {
@@ -939,7 +942,7 @@ function GraphPageInner() {
       });
     }
     if (!localNeighborhoodIds) {
-      return layoutNodes.map((node) => ({
+      return lineageLayoutNodes.map((node) => ({
         ...node,
         data: {
           ...node.data,
@@ -947,7 +950,7 @@ function GraphPageInner() {
         },
       }));
     }
-    return layoutNodes.map((node) => {
+    return lineageLayoutNodes.map((node) => {
       const isFocused = node.id === activeFocusId;
       const isConnected = localNeighborhoodIds.has(node.id);
       const dimmed = !isConnected;
@@ -962,7 +965,7 @@ function GraphPageInner() {
         },
       };
     });
-  }, [layoutNodes, localNeighborhoodIds, attackPathNodeIds, reachabilitySummary, activeFocusId, effectiveLodBand]);
+  }, [lineageLayoutNodes, localNeighborhoodIds, attackPathNodeIds, reachabilitySummary, activeFocusId, effectiveLodBand]);
 
   const compressedGroupCount = aggregatedClusterNodes.length;
   const compressedNodeCount = useMemo(
@@ -1056,6 +1059,14 @@ function GraphPageInner() {
   );
 
   const graphOnlyFindings = displayNodes.length > 0 && !hasContextualGraph;
+  const useLargeGraphOverview = shouldUseLargeGraphOverview({
+    nodeCount: displayNodes.length,
+    edgeCount: displayEdges.length,
+    captureMode,
+    selectedAttackPath: Boolean(selectedAttackPath),
+    reachabilityActive: Boolean(reachabilitySummary),
+    graphOnlyFindings,
+  });
   const graphPanelError = error && snapshots.length > 0 ? graphErrorState(error) : null;
   const findingNodes = useMemo(
     () =>
@@ -1140,6 +1151,12 @@ function GraphPageInner() {
     setPinnedFocusId((current) => (current === node.id ? null : node.id));
     setHoveredNodeId(null);
   }, [loadReachabilityDrillIn]);
+
+  const onLargeGraphNodeSelect = useCallback((nodeId: string) => {
+    const node = displayNodes.find((candidate) => candidate.id === nodeId);
+    if (!node) return;
+    onNodeClick({} as React.MouseEvent, node);
+  }, [displayNodes, onNodeClick]);
 
   const onNodeMouseEnter = useCallback((_event: React.MouseEvent, node: Node) => {
     setHoveredNodeId(node.id);
@@ -1773,6 +1790,13 @@ function GraphPageInner() {
               onExpandScope={() =>
                 setFilters(createExpandedGraphFilters(filters.agentName ?? flow.agentNames[0] ?? null))
               }
+            />
+          ) : useLargeGraphOverview ? (
+            <LargeGraphOverview
+              nodes={displayNodes}
+              edges={displayEdges}
+              legendItems={legendItems}
+              onNodeSelect={onLargeGraphNodeSelect}
             />
           ) : (
             <ReactFlow

--- a/ui/components/large-graph-overview.tsx
+++ b/ui/components/large-graph-overview.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Edge, Node } from "@xyflow/react";
+import { Activity, GitBranch, Layers3, Network, ShieldAlert } from "lucide-react";
+
+import type { LineageNodeData } from "@/components/lineage-nodes";
+import { GraphLegend } from "@/components/graph-chrome";
+import type { LegendItem } from "@/lib/graph-utils";
+import {
+  buildLargeGraphOverviewModel,
+  summarizeLargeGraphOverview,
+  type LargeGraphNode,
+} from "@/lib/large-graph-overview";
+
+interface LargeGraphOverviewProps {
+  nodes: Node<LineageNodeData>[];
+  edges: Edge[];
+  legendItems: LegendItem[];
+  onNodeSelect?: (nodeId: string) => void;
+}
+
+interface Viewport {
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+}
+
+function StatPill({
+  icon: Icon,
+  label,
+  value,
+  tone = "zinc",
+}: {
+  icon: typeof Network;
+  label: string;
+  value: string;
+  tone?: "zinc" | "red" | "amber" | "cyan";
+}) {
+  const toneClass = {
+    zinc: "border-zinc-800 bg-zinc-950/70 text-zinc-300",
+    red: "border-red-500/30 bg-red-950/25 text-red-100",
+    amber: "border-amber-500/30 bg-amber-950/25 text-amber-100",
+    cyan: "border-cyan-500/30 bg-cyan-950/25 text-cyan-100",
+  }[tone];
+
+  return (
+    <div className={`flex min-w-0 items-center gap-2 rounded-lg border px-2.5 py-2 ${toneClass}`}>
+      <Icon className="h-4 w-4 shrink-0" />
+      <span className="min-w-0 truncate text-[11px] uppercase tracking-[0.14em] text-zinc-500">{label}</span>
+      <span className="ml-auto shrink-0 font-mono text-sm font-semibold">{value}</span>
+    </div>
+  );
+}
+
+function RelationshipRail({ items }: { items: Array<{ relationship: string; count: number }> }) {
+  if (items.length === 0) return null;
+  return (
+    <div className="flex min-w-0 flex-wrap items-center gap-2">
+      {items.map((item) => (
+        <span
+          key={item.relationship}
+          className="inline-flex items-center gap-1.5 rounded-full border border-zinc-800 bg-zinc-950/75 px-2.5 py-1 text-[11px] text-zinc-300"
+        >
+          <span className="max-w-36 truncate" title={item.relationship}>
+            {item.relationship.replace(/_/g, " ")}
+          </span>
+          <span className="font-mono text-zinc-500">{item.count}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function graphBounds(nodes: LargeGraphNode[]) {
+  if (nodes.length === 0) return { minX: -1, maxX: 1, minY: -1, maxY: 1 };
+  return nodes.reduce(
+    (bounds, node) => ({
+      minX: Math.min(bounds.minX, node.x),
+      maxX: Math.max(bounds.maxX, node.x),
+      minY: Math.min(bounds.minY, node.y),
+      maxY: Math.max(bounds.maxY, node.y),
+    }),
+    { minX: Infinity, maxX: -Infinity, minY: Infinity, maxY: -Infinity },
+  );
+}
+
+function fitViewport(nodes: LargeGraphNode[], width: number, height: number): Viewport {
+  const bounds = graphBounds(nodes);
+  const graphWidth = Math.max(1, bounds.maxX - bounds.minX);
+  const graphHeight = Math.max(1, bounds.maxY - bounds.minY);
+  const scale = Math.max(0.08, Math.min(1.2, Math.min(width / graphWidth, height / graphHeight) * 0.82));
+  return {
+    scale,
+    offsetX: width / 2 - ((bounds.minX + bounds.maxX) / 2) * scale,
+    offsetY: height / 2 - ((bounds.minY + bounds.maxY) / 2) * scale,
+  };
+}
+
+function screenToGraph(x: number, y: number, viewport: Viewport): { x: number; y: number } {
+  return {
+    x: (x - viewport.offsetX) / viewport.scale,
+    y: (y - viewport.offsetY) / viewport.scale,
+  };
+}
+
+function drawGraph(
+  canvas: HTMLCanvasElement,
+  model: ReturnType<typeof buildLargeGraphOverviewModel>,
+  viewport: Viewport,
+  selectedNodeId: string | null,
+) {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  const width = canvas.clientWidth;
+  const height = canvas.clientHeight;
+  const ratio = window.devicePixelRatio || 1;
+  canvas.width = Math.max(1, Math.floor(width * ratio));
+  canvas.height = Math.max(1, Math.floor(height * ratio));
+  ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+  ctx.clearRect(0, 0, width, height);
+
+  ctx.fillStyle = "#050505";
+  ctx.fillRect(0, 0, width, height);
+  ctx.save();
+  ctx.translate(viewport.offsetX, viewport.offsetY);
+  ctx.scale(viewport.scale, viewport.scale);
+
+  for (const edge of model.edges) {
+    if (edge.hidden) continue;
+    const source = model.nodeById.get(edge.source);
+    const target = model.nodeById.get(edge.target);
+    if (!source || !target || source.hidden || target.hidden) continue;
+    const selected = selectedNodeId && (edge.source === selectedNodeId || edge.target === selectedNodeId);
+    ctx.globalAlpha = selectedNodeId ? (selected ? 0.78 : 0.08) : 0.25;
+    ctx.strokeStyle = edge.color;
+    ctx.lineWidth = selected ? edge.size * 2.1 : edge.size;
+    ctx.beginPath();
+    ctx.moveTo(source.x, source.y);
+    ctx.lineTo(target.x, target.y);
+    ctx.stroke();
+  }
+
+  const orderedNodes = [...model.nodes].sort((left, right) => {
+    const leftScore = left.forceLabel || left.highlighted ? 1 : 0;
+    const rightScore = right.forceLabel || right.highlighted ? 1 : 0;
+    return leftScore - rightScore;
+  });
+  for (const node of orderedNodes) {
+    if (node.hidden) continue;
+    const selected = selectedNodeId === node.id;
+    const dimmed = selectedNodeId !== null && !selected;
+    ctx.globalAlpha = dimmed ? 0.34 : 1;
+    ctx.fillStyle = selected ? "#f8fafc" : node.color;
+    ctx.beginPath();
+    ctx.arc(node.x, node.y, selected ? node.size * 1.9 : node.size, 0, Math.PI * 2);
+    ctx.fill();
+    if (selected || node.forceLabel) {
+      ctx.globalAlpha = selected ? 1 : 0.78;
+      ctx.font = `${Math.max(10, 12 / viewport.scale)}px Inter, ui-sans-serif, system-ui, sans-serif`;
+      ctx.fillStyle = "#e4e4e7";
+      ctx.fillText(node.label, node.x + node.size + 4 / viewport.scale, node.y - node.size);
+    }
+  }
+
+  ctx.restore();
+  ctx.globalAlpha = 1;
+}
+
+export function LargeGraphOverview({
+  nodes,
+  edges,
+  legendItems,
+  onNodeSelect,
+}: LargeGraphOverviewProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const dragRef = useRef<{ x: number; y: number; offsetX: number; offsetY: number } | null>(null);
+  const model = useMemo(() => buildLargeGraphOverviewModel(nodes, edges), [nodes, edges]);
+  const summary = useMemo(() => summarizeLargeGraphOverview(nodes, edges), [nodes, edges]);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [viewport, setViewport] = useState<Viewport>({ scale: 1, offsetX: 0, offsetY: 0 });
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const resize = () => setViewport(fitViewport(model.nodes, canvas.clientWidth, canvas.clientHeight));
+    resize();
+    const observer = new ResizeObserver(resize);
+    observer.observe(canvas);
+    return () => observer.disconnect();
+  }, [model]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    drawGraph(canvas, model, viewport, selectedNodeId);
+  }, [model, selectedNodeId, viewport]);
+
+  return (
+    <div className="flex h-full min-h-[72vh] flex-col overflow-hidden rounded-xl border border-zinc-800 bg-zinc-950 shadow-2xl shadow-black/30">
+      <div className="border-b border-zinc-800 bg-zinc-950/95 p-3">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <span className="inline-flex shrink-0 items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-950/25 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-200">
+            <Network className="h-3.5 w-3.5" />
+            Large graph overview
+          </span>
+          <span className="min-w-0 text-xs text-zinc-500">
+            Canvas renderer for broad estate exploration without loading the focused card graph.
+          </span>
+        </div>
+        <div className="mt-2">
+          <RelationshipRail items={summary.topRelationships} />
+        </div>
+        <div className="mt-3 grid grid-cols-2 gap-2 lg:grid-cols-5">
+          <StatPill icon={Layers3} label="Nodes" value={summary.nodes.toLocaleString()} tone="cyan" />
+          <StatPill icon={GitBranch} label="Edges" value={summary.edges.toLocaleString()} />
+          <StatPill icon={ShieldAlert} label="Findings" value={summary.findings.toLocaleString()} tone="amber" />
+          <StatPill icon={ShieldAlert} label="Critical" value={summary.criticalFindings.toLocaleString()} tone="red" />
+          <StatPill icon={Activity} label="Creds/tools" value={`${summary.credentials}/${summary.tools}`} />
+        </div>
+      </div>
+
+      <div className="relative min-h-0 flex-1 bg-[radial-gradient(circle_at_25%_15%,rgba(16,185,129,0.10),transparent_28%),radial-gradient(circle_at_75%_65%,rgba(59,130,246,0.10),transparent_30%),#050505]">
+        <canvas
+          ref={canvasRef}
+          className="h-full min-h-[58vh] w-full cursor-grab active:cursor-grabbing"
+          aria-label="Large security graph overview"
+          onMouseDown={(event) => {
+            dragRef.current = {
+              x: event.clientX,
+              y: event.clientY,
+              offsetX: viewport.offsetX,
+              offsetY: viewport.offsetY,
+            };
+          }}
+          onMouseMove={(event) => {
+            const drag = dragRef.current;
+            if (!drag) return;
+            setViewport((current) => ({
+              ...current,
+              offsetX: drag.offsetX + event.clientX - drag.x,
+              offsetY: drag.offsetY + event.clientY - drag.y,
+            }));
+          }}
+          onMouseLeave={() => {
+            dragRef.current = null;
+          }}
+          onMouseUp={(event) => {
+            const drag = dragRef.current;
+            dragRef.current = null;
+            if (drag && Math.hypot(event.clientX - drag.x, event.clientY - drag.y) > 4) return;
+            const rect = event.currentTarget.getBoundingClientRect();
+            const point = screenToGraph(event.clientX - rect.left, event.clientY - rect.top, viewport);
+            let nearest: LargeGraphNode | null = null;
+            let nearestDistance = Infinity;
+            for (const node of model.nodes) {
+              const distance = Math.hypot(node.x - point.x, node.y - point.y);
+              if (distance < nearestDistance) {
+                nearest = node;
+                nearestDistance = distance;
+              }
+            }
+            if (!nearest || nearestDistance * viewport.scale > 18) {
+              setSelectedNodeId(null);
+              return;
+            }
+            setSelectedNodeId(nearest.id);
+            onNodeSelect?.(nearest.id);
+          }}
+          onWheel={(event) => {
+            event.preventDefault();
+            const rect = event.currentTarget.getBoundingClientRect();
+            const before = screenToGraph(event.clientX - rect.left, event.clientY - rect.top, viewport);
+            const nextScale = Math.max(0.04, Math.min(3.2, viewport.scale * (event.deltaY > 0 ? 0.9 : 1.1)));
+            setViewport({
+              scale: nextScale,
+              offsetX: event.clientX - rect.left - before.x * nextScale,
+              offsetY: event.clientY - rect.top - before.y * nextScale,
+            });
+          }}
+        />
+        <div className="pointer-events-auto absolute right-3 top-3 max-w-[min(30rem,calc(100vw-2rem))]">
+          <details className="rounded-xl border border-zinc-800 bg-zinc-950/85 p-2 backdrop-blur">
+            <summary className="cursor-pointer list-none text-[10px] uppercase tracking-[0.18em] text-zinc-400 [&::-webkit-details-marker]:hidden">
+              Legend
+            </summary>
+            <div className="mt-2">
+              <GraphLegend items={legendItems} embedded />
+            </div>
+          </details>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/lib/large-graph-overview.ts
+++ b/ui/lib/large-graph-overview.ts
@@ -1,0 +1,206 @@
+import type { Edge, Node } from "@xyflow/react";
+
+import type { LineageNodeData, LineageNodeType } from "@/components/lineage-nodes";
+import { NODE_COLOR_MAP } from "@/lib/graph-utils";
+import { RELATIONSHIP_COLOR_MAP } from "@/lib/graph-schema";
+
+export const LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD = 500;
+export const LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD = 1200;
+
+export interface LargeGraphOverviewDecision {
+  nodeCount: number;
+  edgeCount: number;
+  captureMode?: boolean;
+  selectedAttackPath?: boolean;
+  reachabilityActive?: boolean;
+  graphOnlyFindings?: boolean;
+}
+
+export interface LargeGraphNode {
+  id: string;
+  x: number;
+  y: number;
+  label: string;
+  color: string;
+  size: number;
+  nodeType: LineageNodeType;
+  severity?: string | undefined;
+  highlighted: boolean;
+  hidden: boolean;
+  forceLabel: boolean;
+}
+
+export interface LargeGraphEdge {
+  id: string;
+  source: string;
+  target: string;
+  relationship: string;
+  color: string;
+  size: number;
+  hidden: boolean;
+}
+
+export interface LargeGraphOverviewModel {
+  nodes: LargeGraphNode[];
+  edges: LargeGraphEdge[];
+  nodeById: Map<string, LargeGraphNode>;
+}
+
+export interface LargeGraphOverviewSummary {
+  nodes: number;
+  edges: number;
+  findings: number;
+  criticalFindings: number;
+  credentials: number;
+  tools: number;
+  topRelationships: Array<{ relationship: string; count: number }>;
+}
+
+export function shouldUseLargeGraphOverview({
+  nodeCount,
+  edgeCount,
+  captureMode = false,
+  selectedAttackPath = false,
+  reachabilityActive = false,
+  graphOnlyFindings = false,
+}: LargeGraphOverviewDecision): boolean {
+  if (captureMode || selectedAttackPath || reachabilityActive || graphOnlyFindings) {
+    return false;
+  }
+  return nodeCount >= LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD || edgeCount >= LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD;
+}
+
+function severityRank(severity?: string): number {
+  switch (severity?.toLowerCase()) {
+    case "critical":
+      return 4;
+    case "high":
+      return 3;
+    case "medium":
+      return 2;
+    case "low":
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+function nodeSize(data: LineageNodeData): number {
+  const severity = severityRank(data.severity);
+  if (data.nodeType === "vulnerability" || data.nodeType === "misconfiguration") {
+    return 3.8 + severity * 1.4;
+  }
+  if (data.nodeType === "credential") return 6.6;
+  if (data.nodeType === "tool") return 6.2;
+  if (typeof data.riskScore === "number" && data.riskScore >= 80) return 7.4;
+  if (data.nodeType === "agent" || data.nodeType === "server" || data.nodeType === "sharedServer") return 5.8;
+  return 4.6;
+}
+
+function fallbackPosition(index: number, total: number): { x: number; y: number } {
+  const ring = Math.floor(Math.sqrt(index));
+  const angle = index * 2.399963229728653;
+  const radius = 130 + Math.max(1, ring) * Math.max(26, Math.min(74, total / 180));
+  return {
+    x: Math.cos(angle) * radius,
+    y: Math.sin(angle) * radius,
+  };
+}
+
+function numericPosition(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function edgeRelationship(edge: Edge): string {
+  const relationship = (edge.data as { relationship?: unknown } | undefined)?.relationship;
+  return typeof relationship === "string" && relationship.length > 0 ? relationship : "related_to";
+}
+
+function edgeSize(edge: Edge): number {
+  const strokeWidth = edge.style?.strokeWidth;
+  if (typeof strokeWidth === "number" && Number.isFinite(strokeWidth)) {
+    return Math.max(0.7, Math.min(2.4, strokeWidth * 0.74));
+  }
+  return edgeRelationship(edge) === "vulnerable_to" ? 1.4 : 0.8;
+}
+
+export function summarizeLargeGraphOverview(
+  nodes: Node<LineageNodeData>[],
+  edges: Edge[],
+): LargeGraphOverviewSummary {
+  const relationshipCounts = new Map<string, number>();
+  for (const edge of edges) {
+    const relationship = edgeRelationship(edge);
+    relationshipCounts.set(relationship, (relationshipCounts.get(relationship) ?? 0) + 1);
+  }
+
+  return {
+    nodes: nodes.length,
+    edges: edges.length,
+    findings: nodes.filter((node) => {
+      const type = node.data.nodeType;
+      return type === "vulnerability" || type === "misconfiguration";
+    }).length,
+    criticalFindings: nodes.filter((node) => severityRank(node.data.severity) >= 4).length,
+    credentials: nodes.filter((node) => node.data.nodeType === "credential").length,
+    tools: nodes.filter((node) => node.data.nodeType === "tool").length,
+    topRelationships: [...relationshipCounts.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .slice(0, 4)
+      .map(([relationship, count]) => ({ relationship, count })),
+  };
+}
+
+export function buildLargeGraphOverviewModel(
+  nodes: Node<LineageNodeData>[],
+  edges: Edge[],
+): LargeGraphOverviewModel {
+  const total = Math.max(nodes.length, 1);
+  const overviewNodes: LargeGraphNode[] = nodes.map((node, index) => {
+    const fallback = fallbackPosition(index, total);
+    const data = node.data;
+    const x = numericPosition(node.position?.x) ?? fallback.x;
+    const y = numericPosition(node.position?.y) ?? fallback.y;
+    const severity = severityRank(data.severity);
+    return {
+      id: node.id,
+      x,
+      y,
+      label: data.label,
+      color: NODE_COLOR_MAP[data.nodeType] ?? "#71717a",
+      size: nodeSize(data),
+      nodeType: data.nodeType,
+      severity: data.severity,
+      highlighted: data.highlighted === true,
+      hidden: data.dimmed === true,
+      forceLabel:
+        data.highlighted === true ||
+        severity >= 4 ||
+        data.nodeType === "agent" ||
+        data.nodeType === "server" ||
+        data.nodeType === "sharedServer",
+    };
+  });
+  const nodeById = new Map(overviewNodes.map((node) => [node.id, node]));
+  const overviewEdges: LargeGraphEdge[] = edges.flatMap((edge, index) => {
+    if (!nodeById.has(edge.source) || !nodeById.has(edge.target)) return [];
+    const relationship = edgeRelationship(edge);
+    return [
+      {
+        id: edge.id || `${edge.source}:${edge.target}:${relationship}:${index}`,
+        source: edge.source,
+        target: edge.target,
+        relationship,
+        color: RELATIONSHIP_COLOR_MAP[relationship] ?? "#52525b",
+        size: edgeSize(edge),
+        hidden: edge.hidden === true,
+      },
+    ];
+  });
+
+  return {
+    nodes: overviewNodes,
+    edges: overviewEdges,
+    nodeById,
+  };
+}

--- a/ui/tests/large-graph-overview.test.ts
+++ b/ui/tests/large-graph-overview.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import type { Edge, Node } from "@xyflow/react";
+
+import type { LineageNodeData } from "@/components/lineage-nodes";
+import {
+  buildLargeGraphOverviewModel,
+  LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD,
+  LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD,
+  shouldUseLargeGraphOverview,
+  summarizeLargeGraphOverview,
+} from "@/lib/large-graph-overview";
+
+function node(id: string, data: Partial<LineageNodeData> = {}): Node<LineageNodeData> {
+  return {
+    id,
+    position: { x: data.nodeType === "agent" ? 0 : 100, y: data.nodeType === "agent" ? 0 : 80 },
+    data: {
+      label: id,
+      nodeType: "package",
+      ...data,
+    },
+  };
+}
+
+function edge(id: string, source: string, target: string, relationship = "depends_on"): Edge {
+  return {
+    id,
+    source,
+    target,
+    data: { relationship },
+    style: { strokeWidth: 2 },
+  };
+}
+
+describe("large graph overview", () => {
+  it("only promotes broad, unfocused graph views to the canvas renderer", () => {
+    expect(
+      shouldUseLargeGraphOverview({
+        nodeCount: LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD,
+        edgeCount: 20,
+      }),
+    ).toBe(true);
+    expect(
+      shouldUseLargeGraphOverview({
+        nodeCount: 24,
+        edgeCount: LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD,
+      }),
+    ).toBe(true);
+    expect(
+      shouldUseLargeGraphOverview({
+        nodeCount: LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD + 10,
+        edgeCount: 20,
+        selectedAttackPath: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldUseLargeGraphOverview({
+        nodeCount: LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD + 10,
+        edgeCount: 20,
+        reachabilityActive: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldUseLargeGraphOverview({
+        nodeCount: LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD + 10,
+        edgeCount: 20,
+        captureMode: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("converts lineage nodes and relationship edges into drawable model attributes", () => {
+    const model = buildLargeGraphOverviewModel(
+      [
+        node("agent-a", { nodeType: "agent", label: "analyst-agent" }),
+        node("pkg-a", { nodeType: "package", label: "requests", riskScore: 82 }),
+        node("cve-a", { nodeType: "vulnerability", label: "CVE-2026-0001", severity: "critical" }),
+      ],
+      [
+        edge("agent-pkg", "agent-a", "pkg-a", "uses"),
+        edge("pkg-cve", "pkg-a", "cve-a", "vulnerable_to"),
+        edge("missing", "pkg-a", "does-not-exist", "depends_on"),
+      ],
+    );
+
+    expect(model.nodes).toHaveLength(3);
+    expect(model.edges).toHaveLength(2);
+    expect(model.nodeById.get("agent-a")?.forceLabel).toBe(true);
+    expect(model.nodeById.get("cve-a")?.size).toBeGreaterThan(
+      model.nodeById.get("pkg-a")?.size ?? 0,
+    );
+    expect(model.edges.find((entry) => entry.id === "pkg-cve")?.relationship).toBe("vulnerable_to");
+    expect(model.edges.some((entry) => entry.id === "missing")).toBe(false);
+  });
+
+  it("summarizes findings and dominant relationship families for the graph header", () => {
+    const nodes = [
+      node("agent-a", { nodeType: "agent" }),
+      node("cred-a", { nodeType: "credential" }),
+      node("tool-a", { nodeType: "tool" }),
+      node("cve-a", { nodeType: "vulnerability", severity: "critical" }),
+      node("misconfig-a", { nodeType: "misconfiguration", severity: "high" }),
+    ];
+    const edges = [
+      edge("e1", "agent-a", "cred-a", "exposes_cred"),
+      edge("e2", "cred-a", "tool-a", "reaches_tool"),
+      edge("e3", "tool-a", "cve-a", "vulnerable_to"),
+      edge("e4", "misconfig-a", "tool-a", "vulnerable_to"),
+    ];
+
+    expect(summarizeLargeGraphOverview(nodes, edges)).toMatchObject({
+      nodes: 5,
+      edges: 4,
+      findings: 2,
+      criticalFindings: 1,
+      credentials: 1,
+      tools: 1,
+      topRelationships: [
+        { relationship: "vulnerable_to", count: 2 },
+        { relationship: "exposes_cred", count: 1 },
+        { relationship: "reaches_tool", count: 1 },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
Summary

Add the first renderer-stack lift for large security graphs: /graph now keeps React Flow for focused attack-path and reachability views, but switches broad estate views to a dependency-free canvas overview when visible graph size crosses the large-graph threshold.

Changes

- add a shared large-graph conversion layer for lineage nodes and relationship edges
- add a canvas overview renderer with relationship summary, node/edge/finding KPIs, legend, pan/zoom, and node-click drill-in handoff
- gate the renderer so focused paths, reachability drill-ins, capture mode, and findings-only fallbacks stay on the existing readable React Flow surface
- add regression coverage for the renderer decision, drawable model attributes, and overview summary

Why

React Flow is still the right tool for 10-500 node investigation paths where cards and labels matter. It is the wrong ceiling for broad estate exploration. This PR introduces the scalable overview mode without adding third-party bundle weight or weakening the focused investigation experience.

Validation

- npm test -- --run tests/large-graph-overview.test.ts tests/graph-utils.test.ts
- npm run test:run
- npm run typecheck
- npm run lint
- npm run build
- npm run bundle:check
- npm run lock:normalize
- git diff --check
- browser smoke on /graph with mocked 760-node / 750-edge estate: canvas overview rendered, screenshot at /tmp/large-graph-overview-1440.png

CI fix note

The original #2533 failed UI Validate because sigma + graphology pushed total client JS to 2740.7 KiB over the 2636.7 KiB budget. This update removes those dependencies and the local bundle gate now passes at 2589.2 KiB.
