### PR TITLE
test(api): cover auth rejection edges

### DIFF
--- a/tests/test_api_oidc.py
+++ b/tests/test_api_oidc.py
@@ -376,6 +376,16 @@ def test_verify_oidc_token_allows_modern_asymmetric_algorithms():
     assert "EdDSA" in algorithms
 
 
+def test_oidc_algorithm_allowlist_rejects_none_and_symmetric_algorithms():
+    from agent_bom.api.oidc import OIDC_ALLOWED_ALGORITHMS
+
+    algorithms = {algorithm.lower() for algorithm in OIDC_ALLOWED_ALGORITHMS}
+    assert "none" not in algorithms
+    assert "hs256" not in algorithms
+    assert "hs384" not in algorithms
+    assert "hs512" not in algorithms
+
+
 def test_oidc_config_verify_returns_claims_and_role():
     """verify() on OIDCConfig returns (claims, role) on success."""
     cfg = OIDCConfig(issuer="https://example.com", audience="agent-bom")

--- a/tests/test_api_proxy_websocket_auth.py
+++ b/tests/test_api_proxy_websocket_auth.py
@@ -1,0 +1,32 @@
+"""Regression tests for proxy WebSocket authentication edges."""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from agent_bom.api.server import app
+
+
+def test_proxy_metrics_websocket_rejects_invalid_first_message_token(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_API_KEY", "ws-secret")
+    client = TestClient(app)
+
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect("/ws/proxy/metrics") as websocket:
+            websocket.send_json({"type": "auth", "token": "wrong-secret"})
+            websocket.receive_json()
+
+    assert exc.value.code == 4001
+
+
+def test_proxy_alerts_websocket_rejects_query_token(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_API_KEY", "ws-secret")
+    client = TestClient(app)
+
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect("/ws/proxy/alerts?token=ws-secret"):
+            pass
+
+    assert exc.value.code == 4001


### PR DESCRIPTION
Summary

- add explicit OIDC allowlist coverage that rejects alg:none and symmetric HS algorithms
- add dedicated proxy WebSocket auth rejection tests for invalid first-message tokens and URL query tokens
- make the WebSocket auth coverage discoverable by filename-based audit sweeps

Verification

- uv run pytest tests/test_api_oidc.py::test_oidc_algorithm_allowlist_rejects_none_and_symmetric_algorithms tests/test_api_proxy_websocket_auth.py -q
- uv run ruff check tests/test_api_oidc.py tests/test_api_proxy_websocket_auth.py
- python scripts/check_release_consistency.py
- git diff --check
