### PR TITLE
Add MCP exposure paths tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ agent-bom
 | Browser UI image (`agentbom/agent-bom-ui`) | browser dashboard paired with the same API/control plane | `docker compose -f docker-compose.pilot.yml up -d` | dashboard at `http://localhost:3000` |
 | Kubernetes / Helm | self-hosted API + dashboard, scheduled discovery | `helm upgrade --install agent-bom deploy/helm/agent-bom --set controlPlane.enabled=true` | API, UI, jobs, optional gateway/proxy |
 | REST API (`agent-bom api` / `agent-bom serve`) | platform integration and self-hosted control plane | `agent-bom serve --port 8422 --persist jobs.db` | `/docs`, `/health`, `/v1/scan`, `/v1/fleet` |
-| MCP server (`agent-bom mcp server`) | Claude Desktop, Claude Code, Cursor, Codex, Windsurf, Cortex | `agent-bom mcp server` | 36 read-only MCP security tools |
+| MCP server (`agent-bom mcp server`) | Claude Desktop, Claude Code, Cursor, Codex, Windsurf, Cortex | `agent-bom mcp server` | 37 read-only MCP security tools |
 | Runtime proxy (`agent-bom proxy`) | MCP traffic enforcement | `agent-bom proxy --log audit.jsonl --block-undeclared -- ...` | audit JSONL, metrics, policy decisions |
 | Shield SDK (`from agent_bom.shield import Shield`) | in-process protection | `from agent_bom.shield import Shield` | allow/block decisions and redacted alerts |
 
@@ -488,7 +488,7 @@ see value and where enterprises wire agent-bom into existing controls.
 
 | Integration surface | Examples | What agent-bom does |
 |---|---|---|
-| MCP and coding agents | Claude Desktop / Code, Cursor, Windsurf, VS Code, Cortex Code, OpenAI Codex CLI | discovers configured MCP servers, exposes 36 read-only security tools, and returns findings to the assistant workflow |
+| MCP and coding agents | Claude Desktop / Code, Cursor, Windsurf, VS Code, Cortex Code, OpenAI Codex CLI | discovers configured MCP servers, exposes 37 read-only security tools, and returns findings to the assistant workflow |
 | Skills and plugins | OpenClaw skills, Cortex Code skill, MCP Registry, Smithery, Glama, Docker MCP registry | packages repeatable scan, compliance, registry, runtime, and Snowflake discovery workflows where agent users already work |
 | CI/CD and developer workflow | GitHub Action, SARIF, pre-install `check`, Docker, local CLI | blocks unsafe packages, uploads code-scanning evidence, and keeps SBOM/remediation output scriptable |
 | Cloud, warehouse, and AI infra | AWS, Azure, GCP, Snowflake, Databricks, CoreWeave, Nebius, Hugging Face, OpenAI, W&B, MLflow, Ollama | pulls read-only inventory and posture evidence with operator-controlled credentials |
