### PR TITLE
docs(plugins): add entrypoint examples

### DIFF
--- a/docs/PLUGIN_ENTRYPOINTS.md
+++ b/docs/PLUGIN_ENTRYPOINTS.md
@@ -71,6 +71,22 @@ Group-specific optional fields:
 - `agent_bom.runtime_emitters`: `emit_attr`, default `emit`; `flush_attr`,
   default `flush`.
 
+## Runnable Examples
+
+Concrete examples live in [`examples/plugin_entrypoints/`](../examples/plugin_entrypoints/):
+
+- `example_mcp_tools.py` advertises a read-only MCP posture tool and a
+  `register_tools(mcp)` function.
+- `example_advisory_source.py` advertises a license-aware advisory lookup/sync
+  source that returns summaries and source URLs instead of redistributing full
+  advisory bodies.
+- `example_runtime_emitter.py` advertises a runtime event emitter that keeps
+  only redacted metadata envelopes and avoids raw prompts, arguments, and
+  credential values.
+
+These examples are covered by `tests/test_plugin_entrypoint_examples.py` so the
+documented plugin contract stays importable.
+
 ## First Verification
 
 For plugin package tests, monkeypatch `importlib.metadata.entry_points`, set

--- a/examples/plugin_entrypoints/README.md
+++ b/examples/plugin_entrypoints/README.md
@@ -1,0 +1,32 @@
+# Plugin Entry-Point Examples
+
+These examples make the v0.88 plugin contract concrete without enabling
+third-party code by default.
+
+| Example | Entry-point group | Boundary |
+| --- | --- | --- |
+| `example_mcp_tools.py` | `agent_bom.mcp_tools` | registers a metadata-only posture tool when an operator explicitly enables the package |
+| `example_advisory_source.py` | `agent_bom.advisory_sources` | reads advisory metadata from an operator-owned source and returns hashes, links, and summaries |
+| `example_runtime_emitter.py` | `agent_bom.runtime_emitters` | emits redacted runtime event envelopes to an operator-owned telemetry sink |
+
+Installable packages should expose the registration functions with:
+
+```toml
+[project.entry-points."agent_bom.mcp_tools"]
+example-posture = "example_mcp_tools:registration"
+
+[project.entry-points."agent_bom.advisory_sources"]
+example-advisories = "example_advisory_source:registration"
+
+[project.entry-points."agent_bom.runtime_emitters"]
+example-runtime = "example_runtime_emitter:registration"
+```
+
+Runtime discovery remains opt-in:
+
+```bash
+AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS=true agent-bom agents --demo --offline
+```
+
+The loader discovers and validates metadata only. Operators still decide when
+to attach MCP tools, query advisory sources, or send runtime events.

