### PR TITLE
Decouple skills provenance gaps from malicious status

### DIFF
--- a/src/agent_bom/parsers/trust_assessment.py
+++ b/src/agent_bom/parsers/trust_assessment.py
@@ -657,6 +657,34 @@ def _compute_axis_verdict(categories: list[TrustCategoryResult]) -> Verdict:
     return Verdict.BENIGN
 
 
+def _compute_content_verdict_from_audit(audit: SkillAuditResult) -> Verdict:
+    """Compute behavioral content risk without metadata/provenance signals.
+
+    Metadata gaps should send a skill to review, but they should not label a
+    clean, zero-finding skill as malicious. Reserve the content axis for
+    findings emitted by the skill audit itself.
+    """
+    findings = audit.findings
+    if any(f.category in _BLOCKED_FINDING_CATEGORIES or f.severity == "critical" for f in findings):
+        return Verdict.MALICIOUS
+    if any(f.category in _HIGH_RISK_FINDING_CATEGORIES for f in findings):
+        return Verdict.SUSPICIOUS
+    if any(f.severity == "high" and _is_behavioral_content_finding(f.category) for f in findings):
+        return Verdict.SUSPICIOUS
+    return Verdict.BENIGN
+
+
+def _combine_verdict(provenance_verdict: Verdict, content_verdict: Verdict) -> Verdict:
+    """Combine axes while preventing provenance-only MALICIOUS verdicts."""
+    if content_verdict == Verdict.MALICIOUS:
+        return Verdict.MALICIOUS
+    if content_verdict == Verdict.SUSPICIOUS:
+        return Verdict.SUSPICIOUS
+    if provenance_verdict in {Verdict.SUSPICIOUS, Verdict.MALICIOUS}:
+        return Verdict.SUSPICIOUS
+    return Verdict.BENIGN
+
+
 # ── Recommendations ──────────────────────────────────────────────────────────
 
 
@@ -726,9 +754,23 @@ _HIGH_RISK_FINDING_CATEGORIES = {
     "agent_delegation",
 }
 
+_REVIEW_ONLY_FINDING_CATEGORIES = {
+    "missing_capability_declaration",
+    "undeclared_dependency",
+    "undocumented_network",
+    "unknown_package",
+    "unverified_server",
+}
+
+
+def _is_behavioral_content_finding(category: str) -> bool:
+    """Return whether an audit finding describes skill behavior."""
+    return category not in _REVIEW_ONLY_FINDING_CATEGORIES
+
 
 def _compute_review_verdict(
-    verdict: Verdict,
+    provenance_verdict: Verdict,
+    content_verdict: Verdict,
     categories: list[TrustCategoryResult],
     audit: SkillAuditResult,
 ) -> ReviewVerdict:
