### PR TITLE
fix(gateway): expose empty policy posture

### DIFF
--- a/src/agent_bom/api/routes/gateway.py
+++ b/src/agent_bom/api/routes/gateway.py
@@ -334,6 +334,10 @@ async def evaluate_gateway(body: EvaluateRequest, request: Request):
     store = _get_policy_store()
     policies = store.list_policies(tenant_id=tenant_id)
     active = [p for p in policies if p.enabled]
+    policy_status = "configured" if active else "not_configured"
+    warnings: list[str] = []
+    if not active:
+        warnings.append("No enabled gateway policies are configured; evaluation is observing and allowing by default.")
     (
         allowed,
         reason,
@@ -348,7 +352,7 @@ async def evaluate_gateway(body: EvaluateRequest, request: Request):
     # alert and every allow) must be replayable from the audit store.
     if allowed and reason == "":
         action_taken = "allowed"
-        log_reason = "no matching deny rule"
+        log_reason = "no enabled gateway policies configured" if not active else "no matching deny rule"
     elif allowed:
         # audit-mode match — call went through but a rule would have blocked
         action_taken = "alerted"
@@ -396,6 +400,8 @@ async def evaluate_gateway(body: EvaluateRequest, request: Request):
         "policy_mode": policy_mode,
         "action_taken": action_taken,
         "policies_evaluated": len(active),
+        "policy_status": policy_status,
+        "warnings": warnings,
         "request_id": request_id,
         "trace_id": trace_id,
     }

--- a/tests/test_api_gateway.py
+++ b/tests/test_api_gateway.py
@@ -250,7 +250,10 @@ def test_evaluate_allowed():
     store.put_policy(_make_policy())
     resp = client.post("/v1/gateway/evaluate", json={"tool_name": "safe_tool"})
     assert resp.status_code == 200
-    assert resp.json()["allowed"] is True
+    data = resp.json()
+    assert data["allowed"] is True
+    assert data["policy_status"] == "configured"
+    assert data["warnings"] == []
 
 
 def test_evaluate_blocked():
@@ -266,7 +269,13 @@ def test_evaluate_blocked():
 def test_evaluate_no_policies():
     client, _ = _fresh_client()
     resp = client.post("/v1/gateway/evaluate", json={"tool_name": "anything"})
-    assert resp.json()["allowed"] is True
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["allowed"] is True
+    assert data["action_taken"] == "allowed"
+    assert data["policies_evaluated"] == 0
+    assert data["policy_status"] == "not_configured"
+    assert data["warnings"] == ["No enabled gateway policies are configured; evaluation is observing and allowing by default."]
 
 
 # ── Audit ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Summary
- add explicit policy_status and warnings fields to /v1/gateway/evaluate when no enabled policies are configured
- preserve current allow-by-default behavior while making empty policy posture visible to operators
- record a clearer audit reason for empty-policy allow decisions

Verification
- uv run --extra api pytest tests/test_api_gateway.py -q
- uv run ruff check src/agent_bom/api/routes/gateway.py tests/test_api_gateway.py
- uv run mypy src/agent_bom/api/routes/gateway.py

Closes #2802