### PR TITLE
feat(sdk): expose public Python API

### DIFF
--- a/docs/PYTHON_API.md
+++ b/docs/PYTHON_API.md
@@ -5,7 +5,8 @@ results without shelling out to the CLI. The API is a wrapper over shipped
 scanner, inventory, and diff primitives; it is not a separate scanner.
 
 ```python
-from agent_bom import check, diff, inventory, scan
+from agent_bom import check, diff, scan
+from agent_bom.sdk import inventory
 
 report = scan(project=".", offline=True)
 for finding in report.to_findings():
@@ -28,7 +29,7 @@ print(delta.summary)
 | `scan(...)` | `agent_bom.models.AIBOMReport` | Runs the same local simple scan runner used by CLI scan-consuming commands. |
 | `check(...)` | `PackageCheckResult` | Synchronous single-package vulnerability check. |
 | `async_check(...)` | `PackageCheckResult` | Async single-package vulnerability check for applications already running an event loop. |
-| `inventory(...)` | `InventoryResult` | Parses JSON, CSV, or NDJSON inventory using the canonical inventory loader. |
+| `agent_bom.sdk.inventory(...)` | `InventoryResult` | Parses JSON, CSV, or NDJSON inventory using the canonical inventory loader. Kept under `agent_bom.sdk` to avoid shadowing the existing `agent_bom.inventory` module. |
 | `diff(...)` | `DiffResult` | Diffs two agent-bom reports or SBOM documents using the history diff engine. |
 
 ## Notes

--- a/docs/PYTHON_API.md
+++ b/docs/PYTHON_API.md
@@ -1,0 +1,41 @@
+# Python API
+
+`agent-bom` exposes a small public Python API for tools that want typed scan
+results without shelling out to the CLI. The API is a wrapper over shipped
+scanner, inventory, and diff primitives; it is not a separate scanner.
+
+```python
+from agent_bom import check, diff, inventory, scan
+
+report = scan(project=".", offline=True)
+for finding in report.to_findings():
+    print(finding.id, finding.severity)
+
+package = check("requests@2.31.0", ecosystem="pypi", offline=True)
+print(package.status, package.vulnerabilities)
+
+fleet = inventory("fleet-inventory.json")
+print(fleet.agent_count, fleet.package_count)
+
+delta = diff("baseline.json", "current.json")
+print(delta.summary)
+```
+
+## Functions
+
+| Function | Returns | Boundary |
+|---|---|---|
+| `scan(...)` | `agent_bom.models.AIBOMReport` | Runs the same local simple scan runner used by CLI scan-consuming commands. |
+| `check(...)` | `PackageCheckResult` | Synchronous single-package vulnerability check. |
+| `async_check(...)` | `PackageCheckResult` | Async single-package vulnerability check for applications already running an event loop. |
+| `inventory(...)` | `InventoryResult` | Parses JSON, CSV, or NDJSON inventory using the canonical inventory loader. |
+| `diff(...)` | `DiffResult` | Diffs two agent-bom reports or SBOM documents using the history diff engine. |
+
+## Notes
+
+- `check()` cannot be called from an already running event loop; use
+  `async_check()` in async applications.
+- `scan(config_path=...)` and `scan(project=...)` both define the local scan
+  scope. Passing both is allowed only when they refer to the same path.
+- The returned `AIBOMReport` uses the same typed dataclasses as the rest of the
+  package, including `Finding`, `Asset`, `Package`, and `BlastRadius`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,6 +159,7 @@ nav:
   - Integrations:
       - Smithery: integrations/smithery.md
   - API Reference:
+      - Python API: api/python-sdk.md
       - Models: api/models.md
       - Output: api/output.md
       - Scanners: api/scanners.md

--- a/site-docs/api/python-sdk.md
+++ b/site-docs/api/python-sdk.md
@@ -1,0 +1,26 @@
+# Python API
+
+Use the public Python API when another tool needs typed `agent-bom` results
+without parsing terminal output.
+
+```python
+from agent_bom import check, diff, inventory, scan
+
+report = scan(project=".", offline=True)
+for finding in report.to_findings():
+    print(finding.id, finding.severity)
+
+package = check("requests@2.31.0", ecosystem="pypi", offline=True)
+print(package.status, package.vulnerabilities)
+
+fleet = inventory("fleet-inventory.json")
+print(fleet.agent_count, fleet.package_count)
+
+delta = diff("baseline.json", "current.json")
+print(delta.summary)
+```
+
+The API delegates to the same scanner, inventory, and history-diff primitives
+used elsewhere in the product. It is not a parallel scan engine.
+
+::: agent_bom.sdk

--- a/site-docs/api/python-sdk.md
+++ b/site-docs/api/python-sdk.md
@@ -4,7 +4,8 @@ Use the public Python API when another tool needs typed `agent-bom` results
 without parsing terminal output.
 
 ```python
