### PR TITLE
fix(api): avoid postgres rls bypass noise for in-memory schedules

### DIFF
--- a/src/agent_bom/api/scheduler.py
+++ b/src/agent_bom/api/scheduler.py
@@ -130,7 +130,8 @@ async def scheduler_loop(
 
     consecutive_failures = 0
     leader_conn = None
-    needs_leader_lock = bool(os.environ.get("AGENT_BOM_POSTGRES_URL")) and _uses_postgres_schedule_store(schedule_store)
+    uses_postgres_store = _uses_postgres_schedule_store(schedule_store)
+    needs_leader_lock = bool(os.environ.get("AGENT_BOM_POSTGRES_URL")) and uses_postgres_store
 
     def _try_acquire_postgres_leader_lock():
         if not needs_leader_lock:
@@ -160,11 +161,11 @@ async def scheduler_loop(
 
                 now = datetime.now(timezone.utc)
                 now_iso = now.isoformat()
-                try:
-                    from agent_bom.api.postgres_store import bypass_tenant_rls
-                except Exception:  # pragma: no cover - optional postgres backend
+                if not uses_postgres_store:
                     due = schedule_store.list_due(now_iso)
                 else:
+                    from agent_bom.api.postgres_store import bypass_tenant_rls
+
                     with bypass_tenant_rls():
                         due = schedule_store.list_due(now_iso)
 
@@ -181,11 +182,11 @@ async def scheduler_loop(
                         next_run = parse_cron_next(schedule.cron_expression, now)
                         schedule.next_run = next_run.isoformat() if next_run else None
                         schedule.updated_at = now_iso
-                        try:
-                            from agent_bom.api.postgres_store import bypass_tenant_rls
-                        except Exception:  # pragma: no cover - optional postgres backend
+                        if not uses_postgres_store:
                             schedule_store.put(schedule)
                         else:
+                            from agent_bom.api.postgres_store import bypass_tenant_rls
+
                             with bypass_tenant_rls():
                                 schedule_store.put(schedule)
                     except Exception:

--- a/tests/test_schedule_store.py
+++ b/tests/test_schedule_store.py
@@ -257,6 +257,41 @@ class TestSchedulerLoop:
         asyncio.run(_run())
         assert len(triggered) >= 1
 
+    def test_in_memory_store_does_not_enter_postgres_rls_bypass(self, monkeypatch):
+        """SQLite/in-memory scheduling must not log Postgres RLS bypass activation."""
+        import contextlib
+
+        from agent_bom.api import postgres_store
+        from agent_bom.api.scheduler import scheduler_loop
+
+        @contextlib.contextmanager
+        def fail_if_called():
+            raise AssertionError("in-memory scheduler should not enter Postgres RLS bypass")
+            yield
+
+        store = InMemoryScheduleStore()
+        store.put(_make_schedule("s1", next_run="2020-01-01T00:00:00+00:00", enabled=True))
+        monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://example.invalid/agent_bom")
+        monkeypatch.setattr(postgres_store, "bypass_tenant_rls", fail_if_called)
+
+        triggered = []
+
+        def mock_scan(config):
+            triggered.append(config)
+            return "job-123"
+
+        async def _run():
+            task = asyncio.create_task(scheduler_loop(store, mock_scan, interval_seconds=0))
+            await asyncio.sleep(0.1)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        asyncio.run(_run())
+        assert len(triggered) >= 1
+
     def test_skips_disabled_schedule(self):
         """Scheduler loop skips disabled schedules."""
         from agent_bom.api.scheduler import scheduler_loop


### PR DESCRIPTION
Summary
- gate scheduler RLS-bypass usage on the actual Postgres schedule store backend
- keep in-memory/SQLite scheduling out of the Postgres bypass context even when Postgres support is installed
- add a regression test that fails if the in-memory scheduler enters the Postgres RLS bypass path

Verification
- uv run --extra api pytest tests/test_schedule_store.py -q
- uv run ruff check src/agent_bom/api/scheduler.py tests/test_schedule_store.py
- uv run mypy src/agent_bom/api/scheduler.py
- git diff --check

Closes #2804