### PR TITLE
fix(auth): allow modern OIDC signing algorithms

### DIFF
--- a/src/agent_bom/api/oidc.py
+++ b/src/agent_bom/api/oidc.py
@@ -52,6 +52,7 @@ logger = logging.getLogger(__name__)
 
 _JWKS_CACHE_TTL = 3600  # seconds — re-fetch public keys every hour
 _OIDC_TIMEOUT = 5  # seconds for HTTP requests to OIDC provider
+OIDC_ALLOWED_ALGORITHMS = ("RS256", "ES256", "RS384", "ES384", "RS512", "ES512", "EdDSA")
 _oidc_failure_lock = threading.Lock()
 _oidc_decode_failures = 0
 
@@ -254,7 +255,7 @@ def verify_oidc_token(
         raise OIDCError(f"Failed to resolve signing key: {exc}") from exc
 
     decode_kwargs: dict = {
-        "algorithms": ["RS256", "ES256", "RS384", "ES384", "RS512"],
+        "algorithms": list(OIDC_ALLOWED_ALGORITHMS),
         "issuer": issuer,
         "options": {"require": ["exp", "iat", "iss"]},
     }

--- a/tests/test_api_oidc.py
+++ b/tests/test_api_oidc.py
@@ -348,6 +348,34 @@ def test_verify_raises_oidc_error_on_bad_jwt():
                     verify_oidc_token("not.a.real.jwt", "https://example.com", jwks_uri="https://example.com/.well-known/jwks.json")
 
 
+def test_verify_oidc_token_allows_modern_asymmetric_algorithms():
+    from agent_bom.api.oidc import OIDC_ALLOWED_ALGORITHMS, verify_oidc_token
+
+    mock_jwks_client = MagicMock()
+    mock_signing_key = MagicMock()
+    mock_signing_key.key = "public-key"
+    mock_jwks_client.get_signing_key_from_jwt.return_value = mock_signing_key
+
+    mock_jwt_module = MagicMock()
+    mock_jwt_module.PyJWKClient.return_value = mock_jwks_client
+    mock_jwt_module.PyJWTError = Exception
+    mock_jwt_module.decode.return_value = {
+        "sub": "user-1",
+        "iss": "https://example.com",
+        "exp": 1,
+        "iat": 1,
+    }
+
+    with patch("agent_bom.api.oidc._check_pyjwt"):
+        with patch.dict("sys.modules", {"jwt": mock_jwt_module}):
+            verify_oidc_token("header.payload.signature", "https://example.com", jwks_uri="https://example.com/.well-known/jwks.json")
+
+    algorithms = mock_jwt_module.decode.call_args.kwargs["algorithms"]
+    assert algorithms == list(OIDC_ALLOWED_ALGORITHMS)
+    assert "ES512" in algorithms
+    assert "EdDSA" in algorithms
+
+
 def test_oidc_config_verify_returns_claims_and_role():
     """verify() on OIDCConfig returns (claims, role) on success."""
     cfg = OIDCConfig(issuer="https://example.com", audience="agent-bom")


### PR DESCRIPTION
Summary

- add ES512 and EdDSA to the OIDC JWT verification algorithm allowlist
- centralize the allowed OIDC algorithms in a named constant
- add a regression test that verifies PyJWT receives the complete modern asymmetric algorithm set

Verification

- uv run pytest tests/test_api_oidc.py::test_verify_oidc_token_allows_modern_asymmetric_algorithms tests/test_api_oidc.py::test_verify_raises_oidc_error_on_bad_jwt -q
- uv run ruff check src/agent_bom/api/oidc.py tests/test_api_oidc.py
- python scripts/check_release_consistency.py
- git diff --check

Notes

- Fixes OIDC interoperability for providers issuing ES512 or EdDSA-signed tokens while keeping symmetric algorithms excluded.
