### PR TITLE
fix(api): fail closed without auth config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,7 @@ jobs:
         # The error message tells the dev to run the codegen locally.
         run: |
           set -euo pipefail
-          uv run uvicorn agent_bom.api.server:app \
+          AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1 uv run uvicorn agent_bom.api.server:app \
             --host 127.0.0.1 --port 8422 --log-level warning \
             > /tmp/codegen-api.log 2>&1 &
           API_PID=$!

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -1602,6 +1602,23 @@
           "analytics": {
             "$ref": "#/components/schemas/AnalyticsHealth"
           },
+          "auth_configured": {
+            "default": false,
+            "title": "Auth Configured",
+            "type": "boolean"
+          },
+          "auth_required": {
+            "default": true,
+            "title": "Auth Required",
+            "type": "boolean"
+          },
+          "configured_auth_modes": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Configured Auth Modes",
+            "type": "array"
+          },
           "entitlements": {
             "$ref": "#/components/schemas/EntitlementHealth"
           },
@@ -1615,6 +1632,11 @@
           },
           "tracing": {
             "$ref": "#/components/schemas/TracingHealth"
+          },
+          "unauthenticated_allowed": {
+            "default": false,
+            "title": "Unauthenticated Allowed",
+            "type": "boolean"
           },
           "version": {
             "title": "Version",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -1077,6 +1077,19 @@ components:
       properties:
         analytics:
           $ref: '#/components/schemas/AnalyticsHealth'
+        auth_configured:
+          default: false
+          title: Auth Configured
+          type: boolean
+        auth_required:
+          default: true
+          title: Auth Required
+          type: boolean
+        configured_auth_modes:
+          items:
+            type: string
+          title: Configured Auth Modes
+          type: array
         entitlements:
           $ref: '#/components/schemas/EntitlementHealth'
         status:
@@ -1087,6 +1100,10 @@ components:
           $ref: '#/components/schemas/StorageHealth'
         tracing:
           $ref: '#/components/schemas/TracingHealth'
+        unauthenticated_allowed:
+          default: false
+          title: Unauthenticated Allowed
+          type: boolean
         version:
           title: Version
           type: string

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -24,6 +24,7 @@ so they cannot regress silently, but they are not part of this reference.
 ## API Server Limits
 | Env var | Type | Default | Description |
 |---|---|---|---|
+| `AGENT_BOM_ALLOW_UNAUTHENTICATED_API` | `bool` | `False` | — |
 | `AGENT_BOM_API_JOB_TTL` | `int` | `3600` | — |
 | `AGENT_BOM_API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT` | `int` | `API_MAX_CONCURRENT_JOBS` | — |
 | `AGENT_BOM_API_MAX_FLEET_AGENTS_PER_TENANT` | `int` | `1000` | — |

--- a/docs/schemas/v1/HealthResponse.json
+++ b/docs/schemas/v1/HealthResponse.json
@@ -193,6 +193,23 @@
     "analytics": {
       "$ref": "#/$defs/AnalyticsHealth"
     },
+    "auth_configured": {
+      "default": false,
+      "title": "Auth Configured",
+      "type": "boolean"
+    },
+    "auth_required": {
+      "default": true,
+      "title": "Auth Required",
+      "type": "boolean"
+    },
+    "configured_auth_modes": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Configured Auth Modes",
+      "type": "array"
+    },
     "entitlements": {
       "$ref": "#/$defs/EntitlementHealth"
     },
