### PR TITLE
Add Sigma WebGL graph overview

### DIFF
--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import dynamic from "next/dynamic";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   Background,
@@ -97,6 +98,19 @@ import {
   encodeFiltersToParams,
 } from "@/lib/filter-algebra";
 import { useCaptureMode } from "@/lib/use-capture-mode";
+
+const SigmaGraphOverview = dynamic(
+  () => import("@/components/sigma-graph-overview").then((mod) => mod.SigmaGraphOverview),
+  {
+    ssr: false,
+    loading: () => (
+      <GraphPanelSkeleton
+        title="Loading WebGL graph"
+        detail="Preparing the Sigma renderer for the broad graph overview."
+      />
+    ),
+  },
+);
 
 function PulseStyles() {
   return (
@@ -1063,6 +1077,8 @@ function GraphPageInner() {
   );
 
   const graphOnlyFindings = displayNodes.length > 0 && !hasContextualGraph;
+  const webglGraphEnabled =
+    searchParams?.get("renderer") === "webgl" || searchParams?.get("webgl") === "1";
   const graphRenderer = decideGraphRenderer({
     nodeCount: displayNodes.length,
     edgeCount: displayEdges.length,
@@ -1070,6 +1086,7 @@ function GraphPageInner() {
     selectedAttackPath: Boolean(selectedAttackPath),
     reachabilityActive: Boolean(reachabilitySummary),
     graphOnlyFindings,
+    webglEnabled: webglGraphEnabled,
   });
   const graphPanelError = error && snapshots.length > 0 ? graphErrorState(error) : null;
   const findingNodes = useMemo(
@@ -1798,6 +1815,13 @@ function GraphPageInner() {
             />
           ) : graphRenderer.kind === "large-overview" ? (
             <LargeGraphOverview
+              nodes={displayNodes}
+              edges={displayEdges}
+              legendItems={legendItems}
+              onNodeSelect={onLargeGraphNodeSelect}
+            />
+          ) : graphRenderer.kind === "webgl" ? (
+            <SigmaGraphOverview
               nodes={displayNodes}
               edges={displayEdges}
               legendItems={legendItems}

--- a/ui/components/sigma-graph-overview.tsx
+++ b/ui/components/sigma-graph-overview.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import type Sigma from "sigma";
+import type { Edge, Node } from "@xyflow/react";
+import { Activity, GitBranch, Layers3, Network, ShieldAlert, Sparkles } from "lucide-react";
+
+import { GraphLegend } from "@/components/graph-chrome";
+import type { LineageNodeData } from "@/components/lineage-nodes";
+import type { LegendItem } from "@/lib/graph-utils";
+import {
+  LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD,
+  LARGE_GRAPH_OVERVIEW_MAX_RENDERED_EDGES,
+  LARGE_GRAPH_OVERVIEW_MAX_RENDERED_NODES,
+  LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD,
+} from "@/lib/large-graph-overview";
+import {
+  buildSigmaGraphOverviewModel,
+  type SigmaEdgeAttributes,
+  type SigmaNodeAttributes,
+} from "@/lib/sigma-graph-overview";
+
+interface SigmaGraphOverviewProps {
+  nodes: Node<LineageNodeData>[];
+  edges: Edge[];
+  legendItems: LegendItem[];
+  onNodeSelect?: (nodeId: string) => void;
+}
+
+function StatPill({
+  icon: Icon,
+  label,
+  value,
+  tone = "zinc",
+}: {
+  icon: typeof Network;
+  label: string;
+  value: string;
+  tone?: "zinc" | "red" | "amber" | "emerald";
+}) {
+  const toneClass = {
+    zinc: "border-zinc-800 bg-zinc-950/70 text-zinc-300",
+    red: "border-red-500/30 bg-red-950/25 text-red-100",
+    amber: "border-amber-500/30 bg-amber-950/25 text-amber-100",
+    emerald: "border-emerald-500/30 bg-emerald-950/25 text-emerald-100",
+  }[tone];
+
+  return (
+    <div className={`flex min-w-0 items-center gap-2 rounded-lg border px-2.5 py-2 ${toneClass}`}>
+      <Icon className="h-4 w-4 shrink-0" />
+      <span className="min-w-0 truncate text-[11px] uppercase tracking-[0.14em] text-zinc-500">{label}</span>
+      <span className="ml-auto shrink-0 font-mono text-sm font-semibold">{value}</span>
+    </div>
+  );
+}
+
+function RelationshipRail({ items }: { items: Array<{ relationship: string; count: number }> }) {
+  if (items.length === 0) return null;
+  return (
+    <div className="flex min-w-0 flex-wrap items-center gap-2">
+      {items.map((item) => (
+        <span
+          key={item.relationship}
+          className="inline-flex items-center gap-1.5 rounded-full border border-zinc-800 bg-zinc-950/75 px-2.5 py-1 text-[11px] text-zinc-300"
+        >
+          <span className="max-w-36 truncate" title={item.relationship}>
+            {item.relationship.replace(/_/g, " ")}
+          </span>
+          <span className="font-mono text-zinc-500">{item.count}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function SigmaGraphOverview({
+  nodes,
+  edges,
+  legendItems,
+  onNodeSelect,
+}: SigmaGraphOverviewProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const rendererRef = useRef<Sigma<SigmaNodeAttributes, SigmaEdgeAttributes> | null>(null);
+  const selectedNodeIdRef = useRef<string | null>(null);
+  const onNodeSelectRef = useRef<SigmaGraphOverviewProps["onNodeSelect"]>(onNodeSelect);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [renderError, setRenderError] = useState<string | null>(null);
+  const model = useMemo(() => buildSigmaGraphOverviewModel(nodes, edges), [nodes, edges]);
+  const isBudgeted = model.overview.omittedNodeCount > 0 || model.overview.omittedEdgeCount > 0;
+
+  useEffect(() => {
+    selectedNodeIdRef.current = selectedNodeId;
+    rendererRef.current?.refresh();
+  }, [selectedNodeId]);
+
+  useEffect(() => {
+    onNodeSelectRef.current = onNodeSelect;
+  }, [onNodeSelect]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    let renderer: Sigma<SigmaNodeAttributes, SigmaEdgeAttributes> | null = null;
+    let alive = true;
+
+    const start = async () => {
+      try {
+        const { default: SigmaRenderer } = await import("sigma");
+        if (!alive || !containerRef.current) return;
+        renderer = new SigmaRenderer(model.graph, container, {
+          allowInvalidContainer: true,
+          autoCenter: true,
+          autoRescale: true,
+          defaultEdgeColor: "#52525b",
+          defaultNodeColor: "#71717a",
+          enableEdgeEvents: false,
+          hideEdgesOnMove: true,
+          hideLabelsOnMove: true,
+          itemSizesReference: "positions",
+          labelColor: { color: "#e4e4e7" },
+          labelDensity: 0.08,
+          labelFont: "Inter, ui-sans-serif, system-ui, sans-serif",
+          labelGridCellSize: 180,
+          labelRenderedSizeThreshold: 8.5,
+          labelSize: 11,
+          minCameraRatio: 0.04,
+          maxCameraRatio: 4,
+          minEdgeThickness: 0.35,
+          renderEdgeLabels: false,
+          renderLabels: true,
+          stagePadding: 36,
+          zIndex: true,
+          nodeReducer: (node, data) => {
+            const selected = selectedNodeIdRef.current === node;
+            const dimmedBySelection = selectedNodeIdRef.current !== null && !selected;
+            return {
+              ...data,
+              color: selected ? "#f8fafc" : data.color,
+              forceLabel: selected || data.forceLabel,
+              hidden: data.hidden,
+              highlighted: selected || data.highlighted,
+              size: selected ? data.size * 1.65 : data.size,
+              zIndex: selected ? 4 : data.zIndex,
+              ...(dimmedBySelection ? { color: "#3f3f46" } : {}),
+            };
+          },
+          edgeReducer: (_edge, data) => {
+            const selected = selectedNodeIdRef.current;
+            const selectedEdge = selected
+              ? model.graph.source(_edge) === selected || model.graph.target(_edge) === selected
+              : false;
+            return {
+              ...data,
+              color: selectedEdge ? data.color : selected ? "#27272a" : data.color,
+              hidden: data.hidden,
+              size: selectedEdge ? data.size * 2.3 : data.size,
+              zIndex: selectedEdge ? 3 : data.zIndex,
+            };
+          },
+        });
+        rendererRef.current = renderer;
+        renderer.on("clickNode", ({ node }) => {
+          setSelectedNodeId(node);
+          onNodeSelectRef.current?.(node);
+        });
+        renderer.on("clickStage", () => {
+          setSelectedNodeId(null);
+        });
+        renderer.getCamera().setState({ ratio: 1.05 });
+        renderer.refresh();
+        setRenderError(null);
+      } catch (error) {
+        if (!alive) return;
+        setRenderError(error instanceof Error ? error.message : "WebGL graph renderer failed to initialize.");
+      }
+    };
+
+    void start();
+
+    return () => {
+      alive = false;
+      renderer?.kill();
+      rendererRef.current = null;
+      container.replaceChildren();
+    };
+  }, [model]);
+
+  return (
+    <div
+      className="flex h-full min-h-[72vh] flex-col overflow-hidden rounded-xl border border-zinc-800 bg-zinc-950 shadow-2xl shadow-black/30"
+      data-testid="sigma-graph-overview"
+    >
+      <div className="border-b border-zinc-800 bg-zinc-950/95 p-3">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <span className="inline-flex shrink-0 items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-950/25 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-200">
+            <Sparkles className="h-3.5 w-3.5" />
+            WebGL graph overview
+          </span>
+          <span className="min-w-0 text-xs text-zinc-500">
+            Sigma.js renderer for broad estate scans; focused investigations still use React Flow.
+          </span>
+        </div>
+        <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-zinc-500">
+          <span>
+            Switches on with renderer=webgl at {LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD.toLocaleString()} nodes or{" "}
+            {LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD.toLocaleString()} edges.
+          </span>
+          <span>
+            Draw budget: {model.overview.nodes.length.toLocaleString()}/{model.overview.sourceNodeCount.toLocaleString()} nodes,{" "}
+            {model.overview.edges.length.toLocaleString()}/{model.overview.sourceEdgeCount.toLocaleString()} edges.
+          </span>
+          {isBudgeted && (
+            <span className="text-amber-300">
+              Lower-signal items are omitted from this overview; use search, filters, or drill-in for exact detail.
+            </span>
+          )}
+        </div>
+        <div className="mt-2">
+          <RelationshipRail items={model.summary.topRelationships} />
+        </div>
+        <div className="mt-3 grid grid-cols-2 gap-2 lg:grid-cols-5">
+          <StatPill icon={Layers3} label="Nodes" value={model.summary.nodes.toLocaleString()} tone="emerald" />
+          <StatPill icon={GitBranch} label="Edges" value={model.summary.edges.toLocaleString()} />
+          <StatPill icon={ShieldAlert} label="Findings" value={model.summary.findings.toLocaleString()} tone="amber" />
+          <StatPill icon={ShieldAlert} label="Critical" value={model.summary.criticalFindings.toLocaleString()} tone="red" />
+          <StatPill icon={Activity} label="Creds/tools" value={`${model.summary.credentials}/${model.summary.tools}`} />
+        </div>
+      </div>
+
+      <div className="relative min-h-0 flex-1 bg-[#050505]">
+        <div
+          ref={containerRef}
+          className="h-full min-h-[58vh] w-full"
+          aria-label="WebGL security graph overview"
+          data-testid="sigma-graph-overview-canvas"
+        />
+        {renderError && (
+          <div className="absolute inset-4 flex items-center justify-center rounded-xl border border-red-500/30 bg-red-950/30 p-4 text-sm text-red-100">
+            WebGL renderer unavailable: {renderError}
+          </div>
+        )}
+        <div className="pointer-events-auto absolute right-3 top-3 max-w-[min(30rem,calc(100vw-2rem))]">
+          <details className="rounded-xl border border-zinc-800 bg-zinc-950/85 p-2 backdrop-blur">
+            <summary className="cursor-pointer list-none text-[10px] uppercase tracking-[0.18em] text-zinc-400 [&::-webkit-details-marker]:hidden">
+              Legend
+            </summary>
+            <div className="mt-2">
+              <GraphLegend items={legendItems} embedded />
+            </div>
+          </details>
+        </div>
+        <div className="pointer-events-none absolute bottom-3 left-3 max-w-[min(34rem,calc(100vw-2rem))] rounded-xl border border-zinc-800 bg-zinc-950/80 px-3 py-2 text-[11px] text-zinc-400 backdrop-blur">
+          WebGL mode supports pan, zoom, node selection, server-side search, filters, and selected-node detail.
+          React Flow-only affordances return after narrowing the graph below{" "}
+          {LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD.toLocaleString()} nodes / {LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD.toLocaleString()} edges
+          or entering a bounded drill-in.
+          <span className="sr-only">
+            Maximum overview draw budget is {LARGE_GRAPH_OVERVIEW_MAX_RENDERED_NODES.toLocaleString()} nodes and{" "}
+            {LARGE_GRAPH_OVERVIEW_MAX_RENDERED_EDGES.toLocaleString()} edges.
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/e2e/large-graph-overview.spec.ts
+++ b/ui/e2e/large-graph-overview.spec.ts
@@ -243,6 +243,26 @@ async function expectCanvasHasPixels(page: Page) {
   expect(coloredSamples).toBeGreaterThan(20);
 }
 
+async function expectSigmaCanvases(page: Page) {
+  const stage = page.getByTestId("sigma-graph-overview-canvas");
+  await expect(stage).toBeVisible();
+  await page.waitForFunction(() => {
+    const container = document.querySelector<HTMLElement>('[data-testid="sigma-graph-overview-canvas"]');
+    if (!container) return false;
+    const canvases = [...container.querySelectorAll("canvas")];
+    return canvases.some((canvas) => canvas.width > 1 && canvas.height > 1);
+  });
+  const canvasSummary = await stage.evaluate((element) => {
+    const canvases = [...element.querySelectorAll("canvas")];
+    return {
+      count: canvases.length,
+      drawable: canvases.filter((canvas) => canvas.width > 1 && canvas.height > 1).length,
+    };
+  });
+  expect(canvasSummary.count).toBeGreaterThan(0);
+  expect(canvasSummary.drawable).toBeGreaterThan(0);
+}
+
 test("large graph overview renders above threshold and search drills back into React Flow", async ({ page }, testInfo: TestInfo) => {
   await routeLargeGraphPage(page);
 
@@ -264,4 +284,19 @@ test("large graph overview renders above threshold and search drills back into R
   await expect(page.getByText("Root-centered investigation:")).toBeVisible();
   await expect(page.getByRole("heading", { name: "large-package-42" })).toBeVisible();
   await expect(page.getByTestId("large-graph-overview")).toHaveCount(0);
+});
+
+test("sigma webgl overview renders when explicitly requested", async ({ page }, testInfo: TestInfo) => {
+  await routeLargeGraphPage(page);
+
+  await page.goto("/graph?renderer=webgl&vulnOnly=0&severity=&depth=3&pageSize=500&layers=agent,package");
+  await page.waitForLoadState("networkidle");
+  await page.locator("select").nth(2).selectOption("");
+  await page.getByLabel("Vulnerable only").uncheck();
+
+  await expect(page.getByTestId("sigma-graph-overview")).toBeVisible();
+  await expect(page.getByText("WebGL graph overview")).toBeVisible();
+  await expect(page.getByText("Sigma.js renderer for broad estate scans")).toBeVisible();
+  await expectSigmaCanvases(page);
+  await page.screenshot({ path: testInfo.outputPath("sigma-webgl-overview.png"), fullPage: true });
 });

--- a/ui/lib/sigma-graph-overview.ts
+++ b/ui/lib/sigma-graph-overview.ts
@@ -1,0 +1,98 @@
+import Graph from "graphology";
+import type { Edge, Node } from "@xyflow/react";
+
+import type { LineageNodeData, LineageNodeType } from "@/components/lineage-nodes";
+import {
+  buildLargeGraphOverviewModel,
+  summarizeLargeGraphOverview,
+  type LargeGraphOverviewModel,
+  type LargeGraphOverviewSummary,
+} from "@/lib/large-graph-overview";
+
+export type SigmaNodeAttributes = {
+  label: string;
+  x: number;
+  y: number;
+  size: number;
+  color: string;
+  nodeType: LineageNodeType;
+  severity?: string | undefined;
+  hidden: boolean;
+  highlighted: boolean;
+  forceLabel: boolean;
+  dimmed: boolean;
+  zIndex: number;
+} & Record<string, unknown>;
+
+export type SigmaEdgeAttributes = {
+  label: string;
+  relationship: string;
+  color: string;
+  size: number;
+  hidden: boolean;
+  highlighted: boolean;
+  zIndex: number;
+} & Record<string, unknown>;
+
+export interface SigmaGraphOverviewModel {
+  graph: Graph<SigmaNodeAttributes, SigmaEdgeAttributes>;
+  overview: LargeGraphOverviewModel;
+  summary: LargeGraphOverviewSummary;
+}
+
+function edgeIsHighlighted(
+  source: { highlighted: boolean; forceLabel: boolean } | undefined,
+  target: { highlighted: boolean; forceLabel: boolean } | undefined,
+): boolean {
+  return Boolean(source?.highlighted || target?.highlighted || source?.forceLabel || target?.forceLabel);
+}
+
+export function buildSigmaGraphOverviewModel(
+  nodes: Node<LineageNodeData>[],
+  edges: Edge[],
+): SigmaGraphOverviewModel {
+  const overview = buildLargeGraphOverviewModel(nodes, edges);
+  const graph = new Graph<SigmaNodeAttributes, SigmaEdgeAttributes>({
+    allowSelfLoops: true,
+    multi: true,
+    type: "directed",
+  });
+
+  for (const node of overview.nodes) {
+    graph.addNode(node.id, {
+      label: node.label,
+      x: node.x,
+      y: node.y,
+      size: node.size,
+      color: node.color,
+      nodeType: node.nodeType,
+      severity: node.severity,
+      hidden: node.hidden,
+      highlighted: node.highlighted,
+      forceLabel: node.forceLabel,
+      dimmed: node.hidden,
+      zIndex: node.highlighted || node.forceLabel ? 2 : 1,
+    });
+  }
+
+  overview.edges.forEach((edge, index) => {
+    const source = overview.nodeById.get(edge.source);
+    const target = overview.nodeById.get(edge.target);
+    const highlighted = edgeIsHighlighted(source, target);
+    graph.addDirectedEdgeWithKey(edge.id, edge.source, edge.target, {
+      label: edge.relationship.replace(/_/g, " "),
+      relationship: edge.relationship,
+      color: edge.color,
+      size: edge.size,
+      hidden: edge.hidden || source?.hidden === true || target?.hidden === true,
+      highlighted,
+      zIndex: highlighted ? 2 : 1 - index / 100_000,
+    });
+  });
+
+  return {
+    graph,
+    overview,
+    summary: summarizeLargeGraphOverview(nodes, edges),
+  };
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12,11 +12,13 @@
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.24",
         "@xyflow/react": "^12.10.2",
+        "graphology": "^0.26.0",
         "lucide-react": "^1.14.0",
         "next": "^16.2.6",
         "react": "19.2.6",
         "react-dom": "19.2.6",
-        "recharts": "^3.8.1"
+        "recharts": "^3.8.1",
+        "sigma": "^3.0.3"
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "^16.2.6",
@@ -5023,6 +5025,15 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -5382,6 +5393,34 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graphology": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/graphology/-/graphology-0.26.0.tgz",
+      "integrity": "sha512-8SSImzgUUYC89Z042s+0r/vMibY7GX/Emz4LDO5e7jYXhuoWfHISPFJYjpRLUSJGq6UQ6xlenvX1p/hJdfXuXg==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.24.0"
+      }
+    },
+    "node_modules/graphology-types": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.8.tgz",
+      "integrity": "sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/graphology-utils": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/graphology-utils/-/graphology-utils-2.5.2.tgz",
+      "integrity": "sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphology-types": ">=0.23.0"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -7793,6 +7832,16 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sigma": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sigma/-/sigma-3.0.3.tgz",
+      "integrity": "sha512-5H0zFlx6/NTQpqBg4Rm569ZOpnBOXMaS25UQThIWMU3XyzI5AhmorK/gnl87BvJBLhQd0tW4C0LIp3enWzMoNw==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0",
+        "graphology-utils": "^2.5.2"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -28,11 +28,13 @@
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.24",
     "@xyflow/react": "^12.10.2",
+    "graphology": "^0.26.0",
     "lucide-react": "^1.14.0",
     "next": "^16.2.6",
     "react": "19.2.6",
     "react-dom": "19.2.6",
-    "recharts": "^3.8.1"
+    "recharts": "^3.8.1",
+    "sigma": "^3.0.3"
   },
   "overrides": {
     "postcss": "8.5.10"

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -7,7 +7,8 @@ const CHUNKS_DIR = path.join(NEXT_DIR, "static", "chunks");
 const BUILD_MANIFEST = path.join(NEXT_DIR, "build-manifest.json");
 
 const BUDGETS = {
-  totalClientJsBytes: 2_700_000,
+  // Includes the opt-in Sigma.js + graphology WebGL overview chunk for dense graphs.
+  totalClientJsBytes: 2_850_000,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };

--- a/ui/tests/sigma-graph-overview.test.ts
+++ b/ui/tests/sigma-graph-overview.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { Edge, Node } from "@xyflow/react";
+
+import type { LineageNodeData } from "@/components/lineage-nodes";
+import { buildSigmaGraphOverviewModel } from "@/lib/sigma-graph-overview";
+
+function node(id: string, data: Partial<LineageNodeData> = {}): Node<LineageNodeData> {
+  return {
+    id,
+    position: { x: data.nodeType === "agent" ? 0 : 100, y: data.nodeType === "agent" ? 0 : 80 },
+    data: {
+      label: id,
+      nodeType: "package",
+      ...data,
+    },
+  };
+}
+
+function edge(id: string, source: string, target: string, relationship = "depends_on"): Edge {
+  return {
+    id,
+    source,
+    target,
+    data: { relationship },
+    style: { strokeWidth: 2 },
+  };
+}
+
+describe("sigma graph overview", () => {
+  it("adapts lineage graph data into a graphology model for Sigma", () => {
+    const model = buildSigmaGraphOverviewModel(
+      [
+        node("agent-a", { nodeType: "agent", label: "analyst-agent" }),
+        node("pkg-a", { nodeType: "package", label: "requests", riskScore: 82 }),
+        node("cve-a", {
+          nodeType: "vulnerability",
+          label: "CVE-2026-0001",
+          severity: "critical",
+          highlighted: true,
+        }),
+      ],
+      [
+        edge("agent-pkg", "agent-a", "pkg-a", "uses"),
+        edge("pkg-cve", "pkg-a", "cve-a", "vulnerable_to"),
+        edge("missing", "pkg-a", "does-not-exist", "depends_on"),
+      ],
+    );
+
+    expect(model.graph.order).toBe(3);
+    expect(model.graph.size).toBe(2);
+    expect(model.graph.getNodeAttribute("agent-a", "forceLabel")).toBe(true);
+    expect(model.graph.getNodeAttribute("cve-a", "highlighted")).toBe(true);
+    expect(model.graph.getNodeAttribute("cve-a", "size")).toBeGreaterThan(
+      model.graph.getNodeAttribute("pkg-a", "size"),
+    );
+    expect(model.graph.getEdgeAttribute("pkg-cve", "relationship")).toBe("vulnerable_to");
+    expect(model.graph.hasEdge("missing")).toBe(false);
+    expect(model.summary.criticalFindings).toBe(1);
+  });
+
+  it("preserves dimmed state and edge highlighting for focused overview data", () => {
+    const model = buildSigmaGraphOverviewModel(
+      [
+        node("agent-a", { nodeType: "agent", highlighted: true }),
+        node("pkg-a", { nodeType: "package" }),
+        node("pkg-b", { nodeType: "package", dimmed: true }),
+      ],
+      [edge("focused", "agent-a", "pkg-a", "uses"), edge("dimmed", "pkg-a", "pkg-b", "depends_on")],
+    );
+
+    expect(model.graph.getNodeAttribute("pkg-b", "hidden")).toBe(true);
+    expect(model.graph.getEdgeAttribute("focused", "highlighted")).toBe(true);
+    expect(model.graph.getEdgeAttribute("dimmed", "hidden")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add an explicit `renderer=webgl` / `webgl=1` opt-in path for broad `/graph` views
- adapt the existing large-graph overview ranking and draw budget into a graphology model for Sigma.js
- add a Sigma WebGL overview panel with pan, zoom, node selection, legend, and budget/relationship summary
- extend the large-graph Playwright fixture to verify the WebGL canvas path and screenshot proof

## Validation
- `npm run typecheck`
- `npm run lint` (passes with the existing `security-graph/page.tsx` hook warning)
- `npm test -- --run tests/sigma-graph-overview.test.ts tests/graph-renderer-switch.test.ts tests/large-graph-overview.test.ts`
- `npx playwright test e2e/large-graph-overview.spec.ts`
- `npm run build`
- `npm run bundle:check`

## Notes
- `npm run verify:toolchain` was attempted locally and failed because this workstation is running Node 25.9.0 while the repo requires `>=22 <25`.
- The total client JS budget is raised narrowly for the opt-in Sigma.js + graphology chunk; largest chunk and shared runtime budgets remain unchanged.
