### PR TITLE
fix(audit): chain postgres rls bypass events

### DIFF
--- a/src/agent_bom/api/postgres_common.py
+++ b/src/agent_bom/api/postgres_common.py
@@ -38,13 +38,33 @@ def reset_current_tenant(token: Token[str]) -> None:
     _current_tenant.reset(token)
 
 
+def _audit_rls_bypass_activation(*, caller: str) -> None:
+    """Best-effort signed audit entry for trusted RLS bypass activation."""
+    try:
+        from agent_bom.api.audit_log import log_action
+
+        log_action(
+            "postgres.rls_bypass_activated",
+            actor="system",
+            resource="postgres/tenant-rls",
+            tenant_id=_current_tenant.get(),
+            policy="tenant_rls_bypass",
+            outcome="activated",
+            method="context_manager",
+            source_field=caller,
+        )
+    except Exception:
+        logger.debug("Postgres tenant RLS bypass audit log write failed", exc_info=True)
+
+
 @contextmanager
 def bypass_tenant_rls():
     """Temporarily disable Postgres tenant RLS for trusted internal tasks."""
     stack = inspect.stack(context=0)
-    frame = stack[1] if len(stack) > 1 else None
-    caller = f"{frame.filename}:{frame.lineno}" if frame else "unknown"
+    frame = next((candidate for candidate in stack[1:] if os.path.basename(candidate.filename) != "contextlib.py"), None)
+    caller = f"{os.path.basename(frame.filename)}:{frame.lineno}" if frame else "unknown"
     logger.warning("Postgres tenant RLS bypass activated caller=%s", caller)
+    _audit_rls_bypass_activation(caller=caller)
     token = _bypass_tenant_rls.set(True)
     try:
         yield

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1069,6 +1069,34 @@ def test_apply_tenant_session_sets_explicit_bypass_only_inside_context(monkeypat
     assert ("SELECT set_config('app.bypass_rls', %s, true)", ("0",)) in conn_after.executed
 
 
+def test_tenant_rls_bypass_activation_writes_signed_audit_event(monkeypatch):
+    """Trusted RLS bypass activation should be visible in the HMAC audit chain."""
+    from agent_bom.api import postgres_common
+    from agent_bom.api.audit_log import InMemoryAuditLog, set_audit_log
+
+    audit_log = InMemoryAuditLog()
+    set_audit_log(audit_log)
+    token = postgres_common.set_current_tenant("tenant-alpha")
+    try:
+        with postgres_common.bypass_tenant_rls():
+            assert postgres_common.is_tenant_rls_bypassed() is True
+    finally:
+        postgres_common.reset_current_tenant(token)
+        set_audit_log(InMemoryAuditLog())
+
+    entries = audit_log.list_entries(action="postgres.rls_bypass_activated", tenant_id="tenant-alpha")
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.actor == "system"
+    assert entry.resource == "postgres/tenant-rls"
+    assert entry.details["tenant_id"] == "tenant-alpha"
+    assert entry.details["policy"] == "tenant_rls_bypass"
+    assert entry.details["outcome"] == "activated"
+    assert entry.details["method"] == "context_manager"
+    assert "test_postgres_store.py:" in entry.details["source_field"]
+    assert audit_log.verify_integrity() == (1, 0)
+
+
 def test_ensure_tenant_rls_forces_policy_through_session_helpers():
     """Tenant RLS policies should be enforced by Postgres session state, not app filters alone."""
     from agent_bom.api import postgres_common


### PR DESCRIPTION
Summary
- write a best-effort HMAC audit event whenever trusted Postgres tenant RLS bypass is activated
- keep the existing logger warning while storing only Tier-A-safe metadata in the audit details
- add a regression test that verifies the bypass event is tenant-scoped and chain-verifiable

Verification
- PYTHONPATH=src uv run pytest tests/test_postgres_store.py::test_tenant_rls_bypass_activation_writes_signed_audit_event tests/test_postgres_store.py::test_apply_tenant_session_sets_explicit_bypass_only_inside_context -q
- uv run ruff check src/agent_bom/api/postgres_common.py tests/test_postgres_store.py
- uv run mypy src/agent_bom/api/postgres_common.py --ignore-missing-imports --disable-error-code import-untyped
- python scripts/check_release_consistency.py
- git diff --check

Notes
- Audit write failure is intentionally non-fatal so trusted maintenance tasks do not fail open or deadlock; failures are debug-logged and the original warning remains.