### PR TITLE
feat(connectors): define database evidence fallback lanes

### DIFF
--- a/docs/DATABASE_EVIDENCE.md
+++ b/docs/DATABASE_EVIDENCE.md
@@ -1,0 +1,47 @@
+# Database Evidence Connectors
+
+agent-bom treats database and warehouse integrations as evidence sources, not
+event streams. Connectors query customer-owned systems for inventory,
+governance, access, and lineage evidence, then map that evidence into the
+same findings and graph model used by local scans and runtime telemetry.
+
+## Connector Lanes
+
+| Lane | Status | Default wheel | Use when | Credential boundary |
+|---|---|---:|---|---|
+| Native | Preferred | Mixed | A first-party or vendor-supported Python SDK exists for the source system. | Customer-managed service account, role, or token |
+| ODBC fallback | Optional | No | Customer already operates DSNs or the source has no usable native SDK. | Customer-managed DSN and driver config |
+| JDBC fallback | Optional | No | Customer standardizes on JDBC drivers or JVM-based warehouse access. | Customer-managed JDBC URL, driver, JVM, and secret store |
+
+Native connectors remain the preferred path for security-sensitive posture
+because they avoid host-level DSN/JVM packaging and usually expose richer
+identity, grants, policy, and lineage APIs. ODBC and JDBC are fallback lanes
+for SQL Server, Oracle, Teradata, and customer-managed environments where a
+generic SQL path is the only viable evidence source.
+
+## Evidence Contract
+
+Database evidence connectors should collect:
+
+- schemas, tables, and views
+- grants, roles, and users
+- classification tags and governance metadata
+- external shares, stages, and public/shared objects
+- lineage metadata where available
+
+Connectors must be read-only by default. They should report the source system,
+connector lane, target object, evidence kind, collection timestamp, tenant or
+account boundary, and confidence. If a connector cannot distinguish inventory
+from inferred governance metadata, mark the confidence lower and explain the
+query source.
+
+## Non-Goals
+
+- ODBC/JDBC are not event streaming connectors. Posture-event streaming uses
+  webhooks or runtime emitter plugins.
+- ODBC/JDBC do not replace native Snowflake, Postgres/Supabase, Databricks,
+  BigQuery, Redshift, or Athena paths where native APIs are available.
+- The default wheel does not bundle ODBC drivers, JDBC drivers, a JVM, or
+  customer DSN configuration.
+
+The code-level contract lives in `src/agent_bom/database_evidence.py`.

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -186,6 +186,21 @@ Snowflake) or via per-tenant SQLite paths.
 For the operator-facing logical entity → store/table contract, see
 [`site-docs/deployment/control-plane-data-model.md`](../site-docs/deployment/control-plane-data-model.md).
 
+### Database and warehouse evidence connector lanes
+
+Database posture connectors are evidence sources, not event streams. Native
+connectors are preferred for security-sensitive posture because they expose
+richer identity, grants, governance, and lineage APIs. ODBC/JDBC are optional
+fallback lanes for SQL Server, Oracle, Teradata, and customer-managed DSN/JVM
+environments where a generic SQL path is the only viable evidence source.
+
+The contract in `src/agent_bom/database_evidence.py` keeps ODBC/JDBC out of
+the default wheel, marks them non-preferred, and defines the read-only evidence
+kinds they may collect: schemas, tables, views, grants, roles, users,
+classification tags, governance metadata, external shares/stages, and lineage.
+See [`docs/DATABASE_EVIDENCE.md`](DATABASE_EVIDENCE.md) for the operator-facing
+lane and credential-boundary guidance.
+
 ### SQLite — `src/agent_bom/db/schema.py`
 
 Single-file local store. Used for the offline vuln DB and the

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Canonical docs here:
 
 - `ARCHITECTURE.md`
 - `CONTROL_MAPPING.md`
+- `DATABASE_EVIDENCE.md`
 - `DEPLOYMENT.md`
 - `ENTERPRISE.md`
 - `ENTERPRISE_DEPLOYMENT.md`

