### PR TITLE
Fix skills trust dual-axis recommendations

### DIFF
--- a/config/schemas/skills-scan.schema.json
+++ b/config/schemas/skills-scan.schema.json
@@ -101,7 +101,55 @@
             "items": { "type": "string" }
           },
           "audit": { "type": "object" },
-          "trust": { "type": "object" },
+          "trust": {
+            "type": "object",
+            "properties": {
+              "skill_name": { "type": "string" },
+              "source_file": { "type": "string" },
+              "verdict": {
+                "type": "string",
+                "enum": ["benign", "suspicious", "malicious"]
+              },
+              "content_verdict": {
+                "type": "string",
+                "enum": ["benign", "suspicious", "malicious"]
+              },
+              "provenance_verdict": {
+                "type": "string",
+                "enum": ["verified", "unverified"]
+              },
+              "review_verdict": {
+                "type": "string",
+                "enum": ["trusted", "review", "high_risk", "blocked"]
+              },
+              "overall_recommendation": {
+                "type": "string",
+                "enum": ["trusted", "review", "high_risk", "blocked"]
+              },
+              "confidence": {
+                "type": "string",
+                "enum": ["high", "medium", "low"]
+              },
+              "categories": { "type": "array" },
+              "recommendations": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "review_reasons": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "reviewer_guidance": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "publisher_guidance": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            },
+            "additionalProperties": true
+          },
           "provenance": { "type": "object" },
           "threat_intel": {
             "oneOf": [

--- a/src/agent_bom/output/html.py
+++ b/src/agent_bom/output/html.py
@@ -802,6 +802,9 @@ def _trust_assessment_section(report: "AIBOMReport") -> str:
     skill_name = _esc(data.get("skill_name", ""))
     source_file = _esc(data.get("source_file", ""))
     verdict = data.get("verdict", "benign").upper()
+    content_verdict = data.get("content_verdict", data.get("verdict", "benign")).upper()
+    provenance_verdict = data.get("provenance_verdict", "unverified").upper()
+    recommendation = data.get("overall_recommendation") or data.get("review_verdict", "review")
     confidence = data.get("confidence", "low")
     categories = data.get("categories", [])
     recommendations = data.get("recommendations", [])
@@ -831,6 +834,16 @@ def _trust_assessment_section(report: "AIBOMReport") -> str:
         f'font-size:.82rem;font-weight:700;letter-spacing:.04em">{verdict}</span>'
         f'<span style="color:#64748b;font-size:.78rem;margin-left:8px">({confidence} confidence)</span>'
     )
+    axis_html = (
+        '<div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:16px">'
+        f'<span style="background:#0f766e;color:#fff;padding:4px 10px;border-radius:6px;font-size:.76rem">'
+        f"content: {_esc(content_verdict)}</span>"
+        f'<span style="background:#4338ca;color:#fff;padding:4px 10px;border-radius:6px;font-size:.76rem">'
+        f"provenance: {_esc(provenance_verdict)}</span>"
+        f'<span style="background:#475569;color:#fff;padding:4px 10px;border-radius:6px;font-size:.76rem">'
+        f"recommendation: {_esc(str(recommendation).upper())}</span>"
+        "</div>"
+    )
 
     title_suffix = f" &mdash; {skill_name}" if skill_name else ""
     source_note = (
@@ -857,6 +870,7 @@ def _trust_assessment_section(report: "AIBOMReport") -> str:
         f'<div class="panel">'
         f"{source_note}"
         f'<div style="margin-bottom:16px">{verdict_badge}</div>'
+        f"{axis_html}"
         f"{table_html}"
         f"{rec_html}"
         f"</div></section>"

--- a/src/agent_bom/output/markdown.py
+++ b/src/agent_bom/output/markdown.py
@@ -41,6 +41,10 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
     lines.append(f"| Low | {sev_counts.get('low', 0)} |")
     lines.append("")
 
+    trust_lines = _trust_assessment_section(report)
+    if trust_lines:
+        lines.extend(trust_lines)
+
     if not brs and not policy_findings:
         lines.append("No vulnerabilities found.")
         return "\n".join(lines) + "\n"
@@ -176,6 +180,30 @@ def _severity_counts(brs: list[BlastRadius]) -> dict[str, int]:
 def _non_cve_findings(report: AIBOMReport) -> list[Finding]:
     """Return unified findings that do not already appear in the CVE table."""
     return [finding for finding in report.to_findings() if finding.finding_type != FindingType.CVE]
+
+
+def _trust_assessment_section(report: AIBOMReport) -> list[str]:
+    """Render dual-axis skill trust metadata in Markdown."""
+    data = getattr(report, "trust_assessment_data", None)
+    if not isinstance(data, dict) or not data:
+        return []
+
+    lines = [
+        "## Skill Trust Assessment",
+        "",
+        "| Field | Value |",
+        "|-------|-------|",
+        f"| Verdict | `{_md_cell(data.get('verdict', 'benign'))}` |",
+        f"| Content verdict | `{_md_cell(data.get('content_verdict', 'benign'))}` |",
+        f"| Provenance verdict | `{_md_cell(data.get('provenance_verdict', 'unverified'))}` |",
+        f"| Recommendation | `{_md_cell(data.get('overall_recommendation') or data.get('review_verdict', 'review'))}` |",
+    ]
+    if data.get("skill_name"):
+        lines.append(f"| Skill | {_md_cell(data['skill_name'])} |")
+    if data.get("source_file"):
+        lines.append(f"| Source | `{_md_cell(data['source_file'])}` |")
+    lines.append("")
+    return lines
 
 
 _SEV_ORDER = {Severity.CRITICAL: 0, Severity.HIGH: 1, Severity.MEDIUM: 2, Severity.LOW: 3, Severity.UNKNOWN: 4, Severity.NONE: 5}

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -110,6 +110,19 @@ def _sanitize_sarif_text(field_name: str, value: Any, *, fallback: str = "") -> 
     return str(redacted)
 
 
+def _trust_assessment_sarif_property(data: dict[str, Any]) -> dict[str, str]:
+    """Project safe dual-axis trust fields into SARIF run properties."""
+    allowed_fields = (
+        "verdict",
+        "content_verdict",
+        "provenance_verdict",
+        "review_verdict",
+        "overall_recommendation",
+        "confidence",
+    )
+    return {field: str(data[field]) for field in allowed_fields if data.get(field) is not None}
+
+
 def _build_run_taxonomies(results: list[dict]) -> list[dict]:
     """Build SARIF run-level taxonomies from per-result framework tags."""
     tags_by_property: dict[str, set[str]] = {key: set() for key in _FRAMEWORK_TAXONOMY_META}
@@ -624,6 +637,11 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
         "results": results,
         **({"automationDetails": {"id": f"agent-bom/{report.scan_id}"}} if report.scan_id else {}),
     }
+    trust_assessment = getattr(report, "trust_assessment_data", None)
+    if isinstance(trust_assessment, dict) and trust_assessment:
+        run["properties"] = {
+            "trust_assessment": _trust_assessment_sarif_property(trust_assessment),
+        }
     if taxonomies:
         run["taxonomies"] = taxonomies
 

--- a/src/agent_bom/parsers/trust_assessment.py
+++ b/src/agent_bom/parsers/trust_assessment.py
@@ -48,6 +48,13 @@ class Verdict(str, Enum):
     MALICIOUS = "malicious"
 
 
+class ProvenanceVerdict(str, Enum):
+    """Provenance/signing verification verdict."""
+
+    VERIFIED = "verified"
+    UNVERIFIED = "unverified"
+
+
 class ReviewVerdict(str, Enum):
     """Review-focused skill handling verdict."""
 
@@ -93,18 +100,20 @@ class TrustAssessmentResult:
 
     The result now carries TWO axes:
 
-    - `provenance_verdict` -- signed, install metadata complete, source URL?
+    - `provenance_verdict` -- verified source/signing posture or unverified?
     - `content_verdict`    -- behavioural risk signals from the audit?
 
-    `verdict` (the union of both) and `review_verdict` are preserved so
-    pre-#2197 consumers don't break.
+    `verdict` is preserved for pre-#2197 consumers as a derived content
+    verdict for one compatibility release. Use `review_verdict` or
+    `overall_recommendation` for handling decisions because provenance-only
+    gaps should send a skill to review without implying malicious content.
     """
 
     categories: list[TrustCategoryResult] = field(default_factory=list)
     verdict: Verdict = Verdict.BENIGN
     review_verdict: ReviewVerdict = ReviewVerdict.REVIEW
     confidence: Confidence = Confidence.LOW
-    provenance_verdict: Verdict = Verdict.BENIGN
+    provenance_verdict: ProvenanceVerdict = ProvenanceVerdict.VERIFIED
     content_verdict: Verdict = Verdict.BENIGN
     recommendations: list[str] = field(default_factory=list)
     review_reasons: list[str] = field(default_factory=list)
@@ -128,6 +137,7 @@ class TrustAssessmentResult:
             "source_file": self.source_file,
             "verdict": self.verdict.value,
             "review_verdict": self.review_verdict.value,
+            "overall_recommendation": self.review_verdict.value,
             "confidence": self.confidence.value,
             # Two-axis split (#2197 audit). `verdict` above is kept for
             # backward compat; new consumers should prefer these axes.
@@ -660,12 +670,17 @@ def _compute_axis_verdict(categories: list[TrustCategoryResult]) -> Verdict:
 def _compute_content_verdict_from_audit(audit: SkillAuditResult) -> Verdict:
     """Compute behavioral content risk without metadata/provenance signals.
 
-    Metadata gaps should send a skill to review, but they should not label a
-    clean, zero-finding skill as malicious. Reserve the content axis for
-    findings emitted by the skill audit itself.
+    Severity ladder:
+    - behavioral + critical -> malicious
+    - behavioral + high     -> suspicious
+    - behavioral + medium   -> benign content, review via review_verdict
+    - behavioral + low      -> benign content
+    - metadata/catalog only -> benign content; provenance/review axes handle it
     """
     findings = audit.findings
-    if any(f.category in _BLOCKED_FINDING_CATEGORIES or f.severity == "critical" for f in findings):
+    if any(f.category in _BLOCKED_FINDING_CATEGORIES for f in findings):
+        return Verdict.MALICIOUS
+    if any(f.severity == "critical" and _is_behavioral_content_finding(f.category) for f in findings):
         return Verdict.MALICIOUS
     if any(f.category in _HIGH_RISK_FINDING_CATEGORIES for f in findings):
         return Verdict.SUSPICIOUS
@@ -674,15 +689,16 @@ def _compute_content_verdict_from_audit(audit: SkillAuditResult) -> Verdict:
     return Verdict.BENIGN
 
 
-def _combine_verdict(provenance_verdict: Verdict, content_verdict: Verdict) -> Verdict:
-    """Combine axes while preventing provenance-only MALICIOUS verdicts."""
-    if content_verdict == Verdict.MALICIOUS:
-        return Verdict.MALICIOUS
-    if content_verdict == Verdict.SUSPICIOUS:
-        return Verdict.SUSPICIOUS
-    if provenance_verdict in {Verdict.SUSPICIOUS, Verdict.MALICIOUS}:
-        return Verdict.SUSPICIOUS
-    return Verdict.BENIGN
+def _compute_provenance_verdict(provenance_categories: list[TrustCategoryResult]) -> ProvenanceVerdict:
+    """Compute whether provenance metadata is complete enough to be treated as verified."""
+    if _compute_axis_verdict(provenance_categories) == Verdict.BENIGN:
+        return ProvenanceVerdict.VERIFIED
+    return ProvenanceVerdict.UNVERIFIED
+
+
+def _combine_verdict(provenance_verdict: ProvenanceVerdict, content_verdict: Verdict) -> Verdict:
+    """Return legacy `verdict` as content verdict for one compatibility release."""
+    return content_verdict
 
 
 # ── Recommendations ──────────────────────────────────────────────────────────
@@ -769,20 +785,23 @@ def _is_behavioral_content_finding(category: str) -> bool:
 
 
 def _compute_review_verdict(
-    provenance_verdict: Verdict,
+    provenance_verdict: ProvenanceVerdict,
     content_verdict: Verdict,
     categories: list[TrustCategoryResult],
     audit: SkillAuditResult,
 ) -> ReviewVerdict:
     """Map trust and audit signals to a handling-oriented review verdict."""
     findings = audit.findings
-    if any(f.category in _BLOCKED_FINDING_CATEGORIES or f.severity == "critical" for f in findings):
+    if any(
+        f.category in _BLOCKED_FINDING_CATEGORIES or (f.severity == "critical" and _is_behavioral_content_finding(f.category))
+        for f in findings
+    ):
         return ReviewVerdict.BLOCKED
     if content_verdict == Verdict.MALICIOUS or any(f.category in _HIGH_RISK_FINDING_CATEGORIES for f in findings):
         return ReviewVerdict.HIGH_RISK
     if (
         content_verdict == Verdict.SUSPICIOUS
-        or provenance_verdict in {Verdict.SUSPICIOUS, Verdict.MALICIOUS}
+        or provenance_verdict == ProvenanceVerdict.UNVERIFIED
         or any(c.level in {TrustLevel.WARN, TrustLevel.FAIL} for c in categories)
     ):
         return ReviewVerdict.REVIEW
@@ -856,7 +875,7 @@ def assess_trust(
     # Per #2197 audit: split verdict into provenance + content so a clean
     # skill that's just unsigned no longer reads as `malicious`.
     provenance_categories, _content_categories = _split_categories(categories)
-    provenance_verdict = _compute_axis_verdict(provenance_categories)
+    provenance_verdict = _compute_provenance_verdict(provenance_categories)
     content_verdict = _compute_content_verdict_from_audit(audit)
     verdict = _combine_verdict(provenance_verdict, content_verdict)
     recommendations = _generate_recommendations(categories)

--- a/src/agent_bom/skills_service.py
+++ b/src/agent_bom/skills_service.py
@@ -13,7 +13,7 @@ from typing import Iterable
 from agent_bom.integrity import verify_instruction_file
 from agent_bom.parsers.skill_audit import SkillAuditResult, audit_skill_result
 from agent_bom.parsers.skills import SkillScanResult, discover_skill_files, parse_skill_file
-from agent_bom.parsers.trust_assessment import TrustAssessmentResult, assess_trust
+from agent_bom.parsers.trust_assessment import ProvenanceVerdict, TrustAssessmentResult, Verdict, assess_trust
 from agent_bom.security import sanitize_command_args
 from agent_bom.skill_bundles import SkillBundle, build_skill_bundle
 from agent_bom.skill_intel import ThreatIntelResult, ThreatIntelStatus, lookup_bundle_threat_intel
@@ -286,6 +286,8 @@ def _review_to_status(report: SkillFileReport) -> ThreatIntelStatus:
         return ThreatIntelStatus.CLEAN
     if verdict in {"blocked", "high_risk"}:
         return ThreatIntelStatus.MALICIOUS
+    if report.trust.content_verdict == Verdict.BENIGN:
+        return ThreatIntelStatus.PENDING
     return ThreatIntelStatus.SUSPICIOUS
 
 
@@ -294,6 +296,9 @@ def _build_skill_report(path: Path, *, intel_source: str | None = None) -> Skill
     scan = parse_skill_file(path)
     audit = audit_skill_result(scan)
     trust = assess_trust(scan, audit)
+    provenance = _provenance_to_dict(path)
+    if provenance.get("status") != "verified":
+        trust.provenance_verdict = ProvenanceVerdict.UNVERIFIED
     bundle = build_skill_bundle(path)
     threat_intel = lookup_bundle_threat_intel(bundle, intel_source)
     report = SkillFileReport(
@@ -301,7 +306,7 @@ def _build_skill_report(path: Path, *, intel_source: str | None = None) -> Skill
         scan=scan,
         audit=audit,
         trust=trust,
-        provenance=_provenance_to_dict(path),
+        provenance=provenance,
         bundle=bundle,
         threat_intel=threat_intel,
     )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1591,6 +1591,9 @@ def test_html_trust_assessment_section():
         "skill_name": "test-skill",
         "source_file": "/tmp/SKILL.md",
         "verdict": "suspicious",
+        "content_verdict": "benign",
+        "provenance_verdict": "unverified",
+        "overall_recommendation": "review",
         "confidence": "medium",
         "categories": [
             {"name": "Purpose & Capability", "key": "purpose", "level": "pass", "summary": "Standard tool"},
@@ -1605,6 +1608,9 @@ def test_html_trust_assessment_section():
     assert "Trust Assessment" in html
     assert "test-skill" in html
     assert "SUSPICIOUS" in html
+    assert "content: BENIGN" in html
+    assert "provenance: UNVERIFIED" in html
+    assert "recommendation: REVIEW" in html
     assert "medium confidence" in html
     assert "Purpose &amp; Capability" in html
     assert "Excessive credential access" in html

--- a/tests/test_mcp_tool_impls.py
+++ b/tests/test_mcp_tool_impls.py
@@ -1251,6 +1251,10 @@ def test_skill_trust_impl_success(tmp_path):
     data = json.loads(result)
     assert "verdict" in data
     assert "categories" in data
+    assert data["verdict"] == "benign"
+    assert data["content_verdict"] == "benign"
+    assert data["provenance_verdict"] == "unverified"
+    assert data["overall_recommendation"] == "review"
     assert data["provenance"]["status"] == "unsigned"
 
 

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -549,6 +549,28 @@ class TestMarkdown:
         assert "1 affected agent(s), 1 affected server(s), 1 reachable tool(s), 1 exposed credential reference(s)" in md
         assert "Upgrade lodash to 4.17.21" in md
 
+    def test_skill_trust_axes_render_in_markdown(self):
+        report = _make_report()
+        report.trust_assessment_data = {
+            "skill_name": "scan",
+            "source_file": "SKILL.md",
+            "verdict": "benign",
+            "content_verdict": "benign",
+            "provenance_verdict": "unverified",
+            "review_verdict": "review",
+            "overall_recommendation": "review",
+            "confidence": "medium",
+            "categories": [],
+            "recommendations": [],
+        }
+
+        md = to_markdown(report)
+
+        assert "## Skill Trust Assessment" in md
+        assert "| Content verdict | `benign` |" in md
+        assert "| Provenance verdict | `unverified` |" in md
+        assert "| Recommendation | `review` |" in md
+
 
 def test_exposure_path_is_embedded_in_sarif_properties():
     tool = MCPTool(name="deploy", description="Deploy workloads")
@@ -575,6 +597,30 @@ def test_exposure_path_is_embedded_in_sarif_properties():
         "source": "agent:prod-agent",
         "target": "server:prod-mcp",
     } in exposure_path["relationships"]
+
+
+def test_skill_trust_axes_are_embedded_in_sarif_properties():
+    report = _make_report()
+    report.trust_assessment_data = {
+        "skill_name": "scan",
+        "source_file": "SKILL.md",
+        "verdict": "benign",
+        "content_verdict": "benign",
+        "provenance_verdict": "unverified",
+        "review_verdict": "review",
+        "overall_recommendation": "review",
+        "confidence": "medium",
+        "categories": [],
+        "recommendations": [],
+    }
+
+    sarif = to_sarif(report)
+    trust = sarif["runs"][0]["properties"]["trust_assessment"]
+
+    assert trust["verdict"] == "benign"
+    assert trust["content_verdict"] == "benign"
+    assert trust["provenance_verdict"] == "unverified"
+    assert trust["overall_recommendation"] == "review"
 
 
 def test_html_renders_exposure_path_investigation_briefs():

--- a/tests/test_skills_service.py
+++ b/tests/test_skills_service.py
@@ -72,13 +72,18 @@ def test_clean_unsigned_skill_requires_review_without_malicious_status(tmp_path)
 
     assert file_report["audit"]["findings"] == []
     assert file_report["trust"]["content_verdict"] == "benign"
-    assert file_report["trust"]["verdict"] == "suspicious"
+    assert file_report["trust"]["provenance_verdict"] == "unverified"
+    assert file_report["trust"]["verdict"] == "benign"
     assert file_report["trust"]["review_verdict"] == "review"
-    assert file_report["status"] == "suspicious"
+    assert file_report["trust"]["overall_recommendation"] == "review"
+    assert file_report["status"] == "pending"
     assert data["summary"]["findings"] == 0
+    assert data["summary"]["suspicious_files"] == 0
     assert data["summary"]["high_risk_files"] == 0
     assert data["summary"]["malicious_files"] == 0
+    assert data["summary"]["suspicious_status_files"] == 0
     assert data["summary"]["malicious_status_files"] == 0
+    assert data["summary"]["pending_status_files"] == 1
 
 
 def test_scan_skill_targets_redacts_server_args_in_output(tmp_path):

--- a/tests/test_trust_assessment.py
+++ b/tests/test_trust_assessment.py
@@ -7,6 +7,7 @@ from agent_bom.parsers.skill_audit import SkillAuditResult, SkillFinding, audit_
 from agent_bom.parsers.skills import SkillMetadata, SkillScanResult
 from agent_bom.parsers.trust_assessment import (
     Confidence,
+    ProvenanceVerdict,
     ReviewVerdict,
     TrustAssessmentResult,
     TrustCategoryResult,
@@ -193,6 +194,9 @@ def test_trust_assessment_result_to_dict():
     d = result.to_dict()
     assert d["verdict"] == "benign"
     assert d["review_verdict"] == "trusted"
+    assert d["overall_recommendation"] == "trusted"
+    assert d["provenance_verdict"] == "verified"
+    assert d["content_verdict"] == "benign"
     assert d["confidence"] == "high"
     assert d["skill_name"] == "test-tool"
     assert len(d["categories"]) == 1
@@ -516,6 +520,7 @@ def test_content_verdict_ignores_metadata_only_findings():
     result = assess_trust(scan, audit)
 
     assert result.content_verdict == Verdict.BENIGN
+    assert result.provenance_verdict == ProvenanceVerdict.VERIFIED
     assert result.verdict == Verdict.BENIGN
 
 
@@ -632,8 +637,12 @@ def test_assess_trust_no_frontmatter():
     result = assess_trust(scan, audit)
 
     assert len(result.categories) == 5
-    # Without metadata, most categories should be WARN or INFO
-    assert result.verdict in (Verdict.SUSPICIOUS, Verdict.MALICIOUS)
+    # Without metadata, the content axis stays benign while review captures the
+    # catalog/provenance gaps.
+    assert result.verdict == Verdict.BENIGN
+    assert result.content_verdict == Verdict.BENIGN
+    assert result.provenance_verdict == ProvenanceVerdict.UNVERIFIED
+    assert result.review_verdict == ReviewVerdict.REVIEW
 
 
 def test_assess_trust_agent_bom_skill():
@@ -651,6 +660,7 @@ def test_assess_trust_agent_bom_skill():
 
     assert result.verdict == Verdict.BENIGN
     assert result.content_verdict == Verdict.BENIGN
+    assert result.provenance_verdict == ProvenanceVerdict.VERIFIED
     assert result.confidence in (Confidence.HIGH, Confidence.MEDIUM)
 
 


### PR DESCRIPTION
## Summary
- keep clean unsigned skills content-benign while routing provenance gaps to review
- expose content/provenance/recommendation trust axes in Markdown, HTML, SARIF, skills JSON schema, and MCP skill trust output
- preserve legacy verdict as a content-compatible derived field for backward compatibility

## Verification
- uv run pytest tests/test_trust_assessment.py tests/test_skills_service.py tests/test_mcp_tool_impls.py::test_skill_trust_impl_success tests/test_output_formats.py::TestMarkdown::test_skill_trust_axes_render_in_markdown tests/test_output_formats.py::test_skill_trust_axes_are_embedded_in_sarif_properties tests/test_core.py::test_html_trust_assessment_section -q
- uv run ruff check src/agent_bom/parsers/trust_assessment.py src/agent_bom/skills_service.py src/agent_bom/output/markdown.py src/agent_bom/output/html.py src/agent_bom/output/sarif.py tests/test_trust_assessment.py tests/test_skills_service.py tests/test_mcp_tool_impls.py tests/test_output_formats.py tests/test_core.py
- git diff --check