### PR TITLE
Add time-versioned graph edges

### DIFF
--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -119,6 +119,10 @@ class GraphStoreProtocol(Protocol):
 
     def diff_snapshots(self, scan_id_old: str, scan_id_new: str, *, tenant_id: str = "") -> dict[str, Any]: ...
 
+    def active_edges_at(self, at: str, *, tenant_id: str = "") -> list[dict[str, Any]]: ...
+
+    def changed_edges_between_scans(self, scan_id_old: str, scan_id_new: str, *, tenant_id: str = "") -> dict[str, Any]: ...
+
     def list_snapshots(self, *, tenant_id: str = "", limit: int = 50) -> list[dict[str, Any]]: ...
 
     def delete_tenant(self, *, tenant_id: str = "") -> int: ...
@@ -417,6 +421,12 @@ class SQLiteGraphStore:
             traversable=bool(row["traversable"]),
             first_seen=row["first_seen"],
             last_seen=row["last_seen"],
+            valid_from=row["valid_from"] or row["first_seen"],
+            valid_to=row["valid_to"],
+            confidence=row["confidence"],
+            provenance=json.loads(row["provenance"] or "{}"),
+            source_scan_id=row["source_scan_id"] or row["scan_id"],
+            source_run_id=row["source_run_id"] or "",
             evidence=json.loads(row["evidence"]),
             activity_id=row["activity_id"],
         )
@@ -432,6 +442,12 @@ class SQLiteGraphStore:
             traversable=edge.traversable,
             first_seen=edge.first_seen,
             last_seen=edge.last_seen,
+            valid_from=edge.valid_from,
+            valid_to=edge.valid_to,
+            confidence=edge.confidence,
+            provenance=edge.provenance,
+            source_scan_id=edge.source_scan_id,
+            source_run_id=edge.source_run_id,
             evidence=edge.evidence,
             activity_id=edge.activity_id,
         )
