### PR TITLE
feat(sdk): add Go control-plane client

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Security and release references:
 - [Threat model](docs/THREAT_MODEL.md)
 - [Pentest readiness](docs/PENTEST_READINESS.md)
 - [Python API and control-plane client](docs/PYTHON_API.md)
+- [Go control-plane client](sdks/go/README.md)
 - [Product metrics](docs/PRODUCT_METRICS.md)
 - [Release verification](docs/RELEASE_VERIFICATION.md)
 - [GitHub Action](https://github.com/marketplace/actions/agent-bom)

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -128,7 +128,7 @@ notes discuss agent-native product direction.
 |---|---|---|
 | Human cockpit | Next.js dashboard, graph cockpit, reports, compliance and audit views | every UI action backed by a source registry and persisted workflow state |
 | Agent interface | 55 MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture, admin-gated Shield actions | long-lived posture subscription tool, autonomous remediation actions |
-| Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports, TypeScript control-plane client, TypeScript runtime detector package | Python/Go control-plane SDKs and full scanner SDKs |
+| Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports, Python/Go/TypeScript control-plane clients, TypeScript runtime detector package | full scanner SDKs |
 | Runtime | MCP proxy, gateway, Shield SDK, runtime audit and policy decisions | webhook outbox, Kafka connectors, cloud-log ingestion connectors, Kinesis/Firehose adapter, and MCP posture subscriptions |
 | Graph scale | SQLite/Postgres default path, WebGL overview, optional Neptune adapter work | production Neptune SLOs, public openCypher endpoint, mandatory graph-database backend |
 | Extensibility | Python package internals, skills, runtime detector package | productized detection-as-code YAML registry and stable plugin SDK |

--- a/docs/openapi/README.md
+++ b/docs/openapi/README.md
@@ -15,5 +15,6 @@ Check for drift in CI:
 python scripts/export_openapi.py --check
 ```
 
-The TypeScript, Python, and future Go clients should treat these artifacts as
-the source contract rather than hand-maintaining route paths independently.
+The TypeScript, Python, and Go control-plane clients should treat these
+artifacts as the source contract rather than hand-maintaining route paths
+independently.

--- a/examples/go_sdk/README.md
+++ b/examples/go_sdk/README.md
@@ -1,0 +1,14 @@
+# Go SDK Smoke
+
+Run this against a live agent-bom API deployment to verify the Go
+control-plane client can authenticate and read the first operational surfaces.
+
+```bash
+cd examples/go_sdk
+AGENT_BOM_BASE_URL=http://127.0.0.1:8422 \
+AGENT_BOM_API_KEY=dev-key \
+go run ./control_plane_smoke.go
+```
+
+The smoke reads `/health`, `/v1/agent-bom/manifest`, and
+`/v1/runtime/production-index`. It does not run local scans or write data.

--- a/examples/go_sdk/control_plane_smoke.go
+++ b/examples/go_sdk/control_plane_smoke.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	agentbom "github.com/msaad00/agent-bom/sdks/go"
+)
+
+func main() {
+	baseURL := os.Getenv("AGENT_BOM_BASE_URL")
+	if baseURL == "" {
+		baseURL = "http://127.0.0.1:8422"
+	}
+
+	client, err := agentbom.NewClient(agentbom.Options{
+		BaseURL:     baseURL,
+		APIKey:      os.Getenv("AGENT_BOM_API_KEY"),
+		BearerToken: os.Getenv("AGENT_BOM_BEARER_TOKEN"),
+		TenantID:    os.Getenv("AGENT_BOM_TENANT_ID"),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+	health, err := client.Health(ctx)
+	if err != nil {
+		panic(err)
+	}
+	manifest, err := client.AgentManifest(ctx, "")
+	if err != nil {
+		panic(err)
+	}
+	runtime, err := client.RuntimeProductionIndex(ctx, "")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("health=%v manifest_schema=%v runtime_schema=%v\n", health["status"], manifest["schema_version"], runtime["schema_version"])
+}

--- a/examples/go_sdk/go.mod
+++ b/examples/go_sdk/go.mod
@@ -1,0 +1,7 @@
+module github.com/msaad00/agent-bom/examples/go-sdk
+
+go 1.22
+
+require github.com/msaad00/agent-bom/sdks/go v0.0.0
+
+replace github.com/msaad00/agent-bom/sdks/go => ../../sdks/go

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,6 +161,7 @@ nav:
       - Smithery: integrations/smithery.md
   - API Reference:
       - Python API: api/python-sdk.md
+      - Go SDK: api/go-sdk.md
       - Models: api/models.md
       - Output: api/output.md
       - Scanners: api/scanners.md

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -1,0 +1,58 @@
+# agent-bom Go SDK
+
+The Go SDK is a lightweight control-plane client for stable agent-bom API
+routes. It talks to an existing self-hosted API deployment; it does not embed a
+scanner or duplicate CLI behavior.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	agentbom "github.com/msaad00/agent-bom/sdks/go"
+)
+
+func main() {
+	client, err := agentbom.NewClient(agentbom.Options{
+		BaseURL:  "https://agent-bom.example.com",
+		APIKey:   "...",
+		TenantID: "default",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	health, err := client.Health(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(health["status"])
+}
+```
+
+## Covered Surfaces
+
+- `GET /health`
+- `GET /v1/findings`
+- `POST /v1/findings/bulk`
+- `GET /v1/graph/exposure-paths`
+- `POST /v1/graph/should-i-deploy`
+- `GET|POST /v1/datasets/{dataset_id}/versions`
+- `GET /v1/datasets/{dataset_id}/versions/{version_id}`
+- `GET /v1/agent-bom/manifest`
+- `GET /v1/runtime/production-index`
+- `GET /v1/intel/advisories/{advisory_id}`
+- `POST /v1/intel/match`
+- `GET /v1/intel/sources`
+
+Configure either `APIKey` or `BearerToken`, not both. Tenant scope is sent as
+`X-Agent-Bom-Tenant-ID` and, where the API accepts it, as `tenant_id`.
+
+## Verify
+
+```bash
+cd sdks/go
+go test ./...
+```

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -1,0 +1,353 @@
+// Package agentbom provides a small Go client for the agent-bom control-plane API.
+package agentbom
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// JSON is the generic object envelope returned by stable control-plane routes.
+type JSON map[string]any
+
+// Options configures a control-plane client.
+type Options struct {
+	BaseURL        string
+	APIKey         string
+	BearerToken    string
+	TenantID       string
+	HTTPClient     *http.Client
+	DefaultHeaders map[string]string
+}
+
+// Client is a synchronous control-plane client for stable agent-bom API routes.
+type Client struct {
+	baseURL        string
+	apiKey         string
+	bearerToken    string
+	tenantID       string
+	httpClient     *http.Client
+	defaultHeaders map[string]string
+}
+
+// APIError is returned when the control plane responds with a non-2xx status.
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("agent-bom request failed: %d", e.StatusCode)
+}
+
+// NewClient constructs a control-plane client.
+func NewClient(opts Options) (*Client, error) {
+	baseURL := strings.TrimRight(strings.TrimSpace(opts.BaseURL), "/")
+	if baseURL == "" {
+		return nil, fmt.Errorf("baseURL is required")
+	}
+	if opts.APIKey != "" && opts.BearerToken != "" {
+		return nil, fmt.Errorf("configure either APIKey or BearerToken, not both")
+	}
+	httpClient := opts.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	headers := map[string]string{}
+	for key, value := range opts.DefaultHeaders {
+		headers[key] = value
+	}
+	return &Client{
+		baseURL:        baseURL,
+		apiKey:         opts.APIKey,
+		bearerToken:    opts.BearerToken,
+		tenantID:       opts.TenantID,
+		httpClient:     httpClient,
+		defaultHeaders: headers,
+	}, nil
+}
+
+// Health returns the control-plane health envelope.
+func (c *Client) Health(ctx context.Context) (JSON, error) {
+	return c.request(ctx, http.MethodGet, "/health", nil, nil)
+}
+
+// ExposurePathQuery filters graph exposure paths.
+type ExposurePathQuery struct {
+	TenantID string
+	Limit    *int
+	MinRisk  *int
+}
+
+// ExposurePaths lists graph exposure paths for the request tenant.
+func (c *Client) ExposurePaths(ctx context.Context, query ExposurePathQuery) (JSON, error) {
+	values := url.Values{}
+	tenantID := firstNonEmpty(query.TenantID, c.tenantID)
+	if tenantID != "" {
+		values.Set("tenant_id", tenantID)
+	}
+	if query.Limit != nil {
+		values.Set("limit", fmt.Sprint(*query.Limit))
+	}
+	if query.MinRisk != nil {
+		values.Set("min_risk", fmt.Sprint(*query.MinRisk))
+	}
+	return c.request(ctx, http.MethodGet, "/v1/graph/exposure-paths", values, nil)
+}
+
+// DeployDecisionRequest asks the graph policy engine whether a candidate should deploy.
+type DeployDecisionRequest struct {
+	Candidate any
+	TenantID  string
+	BlockRisk *int
+	Context   JSON
+}
+
+// ShouldIDeploy asks the graph policy engine whether a candidate should deploy.
+func (c *Client) ShouldIDeploy(ctx context.Context, req DeployDecisionRequest) (JSON, error) {
+	return c.request(ctx, http.MethodPost, "/v1/graph/should-i-deploy", nil, compact(JSON{
+		"candidate":  req.Candidate,
+		"tenant_id":  firstNonEmpty(req.TenantID, c.tenantID),
+		"block_risk": req.BlockRisk,
+		"context":    req.Context,
+	}))
+}
+
+// FindingQuery filters normalized findings.
+type FindingQuery struct {
+	Severity string
+	Sort     string
+	Limit    *int
+	Offset   *int
+}
+
+// ListFindings lists normalized findings from scan jobs and bulk ingests.
+func (c *Client) ListFindings(ctx context.Context, query FindingQuery) (JSON, error) {
+	values := url.Values{}
+	if query.Severity != "" {
+		values.Set("severity", query.Severity)
+	}
+	if query.Sort != "" {
+		values.Set("sort", query.Sort)
+	}
+	if query.Limit != nil {
+		values.Set("limit", fmt.Sprint(*query.Limit))
+	}
+	if query.Offset != nil {
+		values.Set("offset", fmt.Sprint(*query.Offset))
+	}
+	return c.request(ctx, http.MethodGet, "/v1/findings", values, nil)
+}
+
+// IngestFindingsRequest posts normalized findings directly into the control plane.
+type IngestFindingsRequest struct {
+	Findings      []JSON
+	Source        string
+	SchemaVersion string
+	Metadata      JSON
+	TenantID      string
+}
+
+// IngestFindings posts normalized findings directly into the control plane.
+func (c *Client) IngestFindings(ctx context.Context, req IngestFindingsRequest) (JSON, error) {
+	return c.request(ctx, http.MethodPost, "/v1/findings/bulk", nil, compact(JSON{
+		"findings":       req.Findings,
+		"source":         req.Source,
+		"schema_version": req.SchemaVersion,
+		"metadata":       req.Metadata,
+		"tenant_id":      firstNonEmpty(req.TenantID, c.tenantID),
+	}))
+}
+
+// DatasetVersionRequest registers one dataset version artifact.
+type DatasetVersionRequest struct {
+	DatasetID       string
+	VersionID       string
+	ArtifactURI     string
+	Digest          string
+	DigestAlgorithm string
+	Source          string
+	Metadata        JSON
+	TenantID        string
+}
+
+// RegisterDatasetVersion registers one dataset version artifact.
+func (c *Client) RegisterDatasetVersion(ctx context.Context, req DatasetVersionRequest) (JSON, error) {
+	path := "/v1/datasets/" + url.PathEscape(req.DatasetID) + "/versions"
+	return c.request(ctx, http.MethodPost, path, nil, compact(JSON{
+		"version_id":       req.VersionID,
+		"artifact_uri":     req.ArtifactURI,
+		"digest":           req.Digest,
+		"digest_algorithm": req.DigestAlgorithm,
+		"source":           req.Source,
+		"metadata":         req.Metadata,
+		"tenant_id":        firstNonEmpty(req.TenantID, c.tenantID),
+	}))
+}
+
+// DatasetVersions lists versions for a dataset.
+func (c *Client) DatasetVersions(ctx context.Context, datasetID string) (JSON, error) {
+	return c.request(ctx, http.MethodGet, "/v1/datasets/"+url.PathEscape(datasetID)+"/versions", nil, nil)
+}
+
+// DatasetVersion returns one dataset version record.
+func (c *Client) DatasetVersion(ctx context.Context, datasetID string, versionID string) (JSON, error) {
+	path := "/v1/datasets/" + url.PathEscape(datasetID) + "/versions/" + url.PathEscape(versionID)
+	return c.request(ctx, http.MethodGet, path, nil, nil)
+}
+
+// AgentManifest returns the tenant-scoped Agent BOM manifest.
+func (c *Client) AgentManifest(ctx context.Context, tenantID string) (JSON, error) {
+	values := url.Values{}
+	if tenantID == "" {
+		tenantID = c.tenantID
+	}
+	if tenantID != "" {
+		values.Set("tenant_id", tenantID)
+	}
+	return c.request(ctx, http.MethodGet, "/v1/agent-bom/manifest", values, nil)
+}
+
+// RuntimeProductionIndex returns runtime production-index posture.
+func (c *Client) RuntimeProductionIndex(ctx context.Context, tenantID string) (JSON, error) {
+	values := url.Values{}
+	if tenantID == "" {
+		tenantID = c.tenantID
+	}
+	if tenantID != "" {
+		values.Set("tenant_id", tenantID)
+	}
+	return c.request(ctx, http.MethodGet, "/v1/runtime/production-index", values, nil)
+}
+
+// IntelLookup looks up one advisory by CVE, GHSA, or OSV identifier.
+func (c *Client) IntelLookup(ctx context.Context, advisoryID string) (JSON, error) {
+	return c.request(ctx, http.MethodGet, "/v1/intel/advisories/"+url.PathEscape(advisoryID), nil, nil)
+}
+
+// IntelMatchRequest matches package coordinates against advisory intelligence.
+type IntelMatchRequest struct {
+	Packages  []JSON
+	PURL      string
+	Ecosystem string
+	Name      string
+	Version   string
+	Limit     *int
+}
+
+// IntelMatch matches package coordinates against advisory intelligence.
+func (c *Client) IntelMatch(ctx context.Context, req IntelMatchRequest) (JSON, error) {
+	return c.request(ctx, http.MethodPost, "/v1/intel/match", nil, compact(JSON{
+		"packages":  req.Packages,
+		"purl":      req.PURL,
+		"ecosystem": req.Ecosystem,
+		"name":      req.Name,
+		"version":   req.Version,
+		"limit":     req.Limit,
+	}))
+}
+
+// IntelSources lists configured advisory intelligence sources and freshness.
+func (c *Client) IntelSources(ctx context.Context) (JSON, error) {
+	return c.request(ctx, http.MethodGet, "/v1/intel/sources", nil, nil)
+}
+
+func (c *Client) request(ctx context.Context, method string, path string, values url.Values, body JSON) (JSON, error) {
+	endpoint := c.url(path)
+	if len(values) > 0 {
+		endpoint += "?" + values.Encode()
+	}
+
+	var reader io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		reader = bytes.NewReader(payload)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, method, endpoint, reader)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Accept", "application/json")
+	for key, value := range c.defaultHeaders {
+		request.Header.Set(key, value)
+	}
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	if c.apiKey != "" {
+		request.Header.Set("X-API-Key", c.apiKey)
+	}
+	if c.bearerToken != "" {
+		request.Header.Set("Authorization", "Bearer "+c.bearerToken)
+	}
+	if c.tenantID != "" {
+		request.Header.Set("X-Agent-Bom-Tenant-ID", c.tenantID)
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	text, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, &APIError{StatusCode: response.StatusCode, Body: string(text)}
+	}
+	if len(text) == 0 {
+		return JSON{}, nil
+	}
+	var data JSON
+	if err := json.Unmarshal(text, &data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (c *Client) url(path string) string {
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return path
+	}
+	return c.baseURL + "/" + strings.TrimLeft(path, "/")
+}
+
+func compact(values JSON) JSON {
+	result := JSON{}
+	for key, value := range values {
+		switch typed := value.(type) {
+		case nil:
+			continue
+		case string:
+			if typed == "" {
+				continue
+			}
+		case JSON:
+			if len(typed) == 0 {
+				continue
+			}
+		}
+		result[key] = value
+	}
+	return result
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -1,0 +1,193 @@
+package agentbom
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func testClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client, err := NewClient(Options{
+		BaseURL:  server.URL + "/",
+		APIKey:   "secret",
+		TenantID: "tenant-a",
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return client
+}
+
+func TestClientSetsAuthHeadersAndStripsEmptyBodyFields(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/graph/should-i-deploy" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-API-Key"); got != "secret" {
+			t.Fatalf("X-API-Key = %q", got)
+		}
+		if got := r.Header.Get("X-Agent-Bom-Tenant-ID"); got != "tenant-a" {
+			t.Fatalf("X-Agent-Bom-Tenant-ID = %q", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("Content-Type = %q", got)
+		}
+		var body JSON
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("Decode body: %v", err)
+		}
+		if _, ok := body["context"]; ok {
+			t.Fatalf("empty context should be omitted: %#v", body)
+		}
+		if body["tenant_id"] != "tenant-a" || body["candidate"] != "flask@2.0.0" {
+			t.Fatalf("unexpected body: %#v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"decision":"allow"}`))
+	})
+
+	blockRisk := 80
+	result, err := client.ShouldIDeploy(context.Background(), DeployDecisionRequest{
+		Candidate: "flask@2.0.0",
+		BlockRisk: &blockRisk,
+	})
+	if err != nil {
+		t.Fatalf("ShouldIDeploy: %v", err)
+	}
+	if result["decision"] != "allow" {
+		t.Fatalf("decision = %#v", result["decision"])
+	}
+}
+
+func TestClientBuildsQueryParams(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/graph/exposure-paths" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		query := r.URL.Query()
+		if query.Get("tenant_id") != "tenant-a" || query.Get("limit") != "5" || query.Get("min_risk") != "70" {
+			t.Fatalf("query = %s", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"paths":[]}`))
+	})
+
+	limit := 5
+	minRisk := 70
+	if _, err := client.ExposurePaths(context.Background(), ExposurePathQuery{Limit: &limit, MinRisk: &minRisk}); err != nil {
+		t.Fatalf("ExposurePaths: %v", err)
+	}
+}
+
+func TestClientExposesHeadlineRoutes(t *testing.T) {
+	var seen []string
+	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	ctx := context.Background()
+	if _, err := client.AgentManifest(ctx, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.RuntimeProductionIndex(ctx, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.IntelLookup(ctx, "GHSA-xxxx-yyyy-zzzz"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.IntelMatch(ctx, IntelMatchRequest{Ecosystem: "pypi", Name: "requests", Version: "2.31.0"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.IntelSources(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"GET /v1/agent-bom/manifest",
+		"GET /v1/runtime/production-index",
+		"GET /v1/intel/advisories/GHSA-xxxx-yyyy-zzzz",
+		"POST /v1/intel/match",
+		"GET /v1/intel/sources",
+	}
+	if len(seen) != len(want) {
+		t.Fatalf("seen = %#v", seen)
+	}
+	for i := range want {
+		if seen[i] != want[i] {
+			t.Fatalf("seen[%d] = %q, want %q", i, seen[i], want[i])
+		}
+	}
+}
+
+func TestClientExposesFindingsAndDatasetLoop(t *testing.T) {
+	var seen []string
+	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	ctx := context.Background()
+	limit := 10
+	if _, err := client.ListFindings(ctx, FindingQuery{Severity: "high", Limit: &limit}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.IngestFindings(ctx, IngestFindingsRequest{Findings: []JSON{{"id": "finding-1", "severity": "high"}}, Source: "sdk-test"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.RegisterDatasetVersion(ctx, DatasetVersionRequest{DatasetID: "dataset-a", VersionID: "v1"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.DatasetVersions(ctx, "dataset-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.DatasetVersion(ctx, "dataset-a", "v1"); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"GET /v1/findings",
+		"POST /v1/findings/bulk",
+		"POST /v1/datasets/dataset-a/versions",
+		"GET /v1/datasets/dataset-a/versions",
+		"GET /v1/datasets/dataset-a/versions/v1",
+	}
+	if len(seen) != len(want) {
+		t.Fatalf("seen = %#v", seen)
+	}
+	for i := range want {
+		if seen[i] != want[i] {
+			t.Fatalf("seen[%d] = %q, want %q", i, seen[i], want[i])
+		}
+	}
+}
+
+func TestClientRejectsAmbiguousAuth(t *testing.T) {
+	_, err := NewClient(Options{BaseURL: "https://agent-bom.example.com", APIKey: "a", BearerToken: "b"})
+	if err == nil {
+		t.Fatal("expected ambiguous auth error")
+	}
+}
+
+func TestClientRaisesAPIErrorWithBody(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"detail":"forbidden"}`, http.StatusForbidden)
+	})
+
+	_, err := client.Health(context.Background())
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusForbidden || apiErr.Body == "" {
+		t.Fatalf("unexpected APIError: %#v", apiErr)
+	}
+}

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/msaad00/agent-bom/sdks/go
+
+go 1.22

