### PR TITLE
feat(onboarding): execute quickstart with --run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `agent-bom quickstart --run` executes first-run onboarding end to end: writes the bundled sample stack, runs a graph-persisting scan that populates the local security-graph cockpit, and seeds the secure-by-default gateway baseline policy. The print-only guide remains the default.
+
 ---
 
 ## [0.88.4] - 2026-05-26

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ the credential environment names in reach, and the agents that can call it.
 
 ```bash
 pip install agent-bom
-agent-bom quickstart --dry-run --offline
+agent-bom quickstart --dry-run --offline   # print the onboarding plan
+agent-bom quickstart --run --offline        # write sample, scan, seed gateway policy, populate the cockpit
 agent-bom agents --demo --offline
 ```
 
@@ -130,6 +131,7 @@ Screenshot capture rules and the full manifest live in
 |---|---|---|
 | Local agent and MCP inventory | `agent-bom agents` | findings, AI BOM, graph-ready JSON |
 | Guided local onboarding | `agent-bom quickstart --dry-run --offline` | scan, sample-data, and local API/UI next steps |
+| One-command onboarding | `agent-bom quickstart --run --offline` | writes sample, runs a graph-persisting scan, seeds a baseline gateway policy |
 | Repo and lockfile scan | `agent-bom agents -p .` | package findings, SARIF/SBOM/HTML when requested |
 | Pre-install guard | `agent-bom check flask@2.0.0 --ecosystem pypi` | deterministic allow/warn/block result |
 | Container image scan | `agent-bom image nginx:latest` | image findings and remediation |

--- a/src/agent_bom/cli/_quickstart.py
+++ b/src/agent_bom/cli/_quickstart.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import json
+import shutil
+import subprocess
+import sys
 from pathlib import Path
+from typing import cast
 
 import click
 
@@ -20,11 +25,54 @@ from agent_bom.samples import write_first_run_sample
     help="Directory used for the bundled sample stack.",
 )
 @click.option("--write-sample", is_flag=True, help="Write the bundled sample stack before printing next steps.")
-@click.option("--force", is_flag=True, help="Overwrite files when used with --write-sample.")
-def quickstart_cmd(dry_run: bool, offline: bool, sample_dir: Path, write_sample: bool, force: bool) -> None:
-    """Print a local onboarding path for scan, API/UI, and sample data."""
+@click.option("--force", is_flag=True, help="Overwrite files when used with --write-sample or --run.")
+@click.option(
+    "--run",
+    "execute",
+    is_flag=True,
+    help="Execute the onboarding: write the sample stack, run a graph-persisting scan, and seed a baseline gateway policy.",
+)
+@click.option(
+    "--gateway-policy/--no-gateway-policy",
+    default=True,
+    show_default=True,
+    help="With --run, render the secure-by-default gateway baseline policy.",
+)
+@click.option(
+    "--gateway-mode",
+    type=click.Choice(["audit", "enforce"], case_sensitive=False),
+    default="audit",
+    show_default=True,
+    help="Enforcement mode for the seeded gateway baseline policy (audit warns before enforcing).",
+)
+@click.option("--port", type=int, default=8422, show_default=True, help="Port suggested for the local API/UI handoff.")
+def quickstart_cmd(
+    dry_run: bool,
+    offline: bool,
+    sample_dir: Path,
+    write_sample: bool,
+    force: bool,
+    execute: bool,
+    gateway_policy: bool,
+    gateway_mode: str,
+    port: int,
+) -> None:
+    """Print — or with --run, execute — a local first-run onboarding path."""
     if dry_run and write_sample:
         raise click.UsageError("--dry-run cannot be combined with --write-sample.")
+    if dry_run and execute:
+        raise click.UsageError("--dry-run cannot be combined with --run.")
+
+    if execute:
+        _run_quickstart(
+            sample_dir=sample_dir,
+            offline=offline,
+            force=force,
+            gateway_policy=gateway_policy,
+            gateway_mode=gateway_mode,
+            port=port,
+        )
+        return
 
     if write_sample:
         try:
@@ -50,11 +98,99 @@ def quickstart_cmd(dry_run: bool, offline: bool, sample_dir: Path, write_sample:
     click.echo("")
     click.echo("Local API/UI:")
     click.echo("  pip install 'agent-bom[ui]'")
-    click.echo("  agent-bom serve --host 127.0.0.1 --port 8422")
-    click.echo("  API docs: http://127.0.0.1:8422/docs")
-    click.echo("  UI:       http://127.0.0.1:8422/")
+    click.echo(f"  agent-bom serve --host 127.0.0.1 --port {port}")
+    click.echo(f"  API docs: http://127.0.0.1:{port}/docs")
+    click.echo(f"  UI:       http://127.0.0.1:{port}/")
+    click.echo("")
+    click.echo("One command:")
+    click.echo("  agent-bom quickstart --run        # writes sample, scans, seeds gateway policy")
     click.echo("")
     click.echo("Everything in this lane can run locally. Use 'agent-bom[all]' for all first-run extras; MLflow remains separate.")
+
+
+def _run_quickstart(
+    *,
+    sample_dir: Path,
+    offline: bool,
+    force: bool,
+    gateway_policy: bool,
+    gateway_mode: str,
+    port: int,
+) -> None:
+    """Execute the onboarding end to end so the local cockpit is populated on first run."""
+    inventory_path = sample_dir / "inventory.json"
+
+    # 1. Sample stack -------------------------------------------------------
+    if inventory_path.exists() and not force:
+        click.echo(f"[1/3] Using existing sample stack at {sample_dir} (pass --force to rewrite)")
+    else:
+        try:
+            written = write_first_run_sample(sample_dir, force=force)
+        except FileExistsError as exc:
+            raise click.ClickException(str(exc)) from exc
+        click.echo(f"[1/3] Wrote {len(written)} sample files to {sample_dir}")
+
+    # 2. Graph-persisting scan ---------------------------------------------
+    executable = _resolve_agent_bom()
+    if executable is None:
+        raise click.ClickException(
+            "Could not locate the 'agent-bom' executable to run the scan. "
+            f"Run it manually: {_sample_scan_command(sample_dir, offline=offline)}"
+        )
+    # --context-graph triggers persistence of the unified graph to the local
+    # control-plane store (~/.agent-bom/db/graph.db) that `agent-bom serve` reads,
+    # so the security-graph cockpit is populated on first run.
+    scan_args = [executable, "agents", "--inventory", str(inventory_path), "-p", str(sample_dir), "--context-graph"]
+    scan_args.append("--offline" if offline else "--enrich")
+    click.echo(f"[2/3] Scanning sample stack: {' '.join(scan_args[1:])}")
+    result = subprocess.run(scan_args, check=False)  # noqa: S603 - args built from validated inputs
+    if result.returncode != 0:
+        raise click.ClickException(f"Scan exited with status {result.returncode}. The cockpit graph may be incomplete.")
+
+    # 3. Secure-by-default gateway policy ----------------------------------
+    policy_path: Path | None = None
+    if gateway_policy:
+        policy_path = sample_dir / "gateway-baseline-policy.json"
+        _write_gateway_baseline(policy_path, mode=gateway_mode)
+        click.echo(f"[3/3] Seeded gateway baseline policy ({gateway_mode}) at {policy_path}")
+    else:
+        click.echo("[3/3] Skipped gateway baseline policy (--no-gateway-policy)")
+
+    # Handoff ---------------------------------------------------------------
+    click.echo("")
+    click.echo("Onboarding complete. The security graph is now populated locally.")
+    click.echo("")
+    click.echo("Open the cockpit:")
+    click.echo(f"  agent-bom serve --host 127.0.0.1 --port {port}")
+    click.echo(f"  Security graph: http://127.0.0.1:{port}/security-graph")
+    click.echo(f"  Dashboard:      http://127.0.0.1:{port}/")
+    if policy_path is not None:
+        click.echo("")
+        click.echo("Enforce the gateway baseline:")
+        click.echo(f"  agent-bom gateway serve --policy {policy_path} --upstreams upstreams.yaml")
+
+
+def _write_gateway_baseline(output_path: Path, *, mode: str) -> None:
+    """Render the bundled secure-by-default gateway baseline policy to ``output_path``."""
+    from agent_bom.gateway_policy_templates import (
+        GatewayBaselineMode,
+        render_gateway_baseline_policy,
+    )
+
+    rendered = render_gateway_baseline_policy(
+        mode=cast(GatewayBaselineMode, mode.lower()),
+        output_format="proxy",
+        tenant_id="default",
+    )
+    output_path.write_text(json.dumps(rendered, indent=2) + "\n")
+
+
+def _resolve_agent_bom() -> str | None:
+    """Resolve the ``agent-bom`` console script, preferring the active interpreter's bin."""
+    candidate = Path(sys.executable).with_name("agent-bom")
+    if candidate.exists():
+        return str(candidate)
+    return shutil.which("agent-bom")
 
 
 def _sample_scan_command(sample_dir: Path, *, offline: bool) -> str:

--- a/src/agent_bom/cli/_quickstart.py
+++ b/src/agent_bom/cli/_quickstart.py
@@ -13,6 +13,8 @@ import click
 
 from agent_bom.samples import write_first_run_sample
 
+QUICKSTART_SCAN_TIMEOUT_SECONDS = 300
+
 
 @click.command("quickstart")
 @click.option("--dry-run", is_flag=True, help="Print the onboarding plan without writing files or starting services.")
@@ -143,7 +145,11 @@ def _run_quickstart(
     scan_args = [executable, "agents", "--inventory", str(inventory_path), "-p", str(sample_dir), "--context-graph"]
     scan_args.append("--offline" if offline else "--enrich")
     click.echo(f"[2/3] Scanning sample stack: {' '.join(scan_args[1:])}")
-    result = subprocess.run(scan_args, check=False)  # noqa: S603 - args built from validated inputs
+    result = subprocess.run(  # noqa: S603 - args built from validated inputs
+        scan_args,
+        check=False,
+        timeout=QUICKSTART_SCAN_TIMEOUT_SECONDS,
+    )
     if result.returncode != 0:
         raise click.ClickException(f"Scan exited with status {result.returncode}. The cockpit graph may be incomplete.")
 

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -1,13 +1,30 @@
 from __future__ import annotations
 
+import json
+import subprocess
 import tomllib
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from agent_bom.cli import main
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture()
+def _fake_scan(monkeypatch):
+    """Capture the scan subprocess instead of running a real scan."""
+    calls: list[list[str]] = []
+
+    def fake_run(args, check=False, **kwargs):  # noqa: ANN001, ANN003
+        calls.append(list(args))
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr("agent_bom.cli._quickstart._resolve_agent_bom", lambda: "agent-bom")
+    monkeypatch.setattr("agent_bom.cli._quickstart.subprocess.run", fake_run)
+    return calls
 
 
 def test_quickstart_dry_run_offline_prints_local_next_steps():
@@ -40,6 +57,63 @@ def test_quickstart_rejects_write_sample_dry_run():
 
     assert result.exit_code != 0
     assert "--dry-run cannot be combined with --write-sample" in result.output
+
+
+def test_quickstart_rejects_dry_run_with_run():
+    result = CliRunner().invoke(main, ["quickstart", "--dry-run", "--run"])
+
+    assert result.exit_code != 0
+    assert "--dry-run cannot be combined with --run" in result.output
+
+
+def test_quickstart_run_scans_with_context_graph_and_seeds_policy(tmp_path, _fake_scan):
+    sample_dir = tmp_path / "stack"
+
+    result = CliRunner().invoke(main, ["quickstart", "--run", "--offline", "--sample-dir", str(sample_dir)])
+
+    assert result.exit_code == 0, result.output
+    # sample written
+    assert (sample_dir / "inventory.json").exists()
+    # scan invoked with --context-graph (graph persistence) and --offline
+    assert len(_fake_scan) == 1
+    scan_args = _fake_scan[0]
+    assert scan_args[1] == "agents"
+    assert "--context-graph" in scan_args
+    assert "--offline" in scan_args
+    assert str(sample_dir / "inventory.json") in scan_args
+    # secure-by-default gateway baseline seeded and valid
+    policy_path = sample_dir / "gateway-baseline-policy.json"
+    assert policy_path.exists()
+    policy = json.loads(policy_path.read_text())
+    assert policy["mode"] == "audit"
+    assert policy["rules"]
+    # handoff printed
+    assert "Onboarding complete" in result.output
+    assert "/security-graph" in result.output
+
+
+def test_quickstart_run_no_gateway_policy_skips_file(tmp_path, _fake_scan):
+    sample_dir = tmp_path / "stack"
+
+    result = CliRunner().invoke(main, ["quickstart", "--run", "--offline", "--no-gateway-policy", "--sample-dir", str(sample_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert not (sample_dir / "gateway-baseline-policy.json").exists()
+    assert "Skipped gateway baseline policy" in result.output
+
+
+def test_quickstart_run_surfaces_scan_failure(tmp_path, monkeypatch):
+    sample_dir = tmp_path / "stack"
+    monkeypatch.setattr("agent_bom.cli._quickstart._resolve_agent_bom", lambda: "agent-bom")
+    monkeypatch.setattr(
+        "agent_bom.cli._quickstart.subprocess.run",
+        lambda args, check=False, **kwargs: subprocess.CompletedProcess(args, 2),
+    )
+
+    result = CliRunner().invoke(main, ["quickstart", "--run", "--offline", "--sample-dir", str(sample_dir)])
+
+    assert result.exit_code != 0
+    assert "Scan exited with status 2" in result.output
 
 
 def test_all_extra_composes_first_run_extras_without_mlflow():


### PR DESCRIPTION
## Summary

Adds `agent-bom quickstart --run` to execute first-run onboarding end to end, instead of only printing the steps. One command takes a fresh install to a populated local cockpit:

1. Writes the bundled sample stack (reuses `write_first_run_sample`).
2. Runs a graph-persisting scan (`agents --inventory ... -p ... --context-graph`) so the unified security graph is saved to the local control-plane store (`~/.agent-bom/db/graph.db`) that `agent-bom serve` reads — the `/security-graph` cockpit is populated on first run.
3. Seeds the secure-by-default gateway baseline policy (reuses the bundled baseline renderer).
4. Prints a handoff with the `serve` command and cockpit URLs.

The print-only onboarding guide remains the **default** behavior; `--run` is opt-in. Builds on the quickstart command and the gateway baseline policy pack already on `main`.

## Why

The shipped quickstart printed the commands a user should run. On a fresh `agent-bom serve`, the premium UI surfaces (security graph, dashboard) render empty until a relationship-rich scan has populated the store. `--run` closes that gap so the first-run experience lands on a populated cockpit rather than instructions.

## Options

- `--run` — execute the onboarding (default off).
- `--gateway-policy / --no-gateway-policy` — seed the baseline policy (default on).
- `--gateway-mode [audit|enforce]` — baseline enforcement mode (default `audit`, warns before enforcing).
- `--offline` — use the local advisory DB (no network).
- `--port`, `--sample-dir`, `--force` — handoff port, sample location, overwrite.

## Verification

- End-to-end (clean dir, isolated graph DB): writes sample, scan finds 35 vulns, prints `Graph persisted (58 nodes ...)`, graph DB shows 58 nodes / 164 edges, policy file rendered (5 rules, audit mode).
- `tests/test_quickstart.py`: 8 passed (4 existing + 4 new: executing path asserts `--context-graph`/`--offline` + valid seeded policy, `--no-gateway-policy` opt-out, `--dry-run`+`--run` rejection, scan-failure surfacing).
- `ruff check`, `ruff-format`, `mypy` clean on changed files.

Relates to the one-command onboarding in #2812.