@@ -474,7 +490,7 @@ class SQLiteGraphStore:
             params.extend(sorted(_DYNAMIC_RELATIONSHIP_VALUES))
         return conn.execute(
             f"""
-            SELECT source_id, target_id, relationship, direction, weight, traversable, first_seen, last_seen, evidence, activity_id
+            SELECT *
             FROM graph_edges
             WHERE {" AND ".join(where)}
             """,  # nosec B608 - clause fragments and placeholders are generated internally
@@ -890,7 +906,7 @@ class SQLiteGraphStore:
                 return None
             rows = conn.execute(
                 """
-                SELECT source_id, target_id, relationship, direction, weight, traversable, first_seen, last_seen, evidence, activity_id
+                SELECT *
                 FROM graph_edges
                 WHERE tenant_id = ? AND scan_id = ? AND (source_id = ? OR target_id = ?)
                 ORDER BY source_id ASC, target_id ASC, relationship ASC
@@ -1079,6 +1095,34 @@ class SQLiteGraphStore:
             }
         try:
             return sqlite_graph_store.diff_snapshots(conn, scan_id_old, scan_id_new, tenant_id=tenant_id)
+        finally:
+            conn.close()
+
+    def active_edges_at(self, at: str, *, tenant_id: str = "") -> list[dict[str, Any]]:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
+        conn = self._open_ro_conn()
+        if conn is None:
+            return []
+        try:
+            return sqlite_graph_store.active_edges_at(conn, at, tenant_id=tenant_id)
+        finally:
+            conn.close()
+
+    def changed_edges_between_scans(self, scan_id_old: str, scan_id_new: str, *, tenant_id: str = "") -> dict[str, Any]:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
+        conn = self._open_ro_conn()
+        if conn is None:
+            return {
+                "scan_id_old": scan_id_old,
+                "scan_id_new": scan_id_new,
+                "edges_added": [],
+                "edges_removed": [],
+                "edges_changed": [],
+                "edges_unchanged": [],
+                "summary": {"added": 0, "removed": 0, "changed": 0, "unchanged": 0},
+            }
+        try:
+            return sqlite_graph_store.changed_edges_between_scans(conn, scan_id_old, scan_id_new, tenant_id=tenant_id)
         finally:
             conn.close()
 
@@ -1288,30 +1332,14 @@ class SQLiteGraphStore:
             placeholders = ",".join("?" for _ in node_ids)
             rows = conn.execute(
                 f"""
-                SELECT source_id, target_id, relationship, direction, weight, traversable, first_seen, last_seen, evidence, activity_id
+                SELECT *
                 FROM graph_edges
                 WHERE tenant_id = ? AND scan_id = ?
                   AND (source_id IN ({placeholders}) OR target_id IN ({placeholders}))
                 """,  # nosec B608 - placeholders are generated solely from "?" markers
                 [tenant_id, effective_scan_id, *node_ids, *node_ids],
             ).fetchall()
-            from agent_bom.graph import RelationshipType, UnifiedEdge
-
-            return [
-                UnifiedEdge(
-                    source=row["source_id"],
-                    target=row["target_id"],
-                    relationship=RelationshipType(row["relationship"]),
-                    direction=row["direction"],
-                    weight=row["weight"],
-                    traversable=bool(row["traversable"]),
-                    first_seen=row["first_seen"],
-                    last_seen=row["last_seen"],
-                    evidence=json.loads(row["evidence"]),
-                    activity_id=row["activity_id"],
-                )
-                for row in rows
-            ]
+            return [self._edge_from_row(row) for row in rows]
         finally:
             conn.close()
 

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -173,6 +173,12 @@ class PostgresGraphStore:
                     traversable INTEGER DEFAULT 1,
                     first_seen TEXT NOT NULL,
                     last_seen TEXT NOT NULL,
+                    valid_from TEXT DEFAULT '',
+                    valid_to TEXT DEFAULT NULL,
+                    confidence DOUBLE PRECISION DEFAULT 1.0,
+                    provenance TEXT DEFAULT '{}',
+                    source_scan_id TEXT DEFAULT '',
+                    source_run_id TEXT DEFAULT '',
                     evidence TEXT DEFAULT '{}',
                     activity_id INTEGER DEFAULT 1,
                     scan_id TEXT NOT NULL,
@@ -184,6 +190,7 @@ class PostgresGraphStore:
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan ON graph_edges(tenant_id, scan_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_source ON graph_edges(tenant_id, scan_id, source_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_target ON graph_edges(tenant_id, scan_id, target_id)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_valid ON graph_edges(tenant_id, valid_from, valid_to)")
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS graph_snapshots (
@@ -224,6 +231,14 @@ class PostgresGraphStore:
             )
             conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS summary TEXT DEFAULT ''")
             conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS tool_exposure TEXT DEFAULT '[]'")
+            conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS valid_from TEXT DEFAULT ''")
+            conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS valid_to TEXT DEFAULT NULL")
+            conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS confidence DOUBLE PRECISION DEFAULT 1.0")
+            conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS provenance TEXT DEFAULT '{}'")
+            conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS source_scan_id TEXT DEFAULT ''")
+            conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS source_run_id TEXT DEFAULT ''")
+            conn.execute("UPDATE graph_edges SET valid_from = first_seen WHERE valid_from = '' OR valid_from IS NULL")
+            conn.execute("UPDATE graph_edges SET source_scan_id = scan_id WHERE source_scan_id = '' OR source_scan_id IS NULL")
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS interaction_risks (
@@ -391,6 +406,30 @@ class PostgresGraphStore:
         batch_size = _graph_write_batch_size()
 
         with _tenant_connection(self._pool) as conn:
+            previous_row = conn.execute(
+                """
+                SELECT scan_id
+                FROM graph_snapshots
+                WHERE tenant_id = %s
+                ORDER BY created_at DESC, scan_id DESC
+                LIMIT 1
+                """,
+                (tenant,),
+            ).fetchone()
+            previous_scan = str(previous_row[0]) if previous_row else ""
+            if previous_scan == scan:
+                previous_scan = self.previous_snapshot_id(tenant_id=tenant, before_scan_id=scan)
+            previous_edges: dict[tuple[str, str, str], Any] = {}
+            if previous_scan:
+                for row in conn.execute(
+                    """
+                    SELECT source_id, target_id, relationship, first_seen, valid_from, valid_to
+                    FROM graph_edges
+                    WHERE tenant_id = %s AND scan_id = %s
+                    """,
+                    (tenant, previous_scan),
+                ).fetchall():
+                    previous_edges[(row[0], row[1], row[2])] = row
 
             def node_rows() -> Iterator[tuple[Any, ...]]:
                 for node in graph.nodes.values():
@@ -431,6 +470,12 @@ class PostgresGraphStore:
             def edge_rows() -> Iterator[tuple[Any, ...]]:
                 for edge in graph.edges:
                     rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else edge.relationship
+                    previous = previous_edges.get((edge.source, edge.target, rel))
+                    valid_from = edge.valid_from or edge.first_seen or now
+                    first_seen = edge.first_seen
+                    if previous is not None:
+                        valid_from = previous[4] or previous[3] or valid_from
+                        first_seen = previous[3] or first_seen
                     yield (
                         edge.source,
                         edge.target,
@@ -438,8 +483,14 @@ class PostgresGraphStore:
                         edge.direction,
                         edge.weight,
                         1 if edge.traversable else 0,
-                        edge.first_seen,
+                        first_seen,
                         edge.last_seen,
+                        valid_from,
+                        edge.valid_to,
+                        edge.confidence,
+                        json.dumps(edge.provenance, default=str),
+                        edge.source_scan_id or scan,
+                        edge.source_run_id,
                         json.dumps(edge.evidence, default=str),
                         edge.activity_id,
                         scan,
@@ -526,21 +577,52 @@ class PostgresGraphStore:
                 """
                 INSERT INTO graph_edges (
                     source_id, target_id, relationship, direction, weight,
-                    traversable, first_seen, last_seen, evidence,
-                    activity_id, scan_id, tenant_id
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    traversable, first_seen, last_seen, valid_from, valid_to,
+                    confidence, provenance, source_scan_id, source_run_id,
+                    evidence, activity_id, scan_id, tenant_id
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (source_id, target_id, relationship, scan_id, tenant_id) DO UPDATE SET
                     direction = EXCLUDED.direction,
                     weight = EXCLUDED.weight,
                     traversable = EXCLUDED.traversable,
                     first_seen = EXCLUDED.first_seen,
                     last_seen = EXCLUDED.last_seen,
+                    valid_from = EXCLUDED.valid_from,
+                    valid_to = EXCLUDED.valid_to,
+                    confidence = EXCLUDED.confidence,
+                    provenance = EXCLUDED.provenance,
+                    source_scan_id = EXCLUDED.source_scan_id,
+                    source_run_id = EXCLUDED.source_run_id,
                     evidence = EXCLUDED.evidence,
                     activity_id = EXCLUDED.activity_id
                 """,
                 edge_rows(),
                 batch_size=batch_size,
             )
+            incoming_edge_keys = {
+                (
+                    edge.source,
+                    edge.target,
+                    edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship),
+                )
+                for edge in graph.edges
+            }
+            removed_edge_keys = set(previous_edges) - incoming_edge_keys
+            if removed_edge_keys:
+                _execute_many_batched(
+                    conn,
+                    """
+                    UPDATE graph_edges
+                    SET valid_to = COALESCE(valid_to, %s),
+                        activity_id = CASE WHEN activity_id = 1 THEN 3 ELSE activity_id END
+                    WHERE tenant_id = %s AND scan_id = %s AND source_id = %s AND target_id = %s AND relationship = %s
+                    """,
+                    (
+                        (now, tenant, previous_scan, source, target, relationship)
+                        for source, target, relationship in sorted(removed_edge_keys)
+                    ),
+                    batch_size=batch_size,
+                )
             _execute_many_batched(
                 conn,
                 """
@@ -653,7 +735,8 @@ class PostgresGraphStore:
             for row in conn.execute(
                 """
                 SELECT source_id, target_id, relationship, direction, weight, traversable,
-                       first_seen, last_seen, evidence, activity_id
+                       first_seen, last_seen, valid_from, valid_to, confidence, provenance,
+                       source_scan_id, source_run_id, evidence, activity_id, scan_id
                 FROM graph_edges
                 WHERE tenant_id = %s AND scan_id = %s
                 """,
@@ -671,8 +754,14 @@ class PostgresGraphStore:
                         traversable=bool(row[5]),
                         first_seen=row[6],
                         last_seen=row[7],
-                        evidence=json.loads(row[8]),
-                        activity_id=row[9],
+                        valid_from=row[8] or row[6],
+                        valid_to=row[9],
+                        confidence=row[10],
+                        provenance=json.loads(row[11] or "{}"),
+                        source_scan_id=row[12] or row[16],
+                        source_run_id=row[13] or "",
+                        evidence=json.loads(row[14]),
+                        activity_id=row[15],
                     )
                 )
 
@@ -1049,7 +1138,117 @@ class PostgresGraphStore:
                 "nodes_changed": sorted(nid for nid in (old_ids & new_ids) if old_nodes[nid] != new_nodes[nid]),
                 "edges_added": sorted(new_edges - old_edges),
                 "edges_removed": sorted(old_edges - new_edges),
+                "edges_changed": self.changed_edges_between_scans(scan_id_old, scan_id_new, tenant_id=tenant_id)["edges_changed"],
             }
+
+    @staticmethod
+    def _edge_history_dict(row) -> dict[str, Any]:
+        return {
+            "source_id": row[0],
+            "target_id": row[1],
+            "relationship": row[2],
+            "direction": row[3],
+            "weight": float(row[4] or 0.0),
+            "traversable": bool(row[5]),
+            "first_seen": row[6],
+            "last_seen": row[7],
+            "valid_from": row[8] or row[6],
+            "valid_to": row[9],
+            "confidence": float(row[10] if row[10] is not None else 1.0),
+            "provenance": json.loads(row[11] or "{}"),
+            "source_scan_id": row[12] or row[16],
+            "source_run_id": row[13] or "",
+            "evidence": json.loads(row[14] or "{}"),
+            "activity_id": int(row[15] or 1),
+            "scan_id": row[16],
+            "tenant_id": row[17],
+        }
+
+    @staticmethod
+    def _edge_change_fingerprint(edge: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "direction": edge["direction"],
+            "weight": edge["weight"],
+            "traversable": edge["traversable"],
+            "confidence": edge["confidence"],
+            "provenance": edge["provenance"],
+            "evidence": edge["evidence"],
+            "activity_id": edge["activity_id"],
+        }
+
+    def active_edges_at(self, at: str, *, tenant_id: str = "") -> list[dict[str, Any]]:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                """
+                SELECT ge.source_id, ge.target_id, ge.relationship, ge.direction, ge.weight, ge.traversable,
+                       ge.first_seen, ge.last_seen, ge.valid_from, ge.valid_to, ge.confidence, ge.provenance,
+                       ge.source_scan_id, ge.source_run_id, ge.evidence, ge.activity_id, ge.scan_id, ge.tenant_id
+                FROM graph_edges ge
+                JOIN graph_snapshots gs ON gs.tenant_id = ge.tenant_id AND gs.scan_id = ge.scan_id
+                WHERE ge.tenant_id = %s
+                  AND gs.created_at <= %s
+                  AND COALESCE(NULLIF(ge.valid_from, ''), ge.first_seen) <= %s
+                  AND (ge.valid_to IS NULL OR ge.valid_to = '' OR ge.valid_to > %s)
+                ORDER BY gs.created_at ASC, ge.scan_id ASC
+                """,
+                (tenant_id, at, at, at),
+            ).fetchall()
+        active_by_key: dict[tuple[str, str, str], dict[str, Any]] = {}
+        for row in rows:
+            edge = self._edge_history_dict(row)
+            active_by_key[(edge["source_id"], edge["target_id"], edge["relationship"])] = edge
+        return [active_by_key[key] for key in sorted(active_by_key)]
+
+    def changed_edges_between_scans(self, scan_id_old: str, scan_id_new: str, *, tenant_id: str = "") -> dict[str, Any]:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
+
+        def by_scan(conn, scan_id: str) -> dict[tuple[str, str, str], dict[str, Any]]:
+            rows = conn.execute(
+                """
+                SELECT source_id, target_id, relationship, direction, weight, traversable,
+                       first_seen, last_seen, valid_from, valid_to, confidence, provenance,
+                       source_scan_id, source_run_id, evidence, activity_id, scan_id, tenant_id
+                FROM graph_edges
+                WHERE tenant_id = %s AND scan_id = %s
+                """,
+                (tenant_id, scan_id),
+            ).fetchall()
+            return {
+                (edge["source_id"], edge["target_id"], edge["relationship"]): edge
+                for edge in (self._edge_history_dict(row) for row in rows)
+            }
+
+        with _tenant_connection(self._pool) as conn:
+            old_edges = by_scan(conn, scan_id_old)
+            new_edges = by_scan(conn, scan_id_new)
+
+        old_keys, new_keys = set(old_edges), set(new_edges)
+        shared = old_keys & new_keys
+        changed = [
+            {"before": old_edges[key], "after": new_edges[key]}
+            for key in sorted(shared)
+            if self._edge_change_fingerprint(old_edges[key]) != self._edge_change_fingerprint(new_edges[key])
+        ]
+        unchanged = [
+            new_edges[key]
+            for key in sorted(shared)
+            if self._edge_change_fingerprint(old_edges[key]) == self._edge_change_fingerprint(new_edges[key])
+        ]
+        return {
+            "scan_id_old": scan_id_old,
+            "scan_id_new": scan_id_new,
+            "edges_added": [new_edges[key] for key in sorted(new_keys - old_keys)],
+            "edges_removed": [old_edges[key] for key in sorted(old_keys - new_keys)],
+            "edges_changed": changed,
+            "edges_unchanged": unchanged,
+            "summary": {
+                "added": len(new_keys - old_keys),
+                "removed": len(old_keys - new_keys),
+                "changed": len(changed),
+                "unchanged": len(unchanged),
+            },
+        }
 
     def list_snapshots(self, *, tenant_id: str = "", limit: int = 50) -> list[dict[str, Any]]:
         tenant_id = normalize_graph_tenant_id(tenant_id)
