### PR TITLE
docs(product): align trust contract surfaces

### DIFF
--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -1,7 +1,10 @@
 # Permissions & Trust Contract
 
-agent-bom is a **read-only security scanner**. This document is an explicit,
-auditable contract of what the tool accesses — and what it never touches.
+agent-bom's scanner lane is **read-only by default**. This document is an
+explicit, auditable contract of what the local scan path accesses — and what it
+never touches. Control-plane, connector, export, proxy/gateway, and Shield
+surfaces have separate operator-approved destinations or write actions called
+out below.
 
 ---
 
@@ -113,10 +116,12 @@ Credential values are **never** read, stored, logged, or transmitted. Only names
 
 ---
 
-## External API Calls (exhaustive list)
+## Scanner and Enrichment API Calls
 
-All network calls are read-only GET/POST to public vulnerability databases.
-Only package names and versions are sent. No user data is included in requests.
+Scanner and enrichment network calls are read-only GET/POST requests to public
+vulnerability and package metadata databases. Only package names, versions,
+CVE IDs, or repository coordinates needed for that lookup are sent. No config
+contents or credential values are included in those requests.
 
 | Service | URL | What we send | What we receive | Auth |
 |---------|-----|-------------|----------------|------|
@@ -127,10 +132,24 @@ Only package names and versions are sent. No user data is included in requests.
 | npm registry | `https://registry.npmjs.org/{pkg}/{version}` | Package name + version | Package metadata | None |
 | PyPI | `https://pypi.org/pypi/{pkg}/{version}/json` | Package name + version | Package metadata | None |
 | OpenSSF Scorecard | `https://api.securityscorecards.dev/projects/github.com/{owner}/{repo}` | GitHub owner/repo | Scorecard scores | None |
-| Jira (optional) | `https://{instance}.atlassian.net/rest/api/3/issue` | Finding summaries | Ticket confirmation | API token (`--jira-token`) |
-| Slack (optional) | User-provided webhook URL | Finding summaries | Delivery status | Webhook URL (`--slack-webhook`) |
-| Vanta (optional) | `https://api.vanta.com/v1/` | Compliance evidence | Upload confirmation | API token (`--vanta-token`) |
-| Drata (optional) | `https://public-api.drata.com/` | Compliance evidence | Upload confirmation | API token (`--drata-token`) |
+## Explicit Push, Export, and Integration Destinations
+
+The destinations below are not hidden telemetry. They are only used when an
+operator configures the corresponding flag, URL, token, connector, or control
+plane setting.
+
+| Destination | Example URL | What we send | Auth |
+|-------------|-------------|--------------|------|
+| Push API / control plane | User-provided `--push-url` or API base URL | Sanitized findings, inventory, graph, or audit payloads | API key or bearer token |
+| Webhook outbox | User-provided webhook URL | Signed posture events and delivery metadata | Operator-provided secret/token |
+| SIEM / audit export | User-provided export destination or `/v1/audit/export` consumer | OCSF-shaped audit events | Deployment-specific |
+| OTLP / Prometheus Pushgateway | User-provided collector endpoint | Metrics/traces, no credential values | Deployment-specific |
+| Jira (optional) | `https://{instance}.atlassian.net/rest/api/3/issue` | Finding summaries | API token (`--jira-token`) |
+| Slack (optional) | User-provided webhook URL | Finding summaries | Webhook URL (`--slack-webhook`) |
+| Vanta (optional) | `https://api.vanta.com/v1/` | Compliance evidence | API token (`--vanta-token`) |
+| Drata (optional) | `https://public-api.drata.com/` | Compliance evidence | API token (`--drata-token`) |
+| SaaS connectors | Connector-specific API URL | Connector evidence requested by the operator | Connector-specific token |
+| AI enrichment | Operator-provided LLM endpoint | Redacted finding context for enrichment | Operator-provided key |
 
 ### Data flow
 
@@ -139,18 +158,21 @@ Only package names and versions are sent. No user data is included in requests.
                           ↓
 [Package names+versions]  →  sent to OSV.dev, NVD, EPSS, KEV, npm, PyPI, OpenSSF Scorecard
                           ↓
