### PR TITLE
docs(product): clarify agent-first positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
 <p align="center"><b>Open security scanner and self-hosted control plane for AI/MCP infrastructure.</b></p>
+<p align="center">Headless agent primitives and human cockpit surfaces over the same evidence model.</p>
 
 <p align="center"><code>agent-bom</code> is also an open security data plane: it generates a reachability-backed AI BOM across agents, MCP servers, packages, credential environment names, cloud, runtime, and skill surfaces, then exposes the same evidence to humans and AI agents through CLI/CI, API/UI, MCP tools, and selected runtime controls.</p>
 
@@ -74,21 +75,33 @@ dashboard-only workflow:
 | Surface | Primary consumer | Shipped boundary |
 |---|---|---|
 | **CLI / CI** | developers, release gates, automation | local scans, SARIF/SBOM/HTML/JSON output, deterministic exit codes |
-| **API / UI** | security teams, auditors, operators | authenticated control plane, graph cockpit, fleet, compliance, audit, evidence review |
+| **REST API** | security platforms, SIEM jobs, custom services | authenticated control plane routes for scans, findings, graph evidence, audit, and governance |
 | **MCP tools** | Claude, Cursor, Codex, Windsurf, Cortex, and custom agents | 38 read-only tools, strict arguments, `exposure_paths`, `should_i_deploy` |
+| **TypeScript client** | services and agent runtimes calling the control plane | typed helper for stable REST endpoints; not a scanner SDK |
+| **TypeScript runtime detectors** | MCP/runtime enforcement integrations | local detector package for runtime policy checks; separate from the control-plane client |
+| **UI cockpit** | security teams, auditors, operators | graph cockpit, fleet, compliance, audit, and evidence review over the same backend data |
 | **Proxy / gateway / Shield** | runtime operators and selected applications | scoped MCP traffic inspection, policy decisions, redacted audit, runtime evidence |
 
 The UI remains a full-fidelity cockpit for humans. MCP/API/CLI give agents and
 other platforms the same underlying security primitives without requiring a
 human to click through the dashboard.
 
+That makes the product Langfuse-like in shape only: humans get a cockpit and
+agents get callable primitives, but the underlying data is security evidence
+and `ExposurePath` graph context rather than LLM traces or evals.
+
 Current boundaries:
 
-- the TypeScript package is `@agent-bom/runtime`, focused on MCP runtime
-  detectors; it is not yet a full scanner or API client SDK
+- `@agent-bom/runtime` is focused on MCP runtime detectors, while
+  `@agent-bom/client` is the TypeScript control-plane API client; neither is a
+  full scanner SDK
+- CLI scan commands run local scan pipelines today; they do not delegate to the
+  API, though CLI and API share lower scanner and discovery libraries
 - there is no managed agent-bom Cloud offering in this repo today
-- streaming SIEM/Kafka-style posture feeds and detection-as-code YAML are
-  roadmap items, not shipped surfaces
+- posture/event streaming is planned via webhook outbox and Kafka-style sinks;
+  AWS cloud-log ingestion should start with CloudTrail S3/SQS and EventBridge;
+  Kinesis is a later adapter, not a release blocker
+- detection-as-code YAML is a roadmap item, not a shipped surface
 - AWS IAM enrichment is opt-in and bounded by the documented read-only provider
   scope; do not treat it as complete IAM coverage across every cloud
 - OSS, self-hosted enterprise, and Snowflake product-lane boundaries are

--- a/docs/POSTURE_EVENT_STREAMING.md
+++ b/docs/POSTURE_EVENT_STREAMING.md
@@ -36,10 +36,21 @@ Posture push connectors should emit:
 
 ## Delivery Order
 
-1. Webhook outbox with signed HTTPS POST.
+1. Generic webhook outbox with signed HTTPS POST, retry, dead-letter handling,
+   and idempotent `event_id` delivery.
 2. OCSF envelope shared by all connector adapters.
