### PR TITLE
feat(sdk): add TypeScript control-plane client

### DIFF
--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -120,7 +120,7 @@ notes discuss agent-native product direction.
 |---|---|---|
 | Human cockpit | Next.js dashboard, graph cockpit, reports, compliance and audit views | every UI action backed by a source registry and persisted workflow state |
 | Agent interface | 38 read-only MCP tools, strict arguments, `exposure_paths`, `should_i_deploy` | long-lived posture subscription tool, autonomous remediation actions |
-| Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports | a full Python scanner SDK and full TypeScript scanner/API SDK |
+| Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports, initial TypeScript control-plane client | a full Python scanner SDK and full TypeScript scanner SDK |
 | Runtime | MCP proxy, gateway, Shield SDK, runtime audit and policy decisions | first-class Kafka/Splunk/EventBridge posture streaming |
 | Graph scale | SQLite/Postgres default path, WebGL overview, optional Neptune adapter work | production Neptune SLOs, public openCypher endpoint, mandatory graph-database backend |
 | Extensibility | Python package internals, skills, runtime detector package | productized detection-as-code YAML registry and stable plugin SDK |

--- a/sdks/typescript-client/.gitignore
+++ b/sdks/typescript-client/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/sdks/typescript-client/README.md
+++ b/sdks/typescript-client/README.md
@@ -1,0 +1,40 @@
+# @agent-bom/client
+
+Typed TypeScript client for the self-hosted `agent-bom` control plane.
+
+This package is the API-client lane. It is separate from `@agent-bom/runtime`,
+which stays focused on local MCP runtime detectors.
+
+## Install
+
+```bash
+npm install @agent-bom/client
+```
+
+## Use
+
+```ts
+import { AgentBomClient } from "@agent-bom/client";
+
+const client = new AgentBomClient({
+  baseUrl: "https://agent-bom.example.com",
+  apiKey: process.env.AGENT_BOM_API_KEY,
+  tenantId: "default",
+});
+
+const health = await client.health();
+const paths = await client.exposurePaths({ limit: 5, minRisk: 70 });
+const decision = await client.shouldIDeploy({
+  candidate: "flask@2.0.0",
+  blockRisk: 80,
+});
+
+console.log(health.status, paths.paths.length, decision.verdict);
+```
+
+## Boundary
+
+This package wraps stable HTTP control-plane calls for JavaScript and
+TypeScript consumers. It does not run local scanners itself, and it does not
+embed secrets. Operators still own the control-plane URL, API key or bearer
+token, tenant ID, network boundary, and retention policy.

