### PR TITLE
docs(cloud): clarify posture and iac lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Screenshot capture rules and the full manifest live in
 | Pre-install guard | `agent-bom check flask@2.0.0 --ecosystem pypi` | deterministic allow/warn/block result |
 | Container image scan | `agent-bom image nginx:latest` | image findings and remediation |
 | IaC scan | `agent-bom iac Dockerfile k8s/ infra/main.tf` | IaC findings and policy context |
+| Cloud posture check | `agent-bom cis-benchmark --provider aws` | runtime CIS posture evidence |
 | CI gate | `uses: msaad00/agent-bom@v0.88.3` | SARIF, PR summary, optional code-scanning upload |
 | MCP tools | `pip install 'agent-bom[mcp-server]' && agent-bom mcp server` | strict-args security tools for MCP clients |
 | Local API/UI | `pip install 'agent-bom[ui]' && agent-bom serve` | API plus bundled dashboard |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - MCP Server Setup: getting-started/mcp-server.md
   - Features:
       - Scanning & Discovery: features/scanning.md
+      - Cloud Posture and IaC Gates: features/cloud-posture.md
       - Blast Radius: features/blast-radius.md
       - Cloud Normalization: features/cloud-normalization.md
       - Compliance: features/compliance.md

--- a/site-docs/features/cloud-posture.md
+++ b/site-docs/features/cloud-posture.md
@@ -1,0 +1,85 @@
+# Cloud Posture and IaC Gates
+
+agent-bom treats cloud posture as two connected checks over the same evidence
+model:
+
+1. **Pre-cloud IaC gates** catch misconfigurations before Terraform,
+   CloudFormation, Kubernetes, or Docker changes reach an account or cluster.
+2. **Runtime cloud posture checks** verify the deployed account or service
+   state after drift, console changes, inherited policies, and provider-side
+   defaults exist.
+
+Use both lanes when possible. The IaC lane is the default pull-request and
+release gate because it is fast, read-only, and blocks unsafe changes before
+deployment. The runtime lane is the drift and assurance check because it sees
+what actually exists in the cloud.
+
+## Pre-cloud lane
+
+Run the focused IaC scanner before apply:
+
+```bash
+agent-bom iac Dockerfile k8s/ infra/main.tf --format sarif --output agent-bom-iac.sarif
+```
+
+In GitHub Actions, use the `iac` scan type or the `iac` input:
+
+```yaml
+- uses: msaad00/agent-bom@v0.88.3
+  with:
+    scan-type: iac
+    scan-ref: infra/main.tf,k8s/
+    format: sarif
+    upload-sarif: true
+    severity-threshold: high
+```
+
+The IaC scanner is read-only. It analyzes local files and emits findings,
+policy context, SARIF, JSON, or other report formats without applying
+infrastructure.
+
+Supported pre-cloud inputs include:
+
+- Terraform
+- CloudFormation
+- Kubernetes manifests and Helm-rendered output
+- Dockerfiles
+
+## Runtime posture lane
+
+Run cloud benchmark checks against the actual environment when credentials are
+available:
+
+```bash
+agent-bom cis-benchmark --provider aws
+agent-bom cis-benchmark --provider azure
+agent-bom cis-benchmark --provider gcp
+agent-bom cis-benchmark --provider snowflake
+```
+
+These checks are for deployed state, not planned state. They catch drift and
+environment properties that do not appear in a pull request, such as:
+
+- manually changed identity or logging settings
+- inherited organization, subscription, or project policy
+- cloud-provider defaults
+- resources created outside the reviewed IaC path
+- service posture that depends on account-level configuration
+
+## How to read the result
+
+The useful question is not "IaC or CSPM?" It is:
+
+| Moment | Best command | What it proves |
+|---|---|---|
+| Before merge | `agent-bom iac ...` | Proposed infrastructure does not introduce known high-risk misconfiguration |
+| Before apply | `agent-bom iac ... --format sarif` in CI | The exact deployment artifact passed the gate |
+| After deploy | `agent-bom cis-benchmark --provider ...` | The live environment still satisfies benchmark expectations |
+| During investigation | graph exposure paths and findings APIs | Misconfiguration, packages, agents, credentials, and runtime evidence can be reviewed together |
+
+## Boundary
+
+agent-bom does not apply Terraform, mutate CloudFormation stacks, or change
+cloud settings as part of posture scanning. It reports evidence and exits with
+deterministic codes so the operator, CI system, or control plane can decide
+whether to block, approve, or open a remediation workflow.

--- a/site-docs/features/scanning.md
+++ b/site-docs/features/scanning.md
@@ -56,3 +56,14 @@ agent-bom image python:3.12-slim
 ```
 
 Uses agent-bom's native image scanning pipeline to enumerate OS and language packages within container images.
+
+## IaC and cloud posture
+
+Use `agent-bom iac` as the pre-cloud gate for Terraform, CloudFormation,
+Kubernetes, Helm-rendered manifests, and Dockerfiles. Use `agent-bom
+cis-benchmark` as the runtime posture check for deployed cloud state. The
+combined workflow catches proposed misconfiguration before apply and drift
+after deployment.
+
+See [Cloud Posture and IaC Gates](cloud-posture.md) for the recommended lane
+split and CI example.

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -45,6 +45,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 |---|---|---|
 | **Local AI BOM** | `agent-bom agents --demo --offline` | terminal findings and graph-ready inventory |
 | **Repository scan** | `agent-bom agents -p . -f html -o agent-bom-report.html` | local HTML review plus exportable evidence |
+| **Cloud posture gate** | `agent-bom iac infra/ && agent-bom cis-benchmark --provider aws` | pre-cloud IaC findings plus live posture evidence |
 | **CI evidence** | `uses: msaad00/agent-bom@v0.88.3` | SARIF, pull-request summary, optional code scanning |
 | **Assistant tools** | `agent-bom mcp server` | read-mostly security tools for MCP clients |
 | **Self-hosted control plane** | `docker compose -f docker-compose.pilot.yml up -d` | API and dashboard in your infrastructure |
@@ -68,6 +69,11 @@ consume through API, CLI, reports, and exports.
 The product shape is cockpit plus callable primitives: humans get a review
 surface and agents get strict-argument tools over the same security evidence
 and `ExposurePath` graphs.
+
+Cloud posture follows the same model: use `agent-bom iac` to block unsafe
+Terraform, CloudFormation, Kubernetes, or Docker changes before deployment,
+then use `agent-bom cis-benchmark` to verify the runtime account or service
+state after drift and inherited provider settings exist.
 
 ## Current graph and agent surfaces
 


### PR DESCRIPTION
Summary

- document cloud posture as two connected lanes: pre-cloud IaC gates and runtime cloud posture verification
- add a dedicated Cloud Posture and IaC Gates feature page with CLI and GitHub Action examples
- link the lane from the README, docs home page, scanning feature page, and MkDocs navigation

Verification

- uv run mkdocs build --strict
- git diff --check

Notes

- The docs keep the boundary explicit: agent-bom reports evidence and deterministic exit codes; it does not apply Terraform, mutate CloudFormation stacks, or change cloud settings as part of posture scanning.
