### PR TITLE
Add graph benchmark evidence scaffold

### DIFF
--- a/.github/workflows/perf-scale-evidence.yml
+++ b/.github/workflows/perf-scale-evidence.yml
@@ -4,8 +4,8 @@ name: Perf Scale Evidence
 # so docs/perf/results/ stays current as the graph builder evolves. The
 # 1k-estate run takes <1 minute on github-hosted runners and is the floor
 # evidence referenced from docs/perf/ingest-throughput.md and
-# docs/ENTERPRISE_DEPLOYMENT.md. Postgres-backed persistence numbers are
-# still tracked in #1806.
+# docs/ENTERPRISE_DEPLOYMENT.md. Graph API/Postgres benchmark scaffolds are
+# dry-run validated here; measured deployment evidence is tracked in #2145.
 
 on:
   schedule:
@@ -53,6 +53,22 @@ jobs:
 
       - name: Validate evidence against schema
         run: uv run python scripts/check_scale_evidence.py
+
+      - name: Validate graph API/Postgres benchmark scaffold
+        run: |
+          set -euo pipefail
+          uv run python scripts/generate_graph_benchmark_estate.py \
+            --agents 25 \
+            --report-output /tmp/graph-benchmark-estate-report.json \
+            --summary-output /tmp/graph-benchmark-estate-summary.json
+          uv run python scripts/run_graph_api_benchmark.py \
+            --dry-run \
+            --output /tmp/graph-api-benchmark.json
+          uv run python scripts/run_graph_postgres_explain.py \
+            --dry-run \
+            --output-dir /tmp/postgres-graph-explain \
+            --summary-output /tmp/postgres-graph-explain.json
+          uv run pytest tests/test_graph_benchmark_scaffold.py -q
 
       - name: Upload result artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -10,6 +10,9 @@ Current evidence pages:
 
 - [`p95-p99-graph-query.md`](p95-p99-graph-query.md) — graph query latency at
   1k / 5k / 10k estate sizes.
+- [`graph-api-postgres-benchmark.md`](graph-api-postgres-benchmark.md) — dry-run
+  scaffold for graph API benchmarks, skewed synthetic estates, and Postgres
+  EXPLAIN artifacts tracked by #2145.
 - [`ingest-throughput.md`](ingest-throughput.md) — graph save throughput and
   batch-size behavior.
 - [`fleet-reconciliation.md`](fleet-reconciliation.md) — fleet and Kubernetes
@@ -20,6 +23,17 @@ Current raw result artifact:
 - [`results/scale-evidence-local-2026-04-26.json`](results/scale-evidence-local-2026-04-26.json)
   — local synthetic graph build/query and Kubernetes reconciliation CPU-path
   run on macOS arm64 with Python 3.13.5.
+- [`results/graph-benchmark-estate-sample.json`](results/graph-benchmark-estate-sample.json)
+  — deterministic skewed-estate shape summary for graph API/Postgres benchmark
+  inputs.
+- [`results/graph-benchmark-estate-sample-report.json`](results/graph-benchmark-estate-sample-report.json)
+  — small scanner-style synthetic estate used to prove the generator output
+  shape.
+- [`results/graph-api-benchmark-sample.json`](results/graph-api-benchmark-sample.json)
+  — dry-run API request-plan artifact; it contains no measured latency.
+- [`results/postgres-graph-explain-sample.json`](results/postgres-graph-explain-sample.json)
+  — dry-run Postgres EXPLAIN artifact index; it contains no measured query
+  plans.
 
 Run the structure check before publishing release numbers:
 
@@ -31,4 +45,12 @@ Regenerate the local synthetic result set:
 
 ```bash
 uv run python scripts/run_scale_evidence.py
+```
+
+Regenerate the graph API/Postgres scaffold artifacts:
+
+```bash
+uv run python scripts/generate_graph_benchmark_estate.py
+uv run python scripts/run_graph_api_benchmark.py --dry-run
+uv run python scripts/run_graph_postgres_explain.py --dry-run
 ```

--- a/docs/perf/graph-api-postgres-benchmark.md
+++ b/docs/perf/graph-api-postgres-benchmark.md
@@ -1,0 +1,134 @@
+# Graph API and Postgres Benchmark Scaffold
+
+Evidence status: scaffolded, not measured
+Owner issue: #2145
+Raw result artifacts:
+
+- `docs/perf/results/graph-benchmark-estate-sample.json`
+- `docs/perf/results/graph-benchmark-estate-sample-report.json`
+- `docs/perf/results/graph-api-benchmark-sample.json`
+- `docs/perf/results/postgres-graph-explain-sample.json`
+- `docs/perf/results/postgres-graph-explain-sample/*.sql`
+
+## Claim
+
+This page documents benchmark commands and checked-in scaffold artifacts for
+graph API and Postgres evidence. The checked-in sample artifacts prove that the
+harnesses and request/query plans exist; they do not claim API latency,
+Postgres latency, Snowflake behavior, browser timing, or operator deployment
+SLOs.
+
+Measured local CPU graph timings remain in
+[`p95-p99-graph-query.md`](p95-p99-graph-query.md). API, Postgres, and
+operator-control-plane claims require live benchmark artifacts produced from the
+commands below.
+
+## Scope
+
+Covered by the scaffold:
+
+- skewed synthetic estate generation with local, CI, fleet, cloud, and
+  operator-pushed source labels
+- API request plan for `/v1/graph/search`, `/v1/graph/node/{id}`,
+  `/v1/graph/paths`, `/v1/graph/diff`, and `/v1/graph/query`
+- Postgres `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` SQL artifacts for node
+  search, node detail, attack-path drilldown, graph diff, and bounded traversal
+- target Postgres estate sizes of 10k / 50k / 100k edges
+
+Excluded until live artifacts are attached:
+
+- authenticated API p50/p95/p99
+- Postgres p50/p95/p99 and actual query plans
+- Snowflake or managed-operator deployment timings
+- browser/UI interaction timing
+
+## Environment
+
+Checked-in sample artifacts were generated as dry-run/scaffold output. They are
+environment-neutral and intentionally contain no latency numbers.
+
+Live evidence must record:
+
+- API base URL, auth mode, tenant, backend, and scan IDs
+- Postgres version, DSN boundary, instance size, loaded edge count, and
+  `EXPLAIN ANALYZE` output path
+- client host CPU/OS/Python and network location relative to the API/database
+
+## Commands
+
+Generate a deterministic skewed estate report:
+
+```bash
+uv run python scripts/generate_graph_benchmark_estate.py \
+  --agents 25 \
+  --report-output docs/perf/results/graph-benchmark-estate-sample-report.json \
+  --summary-output docs/perf/results/graph-benchmark-estate-sample.json
+```
+
+Validate the API benchmark plan without measuring:
+
+```bash
+uv run python scripts/run_graph_api_benchmark.py \
+  --dry-run \
+  --output docs/perf/results/graph-api-benchmark-sample.json
+```
+
+Run the API benchmark against a live control plane:
+
+```bash
+AGENT_BOM_API_TOKEN=... uv run python scripts/run_graph_api_benchmark.py \
+  --base-url http://127.0.0.1:8000 \
+  --tenant-id default \
+  --scan-id graph-benchmark-estate-current \
+  --old-scan-id graph-benchmark-estate-old \
+  --new-scan-id graph-benchmark-estate-current \
+  --source-node agent:agent-00000 \
+  --detail-node package:langchain \
+  --repeat 50 \
+  --output docs/perf/results/graph-api-benchmark-live-$(date -u +%Y-%m-%d).json
+```
+
+Generate Postgres EXPLAIN SQL artifacts without measuring:
+
+```bash
+uv run python scripts/run_graph_postgres_explain.py \
+  --dry-run \
+  --output-dir docs/perf/results/postgres-graph-explain-sample \
+  --summary-output docs/perf/results/postgres-graph-explain-sample.json
+```
+
+Run Postgres EXPLAIN ANALYZE against a loaded graph store:
+
+```bash
+AGENT_BOM_POSTGRES_DSN=postgresql://... uv run python scripts/run_graph_postgres_explain.py \
+  --run \
+  --scan-id graph-benchmark-estate-current \
+  --old-scan-id graph-benchmark-estate-old \
+  --source-node agent:agent-00000 \
+  --detail-node package:langchain \
+  --output-dir docs/perf/results/postgres-graph-explain-live-$(date -u +%Y-%m-%d) \
+  --summary-output docs/perf/results/postgres-graph-explain-live-$(date -u +%Y-%m-%d).json
+```
+
+## Results
+
+| Artifact | Status | What it supports |
+|---|---|---|
+| `graph-benchmark-estate-sample.json` | scaffold | deterministic skewed estate shape and source mix |
+| `graph-api-benchmark-sample.json` | dry-run | API benchmark request coverage only |
+| `postgres-graph-explain-sample.json` | dry-run | Postgres EXPLAIN artifact paths only |
+
+No API or Postgres latency is claimed from these sample artifacts.
+
+## SLOs
+
+No API/Postgres SLO is declared by this scaffold. A future measured page should
+publish p50/p95/p99 for each API operation and attach the matching Postgres
+plans before making an operator or enterprise-pilot claim.
+
+## Gaps
+
+- Seed Postgres with matching 10k / 50k / 100k edge snapshots and check in
+  measured `EXPLAIN ANALYZE` artifacts.
+- Run the API benchmark under the intended auth mode and graph backend.
+- Add browser interaction timing separately if UI scale claims are needed.

--- a/docs/perf/p95-p99-graph-query.md
+++ b/docs/perf/p95-p99-graph-query.md
@@ -10,8 +10,8 @@ Raw result artifact: `docs/perf/results/scale-evidence-local-2026-04-26.json`
 Local synthetic graph search, selector, and bounded-neighborhood CPU paths stay
 sub-millisecond at 1k / 5k / 10k agent-estate sizes when callers use bounded
 selectors and bounded graph traversal. This page does not claim HTTP API,
-Postgres, diff, or attack-path drilldown latency; those remain tracked in
-#1806.
+Postgres, diff, or attack-path drilldown latency; the benchmark scaffold for
+those lanes is tracked in #2145.
 
 ## Scope
 
@@ -63,8 +63,11 @@ python scripts/check_scale_evidence.py
 
 ## EXPLAIN ANALYZE
 
-Not covered by this local synthetic run. Add representative Postgres query
-plans under #1806 when the API/Postgres benchmark lane is measured:
+Not covered by this local synthetic run. The graph-specific Postgres EXPLAIN
+scaffold lives in
+[`graph-api-postgres-benchmark.md`](graph-api-postgres-benchmark.md); add
+representative measured query plans under #2145 when the API/Postgres benchmark
+lane is measured:
 
 - graph node search
 - node detail

--- a/docs/perf/results/graph-api-benchmark-sample.json
+++ b/docs/perf/results/graph-api-benchmark-sample.json
@@ -1,0 +1,78 @@
+{
+  "base_url": "http://127.0.0.1:8000",
+  "commands": {
+    "dry_run": "uv run python scripts/run_graph_api_benchmark.py --dry-run",
+    "live": "AGENT_BOM_API_TOKEN=... uv run python scripts/run_graph_api_benchmark.py --base-url http://127.0.0.1:8000 --scan-id <scan> --old-scan-id <old> --new-scan-id <new>"
+  },
+  "evidence_status": "scaffold_validated_not_measured",
+  "gaps": [
+    "Dry-run does not start the API, authenticate, or measure network/server latency.",
+    "Live results must record the API auth mode, tenant, graph backend, and scan IDs used."
+  ],
+  "generated_at": "2026-05-13T05:57:22.330599+00:00",
+  "owner_issue": 2145,
+  "repeat": 20,
+  "request_plan": [
+    {
+      "method": "GET",
+      "name": "graph_search",
+      "path": "/v1/graph/search",
+      "query": {
+        "entity_types": "package,vulnerability",
+        "limit": "50",
+        "q": "langchain",
+        "scan_id": "graph-benchmark-estate-current"
+      }
+    },
+    {
+      "method": "GET",
+      "name": "node_detail",
+      "path": "/v1/graph/node/package:langchain",
+      "query": {
+        "scan_id": "graph-benchmark-estate-current"
+      }
+    },
+    {
+      "method": "GET",
+      "name": "attack_path_drilldown",
+      "path": "/v1/graph/paths",
+      "query": {
+        "limit": "100",
+        "max_depth": "4",
+        "scan_id": "graph-benchmark-estate-current",
+        "source_id": "agent:agent-00000"
+      }
+    },
+    {
+      "method": "GET",
+      "name": "graph_diff",
+      "path": "/v1/graph/diff",
+      "query": {
+        "new": "graph-benchmark-estate-current",
+        "old": "graph-benchmark-estate-old"
+      }
+    },
+    {
+      "json": {
+        "direction": "both",
+        "include_attack_paths": true,
+        "max_depth": 3,
+        "max_edges": 5000,
+        "max_nodes": 500,
+        "roots": [
+          "agent:agent-00000"
+        ],
+        "scan_id": "graph-benchmark-estate-current",
+        "timeout_ms": 2500,
+        "traversable_only": true
+      },
+      "method": "POST",
+      "name": "bounded_traversal",
+      "path": "/v1/graph/query",
+      "query": {}
+    }
+  ],
+  "results": [],
+  "schema_version": 1,
+  "tenant_id": "default"
+}