--- a/sdks/typescript-client/package-lock.json
+++ b/sdks/typescript-client/package-lock.json
@@ -1,0 +1,51 @@
+{
+  "name": "@agent-bom/client",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@agent-bom/client",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^25.8.0",
+        "typescript": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/sdks/typescript-client/package.json
+++ b/sdks/typescript-client/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@agent-bom/client",
+  "version": "0.1.0",
+  "description": "Typed TypeScript client for the self-hosted agent-bom control plane",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "node --test tests/*.test.js",
+    "pretest": "tsc",
+    "lint": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "keywords": [
+    "agent-bom",
+    "security",
+    "control-plane",
+    "exposure-path",
+    "mcp"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/msaad00/agent-bom",
+    "directory": "sdks/typescript-client"
+  },
+  "devDependencies": {
+    "@types/node": "^25.8.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/sdks/typescript-client/src/index.ts
+++ b/sdks/typescript-client/src/index.ts
@@ -1,0 +1,201 @@
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export type FetchLike = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export interface AgentBomClientOptions {
+  baseUrl: string;
+  apiKey?: string;
+  bearerToken?: string;
+  tenantId?: string;
+  fetch?: FetchLike;
+  defaultHeaders?: Record<string, string>;
+}
+
+export interface HealthResponse {
+  status?: string;
+  version?: string;
+  storage?: Record<string, JsonValue>;
+  [key: string]: JsonValue | undefined;
+}
+
+export interface ExposurePathQuery {
+  tenantId?: string;
+  limit?: number;
+  minRisk?: number;
+}
+
+export interface ExposurePathEnvelope {
+  paths: JsonValue[];
+  nodes?: JsonValue[];
+  edges?: JsonValue[];
+  stats?: Record<string, JsonValue>;
+  [key: string]: JsonValue | undefined;
+}
+
+export interface DeployDecisionRequest {
+  candidate: string | Record<string, JsonValue>;
+  tenantId?: string;
+  blockRisk?: number;
+  context?: Record<string, JsonValue>;
+}
+
+export interface DeployDecision {
+  verdict: "allow" | "warn" | "block" | string;
+  reasons?: string[];
+  paths?: JsonValue[];
+  [key: string]: JsonValue | undefined;
+}
+
+export class AgentBomApiError extends Error {
+  readonly status: number;
+  readonly body: string;
+
+  constructor(message: string, status: number, body: string) {
+    super(message);
+    this.name = "AgentBomApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export class AgentBomClient {
+  readonly baseUrl: string;
+  private readonly apiKey: string | undefined;
+  private readonly bearerToken: string | undefined;
+  private readonly tenantId: string | undefined;
+  private readonly fetchImpl: FetchLike;
+  private readonly defaultHeaders: Record<string, string>;
+
+  constructor(options: AgentBomClientOptions) {
+    if (!options.baseUrl.trim()) {
+      throw new Error("baseUrl is required");
+    }
+    if (options.apiKey && options.bearerToken) {
+      throw new Error("Configure either apiKey or bearerToken, not both");
+    }
+
+    const fetchImpl = options.fetch ?? globalThis.fetch;
+    if (!fetchImpl) {
+      throw new Error("No fetch implementation available");
+    }
+
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.apiKey = options.apiKey;
+    this.bearerToken = options.bearerToken;
+    this.tenantId = options.tenantId;
+    this.fetchImpl = fetchImpl.bind(globalThis) as FetchLike;
+    this.defaultHeaders = options.defaultHeaders ?? {};
+  }
+
+  health(): Promise<HealthResponse> {
+    return this.request<HealthResponse>("GET", "/health");
+  }
+
+  exposurePaths(query: ExposurePathQuery = {}): Promise<ExposurePathEnvelope> {
+    const search = new URLSearchParams();
+    const tenantId = query.tenantId ?? this.tenantId;
+    if (tenantId) {
+      search.set("tenant_id", tenantId);
+    }
+    if (query.limit !== undefined) {
+      search.set("limit", String(query.limit));
+    }
+    if (query.minRisk !== undefined) {
+      search.set("min_risk", String(query.minRisk));
+    }
+    return this.request<ExposurePathEnvelope>(
+      "GET",
+      `/v1/graph/exposure-paths${formatSearch(search)}`,
+    );
+  }
+
+  shouldIDeploy(request: DeployDecisionRequest): Promise<DeployDecision> {
+    return this.request<DeployDecision>("POST", "/v1/graph/should-i-deploy", {
+      candidate: request.candidate,
+      tenant_id: request.tenantId ?? this.tenantId,
+      block_risk: request.blockRisk,
+      context: request.context,
+    });
+  }
+
+  async request<T>(
+    method: string,
+    path: string,
+    body?: Record<string, JsonValue | undefined>,
+  ): Promise<T> {
+    const init: RequestInit = {
+      method,
+      headers: this.headers(body !== undefined),
+    };
+    if (body !== undefined) {
+      init.body = JSON.stringify(stripUndefined(body));
+    }
+
+    const response = await this.fetchImpl(this.url(path), init);
+
+    const text = await response.text();
+    if (!response.ok) {
+      throw new AgentBomApiError(
+        `agent-bom request failed: ${response.status}`,
+        response.status,
+        text,
+      );
+    }
+
+    if (!text) {
+      return undefined as T;
+    }
+    return JSON.parse(text) as T;
+  }
+
+  private url(path: string): string {
+    if (/^https?:\/\//.test(path)) {
+      return path;
+    }
+    return `${this.baseUrl}${path.startsWith("/") ? path : `/${path}`}`;
+  }
+
+  private headers(hasBody: boolean): Record<string, string> {
+    const headers: Record<string, string> = {
+      accept: "application/json",
+      ...this.defaultHeaders,
+    };
+    if (hasBody) {
+      headers["content-type"] = "application/json";
+    }
+    if (this.apiKey) {
+      headers["x-api-key"] = this.apiKey;
+    }
+    if (this.bearerToken) {
+      headers.authorization = `Bearer ${this.bearerToken}`;
+    }
+    if (this.tenantId) {
+      headers["x-agent-bom-tenant-id"] = this.tenantId;
+    }
+    return headers;
+  }
+}
+
+function formatSearch(search: URLSearchParams): string {
+  const value = search.toString();
+  return value ? `?${value}` : "";
+}
+
+function stripUndefined(
+  value: Record<string, JsonValue | undefined>,
+): Record<string, JsonValue> {
+  return Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, JsonValue] => {
+      return entry[1] !== undefined;
+    }),
+  );
+}

