### PR TITLE
feat(runtime): scope gateway rate limits by source agent

### DIFF
--- a/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
+++ b/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
@@ -470,7 +470,7 @@ curl -X POST https://agent-bom.example.com/v1/gateway/policies \
 Evaluated by the same code on every enforcement point:
 [`proxy_policy.py:check_policy`](../src/agent_bom/proxy_policy.py) (line 144).
 
-For the central gateway itself, tenant-scoped runtime throttling is now a separate deploy-time control from the policy bundle. Set `AGENT_BOM_GATEWAY_RATE_LIMIT_PER_TENANT_PER_MINUTE` (or `agent-bom gateway serve --runtime-rate-limit-per-tenant-per-minute <n>`) to bound relay volume per tenant, and pair it with Postgres-backed shared state in multi-replica deployments so limits are not multiplied by pod count.
+For the central gateway itself, runtime throttling is now a separate deploy-time control from the policy bundle. Set `AGENT_BOM_GATEWAY_RATE_LIMIT_PER_TENANT_PER_MINUTE` (or `agent-bom gateway serve --runtime-rate-limit-per-tenant-per-minute <n>`) to bound relay volume per tenant and source-agent bucket. Requests without a valid `_meta.agent_identity` share the tenant-local `anonymous` bucket unless the policy requires identity. Multi-replica deployments should pair the limiter with Postgres-backed shared state so limits are not multiplied by pod count.
 
 ### 6.6 Day-3 evidence for the auditor
 

--- a/docs/OBSERVABILITY_METRICS.md
+++ b/docs/OBSERVABILITY_METRICS.md
@@ -45,7 +45,7 @@ is a credential-spray signal. Page on sustained > 10/min.
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
-| `agent_bom_rate_limit_hits_total` | counter | `bucket` ∈ {global, tenant, ingress, fleet_sync} | Requests rejected by a rate limiter |
+| `agent_bom_rate_limit_hits_total` | counter | `bucket` ∈ {global, tenant, gateway_source_agent, ingress, fleet_sync} | Requests rejected by a rate limiter |
 
 **SLO sketch:** `rate(agent_bom_rate_limit_hits_total{bucket="tenant"}[5m]) > 1`
 for a single tenant for > 10 min means the tenant is mis-configured or

--- a/docs/design/MULTI_MCP_GATEWAY.md
+++ b/docs/design/MULTI_MCP_GATEWAY.md
@@ -23,7 +23,7 @@ One FastAPI service that:
 2. Routes each client connection to one of N configured upstream MCP servers (local or remote), keyed by server name.
 3. Applies gateway policy (from the existing `/v1/gateway/policies` store) inline, on every `tools/call`, `tools/list`, `resources/read`, `prompts/get`.
 4. Pushes every call into the existing HMAC-chained audit log via the existing `/v1/proxy/audit` contract.
-5. Exposes per-upstream and per-tenant metrics on the existing `/metrics` endpoint.
+5. Exposes per-upstream, per-tenant, and source-agent rate-limit metrics on the existing `/metrics` endpoint.
 
 Non-goals (explicitly):
 
@@ -142,7 +142,7 @@ Net new code:
 
 ## Security guarantees
 
-- **Tenant isolation** — every upstream request carries the authenticated tenant's context; per-tenant rate limits + audit scoping (same path as the main API).
+- **Tenant isolation** — every upstream request carries the authenticated tenant's context; runtime rate limits are tenant-scoped and split by source-agent identity, with tenant-local `anonymous` buckets for calls that do not present `_meta.agent_identity`.
 - **mTLS-ready** — gateway accepts a client cert at ingress for zero-trust environments; upstream TLS verification is mandatory (not optional like current proxy dev-mode).
 - **No credential forwarding** — per-upstream credentials are injected by the gateway, never read from the client request. This is the whole point of putting a gateway in front: the laptop doesn't hold the Jira token.
 - **Audit non-repudiation** — gateway calls are signed with the same Ed25519 key path the compliance bundle uses ([`docs/COMPLIANCE_SIGNING.md`](../COMPLIANCE_SIGNING.md)).

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -879,7 +879,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 "Gateway identity policy blocked request for upstream=%s tenant_id=%s source_agent=%s reason=%s",
                 upstream.name,
                 tenant_id,
-                source_agent,
+                _sanitize_for_log(source_agent),
                 _sanitize_for_log(identity_block_reason),
             )
             if settings.audit_sink is not None:

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -43,6 +43,7 @@ from typing import Any, Awaitable, Callable
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, Response
 
