### PR TITLE
docs(graph): align data model taxonomy

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -81,22 +81,24 @@ Used for unified findings outside the SCA / blast-radius path
 The unified graph projects the canonical model into a node/edge form
 used for blast-radius traversal, dashboards, and OCSF export.
 
-### Entity types (18)
+### Entity types (27)
 
-`AGENT`, `SERVER`, `PACKAGE`, `TOOL`, `MODEL`, `DATASET`, `CONTAINER`,
-`CLOUD_RESOURCE`, `VULNERABILITY`, `MISCONFIGURATION`, `CREDENTIAL`,
-`USER`, `GROUP`, `SERVICE_ACCOUNT`, `PROVIDER`, `ENVIRONMENT`, `FLEET`,
-`CLUSTER`.
+`AGENT`, `SERVER`, `PACKAGE`, `TOOL`, `TOOL_CALL`, `MODEL`, `DATASET`,
+`CONTAINER`, `CLOUD_RESOURCE`, `RESOURCE`, `VULNERABILITY`,
+`MISCONFIGURATION`, `CREDENTIAL`, `CREDENTIAL_REF`, `ORG`, `ACCOUNT`, `USER`,
+`GROUP`, `ROLE`, `POLICY`, `SERVICE_ACCOUNT`, `SERVICE_PRINCIPAL`,
+`FEDERATED_IDENTITY`, `PROVIDER`, `ENVIRONMENT`, `FLEET`, `CLUSTER`.
 
-### Relationship types (24)
+### Relationship types (34)
 
 | Group | Relationships | Direction |
 |---|---|---|
-| Composition | `HOSTS`, `USES`, `DEPENDS_ON`, `PROVIDES_TOOL`, `EXPOSES_CRED`, `SERVES_MODEL`, `CONTAINS` | source → target |
+| Composition | `HOSTS`, `USES`, `DEPENDS_ON`, `PROVIDES_TOOL`, `EXPOSES_CRED`, `REACHES_TOOL`, `SERVES_MODEL`, `CONTAINS` | source → target |
 | Risk | `AFFECTS`, `VULNERABLE_TO`, `EXPLOITABLE_VIA`, `REMEDIATES`, `TRIGGERS` | mostly bidirectional |
 | Lateral movement | `SHARES_SERVER`, `SHARES_CRED`, `LATERAL_PATH` | symmetric |
-| Ownership | `MANAGES`, `OWNS`, `PART_OF`, `MEMBER_OF` | hierarchical |
-| Runtime | `INVOKED`, `ACCESSED`, `DELEGATED_TO` | source → target, time-stamped |
+| Ownership and identity | `MANAGES`, `OWNS`, `PART_OF`, `MEMBER_OF`, `ASSUMES`, `TRUSTS`, `ATTACHED`, `INHERITS`, `CAN_ACCESS`, `CROSS_ACCOUNT_TRUST` | hierarchical / access path |
+| Runtime | `ACTED_AS`, `INVOKED`, `CALLED`, `USED_CREDENTIAL`, `ACCESSED`, `DELEGATED_TO` | source → target, time-stamped |
+| Cross-environment correlation | `CORRELATES_WITH`, `POSSIBLY_CORRELATES_WITH` | local ↔ cloud agent correlation |
 
 `EXPLOITABLE_VIA` is a capability-impact edge from a vulnerability to a
 tool when the affected package is connected to the MCP server that provides
@@ -120,6 +122,12 @@ server-scope mappings must not be presented as exact function-level proof.
 The mapping lives in `src/agent_bom/graph/builder.py`. If a new
 entity type is added to the enum, the builder must learn to emit it
 or the dashboard will silently miss it.
+
+`src/agent_bom/context_graph.py` still exposes `NodeKind` and `EdgeKind` for
+backward-compatible reachability scoring and the legacy `context_graph` MCP
+tool. Those enums are a strict subset of the canonical taxonomy above and are
+bridged through `src/agent_bom/graph/compat.py` before data reaches the richer
+API/UI graph. They must not be documented as the complete graph schema.
 
 ---
 

--- a/tests/test_stats_alignment.py
+++ b/tests/test_stats_alignment.py
@@ -92,6 +92,13 @@ def _count_test_files() -> int:
     return len(list((ROOT / "tests").glob("test_*.py")))
 
 
+def _graph_taxonomy_counts() -> tuple[int, int]:
+    """Count canonical graph entities and relationships from code."""
+    from agent_bom.graph import EntityType, RelationshipType
+
+    return len(EntityType), len(RelationshipType)
+
+
 # ---------------------------------------------------------------------------
 # Actual counts (computed once per test session)
 # ---------------------------------------------------------------------------
@@ -104,6 +111,7 @@ ACTUAL_DETECTORS = _count_detector_classes()
 ACTUAL_CLOUD_PROVIDERS = _count_cloud_providers()
 ACTUAL_MODULES = _count_python_modules()
 ACTUAL_TEST_FILES = _count_test_files()
+ACTUAL_GRAPH_ENTITY_TYPES, ACTUAL_GRAPH_RELATIONSHIP_TYPES = _graph_taxonomy_counts()
 
 
 # ---------------------------------------------------------------------------
@@ -222,6 +230,24 @@ class TestMarkdownStats:
         }
         missing = sorted(item for item in required if item not in text)
         assert not missing, f"DATA_MODEL.md missing schema contracts: {missing}"
+
+    def test_data_model_graph_taxonomy_counts_match_code(self):
+        text = (ROOT / "docs" / "DATA_MODEL.md").read_text()
+        entity_match = re.search(r"### Entity types \((\d+)\)", text)
+        relationship_match = re.search(r"### Relationship types \((\d+)\)", text)
+        assert entity_match, "DATA_MODEL.md missing graph entity type count"
+        assert relationship_match, "DATA_MODEL.md missing graph relationship type count"
+        assert int(entity_match.group(1)) == ACTUAL_GRAPH_ENTITY_TYPES
+        assert int(relationship_match.group(1)) == ACTUAL_GRAPH_RELATIONSHIP_TYPES
+
+    def test_data_model_graph_taxonomy_lists_every_code_value(self):
+        from agent_bom.graph import EntityType, RelationshipType
+
+        text = (ROOT / "docs" / "DATA_MODEL.md").read_text()
+        missing_entities = sorted(entity.name for entity in EntityType if f"`{entity.name}`" not in text)
+        missing_relationships = sorted(relationship.name for relationship in RelationshipType if f"`{relationship.name}`" not in text)
+        assert not missing_entities, f"DATA_MODEL.md missing graph entities: {missing_entities}"
+        assert not missing_relationships, f"DATA_MODEL.md missing graph relationships: {missing_relationships}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary

- update the graph taxonomy atlas to match the canonical 27 EntityType values and 34 RelationshipType values
- document context_graph NodeKind/EdgeKind as a legacy subset bridged through graph/compat.py, not the complete graph schema
- add stats-alignment coverage so DATA_MODEL.md graph counts and enum names stay in sync with code

Verification

- uv run pytest tests/test_stats_alignment.py -q
- uv run ruff check tests/test_stats_alignment.py
- python scripts/check_release_consistency.py
- git diff --check
- pre-commit hooks during commit

Notes

- Mermaid scale/readability behavior is intentionally left for a separate artifact-changing PR with CLI/API/MCP output tests.