### PR TITLE
feat(intel): add advisory lookup and package matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
   proxy/gateway traffic with tool-call volume, policy decision summaries,
   active runtime sources, freshness, and explicit retention posture without
   exposing raw prompts, arguments, responses, or credential values.
+- Threat-intel lookup and matching surfaces now expose local source freshness,
+  advisory lookup, and package/purl inventory matching over REST and MCP, with
+  canonical CVE/GHSA/OSV/CWE IDs plus evidence links.
 
 ### Changed
 - **Multi-agent operating contract** - promoted shared engineering, PR style,

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ dashboard-only workflow:
 |---|---|---|
 | **CLI / CI** | developers, release gates, automation | local scans, SARIF/SBOM/HTML/JSON output, deterministic exit codes |
 | **REST API** | security platforms, SIEM jobs, custom services | authenticated control plane routes for scans, normalized bulk findings, dataset versions, graph evidence, audit, and governance |
-| **MCP tools** | Claude, Cursor, Codex, Windsurf, Cortex, and custom agents | 38 read-only tools, strict arguments, `exposure_paths`, `should_i_deploy` |
+| **MCP tools** | Claude, Cursor, Codex, Windsurf, Cortex, and custom agents | 41 read-only tools, strict arguments, `exposure_paths`, `should_i_deploy` |
 | **TypeScript client** | services and agent runtimes calling the control plane | typed helper for stable REST endpoints; not a scanner SDK |
 | **TypeScript runtime detectors** | MCP/runtime enforcement integrations | local detector package for runtime policy checks; separate from the control-plane client |
 | **UI cockpit** | security teams, auditors, operators | graph cockpit, fleet, compliance, audit, and evidence review over the same backend data |
@@ -541,7 +541,7 @@ agent-bom
 | Browser UI image (`agentbom/agent-bom-ui`) | browser dashboard paired with the same API/control plane | `docker compose -f docker-compose.pilot.yml up -d` | dashboard at `http://localhost:3000` |
 | Kubernetes / Helm | self-hosted API + dashboard, scheduled discovery | `helm upgrade --install agent-bom deploy/helm/agent-bom --set controlPlane.enabled=true` | API, UI, jobs, optional gateway/proxy |
 | REST API (`agent-bom api` / `agent-bom serve`) | platform integration and self-hosted control plane | `agent-bom serve --port 8422 --persist jobs.db` | `/docs`, `/health`, `/v1/scan`, `/v1/fleet` |
-| MCP server (`agent-bom mcp server`) | Claude Desktop, Claude Code, Cursor, Codex, Windsurf, Cortex | `agent-bom mcp server` | 38 read-only MCP security tools |
+| MCP server (`agent-bom mcp server`) | Claude Desktop, Claude Code, Cursor, Codex, Windsurf, Cortex | `agent-bom mcp server` | 41 read-only MCP security tools |
 | Runtime proxy (`agent-bom proxy`) | MCP traffic enforcement | `agent-bom proxy --log audit.jsonl --block-undeclared -- ...` | audit JSONL, metrics, policy decisions |
 | Shield SDK (`from agent_bom.shield import Shield`) | in-process protection | `from agent_bom.shield import Shield` | allow/block decisions and redacted alerts |
 
@@ -552,7 +552,7 @@ see value and where enterprises wire agent-bom into existing controls.
 
 | Integration surface | Examples | What agent-bom does |
 |---|---|---|
-| MCP and coding agents | Claude Desktop / Code, Cursor, Windsurf, VS Code, Cortex Code, OpenAI Codex CLI | discovers configured MCP servers, exposes 38 read-only security tools, and returns findings to the assistant workflow |
+| MCP and coding agents | Claude Desktop / Code, Cursor, Windsurf, VS Code, Cortex Code, OpenAI Codex CLI | discovers configured MCP servers, exposes 41 read-only security tools, and returns findings to the assistant workflow |
 | Skills and plugins | OpenClaw skills, Cortex Code skill, MCP Registry, Smithery, Glama, Docker MCP registry | packages repeatable scan, compliance, registry, runtime, and Snowflake discovery workflows where agent users already work |
 | CI/CD and developer workflow | GitHub Action, SARIF, pre-install `check`, Docker, local CLI | blocks unsafe packages, uploads code-scanning evidence, and keeps SBOM/remediation output scriptable |
 | Cloud, warehouse, and AI infra | AWS, Azure, GCP, Snowflake, Databricks, CoreWeave, Nebius, Hugging Face, OpenAI, W&B, MLflow, Ollama | pulls read-only inventory and posture evidence with operator-controlled credentials |
@@ -689,7 +689,7 @@ see [GitHub Action SARIF troubleshooting](docs/GITHUB_ACTION_SARIF_TROUBLESHOOTI
 
 ## MCP server
 
-38 read-only security tools, 6 resources, and 6 workflow prompts available inside any MCP-compatible AI assistant:
+41 read-only security tools, 6 resources, and 6 workflow prompts available inside any MCP-compatible AI assistant:
 
 ```json
 {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -232,7 +232,7 @@ graph TB
 | Output | `src/agent_bom/output/__init__.py` | JSON, CycloneDX, SARIF, SPDX, console |
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine (17 conditions) |
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP proxy (7 inline detectors) |
-| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (38 tools) |
+| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (41 tools) |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse |
 | Asset Tracker | `src/agent_bom/asset_tracker.py` | Persistent vuln tracking — first_seen, resolved, MTTR |
 | Context Graph | `src/agent_bom/context_graph.py` | Lateral movement analysis — see [Graph Contract](graph/CONTRACT.md) for entity/edge coverage, accuracy guarantees, and scaling boundaries |

--- a/docs/CLAUDE_INTEGRATION.md
+++ b/docs/CLAUDE_INTEGRATION.md
@@ -59,7 +59,7 @@ claude mcp add agent-bom -- uvx agent-bom mcp server
 
 ## What users get inside Claude
 
-`agent-bom mcp server` exposes 38 read-only tools for:
+`agent-bom mcp server` exposes 41 read-only tools for:
 
 - agent and MCP discovery
 - package and registry checks

--- a/docs/CODEX_CLI.md
+++ b/docs/CODEX_CLI.md
@@ -20,7 +20,7 @@ command = "agent-bom"
 args = ["mcp", "server"]
 ```
 
-That makes the same 38 read-only `agent-bom` MCP tools available to Codex.
+That makes the same 41 read-only `agent-bom` MCP tools available to Codex.
 
 ## What agent-bom discovers for Codex
 

--- a/docs/CORTEX_CODE.md
+++ b/docs/CORTEX_CODE.md
@@ -41,7 +41,7 @@ Or, if `agent-bom` is already installed:
 }
 ```
 
-This makes the same 38 `agent-bom` MCP tools available in CoCo conversations.
+This makes the same 41 `agent-bom` MCP tools available in CoCo conversations.
 
 ## What agent-bom discovers for Cortex
 

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -150,7 +150,7 @@ An agent operating autonomously can be steered into a multi-step exfiltration se
 │  2. PROXY         Sits between client and server, intercepts     │
 │     (agent-bom proxy) every JSON-RPC message, enforces policy    │
 │                                                                  │
-│  3. MCP SERVER    Exposes 38 scan/governance tools to any agent  │
+│  3. MCP SERVER    Exposes 41 scan/governance tools to any agent  │
 │     (agent-bom mcp server)  — scan, check, registry, compliance  │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -210,7 +210,7 @@ For cross-agent correlation, use the broader runtime protection engine (`agent-b
 agent-bom mcp server
 ```
 
-Exposes 38 tools to any MCP-compatible AI assistant. Your agent can run scans, check packages, query ExposurePaths, ask for deploy decisions, query the registry, and generate compliance reports without leaving the chat:
+Exposes 41 tools to any MCP-compatible AI assistant. Your agent can run scans, check packages, query ExposurePaths, ask for deploy decisions, query threat intel, and generate compliance reports without leaving the chat:
 
 ```
 scan                — full discovery + scan, returns JSON report

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,6 +1,6 @@
 # MCP Server — Connect agent-bom to AI Assistants
 
