### PR TITLE
fix(registry): prefer official mcp sync source

### DIFF
--- a/.github/workflows/mcp-registry-sync.yml
+++ b/.github/workflows/mcp-registry-sync.yml
@@ -32,58 +32,27 @@ jobs:
         id: fetch
         run: |
           uv run python - <<'EOF'
-          import json
-          import urllib.request
-          import sys
           from pathlib import Path
 
-          # Candidate upstream URLs — try in order (upstream may reorganize)
-          REGISTRY_URLS = [
-              "https://raw.githubusercontent.com/modelcontextprotocol/servers/main/scripts/servers.json",
-              "https://raw.githubusercontent.com/modelcontextprotocol/servers/main/servers.json",
-          ]
-          REGISTRY_PATH = Path("src/agent_bom/mcp_registry.json")
+          from agent_bom.mcp_official_registry import (
+              sync_from_legacy_github_registry_sync,
+              sync_from_official_registry_sync,
+          )
 
-          # Load existing registry
-          existing = json.loads(REGISTRY_PATH.read_text())
-          known_packages = set(existing["servers"].keys())
+          result = sync_from_official_registry_sync(max_pages=10, page_size=100)
+          if result.total_fetched == 0:
+              result = sync_from_legacy_github_registry_sync()
+              if result.total_fetched == 0:
+                  print("Official MCP Registry unavailable and legacy fallback returned no entries — skipping new-server sync")
 
