### PR TITLE
feat(intel): add governed source brief metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ integration docs instead of this front door.
 | Python client | services, notebooks, and automation | typed helper for stable REST endpoints in the packaged wheel |
 | TypeScript client | services and agent runtimes | typed helper for stable REST endpoints |
 
-MCP server mode advertises 54 MCP tools, 6 resources, and 6 workflow prompts.
+MCP server mode advertises 55 MCP tools, 6 resources, and 6 workflow prompts.
 Most tools are read-only. The three Shield write actions fail closed unless
 the caller supplies `operator_role=admin` and an audit reason.
 

--- a/docs/CLAUDE_INTEGRATION.md
+++ b/docs/CLAUDE_INTEGRATION.md
@@ -59,7 +59,7 @@ claude mcp add agent-bom -- uvx agent-bom mcp server
 
 ## What users get inside Claude
 
-`agent-bom mcp server` exposes 54 MCP tools for:
+`agent-bom mcp server` exposes 55 MCP tools for:
 
 - agent and MCP discovery
 - package and registry checks

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -322,9 +322,10 @@ tenant boundary, persistence behavior, and redaction behavior here.
 | `runtime.production_index.v1` | `GET /v1/runtime/production-index`, `runtime_production_index` MCP tool | runtime cockpit, deploy/runbooks, drift evaluator, SIEM/export hooks | `traffic`, `policy_decisions`, `authorization_trace`, `alerts`, `active_sources`, `active_sessions`, `freshness`, `retention_posture` | Derived from tenant-scoped proxy/gateway metrics and alerts. Raw prompts and tool arguments are `no_persist`; the endpoint is metadata/redaction-first. |
 | `runtime.blueprints.v1` | `GET /v1/runtime/blueprints`, `runtime_blueprints` MCP tool | admins, runtime policy authors, drift evaluator, docs | role/profile blueprint list with `allowed_tool_categories`, `restricted_tool_categories`, `approval_required_for`, `retention_mode`, `evidence_required` | Static canonical catalog in `runtime_blueprints.py`; custom blueprint persistence is not shipped yet. |
 | `runtime.blueprint_drift.v1` | `GET /v1/runtime/blueprints/{blueprint_id}/drift`, `runtime_blueprint_drift` MCP tool | runtime operators, agents, alerting, release evidence | `status`, `drift_score`, `observed.categories`, `violations`, `warnings`, selected `blueprint`, `retention` | Compares the selected blueprint against the tenant-scoped production index. Current behavior is report-only and fail-closed to metadata retention. |
-| `intel.sources.v1` | `GET /v1/intel/sources`, `intel_sources` MCP tool | analysts, agents, freshness monitors, docs | canonical source catalog with `source_id`, tier, kind, URL, license, redistribution policy, `feed_run` | Reads local vuln DB `sync_meta`; source metadata is shared catalog data, feed-run freshness is local deployment state. |
-| `intel.lookup.v1` | `GET /v1/intel/advisories/{advisory_id}`, `intel_lookup` MCP tool | finding enrichment, analyst lookup, agent investigation | `found`, `query`, `advisory.canonical_ids`, severity, CVSS, EPSS, KEV, CWE, affected packages, `evidence_links` | Read-only local vuln DB lookup. It can resolve CVE, GHSA, and OSV aliases and returns source links without implying every link was fetched. |
-| `intel.match.v1` | `POST /v1/intel/match`, `intel_match` MCP tool | inventory enrichment, CI gates, agent posture checks | submitted packages, matched package count, advisory matches, evidence links | Read-only package-coordinate matching. Inputs use purl when present; otherwise `ecosystem` + `name` + optional `version`. |
+| `intel.sources.v1` | `GET /v1/intel/sources`, `intel_sources` MCP tool | analysts, agents, freshness monitors, docs | canonical source catalog with `source_id`, tier, kind, source/homepage/license URLs, robots policy, connector type, enabled state, owner, parser version, validation status, redistribution policy, `feed_run` | Reads local vuln DB `sync_meta`; source metadata is shared catalog data, feed-run freshness is local deployment state. It does not imply open-ended scraping. |
+| `intel.lookup.v1` | `GET /v1/intel/advisories/{advisory_id}`, `intel_lookup` MCP tool | finding enrichment, analyst lookup, agent investigation | `found`, `query`, `advisory.canonical_ids`, severity, CVSS, EPSS, KEV, CWE, affected packages, `match_method`, `match_confidence`, source policy, `evidence_links` | Read-only local vuln DB lookup. It can resolve CVE, GHSA, and OSV aliases and returns source links without implying every link was fetched. |
+| `intel.match.v1` | `POST /v1/intel/match`, `intel_match` MCP tool | inventory enrichment, CI gates, agent posture checks | submitted packages, matched package count, advisory matches, `match_method`, `match_confidence`, match reason, evidence links | Read-only package-coordinate matching. Inputs use purl when present; otherwise `ecosystem` + `name` + optional `version`. |
+| `intel.daily_brief.v1` | `POST /v1/intel/daily-brief`, `intel_daily_brief` MCP tool | analysts, agents, daily governance jobs | local KEV lookback, high-EPSS inventory matches, vendor advisory matches, source registry freshness, limitations | Read-only summary over local DB and submitted inventory. IoC telemetry, campaign, and sector/geo sections remain empty unless those inputs are configured by a future connector. |
 
 ### `agent-bom.manifest/v1`
 
@@ -391,7 +392,8 @@ fail-open/fail-closed notes in the same PR.
 
 The threat-intel envelopes are local, source-attributed lookup surfaces over
 the existing vulnerability database. They are not yet the full pluggable
-IntelItem corpus proposed for future connector work.
+IntelItem corpus proposed for future connector work, and they do not ship
+open-ended web scraping.
 
 | Join key | Preferred use |
 |---|---|
@@ -403,6 +405,12 @@ IntelItem corpus proposed for future connector work.
 When full IntelItem provenance lands, it must preserve this read-only lookup
 shape while adding raw-artifact provenance, signatures, corroboration, citation
 spans, and connector health as additional fields or linked resources.
