### PR TITLE
pin windows endpoint runner to VS 2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,7 +443,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2022]
     env:
       PYTHONUTF8: "1"
       PYTHONIOENCODING: utf-8
@@ -493,7 +493,7 @@ jobs:
         shell: bash
 
       - name: Validate Windows MSI builder
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         env:
           BUNDLE_DIR: ${{ runner.temp }}/endpoint-bundle
         shell: pwsh


### PR DESCRIPTION
Summary
- Pin the endpoint packaging Windows matrix leg to `windows-2022`.
- Keep the Windows MSI validation condition aligned with the pinned runner label.

Root Cause
GitHub announced that `windows-latest` / `windows-2025` will migrate to Visual Studio 2026 in June 2026. The endpoint packaging job performs a Windows MSI dry-run, so leaving it on the floating label creates avoidable CI drift risk.

Validation
- `rg -n "windows-latest|windows-2025|windows-2022|matrix\\.os == 'windows" .github/workflows/ci.yml`
- `git diff --check`
- commit hooks: YAML check, whitespace, private-key scan, merge-conflict check, duplicate artifact guard