--- a/sdks/typescript-client/tests/client.test.js
+++ b/sdks/typescript-client/tests/client.test.js
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AgentBomApiError, AgentBomClient } from "../dist/index.js";
+
+function jsonResponse(body, init = {}) {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    status: 200,
+    ...init,
+  });
+}
+
+test("adds auth and tenant headers", async () => {
+  let seen;
+  const client = new AgentBomClient({
+    baseUrl: "https://agent-bom.example.com/",
+    apiKey: "test-key",
+    tenantId: "tenant-a",
+    fetch: async (url, init) => {
+      seen = { url, init };
+      return jsonResponse({ status: "ok" });
+    },
+  });
+
+  const response = await client.health();
+
+  assert.equal(response.status, "ok");
+  assert.equal(seen.url, "https://agent-bom.example.com/health");
+  assert.equal(seen.init.headers["x-api-key"], "test-key");
+  assert.equal(seen.init.headers["x-agent-bom-tenant-id"], "tenant-a");
+});
+
+test("builds exposure path query params", async () => {
+  let seenUrl = "";
+  const client = new AgentBomClient({
+    baseUrl: "https://agent-bom.example.com",
+    fetch: async (url) => {
+      seenUrl = String(url);
+      return jsonResponse({ paths: [], stats: { count: 0 } });
+    },
+  });
+
+  await client.exposurePaths({ tenantId: "tenant-b", limit: 5, minRisk: 70 });
+
+  assert.equal(
+    seenUrl,
+    "https://agent-bom.example.com/v1/graph/exposure-paths?tenant_id=tenant-b&limit=5&min_risk=70",
+  );
+});
+
+test("posts deploy decision payload without undefined fields", async () => {
+  let payload;
+  const client = new AgentBomClient({
+    baseUrl: "https://agent-bom.example.com",
+    bearerToken: "token",
+    tenantId: "tenant-c",
+    fetch: async (_url, init) => {
+      payload = JSON.parse(init.body);
+      return jsonResponse({ verdict: "allow", reasons: [] });
+    },
+  });
+
+  const decision = await client.shouldIDeploy({ candidate: "flask@2.0.0" });
+
+  assert.equal(decision.verdict, "allow");
+  assert.deepEqual(payload, {
+    candidate: "flask@2.0.0",
+    tenant_id: "tenant-c",
+  });
+});
+
+test("throws typed errors for non-2xx responses", async () => {
+  const client = new AgentBomClient({
+    baseUrl: "https://agent-bom.example.com",
+    fetch: async () => jsonResponse({ detail: "blocked" }, { status: 403 }),
+  });
+
+  await assert.rejects(client.health(), (error) => {
+    assert.ok(error instanceof AgentBomApiError);
+    assert.equal(error.status, 403);
+    assert.match(error.body, /blocked/);
+    return true;
+  });
+});

--- a/sdks/typescript-client/tsconfig.json
+++ b/sdks/typescript-client/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -39,7 +39,9 @@ const responseAlerts = [
 console.log([...argumentAlerts, ...responseAlerts]);
 ```
 
-For full scans, graph exports, SBOM/SARIF output, MCP tools, or control-plane
-queries, use the `agent-bom` CLI, REST API, or MCP server. A scanner/API SDK is
-roadmap work and should not be described as shipped until it wraps those public
-contracts directly.
+For full scans, graph exports, SBOM/SARIF output, or MCP tools, use the
+`agent-bom` CLI, REST API, or MCP server.
+
+For TypeScript control-plane queries, use the separate `@agent-bom/client`
+package under `sdks/typescript-client`. That package wraps API calls; this
+package remains the runtime detector library.


### PR DESCRIPTION
## Summary

- Add a separate `@agent-bom/client` TypeScript package for control-plane consumers.
- Wrap health, ExposurePath, and deploy-decision API calls with typed request helpers and typed errors.
- Keep `@agent-bom/runtime` scoped to runtime detectors and document the package boundary.

## Verification

- `cd sdks/typescript-client && npm run build && npm test`
- `python scripts/check_release_consistency.py`
- `python scripts/check_product_surface_contract.py`
- `git diff --check`

Refs #2598
