### PR TITLE
test(inventory): lock agent type schema parity

### DIFF
--- a/tests/test_inventory_ingestion.py
+++ b/tests/test_inventory_ingestion.py
@@ -3,14 +3,23 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
 from agent_bom.inventory import InventoryValidationError, load_inventory
+from agent_bom.models import AgentType
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
-def _agent(name: str = "agent-a") -> dict[str, object]:
-    return {"name": name, "agent_type": "custom", "mcp_servers": []}
+def _agent(name: str = "agent-a", *, agent_type: str = "custom") -> dict[str, object]:
+    return {"name": name, "agent_type": agent_type, "mcp_servers": []}
+
+
+def _schema_agent_type_enum(schema_path: Path) -> list[str]:
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    return schema["$defs"]["Agent"]["properties"]["agent_type"]["enum"]
 
 
 def test_json_inventory_schema_version_v1_dispatch(tmp_path):
@@ -44,13 +53,40 @@ def test_json_inventory_validation_suggests_close_root_field(tmp_path):
 
 
 def test_inventory_schema_agent_type_enum_matches_model() -> None:
-    from agent_bom.inventory import _inventory_schema_path
-    from agent_bom.models import AgentType
+    expected = [agent_type.value for agent_type in AgentType]
 
-    schema = json.loads(_inventory_schema_path().read_text(encoding="utf-8"))  # type: ignore[union-attr]
-    enum_values = schema["$defs"]["Agent"]["properties"]["agent_type"]["enum"]
+    assert _schema_agent_type_enum(ROOT / "config/schemas/inventory.schema.json") == expected
+    assert _schema_agent_type_enum(ROOT / "src/agent_bom/data/inventory.schema.json") == expected
 
-    assert enum_values == [agent_type.value for agent_type in AgentType]
+
+@pytest.mark.parametrize("agent_type", [agent_type.value for agent_type in AgentType])
+def test_json_inventory_accepts_all_agent_type_values(tmp_path, agent_type: str) -> None:
+    inventory_path = tmp_path / "inventory.json"
+    inventory_path.write_text(
+        json.dumps({"schema_version": "1", "agents": [_agent(agent_type=agent_type)]}),
+        encoding="utf-8",
+    )
+
+    loaded = load_inventory(str(inventory_path))
+
+    assert loaded["agents"][0]["agent_type"] == agent_type
+
+
+def test_json_inventory_validation_suggests_close_agent_type_value(tmp_path) -> None:
+    inventory_path = tmp_path / "inventory.json"
+    inventory_path.write_text(
+        json.dumps({"schema_version": "1", "agents": [_agent(agent_type="codex-clii")]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(InventoryValidationError, match="Did you mean 'codex-cli'"):
+        load_inventory(str(inventory_path))
+
+
+def test_pushed_inventory_unknown_agent_type_falls_back_to_custom() -> None:
+    from agent_bom.cli._common import _coerce_agent_type_for_inventory
+
+    assert _coerce_agent_type_for_inventory("internal-lab-agent", agent_name="lab") is AgentType.CUSTOM
 
 
 def test_ndjson_inventory_validates_agent_chunks(tmp_path):


### PR DESCRIPTION
Summary
- assert both inventory schema copies track the canonical AgentType model
- verify JSON inventory accepts every model-backed agent_type value
- cover close enum suggestions and pushed-inventory fallback to custom

Verification
- uv run pytest tests/test_inventory_ingestion.py -q
- uv run ruff check tests/test_inventory_ingestion.py
- python scripts/check_release_consistency.py
- git diff --check

Notes
- Lock-in coverage for the graph-demo audit agent profile schema gap after the runtime polish merge.