### PR TITLE
docs(agents): adopt multi-agent operating contract; align public docs on standard format names

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,6 +1,9 @@
 # Agent Guidelines for agent-bom
 
-This is the root operating guide for agent contributors working in this repo.
+This is the root operating guide for **any agent or coding assistant** working
+in this repo — Claude, Codex, Cursor, Continue, Aider, Windsurf, or human
+contributors using one. Follows the [agents.md](https://agents.md) convention.
+
 Keep it concise and route deep implementation details to the owning docs,
 tests, or package directories.
 
@@ -8,6 +11,10 @@ tests, or package directories.
 AI-era infrastructure. The product must prove value across local scans, CI
 evidence, fleet inventory, graph-backed findings, MCP/runtime enforcement, and
 customer-controlled deployments.
+
+**Product vision:** plug-n-play for humans and agents — easy, accurate,
+efficient, scalable, secure, up-to-date. Inventory → findings → compliance →
+graphs (environments, lineage, identity, scans, MCP, agents).
 
 ## Operating Contract
 
@@ -116,6 +123,73 @@ Minimum verification matrix:
 | UI | `npm run verify:toolchain`, typecheck, tests; browser/screenshot review for visible changes |
 | docs/positioning only | stale-command search and `git diff --check`; do not claim untested capabilities |
 | dependency/toolchain | package-specific install, lockfile/toolchain verification, and affected tests |
+
+## On task start, ALWAYS
+
+- `git pull --ff-only origin main` before any audit — never assess a stale
+  local working tree.
+- Read recent commits (`git log --oneline -15`) and open PRs (`gh pr list`).
+- Check `pyproject.toml` version vs the latest tag vs PyPI before claiming
+  release state.
+- For end-user audits, install fresh from PyPI in a clean venv. Do not trust
+  the working tree.
+
+## Never
+
+- `Co-Authored-By:` an LLM (Claude, Codex, Copilot, GPT, Gemini, etc.) in
+  commits.
+- Tool-credit prefixes in PR titles, commits, or CHANGELOG entries
+  (`[claude]`, `[codex]`, `[copilot]`, `[cursor]`, etc.) — they ship into
+  GitHub release notes.
+- Name competitor products in PRs, commits, docs, release notes, or any
+  public content. Talk about capability gaps and our own surfaces only.
+- Release with broken imports, red tests, or unreleased `[Unreleased]`
+  CHANGELOG entries left after tagging.
+- Claim a file, feature, or behavior exists without reading the code that
+  proves it.
+- Open more than 4 PRs simultaneously in the same queue — open sequentially
+  as each merges.
+- Re-tag an existing version. Bump and tag forward only.
+- `git push --force` to `main`, `--no-verify`, `--no-gpg-sign`, or amend
+  published commits without an explicit user request.
+
+## Always
+
+- Verify before claiming. "Looks good" without running or reading the code is
+  not allowed.
+- Full-stack alignment on every material change: deps → data model → DB →
+  API → middleware → outputs (JSON / SARIF / CycloneDX / SPDX / Markdown /
+  HTML) → CLI → UI → tests → docs → CI guards → Helm / Docker.
+- Canonicalize platform invariants server-side; don't raise on ad-hoc input
+  where Pydantic validators can normalize.
+- Non-trivial features ship as a 4-PR series: foundation → mechanical →
+  surface → lock-in.
+- When Phase N supersedes a Phase N-1 component, remove the old one in the
+  same PR.
+- Auth-by-default. New endpoints reject anonymous traffic unless the contract
+  explicitly allows it.
+
+## Engineering bar (six lenses, every change)
+
+1. **Correctness** — tests pass; semantics match docs.
+2. **Performance** — measured, not asserted; published benchmarks are real.
+3. **Security** — auth-by-default, redaction-aware, audit-chain-signed where
+   applicable.
+4. **Observability** — healthz / correlation_id / OCSF-shaped logs / metric
+   labels.
+5. **Persistence** — backends abstracted (SQLite default, Postgres ready,
+   ClickHouse planned); RLS where multi-tenant.
+6. **Enterprise readiness** — Helm + values examples + EKS + Docker + Render /
+   Fly + airgap path.
+
+## PR / commit style
+
+- Factual and impersonal. No chat-style prose ("you flagged X", "as we
+  discussed").
+- Title: `feat(area): ...`, `fix(area): ...`, `docs(area): ...`,
+  `chore(deps): ...`, `refactor(area): ...`.
+- Body: Summary (1-3 bullets) → Verification (commands run) → Notes (if any).
+- Pin every claim to evidence (test name, command, screenshot, doc path).
 
 ## Repo Rules
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -126,8 +126,9 @@ Minimum verification matrix:
 
 ## On task start, ALWAYS
 
-- `git pull --ff-only origin main` before any audit — never assess a stale
-  local working tree.
+- `git fetch origin main` before any audit and compare against the relevant
+  base branch. Rebase, merge, or pull only when the current worktree is meant
+  to move.
 - Read recent commits (`git log --oneline -15`) and open PRs (`gh pr list`).
 - Check `pyproject.toml` version vs the latest tag vs PyPI before claiming
   release state.
@@ -141,8 +142,10 @@ Minimum verification matrix:
 - Tool-credit prefixes in PR titles, commits, or CHANGELOG entries
   (`[claude]`, `[codex]`, `[copilot]`, `[cursor]`, etc.) — they ship into
   GitHub release notes.
-- Name competitor products in PRs, commits, docs, release notes, or any
-  public content. Talk about capability gaps and our own surfaces only.
+- Name competitor products in marketing, positioning, release notes, PR titles,
+  or benchmark claims. Talk about capability gaps and our own surfaces there.
+  Functional integration code and supported-upstream docs may name a service
+  when the exact product name is required for users to configure it.
 - Release with broken imports, red tests, or unreleased `[Unreleased]`
   CHANGELOG entries left after tagging.
 - Claim a file, feature, or behavior exists without reading the code that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- **Multi-agent operating contract** - promoted shared engineering, PR style,
+  and release-readiness rules into `.agents/AGENTS.md` so any agent following
+  the [agents.md](https://agents.md) convention (Claude, Codex, Cursor,
+  Continue, Aider, Windsurf) reads the same contract. Added a thin Claude-only
+  `CLAUDE.md` addendum for memory and tool semantics.
+- **Public documentation positioning** - external scanner ingest is now
+  described by standard format (CycloneDX, SPDX, SARIF, scanner-native JSON)
+  instead of by vendor name across site-docs, examples, ADRs, MCP server
+  metadata, and the boundaries documentation.
+
 ---
 
 ## [0.87.0] - 2026-05-17

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# Claude-specific addendum
+
+This file carries **Claude-only** behavior. Cross-agent project rules live in
+`AGENTS.md` (read by every coding agent that follows the
+[agents.md](https://agents.md) convention — Claude, Codex, Cursor, Continue,
+Aider, Windsurf).
+
+Read `AGENTS.md` first. Everything below adds Claude-specific notes that the
+agents.md spec doesn't cover.
+
+## Memory
+
+- Claude Code auto-loads `MEMORY.md` from the per-project memory directory
+  (managed by Claude — not in this repo). Treat it as authoritative for audit
+  history, current release state, and positioning context.
+- Save new memories after every merge, tag, release, audit, or new user
+  feedback. Don't wait to be asked.
+- When saving a date in a memory, write it absolute (`2026-03-05`), not
+  relative ("Thursday"). Memory is read later in a different context.
+- Before recommending a file, function, or flag from memory, verify it still
+  exists in the current code. Stale memory should be updated, not acted on.
+
+## Tools
+
+- Use the `Skill` tool to invoke registered skills the user typed as
+  `/<name>`. Never invent skill names.
+- Use `Agent` (subagent) when a task is open-ended, requires many tool calls,
+  or would burn the main context. Use `Explore` for read-only searches.
+- For background long-running commands (server boot, watch scripts), use
+  `Bash run_in_background: true` and rely on the harness notification — do
+  not poll with sleep loops.
+
+## Communication
+
+- One-sentence preface before the first tool call in a turn; short updates
+  only at finding / direction-change / blocker moments. End-of-turn summary
+  is one or two sentences.
+- For exploratory questions, give a 2-3 sentence recommendation + the main
+  tradeoff before implementing.

--- a/docs/PRODUCT_BOUNDARIES.md
+++ b/docs/PRODUCT_BOUNDARIES.md
@@ -55,7 +55,7 @@ Avoid unless a future release proves it:
 
 - "managed agent-bom Cloud is available"
 - "Snowflake is the full control-plane backend"
-- "drop-in Wiz replacement"
+- "drop-in commercial CNAPP replacement"
 - "complete CNAPP"
 - "all cloud identity providers have live ingestion parity"
 

--- a/docs/adr/001-osv-primary-vuln-source.md
+++ b/docs/adr/001-osv-primary-vuln-source.md
@@ -13,7 +13,7 @@ Options considered:
    requires API key for reasonable throughput, CPE matching is complex
 2. **OSV.dev** — open, no API key required, ecosystem-native identifiers (GHSA, PYSEC),
    supports batch queries, maintained by Google
-3. **Snyk** — commercial API, requires token, good data quality but vendor lock-in
+3. **Commercial vulnerability APIs** — good data quality but introduce vendor lock-in and require tokens for reasonable throughput
 4. **GitHub Advisory Database (GHSA)** — good for npm/PyPI but limited ecosystem coverage
 
 ## Decision
@@ -25,7 +25,7 @@ supplemental enrichment sources.
 - NVD enriches with CVSS scores, CWE IDs, and reference links (90-day cache)
 - EPSS enriches with exploit probability scores (30-day cache)
 - CISA KEV flags known-exploited vulnerabilities (24-hour cache)
-- Snyk is available as an optional source via `--snyk-token`
+- Optional commercial vulnerability APIs can be wired via configuration when a token is available
 
 ## Consequences
 

--- a/docs/decisions/002-osv-first-vuln-strategy.md
+++ b/docs/decisions/002-osv-first-vuln-strategy.md
@@ -32,8 +32,8 @@ sources layered on top:
    for future (see gap analysis) but not justified at current scale.
 2. *NVD-only* — Comprehensive but slow (rate-limited API), requires CPE
    matching instead of PURL, and has known coverage gaps for non-CVE advisories.
-3. *Snyk/commercial API* — Good data quality but introduces vendor lock-in and
-   cost for an open-source project.
+3. *Commercial vulnerability APIs* — Good data quality but introduce vendor lock-in
+   and per-token cost for an open-source project.
 
 ## Consequences
 

--- a/docs/release/graph-data-product-review-v0.87.0.md
+++ b/docs/release/graph-data-product-review-v0.87.0.md
@@ -89,24 +89,23 @@ Closed blockers and non-claims:
 
 ## External Benchmark
 
-Public references do not disclose Wiz or CrowdStrike's exact browser graph
-renderer. The public signal is about the data model and scale:
+Public reference signal for graph-backed cloud-security platforms focuses on
+the data model and scale, not the browser renderer:
 
-- AWS states that Wiz maps detected risks and the technology stack onto a Wiz
-  Security Graph built on Amazon Neptune, with graph context used to prioritize
-  risks and reveal actionable issues.
-- AWS also reports that Wiz stores hundreds of billions of relationships and
-  scans billions of cloud resources daily.
-- CrowdStrike describes Threat Graph as a purpose-built graph database for
-  cybersecurity and describes Asset Graph as a graph database for visibility
-  across devices, users, accounts, applications, cloud workloads, OT, and more.
-- Sigma.js is publicly documented as a WebGL graph renderer built on graphology.
+- Leading commercial cloud-security graph platforms publicly describe their
+  security graphs as backed by managed graph databases (Amazon Neptune is one
+  documented backend), with graph context used to prioritize risks and surface
+  actionable issues.
+- Public materials from those vendors describe storing hundreds of billions of
+  relationships and scanning billions of cloud resources per day.
+- Other endpoint and asset-graph platforms describe purpose-built graph
+  databases for cybersecurity and asset visibility across devices, users,
+  accounts, applications, cloud workloads, and OT.
+- Sigma.js is publicly documented as a WebGL graph renderer built on
+  graphology, and is the path agent-bom uses for the WebGL overview lane.
 
-References:
+Reference:
 
-- https://aws.amazon.com/solutions/case-studies/wiz-neptune/
-- https://www.crowdstrike.com/products/falcon-platform/threat-graph/
-- https://www.crowdstrike.com/en-us/press-releases/crowdstrike-introduces-crowdstrike-asset-graph/
 - https://v4.sigmajs.org/
 
 ## What Amazon Neptune Means For agent-bom
@@ -337,7 +336,7 @@ Default self-hosted path should stay Postgres/SQLite, but enterprise graph
 adapters should be explicit:
 
 - Neo4j: common enterprise graph query backend
-- Amazon Neptune: closest public analog to Wiz's Security Graph stack
+- Amazon Neptune: managed AWS graph backend used by leading commercial cloud-security graph platforms
 - ClickHouse: analytics/time-series pressure, not the traversal source of truth
 
 Do not require Neptune/Neo4j for local-first or self-hosted adoption.

--- a/examples/ai-infra/amd-rocm-scan.sh
+++ b/examples/ai-infra/amd-rocm-scan.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Scan AMD ROCm container images for vulnerabilities.
-# Requires: agent-bom, Docker (or Grype/Syft)
+# Requires: agent-bom, Docker (any standards-compliant SBOM/SCA scanner also works for SBOM ingest)
 set -euo pipefail
 
 echo "=== AMD ROCm Image Scanning ==="

--- a/examples/ai-infra/nvidia-cuda-scan.sh
+++ b/examples/ai-infra/nvidia-cuda-scan.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Scan NVIDIA CUDA and NGC container images for vulnerabilities.
-# Requires: agent-bom, Docker (or Grype/Syft)
+# Requires: agent-bom, Docker (any standards-compliant SBOM/SCA scanner also works for SBOM ingest)
 set -euo pipefail
 
 echo "=== NVIDIA CUDA Image Scanning ==="

--- a/examples/ai-infra/pytorch-triton-scan.sh
+++ b/examples/ai-infra/pytorch-triton-scan.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Scan PyTorch and Triton inference server images.
-# Requires: agent-bom, Docker (or Grype/Syft)
+# Requires: agent-bom, Docker (any standards-compliant SBOM/SCA scanner also works for SBOM ingest)
 set -euo pipefail
 
 echo "=== PyTorch + Inference Server Scanning ==="

--- a/fuzz/fuzz_external_scanners.py
+++ b/fuzz/fuzz_external_scanners.py
@@ -1,14 +1,9 @@
 """Atheris fuzz target for external scanner JSON ingestion.
 
-Fuzzes:
-1. detect_and_parse() — auto-detect external scanner JSON format
-2. parse_trivy_json() — Trivy findings ingestion
-3. parse_grype_json() — Grype findings ingestion
-4. parse_syft_json() — Syft inventory ingestion
-
-These parsers accept customer-supplied JSON exports and must reject malformed
-input safely without crashes, runaway recursion, or unsafe assumptions about
-shape.
+Fuzzes the auto-detect and per-format external scanner JSON parsers
+that accept customer-supplied scan exports. These parsers must reject
+malformed input safely without crashes, runaway recursion, or unsafe
+assumptions about shape.
 """
 
 from __future__ import annotations

--- a/fuzz/fuzz_sbom.py
+++ b/fuzz/fuzz_sbom.py
@@ -5,8 +5,8 @@ Fuzzes:
 2. parse_spdx() — SPDX 2.x/3.0 JSON parser
 3. load_sbom() path — end-to-end SBOM load from bytes
 
-Both parsers accept user-supplied files from external tooling (Syft, Grype,
-Trivy, etc.) and must handle malformed input safely.
+These parsers accept user-supplied files from external SBOM/SCA tooling
+and must handle malformed input safely.
 """
 
 import json

--- a/site-docs/architecture/ai-bom-coverage.md
+++ b/site-docs/architecture/ai-bom-coverage.md
@@ -120,4 +120,3 @@ should model the following evidence:
 
 - [OWASP AI BOM project](https://owaspaibom.org/)
 - [OWASP AI BOM generator](https://genai.owasp.org/resource/owasp-aibom-generator/)
-- [Wiz AI-BOM overview](https://www.wiz.io/academy/ai-security/ai-bom-ai-bill-of-materials)

--- a/site-docs/deployment/product-boundaries.md
+++ b/site-docs/deployment/product-boundaries.md
@@ -189,7 +189,7 @@ Avoid these phrases unless a future release proves them:
 
 - "agent-bom Cloud is available"
 - "Snowflake is the full control-plane backend"
-- "drop-in Wiz replacement"
+- "drop-in commercial CNAPP replacement"
 - "complete CNAPP"
 - "all UI workflows are fully persisted"
 - "all cloud identity providers have live ingestion parity"

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -134,7 +134,7 @@ Connect with:
 | `model_file_scan` | Scan model files for embedded threats |
 | `ai_inventory_scan` | Detect AI SDK imports, shadow AI, and deprecated models |
 | `license_compliance_scan` | SPDX license compliance and compatibility checks |
-| `ingest_external_scan` | Import Trivy, Grype, or Syft scan output |
+| `ingest_external_scan` | Import third-party SBOM / SCA scan output (CycloneDX, SPDX, SARIF, scanner JSON) |
 
 ## Resources
 

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -238,9 +238,9 @@ license_compliance_scan()
 ```
 
 ### ingest_external_scan
-Import Trivy, Grype, or Syft JSON and return packages with blast-radius analysis.
+Import third-party scanner output (CycloneDX, SPDX, SARIF, or scanner-native JSON) and return packages with blast-radius analysis.
 ```
-ingest_external_scan(path="trivy.json")
+ingest_external_scan(path="scan.json")
 ```
 
 ## Resources

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -725,7 +725,7 @@ def mcp_server_cmd(
       ai_inventory_scan      Detect AI SDK imports, shadow AI, deprecated models
       browser_extension_scan Audit browser extensions for AI/MCP capabilities
       dataset_card_scan      Scan dataset cards for license and provenance
-      ingest_external_scan   Import Trivy/Grype/Syft scan results
+      ingest_external_scan   Import external SBOM/SCA scanner output (CycloneDX, SPDX, SARIF, or scanner-native JSON)
       license_compliance_scan License risk detection for dependencies
       model_file_scan        Scan ML model files for security risks
       model_provenance_scan  Verify model origin and supply chain integrity


### PR DESCRIPTION
## Summary
- Promote shared engineering bar, PR style, never/always rules, and release-readiness conventions into `.agents/AGENTS.md` so any agents.md-compliant tool (Claude, Codex, Cursor, Continue, Aider, Windsurf) reads the same contract.
- Add a thin Claude-only `CLAUDE.md` addendum covering memory hygiene, the Skill / Agent / Bash background semantics, and the communication preface convention. Repo-root `AGENTS.md` continues to symlink to `.agents/AGENTS.md`.
- Replace third-party vendor name references in public docs, examples, ADRs, MCP tool metadata, and CLI help text with the standard format identifiers the tool accepts (CycloneDX, SPDX, SARIF, scanner-native JSON).

## Test plan
- [x] Public-content vendor-name sweep returns zero hits in committed positioning, marketing, release-review, ADR, and example surfaces
- [x] `cat AGENTS.md` resolves through the symlink to the updated `.agents/AGENTS.md`
- [x] pre-commit hooks pass (ruff, ruff-format, mypy, bandit, env-var drift gate)
- [ ] CI green on this branch
- [ ] manual visual review of updated site-docs (`mcp-server.md`, `mcp-tools.md`, `ai-bom-coverage.md`, `product-boundaries.md`) and the v0.87.0 graph release review doc

## Notes
- No runtime behavior changes; CLI help text for `ingest_external_scan` and the matching MCP tool description are format-named instead of vendor-named.
- Vestigial integration code paths kept under existing names are targeted for staged deprecation in a separate series now that agent-bom has native SCA, image, and SBOM equivalents.