### PR TITLE
feat(mcp): expose runtime audit read tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ integration docs instead of this front door.
 | Runtime proxy/gateway | runtime operators | scoped MCP traffic inspection, policy decisions, redacted audit evidence |
 | TypeScript client | services and agent runtimes | typed helper for stable REST endpoints |
 
-MCP server mode advertises 48 read-only security tools, 6 resources, and 6 workflow prompts.
+MCP server mode advertises 51 read-only security tools, 6 resources, and 6 workflow prompts.
 
 CLI scan commands run local scan pipelines today. They share lower scanner and
 discovery libraries with the API, but they are not API wrappers yet.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -232,7 +232,7 @@ graph TB
 | Output | `src/agent_bom/output/__init__.py` | JSON, CycloneDX, SARIF, SPDX, console |
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine (17 conditions) |
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP proxy (7 inline detectors) |
-| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (48 tools) |
+| MCP Server | `src/agent_bom/mcp_server.py` | FastMCP server (51 tools) |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse |
 | Asset Tracker | `src/agent_bom/asset_tracker.py` | Persistent vuln tracking — first_seen, resolved, MTTR |
 | Context Graph | `src/agent_bom/context_graph.py` | Lateral movement analysis — see [Graph Contract](graph/CONTRACT.md) for entity/edge coverage, accuracy guarantees, and scaling boundaries |

--- a/docs/CLAUDE_INTEGRATION.md
+++ b/docs/CLAUDE_INTEGRATION.md
@@ -59,7 +59,7 @@ claude mcp add agent-bom -- uvx agent-bom mcp server
 
 ## What users get inside Claude
 
-`agent-bom mcp server` exposes 48 read-only tools for:
+`agent-bom mcp server` exposes 51 read-only tools for:
 
 - agent and MCP discovery
 - package and registry checks

--- a/docs/CODEX_CLI.md
+++ b/docs/CODEX_CLI.md
@@ -20,7 +20,7 @@ command = "agent-bom"
 args = ["mcp", "server"]
 ```
 
-That makes the same 48 read-only `agent-bom` MCP tools available to Codex.
+That makes the same 51 read-only `agent-bom` MCP tools available to Codex.
 
 ## What agent-bom discovers for Codex
 

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -150,7 +150,7 @@ An agent operating autonomously can be steered into a multi-step exfiltration se
 │  2. PROXY         Sits between client and server, intercepts     │
 │     (agent-bom proxy) every JSON-RPC message, enforces policy    │
 │                                                                  │
-│  3. MCP SERVER    Exposes 48 scan/governance tools to any agent  │
+│  3. MCP SERVER    Exposes 51 scan/governance tools to any agent  │
 │     (agent-bom mcp server)  — scan, check, registry, compliance  │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -210,7 +210,7 @@ For cross-agent correlation, use the broader runtime protection engine (`agent-b
 agent-bom mcp server
 ```
 
-Exposes 48 tools to any MCP-compatible AI assistant. Your agent can run scans, check packages, query ExposurePaths, ask for deploy decisions, query threat intel, inspect runtime posture, and generate compliance reports without leaving the chat:
+Exposes 51 tools to any MCP-compatible AI assistant. Your agent can run scans, check packages, query ExposurePaths, ask for deploy decisions, query threat intel, inspect runtime posture, and generate compliance reports without leaving the chat:
 
 ```
 scan                — full discovery + scan, returns JSON report

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,6 +1,6 @@
 # MCP Server — Connect agent-bom to AI Assistants
 
-agent-bom exposes 48 security tools as an MCP server. Any MCP-compatible client
+agent-bom exposes 51 security tools as an MCP server. Any MCP-compatible client
 can connect and get vulnerability scanning, blast radius analysis, compliance
 checks, and supply chain verification through natural conversation.
 
