### PR TITLE
feat(plugins): add extension entrypoint registries

### DIFF
--- a/docs/PLUGIN_ENTRYPOINTS.md
+++ b/docs/PLUGIN_ENTRYPOINTS.md
@@ -1,0 +1,87 @@
+# Plugin Entry Points
+
+`agent-bom` v0.88 introduces a metadata-only foundation for plugin authors.
+The entry-point loader discovers plugin registrations, validates bounded
+metadata, and reports sanitized loading warnings. It does not execute or attach
+third-party plugins to MCP, advisory, or runtime paths by default.
+
+Third-party entry-point loading is opt-in:
+
+```bash
+AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS=true agent-bom agents --demo --offline
+```
+
+## Supported Groups
+
+| Group | Purpose | Default runtime behavior |
+|---|---|---|
+| `agent_bom.mcp_tools` | Advertise an MCP tool registration module and function. | Not registered on the live MCP server. |
+| `agent_bom.advisory_sources` | Advertise a private advisory lookup or sync source. | Not queried during scans. |
+| `agent_bom.runtime_emitters` | Advertise a runtime event emitter. | Not added to proxy, gateway, or alert dispatch. |
+
+Each group is capped at 32 loaded entry points per process. Import, validation,
+and coercion failures are non-fatal; built-in behavior remains available and
+warnings are sanitized before they can leave the process.
+
+## Author Contract
+
+Expose a callable entry point that returns a registration object. The object may
+be one of the dataclasses in `agent_bom.plugin_entrypoints` or any object with
+the same public attributes.
+
+```toml
+[project.entry-points."agent_bom.advisory_sources"]
+private-feed = "acme_agent_bom_advisories:registration"
+```
+
+```python
+from agent_bom.extensions import ExtensionCapabilities
+from agent_bom.plugin_entrypoints import AdvisorySourcePluginRegistration
+
+
+def registration() -> AdvisorySourcePluginRegistration:
+    return AdvisorySourcePluginRegistration(
+        name="private-feed",
+        module="acme_agent_bom_advisories.feed",
+        lookup_attr="lookup",
+        sync_attr="sync",
+        capabilities=ExtensionCapabilities(
+            scan_modes=("advisory_lookup",),
+            required_scopes=("private_feed_read",),
+            outbound_destinations=("advisories.example.internal",),
+            data_boundary="customer_controlled_advisory_lookup",
+            network_access=True,
+        ),
+        source="entry_point",
+    )
+```
+
+Required fields:
+
+- `name`: stable plugin identifier.
+- `module`: import path for the implementation module.
+- `capabilities`: declared permissions, outbound destinations, and data
+  boundary. If omitted, agent-bom applies conservative metadata-only defaults.
+
+Group-specific optional fields:
+
+- `agent_bom.mcp_tools`: `register_attr`, default `register_tools`.
+- `agent_bom.advisory_sources`: `lookup_attr`, default `lookup`; `sync_attr`,
+  default `sync`.
+- `agent_bom.runtime_emitters`: `emit_attr`, default `emit`; `flush_attr`,
+  default `flush`.
+
+## First Verification
+
+For plugin package tests, monkeypatch `importlib.metadata.entry_points`, set
+`AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS=true`, and call:
+
+```python
+from agent_bom.plugin_entrypoints import list_advisory_source_plugins
+
+plugins = list_advisory_source_plugins()
+assert plugins[0].name == "private-feed"
+```
+
+This verifies discovery only. Runtime activation remains a separate,
+operator-controlled integration step.

