### PR TITLE
Add graph renderer switch contract

### DIFF
--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -89,8 +89,8 @@ import { buildUnifiedFlowGraph } from "@/lib/unified-graph-flow";
 import {
   LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD,
   LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD,
-  shouldUseLargeGraphOverview,
 } from "@/lib/large-graph-overview";
+import { decideGraphRenderer } from "@/lib/graph-renderer-switch";
 import {
   applyFilters,
   decodeFiltersFromParams,
@@ -1063,7 +1063,7 @@ function GraphPageInner() {
   );
 
   const graphOnlyFindings = displayNodes.length > 0 && !hasContextualGraph;
-  const useLargeGraphOverview = shouldUseLargeGraphOverview({
+  const graphRenderer = decideGraphRenderer({
     nodeCount: displayNodes.length,
     edgeCount: displayEdges.length,
     captureMode,
@@ -1796,7 +1796,7 @@ function GraphPageInner() {
                 setFilters(createExpandedGraphFilters(filters.agentName ?? flow.agentNames[0] ?? null))
               }
             />
-          ) : useLargeGraphOverview ? (
+          ) : graphRenderer.kind === "large-overview" ? (
             <LargeGraphOverview
               nodes={displayNodes}
               edges={displayEdges}

--- a/ui/lib/graph-renderer-switch.ts
+++ b/ui/lib/graph-renderer-switch.ts
@@ -1,0 +1,93 @@
+import {
+  LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD,
+  LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD,
+} from "@/lib/large-graph-overview";
+
+export type GraphRendererKind = "react-flow" | "large-overview" | "webgl";
+
+export interface GraphRendererDecisionInput {
+  nodeCount: number;
+  edgeCount: number;
+  captureMode?: boolean | undefined;
+  selectedAttackPath?: boolean | undefined;
+  reachabilityActive?: boolean | undefined;
+  graphOnlyFindings?: boolean | undefined;
+  webglEnabled?: boolean | undefined;
+}
+
+export interface GraphRendererDecision {
+  kind: GraphRendererKind;
+  reason: string;
+  interactive: boolean;
+  supportsInvestigation: boolean;
+}
+
+export function decideGraphRenderer({
+  nodeCount,
+  edgeCount,
+  captureMode = false,
+  selectedAttackPath = false,
+  reachabilityActive = false,
+  graphOnlyFindings = false,
+  webglEnabled = false,
+}: GraphRendererDecisionInput): GraphRendererDecision {
+  if (captureMode) {
+    return {
+      kind: "react-flow",
+      reason: "capture-mode",
+      interactive: true,
+      supportsInvestigation: true,
+    };
+  }
+  if (selectedAttackPath) {
+    return {
+      kind: "react-flow",
+      reason: "attack-path-focus",
+      interactive: true,
+      supportsInvestigation: true,
+    };
+  }
+  if (reachabilityActive) {
+    return {
+      kind: "react-flow",
+      reason: "reachability-drill-in",
+      interactive: true,
+      supportsInvestigation: true,
+    };
+  }
+  if (graphOnlyFindings) {
+    return {
+      kind: "react-flow",
+      reason: "findings-only-fallback",
+      interactive: true,
+      supportsInvestigation: true,
+    };
+  }
+
+  const broadGraph =
+    nodeCount >= LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD ||
+    edgeCount >= LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD;
+  if (broadGraph && webglEnabled) {
+    return {
+      kind: "webgl",
+      reason: "large-graph-webgl-enabled",
+      interactive: true,
+      supportsInvestigation: false,
+    };
+  }
+  if (broadGraph) {
+    return {
+      kind: "large-overview",
+      reason: "large-graph-overview-threshold",
+      interactive: true,
+      supportsInvestigation: false,
+    };
+  }
+
+  return {
+    kind: "react-flow",
+    reason: "focused-interactive-graph",
+    interactive: true,
+    supportsInvestigation: true,
+  };
+}

--- a/ui/tests/graph-renderer-switch.test.ts
+++ b/ui/tests/graph-renderer-switch.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { decideGraphRenderer } from "@/lib/graph-renderer-switch";
+import {
+  LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD,
+  LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD,
+} from "@/lib/large-graph-overview";
+
+describe("graph renderer switch", () => {
+  it("keeps focused investigation modes on React Flow", () => {
+    const broadGraph = {
+      nodeCount: LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD + 10,
+      edgeCount: LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD + 10,
+    };
+
+    expect(decideGraphRenderer({ ...broadGraph, captureMode: true })).toMatchObject({
+      kind: "react-flow",
+      reason: "capture-mode",
+      supportsInvestigation: true,
+    });
+    expect(decideGraphRenderer({ ...broadGraph, selectedAttackPath: true })).toMatchObject({
+      kind: "react-flow",
+      reason: "attack-path-focus",
+      supportsInvestigation: true,
+    });
+    expect(decideGraphRenderer({ ...broadGraph, reachabilityActive: true })).toMatchObject({
+      kind: "react-flow",
+      reason: "reachability-drill-in",
+      supportsInvestigation: true,
+    });
+    expect(decideGraphRenderer({ ...broadGraph, graphOnlyFindings: true })).toMatchObject({
+      kind: "react-flow",
+      reason: "findings-only-fallback",
+      supportsInvestigation: true,
+    });
+  });
+
+  it("preserves the existing large graph overview thresholds", () => {
+    expect(
+      decideGraphRenderer({
+        nodeCount: LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD,
+        edgeCount: 20,
+      }),
+    ).toMatchObject({
+      kind: "large-overview",
+      reason: "large-graph-overview-threshold",
+      supportsInvestigation: false,
+    });
+
+    expect(
+      decideGraphRenderer({
+        nodeCount: 20,
+        edgeCount: LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD,
+      }),
+    ).toMatchObject({
+      kind: "large-overview",
+      reason: "large-graph-overview-threshold",
+      supportsInvestigation: false,
+    });
+  });
+
+  it("keeps WebGL behind an explicit future switch", () => {
+    expect(
+      decideGraphRenderer({
+        nodeCount: LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD + 1,
+        edgeCount: LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD + 1,
+      }),
+    ).toMatchObject({ kind: "large-overview" });
+
+    expect(
+      decideGraphRenderer({
+        nodeCount: LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD + 1,
+        edgeCount: LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD + 1,
+        webglEnabled: true,
+      }),
+    ).toMatchObject({
+      kind: "webgl",
+      reason: "large-graph-webgl-enabled",
+      supportsInvestigation: false,
+    });
+  });
+
+  it("uses React Flow for normal-sized interactive graphs", () => {
+    expect(decideGraphRenderer({ nodeCount: 42, edgeCount: 84 })).toMatchObject({
+      kind: "react-flow",
+      reason: "focused-interactive-graph",
+      interactive: true,
+      supportsInvestigation: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- adds a pure graph renderer decision contract for React Flow, the existing large canvas overview, and a disabled future WebGL slot
- wires `/graph` through that contract instead of the inline large-overview boolean
- adds regression coverage for focused investigation modes, current large-graph thresholds, and the explicit WebGL gate

Closes #2548.

## Verification

- `cd ui && npm ci --ignore-scripts`
- `cd ui && npm test -- --run tests/large-graph-overview.test.ts tests/graph-renderer-switch.test.ts`
- `cd ui && npm run typecheck`
- `cd ui && npm run lint -- app/graph/graph-page-client.tsx lib/graph-renderer-switch.ts tests/graph-renderer-switch.test.ts`
- `git diff --check`

## Notes

- `cd ui && npm run verify:toolchain` was attempted, but this shell is on Node `25.9.0`; the repository requires `>=22 <25`, so the toolchain guard correctly rejects the local runtime.
- This PR does not add Sigma.js, graphology, or WebGL rendering. It creates the switch point for that follow-up.