@@ -206,6 +223,11 @@
     },
     "tracing": {
       "$ref": "#/$defs/TracingHealth"
+    },
+    "unauthenticated_allowed": {
+      "default": false,
+      "title": "Unauthenticated Allowed",
+      "type": "boolean"
     },
     "version": {
       "title": "Version",

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -54,9 +54,11 @@ _TENANT_SCOPED_AUTH_METHODS = {
     "static_api_key",
 }
 _AUTH_RUNTIME_STATUS: dict[str, object] = {
-    "auth_required": False,
+    "auth_required": True,
+    "auth_configured": False,
     "configured_modes": [],
-    "recommended_ui_mode": "no_auth",
+    "recommended_ui_mode": "configure_auth",
+    "unauthenticated_allowed": False,
 }
 _API_CSP = "default-src 'self'"
 # /docs (Swagger UI) and /redoc serve HTML shells that load swagger-ui /
@@ -411,6 +413,7 @@ def configure_auth_runtime(
     oidc_enabled: bool,
     trusted_proxy_enabled: bool,
     scim_enabled: bool = False,
+    unauthenticated_allowed: bool = False,
 ) -> None:
     """Track the active auth modes for operator/UI introspection surfaces."""
     configured_modes: list[str] = []
@@ -423,8 +426,13 @@ def configure_auth_runtime(
     if scim_enabled:
         configured_modes.append("scim_provisioning")
 
-    recommended_ui_mode = "no_auth"
-    if trusted_proxy_enabled:
+    auth_configured = bool(configured_modes)
+    auth_required = auth_configured or not unauthenticated_allowed
+
+    recommended_ui_mode = "configure_auth"
+    if unauthenticated_allowed and not auth_configured:
+        recommended_ui_mode = "no_auth"
+    elif trusted_proxy_enabled:
         recommended_ui_mode = "reverse_proxy_oidc"
     elif oidc_enabled:
         recommended_ui_mode = "oidc_bearer"
@@ -434,9 +442,11 @@ def configure_auth_runtime(
     _AUTH_RUNTIME_STATUS.clear()
     _AUTH_RUNTIME_STATUS.update(
         {
-            "auth_required": bool(configured_modes),
+            "auth_required": auth_required,
+            "auth_configured": auth_configured,
             "configured_modes": configured_modes,
             "recommended_ui_mode": recommended_ui_mode,
+            "unauthenticated_allowed": unauthenticated_allowed,
         }
     )
 

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -222,6 +222,10 @@ class EntitlementHealth(BaseModel):
 class HealthResponse(BaseModel):
     status: str = "ok"
     version: str
+    auth_required: bool = True
+    auth_configured: bool = False
+    configured_auth_modes: list[str] = Field(default_factory=list)
+    unauthenticated_allowed: bool = False
     tracing: TracingHealth
     analytics: AnalyticsHealth
     storage: StorageHealth

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -613,6 +613,7 @@ def configure_api(
     cors_allow_all: bool = False,
     api_key: str | None = None,
     rate_limit_rpm: int = DEFAULT_RATE_LIMIT_RPM,
+    allow_unauthenticated: bool | None = None,
 ) -> None:
     """Configure API hardening before server startup.
 
@@ -640,19 +641,28 @@ def configure_api(
     oidc_enabled = oidc_enabled_from_env()
     scim_enabled = scim_enabled_from_env()
     trusted_proxy_enabled = os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH", "").strip().lower() in {"1", "true", "yes", "on"}
-    auth_required = bool(api_key or env_key_store_configured or oidc_enabled or trusted_proxy_enabled or scim_enabled)
+    auth_configured = bool(api_key or env_key_store_configured or oidc_enabled or trusted_proxy_enabled or scim_enabled)
+    if allow_unauthenticated is None:
+        allow_unauthenticated = _env_truthy("AGENT_BOM_ALLOW_UNAUTHENTICATED_API")
+    auth_required = auth_configured or not allow_unauthenticated
     configure_auth_runtime(
         api_key_configured=bool(api_key or env_key_store_configured),
         oidc_enabled=oidc_enabled,
         trusted_proxy_enabled=trusted_proxy_enabled,
         scim_enabled=scim_enabled,
+        unauthenticated_allowed=allow_unauthenticated,
     )
 
-    # Warn if API is exposed without authentication
-    if not auth_required:
+    if not auth_configured and not allow_unauthenticated:
+        _logger.critical(
+            "SECURITY: No control-plane authentication configured; protected API endpoints will fail closed. "
+            "Set AGENT_BOM_API_KEY, AGENT_BOM_API_KEYS, OIDC/SAML/proxy auth, or "
+            "AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1 for local development only."
+        )
+    elif not auth_configured:
         _logger.warning(
-            "SECURITY: No AGENT_BOM_API_KEY set — API endpoints are unauthenticated. "
-            "Set AGENT_BOM_API_KEY environment variable for production deployments."
+            "SECURITY: AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1 enables unauthenticated API access. "
+            "Use only for single-user local development."
         )
 
     # Refresh runtime-configurable middleware. _replace_middleware inserts at
@@ -671,19 +681,6 @@ def configure_api(
 def configure_api_from_env() -> None:
     """Configure API hardening for direct ASGI imports such as raw uvicorn."""
     api_key = os.environ.get("AGENT_BOM_API_KEY") or None
-    has_api_keys = bool(os.environ.get("AGENT_BOM_API_KEYS", "").strip())
-    auth_env_present = any(
-        (
-            api_key,
-            has_api_keys,
-            os.environ.get("AGENT_BOM_OIDC_ISSUER"),
-            _env_truthy("AGENT_BOM_TRUST_PROXY_AUTH"),
-            os.environ.get("AGENT_BOM_SCIM_BEARER_TOKEN"),
-        )
-    )
-    if not auth_env_present:
-        return
-
     origins, allow_all = _parse_cors_origins_from_env(_default_origins)
     configure_api(
         cors_origins=origins,
@@ -893,11 +890,17 @@ async def root():
 @app.get("/health", response_model=HealthResponse, tags=["meta"])
 async def health() -> HealthResponse:
     """Liveness probe."""
+    from agent_bom.api.middleware import get_auth_runtime_status
     from agent_bom.entitlements import load_entitlement_state
 
+    auth_runtime = get_auth_runtime_status()
     return HealthResponse(
         status="ok",
         version=__version__,
+        auth_required=bool(auth_runtime["auth_required"]),
+        auth_configured=bool(auth_runtime.get("auth_configured", False)),
+        configured_auth_modes=list(cast(list[str], auth_runtime["configured_modes"])),
+        unauthenticated_allowed=bool(auth_runtime.get("unauthenticated_allowed", False)),
         tracing=TracingHealth(**get_tracing_health()),
         analytics=_analytics_health(),
         storage=_storage_health(),

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -388,6 +388,7 @@ def serve_cmd(
     configure_api(
         cors_allow_all=cors_allow_all,
         api_key=api_key,
+        allow_unauthenticated=allow_insecure_no_auth,
     )
 
     _ui_dist = Path(__file__).resolve().parents[1] / "ui_dist"
@@ -604,6 +605,7 @@ def api_cmd(
         cors_allow_all=cors_allow_all,
         api_key=api_key,
         rate_limit_rpm=rate_limit_rpm,
+        allow_unauthenticated=allow_insecure_no_auth,
     )
 
     pg_url = _os.environ.get("AGENT_BOM_POSTGRES_URL")

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -253,6 +253,7 @@ API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT = _int("AGENT_BOM_API_MAX_ACTIVE_SCAN_JOBS_P
 API_MAX_RETAINED_JOBS_PER_TENANT = _int("AGENT_BOM_API_MAX_RETAINED_JOBS_PER_TENANT", 500)
 API_MAX_FLEET_AGENTS_PER_TENANT = _int("AGENT_BOM_API_MAX_FLEET_AGENTS_PER_TENANT", 1_000)
 API_MAX_SCHEDULES_PER_TENANT = _int("AGENT_BOM_API_MAX_SCHEDULES_PER_TENANT", 100)
+API_ALLOW_UNAUTHENTICATED = _bool("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", False)
 # Slowloris throughput floor (audit-5 PR-C): minimum sustained body
 # bytes/second once a request body crosses the warmup threshold inside
 # MaxBodySizeMiddleware. 0 disables the floor entirely (escape hatch

--- a/src/agent_bom/rbac.py
+++ b/src/agent_bom/rbac.py
@@ -443,7 +443,12 @@ def require_authenticated_permission(action: str) -> Callable:
             )
         )
         proxy_identity_headers_present = bool(x_role or x_tenant_id or x_proxy_secret)
-        if not auth_runtime["auth_required"] and not env_auth_configured and not proxy_identity_headers_present:
+        if (
+            auth_runtime.get("unauthenticated_allowed")
+            and not auth_runtime["auth_required"]
+            and not env_auth_configured
+            and not proxy_identity_headers_present
+        ):
             request.state.api_key_name = "local-no-auth"
             request.state.api_key_role = Role.ADMIN.value
             request.state.tenant_id = getattr(request.state, "tenant_id", None) or "default"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import os
+
 import pytest
+
+os.environ.setdefault("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", "1")
 
 
 def _reset_resolver_state() -> None:

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -62,6 +62,46 @@ def test_kubernetes_probe_aliases_no_auth():
         assert resp.json()["status"] == status
 
 
+def test_direct_asgi_import_fails_closed_without_auth_config(monkeypatch):
+    """Raw ASGI imports must not expose protected routes without explicit auth or dev opt-out."""
+    for name in (
+        "AGENT_BOM_API_KEY",
+        "AGENT_BOM_API_KEYS",
+        "AGENT_BOM_OIDC_ISSUER",
+        "AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON",
+        "AGENT_BOM_TRUST_PROXY_AUTH",
+        "AGENT_BOM_SCIM_BEARER_TOKEN",
+        "AGENT_BOM_ALLOW_UNAUTHENTICATED_API",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    configure_api_from_env()
+    try:
+        client = TestClient(app)
+        health = client.get("/health")
+        assert health.status_code == 200
+        assert health.json()["auth_required"] is True
+        assert health.json()["auth_configured"] is False
+        assert health.json()["unauthenticated_allowed"] is False
+        assert client.get("/v1/auth/policy").status_code == 401
+    finally:
+        monkeypatch.setenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", "1")
+        configure_api(api_key=None)
+
+
+def test_explicit_unauthenticated_dev_opt_out(monkeypatch):
+    """Local development can still opt into the legacy unauthenticated mode explicitly."""
+    monkeypatch.setenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", "1")
+    configure_api(api_key=None)
+    client = TestClient(app)
+
+    health = client.get("/health")
+    assert health.status_code == 200
+    assert health.json()["auth_required"] is False
+    assert health.json()["auth_configured"] is False
+    assert health.json()["unauthenticated_allowed"] is True
+    assert client.get("/v1/auth/policy").status_code == 200
+
+
 def test_direct_asgi_import_configures_static_api_key_from_env(monkeypatch):
     """Raw uvicorn imports must honor AGENT_BOM_API_KEY without the CLI wrapper."""
     raw_key = "raw-uvicorn-static-key"


### PR DESCRIPTION
Summary
- fail closed for protected API routes when no API key, tenant key store, OIDC, SCIM, or trusted-proxy auth is configured
- keep unauthenticated local development as an explicit opt-out via AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1 / --allow-insecure-no-auth
- expose auth_required/auth_configured/configured_auth_modes/unauthenticated_allowed in /health and refresh OpenAPI/schema/env-var docs

Verification
- uv run --extra api pytest tests/test_api_hardening.py tests/test_api_auth_boundary.py -q
- uv run ruff check src/agent_bom/config.py src/agent_bom/api/server.py src/agent_bom/api/middleware.py src/agent_bom/api/models.py src/agent_bom/cli/_server.py src/agent_bom/rbac.py tests/conftest.py tests/test_api_hardening.py
- uv run mypy src/agent_bom/api/server.py src/agent_bom/api/middleware.py src/agent_bom/api/models.py src/agent_bom/cli/_server.py src/agent_bom/rbac.py
- uv run python scripts/export_openapi.py --check
- python scripts/check_release_consistency.py
- git diff --check

Notes
- Local docs/schema checks are polluted by an untracked local Finder duplicate schema artifact; tracked OpenAPI and release consistency checks pass.