### PR TITLE
feat(sdk): add Python control-plane client

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ integration docs instead of this front door.
 | MCP tools | agents and assistants | strict arguments, read-only security queries, exposure paths, deploy decisions |
 | Dashboard | security teams and operators | inventory, findings, graph cockpit, compliance, evidence, runtime posture |
 | Runtime proxy/gateway | runtime operators | scoped MCP traffic inspection, policy decisions, redacted audit evidence |
+| Python client | services, notebooks, and automation | typed helper for stable REST endpoints in the packaged wheel |
 | TypeScript client | services and agent runtimes | typed helper for stable REST endpoints |
 
 MCP server mode advertises 51 read-only security tools, 6 resources, and 6 workflow prompts.

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,0 +1,38 @@
+# agent-bom Python SDK
+
+The Python SDK is the packaged `agent_bom.AgentBomClient` control-plane client.
+It talks to an existing agent-bom API deployment and keeps authentication and
+tenant scope explicit.
+
+```python
+from agent_bom import AgentBomClient
+
+client = AgentBomClient(
+    base_url="https://agent-bom.example.com",
+    api_key="...",
+    tenant_id="default",
+)
+
+print(client.health())
+print(client.exposure_paths(limit=5, min_risk=70))
+print(client.runtime_production_index())
+```
+
+## Covered Surfaces
+
+- `GET /health`
+- `GET /v1/findings`
+- `POST /v1/findings/bulk`
+- `GET /v1/graph/exposure-paths`
+- `POST /v1/graph/should-i-deploy`
+- `GET|POST /v1/datasets/{dataset_id}/versions`
+- `GET /v1/datasets/{dataset_id}/versions/{version_id}`
+- `GET /v1/agent-bom/manifest`
+- `GET /v1/runtime/production-index`
+- `GET /v1/intel/advisories/{advisory_id}`
+- `POST /v1/intel/match`
+- `GET /v1/intel/sources`
+
+Configure either `api_key` or `bearer_token`, not both. Tenant scope is sent as
+`X-Agent-Bom-Tenant-ID` and, where the API accepts it, as the request
+`tenant_id`.

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -3,6 +3,7 @@
 import re
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 try:
     __version__ = version("agent-bom")
@@ -31,8 +32,13 @@ from agent_bom.sdk import (  # noqa: E402
     scan,
 )
 
