### PR TITLE
fix(snowflake): add tenant row access policy

### DIFF
--- a/src/agent_bom/api/snowflake_store.py
+++ b/src/agent_bom/api/snowflake_store.py
@@ -36,6 +36,58 @@ def _sf_connect(**kwargs):  # type: ignore[no-untyped-def]
 
 
 _JOB_TTL_SECONDS = 3600
+_SNOWFLAKE_TENANT_ACCESS_TABLE = "agent_bom_tenant_access"
+_SNOWFLAKE_TENANT_ROW_ACCESS_POLICY = "agent_bom_tenant_isolation"
+_SNOWFLAKE_TENANT_TABLES = (
+    "scan_jobs",
+    "fleet_agents",
+    "scan_schedules",
+    "exceptions",
+    "gateway_policies",
+    "policy_audit_log",
+)
+
+
+def _execute_row_access_policy_ddl(cur, sql: str) -> None:  # type: ignore[no-untyped-def]
+    try:
+        cur.execute(sql)
+    except Exception as exc:
+        message = str(exc).lower()
+        if "row access policy" in message and ("already" in message or "exists" in message):
+            return
+        raise
+
+
+def _ensure_tenant_row_access_policy(cur, table_names: tuple[str, ...]) -> None:  # type: ignore[no-untyped-def]
+    """Install Snowflake row access policy hooks for tenant-scoped tables."""
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS agent_bom_tenant_access (
+            tenant_id VARCHAR NOT NULL,
+            snowflake_role VARCHAR NOT NULL,
+            created_at TIMESTAMP_TZ DEFAULT CURRENT_TIMESTAMP(),
+            PRIMARY KEY (tenant_id, snowflake_role)
+        )
+    """)
+    cur.execute("""
+        CREATE ROW ACCESS POLICY IF NOT EXISTS agent_bom_tenant_isolation
+        AS (row_tenant_id VARCHAR) RETURNS BOOLEAN ->
+            row_tenant_id IS NULL
+            OR IS_ROLE_IN_SESSION('AGENT_BOM_RLS_ADMIN')
+            OR NOT EXISTS (
+                SELECT 1 FROM agent_bom_tenant_access
+            )
+            OR EXISTS (
+                SELECT 1
+                FROM agent_bom_tenant_access
+                WHERE tenant_id = row_tenant_id
+                  AND snowflake_role = CURRENT_ROLE()
+            )
+    """)
+    for table_name in table_names:
+        _execute_row_access_policy_ddl(
+            cur,
+            f"ALTER TABLE {table_name} ADD ROW ACCESS POLICY {_SNOWFLAKE_TENANT_ROW_ACCESS_POLICY} ON (tenant_id)",
+        )
 
 
 def build_connection_params() -> dict:
@@ -93,6 +145,7 @@ class SnowflakeJobStore:
                 )
             """)
             conn.cursor().execute("ALTER TABLE scan_jobs ADD COLUMN IF NOT EXISTS tenant_id VARCHAR NOT NULL DEFAULT 'default'")
+            _ensure_tenant_row_access_policy(conn.cursor(), ("scan_jobs",))
 
     def put(self, job: ScanJob) -> None:
         with self._connect() as conn:
@@ -225,6 +278,7 @@ class SnowflakeFleetStore:
             """)
             cur.execute("ALTER TABLE fleet_agents ADD COLUMN IF NOT EXISTS canonical_id VARCHAR NOT NULL DEFAULT ''")
             cur.execute("ALTER TABLE fleet_agents ADD COLUMN IF NOT EXISTS tenant_id VARCHAR NOT NULL DEFAULT 'default'")
+            _ensure_tenant_row_access_policy(cur, ("fleet_agents",))
 
     def put(self, agent: FleetAgent) -> None:
         with self._connect() as conn:
@@ -429,6 +483,7 @@ class SnowflakeScheduleStore:
             """)
             cur.execute("ALTER TABLE scan_schedules ADD COLUMN IF NOT EXISTS tenant_id VARCHAR NOT NULL DEFAULT 'default'")
             cur.execute("CREATE INDEX IF NOT EXISTS idx_sched_tenant_due ON scan_schedules(tenant_id, enabled, next_run)")
