### PR TITLE
fix(ui): keep dashboard topology within bundle budget

### DIFF
--- a/ui/components/agent-topology.tsx
+++ b/ui/components/agent-topology.tsx
@@ -321,7 +321,6 @@ export function AgentTopology({
     const credentialedServers = servers.filter(serverHasCredentials).length;
     const unlinkedAgents = agents.filter((agent) => (agent.mcp_servers?.length ?? 0) === 0).length;
     const environments = new Set(agents.map((agent) => agent.environment || "local")).size;
-    const owners = new Set(agents.map((agent) => agent.owner).filter(Boolean)).size;
     return {
       agents: agents.length,
       servers: servers.length,
@@ -331,7 +330,6 @@ export function AgentTopology({
       credentialedServers,
       unlinkedAgents,
       environments,
-      owners,
     };
   }, [agents]);
   const filteredAgents = useMemo(() => {
@@ -406,11 +404,14 @@ export function AgentTopology({
         <div>
           <p className="text-[10px] uppercase tracking-[0.22em] text-zinc-500">Topology</p>
           <h3 className="mt-1 text-sm font-semibold text-zinc-100">Agent to server trust mesh</h3>
-          <p className="mt-1 text-xs text-zinc-500">
-            Live Agent and MCPServer evidence, grouped by shared service identity with isolation context and unlinked agents called out.
-          </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          <div className="rounded-xl border border-zinc-800 bg-zinc-900/80 px-3 py-1.5 text-xs text-zinc-300">
+            tenant <span className="font-mono text-zinc-100">{session?.tenant_id ?? "local"}</span>
+          </div>
+          <div className="rounded-xl border border-zinc-800 bg-zinc-900/80 px-3 py-1.5 text-xs text-zinc-300">
+            role <span className="font-mono text-zinc-100">{session?.role_summary?.display_name ?? session?.role ?? "viewer"}</span>
+          </div>
           <div className="rounded-xl border border-zinc-800 bg-zinc-900/80 px-3 py-1.5 text-xs text-zinc-300">
             <span className="font-mono text-zinc-100">{summary.agents}</span> agents
           </div>
@@ -469,7 +470,7 @@ export function AgentTopology({
           Security Graph for the remaining {hiddenAgentCount} agents and {hiddenServerCount} servers.
         </div>
       )}
-      <div className="grid min-h-[460px] lg:grid-cols-[1fr_270px]">
+      <div className="min-h-[460px]">
         <div className="px-2 pb-2 pt-1" style={{ height: 460 }}>
           {displayAgents.length === 0 ? (
             <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-zinc-800 bg-zinc-950/50">
@@ -485,52 +486,6 @@ export function AgentTopology({
             </ReactFlowProvider>
           )}
         </div>
-        <aside className="border-t border-zinc-800/80 bg-zinc-950/55 p-4 lg:border-l lg:border-t-0">
-          <p className="text-[10px] uppercase tracking-[0.22em] text-zinc-500">Operator readout</p>
-          <div className="mt-3 space-y-3">
-            <div className="rounded-xl border border-zinc-800 bg-zinc-900/70 p-3">
-              <p className="text-xs font-semibold text-zinc-200">Isolation context</p>
-              <dl className="mt-2 grid grid-cols-2 gap-2 text-xs">
-                <div>
-                  <dt className="text-zinc-500">Tenant</dt>
-                  <dd className="mt-0.5 truncate font-mono text-zinc-200">{session?.tenant_id ?? "local"}</dd>
-                </div>
-                <div>
-                  <dt className="text-zinc-500">Role</dt>
-                  <dd className="mt-0.5 truncate font-mono text-zinc-200">{session?.role_summary?.display_name ?? session?.role ?? "viewer"}</dd>
-                </div>
-                <div>
-                  <dt className="text-zinc-500">Envs</dt>
-                  <dd className="mt-0.5 font-mono text-zinc-200">{summary.environments}</dd>
-                </div>
-                <div>
-                  <dt className="text-zinc-500">Owners</dt>
-                  <dd className="mt-0.5 font-mono text-zinc-200">{summary.owners || "n/a"}</dd>
-                </div>
-              </dl>
-            </div>
-            <div className="rounded-xl border border-zinc-800 bg-zinc-900/70 p-3">
-              <p className="text-xs font-semibold text-zinc-200">Shared service map</p>
-              <p className="mt-1 text-xs leading-5 text-zinc-500">
-                Duplicate MCP service identities are grouped so shared packages, tools, and credentials do not appear as disconnected copies.
-              </p>
-            </div>
-            <div className="rounded-xl border border-zinc-800 bg-zinc-900/70 p-3">
-              <p className="text-xs font-semibold text-zinc-200">Unlinked agents</p>
-              <p className="mt-1 text-xs leading-5 text-zinc-500">
-                {summary.unlinkedAgents > 0
-                  ? `${summary.unlinkedAgents} agent${summary.unlinkedAgents === 1 ? "" : "s"} have no MCP service edge in the current evidence.`
-                  : "Every rendered agent has at least one MCP service edge."}
-              </p>
-            </div>
-            <div className="rounded-xl border border-zinc-800 bg-zinc-900/70 p-3">
-              <p className="text-xs font-semibold text-zinc-200">Priority lanes</p>
-              <p className="mt-1 text-xs leading-5 text-zinc-500">
-                Neutral edges are inventory. Amber edges carry credential evidence. Red edges carry vulnerability evidence.
-              </p>
-            </div>
-          </div>
-        </aside>
       </div>
     </div>
   );

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -51,7 +51,6 @@ interface NavLink {
   label: string;
   icon: React.ElementType;
   capability?: string;
-  description?: string;
 }
 
 interface NavGroup {
@@ -77,10 +76,10 @@ const NAV_GROUPS: NavGroup[] = [
     icon: LayoutDashboard,
     accent: "#58a6ff", // blue — discovery layer
     links: [
-      { href: "/", label: "Dashboard", icon: LayoutDashboard, description: "Estate overview, exposure paths, and service topology." },
-      { href: "/agents", label: "Agents", icon: Server, description: "Discovered coding agents, MCP clients, and local runtime identities." },
-      { href: "/manifest", label: "Agent BOM", icon: Waypoints, description: "Inventory manifest for agents, servers, tools, packages, and evidence." },
-      { href: "/fleet", label: "Fleet", icon: Users, description: "Control-plane fleet inventory and synchronized agent records." },
+      { href: "/", label: "Dashboard", icon: LayoutDashboard },
+      { href: "/agents", label: "Agents", icon: Server },
+      { href: "/manifest", label: "Agent BOM", icon: Waypoints },
+      { href: "/fleet", label: "Fleet", icon: Users },
     ],
   },
   {
@@ -89,10 +88,10 @@ const NAV_GROUPS: NavGroup[] = [
     icon: Scan,
     accent: "#f85149", // red — scanning layer
     links: [
-      { href: "/sources", label: "Data Sources", icon: Database, capability: "sources.manage", description: "Connect repositories, inventories, and evidence sources." },
-      { href: "/scan", label: "New Scan", icon: Scan, capability: "scan.run", description: "Run local, CI, inventory, and control-plane scans." },
-      { href: "/jobs", label: "Scan Jobs", icon: Clock, description: "Track scan runs, status, artifacts, and failures." },
-      { href: "/findings", label: "Findings", icon: Bug, description: "Review vulnerabilities, prompt risks, secrets, and policy findings." },
+      { href: "/sources", label: "Data Sources", icon: Database, capability: "sources.manage" },
+      { href: "/scan", label: "New Scan", icon: Scan, capability: "scan.run" },
+      { href: "/jobs", label: "Scan Jobs", icon: Clock },
+      { href: "/findings", label: "Findings", icon: Bug },
     ],
   },
   {
@@ -101,11 +100,11 @@ const NAV_GROUPS: NavGroup[] = [
     icon: GitBranch,
     accent: "#d29922", // amber — analysis layer
     links: [
-      { href: "/security-graph", label: "Security Graph", icon: Network, description: "Focused exposure paths and graph-backed blast radius." },
-      { href: "/graph", label: "Lineage Graph", icon: GitBranch, description: "Broader graph topology, lineage, and relationship exploration." },
-      { href: "/mesh", label: "Agent Mesh", icon: Network, description: "Agent, server, tool, package, and credential relationship maps." },
-      { href: "/context", label: "Context Map", icon: Waypoints, description: "Context graph for scan evidence and dependency neighborhoods." },
-      { href: "/insights", label: "Insights", icon: BarChart3, description: "Prioritized trends, coverage gaps, and operational signals." },
+      { href: "/security-graph", label: "Security Graph", icon: Network },
+      { href: "/graph", label: "Lineage Graph", icon: GitBranch },
+      { href: "/mesh", label: "Agent Mesh", icon: Network },
+      { href: "/context", label: "Context Map", icon: Waypoints },
+      { href: "/insights", label: "Insights", icon: BarChart3 },
     ],
   },
   {
@@ -114,9 +113,9 @@ const NAV_GROUPS: NavGroup[] = [
     icon: Shield,
     accent: "#f778ba", // pink — enforcement layer
     links: [
-      { href: "/proxy", label: "Proxy", icon: Shield, capability: "runtime.ingest", description: "Runtime proxy events, detector output, and blocked calls." },
-      { href: "/audit", label: "Audit Log", icon: FileText, description: "Signed audit records for API, proxy, gateway, and scan events." },
-      { href: "/gateway", label: "Gateway", icon: Lock, capability: "policy.manage", description: "MCP gateway policy posture, upstreams, and decisions." },
+      { href: "/proxy", label: "Proxy", icon: Shield, capability: "runtime.ingest" },
+      { href: "/audit", label: "Audit Log", icon: FileText },
+      { href: "/gateway", label: "Gateway", icon: Lock, capability: "policy.manage" },
     ],
   },
   {
@@ -125,11 +124,11 @@ const NAV_GROUPS: NavGroup[] = [
     icon: Eye,
     accent: "#3fb950", // green — output/governance layer
     links: [
-      { href: "/compliance", label: "Compliance", icon: Shield, description: "Framework posture, evidence bundles, and mapped controls." },
-      { href: "/remediation", label: "Remediation", icon: Wrench, description: "Tasks, evidence requests, exceptions, and owner workflows." },
-      { href: "/governance", label: "Governance", icon: Eye, capability: "policy.manage", description: "Policy decisions, deployment gates, and posture checks." },
-      { href: "/traces", label: "Traces", icon: Radio, description: "Runtime traces, sessions, and agent/tool activity." },
-      { href: "/activity", label: "Activity", icon: Activity, description: "Recent events, webhooks, and operator activity." },
+      { href: "/compliance", label: "Compliance", icon: Shield },
+      { href: "/remediation", label: "Remediation", icon: Wrench },
+      { href: "/governance", label: "Governance", icon: Eye, capability: "policy.manage" },
+      { href: "/traces", label: "Traces", icon: Radio },
+      { href: "/activity", label: "Activity", icon: Activity },
     ],
   },
 ];
@@ -573,7 +572,7 @@ export function Nav() {
                       </div>
                     </div>
                     <div className="space-y-1">
-                      {group.visibleLinks.map(({ href, label, icon: Icon, description }) => {
+                      {group.visibleLinks.map(({ href, label, icon: Icon }) => {
                         const active =
                           href === "/"
                             ? path === "/"
@@ -597,9 +596,6 @@ export function Nav() {
                             />
                             <span className="min-w-0">
                               <span className="block text-sm font-medium">{label}</span>
-                              <span className="mt-0.5 block text-[11px] leading-4 text-[color:var(--text-tertiary)]">
-                                {description ?? group.description}
-                              </span>
                             </span>
                           </Link>
                         );

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -10,7 +10,8 @@ const BUDGETS = {
   // Includes the opt-in Sigma.js + graphology WebGL overview chunk for dense graphs.
   // Also includes the Agent BOM manifest cockpit filters used for AI visibility triage.
   // Includes the root exposure cockpit path card and operational action tiles.
-  totalClientJsBytes: 2_864_000,
+  // Includes the dashboard trust-mesh topology filters and offline-state workflow.
+  totalClientJsBytes: 2_876_000,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };


### PR DESCRIPTION
Summary
- trim bundled dashboard/nav topology copy after the dashboard polish landed
- record the small intentional budget allowance for the interactive trust-mesh topology controls
- keep the no-scan dashboard free of the unsupported N/A posture grade

Verification
- cd ui && npm run build && npm run bundle:check
- cd ui && npm run typecheck
- cd ui && npm run lint -- app/page.tsx components/nav.tsx components/auth-gate.tsx components/agent-topology.tsx tests/auth-gate.test.tsx scripts/check-bundle-budget.mjs
- cd ui && npm test -- --run auth-gate attack-path-card posture-grade

Notes
- This is the follow-up for the UI Validate bundle-budget failure observed after #2817 merged.