### PR TITLE
Refresh tracked product metrics snapshot

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 473,
+      "value": 461,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
@@ -40,13 +40,13 @@
     },
     {
       "name": "UI app pages",
-      "value": 23,
+      "value": 22,
       "source": "ui/app",
       "notes": "Counts page.tsx and page.jsx files recursively."
     },
     {
       "name": "Python modules",
-      "value": 474,
+      "value": 464,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,10 +14,10 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 35 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 473 | `tests/` | Counts files matching test_*.py. |
+| Test files | 461 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 18 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
-| UI app pages | 23 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 474 | `src/agent_bom` | Counts all Python files recursively. |
+| UI app pages | 22 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
+| Python modules | 464 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 14 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/scripts/product_metrics_snapshot.py
+++ b/scripts/product_metrics_snapshot.py
@@ -7,31 +7,42 @@ import argparse
 import ast
 import json
 import re
+import subprocess
 from datetime import date
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 
 
+def _tracked_files(*pathspecs: str) -> list[Path]:
+    """Return tracked files for metrics so local ignored artifacts do not skew counts."""
+    result = subprocess.run(
+        ["git", "-C", str(ROOT), "ls-files", "--", *pathspecs],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [ROOT / line for line in result.stdout.splitlines() if line]
+
+
 def _count_workflows() -> int:
-    return len(list((ROOT / ".github" / "workflows").glob("*.y*ml")))
+    return len(_tracked_files(".github/workflows/*.yml", ".github/workflows/*.yaml"))
 
 
 def _count_test_files() -> int:
-    return len(list((ROOT / "tests").rglob("test_*.py")))
+    return len(_tracked_files("tests/test_*.py", "tests/**/test_*.py"))
 
 
 def _count_api_route_modules() -> int:
-    return len(list((ROOT / "src" / "agent_bom" / "api" / "routes").glob("*.py")))
+    return len(_tracked_files("src/agent_bom/api/routes/*.py"))
 
 
 def _count_ui_app_pages() -> int:
-    app_root = ROOT / "ui" / "app"
-    return len(list(app_root.rglob("page.tsx"))) + len(list(app_root.rglob("page.jsx")))
+    return len(_tracked_files("ui/app/**/page.tsx", "ui/app/**/page.jsx"))
 
 
 def _count_python_modules() -> int:
-    return len(list((ROOT / "src" / "agent_bom").rglob("*.py")))
+    return len(_tracked_files("src/agent_bom/*.py", "src/agent_bom/**/*.py"))
 
 
 def _count_mcp_tools() -> int:


### PR DESCRIPTION
## Summary
- make the product metrics snapshot count tracked repo files instead of local ignored artifacts
- refresh generated product metrics for tests, UI pages, and Python modules
- keep release metrics reproducible from a dirty developer machine without counting Finder-style duplicates

## Verification
- python scripts/product_metrics_snapshot.py --write
- python scripts/product_metrics_snapshot.py > /tmp/product_metrics_snapshot.md && cmp -s /tmp/product_metrics_snapshot.md docs/PRODUCT_METRICS.md
- JSON snapshot equality against scripts/product_metrics_snapshot.py::build_snapshot
- uv run ruff check scripts/product_metrics_snapshot.py
- python scripts/check_release_consistency.py
- python scripts/check_duplicate_artifacts.py
- git diff --check