--- a/examples/plugin_entrypoints/example_advisory_source.py
+++ b/examples/plugin_entrypoints/example_advisory_source.py
@@ -1,0 +1,60 @@
+"""Example third-party advisory source plugin registration."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from agent_bom.extensions import ExtensionCapabilities
+from agent_bom.plugin_entrypoints import AdvisorySourcePluginRegistration
+
+
+def registration() -> AdvisorySourcePluginRegistration:
+    """Return a metadata registration for an operator-owned advisory feed."""
+
+    return AdvisorySourcePluginRegistration(
+        name="example-advisory-source",
+        module="example_advisory_source",
+        lookup_attr="lookup",
+        sync_attr="sync",
+        capabilities=ExtensionCapabilities(
+            scan_modes=("advisory_lookup", "advisory_sync"),
+            required_scopes=("advisory_source_read",),
+            outbound_destinations=("security-advisories.internal",),
+            data_boundary="operator_owned_advisory_metadata",
+            network_access=True,
+            writes=False,
+            guarantees=("license_declared", "source_url_required", "metadata_only"),
+        ),
+        source="example",
+    )
+
+
+def lookup(advisory_id: str) -> dict[str, Any]:
+    """Return one normalized advisory metadata record.
+
+    The example intentionally returns a short summary and source URL, not a
+    redistributed full advisory body.
+    """
+
+    return {
+        "id": advisory_id,
+        "schema_version": "example.advisory_lookup.v1",
+        "summary": "Example advisory metadata returned by an operator-owned feed.",
+        "source_url": f"https://security-advisories.internal/advisories/{advisory_id}",
+        "license": "link-only",
+        "redistribution": "summary_only",
+        "last_seen": datetime.now(UTC).isoformat(),
+    }
+
+
+def sync(*, since: str | None = None) -> dict[str, Any]:
+    """Return freshness metadata for a feed sync run."""
+
+    return {
+        "schema_version": "example.advisory_sync.v1",
+        "since": since,
+        "items_seen": 0,
+        "last_synced_at": datetime.now(UTC).isoformat(),
+        "license": "link-only",
+    }

--- a/examples/plugin_entrypoints/example_mcp_tools.py
+++ b/examples/plugin_entrypoints/example_mcp_tools.py
@@ -1,0 +1,51 @@
+"""Example third-party MCP tool plugin registration.
+
+The entry point advertises where the operator-owned package registers tools.
+agent-bom discovers this metadata only; it does not attach the tool unless an
+operator intentionally imports and wires the package.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent_bom.extensions import ExtensionCapabilities
+from agent_bom.plugin_entrypoints import McpToolPluginRegistration
+
+
+def registration() -> McpToolPluginRegistration:
+    """Return the plugin registration advertised by package entry points."""
+
+    return McpToolPluginRegistration(
+        name="example-posture-tool",
+        module="example_mcp_tools",
+        register_attr="register_tools",
+        capabilities=ExtensionCapabilities(
+            scan_modes=("mcp_tool",),
+            required_scopes=("operator_enabled_mcp_tool",),
+            data_boundary="metadata_only_example",
+            writes=False,
+            network_access=False,
+            guarantees=("read_only", "operator_enabled"),
+        ),
+        source="example",
+    )
+
+
+def register_tools(mcp: Any) -> None:
+    """Register one read-only tool on a FastMCP-compatible object."""
+
+    @mcp.tool(title="Example Asset Posture")
+    def example_asset_posture(asset_id: str = "local") -> str:
+        """Return a small metadata-only posture payload for an operator asset."""
+
+        return json.dumps(
+            {
+                "asset_id": asset_id,
+                "status": "observed",
+                "data_boundary": "metadata_only_example",
+                "writes": False,
+            },
+            sort_keys=True,
+        )

