### PR TITLE
Harden large graph overview fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Runtime choices:
 Current graph scale boundary:
 
 - the graph is strong for pilot and mid-market investigation flows, but larger tenants should stay windowed by snapshot, page, search, and blast-radius drilldown instead of expecting one giant browser canvas to stay smooth
+- visible graph pages at 500+ nodes or 1,200+ edges use a limited 2D canvas overview with a 3,000-node / 6,000-edge draw budget; narrow the graph, open a search result, select an attack path, or use reachability drill-in to return to the React Flow investigation view
 - operator sizing guidance and the shipped benchmark harness live in [Performance, Sizing, and Benchmarks](site-docs/deployment/performance-and-sizing.md)
 - the full contract — entity / edge coverage, accuracy guarantees, scaling tiers, non-promises, and known gaps — is in [docs/graph/CONTRACT.md](docs/graph/CONTRACT.md)
 

--- a/docs/graph/CONTRACT.md
+++ b/docs/graph/CONTRACT.md
@@ -89,9 +89,9 @@ The graph renderer ships deterministic focused and expanded modes. Operators can
 | Relevant paths default | 2-hop neighbourhood, 50-node page size, high-severity vulnerable scope, sibling fan-outs of 5+ collapsed into expandable cluster pills. | Starts every investigation readable, even on dense self-scans. |
 | Expanded mode | 3-hop neighbourhood, 250-node page size, sibling fan-outs of 20+ collapsed. | Lets operators widen context deliberately without turning the first view into a whole-tenant canvas. |
 | Zoomed out | Level-of-detail renderer swaps detail cards for summary cards and cluster bubbles below the zoom thresholds. | Dense snapshots stay navigable instead of turning into unreadable labels. |
-| Large snapshots | Snapshot selector, search, filters, pagination, and graph query endpoints bound the visible canvas. | Large tenants navigate by scope, not by rendering the whole tenant in one frame. |
+| Large overview | Visible pages at or above 500 nodes or 1,200 edges switch from React Flow to a limited 2D canvas overview. The overview draws up to 3,000 high-signal nodes and 6,000 high-signal edges; search, filters, selected-node detail, and reachability drill-ins remain server-backed. | Keeps broad estate pages from blanking or stalling while preserving React Flow for bounded investigations. |
 
-Operators reaching large-snapshot scale should pivot to scoped queries, security-graph attack paths, the blast-radius drilldown, or the snapshot + page + search workflow described in `site-docs/deployment/performance-and-sizing.md`. The graph is designed for investigation, not for "render the whole tenant in one canvas."
+Operators reaching large-snapshot scale should pivot to scoped queries, security-graph attack paths, the blast-radius drilldown, or the snapshot + page + search workflow described in `site-docs/deployment/performance-and-sizing.md`. The large overview is intentionally not a full React Flow replacement: it supports pan, zoom, node selection, and high-level topology, but not node cards, minimap, or path highlighting. The graph is designed for investigation, not for "render the whole tenant in one canvas."
 
 ---
 

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -86,7 +86,11 @@ import {
   type UnifiedGraphResponse,
 } from "@/lib/api";
 import { buildUnifiedFlowGraph } from "@/lib/unified-graph-flow";