+from agent_bom.agent_identity import ANONYMOUS, check_identity
 from agent_bom.api.auth import Role, get_key_store
 from agent_bom.api.metrics import record_gateway_relay, record_rate_limit_hit
 from agent_bom.api.middleware import InMemoryRateLimitStore, PostgresRateLimitStore
@@ -285,15 +286,20 @@ def _gateway_rate_limit_runtime_status(settings: GatewaySettings) -> dict[str, o
             "Gateway runtime rate limiting disabled."
             if not enabled
             else (
-                "Gateway runtime rate limiting uses Postgres-backed shared state across replicas."
+                "Gateway runtime rate limiting uses Postgres-backed per-source-agent state across replicas."
                 if postgres_configured
                 else (
-                    "Gateway runtime rate limiting is process-local because the gateway is configured "
-                    "for a single replica. Multi-replica deployments must configure AGENT_BOM_POSTGRES_URL."
+                    "Gateway runtime rate limiting is per-source-agent and process-local because the gateway "
+                    "is configured for a single replica. Multi-replica deployments must configure AGENT_BOM_POSTGRES_URL."
                 )
             )
         ),
     }
+
+
+def _rate_limit_bucket_component(value: str) -> str:
+    component = _sanitize_for_log(value).strip() or ANONYMOUS
+    return component.replace(":", "_")[:160]
 
 
 def _request_has_expected_token(request: Request, expected_token: str) -> bool:
@@ -862,10 +868,47 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
 
         # Inline policy check — reuse the exact evaluator the per-MCP proxy uses.
         tenant_id = getattr(request.state, "tenant_id", None) or "default"
+        async with policy_lock:
+            current_policy = dict(policy_state["policy"])
+
+        source_agent, identity_block_reason = check_identity(message, current_policy)
+        source_agent = source_agent or ANONYMOUS
+        if identity_block_reason is not None:
+            record_gateway_relay(upstream.name, "blocked")
+            logger.info(
+                "Gateway identity policy blocked request for upstream=%s tenant_id=%s source_agent=%s reason=%s",
+                upstream.name,
+                tenant_id,
+                source_agent,
+                _sanitize_for_log(identity_block_reason),
+            )
+            if settings.audit_sink is not None:
+                await settings.audit_sink(
+                    {
+                        "action": "gateway.identity_blocked",
+                        "upstream": upstream.name,
+                        "tenant_id": tenant_id,
+                        "source_agent": source_agent,
+                        "reason": identity_block_reason,
+                    }
+                )
+            return JSONResponse(
+                {
+                    "jsonrpc": "2.0",
+                    "id": message.get("id"),
+                    "error": {
+                        "code": -32001,
+                        "message": "Blocked by agent-bom gateway identity policy",
+                        "data": {"reason": "Identity validation failed"},
+                    },
+                },
+                status_code=200,
+            )
+
         rate_limit_headers: dict[str, str] = {}
         if rate_limit_store is not None:
             now = time.time()
-            bucket = f"gateway:tenant:{tenant_id}"
+            bucket = f"gateway:tenant:{_rate_limit_bucket_component(tenant_id)}:source_agent:{_rate_limit_bucket_component(source_agent)}"
             hit_count, reset_at = await asyncio.to_thread(rate_limit_store.hit, bucket, now)
             limit = settings.runtime_rate_limit_per_tenant_per_minute
             remaining = max(0, limit - hit_count)
@@ -877,21 +920,22 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             if hit_count > limit:
                 retry_after = max(int(reset_at - now), 1)
                 record_gateway_relay(upstream.name, "rate_limited")
