### PR TITLE
fix(audit): require persistent HMAC in production

### DIFF
--- a/deploy/helm/agent-bom/templates/NOTES.txt
+++ b/deploy/helm/agent-bom/templates/NOTES.txt
@@ -7,7 +7,8 @@ Enterprise pilot notes:
   Kubernetes Secret shape and `site-docs/deployment/postgres-provisioning.md`
   for the ownership contract.
 - Set `AGENT_BOM_AUDIT_HMAC_KEY` in the control-plane secret.
-- Set `AGENT_BOM_REQUIRE_AUDIT_HMAC=1` to fail closed if the key is missing.
+- Production and multi-replica control planes fail closed when `AGENT_BOM_AUDIT_HMAC_KEY` is missing.
+  Keep `AGENT_BOM_REQUIRE_AUDIT_HMAC=1` set for explicit policy evidence.
 - Use Postgres for the pilot control plane; SQLite is not the multi-replica path.
 - Prefer internal ingress / VPN-only exposure for the API and UI.
 - Run Alembic before first multi-replica rollout: `alembic -c deploy/supabase/postgres/alembic.ini upgrade head`.

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -374,6 +374,7 @@ For secret lifecycle posture, production deployments should declare the external
 secret authority and rotation metadata without exposing secret values:
 
 ```bash
+export AGENT_BOM_AUDIT_HMAC_KEY="mount-from-secret-manager"
 export AGENT_BOM_SECRET_PROVIDER="aws_secrets_manager" # or hashicorp_vault, external_secrets, csi
 export AGENT_BOM_EXTERNAL_SECRETS_ENABLED=1
 export AGENT_BOM_AUDIT_HMAC_LAST_ROTATED="2026-04-24T00:00:00+00:00"
@@ -388,6 +389,11 @@ or inside `GET /v1/auth/policy`. For change windows, use
 that names the affected env vars, customer secret-manager action, rollout
 commands, verification curl, and `*_LAST_ROTATED` timestamp to record. The plan
 never returns secret values and is safe to attach to an internal change ticket.
+
+Production and multi-replica control planes require `AGENT_BOM_AUDIT_HMAC_KEY`
+at startup. The local ephemeral fallback remains available for workstation
+pilots only; using it in a production-shaped environment requires the explicit
+`AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC=1` escape hatch.
 
 **Storage:** SQLite for single-node and local persistence, PostgreSQL-compatible backends such as PostgreSQL and Supabase for the transactional control plane, ClickHouse for analytics, and Snowflake for selected enterprise store paths where parity is explicitly implemented. Snowflake does not yet have full parity for every transactional API store, so PostgreSQL-compatible backends remain the primary control-plane default when you need tenant-scoped keys, exceptions, graph state, and trend history.
 

--- a/docs/IDENTITY_AND_NAMING_CONTRACT.md
+++ b/docs/IDENTITY_AND_NAMING_CONTRACT.md
@@ -107,7 +107,7 @@ Best-of-both-worlds onboarding: works without configuration, accepts your overri
 | Tenant ID | `default` (system fallback bucket) | Any non-reserved string at ingress |
 | Default role | `viewer` (least privilege) | `AGENT_BOM_DEFAULT_ROLE` |
 | Database backend | In-memory (ephemeral) | `AGENT_BOM_DB` (SQLite) or `AGENT_BOM_POSTGRES_URL` (Postgres) |
-| Audit HMAC key | Ephemeral random (not durable across restarts) | `AGENT_BOM_AUDIT_HMAC_KEY` for production |
+| Audit HMAC key | Ephemeral random for local single-process use only | `AGENT_BOM_AUDIT_HMAC_KEY` for production; production or multi-replica control planes fail closed without it unless `AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC=1` is explicitly set |
 
 ---
 

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -277,7 +277,7 @@ agent-bom agents --snowflake --snowflake-authenticator oauth
 | Principle | How agent-bom upholds it |
 |-----------|--------------------------|
 | **Confidentiality** | Credentials pass env → SDK, never logged. `sanitize_error()` strips secrets from all error messages. Audit logs stored at `0600` permissions. |
-| **Integrity** | SHA-256 payload hashing on every proxied MCP call. Audit logs HMAC-signed (SHA-256) for tamper detection. Set `AGENT_BOM_AUDIT_HMAC_KEY` in production to persist verifiability across restarts. Model weight hash verification (`agent-bom verify --model-dir ...` or `--verify-model-hashes` in scan workflows). SBOM + VEX support for supply chain integrity. |
+| **Integrity** | SHA-256 payload hashing on every proxied MCP call. Audit logs HMAC-signed (SHA-256) for tamper detection. Set `AGENT_BOM_AUDIT_HMAC_KEY` in production to persist verifiability across restarts; production or multi-replica control planes fail closed without it unless `AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC=1` is explicitly set. Model weight hash verification (`agent-bom verify --model-dir ...` or `--verify-model-hashes` in scan workflows). SBOM + VEX support for supply chain integrity. |
 | **Availability** | Graceful degradation on auth failure (warning, not crash). Offline mode (`--no-scan`). Rate limiting respected — we never exhaust API quotas. |
 
 ### What we never do

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -34,6 +34,8 @@ AGENT_BOM_API_FIREWALL_POLICY
 AGENT_BOM_API_TOKEN
 AGENT_BOM_API_URL
 AGENT_BOM_AUDIT_DB
+# explicit workstation-only escape hatch for production-shaped audit HMAC fail-closed behavior
+AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC
 # tier-B (replay-only) capture toggle — issue #2261
 AGENT_BOM_CAPTURE_REPLAY
 AGENT_BOM_AUDIT_HMAC_KEY

--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -57,6 +57,31 @@ def _env_int(name: str) -> int | None:
     return parsed if parsed >= 0 else None
 
 
+def _configured_control_plane_replicas() -> int:
+    raw = (os.environ.get("AGENT_BOM_CONTROL_PLANE_REPLICAS") or "").strip()
+    if not raw:
+        return 1
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 1
+
+
+def _production_audit_hmac_required() -> bool:
+    deployment = (
+        (os.environ.get("AGENT_BOM_ENV") or os.environ.get("AGENT_BOM_DEPLOYMENT_ENV") or os.environ.get("ENVIRONMENT") or "")
+        .strip()
+        .lower()
+    )
+    production_env = deployment in {"prod", "production"}
+    clustered = _configured_control_plane_replicas() > 1
+    return (production_env or clustered) and not _env_enabled("AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC")
+
+
+def _audit_hmac_required() -> bool:
+    return _env_enabled("AGENT_BOM_REQUIRE_AUDIT_HMAC") or _production_audit_hmac_required()
+
+
 def _describe_rotation_posture(
     *,
     configured: bool,
@@ -158,8 +183,12 @@ _HMAC_ENV_KEY = (os.environ.get("AGENT_BOM_AUDIT_HMAC_KEY") or "").strip()
 if _HMAC_ENV_KEY:
     _HMAC_KEY = _HMAC_ENV_KEY.encode()
 else:
-    if _env_enabled("AGENT_BOM_REQUIRE_AUDIT_HMAC"):
-        raise RuntimeError("AGENT_BOM_REQUIRE_AUDIT_HMAC is enabled but AGENT_BOM_AUDIT_HMAC_KEY is not set")
+    if _audit_hmac_required():
+        raise RuntimeError(
+            "AGENT_BOM_AUDIT_HMAC_KEY is required when AGENT_BOM_REQUIRE_AUDIT_HMAC is enabled, "
+            "AGENT_BOM_ENV/AGENT_BOM_DEPLOYMENT_ENV/ENVIRONMENT is production, or "
+            "AGENT_BOM_CONTROL_PLANE_REPLICAS is greater than 1"
+        )
     import secrets as _secrets
 
     _HMAC_KEY = _secrets.token_bytes(32)
@@ -239,7 +268,9 @@ def verify_export_payload(payload: bytes, signature: str) -> bool:
 
 def describe_audit_hmac_status() -> dict[str, object]:
     """Return operator-facing audit HMAC posture for auth/policy surfaces."""
-    required = _env_enabled("AGENT_BOM_REQUIRE_AUDIT_HMAC")
+    explicit_required = _env_enabled("AGENT_BOM_REQUIRE_AUDIT_HMAC")
+    production_required = _production_audit_hmac_required()
+    required = explicit_required or production_required
     configured = bool(_HMAC_ENV_KEY)
     key_id = (os.environ.get("AGENT_BOM_AUDIT_HMAC_KEY_ID") or "").strip()
     rotation = _describe_rotation_posture(
@@ -258,6 +289,9 @@ def describe_audit_hmac_status() -> dict[str, object]:
             "status": "configured",
             "configured": True,
             "required": required,
+            "required_reason": (
+                "explicit" if explicit_required else "production_or_clustered_control_plane" if production_required else "not_required"
+            ),
             "source": "AGENT_BOM_AUDIT_HMAC_KEY",
             "persists_across_restart": True,
             "key_id_configured": bool(key_id),
@@ -272,6 +306,9 @@ def describe_audit_hmac_status() -> dict[str, object]:
         "status": "ephemeral",
         "configured": False,
         "required": required,
+        "required_reason": (
+            "explicit" if explicit_required else "production_or_clustered_control_plane" if production_required else "not_required"
+        ),
         "source": "process_ephemeral",
         "persists_across_restart": False,
         "key_id_configured": False,

--- a/tests/test_hardening_phase2.py
+++ b/tests/test_hardening_phase2.py
@@ -244,6 +244,56 @@ class TestAuditHMAC:
             os.environ.pop("AGENT_BOM_REQUIRE_AUDIT_HMAC", None)
             importlib.reload(audit_log)
 
+    def test_production_env_requires_audit_hmac_by_default(self):
+        """Production environments should not silently fall back to ephemeral audit HMAC."""
+        import importlib
+
+        from agent_bom.api import audit_log
+
+        with patch.dict(os.environ, {"AGENT_BOM_ENV": "production"}, clear=False):
+            os.environ.pop("AGENT_BOM_AUDIT_HMAC_KEY", None)
+            os.environ.pop("AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC", None)
+            with pytest.raises(RuntimeError, match="AGENT_BOM_AUDIT_HMAC_KEY is required"):
+                importlib.reload(audit_log)
+
+        with patch.dict(
+            os.environ,
+            {"AGENT_BOM_ENV": "production", "AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC": "1"},
+            clear=False,
+        ):
+            os.environ.pop("AGENT_BOM_AUDIT_HMAC_KEY", None)
+            importlib.reload(audit_log)
+            status = audit_log.describe_audit_hmac_status()
+            assert status["status"] == "ephemeral"
+            assert status["required"] is False
+            assert status["required_reason"] == "not_required"
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AGENT_BOM_AUDIT_HMAC_KEY", None)
+            os.environ.pop("AGENT_BOM_REQUIRE_AUDIT_HMAC", None)
+            os.environ.pop("AGENT_BOM_ENV", None)
+            os.environ.pop("AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC", None)
+            importlib.reload(audit_log)
+
+    def test_clustered_control_plane_requires_audit_hmac_by_default(self):
+        """Clustered API replicas require a persistent audit HMAC key."""
+        import importlib
+
+        from agent_bom.api import audit_log
+
+        with patch.dict(os.environ, {"AGENT_BOM_CONTROL_PLANE_REPLICAS": "2"}, clear=False):
+            os.environ.pop("AGENT_BOM_AUDIT_HMAC_KEY", None)
+            os.environ.pop("AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC", None)
+            with pytest.raises(RuntimeError, match="AGENT_BOM_AUDIT_HMAC_KEY is required"):
+                importlib.reload(audit_log)
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AGENT_BOM_AUDIT_HMAC_KEY", None)
+            os.environ.pop("AGENT_BOM_REQUIRE_AUDIT_HMAC", None)
+            os.environ.pop("AGENT_BOM_CONTROL_PLANE_REPLICAS", None)
+            os.environ.pop("AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC", None)
+            importlib.reload(audit_log)
+
 
 # ── Exception Narrowing ────────────────────────────────────────────────────
 


### PR DESCRIPTION
Summary
- require AGENT_BOM_AUDIT_HMAC_KEY by default for production or multi-replica control planes
- keep local workstation fallback available only through explicit AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC=1
- update Helm notes and deployment/security docs so the startup behavior is operator-visible

Verification
- uv run pytest tests/test_hardening_phase2.py::TestAuditHMAC -q
- uv run pytest tests/test_hardening_phase2.py::TestAuditHMAC tests/test_api_operator_policy.py::test_auth_policy_reports_secret_integrity_posture tests/test_api_operator_policy.py::test_auth_policy_reports_secret_lifecycle_posture tests/test_api_operator_policy.py::test_auth_secret_rotation_plan_is_non_secret_and_actionable -q
- uv run ruff check src/agent_bom/api/audit_log.py tests/test_hardening_phase2.py
- uv run mypy src/agent_bom/api/audit_log.py
- python scripts/check_release_consistency.py
- uv run mkdocs build --strict
- helm template agent-bom deploy/helm/agent-bom >/tmp/agent-bom-helm.yaml
- git diff --check

Notes
- Closes the audit-chain key rotation gap by making persistent signing keys fail-closed for production-shaped deployments instead of relying on operator memory.