--- a/docs/perf/results/graph-benchmark-estate-sample-report.json
+++ b/docs/perf/results/graph-benchmark-estate-sample-report.json
@@ -1,0 +1,11385 @@
+{
+  "agents": [
+    {
+      "discovery_sources": [
+        "cloud-inventory",
+        "local",
+        "operator-push"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-00-00",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00000-00-01",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-00-03",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-00-04",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-00-05",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-00-06",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-00-07",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "next",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-00-09",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-00-10",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "langchain",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "openai",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-00-15",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-00-16",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00000-00-17",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "zod",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "team-shared-0-1",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-00-20",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "protobuf",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-00-23",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "langchain",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-00-25",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-00-26",
+              "version": "3.0.0"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-09"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-10"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-11"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-12"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-13"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-14"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-15"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-16"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-17"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-18"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-19"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-20"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-21"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-22"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-23"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-24"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-25"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-26"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-27"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-28"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-29"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-30"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-31"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-32"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-33"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-34"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-35"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-36"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-37"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-38"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-39"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-40"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-41"
+            },
+            {
+              "name": "agent-00000-mcp-00-tool-42"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-01",
+          "packages": [
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00000-01-00",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00000-01-01",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-01-03",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "requests",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "team-shared-0-5",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-01-06",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-01-07",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-01-08",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "grpc",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-01-10",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-01-11",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "openai",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00000-01-13",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-01-14",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "team-shared-0-6",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-01-16",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "team-shared-0-8",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-01-18",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-01-19",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-01-23",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "openai",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-01-25",
+              "version": "2.1.0"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-01-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-09"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-10"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-11"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-12"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-13"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-14"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-15"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-16"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-17"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-18"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-19"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-20"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-21"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-22"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-23"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-24"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-25"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-26"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-27"
+            },
+            {
+              "name": "agent-00000-mcp-01-tool-28"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-0.example.internal/1"
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-02",
+          "packages": [
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00000-02-00",
+              "version": "1.2.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00000-02-01",
+              "version": "2.2.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-02-02",
+              "version": "3.2.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-02-03",
+              "version": "1.2.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-02-04",
+              "version": "2.2.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00000-02-05",
+              "version": "3.2.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-02-06",
+              "version": "1.2.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "2.2.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "team-shared-0-8",
+              "version": "3.2.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-02-09",
+              "version": "1.2.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-02-10",
+              "version": "2.2.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "openai",
+              "version": "3.2.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-02-12",
+              "version": "1.2.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-02-13",
+              "version": "2.2.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-02-14",
+              "version": "3.2.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-02-15",
+              "version": "1.2.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-02-16",
+              "version": "2.2.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "react",
+              "version": "3.2.0"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-02-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-09"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-10"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-11"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-12"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-13"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-14"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-15"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-16"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-17"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-18"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-19"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-20"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-21"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-22"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-23"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-24"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-25"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-26"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-27"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-28"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-29"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-30"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-31"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-32"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-33"
+            },
+            {
+              "name": "agent-00000-mcp-02-tool-34"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-0.example.internal/2"
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-03",
+          "packages": [
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00000-03-00",
+              "version": "1.3.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00000-03-01",
+              "version": "2.3.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-03-02",
+              "version": "3.3.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "zod",
+              "version": "1.3.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-03-04",
+              "version": "2.3.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-03-05",
+              "version": "3.3.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "team-shared-0-6",
+              "version": "1.3.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-03-07",
+              "version": "2.3.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "3.3.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "langchain",
+              "version": "1.3.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-03-10",
+              "version": "2.3.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-03-11",
+              "version": "3.3.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "1.3.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-03-13",
+              "version": "2.3.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "requests",
+              "version": "3.3.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-03-15",
+              "version": "1.3.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "react",
+              "version": "2.3.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "team-shared-0-8",
+              "version": "3.3.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00000-03-18",
+              "version": "1.3.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "2.3.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-03-20",
+              "version": "3.3.0"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-03-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-09"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-10"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-11"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-12"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-13"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-14"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-15"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-16"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-17"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-18"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-19"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-20"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-21"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-22"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-23"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-24"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-25"
+            },
+            {
+              "name": "agent-00000-mcp-03-tool-26"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-04",
+          "packages": [
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00000-04-00",
+              "version": "1.4.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-04-01",
+              "version": "2.4.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "zod",
+              "version": "3.4.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "react",
+              "version": "1.4.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "next",
+              "version": "2.4.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "team-shared-0-5",
+              "version": "3.4.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "team-shared-0-6",
+              "version": "1.4.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-04-07",
+              "version": "2.4.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "langchain",
+              "version": "3.4.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "openai",
+              "version": "1.4.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "2.4.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "mcp-sdk",
+              "version": "3.4.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-04-12",
+              "version": "1.4.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00000-04-13",
+              "version": "2.4.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-04-14",
+              "version": "3.4.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "react",
+              "version": "1.4.0"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-04-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-04-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-04-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-04-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-04-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-04-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-04-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-04-tool-07"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-0.example.internal/4"
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-05",
+          "packages": [
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "requests",
+              "version": "1.5.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "team-shared-0-1",
+              "version": "2.5.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "react",
+              "version": "3.5.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "next",
+              "version": "1.5.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00000-05-04",
+              "version": "2.5.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "3.5.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "1.5.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-05-07",
+              "version": "2.5.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-05-08",
+              "version": "3.5.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "1.5.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-05-10",
+              "version": "2.5.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00000-05-11",
+              "version": "3.5.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "requests",
+              "version": "1.5.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "zod",
+              "version": "2.5.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00000-05-14",
+              "version": "3.5.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "next",
+              "version": "1.5.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-05-16",
+              "version": "2.5.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "3.5.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-05-18",
+              "version": "1.5.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "langchain",
+              "version": "2.5.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-05-20",
+              "version": "3.5.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-05-21",
+              "version": "1.5.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "2.5.0"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-05-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-05-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-05-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-05-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-05-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-05-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-05-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-05-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-05-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-05-tool-09"
+            },
+            {
+              "name": "agent-00000-mcp-05-tool-10"
+            },
+            {
+              "name": "agent-00000-mcp-05-tool-11"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-0.example.internal/5"
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-06",
+          "packages": [
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "zod",
+              "version": "1.6.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "team-shared-0-1",
+              "version": "2.6.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "team-shared-0-2",
+              "version": "3.6.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "1.6.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-06-04",
+              "version": "2.6.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-06-05",
+              "version": "3.6.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-06-06",
+              "version": "1.6.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "openai",
+              "version": "2.6.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "team-shared-0-8",
+              "version": "3.6.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "1.6.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "2.6.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "requests",
+              "version": "3.6.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-06-12",
+              "version": "1.6.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-06-13",
+              "version": "2.6.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "next",
+              "version": "3.6.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "protobuf",
+              "version": "1.6.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "team-shared-0-7",
+              "version": "2.6.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-06-17",
+              "version": "3.6.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-06-18",
+              "version": "1.6.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "openai",
+              "version": "2.6.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-06-20",
+              "version": "3.6.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00000-06-21",
+              "version": "1.6.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "fastapi",
+              "version": "2.6.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "requests",
+              "version": "3.6.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-06-24",
+              "version": "1.6.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "react",
+              "version": "2.6.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "next",
+              "version": "3.6.0"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-06-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-06-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-06-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-06-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-06-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-06-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-06-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-06-tool-07"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-07",
+          "packages": [
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "react",
+              "version": "1.7.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00000-07-01",
+              "version": "2.7.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "team-shared-0-2",
+              "version": "3.7.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "1.7.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "2.7.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00000-07-05",
+              "version": "3.7.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "openai",
+              "version": "1.7.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "team-shared-0-7",
+              "version": "2.7.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "mcp-sdk",
+              "version": "3.7.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-07-09",
+              "version": "1.7.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "requests",
+              "version": "2.7.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-07-11",
+              "version": "3.7.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-07-12",
+              "version": "1.7.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "next",
+              "version": "2.7.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-07-14",
+              "version": "3.7.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "1.7.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "team-shared-0-7",
+              "version": "2.7.0"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-07-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-07-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-07-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-07-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-07-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-07-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-07-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-07-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-07-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-07-tool-09"
+            },
+            {
+              "name": "agent-00000-mcp-07-tool-10"
+            },
+            {
+              "name": "agent-00000-mcp-07-tool-11"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-0.example.internal/7"
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-08",
+          "packages": [
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "next",
+              "version": "1.8.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00000-08-01",
+              "version": "2.8.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "grpc",
+              "version": "3.8.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "1.8.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "langchain",
+              "version": "2.8.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-08-05",
+              "version": "3.8.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-08-06",
+              "version": "1.8.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "2.8.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-08-08",
+              "version": "3.8.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "team-shared-0-0",
+              "version": "1.8.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00000-08-10",
+              "version": "2.8.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "team-shared-0-2",
+              "version": "3.8.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "next",
+              "version": "1.8.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "protobuf",
+              "version": "2.8.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-08-14",
+              "version": "3.8.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00000-08-15",
+              "version": "1.8.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "langchain",
+              "version": "2.8.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "openai",
+              "version": "3.8.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-08-18",
+              "version": "1.8.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "2.8.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-08-20",
+              "version": "3.8.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-08-21",
+              "version": "1.8.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "zod",
+              "version": "2.8.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "react",
+              "version": "3.8.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "next",
+              "version": "1.8.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "2.8.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-08-26",
+              "version": "3.8.0"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-08-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-08-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-08-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-08-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-08-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-08-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-08-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-08-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-08-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-08-tool-09"
+            },
+            {
+              "name": "agent-00000-mcp-08-tool-10"
+            },
+            {
+              "name": "agent-00000-mcp-08-tool-11"
+            },
+            {
+              "name": "agent-00000-mcp-08-tool-12"
+            },
+            {
+              "name": "agent-00000-mcp-08-tool-13"
+            },
+            {
+              "name": "agent-00000-mcp-08-tool-14"
+            },
+            {
+              "name": "agent-00000-mcp-08-tool-15"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-0.example.internal/8"
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-09",
+          "packages": [
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "protobuf",
+              "version": "1.9.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-09-01",
+              "version": "2.9.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "boto3",
+              "version": "3.9.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-09-03",
+              "version": "1.9.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-09-04",
+              "version": "2.9.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-09-05",
+              "version": "3.9.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "1.9.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00000-09-07",
+              "version": "2.9.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "requests",
+              "version": "3.9.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00000-09-09",
+              "version": "1.9.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "team-shared-0-1",
+              "version": "2.9.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "next",
+              "version": "3.9.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "protobuf",
+              "version": "1.9.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-09-13",
+              "version": "2.9.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-09-14",
+              "version": "3.9.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "langchain",
+              "version": "1.9.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "openai",
+              "version": "2.9.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "3.9.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-09-18",
+              "version": "1.9.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "2.9.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "requests",
+              "version": "3.9.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-09-21",
+              "version": "1.9.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-09-22",
+              "version": "2.9.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-09-23",
+              "version": "3.9.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-09-24",
+              "version": "1.9.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "2.9.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "3.9.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "langchain",
+              "version": "1.9.0"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-09-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-09-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-09-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-09-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-09-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-09-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-09-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-09-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-09-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-09-tool-09"
+            },
+            {
+              "name": "agent-00000-mcp-09-tool-10"
+            },
+            {
+              "name": "agent-00000-mcp-09-tool-11"
+            },
+            {
+              "name": "agent-00000-mcp-09-tool-12"
+            },
+            {
+              "name": "agent-00000-mcp-09-tool-13"
+            },
+            {
+              "name": "agent-00000-mcp-09-tool-14"
+            },
+            {
+              "name": "agent-00000-mcp-09-tool-15"
+            },
+            {
+              "name": "agent-00000-mcp-09-tool-16"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-10",
+          "packages": [
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "grpc",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00000-10-01",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "team-shared-0-2",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "openai",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-10-04",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-10-06",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-10-07",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-10-08",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "react",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-10-10",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-10-11",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-10-12",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-10-14",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "openai",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-10-17",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "team-shared-0-1",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "zod",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-10-21",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-10-22",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-10-23",
+              "version": "3.0.0"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-10-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-10-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-10-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-10-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-10-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-10-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-10-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-10-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-10-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-10-tool-09"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-0.example.internal/10"
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-11",
+          "packages": [
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "team-shared-0-0",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00000-11-01",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-11-02",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-11-03",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "team-shared-0-4",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-11-05",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "requests",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "zod",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "react",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-11-09",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-11-10",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-11-11",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "team-shared-0-4",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-11-14",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00000-11-15",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-11-16",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00000-11-17",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "requests",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "team-shared-0-1",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "react",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "next",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-11-23",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-11-24",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "langchain",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "openai",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "1.1.0"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-11-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-11-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-11-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-11-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-11-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-11-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-11-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-11-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-11-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-11-tool-09"
+            },
+            {
+              "name": "agent-00000-mcp-11-tool-10"
+            },
+            {
+              "name": "agent-00000-mcp-11-tool-11"
+            },
+            {
+              "name": "agent-00000-mcp-11-tool-12"
+            },
+            {
+              "name": "agent-00000-mcp-11-tool-13"
+            },
+            {
+              "name": "agent-00000-mcp-11-tool-14"
+            },
+            {
+              "name": "agent-00000-mcp-11-tool-15"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-0.example.internal/11"
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-12",
+          "packages": [
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00000-12-00",
+              "version": "1.2.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "openai",
+              "version": "2.2.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-12-02",
+              "version": "3.2.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "mcp-sdk",
+              "version": "1.2.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "fastapi",
+              "version": "2.2.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "requests",
+              "version": "3.2.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "team-shared-0-6",
+              "version": "1.2.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-12-07",
+              "version": "2.2.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "next",
+              "version": "3.2.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-12-09",
+              "version": "1.2.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "team-shared-0-1",
+              "version": "2.2.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "boto3",
+              "version": "3.2.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-12-12",
+              "version": "1.2.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-12-13",
+              "version": "2.2.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00000-12-14",
+              "version": "3.2.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "1.2.0"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-12-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-12-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-12-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-12-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-12-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-12-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-12-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-12-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-12-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-12-tool-09"
+            },
+            {
+              "name": "agent-00000-mcp-12-tool-10"
+            },
+            {
+              "name": "agent-00000-mcp-12-tool-11"
+            },
+            {
+              "name": "agent-00000-mcp-12-tool-12"
+            },
+            {
+              "name": "agent-00000-mcp-12-tool-13"
+            },
+            {
+              "name": "agent-00000-mcp-12-tool-14"
+            },
+            {
+              "name": "agent-00000-mcp-12-tool-15"
+            },
+            {
+              "name": "agent-00000-mcp-12-tool-16"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-13",
+          "packages": [
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "openai",
+              "version": "1.3.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00000-13-01",
+              "version": "2.3.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-13-02",
+              "version": "3.3.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "1.3.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "requests",
+              "version": "2.3.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "zod",
+              "version": "3.3.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00000-13-06",
+              "version": "1.3.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-13-07",
+              "version": "2.3.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "3.3.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-13-09",
+              "version": "1.3.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-13-10",
+              "version": "2.3.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "langchain",
+              "version": "3.3.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-13-12",
+              "version": "1.3.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-13-13",
+              "version": "2.3.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "team-shared-0-5",
+              "version": "3.3.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "1.3.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "requests",
+              "version": "2.3.0"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-13-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-13-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-13-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-13-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-13-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-13-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-13-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-13-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-13-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-13-tool-09"
+            },
+            {
+              "name": "agent-00000-mcp-13-tool-10"
+            },
+            {
+              "name": "agent-00000-mcp-13-tool-11"
+            },
+            {
+              "name": "agent-00000-mcp-13-tool-12"
+            },
+            {
+              "name": "agent-00000-mcp-13-tool-13"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-0.example.internal/13"
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-14",
+          "packages": [
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "anthropic",
+              "version": "1.4.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-14-01",
+              "version": "2.4.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-14-02",
+              "version": "3.4.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "requests",
+              "version": "1.4.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00000-14-04",
+              "version": "2.4.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "react",
+              "version": "3.4.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "next",
+              "version": "1.4.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-14-07",
+              "version": "2.4.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-14-08",
+              "version": "3.4.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "boto3",
+              "version": "1.4.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "team-shared-0-1",
+              "version": "2.4.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "openai",
+              "version": "3.4.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-14-12",
+              "version": "1.4.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-14-13",
+              "version": "2.4.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "3.4.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-14-15",
+              "version": "1.4.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-14-16",
+              "version": "2.4.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-14-17",
+              "version": "3.4.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-14-18",
+              "version": "1.4.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "protobuf",
+              "version": "2.4.0"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-14-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-14-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-14-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-14-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-14-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-14-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-14-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-14-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-14-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-14-tool-09"
+            },
+            {
+              "name": "agent-00000-mcp-14-tool-10"
+            },
+            {
+              "name": "agent-00000-mcp-14-tool-11"
+            },
+            {
+              "name": "agent-00000-mcp-14-tool-12"
+            },
+            {
+              "name": "agent-00000-mcp-14-tool-13"
+            },
+            {
+              "name": "agent-00000-mcp-14-tool-14"
+            },
+            {
+              "name": "agent-00000-mcp-14-tool-15"
+            },
+            {
+              "name": "agent-00000-mcp-14-tool-16"
+            },
+            {
+              "name": "agent-00000-mcp-14-tool-17"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-0.example.internal/14"
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-15",
+          "packages": [
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-15-00",
+              "version": "1.5.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00000-15-01",
+              "version": "2.5.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-15-02",
+              "version": "3.5.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "zod",
+              "version": "1.5.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "react",
+              "version": "2.5.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "next",
+              "version": "3.5.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-15-06",
+              "version": "1.5.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-15-07",
+              "version": "2.5.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00000-15-08",
+              "version": "3.5.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "langchain",
+              "version": "1.5.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-15-10",
+              "version": "2.5.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "3.5.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "1.5.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "2.5.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-15-14",
+              "version": "3.5.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "zod",
+              "version": "1.5.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-15-16",
+              "version": "2.5.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-15-17",
+              "version": "3.5.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-15-18",
+              "version": "1.5.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "grpc",
+              "version": "2.5.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "team-shared-0-2",
+              "version": "3.5.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "langchain",
+              "version": "1.5.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00000-15-22",
+              "version": "2.5.0"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-15-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-15-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-15-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-15-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-15-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-15-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-15-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-15-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-15-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-15-tool-09"
+            },
+            {
+              "name": "agent-00000-mcp-15-tool-10"
+            },
+            {
+              "name": "agent-00000-mcp-15-tool-11"
+            },
+            {
+              "name": "agent-00000-mcp-15-tool-12"
+            },
+            {
+              "name": "agent-00000-mcp-15-tool-13"
+            },
+            {
+              "name": "agent-00000-mcp-15-tool-14"
+            },
+            {
+              "name": "agent-00000-mcp-15-tool-15"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-16",
+          "packages": [
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "fastapi",
+              "version": "1.6.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "requests",
+              "version": "2.6.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-16-02",
+              "version": "3.6.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "react",
+              "version": "1.6.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-16-04",
+              "version": "2.6.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00000-16-05",
+              "version": "3.6.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "team-shared-0-6",
+              "version": "1.6.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "2.6.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-16-08",
+              "version": "3.6.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "openai",
+              "version": "1.6.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-16-10",
+              "version": "2.6.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-16-11",
+              "version": "3.6.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00000-16-12",
+              "version": "1.6.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "requests",
+              "version": "2.6.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "zod",
+              "version": "3.6.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "react",
+              "version": "1.6.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00000-16-16",
+              "version": "2.6.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "3.6.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "team-shared-0-0",
+              "version": "1.6.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "boto3",
+              "version": "2.6.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "langchain",
+              "version": "3.6.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-16-21",
+              "version": "1.6.0"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-16-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-16-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-16-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-16-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-16-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-16-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-16-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-16-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-16-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-16-tool-09"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-0.example.internal/16"
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-17",
+          "packages": [
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "team-shared-0-0",
+              "version": "1.7.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00000-17-01",
+              "version": "2.7.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "react",
+              "version": "3.7.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-17-03",
+              "version": "1.7.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "2.7.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00000-17-05",
+              "version": "3.7.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-17-06",
+              "version": "1.7.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "langchain",
+              "version": "2.7.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "openai",
+              "version": "3.7.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-17-09",
+              "version": "1.7.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-17-10",
+              "version": "2.7.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-17-11",
+              "version": "3.7.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "requests",
+              "version": "1.7.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-17-13",
+              "version": "2.7.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "team-shared-0-5",
+              "version": "3.7.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "next",
+              "version": "1.7.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-17-16",
+              "version": "2.7.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-17-17",
+              "version": "3.7.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-17-18",
+              "version": "1.7.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00000-17-19",
+              "version": "2.7.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "openai",
+              "version": "3.7.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "1.7.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-17-22",
+              "version": "2.7.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-17-23",
+              "version": "3.7.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-17-24",
+              "version": "1.7.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "team-shared-0-7",
+              "version": "2.7.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-17-26",
+              "version": "3.7.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "next",
+              "version": "1.7.0"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-17-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-17-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-17-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-17-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-17-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-17-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-17-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-17-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-17-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-17-tool-09"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-0.example.internal/17"
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-18",
+          "packages": [
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00000-18-00",
+              "version": "1.8.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "react",
+              "version": "2.8.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "next",
+              "version": "3.8.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00000-18-03",
+              "version": "1.8.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-18-04",
+              "version": "2.8.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "3.8.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-18-06",
+              "version": "1.8.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-18-07",
+              "version": "2.8.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00000-18-08",
+              "version": "3.8.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "1.8.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-18-10",
+              "version": "2.8.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-18-11",
+              "version": "3.8.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-18-12",
+              "version": "1.8.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-18-13",
+              "version": "2.8.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-18-14",
+              "version": "3.8.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00000-18-15",
+              "version": "1.8.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-18-16",
+              "version": "2.8.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "3.8.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "team-shared-0-0",
+              "version": "1.8.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-18-19",
+              "version": "2.8.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00000-18-20",
+              "version": "3.8.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-18-21",
+              "version": "1.8.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "2.8.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "requests",
+              "version": "3.8.0"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-18-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-18-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-18-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-18-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-18-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-18-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-18-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-18-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-18-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-18-tool-09"
+            },
+            {
+              "name": "agent-00000-mcp-18-tool-10"
+            },
+            {
+              "name": "agent-00000-mcp-18-tool-11"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-19",
+          "packages": [
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "react",
+              "version": "1.9.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-19-01",
+              "version": "2.9.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-19-02",
+              "version": "3.9.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00000-19-03",
+              "version": "1.9.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "2.9.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "team-shared-0-5",
+              "version": "3.9.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "openai",
+              "version": "1.9.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-19-07",
+              "version": "2.9.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-19-08",
+              "version": "3.9.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-19-09",
+              "version": "1.9.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-19-10",
+              "version": "2.9.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-19-11",
+              "version": "3.9.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-19-12",
+              "version": "1.9.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-19-13",
+              "version": "2.9.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "3.9.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-19-15",
+              "version": "1.9.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "2.9.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00000-19-17",
+              "version": "3.9.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00000-19-18",
+              "version": "1.9.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-19-19",
+              "version": "2.9.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "3.9.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "1.9.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "team-shared-0-4",
+              "version": "2.9.0"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-19-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-19-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-19-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-19-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-19-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-19-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-19-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-19-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-19-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-19-tool-09"
+            },
+            {
+              "name": "agent-00000-mcp-19-tool-10"
+            },
+            {
+              "name": "agent-00000-mcp-19-tool-11"
+            },
+            {
+              "name": "agent-00000-mcp-19-tool-12"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-0.example.internal/19"
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-20",
+          "packages": [
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "next",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00000-20-01",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-20-04",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-20-05",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-20-06",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-20-07",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "team-shared-0-8",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "team-shared-0-0",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "zod",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00000-20-11",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-20-12",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "team-shared-0-4",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-20-14",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "langchain",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "openai",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-20-18",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-20-19",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "fastapi",
+              "version": "3.0.0"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-20-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-20-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-20-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-20-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-20-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-20-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-20-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-20-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-20-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-20-tool-09"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-0.example.internal/20"
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-21",
+          "packages": [
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "protobuf",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00000-21-01",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00000-21-02",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "langchain",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-21-04",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "mcp-sdk",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00000-21-07",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-21-08",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "zod",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-21-10",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "team-shared-0-2",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "protobuf",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-21-13",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "team-shared-0-5",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-21-15",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "openai",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00000-21-18",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-21-19",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "requests",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "zod",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "react",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "next",
+              "version": "3.1.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-21-24",
+              "version": "1.1.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-21-25",
+              "version": "2.1.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "3.1.0"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-21-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-21-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-21-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-21-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-21-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-21-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-21-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-21-tool-07"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-22",
+          "packages": [
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "grpc",
+              "version": "1.2.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "team-shared-0-1",
+              "version": "2.2.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "team-shared-0-2",
+              "version": "3.2.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "openai",
+              "version": "1.2.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "2.2.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-22-05",
+              "version": "3.2.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "team-shared-0-6",
+              "version": "1.2.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-22-07",
+              "version": "2.2.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-22-08",
+              "version": "3.2.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "react",
+              "version": "1.2.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "next",
+              "version": "2.2.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "3.2.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00000-22-12",
+              "version": "1.2.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00000-22-13",
+              "version": "2.2.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "langchain",
+              "version": "3.2.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00000-22-15",
+              "version": "1.2.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "anthropic",
+              "version": "2.2.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00000-22-17",
+              "version": "3.2.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "1.2.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "requests",
+              "version": "2.2.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00000-22-20",
+              "version": "3.2.0"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-22-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-22-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-22-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-22-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-22-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-22-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-22-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-22-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-22-tool-08"
+            },
+            {
+              "name": "agent-00000-mcp-22-tool-09"
+            },
+            {
+              "name": "agent-00000-mcp-22-tool-10"
+            },
+            {
+              "name": "agent-00000-mcp-22-tool-11"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-0.example.internal/22"
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00000_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory",
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00000-mcp-23",
+          "packages": [
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00000-23-00",
+              "version": "1.3.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "team-shared-0-1",
+              "version": "2.3.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "openai",
+              "version": "3.3.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-23-03",
+              "version": "1.3.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "2.3.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "3.3.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "requests",
+              "version": "1.3.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "zod",
+              "version": "2.3.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "react",
+              "version": "3.3.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "next",
+              "version": "1.3.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00000-23-10",
+              "version": "2.3.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00000-23-11",
+              "version": "3.3.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00000-23-12",
+              "version": "1.3.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00000-23-13",
+              "version": "2.3.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "openai",
+              "version": "3.3.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "1.3.0"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00000-mcp-23-tool-00"
+            },
+            {
+              "name": "agent-00000-mcp-23-tool-01"
+            },
+            {
+              "name": "agent-00000-mcp-23-tool-02"
+            },
+            {
+              "name": "agent-00000-mcp-23-tool-03"
+            },
+            {
+              "name": "agent-00000-mcp-23-tool-04"
+            },
+            {
+              "name": "agent-00000-mcp-23-tool-05"
+            },
+            {
+              "name": "agent-00000-mcp-23-tool-06"
+            },
+            {
+              "name": "agent-00000-mcp-23-tool-07"
+            },
+            {
+              "name": "agent-00000-mcp-23-tool-08"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-0.example.internal/23"
+        }
+      ],
+      "name": "agent-00000",
+      "source": "cloud-inventory",
+      "status": "configured",
+      "type": "claude-desktop"
+    },
+    {
+      "discovery_sources": [
+        "github-action"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "github-action"
+          ],
+          "name": "agent-00001-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "team-shared-0-0",
+              "version": "1.0.1"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "team-shared-0-1",
+              "version": "2.0.1"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "team-shared-0-2",
+              "version": "3.0.1"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "1.0.1"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00001-00-04",
+              "version": "2.0.1"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "zod",
+              "version": "3.0.1"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "react",
+              "version": "1.0.1"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "next",
+              "version": "2.0.1"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "3.0.1"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "1.0.1"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00001-00-10",
+              "version": "2.0.1"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "langchain",
+              "version": "3.0.1"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "openai",
+              "version": "1.0.1"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00001-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00001-mcp-00-tool-01"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        }
+      ],
+      "name": "agent-00001",
+      "source": "github-action",
+      "status": "configured",
+      "type": "cursor"
+    },
+    {
+      "discovery_sources": [
+        "k8s-fleet"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "k8s-fleet"
+          ],
+          "name": "agent-00002-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00002-00-00",
+              "version": "1.0.2"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00002-00-01",
+              "version": "2.0.2"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "fastapi",
+              "version": "3.0.2"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00002-00-03",
+              "version": "1.0.2"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00002-00-04",
+              "version": "2.0.2"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00002-00-05",
+              "version": "3.0.2"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00002-00-06",
+              "version": "1.0.2"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00002-00-07",
+              "version": "2.0.2"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00002-00-08",
+              "version": "3.0.2"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00002-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00002-mcp-00-tool-01"
+            },
+            {
+              "name": "agent-00002-mcp-00-tool-02"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        }
+      ],
+      "name": "agent-00002",
+      "source": "k8s-fleet",
+      "status": "configured",
+      "type": "windsurf"
+    },
+    {
+      "discovery_sources": [
+        "operator-push"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00003-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00003-00-00",
+              "version": "1.0.3"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "team-shared-0-1",
+              "version": "2.0.3"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00003-00-02",
+              "version": "3.0.3"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00003-00-03",
+              "version": "1.0.3"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00003-00-04",
+              "version": "2.0.3"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "next",
+              "version": "3.0.3"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "1.0.3"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00003-00-07",
+              "version": "2.0.3"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "3.0.3"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00003-00-09",
+              "version": "1.0.3"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00003-00-10",
+              "version": "2.0.3"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00003-00-11",
+              "version": "3.0.3"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "mcp-sdk",
+              "version": "1.0.3"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00003-00-13",
+              "version": "2.0.3"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00003-mcp-00-tool-00"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00003-mcp-01",
+          "packages": [
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "fastapi",
+              "version": "1.1.3"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00003-01-01",
+              "version": "2.1.3"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00003-01-02",
+              "version": "3.1.3"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00003-01-03",
+              "version": "1.1.3"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00003-01-04",
+              "version": "2.1.3"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "protobuf",
+              "version": "3.1.3"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "team-shared-0-6",
+              "version": "1.1.3"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00003-01-07",
+              "version": "2.1.3"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00003-mcp-01-tool-00"
+            },
+            {
+              "name": "agent-00003-mcp-01-tool-01"
+            },
+            {
+              "name": "agent-00003-mcp-01-tool-02"
+            },
+            {
+              "name": "agent-00003-mcp-01-tool-03"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-3.example.internal/1"
+        }
+      ],
+      "name": "agent-00003",
+      "source": "operator-push",
+      "status": "configured",
+      "type": "vscode"
+    },
+    {
+      "discovery_sources": [
+        "cloud-inventory"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "cloud-inventory"
+          ],
+          "name": "agent-00004-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "fastapi",
+              "version": "1.0.4"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "requests",
+              "version": "2.0.4"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "zod",
+              "version": "3.0.4"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00004-00-03",
+              "version": "1.0.4"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00004-00-04",
+              "version": "2.0.4"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "3.0.4"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00004-00-06",
+              "version": "1.0.4"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00004-00-07",
+              "version": "2.0.4"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "langchain",
+              "version": "3.0.4"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00004-00-09",
+              "version": "1.0.4"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00004-mcp-00-tool-00"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        }
+      ],
+      "name": "agent-00004",
+      "source": "cloud-inventory",
+      "status": "configured",
+      "type": "cortex-code"
+    },
+    {
+      "discovery_sources": [
+        "local",
+        "operator-push"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00005-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "requests",
+              "version": "1.0.5"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00005-00-01",
+              "version": "2.0.5"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00005-00-02",
+              "version": "3.0.5"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "next",
+              "version": "1.0.5"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00005-00-04",
+              "version": "2.0.5"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "3.0.5"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00005-00-06",
+              "version": "1.0.5"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00005-00-07",
+              "version": "2.0.5"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "team-shared-0-8",
+              "version": "3.0.5"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00005-00-09",
+              "version": "1.0.5"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00005-00-10",
+              "version": "2.0.5"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00005-00-11",
+              "version": "3.0.5"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "requests",
+              "version": "1.0.5"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "zod",
+              "version": "2.0.5"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00005-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00005-mcp-00-tool-01"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00005-mcp-01",
+          "packages": [
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "team-shared-0-0",
+              "version": "1.1.5"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "react",
+              "version": "2.1.5"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00005-01-02",
+              "version": "3.1.5"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "1.1.5"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00005-01-04",
+              "version": "2.1.5"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "team-shared-0-5",
+              "version": "3.1.5"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00005-01-06",
+              "version": "1.1.5"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00005-mcp-01-tool-00"
+            },
+            {
+              "name": "agent-00005-mcp-01-tool-01"
+            },
+            {
+              "name": "agent-00005-mcp-01-tool-02"
+            },
+            {
+              "name": "agent-00005-mcp-01-tool-03"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-5.example.internal/1"
+        }
+      ],
+      "name": "agent-00005",
+      "source": "local",
+      "status": "configured",
+      "type": "claude-desktop"
+    },
+    {
+      "discovery_sources": [
+        "github-action"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "github-action"
+          ],
+          "name": "agent-00006-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "team-shared-0-0",
+              "version": "1.0.6"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "react",
+              "version": "2.0.6"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "next",
+              "version": "3.0.6"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "1.0.6"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "2.0.6"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00006-00-05",
+              "version": "3.0.6"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00006-00-06",
+              "version": "1.0.6"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00006-00-07",
+              "version": "2.0.6"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00006-00-08",
+              "version": "3.0.6"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00006-mcp-00-tool-00"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        }
+      ],
+      "name": "agent-00006",
+      "source": "github-action",
+      "status": "configured",
+      "type": "cursor"
+    },
+    {
+      "discovery_sources": [
+        "k8s-fleet"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "k8s-fleet"
+          ],
+          "name": "agent-00007-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00007-00-00",
+              "version": "1.0.7"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "next",
+              "version": "2.0.7"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "3.0.7"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00007-00-03",
+              "version": "1.0.7"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "boto3",
+              "version": "2.0.7"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00007-00-05",
+              "version": "3.0.7"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "openai",
+              "version": "1.0.7"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "anthropic",
+              "version": "2.0.7"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00007-00-08",
+              "version": "3.0.7"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00007-00-09",
+              "version": "1.0.7"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00007-mcp-00-tool-00"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "k8s-fleet"
+          ],
+          "name": "agent-00007-mcp-01",
+          "packages": [
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00007-01-00",
+              "version": "1.1.7"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "protobuf",
+              "version": "2.1.7"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "3.1.7"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00007-mcp-01-tool-00"
+            },
+            {
+              "name": "agent-00007-mcp-01-tool-01"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-7.example.internal/1"
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "k8s-fleet"
+          ],
+          "name": "agent-00007-mcp-02",
+          "packages": [
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00007-02-00",
+              "version": "1.2.7"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "grpc",
+              "version": "2.2.7"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "boto3",
+              "version": "3.2.7"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00007-02-03",
+              "version": "1.2.7"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "team-shared-0-4",
+              "version": "2.2.7"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00007-02-05",
+              "version": "3.2.7"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00007-mcp-02-tool-00"
+            },
+            {
+              "name": "agent-00007-mcp-02-tool-01"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-7.example.internal/2"
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "k8s-fleet"
+          ],
+          "name": "agent-00007-mcp-03",
+          "packages": [
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00007-03-00",
+              "version": "1.3.7"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "boto3",
+              "version": "2.3.7"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00007-03-02",
+              "version": "3.3.7"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00007-03-03",
+              "version": "1.3.7"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00007-mcp-03-tool-00"
+            },
+            {
+              "name": "agent-00007-mcp-03-tool-01"
+            },
+            {
+              "name": "agent-00007-mcp-03-tool-02"
+            },
+            {
+              "name": "agent-00007-mcp-03-tool-03"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "k8s-fleet"
+          ],
+          "name": "agent-00007-mcp-04",
+          "packages": [
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "team-shared-0-0",
+              "version": "1.4.7"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "team-shared-0-1",
+              "version": "2.4.7"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "openai",
+              "version": "3.4.7"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00007-mcp-04-tool-00"
+            },
+            {
+              "name": "agent-00007-mcp-04-tool-01"
+            },
+            {
+              "name": "agent-00007-mcp-04-tool-02"
+            },
+            {
+              "name": "agent-00007-mcp-04-tool-03"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-7.example.internal/4"
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "k8s-fleet"
+          ],
+          "name": "agent-00007-mcp-05",
+          "packages": [
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00007-05-00",
+              "version": "1.5.7"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "openai",
+              "version": "2.5.7"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "team-shared-0-2",
+              "version": "3.5.7"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "mcp-sdk",
+              "version": "1.5.7"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "2.5.7"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00007-05-05",
+              "version": "3.5.7"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00007-05-06",
+              "version": "1.5.7"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00007-05-07",
+              "version": "2.5.7"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00007-05-08",
+              "version": "3.5.7"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "protobuf",
+              "version": "1.5.7"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00007-mcp-05-tool-00"
+            },
+            {
+              "name": "agent-00007-mcp-05-tool-01"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-7.example.internal/5"
+        }
+      ],
+      "name": "agent-00007",
+      "source": "k8s-fleet",
+      "status": "configured",
+      "type": "windsurf"
+    },
+    {
+      "discovery_sources": [
+        "operator-push"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00008-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "team-shared-0-0",
+              "version": "1.0.8"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00008-00-01",
+              "version": "2.0.8"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "3.0.8"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "1.0.8"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00008-00-04",
+              "version": "2.0.8"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00008-00-05",
+              "version": "3.0.8"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00008-00-06",
+              "version": "1.0.8"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "team-shared-0-7",
+              "version": "2.0.8"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00008-00-08",
+              "version": "3.0.8"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "requests",
+              "version": "1.0.8"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00008-00-10",
+              "version": "2.0.8"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00008-00-11",
+              "version": "3.0.8"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00008-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00008-mcp-00-tool-01"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        }
+      ],
+      "name": "agent-00008",
+      "source": "operator-push",
+      "status": "configured",
+      "type": "vscode"
+    },
+    {
+      "discovery_sources": [
+        "cloud-inventory"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [
+            "AGENT_00009_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory"
+          ],
+          "name": "agent-00009-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "protobuf",
+              "version": "1.0.9"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "grpc",
+              "version": "2.0.9"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00009-00-02",
+              "version": "3.0.9"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "team-shared-0-3",
+              "version": "1.0.9"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00009-00-04",
+              "version": "2.0.9"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "team-shared-0-5",
+              "version": "3.0.9"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "1.0.9"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00009-00-07",
+              "version": "2.0.9"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00009-00-08",
+              "version": "3.0.9"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00009-00-09",
+              "version": "1.0.9"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00009-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00009-mcp-00-tool-01"
+            },
+            {
+              "name": "agent-00009-mcp-00-tool-02"
+            },
+            {
+              "name": "agent-00009-mcp-00-tool-03"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [
+            "AGENT_00009_TOKEN"
+          ],
+          "discovery_sources": [
+            "cloud-inventory"
+          ],
+          "name": "agent-00009-mcp-01",
+          "packages": [
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "team-shared-0-0",
+              "version": "1.1.9"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00009-01-01",
+              "version": "2.1.9"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "langchain",
+              "version": "3.1.9"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00009-01-03",
+              "version": "1.1.9"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "anthropic",
+              "version": "2.1.9"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00009-01-05",
+              "version": "3.1.9"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00009-mcp-01-tool-00"
+            },
+            {
+              "name": "agent-00009-mcp-01-tool-01"
+            },
+            {
+              "name": "agent-00009-mcp-01-tool-02"
+            },
+            {
+              "name": "agent-00009-mcp-01-tool-03"
+            },
+            {
+              "name": "agent-00009-mcp-01-tool-04"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-9.example.internal/1"
+        }
+      ],
+      "name": "agent-00009",
+      "source": "cloud-inventory",
+      "status": "configured",
+      "type": "cortex-code"
+    },
+    {
+      "discovery_sources": [
+        "local",
+        "operator-push"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00010-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00010-00-00",
+              "version": "1.0.10"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00010-00-01",
+              "version": "2.0.10"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "team-shared-0-2",
+              "version": "3.0.10"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00010-00-03",
+              "version": "1.0.10"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "2.0.10"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "3.0.10"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00010-00-06",
+              "version": "1.0.10"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "requests",
+              "version": "2.0.10"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00010-00-08",
+              "version": "3.0.10"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "react",
+              "version": "1.0.10"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "next",
+              "version": "2.0.10"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00010-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00010-mcp-00-tool-01"
+            },
+            {
+              "name": "agent-00010-mcp-00-tool-02"
+            },
+            {
+              "name": "agent-00010-mcp-00-tool-03"
+            },
+            {
+              "name": "agent-00010-mcp-00-tool-04"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        }
+      ],
+      "name": "agent-00010",
+      "source": "local",
+      "status": "configured",
+      "type": "claude-desktop"
+    },
+    {
+      "discovery_sources": [
+        "cloud-inventory",
+        "github-action"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "cloud-inventory",
+            "github-action"
+          ],
+          "name": "agent-00011-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "boto3",
+              "version": "1.0.11"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00011-00-01",
+              "version": "2.0.11"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "openai",
+              "version": "3.0.11"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00011-00-03",
+              "version": "1.0.11"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "2.0.11"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "3.0.11"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00011-00-06",
+              "version": "1.0.11"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "zod",
+              "version": "2.0.11"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "react",
+              "version": "3.0.11"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00011-00-09",
+              "version": "1.0.11"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00011-00-10",
+              "version": "2.0.11"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "grpc",
+              "version": "3.0.11"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "1.0.11"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "langchain",
+              "version": "2.0.11"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00011-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00011-mcp-00-tool-01"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        }
+      ],
+      "name": "agent-00011",
+      "source": "cloud-inventory",
+      "status": "configured",
+      "type": "cursor"
+    },
+    {
+      "discovery_sources": [
+        "k8s-fleet"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "k8s-fleet"
+          ],
+          "name": "agent-00012-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00012-00-00",
+              "version": "1.0.12"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00012-00-01",
+              "version": "2.0.12"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "3.0.12"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "mcp-sdk",
+              "version": "1.0.12"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "fastapi",
+              "version": "2.0.12"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00012-00-05",
+              "version": "3.0.12"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "zod",
+              "version": "1.0.12"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00012-00-07",
+              "version": "2.0.12"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "next",
+              "version": "3.0.12"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00012-00-09",
+              "version": "1.0.12"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "2.0.12"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00012-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00012-mcp-00-tool-01"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        }
+      ],
+      "name": "agent-00012",
+      "source": "k8s-fleet",
+      "status": "configured",
+      "type": "windsurf"
+    },
+    {
+      "discovery_sources": [
+        "operator-push"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00013-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "team-shared-0-0",
+              "version": "1.0.13"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "team-shared-0-1",
+              "version": "2.0.13"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "3.0.13"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00013-00-03",
+              "version": "1.0.13"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "team-shared-0-4",
+              "version": "2.0.13"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "team-shared-0-5",
+              "version": "3.0.13"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00013-00-06",
+              "version": "1.0.13"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00013-00-07",
+              "version": "2.0.13"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "3.0.13"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "1.0.13"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00013-00-10",
+              "version": "2.0.13"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00013-mcp-00-tool-00"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        }
+      ],
+      "name": "agent-00013",
+      "source": "operator-push",
+      "status": "configured",
+      "type": "vscode"
+    },
+    {
+      "discovery_sources": [
+        "cloud-inventory"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "cloud-inventory"
+          ],
+          "name": "agent-00014-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "anthropic",
+              "version": "1.0.14"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00014-00-01",
+              "version": "2.0.14"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00014-00-02",
+              "version": "3.0.14"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00014-00-03",
+              "version": "1.0.14"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "zod",
+              "version": "2.0.14"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00014-00-05",
+              "version": "3.0.14"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00014-00-06",
+              "version": "1.0.14"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "team-shared-0-7",
+              "version": "2.0.14"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "grpc",
+              "version": "3.0.14"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "1.0.14"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00014-00-10",
+              "version": "2.0.14"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "openai",
+              "version": "3.0.14"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "anthropic",
+              "version": "1.0.14"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "2.0.14"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00014-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00014-mcp-00-tool-01"
+            },
+            {
+              "name": "agent-00014-mcp-00-tool-02"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "cloud-inventory"
+          ],
+          "name": "agent-00014-mcp-01",
+          "packages": [
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00014-01-00",
+              "version": "1.1.14"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "team-shared-0-1",
+              "version": "2.1.14"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00014-01-02",
+              "version": "3.1.14"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00014-01-03",
+              "version": "1.1.14"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "react",
+              "version": "2.1.14"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00014-01-05",
+              "version": "3.1.14"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00014-mcp-01-tool-00"
+            },
+            {
+              "name": "agent-00014-mcp-01-tool-01"
+            },
+            {
+              "name": "agent-00014-mcp-01-tool-02"
+            },
+            {
+              "name": "agent-00014-mcp-01-tool-03"
+            },
+            {
+              "name": "agent-00014-mcp-01-tool-04"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-14.example.internal/1"
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "cloud-inventory"
+          ],
+          "name": "agent-00014-mcp-02",
+          "packages": [
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00014-02-00",
+              "version": "1.2.14"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00014-02-01",
+              "version": "2.2.14"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00014-02-02",
+              "version": "3.2.14"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00014-02-03",
+              "version": "1.2.14"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00014-02-04",
+              "version": "2.2.14"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "3.2.14"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "1.2.14"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00014-mcp-02-tool-00"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-14.example.internal/2"
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "cloud-inventory"
+          ],
+          "name": "agent-00014-mcp-03",
+          "packages": [
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "requests",
+              "version": "1.3.14"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00014-03-01",
+              "version": "2.3.14"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00014-03-02",
+              "version": "3.3.14"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "next",
+              "version": "1.3.14"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "2.3.14"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00014-mcp-03-tool-00"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "cloud-inventory"
+          ],
+          "name": "agent-00014-mcp-04",
+          "packages": [
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00014-04-00",
+              "version": "1.4.14"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00014-04-01",
+              "version": "2.4.14"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "next",
+              "version": "3.4.14"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "protobuf",
+              "version": "1.4.14"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "team-shared-0-4",
+              "version": "2.4.14"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "3.4.14"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "langchain",
+              "version": "1.4.14"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00014-04-07",
+              "version": "2.4.14"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00014-mcp-04-tool-00"
+            },
+            {
+              "name": "agent-00014-mcp-04-tool-01"
+            },
+            {
+              "name": "agent-00014-mcp-04-tool-02"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-14.example.internal/4"
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "cloud-inventory"
+          ],
+          "name": "agent-00014-mcp-05",
+          "packages": [
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "react",
+              "version": "1.5.14"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "next",
+              "version": "2.5.14"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00014-05-02",
+              "version": "3.5.14"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00014-05-03",
+              "version": "1.5.14"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00014-05-04",
+              "version": "2.5.14"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00014-05-05",
+              "version": "3.5.14"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "openai",
+              "version": "1.5.14"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00014-05-07",
+              "version": "2.5.14"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00014-05-08",
+              "version": "3.5.14"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "1.5.14"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00014-05-10",
+              "version": "2.5.14"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "team-shared-0-2",
+              "version": "3.5.14"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "react",
+              "version": "1.5.14"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00014-mcp-05-tool-00"
+            },
+            {
+              "name": "agent-00014-mcp-05-tool-01"
+            },
+            {
+              "name": "agent-00014-mcp-05-tool-02"
+            },
+            {
+              "name": "agent-00014-mcp-05-tool-03"
+            },
+            {
+              "name": "agent-00014-mcp-05-tool-04"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-14.example.internal/5"
+        }
+      ],
+      "name": "agent-00014",
+      "source": "cloud-inventory",
+      "status": "configured",
+      "type": "cortex-code"
+    },
+    {
+      "discovery_sources": [
+        "local",
+        "operator-push"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00015-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "mcp-sdk",
+              "version": "1.0.15"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00015-00-01",
+              "version": "2.0.15"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00015-00-02",
+              "version": "3.0.15"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "zod",
+              "version": "1.0.15"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00015-00-04",
+              "version": "2.0.15"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00015-00-05",
+              "version": "3.0.15"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00015-00-06",
+              "version": "1.0.15"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "2.0.15"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "3.0.15"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "langchain",
+              "version": "1.0.15"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00015-00-10",
+              "version": "2.0.15"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00015-00-11",
+              "version": "3.0.15"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "1.0.15"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00015-00-13",
+              "version": "2.0.15"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00015-mcp-00-tool-00"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00015-mcp-01",
+          "packages": [
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "fastapi",
+              "version": "1.1.15"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "team-shared-0-1",
+              "version": "2.1.15"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00015-01-02",
+              "version": "3.1.15"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00015-01-03",
+              "version": "1.1.15"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00015-01-04",
+              "version": "2.1.15"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "3.1.15"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "grpc",
+              "version": "1.1.15"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "boto3",
+              "version": "2.1.15"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00015-mcp-01-tool-00"
+            },
+            {
+              "name": "agent-00015-mcp-01-tool-01"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-15.example.internal/1"
+        }
+      ],
+      "name": "agent-00015",
+      "source": "local",
+      "status": "configured",
+      "type": "claude-desktop"
+    },
+    {
+      "discovery_sources": [
+        "github-action"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "github-action"
+          ],
+          "name": "agent-00016-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00016-00-00",
+              "version": "1.0.16"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "requests",
+              "version": "2.0.16"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00016-00-02",
+              "version": "3.0.16"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00016-00-03",
+              "version": "1.0.16"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00016-00-04",
+              "version": "2.0.16"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "3.0.16"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "1.0.16"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00016-00-07",
+              "version": "2.0.16"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00016-00-08",
+              "version": "3.0.16"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "team-shared-0-0",
+              "version": "1.0.16"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00016-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00016-mcp-00-tool-01"
+            },
+            {
+              "name": "agent-00016-mcp-00-tool-02"
+            },
+            {
+              "name": "agent-00016-mcp-00-tool-03"
+            },
+            {
+              "name": "agent-00016-mcp-00-tool-04"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        }
+      ],
+      "name": "agent-00016",
+      "source": "github-action",
+      "status": "configured",
+      "type": "cursor"
+    },
+    {
+      "discovery_sources": [
+        "k8s-fleet"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "k8s-fleet"
+          ],
+          "name": "agent-00017-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "requests",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "zod",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00017-00-02",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "next",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "grpc",
+              "version": "3.0.0"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00017-00-06",
+              "version": "1.0.0"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00017-00-07",
+              "version": "2.0.0"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "openai",
+              "version": "3.0.0"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00017-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00017-mcp-00-tool-01"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        }
+      ],
+      "name": "agent-00017",
+      "source": "k8s-fleet",
+      "status": "configured",
+      "type": "windsurf"
+    },
+    {
+      "discovery_sources": [
+        "operator-push"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [
+            "AGENT_00018_TOKEN"
+          ],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00018-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "team-shared-0-0",
+              "version": "1.0.1"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00018-00-01",
+              "version": "2.0.1"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00018-00-02",
+              "version": "3.0.1"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "1.0.1"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00018-00-04",
+              "version": "2.0.1"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "team-shared-0-5",
+              "version": "3.0.1"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00018-00-06",
+              "version": "1.0.1"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00018-00-07",
+              "version": "2.0.1"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00018-00-08",
+              "version": "3.0.1"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00018-00-09",
+              "version": "1.0.1"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "fastapi",
+              "version": "2.0.1"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00018-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00018-mcp-00-tool-01"
+            },
+            {
+              "name": "agent-00018-mcp-00-tool-02"
+            },
+            {
+              "name": "agent-00018-mcp-00-tool-03"
+            },
+            {
+              "name": "agent-00018-mcp-00-tool-04"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        }
+      ],
+      "name": "agent-00018",
+      "source": "operator-push",
+      "status": "configured",
+      "type": "vscode"
+    },
+    {
+      "discovery_sources": [
+        "cloud-inventory"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "cloud-inventory"
+          ],
+          "name": "agent-00019-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00019-00-00",
+              "version": "1.0.2"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00019-00-01",
+              "version": "2.0.2"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "team-shared-0-2",
+              "version": "3.0.2"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00019-00-03",
+              "version": "1.0.2"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00019-00-04",
+              "version": "2.0.2"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "langchain",
+              "version": "3.0.2"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00019-00-06",
+              "version": "1.0.2"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00019-00-07",
+              "version": "2.0.2"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "team-shared-0-8",
+              "version": "3.0.2"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "1.0.2"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00019-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00019-mcp-00-tool-01"
+            },
+            {
+              "name": "agent-00019-mcp-00-tool-02"
+            },
+            {
+              "name": "agent-00019-mcp-00-tool-03"
+            },
+            {
+              "name": "agent-00019-mcp-00-tool-04"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        }
+      ],
+      "name": "agent-00019",
+      "source": "cloud-inventory",
+      "status": "configured",
+      "type": "cortex-code"
+    },
+    {
+      "discovery_sources": [
+        "local",
+        "operator-push"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "local",
+            "operator-push"
+          ],
+          "name": "agent-00020-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "team-shared-0-0",
+              "version": "1.0.3"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "team-shared-0-1",
+              "version": "2.0.3"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "grpc",
+              "version": "3.0.3"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00020-00-03",
+              "version": "1.0.3"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00020-00-04",
+              "version": "2.0.3"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "openai",
+              "version": "3.0.3"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "team-shared-0-6",
+              "version": "1.0.3"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00020-00-07",
+              "version": "2.0.3"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00020-00-08",
+              "version": "3.0.3"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00020-00-09",
+              "version": "1.0.3"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00020-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00020-mcp-00-tool-01"
+            },
+            {
+              "name": "agent-00020-mcp-00-tool-02"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        }
+      ],
+      "name": "agent-00020",
+      "source": "local",
+      "status": "configured",
+      "type": "claude-desktop"
+    },
+    {
+      "discovery_sources": [
+        "github-action"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "github-action"
+          ],
+          "name": "agent-00021-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00021-00-00",
+              "version": "1.0.4"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00021-00-01",
+              "version": "2.0.4"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00021-00-02",
+              "version": "3.0.4"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "langchain",
+              "version": "1.0.4"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00021-00-04",
+              "version": "2.0.4"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00021-00-05",
+              "version": "3.0.4"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00021-00-06",
+              "version": "1.0.4"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00021-00-07",
+              "version": "2.0.4"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00021-00-08",
+              "version": "3.0.4"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00021-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00021-mcp-00-tool-01"
+            },
+            {
+              "name": "agent-00021-mcp-00-tool-02"
+            },
+            {
+              "name": "agent-00021-mcp-00-tool-03"
+            },
+            {
+              "name": "agent-00021-mcp-00-tool-04"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "github-action"
+          ],
+          "name": "agent-00021-mcp-01",
+          "packages": [
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "grpc",
+              "version": "1.1.4"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "boto3",
+              "version": "2.1.4"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00021-01-02",
+              "version": "3.1.4"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "openai",
+              "version": "1.1.4"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "2.1.4"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "mcp-sdk",
+              "version": "3.1.4"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00021-mcp-01-tool-00"
+            },
+            {
+              "name": "agent-00021-mcp-01-tool-01"
+            },
+            {
+              "name": "agent-00021-mcp-01-tool-02"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-21.example.internal/1"
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "github-action"
+          ],
+          "name": "agent-00021-mcp-02",
+          "packages": [
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "boto3",
+              "version": "1.2.4"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "langchain",
+              "version": "2.2.4"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00021-02-02",
+              "version": "3.2.4"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00021-02-03",
+              "version": "1.2.4"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00021-mcp-02-tool-00"
+            },
+            {
+              "name": "agent-00021-mcp-02-tool-01"
+            },
+            {
+              "name": "agent-00021-mcp-02-tool-02"
+            },
+            {
+              "name": "agent-00021-mcp-02-tool-03"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-21.example.internal/2"
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "github-action"
+          ],
+          "name": "agent-00021-mcp-03",
+          "packages": [
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00021-03-00",
+              "version": "1.3.4"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "openai",
+              "version": "2.3.4"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "team-shared-0-2",
+              "version": "3.3.4"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00021-mcp-03-tool-00"
+            },
+            {
+              "name": "agent-00021-mcp-03-tool-01"
+            },
+            {
+              "name": "agent-00021-mcp-03-tool-02"
+            },
+            {
+              "name": "agent-00021-mcp-03-tool-03"
+            },
+            {
+              "name": "agent-00021-mcp-03-tool-04"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        }
+      ],
+      "name": "agent-00021",
+      "source": "github-action",
+      "status": "configured",
+      "type": "cursor"
+    },
+    {
+      "discovery_sources": [
+        "cloud-inventory",
+        "k8s-fleet"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "cloud-inventory",
+            "k8s-fleet"
+          ],
+          "name": "agent-00022-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "grpc",
+              "version": "1.0.5"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "boto3",
+              "version": "2.0.5"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00022-00-02",
+              "version": "3.0.5"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "openai",
+              "version": "1.0.5"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00022-00-04",
+              "version": "2.0.5"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00022-00-05",
+              "version": "3.0.5"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00022-00-06",
+              "version": "1.0.5"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00022-00-07",
+              "version": "2.0.5"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "zod",
+              "version": "3.0.5"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00022-00-09",
+              "version": "1.0.5"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "next",
+              "version": "2.0.5"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00022-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00022-mcp-00-tool-01"
+            },
+            {
+              "name": "agent-00022-mcp-00-tool-02"
+            },
+            {
+              "name": "agent-00022-mcp-00-tool-03"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        }
+      ],
+      "name": "agent-00022",
+      "source": "cloud-inventory",
+      "status": "configured",
+      "type": "windsurf"
+    },
+    {
+      "discovery_sources": [
+        "operator-push"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00023-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00023-00-00",
+              "version": "1.0.6"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00023-00-01",
+              "version": "2.0.6"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "openai",
+              "version": "3.0.6"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "1.0.6"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "team-shared-0-4",
+              "version": "2.0.6"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00023-00-05",
+              "version": "3.0.6"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00023-00-06",
+              "version": "1.0.6"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "zod",
+              "version": "2.0.6"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "react",
+              "version": "3.0.6"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00023-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00023-mcp-00-tool-01"
+            },
+            {
+              "name": "agent-00023-mcp-00-tool-02"
+            },
+            {
+              "name": "agent-00023-mcp-00-tool-03"
+            },
+            {
+              "name": "agent-00023-mcp-00-tool-04"
+            },
+            {
+              "name": "agent-00023-mcp-00-tool-05"
+            },
+            {
+              "name": "agent-00023-mcp-00-tool-06"
+            },
+            {
+              "name": "agent-00023-mcp-00-tool-07"
+            },
+            {
+              "name": "agent-00023-mcp-00-tool-08"
+            },
+            {
+              "name": "agent-00023-mcp-00-tool-09"
+            },
+            {
+              "name": "agent-00023-mcp-00-tool-10"
+            },
+            {
+              "name": "agent-00023-mcp-00-tool-11"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00023-mcp-01",
+          "packages": [
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00023-01-00",
+              "version": "1.1.6"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00023-01-01",
+              "version": "2.1.6"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "anthropic",
+              "version": "3.1.6"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00023-01-03",
+              "version": "1.1.6"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00023-01-04",
+              "version": "2.1.6"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00023-01-05",
+              "version": "3.1.6"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00023-mcp-01-tool-00"
+            },
+            {
+              "name": "agent-00023-mcp-01-tool-01"
+            },
+            {
+              "name": "agent-00023-mcp-01-tool-02"
+            },
+            {
+              "name": "agent-00023-mcp-01-tool-03"
+            },
+            {
+              "name": "agent-00023-mcp-01-tool-04"
+            },
+            {
+              "name": "agent-00023-mcp-01-tool-05"
+            },
+            {
+              "name": "agent-00023-mcp-01-tool-06"
+            },
+            {
+              "name": "agent-00023-mcp-01-tool-07"
+            },
+            {
+              "name": "agent-00023-mcp-01-tool-08"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-23.example.internal/1"
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00023-mcp-02",
+          "packages": [
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00023-02-00",
+              "version": "1.2.6"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00023-02-01",
+              "version": "2.2.6"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00023-02-02",
+              "version": "3.2.6"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "1.2.6"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00023-02-04",
+              "version": "2.2.6"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "zod",
+              "version": "3.2.6"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00023-02-06",
+              "version": "1.2.6"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "next",
+              "version": "2.2.6"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00023-mcp-02-tool-00"
+            },
+            {
+              "name": "agent-00023-mcp-02-tool-01"
+            },
+            {
+              "name": "agent-00023-mcp-02-tool-02"
+            },
+            {
+              "name": "agent-00023-mcp-02-tool-03"
+            },
+            {
+              "name": "agent-00023-mcp-02-tool-04"
+            },
+            {
+              "name": "agent-00023-mcp-02-tool-05"
+            },
+            {
+              "name": "agent-00023-mcp-02-tool-06"
+            },
+            {
+              "name": "agent-00023-mcp-02-tool-07"
+            },
+            {
+              "name": "agent-00023-mcp-02-tool-08"
+            },
+            {
+              "name": "agent-00023-mcp-02-tool-09"
+            },
+            {
+              "name": "agent-00023-mcp-02-tool-10"
+            },
+            {
+              "name": "agent-00023-mcp-02-tool-11"
+            },
+            {
+              "name": "agent-00023-mcp-02-tool-12"
+            },
+            {
+              "name": "agent-00023-mcp-02-tool-13"
+            },
+            {
+              "name": "agent-00023-mcp-02-tool-14"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-23.example.internal/2"
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00023-mcp-03",
+          "packages": [
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "anthropic",
+              "version": "1.3.6"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00023-03-01",
+              "version": "2.3.6"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00023-03-02",
+              "version": "3.3.6"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00023-mcp-03-tool-00"
+            },
+            {
+              "name": "agent-00023-mcp-03-tool-01"
+            },
+            {
+              "name": "agent-00023-mcp-03-tool-02"
+            },
+            {
+              "name": "agent-00023-mcp-03-tool-03"
+            },
+            {
+              "name": "agent-00023-mcp-03-tool-04"
+            },
+            {
+              "name": "agent-00023-mcp-03-tool-05"
+            },
+            {
+              "name": "agent-00023-mcp-03-tool-06"
+            },
+            {
+              "name": "agent-00023-mcp-03-tool-07"
+            },
+            {
+              "name": "agent-00023-mcp-03-tool-08"
+            },
+            {
+              "name": "agent-00023-mcp-03-tool-09"
+            },
+            {
+              "name": "agent-00023-mcp-03-tool-10"
+            },
+            {
+              "name": "agent-00023-mcp-03-tool-11"
+            },
+            {
+              "name": "agent-00023-mcp-03-tool-12"
+            },
+            {
+              "name": "agent-00023-mcp-03-tool-13"
+            },
+            {
+              "name": "agent-00023-mcp-03-tool-14"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00023-mcp-04",
+          "packages": [
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "mcp-sdk",
+              "version": "1.4.6"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00023-04-01",
+              "version": "2.4.6"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00023-04-02",
+              "version": "3.4.6"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00023-04-03",
+              "version": "1.4.6"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00023-mcp-04-tool-00"
+            },
+            {
+              "name": "agent-00023-mcp-04-tool-01"
+            },
+            {
+              "name": "agent-00023-mcp-04-tool-02"
+            },
+            {
+              "name": "agent-00023-mcp-04-tool-03"
+            },
+            {
+              "name": "agent-00023-mcp-04-tool-04"
+            },
+            {
+              "name": "agent-00023-mcp-04-tool-05"
+            },
+            {
+              "name": "agent-00023-mcp-04-tool-06"
+            },
+            {
+              "name": "agent-00023-mcp-04-tool-07"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-23.example.internal/4"
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00023-mcp-05",
+          "packages": [
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "svc-00023-05-00",
+              "version": "1.5.6"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00023-05-01",
+              "version": "2.5.6"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00023-05-02",
+              "version": "3.5.6"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "team-shared-0-3",
+              "version": "1.5.6"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00023-05-04",
+              "version": "2.5.6"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00023-05-05",
+              "version": "3.5.6"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "team-shared-0-6",
+              "version": "1.5.6"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "2.5.6"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00023-mcp-05-tool-00"
+            },
+            {
+              "name": "agent-00023-mcp-05-tool-01"
+            },
+            {
+              "name": "agent-00023-mcp-05-tool-02"
+            },
+            {
+              "name": "agent-00023-mcp-05-tool-03"
+            },
+            {
+              "name": "agent-00023-mcp-05-tool-04"
+            },
+            {
+              "name": "agent-00023-mcp-05-tool-05"
+            },
+            {
+              "name": "agent-00023-mcp-05-tool-06"
+            },
+            {
+              "name": "agent-00023-mcp-05-tool-07"
+            },
+            {
+              "name": "agent-00023-mcp-05-tool-08"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-23.example.internal/5"
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00023-mcp-06",
+          "packages": [
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00023-06-00",
+              "version": "1.6.6"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "zod",
+              "version": "2.6.6"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "svc-00023-06-02",
+              "version": "3.6.6"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00023-mcp-06-tool-00"
+            },
+            {
+              "name": "agent-00023-mcp-06-tool-01"
+            },
+            {
+              "name": "agent-00023-mcp-06-tool-02"
+            },
+            {
+              "name": "agent-00023-mcp-06-tool-03"
+            },
+            {
+              "name": "agent-00023-mcp-06-tool-04"
+            },
+            {
+              "name": "agent-00023-mcp-06-tool-05"
+            },
+            {
+              "name": "agent-00023-mcp-06-tool-06"
+            },
+            {
+              "name": "agent-00023-mcp-06-tool-07"
+            },
+            {
+              "name": "agent-00023-mcp-06-tool-08"
+            },
+            {
+              "name": "agent-00023-mcp-06-tool-09"
+            },
+            {
+              "name": "agent-00023-mcp-06-tool-10"
+            },
+            {
+              "name": "agent-00023-mcp-06-tool-11"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00023-mcp-07",
+          "packages": [
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "zod",
+              "version": "1.7.6"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00023-07-01",
+              "version": "2.7.6"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "next",
+              "version": "3.7.6"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00023-mcp-07-tool-00"
+            },
+            {
+              "name": "agent-00023-mcp-07-tool-01"
+            },
+            {
+              "name": "agent-00023-mcp-07-tool-02"
+            },
+            {
+              "name": "agent-00023-mcp-07-tool-03"
+            },
+            {
+              "name": "agent-00023-mcp-07-tool-04"
+            },
+            {
+              "name": "agent-00023-mcp-07-tool-05"
+            },
+            {
+              "name": "agent-00023-mcp-07-tool-06"
+            },
+            {
+              "name": "agent-00023-mcp-07-tool-07"
+            },
+            {
+              "name": "agent-00023-mcp-07-tool-08"
+            },
+            {
+              "name": "agent-00023-mcp-07-tool-09"
+            },
+            {
+              "name": "agent-00023-mcp-07-tool-10"
+            },
+            {
+              "name": "agent-00023-mcp-07-tool-11"
+            },
+            {
+              "name": "agent-00023-mcp-07-tool-12"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-23.example.internal/7"
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00023-mcp-08",
+          "packages": [
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00023-08-00",
+              "version": "1.8.6"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "next",
+              "version": "2.8.6"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "protobuf",
+              "version": "3.8.6"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00023-08-03",
+              "version": "1.8.6"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "2.8.6"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00023-mcp-08-tool-00"
+            },
+            {
+              "name": "agent-00023-mcp-08-tool-01"
+            },
+            {
+              "name": "agent-00023-mcp-08-tool-02"
+            },
+            {
+              "name": "agent-00023-mcp-08-tool-03"
+            },
+            {
+              "name": "agent-00023-mcp-08-tool-04"
+            },
+            {
+              "name": "agent-00023-mcp-08-tool-05"
+            },
+            {
+              "name": "agent-00023-mcp-08-tool-06"
+            },
+            {
+              "name": "agent-00023-mcp-08-tool-07"
+            },
+            {
+              "name": "agent-00023-mcp-08-tool-08"
+            },
+            {
+              "name": "agent-00023-mcp-08-tool-09"
+            },
+            {
+              "name": "agent-00023-mcp-08-tool-10"
+            },
+            {
+              "name": "agent-00023-mcp-08-tool-11"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-23.example.internal/8"
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00023-mcp-09",
+          "packages": [
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00023-09-00",
+              "version": "1.9.6"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "protobuf",
+              "version": "2.9.6"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00023-09-02",
+              "version": "3.9.6"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00023-09-03",
+              "version": "1.9.6"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "langchain",
+              "version": "2.9.6"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00023-09-05",
+              "version": "3.9.6"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "svc-00023-09-06",
+              "version": "1.9.6"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "team-shared-0-7",
+              "version": "2.9.6"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00023-mcp-09-tool-00"
+            },
+            {
+              "name": "agent-00023-mcp-09-tool-01"
+            },
+            {
+              "name": "agent-00023-mcp-09-tool-02"
+            },
+            {
+              "name": "agent-00023-mcp-09-tool-03"
+            },
+            {
+              "name": "agent-00023-mcp-09-tool-04"
+            },
+            {
+              "name": "agent-00023-mcp-09-tool-05"
+            },
+            {
+              "name": "agent-00023-mcp-09-tool-06"
+            },
+            {
+              "name": "agent-00023-mcp-09-tool-07"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00023-mcp-10",
+          "packages": [
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "protobuf",
+              "version": "1.0.6"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00023-10-01",
+              "version": "2.0.6"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "boto3",
+              "version": "3.0.6"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "team-shared-0-3",
+              "version": "1.0.6"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "openai",
+              "version": "2.0.6"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "3.0.6"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00023-10-06",
+              "version": "1.0.6"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00023-10-07",
+              "version": "2.0.6"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "team-shared-0-8",
+              "version": "3.0.6"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00023-10-09",
+              "version": "1.0.6"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "team-shared-0-1",
+              "version": "2.0.6"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00023-10-11",
+              "version": "3.0.6"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "protobuf",
+              "version": "1.0.6"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00023-mcp-10-tool-00"
+            },
+            {
+              "name": "agent-00023-mcp-10-tool-01"
+            },
+            {
+              "name": "agent-00023-mcp-10-tool-02"
+            },
+            {
+              "name": "agent-00023-mcp-10-tool-03"
+            },
+            {
+              "name": "agent-00023-mcp-10-tool-04"
+            },
+            {
+              "name": "agent-00023-mcp-10-tool-05"
+            },
+            {
+              "name": "agent-00023-mcp-10-tool-06"
+            },
+            {
+              "name": "agent-00023-mcp-10-tool-07"
+            },
+            {
+              "name": "agent-00023-mcp-10-tool-08"
+            },
+            {
+              "name": "agent-00023-mcp-10-tool-09"
+            },
+            {
+              "name": "agent-00023-mcp-10-tool-10"
+            },
+            {
+              "name": "agent-00023-mcp-10-tool-11"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-23.example.internal/10"
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00023-mcp-11",
+          "packages": [
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00023-11-00",
+              "version": "1.1.6"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00023-11-01",
+              "version": "2.1.6"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "langchain",
+              "version": "3.1.6"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00023-mcp-11-tool-00"
+            },
+            {
+              "name": "agent-00023-mcp-11-tool-01"
+            },
+            {
+              "name": "agent-00023-mcp-11-tool-02"
+            },
+            {
+              "name": "agent-00023-mcp-11-tool-03"
+            },
+            {
+              "name": "agent-00023-mcp-11-tool-04"
+            },
+            {
+              "name": "agent-00023-mcp-11-tool-05"
+            },
+            {
+              "name": "agent-00023-mcp-11-tool-06"
+            },
+            {
+              "name": "agent-00023-mcp-11-tool-07"
+            },
+            {
+              "name": "agent-00023-mcp-11-tool-08"
+            },
+            {
+              "name": "agent-00023-mcp-11-tool-09"
+            },
+            {
+              "name": "agent-00023-mcp-11-tool-10"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-23.example.internal/11"
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00023-mcp-12",
+          "packages": [
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "boto3",
+              "version": "1.2.6"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "langchain",
+              "version": "2.2.6"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00023-12-02",
+              "version": "3.2.6"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "1.2.6"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00023-mcp-12-tool-00"
+            },
+            {
+              "name": "agent-00023-mcp-12-tool-01"
+            },
+            {
+              "name": "agent-00023-mcp-12-tool-02"
+            },
+            {
+              "name": "agent-00023-mcp-12-tool-03"
+            },
+            {
+              "name": "agent-00023-mcp-12-tool-04"
+            },
+            {
+              "name": "agent-00023-mcp-12-tool-05"
+            },
+            {
+              "name": "agent-00023-mcp-12-tool-06"
+            },
+            {
+              "name": "agent-00023-mcp-12-tool-07"
+            },
+            {
+              "name": "agent-00023-mcp-12-tool-08"
+            },
+            {
+              "name": "agent-00023-mcp-12-tool-09"
+            },
+            {
+              "name": "agent-00023-mcp-12-tool-10"
+            },
+            {
+              "name": "agent-00023-mcp-12-tool-11"
+            },
+            {
+              "name": "agent-00023-mcp-12-tool-12"
+            },
+            {
+              "name": "agent-00023-mcp-12-tool-13"
+            },
+            {
+              "name": "agent-00023-mcp-12-tool-14"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "operator-push"
+          ],
+          "name": "agent-00023-mcp-13",
+          "packages": [
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00023-13-00",
+              "version": "1.3.6"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "openai",
+              "version": "2.3.6"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "anthropic",
+              "version": "3.3.6"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "mcp-sdk",
+              "version": "1.3.6"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00023-mcp-13-tool-00"
+            },
+            {
+              "name": "agent-00023-mcp-13-tool-01"
+            },
+            {
+              "name": "agent-00023-mcp-13-tool-02"
+            },
+            {
+              "name": "agent-00023-mcp-13-tool-03"
+            },
+            {
+              "name": "agent-00023-mcp-13-tool-04"
+            },
+            {
+              "name": "agent-00023-mcp-13-tool-05"
+            },
+            {
+              "name": "agent-00023-mcp-13-tool-06"
+            },
+            {
+              "name": "agent-00023-mcp-13-tool-07"
+            },
+            {
+              "name": "agent-00023-mcp-13-tool-08"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-23.example.internal/13"
+        }
+      ],
+      "name": "agent-00023",
+      "source": "operator-push",
+      "status": "configured",
+      "type": "vscode"
+    },
+    {
+      "discovery_sources": [
+        "cloud-inventory"
+      ],
+      "mcp_servers": [
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "cloud-inventory"
+          ],
+          "name": "agent-00024-mcp-00",
+          "packages": [
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "langchain",
+              "version": "1.0.7"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00024-00-01",
+              "version": "2.0.7"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "anthropic",
+              "version": "3.0.7"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00024-00-03",
+              "version": "1.0.7"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "2.0.7"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "svc-00024-00-05",
+              "version": "3.0.7"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00024-00-06",
+              "version": "1.0.7"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "team-shared-0-7",
+              "version": "2.0.7"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00024-00-08",
+              "version": "3.0.7"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": true,
+              "name": "protobuf",
+              "version": "1.0.7"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": true,
+              "name": "svc-00024-00-10",
+              "version": "2.0.7"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00024-00-11",
+              "version": "3.0.7"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "langchain",
+              "version": "1.0.7"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00024-00-13",
+              "version": "2.0.7"
+            }
+          ],
+          "registry_verified": false,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00024-mcp-00-tool-00"
+            },
+            {
+              "name": "agent-00024-mcp-00-tool-01"
+            },
+            {
+              "name": "agent-00024-mcp-00-tool-02"
+            },
+            {
+              "name": "agent-00024-mcp-00-tool-03"
+            },
+            {
+              "name": "agent-00024-mcp-00-tool-04"
+            }
+          ],
+          "transport": "stdio",
+          "url": ""
+        },
+        {
+          "credential_env_vars": [],
+          "discovery_sources": [
+            "cloud-inventory"
+          ],
+          "name": "agent-00024-mcp-01",
+          "packages": [
+            {
+              "ecosystem": "npm",
+              "is_direct": true,
+              "name": "svc-00024-01-00",
+              "version": "1.1.7"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": true,
+              "name": "svc-00024-01-01",
+              "version": "2.1.7"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": false,
+              "name": "svc-00024-01-02",
+              "version": "3.1.7"
+            },
+            {
+              "ecosystem": "maven",
+              "is_direct": false,
+              "name": "fastapi",
+              "version": "1.1.7"
+            },
+            {
+              "ecosystem": "oci",
+              "is_direct": false,
+              "name": "team-shared-0-4",
+              "version": "2.1.7"
+            },
+            {
+              "ecosystem": "npm",
+              "is_direct": false,
+              "name": "svc-00024-01-05",
+              "version": "3.1.7"
+            },
+            {
+              "ecosystem": "pypi",
+              "is_direct": false,
+              "name": "react",
+              "version": "1.1.7"
+            },
+            {
+              "ecosystem": "go",
+              "is_direct": true,
+              "name": "svc-00024-01-07",
+              "version": "2.1.7"
+            }
+          ],
+          "registry_verified": true,
+          "surface": "mcp-server",
+          "tools": [
+            {
+              "name": "agent-00024-mcp-01-tool-00"
+            },
+            {
+              "name": "agent-00024-mcp-01-tool-01"
+            },
+            {
+              "name": "agent-00024-mcp-01-tool-02"
+            },
+            {
+              "name": "agent-00024-mcp-01-tool-03"
+            }
+          ],
+          "transport": "sse",
+          "url": "https://mcp-24.example.internal/1"
+        }
+      ],
+      "name": "agent-00024",
+      "source": "cloud-inventory",
+      "status": "configured",
+      "type": "cortex-code"
+    }
+  ],
+  "blast_radius": [
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-00"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-00-tool-00",
+        "agent-00000-mcp-00-tool-01",
+        "agent-00000-mcp-00-tool-02",
+        "agent-00000-mcp-00-tool-03"
+      ],
+      "fixed_version": "1.0.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-00-00",
+      "package_name": "svc-00000-00-00",
+      "package_version": "1.0.0",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000001"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-00"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-00-tool-00",
+        "agent-00000-mcp-00-tool-01",
+        "agent-00000-mcp-00-tool-02",
+        "agent-00000-mcp-00-tool-03"
+      ],
+      "fixed_version": "3.0.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "boto3",
+      "package_name": "boto3",
+      "package_version": "3.0.0",
+      "severity": "low",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000002"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-00"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-00-tool-00",
+        "agent-00000-mcp-00-tool-01",
+        "agent-00000-mcp-00-tool-02",
+        "agent-00000-mcp-00-tool-03"
+      ],
+      "fixed_version": "2.0.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "grpc",
+      "package_name": "grpc",
+      "package_version": "2.0.0",
+      "severity": "medium",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000003"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-01"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-01-tool-00",
+        "agent-00000-mcp-01-tool-01",
+        "agent-00000-mcp-01-tool-02",
+        "agent-00000-mcp-01-tool-03"
+      ],
+      "fixed_version": "2.1.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-01-01",
+      "package_name": "svc-00000-01-01",
+      "package_version": "2.1.0",
+      "severity": "high",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000004"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-01"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-01-tool-00",
+        "agent-00000-mcp-01-tool-01",
+        "agent-00000-mcp-01-tool-02",
+        "agent-00000-mcp-01-tool-03"
+      ],
+      "fixed_version": "2.1.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-01-10",
+      "package_name": "svc-00000-01-10",
+      "package_version": "2.1.0",
+      "severity": "medium",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000005"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-01"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-01-tool-00",
+        "agent-00000-mcp-01-tool-01",
+        "agent-00000-mcp-01-tool-02",
+        "agent-00000-mcp-01-tool-03"
+      ],
+      "fixed_version": "1.1.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "openai",
+      "package_name": "openai",
+      "package_version": "1.1.0",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000006"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-01"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-01-tool-00",
+        "agent-00000-mcp-01-tool-01",
+        "agent-00000-mcp-01-tool-02",
+        "agent-00000-mcp-01-tool-03"
+      ],
+      "fixed_version": "2.1.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-01-13",
+      "package_name": "svc-00000-01-13",
+      "package_version": "2.1.0",
+      "severity": "high",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000007"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-01"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-01-tool-00",
+        "agent-00000-mcp-01-tool-01",
+        "agent-00000-mcp-01-tool-02",
+        "agent-00000-mcp-01-tool-03"
+      ],
+      "fixed_version": "2.1.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-01-16",
+      "package_name": "svc-00000-01-16",
+      "package_version": "2.1.0",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000008"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-02"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-02-tool-00",
+        "agent-00000-mcp-02-tool-01",
+        "agent-00000-mcp-02-tool-02",
+        "agent-00000-mcp-02-tool-03"
+      ],
+      "fixed_version": "1.2.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-02-03",
+      "package_name": "svc-00000-02-03",
+      "package_version": "1.2.0",
+      "severity": "low",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000009"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-02"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-02-tool-00",
+        "agent-00000-mcp-02-tool-01",
+        "agent-00000-mcp-02-tool-02",
+        "agent-00000-mcp-02-tool-03"
+      ],
+      "fixed_version": "2.2.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-02-13",
+      "package_name": "svc-00000-02-13",
+      "package_version": "2.2.0",
+      "severity": "high",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000010"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-03"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-03-tool-00",
+        "agent-00000-mcp-03-tool-01",
+        "agent-00000-mcp-03-tool-02",
+        "agent-00000-mcp-03-tool-03"
+      ],
+      "fixed_version": "3.3.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-03-05",
+      "package_name": "svc-00000-03-05",
+      "package_version": "3.3.0",
+      "severity": "high",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000011"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-04"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-04-tool-00",
+        "agent-00000-mcp-04-tool-01",
+        "agent-00000-mcp-04-tool-02",
+        "agent-00000-mcp-04-tool-03"
+      ],
+      "fixed_version": "1.4.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-04-00",
+      "package_name": "svc-00000-04-00",
+      "package_version": "1.4.0",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000012"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-05"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-05-tool-00",
+        "agent-00000-mcp-05-tool-01",
+        "agent-00000-mcp-05-tool-02",
+        "agent-00000-mcp-05-tool-03"
+      ],
+      "fixed_version": "2.5.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-05-16",
+      "package_name": "svc-00000-05-16",
+      "package_version": "2.5.0",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000013"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-06"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-06-tool-00",
+        "agent-00000-mcp-06-tool-01",
+        "agent-00000-mcp-06-tool-02",
+        "agent-00000-mcp-06-tool-03"
+      ],
+      "fixed_version": "1.6.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "zod",
+      "package_name": "zod",
+      "package_version": "1.6.0",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000014"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-07"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-07-tool-00",
+        "agent-00000-mcp-07-tool-01",
+        "agent-00000-mcp-07-tool-02",
+        "agent-00000-mcp-07-tool-03"
+      ],
+      "fixed_version": "1.7.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "react",
+      "package_name": "react",
+      "package_version": "1.7.0",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000015"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-08"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-08-tool-00",
+        "agent-00000-mcp-08-tool-01",
+        "agent-00000-mcp-08-tool-02",
+        "agent-00000-mcp-08-tool-03"
+      ],
+      "fixed_version": "2.8.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "protobuf",
+      "package_name": "protobuf",
+      "package_version": "2.8.0",
+      "severity": "high",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000016"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-09"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-09-tool-00",
+        "agent-00000-mcp-09-tool-01",
+        "agent-00000-mcp-09-tool-02",
+        "agent-00000-mcp-09-tool-03"
+      ],
+      "fixed_version": "2.9.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-09-01",
+      "package_name": "svc-00000-09-01",
+      "package_version": "2.9.0",
+      "severity": "high",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000017"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-09"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-09-tool-00",
+        "agent-00000-mcp-09-tool-01",
+        "agent-00000-mcp-09-tool-02",
+        "agent-00000-mcp-09-tool-03"
+      ],
+      "fixed_version": "2.9.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-09-07",
+      "package_name": "svc-00000-09-07",
+      "package_version": "2.9.0",
+      "severity": "low",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000018"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-10"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-10-tool-00",
+        "agent-00000-mcp-10-tool-01",
+        "agent-00000-mcp-10-tool-02",
+        "agent-00000-mcp-10-tool-03"
+      ],
+      "fixed_version": "2.0.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-10-01",
+      "package_name": "svc-00000-10-01",
+      "package_version": "2.0.0",
+      "severity": "high",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000019"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-10"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-10-tool-00",
+        "agent-00000-mcp-10-tool-01",
+        "agent-00000-mcp-10-tool-02",
+        "agent-00000-mcp-10-tool-03"
+      ],
+      "fixed_version": "2.0.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-10-04",
+      "package_name": "svc-00000-10-04",
+      "package_version": "2.0.0",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000020"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-10"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-10-tool-00",
+        "agent-00000-mcp-10-tool-01",
+        "agent-00000-mcp-10-tool-02",
+        "agent-00000-mcp-10-tool-03"
+      ],
+      "fixed_version": "1.0.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "fastapi",
+      "package_name": "fastapi",
+      "package_version": "1.0.0",
+      "severity": "medium",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000021"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-11"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-11-tool-00",
+        "agent-00000-mcp-11-tool-01",
+        "agent-00000-mcp-11-tool-02",
+        "agent-00000-mcp-11-tool-03"
+      ],
+      "fixed_version": "1.1.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "requests",
+      "package_name": "requests",
+      "package_version": "1.1.0",
+      "severity": "medium",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000022"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-13"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-13-tool-00",
+        "agent-00000-mcp-13-tool-01",
+        "agent-00000-mcp-13-tool-02",
+        "agent-00000-mcp-13-tool-03"
+      ],
+      "fixed_version": "2.3.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-13-10",
+      "package_name": "svc-00000-13-10",
+      "package_version": "2.3.0",
+      "severity": "medium",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000023"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-15"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-15-tool-00",
+        "agent-00000-mcp-15-tool-01",
+        "agent-00000-mcp-15-tool-02",
+        "agent-00000-mcp-15-tool-03"
+      ],
+      "fixed_version": "2.5.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-15-22",
+      "package_name": "svc-00000-15-22",
+      "package_version": "2.5.0",
+      "severity": "medium",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000024"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-17"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-17-tool-00",
+        "agent-00000-mcp-17-tool-01",
+        "agent-00000-mcp-17-tool-02",
+        "agent-00000-mcp-17-tool-03"
+      ],
+      "fixed_version": "1.7.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "next",
+      "package_name": "next",
+      "package_version": "1.7.0",
+      "severity": "low",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000025"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-18"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-18-tool-00",
+        "agent-00000-mcp-18-tool-01",
+        "agent-00000-mcp-18-tool-02",
+        "agent-00000-mcp-18-tool-03"
+      ],
+      "fixed_version": "1.8.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "mcp-sdk",
+      "package_name": "mcp-sdk",
+      "package_version": "1.8.0",
+      "severity": "high",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000026"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-18"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-18-tool-00",
+        "agent-00000-mcp-18-tool-01",
+        "agent-00000-mcp-18-tool-02",
+        "agent-00000-mcp-18-tool-03"
+      ],
+      "fixed_version": "2.8.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-18-13",
+      "package_name": "svc-00000-18-13",
+      "package_version": "2.8.0",
+      "severity": "high",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000027"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-20"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-20-tool-00",
+        "agent-00000-mcp-20-tool-01",
+        "agent-00000-mcp-20-tool-02",
+        "agent-00000-mcp-20-tool-03"
+      ],
+      "fixed_version": "3.0.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-20-05",
+      "package_name": "svc-00000-20-05",
+      "package_version": "3.0.0",
+      "severity": "high",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000028"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-21"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-21-tool-00",
+        "agent-00000-mcp-21-tool-01",
+        "agent-00000-mcp-21-tool-02",
+        "agent-00000-mcp-21-tool-03"
+      ],
+      "fixed_version": "1.1.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "langchain",
+      "package_name": "langchain",
+      "package_version": "1.1.0",
+      "severity": "low",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000029"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-21"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-21-tool-00",
+        "agent-00000-mcp-21-tool-01",
+        "agent-00000-mcp-21-tool-02",
+        "agent-00000-mcp-21-tool-03"
+      ],
+      "fixed_version": "2.1.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-21-07",
+      "package_name": "svc-00000-21-07",
+      "package_version": "2.1.0",
+      "severity": "low",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000030"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-21"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-21-tool-00",
+        "agent-00000-mcp-21-tool-01",
+        "agent-00000-mcp-21-tool-02",
+        "agent-00000-mcp-21-tool-03"
+      ],
+      "fixed_version": "2.1.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-21-13",
+      "package_name": "svc-00000-21-13",
+      "package_version": "2.1.0",
+      "severity": "high",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000031"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-21"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-21-tool-00",
+        "agent-00000-mcp-21-tool-01",
+        "agent-00000-mcp-21-tool-02",
+        "agent-00000-mcp-21-tool-03"
+      ],
+      "fixed_version": "2.1.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-21-25",
+      "package_name": "svc-00000-21-25",
+      "package_version": "2.1.0",
+      "severity": "high",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000032"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-22"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-22-tool-00",
+        "agent-00000-mcp-22-tool-01",
+        "agent-00000-mcp-22-tool-02",
+        "agent-00000-mcp-22-tool-03"
+      ],
+      "fixed_version": "1.2.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-22-12",
+      "package_name": "svc-00000-22-12",
+      "package_version": "1.2.0",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000033"
+    },
+    {
+      "affected_agents": [
+        "agent-00000"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00000-mcp-23"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00000_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00000-mcp-23-tool-00",
+        "agent-00000-mcp-23-tool-01",
+        "agent-00000-mcp-23-tool-02",
+        "agent-00000-mcp-23-tool-03"
+      ],
+      "fixed_version": "2.3.0.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00000-23-10",
+      "package_name": "svc-00000-23-10",
+      "package_version": "2.3.0",
+      "severity": "medium",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000034"
+    },
+    {
+      "affected_agents": [
+        "agent-00002"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00002-mcp-00"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00002-mcp-00-tool-00",
+        "agent-00002-mcp-00-tool-01",
+        "agent-00002-mcp-00-tool-02"
+      ],
+      "fixed_version": "2.0.2.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00002-00-04",
+      "package_name": "svc-00002-00-04",
+      "package_version": "2.0.2",
+      "severity": "medium",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000035"
+    },
+    {
+      "affected_agents": [
+        "agent-00003"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00003-mcp-01"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00003-mcp-01-tool-00",
+        "agent-00003-mcp-01-tool-01",
+        "agent-00003-mcp-01-tool-02",
+        "agent-00003-mcp-01-tool-03"
+      ],
+      "fixed_version": "2.1.3.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00003-01-07",
+      "package_name": "svc-00003-01-07",
+      "package_version": "2.1.3",
+      "severity": "medium",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000036"
+    },
+    {
+      "affected_agents": [
+        "agent-00005"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00005-mcp-00"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00005-mcp-00-tool-00",
+        "agent-00005-mcp-00-tool-01"
+      ],
+      "fixed_version": "1.0.5.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00005-00-09",
+      "package_name": "svc-00005-00-09",
+      "package_version": "1.0.5",
+      "severity": "medium",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000037"
+    },
+    {
+      "affected_agents": [
+        "agent-00006"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00006-mcp-00"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00006-mcp-00-tool-00"
+      ],
+      "fixed_version": "3.0.6.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00006-00-08",
+      "package_name": "svc-00006-00-08",
+      "package_version": "3.0.6",
+      "severity": "medium",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000038"
+    },
+    {
+      "affected_agents": [
+        "agent-00007"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00007-mcp-00"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00007-mcp-00-tool-00"
+      ],
+      "fixed_version": "3.0.7.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00007-00-05",
+      "package_name": "svc-00007-00-05",
+      "package_version": "3.0.7",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000039"
+    },
+    {
+      "affected_agents": [
+        "agent-00007"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00007-mcp-02"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00007-mcp-02-tool-00",
+        "agent-00007-mcp-02-tool-01"
+      ],
+      "fixed_version": "3.2.7.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00007-02-05",
+      "package_name": "svc-00007-02-05",
+      "package_version": "3.2.7",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000040"
+    },
+    {
+      "affected_agents": [
+        "agent-00007"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00007-mcp-03"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00007-mcp-03-tool-00",
+        "agent-00007-mcp-03-tool-01",
+        "agent-00007-mcp-03-tool-02",
+        "agent-00007-mcp-03-tool-03"
+      ],
+      "fixed_version": "1.3.7.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00007-03-00",
+      "package_name": "svc-00007-03-00",
+      "package_version": "1.3.7",
+      "severity": "low",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000041"
+    },
+    {
+      "affected_agents": [
+        "agent-00009"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00009-mcp-01"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00009_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00009-mcp-01-tool-00",
+        "agent-00009-mcp-01-tool-01",
+        "agent-00009-mcp-01-tool-02",
+        "agent-00009-mcp-01-tool-03"
+      ],
+      "fixed_version": "3.1.9.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00009-01-05",
+      "package_name": "svc-00009-01-05",
+      "package_version": "3.1.9",
+      "severity": "medium",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000042"
+    },
+    {
+      "affected_agents": [
+        "agent-00011"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00011-mcp-00"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00011-mcp-00-tool-00",
+        "agent-00011-mcp-00-tool-01"
+      ],
+      "fixed_version": "2.0.11.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00011-00-01",
+      "package_name": "svc-00011-00-01",
+      "package_version": "2.0.11",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000043"
+    },
+    {
+      "affected_agents": [
+        "agent-00011"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00011-mcp-00"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00011-mcp-00-tool-00",
+        "agent-00011-mcp-00-tool-01"
+      ],
+      "fixed_version": "1.0.11.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00011-00-09",
+      "package_name": "svc-00011-00-09",
+      "package_version": "1.0.11",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000044"
+    },
+    {
+      "affected_agents": [
+        "agent-00014"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00014-mcp-00"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00014-mcp-00-tool-00",
+        "agent-00014-mcp-00-tool-01",
+        "agent-00014-mcp-00-tool-02"
+      ],
+      "fixed_version": "2.0.14.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "team-shared-0-7",
+      "package_name": "team-shared-0-7",
+      "package_version": "2.0.14",
+      "severity": "high",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000045"
+    },
+    {
+      "affected_agents": [
+        "agent-00014"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00014-mcp-01"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00014-mcp-01-tool-00",
+        "agent-00014-mcp-01-tool-01",
+        "agent-00014-mcp-01-tool-02",
+        "agent-00014-mcp-01-tool-03"
+      ],
+      "fixed_version": "1.1.14.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00014-01-03",
+      "package_name": "svc-00014-01-03",
+      "package_version": "1.1.14",
+      "severity": "high",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000046"
+    },
+    {
+      "affected_agents": [
+        "agent-00014"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00014-mcp-02"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00014-mcp-02-tool-00"
+      ],
+      "fixed_version": "3.2.14.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00014-02-02",
+      "package_name": "svc-00014-02-02",
+      "package_version": "3.2.14",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000047"
+    },
+    {
+      "affected_agents": [
+        "agent-00014"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00014-mcp-03"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00014-mcp-03-tool-00"
+      ],
+      "fixed_version": "2.3.14.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00014-03-01",
+      "package_name": "svc-00014-03-01",
+      "package_version": "2.3.14",
+      "severity": "low",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000048"
+    },
+    {
+      "affected_agents": [
+        "agent-00014"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00014-mcp-05"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00014-mcp-05-tool-00",
+        "agent-00014-mcp-05-tool-01",
+        "agent-00014-mcp-05-tool-02",
+        "agent-00014-mcp-05-tool-03"
+      ],
+      "fixed_version": "3.5.14.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00014-05-02",
+      "package_name": "svc-00014-05-02",
+      "package_version": "3.5.14",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000049"
+    },
+    {
+      "affected_agents": [
+        "agent-00015"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00015-mcp-00"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00015-mcp-00-tool-00"
+      ],
+      "fixed_version": "3.0.15.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00015-00-05",
+      "package_name": "svc-00015-00-05",
+      "package_version": "3.0.15",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000050"
+    },
+    {
+      "affected_agents": [
+        "agent-00015"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00015-mcp-01"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00015-mcp-01-tool-00",
+        "agent-00015-mcp-01-tool-01"
+      ],
+      "fixed_version": "1.1.15.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00015-01-03",
+      "package_name": "svc-00015-01-03",
+      "package_version": "1.1.15",
+      "severity": "medium",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000051"
+    },
+    {
+      "affected_agents": [
+        "agent-00018"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00018-mcp-00"
+        }
+      ],
+      "exposed_credentials": [
+        "AGENT_00018_TOKEN"
+      ],
+      "exposed_tools": [
+        "agent-00018-mcp-00-tool-00",
+        "agent-00018-mcp-00-tool-01",
+        "agent-00018-mcp-00-tool-02",
+        "agent-00018-mcp-00-tool-03"
+      ],
+      "fixed_version": "1.0.1.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00018-00-06",
+      "package_name": "svc-00018-00-06",
+      "package_version": "1.0.1",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000052"
+    },
+    {
+      "affected_agents": [
+        "agent-00019"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00019-mcp-00"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00019-mcp-00-tool-00",
+        "agent-00019-mcp-00-tool-01",
+        "agent-00019-mcp-00-tool-02",
+        "agent-00019-mcp-00-tool-03"
+      ],
+      "fixed_version": "2.0.2.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00019-00-01",
+      "package_name": "svc-00019-00-01",
+      "package_version": "2.0.2",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000053"
+    },
+    {
+      "affected_agents": [
+        "agent-00020"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00020-mcp-00"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00020-mcp-00-tool-00",
+        "agent-00020-mcp-00-tool-01",
+        "agent-00020-mcp-00-tool-02"
+      ],
+      "fixed_version": "1.0.3.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "team-shared-0-6",
+      "package_name": "team-shared-0-6",
+      "package_version": "1.0.3",
+      "severity": "medium",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000054"
+    },
+    {
+      "affected_agents": [
+        "agent-00023"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00023-mcp-00"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00023-mcp-00-tool-00",
+        "agent-00023-mcp-00-tool-01",
+        "agent-00023-mcp-00-tool-02",
+        "agent-00023-mcp-00-tool-03"
+      ],
+      "fixed_version": "2.0.6.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "team-shared-0-4",
+      "package_name": "team-shared-0-4",
+      "package_version": "2.0.6",
+      "severity": "low",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000055"
+    },
+    {
+      "affected_agents": [
+        "agent-00023"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00023-mcp-01"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00023-mcp-01-tool-00",
+        "agent-00023-mcp-01-tool-01",
+        "agent-00023-mcp-01-tool-02",
+        "agent-00023-mcp-01-tool-03"
+      ],
+      "fixed_version": "3.1.6.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00023-01-05",
+      "package_name": "svc-00023-01-05",
+      "package_version": "3.1.6",
+      "severity": "critical",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000056"
+    },
+    {
+      "affected_agents": [
+        "agent-00023"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00023-mcp-03"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00023-mcp-03-tool-00",
+        "agent-00023-mcp-03-tool-01",
+        "agent-00023-mcp-03-tool-02",
+        "agent-00023-mcp-03-tool-03"
+      ],
+      "fixed_version": "3.3.6.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00023-03-02",
+      "package_name": "svc-00023-03-02",
+      "package_version": "3.3.6",
+      "severity": "high",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000057"
+    },
+    {
+      "affected_agents": [
+        "agent-00023"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00023-mcp-10"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00023-mcp-10-tool-00",
+        "agent-00023-mcp-10-tool-01",
+        "agent-00023-mcp-10-tool-02",
+        "agent-00023-mcp-10-tool-03"
+      ],
+      "fixed_version": "3.0.6.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "team-shared-0-8",
+      "package_name": "team-shared-0-8",
+      "package_version": "3.0.6",
+      "severity": "low",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000058"
+    },
+    {
+      "affected_agents": [
+        "agent-00024"
+      ],
+      "affected_servers": [
+        {
+          "name": "agent-00024-mcp-01"
+        }
+      ],
+      "exposed_credentials": [],
+      "exposed_tools": [
+        "agent-00024-mcp-01-tool-00",
+        "agent-00024-mcp-01-tool-01",
+        "agent-00024-mcp-01-tool-02",
+        "agent-00024-mcp-01-tool-03"
+      ],
+      "fixed_version": "2.1.7.1",
+      "owasp_tags": [
+        "LLM05",
+        "LLM06"
+      ],
+      "package": "svc-00024-01-01",
+      "package_name": "svc-00024-01-01",
+      "package_version": "2.1.7",
+      "severity": "high",
+      "soc2_tags": [
+        "CC6.1"
+      ],
+      "vulnerability_id": "CVE-2026-000059"
+    }
+  ],
+  "generated_at": "2026-05-13T00:00:00Z",
+  "scan_id": "graph-benchmark-estate-25-2145",
+  "scan_sources": [
+    "cloud-inventory",
+    "github-action",
+    "k8s-fleet",
+    "local",
+    "operator-push"
+  ],
+  "tool_version": "benchmark-scaffold"
+}

