### PR TITLE
fix(cli): stream agents json output

### DIFF
--- a/docs/GITHUB_ACTION_SARIF_TROUBLESHOOTING.md
+++ b/docs/GITHUB_ACTION_SARIF_TROUBLESHOOTING.md
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: msaad00/agent-bom@v0.87.1
+      - uses: msaad00/agent-bom@v0.88.1
         with:
           scan-type: agents
           format: sarif

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -179,4 +179,4 @@ Current limitations:
 ## Review cadence
 
 This threat model is reviewed with each major release (x.0) and after any
-security advisory. Last reviewed: v0.87.1 (May 2026).
+security advisory. Last reviewed: v0.88.1 (May 2026).

--- a/docs/skills/POLICY.md
+++ b/docs/skills/POLICY.md
@@ -84,7 +84,7 @@ Actions are `warn`, `fail`, or `block`; `block` is treated as a failing gate.
 Run skills scanning as its own CI lane:
 
 ```yaml
-- uses: msaad00/agent-bom@v0.87.1
+- uses: msaad00/agent-bom@v0.88.1
   with:
     scan-type: skills
     scan-ref: .

--- a/site-docs/reference/agentic-workflows.md
+++ b/site-docs/reference/agentic-workflows.md
@@ -8,7 +8,7 @@ plane or runtime enforcement rollout.
 |---|---|---|---|---|
 | Local CLI | `agent-bom agents --demo --offline`, then `agent-bom agents -p .` | Reads local agent and MCP configuration from the developer machine. No control-plane credentials required. | Terminal findings, JSON, SARIF, SBOM, HTML, graph export. | Scheduled scan, Docker, GitHub Action. |
 | Claude, Cursor, Windsurf, VS Code, Cortex, Codex CLI | `agent-bom mcp server` | Exposes read-mostly security tools to the assistant. The assistant does not need direct scanner credentials beyond the local process boundary; Shield write actions require admin role and an audit reason. | MCP tool output, inventory, blast-radius answers, compliance checks, ranked `ExposurePath` JSON, deploy guidance. | Shared MCP configuration, skills, fleet sync. |
-| GitHub Actions | `uses: msaad00/agent-bom@v0.87.1` with SARIF upload enabled | Runs in CI with repository-scoped token permissions. Fork PR behavior depends on GitHub security policy. | `agent-bom-results.sarif`, pull-request summary, code-scanning alert category. | Branch protection, required code scanning, artifact retention. |
+| GitHub Actions | `uses: msaad00/agent-bom@v0.88.1` with SARIF upload enabled | Runs in CI with repository-scoped token permissions. Fork PR behavior depends on GitHub security policy. | `agent-bom-results.sarif`, pull-request summary, code-scanning alert category. | Branch protection, required code scanning, artifact retention. |
 | Skills and instruction files | `agent-bom skills scan . --policy skills-policy.yaml` | Reads repo-local instructions such as `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, and `skills/*.md`. | Skill trust findings, referenced package and MCP inventory, credential-env names, policy warn/block result. | Signed skills, provenance verification, registry publishing. |
 | Cloud and AI infrastructure | `agent-bom agents --preset enterprise` plus provider-specific flags only where credentials are approved. | Uses read-only provider APIs or local inventory files. Keep provider secrets in the operator boundary, not in repo docs. | Cloud, warehouse, GPU, model, dataset, and runtime package evidence. | Fleet sync, compliance exports, graph-backed findings. |
 | Runtime proxy | `agent-bom proxy --no-isolate --log audit.jsonl --block-undeclared -- ...` | Wraps selected local MCP traffic. Policy can block before an upstream tool receives the call. Container containment requires a stdio MCP path plus a configured sandbox image or an existing container command. | Tier-A audit JSONL, policy decisions, runtime alerts, metrics, and sandbox posture when isolation is enabled. | Sidecar proxy, gateway policy pull, SIEM export. |
