### PR TITLE
feat(runtime): route graph events through durable outbox

### DIFF
--- a/docs/POSTURE_EVENT_STREAMING.md
+++ b/docs/POSTURE_EVENT_STREAMING.md
@@ -14,6 +14,9 @@ push-delivery primitive:
 - `agent_bom.posture_streaming.WebhookOutbox`, a tenant-scoped SQLite outbox
   for signed webhook delivery with idempotency, retry metadata,
   private-network destination opt-in, and dead-letter state
+- graph delta webhook routing through the same outbox when
+  `AGENT_BOM_GRAPH_DELTA_WEBHOOK` and
+  `AGENT_BOM_GRAPH_DELTA_WEBHOOK_SIGNING_SECRET` are configured
 - REST outbox observability at `GET /v1/posture/webhooks/outbox`,
   `GET /v1/posture/webhooks/outbox/stats`, and
   `POST /v1/posture/webhooks/outbox/{row_id}/retry`
@@ -42,6 +45,24 @@ Posture push connectors should emit:
 | `ocsf` | OCSF projection when available in higher-level adapters |
 | `audit_ref` | audit-chain pointer or verification metadata when available |
 | `schema_version` | connector schema version |
+
+Current reserved event types include `graph.delta`, `runtime.alert`,
+`runtime.policy_decision`, `intel.published`, `intel.matched_inventory`, and
+`intel.exploitation_changed`. The intel event names are reserved for future
+adapters; they are not a shipped intel API or feed registry.
+
+## Graph Delta Webhooks
+
+Graph delta alerts no longer use immediate generic webhook POST dispatch from
+environment-only configuration. When a graph delta webhook is configured, the
+runtime queues one signed `graph.delta` posture event per alert into the
+webhook outbox. Delivery workers then use the existing signed headers,
+idempotency key, retry, and dead-letter behavior. If a webhook URL is set
+without a signing secret, no webhook event is queued and the dispatch metadata
+includes a configuration error. OCSF export metadata is still returned.
+
+Slack delta notifications remain an explicit best-effort notification channel;
+they are separate from the durable generic webhook path.
 
 ## Delivery Order
 

--- a/docs/SCANNER_ACCURACY_BASELINE.md
+++ b/docs/SCANNER_ACCURACY_BASELINE.md
@@ -33,4 +33,8 @@ uv run python scripts/generate_accuracy_baseline.py --check
 
 `active_unresolved` findings count toward posture and policy gates.
 
-`vex_suppressed`, `fixed_verified`, `accepted_risk`, and `false_positive` are evidence states. They must remain visible in audit trails and release evidence, but they should not inflate active-risk counts.
+`fixed_verified`, `accepted_risk`, `not_affected`, and `false_positive` are
+suppression evidence states. `needs_review` is a non-suppressing triage state
+for low-confidence or declaration-only findings. These states must remain
+visible in audit trails and release evidence, but suppressing states should not
+inflate active-risk counts.

--- a/docs/accuracy-baseline.json
+++ b/docs/accuracy-baseline.json
@@ -4,6 +4,8 @@
     "active_unresolved": "Counts toward posture, policy gates, MCP scan gates, and release summaries.",
     "false_positive": "Tracked separately through tenant finding feedback controls and excluded from low-FP claims unless evidence exists.",
     "fixed_verified": "Tracked separately through tenant finding feedback controls.",
