### PR TITLE
fix(cli): infer json output files

### DIFF
--- a/src/agent_bom/cli/agents/_output.py
+++ b/src/agent_bom/cli/agents/_output.py
@@ -366,6 +366,8 @@ def render_output(
     elif output:
         if output.endswith(".cdx.json"):
             export_cyclonedx(report, output)
+        elif output.endswith(".json"):
+            export_json(report, output)
         elif output.endswith(".sarif"):
             export_sarif(report, output, exclude_unfixable=exclude_unfixable)
         elif output.endswith(".spdx.json"):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1312,6 +1312,29 @@ def test_cli_image_rejects_reference_and_tarball_together(monkeypatch):
     assert "Provide exactly one image reference or --tar/--image-tar path" in result.output
 
 
+def test_cli_image_output_json_extension_writes_report(monkeypatch, tmp_path):
+    from agent_bom.models import Package
+
+    output = tmp_path / "image-report.json"
+
+    monkeypatch.setattr(
+        "agent_bom.image.scan_image",
+        lambda image_ref, registry_user=None, registry_pass=None, platform=None: (
+            [Package(name="openssl", version="3.0.16", ecosystem="deb")],
+            "native",
+        ),
+    )
+    monkeypatch.setattr("agent_bom.cli.agents.scan_agents_sync", lambda *args, **kwargs: [])
+
+    result = CliRunner().invoke(main, ["image", "nginx:1.20.0", "-o", str(output), "--quiet"])
+
+    assert result.exit_code == 0, result.output
+    assert output.exists()
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert data["scan_sources"] == ["image"]
+    assert any(package["name"] == "openssl" for package in data["packages"])
+
+
 def test_cli_scan_has_k8s_flags():
     runner = CliRunner()
     result = runner.invoke(main, ["scan", "--help"])


### PR DESCRIPTION
Summary
- infer plain .json output paths in the shared scan renderer when --output is provided without --format
- add a focused image-command regression so agent-bom image -o image-report.json writes the scan artifact

Verification
- uv run pytest tests/test_core.py::test_cli_image_output_json_extension_writes_report -q
- uv run ruff check src/agent_bom/cli/agents/_output.py tests/test_core.py
- uv run mypy src/agent_bom/cli/agents/_output.py
- python scripts/check_release_consistency.py
- git diff --check

Notes
- Closes the graph-demo audit data-loss path where image scans could complete without writing the requested JSON artifact unless users also supplied --format json.