--- a/docs/perf/results/graph-benchmark-estate-sample.json
+++ b/docs/perf/results/graph-benchmark-estate-sample.json
@@ -1,0 +1,46 @@
+{
+  "agents": 25,
+  "counts": {
+    "blast_radius_rows": 59,
+    "package_instances": 996,
+    "servers": 79,
+    "tools": 667,
+    "unique_packages": 523
+  },
+  "evidence_status": "synthetic_estate_shape_only",
+  "generated_at": "2026-05-13T05:58:46.907069+00:00",
+  "schema_version": 1,
+  "seed": 2145,
+  "skew": {
+    "packages_per_server": {
+      "max": 28,
+      "median": 10,
+      "min": 3,
+      "p95": 27,
+      "p99": 28
+    },
+    "servers_per_agent": {
+      "max": 24,
+      "median": 1,
+      "min": 1,
+      "p95": 14,
+      "p99": 24
+    },
+    "tools_per_server": {
+      "max": 43,
+      "median": 5,
+      "min": 1,
+      "p95": 18,
+      "p99": 35
+    }
+  },
+  "source_mix_agent_mentions": {
+    "cloud-inventory": 8,
+    "github-action": 5,
+    "k8s-fleet": 5,
+    "local": 5,
+    "operator-push": 10
+  },
+  "vulnerable_package_rate_observed": 0.1128,
+  "vulnerable_package_rate_target": 0.08
+}

