### PR TITLE
feat(runtime): add role profile blueprints

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -12181,6 +12181,75 @@
         ]
       }
     },
+    "/v1/runtime/blueprints": {
+      "get": {
+        "description": "Return canonical role/profile blueprints for runtime policy design.",
+        "operationId": "list_runtime_blueprints_v1_runtime_blueprints_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Runtime Blueprints V1 Runtime Blueprints Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Runtime Blueprints",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
+    "/v1/runtime/blueprints/{blueprint_id}": {
+      "get": {
+        "description": "Return one canonical role/profile blueprint by ID.",
+        "operationId": "get_runtime_blueprint_v1_runtime_blueprints__blueprint_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "blueprint_id",
+            "required": true,
+            "schema": {
+              "title": "Blueprint Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Runtime Blueprint V1 Runtime Blueprints  Blueprint Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Runtime Blueprint",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
     "/v1/runtime/production-index": {
       "get": {
         "description": "Return tenant-scoped runtime security observability for proxy/gateway traffic.\n\nThe production index is metadata-only by construction: it summarizes\ntool-call volume, policy decisions, alerts, source/session activity, and\nretention posture without returning raw prompts, raw arguments, raw\nresponses, or credential values.",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -8001,6 +8001,52 @@ paths:
       summary: Receive Push
       tags:
       - push
+  /v1/runtime/blueprints:
+    get:
+      description: Return canonical role/profile blueprints for runtime policy design.
+      operationId: list_runtime_blueprints_v1_runtime_blueprints_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response List Runtime Blueprints V1 Runtime Blueprints Get
+                type: object
+          description: Successful Response
+      summary: List Runtime Blueprints
+      tags:
+      - runtime
+  /v1/runtime/blueprints/{blueprint_id}:
+    get:
+      description: Return one canonical role/profile blueprint by ID.
+      operationId: get_runtime_blueprint_v1_runtime_blueprints__blueprint_id__get
+      parameters:
+      - in: path
+        name: blueprint_id
+        required: true
+        schema:
+          title: Blueprint Id
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Runtime Blueprint V1 Runtime Blueprints  Blueprint
+                  Id  Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Runtime Blueprint
+      tags:
+      - runtime
   /v1/runtime/production-index:
     get:
       description: 'Return tenant-scoped runtime security observability for proxy/gateway

--- a/src/agent_bom/api/routes/runtime_blueprints.py
+++ b/src/agent_bom/api/routes/runtime_blueprints.py
@@ -1,0 +1,36 @@
+"""Runtime role/profile blueprint API routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+from agent_bom.runtime_blueprints import runtime_role_blueprint, runtime_role_blueprints
+
+router = APIRouter(tags=["runtime"])
+
+
+def _request_tenant_id(request: Request) -> str:
+    return str(getattr(request.state, "tenant_id", "default") or "default")
+
+
+@router.get("/v1/runtime/blueprints")
+async def list_runtime_blueprints(request: Request) -> dict[str, object]:
+    """Return canonical role/profile blueprints for runtime policy design."""
+    return {
+        "schema_version": "runtime.blueprints.v1",
+        "tenant_id": _request_tenant_id(request),
+        "blueprints": runtime_role_blueprints(),
+    }
+
+
+@router.get("/v1/runtime/blueprints/{blueprint_id}")
+async def get_runtime_blueprint(request: Request, blueprint_id: str) -> dict[str, object]:
+    """Return one canonical role/profile blueprint by ID."""
+    blueprint = runtime_role_blueprint(blueprint_id)
+    if blueprint is None:
+        raise HTTPException(status_code=404, detail="Runtime blueprint not found")
+    return {
+        "schema_version": "runtime.blueprints.v1",
+        "tenant_id": _request_tenant_id(request),
+        "blueprint": blueprint,
+    }

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -731,6 +731,7 @@ from agent_bom.api.routes.observability import router as _observability_router  
 from agent_bom.api.routes.posture_streaming import router as _posture_streaming_router  # noqa: E402
 from agent_bom.api.routes.privacy import router as _privacy_router  # noqa: E402
 from agent_bom.api.routes.proxy import router as _proxy_router  # noqa: E402
+from agent_bom.api.routes.runtime_blueprints import router as _runtime_blueprints_router  # noqa: E402
 from agent_bom.api.routes.scan import router as _scan_router  # noqa: E402
 from agent_bom.api.routes.schedules import router as _schedules_router  # noqa: E402
 from agent_bom.api.routes.scim import router as _scim_router  # noqa: E402
@@ -755,6 +756,7 @@ app.include_router(_observability_router)
 app.include_router(_posture_streaming_router)
 app.include_router(_privacy_router)
 app.include_router(_proxy_router)
+app.include_router(_runtime_blueprints_router)
 app.include_router(_scan_router)
 app.include_router(_schedules_router)
 app.include_router(_scim_router)

--- a/src/agent_bom/runtime_blueprints.py
+++ b/src/agent_bom/runtime_blueprints.py
@@ -1,0 +1,101 @@
+"""Canonical runtime role/profile blueprints for agent and MCP governance."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+
+@dataclass(frozen=True)
+class RuntimeRoleBlueprint:
+    blueprint_id: str
+    label: str
+    description: str
+    intended_users: tuple[str, ...]
+    allowed_tool_categories: tuple[str, ...]
+    restricted_tool_categories: tuple[str, ...]
+    approval_required_for: tuple[str, ...]
+    default_decision: str
+    retention_mode: str
+    evidence_required: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+_BLUEPRINTS: tuple[RuntimeRoleBlueprint, ...] = (
+    RuntimeRoleBlueprint(
+        blueprint_id="developer",
+        label="Developer",
+        description="Build and debug code with bounded repository, package, and local development access.",
+        intended_users=("software_engineer", "platform_engineer"),
+        allowed_tool_categories=("repo_read", "repo_write", "package_scan", "local_runtime", "mcp_discovery"),
+        restricted_tool_categories=("production_write", "payment_data", "privileged_identity"),
+        approval_required_for=("production_deploy", "credential_export", "database_write"),
+        default_decision="warn",
+        retention_mode="metadata_only",
+        evidence_required=("tool_name", "workspace", "package_or_resource", "decision", "trace_id"),
+    ),
+    RuntimeRoleBlueprint(
+        blueprint_id="security_analyst",
+        label="Security Analyst",
+        description="Investigate findings, ExposurePaths, threat intel, and runtime evidence without direct production mutation.",
+        intended_users=("appsec", "soc_analyst", "incident_responder"),
+        allowed_tool_categories=("finding_read", "graph_query", "threat_intel", "audit_read", "evidence_export"),
+        restricted_tool_categories=("production_write", "credential_export", "customer_data_write"),
+        approval_required_for=("remediation_action", "evidence_pack_export", "tenant_scope_change"),
+        default_decision="allow",
+        retention_mode="redacted",
+        evidence_required=("finding_id", "exposure_path_id", "source_id", "decision", "audit_chain_ref"),
+    ),
+    RuntimeRoleBlueprint(
+        blueprint_id="mlops",
+        label="MLOps",
+        description="Operate model, dataset, feature, and agent-runtime surfaces with explicit provenance boundaries.",
+        intended_users=("ml_engineer", "data_platform_engineer"),
+        allowed_tool_categories=("model_registry_read", "dataset_read", "runtime_trace", "experiment_read", "mcp_discovery"),
+        restricted_tool_categories=("training_data_export", "model_delete", "privileged_identity"),
+        approval_required_for=("model_publish", "dataset_export", "production_endpoint_write"),
+        default_decision="warn",
+        retention_mode="metadata_only",
+        evidence_required=("model_ref", "dataset_ref", "tool_name", "decision", "trace_id"),
+    ),
+    RuntimeRoleBlueprint(
+        blueprint_id="finance",
+        label="Finance",
+        description="Use approved business-system tools with strict data filtering and write approvals.",
+        intended_users=("finance_operator", "business_analyst"),
+        allowed_tool_categories=("business_app_read", "report_generate", "ticket_create"),
+        restricted_tool_categories=("payment_write", "payroll_export", "customer_pii_export", "privileged_identity"),
+        approval_required_for=("payment_write", "invoice_update", "bank_data_export"),
+        default_decision="block",
+        retention_mode="redacted",
+        evidence_required=("business_system", "record_type", "data_filter", "decision", "approver_ref"),
+    ),
+    RuntimeRoleBlueprint(
+        blueprint_id="admin",
+        label="Admin",
+        description="Manage runtime policies, credentials, integrations, and tenant controls with full audit evidence.",
+        intended_users=("security_admin", "platform_admin"),
+        allowed_tool_categories=("policy_write", "integration_manage", "credential_reference_manage", "tenant_admin"),
+        restricted_tool_categories=("raw_secret_read", "unredacted_prompt_export"),
+        approval_required_for=("policy_disable", "tenant_delete", "audit_retention_change"),
+        default_decision="warn",
+        retention_mode="redacted",
+        evidence_required=("actor", "resource", "policy_id", "decision", "audit_chain_ref"),
+    ),
+)
+
+
+def runtime_role_blueprints() -> list[dict[str, object]]:
+    return [blueprint.to_dict() for blueprint in _BLUEPRINTS]
+
+
+def runtime_role_blueprint(blueprint_id: str) -> dict[str, object] | None:
+    normalized = blueprint_id.strip().lower().replace("-", "_")
+    for blueprint in _BLUEPRINTS:
+        if blueprint.blueprint_id == normalized:
+            return blueprint.to_dict()
+    return None
+
+
+__all__ = ["RuntimeRoleBlueprint", "runtime_role_blueprint", "runtime_role_blueprints"]

--- a/tests/test_runtime_blueprints.py
+++ b/tests/test_runtime_blueprints.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import app
+from agent_bom.runtime_blueprints import runtime_role_blueprint, runtime_role_blueprints
+
+
+def test_runtime_role_blueprints_are_canonical_profiles() -> None:
+    blueprints = runtime_role_blueprints()
+    ids = {blueprint["blueprint_id"] for blueprint in blueprints}
+    assert ids == {"developer", "security_analyst", "mlops", "finance", "admin"}
+    for blueprint in blueprints:
+        assert blueprint["allowed_tool_categories"]
+        assert blueprint["restricted_tool_categories"]
+        assert blueprint["approval_required_for"]
+        assert blueprint["default_decision"] in {"allow", "warn", "block"}
+        assert blueprint["retention_mode"] in {"metadata_only", "redacted"}
+        assert "decision" in blueprint["evidence_required"]
+
+
+def test_runtime_role_blueprint_lookup_normalizes_ids() -> None:
+    assert runtime_role_blueprint("security-analyst")["blueprint_id"] == "security_analyst"  # type: ignore[index]
+    assert runtime_role_blueprint("missing") is None
+
+
+def test_runtime_blueprints_api_lists_and_gets_profiles() -> None:
+    client = TestClient(app)
+
+    listing = client.get("/v1/runtime/blueprints").json()
+    assert listing["schema_version"] == "runtime.blueprints.v1"
+    assert listing["tenant_id"] == "default"
+    assert [blueprint["blueprint_id"] for blueprint in listing["blueprints"]] == [
+        "developer",
+        "security_analyst",
+        "mlops",
+        "finance",
+        "admin",
+    ]
+
+    finance = client.get("/v1/runtime/blueprints/finance").json()
+    assert finance["blueprint"]["default_decision"] == "block"
+    assert "payment_write" in finance["blueprint"]["approval_required_for"]
+
+    missing = client.get("/v1/runtime/blueprints/not-real")
+    assert missing.status_code == 404


### PR DESCRIPTION
Summary
- add canonical runtime role/profile blueprints for developer, security analyst, MLOps, finance, and admin workflows
- expose tenant-scoped runtime blueprint list/detail API routes with strict unknown-id handling
- refresh OpenAPI artifacts so SDK generators can consume the blueprint contract

Verification
- uv run pytest tests/test_runtime_blueprints.py -q
- PYTHONPATH=src uv run --extra api pytest tests/test_openapi_artifact.py -q
- uv run ruff check src/agent_bom/runtime_blueprints.py src/agent_bom/api/routes/runtime_blueprints.py tests/test_runtime_blueprints.py
- uv run mypy src/agent_bom/runtime_blueprints.py src/agent_bom/api/routes/runtime_blueprints.py
- uv run --extra api python scripts/export_openapi.py --check
- git diff --check

Closes #2659
