### PR TITLE
feat(ui): complete AI visibility cockpit filters

### DIFF
--- a/ui/app/manifest/page.tsx
+++ b/ui/app/manifest/page.tsx
@@ -21,23 +21,13 @@ import {
   Wrench,
 } from "lucide-react";
 import { api, type AgentBomManifestResponse } from "@/lib/api";
-
-function asString(value: unknown, fallback = ""): string {
-  return typeof value === "string" && value.trim() ? value : fallback;
-}
-
-function asNumber(value: unknown): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : 0;
-}
-
-function asStringList(value: unknown): string[] {
-  if (!Array.isArray(value)) return [];
-  return value.map((item) => String(item)).filter(Boolean);
-}
-
-function asRecord(value: unknown): Record<string, unknown> {
-  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
-}
+import {
+  DEFAULT_MANIFEST_FILTERS,
+  deriveManifestRows,
+  filterManifestRows,
+  manifestFilterOptions,
+  type ManifestFilters,
+} from "@/lib/agent-bom-manifest";
 
 function downloadManifest(manifest: AgentBomManifestResponse) {
   const blob = new Blob([JSON.stringify(manifest, null, 2)], { type: "application/json" });
@@ -165,7 +155,7 @@ export default function AgentBomManifestPage() {
   const [manifest, setManifest] = useState<AgentBomManifestResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [query, setQuery] = useState("");
+  const [filters, setFilters] = useState<ManifestFilters>(DEFAULT_MANIFEST_FILTERS);
 
   const load = () => {
     setLoading(true);
@@ -181,57 +171,14 @@ export default function AgentBomManifestPage() {
     load();
   }, []);
 
-  const rows = useMemo(() => {
-    if (!manifest) return [];
-    const agentsByName = new Map(
-      manifest.agents.map((agent) => {
-        const row = asRecord(agent);
-        return [asString(row.name), row] as const;
-      }),
-    );
-    const agentsById = new Map(
-      manifest.agents.map((agent) => {
-        const row = asRecord(agent);
-        return [asString(row.id, asString(row.canonical_id)), row] as const;
-      }),
-    );
-    const needle = query.trim().toLowerCase();
-    return manifest.mcp_servers
-      .map((server) => {
-        const serverRow = asRecord(server);
-        const refs = Array.isArray(serverRow.credential_refs) ? serverRow.credential_refs : [];
-        const tools = Array.isArray(serverRow.tools) ? serverRow.tools : [];
-        const observed = asRecord(serverRow.observed);
-        const agentName = asString(serverRow.agent_name, "local discovery");
-        const agent = agentsByName.get(agentName) ?? agentsById.get(agentName) ?? {};
-        const runtimeObserved = Boolean(observed.runtime_observed);
-        const gatewayRegistered = Boolean(observed.gateway_registered);
-        const configuredLocally = Boolean(observed.configured_locally);
-        const fleetPresent = Boolean(observed.fleet_present);
-        const runtimeState = runtimeObserved
-          ? gatewayRegistered
-            ? "gateway bound"
-            : configuredLocally || fleetPresent
-              ? "runtime observed"
-              : "shadow runtime"
-          : "inventory only";
-        return {
-          id: asString(serverRow.id, asString(serverRow.name, "server")),
-          agentName,
-          owner: asString(agent.owner, "unowned"),
-          environment: asString(agent.environment, "unknown"),
-          name: asString(serverRow.name, "unnamed"),
-          transport: asString(serverRow.transport, "unknown"),
-          authMode: asString(serverRow.auth_mode, "unknown"),
-          toolCount: asNumber(serverRow.tool_count) || tools.length,
-          credentialRefs: refs.map((ref) => (typeof ref === "object" && ref ? asString((ref as Record<string, unknown>).name) : "")).filter(Boolean),
-          runtimeState,
-          lastSeen: asString(observed.last_seen, "-"),
-          warnings: asStringList(asRecord(serverRow.security).warnings),
-        };
-      })
-      .filter((row) => !needle || `${row.agentName} ${row.owner} ${row.environment} ${row.name} ${row.transport} ${row.authMode} ${row.runtimeState}`.toLowerCase().includes(needle));
-  }, [manifest, query]);
+  const allRows = useMemo(() => (manifest ? deriveManifestRows(manifest) : []), [manifest]);
+  const rows = useMemo(() => filterManifestRows(allRows, filters), [allRows, filters]);
+  const options = useMemo(() => manifestFilterOptions(allRows), [allRows]);
+  const hasActiveFilters = JSON.stringify(filters) !== JSON.stringify(DEFAULT_MANIFEST_FILTERS);
+
+  const updateFilter = <K extends keyof ManifestFilters>(key: K, value: ManifestFilters[K]) => {
+    setFilters((current) => ({ ...current, [key]: value }));
+  };
 
   return (
     <main className="min-h-screen bg-[var(--background)] p-6 text-[var(--foreground)]">
@@ -322,17 +269,102 @@ export default function AgentBomManifestPage() {
                 <div className="flex flex-col gap-3 border-b border-[var(--border)] p-4 md:flex-row md:items-center md:justify-between">
                   <div>
                     <h2 className="text-sm font-semibold">Agent and MCP inventory</h2>
-                    <p className="mt-1 text-xs text-[var(--muted-foreground)]">{rows.length} visible server rows</p>
+                    <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+                      {rows.length} of {allRows.length} server rows visible
+                    </p>
                   </div>
                   <label className="relative w-full md:w-80">
                     <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-[var(--muted-foreground)]" />
                     <input
-                      value={query}
-                      onChange={(event) => setQuery(event.target.value)}
+                      value={filters.query}
+                      onChange={(event) => updateFilter("query", event.target.value)}
                       placeholder="Search agents, servers, transports"
                       className="w-full rounded-md border border-[var(--border)] bg-[var(--background)] py-2 pl-9 pr-3 text-sm outline-none focus:border-emerald-500"
                     />
                   </label>
+                </div>
+                <div className="grid gap-3 border-b border-[var(--border)] p-4 md:grid-cols-2 xl:grid-cols-6">
+                  <label className="flex flex-col gap-1 text-xs text-[var(--muted-foreground)]">
+                    Source
+                    <select
+                      value={filters.source}
+                      onChange={(event) => updateFilter("source", event.target.value)}
+                      className="rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
+                    >
+                      <option value="all">All sources</option>
+                      {options.sources.map((source) => (
+                        <option key={source} value={source}>
+                          {source}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="flex flex-col gap-1 text-xs text-[var(--muted-foreground)]">
+                    Owner
+                    <select
+                      value={filters.owner}
+                      onChange={(event) => updateFilter("owner", event.target.value)}
+                      className="rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
+                    >
+                      <option value="all">All owners</option>
+                      {options.owners.map((owner) => (
+                        <option key={owner} value={owner}>
+                          {owner}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="flex flex-col gap-1 text-xs text-[var(--muted-foreground)]">
+                    Risk
+                    <select
+                      value={filters.risk}
+                      onChange={(event) => updateFilter("risk", event.target.value as ManifestFilters["risk"])}
+                      className="rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
+                    >
+                      <option value="all">All risk</option>
+                      <option value="high">High</option>
+                      <option value="medium">Medium</option>
+                      <option value="low">Low</option>
+                    </select>
+                  </label>
+                  <label className="flex flex-col gap-1 text-xs text-[var(--muted-foreground)]">
+                    Freshness
+                    <select
+                      value={filters.freshness}
+                      onChange={(event) => updateFilter("freshness", event.target.value as ManifestFilters["freshness"])}
+                      className="rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
+                    >
+                      <option value="all">All freshness</option>
+                      <option value="seen_24h">Seen 24h</option>
+                      <option value="seen_7d">Seen 7d</option>
+                      <option value="stale">Stale</option>
+                      <option value="unknown">Unknown</option>
+                    </select>
+                  </label>
+                  <label className="flex flex-col gap-1 text-xs text-[var(--muted-foreground)]">
+                    Runtime
+                    <select
+                      value={filters.runtime}
+                      onChange={(event) => updateFilter("runtime", event.target.value as ManifestFilters["runtime"])}
+                      className="rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
+                    >
+                      <option value="all">All runtime</option>
+                      <option value="gateway bound">Gateway bound</option>
+                      <option value="runtime observed">Runtime observed</option>
+                      <option value="shadow runtime">Shadow runtime</option>
+                      <option value="inventory only">Inventory only</option>
+                    </select>
+                  </label>
+                  <div className="flex items-end">
+                    <button
+                      type="button"
+                      disabled={!hasActiveFilters}
+                      onClick={() => setFilters(DEFAULT_MANIFEST_FILTERS)}
+                      className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-[var(--border)] px-3 py-2 text-sm text-[var(--foreground)] hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      Clear filters
+                    </button>
+                  </div>
                 </div>
                 <div className="overflow-x-auto">
                   <table className="w-full text-left text-sm">
@@ -340,8 +372,10 @@ export default function AgentBomManifestPage() {
                       <tr>
                         <th className="px-4 py-3 font-medium">Agent</th>
                         <th className="px-4 py-3 font-medium">Owner</th>
+                        <th className="px-4 py-3 font-medium">Source</th>
                         <th className="px-4 py-3 font-medium">Environment</th>
                         <th className="px-4 py-3 font-medium">MCP server</th>
+                        <th className="px-4 py-3 font-medium">Risk</th>
                         <th className="px-4 py-3 font-medium">Transport</th>
                         <th className="px-4 py-3 font-medium">Runtime</th>
                         <th className="px-4 py-3 font-medium">Tools</th>
@@ -354,8 +388,22 @@ export default function AgentBomManifestPage() {
                         <tr key={row.id}>
                           <td className="px-4 py-3 text-[var(--foreground)]">{row.agentName}</td>
                           <td className="px-4 py-3 text-[var(--muted-foreground)]">{row.owner}</td>
+                          <td className="px-4 py-3 text-[var(--muted-foreground)]">{row.source}</td>
                           <td className="px-4 py-3 text-[var(--muted-foreground)]">{row.environment}</td>
                           <td className="px-4 py-3 font-medium text-[var(--foreground)]">{row.name}</td>
+                          <td className="px-4 py-3">
+                            <span
+                              className={`rounded-full px-2 py-1 text-xs ${
+                                row.riskLevel === "high"
+                                  ? "bg-red-500/10 text-red-300"
+                                  : row.riskLevel === "medium"
+                                    ? "bg-yellow-500/10 text-yellow-300"
+                                    : "bg-emerald-500/10 text-emerald-300"
+                              }`}
+                            >
+                              {row.riskLevel}
+                            </span>
+                          </td>
                           <td className="px-4 py-3 text-[var(--muted-foreground)]">{row.transport}</td>
                           <td className="px-4 py-3 text-[var(--muted-foreground)]">{row.runtimeState}</td>
                           <td className="px-4 py-3 text-[var(--foreground)]">{row.toolCount}</td>
@@ -363,6 +411,13 @@ export default function AgentBomManifestPage() {
                           <td className="px-4 py-3 text-[var(--muted-foreground)]">{row.lastSeen}</td>
                         </tr>
                       ))}
+                      {rows.length === 0 ? (
+                        <tr>
+                          <td colSpan={11} className="px-4 py-8 text-center text-sm text-[var(--muted-foreground)]">
+                            No MCP servers match these filters. Run <code className="rounded bg-[var(--muted)] px-1.5 py-0.5">agent-bom manifest</code> to generate local evidence, or clear filters to inspect the full tenant manifest.
+                          </td>
+                        </tr>
+                      ) : null}
                     </tbody>
                   </table>
                 </div>

--- a/ui/lib/agent-bom-manifest.ts
+++ b/ui/lib/agent-bom-manifest.ts
@@ -1,0 +1,182 @@
+import type { AgentBomManifestResponse } from "./api";
+
+export type ManifestRiskFilter = "all" | "high" | "medium" | "low";
+export type ManifestFreshnessFilter = "all" | "seen_24h" | "seen_7d" | "stale" | "unknown";
+export type ManifestRuntimeFilter = "all" | "gateway bound" | "runtime observed" | "shadow runtime" | "inventory only";
+
+export interface ManifestFilters {
+  query: string;
+  source: string;
+  owner: string;
+  risk: ManifestRiskFilter;
+  freshness: ManifestFreshnessFilter;
+  runtime: ManifestRuntimeFilter;
+}
+
+export interface ManifestRow {
+  id: string;
+  agentName: string;
+  owner: string;
+  environment: string;
+  name: string;
+  transport: string;
+  authMode: string;
+  source: string;
+  toolCount: number;
+  credentialRefs: string[];
+  runtimeState: ManifestRuntimeFilter;
+  freshness: Exclude<ManifestFreshnessFilter, "all">;
+  riskLevel: ManifestRiskFilter;
+  lastSeen: string;
+  warnings: string[];
+}
+
+const RISKY_CREDENTIAL_TOKENS = ["admin", "root", "prod", "token", "key", "secret", "password"];
+
+export const DEFAULT_MANIFEST_FILTERS: ManifestFilters = {
+  query: "",
+  source: "all",
+  owner: "all",
+  risk: "all",
+  freshness: "all",
+  runtime: "all",
+};
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value : fallback;
+}
+
+function asNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function asStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => String(item)).filter(Boolean);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function credentialNames(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((ref) => (typeof ref === "object" && ref ? asString((ref as Record<string, unknown>).name) : ""))
+    .filter(Boolean);
+}
+
+function rowSource(serverRow: Record<string, unknown>, observed: Record<string, unknown>, manifest: AgentBomManifestResponse): string {
+  const discovery = asRecord(serverRow.discovery);
+  const discoverySources = asStringList(discovery.sources);
+  if (discoverySources.length > 0) return discoverySources.join(", ");
+  const observedVia = asStringList(observed.via);
+  if (observedVia.length > 0) return observedVia.join(", ");
+  return asString(manifest.source, "unknown");
+}
+
+export function classifyFreshness(lastSeen: string, now: Date = new Date()): ManifestRow["freshness"] {
+  if (!lastSeen || lastSeen === "-") return "unknown";
+  const parsed = Date.parse(lastSeen);
+  if (!Number.isFinite(parsed)) return "unknown";
+  const ageMs = Math.max(0, now.getTime() - parsed);
+  const dayMs = 24 * 60 * 60 * 1000;
+  if (ageMs <= dayMs) return "seen_24h";
+  if (ageMs <= 7 * dayMs) return "seen_7d";
+  return "stale";
+}
+
+function classifyRuntimeState(observed: Record<string, unknown>): ManifestRow["runtimeState"] {
+  const runtimeObserved = Boolean(observed.runtime_observed);
+  const gatewayRegistered = Boolean(observed.gateway_registered);
+  const configuredLocally = Boolean(observed.configured_locally);
+  const fleetPresent = Boolean(observed.fleet_present);
+  if (!runtimeObserved) return "inventory only";
+  if (gatewayRegistered) return "gateway bound";
+  if (configuredLocally || fleetPresent) return "runtime observed";
+  return "shadow runtime";
+}
+
+function classifyRisk(row: {
+  credentialRefs: string[];
+  runtimeState: ManifestRow["runtimeState"];
+  warnings: string[];
+}): ManifestRiskFilter {
+  const hasRiskyCredential = row.credentialRefs.some((ref) =>
+    RISKY_CREDENTIAL_TOKENS.some((token) => ref.toLowerCase().includes(token)),
+  );
+  if (row.runtimeState === "shadow runtime" || row.warnings.length > 0 || hasRiskyCredential) {
+    return "high";
+  }
+  if (row.credentialRefs.length > 0 || row.runtimeState === "runtime observed") {
+    return "medium";
+  }
+  return "low";
+}
+
+export function deriveManifestRows(manifest: AgentBomManifestResponse, now: Date = new Date()): ManifestRow[] {
+  const agentsByName = new Map(
+    manifest.agents.map((agent) => {
+      const row = asRecord(agent);
+      return [asString(row.name), row] as const;
+    }),
+  );
+  const agentsById = new Map(
+    manifest.agents.map((agent) => {
+      const row = asRecord(agent);
+      return [asString(row.id, asString(row.canonical_id)), row] as const;
+    }),
+  );
+
+  return manifest.mcp_servers.map((server) => {
+    const serverRow = asRecord(server);
+    const tools = Array.isArray(serverRow.tools) ? serverRow.tools : [];
+    const observed = asRecord(serverRow.observed);
+    const agentName = asString(serverRow.agent_name, "local discovery");
+    const agent = agentsByName.get(agentName) ?? agentsById.get(agentName) ?? {};
+    const security = asRecord(serverRow.security);
+    const runtimeState = classifyRuntimeState(observed);
+    const lastSeen = asString(observed.last_seen, "-");
+    const row = {
+      id: asString(serverRow.id, asString(serverRow.name, "server")),
+      agentName,
+      owner: asString(agent.owner, "unowned"),
+      environment: asString(agent.environment, "unknown"),
+      name: asString(serverRow.name, "unnamed"),
+      transport: asString(serverRow.transport, "unknown"),
+      authMode: asString(serverRow.auth_mode, "unknown"),
+      source: rowSource(serverRow, observed, manifest),
+      toolCount: asNumber(serverRow.tool_count) || tools.length,
+      credentialRefs: credentialNames(serverRow.credential_refs),
+      runtimeState,
+      freshness: classifyFreshness(lastSeen, now),
+      riskLevel: "low" as ManifestRiskFilter,
+      lastSeen,
+      warnings: asStringList(security.warnings),
+    };
+    return { ...row, riskLevel: classifyRisk(row) };
+  });
+}
+
+export function filterManifestRows(rows: ManifestRow[], filters: ManifestFilters): ManifestRow[] {
+  const queryTokens = filters.query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  return rows.filter((row) => {
+    const haystack = `${row.agentName} ${row.owner} ${row.environment} ${row.name} ${row.transport} ${row.authMode} ${row.runtimeState} ${row.source}`
+      .toLowerCase();
+    return (
+      (queryTokens.length === 0 || queryTokens.every((token) => haystack.includes(token))) &&
+      (filters.source === "all" || row.source === filters.source) &&
+      (filters.owner === "all" || row.owner === filters.owner) &&
+      (filters.risk === "all" || row.riskLevel === filters.risk) &&
+      (filters.freshness === "all" || row.freshness === filters.freshness) &&
+      (filters.runtime === "all" || row.runtimeState === filters.runtime)
+    );
+  });
+}
+
+export function manifestFilterOptions(rows: ManifestRow[]) {
+  return {
+    sources: [...new Set(rows.map((row) => row.source).filter(Boolean))].sort(),
+    owners: [...new Set(rows.map((row) => row.owner).filter(Boolean))].sort(),
+  };
+}

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -8,7 +8,8 @@ const BUILD_MANIFEST = path.join(NEXT_DIR, "build-manifest.json");
 
 const BUDGETS = {
   // Includes the opt-in Sigma.js + graphology WebGL overview chunk for dense graphs.
-  totalClientJsBytes: 2_850_000,
+  // Also includes the Agent BOM manifest cockpit filters used for AI visibility triage.
+  totalClientJsBytes: 2_856_000,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };

--- a/ui/tests/agent-bom-manifest.test.ts
+++ b/ui/tests/agent-bom-manifest.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_MANIFEST_FILTERS,
+  classifyFreshness,
+  deriveManifestRows,
+  filterManifestRows,
+  manifestFilterOptions,
+  type ManifestFilters,
+} from "@/lib/agent-bom-manifest";
+import type { AgentBomManifestResponse } from "@/lib/api";
+
+const manifest: AgentBomManifestResponse = {
+  schema_version: "agent-bom.manifest/v1",
+  generated_at: "2026-05-19T12:00:00Z",
+  source: "control-plane",
+  tenant_id: "tenant-a",
+  summary: {
+    agents: 2,
+    mcp_servers: 3,
+    tools: 4,
+    credential_refs: 2,
+    runtime_observed_servers: 2,
+    gateway_registered_servers: 1,
+  },
+  visibility: {
+    owners: 1,
+    unowned_agents: 1,
+    shadow_runtime_servers: 1,
+    untracked_runtime_servers: 1,
+    servers_with_warnings: 1,
+    risky_credential_refs: 1,
+    risk_signals: {
+      unowned_agent_ids: ["agent-2"],
+      shadow_runtime_server_ids: ["srv-2"],
+      untracked_runtime_server_ids: ["srv-2"],
+      risky_credential_refs: ["ROOT_TOKEN"],
+    },
+  },
+  blueprint_drift: {
+    status: "needs_review",
+    mode: "observation_only",
+    fail_behavior: "report_only",
+    signal_count: 1,
+    signals: [{ kind: "untracked_runtime_server", entity_id: "srv-2", severity: "warning", message: "shadow" }],
+  },
+  agents: [
+    { id: "agent-1", name: "claude-desktop", owner: "platform", environment: "prod" },
+    { id: "agent-2", name: "cursor", environment: "dev" },
+  ],
+  mcp_servers: [
+    {
+      id: "srv-1",
+      name: "filesystem",
+      agent_name: "claude-desktop",
+      transport: "stdio",
+      auth_mode: "env",
+      credential_refs: [{ name: "API_KEY", kind: "env" }],
+      tools: [{ name: "read_file" }],
+      discovery: { sources: ["local"] },
+      security: { warnings: [] },
+      observed: {
+        runtime_observed: true,
+        gateway_registered: true,
+        configured_locally: true,
+        fleet_present: true,
+        last_seen: "2026-05-19T11:00:00Z",
+      },
+    },
+    {
+      id: "srv-2",
+      name: "cloud-admin",
+      agent_name: "cursor",
+      transport: "stdio",
+      auth_mode: "env",
+      credential_refs: [{ name: "ROOT_TOKEN", kind: "env" }],
+      tool_count: 3,
+      discovery: { sources: ["runtime"] },
+      security: { warnings: ["privileged credential"] },
+      observed: {
+        runtime_observed: true,
+        gateway_registered: false,
+        configured_locally: false,
+        fleet_present: false,
+        last_seen: "2026-05-10T11:00:00Z",
+      },
+    },
+    {
+      id: "srv-3",
+      name: "docs",
+      agent_name: "claude-desktop",
+      transport: "http",
+      auth_mode: "none",
+      credential_refs: [],
+      tools: [],
+      discovery: { sources: ["fleet"] },
+      security: { warnings: [] },
+      observed: {},
+    },
+  ],
+  graph: {
+    nodes: [],
+    edges: [],
+    stats: { nodes: 0, edges: 0, relationships: [] },
+  },
+  boundaries: {
+    stores_credential_values: false,
+    stores_raw_prompts: false,
+    credential_value_policy: "names_only",
+  },
+};
+
+describe("Agent BOM manifest row filters", () => {
+  const now = new Date("2026-05-19T12:00:00Z");
+
+  it("derives cockpit rows with risk, source, runtime, and freshness classifications", () => {
+    const rows = deriveManifestRows(manifest, now);
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map((row) => [row.name, row.source, row.runtimeState, row.riskLevel, row.freshness])).toEqual([
+      ["filesystem", "local", "gateway bound", "high", "seen_24h"],
+      ["cloud-admin", "runtime", "shadow runtime", "high", "stale"],
+      ["docs", "fleet", "inventory only", "low", "unknown"],
+    ]);
+  });
+
+  it("filters by explicit dimensions instead of only free text", () => {
+    const rows = deriveManifestRows(manifest, now);
+    const filters: ManifestFilters = {
+      ...DEFAULT_MANIFEST_FILTERS,
+      owner: "unowned",
+      runtime: "shadow runtime",
+      freshness: "stale",
+      risk: "high",
+    };
+
+    expect(filterManifestRows(rows, filters).map((row) => row.name)).toEqual(["cloud-admin"]);
+  });
+
+  it("filters source options and query text", () => {
+    const rows = deriveManifestRows(manifest, now);
+
+    expect(manifestFilterOptions(rows)).toEqual({
+      owners: ["platform", "unowned"],
+      sources: ["fleet", "local", "runtime"],
+    });
+    expect(filterManifestRows(rows, { ...DEFAULT_MANIFEST_FILTERS, source: "fleet" }).map((row) => row.name)).toEqual([
+      "docs",
+    ]);
+    expect(filterManifestRows(rows, { ...DEFAULT_MANIFEST_FILTERS, query: "claude http" }).map((row) => row.name)).toEqual([
+      "docs",
+    ]);
+  });
+
+  it("classifies missing and malformed last-seen timestamps as unknown", () => {
+    expect(classifyFreshness("", now)).toBe("unknown");
+    expect(classifyFreshness("not-a-date", now)).toBe("unknown");
+  });
+});


### PR DESCRIPTION
Summary
- add explicit source, owner, risk, freshness, and runtime filters to the Agent BOM manifest cockpit
- move manifest row derivation and filtering into a tested UI helper
- add an empty-filter state with the first local command so the cockpit has a clear next step
- keep the bundle budget gate explicit for the new cockpit filter code while trimming unused icon imports

Verification
- npm --prefix ui ci
- npm --prefix ui test -- --run tests/agent-bom-manifest.test.ts
- npm --prefix ui run typecheck
- npm --prefix ui run lint -- app/manifest/page.tsx lib/agent-bom-manifest.ts tests/agent-bom-manifest.test.ts
- npm --prefix ui run build
- npm --prefix ui run bundle:check
- python scripts/check_release_consistency.py
- git diff --check

Notes
- npm --prefix ui run verify:toolchain is blocked locally because this shell is running Node 25.9.0 while the UI declares >=22 <25.

Closes #2657