--- a/examples/plugin_entrypoints/example_runtime_emitter.py
+++ b/examples/plugin_entrypoints/example_runtime_emitter.py
@@ -1,0 +1,59 @@
+"""Example third-party runtime emitter plugin registration."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from agent_bom.extensions import ExtensionCapabilities
+from agent_bom.plugin_entrypoints import RuntimeEmitterPluginRegistration
+
+_BUFFER: list[dict[str, Any]] = []
+
+
+def registration() -> RuntimeEmitterPluginRegistration:
+    """Return a metadata registration for a redacted runtime event sink."""
+
+    return RuntimeEmitterPluginRegistration(
+        name="example-runtime-emitter",
+        module="example_runtime_emitter",
+        emit_attr="emit",
+        flush_attr="flush",
+        capabilities=ExtensionCapabilities(
+            scan_modes=("runtime_event_emit",),
+            required_scopes=("runtime_event_write",),
+            outbound_destinations=("telemetry.internal",),
+            data_boundary="redacted_runtime_metadata",
+            network_access=True,
+            writes=True,
+            guarantees=("operator_enabled", "redacted_payloads", "no_prompt_bodies"),
+        ),
+        source="example",
+    )
+
+
+def emit(event: dict[str, Any]) -> dict[str, Any]:
+    """Buffer a redacted runtime event envelope.
+
+    The example keeps only routing metadata and explicitly avoids raw prompts,
+    arguments, and credential values.
+    """
+
+    envelope = {
+        "schema_version": "example.runtime_event.v1",
+        "received_at": datetime.now(UTC).isoformat(),
+        "tenant_id": str(event.get("tenant_id") or "default"),
+        "source_agent": str(event.get("source_agent") or "anonymous"),
+        "tool": str(event.get("tool") or ""),
+        "decision": str(event.get("decision") or "observed"),
+    }
+    _BUFFER.append(envelope)
+    return {"queued": True, "buffered": len(_BUFFER)}
+
+
+def flush() -> dict[str, Any]:
+    """Flush buffered event envelopes."""
+
+    flushed = len(_BUFFER)
+    _BUFFER.clear()
+    return {"flushed": flushed}

--- a/tests/test_plugin_entrypoint_examples.py
+++ b/tests/test_plugin_entrypoint_examples.py
@@ -1,0 +1,101 @@
+"""Contract tests for documented plugin entry-point examples."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES = ROOT / "examples" / "plugin_entrypoints"
+
+
+def _load_example(name: str) -> ModuleType:
+    path = EXAMPLES / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeMcp:
+    def __init__(self) -> None:
+        self.tools: dict[str, Any] = {}
+
+    def tool(self, *, title: str):
+        def decorator(func):
+            self.tools[func.__name__] = {"title": title, "func": func}
+            return func
+
+        return decorator
+
+
+def test_mcp_tool_example_registers_read_only_tool() -> None:
+    module = _load_example("example_mcp_tools")
+
+    registration = module.registration()
+    assert registration.name == "example-posture-tool"
+    assert registration.register_attr == "register_tools"
+    assert registration.capabilities.writes is False
+    assert registration.capabilities.data_boundary == "metadata_only_example"
+
+    fake_mcp = FakeMcp()
+    module.register_tools(fake_mcp)
+    payload = json.loads(fake_mcp.tools["example_asset_posture"]["func"](asset_id="workstation-1"))
+    assert payload == {
+        "asset_id": "workstation-1",
+        "data_boundary": "metadata_only_example",
+        "status": "observed",
+        "writes": False,
+    }
+
+
+def test_advisory_source_example_declares_license_and_source_url() -> None:
+    module = _load_example("example_advisory_source")
+
+    registration = module.registration()
+    assert registration.name == "example-advisory-source"
+    assert registration.lookup_attr == "lookup"
+    assert registration.sync_attr == "sync"
+    assert registration.capabilities.network_access is True
+    assert registration.capabilities.data_boundary == "operator_owned_advisory_metadata"
+
+    advisory = module.lookup("CVE-2026-0001")
+    assert advisory["id"] == "CVE-2026-0001"
+    assert advisory["license"] == "link-only"
+    assert advisory["redistribution"] == "summary_only"
+    assert advisory["source_url"].endswith("/CVE-2026-0001")
+
+    sync = module.sync(since="2026-05-22T00:00:00+00:00")
+    assert sync["license"] == "link-only"
+    assert sync["items_seen"] == 0
+
+
+def test_runtime_emitter_example_buffers_redacted_metadata_only_events() -> None:
+    module = _load_example("example_runtime_emitter")
+
+    registration = module.registration()
+    assert registration.name == "example-runtime-emitter"
+    assert registration.emit_attr == "emit"
+    assert registration.flush_attr == "flush"
+    assert registration.capabilities.writes is True
+    assert "no_prompt_bodies" in registration.capabilities.guarantees
+
+    queued = module.emit(
+        {
+            "tenant_id": "tenant-alpha",
+            "source_agent": "security-reviewer",
+            "tool": "query",
+            "decision": "blocked",
+            "arguments": {"secret": "not retained"},
+        }
+    )
+    assert queued["queued"] is True
+    assert queued["buffered"] == 1
+
+    flushed = module.flush()
+    assert flushed == {"flushed": 1}


### PR DESCRIPTION
Summary

- add runnable examples for the `agent_bom.mcp_tools`, `agent_bom.advisory_sources`, and `agent_bom.runtime_emitters` entry-point groups
- document the installable package entry-point snippets and opt-in discovery boundary
- add contract tests so the examples stay importable and keep metadata, license, and redaction expectations explicit

Verification

- `uv run pytest tests/test_plugin_entrypoint_examples.py tests/test_plugin_entrypoints.py -q`
- `uv run ruff check examples/plugin_entrypoints/*.py tests/test_plugin_entrypoint_examples.py`
- `uv run mypy examples/plugin_entrypoints/*.py tests/test_plugin_entrypoint_examples.py`
- `python scripts/check_release_consistency.py`
- `git diff --check`

Notes

- Discovery remains opt-in through `AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS=true`; these examples advertise metadata and do not enable third-party code by default.
