### PR TITLE
fix(api): require middleware tenant context

### DIFF
--- a/src/agent_bom/api/routes/agent_manifest.py
+++ b/src/agent_bom/api/routes/agent_manifest.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Request
 
 from agent_bom.agent_manifest import build_control_plane_agent_manifest
 from agent_bom.api.stores import _get_fleet_store, _get_mcp_observation_store
+from agent_bom.api.tenancy import require_request_tenant_id
 
 router = APIRouter(prefix="/v1/agent-bom", tags=["Agent BOM"])
 
@@ -14,7 +15,7 @@ router = APIRouter(prefix="/v1/agent-bom", tags=["Agent BOM"])
 async def get_agent_bom_manifest(request: Request) -> dict[str, object]:
     """Return the tenant-scoped Agent BOM manifest from fleet/runtime stores."""
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     fleet_agents = _get_fleet_store().list_by_tenant(tenant_id)
     observations = _get_mcp_observation_store().list_by_tenant(tenant_id)
     return build_control_plane_agent_manifest(fleet_agents, observations, tenant_id=tenant_id)

--- a/src/agent_bom/api/routes/assets.py
+++ b/src/agent_bom/api/routes/assets.py
@@ -11,6 +11,8 @@ import logging
 
 from fastapi import APIRouter, Request
 
+from agent_bom.api.tenancy import require_request_tenant_id
+
 router = APIRouter()
 _logger = logging.getLogger(__name__)
 
