### PR TITLE
docs(runtime): define posture event streaming contract

### DIFF
--- a/docs/POSTURE_EVENT_STREAMING.md
+++ b/docs/POSTURE_EVENT_STREAMING.md
@@ -1,0 +1,45 @@
+# Posture Event Streaming
+
+This document is the repo-facing contract for issue #2597.
+
+Current shipped posture delivery is pull-first:
+
+- scan report files: SARIF, SBOM, HTML, JSON, graph exports
+- REST API routes for findings, graph, audit, posture, and runtime state
+- MCP tools for agent pull workflows, including `exposure_paths` and
+  `should_i_deploy`
+- selected SIEM/export guidance and OCSF projections
+
+Push connectors are roadmap work until a PR adds the outbox, delivery, and
+retry implementation.
+
+## Event Envelope
+
+Posture push connectors should emit:
+
+| Field | Purpose |
+|---|---|
+| `event_id` | idempotent delivery key |
+| `tenant_id` | tenant owner |
+| `event_type` | finding, exposure path, skill verdict, deploy decision, runtime policy decision, or audit integrity event |
+| `occurred_at` | source timestamp |
+| `observed_at` | connector timestamp |
+| `source` | scan/API/MCP/proxy/gateway/importer |
+| `severity` | normalized severity where applicable |
+| `risk_score` | path or finding risk score where applicable |
+| `entity_refs` | related graph/source/package/agent/cloud/IAM IDs |
+| `exposure_path_id` | linked path ID when present |
+| `payload` | canonical agent-bom object |
+| `ocsf` | OCSF projection when available |
+| `audit_ref` | audit-chain pointer or verification metadata |
+| `schema_version` | connector schema version |
+
+## Delivery Order
+
+1. Webhook outbox with signed HTTPS POST.
+2. OCSF envelope shared by all connector adapters.
+3. Kafka/Pulsar/EventBridge adapters as optional extras.
+4. MCP posture subscription tool backed by the same replay contract.
+
+Do not document Kafka, Pulsar, EventBridge, or MCP posture subscriptions as
+shipped until their adapters and tests land.

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -127,7 +127,7 @@ notes discuss agent-native product direction.
 | Human cockpit | Next.js dashboard, graph cockpit, reports, compliance and audit views | every UI action backed by a source registry and persisted workflow state |
 | Agent interface | 38 read-only MCP tools, strict arguments, `exposure_paths`, `should_i_deploy` | long-lived posture subscription tool, autonomous remediation actions |
 | Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports, initial TypeScript control-plane client | a full Python scanner SDK and full TypeScript scanner SDK |
-| Runtime | MCP proxy, gateway, Shield SDK, runtime audit and policy decisions | first-class Kafka/Splunk/EventBridge posture streaming |
+| Runtime | MCP proxy, gateway, Shield SDK, runtime audit and policy decisions | webhook outbox, Kafka/Pulsar/EventBridge adapters, and MCP posture subscriptions |
 | Graph scale | SQLite/Postgres default path, WebGL overview, optional Neptune adapter work | production Neptune SLOs, public openCypher endpoint, mandatory graph-database backend |
 | Extensibility | Python package internals, skills, runtime detector package | productized detection-as-code YAML registry and stable plugin SDK |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
           - Scaling SLOs and Autoscaling: deployment/scaling-slo.md
           - Worker and Scheduler Concurrency: deployment/worker-and-scheduler-concurrency.md
           - SIEM Integration: deployment/siem-integration.md
+          - Posture Event Streaming: deployment/posture-event-streaming.md
           - Grafana Dashboard: deployment/grafana.md
       - Specialized Reference:
           - Deployment Modes and Alignment: deployment/deployment-modes-and-alignment.md

