### PR TITLE
feat(mcp): add audited Shield write tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,13 +150,15 @@ integration docs instead of this front door.
 |---|---|---|
 | CLI / CI | developers and release gates | local scans, SARIF/SBOM/HTML/JSON, deterministic exit codes |
 | REST API | control-plane integrations | scans, bulk findings, dataset versions, graph evidence, audit, runtime summaries |
-| MCP tools | agents and assistants | strict arguments, read-only security queries, exposure paths, deploy decisions |
+| MCP tools | agents and assistants | strict arguments, read-mostly security queries, exposure paths, deploy decisions, audited Shield actions |
 | Dashboard | security teams and operators | inventory, findings, graph cockpit, compliance, evidence, runtime posture |
 | Runtime proxy/gateway | runtime operators | scoped MCP traffic inspection, policy decisions, redacted audit evidence |
 | Python client | services, notebooks, and automation | typed helper for stable REST endpoints in the packaged wheel |
 | TypeScript client | services and agent runtimes | typed helper for stable REST endpoints |
 
-MCP server mode advertises 51 read-only security tools, 6 resources, and 6 workflow prompts.
+MCP server mode advertises 54 MCP tools, 6 resources, and 6 workflow prompts.
+Most tools are read-only. The three Shield write actions fail closed unless
+the caller supplies `operator_role=admin` and an audit reason.
 
 CLI scan commands run local scan pipelines today. They share lower scanner and
 discovery libraries with the API, but they are not API wrappers yet.

--- a/docs/CLAUDE_INTEGRATION.md
+++ b/docs/CLAUDE_INTEGRATION.md
@@ -59,7 +59,7 @@ claude mcp add agent-bom -- uvx agent-bom mcp server
 
 ## What users get inside Claude
 
-`agent-bom mcp server` exposes 51 read-only tools for:
+`agent-bom mcp server` exposes 54 MCP tools for:
 
 - agent and MCP discovery
 - package and registry checks
@@ -68,6 +68,7 @@ claude mcp add agent-bom -- uvx agent-bom mcp server
 - skills scanning and trust
 - SBOM generation
 - runtime and tool-risk queries
+- admin-gated Shield actions with an audit reason
 
 ## Scan Claude environments directly
 

--- a/docs/CODEX_CLI.md
+++ b/docs/CODEX_CLI.md
@@ -20,7 +20,7 @@ command = "agent-bom"
 args = ["mcp", "server"]
 ```
 
-That makes the same 51 read-only `agent-bom` MCP tools available to Codex.
+That makes the same 54 `agent-bom` MCP tools available to Codex.
 
 ## What agent-bom discovers for Codex
 
@@ -75,7 +75,7 @@ That gives you:
 
 Important boundary:
 
-- `agent-bom mcp server` is read-only
+- `agent-bom mcp server` is read-mostly; Shield write actions require admin role and audit reason
 - `agent-bom agents` is read-only
 - `agent-bom proxy` intentionally runs the wrapped stdio server so it can enforce policy on live traffic
 
@@ -83,7 +83,7 @@ For deeper protection workflows beyond the lighter proxy path, use the broader r
 
 ## Notes
 
-- `agent-bom mcp server` is read-only.
+- `agent-bom mcp server` is read-mostly.
 - `agent-bom proxy` is the runtime enforcement path.
 - Codex TOML configs support both local stdio and remote URL-based MCP servers, but only stdio targets can be wrapped with the local proxy command pattern.
 - See [MCP_CLIENT_GUIDES.md](MCP_CLIENT_GUIDES.md) for the broader client matrix.

--- a/docs/CORTEX_CODE.md
+++ b/docs/CORTEX_CODE.md
@@ -111,6 +111,6 @@ For cross-agent correlation across sessions, use the broader runtime protection 
 ## Notes
 
 - `agent-bom` does not need write access to the target MCP server to scan it.
-- MCP server mode is read-only.
+- MCP server mode is read-mostly; Shield write actions require admin role and an audit reason.
 - Proxy mode is opt-in and is the path for runtime enforcement.
 - See [MCP_CLIENT_GUIDES.md](MCP_CLIENT_GUIDES.md) for the broader client matrix, [MCP_SERVER.md](MCP_SERVER.md) for the MCP tool catalog, and [RUNTIME_MONITORING.md](RUNTIME_MONITORING.md) for deployment details.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -150,7 +150,7 @@ An agent operating autonomously can be steered into a multi-step exfiltration se
 │  2. PROXY         Sits between client and server, intercepts     │
 │     (agent-bom proxy) every JSON-RPC message, enforces policy    │
 │                                                                  │
-│  3. MCP SERVER    Exposes 51 scan/governance tools to any agent  │
+│  3. MCP SERVER    Exposes 54 scan/governance tools to any agent  │
 │     (agent-bom mcp server)  — scan, check, registry, compliance  │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -210,7 +210,10 @@ For cross-agent correlation, use the broader runtime protection engine (`agent-b
 agent-bom mcp server
 ```
 
-Exposes 51 tools to any MCP-compatible AI assistant. Your agent can run scans, check packages, query ExposurePaths, ask for deploy decisions, query threat intel, inspect runtime posture, and generate compliance reports without leaving the chat:
+Exposes 54 tools to any MCP-compatible AI assistant. Your agent can run scans,
+check packages, query ExposurePaths, ask for deploy decisions, query threat
+intel, inspect runtime posture, run admin-gated Shield actions, and generate
+compliance reports without leaving the chat:
 
 ```
 scan                — full discovery + scan, returns JSON report

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,8 +1,9 @@
 # MCP Server — Connect agent-bom to AI Assistants
 
-agent-bom exposes 51 security tools as an MCP server. Any MCP-compatible client
-can connect and get vulnerability scanning, blast radius analysis, compliance
-checks, and supply chain verification through natural conversation.
+agent-bom exposes 54 MCP tools as an MCP server. Any MCP-compatible client can
+connect and get vulnerability scanning, blast radius analysis, compliance
+checks, runtime posture, and supply-chain verification through natural
+conversation.
 
 See also:
 
