### PR TITLE
feat(findings): add triage queue vex API

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,8 +53,8 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 191 |
-| `docs/openapi/v1.json` | component schemas | 59 |
+| `docs/openapi/v1.json` | paths | 194 |
+| `docs/openapi/v1.json` | component schemas | 61 |
 
 <!-- DATA_MODEL_ATLAS:END -->
 
@@ -345,6 +345,8 @@ tenant boundary, persistence behavior, and redaction behavior here.
 | `intel.match.v1` | `POST /v1/intel/match`, `intel_match` MCP tool | inventory enrichment, CI gates, agent posture checks | submitted packages, matched package count, advisory matches, `match_method`, `match_confidence`, match reason, evidence links | Read-only package-coordinate matching. Inputs use purl when present; otherwise `ecosystem` + `name` + optional `version`. |
 | `intel.daily_brief.v1` | `POST /v1/intel/daily-brief`, `intel_daily_brief` MCP tool | analysts, agents, daily governance jobs | local KEV lookback, high-EPSS inventory matches, vendor advisory matches, caller-supplied IoC telemetry hits, campaign matches, ransomware sector matches, source registry freshness, limitations | Read-only summary over local DB, submitted inventory, and governed caller inputs. IoC/campaign/ransomware entries carry source URL, license/terms, fetched time, content hash, validation status, match method, confidence, and match reason. |
 | `evals.runs.v1` | `POST /v1/evaluations`, `GET /v1/evaluations`, Python/Go/TypeScript control-plane clients | headless evaluators, CI jobs, notebooks, graph enrichment | `evaluation_id`, `dataset_id`, `dataset_version_id`, `trace_id`, `model`, `prompt_hash`, `scores`, `summary`, `cases`, `metadata` | Tenant-scoped control-plane state. The contract stores references, hashes, scores, and finding metadata; raw prompts and dataset rows stay in customer-owned artifact storage. |
+| `findings.triage.v1` | `POST /v1/findings/triage`, `GET /v1/findings/triage`, `PUT /v1/findings/triage/{triage_id}/decision` | analysts, auditors, exception review queues, future UI triage workflows | vulnerability/package/server target, queue state, assignee, decision, OpenVEX justification, decision reason, review timestamp, expiration | Tenant-scoped review state stored through the exception store abstraction. The API stores decision metadata and references, not exploit payloads or credential values. |
+| `findings.triage.vex.v1` | `GET /v1/findings/triage/vex` | auditors, CI release evidence, downstream VEX consumers | signed OpenVEX document for eligible `not_affected` decisions with justification, tenant id, statement count, signature metadata | Derived from tenant-scoped triage rows only. Export payloads are canonicalized and signed; only `not_affected` decisions with explicit OpenVEX justification are emitted. |
 
 ### `agent-bom.manifest/v1`
 

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -1182,6 +1182,159 @@
         "title": "FindingFeedbackRequest",
         "type": "object"
       },
