### PR TITLE
release: prepare v0.87.0

### DIFF
--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom
-        run: uv tool install agent-bom==0.86.5  # pinned — bump on each release
+        run: uv tool install agent-bom==0.87.0  # pinned — bump on each release
 
       - name: Scan changed MCP configs
         id: scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,44 +9,65 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+---
+
+## [0.87.0] - 2026-05-17
+
 ### Added
-- **Graph investigation product lane** - the post-`v0.86.5` main branch now
-  carries the first Wiz-grade graph roadmap slice: bitemporal graph edges,
-  measured graph benchmark evidence, a hardened large-graph overview fallback,
-  API-native `ExposurePath`, toxic-combo projection into the graph, renderer
-  switch contracts for React Flow / large overview / WebGL, semantic clusters,
-  and the optional Neptune backend design. These are code and docs on `main`;
-  live Neptune SLOs and a full query DSL remain future work.
-- **Agentic integration positioning** - README and release review docs now tie
-  the MCP server, proxy, gateway, Shield SDK, skills, CI, control-plane API,
-  auth, and self-hosted data boundary into one adoption story for humans and
-  AI agents instead of listing them as separate surfaces.
+- **Graph investigation product lane** - shipped bitemporal graph edges,
+  measured benchmark evidence, hardened large-graph overview fallback,
+  API-native `ExposurePath`, toxic-combo graph projection, semantic clusters,
+  renderer-switch contracts, Sigma WebGL overview, light-mode graph token
+  fixes, and optional Neptune backend plumbing (#2541, #2542, #2543, #2544,
+  #2553, #2554, #2555, #2556, #2558, #2562, #2564, #2568).
+- **Identity-aware investigation flows** - added identity graph taxonomy,
+  AWS IAM enrichment, ExposurePath-first dashboard brief, ExposurePath output
+  parity across JSON/SARIF/Markdown/HTML, and agent-native REST/MCP graph
+  tools for exposure paths and deploy decisions (#2565, #2566, #2567, #2572,
+  #2573, #2574, #2577, #2604).
+- **Headless control-plane primitives** - added the TypeScript control-plane
+  client, public Python SDK entry points, versioned inventory ingestion,
+  normalized bulk findings ingest, dataset version registry, posture webhook
+  outbox and status API, posture streaming contract docs, and local
+  entitlement metadata hooks (#2601, #2602, #2603, #2606, #2607, #2609,
+  #2611, #2613, #2614).
+- **IaC and data-stack scanning** - added first-class dbt project security
+  scanning for project metadata, profiles, packages, SQL models/macros, seed
+  files, and dbt CI workflow guardrails (#2615).
+- **Skills scanner hardening** - decoupled content and provenance verdicts,
+  routed medium behavioral findings to review, added policy-aware CI gates,
+  improved scanner evidence accuracy, and emitted SARIF for skill findings
+  (#2569, #2570, #2575, #2590, #2591, #2592).
+- **Release proof and positioning** - refreshed product metrics, release proof
+  screenshots, graph release positioning, agent-first product boundaries,
+  product lane boundaries, and the docs/runtime posture-event contract without
+  claiming unshipped Kafka, Kinesis, Pub/Sub, Event Hub, or EventBridge
+  adapters (#2530, #2560, #2563, #2579, #2580, #2588, #2600, #2602, #2605).
+- **Dependency and release automation updates** - refreshed UI and SDK
+  development dependencies, Python Alpine base image, Docker base-image policy,
+  PyPI native attestations, and Windows endpoint runner pinning (#2520, #2534,
+  #2535, #2536, #2537, #2538, #2539, #2581, #2582, #2583, #2584, #2585).
 
 ### Fixed
-- **SQLite graph upgrade blocker** - the release-blocking read-path migration
-  regression is tracked as the v0.86.6 blocker: existing local graph DBs must
-  add time-versioned edge columns before any `/v1/graph*` endpoint claims
-  release readiness.
-- **`agent-bom audit` fails on base install** - `cryptography` is now a core
-  dependency (it was previously only in `[runtime]`/`[oidc]` extras), so the
-  proxy audit log viewer no longer crashes with `No module named
-  'cryptography'` after `pip install agent-bom`. The CLI also catches the
-  ImportError defensively and prints a clean `pip install 'agent-bom[runtime]'`
-  hint with exit code 2 instead of a traceback.
-- **`agent-bom sbom -o` (and `image -o` / `iac -o`) ignored when a CLI profile
-  is active** - sibling scan commands forward `--output` to `scan` via
-  `ctx.invoke(scan, output=...)`. Click reports the parameter source as
-  DEFAULT in that case, so `apply_scan_profile_defaults` was overriding the
-  caller's explicit path with the profile's `output =` value (e.g.
-  `agent-bom-report.json`). The profile default is now applied only when the
-  caller value is empty, preserving wrapper-command behavior while still
-  honoring profile defaults for bare `agent-bom agents` invocations.
-- **Auditor export parity** - CSV, Markdown, and SPDX outputs now preserve
-  severity provenance, EPSS percentile, KEV dates, CWE IDs, and framework
-  compliance tags instead of dropping enrichment metadata outside JSON/SARIF.
-- **`agent-bom check --agent-mode` emitted Rich console tables** - pre-install
-  package checks now honor global agent mode and return the stable JSON
-  envelope instead of mixing human tables into automation output.
+- **SQLite graph upgrade blocker** - fixed legacy local graph DB read-path
+  migrations so existing `graph.db` files add time-versioned edge columns
+  before `/v1/graph*` endpoints query them (#2561).
+- **Audit chain and runtime integrity** - reconciled runtime AES-CMAC audit
+  verification with the control-plane HMAC audit table and removed raw
+  exception leakage from audit-integrity errors (#2516, #2571).
+- **CLI and output contract gaps** - made `cryptography` a core dependency for
+  `agent-bom audit`, honored `-o/--output` from wrapper scan commands when CLI
+  profiles are active, preserved auditor enrichment metadata across non-JSON
+  exports, and kept `agent-bom check --agent-mode` machine-readable (#2524,
+  #2525, #2526, #2527, #2540).
+- **Scanner/runtime data quality** - threaded offline mode into enriched scans,
+  tightened CLI runtime audit gates, aligned canonical IDs across report and
+  graph surfaces, fixed API gateway data audit gaps, and cached agent discovery
+  responses for the API/UI path (#2517, #2518, #2519, #2521, #2522, #2523,
+  #2557).
+- **Postgres scale evidence workflow** - restored the scheduled Postgres scale
+  evidence workflow environment contract and kept test-only Postgres settings
+  from leaking into unrelated scheduler and Snowflake startup paths (#2616).
 
 ---
 
@@ -1273,7 +1294,8 @@ Two new product surfaces (inter-agent firewall + per-run discovery envelope) plu
 
 ---
 
-[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.86.5...HEAD
+[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.87.0...HEAD
+[0.87.0]: https://github.com/msaad00/agent-bom/compare/v0.86.5...v0.87.0
 [0.86.5]: https://github.com/msaad00/agent-bom/compare/v0.86.4...v0.86.5
 [0.86.4]: https://github.com/msaad00/agent-bom/compare/v0.86.3...v0.86.4
 [0.86.3]: https://github.com/msaad00/agent-bom/compare/v0.86.2...v0.86.3

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -204,7 +204,7 @@ Focused agent mesh graph:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `0.86.5` | Current stable version (pinned) |
+| `0.87.0` | Current stable version (pinned) |
 
 Published images:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.5-alpine3.23@sha256:7128d274340c3aa2e34596c7a62fff85de8f4d71d46731f9dbe3c0e2cfd9117c
 
-ARG VERSION=0.86.5
+ARG VERSION=0.87.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ later roll into the same self-hosted control plane.
 |---|---|---|
 | **CLI** | `agent-bom agents --demo --offline` | terminal findings + graph-ready inventory |
 | **Your repo** | `agent-bom agents -p . -f html -o agent-bom-report.html` | local HTML review, JSON/SARIF/SBOM/graph exports when requested |
-| **CI** | `uses: msaad00/agent-bom@v0.86.5` | SARIF, PR summary, optional code-scanning upload |
+| **CI** | `uses: msaad00/agent-bom@v0.87.0` | SARIF, PR summary, optional code-scanning upload |
 | **Assistant / MCP** | `agent-bom mcp server` | read-only security tools for Claude, Cursor, Codex, Windsurf, Cortex, and other MCP clients |
 | **Self-hosted control plane** | `docker compose -f docker-compose.pilot.yml up -d` | API + dashboard in your infrastructure |
 
@@ -531,8 +531,8 @@ agent-bom
 |------|----------|---------------|------------------|
 | CLI (`agent-bom agents`) | local audit + project scan | `agent-bom agents -p .` | console, JSON, SARIF, SBOM, HTML |
 | Endpoint fleet (`--push-url .../v1/fleet/sync`) | employee laptops pushing into self-hosted fleet | `agent-bom agents --preset enterprise --push-url https://agent-bom.example.com/v1/fleet/sync` | fleet inventory + trust factors |
-| GitHub Action (`uses: msaad00/agent-bom@v0.86.5`) | CI/CD + SARIF | `uses: msaad00/agent-bom@v0.86.5` | `agent-bom-results.sarif` |
-| Docker (`agentbom/agent-bom`) | isolated CLI/API jobs and non-browser self-hosted entrypoints | `docker run --rm agentbom/agent-bom:0.86.5 agents --demo` | same artifacts as CLI |
+| GitHub Action (`uses: msaad00/agent-bom@v0.87.0`) | CI/CD + SARIF | `uses: msaad00/agent-bom@v0.87.0` | `agent-bom-results.sarif` |
+| Docker (`agentbom/agent-bom`) | isolated CLI/API jobs and non-browser self-hosted entrypoints | `docker run --rm agentbom/agent-bom:0.87.0 agents --demo` | same artifacts as CLI |
 | Browser UI image (`agentbom/agent-bom-ui`) | browser dashboard paired with the same API/control plane | `docker compose -f docker-compose.pilot.yml up -d` | dashboard at `http://localhost:3000` |
 | Kubernetes / Helm | self-hosted API + dashboard, scheduled discovery | `helm upgrade --install agent-bom deploy/helm/agent-bom --set controlPlane.enabled=true` | API, UI, jobs, optional gateway/proxy |
 | REST API (`agent-bom api` / `agent-bom serve`) | platform integration and self-hosted control plane | `agent-bom serve --port 8422 --persist jobs.db` | `/docs`, `/health`, `/v1/scan`, `/v1/fleet` |
@@ -591,7 +591,7 @@ Cortex, Cursor, Windsurf, or another MCP client.
 **CI security review**
 
 ```yaml
-- uses: msaad00/agent-bom@v0.86.5
+- uses: msaad00/agent-bom@v0.87.0
   with:
     scan-type: agents
     severity-threshold: high
@@ -667,7 +667,7 @@ References: [PRODUCT_BRIEF.md](docs/PRODUCT_BRIEF.md) · [PRODUCT_METRICS.md](do
 <summary><b>CI/CD in 60 seconds</b></summary>
 
 ```yaml
-- uses: msaad00/agent-bom@v0.86.5
+- uses: msaad00/agent-bom@v0.87.0
   with:
     scan-type: scan
     severity-threshold: high

--- a/deploy/docker-compose.fullstack.yml
+++ b/deploy/docker-compose.fullstack.yml
@@ -27,7 +27,7 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
-    image: agentbom/agent-bom:0.86.5
+    image: agentbom/agent-bom:0.87.0
     container_name: agent-bom-api
     restart: unless-stopped
     command: api --host 0.0.0.0 --port 8422 --allow-insecure-no-auth
@@ -74,7 +74,7 @@ services:
       args:
         # Baked into the Next.js build — must match the publicly reachable API URL
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8422}
-    image: agentbom/agent-bom-ui:0.86.5
+    image: agentbom/agent-bom-ui:0.87.0
     container_name: agent-bom-ui
     restart: unless-stopped
     ports:

--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -18,7 +18,7 @@
 
 services:
   api:
-    image: agentbom/agent-bom:0.86.5
+    image: agentbom/agent-bom:0.87.0
     container_name: agent-bom-pilot-api
     restart: unless-stopped
     command: >
@@ -45,7 +45,7 @@ services:
       start_period: 10s
 
   ui:
-    image: agentbom/agent-bom-ui:0.86.5
+    image: agentbom/agent-bom-ui:0.87.0
     container_name: agent-bom-pilot-ui
     restart: unless-stopped
     environment:

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -112,7 +112,7 @@ services:
       dockerfile: Dockerfile
       args:
         NEXT_PUBLIC_API_URL: http://localhost:8422
-    image: agentbom/agent-bom-ui:0.86.5
+    image: agentbom/agent-bom-ui:0.87.0
     container_name: agent-bom-ui
     ports:
       - "3000:3000"

--- a/deploy/docker-compose.runtime.yml
+++ b/deploy/docker-compose.runtime.yml
@@ -31,7 +31,7 @@ services:
     build:
       context: ..
       dockerfile: deploy/docker/Dockerfile.runtime
-    image: agentbom/agent-bom:0.86.5
+    image: agentbom/agent-bom:0.87.0
     container_name: agent-bom-runtime-proxy
     depends_on:
       - mcp-server

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -27,7 +27,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.86.5
+ARG VERSION=0.87.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -17,7 +17,7 @@ WORKDIR /app
 COPY pyproject.toml README.md PYPI_README.md LICENSE ./
 COPY src/ ./src/
 
-ARG VERSION=0.86.5
+ARG VERSION=0.87.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
@@ -40,7 +40,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[runtime]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.86.5
+ARG VERSION=0.87.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.snowpark
+++ b/deploy/docker/Dockerfile.snowpark
@@ -26,7 +26,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11.12-slim@sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c
 
-ARG VERSION=0.86.5
+ARG VERSION=0.87.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -41,7 +41,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.86.5
+ARG VERSION=0.87.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: agent-bom
 description: Open security scanner and graph for AI supply chain and infrastructure — discover agents and MCP, map blast radius, and inspect runtime.
-version: 0.86.5
-appVersion: "0.86.5"
+version: 0.87.0
+appVersion: "0.87.0"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -24,17 +24,17 @@
 
 image:
   repository: agentbom/agent-bom
-  tag: "0.86.5"
+  tag: "0.87.0"
   pullPolicy: IfNotPresent
 
 uiImage:
   repository: agentbom/agent-bom-ui
-  tag: "0.86.5"
+  tag: "0.87.0"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom
-  tag: "0.86.5"
+  tag: "0.87.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -57,7 +57,7 @@ tests:
   includeUi: true
   image:
     repository: agentbom/agent-bom
-    tag: "0.86.5"
+    tag: "0.87.0"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deploy/k8s/cronjob.yaml
+++ b/deploy/k8s/cronjob.yaml
@@ -21,7 +21,7 @@ spec:
           serviceAccountName: agent-bom
           containers:
             - name: scanner
-              image: agentbom/agent-bom:0.86.5
+              image: agentbom/agent-bom:0.87.0
               command: ["agent-bom"]
               args:
                 - "scan"

--- a/deploy/k8s/daemonset.yaml
+++ b/deploy/k8s/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: agent-bom
       containers:
         - name: monitor
-          image: agentbom/agent-bom:0.86.5
+          image: agentbom/agent-bom:0.87.0
           command: ["agent-bom"]
           args:
             - "protect"

--- a/deploy/k8s/proxy-sidecar-pilot.yaml
+++ b/deploy/k8s/proxy-sidecar-pilot.yaml
@@ -109,7 +109,7 @@ spec:
               cpu: "500m"
 
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.86.5
+          image: agentbom/agent-bom:0.87.0
           args:
             - "--policy"
             - "/etc/agent-bom/policy.json"

--- a/deploy/k8s/sidecar-example.yaml
+++ b/deploy/k8s/sidecar-example.yaml
@@ -40,7 +40,7 @@ spec:
 
         # agent-bom proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.86.5
+          image: agentbom/agent-bom:0.87.0
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"

--- a/deploy/snowflake/native-app/manifest.yml
+++ b/deploy/snowflake/native-app/manifest.yml
@@ -15,10 +15,10 @@ artifacts:
     endpoint: ui
   container_services:
     images:
-      - /db/schema/agent_bom_repo/agent-bom:v0_86_5
-      - /db/schema/agent_bom_repo/agent-bom-ui:v0_86_5
-      - /db/schema/agent_bom_repo/agent-bom-scanner:v0_86_5
-      - /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_86_5
+      - /db/schema/agent_bom_repo/agent-bom:v0_87_0
+      - /db/schema/agent_bom_repo/agent-bom-ui:v0_87_0
+      - /db/schema/agent_bom_repo/agent-bom-scanner:v0_87_0
+      - /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_87_0
   service_roles:
     - name: api
       comment: >-

--- a/deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml
+++ b/deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom-mcp-runtime
-      image: /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_86_5
+      image: /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_87_0
       env:
         SNOWFLAKE_ACCOUNT: "{{ snowflake_account }}"
         SNOWFLAKE_DATABASE: "{{ database }}"

--- a/deploy/snowflake/native-app/service-specs/scanner-service.yaml
+++ b/deploy/snowflake/native-app/service-specs/scanner-service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom-scanner
-      image: /db/schema/agent_bom_repo/agent-bom-scanner:v0_86_5
+      image: /db/schema/agent_bom_repo/agent-bom-scanner:v0_87_0
       env:
         SNOWFLAKE_ACCOUNT: "{{ snowflake_account }}"
         SNOWFLAKE_DATABASE: "{{ database }}"

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -157,7 +157,7 @@ should not store provider secret values.
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.86.5
+- uses: msaad00/agent-bom@v0.87.0
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -71,7 +71,7 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # GitHub Actions
-- uses: msaad00/agent-bom@v0.86.5
+- uses: msaad00/agent-bom@v0.87.0
   with:
     scan-type: agents        # auto-detect MCP configs + deps
     severity-threshold: high # fail PR on HIGH+ CVEs
@@ -89,21 +89,21 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # Container image gate
-- uses: msaad00/agent-bom@v0.86.5
+- uses: msaad00/agent-bom@v0.87.0
   with:
     scan-type: image
     scan-ref: ghcr.io/acme/agent-runtime:sha-abcdef
     severity-threshold: critical
 
 # IaC gate
-- uses: msaad00/agent-bom@v0.86.5
+- uses: msaad00/agent-bom@v0.87.0
   with:
     scan-type: iac
     iac: Dockerfile,k8s/,infra/main.tf
     severity-threshold: high
 
 # Air-gapped or fully cached CI
-- uses: msaad00/agent-bom@v0.86.5
+- uses: msaad00/agent-bom@v0.87.0
   with:
     auto-update-db: false
     enrich: false
@@ -469,7 +469,7 @@ AmazonEC2ReadOnlyAccess
 docker run --rm \
   -v ~/.config:/home/abom/.config:ro \
   -v $(pwd):/workspace:ro \
-  agentbom/agent-bom:0.86.5 agents --format json
+  agentbom/agent-bom:0.87.0 agents --format json
 ```
 
 Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base image.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -243,7 +243,7 @@ should_i_deploy     — allow/warn/block guidance from ExposurePath risk
 ### CI/CD (GitHub Action)
 
 ```yaml
-- uses: msaad00/agent-bom@v0.86.5
+- uses: msaad00/agent-bom@v0.87.0
   with:
     format: sarif
     upload-sarif: 'true'

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,6 +1,6 @@
 {
   "generated_on": "2026-05-15",
-  "version": "0.86.5",
+  "version": "0.87.0",
   "metrics": [
     {
       "name": "MCP tools",

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -6,7 +6,7 @@ This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
 - Generated on: `2026-05-15`
-- Version: `0.86.5`
+- Version: `0.87.0`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -97,7 +97,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN" --no-browser
 clawhub publish integrations/openclaw/scan \
   --slug agent-bom-scan --name "agent-bom scan" \
-  --version "0.86.5"
+  --version "0.87.0"
 ```
 
 Release automation uses the same official `clawhub` CLI flow, not a custom
@@ -149,8 +149,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.86.5
-git push origin v0.86.5
+git tag v0.87.0
+git push origin v0.87.0
 ```
 
 This triggers:

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -13,7 +13,7 @@ For each tagged GitHub Release, expect:
 ## Download release assets
 
 ```bash
-TAG=v0.86.5
+TAG=v0.87.0
 VERSION="${TAG#v}"
 mkdir -p /tmp/agent-bom-release && cd /tmp/agent-bom-release
 gh release download "$TAG" --repo msaad00/agent-bom

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -33,7 +33,7 @@ The proxy interposes on the stdio channel between an MCP client (Claude Desktop,
 Use the published main runtime image:
 
 ```bash
-docker pull agentbom/agent-bom:0.86.5
+docker pull agentbom/agent-bom:0.87.0
 ```
 
 If you need to rebuild locally from the checked-out repo, you can still use
@@ -45,7 +45,7 @@ Run as a wrapper around any MCP server:
 ```bash
 docker run --rm \
   -v $(pwd)/audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.86.5 \
+  agentbom/agent-bom:0.87.0 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace
@@ -94,7 +94,7 @@ spec:
 
         # agent-bom runtime proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.86.5
+          image: agentbom/agent-bom:0.87.0
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"
@@ -341,7 +341,7 @@ Use the runtime container directly from Claude Desktop:
         "run", "--rm", "-i",
         "-v", "./workspace:/workspace",
         "-v", "./audit-logs:/var/log/agent-bom",
-        "agentbom/agent-bom:0.86.5",
+        "agentbom/agent-bom:0.87.0",
         "--log", "/var/log/agent-bom/audit.jsonl",
         "--block-undeclared",
         "--",

--- a/docs/archive/WINDOWS_CONTAINERS.md
+++ b/docs/archive/WINDOWS_CONTAINERS.md
@@ -113,7 +113,7 @@ container inspection. Windows Server environments should use:
 
 1. **Python CLI** -- `pip install agent-bom` works on Windows natively
 2. **Docker Desktop** -- run the Linux container images on Windows via WSL 2
-3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.86.5`) which
+3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.87.0`) which
    runs on Linux runners
 
 ---

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,4 +1,4 @@
-# agent-bom v0.86.5 blast-radius demo
+# agent-bom v0.87.0 blast-radius demo
 # Shows: blast radius → package gate
 
 Output docs/images/demo-latest.gif

--- a/docs/images/product-screenshots.json
+++ b/docs/images/product-screenshots.json
@@ -1,49 +1,49 @@
 {
-  "release_version": "0.86.5",
+  "release_version": "0.87.0",
   "captured_at": "2026-05-15T06:23:13Z",
-  "capture_note": "Captured from the packaged Next.js dashboard served by agent-bom serve on current main after the graph/ExposurePath/MCP enhancements, with bundled demo data pushed through /v1/results/push. Graph screenshots are real product routes in capture mode; README/Docker proof uses one focused graph capture rather than duplicate dark/light theme copies. Visible product version remains 0.86.5 until the release-version bump lands.",
+  "capture_note": "Captured from the packaged Next.js dashboard served by agent-bom serve on current main after the graph/ExposurePath/MCP enhancements, with bundled demo data pushed through /v1/results/push. Graph screenshots are real product routes in capture mode; README/Docker proof uses one focused graph capture rather than duplicate dark/light theme copies. Manifest metadata targets v0.87.0; recapture is only required if the release proof must show the new version string in the image pixels.",
   "screenshots": [
     {
       "path": "dashboard-live.png",
       "page": "/?capture=1",
       "scope": "Risk overview top frame with headline KPIs, posture grade, and start of attack paths",
-      "visible_version": "0.86.5"
+      "visible_version": "0.87.0"
     },
     {
       "path": "dashboard-paths-live.png",
       "page": "/?capture=1",
       "scope": "Risk overview mid-frame with attack paths and exposure KPIs",
-      "visible_version": "0.86.5"
+      "visible_version": "0.87.0"
     },
     {
       "path": "mesh-live.png",
       "page": "/mesh?capture=1",
       "scope": "Focused agent mesh graph across selected agents, MCP servers, packages, tools, credentials, and findings, cropped to the product graph surface",
-      "visible_version": "0.86.5"
+      "visible_version": "0.87.0"
     },
     {
       "path": "security-graph-live.png",
       "page": "/security-graph?capture=1",
       "scope": "Fix-first attack path queue with snapshot pressure, graph evidence export, and remediation handoff",
-      "visible_version": "0.86.5"
+      "visible_version": "0.87.0"
     },
     {
       "path": "lineage-graph-live.png",
       "page": "/graph?capture=1&investigate=1&root=agent:cursor&q=cursor",
       "scope": "Root-centered lineage investigation with reachable node counts, bounded paths, filters, and graph evidence export",
-      "visible_version": "0.86.5"
+      "visible_version": "0.87.0"
     },
     {
       "path": "dependency-map-live.png",
       "page": "/insights?capture=1",
       "scope": "Supply chain dependency map with scan pipeline counts and package risk distribution",
-      "visible_version": "0.86.5"
+      "visible_version": "0.87.0"
     },
     {
       "path": "remediation-live.png",
       "page": "/remediation",
       "scope": "Fix-first remediation table with prioritized packages and framework context",
-      "visible_version": "0.86.5"
+      "visible_version": "0.87.0"
     }
   ]
 }

--- a/docs/release/product-screenshot-audit-v0.87.0.md
+++ b/docs/release/product-screenshot-audit-v0.87.0.md
@@ -17,18 +17,15 @@ Capture date: 2026-05-15
 
 | Asset | Route | Visible version |
 |---|---|---|
-| `docs/images/dashboard-live.png` | `/?capture=1` | `0.86.5` |
-| `docs/images/dashboard-paths-live.png` | `/?capture=1` | `0.86.5` |
-| `docs/images/mesh-live.png` | `/mesh?capture=1` | `0.86.5` |
-| `docs/images/security-graph-live.png` | `/security-graph?capture=1` | `0.86.5` |
-| `docs/images/lineage-graph-live.png` | `/graph?capture=1&investigate=1&root=agent:cursor&q=cursor` | `0.86.5` |
-| `docs/images/dependency-map-live.png` | `/insights?capture=1` | `0.86.5` |
-| `docs/images/remediation-live.png` | `/remediation` | `0.86.5` |
+| `docs/images/dashboard-live.png` | `/?capture=1` | `0.87.0` |
+| `docs/images/dashboard-paths-live.png` | `/?capture=1` | `0.87.0` |
+| `docs/images/mesh-live.png` | `/mesh?capture=1` | `0.87.0` |
+| `docs/images/security-graph-live.png` | `/security-graph?capture=1` | `0.87.0` |
+| `docs/images/lineage-graph-live.png` | `/graph?capture=1&investigate=1&root=agent:cursor&q=cursor` | `0.87.0` |
+| `docs/images/dependency-map-live.png` | `/insights?capture=1` | `0.87.0` |
+| `docs/images/remediation-live.png` | `/remediation` | `0.87.0` |
 
-The visible version stays `0.86.5` because this PR refreshes proof from current
-`main` before the release-version bump. The release bump PR should update
-`docs/images/product-screenshots.json` and recapture only if the UI-visible
-version changes.
+The screenshot manifest targets `v0.87.0`. Recapture is only required if the release proof must show the new version string in the image pixels.
 
 ## Claim Boundaries
 

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
-  "version": "0.86.5",
+  "version": "0.87.0",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
   "title": "agent-bom",
-  "version": "0.86.5",
+  "version": "0.87.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.86.5",
+      "version": "0.87.0",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   security checks. Use when the user mentions vulnerability scanning,
   MCP server trust, compliance, SBOM generation, CIS benchmarks, blast
   radius, or AI supply chain risk.
-version: 0.86.5
+version: 0.87.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -25,7 +25,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.86.5
+    docker: ghcr.io/msaad00/agent-bom:0.87.0
   openclaw:
     requires:
       bins: []
@@ -415,6 +415,6 @@ provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.86.5`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.87.0`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Analyze blast radius, attack paths, and threat landscape across your AI
   infrastructure. Use when: "blast radius", "threat intel", "risk score",
   "attack path", "lateral movement", "context graph", "who can reach what".
-version: 0.86.5
+version: 0.87.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.86.5
+    docker: ghcr.io/msaad00/agent-bom:0.87.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Generate SBOMs and compliance reports. Use when:
   "compliance report", "NIST", "SOC 2", "ISO 27001", "OWASP", "EU AI Act",
   "AISVS", "generate SBOM", "policy check".
-version: 0.86.5
+version: 0.87.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. OWASP/NIST/EU AI Act/MITRE
@@ -23,7 +23,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.86.5
+    docker: ghcr.io/msaad00/agent-bom:0.87.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/discover-aws/SKILL.md
+++ b/integrations/openclaw/discover-aws/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   inventory AWS Bedrock, ECS, SageMaker, Lambda, EKS, Step Functions, EC2, or
   agentic AWS infrastructure as canonical inventory. Passing that inventory
   to agent-bom is optional and operator-chosen.
-version: 0.86.5
+version: 0.87.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-azure/SKILL.md
+++ b/integrations/openclaw/discover-azure/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   giving agent-bom long-lived Azure credentials. Use when a user asks to
   inventory Azure OpenAI, Container Apps, AKS, Functions, ML, or agentic Azure
   infrastructure as canonical inventory.
-version: 0.86.5
+version: 0.87.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-gcp/SKILL.md
+++ b/integrations/openclaw/discover-gcp/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   giving agent-bom long-lived GCP credentials. Use when a user asks to
   inventory Vertex AI, Cloud Run, Cloud Functions, GKE, or agentic GCP
   infrastructure as canonical inventory.
-version: 0.86.5
+version: 0.87.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-snowflake/SKILL.md
+++ b/integrations/openclaw/discover-snowflake/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   agent-bom inventory JSON, and scan it without giving agent-bom long-lived
   Snowflake credentials. Use when a user asks to inventory Snowflake AI or
   Cortex infrastructure as canonical inventory.
-version: 0.86.5
+version: 0.87.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed with the snowflake extra, and

--- a/integrations/openclaw/discover/SKILL.md
+++ b/integrations/openclaw/discover/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Discover AI agents, MCP servers, and configurations on this machine or
   environment. Use when: "find agents", "what's configured", "doctor",
   "what MCP servers", "show me what's installed", "mcp inventory".
-version: 0.86.5
+version: 0.87.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.86.5
+    docker: ghcr.io/msaad00/agent-bom:0.87.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Enforce security policies on MCP tool calls and block dangerous operations at
   runtime. Use when: "block risky calls", "apply policy", "proxy",
   "runtime protection", "policy enforcement", "intercept MCP calls".
-version: 0.86.5
+version: 0.87.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.86.5
+    docker: ghcr.io/msaad00/agent-bom:0.87.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/ingest/SKILL.md
+++ b/integrations/openclaw/ingest/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   GCP, Snowflake, CMDB, or endpoint collectors. Use when a user has canonical
   inventory JSON and wants local findings, graph, policy, provenance, or
   auditor-ready exports without giving agent-bom direct cloud credentials.
-version: 0.86.5
+version: 0.87.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+ and agent-bom 0.84.4+. Inventory must conform to the

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Monitor agent fleet, track trust scores, and manage lifecycle states. Use
   when: "fleet", "watch agents", "runtime status", "trust scores",
   "fleet sync", "agent lifecycle", "serve dashboard".
-version: 0.86.5
+version: 0.87.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.86.5
+    docker: ghcr.io/msaad00/agent-bom:0.87.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.86.5
+version: 0.87.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.86.5
+version: 0.87.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Scan infrastructure-as-code, cloud configurations, and find secrets. Use when:
   "check terraform", "scan kubernetes", "IaC", "find secrets",
   "scan dockerfile", "cloud security", "misconfigurations".
-version: 0.86.5
+version: 0.87.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.86.5
+    docker: ghcr.io/msaad00/agent-bom:0.87.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   KEV), container images, provenance, filesystems, and SBOMs. Use
   when: "check package", "scan image", "verify", "is this safe",
   "scan dependencies", "CVE lookup", "blast radius".
-version: 0.86.5
+version: 0.87.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Native container image
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.86.5
+    docker: ghcr.io/msaad00/agent-bom:0.87.0
   openclaw:
     requires:
       bins: []
@@ -237,6 +237,6 @@ agent-bom agents
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.86.5`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.87.0`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Diagnose issues, check prerequisites, and validate configurations. Use when:
   "doctor", "debug", "why failing", "validate config", "check prerequisites",
   "something is broken", "db status", "fix my setup".
-version: 0.86.5
+version: 0.87.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.86.5
+    docker: ghcr.io/msaad00/agent-bom:0.87.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/vulnerability-intel/SKILL.md
+++ b/integrations/openclaw/vulnerability-intel/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   with explicit data-boundary choices. Use when a user asks for CVE lookup,
   advisory intelligence, exploitability context, fix versions, GHSA/OSV/NVD
   enrichment, or package vulnerability triage.
-version: 0.86.5
+version: 0.87.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+ and agent-bom installed from this repository or PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.86.5"
+version = "0.87.0"
 description = "Open security scanner and self-hosted control plane for AI/MCP infrastructure."
 readme = "PYPI_README.md"
 license = "Apache-2.0"

--- a/site-docs/deployment/airgapped-image-bundle.md
+++ b/site-docs/deployment/airgapped-image-bundle.md
@@ -16,7 +16,7 @@ From an internet-connected build host:
 
 ```bash
 scripts/release/build-airgap-image-bundle.sh \
-  --version 0.86.5 \
+  --version 0.87.0 \
   --platform linux/amd64 \
   --output-dir dist/airgap
 ```
@@ -37,8 +37,8 @@ machine.
 ## Import On The Disconnected Host
 
 ```bash
-tar -xzf agent-bom-airgap-0.86.5-linux_amd64.tar.gz
-cd agent-bom-airgap-0.86.5-linux_amd64
+tar -xzf agent-bom-airgap-0.87.0-linux_amd64.tar.gz
+cd agent-bom-airgap-0.87.0-linux_amd64
 ./load-images.sh
 ```
 
@@ -47,7 +47,7 @@ The loader verifies archive checksums before running `docker load`.
 ## Push To An Internal Registry
 
 ```bash
-VERSION=0.86.5
+VERSION=0.87.0
 REGISTRY=registry.internal.example.com/security
 
 docker tag "agentbom/agent-bom:${VERSION}" "${REGISTRY}/agent-bom:${VERSION}"
@@ -62,13 +62,13 @@ Then point Helm at the internal registry:
 ```yaml
 image:
   repository: registry.internal.example.com/security/agent-bom
-  tag: "0.86.5"
+  tag: "0.87.0"
 
 controlPlane:
   ui:
     image:
       repository: registry.internal.example.com/security/agent-bom-ui
-      tag: "0.86.5"
+      tag: "0.87.0"
 ```
 
 ## GitHub Actions Bundle Job

--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -332,8 +332,8 @@ through a managed tap instead of direct package upload.
 
 ```bash
 python3 scripts/render_homebrew_formula.py \
-  --version 0.86.5 \
-  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.86.5.tar.gz \
+  --version 0.87.0 \
+  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.87.0.tar.gz \
   --sha256 <release-sha256>
 ```
 

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -171,7 +171,7 @@ Install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.86.5 \
+  --version 0.87.0 \
   -n agent-bom --create-namespace \
   -f values.agent-bom.yaml
 ```
@@ -207,7 +207,7 @@ Then install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.86.5 \
+  --version 0.87.0 \
   -n agent-bom --create-namespace \
   -f deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
 ```

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -90,10 +90,10 @@ docker run --rm \
 ## Runtime proxy against a remote MCP endpoint
 
 ```bash
-docker pull agentbom/agent-bom:0.86.5
+docker pull agentbom/agent-bom:0.87.0
 docker run --rm -i \
   -v ./audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.86.5 \
+  agentbom/agent-bom:0.87.0 \
   proxy \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \

--- a/site-docs/features/policy.md
+++ b/site-docs/features/policy.md
@@ -49,7 +49,7 @@ agent-bom proxy --policy policy.json --block-undeclared -- ...
 
 ```yaml
 - name: Security gate
-  uses: msaad00/agent-bom@v0.86.5
+  uses: msaad00/agent-bom@v0.87.0
   with:
     policy: policy.json
     fail-on-violation: true

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -45,7 +45,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 |---|---|---|
 | **Local AI BOM** | `agent-bom agents --demo --offline` | terminal findings and graph-ready inventory |
 | **Repository scan** | `agent-bom agents -p . -f html -o agent-bom-report.html` | local HTML review plus exportable evidence |
-| **CI evidence** | `uses: msaad00/agent-bom@v0.86.5` | SARIF, pull-request summary, optional code scanning |
+| **CI evidence** | `uses: msaad00/agent-bom@v0.87.0` | SARIF, pull-request summary, optional code scanning |
 | **Assistant tools** | `agent-bom mcp server` | read-only security tools for MCP clients |
 | **Self-hosted control plane** | `docker compose -f docker-compose.pilot.yml up -d` | API and dashboard in your infrastructure |
 

--- a/site-docs/reference/agentic-workflows.md
+++ b/site-docs/reference/agentic-workflows.md
@@ -8,7 +8,7 @@ plane or runtime enforcement rollout.
 |---|---|---|---|---|
 | Local CLI | `agent-bom agents --demo --offline`, then `agent-bom agents -p .` | Reads local agent and MCP configuration from the developer machine. No control-plane credentials required. | Terminal findings, JSON, SARIF, SBOM, HTML, graph export. | Scheduled scan, Docker, GitHub Action. |
 | Claude, Cursor, Windsurf, VS Code, Cortex, Codex CLI | `agent-bom mcp server` | Exposes read-only security tools to the assistant. The assistant does not need direct scanner credentials beyond the local process boundary. | MCP tool output, inventory, blast-radius answers, compliance checks, ranked `ExposurePath` JSON, deploy guidance. | Shared MCP configuration, skills, fleet sync. |
-| GitHub Actions | `uses: msaad00/agent-bom@v0.86.5` with SARIF upload enabled | Runs in CI with repository-scoped token permissions. Fork PR behavior depends on GitHub security policy. | `agent-bom-results.sarif`, pull-request summary, code-scanning alert category. | Branch protection, required code scanning, artifact retention. |
+| GitHub Actions | `uses: msaad00/agent-bom@v0.87.0` with SARIF upload enabled | Runs in CI with repository-scoped token permissions. Fork PR behavior depends on GitHub security policy. | `agent-bom-results.sarif`, pull-request summary, code-scanning alert category. | Branch protection, required code scanning, artifact retention. |
 | Skills and instruction files | `agent-bom skills scan . --policy skills-policy.yaml` | Reads repo-local instructions such as `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, and `skills/*.md`. | Skill trust findings, referenced package and MCP inventory, credential-env names, policy warn/block result. | Signed skills, provenance verification, registry publishing. |
 | Cloud and AI infrastructure | `agent-bom agents --preset enterprise` plus provider-specific flags only where credentials are approved. | Uses read-only provider APIs or local inventory files. Keep provider secrets in the operator boundary, not in repo docs. | Cloud, warehouse, GPU, model, dataset, and runtime package evidence. | Fleet sync, compliance exports, graph-backed findings. |
 | Runtime proxy | `agent-bom proxy --no-isolate --log audit.jsonl --block-undeclared -- ...` | Wraps selected local MCP traffic. Policy can block before an upstream tool receives the call. Container containment requires a stdio MCP path plus a configured sandbox image or an existing container command. | Tier-A audit JSONL, policy decisions, runtime alerts, metrics, and sandbox posture when isolation is enabled. | Sidecar proxy, gateway policy pull, SIEM export. |
@@ -31,7 +31,7 @@ when the buyer or contributor needs to see the first finding path quickly.
 ### CI Security Review
 
 ```yaml
-- uses: msaad00/agent-bom@v0.86.5
+- uses: msaad00/agent-bom@v0.87.0
   with:
     scan-type: agents
     severity-threshold: high
@@ -62,7 +62,7 @@ so future agent and SIEM push workflows share one event envelope.
 ### Skills CI Gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.86.5
+- uses: msaad00/agent-bom@v0.87.0
   with:
     scan-type: skills
     scan-ref: .

--- a/site-docs/reference/remediate-output.md
+++ b/site-docs/reference/remediate-output.md
@@ -27,7 +27,7 @@ agent-bom remediate -p . --format json --server-group --output plan.json
 
 ```json
 {
-  "version": "0.86.5",
+  "version": "0.87.0",
   "generated_at": "2026-04-21T12:00:00+00:00",
   "remediation_plan": [],
   "summary": {

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.86.5"
+    __version__ = "0.87.0"
 
 # Cross-check against pyproject.toml for dev installs where the editable
 # install metadata may be stale (i.e. version bumped but not re-installed).

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.86.5",
+  "version": "0.87.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.86.5",
+      "version": "0.87.0",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
         "@tanstack/react-table": "^8.21.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.86.5",
+  "version": "0.87.0",
   "private": true,
   "packageManager": "npm@10.9.7",
   "engines": {

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/lib/api', () => ({
       scan_sources: [],
       scan_count: 0,
     }),
-    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.86.5' }),
+    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.87.0' }),
   },
 }))
 

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,7 @@ overrides = [
 
 [[package]]
 name = "agent-bom"
-version = "0.86.5"
+version = "0.87.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Summary
- bump release-managed package, UI, Docker, Helm, workflow, registry, OpenClaw, and docs surfaces to 0.87.0
- promote CHANGELOG [Unreleased] to 0.87.0 with the merged graph, headless, skills, entitlement, dbt scanner, and Postgres scale-evidence workflow work through #2616
- align release proof metadata, Docker/PyPI/README examples, and docs references with the v0.87.0 release target

Verification
- python scripts/bump-version.py 0.87.0 --check
- python scripts/check_release_consistency.py
- python scripts/check_product_surface_contract.py
- uv run mkdocs build --strict
- git diff --check

Notes
- #2616 is included in this rebased release-prep branch and called out in the v0.87.0 changelog.
- The screenshot manifest metadata targets v0.87.0; the existing image files remain the latest product proof set and should only be recaptured if the release requires the version string to be visible in image pixels.