-3. Kafka/Pulsar/EventBridge adapters as optional extras.
-4. MCP posture subscription tool backed by the same replay contract.
+3. Kafka connector for enterprise posture-event sinks covering findings,
+   `ExposurePath` changes, skill verdicts, deploy decisions, and audit deltas.
+4. AWS EventBridge plus S3/SQS CloudTrail ingestion for cloud activity
+   evidence.
+5. GCP Pub/Sub plus Azure Event Hub/Event Grid for multi-cloud parity.
+6. Kinesis/Firehose as a later AWS high-volume adapter for customers that
+   already centralize telemetry there.
+7. MCP posture subscription tool backed by the same replay contract.
 
-Do not document Kafka, Pulsar, EventBridge, or MCP posture subscriptions as
-shipped until their adapters and tests land.
+Do not document webhook outbox, Kafka, EventBridge, Pub/Sub, Event Hub,
+Kinesis, Firehose, or MCP posture subscriptions as shipped until their adapters
+and tests land. The current claim is: posture/event streaming is planned via
+webhook outbox and Kafka-style sinks; AWS cloud-log ingestion should start with
+CloudTrail S3/SQS and EventBridge. Kinesis is a later adapter, not a release
+blocker.

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -1,8 +1,9 @@
 # Product Brief
 
-`agent-bom` is an open security data plane, scanner, and self-hosted control
-plane for AI/MCP infrastructure. It generates a reachability-backed AI BOM
-across agents, MCP servers, packages, credential environment names, cloud,
+`agent-bom` is an open security scanner and self-hosted control plane for
+AI/MCP infrastructure. It adds headless agent primitives and human cockpit
+surfaces over the same evidence model. It generates a reachability-backed AI
+BOM across agents, MCP servers, packages, credential environment names, cloud,
 runtime, and skill surfaces, then exposes the same evidence through CLI/CI,
 API/UI, MCP tools, and selected runtime controls.
 
@@ -64,12 +65,13 @@ to request the same `ExposurePath` evidence, skill verdicts, and deploy
 decisions under the same auth, tenant, and audit boundary.
 
 That is the useful lesson from developer-observability products: the cockpit is
-valuable, but the product primitive must be callable. For `agent-bom`, the
-primitive is not a trace; it is graph-backed security evidence:
-`ExposurePath`, findings, skill verdicts, compliance tags, runtime audit, and
-deploy decisions. Public copy should describe this as an open security data
-plane for AI-era infrastructure, while still proving the scanner and
-self-hosted control plane first.
+valuable, but the product primitive must be callable. `agent-bom` is
+Langfuse-like in shape only: humans get a cockpit and agents get callable
+primitives, but the primitive is not a trace. It is graph-backed security
+evidence: `ExposurePath`, findings, skill verdicts, compliance tags, runtime
+audit, and deploy decisions. Public copy should describe this as an open
+security data plane only when paired with exact shipped surfaces and roadmap
+boundaries.
 
 This framing does not narrow the deployment story. It makes "deploy in your
 own cloud / infrastructure" the production form of lane 2, with runtime
@@ -126,8 +128,8 @@ notes discuss agent-native product direction.
 |---|---|---|
 | Human cockpit | Next.js dashboard, graph cockpit, reports, compliance and audit views | every UI action backed by a source registry and persisted workflow state |
 | Agent interface | 38 read-only MCP tools, strict arguments, `exposure_paths`, `should_i_deploy` | long-lived posture subscription tool, autonomous remediation actions |
-| Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports, initial TypeScript control-plane client | a full Python scanner SDK and full TypeScript scanner SDK |
-| Runtime | MCP proxy, gateway, Shield SDK, runtime audit and policy decisions | webhook outbox, Kafka/Pulsar/EventBridge adapters, and MCP posture subscriptions |
+| Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports, TypeScript control-plane client, TypeScript runtime detector package | Python/Go control-plane SDKs and full scanner SDKs |
+| Runtime | MCP proxy, gateway, Shield SDK, runtime audit and policy decisions | webhook outbox, Kafka connectors, cloud-log ingestion connectors, Kinesis/Firehose adapter, and MCP posture subscriptions |
 | Graph scale | SQLite/Postgres default path, WebGL overview, optional Neptune adapter work | production Neptune SLOs, public openCypher endpoint, mandatory graph-database backend |
 | Extensibility | Python package internals, skills, runtime detector package | productized detection-as-code YAML registry and stable plugin SDK |
 