--- a/src/agent_bom/extensions.py
+++ b/src/agent_bom/extensions.py
@@ -76,6 +76,7 @@ def iter_entry_point_registrations(
     group: str,
     coerce: Callable[[Any, str], T],
     warnings: list[str],
+    max_entry_points: int | None = None,
 ) -> list[T]:
     """Load extension registrations from a Python entry-point group.
 
@@ -91,6 +92,12 @@ def iter_entry_point_registrations(
     except Exception as exc:  # noqa: BLE001
         warnings.append(sanitize_registry_warning(f"Could not enumerate entry points for {group}: {exc}"))
         return []
+
+    if max_entry_points is not None and len(entry_points) > max_entry_points:
+        warnings.append(
+            sanitize_registry_warning(f"Entry point group {group} declared {len(entry_points)} entries; loading first {max_entry_points}")
+        )
+        entry_points = entry_points[:max_entry_points]
 
     registrations: list[T] = []
     for entry_point in entry_points:

--- a/src/agent_bom/plugin_entrypoints.py
+++ b/src/agent_bom/plugin_entrypoints.py
@@ -1,0 +1,236 @@
+"""Metadata-only plugin entry-point discovery.
+
+This module intentionally does not wire discovered plugins into runtime
+execution paths. It gives v0.88 plugin authors a bounded, opt-in discovery
+contract for MCP tools, advisory sources, and runtime emitters while keeping
+default behavior unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from agent_bom.extensions import ExtensionCapabilities, RegistryEntry, iter_entry_point_registrations
+
+MCP_TOOLS_ENTRY_POINT_GROUP = "agent_bom.mcp_tools"
+ADVISORY_SOURCES_ENTRY_POINT_GROUP = "agent_bom.advisory_sources"
+RUNTIME_EMITTERS_ENTRY_POINT_GROUP = "agent_bom.runtime_emitters"
+
+PLUGIN_ENTRY_POINT_GROUPS: tuple[str, ...] = (
+    MCP_TOOLS_ENTRY_POINT_GROUP,
+    ADVISORY_SOURCES_ENTRY_POINT_GROUP,
+    RUNTIME_EMITTERS_ENTRY_POINT_GROUP,
+)
+
+MAX_PLUGIN_ENTRY_POINTS_PER_GROUP = 32
+
+
+@dataclass(frozen=True)
+class McpToolPluginRegistration(RegistryEntry):
+    """Metadata for a third-party MCP tool registration function."""
+
+    register_attr: str = "register_tools"
+
+
+@dataclass(frozen=True)
+class AdvisorySourcePluginRegistration(RegistryEntry):
+    """Metadata for a third-party advisory source integration."""
+
+    lookup_attr: str = "lookup"
+    sync_attr: str = "sync"
+
+
+@dataclass(frozen=True)
+class RuntimeEmitterPluginRegistration(RegistryEntry):
+    """Metadata for a third-party runtime event emitter."""
+
+    emit_attr: str = "emit"
+    flush_attr: str = "flush"
+
+
+PluginRegistration = McpToolPluginRegistration | AdvisorySourcePluginRegistration | RuntimeEmitterPluginRegistration
+
+_MCP_TOOL_PLUGINS: dict[str, McpToolPluginRegistration] = {}
+_ADVISORY_SOURCE_PLUGINS: dict[str, AdvisorySourcePluginRegistration] = {}
+_RUNTIME_EMITTER_PLUGINS: dict[str, RuntimeEmitterPluginRegistration] = {}
+_PLUGIN_ENTRYPOINT_WARNINGS: list[str] = []
+_PLUGIN_ENTRYPOINTS_LOADED = False
+
+
+def _plugin_capabilities(
+    *,
+    scan_modes: tuple[str, ...],
+    data_boundary: str,
+    required_scopes: tuple[str, ...] = (),
+    outbound_destinations: tuple[str, ...] = (),
+    network_access: bool = False,
+    writes: bool = False,
+    guarantees: tuple[str, ...] = ("read_only",),
+) -> ExtensionCapabilities:
+    return ExtensionCapabilities(
+        scan_modes=scan_modes,
+        required_scopes=required_scopes,
+        outbound_destinations=outbound_destinations,
+        data_boundary=data_boundary,
+        writes=writes,
+        network_access=network_access,
+        guarantees=guarantees,
+    )
+
+
+def _coerce_capabilities(value: Any, fallback: ExtensionCapabilities) -> ExtensionCapabilities:
+    capabilities = getattr(value, "capabilities", fallback)
+    return capabilities if isinstance(capabilities, ExtensionCapabilities) else fallback
+
+
+def _name_and_module(value: Any, entry_point_name: str, registration_type: str) -> tuple[str, str]:
+    name = str(getattr(value, "name", entry_point_name)).strip()
+    module = str(getattr(value, "module", "")).strip()
+    if not name or not module:
+        raise ValueError(f"{registration_type} plugin registration must declare name and module")
+    return name, module
+
+
+def _coerce_mcp_tool_plugin(value: Any, entry_point_name: str) -> McpToolPluginRegistration:
+    if isinstance(value, McpToolPluginRegistration):
+        return value
+    fallback = _plugin_capabilities(
+        scan_modes=("mcp_tool",),
+        data_boundary="mcp_tool_metadata_only",
+        required_scopes=("operator_enabled_mcp_tool",),
+    )
+    name, module = _name_and_module(value, entry_point_name, "MCP tool")
+    return McpToolPluginRegistration(
+        name=name,
+        module=module,
+        capabilities=_coerce_capabilities(value, fallback),
+        source=str(getattr(value, "source", "entry_point")),
+        discover_attr=str(getattr(value, "discover_attr", "discover")),
+        register_attr=str(getattr(value, "register_attr", "register_tools")),
+    )
+
+
+def _coerce_advisory_source_plugin(value: Any, entry_point_name: str) -> AdvisorySourcePluginRegistration:
+    if isinstance(value, AdvisorySourcePluginRegistration):
+        return value
+    fallback = _plugin_capabilities(
+        scan_modes=("advisory_lookup",),
+        data_boundary="advisory_metadata_lookup",
+        required_scopes=("advisory_source_read",),
+        outbound_destinations=(),
+        network_access=False,
+    )
+    name, module = _name_and_module(value, entry_point_name, "advisory source")
+    return AdvisorySourcePluginRegistration(
+        name=name,
+        module=module,
+        capabilities=_coerce_capabilities(value, fallback),
+        source=str(getattr(value, "source", "entry_point")),
+        discover_attr=str(getattr(value, "discover_attr", "discover")),
+        lookup_attr=str(getattr(value, "lookup_attr", "lookup")),
+        sync_attr=str(getattr(value, "sync_attr", "sync")),
+    )
+
+
+def _coerce_runtime_emitter_plugin(value: Any, entry_point_name: str) -> RuntimeEmitterPluginRegistration:
+    if isinstance(value, RuntimeEmitterPluginRegistration):
+        return value
+    fallback = _plugin_capabilities(
+        scan_modes=("runtime_event_emit",),
+        data_boundary="runtime_event_metadata_redacted",
+        required_scopes=("runtime_event_write",),
+        writes=True,
+        guarantees=("operator_enabled", "redacted_payloads"),
+    )
+    name, module = _name_and_module(value, entry_point_name, "runtime emitter")
+    return RuntimeEmitterPluginRegistration(
+        name=name,
+        module=module,
+        capabilities=_coerce_capabilities(value, fallback),
+        source=str(getattr(value, "source", "entry_point")),
+        discover_attr=str(getattr(value, "discover_attr", "discover")),
+        emit_attr=str(getattr(value, "emit_attr", "emit")),
+        flush_attr=str(getattr(value, "flush_attr", "flush")),
+    )
+
+
+def _register_plugin(registry: dict[str, Any], registration: Any) -> None:
+    registry[registration.name] = registration
+
+
+def _load_group(*, group: str, coerce) -> list[Any]:
+    return iter_entry_point_registrations(
+        group=group,
+        coerce=coerce,
+        warnings=_PLUGIN_ENTRYPOINT_WARNINGS,
+        max_entry_points=MAX_PLUGIN_ENTRY_POINTS_PER_GROUP,
+    )
+
+
+def _ensure_plugin_entrypoints_loaded() -> None:
+    global _PLUGIN_ENTRYPOINTS_LOADED
+    if _PLUGIN_ENTRYPOINTS_LOADED:
+        return
+
+    for registration in _load_group(group=MCP_TOOLS_ENTRY_POINT_GROUP, coerce=_coerce_mcp_tool_plugin):
+        _register_plugin(_MCP_TOOL_PLUGINS, registration)
+    for registration in _load_group(group=ADVISORY_SOURCES_ENTRY_POINT_GROUP, coerce=_coerce_advisory_source_plugin):
+        _register_plugin(_ADVISORY_SOURCE_PLUGINS, registration)
+    for registration in _load_group(group=RUNTIME_EMITTERS_ENTRY_POINT_GROUP, coerce=_coerce_runtime_emitter_plugin):
+        _register_plugin(_RUNTIME_EMITTER_PLUGINS, registration)
+
+    _PLUGIN_ENTRYPOINTS_LOADED = True
+
+
+def list_mcp_tool_plugins() -> list[McpToolPluginRegistration]:
+    """Return discovered third-party MCP tool plugin metadata."""
+
+    _ensure_plugin_entrypoints_loaded()
+    return [_MCP_TOOL_PLUGINS[name] for name in sorted(_MCP_TOOL_PLUGINS)]
+
+
+def list_advisory_source_plugins() -> list[AdvisorySourcePluginRegistration]:
+    """Return discovered third-party advisory source plugin metadata."""
+
+    _ensure_plugin_entrypoints_loaded()
+    return [_ADVISORY_SOURCE_PLUGINS[name] for name in sorted(_ADVISORY_SOURCE_PLUGINS)]
+
+
+def list_runtime_emitter_plugins() -> list[RuntimeEmitterPluginRegistration]:
+    """Return discovered third-party runtime emitter plugin metadata."""
+
+    _ensure_plugin_entrypoints_loaded()
+    return [_RUNTIME_EMITTER_PLUGINS[name] for name in sorted(_RUNTIME_EMITTER_PLUGINS)]
+
+
+def plugin_entrypoint_warnings() -> list[str]:
+    """Return sanitized non-fatal plugin entry-point loading warnings."""
+
+    _ensure_plugin_entrypoints_loaded()
+    return list(_PLUGIN_ENTRYPOINT_WARNINGS)
+
+
+def _reset_plugin_entrypoint_registry_for_tests() -> None:
+    _MCP_TOOL_PLUGINS.clear()
+    _ADVISORY_SOURCE_PLUGINS.clear()
+    _RUNTIME_EMITTER_PLUGINS.clear()
+    _PLUGIN_ENTRYPOINT_WARNINGS.clear()
+    global _PLUGIN_ENTRYPOINTS_LOADED
+    _PLUGIN_ENTRYPOINTS_LOADED = False
+
+
+__all__ = [
+    "ADVISORY_SOURCES_ENTRY_POINT_GROUP",
+    "MCP_TOOLS_ENTRY_POINT_GROUP",
+    "MAX_PLUGIN_ENTRY_POINTS_PER_GROUP",
+    "PLUGIN_ENTRY_POINT_GROUPS",
+    "RUNTIME_EMITTERS_ENTRY_POINT_GROUP",
+    "AdvisorySourcePluginRegistration",
+    "McpToolPluginRegistration",
+    "RuntimeEmitterPluginRegistration",
+    "list_advisory_source_plugins",
+    "list_mcp_tool_plugins",
+    "list_runtime_emitter_plugins",
+    "plugin_entrypoint_warnings",
+]

