### PR TITLE
fix(cli): bound agents metadata discovery progress

### DIFF
--- a/src/agent_bom/autodiscover.py
+++ b/src/agent_bom/autodiscover.py
@@ -210,11 +210,15 @@ async def autodiscover_package(
     }
 
 
-async def enrich_unknown_packages(packages: list[Package]) -> int:
+async def enrich_unknown_packages(packages: list[Package], *, global_timeout: float | None = 30.0) -> int:
     """Batch-enrich packages not found in the bundled registry.
 
     Updates Package objects in-place with auto_risk_level,
     auto_risk_justification, maintainer_count, and source_repo.
+
+    The global timeout bounds the whole enrichment pass. Individual requests
+    already have request timeouts, but large inventories can otherwise wait for
+    many slow registry calls in sequence across semaphore batches.
 
     Returns the number of packages successfully enriched.
     """
@@ -248,8 +252,19 @@ async def enrich_unknown_packages(packages: list[Package]) -> int:
                     return True
                 return False
 
-        tasks = [_enrich_one(pkg) for pkg in to_enrich]
-        results = await asyncio.gather(*tasks, return_exceptions=True)
+        tasks = [asyncio.create_task(_enrich_one(pkg)) for pkg in to_enrich]
+        done, pending = await asyncio.wait(tasks, timeout=global_timeout)
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+            logger.warning(
+                "Auto-discovery metadata enrichment timed out after %.1fs; enriched %s/%s package(s)",
+                global_timeout or 0.0,
+                sum(1 for task in done if task.done() and not task.cancelled() and task.exception() is None and task.result() is True),
+                len(to_enrich),
+            )
+        results = [task.result() if task.exception() is None else task.exception() for task in done if not task.cancelled()]
         enriched = sum(1 for r in results if r is True)
 
     return enriched

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -979,6 +979,8 @@ def scan(
                         )
                     continue
                 _smithery_tok = smithery_token if smithery_flag else None
+                if not quiet:
+                    con.print(f"  [dim]Extracting packages from {agent.name}/{server.name}...[/dim]")
                 discovered = extract_packages(
                     server, resolve_transitive=transitive, max_depth=max_depth, smithery_token=_smithery_tok, mcp_registry=mcp_registry_flag
                 )

--- a/tests/test_autodiscover.py
+++ b/tests/test_autodiscover.py
@@ -1,6 +1,10 @@
 """Tests for the auto-discovery module — risk inference, justification, and enrichment filtering."""
 
+import asyncio
+import time
+
 from agent_bom.autodiscover import (
+    enrich_unknown_packages,
     generate_risk_justification,
     infer_risk_level,
 )
@@ -147,3 +151,30 @@ def test_enrich_skips_registry_packages():
 
     assert registry_pkg not in to_enrich
     assert unknown_pkg in to_enrich
+
+
+def test_enrich_unknown_packages_global_timeout(monkeypatch):
+    """Metadata enrichment should return promptly when the whole batch times out."""
+
+    async def _slow_autodiscover(*_args, **_kwargs):
+        await asyncio.sleep(0.1)
+        return {"auto_risk_level": "low", "auto_risk_justification": "slow"}
+
+    monkeypatch.setattr("agent_bom.autodiscover.autodiscover_package", _slow_autodiscover)
+    packages = [
+        Package(
+            name=f"slow-package-{idx}",
+            version="1.0.0",
+            ecosystem="npm",
+            resolved_from_registry=False,
+        )
+        for idx in range(3)
+    ]
+
+    started = time.monotonic()
+    enriched = asyncio.run(enrich_unknown_packages(packages, global_timeout=0.01))
+    elapsed = time.monotonic() - started
+
+    assert enriched == 0
+    assert elapsed < 0.08
+    assert all(pkg.auto_risk_level is None for pkg in packages)

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -818,6 +818,23 @@ def test_scan_no_tree_flag():
     assert result.exit_code == 0
 
 
+def test_scan_prints_package_extraction_progress(monkeypatch):
+    """Real MCP inventories should show which server is being extracted."""
+    from agent_bom.models import TransportType
+
+    pkg = Package(name="example", version="1.0.0", ecosystem="pypi")
+    server = MCPServer(name="demo-server", command="python", transport=TransportType.STDIO)
+    agent = Agent(name="demo-agent", agent_type=AgentType.CUSTOM, config_path="/tmp/demo.json", mcp_servers=[server])
+
+    monkeypatch.setattr("agent_bom.cli.agents.discover_all", lambda *args, **kwargs: [agent])
+    monkeypatch.setattr("agent_bom.cli.agents.extract_packages", lambda *args, **kwargs: [pkg])
+
+    result = _run(["scan", "--no-scan"])
+
+    assert result.exit_code == 0
+    assert "Extracting packages from demo-agent/demo-server" in result.output
+
+
 def test_demo_scan_hides_synthetic_project_temp_path():
     with (
         patch("agent_bom.cli.agents.discover_all", return_value=[]),


### PR DESCRIPTION
Summary
- print the agent/server currently entering MCP package extraction so real inventories do not appear idle during slow local parsing
- bound unknown-package metadata autodiscovery with a global timeout and return partial enrichment instead of waiting across slow registry batches
- add regression coverage for extraction progress and timed-out metadata enrichment

Verification
- uv run pytest tests/test_cli_scan.py::test_scan_prints_package_extraction_progress tests/test_autodiscover.py::test_enrich_unknown_packages_global_timeout -q
- uv run ruff check src/agent_bom/cli/agents/__init__.py src/agent_bom/autodiscover.py tests/test_cli_scan.py tests/test_autodiscover.py
- uv run mypy src/agent_bom/autodiscover.py
- git diff --check

Closes #2629