@@ -208,9 +210,9 @@ That means public repo copy should emphasize real shipped surfaces, not just asp
 
 The next phase should stay disciplined:
 
-- SDK clarity: keep `@agent-bom/runtime` scoped to runtime detectors until a
-  real TypeScript scanner/API client exists; add a Python client only when it
-  wraps stable public CLI/API contracts
+- SDK clarity: keep `@agent-bom/runtime` scoped to runtime detectors and
+  `@agent-bom/client` scoped to control-plane API calls; add Python and Go
+  clients only when they wrap stable public API contracts
 - enterprise hardening: auth defaults, tenant isolation, Helm and deployment defaults, stable operator contracts
 - scanner depth: stronger lockfile and package coverage so buyers do not need a second tool for basic SCA depth
 - supply chain operations: tighter SBOM import/diff workflows so external vendor BOMs and current scans stay comparable

--- a/site-docs/deployment/posture-event-streaming.md
+++ b/site-docs/deployment/posture-event-streaming.md
@@ -18,7 +18,8 @@ Shipped today:
 Not shipped today:
 
 - managed posture-event streaming service
-- Kafka, Pulsar, or EventBridge connector package
+- webhook outbox connector package
+- Kafka, EventBridge, Pub/Sub, Event Hub, Kinesis, or Firehose connector package
 - long-lived `subscribe_posture_changes` MCP tool
 - guaranteed production streaming SLO
 
@@ -54,8 +55,10 @@ for SIEM/security-lake interoperability, not a replacement for the graph model.
 | Pull by API | shipped | `GET /v1/findings`, `/v1/graph*`, `/v1/audit*` | works for dashboards, SIEM jobs, and custom collectors |
 | Pull by MCP | shipped | `exposure_paths`, `should_i_deploy` | best for AI agents and coding assistants |
 | Webhook outbox | roadmap | signed HTTPS POST to customer URL | should be the first push connector |
-| Kafka/Pulsar | roadmap | topic-per-tenant or topic with tenant key | requires retry, DLQ, and idempotency guidance |
-| EventBridge | roadmap | customer account event bus | AWS-first push lane |
+| Kafka | roadmap | topic-per-tenant or topic with tenant key | first enterprise stream sink for posture events |
+| AWS EventBridge + CloudTrail S3/SQS | roadmap | customer account event bus or S3/SQS trail feed | first AWS cloud activity evidence lane |
+| GCP Pub/Sub + Azure Event Hub/Event Grid | roadmap | customer-owned cloud event transports | multi-cloud parity after AWS |
+| Kinesis/Firehose | roadmap | customer stream or delivery stream | later AWS high-volume adapter, not a release blocker |
 | Long-lived MCP subscription | roadmap | `subscribe_posture_changes` | agent-native stream; needs backpressure and replay contract |
 
 ## Reliability Rules
@@ -88,9 +91,13 @@ credential-reference model, not raw destination secrets.
 2. **OCSF event envelope** — shared serializer for findings, exposure paths,
    deploy decisions, skill verdicts, runtime policy decisions, and audit
    integrity events.
-3. **Connector adapters** — Kafka/Pulsar/EventBridge optional extras that
-   consume the outbox contract.
-4. **Agent subscription** — MCP `subscribe_posture_changes` backed by the same
+3. **Kafka connector** — enterprise stream sink for findings, exposure paths,
+   skill verdicts, deploy decisions, and audit deltas.
+4. **Cloud activity ingestion** — AWS EventBridge plus CloudTrail S3/SQS first,
+   then GCP Pub/Sub and Azure Event Hub/Event Grid.
+5. **High-volume AWS adapter** — Kinesis/Firehose for customers that already
+   centralize telemetry there.
+6. **Agent subscription** — MCP `subscribe_posture_changes` backed by the same
    outbox/replay contract.
 
 Each slice should ship with a first command, an artifact, and a verification

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -2,6 +2,9 @@
 
 **Open security scanner and self-hosted control plane for AI/MCP infrastructure.**
 