--- a/tests/test_plugin_entrypoints.py
+++ b/tests/test_plugin_entrypoints.py
@@ -1,0 +1,190 @@
+"""Regression tests for bounded plugin entry-point discovery."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agent_bom.extensions import ENTRYPOINTS_ENABLED_ENV, ExtensionCapabilities
+from agent_bom.plugin_entrypoints import (
+    ADVISORY_SOURCES_ENTRY_POINT_GROUP,
+    MAX_PLUGIN_ENTRY_POINTS_PER_GROUP,
+    MCP_TOOLS_ENTRY_POINT_GROUP,
+    RUNTIME_EMITTERS_ENTRY_POINT_GROUP,
+)
+
+
+class FakeEntryPoint:
+    def __init__(self, name: str, loader: Callable[[], Any]) -> None:
+        self.name = name
+        self._loader = loader
+
+    def load(self) -> Any:
+        return self._loader()
+
+
+class FakeEntryPoints(list):
+    def select(self, *, group: str) -> list[FakeEntryPoint]:
+        return [entry_point for entry_point in self if getattr(entry_point, "group", group) == group]
+
+
+def _patch_entry_points(monkeypatch, entries_by_group: dict[str, list[FakeEntryPoint]]) -> None:
+    entries = FakeEntryPoints()
+    for group, group_entries in entries_by_group.items():
+        for entry_point in group_entries:
+            entry_point.group = group
+            entries.append(entry_point)
+    monkeypatch.setattr("agent_bom.extensions.metadata.entry_points", lambda: entries)
+
+
+@pytest.fixture(autouse=True)
+def reset_plugin_entrypoint_registry(monkeypatch):
+    import agent_bom.plugin_entrypoints as plugin_entrypoints
+
+    monkeypatch.delenv(ENTRYPOINTS_ENABLED_ENV, raising=False)
+    plugin_entrypoints._reset_plugin_entrypoint_registry_for_tests()
+    yield
+    monkeypatch.delenv(ENTRYPOINTS_ENABLED_ENV, raising=False)
+    plugin_entrypoints._reset_plugin_entrypoint_registry_for_tests()
+
+
+def test_plugin_entrypoints_are_disabled_by_default(monkeypatch) -> None:
+    import agent_bom.plugin_entrypoints as plugin_entrypoints
+
+    _patch_entry_points(
+        monkeypatch,
+        {
+            MCP_TOOLS_ENTRY_POINT_GROUP: [
+                FakeEntryPoint(
+                    "custom-tool",
+                    lambda: SimpleNamespace(name="custom-tool", module="acme_agent_bom.tools"),
+                )
+            ]
+        },
+    )
+
+    assert plugin_entrypoints.list_mcp_tool_plugins() == []
+    assert plugin_entrypoints.list_advisory_source_plugins() == []
+    assert plugin_entrypoints.list_runtime_emitter_plugins() == []
+    assert plugin_entrypoints.plugin_entrypoint_warnings() == []
+
+
+def test_enabled_plugin_entrypoints_discover_three_groups(monkeypatch) -> None:
+    import agent_bom.plugin_entrypoints as plugin_entrypoints
+
+    monkeypatch.setenv(ENTRYPOINTS_ENABLED_ENV, "true")
+    _patch_entry_points(
+        monkeypatch,
+        {
+            MCP_TOOLS_ENTRY_POINT_GROUP: [
+                FakeEntryPoint(
+                    "posture-tool",
+                    lambda: SimpleNamespace(
+                        name="posture-tool",
+                        module="acme_agent_bom.mcp",
+                        register_attr="install_tools",
+                        capabilities=ExtensionCapabilities(
+                            scan_modes=("mcp_tool",),
+                            required_scopes=("operator_enabled_mcp_tool",),
+                            data_boundary="metadata_only",
+                        ),
+                    ),
+                )
+            ],
+            ADVISORY_SOURCES_ENTRY_POINT_GROUP: [
+                FakeEntryPoint(
+                    "private-feed",
+                    lambda: SimpleNamespace(
+                        name="private-feed",
+                        module="acme_agent_bom.advisories",
+                        lookup_attr="lookup_advisory",
+                        sync_attr="sync_feed",
+                    ),
+                )
+            ],
+            RUNTIME_EMITTERS_ENTRY_POINT_GROUP: [
+                FakeEntryPoint(
+                    "kinesis",
+                    lambda: SimpleNamespace(
+                        name="kinesis",
+                        module="acme_agent_bom.emitters",
+                        emit_attr="put_event",
+                        flush_attr="flush_batch",
+                    ),
+                )
+            ],
+        },
+    )
+
+    mcp_plugins = {plugin.name: plugin for plugin in plugin_entrypoints.list_mcp_tool_plugins()}
+    advisory_plugins = {plugin.name: plugin for plugin in plugin_entrypoints.list_advisory_source_plugins()}
+    emitter_plugins = {plugin.name: plugin for plugin in plugin_entrypoints.list_runtime_emitter_plugins()}
+
+    assert mcp_plugins["posture-tool"].module == "acme_agent_bom.mcp"
+    assert mcp_plugins["posture-tool"].register_attr == "install_tools"
+    assert mcp_plugins["posture-tool"].capabilities.data_boundary == "metadata_only"
+    assert advisory_plugins["private-feed"].lookup_attr == "lookup_advisory"
+    assert advisory_plugins["private-feed"].sync_attr == "sync_feed"
+    assert emitter_plugins["kinesis"].emit_attr == "put_event"
+    assert emitter_plugins["kinesis"].flush_attr == "flush_batch"
+
+
+def test_plugin_entrypoint_failures_are_sanitized_and_non_fatal(monkeypatch) -> None:
+    import agent_bom.plugin_entrypoints as plugin_entrypoints
+
+    monkeypatch.setenv(ENTRYPOINTS_ENABLED_ENV, "1")
+
+    def fail_load() -> Any:
+        raise RuntimeError("failed https://user:tok123@example.com/feed?key=secret from /Users/alice/.agent-bom/plugin.py")
+
+    _patch_entry_points(
+        monkeypatch,
+        {
+            ADVISORY_SOURCES_ENTRY_POINT_GROUP: [
+                FakeEntryPoint("bad-feed", fail_load),
+                FakeEntryPoint(
+                    "good-feed",
+                    lambda: SimpleNamespace(name="good-feed", module="acme_agent_bom.good_feed"),
+                ),
+            ]
+        },
+    )
+
+    advisory_plugins = {plugin.name: plugin for plugin in plugin_entrypoints.list_advisory_source_plugins()}
+    warnings = " ".join(plugin_entrypoints.plugin_entrypoint_warnings())
+
+    assert advisory_plugins["good-feed"].module == "acme_agent_bom.good_feed"
+    assert "bad-feed" in warnings
+    assert "tok123" not in warnings
+    assert "key=secret" not in warnings
+    assert "/Users/alice" not in warnings
+
+
+def test_plugin_entrypoint_loading_is_bounded_per_group(monkeypatch) -> None:
+    import agent_bom.plugin_entrypoints as plugin_entrypoints
+
+    monkeypatch.setenv(ENTRYPOINTS_ENABLED_ENV, "yes")
+    _patch_entry_points(
+        monkeypatch,
+        {
+            RUNTIME_EMITTERS_ENTRY_POINT_GROUP: [
+                FakeEntryPoint(
+                    f"emitter-{index:02d}",
+                    lambda index=index: SimpleNamespace(name=f"emitter-{index:02d}", module=f"acme_agent_bom.emitters_{index}"),
+                )
+                for index in range(MAX_PLUGIN_ENTRY_POINTS_PER_GROUP + 3)
+            ]
+        },
+    )
+
+    emitter_plugins = plugin_entrypoints.list_runtime_emitter_plugins()
+    warnings = " ".join(plugin_entrypoints.plugin_entrypoint_warnings())
+
+    assert len(emitter_plugins) == MAX_PLUGIN_ENTRY_POINTS_PER_GROUP
+    assert emitter_plugins[0].name == "emitter-00"
+    assert emitter_plugins[-1].name == f"emitter-{MAX_PLUGIN_ENTRY_POINTS_PER_GROUP - 1:02d}"
+    assert "loading first" in warnings
+    assert RUNTIME_EMITTERS_ENTRY_POINT_GROUP in warnings


### PR DESCRIPTION
Summary
- add opt-in plugin entrypoint registries for MCP tools, advisory sources, and runtime emitters
- expose typed loader helpers with metadata, capability normalization, and sanitized warnings
- document authoring contracts and preserve extension loading behind AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS

Verification
- uv run pytest -q tests/test_plugin_entrypoints.py tests/test_entrypoint_registries.py tests/test_scanner_driver_registry.py
- uv run ruff check src/agent_bom/extensions.py src/agent_bom/plugin_entrypoints.py tests/test_plugin_entrypoints.py
- uv run mypy src/agent_bom/extensions.py src/agent_bom/plugin_entrypoints.py
- git diff --check
- python scripts/check_release_consistency.py
- uv run agent-bom agents --demo --offline