### PR TITLE
feat(api): add normalized bulk findings ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ dashboard-only workflow:
 | Surface | Primary consumer | Shipped boundary |
 |---|---|---|
 | **CLI / CI** | developers, release gates, automation | local scans, SARIF/SBOM/HTML/JSON output, deterministic exit codes |
-| **REST API** | security platforms, SIEM jobs, custom services | authenticated control plane routes for scans, findings, graph evidence, audit, and governance |
+| **REST API** | security platforms, SIEM jobs, custom services | authenticated control plane routes for scans, normalized bulk findings, graph evidence, audit, and governance |
 | **MCP tools** | Claude, Cursor, Codex, Windsurf, Cortex, and custom agents | 38 read-only tools, strict arguments, `exposure_paths`, `should_i_deploy` |
 | **TypeScript client** | services and agent runtimes calling the control plane | typed helper for stable REST endpoints; not a scanner SDK |
 | **TypeScript runtime detectors** | MCP/runtime enforcement integrations | local detector package for runtime policy checks; separate from the control-plane client |

--- a/docs/POSTURE_EVENT_STREAMING.md
+++ b/docs/POSTURE_EVENT_STREAMING.md
@@ -5,7 +5,8 @@ This document is the repo-facing contract for issue #2597.
 Current shipped posture delivery is pull-first:
 
 - scan report files: SARIF, SBOM, HTML, JSON, graph exports
-- REST API routes for findings, graph, audit, posture, and runtime state
+- REST API routes for findings, normalized bulk finding ingest, graph, audit,
+  posture, and runtime state
 - MCP tools for agent pull workflows, including `exposure_paths` and
   `should_i_deploy`
 - selected SIEM/export guidance and OCSF projections

--- a/sdks/typescript-client/README.md
+++ b/sdks/typescript-client/README.md
@@ -28,8 +28,12 @@ const decision = await client.shouldIDeploy({
   candidate: "flask@2.0.0",
   blockRisk: 80,
 });
+const ingest = await client.ingestFindings({
+  source: "agent-runtime",
+  findings: [{ id: "finding-1", severity: "high" }],
+});
 