@@ -1275,7 +1474,9 @@ class PostgresGraphStore:
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute(
                 f"""
-                SELECT source_id, target_id, relationship, direction, weight, traversable, first_seen, last_seen, evidence, activity_id
+                SELECT source_id, target_id, relationship, direction, weight, traversable,
+                       first_seen, last_seen, valid_from, valid_to, confidence, provenance,
+                       source_scan_id, source_run_id, evidence, activity_id, scan_id
                 FROM graph_edges
                 WHERE tenant_id = %s AND scan_id = %s
                   AND (source_id IN ({placeholders}) OR target_id IN ({placeholders}))
@@ -1294,8 +1495,14 @@ class PostgresGraphStore:
                     traversable=bool(row[5]),
                     first_seen=row[6],
                     last_seen=row[7],
-                    evidence=json.loads(row[8]),
-                    activity_id=row[9],
+                    valid_from=row[8] or row[6],
+                    valid_to=row[9],
+                    confidence=row[10],
+                    provenance=json.loads(row[11] or "{}"),
+                    source_scan_id=row[12] or row[16],
+                    source_run_id=row[13] or "",
+                    evidence=json.loads(row[14]),
+                    activity_id=row[15],
                 )
                 for row in rows
             ]

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -3,6 +3,8 @@
 Endpoints:
   GET  /v1/graph                — load unified graph (filtered, paginated)
   GET  /v1/graph/diff           — diff between two scan snapshots
+  GET  /v1/graph/edges/active   — edge versions active at a timestamp
+  GET  /v1/graph/edges/changes  — edge lifecycle changes between scans
   GET  /v1/graph/attack-paths   — global risk-sorted attack path queue
   GET  /v1/graph/paths          — attack paths from a source node
   GET  /v1/graph/impact         — blast radius of a node (reverse BFS)
@@ -870,6 +872,25 @@ async def get_graph_diff(
 ) -> dict:
     """Diff two scan snapshots — nodes/edges added, removed, changed."""
     return await _graph_store_call(_get_graph_store_or_503().diff_snapshots, old, new, tenant_id=_tenant(request))
+
+
+@router.get("/v1/graph/edges/active", tags=["graph"])
+async def get_active_graph_edges(
+    request: Request,
+    at: str = Query(..., description="ISO timestamp for replay lookup"),
+) -> list[dict]:
+    """Return edge versions active at a timestamp for replay views."""
+    return await _graph_store_call(_get_graph_store_or_503().active_edges_at, at, tenant_id=_tenant(request))
+
+
+@router.get("/v1/graph/edges/changes", tags=["graph"])
+async def get_graph_edge_changes(
+    request: Request,
+    old: str = Query(..., description="Old scan ID"),
+    new: str = Query(..., description="New scan ID"),
+) -> dict:
+    """Return edge lifecycle changes between two scan snapshots."""
+    return await _graph_store_call(_get_graph_store_or_503().changed_edges_between_scans, old, new, tenant_id=_tenant(request))
 
 
 @router.get("/v1/graph/attack-paths", tags=["graph"])

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 # ═══════════════════════════════════════════════════════════════════════════
 
 DEFAULT_GRAPH_TENANT_ID = "default"
-_GRAPH_SCHEMA_VERSION = 2
+_GRAPH_SCHEMA_VERSION = 3
 _DEFAULT_GRAPH_WRITE_BATCH_SIZE = 1000
 _GRAPH_TENANT_TABLE_KEYS: dict[str, tuple[str, ...]] = {
     "graph_nodes": ("id", "scan_id"),
@@ -90,6 +90,12 @@ CREATE TABLE IF NOT EXISTS graph_edges (
     traversable     INTEGER DEFAULT 1,
     first_seen      TEXT NOT NULL,
     last_seen       TEXT NOT NULL,
+    valid_from      TEXT DEFAULT '',
+    valid_to        TEXT DEFAULT NULL,
+    confidence      REAL DEFAULT 1.0,
+    provenance      TEXT DEFAULT '{}',
+    source_scan_id  TEXT DEFAULT '',
+    source_run_id   TEXT DEFAULT '',
     evidence        TEXT DEFAULT '{}',
     activity_id     INTEGER DEFAULT 1,
     scan_id         TEXT NOT NULL,
@@ -102,6 +108,7 @@ CREATE INDEX IF NOT EXISTS idx_ge_target ON graph_edges(target_id);
 CREATE INDEX IF NOT EXISTS idx_ge_rel ON graph_edges(relationship);
 CREATE INDEX IF NOT EXISTS idx_ge_scan ON graph_edges(scan_id);
 CREATE INDEX IF NOT EXISTS idx_ge_tenant_scan ON graph_edges(tenant_id, scan_id);
+CREATE INDEX IF NOT EXISTS idx_ge_tenant_valid ON graph_edges(tenant_id, valid_from, valid_to);
 
 -- ── Snapshots ──
 CREATE TABLE IF NOT EXISTS graph_snapshots (
@@ -233,6 +240,22 @@ def _init_db(conn: sqlite3.Connection, *, backfill_legacy_tenants: bool = True) 
         conn.execute("ALTER TABLE attack_paths ADD COLUMN summary TEXT DEFAULT ''")
     if "tool_exposure" not in existing_columns:
         conn.execute("ALTER TABLE attack_paths ADD COLUMN tool_exposure TEXT DEFAULT '[]'")
+    edge_columns = {row["name"] for row in conn.execute("PRAGMA table_info(graph_edges)").fetchall()}
+    # v3 adds replay metadata. Empty valid_from is interpreted as first_seen for
+    # stores created before this migration, so old snapshots remain queryable.
+    edge_migrations = {
+        "valid_from": "ALTER TABLE graph_edges ADD COLUMN valid_from TEXT DEFAULT ''",
+        "valid_to": "ALTER TABLE graph_edges ADD COLUMN valid_to TEXT DEFAULT NULL",
+        "confidence": "ALTER TABLE graph_edges ADD COLUMN confidence REAL DEFAULT 1.0",
+        "provenance": "ALTER TABLE graph_edges ADD COLUMN provenance TEXT DEFAULT '{}'",
+        "source_scan_id": "ALTER TABLE graph_edges ADD COLUMN source_scan_id TEXT DEFAULT ''",
+        "source_run_id": "ALTER TABLE graph_edges ADD COLUMN source_run_id TEXT DEFAULT ''",
+    }
+    for column, statement in edge_migrations.items():
+        if column not in edge_columns:
+            conn.execute(statement)
+    conn.execute("UPDATE graph_edges SET valid_from = first_seen WHERE valid_from = '' OR valid_from IS NULL")
+    conn.execute("UPDATE graph_edges SET source_scan_id = scan_id WHERE source_scan_id = '' OR source_scan_id IS NULL")
     if backfill_legacy_tenants:
         _backfill_empty_tenant_ids(conn)
     conn.commit()
@@ -350,8 +373,22 @@ def save_graph(conn: sqlite3.Connection, graph: UnifiedGraph) -> None:
     """Persist a UnifiedGraph as an immutable per-scan snapshot."""
     tenant = normalize_graph_tenant_id(graph.tenant_id)
     scan = graph.scan_id
-    now = _now_iso()
+    now = graph.created_at or _now_iso()
     batch_size = _graph_write_batch_size()
+    previous_scan = latest_snapshot_id(conn, tenant_id=tenant)
+    if previous_scan == scan:
+        previous_scan = previous_snapshot_id(conn, tenant_id=tenant, before_scan_id=scan)
+    previous_edges: dict[tuple[str, str, str], sqlite3.Row] = {}
+    if previous_scan:
+        for row in conn.execute(
+            """
+            SELECT source_id, target_id, relationship, first_seen, valid_from, valid_to
+            FROM graph_edges
+            WHERE tenant_id = ? AND scan_id = ?
+            """,
+            (tenant, previous_scan),
+        ):
+            previous_edges[(row["source_id"], row["target_id"], row["relationship"])] = row
 
     # ── Nodes ──
     def node_rows() -> Iterator[tuple[Any, ...]]:
@@ -395,6 +432,12 @@ def save_graph(conn: sqlite3.Connection, graph: UnifiedGraph) -> None:
     def edge_rows() -> Iterator[tuple[Any, ...]]:
         for edge in graph.edges:
             rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else edge.relationship
+            previous = previous_edges.get((edge.source, edge.target, rel))
+            valid_from = edge.valid_from or edge.first_seen or now
+            first_seen = edge.first_seen
+            if previous is not None:
+                valid_from = previous["valid_from"] or previous["first_seen"] or valid_from
+                first_seen = previous["first_seen"] or first_seen
             yield (
                 edge.source,
                 edge.target,
@@ -402,8 +445,14 @@ def save_graph(conn: sqlite3.Connection, graph: UnifiedGraph) -> None:
                 edge.direction,
                 edge.weight,
                 1 if edge.traversable else 0,
-                edge.first_seen,
+                first_seen,
                 edge.last_seen,
+                valid_from,
+                edge.valid_to,
+                edge.confidence,
+                json.dumps(edge.provenance, default=str),
+                edge.source_scan_id or scan,
+                edge.source_run_id,
                 json.dumps(edge.evidence, default=str),
                 edge.activity_id,
                 scan,
@@ -415,13 +464,35 @@ def save_graph(conn: sqlite3.Connection, graph: UnifiedGraph) -> None:
         """\
         INSERT OR REPLACE INTO graph_edges (
             source_id, target_id, relationship, direction, weight,
-            traversable, first_seen, last_seen, evidence,
+            traversable, first_seen, last_seen, valid_from, valid_to,
+            confidence, provenance, source_scan_id, source_run_id, evidence,
             activity_id, scan_id, tenant_id
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         edge_rows(),
         batch_size=batch_size,
     )
+
+    incoming_edge_keys = {
+        (
+            edge.source,
+            edge.target,
+            edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship),
+        )
+        for edge in graph.edges
+    }
+    removed_edge_keys = set(previous_edges) - incoming_edge_keys
+    if removed_edge_keys:
+        _executemany_batched(
+            conn,
+            """
+            UPDATE graph_edges
+            SET valid_to = COALESCE(valid_to, ?)
+            WHERE tenant_id = ? AND scan_id = ? AND source_id = ? AND target_id = ? AND relationship = ?
+            """,
+            ((now, tenant, previous_scan, source, target, relationship) for source, target, relationship in sorted(removed_edge_keys)),
+            batch_size=batch_size,
+        )
 
     # ── Attack paths ──
     for ap in graph.attack_paths:
