### PR TITLE
Document Neptune graph backend design

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -207,6 +207,28 @@ control-plane parity:
 For the operator-facing backend matrix and current parity boundaries, see
 `site-docs/deployment/backend-parity.md`.
 
+### Neptune — design-only candidate
+
+Neptune is not wired as a graph backend today. The current implementation
+contract remains SQLite for local graph persistence and Postgres/Supabase for
+the transactional control plane.
+
+The candidate Neptune lane maps to the API `GraphStoreProtocol` rather than
+the analysis-only `GraphBackend` abstraction:
+
+| Graph concept | Candidate Neptune shape | Required invariant |
+|---|---|---|
+| graph snapshot | snapshot metadata vertex or side table keyed by `tenant_id` + `scan_id` | immutable per-scan reads |
+| node | vertex keyed by `tenant_id`, `scan_id`, stable graph node ID | tenant predicate on every query |
+| edge | relationship keyed by `tenant_id`, `scan_id`, source, target, relationship | tenant predicate and bounded traversal |
+| attack path | materialized path vertex/edge payload | no ad hoc unbounded traversal in API calls |
+| temporal edge fields | relationship attributes (`valid_from`, `valid_to`, confidence, provenance) | preserve replay/diff semantics |
+| saved presets | stay in the transactional API store unless a graph-only deployment is designed | no silent feature loss |
+
+No production SLO, support claim, Helm value, dependency extra, or adapter class
+is implied by this mapping. See
+`docs/decisions/008-pluggable-neptune-graph-backend.md` for the design boundary.
+
 ### Deployment-context posture contract — `GET /v1/posture/counts`
 
 This endpoint is the lightweight capability contract used by the UI to