+if TYPE_CHECKING:
+    from agent_bom.client import AgentBomApiError, AgentBomClient
+
 __all__ = [
     "__version__",
+    "AgentBomApiError",
+    "AgentBomClient",
     "AgentBomSDKError",
     "DiffResult",
     "InventoryResult",
@@ -42,3 +48,15 @@ __all__ = [
     "diff",
     "scan",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name in {"AgentBomApiError", "AgentBomClient"}:
+        from agent_bom.client import AgentBomApiError, AgentBomClient
+
+        exports = {
+            "AgentBomApiError": AgentBomApiError,
+            "AgentBomClient": AgentBomClient,
+        }
+        return exports[name]
+    raise AttributeError(f"module 'agent_bom' has no attribute {name!r}")

--- a/src/agent_bom/client.py
+++ b/src/agent_bom/client.py
@@ -1,0 +1,308 @@
+"""Typed Python client for the agent-bom control-plane API."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, TypeAlias
+from urllib.parse import quote
+
+import httpx
+
+JsonValue: TypeAlias = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
+JsonObject: TypeAlias = dict[str, JsonValue]
+QueryValue: TypeAlias = str | int | float | bool | None
+
+
+class AgentBomApiError(RuntimeError):
+    """Raised when the control-plane API returns a non-success status."""
+
+    def __init__(self, message: str, *, status_code: int, body: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body
+
+
+class AgentBomClient:
+    """Synchronous control-plane client for agent-bom.
+
+    The client is intentionally small and hand-written so the Python package can
+    cover the stable API primitives without adding code generation to the
+    release path.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str | None = None,
+        bearer_token: str | None = None,
+        tenant_id: str | None = None,
+        timeout: float = 30.0,
+        default_headers: Mapping[str, str] | None = None,
+        transport: httpx.BaseTransport | None = None,
+        client: httpx.Client | None = None,
+    ) -> None:
+        if not base_url.strip():
+            raise ValueError("base_url is required")
+        if api_key and bearer_token:
+            raise ValueError("configure either api_key or bearer_token, not both")
+        if client is not None and transport is not None:
+            raise ValueError("configure either client or transport, not both")
+
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.bearer_token = bearer_token
+        self.tenant_id = tenant_id
+        self.default_headers = dict(default_headers or {})
+        self._owns_client = client is None
+        self._client = client or httpx.Client(timeout=timeout, transport=transport)
+
+    def close(self) -> None:
+        """Close the underlying HTTP client."""
+
+        if self._owns_client:
+            self._client.close()
+
+    def __enter__(self) -> AgentBomClient:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    def health(self) -> JsonObject:
+        """Return the control-plane health envelope."""
+
+        return self._request("GET", "/health")
+
+    def exposure_paths(self, *, limit: int | None = None, min_risk: int | None = None, tenant_id: str | None = None) -> JsonObject:
+        """List graph exposure paths for the request tenant."""
+
+        return self._request(
+            "GET",
+            "/v1/graph/exposure-paths",
+            params=_strip_query_none(
+                {
+                    "tenant_id": tenant_id or self.tenant_id,
+                    "limit": limit,
+                    "min_risk": min_risk,
+                }
+            ),
+        )
+
+    def should_i_deploy(
+        self,
+        *,
+        candidate: str | Mapping[str, JsonValue],
+        block_risk: int | None = None,
+        context: Mapping[str, JsonValue] | None = None,
+        tenant_id: str | None = None,
+    ) -> JsonObject:
+        """Ask the graph policy engine whether a candidate should deploy."""
+
+        return self._request(
+            "POST",
+            "/v1/graph/should-i-deploy",
+            json=_strip_none(
+                {
+                    "candidate": candidate,
+                    "tenant_id": tenant_id or self.tenant_id,
+                    "block_risk": block_risk,
+                    "context": dict(context) if context is not None else None,
+                }
+            ),
+        )
+
+    def list_findings(
+        self,
+        *,
+        severity: str | None = None,
+        sort: str = "effective_reach",
+        limit: int = 500,
+        offset: int = 0,
+    ) -> JsonObject:
+        """List normalized findings from scan jobs and bulk ingests."""
+
+        return self._request(
+            "GET",
+            "/v1/findings",
+            params=_strip_query_none(
+                {
+                    "severity": severity,
+                    "sort": sort,
+                    "limit": limit,
+                    "offset": offset,
+                }
+            ),
+        )
+
+    def ingest_findings(
+        self,
+        *,
+        findings: Sequence[Mapping[str, JsonValue]],
+        source: str | None = None,
+        schema_version: str | None = None,
+        metadata: Mapping[str, JsonValue] | None = None,
+        tenant_id: str | None = None,
+    ) -> JsonObject:
+        """Post normalized findings directly into the control plane."""
+
+        return self._request(
+            "POST",
+            "/v1/findings/bulk",
+            json=_strip_none(
+                {
+                    "findings": [dict(finding) for finding in findings],
+                    "source": source,
+                    "schema_version": schema_version,
+                    "metadata": dict(metadata) if metadata is not None else None,
+                    "tenant_id": tenant_id or self.tenant_id,
+                }
+            ),
+        )
+
+    def register_dataset_version(
+        self,
+        dataset_id: str,
+        *,
+        version_id: str | None = None,
+        artifact_uri: str | None = None,
+        digest: str | None = None,
+        digest_algorithm: str | None = None,
+        source: str | None = None,
+        metadata: Mapping[str, JsonValue] | None = None,
+        tenant_id: str | None = None,
+    ) -> JsonObject:
+        """Register a dataset version artifact."""
+
+        return self._request(
+            "POST",
+            f"/v1/datasets/{_quote_path(dataset_id)}/versions",
+            json=_strip_none(
+                {
+                    "version_id": version_id,
+                    "artifact_uri": artifact_uri,
+                    "digest": digest,
+                    "digest_algorithm": digest_algorithm,
+                    "source": source,
+                    "metadata": dict(metadata) if metadata is not None else None,
+                    "tenant_id": tenant_id or self.tenant_id,
+                }
+            ),
+        )
+
+    def dataset_versions(self, dataset_id: str) -> JsonObject:
+        """List versions for a dataset."""
+
+        return self._request("GET", f"/v1/datasets/{_quote_path(dataset_id)}/versions")
+
+    def dataset_version(self, dataset_id: str, version_id: str) -> JsonObject:
+        """Return one dataset version record."""
+
+        return self._request("GET", f"/v1/datasets/{_quote_path(dataset_id)}/versions/{_quote_path(version_id)}")
+
+    def agent_manifest(self, *, tenant_id: str | None = None) -> JsonObject:
+        """Return the tenant-scoped Agent BOM manifest."""
+
+        return self._request(
+            "GET",
+            "/v1/agent-bom/manifest",
+            params=_strip_query_none({"tenant_id": tenant_id or self.tenant_id}),
+        )
+
+    def runtime_production_index(self, *, tenant_id: str | None = None) -> JsonObject:
+        """Return the runtime production-index posture summary."""
+
+        return self._request(
+            "GET",
+            "/v1/runtime/production-index",
+            params=_strip_query_none({"tenant_id": tenant_id or self.tenant_id}),
+        )
+
+    def intel_lookup(self, advisory_id: str) -> JsonObject:
+        """Look up one advisory by CVE, GHSA, or OSV identifier."""
+
+        return self._request("GET", f"/v1/intel/advisories/{_quote_path(advisory_id)}")
+
+    def intel_match(
+        self,
+        *,
+        packages: Sequence[Mapping[str, JsonValue]] | None = None,
+        purl: str | None = None,
+        ecosystem: str | None = None,
+        name: str | None = None,
+        version: str | None = None,
+        limit: int | None = None,
+    ) -> JsonObject:
+        """Match package coordinates against advisory intelligence."""
+
+        return self._request(
+            "POST",
+            "/v1/intel/match",
+            json=_strip_none(
+                {
+                    "packages": [dict(package) for package in packages] if packages is not None else None,
+                    "purl": purl,
+                    "ecosystem": ecosystem,
+                    "name": name,
+                    "version": version,
+                    "limit": limit,
+                }
+            ),
+        )
+
+    def intel_sources(self) -> JsonObject:
+        """List configured advisory intelligence sources and freshness."""
+
+        return self._request("GET", "/v1/intel/sources")
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Mapping[str, QueryValue] | None = None,
+        json: Mapping[str, JsonValue] | None = None,
+    ) -> JsonObject:
+        response = self._client.request(method, self._url(path), params=params, json=json, headers=self._headers(json is not None))
+        text = response.text
+        if response.status_code < 200 or response.status_code >= 300:
+            raise AgentBomApiError(
+                f"agent-bom request failed: {response.status_code}",
+                status_code=response.status_code,
+                body=text,
+            )
+        if not text:
+            return {}
+        data = response.json()
+        if not isinstance(data, dict):
+            raise AgentBomApiError("agent-bom response was not a JSON object", status_code=response.status_code, body=text)
+        return data
+
+    def _url(self, path: str) -> str:
+        if path.startswith(("http://", "https://")):
+            return path
+        return f"{self.base_url}/{path.lstrip('/')}"
+
+    def _headers(self, has_body: bool) -> dict[str, str]:
+        headers = {"accept": "application/json", **self.default_headers}
+        if has_body:
+            headers["content-type"] = "application/json"
+        if self.api_key:
+            headers["x-api-key"] = self.api_key
+        if self.bearer_token:
+            headers["authorization"] = f"Bearer {self.bearer_token}"
+        if self.tenant_id:
+            headers["x-agent-bom-tenant-id"] = self.tenant_id
+        return headers
+
+
+def _quote_path(value: str) -> str:
+    return quote(value, safe="")
+
+
+def _strip_none(values: Mapping[str, Any]) -> JsonObject:
+    return {key: value for key, value in values.items() if value is not None}
+
+
+def _strip_query_none(values: Mapping[str, QueryValue]) -> dict[str, str | int | float | bool]:
+    return {key: value for key, value in values.items() if value is not None}