@@ -548,6 +619,12 @@ def load_graph(
                 traversable=bool(row["traversable"]),
                 first_seen=row["first_seen"],
                 last_seen=row["last_seen"],
+                valid_from=row["valid_from"] or row["first_seen"],
+                valid_to=row["valid_to"],
+                confidence=row["confidence"],
+                provenance=json.loads(row["provenance"] or "{}"),
+                source_scan_id=row["source_scan_id"] or row["scan_id"],
+                source_run_id=row["source_run_id"] or "",
                 evidence=json.loads(row["evidence"]),
                 activity_id=row["activity_id"],
             )
@@ -656,6 +733,111 @@ def diff_snapshots(
         "nodes_changed": sorted(nid for nid in (old_ids & new_ids) if old_nodes[nid] != new_nodes[nid]),
         "edges_added": sorted(new_edges - old_edges),
         "edges_removed": sorted(old_edges - new_edges),
+        "edges_changed": changed_edges_between_scans(conn, scan_id_old, scan_id_new, tenant_id=tenant_id)["edges_changed"],
+    }
+
+
+def _edge_history_row(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "source_id": row["source_id"],
+        "target_id": row["target_id"],
+        "relationship": row["relationship"],
+        "direction": row["direction"],
+        "weight": float(row["weight"] or 0.0),
+        "traversable": bool(row["traversable"]),
+        "first_seen": row["first_seen"],
+        "last_seen": row["last_seen"],
+        "valid_from": row["valid_from"] or row["first_seen"],
+        "valid_to": row["valid_to"],
+        "confidence": float(row["confidence"] if row["confidence"] is not None else 1.0),
+        "provenance": json.loads(row["provenance"] or "{}"),
+        "source_scan_id": row["source_scan_id"] or row["scan_id"],
+        "source_run_id": row["source_run_id"] or "",
+        "evidence": json.loads(row["evidence"] or "{}"),
+        "activity_id": int(row["activity_id"] or 1),
+        "scan_id": row["scan_id"],
+        "tenant_id": row["tenant_id"],
+    }
+
+
+def _edge_change_fingerprint(edge: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "direction": edge["direction"],
+        "weight": edge["weight"],
+        "traversable": edge["traversable"],
+        "confidence": edge["confidence"],
+        "provenance": edge["provenance"],
+        "evidence": edge["evidence"],
+        "activity_id": edge["activity_id"],
+    }
+
+
+def active_edges_at(conn: sqlite3.Connection, at: str, *, tenant_id: str = "") -> list[dict[str, Any]]:
+    """Return the latest known edge versions active at an ISO timestamp."""
+    tenant_id = normalize_graph_tenant_id(tenant_id)
+    rows = conn.execute(
+        """
+        SELECT ge.*
+        FROM graph_edges ge
+        JOIN graph_snapshots gs ON gs.tenant_id = ge.tenant_id AND gs.scan_id = ge.scan_id
+        WHERE ge.tenant_id = ?
+          AND gs.created_at <= ?
+          AND COALESCE(NULLIF(ge.valid_from, ''), ge.first_seen) <= ?
+          AND (ge.valid_to IS NULL OR ge.valid_to = '' OR ge.valid_to > ?)
+        ORDER BY gs.created_at ASC, ge.scan_id ASC
+        """,
+        (tenant_id, at, at, at),
+    ).fetchall()
+    active_by_key: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for row in rows:
+        edge = _edge_history_row(row)
+        key = (edge["source_id"], edge["target_id"], edge["relationship"])
+        active_by_key[key] = edge
+    return [active_by_key[key] for key in sorted(active_by_key)]
+
+
+def changed_edges_between_scans(
+    conn: sqlite3.Connection,
+    scan_id_old: str,
+    scan_id_new: str,
+    *,
+    tenant_id: str = "",
+) -> dict[str, Any]:
+    """Return rich edge lifecycle changes between two scan snapshots."""
+    tenant_id = normalize_graph_tenant_id(tenant_id)
+
+    def rows_for(scan_id: str) -> dict[tuple[str, str, str], dict[str, Any]]:
+        rows = conn.execute(
+            "SELECT * FROM graph_edges WHERE scan_id = ? AND tenant_id = ?",
+            (scan_id, tenant_id),
+        ).fetchall()
+        return {(edge["source_id"], edge["target_id"], edge["relationship"]): edge for edge in (_edge_history_row(row) for row in rows)}
+
+    old_edges = rows_for(scan_id_old)
+    new_edges = rows_for(scan_id_new)
+    old_keys, new_keys = set(old_edges), set(new_edges)
+    shared = old_keys & new_keys
+    changed = [
+        {"before": old_edges[key], "after": new_edges[key]}
+        for key in sorted(shared)
+        if _edge_change_fingerprint(old_edges[key]) != _edge_change_fingerprint(new_edges[key])
+    ]
+    unchanged = [
+        new_edges[key] for key in sorted(shared) if _edge_change_fingerprint(old_edges[key]) == _edge_change_fingerprint(new_edges[key])
+    ]
+    return {
+        "scan_id_old": scan_id_old,
+        "scan_id_new": scan_id_new,
+        "edges_added": [new_edges[key] for key in sorted(new_keys - old_keys)],
+        "edges_removed": [old_edges[key] for key in sorted(old_keys - new_keys)],
+        "edges_changed": changed,
+        "edges_unchanged": unchanged,
+        "summary": {
+            "added": len(new_keys - old_keys),
+            "removed": len(old_keys - new_keys),
+            "changed": len(changed),
+            "unchanged": len(unchanged),
+        },
     }
 
 

