### PR TITLE
feat(runtime): add accountable authorization trace

### DIFF
--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -432,6 +432,53 @@ def _runtime_retention_posture() -> dict[str, object]:
     }
 
 
+def _classify_authorization_event(alert: dict) -> str:
+    action = str(alert.get("action") or alert.get("event_type") or alert.get("type") or "").lower()
+    detector = str(alert.get("detector") or "").lower()
+    effective = str(alert.get("effective_decision") or alert.get("decision") or "").lower()
+    message = str(alert.get("message") or "").lower()
+    haystack = " ".join((action, detector, effective, message))
+    if "approval_required" in haystack or "approval required" in haystack or effective == "warn":
+        return "approval_required"
+    if "data_filter" in haystack or "data filter" in haystack or "redact" in haystack or "mask" in haystack:
+        return "data_filter_applied"
+    if "block" in haystack or "deny" in haystack or effective == "deny":
+        return "blocked"
+    if "allow" in haystack or "authorized" in haystack or effective == "allow":
+        return "authorized"
+    return "observed"
+
+
+def _authorization_trace(*, allowed_tool_calls: int, blocked_tool_calls: int, alerts: list[dict]) -> dict[str, object]:
+    """Return accountable runtime authorization counts without raw arguments."""
+    trace_counts: Counter[str] = Counter()
+    recent: list[dict[str, object]] = []
+    for alert in sorted(alerts, key=lambda item: str(item.get("ts") or item.get("timestamp") or ""), reverse=True):
+        trace_class = _classify_authorization_event(alert)
+        if trace_class != "observed":
+            trace_counts[trace_class] += 1
+        if len(recent) < 10:
+            recent.append(
+                {
+                    "ts": alert.get("ts") or alert.get("timestamp") or alert.get("event_timestamp") or "",
+                    "trace_class": trace_class,
+                    "source_id": alert.get("source_id") or "unknown",
+                    "session_id": alert.get("session_id") or "unknown",
+                    "tool_name": alert.get("tool_name") or alert.get("tool") or "",
+                    "decision": alert.get("effective_decision") or alert.get("decision") or "",
+                    "detector": alert.get("detector") or "",
+                }
+            )
+    return {
+        "authorized": max(0, allowed_tool_calls + trace_counts["authorized"]),
+        "blocked": max(0, blocked_tool_calls + trace_counts["blocked"]),
+        "data_filter_applied": trace_counts["data_filter_applied"],
+        "approval_required": trace_counts["approval_required"],
+        "recent": recent,
+        "retention": "metadata_only",
+    }
+
+
 def _runtime_metrics_for_tenant(tenant_id: str) -> dict | None:
     metrics: dict | None = None
     if _proxy_metrics is not None:
@@ -505,6 +552,11 @@ def _build_runtime_production_index(tenant_id: str, metrics: dict | None, alerts
             "blocked": total_blocked,
             "gateway_actions": dict(sorted(gateway_action_counts.items())),
         },
+        "authorization_trace": _authorization_trace(
+            allowed_tool_calls=allowed_tool_calls,
+            blocked_tool_calls=total_blocked,
+            alerts=alerts,
+        ),
         "alerts": {key: value for key, value in alert_summary.items() if key != "recent_alerts"},
         "active_sources": _top_items(source_counts),
         "active_sessions": _top_items(session_counts),

--- a/tests/test_api_proxy_scorecard.py
+++ b/tests/test_api_proxy_scorecard.py
@@ -340,6 +340,23 @@ def test_runtime_production_index_summarizes_security_traffic():
                         "severity": "critical",
                         "message": "credential returned",
                     },
+                    {
+                        "type": "runtime_alert",
+                        "action": "gateway.data_filter_applied",
+                        "detector": "data_filter",
+                        "severity": "medium",
+                        "message": "PCI data masked before tool call",
+                        "tool_name": "crm.getContact",
+                    },
+                    {
+                        "type": "runtime_alert",
+                        "action": "gateway.approval_required",
+                        "detector": "approval_policy",
+                        "severity": "medium",
+                        "message": "approval required for production write",
+                        "tool_name": "salesforce.updateContact",
+                        "effective_decision": "warn",
+                    },
                 ],
                 "summary": {
                     "type": "proxy_summary",
@@ -364,10 +381,24 @@ def test_runtime_production_index_summarizes_security_traffic():
         assert data["traffic"]["block_rate"] == 0.2
         assert data["traffic"]["calls_by_tool"] == {"read_file": 7, "shell.exec": 3}
         assert data["traffic"]["top_tools"][0] == {"name": "read_file", "count": 7}
-        assert data["policy_decisions"]["gateway_actions"] == {"gateway.policy_blocked": 1}
+        assert data["policy_decisions"]["gateway_actions"] == {
+            "gateway.approval_required": 1,
+            "gateway.data_filter_applied": 1,
+            "gateway.policy_blocked": 1,
+        }
+        assert data["authorization_trace"]["authorized"] == 8
+        assert data["authorization_trace"]["blocked"] == 3
+        assert data["authorization_trace"]["data_filter_applied"] == 1
+        assert data["authorization_trace"]["approval_required"] == 1
+        assert data["authorization_trace"]["retention"] == "metadata_only"
+        assert {item["trace_class"] for item in data["authorization_trace"]["recent"]} >= {
+            "approval_required",
+            "data_filter_applied",
+            "blocked",
+        }
         assert data["alerts"]["alerts_by_severity"]["critical"] == 1
-        assert data["active_sources"] == [{"name": "gateway-1", "count": 2}]
-        assert data["active_sessions"] == [{"name": "sess-1", "count": 2}]
+        assert data["active_sources"] == [{"name": "gateway-1", "count": 4}]
+        assert data["active_sessions"] == [{"name": "sess-1", "count": 4}]
         assert data["retention_posture"]["event_classes"]["production_index"] == "metadata_only"
         assert data["retention_posture"]["event_classes"]["raw_tool_arguments"] == "no_persist"
         encoded = json.dumps(data)


### PR DESCRIPTION
Summary

- add metadata-only authorization trace counts to the runtime production index
- classify authorized, blocked, data-filtered, and approval-required runtime events without returning raw prompts or tool arguments
- extend production-index tests for accountable authorization events and redaction boundaries

Verification

- uv run pytest tests/test_api_proxy_scorecard.py -q
- uv run ruff check src/agent_bom/api/routes/proxy.py tests/test_api_proxy_scorecard.py
- uv run mypy src/agent_bom/api/routes/proxy.py
- git diff --check

Closes #2658