### PR TITLE
feat(runtime): evaluate blueprint drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,17 @@ Versions follow [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Runtime blueprints now include a drift evaluation endpoint and MCP tool so
+  operators and agents can compare live runtime posture with an approved role
+  profile without exposing raw prompts, arguments, responses, or credentials.
 - MCP server mode now exposes read-only runtime posture tools for production
   index summaries, runtime blueprints, proxy/gateway status, Shield session
   status, and inter-agent firewall decision dry-runs.
+
+### Fixed
+- Product metrics now count the root dashboard page and refreshed MCP tool
+  counts across generated metrics, MCP docs, Docker MCP metadata, and release
+  consistency checks.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ integration docs instead of this front door.
 | Runtime proxy/gateway | runtime operators | scoped MCP traffic inspection, policy decisions, redacted audit evidence |
 | TypeScript client | services and agent runtimes | typed helper for stable REST endpoints |
 
-MCP server mode advertises 47 read-only security tools, 6 resources, and 6 workflow prompts.
+MCP server mode advertises 48 read-only security tools, 6 resources, and 6 workflow prompts.
 
 CLI scan commands run local scan pipelines today. They share lower scanner and
 discovery libraries with the API, but they are not API wrappers yet.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -232,7 +232,7 @@ graph TB
 | Output | `src/agent_bom/output/__init__.py` | JSON, CycloneDX, SARIF, SPDX, console |
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine (17 conditions) |
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP proxy (7 inline detectors) |
-| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (47 tools) |
+| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (48 tools) |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse |
 | Asset Tracker | `src/agent_bom/asset_tracker.py` | Persistent vuln tracking — first_seen, resolved, MTTR |
 | Context Graph | `src/agent_bom/context_graph.py` | Lateral movement analysis — see [Graph Contract](graph/CONTRACT.md) for entity/edge coverage, accuracy guarantees, and scaling boundaries |

--- a/docs/CLAUDE_INTEGRATION.md
+++ b/docs/CLAUDE_INTEGRATION.md
@@ -59,7 +59,7 @@ claude mcp add agent-bom -- uvx agent-bom mcp server
 
 ## What users get inside Claude
 
-`agent-bom mcp server` exposes 47 read-only tools for:
+`agent-bom mcp server` exposes 48 read-only tools for:
 
 - agent and MCP discovery
 - package and registry checks

--- a/docs/CODEX_CLI.md
+++ b/docs/CODEX_CLI.md
@@ -20,7 +20,7 @@ command = "agent-bom"
 args = ["mcp", "server"]
 ```
 
-That makes the same 47 read-only `agent-bom` MCP tools available to Codex.
+That makes the same 48 read-only `agent-bom` MCP tools available to Codex.
 
 ## What agent-bom discovers for Codex
 

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -150,7 +150,7 @@ An agent operating autonomously can be steered into a multi-step exfiltration se
 │  2. PROXY         Sits between client and server, intercepts     │
 │     (agent-bom proxy) every JSON-RPC message, enforces policy    │
 │                                                                  │
-│  3. MCP SERVER    Exposes 47 scan/governance tools to any agent  │
+│  3. MCP SERVER    Exposes 48 scan/governance tools to any agent  │
 │     (agent-bom mcp server)  — scan, check, registry, compliance  │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -210,7 +210,7 @@ For cross-agent correlation, use the broader runtime protection engine (`agent-b
 agent-bom mcp server
 ```
 
-Exposes 47 tools to any MCP-compatible AI assistant. Your agent can run scans, check packages, query ExposurePaths, ask for deploy decisions, query threat intel, inspect runtime posture, and generate compliance reports without leaving the chat:
+Exposes 48 tools to any MCP-compatible AI assistant. Your agent can run scans, check packages, query ExposurePaths, ask for deploy decisions, query threat intel, inspect runtime posture, and generate compliance reports without leaving the chat:
 
 ```
 scan                — full discovery + scan, returns JSON report

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,6 +1,6 @@
 # MCP Server — Connect agent-bom to AI Assistants
 
-agent-bom exposes 47 security tools as an MCP server. Any MCP-compatible client
+agent-bom exposes 48 security tools as an MCP server. Any MCP-compatible client
 can connect and get vulnerability scanning, blast radius analysis, compliance
 checks, and supply chain verification through natural conversation.
 
@@ -56,7 +56,7 @@ Add to `~/.snowflake/cortex/mcp.json`:
 }
 ```
 
-CoCo can then call the same 47 `agent-bom` tools over MCP.
+CoCo can then call the same 48 `agent-bom` tools over MCP.
 
 agent-bom also discovers Cortex auxiliary security files alongside `mcp.json`:
 
@@ -155,7 +155,7 @@ agent-bom proxy-bootstrap \
 
 `proxy-configure` is best for JSON MCP clients such as Claude Desktop, Cursor, Windsurf, and Cortex CoCo. TOML-based clients like Codex CLI need manual proxy wrapping.
 
-## Tool Categories (47 tools)
+## Tool Categories (48 tools)
 
 | Category | Tools | What They Do |
 |----------|-------|-------------|
@@ -168,7 +168,7 @@ agent-bom proxy-bootstrap \
 | **Inventory** | `inventory` | List agents/servers without CVE scanning |
 | **Trust** | `marketplace_check`, `runtime_correlate`, `tool_risk_assessment` | Score package trust, correlate runtime usage, and assess live tool capability risk |
 | **Skills** | `skill_scan`, `skill_verify`, `skill_trust` | Instruction-file trust, provenance, and tool-poisoning detection |
-| **Graph / Runtime** | `exposure_paths`, `should_i_deploy`, `context_graph`, `graph_export`, `runtime_correlate`, `runtime_production_index`, `runtime_blueprints`, `proxy_status`, `gateway_status`, `shield_status`, `firewall_check`, `tool_risk_assessment` | Return ranked investigation paths, deploy decisions, graph exports, runtime posture, blueprints, and read-only firewall decisions |
+| **Graph / Runtime** | `exposure_paths`, `should_i_deploy`, `context_graph`, `graph_export`, `runtime_correlate`, `runtime_production_index`, `runtime_blueprints`, `runtime_blueprint_drift`, `proxy_status`, `gateway_status`, `shield_status`, `firewall_check`, `tool_risk_assessment` | Return ranked investigation paths, deploy decisions, graph exports, runtime posture, blueprints, drift checks, and read-only firewall decisions |
 | **AI supply chain** | `dataset_card_scan`, `training_pipeline_scan`, `browser_extension_scan`, `model_provenance_scan`, `prompt_scan`, `model_file_scan`, `ingest_external_scan` | Scan AI artifacts, prompts, model files, browser extensions, and external scanner results |
 
 ## Agent-facing decision tools

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -127,7 +127,7 @@ notes discuss agent-native product direction.
 | Area | Shipped today | Not yet shipped |
 |---|---|---|
 | Human cockpit | Next.js dashboard, graph cockpit, reports, compliance and audit views | every UI action backed by a source registry and persisted workflow state |
-| Agent interface | 47 read-only MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture | long-lived posture subscription tool, autonomous remediation actions |
+| Agent interface | 48 read-only MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture | long-lived posture subscription tool, autonomous remediation actions |
 | Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports, TypeScript control-plane client, TypeScript runtime detector package | Python/Go control-plane SDKs and full scanner SDKs |
 | Runtime | MCP proxy, gateway, Shield SDK, runtime audit and policy decisions | webhook outbox, Kafka connectors, cloud-log ingestion connectors, Kinesis/Firehose adapter, and MCP posture subscriptions |
 | Graph scale | SQLite/Postgres default path, WebGL overview, optional Neptune adapter work | production Neptune SLOs, public openCypher endpoint, mandatory graph-database backend |

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,10 +1,10 @@
 {
-  "generated_on": "2026-05-18",
+  "generated_on": "2026-05-19",
   "version": "0.87.1",
   "metrics": [
     {
       "name": "MCP tools",
-      "value": 47,
+      "value": 48,
       "source": "src/agent_bom/mcp_server_metadata.py",
       "notes": "Counted from the advertised server-card tools."
     },
@@ -28,25 +28,25 @@
     },
     {
       "name": "Test files",
-      "value": 477,
+      "value": 478,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
     {
       "name": "API route modules",
-      "value": 24,
+      "value": 25,
       "source": "src/agent_bom/api/routes",
       "notes": "Counts Python files in the routes package, including __init__.py."
     },
     {
       "name": "UI app pages",
-      "value": 23,
+      "value": 24,
       "source": "ui/app",
       "notes": "Counts page.tsx and page.jsx files recursively."
     },
     {
       "name": "Python modules",
-      "value": 483,
+      "value": 485,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,19 +5,19 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-05-18`
+- Generated on: `2026-05-19`
 - Version: `0.87.1`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |
-| MCP tools | 47 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
+| MCP tools | 48 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 35 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 477 | `tests/` | Counts files matching test_*.py. |
-| API route modules | 24 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
-| UI app pages | 23 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 483 | `src/agent_bom` | Counts all Python files recursively. |
+| Test files | 478 | `tests/` | Counts files matching test_*.py. |
+| API route modules | 25 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
+| UI app pages | 24 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
+| Python modules | 485 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 14 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -13,7 +13,7 @@ agent-bom operates in four modes:
 1. **Scanner** — reads local config files + public APIs, produces reports
 2. **Proxy** — sits between an MCP client and server, inspects STDIO traffic
 3. **API server** — exposes REST/WebSocket endpoints for the dashboard
-4. **MCP server** — exposes 47 tools to AI assistants (Claude, Cursor, etc.)
+4. **MCP server** — exposes 48 tools to AI assistants (Claude, Cursor, etc.)
 
 ## Trust boundaries
 

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -12250,6 +12250,51 @@
         ]
       }
     },
+    "/v1/runtime/blueprints/{blueprint_id}/drift": {
+      "get": {
+        "description": "Evaluate current runtime posture against one role/profile blueprint.",
+        "operationId": "get_runtime_blueprint_drift_v1_runtime_blueprints__blueprint_id__drift_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "blueprint_id",
+            "required": true,
+            "schema": {
+              "title": "Blueprint Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Runtime Blueprint Drift V1 Runtime Blueprints  Blueprint Id  Drift Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Runtime Blueprint Drift",
+        "tags": [
+          "runtime"
+        ]
+      }
+    },
     "/v1/runtime/production-index": {
       "get": {
         "description": "Return tenant-scoped runtime security observability for proxy/gateway traffic.\n\nThe production index is metadata-only by construction: it summarizes\ntool-call volume, policy decisions, alerts, source/session activity, and\nretention posture without returning raw prompts, raw arguments, raw\nresponses, or credential values.",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -8047,6 +8047,36 @@ paths:
       summary: Get Runtime Blueprint
       tags:
       - runtime
+  /v1/runtime/blueprints/{blueprint_id}/drift:
+    get:
+      description: Evaluate current runtime posture against one role/profile blueprint.
+      operationId: get_runtime_blueprint_drift_v1_runtime_blueprints__blueprint_id__drift_get
+      parameters:
+      - in: path
+        name: blueprint_id
+        required: true
+        schema:
+          title: Blueprint Id
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Runtime Blueprint Drift V1 Runtime Blueprints  Blueprint
+                  Id  Drift Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Runtime Blueprint Drift
+      tags:
+      - runtime
   /v1/runtime/production-index:
     get:
       description: 'Return tenant-scoped runtime security observability for proxy/gateway

--- a/integrations/docker-mcp-registry/tools.json
+++ b/integrations/docker-mcp-registry/tools.json
@@ -243,6 +243,14 @@
     ]
   },
   {
+    "name": "runtime_blueprint_drift",
+    "description": "Evaluate live runtime posture against a role/profile blueprint.",
+    "arguments": [
+      {"name": "blueprint_id", "type": "string", "desc": "Blueprint id such as developer or security_analyst"},
+      {"name": "tenant_id", "type": "string", "desc": "Tenant scope to summarize"}
+    ]
+  },
+  {
     "name": "proxy_status",
     "description": "Return current MCP proxy metrics and runtime alert posture.",
     "arguments": [

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -398,7 +398,7 @@ def main() -> int:
     tools = len(tool_names)
     resources = len(resource_uris)
     prompts = len(prompt_names)
-    if (tools, resources, prompts) != (47, 6, 6):
+    if (tools, resources, prompts) != (48, 6, 6):
         _fail(f"MCP server card count changed unexpectedly: tools={tools}, resources={resources}, prompts={prompts}")
     docker_mcp_tool_names = [str(tool["name"]) for tool in json.loads(DOCKER_MCP_TOOLS.read_text())]
     if docker_mcp_tool_names != tool_names:

--- a/scripts/product_metrics_snapshot.py
+++ b/scripts/product_metrics_snapshot.py
@@ -10,6 +10,7 @@ import re
 import subprocess
 from datetime import date
 from pathlib import Path
+from typing import cast
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -38,7 +39,7 @@ def _count_api_route_modules() -> int:
 
 
 def _count_ui_app_pages() -> int:
-    return len(_tracked_files("ui/app/**/page.tsx", "ui/app/**/page.jsx"))
+    return len(_tracked_files("ui/app/page.tsx", "ui/app/page.jsx", "ui/app/**/page.tsx", "ui/app/**/page.jsx"))
 
 
 def _count_python_modules() -> int:
@@ -217,7 +218,7 @@ def render_markdown(snapshot: dict[str, object]) -> str:
         "| Metric | Value | Source | Notes |",
         "| --- | ---: | --- | --- |",
     ]
-    for entry in snapshot["metrics"]:
+    for entry in cast(list[dict[str, object]], snapshot["metrics"]):
         lines.append(f"| {entry['name']} | {entry['value']} | `{entry['source']}` | {entry['notes']} |")
     lines.extend(
         [

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server Setup
 
-agent-bom runs as an MCP server, exposing 47 read-only security tools to any MCP client.
+agent-bom runs as an MCP server, exposing 48 read-only security tools to any MCP client.
 The server card also advertises 6 resources and 6 workflow prompts so agents can
 choose structured playbooks instead of guessing tool order.
 
@@ -101,7 +101,12 @@ Connect with:
 |------|-------------|
 | `scan` | Full discovery + vulnerability scan |
 | `check` | Check a package for CVEs |
+| `intel_lookup` | Look up a CVE, GHSA, or OSV advisory |
+| `intel_match` | Match package or purl inventory against local advisories |
+| `intel_sources` | List threat-intel source freshness and licensing metadata |
 | `blast_radius` | Map CVE impact chain |
+| `exposure_paths` | Return ranked ExposurePath investigation paths |
+| `should_i_deploy` | Return allow/warn/block deploy guidance from ExposurePath risk |
 | `registry_lookup` | Look up MCP server security metadata |
 | `compliance` | Run compliance framework checks |
 | `remediate` | Prioritized remediation plan |
@@ -125,6 +130,7 @@ Connect with:
 | `runtime_correlate` | Cross-reference runtime logs with CVEs |
 | `runtime_production_index` | Metadata-only runtime production posture |
 | `runtime_blueprints` | Role/profile blueprints for runtime policy design |
+| `runtime_blueprint_drift` | Evaluate runtime posture against a role/profile blueprint |
 | `proxy_status` | Current MCP proxy metrics and alert posture |
 | `gateway_status` | Gateway policy and inter-agent firewall runtime statistics |
 | `shield_status` | Shield session status without changing enforcement |

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -55,7 +55,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 |---|---|---|
 | **CLI / CI** | developers and pipelines | local scans, SARIF/SBOM/HTML/JSON, graph exports, deterministic gates |
 | **REST API** | security platforms, SIEM jobs, custom services | self-hosted control-plane routes for scans, normalized bulk findings, dataset versions, graph evidence, audit, and governance |
-| **MCP tools** | AI agents and coding assistants | 47 read-only tools, strict args, `exposure_paths`, `should_i_deploy`, runtime posture |
+| **MCP tools** | AI agents and coding assistants | 48 read-only tools, strict args, `exposure_paths`, `should_i_deploy`, runtime posture |
 | **TypeScript client** | services and agent runtimes calling the control plane | typed helper for stable REST endpoints; not a scanner SDK |
 | **TypeScript runtime detectors** | MCP/runtime enforcement integrations | local detector package for runtime policy checks; separate from the control-plane client |
 | **UI cockpit** | security teams and auditors | graph cockpit, compliance, audit, and evidence review over the same backend data |

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -16,6 +16,24 @@ Check a single package for vulnerabilities.
 check(package="langchain", ecosystem="pypi")
 ```
 
+### intel_lookup
+Look up a CVE, GHSA, or OSV advisory in the local threat-intel database.
+```
+intel_lookup(advisory_id="CVE-2026-12345")
+```
+
+### intel_match
+Match package or purl inventory coordinates against local threat-intel advisories.
+```
+intel_match(purl="pkg:pypi/requests@2.31.0")
+```
+
+### intel_sources
+List configured threat-intel sources and local feed freshness metadata.
+```
+intel_sources()
+```
+
 ### blast_radius
 Map the full impact chain of a CVE across agents, servers, credentials, and tools.
 ```
@@ -181,6 +199,12 @@ runtime_production_index(tenant_id="default")
 Return all runtime role/profile blueprints, or a single blueprint by id.
 ```
 runtime_blueprints(blueprint_id="security_analyst")
+```
+
+### runtime_blueprint_drift
+Evaluate live runtime posture against a role/profile blueprint.
+```
+runtime_blueprint_drift(blueprint_id="developer", tenant_id="default")
 ```
 
 ### proxy_status

--- a/src/agent_bom/api/routes/runtime_blueprints.py
+++ b/src/agent_bom/api/routes/runtime_blueprints.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Request
 
-from agent_bom.runtime_blueprints import runtime_role_blueprint, runtime_role_blueprints
+from agent_bom.runtime_blueprints import evaluate_runtime_blueprint_drift, runtime_role_blueprint, runtime_role_blueprints
 
 router = APIRouter(tags=["runtime"])
 
@@ -34,3 +34,16 @@ async def get_runtime_blueprint(request: Request, blueprint_id: str) -> dict[str
         "tenant_id": _request_tenant_id(request),
         "blueprint": blueprint,
     }
+
+
+@router.get("/v1/runtime/blueprints/{blueprint_id}/drift")
+async def get_runtime_blueprint_drift(request: Request, blueprint_id: str) -> dict[str, object]:
+    """Evaluate current runtime posture against one role/profile blueprint."""
+    from agent_bom.api.routes.proxy import _build_runtime_production_index, _load_proxy_alerts, _runtime_metrics_for_tenant
+
+    tenant_id = _request_tenant_id(request)
+    try:
+        production_index = _build_runtime_production_index(tenant_id, _runtime_metrics_for_tenant(tenant_id), _load_proxy_alerts(tenant_id))
+        return evaluate_runtime_blueprint_drift(blueprint_id, production_index, tenant_id=tenant_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Runtime blueprint not found") from exc

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -692,7 +692,7 @@ def mcp_server_cmd(
     Requires:  pip install 'agent-bom[mcp-server]'
 
     \b
-    Exposes 47 security tools via MCP protocol:
+    Exposes 48 security tools via MCP protocol:
       scan                   Full scan — CVEs, config security, blast radius, compliance
       check                  Check a specific package for CVEs before installing
       blast_radius           Look up blast radius for a specific CVE

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -5,7 +5,7 @@ Start with:
     agent-bom mcp server --transport sse          # SSE transport (for remote clients)
     agent-bom mcp server --transport streamable-http
 
-Tools (47):
+Tools (48):
     scan                — Full discovery → scan → output pipeline
     check               — Check a specific package for CVEs before installing
     blast_radius        — Look up blast radius for a specific CVE

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -132,6 +132,11 @@ _SERVER_CARD_TOOLS = [
         "annotations": {"readOnlyHint": True},
     },
     {
+        "name": "runtime_blueprint_drift",
+        "description": "Evaluate live runtime posture against a role/profile blueprint",
+        "annotations": {"readOnlyHint": True},
+    },
+    {
         "name": "proxy_status",
         "description": "Return current MCP proxy metrics and runtime alert posture",
         "annotations": {"readOnlyHint": True},
@@ -248,6 +253,7 @@ _TOOL_CAPABILITY_CLASSES = {
     "runtime_correlate": ["READ", "LOCAL_FILE_READ", "RUNTIME"],
     "runtime_production_index": ["READ", "RUNTIME", "OBSERVABILITY"],
     "runtime_blueprints": ["READ", "RUNTIME", "POLICY"],
+    "runtime_blueprint_drift": ["READ", "RUNTIME", "POLICY", "ANALYZE"],
     "proxy_status": ["READ", "RUNTIME", "OBSERVABILITY"],
     "gateway_status": ["READ", "RUNTIME", "POLICY"],
     "shield_status": ["READ", "RUNTIME", "SECURITY"],

--- a/src/agent_bom/mcp_server_operator_tools.py
+++ b/src/agent_bom/mcp_server_operator_tools.py
@@ -34,6 +34,7 @@ def register_operator_tools(
         firewall_check_impl,
         gateway_status_impl,
         proxy_status_impl,
+        runtime_blueprint_drift_impl,
         runtime_blueprints_impl,
         runtime_correlate_impl,
         runtime_production_index_impl,
@@ -432,6 +433,26 @@ def register_operator_tools(
         return await execute_tool_async(
             "runtime_blueprints",
             runtime_blueprints_impl,
+            blueprint_id=blueprint_id,
+            tenant_id=tenant_id,
+            _truncate_response=truncate_response,
+        )
+
+    @mcp.tool(annotations=read_only, title="Runtime Blueprint Drift")
+    async def runtime_blueprint_drift(
+        blueprint_id: Annotated[
+            str,
+            Field(description="Blueprint id to evaluate, such as developer, security_analyst, mlops, finance, or admin."),
+        ],
+        tenant_id: Annotated[
+            str,
+            Field(description="Tenant scope to summarize. Defaults to the control-plane default tenant."),
+        ] = "default",
+    ) -> str:
+        """Compare current runtime traffic with an approved role/profile blueprint."""
+        return await execute_tool_async(
+            "runtime_blueprint_drift",
+            runtime_blueprint_drift_impl,
             blueprint_id=blueprint_id,
             tenant_id=tenant_id,
             _truncate_response=truncate_response,

--- a/src/agent_bom/mcp_tools/runtime.py
+++ b/src/agent_bom/mcp_tools/runtime.py
@@ -64,6 +64,28 @@ async def runtime_blueprints_impl(
         return json.dumps({"error": sanitize_error(exc)})
 
 
+async def runtime_blueprint_drift_impl(
+    *,
+    blueprint_id: str,
+    tenant_id: str = "default",
+    _truncate_response,
+) -> str:
+    """Implementation of the runtime_blueprint_drift tool."""
+    try:
+        from fastapi import HTTPException
+
+        from agent_bom.api.routes.runtime_blueprints import get_runtime_blueprint_drift
+
+        try:
+            payload = await get_runtime_blueprint_drift(cast(Any, _request_for_tenant(tenant_id)), blueprint_id.strip())
+        except HTTPException as exc:
+            return json.dumps({"error": sanitize_error(exc.detail)})
+        return _truncate_response(json.dumps(payload, indent=2, default=str))
+    except Exception as exc:
+        logger.exception("MCP runtime blueprint drift error")
+        return json.dumps({"error": sanitize_error(exc)})
+
+
 async def proxy_status_impl(
     *,
     tenant_id: str = "default",

--- a/src/agent_bom/runtime_blueprints.py
+++ b/src/agent_bom/runtime_blueprints.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -98,4 +101,205 @@ def runtime_role_blueprint(blueprint_id: str) -> dict[str, object] | None:
     return None
 
 
-__all__ = ["RuntimeRoleBlueprint", "runtime_role_blueprint", "runtime_role_blueprints"]
+_CATEGORY_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("payment_write", ("payment", "payroll", "bank", "invoice_update")),
+    ("production_write", ("deploy", "rollback", "production", "prod_write")),
+    ("database_write", ("insert", "update", "delete", "query_write", "write_query")),
+    ("repo_write", ("write", "edit", "commit", "push", "merge", "create_file", "apply_patch")),
+    ("credential_export", ("credential", "secret", "token", "env", "key", "vault")),
+    ("policy_write", ("policy", "firewall", "shield", "admin")),
+    ("tenant_admin", ("tenant", "scim", "saml", "oidc", "entitlement")),
+    ("threat_intel", ("intel", "advisory", "cve", "ghsa", "osv", "kev", "epss")),
+    ("finding_read", ("finding", "sarif", "vulnerability", "vuln")),
+    ("graph_query", ("graph", "exposure", "path", "blast", "lineage")),
+    ("audit_read", ("audit", "trace", "integrity", "evidence")),
+    ("evidence_export", ("export", "report", "evidence", "bundle")),
+    ("package_scan", ("package", "sbom", "dependency", "scan", "image")),
+    ("model_registry_read", ("model", "huggingface", "ollama", "mlflow")),
+    ("dataset_read", ("dataset", "experiment", "feature")),
+    ("runtime_trace", ("runtime", "proxy", "gateway", "session", "span")),
+    ("mcp_discovery", ("mcp", "tool", "server", "inventory", "manifest")),
+    ("business_app_read", ("salesforce", "snowflake", "jira", "servicenow", "slack")),
+    ("report_generate", ("summary", "brief", "report", "dashboard")),
+    ("ticket_create", ("ticket", "issue", "case")),
+    ("local_runtime", ("shell", "terminal", "docker", "process", "exec")),
+    ("repo_read", ("read", "list", "search", "grep", "git", "repo", "file")),
+)
+
+
+def classify_runtime_tool(tool_name: str) -> str:
+    """Map a runtime tool name to a blueprint category.
+
+    Runtime events often carry only a tool name, not a formal capability map.
+    This conservative classifier keeps drift checks deterministic and
+    explainable until deployments attach richer tool metadata.
+    """
+    normalized = tool_name.strip().lower().replace("-", "_").replace("/", "_").replace(".", "_")
+    if not normalized:
+        return "unknown"
+    for category, keywords in _CATEGORY_KEYWORDS:
+        if any(keyword in normalized for keyword in keywords):
+            return category
+    return "unknown"
+
+
+def _iter_runtime_tools(production_index: dict[str, Any]) -> Counter[str]:
+    traffic = production_index.get("traffic")
+    if not isinstance(traffic, dict):
+        return Counter()
+    calls_by_tool = traffic.get("calls_by_tool")
+    if isinstance(calls_by_tool, dict):
+        return Counter({str(tool): int(count) for tool, count in calls_by_tool.items() if str(tool).strip()})
+    top_tools = traffic.get("top_tools")
+    counts: Counter[str] = Counter()
+    if isinstance(top_tools, list):
+        for item in top_tools:
+            if isinstance(item, dict):
+                name = str(item.get("name") or "").strip()
+                if name:
+                    counts[name] += int(item.get("count") or 0)
+    return counts
+
+
+def _as_str_set(value: object) -> set[str]:
+    if not isinstance(value, list | tuple | set):
+        return set()
+    return {str(item) for item in value}
+
+
+def _as_int(value: object, default: int = 0) -> int:
+    try:
+        return int(value)  # type: ignore[call-overload]
+    except (TypeError, ValueError):
+        return default
+
+
+def evaluate_runtime_blueprint_drift(
+    blueprint_id: str,
+    production_index: dict[str, Any],
+    *,
+    tenant_id: str = "default",
+) -> dict[str, object]:
+    """Compare live runtime posture with an approved role/profile blueprint."""
+    blueprint = runtime_role_blueprint(blueprint_id)
+    if blueprint is None:
+        raise KeyError(blueprint_id)
+
+    allowed = _as_str_set(blueprint.get("allowed_tool_categories"))
+    restricted = _as_str_set(blueprint.get("restricted_tool_categories"))
+    approval_required = _as_str_set(blueprint.get("approval_required_for"))
+    tool_counts = _iter_runtime_tools(production_index)
+    category_counts: Counter[str] = Counter()
+    violations: list[dict[str, object]] = []
+    warnings: list[dict[str, object]] = []
+
+    for tool_name, count in sorted(tool_counts.items()):
+        category = classify_runtime_tool(tool_name)
+        category_counts[category] += count
+        if category in restricted:
+            violations.append(
+                {
+                    "type": "restricted_tool_category",
+                    "severity": "high",
+                    "tool_name": tool_name,
+                    "category": category,
+                    "observed_count": count,
+                    "recommendation": "Block this tool for the selected blueprint or move the agent to a higher-privilege blueprint.",
+                }
+            )
+        elif category in approval_required:
+            warnings.append(
+                {
+                    "type": "approval_required_tool_category",
+                    "severity": "medium",
+                    "tool_name": tool_name,
+                    "category": category,
+                    "observed_count": count,
+                    "recommendation": "Require an approval trace before allowing this action for the selected blueprint.",
+                }
+            )
+        elif category not in allowed and category != "unknown":
+            warnings.append(
+                {
+                    "type": "outside_allowed_tool_category",
+                    "severity": "medium",
+                    "tool_name": tool_name,
+                    "category": category,
+                    "observed_count": count,
+                    "recommendation": "Review whether this category belongs in the blueprint or should be blocked.",
+                }
+            )
+        elif category == "unknown":
+            warnings.append(
+                {
+                    "type": "unclassified_tool",
+                    "severity": "low",
+                    "tool_name": tool_name,
+                    "category": category,
+                    "observed_count": count,
+                    "recommendation": "Attach a tool category annotation so drift evaluation can make a stronger decision.",
+                }
+            )
+
+    authorization = production_index.get("authorization_trace")
+    approval_count = 0
+    data_filter_count = 0
+    if isinstance(authorization, dict):
+        approval_count = _as_int(authorization.get("approval_required"))
+        data_filter_count = _as_int(authorization.get("data_filter_applied"))
+    if approval_count:
+        warnings.append(
+            {
+                "type": "runtime_approval_required",
+                "severity": "medium",
+                "observed_count": approval_count,
+                "recommendation": "Preserve approval evidence and confirm the selected blueprint allows this workflow.",
+            }
+        )
+    if data_filter_count:
+        warnings.append(
+            {
+                "type": "runtime_data_filter_applied",
+                "severity": "low",
+                "observed_count": data_filter_count,
+                "recommendation": "Retain redaction evidence for audit and verify filters match the blueprint.",
+            }
+        )
+
+    raw_traffic = production_index.get("traffic")
+    traffic = raw_traffic if isinstance(raw_traffic, dict) else {}
+    total_tool_calls = _as_int(traffic.get("total_tool_calls"), sum(tool_counts.values()))
+    high_weight = sum(_as_int(item.get("observed_count"), 1) for item in violations if item.get("severity") == "high")
+    medium_weight = sum(_as_int(item.get("observed_count"), 1) for item in warnings if item.get("severity") == "medium")
+    drift_score = 0.0 if not total_tool_calls else min(1.0, (high_weight + medium_weight * 0.5) / max(total_tool_calls, 1))
+    status = "no_runtime_activity" if total_tool_calls == 0 else ("drift_detected" if violations else "review" if warnings else "aligned")
+
+    return {
+        "schema_version": "runtime.blueprint_drift.v1",
+        "tenant_id": tenant_id or "default",
+        "blueprint_id": blueprint["blueprint_id"],
+        "evaluated_at": datetime.now(timezone.utc).isoformat(),
+        "status": status,
+        "drift_score": round(drift_score, 4),
+        "runtime_status": production_index.get("status", "unknown"),
+        "observed": {
+            "total_tool_calls": total_tool_calls,
+            "categories": dict(sorted(category_counts.items())),
+            "tools": [
+                {"name": name, "category": classify_runtime_tool(name), "count": count} for name, count in sorted(tool_counts.items())
+            ],
+        },
+        "blueprint": blueprint,
+        "violations": violations,
+        "warnings": warnings,
+        "retention": "metadata_only",
+    }
+
+
+__all__ = [
+    "RuntimeRoleBlueprint",
+    "classify_runtime_tool",
+    "evaluate_runtime_blueprint_drift",
+    "runtime_role_blueprint",
+    "runtime_role_blueprints",
+]

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -490,7 +490,7 @@ def test_mcp_server_help_shows_skill_tools():
 
     runner = CliRunner()
     result = runner.invoke(main, ["mcp", "server", "--help"])
-    assert "47 security tools" in result.output
+    assert "48 security tools" in result.output
     assert "skill_scan" in result.output
     assert "skill_verify" in result.output
     assert "compliance" in result.output

--- a/tests/test_mcp_strict_args.py
+++ b/tests/test_mcp_strict_args.py
@@ -27,7 +27,7 @@ def mcp_server():
 def test_every_tool_advertises_additional_properties_false(mcp_server) -> None:  # noqa: ANN001
     """Every registered tool's JSON schema must reject unknown properties."""
     tools = list(mcp_server._tool_manager._tools.values())
-    assert len(tools) >= 47, f"expected at least 47 tools, got {len(tools)}"
+    assert len(tools) >= 48, f"expected at least 48 tools, got {len(tools)}"
     leaks: list[str] = []
     for tool in tools:
         params = tool.parameters or {}

--- a/tests/test_mcp_tool_impls.py
+++ b/tests/test_mcp_tool_impls.py
@@ -902,6 +902,36 @@ async def test_runtime_blueprints_impl_lists_and_filters():
 
 
 @pytest.mark.asyncio
+async def test_runtime_blueprint_drift_impl_reports_drift(monkeypatch):
+    import agent_bom.api.routes.proxy as proxy_mod
+    from agent_bom.api.server import push_proxy_metrics
+    from agent_bom.mcp_tools.runtime import runtime_blueprint_drift_impl
+
+    proxy_mod._proxy_alerts.clear()
+    proxy_mod._proxy_metrics = None
+    proxy_mod._proxy_metrics_by_tenant.clear()
+    monkeypatch.delenv("AGENT_BOM_LOG", raising=False)
+    push_proxy_metrics(
+        {
+            "type": "proxy_summary",
+            "tenant_id": "default",
+            "total_tool_calls": 1,
+            "calls_by_tool": {"prod.deploy_service": 1},
+        }
+    )
+
+    result = await runtime_blueprint_drift_impl(blueprint_id="developer", tenant_id="default", _truncate_response=_trunc)
+    data = json.loads(result)
+    assert data["schema_version"] == "runtime.blueprint_drift.v1"
+    assert data["status"] == "drift_detected"
+    assert data["violations"][0]["type"] == "restricted_tool_category"
+
+    proxy_mod._proxy_alerts.clear()
+    proxy_mod._proxy_metrics = None
+    proxy_mod._proxy_metrics_by_tenant.clear()
+
+
+@pytest.mark.asyncio
 async def test_proxy_gateway_and_shield_status_impls_empty_state():
     from agent_bom.mcp_tools.runtime import gateway_status_impl, proxy_status_impl, shield_status_impl
 

--- a/tests/test_runtime_blueprints.py
+++ b/tests/test_runtime_blueprints.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from starlette.testclient import TestClient
 
 from agent_bom.api.server import app
-from agent_bom.runtime_blueprints import runtime_role_blueprint, runtime_role_blueprints
+from agent_bom.runtime_blueprints import (
+    classify_runtime_tool,
+    evaluate_runtime_blueprint_drift,
+    runtime_role_blueprint,
+    runtime_role_blueprints,
+)
 
 
 def test_runtime_role_blueprints_are_canonical_profiles() -> None:
@@ -44,3 +49,48 @@ def test_runtime_blueprints_api_lists_and_gets_profiles() -> None:
 
     missing = client.get("/v1/runtime/blueprints/not-real")
     assert missing.status_code == 404
+
+
+def test_runtime_blueprint_drift_evaluates_live_index(monkeypatch) -> None:
+    import agent_bom.api.routes.proxy as proxy_mod
+    from agent_bom.api.server import push_proxy_metrics
+
+    proxy_mod._proxy_alerts.clear()
+    proxy_mod._proxy_metrics = None
+    proxy_mod._proxy_metrics_by_tenant.clear()
+    monkeypatch.delenv("AGENT_BOM_LOG", raising=False)
+
+    push_proxy_metrics(
+        {
+            "type": "proxy_summary",
+            "tenant_id": "default",
+            "total_tool_calls": 3,
+            "total_blocked": 0,
+            "calls_by_tool": {
+                "repo.read_file": 2,
+                "prod.deploy_service": 1,
+            },
+        }
+    )
+
+    data = TestClient(app).get("/v1/runtime/blueprints/developer/drift").json()
+    assert data["schema_version"] == "runtime.blueprint_drift.v1"
+    assert data["status"] == "drift_detected"
+    assert data["observed"]["categories"]["repo_read"] == 2
+    assert data["observed"]["categories"]["production_write"] == 1
+    assert data["violations"][0]["category"] == "production_write"
+    assert data["retention"] == "metadata_only"
+
+    proxy_mod._proxy_alerts.clear()
+    proxy_mod._proxy_metrics = None
+    proxy_mod._proxy_metrics_by_tenant.clear()
+
+
+def test_runtime_blueprint_drift_empty_runtime_is_no_activity() -> None:
+    payload = evaluate_runtime_blueprint_drift(
+        "security_analyst",
+        {"schema_version": "runtime.production_index.v1", "status": "no_runtime_activity", "traffic": {"calls_by_tool": {}}},
+    )
+    assert payload["status"] == "no_runtime_activity"
+    assert payload["drift_score"] == 0.0
+    assert classify_runtime_tool("intel_lookup") == "threat_intel"


### PR DESCRIPTION
Summary
- add runtime blueprint drift evaluation over the production-index posture so live tool usage is compared against approved role/profile categories
- expose the drift check through REST and MCP, with metadata-only retention and regression coverage for restricted runtime categories
- refresh MCP/product metric surfaces to 48 tools and fix the product-metrics generator so the root dashboard page is counted

Verification
- uv run pytest -q tests/test_runtime_blueprints.py tests/test_mcp_tool_impls.py tests/test_mcp_server.py tests/test_deployment.py tests/test_mcp_strict_args.py
- uv run ruff check scripts/product_metrics_snapshot.py src/agent_bom/runtime_blueprints.py src/agent_bom/api/routes/runtime_blueprints.py src/agent_bom/mcp_tools/runtime.py src/agent_bom/mcp_server_operator_tools.py src/agent_bom/mcp_server_metadata.py tests/test_runtime_blueprints.py tests/test_mcp_tool_impls.py tests/test_deployment.py tests/test_mcp_strict_args.py
- uv run mypy src/agent_bom/runtime_blueprints.py src/agent_bom/api/routes/runtime_blueprints.py src/agent_bom/mcp_tools/runtime.py src/agent_bom/mcp_server_operator_tools.py scripts/product_metrics_snapshot.py
- python scripts/product_metrics_snapshot.py --write
- python scripts/check_release_consistency.py
- uv run --extra api python scripts/export_openapi.py --check
- git diff --check

Notes
- Data-model atlas updates and demo GIF recapture are separate release-surface PRs because they touch broader schema documentation and binary assets.

Closes #2655
Refs #2657