--- a/src/agent_bom/graph/container.py
+++ b/src/agent_bom/graph/container.py
@@ -185,7 +185,13 @@ class UnifiedGraph:
                 traversable=edge.traversable,
                 first_seen=edge.first_seen,
                 last_seen=edge.last_seen,
+                valid_from=edge.valid_from,
+                valid_to=edge.valid_to,
+                source_scan_id=edge.source_scan_id,
+                source_run_id=edge.source_run_id,
                 evidence=edge.evidence,
+                confidence=edge.confidence,
+                provenance=edge.provenance,
                 activity_id=edge.activity_id,
             )
             self.adjacency[edge.target].append(reverse)

--- a/src/agent_bom/graph/edge.py
+++ b/src/agent_bom/graph/edge.py
@@ -31,9 +31,15 @@ class UnifiedEdge:
     # Temporal
     first_seen: str = ""
     last_seen: str = ""
+    valid_from: str = ""
+    valid_to: str | None = None
+    source_scan_id: str = ""
+    source_run_id: str = ""
 
     # Evidence
     evidence: dict[str, Any] = field(default_factory=dict)
+    confidence: float = 1.0
+    provenance: dict[str, Any] = field(default_factory=dict)
 
     # OCSF activity
     activity_id: int = 1  # 1=Create, 2=Update, 3=Close
