### PR TITLE
fix(skills): allow action SARIF upload

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -346,15 +346,8 @@ runs:
             ;;
         esac
 
-        if [ "$INPUT_SCAN_TYPE" = "skills" ] && { [ -z "$INPUT_FORMAT" ] || [ "$INPUT_FORMAT" = "sarif" ]; }; then
-          INPUT_FORMAT="json"
-          if [ -z "$INPUT_OUTPUT" ]; then
-            RESULT_FILE="agent-bom-results.json"
-          fi
-        fi
-
-        if [ "$INPUT_SCAN_TYPE" = "skills" ] && [ -n "$INPUT_FORMAT" ] && [ "$INPUT_FORMAT" != "json" ] && [ "$INPUT_FORMAT" != "console" ]; then
-          echo "::error::scan-type=skills only supports format=json or format=console"
+        if [ "$INPUT_SCAN_TYPE" = "skills" ] && [ -n "$INPUT_FORMAT" ] && [ "$INPUT_FORMAT" != "json" ] && [ "$INPUT_FORMAT" != "console" ] && [ "$INPUT_FORMAT" != "sarif" ]; then
+          echo "::error::scan-type=skills only supports format=json, format=console, or format=sarif"
           exit 1
         fi
 

--- a/docs/skills/POLICY.md
+++ b/docs/skills/POLICY.md
@@ -88,11 +88,14 @@ Run skills scanning as its own CI lane:
   with:
     scan-type: skills
     scan-ref: .
-    format: json
-    output: agent-bom-skills.json
+    format: sarif
+    output: agent-bom-skills.sarif
+    upload-sarif: true
     policy: skills-policy.yaml
     warn-on-review-verdict: review
     fail-on-review-verdict: blocked
 ```
 
-Keep IaC/SBOM/package gates in separate jobs when the desired policies differ.
+Skills SARIF includes finding source locations, trust metadata, and policy
+results for GitHub code scanning. Keep IaC/SBOM/package gates in separate jobs
+when the desired policies or review owners differ.

--- a/site-docs/reference/agentic-workflows.md
+++ b/site-docs/reference/agentic-workflows.md
@@ -66,16 +66,18 @@ so future agent and SIEM push workflows share one event envelope.
   with:
     scan-type: skills
     scan-ref: .
-    format: json
-    output: agent-bom-skills.json
+    format: sarif
+    output: agent-bom-skills.sarif
+    upload-sarif: true
     policy: skills-policy.yaml
     warn-on-review-verdict: review
     fail-on-review-verdict: blocked
 ```
 
-Produces JSON skills evidence and a policy result. Use this lane for
-instruction files and skills; keep package/SARIF gates in a separate job until
-the skills finding schema is exported as SARIF.
+Produces skills SARIF with source locations, trust metadata, and policy
+results for GitHub code scanning. Use this lane for instruction files and
+skills; keep package, IaC, and SBOM gates in separate jobs when their policies
+or review owners differ.
 
 ### Hosted Gateway Or Proxy Review
 

--- a/tests/test_pr_gate_sarif_action_contract.py
+++ b/tests/test_pr_gate_sarif_action_contract.py
@@ -70,6 +70,19 @@ def test_action_exposes_policy_aware_skills_gates() -> None:
     assert 'add_skill_arg_or_warn "--warn-on-review-verdict" "$INPUT_WARN_ON_REVIEW_VERDICT"' in run_script
 
 
+def test_action_allows_skills_sarif_upload_contract() -> None:
+    action_text = (ROOT / "action.yml").read_text(encoding="utf-8")
+    action = yaml.safe_load(action_text)
+    scan_step = next(step for step in action["runs"]["steps"] if step.get("id") == "scan")
+    run_script = scan_step["run"]
+
+    assert "scan-type=skills only supports format=json, format=console, or format=sarif" in run_script
+    assert 'INPUT_FORMAT="json"' not in run_script
+    assert "agent-bom-results.json" not in run_script
+    assert 'if [ "$INPUT_FORMAT" = "sarif" ]; then' in run_script
+    assert "github/codeql-action/upload-sarif" in action_text
+
+
 def test_focused_secrets_and_code_reject_sarif_format(tmp_path: Path) -> None:
     runner = CliRunner()
 


### PR DESCRIPTION
Summary
- allow scan-type=skills to keep format=sarif in the GitHub Action instead of downgrading to JSON
- document skills SARIF upload as the CI evidence path for instruction and skill policy gates
- add an action contract regression that locks the skills SARIF upload behavior

Verification
- uv run pytest tests/test_pr_gate_sarif_action_contract.py::test_action_allows_skills_sarif_upload_contract tests/test_pr_gate_sarif_action_contract.py::test_skills_sarif_output_path_writes_valid_sarif tests/test_pr_gate_sarif_action_contract.py::test_action_exposes_policy_aware_skills_gates -q
- uv run ruff check tests/test_pr_gate_sarif_action_contract.py
- python scripts/check_release_consistency.py
- git diff --check

Notes
- Advances #2589 by completing the GitHub Action SARIF upload lane for skills scanning.