### PR TITLE
fix(ci): dispatch security gate for stranded PRs

### DIFF
--- a/docs/operations/CI_RUNBOOK.md
+++ b/docs/operations/CI_RUNBOOK.md
@@ -46,7 +46,8 @@ lower-privilege fallback:
 scripts/dispatch_required_ci.sh <PR_NUMBER>
 ```
 
-That fallback dispatches `ci.yml` and, when needed, `codeql.yml` through
+That fallback dispatches the required PR workflows (`ci.yml`,
+`pr-security-gate.yml`, and, when needed, `codeql.yml`) through
 `workflow_dispatch` for same-repo PR heads that already contain current `main`.
 It cannot update stale branches, but it prevents the common "all visible checks
 passed, required contexts are still expected" state from wasting a merge cycle.

--- a/scripts/dispatch_required_ci.sh
+++ b/scripts/dispatch_required_ci.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Dispatch required workflows for a PR whose current head is missing required
-# status contexts, without closing/reopening the PR.
+# status contexts, without empty commits or close/reopen churn.
 #
 # This is the safe fallback for repositories where AUTOMATION_GITHUB_TOKEN is
 # not configured. It can only help when the PR branch already contains current
@@ -119,6 +119,7 @@ reason="$(IFS='; '; echo "${reason_parts[*]}")"
 
 echo "PR #${PR}: dispatching required workflows for head ${head_sha} (${reason})."
 gh workflow run ci.yml --repo "${REPO}" --ref "${head_ref}"
+gh workflow run pr-security-gate.yml --repo "${REPO}" --ref "${head_ref}"
 
 codeql_needed=false
 if [ "${#missing[@]}" -gt 0 ] && printf '%s\n' "${missing[@]}" | grep -qx "CodeQL"; then

--- a/tests/test_ci_retrigger_scripts.py
+++ b/tests/test_ci_retrigger_scripts.py
@@ -1,0 +1,23 @@
+"""Regression tests for PR check recovery scripts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_dispatch_required_ci_runs_all_required_workflows() -> None:
+    script = (ROOT / "scripts" / "dispatch_required_ci.sh").read_text(encoding="utf-8")
+
+    assert 'gh workflow run ci.yml --repo "${REPO}" --ref "${head_ref}"' in script
+    assert 'gh workflow run pr-security-gate.yml --repo "${REPO}" --ref "${head_ref}"' in script
+    assert 'gh workflow run codeql.yml --repo "${REPO}" --ref "${head_ref}"' in script
+
+
+def test_ci_runbook_documents_fallback_workflows() -> None:
+    runbook = (ROOT / "docs" / "operations" / "CI_RUNBOOK.md").read_text(encoding="utf-8")
+
+    assert "`ci.yml`" in runbook
+    assert "`pr-security-gate.yml`" in runbook
+    assert "`codeql.yml`" in runbook


### PR DESCRIPTION
Summary
- dispatch pr-security-gate.yml from the stranded-check fallback path alongside ci.yml and CodeQL
- document the full required-workflow fallback so operators do not need empty retrigger commits
- add a regression test locking the required workflow dispatch list

Verification
- uv run pytest tests/test_ci_retrigger_scripts.py -q
- uv run ruff check tests/test_ci_retrigger_scripts.py
- bash -n scripts/dispatch_required_ci.sh scripts/retrigger_stranded_pr.sh scripts/refresh_ready_prs.sh
- python scripts/check_release_consistency.py
- git diff --check

Notes
- Closes #2651.