### PR TITLE
fix(ci): gate PR self-scan on SARIF findings

### DIFF
--- a/.github/workflows/pr-security-gate.yml
+++ b/.github/workflows/pr-security-gate.yml
@@ -169,8 +169,11 @@ jobs:
             exit 2
           fi
 
+          export SCAN_EXIT
           python3 - <<'PY'
           import json
+          import os
+          import sys
           from pathlib import Path
 
           data = json.loads(Path("self-scan.sarif").read_text(encoding="utf-8"))
@@ -191,9 +194,12 @@ jobs:
           print(f"agent-bom self-scan SARIF findings: total={len(results)} high_or_critical={len(high_or_critical)} kev={kev}")
           if kev:
               print(f"::warning::agent-bom self-scan found {kev} KEV-listed finding(s)")
+          if high_or_critical:
+              print(f"::error::agent-bom self-scan found high/critical SARIF finding(s): {', '.join(high_or_critical[:10])}")
+              sys.exit(1)
+          if os.environ.get("SCAN_EXIT") not in {"0", None}:
+              print("::warning::agent-bom self-scan returned non-zero but SARIF contains no blocking findings")
           PY
-
-          exit "$SCAN_EXIT"
 
       - name: Upload SARIF to code-scanning
         if: always() && hashFiles('self-scan.sarif') != ''

--- a/tests/test_pr_gate_sarif_action_contract.py
+++ b/tests/test_pr_gate_sarif_action_contract.py
@@ -27,6 +27,18 @@ def test_pr_security_gate_uses_real_self_scan_sarif_not_fixture() -> None:
     assert yaml.safe_load(workflow)["jobs"]["self-scan-pr"]
 
 
+def test_pr_security_gate_uses_sarif_findings_for_self_scan_exit() -> None:
+    workflow = (ROOT / ".github/workflows/pr-security-gate.yml").read_text(encoding="utf-8")
+    job = yaml.safe_load(workflow)["jobs"]["self-scan-pr"]
+    step = next(step for step in job["steps"] if step.get("id") == "self_scan")
+    script = step["run"]
+
+    assert "high_or_critical" in script
+    assert "sys.exit(1)" in script
+    assert 'exit "$SCAN_EXIT"' not in script
+    assert "self-scan returned non-zero but SARIF contains no blocking findings" in script
+
+
 def test_action_rejects_secrets_and_code_sarif_or_gate_contracts() -> None:
     action_text = (ROOT / "action.yml").read_text(encoding="utf-8")
     action = yaml.safe_load(action_text)


### PR DESCRIPTION
Summary

- make the PR self-scan gate fail on high/critical SARIF findings instead of the raw scanner exit code
- keep missing SARIF as a hard failure and emit a warning when a clean SARIF came from a nonzero scan process
- add a workflow contract test so clean SARIF remains the gate source of truth

Verification

- uv run pytest tests/test_pr_gate_sarif_action_contract.py -q
- uv run ruff check tests/test_pr_gate_sarif_action_contract.py
- python scripts/check_release_consistency.py
- git diff --check

Notes

- Unblocks dependency-only PRs where self-scan writes a clean SARIF but exits nonzero for a non-blocking scanner condition.