### PR TITLE
feat(runtime): expose posture webhook outbox status

### DIFF
--- a/docs/POSTURE_EVENT_STREAMING.md
+++ b/docs/POSTURE_EVENT_STREAMING.md
@@ -14,6 +14,9 @@ push-delivery primitive:
 - `agent_bom.posture_streaming.WebhookOutbox`, a tenant-scoped SQLite outbox
   for signed webhook delivery with idempotency, retry metadata,
   private-network destination opt-in, and dead-letter state
+- REST outbox observability at `GET /v1/posture/webhooks/outbox`,
+  `GET /v1/posture/webhooks/outbox/stats`, and
+  `POST /v1/posture/webhooks/outbox/{row_id}/retry`
 
 The shipped webhook outbox core does not create hidden egress. Operators must
 provide an explicit `WebhookDestination` and delivery function. Managed
@@ -45,15 +48,17 @@ Posture push connectors should emit:
 1. Generic webhook outbox core with signed HTTPS POST headers, retry metadata,
    dead-letter state, and idempotent `event_id` delivery. Shipped in
    `agent_bom.posture_streaming`.
-2. OCSF envelope shared by all connector adapters.
-3. Kafka connector for enterprise posture-event sinks covering findings,
+2. Outbox observability API for tenant-scoped status, stats, dead-letter
+   inspection, and explicit admin retry. Shipped in the REST API.
+3. OCSF envelope shared by all connector adapters.
+4. Kafka connector for enterprise posture-event sinks covering findings,
    `ExposurePath` changes, skill verdicts, deploy decisions, and audit deltas.
-4. AWS EventBridge plus S3/SQS CloudTrail ingestion for cloud activity
+5. AWS EventBridge plus S3/SQS CloudTrail ingestion for cloud activity
    evidence.
-5. GCP Pub/Sub plus Azure Event Hub/Event Grid for multi-cloud parity.
-6. Kinesis/Firehose as a later AWS high-volume adapter for customers that
+6. GCP Pub/Sub plus Azure Event Hub/Event Grid for multi-cloud parity.
+7. Kinesis/Firehose as a later AWS high-volume adapter for customers that
    already centralize telemetry there.
-7. MCP posture subscription tool backed by the same replay contract.
+8. MCP posture subscription tool backed by the same replay contract.
 
 Do not document Kafka, EventBridge, Pub/Sub, Event Hub, Kinesis, Firehose, or
 MCP posture subscriptions as shipped until their adapters and tests land. The

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -137,6 +137,8 @@ AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON
 AGENT_BOM_OTEL_TRACES_ENDPOINT
 AGENT_BOM_OTEL_TRACES_HEADERS
 AGENT_BOM_POSTGRES_URL
+# API posture webhook outbox SQLite path override; deploy-time operator setting.
+AGENT_BOM_POSTURE_WEBHOOK_OUTBOX_DB
 # CLI profile selector; also exposed as the root --profile option.
 AGENT_BOM_PROFILE
 AGENT_BOM_PROTECTION_API_KEY

--- a/site-docs/deployment/posture-event-streaming.md
+++ b/site-docs/deployment/posture-event-streaming.md
@@ -56,6 +56,7 @@ for SIEM/security-lake interoperability, not a replacement for the graph model.
 | Pull by API | shipped | `GET /v1/findings`, `POST /v1/findings/bulk`, `/v1/graph*`, `/v1/audit*` | works for dashboards, SIEM jobs, agent runtimes, and custom collectors |
 | Pull by MCP | shipped | `exposure_paths`, `should_i_deploy` | best for AI agents and coding assistants |
 | Webhook outbox core | shipped | `agent_bom.posture_streaming.WebhookOutbox` | operator-provided sender performs explicit HTTPS POST; no hidden egress |
+| Webhook outbox observability | shipped | `GET /v1/posture/webhooks/outbox` | tenant-scoped status, stats, dead-letter inspection, admin retry |
 | Kafka | roadmap | topic-per-tenant or topic with tenant key | first enterprise stream sink for posture events |
 | AWS EventBridge + CloudTrail S3/SQS | roadmap | customer account event bus or S3/SQS trail feed | first AWS cloud activity evidence lane |
 | GCP Pub/Sub + Azure Event Hub/Event Grid | roadmap | customer-owned cloud event transports | multi-cloud parity after AWS |
