### PR TITLE
fix(api): coordinate scan executor lifecycle

### DIFF
--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -18,7 +18,7 @@ import sys
 import threading
 import uuid
 from collections.abc import Iterable
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
@@ -54,22 +54,34 @@ _executor_lock = threading.RLock()
 _executor = ThreadPoolExecutor(max_workers=max(1, API_SCAN_WORKERS))
 _executor_active_jobs = 0
 _executor_completed_jobs = 0
+_executor_draining = False
 
 
 def get_executor() -> ThreadPoolExecutor:
     """Return the shared scan executor, recreating it if a prior lifespan shut it down."""
     global _executor
     with _executor_lock:
-        if _executor._shutdown:
+        if _executor._shutdown and not _executor_draining:
             _executor = ThreadPoolExecutor(max_workers=max(1, API_SCAN_WORKERS))
         return _executor
+
+
+def _executor_for_submission_locked() -> ThreadPoolExecutor:
+    """Return an executor that can accept work while ``_executor_lock`` is held."""
+
+    global _executor  # noqa: PLW0603
+    if _executor_draining:
+        raise RuntimeError("scan executor is draining during API shutdown")
+    if _executor._shutdown:
+        _executor = ThreadPoolExecutor(max_workers=max(1, API_SCAN_WORKERS))
+    return _executor
 
 
 def _recycle_executor_if_idle() -> None:
     global _executor  # noqa: PLW0603
     if API_SCAN_WORKER_RECYCLE_JOBS <= 0:
         return
-    if _executor_active_jobs != 0 or _executor_completed_jobs % API_SCAN_WORKER_RECYCLE_JOBS != 0:
+    if _executor_draining or _executor_active_jobs != 0 or _executor_completed_jobs % API_SCAN_WORKER_RECYCLE_JOBS != 0:
         return
     old_executor = _executor
     _executor = ThreadPoolExecutor(max_workers=max(1, API_SCAN_WORKERS))
@@ -77,30 +89,73 @@ def _recycle_executor_if_idle() -> None:
     _release_scan_memory()
 
 
+def _observe_scan_future(done_future: Future | Any) -> None:
+    global _executor_active_jobs, _executor_completed_jobs  # noqa: PLW0603
+    try:
+        exc = done_future.exception()
+        if exc is not None:
+            _logger.error("Unhandled API scan worker failure", exc_info=(type(exc), exc, exc.__traceback__))
+    except Exception:  # noqa: BLE001
+        _logger.exception("Failed to observe API scan worker completion")
+    finally:
+        with _executor_lock:
+            _executor_active_jobs = max(0, _executor_active_jobs - 1)
+            _executor_completed_jobs += 1
+            _recycle_executor_if_idle()
+
+
 def submit_scan_job(job: ScanJob) -> None:
     """Submit a scan job to the bounded worker pool and observe completion."""
-    global _executor_active_jobs, _executor_completed_jobs  # noqa: PLW0603
+    global _executor_active_jobs  # noqa: PLW0603
 
     with _executor_lock:
-        executor = get_executor()
+        executor = _executor_for_submission_locked()
         _executor_active_jobs += 1
-        future = executor.submit(_run_scan_sync, job)
-
-    def _done(done_future) -> None:
-        global _executor_active_jobs, _executor_completed_jobs  # noqa: PLW0603
         try:
-            exc = done_future.exception()
-            if exc is not None:
-                _logger.error("Unhandled API scan worker failure", exc_info=(type(exc), exc, exc.__traceback__))
-        except Exception:  # noqa: BLE001
-            _logger.exception("Failed to observe API scan worker completion")
-        finally:
-            with _executor_lock:
-                _executor_active_jobs = max(0, _executor_active_jobs - 1)
-                _executor_completed_jobs += 1
-                _recycle_executor_if_idle()
+            future = executor.submit(_run_scan_sync, job)
+        except Exception:
+            _executor_active_jobs = max(0, _executor_active_jobs - 1)
+            raise
 
-    future.add_done_callback(_done)
+    future.add_done_callback(_observe_scan_future)
+
+
+def submit_scheduled_scan_job(loop: Any, job: ScanJob) -> None:
+    """Submit a scheduler-owned scan on the shared worker pool.
+
+    ``asyncio`` callers must not call ``get_executor()`` and then
+    ``loop.run_in_executor()`` separately, because API shutdown can close the
+    pool between those operations. This helper keeps the lookup and submission
+    under the same lifecycle lock used by HTTP-triggered scans.
+    """
+
+    global _executor_active_jobs  # noqa: PLW0603
+
+    with _executor_lock:
+        executor = _executor_for_submission_locked()
+        _executor_active_jobs += 1
+        try:
+            future = loop.run_in_executor(executor, _run_scan_sync, job)
+        except Exception:
+            _executor_active_jobs = max(0, _executor_active_jobs - 1)
+            raise
+
+    future.add_done_callback(_observe_scan_future)
+
+
+def shutdown_scan_executor(*, wait: bool, cancel_futures: bool) -> None:
+    """Drain or cancel the shared scan executor without racing submissions."""
+
+    global _executor_draining  # noqa: PLW0603
+    with _executor_lock:
+        _executor_draining = True
+        executor = _executor
+    try:
+        executor.shutdown(wait=wait, cancel_futures=cancel_futures)
+    finally:
+        with _executor_lock:
+            if _executor is executor:
+                _executor_draining = False
 
 
 def _release_scan_memory() -> None:

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -416,7 +416,6 @@ async def _lifespan(app_instance: FastAPI):
     # Start scheduler background loop
     global _scheduler_task
     from agent_bom.api.pipeline import _now
