### PR TITLE
fix(graph): bound mermaid export size

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -12921,7 +12921,7 @@
     },
     "/v1/scan/{job_id}/graph-export": {
       "get": {
-        "description": "Export the dependency graph in graph-native formats.\n\nQuery params:\n  ?format=json      JSON nodes/edges (default)\n  ?format=dot       Graphviz DOT\n  ?format=mermaid   Mermaid flowchart\n  ?format=graphml   GraphML with AIBOM attributes (yEd/Gephi/NetworkX)\n  ?format=cypher    Neo4j Cypher import script",
+        "description": "Export the dependency graph in graph-native formats.\n\nQuery params:\n  ?format=json      JSON nodes/edges (default)\n  ?format=dot       Graphviz DOT\n  ?format=mermaid   Mermaid flowchart\n  ?format=graphml   GraphML with AIBOM attributes (yEd/Gephi/NetworkX)\n  ?format=cypher    Neo4j Cypher import script\n  ?mermaid_limit=80 Maximum nodes rendered for Mermaid; 0 renders all",
         "operationId": "get_graph_export_v1_scan__job_id__graph_export_get",
         "parameters": [
           {
@@ -12941,6 +12941,20 @@
               "default": "json",
               "title": "Format",
               "type": "string"
+            }
+          },
+          {
+            "description": "Maximum nodes rendered for Mermaid output; 0 renders the full graph.",
+            "in": "query",
+            "name": "mermaid_limit",
+            "required": false,
+            "schema": {
+              "default": 80,
+              "description": "Maximum nodes rendered for Mermaid output; 0 renders the full graph.",
+              "maximum": 5000,
+              "minimum": 0,
+              "title": "Mermaid Limit",
+              "type": "integer"
             }
           }
         ],

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -8527,7 +8527,8 @@ paths:
         \ params:\n  ?format=json      JSON nodes/edges (default)\n  ?format=dot \
         \      Graphviz DOT\n  ?format=mermaid   Mermaid flowchart\n  ?format=graphml\
         \   GraphML with AIBOM attributes (yEd/Gephi/NetworkX)\n  ?format=cypher \
-        \   Neo4j Cypher import script"
+        \   Neo4j Cypher import script\n  ?mermaid_limit=80 Maximum nodes rendered\
+        \ for Mermaid; 0 renders all"
       operationId: get_graph_export_v1_scan__job_id__graph_export_get
       parameters:
       - in: path
@@ -8543,6 +8544,19 @@ paths:
           default: json
           title: Format
           type: string
+      - description: Maximum nodes rendered for Mermaid output; 0 renders the full
+          graph.
+        in: query
+        name: mermaid_limit
+        required: false
+        schema:
+          default: 80
+          description: Maximum nodes rendered for Mermaid output; 0 renders the full
+            graph.
+          maximum: 5000
+          minimum: 0
+          title: Mermaid Limit
+          type: integer
       responses:
         '200':
           content:

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -709,7 +709,19 @@ async def get_context_graph(request: Request, job_id: str, agent: str | None = N
 
 
 @router.get("/v1/scan/{job_id}/graph-export", tags=["scan"], response_model=None)
-async def get_graph_export(request: Request, job_id: str, format: str = "json") -> dict | str | PlainTextResponse:
+async def get_graph_export(
+    request: Request,
+    job_id: str,
+    format: str = "json",
+    mermaid_limit: Annotated[
+        int,
+        Query(
+            ge=0,
+            le=5000,
+            description="Maximum nodes rendered for Mermaid output; 0 renders the full graph.",
+        ),
+    ] = 80,
+) -> dict | str | PlainTextResponse:
     """Export the dependency graph in graph-native formats.
 
     Query params:
@@ -718,6 +730,7 @@ async def get_graph_export(request: Request, job_id: str, format: str = "json") 
       ?format=mermaid   Mermaid flowchart
       ?format=graphml   GraphML with AIBOM attributes (yEd/Gephi/NetworkX)
       ?format=cypher    Neo4j Cypher import script
+      ?mermaid_limit=80 Maximum nodes rendered for Mermaid; 0 renders all
     """
     from fastapi.responses import PlainTextResponse
 
@@ -739,9 +752,20 @@ async def get_graph_export(request: Request, job_id: str, format: str = "json") 
     result = job.result if isinstance(job.result, dict) else {}
     graph = build_graph_from_scan_data(result)
 
+    def _render_mermaid(g):
+        if mermaid_limit == 0:
+            return PlainTextResponse(
+                to_mermaid(g, max_nodes=None, max_edges=None),
+                media_type="text/plain",
+            )
+        return PlainTextResponse(
+            to_mermaid(g, max_nodes=mermaid_limit),
+            media_type="text/plain",
+        )
+
     _formats = {
         "dot": lambda g: PlainTextResponse(to_dot(g), media_type="text/vnd.graphviz"),
-        "mermaid": lambda g: PlainTextResponse(to_mermaid(g), media_type="text/plain"),
+        "mermaid": _render_mermaid,
         "graphml": lambda g: PlainTextResponse(to_graphml(g), media_type="application/xml"),
         "cypher": lambda g: PlainTextResponse(to_cypher(g), media_type="text/plain"),
     }

--- a/src/agent_bom/cli/_analysis.py
+++ b/src/agent_bom/cli/_analysis.py
@@ -233,7 +233,14 @@ def analytics_cmd(query_type, days, hours, agent, top_limit, clickhouse_url, ten
 )
 @click.option("--output", "-o", "output_path", default=None, help="Write to file instead of stdout.")
 @click.option("--quiet", "-q", is_flag=True, help="Suppress success messages when writing files.")
-def graph_cmd(scan_file: str, fmt: str, output_path: Optional[str], quiet: bool) -> None:
+@click.option(
+    "--mermaid-limit",
+    type=click.IntRange(min=0),
+    default=80,
+    show_default=True,
+    help="Maximum nodes rendered for Mermaid output; 0 renders the full graph.",
+)
+def graph_cmd(scan_file: str, fmt: str, output_path: Optional[str], quiet: bool, mermaid_limit: int) -> None:
     """Export the transitive dependency graph from a saved JSON scan report.
 
     \b
@@ -264,7 +271,10 @@ def graph_cmd(scan_file: str, fmt: str, output_path: Optional[str], quiet: bool)
     if fmt == "dot":
         output = to_dot(graph)
     elif fmt == "mermaid":
-        output = to_mermaid(graph)
+        if mermaid_limit == 0:
+            output = to_mermaid(graph, max_nodes=None, max_edges=None)
+        else:
+            output = to_mermaid(graph, max_nodes=mermaid_limit)
     elif fmt == "graphml":
         output = to_graphml(graph)
     elif fmt == "cypher":

--- a/src/agent_bom/mcp_server_operator_tools.py
+++ b/src/agent_bom/mcp_server_operator_tools.py
@@ -176,6 +176,14 @@ def register_operator_tools(
             str,
             Field(description="Export format: graphml, cypher, dot, mermaid, or json (default)."),
         ] = "json",
+        mermaid_limit: Annotated[
+            int,
+            Field(
+                ge=0,
+                le=5000,
+                description="Maximum nodes rendered for Mermaid output; 0 renders the full graph.",
+            ),
+        ] = 80,
     ) -> str:
         """Export the agent dependency graph in graph-native formats.
 
@@ -224,7 +232,9 @@ def register_operator_tools(
             if _fmt == "dot":
                 return truncate_response(_to_dot(graph))
             if _fmt == "mermaid":
-                return truncate_response(_to_mermaid(graph))
+                if mermaid_limit == 0:
+                    return truncate_response(_to_mermaid(graph, max_nodes=None, max_edges=None))
+                return truncate_response(_to_mermaid(graph, max_nodes=mermaid_limit))
             return truncate_response(json.dumps(_graph_to_json(graph), indent=2))
 
         return await execute_tool_async("graph_export", _impl)

--- a/src/agent_bom/output/graph_export.py
+++ b/src/agent_bom/output/graph_export.py
@@ -352,7 +352,16 @@ def to_dot(graph: DepGraph, title: str = "agent-bom dependency graph") -> str:
     return "\n".join(lines)
 
 
-def to_mermaid(graph: DepGraph) -> str:
+_MERMAID_DEFAULT_MAX_NODES = 80
+_MERMAID_DEFAULT_MAX_EDGES = 240
+
+
+def to_mermaid(
+    graph: DepGraph,
+    *,
+    max_nodes: int | None = _MERMAID_DEFAULT_MAX_NODES,
+    max_edges: int | None = _MERMAID_DEFAULT_MAX_EDGES,
+) -> str:
     """Render a :class:`DepGraph` as a Mermaid LR flowchart.
 
     Paste the output into a markdown fenced block (`` ```mermaid ``) to render
@@ -360,10 +369,18 @@ def to_mermaid(graph: DepGraph) -> str:
 
     Args:
         graph: Populated dependency graph.
+        max_nodes: Maximum rendered nodes before adding an elision marker.
+            ``None`` renders all nodes.
+        max_edges: Maximum rendered edges before adding an elision marker.
+            ``None`` renders all edges whose endpoints are visible.
 
     Returns:
         Mermaid flowchart string.
     """
+    if max_nodes is not None and max_nodes < 1:
+        raise ValueError("max_nodes must be at least 1 or None")
+    if max_edges is not None and max_edges < 1:
+        raise ValueError("max_edges must be at least 1 or None")
 
     id_map: dict[str, str] = {}
 
@@ -387,6 +404,16 @@ def to_mermaid(graph: DepGraph) -> str:
             "cve": "cve",
         }.get(kind, "pkg")
 
+    nodes = graph.nodes
+    visible_nodes = nodes if max_nodes is None else nodes[:max_nodes]
+    visible_node_ids = {node.id for node in visible_nodes}
+    visible_edges = [edge for edge in graph.edges if edge.source in visible_node_ids and edge.target in visible_node_ids]
+    if max_edges is not None:
+        visible_edges = visible_edges[:max_edges]
+
+    omitted_nodes = max(0, graph.node_count() - len(visible_nodes))
+    omitted_edges = max(0, graph.edge_count() - len(visible_edges))
+
     lines = [
         "flowchart LR",
         "    classDef provider fill:#4a9eff,color:#fff,stroke:#2563eb",
@@ -401,8 +428,17 @@ def to_mermaid(graph: DepGraph) -> str:
         "    classDef cve fill:#da3633,color:#fff,stroke:#991b1b",
         "",
     ]
+    if omitted_nodes or omitted_edges:
+        lines.insert(
+            1,
+            f"    %% Rendered {len(visible_nodes)} of {graph.node_count()} nodes and {len(visible_edges)} of {graph.edge_count()} edges.",
+        )
+        lines.insert(
+            -1,
+            "    classDef omitted fill:#111827,color:#fbbf24,stroke:#f59e0b,stroke-dasharray:4 2",
+        )
 
-    for node in graph.nodes:
+    for node in visible_nodes:
         nid = _safe_id(node.id)
         label = node.label.replace('"', "'")
         cls = _style_class(node.kind)
@@ -413,8 +449,12 @@ def to_mermaid(graph: DepGraph) -> str:
         else:
             lines.append(f'    {nid}("{label}"):::{cls}')
 
+    if omitted_nodes or omitted_edges:
+        omitted_label = f"{omitted_nodes} nodes / {omitted_edges} edges omitted; export JSON, DOT, GraphML, or Cypher for full graph"
+        lines.append(f'    omitted_summary["{omitted_label}"]:::omitted')
+
     lines.append("")
-    for edge in graph.edges:
+    for edge in visible_edges:
         src = _safe_id(edge.source)
         tgt = _safe_id(edge.target)
         lines.append(f"    {src} -->|{edge.kind}| {tgt}")

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import uuid
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from starlette.testclient import TestClient
@@ -764,6 +765,36 @@ def test_openapi_runtime_routes_do_not_404(monkeypatch):
     for method, path in checks:
         response = client.request(method, path)
         assert response.status_code != 404, (method, path, response.text)
+
+
+def test_graph_export_mermaid_limit_zero_renders_full_graph():
+    """The API graph export should pass the full-render sentinel to Mermaid output."""
+    client, store = _fresh_client()
+    job = ScanJob(
+        job_id="job-graph-mermaid",
+        status=JobStatus.DONE,
+        created_at="2026-05-20T00:00:00Z",
+        completed_at="2026-05-20T00:00:01Z",
+        request=ScanRequest(),
+        result={
+            "agents": [
+                {
+                    "name": "claude-desktop",
+                    "agent_type": "claude-desktop",
+                    "mcp_servers": [{"name": "filesystem", "packages": []}],
+                }
+            ],
+        },
+    )
+    store.put(job)
+
+    with patch("agent_bom.output.graph_export.to_mermaid", return_value="flowchart LR") as mermaid_mock:
+        response = client.get("/v1/scan/job-graph-mermaid/graph-export?format=mermaid&mermaid_limit=0")
+
+    assert response.status_code == 200
+    assert response.text == "flowchart LR"
+    mermaid_mock.assert_called_once()
+    assert mermaid_mock.call_args.kwargs == {"max_nodes": None, "max_edges": None}
 
 
 def test_baseline_compare_requires_job_ids_without_404():

--- a/tests/test_cli_analysis.py
+++ b/tests/test_cli_analysis.py
@@ -183,10 +183,26 @@ def test_graph_cmd_mermaid(tmp_path):
     mock_graph = MagicMock()
     with (
         patch("agent_bom.output.graph_export.load_graph_from_scan", return_value=mock_graph),
-        patch("agent_bom.output.graph_export.to_mermaid", return_value="graph TD"),
+        patch("agent_bom.output.graph_export.to_mermaid", return_value="graph TD") as mermaid_mock,
     ):
         result = runner.invoke(graph_cmd, [str(scan_file), "-f", "mermaid"])
         assert result.exit_code == 0
+        mermaid_mock.assert_called_once_with(mock_graph, max_nodes=80)
+
+
+def test_graph_cmd_mermaid_limit_zero_renders_full_graph(tmp_path):
+    runner = CliRunner()
+    scan_file = tmp_path / "scan.json"
+    scan_file.write_text("{}")
+
+    mock_graph = MagicMock()
+    with (
+        patch("agent_bom.output.graph_export.load_graph_from_scan", return_value=mock_graph),
+        patch("agent_bom.output.graph_export.to_mermaid", return_value="graph TD") as mermaid_mock,
+    ):
+        result = runner.invoke(graph_cmd, [str(scan_file), "-f", "mermaid", "--mermaid-limit", "0"])
+        assert result.exit_code == 0
+        mermaid_mock.assert_called_once_with(mock_graph, max_nodes=None, max_edges=None)
 
 
 def test_graph_cmd_load_error(tmp_path):

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -380,6 +380,36 @@ def test_to_mermaid_empty_graph():
     assert "-->" not in mmd
 
 
+def test_to_mermaid_elides_large_graph_by_default():
+    g = DepGraph()
+    for index in range(90):
+        g.add_node(f"pkg:{index}", f"pkg-{index}", "pkg")
+        if index:
+            g.add_edge(f"pkg:{index - 1}", f"pkg:{index}", "depends_on")
+
+    mmd = to_mermaid(g)
+
+    assert "Rendered 80 of 90 nodes" in mmd
+    assert "10 nodes / 10 edges omitted" in mmd
+    assert "pkg-0" in mmd
+    assert "pkg-89" not in mmd
+    assert "export JSON, DOT, GraphML, or Cypher for full graph" in mmd
+
+
+def test_to_mermaid_can_render_full_graph_when_requested():
+    g = DepGraph()
+    for index in range(3):
+        g.add_node(f"pkg:{index}", f"pkg-{index}", "pkg")
+        if index:
+            g.add_edge(f"pkg:{index - 1}", f"pkg:{index}", "depends_on")
+
+    mmd = to_mermaid(g, max_nodes=None, max_edges=None)
+
+    assert "Rendered" not in mmd
+    assert "omitted" not in mmd
+    assert "pkg-2" in mmd
+
+
 # ── to_json ──────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -967,6 +967,38 @@ def test_graph_export_uses_scan_pipeline_tuple_contract(mock_pipeline):
 
 
 @patch("agent_bom.mcp_server._run_scan_pipeline")
+def test_graph_export_mermaid_limit_zero_renders_full_graph(mock_pipeline):
+    """graph_export should pass the full-render sentinel through for Mermaid output."""
+    from agent_bom.mcp_server import create_mcp_server
+    from agent_bom.models import Agent, AgentType, MCPServer, Package, TransportType
+
+    pkg = Package(name="requests", version="2.0.0", ecosystem="pypi", vulnerabilities=[])
+    server_obj = MCPServer(
+        name="filesystem",
+        command="npx",
+        args=[],
+        env={},
+        transport=TransportType.STDIO,
+        packages=[pkg],
+    )
+    agent = Agent(
+        name="claude",
+        agent_type=AgentType.CLAUDE_DESKTOP,
+        config_path="/tmp/test",
+        mcp_servers=[server_obj],
+    )
+    mock_pipeline.return_value = ([agent], [], [], ["agent_discovery"])
+
+    server = create_mcp_server()
+    with patch("agent_bom.output.graph_export.to_mermaid", return_value="graph LR") as mermaid_mock:
+        content_blocks, _meta = _run(server.call_tool("graph_export", {"format": "mermaid", "mermaid_limit": 0}))
+
+    assert content_blocks[0].text == "graph LR"
+    mermaid_mock.assert_called_once()
+    assert mermaid_mock.call_args.kwargs == {"max_nodes": None, "max_edges": None}
+
+
+@patch("agent_bom.mcp_server._run_scan_pipeline")
 def test_graph_export_passes_through_pipeline_error_payload(mock_pipeline):
     """graph_export should return a pipeline error payload instead of crashing on string results."""
     from agent_bom.mcp_server import create_mcp_server


### PR DESCRIPTION
Summary

- cap Mermaid graph exports by default and add an explicit omitted-node summary so large agent/fleet graphs stay readable
- add --mermaid-limit for CLI graph export plus matching API and MCP parameters; 0 renders the full graph
- refresh OpenAPI artifacts and add CLI/API/MCP/core regression coverage

Verification

- uv run pytest tests/test_graph_export.py tests/test_cli_analysis.py tests/test_api_endpoints.py::test_graph_export_mermaid_limit_zero_renders_full_graph tests/test_mcp_server.py::test_graph_export_mermaid_limit_zero_renders_full_graph -q
- uv run ruff check src/agent_bom/output/graph_export.py src/agent_bom/cli/_analysis.py src/agent_bom/api/routes/scan.py src/agent_bom/mcp_server_operator_tools.py tests/test_graph_export.py tests/test_cli_analysis.py tests/test_api_endpoints.py tests/test_mcp_server.py
- uv run --extra api python scripts/export_openapi.py --check
- PYTHONPATH=src uv run --extra api pytest tests/test_openapi_artifact.py -q
- python scripts/check_release_consistency.py
- git diff --check

Notes

- Addresses the graph-demo readability gap where multi-agent Mermaid exports collapse at fleet scale.