### PR TITLE
Clarify agent-first security data plane positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 <p align="center"><b>Open security scanner and self-hosted control plane for AI/MCP infrastructure.</b></p>
 
-<p align="center"><code>agent-bom</code> generates a reachability-backed AI BOM across agents, MCP servers, packages, credential environment names, cloud, runtime, and skill surfaces, then exposes the same evidence through CLI/CI, API/UI, MCP tools, and selected runtime controls.</p>
+<p align="center"><code>agent-bom</code> is also an open security data plane: it generates a reachability-backed AI BOM across agents, MCP servers, packages, credential environment names, cloud, runtime, and skill surfaces, then exposes the same evidence to humans and AI agents through CLI/CI, API/UI, MCP tools, and selected runtime controls.</p>
 
 <p align="center">
   <a href="https://msaad00.github.io/agent-bom/">Docs</a> ·
@@ -65,6 +65,32 @@ roadmap placeholders:
 - Neptune is optional enterprise graph-backend work. It is not required for the
   default SQLite/Postgres self-hosted path, and there is no published production
   Neptune latency SLO or openCypher endpoint claim.
+
+## Human and agent surfaces
+
+The product is built as one evidence model with multiple consumers, not as a
+dashboard-only workflow:
+
+| Surface | Primary consumer | Shipped boundary |
+|---|---|---|
+| **CLI / CI** | developers, release gates, automation | local scans, SARIF/SBOM/HTML/JSON output, deterministic exit codes |
+| **API / UI** | security teams, auditors, operators | authenticated control plane, graph cockpit, fleet, compliance, audit, evidence review |
+| **MCP tools** | Claude, Cursor, Codex, Windsurf, Cortex, and custom agents | 38 read-only tools, strict arguments, `exposure_paths`, `should_i_deploy` |
+| **Proxy / gateway / Shield** | runtime operators and selected applications | scoped MCP traffic inspection, policy decisions, redacted audit, runtime evidence |
+
+The UI remains a full-fidelity cockpit for humans. MCP/API/CLI give agents and
+other platforms the same underlying security primitives without requiring a
+human to click through the dashboard.
+
+Current boundaries:
+
+- the TypeScript package is `@agent-bom/runtime`, focused on MCP runtime
+  detectors; it is not yet a full scanner or API client SDK
+- there is no managed agent-bom Cloud offering in this repo today
+- streaming SIEM/Kafka-style posture feeds and detection-as-code YAML are
+  roadmap items, not shipped surfaces
+- AWS IAM enrichment is opt-in and bounded by the documented read-only provider
+  scope; do not treat it as complete IAM coverage across every cloud
 
 ## Try the demo
 

--- a/docs/MCP_CLIENT_GUIDES.md
+++ b/docs/MCP_CLIENT_GUIDES.md
@@ -18,6 +18,9 @@ Two modes matter:
 
 ## Major clients
 
+These clients are first-class today because `agent-bom` can both expose MCP
+tools to them and discover their local MCP configuration during scans.
+
 | Client | Primary config path(s) | Recommended setup | Notes |
 |--------|-------------------------|-------------------|-------|
 | Claude Desktop | macOS: `~/Library/Application Support/Claude/claude_desktop_config.json` Linux: `~/.config/Claude/claude_desktop_config.json` Windows: `~/AppData/Roaming/Claude/claude_desktop_config.json` | `agent-bom mcp server` or `uvx agent-bom mcp server` | Good fit for MCP server mode. Proxy wrapping works for JSON-configured stdio servers. |
@@ -27,6 +30,11 @@ Two modes matter:
 | Windsurf | macOS: `~/.windsurf/mcp.json`, `~/Library/Application Support/Windsurf/User/globalStorage/windsurf.mcp/mcp.json` Linux: `~/.windsurf/mcp.json` Windows: `~/.windsurf/mcp.json` | `agent-bom mcp server` | Same `mcpServers` JSON shape as Claude/Cursor. |
 | Codex CLI | `~/.codex/config.toml` on macOS, Linux, and Windows | `agent-bom mcp server` via `[mcp_servers.agent-bom]` | Codex uses TOML, not JSON. `proxy-configure` does not rewrite TOML configs; wrap manually when needed. |
 | Gemini CLI | `~/.gemini/settings.json` on macOS, Linux, and Windows | `agent-bom mcp server` | Uses standard JSON MCP config. |
