### PR TITLE
feat(gateway): add baseline policy pack

### DIFF
--- a/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
+++ b/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
@@ -163,6 +163,19 @@ One policy engine, shared across all three enforcement points: [`proxy_policy.py
 
 Central policy management at [`/v1/gateway/policies`](../src/agent_bom/api/routes/gateway.py). Sidecars + gateway pull every 30 s and cache by ETag. Policy audit trail persists every create / update / delete with actor + tenant.
 
+Bundled gateway baseline:
+
+```bash
+agent-bom gateway init-policy -o gateway-baseline-policy.json
+agent-bom gateway serve --policy gateway-baseline-policy.json --upstreams upstreams.yaml
+```
+
+The generated artifact is a local gateway runtime policy pack for
+`gateway serve --policy`. It defaults to audit/advisory mode: dangerous tool
+classes, write/execute behavior, secret paths, screen capture, and unknown
+egress are rendered as warnings. Operators can render the same pack with
+`--mode enforce` after reviewing audit evidence.
+
 ### 2.7 Audit + compliance: "Can I hand an external auditor evidence that stands up in a SOC 2 / ISO / PCI review?"
 
 - **HMAC-chained audit log** — [`api/audit_log.py`](../src/agent_bom/api/audit_log.py). Every entry signs the previous entry's signature; tampering with any row invalidates the chain from that point forward.
@@ -239,6 +252,7 @@ Windows + macOS behave identically — the scan, the config parsers, and the pus
 agent-bom gateway serve \
   --from-control-plane https://agent-bom.example.com \
   --control-plane-token "$CP_TOKEN" \
+  --policy /etc/agent-bom/gateway/gateway-baseline-policy.json \
   --upstreams /etc/agent-bom/gateway/overlay.yaml  # operator overlay for auth
 ```
 

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -9,9 +9,11 @@ See docs/design/MULTI_MCP_GATEWAY.md.
 
 from __future__ import annotations
 
+import json
 import logging
 import sys
 from pathlib import Path
+from typing import cast
 
 import click
 
@@ -60,6 +62,62 @@ def _enforce_gateway_auth_defaults(host: str, bearer_token: str | None, allow_in
 @click.group(cls=SuggestingGroup, help="Multi-MCP gateway commands.")
 def gateway_group() -> None:
     """Entry point for gateway subcommands."""
+
+
+@gateway_group.command("init-policy")
+@click.option(
+    "--output",
+    "-o",
+    "output_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=Path("gateway-baseline-policy.json"),
+    show_default=True,
+    help="Output path for the rendered gateway baseline policy.",
+)
+@click.option(
+    "--mode",
+    type=click.Choice(["audit", "enforce"], case_sensitive=False),
+    default="audit",
+    show_default=True,
+    help="Policy rollout mode. Audit renders advisory rules; enforce renders blocking rules.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["proxy", "control-plane"], case_sensitive=False),
+    default="proxy",
+    show_default=True,
+    help="Render for local `gateway serve --policy` or for control-plane policy import.",
+)
+@click.option(
+    "--tenant-id",
+    default="default",
+    show_default=True,
+    help="Tenant id embedded in control-plane policy output.",
+)
+def init_policy_cmd(output_path: Path, mode: str, output_format: str, tenant_id: str) -> None:
+    """Render the bundled secure-by-default gateway baseline policy."""
+    from agent_bom.gateway_policy_templates import GatewayBaselineFormat, GatewayBaselineMode, render_gateway_baseline_policy
+    from agent_bom.proxy_policy import summarize_policy_bundle
+
+    mode_value = cast(GatewayBaselineMode, mode.lower())
+    format_value = cast(GatewayBaselineFormat, output_format.lower())
+    rendered = render_gateway_baseline_policy(
+        mode=mode_value,
+        output_format=format_value,
+        tenant_id=tenant_id,
+    )
+    output_path.write_text(json.dumps(rendered, indent=2) + "\n")
+
+    if output_format.lower() == "proxy":
+        summary = summarize_policy_bundle(rendered)
+        click.echo(f"Gateway baseline policy written to {output_path}")
+        click.echo(f"Use it with: agent-bom gateway serve --policy {output_path} --upstreams <upstreams.yaml>")
+        click.echo(
+            f"Mode={mode.lower()} rules={summary['total_rules']} blocks={summary['blocking_rules']} warnings={summary['advisory_rules']}"
+        )
+    else:
+        click.echo(f"Gateway baseline control-plane policy written to {output_path}")
 
 
 @gateway_group.command("serve")
@@ -358,4 +416,4 @@ def serve_cmd(
     uvicorn.run(app, host=host, port=port_num, log_level=log_level.lower())
 
 
-__all__ = ["gateway_group", "serve_cmd"]
+__all__ = ["gateway_group", "init_policy_cmd", "serve_cmd"]

--- a/src/agent_bom/gateway_policy_templates.py
+++ b/src/agent_bom/gateway_policy_templates.py
@@ -1,0 +1,115 @@
+"""Bundled gateway runtime policy templates."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Literal
+
+from agent_bom.api.policy_store import GatewayPolicy, GatewayRule, PolicyMode
+from agent_bom.gateway import gateway_policies_to_proxy_bundle
+
+GatewayBaselineMode = Literal["audit", "enforce"]
+GatewayBaselineFormat = Literal["proxy", "control-plane"]
+
+BASELINE_GATEWAY_POLICY_ID = "agent-bom-gateway-baseline"
+BASELINE_GATEWAY_POLICY_NAME = "agent-bom gateway baseline"
+BASELINE_GATEWAY_SCHEMA_VERSION = "gateway.policy_pack.v1"
+
+
+def baseline_gateway_rules() -> list[GatewayRule]:
+    """Return secure-by-default gateway rules shared by all renderers."""
+    return [
+        GatewayRule(
+            id="baseline-dangerous-tool-classes",
+            description="Warn or block shell, process, destructive, and admin-style tools.",
+            action="block",
+            deny_tool_classes=["execute", "destructive", "admin"],
+        ),
+        GatewayRule(
+            id="baseline-read-only",
+            description="Warn or block write and execute behavior unless an operator opts out.",
+            action="block",
+            read_only=True,
+        ),
+        GatewayRule(
+            id="baseline-secret-paths",
+            description="Warn or block tool calls that reference common credential and secret paths.",
+            action="block",
+            block_secret_paths=True,
+        ),
+        GatewayRule(
+            id="baseline-screen-capture",
+            description="Warn or block screenshot and screen-capture tools by default.",
+            action="block",
+            deny_tool_classes=["screen_capture"],
+        ),
+        GatewayRule(
+            id="baseline-unknown-egress",
+            description="Warn or block outbound URL/host arguments until allowed hosts are added.",
+            action="block",
+            block_unknown_egress=True,
+            allowed_hosts=[],
+        ),
+    ]
+
+
+def baseline_gateway_policy(
+    *,
+    mode: GatewayBaselineMode = "audit",
+    tenant_id: str = "default",
+) -> GatewayPolicy:
+    """Return the bundled baseline as a GatewayPolicy model."""
+    policy_mode = PolicyMode(mode)
+    now = datetime.now(timezone.utc).isoformat()
+    return GatewayPolicy(
+        policy_id=BASELINE_GATEWAY_POLICY_ID,
+        name=BASELINE_GATEWAY_POLICY_NAME,
+        description=(
+            "Bundled secure-by-default gateway baseline for MCP runtime traffic. "
+            "Audit mode is the default so first rollout produces warnings before enforcement."
+        ),
+        mode=policy_mode,
+        rules=baseline_gateway_rules(),
+        created_at=now,
+        updated_at=now,
+        enabled=True,
+        tenant_id=tenant_id,
+    )
+
+
+def render_gateway_baseline_policy(
+    *,
+    mode: GatewayBaselineMode = "audit",
+    output_format: GatewayBaselineFormat = "proxy",
+    tenant_id: str = "default",
+) -> dict:
+    """Render the baseline for local gateway use or control-plane import."""
+    policy = baseline_gateway_policy(mode=mode, tenant_id=tenant_id)
+    if output_format == "control-plane":
+        payload = policy.model_dump(mode="json")
+        payload["schema_version"] = BASELINE_GATEWAY_SCHEMA_VERSION
+        return payload
+    if output_format != "proxy":
+        raise ValueError(f"unsupported gateway baseline format: {output_format}")
+
+    bundle = gateway_policies_to_proxy_bundle([policy])
+    bundle.update(
+        {
+            "schema_version": BASELINE_GATEWAY_SCHEMA_VERSION,
+            "name": BASELINE_GATEWAY_POLICY_NAME,
+            "policy_id": BASELINE_GATEWAY_POLICY_ID,
+            "mode": mode,
+            "description": policy.description,
+        }
+    )
+    return bundle
+
+
+__all__ = [
+    "BASELINE_GATEWAY_POLICY_ID",
+    "BASELINE_GATEWAY_POLICY_NAME",
+    "BASELINE_GATEWAY_SCHEMA_VERSION",
+    "baseline_gateway_policy",
+    "baseline_gateway_rules",
+    "render_gateway_baseline_policy",
+]

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -58,7 +58,7 @@ from agent_bom.firewall import evaluate as evaluate_firewall_policy
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
 from agent_bom.langfuse_otel import set_langfuse_runtime_attributes
 from agent_bom.proxy import check_policy, is_tools_call, parse_jsonrpc, policy_subject_from_message
-from agent_bom.proxy_policy import summarize_policy_bundle
+from agent_bom.proxy_policy import check_policy_warning, summarize_policy_bundle
 
 logger = logging.getLogger(__name__)
 _GATEWAY_TRACER = get_tracer("agent_bom.gateway")
@@ -970,6 +970,19 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                     },
                     status_code=200,
                     headers=rate_limit_headers or None,
+                )
+            warned, warning_reason, warning_rule_id = check_policy_warning(current_policy, tool_name, arguments)
+            if warned and settings.audit_sink is not None:
+                await settings.audit_sink(
+                    {
+                        "action": "gateway.policy_warned",
+                        "upstream": upstream.name,
+                        "tenant_id": tenant_id,
+                        "method": message.get("method"),
+                        "tool": tool_name,
+                        "rule_id": warning_rule_id,
+                        "reason": warning_reason,
+                    }
                 )
 
         # Forward to the upstream with bounded W3C trace headers and JSON-RPC

--- a/src/agent_bom/proxy_policy.py
+++ b/src/agent_bom/proxy_policy.py
@@ -333,3 +333,21 @@ def check_policy_detail(policy: dict, tool_name: str, arguments: dict) -> tuple[
                 pass
 
     return True, "", None
+
+
+def check_policy_warning(policy: dict, tool_name: str, arguments: dict) -> tuple[bool, str, str | None]:
+    """Return the first advisory rule match without blocking the call."""
+    advisory_rules: list[dict] = []
+    for raw_rule in policy.get("rules", []):
+        if not isinstance(raw_rule, dict):
+            continue
+        action = str(raw_rule.get("action", "warn")).lower()
+        if action in ("fail", "block"):
+            continue
+        advisory_rule = dict(raw_rule)
+        advisory_rule["action"] = "block"
+        advisory_rules.append(advisory_rule)
+    allowed, reason, rule_id = check_policy_detail({"rules": advisory_rules}, tool_name, arguments)
+    if allowed:
+        return False, "", None
+    return True, reason, rule_id

--- a/tests/test_gateway_policy_templates.py
+++ b/tests/test_gateway_policy_templates.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+from starlette.testclient import TestClient
+
+from agent_bom.api.policy_store import GatewayPolicy, PolicyMode
+from agent_bom.cli import main
+from agent_bom.gateway import evaluate_gateway_policies_detail
+from agent_bom.gateway_policy_templates import (
+    BASELINE_GATEWAY_POLICY_ID,
+    BASELINE_GATEWAY_SCHEMA_VERSION,
+    baseline_gateway_policy,
+    render_gateway_baseline_policy,
+)
+from agent_bom.gateway_server import GatewaySettings, create_gateway_app
+from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
+from agent_bom.proxy_policy import check_policy, summarize_policy_bundle
+
+
+def test_baseline_gateway_policy_validates_as_gateway_policy() -> None:
+    rendered = render_gateway_baseline_policy(output_format="control-plane")
+    schema_version = rendered.pop("schema_version")
+
+    policy = GatewayPolicy(**rendered)
+
+    assert schema_version == BASELINE_GATEWAY_SCHEMA_VERSION
+    assert policy.policy_id == BASELINE_GATEWAY_POLICY_ID
+    assert policy.mode == PolicyMode.AUDIT
+    assert policy.enabled is True
+    assert {rule.id for rule in policy.rules} >= {
+        "baseline-dangerous-tool-classes",
+        "baseline-read-only",
+        "baseline-secret-paths",
+        "baseline-screen-capture",
+        "baseline-unknown-egress",
+    }
+
+
+def test_baseline_proxy_render_defaults_to_advisory_rules() -> None:
+    rendered = render_gateway_baseline_policy()
+    summary = summarize_policy_bundle(rendered)
+
+    assert rendered["schema_version"] == BASELINE_GATEWAY_SCHEMA_VERSION
+    assert rendered["mode"] == "audit"
+    assert {rule["action"] for rule in rendered["rules"]} == {"warn"}
+    assert summary["rollout_mode"] == "advisory_only"
+    assert summary["blocks_requests"] is False
+    assert summary["protects_secret_paths"] is True
+
+
+def test_baseline_gateway_audit_mode_warns_on_dangerous_tool() -> None:
+    policy = baseline_gateway_policy()
+
+    allowed, reason, policy_id, rule_id, policy_name, policy_mode = evaluate_gateway_policies_detail(
+        [policy],
+        "run_shell",
+        {"command": "rm -rf /"},
+    )
+
+    assert allowed is True
+    assert "[audit]" in reason
+    assert policy_id == BASELINE_GATEWAY_POLICY_ID
+    assert rule_id in {"baseline-dangerous-tool-classes", "baseline-read-only"}
+    assert policy_name == policy.name
+    assert policy_mode == "audit"
+
+
+def test_baseline_gateway_enforce_mode_blocks_dangerous_tool() -> None:
+    policy = baseline_gateway_policy(mode="enforce")
+
+    allowed, reason, policy_id, rule_id, _policy_name, policy_mode = evaluate_gateway_policies_detail(
+        [policy],
+        "run_shell",
+        {"command": "rm -rf /"},
+    )
+
+    assert allowed is False
+    assert "run_shell" in reason
+    assert policy_id == BASELINE_GATEWAY_POLICY_ID
+    assert rule_id in {"baseline-dangerous-tool-classes", "baseline-read-only"}
+    assert policy_mode == "enforce"
+
+
+def test_baseline_proxy_enforce_render_blocks_dangerous_tool() -> None:
+    rendered = render_gateway_baseline_policy(mode="enforce")
+
+    allowed, reason = check_policy(rendered, "run_shell", {"command": "whoami"})
+
+    assert allowed is False
+    assert "run_shell" in reason
+
+
+def test_gateway_init_policy_cli_writes_default_advisory_policy(tmp_path: Path) -> None:
+    output = tmp_path / "gateway-baseline-policy.json"
+    result = CliRunner().invoke(main, ["gateway", "init-policy", "--output", str(output)])
+
+    assert result.exit_code == 0
+    assert "gateway serve --policy" in result.output
+    rendered = json.loads(output.read_text())
+    assert rendered["mode"] == "audit"
+    assert {rule["action"] for rule in rendered["rules"]} == {"warn"}
+
+
+def test_gateway_server_with_baseline_warns_and_allows_dangerous_tool() -> None:
+    audit_events: list[dict] = []
+    upstream_calls: list[dict] = []
+
+    async def fake_caller(upstream, message, extra_headers):
+        upstream_calls.append(message)
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    async def audit_sink(event):
+        audit_events.append(event)
+
+    settings = GatewaySettings(
+        registry=UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://fs.local:8100")]),
+        policy=render_gateway_baseline_policy(),
+        upstream_caller=fake_caller,
+        audit_sink=audit_sink,
+    )
+    client = TestClient(create_gateway_app(settings))
+
+    resp = client.post(
+        "/mcp/filesystem",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "run_shell", "arguments": {"command": "whoami"}},
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["result"]["ok"] is True
+    assert upstream_calls
+    warning_events = [event for event in audit_events if event["action"] == "gateway.policy_warned"]
+    assert warning_events
+    assert warning_events[0]["tool"] == "run_shell"
+    assert warning_events[0]["rule_id"] in {"baseline-dangerous-tool-classes", "baseline-read-only"}


### PR DESCRIPTION
Summary
- add a bundled gateway baseline policy renderer for audit/advisory and enforce rollout modes
- expose `agent-bom gateway init-policy` for local gateway policy generation
- emit advisory `gateway.policy_warned` audit events when audit-mode rules match runtime calls

Verification
- uv run pytest -q tests/test_gateway_policy_templates.py tests/test_gateway.py tests/test_gateway_server.py::test_healthz_reports_policy_rollout_summary_for_advisory_rules
- uv run ruff check src/agent_bom/gateway_policy_templates.py src/agent_bom/cli/_gateway.py src/agent_bom/proxy_policy.py src/agent_bom/gateway_server.py tests/test_gateway_policy_templates.py
- uv run mypy src/agent_bom/gateway_policy_templates.py src/agent_bom/cli/_gateway.py src/agent_bom/proxy_policy.py src/agent_bom/gateway_server.py
- uv run agent-bom gateway init-policy -o "$tmpdir/gateway-baseline-policy.json"
- python -m json.tool "$tmpdir/gateway-baseline-policy.json"
- git diff --check -- docs/ENTERPRISE_SECURITY_PLAYBOOK.md src/agent_bom/cli/_gateway.py src/agent_bom/gateway_server.py src/agent_bom/proxy_policy.py src/agent_bom/gateway_policy_templates.py tests/test_gateway_policy_templates.py

Notes
- Audit mode is the default so first rollout warns before operators opt into enforcement.
- Advisory audit events are emitted only when the gateway has an audit sink configured.