### PR TITLE
Add semantic graph cluster API

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -10,6 +10,7 @@ Endpoints:
   GET  /v1/graph/impact         — blast radius of a node (reverse BFS)
   GET  /v1/graph/search         — full-text graph search
   GET  /v1/graph/agents         — paginated agent node selector
+  GET  /v1/graph/clusters       — semantic cluster rollups
   POST /v1/graph/query          — programmable traversal query
   GET  /v1/graph/node/{id}      — single node detail with edges + impact
   GET  /v1/graph/snapshots      — list persisted scan snapshots
@@ -35,6 +36,7 @@ from pydantic import BaseModel, Field
 from agent_bom.api.stores import _get_graph_store
 from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
 from agent_bom.graph import SEVERITY_RANK, AttackPath, EntityType, GraphFilterOptions, GraphSemanticLayer, RelationshipType, UnifiedGraph
+from agent_bom.graph.semantic_clusters import SEMANTIC_CLUSTER_KINDS, build_semantic_clusters, semantic_cluster_stats
 from agent_bom.security import sanitize_error
 
 logger = logging.getLogger(__name__)
@@ -1282,6 +1284,52 @@ async def search_graph(
             "next_cursor": next_cursor or "",
             "has_more": bool(next_cursor) if cursor else offset + limit < total,
         },
+    }
+
+
+@router.get("/v1/graph/clusters", tags=["graph"])
+async def get_graph_clusters(
+    request: Request,
+    scan_id: Optional[str] = Query(None, description="Scan snapshot ID; latest if omitted"),
+    kinds: Optional[str] = Query(None, description="Comma-separated semantic cluster kinds"),
+    min_members: int = Query(2, ge=1, le=100, description="Minimum members required to emit a cluster"),
+    limit: int = Query(250, ge=1, le=1000, description="Maximum clusters to return"),
+) -> dict:
+    """Return API-backed semantic clusters for graph readability.
+
+    The response is intentionally reversible: each cluster carries member IDs
+    and expansion metadata so the dashboard can collapse and expand topology
+    without deriving families client-side.
+    """
+
+    tenant = _tenant(request)
+    graph_store = _get_graph_store_or_503()
+    requested_scan_id = scan_id or ""
+    if not requested_scan_id and not await _graph_store_call(graph_store.latest_snapshot_id, tenant_id=tenant):
+        raise HTTPException(status_code=503, detail="Graph snapshots not found. Run a scan first.")
+
+    selected_kinds = {kind.strip() for kind in kinds.split(",") if kind.strip()} if kinds else set(SEMANTIC_CLUSTER_KINDS)
+    unknown_kinds = selected_kinds - set(SEMANTIC_CLUSTER_KINDS)
+    if unknown_kinds:
+        raise HTTPException(status_code=400, detail=f"Unknown semantic cluster kind(s): {', '.join(sorted(unknown_kinds))}")
+
+    graph = await _graph_store_call(
+        graph_store.load_graph,
+        scan_id=requested_scan_id,
+        tenant_id=tenant,
+    )
+    clusters = [
+        cluster
+        for cluster in build_semantic_clusters(graph.nodes.values(), graph.edges, min_members=min_members)
+        if cluster.kind in selected_kinds
+    ][:limit]
+    return {
+        "scan_id": graph.scan_id,
+        "tenant_id": graph.tenant_id,
+        "created_at": graph.created_at,
+        "clusters": [cluster.to_dict() for cluster in clusters],
+        "stats": semantic_cluster_stats(clusters),
+        "available_kinds": list(SEMANTIC_CLUSTER_KINDS),
     }
 
 