+
+For agent-facing investigation, the most useful tools to start with are
+`exposure_paths` for ranked graph context and `should_i_deploy` for
+allow/warn/block deploy guidance. Both return evidence; neither mutates code,
+cloud resources, or third-party systems.
 
 ## Snowflake and skills
 

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -171,6 +171,22 @@ agent-bom proxy-bootstrap \
 | **Graph / Runtime** | `exposure_paths`, `should_i_deploy`, `context_graph`, `graph_export`, `runtime_correlate`, `tool_risk_assessment` | Return ranked investigation paths, deploy decisions, graph exports, and runtime-to-finding correlations |
 | **AI supply chain** | `dataset_card_scan`, `training_pipeline_scan`, `browser_extension_scan`, `model_provenance_scan`, `prompt_scan`, `model_file_scan`, `ingest_external_scan` | Scan AI artifacts, prompts, model files, browser extensions, and external scanner results |
 
+## Agent-facing decision tools
+
+Two graph-native tools are the primary MCP entry points for headless security
+agents:
+
+- `exposure_paths` returns ranked `ExposurePath` JSON from the graph store so
+  an agent can explain what is exposed, why it matters, which entities prove
+  it, and what fix path is recommended.
+- `should_i_deploy` returns allow/warn/block deploy guidance based on matched
+  `ExposurePath` risk and caller-supplied thresholds.
+
+Both tools are read-only decision aids. They do not modify repositories,
+create tickets, deploy workloads, or mutate cloud resources. Use proxy,
+gateway, Shield, or API audit evidence when a decision depends on selected
+live runtime traffic rather than static reachability.
+
 ## Example Conversations
 
 **"Are my AI agents vulnerable?"**

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -1,12 +1,15 @@
 # Product Brief
 
-`agent-bom` is an open security scanner and self-hosted control plane for
-AI/MCP infrastructure. It generates a reachability-backed AI BOM across agents,
-MCP servers, packages, credential environment names, cloud, runtime, and skill
-surfaces, then exposes the same evidence through CLI/CI, API/UI, MCP tools, and
-selected runtime controls.
+`agent-bom` is an open security data plane, scanner, and self-hosted control
+plane for AI/MCP infrastructure. It generates a reachability-backed AI BOM
+across agents, MCP servers, packages, credential environment names, cloud,
+runtime, and skill surfaces, then exposes the same evidence through CLI/CI,
+API/UI, MCP tools, and selected runtime controls.
 
-It is built around a simple thesis: security and visibility for AI infrastructure should be open, transparent, and accessible, not reserved for teams with enterprise budgets.
+It is built around a simple thesis: security and visibility for AI
+infrastructure should be open, transparent, and accessible to both humans and
+AI agents, not reserved for teams with enterprise budgets or a single
+dashboard workflow.
 
 Package risk is only the start. `agent-bom` follows what it can reach across
 MCP servers, agents, credential environment names, tools, runtime behavior, and
@@ -60,6 +63,14 @@ the CLI, reports, and browser cockpit. AI agents use the MCP/API/CLI surfaces
 to request the same `ExposurePath` evidence, skill verdicts, and deploy
 decisions under the same auth, tenant, and audit boundary.
 
+That is the useful lesson from developer-observability products: the cockpit is
+valuable, but the product primitive must be callable. For `agent-bom`, the
+primitive is not a trace; it is graph-backed security evidence:
+`ExposurePath`, findings, skill verdicts, compliance tags, runtime audit, and
+deploy decisions. Public copy should describe this as an open security data
+plane for AI-era infrastructure, while still proving the scanner and
+self-hosted control plane first.
+
 This framing does not narrow the deployment story. It makes "deploy in your
 own cloud / infrastructure" the production form of lane 2, with runtime
 controls from lane 3 added where the customer needs inline enforcement.
@@ -99,6 +110,20 @@ policy model, multiple entry points, no mandatory hosted control plane.
 - Agent security is not just software composition analysis. It is context across packages, MCP servers, agent configuration, credentials, tools, and runtime behavior.
 - Security for agentic infrastructure should be inspectable and explainable. Findings should show blast radius, not just raw package IDs.
 - Strong security and visibility should be available to individual developers and small teams, not only to enterprises with large budgets and long procurement cycles.