+            _ensure_tenant_row_access_policy(cur, ("scan_schedules",))
 
     def put(self, schedule) -> None:
         with self._connect() as conn:
@@ -532,6 +587,7 @@ class SnowflakeExceptionStore:
                 )
             """)
             cur.execute("ALTER TABLE exceptions ADD COLUMN IF NOT EXISTS tenant_id VARCHAR NOT NULL DEFAULT 'default'")
+            _ensure_tenant_row_access_policy(cur, ("exceptions",))
 
     def put(self, exc: VulnException) -> None:
         with self._connect() as conn:
@@ -658,6 +714,7 @@ class SnowflakePolicyStore:
             """)
             cur.execute("ALTER TABLE gateway_policies ADD COLUMN IF NOT EXISTS tenant_id VARCHAR NOT NULL DEFAULT 'default'")
             cur.execute("ALTER TABLE policy_audit_log ADD COLUMN IF NOT EXISTS tenant_id VARCHAR NOT NULL DEFAULT 'default'")
+            _ensure_tenant_row_access_policy(cur, ("gateway_policies", "policy_audit_log"))
 
     # ── policies ──
 

--- a/tests/test_snowflake_stores.py
+++ b/tests/test_snowflake_stores.py
@@ -38,6 +38,39 @@ SF_PARAMS = {
 }
 
 
+# ─── tenant row access policy ────────────────────────────────────────────────
+
+
+def test_tenant_row_access_policy_applies_to_all_tenant_tables():
+    from agent_bom.api.snowflake_store import (
+        _SNOWFLAKE_TENANT_ROW_ACCESS_POLICY,
+        _SNOWFLAKE_TENANT_TABLES,
+        _ensure_tenant_row_access_policy,
+    )
+
+    cur = _mock_cursor()
+
+    _ensure_tenant_row_access_policy(cur, _SNOWFLAKE_TENANT_TABLES)
+
+    sql_calls = [call.args[0] for call in cur.execute.call_args_list]
+    rendered_sql = "\n".join(sql_calls)
+    assert "CREATE TABLE IF NOT EXISTS agent_bom_tenant_access" in rendered_sql
+    assert f"CREATE ROW ACCESS POLICY IF NOT EXISTS {_SNOWFLAKE_TENANT_ROW_ACCESS_POLICY}" in rendered_sql
+    assert "IS_ROLE_IN_SESSION('AGENT_BOM_RLS_ADMIN')" in rendered_sql
+    assert "snowflake_role = CURRENT_ROLE()" in rendered_sql
+    for table_name in _SNOWFLAKE_TENANT_TABLES:
+        assert f"ALTER TABLE {table_name} ADD ROW ACCESS POLICY {_SNOWFLAKE_TENANT_ROW_ACCESS_POLICY} ON (tenant_id)" in sql_calls
+
+
+def test_row_access_policy_duplicate_attachment_is_idempotent():
+    from agent_bom.api.snowflake_store import _execute_row_access_policy_ddl
+
+    cur = _mock_cursor()
+    cur.execute.side_effect = Exception("Row access policy already exists on table")
+
+    _execute_row_access_policy_ddl(cur, "ALTER TABLE scan_jobs ADD ROW ACCESS POLICY agent_bom_tenant_isolation ON (tenant_id)")
+
+
 # ─── build_connection_params ──────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Summary

- add a Snowflake tenant-access mapping table and row access policy for tenant-scoped control-plane tables
- attach the policy to scan jobs, fleet agents, schedules, exceptions, gateway policies, and policy audit rows during store initialization
- keep existing app-level tenant filters while adding warehouse-side isolation hooks for Snowflake deployments

Verification

- uv run pytest tests/test_snowflake_stores.py -q
- uv run ruff check src/agent_bom/api/snowflake_store.py tests/test_snowflake_stores.py
- python scripts/check_release_consistency.py
- git diff --check

Notes

- The row access policy permits existing app-level behavior until tenant-role mappings are populated, then Snowflake role membership can enforce tenant isolation inside the warehouse.