--- a/src/agent_bom/database_evidence.py
+++ b/src/agent_bom/database_evidence.py
@@ -1,0 +1,143 @@
+"""Database and warehouse evidence connector lane definitions.
+
+The default product lane prefers native, API-shaped connectors for posture
+evidence. ODBC/JDBC remain optional enterprise fallback lanes for environments
+where native drivers are unavailable or where customers already manage DSNs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class DatabaseConnectorLane(str, Enum):
+    """Supported database evidence connector lanes."""
+
+    NATIVE = "native"
+    ODBC = "odbc"
+    JDBC = "jdbc"
+
+
+class DatabaseEvidenceKind(str, Enum):
+    """Evidence categories that database and warehouse connectors collect."""
+
+    SCHEMA = "schema"
+    TABLE = "table"
+    VIEW = "view"
+    GRANT = "grant"
+    ROLE = "role"
+    USER = "user"
+    CLASSIFICATION_TAG = "classification_tag"
+    GOVERNANCE_METADATA = "governance_metadata"
+    EXTERNAL_SHARE = "external_share"
+    EXTERNAL_STAGE = "external_stage"
+    LINEAGE = "lineage"
+
+
+@dataclass(frozen=True)
+class DatabaseEvidenceConnector:
+    """Contract metadata for a database evidence source."""
+
+    name: str
+    lane: DatabaseConnectorLane
+    target_systems: tuple[str, ...]
+    evidence_kinds: tuple[DatabaseEvidenceKind, ...]
+    default_wheel: bool
+    preferred: bool
+    packaging_notes: str
+    credential_boundary: str = "customer_managed"
+    writes: bool = False
+
+
+CORE_DATABASE_EVIDENCE: tuple[DatabaseEvidenceKind, ...] = (
+    DatabaseEvidenceKind.SCHEMA,
+    DatabaseEvidenceKind.TABLE,
+    DatabaseEvidenceKind.VIEW,
+    DatabaseEvidenceKind.GRANT,
+    DatabaseEvidenceKind.ROLE,
+    DatabaseEvidenceKind.USER,
+    DatabaseEvidenceKind.CLASSIFICATION_TAG,
+    DatabaseEvidenceKind.GOVERNANCE_METADATA,
+    DatabaseEvidenceKind.EXTERNAL_SHARE,
+    DatabaseEvidenceKind.EXTERNAL_STAGE,
+    DatabaseEvidenceKind.LINEAGE,
+)
+
+
+DATABASE_EVIDENCE_CONNECTORS: tuple[DatabaseEvidenceConnector, ...] = (
+    DatabaseEvidenceConnector(
+        name="postgres-native",
+        lane=DatabaseConnectorLane.NATIVE,
+        target_systems=("postgres", "supabase"),
+        evidence_kinds=CORE_DATABASE_EVIDENCE,
+        default_wheel=True,
+        preferred=True,
+        packaging_notes="Native psycopg/Postgres paths are the preferred posture source for Postgres-compatible stores.",
+    ),
+    DatabaseEvidenceConnector(
+        name="snowflake-native",
+        lane=DatabaseConnectorLane.NATIVE,
+        target_systems=("snowflake",),
+        evidence_kinds=CORE_DATABASE_EVIDENCE,
+        default_wheel=False,
+        preferred=True,
+        packaging_notes="Use the Snowflake connector or Native App path before any generic ODBC/JDBC lane.",
+    ),
+    DatabaseEvidenceConnector(
+        name="databricks-native",
+        lane=DatabaseConnectorLane.NATIVE,
+        target_systems=("databricks",),
+        evidence_kinds=CORE_DATABASE_EVIDENCE,
+        default_wheel=False,
+        preferred=True,
+        packaging_notes="Use Databricks SQL/SDK inventory paths for workspace-governed posture evidence.",
+    ),
+    DatabaseEvidenceConnector(
+        name="odbc-fallback",
+        lane=DatabaseConnectorLane.ODBC,
+        target_systems=("sqlserver", "oracle", "teradata", "customer-dsn"),
+        evidence_kinds=CORE_DATABASE_EVIDENCE,
+        default_wheel=False,
+        preferred=False,
+        packaging_notes="Optional extra only; DSN and native driver setup stay customer-owned.",
+    ),
+    DatabaseEvidenceConnector(
+        name="jdbc-fallback",
+        lane=DatabaseConnectorLane.JDBC,
+        target_systems=("sqlserver", "oracle", "teradata", "customer-jdbc-url"),
+        evidence_kinds=CORE_DATABASE_EVIDENCE,
+        default_wheel=False,
+        preferred=False,
+        packaging_notes="Optional extra only; JVM and JDBC driver packaging stay outside the default wheel.",
+    ),
+)
+
+
+def list_database_evidence_connectors() -> list[dict[str, object]]:
+    """Return the public database evidence connector lane contract."""
+
+    return [
+        {
+            "name": connector.name,
+            "lane": connector.lane.value,
+            "target_systems": list(connector.target_systems),
+            "evidence_kinds": [kind.value for kind in connector.evidence_kinds],
+            "default_wheel": connector.default_wheel,
+            "preferred": connector.preferred,
+            "packaging_notes": connector.packaging_notes,
+            "credential_boundary": connector.credential_boundary,
+            "writes": connector.writes,
+        }
+        for connector in DATABASE_EVIDENCE_CONNECTORS
+    ]
+
+
+def fallback_database_evidence_connectors() -> list[DatabaseEvidenceConnector]:
+    """Return optional ODBC/JDBC fallback connectors, excluding native lanes."""
+
+    return [
+        connector
+        for connector in DATABASE_EVIDENCE_CONNECTORS
+        if connector.lane in {DatabaseConnectorLane.ODBC, DatabaseConnectorLane.JDBC}
+    ]

--- a/tests/test_database_evidence.py
+++ b/tests/test_database_evidence.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from agent_bom.database_evidence import (
+    CORE_DATABASE_EVIDENCE,
+    DatabaseConnectorLane,
+    DatabaseEvidenceKind,
+    fallback_database_evidence_connectors,
+    list_database_evidence_connectors,
+)
+
+
+def test_database_evidence_contract_keeps_odbc_jdbc_out_of_default_wheel() -> None:
+    connectors = {entry["name"]: entry for entry in list_database_evidence_connectors()}
+
+    assert connectors["postgres-native"]["preferred"] is True
+    assert connectors["postgres-native"]["default_wheel"] is True
+
+    for name in ("odbc-fallback", "jdbc-fallback"):
+        fallback = connectors[name]
+        assert fallback["preferred"] is False
+        assert fallback["default_wheel"] is False
+        assert fallback["credential_boundary"] == "customer_managed"
+        assert fallback["writes"] is False
+        assert "optional extra" in str(fallback["packaging_notes"]).lower()
+
+
+def test_database_evidence_contract_covers_governance_inventory() -> None:
+    evidence = {kind.value for kind in CORE_DATABASE_EVIDENCE}
+
+    assert {
+        DatabaseEvidenceKind.SCHEMA.value,
+        DatabaseEvidenceKind.TABLE.value,
+        DatabaseEvidenceKind.VIEW.value,
+        DatabaseEvidenceKind.GRANT.value,
+        DatabaseEvidenceKind.ROLE.value,
+        DatabaseEvidenceKind.USER.value,
+        DatabaseEvidenceKind.CLASSIFICATION_TAG.value,
+        DatabaseEvidenceKind.GOVERNANCE_METADATA.value,
+        DatabaseEvidenceKind.EXTERNAL_SHARE.value,
+        DatabaseEvidenceKind.EXTERNAL_STAGE.value,
+        DatabaseEvidenceKind.LINEAGE.value,
+    } <= evidence
+
+
+def test_fallback_database_evidence_connectors_only_returns_generic_lanes() -> None:
+    fallbacks = fallback_database_evidence_connectors()
+
+    assert {connector.lane for connector in fallbacks} == {DatabaseConnectorLane.ODBC, DatabaseConnectorLane.JDBC}
+    assert {connector.name for connector in fallbacks} == {"odbc-fallback", "jdbc-fallback"}


### PR DESCRIPTION
Summary

- add a code-level database evidence connector contract for native, ODBC, and JDBC lanes
- keep ODBC/JDBC as optional non-default fallback extras with customer-managed credential and driver boundaries
- document the operator-facing evidence lane and pin the contract with regression tests

Verification

- uv run pytest tests/test_database_evidence.py -q
- uv run ruff check src/agent_bom/database_evidence.py tests/test_database_evidence.py
- uv run mypy src/agent_bom/database_evidence.py
- python scripts/check_release_consistency.py
- git diff --check

Notes

- Closes #2634
- This defines the fallback lane only; it does not bundle ODBC/JDBC drivers, DSNs, or JVM dependencies into the default wheel.