### PR TITLE
feat(sdk): expand typescript control-plane client

### DIFF
--- a/sdks/typescript-client/README.md
+++ b/sdks/typescript-client/README.md
@@ -23,6 +23,9 @@ const client = new AgentBomClient({
 });
 
 const health = await client.health();
+const manifest = await client.agentManifest();
+const runtime = await client.runtimeProductionIndex();
+const findings = await client.listFindings({ severity: "high" });
 const paths = await client.exposurePaths({ limit: 5, minRisk: 70 });
 const decision = await client.shouldIDeploy({
   candidate: "flask@2.0.0",
@@ -37,8 +40,27 @@ const dataset = await client.registerDatasetVersion({
   versionId: "2026-05-17",
   source: "ci",
 });
+const versions = await client.datasetVersions("hf-corpus");
+const version = await client.datasetVersion("hf-corpus", "2026-05-17");
+const advisory = await client.intelLookup("CVE-2026-0001");
+const intel = await client.intelMatch({ ecosystem: "npm", name: "demo", version: "1.0.0" });
+const sources = await client.intelSources();
 
-console.log(health.status, paths.paths.length, decision.decision, ingest.ingested, dataset.dataset.version_id);
+console.log(
+  health.status,
+  manifest.schema_version,
+  runtime.schema_version,
+  findings.count,
+  paths.paths.length,
+  decision.decision,
+  ingest.ingested,
+  dataset.dataset.version_id,
+  versions.count,
+  version.dataset.version_id,
+  advisory.schema_version,
+  intel.schema_version,
+  sources.schema_version,
+);
 ```
 
 ## Boundary

--- a/sdks/typescript-client/src/index.ts
+++ b/sdks/typescript-client/src/index.ts
@@ -33,6 +33,13 @@ export interface ExposurePathQuery {
   minRisk?: number;
 }
 
+export interface FindingsQuery {
+  severity?: string;
+  sort?: string;
+  limit?: number;
+  offset?: number;
+}
+
 export interface ExposurePathEnvelope {
   paths: JsonValue[];
   nodes?: JsonValue[];
@@ -114,6 +121,15 @@ export interface DatasetVersionsResponse {
   count: number;
 }
 
+export interface IntelMatchRequest {
+  packages?: Record<string, JsonValue>[];
+  purl?: string;
+  ecosystem?: string;
+  name?: string;
+  version?: string;
+  limit?: number;
+}
+
 export class AgentBomApiError extends Error {
   readonly status: number;
   readonly body: string;
@@ -177,6 +193,20 @@ export class AgentBomClient {
     );
   }
 
+  listFindings(query: FindingsQuery = {}): Promise<Record<string, JsonValue>> {
+    const search = new URLSearchParams();
+    search.set("sort", query.sort ?? "effective_reach");
+    search.set("limit", String(query.limit ?? 500));
+    search.set("offset", String(query.offset ?? 0));
+    if (query.severity) {
+      search.set("severity", query.severity);
+    }
+    return this.request<Record<string, JsonValue>>(
+      "GET",
+      `/v1/findings${formatSearch(search)}`,
+    );
+  }
+
   shouldIDeploy(request: DeployDecisionRequest): Promise<DeployDecision> {
     return this.request<DeployDecision>("POST", "/v1/graph/should-i-deploy", {
       candidate: request.candidate,
@@ -221,6 +251,60 @@ export class AgentBomClient {
       "GET",
       `/v1/datasets/${encodeURIComponent(datasetId)}/versions`,
     );
+  }
+
+  datasetVersion(
+    datasetId: string,
+    versionId: string,
+  ): Promise<DatasetVersionResponse> {
+    return this.request<DatasetVersionResponse>(
+      "GET",
+      `/v1/datasets/${encodeURIComponent(datasetId)}/versions/${encodeURIComponent(versionId)}`,
+    );
+  }
+
+  agentManifest(): Promise<Record<string, JsonValue>> {
+    const search = new URLSearchParams();
+    if (this.tenantId) {
+      search.set("tenant_id", this.tenantId);
+    }
+    return this.request<Record<string, JsonValue>>(
+      "GET",
+      `/v1/agent-bom/manifest${formatSearch(search)}`,
+    );
+  }
+
+  runtimeProductionIndex(): Promise<Record<string, JsonValue>> {
+    const search = new URLSearchParams();
+    if (this.tenantId) {
+      search.set("tenant_id", this.tenantId);
+    }
+    return this.request<Record<string, JsonValue>>(
+      "GET",
+      `/v1/runtime/production-index${formatSearch(search)}`,
+    );
+  }
+
+  intelLookup(advisoryId: string): Promise<Record<string, JsonValue>> {
+    return this.request<Record<string, JsonValue>>(
+      "GET",
+      `/v1/intel/advisories/${encodeURIComponent(advisoryId)}`,
+    );
+  }
+
+  intelMatch(request: IntelMatchRequest): Promise<Record<string, JsonValue>> {
+    return this.request<Record<string, JsonValue>>("POST", "/v1/intel/match", {
+      packages: request.packages,
+      purl: request.purl,
+      ecosystem: request.ecosystem,
+      name: request.name,
+      version: request.version,
+      limit: request.limit,
+    });
+  }
+
+  intelSources(): Promise<Record<string, JsonValue>> {
+    return this.request<Record<string, JsonValue>>("GET", "/v1/intel/sources");
   }
 
   async request<T>(

--- a/sdks/typescript-client/tests/client.test.js
+++ b/sdks/typescript-client/tests/client.test.js
@@ -163,6 +163,103 @@ test("lists dataset versions", async () => {
   assert.equal(response.count, 0);
 });
 
+test("lists findings with default query params", async () => {
+  let seenUrl = "";
+  const client = new AgentBomClient({
+    baseUrl: "https://agent-bom.example.com",
+    fetch: async (url) => {
+      seenUrl = String(url);
+      return jsonResponse({ findings: [], count: 0 });
+    },
+  });
+
+  const response = await client.listFindings({ severity: "high" });
+
+  assert.equal(
+    seenUrl,
+    "https://agent-bom.example.com/v1/findings?sort=effective_reach&limit=500&offset=0&severity=high",
+  );
+  assert.equal(response.count, 0);
+});
+
+test("gets a single dataset version", async () => {
+  let seenUrl = "";
+  const client = new AgentBomClient({
+    baseUrl: "https://agent-bom.example.com",
+    fetch: async (url) => {
+      seenUrl = String(url);
+      return jsonResponse({
+        schema_version: "v1",
+        dataset: {
+          tenant_id: "tenant-d",
+          dataset_id: "hf/corpus",
+          version_id: "2026/05/25",
+          created_at: "2026-05-25T00:00:00Z",
+          source: "ci",
+        },
+      });
+    },
+  });
+
+  const response = await client.datasetVersion("hf/corpus", "2026/05/25");
+
+  assert.equal(
+    seenUrl,
+    "https://agent-bom.example.com/v1/datasets/hf%2Fcorpus/versions/2026%2F05%2F25",
+  );
+  assert.equal(response.dataset.version_id, "2026/05/25");
+});
+
+test("reads manifest and runtime index with tenant query", async () => {
+  const seenUrls = [];
+  const client = new AgentBomClient({
+    baseUrl: "https://agent-bom.example.com",
+    tenantId: "tenant-e",
+    fetch: async (url) => {
+      seenUrls.push(String(url));
+      return jsonResponse({ schema_version: "v1" });
+    },
+  });
+
+  await client.agentManifest();
+  await client.runtimeProductionIndex();
+
+  assert.deepEqual(seenUrls, [
+    "https://agent-bom.example.com/v1/agent-bom/manifest?tenant_id=tenant-e",
+    "https://agent-bom.example.com/v1/runtime/production-index?tenant_id=tenant-e",
+  ]);
+});
+
+test("wraps intel lookup match and sources", async () => {
+  const seen = [];
+  const client = new AgentBomClient({
+    baseUrl: "https://agent-bom.example.com",
+    fetch: async (url, init = {}) => {
+      seen.push({ url: String(url), body: init.body ? JSON.parse(init.body) : undefined });
+      return jsonResponse({ schema_version: "intel.lookup.v1", matches: [] });
+    },
+  });
+
+  await client.intelLookup("CVE-2026-0001");
+  await client.intelMatch({ ecosystem: "npm", name: "demo", version: "1.0.0", limit: 3 });
+  await client.intelSources();
+
+  assert.deepEqual(seen, [
+    {
+      url: "https://agent-bom.example.com/v1/intel/advisories/CVE-2026-0001",
+      body: undefined,
+    },
+    {
+      url: "https://agent-bom.example.com/v1/intel/match",
+      body: { ecosystem: "npm", name: "demo", version: "1.0.0", limit: 3 },
+    },
+    {
+      url: "https://agent-bom.example.com/v1/intel/sources",
+      body: undefined,
+    },
+  ]);
+});
+
 test("throws typed errors for non-2xx responses", async () => {
   const client = new AgentBomClient({
     baseUrl: "https://agent-bom.example.com",


### PR DESCRIPTION
Summary

- add TypeScript control-plane wrappers for findings list, single dataset version lookup, agent manifest, runtime production index, and intel lookup/match/sources
- extend the TypeScript client tests for the added request paths, query serialization, and payload shaping
- refresh the TypeScript client README example to cover the broader stable API surface

Verification

- npm test (sdks/typescript-client)
- npm run lint (sdks/typescript-client)
- PYTHONPATH=src uv run pytest tests/test_typescript_client_route_parity.py -q
- git diff --check

Notes

- The runtime detector package remains separate; this PR only expands the `@agent-bom/client` control-plane package.
