### PR TITLE
feat(ui): connect jobs to source evidence workflow

### DIFF
--- a/docs/release/source-job-evidence-workflow-v0.88.5.md
+++ b/docs/release/source-job-evidence-workflow-v0.88.5.md
@@ -1,0 +1,18 @@
+# Source, Job, And Evidence Workflow
+
+This release slice connects the existing control-plane objects into one operator workflow:
+
+- Sources remain the registered scan inputs under `/sources`.
+- Schedules remain control-plane scan triggers linked by `scan_config.source_id`.
+- Jobs now load hydrated `/v1/jobs?include_details=true` payloads and display the registered source, owner, and evidence state.
+- Completed jobs link directly to findings, the security graph, and compliance evidence for the same `job_id`.
+
+Claim boundary: the UI does not invent evidence or score state. It renders persisted `SourceRecord`, `ScanSchedule`, and `JobListItem` fields, including `source_id` when present.
+
+Verification:
+
+```bash
+uv run pytest tests/test_api_tenant_isolation.py::test_list_jobs_is_summary_first_and_opt_in_for_hydration -q
+cd ui && npm run typecheck
+cd ui && npx playwright test e2e/jobs-workflow.spec.ts --project=chromium
+```

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -515,6 +515,7 @@ def _job_summary_payload(job: ScanJob) -> dict[str, Any]:
     return {
         "job_id": job.job_id,
         "tenant_id": job.tenant_id,
+        "source_id": job.source_id,
         "status": job.status,
         "created_at": job.created_at,
         "completed_at": job.completed_at,

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -565,6 +565,7 @@ async def test_list_jobs_is_summary_first_and_opt_in_for_hydration():
                 status=JobStatus.DONE,
                 created_at=_now(),
                 completed_at=_now(),
+                source_id="source-alpha",
                 request=ScanRequest(images=["example:latest"]),
                 result={"summary": {"total_packages": 12, "total_vulnerabilities": 3}},
             )
@@ -582,6 +583,7 @@ async def test_list_jobs_is_summary_first_and_opt_in_for_hydration():
 
         hydrated = await scan_routes.list_jobs(req, include_details=True)
         assert store.get_calls == 1
+        assert hydrated["jobs"][0]["source_id"] == "source-alpha"
         assert hydrated["jobs"][0]["request"] == {"images": ["example:latest"]}
         assert hydrated["jobs"][0]["summary"]["total_packages"] == 12
 