--- a/docs/decisions/008-pluggable-neptune-graph-backend.md
+++ b/docs/decisions/008-pluggable-neptune-graph-backend.md
@@ -1,0 +1,101 @@
+# ADR-008: Pluggable Neptune Graph Backend
+
+**Status:** Proposed
+**Date:** 2026-05-13
+
+## Context
+
+The self-hosted control plane currently persists graph snapshots through
+`GraphStoreProtocol` with SQLite as the local default and Postgres as the
+multi-tenant control-plane backend. That contract already covers snapshot
+writes, search, pagination, node context, bounded traversal, attack paths,
+diffs, compliance summaries, saved filters, and tenant deletion.
+
+Enterprise graph platforms such as Amazon Neptune solve a different scale
+problem: long-lived relationship stores with graph-native traversal and
+managed operational scaling. Adding that lane should not make Neptune a
+required dependency, weaken the Postgres default, or turn roadmap positioning
+into a shipped-product claim.
+
+## Decision
+
+Keep SQLite and Postgres as the shipped defaults. Add Neptune as an optional
+enterprise graph-store backend only after the adapter can satisfy the same
+`GraphStoreProtocol` contract or explicitly decline unsupported operations with
+typed, fail-closed errors.
+
+The Neptune lane maps the API graph store contract, not the analysis-only
+`GraphBackend` contract in `src/agent_bom/graph_backend.py`. `GraphBackend`
+supports local analytics such as centrality and shortest paths; it is not the
+API persistence boundary.
+
+The adapter design is:
+
+- **Configuration:** opt in with a backend selector such as
+  `AGENT_BOM_GRAPH_BACKEND=neptune` plus endpoint, AWS auth mode, region, TLS,
+  and optional IAM role settings. Missing config must fail startup for the
+  Neptune backend rather than falling back silently to another tenant's store.
+- **Dependency boundary:** keep AWS/Gremlin dependencies in an optional extra.
+  Base installs, CLI scans, SQLite, and Postgres deployments must not import
+  those packages at module import time.
+- **Tenant isolation:** every vertex and edge carries `tenant_id`; every query
+  includes the tenant predicate; cross-tenant traversals are not supported.
+  IAM/network isolation is defense in depth, not a substitute for tenant
+  predicates.
+- **Snapshot model:** preserve `scan_id` as the immutable snapshot key.
+  Vertices and edges are versioned by `(tenant_id, scan_id, id)` or
+  `(tenant_id, scan_id, source, target, relationship)`. Temporal edge fields
+  remain attributes on relationships.
+- **Query language:** implement through Gremlin or Neptune openCypher behind
+  repository methods. Do not expose arbitrary graph queries through the public
+  API until auth, tenant scoping, audit, and query budgets are designed.
+- **Audit posture:** backend selection, connection failures, query timeouts,
+  and tenant deletes emit normal API audit events. The adapter must never log
+  credentials, raw SigV4 material, or full customer graph payloads.
+- **Failure modes:** unsupported operations return deterministic 501-style
+  adapter errors through the API layer; transient Neptune errors map to 503;
+  tenant delete failures are fail-closed and require operator retry.
+
+## Operation Mapping
+
+| `GraphStoreProtocol` operation | Neptune strategy | Initial support |
+|---|---|---|
+| `save_graph` | batch upsert vertices/edges by tenant and scan | required |
+| `latest_snapshot_id`, `previous_snapshot_id`, `list_snapshots` | snapshot metadata vertices or side table | required |
+| `page_nodes`, `nodes_by_ids` | tenant + scan filtered vertex queries | required |
+| `edges_for_node_ids`, `node_context` | bounded incident-edge traversal | required |
+| `search_nodes` | start with exact/contains properties; add OpenSearch only as a separate design | required, may be slower |
+| `attack_paths`, `attack_paths_for_sources` | materialized path vertices/edges, not ad hoc deep traversal | required |
+| `traverse_subgraph`, `bfs_paths`, `impact_of` | graph-native bounded traversal with max node/edge/deadline budgets | required |
+| `diff_snapshots`, temporal edge queries | scan-scoped compare queries over versioned relationships | required |
+| `compliance_summary` | aggregate vertex properties by framework prefix | required |
+| presets | keep in Postgres/API store unless a graph-only deployment exists | optional |
+| `delete_tenant` | delete all tenant-scoped graph objects with audited count | required |
+
+## Migration Strategy
+
+1. Add a `NeptuneGraphStore` skeleton behind an optional import boundary and
+   feature flag.
+2. Add mocked adapter contract tests that exercise the full
+   `GraphStoreProtocol` surface without requiring AWS.
+3. Add a local serializer that exports a `UnifiedGraph` into the exact
+   vertex/edge/property mutations the adapter will submit.
+4. Add an integration smoke that runs only when Neptune endpoint credentials
+   are present.
+5. Document first command, credential boundary, produced artifact, and rollback
+   path before advertising the backend as available.
+
+## Consequences
+
+- **Positive:** The product can pursue Neptune-grade scale without rewriting the
+  API or UI surfaces.
+- **Positive:** The self-hosted Postgres path remains the default and stays
+  honest for most deployments.
+- **Positive:** Tenant, audit, and failure behavior are defined before any AWS
+  dependency enters the runtime.
+- **Trade-off:** The first Neptune milestone is a design and contract milestone,
+  not a shipped managed graph backend.
+- **Trade-off:** Search may need a separate indexed text service at very large
+  scale; that is outside the first adapter.
+- **Boundary:** This ADR does not add Neptune code, Gremlin/openCypher public
+  query endpoints, WebGL rendering, or production latency claims.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -25,6 +25,7 @@ Each ADR follows this structure:
 | 005 | [Re-Export Pattern for Backward Compatibility](005-re-export-pattern.md) | Accepted | 2026-03-11 |
 | 006 | [Unified Graph Write Batching](006-unified-graph-write-batching.md) | Accepted | 2026-04-25 |
 | 007 | [MCP Package Version Provenance](007-mcp-package-version-provenance.md) | Accepted | 2026-05-01 |
+| 008 | [Pluggable Neptune Graph Backend](008-pluggable-neptune-graph-backend.md) | Proposed | 2026-05-13 |
 
 ## Adding a New ADR
 

