### PR TITLE
fix(ci): compare pip-audit PR deltas

### DIFF
--- a/.github/workflows/pr-security-gate.yml
+++ b/.github/workflows/pr-security-gate.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install runtime deps (not dev) — scan the shipping dep set
         run: uv sync --frozen --extra api --extra postgres --extra mcp-server --extra oidc
 
-      - name: Run pip-audit with JSON gate
+      - name: Run pip-audit on current checkout
         run: |
           set +e
           uv run --with pip-audit pip-audit --ignore-vuln CVE-2026-3219 \
@@ -95,44 +95,45 @@ jobs:
             --output audit.json
           set -e
 
-          python3 - <<'PY'
-          import json
-          from pathlib import Path
+      - name: Run pip-audit on PR base for delta comparison
+        if: github.event_name == 'pull_request'
+        run: |
+          current_dir="$PWD"
+          base_dir="$RUNNER_TEMP/agent-bom-base"
+          git fetch --depth=1 origin "+${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+          git worktree add "$base_dir" "origin/${{ github.base_ref }}"
+          (
+            cd "$base_dir"
+            uv sync --frozen --extra api --extra postgres --extra mcp-server --extra oidc
+            set +e
+            uv run --with pip-audit pip-audit --ignore-vuln CVE-2026-3219 \
+              -s osv \
+              --format json \
+              --output "$current_dir/base-audit.json"
+            set -e
+          )
 
-          path = Path("audit.json")
-          if not path.is_file():
-              raise SystemExit("pip-audit did not produce audit.json")
-          data = json.loads(path.read_text(encoding="utf-8"))
-          fixable = []
-          severe = []
-          for dependency in data.get("dependencies", []):
-              dep_name = dependency.get("name", "<unknown>")
-              dep_version = dependency.get("version", "<unknown>")
-              for vuln in dependency.get("vulns", []):
-                  vuln_id = vuln.get("id", "<unknown>")
-                  severity = str(vuln.get("severity") or vuln.get("severity_level") or "").upper()
-                  fix_versions = vuln.get("fix_versions") or []
-                  if severity in {"HIGH", "CRITICAL"}:
-                      severe.append(f"{dep_name} {dep_version} {vuln_id} severity={severity}")
-                  if fix_versions:
-                      fixable.append(f"{dep_name} {dep_version} {vuln_id} fixes={','.join(fix_versions)}")
-          if severe:
-              print("::error::pip-audit found HIGH/CRITICAL vulnerabilities:")
-              print("\n".join(severe[:20]))
-              raise SystemExit(1)
-          if fixable:
-              print("::error::pip-audit found vulnerabilities with available fixes:")
-              print("\n".join(fixable[:20]))
-              raise SystemExit(1)
-          print("pip-audit JSON gate passed: no HIGH/CRITICAL or fixable findings")
-          PY
+      - name: Evaluate pip-audit gate
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            python scripts/pip_audit_delta_gate.py \
+              --mode delta \
+              --current audit.json \
+              --base base-audit.json
+          else
+            python scripts/pip_audit_delta_gate.py \
+              --mode strict \
+              --current audit.json
+          fi
 
       - name: Upload pip-audit report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pip-audit-report
-          path: audit.json
+          path: |
+            audit.json
+            base-audit.json
 
   self-scan-pr:
     name: agent-bom self-scan on PR