@@ -90,16 +91,18 @@ credential-reference model, not raw destination secrets.
 1. **Webhook outbox core** — tenant-scoped table, signed delivery headers,
    retry policy metadata, dead-letter state, private-network destination
    opt-in, and tests. Shipped in `agent_bom.posture_streaming`.
-2. **OCSF event envelope** — shared serializer for findings, exposure paths,
+2. **Webhook outbox observability API** — tenant-scoped status and stats,
+   dead-letter inspection, and explicit admin retry.
+3. **OCSF event envelope** — shared serializer for findings, exposure paths,
    deploy decisions, skill verdicts, runtime policy decisions, and audit
    integrity events.
-3. **Kafka connector** — enterprise stream sink for findings, exposure paths,
+4. **Kafka connector** — enterprise stream sink for findings, exposure paths,
    skill verdicts, deploy decisions, and audit deltas.
-4. **Cloud activity ingestion** — AWS EventBridge plus CloudTrail S3/SQS first,
+5. **Cloud activity ingestion** — AWS EventBridge plus CloudTrail S3/SQS first,
    then GCP Pub/Sub and Azure Event Hub/Event Grid.
-5. **High-volume AWS adapter** — Kinesis/Firehose for customers that already
+6. **High-volume AWS adapter** — Kinesis/Firehose for customers that already
    centralize telemetry there.
