### PR TITLE
fix(cli): relax graph export outputs

### DIFF
--- a/src/agent_bom/cli/_analysis.py
+++ b/src/agent_bom/cli/_analysis.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sys
 from collections import Counter
+from io import StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
@@ -87,6 +88,14 @@ def _render_mesh_summary(con: Console, agents_data: list[dict], mesh: dict, *, s
             )
     if not quiet:
         con.print()
+
+
+def _mesh_summary_text(agents_data: list[dict], mesh: dict, *, scope_label: str, quiet: bool = False) -> str:
+    """Render the human mesh summary to plain text for file output."""
+    buffer = StringIO()
+    con = Console(file=buffer, force_terminal=False, color_system=None, width=120)
+    _render_mesh_summary(con, agents_data, mesh, scope_label=scope_label, quiet=quiet)
+    return buffer.getvalue()
 
 
 @click.command("analytics")
@@ -349,8 +358,10 @@ def mesh_cmd(scan_file: Optional[str], project_dir: Optional[str], fmt: str, out
         return
 
     if output_path:
-        con.print("[red]--output is only supported with --format json for mesh.[/red]")
-        raise SystemExit(2)
+        Path(output_path).write_text(_mesh_summary_text(agents_data, mesh, scope_label=scope_label, quiet=quiet))
+        if not quiet:
+            con.print(f"[green]Mesh summary exported[/green] → {output_path}")
+        return
 
     _render_mesh_summary(con, agents_data, mesh, scope_label=scope_label, quiet=quiet)
 

--- a/src/agent_bom/cli/agents/_output.py
+++ b/src/agent_bom/cli/agents/_output.py
@@ -64,7 +64,7 @@ _FORMAT_OUTPUT_RULES: dict[str, tuple[str, tuple[str, ...]]] = {
     "pdf": ("agent-bom-report.pdf", (".pdf",)),
     "prometheus": ("agent-bom-metrics.prom", (".prom", ".txt")),
     "graph": ("agent-bom-graph.json", (".json",)),
-    "mermaid": ("agent-bom-diagram.mmd", (".mmd", ".md")),
+    "mermaid": ("agent-bom-diagram.mmd", (".mmd", ".mermaid", ".md")),
     "svg": ("agent-bom-supply-chain.svg", (".svg",)),
     "graph-html": ("agent-bom-graph.html", (".html", ".htm")),
     "badge": ("agent-bom-badge.json", (".json",)),

--- a/tests/test_cli_analysis.py
+++ b/tests/test_cli_analysis.py
@@ -287,12 +287,37 @@ def test_mesh_cmd_live_summary():
         assert "filesystem" in result.output
 
 
-def test_mesh_cmd_summary_rejects_output_path(tmp_path):
+def test_mesh_cmd_summary_writes_output_path(tmp_path):
     runner = CliRunner()
     scan_file = tmp_path / "scan.json"
-    scan_file.write_text(json.dumps({"agents": [{"name": "a", "mcp_servers": []}], "blast_radius": []}))
-    result = runner.invoke(mesh_cmd, [str(scan_file), "--output", str(tmp_path / "mesh.txt")])
-    assert result.exit_code == 2
+    scan_file.write_text(
+        json.dumps(
+            {
+                "agents": [
+                    {
+                        "name": "a",
+                        "mcp_servers": [
+                            {
+                                "name": "filesystem",
+                                "packages": [],
+                                "tools": [{"name": "read_file"}],
+                                "env": {},
+                            }
+                        ],
+                    }
+                ],
+                "blast_radius": [],
+            }
+        )
+    )
+    out = tmp_path / "mesh.txt"
+    result = runner.invoke(mesh_cmd, [str(scan_file), "--output", str(out)])
+    assert result.exit_code == 0
+    assert out.exists()
+    text = out.read_text()
+    assert "Mesh" in text
+    assert "saved scan" in text
+    assert "filesystem" in text
 
 
 def test_mesh_cmd_json_error_is_wrapped(tmp_path):

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -1362,6 +1362,18 @@ def test_scan_format_mermaid_writes_file(tmp_path):
     assert out.exists(), "mermaid output file was not created"
 
 
+def test_scan_format_mermaid_accepts_mermaid_extension(tmp_path):
+    """--format mermaid accepts the explicit .mermaid extension."""
+    out = tmp_path / "diagram.mermaid"
+    with (
+        patch("agent_bom.cli.agents.scan_agents_sync", return_value=([], [])),
+        patch("agent_bom.cli.agents.resolve_all_versions_sync", return_value=[]),
+    ):
+        result = _run(["scan", "--demo", "--format", "mermaid", "--output", str(out), "--no-scan"])
+    assert result.exit_code == 0
+    assert out.exists(), "mermaid output file was not created"
+
+
 def test_scan_format_graph_html_writes_file(tmp_path):
     """--format graph-html writes an interactive HTML file."""
     out = tmp_path / "graph.html"


### PR DESCRIPTION
Summary
- allow Mermaid scan output to use the explicit .mermaid extension as well as .mmd/.md
- allow agent-bom mesh --output to write the human-readable summary instead of requiring JSON
- add regressions for both export paths

Verification
- uv run pytest tests/test_cli_analysis.py::test_mesh_cmd_summary_writes_output_path tests/test_cli_scan.py::test_scan_format_mermaid_accepts_mermaid_extension -q
- uv run ruff check src/agent_bom/cli/_analysis.py src/agent_bom/cli/agents/_output.py tests/test_cli_analysis.py tests/test_cli_scan.py
- uv run mypy src/agent_bom/cli/_analysis.py src/agent_bom/cli/agents/_output.py
- python scripts/check_release_consistency.py
- git diff --check