--- a/docs/perf/results/postgres-graph-explain-sample.json
+++ b/docs/perf/results/postgres-graph-explain-sample.json
@@ -1,0 +1,25 @@
+{
+  "commands": {
+    "dry_run": "uv run python scripts/run_graph_postgres_explain.py --dry-run",
+    "live": "AGENT_BOM_POSTGRES_DSN=postgresql://... uv run python scripts/run_graph_postgres_explain.py --run --scan-id <new> --old-scan-id <old>"
+  },
+  "edge_targets": "10000,50000,100000",
+  "evidence_status": "explain_sql_scaffold_not_measured",
+  "gaps": [
+    "Dry-run writes EXPLAIN SQL only; it does not seed Postgres or execute EXPLAIN ANALYZE.",
+    "Measured artifacts must be captured from a database loaded with the matching synthetic estate snapshots."
+  ],
+  "generated_at": "2026-05-13T05:59:51.330122+00:00",
+  "old_scan_id": "graph-benchmark-estate-old",
+  "owner_issue": 2145,
+  "query_artifacts": {
+    "attack_path_drilldown": "docs/perf/results/postgres-graph-explain-sample/attack_path_drilldown.sql",
+    "bounded_traversal_edges": "docs/perf/results/postgres-graph-explain-sample/bounded_traversal_edges.sql",
+    "graph_diff_nodes": "docs/perf/results/postgres-graph-explain-sample/graph_diff_nodes.sql",
+    "node_detail": "docs/perf/results/postgres-graph-explain-sample/node_detail.sql",
+    "node_search": "docs/perf/results/postgres-graph-explain-sample/node_search.sql"
+  },
+  "scan_id": "graph-benchmark-estate-current",
+  "schema_version": 1,
+  "tenant_id": "default"
+}