+
+Vendor advisory feed policy is explicit in `intel.sources.v1`: structured CSAF
+matching is supported where a structured feed exists; curated vendor seeds are
+marked experimental and source-linked until a governed connector with validated
+license/robots handling is shipped. Current daily briefs use these decisions
+to distinguish supported source records from experimental seed matches.
 
 ### `inventory_snapshot.packages`
 

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,8 +53,8 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 180 |
-| `docs/openapi/v1.json` | component schemas | 55 |
+| `docs/openapi/v1.json` | paths | 181 |
+| `docs/openapi/v1.json` | component schemas | 56 |
 
 <!-- DATA_MODEL_ATLAS:END -->
 

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -210,7 +210,7 @@ For cross-agent correlation, use the broader runtime protection engine (`agent-b
 agent-bom mcp server
 ```
 
-Exposes 54 tools to any MCP-compatible AI assistant. Your agent can run scans,
+Exposes 55 tools to any MCP-compatible AI assistant. Your agent can run scans,
 check packages, query ExposurePaths, ask for deploy decisions, query threat
 intel, inspect runtime posture, run admin-gated Shield actions, and generate
 compliance reports without leaving the chat:

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,6 +1,6 @@
 # MCP Server — Connect agent-bom to AI Assistants
 
-agent-bom exposes 54 MCP tools as an MCP server. Any MCP-compatible client can
+agent-bom exposes 55 MCP tools as an MCP server. Any MCP-compatible client can
 connect and get vulnerability scanning, blast radius analysis, compliance
 checks, runtime posture, and supply-chain verification through natural
 conversation.
@@ -156,7 +156,7 @@ agent-bom proxy-bootstrap \
 
 `proxy-configure` is best for JSON MCP clients such as Claude Desktop, Cursor, Windsurf, and Cortex CoCo. TOML-based clients like Codex CLI need manual proxy wrapping.
 
-## Tool Categories (54 tools)
+## Tool Categories (55 tools)
 
 | Category | Tools | What They Do |
 |----------|-------|-------------|

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -127,7 +127,7 @@ notes discuss agent-native product direction.
 | Area | Shipped today | Not yet shipped |
 |---|---|---|
 | Human cockpit | Next.js dashboard, graph cockpit, reports, compliance and audit views | every UI action backed by a source registry and persisted workflow state |
-| Agent interface | 54 MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture, admin-gated Shield actions | long-lived posture subscription tool, autonomous remediation actions |
+| Agent interface | 55 MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture, admin-gated Shield actions | long-lived posture subscription tool, autonomous remediation actions |
 | Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports, TypeScript control-plane client, TypeScript runtime detector package | Python/Go control-plane SDKs and full scanner SDKs |
 | Runtime | MCP proxy, gateway, Shield SDK, runtime audit and policy decisions | webhook outbox, Kafka connectors, cloud-log ingestion connectors, Kinesis/Firehose adapter, and MCP posture subscriptions |
 | Graph scale | SQLite/Postgres default path, WebGL overview, optional Neptune adapter work | production Neptune SLOs, public openCypher endpoint, mandatory graph-database backend |

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -4,7 +4,7 @@
   "metrics": [
     {
       "name": "MCP tools",
-      "value": 54,
+      "value": 55,
       "source": "src/agent_bom/mcp_server_metadata.py",
       "notes": "Counted from the advertised server-card tools."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -10,7 +10,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |
-| MCP tools | 54 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
+| MCP tools | 55 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 35 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -1249,6 +1249,43 @@
         "title": "HealthResponse",
         "type": "object"
       },
+      "IntelDailyBriefRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "epss_threshold": {
+            "default": 0.7,
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Epss Threshold",
+            "type": "number"
+          },
+          "kev_window_hours": {
+            "default": 24,
+            "maximum": 168.0,
+            "minimum": 1.0,
+            "title": "Kev Window Hours",
+            "type": "integer"
+          },
+          "limit": {
+            "default": 100,
+            "maximum": 500.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "packages": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "maxItems": 500,
+            "title": "Packages",
+            "type": "array"
+          }
+        },
+        "title": "IntelDailyBriefRequest",
+        "type": "object"
+      },
       "IntelPackageMatchRequest": {
         "additionalProperties": false,
         "properties": {
@@ -10953,6 +10990,50 @@
           }
         },
         "summary": "Get Intel Advisory",
