### PR TITLE
fix(discovery): accept project config files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -680,13 +680,13 @@ jobs:
       - name: Install build deps (Alpine)
         run: |
           for attempt in 1 2 3; do
-            if apk add --no-cache bash gcc g++ musl-dev libffi-dev openssl-dev git curl; then
+            if apk add --no-cache bash gcc g++ musl-dev libffi-dev openssl-dev git curl tar; then
               exit 0
             fi
             echo "apk add failed on attempt ${attempt}; retrying after transient package-index/network failure..."
             sleep $((attempt * 5))
           done
-          apk add --no-cache bash gcc g++ musl-dev libffi-dev openssl-dev git curl
+          apk add --no-cache bash gcc g++ musl-dev libffi-dev openssl-dev git curl tar
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/src/agent_bom/discovery/__init__.py
+++ b/src/agent_bom/discovery/__init__.py
@@ -311,6 +311,33 @@ def expand_path(path_str: str) -> Path:
     return Path(os.path.expanduser(path_str)).resolve()
 
 
+def _project_scope_path(project_dir: Optional[str]) -> Path:
+    """Return the configured project scope path, preserving file inputs."""
+    return Path(project_dir).expanduser().resolve() if project_dir else Path.cwd()
+
+
+def _project_search_dir(project_dir: Optional[str]) -> Path:
+    """Return the directory used for project-adjacent discovery."""
+    path = _project_scope_path(project_dir)
+    return path.parent if path.is_file() else path
+
+
+def _project_config_candidates(project_dir: Optional[str]) -> list[Path]:
+    """Return explicit project config files to parse."""
+    path = _project_scope_path(project_dir)
+    if path.is_file():
+        return [path]
+    return [path / config_name for config_name in PROJECT_CONFIG_FILES]
+
+
+def _parse_project_config_file(config_path: Path) -> list[MCPServer]:
+    """Parse one project-level MCP config file."""
+    if config_path.suffix == ".toml":
+        return parse_codex_config(str(config_path))
+    config_data = _read_json_config_no_symlink(config_path)
+    return parse_mcp_config(config_data, str(config_path))
+
+
 def get_all_discovery_paths(plat: Optional[str] = None) -> list[tuple[str, str]]:
     """Return all config paths that would be checked during discovery.
 
@@ -481,20 +508,12 @@ def discover_global_configs(agent_types: Optional[list[AgentType]] = None, *, qu
 def discover_project_configs(project_dir: Optional[str] = None) -> list[Agent]:
     """Discover project-level MCP configurations."""
     agents = []
-    search_dir = Path(project_dir) if project_dir else Path.cwd()
+    search_dir = _project_search_dir(project_dir)
 
-    for config_name in PROJECT_CONFIG_FILES:
-        config_path = search_dir / config_name
+    for config_path in _project_config_candidates(project_dir):
         if config_path.exists():
             try:
-                servers: list[MCPServer] = []
-
-                if config_name.endswith(".toml"):
-                    # Codex project config
-                    servers = parse_codex_config(str(config_path))
-                else:
-                    config_data = _read_json_config_no_symlink(config_path)
-                    servers = parse_mcp_config(config_data, str(config_path))
+                servers = _parse_project_config_file(config_path)
 
                 if servers:
                     agent = Agent(
@@ -1211,6 +1230,7 @@ def discover_all(
         k8s_context: kubectl context to use (uses current context if None).
     """
     console.print("\n[bold blue]🔍 Discovering MCP configurations...[/bold blue]\n")
+    project_search_dir = str(_project_search_dir(project_dir)) if project_dir else None
 
     if project_dir:
         agents = discover_project_configs(project_dir)
@@ -1219,7 +1239,7 @@ def discover_all(
         agents.extend(discover_project_configs())
 
     # Docker Compose MCP server discovery
-    compose_agent = discover_compose_mcp_servers(project_dir)
+    compose_agent = discover_compose_mcp_servers(project_search_dir)
     if compose_agent:
         console.print(
             f"  [green]✓[/green] Found {len(compose_agent.mcp_servers)} MCP server(s) "
@@ -1294,7 +1314,7 @@ def discover_all(
         console.print("\n  [bold cyan]🔎 Running dynamic discovery...[/bold cyan]")
         known_paths = {a.config_path for a in agents if a.config_path}
         dyn_result = discover_dynamic(
-            root=_DynPath(project_dir) if project_dir else _DynPath.cwd(),
+            root=_DynPath(project_search_dir) if project_search_dir else _DynPath.cwd(),
             max_depth=dynamic_max_depth,
             exclude_paths=known_paths,
         )

--- a/tests/test_project_mode.py
+++ b/tests/test_project_mode.py
@@ -430,6 +430,33 @@ def test_discover_all_project_dir_scopes_to_project_only(tmp_path):
     assert [a.name for a in agents] == ["project-only"]
 
 
+def test_discover_all_accepts_project_config_file_scope(tmp_path):
+    """Project-scoped discovery accepts a direct MCP config file path."""
+    from agent_bom.discovery import discover_all
+
+    config_dir = tmp_path / ".cursor"
+    config_dir.mkdir()
+    config_file = config_dir / "mcp.json"
+    config_file.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "filesystem": {
+                        "command": "npx",
+                        "args": ["@modelcontextprotocol/server-filesystem", str(tmp_path)],
+                    }
+                }
+            }
+        )
+    )
+
+    agents = discover_all(project_dir=str(config_file))
+
+    assert len(agents) == 1
+    assert agents[0].config_path == str(config_file)
+    assert [server.name for server in agents[0].mcp_servers] == ["filesystem"]
+
+
 def test_sbom_name_overrides_metadata(tmp_path):
     """--sbom-name takes precedence over auto-detected name."""
     from unittest.mock import AsyncMock, patch


### PR DESCRIPTION
Summary
- accept direct project MCP config file paths wherever project-scoped discovery is used
- keep Docker Compose and dynamic discovery scoped to the config file parent directory instead of treating the file as a directory
- add a regression for direct .cursor/mcp.json discovery

Verification
- uv run pytest tests/test_project_mode.py::test_discover_all_accepts_project_config_file_scope -q
- uv run ruff check src/agent_bom/discovery/__init__.py tests/test_project_mode.py
- uv run mypy src/agent_bom/discovery/__init__.py
- python scripts/check_release_consistency.py
- git diff --check