### PR TITLE
feat(graph): expose agent-native REST decisions

### DIFF
--- a/sdks/typescript-client/README.md
+++ b/sdks/typescript-client/README.md
@@ -29,7 +29,7 @@ const decision = await client.shouldIDeploy({
   blockRisk: 80,
 });
 
-console.log(health.status, paths.paths.length, decision.verdict);
+console.log(health.status, paths.paths.length, decision.decision);
 ```
 
 ## Boundary

--- a/sdks/typescript-client/src/index.ts
+++ b/sdks/typescript-client/src/index.ts
@@ -49,9 +49,12 @@ export interface DeployDecisionRequest {
 }
 
 export interface DeployDecision {
-  verdict: "allow" | "warn" | "block" | string;
+  decision: "allow" | "warn" | "block" | string;
   reasons?: string[];
-  paths?: JsonValue[];
+  matchedPaths?: JsonValue[];
+  matchedPathCount?: number;
+  maxRisk?: number;
+  thresholds?: Record<string, JsonValue>;
   [key: string]: JsonValue | undefined;
 }
 

--- a/sdks/typescript-client/tests/client.test.js
+++ b/sdks/typescript-client/tests/client.test.js
@@ -57,13 +57,13 @@ test("posts deploy decision payload without undefined fields", async () => {
     tenantId: "tenant-c",
     fetch: async (_url, init) => {
       payload = JSON.parse(init.body);
-      return jsonResponse({ verdict: "allow", reasons: [] });
+      return jsonResponse({ decision: "allow", reasons: [] });
     },
   });
 
   const decision = await client.shouldIDeploy({ candidate: "flask@2.0.0" });
 
-  assert.equal(decision.verdict, "allow");
+  assert.equal(decision.decision, "allow");
   assert.deepEqual(payload, {
     candidate: "flask@2.0.0",
     tenant_id: "tenant-c",

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -6,6 +6,8 @@ Endpoints:
   GET  /v1/graph/edges/active   — edge versions active at a timestamp
   GET  /v1/graph/edges/changes  — edge lifecycle changes between scans
   GET  /v1/graph/attack-paths   — global risk-sorted attack path queue
+  GET  /v1/graph/exposure-paths — agent-native ExposurePath queue
+  POST /v1/graph/should-i-deploy — agent-native deploy decision
   GET  /v1/graph/paths          — attack paths from a source node
   GET  /v1/graph/impact         — blast radius of a node (reverse BFS)
   GET  /v1/graph/search         — full-text graph search
@@ -24,6 +26,7 @@ Endpoints:
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import time
@@ -31,7 +34,7 @@ from typing import Any, Literal, Optional
 from urllib.parse import quote
 
 from fastapi import APIRouter, HTTPException, Query, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from agent_bom.api.stores import _get_graph_store
 from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
@@ -872,6 +875,42 @@ class GraphQueryRequest(BaseModel):
     data_sources: list[str] = Field(default_factory=list)
 
 
+class GraphDeployDecisionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    candidate: str | dict[str, Any] = Field(..., description="Package, image, service, or structured candidate descriptor")
+    tenant_id: str | None = Field(default=None, description="Accepted for SDK compatibility; request tenant scope is authoritative")
+    scan_id: str | None = Field(default=None, description="Scan snapshot ID; latest if omitted")
+    limit: int = Field(5, ge=1, le=25, description="Maximum matched exposure paths")
+    warn_risk: float = Field(40.0, ge=0, le=100, alias="warnRisk", description="Risk threshold for warning")
+    block_risk: float = Field(80.0, ge=0, le=100, alias="blockRisk", description="Risk threshold for blocking")
+    context: dict[str, Any] = Field(default_factory=dict, description="Optional caller context for future policy extensions")
+
+
+def _candidate_to_string(candidate: str | dict[str, Any]) -> str:
+    if isinstance(candidate, str):
+        return candidate.strip()
+    return json.dumps(candidate, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _raise_mcp_error_as_http(payload: dict[str, Any]) -> None:
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return
+    category = str(error.get("category") or "internal")
+    status_by_category = {
+        "validation": 422,
+        "auth": 403,
+        "rate_limited": 429,
+        "not_found": 404,
+        "unsupported": 400,
+        "timeout": 504,
+        "upstream": 502,
+        "internal": 500,
+    }
+    raise HTTPException(status_code=status_by_category.get(category, 500), detail=error)
+
+
 def _node_matches_query(
     node,
     *,
@@ -1228,6 +1267,76 @@ async def get_graph_attack_paths(
         "stats": stats,
         "pagination": _page_meta(total, offset, limit),
     }
+
+
+@router.get("/v1/graph/exposure-paths", tags=["graph"])
+async def get_graph_exposure_paths(
+    request: Request,
+    tenant_id: Optional[str] = Query(None, include_in_schema=False),
+    scan_id: Optional[str] = Query(None, description="Scan ID"),
+    limit: int = Query(5, ge=1, le=100, description="Maximum ExposurePaths"),
+    min_risk: float = Query(0.0, ge=0, le=100, description="Minimum ExposurePath risk score"),
+) -> dict:
+    """Return the MCP-compatible ExposurePath queue over REST for SDK consumers."""
+    del tenant_id  # SDK compatibility only; request tenant scope is authoritative.
+    from agent_bom.mcp_tools.graph import exposure_paths_impl
+
+    graph_store = _get_graph_store_or_503()
+    raw = await exposure_paths_impl(
+        tenant_id=_tenant(request),
+        scan_id=scan_id,
+        limit=limit,
+        min_risk=min_risk,
+        _get_graph_store=lambda: graph_store,
+        _truncate_response=lambda value: value,
+    )
+    payload = json.loads(raw)
+    _raise_mcp_error_as_http(payload)
+    return payload
+
+
+@router.post("/v1/graph/should-i-deploy", tags=["graph"])
+async def post_graph_should_i_deploy(request: Request, body: GraphDeployDecisionRequest) -> dict:
+    """Return the MCP-compatible allow/warn/block deploy decision over REST."""
+    _ = (body.tenant_id, body.context)  # SDK compatibility/future policy context; request tenant scope is authoritative today.
+    from agent_bom.mcp_tools.graph import deploy_decision_impl
+
+    candidate = _candidate_to_string(body.candidate)
+    if not candidate:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "AGENTBOM_MCP_VALIDATION_INVALID_ARGUMENT",
+                "category": "validation",
+                "message": "candidate must not be empty",
+                "details": {"argument": "candidate"},
+            },
+        )
+    if body.warn_risk > body.block_risk:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "AGENTBOM_MCP_VALIDATION_INVALID_ARGUMENT",
+                "category": "validation",
+                "message": "warn_risk and block_risk must be ordered thresholds between 0 and 100",
+                "details": {"warn_risk": body.warn_risk, "block_risk": body.block_risk},
+            },
+        )
+
+    graph_store = _get_graph_store_or_503()
+    raw = await deploy_decision_impl(
+        candidate=candidate,
+        tenant_id=_tenant(request),
+        scan_id=body.scan_id,
+        limit=body.limit,
+        warn_risk=body.warn_risk,
+        block_risk=body.block_risk,
+        _get_graph_store=lambda: graph_store,
+        _truncate_response=lambda value: value,
+    )
+    payload = json.loads(raw)
+    _raise_mcp_error_as_http(payload)
+    return payload
 
 
 @router.get("/v1/graph/paths", tags=["graph"])

--- a/src/agent_bom/mcp_tools/graph.py
+++ b/src/agent_bom/mcp_tools/graph.py
@@ -193,9 +193,9 @@ async def exposure_paths_impl(
         }
         encoded = json.dumps(payload, indent=2, default=str)
         return _truncate_response(encoded) if _truncate_response is not None else encoded
-    except Exception as exc:
+    except Exception:
         logger.exception("MCP graph tool error")
-        return mcp_error_json(CODE_INTERNAL_UNEXPECTED, exc)
+        return mcp_error_json(CODE_INTERNAL_UNEXPECTED, "An internal error has occurred.")
 
 
 async def deploy_decision_impl(

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -1712,6 +1712,92 @@ class TestGraphStoreBackendSelection:
         assert any(call[0] == "attack_paths" for call in recording_graph_store.calls)
         assert any(call[0] == "nodes_by_ids" for call in recording_graph_store.calls)
 
+    def test_exposure_paths_rest_route_matches_agent_native_contract(self, recording_graph_store):
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        recording_graph_store.graph.add_node(
+            UnifiedNode(id="vuln:cve", entity_type=EntityType.VULNERABILITY, label="CVE-2026-1", severity="high", risk_score=88.0)
+        )
+        recording_graph_store.graph.add_edge(UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES))
+        recording_graph_store.graph.add_edge(UnifiedEdge(source="server:s", target="vuln:cve", relationship=RelationshipType.VULNERABLE_TO))
+        recording_graph_store.graph.attack_paths.append(
+            AttackPath(
+                source="agent:a",
+                target="vuln:cve",
+                hops=["agent:a", "server:s", "vuln:cve"],
+                edges=["uses", "vulnerable_to"],
+                composite_risk=88.0,
+                summary="agent-a reaches CVE-2026-1 through server-s",
+                tool_exposure=["run_shell"],
+                credential_exposure=["AWS_TOKEN"],
+                vuln_ids=["CVE-2026-1"],
+            )
+        )
+        client = TestClient(app)
+
+        response = client.get("/v1/graph/exposure-paths", params={"limit": 1, "min_risk": 70})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["schema_version"] == "v1"
+        assert body["tool"] == "exposure_paths"
+        assert body["tenant_id"] == "default"
+        assert body["filters"] == {"limit": 1, "min_risk": 70.0}
+        assert body["paths"][0]["riskScore"] == 88.0
+        assert body["paths"][0]["source"]["id"] == "agent:a"
+        assert body["paths"][0]["target"]["id"] == "vuln:cve"
+        assert body["paths"][0]["reachableTools"] == ["run_shell"]
+        assert body["paths"][0]["exposedCredentials"] == ["AWS_TOKEN"]
+        assert {node["id"] for node in body["nodes"]} == {"agent:a", "server:s", "vuln:cve"}
+        assert {edge["source_id"] for edge in body["edges"]} == {"agent:a", "server:s"}
+
+    def test_should_i_deploy_rest_route_returns_agent_native_decision(self, recording_graph_store):
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        recording_graph_store.graph.add_node(
+            UnifiedNode(id="vuln:cve", entity_type=EntityType.VULNERABILITY, label="CVE-2026-1", severity="high", risk_score=88.0)
+        )
+        recording_graph_store.graph.add_edge(UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES))
+        recording_graph_store.graph.add_edge(UnifiedEdge(source="server:s", target="vuln:cve", relationship=RelationshipType.VULNERABLE_TO))
+        recording_graph_store.graph.attack_paths.append(
+            AttackPath(
+                source="agent:a",
+                target="vuln:cve",
+                hops=["agent:a", "server:s", "vuln:cve"],
+                edges=["uses", "vulnerable_to"],
+                composite_risk=88.0,
+                summary="agent-a reaches CVE-2026-1 through server-s",
+                vuln_ids=["CVE-2026-1"],
+            )
+        )
+        client = TestClient(app)
+
+        response = client.post(
+            "/v1/graph/should-i-deploy",
+            json={"candidate": "server:s", "tenant_id": "ignored-by-route", "warnRisk": 40, "blockRisk": 80},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["schema_version"] == "v1"
+        assert body["tool"] == "should_i_deploy"
+        assert body["tenant_id"] == "default"
+        assert body["decision"] == "block"
+        assert body["maxRisk"] == 88.0
+        assert body["matchedPathCount"] == 1
+        assert body["matchedPaths"][0]["findings"] == ["CVE-2026-1"]
+
+    def test_agent_native_graph_rest_routes_validate_inputs(self, recording_graph_store):
+        client = TestClient(app)
+
+        exposure_response = client.get("/v1/graph/exposure-paths", params={"limit": 0})
+        empty_candidate = client.post("/v1/graph/should-i-deploy", json={"candidate": " "})
+        bad_thresholds = client.post("/v1/graph/should-i-deploy", json={"candidate": "server:s", "warnRisk": 90, "blockRisk": 20})
+
+        assert exposure_response.status_code == 422
+        assert empty_candidate.status_code == 422
+        assert empty_candidate.json()["detail"]["details"]["argument"] == "candidate"
+        assert bad_thresholds.status_code == 422
+        assert bad_thresholds.json()["detail"]["details"] == {"warn_risk": 90.0, "block_risk": 20.0}
+
     def test_persisted_graph_routes_return_incident_edges_for_dense_finding_pages(self, tmp_path):
         store = SQLiteGraphStore(tmp_path / "dense-live-graph.db")
         graph = UnifiedGraph(scan_id="dense-live-scan", tenant_id="default")

--- a/tests/test_mcp_exposure_paths.py
+++ b/tests/test_mcp_exposure_paths.py
@@ -51,6 +51,11 @@ class _GraphStore:
         return {"attack_path_count": 1, "max_attack_path_risk": 88.0}
 
 
+class _FailingGraphStore:
+    def attack_paths(self, **_kwargs):
+        raise RuntimeError("failed to read /Users/example/.agent-bom/db/graph.db")
+
+
 @pytest.mark.asyncio
 async def test_exposure_paths_impl_returns_agent_native_contract():
     response = await exposure_paths_impl(_get_graph_store=lambda: _GraphStore(), _truncate_response=lambda value: value)
@@ -78,6 +83,16 @@ async def test_exposure_paths_impl_validates_agent_limits():
 
     assert payload["error"]["code"] == "AGENTBOM_MCP_VALIDATION_INVALID_ARGUMENT"
     assert payload["error"]["details"]["argument"] == "limit"
+
+
+@pytest.mark.asyncio
+async def test_exposure_paths_impl_redacts_internal_errors():
+    response = await exposure_paths_impl(_get_graph_store=lambda: _FailingGraphStore())
+    payload = json.loads(response)
+
+    assert payload["error"]["code"] == "AGENTBOM_MCP_INTERNAL_UNEXPECTED"
+    assert payload["error"]["message"] == "An internal error has occurred."
+    assert "graph.db" not in payload["error"]["message"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_typescript_client_route_parity.py
+++ b/tests/test_typescript_client_route_parity.py
@@ -1,0 +1,19 @@
+"""Route parity checks for the TypeScript control-plane client."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from agent_bom.api.server import app
+
+
+def test_typescript_control_plane_client_paths_exist_in_api() -> None:
+    source = Path("sdks/typescript-client/src/index.ts").read_text(encoding="utf-8")
+    client_paths = {
+        match for match in re.findall(r"[\"`](/(?:health|v1/[^\"`?$]+))", source) if not match.startswith("/v1/graph/") or "{" not in match
+    }
+    registered_paths = {getattr(route, "path", "") for route in app.routes}
+
+    assert client_paths
+    assert client_paths <= registered_paths


### PR DESCRIPTION
Summary
- add REST equivalents for the agent-native graph tools: exposure paths and deploy decisions
- reuse the existing MCP graph decision logic so MCP, REST, and the TypeScript client return the same envelope fields
- align the TypeScript client with the REST/MCP decision field and add route-parity coverage so SDK paths must exist in the API

Verification
- uv run pytest tests/test_graph_api.py tests/test_mcp_exposure_paths.py tests/test_typescript_client_route_parity.py -q
- uv run ruff check src/agent_bom/api/routes/graph.py tests/test_graph_api.py tests/test_typescript_client_route_parity.py
- uv run mypy src/agent_bom/api/routes/graph.py
- cd sdks/typescript-client && npm test
- git diff --check