+        "tags": [
+          "intel"
+        ]
+      }
+    },
+    "/v1/intel/daily-brief": {
+      "post": {
+        "description": "Return a local analyst threat brief from governed intel sources.",
+        "operationId": "post_intel_daily_brief_v1_intel_daily_brief_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IntelDailyBriefRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Post Intel Daily Brief V1 Intel Daily Brief Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Post Intel Daily Brief",
         "tags": [
           "intel"
         ]

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -852,6 +852,36 @@ components:
       - storage
       title: HealthResponse
       type: object
+    IntelDailyBriefRequest:
+      additionalProperties: false
+      properties:
+        epss_threshold:
+          default: 0.7
+          maximum: 1.0
+          minimum: 0.0
+          title: Epss Threshold
+          type: number
+        kev_window_hours:
+          default: 24
+          maximum: 168.0
+          minimum: 1.0
+          title: Kev Window Hours
+          type: integer
+        limit:
+          default: 100
+          maximum: 500.0
+          minimum: 1.0
+          title: Limit
+          type: integer
+        packages:
+          items:
+            additionalProperties: true
+            type: object
+          maxItems: 500
+          title: Packages
+          type: array
+      title: IntelDailyBriefRequest
+      type: object
     IntelPackageMatchRequest:
       additionalProperties: false
       properties:
@@ -7201,6 +7231,34 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Get Intel Advisory
+      tags:
+      - intel
+  /v1/intel/daily-brief:
+    post:
+      description: Return a local analyst threat brief from governed intel sources.
+      operationId: post_intel_daily_brief_v1_intel_daily_brief_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IntelDailyBriefRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Post Intel Daily Brief V1 Intel Daily Brief Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Post Intel Daily Brief
       tags:
       - intel
   /v1/intel/match:

--- a/integrations/docker-mcp-registry/tools.json
+++ b/integrations/docker-mcp-registry/tools.json
@@ -42,6 +42,16 @@
     "arguments": []
   },
   {
+    "name": "intel_daily_brief",
+    "description": "Return a local analyst threat brief from governed intel sources.",
+    "arguments": [
+      {"name": "packages", "type": "array", "desc": "Optional package coordinates with purl or ecosystem/name/version fields"},
+      {"name": "epss_threshold", "type": "number", "desc": "Minimum EPSS probability for high-EPSS inventory matches"},
+      {"name": "kev_window_hours", "type": "integer", "desc": "Lookback window for recent KEV additions"},
+      {"name": "limit", "type": "integer", "desc": "Maximum advisories to return per section"}
+    ]
+  },
+  {
     "name": "blast_radius",
     "description": "Look up the blast radius of a specific CVE — shows which agents, credentials, and tools are affected.",
     "arguments": [

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -398,7 +398,7 @@ def main() -> int:
     tools = len(tool_names)
     resources = len(resource_uris)
     prompts = len(prompt_names)
-    if (tools, resources, prompts) != (54, 6, 6):
+    if (tools, resources, prompts) != (55, 6, 6):
         _fail(f"MCP server card count changed unexpectedly: tools={tools}, resources={resources}, prompts={prompts}")
     docker_mcp_tool_names = [str(tool["name"]) for tool in json.loads(DOCKER_MCP_TOOLS.read_text())]
     if docker_mcp_tool_names != tool_names:

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server Setup
 
-agent-bom runs as an MCP server, exposing 54 MCP tools to any MCP client.
+agent-bom runs as an MCP server, exposing 55 MCP tools to any MCP client.
 The server card also advertises 6 resources and 6 workflow prompts so agents can
 choose structured playbooks instead of guessing tool order.
 Most tools are read-only. Shield write actions require `operator_role=admin`

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -55,7 +55,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 |---|---|---|
 | **CLI / CI** | developers and pipelines | local scans, SARIF/SBOM/HTML/JSON, graph exports, deterministic gates |
 | **REST API** | security platforms, SIEM jobs, custom services | self-hosted control-plane routes for scans, normalized bulk findings, dataset versions, graph evidence, audit, and governance |
-| **MCP tools** | AI agents and coding assistants | 54 tools, strict args, `exposure_paths`, `should_i_deploy`, runtime posture, audited Shield actions |
+| **MCP tools** | AI agents and coding assistants | 55 tools, strict args, `exposure_paths`, `should_i_deploy`, runtime posture, audited Shield actions |
 | **TypeScript client** | services and agent runtimes calling the control plane | typed helper for stable REST endpoints; not a scanner SDK |
 | **TypeScript runtime detectors** | MCP/runtime enforcement integrations | local detector package for runtime policy checks; separate from the control-plane client |
 | **UI cockpit** | security teams and auditors | graph cockpit, compliance, audit, and evidence review over the same backend data |

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -30,9 +30,17 @@ intel_match(purl="pkg:pypi/requests@2.31.0")
 ```
 
 ### intel_sources
-List configured threat-intel sources and local feed freshness metadata.
+List governed threat-intel sources, source policy, and local feed freshness metadata.
 ```
 intel_sources()
+```
+
+### intel_daily_brief
+Return a local analyst brief with KEV lookback, high-EPSS inventory matches,
+vendor advisory matches, and source-registry freshness. It summarizes local DB
+evidence and submitted inventory only; it does not scrape vendor pages.
+```
+intel_daily_brief(packages=[{"purl": "pkg:pypi/requests@2.31.0"}])
 ```
 
 ### blast_radius

--- a/src/agent_bom/advisory_sources.py
+++ b/src/agent_bom/advisory_sources.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from agent_bom.models import Package, Vulnerability
 
-PRIMARY_ADVISORY_SOURCES: tuple[str, ...] = ("osv", "ghsa", "nvidia_csaf", "amd_psirt")
+PRIMARY_ADVISORY_SOURCES: tuple[str, ...] = ("osv", "ghsa", "nvidia_csaf", "amd_psirt", "intel_psirt")
 ENRICHMENT_ADVISORY_SOURCES: tuple[str, ...] = ("nvd", "epss", "cisa_kev")
 _PREFERRED_SOURCE_ORDER: tuple[str, ...] = PRIMARY_ADVISORY_SOURCES + ENRICHMENT_ADVISORY_SOURCES
 
@@ -31,6 +31,9 @@ def normalize_advisory_source(source: str | None) -> str | None:
         "amd": "amd_psirt",
         "amd_advisory": "amd_psirt",
         "amd_psirt_advisory": "amd_psirt",
+        "intel": "intel_psirt",
+        "intel_advisory": "intel_psirt",
+        "intel_psirt_advisory": "intel_psirt",
     }
     return aliases.get(value, value)
 

--- a/src/agent_bom/api/routes/intel.py
+++ b/src/agent_bom/api/routes/intel.py
@@ -7,7 +7,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field
 
-from agent_bom.intel_lookup import list_intel_sources, lookup_advisory, match_packages
+from agent_bom.intel_lookup import build_daily_brief, list_intel_sources, lookup_advisory, match_packages
 
 router = APIRouter()
 
@@ -16,6 +16,15 @@ class IntelPackageMatchRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     packages: list[dict[str, Any]] = Field(min_length=1, max_length=500)
+    limit: int = Field(default=100, ge=1, le=500)
+
+
+class IntelDailyBriefRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    packages: list[dict[str, Any]] = Field(default_factory=list, max_length=500)
+    epss_threshold: float = Field(default=0.7, ge=0, le=1)
+    kev_window_hours: int = Field(default=24, ge=1, le=168)
     limit: int = Field(default=100, ge=1, le=500)
 
 
@@ -50,3 +59,18 @@ async def post_intel_match(
     if not include_unmatched:
         result["matches"] = [item for item in result["matches"] if item["match_count"] > 0]
     return result
+
+
+@router.post("/v1/intel/daily-brief", tags=["intel"])
+async def post_intel_daily_brief(body: IntelDailyBriefRequest) -> dict[str, Any]:
+    """Return a local analyst threat brief from governed intel sources."""
+
+    try:
+        return build_daily_brief(
+            body.packages,
+            epss_threshold=body.epss_threshold,
+            kev_window_hours=body.kev_window_hours,
+            limit=body.limit,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -692,7 +692,7 @@ def mcp_server_cmd(
     Requires:  pip install 'agent-bom[mcp-server]'
 
     \b
-    Exposes 54 security tools via MCP protocol:
+    Exposes 55 security tools via MCP protocol:
       scan                   Full scan — CVEs, config security, blast radius, compliance
       check                  Check a specific package for CVEs before installing
       blast_radius           Look up blast radius for a specific CVE

--- a/src/agent_bom/intel_lookup.py
+++ b/src/agent_bom/intel_lookup.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import sqlite3
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from urllib.parse import unquote
@@ -23,10 +25,20 @@ _CWE_RE = re.compile(r"^CWE-\d+$", re.IGNORECASE)
 class IntelSource:
     source_id: str
     display_name: str
-    tier: int
+    source_tier: int
     kind: str
-    url: str
+    source_url: str
+    homepage_url: str
+    license_or_terms_url: str
     license: str
+    robots_policy: str
+    crawl_delay_seconds: int | None
+    connector_type: str
+    enabled: bool
+    owner: str
+    parser_version: str
+    validation_status: str
+    support_status: str
     redistribution: str
     sync_meta_source: str
     description: str
@@ -36,10 +48,20 @@ CANONICAL_INTEL_SOURCES: tuple[IntelSource, ...] = (
     IntelSource(
         source_id="osv",
         display_name="OSV",
-        tier=1,
+        source_tier=1,
         kind="vulnerability",
-        url="https://osv.dev/list",
+        source_url="https://osv.dev/list",
+        homepage_url="https://osv.dev/",
+        license_or_terms_url="https://github.com/google/osv.dev/blob/master/LICENSE",
         license="CC-BY-4.0",
+        robots_policy="structured_api",
+        crawl_delay_seconds=None,
+        connector_type="structured_api",
+        enabled=True,
+        owner="agent-bom",
+        parser_version="osv-db-sync.v1",
+        validation_status="structured_feed",
+        support_status="supported",
         redistribution="structured_records",
         sync_meta_source="osv",
         description="Ecosystem-native vulnerability advisories keyed by purl-like package coordinates.",
@@ -47,10 +69,20 @@ CANONICAL_INTEL_SOURCES: tuple[IntelSource, ...] = (
     IntelSource(
         source_id="ghsa",
         display_name="GitHub Security Advisories",
-        tier=1,
+        source_tier=1,
         kind="vulnerability",
-        url="https://github.com/advisories",
+        source_url="https://github.com/advisories",
+        homepage_url="https://github.com/advisories",
+        license_or_terms_url="https://docs.github.com/en/site-policy/github-terms/github-terms-of-service",
         license="GitHub advisory database terms",
+        robots_policy="api_or_osv_mirror",
+        crawl_delay_seconds=None,
+        connector_type="structured_api",
+        enabled=True,
+        owner="agent-bom",
+        parser_version="ghsa-sync.v1",
+        validation_status="structured_feed",
+        support_status="supported",
         redistribution="structured_records",
         sync_meta_source="ghsa",
         description="GitHub Security Advisory records for package ecosystems supported by the local DB syncer.",
@@ -58,10 +90,20 @@ CANONICAL_INTEL_SOURCES: tuple[IntelSource, ...] = (
     IntelSource(
         source_id="nvd",
         display_name="NVD",
-        tier=1,
+        source_tier=1,
         kind="enrichment",
-        url="https://services.nvd.nist.gov/rest/json/cves/2.0",
+        source_url="https://services.nvd.nist.gov/rest/json/cves/2.0",
+        homepage_url="https://nvd.nist.gov/",
+        license_or_terms_url="https://nvd.nist.gov/general/terms-of-use",
         license="public_domain_us_government",
+        robots_policy="structured_api",
+        crawl_delay_seconds=None,
+        connector_type="structured_api",
+        enabled=True,
+        owner="agent-bom",
+        parser_version="nvd-enrichment.v1",
+        validation_status="structured_feed",
+        support_status="supported",
         redistribution="structured_enrichment",
         sync_meta_source="nvd",
         description="CVSS, CWE, and CVE enrichment used to explain impact and remediation priority.",
@@ -69,10 +111,20 @@ CANONICAL_INTEL_SOURCES: tuple[IntelSource, ...] = (
     IntelSource(
         source_id="epss",
         display_name="FIRST EPSS",
-        tier=1,
+        source_tier=1,
         kind="exploitability",
-        url="https://epss.empiricalsecurity.com/epss_scores-current.csv.gz",
+        source_url="https://epss.empiricalsecurity.com/epss_scores-current.csv.gz",
+        homepage_url="https://www.first.org/epss/",
+        license_or_terms_url="https://www.first.org/epss/",
         license="FIRST EPSS terms",
+        robots_policy="published_bulk_feed",
+        crawl_delay_seconds=None,
+        connector_type="bulk_file",
+        enabled=True,
+        owner="agent-bom",
+        parser_version="epss-sync.v1",
+        validation_status="structured_feed",
+        support_status="supported",
         redistribution="structured_enrichment",
         sync_meta_source="epss",
         description="Exploit Prediction Scoring System probability and percentile enrichment.",
@@ -80,10 +132,20 @@ CANONICAL_INTEL_SOURCES: tuple[IntelSource, ...] = (
     IntelSource(
         source_id="cisa_kev",
         display_name="CISA KEV",
-        tier=1,
+        source_tier=1,
         kind="exploitation",
-        url="https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+        source_url="https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json",
+        homepage_url="https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+        license_or_terms_url="https://www.cisa.gov/about/website-policies",
         license="public_domain_us_government",
+        robots_policy="published_bulk_feed",
+        crawl_delay_seconds=None,
+        connector_type="bulk_json",
+        enabled=True,
+        owner="agent-bom",
+        parser_version="kev-sync.v1",
+        validation_status="structured_feed",
+        support_status="supported",
         redistribution="structured_enrichment",
         sync_meta_source="kev",
         description="Known-exploited vulnerability signal for prioritizing active exploitation risk.",
@@ -91,15 +153,90 @@ CANONICAL_INTEL_SOURCES: tuple[IntelSource, ...] = (
     IntelSource(
         source_id="alpine_secdb",
         display_name="Alpine SecDB",
-        tier=1,
+        source_tier=1,
         kind="os_package",
-        url="https://secdb.alpinelinux.org",
+        source_url="https://secdb.alpinelinux.org",
+        homepage_url="https://secdb.alpinelinux.org",
+        license_or_terms_url="https://gitlab.alpinelinux.org/alpine/security/secdb",
         license="Alpine Linux SecDB terms",
+        robots_policy="published_bulk_feed",
+        crawl_delay_seconds=None,
+        connector_type="bulk_json",
+        enabled=True,
+        owner="agent-bom",
+        parser_version="alpine-secdb-sync.v1",
+        validation_status="structured_feed",
+        support_status="supported",
         redistribution="structured_records",
         sync_meta_source="alpine",
         description="Alpine package security database records for container and OS image matching.",
     ),
+    IntelSource(
+        source_id="nvidia_csaf",
+        display_name="NVIDIA CSAF",
+        source_tier=2,
+        kind="vendor_psirt",
+        source_url="https://api.github.com/repos/NVIDIA/product-security/contents",
+        homepage_url="https://www.nvidia.com/en-us/security/",
+        license_or_terms_url="https://github.com/NVIDIA/product-security",
+        license="vendor product-security repository terms",
+        robots_policy="structured_repository_api",
+        crawl_delay_seconds=None,
+        connector_type="csaf_json",
+        enabled=True,
+        owner="agent-bom",
+        parser_version="nvidia-csaf.v1",
+        validation_status="supported_structured_vendor_feed",
+        support_status="supported",
+        redistribution="source_links_and_structured_findings",
+        sync_meta_source="nvidia_csaf",
+        description="Structured CSAF advisory matching for known AI infrastructure package mappings.",
+    ),
+    IntelSource(
+        source_id="amd_psirt",
+        display_name="AMD PSIRT",
+        source_tier=3,
+        kind="vendor_psirt",
+        source_url="https://www.amd.com/en/resources/product-security.html",
+        homepage_url="https://www.amd.com/en/resources/product-security.html",
+        license_or_terms_url="https://www.amd.com/en/legal/copyright.html",
+        license="vendor website terms",
+        robots_policy="manual_seed_with_guarded_refresh",
+        crawl_delay_seconds=None,
+        connector_type="vendor_json_seed",
+        enabled=True,
+        owner="agent-bom",
+        parser_version="amd-psirt-seed.v1",
+        validation_status="experimental_seed_plus_guarded_refresh",
+        support_status="experimental",
+        redistribution="source_links_and_structured_findings",
+        sync_meta_source="amd_psirt",
+        description="ROCm and AMD GPU advisory matching from a curated seed with guarded refresh fallback.",
+    ),
+    IntelSource(
+        source_id="intel_psirt",
+        display_name="Intel PSIRT",
+        source_tier=3,
+        kind="vendor_psirt",
+        source_url="https://www.intel.com/content/www/us/en/security-center/default.html",
+        homepage_url="https://www.intel.com/content/www/us/en/security-center/default.html",
+        license_or_terms_url="https://www.intel.com/content/www/us/en/legal/terms-of-use.html",
+        license="vendor website terms",
+        robots_policy="manual_seed_only",
+        crawl_delay_seconds=None,
+        connector_type="curated_seed",
+        enabled=True,
+        owner="agent-bom",
+        parser_version="intel-psirt-seed.v1",
+        validation_status="experimental_seed_only",
+        support_status="experimental",
+        redistribution="source_links_and_structured_findings",
+        sync_meta_source="intel_psirt",
+        description="GPU and oneAPI advisory matching from curated seed data; no automated webpage scraping is shipped.",
+    ),
 )
+
+VENDOR_ADVISORY_SOURCE_IDS = {"nvidia_csaf", "amd_psirt", "intel_psirt"}
 
 
 def resolve_intel_db_path() -> Path:
@@ -112,8 +249,23 @@ def resolve_intel_db_path() -> Path:
 
 
 def _sync_meta(conn: sqlite3.Connection) -> dict[str, dict[str, Any]]:
-    rows = conn.execute("SELECT source, last_synced, record_count FROM sync_meta").fetchall()
-    return {row["source"]: {"last_synced": row["last_synced"], "record_count": row["record_count"]} for row in rows}
+    rows = conn.execute("SELECT source, last_synced, record_count, metadata_json FROM sync_meta").fetchall()
+    meta: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        metadata: dict[str, Any] = {}
+        if row["metadata_json"]:
+            try:
+                parsed = json.loads(row["metadata_json"])
+                if isinstance(parsed, dict):
+                    metadata = parsed
+            except json.JSONDecodeError:
+                metadata = {"validation_status": "metadata_parse_error"}
+        meta[row["source"]] = {
+            "last_synced": row["last_synced"],
+            "record_count": row["record_count"],
+            "metadata": metadata,
+        }
+    return meta
 
 
 def list_intel_sources(*, db_path: Path | None = None) -> dict[str, Any]:
@@ -128,14 +280,27 @@ def list_intel_sources(*, db_path: Path | None = None) -> dict[str, Any]:
     sources: list[dict[str, Any]] = []
     for source in CANONICAL_INTEL_SOURCES:
         run = meta.get(source.sync_meta_source, {})
+        metadata = run.get("metadata") or {}
+        validation_status = str(metadata.get("validation_status") or source.validation_status)
         sources.append(
             {
                 "source_id": source.source_id,
                 "display_name": source.display_name,
-                "tier": source.tier,
+                "tier": source.source_tier,
+                "source_tier": source.source_tier,
                 "kind": source.kind,
-                "url": source.url,
+                "source_url": source.source_url,
+                "homepage_url": source.homepage_url,
+                "license_or_terms_url": source.license_or_terms_url,
                 "license": source.license,
+                "robots_policy": source.robots_policy,
+                "crawl_delay_seconds": source.crawl_delay_seconds,
+                "connector_type": source.connector_type,
+                "enabled": source.enabled,
+                "owner": source.owner,
+                "parser_version": str(metadata.get("parser_version") or source.parser_version),
+                "validation_status": validation_status,
+                "support_status": source.support_status,
                 "redistribution": source.redistribution,
                 "description": source.description,
                 "feed_run": {
@@ -143,6 +308,15 @@ def list_intel_sources(*, db_path: Path | None = None) -> dict[str, Any]:
                     "last_synced": run.get("last_synced"),
                     "record_count": run.get("record_count", 0),
                     "status": "freshness_unknown" if not run.get("last_synced") else "synced",
+                    "last_validated_at": metadata.get("last_validated_at"),
+                    "fetched_at": metadata.get("fetched_at") or run.get("last_synced"),
+                    "content_hash": metadata.get("content_hash"),
+                    "etag": metadata.get("etag"),
+                    "last_modified": metadata.get("last_modified"),
+                    "parse_errors": int(metadata.get("parse_errors") or 0),
+                    "validation_failures": int(metadata.get("validation_failures") or 0),
+                    "cap_hit": bool(metadata.get("cap_hit") or False),
+                    "validation_status": validation_status,
                 },
             }
         )
@@ -179,6 +353,8 @@ def evidence_links(vuln_id: str, aliases: list[str], cwe_ids: list[str], source:
 
 def _local_vuln_to_advisory(vuln: LocalVuln, *, matched_by: str) -> dict[str, Any]:
     ids = _canonical_ids(vuln.id, vuln.aliases, vuln.cwe_ids)
+    match_method = "inventory_native_package" if matched_by == "package" else matched_by
+    confidence = "high" if match_method in {"inventory_native_package", "id_or_alias"} else "medium"
     return {
         "id": vuln.id,
         "canonical_ids": ids,
@@ -203,6 +379,9 @@ def _local_vuln_to_advisory(vuln: LocalVuln, *, matched_by: str) -> dict[str, An
             }
         ],
         "matched_by": matched_by,
+        "match_method": match_method,
+        "match_confidence": confidence,
+        "match_reason": "Matched by normalized package ecosystem/name/version from tenant inventory.",
         "evidence_links": evidence_links(vuln.id, vuln.aliases, vuln.cwe_ids, vuln.source),
     }
 
@@ -239,6 +418,82 @@ def _lookup_cve_enrichment(conn: sqlite3.Connection, cve_ids: list[str]) -> tupl
     epss_percentile = epss_row["percentile"] if epss_row else None
     kev_date_added = kev_row["date_added"] if kev_row else None
     return epss_probability, epss_percentile, kev_date_added
+
+
+def _source_registry_by_id() -> dict[str, IntelSource]:
+    return {source.source_id: source for source in CANONICAL_INTEL_SOURCES}
+
+
+def _source_policy(source_id: str | None) -> dict[str, Any]:
+    source = _source_registry_by_id().get(source_id or "")
+    if not source:
+        return {
+            "source_id": source_id or "unknown",
+            "support_status": "unknown",
+            "redistribution": "unknown",
+            "license_or_terms_url": None,
+            "validation_status": "unknown",
+        }
+    return {
+        "source_id": source.source_id,
+        "support_status": source.support_status,
+        "redistribution": source.redistribution,
+        "license_or_terms_url": source.license_or_terms_url,
+        "validation_status": source.validation_status,
+    }
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _parse_date_or_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    normalized = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        try:
+            parsed = datetime.strptime(normalized, "%Y-%m-%d").replace(tzinfo=UTC)
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _row_aliases(row: sqlite3.Row) -> list[str]:
+    return [alias for alias in (row["aliases"] or "").split(",") if alias]
+
+
+def _row_cwes(row: sqlite3.Row) -> list[str]:
+    return [cwe for cwe in (row["cwe_ids"] or "").split(",") if cwe]
+
+
+def _brief_advisory(row: sqlite3.Row, *, section: str, match_reason: str) -> dict[str, Any]:
+    aliases = _row_aliases(row)
+    cwes = _row_cwes(row)
+    source = row["source"]
+    return {
+        "id": row["id"],
+        "canonical_ids": _canonical_ids(row["id"], aliases, cwes),
+        "summary": row["summary"],
+        "severity": row["severity"],
+        "cvss_score": row["cvss_score"],
+        "source": source,
+        "source_policy": _source_policy(source),
+        "published_at": row["published"],
+        "modified_at": row["modified"],
+        "epss_probability": row["epss_prob"],
+        "epss_percentile": row["epss_pct"],
+        "is_kev": row["kev_date"] is not None,
+        "kev_date_added": row["kev_date"],
+        "match_method": "inventory_native_package" if section != "kev_last_24h" else "source_signal",
+        "match_confidence": "high",
+        "match_reason": match_reason,
+        "evidence_links": evidence_links(row["id"], aliases, cwes, source),
+    }
 
 
 def lookup_advisory(advisory_id: str, *, db_path: Path | None = None) -> dict[str, Any]:
@@ -304,6 +559,10 @@ def lookup_advisory(advisory_id: str, *, db_path: Path | None = None) -> dict[st
             "kev_date_added": kev_date_added,
             "affected": affected,
             "matched_by": "id_or_alias",
+            "match_method": "id_or_alias",
+            "match_confidence": "high",
+            "match_reason": "Matched advisory identifier or alias exactly.",
+            "source_policy": _source_policy(first["source"]),
             "evidence_links": evidence_links(first["id"], aliases, cwes, first["source"]),
         }
         return {"schema_version": "intel.lookup.v1", "found": True, "query": raw_id, "advisory": advisory}
@@ -377,4 +636,114 @@ def match_packages(packages: list[dict[str, Any]], *, db_path: Path | None = Non
         "matched_packages": sum(1 for item in matches if item["match_count"] > 0),
         "match_count": sum(item["match_count"] for item in matches),
         "matches": matches,
+    }
+
+
+def build_daily_brief(
+    packages: list[dict[str, Any]] | None = None,
+    *,
+    db_path: Path | None = None,
+    epss_threshold: float = 0.7,
+    kev_window_hours: int = 24,
+    limit: int = 100,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build a local analyst brief from currently shipped intel sources.
+
+    This summarizes local DB evidence only. It does not scrape research sites,
+    redistribute vendor pages, or infer telemetry/campaign matches without
+    configured input data.
+    """
+
+    if epss_threshold < 0 or epss_threshold > 1:
+        raise ValueError("epss_threshold must be between 0 and 1")
+    if kev_window_hours < 1 or kev_window_hours > 168:
+        raise ValueError("kev_window_hours must be between 1 and 168")
+    generated_at = now.astimezone(UTC) if now else _utc_now()
+    kev_cutoff = generated_at - timedelta(hours=kev_window_hours)
+    conn = init_db(db_path or resolve_intel_db_path())
+    try:
+        source_meta = _sync_meta(conn)
+        rows = conn.execute(
+            """
+            SELECT
+                v.id, v.summary, v.severity, v.cvss_score, v.cvss_vector, v.fixed_version, v.cwe_ids,
+                COALESCE(v.aliases, '') AS aliases, v.source, v.published, v.modified,
+                e.probability AS epss_prob, e.percentile AS epss_pct,
+                k.date_added AS kev_date
+            FROM vulns v
+            LEFT JOIN epss_scores e ON e.cve_id = v.id
+            LEFT JOIN kev_entries k
+                ON k.cve_id = v.id
+                OR instr(',' || UPPER(COALESCE(v.aliases, '')) || ',', ',' || UPPER(k.cve_id) || ',') > 0
+            WHERE k.date_added IS NOT NULL
+            ORDER BY k.date_added DESC, v.id
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    kev_last_24h = [
+        _brief_advisory(row, section="kev_last_24h", match_reason=f"CISA KEV date_added is within the last {kev_window_hours} hours.")
+        for row in rows
+        if (parsed := _parse_date_or_datetime(row["kev_date"])) and parsed >= kev_cutoff
+    ]
+
+    package_inputs = packages or []
+    inventory_match = match_packages(package_inputs, db_path=db_path, limit=limit) if package_inputs else None
+    high_epss_inventory: list[dict[str, Any]] = []
+    vendor_advisories: list[dict[str, Any]] = []
+    if inventory_match:
+        for package_match in inventory_match["matches"]:
+            for advisory in package_match["advisories"]:
+                item = {
+                    "package": package_match["package"],
+                    "advisory": advisory,
+                    "match_reason": advisory.get("match_reason", "Matched by tenant inventory package coordinates."),
+                }
+                if advisory.get("epss_probability") is not None and advisory["epss_probability"] >= epss_threshold:
+                    high_epss_inventory.append(item)
+                if advisory.get("source") in VENDOR_ADVISORY_SOURCE_IDS:
+                    vendor_advisories.append(item)
+
+    feed_runs = {
+        source.source_id: {
+            "last_synced": (source_meta.get(source.sync_meta_source) or {}).get("last_synced"),
+            "record_count": (source_meta.get(source.sync_meta_source) or {}).get("record_count", 0),
+            "support_status": source.support_status,
+            "validation_status": ((source_meta.get(source.sync_meta_source) or {}).get("metadata") or {}).get(
+                "validation_status", source.validation_status
+            ),
+        }
+        for source in CANONICAL_INTEL_SOURCES
+    }
+    return {
+        "schema_version": "intel.daily_brief.v1",
+        "generated_at": generated_at.isoformat(),
+        "inputs": {
+            "package_count": len(package_inputs),
+            "epss_threshold": epss_threshold,
+            "kev_window_hours": kev_window_hours,
+            "telemetry_configured": False,
+            "sector_geo_configured": False,
+        },
+        "sections": {
+            "kev_last_24h": kev_last_24h,
+            "high_epss_inventory": high_epss_inventory,
+            "vendor_advisories": vendor_advisories,
+            "ioc_telemetry_hits": [],
+            "campaign_matches": [],
+            "ransomware_sector_matches": [],
+        },
+        "inventory_match": inventory_match,
+        "source_registry": {
+            "schema_version": "intel.sources.v1",
+            "feed_runs": feed_runs,
+        },
+        "limitations": [
+            "IoC telemetry, campaign, and sector matching require configured telemetry or tenant profile inputs.",
+            "Vendor webpage scraping is not shipped; vendor entries use structured feeds or curated source-linked seeds only.",
+        ],
     }

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -5,7 +5,7 @@ Start with:
     agent-bom mcp server --transport sse          # SSE transport (for remote clients)
     agent-bom mcp server --transport streamable-http
 
-Tools (54):
+Tools (55):
     scan                — Full discovery → scan → output pipeline
     check               — Check a specific package for CVEs before installing
     blast_radius        — Look up blast radius for a specific CVE

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -395,7 +395,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
         policy_check_impl,
     )
     from agent_bom.mcp_tools.graph import deploy_decision_impl, exposure_paths_impl
-    from agent_bom.mcp_tools.intel import intel_lookup_impl, intel_match_impl, intel_sources_impl
+    from agent_bom.mcp_tools.intel import intel_daily_brief_impl, intel_lookup_impl, intel_match_impl, intel_sources_impl
     from agent_bom.mcp_tools.registry import registry_lookup_impl
     from agent_bom.mcp_tools.runtime import verify_impl
     from agent_bom.mcp_tools.sbom import generate_sbom_impl, remediate_impl
@@ -587,6 +587,28 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
         return await _execute_tool_async(
             "intel_sources",
             intel_sources_impl,
+            _truncate_response=_truncate_response,
+        )
+
+    @mcp.tool(annotations=_READ_ONLY, title="Threat Intel Daily Brief")
+    async def intel_daily_brief(
+        packages: Annotated[
+            list[dict] | None,
+            Field(description="Optional inventory packages with purl or ecosystem/name/version objects for local matching."),
+        ] = None,
+        epss_threshold: Annotated[float, Field(description="Minimum EPSS probability for inventory-prioritized CVEs, 0-1.")] = 0.7,
+        kev_window_hours: Annotated[int, Field(description="KEV date_added lookback window, 1-168 hours.")] = 24,
+        limit: Annotated[int, Field(description="Maximum packages/advisories to inspect, 1-500.")] = 100,
+    ) -> str:
+        """Return a local analyst threat brief from governed intel sources."""
+
+        return await _execute_tool_async(
+            "intel_daily_brief",
+            intel_daily_brief_impl,
+            packages=packages,
+            epss_threshold=epss_threshold,
+            kev_window_hours=kev_window_hours,
+            limit=limit,
             _truncate_response=_truncate_response,
         )
 

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -23,6 +23,11 @@ _SERVER_CARD_TOOLS = [
         "description": "Return canonical intel sources and local feed-run freshness",
         "annotations": {"readOnlyHint": True},
     },
+    {
+        "name": "intel_daily_brief",
+        "description": "Return a local analyst threat brief from governed intel sources",
+        "annotations": {"readOnlyHint": True},
+    },
     {"name": "blast_radius", "description": "Look up blast radius for a specific CVE", "annotations": {"readOnlyHint": True}},
     {
         "name": "exposure_paths",
@@ -257,6 +262,7 @@ _TOOL_CAPABILITY_CLASSES = {
     "intel_lookup": ["READ", "THREAT_INTEL"],
     "intel_match": ["READ", "THREAT_INTEL", "INVENTORY"],
     "intel_sources": ["READ", "THREAT_INTEL"],
+    "intel_daily_brief": ["READ", "THREAT_INTEL", "INVENTORY"],
     "blast_radius": ["READ", "ANALYZE"],
     "exposure_paths": ["READ", "GRAPH", "ANALYZE"],
     "should_i_deploy": ["READ", "GRAPH", "POLICY"],

--- a/src/agent_bom/mcp_tools/intel.py
+++ b/src/agent_bom/mcp_tools/intel.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 
-from agent_bom.intel_lookup import list_intel_sources, lookup_advisory, match_packages
+from agent_bom.intel_lookup import build_daily_brief, list_intel_sources, lookup_advisory, match_packages
 from agent_bom.mcp_errors import CODE_INTERNAL_UNEXPECTED, CODE_VALIDATION_INVALID_ARGUMENT, mcp_error_json
 from agent_bom.security import sanitize_error
 
@@ -65,3 +65,33 @@ async def intel_sources_impl(*, _truncate_response=lambda value: value) -> str:
     except Exception as exc:  # pragma: no cover - defensive redaction
         logger.exception("MCP intel sources failed")
         return mcp_error_json(CODE_INTERNAL_UNEXPECTED, "Intel sources failed.", details={"error": sanitize_error(exc)})
+
+
+async def intel_daily_brief_impl(
+    *,
+    packages: list[dict] | None = None,
+    epss_threshold: float = 0.7,
+    kev_window_hours: int = 24,
+    limit: int = 100,
+    _truncate_response=lambda value: value,
+) -> str:
+    """Return a local analyst threat brief from governed intel sources."""
+
+    try:
+        return _truncate_response(
+            json.dumps(
+                build_daily_brief(
+                    packages or [],
+                    epss_threshold=epss_threshold,
+                    kev_window_hours=kev_window_hours,
+                    limit=limit,
+                ),
+                indent=2,
+                default=str,
+            )
+        )
+    except ValueError as exc:
+        return mcp_error_json(CODE_VALIDATION_INVALID_ARGUMENT, sanitize_error(exc), details={"argument": "daily_brief"})
+    except Exception as exc:  # pragma: no cover - defensive redaction
+        logger.exception("MCP intel daily brief failed")
+        return mcp_error_json(CODE_INTERNAL_UNEXPECTED, "Intel daily brief failed.", details={"error": sanitize_error(exc)})

--- a/src/agent_bom/scanners/nvidia_advisory.py
+++ b/src/agent_bom/scanners/nvidia_advisory.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import re
+from datetime import UTC, datetime
 
 import httpx
 
@@ -147,6 +148,13 @@ def get_nvidia_products_for_package(pkg_name: str) -> list[str]:
     return _PYPI_TO_NVIDIA.get(_normalise(pkg_name), [])
 
 
+def default_nvidia_advisory_years(now: datetime | None = None) -> list[str]:
+    """Return recent advisory years without pinning the scanner to a release year."""
+
+    current_year = (now or datetime.now(UTC)).year
+    return [str(current_year), str(current_year - 1)]
+
+
 def _parse_csaf_severity(scores: list[dict]) -> tuple[Severity, float | None]:
     """Extract severity and CVSS score from CSAF scores array."""
     for score_entry in scores:
@@ -187,7 +195,7 @@ async def fetch_nvidia_advisory_index(
     Only fetches recent years by default.
     """
     if years is None:
-        years = ["2025", "2026"]
+        years = default_nvidia_advisory_years()
 
     close_client = False
     if client is None:

--- a/tests/test_intel_lookup.py
+++ b/tests/test_intel_lookup.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from datetime import UTC, datetime
 
 import pytest
 from starlette.testclient import TestClient
 
 from agent_bom.api.server import app, configure_api
 from agent_bom.db.schema import init_db
-from agent_bom.intel_lookup import list_intel_sources, lookup_advisory, match_packages
-from agent_bom.mcp_tools.intel import intel_lookup_impl, intel_match_impl, intel_sources_impl
+from agent_bom.intel_lookup import build_daily_brief, list_intel_sources, lookup_advisory, match_packages
+from agent_bom.mcp_tools.intel import intel_daily_brief_impl, intel_lookup_impl, intel_match_impl, intel_sources_impl
 from tests.auth_helpers import PROXY_SECRET
 
 VIEWER_HEADERS = {
@@ -72,6 +73,34 @@ def _seed_intel(conn: sqlite3.Connection) -> None:
         ("GHSA-abcd-1234-wxyz", "pypi", "requests", "0", "2.32.0", ""),
     )
     conn.execute(
+        """
+        INSERT INTO vulns (
+            id, summary, severity, cvss_score, cvss_vector, fixed_version,
+            cwe_ids, aliases, published, modified, source
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "CVE-2026-55555",
+            "vendor GPU advisory",
+            "high",
+            7.8,
+            "",
+            "6.2",
+            "CWE-119",
+            "",
+            "2026-05-04T00:00:00+00:00",
+            "2026-05-05T00:00:00+00:00",
+            "amd_psirt",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO affected(vuln_id, ecosystem, package_name, introduced, fixed, last_affected)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        ("CVE-2026-55555", "pypi", "rocm-smi-lib", "0", "6.2", ""),
+    )
+    conn.execute(
         "INSERT INTO epss_scores(cve_id, probability, percentile, updated_at) VALUES (?, ?, ?, ?)",
         ("CVE-2026-12345", 0.91, 99.1, "2026-05-03T00:00:00+00:00"),
     )
@@ -80,12 +109,25 @@ def _seed_intel(conn: sqlite3.Connection) -> None:
         ("CVE-2026-12345", "2026-05-04", "2026-06-04", "requests", "python"),
     )
     conn.execute(
+        "INSERT INTO kev_entries(cve_id, date_added, due_date, product, vendor_project) VALUES (?, ?, ?, ?, ?)",
+        ("CVE-2026-55555", "2026-05-21", "2026-06-21", "rocm-smi-lib", "gpu"),
+    )
+    conn.execute(
         "INSERT OR REPLACE INTO sync_meta(source, last_synced, record_count) VALUES (?, ?, ?)",
         ("ghsa", "2026-05-05T00:00:00+00:00", 1),
     )
     conn.execute(
         "INSERT OR REPLACE INTO sync_meta(source, last_synced, record_count) VALUES (?, ?, ?)",
         ("epss", "2026-05-05T00:00:00+00:00", 1),
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO sync_meta(source, last_synced, record_count, metadata_json) VALUES (?, ?, ?, ?)",
+        (
+            "amd_psirt",
+            "2026-05-05T00:00:00+00:00",
+            1,
+            '{"validation_status":"experimental_seed_plus_guarded_refresh","content_hash":"sha256:test"}',
+        ),
     )
     conn.commit()
 
@@ -96,8 +138,17 @@ def test_list_intel_sources_includes_feed_run_metadata(intel_db) -> None:  # noq
     assert body["schema_version"] == "intel.sources.v1"
     ghsa = next(source for source in body["sources"] if source["source_id"] == "ghsa")
     assert ghsa["tier"] == 1
+    assert ghsa["source_url"]
+    assert ghsa["license_or_terms_url"]
+    assert ghsa["robots_policy"] == "api_or_osv_mirror"
+    assert ghsa["support_status"] == "supported"
     assert ghsa["feed_run"]["last_synced"] == "2026-05-05T00:00:00+00:00"
     assert ghsa["feed_run"]["record_count"] == 1
+
+    amd = next(source for source in body["sources"] if source["source_id"] == "amd_psirt")
+    assert amd["support_status"] == "experimental"
+    assert amd["validation_status"] == "experimental_seed_plus_guarded_refresh"
+    assert amd["feed_run"]["content_hash"] == "sha256:test"
 
 
 def test_lookup_advisory_by_alias_returns_evidence_links(intel_db) -> None:  # noqa: ANN001
@@ -110,6 +161,9 @@ def test_lookup_advisory_by_alias_returns_evidence_links(intel_db) -> None:  # n
     assert advisory["canonical_ids"]["cwes"] == ["CWE-352", "CWE-79"]
     assert advisory["epss_probability"] == pytest.approx(0.91)
     assert advisory["is_kev"] is True
+    assert advisory["match_method"] == "id_or_alias"
+    assert advisory["match_confidence"] == "high"
+    assert advisory["source_policy"]["support_status"] == "supported"
     assert any(link["kind"] == "cve" for link in advisory["evidence_links"])
     assert advisory["affected"][0]["package_name"] == "requests"
 
@@ -128,7 +182,28 @@ def test_match_packages_returns_inventory_linked_advisories(intel_db) -> None:  
     advisory = match["advisories"][0]
     assert advisory["epss_probability"] == pytest.approx(0.91)
     assert advisory["is_kev"] is True
+    assert advisory["match_method"] == "inventory_native_package"
+    assert advisory["match_confidence"] == "high"
     assert any(link["kind"] == "cwe" for link in match["evidence_links"])
+
+
+def test_daily_brief_summarizes_local_sources_without_scraping_claims(intel_db) -> None:  # noqa: ANN001
+    body = build_daily_brief(
+        [
+            {"purl": "pkg:pypi/requests@2.31.0", "inventory_ref": "pkg-1"},
+            {"ecosystem": "pypi", "name": "rocm-smi-lib", "version": "6.1", "inventory_ref": "gpu-1"},
+        ],
+        db_path=intel_db,
+        now=datetime(2026, 5, 22, tzinfo=UTC),
+    )
+
+    assert body["schema_version"] == "intel.daily_brief.v1"
+    assert body["inputs"]["epss_threshold"] == 0.7
+    assert any(item["id"] == "CVE-2026-55555" for item in body["sections"]["kev_last_24h"])
+    assert body["sections"]["high_epss_inventory"][0]["advisory"]["id"] == "GHSA-abcd-1234-wxyz"
+    assert body["sections"]["vendor_advisories"][0]["advisory"]["source"] == "amd_psirt"
+    assert body["source_registry"]["feed_runs"]["amd_psirt"]["support_status"] == "experimental"
+    assert "Vendor webpage scraping is not shipped" in body["limitations"][1]
 
 
 def test_intel_api_routes_are_read_only_and_tenant_scoped(intel_client: TestClient) -> None:
@@ -147,6 +222,14 @@ def test_intel_api_routes_are_read_only_and_tenant_scoped(intel_client: TestClie
     )
     assert match.status_code == 200
     assert match.json()["matched_packages"] == 1
+
+    brief = intel_client.post(
+        "/v1/intel/daily-brief",
+        headers=VIEWER_HEADERS,
+        json={"packages": [{"ecosystem": "pypi", "name": "requests", "version": "2.31.0"}]},
+    )
+    assert brief.status_code == 200
+    assert brief.json()["schema_version"] == "intel.daily_brief.v1"
 
 
 def test_intel_api_match_validates_package_shape(intel_client: TestClient) -> None:
@@ -178,3 +261,6 @@ async def test_mcp_intel_tools_return_agent_native_json(intel_db) -> None:  # no
 
     sources = json.loads(await intel_sources_impl())
     assert sources["schema_version"] == "intel.sources.v1"
+
+    brief = json.loads(await intel_daily_brief_impl(packages=[{"purl": "pkg:pypi/requests@2.31.0"}]))
+    assert brief["schema_version"] == "intel.daily_brief.v1"

--- a/tests/test_nvidia_advisory.py
+++ b/tests/test_nvidia_advisory.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest
 
 from agent_bom.scanners.nvidia_advisory import (
     _csaf_affects_product,
     _word_boundary_match,
+    default_nvidia_advisory_years,
     get_nvidia_products_for_package,
 )
 
@@ -143,6 +146,12 @@ def test_get_nvidia_products_for_package(pkg_name: str, expected_products: list[
         assert expected in result, f"{pkg_name!r} should map to {expected!r}, got {result}"
     if not expected_products:
         assert result == [], f"{pkg_name!r} should have no NVIDIA product mapping, got {result}"
+
+
+def test_default_nvidia_advisory_years_follow_current_year():
+    """The CSAF index window follows the current year instead of a hard-coded release window."""
+
+    assert default_nvidia_advisory_years(datetime(2027, 1, 15, tzinfo=UTC)) == ["2027", "2026"]
 
 
 def test_torch_cuda_advisory_wiring():


### PR DESCRIPTION
Summary
- Expand the intel source catalog with source URLs, license/terms, robots policy, connector type, parser/validation state, and supported vs experimental vendor feed decisions.
- Add match_method/match_confidence metadata plus a local daily threat brief API/MCP surface for KEV lookback, high-EPSS inventory matches, and vendor advisory matches without claiming full scraping.
- Replace the hard-coded NVIDIA CSAF year window with current/previous-year freshness handling.

Verification
- uv run pytest tests/test_intel_lookup.py tests/test_nvidia_advisory.py tests/test_advisory_sources.py tests/test_mcp_server.py -q
- uv run ruff check src/agent_bom/intel_lookup.py src/agent_bom/api/routes/intel.py src/agent_bom/mcp_tools/intel.py src/agent_bom/mcp_server.py src/agent_bom/mcp_server_metadata.py src/agent_bom/advisory_sources.py src/agent_bom/scanners/nvidia_advisory.py tests/test_intel_lookup.py tests/test_nvidia_advisory.py tests/test_advisory_sources.py tests/test_mcp_server.py
- git diff --check HEAD~1..HEAD

Notes
- Advances #2643, #2645, and #2639. #2644 remains broader than the intel-only scope; this PR only adds intel match confidence/method metadata. #2638 is runtime/outbox-owned and intentionally untouched.
- Daily brief IoC, campaign, and sector/geo sections remain empty unless future telemetry/profile connectors provide those inputs.
- Vendor webpage scraping is not shipped; experimental vendor seed sources are marked as such.