### PR TITLE
feat(api): add dataset version registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ dashboard-only workflow:
 | Surface | Primary consumer | Shipped boundary |
 |---|---|---|
 | **CLI / CI** | developers, release gates, automation | local scans, SARIF/SBOM/HTML/JSON output, deterministic exit codes |
-| **REST API** | security platforms, SIEM jobs, custom services | authenticated control plane routes for scans, normalized bulk findings, graph evidence, audit, and governance |
+| **REST API** | security platforms, SIEM jobs, custom services | authenticated control plane routes for scans, normalized bulk findings, dataset versions, graph evidence, audit, and governance |
 | **MCP tools** | Claude, Cursor, Codex, Windsurf, Cortex, and custom agents | 38 read-only tools, strict arguments, `exposure_paths`, `should_i_deploy` |
 | **TypeScript client** | services and agent runtimes calling the control plane | typed helper for stable REST endpoints; not a scanner SDK |
 | **TypeScript runtime detectors** | MCP/runtime enforcement integrations | local detector package for runtime policy checks; separate from the control-plane client |

--- a/sdks/typescript-client/README.md
+++ b/sdks/typescript-client/README.md
@@ -32,8 +32,13 @@ const ingest = await client.ingestFindings({
   source: "agent-runtime",
   findings: [{ id: "finding-1", severity: "high" }],
 });
+const dataset = await client.registerDatasetVersion({
+  datasetId: "hf-corpus",
+  versionId: "2026-05-17",
+  source: "ci",
+});
 
