### PR TITLE
feat(integrations): persist issue mappings

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,8 +53,8 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 181 |
-| `docs/openapi/v1.json` | component schemas | 56 |
+| `docs/openapi/v1.json` | paths | 182 |
+| `docs/openapi/v1.json` | component schemas | 57 |
 
 <!-- DATA_MODEL_ATLAS:END -->
 

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -1347,6 +1347,21 @@
         "title": "IntelPackageMatchRequest",
         "type": "object"
       },
+      "IssueStatusUpdateRequest": {
+        "properties": {
+          "status": {
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "IssueStatusUpdateRequest",
+        "type": "object"
+      },
       "JiraTicketRequest": {
         "description": "Request body for POST /v1/findings/jira.",
         "properties": {
@@ -1365,6 +1380,18 @@
           },
           "project_key": {
             "title": "Project Key",
+            "type": "string"
+          },
+          "target_id": {
+            "default": "",
+            "maxLength": 256,
+            "title": "Target Id",
+            "type": "string"
+          },
+          "target_kind": {
+            "default": "finding",
+            "pattern": "^(finding|exposure_path)$",
+            "title": "Target Kind",
             "type": "string"
           }
         },
@@ -10981,6 +11008,61 @@
         "summary": "Get Fix First Graph View",
         "tags": [
           "graph"
+        ]
+      }
+    },
+    "/v1/integrations/issues/{mapping_id}/status": {
+      "put": {
+        "description": "Update tenant-scoped external issue mapping status after provider sync.",
+        "operationId": "update_issue_mapping_status_v1_integrations_issues__mapping_id__status_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "mapping_id",
+            "required": true,
+            "schema": {
+              "title": "Mapping Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IssueStatusUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Update Issue Mapping Status V1 Integrations Issues  Mapping Id  Status Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Issue Mapping Status",
+        "tags": [
+          "enterprise"
         ]
       }
     },

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -930,6 +930,17 @@ components:
       - packages
       title: IntelPackageMatchRequest
       type: object
+    IssueStatusUpdateRequest:
+      properties:
+        status:
+          maxLength: 64
+          minLength: 1
+          title: Status
+          type: string
+      required:
+      - status
+      title: IssueStatusUpdateRequest
+      type: object
     JiraTicketRequest:
       description: Request body for POST /v1/findings/jira.
       properties:
@@ -945,6 +956,16 @@ components:
           type: string
         project_key:
           title: Project Key
+          type: string
+        target_id:
+          default: ''
+          maxLength: 256
+          title: Target Id
+          type: string
+        target_kind:
+          default: finding
+          pattern: ^(finding|exposure_path)$
+          title: Target Kind
           type: string
       required:
       - jira_url
@@ -7231,6 +7252,43 @@ paths:
       summary: Get Fix First Graph View
       tags:
       - graph
+  /v1/integrations/issues/{mapping_id}/status:
+    put:
+      description: Update tenant-scoped external issue mapping status after provider
+        sync.
+      operationId: update_issue_mapping_status_v1_integrations_issues__mapping_id__status_put
+      parameters:
+      - in: path
+        name: mapping_id
+        required: true
+        schema:
+          title: Mapping Id
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IssueStatusUpdateRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Update Issue Mapping Status V1 Integrations Issues  Mapping
+                  Id  Status Put
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Update Issue Mapping Status
+      tags:
+      - enterprise
   /v1/intel/advisories/{advisory_id}:
     get:
       description: Look up one CVE/GHSA/OSV advisory from local intel.

--- a/docs/schemas/v1/IssueStatusUpdateRequest.json
+++ b/docs/schemas/v1/IssueStatusUpdateRequest.json
@@ -1,0 +1,15 @@
+{
+  "properties": {
+    "status": {
+      "maxLength": 64,
+      "minLength": 1,
+      "title": "Status",
+      "type": "string"
+    }
+  },
+  "required": [
+    "status"
+  ],
+  "title": "IssueStatusUpdateRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/JiraTicketRequest.json
+++ b/docs/schemas/v1/JiraTicketRequest.json
@@ -17,6 +17,18 @@
     "project_key": {
       "title": "Project Key",
       "type": "string"
+    },
+    "target_id": {
+      "default": "",
+      "maxLength": 256,
+      "title": "Target Id",
+      "type": "string"
+    },
+    "target_kind": {
+      "default": "finding",
+      "pattern": "^(finding|exposure_path)$",
+      "title": "Target Kind",
+      "type": "string"
     }
   },
   "required": [

--- a/docs/schemas/v1/index.json
+++ b/docs/schemas/v1/index.json
@@ -107,6 +107,11 @@
       "schema": "HealthResponse.json"
     },
     {
+      "doc": "",
+      "name": "IssueStatusUpdateRequest",
+      "schema": "IssueStatusUpdateRequest.json"
+    },
+    {
       "doc": "Request body for POST /v1/findings/jira.",
       "name": "JiraTicketRequest",
       "schema": "JiraTicketRequest.json"

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import ast
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 from typing import NoReturn
@@ -163,6 +164,19 @@ def _assert_mcp_registry_serialization_stable() -> None:
     normalized = dumps_registry_json(json.loads(current))
     if normalized != current:
         _fail("src/agent_bom/mcp_registry.json is not in canonical registry serialization. Run the registry formatter before tagging.")
+
+
+def _assert_data_model_atlas_current() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/regenerate_data_model_atlas.py", "--check"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        _fail(detail or "docs/DATA_MODEL.md generated atlas is stale")
 
 
 def _server_card_list(variable_name: str) -> list[dict[str, object]]:
@@ -337,6 +351,7 @@ def main() -> int:
             _fail(f"pyproject.toml description contains stale storefront phrase: {marker}")
 
     _assert_mcp_registry_serialization_stable()
+    _assert_data_model_atlas_current()
 
     if f"## [{version}]" not in changelog:
         _fail(f"CHANGELOG.md must include a {version} release entry before tagging")

--- a/src/agent_bom/api/issue_mapping_store.py
+++ b/src/agent_bom/api/issue_mapping_store.py
@@ -1,0 +1,243 @@
+"""Tenant-scoped external issue mapping store."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Protocol
+
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+@dataclass
+class IssueMapping:
+    mapping_id: str
+    tenant_id: str
+    target_kind: str
+    target_id: str
+    provider: str
+    external_id: str
+    external_url: str
+    status: str
+    created_at: str
+    updated_at: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "id": self.mapping_id,
+            "tenant_id": self.tenant_id,
+            "target_kind": self.target_kind,
+            "target_id": self.target_id,
+            "provider": self.provider,
+            "external_id": self.external_id,
+            "external_url": self.external_url,
+            "status": self.status,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+class IssueMappingStore(Protocol):
+    def get(self, mapping_id: str, *, tenant_id: str) -> IssueMapping | None: ...
+
+    def find(self, *, tenant_id: str, target_kind: str, target_id: str, provider: str) -> IssueMapping | None: ...
+
+    def put(
+        self,
+        *,
+        tenant_id: str,
+        target_kind: str,
+        target_id: str,
+        provider: str,
+        external_id: str,
+        external_url: str,
+        status: str = "open",
+    ) -> IssueMapping: ...
+
+    def update_status(self, mapping_id: str, *, tenant_id: str, status: str) -> IssueMapping | None: ...
+
+
+class InMemoryIssueMappingStore:
+    def __init__(self) -> None:
+        self._records: dict[str, IssueMapping] = {}
+        self._lock = threading.Lock()
+
+    def get(self, mapping_id: str, *, tenant_id: str) -> IssueMapping | None:
+        with self._lock:
+            record = self._records.get(mapping_id)
+            return record if record and record.tenant_id == tenant_id else None
+
+    def find(self, *, tenant_id: str, target_kind: str, target_id: str, provider: str) -> IssueMapping | None:
+        with self._lock:
+            for record in self._records.values():
+                if (
+                    record.tenant_id == tenant_id
+                    and record.target_kind == target_kind
+                    and record.target_id == target_id
+                    and record.provider == provider
+                ):
+                    return record
+        return None
+
+    def put(
+        self,
+        *,
+        tenant_id: str,
+        target_kind: str,
+        target_id: str,
+        provider: str,
+        external_id: str,
+        external_url: str,
+        status: str = "open",
+    ) -> IssueMapping:
+        now = _utcnow()
+        with self._lock:
+            existing = next(
+                (
+                    record
+                    for record in self._records.values()
+                    if record.tenant_id == tenant_id
+                    and record.target_kind == target_kind
+                    and record.target_id == target_id
+                    and record.provider == provider
+                ),
+                None,
+            )
+            if existing:
+                existing.external_id = external_id
+                existing.external_url = external_url
+                existing.status = status
+                existing.updated_at = now
+                return existing
+            record = IssueMapping(
+                mapping_id=f"issue-map-{uuid.uuid4().hex}",
+                tenant_id=tenant_id,
+                target_kind=target_kind,
+                target_id=target_id,
+                provider=provider,
+                external_id=external_id,
+                external_url=external_url,
+                status=status,
+                created_at=now,
+                updated_at=now,
+            )
+            self._records[record.mapping_id] = record
+            return record
+
+    def update_status(self, mapping_id: str, *, tenant_id: str, status: str) -> IssueMapping | None:
+        with self._lock:
+            record = self._records.get(mapping_id)
+            if not record or record.tenant_id != tenant_id:
+                return None
+            record.status = status
+            record.updated_at = _utcnow()
+            return record
+
+
+class SQLiteIssueMappingStore:
+    def __init__(self, db_path: str = "agent_bom_jobs.db") -> None:
+        self._db_path = db_path
+        self._local = threading.local()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        if not hasattr(self._local, "conn") or self._local.conn is None:
+            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            self._local.conn.execute("PRAGMA journal_mode=WAL")
+        conn: sqlite3.Connection = self._local.conn
+        return conn
+
+    def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "issue_mappings")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS issue_mappings (
+                mapping_id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                target_kind TEXT NOT NULL,
+                target_id TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                external_id TEXT NOT NULL,
+                external_url TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                UNIQUE(tenant_id, target_kind, target_id, provider)
+            )
+            """
+        )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_issue_mappings_tenant ON issue_mappings(tenant_id)")
+        self._conn.commit()
+
+    def _row_to_mapping(self, row: sqlite3.Row | tuple | None) -> IssueMapping | None:
+        if not row:
+            return None
+        return IssueMapping(*row)
+
+    def get(self, mapping_id: str, *, tenant_id: str) -> IssueMapping | None:
+        row = self._conn.execute(
+            """SELECT mapping_id, tenant_id, target_kind, target_id, provider,
+                      external_id, external_url, status, created_at, updated_at
+               FROM issue_mappings WHERE mapping_id = ? AND tenant_id = ?""",
+            (mapping_id, tenant_id),
+        ).fetchone()
+        return self._row_to_mapping(row)
+
+    def find(self, *, tenant_id: str, target_kind: str, target_id: str, provider: str) -> IssueMapping | None:
+        row = self._conn.execute(
+            """SELECT mapping_id, tenant_id, target_kind, target_id, provider,
+                      external_id, external_url, status, created_at, updated_at
+               FROM issue_mappings
+               WHERE tenant_id = ? AND target_kind = ? AND target_id = ? AND provider = ?""",
+            (tenant_id, target_kind, target_id, provider),
+        ).fetchone()
+        return self._row_to_mapping(row)
+
+    def put(
+        self,
+        *,
+        tenant_id: str,
+        target_kind: str,
+        target_id: str,
+        provider: str,
+        external_id: str,
+        external_url: str,
+        status: str = "open",
+    ) -> IssueMapping:
+        now = _utcnow()
+        existing = self.find(tenant_id=tenant_id, target_kind=target_kind, target_id=target_id, provider=provider)
+        mapping_id = existing.mapping_id if existing else f"issue-map-{uuid.uuid4().hex}"
+        created_at = existing.created_at if existing else now
+        self._conn.execute(
+            """INSERT INTO issue_mappings
+               (mapping_id, tenant_id, target_kind, target_id, provider,
+                external_id, external_url, status, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(tenant_id, target_kind, target_id, provider)
+               DO UPDATE SET external_id = excluded.external_id,
+                             external_url = excluded.external_url,
+                             status = excluded.status,
+                             updated_at = excluded.updated_at""",
+            (mapping_id, tenant_id, target_kind, target_id, provider, external_id, external_url, status, created_at, now),
+        )
+        self._conn.commit()
+        record = self.find(tenant_id=tenant_id, target_kind=target_kind, target_id=target_id, provider=provider)
+        assert record is not None
+        return record
+
+    def update_status(self, mapping_id: str, *, tenant_id: str, status: str) -> IssueMapping | None:
+        now = _utcnow()
+        self._conn.execute(
+            "UPDATE issue_mappings SET status = ?, updated_at = ? WHERE mapping_id = ? AND tenant_id = ?",
+            (status, now, mapping_id, tenant_id),
+        )
+        self._conn.commit()
+        return self.get(mapping_id, tenant_id=tenant_id)

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -593,6 +593,12 @@ class JiraTicketRequest(BaseModel):
     email: str
     project_key: str
     finding: dict[str, Any]
+    target_kind: str = Field("finding", pattern="^(finding|exposure_path)$")
+    target_id: str = Field("", max_length=256)
+
+
+class IssueStatusUpdateRequest(BaseModel):
+    status: str = Field(..., min_length=1, max_length=64)
 
 
 class FalsePositiveRequest(BaseModel):

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -49,12 +49,13 @@ from agent_bom.api.models import (
     ExceptionRequest,
     FalsePositiveRequest,
     FindingFeedbackRequest,
+    IssueStatusUpdateRequest,
     JiraTicketRequest,
     RotateKeyRequest,
     SAMLLoginRequest,
     TenantQuotaUpdateRequest,
 )
-from agent_bom.api.stores import _get_exception_store, _get_store, _get_trend_store
+from agent_bom.api.stores import _get_exception_store, _get_issue_mapping_store, _get_store, _get_trend_store
 from agent_bom.security import sanitize_error
 
 router = APIRouter()
@@ -198,6 +199,25 @@ def _feedback_response(exc: Any) -> dict[str, Any]:
         "expires_at": exc.expires_at,
         "tenant_id": exc.tenant_id,
     }
