### PR TITLE
feat(intel): complete governed daily brief inputs

### DIFF
--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -79,9 +79,14 @@ reports vendor advisory matches.
 | AMD PSIRT | experimental | `vendor_json_seed` | ROCm and AMD GPU package/image signals from curated advisory seeds | No open-ended website scraping is shipped; matches remain source-linked and marked experimental. |
 | Intel PSIRT | experimental | `curated_seed` | GPU and oneAPI advisory seeds | No automated webpage scraping is shipped; matches remain source-linked and marked experimental. |
 
-Daily threat briefs summarize local database evidence and submitted inventory.
-They do not claim IoC telemetry, campaign attribution, ransomware tracking, or
-sector/geo targeting unless a future connector supplies those inputs.
+Daily threat briefs summarize local database evidence, submitted inventory, and
+governed caller-supplied threat inputs. When a caller supplies IoC telemetry,
+campaign activity, ransomware claims, and a tenant sector/geo profile, the brief
+adds exact telemetry-hit matches and profile-overlap matches with source URL,
+license/terms, fetched time, content hash, validation status, and match reason.
+They still do not claim open-ended vendor webpage scraping; vendor pages remain
+structured feed or curated source-linked seed coverage unless a governed
+connector policy explicitly allows more.
 
 ## Scanning GPU container images
 

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -325,7 +325,7 @@ tenant boundary, persistence behavior, and redaction behavior here.
 | `intel.sources.v1` | `GET /v1/intel/sources`, `intel_sources` MCP tool | analysts, agents, freshness monitors, docs | canonical source catalog with `source_id`, tier, kind, source/homepage/license URLs, robots policy, connector type, enabled state, owner, parser version, validation status, redistribution policy, `feed_run` | Reads local vuln DB `sync_meta`; source metadata is shared catalog data, feed-run freshness is local deployment state. It does not imply open-ended scraping. |
 | `intel.lookup.v1` | `GET /v1/intel/advisories/{advisory_id}`, `intel_lookup` MCP tool | finding enrichment, analyst lookup, agent investigation | `found`, `query`, `advisory.canonical_ids`, severity, CVSS, EPSS, KEV, CWE, affected packages, `match_method`, `match_confidence`, source policy, `evidence_links` | Read-only local vuln DB lookup. It can resolve CVE, GHSA, and OSV aliases and returns source links without implying every link was fetched. |
 | `intel.match.v1` | `POST /v1/intel/match`, `intel_match` MCP tool | inventory enrichment, CI gates, agent posture checks | submitted packages, matched package count, advisory matches, `match_method`, `match_confidence`, match reason, evidence links | Read-only package-coordinate matching. Inputs use purl when present; otherwise `ecosystem` + `name` + optional `version`. |
-| `intel.daily_brief.v1` | `POST /v1/intel/daily-brief`, `intel_daily_brief` MCP tool | analysts, agents, daily governance jobs | local KEV lookback, high-EPSS inventory matches, vendor advisory matches, source registry freshness, limitations | Read-only summary over local DB and submitted inventory. IoC telemetry, campaign, and sector/geo sections remain empty unless those inputs are configured by a future connector. |
+| `intel.daily_brief.v1` | `POST /v1/intel/daily-brief`, `intel_daily_brief` MCP tool | analysts, agents, daily governance jobs | local KEV lookback, high-EPSS inventory matches, vendor advisory matches, caller-supplied IoC telemetry hits, campaign matches, ransomware sector matches, source registry freshness, limitations | Read-only summary over local DB, submitted inventory, and governed caller inputs. IoC/campaign/ransomware entries carry source URL, license/terms, fetched time, content hash, validation status, match method, confidence, and match reason. |
 
 ### `agent-bom.manifest/v1`
 
@@ -409,8 +409,12 @@ spans, and connector health as additional fields or linked resources.
 Vendor advisory feed policy is explicit in `intel.sources.v1`: structured CSAF
 matching is supported where a structured feed exists; curated vendor seeds are
 marked experimental and source-linked until a governed connector with validated
