### PR TITLE
docs(release): align v0.87.1 public references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
   a top-level `agent-bom manifest` CLI command, `GET /v1/agent-bom/manifest`,
   redacted credential references, graph relationships, and a dashboard cockpit
   for agent/MCP/tool visibility.
+- Architecture docs now include an AI governance control-plane diagram that
+  ties scans, fleet and endpoint inventory, runtime decisions, threat intel,
+  Agent BOM manifests, graph evidence, and human/agent surfaces together.
 - **Runtime production index** - added a tenant-scoped
   `/v1/runtime/production-index` security-observability endpoint for
   proxy/gateway traffic with tool-call volume, policy decision summaries,

--- a/docs/GITHUB_ACTION_SARIF_TROUBLESHOOTING.md
+++ b/docs/GITHUB_ACTION_SARIF_TROUBLESHOOTING.md
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: msaad00/agent-bom@v0.87.0
+      - uses: msaad00/agent-bom@v0.87.1
         with:
           scan-type: agents
           format: sarif

--- a/docs/skills/POLICY.md
+++ b/docs/skills/POLICY.md
@@ -84,7 +84,7 @@ Actions are `warn`, `fail`, or `block`; `block` is treated as a failing gate.
 Run skills scanning as its own CI lane:
 
 ```yaml
-- uses: msaad00/agent-bom@v0.87.0
+- uses: msaad00/agent-bom@v0.87.1
   with:
     scan-type: skills
     scan-ref: .

--- a/site-docs/reference/agentic-workflows.md
+++ b/site-docs/reference/agentic-workflows.md
@@ -8,7 +8,7 @@ plane or runtime enforcement rollout.
 |---|---|---|---|---|
 | Local CLI | `agent-bom agents --demo --offline`, then `agent-bom agents -p .` | Reads local agent and MCP configuration from the developer machine. No control-plane credentials required. | Terminal findings, JSON, SARIF, SBOM, HTML, graph export. | Scheduled scan, Docker, GitHub Action. |
 | Claude, Cursor, Windsurf, VS Code, Cortex, Codex CLI | `agent-bom mcp server` | Exposes read-only security tools to the assistant. The assistant does not need direct scanner credentials beyond the local process boundary. | MCP tool output, inventory, blast-radius answers, compliance checks, ranked `ExposurePath` JSON, deploy guidance. | Shared MCP configuration, skills, fleet sync. |
-| GitHub Actions | `uses: msaad00/agent-bom@v0.87.0` with SARIF upload enabled | Runs in CI with repository-scoped token permissions. Fork PR behavior depends on GitHub security policy. | `agent-bom-results.sarif`, pull-request summary, code-scanning alert category. | Branch protection, required code scanning, artifact retention. |
+| GitHub Actions | `uses: msaad00/agent-bom@v0.87.1` with SARIF upload enabled | Runs in CI with repository-scoped token permissions. Fork PR behavior depends on GitHub security policy. | `agent-bom-results.sarif`, pull-request summary, code-scanning alert category. | Branch protection, required code scanning, artifact retention. |
 | Skills and instruction files | `agent-bom skills scan . --policy skills-policy.yaml` | Reads repo-local instructions such as `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, and `skills/*.md`. | Skill trust findings, referenced package and MCP inventory, credential-env names, policy warn/block result. | Signed skills, provenance verification, registry publishing. |
 | Cloud and AI infrastructure | `agent-bom agents --preset enterprise` plus provider-specific flags only where credentials are approved. | Uses read-only provider APIs or local inventory files. Keep provider secrets in the operator boundary, not in repo docs. | Cloud, warehouse, GPU, model, dataset, and runtime package evidence. | Fleet sync, compliance exports, graph-backed findings. |
 | Runtime proxy | `agent-bom proxy --no-isolate --log audit.jsonl --block-undeclared -- ...` | Wraps selected local MCP traffic. Policy can block before an upstream tool receives the call. Container containment requires a stdio MCP path plus a configured sandbox image or an existing container command. | Tier-A audit JSONL, policy decisions, runtime alerts, metrics, and sandbox posture when isolation is enabled. | Sidecar proxy, gateway policy pull, SIEM export. |
@@ -31,7 +31,7 @@ when the buyer or contributor needs to see the first finding path quickly.
 ### CI Security Review
 
 ```yaml
-- uses: msaad00/agent-bom@v0.87.0
+- uses: msaad00/agent-bom@v0.87.1
   with:
     scan-type: agents
     severity-threshold: high
@@ -62,7 +62,7 @@ so future agent and SIEM push workflows share one event envelope.
 ### Skills CI Gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.87.0
+- uses: msaad00/agent-bom@v0.87.1
   with:
     scan-type: skills
     scan-ref: .


### PR DESCRIPTION
Summary
- add the merged AI governance control-plane diagram to the v0.87.1 changelog
- update public GitHub Action examples from v0.87.0 to v0.87.1
- keep release docs aligned before tagging v0.87.1

Verification
- python scripts/check_release_consistency.py
- uv run mkdocs build --strict
- git diff --check
- git grep -n "uses: msaad00/agent-bom@v0\\.87\\.0" -- docs site-docs || true
