### PR TITLE
feat(runtime): add Langfuse OTLP span profile

### DIFF
--- a/docs/OBSERVABILITY_METRICS.md
+++ b/docs/OBSERVABILITY_METRICS.md
@@ -76,14 +76,21 @@ rate(agent_bom_scan_completions_total[15m]) > 0.1` — failure rate above
 
 ## Tracing (OpenTelemetry)
 
-Tracing is configured by `OTEL_EXPORTER_OTLP_ENDPOINT` and
-`AGENT_BOM_OTEL_ENABLED=1`. When on, every FastAPI request emits a trace
-via the middleware in `src/agent_bom/api/tracing.py`. Recommended
-exporters:
+Tracing is configured by `AGENT_BOM_OTEL_TRACES_ENDPOINT`. Optional
+collector authentication headers can be passed with
+`AGENT_BOM_OTEL_TRACES_HEADERS` as comma-separated `key=value` pairs. When
+configured, FastAPI, gateway, graph, and MCP proxy spans are exported over
+OTLP/HTTP through `src/agent_bom/api/tracing.py`. Recommended exporters:
 
 - **Local / self-hosted:** OTel Collector → Jaeger, Tempo, or any
   OTLP-compatible sink.
 - **AWS:** ADOT collector → CloudWatch / X-Ray.
+- **Langfuse-compatible:** point `AGENT_BOM_OTEL_TRACES_ENDPOINT` at the
+  Langfuse OTLP/HTTP traces endpoint and set `AGENT_BOM_OTEL_TRACES_HEADERS`
+  for Basic auth plus ingestion headers. agent-bom emits redaction-safe
+  `langfuse.*` attributes on runtime proxy and gateway spans, but Langfuse
+  scores, dataset replay, and native trace import remain roadmap work until
+  code and tests land for those paths.
 
 Correlate traces with audit entries via the `trace_id` field written to
 every `compliance.report_exported` audit entry.

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -55,6 +55,7 @@ from agent_bom.firewall import (
 )
 from agent_bom.firewall import evaluate as evaluate_firewall_policy
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
+from agent_bom.langfuse_otel import set_langfuse_runtime_attributes
 from agent_bom.proxy import check_policy, is_tools_call, parse_jsonrpc, policy_subject_from_message
 from agent_bom.proxy_policy import summarize_policy_bundle
 
@@ -960,6 +961,16 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                         span.set_attribute("agent_bom.gateway.tracestate_present", True)
                     if trace_meta["baggage"]:
                         span.set_attribute("agent_bom.gateway.baggage_present", True)
+                    set_langfuse_runtime_attributes(
+                        span,
+                        surface="gateway",
+                        tenant_id=tenant_id,
+                        method=str(message.get("method", "unknown")),
+                        tool_name=message.get("params", {}).get("name") if is_tools_call(message) else None,
+                        decision="allowed",
+                        upstream=upstream.name,
+                        trace_id=str(trace_meta["trace_id"]),
+                    )
                 upstream_response = await upstream_caller(upstream, forwarded_message, extra_headers)
         except GatewayCircuitOpenError as exc:
             logger.warning("gateway upstream circuit open for %s", upstream.name)

--- a/src/agent_bom/langfuse_otel.py
+++ b/src/agent_bom/langfuse_otel.py
@@ -1,0 +1,115 @@
+"""Langfuse-compatible OTLP span attributes.
+
+This module does not depend on Langfuse's SDK. It projects the existing
+agent-bom runtime/proxy/gateway span metadata into safe `langfuse.*`
+attributes for operators who point OTLP/HTTP export at Langfuse.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from typing import Any
+
+_MAX_ATTR_VALUE = 256
+_MAX_REASON_VALUE = 512
+_SECRET_KEY_HINTS = ("key", "token", "secret", "password", "credential", "authorization", "cookie")
+
+
+def _bounded(value: object, *, limit: int = _MAX_ATTR_VALUE) -> str:
+    text = str(value or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)] + "..."
+
+
+def _safe_argument_keys(arguments: Mapping[str, object] | None) -> list[str]:
+    if not arguments:
+        return []
+    keys: list[str] = []
+    for raw_key in sorted(str(key) for key in arguments):
+        lowered = raw_key.lower()
+        if any(hint in lowered for hint in _SECRET_KEY_HINTS):
+            keys.append("<redacted>")
+        else:
+            keys.append(_bounded(raw_key, limit=64))
+    return keys[:20]
+
+
+def _arguments_fingerprint(arguments: Mapping[str, object] | None) -> str:
+    keys = _safe_argument_keys(arguments)
+    if not keys:
+        return ""
+    digest = hashlib.sha256("\n".join(keys).encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
+def langfuse_runtime_attributes(
+    *,
+    surface: str,
+    tenant_id: str,
+    method: str,
+    tool_name: str | None = None,
+    decision: str | None = None,
+    reason: str | None = None,
+    upstream: str | None = None,
+    agent_id: str | None = None,
+    event_id: str | None = None,
+    trace_id: str | None = None,
+    arguments: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    """Return redaction-safe Langfuse OTLP attributes for runtime spans."""
+    safe_tool = _bounded(tool_name or method or "unknown")
+    safe_surface = _bounded(surface or "runtime")
+    safe_method = _bounded(method or "unknown")
+    safe_tenant = _bounded(tenant_id or "default")
+    safe_decision = _bounded((decision or "observed").lower())
+    argument_keys = _safe_argument_keys(arguments)
+
+    attrs: dict[str, object] = {
+        "langfuse.trace.name": f"agent-bom.{safe_surface}",
+        "langfuse.trace.tags": ["agent-bom", safe_surface, "security"],
+        "langfuse.trace.metadata.tenant_id": safe_tenant,
+        "langfuse.trace.metadata.surface": safe_surface,
+        "langfuse.trace.metadata.method": safe_method,
+        "langfuse.trace.metadata.policy_decision": safe_decision,
+        "langfuse.observation.type": "span",
+        "langfuse.observation.metadata.surface": safe_surface,
+        "langfuse.observation.metadata.method": safe_method,
+        "langfuse.observation.metadata.policy_decision": safe_decision,
+        "agent_bom.runtime.surface": safe_surface,
+        "agent_bom.runtime.tenant_id": safe_tenant,
+        "agent_bom.runtime.method": safe_method,
+        "agent_bom.runtime.policy_decision": safe_decision,
+        "agent_bom.runtime.argument_count": len(arguments or {}),
+    }
+    if tool_name:
+        attrs["langfuse.observation.metadata.tool"] = safe_tool
+        attrs["agent_bom.runtime.tool"] = safe_tool
+    if upstream:
+        attrs["langfuse.trace.metadata.upstream"] = _bounded(upstream)
+        attrs["agent_bom.runtime.upstream"] = _bounded(upstream)
+    if agent_id:
+        attrs["langfuse.user.id"] = _bounded(agent_id)
+        attrs["agent_bom.runtime.agent_id"] = _bounded(agent_id)
+    if event_id:
+        attrs["langfuse.observation.metadata.event_id"] = _bounded(event_id)
+        attrs["agent_bom.runtime.event_id"] = _bounded(event_id)
+    if trace_id:
+        attrs["langfuse.trace.metadata.trace_id"] = _bounded(trace_id)
+        attrs["agent_bom.runtime.trace_id"] = _bounded(trace_id)
+    if reason:
+        attrs["langfuse.observation.metadata.reason_code"] = _bounded(reason, limit=_MAX_REASON_VALUE)
+        attrs["agent_bom.runtime.reason"] = _bounded(reason, limit=_MAX_REASON_VALUE)
+    if argument_keys:
+        attrs["agent_bom.runtime.argument_keys"] = argument_keys
+        attrs["agent_bom.runtime.argument_fingerprint"] = _arguments_fingerprint(arguments)
+    return attrs
+
+
+def set_langfuse_runtime_attributes(span: Any, **kwargs: Any) -> None:
+    """Set redaction-safe Langfuse attributes on an OpenTelemetry span."""
+    if span is None:
+        return
+    for key, value in langfuse_runtime_attributes(**kwargs).items():
+        span.set_attribute(key, value)

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -41,6 +41,7 @@ from agent_bom.api.tracing import (
     parse_tracestate,
 )
 from agent_bom.async_stdin import create_async_stdin_reader, read_async_stdin_line
+from agent_bom.langfuse_otel import set_langfuse_runtime_attributes
 from agent_bom.proxy_sandbox import SandboxConfig, build_sandboxed_command
 from agent_bom.proxy_scanner import ScanConfig, load_scan_config, scan_tool_call, scan_tool_response
 from agent_bom.security import validate_arguments, validate_command
@@ -1061,6 +1062,17 @@ async def _proxy_sse_server(
                             span.set_attribute("agent_bom.proxy.subject", tool_name)
                             span.set_attribute("agent_bom.proxy.method", msg.get("method", "unknown"))
                             span.set_attribute("agent_bom.proxy.call_counter", call_counter)
+                            set_langfuse_runtime_attributes(
+                                span,
+                                surface="proxy",
+                                tenant_id=control_plane_tenant_id,
+                                method=str(msg.get("method", "unknown")),
+                                tool_name=tool_name,
+                                decision="allowed",
+                                agent_id=agent_id,
+                                trace_id=str(request_trace_meta.get("trace_id") or ""),
+                                arguments=arguments,
+                            )
                         forwarded_message = _inject_jsonrpc_trace_meta(
                             msg,
                             traceparent=request_trace_meta.get("traceparent"),
@@ -1812,7 +1824,19 @@ async def run_proxy(
                 if span is not None and msg is not None:
                     span.set_attribute("agent_bom.proxy.message_kind", msg.get("method", "unknown"))
                     if is_tools_call(msg):
-                        span.set_attribute("agent_bom.proxy.tool_name", extract_tool_name(msg) or "unknown")
+                        tool_name = extract_tool_name(msg) or "unknown"
+                        span.set_attribute("agent_bom.proxy.tool_name", tool_name)
+                        set_langfuse_runtime_attributes(
+                            span,
+                            surface="proxy",
+                            tenant_id=control_plane_tenant_id,
+                            method=str(msg.get("method", "unknown")),
+                            tool_name=tool_name,
+                            decision="allowed",
+                            agent_id=agent_id,
+                            trace_id=str(request_trace_meta.get("trace_id") or ""),
+                            arguments=extract_tool_arguments(msg),
+                        )
                 # Forward to server
                 if process.stdin:
                     if msg is not None:

--- a/tests/test_langfuse_otel.py
+++ b/tests/test_langfuse_otel.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from agent_bom.langfuse_otel import langfuse_runtime_attributes, set_langfuse_runtime_attributes
+
+
+class _Span:
+    def __init__(self) -> None:
+        self.attrs: dict[str, object] = {}
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attrs[key] = value
+
+
+def test_langfuse_runtime_attributes_emit_safe_trace_metadata() -> None:
+    attrs = langfuse_runtime_attributes(
+        surface="proxy",
+        tenant_id="tenant-a",
+        method="tools/call",
+        tool_name="read_file",
+        decision="allowed",
+        agent_id="agent-1",
+        trace_id="trace-1",
+        arguments={"path": "/tmp/report.txt", "api_token": "secret-value"},
+    )
+
+    assert attrs["langfuse.trace.name"] == "agent-bom.proxy"
+    assert attrs["langfuse.trace.metadata.tenant_id"] == "tenant-a"
+    assert attrs["langfuse.observation.metadata.tool"] == "read_file"
+    assert attrs["langfuse.observation.metadata.policy_decision"] == "allowed"
+    assert attrs["agent_bom.runtime.argument_count"] == 2
+    assert attrs["agent_bom.runtime.argument_keys"] == ["<redacted>", "path"]
+
+
+def test_langfuse_runtime_attributes_do_not_emit_raw_arguments() -> None:
+    attrs = langfuse_runtime_attributes(
+        surface="gateway",
+        tenant_id="tenant-a",
+        method="tools/call",
+        tool_name="query",
+        arguments={
+            "sql": "select * from private_table",
+            "password": "super-secret",
+            "nested": {"token": "nested-secret"},
+        },
+    )
+
+    rendered = repr(attrs)
+    assert "super-secret" not in rendered
+    assert "nested-secret" not in rendered
+    assert "select * from private_table" not in rendered
+    assert "langfuse.observation.input" not in attrs
+    assert "langfuse.observation.output" not in attrs
+
+
+def test_set_langfuse_runtime_attributes_sets_span_values() -> None:
+    span = _Span()
+
+    set_langfuse_runtime_attributes(
+        span,
+        surface="gateway",
+        tenant_id="default",
+        method="tools/call",
+        tool_name="web_search",
+        decision="blocked",
+        reason="blocked by read-only policy",
+        upstream="search",
+    )
+
+    assert span.attrs["langfuse.trace.name"] == "agent-bom.gateway"
+    assert span.attrs["langfuse.trace.metadata.upstream"] == "search"
+    assert span.attrs["langfuse.observation.metadata.reason_code"] == "blocked by read-only policy"


### PR DESCRIPTION
Summary
- add a redaction-safe Langfuse OTLP attribute profile for existing runtime proxy and gateway spans
- keep agent-bom's canonical security model primary while projecting safe `langfuse.*` and `agent_bom.runtime.*` metadata onto spans
- update observability docs to use the shipped `AGENT_BOM_OTEL_TRACES_*` env vars and clearly mark Langfuse scores/dataset replay/native import as roadmap

Verification
- uv run pytest tests/test_langfuse_otel.py tests/test_proxy.py::test_stitch_jsonrpc_trace_meta_prefers_upstream_response_values tests/test_gateway_server.py::test_relay_propagates_trace_context_to_headers_and_jsonrpc_meta -q
- uv run ruff check src/agent_bom/langfuse_otel.py src/agent_bom/proxy.py src/agent_bom/gateway_server.py tests/test_langfuse_otel.py
- uv run mypy src/agent_bom/langfuse_otel.py src/agent_bom/proxy.py src/agent_bom/gateway_server.py --ignore-missing-imports --disable-error-code import-untyped
- git diff --check

Refs #2619