-6. **Agent subscription** — MCP `subscribe_posture_changes` backed by the same
+7. **Agent subscription** — MCP `subscribe_posture_changes` backed by the same
    outbox/replay contract.
 
 Each slice should ship with a first command, an artifact, and a verification

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -762,6 +762,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
     _ROLE_RULES: tuple[tuple[str, str, str], ...] = (
         ("GET", "/v1/compliance", "viewer"),
         ("GET", "/v1/posture/backpressure", "viewer"),
+        ("GET", "/v1/posture/webhooks/", "analyst"),
         ("GET", "/v1/posture", "viewer"),
         ("GET", "/v1/auth/debug", "viewer"),
         ("GET", "/v1/auth/me", "viewer"),
@@ -786,6 +787,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         ("DELETE", "/v1/credentials/", "admin"),
         ("DELETE", "/v1/tenant/", "admin"),
         ("POST", "/v1/gateway/policies", "admin"),
+        ("POST", "/v1/posture/webhooks/", "admin"),
         ("PUT", "/v1/gateway/policies/", "admin"),
         ("DELETE", "/v1/gateway/policies/", "admin"),
         ("POST", "/v1/fleet/sync", "admin"),

--- a/src/agent_bom/api/routes/posture_streaming.py
+++ b/src/agent_bom/api/routes/posture_streaming.py
@@ -1,0 +1,97 @@
+"""Posture webhook outbox observability routes."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from agent_bom.api.audit_log import log_action
+from agent_bom.posture_streaming import WebhookOutbox
+
+router = APIRouter()
+
+_OUTBOX: WebhookOutbox | None = None
+_OUTBOX_OVERRIDE = False
+
+
+def _tenant_id(request: Request) -> str:
+    return getattr(request.state, "tenant_id", "default")
+
+
+def _actor(request: Request) -> str:
+    return getattr(request.state, "api_key_name", "") or getattr(request.state, "auth_method", "") or "api"
+
+
+def _outbox_path() -> Path:
+    configured = os.environ.get("AGENT_BOM_POSTURE_WEBHOOK_OUTBOX_DB", "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    shared_db = os.environ.get("AGENT_BOM_DB", "").strip()
+    if shared_db:
+        return Path(shared_db).expanduser()
+    return Path.home() / ".agent-bom" / "db" / "posture-webhooks.db"
+
+
+def get_posture_webhook_outbox() -> WebhookOutbox:
+    global _OUTBOX
+    path = _outbox_path()
+    if _OUTBOX_OVERRIDE and _OUTBOX is not None:
+        return _OUTBOX
+    if _OUTBOX is None or _OUTBOX.path != path:
+        _OUTBOX = WebhookOutbox(path)
+    return _OUTBOX
+
+
+def set_posture_webhook_outbox(outbox: WebhookOutbox | None) -> None:
+    global _OUTBOX, _OUTBOX_OVERRIDE
+    _OUTBOX = outbox
+    _OUTBOX_OVERRIDE = outbox is not None
+
+
+@router.get("/v1/posture/webhooks/outbox", tags=["posture"])
+async def list_posture_webhook_outbox(
+    request: Request,
+    status: str | None = Query(default=None, pattern="^(pending|delivered|dead_letter)$"),
+    limit: Annotated[int, Query(ge=1, le=500)] = 100,
+) -> dict:
+    """List webhook outbox rows for the current tenant.
+
+    This is an observability surface for the shipped outbox core. It does not
+    deliver events and does not configure webhook destinations.
+    """
+    tenant_id = _tenant_id(request)
+    outbox = get_posture_webhook_outbox()
+    rows = [record.to_dict() for record in outbox.records(tenant_id=tenant_id, status=status, limit=limit)]
+    return {
+        "schema_version": "v1",
+        "tenant_id": tenant_id,
+        "status": status,
+        "count": len(rows),
+        "records": rows,
+        "stats": outbox.stats(tenant_id=tenant_id),
+    }
+
+
+@router.get("/v1/posture/webhooks/outbox/stats", tags=["posture"])
+async def get_posture_webhook_outbox_stats(request: Request) -> dict:
+    """Return webhook outbox status counts for the current tenant."""
+    return {"schema_version": "v1", "stats": get_posture_webhook_outbox().stats(tenant_id=_tenant_id(request))}
+
+
+@router.post("/v1/posture/webhooks/outbox/{row_id}/retry", tags=["posture"], status_code=202)
+async def retry_posture_webhook_outbox_record(request: Request, row_id: int) -> dict:
+    """Requeue one dead-lettered webhook row for the current tenant."""
+    tenant_id = _tenant_id(request)
+    outbox = get_posture_webhook_outbox()
+    if not outbox.requeue_dead_letter(tenant_id=tenant_id, row_id=row_id):
+        raise HTTPException(status_code=404, detail="Dead-letter webhook row not found")
+    log_action(
+        "posture.webhook_outbox_requeued",
+        actor=_actor(request),
+        resource=f"posture-webhook-outbox/{row_id}",
+        tenant_id=tenant_id,
+    )
+    return {"schema_version": "v1", "row_id": row_id, "status": "pending"}

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -723,6 +723,7 @@ from agent_bom.api.routes.gateway import router as _gateway_router  # noqa: E402
 from agent_bom.api.routes.governance import router as _governance_router  # noqa: E402
 from agent_bom.api.routes.graph import router as _graph_router  # noqa: E402
 from agent_bom.api.routes.observability import router as _observability_router  # noqa: E402
+from agent_bom.api.routes.posture_streaming import router as _posture_streaming_router  # noqa: E402
 from agent_bom.api.routes.privacy import router as _privacy_router  # noqa: E402
 from agent_bom.api.routes.proxy import router as _proxy_router  # noqa: E402
 from agent_bom.api.routes.scan import router as _scan_router  # noqa: E402
@@ -743,6 +744,7 @@ app.include_router(_gateway_router)
 app.include_router(_governance_router)
 app.include_router(_graph_router)
 app.include_router(_observability_router)
+app.include_router(_posture_streaming_router)
 app.include_router(_privacy_router)
 app.include_router(_proxy_router)
 app.include_router(_scan_router)

--- a/src/agent_bom/posture_streaming.py
+++ b/src/agent_bom/posture_streaming.py
@@ -164,6 +164,38 @@ class QueuedDelivery:
     last_error: str = ""
 
 
+@dataclass(frozen=True)
+class OutboxRecord:
+    """Operator-visible outbox row without signing secret material."""
+
+    row_id: int
+    event_id: str
+    tenant_id: str
+    destination_id: str
+    url: str
+    status: str
+    attempts: int
+    next_attempt_at: float
+    created_at: float
+    delivered_at: float | None = None
+    last_error: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "row_id": self.row_id,
+            "event_id": self.event_id,
+            "tenant_id": self.tenant_id,
+            "destination_id": self.destination_id,
+            "url": self.url,
+            "status": self.status,
+            "attempts": self.attempts,
+            "next_attempt_at": self.next_attempt_at,
+            "created_at": self.created_at,
+            "delivered_at": self.delivered_at,
+            "last_error": self.last_error,
+        }
+
+
 class WebhookOutbox:
     """SQLite-backed webhook outbox with retry and idempotency metadata."""
 
@@ -291,6 +323,95 @@ class WebhookOutbox:
                 (status, attempts, retry_at, sanitize_error(error), row_id),
             )
 
+    def records(self, *, tenant_id: str, status: str | None = None, limit: int = 100) -> list[OutboxRecord]:
+        clean_tenant = _validate_tenant_id(tenant_id)
+        bounded_limit = max(1, min(int(limit), 500))
+        params: list[Any] = [clean_tenant]
+        if status:
+            params.append(status)
+            query = """
+                SELECT id, event_id, tenant_id, destination_id, url, status,
+                       attempts, next_attempt_at, created_at, delivered_at,
+                       last_error
+                FROM posture_webhook_outbox
+                WHERE tenant_id = ? AND status = ?
+                ORDER BY created_at DESC, id DESC
+                LIMIT ?
+                """
+        else:
+            query = """
+                SELECT id, event_id, tenant_id, destination_id, url, status,
+                       attempts, next_attempt_at, created_at, delivered_at,
+                       last_error
+                FROM posture_webhook_outbox
+                WHERE tenant_id = ?
+                ORDER BY created_at DESC, id DESC
+                LIMIT ?
+                """
+        params.append(bounded_limit)
+        with self._connect() as conn:
+            rows = conn.execute(query, tuple(params)).fetchall()
+        return [_outbox_record_from_row(row) for row in rows]
+
+    def stats(self, *, tenant_id: str) -> dict[str, Any]:
+        clean_tenant = _validate_tenant_id(tenant_id)
+        with self._connect() as conn:
+            counts = conn.execute(
+                """
+                SELECT status, COUNT(*) AS count
+                FROM posture_webhook_outbox
+                WHERE tenant_id = ?
+                GROUP BY status
+                """,
+                (clean_tenant,),
+            ).fetchall()
+            pending = conn.execute(
+                """
+                SELECT MIN(created_at) AS oldest_created_at, MIN(next_attempt_at) AS next_attempt_at
+                FROM posture_webhook_outbox
+                WHERE tenant_id = ? AND status = 'pending'
+                """,
+                (clean_tenant,),
+            ).fetchone()
+        by_status = {str(row["status"]): int(row["count"]) for row in counts}
+        return {
+            "tenant_id": clean_tenant,
+            "total": sum(by_status.values()),
+            "by_status": by_status,
+            "oldest_pending_created_at": pending["oldest_created_at"] if pending else None,
+            "next_pending_attempt_at": pending["next_attempt_at"] if pending else None,
+        }
+
+    def requeue_dead_letter(self, *, tenant_id: str, row_id: int, retry_at: float | None = None) -> bool:
+        clean_tenant = _validate_tenant_id(tenant_id)
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                UPDATE posture_webhook_outbox
+                SET status = 'pending', next_attempt_at = ?, last_error = ''
+                WHERE id = ? AND tenant_id = ? AND status = 'dead_letter'
+                """,
+                (_now() if retry_at is None else retry_at, row_id, clean_tenant),
+            )
+            return bool(cur.rowcount)
+
+
+def _outbox_record_from_row(row: sqlite3.Row) -> OutboxRecord:
+    delivered = row["delivered_at"]
+    return OutboxRecord(
+        row_id=int(row["id"]),
+        event_id=str(row["event_id"]),
+        tenant_id=str(row["tenant_id"]),
+        destination_id=str(row["destination_id"]),
+        url=str(row["url"]),
+        status=str(row["status"]),
+        attempts=int(row["attempts"]),
+        next_attempt_at=float(row["next_attempt_at"]),
+        created_at=float(row["created_at"]),
+        delivered_at=float(delivered) if delivered is not None else None,
+        last_error=str(row["last_error"] or ""),
+    )
+
 
 def signed_webhook_headers(event: PostureEvent, destination: WebhookDestination, *, attempt: int = 1) -> dict[str, str]:
     payload_json = _canonical_json(event.to_dict())
