### PR TITLE
feat(plugins): expose registry status

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 183 |
+| `docs/openapi/v1.json` | paths | 184 |
 | `docs/openapi/v1.json` | component schemas | 57 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/PLUGIN_ENTRYPOINTS.md
+++ b/docs/PLUGIN_ENTRYPOINTS.md
@@ -11,6 +11,17 @@ Third-party entry-point loading is opt-in:
 AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS=true agent-bom agents --demo --offline
 ```
 
+Operators can inspect the registry without loading third-party plugin code:
+
+```bash
+agent-bom plugins status --format json
+curl -H "Authorization: Bearer $AGENT_BOM_API_KEY" \
+  http://localhost:8422/v1/plugins/status
+```
+
+The status contract is metadata-only. It reports built-in registration counts,
+installed entry-point declarations, and whether opt-in loading is enabled.
+
 ## Supported Groups
 
 | Group | Purpose | Default runtime behavior |
@@ -18,6 +29,10 @@ AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS=true agent-bom agents --demo --offline
 | `agent_bom.mcp_tools` | Advertise an MCP tool registration module and function. | Not registered on the live MCP server. |
 | `agent_bom.advisory_sources` | Advertise a private advisory lookup or sync source. | Not queried during scans. |
 | `agent_bom.runtime_emitters` | Advertise a runtime event emitter. | Not added to proxy, gateway, or alert dispatch. |
+
+The registry status view also includes existing built-in extension groups:
+`agent_bom.cloud_providers`, `agent_bom.connectors`, and
+`agent_bom.inventory_parsers`.
 
 Each group is capped at 32 loaded entry points per process. Import, validation,
 and coercion failures are non-fatal; built-in behavior remains available and

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -11522,6 +11522,30 @@
         ]
       }
     },
+    "/v1/plugins/status": {
+      "get": {
+        "description": "Return metadata-only plugin registry status for operator dashboards.",
+        "operationId": "get_plugin_registry_status_v1_plugins_status_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Plugin Registry Status V1 Plugins Status Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Plugin Registry Status",
+        "tags": [
+          "plugins"
+        ]
+      }
+    },
     "/v1/posture": {
       "get": {
         "description": "Compute enterprise posture scorecard from the latest completed scan.\n\nReturns a letter grade (A-F), numeric score (0-100), and per-dimension\nbreakdown covering vulnerability posture, credential hygiene, supply\nchain quality, compliance coverage, active exploitation, and configuration.",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -7594,6 +7594,22 @@ paths:
       summary: Ingest Ocsf
       tags:
       - observability
+  /v1/plugins/status:
+    get:
+      description: Return metadata-only plugin registry status for operator dashboards.
+      operationId: get_plugin_registry_status_v1_plugins_status_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Plugin Registry Status V1 Plugins Status Get
+                type: object
+          description: Successful Response
+      summary: Get Plugin Registry Status
+      tags:
+      - plugins
   /v1/posture:
     get:
       description: 'Compute enterprise posture scorecard from the latest completed

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -73,6 +73,7 @@
 | `doctor` | Check environment readiness for scanning |
 | `gateway` | Multi-MCP gateway commands |
 | `interactive` | Start an interactive command shell for repeated CLI workflows |
+| `plugins` | Inspect extension plugin registry status without loading third-party plugin code |
 | `profiles` | Manage named CLI profiles for repeatable scan contexts |
 | `proxy-bootstrap` | Generate managed endpoint onboarding material |
 | `samples` | Create bundled sample inputs for demos and first runs |

--- a/src/agent_bom/api/routes/plugins.py
+++ b/src/agent_bom/api/routes/plugins.py
@@ -1,0 +1,16 @@
+"""Plugin registry status routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from agent_bom.plugin_entrypoints import plugin_registry_status
+
+router = APIRouter()
+
+
+@router.get("/v1/plugins/status", tags=["plugins"])
+def get_plugin_registry_status() -> dict[str, object]:
+    """Return metadata-only plugin registry status for operator dashboards."""
+
+    return plugin_registry_status()

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -729,6 +729,7 @@ from agent_bom.api.routes.governance import router as _governance_router  # noqa
 from agent_bom.api.routes.graph import router as _graph_router  # noqa: E402
 from agent_bom.api.routes.intel import router as _intel_router  # noqa: E402
 from agent_bom.api.routes.observability import router as _observability_router  # noqa: E402
+from agent_bom.api.routes.plugins import router as _plugins_router  # noqa: E402
 from agent_bom.api.routes.posture_streaming import router as _posture_streaming_router  # noqa: E402
 from agent_bom.api.routes.privacy import router as _privacy_router  # noqa: E402
 from agent_bom.api.routes.proxy import router as _proxy_router  # noqa: E402
@@ -754,6 +755,7 @@ app.include_router(_governance_router)
 app.include_router(_graph_router)
 app.include_router(_intel_router)
 app.include_router(_observability_router)
+app.include_router(_plugins_router)
 app.include_router(_posture_streaming_router)
 app.include_router(_privacy_router)
 app.include_router(_proxy_router)

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -301,6 +301,10 @@ from agent_bom.cli._profiles import profiles_group  # noqa: E402
 
 main.add_command(profiles_group)
 
+from agent_bom.cli._plugins import plugins_group  # noqa: E402
+
+main.add_command(plugins_group)
+
 from agent_bom.cli._interactive import interactive_cmd  # noqa: E402
 
 main.add_command(interactive_cmd)

--- a/src/agent_bom/cli/_plugins.py
+++ b/src/agent_bom/cli/_plugins.py
@@ -1,0 +1,52 @@
+"""Plugin registry inspection commands."""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from agent_bom.cli._grouped_help import SuggestingGroup
+from agent_bom.plugin_entrypoints import plugin_registry_status
+
+
+@click.group("plugins", cls=SuggestingGroup, invoke_without_command=True)
+@click.pass_context
+def plugins_group(ctx: click.Context) -> None:
+    """Inspect extension plugin entry-point registrations."""
+
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@plugins_group.command("status")
+@click.option("-f", "--format", "output_format", type=click.Choice(["console", "json"]), default="console", show_default=True)
+def plugins_status_cmd(output_format: str) -> None:
+    """Show built-in plugin slots and installed entry-point declarations."""
+
+    status = plugin_registry_status()
+    if output_format == "json":
+        click.echo(json.dumps(status, indent=2, sort_keys=True))
+        return
+
+    totals = status["totals"]
+    click.echo("Plugin registry status")
+    click.echo(f"  schema_version:        {status['schema_version']}")
+    click.echo(f"  entrypoints_enabled:   {str(status['entrypoints_enabled']).lower()}")
+    click.echo(f"  metadata_only:         {str(status['metadata_only']).lower()}")
+    click.echo(f"  builtin_registrations: {totals['builtin_registrations']}")
+    click.echo(f"  declared_entrypoints:  {totals['declared_entrypoints']}")
+    click.echo("")
+    for group in status["groups"]:
+        click.echo(f"{group['group']}")
+        click.echo(f"  {group['description']}")
+        click.echo(f"  builtin={group['builtin_count']} declared_entrypoints={group['declared_entrypoint_count']}")
+        for entry in group["declared_entrypoints"]:
+            value = f" -> {entry['value']}" if entry["value"] else ""
+            distribution = f" ({entry['distribution']})" if entry["distribution"] else ""
+            click.echo(f"  - {entry['name']}{value}{distribution}")
+    if status["warnings"]:
+        click.echo("")
+        click.echo("Warnings:")
+        for warning in status["warnings"]:
+            click.echo(f"  - {warning}")

--- a/src/agent_bom/plugin_entrypoints.py
+++ b/src/agent_bom/plugin_entrypoints.py
@@ -11,7 +11,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from agent_bom.extensions import ExtensionCapabilities, RegistryEntry, iter_entry_point_registrations
+from agent_bom.extensions import (
+    ExtensionCapabilities,
+    RegistryEntry,
+    _entry_points_for_group,
+    entrypoint_extensions_enabled,
+    iter_entry_point_registrations,
+    sanitize_registry_warning,
+)
+from agent_bom.security import sanitize_text
 
 MCP_TOOLS_ENTRY_POINT_GROUP = "agent_bom.mcp_tools"
 ADVISORY_SOURCES_ENTRY_POINT_GROUP = "agent_bom.advisory_sources"
@@ -21,6 +29,41 @@ PLUGIN_ENTRY_POINT_GROUPS: tuple[str, ...] = (
     MCP_TOOLS_ENTRY_POINT_GROUP,
     ADVISORY_SOURCES_ENTRY_POINT_GROUP,
     RUNTIME_EMITTERS_ENTRY_POINT_GROUP,
+)
+
+PLUGIN_REGISTRY_STATUS_SCHEMA_VERSION = "agent-bom.plugin_registry_status.v1"
+
+PLUGIN_REGISTRY_GROUPS: tuple[dict[str, str], ...] = (
+    {
+        "group": "agent_bom.cloud_providers",
+        "label": "Cloud providers",
+        "description": "Agentless cloud and AI-platform inventory discovery providers.",
+    },
+    {
+        "group": "agent_bom.connectors",
+        "label": "Connectors",
+        "description": "SaaS and workflow connectors used for inventory and evidence exchange.",
+    },
+    {
+        "group": "agent_bom.inventory_parsers",
+        "label": "Inventory parsers",
+        "description": "Local manifest and package inventory parser plugins.",
+    },
+    {
+        "group": MCP_TOOLS_ENTRY_POINT_GROUP,
+        "label": "MCP tools",
+        "description": "Third-party MCP tool registration plugins.",
+    },
+    {
+        "group": ADVISORY_SOURCES_ENTRY_POINT_GROUP,
+        "label": "Advisory sources",
+        "description": "Threat-intel and advisory lookup source plugins.",
+    },
+    {
+        "group": RUNTIME_EMITTERS_ENTRY_POINT_GROUP,
+        "label": "Runtime emitters",
+        "description": "Runtime event emitter plugins for operator-enabled sinks.",
+    },
 )
 
 MAX_PLUGIN_ENTRY_POINTS_PER_GROUP = 32
@@ -211,6 +254,87 @@ def plugin_entrypoint_warnings() -> list[str]:
     return list(_PLUGIN_ENTRYPOINT_WARNINGS)
 
 
+def _safe_entrypoint_metadata(group: str, warnings: list[str]) -> list[dict[str, str]]:
+    try:
+        entry_points = list(_entry_points_for_group(group))
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(sanitize_registry_warning(f"Could not enumerate entry points for {group}: {exc}"))
+        return []
+
+    entries: list[dict[str, str]] = []
+    for entry_point in entry_points:
+        distribution = ""
+        dist = getattr(entry_point, "dist", None)
+        if dist is not None:
+            metadata = getattr(dist, "metadata", {}) or {}
+            distribution = str(metadata.get("Name", "") or getattr(dist, "name", "") or "")
+        entries.append(
+            {
+                "name": sanitize_text(str(getattr(entry_point, "name", "unknown")), max_len=120),
+                "value": sanitize_text(str(getattr(entry_point, "value", "")), max_len=300),
+                "distribution": sanitize_text(distribution, max_len=120),
+            }
+        )
+    return sorted(entries, key=lambda item: (item["name"], item["value"]))
+
+
+def _builtin_registry_counts() -> dict[str, int]:
+    from agent_bom.cloud import builtin_provider_registrations
+    from agent_bom.connectors import builtin_connector_registrations
+    from agent_bom.parsers import builtin_inventory_parser_registrations
+
+    return {
+        "agent_bom.cloud_providers": len(builtin_provider_registrations()),
+        "agent_bom.connectors": len(builtin_connector_registrations()),
+        "agent_bom.inventory_parsers": len(builtin_inventory_parser_registrations()),
+        MCP_TOOLS_ENTRY_POINT_GROUP: 0,
+        ADVISORY_SOURCES_ENTRY_POINT_GROUP: 0,
+        RUNTIME_EMITTERS_ENTRY_POINT_GROUP: 0,
+    }
+
+
+def plugin_registry_status() -> dict[str, Any]:
+    """Return metadata-only plugin registry status for CLI and API callers.
+
+    This intentionally enumerates installed entry-point declarations without
+    calling ``EntryPoint.load()``. Runtime activation remains opt-in via
+    ``AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS``.
+    """
+
+    warnings: list[str] = []
+    builtin_counts = _builtin_registry_counts()
+    groups: list[dict[str, Any]] = []
+    total_builtin = 0
+    total_declared = 0
+    for group_info in PLUGIN_REGISTRY_GROUPS:
+        group_name = group_info["group"]
+        entry_points = _safe_entrypoint_metadata(group_name, warnings)
+        builtin_count = builtin_counts.get(group_name, 0)
+        total_builtin += builtin_count
+        total_declared += len(entry_points)
+        groups.append(
+            {
+                **group_info,
+                "builtin_count": builtin_count,
+                "declared_entrypoint_count": len(entry_points),
+                "declared_entrypoints": entry_points,
+            }
+        )
+    return {
+        "schema_version": PLUGIN_REGISTRY_STATUS_SCHEMA_VERSION,
+        "entrypoints_enabled": entrypoint_extensions_enabled(),
+        "metadata_only": True,
+        "activation_env": "AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS",
+        "totals": {
+            "groups": len(groups),
+            "builtin_registrations": total_builtin,
+            "declared_entrypoints": total_declared,
+        },
+        "groups": groups,
+        "warnings": warnings,
+    }
+
+
 def _reset_plugin_entrypoint_registry_for_tests() -> None:
     _MCP_TOOL_PLUGINS.clear()
     _ADVISORY_SOURCE_PLUGINS.clear()
@@ -233,4 +357,5 @@ __all__ = [
     "list_mcp_tool_plugins",
     "list_runtime_emitter_plugins",
     "plugin_entrypoint_warnings",
+    "plugin_registry_status",
 ]

--- a/src/agent_bom/plugin_entrypoints.py
+++ b/src/agent_bom/plugin_entrypoints.py
@@ -257,8 +257,8 @@ def plugin_entrypoint_warnings() -> list[str]:
 def _safe_entrypoint_metadata(group: str, warnings: list[str]) -> list[dict[str, str]]:
     try:
         entry_points = list(_entry_points_for_group(group))
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(sanitize_registry_warning(f"Could not enumerate entry points for {group}: {exc}"))
+    except Exception:  # noqa: BLE001
+        warnings.append(sanitize_registry_warning(f"Could not enumerate entry points for {group}"))
         return []
 
     entries: list[dict[str, str]] = []

--- a/tests/test_plugin_registry_status.py
+++ b/tests/test_plugin_registry_status.py
@@ -62,6 +62,21 @@ def test_plugin_registry_status_is_metadata_only_and_counts_builtins(monkeypatch
     ]
 
 
+def test_plugin_registry_status_does_not_expose_entrypoint_enumeration_errors(monkeypatch):
+    def fail_entry_points() -> object:
+        raise RuntimeError("boom token=secret from /Users/alice/plugin.py")
+
+    monkeypatch.setattr("agent_bom.extensions.metadata.entry_points", fail_entry_points)
+
+    status = plugin_registry_status()
+    warning_text = " ".join(status["warnings"])
+
+    assert "Could not enumerate entry points for agent_bom.cloud_providers" in warning_text
+    assert "secret" not in warning_text
+    assert "/Users/alice" not in warning_text
+    assert "boom" not in warning_text
+
+
 def test_plugins_status_cli_emits_json(monkeypatch):
     _patch_entry_points(
         monkeypatch,

--- a/tests/test_plugin_registry_status.py
+++ b/tests/test_plugin_registry_status.py
@@ -1,0 +1,88 @@
+"""Plugin registry status CLI/API contract tests."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from click.testing import CliRunner
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import app
+from agent_bom.cli import main
+from agent_bom.extensions import ENTRYPOINTS_ENABLED_ENV
+from agent_bom.plugin_entrypoints import plugin_registry_status
+
+
+class FakeEntryPoint:
+    def __init__(self, name: str, value: str, group: str, distribution: str = "acme-plugin") -> None:
+        self.name = name
+        self.value = value
+        self.group = group
+        self.dist = type("FakeDist", (), {"metadata": {"Name": distribution}})()
+
+
+class FakeEntryPoints(list[FakeEntryPoint]):
+    def select(self, *, group: str) -> list[FakeEntryPoint]:
+        return [entry_point for entry_point in self if entry_point.group == group]
+
+
+def _patch_entry_points(monkeypatch, entries: list[FakeEntryPoint]) -> None:
+    monkeypatch.setattr("agent_bom.extensions.metadata.entry_points", lambda: FakeEntryPoints(entries))
+
+
+def test_plugin_registry_status_is_metadata_only_and_counts_builtins(monkeypatch):
+    monkeypatch.delenv(ENTRYPOINTS_ENABLED_ENV, raising=False)
+    _patch_entry_points(
+        monkeypatch,
+        [
+            FakeEntryPoint(
+                "acme-tools",
+                "acme_agent_bom.tools:register",
+                "agent_bom.mcp_tools",
+            )
+        ],
+    )
+
+    status = plugin_registry_status()
+
+    assert status["schema_version"] == "agent-bom.plugin_registry_status.v1"
+    assert status["entrypoints_enabled"] is False
+    assert status["metadata_only"] is True
+    assert status["totals"]["groups"] == 6
+    assert status["totals"]["builtin_registrations"] >= 38
+    assert status["totals"]["declared_entrypoints"] == 1
+    mcp_group = next(group for group in status["groups"] if group["group"] == "agent_bom.mcp_tools")
+    assert mcp_group["declared_entrypoints"] == [
+        {
+            "name": "acme-tools",
+            "value": "acme_agent_bom.tools:register",
+            "distribution": "acme-plugin",
+        }
+    ]
+
+
+def test_plugins_status_cli_emits_json(monkeypatch):
+    _patch_entry_points(
+        monkeypatch,
+        [FakeEntryPoint("briefs", "acme.intel:source", "agent_bom.advisory_sources")],
+    )
+
+    result = CliRunner().invoke(main, ["plugins", "status", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload: dict[str, Any] = json.loads(result.output)
+    assert payload["schema_version"] == "agent-bom.plugin_registry_status.v1"
+    assert payload["totals"]["declared_entrypoints"] == 1
+
+
+def test_plugin_status_api_returns_registry_metadata(monkeypatch):
+    _patch_entry_points(monkeypatch, [FakeEntryPoint("otlp", "acme.runtime:emit", "agent_bom.runtime_emitters")])
+
+    response = TestClient(app, raise_server_exceptions=False).get("/v1/plugins/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["schema_version"] == "agent-bom.plugin_registry_status.v1"
+    assert payload["metadata_only"] is True
+    assert payload["totals"]["declared_entrypoints"] == 1


### PR DESCRIPTION
Summary

- add metadata-only plugin registry status for built-in extension slots and installed entry-point declarations
- expose the status through `agent-bom plugins status` and `GET /v1/plugins/status` without loading third-party plugin code
- refresh OpenAPI/DATA_MODEL artifacts and document the operator inspection commands

Verification

- PYTHONPATH=src uv run --extra api pytest tests/test_plugin_registry_status.py tests/test_entrypoint_registries.py tests/test_openapi_artifact.py -q
- uv run ruff check src/agent_bom/plugin_entrypoints.py src/agent_bom/cli/_plugins.py src/agent_bom/api/routes/plugins.py tests/test_plugin_registry_status.py
- uv run mypy src/agent_bom/plugin_entrypoints.py src/agent_bom/cli/_plugins.py src/agent_bom/api/routes/plugins.py
- uv run --extra api python scripts/export_openapi.py --check
- python scripts/check_release_consistency.py
- git diff --check
- uv run agent-bom plugins status --format json

Notes

- The status contract is metadata-only and does not call `EntryPoint.load()`. Runtime plugin activation remains gated by `AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS`.
