### PR TITLE
fix(api): allow manifest dashboard shell

### DIFF
--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -719,6 +719,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             "index",
             "insights",
             "jobs",
+            "manifest",
             "mesh",
             "proxy",
             "registry",

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -375,6 +375,8 @@ def test_api_key_middleware_exempts_packaged_dashboard_assets():
         routes=[
             Route("/_next/static/app.js", dummy),
             Route("/agents/index.html", dummy),
+            Route("/manifest", dummy),
+            Route("/manifest/index.html", dummy),
             Route("/vulns.html", dummy),
             Route("/admin.js", dummy),
             Route("/v1/test.js", dummy),
@@ -385,6 +387,8 @@ def test_api_key_middleware_exempts_packaged_dashboard_assets():
     client = TestClient(test_app)
     assert client.get("/_next/static/app.js").status_code == 200
     assert client.get("/agents/index.html").status_code == 200
+    assert client.get("/manifest").status_code == 200
+    assert client.get("/manifest/index.html").status_code == 200
     assert client.get("/vulns.html").status_code == 200
     assert client.get("/admin.js").status_code == 401
     assert client.get("/v1/test.js").status_code == 401


### PR DESCRIPTION
Summary
- allow the packaged /manifest dashboard shell to load under API-key middleware like the other dashboard pages
- keep /v1/agent-bom/manifest protected while only exempting GET/HEAD dashboard shell routes
- add regression coverage for /manifest and /manifest/index.html in the dashboard asset allowlist

Verification
- uv run pytest tests/test_api_hardening.py::test_api_key_middleware_exempts_packaged_dashboard_assets -q
- uv run ruff check src/agent_bom/api/middleware.py tests/test_api_hardening.py
- git diff --check

Closes #2685