### PR TITLE
test(first-run): isolate GHSA enrichment fixture

### DIFF
--- a/tests/test_first_run_sample.py
+++ b/tests/test_first_run_sample.py
@@ -123,8 +123,12 @@ async def test_generated_first_run_manifests_resolve_vulnerability_findings(
             ],
         }
 
+    async def fake_github_advisories(_packages: list[Package]) -> int:
+        return 0
+
     monkeypatch.setattr("agent_bom.scanners._scan_packages_local_db", lambda _packages: (0, set()))
     monkeypatch.setattr("agent_bom.scanners.query_osv_batch", fake_osv_batch)
+    monkeypatch.setattr("agent_bom.scanners.ghsa_advisory.check_github_advisories", fake_github_advisories)
 
     total = await scan_packages(packages, options=ScanOptions(offline=False))
 


### PR DESCRIPTION
Summary
- mock supplemental GHSA enrichment in the first-run fixture test so live advisory data cannot change the expected count
- keep production GHSA enrichment untouched while stabilizing the main CI regression

Verification
- uv run --extra api pytest tests/test_first_run_sample.py::test_generated_first_run_manifests_resolve_vulnerability_findings -q
- uv run --extra api pytest tests/test_first_run_sample.py -q
- uv run ruff check tests/test_first_run_sample.py
- git diff --check

Notes
- Closes #2834
- Unrelated local Makefile/pre-commit edits and screenshot artifacts were left unstaged.