### PR TITLE
feat(inventory): stream versioned inventory ingestion

### DIFF
--- a/src/agent_bom/cli/_inventory.py
+++ b/src/agent_bom/cli/_inventory.py
@@ -14,7 +14,7 @@ from rich.console import Console
 
 from agent_bom.cli._common import _build_agents_from_inventory, _make_console, read_json_file_for_cli
 from agent_bom.discovery import discover_all
-from agent_bom.inventory import _inventory_schema_path, _inventory_validator
+from agent_bom.inventory import _inventory_payload_and_version, _inventory_schema_path, _inventory_validator
 from agent_bom.mcp_blocklist import flag_blocklisted_mcp_servers
 from agent_bom.models import AIBOMReport
 from agent_bom.output import print_agent_tree, print_summary
@@ -158,22 +158,25 @@ def validate(inventory_file: str):
     """
     console = Console()
 
-    schema_path = _inventory_schema_path()
-    if not schema_path or not schema_path.exists():
-        console.print("[red]Schema file not found. Run from the agent-bom repo root.[/red]")
-        sys.exit(1)
-
     data = read_json_file_for_cli(inventory_file, label="inventory file")
 
     try:
-        validator = _inventory_validator()
+        payload, schema_version = _inventory_payload_and_version(data)
+        schema_path = _inventory_schema_path(schema_version)
+        if not schema_path or not schema_path.exists():
+            console.print("[red]Schema file not found. Run from the agent-bom repo root.[/red]")
+            sys.exit(1)
+        validator = _inventory_validator(schema_version)
+    except ValueError as exc:
+        console.print(f"\n  [red]✗ Invalid — {exc}[/red]\n")
+        sys.exit(1)
     except ImportError:
         console.print("[red]jsonschema not installed. Run: pip install jsonschema[/red]")
         sys.exit(1)
-    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
+    errors = sorted(validator.iter_errors(payload), key=lambda e: list(e.path))
 
     if not errors:
-        agents = data.get("agents", [])
+        agents = payload.get("agents", [])
         total_servers = sum(len(a.get("mcp_servers", [])) for a in agents)
         total_packages = sum(len(s.get("packages", [])) for a in agents for s in a.get("mcp_servers", []))
         console.print(f"\n  [green]✓ Valid[/green] — {len(agents)} agent(s), {total_servers} server(s), {total_packages} package(s)")

--- a/src/agent_bom/inventory.py
+++ b/src/agent_bom/inventory.py
@@ -46,6 +46,8 @@ _CSV_REQUIRED_COLUMNS = frozenset({"name", "version", "ecosystem"})
 
 # Size guard to prevent OOM on malicious/huge inputs.
 _MAX_INVENTORY_SIZE = 100 * 1024 * 1024  # 100 MB
+_DEFAULT_INVENTORY_SCHEMA_VERSION = "1"
+_SUPPORTED_INVENTORY_SCHEMA_VERSIONS = frozenset({_DEFAULT_INVENTORY_SCHEMA_VERSION})
 _ECOSYSTEM_ALIASES = {
     "pip": "pypi",
     "python": "pypi",
@@ -56,8 +58,10 @@ _ECOSYSTEM_ALIASES = {
 }
 
 
-def _inventory_schema_path() -> Path | None:
+def _inventory_schema_path(version: str = _DEFAULT_INVENTORY_SCHEMA_VERSION) -> Path | None:
     """Return the inventory schema path from source or installed package data."""
+    if version not in _SUPPORTED_INVENTORY_SCHEMA_VERSIONS:
+        return None
     candidate_paths = [
         Path(__file__).parent.parent.parent / "config" / "schemas" / "inventory.schema.json",
         Path(__file__).parent / "data" / "inventory.schema.json",
@@ -89,20 +93,33 @@ def _inventory_schema_path() -> Path | None:
     return None
 
 
-@lru_cache(maxsize=1)
-def _inventory_validator():
-    """Build and cache the inventory JSON Schema validator."""
+@lru_cache(maxsize=len(_SUPPORTED_INVENTORY_SCHEMA_VERSIONS))
+def _inventory_validator(version: str = _DEFAULT_INVENTORY_SCHEMA_VERSION):
+    """Build and cache the inventory JSON Schema validator for *version*."""
     import jsonschema
 
-    schema_path = _inventory_schema_path()
+    schema_path = _inventory_schema_path(version)
     if not schema_path or not schema_path.exists():
-        raise RuntimeError("Inventory schema file not found")
+        raise RuntimeError(f"Inventory schema file not found for schema_version {version!r}")
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
     return jsonschema.Draft202012Validator(schema)
 
 
-def _validate_inventory_payload(data: Any) -> dict[str, Any]:
-    """Validate an inventory payload against the canonical schema."""
+def _coerce_inventory_schema_version(value: Any) -> str:
+    if value is None:
+        return _DEFAULT_INVENTORY_SCHEMA_VERSION
+    if isinstance(value, int):
+        value = str(value)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("Inventory schema_version must be a non-empty string")
+    version = value.strip()
+    if version not in _SUPPORTED_INVENTORY_SCHEMA_VERSIONS:
+        supported = ", ".join(sorted(_SUPPORTED_INVENTORY_SCHEMA_VERSIONS))
+        raise ValueError(f"Unsupported inventory schema_version {version!r}; supported versions: {supported}")
+    return version
+
+
+def _inventory_payload_and_version(data: Any) -> tuple[dict[str, Any], str]:
     if not isinstance(data, dict):
         raise ValueError("Inventory JSON root must be an object with an 'agents' array")
 
@@ -112,7 +129,15 @@ def _validate_inventory_payload(data: Any) -> dict[str, Any]:
             raise ValueError("Inventory snapshot in scan report must be an object")
         data = snapshot
 
-    errors = sorted(_inventory_validator().iter_errors(data), key=lambda e: list(e.path))
+    version = _coerce_inventory_schema_version(data.get("schema_version"))
+    return data, version
+
+
+def _validate_inventory_payload(data: Any) -> dict[str, Any]:
+    """Validate an inventory payload against the canonical schema."""
+    data, version = _inventory_payload_and_version(data)
+
+    errors = sorted(_inventory_validator(version).iter_errors(data), key=lambda e: list(e.path))
     if errors:
         first = errors[0]
         path = " -> ".join(str(part) for part in first.path) or "(root)"
@@ -158,6 +183,10 @@ def load_inventory(source: str) -> dict:
         with open(path, newline="", encoding="utf-8") as fp:
             return _load_csv_inventory(fp)
 
+    if path.suffix.lower() in {".jsonl", ".ndjson"}:
+        with open(path, encoding="utf-8") as fp:
+            return _load_ndjson_inventory(fp)
+
     with open(path, encoding="utf-8") as fp:
         return _load_json_inventory(fp)
 
@@ -195,6 +224,68 @@ def _load_json_inventory(fp: io.TextIOBase) -> dict:  # type: ignore[override]
     except json.JSONDecodeError as exc:
         source = getattr(fp, "name", "inventory file")
         raise ValueError(f"Inventory JSON error in {source}: line {exc.lineno}, column {exc.colno}: {exc.msg}") from exc
+
+
+def _load_ndjson_inventory(fp: io.TextIOBase) -> dict:
+    """Parse line-delimited inventory and validate each agent chunk.
+
+    The first non-empty line may be a metadata object with ``schema_version``,
+    ``source``, ``generated_at``, or ``discovery_provenance``. Later lines can
+    be either full inventory objects with ``agents`` or individual agent
+    objects. This keeps fleet-scale pushed inventory parseable without loading
+    one monolithic JSON document before validation.
+    """
+    source = getattr(fp, "name", "inventory file")
+    version = _DEFAULT_INVENTORY_SCHEMA_VERSION
+    metadata: dict[str, Any] = {}
+    metadata_keys = {"schema_version", "source", "generated_at", "discovery_provenance"}
+    agents: list[dict[str, Any]] = []
+    saw_payload = False
+
+    for line_no, raw_line in enumerate(fp, start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Inventory NDJSON error in {source}: line {line_no}, column {exc.colno}: {exc.msg}") from exc
+        if not isinstance(record, dict):
+            raise ValueError(f"Inventory NDJSON error in {source}: line {line_no}: record must be an object")
+
+        if not saw_payload and "agents" not in record and "name" not in record and set(record).issubset(metadata_keys):
+            version = _coerce_inventory_schema_version(record.get("schema_version"))
+            metadata = {key: record[key] for key in metadata_keys if key in record}
+            metadata["schema_version"] = version
+            continue
+
+        saw_payload = True
+        if "agents" in record:
+            chunk, chunk_version = _inventory_payload_and_version(record)
+            if chunk_version != version:
+                raise ValueError(
+                    f"Inventory NDJSON error in {source}: line {line_no}: mixed schema_version {chunk_version!r} does not match {version!r}"
+                )
+            chunk_agents = chunk.get("agents")
+            if not isinstance(chunk_agents, list):
+                raise ValueError(f"Inventory NDJSON error in {source}: line {line_no}: agents must be an array")
+        else:
+            chunk_agents = [record]
+
+        for agent in chunk_agents:
+            try:
+                _validate_inventory_payload({"schema_version": version, "agents": [agent]})
+            except ValueError as exc:
+                raise ValueError(f"Inventory NDJSON error in {source}: line {line_no}: {exc}") from exc
+            agents.append(agent)
+
+    if not agents:
+        raise ValueError(f"Inventory NDJSON in {source} produced no agent records")
+
+    payload = dict(metadata)
+    payload.setdefault("schema_version", version)
+    payload["agents"] = agents
+    return _validate_inventory_payload(payload)
 
 
 def _load_csv_inventory(fp: io.TextIOBase) -> dict:  # type: ignore[override]

--- a/tests/test_cli_inventory.py
+++ b/tests/test_cli_inventory.py
@@ -210,6 +210,17 @@ def test_validate_valid_file(tmp_path):
     assert "Valid" in result.output
 
 
+def test_validate_unknown_inventory_schema_version(tmp_path):
+    runner = CliRunner()
+    inv_file = tmp_path / "inv.json"
+    inv_file.write_text(json.dumps({"schema_version": "2", "agents": [{"name": "demo-agent"}]}))
+
+    result = runner.invoke(validate, [str(inv_file)])
+
+    assert result.exit_code == 1
+    assert "Unsupported inventory schema_version '2'" in result.output
+
+
 def test_validate_invalid_json(tmp_path):
     runner = CliRunner()
     inv_file = tmp_path / "bad.json"

--- a/tests/test_inventory_ingestion.py
+++ b/tests/test_inventory_ingestion.py
@@ -1,0 +1,101 @@
+"""Inventory schema dispatch and streaming ingestion regressions."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent_bom.inventory import load_inventory
+
+
+def _agent(name: str = "agent-a") -> dict[str, object]:
+    return {"name": name, "agent_type": "custom", "mcp_servers": []}
+
+
+def test_json_inventory_schema_version_v1_dispatch(tmp_path):
+    inventory_path = tmp_path / "inventory.json"
+    inventory_path.write_text(
+        json.dumps({"schema_version": "1", "source": "operator", "agents": [_agent()]}),
+        encoding="utf-8",
+    )
+
+    loaded = load_inventory(str(inventory_path))
+
+    assert loaded["schema_version"] == "1"
+    assert loaded["source"] == "operator"
+    assert loaded["agents"][0]["name"] == "agent-a"
+
+
+def test_json_inventory_unknown_schema_version_rejected(tmp_path):
+    inventory_path = tmp_path / "inventory.json"
+    inventory_path.write_text(json.dumps({"schema_version": "2", "agents": [_agent()]}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Unsupported inventory schema_version '2'"):
+        load_inventory(str(inventory_path))
+
+
+def test_ndjson_inventory_validates_agent_chunks(tmp_path):
+    inventory_path = tmp_path / "inventory.ndjson"
+    inventory_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"schema_version": "1", "source": "fleet-push"}),
+                json.dumps(_agent("agent-a")),
+                json.dumps(_agent("agent-b")),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = load_inventory(str(inventory_path))
+
+    assert loaded["schema_version"] == "1"
+    assert loaded["source"] == "fleet-push"
+    assert [agent["name"] for agent in loaded["agents"]] == ["agent-a", "agent-b"]
+
+
+def test_ndjson_inventory_handles_large_chunked_path(tmp_path):
+    inventory_path = tmp_path / "large-inventory.ndjson"
+    records = [json.dumps({"schema_version": "1", "source": "fleet-push"})]
+    records.extend(json.dumps(_agent(f"agent-{idx:04d}")) for idx in range(1000))
+    inventory_path.write_text("\n".join(records), encoding="utf-8")
+
+    loaded = load_inventory(str(inventory_path))
+
+    assert loaded["schema_version"] == "1"
+    assert loaded["source"] == "fleet-push"
+    assert len(loaded["agents"]) == 1000
+    assert loaded["agents"][999]["name"] == "agent-0999"
+
+
+def test_ndjson_inventory_rejects_bad_chunk_with_line_context(tmp_path):
+    inventory_path = tmp_path / "inventory.ndjson"
+    inventory_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"schema_version": "1"}),
+                json.dumps({"agent_type": "custom", "mcp_servers": []}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="line 2|Inventory schema validation failed"):
+        load_inventory(str(inventory_path))
+
+
+def test_ndjson_inventory_rejects_mixed_schema_versions(tmp_path):
+    inventory_path = tmp_path / "inventory.ndjson"
+    inventory_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"schema_version": "1", "source": "fleet-push"}),
+                json.dumps({"schema_version": "2", "agents": [_agent("agent-a")]}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Unsupported inventory schema_version '2'"):
+        load_inventory(str(inventory_path))


### PR DESCRIPTION
Summary
- add schema-version dispatch for inventory JSON validation so future versions do not share one cached validator
- support .jsonl/.ndjson inventory ingestion with per-agent chunk validation and line-specific malformed-input errors
- keep the existing 100 MB file cap and route CLI validation through the same schema-version path

Verification
- uv run pytest tests/test_inventory_ingestion.py tests/test_cli_inventory.py -q
- uv run ruff check src/agent_bom/inventory.py src/agent_bom/cli/_inventory.py tests/test_inventory_ingestion.py tests/test_cli_inventory.py
- uv run mypy src/agent_bom/inventory.py src/agent_bom/cli/_inventory.py
- git diff --check

Closes #2075
