### PR TITLE
Fix graph light mode tokens

### DIFF
--- a/ui/components/graph-chrome.tsx
+++ b/ui/components/graph-chrome.tsx
@@ -86,16 +86,16 @@ export function GraphLegend({
       <button
         type="button"
         onClick={() => setOpen((current) => !current)}
-        className={`${embedded ? "hidden" : "flex"} items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800/80 px-2.5 py-1.5 text-xs text-zinc-300 transition-colors hover:bg-zinc-700 backdrop-blur-sm`}
+        className={`${embedded ? "hidden" : "flex"} items-center gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-muted)] px-2.5 py-1.5 text-xs text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-elevated)] backdrop-blur-sm`}
         aria-expanded={visible}
         aria-label={visible ? "Hide legend" : "Show legend"}
       >
         <span className="font-medium">Legend</span>
-        <span className="rounded-full bg-zinc-900 px-1.5 py-0.5 text-[10px] text-zinc-400">{items.length}</span>
+        <span className="rounded-full bg-[var(--surface)] px-1.5 py-0.5 text-[10px] text-[var(--text-tertiary)]">{items.length}</span>
         <ChevronDown className={`h-3.5 w-3.5 transition-transform ${visible ? "rotate-180" : ""}`} />
       </button>
       {visible && (
-        <div className={`${embedded ? "relative w-[min(30rem,calc(100vw-2rem))] shadow-none" : "absolute right-0 top-full z-20 mt-2 w-[min(30rem,calc(100vw-2rem))] shadow-2xl shadow-black/30"} max-h-[60vh] overflow-y-auto rounded-xl border border-zinc-700 bg-zinc-900/95 p-3 backdrop-blur-md`}>
+        <div className={`${embedded ? "relative w-[min(30rem,calc(100vw-2rem))] shadow-none" : "absolute right-0 top-full z-20 mt-2 w-[min(30rem,calc(100vw-2rem))] shadow-2xl shadow-[var(--shadow-color)]"} max-h-[60vh] overflow-y-auto rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)] p-3 text-[var(--foreground)] backdrop-blur-md`}>
           {nodeItems.length > 0 && <LayeredLegendSections items={nodeItems} />}
           {edgeItems.length > 0 && (
             <LegendSection title="Relationships" items={edgeItems} />
@@ -135,8 +135,8 @@ function LayeredLegendSections({ items }: { items: LegendItem[] }) {
 function LegendSection({ title, items }: { title: string; items: LegendItem[] }) {
   return (
     <div className="first:mt-0 mt-3">
-      <div className="mb-2 text-[10px] uppercase tracking-[0.18em] text-zinc-500">{title}</div>
-      <div className="grid grid-cols-1 gap-x-3 gap-y-2 text-[11px] text-zinc-300 sm:grid-cols-2">
+      <div className="mb-2 text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">{title}</div>
+      <div className="grid grid-cols-1 gap-x-3 gap-y-2 text-[11px] text-[var(--text-secondary)] sm:grid-cols-2">
         {items.map((item) => (
           <span key={`${title}:${item.label}`} className="flex min-w-0 items-center gap-2">
             <LegendMarker item={item} />
@@ -231,7 +231,7 @@ export function FullscreenButton() {
   return (
     <button
       onClick={toggle}
-      className="flex items-center gap-1.5 px-2.5 py-1.5 bg-zinc-800/80 border border-zinc-700 rounded-lg text-xs text-zinc-300 hover:bg-zinc-700 transition-colors backdrop-blur-sm"
+      className="flex items-center gap-1.5 px-2.5 py-1.5 bg-[var(--surface-muted)] border border-[var(--border-subtle)] rounded-lg text-xs text-[var(--text-secondary)] hover:bg-[var(--surface-elevated)] transition-colors backdrop-blur-sm"
       title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
     >
       {isFullscreen ? <Minimize2 className="w-3.5 h-3.5" /> : <Maximize2 className="w-3.5 h-3.5" />}
@@ -258,7 +258,7 @@ export function GraphExportButton({ filename }: { filename?: string }) {
   return (
     <button
       onClick={handleExport}
-      className="flex items-center gap-1.5 px-2.5 py-1.5 bg-zinc-800/80 border border-zinc-700 rounded-lg text-xs text-zinc-300 hover:bg-zinc-700 transition-colors backdrop-blur-sm"
+      className="flex items-center gap-1.5 px-2.5 py-1.5 bg-[var(--surface-muted)] border border-[var(--border-subtle)] rounded-lg text-xs text-[var(--text-secondary)] hover:bg-[var(--surface-elevated)] transition-colors backdrop-blur-sm"
     >
       <Download className="w-3.5 h-3.5" />
       Export
@@ -312,7 +312,7 @@ export function GraphEvidenceExportButton({
         aria-label="Graph evidence format"
         value={format}
         onChange={(event) => setFormat(event.target.value as GraphExportFormat)}
-        className="rounded-lg border border-zinc-700 bg-zinc-900/90 px-2.5 py-1.5 text-xs text-zinc-300 focus:border-sky-600 focus:outline-none"
+        className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] px-2.5 py-1.5 text-xs text-[var(--text-secondary)] focus:border-sky-600 focus:outline-none"
       >
         {formats.map((item) => (
           <option key={item} value={item}>
@@ -324,7 +324,7 @@ export function GraphEvidenceExportButton({
         type="button"
         onClick={() => void handleDownload()}
         disabled={!scanId || exporting}
-        className="inline-flex items-center gap-1.5 rounded-lg border border-cyan-900/60 bg-cyan-950/30 px-2.5 py-1.5 text-xs font-medium text-cyan-200 transition-colors hover:border-cyan-800 hover:bg-cyan-950/50 disabled:cursor-not-allowed disabled:opacity-50"
+        className="inline-flex items-center gap-1.5 rounded-lg border border-cyan-700/45 bg-cyan-50 px-2.5 py-1.5 text-xs font-medium text-cyan-800 transition-colors hover:border-cyan-700 hover:bg-cyan-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-cyan-900/60 dark:bg-cyan-950/30 dark:text-cyan-200 dark:hover:border-cyan-800 dark:hover:bg-cyan-950/50"
         title="Download the selected scan graph in an evidence format for review, import, or audit handoff."
       >
         {exporting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Download className="h-3.5 w-3.5" />}

--- a/ui/components/lineage-filter.tsx
+++ b/ui/components/lineage-filter.tsx
@@ -259,15 +259,15 @@ export function FilterPanel({ filters, onChange, agentNames, validValues, onRese
   };
 
   return (
-    <div className="w-48 bg-zinc-950/90 backdrop-blur-sm border-r border-zinc-800 p-3 space-y-4 overflow-y-auto text-xs">
+    <div className="w-48 bg-[var(--surface)] backdrop-blur-sm border-r border-[var(--border-subtle)] p-3 space-y-4 overflow-y-auto text-xs text-[var(--text-secondary)]">
       <div className="flex items-center justify-between -mt-1 -mx-1 mb-1">
-        <span className="text-[10px] uppercase tracking-[0.2em] text-zinc-500 px-1">Filters</span>
+        <span className="text-[10px] uppercase tracking-[0.2em] text-[var(--text-tertiary)] px-1">Filters</span>
         {onReset && (
           <button
             type="button"
             onClick={onReset}
             title="Reset to the bounded graph scope"
-            className="flex items-center gap-1 rounded border border-zinc-800 bg-zinc-900/80 px-2 py-1 text-[10px] text-zinc-400 transition hover:border-emerald-600/40 hover:text-emerald-200"
+            className="flex items-center gap-1 rounded border border-[var(--border-subtle)] bg-[var(--surface-muted)] px-2 py-1 text-[10px] text-[var(--text-secondary)] transition hover:border-emerald-600/40 hover:text-emerald-600 dark:hover:text-emerald-200"
           >
             <RotateCcw className="h-3 w-3" />
             Reset
@@ -291,8 +291,8 @@ export function FilterPanel({ filters, onChange, agentNames, validValues, onRese
                 title={enabled ? undefined : DISABLED_TOOLTIP}
                 className={`flex items-center gap-2 ${
                   enabled || checked
-                    ? "cursor-pointer text-zinc-400 hover:text-zinc-200"
-                    : "cursor-not-allowed text-zinc-600 opacity-50"
+                    ? "cursor-pointer text-[var(--text-secondary)] hover:text-[var(--foreground)]"
+                    : "cursor-not-allowed text-[var(--text-tertiary)] opacity-50"
                 }`}
               >
                 <input
@@ -319,7 +319,7 @@ export function FilterPanel({ filters, onChange, agentNames, validValues, onRese
         <select
           value={filters.severity ?? ""}
           onChange={(e) => onChange({ ...filters, severity: e.target.value || null })}
-          className="w-full bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-zinc-300 focus:outline-none focus:border-emerald-600"
+          className="w-full bg-[var(--surface)] border border-[var(--border-subtle)] rounded px-2 py-1 text-[var(--foreground)] focus:outline-none focus:border-emerald-600"
         >
           {SEVERITY_OPTIONS.map(({ value, label }) => {
             const enabled = isSeverityEnabled(value);
@@ -352,7 +352,7 @@ export function FilterPanel({ filters, onChange, agentNames, validValues, onRese
               relationshipScope: e.target.value as FilterState["relationshipScope"],
             })
           }
-          className="w-full bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-zinc-300 focus:outline-none focus:border-emerald-600"
+          className="w-full bg-[var(--surface)] border border-[var(--border-subtle)] rounded px-2 py-1 text-[var(--foreground)] focus:outline-none focus:border-emerald-600"
         >
           {RELATIONSHIP_SCOPE_OPTIONS.map(({ value, label }) => {
             const enabled = isScopeEnabled(value);
@@ -386,7 +386,7 @@ export function FilterPanel({ filters, onChange, agentNames, validValues, onRese
                 runtimeMode: e.target.value as FilterState["runtimeMode"],
               })
             }
-            className="w-full bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-zinc-300 focus:outline-none focus:border-emerald-600"
+            className="w-full bg-[var(--surface)] border border-[var(--border-subtle)] rounded px-2 py-1 text-[var(--foreground)] focus:outline-none focus:border-emerald-600"
           >
             <option value="all">Static + runtime</option>
             <option value="static">Static only</option>
@@ -401,7 +401,7 @@ export function FilterPanel({ filters, onChange, agentNames, validValues, onRese
                 maxDepth: Number(e.target.value),
               })
             }
-            className="w-full bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-zinc-300 focus:outline-none focus:border-emerald-600"
+            className="w-full bg-[var(--surface)] border border-[var(--border-subtle)] rounded px-2 py-1 text-[var(--foreground)] focus:outline-none focus:border-emerald-600"
           >
             <option value="1">Depth 1</option>
             <option value="2">Depth 2</option>
@@ -428,7 +428,7 @@ export function FilterPanel({ filters, onChange, agentNames, validValues, onRese
       )}
 
       <div>
-        <label className="flex items-center gap-2 cursor-pointer text-zinc-400 hover:text-zinc-200">
+        <label className="flex items-center gap-2 cursor-pointer text-[var(--text-secondary)] hover:text-[var(--foreground)]">
           <input
             type="checkbox"
             checked={filters.vulnOnly}
@@ -448,7 +448,7 @@ export function FilterPanel({ filters, onChange, agentNames, validValues, onRese
         <select
           value={String(filters.pageSize)}
           onChange={(e) => onChange({ ...filters, pageSize: Number(e.target.value) })}
-          className="w-full bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-zinc-300 focus:outline-none focus:border-emerald-600"
+          className="w-full bg-[var(--surface)] border border-[var(--border-subtle)] rounded px-2 py-1 text-[var(--foreground)] focus:outline-none focus:border-emerald-600"
         >
           <option value="25">25 nodes</option>
           <option value="50">50 nodes</option>
@@ -500,21 +500,21 @@ function VirtualizedAgentPicker({
         }}
         placeholder={`Filter ${agentNames.length.toLocaleString()} agents`}
         aria-label="Filter graph agents"
-        className="w-full rounded border border-zinc-700 bg-zinc-900 px-2 py-1 text-zinc-300 placeholder:text-zinc-600 focus:border-emerald-600 focus:outline-none"
+        className="w-full rounded border border-[var(--border-subtle)] bg-[var(--surface)] px-2 py-1 text-[var(--foreground)] placeholder:text-[var(--text-tertiary)] focus:border-emerald-600 focus:outline-none"
       />
       <button
         type="button"
         onClick={() => onSelect(null)}
         className={`flex h-8 w-full items-center rounded px-2 text-left text-[11px] transition ${
           selectedAgent === null
-            ? "border border-emerald-500/40 bg-emerald-500/10 text-emerald-200"
-            : "border border-zinc-800 bg-zinc-900/70 text-zinc-400 hover:border-zinc-700 hover:text-zinc-200"
+            ? "border border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200"
+            : "border border-[var(--border-subtle)] bg-[var(--surface-muted)] text-[var(--text-secondary)] hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
         }`}
       >
         All agents
       </button>
       <div
-        className="overflow-y-auto rounded border border-zinc-800 bg-zinc-950/70"
+        className="overflow-y-auto rounded border border-[var(--border-subtle)] bg-[var(--surface)]"
         style={{ height: listHeight }}
         onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
         role="listbox"
@@ -534,10 +534,10 @@ function VirtualizedAgentPicker({
                 onClick={() => onSelect(agentName)}
                 className={`block h-8 w-full truncate px-2 text-left font-mono text-[11px] transition ${
                   isSelected
-                    ? "bg-emerald-500/15 text-emerald-200"
+                    ? "bg-emerald-500/15 text-emerald-700 dark:text-emerald-200"
                     : enabled
-                      ? "text-zinc-400 hover:bg-zinc-900 hover:text-zinc-200"
-                      : "cursor-not-allowed text-zinc-600 opacity-50"
+                      ? "text-[var(--text-secondary)] hover:bg-[var(--surface-elevated)] hover:text-[var(--foreground)]"
+                      : "cursor-not-allowed text-[var(--text-tertiary)] opacity-50"
                 }`}
                 title={enabled ? agentName : DISABLED_TOOLTIP}
               >
@@ -546,11 +546,11 @@ function VirtualizedAgentPicker({
             );
           })}
           {visibleAgents.length === 0 && (
-            <div className="px-2 py-3 text-[11px] text-zinc-500">No agents match this filter.</div>
+            <div className="px-2 py-3 text-[11px] text-[var(--text-tertiary)]">No agents match this filter.</div>
           )}
         </div>
       </div>
-      <p className="text-[10px] text-zinc-600">
+      <p className="text-[10px] text-[var(--text-tertiary)]">
         Showing {visibleAgents.length.toLocaleString()} of {filteredAgents.length.toLocaleString()} matches.
       </p>
     </div>
@@ -571,19 +571,19 @@ function FilterSection({
   children: React.ReactNode;
 }) {
   return (
-    <section className="rounded-xl border border-zinc-800 bg-zinc-950/50">
+    <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-muted)]">
       <button
         type="button"
         onClick={onToggle}
         className="flex w-full items-center justify-between px-3 py-2 text-left"
       >
         <div>
-          <h3 className="font-semibold text-zinc-300 uppercase tracking-wider text-[10px]">{title}</h3>
-          {summary ? <p className="mt-1 text-[10px] text-zinc-600">{summary}</p> : null}
+          <h3 className="font-semibold text-[var(--text-secondary)] uppercase tracking-wider text-[10px]">{title}</h3>
+          {summary ? <p className="mt-1 text-[10px] text-[var(--text-tertiary)]">{summary}</p> : null}
         </div>
-        {open ? <ChevronDown className="h-3.5 w-3.5 text-zinc-500" /> : <ChevronRight className="h-3.5 w-3.5 text-zinc-500" />}
+        {open ? <ChevronDown className="h-3.5 w-3.5 text-[var(--text-tertiary)]" /> : <ChevronRight className="h-3.5 w-3.5 text-[var(--text-tertiary)]" />}
       </button>
-      {open ? <div className="border-t border-zinc-800 px-3 py-3">{children}</div> : null}
+      {open ? <div className="border-t border-[var(--border-subtle)] px-3 py-3">{children}</div> : null}
     </section>
   );
 }

--- a/ui/tests/light-theme-token-guard.test.ts
+++ b/ui/tests/light-theme-token-guard.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const GUARDED_GRAPH_SURFACES = [
+  "components/graph-chrome.tsx",
+  "components/lineage-filter.tsx",
+] as const;
+
+const DARK_ONLY_SURFACE_CLASS =
+  /\b(?:bg|border)-zinc-(?:700|800|900|950)(?:\/\d+)?\b|\btext-zinc-(?:100|200|300|400|500|600)(?:\/\d+)?\b|\b(?:bg-black|text-white|shadow-black)(?:\/\d+)?\b/g;
+
+describe("light theme token guard", () => {
+  it("keeps shared graph chrome and filters on theme tokens instead of dark-only panels", () => {
+    const violations = GUARDED_GRAPH_SURFACES.flatMap((file) => {
+      const source = readFileSync(path.join(process.cwd(), file), "utf8");
+      return [...source.matchAll(DARK_ONLY_SURFACE_CLASS)].map((match) => `${file}: ${match[0]}`);
+    });
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace dark-only graph chrome and lineage filter panel classes with shared theme tokens so light mode keeps readable surfaces, borders, and labels.
- Keep the graph evidence export button visually balanced in light mode while preserving the existing dark styling.
- Add a focused Vitest guard to prevent these graph surfaces from regressing to dark-only zinc/black/white panel classes.

Closes #2485 for the graph chrome/filter slice.

## Verification
- npm test -- --run tests/light-theme-token-guard.test.ts
- npx eslint components/graph-chrome.tsx components/lineage-filter.tsx tests/light-theme-token-guard.test.ts
- npm run typecheck
- npm run build
- npx playwright test e2e/lineage-graph-readability.spec.ts
- git diff --check

## Notes
- npm run verify:toolchain was attempted and correctly failed locally because this shell is on Node 25.9.0 while the UI declares >=22 <25.