-import { shouldUseLargeGraphOverview } from "@/lib/large-graph-overview";
+import {
+  LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD,
+  LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD,
+  shouldUseLargeGraphOverview,
+} from "@/lib/large-graph-overview";
 import {
   applyFilters,
   decodeFiltersFromParams,
@@ -1638,6 +1642,7 @@ function GraphPageInner() {
             <li>Node IDs are stable identifiers inside the graph model; the detail panel shows the node ID, first seen, last seen, sources, and edge counts.</li>
             <li>Pagination changes the visible canvas, not the persisted snapshot itself. Narrow the scope when the graph gets large; page when you need broader coverage.</li>
             <li>Relevant paths is for operator triage. Expanded is for topology review. Attack-path cards are the fix-first shortlist, not the whole graph.</li>
+            <li>Pages at or above {LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD.toLocaleString()} visible nodes or {LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD.toLocaleString()} visible edges use the limited 2D overview. Narrowing, search results, attack-path focus, and reachability drill-ins return to React Flow.</li>
             <li>Hop depth controls how far traversal can move from the selected agent or root. Entity layers control what kinds of nodes can render, without changing the persisted graph.</li>
           </ul>
         </details>

--- a/ui/components/large-graph-overview.tsx
+++ b/ui/components/large-graph-overview.tsx
@@ -9,6 +9,10 @@ import { GraphLegend } from "@/components/graph-chrome";
 import type { LegendItem } from "@/lib/graph-utils";
 import {
   buildLargeGraphOverviewModel,
+  LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD,
+  LARGE_GRAPH_OVERVIEW_MAX_RENDERED_EDGES,
+  LARGE_GRAPH_OVERVIEW_MAX_RENDERED_NODES,
+  LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD,
   summarizeLargeGraphOverview,
   type LargeGraphNode,
 } from "@/lib/large-graph-overview";
@@ -177,6 +181,7 @@ export function LargeGraphOverview({
   const dragRef = useRef<{ x: number; y: number; offsetX: number; offsetY: number } | null>(null);
   const model = useMemo(() => buildLargeGraphOverviewModel(nodes, edges), [nodes, edges]);
   const summary = useMemo(() => summarizeLargeGraphOverview(nodes, edges), [nodes, edges]);
+  const isBudgeted = model.omittedNodeCount > 0 || model.omittedEdgeCount > 0;
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [viewport, setViewport] = useState<Viewport>({ scale: 1, offsetX: 0, offsetY: 0 });
 
@@ -197,7 +202,7 @@ export function LargeGraphOverview({
   }, [model, selectedNodeId, viewport]);
 
   return (
-    <div className="flex h-full min-h-[72vh] flex-col overflow-hidden rounded-xl border border-zinc-800 bg-zinc-950 shadow-2xl shadow-black/30">
+    <div className="flex h-full min-h-[72vh] flex-col overflow-hidden rounded-xl border border-zinc-800 bg-zinc-950 shadow-2xl shadow-black/30" data-testid="large-graph-overview">
       <div className="border-b border-zinc-800 bg-zinc-950/95 p-3">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
           <span className="inline-flex shrink-0 items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-950/25 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-200">
@@ -205,8 +210,23 @@ export function LargeGraphOverview({
             Large graph overview
           </span>
           <span className="min-w-0 text-xs text-zinc-500">
-            Canvas renderer for broad estate exploration without loading the focused card graph.
+            2D canvas overview for broad estate scans; focused investigations still use React Flow.
           </span>
+        </div>
+        <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-zinc-500">
+          <span>
+            Switches on at {LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD.toLocaleString()} nodes or{" "}
+            {LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD.toLocaleString()} edges.
+          </span>
+          <span>
+            Draw budget: {model.nodes.length.toLocaleString()}/{model.sourceNodeCount.toLocaleString()} nodes,{" "}
+            {model.edges.length.toLocaleString()}/{model.sourceEdgeCount.toLocaleString()} edges.
+          </span>
+          {isBudgeted && (
+            <span className="text-amber-300">
+              Lower-signal items are omitted from this overview; use search, filters, or drill-in for exact detail.
+            </span>
+          )}
         </div>
         <div className="mt-2">
           <RelationshipRail items={summary.topRelationships} />
@@ -225,6 +245,7 @@ export function LargeGraphOverview({
           ref={canvasRef}
           className="h-full min-h-[58vh] w-full cursor-grab active:cursor-grabbing"
           aria-label="Large security graph overview"
+          data-testid="large-graph-overview-canvas"
           onMouseDown={(event) => {
             dragRef.current = {
               x: event.clientX,
@@ -254,6 +275,7 @@ export function LargeGraphOverview({
             let nearest: LargeGraphNode | null = null;
             let nearestDistance = Infinity;
             for (const node of model.nodes) {
+              if (node.hidden) continue;
               const distance = Math.hypot(node.x - point.x, node.y - point.y);
               if (distance < nearestDistance) {
                 nearest = node;
@@ -288,6 +310,16 @@ export function LargeGraphOverview({
               <GraphLegend items={legendItems} embedded />
             </div>
           </details>
+        </div>
+        <div className="pointer-events-none absolute bottom-3 left-3 max-w-[min(34rem,calc(100vw-2rem))] rounded-xl border border-zinc-800 bg-zinc-950/80 px-3 py-2 text-[11px] text-zinc-400 backdrop-blur">
+          Large mode supports pan, zoom, node selection, server-side search, filters, selected-node detail, and reachability drill-in.
+          React Flow-only affordances such as node cards, minimap, and path highlighting return after narrowing the graph below{" "}
+          {LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD.toLocaleString()} nodes / {LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD.toLocaleString()} edges
+          or entering a bounded drill-in.
+          <span className="sr-only">
+            Maximum overview draw budget is {LARGE_GRAPH_OVERVIEW_MAX_RENDERED_NODES.toLocaleString()} nodes and{" "}
+            {LARGE_GRAPH_OVERVIEW_MAX_RENDERED_EDGES.toLocaleString()} edges.
+          </span>
         </div>
       </div>
     </div>

--- a/ui/e2e/large-graph-overview.spec.ts
+++ b/ui/e2e/large-graph-overview.spec.ts
@@ -1,0 +1,267 @@
+import { expect, test, type Page, type TestInfo } from "@playwright/test";
+
+const scanId = "scan-large-overview";
+const createdAt = "2026-05-08T16:00:00Z";
+
+type GraphNode = {
+  id: string;
+  entity_type: string;
+  label: string;
+  category_uid: number;
+  class_uid: number;
+  type_uid: number;
+  status: string;
+  risk_score: number;
+  severity: string;
+  severity_id: number;
+  first_seen: string;
+  last_seen: string;
+  attributes: Record<string, unknown>;
+  compliance_tags: string[];
+  data_sources: string[];
+  dimensions: Record<string, string>;
+};
+
+type GraphEdge = {
+  id: string;
+  source: string;
+  target: string;
+  relationship: string;
+  direction: "directed";
+  weight: number;
+  traversable: boolean;
+  first_seen: string;
+  last_seen: string;
+  evidence: Record<string, unknown>;
+  activity_id: number;
+};
+
+function node(id: string, entityType: string, label: string, severity = "none", riskScore = 0): GraphNode {
+  const severityRank: Record<string, number> = { none: 0, low: 1, medium: 2, high: 3, critical: 4 };
+  return {
+    id,
+    entity_type: entityType,
+    label,
+    category_uid: 0,
+    class_uid: 0,
+    type_uid: 0,
+    status: "active",
+    risk_score: riskScore,
+    severity,
+    severity_id: severityRank[severity] ?? 0,
+    first_seen: createdAt,
+    last_seen: createdAt,
+    attributes: {},
+    compliance_tags: [],
+    data_sources: ["e2e"],
+    dimensions: {},
+  };
+}
+
+function edge(source: string, target: string, relationship: string, weight = 1): GraphEdge {
+  return {
+    id: `${source}->${target}:${relationship}`,
+    source,
+    target,
+    relationship,
+    direction: "directed",
+    weight,
+    traversable: true,
+    first_seen: createdAt,
+    last_seen: createdAt,
+    evidence: {},
+    activity_id: 1,
+  };
+}
+
+function buildLargeGraph() {
+  const nodes: GraphNode[] = [node("agent:large", "agent", "Large Estate Agent", "high", 9)];
+  const edges: GraphEdge[] = [edge("agent:large", "pkg:0", "uses")];
+
+  for (let index = 0; index < 620; index += 1) {
+    const packageId = `pkg:${index}`;
+    nodes.push(node(packageId, "package", `large-package-${index}`, "high", 7.2));
+    if (index > 0) {
+      edges.push(edge(`pkg:${index - 1}`, packageId, "depends_on"));
+    }
+  }
+
+  for (let index = 0; index < 620; index += 1) {
+    edges.push(edge(`pkg:${index}`, `pkg:${(index + 301) % 620}`, "related_to", 0.8));
+  }
+
+  return {
+    scan_id: scanId,
+    tenant_id: "default",
+    created_at: createdAt,
+    nodes,
+    edges,
+    attack_paths: [],
+    interaction_risks: [],
+    stats: {
+      total_nodes: nodes.length,
+      total_edges: edges.length,
+      node_types: { agent: 1, package: 620 },
+      severity_counts: { high: 621 },
+      relationship_types: { uses: 1, depends_on: 619, related_to: 620 },
+      attack_path_count: 0,
+      interaction_risk_count: 0,
+      max_attack_path_risk: 0,
+      highest_interaction_risk: 0,
+    },
+    pagination: {
+      total: nodes.length,
+      offset: 0,
+      limit: 500,
+      has_more: true,
+    },
+  };
+}
+
+async function routeLargeGraphPage(page: Page) {
+  const graph = buildLargeGraph();
+  const root = graph.nodes.find((entry) => entry.id === "pkg:42") ?? graph.nodes[0];
+  const focusedNodes = graph.nodes.filter((entry) => ["agent:large", "pkg:41", "pkg:42", "pkg:43"].includes(entry.id));
+  const focusedEdges = graph.edges.filter((entry) =>
+    focusedNodes.some((node) => node.id === entry.source) && focusedNodes.some((node) => node.id === entry.target),
+  );
+
+  await page.route("**/health", async (route) => {
+    await route.fulfill({ contentType: "application/json", body: JSON.stringify({ status: "ok" }) });
+  });
+  await page.route("**/v1/auth/me", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        authenticated: true,
+        auth_required: false,
+        configured_modes: [],
+        recommended_ui_mode: "no_auth",
+        auth_method: null,
+        subject: null,
+        role: null,
+        role_summary: null,
+        tenant_id: "default",
+        memberships: [],
+        request_id: "req-large-overview",
+        trace_id: "trace-large-overview",
+        span_id: "span-large-overview",
+      }),
+    });
+  });
+  await page.route("**/v1/posture/counts", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ critical: 0, high: 621, medium: 0, low: 0, total: 621, kev: 0, compound_issues: 0 }),
+    });
+  });
+  await page.route("**/v1/graph/snapshots?limit=40", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify([
+        { scan_id: scanId, created_at: createdAt, node_count: graph.nodes.length, edge_count: graph.edges.length, risk_summary: graph.stats.severity_counts },
+      ]),
+    });
+  });
+  await page.route("**/v1/graph/diff?**", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ nodes_added: [], nodes_removed: [], nodes_changed: [], edges_added: [], edges_removed: [] }),
+    });
+  });
+  await page.route("**/v1/graph/search?**", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        query: "large-package-42",
+        results: [root],
+        pagination: { total: 1, offset: 0, limit: 16, has_more: false },
+      }),
+    });
+  });
+  await page.route("**/v1/graph/query", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        scan_id: scanId,
+        tenant_id: "default",
+        created_at: createdAt,
+        nodes: focusedNodes,
+        edges: focusedEdges,
+        attack_paths: [],
+        interaction_risks: [],
+        stats: {
+          total_nodes: focusedNodes.length,
+          total_edges: focusedEdges.length,
+          node_types: { agent: 1, package: 3 },
+          severity_counts: { high: focusedNodes.length },
+          relationship_types: { uses: 1, depends_on: 2 },
+          attack_path_count: 0,
+          interaction_risk_count: 0,
+          max_attack_path_risk: 0,
+          highest_interaction_risk: 0,
+        },
+        roots: ["pkg:42"],
+        direction: "both",
+        max_depth: 4,
+        max_nodes: 800,
+        max_edges: 8000,
+        timeout_ms: 2500,
+        budget: {},
+        depth_by_node: { "pkg:42": 0, "pkg:41": 1, "pkg:43": 1, "agent:large": 2 },
+        truncated: false,
+      }),
+    });
+  });
+  await page.route("**/v1/graph?**", async (route) => {
+    await route.fulfill({ contentType: "application/json", body: JSON.stringify(graph) });
+  });
+}
+
+async function expectCanvasHasPixels(page: Page) {
+  const canvas = page.getByTestId("large-graph-overview-canvas");
+  await expect(canvas).toBeVisible();
+  await page.waitForFunction(() => {
+    const canvas = document.querySelector<HTMLCanvasElement>('[data-testid="large-graph-overview-canvas"]');
+    return Boolean(canvas && canvas.width > 1 && canvas.height > 1);
+  });
+  const coloredSamples = await canvas.evaluate((element) => {
+    const canvasElement = element as HTMLCanvasElement;
+    const context = canvasElement.getContext("2d");
+    if (!context) return 0;
+    const { width, height } = canvasElement;
+    const pixels = context.getImageData(0, 0, width, height).data;
+    let count = 0;
+    for (let index = 0; index < pixels.length; index += 400) {
+      const red = pixels[index] ?? 0;
+      const green = pixels[index + 1] ?? 0;
+      const blue = pixels[index + 2] ?? 0;
+      if (red + green + blue > 40) count += 1;
+    }
+    return count;
+  });
+  expect(coloredSamples).toBeGreaterThan(20);
+}
+
+test("large graph overview renders above threshold and search drills back into React Flow", async ({ page }, testInfo: TestInfo) => {
+  await routeLargeGraphPage(page);
+
+  await page.goto("/graph?vulnOnly=0&severity=&depth=3&pageSize=500&layers=agent,package");
+  await page.waitForLoadState("networkidle");
+  await page.locator("select").nth(2).selectOption("");
+  await page.getByLabel("Vulnerable only").uncheck();
+
+  await expect(page.getByTestId("large-graph-overview")).toBeVisible();
+  await expect(page.getByText("Switches on at 500 nodes or 1,200 edges.")).toBeVisible();
+  await expect(page.getByText("React Flow-only affordances")).toBeVisible();
+  await expectCanvasHasPixels(page);
+  await page.screenshot({ path: testInfo.outputPath("large-graph-overview.png"), fullPage: true });
+
+  await page.getByPlaceholder("Search nodes, tags, severities, or attributes").fill("large-package-42");
+  await page.getByRole("button", { name: "Search", exact: true }).click();
+  await page.getByRole("button", { name: "large-package-42" }).click();
+
+  await expect(page.getByText("Root-centered investigation:")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "large-package-42" })).toBeVisible();
+  await expect(page.getByTestId("large-graph-overview")).toHaveCount(0);
+});

