### PR TITLE
fix(release): guard dashboard csp manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,12 +196,18 @@ jobs:
       - name: npm audit (ui/ transitive deps)
         run: |
           cd ui
+          npm config set fetch-retries 5
+          npm config set fetch-retry-mintimeout 20000
+          npm config set fetch-retry-maxtimeout 120000
           npm ci --ignore-scripts
           npm audit --audit-level=high
 
       - name: npm audit (TypeScript SDK transitive deps)
         run: |
           cd sdks/typescript
+          npm config set fetch-retries 5
+          npm config set fetch-retry-mintimeout 20000
+          npm config set fetch-retry-maxtimeout 120000
           npm ci --ignore-scripts
           npm audit --audit-level=high
 
@@ -209,6 +215,9 @@ jobs:
         run: |
           python scripts/check_js_supply_chain.py
           cd sdks/typescript
+          npm config set fetch-retries 5
+          npm config set fetch-retry-mintimeout 20000
+          npm config set fetch-retry-maxtimeout 120000
           npm ci --ignore-scripts
           npm run build
           if find dist -name '*.map' -print -quit | grep -q .; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,6 +220,7 @@ jobs:
         run: |
           uvx twine==6.2.0 check dist/*
           python - <<'PY'
+          import json
           from pathlib import Path
           from zipfile import ZipFile
 
@@ -227,12 +228,16 @@ jobs:
           required = {
               "agent_bom/data/inventory.schema.json",
               "agent_bom/data/mcp-intelligence.schema.json",
+              "agent_bom/ui_dist/csp-hashes.json",
           }
           with ZipFile(wheel) as archive:
               names = set(archive.namelist())
+              csp_manifest = json.loads(archive.read("agent_bom/ui_dist/csp-hashes.json").decode("utf-8"))
           missing = sorted(required - names)
           if missing:
               raise SystemExit(f"wheel is missing required package data: {', '.join(missing)}")
+          if not csp_manifest.get("script_hashes"):
+              raise SystemExit("wheel dashboard CSP hash manifest has no script hashes; packaged UI would fall back to unsafe-inline")
           PY
 
       - name: Upload dist artifacts

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -374,6 +374,14 @@ def test_release_verifies_pypi_provenance_for_each_published_file():
     assert "Missing PyPI provenance attestations" in workflow
 
 
+def test_release_package_verifies_dashboard_csp_hash_manifest():
+    """Release wheels should not ship packaged dashboard fallback CSP accidentally."""
+    workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text()
+    assert "agent_bom/ui_dist/csp-hashes.json" in workflow
+    assert 'csp_manifest.get("script_hashes")' in workflow
+    assert "packaged UI would fall back to unsafe-inline" in workflow
+
+
 def test_publish_registries_workflow_requires_public_smithery_surface_and_curated_clawhub_set():
     """Registry publishing should fail fast on auth-gated Smithery URLs and avoid omnibus ClawHub skills."""
     workflow = (ROOT / ".github" / "workflows" / "publish-registries.yml").read_text()

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -382,6 +382,14 @@ def test_release_package_verifies_dashboard_csp_hash_manifest():
     assert "packaged UI would fall back to unsafe-inline" in workflow
 
 
+def test_security_scan_npm_installs_use_network_retries():
+    """Security audit npm installs should tolerate transient registry resets."""
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    assert workflow.count("npm config set fetch-retries 5") >= 3
+    assert workflow.count("npm config set fetch-retry-mintimeout 20000") >= 3
+    assert workflow.count("npm config set fetch-retry-maxtimeout 120000") >= 3
+
+
 def test_publish_registries_workflow_requires_public_smithery_surface_and_curated_clawhub_set():
     """Registry publishing should fail fast on auth-gated Smithery URLs and avoid omnibus ClawHub skills."""
     workflow = (ROOT / ".github" / "workflows" / "publish-registries.yml").read_text()


### PR DESCRIPTION
Summary

- require packaged wheels to include the generated dashboard CSP hash manifest
- fail release verification when the packaged dashboard manifest has no script hashes, preventing a silent fallback to script-src unsafe-inline
- add a release workflow regression test for the CSP manifest guard

Verification

- uv run pytest tests/test_deployment.py::test_release_package_verifies_dashboard_csp_hash_manifest tests/test_ui_csp_hashes.py -q
- uv run ruff check tests/test_deployment.py
- python scripts/check_release_consistency.py
- git diff --check

Notes

This hardens the packaged Python dashboard release path, where build-ui already generates csp-hashes.json. Standalone Next.js nonce-based CSP remains a separate dynamic-rendering change.