--- a/scripts/pip_audit_delta_gate.py
+++ b/scripts/pip_audit_delta_gate.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Evaluate pip-audit JSON output for PR and strict dependency gates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SEVERE_LEVELS = {"HIGH", "CRITICAL"}
+
+
+@dataclass(frozen=True, order=True)
+class AuditFinding:
+    package: str
+    version: str
+    vulnerability_id: str
+    severe: bool
+    fix_versions: tuple[str, ...]
+
+    @property
+    def identity(self) -> tuple[str, str, str]:
+        return (self.package.lower(), self.version, self.vulnerability_id)
+
+    @property
+    def actionable(self) -> bool:
+        return self.severe or bool(self.fix_versions)
+
+    def summary(self) -> str:
+        parts = [self.package, self.version, self.vulnerability_id]
+        if self.severe:
+            parts.append("severity=HIGH/CRITICAL")
+        if self.fix_versions:
+            parts.append(f"fixes={','.join(self.fix_versions)}")
+        return " ".join(parts)
+
+
+def load_audit(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise SystemExit(f"pip-audit did not produce {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def actionable_findings(data: dict[str, Any]) -> list[AuditFinding]:
+    findings: list[AuditFinding] = []
+    for dependency in data.get("dependencies", []):
+        dep_name = str(dependency.get("name") or "<unknown>")
+        dep_version = str(dependency.get("version") or "<unknown>")
+        for vuln in dependency.get("vulns", []):
+            vuln_id = str(vuln.get("id") or "<unknown>")
+            severity = str(vuln.get("severity") or vuln.get("severity_level") or "").upper()
+            fix_versions = tuple(str(version) for version in (vuln.get("fix_versions") or []))
+            finding = AuditFinding(
+                package=dep_name,
+                version=dep_version,
+                vulnerability_id=vuln_id,
+                severe=severity in SEVERE_LEVELS,
+                fix_versions=fix_versions,
+            )
+            if finding.actionable:
+                findings.append(finding)
+    return sorted(findings)
+
+
+def introduced_findings(current: list[AuditFinding], base: list[AuditFinding]) -> list[AuditFinding]:
+    base_ids = {finding.identity for finding in base}
+    return [finding for finding in current if finding.identity not in base_ids]
+
+
+def emit_blocking(kind: str, findings: list[AuditFinding]) -> None:
+    print(f"::error::pip-audit found {len(findings)} {kind} actionable finding(s):")
+    for finding in findings[:20]:
+        print(finding.summary())
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--current", type=Path, required=True, help="pip-audit JSON for the current checkout")
+    parser.add_argument("--base", type=Path, help="pip-audit JSON for the PR base branch")
+    parser.add_argument("--mode", choices=("strict", "delta"), default="strict")
+    args = parser.parse_args(argv)
+
+    current = actionable_findings(load_audit(args.current))
+    if args.mode == "strict":
+        if current:
+            emit_blocking("current", current)
+            return 1
+        print("pip-audit strict gate passed: no HIGH/CRITICAL or fixable findings")
+        return 0
+
+    if args.base is None:
+        raise SystemExit("--base is required in delta mode")
+    base = actionable_findings(load_audit(args.base))
+    introduced = introduced_findings(current, base)
+    if introduced:
+        emit_blocking("new", introduced)
+        print(f"Base branch already had {len(base)} actionable finding(s); only new PR-introduced findings block this gate.")
+        return 1
+    if current:
+        print(f"::warning::pip-audit found {len(current)} actionable finding(s), all already present on the base branch")
+    print("pip-audit PR delta gate passed: no new HIGH/CRITICAL or fixable findings")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_pip_audit_delta_gate.py
+++ b/tests/test_pip_audit_delta_gate.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "pip_audit_delta_gate.py"
+SPEC = importlib.util.spec_from_file_location("pip_audit_delta_gate", MODULE_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+gate = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = gate
+SPEC.loader.exec_module(gate)
+
+
+def _audit(*dependencies: dict[str, object]) -> dict[str, object]:
+    return {"dependencies": list(dependencies)}
+
+
+def _dependency(
+    name: str = "starlette",
+    version: str = "1.0.0",
+    vuln_id: str = "PYSEC-2026-161",
+    *,
+    fix_versions: list[str] | None = None,
+    severity: str | None = None,
+) -> dict[str, object]:
+    vuln: dict[str, object] = {"id": vuln_id}
+    if fix_versions is not None:
+        vuln["fix_versions"] = fix_versions
+    if severity is not None:
+        vuln["severity"] = severity
+    return {"name": name, "version": version, "vulns": [vuln]}
+
+
+def _write_json(path: Path, data: dict[str, object]) -> None:
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_delta_gate_allows_findings_already_present_on_base(tmp_path: Path) -> None:
+    current = tmp_path / "current.json"
+    base = tmp_path / "base.json"
+    finding = _dependency(fix_versions=["1.0.1"])
+    _write_json(current, _audit(finding))
+    _write_json(base, _audit(finding))
+
+    assert gate.main(["--mode", "delta", "--current", str(current), "--base", str(base)]) == 0
+
+
+def test_delta_gate_blocks_new_fixable_findings(tmp_path: Path) -> None:
+    current = tmp_path / "current.json"
+    base = tmp_path / "base.json"
+    _write_json(current, _audit(_dependency(fix_versions=["1.0.1"])))
+    _write_json(base, _audit())
+
+    assert gate.main(["--mode", "delta", "--current", str(current), "--base", str(base)]) == 1
+
+
+def test_strict_gate_blocks_existing_actionable_findings(tmp_path: Path) -> None:
+    current = tmp_path / "current.json"
+    _write_json(current, _audit(_dependency(fix_versions=["1.0.1"])))
+
+    assert gate.main(["--mode", "strict", "--current", str(current)]) == 1
+
+
+def test_high_severity_without_fix_is_actionable() -> None:
+    findings = gate.actionable_findings(_audit(_dependency(severity="HIGH")))
+
+    assert len(findings) == 1
+    assert findings[0].severe is True


### PR DESCRIPTION
Summary
- make the PR pip-audit gate compare current checkout findings against the PR base branch
- keep PRs blocking on newly introduced HIGH/CRITICAL or fixable dependency findings while warning on known base-branch findings
- preserve strict pip-audit behavior for main, merge-group, and manually dispatched gate runs

Verification
- uv run pytest tests/test_pip_audit_delta_gate.py -q
- uv run ruff check scripts/pip_audit_delta_gate.py tests/test_pip_audit_delta_gate.py
- python scripts/check_release_consistency.py
- git diff --check HEAD~1..HEAD

Notes
- This prevents unrelated PRs from repeatedly failing while a base-branch advisory fix is already in flight.