--- a/src/agent_bom/graph/__init__.py
+++ b/src/agent_bom/graph/__init__.py
@@ -25,6 +25,7 @@ from agent_bom.graph.dependency_reach import (
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import NodeDimensions, UnifiedNode, stable_node_id
 from agent_bom.graph.ocsf import ENTITY_OCSF_MAP, FINDING_ENTITY_TYPES, ocsf_type_uid
+from agent_bom.graph.semantic_clusters import SEMANTIC_CLUSTER_KINDS, SemanticCluster, build_semantic_clusters, semantic_cluster_stats
 from agent_bom.graph.severity import (
     OCSF_SEVERITY_NAMES,
     OCSF_TO_SYSLOG,
@@ -49,6 +50,7 @@ __all__ = [
     "NodeStatus",
     "GraphLayout",
     "OCSFSeverity",
+    "SEMANTIC_CLUSTER_KINDS",
     # Severity
     "SEVERITY_TO_OCSF",
     "OCSF_SEVERITY_NAMES",
@@ -75,8 +77,11 @@ __all__ = [
     "InteractionRisk",
     "GraphFilterOptions",
     "LegendEntry",
+    "SemanticCluster",
     "ENTITY_LEGEND",
     "RELATIONSHIP_LEGEND",
+    "build_semantic_clusters",
+    "semantic_cluster_stats",
     # Compat
     "NODE_KIND_TO_ENTITY",
     "EDGE_KIND_TO_RELATIONSHIP",

--- a/src/agent_bom/graph/semantic_clusters.py
+++ b/src/agent_bom/graph/semantic_clusters.py
@@ -1,0 +1,279 @@
+"""Semantic graph clusters for API-backed graph readability."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.severity import SEVERITY_RANK
+from agent_bom.graph.types import EntityType, RelationshipType
+
+SEMANTIC_CLUSTER_KINDS = (
+    "package_family",
+    "cve_family",
+    "agent_fleet",
+    "server_fleet",
+    "credential_family",
+    "tool_capability",
+    "source_environment",
+)
+
+_RISK_SEVERITY = (
+    (90.0, "critical"),
+    (70.0, "high"),
+    (40.0, "medium"),
+    (1.0, "low"),
+)
+
+
+@dataclass(slots=True)
+class SemanticClusterExpansion:
+    mode: str = "members"
+    member_ids: list[str] = field(default_factory=list)
+    collapse_id: str = ""
+    reversible: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "member_ids": self.member_ids,
+            "collapse_id": self.collapse_id,
+            "reversible": self.reversible,
+        }
+
+
+@dataclass(slots=True)
+class SemanticCluster:
+    id: str
+    kind: str
+    label: str
+    layer: str
+    entity_types: list[str]
+    count: int
+    member_ids: list[str]
+    max_risk: float
+    severity: str
+    risk_summary: dict[str, int]
+    relationship_counts: dict[str, int]
+    expansion: SemanticClusterExpansion
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "kind": self.kind,
+            "label": self.label,
+            "layer": self.layer,
+            "entity_types": self.entity_types,
+            "count": self.count,
+            "member_ids": self.member_ids,
+            "max_risk": self.max_risk,
+            "severity": self.severity,
+            "risk_summary": self.risk_summary,
+            "relationship_counts": self.relationship_counts,
+            "expansion": self.expansion.to_dict(),
+        }
+
+
+def build_semantic_clusters(
+    nodes: Iterable[UnifiedNode],
+    edges: Iterable[UnifiedEdge],
+    *,
+    min_members: int = 2,
+) -> list[SemanticCluster]:
+    """Build reversible semantic clusters from canonical graph nodes.
+
+    The output is intentionally UI-neutral: each cluster includes its members,
+    risk rollup, relationship counts, and reversible expansion metadata. The
+    dashboard can render these clusters without inferring families client-side.
+    """
+
+    node_list = list(nodes)
+    edge_list = list(edges)
+    groups: dict[tuple[str, str, str, str], list[UnifiedNode]] = defaultdict(list)
+    for node in node_list:
+        for kind, layer, key, label in _cluster_keys_for_node(node):
+            groups[(kind, layer, key, label)].append(node)
+
+    clusters: list[SemanticCluster] = []
+    for (kind, layer, key, label), members in groups.items():
+        if len(members) < min_members:
+            continue
+        member_ids = sorted(node.id for node in members)
+        cluster_id = f"cluster:{kind}:{_slug(key)}"
+        clusters.append(
+            SemanticCluster(
+                id=cluster_id,
+                kind=kind,
+                label=label,
+                layer=layer,
+                entity_types=sorted({_entity_value(node.entity_type) for node in members}),
+                count=len(members),
+                member_ids=member_ids,
+                max_risk=_max_risk(members),
+                severity=_cluster_severity(members),
+                risk_summary=_risk_summary(members),
+                relationship_counts=_relationship_counts(edge_list, set(member_ids)),
+                expansion=SemanticClusterExpansion(member_ids=member_ids, collapse_id=cluster_id),
+            )
+        )
+
+    return sorted(clusters, key=lambda cluster: (-cluster.max_risk, -cluster.count, cluster.kind, cluster.label))
+
+
+def semantic_cluster_stats(clusters: Iterable[SemanticCluster]) -> dict[str, int]:
+    cluster_list = list(clusters)
+    member_ids = {member_id for cluster in cluster_list for member_id in cluster.member_ids}
+    by_kind = Counter(cluster.kind for cluster in cluster_list)
+    return {
+        "cluster_count": len(cluster_list),
+        "member_count": len(member_ids),
+        **{f"{kind}_count": by_kind.get(kind, 0) for kind in SEMANTIC_CLUSTER_KINDS},
+    }
+
+
+def _cluster_keys_for_node(node: UnifiedNode) -> list[tuple[str, str, str, str]]:
+    entity_type = _entity_value(node.entity_type)
+    attrs = node.attributes or {}
+    dims = node.dimensions
+    keys: list[tuple[str, str, str, str]] = []
+
+    environment = dims.environment or _string_attr(attrs, "environment", "env", "workspace", "account")
+    source = node.data_sources[0] if node.data_sources else _string_attr(attrs, "source", "provider")
+    if environment or source:
+        env_key = environment or source
+        source_part = f" / {source}" if source and source != env_key else ""
+        keys.append(("source_environment", "infra", f"{env_key}:{source}", f"{env_key}{source_part}"))
+
+    if entity_type == EntityType.PACKAGE.value:
+        ecosystem = dims.ecosystem or _string_attr(attrs, "ecosystem", "package_ecosystem") or "unknown"
+        package_name = _package_name(node)
+        keys.append(("package_family", "package", f"{ecosystem}:{package_name}", f"{ecosystem} / {package_name}"))
+    elif entity_type == EntityType.VULNERABILITY.value:
+        cve_family = _cve_family(node)
+        keys.append(("cve_family", "finding", cve_family, cve_family))
+    elif entity_type == EntityType.AGENT.value:
+        fleet = dims.agent_type or environment or source or _string_attr(attrs, "fleet", "agent_type", "kind") or "agents"
+        keys.append(("agent_fleet", "orchestration", fleet, f"{fleet} agents"))
+    elif entity_type == EntityType.SERVER.value:
+        fleet = dims.surface or environment or source or _string_attr(attrs, "fleet", "server_type", "kind") or "servers"
+        keys.append(("server_fleet", "mcp_server", fleet, f"{fleet} servers"))
+    elif entity_type == EntityType.CREDENTIAL.value:
+        family = _credential_family(node)
+        keys.append(("credential_family", "identity", family, f"{family} credentials"))
+    elif entity_type == EntityType.TOOL.value:
+        capability = _string_attr(attrs, "capability", "category", "tool_type") or _tool_capability(node)
+        keys.append(("tool_capability", "tool", capability, f"{capability} tools"))
+
+    return keys
+
+
+def _string_attr(attrs: dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        value = attrs.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _package_name(node: UnifiedNode) -> str:
+    attrs = node.attributes or {}
+    raw = _string_attr(attrs, "name", "package_name", "package") or node.label or node.id
+    if "@" in raw and not raw.startswith("@"):
+        raw = raw.split("@", 1)[0]
+    return raw.replace("pkg:", "").strip() or "unknown"
+
+
+def _cve_family(node: UnifiedNode) -> str:
+    raw = " ".join([node.id, node.label, *(str(value) for value in (node.attributes or {}).values() if isinstance(value, str))])
+    match = re.search(r"CVE-(\d{4})-", raw, flags=re.IGNORECASE)
+    if match:
+        return f"CVE {match.group(1)}"
+    cwe = re.search(r"CWE-(\d+)", raw, flags=re.IGNORECASE)
+    if cwe:
+        return f"CWE {cwe.group(1)}"
+    return "unclassified findings"
+
+
+def _credential_family(node: UnifiedNode) -> str:
+    attrs = node.attributes or {}
+    provider = _string_attr(attrs, "provider", "cloud_provider", "service")
+    if provider:
+        return provider
+    label = (node.label or node.id).upper()
+    for token in ("AWS", "AZURE", "GCP", "OPENAI", "ANTHROPIC", "GITHUB", "SNOWFLAKE"):
+        if token in label:
+            return token
+    return "generic"
+
+
+def _tool_capability(node: UnifiedNode) -> str:
+    label = (node.label or node.id).lower()
+    if any(token in label for token in ("shell", "exec", "command")):
+        return "execution"
+    if any(token in label for token in ("read", "file", "fs")):
+        return "file access"
+    if any(token in label for token in ("http", "fetch", "web")):
+        return "network access"
+    return "general"
+
+
+def _risk_summary(nodes: Iterable[UnifiedNode]) -> dict[str, int]:
+    summary = {"critical": 0, "high": 0, "medium": 0, "low": 0, "none": 0}
+    for node in nodes:
+        summary[_node_severity(node)] += 1
+    return summary
+
+
+def _cluster_severity(nodes: Iterable[UnifiedNode]) -> str:
+    highest = "none"
+    for node in nodes:
+        severity = _node_severity(node)
+        if SEVERITY_RANK.get(severity, 0) > SEVERITY_RANK.get(highest, 0):
+            highest = severity
+    return highest
+
+
+def _node_severity(node: UnifiedNode) -> str:
+    severity = (node.severity or "").lower()
+    if severity in {"critical", "high", "medium", "low"}:
+        return severity
+    risk = _node_risk_100(node)
+    for threshold, level in _RISK_SEVERITY:
+        if risk >= threshold:
+            return level
+    return "none"
+
+
+def _max_risk(nodes: Iterable[UnifiedNode]) -> float:
+    return max((_node_risk_100(node) for node in nodes), default=0.0)
+
+
+def _node_risk_100(node: UnifiedNode) -> float:
+    risk = float(node.risk_score or 0.0)
+    if risk <= 10.0:
+        risk *= 10.0
+    if risk <= 0 and node.severity:
+        risk = float(SEVERITY_RANK.get(node.severity.lower(), 0) * 20)
+    return round(min(100.0, max(0.0, risk)), 3)
+
+
+def _relationship_counts(edges: Iterable[UnifiedEdge], member_ids: set[str]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for edge in edges:
+        if edge.source in member_ids or edge.target in member_ids:
+            relationship = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship)
+            counts[relationship] += 1
+    return dict(sorted(counts.items()))
+
+
+def _entity_value(entity_type: EntityType | str) -> str:
+    return entity_type.value if isinstance(entity_type, EntityType) else str(entity_type)
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "unknown"

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -18,6 +18,7 @@ from agent_bom.db.graph_store import DEFAULT_GRAPH_TENANT_ID, _init_db, active_e
 from agent_bom.graph import (
     AttackPath,
     EntityType,
+    NodeDimensions,
     RelationshipType,
     UnifiedEdge,
     UnifiedGraph,
@@ -1826,6 +1827,115 @@ class TestGraphStoreBackendSelection:
         }
         assert "source_id" in parameter_names
         assert "source" not in parameter_names
+
+    def test_graph_clusters_return_reversible_semantic_rollups(self, recording_graph_store):
+        recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="agent:a",
+                entity_type=EntityType.AGENT,
+                label="agent-a",
+                data_sources=["fleet-sync"],
+                dimensions=NodeDimensions(agent_type="codex", environment="prod"),
+            )
+        )
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="agent:b",
+                entity_type=EntityType.AGENT,
+                label="agent-b",
+                data_sources=["fleet-sync"],
+                dimensions=NodeDimensions(agent_type="codex", environment="prod"),
+            )
+        )
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="server:fs-a",
+                entity_type=EntityType.SERVER,
+                label="mcp-fs-a",
+                dimensions=NodeDimensions(surface="mcp", environment="prod"),
+            )
+        )
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="server:fs-b",
+                entity_type=EntityType.SERVER,
+                label="mcp-fs-b",
+                dimensions=NodeDimensions(surface="mcp", environment="prod"),
+            )
+        )
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="pkg:npm:express@4.18.2",
+                entity_type=EntityType.PACKAGE,
+                label="express@4.18.2",
+                severity="high",
+                risk_score=8.1,
+                attributes={"name": "express", "ecosystem": "npm", "version": "4.18.2"},
+                dimensions=NodeDimensions(ecosystem="npm", environment="prod"),
+            )
+        )
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="pkg:npm:express@4.19.0",
+                entity_type=EntityType.PACKAGE,
+                label="express@4.19.0",
+                severity="critical",
+                risk_score=9.6,
+                attributes={"name": "express", "ecosystem": "npm", "version": "4.19.0"},
+                dimensions=NodeDimensions(ecosystem="npm", environment="prod"),
+            )
+        )
+        recording_graph_store.graph.add_node(
+            UnifiedNode(id="vuln:CVE-2026-1", entity_type=EntityType.VULNERABILITY, label="CVE-2026-1", severity="critical")
+        )
+        recording_graph_store.graph.add_node(
+            UnifiedNode(id="vuln:CVE-2026-2", entity_type=EntityType.VULNERABILITY, label="CVE-2026-2", severity="high")
+        )
+        recording_graph_store.graph.add_edge(UnifiedEdge(source="agent:a", target="server:fs-a", relationship=RelationshipType.USES))
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="server:fs-a", target="pkg:npm:express@4.18.2", relationship=RelationshipType.DEPENDS_ON)
+        )
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="pkg:npm:express@4.18.2", target="vuln:CVE-2026-1", relationship=RelationshipType.VULNERABLE_TO)
+        )
+        client = TestClient(app)
+
+        response = client.get("/v1/graph/clusters", params={"scan_id": "store-scan", "min_members": 2})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["scan_id"] == "store-scan"
+        clusters = {cluster["id"]: cluster for cluster in body["clusters"]}
+        package_cluster = clusters["cluster:package_family:npm-express"]
+        assert package_cluster["kind"] == "package_family"
+        assert package_cluster["label"] == "npm / express"
+        assert package_cluster["count"] == 2
+        assert package_cluster["max_risk"] == 96.0
+        assert package_cluster["severity"] == "critical"
+        assert package_cluster["risk_summary"]["critical"] == 1
+        assert package_cluster["relationship_counts"]["depends_on"] == 1
+        assert package_cluster["relationship_counts"]["vulnerable_to"] == 1
+        assert package_cluster["expansion"] == {
+            "mode": "members",
+            "member_ids": ["pkg:npm:express@4.18.2", "pkg:npm:express@4.19.0"],
+            "collapse_id": "cluster:package_family:npm-express",
+            "reversible": True,
+        }
+        assert clusters["cluster:cve_family:cve-2026"]["member_ids"] == ["vuln:CVE-2026-1", "vuln:CVE-2026-2"]
+        assert clusters["cluster:agent_fleet:codex"]["layer"] == "orchestration"
+        assert body["stats"]["cluster_count"] >= 4
+        assert body["stats"]["package_family_count"] == 1
+        assert "source_environment" in body["available_kinds"]
+        assert any(call[0] == "load_graph" for call in recording_graph_store.calls)
+
+    def test_graph_clusters_reject_unknown_kind(self, recording_graph_store):
+        client = TestClient(app)
+
+        response = client.get("/v1/graph/clusters", params={"kinds": "package_family,nope"})
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Unknown semantic cluster kind(s): nope"
 
     def test_graph_impact_uses_store_native_traversal(self, recording_graph_store):
         recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -1221,3 +1221,41 @@ class TestGraphSchemaEndpoint:
         assert new_entry["layer"] == "asset"
         # Silence flake8 for the unused alias — kept for future legend tests.
         assert _container is not None
+
+
+def test_semantic_clusters_are_reversible_api_contract():
+    from agent_bom.graph import EntityType, NodeDimensions, RelationshipType, UnifiedEdge, UnifiedNode
+    from agent_bom.graph.semantic_clusters import build_semantic_clusters, semantic_cluster_stats
+
+    nodes = [
+        UnifiedNode(
+            id="pkg:npm:express@4.18.2",
+            entity_type=EntityType.PACKAGE,
+            label="express@4.18.2",
+            severity="high",
+            attributes={"name": "express", "ecosystem": "npm"},
+            dimensions=NodeDimensions(ecosystem="npm"),
+        ),
+        UnifiedNode(
+            id="pkg:npm:express@4.19.0",
+            entity_type=EntityType.PACKAGE,
+            label="express@4.19.0",
+            severity="critical",
+            attributes={"name": "express", "ecosystem": "npm"},
+            dimensions=NodeDimensions(ecosystem="npm"),
+        ),
+        UnifiedNode(id="vuln:CVE-2026-1", entity_type=EntityType.VULNERABILITY, label="CVE-2026-1"),
+    ]
+    edges = [UnifiedEdge(source="pkg:npm:express@4.18.2", target="vuln:CVE-2026-1", relationship=RelationshipType.VULNERABLE_TO)]
+
+    clusters = build_semantic_clusters(nodes, edges, min_members=2)
+
+    assert len(clusters) == 1
+    cluster = clusters[0].to_dict()
+    assert cluster["id"] == "cluster:package_family:npm-express"
+    assert cluster["entity_types"] == ["package"]
+    assert cluster["member_ids"] == ["pkg:npm:express@4.18.2", "pkg:npm:express@4.19.0"]
+    assert cluster["expansion"]["collapse_id"] == cluster["id"]
+    assert cluster["expansion"]["reversible"] is True
+    assert cluster["relationship_counts"] == {"vulnerable_to": 1}
+    assert semantic_cluster_stats(clusters)["member_count"] == 2

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -218,6 +218,46 @@ export interface GraphSearchResponse {
   pagination: GraphPagination;
 }
 
+export type GraphSemanticClusterKind =
+  | "package_family"
+  | "cve_family"
+  | "agent_fleet"
+  | "server_fleet"
+  | "credential_family"
+  | "tool_capability"
+  | "source_environment";
+
+export interface GraphSemanticClusterExpansion {
+  mode: "members" | string;
+  member_ids: string[];
+  collapse_id: string;
+  reversible: boolean;
+}
+
+export interface GraphSemanticCluster {
+  id: string;
+  kind: GraphSemanticClusterKind;
+  label: string;
+  layer: string;
+  entity_types: string[];
+  count: number;
+  member_ids: string[];
+  max_risk: number;
+  severity: "critical" | "high" | "medium" | "low" | "none" | string;
+  risk_summary: Record<string, number>;
+  relationship_counts: Record<string, number>;
+  expansion: GraphSemanticClusterExpansion;
+}
+
+export interface GraphSemanticClustersResponse {
+  scan_id: string;
+  tenant_id: string;
+  created_at: string;
+  clusters: GraphSemanticCluster[];
+  stats: Record<string, number>;
+  available_kinds: GraphSemanticClusterKind[];
+}
+
 export interface GraphAgentSelectorItem {
   id: string;
   label: string;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -17,6 +17,7 @@ import type {
   GraphQueryResponse,
   GraphNodeDetailResponse,
   GraphSearchResponse,
+  GraphSemanticClustersResponse,
   GraphAgentsResponse,
   GraphDiffResponse,
   GraphExportFormat,
@@ -102,6 +103,10 @@ export type {
   GraphImpactResponse,
   GraphNodeDetailResponse,
   GraphSearchResponse,
+  GraphSemanticClusterKind,
+  GraphSemanticClusterExpansion,
+  GraphSemanticCluster,
+  GraphSemanticClustersResponse,
   GraphAgentSelectorItem,
   GraphAgentsResponse,
   GraphDiffResponse,
@@ -565,6 +570,22 @@ export const api = {
     if (filters?.limit != null) params.set("limit", String(filters.limit));
     if (filters?.cursor) params.set("cursor", filters.cursor);
     return get<GraphSearchResponse>(`/v1/graph/search?${params.toString()}`);
+  },
+
+  /** Load API-backed semantic graph clusters without client-only inference */
+  getGraphClusters: (filters?: {
+    scanId?: string;
+    kinds?: string[];
+    minMembers?: number;
+    limit?: number;
+  }) => {
+    const params = new URLSearchParams();
+    if (filters?.scanId) params.set("scan_id", filters.scanId);
+    if (filters?.kinds && filters.kinds.length > 0) params.set("kinds", filters.kinds.join(","));
+    if (filters?.minMembers != null) params.set("min_members", String(filters.minMembers));
+    if (filters?.limit != null) params.set("limit", String(filters.limit));
+    const qs = params.toString();
+    return get<GraphSemanticClustersResponse>(`/v1/graph/clusters${qs ? `?${qs}` : ""}`);
   },
 
   /** List agent nodes for large graph selectors without loading the full graph */


### PR DESCRIPTION
## Summary

- adds an API-backed semantic cluster builder for package families, CVE families, agent/server fleets, credential families, tool capabilities, and source environments
- exposes `GET /v1/graph/clusters` with reversible expansion metadata, member IDs, risk summaries, max risk, and relationship counts
- adds TypeScript response contracts and an API client helper so the UI can consume clusters without client-only inference

Closes #2547.

## Verification

- `uv run pytest -q tests/test_graph_api.py tests/test_graph_schema.py`
- `uv run ruff check src/agent_bom/graph/semantic_clusters.py src/agent_bom/graph/__init__.py src/agent_bom/api/routes/graph.py tests/test_graph_api.py tests/test_graph_schema.py`
- `uv run ruff format --check src/agent_bom/graph/semantic_clusters.py src/agent_bom/graph/__init__.py src/agent_bom/api/routes/graph.py tests/test_graph_api.py tests/test_graph_schema.py`
- `uv run mypy src/agent_bom/graph/semantic_clusters.py src/agent_bom/api/routes/graph.py`
- `cd ui && npm ci --ignore-scripts`
- `cd ui && npm run typecheck`
- `cd ui && npm run lint -- lib/api.ts lib/api-types.ts`
- `cd ui && npm run codegen:graph-schema:check` with a local API on `127.0.0.1:8422`
- `curl -i -sS 'http://127.0.0.1:8422/v1/graph/clusters?min_members=1&limit=1'` against a fresh temp graph DB returned the expected 503 when no graph snapshot exists
- `git diff --check`

## Notes

- `cd ui && npm run verify:toolchain` was attempted, but this shell is on Node `25.9.0`; the repository requires `>=22 <25`, so the guard correctly rejects the local runtime.
- This PR is API contract and SDK surface only; it does not add cluster rendering to the graph UI.