@@ -625,7 +625,7 @@ see [GitHub Action SARIF troubleshooting](docs/GITHUB_ACTION_SARIF_TROUBLESHOOTI
 
 ## MCP server
 
-36 read-only security tools, 6 resources, and 6 workflow prompts available inside any MCP-compatible AI assistant:
+37 read-only security tools, 6 resources, and 6 workflow prompts available inside any MCP-compatible AI assistant:
 
 ```json
 {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -232,7 +232,7 @@ graph TB
 | Output | `src/agent_bom/output/__init__.py` | JSON, CycloneDX, SARIF, SPDX, console |
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine (17 conditions) |
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP proxy (7 inline detectors) |
-| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (36 tools) |
+| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (37 tools) |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse |
 | Asset Tracker | `src/agent_bom/asset_tracker.py` | Persistent vuln tracking — first_seen, resolved, MTTR |
 | Context Graph | `src/agent_bom/context_graph.py` | Lateral movement analysis — see [Graph Contract](graph/CONTRACT.md) for entity/edge coverage, accuracy guarantees, and scaling boundaries |

--- a/docs/CLAUDE_INTEGRATION.md
+++ b/docs/CLAUDE_INTEGRATION.md
@@ -59,7 +59,7 @@ claude mcp add agent-bom -- uvx agent-bom mcp server
 
 ## What users get inside Claude
 
-`agent-bom mcp server` exposes 36 read-only tools for:
+`agent-bom mcp server` exposes 37 read-only tools for:
 
 - agent and MCP discovery
 - package and registry checks

--- a/docs/CODEX_CLI.md
+++ b/docs/CODEX_CLI.md
@@ -20,7 +20,7 @@ command = "agent-bom"
 args = ["mcp", "server"]
 ```
 
-That makes the same 36 read-only `agent-bom` MCP tools available to Codex.
+That makes the same 37 read-only `agent-bom` MCP tools available to Codex.
 
 ## What agent-bom discovers for Codex
 

--- a/docs/CORTEX_CODE.md
+++ b/docs/CORTEX_CODE.md
@@ -41,7 +41,7 @@ Or, if `agent-bom` is already installed:
 }
 ```
 
-This makes the same 36 `agent-bom` MCP tools available in CoCo conversations.
+This makes the same 37 `agent-bom` MCP tools available in CoCo conversations.
 
 ## What agent-bom discovers for Cortex
 

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -210,7 +210,7 @@ For cross-agent correlation, use the broader runtime protection engine (`agent-b
 agent-bom mcp server
 ```
 
-Exposes 36 tools to any MCP-compatible AI assistant. Your agent can run scans, check packages, query the registry, and generate compliance reports without leaving the chat:
+Exposes 37 tools to any MCP-compatible AI assistant. Your agent can run scans, check packages, query ExposurePaths, query the registry, and generate compliance reports without leaving the chat:
 
 ```
 scan                — full discovery + scan, returns JSON report

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -150,7 +150,7 @@ An agent operating autonomously can be steered into a multi-step exfiltration se
 │  2. PROXY         Sits between client and server, intercepts     │
 │     (agent-bom proxy) every JSON-RPC message, enforces policy    │
 │                                                                  │
-│  3. MCP SERVER    Exposes 36 scan/governance tools to any agent  │
+│  3. MCP SERVER    Exposes 37 scan/governance tools to any agent  │
 │     (agent-bom mcp server)  — scan, check, registry, compliance  │
 └─────────────────────────────────────────────────────────────────┘
 ```

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,6 +1,6 @@
 # MCP Server — Connect agent-bom to AI Assistants
 
-agent-bom exposes 36 security tools as an MCP server. Any MCP-compatible client
+agent-bom exposes 37 security tools as an MCP server. Any MCP-compatible client
 can connect and get vulnerability scanning, blast radius analysis, compliance
 checks, and supply chain verification through natural conversation.
 
@@ -155,20 +155,20 @@ agent-bom proxy-bootstrap \
 
 `proxy-configure` is best for JSON MCP clients such as Claude Desktop, Cursor, Windsurf, and Cortex CoCo. TOML-based clients like Codex CLI need manual proxy wrapping.
 
-## Tool Categories (36 tools)
+## Tool Categories (37 tools)
 
 | Category | Tools | What They Do |
 |----------|-------|-------------|
 | **Scan** | `scan`, `code_scan`, `vector_db_scan`, `gpu_infra_scan`, `ai_inventory_scan` | Discover agents, scan packages, code, vector stores, GPU infra, and AI usage |
 | **Check** | `check`, `verify`, `marketplace_check`, `license_compliance_scan` | Pre-install CVE gate, integrity verification, marketplace trust, and license policy |
-| **Blast Radius** | `blast_radius` | Map package → vulnerability finding → MCP server (tools + credential env names) → connected agents |
+| **Blast Radius** | `blast_radius`, `exposure_paths` | Map package → vulnerability finding → MCP server (tools + credential env names) → connected agents; return ranked ExposurePath JSON for headless agents |
 | **Registry** | `registry_lookup`, `inventory`, `where`, `fleet_scan` | Query the MCP registry, inspect discovery paths, and summarize fleet inventories |
 | **Compliance** | `compliance`, `cis_benchmark`, `aisvs_benchmark` | Run OWASP, NIST, MITRE ATLAS, CIS, and AISVS-aligned posture checks |
 | **Policy** | `policy_check`, `remediate` | Evaluate policies and generate guided remediation plans |
 | **Inventory** | `inventory` | List agents/servers without CVE scanning |
 | **Trust** | `marketplace_check`, `runtime_correlate`, `tool_risk_assessment` | Score package trust, correlate runtime usage, and assess live tool capability risk |
 | **Skills** | `skill_scan`, `skill_verify`, `skill_trust` | Instruction-file trust, provenance, and tool-poisoning detection |
-| **Graph / Runtime** | `context_graph`, `graph_export`, `runtime_correlate`, `tool_risk_assessment` | Visualize lateral movement, export graph data, and connect runtime logs to findings |
+| **Graph / Runtime** | `exposure_paths`, `context_graph`, `graph_export`, `runtime_correlate`, `tool_risk_assessment` | Return ranked investigation paths, visualize lateral movement, export graph data, and connect runtime logs to findings |
 | **AI supply chain** | `dataset_card_scan`, `training_pipeline_scan`, `browser_extension_scan`, `model_provenance_scan`, `prompt_scan`, `model_file_scan`, `ingest_external_scan` | Scan AI artifacts, prompts, model files, browser extensions, and external scanner results |
 
 ## Example Conversations

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -56,7 +56,7 @@ Add to `~/.snowflake/cortex/mcp.json`:
 }
 ```
 