--- a/ui/lib/large-graph-overview.ts
+++ b/ui/lib/large-graph-overview.ts
@@ -6,6 +6,8 @@ import { RELATIONSHIP_COLOR_MAP } from "@/lib/graph-schema";
 
 export const LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD = 500;
 export const LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD = 1200;
+export const LARGE_GRAPH_OVERVIEW_MAX_RENDERED_NODES = 3000;
+export const LARGE_GRAPH_OVERVIEW_MAX_RENDERED_EDGES = 6000;
 
 export interface LargeGraphOverviewDecision {
   nodeCount: number;
@@ -44,6 +46,10 @@ export interface LargeGraphOverviewModel {
   nodes: LargeGraphNode[];
   edges: LargeGraphEdge[];
   nodeById: Map<string, LargeGraphNode>;
+  sourceNodeCount: number;
+  sourceEdgeCount: number;
+  omittedNodeCount: number;
+  omittedEdgeCount: number;
 }
 
 export interface LargeGraphOverviewSummary {
@@ -124,6 +130,31 @@ function edgeSize(edge: Edge): number {
   return edgeRelationship(edge) === "vulnerable_to" ? 1.4 : 0.8;
 }
 
+function nodeSignalScore(node: Node<LineageNodeData>, index: number): number {
+  const data = node.data;
+  let score = 0;
+  const severity = severityRank(data.severity);
+  if (data.highlighted === true) score += 1_000_000;
+  if (data.nodeType === "agent" || data.nodeType === "server" || data.nodeType === "sharedServer") score += 800_000;
+  if (data.nodeType === "credential" || data.nodeType === "tool") score += 500_000;
+  if (data.nodeType === "vulnerability" || data.nodeType === "misconfiguration") score += 350_000 + severity * 20_000;
+  if (typeof data.riskScore === "number" && Number.isFinite(data.riskScore)) score += Math.min(100, Math.max(0, data.riskScore)) * 100;
+  return score - index / 10_000;
+}
+
+function edgeSignalScore(edge: Edge, nodeById: Map<string, LargeGraphNode>, index: number): number {
+  const relationship = edgeRelationship(edge);
+  let score = 0;
+  if (relationship === "vulnerable_to") score += 500_000;
+  if (relationship === "exposes_cred" || relationship === "reaches_tool") score += 450_000;
+  if (relationship === "uses" || relationship === "depends_on") score += 150_000;
+  const source = nodeById.get(edge.source);
+  const target = nodeById.get(edge.target);
+  if (source?.highlighted || target?.highlighted) score += 750_000;
+  if (source?.forceLabel || target?.forceLabel) score += 200_000;
+  return score - index / 10_000;
+}
+
 export function summarizeLargeGraphOverview(
   nodes: Node<LineageNodeData>[],
   edges: Edge[],
@@ -156,7 +187,12 @@ export function buildLargeGraphOverviewModel(
   edges: Edge[],
 ): LargeGraphOverviewModel {
   const total = Math.max(nodes.length, 1);
-  const overviewNodes: LargeGraphNode[] = nodes.map((node, index) => {
+  const rankedNodes = nodes
+    .map((node, index) => ({ node, index, score: nodeSignalScore(node, index) }))
+    .sort((left, right) => right.score - left.score)
+    .slice(0, LARGE_GRAPH_OVERVIEW_MAX_RENDERED_NODES)
+    .sort((left, right) => left.index - right.index);
+  const overviewNodes: LargeGraphNode[] = rankedNodes.map(({ node, index }) => {
     const fallback = fallbackPosition(index, total);
     const data = node.data;
     const x = numericPosition(node.position?.x) ?? fallback.x;
@@ -182,25 +218,32 @@ export function buildLargeGraphOverviewModel(
     };
   });
   const nodeById = new Map(overviewNodes.map((node) => [node.id, node]));
-  const overviewEdges: LargeGraphEdge[] = edges.flatMap((edge, index) => {
-    if (!nodeById.has(edge.source) || !nodeById.has(edge.target)) return [];
+  const drawableEdges = edges
+    .map((edge, index) => ({ edge, index, score: edgeSignalScore(edge, nodeById, index) }))
+    .filter(({ edge }) => nodeById.has(edge.source) && nodeById.has(edge.target))
+    .sort((left, right) => right.score - left.score)
+    .slice(0, LARGE_GRAPH_OVERVIEW_MAX_RENDERED_EDGES)
+    .sort((left, right) => left.index - right.index);
+  const overviewEdges: LargeGraphEdge[] = drawableEdges.map(({ edge, index }) => {
     const relationship = edgeRelationship(edge);
-    return [
-      {
-        id: edge.id || `${edge.source}:${edge.target}:${relationship}:${index}`,
-        source: edge.source,
-        target: edge.target,
-        relationship,
-        color: RELATIONSHIP_COLOR_MAP[relationship] ?? "#52525b",
-        size: edgeSize(edge),
-        hidden: edge.hidden === true,
-      },
-    ];
+    return {
+      id: edge.id || `${edge.source}:${edge.target}:${relationship}:${index}`,
+      source: edge.source,
+      target: edge.target,
+      relationship,
+      color: RELATIONSHIP_COLOR_MAP[relationship] ?? "#52525b",
+      size: edgeSize(edge),
+      hidden: edge.hidden === true,
+    };
   });
 
   return {
     nodes: overviewNodes,
     edges: overviewEdges,
     nodeById,
+    sourceNodeCount: nodes.length,
+    sourceEdgeCount: edges.length,
+    omittedNodeCount: Math.max(0, nodes.length - overviewNodes.length),
+    omittedEdgeCount: Math.max(0, edges.length - overviewEdges.length),
   };
 }

--- a/ui/tests/large-graph-overview.test.ts
+++ b/ui/tests/large-graph-overview.test.ts
@@ -5,6 +5,8 @@ import type { LineageNodeData } from "@/components/lineage-nodes";
 import {
   buildLargeGraphOverviewModel,
   LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD,
+  LARGE_GRAPH_OVERVIEW_MAX_RENDERED_EDGES,
+  LARGE_GRAPH_OVERVIEW_MAX_RENDERED_NODES,
   LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD,
   shouldUseLargeGraphOverview,
   summarizeLargeGraphOverview,
@@ -91,6 +93,33 @@ describe("large graph overview", () => {
     );
     expect(model.edges.find((entry) => entry.id === "pkg-cve")?.relationship).toBe("vulnerable_to");
     expect(model.edges.some((entry) => entry.id === "missing")).toBe(false);
+    expect(model.omittedNodeCount).toBe(0);
+    expect(model.omittedEdgeCount).toBe(1);
+  });
+
+  it("keeps a deterministic high-signal draw budget for oversized pages", () => {
+    const nodes: Node<LineageNodeData>[] = [
+      node("agent-a", { nodeType: "agent" }),
+      node("critical-a", { nodeType: "vulnerability", severity: "critical" }),
+    ];
+    for (let index = 0; index < LARGE_GRAPH_OVERVIEW_MAX_RENDERED_NODES + 50; index += 1) {
+      nodes.push(node(`pkg-${index}`, { nodeType: "package", riskScore: index % 11 }));
+    }
+
+    const edges: Edge[] = [];
+    for (let index = 0; index < LARGE_GRAPH_OVERVIEW_MAX_RENDERED_EDGES + 100; index += 1) {
+      edges.push(edge(`e-${index}`, "agent-a", "critical-a", index === 3 ? "exposes_cred" : "depends_on"));
+    }
+
+    const model = buildLargeGraphOverviewModel(nodes, edges);
+
+    expect(model.nodes).toHaveLength(LARGE_GRAPH_OVERVIEW_MAX_RENDERED_NODES);
+    expect(model.edges).toHaveLength(LARGE_GRAPH_OVERVIEW_MAX_RENDERED_EDGES);
+    expect(model.omittedNodeCount).toBe(52);
+    expect(model.omittedEdgeCount).toBe(100);
+    expect(model.nodeById.has("agent-a")).toBe(true);
+    expect(model.nodeById.has("critical-a")).toBe(true);
+    expect(model.edges.some((entry) => entry.relationship === "exposes_cred")).toBe(true);
   });
 
   it("summarizes findings and dominant relationship families for the graph header", () => {


### PR DESCRIPTION
## Summary

Hardens the large graph rendering fallback so broad graph pages stay responsive while bounded investigations continue to use React Flow.

## Changes

- Documents the large-mode switch threshold at 500 visible nodes or 1,200 visible edges.
- Adds a deterministic 2D canvas overview budget of 3,000 high-signal nodes and 6,000 high-signal edges.
- Keeps search, filters, selected-node detail, and reachability drill-in server-backed from the same graph page.
- Documents intentional large-mode limits and the path back to React Flow through narrowing, search, attack-path focus, or drill-in.
- Adds unit and Playwright coverage for threshold switching, nonblank canvas rendering, screenshot capture, and search-driven drill-in back to React Flow.

## Validation

- `npm test -- --run tests/large-graph-overview.test.ts`
- `npm run typecheck`
- `npm run test:e2e -- large-graph-overview.spec.ts`
- `git diff --check`

Fixes #2490