-agent-bom exposes 38 security tools as an MCP server. Any MCP-compatible client
+agent-bom exposes 41 security tools as an MCP server. Any MCP-compatible client
 can connect and get vulnerability scanning, blast radius analysis, compliance
 checks, and supply chain verification through natural conversation.
 
@@ -56,7 +56,7 @@ Add to `~/.snowflake/cortex/mcp.json`:
 }
 ```
 
-CoCo can then call the same 38 `agent-bom` tools over MCP.
+CoCo can then call the same 41 `agent-bom` tools over MCP.
 
 agent-bom also discovers Cortex auxiliary security files alongside `mcp.json`:
 
@@ -155,7 +155,7 @@ agent-bom proxy-bootstrap \
 
 `proxy-configure` is best for JSON MCP clients such as Claude Desktop, Cursor, Windsurf, and Cortex CoCo. TOML-based clients like Codex CLI need manual proxy wrapping.
 
-## Tool Categories (38 tools)
+## Tool Categories (41 tools)
 
 | Category | Tools | What They Do |
 |----------|-------|-------------|

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -127,7 +127,7 @@ notes discuss agent-native product direction.
 | Area | Shipped today | Not yet shipped |
 |---|---|---|
 | Human cockpit | Next.js dashboard, graph cockpit, reports, compliance and audit views | every UI action backed by a source registry and persisted workflow state |
-| Agent interface | 38 read-only MCP tools, strict arguments, `exposure_paths`, `should_i_deploy` | long-lived posture subscription tool, autonomous remediation actions |
+| Agent interface | 41 read-only MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup | long-lived posture subscription tool, autonomous remediation actions |
 | Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports, TypeScript control-plane client, TypeScript runtime detector package | Python/Go control-plane SDKs and full scanner SDKs |
 | Runtime | MCP proxy, gateway, Shield SDK, runtime audit and policy decisions | webhook outbox, Kafka connectors, cloud-log ingestion connectors, Kinesis/Firehose adapter, and MCP posture subscriptions |
 | Graph scale | SQLite/Postgres default path, WebGL overview, optional Neptune adapter work | production Neptune SLOs, public openCypher endpoint, mandatory graph-database backend |

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -4,7 +4,7 @@
   "metrics": [
     {
       "name": "MCP tools",
-      "value": 38,
+      "value": 41,
       "source": "src/agent_bom/mcp_server_metadata.py",
       "notes": "Counted from the advertised server-card tools."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -10,7 +10,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |
-| MCP tools | 38 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
+| MCP tools | 41 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 35 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -13,7 +13,7 @@ agent-bom operates in four modes:
 1. **Scanner** — reads local config files + public APIs, produces reports
 2. **Proxy** — sits between an MCP client and server, inspects STDIO traffic
 3. **API server** — exposes REST/WebSocket endpoints for the dashboard
-4. **MCP server** — exposes 38 tools to AI assistants (Claude, Cursor, etc.)
+4. **MCP server** — exposes 41 tools to AI assistants (Claude, Cursor, etc.)
 
 ## Trust boundaries
 

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -1249,6 +1249,33 @@
         "title": "HealthResponse",
         "type": "object"
       },
+      "IntelPackageMatchRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "limit": {
+            "default": 100,
+            "maximum": 500.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "packages": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "maxItems": 500,
+            "minItems": 1,
+            "title": "Packages",
+            "type": "array"
+          }
+        },
+        "required": [
+          "packages"
+        ],
+        "title": "IntelPackageMatchRequest",
+        "type": "object"
+      },
       "JiraTicketRequest": {
         "description": "Request body for POST /v1/findings/jira.",
         "properties": {
@@ -10859,6 +10886,133 @@
         "summary": "Get Fix First Graph View",
         "tags": [
           "graph"
+        ]
+      }
+    },
+    "/v1/intel/advisories/{advisory_id}": {
+      "get": {
+        "description": "Look up one CVE/GHSA/OSV advisory from local intel.",
+        "operationId": "get_intel_advisory_v1_intel_advisories__advisory_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "advisory_id",
+            "required": true,
+            "schema": {
+              "title": "Advisory Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Intel Advisory V1 Intel Advisories  Advisory Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Intel Advisory",
+        "tags": [
+          "intel"
+        ]
+      }
+    },
+    "/v1/intel/match": {
+      "post": {
+        "description": "Match inventory package coordinates to local advisory intel.",
+        "operationId": "post_intel_match_v1_intel_match_post",
+        "parameters": [
+          {
+            "description": "Return packages with zero matched advisories.",
+            "in": "query",
+            "name": "include_unmatched",
+            "required": false,
+            "schema": {
+              "default": true,
+              "description": "Return packages with zero matched advisories.",
+              "title": "Include Unmatched",
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IntelPackageMatchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Post Intel Match V1 Intel Match Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Post Intel Match",
+        "tags": [
+          "intel"
+        ]
+      }
+    },
+    "/v1/intel/sources": {
+      "get": {
+        "description": "Return canonical threat-intel source and feed-run metadata.",
+        "operationId": "get_intel_sources_v1_intel_sources_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Intel Sources V1 Intel Sources Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Intel Sources",
+        "tags": [
+          "intel"
         ]
       }
     },

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -852,6 +852,27 @@ components:
       - storage
       title: HealthResponse
       type: object
+    IntelPackageMatchRequest:
+      additionalProperties: false
+      properties:
+        limit:
+          default: 100
+          maximum: 500.0
+          minimum: 1.0
+          title: Limit
+          type: integer
+        packages:
+          items:
+            additionalProperties: true
+            type: object
+          maxItems: 500
+          minItems: 1
+          title: Packages
+          type: array
+      required:
+      - packages
+      title: IntelPackageMatchRequest
+      type: object
     JiraTicketRequest:
       description: Request body for POST /v1/findings/jira.
       properties:
@@ -7136,6 +7157,89 @@ paths:
       summary: Get Fix First Graph View
       tags:
       - graph
+  /v1/intel/advisories/{advisory_id}:
+    get:
+      description: Look up one CVE/GHSA/OSV advisory from local intel.
+      operationId: get_intel_advisory_v1_intel_advisories__advisory_id__get
+      parameters:
+      - in: path
+        name: advisory_id
+        required: true
+        schema:
+          title: Advisory Id
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Intel Advisory V1 Intel Advisories  Advisory Id  Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Intel Advisory
+      tags:
+      - intel
+  /v1/intel/match:
+    post:
+      description: Match inventory package coordinates to local advisory intel.
+      operationId: post_intel_match_v1_intel_match_post
+      parameters:
+      - description: Return packages with zero matched advisories.
+        in: query
+        name: include_unmatched
+        required: false
+        schema:
+          default: true
+          description: Return packages with zero matched advisories.
+          title: Include Unmatched
+          type: boolean
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IntelPackageMatchRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Post Intel Match V1 Intel Match Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Post Intel Match
+      tags:
+      - intel
+  /v1/intel/sources:
+    get:
+      description: Return canonical threat-intel source and feed-run metadata.
+      operationId: get_intel_sources_v1_intel_sources_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Intel Sources V1 Intel Sources Get
+                type: object
+          description: Successful Response
+      summary: Get Intel Sources
+      tags:
+      - intel
   /v1/inventory:
     get:
       description: List agent and package inventory aggregated from completed scan

--- a/integrations/docker-mcp-registry/SUBMISSION.md
+++ b/integrations/docker-mcp-registry/SUBMISSION.md
@@ -5,7 +5,7 @@ Submission files for listing agent-bom in the Docker Desktop MCP Toolkit catalog
 ## Files
 
 - `server.yaml` — server metadata, image, allowed hosts, optional secrets
-- `tools.json` — all 38 MCP tools with descriptions and parameters
+- `tools.json` — all 41 MCP tools with descriptions and parameters
 - `readme.md` — Docker MCP Toolkit detail page content
 
 ## How to submit

--- a/integrations/docker-mcp-registry/tools.json
+++ b/integrations/docker-mcp-registry/tools.json
@@ -18,6 +18,30 @@
     ]
   },
   {
+    "name": "intel_lookup",
+    "description": "Look up a CVE, GHSA, or OSV advisory in the local threat-intel database.",
+    "arguments": [
+      {"name": "advisory_id", "type": "string", "desc": "Advisory identifier such as CVE-2026-12345 or GHSA-abcd-1234-wxyz"}
+    ]
+  },
+  {
+    "name": "intel_match",
+    "description": "Match package or purl inventory coordinates against local threat-intel advisories.",
+    "arguments": [
+      {"name": "packages", "type": "array", "desc": "Package coordinates with purl or ecosystem/name/version fields"},
+      {"name": "purl", "type": "string", "desc": "Single package URL, e.g. pkg:pypi/requests@2.31.0"},
+      {"name": "ecosystem", "type": "string", "desc": "Package ecosystem for single-package matching"},
+      {"name": "name", "type": "string", "desc": "Package name for single-package matching"},
+      {"name": "version", "type": "string", "desc": "Package version for single-package matching"},
+      {"name": "limit", "type": "integer", "desc": "Maximum package coordinates to match"}
+    ]
+  },
+  {
+    "name": "intel_sources",
+    "description": "List configured threat-intel sources and local feed freshness metadata.",
+    "arguments": []
+  },
+  {
     "name": "blast_radius",
     "description": "Look up the blast radius of a specific CVE — shows which agents, credentials, and tools are affected.",
     "arguments": [

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -398,7 +398,7 @@ def main() -> int:
     tools = len(tool_names)
     resources = len(resource_uris)
     prompts = len(prompt_names)
-    if (tools, resources, prompts) != (38, 6, 6):
+    if (tools, resources, prompts) != (41, 6, 6):
         _fail(f"MCP server card count changed unexpectedly: tools={tools}, resources={resources}, prompts={prompts}")
     docker_mcp_tool_names = [str(tool["name"]) for tool in json.loads(DOCKER_MCP_TOOLS.read_text())]
     if docker_mcp_tool_names != tool_names:

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server Setup
 
-agent-bom runs as an MCP server, exposing 38 read-only security tools to any MCP client.
+agent-bom runs as an MCP server, exposing 41 read-only security tools to any MCP client.
 The server card also advertises 6 resources and 6 workflow prompts so agents can
 choose structured playbooks instead of guessing tool order.
 

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -55,7 +55,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 |---|---|---|
 | **CLI / CI** | developers and pipelines | local scans, SARIF/SBOM/HTML/JSON, graph exports, deterministic gates |
 | **REST API** | security platforms, SIEM jobs, custom services | self-hosted control-plane routes for scans, normalized bulk findings, dataset versions, graph evidence, audit, and governance |
-| **MCP tools** | AI agents and coding assistants | 38 read-only tools, strict args, `exposure_paths`, `should_i_deploy` |
+| **MCP tools** | AI agents and coding assistants | 41 read-only tools, strict args, `exposure_paths`, `should_i_deploy` |
 | **TypeScript client** | services and agent runtimes calling the control plane | typed helper for stable REST endpoints; not a scanner SDK |
 | **TypeScript runtime detectors** | MCP/runtime enforcement integrations | local detector package for runtime policy checks; separate from the control-plane client |
 | **UI cockpit** | security teams and auditors | graph cockpit, compliance, audit, and evidence review over the same backend data |

--- a/src/agent_bom/api/routes/intel.py
+++ b/src/agent_bom/api/routes/intel.py
@@ -1,0 +1,52 @@
+"""Threat-intel lookup and inventory match routes."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, ConfigDict, Field
+
+from agent_bom.intel_lookup import list_intel_sources, lookup_advisory, match_packages
+
+router = APIRouter()
+
+
+class IntelPackageMatchRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    packages: list[dict[str, Any]] = Field(min_length=1, max_length=500)
+    limit: int = Field(default=100, ge=1, le=500)
+
+
+@router.get("/v1/intel/sources", tags=["intel"])
+async def get_intel_sources() -> dict[str, Any]:
+    """Return canonical threat-intel source and feed-run metadata."""
+
+    return list_intel_sources()
+
+
+@router.get("/v1/intel/advisories/{advisory_id}", tags=["intel"])
+async def get_intel_advisory(advisory_id: str) -> dict[str, Any]:
+    """Look up one CVE/GHSA/OSV advisory from local intel."""
+
+    try:
+        return lookup_advisory(advisory_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.post("/v1/intel/match", tags=["intel"])
+async def post_intel_match(
+    body: IntelPackageMatchRequest,
+    include_unmatched: Annotated[bool, Query(description="Return packages with zero matched advisories.")] = True,
+) -> dict[str, Any]:
+    """Match inventory package coordinates to local advisory intel."""
+
+    try:
+        result = match_packages(body.packages, limit=body.limit)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    if not include_unmatched:
+        result["matches"] = [item for item in result["matches"] if item["match_count"] > 0]
+    return result

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -725,6 +725,7 @@ from agent_bom.api.routes.frameworks import router as _frameworks_router  # noqa
 from agent_bom.api.routes.gateway import router as _gateway_router  # noqa: E402
 from agent_bom.api.routes.governance import router as _governance_router  # noqa: E402
 from agent_bom.api.routes.graph import router as _graph_router  # noqa: E402
+from agent_bom.api.routes.intel import router as _intel_router  # noqa: E402
 from agent_bom.api.routes.observability import router as _observability_router  # noqa: E402
 from agent_bom.api.routes.posture_streaming import router as _posture_streaming_router  # noqa: E402
 from agent_bom.api.routes.privacy import router as _privacy_router  # noqa: E402
@@ -747,6 +748,7 @@ app.include_router(_frameworks_router)
 app.include_router(_gateway_router)
 app.include_router(_governance_router)
 app.include_router(_graph_router)
+app.include_router(_intel_router)
 app.include_router(_observability_router)
 app.include_router(_posture_streaming_router)
 app.include_router(_privacy_router)

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -692,7 +692,7 @@ def mcp_server_cmd(
     Requires:  pip install 'agent-bom[mcp-server]'
 
     \b
-    Exposes 38 security tools via MCP protocol:
+    Exposes 41 security tools via MCP protocol:
       scan                   Full scan — CVEs, config security, blast radius, compliance
       check                  Check a specific package for CVEs before installing
       blast_radius           Look up blast radius for a specific CVE

--- a/src/agent_bom/intel_lookup.py
+++ b/src/agent_bom/intel_lookup.py
@@ -1,0 +1,380 @@
+"""Threat-intel source catalog, advisory lookup, and inventory matching."""
+
+from __future__ import annotations
+
+import os
+import re
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote
+
+from agent_bom.db.lookup import LocalVuln, lookup_package
+from agent_bom.db.schema import DB_PATH, _validated_db_path, init_db
+from agent_bom.package_utils import normalize_package_name
+
+_CVE_RE = re.compile(r"^CVE-\d{4}-\d{4,}$", re.IGNORECASE)
+_GHSA_RE = re.compile(r"^GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}$", re.IGNORECASE)
+_CWE_RE = re.compile(r"^CWE-\d+$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class IntelSource:
+    source_id: str
+    display_name: str
+    tier: int
+    kind: str
+    url: str
+    license: str
+    redistribution: str
+    sync_meta_source: str
+    description: str
+
+
+CANONICAL_INTEL_SOURCES: tuple[IntelSource, ...] = (
+    IntelSource(
+        source_id="osv",
+        display_name="OSV",
+        tier=1,
+        kind="vulnerability",
+        url="https://osv.dev/list",
+        license="CC-BY-4.0",
+        redistribution="structured_records",
+        sync_meta_source="osv",
+        description="Ecosystem-native vulnerability advisories keyed by purl-like package coordinates.",
+    ),
+    IntelSource(
+        source_id="ghsa",
+        display_name="GitHub Security Advisories",
+        tier=1,
+        kind="vulnerability",
+        url="https://github.com/advisories",
+        license="GitHub advisory database terms",
+        redistribution="structured_records",
+        sync_meta_source="ghsa",
+        description="GitHub Security Advisory records for package ecosystems supported by the local DB syncer.",
+    ),
+    IntelSource(
+        source_id="nvd",
+        display_name="NVD",
+        tier=1,
+        kind="enrichment",
+        url="https://services.nvd.nist.gov/rest/json/cves/2.0",
+        license="public_domain_us_government",
+        redistribution="structured_enrichment",
+        sync_meta_source="nvd",
+        description="CVSS, CWE, and CVE enrichment used to explain impact and remediation priority.",
+    ),
+    IntelSource(
+        source_id="epss",
+        display_name="FIRST EPSS",
+        tier=1,
+        kind="exploitability",
+        url="https://epss.empiricalsecurity.com/epss_scores-current.csv.gz",
+        license="FIRST EPSS terms",
+        redistribution="structured_enrichment",
+        sync_meta_source="epss",
+        description="Exploit Prediction Scoring System probability and percentile enrichment.",
+    ),
+    IntelSource(
+        source_id="cisa_kev",
+        display_name="CISA KEV",
+        tier=1,
+        kind="exploitation",
+        url="https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+        license="public_domain_us_government",
+        redistribution="structured_enrichment",
+        sync_meta_source="kev",
+        description="Known-exploited vulnerability signal for prioritizing active exploitation risk.",
+    ),
+    IntelSource(
+        source_id="alpine_secdb",
+        display_name="Alpine SecDB",
+        tier=1,
+        kind="os_package",
+        url="https://secdb.alpinelinux.org",
+        license="Alpine Linux SecDB terms",
+        redistribution="structured_records",
+        sync_meta_source="alpine",
+        description="Alpine package security database records for container and OS image matching.",
+    ),
+)
+
+
+def resolve_intel_db_path() -> Path:
+    """Return the local vulnerability DB path for read-only intel surfaces."""
+
+    configured = (os.environ.get("AGENT_BOM_DB_PATH") or "").strip()
+    if configured:
+        return _validated_db_path(configured)
+    return DB_PATH
+
+
+def _sync_meta(conn: sqlite3.Connection) -> dict[str, dict[str, Any]]:
+    rows = conn.execute("SELECT source, last_synced, record_count FROM sync_meta").fetchall()
+    return {row["source"]: {"last_synced": row["last_synced"], "record_count": row["record_count"]} for row in rows}
+
+
+def list_intel_sources(*, db_path: Path | None = None) -> dict[str, Any]:
+    """Return canonical source metadata plus local feed-run freshness."""
+
+    conn = init_db(db_path or resolve_intel_db_path())
+    try:
+        meta = _sync_meta(conn)
+    finally:
+        conn.close()
+
+    sources: list[dict[str, Any]] = []
+    for source in CANONICAL_INTEL_SOURCES:
+        run = meta.get(source.sync_meta_source, {})
+        sources.append(
+            {
+                "source_id": source.source_id,
+                "display_name": source.display_name,
+                "tier": source.tier,
+                "kind": source.kind,
+                "url": source.url,
+                "license": source.license,
+                "redistribution": source.redistribution,
+                "description": source.description,
+                "feed_run": {
+                    "sync_meta_source": source.sync_meta_source,
+                    "last_synced": run.get("last_synced"),
+                    "record_count": run.get("record_count", 0),
+                    "status": "freshness_unknown" if not run.get("last_synced") else "synced",
+                },
+            }
+        )
+    return {"schema_version": "intel.sources.v1", "sources": sources, "count": len(sources)}
+
+
+def _canonical_ids(vuln_id: str, aliases: list[str], cwe_ids: list[str]) -> dict[str, list[str]]:
+    values = [vuln_id, *aliases]
+    cves = sorted({value.upper() for value in values if _CVE_RE.match(value)})
+    ghsas = sorted({value.upper() for value in values if _GHSA_RE.match(value)})
+    osv = sorted({value for value in values if not _CVE_RE.match(value) and not _GHSA_RE.match(value)})
+    cwes = sorted({value.upper() for value in cwe_ids if _CWE_RE.match(value)})
+    return {"cves": cves, "ghsas": ghsas, "osv": osv, "cwes": cwes}
+
+
+def evidence_links(vuln_id: str, aliases: list[str], cwe_ids: list[str], source: str) -> list[dict[str, str]]:
+    """Return source links without implying that every link was fetched."""
+
+    links: list[dict[str, str]] = []
+    ids = _canonical_ids(vuln_id, aliases, cwe_ids)
+    for cve_id in ids["cves"]:
+        links.append({"kind": "cve", "id": cve_id, "url": f"https://nvd.nist.gov/vuln/detail/{cve_id}"})
+        links.append({"kind": "epss", "id": cve_id, "url": f"https://api.first.org/data/v1/epss?cve={cve_id}"})
+    for ghsa_id in ids["ghsas"]:
+        links.append({"kind": "ghsa", "id": ghsa_id, "url": f"https://github.com/advisories/{ghsa_id}"})
+    for osv_id in ids["osv"]:
+        if osv_id:
+            links.append({"kind": source or "osv", "id": osv_id, "url": f"https://osv.dev/vulnerability/{osv_id}"})
+    for cwe_id in ids["cwes"]:
+        cwe_num = cwe_id.removeprefix("CWE-")
+        links.append({"kind": "cwe", "id": cwe_id, "url": f"https://cwe.mitre.org/data/definitions/{cwe_num}.html"})
+    return links
+
+
+def _local_vuln_to_advisory(vuln: LocalVuln, *, matched_by: str) -> dict[str, Any]:
+    ids = _canonical_ids(vuln.id, vuln.aliases, vuln.cwe_ids)
+    return {
+        "id": vuln.id,
+        "canonical_ids": ids,
+        "summary": vuln.summary,
+        "severity": vuln.severity,
+        "cvss_score": vuln.cvss_score,
+        "cvss_vector": vuln.cvss_vector,
+        "fixed_version": vuln.fixed_version,
+        "source": vuln.source,
+        "published_at": vuln.published_at,
+        "modified_at": vuln.modified_at,
+        "epss_probability": vuln.epss_probability,
+        "epss_percentile": vuln.epss_percentile,
+        "is_kev": vuln.is_kev,
+        "kev_date_added": vuln.kev_date_added,
+        "affected": [
+            {
+                "ecosystem": vuln.ecosystem,
+                "package_name": vuln.package_name,
+                "introduced": vuln.introduced,
+                "fixed": vuln.fixed_version,
+            }
+        ],
+        "matched_by": matched_by,
+        "evidence_links": evidence_links(vuln.id, vuln.aliases, vuln.cwe_ids, vuln.source),
+    }
+
+
+def _candidate_ids(value: str) -> tuple[str, str]:
+    advisory_id = value.strip()
+    return advisory_id, advisory_id.upper()
+
+
+def _lookup_cve_enrichment(conn: sqlite3.Connection, cve_ids: list[str]) -> tuple[float | None, float | None, str | None]:
+    """Return EPSS and KEV enrichment for any CVE mapped to an advisory."""
+
+    unique_cves = list(dict.fromkeys(cve_id.upper() for cve_id in cve_ids if _CVE_RE.match(cve_id)))
+    if not unique_cves:
+        return None, None, None
+    placeholders = ", ".join("?" for _ in unique_cves)
+    epss_query = f"""
+        SELECT cve_id, probability, percentile
+        FROM epss_scores
+        WHERE cve_id IN ({placeholders})
+        ORDER BY probability DESC
+        LIMIT 1
+    """  # nosec B608 - placeholders are generated solely from "?" markers
+    kev_query = f"""
+        SELECT cve_id, date_added
+        FROM kev_entries
+        WHERE cve_id IN ({placeholders})
+        ORDER BY date_added DESC
+        LIMIT 1
+    """  # nosec B608 - placeholders are generated solely from "?" markers
+    epss_row = conn.execute(epss_query, unique_cves).fetchone()
+    kev_row = conn.execute(kev_query, unique_cves).fetchone()
+    epss_probability = epss_row["probability"] if epss_row else None
+    epss_percentile = epss_row["percentile"] if epss_row else None
+    kev_date_added = kev_row["date_added"] if kev_row else None
+    return epss_probability, epss_percentile, kev_date_added
+
+
+def lookup_advisory(advisory_id: str, *, db_path: Path | None = None) -> dict[str, Any]:
+    """Look up one advisory by ID or alias from the local intel DB."""
+
+    raw_id, upper_id = _candidate_ids(advisory_id)
+    if not raw_id:
+        raise ValueError("advisory_id is required")
+    conn = init_db(db_path or resolve_intel_db_path())
+    try:
+        rows = conn.execute(
+            """
+            SELECT
+                v.id, v.summary, v.severity, v.cvss_score, v.cvss_vector, v.fixed_version, v.cwe_ids,
+                COALESCE(v.aliases, '') AS aliases, v.source, v.published, v.modified,
+                a.ecosystem, a.package_name, a.introduced, a.fixed, a.last_affected,
+                e.probability AS epss_prob, e.percentile AS epss_pct,
+                k.date_added AS kev_date
+            FROM vulns v
+            LEFT JOIN affected a ON a.vuln_id = v.id
+            LEFT JOIN epss_scores e ON e.cve_id = v.id
+            LEFT JOIN kev_entries k ON k.cve_id = v.id
+            WHERE UPPER(v.id) = ? OR instr(',' || UPPER(COALESCE(v.aliases, '')) || ',', ',' || ? || ',') > 0
+            ORDER BY a.ecosystem, a.package_name
+            """,
+            (upper_id, upper_id),
+        ).fetchall()
+        if not rows:
+            return {"schema_version": "intel.lookup.v1", "found": False, "query": raw_id, "advisory": None}
+        first = rows[0]
+        aliases = [alias for alias in (first["aliases"] or "").split(",") if alias]
+        cwes = [cwe for cwe in (first["cwe_ids"] or "").split(",") if cwe]
+        canonical_ids = _canonical_ids(first["id"], aliases, cwes)
+        epss_probability, epss_percentile, kev_date_added = _lookup_cve_enrichment(conn, canonical_ids["cves"])
+        epss_probability = first["epss_prob"] if first["epss_prob"] is not None else epss_probability
+        epss_percentile = first["epss_pct"] if first["epss_pct"] is not None else epss_percentile
+        kev_date_added = first["kev_date"] or kev_date_added
+        affected = [
+            {
+                "ecosystem": row["ecosystem"],
+                "package_name": row["package_name"],
+                "introduced": row["introduced"],
+                "fixed": row["fixed"] or row["fixed_version"],
+                "last_affected": row["last_affected"],
+            }
+            for row in rows
+            if row["ecosystem"] and row["package_name"]
+        ]
+        advisory = {
+            "id": first["id"],
+            "canonical_ids": canonical_ids,
+            "summary": first["summary"],
+            "severity": first["severity"],
+            "cvss_score": first["cvss_score"],
+            "cvss_vector": first["cvss_vector"],
+            "fixed_version": first["fixed_version"],
+            "source": first["source"],
+            "published_at": first["published"],
+            "modified_at": first["modified"],
+            "epss_probability": epss_probability,
+            "epss_percentile": epss_percentile,
+            "is_kev": kev_date_added is not None,
+            "kev_date_added": kev_date_added,
+            "affected": affected,
+            "matched_by": "id_or_alias",
+            "evidence_links": evidence_links(first["id"], aliases, cwes, first["source"]),
+        }
+        return {"schema_version": "intel.lookup.v1", "found": True, "query": raw_id, "advisory": advisory}
+    finally:
+        conn.close()
+
+
+def parse_purl(purl: str) -> dict[str, str]:
+    """Parse a package URL subset into ecosystem/name/version fields."""
+
+    if not purl.startswith("pkg:"):
+        raise ValueError("purl must start with pkg:")
+    body = purl[4:].split("?", 1)[0].split("#", 1)[0]
+    ecosystem, _, remainder = body.partition("/")
+    if not ecosystem or not remainder:
+        raise ValueError("purl must include ecosystem and package name")
+    name_part, _, version = remainder.rpartition("@")
+    if not name_part:
+        name_part = version
+        version = ""
+    name = unquote(name_part)
+    return {"ecosystem": ecosystem.lower(), "name": name, "version": unquote(version)}
+
+
+def normalize_package_query(package: dict[str, Any]) -> dict[str, str]:
+    """Normalize a package match input into ecosystem/name/version/purl."""
+
+    purl = str(package.get("purl") or "").strip()
+    parsed = parse_purl(purl) if purl else {}
+    ecosystem = str(package.get("ecosystem") or parsed.get("ecosystem") or "").strip().lower()
+    name = str(package.get("name") or parsed.get("name") or "").strip()
+    version = str(package.get("version") or parsed.get("version") or "").strip()
+    if not ecosystem or not name:
+        raise ValueError("each package requires purl or ecosystem plus name")
+    normalized_name = normalize_package_name(name, ecosystem)
+    return {
+        "purl": purl,
+        "ecosystem": ecosystem,
+        "name": name,
+        "normalized_name": normalized_name,
+        "version": version,
+        "inventory_ref": str(package.get("inventory_ref") or package.get("id") or "").strip(),
+    }
+
+
+def match_packages(packages: list[dict[str, Any]], *, db_path: Path | None = None, limit: int = 100) -> dict[str, Any]:
+    """Match package coordinates against local advisory intel."""
+
+    if limit < 1 or limit > 500:
+        raise ValueError("limit must be between 1 and 500")
+    normalized = [normalize_package_query(package) for package in packages[:limit]]
+    conn = init_db(db_path or resolve_intel_db_path())
+    try:
+        matches: list[dict[str, Any]] = []
+        for package in normalized:
+            vulns = lookup_package(conn, package["ecosystem"], package["normalized_name"], package["version"] or None)
+            advisories = [_local_vuln_to_advisory(vuln, matched_by="package") for vuln in vulns]
+            matches.append(
+                {
+                    "package": package,
+                    "match_count": len(advisories),
+                    "advisories": advisories,
+                    "evidence_links": [link for advisory in advisories for link in advisory["evidence_links"]],
+                }
+            )
+    finally:
+        conn.close()
+    return {
+        "schema_version": "intel.match.v1",
+        "submitted": len(packages),
+        "matched_packages": sum(1 for item in matches if item["match_count"] > 0),
+        "match_count": sum(item["match_count"] for item in matches),
+        "matches": matches,
+    }

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -5,7 +5,7 @@ Start with:
     agent-bom mcp server --transport sse          # SSE transport (for remote clients)
     agent-bom mcp server --transport streamable-http
 
-Tools (38):
+Tools (41):
     scan                — Full discovery → scan → output pipeline
     check               — Check a specific package for CVEs before installing
     blast_radius        — Look up blast radius for a specific CVE
@@ -377,6 +377,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
         policy_check_impl,
     )
     from agent_bom.mcp_tools.graph import deploy_decision_impl, exposure_paths_impl
+    from agent_bom.mcp_tools.intel import intel_lookup_impl, intel_match_impl, intel_sources_impl
     from agent_bom.mcp_tools.registry import registry_lookup_impl
     from agent_bom.mcp_tools.runtime import verify_impl
     from agent_bom.mcp_tools.sbom import generate_sbom_impl, remediate_impl
@@ -514,6 +515,60 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
             package=package,
             ecosystem=ecosystem,
             _validate_ecosystem=_validate_ecosystem,
+            _truncate_response=_truncate_response,
+        )
+
+    # ── Tool 2b: threat intel lookup ──────────────────────────────────
+
+    @mcp.tool(annotations=_READ_ONLY, title="Threat Intel Advisory Lookup")
+    async def intel_lookup(
+        advisory_id: Annotated[str, Field(description="CVE, GHSA, or OSV advisory ID, e.g. CVE-2024-1234 or GHSA-abcd-1234-wxyz.")],
+    ) -> str:
+        """Look up one advisory from the local threat-intel database."""
+
+        return await _execute_tool_async(
+            "intel_lookup",
+            intel_lookup_impl,
+            advisory_id=advisory_id,
+            _truncate_response=_truncate_response,
+        )
+
+    @mcp.tool(annotations=_READ_ONLY, title="Threat Intel Package Match")
+    async def intel_match(
+        purl: Annotated[str | None, Field(description="Package URL, e.g. pkg:pypi/requests@2.31.0.")] = None,
+        ecosystem: Annotated[
+            str | None,
+            Field(description="Package ecosystem when purl is omitted, e.g. pypi, npm, go, maven, apk."),
+        ] = None,
+        name: Annotated[str | None, Field(description="Package name when purl is omitted.")] = None,
+        version: Annotated[str | None, Field(description="Package version when known.")] = None,
+        packages: Annotated[
+            list[dict] | None,
+            Field(description="Optional package list with purl or ecosystem/name/version objects for batch matching."),
+        ] = None,
+        limit: Annotated[int, Field(description="Maximum packages to match, 1-500.")] = 100,
+    ) -> str:
+        """Match package inventory coordinates to local threat-intel advisories."""
+
+        return await _execute_tool_async(
+            "intel_match",
+            intel_match_impl,
+            packages=packages,
+            purl=purl,
+            ecosystem=ecosystem,
+            name=name,
+            version=version,
+            limit=limit,
+            _truncate_response=_truncate_response,
+        )
+
+    @mcp.tool(annotations=_READ_ONLY, title="Threat Intel Source Catalog")
+    async def intel_sources() -> str:
+        """Return canonical threat-intel sources and local feed-run freshness."""
+
+        return await _execute_tool_async(
+            "intel_sources",
+            intel_sources_impl,
             _truncate_response=_truncate_response,
         )
 

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -8,6 +8,21 @@ from typing import Any
 _SERVER_CARD_TOOLS = [
     {"name": "scan", "description": "Full discovery → scan → output pipeline", "annotations": {"readOnlyHint": True}},
     {"name": "check", "description": "Check a specific package for CVEs before installing", "annotations": {"readOnlyHint": True}},
+    {
+        "name": "intel_lookup",
+        "description": "Look up a CVE, GHSA, or OSV advisory from local threat intel",
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "intel_match",
+        "description": "Match package inventory coordinates to local advisory intel",
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "intel_sources",
+        "description": "Return canonical intel sources and local feed-run freshness",
+        "annotations": {"readOnlyHint": True},
+    },
     {"name": "blast_radius", "description": "Look up blast radius for a specific CVE", "annotations": {"readOnlyHint": True}},
     {
         "name": "exposure_paths",
@@ -174,6 +189,9 @@ _SERVER_CARD_TOOLS = [
 _TOOL_CAPABILITY_CLASSES = {
     "scan": ["READ", "NETWORK", "LOCAL_FILE_READ"],
     "check": ["READ", "NETWORK"],
+    "intel_lookup": ["READ", "THREAT_INTEL"],
+    "intel_match": ["READ", "THREAT_INTEL", "INVENTORY"],
+    "intel_sources": ["READ", "THREAT_INTEL"],
     "blast_radius": ["READ", "ANALYZE"],
     "exposure_paths": ["READ", "GRAPH", "ANALYZE"],
     "should_i_deploy": ["READ", "GRAPH", "POLICY"],

--- a/src/agent_bom/mcp_tools/intel.py
+++ b/src/agent_bom/mcp_tools/intel.py
@@ -1,0 +1,67 @@
+"""Threat-intel MCP tool implementations."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from agent_bom.intel_lookup import list_intel_sources, lookup_advisory, match_packages
+from agent_bom.mcp_errors import CODE_INTERNAL_UNEXPECTED, CODE_VALIDATION_INVALID_ARGUMENT, mcp_error_json
+from agent_bom.security import sanitize_error
+
+logger = logging.getLogger(__name__)
+
+
+async def intel_lookup_impl(*, advisory_id: str, _truncate_response=lambda value: value) -> str:
+    """Look up one CVE/GHSA/OSV advisory from local intel."""
+
+    try:
+        advisory = (advisory_id or "").strip()
+        if not advisory:
+            return mcp_error_json(CODE_VALIDATION_INVALID_ARGUMENT, "advisory_id is required", details={"argument": "advisory_id"})
+        return _truncate_response(json.dumps(lookup_advisory(advisory), indent=2, default=str))
+    except ValueError as exc:
+        return mcp_error_json(CODE_VALIDATION_INVALID_ARGUMENT, sanitize_error(exc), details={"argument": "advisory_id"})
+    except Exception as exc:  # pragma: no cover - defensive redaction
+        logger.exception("MCP intel lookup failed")
+        return mcp_error_json(CODE_INTERNAL_UNEXPECTED, "Intel lookup failed.", details={"error": sanitize_error(exc)})
+
+
+async def intel_match_impl(
+    *,
+    packages: list[dict] | None = None,
+    purl: str | None = None,
+    ecosystem: str | None = None,
+    name: str | None = None,
+    version: str | None = None,
+    limit: int = 100,
+    _truncate_response=lambda value: value,
+) -> str:
+    """Match package inventory coordinates to local advisory intel."""
+
+    try:
+        submitted = list(packages or [])
+        if purl or ecosystem or name:
+            submitted.append({"purl": purl or "", "ecosystem": ecosystem or "", "name": name or "", "version": version or ""})
+        if not submitted:
+            return mcp_error_json(
+                CODE_VALIDATION_INVALID_ARGUMENT,
+                "Provide packages or a single purl/ecosystem/name package.",
+                details={"argument": "packages"},
+            )
+        return _truncate_response(json.dumps(match_packages(submitted, limit=limit), indent=2, default=str))
+    except ValueError as exc:
+        return mcp_error_json(CODE_VALIDATION_INVALID_ARGUMENT, sanitize_error(exc), details={"argument": "packages"})
+    except Exception as exc:  # pragma: no cover - defensive redaction
+        logger.exception("MCP intel match failed")
+        return mcp_error_json(CODE_INTERNAL_UNEXPECTED, "Intel match failed.", details={"error": sanitize_error(exc)})
+
+
+async def intel_sources_impl(*, _truncate_response=lambda value: value) -> str:
+    """Return canonical threat-intel source and feed-run metadata."""
+
+    try:
+        return _truncate_response(json.dumps(list_intel_sources(), indent=2, default=str))
+    except Exception as exc:  # pragma: no cover - defensive redaction
+        logger.exception("MCP intel sources failed")
+        return mcp_error_json(CODE_INTERNAL_UNEXPECTED, "Intel sources failed.", details={"error": sanitize_error(exc)})

--- a/src/agent_bom/version_utils.py
+++ b/src/agent_bom/version_utils.py
@@ -457,7 +457,21 @@ def compare_version_order(left: str, right: str, ecosystem: str) -> int | None:
             return None
 
 
-_SEMVER_PRERELEASE_TAG_RE = None
+_SEMVER_PRERELEASE_TAGS = frozenset(
+    {
+        "canary",
+        "beta",
+        "alpha",
+        "rc",
+        "pre",
+        "dev",
+        "nightly",
+        "next",
+        "snapshot",
+        "m",
+        "preview",
+    }
+)
 
 
 def _strip_semver_prerelease_tag(version: str) -> str:
@@ -470,15 +484,13 @@ def _strip_semver_prerelease_tag(version: str) -> str:
     unchanged when no recognized suffix is present so the caller can
     detect "nothing to retry" and avoid an infinite loop.
     """
-    global _SEMVER_PRERELEASE_TAG_RE
-    if _SEMVER_PRERELEASE_TAG_RE is None:
-        import re
-
-        _SEMVER_PRERELEASE_TAG_RE = re.compile(
-            r"-(?:canary|beta|alpha|rc|pre|dev|nightly|next|snapshot|m|preview)(?:\.[A-Za-z0-9.-]+)?$",
-            re.IGNORECASE,
-        )
-    return _SEMVER_PRERELEASE_TAG_RE.sub("", version)
+    base, separator, suffix = version.partition("-")
+    if not separator:
+        return version
+    tag = suffix.split(".", 1)[0].lower()
+    if tag in _SEMVER_PRERELEASE_TAGS:
+        return base
+    return version
 
 
 @lru_cache(maxsize=65536)

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -490,7 +490,7 @@ def test_mcp_server_help_shows_skill_tools():
 
     runner = CliRunner()
     result = runner.invoke(main, ["mcp", "server", "--help"])
-    assert "38 security tools" in result.output
+    assert "41 security tools" in result.output
     assert "skill_scan" in result.output
     assert "skill_verify" in result.output
     assert "compliance" in result.output

--- a/tests/test_intel_lookup.py
+++ b/tests/test_intel_lookup.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import app, configure_api
+from agent_bom.db.schema import init_db
+from agent_bom.intel_lookup import list_intel_sources, lookup_advisory, match_packages
+from agent_bom.mcp_tools.intel import intel_lookup_impl, intel_match_impl, intel_sources_impl
+from tests.auth_helpers import PROXY_SECRET
+
+VIEWER_HEADERS = {
+    "X-Agent-Bom-Role": "viewer",
+    "X-Agent-Bom-Tenant-ID": "tenant-alpha",
+    "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
+}
+
+
+@pytest.fixture
+def intel_db(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    db_path = tmp_path / "intel.db"
+    monkeypatch.setenv("AGENT_BOM_DB_PATH", str(db_path))
+    conn = init_db(db_path)
+    _seed_intel(conn)
+    conn.close()
+    return db_path
+
+
+@pytest.fixture
+def intel_client(monkeypatch: pytest.MonkeyPatch, intel_db):  # noqa: ANN001
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", PROXY_SECRET)
+    configure_api(api_key=None)
+    try:
+        with TestClient(app) as client:
+            yield client
+    finally:
+        monkeypatch.delenv("AGENT_BOM_TRUST_PROXY_AUTH", raising=False)
+        configure_api(api_key=None)
+
+
+def _seed_intel(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        INSERT INTO vulns (
+            id, summary, severity, cvss_score, cvss_vector, fixed_version,
+            cwe_ids, aliases, published, modified, source
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "GHSA-abcd-1234-wxyz",
+            "requests test advisory",
+            "high",
+            8.1,
+            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+            "2.32.0",
+            "CWE-79,CWE-352",
+            "CVE-2026-12345",
+            "2026-05-01T00:00:00+00:00",
+            "2026-05-02T00:00:00+00:00",
+            "ghsa",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO affected(vuln_id, ecosystem, package_name, introduced, fixed, last_affected)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        ("GHSA-abcd-1234-wxyz", "pypi", "requests", "0", "2.32.0", ""),
+    )
+    conn.execute(
+        "INSERT INTO epss_scores(cve_id, probability, percentile, updated_at) VALUES (?, ?, ?, ?)",
+        ("CVE-2026-12345", 0.91, 99.1, "2026-05-03T00:00:00+00:00"),
+    )
+    conn.execute(
+        "INSERT INTO kev_entries(cve_id, date_added, due_date, product, vendor_project) VALUES (?, ?, ?, ?, ?)",
+        ("CVE-2026-12345", "2026-05-04", "2026-06-04", "requests", "python"),
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO sync_meta(source, last_synced, record_count) VALUES (?, ?, ?)",
+        ("ghsa", "2026-05-05T00:00:00+00:00", 1),
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO sync_meta(source, last_synced, record_count) VALUES (?, ?, ?)",
+        ("epss", "2026-05-05T00:00:00+00:00", 1),
+    )
+    conn.commit()
+
+
+def test_list_intel_sources_includes_feed_run_metadata(intel_db) -> None:  # noqa: ANN001
+    body = list_intel_sources(db_path=intel_db)
+
+    assert body["schema_version"] == "intel.sources.v1"
+    ghsa = next(source for source in body["sources"] if source["source_id"] == "ghsa")
+    assert ghsa["tier"] == 1
+    assert ghsa["feed_run"]["last_synced"] == "2026-05-05T00:00:00+00:00"
+    assert ghsa["feed_run"]["record_count"] == 1
+
+
+def test_lookup_advisory_by_alias_returns_evidence_links(intel_db) -> None:  # noqa: ANN001
+    body = lookup_advisory("CVE-2026-12345", db_path=intel_db)
+
+    assert body["found"] is True
+    advisory = body["advisory"]
+    assert advisory["id"] == "GHSA-abcd-1234-wxyz"
+    assert advisory["canonical_ids"]["cves"] == ["CVE-2026-12345"]
+    assert advisory["canonical_ids"]["cwes"] == ["CWE-352", "CWE-79"]
+    assert advisory["epss_probability"] == pytest.approx(0.91)
+    assert advisory["is_kev"] is True
+    assert any(link["kind"] == "cve" for link in advisory["evidence_links"])
+    assert advisory["affected"][0]["package_name"] == "requests"
+
+
+def test_match_packages_returns_inventory_linked_advisories(intel_db) -> None:  # noqa: ANN001
+    body = match_packages(
+        [{"purl": "pkg:pypi/requests@2.31.0", "inventory_ref": "pkg-1"}],
+        db_path=intel_db,
+    )
+
+    assert body["schema_version"] == "intel.match.v1"
+    assert body["matched_packages"] == 1
+    match = body["matches"][0]
+    assert match["package"]["inventory_ref"] == "pkg-1"
+    assert match["match_count"] == 1
+    advisory = match["advisories"][0]
+    assert advisory["epss_probability"] == pytest.approx(0.91)
+    assert advisory["is_kev"] is True
+    assert any(link["kind"] == "cwe" for link in match["evidence_links"])
+
+
+def test_intel_api_routes_are_read_only_and_tenant_scoped(intel_client: TestClient) -> None:
+    sources = intel_client.get("/v1/intel/sources", headers=VIEWER_HEADERS)
+    assert sources.status_code == 200
+    assert sources.json()["count"] >= 3
+
+    advisory = intel_client.get("/v1/intel/advisories/CVE-2026-12345", headers=VIEWER_HEADERS)
+    assert advisory.status_code == 200
+    assert advisory.json()["found"] is True
+
+    match = intel_client.post(
+        "/v1/intel/match",
+        headers=VIEWER_HEADERS,
+        json={"packages": [{"ecosystem": "pypi", "name": "requests", "version": "2.31.0"}]},
+    )
+    assert match.status_code == 200
+    assert match.json()["matched_packages"] == 1
+
+
+def test_intel_api_match_validates_package_shape(intel_client: TestClient) -> None:
+    response = intel_client.post("/v1/intel/match", headers=VIEWER_HEADERS, json={"packages": [{"name": "requests"}]})
+
+    assert response.status_code == 422
+    assert "ecosystem" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_mcp_intel_tools_return_agent_native_json(intel_db) -> None:  # noqa: ANN001
+    lookup = json.loads(await intel_lookup_impl(advisory_id="CVE-2026-12345"))
+    assert lookup["found"] is True
+
+    match = json.loads(await intel_match_impl(purl="pkg:pypi/requests@2.31.0"))
+    assert match["matched_packages"] == 1
+
+    sources = json.loads(await intel_sources_impl())
+    assert sources["schema_version"] == "intel.sources.v1"

--- a/tests/test_mcp_strict_args.py
+++ b/tests/test_mcp_strict_args.py
@@ -27,7 +27,7 @@ def mcp_server():
 def test_every_tool_advertises_additional_properties_false(mcp_server) -> None:  # noqa: ANN001
     """Every registered tool's JSON schema must reject unknown properties."""
     tools = list(mcp_server._tool_manager._tools.values())
-    assert len(tools) >= 30, f"expected ~38 tools, got {len(tools)}"
+    assert len(tools) >= 30, f"expected ~41 tools, got {len(tools)}"
     leaks: list[str] = []
     for tool in tools:
         params = tool.parameters or {}


### PR DESCRIPTION
Summary
- add local threat-intel source/feed-run catalog over REST and MCP
- add advisory lookup by CVE/GHSA/OSV with canonical IDs, EPSS/KEV alias enrichment, affected packages, and evidence links
- add package/purl inventory matching over REST and MCP, refresh OpenAPI artifacts, and align MCP metadata/docs to 41 tools

Verification
- uv run pytest tests/test_intel_lookup.py -q
- PYTHONPATH=src uv run pytest tests/test_intel_lookup.py tests/test_openapi_artifact.py tests/test_mcp_server.py::test_mcp_server_has_correct_tool_count tests/test_mcp_server.py::test_mcp_server_tool_names tests/test_mcp_strict_args.py tests/test_stats_alignment.py tests/test_deployment.py -q
- uv run ruff check src/agent_bom/intel_lookup.py src/agent_bom/api/routes/intel.py src/agent_bom/mcp_tools/intel.py src/agent_bom/mcp_server.py src/agent_bom/mcp_server_metadata.py src/agent_bom/cli/_server.py scripts/check_release_consistency.py tests/test_intel_lookup.py tests/test_deployment.py tests/test_mcp_strict_args.py
- uv run mypy src/agent_bom/intel_lookup.py src/agent_bom/api/routes/intel.py src/agent_bom/mcp_tools/intel.py
- python scripts/check_release_consistency.py
- uv run --extra api python scripts/export_openapi.py --check
- git diff --check

Closes #2636
Closes #2637
Closes #2646
Refs #2643
Refs #2645
