### PR TITLE
fix(sdk): align runtime detector count

### DIFF
--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * @agent-bom/runtime — Runtime security detectors for MCP traffic.
  *
- * 8 detectors that analyze MCP JSON-RPC traffic in real-time:
+ * 7 detectors that analyze MCP JSON-RPC traffic in real-time:
  * - ToolDriftDetector — rug pull detection (new tools after baseline)
  * - ArgumentAnalyzer — shell injection, path traversal, credential values
  * - CredentialLeakDetector — API keys/tokens in tool responses

--- a/tests/test_typescript_runtime_sdk.py
+++ b/tests/test_typescript_runtime_sdk.py
@@ -1,0 +1,20 @@
+"""Static contract checks for the TypeScript runtime SDK."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_INDEX = ROOT / "sdks" / "typescript" / "src" / "index.ts"
+
+
+def test_runtime_sdk_detector_count_matches_exports() -> None:
+    body = RUNTIME_INDEX.read_text(encoding="utf-8")
+
+    header_count_match = re.search(r"\*\s+(\d+) detectors that analyze MCP JSON-RPC traffic", body)
+    assert header_count_match is not None
+
+    detector_exports = re.findall(r"^export \{ (?:[A-Z][A-Za-z]+(?:Detector|Analyzer|Tracker|Inspector)) \}", body, re.MULTILINE)
+
+    assert int(header_count_match.group(1)) == len(detector_exports)


### PR DESCRIPTION
Summary

- align the @agent-bom/runtime source header with the seven exported detector classes
- add a static regression so detector-count copy stays tied to runtime exports
- keep the Shield SDK detector wording out of scope because it describes the Python protection engine

Verification

- npm --prefix sdks/typescript run build
- npm --prefix sdks/typescript test
- uv run pytest tests/test_typescript_runtime_sdk.py -q
- uv run ruff check tests/test_typescript_runtime_sdk.py
- python scripts/check_release_consistency.py
- git diff --check

Notes

- Closes the TypeScript runtime detector-count audit carryover.