### PR TITLE
fix(hardening): close week-one audit gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,10 @@ ui/**/* [0-9].ts
 ui/**/* [0-9].tsx
 deploy/helm/agent-bom/**/* [0-9].yaml
 .github/workflows/* [0-9].yml
+# Catch-all for Finder copies anywhere (iCloud Desktop sync spawns these on
+# every edit). The pre-commit guard still fails the commit if one is staged;
+# this just keeps them out of `git add .` in the first place.
+* [0-9].*
+# Local working screenshots dropped at the repo root (graph/console captures);
+# real docs imagery lives under docs/images/.
+/*.png

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,10 @@ repos:
         files: ^(src/agent_bom/.*\.py|src/agent_bom/config\.py|scripts/env_var_allowlist\.txt|docs/operations/ENV_VARS\.md)$
       - id: duplicate-artifact-guard
         name: Finder duplicate artifact guard
-        entry: python3 scripts/check_duplicate_artifacts.py
+        # --working-tree also catches untracked Finder copies (e.g. 'nav 2.tsx')
+        # that break local tsc/pytest collection but are never staged, so the
+        # tracked-only CI guard misses them. Build/cache dirs are ignored.
+        entry: python3 scripts/check_duplicate_artifacts.py --working-tree
         language: system
         pass_filenames: false
-        files: ^(src/|tests/|docs/|site-docs/|ui/|contracts/|deploy/|\.github/workflows/)
+        always_run: true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install test lint docker-build docker-run scan clean build-ui analytics dev
+.PHONY: help install test lint docker-build docker-run scan clean build-ui analytics dev check-dupes clean-dupes
 
 help:  ## Show this help message
 	@echo 'Usage: make [target]'
@@ -62,6 +62,14 @@ docker-compose-down:  ## Stop Docker Compose services
 
 build-ui:  ## Build Next.js dashboard and bundle into package
 	bash scripts/build-ui.sh
+
+check-dupes:  ## Detect Finder-style duplicate files (incl. untracked) in the working tree
+	python3 scripts/check_duplicate_artifacts.py --working-tree
+
+clean-dupes:  ## Delete untracked Finder-style duplicates (e.g. 'foo 2.py'); tracked files are never removed
+	@python3 scripts/check_duplicate_artifacts.py --working-tree 2>&1 | sed -n 's/^- //p' | while IFS= read -r f; do \
+		if [ -n "$$f" ] && [ -z "$$(git ls-files -- "$$f")" ]; then echo "removing $$f"; rm -rf -- "$$f"; fi; \
+	done; echo "✓ untracked duplicates removed (tracked files untouched)"
 
 clean:  ## Clean build artifacts
 	rm -rf build/ dist/ *.egg-info

--- a/deploy/supabase/postgres/alembic/versions/20260530_01_graph_edges_versioning_columns.py
+++ b/deploy/supabase/postgres/alembic/versions/20260530_01_graph_edges_versioning_columns.py
@@ -1,0 +1,45 @@
+"""Add graph_edges versioning + provenance columns to the migration path.
+
+These six columns (schema v3) were only created by the application bootstrap in
+``api/postgres_graph.py`` (``ALTER TABLE ... ADD COLUMN IF NOT EXISTS``). Fresh
+Postgres deployments provisioned purely from ``init.sql`` plus Alembic — or any
+read-only / migration-only path that never runs the app bootstrap — were missing
+them, causing ``column "valid_from" does not exist`` on edge reads/writes.
+
+``init.sql`` now defines them in the baseline; this migration covers databases
+that were created before that change. All statements are idempotent.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260530_01"
+down_revision = "20260513_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS valid_from TEXT DEFAULT ''")
+    op.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS valid_to TEXT DEFAULT NULL")
+    op.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS confidence DOUBLE PRECISION DEFAULT 1.0")
+    op.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS provenance TEXT DEFAULT '{}'")
+    op.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS source_scan_id TEXT DEFAULT ''")
+    op.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS source_run_id TEXT DEFAULT ''")
+    # Backfill: empty valid_from is interpreted as first_seen; source_scan_id
+    # defaults to the owning scan. Mirrors api/postgres_graph.py bootstrap.
+    op.execute("UPDATE graph_edges SET valid_from = first_seen WHERE valid_from = '' OR valid_from IS NULL")
+    op.execute("UPDATE graph_edges SET source_scan_id = scan_id WHERE source_scan_id = '' OR source_scan_id IS NULL")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_valid ON graph_edges(tenant_id, valid_from, valid_to)")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_pg_graph_edges_valid")
+    op.execute("ALTER TABLE graph_edges DROP COLUMN IF EXISTS source_run_id")
+    op.execute("ALTER TABLE graph_edges DROP COLUMN IF EXISTS source_scan_id")
+    op.execute("ALTER TABLE graph_edges DROP COLUMN IF EXISTS provenance")
+    op.execute("ALTER TABLE graph_edges DROP COLUMN IF EXISTS confidence")
+    op.execute("ALTER TABLE graph_edges DROP COLUMN IF EXISTS valid_to")
+    op.execute("ALTER TABLE graph_edges DROP COLUMN IF EXISTS valid_from")

--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -249,12 +249,23 @@ CREATE TABLE IF NOT EXISTS graph_edges (
     activity_id  INTEGER DEFAULT 1,
     scan_id      TEXT NOT NULL,
     tenant_id    TEXT NOT NULL DEFAULT 'default',
+    -- Edge versioning + provenance (schema v3). Must mirror the application
+    -- bootstrap in api/postgres_graph.py and the SQLite db/graph_store.py
+    -- definitions; read-only connections and migration-only deploys never run
+    -- the app's ADD COLUMN bootstrap, so the baseline must include these.
+    valid_from     TEXT DEFAULT '',
+    valid_to       TEXT DEFAULT NULL,
+    confidence     DOUBLE PRECISION DEFAULT 1.0,
+    provenance     TEXT DEFAULT '{}',
+    source_scan_id TEXT DEFAULT '',
+    source_run_id  TEXT DEFAULT '',
     PRIMARY KEY (source_id, target_id, relationship, scan_id, tenant_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan ON graph_edges(tenant_id, scan_id);
 CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_source ON graph_edges(tenant_id, scan_id, source_id);
 CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_target ON graph_edges(tenant_id, scan_id, target_id);
+CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_valid ON graph_edges(tenant_id, valid_from, valid_to);
 CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_source_traversable
     ON graph_edges(tenant_id, scan_id, source_id)
     WHERE traversable = 1;

--- a/src/agent_bom/api/tenant_quota.py
+++ b/src/agent_bom/api/tenant_quota.py
@@ -91,16 +91,38 @@ def _maybe_postgres_advisory_lock(tenant_id: str) -> Iterator[None]:
         pool = _get_pool()
         conn = pool.getconn(timeout=5.0)
     except Exception as exc:  # noqa: BLE001
-        _logger.warning(
-            "tenant_quota_guard could not acquire Postgres advisory lock for tenant=%s: %s. Falling back to per-process serialisation.",
-            tenant_id,
-            exc,
-        )
         if conn is not None and pool is not None:
             try:
                 pool.putconn(conn)
             except Exception:  # noqa: BLE001
                 pass
+        # Under a clustered control plane the per-process lock only serialises
+        # within one replica, so silently falling back would let N replicas each
+        # pass the check and overshoot the quota by N. Fail closed instead: a
+        # rejected request is safer than an unenforced quota. Single-replica /
+        # SQLite paths keep the harmless fallback.
+        from agent_bom.api.middleware import clustered_control_plane_required
+
+        if clustered_control_plane_required():
+            _logger.error(
+                "tenant_quota_guard could not acquire Postgres advisory lock for tenant=%s in clustered mode: %s. "
+                "Refusing the request to avoid cross-replica quota overshoot.",
+                tenant_id,
+                exc,
+            )
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "Tenant quota enforcement is temporarily unavailable: the control plane could not "
+                    "acquire its cross-replica lock. Retry shortly; if this persists, check the Postgres "
+                    "connection pool used for cluster-safe quota serialisation."
+                ),
+            ) from exc
+        _logger.warning(
+            "tenant_quota_guard could not acquire Postgres advisory lock for tenant=%s: %s. Falling back to per-process serialisation.",
+            tenant_id,
+            exc,
+        )
         yield
         return
     try:

--- a/src/agent_bom/iac/__init__.py
+++ b/src/agent_bom/iac/__init__.py
@@ -155,13 +155,18 @@ def scan_iac_with_context(
     ctx = context or ScanContext()
     root_path = Path(root).expanduser().resolve()
 
-    if not root_path.is_dir():
+    # A single explicit file (e.g. `agent-bom iac Dockerfile`) scans just that
+    # file; a directory walks recursively. Only a genuinely missing path is a
+    # hard no-op — silently returning zero findings for an existing file the
+    # operator named is a false-negative in CI gates.
+    explicit_file = root_path.is_file()
+    if not root_path.exists():
         early_verdicts: list[ScannerVerdict] = [
             ScannerVerdict(
                 scanner_id=sid,
                 status="disabled" if (ctx.enabled_scanners is not None and sid not in ctx.enabled_scanners) else "not-applicable",
                 files_scanned=0,
-                reason="scan root does not exist or is not a directory",
+                reason="scan root does not exist",
             )
             for sid in _SCANNER_IDS
         ]
@@ -177,14 +182,19 @@ def scan_iac_with_context(
     files_matched: dict[str, int] = defaultdict(int)
     severity_order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
 
-    for path in sorted(root_path.rglob("*")):
+    walk_root = root_path.parent if explicit_file else root_path
+    walk_paths = [root_path] if explicit_file else sorted(root_path.rglob("*"))
+    for path in walk_paths:
         if not path.is_file():
             continue
-        relative_parts = path.relative_to(root_path).parts
-        if any(part.startswith(".") for part in relative_parts) and not (".github" in relative_parts and "workflows" in relative_parts):
-            continue
-        if "node_modules" in path.parts or "__pycache__" in path.parts:
-            continue
+        # An explicitly named file is always scanned; the dotfile/vendored-dir
+        # filters below only apply when walking a directory tree.
+        if not explicit_file:
+            relative_parts = path.relative_to(walk_root).parts
+            if any(part.startswith(".") for part in relative_parts) and not (".github" in relative_parts and "workflows" in relative_parts):
+                continue
+            if "node_modules" in path.parts or "__pycache__" in path.parts:
+                continue
 
         # Dispatch in priority order: more specific checks first.
         if _is_chart_yaml(path) or _is_values_yaml(path):

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -1177,3 +1177,36 @@ async def test_posture_counts_include_deployment_context_by_tenant():
     assert counts["has_traces"] is True
     assert counts["has_registry"] is True
     assert counts["scan_count"] == 1
+
+
+class TestTenantQuotaAdvisoryLockFailClosed:
+    """Cross-replica advisory-lock failure must fail closed under a clustered
+    control plane (refuse, don't silently degrade to per-process locking which
+    lets N replicas overshoot the quota by N). Single-replica deployments keep
+    the harmless fallback."""
+
+    def test_clustered_lock_failure_raises_503(self, monkeypatch):
+        monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://unreachable/db")
+        monkeypatch.setattr(
+            "agent_bom.api.postgres_common._get_pool",
+            lambda: (_ for _ in ()).throw(RuntimeError("pool down")),
+        )
+        monkeypatch.setattr("agent_bom.api.middleware.clustered_control_plane_required", lambda: True)
+
+        with pytest.raises(HTTPException) as exc_info:
+            with tenant_quota_module._maybe_postgres_advisory_lock("tenant-x"):
+                pass
+        assert exc_info.value.status_code == 503
+
+    def test_single_replica_lock_failure_falls_back(self, monkeypatch):
+        monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://unreachable/db")
+        monkeypatch.setattr(
+            "agent_bom.api.postgres_common._get_pool",
+            lambda: (_ for _ in ()).throw(RuntimeError("pool down")),
+        )
+        monkeypatch.setattr("agent_bom.api.middleware.clustered_control_plane_required", lambda: False)
+
+        entered = False
+        with tenant_quota_module._maybe_postgres_advisory_lock("tenant-x"):
+            entered = True
+        assert entered, "single-replica path must fall back to per-process serialisation, not raise"

--- a/tests/test_iac_dockerfile.py
+++ b/tests/test_iac_dockerfile.py
@@ -250,3 +250,34 @@ class TestDockerSeverities:
         assert by_id.get("DOCKER-008") == "medium"
         assert by_id.get("DOCKER-021") == "high"
         assert by_id.get("DOCKER-022") == "high"
+
+
+class TestSingleFileScanParity:
+    """A single explicit file path must scan that file, not silently no-op.
+
+    Regression: ``scan_iac_with_context`` early-returned ``not-applicable`` for
+    any non-directory root, so ``agent-bom iac Dockerfile`` reported zero
+    findings while the same file inside a directory reported many — a silent
+    false-negative in CI gates.
+    """
+
+    def test_single_file_matches_directory(self, tmp_path: Path):
+        from agent_bom.iac import scan_iac_with_context
+
+        content = "FROM ubuntu\nUSER root\nADD https://x.com/i /tmp/i\nRUN curl https://x.com/i | sh\n"
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text(content)
+
+        file_result = scan_iac_with_context(dockerfile)
+        dir_result = scan_iac_with_context(tmp_path)
+
+        assert file_result.findings, "single-file scan must return findings, not silently no-op"
+        assert {f.rule_id for f in file_result.findings} == {f.rule_id for f in dir_result.findings}
+        assert any(v.status == "ran" for v in file_result.verdicts)
+
+    def test_missing_path_is_clean_no_op(self, tmp_path: Path):
+        from agent_bom.iac import scan_iac_with_context
+
+        result = scan_iac_with_context(tmp_path / "does-not-exist")
+        assert result.findings == []
+        assert all(v.status in {"not-applicable", "disabled"} for v in result.verdicts)

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -141,6 +141,36 @@ def test_graph_tables_have_rls_policies():
         assert f"CREATE POLICY {table}_tenant_isolation ON {table}" in SQL
 
 
+def test_graph_edges_has_versioning_columns():
+    """graph_edges baseline must define the schema-v3 versioning + provenance
+    columns. Regression: these were only created by the app bootstrap in
+    api/postgres_graph.py, so fresh Postgres / read-only / migration-only
+    deployments failed with 'column "valid_from" does not exist'."""
+    cols = _columns_for("graph_edges")
+    for col in (
+        "valid_from",
+        "valid_to",
+        "confidence",
+        "provenance",
+        "source_scan_id",
+        "source_run_id",
+    ):
+        assert col in cols, f"graph_edges baseline missing schema-v3 column: {col}"
+    assert "idx_pg_graph_edges_valid" in _indexes()
+
+
+def test_graph_edges_versioning_migration_exists():
+    """An Alembic migration must add the versioning columns for databases
+    provisioned before they were added to the init.sql baseline."""
+    versions = Path(__file__).parent.parent / "deploy" / "supabase" / "postgres" / "alembic" / "versions"
+    migration = versions / "20260530_01_graph_edges_versioning_columns.py"
+    assert migration.exists(), "missing graph_edges versioning Alembic migration"
+    body = migration.read_text()
+    for col in ("valid_from", "valid_to", "confidence", "provenance", "source_scan_id", "source_run_id"):
+        assert f"ADD COLUMN IF NOT EXISTS {col}" in body, f"migration does not add {col}"
+    assert 'down_revision = "20260513_01"' in body
+
+
 def test_schema_summary_comment_is_current():
     assert "--  Schema (21+ tables):" in SQL
     assert "--   api_rate_limits    — shared API rate-limiter buckets" in SQL

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -254,7 +254,7 @@ function SecurityGraphPageContent() {
             rank: selectedFixFirstCard?.rank,
           })
         : null,
-    [graphNodeById, selectedAttackPath, selectedFixFirstCard?.rank, selectedScanId],
+    [graphNodeById, selectedAttackPath, selectedFixFirstCard, selectedScanId],
   );
 
   const selectedPathActions = useMemo(


### PR DESCRIPTION
Summary
- add a working-tree Finder duplicate guard plus make targets to detect and clean local duplicate artifacts
- scan explicit single-file IaC targets instead of silently no-oping, and add fresh Postgres graph_edges versioning columns to the baseline schema
- fail closed when clustered tenant quota advisory locks cannot be acquired, and refresh the security graph memo dependency for selected exposure cards

Verification
- uv run --extra api pytest tests/test_iac_dockerfile.py tests/test_postgres_schema.py tests/test_api_tenant_isolation.py -q
- cd ui && npm run typecheck
- uv run ruff check src/agent_bom/iac/__init__.py src/agent_bom/api/tenant_quota.py tests/test_iac_dockerfile.py tests/test_postgres_schema.py tests/test_api_tenant_isolation.py
- git diff --check origin/main..HEAD
- make check-dupes

Notes
- Branch rebuilt from current origin/main and excludes the stray local test commit from the prior working branch.
- Existing untracked local artifacts were left untouched.