### PR TITLE
fix(graph): optimize delta alert scans

### DIFF
--- a/src/agent_bom/graph/webhooks.py
+++ b/src/agent_bom/graph/webhooks.py
@@ -86,12 +86,16 @@ def compute_delta_alerts(
     """
     alerts: list[dict[str, Any]] = []
 
-    old_node_ids = set(old_graph.nodes) if old_graph else set()
-    new_node_ids = set(new_graph.nodes)
+    old_nodes = old_graph.nodes if old_graph else {}
 
-    # ── New critical/high vulnerabilities ────────────────────────────
-    for nid in new_node_ids - old_node_ids:
-        node = new_graph.nodes[nid]
+    # ── New critical/high findings ───────────────────────────────────
+    # Large control-plane snapshots are usually dominated by unchanged
+    # inventory nodes. Walk the new node mapping once and use O(1) membership
+    # against the prior snapshot instead of materializing full node-id
+    # difference sets or scanning the same delta twice.
+    for nid, node in new_graph.nodes.items():
+        if nid in old_nodes:
+            continue
         if node.entity_type == EntityType.VULNERABILITY and SEVERITY_RANK.get(node.severity, 0) >= 4:
             details = {
                 "node_ids": [nid],
@@ -124,11 +128,7 @@ def compute_delta_alerts(
                     },
                 }
             )
-
-    # ── New misconfigurations ────────────────────────────────────────
-    for nid in new_node_ids - old_node_ids:
-        node = new_graph.nodes[nid]
-        if node.entity_type == EntityType.MISCONFIGURATION and SEVERITY_RANK.get(node.severity, 0) >= 4:
+        elif node.entity_type == EntityType.MISCONFIGURATION and SEVERITY_RANK.get(node.severity, 0) >= 4:
             details = {
                 "node_ids": [nid],
                 "scan_id": new_graph.scan_id,
@@ -234,9 +234,8 @@ def compute_delta_alerts(
             )
 
     # ── Nodes removed (potential drift) ──────────────────────────────
-    removed = old_node_ids - new_node_ids
-    if removed and old_graph:
-        agent_removed = [nid for nid in removed if old_graph.nodes[nid].entity_type == EntityType.AGENT]
+    if old_graph:
+        agent_removed = [nid for nid, node in old_nodes.items() if nid not in new_graph.nodes and node.entity_type == EntityType.AGENT]
         if agent_removed:
             details = {
                 "node_ids": agent_removed,

--- a/tests/test_graph_wave23.py
+++ b/tests/test_graph_wave23.py
@@ -171,6 +171,24 @@ class TestDeltaAlerts:
         assert len(removed) == 1
         assert "agent:b" in removed[0]["node_ids"]
 
+    def test_delta_alerts_handle_large_stable_snapshots_without_noise(self):
+        from agent_bom.graph.webhooks import compute_delta_alerts
+
+        old = UnifiedGraph(scan_id="s1")
+        new = UnifiedGraph(scan_id="s2")
+        for idx in range(5000):
+            old.add_node(UnifiedNode(id=f"package:p{idx}", entity_type=EntityType.PACKAGE, label=f"p{idx}"))
+            new.add_node(UnifiedNode(id=f"package:p{idx}", entity_type=EntityType.PACKAGE, label=f"p{idx}"))
+
+        old.add_node(UnifiedNode(id="agent:removed", entity_type=EntityType.AGENT, label="removed"))
+        new.add_node(UnifiedNode(id="vuln:CVE-new", entity_type=EntityType.VULNERABILITY, label="CVE-new", severity="high"))
+
+        alerts = compute_delta_alerts(old, new)
+
+        assert [alert["type"] for alert in alerts] == ["new_vulnerability", "agent_removed"]
+        assert alerts[0]["node_ids"] == ["vuln:CVE-new"]
+        assert alerts[1]["node_ids"] == ["agent:removed"]
+
     def test_first_scan_no_old_graph(self):
         from agent_bom.graph.webhooks import compute_delta_alerts
 


### PR DESCRIPTION
Summary

- scan new graph nodes once when computing delta alerts instead of materializing full old/new node-id sets
- preserve vulnerability, misconfiguration, attack-path, interaction-risk, and removed-agent alert semantics
- add a large stable snapshot regression so unchanged inventory does not produce noisy alerts

Verification

- uv run pytest tests/test_graph_wave23.py::TestDeltaAlerts -q
- uv run ruff check src/agent_bom/graph/webhooks.py tests/test_graph_wave23.py
- uv run mypy src/agent_bom/graph/webhooks.py
- python scripts/check_release_consistency.py
- git diff --check

Notes

Closes the residual graph delta performance polish item for large mostly-stable snapshots.