### PR TITLE
fix(reports): align inventory and API posture

### DIFF
--- a/config/schemas/inventory.schema.json
+++ b/config/schemas/inventory.schema.json
@@ -378,6 +378,12 @@
       "description": "ISO 8601 timestamp when this inventory was generated"
     },
 
+    "packages": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Package" },
+      "description": "Optional flattened package list for consumers that need report-level package coordinates. Nested agent mcp_servers packages remain authoritative for ownership and blast-radius correlation."
+    },
+
     "discovery_provenance": {
       "$ref": "#/$defs/DiscoveryProvenance",
       "description": "Default provenance for assets in this inventory."

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -1487,17 +1487,28 @@ def get_rate_limit_key_status(now: "datetime | None" = None) -> dict:
     fallback_source = None
 
     if not raw_key:
+        production_or_clustered = _production_or_clustered_control_plane()
         return {
             "status": "ephemeral",
+            "severity": "warning" if production_or_clustered else "info",
+            "production_or_clustered": production_or_clustered,
             "rotation_days": RATE_LIMIT_KEY_ROTATION_DAYS,
             "max_age_days": RATE_LIMIT_KEY_MAX_AGE_DAYS,
             "fallback_source": None,
             "last_rotated": None,
             "age_days": None,
             "message": (
-                "No AGENT_BOM_RATE_LIMIT_KEY configured. Rate-limit fingerprints use a "
-                "process-local random key that resets on restart and breaks shared bucket "
-                "scoping across replicas. Set AGENT_BOM_RATE_LIMIT_KEY for production."
+                (
+                    "No AGENT_BOM_RATE_LIMIT_KEY configured. Rate-limit fingerprints use a "
+                    "process-local random key that resets on restart and breaks shared bucket "
+                    "scoping across replicas. Set AGENT_BOM_RATE_LIMIT_KEY for production."
+                )
+                if production_or_clustered
+                else (
+                    "No AGENT_BOM_RATE_LIMIT_KEY configured. Rate-limit fingerprints use a "
+                    "process-local random key that resets on restart; this is acceptable for "
+                    "single-process local development."
+                )
             ),
         }
 

--- a/src/agent_bom/data/inventory.schema.json
+++ b/src/agent_bom/data/inventory.schema.json
@@ -378,6 +378,12 @@
       "description": "ISO 8601 timestamp when this inventory was generated"
     },
 
+    "packages": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Package" },
+      "description": "Optional flattened package list for consumers that need report-level package coordinates. Nested agent mcp_servers packages remain authoritative for ownership and blast-radius correlation."
+    },
+
     "discovery_provenance": {
       "$ref": "#/$defs/DiscoveryProvenance",
       "description": "Default provenance for assets in this inventory."

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -669,6 +669,7 @@ def _schema_server(server, *, inherited_provenance: dict | None = None) -> dict[
 def _build_inventory_snapshot(report: AIBOMReport) -> dict:
     """Build a strict inventory-schema payload suitable for --inventory reuse."""
     agents: list[dict[str, object]] = []
+    packages: list[dict[str, object]] = []
     for agent in report.agents:
         agent_provenance = _schema_discovery_provenance(agent_discovery_provenance(agent))
         agents.append(
@@ -687,10 +688,13 @@ def _build_inventory_snapshot(report: AIBOMReport) -> dict:
                 }
             )
         )
+        for server in agent.mcp_servers:
+            packages.extend(_schema_package(pkg, inherited_provenance=agent_provenance) for pkg in server.packages)
 
     return {
         "schema_version": INVENTORY_SNAPSHOT_SCHEMA_VERSION,
         "generated_at": report.generated_at.isoformat(),
+        "packages": packages,
         "agents": agents,
     }
 

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -109,8 +109,22 @@ def test_status_ephemeral_when_no_key(monkeypatch: pytest.MonkeyPatch) -> None:
     _reload_config()
     status = get_rate_limit_key_status()
     assert status["status"] == "ephemeral"
+    assert status["severity"] == "info"
+    assert status["production_or_clustered"] is False
     assert status["last_rotated"] is None
     assert status["age_days"] is None
