### PR TITLE
fix(ci): dispatch required checks for current PRs

### DIFF
--- a/.github/workflows/auto-retrigger-stranded.yml
+++ b/.github/workflows/auto-retrigger-stranded.yml
@@ -16,10 +16,11 @@ name: Auto-Retrigger Stranded PRs
 # behind main, then retriggers any PR whose current head SHA is missing or has a
 # stale required check.
 #
-# The refresh/retrigger token must be a dedicated GitHub App token or PAT.
-# GITHUB_TOKEN-authored pushes and close/reopen events do not recursively
-# trigger pull_request workflows, so falling back to GITHUB_TOKEN recreates the
-# frozen-PR loop this workflow is meant to break.
+# Branch refresh and close/reopen retriggering still require a dedicated GitHub
+# App token or PAT. When that token is absent, this workflow falls back to
+# dispatching the required workflows for PR heads that already contain current
+# main. That fallback cannot update stale branches, but it prevents approved PRs
+# from sitting behind "expected" required contexts when no code fix is needed.
 
 on:
   push:
@@ -51,6 +52,7 @@ on:
         type: boolean
 
 permissions:
+  actions: write
   contents: read
   pull-requests: read
 
@@ -71,7 +73,8 @@ jobs:
 
       - name: Find and retrigger stranded PRs
         env:
-          GH_TOKEN: ${{ secrets.AUTOMATION_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTOMATION_GITHUB_TOKEN || github.token }}
+          AUTOMATION_TOKEN_CONFIGURED: ${{ secrets.AUTOMATION_GITHUB_TOKEN != '' }}
           AUTOMATION_SSH_SIGNING_KEY: ${{ secrets.AUTOMATION_SSH_SIGNING_KEY }}
           REQUIRED_CHECKS: "Lint and Type Check,Test (Python 3.11),Test (Python 3.13),Build Package,Security Scan,CodeQL,Test (Python 3.14)"
           MIN_AGE_MINUTES: ${{ inputs.min_age_minutes || '3' }}
@@ -80,8 +83,48 @@ jobs:
           REFRESH_READY_PRS: ${{ github.event_name != 'workflow_dispatch' || inputs.refresh_ready_prs }}
         run: |
           set -euo pipefail
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::warning::AUTOMATION_GITHUB_TOKEN is not configured; skipping auto refresh/retrigger. GITHUB_TOKEN-authored events cannot start PR checks."
+
+          if [ "${AUTOMATION_TOKEN_CONFIGURED}" != "true" ]; then
+            echo "::warning::AUTOMATION_GITHUB_TOKEN is not configured; branch refresh and close/reopen retrigger are disabled."
+            echo "::notice::Using GITHUB_TOKEN fallback to dispatch required CI for current PR heads with missing contexts."
+
+            if [ -n "${PR_NUMBER}" ]; then
+              echo "Manual fallback dispatch requested for PR #${PR_NUMBER}."
+              scripts/dispatch_required_ci.sh "${PR_NUMBER}"
+              exit 0
+            fi
+
+            echo "Listing open PRs for fallback dispatch…"
+            mapfile -t PRS < <(
+              gh pr list \
+                --state open \
+                --limit 50 \
+                --json number,headRefOid,updatedAt,isDraft \
+                --jq '.[] | select(.isDraft == false) | "\(.number) \(.headRefOid) \(.updatedAt)"'
+            )
+
+            NOW_EPOCH="$(date -u +%s)"
+            CHECKED=0
+            DISPATCHED=0
+            for line in "${PRS[@]}"; do
+              read -r PR SHA UPDATED <<< "$line"
+              UPDATED_EPOCH="$(date -u -d "$UPDATED" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED" +%s)"
+              AGE_SECONDS=$(( NOW_EPOCH - UPDATED_EPOCH ))
+              if [ "$AGE_SECONDS" -lt $(( 60 * MIN_AGE_MINUTES )) ]; then
+                echo "PR #${PR}: too young (${AGE_SECONDS}s old), skipping."
+                continue
+              fi
+
+              CHECKED=$(( CHECKED + 1 ))
+              if scripts/dispatch_required_ci.sh "$PR"; then
+                DISPATCHED=$(( DISPATCHED + 1 ))
+              else
+                echo "PR #${PR}: fallback dispatch check failed (continuing with next PR)."
+              fi
+            done
+
+            echo
+            echo "Summary: ${CHECKED} eligible PR(s) checked, ${DISPATCHED} fallback dispatch command(s) completed."
             exit 0
           fi
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,7 @@ on:
     branches: [main]
   merge_group:
     types: [checks_requested]
