### PR TITLE
Harden Postgres graph hot path indexes

### DIFF
--- a/deploy/supabase/postgres/alembic/versions/20260513_01_graph_hot_path_indexes.py
+++ b/deploy/supabase/postgres/alembic/versions/20260513_01_graph_hot_path_indexes.py
@@ -1,0 +1,54 @@
+"""Add benchmark-backed indexes for Postgres graph hot paths."""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260513_01"
+down_revision = "20260416_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_pg_graph_nodes_scan_id_cover
+        ON graph_nodes(tenant_id, scan_id, id) INCLUDE (attributes)
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_source_traversable
+        ON graph_edges(tenant_id, scan_id, source_id)
+        WHERE traversable = 1
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_pg_attack_paths_source_risk
+        ON attack_paths(tenant_id, scan_id, source_node, composite_risk DESC, target_node)
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_pg_graph_node_search_trgm
+        ON graph_node_search USING gin (search_text gin_trgm_ops)
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_pg_graph_node_search_lower_trgm
+        ON graph_node_search USING gin (LOWER(search_text) gin_trgm_ops)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_pg_graph_node_search_lower_trgm")
+    op.execute("DROP INDEX IF EXISTS idx_pg_graph_node_search_trgm")
+    op.execute("DROP INDEX IF EXISTS idx_pg_attack_paths_source_risk")
+    op.execute("DROP INDEX IF EXISTS idx_pg_graph_edges_scan_source_traversable")
+    op.execute("DROP INDEX IF EXISTS idx_pg_graph_nodes_scan_id_cover")

--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -31,6 +31,7 @@
 -- ── Extensions ────────────────────────────────────────────────────────────────
 
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
 -- ── Table: teams ──────────────────────────────────────────────────────────────
 -- Central multi-tenant entity. All other tables reference team_id.
