### PR TITLE
test(api): avoid tenant scan background work

### DIFF
--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -346,6 +346,7 @@ async def test_create_scan_and_push_stamp_request_tenant(monkeypatch):
             return None
 
     monkeypatch.setattr(scan_routes.asyncio, "get_running_loop", lambda: _Loop())
+    monkeypatch.setattr(scan_routes, "submit_scan_job", lambda _job: None)
 
     created = await scan_routes.create_scan(req, ScanRequest())
     assert created.tenant_id == "tenant-alpha"


### PR DESCRIPTION
Summary
- keep the tenant isolation route test from launching a real background scan worker
- preserve the tenant stamping assertions while preventing post-test MCP discovery/enrichment noise
- closes the release-audit lifecycle-noise finding without changing production scan behavior

Verification
- uv run pytest tests/test_api_tenant_isolation.py::test_create_scan_and_push_stamp_request_tenant -q -s
- uv run ruff check tests/test_api_tenant_isolation.py
- python scripts/check_release_consistency.py
- git diff --check

Notes
- Test-only cleanup. The production scan executor lifecycle remains unchanged.