### PR TITLE
Route medium behavioral skill findings to review

### DIFF
--- a/src/agent_bom/parsers/trust_assessment.py
+++ b/src/agent_bom/parsers/trust_assessment.py
@@ -799,6 +799,8 @@ def _compute_review_verdict(
         return ReviewVerdict.BLOCKED
     if content_verdict == Verdict.MALICIOUS or any(f.category in _HIGH_RISK_FINDING_CATEGORIES for f in findings):
         return ReviewVerdict.HIGH_RISK
+    if any(f.severity == "medium" and _is_behavioral_content_finding(f.category) for f in findings):
+        return ReviewVerdict.REVIEW
     if (
         content_verdict == Verdict.SUSPICIOUS
         or provenance_verdict == ProvenanceVerdict.UNVERIFIED

--- a/tests/test_mcp_tool_impls.py
+++ b/tests/test_mcp_tool_impls.py
@@ -1094,6 +1094,11 @@ def test_skill_scan_impl_success(tmp_path):
     )
     data = json.loads(result)
     assert data["summary"]["files_scanned"] == 1
+    trust = data["files"][0]["trust"]
+    assert trust["verdict"] == "benign"
+    assert trust["content_verdict"] == "benign"
+    assert trust["provenance_verdict"] == "unverified"
+    assert trust["overall_recommendation"] == "review"
 
 
 def test_skill_verify_impl_success(tmp_path):

--- a/tests/test_trust_assessment.py
+++ b/tests/test_trust_assessment.py
@@ -557,6 +557,20 @@ def test_high_severity_behavioral_finding_is_suspicious():
     assert result.verdict == Verdict.SUSPICIOUS
 
 
+def test_medium_behavioral_finding_requires_review_without_content_suspicion():
+    """Medium behavioral findings are benign content but still need review."""
+    scan = _make_scan()
+    audit = _make_audit(findings=[_finding("network_exposure", severity="medium", title="Network exposure")])
+
+    result = assess_trust(scan, audit)
+
+    assert result.content_verdict == Verdict.BENIGN
+    assert result.verdict == Verdict.BENIGN
+    assert result.provenance_verdict == ProvenanceVerdict.VERIFIED
+    assert result.review_verdict == ReviewVerdict.REVIEW
+    assert result.to_dict()["overall_recommendation"] == "review"
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # 8. Recommendation tests
 # ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- route medium-severity behavioral skill findings to `review_verdict=review`
- keep the content axis benign for medium behavioral findings so `verdict` remains backward-compatible
- add MCP `skill_scan` response-shape assertions for content/provenance/recommendation fields

## Why
The dual-axis skills verdict split should not label provenance-only or medium behavioral review items as suspicious content, but medium behavioral signals still need a handling decision. This closes the remaining gap from the #2569 acceptance review.

## Verification
- `uv run pytest -q tests/test_skills_service.py::test_clean_unsigned_skill_requires_review_without_malicious_status tests/test_trust_assessment.py::test_content_verdict_ignores_metadata_only_findings tests/test_trust_assessment.py::test_credential_file_access_blocks_content_verdict tests/test_trust_assessment.py::test_shell_access_remains_high_risk_content_verdict tests/test_trust_assessment.py::test_high_severity_behavioral_finding_is_suspicious tests/test_trust_assessment.py::test_medium_behavioral_finding_requires_review_without_content_suspicion tests/test_trust_assessment.py::test_assess_trust_no_frontmatter tests/test_skill_audit.py::test_metadata_undeclared_docker_dep tests/test_skill_audit.py::test_metadata_declared_docker_no_finding tests/test_skill_audit.py::test_metadata_undocumented_network tests/test_skill_audit.py::test_metadata_documented_network_no_finding tests/test_output_formats.py::TestMarkdown::test_skill_trust_axes_render_in_markdown tests/test_output_formats.py::test_skill_trust_axes_are_embedded_in_sarif_properties tests/test_core.py::test_html_trust_assessment_section tests/test_mcp_tool_impls.py::test_skill_trust_impl_success tests/test_mcp_tool_impls.py::test_skill_scan_impl_success tests/test_mcp_strict_args.py`
- `uv run ruff check src/agent_bom/parsers/trust_assessment.py tests/test_trust_assessment.py tests/test_mcp_tool_impls.py`
- `git diff --check`
