### PR TITLE
docs(intel): document vendor advisory feed support

### DIFF
--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -65,6 +65,24 @@ A vulnerability in `nvidia-cudnn-cu12` or `hip-python` doesn't just affect one m
 | `trubrics` | Trubrics feedback and evaluation telemetry |
 | `@helicone/helicone` | Helicone request and LLM observability instrumentation |
 
+## Vendor advisory feed support
+
+agent-bom separates structured vendor feeds from curated seed data so operators
+can tell which advisory matches are feed-backed and which are best-effort
+coverage. The source catalog is exposed through `GET /v1/intel/sources` and
+the `intel_sources` MCP tool; the daily brief uses the same metadata when it
+reports vendor advisory matches.
+
+| Source | Status | Connector | Matching scope | Boundary |
+|---|---|---|---|---|
+| NVIDIA CSAF | supported | `csaf_json` | CUDA, cuDNN, NCCL, TensorRT, Triton, NIM, NeMo, PyTorch/vLLM mappings, and related GPU container/package signals | Structured CSAF records are matched and source-linked; year windows follow current and previous year feeds. |
+| AMD PSIRT | experimental | `vendor_json_seed` | ROCm and AMD GPU package/image signals from curated advisory seeds | No open-ended website scraping is shipped; matches remain source-linked and marked experimental. |
+| Intel PSIRT | experimental | `curated_seed` | GPU and oneAPI advisory seeds | No automated webpage scraping is shipped; matches remain source-linked and marked experimental. |
+
+Daily threat briefs summarize local database evidence and submitted inventory.
+They do not claim IoC telemetry, campaign attribution, ransomware tracking, or
+sector/geo targeting unless a future connector supplies those inputs.
+
 ## Scanning GPU container images
 
 ### NVIDIA CUDA images

--- a/site-docs/architecture/ai-infrastructure.md
+++ b/site-docs/architecture/ai-infrastructure.md
@@ -17,6 +17,19 @@ For the seven-layer AI-BOM evidence map, see
 | **AI observability** | LangSmith, Langfuse, Braintrust, Arize/Phoenix, Trubrics, Helicone SDK inventory |
 | **Code** | SAST via Semgrep with CWE mapping |
 
+## Vendor advisory feeds
+
+Vendor advisory matches are surfaced through the same local intel APIs as OSV,
+GHSA, NVD, EPSS, and KEV data. `intel_sources` reports source policy and
+freshness so operators can distinguish structured feed coverage from
+experimental seed coverage.
+
+| Source | Support status | Connector | Boundary |
+|---|---|---|---|
+| NVIDIA CSAF | supported | `csaf_json` | Structured CSAF matching for mapped GPU, CUDA, NIM, NeMo, inference, and container package signals. |
+| AMD PSIRT | experimental | `vendor_json_seed` | ROCm and AMD GPU matches from curated seeds; no open-ended web scraping is shipped. |
+| Intel PSIRT | experimental | `curated_seed` | GPU and oneAPI matches from curated seeds; no automated webpage scraping is shipped. |
+
 ## Coverage Matrix
 
 Use this matrix when deciding which AI infrastructure path to run first. The


### PR DESCRIPTION
Summary

- document the current vendor advisory feed support matrix for NVIDIA CSAF, AMD PSIRT, and Intel PSIRT
- make structured-feed versus curated-seed support explicit across repo docs and published site docs
- keep the daily-brief boundary honest: local DB and submitted inventory only, with no claim of open-ended vendor scraping or IoC/campaign telemetry

Verification

- python scripts/check_release_consistency.py
- git diff --check
- rg -n "v0\\.87|v0\\.86|NVIDIA CSAF|AMD PSIRT|Intel PSIRT" docs/AI_INFRASTRUCTURE_SCANNING.md site-docs/architecture/ai-infrastructure.md

Notes

Closes #2639 by documenting the decided vendor advisory lane now backed by the governed source catalog and vendor advisory scanners.