--- a/docs/perf/results/postgres-graph-explain-sample/attack_path_drilldown.sql
+++ b/docs/perf/results/postgres-graph-explain-sample/attack_path_drilldown.sql
@@ -1,0 +1,8 @@
+EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+SELECT source_node, target_node, hop_count, composite_risk, path_nodes, path_edges
+FROM attack_paths
+WHERE tenant_id = 'default'
+  AND scan_id = 'graph-benchmark-estate-current'
+  AND source_node = 'agent:agent-00000'
+ORDER BY composite_risk DESC
+LIMIT 100;

--- a/docs/perf/results/postgres-graph-explain-sample/bounded_traversal_edges.sql
+++ b/docs/perf/results/postgres-graph-explain-sample/bounded_traversal_edges.sql
@@ -1,0 +1,16 @@
+EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+WITH RECURSIVE walk(node_id, depth) AS (
+  SELECT 'agent:agent-00000'::text, 0
+  UNION ALL
+  SELECT e.target_id, walk.depth + 1
+  FROM walk
+  JOIN graph_edges e
+    ON e.tenant_id = 'default'
+   AND e.scan_id = 'graph-benchmark-estate-current'
+   AND e.source_id = walk.node_id
+   AND e.traversable = 1
+  WHERE walk.depth < 3
+)
+SELECT DISTINCT node_id, depth
+FROM walk
+LIMIT 500;