-                record_rate_limit_hit("gateway_tenant")
+                record_rate_limit_hit("gateway_source_agent")
                 if settings.audit_sink is not None:
                     await settings.audit_sink(
                         {
                             "action": "gateway.rate_limited",
                             "upstream": upstream.name,
                             "tenant_id": tenant_id,
+                            "source_agent": source_agent,
                             "limit": limit,
                             "bucket": bucket,
-                            "reason": "tenant_runtime_rate_limit",
+                            "reason": "source_agent_runtime_rate_limit",
                         }
                     )
                 return JSONResponse(
                     status_code=429,
-                    content={"detail": "Gateway tenant rate limit exceeded"},
+                    content={"detail": "Gateway source-agent rate limit exceeded"},
                     headers={
                         **rate_limit_headers,
                         "Retry-After": str(retry_after),
@@ -901,8 +945,6 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         policy_subject = policy_subject_from_message(message)
         if policy_subject:
             tool_name, arguments = policy_subject
-            async with policy_lock:
-                current_policy = dict(policy_state["policy"])
             allowed, reason = check_policy(current_policy, tool_name, arguments)
             if not allowed:
                 record_gateway_relay(upstream.name, "blocked")

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -1739,7 +1739,11 @@ async def run_proxy(
                     if rate_limit_threshold > 0:
                         effective_rule_rate_limit = rate_limit_threshold
                     if rate_tracker and effective_rule_rate_limit > 0:
-                        rate_alerts = rate_tracker.record(tool_name, threshold=effective_rule_rate_limit)
+                        rate_alerts = rate_tracker.record(
+                            tool_name,
+                            threshold=effective_rule_rate_limit,
+                            source_agent=agent_id or "anonymous",
+                        )
                         await _handle_alerts(rate_alerts, log_file)
                         if rate_alerts and not log_only:
                             rl_reason = rate_alerts[0].message

--- a/src/agent_bom/runtime/detectors.py
+++ b/src/agent_bom/runtime/detectors.py
@@ -373,9 +373,9 @@ class CredentialLeakDetector:
 class RateLimitTracker:
     """Track tool call rates and block on excessive usage.
 
-    Uses a sliding window to track calls per tool. When any tool exceeds
-    the threshold, returns a CRITICAL alert with ``blocked=True`` so the
-    caller can enforce the rate limit (zero trust — deny by default).
+    Uses a sliding window to track calls per source-agent and tool. When any
+    bucket exceeds the threshold, returns a CRITICAL alert with
+    ``blocked=True`` so the caller can enforce the rate limit.
     """
 
     def __init__(self, threshold: int = 50, window_seconds: float = 60.0) -> None:
@@ -383,7 +383,7 @@ class RateLimitTracker:
         self._window = window_seconds
         self._calls: dict[str, deque[float]] = {}
 
-    def record(self, tool_name: str, threshold: int | None = None) -> list[Alert]:
+    def record(self, tool_name: str, threshold: int | None = None, source_agent: str | None = None) -> list[Alert]:
         """Record a tool call and check rate limits.
 
         Returns a CRITICAL alert with ``details.blocked = True`` when the
@@ -393,10 +393,12 @@ class RateLimitTracker:
         if effective_threshold <= 0:
             return []
         now = time.monotonic()
-        if tool_name not in self._calls:
-            self._calls[tool_name] = deque()
+        agent_bucket = (source_agent or "anonymous").strip() or "anonymous"
+        bucket = f"{agent_bucket}:{tool_name}"
+        if bucket not in self._calls:
+            self._calls[bucket] = deque()
 
-        q = self._calls[tool_name]
+        q = self._calls[bucket]
         q.append(now)
 
         # Prune old entries
@@ -415,6 +417,8 @@ class RateLimitTracker:
                     message=f"Rate limit exceeded: {tool_name} called {len(q)} times in {self._window}s (threshold: {effective_threshold})",
                     details={
                         "tool": tool_name,
+                        "source_agent": agent_bucket,
+                        "bucket": bucket,
                         "count": len(q),
                         "threshold": effective_threshold,
                         "window_seconds": self._window,

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -639,7 +639,7 @@ def test_gateway_rate_limit_is_tenant_scoped(monkeypatch) -> None:
         json=_json_rpc("tools/call", name="read_file", arguments={"path": "/etc/hosts"}),
     )
     assert second.status_code == 429
-    assert second.json()["detail"] == "Gateway tenant rate limit exceeded"
+    assert second.json()["detail"] == "Gateway source-agent rate limit exceeded"
 
     other_tenant = client.post(
         "/mcp/filesystem",
@@ -709,7 +709,87 @@ def test_gateway_rate_limit_shared_store_holds_under_concurrency(monkeypatch) ->
             statuses = list(executor.map(lambda _idx: _post(), range(2)))
 
     assert sorted(statuses) == [200, 429]
-    assert shared_store.counts == {"gateway:tenant:tenant-alpha": 2}
+    assert shared_store.counts == {"gateway:tenant:tenant-alpha:source_agent:anonymous": 2}
+
+
+def test_gateway_rate_limit_is_source_agent_scoped_within_tenant(monkeypatch) -> None:
+    class _FakeKeyStore:
+        def has_keys(self) -> bool:
+            return True
+
+        def verify(self, raw_key: str):
+            if raw_key == "tenant-alpha-key":
+                return _gateway_api_key("tenant-alpha")
+            return None
+
+    monkeypatch.setattr("agent_bom.gateway_server.get_key_store", lambda: _FakeKeyStore())
+
+    async def fake_caller(upstream, message, extra_headers):
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={"agent_tokens": {"token-a": "agent-a", "token-b": "agent-b"}},
+        upstream_caller=fake_caller,
+        runtime_rate_limit_per_tenant_per_minute=1,
+    )
+    client = TestClient(create_gateway_app(settings))
+
+    agent_a = _json_rpc(
+        "tools/call",
+        name="read_file",
+        arguments={"path": "/etc/hosts"},
+        _meta={"agent_identity": "token-a"},
+    )
+    agent_b = _json_rpc(
+        "tools/call",
+        name="read_file",
+        arguments={"path": "/etc/hosts"},
+        _meta={"agent_identity": "token-b"},
+    )
+
+    first_a = client.post("/mcp/filesystem", headers={"X-API-Key": "tenant-alpha-key"}, json=agent_a)
+    assert first_a.status_code == 200
+    first_b = client.post("/mcp/filesystem", headers={"X-API-Key": "tenant-alpha-key"}, json=agent_b)
+    assert first_b.status_code == 200
+
+    second_a = client.post("/mcp/filesystem", headers={"X-API-Key": "tenant-alpha-key"}, json=agent_a)
+    assert second_a.status_code == 429
+    assert second_a.json()["detail"] == "Gateway source-agent rate limit exceeded"
+
+
+def test_gateway_rate_limit_identity_required_blocks_before_relay(monkeypatch) -> None:
+    class _FakeKeyStore:
+        def has_keys(self) -> bool:
+            return True
+
+        def verify(self, raw_key: str):
+            if raw_key == "tenant-alpha-key":
+                return _gateway_api_key("tenant-alpha")
+            return None
+
+    monkeypatch.setattr("agent_bom.gateway_server.get_key_store", lambda: _FakeKeyStore())
+
+    async def fake_caller(upstream, message, extra_headers):
+        raise AssertionError("identity-blocked calls must not relay upstream")
+
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={"require_agent_identity": True},
+        upstream_caller=fake_caller,
+        runtime_rate_limit_per_tenant_per_minute=1,
+    )
+    client = TestClient(create_gateway_app(settings))
+
+    response = client.post(
+        "/mcp/filesystem",
+        headers={"X-API-Key": "tenant-alpha-key"},
+        json=_json_rpc("tools/call", name="read_file", arguments={"path": "/etc/hosts"}),
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["error"]["message"] == "Blocked by agent-bom gateway identity policy"
+    assert payload["error"]["data"]["reason"] == "Identity validation failed"
 
 
 def test_gateway_rate_limit_can_require_shared_backend(monkeypatch) -> None:

--- a/tests/test_runtime_detectors.py
+++ b/tests/test_runtime_detectors.py
@@ -332,6 +332,30 @@ def test_rate_limit_different_tools_independent():
     assert len(alerts2) == 1  # tool2 hit 3
 
 
+def test_rate_limit_different_source_agents_independent():
+    r = RateLimitTracker(threshold=2, window_seconds=60.0)
+    assert r.record("tool1", source_agent="agent-a") == []
+    assert r.record("tool1", source_agent="agent-b") == []
+
+    alerts_a = r.record("tool1", source_agent="agent-a")
+    assert len(alerts_a) == 1
+    assert alerts_a[0].details["source_agent"] == "agent-a"
+    assert alerts_a[0].details["bucket"] == "agent-a:tool1"
+
+    alerts_b = r.record("tool1", source_agent="agent-b")
+    assert len(alerts_b) == 1
+    assert alerts_b[0].details["source_agent"] == "agent-b"
+
+
+def test_rate_limit_missing_source_agent_uses_anonymous_bucket():
+    r = RateLimitTracker(threshold=2, window_seconds=60.0)
+    assert r.record("tool1") == []
+    alerts = r.record("tool1")
+    assert len(alerts) == 1
+    assert alerts[0].details["source_agent"] == "anonymous"
+    assert alerts[0].details["bucket"] == "anonymous:tool1"
+
+
 def test_rate_limit_properties():
     r = RateLimitTracker(threshold=10, window_seconds=30.0)
     assert r.threshold == 10


### PR DESCRIPTION
Summary
- scope runtime proxy rate buckets by source-agent plus tool, with anonymous fallback
- scope gateway relay limits by tenant plus source-agent so one caller cannot exhaust a tenant-wide bucket
- preserve fail-closed shared limiter behavior and document the new gateway_source_agent metric bucket

Verification
- uv run pytest -q tests/test_runtime_detectors.py tests/test_gateway_server.py
- uv run ruff check src/agent_bom/runtime/detectors.py src/agent_bom/proxy.py src/agent_bom/gateway_server.py tests/test_runtime_detectors.py tests/test_gateway_server.py
- uv run mypy src/agent_bom/runtime/detectors.py src/agent_bom/gateway_server.py
- git diff --check origin/main...HEAD
- python scripts/check_release_consistency.py

Notes
- Gateway requests without valid _meta.agent_identity share a tenant-local anonymous bucket unless policy requires identity.