### PR TITLE
Verify runtime audit chain algorithms

### DIFF
--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -37,6 +37,7 @@ import secrets
 import threading
 import time
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Header, HTTPException, Query, Request, Response
@@ -896,14 +897,69 @@ async def list_audit_entries(
     }
 
 
+def _configured_runtime_audit_log_path() -> Path | None:
+    """Return the configured runtime proxy JSONL audit log, when readable."""
+    log_env = os.environ.get("AGENT_BOM_LOG")
+    if not log_env:
+        return None
+    path = Path(log_env).resolve()
+    if path.is_file() and path.suffix == ".jsonl":
+        return path
+    return None
+
+
 @router.get("/v1/audit/integrity", tags=["enterprise"])
-async def audit_integrity(request: Request, limit: Annotated[int, Query(ge=1, le=10_000)] = 1000) -> dict:
-    """Verify HMAC integrity of audit log entries."""
+async def audit_integrity(
+    request: Request,
+    limit: Annotated[int, Query(ge=1, le=10_000)] = 1000,
+    include_runtime: bool = True,
+) -> dict:
+    """Verify control-plane and runtime audit-chain integrity."""
     from agent_bom.api.audit_log import get_audit_log
+    from agent_bom.audit_integrity import verify_audit_jsonl_chain
 
     tenant_id = getattr(request.state, "tenant_id", "default")
     verified, tampered = get_audit_log().verify_integrity(limit=limit, tenant_id=tenant_id)
-    return {"verified": verified, "tampered": tampered, "checked": verified + tampered}
+    chains: list[dict[str, Any]] = [
+        {
+            "name": "control_plane",
+            "algorithm": "hmac-sha256",
+            "verified": verified,
+            "tampered": tampered,
+            "checked": verified + tampered,
+            "tenant_scoped": True,
+        }
+    ]
+
+    if include_runtime:
+        runtime_log = _configured_runtime_audit_log_path()
+        if runtime_log is not None:
+            runtime = verify_audit_jsonl_chain(runtime_log, max_lines=limit)
+            runtime_algorithms = list(runtime.get("algorithms") or ["unknown"])
+            chains.append(
+                {
+                    "name": "runtime_proxy",
+                    "algorithm": ",".join(runtime_algorithms),
+                    "algorithms": runtime_algorithms,
+                    "verified": int(runtime.get("verified", 0)),
+                    "tampered": int(runtime.get("tampered", 0)),
+                    "checked": int(runtime.get("checked", 0)),
+                    "tenant_scoped": False,
+                    "source": "AGENT_BOM_LOG",
+                    "error": runtime.get("error", ""),
+                }
+            )
+
+    total_verified = sum(int(chain["verified"]) for chain in chains)
+    total_tampered = sum(int(chain["tampered"]) for chain in chains)
+    algorithms = sorted({algorithm for chain in chains for algorithm in str(chain["algorithm"]).split(",") if algorithm})
+    return {
+        "verified": total_verified,
+        "tampered": total_tampered,
+        "checked": total_verified + total_tampered,
+        "algorithms": algorithms,
+        "chains": chains,
+    }
 
 
 @router.get("/v1/audit/export", tags=["enterprise"])

--- a/src/agent_bom/audit_integrity.py
+++ b/src/agent_bom/audit_integrity.py
@@ -128,13 +128,14 @@ def verify_audit_jsonl_chain(log_path: Path, *, max_lines: int = 50_000) -> dict
 
     try:
         lines = log_path.read_text().splitlines()
-    except OSError as exc:
+    except OSError:
+        _logger.warning("Failed to read runtime audit log: %s", log_path, exc_info=True)
         return {
             "verified": 0,
             "tampered": 1,
             "checked": 1,
             "algorithms": [],
-            "error": f"audit_log_unreadable: {exc}",
+            "error": "audit_log_unreadable",
         }
 
     chain_key = resolve_verifier_chain_key(log_path)

--- a/src/agent_bom/audit_integrity.py
+++ b/src/agent_bom/audit_integrity.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import logging
 import os
