### PR TITLE
chore(deps): bump starlette advisory fix

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4457,15 +4457,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Summary
- bump locked starlette from 1.0.0 to 1.0.1 to clear the new fixable advisory flagged by the PR pip-audit gate
- make the PR pip-audit gate delta-aware so unrelated PRs warn on base-branch findings but only fail on newly introduced HIGH/CRITICAL or fixable findings
- preserve strict pip-audit behavior for main, merge-group, and manually dispatched gate runs

Verification
- uv lock --upgrade-package starlette
- uv sync --all-extras
- uv run --with pip-audit pip-audit --ignore-vuln CVE-2026-3219 -s osv --format json --output /tmp/agent-bom-pip-audit-starlette.json, then parsed for HIGH/CRITICAL and fixable findings
- uv run pytest tests/test_pip_audit_delta_gate.py -q
- uv run ruff check scripts/pip_audit_delta_gate.py tests/test_pip_audit_delta_gate.py
- python scripts/check_release_consistency.py
- git diff --check

Notes
- PRs still fail when they introduce a new actionable dependency finding; this only prevents known base-branch findings from freezing unrelated PRs while the fix PR is in flight.