-console.log(health.status, paths.paths.length, decision.decision);
+console.log(health.status, paths.paths.length, decision.decision, ingest.ingested);
 ```
 
 ## Boundary

--- a/sdks/typescript-client/src/index.ts
+++ b/sdks/typescript-client/src/index.ts
@@ -58,6 +58,25 @@ export interface DeployDecision {
   [key: string]: JsonValue | undefined;
 }
 
+export interface BulkFindingIngestRequest {
+  findings: Record<string, JsonValue>[];
+  source?: string;
+  schemaVersion?: string;
+  metadata?: Record<string, JsonValue>;
+  tenantId?: string;
+}
+
+export interface BulkFindingIngestResponse {
+  schema_version: string;
+  batch_id: string;
+  ingested: number;
+  tenant_total: number;
+  tenant_id: string;
+  source: string;
+  warnings?: string[];
+  [key: string]: JsonValue | undefined;
+}
+
 export class AgentBomApiError extends Error {
   readonly status: number;
   readonly body: string;
@@ -127,6 +146,18 @@ export class AgentBomClient {
       tenant_id: request.tenantId ?? this.tenantId,
       block_risk: request.blockRisk,
       context: request.context,
+    });
+  }
+
+  ingestFindings(
+    request: BulkFindingIngestRequest,
+  ): Promise<BulkFindingIngestResponse> {
+    return this.request<BulkFindingIngestResponse>("POST", "/v1/findings/bulk", {
+      findings: request.findings,
+      source: request.source,
+      schema_version: request.schemaVersion,
+      metadata: request.metadata,
+      tenant_id: request.tenantId ?? this.tenantId,
     });
   }
 

--- a/sdks/typescript-client/tests/client.test.js
+++ b/sdks/typescript-client/tests/client.test.js
@@ -70,6 +70,40 @@ test("posts deploy decision payload without undefined fields", async () => {
   });
 });
 
+test("posts normalized bulk findings", async () => {
+  let seenUrl = "";
+  let payload;
+  const client = new AgentBomClient({
+    baseUrl: "https://agent-bom.example.com",
+    tenantId: "tenant-d",
+    fetch: async (url, init) => {
+      seenUrl = String(url);
+      payload = JSON.parse(init.body);
+      return jsonResponse({
+        schema_version: "v1",
+        batch_id: "batch-1",
+        ingested: 1,
+        tenant_total: 1,
+        tenant_id: "tenant-d",
+        source: "agent-runtime",
+      });
+    },
+  });
+
+  const response = await client.ingestFindings({
+    source: "agent-runtime",
+    findings: [{ id: "finding-1", severity: "high" }],
+  });
+
+  assert.equal(seenUrl, "https://agent-bom.example.com/v1/findings/bulk");
+  assert.equal(response.ingested, 1);
+  assert.deepEqual(payload, {
+    findings: [{ id: "finding-1", severity: "high" }],
+    source: "agent-runtime",
+    tenant_id: "tenant-d",
+  });
+});
+
 test("throws typed errors for non-2xx responses", async () => {
   const client = new AgentBomClient({
     baseUrl: "https://agent-bom.example.com",

--- a/site-docs/deployment/posture-event-streaming.md
+++ b/site-docs/deployment/posture-event-streaming.md
@@ -52,7 +52,7 @@ for SIEM/security-lake interoperability, not a replacement for the graph model.
 
 | Mode | Status | First proof | Notes |
 |---|---|---|---|
-| Pull by API | shipped | `GET /v1/findings`, `/v1/graph*`, `/v1/audit*` | works for dashboards, SIEM jobs, and custom collectors |
+| Pull by API | shipped | `GET /v1/findings`, `POST /v1/findings/bulk`, `/v1/graph*`, `/v1/audit*` | works for dashboards, SIEM jobs, agent runtimes, and custom collectors |
 | Pull by MCP | shipped | `exposure_paths`, `should_i_deploy` | best for AI agents and coding assistants |
 | Webhook outbox | roadmap | signed HTTPS POST to customer URL | should be the first push connector |
 | Kafka | roadmap | topic-per-tenant or topic with tenant key | first enterprise stream sink for posture events |

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -54,7 +54,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 | Surface | Who uses it | What is shipped |
 |---|---|---|
 | **CLI / CI** | developers and pipelines | local scans, SARIF/SBOM/HTML/JSON, graph exports, deterministic gates |
-| **REST API** | security platforms, SIEM jobs, custom services | self-hosted control-plane routes for scans, findings, graph evidence, audit, and governance |
+| **REST API** | security platforms, SIEM jobs, custom services | self-hosted control-plane routes for scans, normalized bulk findings, graph evidence, audit, and governance |
 | **MCP tools** | AI agents and coding assistants | 38 read-only tools, strict args, `exposure_paths`, `should_i_deploy` |
 | **TypeScript client** | services and agent runtimes calling the control plane | typed helper for stable REST endpoints; not a scanner SDK |
 | **TypeScript runtime detectors** | MCP/runtime enforcement integrations | local detector package for runtime policy checks; separate from the control-plane client |

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -46,6 +46,9 @@ def _redact_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
             clean["id"] = str(payload["id"])
         if "source" not in clean and "source" in payload:
             clean["source"] = str(payload["source"])
+        for key in ("origin", "batch_id", "bulk_ordinal"):
+            if key not in clean and key in payload:
+                clean[key] = payload[key]
         redacted.append(clean)
     return redacted
 

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -800,6 +800,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         ("DELETE", "/v1/scan/", "admin"),
         ("POST", "/v1/exceptions", "analyst"),
         ("POST", "/v1/findings/jira", "analyst"),
+        ("POST", "/v1/findings/bulk", "analyst"),
         ("POST", "/v1/findings/false-positive", "analyst"),
         ("POST", "/v1/findings/feedback", "analyst"),
         ("DELETE", "/v1/findings/false-positive/", "analyst"),

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -35,6 +35,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import PlainTextResponse
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from werkzeug.security import safe_join
 
 from agent_bom.api.models import (
@@ -64,6 +65,8 @@ from agent_bom.evidence import EvidenceTier, redact_for_persistence
 router = APIRouter()
 _logger = logging.getLogger(__name__)
 _LOCAL_SCAN_DISABLE_VALUES = {"0", "false", "no", "off", "disabled"}
+_BULK_FINDINGS_MAX_ITEMS = 1000
+_BULK_FINDINGS_SOURCE_MAX_LENGTH = 128
 
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -223,6 +226,66 @@ def _visible_to_tenant(job: ScanJob, tenant_id: str) -> bool:
 
 def _completed_jobs_for_tenant(tenant_id: str) -> list[ScanJob]:
     return [job for job in _get_store().list_all(tenant_id=tenant_id) if job.status == JobStatus.DONE and job.result]
+
+
+class BulkFindingsRequest(BaseModel):
+    """Normalized finding ingest for headless clients and agent runtimes."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    findings: list[dict[str, Any]] = Field(min_length=1, max_length=_BULK_FINDINGS_MAX_ITEMS)
+    source: str = Field(default="api", min_length=1, max_length=_BULK_FINDINGS_SOURCE_MAX_LENGTH)
+    schema_version: str = Field(default="v1", min_length=1, max_length=32)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    tenant_id: str | None = Field(default=None, description="Deprecated compatibility field; request tenant scope is authoritative.")
+
+    @field_validator("findings")
+    @classmethod
+    def _findings_must_be_objects(cls, value: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        for item in value:
+            if not item:
+                raise ValueError("findings must contain non-empty objects")
+        return value
+
+    @field_validator("source")
+    @classmethod
+    def _source_must_be_stable_label(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("source is required")
+        return normalized
+
+
+def _bulk_ingested_findings_for_tenant(tenant_id: str) -> list[dict[str, Any]]:
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+
+    return [item for item in get_compliance_hub_store().list(tenant_id) if isinstance(item, dict) and item.get("origin") == "bulk_ingest"]
+
+
+def _normalized_bulk_finding(row: dict[str, Any], *, source: str, batch_id: str, ordinal: int) -> dict[str, Any]:
+    payload = dict(row)
+    payload.setdefault("id", f"{batch_id}:{ordinal}")
+    payload.setdefault("source", source)
+    payload.setdefault("severity", "unknown")
+    payload["origin"] = "bulk_ingest"
+    payload["batch_id"] = batch_id
+    payload["bulk_ordinal"] = ordinal
+    return payload
+
+
+def _redact_finding_page(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    redacted = redact_for_persistence(rows, EvidenceTier.SAFE_TO_STORE)
+    if not isinstance(redacted, list):
+        return []
+    page: list[dict[str, Any]] = []
+    for clean, raw in zip(redacted, rows):
+        if not isinstance(clean, dict):
+            continue
+        for key in ("origin", "batch_id", "bulk_ordinal"):
+            if key not in clean and key in raw:
+                clean[key] = raw[key]
+        page.append(clean)
+    return page
 
 
 def _scan_source_labels(job: ScanJob) -> list[str]:
@@ -942,6 +1005,7 @@ async def list_findings(
     findings: list[dict[str, Any]] = []
     for job in _completed_jobs_for_tenant(tenant_id):
         findings.extend(_iter_scan_findings(job))
+    findings.extend(_bulk_ingested_findings_for_tenant(tenant_id))
 
     if severity:
         normalized = severity.lower()
@@ -953,7 +1017,7 @@ async def list_findings(
     findings.sort(key=lambda row: _finding_sort_key(row, sort_key))
 
     total = len(findings)
-    page = redact_for_persistence(findings[offset : offset + limit], EvidenceTier.SAFE_TO_STORE)
+    page = _redact_finding_page(findings[offset : offset + limit])
     return {
         # P1-16 v0.86.5 audit: emit schema_version so consumers can pin a
         # contract independent of API path.
@@ -965,6 +1029,37 @@ async def list_findings(
         "offset": offset,
         "sort": sort_key,
         "warnings": [],
+    }
+
+
+@router.post("/v1/findings/bulk", tags=["scan"], status_code=201)
+async def ingest_bulk_findings(request: Request, body: BulkFindingsRequest) -> dict:
+    """Append normalized findings for the request tenant.
+
+    This is the agent-native counterpart to `/v1/compliance/ingest`: callers
+    that already have normalized finding objects can post them directly instead
+    of wrapping them as SARIF/CycloneDX/CSV content. Request authentication owns
+    the tenant scope; `tenant_id` in the JSON body is accepted only for legacy
+    clients and is never trusted for routing.
+    """
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+
+    tenant_id = _tenant_id(request)
+    ignored_body_tenant = bool(body.tenant_id and body.tenant_id != tenant_id)
+    batch_id = str(uuid.uuid4())
+    payloads = [
+        _normalized_bulk_finding(row, source=body.source, batch_id=batch_id, ordinal=idx) for idx, row in enumerate(body.findings, start=1)
+    ]
+    new_total = get_compliance_hub_store().add(tenant_id, payloads)
+    warnings = ["tenant_id in body ignored; request tenant scope is authoritative"] if ignored_body_tenant else []
+    return {
+        "schema_version": "v1",
+        "batch_id": batch_id,
+        "ingested": len(payloads),
+        "tenant_total": new_total,
+        "tenant_id": tenant_id,
+        "source": body.source,
+        "warnings": warnings,
     }
 
 

--- a/tests/test_findings_bulk_api.py
+++ b/tests/test_findings_bulk_api.py
@@ -1,0 +1,110 @@
+"""Tests for normalized bulk finding ingest."""
+
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.compliance_hub_store import reset_compliance_hub_store
+from agent_bom.api.server import app
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+
+
+def setup_function() -> None:
+    reset_compliance_hub_store()
+
+
+def teardown_function() -> None:
+    reset_compliance_hub_store()
+
+
+def _client(tenant: str = "tenant-alpha", role: str = "analyst") -> TestClient:
+    client = TestClient(app)
+    client.headers.update(proxy_headers(role=role, tenant=tenant))
+    return client
+
+
+def test_bulk_findings_ingest_returns_agent_native_envelope() -> None:
+    client = _client()
+
+    resp = client.post(
+        "/v1/findings/bulk",
+        json={
+            "source": "agent-runtime",
+            "schema_version": "v1",
+            "tenant_id": "tenant-beta",
+            "findings": [
+                {
+                    "id": "agent-runtime:finding-1",
+                    "title": "Tool can reach production secret",
+                    "severity": "high",
+                    "applicable_frameworks": ["soc2", "iso-27001"],
+                    "evidence": {"summary": "safe tier-A evidence"},
+                }
+            ],
+        },
+    )
+
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["schema_version"] == "v1"
+    assert body["ingested"] == 1
+    assert body["tenant_total"] == 1
+    assert body["tenant_id"] == "tenant-alpha"
+    assert body["source"] == "agent-runtime"
+    assert body["warnings"] == ["tenant_id in body ignored; request tenant scope is authoritative"]
+    assert body["batch_id"]
+
+
+def test_bulk_findings_are_listed_and_tenant_scoped() -> None:
+    tenant_a = _client(tenant="tenant-alpha")
+    tenant_b = _client(tenant="tenant-beta")
+
+    created = tenant_a.post(
+        "/v1/findings/bulk",
+        json={
+            "source": "external-agent",
+            "findings": [
+                {
+                    "id": "finding-alpha",
+                    "title": "Reachable risky MCP tool",
+                    "severity": "critical",
+                    "cvss_score": 9.8,
+                }
+            ],
+        },
+    )
+    assert created.status_code == 201, created.text
+
+    listed_a = tenant_a.get("/v1/findings").json()
+    listed_b = tenant_b.get("/v1/findings").json()
+
+    assert listed_a["total"] == 1
+    finding = listed_a["findings"][0]
+    assert finding["id"] == "finding-alpha"
+    assert finding["origin"] == "bulk_ingest"
+    assert finding["source"] == "external-agent"
+    assert finding["batch_id"] == created.json()["batch_id"]
+    assert listed_b["total"] == 0
+
+
+def test_bulk_findings_rejects_empty_batches() -> None:
+    resp = _client().post("/v1/findings/bulk", json={"findings": []})
+
+    assert resp.status_code == 422
+
+
+def test_bulk_findings_requires_analyst_role() -> None:
+    resp = _client(role="viewer").post(
+        "/v1/findings/bulk",
+        json={"findings": [{"id": "viewer-finding", "severity": "low"}]},
+    )
+
+    assert resp.status_code == 403


### PR DESCRIPTION
Summary
- add `POST /v1/findings/bulk` for headless clients that already have normalized finding objects
- store bulk findings through the existing tenant-scoped compliance hub store with tier-A redaction and request-scoped tenant authority
- include bulk-ingested findings in `GET /v1/findings` for the same tenant
- expose `ingestFindings()` in the TypeScript control-plane client and keep route-parity coverage
- document the REST API surface as normalized bulk finding capable without claiming streaming connectors are shipped

Verification
- `uv run pytest tests/test_findings_bulk_api.py tests/test_compliance_hub_api.py tests/test_api_data_p1_batch_v0867.py tests/test_typescript_client_route_parity.py -q`
- `uv run ruff check src/agent_bom/api/routes/scan.py src/agent_bom/api/middleware.py src/agent_bom/api/compliance_hub_store.py tests/test_findings_bulk_api.py tests/test_typescript_client_route_parity.py`
- `uv run mypy src/agent_bom/api/routes/scan.py src/agent_bom/api/compliance_hub_store.py`
- `cd sdks/typescript-client && npm test`
- `uv run mkdocs build --strict`
- `git diff --check`

Closes #2608
