### PR TITLE
fix(api): add fleet agents list alias

### DIFF
--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -2,6 +2,7 @@
 
 Endpoints:
     GET   /v1/fleet                   list fleet agents (filterable)
+    GET   /v1/fleet/agents            alias for list fleet agents
     GET   /v1/fleet/stats             fleet-wide statistics
     GET   /v1/fleet/{agent_id}        single agent with trust breakdown
     POST  /v1/fleet/sync              discovery + sync to fleet registry
@@ -78,6 +79,7 @@ def _request_header(request: Request, key: str) -> str:
 
 
 @router.get("/v1/fleet", tags=["fleet"])
+@router.get("/v1/fleet/agents", tags=["fleet"], include_in_schema=False)
 async def list_fleet(
     request: Request,
     state: str | None = None,

--- a/tests/test_api_fleet.py
+++ b/tests/test_api_fleet.py
@@ -78,6 +78,18 @@ def test_list_empty():
     assert data["count"] == 0
 
 
+def test_list_agents_alias_does_not_hit_agent_detail_route():
+    client, store = _fresh_client()
+    store.put(_make(agent_id="a-1", name="one"))
+
+    resp = client.get("/v1/fleet/agents")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 1
+    assert data["agents"][0]["agent_id"] == "a-1"
+
+
 def test_list_with_agents():
     client, store = _fresh_client()
     store.put(_make(agent_id="a-1", name="one"))


### PR DESCRIPTION
Summary
- add /v1/fleet/agents as a list alias for the fleet registry envelope
- keep the alias out of OpenAPI to avoid duplicating the canonical /v1/fleet route
- add a regression so /v1/fleet/agents does not fall through to the single-agent route

Verification
- uv run pytest tests/test_api_fleet.py::test_list_agents_alias_does_not_hit_agent_detail_route tests/test_api_fleet.py::test_list_empty -q
- uv run ruff check src/agent_bom/api/routes/fleet.py tests/test_api_fleet.py
- python scripts/check_release_consistency.py
- git diff --check

Notes
- Additive API UX alias; canonical documented route remains /v1/fleet.