-          # Fetch upstream — try each URL, skip silently if none work
-          upstream = None
-          for url in REGISTRY_URLS:
-              try:
-                  with urllib.request.urlopen(url, timeout=30) as resp:
-                      upstream = json.loads(resp.read())
-                  break
-              except Exception:
-                  continue
-          if upstream is None:
-              print("Upstream MCP server list unavailable — skipping new-server sync", file=sys.stderr)
-              Path("/tmp/new_count").write_text("0")
-              sys.exit(0)
-
-          new_servers = {}
-          for entry in upstream if isinstance(upstream, list) else upstream.get("servers", []):
-              if isinstance(entry, dict):
-                  name = entry.get("package") or entry.get("name", "")
-                  ecosystem = "npm" if name.startswith("@") or "-" in name else "pypi"
-                  if name and name not in known_packages:
-                      new_servers[name] = {
-                          "ecosystem": ecosystem,
-                          "package": name,
-                          "description": entry.get("description", ""),
-                          "command_patterns": [name.split("/")[-1]],
-                          "category": entry.get("category", "uncategorized"),
-                      }
-
-          if new_servers:
-              existing["servers"].update(new_servers)
-              from datetime import datetime, timezone
-              existing["_updated"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-              REGISTRY_PATH.write_text(json.dumps(existing, indent=2) + "\n")
-              print(f"Added {len(new_servers)} new server(s): {', '.join(new_servers.keys())}")
-
-          Path("/tmp/new_count").write_text(str(len(new_servers)))
+          print(
+              f"MCP registry source={result.source} "
+              f"source_url={result.source_url} fetched={result.total_fetched} "
+              f"added={result.added} skipped={result.skipped} fallback={result.fallback_used}"
+          )
+          Path("/tmp/new_count").write_text(str(result.added))
+          Path("/tmp/sync_source").write_text(result.source)
+          Path("/tmp/sync_source_url").write_text(result.source_url)
           EOF
 
       - name: Refresh registry versions from npm/PyPI
@@ -122,6 +91,7 @@ jobs:
                       v = await fetch_version(client, entry["package"], entry["ecosystem"])
                       if v and v != entry.get("latest_version"):
                           entry["latest_version"] = v
+                          entry["version_source"] = entry["ecosystem"]
                           updated += 1
 
               async with httpx.AsyncClient() as client:
@@ -167,6 +137,8 @@ jobs:
           echo "new_count=$(cat /tmp/new_count)" >> "$GITHUB_OUTPUT"
           echo "version_count=$(cat /tmp/version_count 2>/dev/null || echo 0)" >> "$GITHUB_OUTPUT"
           echo "cve_count=$(cat /tmp/cve_count 2>/dev/null || echo 0)" >> "$GITHUB_OUTPUT"
+          echo "sync_source=$(cat /tmp/sync_source 2>/dev/null || echo unknown)" >> "$GITHUB_OUTPUT"
+          echo "sync_source_url=$(cat /tmp/sync_source_url 2>/dev/null || echo unknown)" >> "$GITHUB_OUTPUT"
 
       - name: Configure signed automation commits
         id: signing
@@ -204,6 +176,8 @@ jobs:
           NEW_COUNT: ${{ steps.count.outputs.new_count }}
           VERSION_COUNT: ${{ steps.count.outputs.version_count }}
           CVE_COUNT: ${{ steps.count.outputs.cve_count }}
+          SOURCE: ${{ steps.count.outputs.sync_source }}
+          SOURCE_URL: ${{ steps.count.outputs.sync_source_url }}
         run: |
           BRANCH="chore/mcp-registry-$(date +%Y%m%d)"
           git switch -C "$BRANCH" origin/main
@@ -212,7 +186,8 @@ jobs:
           git push --force-with-lease origin "$BRANCH"
           BODY="Automated weekly sync from the official MCP server registry.
 
-          **New servers added (MCP official):** ${NEW_COUNT}
+          **New-server source:** ${SOURCE} (${SOURCE_URL})
+          **New servers added:** ${NEW_COUNT}
           **Versions refreshed:** ${VERSION_COUNT}
           **Servers with CVE data:** ${CVE_COUNT}
 

--- a/src/agent_bom/mcp_official_registry.py
+++ b/src/agent_bom/mcp_official_registry.py
@@ -12,6 +12,7 @@ import asyncio
 import json
 import logging
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 
 from agent_bom.http_client import create_client, request_with_retry
@@ -21,6 +22,11 @@ from agent_bom.models import MCPServer, Package
 logger = logging.getLogger(__name__)
 
 _API_BASE = "https://registry.modelcontextprotocol.io"
+_API_SERVERS_URL = f"{_API_BASE}/v0/servers"
+_LEGACY_GITHUB_REGISTRY_URLS = (
+    "https://raw.githubusercontent.com/modelcontextprotocol/servers/main/scripts/servers.json",
+    "https://raw.githubusercontent.com/modelcontextprotocol/servers/main/servers.json",
+)
 _REGISTRY_PATH = Path(__file__).parent / "mcp_registry.json"
 
 
@@ -53,6 +59,9 @@ class OfficialRegistrySyncResult:
     added: int = 0
     skipped: int = 0
     total_fetched: int = 0
+    source: str = "mcp-official"
+    source_url: str = _API_SERVERS_URL
+    fallback_used: bool = False
     details: list[dict] = field(default_factory=list)
 
 
@@ -194,6 +203,41 @@ def _build_command_patterns(qualified_name: str) -> list[str]:
     return patterns
 
 
+def _utc_date() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _load_local_registry() -> dict:
+    try:
+        return json.loads(_REGISTRY_PATH.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Could not load local MCP registry %s: %s — defaulting to empty", _REGISTRY_PATH, exc)
+        return {"servers": {}}
+
+
+def _infer_raw_github_ecosystem(name: str) -> str:
+    if name.startswith("@"):
+        return "npm"
+    if "/" in name and not name.startswith("io."):
+        return "mcp-registry"
+    if "-" in name:
+        return "npm"
+    return "pypi"
+
+
+def _raw_registry_entries(upstream: object) -> list[dict]:
+    if isinstance(upstream, list):
+        return [entry for entry in upstream if isinstance(entry, dict)]
+    if isinstance(upstream, dict):
+        servers = upstream.get("servers", [])
+        return [entry for entry in servers if isinstance(entry, dict)]
+    return []
+
+
 async def sync_from_official_registry(
     max_pages: int = 10,
     page_size: int = 100,
@@ -204,17 +248,14 @@ async def sync_from_official_registry(
     Fetches servers and adds entries that don't already exist in the local
     mcp_registry.json. Does not overwrite existing entries.
     """
-    try:
-        local_data = json.loads(_REGISTRY_PATH.read_text())
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("Could not load local MCP registry %s: %s — defaulting to empty", _REGISTRY_PATH, exc)
-        local_data = {"servers": {}}
+    local_data = _load_local_registry()
 
     local_servers = local_data.get("servers", {})
     local_names = {v.get("package", k).lower() for k, v in local_servers.items()}
 
-    result = OfficialRegistrySyncResult()
+    result = OfficialRegistrySyncResult(source="mcp-official", source_url=_API_SERVERS_URL, fallback_used=False)
     cursor = None
+    fetched_at = _utc_timestamp()
 
     async with create_client(timeout=30.0) as client:
         for _page in range(max_pages):
@@ -225,7 +266,7 @@ async def sync_from_official_registry(
             resp = await request_with_retry(
                 client,
                 "GET",
-                f"{_API_BASE}/v0/servers",
+                _API_SERVERS_URL,
                 params=params,
             )
 
@@ -273,6 +314,10 @@ async def sync_from_official_registry(
                     "credential_env_vars": cred_vars,
                     "command_patterns": _build_command_patterns(qn),
                     "source_url": s.get("repository", {}).get("url", "") if isinstance(s.get("repository"), dict) else "",
+                    "source": "mcp-official",
+                    "source_fetched_at": fetched_at,
+                    "registry_source_url": _API_SERVERS_URL,
+                    "version_source": "official-registry",
                     "auto_enriched": True,
                 }
 
@@ -294,11 +339,75 @@ async def sync_from_official_registry(
                 break
 
     if not dry_run and result.added > 0:
-        from datetime import datetime, timezone
-
         local_data["servers"] = local_servers
-        local_data["_updated"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        local_data["_mcp_registry_sync"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        local_data["_updated"] = _utc_date()
+        local_data["_mcp_registry_sync"] = _utc_timestamp()
+        local_data["_mcp_registry_sync_source"] = result.source
+        _REGISTRY_PATH.write_text(dumps_registry_json(local_data), encoding="utf-8")
+
+    return result
+
+
+async def sync_from_legacy_github_registry(
+    *,
+    urls: tuple[str, ...] = _LEGACY_GITHUB_REGISTRY_URLS,
+    dry_run: bool = False,
+) -> OfficialRegistrySyncResult:
+    """Fallback import from legacy raw GitHub MCP server lists.
+
+    This path exists only for continuity when the Official MCP Registry API is
+    unavailable. Entries are explicitly labeled as fallback-sourced so the
+    bundled registry does not overclaim official API provenance.
+    """
+    local_data = _load_local_registry()
+    local_servers = local_data.get("servers", {})
+    local_names = {v.get("package", k).lower() for k, v in local_servers.items()}
+    fetched_at = _utc_timestamp()
+    result = OfficialRegistrySyncResult(
+        source="mcp-official-github-fallback",
+        source_url="",
+        fallback_used=True,
+    )
+
+    async with create_client(timeout=30.0) as client:
+        for url in urls:
+            resp = await request_with_retry(client, "GET", url)
+            if resp is None or resp.status_code != 200:
+                continue
+
+            result.source_url = url
+            for entry in _raw_registry_entries(resp.json()):
+                name = entry.get("package") or entry.get("name", "")
+                if not name:
+                    continue
+                result.total_fetched += 1
+                if name.lower() in local_names:
+                    result.skipped += 1
+                    continue
+
+                reg_entry = {
+                    "ecosystem": _infer_raw_github_ecosystem(name),
+                    "package": name,
+                    "description": normalize_registry_description(entry.get("description", "")),
+                    "command_patterns": _build_command_patterns(name),
+                    "category": entry.get("category", "uncategorized"),
+                    "source": result.source,
+                    "source_url": url,
+                    "source_fetched_at": fetched_at,
+                    "version_source": "legacy-github-fallback",
+                }
+                if not dry_run:
+                    local_servers[name] = reg_entry
+                result.added += 1
+                result.details.append({"server": name, "status": "added", "source": result.source})
+
+            break
+
+    if not dry_run and result.added > 0:
+        local_data["servers"] = local_servers
+        local_data["_updated"] = _utc_date()
+        local_data["_mcp_registry_sync"] = _utc_timestamp()
+        local_data["_mcp_registry_sync_source"] = result.source
         _REGISTRY_PATH.write_text(dumps_registry_json(local_data), encoding="utf-8")
 
     return result
@@ -311,3 +420,12 @@ def sync_from_official_registry_sync(
 ) -> OfficialRegistrySyncResult:
     """Sync wrapper for sync_from_official_registry."""
     return asyncio.run(sync_from_official_registry(max_pages, page_size, dry_run))
+
+
+def sync_from_legacy_github_registry_sync(
+    *,
+    urls: tuple[str, ...] = _LEGACY_GITHUB_REGISTRY_URLS,
+    dry_run: bool = False,
+) -> OfficialRegistrySyncResult:
+    """Sync wrapper for sync_from_legacy_github_registry."""
+    return asyncio.run(sync_from_legacy_github_registry(urls=urls, dry_run=dry_run))

--- a/tests/test_mcp_official_registry.py
+++ b/tests/test_mcp_official_registry.py
@@ -10,6 +10,7 @@ from agent_bom.mcp_official_registry import (
     OfficialRegistryServer,
     official_registry_lookup_sync,
     search_official_registry_sync,
+    sync_from_legacy_github_registry_sync,
     sync_from_official_registry_sync,
 )
 from agent_bom.models import MCPServer, TransportType
@@ -223,6 +224,12 @@ def test_sync_adds_new(mock_client_factory, mock_request, tmp_path):
 
         data = json.loads(reg_file.read_text())
         assert "new/server" in data["servers"]
+        entry = data["servers"]["new/server"]
+        assert entry["source"] == "mcp-official"
+        assert entry["registry_source_url"] == "https://registry.modelcontextprotocol.io/v0/servers"
+        assert entry["source_fetched_at"].endswith("Z")
+        assert entry["version_source"] == "official-registry"
+        assert data["_mcp_registry_sync_source"] == "mcp-official"
 
 
 @patch("agent_bom.mcp_official_registry.request_with_retry")
@@ -252,6 +259,58 @@ def test_sync_skips_existing(mock_client_factory, mock_request, tmp_path):
         result = sync_from_official_registry_sync(max_pages=1, dry_run=False)
         assert result.added == 1
         assert result.skipped == 1
+
+
+@patch("agent_bom.mcp_official_registry.request_with_retry")
+@patch("agent_bom.mcp_official_registry.create_client")
+def test_legacy_github_fallback_labels_provenance(mock_client_factory, mock_request, tmp_path):
+    """Legacy raw GitHub fallback entries must not claim official API provenance."""
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client_factory.return_value = mock_client
+
+    mock_request.return_value = _make_response(
+        {
+            "servers": [
+                {
+                    "name": "legacy/server",
+                    "description": "Legacy registry entry",
+                    "category": "developer-tools",
+                }
+            ]
+        }
+    )
+
+    reg_file = tmp_path / "mcp_registry.json"
+    reg_file.write_text(json.dumps({"servers": {}}), encoding="utf-8")
+    fallback_url = "https://raw.githubusercontent.com/modelcontextprotocol/servers/main/servers.json"
+
+    with patch("agent_bom.mcp_official_registry._REGISTRY_PATH", reg_file):
+        result = sync_from_legacy_github_registry_sync(urls=(fallback_url,), dry_run=False)
+        assert result.added == 1
+        assert result.source == "mcp-official-github-fallback"
+        assert result.fallback_used is True
+
+        data = json.loads(reg_file.read_text(encoding="utf-8"))
+        entry = data["servers"]["legacy/server"]
+        assert entry["source"] == "mcp-official-github-fallback"
+        assert entry["source_url"] == fallback_url
+        assert entry["source_fetched_at"].endswith("Z")
+        assert entry["version_source"] == "legacy-github-fallback"
+        assert data["_mcp_registry_sync_source"] == "mcp-official-github-fallback"
+
+
+def test_mcp_registry_sync_workflow_prefers_official_api_and_labels_fallback():
+    """Scheduled sync should use the Official MCP Registry API before fallback."""
+    from pathlib import Path
+
+    workflow = Path(".github/workflows/mcp-registry-sync.yml").read_text(encoding="utf-8")
+    assert "sync_from_official_registry_sync" in workflow
+    assert "sync_from_legacy_github_registry_sync" in workflow
+    assert "result.total_fetched == 0" in workflow
+    assert "sync_source" in workflow
+    assert "version_source" in workflow
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary
- route scheduled MCP registry new-server sync through the Official MCP Registry API first
- keep legacy raw GitHub server lists as an explicit fallback with fallback provenance
- record sync source metadata and version_source fields; add regression coverage for provenance and workflow wiring

Verification
- PYTHONPATH=src uv run pytest tests/test_mcp_official_registry.py tests/test_deployment.py::test_mcp_registry_has_source_metadata tests/test_deployment.py::test_mcp_registry_descriptions_are_bounded -q
- uv run ruff check src/agent_bom/mcp_official_registry.py tests/test_mcp_official_registry.py
- uv run mypy src/agent_bom/mcp_official_registry.py --ignore-missing-imports --disable-error-code import-untyped
- PYTHONPATH=src python scripts/check_release_consistency.py && git diff --check

Notes
- The fallback path is labeled `mcp-official-github-fallback` so scheduled syncs do not overclaim Official MCP Registry API provenance when the API is unavailable.
- This PR changes sync provenance and workflow behavior only; it does not add or remove bundled registry entries.