@@ -43,6 +49,11 @@ class UnifiedEdge:
             self.first_seen = _now_iso()
         if not self.last_seen:
             self.last_seen = self.first_seen
+        if not self.valid_from:
+            self.valid_from = self.first_seen
+        self.confidence = float(self.confidence)
+        if self.confidence < 0.0 or self.confidence > 1.0:
+            raise ValueError("edge confidence must be between 0.0 and 1.0")
 
     @property
     def is_bidirectional(self) -> bool:
@@ -73,6 +84,12 @@ class UnifiedEdge:
             "traversable": self.traversable,
             "first_seen": self.first_seen,
             "last_seen": self.last_seen,
+            "valid_from": self.valid_from,
+            "valid_to": self.valid_to,
+            "confidence": self.confidence,
+            "provenance": self.provenance,
+            "source_scan_id": self.source_scan_id,
+            "source_run_id": self.source_run_id,
             "evidence": self.evidence,
             "activity_id": self.activity_id,
         }
@@ -88,6 +105,12 @@ class UnifiedEdge:
             traversable=data.get("traversable", True),
             first_seen=data.get("first_seen", ""),
             last_seen=data.get("last_seen", ""),
+            valid_from=data.get("valid_from", ""),
+            valid_to=data.get("valid_to"),
+            confidence=data.get("confidence", 1.0),
+            provenance=data.get("provenance", {}),
+            source_scan_id=data.get("source_scan_id", ""),
+            source_run_id=data.get("source_run_id", ""),
             evidence=data.get("evidence", {}),
             activity_id=data.get("activity_id", 1),
         )

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -14,7 +14,7 @@ from agent_bom.api.graph_store import SQLiteGraphStore
 from agent_bom.api.routes import graph as graph_routes
 from agent_bom.api.server import app
 from agent_bom.api.stores import set_graph_store
