### PR TITLE
fix(intel): harden GHSA NVD sync coverage

### DIFF
--- a/src/agent_bom/cli/_db.py
+++ b/src/agent_bom/cli/_db.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import click
 
 from agent_bom.cli._grouped_help import SuggestingGroup
+from agent_bom.db.sync import GHSA_ECOSYSTEMS
 
 
 @click.group("db", cls=SuggestingGroup)
@@ -56,7 +57,7 @@ def db_cmd() -> None:
     "--ghsa-ecosystems",
     "ghsa_ecosystems",
     multiple=True,
-    type=click.Choice(["pip", "npm", "go", "maven", "nuget", "rubygems", "cargo"], case_sensitive=False),
+    type=click.Choice(GHSA_ECOSYSTEMS, case_sensitive=False),
     help="Filter GHSA sync to specific ecosystems (default: all). Repeatable.",
 )
 def db_update(
@@ -71,7 +72,8 @@ def db_update(
 
     Pulls from OSV.dev (bulk export), Alpine secdb, FIRST EPSS scores, and CISA KEV catalog by default.
     Pass --source ghsa to also fetch GitHub Security Advisories across all supported
-    ecosystems (pip, npm, go, maven, nuget, rubygems, cargo).
+    ecosystems (pip, npm, go, maven, nuget, rubygems, cargo, composer, swift,
+    pub, erlang, actions).
     Pass --source nvd to enrich CVEs missing CVSS data from the NVD API (requires NVD_API_KEY
     for reasonable speed; without a key the rate limit is 5 req/30s).
 
@@ -156,8 +158,13 @@ def db_status(db_path: str | None) -> None:
         table.add_column("Source")
         table.add_column("Last synced")
         table.add_column("Records", justify="right")
+        table.add_column("Coverage")
         for src, info in sorted(meta.items()):
-            table.add_row(src, info.get("last_synced") or "—", f"{info.get('count', 0):,}")
+            metadata = info.get("metadata") or {}
+            coverage = str(metadata.get("coverage") or metadata.get("mode") or "—")
+            if metadata.get("cap_hit"):
+                coverage = f"{coverage} [yellow](cap hit)[/yellow]"
+            table.add_row(src, info.get("last_synced") or "—", f"{info.get('count', 0):,}", coverage)
         con.print(table)
     else:
         con.print("  [yellow]No sync data — run agent-bom db update to populate.[/yellow]")

--- a/src/agent_bom/db/schema.py
+++ b/src/agent_bom/db/schema.py
@@ -10,6 +10,7 @@ Tables:
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import sqlite3
@@ -63,7 +64,7 @@ def _validated_db_path(raw: str) -> Path:
 DB_PATH: Path = _validated_db_path(_RAW_DB_PATH)
 
 # Schema version — bump when DDL changes incompatibly
-_SCHEMA_VERSION = 3
+_SCHEMA_VERSION = 4
 
 # Migration scripts: list of (from_version, to_version, sql) tuples.
 # Add a new entry here whenever _SCHEMA_VERSION is bumped.
@@ -71,6 +72,7 @@ _SCHEMA_VERSION = 3
 _MIGRATIONS: list[tuple[int, int, str]] = [
     (1, 2, "ALTER TABLE vulns ADD COLUMN cwe_ids TEXT DEFAULT '';"),
     (2, 3, "ALTER TABLE vulns ADD COLUMN aliases TEXT DEFAULT '';"),
+    (3, 4, "ALTER TABLE sync_meta ADD COLUMN metadata_json TEXT DEFAULT '';"),
 ]
 
 _DDL = """
@@ -125,7 +127,8 @@ CREATE TABLE IF NOT EXISTS kev_entries (
 CREATE TABLE IF NOT EXISTS sync_meta (
     source          TEXT PRIMARY KEY,   -- osv | epss | kev
     last_synced     TEXT,               -- ISO-8601 UTC
-    record_count    INTEGER DEFAULT 0
+    record_count    INTEGER DEFAULT 0,
+    metadata_json   TEXT DEFAULT ''     -- source-specific coverage/freshness details
 );
 """
 
@@ -286,6 +289,17 @@ def db_stats(conn: sqlite3.Connection) -> dict:
     stats["affected_count"] = conn.execute("SELECT COUNT(*) FROM affected").fetchone()[0]
     stats["epss_count"] = conn.execute("SELECT COUNT(*) FROM epss_scores").fetchone()[0]
     stats["kev_count"] = conn.execute("SELECT COUNT(*) FROM kev_entries").fetchone()[0]
-    rows = conn.execute("SELECT source, last_synced, record_count FROM sync_meta").fetchall()
-    stats["sync_meta"] = {r["source"]: {"last_synced": r["last_synced"], "count": r["record_count"]} for r in rows}
+    columns = {row["name"] for row in conn.execute("PRAGMA table_info(sync_meta)").fetchall()}
+    if "metadata_json" in columns:
+        rows = conn.execute("SELECT source, last_synced, record_count, metadata_json FROM sync_meta").fetchall()
+    else:
+        rows = conn.execute("SELECT source, last_synced, record_count, '' AS metadata_json FROM sync_meta").fetchall()
+    stats["sync_meta"] = {
+        r["source"]: {
+            "last_synced": r["last_synced"],
+            "count": r["record_count"],
+            "metadata": json.loads(r["metadata_json"] or "{}"),
+        }
+        for r in rows
+    }
     return stats

--- a/src/agent_bom/db/sync.py
+++ b/src/agent_bom/db/sync.py
@@ -955,7 +955,11 @@ def sync_ghsa(
     _validate_sync_url(base_url, "ghsa url")
 
     token = github_token or os.environ.get("GITHUB_TOKEN")
-    target_ecosystems = ecosystems or list(GHSA_ECOSYSTEMS)
+    target_ecosystems = [ecosystem.lower() for ecosystem in (ecosystems or list(GHSA_ECOSYSTEMS))]
+    unsupported = sorted(set(target_ecosystems) - set(GHSA_ECOSYSTEMS))
+    if unsupported:
+        supported = ", ".join(GHSA_ECOSYSTEMS)
+        raise ValueError(f"Unsupported GHSA ecosystem(s): {', '.join(unsupported)}. Supported ecosystems: {supported}")
 
     _logger.info(
         "Fetching GHSA advisories from %s for ecosystems: %s",
@@ -969,8 +973,10 @@ def sync_ghsa(
 
     from agent_bom.package_utils import normalize_package_name
 
+    cap_hit = False
     for ecosystem in target_ecosystems:
         if count >= max_entries:
+            cap_hit = True
             break
 
         eco_count = 0
@@ -996,6 +1002,7 @@ def sync_ghsa(
 
             for advisory in advisories:
                 if count >= max_entries:
+                    cap_hit = True
                     break
 
                 if _ingest_ghsa_advisory(conn, advisory, normalize_package_name):
@@ -1015,7 +1022,23 @@ def sync_ghsa(
         eco_counts[ecosystem] = eco_count
 
     conn.commit()
-    _update_sync_meta(conn, "ghsa", count)
+    _update_sync_meta(
+        conn,
+        "ghsa",
+        count,
+        {
+            "ecosystems_requested": target_ecosystems,
+            "ecosystem_counts": eco_counts,
+            "max_entries": max_entries,
+            "cap_hit": cap_hit,
+            "coverage": "truncated" if cap_hit else "complete_for_requested_pages",
+        },
+    )
+    if cap_hit:
+        _logger.warning(
+            "GHSA sync hit max_entries=%d; coverage is truncated. Increase --max-ghsa-entries for fuller coverage.",
+            max_entries,
+        )
     eco_summary = ", ".join(f"{e}={c}" for e, c in eco_counts.items() if c > 0)
     _logger.info(
         "GHSA sync complete: ingested %d advisories across %d ecosystems (%s)",
@@ -1072,6 +1095,13 @@ def sync_nvd(
     # Find CVE-backed rows in our DB that are missing CVSS data. Some OSV
     # distro advisories use IDs such as DEBIAN-CVE-2014-6271 but still map to
     # the canonical CVE in aliases or in the ID suffix.
+    total_candidates = conn.execute(
+        """
+        SELECT COUNT(*) FROM vulns
+        WHERE (severity = 'unknown' OR cvss_score IS NULL)
+          AND (id LIKE '%CVE-%' OR aliases LIKE '%CVE-%')
+        """
+    ).fetchone()[0]
     rows = conn.execute(
         """
         SELECT id, COALESCE(aliases, '') AS aliases FROM vulns
@@ -1090,7 +1120,18 @@ def sync_nvd(
 
     if not row_targets:
         _logger.info("NVD enrichment: no CVEs missing CVSS data — nothing to do")
-        _update_sync_meta(conn, "nvd", 0)
+        _update_sync_meta(
+            conn,
+            "nvd",
+            0,
+            {
+                "mode": "enrichment_only",
+                "candidate_rows": total_candidates,
+                "selected_rows": 0,
+                "max_entries": max_entries,
+                "cap_hit": total_candidates > max_entries,
+            },
+        )
         return 0
 
     _logger.info("NVD enrichment: fetching CVSS data for %d CVE-backed rows …", len(row_targets))
@@ -1190,7 +1231,18 @@ def sync_nvd(
         time.sleep(sleep_seconds)
 
     conn.commit()
-    _update_sync_meta(conn, "nvd", enriched)
+    _update_sync_meta(
+        conn,
+        "nvd",
+        enriched,
+        {
+            "mode": "enrichment_only",
+            "candidate_rows": total_candidates,
+            "selected_rows": len(row_targets),
+            "max_entries": max_entries,
+            "cap_hit": total_candidates > max_entries,
+        },
+    )
     _logger.info("NVD enrichment complete: %d CVEs updated", enriched)
     return enriched
 
@@ -1200,11 +1252,22 @@ def sync_nvd(
 # ---------------------------------------------------------------------------
 
 
-def _update_sync_meta(conn: sqlite3.Connection, source: str, count: int) -> None:
-    conn.execute(
-        "INSERT OR REPLACE INTO sync_meta(source, last_synced, record_count) VALUES (?, ?, ?)",
-        (source, _now_utc(), count),
-    )
+def _sync_meta_has_metadata_column(conn: sqlite3.Connection) -> bool:
+    return any(row[1] == "metadata_json" for row in conn.execute("PRAGMA table_info(sync_meta)").fetchall())
+
+
+def _update_sync_meta(conn: sqlite3.Connection, source: str, count: int, metadata: dict[str, Any] | None = None) -> None:
+    metadata_json = json.dumps(metadata or {}, sort_keys=True, separators=(",", ":"))
+    if _sync_meta_has_metadata_column(conn):
+        conn.execute(
+            "INSERT OR REPLACE INTO sync_meta(source, last_synced, record_count, metadata_json) VALUES (?, ?, ?, ?)",
+            (source, _now_utc(), count, metadata_json),
+        )
+    else:
+        conn.execute(
+            "INSERT OR REPLACE INTO sync_meta(source, last_synced, record_count) VALUES (?, ?, ?)",
+            (source, _now_utc(), count),
+        )
     conn.commit()
 
 

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -1147,6 +1147,16 @@ def test_db_update_single_source(tmp_path):
     assert mock_sync.call_args[1]["sources"] == ["epss"]
 
 
+def test_db_update_ghsa_accepts_full_backend_ecosystem_set(tmp_path):
+    """CLI GHSA ecosystem choices should not lag behind the sync backend."""
+    db_path = str(tmp_path / "test.db")
+    with patch("agent_bom.db.sync.sync_db", return_value={"ghsa": 1}) as mock_sync:
+        result = _run(["db", "update", "--source", "ghsa", "--ghsa-ecosystems", "actions", "--path", db_path])
+
+    assert result.exit_code == 0
+    assert mock_sync.call_args[1]["ghsa_ecosystems"] == ["actions"]
+
+
 # ---------------------------------------------------------------------------
 # check / verify / where CLI commands (quick smoke tests)
 # ---------------------------------------------------------------------------

--- a/tests/test_cwe_enrichment.py
+++ b/tests/test_cwe_enrichment.py
@@ -408,6 +408,12 @@ def test_sync_nvd_stores_cwe_ids() -> None:
     row = conn.execute("SELECT cwe_ids FROM vulns WHERE id = 'CVE-2024-99010'").fetchone()
     cwes = set(row["cwe_ids"].split(","))
     assert cwes == {"CWE-79", "CWE-89"}
+    meta = conn.execute("SELECT metadata_json FROM sync_meta WHERE source='nvd'").fetchone()
+    assert meta is not None
+    details = json.loads(meta["metadata_json"])
+    assert details["mode"] == "enrichment_only"
+    assert details["candidate_rows"] == 1
+    assert details["selected_rows"] == 1
 
 
 def test_sync_nvd_derives_canonical_cve_for_debian_advisory() -> None:

--- a/tests/test_db_sync_ghsa.py
+++ b/tests/test_db_sync_ghsa.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -255,7 +256,7 @@ def test_sync_ghsa_ecosystem_filtering() -> None:
 def test_sync_ghsa_default_ecosystems() -> None:
     """When no ecosystems are specified, all GHSA_ECOSYSTEMS are used."""
     # Verify minimum required ecosystems are present (no hardcoded count)
-    required = {"pip", "npm", "go", "maven", "nuget", "rubygems", "cargo"}
+    required = {"pip", "npm", "go", "maven", "nuget", "rubygems", "cargo", "composer", "swift", "pub", "erlang", "actions"}
     assert required.issubset(set(GHSA_ECOSYSTEMS)), f"Missing: {required - set(GHSA_ECOSYSTEMS)}"
     assert len(GHSA_ECOSYSTEMS) >= len(required), "GHSA_ECOSYSTEMS shrunk below minimum"
     # No duplicates
@@ -283,3 +284,10 @@ def test_sync_ghsa_respects_max_entries() -> None:
         count = sync_ghsa(conn, url="https://api.github.com/advisories", max_entries=3, ecosystems=["pip"])
 
     assert count == 3
+    meta = conn.execute("SELECT metadata_json FROM sync_meta WHERE source='ghsa'").fetchone()
+    assert meta is not None
+    details = json.loads(meta["metadata_json"])
+    assert details["cap_hit"] is True
+    assert details["coverage"] == "truncated"
+    assert details["max_entries"] == 3
+    assert details["ecosystem_counts"] == {"pip": 3}


### PR DESCRIPTION
Summary
- expand GHSA sync coverage metadata so backend ecosystem support is visible and auditable
- add NVD/CWE sync metadata and DB schema handling for richer advisory provenance
- cover the GHSA full-backend CLI path and local DB stats with regression tests

Verification
- uv run pytest tests/test_db_sync_ghsa.py tests/test_cwe_enrichment.py::test_sync_nvd_stores_cwe_ids tests/test_cli_scan.py::test_db_update_ghsa_accepts_full_backend_ecosystem_set tests/test_local_vuln_db.py::test_db_stats_empty tests/test_local_vuln_db.py::test_db_stats_after_inserts -q
- uv run ruff check src/agent_bom/cli/_db.py src/agent_bom/db/schema.py src/agent_bom/db/sync.py tests/test_cli_scan.py tests/test_cwe_enrichment.py tests/test_db_sync_ghsa.py tests/test_local_vuln_db.py
- uv run mypy src/agent_bom/db/sync.py src/agent_bom/db/schema.py
- git diff --check origin/main...HEAD

Closes #2640
