### PR TITLE
docs(sdk): add Python adoption smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Security and release references:
 
 - [Threat model](docs/THREAT_MODEL.md)
 - [Pentest readiness](docs/PENTEST_READINESS.md)
+- [Python API and control-plane client](docs/PYTHON_API.md)
 - [Product metrics](docs/PRODUCT_METRICS.md)
 - [Release verification](docs/RELEASE_VERIFICATION.md)
 - [GitHub Action](https://github.com/marketplace/actions/agent-bom)

--- a/docs/PYTHON_API.md
+++ b/docs/PYTHON_API.md
@@ -1,8 +1,23 @@
 # Python API
 
 `agent-bom` exposes a small public Python API for tools that want typed scan
-results without shelling out to the CLI. The API is a wrapper over shipped
-scanner, inventory, and diff primitives; it is not a separate scanner.
+results without shelling out to the CLI, plus a typed control-plane client for
+stable REST endpoints. These surfaces are wrappers over shipped scanner,
+inventory, diff, and API primitives; they are not parallel implementations.
+
+## Install
+
+```bash
+pip install agent-bom
+```
+
+Use the API extra when the same environment also starts a local control plane:
+
+```bash
+pip install 'agent-bom[api]'
+```
+
+## Local Scan Helpers
 
 ```python
 from agent_bom import check, diff, scan
@@ -22,6 +37,37 @@ delta = diff("baseline.json", "current.json")
 print(delta.summary)
 ```
 
+## Control-Plane Client
+
+Use `AgentBomClient` from services, notebooks, and automation that already have
+an agent-bom API URL and token. The client keeps auth and tenant headers in one
+place and exposes stable evidence endpoints without requiring callers to build
+URLs manually.
+
+```python
+from agent_bom import AgentBomClient
+
+with AgentBomClient(
+    base_url="https://agent-bom.internal",
+    api_key="agent-bom-api-key",
+    tenant_id="tenant-a",
+) as client:
+    print(client.health()["status"])
+    manifest = client.agent_manifest()
+    runtime = client.runtime_production_index()
+    intel = client.intel_sources()
+
+print(manifest["schema_version"], runtime["schema_version"], len(intel.get("sources", [])))
+```
+
+For a smoke test against a running API:
+
+```bash
+AGENT_BOM_BASE_URL=http://127.0.0.1:8422 \
+AGENT_BOM_API_KEY=dev-key \
+python examples/python_sdk/control_plane_smoke.py
+```
+
 ## Functions
 
 | Function | Returns | Boundary |
@@ -32,6 +78,22 @@ print(delta.summary)
 | `agent_bom.sdk.inventory(...)` | `InventoryResult` | Parses JSON, CSV, or NDJSON inventory using the canonical inventory loader. Kept under `agent_bom.sdk` to avoid shadowing the existing `agent_bom.inventory` module. |
 | `diff(...)` | `DiffResult` | Diffs two agent-bom reports or SBOM documents using the history diff engine. |
 
+## Client Methods
+
+| Method | Endpoint | Use |
+|---|---|---|
+| `health()` | `GET /health` | API liveness and configured subsystem health. |
+| `agent_manifest()` | `GET /v1/agent-bom/manifest` | Tenant-scoped agent, MCP server, tool, and credential-reference posture. |
+| `runtime_production_index()` | `GET /v1/runtime/production-index` | Runtime traffic, policy, freshness, alert, and retention posture. |
+| `exposure_paths()` | `GET /v1/graph/exposure-paths` | Graph-backed reachability and blast-radius paths. |
+| `should_i_deploy(...)` | `POST /v1/graph/should-i-deploy` | Allow/warn/block deployment guidance from graph risk. |
+| `list_findings(...)` | `GET /v1/findings` | Normalized findings with severity and pagination filters. |
+| `ingest_findings(...)` | `POST /v1/findings/bulk` | Bulk finding ingest from external scanners or jobs. |
+| `register_dataset_version(...)` | `POST /v1/datasets/{dataset_id}/versions` | Dataset artifact evidence registration. |
+| `intel_lookup(...)` | `GET /v1/intel/advisories/{advisory_id}` | Advisory lookup by CVE, GHSA, or OSV ID. |
+| `intel_match(...)` | `POST /v1/intel/match` | Match package coordinates against local advisory intelligence. |
+| `intel_sources()` | `GET /v1/intel/sources` | Source registry and freshness metadata. |
+
 ## Notes
 
 - `check()` cannot be called from an already running event loop; use
@@ -40,3 +102,6 @@ print(delta.summary)
   scope. Passing both is allowed only when they refer to the same path.
 - The returned `AIBOMReport` uses the same typed dataclasses as the rest of the
   package, including `Finding`, `Asset`, `Package`, and `BlastRadius`.
+- The control-plane client accepts either `api_key` or `bearer_token`, not both.
+  `tenant_id` is sent as `X-Agent-Bom-Tenant-ID` and is also used as the
+  default tenant query/body value for tenant-scoped methods.

--- a/examples/python_sdk/README.md
+++ b/examples/python_sdk/README.md
@@ -1,0 +1,25 @@
+# Python SDK Examples
+
+These examples show the packaged Python adoption path for services, notebooks,
+and automation that need typed `agent-bom` evidence.
+
+## Control-Plane Smoke
+
+Start or point at an agent-bom API, then run:
+
+```bash
+AGENT_BOM_BASE_URL=http://127.0.0.1:8422 \
+AGENT_BOM_API_KEY=dev-key \
+AGENT_BOM_TENANT_ID=default \
+python examples/python_sdk/control_plane_smoke.py
+```
+
+The script calls the same stable endpoints exposed by `AgentBomClient`:
+
+- `/health`
+- `/v1/agent-bom/manifest`
+- `/v1/runtime/production-index`
+- `/v1/intel/sources`
+
+It prints one JSON envelope with status, schema versions, and intel source
+count. It does not send scan artifacts or secret values.

--- a/examples/python_sdk/control_plane_smoke.py
+++ b/examples/python_sdk/control_plane_smoke.py
@@ -1,0 +1,66 @@
+"""Smoke test a running agent-bom control plane with the Python client.
+
+Environment:
+    AGENT_BOM_BASE_URL   API base URL, for example http://127.0.0.1:8422
+    AGENT_BOM_API_KEY    Optional x-api-key value
+    AGENT_BOM_BEARER_TOKEN Optional bearer token; mutually exclusive with API key
+    AGENT_BOM_TENANT_ID  Optional tenant scope
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Sequence
+
+from agent_bom import AgentBomApiError, AgentBomClient
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Smoke test an agent-bom API with the Python client.")
+    parser.add_argument("--base-url", default=os.environ.get("AGENT_BOM_BASE_URL", "http://127.0.0.1:8422"))
+    parser.add_argument("--api-key", default=os.environ.get("AGENT_BOM_API_KEY"))
+    parser.add_argument("--bearer-token", default=os.environ.get("AGENT_BOM_BEARER_TOKEN"))
+    parser.add_argument("--tenant-id", default=os.environ.get("AGENT_BOM_TENANT_ID"))
+    return parser
+
+
+def run_smoke(*, base_url: str, api_key: str | None, bearer_token: str | None, tenant_id: str | None) -> dict[str, object]:
+    """Call stable read endpoints and return a compact adoption-smoke envelope."""
+
+    with AgentBomClient(base_url=base_url, api_key=api_key, bearer_token=bearer_token, tenant_id=tenant_id) as client:
+        health = client.health()
+        manifest = client.agent_manifest()
+        runtime = client.runtime_production_index()
+        intel_sources = client.intel_sources()
+
+    sources = intel_sources.get("sources", [])
+    return {
+        "status": "ok",
+        "health_status": health.get("status"),
+        "manifest_schema": manifest.get("schema_version"),
+        "runtime_schema": runtime.get("schema_version"),
+        "intel_sources": len(sources) if isinstance(sources, list) else 0,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        result = run_smoke(
+            base_url=args.base_url,
+            api_key=args.api_key,
+            bearer_token=args.bearer_token,
+            tenant_id=args.tenant_id,
+        )
+    except AgentBomApiError as exc:
+        sys.stdout.write(json.dumps({"status": "error", "status_code": exc.status_code, "body": exc.body}, sort_keys=True) + "\n")
+        return 1
+    sys.stdout.write(json.dumps(result, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site-docs/api/python-sdk.md
+++ b/site-docs/api/python-sdk.md
@@ -1,7 +1,22 @@
 # Python API
 
 Use the public Python API when another tool needs typed `agent-bom` results
-without parsing terminal output.
+without parsing terminal output, or when services and notebooks need a small
+control-plane client for stable REST endpoints.
+
+## Install
+
+```bash
+pip install agent-bom
+```
+
+Use the API extra when the same environment also starts a local control plane:
+
+```bash
+pip install 'agent-bom[api]'
+```
+
+## Local Scan Helpers
 
 ```python
 from agent_bom import check, diff, scan
@@ -23,5 +38,35 @@ print(delta.summary)
 
 The API delegates to the same scanner, inventory, and history-diff primitives
 used elsewhere in the product. It is not a parallel scan engine.
+
+## Control-Plane Client
+
+```python
+from agent_bom import AgentBomClient
+
+with AgentBomClient(
+    base_url="https://agent-bom.internal",
+    api_key="agent-bom-api-key",
+    tenant_id="tenant-a",
+) as client:
+    print(client.health()["status"])
+    manifest = client.agent_manifest()
+    runtime = client.runtime_production_index()
+    intel = client.intel_sources()
+
+print(manifest["schema_version"], runtime["schema_version"], len(intel.get("sources", [])))
+```
+
+Run the packaged smoke example against a live API:
+
+```bash
+AGENT_BOM_BASE_URL=http://127.0.0.1:8422 \
+AGENT_BOM_API_KEY=dev-key \
+python examples/python_sdk/control_plane_smoke.py
+```
+
+The client accepts either `api_key` or `bearer_token`. `tenant_id` is sent as
+`X-Agent-Bom-Tenant-ID` and used as the default tenant scope for tenant-aware
+methods.
 
 ::: agent_bom.sdk

--- a/tests/test_python_client_smoke_example.py
+++ b/tests/test_python_client_smoke_example.py
@@ -1,0 +1,84 @@
+"""Live smoke coverage for the documented Python control-plane example."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+from urllib.parse import urlparse
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE = ROOT / "examples" / "python_sdk" / "control_plane_smoke.py"
+
+
+def _load_example() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("control_plane_smoke", EXAMPLE)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Handler(BaseHTTPRequestHandler):
+    seen_headers: list[dict[str, str]] = []
+
+    def log_message(self, _format: str, *_args: Any) -> None:
+        return
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
+        _Handler.seen_headers.append(dict(self.headers))
+        path = urlparse(self.path).path
+        payloads = {
+            "/health": {"status": "ok"},
+            "/v1/agent-bom/manifest": {"schema_version": "agent-bom.manifest/v1", "agents": []},
+            "/v1/runtime/production-index": {"schema_version": "runtime.production_index.v1", "status": "ok"},
+            "/v1/intel/sources": {"schema_version": "intel.sources.v1", "sources": [{"name": "osv"}]},
+        }
+        payload = payloads.get(path)
+        if payload is None:
+            self.send_response(404)
+            self.end_headers()
+            return
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def test_python_sdk_control_plane_smoke_example_runs_against_local_http_server() -> None:
+    _Handler.seen_headers = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        module = _load_example()
+        result = module.run_smoke(
+            base_url=f"http://127.0.0.1:{server.server_port}",
+            api_key="dev-key",
+            bearer_token=None,
+            tenant_id="tenant-a",
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert result == {
+        "health_status": "ok",
+        "intel_sources": 1,
+        "manifest_schema": "agent-bom.manifest/v1",
+        "runtime_schema": "runtime.production_index.v1",
+        "status": "ok",
+    }
+    assert _Handler.seen_headers
+    for headers in _Handler.seen_headers:
+        normalized = {key.lower(): value for key, value in headers.items()}
+        assert normalized["x-api-key"] == "dev-key"
+        assert normalized["x-agent-bom-tenant-id"] == "tenant-a"


### PR DESCRIPTION
Summary
- document the Python control-plane client install path, auth modes, and common methods
- add a runnable local smoke example for health, manifest, runtime production index, and intel sources
- add a regression test that exercises the example against a local HTTP server

Verification
- `uv run pytest tests/test_python_client.py tests/test_python_client_route_parity.py tests/test_public_python_api.py tests/test_python_client_smoke_example.py -q`
- `uv run ruff check examples/python_sdk/control_plane_smoke.py tests/test_python_client_smoke_example.py`
- `uv run mypy examples/python_sdk/control_plane_smoke.py tests/test_python_client_smoke_example.py`
- `python scripts/check_release_consistency.py`
- `git diff --check main...HEAD`

Notes
- This turns the shipped Python client into a copy-paste adoption path without changing the SDK runtime surface.