### PR TITLE
Add ExposurePath envelope to JSON reports

### DIFF
--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -16,6 +16,7 @@ from agent_bom.compliance_utils import effective_blast_radius_tags
 from agent_bom.finding import FINDING_SCHEMA_VERSION
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
+from agent_bom.output.exposure_path import exposure_path_for_blast_radius
 from agent_bom.security import (
     sanitize_command_args,
     sanitize_path_label,
@@ -802,6 +803,7 @@ def to_json(report: AIBOMReport) -> dict:
     from agent_bom.scorecard import summarize_scorecard_coverage
 
     all_packages = [pkg for agent in report.agents for server in agent.mcp_servers for pkg in server.packages]
+    exposure_paths = [exposure_path_for_blast_radius(br, rank=rank) for rank, br in enumerate(report.blast_radii, start=1)]
     result = {
         "schema_version": SCAN_REPORT_SCHEMA_VERSION,
         "document_type": "AI-BOM",
@@ -1036,6 +1038,7 @@ def to_json(report: AIBOMReport) -> dict:
         "blast_radius": [
             {
                 "schema_version": BLAST_RADIUS_SCHEMA_VERSION,
+                "exposure_path": exposure_paths[rank - 1],
                 **({"package_name": br.package.name, "package_version": br.package.version, "package_stable_id": br.package.stable_id}),
                 "package_canonical_id": br.package.canonical_id,
                 **effective_blast_radius_tags(br),
@@ -1103,8 +1106,14 @@ def to_json(report: AIBOMReport) -> dict:
                 "graph_min_hop_distance": getattr(br, "graph_min_hop_distance", None),
                 "graph_reachable_from_agents": getattr(br, "graph_reachable_from_agents", []),
             }
-            for br in report.blast_radii
+            for rank, br in enumerate(report.blast_radii, start=1)
         ],
+        "exposure_paths": {
+            "schema_version": "1",
+            "source": "blast_radius_output",
+            "path_count": len(exposure_paths),
+            "paths": exposure_paths,
+        },
         "findings": [finding.to_dict() for finding in report.to_findings()],
         "threat_framework_summary": _build_framework_summary(report.blast_radii),
         "scorecard_summary": summarize_scorecard_coverage(all_packages).to_dict(),

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -599,6 +599,30 @@ def test_exposure_path_is_embedded_in_sarif_properties():
     } in exposure_path["relationships"]
 
 
+def test_exposure_path_is_embedded_in_json_report():
+    tool = MCPTool(name="deploy", description="Deploy workloads")
+    server = _make_server(name="prod-mcp", tools=[tool], env={"AWS_SECRET_ACCESS_KEY": "redacted"})
+    agent = _make_agent(name="prod-agent", servers=[server])
+    br = _make_blast_radius(agents=[agent])
+    br.affected_servers = [server]
+    br.exposed_tools = [tool]
+    br.exposed_credentials = ["AWS_SECRET_ACCESS_KEY"]
+    br.risk_score = 9.4
+    report = _make_report(agents=[agent], blast_radii=[br])
+
+    payload = to_json(report)
+    exposure_path = payload["exposure_paths"]["paths"][0]
+
+    assert payload["exposure_paths"]["schema_version"] == "1"
+    assert payload["exposure_paths"]["path_count"] == 1
+    assert payload["blast_radius"][0]["exposure_path"] == exposure_path
+    assert exposure_path["label"] == "lodash@4.17.20 -> CVE-2024-0001"
+    assert exposure_path["affectedAgents"] == ["prod-agent"]
+    assert exposure_path["affectedServers"] == ["prod-mcp"]
+    assert exposure_path["reachableTools"] == ["deploy"]
+    assert exposure_path["exposedCredentials"] == ["AWS_SECRET_ACCESS_KEY"]
+
+
 def test_skill_trust_axes_are_embedded_in_sarif_properties():
     report = _make_report()
     report.trust_assessment_data = {


### PR DESCRIPTION
## Summary
- add a top-level JSON exposure_paths envelope sourced from blast-radius findings
- embed the same ExposurePath object on each blast_radius entry for format parity with SARIF, Markdown, and HTML
- add regression coverage for affected agents, servers, tools, and credentials in JSON output

## Verification
- uv run pytest tests/test_output_formats.py -q
- uv run ruff check src/agent_bom/output/json_fmt.py tests/test_output_formats.py
- git diff --check