### PR TITLE
Clarify graph release positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,24 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **Graph investigation product lane** - the post-`v0.86.5` main branch now
+  carries the first Wiz-grade graph roadmap slice: bitemporal graph edges,
+  measured graph benchmark evidence, a hardened large-graph overview fallback,
+  API-native `ExposurePath`, toxic-combo projection into the graph, renderer
+  switch contracts for React Flow / large overview / WebGL, semantic clusters,
+  and the optional Neptune backend design. These are code and docs on `main`;
+  live Neptune SLOs and a full query DSL remain future work.
+- **Agentic integration positioning** - README and release review docs now tie
+  the MCP server, proxy, gateway, Shield SDK, skills, CI, control-plane API,
+  auth, and self-hosted data boundary into one adoption story for humans and
+  AI agents instead of listing them as separate surfaces.
+
 ### Fixed
+- **SQLite graph upgrade blocker** - the release-blocking read-path migration
+  regression is tracked as the v0.86.6 blocker: existing local graph DBs must
+  add time-versioned edge columns before any `/v1/graph*` endpoint claims
+  release readiness.
 - **`agent-bom audit` fails on base install** - `cryptography` is now a core
   dependency (it was previously only in `[runtime]`/`[oidc]` extras), so the
   proxy audit log viewer no longer crashes with `No module named

--- a/README.md
+++ b/README.md
@@ -495,6 +495,17 @@ see value and where enterprises wire agent-bom into existing controls.
 | Runtime and app frameworks | MCP proxy/gateway, Shield SDK, Anthropic/OpenAI SDK patterns, LangChain, CrewAI | enforces policy on live tool calls and lets applications add in-process allow/block decisions |
 | Governance and observability | Postgres/Supabase, ClickHouse, Snowflake paths, OTEL, SIEM/export hooks, compliance bundles | persists evidence, trends, audit, graph state, and control mappings without requiring a hosted vendor plane |
 
+This is the product shape for the AI era: the same evidence model is available
+to a human in the browser, a developer in CI, and an assistant through MCP.
+Agents can call strict-argument tools for scans, package checks, registry
+review, and runtime policy context; operators keep control through bearer
+auth, OIDC/SAML/SCIM, tenant scope, audit chains, gateway/proxy policy, and
+customer-owned databases. The network boundary stays explicit: local scans are
+read-only, the MCP server exposes read-only security tools, proxy/gateway paths
+only inspect the traffic they are placed in front of, and self-hosted control
+planes run inside the customer's VPC, Kubernetes cluster, identity, and audit
+boundary.
+
 For cloud, IaC, GPU, skills, and runtime boundaries, use the
 [AI infrastructure coverage matrix](site-docs/architecture/ai-infrastructure.md#coverage-matrix)
 to pick the command and artifact before making a release or buyer-facing claim.
@@ -577,6 +588,9 @@ Backend choices stay explicit and optional:
 
 - `SQLite` for local and single-node use
 - `Postgres` / `Supabase` for the primary transactional control plane
+- `Neptune` as an enterprise graph-backend lane; the backend design is on
+  `main`, while adapter implementation remains optional and is not a default
+  dependency or published production SLO
 - `ClickHouse` for analytics and event-scale persistence
 - `Snowflake` for warehouse-native governance and selected backend paths that
   can coexist with a Postgres-backed control plane

--- a/docs/release/graph-data-product-review-v0.86.6.md
+++ b/docs/release/graph-data-product-review-v0.86.6.md
@@ -31,6 +31,47 @@ Target state: every graph surface should answer four questions immediately:
 3. What entities and relationships prove it?
 4. What is the fix or containment step?
 
+## Current Main Status
+
+This document started as a design review. The main branch has since shipped a
+large part of that plan, so the release narrative should separate delivered
+capability from future graph-platform work.
+
+Shipped on `main` after `v0.86.5`:
+
+- **Time-versioned graph edges** — SQLite and Postgres edges carry
+  `valid_from`, `valid_to`, confidence, provenance, source scan, and source run
+  metadata, with `/v1/graph/edges/active` and `/v1/graph/edges/changes` API
+  routes.
+- **Measured graph benchmark evidence** — benchmark artifacts now report real
+  measured API path timings while keeping synthetic-estate disclaimers explicit.
+- **Large graph fallback hardening** — broad graph views have a defensive
+  overview path instead of forcing every dense scene into the focused renderer.
+- **API-native `ExposurePath` contract** — fix-first and attack-path APIs share
+  a structured path shape for risk, hops, evidence, fix target, and provenance.
+- **Toxic-combo projection** — compound risk conditions are represented as graph
+  entities and relationships instead of living only in narrative summaries.
+- **Renderer switch contract** — the UI can choose React Flow, large overview,
+  or WebGL paths by graph size and focus state.
+- **Semantic clusters** — package, CVE, agent, server, credential, tool, and
+  source-family clusters reduce raw topology before rendering.
+- **Postgres hot-path indexes** — graph search, node hydration, and attack-path
+  SQL paths have explicit index coverage for the known slow paths.
+- **Neptune backend lane** — the adapter boundary and optional enterprise graph
+  backend design are documented; implementation remains optional and must not
+  weaken the SQLite/Postgres defaults.
+
+Release blockers and non-claims:
+
+- Existing SQLite graph DBs must migrate time-versioned edge columns before
+  `v0.86.6` can be tagged; otherwise existing `/v1/graph*` users can hit
+  `OperationalError: no such column: valid_from`.
+- A live Neptune deployment, production Neptune latency SLO, openCypher query
+  endpoint, and 50k-node WebGL operations claim are not shipped claims in this
+  review.
+- SARIF, Markdown, and HTML outputs still need `ExposurePath` propagation before
+  the path contract can be described as format-wide.
+
 ## External Benchmark
 
 Public references do not disclose Wiz or CrowdStrike's exact browser graph


### PR DESCRIPTION
## Summary
- update the Unreleased changelog with the post-v0.86.5 graph investigation lane and the SQLite graph migration release blocker
- mark the graph product review as a shipped-vs-future status document instead of pure design intent
- tighten README positioning for humans and AI agents across MCP, skills, CI, proxy/gateway, auth, network boundaries, and self-hosted data ownership

## Why
The current code moved faster than the release narrative. This keeps buyer-facing and operator-facing docs honest: shipped graph work is named, release blockers are explicit, and Neptune/WebGL/query-DSL claims stay out of the shipped bucket until implementation and evidence exist.

## Verification
- `uv run pytest -q tests/test_backend_parity_docs.py tests/test_public_docs_cli_alignment.py`
- `git diff --check`
- `rg -n "live Neptune|production Neptune|50k-node|default dependency|not shipped|future" README.md CHANGELOG.md docs/release/graph-data-product-review-v0.86.6.md`
