### PR TITLE
feat(runtime): add posture webhook outbox

### DIFF
--- a/docs/POSTURE_EVENT_STREAMING.md
+++ b/docs/POSTURE_EVENT_STREAMING.md
@@ -2,16 +2,22 @@
 
 This document is the repo-facing contract for issue #2597.
 
-Current shipped posture delivery is pull-first:
+Current shipped posture delivery includes pull workflows and the first
+push-delivery primitive:
 
 - scan report files: SARIF, SBOM, HTML, JSON, graph exports
 - REST API routes for findings, graph, audit, posture, and runtime state
 - MCP tools for agent pull workflows, including `exposure_paths` and
   `should_i_deploy`
 - selected SIEM/export guidance and OCSF projections
+- `agent_bom.posture_streaming.WebhookOutbox`, a tenant-scoped SQLite outbox
+  for signed webhook delivery with idempotency, retry metadata,
+  private-network destination opt-in, and dead-letter state
 
-Push connectors are roadmap work until a PR adds the outbox, delivery, and
-retry implementation.
+The shipped webhook outbox core does not create hidden egress. Operators must
+provide an explicit `WebhookDestination` and delivery function. Managed
+connector packages for Kafka, EventBridge, Pub/Sub, Event Hub, Kinesis, and
+Firehose remain roadmap work until adapter code and tests land.
 
 ## Event Envelope
 
@@ -22,22 +28,22 @@ Posture push connectors should emit:
 | `event_id` | idempotent delivery key |
 | `tenant_id` | tenant owner |
 | `event_type` | finding, exposure path, skill verdict, deploy decision, runtime policy decision, or audit integrity event |
-| `occurred_at` | source timestamp |
-| `observed_at` | connector timestamp |
+| `created_at` | source or enqueue timestamp |
 | `source` | scan/API/MCP/proxy/gateway/importer |
 | `severity` | normalized severity where applicable |
 | `risk_score` | path or finding risk score where applicable |
 | `entity_refs` | related graph/source/package/agent/cloud/IAM IDs |
 | `exposure_path_id` | linked path ID when present |
 | `payload` | canonical agent-bom object |
-| `ocsf` | OCSF projection when available |
-| `audit_ref` | audit-chain pointer or verification metadata |
+| `ocsf` | OCSF projection when available in higher-level adapters |
+| `audit_ref` | audit-chain pointer or verification metadata when available |
 | `schema_version` | connector schema version |
 
 ## Delivery Order
 
-1. Generic webhook outbox with signed HTTPS POST, retry, dead-letter handling,
-   and idempotent `event_id` delivery.
+1. Generic webhook outbox core with signed HTTPS POST headers, retry metadata,
+   dead-letter state, and idempotent `event_id` delivery. Shipped in
+   `agent_bom.posture_streaming`.
 2. OCSF envelope shared by all connector adapters.
 3. Kafka connector for enterprise posture-event sinks covering findings,
    `ExposurePath` changes, skill verdicts, deploy decisions, and audit deltas.
@@ -48,9 +54,9 @@ Posture push connectors should emit:
    already centralize telemetry there.
 7. MCP posture subscription tool backed by the same replay contract.
 
-Do not document webhook outbox, Kafka, EventBridge, Pub/Sub, Event Hub,
-Kinesis, Firehose, or MCP posture subscriptions as shipped until their adapters
-and tests land. The current claim is: posture/event streaming is planned via
-webhook outbox and Kafka-style sinks; AWS cloud-log ingestion should start with
+Do not document Kafka, EventBridge, Pub/Sub, Event Hub, Kinesis, Firehose, or
+MCP posture subscriptions as shipped until their adapters and tests land. The
+current claim is: posture/event streaming has a signed webhook outbox core;
+Kafka-style sinks are next; AWS cloud-log ingestion should start with
 CloudTrail S3/SQS and EventBridge. Kinesis is a later adapter, not a release
 blocker.