+
+
+def _jira_mapping_target(req: JiraTicketRequest) -> tuple[str, str]:
+    target_kind = req.target_kind or "finding"
+    if req.target_id:
+        return target_kind, req.target_id
+    finding = req.finding or {}
+    if target_kind == "exposure_path":
+        target_id = str(finding.get("exposure_path_id") or finding.get("path_id") or finding.get("id") or "")
+    else:
+        vuln_id = str(finding.get("vulnerability_id") or finding.get("cve_id") or finding.get("id") or "unknown")
+        package = str(finding.get("package") or finding.get("package_name") or "*")
+        server = str(finding.get("server_name") or finding.get("server") or "")
+        target_id = "|".join(part for part in (vuln_id, package, server) if part)
+    return target_kind, target_id[:256] or "unknown"
+
+
+def _jira_issue_url(jira_url: str, ticket_key: str) -> str:
+    return f"{jira_url.rstrip('/')}/browse/{ticket_key}"
 
 
 def _auth_session_state(request: Request) -> dict:
@@ -1318,6 +1338,17 @@ async def create_jira_ticket_route(
 
     if not jira_api_token:
         raise HTTPException(status_code=400, detail="Missing X-Jira-Api-Token header")
+    tenant_id = getattr(request.state, "tenant_id", "default")
+    actor = getattr(request.state, "api_key_name", "") or req.email or "system"
+    target_kind, target_id = _jira_mapping_target(req)
+    mapping_store = _get_issue_mapping_store()
+    existing = mapping_store.find(tenant_id=tenant_id, target_kind=target_kind, target_id=target_id, provider="jira")
+    if existing:
+        return {
+            "ticket_key": existing.external_id,
+            "status": "existing",
+            "mapping": existing.to_dict(),
+        }
 
     # Validate Jira URL to prevent SSRF
     try:
@@ -1340,8 +1371,15 @@ async def create_jira_ticket_route(
     if not ticket_key:
         raise HTTPException(status_code=502, detail="Jira API returned no ticket key")
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
-    actor = getattr(request.state, "api_key_name", "") or req.email or "system"
+    mapping = mapping_store.put(
+        tenant_id=tenant_id,
+        target_kind=target_kind,
+        target_id=target_id,
+        provider="jira",
+        external_id=ticket_key,
+        external_url=_jira_issue_url(req.jira_url, ticket_key),
+        status="open",
+    )
     log_action(
         "findings.jira_ticket_created",
         actor=actor,
@@ -1349,9 +1387,33 @@ async def create_jira_ticket_route(
         tenant_id=tenant_id,
         vuln_id=req.finding.get("vulnerability_id", ""),
         package=req.finding.get("package", ""),
+        issue_mapping_id=mapping.mapping_id,
+        target_kind=target_kind,
+        target_id=target_id,
     )
 
-    return {"ticket_key": ticket_key, "status": "created"}
+    return {"ticket_key": ticket_key, "status": "created", "mapping": mapping.to_dict()}
+
+
+@router.put("/v1/integrations/issues/{mapping_id}/status", tags=["enterprise"])
+async def update_issue_mapping_status(request: Request, mapping_id: str, req: IssueStatusUpdateRequest) -> dict:
+    """Update tenant-scoped external issue mapping status after provider sync."""
+    from agent_bom.api.audit_log import log_action
+
+    tenant_id = getattr(request.state, "tenant_id", "default")
+    actor = getattr(request.state, "api_key_name", "") or "system"
+    mapping = _get_issue_mapping_store().update_status(mapping_id, tenant_id=tenant_id, status=req.status)
+    if not mapping:
+        raise HTTPException(status_code=404, detail="Issue mapping not found")
+    log_action(
+        "integrations.issue_status_updated",
+        actor=actor,
+        resource=f"{mapping.provider}/{mapping.external_id}",
+        tenant_id=tenant_id,
+        issue_mapping_id=mapping.mapping_id,
+        status=mapping.status,
+    )
+    return {"mapping": mapping.to_dict()}
 
 
 # ── False Positive Management ────────────────────────────────────────────────

--- a/src/agent_bom/api/stores.py
+++ b/src/agent_bom/api/stores.py
@@ -17,6 +17,7 @@ from agent_bom.config import API_MAX_IN_MEMORY_JOBS as _MAX_IN_MEMORY_JOBS
 if TYPE_CHECKING:
     from agent_bom.api.credential_store import CredentialRefStore
     from agent_bom.api.graph_store import GraphStoreProtocol
+    from agent_bom.api.issue_mapping_store import IssueMappingStore
     from agent_bom.api.mcp_observation_store import MCPObservationStore
     from agent_bom.api.models import ScanJob
     from agent_bom.api.schedule_store import ScheduleStore
@@ -328,6 +329,7 @@ def set_scim_store(store: SCIMStore | None) -> None:
 _source_store: SourceStore | None = None
 _credential_ref_store: CredentialRefStore | None = None
 _mcp_observation_store: MCPObservationStore | None = None
+_issue_mapping_store: IssueMappingStore | None = None
 
 
 def _get_source_store() -> SourceStore:
@@ -377,6 +379,29 @@ def set_mcp_observation_store(store: Any) -> None:
     """Switch the MCP observation store backend."""
     global _mcp_observation_store
     _mcp_observation_store = store
+
+
+def _get_issue_mapping_store() -> IssueMappingStore:
+    """Get the tenant-scoped external issue mapping store."""
+    global _issue_mapping_store
+    if _issue_mapping_store is None:
+        with _store_lock:
+            if _issue_mapping_store is None:
+                if os.environ.get("AGENT_BOM_DB"):
+                    from agent_bom.api.issue_mapping_store import SQLiteIssueMappingStore
+
+                    _issue_mapping_store = SQLiteIssueMappingStore(os.environ["AGENT_BOM_DB"])
+                else:
+                    from agent_bom.api.issue_mapping_store import InMemoryIssueMappingStore
+
+                    _issue_mapping_store = InMemoryIssueMappingStore()
+    return _issue_mapping_store
+
+
+def set_issue_mapping_store(store: IssueMappingStore | None) -> None:
+    """Switch the issue mapping store backend."""
+    global _issue_mapping_store
+    _issue_mapping_store = store
 
 
 # ─── Exception store (enterprise) ───────────────────────────────────────────

--- a/tests/test_api_enterprise_tenant.py
+++ b/tests/test_api_enterprise_tenant.py
@@ -11,10 +11,19 @@ from fastapi import HTTPException
 from agent_bom.api.audit_log import AuditEntry, InMemoryAuditLog, get_audit_log, set_audit_log
 from agent_bom.api.auth import KeyStore, Role, create_api_key, get_key_store, set_key_store
 from agent_bom.api.exception_store import ExceptionStatus, InMemoryExceptionStore, VulnException
-from agent_bom.api.models import CreateKeyRequest, FindingFeedbackRequest, JobStatus, RotateKeyRequest, ScanJob, ScanRequest
+from agent_bom.api.issue_mapping_store import InMemoryIssueMappingStore
+from agent_bom.api.models import (
+    CreateKeyRequest,
+    FindingFeedbackRequest,
+    IssueStatusUpdateRequest,
+    JobStatus,
+    RotateKeyRequest,
+    ScanJob,
+    ScanRequest,
+)
 from agent_bom.api.routes import enterprise
 from agent_bom.api.store import InMemoryJobStore
-from agent_bom.api.stores import _get_store, _get_trend_store, set_job_store, set_trend_store
+from agent_bom.api.stores import _get_store, _get_trend_store, set_issue_mapping_store, set_job_store, set_trend_store
 from agent_bom.audit_integrity import compute_audit_record_mac
 from agent_bom.baseline import InMemoryTrendStore, TrendPoint
 
@@ -72,6 +81,16 @@ def isolated_audit_log():
         yield store
     finally:
         set_audit_log(original)
+
+
+@pytest.fixture
+def isolated_issue_mapping_store():
+    store = InMemoryIssueMappingStore()
+    set_issue_mapping_store(store)
+    try:
+        yield store
+    finally:
+        set_issue_mapping_store(None)
 
 
 @pytest.mark.asyncio
@@ -286,7 +305,7 @@ async def test_create_jira_ticket_requires_header_token(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_create_jira_ticket_uses_header_token(monkeypatch):
+async def test_create_jira_ticket_uses_header_token(monkeypatch, isolated_issue_mapping_store):
     req = enterprise.JiraTicketRequest(
         jira_url="https://example.atlassian.net",
         email="user@example.com",
@@ -311,9 +330,73 @@ async def test_create_jira_ticket_uses_header_token(monkeypatch):
 
     result = await enterprise.create_jira_ticket_route(_request("tenant-alpha"), req, jira_api_token="token-abc")
 
-    assert result == {"ticket_key": "SEC-42", "status": "created"}
+    assert result["ticket_key"] == "SEC-42"
+    assert result["status"] == "created"
+    assert result["mapping"]["tenant_id"] == "tenant-alpha"
+    assert result["mapping"]["target_kind"] == "finding"
+    assert result["mapping"]["provider"] == "jira"
+    assert result["mapping"]["external_id"] == "SEC-42"
     assert captured["api_token"] == "token-abc"
     assert captured["project_key"] == "SEC"
+
+
+@pytest.mark.asyncio
+async def test_create_jira_ticket_is_idempotent_by_tenant_target_provider(monkeypatch, isolated_issue_mapping_store):
+    req = enterprise.JiraTicketRequest(
+        jira_url="https://example.atlassian.net",
+        email="user@example.com",
+        project_key="SEC",
+        finding={"vulnerability_id": "CVE-1", "package": "pkg"},
+    )
+    calls = 0
+
+    async def fake_create_jira_ticket(*, jira_url: str, email: str, api_token: str, project_key: str, finding: dict):
+        nonlocal calls
+        calls += 1
+        return "SEC-42"
+
+    monkeypatch.setattr("agent_bom.integrations.jira.create_jira_ticket", fake_create_jira_ticket)
+
+    first = await enterprise.create_jira_ticket_route(_request("tenant-alpha"), req, jira_api_token="token-abc")
+    second = await enterprise.create_jira_ticket_route(_request("tenant-alpha"), req, jira_api_token="token-abc")
+
+    assert calls == 1
+    assert first["status"] == "created"
+    assert second["status"] == "existing"
+    assert second["mapping"]["id"] == first["mapping"]["id"]
+
+
+@pytest.mark.asyncio
+async def test_issue_mapping_status_update_is_tenant_scoped(isolated_issue_mapping_store):
+    alpha = isolated_issue_mapping_store.put(
+        tenant_id="tenant-alpha",
+        target_kind="finding",
+        target_id="CVE-1|pkg",
+        provider="jira",
+        external_id="SEC-42",
+        external_url="https://example.atlassian.net/browse/SEC-42",
+    )
+    beta = isolated_issue_mapping_store.put(
+        tenant_id="tenant-beta",
+        target_kind="finding",
+        target_id="CVE-1|pkg",
+        provider="jira",
+        external_id="SEC-43",
+        external_url="https://example.atlassian.net/browse/SEC-43",
+    )
+
+    result = await enterprise.update_issue_mapping_status(
+        _request("tenant-alpha"),
+        alpha.mapping_id,
+        IssueStatusUpdateRequest(status="done"),
+    )
+
+    assert result["mapping"]["status"] == "done"
+    assert isolated_issue_mapping_store.get(alpha.mapping_id, tenant_id="tenant-alpha").status == "done"
+    assert isolated_issue_mapping_store.get(beta.mapping_id, tenant_id="tenant-beta").status == "open"
+    with pytest.raises(HTTPException) as error:
+        await enterprise.update_issue_mapping_status(_request("tenant-beta"), alpha.mapping_id, IssueStatusUpdateRequest(status="done"))
+    assert error.value.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -354,6 +354,14 @@ def test_release_registry_gate_is_deterministic_without_live_sync():
     assert "agent-bom registry sync-all" not in workflow
 
 
+def test_release_consistency_checks_generated_data_model_atlas():
+    """The fast release gate should catch stale DATA_MODEL atlas counts before matrix tests."""
+    release_check = (ROOT / "scripts" / "check_release_consistency.py").read_text()
+    assert "_assert_data_model_atlas_current" in release_check
+    assert "scripts/regenerate_data_model_atlas.py" in release_check
+    assert "--check" in release_check
+
+
 def test_release_verifies_pypi_provenance_for_each_published_file():
     """The release workflow should fail if any uploaded PyPI file lacks provenance."""
     workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text()


### PR DESCRIPTION
Summary
- add a tenant-scoped provider-neutral issue mapping store with in-memory and SQLite backends
- make Jira ticket creation idempotent by tenant, target, and provider before calling the Jira API
- add a tenant-scoped status update endpoint for provider sync workflows

Verification
- uv run pytest tests/test_api_enterprise_tenant.py::test_create_jira_ticket_requires_header_token tests/test_api_enterprise_tenant.py::test_create_jira_ticket_uses_header_token tests/test_api_enterprise_tenant.py::test_create_jira_ticket_is_idempotent_by_tenant_target_provider tests/test_api_enterprise_tenant.py::test_issue_mapping_status_update_is_tenant_scoped -q
- uv run ruff check src/agent_bom/api/issue_mapping_store.py src/agent_bom/api/stores.py src/agent_bom/api/models.py src/agent_bom/api/routes/enterprise.py tests/test_api_enterprise_tenant.py
- uv run mypy src/agent_bom/api/issue_mapping_store.py src/agent_bom/api/stores.py src/agent_bom/api/models.py src/agent_bom/api/routes/enterprise.py
- python scripts/check_release_consistency.py
- git diff --check

Notes
- Closes #2622. This is the persistence/idempotency foundation; provider-specific background pollers can build on the mapping store.