--- a/ui/app/jobs/page.tsx
+++ b/ui/app/jobs/page.tsx
@@ -1,11 +1,21 @@
 "use client";
 
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { api, JobStatus, formatDate } from "@/lib/api";
-import { ShieldAlert, Clock, CheckCircle2, XCircle, Loader2, Trash2, Download, Search, ChevronLeft, ChevronRight } from "lucide-react";
-import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from "recharts";
+import { api, formatDate, type JobListItem, type JobStatus, type ScanSchedule, type SourceRecord } from "@/lib/api";
+import {
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  Download,
+  Loader2,
+  Search,
+  ShieldAlert,
+  Trash2,
+  XCircle,
+} from "lucide-react";
 
 function downloadJson(data: unknown, filename: string) {
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
@@ -13,13 +23,6 @@ function downloadJson(data: unknown, filename: string) {
   const a = document.createElement('a');
   a.href = url; a.download = filename; a.click();
   URL.revokeObjectURL(url);
-}
-
-interface JobSummary {
-  job_id: string;
-  status: JobStatus;
-  created_at: string;
-  completed_at?: string | undefined;
 }
 
 function StatusIcon({ status }: { status: JobStatus }) {
@@ -53,11 +56,44 @@ function statusColor(s: JobStatus) {
 
 const STATUS_TABS = ["all", "pending", "running", "done", "failed", "cancelled"];
 
+function sourceIdForJob(job: JobListItem): string {
+  const direct = typeof job.source_id === "string" ? job.source_id.trim() : "";
+  if (direct) return direct;
+  const requestSource = typeof job.request?.source_id === "string" ? job.request.source_id.trim() : "";
+  return requestSource;
+}
+
+function sourceForJob(
+  job: JobListItem,
+  sourceById: Map<string, SourceRecord>,
+  sourceByLastJobId: Map<string, SourceRecord>,
+): SourceRecord | undefined {
+  const sourceId = sourceIdForJob(job);
+  if (sourceId) return sourceById.get(sourceId);
+  return sourceByLastJobId.get(job.job_id);
+}
+
+function evidenceSummary(job: JobListItem): string {
+  const summary = job.summary;
+  if (!summary) return "No summary";
+  const vulns = summary.total_vulnerabilities ?? 0;
+  const critical = summary.critical_findings ?? 0;
+  const packages = summary.total_packages ?? 0;
+  return `${vulns} CVEs · ${critical} critical · ${packages} packages`;
+}
+
+function scheduleSourceId(schedule: ScanSchedule): string {
+  const raw = schedule.scan_config?.source_id;
+  return typeof raw === "string" ? raw.trim() : "";
+}
+
 function JobsPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const queryParam = searchParams.get("q") ?? "";
-  const [jobs, setJobs] = useState<JobSummary[]>([]);
+  const [jobs, setJobs] = useState<JobListItem[]>([]);
+  const [sources, setSources] = useState<SourceRecord[]>([]);
+  const [schedules, setSchedules] = useState<ScanSchedule[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [deleting, setDeleting] = useState<string | null>(null);
@@ -74,9 +110,23 @@ function JobsPageContent() {
   const load = () => {
     setLoading(true);
     setError("");
-    api.listJobs()
-      .then((r) => setJobs(r.jobs))
-      .catch((e) => setError(e.message))
+    Promise.allSettled([
+      api.listJobs({ includeDetails: true, limit: 200 }),
+      api.listSources(),
+      api.listSchedules(),
+    ])
+      .then(([jobsResult, sourcesResult, schedulesResult]) => {
+        if (jobsResult.status === "fulfilled") {
+          setJobs(jobsResult.value.jobs);
+        } else {
+          setError(jobsResult.reason instanceof Error ? jobsResult.reason.message : "Unable to load jobs");
+        }
+        setSources(sourcesResult.status === "fulfilled" ? sourcesResult.value.sources : []);
+        setSchedules(schedulesResult.status === "fulfilled" ? schedulesResult.value : []);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "Unable to load job workflow");
+      })
       .finally(() => setLoading(false));
   };
 
@@ -94,9 +144,30 @@ function JobsPageContent() {
     }
   }
 
+  const sourceById = useMemo(() => new Map(sources.map((source) => [source.source_id, source])), [sources]);
+  const sourceByLastJobId = useMemo(
+    () => new Map(sources.filter((source) => source.last_job_id).map((source) => [source.last_job_id as string, source])),
+    [sources],
+  );
+  const scheduledSourceIds = useMemo(
+    () => new Set(schedules.map(scheduleSourceId).filter(Boolean)),
+    [schedules],
+  );
+  const evidenceReadyJobs = useMemo(() => jobs.filter((job) => job.status === "done"), [jobs]);
+
   const filteredJobs = jobs
     .filter((j) => statusFilter === "all" || j.status === statusFilter)
-    .filter((j) => !search || j.job_id.toLowerCase().includes(search.toLowerCase()));
+    .filter((j) => {
+      if (!search) return true;
+      const normalized = search.toLowerCase();
+      const linkedSource = sourceForJob(j, sourceById, sourceByLastJobId);
+      return (
+        j.job_id.toLowerCase().includes(normalized) ||
+        sourceIdForJob(j).toLowerCase().includes(normalized) ||
+        (linkedSource?.display_name ?? "").toLowerCase().includes(normalized) ||
+        (linkedSource?.owner ?? "").toLowerCase().includes(normalized)
+      );
+    });
   const totalPages = Math.max(1, Math.ceil(filteredJobs.length / PAGE_SIZE));
   const pagedJobs = filteredJobs.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
@@ -146,36 +217,70 @@ function JobsPageContent() {
         </div>
       )}
 
-      {jobs.length > 0 && (() => {
-        const STATUS_COLORS: Record<string, string> = { done: "#22c55e", failed: "#ef4444", running: "#3b82f6", cancelled: "#71717a", pending: "#a1a1aa" };
-        const counts: Record<string, number> = {};
-        for (const j of jobs) counts[j.status] = (counts[j.status] ?? 0) + 1;
-        const pieData = Object.entries(counts).map(([status, value]) => ({ status, value, fill: STATUS_COLORS[status] ?? "#71717a" }));
-        return (
-          <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5 flex items-center gap-8">
-            <div className="w-28 h-28 flex-shrink-0">
-              <ResponsiveContainer width="100%" height="100%">
-                <PieChart>
-                  <Pie data={pieData} dataKey="value" innerRadius="55%" outerRadius="85%" paddingAngle={2} stroke="none">
-                    {pieData?.map((entry, i) => <Cell key={i} fill={entry.fill} fillOpacity={0.85} />)}
-                  </Pie>
-                  <Tooltip contentStyle={{ background: "#09090b", border: "1px solid #27272a", borderRadius: 8, fontSize: 12 }} itemStyle={{ color: "#e4e4e7" }} />
-                </PieChart>
-              </ResponsiveContainer>
+      {!loading && (jobs.length > 0 || sources.length > 0 || schedules.length > 0) && (
+        <section
+          data-testid="source-job-evidence-workflow"
+          className="border border-zinc-800 bg-zinc-950 rounded-xl overflow-hidden"
+        >
+          <div className="flex flex-col gap-4 border-b border-zinc-800 bg-zinc-900/60 px-5 py-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-emerald-400">
+                Source → job → evidence
+              </p>
+              <h2 className="mt-1 text-base font-semibold text-zinc-100">Control-plane workflow</h2>
+              <p className="mt-1 max-w-3xl text-sm text-zinc-500">
+                Registered sources create scan jobs; completed jobs become findings, graph, and compliance evidence for operators and API clients.
+              </p>
             </div>
-            <div className="space-y-2">
-              <p className="text-xs font-semibold text-zinc-400 uppercase tracking-wide mb-3">Job Status</p>
-              {pieData?.map((d) => (
-                <div key={d.status} className="flex items-center gap-2 text-xs">
-                  <span className="w-2 h-2 rounded-full" style={{ background: d.fill }} />
-                  <span className="capitalize text-zinc-300 w-20">{d.status}</span>
-                  <span className="font-mono text-zinc-500">{d.value}</span>
-                </div>
-              ))}
-            </div>
+            <Link
+              href="/sources"
+              className="inline-flex items-center gap-1.5 self-start rounded-lg border border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-300 hover:border-zinc-600 hover:text-zinc-100"
+            >
+              Manage sources
+            </Link>
           </div>
-        );
-      })()}
+          <div className="grid gap-px bg-zinc-800 sm:grid-cols-2 xl:grid-cols-4">
+            {[
+              {
+                label: "Registered sources",
+                value: sources.length,
+                detail: `${sources.filter((source) => source.enabled).length} enabled`,
+                icon: ShieldAlert,
+              },
+              {
+                label: "Scheduled sources",
+                value: scheduledSourceIds.size,
+                detail: `${schedules.filter((schedule) => schedule.enabled).length} schedules active`,
+                icon: Clock,
+              },
+              {
+                label: "Scan jobs",
+                value: jobs.length,
+                detail: `${jobs.filter((job) => job.status === "running").length} running now`,
+                icon: Search,
+              },
+              {
+                label: "Evidence-ready",
+                value: evidenceReadyJobs.length,
+                detail: "findings · graph · compliance",
+                icon: CheckCircle2,
+              },
+            ].map((item) => (
+              <div key={item.label} className="bg-zinc-950 p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <item.icon className="h-4 w-4 text-zinc-500" />
+                  <span className="rounded-full border border-zinc-800 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-zinc-500">
+                    live
+                  </span>
+                </div>
+                <p className="mt-4 text-2xl font-semibold text-zinc-100">{item.value}</p>
+                <p className="mt-1 text-xs text-zinc-500">{item.label}</p>
+                <p className="mt-2 text-xs text-zinc-600">{item.detail}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
 
       {jobs.length > 0 && (
         <>
@@ -202,7 +307,7 @@ function JobsPageContent() {
               <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-zinc-600" />
               <input
                 type="text"
-                placeholder="Search job ID…"
+                placeholder="Search jobs or sources…"
                 value={search}
                 onChange={(e) => { setSearch(e.target.value); setPage(1); }}
                 className="w-full bg-zinc-900 border border-zinc-700 rounded-lg pl-8 pr-3 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500"
@@ -216,53 +321,95 @@ function JobsPageContent() {
                 <tr>
                   <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Job ID</th>
                   <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Status</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Source</th>
                   <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Started</th>
                   <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Completed</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Evidence</th>
                   <th className="px-4 py-3" />
                 </tr>
               </thead>
               <tbody className="divide-y divide-zinc-800 bg-zinc-950">
-                {pagedJobs?.map((job) => (
-                  <tr
-                    key={job.job_id}
-                    className="hover:bg-zinc-900 transition-colors cursor-pointer group"
-                    onClick={() => router.push(`/scan?id=${job.job_id}`)}
-                  >
-                    <td className="px-4 py-3">
-                      <span className="font-mono text-xs text-zinc-300">
-                        {job.job_id.slice(0, 8)}…
-                      </span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className={`flex items-center gap-1.5 ${statusColor(job.status)}`}>
-                        <StatusIcon status={job.status} />
-                        <span className="text-xs font-medium">{statusLabel(job.status)}</span>
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 text-xs text-zinc-500">
-                      {formatDate(job.created_at)}
-                    </td>
-                    <td className="px-4 py-3 text-xs text-zinc-500">
-                      {job.completed_at ? formatDate(job.completed_at) : "—"}
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      <button
-                        onClick={(e) => handleDelete(job.job_id, e)}
-                        disabled={deleting === job.job_id}
-                        className="opacity-0 group-hover:opacity-100 p-1 text-zinc-600 hover:text-red-400 transition-all rounded"
-                        title="Delete job"
-                      >
-                        {deleting === job.job_id
-                          ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                          : <Trash2 className="w-3.5 h-3.5" />
-                        }
-                      </button>
-                    </td>
-                  </tr>
-                ))}
+                {pagedJobs?.map((job) => {
+                  const linkedSource = sourceForJob(job, sourceById, sourceByLastJobId);
+                  const sourceId = sourceIdForJob(job);
+                  const evidenceReady = job.status === "done";
+                  return (
+                    <tr
+                      key={job.job_id}
+                      className="hover:bg-zinc-900 transition-colors cursor-pointer group"
+                      onClick={() => router.push(`/scan?id=${job.job_id}`)}
+                    >
+                      <td className="px-4 py-3">
+                        <span className="font-mono text-xs text-zinc-300">
+                          {job.job_id.slice(0, 8)}…
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className={`flex items-center gap-1.5 ${statusColor(job.status)}`}>
+                          <StatusIcon status={job.status} />
+                          <span className="text-xs font-medium">{statusLabel(job.status)}</span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="max-w-56">
+                          <p className="truncate text-xs font-medium text-zinc-300">
+                            {linkedSource?.display_name ?? (sourceId || "Manual / pushed scan")}
+                          </p>
+                          <p className="mt-0.5 truncate text-[11px] text-zinc-600">
+                            {linkedSource ? `${linkedSource.kind} · ${linkedSource.owner || "unowned"}` : sourceId || "No registered source"}
+                          </p>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-xs text-zinc-500">
+                        {formatDate(job.created_at)}
+                      </td>
+                      <td className="px-4 py-3 text-xs text-zinc-500">
+                        {job.completed_at ? formatDate(job.completed_at) : "—"}
+                      </td>
+                      <td className="px-4 py-3">
+                        {evidenceReady ? (
+                          <div className="space-y-2">
+                            <p className="text-[11px] text-zinc-500">{evidenceSummary(job)}</p>
+                            <div className="flex flex-wrap gap-1.5">
+                              {[
+                                { href: `/findings?scan=${encodeURIComponent(job.job_id)}`, label: "Findings" },
+                                { href: `/security-graph?scan=${encodeURIComponent(job.job_id)}`, label: "Graph" },
+                                { href: `/compliance?scan=${encodeURIComponent(job.job_id)}`, label: "Compliance" },
+                              ].map((link) => (
+                                <Link
+                                  key={link.label}
+                                  href={link.href}
+                                  onClick={(event) => event.stopPropagation()}
+                                  className="rounded-md border border-zinc-800 px-2 py-1 text-[11px] font-medium text-zinc-400 hover:border-zinc-700 hover:text-zinc-100"
+                                >
+                                  {link.label}
+                                </Link>
+                              ))}
+                            </div>
+                          </div>
+                        ) : (
+                          <span className="text-xs text-zinc-600">Available when complete</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <button
+                          onClick={(e) => handleDelete(job.job_id, e)}
+                          disabled={deleting === job.job_id}
+                          className="opacity-0 group-hover:opacity-100 p-1 text-zinc-600 hover:text-red-400 transition-all rounded"
+                          title="Delete job"
+                        >
+                          {deleting === job.job_id
+                            ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                            : <Trash2 className="w-3.5 h-3.5" />
+                          }
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
                 {pagedJobs.length === 0 && (
                   <tr>
-                    <td colSpan={5} className="px-4 py-8 text-center text-zinc-600 text-sm">
+                    <td colSpan={7} className="px-4 py-8 text-center text-zinc-600 text-sm">
                       No jobs match your filters.
                     </td>
                   </tr>

--- a/ui/e2e/jobs-workflow.spec.ts
+++ b/ui/e2e/jobs-workflow.spec.ts
@@ -1,0 +1,150 @@
+import { expect, test } from "@playwright/test";
+
+const source = {
+  source_id: "src-prod-cloud",
+  tenant_id: "default",
+  display_name: "Prod cloud account",
+  kind: "scan.cloud",
+  description: "Production cloud discovery source",
+  owner: "security-platform",
+  connector_name: "aws",
+  credential_mode: "credential_ref",
+  credential_ref: "aws/prod/read-only",
+  enabled: true,
+  status: "healthy",
+  config: {},
+  last_tested_at: "2026-05-28T10:00:00Z",
+  last_test_status: "healthy",
+  last_test_message: "OK",
+  last_run_at: "2026-05-28T10:12:00Z",
+  last_run_status: "done",
+  last_job_id: "job-prod-cloud",
+  created_at: "2026-05-28T09:00:00Z",
+  updated_at: "2026-05-28T10:12:00Z",
+};
+
+const job = {
+  job_id: "job-prod-cloud",
+  tenant_id: "default",
+  source_id: source.source_id,
+  status: "done",
+  created_at: "2026-05-28T10:12:00Z",
+  completed_at: "2026-05-28T10:14:00Z",
+  request: {
+    source_id: source.source_id,
+    k8s: true,
+  },
+  summary: {
+    total_agents: 2,
+    total_servers: 3,
+    total_packages: 8,
+    total_vulnerabilities: 3,
+    critical_findings: 1,
+    high_findings: 1,
+    medium_findings: 1,
+    low_findings: 0,
+  },
+};
+
+test("jobs page links sources to completed evidence surfaces", async ({ page }) => {
+  await page.route("**/health", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ status: "ok" }),
+    });
+  });
+
+  await page.route("**/v1/auth/me", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        authenticated: true,
+        auth_required: false,
+        configured_modes: [],
+        recommended_ui_mode: "no_auth",
+        auth_method: null,
+        subject: null,
+        role: null,
+        role_summary: null,
+        tenant_id: "default",
+        memberships: [],
+        request_id: "req-jobs-e2e",
+        trace_id: "trace-jobs-e2e",
+        span_id: "span-jobs-e2e",
+      }),
+    });
+  });
+
+  await page.route("**/v1/posture/counts", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        critical: 1,
+        high: 1,
+        medium: 1,
+        low: 0,
+        total: 3,
+        kev: 0,
+        compound_issues: 0,
+      }),
+    });
+  });
+
+  await page.route("**/v1/jobs**", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        schema_version: "v1",
+        jobs: [job],
+        count: 1,
+        total: 1,
+        limit: 200,
+        offset: 0,
+      }),
+    });
+  });
+
+  await page.route("**/v1/sources", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        sources: [source],
+        count: 1,
+      }),
+    });
+  });
+
+  await page.route("**/v1/schedules", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          schedule_id: "schedule-prod-cloud",
+          name: "Prod cloud daily",
+          cron_expression: "0 8 * * *",
+          scan_config: { source_id: source.source_id },
+          enabled: true,
+          last_run: "2026-05-28T10:12:00Z",
+          next_run: "2026-05-29T08:00:00Z",
+          last_job_id: job.job_id,
+          created_at: "2026-05-28T09:00:00Z",
+          updated_at: "2026-05-28T10:12:00Z",
+          tenant_id: "default",
+        },
+      ]),
+    });
+  });
+
+  await page.goto("/jobs");
+  await page.waitForLoadState("networkidle");
+
+  await expect(page.getByRole("heading", { name: "Jobs" })).toBeVisible();
+  await expect(page.getByTestId("source-job-evidence-workflow")).toContainText("Source → job → evidence");
+  await expect(page.getByTestId("source-job-evidence-workflow")).toContainText("Evidence-ready");
+  await expect(page.getByText("Prod cloud account")).toBeVisible();
+  await expect(page.getByText("3 CVEs · 1 critical · 8 packages")).toBeVisible();
+
+  await expect(page.getByRole("link", { name: "Findings", exact: true })).toHaveAttribute("href", "/findings?scan=job-prod-cloud");
+  await expect(page.getByRole("link", { name: "Graph", exact: true })).toHaveAttribute("href", "/security-graph?scan=job-prod-cloud");
+  await expect(page.getByRole("link", { name: "Compliance", exact: true })).toHaveAttribute("href", "/compliance?scan=job-prod-cloud");
+});

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -6,6 +6,7 @@ import type { ExposurePath } from "./exposure-path";
 export type JobStatus = "pending" | "running" | "done" | "failed" | "cancelled";
 
 export interface ScanRequest {
+  source_id?: string | undefined;
   inventory?: string | undefined;
   images?: string[] | undefined;
   k8s?: boolean | undefined;
@@ -1327,6 +1328,7 @@ export interface JobListItem {
   status: JobStatus;
   created_at: string;
   tenant_id?: string | undefined;
+  source_id?: string | undefined;
   completed_at?: string | undefined;
   request?: ScanRequest | undefined;
   summary?: Summary | undefined;


### PR DESCRIPTION
Summary
- connect the Jobs page to hydrated job, source, and schedule API data so operators can see source -> job -> evidence lineage
- expose source_id on job summary payloads and UI contracts for data-model alignment
- add Playwright coverage and release evidence notes for the Jobs evidence workflow

Verification
- uv run pytest tests/test_api_tenant_isolation.py::test_list_jobs_is_summary_first_and_opt_in_for_hydration -q
- uv run ruff check src/agent_bom/api/routes/scan.py tests/test_api_tenant_isolation.py
- cd ui && npm run typecheck
- cd ui && npx playwright test e2e/jobs-workflow.spec.ts --project=chromium
- git diff --check

Notes
- Closes #2594.
- UI validation temporarily quarantined local untracked Finder duplicate files and restored them after each command.