### PR TITLE
fix(reports): expose SARIF taxonomy catalog

### DIFF
--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -153,6 +153,20 @@ def _build_run_taxonomies(results: list[dict]) -> list[dict]:
     return taxonomies
 
 
+def _taxonomies_as_tool_extensions(taxonomies: list[dict]) -> list[dict]:
+    """Expose framework catalogs as SARIF tool extensions for catalog readers."""
+    extensions: list[dict] = []
+    for taxonomy in taxonomies:
+        extension = {
+            "name": taxonomy["name"],
+            "fullName": taxonomy.get("fullName", taxonomy["name"]),
+            "informationUri": taxonomy.get("informationUri", ""),
+            "taxa": taxonomy.get("taxa", []),
+        }
+        extensions.append(extension)
+    return extensions
+
+
 def _framework_taxa_references(properties: dict[str, Any]) -> list[dict]:
     """Build result-level SARIF taxa references for declared framework taxonomies."""
     refs: list[dict] = []
@@ -644,6 +658,7 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
         }
     if taxonomies:
         run["taxonomies"] = taxonomies
+        run["tool"]["extensions"] = _taxonomies_as_tool_extensions(taxonomies)
 
     return {
         "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",

--- a/tests/test_exploit_likelihood.py
+++ b/tests/test_exploit_likelihood.py
@@ -116,6 +116,22 @@ def test_sarif_embeds_run_level_framework_taxonomies():
     assert {"id": "AML.T0010", "toolComponent": {"name": "mitre-atlas"}} in result_taxa
 
 
+def test_sarif_mirrors_framework_taxonomies_as_tool_extensions():
+    from agent_bom.models import AIBOMReport
+
+    br = _br(_vuln())
+    br.nist_ai_rmf_tags = ["MAP-1"]
+    br.soc2_tags = ["CC7.1"]
+    sarif = to_sarif(AIBOMReport(blast_radii=[br], tool_version="0.87.1"))
+
+    extensions = sarif["runs"][0]["tool"]["extensions"]
+    extension_names = {extension["name"] for extension in extensions}
+    assert {"nist-ai-rmf", "soc2"}.issubset(extension_names)
+    taxa_by_name = {extension["name"]: {taxon["id"] for taxon in extension["taxa"]} for extension in extensions}
+    assert "MAP-1" in taxa_by_name["nist-ai-rmf"]
+    assert "CC7.1" in taxa_by_name["soc2"]
+
+
 # ── HTML propagation ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Summary
- mirror framework taxonomy catalogs into SARIF tool extensions while preserving run-level taxonomies and result-level taxa references
- keep compliance consumers from needing to parse every result to discover NIST/SOC2/OWASP framework catalogs
- add regression coverage for the tool metadata catalog shape

Verification
- uv run pytest tests/test_exploit_likelihood.py::test_sarif_embeds_run_level_framework_taxonomies tests/test_exploit_likelihood.py::test_sarif_mirrors_framework_taxonomies_as_tool_extensions -q
- uv run ruff check src/agent_bom/output/sarif.py tests/test_exploit_likelihood.py
- git diff --check

Closes #2687