+    "needs_review": "Tracked as a non-suppressing review state for low-confidence findings.",
+    "not_affected": "Tracked separately through tenant finding feedback controls.",
     "vex_suppressed": "Tracked separately when VEX marks a vulnerability as fixed or not_affected."
   },
   "release_validation": [

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -935,8 +935,10 @@
             "enum": [
               "false_positive",
               "accepted_risk",
+              "not_affected",
               "not_applicable",
-              "fixed_verified"
+              "fixed_verified",
+              "needs_review"
             ],
             "title": "State",
             "type": "string"

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -635,8 +635,10 @@ components:
           enum:
           - false_positive
           - accepted_risk
+          - not_affected
           - not_applicable
           - fixed_verified
+          - needs_review
           title: State
           type: string
         vulnerability_id:

--- a/docs/schemas/v1/FindingFeedbackRequest.json
+++ b/docs/schemas/v1/FindingFeedbackRequest.json
@@ -31,8 +31,10 @@
       "enum": [
         "false_positive",
         "accepted_risk",
+        "not_affected",
         "not_applicable",
-        "fixed_verified"
+        "fixed_verified",
+        "needs_review"
       ],
       "title": "State",
       "type": "string"

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -92,6 +92,12 @@ AGENT_BOM_GATEWAY_REQUIRE_SHARED_RATE_LIMIT
 AGENT_BOM_GRAPH_DB
 AGENT_BOM_GRAPH_DELTA_SLACK_WEBHOOK
 AGENT_BOM_GRAPH_DELTA_WEBHOOK
+# Graph delta generic webhook destination identity; read only when graph delta dispatch runs.
+AGENT_BOM_GRAPH_DELTA_WEBHOOK_DESTINATION_ID
+# Graph delta generic webhook signing key; required before durable delivery is queued.
+AGENT_BOM_GRAPH_DELTA_WEBHOOK_SIGNING_SECRET
+# Graph delta generic webhook private-network opt-in; deploy-time egress boundary.
+AGENT_BOM_GRAPH_DELTA_WEBHOOK_ALLOW_PRIVATE_NETWORKS
 AGENT_BOM_GRAPH_WRITE_BATCH_SIZE
 AGENT_BOM_HSTS_MAX_AGE_SECONDS
 AGENT_BOM_HSTS_PRELOAD
@@ -141,6 +147,8 @@ AGENT_BOM_OTEL_TRACES_HEADERS
 AGENT_BOM_POSTGRES_URL
 # API posture webhook outbox SQLite path override; deploy-time operator setting.
 AGENT_BOM_POSTURE_WEBHOOK_OUTBOX_DB
+# Posture webhook signing key fallback for graph delta delivery.
+AGENT_BOM_POSTURE_WEBHOOK_SIGNING_SECRET
 # CLI profile selector; also exposed as the root --profile option.
 AGENT_BOM_PROFILE
 AGENT_BOM_PROTECTION_API_KEY

--- a/src/agent_bom/accuracy_baseline.py
+++ b/src/agent_bom/accuracy_baseline.py
@@ -60,6 +60,8 @@ def build_accuracy_baseline() -> dict[str, Any]:
             "vex_suppressed": "Tracked separately when VEX marks a vulnerability as fixed or not_affected.",
             "fixed_verified": "Tracked separately through tenant finding feedback controls.",
             "accepted_risk": "Tracked separately through tenant finding feedback controls.",
+            "not_affected": "Tracked separately through tenant finding feedback controls.",
+            "needs_review": "Tracked as a non-suppressing review state for low-confidence findings.",
             "false_positive": (
                 "Tracked separately through tenant finding feedback controls and excluded from low-FP claims unless evidence exists."
             ),

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -604,7 +604,7 @@ class FalsePositiveRequest(BaseModel):
     marked_by: str = ""
 
 
-FindingFeedbackState = Literal["false_positive", "accepted_risk", "not_applicable", "fixed_verified"]
+FindingFeedbackState = Literal["false_positive", "accepted_risk", "not_affected", "not_applicable", "fixed_verified", "needs_review"]
 
 
 class FindingFeedbackRequest(BaseModel):

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -254,7 +254,7 @@ def _persist_graph_snapshot(
         reset_current_tenant(tenant_token)
 
     alerts = compute_delta_alerts(previous_graph, graph)
-    delivery = dispatch_delta_alerts(alerts, product_version=__version__) if alerts else None
+    delivery = dispatch_delta_alerts(alerts, product_version=__version__, tenant_id=tenant_id) if alerts else None
     _logger.info(
         "Graph persisted for scan=%s tenant=%s nodes=%d edges=%d delta_alerts=%d delta_delivered=%d",
         scan_id,

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -163,6 +163,8 @@ def _request_actor(request: Request) -> str:
 
 def _feedback_reason(state: str, reason: str) -> str:
     clean_state = state.strip().lower().replace("-", "_")
+    if clean_state == "not_applicable":
+        clean_state = "not_affected"
     clean_reason = reason.strip()
     return f"{_FEEDBACK_PREFIX}{clean_state}] {clean_reason}".strip()
 
@@ -172,6 +174,8 @@ def _parse_feedback_reason(reason: str) -> tuple[str, str] | None:
         close = reason.find("]")
         if close > len(_FEEDBACK_PREFIX):
             state = reason[len(_FEEDBACK_PREFIX) : close].strip().lower()
+            if state == "not_applicable":
+                state = "not_affected"
             return state, reason[close + 1 :].strip()
     if reason.startswith(_LEGACY_FALSE_POSITIVE_PREFIX):
         return "false_positive", reason.removeprefix(_LEGACY_FALSE_POSITIVE_PREFIX).strip()
@@ -189,7 +193,7 @@ def _feedback_response(exc: Any) -> dict[str, Any]:
         "state": state,
         "reason": reason,
         "marked_by": exc.requested_by,
-        "status": "suppressed" if state in {"false_positive", "accepted_risk", "not_applicable"} else state,
+        "status": "suppressed" if state in {"false_positive", "accepted_risk", "not_affected", "fixed_verified"} else state,
         "created_at": exc.created_at,
         "expires_at": exc.expires_at,
         "tenant_id": exc.tenant_id,

--- a/src/agent_bom/api/routes/posture_streaming.py
+++ b/src/agent_bom/api/routes/posture_streaming.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
 from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query, Request
 
 from agent_bom.api.audit_log import log_action
-from agent_bom.posture_streaming import WebhookOutbox
+from agent_bom.posture_streaming import WebhookOutbox, default_webhook_outbox_path
 
 router = APIRouter()
 
@@ -25,19 +23,9 @@ def _actor(request: Request) -> str:
     return getattr(request.state, "api_key_name", "") or getattr(request.state, "auth_method", "") or "api"
 
 
-def _outbox_path() -> Path:
-    configured = os.environ.get("AGENT_BOM_POSTURE_WEBHOOK_OUTBOX_DB", "").strip()
-    if configured:
-        return Path(configured).expanduser()
-    shared_db = os.environ.get("AGENT_BOM_DB", "").strip()
-    if shared_db:
-        return Path(shared_db).expanduser()
-    return Path.home() / ".agent-bom" / "db" / "posture-webhooks.db"
-
-
 def get_posture_webhook_outbox() -> WebhookOutbox:
     global _OUTBOX
-    path = _outbox_path()
+    path = default_webhook_outbox_path()
     if _OUTBOX_OVERRIDE and _OUTBOX is not None:
         return _OUTBOX
     if _OUTBOX is None or _OUTBOX.path != path:

--- a/src/agent_bom/graph/webhooks.py
+++ b/src/agent_bom/graph/webhooks.py
@@ -14,12 +14,15 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from collections.abc import Mapping
 from typing import Any
 
 from agent_bom.event_normalization import build_event_ref, build_event_relationships
 from agent_bom.graph.container import UnifiedGraph
 from agent_bom.graph.severity import SEVERITY_RANK
 from agent_bom.graph.types import EntityType
+from agent_bom.posture_streaming import PostureEvent, WebhookDestination, WebhookOutbox, default_webhook_outbox
+from agent_bom.security import sanitize_error
 
 logger = logging.getLogger(__name__)
 
@@ -265,54 +268,148 @@ def _graph_delta_webhook_url() -> str:
     return os.environ.get("AGENT_BOM_GRAPH_DELTA_WEBHOOK", "").strip() or os.environ.get("AGENT_BOM_ALERT_WEBHOOK", "").strip()
 
 
+def _graph_delta_webhook_signing_secret() -> str:
+    return (
+        os.environ.get("AGENT_BOM_GRAPH_DELTA_WEBHOOK_SIGNING_SECRET", "").strip()
+        or os.environ.get("AGENT_BOM_POSTURE_WEBHOOK_SIGNING_SECRET", "").strip()
+    )
+
+
+def _graph_delta_destination_id() -> str:
+    return os.environ.get("AGENT_BOM_GRAPH_DELTA_WEBHOOK_DESTINATION_ID", "").strip() or "graph-delta-webhook"
+
+
 def _graph_delta_slack_webhook_url() -> str:
     return os.environ.get("AGENT_BOM_GRAPH_DELTA_SLACK_WEBHOOK", "").strip() or os.environ.get("SLACK_WEBHOOK_URL", "").strip()
+
+
+def _graph_delta_webhook_destination(*, tenant_id: str) -> tuple[WebhookDestination | None, str]:
+    webhook_url = _graph_delta_webhook_url()
+    if not webhook_url:
+        return None, ""
+    signing_secret = _graph_delta_webhook_signing_secret()
+    if not signing_secret:
+        return None, "AGENT_BOM_GRAPH_DELTA_WEBHOOK_SIGNING_SECRET is required for durable graph delta webhook delivery"
+    try:
+        return (
+            WebhookDestination(
+                destination_id=_graph_delta_destination_id(),
+                tenant_id=tenant_id,
+                url=webhook_url,
+                signing_secret=signing_secret,
+                allow_private_networks=os.environ.get("AGENT_BOM_GRAPH_DELTA_WEBHOOK_ALLOW_PRIVATE_NETWORKS", "").strip().lower()
+                in {"1", "true", "yes", "on"},
+            ),
+            "",
+        )
+    except ValueError as exc:
+        return None, sanitize_error(exc)
+
+
+def _posture_event_for_graph_delta(alert: dict[str, Any], *, tenant_id: str, product_version: str) -> PostureEvent:
+    raw_details = alert.get("details")
+    details: Mapping[str, Any] = raw_details if isinstance(raw_details, Mapping) else {}
+    subject_id = str(alert.get("scan_id") or details.get("scan_id") or "")
+    alert_type = str(alert.get("type") or "graph_delta")
+    primary_node = ""
+    node_ids = alert.get("node_ids")
+    if isinstance(node_ids, list) and node_ids:
+        primary_node = str(node_ids[0])
+    if primary_node:
+        subject_id = f"{subject_id}:{alert_type}:{primary_node}" if subject_id else f"{alert_type}:{primary_node}"
+    return PostureEvent(
+        event_type="graph.delta",
+        tenant_id=tenant_id,
+        source="graph_delta",
+        subject_id=subject_id,
+        payload={
+            "alert": alert,
+            "product_version": product_version,
+        },
+    )
+
+
+def enqueue_delta_alerts(
+    alerts: list[dict[str, Any]],
+    *,
+    destination: WebhookDestination,
+    product_version: str = "0.0.0",
+    outbox: WebhookOutbox | None = None,
+) -> dict[str, Any]:
+    """Queue graph delta alerts into the signed posture webhook outbox."""
+
+    target_outbox = outbox or default_webhook_outbox()
+    queued = 0
+    row_ids: list[int] = []
+    for alert in alerts:
+        event = _posture_event_for_graph_delta(alert, tenant_id=destination.tenant_id, product_version=product_version)
+        row_id = target_outbox.enqueue(event, destination)
+        row_ids.append(row_id)
+        queued += 1
+    return {"queued": queued, "outbox_row_ids": row_ids, "destination_id": destination.destination_id}
 
 
 def dispatch_delta_alerts(
     alerts: list[dict[str, Any]],
     *,
     product_version: str = "0.0.0",
+    tenant_id: str = "default",
+    outbox: WebhookOutbox | None = None,
 ) -> dict[str, Any]:
     """Dispatch graph delta alerts to configured outbound channels.
 
-    Uses dedicated graph delta webhook/slack env vars when present and falls
-    back to the generic scan/runtime webhook env vars. Returns delivery
-    metadata plus OCSF-ready events for downstream export.
+    Generic graph-delta webhooks are queued through the durable posture outbox
+    when a signing secret is configured. Slack delivery remains an explicit
+    best-effort notification channel. Returns delivery metadata plus OCSF-ready
+    events for downstream export.
     """
     from agent_bom.alerts.dispatcher import AlertDispatcher
 
-    webhook_url = _graph_delta_webhook_url()
+    webhook_destination, webhook_config_error = _graph_delta_webhook_destination(tenant_id=tenant_id)
     slack_webhook_url = _graph_delta_slack_webhook_url()
-    outbound_channels = int(bool(webhook_url)) + int(bool(slack_webhook_url))
+    outbound_channels = int(bool(webhook_destination)) + int(bool(slack_webhook_url))
     ocsf_events = format_alerts_for_siem(alerts, product_version)
     result = {
         "configured": outbound_channels > 0,
         "attempted": len(alerts),
         "delivered": 0,
         "queued": 0,
+        "dead_lettered": 0,
         "outbound_channels": outbound_channels,
+        "outbox_row_ids": [],
+        "webhook_config_error": webhook_config_error,
         "ocsf_event_count": len(ocsf_events),
         "ocsf_events": ocsf_events,
     }
     if not alerts or outbound_channels == 0:
         return result
 
+    if webhook_destination:
+        queued = enqueue_delta_alerts(
+            alerts,
+            destination=webhook_destination,
+            product_version=product_version,
+            outbox=outbox,
+        )
+        result["queued"] = queued["queued"]
+        result["outbox_row_ids"] = queued["outbox_row_ids"]
+
+    if not slack_webhook_url:
+        return result
+
     dispatcher = AlertDispatcher()
-    if webhook_url:
-        dispatcher.add_webhook(webhook_url)
-    if slack_webhook_url:
-        dispatcher.add_slack(slack_webhook_url)
+    dispatcher.add_slack(slack_webhook_url)
 
     delivered = 0
-    queued = 0
+    scheduled = 0
     for alert in alerts:
-        dispatched, scheduled = _dispatch_outbound_alert(dispatcher, alert, outbound_channels)
+        dispatched, alert_scheduled = _dispatch_outbound_alert(dispatcher, alert, 1)
         delivered += dispatched
-        queued += scheduled
+        scheduled += alert_scheduled
 
     result["delivered"] = delivered
-    result["queued"] = queued
+    queued_count = result.get("queued", 0)
+    result["queued"] = (queued_count if isinstance(queued_count, int) else 0) + scheduled
     return result
 
 

--- a/src/agent_bom/posture_streaming.py
+++ b/src/agent_bom/posture_streaming.py
@@ -12,6 +12,7 @@ import hashlib
 import hmac
 import ipaddress
 import json
+import os
 import sqlite3
 import time
 from dataclasses import dataclass, field
@@ -23,6 +24,21 @@ from agent_bom.security import sanitize_error, sanitize_sensitive_payload
 
 POSTURE_EVENT_SCHEMA_VERSION = "1"
 WebhookSender = Callable[[str, dict[str, str], dict[str, Any]], Awaitable[int]]
+POSTURE_EVENT_TYPES = frozenset(
+    {
+        "audit.delta",
+        "deploy.decision",
+        "exposure_path.changed",
+        "finding.created",
+        "graph.delta",
+        "intel.exploitation_changed",
+        "intel.matched_inventory",
+        "intel.published",
+        "runtime.alert",
+        "runtime.policy_decision",
+        "skill.verdict",
+    }
+)
 
 
 class PostureStreamingError(RuntimeError):
@@ -396,6 +412,20 @@ class WebhookOutbox:
             return bool(cur.rowcount)
 
 
+def default_webhook_outbox_path() -> Path:
+    configured = os.environ.get("AGENT_BOM_POSTURE_WEBHOOK_OUTBOX_DB", "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    shared_db = os.environ.get("AGENT_BOM_DB", "").strip()
+    if shared_db:
+        return Path(shared_db).expanduser()
+    return Path.home() / ".agent-bom" / "db" / "posture-webhooks.db"
+
+
+def default_webhook_outbox() -> WebhookOutbox:
+    return WebhookOutbox(default_webhook_outbox_path())
+
+
 def _outbox_record_from_row(row: sqlite3.Row) -> OutboxRecord:
     delivered = row["delivered_at"]
     return OutboxRecord(
@@ -478,12 +508,15 @@ async def deliver_due_webhooks(
 
 __all__ = [
     "POSTURE_EVENT_SCHEMA_VERSION",
+    "POSTURE_EVENT_TYPES",
     "OutboxRecord",
     "PostureEvent",
     "PostureStreamingError",
     "QueuedDelivery",
     "WebhookDestination",
     "WebhookOutbox",
+    "default_webhook_outbox",
+    "default_webhook_outbox_path",
     "deliver_due_webhooks",
     "signed_webhook_headers",
 ]

--- a/src/agent_bom/suppression_rules.py
+++ b/src/agent_bom/suppression_rules.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 _SUPPRESSING_FEEDBACK_STATES = {
     "false_positive",
     "accepted_risk",
+    "not_affected",
     "not_applicable",
     "fixed_verified",
 }
@@ -31,6 +32,8 @@ def feedback_state_from_reason(reason: str) -> tuple[str | None, str]:
     if closing <= len(marker):
         return None, reason
     state = reason[len(marker) : closing].strip()
+    if state == "not_applicable":
+        state = "not_affected"
     clean_reason = reason[closing + 1 :].strip()
     return state or None, clean_reason
 

--- a/tests/test_api_enterprise_tenant.py
+++ b/tests/test_api_enterprise_tenant.py
@@ -385,6 +385,36 @@ async def test_finding_feedback_uses_authenticated_actor_and_tenant(isolated_exc
 
 
 @pytest.mark.asyncio
+async def test_finding_feedback_accepts_not_affected_and_needs_review(isolated_exception_store):
+    not_affected = await enterprise.create_finding_feedback(
+        _request("tenant-alpha", "alice-admin"),
+        FindingFeedbackRequest(
+            vulnerability_id="CVE-2026-0001",
+            package="requests",
+            state="not_affected",
+            reason="not deployed",
+        ),
+    )
+    needs_review = await enterprise.create_finding_feedback(
+        _request("tenant-alpha", "alice-admin"),
+        FindingFeedbackRequest(
+            vulnerability_id="CVE-2026-0002",
+            package="urllib3",
+            state="needs_review",
+            reason="runtime declaration gap only",
+        ),
+    )
+
+    assert not_affected["state"] == "not_affected"
+    assert not_affected["status"] == "suppressed"
+    assert needs_review["state"] == "needs_review"
+    assert needs_review["status"] == "needs_review"
+    stored = isolated_exception_store.get(not_affected["id"], tenant_id="tenant-alpha")
+    assert stored is not None
+    assert stored.reason.startswith("[finding_feedback:not_affected]")
+
+
+@pytest.mark.asyncio
 async def test_finding_feedback_list_is_tenant_scoped(isolated_exception_store):
     alpha = VulnException(
         vuln_id="CVE-2026-0001",

--- a/tests/test_graph_wave23.py
+++ b/tests/test_graph_wave23.py
@@ -246,6 +246,8 @@ class TestDeltaAlerts:
 
         monkeypatch.delenv("AGENT_BOM_GRAPH_DELTA_WEBHOOK", raising=False)
         monkeypatch.delenv("AGENT_BOM_ALERT_WEBHOOK", raising=False)
+        monkeypatch.delenv("AGENT_BOM_GRAPH_DELTA_WEBHOOK_SIGNING_SECRET", raising=False)
+        monkeypatch.delenv("AGENT_BOM_POSTURE_WEBHOOK_SIGNING_SECRET", raising=False)
         monkeypatch.delenv("AGENT_BOM_GRAPH_DELTA_SLACK_WEBHOOK", raising=False)
         monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
 
@@ -260,7 +262,57 @@ class TestDeltaAlerts:
         assert result["queued"] == 0
         assert result["ocsf_event_count"] == len(alerts)
 
-    def test_dispatch_delta_alerts_to_configured_channels(self, monkeypatch):
+    def test_dispatch_delta_alerts_queues_configured_webhook_outbox(self, monkeypatch, tmp_path):
+        from agent_bom.graph.webhooks import compute_delta_alerts, dispatch_delta_alerts
+        from agent_bom.posture_streaming import WebhookOutbox
+
+        monkeypatch.setenv("AGENT_BOM_GRAPH_DELTA_WEBHOOK", "https://hooks.example.test/graph")
+        monkeypatch.setenv("AGENT_BOM_GRAPH_DELTA_WEBHOOK_SIGNING_SECRET", "secret")
+        monkeypatch.delenv("AGENT_BOM_GRAPH_DELTA_SLACK_WEBHOOK", raising=False)
+        monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+
+        new = UnifiedGraph(scan_id="s1")
+        new.add_node(UnifiedNode(id="vuln:CVE-1", entity_type=EntityType.VULNERABILITY, label="CVE-1", severity="critical"))
+
+        alerts = compute_delta_alerts(None, new)
+        outbox = WebhookOutbox(tmp_path / "graph-outbox.db")
+        result = dispatch_delta_alerts(alerts, product_version="0.76.0", tenant_id="tenant-a", outbox=outbox)
+
+        assert result["configured"] is True
+        assert result["outbound_channels"] == 1
+        assert result["delivered"] == 0
+        assert result["queued"] == len(alerts)
+        assert result["webhook_config_error"] == ""
+        records = outbox.records(tenant_id="tenant-a")
+        assert len(records) == 1
+        assert records[0].destination_id == "graph-delta-webhook"
+        due = outbox.due(tenant_id="tenant-a", now=10**12)
+        assert due[0].payload["event_type"] == "graph.delta"
+        assert due[0].payload["payload"]["alert"]["type"] == "new_vulnerability"
+
+    def test_dispatch_delta_alerts_requires_signing_secret_for_webhook(self, monkeypatch, tmp_path):
+        from agent_bom.graph.webhooks import compute_delta_alerts, dispatch_delta_alerts
+        from agent_bom.posture_streaming import WebhookOutbox
+
+        monkeypatch.setenv("AGENT_BOM_GRAPH_DELTA_WEBHOOK", "https://hooks.example.test/graph")
+        monkeypatch.delenv("AGENT_BOM_GRAPH_DELTA_WEBHOOK_SIGNING_SECRET", raising=False)
+        monkeypatch.delenv("AGENT_BOM_POSTURE_WEBHOOK_SIGNING_SECRET", raising=False)
+        monkeypatch.delenv("AGENT_BOM_GRAPH_DELTA_SLACK_WEBHOOK", raising=False)
+        monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+
+        new = UnifiedGraph(scan_id="s1")
+        new.add_node(UnifiedNode(id="vuln:CVE-1", entity_type=EntityType.VULNERABILITY, label="CVE-1", severity="critical"))
+
+        alerts = compute_delta_alerts(None, new)
+        outbox = WebhookOutbox(tmp_path / "graph-outbox.db")
+        result = dispatch_delta_alerts(alerts, product_version="0.76.0", tenant_id="tenant-a", outbox=outbox)
+
+        assert result["configured"] is False
+        assert result["queued"] == 0
+        assert "SIGNING_SECRET" in result["webhook_config_error"]
+        assert outbox.records(tenant_id="tenant-a") == []
+
+    def test_dispatch_delta_alerts_to_configured_slack_channel(self, monkeypatch):
         import agent_bom.alerts.dispatcher as dispatcher_mod
         from agent_bom.graph.webhooks import compute_delta_alerts, dispatch_delta_alerts
 
@@ -284,7 +336,8 @@ class TestDeltaAlerts:
                 return 1 + len(self.webhooks) + len(self.slacks)
 
         monkeypatch.setattr(dispatcher_mod, "AlertDispatcher", FakeDispatcher)
-        monkeypatch.setenv("AGENT_BOM_GRAPH_DELTA_WEBHOOK", "https://hooks.example.test/graph")
+        monkeypatch.delenv("AGENT_BOM_GRAPH_DELTA_WEBHOOK", raising=False)
+        monkeypatch.delenv("AGENT_BOM_ALERT_WEBHOOK", raising=False)
         monkeypatch.setenv("AGENT_BOM_GRAPH_DELTA_SLACK_WEBHOOK", "https://hooks.slack.test/services/example")
 
         new = UnifiedGraph(scan_id="s1")
@@ -294,10 +347,10 @@ class TestDeltaAlerts:
         result = dispatch_delta_alerts(alerts, product_version="0.76.0")
 
         assert result["configured"] is True
-        assert result["outbound_channels"] == 2
-        assert result["delivered"] == len(alerts) * 2
+        assert result["outbound_channels"] == 1
+        assert result["delivered"] == len(alerts)
         assert FakeDispatcher.last is not None
-        assert FakeDispatcher.last.webhooks == [("https://hooks.example.test/graph", None)]
+        assert FakeDispatcher.last.webhooks == []
         assert FakeDispatcher.last.slacks == ["https://hooks.slack.test/services/example"]
         assert FakeDispatcher.last.dispatched
         assert FakeDispatcher.last.dispatched[0]["type"] == "new_vulnerability"
@@ -329,7 +382,8 @@ class TestDeltaAlerts:
                 asyncio.get_running_loop().create_task(self.dispatch(alert))
 
         monkeypatch.setattr(dispatcher_mod, "AlertDispatcher", FakeDispatcher)
-        monkeypatch.setenv("AGENT_BOM_GRAPH_DELTA_WEBHOOK", "https://hooks.example.test/graph")
+        monkeypatch.delenv("AGENT_BOM_GRAPH_DELTA_WEBHOOK", raising=False)
+        monkeypatch.delenv("AGENT_BOM_ALERT_WEBHOOK", raising=False)
         monkeypatch.setenv("AGENT_BOM_GRAPH_DELTA_SLACK_WEBHOOK", "https://hooks.slack.test/services/example")
 
         new = UnifiedGraph(scan_id="s1")
@@ -347,7 +401,7 @@ class TestDeltaAlerts:
 
         assert result["configured"] is True
         assert result["delivered"] == 0
-        assert result["queued"] == len(alerts) * 2
+        assert result["queued"] == len(alerts)
         assert FakeDispatcher.last is not None
         assert FakeDispatcher.last.dispatched
         assert not any("was never awaited" in str(w.message) for w in caught)

--- a/tests/test_suppression_rules.py
+++ b/tests/test_suppression_rules.py
@@ -80,7 +80,7 @@ def test_suppression_metadata_is_exported_in_json_report():
             vuln_id="CVE-2026-12345",
             package_name="requests",
             server_name="github",
-            reason="[finding_feedback:not_applicable] not deployed",
+            reason="[finding_feedback:not_affected] not deployed",
             status=ExceptionStatus.ACTIVE,
             tenant_id="tenant-a",
         )
@@ -92,6 +92,27 @@ def test_suppression_metadata_is_exported_in_json_report():
 
     finding = payload["blast_radius"][0]
     assert finding["suppressed"] is True
-    assert finding["suppression_state"] == "not_applicable"
+    assert finding["suppression_state"] == "not_affected"
     assert finding["suppression_reason"] == "not deployed"
     assert finding["unsuppressed_risk_score"] == 8.4
+
+
+def test_needs_review_feedback_does_not_suppress_actionability():
+    store = InMemoryExceptionStore()
+    store.put(
+        VulnException(
+            vuln_id="CVE-2026-12345",
+            package_name="requests",
+            server_name="github",
+            reason="[finding_feedback:needs_review] low confidence runtime-only match",
+            status=ExceptionStatus.ACTIVE,
+            tenant_id="tenant-a",
+        )
+    )
+    blast_radii = [_blast_radius()]
+
+    summary = apply_tenant_suppression_rules(blast_radii, store, tenant_id="tenant-a")
+
+    assert summary == {"evaluated": 1, "suppressed": 0}
+    assert blast_radii[0].suppressed is False
+    assert blast_radii[0].risk_score == 8.4


### PR DESCRIPTION
Summary
- queue graph delta webhook events through the signed posture webhook outbox instead of direct generic webhook dispatch
- preserve OCSF export metadata and add reserved posture event types for graph, intel, runtime, and finding events
- add cross-workload feedback controls for canonical not_affected and non-suppressing needs_review states

Verification
- uv run pytest tests/test_graph_wave23.py tests/test_posture_streaming.py tests/test_suppression_rules.py tests/test_api_enterprise_tenant.py -q
- uv run ruff check src/agent_bom/graph/webhooks.py src/agent_bom/posture_streaming.py src/agent_bom/api/routes/posture_streaming.py src/agent_bom/api/pipeline.py src/agent_bom/api/models.py src/agent_bom/api/routes/enterprise.py src/agent_bom/suppression_rules.py src/agent_bom/accuracy_baseline.py tests/test_graph_wave23.py tests/test_suppression_rules.py tests/test_api_enterprise_tenant.py
- uv run mypy src/agent_bom/graph/webhooks.py src/agent_bom/posture_streaming.py src/agent_bom/api/routes/posture_streaming.py src/agent_bom/api/pipeline.py src/agent_bom/api/models.py src/agent_bom/api/routes/enterprise.py src/agent_bom/suppression_rules.py src/agent_bom/accuracy_baseline.py
- uv run python scripts/generate_accuracy_baseline.py --check
- python scripts/check_release_consistency.py
- git diff --check

Notes
- Partially closes #2638 by routing graph delta delivery through the durable outbox.
- Partially closes #2644 by making needs_review non-suppressing while keeping not_affected suppressing and preserving not_applicable as a legacy alias.