@@ -56,7 +57,7 @@ Add to `~/.snowflake/cortex/mcp.json`:
 }
 ```
 
-CoCo can then call the same 51 `agent-bom` tools over MCP.
+CoCo can then call the same 54 `agent-bom` tools over MCP.
 
 agent-bom also discovers Cortex auxiliary security files alongside `mcp.json`:
 
@@ -155,7 +156,7 @@ agent-bom proxy-bootstrap \
 
 `proxy-configure` is best for JSON MCP clients such as Claude Desktop, Cursor, Windsurf, and Cortex CoCo. TOML-based clients like Codex CLI need manual proxy wrapping.
 
-## Tool Categories (51 tools)
+## Tool Categories (54 tools)
 
 | Category | Tools | What They Do |
 |----------|-------|-------------|
@@ -168,7 +169,7 @@ agent-bom proxy-bootstrap \
 | **Inventory** | `inventory` | List agents/servers without CVE scanning |
 | **Trust** | `marketplace_check`, `runtime_correlate`, `tool_risk_assessment` | Score package trust, correlate runtime usage, and assess live tool capability risk |
 | **Skills** | `skill_scan`, `skill_verify`, `skill_trust` | Instruction-file trust, provenance, and tool-poisoning detection |
-| **Graph / Runtime** | `exposure_paths`, `should_i_deploy`, `context_graph`, `graph_export`, `runtime_correlate`, `runtime_production_index`, `runtime_blueprints`, `runtime_blueprint_drift`, `proxy_status`, `proxy_alerts`, `gateway_status`, `shield_status`, `firewall_check`, `audit_query`, `audit_integrity`, `tool_risk_assessment` | Return ranked investigation paths, deploy decisions, graph exports, runtime posture, blueprints, drift checks, proxy alerts, audit-chain evidence, and read-only firewall decisions |
+| **Graph / Runtime** | `exposure_paths`, `should_i_deploy`, `context_graph`, `graph_export`, `runtime_correlate`, `runtime_production_index`, `runtime_blueprints`, `runtime_blueprint_drift`, `proxy_status`, `proxy_alerts`, `gateway_status`, `shield_status`, `shield_start`, `shield_unblock`, `shield_break_glass`, `firewall_check`, `audit_query`, `audit_integrity`, `tool_risk_assessment` | Return ranked investigation paths, deploy decisions, graph exports, runtime posture, blueprints, drift checks, proxy alerts, audit-chain evidence, read-only firewall decisions, and audited Shield actions |
 | **AI supply chain** | `dataset_card_scan`, `training_pipeline_scan`, `browser_extension_scan`, `model_provenance_scan`, `prompt_scan`, `model_file_scan`, `ingest_external_scan` | Scan AI artifacts, prompts, model files, browser extensions, and external scanner results |
 
 ## Agent-facing decision tools
@@ -204,7 +205,9 @@ live runtime traffic rather than static reachability.
 
 ## Security Model
 
-- **Read-only**: Only List/Describe/Get operations. Zero write calls.
+- **Read-mostly**: scanner, graph, audit, and posture tools are read-only.
+  Shield write tools require `operator_role=admin` plus a reason and are
+  audit-logged.
 - **No credential storage**: Never stores, logs, or transmits your credentials.
 - **No network exfiltration**: Scans local configs, queries public CVE databases.
 - **Agentless**: No agents installed on targets.

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -86,10 +86,10 @@ every API/UI workflow.
 Integrations should be described as distribution and workflow fit, not as a
 miscellaneous compatibility list. The strongest story is:
 
-- **coding agents and MCP clients**: Claude, Cursor, Windsurf, VS Code, Cortex
-  Code, OpenAI Codex CLI, and similar clients can invoke agent-bom as a
-  read-only security tool surface, including `exposure_paths` and
-  `should_i_deploy` for headless investigation and deploy guidance.
+- **coding agents and MCP clients**: supported clients can invoke agent-bom as
+  a read-mostly security tool surface, including `exposure_paths` and
+  `should_i_deploy` for headless investigation and deploy guidance. Shield
+  write actions require admin role and audit reason.
 - **skills and registries**: OpenClaw skills, Cortex Code skill packaging, MCP
   Registry, Smithery, Glama, and Docker MCP registry make repeatable
   agent-bom workflows available where agent users already discover tools.
@@ -127,7 +127,7 @@ notes discuss agent-native product direction.
 | Area | Shipped today | Not yet shipped |
 |---|---|---|
 | Human cockpit | Next.js dashboard, graph cockpit, reports, compliance and audit views | every UI action backed by a source registry and persisted workflow state |
-| Agent interface | 51 read-only MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture | long-lived posture subscription tool, autonomous remediation actions |
+| Agent interface | 54 MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture, admin-gated Shield actions | long-lived posture subscription tool, autonomous remediation actions |
 | Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports, TypeScript control-plane client, TypeScript runtime detector package | Python/Go control-plane SDKs and full scanner SDKs |
 | Runtime | MCP proxy, gateway, Shield SDK, runtime audit and policy decisions | webhook outbox, Kafka connectors, cloud-log ingestion connectors, Kinesis/Firehose adapter, and MCP posture subscriptions |
 | Graph scale | SQLite/Postgres default path, WebGL overview, optional Neptune adapter work | production Neptune SLOs, public openCypher endpoint, mandatory graph-database backend |

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,10 +1,10 @@
 {
-  "generated_on": "2026-05-21",
+  "generated_on": "2026-05-22",
   "version": "0.88.1",
   "metrics": [
     {
       "name": "MCP tools",
-      "value": 51,
+      "value": 54,
       "source": "src/agent_bom/mcp_server_metadata.py",
       "notes": "Counted from the advertised server-card tools."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,12 +5,12 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-05-21`