--- a/site-docs/deployment/posture-event-streaming.md
+++ b/site-docs/deployment/posture-event-streaming.md
@@ -1,9 +1,10 @@
 # Posture Event Streaming
 
 `agent-bom` already produces security evidence through reports, API routes,
-MCP tools, audit records, and selected SIEM/export paths. This page defines the
-next connector contract for pushing posture changes into security lakes, SIEMs,
-SOARs, and agent queues without making a shipped-connector claim too early.
+MCP tools, audit records, and selected SIEM/export paths. It also ships the
+first push-delivery primitive: a signed webhook outbox core for posture events.
+This page separates shipped primitives from connector roadmap work so release
+claims stay precise.
 
 ## Current State
 
@@ -14,11 +15,12 @@ Shipped today:
 - `/v1/proxy/audit` and audit-chain verification for runtime events
 - SIEM integration guidance for supported export paths
 - `exposure_paths` and `should_i_deploy` MCP tools for agent pull workflows
+- `agent_bom.posture_streaming.WebhookOutbox` for tenant-scoped, idempotent,
+  signed webhook deliveries with retry and dead-letter metadata
 
 Not shipped today:
 
 - managed posture-event streaming service
-- webhook outbox connector package
 - Kafka, EventBridge, Pub/Sub, Event Hub, Kinesis, or Firehose connector package
 - long-lived `subscribe_posture_changes` MCP tool
 - guaranteed production streaming SLO
@@ -33,8 +35,7 @@ systems do not need per-connector parsers.
 | `event_id` | stable UUID for idempotency |
 | `tenant_id` | tenant that owns the event |
 | `event_type` | `finding.created`, `finding.updated`, `exposure_path.created`, `skill.verdict`, `deploy.decision`, `runtime.policy_decision`, or `audit.integrity` |
-| `occurred_at` | source event timestamp |
-| `observed_at` | connector observation timestamp |
+| `created_at` | source event or enqueue timestamp |
 | `source` | scan, API route, MCP tool, proxy, gateway, or importer that produced the event |
 | `severity` | normalized severity where applicable |
 | `risk_score` | numeric risk score where applicable |
@@ -54,7 +55,7 @@ for SIEM/security-lake interoperability, not a replacement for the graph model.
 |---|---|---|---|
 | Pull by API | shipped | `GET /v1/findings`, `/v1/graph*`, `/v1/audit*` | works for dashboards, SIEM jobs, and custom collectors |
 | Pull by MCP | shipped | `exposure_paths`, `should_i_deploy` | best for AI agents and coding assistants |
-| Webhook outbox | roadmap | signed HTTPS POST to customer URL | should be the first push connector |
+| Webhook outbox core | shipped | `agent_bom.posture_streaming.WebhookOutbox` | operator-provided sender performs explicit HTTPS POST; no hidden egress |
 | Kafka | roadmap | topic-per-tenant or topic with tenant key | first enterprise stream sink for posture events |
 | AWS EventBridge + CloudTrail S3/SQS | roadmap | customer account event bus or S3/SQS trail feed | first AWS cloud activity evidence lane |
 | GCP Pub/Sub + Azure Event Hub/Event Grid | roadmap | customer-owned cloud event transports | multi-cloud parity after AWS |
@@ -86,8 +87,9 @@ credential-reference model, not raw destination secrets.
 
 ## Implementation Slices
 
-1. **Webhook outbox** — tenant-scoped table, signed delivery, retry policy,
-   dead-letter API, and tests.
+1. **Webhook outbox core** — tenant-scoped table, signed delivery headers,
+   retry policy metadata, dead-letter state, private-network destination
+   opt-in, and tests. Shipped in `agent_bom.posture_streaming`.
 2. **OCSF event envelope** — shared serializer for findings, exposure paths,
    deploy decisions, skill verdicts, runtime policy decisions, and audit
    integrity events.

