### PR TITLE
refactor(scan): share scan option contract

### DIFF
--- a/src/agent_bom/cli/_scan_runner.py
+++ b/src/agent_bom/cli/_scan_runner.py
@@ -16,25 +16,12 @@ import tempfile
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Optional
 
+from agent_bom.scan_contract import ScanConfig
+
 if TYPE_CHECKING:
     from rich.console import Console
 
     from agent_bom.models import Agent, AIBOMReport, BlastRadius
-
-
-@dataclass
-class ScanConfig:
-    """Inputs for a default scan invocation."""
-
-    project: Optional[str] = None
-    demo: bool = False
-    offline: bool = False
-    enrich: bool = False
-    compliance: bool = False
-    resolve_transitive: bool = False
-    max_depth: int = 3
-    blast_radius_depth: int = 2
-    quiet: bool = False
 
 
 @dataclass

--- a/src/agent_bom/scan_contract.py
+++ b/src/agent_bom/scan_contract.py
@@ -1,0 +1,62 @@
+"""Shared scan option contract for CLI, SDK, and API surfaces.
+
+The full ``agents`` command still owns the broad scanner option surface. This
+module captures the stable simple-scan subset that already exists across the
+public Python API, remediation flow, and REST scan request model so those
+surfaces do not keep growing separate option names and defaults.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class ScanConfig:
+    """Inputs for a default local scan invocation."""
+
+    project: str | None = None
+    demo: bool = False
+    offline: bool = False
+    enrich: bool = False
+    compliance: bool = False
+    resolve_transitive: bool = False
+    max_depth: int = 3
+    blast_radius_depth: int = 2
+    quiet: bool = False
+
+    def to_api_payload(self) -> dict[str, Any]:
+        """Return the overlapping POST /v1/scan payload fields.
+
+        The API does not currently accept demo/compliance/quiet flags. The
+        payload deliberately includes only fields the API contract can consume
+        today, so this helper is safe for future CLI-as-control-plane routing.
+        """
+        payload: dict[str, Any] = {
+            "offline": self.offline,
+            "enrich": self.enrich,
+        }
+        if self.project:
+            payload["agent_projects"] = [self.project]
+        return payload
+
+
+def scan_config_from_api_request(request: object, *, project: str | None = None, quiet: bool = False) -> ScanConfig:
+    """Map the overlapping POST /v1/scan request fields to ``ScanConfig``.
+
+    ``ScanRequest`` lives under ``agent_bom.api`` and should not be imported by
+    CLI-only code. Accepting an object with matching attributes keeps this
+    contract independent and easy to test from both sides.
+    """
+    request_project = project
+    if request_project is None:
+        agent_projects = getattr(request, "agent_projects", None)
+        if isinstance(agent_projects, list) and agent_projects:
+            request_project = str(agent_projects[0])
+    return ScanConfig(
+        project=request_project,
+        offline=bool(getattr(request, "offline", False)),
+        enrich=bool(getattr(request, "enrich", False)),
+        quiet=quiet,
+    )

--- a/tests/test_scan_contract.py
+++ b/tests/test_scan_contract.py
@@ -1,0 +1,45 @@
+"""Shared scan option contract tests."""
+
+from __future__ import annotations
+
+from agent_bom.api.models import ScanRequest
+from agent_bom.scan_contract import ScanConfig, scan_config_from_api_request
+
+
+def test_scan_config_to_api_payload_uses_supported_fields_only() -> None:
+    config = ScanConfig(
+        project=".",
+        demo=True,
+        offline=True,
+        enrich=True,
+        compliance=True,
+        resolve_transitive=True,
+        max_depth=7,
+        blast_radius_depth=4,
+        quiet=True,
+    )
+
+    assert config.to_api_payload() == {
+        "agent_projects": ["."],
+        "offline": True,
+        "enrich": True,
+    }
+
+
+def test_scan_config_from_api_request_maps_overlap() -> None:
+    request = ScanRequest(agent_projects=["/repo"], offline=True, enrich=True, images=["example:latest"])
+
+    config = scan_config_from_api_request(request, quiet=True)
+
+    assert config.project == "/repo"
+    assert config.offline is True
+    assert config.enrich is True
+    assert config.quiet is True
+    assert config.demo is False
+    assert config.compliance is False
+
+
+def test_cli_scan_runner_reexports_shared_scan_config() -> None:
+    from agent_bom.cli._scan_runner import ScanConfig as RunnerScanConfig
+
+    assert RunnerScanConfig is ScanConfig


### PR DESCRIPTION
Summary
- add a shared ScanConfig contract for the stable simple-scan option subset used across CLI, SDK, and API surfaces
- move the default CLI scan runner onto the shared contract without changing scanner behavior
- add regression coverage for API payload mapping and the CLI re-export boundary

Verification
- uv run pytest tests/test_scan_contract.py tests/test_public_python_api.py tests/test_cli_remediate.py::test_default_scan_restores_offline_mode_on_discovery_error -q
- uv run ruff check src/agent_bom/scan_contract.py src/agent_bom/cli/_scan_runner.py tests/test_scan_contract.py
- uv run mypy src/agent_bom/scan_contract.py src/agent_bom/cli/_scan_runner.py
- python scripts/check_release_consistency.py
- git diff --check

Notes
- This is a foundation slice for the CLI-as-control-plane refactor; it deliberately avoids routing CLI scans through the API in this PR.