@@ -232,6 +233,8 @@ CREATE INDEX IF NOT EXISTS idx_pg_graph_nodes_entity_type ON graph_nodes(entity_
 CREATE INDEX IF NOT EXISTS idx_pg_graph_nodes_scan ON graph_nodes(tenant_id, scan_id);
 CREATE INDEX IF NOT EXISTS idx_pg_graph_nodes_scan_order
     ON graph_nodes(tenant_id, scan_id, severity_id DESC, risk_score DESC, label);
+CREATE INDEX IF NOT EXISTS idx_pg_graph_nodes_scan_id_cover
+    ON graph_nodes(tenant_id, scan_id, id) INCLUDE (attributes);
 
 CREATE TABLE IF NOT EXISTS graph_edges (
     source_id    TEXT NOT NULL,
@@ -252,6 +255,9 @@ CREATE TABLE IF NOT EXISTS graph_edges (
 CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan ON graph_edges(tenant_id, scan_id);
 CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_source ON graph_edges(tenant_id, scan_id, source_id);
 CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_target ON graph_edges(tenant_id, scan_id, target_id);
+CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_source_traversable
+    ON graph_edges(tenant_id, scan_id, source_id)
+    WHERE traversable = 1;
 
 CREATE TABLE IF NOT EXISTS graph_snapshots (
     scan_id      TEXT NOT NULL,
@@ -282,6 +288,8 @@ CREATE TABLE IF NOT EXISTS attack_paths (
 
 CREATE INDEX IF NOT EXISTS idx_pg_attack_paths_scan ON attack_paths(tenant_id, scan_id);
 CREATE INDEX IF NOT EXISTS idx_pg_attack_paths_scan_risk ON attack_paths(tenant_id, scan_id, composite_risk DESC);
+CREATE INDEX IF NOT EXISTS idx_pg_attack_paths_source_risk
+    ON attack_paths(tenant_id, scan_id, source_node, composite_risk DESC, target_node);
 
 CREATE TABLE IF NOT EXISTS interaction_risks (
     pattern           TEXT NOT NULL,
@@ -321,6 +329,10 @@ CREATE INDEX IF NOT EXISTS idx_pg_graph_node_search_scope
     ON graph_node_search(tenant_id, scan_id, entity_type);
 CREATE INDEX IF NOT EXISTS idx_pg_graph_node_search_severity
     ON graph_node_search(tenant_id, scan_id, severity);
+CREATE INDEX IF NOT EXISTS idx_pg_graph_node_search_trgm
+    ON graph_node_search USING gin (search_text gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_pg_graph_node_search_lower_trgm
+    ON graph_node_search USING gin (LOWER(search_text) gin_trgm_ops);
 
 -- ── Tables: OSV Scan Cache ────────────────────────────────────────────────────
 

--- a/docs/perf/graph-api-postgres-benchmark.md
+++ b/docs/perf/graph-api-postgres-benchmark.md
@@ -218,6 +218,22 @@ Top-level Postgres plan times from
 | graph diff nodes | 38.421 ms |
 | bounded traversal edges | 8.903 ms |
 
+## Plan-Driven Hardening
+
+The first follow-up hardening pass targets only query plans supported by the
+checked-in artifacts above:
+
+- node search now queries the already-normalized `graph_node_search.search_text`
+  value directly instead of wrapping it in `LOWER(...)`, so the trigram index is
+  eligible for `%term%` search.
+- the Postgres bootstrap, runtime DDL, and Alembic path include trigram search,
+  source-scoped attack-path ordering, traversable source-edge traversal, and
+  scan/id node-covering indexes.
+- the slowest API timings above are not explained by the database plans alone:
+  attack-path drilldown and bounded traversal show fast single-query plans but
+  much slower API timings. Treat app-side graph hydration/serialization as a
+  separate optimization lane before making production SLO claims.
+
 ## SLOs
 
 No production API/Postgres SLO is declared from this local run. A future SLO

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -164,6 +164,12 @@ class PostgresGraphStore:
             )
             conn.execute(
                 """
+                CREATE INDEX IF NOT EXISTS idx_pg_graph_nodes_scan_id_cover
+                ON graph_nodes(tenant_id, scan_id, id) INCLUDE (attributes)
+                """
+            )
+            conn.execute(
+                """
                 CREATE TABLE IF NOT EXISTS graph_edges (
                     source_id TEXT NOT NULL,
                     target_id TEXT NOT NULL,
@@ -191,6 +197,13 @@ class PostgresGraphStore:
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_source ON graph_edges(tenant_id, scan_id, source_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_target ON graph_edges(tenant_id, scan_id, target_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_valid ON graph_edges(tenant_id, valid_from, valid_to)")
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_source_traversable
+                ON graph_edges(tenant_id, scan_id, source_id)
+                WHERE traversable = 1
+                """
+            )
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS graph_snapshots (
@@ -228,6 +241,12 @@ class PostgresGraphStore:
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_attack_paths_scan ON attack_paths(tenant_id, scan_id)")
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_pg_attack_paths_scan_risk ON attack_paths(tenant_id, scan_id, composite_risk DESC)"
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_pg_attack_paths_source_risk
+                ON attack_paths(tenant_id, scan_id, source_node, composite_risk DESC, target_node)
+                """
             )
             conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS summary TEXT DEFAULT ''")
             conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS tool_exposure TEXT DEFAULT '[]'")
@@ -303,6 +322,12 @@ class PostgresGraphStore:
                     """
                     CREATE INDEX IF NOT EXISTS idx_pg_graph_node_search_trgm
                     ON graph_node_search USING gin (search_text gin_trgm_ops)
+                    """
+                )
+                conn.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_pg_graph_node_search_lower_trgm
+                    ON graph_node_search USING gin (LOWER(search_text) gin_trgm_ops)
                     """
                 )
             except Exception:
@@ -1532,7 +1557,7 @@ class PostgresGraphStore:
             search_where = [
                 "gns.tenant_id = %s",
                 "gns.scan_id = %s",
-                "LOWER(gns.search_text) LIKE %s ESCAPE '\\'",
+                "gns.search_text LIKE %s ESCAPE '\\'",
             ]
             params: list[Any] = [tenant_id, effective_scan_id, f"%{_escape_like_query(query.lower())}%"]
             if entity_types:

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -10,6 +10,7 @@ POSTGRES_DIR = Path(__file__).parent.parent / "deploy" / "supabase" / "postgres"
 ALEMBIC_DIR = POSTGRES_DIR / "alembic"
 VERSIONS_DIR = ALEMBIC_DIR / "versions"
 BASELINE = VERSIONS_DIR / "20260416_01_control_plane_baseline.py"
+GRAPH_HOT_PATH_INDEXES = VERSIONS_DIR / "20260513_01_graph_hot_path_indexes.py"
 BOOTSTRAP = ALEMBIC_DIR / "bootstrap.py"
 
 
@@ -27,6 +28,7 @@ def test_alembic_scaffolding_exists():
     assert BOOTSTRAP.exists()
     assert (ALEMBIC_DIR / "script.py.mako").exists()
     assert BASELINE.exists()
+    assert GRAPH_HOT_PATH_INDEXES.exists()
 
 
 def test_baseline_migration_points_at_bootstrap_sql():
@@ -47,3 +49,18 @@ GRANT CONNECT ON DATABASE agent_bom TO agent_bom_readonly;
     assert "GRANT CONNECT ON DATABASE pilot_customer TO agent_bom_app;" in rewritten
     assert "GRANT CONNECT ON DATABASE pilot_customer TO agent_bom_readonly;" in rewritten
     assert "GRANT CONNECT ON DATABASE agent_bom TO agent_bom_app;" not in rewritten
+
+
+def test_graph_hot_path_index_migration_chains_from_baseline():
+    sql = GRAPH_HOT_PATH_INDEXES.read_text()
+    assert re.search(r'revision\s*=\s*"20260513_01"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260416_01"', sql)
+    for index_name in (
+        "idx_pg_graph_nodes_scan_id_cover",
+        "idx_pg_graph_edges_scan_source_traversable",
+        "idx_pg_attack_paths_source_risk",
+        "idx_pg_graph_node_search_trgm",
+        "idx_pg_graph_node_search_lower_trgm",
+    ):
+        assert index_name in sql
+    assert "CREATE EXTENSION IF NOT EXISTS pg_trgm" in sql

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -465,3 +465,18 @@ def test_all_creates_use_if_not_exists():
 
 def test_extensions_present():
     assert "CREATE EXTENSION IF NOT EXISTS pgcrypto" in SQL
+    assert "CREATE EXTENSION IF NOT EXISTS pg_trgm" in SQL
+
+
+def test_graph_hot_path_indexes_exist():
+    indexes = _indexes()
+    for index_name in (
+        "idx_pg_graph_nodes_scan_id_cover",
+        "idx_pg_graph_edges_scan_source_traversable",
+        "idx_pg_attack_paths_source_risk",
+        "idx_pg_graph_node_search_trgm",
+        "idx_pg_graph_node_search_lower_trgm",
+    ):
+        assert index_name in indexes
+    assert "LOWER(search_text) gin_trgm_ops" in SQL
+    assert "WHERE traversable = 1" in SQL

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1263,9 +1263,14 @@ def test_graph_store_init_adds_query_indexes(mock_pool):
     store = PostgresGraphStore(pool=mock_pool)
     assert store is not None
     assert any("idx_pg_graph_nodes_scan_order" in sql for sql, _ in mock_pool._conn.executed)
+    assert any("idx_pg_graph_nodes_scan_id_cover" in sql for sql, _ in mock_pool._conn.executed)
     assert any("idx_pg_graph_edges_scan_source" in sql for sql, _ in mock_pool._conn.executed)
     assert any("idx_pg_graph_edges_scan_target" in sql for sql, _ in mock_pool._conn.executed)
+    assert any("idx_pg_graph_edges_scan_source_traversable" in sql for sql, _ in mock_pool._conn.executed)
     assert any("idx_pg_attack_paths_scan_risk" in sql for sql, _ in mock_pool._conn.executed)
+    assert any("idx_pg_attack_paths_source_risk" in sql for sql, _ in mock_pool._conn.executed)
+    assert any("idx_pg_graph_node_search_trgm" in sql for sql, _ in mock_pool._conn.executed)
+    assert any("idx_pg_graph_node_search_lower_trgm" in sql for sql, _ in mock_pool._conn.executed)
 
 
 def test_graph_store_init_backfills_empty_tenant_rows(mock_pool):
@@ -1400,6 +1405,9 @@ def test_graph_store_search_applies_local_timeout(mock_pool, monkeypatch):
     store.search_nodes(tenant_id="tenant-alpha", scan_id="scan-search", query="agent", limit=10)
 
     assert ("SELECT set_config('statement_timeout', %s, true)", ("2500",)) in mock_pool._conn.executed
+    search_sql = " ".join(sql for sql, _params in mock_pool._conn.executed if "FROM graph_node_search gns" in sql)
+    assert "gns.search_text LIKE %s" in search_sql
+    assert "LOWER(gns.search_text)" not in search_sql
 
 
 def test_graph_store_search_timeout_is_capped_by_statement_timeout(monkeypatch):


### PR DESCRIPTION
## Summary
- add Postgres graph hot-path indexes for node search, source-risk attack paths, traversable source edges, and scan/node lookups
- add Alembic migration coverage plus baseline SQL checks so fresh installs and migrated installs stay aligned
- tighten the graph node search query to use the normalized search text index path
- document the index-backed benchmark lane without claiming live API/Postgres latency evidence from this PR alone

## Validation
- `uv run pytest -q tests/test_postgres_store.py tests/test_postgres_schema.py tests/test_postgres_migrations.py tests/test_graph_benchmark_scaffold.py`
- `uv run ruff check src/agent_bom/api/postgres_graph.py tests/test_postgres_store.py tests/test_postgres_schema.py tests/test_postgres_migrations.py`
- `uv run ruff format --check src/agent_bom/api/postgres_graph.py tests/test_postgres_store.py tests/test_postgres_schema.py tests/test_postgres_migrations.py`
- `uv run mypy src/agent_bom/api/postgres_graph.py`
- `uv run python -m py_compile src/agent_bom/api/postgres_graph.py`
- `uv run python scripts/run_graph_postgres_explain.py --dry-run --dsn postgresql://agent_bom:agent_bom@127.0.0.1:54329/agent_bom`
- `git diff --check`

## Notes
- The explain command was run in dry-run mode; it validates the script path and output generation, not a live Postgres latency claim.