-    from agent_bom.api.pipeline import _run_scan_sync as _run_scan  # local alias avoids F811 with re-export
     from agent_bom.api.scheduler import scheduler_loop
     from agent_bom.api.tenant_quota import enforce_active_scan_quota, enforce_retained_jobs_quota, tenant_quota_guard
 
@@ -450,7 +449,7 @@ async def _lifespan(app_instance: FastAPI):
             except Exception:  # noqa: BLE001
                 pass
         loop = asyncio.get_running_loop()
-        loop.run_in_executor(get_executor(), _run_scan, job)
+        submit_scheduled_scan_job(loop, job)
         return job.job_id
 
     _scheduler_task = asyncio.create_task(scheduler_loop(_get_schedule_store(), _schedule_scan))
@@ -473,7 +472,7 @@ async def _lifespan(app_instance: FastAPI):
     _drain_seconds = float(os.environ.get("AGENT_BOM_SHUTDOWN_DRAIN_SECONDS", "25"))
     try:
         await asyncio.wait_for(
-            asyncio.to_thread(lambda: get_executor().shutdown(wait=True, cancel_futures=False)),
+            asyncio.to_thread(lambda: shutdown_scan_executor(wait=True, cancel_futures=False)),
             timeout=_drain_seconds,
         )
     except asyncio.TimeoutError:
@@ -481,7 +480,7 @@ async def _lifespan(app_instance: FastAPI):
             "shutdown drain timeout after %.1fs; force-cancelling in-flight scans",
             _drain_seconds,
         )
-        get_executor().shutdown(wait=False, cancel_futures=True)
+        shutdown_scan_executor(wait=False, cancel_futures=True)
     # Close Postgres connection pool if active
     try:
         if os.environ.get("AGENT_BOM_POSTGRES_URL"):
@@ -709,6 +708,8 @@ from agent_bom.api.pipeline import (  # noqa: E402
     get_executor,  # noqa: F401 — re-exported for tests
     iter_pipeline_dag_event_records,  # noqa: F401 — re-exported for tests/artifact consumers
     pipeline_dag_events_jsonl,  # noqa: F401 — re-exported for tests/artifact consumers
+    shutdown_scan_executor,
+    submit_scheduled_scan_job,
 )
 from agent_bom.api.routes.agent_manifest import router as _agent_manifest_router  # noqa: E402
 

--- a/tests/test_api_store.py
+++ b/tests/test_api_store.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 from agent_bom.api.server import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.store import InMemoryJobStore, SQLiteJobStore
@@ -120,6 +123,50 @@ def test_scan_memory_release_is_best_effort(monkeypatch):
     monkeypatch.setattr(pipeline.ctypes, "CDLL", lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("missing libc")))
 
     pipeline._release_scan_memory()
+
+
+def test_scan_executor_recreates_after_shutdown() -> None:
+    from agent_bom.api import pipeline
+
+    pipeline.shutdown_scan_executor(wait=True, cancel_futures=False)
+
+    executor = pipeline.get_executor()
+
+    assert executor._max_workers >= 1
+    assert not executor._shutdown
+
+
+def test_scan_executor_rejects_submissions_while_draining() -> None:
+    from agent_bom.api import pipeline
+
+    with pipeline._executor_lock:
+        pipeline._executor_draining = True
+    try:
+        with pytest.raises(RuntimeError, match="scan executor is draining"):
+            pipeline.submit_scan_job(_make_job("during-drain"))
+    finally:
+        with pipeline._executor_lock:
+            pipeline._executor_draining = False
+
+
+def test_scheduled_scan_submission_uses_shared_lifecycle(monkeypatch) -> None:
+    from agent_bom.api import pipeline
+
+    completed: list[str] = []
+    monkeypatch.setattr(pipeline, "_run_scan_sync", lambda job: completed.append(job.job_id))
+
+    async def _run() -> None:
+        pipeline.shutdown_scan_executor(wait=True, cancel_futures=False)
+        loop = asyncio.get_running_loop()
+        pipeline.submit_scheduled_scan_job(loop, _make_job("scheduled-after-shutdown"))
+        for _ in range(20):
+            if completed:
+                return
+            await asyncio.sleep(0.01)
+
+    asyncio.run(_run())
+
+    assert completed == ["scheduled-after-shutdown"]
 
 
 def test_compacted_hot_cache_job_hydrates_full_scan_response(monkeypatch):


### PR DESCRIPTION
Summary

- coordinate scan worker submissions, scheduler submissions, executor recycling, and shutdown through one lifecycle lock
- fail closed for new scan submissions while the API is draining during shutdown
- keep executor recreation recoverable after lifespan shutdown for tests and subsequent local API boots

Verification

- uv run pytest tests/test_api_store.py::test_scan_executor_recreates_after_shutdown tests/test_api_store.py::test_scan_executor_rejects_submissions_while_draining tests/test_api_store.py::test_scheduled_scan_submission_uses_shared_lifecycle -q
- uv run pytest tests/test_api_store.py -q
- uv run ruff check src/agent_bom/api/pipeline.py src/agent_bom/api/server.py tests/test_api_store.py
- uv run mypy src/agent_bom/api/pipeline.py src/agent_bom/api/server.py
- python scripts/check_release_consistency.py
- git diff --check

Notes

- Addresses the residual API ThreadPool lifecycle race audit item without changing scan result semantics.