+  workflow_dispatch:
   schedule:
     - cron: '30 1 * * 1'  # Weekly on Monday at 01:30 UTC
 

--- a/docs/operations/CI_RUNBOOK.md
+++ b/docs/operations/CI_RUNBOOK.md
@@ -33,10 +33,23 @@ scripts/refresh_ready_prs.sh
 
 The script only refreshes same-repo, non-draft PRs targeting `main`. By default
 it further limits writes to PRs with auto-merge already enabled, so exploratory
-branches are left alone. The workflow must use `AUTOMATION_GITHUB_TOKEN`, a
-dedicated GitHub App token or PAT with repo pull-request/write access. Do not
-fall back to `GITHUB_TOKEN` for refresh or retrigger events: GitHub suppresses
-workflows triggered by that token, which recreates the frozen-check loop.
+branches are left alone. Branch refresh and close/reopen retrigger require
+`AUTOMATION_GITHUB_TOKEN`, a dedicated GitHub App token or PAT with repo
+pull-request/write access. Do not use `GITHUB_TOKEN` for refresh or
+close/reopen events: GitHub suppresses workflows triggered by that token, which
+recreates the frozen-check loop.
+
+If `AUTOMATION_GITHUB_TOKEN` is not configured, the workflow now uses a
+lower-privilege fallback:
+
+```sh
+scripts/dispatch_required_ci.sh <PR_NUMBER>
+```
+
+That fallback dispatches `ci.yml` and, when needed, `codeql.yml` through
+`workflow_dispatch` for same-repo PR heads that already contain current `main`.
+It cannot update stale branches, but it prevents the common "all visible checks
+passed, required contexts are still expected" state from wasting a merge cycle.
 
 Manual one-shot refresh:
 
@@ -104,11 +117,17 @@ and through `workflow_dispatch` for on-demand. Once this workflow is on the
 default branch and `AUTOMATION_GITHUB_TOKEN` is configured, stranded PRs
 unstrand themselves within five minutes — no operator action required.
 
+When the automation token is absent, the workflow falls back to
+`scripts/dispatch_required_ci.sh` and dispatches required workflows for current
+same-repo PR heads. This is less powerful than branch refresh, but it is enough
+for PRs that are already rebased and only missing required status contexts.
+
 Operator-side troubleshooting if a strand persists past ~10 minutes:
 
 - Did the workflow itself run? `gh run list --workflow=auto-retrigger-stranded.yml --limit 5`
-- Is `AUTOMATION_GITHUB_TOKEN` configured? Without it the workflow intentionally
-  skips write actions because `GITHUB_TOKEN` cannot start required PR checks.
+- Is `AUTOMATION_GITHUB_TOKEN` configured? Without it the workflow can dispatch
+  required checks for current heads, but cannot refresh stale branches or use
+  the close/reopen retrigger path.
 - Was the PR younger than `MIN_AGE_MINUTES` (3 min by default)? It's intentionally
   skipped to give the initial `pull_request` workflow a chance to start.
 - Did `gh api commits/{sha}/check-runs` return zero, or is there a