--- a/src/agent_bom/posture_streaming.py
+++ b/src/agent_bom/posture_streaming.py
@@ -1,0 +1,367 @@
+"""Posture-event streaming primitives.
+
+The module provides the first concrete push lane for posture events: a
+tenant-scoped, retry-aware webhook outbox. It deliberately does not create
+hidden egress. Operators must enqueue events for an explicit destination and
+provide the delivery function that performs the HTTPS POST.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import ipaddress
+import json
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+from urllib.parse import urlparse
+
+from agent_bom.security import sanitize_error, sanitize_sensitive_payload
+
+POSTURE_EVENT_SCHEMA_VERSION = "1"
+WebhookSender = Callable[[str, dict[str, str], dict[str, Any]], Awaitable[int]]
+
+
+class PostureStreamingError(RuntimeError):
+    """Raised when a posture event cannot be queued or delivered safely."""
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _validate_tenant_id(tenant_id: str) -> str:
+    cleaned = tenant_id.strip()
+    if not cleaned:
+        raise ValueError("tenant_id must not be empty")
+    return cleaned
+
+
+def _validate_destination_url(url: str, *, allow_private_networks: bool = False) -> str:
+    cleaned = url.strip()
+    parsed = urlparse(cleaned)
+    if parsed.scheme != "https":
+        raise ValueError("webhook destinations must use https")
+    if not parsed.netloc:
+        raise ValueError("webhook destination must include a host")
+    if parsed.username or parsed.password:
+        raise ValueError("webhook destination must not embed credentials")
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("webhook destination must include a host")
+    if not allow_private_networks:
+        normalized_host = hostname.lower().strip("[]")
+        if normalized_host in {"localhost", "localhost.localdomain"} or normalized_host.endswith(".localhost"):
+            raise ValueError("webhook destination private networks require explicit opt-in")
+        try:
+            ip_addr = ipaddress.ip_address(normalized_host)
+        except ValueError:
+            ip_addr = None
+        if ip_addr and (
+            ip_addr.is_private
+            or ip_addr.is_loopback
+            or ip_addr.is_link_local
+            or ip_addr.is_multicast
+            or ip_addr.is_unspecified
+            or ip_addr.is_reserved
+        ):
+            raise ValueError("webhook destination private networks require explicit opt-in")
+    return cleaned
+
+
+@dataclass(frozen=True)
+class PostureEvent:
+    """Redacted, tenant-scoped event queued for streaming sinks."""
+
+    event_type: str
+    tenant_id: str
+    source: str
+    payload: dict[str, Any]
+    subject_id: str = ""
+    event_id: str = ""
+    created_at: float = field(default_factory=_now)
+    schema_version: str = POSTURE_EVENT_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        clean_tenant = _validate_tenant_id(self.tenant_id)
+        clean_payload = sanitize_sensitive_payload(self.payload)
+        if not isinstance(clean_payload, dict):
+            clean_payload = {"value": clean_payload}
+        object.__setattr__(self, "tenant_id", clean_tenant)
+        object.__setattr__(self, "payload", clean_payload)
+        if not self.event_type.strip():
+            raise ValueError("event_type must not be empty")
+        if not self.source.strip():
+            raise ValueError("source must not be empty")
+        if not self.event_id:
+            fingerprint = _canonical_json(
+                {
+                    "schema_version": self.schema_version,
+                    "event_type": self.event_type,
+                    "tenant_id": self.tenant_id,
+                    "source": self.source,
+                    "subject_id": self.subject_id,
+                    "payload": self.payload,
+                }
+            )
+            object.__setattr__(self, "event_id", hashlib.sha256(fingerprint.encode("utf-8")).hexdigest())
+
+    @property
+    def idempotency_key(self) -> str:
+        return f"{self.tenant_id}:{self.event_id}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "event_id": self.event_id,
+            "event_type": self.event_type,
+            "tenant_id": self.tenant_id,
+            "source": self.source,
+            "subject_id": self.subject_id,
+            "created_at": self.created_at,
+            "payload": self.payload,
+        }
+
+
+@dataclass(frozen=True)
+class WebhookDestination:
+    """Operator-approved webhook destination."""
+
+    destination_id: str
+    tenant_id: str
+    url: str
+    signing_secret: str
+    allow_private_networks: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.destination_id.strip():
+            raise ValueError("destination_id must not be empty")
+        if not self.signing_secret:
+            raise ValueError("signing_secret must not be empty")
+        object.__setattr__(self, "tenant_id", _validate_tenant_id(self.tenant_id))
+        object.__setattr__(self, "url", _validate_destination_url(self.url, allow_private_networks=self.allow_private_networks))
+
+
+@dataclass(frozen=True)
+class QueuedDelivery:
+    """One outbox delivery attempt candidate."""
+
+    row_id: int
+    event_id: str
+    tenant_id: str
+    destination_id: str
+    url: str
+    payload: dict[str, Any]
+    attempts: int
+    next_attempt_at: float
+    last_error: str = ""
+
+
+class WebhookOutbox:
+    """SQLite-backed webhook outbox with retry and idempotency metadata."""
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS posture_webhook_outbox (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    event_id TEXT NOT NULL,
+                    tenant_id TEXT NOT NULL,
+                    destination_id TEXT NOT NULL,
+                    url TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    next_attempt_at REAL NOT NULL DEFAULT 0,
+                    last_error TEXT NOT NULL DEFAULT '',
+                    created_at REAL NOT NULL,
+                    delivered_at REAL,
+                    idempotency_key TEXT NOT NULL,
+                    UNIQUE(tenant_id, destination_id, event_id)
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_posture_webhook_outbox_due
+                ON posture_webhook_outbox(status, tenant_id, next_attempt_at)
+                """
+            )
+
+    def enqueue(self, event: PostureEvent, destination: WebhookDestination) -> int:
+        if event.tenant_id != destination.tenant_id:
+            raise ValueError("event tenant_id must match destination tenant_id")
+        payload_json = _canonical_json(event.to_dict())
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO posture_webhook_outbox (
+                    event_id, tenant_id, destination_id, url, payload_json,
+                    status, attempts, next_attempt_at, created_at, idempotency_key
+                ) VALUES (?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?)
+                """,
+                (
+                    event.event_id,
+                    event.tenant_id,
+                    destination.destination_id,
+                    destination.url,
+                    payload_json,
+                    event.created_at,
+                    event.created_at,
+                    event.idempotency_key,
+                ),
+            )
+            row = conn.execute(
+                """
+                SELECT id FROM posture_webhook_outbox
+                WHERE tenant_id = ? AND destination_id = ? AND event_id = ?
+                """,
+                (event.tenant_id, destination.destination_id, event.event_id),
+            ).fetchone()
+            return int(row["id"])
+
+    def due(self, *, tenant_id: str, limit: int = 100, now: float | None = None) -> list[QueuedDelivery]:
+        clean_tenant = _validate_tenant_id(tenant_id)
+        effective_now = _now() if now is None else now
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT * FROM posture_webhook_outbox
+                WHERE tenant_id = ? AND status = 'pending' AND next_attempt_at <= ?
+                ORDER BY created_at ASC, id ASC
+                LIMIT ?
+                """,
+                (clean_tenant, effective_now, limit),
+            ).fetchall()
+        return [
+            QueuedDelivery(
+                row_id=int(row["id"]),
+                event_id=str(row["event_id"]),
+                tenant_id=str(row["tenant_id"]),
+                destination_id=str(row["destination_id"]),
+                url=str(row["url"]),
+                payload=json.loads(str(row["payload_json"])),
+                attempts=int(row["attempts"]),
+                next_attempt_at=float(row["next_attempt_at"]),
+                last_error=str(row["last_error"] or ""),
+            )
+            for row in rows
+        ]
+
+    def mark_delivered(self, row_id: int, *, delivered_at: float | None = None) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE posture_webhook_outbox
+                SET status = 'delivered', delivered_at = ?, last_error = ''
+                WHERE id = ?
+                """,
+                (_now() if delivered_at is None else delivered_at, row_id),
+            )
+
+    def mark_failed(self, row_id: int, *, error: str, retry_at: float, max_attempts: int = 5) -> None:
+        with self._connect() as conn:
+            row = conn.execute("SELECT attempts FROM posture_webhook_outbox WHERE id = ?", (row_id,)).fetchone()
+            attempts = int(row["attempts"]) + 1 if row else 1
+            status = "dead_letter" if attempts >= max_attempts else "pending"
+            conn.execute(
+                """
+                UPDATE posture_webhook_outbox
+                SET status = ?, attempts = ?, next_attempt_at = ?, last_error = ?
+                WHERE id = ?
+                """,
+                (status, attempts, retry_at, sanitize_error(error), row_id),
+            )
+
+
+def signed_webhook_headers(event: PostureEvent, destination: WebhookDestination, *, attempt: int = 1) -> dict[str, str]:
+    payload_json = _canonical_json(event.to_dict())
+    signature = hmac.new(destination.signing_secret.encode("utf-8"), payload_json.encode("utf-8"), hashlib.sha256).hexdigest()
+    return {
+        "content-type": "application/json",
+        "x-agent-bom-event-id": event.event_id,
+        "x-agent-bom-tenant-id": event.tenant_id,
+        "x-agent-bom-signature": f"sha256={signature}",
+        "x-agent-bom-delivery-attempt": str(attempt),
+        "idempotency-key": event.idempotency_key,
+    }
+
+
+async def deliver_due_webhooks(
+    outbox: WebhookOutbox,
+    *,
+    destination: WebhookDestination,
+    sender: WebhookSender,
+    limit: int = 100,
+    now: float | None = None,
+    max_attempts: int = 5,
+) -> dict[str, int]:
+    """Deliver due webhook events for one tenant and explicit destination."""
+
+    delivered = 0
+    failed = 0
+    dead_lettered = 0
+    effective_now = _now() if now is None else now
+    for item in outbox.due(tenant_id=destination.tenant_id, limit=limit, now=effective_now):
+        if item.destination_id != destination.destination_id:
+            continue
+        event_payload = item.payload
+        event = PostureEvent(
+            event_type=str(event_payload["event_type"]),
+            tenant_id=str(event_payload["tenant_id"]),
+            source=str(event_payload["source"]),
+            subject_id=str(event_payload.get("subject_id") or ""),
+            payload=dict(event_payload.get("payload") or {}),
+            event_id=str(event_payload["event_id"]),
+            created_at=float(event_payload.get("created_at") or effective_now),
+            schema_version=str(event_payload.get("schema_version") or POSTURE_EVENT_SCHEMA_VERSION),
+        )
+        headers = signed_webhook_headers(event, destination, attempt=item.attempts + 1)
+        try:
+            status = await sender(destination.url, headers, event.to_dict())
+            if 200 <= status < 300:
+                outbox.mark_delivered(item.row_id, delivered_at=effective_now)
+                delivered += 1
+            else:
+                failed += 1
+                retry_at = effective_now + min(3600, 2 ** max(item.attempts, 0))
+                outbox.mark_failed(item.row_id, error=f"webhook returned HTTP {status}", retry_at=retry_at, max_attempts=max_attempts)
+                if item.attempts + 1 >= max_attempts:
+                    dead_lettered += 1
+        except Exception as exc:  # noqa: BLE001
+            failed += 1
+            retry_at = effective_now + min(3600, 2 ** max(item.attempts, 0))
+            outbox.mark_failed(item.row_id, error=sanitize_error(exc), retry_at=retry_at, max_attempts=max_attempts)
+            if item.attempts + 1 >= max_attempts:
+                dead_lettered += 1
+    return {"delivered": delivered, "failed": failed, "dead_lettered": dead_lettered}
+
+
+__all__ = [
+    "POSTURE_EVENT_SCHEMA_VERSION",
+    "PostureEvent",
+    "PostureStreamingError",
+    "QueuedDelivery",
+    "WebhookDestination",
+    "WebhookOutbox",
+    "deliver_due_webhooks",
+    "signed_webhook_headers",
+]

--- a/tests/test_posture_streaming.py
+++ b/tests/test_posture_streaming.py
@@ -1,0 +1,171 @@
+"""Tests for posture-event webhook outbox streaming."""
+
+from __future__ import annotations
+
+import hmac
+import json
+
+import pytest
+
+from agent_bom.posture_streaming import (
+    PostureEvent,
+    WebhookDestination,
+    WebhookOutbox,
+    deliver_due_webhooks,
+    signed_webhook_headers,
+)
+
+
+def test_posture_event_redacts_sensitive_payload_and_is_idempotent():
+    event_a = PostureEvent(
+        event_type="finding.created",
+        tenant_id="tenant-a",
+        source="test",
+        subject_id="finding-1",
+        payload={"api_token": "ghp_abcdefghijklmnopqrstuvwxyz123456", "severity": "high"},
+    )
+    event_b = PostureEvent(
+        event_type="finding.created",
+        tenant_id="tenant-a",
+        source="test",
+        subject_id="finding-1",
+        payload={"api_token": "ghp_abcdefghijklmnopqrstuvwxyz123456", "severity": "high"},
+    )
+
+    assert event_a.event_id == event_b.event_id
+    assert event_a.payload["api_token"] == "***REDACTED***"
+    assert "abcdefghijklmnopqrstuvwxyz" not in json.dumps(event_a.to_dict())
+    assert event_a.idempotency_key == f"tenant-a:{event_a.event_id}"
+
+
+def test_webhook_outbox_enforces_tenant_scope_and_deduplicates(tmp_path):
+    outbox = WebhookOutbox(tmp_path / "outbox.db")
+    event = PostureEvent(event_type="exposure_path.changed", tenant_id="tenant-a", source="graph", payload={"path_id": "p1"})
+    destination = WebhookDestination(
+        destination_id="siem",
+        tenant_id="tenant-a",
+        url="https://siem.example.test/webhook",
+        signing_secret="secret",
+    )
+
+    first_id = outbox.enqueue(event, destination)
+    second_id = outbox.enqueue(event, destination)
+
+    assert first_id == second_id
+    assert len(outbox.due(tenant_id="tenant-a", now=event.created_at + 1)) == 1
+    assert outbox.due(tenant_id="tenant-b", now=event.created_at + 1) == []
+
+    wrong_tenant = WebhookDestination(
+        destination_id="siem",
+        tenant_id="tenant-b",
+        url="https://siem.example.test/webhook",
+        signing_secret="secret",
+    )
+    with pytest.raises(ValueError, match="tenant_id"):
+        outbox.enqueue(event, wrong_tenant)
+
+
+def test_webhook_destination_rejects_unsafe_urls():
+    with pytest.raises(ValueError, match="https"):
+        WebhookDestination(destination_id="bad", tenant_id="tenant-a", url="http://example.test/hook", signing_secret="secret")
+    with pytest.raises(ValueError, match="credentials"):
+        WebhookDestination(destination_id="bad", tenant_id="tenant-a", url="https://user:pass@example.test/hook", signing_secret="secret")
+    with pytest.raises(ValueError, match="private networks"):
+        WebhookDestination(destination_id="bad", tenant_id="tenant-a", url="https://localhost/hook", signing_secret="secret")
+    with pytest.raises(ValueError, match="private networks"):
+        WebhookDestination(destination_id="bad", tenant_id="tenant-a", url="https://10.0.0.5/hook", signing_secret="secret")
+
+    destination = WebhookDestination(
+        destination_id="internal-siem",
+        tenant_id="tenant-a",
+        url="https://10.0.0.5/hook",
+        signing_secret="secret",
+        allow_private_networks=True,
+    )
+    assert destination.url == "https://10.0.0.5/hook"
+
+
+def test_signed_headers_are_verifiable():
+    event = PostureEvent(event_type="skill.verdict", tenant_id="tenant-a", source="skills", payload={"verdict": "review"})
+    destination = WebhookDestination(
+        destination_id="soc",
+        tenant_id="tenant-a",
+        url="https://soc.example.test/webhook",
+        signing_secret="top-secret",
+    )
+
+    headers = signed_webhook_headers(event, destination, attempt=3)
+
+    assert headers["x-agent-bom-event-id"] == event.event_id
+    assert headers["x-agent-bom-tenant-id"] == "tenant-a"
+    assert headers["x-agent-bom-delivery-attempt"] == "3"
+    expected = hmac.new(
+        b"top-secret",
+        json.dumps(event.to_dict(), sort_keys=True, separators=(",", ":"), default=str).encode("utf-8"),
+        "sha256",
+    ).hexdigest()
+    assert headers["x-agent-bom-signature"] == f"sha256={expected}"
+
+
+@pytest.mark.asyncio
+async def test_deliver_due_webhooks_marks_success(tmp_path):
+    outbox = WebhookOutbox(tmp_path / "outbox.db")
+    event = PostureEvent(event_type="deploy.decision", tenant_id="tenant-a", source="mcp", payload={"decision": "warn"})
+    destination = WebhookDestination(
+        destination_id="agent-queue",
+        tenant_id="tenant-a",
+        url="https://queue.example.test/webhook",
+        signing_secret="secret",
+    )
+    outbox.enqueue(event, destination)
+    sent = []
+
+    async def sender(url, headers, payload):
+        sent.append((url, headers, payload))
+        return 202
+
+    result = await deliver_due_webhooks(outbox, destination=destination, sender=sender, now=event.created_at + 1)
+
+    assert result == {"delivered": 1, "failed": 0, "dead_lettered": 0}
+    assert sent[0][0] == destination.url
+    assert outbox.due(tenant_id="tenant-a", now=event.created_at + 2) == []
+
+
+@pytest.mark.asyncio
+async def test_deliver_due_webhooks_tracks_retry_and_dead_letter(tmp_path):
+    outbox = WebhookOutbox(tmp_path / "outbox.db")
+    event = PostureEvent(event_type="audit.delta", tenant_id="tenant-a", source="audit", payload={"status": "tampered"})
+    destination = WebhookDestination(
+        destination_id="soc",
+        tenant_id="tenant-a",
+        url="https://soc.example.test/webhook",
+        signing_secret="secret",
+    )
+    outbox.enqueue(event, destination)
+
+    async def sender(_url, _headers, _payload):
+        return 500
+
+    first = await deliver_due_webhooks(
+        outbox,
+        destination=destination,
+        sender=sender,
+        now=event.created_at + 1,
+        max_attempts=2,
+    )
+    assert first == {"delivered": 0, "failed": 1, "dead_lettered": 0}
+    retry = outbox.due(tenant_id="tenant-a", now=event.created_at + 1.5)
+    assert retry == []
+    retry = outbox.due(tenant_id="tenant-a", now=event.created_at + 2)
+    assert retry[0].attempts == 1
+    assert "HTTP 500" in retry[0].last_error
+
+    second = await deliver_due_webhooks(
+        outbox,
+        destination=destination,
+        sender=sender,
+        now=event.created_at + 2,
+        max_attempts=2,
+    )
+    assert second == {"delivered": 0, "failed": 1, "dead_lettered": 1}
+    assert outbox.due(tenant_id="tenant-a", now=event.created_at + 100) == []


### PR DESCRIPTION
Summary
- add a tenant-scoped posture event envelope and SQLite webhook outbox core
- add signed webhook headers, idempotency keys, retry metadata, dead-letter state, redacted payloads, and private-network destination opt-in
- update repo and site docs to mark the webhook outbox core as shipped while keeping Kafka, EventBridge, Pub/Sub, Event Hub, Kinesis, and Firehose as roadmap adapters

Verification
- `uv run pytest tests/test_posture_streaming.py -q`
- `uv run ruff check src/agent_bom/posture_streaming.py tests/test_posture_streaming.py`
- `uv run mypy src/agent_bom/posture_streaming.py`
- `uv run mkdocs build --strict`
- `git diff --check`

Refs #2597