@@ -736,9 +778,13 @@ def _compute_review_verdict(
     findings = audit.findings
     if any(f.category in _BLOCKED_FINDING_CATEGORIES or f.severity == "critical" for f in findings):
         return ReviewVerdict.BLOCKED
-    if verdict == Verdict.MALICIOUS or any(f.category in _HIGH_RISK_FINDING_CATEGORIES for f in findings):
+    if content_verdict == Verdict.MALICIOUS or any(f.category in _HIGH_RISK_FINDING_CATEGORIES for f in findings):
         return ReviewVerdict.HIGH_RISK
-    if verdict == Verdict.SUSPICIOUS or any(c.level in {TrustLevel.WARN, TrustLevel.FAIL} for c in categories):
+    if (
+        content_verdict == Verdict.SUSPICIOUS
+        or provenance_verdict in {Verdict.SUSPICIOUS, Verdict.MALICIOUS}
+        or any(c.level in {TrustLevel.WARN, TrustLevel.FAIL} for c in categories)
+    ):
         return ReviewVerdict.REVIEW
     return ReviewVerdict.TRUSTED
 
@@ -806,14 +852,15 @@ def assess_trust(
         _assess_persistence_privilege(meta, scan, audit),
     ]
 
-    verdict, confidence = _compute_verdict(categories)
+    _legacy_verdict, confidence = _compute_verdict(categories)
     # Per #2197 audit: split verdict into provenance + content so a clean
     # skill that's just unsigned no longer reads as `malicious`.
-    provenance_categories, content_categories = _split_categories(categories)
+    provenance_categories, _content_categories = _split_categories(categories)
     provenance_verdict = _compute_axis_verdict(provenance_categories)
-    content_verdict = _compute_axis_verdict(content_categories)
+    content_verdict = _compute_content_verdict_from_audit(audit)
+    verdict = _combine_verdict(provenance_verdict, content_verdict)
     recommendations = _generate_recommendations(categories)
-    review_verdict = _compute_review_verdict(verdict, categories, audit)
+    review_verdict = _compute_review_verdict(provenance_verdict, content_verdict, categories, audit)
     review_reasons = _build_review_reasons(categories, audit)
     reviewer_guidance = _build_reviewer_guidance(audit)
 

--- a/tests/test_skills_service.py
+++ b/tests/test_skills_service.py
@@ -61,6 +61,26 @@ def test_high_risk_local_skill_review_counts_as_malicious_status():
     assert _review_to_status(report) == ThreatIntelStatus.MALICIOUS
 
 
+def test_clean_unsigned_skill_requires_review_without_malicious_status(tmp_path):
+    """Metadata/provenance gaps should not label a zero-finding skill malicious."""
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text("# Clean skill\n\nRead source files and explain the implementation.\n")
+
+    report = scan_skill_targets([skill_file])
+    data = report.to_dict()
+    file_report = data["files"][0]
+
+    assert file_report["audit"]["findings"] == []
+    assert file_report["trust"]["content_verdict"] == "benign"
+    assert file_report["trust"]["verdict"] == "suspicious"
+    assert file_report["trust"]["review_verdict"] == "review"
+    assert file_report["status"] == "suspicious"
+    assert data["summary"]["findings"] == 0
+    assert data["summary"]["high_risk_files"] == 0
+    assert data["summary"]["malicious_files"] == 0
+    assert data["summary"]["malicious_status_files"] == 0
+
+
 def test_scan_skill_targets_redacts_server_args_in_output(tmp_path):
     raw_token = "ghp_" + "A" * 36
     skill_file = tmp_path / "SKILL.md"

--- a/tests/test_trust_assessment.py
+++ b/tests/test_trust_assessment.py
@@ -495,8 +495,61 @@ def test_review_verdict_blocked_for_prompt_coercion():
     scan = _make_scan()
     audit = _make_audit(findings=[_finding("prompt_coercion", severity="high", title="Guardrail override")])
     result = assess_trust(scan, audit)
+    assert result.content_verdict == Verdict.MALICIOUS
     assert result.review_verdict == ReviewVerdict.BLOCKED
     assert any("guardrail" in reason.lower() or "prompt coercion" in reason.lower() for reason in result.review_reasons)
+
+
+def test_content_verdict_ignores_metadata_only_findings():
+    """Catalog/provenance review findings should not become content risk."""
+    scan = _make_scan()
+    audit = _make_audit(
+        findings=[
+            _finding("unknown_package", severity="low", title="Unknown package"),
+            _finding("unverified_server", severity="medium", title="Unverified server"),
+            _finding("missing_capability_declaration", severity="low", title="Missing capabilities"),
+            _finding("undeclared_dependency", severity="medium", title="Undeclared dependency"),
+            _finding("undocumented_network", severity="medium", title="Undocumented network"),
+        ]
+    )
+
+    result = assess_trust(scan, audit)
+
+    assert result.content_verdict == Verdict.BENIGN
+    assert result.verdict == Verdict.BENIGN
+
+
+def test_credential_file_access_blocks_content_verdict():
+    """Credential file access is behavioral and should remain blocking."""
+    scan = _make_scan()
+    audit = _make_audit(findings=[_finding("credential_file_access", severity="critical", title="Credential file access")])
+
+    result = assess_trust(scan, audit)
+
+    assert result.content_verdict == Verdict.MALICIOUS
+    assert result.review_verdict == ReviewVerdict.BLOCKED
+
+
+def test_shell_access_remains_high_risk_content_verdict():
+    """High-risk behavior categories should still escalate content risk."""
+    scan = _make_scan()
+    audit = _make_audit(findings=[_finding("shell_access", severity="low", title="Shell access")])
+
+    result = assess_trust(scan, audit)
+
+    assert result.content_verdict == Verdict.SUSPICIOUS
+    assert result.review_verdict == ReviewVerdict.HIGH_RISK
+
+
+def test_high_severity_behavioral_finding_is_suspicious():
+    """High-severity behavioral findings should stay suspicious."""
+    scan = _make_scan()
+    audit = _make_audit(findings=[_finding("network_exposure", severity="high", title="Network exposure")])
+
+    result = assess_trust(scan, audit)
+
+    assert result.content_verdict == Verdict.SUSPICIOUS
+    assert result.verdict == Verdict.SUSPICIOUS
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -597,6 +650,7 @@ def test_assess_trust_agent_bom_skill():
     result = assess_trust(scan, audit)
 
     assert result.verdict == Verdict.BENIGN
+    assert result.content_verdict == Verdict.BENIGN
     assert result.confidence in (Confidence.HIGH, Confidence.MEDIUM)
 
 


### PR DESCRIPTION
## Summary
- compute the skills content verdict from behavioral audit findings instead of metadata/provenance category gaps
- keep unsigned or metadata-poor zero-finding skills in `review`/`suspicious` handling instead of `high_risk`/`malicious`
- preserve malicious status for threat-intel hits, blocked findings, critical findings, and high-risk behavioral categories
- add a regression covering a clean unsigned `SKILL.md` with zero audit findings

## Why
Clean skills with missing provenance or frontmatter were being counted as malicious because `review_verdict` still keyed off the legacy combined trust verdict. That conflated provenance completeness with behavioral content risk and inflated MLOps/operator status counts.

## Validation
- `uv run pytest -q tests/test_skills_service.py tests/test_skill_audit.py tests/test_skills_cli.py tests/test_aws_discovery_skill.py`
- `uv run ruff check src/agent_bom/parsers/trust_assessment.py tests/test_skills_service.py`
- `git diff --check`
- local smoke: clean unsigned `SKILL.md` now reports `content_verdict=benign`, `review_verdict=review`, `status=suspicious`, and `malicious_status_files=0`
