### PR TITLE
fix(runtime): sanitize identity error logs

### DIFF
--- a/src/agent_bom/agent_identity.py
+++ b/src/agent_bom/agent_identity.py
@@ -35,6 +35,8 @@ import threading
 import time
 from typing import Any
 
+from agent_bom.security import sanitize_log_label
+
 logger = logging.getLogger(__name__)
 
 # Sentinel used when no identity token is provided
@@ -47,6 +49,14 @@ _ACCEPTED_ALGORITHMS = ["RS256", "RS384", "RS512", "ES256", "ES384", "ES512"]
 _jwks_cache: dict[str, tuple[dict, float]] = {}
 _jwks_lock = threading.Lock()
 _JWKS_CACHE_TTL = 3600.0  # 1 hour
+
+
+def _sanitize_identity_error(error: str) -> str:
+    """Return a bounded single-line identity validation reason."""
+
+    sanitized = sanitize_log_label(error, max_len=240)
+    sanitized = sanitized.replace("\\r", " ").replace("\\n", " ").replace("\\t", " ")
+    return sanitize_log_label(sanitized, max_len=240) or "identity validation failed"
 
 
 # ─── JWKS helpers ────────────────────────────────────────────────────────────
@@ -293,9 +303,10 @@ def check_identity(
     agent_id, error = resolve_agent_id(token, policy)
 
     if error is not None:
-        logger.debug("Identity token error: %s", error)
+        safe_error = _sanitize_identity_error(error)
+        logger.debug("Identity token error: %s", safe_error)
         if policy.get("require_agent_identity"):
-            return agent_id, f"Identity required: {error}"
+            return agent_id, f"Identity required: {safe_error}"
         return ANONYMOUS, None
 
     return agent_id, None

--- a/tests/test_agent_identity.py
+++ b/tests/test_agent_identity.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import base64
 import io
 import json
+import logging
 import time
 
+import agent_bom.agent_identity as identity_mod
 from agent_bom.agent_identity import (
     ANONYMOUS,
     check_identity,
@@ -234,6 +236,30 @@ def test_check_identity_unknown_token_required_blocks():
     policy = {"require_agent_identity": True}
     agent_id, block = check_identity(msg, policy)
     assert block is not None
+
+
+def test_check_identity_sanitizes_error_before_logging(caplog, monkeypatch):
+    token = _make_jwt({"sub": "agent-x"}, header={"alg": "RS256", "kid": "line1\nline2"})
+    msg = _msg_with_identity(token)
+    policy = {"require_agent_identity": True, "jwks_uri": "https://idp.example.invalid/jwks"}
+    monkeypatch.setattr(identity_mod, "_fetch_jwks", lambda _uri: {"keys": []})
+
+    caplog.set_level(logging.DEBUG, logger="agent_bom.agent_identity")
+    _agent_id, block = check_identity(msg, policy)
+
+    assert block is not None
+    assert "line1 line2" in block
+    assert "\n" not in block
+    assert "\r" not in block
+    assert "\\n" not in block
+    assert "\\r" not in block
+    assert all(
+        "\n" not in record.getMessage()
+        and "\r" not in record.getMessage()
+        and "\\n" not in record.getMessage()
+        and "\\r" not in record.getMessage()
+        for record in caplog.records
+    )
 
 
 # ─── log_tool_call carries agent_id ──────────────────────────────────────────


### PR DESCRIPTION
Summary
- sanitize agent identity validation errors before logging or returning enforced block reasons
- normalize literal and escaped control characters from malformed JWT metadata
- add a regression test for newline-safe identity error logging

Verification
- uv run pytest tests/test_agent_identity.py -q
- uv run ruff check src/agent_bom/agent_identity.py tests/test_agent_identity.py
- python scripts/check_release_consistency.py
- git diff --check

Notes
- Addresses the CodeQL log-injection alert in agent identity validation.