--- a/docs/graph/CONTRACT.md
+++ b/docs/graph/CONTRACT.md
@@ -77,6 +77,7 @@ agent-bom's graph is a static analytical artifact derived from inventory plus ca
 - **Framework tags from canonical sources only.** Every framework tag attached to a vulnerability node comes from CISA KEV, OSV, NVD, EPSS, MITRE ATLAS, or MITRE ATT&CK. The bundled canonical metadata lives in `src/agent_bom/compliance_coverage.py`. agent-bom never invents a framework label, never derives one from heuristics, and never re-tags advisories from secondary aggregators.
 - **No cross-tenant leakage.** Every `UnifiedGraph` carries a `tenant_id` (`context_graph.py:808`). Persistence enforces row-level security in Postgres, scoped by tenant, on every read and write path. A query for tenant A's graph cannot return tenant B's nodes or edges, regardless of API surface.
 - **Untrusted external metadata is fenced.** Tool descriptions ingested from MCP `tools/list` are passed through `_untrusted_metadata_text()` (`context_graph.py:47`), control characters are stripped, length is bounded, and the field is marked `description_trust = "untrusted_external_mcp_metadata"`. Downstream consumers must treat that field as data, never as a label or instruction.
+- **Alternative graph backends must preserve this contract first.** SQLite and Postgres are the shipped graph persistence backends today. Any future backend, including the proposed Neptune lane, must preserve stable IDs, tenant predicates, snapshot semantics, bounded traversal, audit behavior, and explicit unsupported-operation errors before it can be documented as supported.
 
 ---
 

--- a/site-docs/deployment/backend-parity.md
+++ b/site-docs/deployment/backend-parity.md
@@ -1,7 +1,8 @@
 # Backend Parity Matrix
 
 > **You do not need to read this unless** you are choosing between
-> SQLite, Postgres / Supabase, ClickHouse, and Snowflake — or verifying
+> SQLite, Postgres / Supabase, ClickHouse, Snowflake, and future graph
+> backends such as Neptune — or verifying
 > exactly which API surfaces are wired against each backend today.
 > Most deployments should use Postgres (the documented default).
 
@@ -13,44 +14,46 @@ The product contract is:
 - `Postgres` / `Supabase`: transactional control-plane default
 - `ClickHouse`: analytics and time-series backend
 - `Snowflake`: warehouse-native and governance-oriented backend where parity is explicitly implemented
+- `Neptune`: design-only enterprise graph-store candidate; not wired today
 
 This page documents what is wired today, not what might exist as a class on disk.
 
 ## Current API Backend Matrix
 
-| Capability | SQLite | Postgres / Supabase | ClickHouse | Snowflake |
-|---|---|---|---|---|
-| Scan job persistence | Yes | Yes | No | Yes |
-| Fleet agent persistence | Yes | Yes | No | Yes |
-| Gateway policy persistence | Yes | Yes | No | Yes |
-| Audit log persistence | Yes | Yes | No | Yes, via `SnowflakePolicyStore` |
-| Source registry persistence | Yes | Yes | No | No |
-| Exception workflow persistence | No default API wiring | Yes | No | Yes |
-| API key persistence / RBAC store | No default API wiring | Yes | No | No |
-| Schedule persistence | Yes | Yes | No | Yes |
-| Trend / baseline persistence | Yes | Yes | No | No |
-| Graph persistence | Yes | Yes | No | No |
-| Analytics / OLAP writes | No | No | Yes | No |
-| Snowflake governance discovery routes | No | No | No | Yes |
+| Capability | SQLite | Postgres / Supabase | ClickHouse | Snowflake | Neptune |
+|---|---|---|---|---|---|
+| Scan job persistence | Yes | Yes | No | Yes | No |
+| Fleet agent persistence | Yes | Yes | No | Yes | No |
+| Gateway policy persistence | Yes | Yes | No | Yes | No |
+| Audit log persistence | Yes | Yes | No | Yes, via `SnowflakePolicyStore` | No |
+| Source registry persistence | Yes | Yes | No | No | No |
+| Exception workflow persistence | No default API wiring | Yes | No | Yes | No |
+| API key persistence / RBAC store | No default API wiring | Yes | No | No | No |
+| Schedule persistence | Yes | Yes | No | Yes | No |
+| Trend / baseline persistence | Yes | Yes | No | No | No |
+| Graph persistence | Yes | Yes | No | No | Design only / not wired |
+| Analytics / OLAP writes | No | No | Yes | No | No |
+| Snowflake governance discovery routes | No | No | No | Yes | No |
 
 ## Route-level parity summary
 
 This is the operator-facing answer to: "which API surfaces are real on which
 backend?"
 