-from agent_bom.db.graph_store import DEFAULT_GRAPH_TENANT_ID, _init_db, load_graph, save_graph
+from agent_bom.db.graph_store import DEFAULT_GRAPH_TENANT_ID, _init_db, active_edges_at, changed_edges_between_scans, load_graph, save_graph
 from agent_bom.graph import (
     AttackPath,
     EntityType,
@@ -352,6 +352,101 @@ class TestGraphEndpointLogic:
         assert diff["nodes_added"][0]["entity_type"] == "agent"
         assert diff["nodes_added"][0]["label"] == "new-agent"
         assert {node["id"] for node in diff["nodes_removed"]} >= {"agent:b"}
+
+    def test_edge_history_tracks_new_changed_removed_and_unchanged_edges(self, graph_db):
+        g1 = UnifiedGraph(scan_id="history-s1", tenant_id="default", created_at="2026-06-01T00:00:00Z")
+        for node_id in ("agent:a", "server:b", "tool:c", "vuln:d"):
+            entity_type = EntityType.AGENT if node_id.startswith("agent:") else EntityType.SERVER
+            g1.add_node(UnifiedNode(id=node_id, entity_type=entity_type, label=node_id))
+        g1.add_edge(
+            UnifiedEdge(
+                source="agent:a",
+                target="server:b",
+                relationship=RelationshipType.USES,
+                confidence=0.95,
+                provenance={"collector": "scan-one"},
+                source_run_id="run-1",
+            )
+        )
+        g1.add_edge(UnifiedEdge(source="server:b", target="tool:c", relationship=RelationshipType.PROVIDES_TOOL, confidence=0.8))
+        g1.add_edge(UnifiedEdge(source="tool:c", target="vuln:d", relationship=RelationshipType.VULNERABLE_TO))
+        save_graph(graph_db, g1)
+
+        g2 = UnifiedGraph(scan_id="history-s2", tenant_id="default", created_at="2026-06-02T00:00:00Z")
+        for node_id in ("agent:a", "server:b", "tool:c", "vuln:d"):
+            entity_type = EntityType.AGENT if node_id.startswith("agent:") else EntityType.SERVER
+            g2.add_node(UnifiedNode(id=node_id, entity_type=entity_type, label=node_id))
+        g2.add_edge(
+            UnifiedEdge(
+                source="agent:a",
+                target="server:b",
+                relationship=RelationshipType.USES,
+                confidence=0.55,
+                provenance={"collector": "scan-two"},
+                source_run_id="run-2",
+            )
+        )
+        g2.add_edge(UnifiedEdge(source="server:b", target="tool:c", relationship=RelationshipType.PROVIDES_TOOL, confidence=0.8))
+        g2.add_edge(UnifiedEdge(source="agent:a", target="tool:c", relationship=RelationshipType.REACHES_TOOL))
+        save_graph(graph_db, g2)
+
+        changes = changed_edges_between_scans(graph_db, "history-s1", "history-s2", tenant_id="default")
+
+        assert changes["summary"] == {"added": 1, "removed": 1, "changed": 1, "unchanged": 1}
+        assert [(edge["source_id"], edge["target_id"], edge["relationship"]) for edge in changes["edges_added"]] == [
+            ("agent:a", "tool:c", "reaches_tool")
+        ]
+        assert [(edge["source_id"], edge["target_id"], edge["relationship"]) for edge in changes["edges_removed"]] == [
+            ("tool:c", "vuln:d", "vulnerable_to")
+        ]
+        changed = changes["edges_changed"][0]
+        assert changed["before"]["confidence"] == 0.95
+        assert changed["after"]["confidence"] == 0.55
+        assert changed["after"]["source_scan_id"] == "history-s2"
+        assert changed["after"]["source_run_id"] == "run-2"
+        assert changed["after"]["provenance"] == {"collector": "scan-two"}
+        assert [(edge["source_id"], edge["target_id"], edge["relationship"]) for edge in changes["edges_unchanged"]] == [
+            ("server:b", "tool:c", "provides_tool")
+        ]
+
+        s1_created = graph_db.execute("SELECT created_at FROM graph_snapshots WHERE scan_id = 'history-s1'").fetchone()[0]
+        s2_created = graph_db.execute("SELECT created_at FROM graph_snapshots WHERE scan_id = 'history-s2'").fetchone()[0]
+        active_s1 = {(edge["source_id"], edge["target_id"], edge["relationship"]) for edge in active_edges_at(graph_db, s1_created)}
+        active_s2 = {(edge["source_id"], edge["target_id"], edge["relationship"]) for edge in active_edges_at(graph_db, s2_created)}
+
+        assert ("tool:c", "vuln:d", "vulnerable_to") in active_s1
+        assert ("tool:c", "vuln:d", "vulnerable_to") not in active_s2
+        assert ("agent:a", "tool:c", "reaches_tool") in active_s2
+
+    def test_edge_history_fields_round_trip_without_legacy_payload_breakage(self, graph_db):
+        g = UnifiedGraph(scan_id="edge-fields", tenant_id="default")
+        g.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        g.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        g.add_edge(
+            UnifiedEdge(
+                source="agent:a",
+                target="server:s",
+                relationship=RelationshipType.USES,
+                valid_from="2026-05-01T00:00:00Z",
+                valid_to=None,
+                confidence=0.72,
+                provenance={"source": "fixture"},
+                source_scan_id="source-scan",
+                source_run_id="source-run",
+            )
+        )
+        save_graph(graph_db, g)
+
+        loaded = load_graph(graph_db, scan_id="edge-fields")
+        edge = loaded.edges[0]
+
+        assert edge.valid_from == "2026-05-01T00:00:00Z"
+        assert edge.valid_to is None
+        assert edge.confidence == 0.72
+        assert edge.provenance == {"source": "fixture"}
+        assert edge.source_scan_id == "source-scan"
+        assert edge.source_run_id == "source-run"
+        assert UnifiedEdge.from_dict({"source": "a", "target": "b", "relationship": "uses"}).confidence == 1.0
 
     def test_bfs_from_persisted_graph(self, graph_db):
         _build_persisted_graph(graph_db)
@@ -890,6 +985,22 @@ class _RecordingGraphStore:
         self.calls.append(("diff_snapshots", tenant_id, scan_id_old, scan_id_new))
         return {"nodes_added": [], "nodes_removed": [], "nodes_changed": [], "edges_added": [], "edges_removed": []}
 
+    def active_edges_at(self, at: str, *, tenant_id: str = "") -> list[dict]:
+        self.calls.append(("active_edges_at", tenant_id, at))
+        return [edge.to_dict() for edge in self.graph.edges]
+
+    def changed_edges_between_scans(self, scan_id_old: str, scan_id_new: str, *, tenant_id: str = "") -> dict:
+        self.calls.append(("changed_edges_between_scans", tenant_id, scan_id_old, scan_id_new))
+        return {
+            "scan_id_old": scan_id_old,
+            "scan_id_new": scan_id_new,
+            "edges_added": [],
+            "edges_removed": [],
+            "edges_changed": [],
+            "edges_unchanged": [],
+            "summary": {"added": 0, "removed": 0, "changed": 0, "unchanged": 0},
+        }
+
     def list_snapshots(self, *, tenant_id: str = "", limit: int = 50) -> list[dict]:
         self.calls.append(("list_snapshots", tenant_id, limit))
         return [{"scan_id": self.graph.scan_id, "created_at": self.graph.created_at, "node_count": 1, "edge_count": 0, "risk_summary": {}}]
@@ -1207,6 +1318,21 @@ class TestGraphStoreBackendSelection:
         assert body["attack_paths"][0]["tool_exposure"] == ["run_shell"]
         assert any(call[0] == "latest_snapshot_id" for call in recording_graph_store.calls)
         assert any(call[0] == "page_nodes" for call in recording_graph_store.calls)
+
+    def test_graph_edge_history_routes_use_pluggable_store(self, recording_graph_store):
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        recording_graph_store.graph.add_edge(UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES))
+        client = TestClient(app)
+
+        active_response = client.get("/v1/graph/edges/active", params={"at": "2026-05-13T00:00:00Z"})
+        changes_response = client.get("/v1/graph/edges/changes", params={"old": "s1", "new": "s2"})
+
+        assert active_response.status_code == 200
+        assert active_response.json()[0]["valid_from"]
+        assert changes_response.status_code == 200
+        assert changes_response.json()["summary"] == {"added": 0, "removed": 0, "changed": 0, "unchanged": 0}
+        assert ("active_edges_at", "default", "2026-05-13T00:00:00Z") in recording_graph_store.calls
+        assert ("changed_edges_between_scans", "default", "s1", "s2") in recording_graph_store.calls
 
     def test_fix_first_graph_view_returns_ranked_operator_cards(self, recording_graph_store):
         recording_graph_store.graph.add_node(UnifiedNode(id="server:a:fs", entity_type=EntityType.SERVER, label="mcp-fs"))


### PR DESCRIPTION
## Summary

Adds time-versioned edge metadata to the unified graph model and persistence layers so scan history can be replayed and compared over time.

## Changes

- Adds `valid_from`, `valid_to`, `confidence`, `provenance`, `source_scan_id`, and `source_run_id` to graph edges.
- Migrates SQLite and Postgres graph stores with backward-compatible defaults for existing snapshots.
- Preserves current graph API consumers through additive fields only.
- Adds active-at-time and changed-between-scans edge history helpers plus API routes.
- Adds regression coverage for new, changed, removed, and unchanged edges across scan runs.

## Validation

- `uv run pytest tests/test_graph_api.py -q`
- `uv run ruff check src/agent_bom/graph/edge.py src/agent_bom/graph/container.py src/agent_bom/db/graph_store.py src/agent_bom/api/graph_store.py src/agent_bom/api/postgres_graph.py src/agent_bom/api/routes/graph.py tests/test_graph_api.py`
- `git diff --check`

Fixes #2488
