### PR TITLE
fix(intel): secure remote skill intel feeds

### DIFF
--- a/src/agent_bom/skill_intel.py
+++ b/src/agent_bom/skill_intel.py
@@ -7,9 +7,16 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from urllib.parse import urlparse
-from urllib.request import urlopen
 
+import httpx
+
+from agent_bom.http_client import _safe_url
+from agent_bom.security import SecurityError, validate_url
 from agent_bom.skill_bundles import SkillBundle
+
+_REMOTE_TIMEOUT_SECONDS = 5.0
+_MAX_REMOTE_FEED_BYTES = 1_000_000
+_JSON_CONTENT_TYPES = {"application/json", "text/json"}
 
 
 class ThreatIntelStatus(str, Enum):
@@ -51,17 +58,56 @@ def _provider_name(document: object, source: str) -> str:
         if isinstance(provider, str) and provider.strip():
             return provider.strip()
     parsed = urlparse(source)
-    if parsed.scheme in {"http", "https"} and parsed.netloc:
-        return parsed.netloc
+    if parsed.scheme in {"http", "https"} and parsed.hostname:
+        return parsed.hostname
     return Path(source).name or "threat-intel"
+
+
+def _is_json_content_type(content_type: str) -> bool:
+    media_type = content_type.split(";", 1)[0].strip().lower()
+    return media_type in _JSON_CONTENT_TYPES or media_type.endswith("+json")
+
+
+def _validate_remote_source(source: str) -> None:
+    parsed = urlparse(source)
+    if parsed.username or parsed.password:
+        raise SecurityError("Remote threat-intel feed URLs must not include credentials")
+    validate_url(source, allowed_schemes=("https",), allow_private=False)
+
+
+def _read_remote_json_bytes(source: str) -> bytes:
+    _validate_remote_source(source)
+    with httpx.Client(timeout=_REMOTE_TIMEOUT_SECONDS, follow_redirects=False, verify=True) as client:
+        with client.stream("GET", source, headers={"Accept": "application/json"}) as response:
+            response.raise_for_status()
+            content_type = response.headers.get("content-type", "")
+            if content_type and not _is_json_content_type(content_type):
+                raise ValueError("remote feed must return JSON content")
+            chunks: list[bytes] = []
+            total = 0
+            for chunk in response.iter_bytes():
+                total += len(chunk)
+                if total > _MAX_REMOTE_FEED_BYTES:
+                    raise ValueError("remote feed exceeds maximum size")
+                chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def _load_document(source: str) -> object:
     parsed = urlparse(source)
     if parsed.scheme in {"http", "https"}:
-        with urlopen(source, timeout=5) as response:  # nosec B310
-            return json.loads(response.read().decode("utf-8"))
+        return json.loads(_read_remote_json_bytes(source).decode("utf-8"))
     return json.loads(Path(source).read_text(encoding="utf-8"))
+
+
+def _lookup_failure_detail(source: str, exc: Exception) -> str:
+    parsed = urlparse(source)
+    if parsed.scheme in {"http", "https"}:
+        safe_source = _safe_url(source)
+        if isinstance(exc, SecurityError):
+            return f"remote feed rejected: {exc}"
+        return f"remote feed unavailable: {safe_source}"
+    return f"lookup failed: {exc}"
 
 
 def _iter_entries(document: object) -> list[dict[str, object]]:
@@ -116,7 +162,7 @@ def lookup_bundle_threat_intel(bundle: SkillBundle, source: str | None) -> Threa
             status=ThreatIntelStatus.UNAVAILABLE,
             source=source,
             matched=False,
-            detail=f"lookup failed: {exc}",
+            detail=_lookup_failure_detail(source, exc),
         )
 
     provider = _provider_name(document, source)

