### PR TITLE
fix(compose): unblock first-run env rendering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,17 +44,20 @@ REDIS_URL=redis://localhost:6379/0
 
 # ── PostgreSQL ──────────────────────────────────────────────────────────────
 # Docker Compose requires POSTGRES_PASSWORD (will refuse to start without it).
+# The placeholders below are intentionally non-empty so `docker compose config`
+# and local first-run stacks render before you replace them. Change both values
+# before using any shared, long-lived, or production-shaped deployment.
 # POSTGRES_APP_PASSWORD enables least-privilege: the app connects as agent_bom_app
 # (DML only — cannot CREATE/DROP/ALTER tables). If not set, falls back to admin user.
 
 # Admin user (owns schema, runs migrations — do NOT give to the app)
-POSTGRES_PASSWORD=
+POSTGRES_PASSWORD=change-me-postgres-admin-password
 POSTGRES_USER=agent_bom
 POSTGRES_DB=agent_bom
 POSTGRES_PORT=5432
 
 # App user (least privilege — SELECT, INSERT, UPDATE, DELETE only)
-POSTGRES_APP_PASSWORD=
+POSTGRES_APP_PASSWORD=change-me-postgres-app-password
 POSTGRES_APP_USER=agent_bom_app
 
 # For external/managed Postgres (Supabase, Neon, RDS), set this directly:

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -22,9 +22,12 @@ version: "3.8"
 #     /run/secrets/...), not raw env. Operators provide:
 #         deploy/secrets/postgres_password
 #         deploy/secrets/postgres_app_password   (optional, for DML-only role)
-#     A starter pair lives at deploy/secrets/.gitkeep with file-permission
-#     guidance. The api service still consumes POSTGRES_APP_PASSWORD via
-#     env to construct AGENT_BOM_POSTGRES_URL (URL-form requirement);
+#     A non-secret placeholder lives at deploy/secrets/postgres_password.example
+#     so `docker compose config --env-file .env.example` can render for
+#     first-run inspection. Replace it with deploy/secrets/postgres_password
+#     before starting any shared or long-lived stack. The api service still
+#     consumes POSTGRES_APP_PASSWORD via env to construct AGENT_BOM_POSTGRES_URL
+#     (URL-form requirement);
 #     wrapper-based file-only injection is tracked as a #1962 follow-up.
 #
 # Usage:
@@ -139,7 +142,7 @@ secrets:
   # Mount-provisioned credentials. Populate the files before `docker compose up`.
   # See the header comment for permissions guidance (chmod 0400).
   postgres_password:
-    file: ./secrets/postgres_password
+    file: ${POSTGRES_PASSWORD_FILE:-./secrets/postgres_password.example}
 
 networks:
   backend:

--- a/deploy/secrets/.gitignore
+++ b/deploy/secrets/.gitignore
@@ -2,3 +2,4 @@
 *
 !.gitignore
 !README.md
+!*.example

--- a/deploy/secrets/README.md
+++ b/deploy/secrets/README.md
@@ -11,6 +11,10 @@ printf %s "$POSTGRES_PASSWORD" > deploy/secrets/postgres_password
 chmod 0400 deploy/secrets/postgres_password
 ```
 
+`postgres_password.example` is a non-secret placeholder for first-run
+`docker compose config` rendering only. Copy it to `postgres_password` or
+write a real secret before starting any shared or long-lived stack.
+
 The `chmod 0400` prevents the file from being world-readable; Docker still
 mounts it read-only inside the container at `/run/secrets/postgres_password`.
 

--- a/deploy/secrets/postgres_password.example
+++ b/deploy/secrets/postgres_password.example
@@ -1,0 +1,1 @@
+change-me-postgres-admin-password

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -23,6 +23,7 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 COMPOSE_DIR = ROOT / "deploy"
+ENV_EXAMPLE = ROOT / ".env.example"
 
 # Services that intentionally have no healthcheck — keep this list short and
 # explain each. Anything else missing a healthcheck fails the test.
@@ -64,8 +65,14 @@ def test_platform_compose_uses_docker_secrets_for_postgres_password() -> None:
     assert "postgres_password" in secrets_block, (
         "docker-compose.platform.yml must declare a top-level secrets: block with a postgres_password entry sourced from a file mount."
     )
-    assert "file" in secrets_block["postgres_password"], (
+    secret_file = secrets_block["postgres_password"].get("file")
+    assert secret_file, (
         "postgres_password secret must be file-sourced (file: ./secrets/postgres_password) so docker-compose binds it read-only."
+    )
+    assert str(secret_file).endswith("postgres_password.example}"), (
+        "platform compose must retain a non-secret example fallback so "
+        "`docker compose config --env-file .env.example` renders before operators "
+        "replace it with deploy/secrets/postgres_password."
     )
 
     postgres = (data.get("services") or {}).get("postgres") or {}
@@ -86,6 +93,24 @@ def test_platform_compose_uses_docker_secrets_for_postgres_password() -> None:
     assert "postgres_password" in (postgres.get("secrets") or []), (
         "platform postgres service must list postgres_password under its secrets: block so the file mount is created."
     )
+
+
+def test_env_example_unblocks_compose_first_run_without_real_secrets() -> None:
+    env_values: dict[str, str] = {}
+    for line in ENV_EXAMPLE.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        env_values[key] = value
+
+    for key in ("POSTGRES_PASSWORD", "POSTGRES_APP_PASSWORD"):
+        assert env_values.get(key), f".env.example must set a non-empty {key} placeholder for compose first-run rendering"
+        assert "change-me" in env_values[key], f".env.example {key} should be an obvious placeholder, not a real-looking secret"
+
+    placeholder = COMPOSE_DIR / "secrets" / "postgres_password.example"
+    assert placeholder.exists(), "platform compose default secret placeholder must exist for config rendering"
+    assert placeholder.read_text(encoding="utf-8").strip() == env_values["POSTGRES_PASSWORD"]
 
 
 def test_platform_api_fails_closed_for_auth_docs_and_local_scans() -> None:


### PR DESCRIPTION
Summary
- add non-secret Postgres placeholders to .env.example so default/fullstack compose render before first start
- add a file-based platform compose placeholder secret while keeping real secret files ignored
- add regression coverage for compose first-run env placeholders and the platform secret fallback

Verification
- docker compose --env-file .env.example -f deploy/docker-compose.yml config
- docker compose --env-file .env.example -f deploy/docker-compose.fullstack.yml config
- docker compose --env-file .env.example -f deploy/docker-compose.platform.yml config
- PYTHONPATH=src uv run --extra api pytest tests/test_compose_secrets_healthcheck.py -q
- uv run ruff check tests/test_compose_secrets_healthcheck.py
- python scripts/check_release_consistency.py
- git diff --check

Notes
- Real platform secret files remain ignored; the tracked example is explicitly a non-secret first-run/config placeholder.