@@ -31,7 +31,7 @@ when the buyer or contributor needs to see the first finding path quickly.
 ### CI Security Review
 
 ```yaml
-- uses: msaad00/agent-bom@v0.87.1
+- uses: msaad00/agent-bom@v0.88.1
   with:
     scan-type: agents
     severity-threshold: high
@@ -62,7 +62,7 @@ so future agent and SIEM push workflows share one event envelope.
 ### Skills CI Gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.87.1
+- uses: msaad00/agent-bom@v0.88.1
   with:
     scan-type: skills
     scan-ref: .

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -157,10 +157,31 @@ def _exit_incomplete_scan_with_partial_summary(
             "coverage_reason": str(exc),
         },
     )
-    ctx.con.print(f"  [yellow]⚠[/yellow] {exc}")
-    profile_defaulted_output = not _scan_output_target_was_explicit()
-    should_render_console_summary = (output_format == "console" and not output) or profile_defaulted_output
-    if should_render_console_summary and not quiet:
+    explicit_output_target = _scan_output_target_was_explicit()
+    machine_stdout = explicit_output_target and output_format != "console" and output in (None, "", "-")
+    if not machine_stdout:
+        ctx.con.print(f"  [yellow]⚠[/yellow] {exc}")
+    profile_defaulted_output = not explicit_output_target
+    if explicit_output_target:
+        render_output(
+            ctx,
+            output=output,
+            output_format=output_format,
+            no_tree=no_tree,
+            quiet=quiet,
+            no_color=no_color,
+            open_report=open_report,
+            compliance_export=compliance_export,
+            mermaid_mode=mermaid_mode,
+            push_gateway=push_gateway,
+            otel_endpoint=otel_endpoint,
+            baseline=baseline,
+            delta_mode=delta_mode,
+            verbose=verbose,
+            exclude_unfixable=exclude_unfixable,
+            fixable_only=fixable_only,
+        )
+    elif ((output_format == "console" and not output) or profile_defaulted_output) and not quiet:
         render_output(
             ctx,
             output=None,

--- a/src/agent_bom/cli/agents/_output.py
+++ b/src/agent_bom/cli/agents/_output.py
@@ -261,9 +261,13 @@ def render_output(
     elif output_format in ("text", "plain") and not output:
         _print_text(report, blast_radii)
     elif output_format == "json":
-        out_path = _resolve_output_path(output, output_format)
-        export_json(report, out_path)
-        con.print(f"\n  [green]✓[/green] JSON report: {out_path}")
+        if output in (None, "", "-"):
+            sys.stdout.write(json.dumps(to_json(report), indent=2))
+            sys.stdout.write("\n")
+        else:
+            out_path = _resolve_output_path(output, output_format)
+            export_json(report, out_path)
+            con.print(f"\n  [green]✓[/green] JSON report: {out_path}")
     elif output_format == "cyclonedx":
         out_path = _resolve_output_path(output, output_format)
         export_cyclonedx(report, out_path)

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -4,6 +4,7 @@ import json
 import os
 from urllib.parse import urlparse
 
+import pytest
 from click.testing import CliRunner
 
 from agent_bom.cli import main
@@ -186,6 +187,48 @@ def test_check_fail_on_severity_exits_one_when_threshold_matches(monkeypatch):
     payload = json.loads(result.output)
     assert payload["fail_on_severity"] == "high"
     assert payload["fail_on_severity_count"] == 1
+
+
+@pytest.mark.parametrize(
+    ("severities", "threshold", "expected_exit", "expected_count"),
+    [
+        ([Severity.HIGH], "high", 1, 1),
+        ([Severity.HIGH], "critical", 0, 0),
+        ([Severity.HIGH, Severity.LOW], "medium", 1, 1),
+        ([Severity.HIGH, Severity.LOW], "low", 1, 2),
+        ([Severity.MEDIUM], "medium", 1, 1),
+        ([Severity.MEDIUM], "low", 1, 1),
+    ],
+)
+def test_check_fail_on_severity_uses_at_or_above_threshold(
+    monkeypatch,
+    severities,
+    threshold,
+    expected_exit,
+    expected_count,
+):
+    _patch_check_scan(
+        monkeypatch,
+        [
+            Vulnerability(
+                id=f"CVE-2026-{idx:04d}",
+                summary=f"{severity.value.title()} issue",
+                severity=severity,
+                fixed_version="2.0.0",
+            )
+            for idx, severity in enumerate(severities, start=10)
+        ],
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["check", "demo@1.0.0", "--ecosystem", "pypi", "--fail-on-severity", threshold, "--format", "json", "--quiet"],
+    )
+
+    assert result.exit_code == expected_exit
+    payload = json.loads(result.output)
+    assert payload["fail_on_severity"] == threshold
+    assert payload["fail_on_severity_count"] == expected_count
 
 
 def test_check_incomplete_offline_scan_exits_two(monkeypatch):

--- a/tests/test_cli_p1_polish.py
+++ b/tests/test_cli_p1_polish.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from click.testing import CliRunner
 
@@ -37,9 +38,26 @@ def test_scan_inventory_stdin_sentinel_loads_json_payload() -> None:
             input=payload,
         )
         assert result.exit_code == 0, result.output
-        with open("agent-bom-report.json", encoding="utf-8") as report_file:
-            body = json.load(report_file)
+        body = json.loads(result.stdout)
         assert body["agents"][0]["name"] == "stdin-agent"
+        assert not (Path("agent-bom-report.json")).exists()
+
+
+def test_agents_json_output_path_is_honored() -> None:
+    payload = '{"agents":[{"name":"file-agent","agent_type":"custom","mcp_servers":[]}]}'
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            main,
+            ["agents", "--inventory", "-", "--no-scan", "-f", "json", "-o", "requested.json"],
+            input=payload,
+        )
+        assert result.exit_code == 0, result.output
+        assert result.stdout == ""
+        assert Path("requested.json").exists()
+        assert not Path("agent-bom-report.json").exists()
+        body = json.loads(Path("requested.json").read_text())
+        assert body["agents"][0]["name"] == "file-agent"
 
 
 def test_discovery_banner_deferred_until_after_inventory_validation() -> None:

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -983,6 +983,25 @@ output = "{profile_output}"
     assert not profile_output.exists()
 
 
+def test_scan_incomplete_offline_scan_honors_explicit_output(monkeypatch, tmp_path):
+    output = tmp_path / "partial-report.json"
+    monkeypatch.setattr("agent_bom.cli.agents.discover_all", lambda *args, **kwargs: [])
+
+    def _scan_agents_sync(*args, **kwargs):
+        raise IncompleteScanError("Offline mode requires a populated local vulnerability DB.")
+
+    monkeypatch.setattr("agent_bom.cli.agents.scan_agents_sync", _scan_agents_sync)
+
+    result = _run(["scan", "--demo", "--no-auto-update-db", "--format", "json", "--output", str(output)])
+
+    assert result.exit_code == 2
+    assert "populated local vulnerability DB" in result.output
+    assert output.exists()
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["scan_performance"]["coverage_state"] == "incomplete"
+    assert payload["scan_performance"]["coverage_reason"] == "Offline mode requires a populated local vulnerability DB."
+
+
 def test_scan_expands_local_docker_mcp_image():
     from agent_bom.cli.agents import _expand_docker_mcp_packages
     from agent_bom.models import MCPServer, Package, TransportType


### PR DESCRIPTION
Summary
- stream `agent-bom agents --format json` to stdout when no output path is supplied instead of silently writing `agent-bom-report.json`
- render explicit `--output` / machine-format targets even when an incomplete offline scan exits with partial coverage
- lock `check --fail-on-severity` as severity-at-or-above-threshold across critical/high/medium/low cases
- refresh stale v0.88.1 action examples and threat-model review stamp

Verification
- `uv run pytest tests/test_cli_p1_polish.py tests/test_cli_check.py::test_check_fail_on_severity_exits_zero_when_findings_below_threshold tests/test_cli_check.py::test_check_fail_on_severity_exits_one_when_threshold_matches tests/test_cli_check.py::test_check_fail_on_severity_uses_at_or_above_threshold tests/test_cli_scan.py::test_scan_incomplete_offline_scan_exits_two tests/test_cli_scan.py::test_scan_incomplete_offline_scan_honors_explicit_output -q`
- `uv run ruff check src/agent_bom/cli/agents/__init__.py src/agent_bom/cli/agents/_output.py tests/test_cli_p1_polish.py tests/test_cli_check.py tests/test_cli_scan.py`
- `python scripts/check_release_consistency.py`
- `git diff --check origin/main...HEAD`

Notes
- Incomplete offline scans still fail closed with exit 2; this change preserves explicit operator artifacts before exiting.