-[Findings (optional)]     →  sent to Jira, Slack, Vanta, Drata (only if flags provided)
+[Findings (optional)]     →  sent to configured push/export/integration destinations
                           ↓
 [CVE results]  →  returned to local process, written to stdout or --output file
 ```
 
-- **Sent to APIs**: package name + version only (e.g., `express@4.17.1`)
+- **Sent to scanner/enrichment APIs**: package name + version, CVE ID, or repository coordinate only
 - **Returned from APIs**: CVE IDs, severity scores, advisory URLs
-- **Never sent**: file paths, config contents, env var values, scan results, hostnames, IP addresses
+- **Never sent to public scanner/enrichment APIs**: file paths, config contents, env var values, scan results, hostnames, IP addresses
+- **Sent to configured destinations**: only the sanitized payload for the explicit push, export, connector, or webhook action the operator enabled
 
 All external calls can be completely disabled with `--no-scan` (inventory-only mode).
 
-**No telemetry, analytics, or tracking.** Zero network calls unless scanning for vulnerabilities.
+**No hidden telemetry, analytics, or tracking.** Network calls occur only for
+requested scanner/enrichment lookups or explicitly configured push, export,
+connector, webhook, metrics, trace, or AI-enrichment destinations.
 
 ---
 
@@ -206,7 +228,7 @@ This is an open-source tool — you can verify every claim above:
 | Verification | How |
 |---|---|
 | Read source code | `src/agent_bom/` — all scanning logic is in plain Python |
-| Audit network calls | `grep -rn "osv.dev\|nvd.nist\|first.org\|cisa.gov\|npmjs.org\|pypi.org" src/agent_bom/` — exhaustive list of all outbound URLs |
+| Audit scanner/enrichment calls | `grep -rn "osv.dev\|nvd.nist\|first.org\|cisa.gov\|npmjs.org\|pypi.org" src/agent_bom/` — public vulnerability and package metadata lookups used by scanner/enrichment paths |
 | Audit file access | `grep -rn "open(\|Path(" src/agent_bom/discovery/` — all file reads in the discovery module |
 | Audit credential handling | `src/agent_bom/models.py` — `MCPServer.credential_names` property + `SENSITIVE_PATTERNS` in `security.py` |
 | Inspect boundary contract | `agent-bom trust --format json` — code-generated data, network, storage, auth, and SCIM boundaries surfaced through CLI/API/UI |

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -64,14 +64,12 @@ the CLI, reports, and browser cockpit. AI agents use the MCP/API/CLI surfaces
 to request the same `ExposurePath` evidence, skill verdicts, and deploy
 decisions under the same auth, tenant, and audit boundary.
 
-That is the useful lesson from developer-observability products: the cockpit is
-valuable, but the product primitive must be callable. `agent-bom` is
-Langfuse-like in shape only: humans get a cockpit and agents get callable
-primitives, but the primitive is not a trace. It is graph-backed security
-evidence: `ExposurePath`, findings, skill verdicts, compliance tags, runtime
-audit, and deploy decisions. Public copy should describe this as an open
-security data plane only when paired with exact shipped surfaces and roadmap
-boundaries.
+The useful lesson from developer-observability products is that the cockpit is
+valuable, but the product primitive must be callable. `agent-bom` gives humans
+a cockpit and agents strict-argument tools over graph-backed security evidence:
+`ExposurePath`, findings, skill verdicts, compliance tags, runtime audit, and
+deploy decisions. Public copy should describe this as an open security data
+plane only when paired with exact shipped surfaces and roadmap boundaries.
 
 This framing does not narrow the deployment story. It makes "deploy in your
 own cloud / infrastructure" the production form of lane 2, with runtime

--- a/integrations/docker-mcp-registry/SUBMISSION.md
+++ b/integrations/docker-mcp-registry/SUBMISSION.md
@@ -5,7 +5,7 @@ Submission files for listing agent-bom in the Docker Desktop MCP Toolkit catalog
 ## Files
 
 - `server.yaml` — server metadata, image, allowed hosts, optional secrets
-- `tools.json` — all 41 MCP tools with descriptions and parameters
+- `tools.json` — all 55 MCP tools with descriptions and parameters
 - `readme.md` — Docker MCP Toolkit detail page content
 
 ## How to submit

--- a/integrations/docker-mcp-registry/readme.md
+++ b/integrations/docker-mcp-registry/readme.md
@@ -1,8 +1,8 @@
 # agent-bom
 
-Open security scanner and graph for agentic infrastructure — discover agents and MCP, map blast radius, and inspect runtime.
+Open security scanner and self-hosted control plane for agentic infrastructure — discover agents and MCP, map blast radius, and inspect selected runtime paths.
 
-Discovers AI agents and MCP servers, scans packages, images, filesystems, IaC, and cloud AI infrastructure, maps blast radius showing which credentials and tools each CVE reaches, enforces policy in real time, and generates compliance evidence.
+Discovers AI agents and MCP servers, scans packages, images, filesystems, IaC, and cloud AI infrastructure, maps blast radius showing which credential names and tools each CVE reaches, applies optional proxy/gateway policy to selected MCP traffic, and generates compliance evidence.
 
 Package risk is only the start. agent-bom maps what it can reach across MCP servers, agents, credentials, tools, and runtime context.
 
@@ -21,7 +21,7 @@ docker run --rm -v "$(pwd):/workspace" agentbom/agent-bom agents -p /workspace -
 
 ## What it scans
 
-- **30 MCP client types** — Claude Desktop, Cursor, Windsurf, VS Code Copilot, and more
+- **29 first-class MCP client types** — Claude Desktop, Cursor, Windsurf, VS Code Copilot, and more
 - **Packages** — npm, pip, cargo, go modules, OS packages via OSV, NVD, EPSS, CISA KEV
 - **Containers** — Docker images with native OCI package discovery
 - **IaC** — Dockerfile, Kubernetes, Terraform, CloudFormation, Helm (89 rules)

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -65,9 +65,9 @@ The dashboard is not the only door into the product. It is the human cockpit
 over the same evidence that agents can request through MCP and platforms can
 consume through API, CLI, reports, and exports.
 
-This is Langfuse-like in shape only: humans get a cockpit and agents get
-callable primitives, but `agent-bom` works on security evidence and
-`ExposurePath` graphs rather than LLM traces or evals.
+The product shape is cockpit plus callable primitives: humans get a review
+surface and agents get strict-argument tools over the same security evidence
+and `ExposurePath` graphs.
 
 ## Current graph and agent surfaces
 
@@ -106,7 +106,7 @@ SLO or openCypher endpoint.
 | **Discovery** | Auto-detect 29 first-class MCP client types plus dynamic/project surfaces |
 | **CVE scanning** | OSV + NVD CVSS v4 + EPSS + CISA KEV + GHSA |
 | **Blast radius** | Map CVE impact: package → vulnerability finding → MCP server (tools + credential env names) → connected agents |
-| **Registry** | 427+ MCP server security metadata entries |
+| **Registry** | 738 MCP server security metadata entries |
 | **Compliance** | OWASP LLM/Agentic/MCP Top 10, MITRE ATLAS, EU AI Act, NIST AI RMF, CIS |
 | **Runtime proxy** | Policy enforcement, credential leak detection, audit logging |
 | **SBOM** | CycloneDX 1.6, SPDX 3.0 output |

--- a/src/agent_bom/mcp_server_factory.py
+++ b/src/agent_bom/mcp_server_factory.py
@@ -12,10 +12,10 @@ def _server_instructions(version: str) -> str:
         f"agent-bom v{version} — AI infrastructure security scanner with MCP security tools. "
         "Scans packages and images for CVEs (OSV, NVD, EPSS, CISA KEV), maps blast radius "
         "from vulnerabilities to credentials and tools, generates SBOMs (CycloneDX, SPDX), "
-        "enforces security policies, and maps to 14 compliance frameworks"
+        "checks security policies, and maps to 14 compliance frameworks"
         "(OWASP LLM/MCP/Agentic, MITRE ATLAS, NIST AI RMF/CSF/800-53, FedRAMP, EU AI Act, ISO 27001, SOC 2). "
         "Discovers 29 first-class MCP client types plus dynamic/project surfaces. "
-        "Read-only, agentless, no credentials required."
+        "Scanner and posture tools are read-only; Shield write actions require admin role and an audit reason."
     )
 
 

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -74,3 +74,21 @@ def test_public_docs_do_not_overclaim_smithery_catalog_liveness() -> None:
     assert "agent-bom is published in the [Smithery]" not in smithery_doc
     assert "Also on [Glama]" not in readme
     assert "Smithery manifest" in readme
+
+
+def test_permissions_doc_keeps_network_boundary_scoped() -> None:
+    permissions = (ROOT / "docs" / "PERMISSIONS.md").read_text(encoding="utf-8")
+
+    assert "External API Calls (exhaustive list)" not in permissions
+    assert "exhaustive list of all outbound URLs" not in permissions
+    assert "Zero network calls unless scanning for vulnerabilities" not in permissions
+    assert "No hidden telemetry, analytics, or tracking." in permissions
+    assert "Explicit Push, Export, and Integration Destinations" in permissions
+
+
+def test_mcp_server_instructions_do_not_overclaim_read_only_surface() -> None:
+    factory = (ROOT / "src" / "agent_bom" / "mcp_server_factory.py").read_text(encoding="utf-8")
+
+    assert "Read-only, agentless, no credentials required." not in factory
+    assert "Scanner and posture tools are read-only" in factory
+    assert "Shield write actions require admin role and an audit reason" in factory

--- a/tests/test_stats_alignment.py
+++ b/tests/test_stats_alignment.py
@@ -92,6 +92,12 @@ def _count_test_files() -> int:
     return len(list((ROOT / "tests").glob("test_*.py")))
 
 
+def _count_mcp_registry_servers() -> int:
+    """Count bundled MCP registry server records."""
+    data = json.loads((SRC / "mcp_registry.json").read_text())
+    return int(data.get("_total_servers") or len(data.get("servers", [])))
+
+
 def _graph_taxonomy_counts() -> tuple[int, int]:
     """Count canonical graph entities and relationships from code."""
     from agent_bom.graph import EntityType, RelationshipType
@@ -111,6 +117,7 @@ ACTUAL_DETECTORS = _count_detector_classes()
 ACTUAL_CLOUD_PROVIDERS = _count_cloud_providers()
 ACTUAL_MODULES = _count_python_modules()
 ACTUAL_TEST_FILES = _count_test_files()
+ACTUAL_MCP_REGISTRY_SERVERS = _count_mcp_registry_servers()
 ACTUAL_GRAPH_ENTITY_TYPES, ACTUAL_GRAPH_RELATIONSHIP_TYPES = _graph_taxonomy_counts()
 
 
@@ -249,6 +256,10 @@ class TestMarkdownStats:
         assert not missing_entities, f"DATA_MODEL.md missing graph entities: {missing_entities}"
         assert not missing_relationships, f"DATA_MODEL.md missing graph relationships: {missing_relationships}"
 
+    def test_site_index_registry_count_matches_bundled_registry(self):
+        text = (ROOT / "site-docs" / "index.md").read_text()
+        assert f"{ACTUAL_MCP_REGISTRY_SERVERS} MCP server security metadata entries" in text
+
 
 # ---------------------------------------------------------------------------
 # Integration files alignment
@@ -257,6 +268,31 @@ class TestMarkdownStats:
 
 class TestIntegrationStats:
     """Verify integration metadata reflects actual counts."""
+
+    def test_docker_mcp_tools_json_matches_tool_count(self):
+        path = ROOT / "integrations" / "docker-mcp-registry" / "tools.json"
+        if not path.exists():
+            pytest.skip("Docker MCP tools.json not found")
+        data = json.loads(path.read_text())
+        assert len(data) == ACTUAL_MCP_TOOLS
+
+    def test_docker_mcp_submission_tool_count_matches_code(self):
+        path = ROOT / "integrations" / "docker-mcp-registry" / "SUBMISSION.md"
+        if not path.exists():
+            pytest.skip("Docker MCP submission docs not found")
+        text = path.read_text()
+        assert f"all {ACTUAL_MCP_TOOLS} MCP tools" in text
+        assert "all 41 MCP tools" not in text
+
+    def test_docker_mcp_readme_client_count_matches_code(self):
+        from agent_bom.discovery.coverage import supported_clients
+
+        path = ROOT / "integrations" / "docker-mcp-registry" / "readme.md"
+        if not path.exists():
+            pytest.skip("Docker MCP readme not found")
+        text = path.read_text()
+        assert f"{len(supported_clients())} first-class MCP client types" in text
+        assert "30 MCP client types" not in text
 
     def test_mcp_registry_version_matches(self):
         from agent_bom import __version__
@@ -317,3 +353,4 @@ def test_print_actual_counts(capsys):
     print(f"Cloud providers:          {ACTUAL_CLOUD_PROVIDERS}")
     print(f"Python modules:           {ACTUAL_MODULES}")
     print(f"Test files:               {ACTUAL_TEST_FILES}")
+    print(f"MCP registry servers:     {ACTUAL_MCP_REGISTRY_SERVERS}")


### PR DESCRIPTION
Summary

- align Docker MCP registry submission/readme copy with the current 55-tool MCP surface and 29 first-class MCP client discovery matrix
- scope runtime-enforcement wording to optional proxy/gateway policy on selected MCP traffic
- remove product-name comparison copy from public docs and add stats guards for Docker MCP listing, site registry count, outbound-boundary wording, and MCP read-only claims
- scope the permissions trust contract to the scanner lane and explicitly separate configured push, export, connector, webhook, metrics, trace, and AI-enrichment destinations
- narrow MCP server instructions so the full server is not described as universally read-only now that Shield write tools exist

Verification

- uv run pytest tests/test_stats_alignment.py::TestIntegrationStats tests/test_stats_alignment.py::TestMarkdownStats::test_site_index_registry_count_matches_bundled_registry tests/test_public_docs_cli_alignment.py::test_permissions_doc_keeps_network_boundary_scoped tests/test_public_docs_cli_alignment.py::test_mcp_server_instructions_do_not_overclaim_read_only_surface -q
- uv run ruff check src/agent_bom/mcp_server_factory.py tests/test_stats_alignment.py tests/test_public_docs_cli_alignment.py
- python scripts/check_release_consistency.py
- git diff --check

Notes

- Documentation, server instruction text, and regression guards only; no runtime behavior changes.
- Supersedes #2767.