+
+## Shipped vs. not yet
+
+This table keeps strategy honest when docs, sales material, demos, and release
+notes discuss agent-native product direction.
+
+| Area | Shipped today | Not yet shipped |
+|---|---|---|
+| Human cockpit | Next.js dashboard, graph cockpit, reports, compliance and audit views | every UI action backed by a source registry and persisted workflow state |
+| Agent interface | 38 read-only MCP tools, strict arguments, `exposure_paths`, `should_i_deploy` | long-lived posture subscription tool, autonomous remediation actions |
+| Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports | a full Python scanner SDK and full TypeScript scanner/API SDK |
+| Runtime | MCP proxy, gateway, Shield SDK, runtime audit and policy decisions | first-class Kafka/Splunk/EventBridge posture streaming |
+| Graph scale | SQLite/Postgres default path, WebGL overview, optional Neptune adapter work | production Neptune SLOs, public openCypher endpoint, mandatory graph-database backend |
+| Extensibility | Python package internals, skills, runtime detector package | productized detection-as-code YAML registry and stable plugin SDK |
 
 ## Stable capability brief
 
@@ -177,6 +202,9 @@ That means public repo copy should emphasize real shipped surfaces, not just asp
 
 The next phase should stay disciplined:
 
+- SDK clarity: keep `@agent-bom/runtime` scoped to runtime detectors until a
+  real TypeScript scanner/API client exists; add a Python client only when it
+  wraps stable public CLI/API contracts
 - enterprise hardening: auth defaults, tenant isolation, Helm and deployment defaults, stable operator contracts
 - scanner depth: stronger lockfile and package coverage so buyers do not need a second tool for basic SCA depth
 - supply chain operations: tighter SBOM import/diff workflows so external vendor BOMs and current scans stay comparable

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -1,0 +1,45 @@
+# @agent-bom/runtime
+
+`@agent-bom/runtime` is the TypeScript runtime-detector package for selected
+MCP traffic. It is not a full `agent-bom` scanner SDK and it is not an API
+client for the self-hosted control plane.
+
+Use it when a JavaScript or TypeScript runtime already sees MCP JSON-RPC
+traffic and needs local detectors for:
+
+- tool drift after a baseline
+- suspicious arguments such as shell injection or path traversal
+- credential-like values in responses
+- excessive tool-call rates
+- suspicious multi-step sequences
+- cloaked or prompt-injection-like responses
+- vector database or RAG response injection patterns
+
+```ts
+import {
+  ArgumentAnalyzer,
+  CredentialLeakDetector,
+  ResponseInspector,
+} from "@agent-bom/runtime";
+
+const argumentAnalyzer = new ArgumentAnalyzer();
+const credentialLeakDetector = new CredentialLeakDetector();
+const responseInspector = new ResponseInspector();
+
+const argumentAlerts = argumentAnalyzer.analyze({
+  method: "tools/call",
+  params: { name: "read_file", arguments: { path: "../secrets.txt" } },
+});
+
+const responseAlerts = [
+  ...credentialLeakDetector.analyze("token=ghp_example"),
+  ...responseInspector.inspect("normal response"),
+];
+
+console.log([...argumentAlerts, ...responseAlerts]);
+```
+
+For full scans, graph exports, SBOM/SARIF output, MCP tools, or control-plane
+queries, use the `agent-bom` CLI, REST API, or MCP server. A scanner/API SDK is
+roadmap work and should not be described as shipped until it wraps those public
+contracts directly.

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -2,10 +2,11 @@
 
 **Open security scanner and self-hosted control plane for AI/MCP infrastructure.**
 
