### PR TITLE
feat(auth): expose scope catalog

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 184 |
+| `docs/openapi/v1.json` | paths | 185 |
 | `docs/openapi/v1.json` | component schemas | 57 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -4624,6 +4624,30 @@
         ]
       }
     },
+    "/v1/auth/scopes": {
+      "get": {
+        "description": "Return the enforced RBAC scope catalog for operator tooling.",
+        "operationId": "auth_scopes_v1_auth_scopes_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Auth Scopes V1 Auth Scopes Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Auth Scopes",
+        "tags": [
+          "enterprise"
+        ]
+      }
+    },
     "/v1/auth/secrets/lifecycle": {
       "get": {
         "description": "Return non-secret lifecycle posture for configured control-plane secrets.",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -3080,6 +3080,22 @@ paths:
       summary: Auth Scim Config
       tags:
       - enterprise
+  /v1/auth/scopes:
+    get:
+      description: Return the enforced RBAC scope catalog for operator tooling.
+      operationId: auth_scopes_v1_auth_scopes_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Auth Scopes V1 Auth Scopes Get
+                type: object
+          description: Successful Response
+      summary: Auth Scopes
+      tags:
+      - enterprise
   /v1/auth/secrets/lifecycle:
     get:
       description: Return non-secret lifecycle posture for configured control-plane

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -768,6 +768,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         ("GET", "/v1/auth/debug", "viewer"),
         ("GET", "/v1/auth/me", "viewer"),
         ("GET", "/v1/auth/policy", "admin"),
+        ("GET", "/v1/auth/scopes", "admin"),
         ("GET", "/v1/auth/secrets/lifecycle", "admin"),
         ("GET", "/v1/auth/secrets/rotation-plan", "admin"),
         ("GET", "/v1/auth/scim/config", "admin"),
@@ -875,6 +876,32 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         ("PUT", "/v1/exceptions/", "exception:write"),
         ("DELETE", "/v1/exceptions/", "exception:write"),
     )
+
+    @classmethod
+    def scope_catalog(cls) -> list[dict[str, str]]:
+        """Return the enforced API scope catalog for operator discovery."""
+        catalog: list[dict[str, str]] = []
+        for method, path_prefix, scope in cls._SCOPE_RULES:
+            required_role = "viewer"
+            for role_method, role_path_prefix, role in cls._ROLE_RULES:
+                if method == role_method and path_prefix.startswith(role_path_prefix):
+                    required_role = role
+                    break
+            if ":" in scope:
+                family, action = scope.rsplit(":", 1)
+            else:
+                family, action = scope, "access"
+            catalog.append(
+                {
+                    "scope": scope,
+                    "family": family,
+                    "action": action,
+                    "method": method,
+                    "path_prefix": path_prefix,
+                    "required_role": required_role,
+                }
+            )
+        return sorted(catalog, key=lambda item: (item["scope"], item["method"], item["path_prefix"]))
 
     def __init__(self, app: ASGIApp, api_key: str) -> None:
         super().__init__(app)

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -661,6 +661,20 @@ async def auth_policy(request: Request) -> dict:
     }
 
 
+@router.get("/v1/auth/scopes", tags=["enterprise"])
+async def auth_scopes() -> dict:
+    """Return the enforced RBAC scope catalog for operator tooling."""
+    from agent_bom.api.middleware import APIKeyMiddleware
+
+    scopes = APIKeyMiddleware.scope_catalog()
+    return {
+        "schema_version": "v1",
+        "count": len(scopes),
+        "wildcard_examples": ["*", "auth.*", "auth.keys:*"],
+        "scopes": scopes,
+    }
+
+
 @router.get("/v1/auth/secrets/lifecycle", tags=["enterprise"])
 async def auth_secret_lifecycle() -> dict:
     """Return non-secret lifecycle posture for configured control-plane secrets."""

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -354,6 +354,27 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "service_keys" in body["identity_provisioning"]["session_revocation"]
 
 
+def test_auth_scope_catalog_surface_shape() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/auth/scopes")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["schema_version"] == "v1"
+    assert body["count"] == len(body["scopes"])
+    assert body["wildcard_examples"] == ["*", "auth.*", "auth.keys:*"]
+
+    entries = {(item["scope"], item["method"], item["path_prefix"]): item for item in body["scopes"]}
+    assert entries[("auth.keys:write", "POST", "/v1/auth/keys")] == {
+        "scope": "auth.keys:write",
+        "family": "auth.keys",
+        "action": "write",
+        "method": "POST",
+        "path_prefix": "/v1/auth/keys",
+        "required_role": "admin",
+    }
+    assert entries[("scan:write", "POST", "/v1/scan")]["required_role"] == "analyst"
+
+
 def test_proxy_control_plane_mtls_posture_requires_delegated_evidence(monkeypatch: pytest.MonkeyPatch) -> None:
     _clear_rate_limit_env(monkeypatch)
     monkeypatch.setenv("AGENT_BOM_PROXY_CONTROL_PLANE_MTLS_MODE", "delegated")
@@ -787,6 +808,7 @@ def test_apikey_middleware_rejects_exempt_paths_overlapping_role_rules(monkeypat
 def test_auth_policy_requires_admin_role_in_api_middleware() -> None:
     middleware = APIKeyMiddleware(app, api_key="static-secret")
     assert middleware._required_role("GET", "/v1/auth/policy") == "admin"
+    assert middleware._required_role("GET", "/v1/auth/scopes") == "admin"
     assert middleware._required_role("GET", "/v1/auth/secrets/lifecycle") == "admin"
     assert middleware._required_role("GET", "/v1/auth/secrets/rotation-plan") == "admin"
     assert middleware._required_scope("GET", "/v1/auth/secrets/lifecycle") == "auth.secrets:read"


### PR DESCRIPTION
Summary
- add a metadata-only GET /v1/auth/scopes endpoint for operator scope discovery
- derive the catalog from APIKeyMiddleware scope rules so it stays aligned with enforcement
- refresh OpenAPI and data-model generated artifacts

Verification
- PYTHONPATH=src uv run --extra api pytest tests/test_api_operator_policy.py::test_auth_scope_catalog_surface_shape tests/test_api_operator_policy.py::test_auth_policy_requires_admin_role_in_api_middleware tests/test_data_model_atlas_generator.py tests/test_openapi_artifact.py -q
- uv run ruff check src/agent_bom/api/middleware.py src/agent_bom/api/routes/enterprise.py tests/test_api_operator_policy.py
- uv run mypy src/agent_bom/api/middleware.py src/agent_bom/api/routes/enterprise.py --ignore-missing-imports --disable-error-code import-untyped
- uv run --extra api python scripts/export_openapi.py --check
- python scripts/check_release_consistency.py
- git diff --check

Notes
- The endpoint is admin-gated and returns only route prefixes, required roles, and scope names; it does not expose keys, tokens, or tenant data.