### PR TITLE
Fix Neptune ADR site docs link

### DIFF
--- a/site-docs/deployment/backend-parity.md
+++ b/site-docs/deployment/backend-parity.md
@@ -70,7 +70,7 @@ enterprise graph-store candidate for deployments that eventually need
 graph-native traversal at a scale beyond the Postgres default.
 
 The current design target is documented in
-[`../../docs/decisions/008-pluggable-neptune-graph-backend.md`](../../docs/decisions/008-pluggable-neptune-graph-backend.md).
+[`docs/decisions/008-pluggable-neptune-graph-backend.md`](https://github.com/msaad00/agent-bom/blob/main/docs/decisions/008-pluggable-neptune-graph-backend.md).
 Any future Neptune implementation must preserve the API `GraphStoreProtocol`
 surface, tenant predicates, audit behavior, and fail-closed configuration
 rules before this matrix can mark it supported.


### PR DESCRIPTION
## Summary
- fix the Backend Parity page's Neptune ADR link for strict MkDocs builds
- keep the published page honest that Neptune remains design-only and not wired

## Why
`mkdocs build --strict` treats links outside the site-docs tree as unresolved internal pages. The Neptune ADR lives under repo-root `docs/decisions`, so the published deployment doc should link to the GitHub source URL instead of a relative site path.

## Verification
- `uv run mkdocs build --strict`
- `git diff --check`