--- a/site-docs/deployment/posture-event-streaming.md
+++ b/site-docs/deployment/posture-event-streaming.md
@@ -1,0 +1,97 @@
+# Posture Event Streaming
+
+`agent-bom` already produces security evidence through reports, API routes,
+MCP tools, audit records, and selected SIEM/export paths. This page defines the
+next connector contract for pushing posture changes into security lakes, SIEMs,
+SOARs, and agent queues without making a shipped-connector claim too early.
+
+## Current State
+
+Shipped today:
+
+- SARIF, SBOM, HTML, JSON, and graph exports from scans
+- OCSF projection helpers for findings where the canonical event maps cleanly
+- `/v1/proxy/audit` and audit-chain verification for runtime events
+- SIEM integration guidance for supported export paths
+- `exposure_paths` and `should_i_deploy` MCP tools for agent pull workflows
+
+Not shipped today:
+
+- managed posture-event streaming service
+- Kafka, Pulsar, or EventBridge connector package
+- long-lived `subscribe_posture_changes` MCP tool
+- guaranteed production streaming SLO
+
+## Connector Contract
+
+Every posture event connector should preserve the same envelope so downstream
+systems do not need per-connector parsers.
+
+| Field | Meaning |
+|---|---|
+| `event_id` | stable UUID for idempotency |
+| `tenant_id` | tenant that owns the event |
+| `event_type` | `finding.created`, `finding.updated`, `exposure_path.created`, `skill.verdict`, `deploy.decision`, `runtime.policy_decision`, or `audit.integrity` |
+| `occurred_at` | source event timestamp |
+| `observed_at` | connector observation timestamp |
+| `source` | scan, API route, MCP tool, proxy, gateway, or importer that produced the event |
+| `severity` | normalized severity where applicable |
+| `risk_score` | numeric risk score where applicable |
+| `entity_refs` | related package, source, agent, cloud, IAM, MCP, skill, or graph IDs |
+| `exposure_path_id` | linked `ExposurePath` ID when the event is path-backed |
+| `payload` | canonical `agent-bom` object |
+| `ocsf` | OCSF projection when the event maps cleanly |
+| `audit_ref` | audit-chain pointer or verification metadata where available |
+| `schema_version` | connector event schema version |
+
+The canonical `agent-bom` payload remains authoritative. OCSF is a projection
+for SIEM/security-lake interoperability, not a replacement for the graph model.
+
+## Delivery Modes
+
+| Mode | Status | First proof | Notes |
+|---|---|---|---|
+| Pull by API | shipped | `GET /v1/findings`, `/v1/graph*`, `/v1/audit*` | works for dashboards, SIEM jobs, and custom collectors |
+| Pull by MCP | shipped | `exposure_paths`, `should_i_deploy` | best for AI agents and coding assistants |
+| Webhook outbox | roadmap | signed HTTPS POST to customer URL | should be the first push connector |
+| Kafka/Pulsar | roadmap | topic-per-tenant or topic with tenant key | requires retry, DLQ, and idempotency guidance |
+| EventBridge | roadmap | customer account event bus | AWS-first push lane |
+| Long-lived MCP subscription | roadmap | `subscribe_posture_changes` | agent-native stream; needs backpressure and replay contract |
+
+## Reliability Rules
+
+Push connectors should be fail-closed for configuration and fail-safe for
+delivery:
+
+- reject missing tenant IDs, unsigned destinations, and private-network
+  destinations unless explicitly allowed by operator policy
+- persist an outbox record before first delivery attempt
+- use `event_id` for idempotent retries
+- record delivery status, attempt count, and final failure reason
+- expose dead-letter records through API and audit logs
+- never include raw secret values in payloads
+- preserve `audit_ref` so the downstream event can be tied back to the
+  customer-owned evidence chain
+
+## Security Boundary
+
+Operators own destination credentials, webhook signing keys, Kafka credentials,
+EventBridge role grants, retention, and downstream access control.
+
+`agent-bom` should only store references to those credentials through the
+credential-reference model, not raw destination secrets.
+
+## Implementation Slices
+
+1. **Webhook outbox** — tenant-scoped table, signed delivery, retry policy,
+   dead-letter API, and tests.
+2. **OCSF event envelope** — shared serializer for findings, exposure paths,
+   deploy decisions, skill verdicts, runtime policy decisions, and audit
+   integrity events.
+3. **Connector adapters** — Kafka/Pulsar/EventBridge optional extras that
+   consume the outbox contract.
+4. **Agent subscription** — MCP `subscribe_posture_changes` backed by the same
+   outbox/replay contract.
+
+Each slice should ship with a first command, an artifact, and a verification
+path before release docs describe it as available.

--- a/site-docs/reference/agentic-workflows.md
+++ b/site-docs/reference/agentic-workflows.md
@@ -55,6 +55,10 @@ but as MCP tool output for an AI agent or coding assistant. `should_i_deploy`
 returns deploy guidance; it does not modify code, open pull requests, or mutate
 cloud resources.
 
+Posture-change subscriptions are not shipped yet. The connector contract is
+tracked in [Posture Event Streaming](../deployment/posture-event-streaming.md)
+so future agent and SIEM push workflows share one event envelope.
+
 ### Skills CI Gate
 
 ```yaml


### PR DESCRIPTION
## Summary

- Define the posture-event connector envelope for future webhook, Kafka/Pulsar, EventBridge, and MCP subscription work.
- Document shipped pull surfaces versus roadmap push connectors so release docs stay honest.
- Link the contract from the agentic workflow docs and MkDocs deployment nav.

## Verification

- `python scripts/check_release_consistency.py`
- `python scripts/check_product_surface_contract.py`
- `uv run mkdocs build --strict`
- `git diff --check`

Refs #2597
