### PR TITLE
fix(scanning): reduce docs PII noise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ docs/CAPTURE [0-9].md
 docs/images/* [0-9].png
 docs/images/* [0-9].gif
 docs/images/* [0-9].svg
+docs/**/* [0-9].png
+docs/**/* [0-9].gif
+docs/**/* [0-9].svg
 docs/**/* [0-9].md
 site-docs/**/* [0-9].md
 src/agent_bom/**/* [0-9].py

--- a/src/agent_bom/secret_scanner.py
+++ b/src/agent_bom/secret_scanner.py
@@ -113,6 +113,34 @@ _SCAN_FILENAMES = frozenset(
 )
 
 _PII_SCAN_EXTENSIONS = frozenset({".env", ".yaml", ".yml", ".json", ".conf"})
+_PII_CODE_EXTENSIONS = frozenset(
+    {
+        ".py",
+        ".js",
+        ".ts",
+        ".jsx",
+        ".tsx",
+        ".go",
+        ".rs",
+        ".java",
+        ".rb",
+        ".php",
+        ".toml",
+        ".ini",
+        ".cfg",
+        ".properties",
+        ".tf",
+        ".hcl",
+        ".sh",
+        ".bash",
+        ".zsh",
+        ".ps1",
+    }
+)
+_PII_CONTEXT_RE = re.compile(
+    r"(?:=|:|\b(?:addr|address|allowlist|bind|database|endpoint|host|ip|listen|proxy|redis|server|url|uri)\b)",
+    re.IGNORECASE,
+)
 
 _MAX_FILE_SIZE = 1024 * 1024  # 1MB
 _MAX_FILES = 1000
@@ -257,9 +285,10 @@ def _scan_file(file_path: Path, rel_path: str) -> list[SecretFinding]:
                 break
 
         # PII patterns (MEDIUM) stay limited to structured config/secrets
-        # surfaces. Markdown/plain-text docs are still scanned for credentials
-        # above, but generic emails/IPs there are usually examples or contacts.
-        if file_path.suffix in _PII_SCAN_EXTENSIONS or file_path.name in _SCAN_FILENAMES:
+        # surfaces and config-like code lines. Markdown/plain-text docs are
+        # still scanned for credentials above, but generic emails/IPs there
+        # are usually examples or contacts.
+        if _should_scan_pii_line(file_path, line):
             for name, pattern in PII_PATTERNS:
                 if pattern.search(line):
                     findings.append(
@@ -275,6 +304,14 @@ def _scan_file(file_path: Path, rel_path: str) -> list[SecretFinding]:
                     break
 
     return findings
+
+
+def _should_scan_pii_line(file_path: Path, line: str) -> bool:
+    """Limit generic PII checks to structured or config-like file content."""
+    suffix = file_path.suffix.lower()
+    if suffix in _PII_SCAN_EXTENSIONS or file_path.name in _SCAN_FILENAMES:
+        return True
+    return suffix in _PII_CODE_EXTENSIONS and bool(_PII_CONTEXT_RE.search(line))
 
 
 def scan_secrets(project_path: str | Path) -> SecretScanResult:

--- a/tests/test_duplicate_artifact_guard.py
+++ b/tests/test_duplicate_artifact_guard.py
@@ -11,11 +11,17 @@ def test_duplicate_artifact_guard_detects_finder_copies() -> None:
         "src/agent_bom/model_advisories 2.py",
         "contracts/v1/scan.schema.json",
         "contracts/v1 2/scan.schema.json",
+        "README 2.md",
+        "docs/cli 2.md",
+        "docs/images/agent-bom-live 2.png",
         "tests/test_cloud_resilience 3.py",
     ]
 
     assert find_duplicate_artifacts(paths) == [
+        "README 2.md",
         "contracts/v1 2/scan.schema.json",
+        "docs/cli 2.md",
+        "docs/images/agent-bom-live 2.png",
         "src/agent_bom/model_advisories 2.py",
         "tests/test_cloud_resilience 3.py",
     ]

--- a/tests/test_secret_scanner.py
+++ b/tests/test_secret_scanner.py
@@ -42,6 +42,12 @@ def test_scan_secrets_suppresses_doc_pii_but_keeps_doc_credentials(tmp_path: Pat
         f'Contact security@example.com or test 192.168.1.10 in local docs.\nOPENAI_KEY = "{doc_key}"\n',
         encoding="utf-8",
     )
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "tutorial.md").write_text(
+        "Use 10.0.0.5 or 203.0.113.10 as tutorial addresses, then email docs@example.com.\n",
+        encoding="utf-8",
+    )
     (tmp_path / "notes.txt").write_text("Email docs@example.com from 10.0.0.5.\n", encoding="utf-8")
 
     result = scan_secrets(tmp_path)
@@ -49,6 +55,29 @@ def test_scan_secrets_suppresses_doc_pii_but_keeps_doc_credentials(tmp_path: Pat
     findings = {(finding.file_path, finding.secret_type, finding.category) for finding in result.findings}
     assert ("README.md", "OpenAI API Key", "credential") in findings
     assert not any(finding.category == "pii" for finding in result.findings)
+
+
+def test_scan_secrets_keeps_ipv4_pii_in_code_config_and_secret_contexts(tmp_path: Path):
+    (tmp_path / "app.py").write_text('ADMIN_BIND_IP = "198.51.100.24"\n', encoding="utf-8")
+    (tmp_path / "service.yaml").write_text("upstream_ip: 198.51.100.25\n", encoding="utf-8")
+    (tmp_path / ".env").write_text("SERVICE_IP=198.51.100.26\n", encoding="utf-8")
+    (tmp_path / "implementation-notes.txt").write_text(
+        "The tutorial mentions 198.51.100.27 as an example address.\n",
+        encoding="utf-8",
+    )
+
+    result = scan_secrets(tmp_path)
+
+    ip_findings = {
+        (finding.file_path, finding.secret_type, finding.category)
+        for finding in result.findings
+        if finding.secret_type == "IP Address (IPv4)"
+    }
+    assert ip_findings == {
+        (".env", "IP Address (IPv4)", "pii"),
+        ("app.py", "IP Address (IPv4)", "pii"),
+        ("service.yaml", "IP Address (IPv4)", "pii"),
+    }
 
 
 def test_scan_secrets_warns_on_non_directory(tmp_path: Path):


### PR DESCRIPTION
Summary
- harden Finder duplicate artifact prevention for root docs, nested docs, and copied screenshot assets
- suppress generic IPv4/email PII matches in markdown and plain-text docs while preserving credential scanning
- keep IPv4 PII detection for structured config, .env files, and config-like code lines

Verification
- python scripts/check_duplicate_artifacts.py
- uv run pytest -q tests/test_duplicate_artifact_guard.py tests/test_secret_scanner.py
- uv run ruff check src/agent_bom/secret_scanner.py tests/test_duplicate_artifact_guard.py tests/test_secret_scanner.py
- git diff --check

Closes #2690
Refs #2644