-console.log(health.status, paths.paths.length, decision.decision, ingest.ingested);
+console.log(health.status, paths.paths.length, decision.decision, ingest.ingested, dataset.dataset.version_id);
 ```
 
 ## Boundary

--- a/sdks/typescript-client/src/index.ts
+++ b/sdks/typescript-client/src/index.ts
@@ -66,6 +66,17 @@ export interface BulkFindingIngestRequest {
   tenantId?: string;
 }
 
+export interface DatasetVersionCreateRequest {
+  datasetId: string;
+  versionId?: string;
+  artifactUri?: string;
+  digest?: string;
+  digestAlgorithm?: string;
+  source?: string;
+  metadata?: Record<string, JsonValue>;
+  tenantId?: string;
+}
+
 export interface BulkFindingIngestResponse {
   schema_version: string;
   batch_id: string;
@@ -75,6 +86,32 @@ export interface BulkFindingIngestResponse {
   source: string;
   warnings?: string[];
   [key: string]: JsonValue | undefined;
+}
+
+export interface DatasetVersionRecord {
+  tenant_id: string;
+  dataset_id: string;
+  version_id: string;
+  created_at: string;
+  source: string;
+  artifact_uri?: string | null;
+  digest?: string | null;
+  digest_algorithm?: string;
+  metadata?: Record<string, JsonValue>;
+}
+
+export interface DatasetVersionResponse {
+  schema_version: string;
+  dataset: DatasetVersionRecord;
+  warnings?: string[];
+}
+
+export interface DatasetVersionsResponse {
+  schema_version: string;
+  tenant_id: string;
+  dataset_id: string;
+  versions: DatasetVersionRecord[];
+  count: number;
 }
 
 export class AgentBomApiError extends Error {
@@ -159,6 +196,31 @@ export class AgentBomClient {
       metadata: request.metadata,
       tenant_id: request.tenantId ?? this.tenantId,
     });
+  }
+
+  registerDatasetVersion(
+    request: DatasetVersionCreateRequest,
+  ): Promise<DatasetVersionResponse> {
+    return this.request<DatasetVersionResponse>(
+      "POST",
+      `/v1/datasets/${encodeURIComponent(request.datasetId)}/versions`,
+      {
+        version_id: request.versionId,
+        artifact_uri: request.artifactUri,
+        digest: request.digest,
+        digest_algorithm: request.digestAlgorithm,
+        source: request.source,
+        metadata: request.metadata,
+        tenant_id: request.tenantId ?? this.tenantId,
+      },
+    );
+  }
+
+  datasetVersions(datasetId: string): Promise<DatasetVersionsResponse> {
+    return this.request<DatasetVersionsResponse>(
+      "GET",
+      `/v1/datasets/${encodeURIComponent(datasetId)}/versions`,
+    );
   }
 
   async request<T>(

--- a/sdks/typescript-client/tests/client.test.js
+++ b/sdks/typescript-client/tests/client.test.js
@@ -104,6 +104,65 @@ test("posts normalized bulk findings", async () => {
   });
 });
 
+test("registers dataset versions", async () => {
+  let seenUrl = "";
+  let payload;
+  const client = new AgentBomClient({
+    baseUrl: "https://agent-bom.example.com",
+    tenantId: "tenant-d",
+    fetch: async (url, init) => {
+      seenUrl = String(url);
+      payload = JSON.parse(init.body);
+      return jsonResponse({
+        schema_version: "v1",
+        dataset: {
+          tenant_id: "tenant-d",
+          dataset_id: "hf-corpus",
+          version_id: "v1",
+          created_at: "2026-05-17T00:00:00Z",
+          source: "ci",
+        },
+      });
+    },
+  });
+
+  const response = await client.registerDatasetVersion({
+    datasetId: "hf-corpus",
+    versionId: "v1",
+    source: "ci",
+  });
+
+  assert.equal(seenUrl, "https://agent-bom.example.com/v1/datasets/hf-corpus/versions");
+  assert.equal(response.dataset.version_id, "v1");
+  assert.deepEqual(payload, {
+    version_id: "v1",
+    source: "ci",
+    tenant_id: "tenant-d",
+  });
+});
+
+test("lists dataset versions", async () => {
+  let seenUrl = "";
+  const client = new AgentBomClient({
+    baseUrl: "https://agent-bom.example.com",
+    fetch: async (url) => {
+      seenUrl = String(url);
+      return jsonResponse({
+        schema_version: "v1",
+        tenant_id: "tenant-d",
+        dataset_id: "hf-corpus",
+        versions: [],
+        count: 0,
+      });
+    },
+  });
+
+  const response = await client.datasetVersions("hf-corpus");
+
+  assert.equal(seenUrl, "https://agent-bom.example.com/v1/datasets/hf-corpus/versions");
+  assert.equal(response.count, 0);
+});
+
 test("throws typed errors for non-2xx responses", async () => {
   const client = new AgentBomClient({
     baseUrl: "https://agent-bom.example.com",

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -54,7 +54,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 | Surface | Who uses it | What is shipped |
 |---|---|---|
 | **CLI / CI** | developers and pipelines | local scans, SARIF/SBOM/HTML/JSON, graph exports, deterministic gates |
-| **REST API** | security platforms, SIEM jobs, custom services | self-hosted control-plane routes for scans, normalized bulk findings, graph evidence, audit, and governance |
+| **REST API** | security platforms, SIEM jobs, custom services | self-hosted control-plane routes for scans, normalized bulk findings, dataset versions, graph evidence, audit, and governance |
 | **MCP tools** | AI agents and coding assistants | 38 read-only tools, strict args, `exposure_paths`, `should_i_deploy` |
 | **TypeScript client** | services and agent runtimes calling the control plane | typed helper for stable REST endpoints; not a scanner SDK |
 | **TypeScript runtime detectors** | MCP/runtime enforcement integrations | local detector package for runtime policy checks; separate from the control-plane client |

--- a/src/agent_bom/api/dataset_version_store.py
+++ b/src/agent_bom/api/dataset_version_store.py
@@ -1,0 +1,161 @@
+"""Tenant-scoped dataset version registry for headless API clients."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+from dataclasses import asdict, dataclass, field
+from typing import Any, Protocol
+
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
+
+@dataclass(frozen=True)
+class DatasetVersionRecord:
+    tenant_id: str
+    dataset_id: str
+    version_id: str
+    created_at: str
+    source: str
+    artifact_uri: str | None = None
+    digest: str | None = None
+    digest_algorithm: str = "sha256"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class DatasetVersionStore(Protocol):
+    def put(self, record: DatasetVersionRecord) -> None: ...
+    def get(self, tenant_id: str, dataset_id: str, version_id: str) -> DatasetVersionRecord | None: ...
+    def list(self, tenant_id: str, dataset_id: str) -> list[DatasetVersionRecord]: ...
+
+
+class InMemoryDatasetVersionStore:
+    def __init__(self) -> None:
+        self._records: dict[tuple[str, str, str], DatasetVersionRecord] = {}
+        self._lock = threading.Lock()
+
+    def put(self, record: DatasetVersionRecord) -> None:
+        with self._lock:
+            self._records[(record.tenant_id, record.dataset_id, record.version_id)] = record
+
+    def get(self, tenant_id: str, dataset_id: str, version_id: str) -> DatasetVersionRecord | None:
+        with self._lock:
+            return self._records.get((tenant_id, dataset_id, version_id))
+
+    def list(self, tenant_id: str, dataset_id: str) -> list[DatasetVersionRecord]:
+        with self._lock:
+            records = [record for record in self._records.values() if record.tenant_id == tenant_id and record.dataset_id == dataset_id]
+        return sorted(records, key=lambda record: record.created_at, reverse=True)
+
+
+class SQLiteDatasetVersionStore:
+    def __init__(self, db_path: str = "agent_bom.db") -> None:
+        self._db_path = db_path
+        self._local = threading.local()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        if not hasattr(self._local, "conn") or self._local.conn is None:
+            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            self._local.conn.execute("PRAGMA journal_mode=WAL")
+        conn: sqlite3.Connection = self._local.conn
+        return conn
+
+    def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "dataset_versions")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS dataset_versions (
+                tenant_id TEXT NOT NULL,
+                dataset_id TEXT NOT NULL,
+                version_id TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                data TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, dataset_id, version_id)
+            )
+            """
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_dataset_versions_tenant_dataset_created "
+            "ON dataset_versions(tenant_id, dataset_id, created_at DESC)"
+        )
+        self._conn.commit()
+
+    def put(self, record: DatasetVersionRecord) -> None:
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO dataset_versions
+                (tenant_id, dataset_id, version_id, created_at, data)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                record.tenant_id,
+                record.dataset_id,
+                record.version_id,
+                record.created_at,
+                json.dumps(record.to_dict(), sort_keys=True),
+            ),
+        )
+        self._conn.commit()
+
+    def get(self, tenant_id: str, dataset_id: str, version_id: str) -> DatasetVersionRecord | None:
+        row = self._conn.execute(
+            "SELECT data FROM dataset_versions WHERE tenant_id = ? AND dataset_id = ? AND version_id = ?",
+            (tenant_id, dataset_id, version_id),
+        ).fetchone()
+        return _record_from_json(row[0]) if row else None
+
+    def list(self, tenant_id: str, dataset_id: str) -> list[DatasetVersionRecord]:
+        rows = self._conn.execute(
+            """
+            SELECT data FROM dataset_versions
+            WHERE tenant_id = ? AND dataset_id = ?
+            ORDER BY created_at DESC
+            """,
+            (tenant_id, dataset_id),
+        ).fetchall()
+        return [_record_from_json(row[0]) for row in rows]
+
+
+def _record_from_json(raw: str) -> DatasetVersionRecord:
+    payload = json.loads(raw)
+    return DatasetVersionRecord(
+        tenant_id=str(payload["tenant_id"]),
+        dataset_id=str(payload["dataset_id"]),
+        version_id=str(payload["version_id"]),
+        created_at=str(payload["created_at"]),
+        source=str(payload["source"]),
+        artifact_uri=payload.get("artifact_uri"),
+        digest=payload.get("digest"),
+        digest_algorithm=str(payload.get("digest_algorithm") or "sha256"),
+        metadata=payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {},
+    )
+
+
+_DATASET_VERSION_STORE: DatasetVersionStore | None = None
+
+
+def get_dataset_version_store() -> DatasetVersionStore:
+    global _DATASET_VERSION_STORE
+    if _DATASET_VERSION_STORE is not None:
+        return _DATASET_VERSION_STORE
+    if os.environ.get("AGENT_BOM_DB"):
+        _DATASET_VERSION_STORE = SQLiteDatasetVersionStore(os.environ["AGENT_BOM_DB"])
+    else:
+        _DATASET_VERSION_STORE = InMemoryDatasetVersionStore()
+    return _DATASET_VERSION_STORE
+
+
+def set_dataset_version_store(store: DatasetVersionStore | None) -> None:
+    global _DATASET_VERSION_STORE
+    _DATASET_VERSION_STORE = store
+
+
+def reset_dataset_version_store() -> None:
+    set_dataset_version_store(None)

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -808,6 +808,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         ("POST", "/v1/scan", "analyst"),
         ("POST", "/v1/credentials", "analyst"),
         ("POST", "/v1/credentials/", "analyst"),
+        ("POST", "/v1/datasets/", "analyst"),
         ("POST", "/v1/gateway/evaluate", "analyst"),
         ("POST", "/v1/firewall/check", "analyst"),
         ("POST", "/v1/proxy/audit", "analyst"),

--- a/src/agent_bom/api/routes/datasets.py
+++ b/src/agent_bom/api/routes/datasets.py
@@ -1,0 +1,132 @@
+"""Dataset version registry API routes."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Annotated, Any
+
+from fastapi import APIRouter, HTTPException, Path, Request
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from agent_bom.api.audit_log import log_action
+from agent_bom.api.dataset_version_store import DatasetVersionRecord, get_dataset_version_store
+
+router = APIRouter()
+
+_STABLE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$")
+
+
+class DatasetVersionCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version_id: str | None = Field(default=None, min_length=1, max_length=128)
+    artifact_uri: str | None = Field(default=None, max_length=2048)
+    digest: str | None = Field(default=None, max_length=256)
+    digest_algorithm: str = Field(default="sha256", min_length=1, max_length=32)
+    source: str = Field(default="api", min_length=1, max_length=128)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    tenant_id: str | None = Field(default=None, description="Deprecated compatibility field; request tenant scope is authoritative.")
+
+    @field_validator("version_id")
+    @classmethod
+    def _version_id_must_be_stable(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        normalized = value.strip()
+        if not _STABLE_ID_RE.fullmatch(normalized):
+            raise ValueError("version_id must be a stable identifier")
+        return normalized
+
+    @field_validator("digest_algorithm", "source")
+    @classmethod
+    def _non_empty_label(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("value must not be empty")
+        return normalized
+
+
+def _tenant_id(request: Request) -> str:
+    return getattr(request.state, "tenant_id", "default")
+
+
+def _actor(request: Request) -> str:
+    return getattr(request.state, "api_key_name", "") or getattr(request.state, "auth_method", "") or "api"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _validate_dataset_id(dataset_id: str) -> str:
+    normalized = dataset_id.strip()
+    if not _STABLE_ID_RE.fullmatch(normalized):
+        raise HTTPException(status_code=422, detail="dataset_id must be a stable identifier")
+    return normalized
+
+
+@router.post("/v1/datasets/{dataset_id}/versions", tags=["datasets"], status_code=201)
+async def register_dataset_version(
+    request: Request,
+    dataset_id: Annotated[str, Path(min_length=1, max_length=128)],
+    body: DatasetVersionCreate,
+) -> dict[str, Any]:
+    """Register a dataset artifact version for headless agents and scanners."""
+    tenant_id = _tenant_id(request)
+    normalized_dataset_id = _validate_dataset_id(dataset_id)
+    version_id = body.version_id or str(uuid.uuid4())
+    ignored_body_tenant = bool(body.tenant_id and body.tenant_id != tenant_id)
+    record = DatasetVersionRecord(
+        tenant_id=tenant_id,
+        dataset_id=normalized_dataset_id,
+        version_id=version_id,
+        created_at=_now(),
+        source=body.source,
+        artifact_uri=body.artifact_uri,
+        digest=body.digest,
+        digest_algorithm=body.digest_algorithm,
+        metadata=body.metadata,
+    )
+    get_dataset_version_store().put(record)
+    log_action(
+        "datasets.version_registered",
+        actor=_actor(request),
+        resource=f"dataset/{normalized_dataset_id}/version/{version_id}",
+        tenant_id=tenant_id,
+    )
+    warnings = ["tenant_id in body ignored; request tenant scope is authoritative"] if ignored_body_tenant else []
+    return {"schema_version": "v1", "dataset": record.to_dict(), "warnings": warnings}
+
+
+@router.get("/v1/datasets/{dataset_id}/versions", tags=["datasets"])
+async def list_dataset_versions(
+    request: Request,
+    dataset_id: Annotated[str, Path(min_length=1, max_length=128)],
+) -> dict[str, Any]:
+    tenant_id = _tenant_id(request)
+    normalized_dataset_id = _validate_dataset_id(dataset_id)
+    versions = [record.to_dict() for record in get_dataset_version_store().list(tenant_id, normalized_dataset_id)]
+    return {
+        "schema_version": "v1",
+        "tenant_id": tenant_id,
+        "dataset_id": normalized_dataset_id,
+        "versions": versions,
+        "count": len(versions),
+    }
+
+
+@router.get("/v1/datasets/{dataset_id}/versions/{version_id}", tags=["datasets"])
+async def get_dataset_version(
+    request: Request,
+    dataset_id: Annotated[str, Path(min_length=1, max_length=128)],
+    version_id: Annotated[str, Path(min_length=1, max_length=128)],
+) -> dict[str, Any]:
+    tenant_id = _tenant_id(request)
+    normalized_dataset_id = _validate_dataset_id(dataset_id)
+    normalized_version_id = _validate_dataset_id(version_id)
+    record = get_dataset_version_store().get(tenant_id, normalized_dataset_id, normalized_version_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="Dataset version not found")
+    return {"schema_version": "v1", "dataset": record.to_dict()}

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -714,6 +714,7 @@ from agent_bom.api.routes.assets import router as _assets_router  # noqa: E402
 from agent_bom.api.routes.compliance import router as _compliance_router  # noqa: E402
 from agent_bom.api.routes.connectors import router as _connectors_router  # noqa: E402
 from agent_bom.api.routes.credentials import router as _credentials_router  # noqa: E402
+from agent_bom.api.routes.datasets import router as _datasets_router  # noqa: E402
 from agent_bom.api.routes.discovery import router as _discovery_router  # noqa: E402
 from agent_bom.api.routes.enterprise import router as _enterprise_router  # noqa: E402
 from agent_bom.api.routes.fleet import router as _fleet_router  # noqa: E402
@@ -733,6 +734,7 @@ app.include_router(_assets_router)
 app.include_router(_compliance_router)
 app.include_router(_connectors_router)
 app.include_router(_credentials_router)
+app.include_router(_datasets_router)
 app.include_router(_discovery_router)
 app.include_router(_enterprise_router)
 app.include_router(_fleet_router)

--- a/tests/test_dataset_versions_api.py
+++ b/tests/test_dataset_versions_api.py
@@ -1,0 +1,91 @@
+"""Tests for dataset version registry routes."""
+
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.dataset_version_store import reset_dataset_version_store
+from agent_bom.api.server import app
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+
+
+def setup_function() -> None:
+    reset_dataset_version_store()
+
+
+def teardown_function() -> None:
+    reset_dataset_version_store()
+
+
+def _client(tenant: str = "tenant-alpha", role: str = "analyst") -> TestClient:
+    client = TestClient(app)
+    client.headers.update(proxy_headers(role=role, tenant=tenant))
+    return client
+
+
+def test_register_dataset_version_uses_request_tenant() -> None:
+    response = _client().post(
+        "/v1/datasets/hf-corpus/versions",
+        json={
+            "version_id": "2026-05-17",
+            "artifact_uri": "s3://customer-bucket/datasets/hf-corpus",
+            "digest": "sha256:abc123",
+            "source": "training-agent",
+            "metadata": {"license": "apache-2.0"},
+            "tenant_id": "tenant-beta",
+        },
+    )
+
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["schema_version"] == "v1"
+    assert body["warnings"] == ["tenant_id in body ignored; request tenant scope is authoritative"]
+    dataset = body["dataset"]
+    assert dataset["tenant_id"] == "tenant-alpha"
+    assert dataset["dataset_id"] == "hf-corpus"
+    assert dataset["version_id"] == "2026-05-17"
+    assert dataset["source"] == "training-agent"
+    assert dataset["metadata"] == {"license": "apache-2.0"}
+
+
+def test_dataset_versions_are_listed_and_tenant_scoped() -> None:
+    tenant_a = _client(tenant="tenant-alpha")
+    tenant_b = _client(tenant="tenant-beta")
+    tenant_a.post("/v1/datasets/data-prod/versions", json={"version_id": "v1", "source": "ci"})
+    tenant_a.post("/v1/datasets/data-prod/versions", json={"version_id": "v2", "source": "ci"})
+
+    listed_a = tenant_a.get("/v1/datasets/data-prod/versions").json()
+    listed_b = tenant_b.get("/v1/datasets/data-prod/versions").json()
+
+    assert listed_a["count"] == 2
+    assert {item["version_id"] for item in listed_a["versions"]} == {"v1", "v2"}
+    assert listed_b["count"] == 0
+
+
+def test_get_dataset_version_returns_404_for_other_tenant() -> None:
+    tenant_a = _client(tenant="tenant-alpha")
+    tenant_b = _client(tenant="tenant-beta")
+    tenant_a.post("/v1/datasets/shared-data/versions", json={"version_id": "v1"})
+
+    assert tenant_a.get("/v1/datasets/shared-data/versions/v1").status_code == 200
+    assert tenant_b.get("/v1/datasets/shared-data/versions/v1").status_code == 404
+
+
+def test_dataset_version_rejects_unstable_ids() -> None:
+    response = _client().post("/v1/datasets/bad$id/versions", json={"version_id": "v1"})
+
+    assert response.status_code == 422
+
+
+def test_dataset_version_requires_analyst_role() -> None:
+    response = _client(role="viewer").post("/v1/datasets/data-prod/versions", json={"version_id": "v1"})
+
+    assert response.status_code == 403

--- a/tests/test_typescript_client_route_parity.py
+++ b/tests/test_typescript_client_route_parity.py
@@ -11,7 +11,7 @@ from agent_bom.api.server import app
 def test_typescript_control_plane_client_paths_exist_in_api() -> None:
     source = Path("sdks/typescript-client/src/index.ts").read_text(encoding="utf-8")
     client_paths = {
-        match for match in re.findall(r"[\"`](/(?:health|v1/[^\"`?$]+))", source) if not match.startswith("/v1/graph/") or "{" not in match
+        match for match in re.findall(r"[\"`](/(?:health|v1/[^\"`?$]+))", source) if "{" not in match and not match.endswith("/")
     }
     registered_paths = {getattr(route, "path", "") for route in app.routes}
 


### PR DESCRIPTION
Summary
- add tenant-scoped dataset version registration routes for headless agents and CI clients
- persist versions through in-memory or `AGENT_BOM_DB` SQLite backends with request tenant scope as authoritative
- expose dataset version registration/listing helpers in the TypeScript control-plane client
- document REST API coverage as dataset-version aware without claiming full experiment tracking

Verification
- `uv run pytest tests/test_dataset_versions_api.py tests/test_typescript_client_route_parity.py -q`
- `uv run ruff check src/agent_bom/api/dataset_version_store.py src/agent_bom/api/routes/datasets.py src/agent_bom/api/server.py src/agent_bom/api/middleware.py tests/test_dataset_versions_api.py tests/test_typescript_client_route_parity.py`
- `uv run mypy src/agent_bom/api/dataset_version_store.py src/agent_bom/api/routes/datasets.py`
- `cd sdks/typescript-client && npm test`
- `uv run mkdocs build --strict`
- `git diff --check`

Closes #2610
