### PR TITLE
feat(findings): surface triage queue in UI

### DIFF
--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -3,11 +3,24 @@
 import { Fragment, Suspense, useCallback, useEffect, useState, useMemo, type ReactNode } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { api, Vulnerability, ScanJob, ScanResult, severityColor, severityDot, JobListItem, RemediationItem, type UnifiedGraphResponse } from "@/lib/api";
+import {
+  api,
+  Vulnerability,
+  ScanJob,
+  ScanResult,
+  severityColor,
+  severityDot,
+  JobListItem,
+  RemediationItem,
+  type FindingTriageDecision,
+  type FindingTriageItem,
+  type FindingTriageJustification,
+  type UnifiedGraphResponse,
+} from "@/lib/api";
 import { ApiOfflineState } from "@/components/api-offline-state";
 import { PageEmptyState, PageLoadingState } from "@/components/states/page-state";
 import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
-import { Bug, Download, ExternalLink, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Layers, Loader2, Package, Server, ShieldOff, Radar, FileSearch, ShieldAlert } from "lucide-react";
+import { Bug, Download, ExternalLink, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Layers, Loader2, Package, Server, ShieldOff, Radar, FileSearch, ShieldAlert, ClipboardCheck } from "lucide-react";
 
 function _classifyApiErrorKind(err: unknown): "network" | "auth" | "forbidden" {
   if (err instanceof ApiAuthError) return "auth";
@@ -133,6 +146,10 @@ function mergeRemediationItems(existing: RemediationSummary[], incoming: Remedia
     }
   }
   return Array.from(merged.values());
+}
+
+function triageKey(vulnerabilityId: string, packageName: string) {
+  return `${vulnerabilityId}::${packageName || "*"}`;
 }
 
 type GraphNode = UnifiedGraphResponse["nodes"][number];
@@ -287,6 +304,10 @@ function VulnsPage() {
   const [search, setSearch] = useState(paramCve ?? paramAgent ?? "");
   const [groupBy, setGroupBy] = useState<GroupKey>("none");
   const [suppressed, setSuppressed] = useState<Set<string>>(new Set());
+  const [triageRows, setTriageRows] = useState<FindingTriageItem[]>([]);
+  const [triageError, setTriageError] = useState("");
+  const [triageBusyKey, setTriageBusyKey] = useState<string | null>(null);
+  const [vexExporting, setVexExporting] = useState(false);
   const [expandedId, setExpandedId] = useState<string | null>(paramCve ?? null);
   const [page, setPage] = useState(1);
   const PAGE_SIZE = 50;
@@ -399,6 +420,83 @@ function VulnsPage() {
     }
   }, []);
 