--- a/docs/perf/results/postgres-graph-explain-sample/graph_diff_nodes.sql
+++ b/docs/perf/results/postgres-graph-explain-sample/graph_diff_nodes.sql
@@ -1,0 +1,20 @@
+EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+SELECT COALESCE(new_nodes.id, old_nodes.id) AS node_id,
+       CASE
+         WHEN old_nodes.id IS NULL THEN 'added'
+         WHEN new_nodes.id IS NULL THEN 'removed'
+         WHEN old_nodes.attributes <> new_nodes.attributes THEN 'changed'
+         ELSE 'same'
+       END AS diff_state
+FROM (
+  SELECT id, attributes FROM graph_nodes
+  WHERE tenant_id = 'default' AND scan_id = 'graph-benchmark-estate-old'
+) old_nodes
+FULL OUTER JOIN (
+  SELECT id, attributes FROM graph_nodes
+  WHERE tenant_id = 'default' AND scan_id = 'graph-benchmark-estate-current'
+) new_nodes USING (id)
+WHERE old_nodes.id IS NULL
+   OR new_nodes.id IS NULL
+   OR old_nodes.attributes <> new_nodes.attributes
+LIMIT 500;

--- a/docs/perf/results/postgres-graph-explain-sample/node_detail.sql
+++ b/docs/perf/results/postgres-graph-explain-sample/node_detail.sql
@@ -1,0 +1,6 @@
+EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+SELECT source_id, target_id, relationship, direction, weight, traversable
+FROM graph_edges
+WHERE tenant_id = 'default'
+  AND scan_id = 'graph-benchmark-estate-current'
+  AND (source_id = 'package:langchain' OR target_id = 'package:langchain');