-| Route group | SQLite | Postgres / Supabase | ClickHouse | Snowflake |
-|---|---|---|---|---|
-| `/v1/scan*` job lifecycle | Yes | Yes | No | Yes |
-| `/v1/fleet*` | Yes | Yes | No | Yes |
-| `/v1/gateway/policies*` | Yes | Yes | No | Yes |
-| `/v1/sources*` source registry | Yes | Yes | No | No |
-| `/v1/audit*` primary trail | Yes | Yes | No | Partial; Snowflake policy audit exists, but it is not the full transactional audit replacement |
-| `/v1/auth/keys*` | No default API wiring | Yes | No | No |
-| `/v1/auth/me` capability contract | session-local only | Yes | No | No |
-| `/v1/exceptions*` | No default API wiring | Yes | No | Yes |
-| `/v1/schedules*` | Yes | Yes | No | Yes |
-| `/v1/traces`, `/v1/proxy/audit`, `/v1/ocsf/ingest` analytics writes | No | No | Yes | No |
-| Snowflake governance/account discovery routes | No | No | No | Yes |
+| Route group | SQLite | Postgres / Supabase | ClickHouse | Snowflake | Neptune |
+|---|---|---|---|---|---|
+| `/v1/scan*` job lifecycle | Yes | Yes | No | Yes | No |
+| `/v1/fleet*` | Yes | Yes | No | Yes | No |
+| `/v1/gateway/policies*` | Yes | Yes | No | Yes | No |
+| `/v1/sources*` source registry | Yes | Yes | No | No | No |
+| `/v1/audit*` primary trail | Yes | Yes | No | Partial; Snowflake policy audit exists, but it is not the full transactional audit replacement | No |
+| `/v1/auth/keys*` | No default API wiring | Yes | No | No | No |
+| `/v1/auth/me` capability contract | session-local only | Yes | No | No | No |
+| `/v1/exceptions*` | No default API wiring | Yes | No | Yes | No |
+| `/v1/schedules*` | Yes | Yes | No | Yes | No |
+| `/v1/graph*` | Yes | Yes | No | No | Design only / not wired |
+| `/v1/traces`, `/v1/proxy/audit`, `/v1/ocsf/ingest` analytics writes | No | No | Yes | No | No |
+| Snowflake governance/account discovery routes | No | No | No | Yes | No |
 
 The key distinction is:
 
@@ -59,6 +62,18 @@ The key distinction is:
 - warehouse-native discovery parity
 
 These are related, but not interchangeable.
+
+## Neptune graph backend status
+
+Neptune is not a shipped backend in agent-bom today. It is a design-only
+enterprise graph-store candidate for deployments that eventually need
+graph-native traversal at a scale beyond the Postgres default.
+
+The current design target is documented in
+[`../../docs/decisions/008-pluggable-neptune-graph-backend.md`](../../docs/decisions/008-pluggable-neptune-graph-backend.md).
+Any future Neptune implementation must preserve the API `GraphStoreProtocol`
+surface, tenant predicates, audit behavior, and fail-closed configuration
+rules before this matrix can mark it supported.
 
 ## Snowflake parity target
 


### PR DESCRIPTION
## Summary
- document the proposed Neptune graph backend as a design-only enterprise lane
- define the adapter boundary against `GraphStoreProtocol`, including tenant, audit, unsupported-operation, and fail-closed behavior
- update backend parity and graph contract docs so SQLite/Postgres remain the shipped defaults

## Validation
- `uv run pytest -q tests/test_backend_parity_docs.py tests/test_public_docs_cli_alignment.py`
- `git diff --check`
- `rg -n "Neptune|AGENT_BOM_GRAPH_BACKEND|GraphStoreProtocol|not shipped|not ship|future|adapter" docs/DATA_MODEL.md docs/decisions/008-pluggable-neptune-graph-backend.md docs/decisions/README.md docs/graph/CONTRACT.md site-docs/deployment/backend-parity.md`

## Notes
- This PR does not add a Neptune adapter, dependency extra, Helm value, production SLO, or support claim.
- SQLite and Postgres remain the shipped graph persistence backends.
