### PR TITLE
fix(graph): expose static schema type aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Versions follow [Semantic Versioning](https://semver.org/).
   active runtime sources, freshness, and explicit retention posture without
   exposing raw prompts, arguments, responses, or credential values.
 
+### Fixed
+- Graph schema now exposes static `node_types` and `edge_types` aliases from
+  the canonical enum taxonomy, so empty graph stores still return the complete
+  type catalog for clients.
+
 ### Changed
 - **Multi-agent operating contract** - promoted shared engineering, PR style,
   and release-readiness rules into `.agents/AGENTS.md` so any agent following

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -2111,6 +2111,8 @@ async def get_graph_schema() -> dict:
         "semantic_layers": [{"key": layer.value, "label": _SEMANTIC_LAYER_LABELS[layer.value]} for layer in GraphSemanticLayer],
         "node_kinds": sorted(node_kinds, key=lambda d: d["key"]),
         "edge_kinds": sorted(edge_kinds, key=lambda d: d["key"]),
+        "node_types": sorted(entity.value for entity in EntityType),
+        "edge_types": sorted(rel.value for rel in RelationshipType),
     }
 
 

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -1114,6 +1114,17 @@ class TestGraphSchemaEndpoint:
         assert node_keys == {et.value for et in EntityType}
         assert edge_keys == {rt.value for rt in RelationshipType}
 
+    def test_schema_endpoint_exposes_static_type_aliases_without_graph_data(self):
+        from agent_bom.graph.types import EntityType, RelationshipType
+
+        client = self._client()
+        body = client.get("/v1/graph/schema").json()
+
+        assert body["node_types"] == sorted(entity.value for entity in EntityType)
+        assert body["edge_types"] == sorted(relationship.value for relationship in RelationshipType)
+        assert len(body["node_types"]) == len(EntityType)
+        assert len(body["edge_types"]) == len(RelationshipType)
+
     def test_schema_entries_carry_label_color_shape_icon(self):
         client = self._client()
         body = client.get("/v1/graph/schema").json()


### PR DESCRIPTION
Summary
- expose static node_types and edge_types aliases from the canonical graph enums on /v1/graph/schema
- keep the existing node_kinds/edge_kinds codegen contract intact while giving clients a simple empty-data-independent catalog
- add regression coverage that the alias arrays include every EntityType and RelationshipType without needing graph rows

Verification
- PYTHONPATH=src uv run pytest tests/test_graph_schema.py::TestGraphSchemaEndpoint -q
- uv run ruff check src/agent_bom/api/routes/graph.py tests/test_graph_schema.py
- uv run mypy src/agent_bom/api/routes/graph.py
- uv run --extra api python scripts/export_openapi.py --check
- python scripts/check_release_consistency.py
- git diff --check

Refs #2487
