### PR TITLE
fix(mcp): scan direct package specs

### DIFF
--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -9,7 +9,12 @@ fail closed unless the caller supplies an admin role and audit reason.
 ## Tools
 
 ### scan
-Full discovery + vulnerability scan pipeline. Auto-discovers MCP clients, extracts servers and packages, scans for CVEs, computes blast radius.
+Full discovery + vulnerability scan pipeline. Auto-discovers MCP clients,
+extracts servers and packages, scans for CVEs, computes blast radius, or scans
+a direct MCP launch package when no local config is available.
+```
+scan(package="npx @modelcontextprotocol/server-filesystem@2025.1.14")
+```
 
 ### check
 Check a single package for vulnerabilities.

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -345,6 +345,7 @@ async def _run_scan_pipeline(
     config_path: Optional[str] = None,
     image: Optional[str] = None,
     sbom_path: Optional[str] = None,
+    package: Optional[str] = None,
     enrich: bool = False,
     transitive: bool = False,
     offline: bool = False,
@@ -355,6 +356,7 @@ async def _run_scan_pipeline(
         config_path=config_path,
         image=image,
         sbom_path=sbom_path,
+        package=package,
         enrich=enrich,
         transitive=transitive,
         offline=offline,
@@ -408,6 +410,15 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
         config_path: Annotated[str | None, Field(description="Path to MCP client config directory. Auto-discovers all if omitted.")] = None,
         image: Annotated[str | None, Field(description="Docker image to scan (e.g. 'nginx:1.25', 'ghcr.io/org/app:v1').")] = None,
         sbom_path: Annotated[str | None, Field(description="Path to existing CycloneDX or SPDX JSON SBOM file to ingest.")] = None,
+        package: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Direct package or MCP launch command to scan, e.g. "
+                    "'npx @modelcontextprotocol/server-filesystem@2025.1.14' or '@modelcontextprotocol/server-filesystem'."
+                )
+            ),
+        ] = None,
         enrich: Annotated[bool, Field(description="Enable NVD CVSS, EPSS probability, and CISA KEV enrichment.")] = False,
         offline: Annotated[
             bool,
@@ -471,6 +482,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
             config_path=config_path,
             image=image,
             sbom_path=sbom_path,
+            package=package,
             enrich=enrich,
             offline=offline,
             scorecard=scorecard,

--- a/src/agent_bom/mcp_server_scan.py
+++ b/src/agent_bom/mcp_server_scan.py
@@ -7,6 +7,7 @@ while moving the discovery + scan pipeline out of the monolith.
 from __future__ import annotations
 
 import logging
+import shlex
 from pathlib import Path
 from typing import Optional
 
@@ -21,12 +22,49 @@ from agent_bom.security import sanitize_error  # noqa: F401 — kept for downstr
 logger = logging.getLogger(__name__)
 
 
+def _package_spec_agent(package_spec: str):
+    """Build a synthetic MCP inventory entry from a direct package command."""
+    from agent_bom.models import Agent, AgentType, MCPServer, TransportType
+
+    tokens = shlex.split(package_spec)
+    if not tokens:
+        raise ValueError("package must not be empty")
+
+    command = tokens[0]
+    args = tokens[1:]
+    if command not in {"npx", "npm", "pnpm", "yarn", "bunx", "uvx", "uv"}:
+        command = "npx"
+        args = tokens
+    elif command in {"npm", "pnpm", "yarn"} and args and args[0] in {"dlx", "exec"}:
+        command = "npx"
+        args = args[1:]
+    elif command == "bunx":
+        command = "npx"
+
+    server = MCPServer(
+        name=f"package:{' '.join([command, *args]).strip()}",
+        command=command,
+        args=args,
+        env={},
+        transport=TransportType.STDIO,
+        config_path="mcp-scan-package",
+        discovery_sources=["mcp_scan_package"],
+    )
+    return Agent(
+        name=f"package:{package_spec}",
+        agent_type=AgentType.CUSTOM,
+        config_path="mcp-scan-package",
+        mcp_servers=[server],
+    )
+
+
 async def run_scan_pipeline(
     *,
     safe_path,
     config_path: Optional[str] = None,
     image: Optional[str] = None,
     sbom_path: Optional[str] = None,
+    package: Optional[str] = None,
     enrich: bool = False,
     transitive: bool = False,
     offline: bool = False,
@@ -63,6 +101,13 @@ async def run_scan_pipeline(
     agents = discover_all(project_dir=config_path)
     if agents:
         scan_sources.append("agent_discovery")
+
+    if package:
+        try:
+            agents.append(_package_spec_agent(package))
+            scan_sources.append("mcp_package")
+        except ValueError as exc:
+            return mcp_error_json(CODE_VALIDATION_INVALID_PATH, exc, details={"argument": "package"})
 
     if image:
         try:
@@ -136,6 +181,13 @@ async def run_scan_pipeline(
         for server in agent.mcp_servers:
             if not server.packages:
                 server.packages = extract_packages(server)
+            if offline:
+                for pkg in server.packages:
+                    if pkg.floating_reference and pkg.declared_version in {"latest", "*"}:
+                        warnings.append(
+                            f"{pkg.name} uses a floating package reference; pass {pkg.name}@version "
+                            "or set offline=false for registry-backed resolution."
+                        )
 
     if enrich and not offline:
         blast_radii = await scan_agents_with_enrichment(agents, options=ScanOptions(offline=offline))

--- a/src/agent_bom/mcp_tools/scanning.py
+++ b/src/agent_bom/mcp_tools/scanning.py
@@ -17,6 +17,7 @@ async def scan_impl(
     config_path: str | None = None,
     image: str | None = None,
     sbom_path: str | None = None,
+    package: str | None = None,
     enrich: bool = False,
     offline: bool = True,
     scorecard: bool = False,
@@ -46,6 +47,12 @@ async def scan_impl(
         if offline and verify_integrity:
             verify_integrity = False
             pre_warnings.append("Package integrity verification skipped because offline mode was requested")
+        if package is not None:
+            package = package.strip()
+            if not package:
+                raise ToolError("package must not be empty")
+            if len(package) > 256:
+                raise ToolError("package must be 256 characters or fewer")
 
         # Auto-refresh stale DB before scanning only when explicitly requested.
         if auto_update_db and not offline:
@@ -67,6 +74,7 @@ async def scan_impl(
             config_path,
             image,
             sbom_path,
+            package,
             enrich,
             transitive=transitive,
             offline=offline,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -262,6 +262,57 @@ def test_scan_no_agents(mock_pipeline):
 
 
 @patch("agent_bom.mcp_server._run_scan_pipeline")
+def test_scan_accepts_direct_npx_package(mock_pipeline):
+    """Scan can target a direct npx package spec without local config discovery."""
+    mock_pipeline.return_value = ([], [], [], [])
+    from agent_bom.mcp_server import create_mcp_server
+
+    server = create_mcp_server()
+    result = _call_tool(
+        server,
+        "scan",
+        {"package": "npx -y @modelcontextprotocol/server-filesystem", "auto_update_db": False},
+    )
+
+    assert result["status"] == "no_agents_found"
+    args, kwargs = mock_pipeline.call_args
+    assert args[:4] == (None, None, None, "npx -y @modelcontextprotocol/server-filesystem")
+    assert kwargs["offline"] is True
+
+
+def test_scan_pipeline_builds_inventory_from_npx_package(monkeypatch):
+    """The scan pipeline converts npx specs into a synthetic MCP server inventory."""
+    from agent_bom.mcp_server_scan import run_scan_pipeline
+
+    captured_agents = []
+
+    async def _fake_scan_agents(agents, *, options):
+        captured_agents.extend(agents)
+        return []
+
+    monkeypatch.setattr("agent_bom.discovery.discover_all", lambda project_dir=None: [])
+    monkeypatch.setattr("agent_bom.scanners.scan_agents", _fake_scan_agents)
+
+    agents, _blast_radii, warnings, scan_sources = _run(
+        run_scan_pipeline(
+            safe_path=lambda value: Path(value),
+            package="npx -y @modelcontextprotocol/server-filesystem",
+            offline=True,
+        )
+    )
+
+    assert agents == captured_agents
+    assert scan_sources == ["mcp_package"]
+    server = agents[0].mcp_servers[0]
+    assert server.command == "npx"
+    assert server.args == ["-y", "@modelcontextprotocol/server-filesystem"]
+    assert server.packages[0].name == "@modelcontextprotocol/server-filesystem"
+    assert server.packages[0].declared_version == "latest"
+    assert server.packages[0].floating_reference is True
+    assert any("pass @modelcontextprotocol/server-filesystem@version" in warning for warning in warnings)
+
+
+@patch("agent_bom.mcp_server._run_scan_pipeline")
 def test_scan_default_read_only_contract_does_not_refresh_db_and_uses_offline_scan(mock_pipeline):
     """Default read-only scan must avoid DB refresh and online vulnerability scans."""
     mock_pipeline.return_value = ([], [], [], [])


### PR DESCRIPTION
Summary

- add a direct `package` input to the MCP `scan` tool for package or launch-command scans such as `npx @modelcontextprotocol/server-filesystem`
- synthesize a read-only MCP server inventory entry from direct package specs and reuse the existing npx/uvx package parsers
- warn clearly when offline scans see floating package refs so callers know to pass `package@version` or opt into online registry resolution

Verification

- uv run pytest tests/test_mcp_server.py -q
- uv run ruff check src/agent_bom/mcp_server.py src/agent_bom/mcp_tools/scanning.py src/agent_bom/mcp_server_scan.py tests/test_mcp_server.py
- uv run mypy src/agent_bom/mcp_server.py src/agent_bom/mcp_tools/scanning.py src/agent_bom/mcp_server_scan.py
- python scripts/check_release_consistency.py
- git diff --check

Notes

Closes the MCP scan UX gap where `scan` could only discover local config/image/SBOM inputs and direct unversioned `npx <pkg>` requests had no useful scan path.
