### PR TITLE
docs(runtime): align proxy detector docs

### DIFF
--- a/site-docs/features/runtime-proxy.md
+++ b/site-docs/features/runtime-proxy.md
@@ -21,15 +21,17 @@ agent-bom proxy  ←── policy.json
 MCP Server (filesystem, postgres, etc.)
 ```
 
-## Five detectors
+## 7 inline proxy detectors
 
 | Detector | What it catches |
 |----------|----------------|
-| **Tool Drift** | Tools invoked at runtime not declared in `tools/list` (rug pull detection) |
-| **Argument Analyzer** | Shell injection, path traversal, credential values in arguments |
-| **Credential Leak** | API keys/tokens in tool call arguments or responses |
-| **Rate Limiter** | Excessive calls per tool within a time window |
-| **Sequence Analyzer** | Multi-step attack patterns (bulk exfiltration, recon + lateral movement) |
+| **ToolDriftDetector** | New, removed, or changed tools after the initial `tools/list` baseline |
+| **ArgumentAnalyzer** | Shell injection, path traversal, SSRF targets, prompt injection, and credential values in arguments |
+| **CredentialLeakDetector** | API keys, tokens, passwords, and PII in tool call arguments or responses |
+| **RateLimitTracker** | Excessive calls per tool within a sliding time window |
+| **SequenceAnalyzer** | Multi-step attack patterns such as bulk exfiltration and recon followed by lateral movement |
+| **ResponseInspector** | Cloaking, SVG payloads, invisible characters, and response-side prompt injection |
+| **VectorDBInjectionDetector** | Prompt injection from retrieved RAG or vector database chunks |
 
 ## Usage
 

--- a/tests/test_runtime_proxy_docs.py
+++ b/tests/test_runtime_proxy_docs.py
@@ -1,0 +1,27 @@
+"""Runtime proxy public-doc contract checks."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PROXY = ROOT / "src" / "agent_bom" / "proxy.py"
+RUNTIME_PROXY_DOC = ROOT / "site-docs" / "features" / "runtime-proxy.md"
+
+
+def _inline_proxy_detector_names() -> list[str]:
+    body = PROXY.read_text(encoding="utf-8")
+    match = re.search(r"# Runtime detectors\s+from agent_bom\.runtime\.detectors import \((.*?)\)", body, re.DOTALL)
+    assert match is not None
+    return sorted(name.strip().rstrip(",") for name in match.group(1).splitlines() if name.strip() and not name.strip().startswith("#"))
+
+
+def test_runtime_proxy_docs_list_inline_detector_set() -> None:
+    doc = RUNTIME_PROXY_DOC.read_text(encoding="utf-8")
+    detectors = _inline_proxy_detector_names()
+
+    assert f"## {len(detectors)} inline proxy detectors" in doc
+    for detector in detectors:
+        assert f"**{detector}**" in doc
+    assert "## Five detectors" not in doc


### PR DESCRIPTION
Summary

- update the runtime proxy docs site page from five stale detectors to the current seven inline proxy detectors
- use concrete detector class names so the page matches the implementation and security model
- add a regression that derives the inline detector set from proxy.py and checks the docs page

Verification

- uv run pytest tests/test_runtime_proxy_docs.py -q
- uv run ruff check tests/test_runtime_proxy_docs.py
- python scripts/check_release_consistency.py
- git diff --check

Notes

- Closes the runtime proxy detector-count docs drift found during release-readiness cleanup.