### PR TITLE
test(deploy): capture eks verification evidence

### DIFF
--- a/scripts/deploy/verify-eks-reference.sh
+++ b/scripts/deploy/verify-eks-reference.sh
@@ -8,6 +8,7 @@ RELEASE_NAME="agent-bom"
 BASE_URL=""
 API_KEY="${AGENT_BOM_API_KEY:-}"
 CHECK_GATEWAY=0
+EVIDENCE_DIR=""
 
 usage() {
   cat <<'EOF'
@@ -24,6 +25,7 @@ Options:
   --base-url URL        Reachable control-plane base URL (required)
   --api-key VALUE       Operator API key for /v1/auth/debug verification
   --check-gateway       Also verify the gateway Deployment rollout and /healthz
+  --evidence-dir DIR    Write verification log and response artifacts to DIR
   -h, --help            Show this help
 
 Examples:
@@ -50,12 +52,18 @@ while [ "$#" -gt 0 ]; do
     --base-url) BASE_URL="$2"; shift 2 ;;
     --api-key) API_KEY="$2"; shift 2 ;;
     --check-gateway) CHECK_GATEWAY=1; shift ;;
+    --evidence-dir) EVIDENCE_DIR="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) fail "unknown option: $1" ;;
   esac
 done
 
 [ -n "${BASE_URL}" ] || fail "--base-url is required"
+
+if [ -n "${EVIDENCE_DIR}" ]; then
+  mkdir -p "${EVIDENCE_DIR}"
+  exec > >(tee "${EVIDENCE_DIR}/verify-eks-reference.log") 2>&1
+fi
 
 need_cmd aws
 need_cmd kubectl
@@ -64,6 +72,7 @@ need_cmd curl
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
+started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 hdrs=()
 if [ -n "${API_KEY}" ]; then
@@ -120,6 +129,40 @@ PY
 ))"
 else
   ok "skipped (pass --api-key to verify /v1/auth/debug resolution)"
+fi
+
+if [ -n "${EVIDENCE_DIR}" ]; then
+  completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  cp "$tmp/health.json" "${EVIDENCE_DIR}/healthz.json"
+  cp "$tmp/ui.html" "${EVIDENCE_DIR}/ui-root.html"
+  if [ -f "$tmp/auth.json" ]; then
+    cp "$tmp/auth.json" "${EVIDENCE_DIR}/auth-debug.json"
+  fi
+  cat >"${EVIDENCE_DIR}/summary.md" <<EOF
+# agent-bom EKS reference verification
+
+status: passed
+started_at: ${started_at}
+completed_at: ${completed_at}
+
+## Target
+
+- cluster: ${CLUSTER_NAME}
+- region: ${REGION}
+- namespace: ${NAMESPACE}
+- release: ${RELEASE_NAME}
+- base_url: ${BASE_URL}
+- gateway_checked: ${CHECK_GATEWAY}
+- auth_debug_checked: $( [ -n "${API_KEY}" ] && printf yes || printf no )
+
+## Artifacts
+
+- verify-eks-reference.log
+- healthz.json
+- ui-root.html
+$( [ -f "$tmp/auth.json" ] && printf -- "- auth-debug.json\n" )
+EOF
+  ok "evidence written to ${EVIDENCE_DIR}"
 fi
 
 bold "reference verification passed"

--- a/tests/test_deploy_reference.py
+++ b/tests/test_deploy_reference.py
@@ -114,6 +114,73 @@ def test_verify_wrapper_script_exists_and_parses():
     assert result.returncode == 0, result.stderr
 
 
+def test_verify_reference_writes_evidence_artifacts(tmp_path: Path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_fake_command(fake_bin, "aws", "exit 0\n")
+    _write_fake_command(fake_bin, "helm", "exit 0\n")
+    _write_fake_command(fake_bin, "kubectl", "exit 0\n")
+    _write_fake_command(
+        fake_bin,
+        "curl",
+        r"""
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -w) shift 2 ;;
+    -sS) shift ;;
+    -H) shift 2 ;;
+    *) url="$1"; shift ;;
+  esac
+done
+case "$url" in
+  */healthz) printf '{"status":"ok"}' > "$out" ;;
+  */v1/auth/debug) printf '{"method":"api_key"}' > "$out" ;;
+  *) printf '<html>agent-bom dashboard</html>' > "$out" ;;
+esac
+printf "200"
+""",
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    evidence_dir = tmp_path / "evidence"
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(ROOT / "scripts" / "deploy" / "verify-eks-reference.sh"),
+            "--cluster-name",
+            "corp-ai",
+            "--region",
+            "us-east-1",
+            "--base-url",
+            "https://agent-bom.example.com",
+            "--api-key",
+            "test-key",
+            "--evidence-dir",
+            str(evidence_dir),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (evidence_dir / "verify-eks-reference.log").exists()
+    assert (evidence_dir / "healthz.json").read_text() == '{"status":"ok"}'
+    assert "agent-bom dashboard" in (evidence_dir / "ui-root.html").read_text()
+    assert (evidence_dir / "auth-debug.json").read_text() == '{"method":"api_key"}'
+    summary = (evidence_dir / "summary.md").read_text()
+    assert "status: passed" in summary
+    assert "base_url: https://agent-bom.example.com" in summary
+    assert "- auth-debug.json" in summary
+
+
 def test_install_reference_dry_run_gateway_summary_includes_gateway_verify(tmp_path: Path):
     result = subprocess.run(
         [


### PR DESCRIPTION
Summary
- add --evidence-dir to scripts/deploy/verify-eks-reference.sh so real EKS verification runs persist logs and response artifacts
- capture healthz, UI root, optional auth-debug, and a timestamped summary for release/procurement evidence
- add a fake-command regression test for the evidence writer without requiring live AWS/EKS in CI

Verification
- uv run pytest tests/test_deploy_reference.py -q
- bash -n scripts/deploy/verify-eks-reference.sh
- uv run ruff check tests/test_deploy_reference.py
- git diff --check

Notes
- Does not close #2155 by itself; #2155 still requires a real disposable EKS + BYO Postgres run using this evidence path.