+      "FindingTriageDecisionRequest": {
+        "description": "Request body for PUT /v1/findings/triage/{triage_id}/decision.",
+        "properties": {
+          "assignee": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assignee"
+          },
+          "decision": {
+            "enum": [
+              "not_affected",
+              "affected",
+              "under_investigation"
+            ],
+            "title": "Decision",
+            "type": "string"
+          },
+          "decision_reason": {
+            "default": "",
+            "maxLength": 2000,
+            "title": "Decision Reason",
+            "type": "string"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "maxLength": 64,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "justification": {
+            "anyOf": [
+              {
+                "enum": [
+                  "component_not_present",
+                  "vulnerable_code_not_present",
+                  "vulnerable_code_not_in_execute_path",
+                  "vulnerable_code_cannot_be_controlled_by_adversary",
+                  "inline_mitigations_already_exist"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Justification"
+          }
+        },
+        "required": [
+          "decision"
+        ],
+        "title": "FindingTriageDecisionRequest",
+        "type": "object"
+      },
+      "FindingTriageRequest": {
+        "description": "Request body for POST /v1/findings/triage.",
+        "properties": {
+          "assignee": {
+            "default": "",
+            "maxLength": 256,
+            "title": "Assignee",
+            "type": "string"
+          },
+          "decision": {
+            "default": "under_investigation",
+            "enum": [
+              "not_affected",
+              "affected",
+              "under_investigation"
+            ],
+            "title": "Decision",
+            "type": "string"
+          },
+          "decision_reason": {
+            "default": "",
+            "maxLength": 2000,
+            "title": "Decision Reason",
+            "type": "string"
+          },
+          "expires_at": {
+            "default": "",
+            "maxLength": 64,
+            "title": "Expires At",
+            "type": "string"
+          },
+          "justification": {
+            "anyOf": [
+              {
+                "enum": [
+                  "component_not_present",
+                  "vulnerable_code_not_present",
+                  "vulnerable_code_not_in_execute_path",
+                  "vulnerable_code_cannot_be_controlled_by_adversary",
+                  "inline_mitigations_already_exist"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Justification"
+          },
+          "package": {
+            "default": "*",
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "Package",
+            "type": "string"
+          },
+          "queue_state": {
+            "default": "open",
+            "enum": [
+              "open",
+              "assigned",
+              "reviewing",
+              "decided"
+            ],
+            "title": "Queue State",
+            "type": "string"
+          },
+          "server_name": {
+            "default": "",
+            "maxLength": 256,
+            "title": "Server Name",
+            "type": "string"
+          },
+          "vulnerability_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Vulnerability Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "vulnerability_id"
+        ],
+        "title": "FindingTriageRequest",
+        "type": "object"
+      },
       "FleetAgentUpdate": {
         "properties": {
           "environment": {
@@ -8013,6 +8166,218 @@
           }
         },
         "summary": "Create Jira Ticket Route",
+        "tags": [
+          "enterprise"
+        ]
+      }
+    },
+    "/v1/findings/triage": {
+      "get": {
+        "description": "List tenant-scoped finding triage queue items.",
+        "operationId": "list_finding_triage_v1_findings_triage_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "queue_state",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Queue State"
+            }
+          },
+          {
+            "in": "query",
+            "name": "decision",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Decision"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 1000,
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Finding Triage V1 Findings Triage Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Finding Triage",
+        "tags": [
+          "enterprise"
+        ]
+      },
+      "post": {
+        "description": "Create a tenant-scoped finding triage queue item.",
+        "operationId": "create_finding_triage_v1_findings_triage_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FindingTriageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Create Finding Triage V1 Findings Triage Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Finding Triage",
+        "tags": [
+          "enterprise"
+        ]
+      }
+    },
+    "/v1/findings/triage/vex": {
+      "get": {
+        "description": "Export signed OpenVEX for eligible tenant-scoped not_affected triage decisions.",
+        "operationId": "export_finding_triage_vex_v1_findings_triage_vex_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Export Finding Triage Vex V1 Findings Triage Vex Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Export Finding Triage Vex",
+        "tags": [
+          "enterprise"
+        ]
+      }
+    },
+    "/v1/findings/triage/{triage_id}/decision": {
+      "put": {
+        "description": "Record a finding triage decision and review timestamp.",
+        "operationId": "update_finding_triage_decision_v1_findings_triage__triage_id__decision_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "triage_id",
+            "required": true,
+            "schema": {
+              "title": "Triage Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FindingTriageDecisionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Update Finding Triage Decision V1 Findings Triage  Triage Id  Decision Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Finding Triage Decision",
         "tags": [
           "enterprise"
         ]

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -785,6 +785,114 @@ components:
       - vulnerability_id
       title: FindingFeedbackRequest
       type: object
+    FindingTriageDecisionRequest:
+      description: Request body for PUT /v1/findings/triage/{triage_id}/decision.
+      properties:
+        assignee:
+          anyOf:
+          - maxLength: 256
+            type: string
+          - type: 'null'
+          title: Assignee
+        decision:
+          enum:
+          - not_affected
+          - affected
+          - under_investigation
+          title: Decision
+          type: string
+        decision_reason:
+          default: ''
+          maxLength: 2000
+          title: Decision Reason
+          type: string
+        expires_at:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Expires At
+        justification:
+          anyOf:
+          - enum:
+            - component_not_present
+            - vulnerable_code_not_present
+            - vulnerable_code_not_in_execute_path
+            - vulnerable_code_cannot_be_controlled_by_adversary
+            - inline_mitigations_already_exist
+            type: string
+          - type: 'null'
+          title: Justification
+      required:
+      - decision
+      title: FindingTriageDecisionRequest
+      type: object
+    FindingTriageRequest:
+      description: Request body for POST /v1/findings/triage.
+      properties:
+        assignee:
+          default: ''
+          maxLength: 256
+          title: Assignee
+          type: string
+        decision:
+          default: under_investigation
+          enum:
+          - not_affected
+          - affected
+          - under_investigation
+          title: Decision
+          type: string
+        decision_reason:
+          default: ''
+          maxLength: 2000
+          title: Decision Reason
+          type: string
+        expires_at:
+          default: ''
+          maxLength: 64
+          title: Expires At
+          type: string
+        justification:
+          anyOf:
+          - enum:
+            - component_not_present
+            - vulnerable_code_not_present
+            - vulnerable_code_not_in_execute_path
+            - vulnerable_code_cannot_be_controlled_by_adversary
+            - inline_mitigations_already_exist
+            type: string
+          - type: 'null'
+          title: Justification
+        package:
+          default: '*'
+          maxLength: 256
+          minLength: 1
+          title: Package
+          type: string
+        queue_state:
+          default: open
+          enum:
+          - open
+          - assigned
+          - reviewing
+          - decided
+          title: Queue State
+          type: string
+        server_name:
+          default: ''
+          maxLength: 256
+          title: Server Name
+          type: string
+        vulnerability_id:
+          maxLength: 128
+          minLength: 1
+          title: Vulnerability Id
+          type: string
+      required:
+      - vulnerability_id
+      title: FindingTriageRequest
+      type: object
     FleetAgentUpdate:
       properties:
         environment:
@@ -5281,6 +5389,142 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Create Jira Ticket Route
+      tags:
+      - enterprise
+  /v1/findings/triage:
+    get:
+      description: List tenant-scoped finding triage queue items.
+      operationId: list_finding_triage_v1_findings_triage_get
+      parameters:
+      - in: query
+        name: queue_state
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Queue State
+      - in: query
+        name: decision
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Decision
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 1000
+          maximum: 1000
+          minimum: 1
+          title: Limit
+          type: integer
+      - in: query
+        name: offset
+        required: false
+        schema:
+          default: 0
+          minimum: 0
+          title: Offset
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response List Finding Triage V1 Findings Triage Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: List Finding Triage
+      tags:
+      - enterprise
+    post:
+      description: Create a tenant-scoped finding triage queue item.
+      operationId: create_finding_triage_v1_findings_triage_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FindingTriageRequest'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Create Finding Triage V1 Findings Triage Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Create Finding Triage
+      tags:
+      - enterprise
+  /v1/findings/triage/vex:
+    get:
+      description: Export signed OpenVEX for eligible tenant-scoped not_affected triage
+        decisions.
+      operationId: export_finding_triage_vex_v1_findings_triage_vex_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Export Finding Triage Vex V1 Findings Triage Vex Get
+                type: object
+          description: Successful Response
+      summary: Export Finding Triage Vex
+      tags:
+      - enterprise
+  /v1/findings/triage/{triage_id}/decision:
+    put:
+      description: Record a finding triage decision and review timestamp.
+      operationId: update_finding_triage_decision_v1_findings_triage__triage_id__decision_put
+      parameters:
+      - in: path
+        name: triage_id
+        required: true
+        schema:
+          title: Triage Id
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FindingTriageDecisionRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Update Finding Triage Decision V1 Findings Triage  Triage
+                  Id  Decision Put
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Update Finding Triage Decision
       tags:
       - enterprise
   /v1/firewall/check:

--- a/docs/schemas/v1/FindingTriageDecisionRequest.json
+++ b/docs/schemas/v1/FindingTriageDecisionRequest.json
@@ -1,0 +1,70 @@
+{
+  "description": "Request body for PUT /v1/findings/triage/{triage_id}/decision.",
+  "properties": {
+    "assignee": {
+      "anyOf": [
+        {
+          "maxLength": 256,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Assignee"
+    },
+    "decision": {
+      "enum": [
+        "not_affected",
+        "affected",
+        "under_investigation"
+      ],
+      "title": "Decision",
+      "type": "string"
+    },
+    "decision_reason": {
+      "default": "",
+      "maxLength": 2000,
+      "title": "Decision Reason",
+      "type": "string"
+    },
+    "expires_at": {
+      "anyOf": [
+        {
+          "maxLength": 64,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Expires At"
+    },
+    "justification": {
+      "anyOf": [
+        {
+          "enum": [
+            "component_not_present",
+            "vulnerable_code_not_present",
+            "vulnerable_code_not_in_execute_path",
+            "vulnerable_code_cannot_be_controlled_by_adversary",
+            "inline_mitigations_already_exist"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Justification"
+    }
+  },
+  "required": [
+    "decision"
+  ],
+  "title": "FindingTriageDecisionRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/FindingTriageRequest.json
+++ b/docs/schemas/v1/FindingTriageRequest.json
@@ -1,0 +1,87 @@
+{
+  "description": "Request body for POST /v1/findings/triage.",
+  "properties": {
+    "assignee": {
+      "default": "",
+      "maxLength": 256,
+      "title": "Assignee",
+      "type": "string"
+    },
+    "decision": {
+      "default": "under_investigation",
+      "enum": [
+        "not_affected",
+        "affected",
+        "under_investigation"
+      ],
+      "title": "Decision",
+      "type": "string"
+    },
+    "decision_reason": {
+      "default": "",
+      "maxLength": 2000,
+      "title": "Decision Reason",
+      "type": "string"
+    },
+    "expires_at": {
+      "default": "",
+      "maxLength": 64,
+      "title": "Expires At",
+      "type": "string"
+    },
+    "justification": {
+      "anyOf": [
+        {
+          "enum": [
+            "component_not_present",
+            "vulnerable_code_not_present",
+            "vulnerable_code_not_in_execute_path",
+            "vulnerable_code_cannot_be_controlled_by_adversary",
+            "inline_mitigations_already_exist"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Justification"
+    },
+    "package": {
+      "default": "*",
+      "maxLength": 256,
+      "minLength": 1,
+      "title": "Package",
+      "type": "string"
+    },
+    "queue_state": {
+      "default": "open",
+      "enum": [
+        "open",
+        "assigned",
+        "reviewing",
+        "decided"
+      ],
+      "title": "Queue State",
+      "type": "string"
+    },
+    "server_name": {
+      "default": "",
+      "maxLength": 256,
+      "title": "Server Name",
+      "type": "string"
+    },
+    "vulnerability_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "title": "Vulnerability Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "vulnerability_id"
+  ],
+  "title": "FindingTriageRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/index.json
+++ b/docs/schemas/v1/index.json
@@ -97,6 +97,16 @@
       "schema": "FindingFeedbackRequest.json"
     },
     {
+      "doc": "Request body for PUT /v1/findings/triage/{triage_id}/decision.",
+      "name": "FindingTriageDecisionRequest",
+      "schema": "FindingTriageDecisionRequest.json"
+    },
+    {
+      "doc": "Request body for POST /v1/findings/triage.",
+      "name": "FindingTriageRequest",
+      "schema": "FindingTriageRequest.json"
+    },
+    {
       "doc": "",
       "name": "FleetAgentUpdate",
       "schema": "FleetAgentUpdate.json"

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -611,6 +611,15 @@ class FalsePositiveRequest(BaseModel):
 
 
 FindingFeedbackState = Literal["false_positive", "accepted_risk", "not_affected", "not_applicable", "fixed_verified", "needs_review"]
+FindingTriageQueueState = Literal["open", "assigned", "reviewing", "decided"]
+FindingTriageDecision = Literal["not_affected", "affected", "under_investigation"]
+FindingTriageJustification = Literal[
+    "component_not_present",
+    "vulnerable_code_not_present",
+    "vulnerable_code_not_in_execute_path",
+    "vulnerable_code_cannot_be_controlled_by_adversary",
+    "inline_mitigations_already_exist",
+]
 
 
 class FindingFeedbackRequest(BaseModel):
@@ -622,3 +631,27 @@ class FindingFeedbackRequest(BaseModel):
     reason: str = Field("", max_length=2000)
     server_name: str = Field("", max_length=256)
     expires_at: str = Field("", max_length=64)
+
+
+class FindingTriageRequest(BaseModel):
+    """Request body for POST /v1/findings/triage."""
+
+    vulnerability_id: str = Field(..., min_length=1, max_length=128)
+    package: str = Field("*", min_length=1, max_length=256)
+    server_name: str = Field("", max_length=256)
+    assignee: str = Field("", max_length=256)
+    queue_state: FindingTriageQueueState = "open"
+    decision: FindingTriageDecision = "under_investigation"
+    justification: FindingTriageJustification | None = None
+    decision_reason: str = Field("", max_length=2000)
+    expires_at: str = Field("", max_length=64)
+
+
+class FindingTriageDecisionRequest(BaseModel):
+    """Request body for PUT /v1/findings/triage/{triage_id}/decision."""
+
+    decision: FindingTriageDecision
+    justification: FindingTriageJustification | None = None
+    decision_reason: str = Field("", max_length=2000)
+    assignee: str | None = Field(None, max_length=256)
+    expires_at: str | None = Field(None, max_length=64)

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -49,6 +49,8 @@ from agent_bom.api.models import (
     ExceptionRequest,
     FalsePositiveRequest,
     FindingFeedbackRequest,
+    FindingTriageDecisionRequest,
+    FindingTriageRequest,
     IssueStatusUpdateRequest,
     JiraTicketRequest,
     RotateKeyRequest,
@@ -79,6 +81,7 @@ class AuditExportVerifyRequest(BaseModel):
 _SAML_RELAY_STATES: dict[str, float] = {}
 _SAML_RELAY_LOCK = threading.Lock()
 _FEEDBACK_PREFIX = "[finding_feedback:"
+_TRIAGE_PREFIX = "[finding_triage]"
 _LEGACY_FALSE_POSITIVE_PREFIX = "[false_positive]"
 
 
@@ -184,6 +187,28 @@ def _parse_feedback_reason(reason: str) -> tuple[str, str] | None:
     return None
 
 
+def _validate_triage_decision(decision: str, justification: str | None) -> None:
+    if decision == "not_affected" and not justification:
+        raise HTTPException(status_code=400, detail="not_affected triage decisions require an OpenVEX justification")
+
+
+def _triage_reason(payload: dict[str, Any]) -> str:
+    return f"{_TRIAGE_PREFIX} {json.dumps(payload, sort_keys=True, separators=(',', ':'))}"
+
+
+def _parse_triage_reason(reason: str) -> dict[str, Any] | None:
+    if not reason.startswith(_TRIAGE_PREFIX):
+        return None
+    raw = reason.removeprefix(_TRIAGE_PREFIX).strip()
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
 def _feedback_response(exc: Any) -> dict[str, Any]:
     parsed = _parse_feedback_reason(str(exc.reason))
     state, reason = parsed if parsed else ("unknown", str(exc.reason))
@@ -199,6 +224,30 @@ def _feedback_response(exc: Any) -> dict[str, Any]:
         "created_at": exc.created_at,
         "expires_at": exc.expires_at,
         "tenant_id": exc.tenant_id,
+    }
+
+
+def _triage_response(exc: Any) -> dict[str, Any]:
+    data = _parse_triage_reason(str(exc.reason)) or {}
+    decision = str(data.get("decision") or "under_investigation")
+    queue_state = str(data.get("queue_state") or "open")
+    reviewed_at = str(data.get("reviewed_at") or exc.approved_at or "")
+    return {
+        "id": exc.exception_id,
+        "vulnerability_id": exc.vuln_id,
+        "package": exc.package_name,
+        "server_name": exc.server_name,
+        "queue_state": queue_state,
+        "decision": decision,
+        "justification": data.get("justification"),
+        "decision_reason": str(data.get("decision_reason") or ""),
+        "assignee": str(data.get("assignee") or exc.approved_by or ""),
+        "created_by": exc.requested_by,
+        "created_at": exc.created_at,
+        "reviewed_at": reviewed_at,
+        "expires_at": exc.expires_at,
+        "tenant_id": exc.tenant_id,
+        "vex_eligible": decision == "not_affected" and bool(data.get("justification")),
     }
 
 
@@ -1505,6 +1554,177 @@ async def list_finding_feedback(request: Request, state: str | None = None) -> d
             continue
         entries.append(_feedback_response(exc))
     return {"feedback": entries, "total": len(entries)}
+
+
+@router.post("/v1/findings/triage", tags=["enterprise"], status_code=201)
+async def create_finding_triage(request: Request, req: FindingTriageRequest) -> dict:
+    """Create a tenant-scoped finding triage queue item."""
+    from agent_bom.api.audit_log import log_action
+    from agent_bom.api.exception_store import ExceptionStatus, VulnException
+
+    _validate_triage_decision(req.decision, req.justification)
+    tenant_id = require_request_tenant_id(request)
+    actor = _request_actor(request)
+    now = datetime.now(timezone.utc).isoformat()
+    queue_state = "decided" if req.decision in {"affected", "not_affected"} else req.queue_state
+    reviewed_at = now if queue_state == "decided" else ""
+    exc = VulnException(
+        vuln_id=req.vulnerability_id,
+        package_name=req.package,
+        server_name=req.server_name,
+        reason=_triage_reason(
+            {
+                "queue_state": queue_state,
+                "decision": req.decision,
+                "justification": req.justification,
+                "decision_reason": req.decision_reason,
+                "assignee": req.assignee,
+                "reviewed_at": reviewed_at,
+            }
+        ),
+        requested_by=actor,
+        approved_by=req.assignee,
+        status=ExceptionStatus.ACTIVE,
+        expires_at=req.expires_at,
+        approved_at=reviewed_at,
+        tenant_id=tenant_id,
+    )
+    _get_exception_store().put(exc)
+    log_action(
+        "findings.triage_created",
+        actor=actor,
+        resource=f"finding-triage/{exc.exception_id}",
+        tenant_id=tenant_id,
+        vuln_id=req.vulnerability_id,
+        package=req.package,
+        queue_state=queue_state,
+        decision=req.decision,
+    )
+    return _triage_response(exc)
+
+
+@router.get("/v1/findings/triage", tags=["enterprise"])
+async def list_finding_triage(
+    request: Request,
+    queue_state: str | None = None,
+    decision: str | None = None,
+    limit: Annotated[int, Query(ge=1, le=1000)] = 1000,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> dict:
+    """List tenant-scoped finding triage queue items."""
+    tenant_id = require_request_tenant_id(request)
+    entries = []
+    for exc in _get_exception_store().list_all(tenant_id=tenant_id):
+        data = _parse_triage_reason(exc.reason)
+        if data is None:
+            continue
+        response = _triage_response(exc)
+        if queue_state and response["queue_state"] != queue_state:
+            continue
+        if decision and response["decision"] != decision:
+            continue
+        entries.append(response)
+    total = len(entries)
+    return {
+        "schema_version": "findings.triage.v1",
+        "triage": entries[offset : offset + limit],
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+@router.put("/v1/findings/triage/{triage_id}/decision", tags=["enterprise"])
+async def update_finding_triage_decision(request: Request, triage_id: str, req: FindingTriageDecisionRequest) -> dict:
+    """Record a finding triage decision and review timestamp."""
+    from agent_bom.api.audit_log import log_action
+
+    _validate_triage_decision(req.decision, req.justification)
+    tenant_id = require_request_tenant_id(request)
+    actor = _request_actor(request)
+    store = _get_exception_store()
+    exc = store.get(triage_id, tenant_id=tenant_id)
+    if exc is None or _parse_triage_reason(exc.reason) is None:
+        raise HTTPException(status_code=404, detail=f"Finding triage item {triage_id} not found")
+    reviewed_at = datetime.now(timezone.utc).isoformat()
+    current = _parse_triage_reason(exc.reason) or {}
+    assignee = req.assignee if req.assignee is not None else str(current.get("assignee") or exc.approved_by or "")
+    exc.reason = _triage_reason(
+        {
+            "queue_state": "decided",
+            "decision": req.decision,
+            "justification": req.justification,
+            "decision_reason": req.decision_reason,
+            "assignee": assignee,
+            "reviewed_at": reviewed_at,
+        }
+    )
+    exc.approved_by = assignee
+    exc.approved_at = reviewed_at
+    if req.expires_at is not None:
+        exc.expires_at = req.expires_at
+    store.put(exc)
+    log_action(
+        "findings.triage_decision_recorded",
+        actor=actor,
+        resource=f"finding-triage/{triage_id}",
+        tenant_id=tenant_id,
+        vuln_id=exc.vuln_id,
+        package=exc.package_name,
+        decision=req.decision,
+    )
+    return _triage_response(exc)
+
+
+@router.get("/v1/findings/triage/vex", tags=["enterprise"])
+async def export_finding_triage_vex(request: Request) -> dict:
+    """Export signed OpenVEX for eligible tenant-scoped not_affected triage decisions."""
+    from agent_bom.api.compliance_signing import sign_compliance_bundle
+    from agent_bom.vex import VexDocument, VexJustification, VexStatement, VexStatus, export_openvex
+
+    tenant_id = require_request_tenant_id(request)
+    statements = []
+    for exc in _get_exception_store().list_all(tenant_id=tenant_id):
+        data = _parse_triage_reason(exc.reason)
+        if data is None:
+            continue
+        if data.get("decision") != "not_affected" or not data.get("justification"):
+            continue
+        statements.append(
+            VexStatement(
+                vulnerability_id=exc.vuln_id,
+                status=VexStatus.NOT_AFFECTED,
+                justification=VexJustification(str(data["justification"])),
+                impact_statement=str(data.get("decision_reason") or ""),
+                products=[] if exc.package_name in {"", "*"} else [exc.package_name],
+                timestamp=str(data.get("reviewed_at") or exc.approved_at or exc.created_at),
+                author=str(data.get("assignee") or exc.approved_by or exc.requested_by or "agent-bom"),
+            )
+        )
+    doc = VexDocument(
+        statements=statements,
+        metadata={
+            "id": f"urn:agent-bom:vex:{tenant_id}:{len(statements)}",
+            "author": "agent-bom",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "version": 1,
+        },
+    )
+    payload = export_openvex(doc)
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    signature = sign_compliance_bundle(canonical)
+    return {
+        "schema_version": "findings.triage.vex.v1",
+        "tenant_id": tenant_id,
+        "count": len(statements),
+        "format": "openvex",
+        "vex": payload,
+        "signature": {
+            "algorithm": signature.algorithm,
+            "signature_hex": signature.signature_hex,
+            "key_id": signature.key_id,
+        },
+    }
 
 
 @router.get("/v1/findings/false-positives", tags=["enterprise"])

--- a/tests/test_api_enterprise_tenant.py
+++ b/tests/test_api_enterprise_tenant.py
@@ -8,13 +8,15 @@ from types import SimpleNamespace
 import pytest
 from fastapi import HTTPException
 
-from agent_bom.api.audit_log import AuditEntry, InMemoryAuditLog, get_audit_log, set_audit_log
+from agent_bom.api.audit_log import AuditEntry, InMemoryAuditLog, get_audit_log, set_audit_log, verify_export_payload
 from agent_bom.api.auth import KeyStore, Role, create_api_key, get_key_store, set_key_store
 from agent_bom.api.exception_store import ExceptionStatus, InMemoryExceptionStore, VulnException
 from agent_bom.api.issue_mapping_store import InMemoryIssueMappingStore
 from agent_bom.api.models import (
     CreateKeyRequest,
     FindingFeedbackRequest,
+    FindingTriageDecisionRequest,
+    FindingTriageRequest,
     IssueStatusUpdateRequest,
     JobStatus,
     RotateKeyRequest,
@@ -521,6 +523,122 @@ async def test_finding_feedback_list_is_tenant_scoped(isolated_exception_store):
     assert result["total"] == 1
     assert result["feedback"][0]["id"] == alpha.exception_id
     assert result["feedback"][0]["tenant_id"] == "tenant-alpha"
+
+
+@pytest.mark.asyncio
+async def test_finding_triage_queue_is_tenant_scoped_and_records_decisions(isolated_exception_store, isolated_audit_log):
+    created = await enterprise.create_finding_triage(
+        _request("tenant-alpha", "alice-admin"),
+        FindingTriageRequest(
+            vulnerability_id="CVE-2026-0101",
+            package="pkg:pypi/requests@2.31.0",
+            assignee="secops@example.com",
+            queue_state="assigned",
+            decision="under_investigation",
+            decision_reason="needs runtime confirmation",
+            expires_at="2026-12-31T00:00:00Z",
+        ),
+    )
+    await enterprise.create_finding_triage(
+        _request("tenant-beta", "bob-admin"),
+        FindingTriageRequest(
+            vulnerability_id="CVE-2026-0202",
+            package="pkg:pypi/django@5.0.0",
+            assignee="beta@example.com",
+        ),
+    )
+
+    assert created["queue_state"] == "assigned"
+    assert created["decision"] == "under_investigation"
+    assert created["assignee"] == "secops@example.com"
+    assert created["tenant_id"] == "tenant-alpha"
+
+    decided = await enterprise.update_finding_triage_decision(
+        _request("tenant-alpha", "alice-reviewer"),
+        created["id"],
+        FindingTriageDecisionRequest(
+            decision="not_affected",
+            justification="vulnerable_code_not_in_execute_path",
+            decision_reason="package is present but the vulnerable handler is not reachable",
+        ),
+    )
+    assert decided["queue_state"] == "decided"
+    assert decided["decision"] == "not_affected"
+    assert decided["vex_eligible"] is True
+    assert decided["reviewed_at"]
+
+    alpha = await enterprise.list_finding_triage(_request("tenant-alpha"), decision="not_affected")
+    beta = await enterprise.list_finding_triage(_request("tenant-beta"))
+
+    assert alpha["schema_version"] == "findings.triage.v1"
+    assert alpha["total"] == 1
+    assert alpha["triage"][0]["id"] == created["id"]
+    assert beta["total"] == 1
+    assert beta["triage"][0]["vulnerability_id"] == "CVE-2026-0202"
+
+    actions = [entry.action for entry in isolated_audit_log.list_entries()]
+    assert "findings.triage_created" in actions
+    assert "findings.triage_decision_recorded" in actions
+
+
+@pytest.mark.asyncio
+async def test_finding_triage_requires_justification_for_not_affected(isolated_exception_store):
+    with pytest.raises(HTTPException) as error:
+        await enterprise.create_finding_triage(
+            _request("tenant-alpha"),
+            FindingTriageRequest(
+                vulnerability_id="CVE-2026-0101",
+                package="requests",
+                decision="not_affected",
+            ),
+        )
+
+    assert error.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_finding_triage_exports_signed_openvex_for_eligible_decisions(isolated_exception_store):
+    await enterprise.create_finding_triage(
+        _request("tenant-alpha", "alice-admin"),
+        FindingTriageRequest(
+            vulnerability_id="CVE-2026-0101",
+            package="pkg:pypi/requests@2.31.0",
+            assignee="secops@example.com",
+            decision="not_affected",
+            justification="vulnerable_code_not_in_execute_path",
+            decision_reason="not in the executable path for this tenant",
+        ),
+    )
+    await enterprise.create_finding_triage(
+        _request("tenant-alpha", "alice-admin"),
+        FindingTriageRequest(
+            vulnerability_id="CVE-2026-0102",
+            package="pkg:pypi/flask@3.0.0",
+            decision="affected",
+            decision_reason="reachable endpoint",
+        ),
+    )
+    await enterprise.create_finding_triage(
+        _request("tenant-beta", "bob-admin"),
+        FindingTriageRequest(
+            vulnerability_id="CVE-2026-0202",
+            package="pkg:pypi/django@5.0.0",
+            decision="not_affected",
+            justification="component_not_present",
+        ),
+    )
+
+    exported = await enterprise.export_finding_triage_vex(_request("tenant-alpha"))
+
+    assert exported["schema_version"] == "findings.triage.vex.v1"
+    assert exported["tenant_id"] == "tenant-alpha"
+    assert exported["count"] == 1
+    statement = exported["vex"]["statements"][0]
+    assert statement["vulnerability"]["name"] == "CVE-2026-0101"
+    assert statement["status"] == "not_affected"
+    assert statement["justification"] == "vulnerable_code_not_in_execute_path"
+    canonical = json.dumps(exported["vex"], sort_keys=True, separators=(",", ":")).encode("utf-8")
+    assert verify_export_payload(canonical, exported["signature"]["signature_hex"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Summary
- add tenant-scoped finding triage queue endpoints with assignee, queue state, decision reason, expiry, and review timestamp
- support affected, not_affected, and under_investigation decisions with OpenVEX justification enforcement for not_affected
- emit signed OpenVEX output for eligible not_affected triage decisions and refresh OpenAPI/data-model artifacts

Verification
- uv run ruff check --fix src/agent_bom/api/models.py src/agent_bom/api/routes/enterprise.py tests/test_api_enterprise_tenant.py
- uv run pytest tests/test_api_enterprise_tenant.py::test_finding_triage_queue_is_tenant_scoped_and_records_decisions tests/test_api_enterprise_tenant.py::test_finding_triage_requires_justification_for_not_affected tests/test_api_enterprise_tenant.py::test_finding_triage_exports_signed_openvex_for_eligible_decisions -q
- uv run mypy src/agent_bom/api/models.py src/agent_bom/api/routes/enterprise.py
- uv run --extra api python scripts/export_openapi.py --check
- python scripts/regenerate_data_model_atlas.py
- python scripts/check_release_consistency.py
- uv run pytest tests/test_api_enterprise_tenant.py -q
- git diff --check

Notes
- Contributes to #2621.
- Uses the existing tenant-scoped exception store abstraction; no database schema migration.