-CoCo can then call the same 36 `agent-bom` tools over MCP.
+CoCo can then call the same 37 `agent-bom` tools over MCP.
 
 agent-bom also discovers Cortex auxiliary security files alongside `mcp.json`:
 

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,10 +1,10 @@
 {
-  "generated_on": "2026-04-30",
+  "generated_on": "2026-05-14",
   "version": "0.86.5",
   "metrics": [
     {
       "name": "MCP tools",
-      "value": 36,
+      "value": 37,
       "source": "src/agent_bom/mcp_server_metadata.py",
       "notes": "Counted from the advertised server-card tools."
     },
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 438,
+      "value": 468,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 421,
+      "value": 470,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },
@@ -58,9 +58,9 @@
     },
     {
       "name": "Compliance surfaces",
-      "value": 15,
+      "value": 16,
       "source": "src/agent_bom/compliance_coverage.py",
-      "notes": "15 tag-mapped frameworks plus the OWASP AISVS benchmark surface."
+      "notes": "14 tag-mapped frameworks plus the OWASP AISVS benchmark surface."
     },
     {
       "name": "Proxy inline detectors",

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,21 +5,21 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-04-30`
+- Generated on: `2026-05-14`
 - Version: `0.86.5`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |
-| MCP tools | 36 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
+| MCP tools | 37 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 35 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 438 | `tests/` | Counts files matching test_*.py. |
+| Test files | 468 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 18 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 23 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 421 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 470 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
-| Compliance surfaces | 15 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
+| Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 14 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |
 | Runtime protection engine detectors | 8 | `src/agent_bom/runtime/protection.py` | Broader protection engine used outside the lighter proxy-only path. |
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -13,7 +13,7 @@ agent-bom operates in four modes:
 1. **Scanner** — reads local config files + public APIs, produces reports
 2. **Proxy** — sits between an MCP client and server, inspects STDIO traffic
 3. **API server** — exposes REST/WebSocket endpoints for the dashboard
-4. **MCP server** — exposes 36 tools to AI assistants (Claude, Cursor, etc.)
+4. **MCP server** — exposes 37 tools to AI assistants (Claude, Cursor, etc.)
 
 ## Trust boundaries
 

--- a/integrations/docker-mcp-registry/tools.json
+++ b/integrations/docker-mcp-registry/tools.json
@@ -25,6 +25,16 @@
     ]
   },
   {
+    "name": "exposure_paths",
+    "description": "Return ranked ExposurePath JSON from the graph store for headless security agents.",
+    "arguments": [
+      {"name": "tenant_id", "type": "string", "desc": "Tenant ID for the graph snapshot (default: default)"},
+      {"name": "scan_id", "type": "string", "desc": "Optional graph scan ID; omit to use latest snapshot"},
+      {"name": "limit", "type": "integer", "desc": "Maximum ranked exposure paths to return (1-100)"},
+      {"name": "min_risk", "type": "number", "desc": "Minimum path risk score to include (0-100)"}
+    ]
+  },
+  {
     "name": "policy_check",
     "description": "Evaluate a security policy against current scan results — returns pass/fail per rule.",
     "arguments": [

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -398,7 +398,7 @@ def main() -> int:
     tools = len(tool_names)
     resources = len(resource_uris)
     prompts = len(prompt_names)
-    if (tools, resources, prompts) != (36, 6, 6):
+    if (tools, resources, prompts) != (37, 6, 6):
         _fail(f"MCP server card count changed unexpectedly: tools={tools}, resources={resources}, prompts={prompts}")
     docker_mcp_tool_names = [str(tool["name"]) for tool in json.loads(DOCKER_MCP_TOOLS.read_text())]
     if docker_mcp_tool_names != tool_names:

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server Setup
 
-agent-bom runs as an MCP server, exposing 36 read-only security tools to any MCP client.
+agent-bom runs as an MCP server, exposing 37 read-only security tools to any MCP client.
 The server card also advertises 6 resources and 6 workflow prompts so agents can
 choose structured playbooks instead of guessing tool order.
 

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -19,6 +19,12 @@ Map the full impact chain of a CVE across agents, servers, credentials, and tool
 blast_radius(cve_id="CVE-2024-21538")
 ```
 
+### exposure_paths
+Return ranked ExposurePath JSON from the graph store for headless security agents.
+```
+exposure_paths(tenant_id="default", limit=5, min_risk=70)
+```
+
 ### registry_lookup
 Look up an MCP server in the 427+ server security metadata registry.
 ```

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -674,10 +674,11 @@ def mcp_server_cmd(
     Requires:  pip install 'agent-bom[mcp-server]'
 
     \b
-    Exposes 36 security tools via MCP protocol:
+    Exposes 37 security tools via MCP protocol:
       scan                   Full scan — CVEs, config security, blast radius, compliance
       check                  Check a specific package for CVEs before installing
       blast_radius           Look up blast radius for a specific CVE
+      exposure_paths         Return ranked ExposurePath JSON for headless agents
       policy_check           Evaluate policy rules against scan findings
       registry_lookup        Query MCP server security metadata registry
       generate_sbom          Generate CycloneDX or SPDX SBOM

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -375,6 +375,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
         compliance_impl,
         policy_check_impl,
     )
+    from agent_bom.mcp_tools.graph import exposure_paths_impl
     from agent_bom.mcp_tools.registry import registry_lookup_impl
     from agent_bom.mcp_tools.runtime import verify_impl
     from agent_bom.mcp_tools.sbom import generate_sbom_impl, remediate_impl
@@ -545,7 +546,32 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
             _truncate_response=_truncate_response,
         )
 
-    # ── Tool 4: policy_check ──────────────────────────────────────────
+    # ── Tool 4: exposure_paths ───────────────────────────────────────
+
+    @mcp.tool(annotations=_READ_ONLY, title="Exposure Paths")
+    async def exposure_paths(
+        tenant_id: Annotated[str, Field(description="Tenant ID for the graph snapshot. Defaults to 'default'.")] = "default",
+        scan_id: Annotated[str | None, Field(description="Optional graph scan ID. Omit to use the latest snapshot.")] = None,
+        limit: Annotated[int, Field(ge=1, le=100, description="Maximum number of ranked exposure paths to return.")] = 5,
+        min_risk: Annotated[float, Field(ge=0, le=100, description="Minimum path risk score to include.")] = 0.0,
+    ) -> str:
+        """Return ranked ExposurePath JSON for headless security agents.
+
+        This is the agent-native graph surface: Claude, Cursor, Codex,
+        Windsurf, Cortex, and other MCP clients can request the same
+        investigation objects used by the dashboard without scraping UI state.
+        """
+        return await _execute_tool_async(
+            "exposure_paths",
+            exposure_paths_impl,
+            tenant_id=tenant_id,
+            scan_id=scan_id,
+            limit=limit,
+            min_risk=min_risk,
+            _truncate_response=_truncate_response,
+        )
+
+    # ── Tool 5: policy_check ──────────────────────────────────────────
 
     @mcp.tool(annotations=_READ_ONLY, title="Policy Evaluation")
     async def policy_check(

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -5,7 +5,7 @@ Start with:
     agent-bom mcp server --transport sse          # SSE transport (for remote clients)
     agent-bom mcp server --transport streamable-http
 
-Tools (36):
+Tools (37):
     scan                — Full discovery → scan → output pipeline
     check               — Check a specific package for CVEs before installing
     blast_radius        — Look up blast radius for a specific CVE

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -10,6 +10,11 @@ _SERVER_CARD_TOOLS = [
     {"name": "check", "description": "Check a specific package for CVEs before installing", "annotations": {"readOnlyHint": True}},
     {"name": "blast_radius", "description": "Look up blast radius for a specific CVE", "annotations": {"readOnlyHint": True}},
     {
+        "name": "exposure_paths",
+        "description": "Return ranked ExposurePath JSON for headless security agents and MCP clients",
+        "annotations": {"readOnlyHint": True},
+    },
+    {
         "name": "policy_check",
         "description": (
             "Evaluate security policy rules against scan findings — supports 17 conditions"
@@ -165,6 +170,7 @@ _TOOL_CAPABILITY_CLASSES = {
     "scan": ["READ", "NETWORK", "LOCAL_FILE_READ"],
     "check": ["READ", "NETWORK"],
     "blast_radius": ["READ", "ANALYZE"],
+    "exposure_paths": ["READ", "GRAPH", "ANALYZE"],
     "policy_check": ["READ", "POLICY"],
     "registry_lookup": ["READ", "REGISTRY"],
     "generate_sbom": ["READ", "EXPORT"],

--- a/src/agent_bom/mcp_tools/graph.py
+++ b/src/agent_bom/mcp_tools/graph.py
@@ -1,0 +1,167 @@
+"""Graph-native MCP tools for headless agent consumers."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from agent_bom.mcp_errors import CODE_INTERNAL_UNEXPECTED, CODE_VALIDATION_INVALID_ARGUMENT, mcp_error_json
+
+logger = logging.getLogger(__name__)
+
+
+def _node_role(node: Any) -> str:
+    entity_type = getattr(node, "entity_type", "")
+    value = entity_type.value if hasattr(entity_type, "value") else str(entity_type)
+    return value or "unknown"
+
+
+def _node_ref(node_id: str, nodes_by_id: dict[str, Any]) -> dict[str, Any]:
+    node = nodes_by_id.get(node_id)
+    if node is None:
+        return {"id": node_id, "label": node_id, "role": "unknown"}
+    return {
+        "id": node.id,
+        "label": node.label,
+        "role": _node_role(node),
+        "severity": getattr(node, "severity", ""),
+        "riskScore": float(getattr(node, "risk_score", 0.0) or 0.0),
+    }
+
+
+def _relationship_refs(path: Any, edges: list[Any]) -> list[dict[str, Any]]:
+    edge_ids = set(getattr(path, "edges", []) or [])
+    hop_pairs = set(zip(getattr(path, "hops", [])[:-1], getattr(path, "hops", [])[1:]))
+    refs: list[dict[str, Any]] = []
+    for edge in edges:
+        edge_id = str(getattr(edge, "id", ""))
+        source = str(getattr(edge, "source", ""))
+        target = str(getattr(edge, "target", ""))
+        if edge_id not in edge_ids and (source, target) not in hop_pairs:
+            continue
+        relationship = getattr(edge, "relationship", "")
+        relationship_value = relationship.value if hasattr(relationship, "value") else str(relationship)
+        refs.append(
+            {
+                "id": edge_id,
+                "source": source,
+                "target": target,
+                "relationship": relationship_value,
+                "confidence": float(getattr(edge, "confidence", 1.0) or 0.0),
+            }
+        )
+    return refs
+
+
+def _severity_for_path(path: Any, nodes_by_id: dict[str, Any]) -> str:
+    severity_order = {"critical": 4, "high": 3, "medium": 2, "low": 1, "none": 0, "": 0}
+    severity = ""
+    for hop in getattr(path, "hops", []) or []:
+        node = nodes_by_id.get(hop)
+        candidate = str(getattr(node, "severity", "") or "").lower() if node is not None else ""
+        if severity_order.get(candidate, 0) > severity_order.get(severity, 0):
+            severity = candidate
+    if severity:
+        return severity
+    risk = float(getattr(path, "composite_risk", 0.0) or 0.0)
+    if risk >= 90 or risk >= 9:
+        return "critical"
+    if risk >= 70 or risk >= 7:
+        return "high"
+    if risk >= 40 or risk >= 4:
+        return "medium"
+    return "none"
+
+
+def _exposure_path_payload(path: Any, *, nodes_by_id: dict[str, Any], edges: list[Any], rank: int, scan_id: str) -> dict[str, Any]:
+    hops = [_node_ref(hop, nodes_by_id) for hop in getattr(path, "hops", []) or []]
+    source = _node_ref(str(getattr(path, "source", "") or ""), nodes_by_id) if getattr(path, "source", "") else (hops[0] if hops else {})
+    target = _node_ref(str(getattr(path, "target", "") or ""), nodes_by_id) if getattr(path, "target", "") else (hops[-1] if hops else {})
+    relationships = _relationship_refs(path, edges)
+    return {
+        "id": f"{source.get('id', '')}::{target.get('id', '')}::{'->'.join(getattr(path, 'hops', []) or [])}",
+        "rank": rank,
+        "label": getattr(path, "summary", "") or "Exposure path",
+        "summary": getattr(path, "summary", ""),
+        "riskScore": float(getattr(path, "composite_risk", 0.0) or 0.0),
+        "severity": _severity_for_path(path, nodes_by_id),
+        "source": source,
+        "target": target,
+        "hops": hops,
+        "relationships": relationships,
+        "nodeIds": list(getattr(path, "hops", []) or []),
+        "edgeIds": [relationship["id"] for relationship in relationships if relationship.get("id")],
+        "findings": list(getattr(path, "vuln_ids", []) or []),
+        "reachableTools": list(getattr(path, "tool_exposure", []) or []),
+        "exposedCredentials": list(getattr(path, "credential_exposure", []) or []),
+        "provenance": {"source": "mcp_exposure_paths", "scanId": scan_id},
+    }
+
+
+async def exposure_paths_impl(
+    *,
+    tenant_id: str = "default",
+    scan_id: str | None = None,
+    limit: int = 5,
+    min_risk: float = 0.0,
+    _get_graph_store=None,
+    _truncate_response=None,
+) -> str:
+    """Return ranked ExposurePath JSON for headless agent consumers."""
+    if limit < 1 or limit > 100:
+        return mcp_error_json(
+            CODE_VALIDATION_INVALID_ARGUMENT,
+            "limit must be between 1 and 100",
+            details={"argument": "limit", "value": limit},
+        )
+    if min_risk < 0 or min_risk > 100:
+        return mcp_error_json(
+            CODE_VALIDATION_INVALID_ARGUMENT,
+            "min_risk must be between 0 and 100",
+            details={"argument": "min_risk", "value": min_risk},
+        )
+
+    try:
+        if _get_graph_store is None:
+            from agent_bom.api.stores import _get_graph_store as _default_get_graph_store
+
+            _get_graph_store = _default_get_graph_store
+
+        store = _get_graph_store()
+        effective_scan_id, created_at, paths, total = await asyncio.to_thread(
+            store.attack_paths,
+            tenant_id=tenant_id,
+            scan_id=scan_id or "",
+            offset=0,
+            limit=min(max(limit * 3, limit), 1000),
+        )
+        ranked_paths = [path for path in paths if float(getattr(path, "composite_risk", 0.0) or 0.0) >= min_risk][:limit]
+        hop_ids = {hop for path in ranked_paths for hop in (getattr(path, "hops", []) or [])}
+        nodes = await asyncio.to_thread(store.nodes_by_ids, tenant_id=tenant_id, scan_id=effective_scan_id, node_ids=hop_ids)
+        edges = await asyncio.to_thread(store.edges_for_node_ids, tenant_id=tenant_id, scan_id=effective_scan_id, node_ids=hop_ids)
+        stats = await asyncio.to_thread(store.snapshot_stats, tenant_id=tenant_id, scan_id=effective_scan_id)
+        nodes_by_id = {node.id: node for node in nodes}
+        payload = {
+            "schema_version": "v1",
+            "tool": "exposure_paths",
+            "tenant_id": tenant_id,
+            "scan_id": effective_scan_id,
+            "created_at": created_at,
+            "count": len(ranked_paths),
+            "total": total,
+            "filters": {"limit": limit, "min_risk": min_risk},
+            "paths": [
+                _exposure_path_payload(path, nodes_by_id=nodes_by_id, edges=edges, rank=index + 1, scan_id=effective_scan_id)
+                for index, path in enumerate(ranked_paths)
+            ],
+            "nodes": [node.to_dict() for node in nodes],
+            "edges": [edge.to_dict() for edge in edges],
+            "stats": stats,
+        }
+        encoded = json.dumps(payload, indent=2, default=str)
+        return _truncate_response(encoded) if _truncate_response is not None else encoded
+    except Exception as exc:
+        logger.exception("MCP graph tool error")
+        return mcp_error_json(CODE_INTERNAL_UNEXPECTED, exc)

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -157,6 +157,7 @@ def test_server_card_has_all_tools():
     assert "scan" in tool_names
     assert "check" in tool_names
     assert "blast_radius" in tool_names
+    assert "exposure_paths" in tool_names
     assert "policy_check" in tool_names
     assert "registry_lookup" in tool_names
     assert "generate_sbom" in tool_names
@@ -228,7 +229,7 @@ def test_mcp_docs_match_resource_and_prompt_catalog():
     )
     card = build_server_card()
     assert "35 security tools" not in docs
-    assert "36" in docs
+    assert "37" in docs
     for resource in card["resources"]:
         assert resource["uri"] in docs
     for prompt in card["prompts"]:
@@ -488,7 +489,7 @@ def test_mcp_server_help_shows_skill_tools():
 
     runner = CliRunner()
     result = runner.invoke(main, ["mcp", "server", "--help"])
-    assert "36 security tools" in result.output
+    assert "37 security tools" in result.output
     assert "skill_scan" in result.output
     assert "skill_verify" in result.output
     assert "compliance" in result.output

--- a/tests/test_mcp_exposure_paths.py
+++ b/tests/test_mcp_exposure_paths.py
@@ -1,0 +1,80 @@
+"""Tests for MCP graph ExposurePath tooling."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent_bom.graph import AttackPath, EntityType, RelationshipType, UnifiedEdge, UnifiedNode
+from agent_bom.mcp_tools.graph import exposure_paths_impl
+
+
+class _GraphStore:
+    def __init__(self) -> None:
+        self.path = AttackPath(
+            source="agent:prod-assistant",
+            target="vuln:CVE-2026-0001",
+            hops=["agent:prod-assistant", "package:requests", "vuln:CVE-2026-0001"],
+            composite_risk=88.0,
+            summary="Prod assistant reaches vulnerable requests package",
+            credential_exposure=["AWS_TOKEN"],
+            tool_exposure=["read_file"],
+            vuln_ids=["CVE-2026-0001"],
+        )
+        self.nodes = [
+            UnifiedNode(id="agent:prod-assistant", entity_type=EntityType.AGENT, label="prod-assistant", risk_score=72.0),
+            UnifiedNode(id="package:requests", entity_type=EntityType.PACKAGE, label="requests", risk_score=70.0),
+            UnifiedNode(
+                id="vuln:CVE-2026-0001",
+                entity_type=EntityType.VULNERABILITY,
+                label="CVE-2026-0001",
+                severity="high",
+                risk_score=88.0,
+            ),
+        ]
+        self.edges = [
+            UnifiedEdge(source="agent:prod-assistant", target="package:requests", relationship=RelationshipType.DEPENDS_ON),
+            UnifiedEdge(source="package:requests", target="vuln:CVE-2026-0001", relationship=RelationshipType.VULNERABLE_TO),
+        ]
+
+    def attack_paths(self, **_kwargs):
+        return "scan-1", "2026-05-14T18:00:00Z", [self.path], 1
+
+    def nodes_by_ids(self, *, node_ids: set[str], **_kwargs):
+        return [node for node in self.nodes if node.id in node_ids]
+
+    def edges_for_node_ids(self, **_kwargs):
+        return self.edges
+
+    def snapshot_stats(self, **_kwargs):
+        return {"attack_path_count": 1, "max_attack_path_risk": 88.0}
+
+
+@pytest.mark.asyncio
+async def test_exposure_paths_impl_returns_agent_native_contract():
+    response = await exposure_paths_impl(_get_graph_store=lambda: _GraphStore(), _truncate_response=lambda value: value)
+    payload = json.loads(response)
+
+    assert payload["schema_version"] == "v1"
+    assert payload["tool"] == "exposure_paths"
+    assert payload["scan_id"] == "scan-1"
+    assert payload["count"] == 1
+    path = payload["paths"][0]
+    assert path["riskScore"] == 88.0
+    assert path["severity"] == "high"
+    assert path["source"]["role"] == "agent"
+    assert path["target"]["role"] == "vulnerability"
+    assert path["findings"] == ["CVE-2026-0001"]
+    assert path["reachableTools"] == ["read_file"]
+    assert path["exposedCredentials"] == ["AWS_TOKEN"]
+    assert path["relationships"]
+
+
+@pytest.mark.asyncio
+async def test_exposure_paths_impl_validates_agent_limits():
+    response = await exposure_paths_impl(limit=0, _get_graph_store=lambda: _GraphStore())
+    payload = json.loads(response)
+
+    assert payload["error"]["code"] == "AGENTBOM_MCP_VALIDATION_INVALID_ARGUMENT"
+    assert payload["error"]["details"]["argument"] == "limit"

--- a/tests/test_mcp_strict_args.py
+++ b/tests/test_mcp_strict_args.py
@@ -27,7 +27,7 @@ def mcp_server():
 def test_every_tool_advertises_additional_properties_false(mcp_server) -> None:  # noqa: ANN001
     """Every registered tool's JSON schema must reject unknown properties."""
     tools = list(mcp_server._tool_manager._tools.values())
-    assert len(tools) >= 30, f"expected ~36 tools, got {len(tools)}"
+    assert len(tools) >= 30, f"expected ~37 tools, got {len(tools)}"
     leaks: list[str] = []
     for tool in tools:
         params = tool.parameters or {}


### PR DESCRIPTION
## Summary
- add an MCP `exposure_paths` tool that returns ranked ExposurePath JSON from the graph store
- register the tool in server-card metadata with graph analysis capability classes
- update MCP docs and CLI help to the 37-tool surface

## Verification
- uv run pytest tests/test_mcp_exposure_paths.py tests/test_deployment.py::test_server_card_has_all_tools tests/test_deployment.py::test_server_card_tool_count_matches_decorators tests/test_deployment.py::test_mcp_docs_match_resource_and_prompt_catalog tests/test_deployment.py::test_mcp_server_help_shows_skill_tools -q
- uv run ruff check src/agent_bom/mcp_tools/graph.py src/agent_bom/mcp_server.py src/agent_bom/mcp_server_metadata.py src/agent_bom/cli/_server.py tests/test_mcp_exposure_paths.py tests/test_deployment.py
- git diff --check

## Notes
- The tool is read-only and uses existing graph-store attack paths.
- This gives headless security agents the same investigation object the UI uses, without making the dashboard mandatory.