### PR TITLE
feat(inventory): emit Agent BOM manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Agent BOM manifest now has a canonical local/tenant inventory contract with
+  a top-level `agent-bom manifest` CLI command, `GET /v1/agent-bom/manifest`,
+  redacted credential references, graph relationships, and a dashboard cockpit
+  for agent/MCP/tool visibility.
 - **Runtime production index** - added a tenant-scoped
   `/v1/runtime/production-index` security-observability endpoint for
   proxy/gateway traffic with tool-call volume, policy decision summaries,

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -3444,6 +3444,30 @@
         ]
       }
     },
+    "/v1/agent-bom/manifest": {
+      "get": {
+        "description": "Return the tenant-scoped Agent BOM manifest from fleet/runtime stores.",
+        "operationId": "get_agent_bom_manifest_v1_agent_bom_manifest_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Agent Bom Manifest V1 Agent Bom Manifest Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Agent Bom Manifest",
+        "tags": [
+          "Agent BOM"
+        ]
+      }
+    },
     "/v1/agents": {
       "get": {
         "description": "Quick auto-discovery of local AI agent configs (Claude Desktop, Cursor, Windsurf...).\nNo CVE scan \u2014 instant results for the UI sidebar.",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -2268,6 +2268,23 @@ paths:
       summary: Activity Timeline
       tags:
       - governance
+  /v1/agent-bom/manifest:
+    get:
+      description: Return the tenant-scoped Agent BOM manifest from fleet/runtime
+        stores.
+      operationId: get_agent_bom_manifest_v1_agent_bom_manifest_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Agent Bom Manifest V1 Agent Bom Manifest Get
+                type: object
+          description: Successful Response
+      summary: Get Agent Bom Manifest
+      tags:
+      - Agent BOM
   /v1/agents:
     get:
       description: "Quick auto-discovery of local AI agent configs (Claude Desktop,\

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -7,6 +7,7 @@
 | Command | Description |
 |---------|-------------|
 | `agents` | Discover MCP clients, extract dependencies, scan packages, and compute blast radius |
+| `manifest` | Emit the canonical Agent BOM manifest for local agent, MCP server, tool, and credential-reference posture |
 | `skills` | Scan, verify, and rescan AI instruction files and skills |
 | `image` | Scan a container image |
 | `fs` | Scan a filesystem directory or mounted VM disk snapshot |

--- a/src/agent_bom/agent_manifest.py
+++ b/src/agent_bom/agent_manifest.py
@@ -1,0 +1,352 @@
+"""Canonical Agent BOM manifest helpers.
+
+The manifest is the portable inventory contract for agent runtimes: which
+humans/agents are present, which MCP servers and tools they can reach, and
+which credential references are configured. It deliberately emits credential
+names only, never values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from agent_bom.api.fleet_store import FleetAgent
+from agent_bom.api.mcp_observation_store import MCPObservation
+from agent_bom.models import Agent, MCPServer, MCPTool
+from agent_bom.platform_invariants import now_utc_iso
+from agent_bom.security import sanitize_command_args, sanitize_security_warnings, sanitize_text, sanitize_url
+
+AGENT_BOM_MANIFEST_SCHEMA_VERSION = "agent-bom.manifest/v1"
+AGENT_BOM_GRAPH_RELATIONSHIPS = ("uses", "provides_tool", "exposes_cred")
+
+
+def _value(value: object) -> str:
+    if hasattr(value, "value"):
+        return str(getattr(value, "value"))
+    return str(value)
+
+
+def _safe_path(value: object) -> str | None:
+    if not value:
+        return None
+    return sanitize_text(str(value), max_len=300)
+
+
+def _credential_refs(names: Iterable[str]) -> list[dict[str, str]]:
+    return [{"name": sanitize_text(name, max_len=120), "kind": "env"} for name in sorted({name for name in names if name})]
+
+
+def _tool(tool: MCPTool) -> dict[str, object]:
+    return {
+        "name": sanitize_text(tool.name, max_len=160),
+        "description": sanitize_text(tool.description, max_len=300) if tool.description else "",
+    }
+
+
+def _server(server: MCPServer) -> dict[str, object]:
+    permission_profile = server.permission_profile
+    return {
+        "id": server.stable_id,
+        "canonical_id": server.canonical_id,
+        "fingerprint": server.fingerprint,
+        "name": sanitize_text(server.name, max_len=160),
+        "transport": _value(server.transport),
+        "url": sanitize_url(server.url) if server.url else None,
+        "command": sanitize_text(server.command, max_len=200),
+        "args": sanitize_command_args(server.args),
+        "config_path": _safe_path(server.config_path),
+        "working_dir": _safe_path(server.working_dir),
+        "auth_mode": server.auth_mode,
+        "credential_refs": _credential_refs(server.credential_names),
+        "tools": [_tool(tool) for tool in server.tools],
+        "tool_count": len(server.tools),
+        "resource_count": len(server.resources),
+        "prompt_count": len(server.prompts),
+        "package_count": len(server.packages),
+        "registry": {
+            "verified": bool(server.registry_verified),
+            "id": sanitize_text(server.registry_id, max_len=200) if server.registry_id else None,
+        },
+        "security": {
+            "blocked": bool(server.security_blocked),
+            "warnings": sanitize_security_warnings(server.security_warnings),
+            "privilege_level": permission_profile.privilege_level if permission_profile else "unknown",
+        },
+        "discovery": {
+            "sources": sorted(set(server.discovery_sources)),
+            "surface": sanitize_text(server.surface, max_len=80),
+        },
+    }
+
+
+def _agent(agent: Agent) -> dict[str, object]:
+    return {
+        "id": agent.stable_id,
+        "canonical_id": agent.canonical_id,
+        "name": sanitize_text(agent.name, max_len=160),
+        "agent_type": _value(agent.agent_type),
+        "status": _value(agent.status),
+        "source": sanitize_text(agent.source, max_len=120),
+        "config_path": _safe_path(agent.config_path),
+        "version": sanitize_text(agent.version, max_len=80) if agent.version else None,
+        "discovered_at": agent.discovered_at,
+        "last_seen": agent.last_seen,
+        "mcp_server_ids": [server.stable_id for server in agent.mcp_servers],
+    }
+
+
+def _fleet_agent(agent: FleetAgent) -> dict[str, object]:
+    return {
+        "id": agent.agent_id,
+        "canonical_id": agent.canonical_id,
+        "name": sanitize_text(agent.name, max_len=160),
+        "agent_type": sanitize_text(agent.agent_type, max_len=120),
+        "status": _value(agent.lifecycle_state),
+        "source_id": sanitize_text(agent.source_id, max_len=160) if agent.source_id else "",
+        "owner": sanitize_text(agent.owner, max_len=160) if agent.owner else None,
+        "environment": sanitize_text(agent.environment, max_len=120) if agent.environment else None,
+        "tags": [sanitize_text(tag, max_len=80) for tag in agent.tags],
+        "trust_score": agent.trust_score,
+        "counts": {
+            "mcp_servers": agent.server_count,
+            "packages": agent.package_count,
+            "credential_refs": agent.credential_count,
+            "vulnerabilities": agent.vuln_count,
+        },
+        "config_path": _safe_path(agent.config_path),
+        "last_discovery": agent.last_discovery,
+        "last_scan": agent.last_scan,
+        "updated_at": agent.updated_at,
+    }
+
+
+def _observed_server(observation: MCPObservation) -> dict[str, object]:
+    return {
+        "id": observation.server_stable_id,
+        "canonical_id": observation.server_canonical_id,
+        "fingerprint": observation.server_fingerprint,
+        "name": sanitize_text(observation.server_name, max_len=160),
+        "agent_name": sanitize_text(observation.agent_name, max_len=160),
+        "transport": sanitize_text(observation.transport, max_len=80),
+        "url": observation.url,
+        "command": observation.command,
+        "args": observation.args,
+        "config_path": _safe_path(observation.config_path),
+        "auth_mode": observation.auth_mode,
+        "credential_refs": _credential_refs(observation.credential_env_vars),
+        "security": {
+            "blocked": bool(observation.security_blocked),
+            "warnings": observation.security_warnings,
+        },
+        "observed": {
+            "configured_locally": bool(observation.configured_locally),
+            "fleet_present": bool(observation.fleet_present),
+            "gateway_registered": bool(observation.gateway_registered),
+            "runtime_observed": bool(observation.runtime_observed),
+            "via": sorted(set(observation.observed_via)),
+            "scopes": sorted(set(observation.observed_scopes)),
+            "first_seen": observation.first_seen,
+            "last_seen": observation.last_seen,
+            "last_synced": observation.last_synced,
+        },
+    }
+
+
+def _summary(agents: list[dict[str, object]], servers: list[dict[str, object]]) -> dict[str, int]:
+    def _credential_ref_rows(server: dict[str, object]) -> list[dict[str, object]]:
+        refs = server.get("credential_refs")
+        return refs if isinstance(refs, list) else []
+
+    def _tool_count(server: dict[str, object]) -> int:
+        explicit = server.get("tool_count")
+        if isinstance(explicit, int):
+            return explicit
+        tools = server.get("tools")
+        return len(tools) if isinstance(tools, list) else 0
+
+    credential_refs = {
+        str(ref.get("name")) for server in servers for ref in _credential_ref_rows(server) if isinstance(ref, dict) and ref.get("name")
+    }
+    runtime_observed = 0
+    gateway_registered = 0
+    for server in servers:
+        observed = server.get("observed")
+        if isinstance(observed, dict):
+            runtime_observed += 1 if observed.get("runtime_observed") else 0
+            gateway_registered += 1 if observed.get("gateway_registered") else 0
+    return {
+        "agents": len(agents),
+        "mcp_servers": len(servers),
+        "tools": sum(_tool_count(server) for server in servers),
+        "credential_refs": len(credential_refs),
+        "runtime_observed_servers": runtime_observed,
+        "gateway_registered_servers": gateway_registered,
+    }
+
+
+def _node(node_id: str, entity_type: str, label: str, **attributes: object) -> dict[str, object]:
+    return {
+        "id": node_id,
+        "entity_type": entity_type,
+        "label": sanitize_text(label, max_len=180),
+        "attributes": {key: value for key, value in attributes.items() if value not in (None, "", [])},
+    }
+
+
+def _edge(edge_id: str, source: str, target: str, relationship: str, **attributes: object) -> dict[str, object]:
+    return {
+        "id": edge_id,
+        "source": source,
+        "target": target,
+        "relationship": relationship,
+        "attributes": {key: value for key, value in attributes.items() if value not in (None, "", [])},
+    }
+
+
+def _graph(agents: list[dict[str, object]], servers: list[dict[str, object]]) -> dict[str, object]:
+    nodes: dict[str, dict[str, object]] = {}
+    edges: dict[str, dict[str, object]] = {}
+
+    for agent in agents:
+        agent_id = str(agent.get("id") or agent.get("canonical_id") or agent.get("name"))
+        if not agent_id:
+            continue
+        nodes[agent_id] = _node(
+            agent_id,
+            "agent",
+            str(agent.get("name") or agent_id),
+            agent_type=agent.get("agent_type"),
+            status=agent.get("status"),
+            owner=agent.get("owner"),
+            environment=agent.get("environment"),
+        )
+
+    agent_by_name = {
+        str(agent.get("name")): str(agent.get("id") or agent.get("canonical_id") or agent.get("name"))
+        for agent in agents
+        if agent.get("name")
+    }
+
+    for server in servers:
+        server_id = str(server.get("id") or server.get("canonical_id") or server.get("name"))
+        if not server_id:
+            continue
+        nodes[server_id] = _node(
+            server_id,
+            "server",
+            str(server.get("name") or server_id),
+            transport=server.get("transport"),
+            auth_mode=server.get("auth_mode"),
+        )
+
+        agent_name = str(server.get("agent_name") or "")
+        linked_agent_ids: list[str] = []
+        if agent_name and agent_name in agent_by_name:
+            linked_agent_ids.append(agent_by_name[agent_name])
+        for agent in agents:
+            server_ids = agent.get("mcp_server_ids")
+            if isinstance(server_ids, list) and server_id in {str(item) for item in server_ids}:
+                linked_agent_ids.append(str(agent.get("id") or agent.get("canonical_id") or agent.get("name")))
+        for agent_id in sorted(set(linked_agent_ids)):
+            edges[f"{agent_id}:uses:{server_id}"] = _edge(f"{agent_id}:uses:{server_id}", agent_id, server_id, "uses")
+
+        tools = server.get("tools")
+        if isinstance(tools, list):
+            for tool in tools:
+                if not isinstance(tool, dict):
+                    continue
+                tool_name = str(tool.get("name") or "")
+                if not tool_name:
+                    continue
+                tool_id = f"{server_id}:tool:{tool_name}"
+                nodes[tool_id] = _node(tool_id, "tool", tool_name, server=server.get("name"))
+                edges[f"{server_id}:provides_tool:{tool_id}"] = _edge(
+                    f"{server_id}:provides_tool:{tool_id}",
+                    server_id,
+                    tool_id,
+                    "provides_tool",
+                )
+
+        refs = server.get("credential_refs")
+        if isinstance(refs, list):
+            for ref in refs:
+                if not isinstance(ref, dict):
+                    continue
+                ref_name = str(ref.get("name") or "")
+                if not ref_name:
+                    continue
+                cred_id = f"credential:{ref_name}"
+                nodes[cred_id] = _node(cred_id, "credential", ref_name, kind=ref.get("kind"))
+                edges[f"{server_id}:exposes_cred:{cred_id}"] = _edge(
+                    f"{server_id}:exposes_cred:{cred_id}",
+                    server_id,
+                    cred_id,
+                    "exposes_cred",
+                )
+
+    return {
+        "nodes": list(nodes.values()),
+        "edges": list(edges.values()),
+        "stats": {
+            "nodes": len(nodes),
+            "edges": len(edges),
+            "relationships": list(AGENT_BOM_GRAPH_RELATIONSHIPS),
+        },
+    }
+
+
+def _manifest(
+    source: str,
+    agents: list[dict[str, object]],
+    servers: list[dict[str, object]],
+    tenant_id: str | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": AGENT_BOM_MANIFEST_SCHEMA_VERSION,
+        "generated_at": now_utc_iso(),
+        "source": source,
+        "summary": _summary(agents, servers),
+        "agents": agents,
+        "mcp_servers": servers,
+        "graph": _graph(agents, servers),
+        "boundaries": {
+            "stores_credential_values": False,
+            "stores_raw_prompts": False,
+            "credential_value_policy": "redacted",
+        },
+    }
+    if tenant_id is not None:
+        payload["tenant_id"] = tenant_id
+    return payload
+
+
+def build_local_agent_manifest(
+    agents: Iterable[Agent],
+    *,
+    source: str = "local-discovery",
+    tenant_id: str | None = None,
+) -> dict[str, object]:
+    agent_list = list(agents)
+    agent_rows = [_agent(agent) for agent in agent_list]
+    server_rows = [_server(server) for agent in agent_list for server in agent.mcp_servers]
+    return _manifest(source, agent_rows, server_rows, tenant_id)
+
+
+def build_control_plane_agent_manifest(
+    fleet_agents: Iterable[FleetAgent],
+    observations: Iterable[MCPObservation],
+    *,
+    tenant_id: str,
+) -> dict[str, object]:
+    agent_rows = [_fleet_agent(agent) for agent in fleet_agents]
+    server_rows = [_observed_server(observation) for observation in observations]
+    return _manifest("control-plane", agent_rows, server_rows, tenant_id)
+
+
+def assert_no_credential_values(payload: dict[str, Any]) -> None:
+    """Guardrail used by tests and future exporters."""
+    text = repr(payload).lower()
+    forbidden_tokens = ("sk-", "secret=", "token=", "password=", "apikey=")
+    if any(token in text for token in forbidden_tokens):
+        raise ValueError("agent manifest contains credential-like values")

--- a/src/agent_bom/api/routes/agent_manifest.py
+++ b/src/agent_bom/api/routes/agent_manifest.py
@@ -1,0 +1,20 @@
+"""Agent BOM manifest API routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from agent_bom.agent_manifest import build_control_plane_agent_manifest
+from agent_bom.api.stores import _get_fleet_store, _get_mcp_observation_store
+
+router = APIRouter(prefix="/v1/agent-bom", tags=["Agent BOM"])
+
+
+@router.get("/manifest")
+async def get_agent_bom_manifest(request: Request) -> dict[str, object]:
+    """Return the tenant-scoped Agent BOM manifest from fleet/runtime stores."""
+
+    tenant_id = getattr(request.state, "tenant_id", "default")
+    fleet_agents = _get_fleet_store().list_by_tenant(tenant_id)
+    observations = _get_mcp_observation_store().list_by_tenant(tenant_id)
+    return build_control_plane_agent_manifest(fleet_agents, observations, tenant_id=tenant_id)

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -710,6 +710,7 @@ from agent_bom.api.pipeline import (  # noqa: E402
     iter_pipeline_dag_event_records,  # noqa: F401 — re-exported for tests/artifact consumers
     pipeline_dag_events_jsonl,  # noqa: F401 — re-exported for tests/artifact consumers
 )
+from agent_bom.api.routes.agent_manifest import router as _agent_manifest_router  # noqa: E402
 
 # ─── Route modules ────────────────────────────────────────────────────────
 from agent_bom.api.routes.assets import router as _assets_router  # noqa: E402
@@ -736,6 +737,7 @@ from agent_bom.api.routes.scim import router as _scim_router  # noqa: E402
 from agent_bom.api.routes.sources import router as _sources_router  # noqa: E402
 
 app.include_router(_assets_router)
+app.include_router(_agent_manifest_router)
 app.include_router(_compliance_router)
 app.include_router(_connectors_router)
 app.include_router(_credentials_router)

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -139,10 +139,12 @@ def main(ctx: click.Context, profile: str | None, agent_mode: bool):
 # Register subcommands from each module
 # ---------------------------------------------------------------------------
 
+from agent_bom.cli._agent_manifest import manifest_cmd  # noqa: E402
 from agent_bom.cli.agents import scan as _agents_cmd  # noqa: E402
 
 # 'agents' is the primary visible command.
 main.add_command(_agents_cmd, "agents")
+main.add_command(manifest_cmd, "manifest")
 
 # 'scan' kept as hidden backward-compat CLI alias (50+ tests + CI use it).
 # Clone the command object so hiding doesn't affect 'agents'.

--- a/src/agent_bom/cli/_agent_manifest.py
+++ b/src/agent_bom/cli/_agent_manifest.py
@@ -1,0 +1,69 @@
+"""Agent BOM manifest CLI."""
+
+from __future__ import annotations
+
+import json
+from contextlib import nullcontext, redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+import click
+
+from agent_bom.agent_manifest import build_local_agent_manifest
+from agent_bom.cli._common import _build_agents_from_inventory, read_json_file_for_cli
+from agent_bom.cli._inventory import _project_inventory_path
+from agent_bom.discovery import discover_all
+
+
+def _discover_manifest_agents(config: str | None, project: str | None):
+    if config:
+        config_path = Path(config)
+        config_data = read_json_file_for_cli(config_path, label="MCP config")
+        from agent_bom.discovery import parse_mcp_config
+        from agent_bom.models import Agent, AgentType
+
+        servers = parse_mcp_config(config_data, str(config_path))
+        return (
+            [
+                Agent(
+                    name=f"custom:{config_path.stem}",
+                    agent_type=AgentType.CUSTOM,
+                    config_path=str(config_path),
+                    mcp_servers=servers,
+                )
+            ]
+            if servers
+            else []
+        )
+
+    project_inventory = _project_inventory_path(project)
+    if project_inventory is not None:
+        from agent_bom.inventory import load_inventory
+
+        inventory_data = load_inventory(str(project_inventory))
+        return _build_agents_from_inventory(inventory_data, str(project_inventory))
+
+    return discover_all(project_dir=project)
+
+
+@click.command("manifest")
+@click.option("--config", "-c", type=click.Path(exists=True), help="Path to a specific MCP config file.")
+@click.option("--project", "-p", type=click.Path(exists=True), help="Project directory to inspect for agent inventory.")
+@click.option("--tenant-id", default=None, help="Optional tenant identifier to stamp into the manifest.")
+@click.option("--output", "-o", type=click.Path(dir_okay=False), help="Write the manifest JSON to a file instead of stdout.")
+@click.option("--compact", is_flag=True, help="Emit compact JSON without indentation.")
+def manifest_cmd(config: str | None, project: str | None, tenant_id: str | None, output: str | None, compact: bool) -> None:
+    """Emit the canonical Agent BOM manifest for local agent/MCP posture."""
+
+    with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+        agents = _discover_manifest_agents(config, project)
+
+    payload = build_local_agent_manifest(agents, tenant_id=tenant_id)
+    rendered = json.dumps(payload, separators=(",", ":") if compact else None, indent=None if compact else 2)
+
+    if output:
+        Path(output).write_text(rendered + "\n")
+        click.echo(f"Wrote Agent BOM manifest to {output}")
+        return
+    with nullcontext():
+        click.echo(rendered)

--- a/tests/test_agent_manifest.py
+++ b/tests/test_agent_manifest.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from click.testing import CliRunner
+from starlette.testclient import TestClient
+
+from agent_bom.agent_manifest import build_local_agent_manifest
+from agent_bom.api import stores as api_stores
+from agent_bom.api.fleet_store import FleetAgent, FleetLifecycleState, InMemoryFleetStore
+from agent_bom.api.mcp_observation_store import InMemoryMCPObservationStore, MCPObservation
+from agent_bom.api.server import app
+from agent_bom.cli import main
+from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, TransportType
+
+
+def _agent() -> Agent:
+    return Agent(
+        name="local-coder",
+        agent_type=AgentType.CLAUDE_DESKTOP,
+        config_path="/tmp/claude.json",
+        mcp_servers=[
+            MCPServer(
+                name="filesystem",
+                command="npx",
+                args=["-y", "@modelcontextprotocol/server-filesystem", "--token", "sk-hidden"],
+                env={"API_KEY": "sk-secret-value", "SAFE_FLAG": "1"},
+                transport=TransportType.STDIO,
+                tools=[MCPTool(name="read_file", description="Read files")],
+            )
+        ],
+    )
+
+
+def test_local_agent_manifest_redacts_credential_values() -> None:
+    payload = build_local_agent_manifest([_agent()])
+    rendered = repr(payload)
+
+    assert payload["schema_version"] == "agent-bom.manifest/v1"
+    assert payload["summary"]["agents"] == 1
+    assert payload["summary"]["mcp_servers"] == 1
+    assert payload["summary"]["tools"] == 1
+    assert payload["graph"]["stats"]["nodes"] == 4
+    assert payload["graph"]["stats"]["edges"] == 3
+    assert payload["mcp_servers"][0]["credential_refs"] == [{"name": "API_KEY", "kind": "env"}]
+    assert "sk-secret-value" not in rendered
+    assert "SAFE_FLAG" not in rendered
+
+
+def test_manifest_cli_emits_agent_bom_json(monkeypatch) -> None:
+    monkeypatch.setattr("agent_bom.cli._agent_manifest.discover_all", lambda project_dir=None: [_agent()])
+
+    result = CliRunner().invoke(main, ["manifest", "--tenant-id", "tenant-a"])
+
+    assert result.exit_code == 0, result.output
+    assert '"schema_version": "agent-bom.manifest/v1"' in result.output
+    assert '"tenant_id": "tenant-a"' in result.output
+    assert "sk-secret-value" not in result.output
+
+
+def test_agent_bom_manifest_api_is_tenant_scoped_and_redacted() -> None:
+    fleet = InMemoryFleetStore()
+    observations = InMemoryMCPObservationStore()
+    fleet.put(
+        FleetAgent(
+            tenant_id="default",
+            agent_id="agent-1",
+            name="prod-agent",
+            agent_type="claude-desktop",
+            lifecycle_state=FleetLifecycleState.APPROVED,
+            server_count=1,
+            credential_count=1,
+        )
+    )
+    observations.put(
+        MCPObservation(
+            tenant_id="default",
+            observation_id="obs-1",
+            server_stable_id="srv-1",
+            server_name="filesystem",
+            agent_name="prod-agent",
+            transport="stdio",
+            command="npx",
+            args=["-y", "server", "--token", "sk-hidden"],
+            credential_env_vars=["API_KEY"],
+            gateway_registered=True,
+            runtime_observed=True,
+        )
+    )
+
+    previous_fleet = api_stores._fleet_store
+    previous_observations = api_stores._mcp_observation_store
+    try:
+        api_stores.set_fleet_store(fleet)
+        api_stores.set_mcp_observation_store(observations)
+        response = TestClient(app).get("/v1/agent-bom/manifest")
+    finally:
+        api_stores.set_fleet_store(previous_fleet)
+        api_stores.set_mcp_observation_store(previous_observations)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["tenant_id"] == "default"
+    assert payload["summary"]["agents"] == 1
+    assert payload["summary"]["mcp_servers"] == 1
+    assert payload["summary"]["runtime_observed_servers"] == 1
+    assert payload["graph"]["stats"]["nodes"] == 3
+    assert payload["graph"]["stats"]["edges"] == 2
+    assert payload["mcp_servers"][0]["credential_refs"] == [{"name": "API_KEY", "kind": "env"}]
+    assert "sk-hidden" not in response.text

--- a/ui/app/manifest/page.tsx
+++ b/ui/app/manifest/page.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { ElementType } from "react";
+import Link from "next/link";
+import {
+  Activity,
+  AlertTriangle,
+  Download,
+  GitBranch,
+  KeyRound,
+  Loader2,
+  Network,
+  RefreshCw,
+  Search,
+  Server,
+  ShieldCheck,
+  TerminalSquare,
+  Wrench,
+} from "lucide-react";
+import { api, type AgentBomManifestResponse } from "@/lib/api";
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value : fallback;
+}
+
+function asNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function asStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => String(item)).filter(Boolean);
+}
+
+function downloadManifest(manifest: AgentBomManifestResponse) {
+  const blob = new Blob([JSON.stringify(manifest, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `agent-bom-manifest-${manifest.tenant_id ?? "local"}.json`;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+function SummaryCard({
+  label,
+  value,
+  icon: Icon,
+  tone = "text-zinc-300",
+}: {
+  label: string;
+  value: number;
+  icon: ElementType;
+  tone?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-sm text-[var(--muted-foreground)]">{label}</span>
+        <Icon className={`h-4 w-4 ${tone}`} />
+      </div>
+      <div className="mt-3 text-2xl font-semibold tracking-tight text-[var(--foreground)]">{value.toLocaleString()}</div>
+    </div>
+  );
+}
+
+function BoundaryBadge({ ok, label }: { ok: boolean; label: string }) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs ${
+        ok ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300" : "border-yellow-500/30 bg-yellow-500/10 text-yellow-300"
+      }`}
+    >
+      {ok ? <ShieldCheck className="h-3 w-3" /> : <AlertTriangle className="h-3 w-3" />}
+      {label}
+    </span>
+  );
+}
+
+function MiniGraph({ manifest }: { manifest: AgentBomManifestResponse }) {
+  const nodes = manifest.graph.nodes.slice(0, 16);
+  const edges = manifest.graph.edges.slice(0, 24);
+  const columns = Math.min(4, Math.max(1, Math.ceil(Math.sqrt(nodes.length || 1))));
+
+  return (
+    <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-[var(--foreground)]">Manifest graph</h2>
+          <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+            {manifest.graph.stats.nodes} nodes · {manifest.graph.stats.edges} edges
+          </p>
+        </div>
+        <Link
+          href="/graph?layers=agent,server,tool,credential"
+          className="inline-flex items-center gap-1 rounded-md border border-[var(--border)] px-2.5 py-1.5 text-xs text-[var(--foreground)] hover:bg-[var(--accent)]"
+        >
+          Open graph <GitBranch className="h-3 w-3" />
+        </Link>
+      </div>
+
+      <div className="mt-4 grid gap-3" style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}>
+        {nodes.map((node) => (
+          <div key={node.id} className="min-h-20 rounded-md border border-[var(--border)] bg-[var(--background)] p-3">
+            <div className="text-xs uppercase tracking-wide text-[var(--muted-foreground)]">{node.entity_type}</div>
+            <div className="mt-2 truncate text-sm font-medium text-[var(--foreground)]" title={node.label}>
+              {node.label}
+            </div>
+          </div>
+        ))}
+        {nodes.length === 0 ? <div className="text-sm text-[var(--muted-foreground)]">No manifest graph nodes yet.</div> : null}
+      </div>
+
+      <div className="mt-4 max-h-48 overflow-auto rounded-md border border-[var(--border)]">
+        <table className="w-full text-left text-xs">
+          <thead className="bg-[var(--muted)] text-[var(--muted-foreground)]">
+            <tr>
+              <th className="px-3 py-2 font-medium">Relationship</th>
+              <th className="px-3 py-2 font-medium">Source</th>
+              <th className="px-3 py-2 font-medium">Target</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-[var(--border)]">
+            {edges.map((edge) => (
+              <tr key={edge.id}>
+                <td className="px-3 py-2 text-[var(--foreground)]">{edge.relationship}</td>
+                <td className="px-3 py-2 text-[var(--muted-foreground)]">{edge.source}</td>
+                <td className="px-3 py-2 text-[var(--muted-foreground)]">{edge.target}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default function AgentBomManifestPage() {
+  const [manifest, setManifest] = useState<AgentBomManifestResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+
+  const load = () => {
+    setLoading(true);
+    setError(null);
+    api
+      .getAgentBomManifest()
+      .then(setManifest)
+      .catch((err) => setError(err instanceof Error ? err.message : "Manifest request failed"))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const rows = useMemo(() => {
+    if (!manifest) return [];
+    const needle = query.trim().toLowerCase();
+    return manifest.mcp_servers
+      .map((server) => {
+        const refs = Array.isArray(server.credential_refs) ? server.credential_refs : [];
+        const tools = Array.isArray(server.tools) ? server.tools : [];
+        return {
+          id: asString(server.id, asString(server.name, "server")),
+          agentName: asString(server.agent_name, "local discovery"),
+          name: asString(server.name, "unnamed"),
+          transport: asString(server.transport, "unknown"),
+          authMode: asString(server.auth_mode, "unknown"),
+          toolCount: asNumber(server.tool_count) || tools.length,
+          credentialRefs: refs.map((ref) => (typeof ref === "object" && ref ? asString((ref as Record<string, unknown>).name) : "")).filter(Boolean),
+          warnings: asStringList((server.security as Record<string, unknown> | undefined)?.warnings),
+        };
+      })
+      .filter((row) => !needle || `${row.agentName} ${row.name} ${row.transport} ${row.authMode}`.toLowerCase().includes(needle));
+  }, [manifest, query]);
+
+  return (
+    <main className="min-h-screen bg-[var(--background)] p-6 text-[var(--foreground)]">
+      <div className="mx-auto flex max-w-7xl flex-col gap-6">
+        <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <p className="text-sm font-medium text-emerald-400">Agent BOM</p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight">Agent runtime manifest</h1>
+            <p className="mt-2 max-w-3xl text-sm text-[var(--muted-foreground)]">
+              Tenant-scoped inventory of agents, MCP servers, tools, credential references, and graph relationships.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={load}
+              className="inline-flex items-center gap-2 rounded-md border border-[var(--border)] px-3 py-2 text-sm hover:bg-[var(--accent)]"
+            >
+              {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+              Refresh
+            </button>
+            <button
+              type="button"
+              disabled={!manifest}
+              onClick={() => manifest && downloadManifest(manifest)}
+              className="inline-flex items-center gap-2 rounded-md border border-[var(--border)] px-3 py-2 text-sm hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <Download className="h-4 w-4" />
+              Download JSON
+            </button>
+          </div>
+        </header>
+
+        {error ? <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-300">{error}</div> : null}
+
+        {manifest ? (
+          <>
+            <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-6">
+              <SummaryCard label="Agents" value={manifest.summary.agents} icon={TerminalSquare} tone="text-blue-300" />
+              <SummaryCard label="MCP servers" value={manifest.summary.mcp_servers} icon={Server} tone="text-cyan-300" />
+              <SummaryCard label="Tools" value={manifest.summary.tools} icon={Wrench} tone="text-emerald-300" />
+              <SummaryCard label="Credentials" value={manifest.summary.credential_refs} icon={KeyRound} tone="text-yellow-300" />
+              <SummaryCard label="Runtime seen" value={manifest.summary.runtime_observed_servers} icon={Activity} tone="text-pink-300" />
+              <SummaryCard label="Gateway bound" value={manifest.summary.gateway_registered_servers} icon={Network} tone="text-violet-300" />
+            </section>
+
+            <section className="flex flex-wrap items-center gap-2">
+              <BoundaryBadge ok={!manifest.boundaries.stores_credential_values} label="credential values redacted" />
+              <BoundaryBadge ok={!manifest.boundaries.stores_raw_prompts} label="raw prompts not persisted" />
+              <span className="text-xs text-[var(--muted-foreground)]">
+                {manifest.schema_version} · {manifest.tenant_id ?? "local"} · {new Date(manifest.generated_at).toLocaleString()}
+              </span>
+            </section>
+
+            <div className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(360px,0.9fr)]">
+              <section className="rounded-lg border border-[var(--border)] bg-[var(--card)]">
+                <div className="flex flex-col gap-3 border-b border-[var(--border)] p-4 md:flex-row md:items-center md:justify-between">
+                  <div>
+                    <h2 className="text-sm font-semibold">Agent and MCP inventory</h2>
+                    <p className="mt-1 text-xs text-[var(--muted-foreground)]">{rows.length} visible server rows</p>
+                  </div>
+                  <label className="relative w-full md:w-80">
+                    <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-[var(--muted-foreground)]" />
+                    <input
+                      value={query}
+                      onChange={(event) => setQuery(event.target.value)}
+                      placeholder="Search agents, servers, transports"
+                      className="w-full rounded-md border border-[var(--border)] bg-[var(--background)] py-2 pl-9 pr-3 text-sm outline-none focus:border-emerald-500"
+                    />
+                  </label>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-left text-sm">
+                    <thead className="bg-[var(--muted)] text-xs uppercase tracking-wide text-[var(--muted-foreground)]">
+                      <tr>
+                        <th className="px-4 py-3 font-medium">Agent</th>
+                        <th className="px-4 py-3 font-medium">MCP server</th>
+                        <th className="px-4 py-3 font-medium">Transport</th>
+                        <th className="px-4 py-3 font-medium">Auth</th>
+                        <th className="px-4 py-3 font-medium">Tools</th>
+                        <th className="px-4 py-3 font-medium">Credential refs</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-[var(--border)]">
+                      {rows.map((row) => (
+                        <tr key={row.id}>
+                          <td className="px-4 py-3 text-[var(--foreground)]">{row.agentName}</td>
+                          <td className="px-4 py-3 font-medium text-[var(--foreground)]">{row.name}</td>
+                          <td className="px-4 py-3 text-[var(--muted-foreground)]">{row.transport}</td>
+                          <td className="px-4 py-3 text-[var(--muted-foreground)]">{row.authMode}</td>
+                          <td className="px-4 py-3 text-[var(--foreground)]">{row.toolCount}</td>
+                          <td className="px-4 py-3 text-[var(--muted-foreground)]">{row.credentialRefs.join(", ") || "none"}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+
+              <MiniGraph manifest={manifest} />
+            </div>
+          </>
+        ) : loading ? (
+          <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-8 text-sm text-[var(--muted-foreground)]">
+            <Loader2 className="mr-2 inline h-4 w-4 animate-spin" />
+            Loading Agent BOM manifest
+          </div>
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -78,6 +78,7 @@ const NAV_GROUPS: NavGroup[] = [
     links: [
       { href: "/", label: "Dashboard", icon: LayoutDashboard },
       { href: "/agents", label: "Agents", icon: Server },
+      { href: "/manifest", label: "Agent BOM", icon: Waypoints },
       { href: "/fleet", label: "Fleet", icon: Users },
     ],
   },

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -107,6 +107,52 @@ export interface UnifiedGraphResponse extends Omit<UnifiedGraphData, "attack_pat
   pagination: GraphPagination;
 }
 
+export interface AgentBomManifestNode {
+  id: string;
+  entity_type: string;
+  label: string;
+  attributes: Record<string, unknown>;
+}
+
+export interface AgentBomManifestEdge {
+  id: string;
+  source: string;
+  target: string;
+  relationship: string;
+  attributes: Record<string, unknown>;
+}
+
+export interface AgentBomManifestResponse {
+  schema_version: "agent-bom.manifest/v1" | string;
+  generated_at: string;
+  source: "local-discovery" | "control-plane" | string;
+  tenant_id?: string | undefined;
+  summary: {
+    agents: number;
+    mcp_servers: number;
+    tools: number;
+    credential_refs: number;
+    runtime_observed_servers: number;
+    gateway_registered_servers: number;
+  };
+  agents: Array<Record<string, unknown>>;
+  mcp_servers: Array<Record<string, unknown>>;
+  graph: {
+    nodes: AgentBomManifestNode[];
+    edges: AgentBomManifestEdge[];
+    stats: {
+      nodes: number;
+      edges: number;
+      relationships: string[];
+    };
+  };
+  boundaries: {
+    stores_credential_values: boolean;
+    stores_raw_prompts: boolean;
+    credential_value_policy: string;
+  };
+}
+
 export interface FixFirstRiskReason {
   kind: string;
   label: string;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -21,6 +21,7 @@ import type {
   GraphAgentsResponse,
   GraphDiffResponse,
   GraphExportFormat,
+  AgentBomManifestResponse,
   PostureCountsResponse,
   RemediationItem,
   AttackFlowResponse,
@@ -111,6 +112,9 @@ export type {
   GraphAgentsResponse,
   GraphDiffResponse,
   GraphExportFormat,
+  AgentBomManifestResponse,
+  AgentBomManifestNode,
+  AgentBomManifestEdge,
   DeploymentMode,
   PostureCountsResponse,
   RemediationItem,
@@ -439,6 +443,9 @@ export const api = {
   /** MCP registry catalog */
   listRegistry: () => get<RegistryResponse>("/v1/registry"),
   getRegistryServer: (id: string) => get<RegistryServer>(`/v1/registry/${id}`),
+
+  /** Canonical Agent BOM manifest for humans and agent callers. */
+  getAgentBomManifest: () => get<AgentBomManifestResponse>("/v1/agent-bom/manifest"),
 
   /** Get attack flow graph for a completed scan */
   getAttackFlow: (

--- a/ui/tests/api.test.ts
+++ b/ui/tests/api.test.ts
@@ -432,6 +432,45 @@ describe('api.downloadScanGraph', () => {
   })
 })
 
+describe('api.getAgentBomManifest', () => {
+  it('loads the canonical Agent BOM manifest route', async () => {
+    const payload = {
+      schema_version: 'agent-bom.manifest/v1',
+      generated_at: '2026-05-18T00:00:00Z',
+      source: 'control-plane',
+      summary: {
+        agents: 1,
+        mcp_servers: 1,
+        tools: 2,
+        credential_refs: 1,
+        runtime_observed_servers: 1,
+        gateway_registered_servers: 0,
+      },
+      agents: [],
+      mcp_servers: [],
+      graph: { nodes: [], edges: [], stats: { nodes: 0, edges: 0, relationships: [] } },
+      boundaries: {
+        stores_credential_values: false,
+        stores_raw_prompts: false,
+        credential_value_policy: 'redacted',
+      },
+    }
+    const fetchMock = mockFetch(payload)
+    global.fetch = fetchMock
+
+    const result = await api.getAgentBomManifest()
+
+    expect(result.schema_version).toBe('agent-bom.manifest/v1')
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/v1/agent-bom/manifest',
+      expect.objectContaining({
+        headers: {},
+        signal: expect.any(AbortSignal),
+      }),
+    )
+  })
+})
+
 describe('api.getPosture', () => {
   it('returns expected shape', async () => {
     const payload = {


### PR DESCRIPTION
Summary
- add a canonical Agent BOM manifest builder that emits local and tenant-scoped agent/MCP/tool posture without credential values
- expose the manifest through `agent-bom manifest` and `GET /v1/agent-bom/manifest`, including a graph projection for agents, MCP servers, tools, and credential references
- add a `/manifest` dashboard cockpit with summary cards, searchable MCP inventory, graph preview, download action, nav link, API client types, and refreshed OpenAPI artifacts

Verification
- uv run pytest tests/test_agent_manifest.py -q
- uv run ruff check src/agent_bom/agent_manifest.py src/agent_bom/cli/_agent_manifest.py src/agent_bom/api/routes/agent_manifest.py tests/test_agent_manifest.py
- uv run mypy src/agent_bom/agent_manifest.py src/agent_bom/api/routes/agent_manifest.py src/agent_bom/cli/_agent_manifest.py
- uv run --extra api python scripts/export_openapi.py --check
- PYTHONPATH=src uv run --extra api pytest tests/test_openapi_artifact.py -q
- npm --prefix ui run typecheck
- npm --prefix ui test -- --run tests/api.test.ts
- npm --prefix ui run build
- python scripts/check_release_consistency.py
- git diff --check

Closes #2656