--- a/tests/test_skill_intel.py
+++ b/tests/test_skill_intel.py
@@ -1,0 +1,112 @@
+"""Regression tests for skill threat-intel feed loading."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+
+import pytest
+
+from agent_bom.skill_bundles import build_skill_bundle
+from agent_bom.skill_intel import (
+    ThreatIntelStatus,
+    _load_document,
+    _read_remote_json_bytes,
+    lookup_bundle_threat_intel,
+)
+
+
+class _FakeResponse:
+    def __init__(self, chunks: Iterable[bytes], *, content_type: str = "application/json") -> None:
+        self._chunks = list(chunks)
+        self.headers = {"content-type": content_type}
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_bytes(self) -> Iterable[bytes]:
+        return iter(self._chunks)
+
+
+class _FakeClient:
+    chunks: list[bytes] = [b'{"entries": []}']
+    content_type = "application/json"
+
+    def __init__(self, **_kwargs: object) -> None:
+        return None
+
+    def __enter__(self) -> _FakeClient:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def stream(self, *_args: object, **_kwargs: object) -> _FakeResponse:
+        return _FakeResponse(self.chunks, content_type=self.content_type)
+
+
+def test_remote_skill_intel_rejects_http_without_fetching(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text("# Skill\n\nStay read-only.\n")
+    bundle = build_skill_bundle(skill_file)
+
+    result = lookup_bundle_threat_intel(bundle, "http://user:secret@example.com/feed.json?token=abc")
+
+    assert result is not None
+    assert result.status == ThreatIntelStatus.UNAVAILABLE
+    assert result.provider == "example.com"
+    assert result.detail is not None
+    assert "remote feed rejected" in result.detail
+    assert "secret" not in result.detail
+    assert "token=abc" not in result.detail
+
+
+def test_remote_skill_intel_rejects_private_hosts_without_fetching(tmp_path):
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text("# Skill\n\nStay read-only.\n")
+    bundle = build_skill_bundle(skill_file)
+
+    result = lookup_bundle_threat_intel(bundle, "https://127.0.0.1/feed.json")
+
+    assert result is not None
+    assert result.status == ThreatIntelStatus.UNAVAILABLE
+    assert result.detail is not None
+    assert "remote feed rejected" in result.detail
+
+
+def test_remote_skill_intel_requires_json_content_type(monkeypatch):
+    monkeypatch.setattr("agent_bom.skill_intel.validate_url", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("agent_bom.skill_intel.httpx.Client", _FakeClient)
+    _FakeClient.content_type = "text/html"
+    _FakeClient.chunks = [b"<html></html>"]
+
+    with pytest.raises(ValueError, match="JSON content"):
+        _read_remote_json_bytes("https://example.com/feed.json")
+
+
+def test_remote_skill_intel_enforces_max_size(monkeypatch):
+    monkeypatch.setattr("agent_bom.skill_intel.validate_url", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("agent_bom.skill_intel.httpx.Client", _FakeClient)
+    _FakeClient.content_type = "application/json"
+    _FakeClient.chunks = [b"{" + (b'"a":' + b'"b"' * 600_000) + b"}"]
+
+    with pytest.raises(ValueError, match="maximum size"):
+        _read_remote_json_bytes("https://example.com/feed.json")
+
+
+def test_remote_skill_intel_loads_https_json(monkeypatch):
+    monkeypatch.setattr("agent_bom.skill_intel.validate_url", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("agent_bom.skill_intel.httpx.Client", _FakeClient)
+    _FakeClient.content_type = "application/vnd.agent-bom+json"
+    _FakeClient.chunks = [json.dumps({"provider": "fixture-feed", "entries": []}).encode()]
+
+    assert _load_document("https://example.com/feed.json") == {
+        "provider": "fixture-feed",
+        "entries": [],
+    }


### PR DESCRIPTION
Summary
- replace ad hoc urlopen skill intel loading with HTTPS-only remote feed validation
- reject URL credentials, private/internal hosts, non-JSON content types, and oversized remote feeds
- sanitize remote lookup failure details while preserving local JSON feed behavior

Verification
- uv run pytest tests/test_skill_intel.py tests/test_skills_service.py::test_scan_skill_targets_records_catalog_and_intel -q
- uv run ruff check src/agent_bom/skill_intel.py tests/test_skill_intel.py
- uv run mypy src/agent_bom/skill_intel.py
- git diff --check

Closes #2635