@@ -32,7 +34,7 @@ async def list_assets(
     try:
         from agent_bom.asset_tracker import AssetTracker
 
-        with AssetTracker(tenant_id=getattr(request.state, "tenant_id", "default")) as tracker:
+        with AssetTracker(tenant_id=require_request_tenant_id(request)) as tracker:
             assets = tracker.list_assets(status=status, severity=severity, limit=limit)
             stats = tracker.stats()
             mttr = tracker.mttr_days()
@@ -59,7 +61,7 @@ async def get_asset_stats(request: Request) -> dict:
     try:
         from agent_bom.asset_tracker import AssetTracker
 
-        with AssetTracker(tenant_id=getattr(request.state, "tenant_id", "default")) as tracker:
+        with AssetTracker(tenant_id=require_request_tenant_id(request)) as tracker:
             stats = tracker.stats()
             mttr = tracker.mttr_days()
         return {"stats": stats, "mttr_days": mttr}

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -28,6 +28,7 @@ from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 
 from agent_bom.api.models import ComplianceReportBundle, JobStatus
 from agent_bom.api.stores import _get_analytics_store, _get_fleet_store, _get_policy_store, _get_store
+from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
 from agent_bom.rbac import require_authenticated_permission
 
@@ -64,7 +65,7 @@ _CLUSTER_ENVIRONMENTS = {"aks", "cluster", "eks", "gke", "k8s", "kubernetes"}
 
 
 def _tenant_id(request: Request) -> str:
-    return getattr(request.state, "tenant_id", "default")
+    return require_request_tenant_id(request)
 
 
 def _tenant_jobs(request: Request) -> list:

--- a/src/agent_bom/api/routes/credentials.py
+++ b/src/agent_bom/api/routes/credentials.py
@@ -15,6 +15,7 @@ from agent_bom.api.models import (
     CredentialRefUpdate,
 )
 from agent_bom.api.stores import _get_credential_ref_store
+from agent_bom.api.tenancy import require_request_tenant_id
 
 router = APIRouter()
 
@@ -24,7 +25,7 @@ def _now() -> str:
 
 
 def _tenant_id(request: Request) -> str:
-    return getattr(request.state, "tenant_id", "default")
+    return require_request_tenant_id(request)
 
 
 def _actor(request: Request) -> str:

--- a/src/agent_bom/api/routes/datasets.py
+++ b/src/agent_bom/api/routes/datasets.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from agent_bom.api.audit_log import log_action
 from agent_bom.api.dataset_version_store import DatasetVersionRecord, get_dataset_version_store
+from agent_bom.api.tenancy import require_request_tenant_id
 
 router = APIRouter()
 
@@ -49,7 +50,7 @@ class DatasetVersionCreate(BaseModel):
 
 
 def _tenant_id(request: Request) -> str:
-    return getattr(request.state, "tenant_id", "default")
+    return require_request_tenant_id(request)
 
 
 def _actor(request: Request) -> str:

--- a/src/agent_bom/api/routes/discovery.py
+++ b/src/agent_bom/api/routes/discovery.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from agent_bom.api.mcp_observation_store import MCPObservation, merge_observations
 from agent_bom.api.models import JobStatus
 from agent_bom.api.stores import _get_fleet_store, _get_mcp_observation_store, _get_store
+from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.asset_provenance import agent_discovery_provenance, package_discovery_provenance, package_version_provenance
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.security import (
@@ -42,7 +43,7 @@ def _clear_agents_response_cache_for_tests() -> None:
 
 
 def _tenant_id(request: Request) -> str:
-    return getattr(request.state, "tenant_id", "default")
+    return require_request_tenant_id(request)
 
 
 def _merge_strings(*values: list[str]) -> list[str]:

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -56,6 +56,7 @@ from agent_bom.api.models import (
     TenantQuotaUpdateRequest,
 )
 from agent_bom.api.stores import _get_exception_store, _get_issue_mapping_store, _get_store, _get_trend_store
+from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.security import sanitize_error
 
 router = APIRouter()
@@ -423,7 +424,7 @@ async def delete_browser_session(request: Request, response: Response) -> None:
     """Clear the same-origin browser session cookie."""
     from agent_bom.api.audit_log import log_action
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "browser-session"
     _clear_browser_session_cookie(response, request)
     log_action("auth.browser_session_cleared", actor=actor, resource="auth/session", tenant_id=tenant_id)
@@ -436,7 +437,7 @@ async def create_key(request: Request, req: CreateKeyRequest) -> dict:
     from agent_bom.api.audit_log import log_action
     from agent_bom.api.auth import Role, create_api_key, get_key_store
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or req.name
 
     try:
@@ -497,7 +498,7 @@ async def rotate_key(
     if req is None:
         req = RotateKeyRequest()
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "system"
     store = get_key_store()
     current_key = store.get(key_id)
@@ -557,7 +558,7 @@ async def list_keys(request: Request) -> dict:
     """List all API keys (without hashes or raw values)."""
     from agent_bom.api.auth import get_key_store
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     keys = get_key_store().list_keys(tenant_id=tenant_id)
     # P1-16 v0.86.5 audit: schema_version on terminal list response.
     return {"schema_version": "v1", "keys": [k.to_dict() for k in keys]}
@@ -600,7 +601,7 @@ async def auth_policy(request: Request) -> dict:
     rl_status = get_rate_limit_key_status()
     rl_runtime = get_rate_limit_runtime_status()
     auth_runtime = get_auth_runtime_status()
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     defaults = default_tenant_quotas()
     return {
         "api_key": {
@@ -704,7 +705,7 @@ async def auth_quota(request: Request) -> dict:
     """Return the effective tenant quota runtime surface for the current tenant."""
     from agent_bom.api.tenant_quota import get_tenant_quota_runtime
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     return get_tenant_quota_runtime(tenant_id)
 
 
@@ -719,7 +720,7 @@ async def update_auth_quota(request: Request, req: TenantQuotaUpdateRequest) -> 
         set_tenant_quota_overrides,
     )
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "system"
     updates = {name: getattr(req, name) for name in QUOTA_NAMES if name in req.model_fields_set}
     if not updates:
@@ -745,7 +746,7 @@ async def reset_auth_quota(request: Request) -> None:
     from agent_bom.api.audit_log import log_action
     from agent_bom.api.tenant_quota import clear_tenant_quota_overrides, get_tenant_quota_overrides
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "system"
     previous = get_tenant_quota_overrides(tenant_id)
     clear_tenant_quota_overrides(tenant_id)
@@ -830,7 +831,7 @@ async def delete_key(request: Request, key_id: str) -> None:
     from agent_bom.api.audit_log import log_action
     from agent_bom.api.auth import get_key_store
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "")
     store = get_key_store()
     key = store.get(key_id)
@@ -922,7 +923,7 @@ async def list_audit_entries(
     """List audit log entries with optional filters."""
     from agent_bom.api.audit_log import get_audit_log
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     store = get_audit_log()
     entries = store.list_entries(action=action, resource=resource, since=since, limit=limit, offset=offset, tenant_id=tenant_id)
     return {
@@ -956,7 +957,7 @@ async def audit_integrity(
     from agent_bom.api.audit_log import get_audit_log
     from agent_bom.audit_integrity import verify_audit_jsonl_chain
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     verified, tampered = get_audit_log().verify_integrity(limit=limit, tenant_id=tenant_id)
     chains: list[dict[str, Any]] = [
         {
@@ -1017,7 +1018,7 @@ async def export_audit_entries(
     if fmt not in {"json", "jsonl"}:
         raise HTTPException(status_code=400, detail="format must be one of: json, jsonl")
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "system"
     store = get_audit_log()
     entries = store.list_entries(action=action, resource=resource, since=since, limit=limit, offset=offset, tenant_id=tenant_id)
@@ -1084,7 +1085,7 @@ async def verify_audit_export(request: Request, body: AuditExportVerifyRequest) 
         payload = json.dumps(body.payload, sort_keys=True).encode("utf-8")
 
     valid = verify_export_payload(payload, body.signature)
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "system"
     log_action(
         "audit.export_verify",
@@ -1106,7 +1107,7 @@ async def create_exception(request: Request, req: ExceptionRequest) -> dict:
     from agent_bom.api.audit_log import log_action
     from agent_bom.api.exception_store import VulnException
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     exc = VulnException(
         vuln_id=req.vuln_id,
         package_name=req.package_name,
@@ -1137,7 +1138,7 @@ async def list_exceptions(
     offset: Annotated[int, Query(ge=0)] = 0,
 ) -> dict:
     """List all vulnerability exceptions."""
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     all_exceptions = _get_exception_store().list_all(status=status, tenant_id=tenant_id)
     total = len(all_exceptions)
     page = all_exceptions[offset : offset + limit]
@@ -1154,7 +1155,7 @@ async def list_exceptions(
 @router.get("/v1/exceptions/{exception_id}", tags=["enterprise"])
 async def get_exception(request: Request, exception_id: str) -> dict:
     """Get a specific exception."""
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     exc = _get_exception_store().get(exception_id, tenant_id=tenant_id)
     if exc is None:
         raise HTTPException(status_code=404, detail=f"Exception {exception_id} not found")
@@ -1167,7 +1168,7 @@ async def approve_exception(request: Request, exception_id: str) -> dict:
     from agent_bom.api.audit_log import log_action
     from agent_bom.api.exception_store import ExceptionStatus
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "system"
     store = _get_exception_store()
     exc = store.get(exception_id, tenant_id=tenant_id)
@@ -1189,7 +1190,7 @@ async def revoke_exception(request: Request, exception_id: str) -> dict:
     from agent_bom.api.audit_log import log_action
     from agent_bom.api.exception_store import ExceptionStatus
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "system"
     store = _get_exception_store()
     exc = store.get(exception_id, tenant_id=tenant_id)
@@ -1207,7 +1208,7 @@ async def delete_exception(request: Request, exception_id: str) -> None:
     """Delete an exception."""
     from agent_bom.api.audit_log import log_action
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "system"
     store = _get_exception_store()
     exc = store.get(exception_id, tenant_id=tenant_id)
@@ -1233,7 +1234,7 @@ async def compare_baseline(
     from agent_bom.baseline import compare_reports
 
     store = _get_store()
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "system"
     prev_job = store.get(previous_job_id, tenant_id=tenant_id)
     curr_job = store.get(current_job_id, tenant_id=tenant_id)
@@ -1262,7 +1263,7 @@ async def get_trends(request: Request, limit: int = 30) -> dict:
     """Get historical trend data — posture score and vuln counts over time."""
     from agent_bom.api.audit_log import log_action
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "system"
     history = _get_trend_store().get_history(limit=limit, tenant_id=tenant_id)
     log_action("trends.view", actor=actor, resource="trends", tenant_id=tenant_id, limit=limit)
@@ -1290,7 +1291,7 @@ async def test_siem_connection(request: Request, siem_type: str = "", url: str =
     from agent_bom.security import validate_url
     from agent_bom.siem import SIEMConfig, create_connector
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "system"
 
     # Validate URL to prevent SSRF
@@ -1352,7 +1353,7 @@ async def create_jira_ticket_route(
 
     if not jira_api_token:
         raise HTTPException(status_code=400, detail="Missing X-Jira-Api-Token header")
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or req.email or "system"
     target_kind, target_id = _jira_mapping_target(req)
     mapping_store = _get_issue_mapping_store()
@@ -1414,7 +1415,7 @@ async def update_issue_mapping_status(request: Request, mapping_id: str, req: Is
     """Update tenant-scoped external issue mapping status after provider sync."""
     from agent_bom.api.audit_log import log_action
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "system"
     mapping = _get_issue_mapping_store().update_status(mapping_id, tenant_id=tenant_id, status=req.status)
     if not mapping:
@@ -1464,7 +1465,7 @@ async def create_finding_feedback(request: Request, req: FindingFeedbackRequest)
     from agent_bom.api.audit_log import log_action
     from agent_bom.api.exception_store import ExceptionStatus, VulnException
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = _request_actor(request)
     exc = VulnException(
         vuln_id=req.vulnerability_id,
@@ -1493,7 +1494,7 @@ async def create_finding_feedback(request: Request, req: FindingFeedbackRequest)
 @router.get("/v1/findings/feedback", tags=["enterprise"])
 async def list_finding_feedback(request: Request, state: str | None = None) -> dict:
     """List tenant-scoped finding feedback entries."""
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     entries = []
     for exc in _get_exception_store().list_all(tenant_id=tenant_id):
         parsed = _parse_feedback_reason(exc.reason)
@@ -1509,7 +1510,7 @@ async def list_finding_feedback(request: Request, state: str | None = None) -> d
 @router.get("/v1/findings/false-positives", tags=["enterprise"])
 async def list_false_positives(request: Request) -> dict:
     """List all false positive entries."""
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     all_exceptions = _get_exception_store().list_all(tenant_id=tenant_id)
     fps = [e for e in all_exceptions if (_parse_feedback_reason(e.reason) or ("", ""))[0] == "false_positive"]
     return {
@@ -1534,7 +1535,7 @@ async def remove_false_positive(request: Request, fp_id: str) -> None:
     """Un-mark a false positive."""
     from agent_bom.api.audit_log import log_action
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = _request_actor(request)
     store = _get_exception_store()
     exc = store.get(fp_id, tenant_id=tenant_id)
@@ -1551,7 +1552,7 @@ async def remove_finding_feedback(request: Request, feedback_id: str) -> None:
     """Remove tenant-scoped finding feedback without deleting audit history."""
     from agent_bom.api.audit_log import log_action
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = _request_actor(request)
     store = _get_exception_store()
     exc = store.get(feedback_id, tenant_id=tenant_id)

--- a/src/agent_bom/api/routes/entitlements.py
+++ b/src/agent_bom/api/routes/entitlements.py
@@ -7,6 +7,7 @@ import logging
 from fastapi import APIRouter, Request
 
 from agent_bom.api.audit_log import AuditEntry, get_audit_log
+from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.entitlements import load_entitlement_state
 
 router = APIRouter()
@@ -14,7 +15,7 @@ _logger = logging.getLogger(__name__)
 
 
 def _audit_entitlement_read(request: Request, *, resource: str, details: dict[str, object]) -> None:
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", None) or getattr(request.state, "api_key_role", None) or "system"
     try:
         get_audit_log().append(

--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, HTTPException, Request
 from agent_bom.api.mcp_observation_store import MCPObservation, merge_observations
 from agent_bom.api.models import FleetAgentUpdate, PushPayload, StateUpdate
 from agent_bom.api.stores import _get_fleet_store, _get_idempotency_store, _get_mcp_observation_store
+from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.api.tenant_quota import enforce_fleet_agents_quota, tenant_quota_guard
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.security import sanitize_command_args, sanitize_security_warnings, sanitize_text, sanitize_url
@@ -98,7 +99,7 @@ async def list_fleet(
     """
     limit = max(1, min(limit, 200))
     offset = max(0, offset)
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     min_trust_value = float(min_trust) if min_trust is not None else None
     search_value = (search or "").strip() or None
     store = _get_fleet_store()
@@ -141,7 +142,7 @@ async def list_fleet(
 @router.get("/v1/fleet/stats", tags=["fleet"])
 async def fleet_stats(request: Request):
     """Fleet-wide statistics."""
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     agents = _get_fleet_store().list_by_tenant(tenant_id)
     by_state: dict[str, int] = {}
     by_env: dict[str, int] = {}
@@ -164,7 +165,7 @@ async def fleet_stats(request: Request):
 @router.get("/v1/fleet/{agent_id}", tags=["fleet"])
 async def get_fleet_agent(request: Request, agent_id: str):
     """Get a single fleet agent with trust score breakdown."""
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     agent = _get_fleet_store().get(agent_id, tenant_id=tenant_id)
     if agent is None:
         raise HTTPException(status_code=404, detail="Fleet agent not found")
@@ -265,7 +266,7 @@ async def sync_fleet(request: Request, body: PushPayload | None = None):
     from agent_bom.fleet.trust_scoring import compute_trust_score
 
     store = _get_fleet_store()
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "system"
     now = datetime.now(timezone.utc).isoformat()
     source_id = (body.source_id if body else "") or _request_header(request, "X-Agent-Bom-Source-Id") or "server-discovery"
@@ -450,7 +451,7 @@ async def update_fleet_state(request: Request, agent_id: str, body: StateUpdate)
             detail=f"Invalid state: {body.state}. Valid: {[s.value for s in FleetLifecycleState]}",
         )
     store = _get_fleet_store()
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "system"
     agent = store.get(agent_id, tenant_id=tenant_id)
     if agent is None:
@@ -472,7 +473,7 @@ async def update_fleet_agent(request: Request, agent_id: str, body: FleetAgentUp
     from agent_bom.api.audit_log import log_action
 
     store = _get_fleet_store()
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "system"
     agent = store.get(agent_id, tenant_id=tenant_id)
     if agent is None:

--- a/src/agent_bom/api/routes/gateway.py
+++ b/src/agent_bom/api/routes/gateway.py
@@ -28,6 +28,7 @@ from fastapi.responses import JSONResponse, Response
 
 from agent_bom.api.models import EvaluateRequest, JobStatus, PolicyCreate, PolicyUpdate
 from agent_bom.api.stores import _get_firewall_decision_store, _get_policy_store, _get_store
+from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.gateway_upstreams import is_gateway_compatible_upstream_transport
 from agent_bom.rbac import require_authenticated_permission
 
@@ -166,7 +167,7 @@ def _firewall_string_list(value: Any, field_name: str) -> set[str]:
 @router.get("/v1/gateway/policies", tags=["gateway"], dependencies=[_dep("policy_read")])
 async def list_gateway_policies(request: Request, enabled: bool | None = None, mode: str | None = None):
     """List all gateway policies."""
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     policies = _get_policy_store().list_policies(tenant_id=tenant_id)
     if enabled is not None:
         policies = [p for p in policies if p.enabled == enabled]
@@ -196,7 +197,7 @@ async def create_gateway_policy(body: PolicyCreate, request: Request):
         )
     now = datetime.now(timezone.utc).isoformat()
     rules = [GatewayRule(**r) for r in body.rules]
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     policy = GatewayPolicy(
         policy_id=str(uuid.uuid4()),
         name=body.name,
@@ -229,7 +230,7 @@ async def create_gateway_policy(body: PolicyCreate, request: Request):
 @router.get("/v1/gateway/policies/{policy_id}", tags=["gateway"], dependencies=[_dep("policy_read")])
 async def get_gateway_policy(policy_id: str, request: Request):
     """Get a gateway policy by ID."""
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     policy = _get_policy_store().get_policy(policy_id, tenant_id=tenant_id)
     if policy is None:
         raise HTTPException(status_code=404, detail="Policy not found")
@@ -243,7 +244,7 @@ async def update_gateway_policy(policy_id: str, body: PolicyUpdate, request: Req
     from agent_bom.api.policy_store import GatewayRule, PolicyMode
 
     store = _get_policy_store()
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     policy = store.get_policy(policy_id, tenant_id=tenant_id)
     if policy is None:
         raise HTTPException(status_code=404, detail="Policy not found")
@@ -288,7 +289,7 @@ async def update_gateway_policy(policy_id: str, body: PolicyUpdate, request: Req
 @router.delete("/v1/gateway/policies/{policy_id}", tags=["gateway"], dependencies=[_dep("policy_write")])
 async def delete_gateway_policy(policy_id: str, request: Request):
     """Delete a gateway policy."""
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     store = _get_policy_store()
     policy = store.get_policy(policy_id, tenant_id=tenant_id)
     if policy is None:
@@ -329,7 +330,7 @@ async def evaluate_gateway(body: EvaluateRequest, request: Request):
     from agent_bom.api.policy_store import PolicyAuditEntry
     from agent_bom.gateway import evaluate_gateway_policies_detail
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     store = _get_policy_store()
     policies = store.list_policies(tenant_id=tenant_id)
     active = [p for p in policies if p.enabled]
@@ -408,7 +409,7 @@ async def list_gateway_audit(
     limit: int = Query(100, ge=1, le=1000),
 ):
     """Query the gateway policy audit log."""
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     entries = _get_policy_store().list_audit_entries(
         policy_id=policy_id,
         agent_name=agent_name,
@@ -458,7 +459,7 @@ async def discovered_upstreams(request: Request) -> dict:
     upstream whether to switch it to ``bearer`` + ``token_env`` when
     merging with their authored overrides.
     """
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     jobs = _get_store().list_all(tenant_id=tenant_id)
 
     # Key by (name, url) so two laptops reporting the same MCP name pointed
@@ -539,7 +540,7 @@ async def gateway_stats(request: Request):
     """Gateway-wide statistics."""
     from agent_bom.gateway import summarize_gateway_policies
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     policies = _get_policy_store().list_policies(tenant_id=tenant_id)
     audit = _get_policy_store().list_audit_entries(limit=10000, tenant_id=tenant_id)
     active_policies = [p for p in policies if p.enabled]
@@ -606,7 +607,7 @@ async def firewall_check(request: Request):
         source_roles=source_roles,
         target_roles=target_roles,
     )
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     now = datetime.now(timezone.utc).timestamp()
     matched_rule = _firewall_rule_payload(result.matched_rule)
     event = {
@@ -648,5 +649,5 @@ async def firewall_stats(request: Request):
     """
     from agent_bom.api.stores import _get_firewall_decision_store
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     return _get_firewall_decision_store().stats(tenant_id=tenant_id, recent_limit=200, top_pairs=25)

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -37,6 +37,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict, Field
 
 from agent_bom.api.stores import _get_graph_store
+from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
 from agent_bom.graph import SEVERITY_RANK, AttackPath, EntityType, GraphFilterOptions, GraphSemanticLayer, RelationshipType, UnifiedGraph
 from agent_bom.graph.semantic_clusters import SEMANTIC_CLUSTER_KINDS, build_semantic_clusters, semantic_cluster_stats
@@ -174,7 +175,7 @@ def _get_graph_store_or_503():
 
 def _tenant(request: Request) -> str:
     """Extract tenant_id from request (set by auth middleware)."""
-    return getattr(request.state, "tenant_id", "default")
+    return require_request_tenant_id(request)
 
 
 def _paginate(items: list, offset: int, limit: int) -> tuple[list, dict]:

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, HTTPException, Request
 from agent_bom.api.models import JobStatus, PushPayload, ScanJob, ScanRequest
 from agent_bom.api.pipeline import _persist_graph_snapshot
 from agent_bom.api.stores import _get_analytics_store, _get_fleet_store, _get_store
+from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.api.tenant_quota import enforce_retained_jobs_quota, tenant_quota_guard
 from agent_bom.graph.severity import ocsf_to_severity
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
@@ -46,7 +47,7 @@ def _now() -> str:
 
 
 def _tenant_id(request: Request) -> str:
-    return getattr(request.state, "tenant_id", "default")
+    return require_request_tenant_id(request)
 
 
 def _triggered_by(request: Request) -> str:

--- a/src/agent_bom/api/routes/posture_streaming.py
+++ b/src/agent_bom/api/routes/posture_streaming.py
@@ -7,6 +7,7 @@ from typing import Annotated
 from fastapi import APIRouter, HTTPException, Query, Request
 
 from agent_bom.api.audit_log import log_action
+from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.posture_streaming import WebhookOutbox, default_webhook_outbox_path
 
 router = APIRouter()
@@ -16,7 +17,7 @@ _OUTBOX_OVERRIDE = False
 
 
 def _tenant_id(request: Request) -> str:
-    return getattr(request.state, "tenant_id", "default")
+    return require_request_tenant_id(request)
 
 
 def _actor(request: Request) -> str:

--- a/src/agent_bom/api/routes/privacy.py
+++ b/src/agent_bom/api/routes/privacy.py
@@ -19,6 +19,7 @@ from agent_bom.api.stores import (
     _get_store,
     _get_tenant_quota_store,
 )
+from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.platform_invariants import normalize_tenant_id
 from agent_bom.rbac import require_authenticated_permission
 
@@ -43,7 +44,7 @@ def _sanitize_log_value(value: object, max_len: int = 128) -> str:
 
 
 def _request_tenant(request: Request) -> str:
-    return normalize_tenant_id(str(getattr(request.state, "tenant_id", "") or "default"))
+    return require_request_tenant_id(request)
 
 
 def _require_same_tenant(request: Request, tenant_id: str) -> None:

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, HTTPException, Query, Request, WebSocket
 
+from agent_bom.api.tenancy import require_request_tenant_id
+
 if TYPE_CHECKING:
     from agent_bom.runtime.protection import ProtectionEngine
 
@@ -111,7 +113,7 @@ def push_proxy_metrics(metrics: dict) -> None:
 
 def _request_tenant_id(request: Request) -> str:
     """Return the authenticated tenant for HTTP proxy endpoints."""
-    return str(getattr(request.state, "tenant_id", "default") or "default")
+    return require_request_tenant_id(request)
 
 
 def _alert_visible_to_tenant(alert: dict, tenant_id: str) -> bool:
@@ -132,7 +134,7 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
     from agent_bom.api.stores import _get_analytics_store
 
     actor = getattr(request.state, "api_key_name", "") or "proxy-client"
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     request_id = getattr(request.state, "request_id", "") or ""
     trace_id = getattr(request.state, "trace_id", "") or ""
     source_id = body.source_id or "unknown"
@@ -1105,7 +1107,7 @@ async def break_glass(request: Request, session_id: str = "default", reason: str
     try:
         from agent_bom.api.audit_log import log_action
 
-        tenant_id = getattr(request.state, "tenant_id", "default")
+        tenant_id = require_request_tenant_id(request)
         log_action(
             "break_glass",
             actor=role,

--- a/src/agent_bom/api/routes/runtime_blueprints.py
+++ b/src/agent_bom/api/routes/runtime_blueprints.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Request
 
+from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.runtime_blueprints import evaluate_runtime_blueprint_drift, runtime_role_blueprint, runtime_role_blueprints
 
 router = APIRouter(tags=["runtime"])
 
 
 def _request_tenant_id(request: Request) -> str:
-    return str(getattr(request.state, "tenant_id", "default") or "default")
+    return require_request_tenant_id(request)
 
 
 @router.get("/v1/runtime/blueprints")

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -59,6 +59,7 @@ from agent_bom.api.stores import (
     _jobs_pop,
     _jobs_put,
 )
+from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.api.tenant_quota import enforce_active_scan_quota, enforce_retained_jobs_quota, tenant_quota_guard
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
 
@@ -213,7 +214,7 @@ def _dataclass_to_dict(obj: object) -> object:
 
 
 def _tenant_id(request: Request) -> str:
-    return getattr(request.state, "tenant_id", "default")
+    return require_request_tenant_id(request)
 
 
 def _triggered_by(request: Request) -> str:

--- a/src/agent_bom/api/routes/schedules.py
+++ b/src/agent_bom/api/routes/schedules.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from agent_bom.api.models import ScheduleCreate
 from agent_bom.api.stores import _get_schedule_store
+from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.api.tenant_quota import enforce_schedule_quota, tenant_quota_guard
 
 router = APIRouter()
@@ -29,7 +30,7 @@ async def create_schedule(request: Request, body: ScheduleCreate) -> dict:
     from agent_bom.api.schedule_store import ScanSchedule
     from agent_bom.api.scheduler import parse_cron_next, validate_cron_expression
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "system"
     if body.tenant_id not in ("default", tenant_id):
         raise HTTPException(status_code=403, detail="Forbidden — tenant_id must match the authenticated tenant")
@@ -67,14 +68,14 @@ async def create_schedule(request: Request, body: ScheduleCreate) -> dict:
 @router.get("/v1/schedules", tags=["schedules"])
 async def list_schedules(request: Request) -> list[dict]:
     """List all scan schedules."""
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     return [s.model_dump() for s in _get_schedule_store().list_all(tenant_id=tenant_id)]
 
 
 @router.get("/v1/schedules/{schedule_id}", tags=["schedules"])
 async def get_schedule(request: Request, schedule_id: str) -> dict:
     """Get a specific schedule."""
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     s = _get_schedule_store().get(schedule_id, tenant_id=tenant_id)
     if s is None:
         raise HTTPException(status_code=404, detail=f"Schedule {schedule_id} not found")
@@ -86,7 +87,7 @@ async def delete_schedule(request: Request, schedule_id: str):
     """Delete a schedule."""
     from agent_bom.api.audit_log import log_action
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "system"
     s = _get_schedule_store().get(schedule_id, tenant_id=tenant_id)
     if s is None:
@@ -100,7 +101,7 @@ async def toggle_schedule(request: Request, schedule_id: str) -> dict:
     """Enable or disable a schedule."""
     from agent_bom.api.audit_log import log_action
 
-    tenant_id = getattr(request.state, "tenant_id", "default")
+    tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or "system"
     s = _get_schedule_store().get(schedule_id, tenant_id=tenant_id)
     if s is None:

--- a/src/agent_bom/api/routes/scim.py
+++ b/src/agent_bom/api/routes/scim.py
@@ -12,6 +12,7 @@ from agent_bom.api.audit_log import log_action
 from agent_bom.api.scim import extract_scim_roles, scim_base_path, scim_enabled_from_env, scim_role_attribute
 from agent_bom.api.scim_store import SCIMGroup, SCIMUser
 from agent_bom.api.stores import _get_scim_store
+from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.platform_invariants import now_utc_iso
 
 SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User"
@@ -33,7 +34,7 @@ _ACTIVE_FILTER_RE = re.compile(r'^\s*active\s+eq\s+"?(true|false)"?\s*$', re.IGN
 
 
 def _tenant_id(request: Request) -> str:
-    return str(getattr(request.state, "tenant_id", "") or "default")
+    return require_request_tenant_id(request)
 
 
 def _actor(request: Request) -> str:

--- a/src/agent_bom/api/routes/sources.py
+++ b/src/agent_bom/api/routes/sources.py
@@ -21,6 +21,7 @@ from agent_bom.api.models import (
 )
 from agent_bom.api.routes.scan import enqueue_scan_job
 from agent_bom.api.stores import _get_credential_ref_store, _get_source_store, _get_store
+from agent_bom.api.tenancy import require_request_tenant_id
 
 router = APIRouter()
 
@@ -30,7 +31,7 @@ def _now() -> str:
 
 
 def _tenant_id(request: Request) -> str:
-    return getattr(request.state, "tenant_id", "default")
+    return require_request_tenant_id(request)
 
 
 def _actor(request: Request) -> str:

--- a/src/agent_bom/api/tenancy.py
+++ b/src/agent_bom/api/tenancy.py
@@ -1,0 +1,19 @@
+"""Tenant helpers for authenticated API request handlers."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, Request
+
+from agent_bom.platform_invariants import normalize_tenant_id
+
+
+def require_request_tenant_id(request: Request) -> str:
+    """Return the middleware-established tenant id for an API request.
+
+    Route handlers should not silently invent the default tenant. The API
+    middleware owns that fallback so a missing request tenant fails closed
+    instead of crossing into the single-tenant bucket by accident.
+    """
+    if not hasattr(request.state, "tenant_id"):
+        raise HTTPException(status_code=500, detail="Authenticated tenant context is unavailable")
+    return normalize_tenant_id(str(request.state.tenant_id))

--- a/tests/test_api_tenancy.py
+++ b/tests/test_api_tenancy.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from agent_bom.api.routes import credentials as credential_routes
+from agent_bom.api.tenancy import require_request_tenant_id
+
+
+def _request_with_state(**state: object) -> SimpleNamespace:
+    return SimpleNamespace(state=SimpleNamespace(**state))
+
+
+def test_require_request_tenant_id_uses_middleware_state() -> None:
+    request = _request_with_state(tenant_id=" tenant-alpha ")
+
+    assert require_request_tenant_id(request) == "tenant-alpha"  # type: ignore[arg-type]
+
+
+def test_require_request_tenant_id_fails_closed_without_state() -> None:
+    request = _request_with_state()
+
+    with pytest.raises(HTTPException) as exc:
+        require_request_tenant_id(request)  # type: ignore[arg-type]
+
+    assert exc.value.status_code == 500
+    assert exc.value.detail == "Authenticated tenant context is unavailable"
+
+
+def test_route_tenant_helpers_do_not_invent_default_tenant() -> None:
+    request = _request_with_state()
+
+    with pytest.raises(HTTPException) as exc:
+        credential_routes._tenant_id(request)  # type: ignore[arg-type]
+
+    assert exc.value.status_code == 500


### PR DESCRIPTION
Summary

- add a shared request-tenant helper that fails closed when middleware did not establish tenant context
- route API tenant lookups through the helper instead of silently inventing the default tenant
- add regression coverage for middleware-provided tenant IDs and missing tenant context

Verification

- uv run ruff check src/agent_bom/api/tenancy.py src/agent_bom/api/routes tests/test_api_tenancy.py
- PYTHONPATH=src uv run pytest tests/test_api_tenancy.py tests/test_api_tenant_isolation.py tests/test_api_scim_lifecycle.py -q
- uv run mypy src/agent_bom/api/tenancy.py src/agent_bom/api/routes --ignore-missing-imports --disable-error-code import-untyped
- git diff --check

Notes

- The documented single-tenant default remains owned by API middleware; route handlers no longer create that fallback if request state is missing.
