### PR TITLE
fix(cli): quiet doctor MCP discovery output

### DIFF
--- a/src/agent_bom/cli/_doctor.py
+++ b/src/agent_bom/cli/_doctor.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 import shutil
 import sys
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
 
 import click
 from rich.console import Console
@@ -90,10 +92,23 @@ def doctor_cmd() -> None:
     try:
         from agent_bom.discovery import discover_global_configs
 
-        configs = discover_global_configs()
-        runtime_checks.append(("MCP configs", f"{len(configs)} found", "ok" if configs else "info"))
+        with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+            configs = discover_global_configs(quiet=True)
+        server_count = sum(len(agent.mcp_servers) for agent in configs)
+        if configs:
+            client_names = ", ".join(agent.name for agent in configs[:3])
+            suffix = "" if len(configs) <= 3 else f", +{len(configs) - 3} more"
+            runtime_checks.append(
+                (
+                    "MCP discovery",
+                    f"{len(configs)} client config(s), {server_count} MCP server(s) ({client_names}{suffix})",
+                    "ok",
+                )
+            )
+        else:
+            runtime_checks.append(("MCP discovery", "0 client configs, 0 MCP servers", "info"))
     except Exception:
-        runtime_checks.append(("MCP configs", "discovery error", "warn"))
+        runtime_checks.append(("MCP discovery", "discovery error", "warn"))
 
     # API keys
     api_keys = {

--- a/src/agent_bom/discovery/__init__.py
+++ b/src/agent_bom/discovery/__init__.py
@@ -389,7 +389,7 @@ def detect_installed_agents(discovered_types: set[AgentType]) -> list[Agent]:
     return installed
 
 
-def discover_global_configs(agent_types: Optional[list[AgentType]] = None) -> list[Agent]:
+def discover_global_configs(agent_types: Optional[list[AgentType]] = None, *, quiet: bool = False) -> list[Agent]:
     """Discover all global MCP client configurations."""
     agents: list[Agent] = []
     sys_platform = get_platform()
@@ -466,12 +466,14 @@ def discover_global_configs(agent_types: Optional[list[AgentType]] = None) -> li
                             mcp_servers=servers,
                         )
                         agents.append(agent)
-                        console.print(
-                            f"  [green]✓[/green] Found {_display_label(agent_type.value)} "
-                            f"with {len(servers)} MCP server(s): {_display_label(config_path)}"
-                        )
+                        if not quiet:
+                            console.print(
+                                f"  [green]✓[/green] Found {_display_label(agent_type.value)} "
+                                f"with {len(servers)} MCP server(s): {_display_label(config_path)}"
+                            )
                 except (json.JSONDecodeError, KeyError, TypeError, Exception) as e:
-                    console.print(f"  [yellow]⚠[/yellow] Error parsing {_display_label(config_path)}: {_display_label(e)}")
+                    if not quiet:
+                        console.print(f"  [yellow]⚠[/yellow] Error parsing {_display_label(config_path)}: {_display_label(e)}")
 
     return agents
 

--- a/tests/test_doctor_cli.py
+++ b/tests/test_doctor_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from click.testing import CliRunner
 
 from agent_bom.cli import main
+from agent_bom.models import Agent, AgentType, MCPServer
 
 
 def test_doctor_groups_output_and_shows_next_steps():
@@ -14,3 +15,43 @@ def test_doctor_groups_output_and_shows_next_steps():
     assert "Platform integrations" in result.output
     assert "Next commands" in result.output
     assert "agent-bom agents --demo --offline" in result.output
+
+
+def test_doctor_suppresses_raw_discovery_output(monkeypatch):
+    def noisy_discovery(*, quiet: bool = False):
+        assert quiet is True
+        print("raw discovery line before banner")
+        return [
+            Agent(
+                name="Claude Desktop",
+                agent_type=AgentType.CLAUDE_DESKTOP,
+                config_path="/tmp/claude.json",
+                mcp_servers=[MCPServer(name="filesystem"), MCPServer(name="git")],
+            )
+        ]
+
+    monkeypatch.setattr("agent_bom.discovery.discover_global_configs", noisy_discovery)
+
+    result = CliRunner().invoke(main, ["doctor"])
+
+    assert result.exit_code == 0
+    assert "raw discovery line before banner" not in result.output
+    assert "agent-bom doctor" in result.output
+    assert "MCP discovery" in result.output
+    assert "1 client config(s), 2 MCP server(s) (Claude Desktop)" in result.output
+
+
+def test_doctor_reports_mcp_discovery_error_without_raw_parser_line(monkeypatch):
+    def failing_discovery(*, quiet: bool = False):
+        assert quiet is True
+        print("raw parser warning")
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("agent_bom.discovery.discover_global_configs", failing_discovery)
+
+    result = CliRunner().invoke(main, ["doctor"])
+
+    assert result.exit_code == 0
+    assert "raw parser warning" not in result.output
+    assert "MCP discovery" in result.output
+    assert "discovery error" in result.output


### PR DESCRIPTION
Summary
- add quiet MCP config discovery support for doctor diagnostics
- capture accidental discovery stdout/stderr so the doctor banner remains the first visible output
- render a structured MCP discovery summary after the doctor header
- add CLI regression coverage for noisy discovery and discovery error handling

Verification
- uv run pytest -q tests/test_doctor_cli.py
- uv run ruff check src/agent_bom/cli/_doctor.py src/agent_bom/discovery/__init__.py tests/test_doctor_cli.py
- uv run mypy src/agent_bom/cli/_doctor.py src/agent_bom/discovery/__init__.py
- uv run agent-bom doctor
- git diff --check

Closes #2628