### PR TITLE
Adapt Sigma overview to unified graph data

### DIFF
--- a/ui/components/sigma-graph-overview.tsx
+++ b/ui/components/sigma-graph-overview.tsx
@@ -8,6 +8,8 @@ import { Activity, GitBranch, Layers3, Network, ShieldAlert, Sparkles } from "lu
 import { GraphLegend } from "@/components/graph-chrome";
 import type { LineageNodeData } from "@/components/lineage-nodes";
 import type { LegendItem } from "@/lib/graph-utils";
+import type { UnifiedGraphData } from "@/lib/graph-schema";
+import type { UnifiedGraphFlowFilters } from "@/lib/unified-graph-flow";
 import {
   LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD,
   LARGE_GRAPH_OVERVIEW_MAX_RENDERED_EDGES,
@@ -16,16 +18,28 @@ import {
 } from "@/lib/large-graph-overview";
 import {
   buildSigmaGraphOverviewModel,
+  buildSigmaGraphOverviewModelFromUnifiedGraph,
   type SigmaEdgeAttributes,
   type SigmaNodeAttributes,
 } from "@/lib/sigma-graph-overview";
 
-interface SigmaGraphOverviewProps {
-  nodes: Node<LineageNodeData>[];
-  edges: Edge[];
+type SigmaGraphOverviewProps = {
   legendItems: LegendItem[];
   onNodeSelect?: (nodeId: string) => void;
-}
+} & (
+  {
+    nodes: Node<LineageNodeData>[];
+    edges: Edge[];
+    graph?: never;
+    filters?: never;
+  }
+  | {
+      graph: UnifiedGraphData;
+      filters?: UnifiedGraphFlowFilters;
+      nodes?: never;
+      edges?: never;
+    }
+);
 
 function StatPill({
   icon: Icon,
@@ -74,6 +88,8 @@ function RelationshipRail({ items }: { items: Array<{ relationship: string; coun
 }
 
 export function SigmaGraphOverview({
+  graph,
+  filters,
   nodes,
   edges,
   legendItems,
@@ -85,7 +101,13 @@ export function SigmaGraphOverview({
   const onNodeSelectRef = useRef<SigmaGraphOverviewProps["onNodeSelect"]>(onNodeSelect);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [renderError, setRenderError] = useState<string | null>(null);
-  const model = useMemo(() => buildSigmaGraphOverviewModel(nodes, edges), [nodes, edges]);
+  const model = useMemo(
+    () =>
+      graph
+        ? buildSigmaGraphOverviewModelFromUnifiedGraph(graph, filters)
+        : buildSigmaGraphOverviewModel(nodes, edges),
+    [edges, filters, graph, nodes],
+  );
   const isBudgeted = model.overview.omittedNodeCount > 0 || model.overview.omittedEdgeCount > 0;
 
   useEffect(() => {

--- a/ui/lib/sigma-graph-overview.ts
+++ b/ui/lib/sigma-graph-overview.ts
@@ -2,12 +2,17 @@ import Graph from "graphology";
 import type { Edge, Node } from "@xyflow/react";
 
 import type { LineageNodeData, LineageNodeType } from "@/components/lineage-nodes";
+import type { UnifiedGraphData } from "@/lib/graph-schema";
 import {
   buildLargeGraphOverviewModel,
   summarizeLargeGraphOverview,
   type LargeGraphOverviewModel,
   type LargeGraphOverviewSummary,
 } from "@/lib/large-graph-overview";
+import {
+  buildUnifiedFlowGraph,
+  type UnifiedGraphFlowFilters,
+} from "@/lib/unified-graph-flow";
 
 export type SigmaNodeAttributes = {
   label: string;
@@ -39,6 +44,36 @@ export interface SigmaGraphOverviewModel {
   overview: LargeGraphOverviewModel;
   summary: LargeGraphOverviewSummary;
 }
+
+const SIGMA_DEFAULT_LAYERS: Record<LineageNodeType, boolean> = {
+  provider: true,
+  agent: true,
+  user: true,
+  group: true,
+  serviceAccount: true,
+  environment: true,
+  fleet: true,
+  cluster: true,
+  server: true,
+  sharedServer: true,
+  package: true,
+  vulnerability: true,
+  credential: true,
+  tool: true,
+  model: true,
+  dataset: true,
+  container: true,
+  cloudResource: true,
+  misconfiguration: true,
+};
+
+const SIGMA_DEFAULT_FILTERS: UnifiedGraphFlowFilters = {
+  layers: SIGMA_DEFAULT_LAYERS,
+  severity: null,
+  agentName: null,
+  vulnOnly: false,
+  maxDepth: 8,
+};
 
 function edgeIsHighlighted(
   source: { highlighted: boolean; forceLabel: boolean } | undefined,
@@ -95,4 +130,12 @@ export function buildSigmaGraphOverviewModel(
     overview,
     summary: summarizeLargeGraphOverview(nodes, edges),
   };
+}
+
+export function buildSigmaGraphOverviewModelFromUnifiedGraph(
+  graph: UnifiedGraphData,
+  filters: UnifiedGraphFlowFilters = SIGMA_DEFAULT_FILTERS,
+): SigmaGraphOverviewModel {
+  const flow = buildUnifiedFlowGraph(graph, filters);
+  return buildSigmaGraphOverviewModel(flow.nodes, flow.edges);
 }

--- a/ui/tests/sigma-graph-overview.test.ts
+++ b/ui/tests/sigma-graph-overview.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from "vitest";
 import type { Edge, Node } from "@xyflow/react";
 
 import type { LineageNodeData } from "@/components/lineage-nodes";
-import { buildSigmaGraphOverviewModel } from "@/lib/sigma-graph-overview";
+import type { UnifiedGraphData, UnifiedNode, UnifiedEdge } from "@/lib/graph-schema";
+import { EntityType, NodeStatus, RelationshipType } from "@/lib/graph-schema";
+import {
+  buildSigmaGraphOverviewModel,
+  buildSigmaGraphOverviewModelFromUnifiedGraph,
+} from "@/lib/sigma-graph-overview";
 
 function node(id: string, data: Partial<LineageNodeData> = {}): Node<LineageNodeData> {
   return {
@@ -23,6 +28,81 @@ function edge(id: string, source: string, target: string, relationship = "depend
     target,
     data: { relationship },
     style: { strokeWidth: 2 },
+  };
+}
+
+function unifiedNode(
+  id: string,
+  entityType: EntityType,
+  overrides: Partial<UnifiedNode> = {},
+): UnifiedNode {
+  return {
+    id,
+    entity_type: entityType,
+    label: id,
+    category_uid: 5,
+    class_uid: 4001,
+    type_uid: 0,
+    status: NodeStatus.ACTIVE,
+    risk_score: 0,
+    severity: "unknown",
+    severity_id: 0,
+    first_seen: "2026-05-14T00:00:00Z",
+    last_seen: "2026-05-14T00:00:00Z",
+    attributes: {},
+    compliance_tags: [],
+    data_sources: ["fixture"],
+    dimensions: {},
+    ...overrides,
+  };
+}
+
+function unifiedEdge(
+  id: string,
+  source: string,
+  target: string,
+  relationship: RelationshipType,
+  overrides: Partial<UnifiedEdge> = {},
+): UnifiedEdge {
+  return {
+    id,
+    source,
+    target,
+    relationship,
+    direction: "directed",
+    weight: 1,
+    traversable: true,
+    first_seen: "2026-05-14T00:00:00Z",
+    last_seen: "2026-05-14T00:00:00Z",
+    evidence: {},
+    activity_id: 0,
+    ...overrides,
+  };
+}
+
+function unifiedGraph(
+  nodes: UnifiedNode[],
+  edges: UnifiedEdge[],
+): UnifiedGraphData {
+  return {
+    scan_id: "scan-fixture",
+    tenant_id: "tenant-fixture",
+    created_at: "2026-05-14T00:00:00Z",
+    nodes,
+    edges,
+    attack_paths: [],
+    interaction_risks: [],
+    stats: {
+      total_nodes: nodes.length,
+      total_edges: edges.length,
+      node_types: {},
+      severity_counts: {},
+      relationship_types: {},
+      attack_path_count: 0,
+      interaction_risk_count: 0,
+      max_attack_path_risk: 0,
+      highest_interaction_risk: 0,
+    },
   };
 }
 
@@ -71,5 +151,39 @@ describe("sigma graph overview", () => {
     expect(model.graph.getNodeAttribute("pkg-b", "hidden")).toBe(true);
     expect(model.graph.getEdgeAttribute("focused", "highlighted")).toBe(true);
     expect(model.graph.getEdgeAttribute("dimmed", "hidden")).toBe(true);
+  });
+
+  it("adapts canonical unified graph data before building the Sigma model", () => {
+    const model = buildSigmaGraphOverviewModelFromUnifiedGraph(
+      unifiedGraph(
+        [
+          unifiedNode("agent-a", EntityType.AGENT, { label: "agent-a" }),
+          unifiedNode("server-a", EntityType.SERVER, { label: "mcp-server" }),
+          unifiedNode("pkg-a", EntityType.PACKAGE, { label: "requests", risk_score: 41 }),
+          unifiedNode("cve-a", EntityType.VULNERABILITY, {
+            label: "CVE-2026-0001",
+            risk_score: 95,
+            severity: "critical",
+            severity_id: 5,
+          }),
+        ],
+        [
+          unifiedEdge("agent-server", "agent-a", "server-a", RelationshipType.USES),
+          unifiedEdge("server-pkg", "server-a", "pkg-a", RelationshipType.DEPENDS_ON),
+          unifiedEdge("pkg-cve", "pkg-a", "cve-a", RelationshipType.VULNERABLE_TO, {
+            weight: 3,
+          }),
+          unifiedEdge("dangling", "pkg-a", "missing-node", RelationshipType.DEPENDS_ON),
+        ],
+      ),
+    );
+
+    expect(model.graph.order).toBe(4);
+    expect(model.graph.size).toBe(3);
+    expect(model.graph.getNodeAttribute("agent-a", "nodeType")).toBe("agent");
+    expect(model.graph.getNodeAttribute("cve-a", "severity")).toBe("critical");
+    expect(model.graph.getEdgeAttribute("pkg-cve", "relationship")).toBe("vulnerable_to");
+    expect(model.graph.hasEdge("dangling")).toBe(false);
+    expect(model.summary.criticalFindings).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- let `SigmaGraphOverview` consume canonical `UnifiedGraphData` plus optional graph-flow filters
- add a shared adapter that routes unified graph payloads through the existing `buildUnifiedFlowGraph` path before building the Sigma/graphology model
- keep the existing React Flow node/edge prop path for current callers
- add regression coverage for unified graph conversion and dangling-edge filtering

## Why
The WebGL overview should sit behind the same canonical graph contract as the rest of the dashboard. This is an adapter-level step only: it does not claim new 50k-node browser evidence or change the renderer dispatcher thresholds.

## Validation
- `npm test -- --run tests/sigma-graph-overview.test.ts tests/graph-renderer-switch.test.ts`
- `npx eslint components/sigma-graph-overview.tsx lib/sigma-graph-overview.ts tests/sigma-graph-overview.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
