### PR TITLE
fix(ui): harden dashboard offline and navigation states

### DIFF
--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -13,6 +13,7 @@ import {
 import { AttackPathCard } from "@/components/attack-path-card";
 import { ApiOfflineState } from "@/components/api-offline-state";
 import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
+import { useAuthState } from "@/components/auth-provider";
 
 function _classifyApiErrorKind(err: unknown): "network" | "auth" | "forbidden" {
   if (err instanceof ApiAuthError) return "auth";
@@ -337,6 +338,7 @@ function aggregateCompoundIssues(allBlast: BlastRadius[]): CompoundIssue[] {
 // ─── Dashboard ────────────────────────────────────────────────────────────────
 
 export default function Dashboard() {
+  const { session } = useAuthState();
   const [jobs, setJobs] = useState<JobListItem[]>([]);
   const [detailJobs, setDetailJobs] = useState<ScanJob[]>([]);
   const [agentCount, setAgentCount] = useState<number>(0);
@@ -861,7 +863,7 @@ export default function Dashboard() {
               View all <ArrowRight className="w-3 h-3" />
             </Link>
           </div>
-          <AgentTopology agents={agentList} />
+          <AgentTopology agents={agentList} session={session} />
         </section>
       )}
 

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -495,6 +495,35 @@ export default function Dashboard() {
   const credentialExposureCount = useMemo(() => allBlast.filter((b) => blastCredentials(b).length > 0).length, [allBlast]);
   const reachableToolCount = useMemo(() => new Set(allBlast.flatMap(blastTools)).size, [allBlast]);
   const impactedAgentCount = useMemo(() => new Set(allBlast.flatMap(blastAgents)).size, [allBlast]);
+  const estateSummary = useMemo(() => {
+    const environments = new Set<string>();
+    const servers = new Set<string>();
+    const credentialedServers = new Set<string>();
+    const tools = new Set<string>();
+    const configuredAgents = agentList.filter((agent) => agent.status !== "installed-not-configured").length;
+
+    for (const agent of agentList) {
+      environments.add(agent.environment || "local");
+      for (const server of agent.mcp_servers ?? []) {
+        const serverKey = `${agent.name}:${server.name}`;
+        servers.add(serverKey);
+        if (server.has_credentials || (server.credential_env_vars?.length ?? 0) > 0) {
+          credentialedServers.add(serverKey);
+        }
+        for (const tool of server.tools ?? []) {
+          tools.add(`${server.name}:${tool.name}`);
+        }
+      }
+    }
+
+    return {
+      configuredAgents,
+      environments: environments.size,
+      servers: servers.size,
+      credentialedServers: credentialedServers.size,
+      tools: tools.size,
+    };
+  }, [agentList]);
 
   // Unique CVE count
   const uniqueCVEs = useMemo(() => {
@@ -608,8 +637,8 @@ export default function Dashboard() {
           </div>
         </div>
 
-        {topExposurePath && (
-          <div className="mt-6 grid gap-4 xl:grid-cols-[1.15fr_0.85fr]">
+        <div className="mt-6 grid gap-4 xl:grid-cols-[1.15fr_0.85fr]">
+          {topExposurePath ? (
             <div className="rounded-3xl border border-emerald-500/20 bg-emerald-500/[0.06] p-4">
               <div className="mb-3 flex items-center justify-between gap-3">
                 <div>
@@ -624,27 +653,56 @@ export default function Dashboard() {
               </div>
               <AttackPathCard nodes={topExposurePath.nodes} riskScore={topExposurePath.riskScore} href={topExposurePath.href} captureMode />
             </div>
-            <div className="grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
-              <Link href="/findings?severity=critical" className="rounded-2xl border border-red-500/20 bg-red-500/10 p-4 transition-colors hover:border-red-400/40">
-                <p className="text-[10px] uppercase tracking-[0.2em] text-red-200/70">Fix queue</p>
-                <p className="mt-2 font-mono text-2xl font-semibold text-red-100">{severity.critical}</p>
-                <p className="mt-1 text-xs text-red-100/60">critical findings</p>
-              </Link>
-              <Link href="/security-graph" className="rounded-2xl border border-amber-500/20 bg-amber-500/10 p-4 transition-colors hover:border-amber-400/40">
-                <p className="text-[10px] uppercase tracking-[0.2em] text-amber-200/70">Identity paths</p>
-                <p className="mt-2 font-mono text-2xl font-semibold text-amber-100">{credentialExposureCount}</p>
-                <p className="mt-1 text-xs text-amber-100/60">credential-linked exposures</p>
-              </Link>
-              <Link href="/agents" className="rounded-2xl border border-sky-500/20 bg-sky-500/10 p-4 transition-colors hover:border-sky-400/40">
-                <p className="text-[10px] uppercase tracking-[0.2em] text-sky-200/70">Active services</p>
-                <p className="mt-2 font-mono text-2xl font-semibold text-sky-100">{impactedAgentCount || (displayedAgentCount ?? 0)}</p>
-                <p className="mt-1 text-xs text-sky-100/60">agent-facing blast radius</p>
-              </Link>
+          ) : (
+            <div className="rounded-3xl border border-zinc-800 bg-zinc-950/70 p-4">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.22em] text-emerald-300">Estate map</p>
+              <p className="mt-1 max-w-2xl text-sm leading-6 text-zinc-400">
+                No scored exposure path is available yet. The overview stays grounded in discovered environments, agent services, credential boundaries, and scan coverage until findings produce evidence.
+              </p>
+              <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                <Link href="/agents" className="rounded-2xl border border-sky-500/20 bg-sky-500/10 p-4 transition-colors hover:border-sky-400/40">
+                  <p className="text-[10px] uppercase tracking-[0.2em] text-sky-200/70">Agents</p>
+                  <p className="mt-2 font-mono text-2xl font-semibold text-sky-100">{agentsReady ? estateSummary.configuredAgents : "—"}</p>
+                  <p className="mt-1 text-xs text-sky-100/60">configured clients</p>
+                </Link>
+                <Link href="/agents" className="rounded-2xl border border-emerald-500/20 bg-emerald-500/10 p-4 transition-colors hover:border-emerald-400/40">
+                  <p className="text-[10px] uppercase tracking-[0.2em] text-emerald-200/70">Services</p>
+                  <p className="mt-2 font-mono text-2xl font-semibold text-emerald-100">{agentsReady ? estateSummary.servers : "—"}</p>
+                  <p className="mt-1 text-xs text-emerald-100/60">MCP servers</p>
+                </Link>
+                <Link href="/security-graph" className="rounded-2xl border border-amber-500/20 bg-amber-500/10 p-4 transition-colors hover:border-amber-400/40">
+                  <p className="text-[10px] uppercase tracking-[0.2em] text-amber-200/70">Identities</p>
+                  <p className="mt-2 font-mono text-2xl font-semibold text-amber-100">{agentsReady ? estateSummary.credentialedServers : "—"}</p>
+                  <p className="mt-1 text-xs text-amber-100/60">credentialed services</p>
+                </Link>
+                <Link href="/graph" className="rounded-2xl border border-fuchsia-500/20 bg-fuchsia-500/10 p-4 transition-colors hover:border-fuchsia-400/40">
+                  <p className="text-[10px] uppercase tracking-[0.2em] text-fuchsia-200/70">Environments</p>
+                  <p className="mt-2 font-mono text-2xl font-semibold text-fuchsia-100">{agentsReady ? estateSummary.environments : "—"}</p>
+                  <p className="mt-1 text-xs text-fuchsia-100/60">observed scopes</p>
+                </Link>
+              </div>
             </div>
+          )}
+          <div className="grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
+            <Link href="/findings?severity=critical" className="rounded-2xl border border-red-500/20 bg-red-500/10 p-4 transition-colors hover:border-red-400/40">
+              <p className="text-[10px] uppercase tracking-[0.2em] text-red-200/70">Fix queue</p>
+              <p className="mt-2 font-mono text-2xl font-semibold text-red-100">{severity.critical}</p>
+              <p className="mt-1 text-xs text-red-100/60">critical findings</p>
+            </Link>
+            <Link href="/security-graph" className="rounded-2xl border border-amber-500/20 bg-amber-500/10 p-4 transition-colors hover:border-amber-400/40">
+              <p className="text-[10px] uppercase tracking-[0.2em] text-amber-200/70">Identity paths</p>
+              <p className="mt-2 font-mono text-2xl font-semibold text-amber-100">{credentialExposureCount || estateSummary.credentialedServers}</p>
+              <p className="mt-1 text-xs text-amber-100/60">credential-linked services</p>
+            </Link>
+            <Link href="/agents" className="rounded-2xl border border-sky-500/20 bg-sky-500/10 p-4 transition-colors hover:border-sky-400/40">
+              <p className="text-[10px] uppercase tracking-[0.2em] text-sky-200/70">Active services</p>
+              <p className="mt-2 font-mono text-2xl font-semibold text-sky-100">{impactedAgentCount || estateSummary.servers || (displayedAgentCount ?? 0)}</p>
+              <p className="mt-1 text-xs text-sky-100/60">agent-facing services</p>
+            </Link>
           </div>
-        )}
+        </div>
 
-        {posture && (
+        {posture && doneJobs.length > 0 && (
           <div className="mt-6">
             <PostureGrade
               grade={posture.grade}

--- a/ui/components/agent-topology.tsx
+++ b/ui/components/agent-topology.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   ReactFlow,
@@ -15,21 +15,28 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { Lock, Network, Package, Server, ShieldAlert, Wrench } from "lucide-react";
-import type { Agent } from "@/lib/api";
+import type { Agent, AuthMeResponse } from "@/lib/api";
 
 const MAX_RENDERED_AGENTS = 75;
 const MAX_RENDERED_SERVERS = 220;
+type TopologyFilter = "all" | "attention" | "credentialed" | "unlinked";
 
 // ─── Custom Node Components with proper Handles ─────────────────────────────
 
-function AgentNode({ data }: { data: { label: string; type: string; serverCount: number; vulnCount: number } }) {
+function AgentNode({ data }: { data: { label: string; type: string; serverCount: number; vulnCount: number; unlinked: boolean } }) {
   return (
-    <div className="rounded-xl border border-emerald-500/40 bg-zinc-900/90 backdrop-blur px-4 py-3 min-w-[140px] shadow-lg shadow-emerald-500/5 hover:border-emerald-400/60 transition-colors cursor-pointer">
+    <div
+      className={`min-w-[168px] rounded-xl border bg-zinc-950/95 px-4 py-3 shadow-sm backdrop-blur transition-colors ${
+        data.unlinked
+          ? "border-zinc-700/70 hover:border-zinc-500"
+          : "cursor-pointer border-zinc-700/80 hover:border-emerald-500/45"
+      }`}
+    >
       <Handle type="source" position={Position.Right} className="!w-2 !h-2 !bg-emerald-400 !border-emerald-500" />
       <Handle type="source" position={Position.Bottom} className="!w-2 !h-2 !bg-emerald-400 !border-emerald-500" />
       <div className="flex items-center gap-2.5 mb-1.5">
-        <div className="w-7 h-7 rounded-lg bg-emerald-500/15 flex items-center justify-center">
-          <ShieldAlert className="w-3.5 h-3.5 text-emerald-400" />
+        <div className="w-7 h-7 rounded-lg flex items-center justify-center bg-zinc-900 ring-1 ring-zinc-800">
+          <ShieldAlert className={`w-3.5 h-3.5 ${data.unlinked ? "text-zinc-500" : "text-zinc-300"}`} />
         </div>
         <div className="min-w-0">
           <span className="text-xs font-semibold text-zinc-100 block truncate">{data.label}</span>
@@ -41,6 +48,12 @@ function AgentNode({ data }: { data: { label: string; type: string; serverCount:
           <Server className="w-3 h-3" />
           {data.serverCount}
         </span>
+        {data.unlinked && (
+          <span className="flex items-center gap-1 text-zinc-400">
+            <span className="w-1.5 h-1.5 rounded-full bg-zinc-500" />
+            no services
+          </span>
+        )}
         {data.vulnCount > 0 && (
           <span className="flex items-center gap-1 text-red-400">
             <span className="w-1.5 h-1.5 rounded-full bg-red-500" />
@@ -52,21 +65,29 @@ function AgentNode({ data }: { data: { label: string; type: string; serverCount:
   );
 }
 
-function ServerNode({ data }: { data: { label: string; pkgCount: number; toolCount: number; hasCredentials: boolean; vulnCount: number } }) {
-  const borderColor = data.vulnCount > 0 ? "border-red-500/40 hover:border-red-400/60" : "border-blue-500/30 hover:border-blue-400/50";
-  const shadowColor = data.vulnCount > 0 ? "shadow-red-500/5" : "shadow-blue-500/5";
+function ServerNode({
+  data,
+}: {
+  data: { label: string; agentCount: number; pkgCount: number; toolCount: number; hasCredentials: boolean; vulnCount: number };
+}) {
+  const borderColor = data.vulnCount > 0 ? "border-red-500/35 hover:border-red-400/50" : "border-zinc-700/80 hover:border-blue-500/45";
+  const shadowColor = data.vulnCount > 0 ? "shadow-red-500/5" : "shadow-zinc-950/10";
 
   return (
-    <div className={`rounded-xl border ${borderColor} bg-zinc-900/90 backdrop-blur px-4 py-3 min-w-[140px] shadow-lg ${shadowColor} transition-colors`}>
+    <div className={`min-w-[178px] rounded-xl border ${borderColor} bg-zinc-950/95 px-4 py-3 shadow-sm ${shadowColor} backdrop-blur transition-colors`}>
       <Handle type="target" position={Position.Left} className="!w-2 !h-2 !bg-blue-400 !border-blue-500" />
       <Handle type="target" position={Position.Top} className="!w-2 !h-2 !bg-blue-400 !border-blue-500" />
       <div className="flex items-center gap-2.5 mb-1.5">
-        <div className={`w-7 h-7 rounded-lg flex items-center justify-center ${data.vulnCount > 0 ? "bg-red-500/15" : "bg-blue-500/15"}`}>
-          <Server className={`w-3.5 h-3.5 ${data.vulnCount > 0 ? "text-red-400" : "text-blue-400"}`} />
+        <div className="w-7 h-7 rounded-lg flex items-center justify-center bg-zinc-900 ring-1 ring-zinc-800">
+          <Server className={`w-3.5 h-3.5 ${data.vulnCount > 0 ? "text-red-300" : "text-zinc-300"}`} />
         </div>
         <span className="text-xs font-semibold text-zinc-100 truncate max-w-[120px]">{data.label}</span>
       </div>
       <div className="flex items-center gap-2.5 text-[10px] text-zinc-500 mt-1 border-t border-zinc-800/60 pt-1.5 flex-wrap">
+        <span className="flex items-center gap-1">
+          <ShieldAlert className="w-3 h-3" />
+          {data.agentCount}
+        </span>
         <span className="flex items-center gap-1">
           <Package className="w-3 h-3" />
           {data.pkgCount}
@@ -96,96 +117,138 @@ const nodeTypes = { agentNode: AgentNode, serverNode: ServerNode };
 
 // ─── Graph builder ──────────────────────────────────────────────────────────
 
+function serverVulnerabilityCount(server: NonNullable<Agent["mcp_servers"]>[number]): number {
+  return (
+    (server.vulnerabilities?.length ?? 0) +
+    (server.packages ?? []).reduce((sum, pkg) => sum + (pkg.vulnerabilities?.length ?? 0), 0)
+  );
+}
+
+function serverHasCredentials(server: NonNullable<Agent["mcp_servers"]>[number]): boolean {
+  return Boolean(
+    server.has_credentials ||
+      Object.keys(server.env ?? {}).length > 0 ||
+      (server.credential_env_vars?.length ?? 0) > 0
+  );
+}
+
+function serverMatchesFilter(server: NonNullable<Agent["mcp_servers"]>[number], filter: TopologyFilter): boolean {
+  if (filter === "credentialed") return serverHasCredentials(server);
+  if (filter === "attention") return serverHasCredentials(server) || serverVulnerabilityCount(server) > 0 || (server.security_warnings?.length ?? 0) > 0;
+  return true;
+}
+
+function serviceKey(server: NonNullable<Agent["mcp_servers"]>[number]): string {
+  return `${server.name}|${server.transport ?? ""}|${server.url ?? server.command ?? ""}`;
+}
+
 function buildGraph(agents: Agent[], direction: "LR" | "TB" = "LR"): { nodes: Node[]; edges: Edge[] } {
   const nodes: Node[] = [];
   const edges: Edge[] = [];
-  const GAP_Y = 110;
-  const GAP_X = 120;
-  const OFFSET = 320;
+  const GAP_Y = 132;
+  const GAP_X = 220;
+  const OFFSET = 420;
 
-  let cursor = 0;
+  const serviceSummaries = new Map<
+    string,
+    {
+      label: string;
+      agentNames: Set<string>;
+      pkgCount: number;
+      toolCount: number;
+      hasCredentials: boolean;
+      vulnCount: number;
+    }
+  >();
+
+  for (const agent of agents) {
+    for (const server of agent.mcp_servers ?? []) {
+      const key = serviceKey(server);
+      const existing = serviceSummaries.get(key) ?? {
+        label: server.name,
+        agentNames: new Set<string>(),
+        pkgCount: 0,
+        toolCount: 0,
+        hasCredentials: false,
+        vulnCount: 0,
+      };
+      existing.agentNames.add(agent.name);
+      existing.pkgCount += server.packages?.length ?? 0;
+      existing.toolCount += server.tools?.length ?? 0;
+      existing.hasCredentials = existing.hasCredentials || serverHasCredentials(server);
+      existing.vulnCount += serverVulnerabilityCount(server);
+      serviceSummaries.set(key, existing);
+    }
+  }
+
+  const serviceEntries = [...serviceSummaries.entries()].sort(([, left], [, right]) => {
+    return (
+      Number(right.hasCredentials) - Number(left.hasCredentials) ||
+      right.vulnCount - left.vulnCount ||
+      right.agentNames.size - left.agentNames.size ||
+      left.label.localeCompare(right.label)
+    );
+  });
+  const visibleServiceEntries = serviceEntries.slice(0, MAX_RENDERED_SERVERS);
+  const visibleServiceKeys = new Set(visibleServiceEntries.map(([key]) => key));
+  const totalAgentHeight = Math.max(agents.length - 1, 0) * GAP_Y;
+  const totalServiceHeight = Math.max(visibleServiceEntries.length - 1, 0) * GAP_Y;
+  const agentBaseY = Math.max(0, (totalServiceHeight - totalAgentHeight) / 2);
+  const serviceBaseY = Math.max(0, (totalAgentHeight - totalServiceHeight) / 2);
+
+  agents.forEach((agent, index) => {
+    const servers = agent.mcp_servers ?? [];
+    const totalVulns = servers.reduce((sum, server) => sum + serverVulnerabilityCount(server), 0);
+    nodes.push({
+      id: `agent-${agent.name}`,
+      type: "agentNode",
+      position: direction === "TB" ? { x: index * GAP_X, y: 0 } : { x: 0, y: agentBaseY + index * GAP_Y },
+      data: {
+        label: agent.name,
+        type: agent.agent_type || "agent",
+        serverCount: servers.length,
+        vulnCount: totalVulns,
+        unlinked: servers.length === 0,
+      },
+    });
+  });
+
+  visibleServiceEntries.forEach(([key, service], index) => {
+    const id = `srv-${key}`;
+    nodes.push({
+      id,
+      type: "serverNode",
+      position: direction === "TB" ? { x: index * GAP_X, y: OFFSET } : { x: OFFSET, y: serviceBaseY + index * GAP_Y },
+      data: {
+        label: service.label,
+        agentCount: service.agentNames.size,
+        pkgCount: service.pkgCount,
+        toolCount: service.toolCount,
+        hasCredentials: service.hasCredentials,
+        vulnCount: service.vulnCount,
+      },
+    });
+  });
 
   for (const agent of agents) {
     const agentId = `agent-${agent.name}`;
-    const servers = agent.mcp_servers || [];
-
-    // Count total vulns across servers
-    const totalVulns = servers.reduce((acc, srv) => {
-      return acc + (srv.packages || []).reduce((a, p) => a + (p.vulnerabilities?.length || 0), 0);
-    }, 0);
-
-    if (direction === "TB") {
-      nodes.push({
-        id: agentId,
-        type: "agentNode",
-        position: { x: cursor, y: 0 },
-        data: { label: agent.name, type: agent.agent_type || "agent", serverCount: servers.length, vulnCount: totalVulns },
+    for (const server of agent.mcp_servers ?? []) {
+      const key = serviceKey(server);
+      if (!visibleServiceKeys.has(key)) continue;
+      const srvVulns = serverVulnerabilityCount(server);
+      const hasCredential = serverHasCredentials(server);
+      edges.push({
+        id: `e-${agentId}-${key}`,
+        source: agentId,
+        target: `srv-${key}`,
+        type: "smoothstep",
+        animated: srvVulns > 0 || hasCredential,
+        style: {
+          stroke: srvVulns > 0 ? "#f87171" : hasCredential ? "#d97706" : "#64748b",
+          strokeWidth: srvVulns > 0 || hasCredential ? 2 : 1.3,
+          opacity: srvVulns > 0 || hasCredential ? 0.78 : 0.45,
+        },
       });
-
-      const serverStartX = cursor - ((servers.length - 1) * GAP_X) / 2;
-      servers.forEach((srv, i) => {
-        const srvId = `srv-${agent.name}-${srv.name}`;
-        const srvVulns = (srv.packages || []).reduce((a, p) => a + (p.vulnerabilities?.length || 0), 0);
-
-        nodes.push({
-          id: srvId,
-          type: "serverNode",
-          position: { x: serverStartX + i * GAP_X, y: OFFSET },
-          data: {
-            label: srv.name,
-            pkgCount: (srv.packages || []).length,
-            toolCount: srv.tools?.length ?? 0,
-            hasCredentials: Object.keys(srv.env || {}).length > 0,
-            vulnCount: srvVulns,
-          },
-        });
-        edges.push({
-          id: `e-${agentId}-${srvId}`,
-          source: agentId,
-          target: srvId,
-          type: "smoothstep",
-          animated: srvVulns > 0,
-          style: { stroke: srvVulns > 0 ? "#ef4444" : "#10b981", strokeWidth: 1.5, opacity: 0.7 },
-        });
-      });
-
-      cursor += Math.max(servers.length, 1) * GAP_X + 100;
-    } else {
-      nodes.push({
-        id: agentId,
-        type: "agentNode",
-        position: { x: 0, y: cursor },
-        data: { label: agent.name, type: agent.agent_type || "agent", serverCount: servers.length, vulnCount: totalVulns },
-      });
-
-      const serverStartY = cursor - ((servers.length - 1) * GAP_Y) / 2;
-      servers.forEach((srv, i) => {
-        const srvId = `srv-${agent.name}-${srv.name}`;
-        const srvVulns = (srv.packages || []).reduce((a, p) => a + (p.vulnerabilities?.length || 0), 0);
-
-        nodes.push({
-          id: srvId,
-          type: "serverNode",
-          position: { x: OFFSET, y: serverStartY + i * GAP_Y },
-          data: {
-            label: srv.name,
-            pkgCount: (srv.packages || []).length,
-            toolCount: srv.tools?.length ?? 0,
-            hasCredentials: Object.keys(srv.env || {}).length > 0,
-            vulnCount: srvVulns,
-          },
-        });
-        edges.push({
-          id: `e-${agentId}-${srvId}`,
-          source: agentId,
-          target: srvId,
-          type: "smoothstep",
-          animated: srvVulns > 0,
-          style: { stroke: srvVulns > 0 ? "#ef4444" : "#10b981", strokeWidth: 1.5, opacity: 0.7 },
-        });
-      });
-
-      cursor += Math.max(servers.length, 1) * GAP_Y + 50;
     }
   }
 
@@ -199,7 +262,8 @@ function TopologyFlow({ agents, onAgentClick, direction = "LR" }: { agents: Agen
   const { nodes, edges } = useMemo(() => buildGraph(agents, direction), [agents, direction]);
 
   useEffect(() => {
-    setTimeout(() => fitView({ padding: 0.25 }), 150);
+    const timer = window.setTimeout(() => fitView({ padding: 0.18, duration: 350 }), 120);
+    return () => window.clearTimeout(timer);
   }, [fitView, nodes]);
 
   const handleNodeClick = useCallback(
@@ -219,13 +283,13 @@ function TopologyFlow({ agents, onAgentClick, direction = "LR" }: { agents: Agen
       onNodeClick={handleNodeClick}
       fitView
       minZoom={0.2}
-      maxZoom={2}
+      maxZoom={1.6}
       panOnDrag
       zoomOnScroll
-      className="!bg-zinc-950"
+      className="!bg-transparent"
       proOptions={{ hideAttribution: true }}
     >
-      <Background color="#1a1a1e" gap={24} size={1} />
+      <Background color="#24242a" gap={28} size={1} />
       <Controls
         showInteractive={false}
         className="!bg-zinc-900 !border-zinc-700 !rounded-lg !shadow-lg [&>button]:!bg-zinc-800 [&>button]:!border-zinc-700 [&>button]:!text-zinc-400 [&>button:hover]:!bg-zinc-700"
@@ -236,24 +300,54 @@ function TopologyFlow({ agents, onAgentClick, direction = "LR" }: { agents: Agen
 
 // ─── Public component ───────────────────────────────────────────────────────
 
-export function AgentTopology({ agents, direction = "LR" }: { agents: Agent[]; direction?: "LR" | "TB" }) {
+export function AgentTopology({
+  agents,
+  direction = "LR",
+  session,
+}: {
+  agents: Agent[];
+  direction?: "LR" | "TB";
+  session?: AuthMeResponse | null;
+}) {
   const router = useRouter();
+  const [filter, setFilter] = useState<TopologyFilter>("all");
   const summary = useMemo(() => {
     const servers = agents.flatMap((agent) => agent.mcp_servers ?? []);
+    const packages = servers.reduce((sum, server) => sum + (server.packages?.length ?? 0), 0);
+    const tools = servers.reduce((sum, server) => sum + (server.tools?.length ?? 0), 0);
     const vulnerableServers = servers.filter((srv) =>
-      (srv.packages ?? []).some((pkg) => (pkg.vulnerabilities?.length ?? 0) > 0)
+      serverVulnerabilityCount(srv) > 0
     ).length;
-    const credentialedServers = servers.filter((srv) => Object.keys(srv.env ?? {}).length > 0).length;
+    const credentialedServers = servers.filter(serverHasCredentials).length;
+    const unlinkedAgents = agents.filter((agent) => (agent.mcp_servers?.length ?? 0) === 0).length;
+    const environments = new Set(agents.map((agent) => agent.environment || "local")).size;
+    const owners = new Set(agents.map((agent) => agent.owner).filter(Boolean)).size;
     return {
       agents: agents.length,
       servers: servers.length,
+      packages,
+      tools,
       vulnerableServers,
       credentialedServers,
+      unlinkedAgents,
+      environments,
+      owners,
     };
   }, [agents]);
+  const filteredAgents = useMemo(() => {
+    if (filter === "all") return agents;
+    if (filter === "unlinked") {
+      return agents
+        .filter((agent) => (agent.mcp_servers?.length ?? 0) === 0)
+        .map((agent) => ({ ...agent, mcp_servers: [] }));
+    }
+    return agents
+      .map((agent) => ({ ...agent, mcp_servers: (agent.mcp_servers ?? []).filter((server) => serverMatchesFilter(server, filter)) }))
+      .filter((agent) => agent.mcp_servers.length > 0);
+  }, [agents, filter]);
   const displayAgents = useMemo(() => {
     let renderedServers = 0;
-    return [...agents]
+    return [...filteredAgents]
       .sort((left, right) => {
         const leftServers = left.mcp_servers ?? [];
         const rightServers = right.mcp_servers ?? [];
@@ -273,9 +367,19 @@ export function AgentTopology({ agents, direction = "LR" }: { agents: Agent[]; d
         return true;
       })
       .slice(0, MAX_RENDERED_AGENTS);
-  }, [agents]);
-  const hiddenAgentCount = Math.max(0, agents.length - displayAgents.length);
-  const hiddenServerCount = Math.max(0, summary.servers - displayAgents.flatMap((agent) => agent.mcp_servers ?? []).length);
+  }, [filteredAgents]);
+  const visibleServerCount = displayAgents.flatMap((agent) => agent.mcp_servers ?? []).length;
+  const hiddenAgentCount = Math.max(0, filteredAgents.length - displayAgents.length);
+  const hiddenServerCount = Math.max(0, filteredAgents.flatMap((agent) => agent.mcp_servers ?? []).length - visibleServerCount);
+  const filterOptions = useMemo(
+    () => [
+      { key: "all" as const, label: "All", count: summary.servers + summary.unlinkedAgents },
+      { key: "attention" as const, label: "Attention", count: summary.vulnerableServers + summary.credentialedServers },
+      { key: "credentialed" as const, label: "Credentialed", count: summary.credentialedServers },
+      { key: "unlinked" as const, label: "Unlinked", count: summary.unlinkedAgents },
+    ],
+    [summary.credentialedServers, summary.servers, summary.unlinkedAgents, summary.vulnerableServers],
+  );
 
   const handleAgentClick = useCallback(
     (name: string) => {
@@ -297,11 +401,14 @@ export function AgentTopology({ agents, direction = "LR" }: { agents: Agent[]; d
   }
 
   return (
-    <div className="overflow-hidden rounded-2xl border border-zinc-800/70 bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.12),transparent_28%),radial-gradient(circle_at_top_right,rgba(59,130,246,0.14),transparent_30%),rgba(9,9,11,0.92)]">
+    <div className="overflow-hidden rounded-2xl border border-zinc-800/70 bg-zinc-950/80">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-zinc-800/80 px-4 py-3">
         <div>
           <p className="text-[10px] uppercase tracking-[0.22em] text-zinc-500">Topology</p>
           <h3 className="mt-1 text-sm font-semibold text-zinc-100">Agent to server trust mesh</h3>
+          <p className="mt-1 text-xs text-zinc-500">
+            Live Agent and MCPServer evidence, grouped by shared service identity with isolation context and unlinked agents called out.
+          </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <div className="rounded-xl border border-zinc-800 bg-zinc-900/80 px-3 py-1.5 text-xs text-zinc-300">
@@ -310,11 +417,48 @@ export function AgentTopology({ agents, direction = "LR" }: { agents: Agent[]; d
           <div className="rounded-xl border border-zinc-800 bg-zinc-900/80 px-3 py-1.5 text-xs text-zinc-300">
             <span className="font-mono text-zinc-100">{summary.servers}</span> servers
           </div>
-          <div className="rounded-xl border border-red-500/20 bg-red-500/10 px-3 py-1.5 text-xs text-red-200">
+          <div className="rounded-xl border border-red-500/20 bg-zinc-900/80 px-3 py-1.5 text-xs text-red-200">
             <span className="font-mono text-red-100">{summary.vulnerableServers}</span> vulnerable
           </div>
-          <div className="rounded-xl border border-amber-500/20 bg-amber-500/10 px-3 py-1.5 text-xs text-amber-200">
+          <div className="rounded-xl border border-amber-500/20 bg-zinc-900/80 px-3 py-1.5 text-xs text-amber-200">
             <span className="font-mono text-amber-100">{summary.credentialedServers}</span> credentialed
+          </div>
+        </div>
+      </div>
+      <div className="grid gap-3 border-b border-zinc-800/80 bg-zinc-950/65 px-4 py-3 lg:grid-cols-[1fr_auto]">
+        <div className="flex flex-wrap items-center gap-2">
+          {filterOptions.map((option) => (
+            <button
+              key={option.key}
+              type="button"
+              onClick={() => setFilter(option.key)}
+              className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
+                filter === option.key
+                  ? "border-zinc-500 bg-zinc-800 text-zinc-100"
+                  : "border-zinc-800 bg-zinc-900/70 text-zinc-400 hover:border-zinc-700 hover:text-zinc-100"
+              }`}
+            >
+              {option.label}
+              <span className="ml-2 font-mono text-[10px] text-zinc-500">{option.count}</span>
+            </button>
+          ))}
+        </div>
+        <div className="grid grid-cols-2 gap-2 text-xs sm:grid-cols-4">
+          <div className="rounded-xl border border-zinc-800 bg-zinc-900/70 px-3 py-2">
+            <div className="flex items-center gap-1.5 text-zinc-500"><Package className="h-3.5 w-3.5" />Packages</div>
+            <div className="mt-1 font-mono text-sm text-zinc-100">{summary.packages}</div>
+          </div>
+          <div className="rounded-xl border border-zinc-800 bg-zinc-900/70 px-3 py-2">
+            <div className="flex items-center gap-1.5 text-zinc-500"><Wrench className="h-3.5 w-3.5" />Tools</div>
+            <div className="mt-1 font-mono text-sm text-zinc-100">{summary.tools}</div>
+          </div>
+          <div className="rounded-xl border border-amber-500/20 bg-zinc-900/70 px-3 py-2">
+            <div className="flex items-center gap-1.5 text-amber-300/80"><Lock className="h-3.5 w-3.5" />Secrets</div>
+            <div className="mt-1 font-mono text-sm text-amber-100">{summary.credentialedServers}</div>
+          </div>
+          <div className="rounded-xl border border-zinc-800 bg-zinc-900/70 px-3 py-2">
+            <div className="flex items-center gap-1.5 text-zinc-500"><Network className="h-3.5 w-3.5" />Unlinked</div>
+            <div className="mt-1 font-mono text-sm text-zinc-100">{summary.unlinkedAgents}</div>
           </div>
         </div>
       </div>
@@ -325,10 +469,68 @@ export function AgentTopology({ agents, direction = "LR" }: { agents: Agent[]; d
           Security Graph for the remaining {hiddenAgentCount} agents and {hiddenServerCount} servers.
         </div>
       )}
-      <div className="px-2 pb-2 pt-1" style={{ height: 400 }}>
-        <ReactFlowProvider>
-          <TopologyFlow agents={displayAgents} onAgentClick={handleAgentClick} direction={direction} />
-        </ReactFlowProvider>
+      <div className="grid min-h-[460px] lg:grid-cols-[1fr_270px]">
+        <div className="px-2 pb-2 pt-1" style={{ height: 460 }}>
+          {displayAgents.length === 0 ? (
+            <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-zinc-800 bg-zinc-950/50">
+              <div className="max-w-sm text-center">
+                <ShieldAlert className="mx-auto h-7 w-7 text-zinc-600" />
+                <p className="mt-3 text-sm font-medium text-zinc-300">No topology entities match this filter</p>
+                <p className="mt-1 text-xs text-zinc-500">Switch filters or run a scan with more agent and MCP server evidence.</p>
+              </div>
+            </div>
+          ) : (
+            <ReactFlowProvider>
+              <TopologyFlow agents={displayAgents} onAgentClick={handleAgentClick} direction={direction} />
+            </ReactFlowProvider>
+          )}
+        </div>
+        <aside className="border-t border-zinc-800/80 bg-zinc-950/55 p-4 lg:border-l lg:border-t-0">
+          <p className="text-[10px] uppercase tracking-[0.22em] text-zinc-500">Operator readout</p>
+          <div className="mt-3 space-y-3">
+            <div className="rounded-xl border border-zinc-800 bg-zinc-900/70 p-3">
+              <p className="text-xs font-semibold text-zinc-200">Isolation context</p>
+              <dl className="mt-2 grid grid-cols-2 gap-2 text-xs">
+                <div>
+                  <dt className="text-zinc-500">Tenant</dt>
+                  <dd className="mt-0.5 truncate font-mono text-zinc-200">{session?.tenant_id ?? "local"}</dd>
+                </div>
+                <div>
+                  <dt className="text-zinc-500">Role</dt>
+                  <dd className="mt-0.5 truncate font-mono text-zinc-200">{session?.role_summary?.display_name ?? session?.role ?? "viewer"}</dd>
+                </div>
+                <div>
+                  <dt className="text-zinc-500">Envs</dt>
+                  <dd className="mt-0.5 font-mono text-zinc-200">{summary.environments}</dd>
+                </div>
+                <div>
+                  <dt className="text-zinc-500">Owners</dt>
+                  <dd className="mt-0.5 font-mono text-zinc-200">{summary.owners || "n/a"}</dd>
+                </div>
+              </dl>
+            </div>
+            <div className="rounded-xl border border-zinc-800 bg-zinc-900/70 p-3">
+              <p className="text-xs font-semibold text-zinc-200">Shared service map</p>
+              <p className="mt-1 text-xs leading-5 text-zinc-500">
+                Duplicate MCP service identities are grouped so shared packages, tools, and credentials do not appear as disconnected copies.
+              </p>
+            </div>
+            <div className="rounded-xl border border-zinc-800 bg-zinc-900/70 p-3">
+              <p className="text-xs font-semibold text-zinc-200">Unlinked agents</p>
+              <p className="mt-1 text-xs leading-5 text-zinc-500">
+                {summary.unlinkedAgents > 0
+                  ? `${summary.unlinkedAgents} agent${summary.unlinkedAgents === 1 ? "" : "s"} have no MCP service edge in the current evidence.`
+                  : "Every rendered agent has at least one MCP service edge."}
+              </p>
+            </div>
+            <div className="rounded-xl border border-zinc-800 bg-zinc-900/70 p-3">
+              <p className="text-xs font-semibold text-zinc-200">Priority lanes</p>
+              <p className="mt-1 text-xs leading-5 text-zinc-500">
+                Neutral edges are inventory. Amber edges carry credential evidence. Red edges carry vulnerability evidence.
+              </p>
+            </div>
+          </div>
+        </aside>
       </div>
     </div>
   );

--- a/ui/components/auth-gate.tsx
+++ b/ui/components/auth-gate.tsx
@@ -13,6 +13,19 @@ function isAuthFailure(message: string): boolean {
   return normalized.includes("unauthorized") || normalized.includes("invalid api key") || normalized.includes("forbidden");
 }
 
+function isApiReachabilityFailure(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("network request failed") ||
+    normalized.includes("failed to fetch") ||
+    normalized.includes("econnrefused") ||
+    normalized.includes("500 internal server error") ||
+    normalized.includes("502 bad gateway") ||
+    normalized.includes("503 service unavailable") ||
+    normalized.includes("504 gateway timeout")
+  );
+}
+
 export function AuthGate({ children }: { children: React.ReactNode }) {
   const { session, loading, error, refresh } = useAuthState();
   const [apiKey, setApiKey] = useState("");
@@ -27,6 +40,10 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
   }
 
   if (session && (!session.auth_required || session.authenticated)) {
+    return <>{children}</>;
+  }
+
+  if (error && isApiReachabilityFailure(error)) {
     return <>{children}</>;
   }
 

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState, useCallback, useMemo } from "react";
+import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import {
   Scan,
   Server,
@@ -51,6 +51,7 @@ interface NavLink {
   label: string;
   icon: React.ElementType;
   capability?: string;
+  description?: string;
 }
 
 interface NavGroup {
@@ -76,10 +77,10 @@ const NAV_GROUPS: NavGroup[] = [
     icon: LayoutDashboard,
     accent: "#58a6ff", // blue — discovery layer
     links: [
-      { href: "/", label: "Dashboard", icon: LayoutDashboard },
-      { href: "/agents", label: "Agents", icon: Server },
-      { href: "/manifest", label: "Agent BOM", icon: Waypoints },
-      { href: "/fleet", label: "Fleet", icon: Users },
+      { href: "/", label: "Dashboard", icon: LayoutDashboard, description: "Estate overview, exposure paths, and service topology." },
+      { href: "/agents", label: "Agents", icon: Server, description: "Discovered coding agents, MCP clients, and local runtime identities." },
+      { href: "/manifest", label: "Agent BOM", icon: Waypoints, description: "Inventory manifest for agents, servers, tools, packages, and evidence." },
+      { href: "/fleet", label: "Fleet", icon: Users, description: "Control-plane fleet inventory and synchronized agent records." },
     ],
   },
   {
@@ -88,10 +89,10 @@ const NAV_GROUPS: NavGroup[] = [
     icon: Scan,
     accent: "#f85149", // red — scanning layer
     links: [
-      { href: "/sources", label: "Data Sources", icon: Database, capability: "sources.manage" },
-      { href: "/scan", label: "New Scan", icon: Scan, capability: "scan.run" },
-      { href: "/jobs", label: "Scan Jobs", icon: Clock },
-      { href: "/findings", label: "Findings", icon: Bug },
+      { href: "/sources", label: "Data Sources", icon: Database, capability: "sources.manage", description: "Connect repositories, inventories, and evidence sources." },
+      { href: "/scan", label: "New Scan", icon: Scan, capability: "scan.run", description: "Run local, CI, inventory, and control-plane scans." },
+      { href: "/jobs", label: "Scan Jobs", icon: Clock, description: "Track scan runs, status, artifacts, and failures." },
+      { href: "/findings", label: "Findings", icon: Bug, description: "Review vulnerabilities, prompt risks, secrets, and policy findings." },
     ],
   },
   {
@@ -100,11 +101,11 @@ const NAV_GROUPS: NavGroup[] = [
     icon: GitBranch,
     accent: "#d29922", // amber — analysis layer
     links: [
-      { href: "/security-graph", label: "Security Graph", icon: Network },
-      { href: "/graph", label: "Lineage Graph", icon: GitBranch },
-      { href: "/mesh", label: "Agent Mesh", icon: Network },
-      { href: "/context", label: "Context Map", icon: Waypoints },
-      { href: "/insights", label: "Insights", icon: BarChart3 },
+      { href: "/security-graph", label: "Security Graph", icon: Network, description: "Focused exposure paths and graph-backed blast radius." },
+      { href: "/graph", label: "Lineage Graph", icon: GitBranch, description: "Broader graph topology, lineage, and relationship exploration." },
+      { href: "/mesh", label: "Agent Mesh", icon: Network, description: "Agent, server, tool, package, and credential relationship maps." },
+      { href: "/context", label: "Context Map", icon: Waypoints, description: "Context graph for scan evidence and dependency neighborhoods." },
+      { href: "/insights", label: "Insights", icon: BarChart3, description: "Prioritized trends, coverage gaps, and operational signals." },
     ],
   },
   {
@@ -113,9 +114,9 @@ const NAV_GROUPS: NavGroup[] = [
     icon: Shield,
     accent: "#f778ba", // pink — enforcement layer
     links: [
-      { href: "/proxy", label: "Proxy", icon: Shield, capability: "runtime.ingest" },
-      { href: "/audit", label: "Audit Log", icon: FileText },
-      { href: "/gateway", label: "Gateway", icon: Lock, capability: "policy.manage" },
+      { href: "/proxy", label: "Proxy", icon: Shield, capability: "runtime.ingest", description: "Runtime proxy events, detector output, and blocked calls." },
+      { href: "/audit", label: "Audit Log", icon: FileText, description: "Signed audit records for API, proxy, gateway, and scan events." },
+      { href: "/gateway", label: "Gateway", icon: Lock, capability: "policy.manage", description: "MCP gateway policy posture, upstreams, and decisions." },
     ],
   },
   {
@@ -124,11 +125,11 @@ const NAV_GROUPS: NavGroup[] = [
     icon: Eye,
     accent: "#3fb950", // green — output/governance layer
     links: [
-      { href: "/compliance", label: "Compliance", icon: Shield },
-      { href: "/remediation", label: "Remediation", icon: Wrench },
-      { href: "/governance", label: "Governance", icon: Eye, capability: "policy.manage" },
-      { href: "/traces", label: "Traces", icon: Radio },
-      { href: "/activity", label: "Activity", icon: Activity },
+      { href: "/compliance", label: "Compliance", icon: Shield, description: "Framework posture, evidence bundles, and mapped controls." },
+      { href: "/remediation", label: "Remediation", icon: Wrench, description: "Tasks, evidence requests, exceptions, and owner workflows." },
+      { href: "/governance", label: "Governance", icon: Eye, capability: "policy.manage", description: "Policy decisions, deployment gates, and posture checks." },
+      { href: "/traces", label: "Traces", icon: Radio, description: "Runtime traces, sessions, and agent/tool activity." },
+      { href: "/activity", label: "Activity", icon: Activity, description: "Recent events, webhooks, and operator activity." },
     ],
   },
 ];
@@ -149,6 +150,9 @@ export function Nav() {
   );
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
+  const [collapsedFlyoutGroup, setCollapsedFlyoutGroup] = useState<string | null>(null);
+  const [collapsedFlyoutTop, setCollapsedFlyoutTop] = useState(96);
+  const collapsedFlyoutTimer = useRef<number | null>(null);
   const { counts } = useDeploymentContext();
   const { session, loading: authLoading, hasCapability } = useAuthState();
 
@@ -196,6 +200,45 @@ export function Nav() {
       return new Set([label]);
     });
   }, [captureMode]);
+
+  const cancelCollapsedFlyoutClose = useCallback(() => {
+    if (collapsedFlyoutTimer.current) {
+      window.clearTimeout(collapsedFlyoutTimer.current);
+      collapsedFlyoutTimer.current = null;
+    }
+  }, []);
+
+  const scheduleCollapsedFlyoutClose = useCallback(() => {
+    cancelCollapsedFlyoutClose();
+    collapsedFlyoutTimer.current = window.setTimeout(() => {
+      setCollapsedFlyoutGroup(null);
+    }, 280);
+  }, [cancelCollapsedFlyoutClose]);
+
+  const openCollapsedFlyout = useCallback(
+    (label: string, target: HTMLElement) => {
+      if (!collapsed) return;
+      cancelCollapsedFlyoutClose();
+      const rect = target.getBoundingClientRect();
+      setCollapsedFlyoutTop(Math.max(12, Math.min(rect.top - 10, window.innerHeight - 380)));
+      setCollapsedFlyoutGroup(label);
+    },
+    [cancelCollapsedFlyoutClose, collapsed],
+  );
+
+  useEffect(() => {
+    if (!collapsed) {
+      setCollapsedFlyoutGroup(null);
+    }
+  }, [collapsed]);
+
+  useEffect(() => {
+    return () => {
+      if (collapsedFlyoutTimer.current) {
+        window.clearTimeout(collapsedFlyoutTimer.current);
+      }
+    };
+  }, []);
 
   // Keyboard shortcut: Cmd/Ctrl+K for search, Cmd/Ctrl+B for sidebar
   useEffect(() => {
@@ -382,11 +425,15 @@ export function Nav() {
                     return;
                   }
                   if (collapsed) {
-                    setCollapsed(false);
+                    return;
                   } else {
                     toggleGroup(group.label);
                   }
                 }}
+                onMouseEnter={(event) => openCollapsedFlyout(group.label, event.currentTarget)}
+                onMouseLeave={scheduleCollapsedFlyoutClose}
+                onFocus={(event) => openCollapsedFlyout(group.label, event.currentTarget)}
+                onBlur={scheduleCollapsedFlyoutClose}
                 className={`w-full flex items-center gap-2 px-2.5 py-2 rounded-xl text-xs font-medium transition-colors border-l-2 ${
                   collapsed ? "justify-center px-2 py-3" : ""
                 } ${
@@ -395,7 +442,7 @@ export function Nav() {
                     : "text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] hover:bg-[color:var(--surface-muted)]"
                 }`}
                 style={{ borderLeftColor: group.accent }}
-                title={collapsed ? group.label : undefined}
+                aria-expanded={collapsed ? collapsedFlyoutGroup === group.label : isExpanded}
                 aria-label={collapsed ? `${group.label}: ${group.description}` : undefined}
               >
                 <GroupIcon
@@ -420,53 +467,6 @@ export function Nav() {
                   </>
                 )}
               </button>
-
-              {collapsed && (
-                <div className="pointer-events-none fixed left-[68px] z-50 mt-[-44px] w-72 translate-x-1 opacity-0 transition-all duration-150 group-hover/navlane:pointer-events-auto group-hover/navlane:translate-x-0 group-hover/navlane:opacity-100 group-focus-within/navlane:pointer-events-auto group-focus-within/navlane:translate-x-0 group-focus-within/navlane:opacity-100">
-                  <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3 shadow-2xl shadow-black/40">
-                    <div className="flex items-start gap-3">
-                      <div
-                        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border"
-                        style={{ borderColor: `${group.accent}55`, backgroundColor: `${group.accent}16`, color: group.accent }}
-                      >
-                        <GroupIcon className="h-4 w-4" />
-                      </div>
-                      <div className="min-w-0">
-                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--foreground)]">
-                          {group.label}
-                        </p>
-                        <p className="mt-1 text-xs leading-5 text-[color:var(--text-secondary)]">
-                          {group.description}
-                        </p>
-                      </div>
-                    </div>
-                    <div className="mt-3 space-y-1">
-                      {group.visibleLinks.map(({ href, label, icon: Icon }) => {
-                        const active =
-                          href === "/"
-                            ? path === "/"
-                            : href === "/findings"
-                            ? path.startsWith("/findings") || path.startsWith("/vulns")
-                            : path.startsWith(href);
-                        return (
-                          <Link
-                            key={href}
-                            href={href}
-                            className={`flex items-center gap-2 rounded-xl px-3 py-2 text-sm transition-colors ${
-                              active
-                                ? "bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]"
-                                : "text-[color:var(--text-secondary)] hover:bg-[color:var(--surface-muted)] hover:text-[color:var(--foreground)]"
-                            }`}
-                          >
-                            <Icon className="h-4 w-4 shrink-0" style={active ? { color: group.accent } : undefined} />
-                            <span className="truncate">{label}</span>
-                          </Link>
-                        );
-                      })}
-                    </div>
-                  </div>
-                </div>
-              )}
 
               {/* Group Links */}
               {(isExpanded || collapsed) && !collapsed && (
@@ -543,6 +543,77 @@ export function Nav() {
                 </div>
               )}
 
+              {collapsed && collapsedFlyoutGroup === group.label && (
+                <div
+                  className="fixed left-[52px] z-[70] w-[340px] pl-4"
+                  style={{ top: collapsedFlyoutTop }}
+                  onMouseEnter={cancelCollapsedFlyoutClose}
+                  onMouseLeave={scheduleCollapsedFlyoutClose}
+                  onFocus={cancelCollapsedFlyoutClose}
+                  onBlur={scheduleCollapsedFlyoutClose}
+                >
+                  <div
+                    className="rounded-2xl border bg-[color:var(--surface)] p-3 shadow-2xl shadow-black/45"
+                    style={{ borderColor: `${group.accent}55` }}
+                  >
+                    <div className="mb-3 flex items-start gap-3">
+                      <div
+                        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border"
+                        style={{ borderColor: `${group.accent}66`, backgroundColor: `${group.accent}16`, color: group.accent }}
+                      >
+                        <GroupIcon className="h-5 w-5" />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-[color:var(--foreground)]">
+                          {group.label}
+                        </p>
+                        <p className="mt-1 text-[12px] leading-5 text-[color:var(--text-secondary)]">
+                          {group.description}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="space-y-1">
+                      {group.visibleLinks.map(({ href, label, icon: Icon, description }) => {
+                        const active =
+                          href === "/"
+                            ? path === "/"
+                            : href === "/findings"
+                            ? path.startsWith("/findings") || path.startsWith("/vulns")
+                            : path.startsWith(href);
+                        return (
+                          <Link
+                            key={href}
+                            href={href}
+                            className={`group/link flex items-start gap-3 rounded-xl px-3 py-2.5 transition-colors ${
+                              active
+                                ? "bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]"
+                                : "text-[color:var(--text-secondary)] hover:bg-[color:var(--surface-muted)] hover:text-[color:var(--foreground)]"
+                            }`}
+                            onClick={() => setCollapsedFlyoutGroup(null)}
+                          >
+                            <Icon
+                              className="mt-0.5 h-4 w-4 shrink-0 text-[color:var(--text-tertiary)] group-hover/link:text-[color:var(--foreground)]"
+                              style={active ? { color: group.accent } : undefined}
+                            />
+                            <span className="min-w-0">
+                              <span className="block text-sm font-medium">{label}</span>
+                              <span className="mt-0.5 block text-[11px] leading-4 text-[color:var(--text-tertiary)]">
+                                {description ?? group.description}
+                              </span>
+                            </span>
+                          </Link>
+                        );
+                      })}
+                    </div>
+                    {group.hiddenLinks.length > 0 && (
+                      <p className="mt-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-[11px] text-[color:var(--text-tertiary)]">
+                        {group.hiddenLinks.length} page{group.hiddenLinks.length === 1 ? "" : "s"} hidden for{" "}
+                        {deploymentModeLabel(counts?.deployment_mode)} mode.
+                      </p>
+                    )}
+                  </div>
+                </div>
+              )}
             </div>
           );
         })}

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -360,7 +360,7 @@ export function Nav() {
       )}
 
       {/* Navigation Groups */}
-      <nav className="flex-1 overflow-y-auto px-2 py-2 space-y-2 scrollbar-thin">
+      <nav className={`${collapsed ? "overflow-visible" : "overflow-y-auto scrollbar-thin"} flex-1 px-2 py-2 space-y-2`}>
         {navGroups.map((group) => {
           const isExpanded = captureMode || expandedGroups.has(group.label);
           const GroupIcon = group.icon;
@@ -369,7 +369,12 @@ export function Nav() {
           );
 
           return (
-            <div key={group.label} className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)]">
+            <div
+              key={group.label}
+              className={`rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] ${
+                collapsed ? "group/navlane relative" : ""
+              }`}
+            >
               {/* Group Header */}
               <button
                 onClick={() => {
@@ -383,15 +388,18 @@ export function Nav() {
                   }
                 }}
                 className={`w-full flex items-center gap-2 px-2.5 py-2 rounded-xl text-xs font-medium transition-colors border-l-2 ${
+                  collapsed ? "justify-center px-2 py-3" : ""
+                } ${
                   hasActiveChild
                     ? "text-[color:var(--foreground)] bg-[color:var(--surface-elevated)]"
                     : "text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] hover:bg-[color:var(--surface-muted)]"
                 }`}
                 style={{ borderLeftColor: group.accent }}
                 title={collapsed ? group.label : undefined}
+                aria-label={collapsed ? `${group.label}: ${group.description}` : undefined}
               >
                 <GroupIcon
-                  className="w-4 h-4 shrink-0"
+                  className={`${collapsed ? "h-5 w-5" : "h-4 w-4"} shrink-0`}
                   style={{ color: hasActiveChild ? group.accent : group.accent + "99" }}
                 />
                 {!collapsed && (
@@ -412,6 +420,53 @@ export function Nav() {
                   </>
                 )}
               </button>
+
+              {collapsed && (
+                <div className="pointer-events-none fixed left-[68px] z-50 mt-[-44px] w-72 translate-x-1 opacity-0 transition-all duration-150 group-hover/navlane:pointer-events-auto group-hover/navlane:translate-x-0 group-hover/navlane:opacity-100 group-focus-within/navlane:pointer-events-auto group-focus-within/navlane:translate-x-0 group-focus-within/navlane:opacity-100">
+                  <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3 shadow-2xl shadow-black/40">
+                    <div className="flex items-start gap-3">
+                      <div
+                        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border"
+                        style={{ borderColor: `${group.accent}55`, backgroundColor: `${group.accent}16`, color: group.accent }}
+                      >
+                        <GroupIcon className="h-4 w-4" />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--foreground)]">
+                          {group.label}
+                        </p>
+                        <p className="mt-1 text-xs leading-5 text-[color:var(--text-secondary)]">
+                          {group.description}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="mt-3 space-y-1">
+                      {group.visibleLinks.map(({ href, label, icon: Icon }) => {
+                        const active =
+                          href === "/"
+                            ? path === "/"
+                            : href === "/findings"
+                            ? path.startsWith("/findings") || path.startsWith("/vulns")
+                            : path.startsWith(href);
+                        return (
+                          <Link
+                            key={href}
+                            href={href}
+                            className={`flex items-center gap-2 rounded-xl px-3 py-2 text-sm transition-colors ${
+                              active
+                                ? "bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]"
+                                : "text-[color:var(--text-secondary)] hover:bg-[color:var(--surface-muted)] hover:text-[color:var(--foreground)]"
+                            }`}
+                          >
+                            <Icon className="h-4 w-4 shrink-0" style={active ? { color: group.accent } : undefined} />
+                            <span className="truncate">{label}</span>
+                          </Link>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </div>
+              )}
 
               {/* Group Links */}
               {(isExpanded || collapsed) && !collapsed && (
@@ -488,28 +543,6 @@ export function Nav() {
                 </div>
               )}
 
-              {/* Collapsed: just show icons as tooltips */}
-              {collapsed && (
-                <div className="space-y-0.5 mt-0.5">
-                  {group.visibleLinks.map(({ href, label, icon: Icon }) => {
-                    const active = href === "/" ? path === "/" : path.startsWith(href);
-                    return (
-                      <Link
-                        key={href}
-                        href={href}
-                        className={`flex items-center justify-center p-2 rounded-lg transition-colors ${
-                          active
-                            ? "bg-emerald-500/10 text-emerald-400"
-                            : "text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] hover:bg-[color:var(--surface-muted)]"
-                        }`}
-                        title={label}
-                      >
-                        <Icon className="w-4 h-4" />
-                      </Link>
-                    );
-                  })}
-                </div>
-              )}
             </div>
           );
         })}

--- a/ui/tests/auth-gate.test.tsx
+++ b/ui/tests/auth-gate.test.tsx
@@ -90,4 +90,25 @@ describe("AuthGate", () => {
     fireEvent.change(screen.getByLabelText("API key"), { target: { value: "abk_test" } });
     expect(unlock).toBeEnabled();
   });
+
+  it("lets pages render their own offline state when auth discovery gets a server error", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: () => Promise.resolve({ detail: "500 Internal Server Error" }),
+      headers: new Headers(),
+      url: "/v1/auth/me",
+    }) as typeof fetch;
+
+    render(
+      <AuthProvider>
+        <AuthGate>
+          <div>page-level offline state</div>
+        </AuthGate>
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByText("page-level offline state")).toBeInTheDocument());
+  });
 });


### PR DESCRIPTION
Summary
- let page-level offline/import states render when auth discovery sees API reachability or 5xx failures
- simplify collapsed navigation to product lanes with hover/focus workflow panels
- replace unsupported no-scan posture grade with an estate/services overview grounded in agents, MCP services, identities, and environments

Verification
- cd ui && npm run lint -- app/page.tsx components/nav.tsx components/auth-gate.tsx tests/auth-gate.test.tsx
- cd ui && npm run typecheck
- cd ui && npm test -- --run auth-gate attack-path-card posture-grade
- Browser smoke: API-down landing shows offline/import workflow instead of raw 500
- Browser smoke: API-up landing shows estate map without N/A grade before completed scan evidence
- Browser smoke: collapsed nav lane hover reveals labeled workflow links

Notes
- Posture grade remains available when completed scan evidence exists; the overview no longer implies a score when only inventory data is present.