--- a/scripts/dispatch_required_ci.sh
+++ b/scripts/dispatch_required_ci.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Dispatch required workflows for a PR whose current head is missing required
+# status contexts, without closing/reopening the PR.
+#
+# This is the safe fallback for repositories where AUTOMATION_GITHUB_TOKEN is
+# not configured. It can only help when the PR branch already contains current
+# main. If the branch is stale, a signed refresh still needs the dedicated
+# automation token path in scripts/refresh_ready_prs.sh.
+#
+# Usage:
+#   scripts/dispatch_required_ci.sh <PR_NUMBER>
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <PR_NUMBER>" >&2
+  exit 64
+fi
+
+PR="$1"
+REQUIRED_CHECKS="${REQUIRED_CHECKS:-Lint and Type Check,Test (Python 3.11),Test (Python 3.13),Build Package,Security Scan,CodeQL,Test (Python 3.14)}"
+REPO="${GH_REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+
+pr_json="$(
+  gh pr view "${PR}" \
+    --repo "${REPO}" \
+    --json baseRefName,headRefName,headRefOid,headRepositoryOwner,isCrossRepository,isDraft
+)"
+
+is_draft="$(jq -r '.isDraft' <<< "${pr_json}")"
+is_cross_repo="$(jq -r '.isCrossRepository' <<< "${pr_json}")"
+head_owner="$(jq -r '.headRepositoryOwner.login' <<< "${pr_json}")"
+head_ref="$(jq -r '.headRefName' <<< "${pr_json}")"
+head_sha="$(jq -r '.headRefOid' <<< "${pr_json}")"
+base_ref="$(jq -r '.baseRefName' <<< "${pr_json}")"
+repo_owner="${REPO%%/*}"
+
+if [ "${is_draft}" = "true" ]; then
+  echo "PR #${PR}: draft, skipping fallback dispatch."
+  exit 0
+fi
+
+if [ "${is_cross_repo}" = "true" ] || [ "${head_owner}" != "${repo_owner}" ]; then
+  echo "PR #${PR}: fork-owned branch (${head_owner}/${head_ref}), skipping fallback dispatch."
+  exit 0
+fi
+
+base_sha="$(gh api "repos/${REPO}/git/ref/heads/${base_ref}" --jq .object.sha)"
+missing_from_head="$(gh api "repos/${REPO}/compare/${head_sha}...${base_sha}" --jq .ahead_by)"
+if [ "${missing_from_head}" -gt 0 ]; then
+  echo "PR #${PR}: ${missing_from_head} ${base_ref} commit(s) missing; fallback dispatch cannot refresh stale branches."
+  exit 0
+fi
+
+check_runs="$(
+  gh api "repos/${REPO}/commits/${head_sha}/check-runs?per_page=100" --jq '.check_runs' || printf '[]'
+)"
+if [ -z "${check_runs}" ]; then
+  check_runs="[]"
+fi
+
+IFS=',' read -r -a required_check_list <<< "${REQUIRED_CHECKS}"
+missing=()
+stale=()
+active=()
+successful=()
+failed=()
+
+for raw_check in "${required_check_list[@]}"; do
+  check="$(xargs <<< "${raw_check}")"
+  [ -n "${check}" ] || continue
+
+  check_state="$(jq --arg name "${check}" '[.[] | select(.name == $name) | {status, conclusion}]' <<< "${check_runs}")"
+  check_hits="$(jq 'length' <<< "${check_state}")"
+  active_hits="$(jq '[.[] | select(.status != "completed")] | length' <<< "${check_state}")"
+  success_hits="$(jq '[.[] | select(.conclusion == "success" or .conclusion == "neutral")] | length' <<< "${check_state}")"
+  stale_hits="$(jq '[.[] | select(.conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "startup_failure" or .conclusion == "stale" or .conclusion == "skipped")] | length' <<< "${check_state}")"
+  failed_hits="$(jq '[.[] | select(.conclusion == "failure" or .conclusion == "action_required")] | length' <<< "${check_state}")"
+
+  if [ "${active_hits}" -gt 0 ]; then
+    active+=("${check}")
+  elif [ "${success_hits}" -gt 0 ]; then
+    successful+=("${check}")
+  elif [ "${failed_hits}" -gt 0 ] && [ "${stale_hits}" -eq 0 ]; then
+    failed+=("${check}")
+  elif [ "${check_hits}" -eq 0 ]; then
+    missing+=("${check}")
+  else
+    stale+=("${check}")
+  fi
+done
+
+if [ "${#failed[@]}" -gt 0 ]; then
+  printf "PR #%s: required check(s) failed on head %s: %s. Not dispatching over real failures.\n" \
+    "${PR}" "${head_sha}" "$(IFS=', '; echo "${failed[*]}")"
+  exit 0
+fi
+
+if [ "${#active[@]}" -gt 0 ]; then
+  printf "PR #%s: required checks are active on head %s (%s active, %s successful, %s missing, %s stale). Not dispatching a duplicate run.\n" \
+    "${PR}" "${head_sha}" "${#active[@]}" "${#successful[@]}" "${#missing[@]}" "${#stale[@]}"
+  exit 0
+fi
+
+if [ "${#missing[@]}" -eq 0 ] && [ "${#stale[@]}" -eq 0 ]; then
+  printf "PR #%s: required checks are attached on head %s (%s successful). No fallback dispatch needed.\n" \
+    "${PR}" "${head_sha}" "${#successful[@]}"
+  exit 0
+fi
+
+reason_parts=()
+if [ "${#missing[@]}" -gt 0 ]; then
+  reason_parts+=("missing: $(IFS=', '; echo "${missing[*]}")")
+fi
+if [ "${#stale[@]}" -gt 0 ]; then
+  reason_parts+=("stale: $(IFS=', '; echo "${stale[*]}")")
+fi
+reason="$(IFS='; '; echo "${reason_parts[*]}")"
+
+echo "PR #${PR}: dispatching required workflows for head ${head_sha} (${reason})."
+gh workflow run ci.yml --repo "${REPO}" --ref "${head_ref}"
+
+if printf '%s\n' "${missing[@]}" "${stale[@]}" | grep -qx "CodeQL"; then
+  gh workflow run codeql.yml --repo "${REPO}" --ref "${head_ref}"
+fi
+
+echo "PR #${PR}: required workflow dispatch requested."