+Headless agent primitives and human cockpit surfaces use the same evidence
+model.
+
 `agent-bom` is also an open security data plane. It generates a
 reachability-backed AI BOM across agents, MCP servers, tools, packages,
 credential environment names, cloud, runtime, and skill surfaces, then exposes
@@ -50,14 +53,21 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 
 | Surface | Who uses it | What is shipped |
 |---|---|---|
-| **CLI / CI** | developers and pipelines | scans, SARIF/SBOM/HTML/JSON, graph exports, deterministic gates |
-| **API / UI** | security teams and auditors | self-hosted control plane, graph cockpit, compliance, audit, evidence review |
+| **CLI / CI** | developers and pipelines | local scans, SARIF/SBOM/HTML/JSON, graph exports, deterministic gates |
+| **REST API** | security platforms, SIEM jobs, custom services | self-hosted control-plane routes for scans, findings, graph evidence, audit, and governance |
 | **MCP tools** | AI agents and coding assistants | 38 read-only tools, strict args, `exposure_paths`, `should_i_deploy` |
+| **TypeScript client** | services and agent runtimes calling the control plane | typed helper for stable REST endpoints; not a scanner SDK |
+| **TypeScript runtime detectors** | MCP/runtime enforcement integrations | local detector package for runtime policy checks; separate from the control-plane client |
+| **UI cockpit** | security teams and auditors | graph cockpit, compliance, audit, and evidence review over the same backend data |
 | **Runtime controls** | platform and runtime operators | proxy/gateway/Shield policy decisions, redacted audit, selected live evidence |
 
 The dashboard is not the only door into the product. It is the human cockpit
 over the same evidence that agents can request through MCP and platforms can
 consume through API, CLI, reports, and exports.
+
+This is Langfuse-like in shape only: humans get a cockpit and agents get
+callable primitives, but `agent-bom` works on security evidence and
+`ExposurePath` graphs rather than LLM traces or evals.
 
 ## Current graph and agent surfaces
 
@@ -76,10 +86,16 @@ SLO or openCypher endpoint.
 
 ## Current boundaries
 
-- `@agent-bom/runtime` is a TypeScript runtime-detector package, not a full
-  scanner or API SDK.
+- `@agent-bom/runtime` is a TypeScript runtime-detector package, while
+  `@agent-bom/client` is the TypeScript control-plane API client; neither is a
+  full scanner SDK.
+- CLI scan commands run local pipelines today; they do not delegate to the API,
+  though CLI and API share lower scanner and discovery libraries.
 - Managed agent-bom Cloud, posture-event streaming connectors, and
   detection-as-code YAML are roadmap items, not shipped product in this repo.
+- Posture/event streaming is planned via webhook outbox and Kafka-style sinks.
+  AWS cloud-log ingestion should start with CloudTrail S3/SQS and EventBridge;
+  Kinesis/Firehose is a later adapter, not a release blocker.
 - AWS IAM identity enrichment is opt-in and read-only; it does not imply
   complete identity coverage across every provider.
 


### PR DESCRIPTION
Summary
- clarify the agent-first positioning while preserving the canonical release tagline
- add an honest headless surface matrix across CLI, REST API, MCP, TypeScript client, TypeScript runtime detectors, UI, and runtime controls
- document the streaming roadmap order: webhook outbox first, Kafka next, cloud activity ingestion after that, and Kinesis/Firehose later

Verification
- python scripts/check_release_consistency.py
- python scripts/check_product_surface_contract.py
- uv run mkdocs build --strict
- git diff --check

Refs #2597