-license/robots handling is shipped. Current daily briefs use these decisions
-to distinguish supported source records from experimental seed matches.
+license/robots handling is shipped. `intel_fetch.py` is the governed raw
+artifact lane for fetchable structured sources: it rejects manual-only sources,
+uses the shared SSRF-safe HTTP client, caps content type and response size,
+computes a SHA-256 content hash, and stores raw bytes separately from derived
+records. Current daily briefs use these decisions to distinguish supported
+source records from experimental seed matches.
 
 ### `inventory_snapshot.packages`
 

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -1254,6 +1254,15 @@
       "IntelDailyBriefRequest": {
         "additionalProperties": false,
         "properties": {
+          "campaign_activity": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "maxItems": 500,
+            "title": "Campaign Activity",
+            "type": "array"
+          },
           "epss_threshold": {
             "default": 0.7,
             "maximum": 1.0,
@@ -1283,6 +1292,29 @@
             "maxItems": 500,
             "title": "Packages",
             "type": "array"
+          },
+          "ransomware_claims": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "maxItems": 500,
+            "title": "Ransomware Claims",
+            "type": "array"
+          },
+          "telemetry_indicators": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "maxItems": 500,
+            "title": "Telemetry Indicators",
+            "type": "array"
+          },
+          "tenant_profile": {
+            "additionalProperties": true,
+            "title": "Tenant Profile",
+            "type": "object"
           }
         },
         "title": "IntelDailyBriefRequest",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -857,6 +857,13 @@ components:
     IntelDailyBriefRequest:
       additionalProperties: false
       properties:
+        campaign_activity:
+          items:
+            additionalProperties: true
+            type: object
+          maxItems: 500
+          title: Campaign Activity
+          type: array
         epss_threshold:
           default: 0.7
           maximum: 1.0
@@ -882,6 +889,24 @@ components:
           maxItems: 500
           title: Packages
           type: array
+        ransomware_claims:
+          items:
+            additionalProperties: true
+            type: object
+          maxItems: 500
+          title: Ransomware Claims
+          type: array
+        telemetry_indicators:
+          items:
+            additionalProperties: true
+            type: object
+          maxItems: 500
+          title: Telemetry Indicators
+          type: array
+        tenant_profile:
+          additionalProperties: true
+          title: Tenant Profile
+          type: object
       title: IntelDailyBriefRequest
       type: object
     IntelPackageMatchRequest:

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -42,10 +42,15 @@ intel_sources()
 
 ### intel_daily_brief
 Return a local analyst brief with KEV lookback, high-EPSS inventory matches,
-vendor advisory matches, and source-registry freshness. It summarizes local DB
-evidence and submitted inventory only; it does not scrape vendor pages.
+vendor advisory matches, caller-supplied IoC telemetry hits, sector/geo campaign
+matches, ransomware claim matches, and source-registry freshness. It summarizes
+local DB evidence plus governed caller inputs; it does not scrape vendor pages.
 ```
-intel_daily_brief(packages=[{"purl": "pkg:pypi/requests@2.31.0"}])
+intel_daily_brief(
+  packages=[{"purl": "pkg:pypi/requests@2.31.0"}],
+  telemetry_indicators=[{"indicator": "198.51.100.42", "hit_count": 2}],
+  tenant_profile={"sectors": ["ai infrastructure"], "geos": ["us"]}
+)
 ```
 
 ### blast_radius

--- a/src/agent_bom/api/routes/intel.py
+++ b/src/agent_bom/api/routes/intel.py
@@ -23,6 +23,10 @@ class IntelDailyBriefRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     packages: list[dict[str, Any]] = Field(default_factory=list, max_length=500)
+    telemetry_indicators: list[dict[str, Any]] = Field(default_factory=list, max_length=500)
+    campaign_activity: list[dict[str, Any]] = Field(default_factory=list, max_length=500)
+    ransomware_claims: list[dict[str, Any]] = Field(default_factory=list, max_length=500)
+    tenant_profile: dict[str, Any] = Field(default_factory=dict)
     epss_threshold: float = Field(default=0.7, ge=0, le=1)
     kev_window_hours: int = Field(default=24, ge=1, le=168)
     limit: int = Field(default=100, ge=1, le=500)