--- a/scripts/dispatch_required_ci.sh
+++ b/scripts/dispatch_required_ci.sh
@@ -120,7 +120,14 @@ reason="$(IFS='; '; echo "${reason_parts[*]}")"
 echo "PR #${PR}: dispatching required workflows for head ${head_sha} (${reason})."
 gh workflow run ci.yml --repo "${REPO}" --ref "${head_ref}"
 
-if printf '%s\n' "${missing[@]}" "${stale[@]}" | grep -qx "CodeQL"; then
+codeql_needed=false
+if [ "${#missing[@]}" -gt 0 ] && printf '%s\n' "${missing[@]}" | grep -qx "CodeQL"; then
+  codeql_needed=true
+fi
+if [ "${#stale[@]}" -gt 0 ] && printf '%s\n' "${stale[@]}" | grep -qx "CodeQL"; then
+  codeql_needed=true
+fi
+if [ "${codeql_needed}" = "true" ]; then
   gh workflow run codeql.yml --repo "${REPO}" --ref "${head_ref}"
 fi
 

--- a/scripts/enable_merge_queue.sh
+++ b/scripts/enable_merge_queue.sh
@@ -12,10 +12,10 @@
 # For the recurring stranded-CI pain that motivated wanting merge queue,
 # `.github/workflows/auto-retrigger-stranded.yml` is the practical fix:
 # it runs after main advances, polls open PRs every 5 minutes, refreshes
-# ready auto-merge PRs that are behind main with a dedicated automation token, and runs
-# scripts/retrigger_stranded_pr.sh against any whose current head SHA has zero
-# or stale check-runs. That neutralises strict-branch staleness without falling
-# back to GITHUB_TOKEN-authored events, which GitHub intentionally suppresses.
+# ready auto-merge PRs that are behind main with a dedicated automation token,
+# and runs scripts/retrigger_stranded_pr.sh against any whose current head SHA
+# has zero or stale check-runs. If the dedicated token is absent, it can still
+# dispatch required workflows for PR heads that already contain current main.
 #
 # Usage:
 #   scripts/enable_merge_queue.sh         # print steps
@@ -65,5 +65,6 @@ Until the toggle is on, the practical fix for stale/stranded PRs is the
 workflow at .github/workflows/auto-retrigger-stranded.yml, which refreshes
 ready auto-merge PRs after main advances and auto-runs
 scripts/retrigger_stranded_pr.sh every 5 minutes. Configure the
-AUTOMATION_GITHUB_TOKEN secret first; GITHUB_TOKEN cannot retrigger PR checks.
+AUTOMATION_GITHUB_TOKEN secret for branch refreshes; without it, the workflow
+falls back to scripts/dispatch_required_ci.sh for already-current PR heads.
 EOF


### PR DESCRIPTION
Summary
- add a safe required-check dispatcher for same-repo PR heads that are already current with main
- let the stranded-PR workflow fall back to workflow_dispatch when AUTOMATION_GITHUB_TOKEN is absent
- add CodeQL workflow_dispatch and document the token boundary in the CI runbook

Verification
- bash -n scripts/dispatch_required_ci.sh scripts/retrigger_stranded_pr.sh scripts/refresh_ready_prs.sh scripts/enable_merge_queue.sh
- REQUIRED_CHECKS='Lint and Type Check,Test (Python 3.11),Test (Python 3.13),Build Package,Security Scan,CodeQL,Test (Python 3.14)' scripts/dispatch_required_ci.sh 2652
- git diff --check

Closes #2661