--- a/docs/perf/results/postgres-graph-explain-sample/node_search.sql
+++ b/docs/perf/results/postgres-graph-explain-sample/node_search.sql
@@ -1,0 +1,12 @@
+EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+SELECT gn.id, gn.entity_type, gn.label, gn.severity_id, gn.risk_score
+FROM graph_node_search gns
+JOIN graph_nodes gn
+  ON gn.id = gns.node_id
+ AND gn.scan_id = gns.scan_id
+ AND gn.tenant_id = gns.tenant_id
+WHERE gns.tenant_id = 'default'
+  AND gns.scan_id = 'graph-benchmark-estate-current'
+  AND LOWER(gns.search_text) LIKE '%langchain%'
+ORDER BY gn.severity_id DESC, gn.risk_score DESC, gn.label ASC, gn.id ASC
+LIMIT 50;

--- a/scripts/check_scale_evidence.py
+++ b/scripts/check_scale_evidence.py
@@ -16,6 +16,7 @@ PERF_DIR = ROOT / "docs" / "perf"
 
 REQUIRED_FILES = (
     PERF_DIR / "p95-p99-graph-query.md",
+    PERF_DIR / "graph-api-postgres-benchmark.md",
     PERF_DIR / "ingest-throughput.md",
     PERF_DIR / "fleet-reconciliation.md",
 )
@@ -40,8 +41,10 @@ def _check_file(path: Path) -> list[str]:
     for marker in REQUIRED_MARKERS:
         if marker not in text:
             errors.append(f"{path.relative_to(ROOT)} missing marker: {marker}")
-    if "TBD" not in text and "Evidence status: measured" not in text:
-        errors.append(f"{path.relative_to(ROOT)} must either keep TBD placeholders or declare measured evidence")
+    if "TBD" not in text and "Evidence status: measured" not in text and "Evidence status: scaffolded" not in text:
+        errors.append(
+            f"{path.relative_to(ROOT)} must either keep TBD placeholders, declare measured evidence, or declare scaffolded evidence"
+        )
     if "Evidence status: measured" in text:
         marker = "Raw result artifact: `"
         if marker not in text:

--- a/scripts/generate_graph_benchmark_estate.py
+++ b/scripts/generate_graph_benchmark_estate.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Generate a deterministic synthetic graph estate for benchmark evidence.
+
+The shape is intentionally skewed: a small number of agents have many MCP
+servers/tools, most have few, and packages include a mix of shared platform
+dependencies and unique service dependencies. The output is a scanner-style
+report that can be loaded by the existing graph builder without changing graph
+runtime behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import statistics
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+DEFAULT_REPORT = ROOT / "docs" / "perf" / "results" / "graph-benchmark-estate-sample-report.json"
+DEFAULT_SUMMARY = ROOT / "docs" / "perf" / "results" / "graph-benchmark-estate-sample.json"
+
+SOURCES = ("local", "github-action", "k8s-fleet", "operator-push", "cloud-inventory")
+AGENT_TYPES = ("claude-desktop", "cursor", "windsurf", "vscode", "cortex-code")
+ECOSYSTEMS = ("npm", "pypi", "go", "maven", "oci")
+SEVERITIES = ("critical", "high", "medium", "low")
+POPULAR_PACKAGES = (
+    "langchain",
+    "openai",
+    "anthropic",
+    "mcp-sdk",
+    "fastapi",
+    "requests",
+    "zod",
+    "react",
+    "next",
+    "protobuf",
+    "grpc",
+    "boto3",
+)
+
+
+def _percentile(values: list[int], pct: float) -> int:
+    ordered = sorted(values)
+    if not ordered:
+        return 0
+    idx = min(len(ordered) - 1, max(0, round((len(ordered) - 1) * pct)))
+    return ordered[idx]
+
+
+def _skewed_server_count(idx: int, rng: random.Random) -> int:
+    if idx % 97 == 0:
+        return rng.randint(18, 32)
+    if idx % 23 == 0:
+        return rng.randint(7, 14)
+    if idx % 7 == 0:
+        return rng.randint(3, 6)
+    return 1 if rng.random() < 0.68 else 2
+
+
+def _skewed_tool_count(agent_idx: int, server_idx: int, rng: random.Random) -> int:
+    if agent_idx % 97 == 0 and server_idx < 4:
+        return rng.randint(20, 45)
+    if agent_idx % 23 == 0:
+        return rng.randint(8, 18)
+    return rng.randint(1, 5)
+
+
+def _package_count(agent_idx: int, server_idx: int, rng: random.Random) -> int:
+    if agent_idx % 97 == 0:
+        return rng.randint(16, 28)
+    if server_idx % 5 == 0:
+        return rng.randint(8, 14)
+    return rng.randint(3, 8)
+
+
+def _source_mix(idx: int) -> list[str]:
+    primary = SOURCES[idx % len(SOURCES)]
+    sources = [primary]
+    if idx % 5 == 0:
+        sources.append("operator-push")
+    if idx % 11 == 0:
+        sources.append("cloud-inventory")
+    return sorted(set(sources))
+
+
+def _package_name(agent_idx: int, server_idx: int, package_idx: int, rng: random.Random) -> str:
+    if rng.random() < 0.42:
+        return POPULAR_PACKAGES[(agent_idx + server_idx + package_idx) % len(POPULAR_PACKAGES)]
+    if rng.random() < 0.18:
+        return f"team-shared-{(agent_idx // 25) % 25}-{package_idx % 9}"
+    return f"svc-{agent_idx:05d}-{server_idx:02d}-{package_idx:02d}"
+
+
+def generate_estate(*, agents: int, seed: int, vulnerable_package_rate: float) -> tuple[dict[str, Any], dict[str, Any]]:
+    rng = random.Random(seed)
+    report_agents: list[dict[str, Any]] = []
+    blast_radius: list[dict[str, Any]] = []
+    server_counts: list[int] = []
+    tool_counts: list[int] = []
+    package_counts: list[int] = []
+    source_counts = {source: 0 for source in SOURCES}
+    package_seen: set[str] = set()
+    vulnerable_seen: set[str] = set()
+
+    for agent_idx in range(agents):
+        agent_name = f"agent-{agent_idx:05d}"
+        agent_sources = _source_mix(agent_idx)
+        for source in agent_sources:
+            source_counts[source] += 1
+        servers: list[dict[str, Any]] = []
+        server_count = _skewed_server_count(agent_idx, rng)
+        server_counts.append(server_count)
+        for server_idx in range(server_count):
+            server_name = f"{agent_name}-mcp-{server_idx:02d}"
+            tool_count = _skewed_tool_count(agent_idx, server_idx, rng)
+            package_count = _package_count(agent_idx, server_idx, rng)
+            tool_counts.append(tool_count)
+            package_counts.append(package_count)
+            packages: list[dict[str, Any]] = []
+            for package_idx in range(package_count):
+                package_name = _package_name(agent_idx, server_idx, package_idx, rng)
+                package_seen.add(package_name)
+                ecosystem = ECOSYSTEMS[(agent_idx + server_idx + package_idx) % len(ECOSYSTEMS)]
+                packages.append(
+                    {
+                        "name": package_name,
+                        "version": f"{1 + package_idx % 3}.{server_idx % 10}.{agent_idx % 17}",
+                        "ecosystem": ecosystem,
+                        "is_direct": package_idx < 2 or rng.random() < 0.22,
+                    }
+                )
+                if package_name not in vulnerable_seen and rng.random() < vulnerable_package_rate:
+                    vulnerable_seen.add(package_name)
+                    vuln_id = f"CVE-2026-{len(vulnerable_seen):06d}"
+                    blast_radius.append(
+                        {
+                            "vulnerability_id": vuln_id,
+                            "severity": SEVERITIES[(agent_idx + package_idx) % len(SEVERITIES)],
+                            "package": package_name,
+                            "package_name": package_name,
+                            "package_version": packages[-1]["version"],
+                            "fixed_version": f"{packages[-1]['version']}.1",
+                            "affected_agents": [agent_name],
+                            "affected_servers": [{"name": server_name}],
+                            "exposed_tools": [f"{server_name}-tool-{i:02d}" for i in range(min(tool_count, 4))],
+                            "exposed_credentials": [f"{agent_name.upper().replace('-', '_')}_TOKEN"] if agent_idx % 9 == 0 else [],
+                            "owasp_tags": ["LLM05", "LLM06"],
+                            "soc2_tags": ["CC6.1"],
+                        }
+                    )
+            servers.append(
+                {
+                    "name": server_name,
+                    "transport": "sse" if server_idx % 3 else "stdio",
+                    "url": f"https://mcp-{agent_idx % 200}.example.internal/{server_idx}" if server_idx % 3 else "",
+                    "surface": "mcp-server",
+                    "credential_env_vars": [f"{agent_name.upper().replace('-', '_')}_TOKEN"] if agent_idx % 9 == 0 else [],
+                    "packages": packages,
+                    "tools": [{"name": f"{server_name}-tool-{tool_idx:02d}"} for tool_idx in range(tool_count)],
+                    "discovery_sources": agent_sources,
+                    "registry_verified": server_idx % 4 != 0,
+                }
+            )
+        report_agents.append(
+            {
+                "name": agent_name,
+                "type": AGENT_TYPES[agent_idx % len(AGENT_TYPES)],
+                "status": "configured",
+                "mcp_servers": servers,
+                "discovery_sources": agent_sources,
+                "source": agent_sources[0],
+            }
+        )
+
+    report = {
+        "scan_id": f"graph-benchmark-estate-{agents}-{seed}",
+        "generated_at": "2026-05-13T00:00:00Z",
+        "tool_version": "benchmark-scaffold",
+        "scan_sources": sorted(source for source, count in source_counts.items() if count),
+        "agents": report_agents,
+        "blast_radius": blast_radius,
+    }
+    summary = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "evidence_status": "synthetic_estate_shape_only",
+        "seed": seed,
+        "agents": agents,
+        "source_mix_agent_mentions": source_counts,
+        "vulnerable_package_rate_target": vulnerable_package_rate,
+        "vulnerable_package_rate_observed": round(len(vulnerable_seen) / max(len(package_seen), 1), 4),
+        "counts": {
+            "servers": sum(server_counts),
+            "tools": sum(tool_counts),
+            "package_instances": sum(package_counts),
+            "unique_packages": len(package_seen),
+            "blast_radius_rows": len(blast_radius),
+        },
+        "skew": {
+            "servers_per_agent": {
+                "min": min(server_counts, default=0),
+                "median": statistics.median(server_counts) if server_counts else 0,
+                "p95": _percentile(server_counts, 0.95),
+                "p99": _percentile(server_counts, 0.99),
+                "max": max(server_counts, default=0),
+            },
+            "tools_per_server": {
+                "min": min(tool_counts, default=0),
+                "median": statistics.median(tool_counts) if tool_counts else 0,
+                "p95": _percentile(tool_counts, 0.95),
+                "p99": _percentile(tool_counts, 0.99),
+                "max": max(tool_counts, default=0),
+            },
+            "packages_per_server": {
+                "min": min(package_counts, default=0),
+                "median": statistics.median(package_counts) if package_counts else 0,
+                "p95": _percentile(package_counts, 0.95),
+                "p99": _percentile(package_counts, 0.99),
+                "max": max(package_counts, default=0),
+            },
+        },
+    }
+    return report, summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate a skewed synthetic graph estate report and summary.")
+    parser.add_argument("--agents", type=int, default=150, help="Number of synthetic agents to generate.")
+    parser.add_argument("--seed", type=int, default=2145, help="Deterministic random seed.")
+    parser.add_argument("--vulnerable-package-rate", type=float, default=0.08, help="Target vulnerable unique-package rate.")
+    parser.add_argument("--report-output", type=Path, default=DEFAULT_REPORT, help="Scanner-style report JSON output path.")
+    parser.add_argument("--summary-output", type=Path, default=DEFAULT_SUMMARY, help="Summary JSON output path.")
+    args = parser.parse_args()
+
+    if args.agents < 1:
+        parser.error("--agents must be >= 1")
+    if not 0 <= args.vulnerable_package_rate <= 1:
+        parser.error("--vulnerable-package-rate must be between 0 and 1")
+
+    report, summary = generate_estate(agents=args.agents, seed=args.seed, vulnerable_package_rate=args.vulnerable_package_rate)
+    args.report_output.parent.mkdir(parents=True, exist_ok=True)
+    args.summary_output.parent.mkdir(parents=True, exist_ok=True)
+    args.report_output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.summary_output.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(args.report_output)
+    print(args.summary_output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_graph_api_benchmark.py
+++ b/scripts/run_graph_api_benchmark.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Run or dry-run graph API benchmark requests.
+
+Dry-run mode validates the request plan and writes a truthful artifact with no
+latency claims. Live mode sends bounded requests to an already-running API and
+records p50/p95/p99 wall-clock timings from this client.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT = ROOT / "docs" / "perf" / "results" / "graph-api-benchmark-sample.json"
+
+
+def _percentiles(values_ms: list[float]) -> dict[str, float | int]:
+    if not values_ms:
+        return {"p50_ms": 0.0, "p95_ms": 0.0, "p99_ms": 0.0, "max_ms": 0.0, "mean_ms": 0.0, "samples": 0}
+    ordered = sorted(values_ms)
+
+    def pct(percent: float) -> float:
+        idx = min(len(ordered) - 1, max(0, round((len(ordered) - 1) * percent)))
+        return round(ordered[idx], 3)
+
+    return {
+        "p50_ms": pct(0.50),
+        "p95_ms": pct(0.95),
+        "p99_ms": pct(0.99),
+        "max_ms": round(max(ordered), 3),
+        "mean_ms": round(statistics.fmean(ordered), 3),
+        "samples": len(ordered),
+    }
+
+
+def request_plan(*, scan_id: str, old_scan_id: str, new_scan_id: str, source_node: str, detail_node: str) -> list[dict[str, Any]]:
+    scan_param = {"scan_id": scan_id} if scan_id else {}
+    return [
+        {
+            "name": "graph_search",
+            "method": "GET",
+            "path": "/v1/graph/search",
+            "query": {"q": "langchain", "entity_types": "package,vulnerability", "limit": "50", **scan_param},
+        },
+        {
+            "name": "node_detail",
+            "method": "GET",
+            "path": f"/v1/graph/node/{detail_node}",
+            "query": scan_param,
+        },
+        {
+            "name": "attack_path_drilldown",
+            "method": "GET",
+            "path": "/v1/graph/paths",
+            "query": {"source_id": source_node, "max_depth": "4", "limit": "100", **scan_param},
+        },
+        {
+            "name": "graph_diff",
+            "method": "GET",
+            "path": "/v1/graph/diff",
+            "query": {"old": old_scan_id, "new": new_scan_id},
+        },
+        {
+            "name": "bounded_traversal",
+            "method": "POST",
+            "path": "/v1/graph/query",
+            "query": {},
+            "json": {
+                "roots": [source_node],
+                "scan_id": scan_id,
+                "direction": "both",
+                "max_depth": 3,
+                "max_nodes": 500,
+                "max_edges": 5000,
+                "timeout_ms": 2500,
+                "traversable_only": True,
+                "include_attack_paths": True,
+            },
+        },
+    ]
+
+
+def _url(base_url: str, operation: dict[str, Any]) -> str:
+    base = base_url.rstrip("/") + operation["path"]
+    query = operation.get("query") or {}
+    return base + ("?" + urlencode(query) if query else "")
+
+
+def _send(base_url: str, operation: dict[str, Any], *, token: str, tenant_id: str, timeout: float) -> tuple[int, int]:
+    body = None
+    headers = {"Accept": "application/json", "X-Agent-Bom-Tenant-ID": tenant_id}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if operation["method"] == "POST":
+        body = json.dumps(operation.get("json") or {}).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    request = Request(_url(base_url, operation), data=body, headers=headers, method=operation["method"])
+    with urlopen(request, timeout=timeout) as response:  # noqa: S310 - benchmark target is user-supplied by CLI.
+        payload = response.read()
+        return response.status, len(payload)
+
+
+def run_live(
+    *,
+    base_url: str,
+    operations: list[dict[str, Any]],
+    repeat: int,
+    token: str,
+    tenant_id: str,
+    timeout: float,
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for operation in operations:
+        timings: list[float] = []
+        statuses: dict[str, int] = {}
+        bytes_read = 0
+        failures: list[str] = []
+        for _ in range(repeat):
+            started = time.perf_counter()
+            try:
+                status, size = _send(base_url, operation, token=token, tenant_id=tenant_id, timeout=timeout)
+                timings.append((time.perf_counter() - started) * 1000)
+                statuses[str(status)] = statuses.get(str(status), 0) + 1
+                bytes_read = size
+            except HTTPError as exc:
+                statuses[str(exc.code)] = statuses.get(str(exc.code), 0) + 1
+                failures.append(f"HTTP {exc.code}: {exc.reason}")
+            except URLError as exc:
+                failures.append(str(exc.reason))
+            except TimeoutError:
+                failures.append("request timed out")
+        results.append(
+            {
+                "name": operation["name"],
+                "method": operation["method"],
+                "path": operation["path"],
+                "status_counts": statuses,
+                "response_bytes_last": bytes_read,
+                "latency": _percentiles(timings),
+                "failures_sample": failures[:5],
+            }
+        )
+    return results
+
+
+def generate(args: argparse.Namespace) -> dict[str, Any]:
+    operations = request_plan(
+        scan_id=args.scan_id,
+        old_scan_id=args.old_scan_id,
+        new_scan_id=args.new_scan_id,
+        source_node=args.source_node,
+        detail_node=args.detail_node,
+    )
+    evidence: dict[str, Any] = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "owner_issue": 2145,
+        "base_url": args.base_url,
+        "tenant_id": args.tenant_id,
+        "repeat": args.repeat,
+        "request_plan": operations,
+        "commands": {
+            "dry_run": "uv run python scripts/run_graph_api_benchmark.py --dry-run",
+            "live": (
+                "AGENT_BOM_API_TOKEN=... uv run python scripts/run_graph_api_benchmark.py "
+                "--base-url http://127.0.0.1:8000 --scan-id <scan> --old-scan-id <old> --new-scan-id <new>"
+            ),
+        },
+    }
+    if args.dry_run:
+        evidence["evidence_status"] = "scaffold_validated_not_measured"
+        evidence["results"] = []
+        evidence["gaps"] = [
+            "Dry-run does not start the API, authenticate, or measure network/server latency.",
+            "Live results must record the API auth mode, tenant, graph backend, and scan IDs used.",
+        ]
+        return evidence
+
+    evidence["evidence_status"] = "measured_api_client_wall_clock"
+    evidence["results"] = run_live(
+        base_url=args.base_url,
+        operations=operations,
+        repeat=args.repeat,
+        token=args.token or os.environ.get("AGENT_BOM_API_TOKEN", ""),
+        tenant_id=args.tenant_id,
+        timeout=args.timeout,
+    )
+    evidence["gaps"] = [
+        "Client-side timings include local network and client JSON transfer time.",
+        "Server-side DB plans are measured separately by scripts/run_graph_postgres_explain.py.",
+    ]
+    return evidence
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Benchmark graph API hot paths or emit a dry-run request plan.")
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000", help="Running agent-bom API base URL.")
+    parser.add_argument("--tenant-id", default="default", help="Tenant header to send.")
+    parser.add_argument("--token", default="", help="Bearer token. Defaults to AGENT_BOM_API_TOKEN.")
+    parser.add_argument("--scan-id", default="graph-benchmark-estate-current", help="Scan ID for latest/single-snapshot requests.")
+    parser.add_argument("--old-scan-id", default="graph-benchmark-estate-old", help="Old scan ID for /v1/graph/diff.")
+    parser.add_argument("--new-scan-id", default="graph-benchmark-estate-current", help="New scan ID for /v1/graph/diff.")
+    parser.add_argument("--source-node", default="agent:agent-00000", help="Source node for path/traversal requests.")
+    parser.add_argument("--detail-node", default="package:langchain", help="Node ID for detail request.")
+    parser.add_argument("--repeat", type=int, default=20, help="Requests per operation in live mode.")
+    parser.add_argument("--timeout", type=float, default=10.0, help="Per-request timeout in seconds.")
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT, help="JSON evidence output path.")
+    parser.add_argument("--dry-run", action="store_true", help="Write request plan without sending HTTP requests.")
+    args = parser.parse_args()
+
+    if args.repeat < 1:
+        parser.error("--repeat must be >= 1")
+    evidence = generate(args)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_graph_postgres_explain.py
+++ b/scripts/run_graph_postgres_explain.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Generate or run Postgres EXPLAIN plans for graph hot-path queries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT_DIR = ROOT / "docs" / "perf" / "results" / "postgres-graph-explain-sample"
+DEFAULT_SUMMARY = ROOT / "docs" / "perf" / "results" / "postgres-graph-explain-sample.json"
+
+
+def _sql_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def explain_queries(*, tenant_id: str, scan_id: str, old_scan_id: str, source_node: str, detail_node: str) -> dict[str, str]:
+    prefix = "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)"
+    tenant = _sql_literal(tenant_id)
+    scan = _sql_literal(scan_id)
+    old_scan = _sql_literal(old_scan_id)
+    source = _sql_literal(source_node)
+    detail = _sql_literal(detail_node)
+    return {
+        "node_search": f"""
+{prefix}
+SELECT gn.id, gn.entity_type, gn.label, gn.severity_id, gn.risk_score
+FROM graph_node_search gns
+JOIN graph_nodes gn
+  ON gn.id = gns.node_id
+ AND gn.scan_id = gns.scan_id
+ AND gn.tenant_id = gns.tenant_id
+WHERE gns.tenant_id = {tenant}
+  AND gns.scan_id = {scan}
+  AND LOWER(gns.search_text) LIKE '%langchain%'
+ORDER BY gn.severity_id DESC, gn.risk_score DESC, gn.label ASC, gn.id ASC
+LIMIT 50;
+""".strip(),
+        "node_detail": f"""
+{prefix}
+SELECT source_id, target_id, relationship, direction, weight, traversable
+FROM graph_edges
+WHERE tenant_id = {tenant}
+  AND scan_id = {scan}
+  AND (source_id = {detail} OR target_id = {detail});
+""".strip(),
+        "attack_path_drilldown": f"""
+{prefix}
+SELECT source_node, target_node, hop_count, composite_risk, path_nodes, path_edges
+FROM attack_paths
+WHERE tenant_id = {tenant}
+  AND scan_id = {scan}
+  AND source_node = {source}
+ORDER BY composite_risk DESC
+LIMIT 100;
+""".strip(),
+        "graph_diff_nodes": f"""
+{prefix}
+SELECT COALESCE(new_nodes.id, old_nodes.id) AS node_id,
+       CASE
+         WHEN old_nodes.id IS NULL THEN 'added'
+         WHEN new_nodes.id IS NULL THEN 'removed'
+         WHEN old_nodes.attributes <> new_nodes.attributes THEN 'changed'
+         ELSE 'same'
+       END AS diff_state
+FROM (
+  SELECT id, attributes FROM graph_nodes
+  WHERE tenant_id = {tenant} AND scan_id = {old_scan}
+) old_nodes
+FULL OUTER JOIN (
+  SELECT id, attributes FROM graph_nodes
+  WHERE tenant_id = {tenant} AND scan_id = {scan}
+) new_nodes USING (id)
+WHERE old_nodes.id IS NULL
+   OR new_nodes.id IS NULL
+   OR old_nodes.attributes <> new_nodes.attributes
+LIMIT 500;
+""".strip(),
+        "bounded_traversal_edges": f"""
+{prefix}
+WITH RECURSIVE walk(node_id, depth) AS (
+  SELECT {source}::text, 0
+  UNION ALL
+  SELECT e.target_id, walk.depth + 1
+  FROM walk
+  JOIN graph_edges e
+    ON e.tenant_id = {tenant}
+   AND e.scan_id = {scan}
+   AND e.source_id = walk.node_id
+   AND e.traversable = 1
+  WHERE walk.depth < 3
+)
+SELECT DISTINCT node_id, depth
+FROM walk
+LIMIT 500;
+""".strip(),
+    }
+
+
+def _write_queries(output_dir: Path, queries: dict[str, str]) -> dict[str, str]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    paths: dict[str, str] = {}
+    for name, sql in queries.items():
+        path = output_dir / f"{name}.sql"
+        path.write_text(sql + "\n", encoding="utf-8")
+        paths[name] = str(path)
+    return paths
+
+
+def _display_path(path: str) -> str:
+    resolved = Path(path).resolve()
+    try:
+        return str(resolved.relative_to(ROOT))
+    except ValueError:
+        return str(resolved)
+
+
+def _run_psql(dsn: str, sql_path: Path, output_path: Path) -> dict[str, Any]:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        ["psql", dsn, "--no-psqlrc", "--set=ON_ERROR_STOP=1", "--file", str(sql_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    output_path.write_text(result.stdout + ("\n" + result.stderr if result.stderr else ""), encoding="utf-8")
+    return {"returncode": result.returncode, "output": str(output_path)}
+
+
+def generate(args: argparse.Namespace) -> dict[str, Any]:
+    queries = explain_queries(
+        tenant_id=args.tenant_id,
+        scan_id=args.scan_id,
+        old_scan_id=args.old_scan_id,
+        source_node=args.source_node,
+        detail_node=args.detail_node,
+    )
+    query_paths = _write_queries(args.output_dir, queries)
+    summary: dict[str, Any] = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "owner_issue": 2145,
+        "evidence_status": "explain_sql_scaffold_not_measured" if args.dry_run else "explain_analyze_artifacts",
+        "tenant_id": args.tenant_id,
+        "scan_id": args.scan_id,
+        "old_scan_id": args.old_scan_id,
+        "edge_targets": args.edge_targets,
+        "query_artifacts": {name: _display_path(path) for name, path in query_paths.items()},
+        "commands": {
+            "dry_run": "uv run python scripts/run_graph_postgres_explain.py --dry-run",
+            "live": (
+                "AGENT_BOM_POSTGRES_DSN=postgresql://... uv run python scripts/run_graph_postgres_explain.py "
+                "--run --scan-id <new> --old-scan-id <old>"
+            ),
+        },
+    }
+    if args.dry_run:
+        summary["gaps"] = [
+            "Dry-run writes EXPLAIN SQL only; it does not seed Postgres or execute EXPLAIN ANALYZE.",
+            "Measured artifacts must be captured from a database loaded with the matching synthetic estate snapshots.",
+        ]
+        return summary
+
+    dsn = args.dsn or os.environ.get("AGENT_BOM_POSTGRES_DSN", "")
+    if not dsn:
+        raise SystemExit("AGENT_BOM_POSTGRES_DSN or --dsn is required unless --dry-run is used.")
+    plan_dir = args.output_dir / "plans"
+    summary["plans"] = {name: _run_psql(dsn, Path(path), plan_dir / f"{name}.txt") for name, path in query_paths.items()}
+    summary["gaps"] = [
+        "EXPLAIN ANALYZE timings are database-local and should be paired with API client timings for full deployment evidence.",
+        "Plan quality depends on loaded scan cardinality, index availability, Postgres version, and tenant/session settings.",
+    ]
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate or run Postgres EXPLAIN ANALYZE artifacts for graph hot paths.")
+    parser.add_argument("--dsn", default="", help="Postgres DSN. Defaults to AGENT_BOM_POSTGRES_DSN.")
+    parser.add_argument("--tenant-id", default="default")
+    parser.add_argument("--scan-id", default="graph-benchmark-estate-current")
+    parser.add_argument("--old-scan-id", default="graph-benchmark-estate-old")
+    parser.add_argument("--source-node", default="agent:agent-00000")
+    parser.add_argument("--detail-node", default="package:langchain")
+    parser.add_argument("--edge-targets", default="10000,50000,100000", help="Documented target edge counts for the loaded estates.")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--summary-output", type=Path, default=DEFAULT_SUMMARY)
+    parser.add_argument("--dry-run", action="store_true", help="Write SQL artifacts without running psql.")
+    parser.add_argument("--run", action="store_true", help="Run psql against the configured DSN.")
+    args = parser.parse_args()
+
+    if args.run:
+        args.dry_run = False
+    elif not args.dry_run:
+        args.dry_run = True
+    summary = generate(args)
+    args.summary_output.parent.mkdir(parents=True, exist_ok=True)
+    args.summary_output.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(args.summary_output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_graph_benchmark_scaffold.py
+++ b/tests/test_graph_benchmark_scaffold.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.generate_graph_benchmark_estate import generate_estate
+from scripts.run_graph_api_benchmark import request_plan
+from scripts.run_graph_postgres_explain import explain_queries
+
+
+def test_synthetic_estate_has_skewed_topology_and_sources() -> None:
+    report, summary = generate_estate(agents=120, seed=2145, vulnerable_package_rate=0.08)
+
+    assert len(report["agents"]) == 120
+    assert summary["counts"]["servers"] > 120
+    assert summary["counts"]["tools"] > summary["counts"]["servers"]
+    assert summary["counts"]["blast_radius_rows"] > 0
+    assert summary["skew"]["servers_per_agent"]["p95"] > summary["skew"]["servers_per_agent"]["median"]
+    assert summary["skew"]["tools_per_server"]["p99"] > summary["skew"]["tools_per_server"]["median"]
+    assert {"local", "k8s-fleet", "operator-push", "cloud-inventory"}.issubset(set(report["scan_sources"]))
+
+
+def test_api_request_plan_covers_issue_2145_hot_paths() -> None:
+    operations = request_plan(
+        scan_id="new-scan",
+        old_scan_id="old-scan",
+        new_scan_id="new-scan",
+        source_node="agent:agent-00000",
+        detail_node="package:langchain",
+    )
+
+    names = {operation["name"] for operation in operations}
+    assert names == {"graph_search", "node_detail", "attack_path_drilldown", "graph_diff", "bounded_traversal"}
+    assert any(operation["path"] == "/v1/graph/search" for operation in operations)
+    assert any(operation["path"].startswith("/v1/graph/node/") for operation in operations)
+    assert any(operation["path"] == "/v1/graph/paths" for operation in operations)
+    assert any(operation["path"] == "/v1/graph/diff" for operation in operations)
+    assert any(operation["method"] == "POST" and operation["path"] == "/v1/graph/query" for operation in operations)
+
+
+def test_postgres_explain_queries_cover_graph_hot_paths() -> None:
+    queries = explain_queries(
+        tenant_id="default",
+        scan_id="new-scan",
+        old_scan_id="old-scan",
+        source_node="agent:agent-00000",
+        detail_node="package:langchain",
+    )
+
+    assert set(queries) == {"node_search", "node_detail", "attack_path_drilldown", "graph_diff_nodes", "bounded_traversal_edges"}
+    assert all("EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)" in sql for sql in queries.values())
+    assert "graph_node_search" in queries["node_search"]
+    assert "attack_paths" in queries["attack_path_drilldown"]
+    assert "FULL OUTER JOIN" in queries["graph_diff_nodes"]
+    assert "WITH RECURSIVE" in queries["bounded_traversal_edges"]
+
+
+def test_graph_benchmark_scripts_write_dry_run_artifacts(tmp_path: Path) -> None:
+    estate_report = tmp_path / "estate-report.json"
+    estate_summary = tmp_path / "estate-summary.json"
+    api_output = tmp_path / "api.json"
+    explain_dir = tmp_path / "explain"
+    explain_summary = tmp_path / "explain.json"
+
+    commands = [
+        [
+            sys.executable,
+            "scripts/generate_graph_benchmark_estate.py",
+            "--agents",
+            "25",
+            "--report-output",
+            str(estate_report),
+            "--summary-output",
+            str(estate_summary),
+        ],
+        [sys.executable, "scripts/run_graph_api_benchmark.py", "--dry-run", "--output", str(api_output)],
+        [
+            sys.executable,
+            "scripts/run_graph_postgres_explain.py",
+            "--dry-run",
+            "--output-dir",
+            str(explain_dir),
+            "--summary-output",
+            str(explain_summary),
+        ],
+    ]
+    for command in commands:
+        result = subprocess.run(command, check=False, capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+
+    assert json.loads(estate_summary.read_text())["evidence_status"] == "synthetic_estate_shape_only"
+    assert json.loads(api_output.read_text())["evidence_status"] == "scaffold_validated_not_measured"
+    explain = json.loads(explain_summary.read_text())
+    assert explain["evidence_status"] == "explain_sql_scaffold_not_measured"
+    assert (explain_dir / "node_search.sql").exists()


### PR DESCRIPTION
## Summary

Adds a benchmark-evidence scaffold for graph API and Postgres scale work without making unmeasured latency claims.

## Changes

- Adds a deterministic skewed estate generator with mixed local, fleet, cloud, and operator-pushed source labels.
- Adds dry-run API benchmark request coverage for graph search, node detail, attack-path drilldown, diff, and bounded traversal.
- Adds Postgres `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` SQL scaffold artifacts for graph hot paths.
- Checks in raw sample scaffold artifacts under `docs/perf/results/`.
- Updates perf docs and the scheduled perf workflow to validate the lightweight scaffold.

## Validation

- `uv run pytest tests/test_graph_benchmark_scaffold.py tests/test_scale_evidence.py -q`
- `uv run ruff check scripts/generate_graph_benchmark_estate.py scripts/run_graph_api_benchmark.py scripts/run_graph_postgres_explain.py tests/test_graph_benchmark_scaffold.py scripts/check_scale_evidence.py`
- `uv run python scripts/check_scale_evidence.py`
- `git diff --check`

## Limits

This is scaffold evidence, not live API or Postgres latency evidence. The docs keep API/Postgres p50/p95/p99 and SLO claims out of scope until live artifacts are produced.

Refs #2145
