### PR TITLE
fix(cli): clarify optional runtime extras

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -63,6 +63,11 @@ pip install 'agent-bom[ui]'                      # once, if you want the dashboa
 agent-bom serve                                  # API + dashboard + graph explorer
 ```
 
+The base wheel is the scanner/CLI path. Install optional surfaces explicitly:
+`pip install 'agent-bom[mcp-server]'` for MCP server mode and
+`pip install 'agent-bom[ui]'` for the local API/dashboard process. If an extra
+is missing, the command exits with the matching install hint.
+
 Self-hosted pilot:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ agent-bom image nginx:latest                  # container image scan
 agent-bom iac Dockerfile k8s/ infra/main.tf   # IaC scan, optionally `--k8s-live`
 ```
 
+The base wheel is the scanner/CLI path. Install the optional runtime surfaces
+when you need them: `pip install 'agent-bom[mcp-server]'` for MCP server mode
+and `pip install 'agent-bom[ui]'` for the local API/dashboard process. Those
+commands fail fast with the same install hints if an extra is missing.
+
 Recommended pilot on one workstation:
 
 ```bash

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import ipaddress
 import os
 import ssl
@@ -12,6 +13,25 @@ from typing import Any, Optional
 import click
 
 from agent_bom.cli._common import LISTEN_PORT_RANGE
+
+
+def _require_optional_dependencies(command: str, extra: str, modules: dict[str, str]) -> None:
+    """Fail fast with an actionable install hint for optional runtime surfaces."""
+    missing = [label for label, module_name in modules.items() if importlib.util.find_spec(module_name) is None]
+    if not missing:
+        return
+    _fail_missing_optional_dependencies(command, extra, missing)
+
+
+def _fail_missing_optional_dependencies(command: str, extra: str, missing: list[str]) -> None:
+    """Print the shared optional-extra install hint and exit."""
+    missing_text = ", ".join(missing)
+    click.echo(
+        f"ERROR: {missing_text} required for `{command}`.\n"
+        f"Install with:  uv pip install 'agent-bom[{extra}]'  (or: pip install 'agent-bom[{extra}]')",
+        err=True,
+    )
+    sys.exit(1)
 
 
 def _is_loopback_host(host: str) -> bool:
@@ -339,16 +359,11 @@ def serve_cmd(
 
     setup_logging(level=log_level, json_output=log_json)
 
-    try:
-        import uvicorn  # noqa: F401
-    except ImportError:
-        click.echo(
-            "ERROR: FastAPI + Uvicorn are required for `agent-bom serve`.\n"
-            "Install them with:  uv pip install 'agent-bom[ui]'  "
-            "(or: pip install 'agent-bom[ui]')",
-            err=True,
-        )
-        sys.exit(1)
+    _require_optional_dependencies(
+        "agent-bom serve",
+        "ui",
+        {"FastAPI": "fastapi", "Uvicorn": "uvicorn"},
+    )
 
     import os as _os
 
@@ -396,7 +411,10 @@ def serve_cmd(
     ]
     _emit_runtime_summary("agent-bom serve", rows)
 
-    import uvicorn as _uvicorn
+    try:
+        import uvicorn as _uvicorn
+    except ImportError:
+        _fail_missing_optional_dependencies("agent-bom serve", "ui", ["Uvicorn"])
 
     _uvicorn.run(
         "agent_bom.api.server:app",
@@ -552,18 +570,18 @@ def api_cmd(
 
     setup_logging(level=log_level, json_output=log_json)
 
+    _require_optional_dependencies(
+        "agent-bom api",
+        "api",
+        {"FastAPI": "fastapi", "Uvicorn": "uvicorn"},
+    )
+
+    import os as _os
+
     try:
         import uvicorn
     except ImportError:
-        click.echo(
-            "ERROR: uvicorn is required for `agent-bom api`.\n"
-            "Install it with:  uv pip install 'agent-bom[api]'  "
-            "(or: pip install 'agent-bom[api]')",
-            err=True,
-        )
-        sys.exit(1)
-
-    import os as _os
+        _fail_missing_optional_dependencies("agent-bom api", "api", ["Uvicorn"])
 
     resolved_backend, resolved_url = _configure_analytics_backend(
         analytics_backend=analytics_backend,
@@ -730,14 +748,16 @@ def mcp_server_cmd(
 
     setup_logging(level=log_level, json_output=log_json)
 
+    _require_optional_dependencies(
+        "agent-bom mcp server",
+        "mcp-server",
+        {"MCP SDK": "mcp"},
+    )
+
     try:
         from agent_bom.mcp_server import create_mcp_server
     except ImportError:
-        click.echo(
-            "ERROR: mcp SDK is required for `agent-bom mcp server`.\nInstall it with:  pip install 'agent-bom[mcp-server]'",
-            err=True,
-        )
-        sys.exit(1)
+        _fail_missing_optional_dependencies("agent-bom mcp server", "mcp-server", ["MCP SDK"])
 
     if transport in ("sse", "streamable-http"):
         _enforce_remote_mcp_auth_defaults(host, bearer_token, allow_insecure_no_auth)

--- a/tests/test_cli_optional_extras.py
+++ b/tests/test_cli_optional_extras.py
@@ -1,0 +1,50 @@
+"""First-run checks for optional CLI runtime surfaces."""
+
+from __future__ import annotations
+
+import importlib.util
+
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+
+
+def _hide_module(monkeypatch, module_name: str) -> None:
+    original_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name: str, *args, **kwargs):
+        if name == module_name:
+            return None
+        return original_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+
+def test_api_missing_fastapi_prints_api_extra_hint(monkeypatch):
+    _hide_module(monkeypatch, "fastapi")
+
+    result = CliRunner().invoke(main, ["api"])
+
+    assert result.exit_code == 1
+    assert "FastAPI required for `agent-bom api`" in result.output
+    assert "pip install 'agent-bom[api]'" in result.output
+
+
+def test_serve_missing_uvicorn_prints_ui_extra_hint(monkeypatch):
+    _hide_module(monkeypatch, "uvicorn")
+
+    result = CliRunner().invoke(main, ["serve"])
+
+    assert result.exit_code == 1
+    assert "Uvicorn required for `agent-bom serve`" in result.output
+    assert "pip install 'agent-bom[ui]'" in result.output
+
+
+def test_mcp_server_missing_sdk_prints_mcp_extra_hint(monkeypatch):
+    _hide_module(monkeypatch, "mcp")
+
+    result = CliRunner().invoke(main, ["mcp", "server"])
+
+    assert result.exit_code == 1
+    assert "MCP SDK required for `agent-bom mcp server`" in result.output
+    assert "pip install 'agent-bom[mcp-server]'" in result.output


### PR DESCRIPTION
Summary
- fail fast when optional API/UI/MCP runtime dependencies are missing, including FastAPI as well as Uvicorn
- keep the same install hint when an optional dependency is present in metadata but fails during import
- add CLI smoke coverage for missing `[api]`, `[ui]`, and `[mcp-server]` extras
- clarify README/PyPI first-run docs that the base wheel is the scanner/CLI path and runtime surfaces are explicit extras

Verification
- uv run pytest tests/test_cli_server.py::test_api_cmd_missing_uvicorn tests/test_cli_server.py::test_serve_cmd_missing_uvicorn tests/test_cli_optional_extras.py -q
- uv run pytest tests/test_cli_optional_extras.py tests/test_cli_entry_points.py::TestAgentBom::test_backward_compat_mcp_group -q
- uv run ruff check src/agent_bom/cli/_server.py tests/test_cli_optional_extras.py tests/test_cli_server.py
- uv run mypy src/agent_bom/cli/_server.py
- python scripts/check_release_consistency.py
- git diff --check

Closes #2627