### PR TITLE
fix(graph): explain empty exposure paths

### DIFF
--- a/src/agent_bom/mcp_tools/graph.py
+++ b/src/agent_bom/mcp_tools/graph.py
@@ -131,6 +131,16 @@ def _decision_for_risk(risk: float, *, warn_risk: float, block_risk: float) -> s
     return "allow"
 
 
+def _empty_exposure_paths_message(*, total: int, min_risk: float) -> str | None:
+    if total == 0:
+        return (
+            "0 paths means no agent-to-vulnerability ExposurePath currently reaches a credential exposure or reachable tool in this scan."
+        )
+    if min_risk > 0:
+        return f"0 paths matched min_risk={min_risk}; lower min_risk to inspect lower-risk ExposurePaths."
+    return "0 paths matched the current filters."
+
+
 async def exposure_paths_impl(
     *,
     tenant_id: str = "default",
@@ -191,6 +201,8 @@ async def exposure_paths_impl(
             "edges": [edge.to_dict() for edge in edges],
             "stats": stats,
         }
+        if not ranked_paths:
+            payload["message"] = _empty_exposure_paths_message(total=total, min_risk=min_risk)
         encoded = json.dumps(payload, indent=2, default=str)
         return _truncate_response(encoded) if _truncate_response is not None else encoded
     except Exception:

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -1750,6 +1750,23 @@ class TestGraphStoreBackendSelection:
         assert {node["id"] for node in body["nodes"]} == {"agent:a", "server:s", "vuln:cve"}
         assert {edge["source_id"] for edge in body["edges"]} == {"agent:a", "server:s"}
 
+    def test_exposure_paths_rest_route_explains_empty_queue(self, recording_graph_store):
+        recording_graph_store.graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        recording_graph_store.graph.add_edge(UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES))
+        client = TestClient(app)
+
+        response = client.get("/v1/graph/exposure-paths")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["count"] == 0
+        assert body["total"] == 0
+        assert body["message"] == (
+            "0 paths means no agent-to-vulnerability ExposurePath currently reaches a credential exposure or reachable tool in this scan."
+        )
+        assert body["stats"]["total_edges"] == 1
+
     def test_should_i_deploy_rest_route_returns_agent_native_decision(self, recording_graph_store):
         recording_graph_store.graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
         recording_graph_store.graph.add_node(

--- a/tests/test_mcp_exposure_paths.py
+++ b/tests/test_mcp_exposure_paths.py
@@ -86,6 +86,16 @@ async def test_exposure_paths_impl_validates_agent_limits():
 
 
 @pytest.mark.asyncio
+async def test_exposure_paths_impl_explains_empty_queue():
+    response = await exposure_paths_impl(min_risk=95, _get_graph_store=lambda: _GraphStore(), _truncate_response=lambda value: value)
+    payload = json.loads(response)
+
+    assert payload["count"] == 0
+    assert payload["total"] == 1
+    assert payload["message"] == "0 paths matched min_risk=95; lower min_risk to inspect lower-risk ExposurePaths."
+
+
+@pytest.mark.asyncio
 async def test_exposure_paths_impl_redacts_internal_errors():
     response = await exposure_paths_impl(_get_graph_store=lambda: _FailingGraphStore())
     payload = json.loads(response)


### PR DESCRIPTION
Summary
- add an operator-facing message when exposure-path results are empty
- distinguish no ExposurePaths in the scan from min_risk filtering
- cover both MCP-tool and REST exposure-path responses

Verification
- PYTHONPATH=src uv run pytest tests/test_mcp_exposure_paths.py tests/test_graph_api.py::TestGraphStoreBackendSelection::test_exposure_paths_rest_route_matches_agent_native_contract tests/test_graph_api.py::TestGraphStoreBackendSelection::test_exposure_paths_rest_route_explains_empty_queue -q
- uv run ruff check src/agent_bom/mcp_tools/graph.py tests/test_mcp_exposure_paths.py tests/test_graph_api.py
- uv run mypy src/agent_bom/mcp_tools/graph.py --ignore-missing-imports --disable-error-code import-untyped
- python scripts/check_release_consistency.py
- git diff --check

Notes
- This is a response-shape clarification only; existing path, node, edge, stats, and filter fields are unchanged.