### PR TITLE
fix(sdk): accept positional client payloads

### DIFF
--- a/docs/PYTHON_API.md
+++ b/docs/PYTHON_API.md
@@ -56,8 +56,9 @@ with AgentBomClient(
     manifest = client.agent_manifest()
     runtime = client.runtime_production_index()
     intel = client.intel_sources()
+    decision = client.should_i_deploy("flask@2.0.0", block_risk=80)
 
-print(manifest["schema_version"], runtime["schema_version"], len(intel.get("sources", [])))
+print(manifest["schema_version"], runtime["schema_version"], len(intel.get("sources", [])), decision["decision"])
 ```
 
 For a smoke test against a running API:
@@ -93,6 +94,18 @@ python examples/python_sdk/control_plane_smoke.py
 | `intel_lookup(...)` | `GET /v1/intel/advisories/{advisory_id}` | Advisory lookup by CVE, GHSA, or OSV ID. |
 | `intel_match(...)` | `POST /v1/intel/match` | Match package coordinates against local advisory intelligence. |
 | `intel_sources()` | `GET /v1/intel/sources` | Source registry and freshness metadata. |
+
+Common write and governance calls keep the payload in the first positional
+argument:
+
+```python
+client.ingest_findings(
+    [{"id": "finding-1", "severity": "high", "title": "External scanner finding"}],
+    source="external-scanner",
+)
+client.register_dataset_version("training-set", version_id="2026-05-24")
+client.should_i_deploy("flask@2.0.0", block_risk=80)
+```
 
 ## Notes
 

--- a/examples/python_sdk/control_plane_smoke.py
+++ b/examples/python_sdk/control_plane_smoke.py
@@ -35,6 +35,7 @@ def run_smoke(*, base_url: str, api_key: str | None, bearer_token: str | None, t
         manifest = client.agent_manifest()
         runtime = client.runtime_production_index()
         intel_sources = client.intel_sources()
+        deploy_decision = client.should_i_deploy("flask@2.0.0", block_risk=80)
 
     sources = intel_sources.get("sources", [])
     return {
@@ -43,6 +44,7 @@ def run_smoke(*, base_url: str, api_key: str | None, bearer_token: str | None, t
         "manifest_schema": manifest.get("schema_version"),
         "runtime_schema": runtime.get("schema_version"),
         "intel_sources": len(sources) if isinstance(sources, list) else 0,
+        "deploy_decision": deploy_decision.get("decision"),
     }
 
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -16,6 +16,7 @@ client = AgentBomClient(
 print(client.health())
 print(client.exposure_paths(limit=5, min_risk=70))
 print(client.runtime_production_index())
+print(client.should_i_deploy("flask@2.0.0", block_risk=80))
 ```
 
 ## Covered Surfaces
@@ -36,3 +37,22 @@ print(client.runtime_production_index())
 Configure either `api_key` or `bearer_token`, not both. Tenant scope is sent as
 `X-Agent-Bom-Tenant-ID` and, where the API accepts it, as the request
 `tenant_id`.
+
+## Workflow Examples
+
+```python
+client.ingest_findings(
+    [{"id": "finding-1", "severity": "high", "title": "Demo finding"}],
+    source="external-scanner",
+)
+
+client.register_dataset_version(
+    "training-set",
+    version_id="2026-05-24",
+    artifact_uri="s3://customer-owned-bucket/training-set.jsonl",
+    digest="sha256:...",
+)
+
+versions = client.dataset_versions("training-set")
+decision = client.should_i_deploy("flask@2.0.0", block_risk=80)
+```

--- a/site-docs/api/python-sdk.md
+++ b/site-docs/api/python-sdk.md
@@ -53,8 +53,9 @@ with AgentBomClient(
     manifest = client.agent_manifest()
     runtime = client.runtime_production_index()
     intel = client.intel_sources()
+    decision = client.should_i_deploy("flask@2.0.0", block_risk=80)
 
-print(manifest["schema_version"], runtime["schema_version"], len(intel.get("sources", [])))
+print(manifest["schema_version"], runtime["schema_version"], len(intel.get("sources", [])), decision["decision"])
 ```
 
 Run the packaged smoke example against a live API:
@@ -68,5 +69,16 @@ python examples/python_sdk/control_plane_smoke.py
 The client accepts either `api_key` or `bearer_token`. `tenant_id` is sent as
 `X-Agent-Bom-Tenant-ID` and used as the default tenant scope for tenant-aware
 methods.
+
+Payload-first methods accept the obvious positional form:
+
+```python
+client.ingest_findings(
+    [{"id": "finding-1", "severity": "high", "title": "External scanner finding"}],
+    source="external-scanner",
+)
+client.register_dataset_version("training-set", version_id="2026-05-24")
+client.should_i_deploy("flask@2.0.0", block_risk=80)
+```
 
 ::: agent_bom.sdk

--- a/src/agent_bom/client.py
+++ b/src/agent_bom/client.py
@@ -91,8 +91,8 @@ class AgentBomClient:
 
     def should_i_deploy(
         self,
-        *,
         candidate: str | Mapping[str, JsonValue],
+        *,
         block_risk: int | None = None,
         context: Mapping[str, JsonValue] | None = None,
         tenant_id: str | None = None,
@@ -137,8 +137,8 @@ class AgentBomClient:
 
     def ingest_findings(
         self,
-        *,
         findings: Sequence[Mapping[str, JsonValue]],
+        *,
         source: str | None = None,
         schema_version: str | None = None,
         metadata: Mapping[str, JsonValue] | None = None,

--- a/tests/test_python_client.py
+++ b/tests/test_python_client.py
@@ -38,6 +38,21 @@ def test_client_sets_auth_headers_and_strips_none_body_fields() -> None:
     assert captured["body"] == {"candidate": "flask@2.0.0", "tenant_id": "tenant-a", "block_risk": 80}
 
 
+def test_client_accepts_positional_deploy_candidate() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(200, json={"decision": "warn"})
+
+    client = _client(handler)
+
+    result = client.should_i_deploy("flask@2.0.0", block_risk=60)
+
+    assert result["decision"] == "warn"
+    assert captured["body"] == {"candidate": "flask@2.0.0", "tenant_id": "tenant-a", "block_risk": 60}
+
+
 def test_client_builds_query_params() -> None:
     urls: list[str] = []
 
@@ -98,6 +113,25 @@ def test_client_exposes_findings_and_dataset_loop() -> None:
         ("GET", "/v1/datasets/dataset-a/versions"),
         ("GET", "/v1/datasets/dataset-a/versions/v1"),
     ]
+
+
+def test_client_accepts_positional_findings_payload() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(201, json={"ingested": 1})
+
+    client = _client(handler)
+
+    result = client.ingest_findings([{"id": "finding-1", "severity": "high"}], source="sdk-test")
+
+    assert result["ingested"] == 1
+    assert captured["body"] == {
+        "findings": [{"id": "finding-1", "severity": "high"}],
+        "source": "sdk-test",
+        "tenant_id": "tenant-a",
+    }
 
 
 def test_client_rejects_ambiguous_auth() -> None:

--- a/tests/test_python_client_smoke_example.py
+++ b/tests/test_python_client_smoke_example.py
@@ -51,6 +51,20 @@ class _Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler API
+        _Handler.seen_headers.append(dict(self.headers))
+        path = urlparse(self.path).path
+        if path != "/v1/graph/should-i-deploy":
+            self.send_response(404)
+            self.end_headers()
+            return
+        body = json.dumps({"decision": "allow"}).encode("utf-8")
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
 
 def test_python_sdk_control_plane_smoke_example_runs_against_local_http_server() -> None:
     _Handler.seen_headers = []
@@ -73,6 +87,7 @@ def test_python_sdk_control_plane_smoke_example_runs_against_local_http_server()
     assert result == {
         "health_status": "ok",
         "intel_sources": 1,
+        "deploy_decision": "allow",
         "manifest_schema": "agent-bom.manifest/v1",
         "runtime_schema": "runtime.production_index.v1",
         "status": "ok",


### PR DESCRIPTION
Summary

- allow Python SDK payload-first helpers to accept intuitive positional candidate/findings arguments
- add regression coverage for positional `should_i_deploy(...)` and `ingest_findings(...)` calls
- expand Python SDK docs and smoke example to cover governance and ingest workflows

Verification

- PYTHONPATH=src uv run --extra api pytest tests/test_python_client.py tests/test_public_python_api.py -q
- uv run ruff check src/agent_bom/client.py tests/test_python_client.py examples/python_sdk/control_plane_smoke.py
- uv run mypy src/agent_bom/client.py examples/python_sdk/control_plane_smoke.py
- python scripts/check_release_consistency.py
- git diff --check

Notes

- Existing keyword call sites remain compatible. Request bodies and API routes are unchanged.