@@ -357,6 +478,7 @@ async def deliver_due_webhooks(
 
 __all__ = [
     "POSTURE_EVENT_SCHEMA_VERSION",
+    "OutboxRecord",
     "PostureEvent",
     "PostureStreamingError",
     "QueuedDelivery",

--- a/tests/test_posture_webhook_outbox_api.py
+++ b/tests/test_posture_webhook_outbox_api.py
@@ -1,0 +1,93 @@
+"""API tests for posture webhook outbox observability."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.routes.posture_streaming import set_posture_webhook_outbox
+from agent_bom.api.server import app
+from agent_bom.posture_streaming import PostureEvent, WebhookDestination, WebhookOutbox
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+
+
+def teardown_function() -> None:
+    set_posture_webhook_outbox(None)
+
+
+def _client(tenant: str = "tenant-alpha", role: str = "analyst") -> TestClient:
+    client = TestClient(app)
+    client.headers.update(proxy_headers(role=role, tenant=tenant))
+    return client
+
+
+def _seed_outbox(path: Path, tenant: str = "tenant-alpha") -> tuple[WebhookOutbox, int]:
+    outbox = WebhookOutbox(path)
+    event = PostureEvent(
+        event_type="finding.created",
+        tenant_id=tenant,
+        source="test",
+        subject_id="finding-1",
+        payload={"id": "finding-1", "severity": "high"},
+    )
+    destination = WebhookDestination(
+        destination_id="siem",
+        tenant_id=tenant,
+        url="https://siem.example.test/webhook",
+        signing_secret="secret",
+    )
+    row_id = outbox.enqueue(event, destination)
+    set_posture_webhook_outbox(outbox)
+    return outbox, row_id
+
+
+def test_outbox_stats_and_records_are_tenant_scoped(tmp_path: Path) -> None:
+    _seed_outbox(tmp_path / "outbox.db", tenant="tenant-alpha")
+
+    alpha = _client(tenant="tenant-alpha").get("/v1/posture/webhooks/outbox")
+    beta = _client(tenant="tenant-beta").get("/v1/posture/webhooks/outbox")
+
+    assert alpha.status_code == 200
+    body = alpha.json()
+    assert body["count"] == 1
+    assert body["stats"]["by_status"] == {"pending": 1}
+    assert body["records"][0]["destination_id"] == "siem"
+    assert body["records"][0]["tenant_id"] == "tenant-alpha"
+    assert beta.json()["count"] == 0
+
+
+def test_outbox_filter_and_stats_endpoint(tmp_path: Path) -> None:
+    outbox, row_id = _seed_outbox(tmp_path / "outbox.db")
+    outbox.mark_delivered(row_id, delivered_at=100.0)
+
+    pending = _client().get("/v1/posture/webhooks/outbox?status=pending")
+    delivered = _client().get("/v1/posture/webhooks/outbox?status=delivered")
+    stats = _client().get("/v1/posture/webhooks/outbox/stats")
+
+    assert pending.json()["count"] == 0
+    assert delivered.json()["count"] == 1
+    assert stats.json()["stats"]["by_status"] == {"delivered": 1}
+
+
+def test_retry_dead_letter_requires_admin_and_current_tenant(tmp_path: Path) -> None:
+    outbox, row_id = _seed_outbox(tmp_path / "outbox.db")
+    outbox.mark_failed(row_id, error="network token abc123", retry_at=10.0, max_attempts=1)
+
+    viewer = _client(role="analyst").post(f"/v1/posture/webhooks/outbox/{row_id}/retry")
+    other_tenant = _client(tenant="tenant-beta", role="admin").post(f"/v1/posture/webhooks/outbox/{row_id}/retry")
+    admin = _client(role="admin").post(f"/v1/posture/webhooks/outbox/{row_id}/retry")
+
+    assert viewer.status_code == 403
+    assert other_tenant.status_code == 404
+    assert admin.status_code == 202
+    assert admin.json()["status"] == "pending"
+    assert outbox.stats(tenant_id="tenant-alpha")["by_status"] == {"pending": 1}


### PR DESCRIPTION
Summary
- add tenant-scoped webhook outbox records, stats, and dead-letter requeue helpers to the posture streaming core
- expose REST observability routes for listing outbox rows, reading status counts, and explicitly retrying dead-letter rows
- gate read access to analyst+ and retry access to admin+ through the existing API role table
- document shipped outbox observability while keeping Kafka, EventBridge, Pub/Sub, Event Hub, Kinesis, Firehose, and MCP subscriptions as roadmap work

Verification
- `uv run pytest tests/test_posture_webhook_outbox_api.py tests/test_posture_streaming.py -q`
- `uv run ruff check src/agent_bom/posture_streaming.py src/agent_bom/api/routes/posture_streaming.py src/agent_bom/api/server.py src/agent_bom/api/middleware.py tests/test_posture_webhook_outbox_api.py tests/test_posture_streaming.py`
- `uv run mypy src/agent_bom/posture_streaming.py src/agent_bom/api/routes/posture_streaming.py`
- `uv run mkdocs build --strict`
- `git diff --check`

Closes #2612
Refs #2597