+    assert "local development" in status["message"]
+
+
+def test_status_ephemeral_warns_for_production_without_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_rate_limit_env(monkeypatch)
+    monkeypatch.setenv("AGENT_BOM_ENV", "production")
+    _reload_config()
+    status = get_rate_limit_key_status()
+    assert status["status"] == "ephemeral"
+    assert status["severity"] == "warning"
+    assert status["production_or_clustered"] is True
+    assert "Set AGENT_BOM_RATE_LIMIT_KEY for production" in status["message"]
 
 
 def test_status_unknown_age_when_key_without_rotation_timestamp(

--- a/tests/test_intel_lookup.py
+++ b/tests/test_intel_lookup.py
@@ -156,6 +156,18 @@ def test_intel_api_match_validates_package_shape(intel_client: TestClient) -> No
     assert "ecosystem" in response.json()["detail"]
 
 
+def test_intel_api_match_value_errors_use_single_error_envelope(intel_client: TestClient) -> None:
+    response = intel_client.post("/v1/intel/match", headers=VIEWER_HEADERS, json={"packages": [{"purl": "not-a-purl"}]})
+
+    assert response.status_code == 422
+    body = response.json()
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+    assert body["error"]["message"] == "purl must start with pkg:"
+    assert body["error"]["details"] == "purl must start with pkg:"
+    assert body["detail"] == "purl must start with pkg:"
+    assert not body["error"]["details"].startswith("{")
+
+
 @pytest.mark.asyncio
 async def test_mcp_intel_tools_return_agent_native_json(intel_db) -> None:  # noqa: ANN001
     lookup = json.loads(await intel_lookup_impl(advisory_id="CVE-2026-12345"))

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -435,12 +435,34 @@ def test_json_inventory_snapshot_round_trips_through_inventory_schema(tmp_path):
 
     errors = sorted(_inventory_validator().iter_errors(snapshot), key=lambda error: list(error.path))
     assert errors == []
+    assert snapshot["packages"][0]["name"] == "openssl"
+    assert snapshot["packages"][0]["version"] == "3.0.16"
+    assert snapshot["packages"][0]["ecosystem"] == "unknown"
     assert snapshot["agents"][0]["mcp_servers"][0]["packages"][0]["ecosystem"] == "unknown"
 
     path = tmp_path / "inventory.json"
     path.write_text(json.dumps(snapshot), encoding="utf-8")
     loaded = load_inventory(str(path))
     assert loaded["agents"][0]["name"] == "image:agent-bom"
+    assert loaded["packages"][0]["name"] == "openssl"
+
+
+def test_json_inventory_snapshot_flattened_packages_preserve_nested_server_packages():
+    pkg_a = _make_pkg(name="lodash", version="4.17.20", ecosystem="npm")
+    pkg_b = _make_pkg(name="requests", version="2.31.0", ecosystem="pypi")
+    agent = _make_agent(
+        servers=[
+            _make_server(name="node-server", packages=[pkg_a]),
+            _make_server(name="python-server", packages=[pkg_b]),
+        ]
+    )
+
+    snapshot = to_json(_make_report(agents=[agent]))["inventory_snapshot"]
+
+    assert [pkg["name"] for pkg in snapshot["packages"]] == ["lodash", "requests"]
+    nested = snapshot["agents"][0]["mcp_servers"]
+    assert nested[0]["packages"] == [snapshot["packages"][0]]
+    assert nested[1]["packages"] == [snapshot["packages"][1]]
 
 
 # ── Markdown ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Summary
- populate inventory_snapshot.packages with flattened package coordinates while preserving nested MCP server package ownership
- update inventory schemas so snapshots with flattened package lists validate and round-trip through inventory loading
- distinguish local-dev vs production missing rate-limit-key posture and lock /v1/intel/match validation envelope behavior

Verification
- uv run pytest -q tests/test_output_formats.py tests/test_intel_lookup.py tests/test_api_operator_policy.py
- uv run ruff check src/agent_bom/output/json_fmt.py src/agent_bom/api/middleware.py tests/test_output_formats.py tests/test_intel_lookup.py tests/test_api_operator_policy.py
- git diff --check

Closes #2689