--- a/tests/test_public_python_api.py
+++ b/tests/test_public_python_api.py
@@ -17,6 +17,8 @@ def test_public_api_exports_expected_functions():
     assert agent_bom.scan is sdk.scan
     assert agent_bom.check is sdk.check
     assert agent_bom.diff is sdk.diff
+    assert agent_bom.AgentBomClient.__name__ == "AgentBomClient"
+    assert agent_bom.AgentBomApiError.__name__ == "AgentBomApiError"
     assert sdk.inventory.__name__ == "inventory"
 
 

--- a/tests/test_python_client.py
+++ b/tests/test_python_client.py
@@ -1,0 +1,118 @@
+"""Tests for the Python control-plane client."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from agent_bom import AgentBomApiError, AgentBomClient
+
+
+def _client(handler):
+    transport = httpx.MockTransport(handler)
+    return AgentBomClient(base_url="https://agent-bom.example.com/", api_key="secret", tenant_id="tenant-a", transport=transport)
+
+
+def test_client_sets_auth_headers_and_strips_none_body_fields() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(200, json={"decision": "allow"})
+
+    client = _client(handler)
+
+    result = client.should_i_deploy(candidate="flask@2.0.0", block_risk=80, context=None)
+
+    assert result["decision"] == "allow"
+    assert captured["url"] == "https://agent-bom.example.com/v1/graph/should-i-deploy"
+    headers = captured["headers"]
+    assert isinstance(headers, dict)
+    assert headers["x-api-key"] == "secret"
+    assert headers["x-agent-bom-tenant-id"] == "tenant-a"
+    assert headers["content-type"] == "application/json"
+    assert captured["body"] == {"candidate": "flask@2.0.0", "tenant_id": "tenant-a", "block_risk": 80}
+
+
+def test_client_builds_query_params() -> None:
+    urls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        urls.append(str(request.url))
+        return httpx.Response(200, json={"paths": []})
+
+    client = _client(handler)
+
+    client.exposure_paths(limit=5, min_risk=70)
+
+    assert urls == ["https://agent-bom.example.com/v1/graph/exposure-paths?tenant_id=tenant-a&limit=5&min_risk=70"]
+
+
+def test_client_exposes_v0871_headline_routes() -> None:
+    seen: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path))
+        return httpx.Response(200, json={"ok": True})
+
+    client = _client(handler)
+
+    client.agent_manifest()
+    client.runtime_production_index()
+    client.intel_lookup("GHSA-xxxx-yyyy-zzzz")
+    client.intel_match(ecosystem="pypi", name="requests", version="2.31.0")
+    client.intel_sources()
+
+    assert seen == [
+        ("GET", "/v1/agent-bom/manifest"),
+        ("GET", "/v1/runtime/production-index"),
+        ("GET", "/v1/intel/advisories/GHSA-xxxx-yyyy-zzzz"),
+        ("POST", "/v1/intel/match"),
+        ("GET", "/v1/intel/sources"),
+    ]
+
+
+def test_client_exposes_findings_and_dataset_loop() -> None:
+    seen: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path))
+        return httpx.Response(200, json={"ok": True})
+
+    client = _client(handler)
+
+    client.list_findings(severity="high", limit=10)
+    client.ingest_findings(findings=[{"id": "finding-1", "severity": "high"}], source="sdk-test")
+    client.register_dataset_version("dataset-a", version_id="v1")
+    client.dataset_versions("dataset-a")
+    client.dataset_version("dataset-a", "v1")
+
+    assert seen == [
+        ("GET", "/v1/findings"),
+        ("POST", "/v1/findings/bulk"),
+        ("POST", "/v1/datasets/dataset-a/versions"),
+        ("GET", "/v1/datasets/dataset-a/versions"),
+        ("GET", "/v1/datasets/dataset-a/versions/v1"),
+    ]
+
+
+def test_client_rejects_ambiguous_auth() -> None:
+    with pytest.raises(ValueError, match="either api_key or bearer_token"):
+        AgentBomClient(base_url="https://agent-bom.example.com", api_key="a", bearer_token="b")
+
+
+def test_client_raises_api_error_with_body() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, text='{"detail":"forbidden"}')
+
+    client = AgentBomClient(base_url="https://agent-bom.example.com", bearer_token="token", transport=httpx.MockTransport(handler))
+
+    with pytest.raises(AgentBomApiError) as exc:
+        client.health()
+
+    assert exc.value.status_code == 403
+    assert exc.value.body == '{"detail":"forbidden"}'

--- a/tests/test_python_client_route_parity.py
+++ b/tests/test_python_client_route_parity.py
@@ -1,0 +1,26 @@
+"""Route parity checks for the Python control-plane client."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from agent_bom.api.server import app
+
+
+def test_python_control_plane_client_paths_exist_in_api() -> None:
+    source = Path("src/agent_bom/client.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    client_paths = {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and (node.value == "/health" or node.value.startswith("/v1/"))
+        and "{" not in node.value
+        and not node.value.endswith("/")
+    }
+    registered_paths = {getattr(route, "path", "") for route in app.routes}
+
+    assert client_paths
+    assert client_paths <= registered_paths


### PR DESCRIPTION
Summary

- add `agent_bom.AgentBomClient`, a typed synchronous Python control-plane client for stable REST endpoints
- cover health, findings ingest/listing, graph deploy decisions, datasets, manifest, runtime production-index, and intel lookup/match/source reads
- document the packaged Python SDK entry point and lock route parity against the FastAPI app

Verification

- `uv run pytest -q tests/test_python_client.py tests/test_python_client_route_parity.py tests/test_public_python_api.py`
- `uv run ruff check src/agent_bom/client.py tests/test_python_client.py tests/test_python_client_route_parity.py`
- `uv run mypy src/agent_bom/client.py`
- `PYTHONPATH=src uv run --extra api python scripts/export_openapi.py --check`
- `PYTHONPATH=src uv run --extra api pytest -q tests/test_openapi_artifact.py tests/test_findings_bulk_api.py tests/test_dataset_versions_api.py tests/test_graph_api.py`
- `python scripts/check_release_consistency.py`
- `git diff --check`