+  const refreshTriage = useCallback(async () => {
+    try {
+      const response = await api.listFindingTriage({ limit: 1000 });
+      setTriageRows(response.triage);
+      setTriageError("");
+    } catch (e: unknown) {
+      if (e instanceof ApiAuthError || e instanceof ApiForbiddenError) {
+        setTriageError("Sign in with an analyst or admin role to record triage decisions.");
+      } else {
+        setTriageError(e instanceof Error ? e.message : "Unable to load finding triage queue.");
+      }
+    }
+  }, []);
+
+  const handleTriageDecision = useCallback(async (
+    vuln: EnrichedVuln,
+    decision: FindingTriageDecision,
+    justification?: FindingTriageJustification,
+  ) => {
+    const packageName = vuln.packages[0] ?? "*";
+    const key = triageKey(vuln.id, packageName);
+    setTriageBusyKey(key);
+    setTriageError("");
+    const decisionReason =
+      decision === "not_affected"
+        ? "Reviewed from the findings UI: vulnerable code is not in the executable path for this deployment."
+        : decision === "affected"
+          ? "Reviewed from the findings UI: finding remains applicable to this deployment."
+          : "Queued from the findings UI for analyst investigation.";
+    try {
+      const existing = triageRows.find((row) => triageKey(row.vulnerability_id, row.package) === key);
+      if (existing && decision !== "under_investigation") {
+        const updated = await api.updateFindingTriageDecision(existing.id, {
+          decision,
+          justification,
+          decision_reason: decisionReason,
+        });
+        setTriageRows((rows) => rows.map((row) => (row.id === updated.id ? updated : row)));
+      } else if (!existing) {
+        const created = await api.createFindingTriage({
+          vulnerability_id: vuln.id,
+          package: packageName,
+          queue_state: decision === "under_investigation" ? "assigned" : "decided",
+          decision,
+          justification,
+          decision_reason: decisionReason,
+        });
+        setTriageRows((rows) => [created, ...rows]);
+      }
+    } catch (e: unknown) {
+      if (e instanceof ApiAuthError || e instanceof ApiForbiddenError) {
+        setTriageError("Sign in with an analyst or admin role to record triage decisions.");
+      } else {
+        setTriageError(e instanceof Error ? e.message : "Unable to record triage decision.");
+      }
+    } finally {
+      setTriageBusyKey(null);
+    }
+  }, [triageRows]);
+
+  const handleExportVex = useCallback(async () => {
+    setVexExporting(true);
+    setTriageError("");
+    try {
+      const exported = await api.exportFindingTriageVex();
+      downloadJson(exported, `finding-triage-openvex-${new Date().toISOString().slice(0, 10)}.json`);
+    } catch (e: unknown) {
+      if (e instanceof ApiAuthError || e instanceof ApiForbiddenError) {
+        setTriageError("Sign in with an analyst or admin role to export signed VEX evidence.");
+      } else {
+        setTriageError(e instanceof Error ? e.message : "Unable to export signed VEX evidence.");
+      }
+    } finally {
+      setVexExporting(false);
+    }
+  }, []);
+
   useEffect(() => {
     async function loadSummaries() {
       try {
@@ -416,6 +514,10 @@ function VulnsPage() {
     }
     void loadSummaries();
   }, []);
+
+  useEffect(() => {
+    void refreshTriage();
+  }, [refreshTriage]);
 
   useEffect(() => {
     async function loadDetails() {
@@ -517,6 +619,14 @@ function VulnsPage() {
 
   const totalPages = Math.max(1, Math.ceil(displayed.length / PAGE_SIZE));
   const paged = displayed.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+  const triageByKey = useMemo(() => {
+    const rows = new Map<string, FindingTriageItem>();
+    for (const row of triageRows) {
+      rows.set(triageKey(row.vulnerability_id, row.package), row);
+    }
+    return rows;
+  }, [triageRows]);
+  const vexEligibleCount = triageRows.filter((row) => row.vex_eligible).length;
 
   // Group displayed vulns
   const grouped = useMemo(() => {
@@ -579,16 +689,33 @@ function VulnsPage() {
           </p>
         </div>
         {vulns.length > 0 && (
-          <button
-            onClick={() => downloadJson(displayed, `findings-${new Date().toISOString().slice(0, 10)}.json`)}
-            className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-300 text-sm font-medium rounded-lg transition-colors"
-            title="Export filtered findings as JSON"
-          >
-            <Download className="w-3.5 h-3.5" />
-            Export
-          </button>
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <button
+              onClick={handleExportVex}
+              disabled={vexExporting || vexEligibleCount === 0}
+              className="flex items-center gap-1.5 rounded-lg border border-emerald-900 bg-emerald-950/40 px-3 py-1.5 text-sm font-medium text-emerald-300 transition-colors hover:bg-emerald-950/70 disabled:cursor-not-allowed disabled:opacity-50"
+              title={vexEligibleCount > 0 ? "Export signed OpenVEX for not_affected triage decisions" : "Record a not_affected triage decision before exporting VEX"}
+            >
+              {vexExporting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ClipboardCheck className="h-3.5 w-3.5" />}
+              Export VEX
+            </button>
+            <button
+              onClick={() => downloadJson(displayed, `findings-${new Date().toISOString().slice(0, 10)}.json`)}
+              className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-300 text-sm font-medium rounded-lg transition-colors"
+              title="Export filtered findings as JSON"
+            >
+              <Download className="w-3.5 h-3.5" />
+              Export JSON
+            </button>
+          </div>
         )}
       </div>
+
+      {triageError && (
+        <div className="rounded-lg border border-amber-900/60 bg-amber-950/20 px-3 py-2 text-sm text-amber-200">
+          {triageError}
+        </div>
+      )}
 
       {loading && (
         <PageLoadingState
@@ -729,6 +856,9 @@ function VulnsPage() {
                       handleSort={handleSort}
                       suppressed={suppressed}
                       onMarkFP={handleMarkFP}
+                      triageByKey={triageByKey}
+                      triageBusyKey={triageBusyKey}
+                      onTriageDecision={handleTriageDecision}
                       expandedId={expandedId}
                       onToggleExpanded={setExpandedId}
                     />
@@ -751,6 +881,9 @@ function VulnsPage() {
               handleSort={handleSort}
               suppressed={suppressed}
               onMarkFP={handleMarkFP}
+              triageByKey={triageByKey}
+              triageBusyKey={triageBusyKey}
+              onTriageDecision={handleTriageDecision}
               expandedId={expandedId}
               onToggleExpanded={setExpandedId}
             />
@@ -801,6 +934,9 @@ function VulnTable({
   handleSort,
   suppressed,
   onMarkFP,
+  triageByKey,
+  triageBusyKey,
+  onTriageDecision,
   expandedId,
   onToggleExpanded,
 }: {
@@ -810,6 +946,13 @@ function VulnTable({
   handleSort: (f: SortKey) => void;
   suppressed: Set<string>;
   onMarkFP: (vulnId: string, packageName: string) => void;
+  triageByKey: Map<string, FindingTriageItem>;
+  triageBusyKey: string | null;
+  onTriageDecision: (
+    vuln: EnrichedVuln,
+    decision: FindingTriageDecision,
+    justification?: FindingTriageJustification,
+  ) => void;
   expandedId: string | null;
   onToggleExpanded: (vulnId: string | null) => void;
 }) {
@@ -839,6 +982,9 @@ function VulnTable({
         <tbody className="divide-y divide-zinc-800 bg-zinc-950">
           {vulns?.map((v) => {
             const isExpanded = expandedId === v.id;
+            const primaryPackage = v.packages[0] ?? "*";
+            const currentTriage = triageByKey.get(triageKey(v.id, primaryPackage));
+            const busy = triageBusyKey === triageKey(v.id, primaryPackage);
             return (
               <Fragment key={v.id}>
                 <tr key={v.id} className={`transition-colors ${isExpanded ? "bg-zinc-900/80" : "hover:bg-zinc-900"}`}>
@@ -934,7 +1080,12 @@ function VulnTable({
                 {isExpanded && (
                   <tr key={`${v.id}-detail`} className="bg-zinc-950">
                     <td colSpan={8} className="px-4 pb-4">
-                      <VulnDetailPanel vuln={v} />
+                      <VulnDetailPanel
+                        vuln={v}
+                        triage={currentTriage}
+                        triageBusy={busy}
+                        onTriageDecision={onTriageDecision}
+                      />
                     </td>
                   </tr>
                 )}
@@ -975,7 +1126,21 @@ function renderPercentValue(value: number | undefined, missingLabel: string) {
   );
 }
 
-function VulnDetailPanel({ vuln }: { vuln: EnrichedVuln }) {
+function VulnDetailPanel({
+  vuln,
+  triage,
+  triageBusy,
+  onTriageDecision,
+}: {
+  vuln: EnrichedVuln;
+  triage: FindingTriageItem | undefined;
+  triageBusy: boolean;
+  onTriageDecision: (
+    vuln: EnrichedVuln,
+    decision: FindingTriageDecision,
+    justification?: FindingTriageJustification,
+  ) => void;
+}) {
   const summary = vuln.attack_vector_summary ?? vuln.summary ?? vuln.description ?? "No advisory summary available.";
   const cweMatches = summary.match(/CWE-\d+/gi) ?? [];
   const published = vuln.published_at ?? vuln.published ?? vuln.nvd_published;
@@ -1103,6 +1268,50 @@ function VulnDetailPanel({ vuln }: { vuln: EnrichedVuln }) {
               )}
             </div>
           </div>
+          <div className="rounded-lg border border-zinc-800 bg-zinc-950/70 p-3">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h4 className="text-xs font-medium uppercase tracking-wide text-zinc-500">Review queue</h4>
+                <p className="mt-2 text-xs leading-5 text-zinc-400">
+                  Record analyst disposition for this package finding. Not affected decisions require an OpenVEX justification and become eligible for signed VEX export.
+                </p>
+              </div>
+              {triage && (
+                <span className="rounded-full border border-zinc-700 bg-zinc-900 px-2 py-0.5 text-[11px] font-medium text-zinc-300">
+                  {triage.queue_state}
+                </span>
+              )}
+            </div>
+            {triage ? (
+              <div className="mt-3 grid gap-2 text-xs text-zinc-400 sm:grid-cols-2">
+                <div><span className="text-zinc-500">Decision:</span> {triage.decision}</div>
+                <div><span className="text-zinc-500">Assignee:</span> {triage.assignee || "unassigned"}</div>
+                {triage.justification && <div className="sm:col-span-2"><span className="text-zinc-500">Justification:</span> {triage.justification}</div>}
+                {triage.decision_reason && <div className="sm:col-span-2"><span className="text-zinc-500">Reason:</span> {triage.decision_reason}</div>}
+              </div>
+            ) : (
+              <p className="mt-3 text-xs text-zinc-500">No triage item recorded for this finding/package pair.</p>
+            )}
+            <div className="mt-4 flex flex-wrap gap-2">
+              <TriageButton
+                label="Investigate"
+                busy={triageBusy}
+                disabled={Boolean(triage)}
+                onClick={() => onTriageDecision(vuln, "under_investigation")}
+              />
+              <TriageButton
+                label="Affected"
+                busy={triageBusy}
+                onClick={() => onTriageDecision(vuln, "affected")}
+              />
+              <TriageButton
+                label="Not affected"
+                busy={triageBusy}
+                tone="green"
+                onClick={() => onTriageDecision(vuln, "not_affected", "vulnerable_code_not_in_execute_path")}
+              />
+            </div>
+          </div>
           <div className="flex flex-wrap gap-2">
             <a
               href={`https://osv.dev/vulnerability/${vuln.id}`}
@@ -1123,6 +1332,36 @@ function VulnDetailPanel({ vuln }: { vuln: EnrichedVuln }) {
         </div>
       </div>
     </div>
+  );
+}
+
+function TriageButton({
+  label,
+  busy,
+  disabled = false,
+  tone = "zinc",
+  onClick,
+}: {
+  label: string;
+  busy: boolean;
+  disabled?: boolean;
+  tone?: "zinc" | "green";
+  onClick: () => void;
+}) {
+  const classes =
+    tone === "green"
+      ? "border-emerald-800 bg-emerald-950/40 text-emerald-300 hover:bg-emerald-950/70"
+      : "border-zinc-700 bg-zinc-900 text-zinc-300 hover:border-zinc-600 hover:text-zinc-100";
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={busy || disabled}
+      className={`inline-flex items-center gap-1 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${classes}`}
+    >
+      {busy && <Loader2 className="h-3 w-3 animate-spin" />}
+      {label}
+    </button>
   );
 }
 

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -421,6 +421,74 @@ export interface RemediationItem {
   risk_narrative: string;
 }
 
+export type FindingTriageQueueState = "open" | "assigned" | "reviewing" | "decided";
+export type FindingTriageDecision = "not_affected" | "affected" | "under_investigation";
+export type FindingTriageJustification =
+  | "component_not_present"
+  | "vulnerable_code_not_present"
+  | "vulnerable_code_not_in_execute_path"
+  | "vulnerable_code_cannot_be_controlled_by_adversary"
+  | "inline_mitigations_already_exist";
+
+export interface FindingTriageRequest {
+  vulnerability_id: string;
+  package?: string | undefined;
+  server_name?: string | undefined;
+  assignee?: string | undefined;
+  queue_state?: FindingTriageQueueState | undefined;
+  decision?: FindingTriageDecision | undefined;
+  justification?: FindingTriageJustification | null | undefined;
+  decision_reason?: string | undefined;
+  expires_at?: string | undefined;
+}
+
+export interface FindingTriageDecisionRequest {
+  decision: FindingTriageDecision;
+  justification?: FindingTriageJustification | null | undefined;
+  decision_reason?: string | undefined;
+  assignee?: string | null | undefined;
+  expires_at?: string | null | undefined;
+}
+
+export interface FindingTriageItem {
+  id: string;
+  vulnerability_id: string;
+  package: string;
+  server_name: string;
+  queue_state: FindingTriageQueueState | string;
+  decision: FindingTriageDecision | string;
+  justification?: FindingTriageJustification | string | null | undefined;
+  decision_reason: string;
+  assignee: string;
+  created_by: string;
+  created_at: string;
+  reviewed_at: string;
+  expires_at: string;
+  tenant_id: string;
+  vex_eligible: boolean;
+}
+
+export interface FindingTriageResponse {
+  schema_version: "findings.triage.v1" | string;
+  triage: FindingTriageItem[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface FindingTriageVexResponse {
+  schema_version: "findings.triage.vex.v1" | string;
+  tenant_id: string;
+  count: number;
+  format: "openvex" | string;
+  vex: Record<string, unknown>;
+  signature: {
+    algorithm: string;
+    signature_hex: string;
+    key_id: string;
+  };
+}
+
 export type AgentStatus = "configured" | "installed-not-configured";
 
 export interface Agent {

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -24,6 +24,10 @@ import type {
   AgentBomManifestResponse,
   PostureCountsResponse,
   RemediationItem,
+  FindingTriageRequest,
+  FindingTriageDecisionRequest,
+  FindingTriageResponse,
+  FindingTriageVexResponse,
   AttackFlowResponse,
   ContextGraphResponse,
   HealthResponse,
@@ -118,6 +122,14 @@ export type {
   DeploymentMode,
   PostureCountsResponse,
   RemediationItem,
+  FindingTriageQueueState,
+  FindingTriageDecision,
+  FindingTriageJustification,
+  FindingTriageRequest,
+  FindingTriageDecisionRequest,
+  FindingTriageItem,
+  FindingTriageResponse,
+  FindingTriageVexResponse,
   AgentStatus,
   Agent,
   MCPServer,
@@ -804,6 +816,22 @@ export const api = {
       total: number;
     }>("/v1/findings/false-positives"),
   removeFalsePositive: (id: string) => del(`/v1/findings/false-positive/${id}`),
+
+  // ── Finding triage and signed VEX ──
+  createFindingTriage: (body: FindingTriageRequest) =>
+    post<FindingTriageResponse["triage"][number]>("/v1/findings/triage", body),
+  listFindingTriage: (filters?: { queueState?: string; decision?: string; limit?: number; offset?: number }) => {
+    const params = new URLSearchParams();
+    if (filters?.queueState) params.set("queue_state", filters.queueState);
+    if (filters?.decision) params.set("decision", filters.decision);
+    if (filters?.limit != null) params.set("limit", String(filters.limit));
+    if (filters?.offset != null) params.set("offset", String(filters.offset));
+    const qs = params.toString();
+    return get<FindingTriageResponse>(`/v1/findings/triage${qs ? `?${qs}` : ""}`);
+  },
+  updateFindingTriageDecision: (triageId: string, body: FindingTriageDecisionRequest) =>
+    put<FindingTriageResponse["triage"][number]>(`/v1/findings/triage/${encodeURIComponent(triageId)}/decision`, body),
+  exportFindingTriageVex: () => get<FindingTriageVexResponse>("/v1/findings/triage/vex"),
 
   // ── Remediation ──
   /** Extract remediation plan from the latest completed scan */

--- a/ui/tests/api.test.ts
+++ b/ui/tests/api.test.ts
@@ -632,6 +632,125 @@ describe('api.markFalsePositive', () => {
   })
 })
 
+describe('api finding triage helpers', () => {
+  it('lists tenant-scoped triage queue entries with filters', async () => {
+    global.fetch = mockFetch({
+      schema_version: 'findings.triage.v1',
+      triage: [
+        {
+          id: 'triage-1',
+          vulnerability_id: 'CVE-2026-0101',
+          package: 'pkg:pypi/requests@2.31.0',
+          server_name: '',
+          queue_state: 'decided',
+          decision: 'not_affected',
+          justification: 'vulnerable_code_not_in_execute_path',
+          decision_reason: 'not reachable',
+          assignee: 'secops@example.com',
+          created_by: 'alice',
+          created_at: '2026-05-29T00:00:00Z',
+          reviewed_at: '2026-05-29T00:01:00Z',
+          expires_at: '',
+          tenant_id: 'tenant-alpha',
+          vex_eligible: true,
+        },
+      ],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    })
+
+    const result = await api.listFindingTriage({ decision: 'not_affected', limit: 100 })
+
+    expect(global.fetch).toHaveBeenCalledOnce()
+    const [url, opts] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+    expect(url).toContain('/v1/findings/triage?')
+    expect(url).toContain('decision=not_affected')
+    expect(url).toContain('limit=100')
+    expect(opts.method).toBeUndefined()
+    expect(result.triage[0]!.vex_eligible).toBe(true)
+  })
+
+  it('creates and updates finding triage decisions', async () => {
+    const created = {
+      id: 'triage-1',
+      vulnerability_id: 'CVE-2026-0101',
+      package: 'requests',
+      server_name: '',
+      queue_state: 'assigned',
+      decision: 'under_investigation',
+      decision_reason: 'needs review',
+      assignee: '',
+      created_by: 'alice',
+      created_at: '2026-05-29T00:00:00Z',
+      reviewed_at: '',
+      expires_at: '',
+      tenant_id: 'tenant-alpha',
+      vex_eligible: false,
+    }
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+        json: () => Promise.resolve(created),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () => Promise.resolve({
+          ...created,
+          queue_state: 'decided',
+          decision: 'affected',
+          reviewed_at: '2026-05-29T00:01:00Z',
+        }),
+      })
+    global.fetch = fetchMock
+
+    const result = await api.createFindingTriage({
+      vulnerability_id: 'CVE-2026-0101',
+      package: 'requests',
+      decision: 'under_investigation',
+    })
+    const updated = await api.updateFindingTriageDecision('triage-1', {
+      decision: 'affected',
+      decision_reason: 'reachable package',
+    })
+
+    expect(result.id).toBe('triage-1')
+    expect(updated.decision).toBe('affected')
+    const [createUrl, createOpts] = fetchMock.mock.calls[0]!
+    expect(createUrl).toContain('/v1/findings/triage')
+    expect(createOpts.method).toBe('POST')
+    expect(JSON.parse(createOpts.body as string).decision).toBe('under_investigation')
+    const [updateUrl, updateOpts] = fetchMock.mock.calls[1]!
+    expect(updateUrl).toContain('/v1/findings/triage/triage-1/decision')
+    expect(updateOpts.method).toBe('PUT')
+    expect(JSON.parse(updateOpts.body as string).decision).toBe('affected')
+  })
+
+  it('exports signed OpenVEX triage evidence', async () => {
+    global.fetch = mockFetch({
+      schema_version: 'findings.triage.vex.v1',
+      tenant_id: 'tenant-alpha',
+      count: 1,
+      format: 'openvex',
+      vex: { statements: [{ status: 'not_affected' }] },
+      signature: { algorithm: 'HMAC-SHA256', signature_hex: 'abc123', key_id: 'audit-hmac' },
+    })
+
+    const result = await api.exportFindingTriageVex()
+
+    expect(global.fetch).toHaveBeenCalledOnce()
+    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+    expect(url).toContain('/v1/findings/triage/vex')
+    expect(result.count).toBe(1)
+    expect(result.signature.signature_hex).toBe('abc123')
+  })
+})
+
 describe('api error handling', () => {
   it('listJobs rejects with network error', async () => {
     global.fetch = vi.fn().mockRejectedValue(new Error('Network error'))


### PR DESCRIPTION
Summary
- add typed dashboard API helpers for finding triage queue creation, decision updates, listing, and signed OpenVEX export
- surface a compact review queue panel inside expanded findings with investigate, affected, and not_affected decisions
- add signed VEX export from the findings page once eligible not_affected decisions exist

Verification
- npm test -- --run tests/api.test.ts
- npm run lint -- app/vulns/page.tsx lib/api.ts lib/api-types.ts tests/api.test.ts
- git diff --check

Notes
- Continues #2621 after the merged API foundation.
- Local npm run verify:toolchain is blocked by Node 25.9.0; this repo declares >=22 <25.
- Local npm run typecheck is also polluted by ignored Finder duplicate files under ui/ (for example ui/components/nav 2.tsx and duplicate .next type files); these are not staged or included in this PR.