-from agent_bom import check, diff, inventory, scan
+from agent_bom import check, diff, scan
+from agent_bom.sdk import inventory
 
 report = scan(project=".", offline=True)
 for finding in report.to_findings():

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -19,3 +19,28 @@ if _pyproject.exists():
             __version__ = _m.group(1)
     except Exception:
         pass  # Never block import due to pyproject read failure
+
+from agent_bom.sdk import (  # noqa: E402
+    AgentBomSDKError,
+    DiffResult,
+    InventoryResult,
+    PackageCheckResult,
+    async_check,
+    check,
+    diff,
+    inventory,
+    scan,
+)
+
+__all__ = [
+    "__version__",
+    "AgentBomSDKError",
+    "DiffResult",
+    "InventoryResult",
+    "PackageCheckResult",
+    "async_check",
+    "check",
+    "diff",
+    "inventory",
+    "scan",
+]

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -28,7 +28,6 @@ from agent_bom.sdk import (  # noqa: E402
     async_check,
     check,
     diff,
-    inventory,
     scan,
 )
 
@@ -41,6 +40,5 @@ __all__ = [
     "async_check",
     "check",
     "diff",
-    "inventory",
     "scan",
 ]

--- a/src/agent_bom/sdk.py
+++ b/src/agent_bom/sdk.py
@@ -1,0 +1,270 @@
+"""Public Python API for embedding agent-bom in other tools.
+
+This module is intentionally thin: it exposes stable Python functions while
+delegating to the same scanner, inventory, and history primitives used by the
+CLI and MCP surfaces. It is not a second scan implementation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+from agent_bom.ecosystems import SUPPORTED_PACKAGE_ECOSYSTEM_SET
+from agent_bom.finding import Asset, Finding
+from agent_bom.mcp_server_runtime import validate_ecosystem
+from agent_bom.models import AIBOMReport, Package
+
+
+class AgentBomSDKError(RuntimeError):
+    """Raised when the public Python API cannot complete a requested operation."""
+
+
+@dataclass(frozen=True)
+class PackageCheckResult:
+    """Typed result returned by :func:`check` and :func:`async_check`."""
+
+    package: str
+    version: str
+    ecosystem: str
+    status: str
+    vulnerabilities: int
+    details: list[dict[str, Any]] = field(default_factory=list)
+    message: str = ""
+
+    @property
+    def is_clean(self) -> bool:
+        return self.status == "clean"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "package": self.package,
+            "version": self.version,
+            "ecosystem": self.ecosystem,
+            "status": self.status,
+            "vulnerabilities": self.vulnerabilities,
+            "details": self.details,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True)
+class InventoryResult:
+    """Typed inventory wrapper returned by :func:`inventory`."""
+
+    data: dict[str, Any]
+    agent_count: int
+    server_count: int
+    package_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "data": self.data,
+            "agent_count": self.agent_count,
+            "server_count": self.server_count,
+            "package_count": self.package_count,
+        }
+
+
+@dataclass(frozen=True)
+class DiffResult:
+    """Typed report diff wrapper returned by :func:`diff`."""
+
+    data: dict[str, Any]
+
+    @property
+    def summary(self) -> dict[str, Any]:
+        summary = self.data.get("summary", {})
+        return summary if isinstance(summary, dict) else {}
+
+    @property
+    def new_findings(self) -> int:
+        return int(self.summary.get("new_findings", 0) or 0)
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.data
+
+
+def scan(
+    *,
+    config_path: str | Path | None = None,
+    project: str | Path | None = None,
+    demo: bool = False,
+    offline: bool = False,
+    enrich: bool = False,
+    compliance: bool = False,
+    transitive: bool = False,
+    max_depth: int = 3,
+    blast_radius_depth: int = 2,
+) -> AIBOMReport:
+    """Run the standard local scan pipeline and return a typed report.
+
+    ``project`` and ``config_path`` both point at a local project/config scope.
+    The name ``config_path`` is kept for MCP/API users who are already familiar
+    with that argument; internally this delegates to the same simple scan runner
+    used by CLI commands.
+    """
+
+    if project is not None and config_path is not None and Path(project).expanduser() != Path(config_path).expanduser():
+        raise ValueError("project and config_path refer to different scan scopes")
+
+    from rich.console import Console
+
+    from agent_bom.cli._scan_runner import ScanConfig, run_default_scan
+
+    output = io.StringIO()
+    console = Console(file=output, force_terminal=False, no_color=True, width=120)
+    scan_scope = project if project is not None else config_path
+    result = run_default_scan(
+        ScanConfig(
+            project=str(scan_scope) if scan_scope is not None else None,
+            demo=demo,
+            offline=offline,
+            enrich=enrich,
+            compliance=compliance,
+            resolve_transitive=transitive,
+            max_depth=max_depth,
+            blast_radius_depth=blast_radius_depth,
+            quiet=True,
+        ),
+        console,
+    )
+    if result.report is None:
+        raise AgentBomSDKError("scan completed without a report")
+    return result.report
+
+
+def _parse_package_spec(spec: str) -> tuple[str, str]:
+    cleaned = spec.strip()
+    if not cleaned:
+        raise ValueError("package must not be empty")
+    if "@" in cleaned and not cleaned.startswith("@"):
+        name, version = cleaned.rsplit("@", 1)
+    elif cleaned.startswith("@") and cleaned.count("@") > 1:
+        last_at = cleaned.rindex("@")
+        name, version = cleaned[:last_at], cleaned[last_at + 1 :]
+    elif "==" in cleaned:
+        name, version = cleaned.split("==", 1)
+    else:
+        name, version = cleaned, "latest"
+    name = name.strip()
+    version = version.strip() or "latest"
+    if not name:
+        raise ValueError("package name must not be empty")
+    return name, version
+
+
+def _vulnerability_details(pkg: Package) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": vuln.id,
+            "severity": vuln.severity.value,
+            "cvss_score": vuln.cvss_score,
+            "fixed_version": vuln.fixed_version,
+            "summary": vuln.summary or "",
+            "compliance_tags": vuln.compliance_tags,
+        }
+        for vuln in pkg.vulnerabilities
+    ]
+
+
+async def async_check(package: str, *, ecosystem: str = "npm", offline: bool = False) -> PackageCheckResult:
+    """Check one package spec and return a typed vulnerability result."""
+
+    eco = validate_ecosystem(ecosystem, SUPPORTED_PACKAGE_ECOSYSTEM_SET)
+    name, version = _parse_package_spec(package)
+    if eco in {"deb", "apk", "rpm"} and version in {"", "latest"}:
+        raise ValueError(f"explicit version required for {eco} packages")
+
+    from agent_bom.scanners import ScanOptions, scan_packages
+
+    pkg = Package(name=name, version=version, ecosystem=eco)
+    await scan_packages([pkg], options=ScanOptions(offline=offline))
+    details = _vulnerability_details(pkg)
+    status = "vulnerable" if details else "clean"
+    return PackageCheckResult(
+        package=pkg.name,
+        version=pkg.version,
+        ecosystem=eco,
+        status=status,
+        vulnerabilities=len(details),
+        details=details,
+        message=f"No known vulnerabilities in {pkg.name}@{pkg.version}" if status == "clean" else "",
+    )
+
+
+def check(package: str, *, ecosystem: str = "npm", offline: bool = False) -> PackageCheckResult:
+    """Synchronous wrapper around :func:`async_check`.
+
+    Async applications should call :func:`async_check` directly to avoid nesting
+    event loops.
+    """
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(async_check(package, ecosystem=ecosystem, offline=offline))
+    raise AgentBomSDKError("check() cannot run inside an active event loop; use async_check() instead")
+
+
+def inventory(source: str | Path) -> InventoryResult:
+    """Load a JSON/CSV/NDJSON inventory artifact and return typed counts."""
+
+    from agent_bom.inventory import load_inventory
+
+    data = load_inventory(str(source))
+    agents = data.get("agents", [])
+    agent_count = len(agents) if isinstance(agents, list) else 0
+    server_count = 0
+    package_count = 0
+    if isinstance(agents, list):
+        for agent in agents:
+            servers = agent.get("mcp_servers", []) if isinstance(agent, dict) else []
+            if not isinstance(servers, list):
+                continue
+            server_count += len(servers)
+            for server in servers:
+                packages = server.get("packages", []) if isinstance(server, dict) else []
+                if isinstance(packages, list):
+                    package_count += len(packages)
+    return InventoryResult(
+        data=data,
+        agent_count=agent_count,
+        server_count=server_count,
+        package_count=package_count,
+    )
+
+
+def _coerce_report_input(value: str | Path | Mapping[str, Any]) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    from agent_bom.history import load_report_or_sbom
+
+    return load_report_or_sbom(Path(value))
+
+
+def diff(baseline: str | Path | Mapping[str, Any], current: str | Path | Mapping[str, Any]) -> DiffResult:
+    """Diff two agent-bom reports or SBOM documents."""
+
+    from agent_bom.history import diff_reports
+
+    return DiffResult(diff_reports(_coerce_report_input(baseline), _coerce_report_input(current)))
+
+
+__all__ = [
+    "AIBOMReport",
+    "AgentBomSDKError",
+    "Asset",
+    "DiffResult",
+    "Finding",
+    "InventoryResult",
+    "PackageCheckResult",
+    "async_check",
+    "check",
+    "diff",
+    "inventory",
+    "scan",
+]

--- a/tests/test_public_python_api.py
+++ b/tests/test_public_python_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 from types import SimpleNamespace
 
@@ -15,8 +16,15 @@ from agent_bom.models import AIBOMReport, Package, Severity, Vulnerability
 def test_public_api_exports_expected_functions():
     assert agent_bom.scan is sdk.scan
     assert agent_bom.check is sdk.check
-    assert agent_bom.inventory is sdk.inventory
     assert agent_bom.diff is sdk.diff
+    assert sdk.inventory.__name__ == "inventory"
+
+
+def test_inventory_sdk_helper_does_not_shadow_inventory_module():
+    inventory_module = importlib.import_module("agent_bom.inventory")
+
+    assert agent_bom.inventory is inventory_module
+    assert sdk.inventory.__name__ == "inventory"
 
 
 def test_scan_delegates_to_cli_scan_runner(monkeypatch):

--- a/tests/test_public_python_api.py
+++ b/tests/test_public_python_api.py
@@ -1,0 +1,121 @@
+"""Tests for the public ``agent_bom`` Python API."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+import agent_bom
+from agent_bom import sdk
+from agent_bom.models import AIBOMReport, Package, Severity, Vulnerability
+
+
+def test_public_api_exports_expected_functions():
+    assert agent_bom.scan is sdk.scan
+    assert agent_bom.check is sdk.check
+    assert agent_bom.inventory is sdk.inventory
+    assert agent_bom.diff is sdk.diff
+
+
+def test_scan_delegates_to_cli_scan_runner(monkeypatch):
+    report = AIBOMReport(scan_sources=["agent_discovery"])
+    captured = {}
+
+    def fake_run_default_scan(cfg, _console):
+        captured["cfg"] = cfg
+        return SimpleNamespace(report=report)
+
+    monkeypatch.setattr("agent_bom.cli._scan_runner.run_default_scan", fake_run_default_scan)
+
+    result = sdk.scan(project=".", offline=True, transitive=True)
+
+    assert result is report
+    assert captured["cfg"].project == "."
+    assert captured["cfg"].offline is True
+    assert captured["cfg"].resolve_transitive is True
+    assert captured["cfg"].quiet is True
+
+
+@pytest.mark.asyncio
+async def test_async_check_returns_typed_package_result(monkeypatch):
+    async def fake_scan_packages(packages: list[Package], **_kwargs):
+        packages[0].vulnerabilities.append(
+            Vulnerability(id="CVE-2026-0001", summary="test vuln", severity=Severity.HIGH, fixed_version="2.0.0")
+        )
+        return 1
+
+    monkeypatch.setattr("agent_bom.scanners.scan_packages", fake_scan_packages)
+
+    result = await sdk.async_check("Django@1.0.0", ecosystem="pypi", offline=True)
+
+    assert result.package == "Django"
+    assert result.version == "1.0.0"
+    assert result.ecosystem == "pypi"
+    assert result.status == "vulnerable"
+    assert result.vulnerabilities == 1
+    assert result.details[0]["id"] == "CVE-2026-0001"
+    assert result.to_dict()["status"] == "vulnerable"
+
+
+def test_check_rejects_nested_event_loop():
+    async def run_inside_loop():
+        with pytest.raises(sdk.AgentBomSDKError, match="async_check"):
+            sdk.check("requests@2.31.0", ecosystem="pypi")
+
+    import asyncio
+
+    asyncio.run(run_inside_loop())
+
+
+def test_inventory_returns_counts(tmp_path):
+    path = tmp_path / "inventory.json"
+    path.write_text(
+        json.dumps(
+            {
+                "agents": [
+                    {
+                        "name": "agent-a",
+                        "mcp_servers": [
+                            {
+                                "name": "server-a",
+                                "packages": [
+                                    {"name": "requests", "version": "2.31.0", "ecosystem": "pypi"},
+                                    {"name": "express", "version": "4.18.0", "ecosystem": "npm"},
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+    )
+
+    result = sdk.inventory(path)
+
+    assert result.agent_count == 1
+    assert result.server_count == 1
+    assert result.package_count == 2
+    assert result.to_dict()["package_count"] == 2
+
+
+def test_diff_accepts_report_dicts():
+    baseline = {
+        "blast_radius": [
+            {"vulnerability_id": "CVE-2026-OLD", "package": "oldpkg", "ecosystem": "pypi"},
+        ],
+        "agents": [],
+    }
+    current = {
+        "blast_radius": [
+            {"vulnerability_id": "CVE-2026-NEW", "package": "newpkg", "ecosystem": "pypi"},
+        ],
+        "agents": [],
+    }
+
+    result = sdk.diff(baseline, current)
+
+    assert result.summary["new_findings"] == 1
+    assert result.summary["resolved_findings"] == 1
+    assert result.new_findings == 1


### PR DESCRIPTION
Summary
- add a public Python API with `scan`, `check`, `async_check`, `agent_bom.sdk.inventory`, and `diff`
- reuse existing scanner, inventory, and history-diff primitives instead of creating a parallel scan engine
- keep `agent_bom.inventory` as the existing inventory module, and document the SDK inventory helper under `agent_bom.sdk` to avoid import-order shadowing
- document the Python API in repo docs and the MkDocs API reference

Verification
- `uv run pytest tests/test_public_python_api.py -q`
- `uv run ruff check src/agent_bom/sdk.py src/agent_bom/__init__.py tests/test_public_python_api.py`
- `uv run mypy src/agent_bom/sdk.py`
- `uv run mkdocs build --strict`
- `git diff --check`

Closes #795