-Generate a reachability-backed AI BOM across agents, MCP servers, tools,
-packages, credential environment names, cloud, runtime, and skill surfaces,
-then expose the same evidence through CLI/CI, API/UI, MCP tools, and selected
-runtime controls. For source-by-source boundaries, see the
+`agent-bom` is also an open security data plane. It generates a
+reachability-backed AI BOM across agents, MCP servers, tools, packages,
+credential environment names, cloud, runtime, and skill surfaces, then exposes
+the same evidence to humans and AI agents through CLI/CI, API/UI, MCP tools,
+and selected runtime controls. For source-by-source boundaries, see the
 [AI infrastructure coverage matrix](architecture/ai-infrastructure.md#coverage-matrix).
 
 ## What it does
@@ -45,6 +46,19 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 | **Assistant tools** | `agent-bom mcp server` | read-only security tools for MCP clients |
 | **Self-hosted control plane** | `docker compose -f docker-compose.pilot.yml up -d` | API and dashboard in your infrastructure |
 
+## One evidence model, four consumers
+
+| Surface | Who uses it | What is shipped |
+|---|---|---|
+| **CLI / CI** | developers and pipelines | scans, SARIF/SBOM/HTML/JSON, graph exports, deterministic gates |
+| **API / UI** | security teams and auditors | self-hosted control plane, graph cockpit, compliance, audit, evidence review |
+| **MCP tools** | AI agents and coding assistants | 38 read-only tools, strict args, `exposure_paths`, `should_i_deploy` |
+| **Runtime controls** | platform and runtime operators | proxy/gateway/Shield policy decisions, redacted audit, selected live evidence |
+
+The dashboard is not the only door into the product. It is the human cockpit
+over the same evidence that agents can request through MCP and platforms can
+consume through API, CLI, reports, and exports.
+
 ## Current graph and agent surfaces
 
 - `ExposurePath` is the shared investigation object for API, UI, reports, JSON,
@@ -59,6 +73,15 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 Neptune is an optional enterprise backend lane. The default self-hosted path
 remains SQLite/Postgres, and the docs do not claim a live Neptune production
 SLO or openCypher endpoint.
+
+## Current boundaries
+
+- `@agent-bom/runtime` is a TypeScript runtime-detector package, not a full
+  scanner or API SDK.
+- Managed agent-bom Cloud, posture-event streaming connectors, and
+  detection-as-code YAML are roadmap items, not shipped product in this repo.
+- AWS IAM identity enrichment is opt-in and read-only; it does not imply
+  complete identity coverage across every provider.
 
 ## Key capabilities
 

--- a/site-docs/reference/agentic-workflows.md
+++ b/site-docs/reference/agentic-workflows.md
@@ -7,8 +7,8 @@ plane or runtime enforcement rollout.
 | Surface | Start with | Trust boundary | Evidence artifact | Move up to |
 |---|---|---|---|---|
 | Local CLI | `agent-bom agents --demo --offline`, then `agent-bom agents -p .` | Reads local agent and MCP configuration from the developer machine. No control-plane credentials required. | Terminal findings, JSON, SARIF, SBOM, HTML, graph export. | Scheduled scan, Docker, GitHub Action. |
-| Claude, Cursor, Windsurf, VS Code, Cortex, Codex CLI | `agent-bom mcp server` | Exposes read-only security tools to the assistant. The assistant does not need direct scanner credentials beyond the local process boundary. | MCP tool output, inventory, blast-radius answers, compliance checks. | Shared MCP configuration, skills, fleet sync. |
-| GitHub Actions | `uses: msaad00/agent-bom@v0.86.3` with SARIF upload enabled | Runs in CI with repository-scoped token permissions. Fork PR behavior depends on GitHub security policy. | `agent-bom-results.sarif`, pull-request summary, code-scanning alert category. | Branch protection, required code scanning, artifact retention. |
+| Claude, Cursor, Windsurf, VS Code, Cortex, Codex CLI | `agent-bom mcp server` | Exposes read-only security tools to the assistant. The assistant does not need direct scanner credentials beyond the local process boundary. | MCP tool output, inventory, blast-radius answers, compliance checks, ranked `ExposurePath` JSON, deploy guidance. | Shared MCP configuration, skills, fleet sync. |
+| GitHub Actions | `uses: msaad00/agent-bom@v0.86.5` with SARIF upload enabled | Runs in CI with repository-scoped token permissions. Fork PR behavior depends on GitHub security policy. | `agent-bom-results.sarif`, pull-request summary, code-scanning alert category. | Branch protection, required code scanning, artifact retention. |
 | Skills and instruction files | `agent-bom skills scan .` | Reads repo-local instructions such as `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, and `skills/*.md`. | Skill trust findings, referenced package and MCP inventory, credential-env names. | Signed skills, provenance verification, registry publishing. |
 | Cloud and AI infrastructure | `agent-bom agents --preset enterprise` plus provider-specific flags only where credentials are approved. | Uses read-only provider APIs or local inventory files. Keep provider secrets in the operator boundary, not in repo docs. | Cloud, warehouse, GPU, model, dataset, and runtime package evidence. | Fleet sync, compliance exports, graph-backed findings. |
 | Runtime proxy | `agent-bom proxy --no-isolate --log audit.jsonl --block-undeclared -- ...` | Wraps selected local MCP traffic. Policy can block before an upstream tool receives the call. Container containment requires a stdio MCP path plus a configured sandbox image or an existing container command. | Tier-A audit JSONL, policy decisions, runtime alerts, metrics, and sandbox posture when isolation is enabled. | Sidecar proxy, gateway policy pull, SIEM export. |
@@ -31,7 +31,7 @@ when the buyer or contributor needs to see the first finding path quickly.
 ### CI Security Review
 
 ```yaml
-- uses: msaad00/agent-bom@v0.86.3
+- uses: msaad00/agent-bom@v0.86.5
   with:
     scan-type: agents
     severity-threshold: high
@@ -42,6 +42,18 @@ when the buyer or contributor needs to see the first finding path quickly.
 
 Produces SARIF and pull-request evidence. If Code Scanning is empty, check the
 SARIF troubleshooting guide before changing scanner behavior.
+
+### Agent Decision Review
+
+```text
+exposure_paths(tenant_id="default", limit=5, min_risk=70)
+should_i_deploy(candidate="requests", tenant_id="default", block_risk=80)
+```
+
+Produces the same graph-backed investigation context a human sees in the UI,
+but as MCP tool output for an AI agent or coding assistant. `should_i_deploy`
+returns deploy guidance; it does not modify code, open pull requests, or mutate
+cloud resources.
 
 ### Hosted Gateway Or Proxy Review
 
@@ -78,3 +90,5 @@ upstream server.
   demos.
 - Runtime causality requires proxy, gateway, trace, or Shield evidence. Static
   scans show reachability and exposure, not live tool-call causality.
+- MCP server mode is read-only. Use proxy, gateway, or Shield when the question
+  depends on selected live tool-call traffic.

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -1,6 +1,9 @@
 # MCP Tools Reference
 
-agent-bom exposes MCP tools for scanning, blast radius, trust, compliance, runtime, and remediation.
+agent-bom exposes MCP tools for scanning, blast radius, trust, compliance,
+runtime, and remediation. The tools are read-only by default: agent consumers
+can request evidence and deploy guidance, but the MCP server does not mutate
+repos, cloud resources, or runtime targets.
 
 ## Tools
 
@@ -25,11 +28,18 @@ Return ranked ExposurePath JSON from the graph store for headless security agent
 exposure_paths(tenant_id="default", limit=5, min_risk=70)
 ```
 
+Use this when an AI agent needs the same ranked investigation queue that a
+human reviews in the graph cockpit.
+
 ### should_i_deploy
 Return an allow/warn/block deployment decision from matched ExposurePath risk.
 ```
 should_i_deploy(candidate="requests", tenant_id="default", block_risk=80)
 ```
+
+Use this as a decision aid in CI or assistant workflows. It returns reasons,
+matched paths, and a verdict; it does not deploy, remediate, or open pull
+requests.
 
 ### registry_lookup
 Look up an MCP server in the 427+ server security metadata registry.
@@ -80,12 +90,21 @@ Runs 17 behavioral risk patterns (credential file access, confirmation bypass, m
 | Credentials | proportionate, scoped, documented env vars |
 | Persistence & Privilege | no persistence, no escalation, no telemetry |
 
-Returns a verdict (`benign` / `suspicious` / `malicious`), confidence level, per-category results, and all findings with severity and recommendations.
+Returns a backward-compatible verdict (`benign` / `suspicious` /
+`malicious`), dual-axis `content_verdict` and `provenance_verdict` fields,
+`review_verdict`, `overall_recommendation`, confidence level, per-category
+results, and all findings with severity and recommendations. Clean content
+with missing provenance should remain content-benign while routing the overall
+recommendation to review.
 
 ```
 skill_trust(skill_path="./SKILL.md")
 # → {
-#     "verdict": "suspicious",
+#     "verdict": "benign",
+#     "content_verdict": "benign",
+#     "provenance_verdict": "unverified",
+#     "review_verdict": "review",
+#     "overall_recommendation": "review",
 #     "confidence": "high",
 #     "categories": [
 #       { "name": "Install Mechanism", "level": "fail", "summary": "Unverified install source" },


### PR DESCRIPTION
## Summary
- position agent-bom as an open security data plane while preserving the canonical scanner/control-plane tagline
- document humans and AI agents as peer consumers across CLI/CI, API/UI, MCP, and runtime surfaces
- add shipped/not-yet boundaries for SDKs, managed cloud, streaming, detection-as-code, Neptune, and IAM coverage
- clarify MCP agent-facing decision tools and the current @agent-bom/runtime TypeScript package scope

## Validation
- python scripts/check_release_consistency.py
- git diff --check
- rg -n "v0\.86\.3|Langfuse for security|SaaS is dead|UI is dead|from agent_bom import Scanner|new Scanner|production Neptune latency|50k-node" README.md docs/PRODUCT_BRIEF.md site-docs/index.md site-docs/reference/agentic-workflows.md site-docs/reference/mcp-tools.md docs/MCP_SERVER.md docs/MCP_CLIENT_GUIDES.md sdks/typescript/README.md