--- a/site-docs/api/go-sdk.md
+++ b/site-docs/api/go-sdk.md
@@ -1,0 +1,53 @@
+# Go Control-Plane Client
+
+Use the Go SDK when services, CI workers, or agent runtimes need to read or
+write stable agent-bom control-plane surfaces without shelling out to the CLI.
+
+## Install
+
+```bash
+go get github.com/msaad00/agent-bom/sdks/go
+```
+
+## First Call
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	agentbom "github.com/msaad00/agent-bom/sdks/go"
+)
+
+func main() {
+	client, err := agentbom.NewClient(agentbom.Options{
+		BaseURL:  "https://agent-bom.internal",
+		APIKey:   "agent-bom-api-key",
+		TenantID: "tenant-a",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	health, err := client.Health(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(health["status"])
+}
+```
+
+Run the packaged smoke example against a live API:
+
+```bash
+cd examples/go_sdk
+AGENT_BOM_BASE_URL=http://127.0.0.1:8422 \
+AGENT_BOM_API_KEY=dev-key \
+go run ./control_plane_smoke.go
+```
+
+The client accepts either `APIKey` or `BearerToken`. `TenantID` is sent as
+`X-Agent-Bom-Tenant-ID` and used as the default tenant scope for tenant-aware
+methods.

--- a/tests/test_go_client_route_parity.py
+++ b/tests/test_go_client_route_parity.py
@@ -1,0 +1,21 @@
+"""Route parity checks for the Go control-plane client."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from agent_bom.api.server import app
+
+
+def test_go_control_plane_client_paths_exist_in_api() -> None:
+    source = Path("sdks/go/client.go").read_text(encoding="utf-8")
+    client_paths = {
+        match
+        for match in re.findall(r'"(/(?:health|v1/[^"?]+))"', source)
+        if "{" not in match and not match.endswith("/") and "+" not in match
+    }
+    registered_paths = {getattr(route, "path", "") for route in app.routes}
+
+    assert client_paths
+    assert client_paths <= registered_paths


### PR DESCRIPTION
Summary
- add a lightweight Go control-plane client for the stable API surfaces already covered by Python and TypeScript clients
- add Go unit tests plus a Python route-parity guard against the FastAPI route table
- document install, smoke usage, and shipped SDK status in README, docs, and site navigation

Verification
- cd sdks/go && go test ./...
- cd examples/go_sdk && go test ./...
- uv run pytest tests/test_go_client_route_parity.py -q
- python scripts/check_release_consistency.py
- git diff --check
- uv run mkdocs build --strict

Notes
- Uses the committed OpenAPI/API route contract as the boundary; this is a control-plane client, not a local scanner SDK.