@@ -56,7 +56,7 @@ Add to `~/.snowflake/cortex/mcp.json`:
 }
 ```
 
-CoCo can then call the same 48 `agent-bom` tools over MCP.
+CoCo can then call the same 51 `agent-bom` tools over MCP.
 
 agent-bom also discovers Cortex auxiliary security files alongside `mcp.json`:
 
@@ -155,7 +155,7 @@ agent-bom proxy-bootstrap \
 
 `proxy-configure` is best for JSON MCP clients such as Claude Desktop, Cursor, Windsurf, and Cortex CoCo. TOML-based clients like Codex CLI need manual proxy wrapping.
 
-## Tool Categories (48 tools)
+## Tool Categories (51 tools)
 
 | Category | Tools | What They Do |
 |----------|-------|-------------|
@@ -168,7 +168,7 @@ agent-bom proxy-bootstrap \
 | **Inventory** | `inventory` | List agents/servers without CVE scanning |
 | **Trust** | `marketplace_check`, `runtime_correlate`, `tool_risk_assessment` | Score package trust, correlate runtime usage, and assess live tool capability risk |
 | **Skills** | `skill_scan`, `skill_verify`, `skill_trust` | Instruction-file trust, provenance, and tool-poisoning detection |
-| **Graph / Runtime** | `exposure_paths`, `should_i_deploy`, `context_graph`, `graph_export`, `runtime_correlate`, `runtime_production_index`, `runtime_blueprints`, `runtime_blueprint_drift`, `proxy_status`, `gateway_status`, `shield_status`, `firewall_check`, `tool_risk_assessment` | Return ranked investigation paths, deploy decisions, graph exports, runtime posture, blueprints, drift checks, and read-only firewall decisions |
+| **Graph / Runtime** | `exposure_paths`, `should_i_deploy`, `context_graph`, `graph_export`, `runtime_correlate`, `runtime_production_index`, `runtime_blueprints`, `runtime_blueprint_drift`, `proxy_status`, `proxy_alerts`, `gateway_status`, `shield_status`, `firewall_check`, `audit_query`, `audit_integrity`, `tool_risk_assessment` | Return ranked investigation paths, deploy decisions, graph exports, runtime posture, blueprints, drift checks, proxy alerts, audit-chain evidence, and read-only firewall decisions |
 | **AI supply chain** | `dataset_card_scan`, `training_pipeline_scan`, `browser_extension_scan`, `model_provenance_scan`, `prompt_scan`, `model_file_scan`, `ingest_external_scan` | Scan AI artifacts, prompts, model files, browser extensions, and external scanner results |
 
 ## Agent-facing decision tools

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -127,7 +127,7 @@ notes discuss agent-native product direction.
 | Area | Shipped today | Not yet shipped |
 |---|---|---|
 | Human cockpit | Next.js dashboard, graph cockpit, reports, compliance and audit views | every UI action backed by a source registry and persisted workflow state |
-| Agent interface | 48 read-only MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture | long-lived posture subscription tool, autonomous remediation actions |
+| Agent interface | 51 read-only MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture | long-lived posture subscription tool, autonomous remediation actions |
 | Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports, TypeScript control-plane client, TypeScript runtime detector package | Python/Go control-plane SDKs and full scanner SDKs |
 | Runtime | MCP proxy, gateway, Shield SDK, runtime audit and policy decisions | webhook outbox, Kafka connectors, cloud-log ingestion connectors, Kinesis/Firehose adapter, and MCP posture subscriptions |
 | Graph scale | SQLite/Postgres default path, WebGL overview, optional Neptune adapter work | production Neptune SLOs, public openCypher endpoint, mandatory graph-database backend |

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,10 +1,10 @@
 {
-  "generated_on": "2026-05-19",
+  "generated_on": "2026-05-20",
   "version": "0.87.1",
   "metrics": [
     {
       "name": "MCP tools",
-      "value": 48,
+      "value": 51,
       "source": "src/agent_bom/mcp_server_metadata.py",
       "notes": "Counted from the advertised server-card tools."
     },
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 478,
+      "value": 483,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,16 +5,16 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-05-19`
+- Generated on: `2026-05-20`
 - Version: `0.87.1`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |
-| MCP tools | 48 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
+| MCP tools | 51 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 35 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 478 | `tests/` | Counts files matching test_*.py. |
+| Test files | 483 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 25 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 24 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 485 | `src/agent_bom` | Counts all Python files recursively. |

--- a/integrations/docker-mcp-registry/tools.json
+++ b/integrations/docker-mcp-registry/tools.json
@@ -258,6 +258,16 @@
     ]
   },
   {
+    "name": "proxy_alerts",
+    "description": "Return recent tenant-scoped runtime proxy alerts with severity and detector filters.",
+    "arguments": [
+      {"name": "tenant_id", "type": "string", "desc": "Tenant scope to read"},
+      {"name": "severity", "type": "string", "desc": "Optional severity filter"},
+      {"name": "detector", "type": "string", "desc": "Optional detector name filter"},
+      {"name": "limit", "type": "integer", "desc": "Maximum alerts to return"}
+    ]
+  },
+  {
     "name": "gateway_status",
     "description": "Return gateway policy and inter-agent firewall runtime statistics.",
     "arguments": [
@@ -279,6 +289,27 @@
       {"name": "target_agent", "type": "string", "desc": "Target agent or service identity"},
       {"name": "source_roles", "type": "string", "desc": "Optional comma-separated source roles"},
       {"name": "target_roles", "type": "string", "desc": "Optional comma-separated target roles"}
+    ]
+  },
+  {
+    "name": "audit_query",
+    "description": "Read tenant-scoped control-plane audit records with filters.",
+    "arguments": [
+      {"name": "tenant_id", "type": "string", "desc": "Tenant scope to read"},
+      {"name": "action", "type": "string", "desc": "Optional audit action filter"},
+      {"name": "resource", "type": "string", "desc": "Optional audit resource filter"},
+      {"name": "since", "type": "string", "desc": "Optional ISO timestamp lower bound"},
+      {"name": "limit", "type": "integer", "desc": "Maximum audit records to return"},
+      {"name": "offset", "type": "integer", "desc": "Pagination offset"}
+    ]
+  },
+  {
+    "name": "audit_integrity",
+    "description": "Verify control-plane and runtime audit-chain integrity.",
+    "arguments": [
+      {"name": "tenant_id", "type": "string", "desc": "Tenant scope to verify"},
+      {"name": "limit", "type": "integer", "desc": "Maximum audit records to verify"},
+      {"name": "include_runtime", "type": "boolean", "desc": "Include configured runtime proxy audit log"}
     ]
   },
   {

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -398,7 +398,7 @@ def main() -> int:
     tools = len(tool_names)
     resources = len(resource_uris)
     prompts = len(prompt_names)
-    if (tools, resources, prompts) != (48, 6, 6):
+    if (tools, resources, prompts) != (51, 6, 6):
         _fail(f"MCP server card count changed unexpectedly: tools={tools}, resources={resources}, prompts={prompts}")
     docker_mcp_tool_names = [str(tool["name"]) for tool in json.loads(DOCKER_MCP_TOOLS.read_text())]
     if docker_mcp_tool_names != tool_names:

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server Setup
 
-agent-bom runs as an MCP server, exposing 48 read-only security tools to any MCP client.
+agent-bom runs as an MCP server, exposing 51 read-only security tools to any MCP client.
 The server card also advertises 6 resources and 6 workflow prompts so agents can
 choose structured playbooks instead of guessing tool order.
 
@@ -132,9 +132,12 @@ Connect with:
 | `runtime_blueprints` | Role/profile blueprints for runtime policy design |
 | `runtime_blueprint_drift` | Evaluate runtime posture against a role/profile blueprint |
 | `proxy_status` | Current MCP proxy metrics and alert posture |
+| `proxy_alerts` | Recent tenant-scoped runtime proxy alerts |
 | `gateway_status` | Gateway policy and inter-agent firewall runtime statistics |
 | `shield_status` | Shield session status without changing enforcement |
 | `firewall_check` | Read-only inter-agent firewall decision dry run |
+| `audit_query` | Tenant-scoped control-plane audit records |
+| `audit_integrity` | Control-plane and runtime audit-chain verification |
 | `vector_db_scan` | Probe vector DBs for auth misconfigurations |
 | `aisvs_benchmark` | OWASP AISVS v1.0 compliance checks |
 | `gpu_infra_scan` | GPU/AI compute infrastructure scanning |

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -55,7 +55,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 |---|---|---|
 | **CLI / CI** | developers and pipelines | local scans, SARIF/SBOM/HTML/JSON, graph exports, deterministic gates |
 | **REST API** | security platforms, SIEM jobs, custom services | self-hosted control-plane routes for scans, normalized bulk findings, dataset versions, graph evidence, audit, and governance |
-| **MCP tools** | AI agents and coding assistants | 48 read-only tools, strict args, `exposure_paths`, `should_i_deploy`, runtime posture |
+| **MCP tools** | AI agents and coding assistants | 51 read-only tools, strict args, `exposure_paths`, `should_i_deploy`, runtime posture |
 | **TypeScript client** | services and agent runtimes calling the control plane | typed helper for stable REST endpoints; not a scanner SDK |
 | **TypeScript runtime detectors** | MCP/runtime enforcement integrations | local detector package for runtime policy checks; separate from the control-plane client |
 | **UI cockpit** | security teams and auditors | graph cockpit, compliance, audit, and evidence review over the same backend data |

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -213,6 +213,12 @@ Return current MCP proxy metrics and runtime alert posture.
 proxy_status(tenant_id="default")
 ```
 
+### proxy_alerts
+Return recent tenant-scoped runtime proxy alerts with optional severity and detector filters.
+```
+proxy_alerts(tenant_id="default", severity="critical", detector="", limit=50)
+```
+
 ### gateway_status
 Return gateway policy and inter-agent firewall runtime statistics.
 ```
@@ -229,6 +235,18 @@ shield_status(session_id="default")
 Dry-run an inter-agent firewall decision without recording control-plane state.
 ```
 firewall_check(source_agent="developer-agent", target_agent="ticketing-agent")
+```
+
+### audit_query
+Read tenant-scoped control-plane audit records with action, resource, time, and pagination filters.
+```
+audit_query(tenant_id="default", action="", resource="", since="", limit=100, offset=0)
+```
+
+### audit_integrity
+Verify control-plane and runtime audit-chain integrity without mutating enforcement state.
+```
+audit_integrity(tenant_id="default", limit=1000, include_runtime=true)
 ```
 
 ### vector_db_scan

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -692,7 +692,7 @@ def mcp_server_cmd(
     Requires:  pip install 'agent-bom[mcp-server]'
 
     \b
-    Exposes 48 security tools via MCP protocol:
+    Exposes 51 security tools via MCP protocol:
       scan                   Full scan — CVEs, config security, blast radius, compliance
       check                  Check a specific package for CVEs before installing
       blast_radius           Look up blast radius for a specific CVE
@@ -722,9 +722,12 @@ def mcp_server_cmd(
       runtime_production_index Runtime production posture summary
       runtime_blueprints     Role/profile blueprints for runtime policy design
       proxy_status           Current MCP proxy metrics and alert posture
+      proxy_alerts           Recent tenant-scoped runtime proxy alerts
       gateway_status         Gateway policy and firewall runtime statistics
       shield_status          Shield session status without changing enforcement
       firewall_check         Read-only inter-agent firewall decision dry run
+      audit_query            Tenant-scoped control-plane audit records
+      audit_integrity        Control-plane and runtime audit-chain verification
       vector_db_scan         Discover vector databases and assess auth exposure
       aisvs_benchmark        OWASP AISVS v1.0 compliance checks
       gpu_infra_scan         GPU container and K8s node inventory + DCGM probe

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -5,7 +5,7 @@ Start with:
     agent-bom mcp server --transport sse          # SSE transport (for remote clients)
     agent-bom mcp server --transport streamable-http
 
-Tools (48):
+Tools (51):
     scan                — Full discovery → scan → output pipeline
     check               — Check a specific package for CVEs before installing
     blast_radius        — Look up blast radius for a specific CVE
@@ -30,6 +30,16 @@ Tools (48):
     cis_benchmark       — Run CIS benchmark checks against cloud accounts
     fleet_scan          — Batch registry lookup for fleet inventories
     runtime_correlate   — Cross-reference runtime audit logs with CVE findings
+    runtime_production_index — Runtime production posture summary
+    runtime_blueprints  — Role/profile blueprints for runtime policy design
+    runtime_blueprint_drift — Evaluate runtime posture against a blueprint
+    proxy_status        — Current MCP proxy metrics and alert posture
+    proxy_alerts        — Recent tenant-scoped runtime proxy alerts
+    gateway_status      — Gateway policy and firewall runtime statistics
+    shield_status       — Shield session status without changing enforcement
+    firewall_check      — Read-only inter-agent firewall decision dry run
+    audit_query         — Tenant-scoped control-plane audit records
+    audit_integrity     — Control-plane and runtime audit-chain verification
     vector_db_scan      — Scan vector databases for embedding poisoning and access risks
     aisvs_benchmark     — OWASP AI Security Verification Standard benchmark
     gpu_infra_scan      — Scan GPU infrastructure for CVEs and misconfigurations

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -142,6 +142,11 @@ _SERVER_CARD_TOOLS = [
         "annotations": {"readOnlyHint": True},
     },
     {
+        "name": "proxy_alerts",
+        "description": "Return recent tenant-scoped runtime proxy alerts with severity and detector filters",
+        "annotations": {"readOnlyHint": True},
+    },
+    {
         "name": "gateway_status",
         "description": "Return gateway policy and inter-agent firewall runtime statistics",
         "annotations": {"readOnlyHint": True},
@@ -154,6 +159,16 @@ _SERVER_CARD_TOOLS = [
     {
         "name": "firewall_check",
         "description": "Dry-run an inter-agent firewall decision without recording control-plane state",
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "audit_query",
+        "description": "Read tenant-scoped control-plane audit records with action, resource, time, and pagination filters",
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "audit_integrity",
+        "description": "Verify control-plane and runtime audit-chain integrity without mutating enforcement state",
         "annotations": {"readOnlyHint": True},
     },
     {
@@ -255,9 +270,12 @@ _TOOL_CAPABILITY_CLASSES = {
     "runtime_blueprints": ["READ", "RUNTIME", "POLICY"],
     "runtime_blueprint_drift": ["READ", "RUNTIME", "POLICY", "ANALYZE"],
     "proxy_status": ["READ", "RUNTIME", "OBSERVABILITY"],
+    "proxy_alerts": ["READ", "RUNTIME", "OBSERVABILITY"],
     "gateway_status": ["READ", "RUNTIME", "POLICY"],
     "shield_status": ["READ", "RUNTIME", "SECURITY"],
     "firewall_check": ["READ", "RUNTIME", "POLICY"],
+    "audit_query": ["READ", "AUDIT"],
+    "audit_integrity": ["READ", "AUDIT", "PROVENANCE"],
     "vector_db_scan": ["READ", "NETWORK", "RUNTIME"],
     "aisvs_benchmark": ["READ", "COMPLIANCE"],
     "gpu_infra_scan": ["READ", "NETWORK", "INFRA"],

--- a/src/agent_bom/mcp_server_operator_tools.py
+++ b/src/agent_bom/mcp_server_operator_tools.py
@@ -31,8 +31,11 @@ def register_operator_tools(
     from agent_bom.mcp_tools.compliance import cis_benchmark_impl
     from agent_bom.mcp_tools.registry import fleet_scan_impl, marketplace_check_impl
     from agent_bom.mcp_tools.runtime import (
+        audit_integrity_impl,
+        audit_query_impl,
         firewall_check_impl,
         gateway_status_impl,
+        proxy_alerts_impl,
         proxy_status_impl,
         runtime_blueprint_drift_impl,
         runtime_blueprints_impl,
@@ -483,6 +486,36 @@ def register_operator_tools(
             _truncate_response=truncate_response,
         )
 
+    @mcp.tool(annotations=read_only, title="Proxy Alerts")
+    async def proxy_alerts(
+        tenant_id: Annotated[
+            str,
+            Field(description="Tenant scope to read. Defaults to the control-plane default tenant."),
+        ] = "default",
+        severity: Annotated[
+            str,
+            Field(description="Optional severity filter: critical, high, medium, low, or info."),
+        ] = "",
+        detector: Annotated[
+            str,
+            Field(description="Optional detector name filter, for example credential_leak."),
+        ] = "",
+        limit: Annotated[
+            int,
+            Field(ge=1, le=1000, description="Maximum alerts to return."),
+        ] = 100,
+    ) -> str:
+        """Return recent runtime proxy alerts without prompts, arguments, or responses."""
+        return await execute_tool_async(
+            "proxy_alerts",
+            proxy_alerts_impl,
+            tenant_id=tenant_id,
+            severity=severity,
+            detector=detector,
+            limit=limit,
+            _truncate_response=truncate_response,
+        )
+
     @mcp.tool(annotations=read_only, title="Gateway Status")
     async def gateway_status(
         tenant_id: Annotated[
@@ -534,5 +567,70 @@ def register_operator_tools(
             target_agent=target_agent,
             source_roles=source_roles,
             target_roles=target_roles,
+            _truncate_response=truncate_response,
+        )
+
+    @mcp.tool(annotations=read_only, title="Audit Query")
+    async def audit_query(
+        tenant_id: Annotated[
+            str,
+            Field(description="Tenant scope to read. Defaults to the control-plane default tenant."),
+        ] = "default",
+        action: Annotated[
+            str,
+            Field(description="Optional audit action filter."),
+        ] = "",
+        resource: Annotated[
+            str,
+            Field(description="Optional audit resource filter."),
+        ] = "",
+        since: Annotated[
+            str,
+            Field(description="Optional ISO timestamp lower bound."),
+        ] = "",
+        limit: Annotated[
+            int,
+            Field(ge=1, le=1000, description="Maximum audit records to return."),
+        ] = 100,
+        offset: Annotated[
+            int,
+            Field(ge=0, description="Pagination offset."),
+        ] = 0,
+    ) -> str:
+        """Read tenant-scoped control-plane audit records."""
+        return await execute_tool_async(
+            "audit_query",
+            audit_query_impl,
+            tenant_id=tenant_id,
+            action=action,
+            resource=resource,
+            since=since,
+            limit=limit,
+            offset=offset,
+            _truncate_response=truncate_response,
+        )
+
+    @mcp.tool(annotations=read_only, title="Audit Integrity")
+    async def audit_integrity(
+        tenant_id: Annotated[
+            str,
+            Field(description="Tenant scope to verify. Defaults to the control-plane default tenant."),
+        ] = "default",
+        limit: Annotated[
+            int,
+            Field(ge=1, le=10000, description="Maximum audit records to verify."),
+        ] = 1000,
+        include_runtime: Annotated[
+            bool,
+            Field(description="Also verify the configured runtime proxy audit log when AGENT_BOM_LOG is set."),
+        ] = True,
+    ) -> str:
+        """Verify control-plane and runtime audit chain integrity."""
+        return await execute_tool_async(
+            "audit_integrity",
+            audit_integrity_impl,
+            tenant_id=tenant_id,
+            limit=limit,
+            include_runtime=include_runtime,
             _truncate_response=truncate_response,
         )

--- a/src/agent_bom/mcp_tools/runtime.py
+++ b/src/agent_bom/mcp_tools/runtime.py
@@ -102,6 +102,31 @@ async def proxy_status_impl(
         return json.dumps({"error": sanitize_error(exc)})
 
 
+async def proxy_alerts_impl(
+    *,
+    tenant_id: str = "default",
+    severity: str = "",
+    detector: str = "",
+    limit: int = 100,
+    _truncate_response,
+) -> str:
+    """Implementation of the proxy_alerts tool."""
+    try:
+        from agent_bom.api.routes.proxy import proxy_alerts
+
+        bounded_limit = max(1, min(int(limit), 1000))
+        payload = await proxy_alerts(
+            cast(Any, _request_for_tenant(tenant_id)),
+            severity=severity.strip() or None,
+            detector=detector.strip() or None,
+            limit=bounded_limit,
+        )
+        return _truncate_response(json.dumps(payload, indent=2, default=str))
+    except Exception as exc:
+        logger.exception("MCP proxy alerts error")
+        return json.dumps({"error": sanitize_error(exc)})
+
+
 async def shield_status_impl(
     *,
     session_id: str = "default",
@@ -131,6 +156,59 @@ async def gateway_status_impl(
         return _truncate_response(json.dumps(payload, indent=2, default=str))
     except Exception as exc:
         logger.exception("MCP gateway status error")
+        return json.dumps({"error": sanitize_error(exc)})
+
+
+async def audit_query_impl(
+    *,
+    tenant_id: str = "default",
+    action: str = "",
+    resource: str = "",
+    since: str = "",
+    limit: int = 100,
+    offset: int = 0,
+    _truncate_response,
+) -> str:
+    """Implementation of the audit_query tool."""
+    try:
+        from agent_bom.api.routes.enterprise import list_audit_entries
+
+        bounded_limit = max(1, min(int(limit), 1000))
+        bounded_offset = max(0, int(offset))
+        payload = await list_audit_entries(
+            cast(Any, _request_for_tenant(tenant_id)),
+            action=action.strip() or None,
+            resource=resource.strip() or None,
+            since=since.strip() or None,
+            limit=bounded_limit,
+            offset=bounded_offset,
+        )
+        return _truncate_response(json.dumps(payload, indent=2, default=str))
+    except Exception as exc:
+        logger.exception("MCP audit query error")
+        return json.dumps({"error": sanitize_error(exc)})
+
+
+async def audit_integrity_impl(
+    *,
+    tenant_id: str = "default",
+    limit: int = 1000,
+    include_runtime: bool = True,
+    _truncate_response,
+) -> str:
+    """Implementation of the audit_integrity tool."""
+    try:
+        from agent_bom.api.routes.enterprise import audit_integrity
+
+        bounded_limit = max(1, min(int(limit), 10_000))
+        payload = await audit_integrity(
+            cast(Any, _request_for_tenant(tenant_id)),
+            limit=bounded_limit,
+            include_runtime=include_runtime,
+        )
+        return _truncate_response(json.dumps(payload, indent=2, default=str))
+    except Exception as exc:
+        logger.exception("MCP audit integrity error")
         return json.dumps({"error": sanitize_error(exc)})
 
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -487,10 +487,11 @@ def test_mcp_server_help_shows_skill_tools():
     from click.testing import CliRunner
 
     from agent_bom.cli import main
+    from agent_bom.mcp_server import _SERVER_CARD_TOOLS
 
     runner = CliRunner()
     result = runner.invoke(main, ["mcp", "server", "--help"])
-    assert "48 security tools" in result.output
+    assert f"{len(_SERVER_CARD_TOOLS)} security tools" in result.output
     assert "skill_scan" in result.output
     assert "skill_verify" in result.output
     assert "compliance" in result.output

--- a/tests/test_mcp_tool_impls.py
+++ b/tests/test_mcp_tool_impls.py
@@ -949,6 +949,59 @@ async def test_proxy_gateway_and_shield_status_impls_empty_state():
     assert shield_data["active"] is False
 
 
+@pytest.mark.asyncio
+async def test_proxy_alerts_impl_filters_metadata_only_alerts():
+    import agent_bom.api.routes.proxy as proxy_mod
+    from agent_bom.api.routes.proxy import push_proxy_alert
+    from agent_bom.mcp_tools.runtime import proxy_alerts_impl
+
+    proxy_mod._proxy_alerts.clear()
+    push_proxy_alert(
+        {
+            "tenant_id": "default",
+            "severity": "critical",
+            "detector": "credential_leak",
+            "message": "blocked secret",
+            "raw_arguments": {"token": "sk-test"},
+        }
+    )
+
+    result = await proxy_alerts_impl(
+        tenant_id="default",
+        severity="critical",
+        detector="credential_leak",
+        limit=10,
+        _truncate_response=_trunc,
+    )
+    data = json.loads(result)
+    assert data["count"] == 1
+    assert data["alerts"][0]["detector"] == "credential_leak"
+    assert "raw_arguments" not in data["alerts"][0]
+
+    proxy_mod._proxy_alerts.clear()
+
+
+@pytest.mark.asyncio
+async def test_audit_query_and_integrity_impls_are_tenant_scoped():
+    from agent_bom.api.audit_log import AuditEntry, InMemoryAuditLog, set_audit_log
+    from agent_bom.mcp_tools.runtime import audit_integrity_impl, audit_query_impl
+
+    store = InMemoryAuditLog()
+    store.append(AuditEntry(action="scan", actor="alice", resource="job/alpha", details={"tenant_id": "tenant-alpha"}))
+    store.append(AuditEntry(action="scan", actor="bob", resource="job/beta", details={"tenant_id": "tenant-beta"}))
+    set_audit_log(store)
+
+    query_result = await audit_query_impl(tenant_id="tenant-alpha", action="scan", limit=10, _truncate_response=_trunc)
+    query_data = json.loads(query_result)
+    assert query_data["total"] == 1
+    assert query_data["entries"][0]["resource"] == "job/alpha"
+
+    integrity_result = await audit_integrity_impl(tenant_id="tenant-alpha", include_runtime=False, _truncate_response=_trunc)
+    integrity_data = json.loads(integrity_result)
+    assert integrity_data["checked"] == 1
+    assert integrity_data["chains"][0]["tenant_scoped"] is True
+
+
 def test_firewall_check_impl_is_read_only_default_allow():
     from agent_bom.mcp_tools.runtime import firewall_check_impl
 


### PR DESCRIPTION
Summary
- add read-only MCP tools for proxy alerts, tenant-scoped audit queries, and audit-chain integrity verification
- refresh MCP server metadata, Docker MCP registry tool specs, and public tool-count docs from 48 to 51 tools
- add regression coverage for metadata-only proxy alerts and tenant-scoped audit reads/integrity

Verification
- uv run pytest tests/test_mcp_tool_impls.py::test_proxy_gateway_and_shield_status_impls_empty_state tests/test_mcp_tool_impls.py::test_proxy_alerts_impl_filters_metadata_only_alerts tests/test_mcp_tool_impls.py::test_audit_query_and_integrity_impls_are_tenant_scoped tests/test_fleet_scan.py::test_server_card_tools_count_matches_mcp_tools -q
- uv run ruff check src/agent_bom/mcp_tools/runtime.py src/agent_bom/mcp_server_operator_tools.py tests/test_mcp_tool_impls.py
- uv run pytest tests/test_stats_alignment.py::test_print_actual_counts tests/test_fleet_scan.py::test_server_card_tools_count_matches_mcp_tools -q
- python scripts/check_release_consistency.py
- git diff --check

Notes
- Keeps the MCP server read-only; mutating Shield controls remain separate opt-in runtime/API work.