### PR TITLE
fix(secrets): reduce docs PII false positives

### DIFF
--- a/src/agent_bom/secret_scanner.py
+++ b/src/agent_bom/secret_scanner.py
@@ -112,6 +112,8 @@ _SCAN_FILENAMES = frozenset(
     }
 )
 
+_PII_SCAN_EXTENSIONS = frozenset({".env", ".yaml", ".yml", ".json", ".conf"})
+
 _MAX_FILE_SIZE = 1024 * 1024  # 1MB
 _MAX_FILES = 1000
 
@@ -254,8 +256,10 @@ def _scan_file(file_path: Path, rel_path: str) -> list[SecretFinding]:
                 )
                 break
 
-        # PII patterns (MEDIUM) — only in text/config files
-        if file_path.suffix in (".env", ".yaml", ".yml", ".json", ".txt", ".md", ".conf") or file_path.name in _SCAN_FILENAMES:
+        # PII patterns (MEDIUM) stay limited to structured config/secrets
+        # surfaces. Markdown/plain-text docs are still scanned for credentials
+        # above, but generic emails/IPs there are usually examples or contacts.
+        if file_path.suffix in _PII_SCAN_EXTENSIONS or file_path.name in _SCAN_FILENAMES:
             for name, pattern in PII_PATTERNS:
                 if pattern.search(line):
                     findings.append(

--- a/tests/test_secret_scanner.py
+++ b/tests/test_secret_scanner.py
@@ -36,6 +36,21 @@ def test_scan_secrets_detects_real_findings_and_skips_test_fixtures(tmp_path: Pa
     }
 
 
+def test_scan_secrets_suppresses_doc_pii_but_keeps_doc_credentials(tmp_path: Path):
+    doc_key = "sk-" + "proj-" + "abc123def456" + "ghi789jkl012" + "mno345pqr678stu"
+    (tmp_path / "README.md").write_text(
+        f'Contact security@example.com or test 192.168.1.10 in local docs.\nOPENAI_KEY = "{doc_key}"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "notes.txt").write_text("Email docs@example.com from 10.0.0.5.\n", encoding="utf-8")
+
+    result = scan_secrets(tmp_path)
+
+    findings = {(finding.file_path, finding.secret_type, finding.category) for finding in result.findings}
+    assert ("README.md", "OpenAI API Key", "credential") in findings
+    assert not any(finding.category == "pii" for finding in result.findings)
+
+
 def test_scan_secrets_warns_on_non_directory(tmp_path: Path):
     target = tmp_path / "not-a-dir.txt"
     target.write_text("hello", encoding="utf-8")


### PR DESCRIPTION
Summary
- keep credential and hardcoded-secret detection active for markdown and text files
- stop treating generic emails and IPs in README/docs/plain text as default PII findings
- add regression coverage proving docs PII is suppressed while doc credentials still fail

Verification
- uv run pytest tests/test_secret_scanner.py -q
- uv run ruff check src/agent_bom/secret_scanner.py tests/test_secret_scanner.py
- uv run mypy src/agent_bom/secret_scanner.py
- git diff --check

Closes #2625