@@ -68,6 +72,10 @@ async def post_intel_daily_brief(body: IntelDailyBriefRequest) -> dict[str, Any]
     try:
         return build_daily_brief(
             body.packages,
+            telemetry_indicators=body.telemetry_indicators,
+            campaign_activity=body.campaign_activity,
+            ransomware_claims=body.ransomware_claims,
+            tenant_profile=body.tenant_profile,
             epss_threshold=body.epss_threshold,
             kev_window_hours=body.kev_window_hours,
             limit=body.limit,

--- a/src/agent_bom/intel_fetch.py
+++ b/src/agent_bom/intel_fetch.py
@@ -1,0 +1,147 @@
+"""Governed threat-intel raw artifact fetch helpers.
+
+This module is intentionally narrow: it fetches allowlisted structured sources
+from the canonical intel source registry, records provenance, and leaves
+parsing/redistribution to higher-level connectors.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from agent_bom.http_client import create_client, request_with_retry
+from agent_bom.intel_lookup import IntelSource
+
+_ALLOWED_CONTENT_TYPES = (
+    "application/json",
+    "application/xml",
+    "application/stix+json",
+    "application/taxii+json",
+    "application/gzip",
+    "application/x-gzip",
+    "text/csv",
+    "text/plain",
+    "text/xml",
+)
+_FETCHABLE_CONNECTORS = {
+    "structured_api",
+    "bulk_file",
+    "bulk_json",
+    "csaf_json",
+    "vendor_json_seed",
+}
+
+
+class GovernedIntelFetchError(ValueError):
+    """Raised when a source cannot be fetched under the governed policy."""
+
+
+@dataclass(frozen=True)
+class GovernedRawArtifact:
+    """Fetched raw source bytes plus provenance required for later parsing."""
+
+    source_id: str
+    source_url: str
+    fetched_at: str
+    content_type: str
+    size_bytes: int
+    content_hash: str
+    etag: str | None
+    last_modified: str | None
+    parser_version: str
+    license: str
+    license_or_terms_url: str
+    robots_policy: str
+    body: bytes
+
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "source_id": self.source_id,
+            "source_url": self.source_url,
+            "fetched_at": self.fetched_at,
+            "content_type": self.content_type,
+            "size_bytes": self.size_bytes,
+            "content_hash": self.content_hash,
+            "etag": self.etag,
+            "last_modified": self.last_modified,
+            "parser_version": self.parser_version,
+            "license": self.license,
+            "license_or_terms_url": self.license_or_terms_url,
+            "robots_policy": self.robots_policy,
+        }
+
+
+def ensure_source_fetch_allowed(source: IntelSource) -> None:
+    """Validate source registry metadata before any network fetch."""
+
+    if not source.enabled:
+        raise GovernedIntelFetchError(f"{source.source_id} is disabled")
+    if source.connector_type not in _FETCHABLE_CONNECTORS:
+        raise GovernedIntelFetchError(f"{source.source_id} connector {source.connector_type!r} is not fetchable")
+    if source.robots_policy in {"manual_seed_only", "manual_only"}:
+        raise GovernedIntelFetchError(f"{source.source_id} is marked manual-only")
+    if not source.license_or_terms_url or not source.license:
+        raise GovernedIntelFetchError(f"{source.source_id} is missing license or terms metadata")
+
+
+def _content_type_allowed(content_type: str) -> bool:
+    normalized = content_type.split(";", 1)[0].strip().lower()
+    return any(normalized == allowed for allowed in _ALLOWED_CONTENT_TYPES)
+
+
+async def fetch_governed_raw_artifact(
+    source: IntelSource,
+    *,
+    max_bytes: int = 1_000_000,
+    timeout: float = 15.0,
+) -> GovernedRawArtifact:
+    """Fetch one canonical source under the governed intel policy."""
+
+    ensure_source_fetch_allowed(source)
+    async with create_client(timeout=timeout) as client:
+        response = await request_with_retry(client, "GET", source.source_url, max_retries=1)
+    if response is None:
+        raise GovernedIntelFetchError(f"{source.source_id} fetch did not return a response")
+    if response.status_code >= 400:
+        raise GovernedIntelFetchError(f"{source.source_id} fetch returned HTTP {response.status_code}")
+    content_type = response.headers.get("content-type", "application/octet-stream")
+    if not _content_type_allowed(content_type):
+        raise GovernedIntelFetchError(f"{source.source_id} returned unsupported content type {content_type!r}")
+    body = response.content
+    if len(body) > max_bytes:
+        raise GovernedIntelFetchError(f"{source.source_id} response exceeded {max_bytes} bytes")
+    digest = hashlib.sha256(body).hexdigest()
+    return GovernedRawArtifact(
+        source_id=source.source_id,
+        source_url=source.source_url,
+        fetched_at=datetime.now(UTC).isoformat(),
+        content_type=content_type,
+        size_bytes=len(body),
+        content_hash=f"sha256:{digest}",
+        etag=response.headers.get("etag"),
+        last_modified=response.headers.get("last-modified"),
+        parser_version=source.parser_version,
+        license=source.license,
+        license_or_terms_url=source.license_or_terms_url,
+        robots_policy=source.robots_policy,
+        body=body,
+    )
+
+
+def store_raw_artifact(artifact: GovernedRawArtifact, root: Path) -> dict[str, Any]:
+    """Persist raw bytes separately from derived intel records."""
+
+    digest = artifact.content_hash.removeprefix("sha256:")
+    source_dir = root / artifact.source_id
+    source_dir.mkdir(parents=True, exist_ok=True)
+    body_path = source_dir / f"{digest}.raw"
+    metadata_path = source_dir / f"{digest}.metadata.json"
+    body_path.write_bytes(artifact.body)
+    metadata = artifact.metadata() | {"body_path": str(body_path)}
+    metadata_path.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n")
+    return metadata | {"metadata_path": str(metadata_path)}

--- a/src/agent_bom/intel_lookup.py
+++ b/src/agent_bom/intel_lookup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -237,6 +238,7 @@ CANONICAL_INTEL_SOURCES: tuple[IntelSource, ...] = (
 )
 
 VENDOR_ADVISORY_SOURCE_IDS = {"nvidia_csaf", "amd_psirt", "intel_psirt"}
+_MAX_BRIEF_INPUTS = 500
 
 
 def resolve_intel_db_path() -> Path:
@@ -266,6 +268,150 @@ def _sync_meta(conn: sqlite3.Connection) -> dict[str, dict[str, Any]]:
             "metadata": metadata,
         }
     return meta
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip().lower() for item in value if str(item or "").strip()]
+
+
+def _tenant_profile(profile: dict[str, Any] | None) -> dict[str, Any]:
+    profile = profile or {}
+    return {
+        "sectors": _string_list(profile.get("sectors")),
+        "geos": _string_list(profile.get("geos")),
+        "tenant_ref": str(profile.get("tenant_ref") or "").strip() or None,
+    }
+
+
+def _governed_evidence(item: dict[str, Any]) -> dict[str, Any]:
+    """Return provenance fields expected on caller-supplied intel items."""
+
+    content_hash = str(item.get("content_hash") or "").strip()
+    if not content_hash:
+        seed = json.dumps(
+            {
+                "source_url": item.get("source_url"),
+                "indicator": item.get("indicator"),
+                "name": item.get("name"),
+                "group": item.get("group"),
+                "first_seen_at": item.get("first_seen_at"),
+            },
+            sort_keys=True,
+            default=str,
+        )
+        content_hash = "sha256:" + hashlib.sha256(seed.encode("utf-8")).hexdigest()
+    return {
+        "source": str(item.get("source") or item.get("source_id") or "caller_supplied").strip(),
+        "source_url": str(item.get("source_url") or "").strip(),
+        "license": str(item.get("license") or item.get("terms") or "caller_supplied").strip(),
+        "fetched_at": str(item.get("fetched_at") or item.get("updated_at") or "").strip(),
+        "first_seen_at": str(item.get("first_seen_at") or item.get("discovered_at") or "").strip(),
+        "updated_at": str(item.get("updated_at") or "").strip(),
+        "content_hash": content_hash,
+        "validation_status": str(item.get("validation_status") or "caller_supplied").strip(),
+    }
+
+
+def _match_ioc_telemetry(
+    telemetry_indicators: list[dict[str, Any]] | None,
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Return governed IoC hits when callers provide telemetry observations."""
+
+    matches: list[dict[str, Any]] = []
+    for item in (telemetry_indicators or [])[:_MAX_BRIEF_INPUTS]:
+        indicator = str(item.get("indicator") or item.get("value") or "").strip()
+        if not indicator:
+            continue
+        telemetry_hits = item.get("hits") or item.get("telemetry_hits") or []
+        hit_count = int(item.get("hit_count") or (len(telemetry_hits) if isinstance(telemetry_hits, list) else 0) or 0)
+        if hit_count <= 0:
+            continue
+        matches.append(
+            {
+                "indicator": indicator,
+                "indicator_type": str(item.get("type") or item.get("indicator_type") or "unknown").strip(),
+                "hit_count": hit_count,
+                "telemetry_refs": telemetry_hits if isinstance(telemetry_hits, list) else [],
+                "match_method": "telemetry_indicator_exact",
+                "match_confidence": str(item.get("confidence") or "high").strip(),
+                "match_reason": "Caller-supplied telemetry contains an exact indicator hit.",
+                "evidence": _governed_evidence(item),
+            }
+        )
+        if len(matches) >= limit:
+            break
+    return matches
+
+
+def _profile_matches(item: dict[str, Any], profile: dict[str, Any]) -> tuple[bool, list[str]]:
+    reasons: list[str] = []
+    item_sectors = _string_list(item.get("sectors") or item.get("target_sectors") or item.get("victim_sectors"))
+    item_geos = _string_list(item.get("geos") or item.get("target_geos") or item.get("victim_geos"))
+    sectors = set(profile.get("sectors") or [])
+    geos = set(profile.get("geos") or [])
+    if sectors and item_sectors and sectors.intersection(item_sectors):
+        reasons.append("sector")
+    if geos and item_geos and geos.intersection(item_geos):
+        reasons.append("geo")
+    return bool(reasons), reasons
+
+
+def _match_campaign_activity(
+    campaign_activity: list[dict[str, Any]] | None,
+    *,
+    tenant_profile: dict[str, Any],
+    limit: int,
+) -> list[dict[str, Any]]:
+    matches: list[dict[str, Any]] = []
+    for item in (campaign_activity or [])[:_MAX_BRIEF_INPUTS]:
+        matched, reasons = _profile_matches(item, tenant_profile)
+        if not matched:
+            continue
+        matches.append(
+            {
+                "name": str(item.get("name") or item.get("campaign") or "unnamed_campaign").strip(),
+                "activity_type": str(item.get("activity_type") or "campaign").strip(),
+                "matched_on": reasons,
+                "match_method": "tenant_profile_sector_geo",
+                "match_confidence": str(item.get("confidence") or "medium").strip(),
+                "match_reason": "Caller-supplied campaign activity overlaps configured tenant sector or geography.",
+                "evidence": _governed_evidence(item),
+            }
+        )
+        if len(matches) >= limit:
+            break
+    return matches
+
+
+def _match_ransomware_claims(
+    ransomware_claims: list[dict[str, Any]] | None,
+    *,
+    tenant_profile: dict[str, Any],
+    limit: int,
+) -> list[dict[str, Any]]:
+    matches: list[dict[str, Any]] = []
+    for item in (ransomware_claims or [])[:_MAX_BRIEF_INPUTS]:
+        matched, reasons = _profile_matches(item, tenant_profile)
+        if not matched:
+            continue
+        matches.append(
+            {
+                "group": str(item.get("group") or item.get("actor") or "unknown_group").strip(),
+                "claim": str(item.get("claim") or item.get("victim") or "").strip(),
+                "matched_on": reasons,
+                "match_method": "tenant_profile_sector_geo",
+                "match_confidence": str(item.get("confidence") or "medium").strip(),
+                "match_reason": "Caller-supplied ransomware claim overlaps configured tenant sector or geography.",
+                "evidence": _governed_evidence(item),
+            }
+        )
+        if len(matches) >= limit:
+            break
+    return matches
 
 
 def list_intel_sources(*, db_path: Path | None = None) -> dict[str, Any]:
@@ -642,6 +788,10 @@ def match_packages(packages: list[dict[str, Any]], *, db_path: Path | None = Non
 def build_daily_brief(
     packages: list[dict[str, Any]] | None = None,
     *,
+    telemetry_indicators: list[dict[str, Any]] | None = None,
+    campaign_activity: list[dict[str, Any]] | None = None,
+    ransomware_claims: list[dict[str, Any]] | None = None,
+    tenant_profile: dict[str, Any] | None = None,
     db_path: Path | None = None,
     epss_threshold: float = 0.7,
     kev_window_hours: int = 24,
@@ -661,6 +811,7 @@ def build_daily_brief(
         raise ValueError("kev_window_hours must be between 1 and 168")
     generated_at = now.astimezone(UTC) if now else _utc_now()
     kev_cutoff = generated_at - timedelta(hours=kev_window_hours)
+    profile = _tenant_profile(tenant_profile)
     conn = init_db(db_path or resolve_intel_db_path())
     try:
         source_meta = _sync_meta(conn)
@@ -707,6 +858,9 @@ def build_daily_brief(
                     high_epss_inventory.append(item)
                 if advisory.get("source") in VENDOR_ADVISORY_SOURCE_IDS:
                     vendor_advisories.append(item)
+    ioc_hits = _match_ioc_telemetry(telemetry_indicators, limit=limit)
+    campaign_matches = _match_campaign_activity(campaign_activity, tenant_profile=profile, limit=limit)
+    ransomware_sector_matches = _match_ransomware_claims(ransomware_claims, tenant_profile=profile, limit=limit)
 
     feed_runs = {
         source.source_id: {
@@ -724,18 +878,22 @@ def build_daily_brief(
         "generated_at": generated_at.isoformat(),
         "inputs": {
             "package_count": len(package_inputs),
+            "telemetry_indicator_count": len(telemetry_indicators or []),
+            "campaign_activity_count": len(campaign_activity or []),
+            "ransomware_claim_count": len(ransomware_claims or []),
             "epss_threshold": epss_threshold,
             "kev_window_hours": kev_window_hours,
-            "telemetry_configured": False,
-            "sector_geo_configured": False,
+            "telemetry_configured": bool(telemetry_indicators),
+            "sector_geo_configured": bool(profile["sectors"] or profile["geos"]),
+            "tenant_profile": profile,
         },
         "sections": {
             "kev_last_24h": kev_last_24h,
             "high_epss_inventory": high_epss_inventory,
             "vendor_advisories": vendor_advisories,
-            "ioc_telemetry_hits": [],
-            "campaign_matches": [],
-            "ransomware_sector_matches": [],
+            "ioc_telemetry_hits": ioc_hits,
+            "campaign_matches": campaign_matches,
+            "ransomware_sector_matches": ransomware_sector_matches,
         },
         "inventory_match": inventory_match,
         "source_registry": {
@@ -743,7 +901,10 @@ def build_daily_brief(
             "feed_runs": feed_runs,
         },
         "limitations": [
-            "IoC telemetry, campaign, and sector matching require configured telemetry or tenant profile inputs.",
+            (
+                "IoC telemetry, campaign, and sector matching run only when the caller supplies governed telemetry, "
+                "campaign, ransomware, or tenant-profile inputs."
+            ),
             "Vendor webpage scraping is not shipped; vendor entries use structured feeds or curated source-linked seeds only.",
         ],
     }

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -608,6 +608,26 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
             list[dict] | None,
             Field(description="Optional inventory packages with purl or ecosystem/name/version objects for local matching."),
         ] = None,
+        telemetry_indicators: Annotated[
+            list[dict] | None,
+            Field(
+                description=(
+                    "Optional governed IoC observations with indicator, hit_count, source_url, license, fetched_at, and content_hash."
+                )
+            ),
+        ] = None,
+        campaign_activity: Annotated[
+            list[dict] | None,
+            Field(description="Optional governed campaign activity items with sectors/geos and provenance for tenant-profile matching."),
+        ] = None,
+        ransomware_claims: Annotated[
+            list[dict] | None,
+            Field(description="Optional governed ransomware claim items with sectors/geos and provenance for tenant-profile matching."),
+        ] = None,
+        tenant_profile: Annotated[
+            dict | None,
+            Field(description="Optional tenant profile with sectors and geos used to match campaign/ransomware inputs."),
+        ] = None,
         epss_threshold: Annotated[float, Field(description="Minimum EPSS probability for inventory-prioritized CVEs, 0-1.")] = 0.7,
         kev_window_hours: Annotated[int, Field(description="KEV date_added lookback window, 1-168 hours.")] = 24,
         limit: Annotated[int, Field(description="Maximum packages/advisories to inspect, 1-500.")] = 100,
@@ -618,6 +638,10 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
             "intel_daily_brief",
             intel_daily_brief_impl,
             packages=packages,
+            telemetry_indicators=telemetry_indicators,
+            campaign_activity=campaign_activity,
+            ransomware_claims=ransomware_claims,
+            tenant_profile=tenant_profile,
             epss_threshold=epss_threshold,
             kev_window_hours=kev_window_hours,
             limit=limit,

--- a/src/agent_bom/mcp_tools/intel.py
+++ b/src/agent_bom/mcp_tools/intel.py
@@ -70,6 +70,10 @@ async def intel_sources_impl(*, _truncate_response=lambda value: value) -> str:
 async def intel_daily_brief_impl(
     *,
     packages: list[dict] | None = None,
+    telemetry_indicators: list[dict] | None = None,
+    campaign_activity: list[dict] | None = None,
+    ransomware_claims: list[dict] | None = None,
+    tenant_profile: dict | None = None,
     epss_threshold: float = 0.7,
     kev_window_hours: int = 24,
     limit: int = 100,
@@ -82,6 +86,10 @@ async def intel_daily_brief_impl(
             json.dumps(
                 build_daily_brief(
                     packages or [],
+                    telemetry_indicators=telemetry_indicators or [],
+                    campaign_activity=campaign_activity or [],
+                    ransomware_claims=ransomware_claims or [],
+                    tenant_profile=tenant_profile or {},
                     epss_threshold=epss_threshold,
                     kev_window_hours=kev_window_hours,
                     limit=limit,

--- a/tests/test_intel_lookup.py
+++ b/tests/test_intel_lookup.py
@@ -3,12 +3,18 @@ from __future__ import annotations
 import json
 import sqlite3
 from datetime import UTC, datetime
+from types import SimpleNamespace
 
 import pytest
 from starlette.testclient import TestClient
 
 from agent_bom.api.server import app, configure_api
 from agent_bom.db.schema import init_db
+from agent_bom.intel_fetch import (
+    GovernedIntelFetchError,
+    fetch_governed_raw_artifact,
+    store_raw_artifact,
+)
 from agent_bom.intel_lookup import build_daily_brief, list_intel_sources, lookup_advisory, match_packages
 from agent_bom.mcp_tools.intel import intel_daily_brief_impl, intel_lookup_impl, intel_match_impl, intel_sources_impl
 from tests.auth_helpers import PROXY_SECRET
@@ -206,6 +212,52 @@ def test_daily_brief_summarizes_local_sources_without_scraping_claims(intel_db) 
     assert "Vendor webpage scraping is not shipped" in body["limitations"][1]
 
 
+def test_daily_brief_matches_governed_telemetry_and_tenant_profile(intel_db) -> None:  # noqa: ANN001
+    body = build_daily_brief(
+        [{"purl": "pkg:pypi/requests@2.31.0", "inventory_ref": "pkg-1"}],
+        telemetry_indicators=[
+            {
+                "indicator": "198.51.100.42",
+                "type": "ipv4",
+                "hit_count": 3,
+                "telemetry_hits": ["runtime-session-1"],
+                "source_url": "https://example.invalid/ioc-feed",
+                "license": "internal-use",
+                "fetched_at": "2026-05-22T00:00:00+00:00",
+                "content_hash": "sha256:ioc",
+            }
+        ],
+        campaign_activity=[
+            {
+                "name": "gpu-targeting-campaign",
+                "sectors": ["ai infrastructure"],
+                "geos": ["us"],
+                "source_url": "https://example.invalid/campaign",
+                "license": "link-only",
+            }
+        ],
+        ransomware_claims=[
+            {
+                "group": "example-extortion",
+                "victim_sectors": ["ai infrastructure"],
+                "victim_geos": ["us"],
+                "source_url": "https://example.invalid/ransomware",
+                "license": "link-only",
+            }
+        ],
+        tenant_profile={"sectors": ["AI Infrastructure"], "geos": ["US"], "tenant_ref": "tenant-alpha"},
+        db_path=intel_db,
+        now=datetime(2026, 5, 22, tzinfo=UTC),
+    )
+
+    assert body["inputs"]["telemetry_configured"] is True
+    assert body["inputs"]["sector_geo_configured"] is True
+    assert body["sections"]["ioc_telemetry_hits"][0]["match_method"] == "telemetry_indicator_exact"
+    assert body["sections"]["ioc_telemetry_hits"][0]["evidence"]["content_hash"] == "sha256:ioc"
+    assert body["sections"]["campaign_matches"][0]["matched_on"] == ["sector", "geo"]
+    assert body["sections"]["ransomware_sector_matches"][0]["group"] == "example-extortion"
+
+
 def test_intel_api_routes_are_read_only_and_tenant_scoped(intel_client: TestClient) -> None:
     sources = intel_client.get("/v1/intel/sources", headers=VIEWER_HEADERS)
     assert sources.status_code == 200
@@ -226,10 +278,15 @@ def test_intel_api_routes_are_read_only_and_tenant_scoped(intel_client: TestClie
     brief = intel_client.post(
         "/v1/intel/daily-brief",
         headers=VIEWER_HEADERS,
-        json={"packages": [{"ecosystem": "pypi", "name": "requests", "version": "2.31.0"}]},
+        json={
+            "packages": [{"ecosystem": "pypi", "name": "requests", "version": "2.31.0"}],
+            "telemetry_indicators": [{"indicator": "198.51.100.42", "hit_count": 1}],
+            "tenant_profile": {"sectors": ["AI Infrastructure"]},
+        },
     )
     assert brief.status_code == 200
     assert brief.json()["schema_version"] == "intel.daily_brief.v1"
+    assert brief.json()["sections"]["ioc_telemetry_hits"][0]["indicator"] == "198.51.100.42"
 
 
 def test_intel_api_match_validates_package_shape(intel_client: TestClient) -> None:
@@ -264,3 +321,46 @@ async def test_mcp_intel_tools_return_agent_native_json(intel_db) -> None:  # no
 
     brief = json.loads(await intel_daily_brief_impl(packages=[{"purl": "pkg:pypi/requests@2.31.0"}]))
     assert brief["schema_version"] == "intel.daily_brief.v1"
+
+
+@pytest.mark.asyncio
+async def test_governed_raw_artifact_fetch_records_metadata(monkeypatch, tmp_path) -> None:  # noqa: ANN001
+    source = next(source for source in list_intel_sources()["sources"] if source["source_id"] == "cisa_kev")
+    from agent_bom.intel_lookup import CANONICAL_INTEL_SOURCES
+
+    canonical = next(item for item in CANONICAL_INTEL_SOURCES if item.source_id == source["source_id"])
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+    async def _fake_request(_client, _method, _url, **_kwargs):
+        return SimpleNamespace(
+            status_code=200,
+            headers={"content-type": "application/json", "etag": "abc", "last-modified": "Fri, 22 May 2026 00:00:00 GMT"},
+            content=b'{"knownExploitedVulnerabilities":[]}',
+        )
+
+    monkeypatch.setattr("agent_bom.intel_fetch.create_client", lambda timeout=15.0: _Client())
+    monkeypatch.setattr("agent_bom.intel_fetch.request_with_retry", _fake_request)
+
+    artifact = await fetch_governed_raw_artifact(canonical)
+    stored = store_raw_artifact(artifact, tmp_path)
+
+    assert artifact.source_id == "cisa_kev"
+    assert artifact.content_hash.startswith("sha256:")
+    assert stored["etag"] == "abc"
+    assert (tmp_path / "cisa_kev").exists()
+
+
+def test_governed_raw_artifact_fetch_rejects_manual_only_sources() -> None:
+    from agent_bom.intel_fetch import ensure_source_fetch_allowed
+    from agent_bom.intel_lookup import CANONICAL_INTEL_SOURCES
+
+    intel = next(source for source in CANONICAL_INTEL_SOURCES if source.source_id == "intel_psirt")
+
+    with pytest.raises(GovernedIntelFetchError):
+        ensure_source_fetch_allowed(intel)


### PR DESCRIPTION
Summary

- add governed telemetry, campaign, ransomware, and tenant-profile inputs to the analyst daily threat brief with provenance, confidence, and match reasons
- add a governed raw-artifact fetch/store helper for structured source registry entries using the SSRF-safe HTTP path, content-type and size caps, and sha256 metadata
- refresh MCP/API/OpenAPI/data-model docs and regression coverage for the completed intel closeout path

Verification

- uv run pytest tests/test_intel_lookup.py -q
- uv run pytest tests/test_intel_lookup.py tests/test_stats_alignment.py::TestCodeConsistency::test_mcp_tools_docstring -q
- uv run ruff check src/agent_bom/intel_lookup.py src/agent_bom/intel_fetch.py src/agent_bom/api/routes/intel.py src/agent_bom/mcp_tools/intel.py src/agent_bom/mcp_server.py tests/test_intel_lookup.py
- uv run mypy src/agent_bom/intel_lookup.py src/agent_bom/intel_fetch.py src/agent_bom/api/routes/intel.py src/agent_bom/mcp_tools/intel.py
- uv run python scripts/export_openapi.py --check
- python scripts/check_release_consistency.py
- git diff --check
- uv run mkdocs build --strict

Notes

- Closes #2643
- Closes #2645
- The fetch lane is governed and allowlisted; manual-only sources are rejected and this does not claim open-ended vendor webpage scraping.