@@ -81,6 +83,100 @@ def compute_audit_record_mac_with_key(payload: dict[str, Any], prev_hash: str, k
     mac = CMAC(algorithms.AES(_normalize_cmac_key(key)))
     mac.update(message)
     return mac.finalize().hex()
+
+
+def compute_audit_record_hmac_with_key(payload: dict[str, Any], prev_hash: str, key: bytes) -> str:
+    """Return a HMAC-SHA256 chain digest for an audit payload."""
+    canonical = canonical_audit_payload(payload)
+    message = f"{prev_hash}|{canonical}".encode("utf-8")
+    return hmac.new(key, message, hashlib.sha256).hexdigest()
+
+
+def compute_audit_record_hash(
+    payload: dict[str, Any],
+    prev_hash: str,
+    algorithm: str,
+    *,
+    key: bytes | None = None,
+) -> str | None:
+    """Return the expected record hash for a declared audit-chain algorithm.
+
+    Runtime proxy logs declare ``aes-cmac-128``. Older runtime logs omitted
+    the field, so the empty algorithm remains a CMAC-compatible legacy path.
+    HMAC-SHA256 support exists for JSONL chain records that use the same
+    algorithm family as the control-plane audit table. Unknown algorithms are
+    not guessed; they are treated as unverifiable by callers.
+    """
+    normalized = algorithm.strip().lower().replace("_", "-")
+    if normalized in {"", "aes-cmac-128"}:
+        if key is not None:
+            return compute_audit_record_mac_with_key(payload, prev_hash, key)
+        return compute_audit_record_mac(payload, prev_hash)
+    if normalized == "hmac-sha256":
+        if key is not None:
+            return compute_audit_record_hmac_with_key(payload, prev_hash, key)
+        return compute_audit_record_hmac_with_key(payload, prev_hash, audit_chain_key())
+    return None
+
+
+def verify_audit_jsonl_chain(log_path: Path, *, max_lines: int = 50_000) -> dict[str, Any]:
+    """Verify a runtime JSONL audit chain with per-record algorithm dispatch."""
+    verified = 0
+    tampered = 0
+    previous_hash = ""
+    algorithms_seen: set[str] = set()
+
+    try:
+        lines = log_path.read_text().splitlines()
+    except OSError as exc:
+        return {
+            "verified": 0,
+            "tampered": 1,
+            "checked": 1,
+            "algorithms": [],
+            "error": f"audit_log_unreadable: {exc}",
+        }
+
+    chain_key = resolve_verifier_chain_key(log_path)
+
+    processed = 0
+    for raw_line in lines:
+        if processed >= max_lines:
+            break
+        line = raw_line.strip()
+        if not line:
+            continue
+        processed += 1
+
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            tampered += 1
+            continue
+        if not isinstance(entry, dict):
+            tampered += 1
+            continue
+
+        actual_prev = str(entry.get("prev_hash", ""))
+        actual_hash = str(entry.get("record_hash", ""))
+        algorithm = str(entry.get("record_hash_algorithm", "")).strip().lower().replace("_", "-")
+        algorithms_seen.add(algorithm or "aes-cmac-128")
+        payload = {k: v for k, v in entry.items() if k not in {"prev_hash", "record_hash"}}
+        expected_hash = compute_audit_record_hash(payload, actual_prev, algorithm, key=chain_key)
+
+        if expected_hash and actual_prev == previous_hash and actual_hash and hmac.compare_digest(actual_hash, expected_hash):
+            verified += 1
+        else:
+            tampered += 1
+
+        previous_hash = actual_hash or previous_hash
+
+    return {
+        "verified": verified,
+        "tampered": tampered,
+        "checked": verified + tampered,
+        "algorithms": sorted(algorithms_seen),
+    }
 
 
 def _sidecar_path_for(log_path: str | os.PathLike[str]) -> Path:

--- a/src/agent_bom/audit_replay.py
+++ b/src/agent_bom/audit_replay.py
@@ -28,11 +28,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
-from agent_bom.audit_integrity import (
-    compute_audit_record_mac,
-    compute_audit_record_mac_with_key,
-    resolve_verifier_chain_key,
-)
+from agent_bom.audit_integrity import verify_audit_jsonl_chain
 
 # ─── Entry dataclasses ────────────────────────────────────────────────────────
 
@@ -268,47 +264,8 @@ def verify_hash_chain(path: Path) -> tuple[int, int]:
     is set). Records emitted without ``record_hash_algorithm`` are treated
     as legacy and validated against the process-global chain key.
     """
-    verified = 0
-    tampered = 0
-    previous_hash = ""
-
-    # Resolve the verification key once per call so a sidecar-persisted
-    # ephemeral key is honoured even when AGENT_BOM_AUDIT_HMAC_KEY is unset
-    # in the verifier process.
-    chain_key = resolve_verifier_chain_key(path)
-
-    for raw_line in path.read_text().splitlines():
-        line = raw_line.strip()
-        if not line:
-            continue
-        try:
-            entry = json.loads(line)
-        except json.JSONDecodeError:
-            tampered += 1
-            continue
-        if not isinstance(entry, dict):
-            tampered += 1
-            continue
-
-        actual_prev = str(entry.get("prev_hash", ""))
-        actual_hash = str(entry.get("record_hash", ""))
-        algorithm = str(entry.get("record_hash_algorithm", "")).strip().lower()
-        payload = {k: v for k, v in entry.items() if k not in {"prev_hash", "record_hash"}}
-        if algorithm in {"", "aes-cmac-128"}:
-            expected_hash = compute_audit_record_mac_with_key(payload, actual_prev, chain_key)
-        else:
-            # Unknown algorithm — fall back to the process-global computation
-            # so legacy records still produce a meaningful result.
-            expected_hash = compute_audit_record_mac(payload, actual_prev)
-
-        if actual_prev == previous_hash and actual_hash and hmac.compare_digest(actual_hash, expected_hash):
-            verified += 1
-        else:
-            tampered += 1
-
-        previous_hash = actual_hash or previous_hash
-
-    return verified, tampered
+    result = verify_audit_jsonl_chain(path)
+    return int(result["verified"]), int(result["tampered"])
 
 
 # ─── Rich display ─────────────────────────────────────────────────────────────

--- a/tests/test_api_enterprise_tenant.py
+++ b/tests/test_api_enterprise_tenant.py
@@ -15,6 +15,7 @@ from agent_bom.api.models import CreateKeyRequest, FindingFeedbackRequest, JobSt
 from agent_bom.api.routes import enterprise
 from agent_bom.api.store import InMemoryJobStore
 from agent_bom.api.stores import _get_store, _get_trend_store, set_job_store, set_trend_store
+from agent_bom.audit_integrity import compute_audit_record_mac
 from agent_bom.baseline import InMemoryTrendStore, TrendPoint
 
 
@@ -516,6 +517,7 @@ async def test_export_audit_entries_supports_jsonl(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_list_audit_entries_and_integrity_are_tenant_scoped(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_LOG", raising=False)
     store = InMemoryAuditLog()
     store.append(AuditEntry(action="scan", actor="alice", resource="job/alpha", details={"tenant_id": "tenant-alpha"}))
     store.append(AuditEntry(action="scan", actor="bob", resource="job/beta", details={"tenant_id": "tenant-beta"}))
@@ -526,7 +528,53 @@ async def test_list_audit_entries_and_integrity_are_tenant_scoped(monkeypatch):
 
     assert listed["total"] == 1
     assert [entry["resource"] for entry in listed["entries"]] == ["job/alpha"]
-    assert integrity == {"verified": 1, "tampered": 0, "checked": 1}
+    assert integrity["verified"] == 1
+    assert integrity["tampered"] == 0
+    assert integrity["checked"] == 1
+    assert integrity["algorithms"] == ["hmac-sha256"]
+    assert integrity["chains"] == [
+        {
+            "name": "control_plane",
+            "algorithm": "hmac-sha256",
+            "verified": 1,
+            "tampered": 0,
+            "checked": 1,
+            "tenant_scoped": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_audit_integrity_includes_runtime_aes_cmac_chain(monkeypatch, tmp_path):
+    store = InMemoryAuditLog()
+    store.append(AuditEntry(action="scan", actor="alice", resource="job/alpha", details={"tenant_id": "tenant-alpha"}))
+    monkeypatch.setattr("agent_bom.api.audit_log.get_audit_log", lambda: store)
+
+    runtime_log = tmp_path / "proxy-audit.jsonl"
+    previous_hash = ""
+    lines = []
+    for payload in [
+        {"type": "tools/call", "tenant_id": "tenant-alpha", "tool": "read_file"},
+        {"type": "proxy_summary", "tenant_id": "tenant-alpha", "total_tool_calls": 1},
+    ]:
+        record = {**payload, "prev_hash": previous_hash, "record_hash_algorithm": "aes-cmac-128"}
+        digest_payload = {k: v for k, v in record.items() if k not in {"prev_hash", "record_hash"}}
+        record["record_hash"] = compute_audit_record_mac(digest_payload, previous_hash)
+        previous_hash = record["record_hash"]
+        lines.append(json.dumps(record))
+    runtime_log.write_text("\n".join(lines) + "\n")
+    monkeypatch.setenv("AGENT_BOM_LOG", str(runtime_log))
+
+    integrity = await enterprise.audit_integrity(_request("tenant-alpha"))
+
+    assert integrity["verified"] == 3
+    assert integrity["tampered"] == 0
+    assert integrity["checked"] == 3
+    assert integrity["algorithms"] == ["aes-cmac-128", "hmac-sha256"]
+    assert integrity["chains"][1]["name"] == "runtime_proxy"
+    assert integrity["chains"][1]["algorithm"] == "aes-cmac-128"
+    assert integrity["chains"][1]["verified"] == 2
+    assert integrity["chains"][1]["tenant_scoped"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_audit_replay.py
+++ b/tests/test_audit_replay.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from agent_bom import audit_integrity
-from agent_bom.audit_integrity import compute_audit_record_mac
+from agent_bom.audit_integrity import compute_audit_record_hash, compute_audit_record_mac
 from agent_bom.audit_replay import (
     AlertEntry,
     AuditLog,
@@ -49,6 +49,20 @@ def _chained(entries: list[dict]) -> list[dict]:
         digest_payload = {k: v for k, v in payload.items() if k not in {"prev_hash", "record_hash"}}
         payload["record_hash"] = compute_audit_record_mac(digest_payload, prev_hash)
         prev_hash = payload["record_hash"]
+        chained.append(payload)
+    return chained
+
+
+def _hmac_chained(entries: list[dict]) -> list[dict]:
+    chained: list[dict] = []
+    prev_hash = ""
+    for entry in entries:
+        payload = dict(entry)
+        payload["prev_hash"] = prev_hash
+        payload["record_hash_algorithm"] = "hmac-sha256"
+        digest_payload = {k: v for k, v in payload.items() if k not in {"prev_hash", "record_hash"}}
+        payload["record_hash"] = compute_audit_record_hash(digest_payload, prev_hash, "hmac-sha256")
+        prev_hash = str(payload["record_hash"])
         chained.append(payload)
     return chained
 
@@ -531,6 +545,27 @@ def test_verify_hash_chain_detects_tamper():
     p = _write_log(entries)
     verified, tampered = verify_hash_chain(p)
     assert verified == 1
+    assert tampered == 1
+
+
+def test_verify_hash_chain_accepts_hmac_sha256_records(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_AUDIT_HMAC_KEY", "unit-test-chain-key")
+    p = _write_log(_hmac_chained([TOOL_CALL, BLOCKED_CALL]))
+
+    verified, tampered = verify_hash_chain(p)
+
+    assert verified == 2
+    assert tampered == 0
+
+
+def test_verify_hash_chain_rejects_unknown_record_algorithm():
+    entries = _chained([TOOL_CALL])
+    entries[0]["record_hash_algorithm"] = "sha1"
+    p = _write_log(entries)
+
+    verified, tampered = verify_hash_chain(p)
+
+    assert verified == 0
     assert tampered == 1
 
 


### PR DESCRIPTION
## Summary
- add shared JSONL audit-chain verification with per-record algorithm dispatch
- verify runtime proxy AES-CMAC logs from /v1/audit/integrity when AGENT_BOM_LOG is configured
- keep CLI audit replay on the same verifier and fail closed on unknown record hash algorithms

## Verification
- uv run pytest tests/test_audit_replay.py tests/test_api_enterprise_tenant.py::test_list_audit_entries_and_integrity_are_tenant_scoped tests/test_api_enterprise_tenant.py::test_audit_integrity_includes_runtime_aes_cmac_chain -q
- uv run ruff check src/agent_bom/audit_integrity.py src/agent_bom/audit_replay.py src/agent_bom/api/routes/enterprise.py tests/test_audit_replay.py tests/test_api_enterprise_tenant.py
- git diff --check

## Notes
- The control-plane audit table remains tenant-scoped HMAC-SHA256.
- Runtime proxy JSONL verification is chain-wide because the hash chain can cross tenant records in a single configured log file.