+- Generated on: `2026-05-22`
 - Version: `0.88.1`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |
-| MCP tools | 51 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
+| MCP tools | 54 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 35 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |

--- a/integrations/docker-mcp-registry/tools.json
+++ b/integrations/docker-mcp-registry/tools.json
@@ -282,6 +282,37 @@
     ]
   },
   {
+    "name": "shield_start",
+    "description": "Start Shield enforcement for a session; requires admin role and an audit reason.",
+    "arguments": [
+      {"name": "session_id", "type": "string", "desc": "Shield session id to enforce"},
+      {"name": "correlation_window", "type": "number", "desc": "Correlation window in seconds"},
+      {"name": "operator_role", "type": "string", "desc": "Caller role; must be admin"},
+      {"name": "reason", "type": "string", "desc": "Audit reason for the write action"},
+      {"name": "tenant_id", "type": "string", "desc": "Tenant scope for audit logging"}
+    ]
+  },
+  {
+    "name": "shield_unblock",
+    "description": "Unblock Shield enforcement for a session; requires admin role and an audit reason.",
+    "arguments": [
+      {"name": "session_id", "type": "string", "desc": "Shield session id to unblock"},
+      {"name": "operator_role", "type": "string", "desc": "Caller role; must be admin"},
+      {"name": "reason", "type": "string", "desc": "Audit reason for the write action"},
+      {"name": "tenant_id", "type": "string", "desc": "Tenant scope for audit logging"}
+    ]
+  },
+  {
+    "name": "shield_break_glass",
+    "description": "Emergency Shield override; requires admin role and an audit reason.",
+    "arguments": [
+      {"name": "session_id", "type": "string", "desc": "Shield session id to override"},
+      {"name": "operator_role", "type": "string", "desc": "Caller role; must be admin"},
+      {"name": "reason", "type": "string", "desc": "Audit reason for the emergency override"},
+      {"name": "tenant_id", "type": "string", "desc": "Tenant scope for audit logging"}
+    ]
+  },
+  {
     "name": "firewall_check",
     "description": "Dry-run an inter-agent firewall decision without recording control-plane state.",
     "arguments": [

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -398,7 +398,7 @@ def main() -> int:
     tools = len(tool_names)
     resources = len(resource_uris)
     prompts = len(prompt_names)
-    if (tools, resources, prompts) != (51, 6, 6):
+    if (tools, resources, prompts) != (54, 6, 6):
         _fail(f"MCP server card count changed unexpectedly: tools={tools}, resources={resources}, prompts={prompts}")
     docker_mcp_tool_names = [str(tool["name"]) for tool in json.loads(DOCKER_MCP_TOOLS.read_text())]
     if docker_mcp_tool_names != tool_names:
@@ -407,7 +407,7 @@ def main() -> int:
         _fail(f"integrations/docker-mcp-registry/tools.json is out of sync with MCP server-card tools: missing={missing}, extra={extra}")
     for path in MCP_COUNT_DOCS:
         text = path.read_text()
-        readme_count_phrase = f"{tools} read-only security tools, {resources} resources, and {prompts} workflow prompts"
+        readme_count_phrase = f"{tools} MCP tools, {resources} resources, and {prompts} workflow prompts"
         if path.name == "README.md" and readme_count_phrase not in text:
             _fail("README.md must advertise current MCP tool/resource/prompt counts")
         if path.name == "MCP_SERVER.md" and f"Tool Categories ({tools} tools)" not in text:

--- a/site-docs/architecture/how-agent-bom-works.md
+++ b/site-docs/architecture/how-agent-bom-works.md
@@ -235,7 +235,7 @@ Mode matters.
 | Mode | Execution posture |
 |---|---|
 | Scanner mode | read-only discovery and analysis |
-| MCP server mode | read-only tool surface |
+| MCP server mode | read-mostly tool surface; Shield write actions require admin role and audit reason |
 | Proxy mode | live execution and enforcement boundary |
 
 Guardrails include:

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -64,7 +64,7 @@ Everything else in the deployment section is reference material.
 | **API + UI** | self-hosted pilots and production | auth, RBAC, tenant scope, graph, remediation, audit, policy |
 | **Proxy** | selected local or sidecar MCPs | inline local MCP inspection, policy decisions, signed audit events |
 | **Gateway** | shared remote MCP traffic | central remote MCP relay, policy distribution, audit events |
-| **MCP server mode** | agent-invoked scanning | exposes `agent-bom` as read-only MCP tools, resources, and prompts |
+| **MCP server mode** | agent-invoked scanning | exposes `agent-bom` as read-mostly MCP tools, resources, and prompts |
 
 Default rollout: deploy API + UI with Postgres, add scans and fleet sync, then
 add proxy or gateway only where runtime enforcement is worth the extra operating

--- a/site-docs/features/runtime-proxy.md
+++ b/site-docs/features/runtime-proxy.md
@@ -5,7 +5,7 @@ The `agent-bom proxy` command sits between MCP clients and servers, intercepting
 Important boundary:
 
 - scanner mode is read-only
-- MCP server mode is read-only
+- MCP server mode is read-mostly; Shield write actions require admin role and an audit reason
 - proxy mode intentionally executes the wrapped stdio server or connects to the remote SSE/HTTP server so it can enforce policy on live traffic
 
 ## Architecture

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -1,8 +1,10 @@
 # MCP Server Setup
 
-agent-bom runs as an MCP server, exposing 51 read-only security tools to any MCP client.
+agent-bom runs as an MCP server, exposing 54 MCP tools to any MCP client.
 The server card also advertises 6 resources and 6 workflow prompts so agents can
 choose structured playbooks instead of guessing tool order.
+Most tools are read-only. Shield write actions require `operator_role=admin`
+and an audit reason.
 
 ## Local (stdio)
 
@@ -135,6 +137,9 @@ Connect with:
 | `proxy_alerts` | Recent tenant-scoped runtime proxy alerts |
 | `gateway_status` | Gateway policy and inter-agent firewall runtime statistics |
 | `shield_status` | Shield session status without changing enforcement |
+| `shield_start` | Start Shield enforcement with admin role and audit reason |
+| `shield_unblock` | Unblock Shield enforcement with admin role and audit reason |
+| `shield_break_glass` | Emergency Shield override with admin role and audit reason |
 | `firewall_check` | Read-only inter-agent firewall decision dry run |
 | `audit_query` | Tenant-scoped control-plane audit records |
 | `audit_integrity` | Control-plane and runtime audit-chain verification |

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -46,7 +46,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 | **Local AI BOM** | `agent-bom agents --demo --offline` | terminal findings and graph-ready inventory |
 | **Repository scan** | `agent-bom agents -p . -f html -o agent-bom-report.html` | local HTML review plus exportable evidence |
 | **CI evidence** | `uses: msaad00/agent-bom@v0.88.1` | SARIF, pull-request summary, optional code scanning |
-| **Assistant tools** | `agent-bom mcp server` | read-only security tools for MCP clients |
+| **Assistant tools** | `agent-bom mcp server` | read-mostly security tools for MCP clients |
 | **Self-hosted control plane** | `docker compose -f docker-compose.pilot.yml up -d` | API and dashboard in your infrastructure |
 
 ## One evidence model, four consumers
@@ -55,7 +55,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 |---|---|---|
 | **CLI / CI** | developers and pipelines | local scans, SARIF/SBOM/HTML/JSON, graph exports, deterministic gates |
 | **REST API** | security platforms, SIEM jobs, custom services | self-hosted control-plane routes for scans, normalized bulk findings, dataset versions, graph evidence, audit, and governance |
-| **MCP tools** | AI agents and coding assistants | 51 read-only tools, strict args, `exposure_paths`, `should_i_deploy`, runtime posture |
+| **MCP tools** | AI agents and coding assistants | 54 tools, strict args, `exposure_paths`, `should_i_deploy`, runtime posture, audited Shield actions |
 | **TypeScript client** | services and agent runtimes calling the control plane | typed helper for stable REST endpoints; not a scanner SDK |
 | **TypeScript runtime detectors** | MCP/runtime enforcement integrations | local detector package for runtime policy checks; separate from the control-plane client |
 | **UI cockpit** | security teams and auditors | graph cockpit, compliance, audit, and evidence review over the same backend data |

--- a/site-docs/reference/agentic-workflows.md
+++ b/site-docs/reference/agentic-workflows.md
@@ -7,7 +7,7 @@ plane or runtime enforcement rollout.
 | Surface | Start with | Trust boundary | Evidence artifact | Move up to |
 |---|---|---|---|---|
 | Local CLI | `agent-bom agents --demo --offline`, then `agent-bom agents -p .` | Reads local agent and MCP configuration from the developer machine. No control-plane credentials required. | Terminal findings, JSON, SARIF, SBOM, HTML, graph export. | Scheduled scan, Docker, GitHub Action. |
-| Claude, Cursor, Windsurf, VS Code, Cortex, Codex CLI | `agent-bom mcp server` | Exposes read-only security tools to the assistant. The assistant does not need direct scanner credentials beyond the local process boundary. | MCP tool output, inventory, blast-radius answers, compliance checks, ranked `ExposurePath` JSON, deploy guidance. | Shared MCP configuration, skills, fleet sync. |
+| Claude, Cursor, Windsurf, VS Code, Cortex, Codex CLI | `agent-bom mcp server` | Exposes read-mostly security tools to the assistant. The assistant does not need direct scanner credentials beyond the local process boundary; Shield write actions require admin role and an audit reason. | MCP tool output, inventory, blast-radius answers, compliance checks, ranked `ExposurePath` JSON, deploy guidance. | Shared MCP configuration, skills, fleet sync. |
 | GitHub Actions | `uses: msaad00/agent-bom@v0.87.1` with SARIF upload enabled | Runs in CI with repository-scoped token permissions. Fork PR behavior depends on GitHub security policy. | `agent-bom-results.sarif`, pull-request summary, code-scanning alert category. | Branch protection, required code scanning, artifact retention. |
 | Skills and instruction files | `agent-bom skills scan . --policy skills-policy.yaml` | Reads repo-local instructions such as `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, and `skills/*.md`. | Skill trust findings, referenced package and MCP inventory, credential-env names, policy warn/block result. | Signed skills, provenance verification, registry publishing. |
 | Cloud and AI infrastructure | `agent-bom agents --preset enterprise` plus provider-specific flags only where credentials are approved. | Uses read-only provider APIs or local inventory files. Keep provider secrets in the operator boundary, not in repo docs. | Cloud, warehouse, GPU, model, dataset, and runtime package evidence. | Fleet sync, compliance exports, graph-backed findings. |
@@ -114,5 +114,6 @@ upstream server.
   demos.
 - Runtime causality requires proxy, gateway, trace, or Shield evidence. Static
   scans show reachability and exposure, not live tool-call causality.
-- MCP server mode is read-only. Use proxy, gateway, or Shield when the question
-  depends on selected live tool-call traffic.
+- MCP server mode is read-mostly. Scanner and posture tools are read-only; use
+  admin-gated Shield actions only when the question depends on selected live
+  tool-call traffic.

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -2,8 +2,9 @@
 
 agent-bom exposes MCP tools for scanning, blast radius, trust, compliance,
 runtime, and remediation. The tools are read-only by default: agent consumers
-can request evidence and deploy guidance, but the MCP server does not mutate
-repos, cloud resources, or runtime targets.
+can request evidence and deploy guidance without mutating repos, cloud
+resources, or runtime targets. Shield write actions are the exception: they
+fail closed unless the caller supplies an admin role and audit reason.
 
 ## Tools
 
@@ -229,6 +230,27 @@ gateway_status(tenant_id="default")
 Return Shield session status without starting, stopping, or unblocking a session.
 ```
 shield_status(session_id="default")
+```
+
+### shield_start
+Start Shield enforcement for a session. Requires `operator_role="admin"` and an
+audit reason of at least eight characters.
+```
+shield_start(session_id="default", operator_role="admin", reason="incident response")
+```
+
+### shield_unblock
+Unblock Shield enforcement for a session. Requires `operator_role="admin"` and
+an audit reason of at least eight characters.
+```
+shield_unblock(session_id="default", operator_role="admin", reason="validated unblock")
+```
+
+### shield_break_glass
+Activate the Shield emergency override. Requires `operator_role="admin"` and an
+audit reason of at least eight characters. The action is audit logged.
+```
+shield_break_glass(session_id="default", operator_role="admin", reason="approved emergency override")
 ```
 
 ### firewall_check

--- a/site-docs/security.md
+++ b/site-docs/security.md
@@ -20,7 +20,7 @@ We aim to respond within 48 hours and provide a fix within 7 days for critical i
 agent-bom has three distinct security postures:
 
 - **Scanner mode** (`agent-bom agents`, `agent-bom fs`, `agent-bom check`) is read-only. It reads config files and queries public APIs (OSV.dev, NVD, EPSS, CISA KEV).
-- **MCP server mode** (`agent-bom mcp server`) is read-only. It exposes scan/governance tools and does not execute third-party MCP servers.
+- **MCP server mode** (`agent-bom mcp server`) is read-mostly. Scanner, posture, graph, and audit tools are read-only; Shield write actions require admin role and an audit reason.
 - **Proxy mode** (`agent-bom proxy`) is an execution and enforcement surface. It intentionally launches or connects to the target MCP server so it can inspect, block, and audit tool traffic in real time.
 
 Across all modes, agent-bom never stores credential values — only their names appear in output as `***REDACTED***`.

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -692,7 +692,7 @@ def mcp_server_cmd(
     Requires:  pip install 'agent-bom[mcp-server]'
 
     \b
-    Exposes 51 security tools via MCP protocol:
+    Exposes 54 security tools via MCP protocol:
       scan                   Full scan — CVEs, config security, blast radius, compliance
       check                  Check a specific package for CVEs before installing
       blast_radius           Look up blast radius for a specific CVE
@@ -725,6 +725,9 @@ def mcp_server_cmd(
       proxy_alerts           Recent tenant-scoped runtime proxy alerts
       gateway_status         Gateway policy and firewall runtime statistics
       shield_status          Shield session status without changing enforcement
+      shield_start           Start Shield enforcement with admin/audit gating
+      shield_unblock         Unblock Shield enforcement with admin/audit gating
+      shield_break_glass     Emergency Shield override with admin/audit gating
       firewall_check         Read-only inter-agent firewall decision dry run
       audit_query            Tenant-scoped control-plane audit records
       audit_integrity        Control-plane and runtime audit-chain verification

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -5,7 +5,7 @@ Start with:
     agent-bom mcp server --transport sse          # SSE transport (for remote clients)
     agent-bom mcp server --transport streamable-http
 
-Tools (51):
+Tools (54):
     scan                — Full discovery → scan → output pipeline
     check               — Check a specific package for CVEs before installing
     blast_radius        — Look up blast radius for a specific CVE
@@ -37,6 +37,9 @@ Tools (51):
     proxy_alerts        — Recent tenant-scoped runtime proxy alerts
     gateway_status      — Gateway policy and firewall runtime statistics
     shield_status       — Shield session status without changing enforcement
+    shield_start        — Start Shield enforcement with admin/audit gating
+    shield_unblock      — Unblock Shield enforcement with admin/audit gating
+    shield_break_glass  — Emergency Shield override with admin/audit gating
     firewall_check      — Read-only inter-agent firewall decision dry run
     audit_query         — Tenant-scoped control-plane audit records
     audit_integrity     — Control-plane and runtime audit-chain verification
@@ -61,7 +64,9 @@ Resources (6):
     bestpractices://mcp-hardening — MCP deployment hardening checklist
     compliance://framework-controls — Framework coverage and evidence mapping
 
-Security: Read-only. Never executes MCP servers or reads credential values.
+Security: read-mostly. Scanner, graph, audit, and runtime posture tools are
+read-only. Shield write tools require explicit admin role + audit reason and
+never read credential values.
 """
 
 from __future__ import annotations
@@ -319,8 +324,11 @@ _recent_tool_requests: deque[dict[str, Any]] = deque(maxlen=_MCP_MAX_REQUEST_TRA
 _MAX_CACHED_TOOL_LOOPS = 8
 
 
-# All agent-bom tools are read-only scanners
+# Most agent-bom MCP tools are read-only scanners. Shield write tools are
+# explicitly annotated as mutating and fail closed unless an admin role and
+# audit reason are supplied.
 _READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=True)
+_WRITE_ACTION = ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=False, openWorldHint=False)
 
 
 def _check_mcp_sdk() -> None:
@@ -869,6 +877,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
     register_operator_tools(
         mcp,
         read_only=_READ_ONLY,
+        write_action=_WRITE_ACTION,
         execute_tool_async=_execute_tool_async,
         safe_path=_safe_path,
         run_scan_pipeline=_run_scan_pipeline,

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -157,6 +157,21 @@ _SERVER_CARD_TOOLS = [
         "annotations": {"readOnlyHint": True},
     },
     {
+        "name": "shield_start",
+        "description": "Start Shield enforcement for a session; requires admin role and an audit reason",
+        "annotations": {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False},
+    },
+    {
+        "name": "shield_unblock",
+        "description": "Unblock Shield enforcement for a session; requires admin role and an audit reason",
+        "annotations": {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False},
+    },
+    {
+        "name": "shield_break_glass",
+        "description": "Emergency Shield override; requires admin role and an audit reason",
+        "annotations": {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False},
+    },
+    {
         "name": "firewall_check",
         "description": "Dry-run an inter-agent firewall decision without recording control-plane state",
         "annotations": {"readOnlyHint": True},
@@ -273,6 +288,9 @@ _TOOL_CAPABILITY_CLASSES = {
     "proxy_alerts": ["READ", "RUNTIME", "OBSERVABILITY"],
     "gateway_status": ["READ", "RUNTIME", "POLICY"],
     "shield_status": ["READ", "RUNTIME", "SECURITY"],
+    "shield_start": ["WRITE", "RUNTIME", "SECURITY", "AUDIT"],
+    "shield_unblock": ["WRITE", "RUNTIME", "SECURITY", "AUDIT"],
+    "shield_break_glass": ["WRITE", "RUNTIME", "SECURITY", "AUDIT"],
     "firewall_check": ["READ", "RUNTIME", "POLICY"],
     "audit_query": ["READ", "AUDIT"],
     "audit_integrity": ["READ", "AUDIT", "PROVENANCE"],

--- a/src/agent_bom/mcp_server_operator_tools.py
+++ b/src/agent_bom/mcp_server_operator_tools.py
@@ -18,6 +18,7 @@ def register_operator_tools(
     mcp,
     *,
     read_only,
+    write_action,
     execute_tool_async,
     safe_path,
     run_scan_pipeline,
@@ -41,7 +42,10 @@ def register_operator_tools(
         runtime_blueprints_impl,
         runtime_correlate_impl,
         runtime_production_index_impl,
+        shield_break_glass_impl,
+        shield_start_impl,
         shield_status_impl,
+        shield_unblock_impl,
     )
     from agent_bom.mcp_tools.sbom import diff_impl
     from agent_bom.mcp_tools.scanning import code_scan_impl
@@ -543,6 +547,101 @@ def register_operator_tools(
             "shield_status",
             shield_status_impl,
             session_id=session_id,
+            _truncate_response=truncate_response,
+        )
+
+    @mcp.tool(annotations=write_action, title="Shield Start")
+    async def shield_start(
+        session_id: Annotated[
+            str,
+            Field(description="Shield session id to start."),
+        ] = "default",
+        correlation_window: Annotated[
+            float,
+            Field(ge=1.0, le=3600.0, description="Alert correlation window in seconds."),
+        ] = 30.0,
+        operator_role: Annotated[
+            str,
+            Field(description="Operator role for this write action. Must be admin."),
+        ] = "viewer",
+        reason: Annotated[
+            str,
+            Field(description="Human audit reason for starting Shield enforcement."),
+        ] = "",
+        tenant_id: Annotated[
+            str,
+            Field(description="Tenant scope for audit logging."),
+        ] = "default",
+    ) -> str:
+        """Start Shield enforcement for a session. Requires admin role and audit reason."""
+        return await execute_tool_async(
+            "shield_start",
+            shield_start_impl,
+            session_id=session_id,
+            correlation_window=correlation_window,
+            operator_role=operator_role,
+            reason=reason,
+            tenant_id=tenant_id,
+            _truncate_response=truncate_response,
+        )
+
+    @mcp.tool(annotations=write_action, title="Shield Unblock")
+    async def shield_unblock(
+        session_id: Annotated[
+            str,
+            Field(description="Shield session id to unblock."),
+        ] = "default",
+        operator_role: Annotated[
+            str,
+            Field(description="Operator role for this write action. Must be admin."),
+        ] = "viewer",
+        reason: Annotated[
+            str,
+            Field(description="Human audit reason for unblocking Shield enforcement."),
+        ] = "",
+        tenant_id: Annotated[
+            str,
+            Field(description="Tenant scope for audit logging."),
+        ] = "default",
+    ) -> str:
+        """Unblock Shield enforcement for a session. Requires admin role and audit reason."""
+        return await execute_tool_async(
+            "shield_unblock",
+            shield_unblock_impl,
+            session_id=session_id,
+            operator_role=operator_role,
+            reason=reason,
+            tenant_id=tenant_id,
+            _truncate_response=truncate_response,
+        )
+
+    @mcp.tool(annotations=write_action, title="Shield Break Glass")
+    async def shield_break_glass(
+        session_id: Annotated[
+            str,
+            Field(description="Shield session id to override."),
+        ] = "default",
+        operator_role: Annotated[
+            str,
+            Field(description="Operator role for this write action. Must be admin."),
+        ] = "viewer",
+        reason: Annotated[
+            str,
+            Field(description="Human audit reason for emergency Shield override."),
+        ] = "",
+        tenant_id: Annotated[
+            str,
+            Field(description="Tenant scope for audit logging."),
+        ] = "default",
+    ) -> str:
+        """Run Shield break-glass override. Requires admin role and audit reason."""
+        return await execute_tool_async(
+            "shield_break_glass",
+            shield_break_glass_impl,
+            session_id=session_id,
+            operator_role=operator_role,
+            reason=reason,
+            tenant_id=tenant_id,
             _truncate_response=truncate_response,
         )
 

--- a/src/agent_bom/mcp_tools/runtime.py
+++ b/src/agent_bom/mcp_tools/runtime.py
@@ -22,6 +22,65 @@ def _csv_set(value: str) -> set[str]:
     return {part.strip() for part in value.split(",") if part.strip()}
 
 
+def _authorize_shield_write(
+    *,
+    action: str,
+    operator_role: str,
+    reason: str,
+    tenant_id: str,
+    session_id: str,
+) -> tuple[bool, dict[str, Any]]:
+    normalized_role = (operator_role or "").strip().lower()
+    clean_reason = (reason or "").strip()
+    if normalized_role != "admin":
+        return (
+            False,
+            {
+                "error": "shield write action requires admin role",
+                "action": action,
+                "required_role": "admin",
+                "provided_role": normalized_role or "unset",
+                "status": "blocked",
+            },
+        )
+    if len(clean_reason) < 8:
+        return (
+            False,
+            {
+                "error": "shield write action requires an audit reason of at least 8 characters",
+                "action": action,
+                "required_role": "admin",
+                "status": "blocked",
+            },
+        )
+    return (
+        True,
+        {
+            "action": action,
+            "actor": normalized_role,
+            "tenant_id": tenant_id or "default",
+            "resource": f"shield/{session_id or 'default'}",
+            "reason": clean_reason,
+        },
+    )
+
+
+def _record_shield_write_audit(context: dict[str, Any], *, result: dict[str, Any]) -> None:
+    try:
+        from agent_bom.api.audit_log import log_action
+
+        log_action(
+            context["action"],
+            actor=context["actor"],
+            resource=context["resource"],
+            tenant_id=context["tenant_id"],
+            reason=context["reason"],
+            result_status=result.get("status", "unknown"),
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("MCP shield write audit logging failed")
+
+
 async def runtime_production_index_impl(
     *,
     tenant_id: str = "default",
@@ -140,6 +199,114 @@ async def shield_status_impl(
         return _truncate_response(json.dumps(payload, indent=2, default=str))
     except Exception as exc:
         logger.exception("MCP shield status error")
+        return json.dumps({"error": sanitize_error(exc)})
+
+
+async def shield_start_impl(
+    *,
+    session_id: str = "default",
+    correlation_window: float = 30.0,
+    operator_role: str = "viewer",
+    reason: str = "",
+    tenant_id: str = "default",
+    _truncate_response,
+) -> str:
+    """Implementation of the shield_start write tool."""
+    authorized, context = _authorize_shield_write(
+        action="shield_start",
+        operator_role=operator_role,
+        reason=reason,
+        tenant_id=tenant_id,
+        session_id=session_id,
+    )
+    if not authorized:
+        return json.dumps(context)
+    try:
+        from agent_bom.api.routes.proxy import shield_start
+
+        bounded_window = max(1.0, min(float(correlation_window), 3600.0))
+        payload = await shield_start(session_id=session_id or "default", correlation_window=bounded_window)
+        payload["mcp_write_policy"] = {
+            "required_role": "admin",
+            "actor_role": context["actor"],
+            "audit_logged": True,
+            "tenant_id": context["tenant_id"],
+        }
+        _record_shield_write_audit(context, result=payload)
+        return _truncate_response(json.dumps(payload, indent=2, default=str))
+    except Exception as exc:
+        logger.exception("MCP shield start error")
+        return json.dumps({"error": sanitize_error(exc)})
+
+
+async def shield_unblock_impl(
+    *,
+    session_id: str = "default",
+    operator_role: str = "viewer",
+    reason: str = "",
+    tenant_id: str = "default",
+    _truncate_response,
+) -> str:
+    """Implementation of the shield_unblock write tool."""
+    authorized, context = _authorize_shield_write(
+        action="shield_unblock",
+        operator_role=operator_role,
+        reason=reason,
+        tenant_id=tenant_id,
+        session_id=session_id,
+    )
+    if not authorized:
+        return json.dumps(context)
+    try:
+        from agent_bom.api.routes.proxy import shield_unblock
+
+        payload = await shield_unblock(session_id=session_id or "default")
+        payload["mcp_write_policy"] = {
+            "required_role": "admin",
+            "actor_role": context["actor"],
+            "audit_logged": True,
+            "tenant_id": context["tenant_id"],
+        }
+        _record_shield_write_audit(context, result=payload)
+        return _truncate_response(json.dumps(payload, indent=2, default=str))
+    except Exception as exc:
+        logger.exception("MCP shield unblock error")
+        return json.dumps({"error": sanitize_error(exc)})
+
+
+async def shield_break_glass_impl(
+    *,
+    session_id: str = "default",
+    operator_role: str = "viewer",
+    reason: str = "",
+    tenant_id: str = "default",
+    _truncate_response,
+) -> str:
+    """Implementation of the shield_break_glass write tool."""
+    authorized, context = _authorize_shield_write(
+        action="shield_break_glass",
+        operator_role=operator_role,
+        reason=reason,
+        tenant_id=tenant_id,
+        session_id=session_id,
+    )
+    if not authorized:
+        return json.dumps(context)
+    try:
+        from agent_bom.api.routes.proxy import break_glass
+
+        request = _request_for_tenant(context["tenant_id"])
+        request.state.api_key_role = context["actor"]
+        payload = await break_glass(cast(Any, request), session_id=session_id or "default", reason=context["reason"])
+        payload["mcp_write_policy"] = {
+            "required_role": "admin",
+            "actor_role": context["actor"],
+            "audit_logged": True,
+            "tenant_id": context["tenant_id"],
+        }
+        return _truncate_response(json.dumps(payload, indent=2, default=str))
+    except Exception as exc:
+        logger.exception("MCP shield break-glass error")
         return json.dumps({"error": sanitize_error(exc)})
 
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -186,13 +186,19 @@ def test_server_card_tools_expose_capability_classes():
     """Server card should classify tool capabilities for agents and marketplaces."""
     from agent_bom.mcp_server import build_server_card
 
+    write_tools = {"shield_start", "shield_unblock", "shield_break_glass"}
     card = build_server_card()
     for tool in card["tools"]:
         classes = tool.get("capability_classes")
         assert isinstance(classes, list), tool["name"]
         assert classes, tool["name"]
-        assert "READ" in classes, tool["name"]
-        assert tool["annotations"]["readOnlyHint"] is True
+        if tool["name"] in write_tools:
+            assert "WRITE" in classes, tool["name"]
+            assert tool["annotations"]["readOnlyHint"] is False
+            assert tool["annotations"]["destructiveHint"] is True
+        else:
+            assert "READ" in classes, tool["name"]
+            assert tool["annotations"]["readOnlyHint"] is True
 
 
 def test_server_card_exposes_resources_and_workflow_prompts():

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -236,7 +236,11 @@ def test_mcp_docs_match_resource_and_prompt_catalog():
     )
     card = build_server_card()
     assert "35 security tools" not in docs
-    assert f"{len(card['tools'])} read-only security tools" in docs
+    assert f"{len(card['tools'])} MCP tools" in docs
+    assert "Most tools are read-only" in docs
+    assert "Shield write actions require `operator_role=admin`" in docs
+    write_tools = [tool["name"] for tool in card["tools"] if tool.get("annotations", {}).get("readOnlyHint") is False]
+    assert sorted(write_tools) == ["shield_break_glass", "shield_start", "shield_unblock"]
     for resource in card["resources"]:
         assert resource["uri"] in docs
     for prompt in card["prompts"]:

--- a/tests/test_mcp_tool_impls.py
+++ b/tests/test_mcp_tool_impls.py
@@ -950,6 +950,105 @@ async def test_proxy_gateway_and_shield_status_impls_empty_state():
 
 
 @pytest.mark.asyncio
+async def test_shield_write_tools_require_admin_and_audit_reason():
+    from agent_bom.api.audit_log import InMemoryAuditLog, set_audit_log
+    from agent_bom.api.routes import proxy as proxy_routes
+    from agent_bom.mcp_tools.runtime import shield_start_impl, shield_unblock_impl
+
+    store = InMemoryAuditLog()
+    set_audit_log(store)
+    proxy_routes._shield_engines.clear()
+
+    blocked = json.loads(
+        await shield_start_impl(
+            session_id="incident-1",
+            operator_role="viewer",
+            reason="start incident shield",
+            tenant_id="tenant-alpha",
+            _truncate_response=_trunc,
+        )
+    )
+    assert blocked["status"] == "blocked"
+    assert blocked["required_role"] == "admin"
+
+    missing_reason = json.loads(
+        await shield_start_impl(
+            session_id="incident-1",
+            operator_role="admin",
+            reason="short",
+            tenant_id="tenant-alpha",
+            _truncate_response=_trunc,
+        )
+    )
+    assert missing_reason["status"] == "blocked"
+    assert "audit reason" in missing_reason["error"]
+
+    started = json.loads(
+        await shield_start_impl(
+            session_id="incident-1",
+            operator_role="admin",
+            reason="incident response validation",
+            tenant_id="tenant-alpha",
+            _truncate_response=_trunc,
+        )
+    )
+    assert started["status"] == "started"
+    assert started["mcp_write_policy"]["required_role"] == "admin"
+    assert started["mcp_write_policy"]["audit_logged"] is True
+
+    unblocked = json.loads(
+        await shield_unblock_impl(
+            session_id="incident-1",
+            operator_role="admin",
+            reason="incident response validation",
+            tenant_id="tenant-alpha",
+            _truncate_response=_trunc,
+        )
+    )
+    assert unblocked["status"] in {"not_blocked", "unblocked"}
+
+    entries = store.list_entries(tenant_id="tenant-alpha", limit=10)
+    assert [entry.action for entry in entries] == ["shield_unblock", "shield_start"]
+
+    proxy_routes._shield_engines.clear()
+
+
+@pytest.mark.asyncio
+async def test_shield_break_glass_tool_uses_admin_role_context():
+    from agent_bom.api.audit_log import InMemoryAuditLog, set_audit_log
+    from agent_bom.api.routes import proxy as proxy_routes
+    from agent_bom.mcp_tools.runtime import shield_break_glass_impl, shield_start_impl
+
+    store = InMemoryAuditLog()
+    set_audit_log(store)
+    proxy_routes._shield_engines.clear()
+
+    await shield_start_impl(
+        session_id="incident-2",
+        operator_role="admin",
+        reason="incident response validation",
+        tenant_id="tenant-alpha",
+        _truncate_response=_trunc,
+    )
+    result = json.loads(
+        await shield_break_glass_impl(
+            session_id="incident-2",
+            operator_role="admin",
+            reason="emergency operator override",
+            tenant_id="tenant-alpha",
+            _truncate_response=_trunc,
+        )
+    )
+    assert result["status"] == "break_glass_activated"
+    assert result["mcp_write_policy"]["actor_role"] == "admin"
+
+    entries = store.list_entries(tenant_id="tenant-alpha", limit=10)
+    assert [entry.action for entry in entries][:2] == ["break_glass", "shield_start"]
+
+    proxy_routes._shield_engines.clear()
+
+
+@pytest.mark.asyncio
 async def test_proxy_alerts_impl_filters_metadata_only_alerts():
     import agent_bom.api.routes.proxy as proxy_mod
     from agent_bom.api.routes.proxy import push_proxy_alert


### PR DESCRIPTION
Summary

- add admin-gated MCP tools for Shield start, unblock, and break-glass actions
- require an explicit audit reason before any Shield write action succeeds
- refresh MCP tool counts, docker-mcp metadata, and public read-mostly wording across docs/site surfaces

Verification

- uv run pytest tests/test_mcp_tool_impls.py::test_shield_write_tools_require_admin_and_audit_reason tests/test_mcp_tool_impls.py::test_shield_break_glass_tool_uses_admin_role_context tests/test_stats_alignment.py::TestCodeConsistency::test_mcp_tools_match_card_tools tests/test_stats_alignment.py::TestCodeConsistency::test_mcp_tools_docstring tests/test_deployment.py::test_server_card_has_all_tools tests/test_deployment.py::test_server_card_tool_count_matches_decorators -q
- uv run ruff check src/agent_bom/mcp_tools/runtime.py src/agent_bom/mcp_server.py src/agent_bom/mcp_server_operator_tools.py src/agent_bom/mcp_server_metadata.py tests/test_mcp_tool_impls.py
- uv run mypy src/agent_bom/mcp_tools/runtime.py src/agent_bom/mcp_server_operator_tools.py src/agent_bom/mcp_server.py
- python scripts/check_release_consistency.py
- git diff --check

Notes

- Shield write tools fail closed unless operator_role=admin and an audit reason of at least eight characters are supplied.
