### PR TITLE
feat(remediation): add guarded apply and draft PR flow

### DIFF
--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -63,7 +63,7 @@
 | `serve` | Start the API server and dashboard |
 | `api` | Start the REST API server |
 | `schedule` | Manage recurring scan schedules |
-| `remediate` | Generate a prioritized remediation plan |
+| `remediate` | Generate a prioritized remediation plan; with explicit `--apply`, patch supported dependency manifests |
 | `teardown` | Tear down the AWS/EKS reference install owned by agent-bom |
 
 ### Database And Utilities
@@ -88,7 +88,8 @@
 - `report history` and `report diff` support `--format json` for CI and automation.
 - `report pipeline-events <scan-job.json>` exports structured scan progress as JSONL for DAG/dashboard consumers.
 - `report query "SELECT ..."` runs read-only SQL against the local scan analytics store.
-- `remediate` supports `--format json` as the machine-readable remediation contract.
+- `remediate` is read-only by default and supports `--format json` as the machine-readable remediation contract.
+- `remediate --apply` patches supported package dependency manifests only after confirmation; `--apply --open-pr` creates a draft PR instead of pushing to the default branch.
 - `agents --agent-mode` emits a stable JSON envelope for assistant and automation callers. It defaults to JSON stdout, reports `ok`, `exit_code`, summary counts, confidence signals, truncation metadata, and the full scan payload under `data`.
 - Use `agent-bom agents -f <format> -o <path>` for SARIF, HTML, SBOM, and richer environment exports.
 - Use `agent-bom agents -f sarif -o -` when you need SARIF on stdout for piping.

--- a/site-docs/reference/remediate-output.md
+++ b/site-docs/reference/remediate-output.md
@@ -23,6 +23,24 @@ Optional grouping:
 agent-bom remediate -p . --format json --server-group --output plan.json
 ```
 
+Guarded apply:
+
+```bash
+agent-bom remediate -p . --apply
+```
+
+Draft PR flow:
+
+```bash
+agent-bom remediate -p . --apply --open-pr
+```
+
+`remediate` remains read-only unless `--apply` is present. The apply path is
+limited to package CVE dependency updates, refuses dirty worktrees, refuses
+writes outside the git repo root, writes an audit JSONL event, and validates
+dependency files before opening a draft PR. SAST, IaC, and credential
+remediation remain advisory/manual in this command.
+
 ## Top-level JSON shape
 
 ```json
@@ -49,6 +67,25 @@ When `--server-group` is set, one additional top-level field is present:
   "server_groups": {
     "jira": ["urllib3", "requests"],
     "github": ["openssl"]
+  }
+}
+```
+
+When `--apply` is set with JSON output, one additional top-level field is
+present:
+
+```json
+{
+  "apply_result": {
+    "dry_run": false,
+    "applied": [],
+    "skipped": [],
+    "backed_up": [],
+    "changed_files": [],
+    "validation_commands": [],
+    "audit_log_path": ".agent-bom/remediation-audit.jsonl",
+    "branch_name": null,
+    "pr_url": null
   }
 }
 ```
@@ -100,6 +137,7 @@ These keys are the supported JSON contract for automation:
 
 - top level: `version`, `generated_at`, `remediation_plan`, `summary`
 - optional top level with `--server-group`: `server_groups`
+- optional top level with `--apply`: `apply_result`
 - item fields:
   - `package`
   - `ecosystem`

--- a/src/agent_bom/cli/_remediate.py
+++ b/src/agent_bom/cli/_remediate.py
@@ -16,6 +16,7 @@ import click
 from agent_bom import __version__
 from agent_bom.cli._common import _make_console, _sync_runtime_consoles, logger
 from agent_bom.cli._scan_runner import ScanConfig, run_default_scan
+from agent_bom.remediation_apply import RemediationApplyError, apply_remediation_plan
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -166,6 +167,30 @@ def _plan_to_json(plan_items: list[dict]) -> dict:
     }
 
 
+def _print_apply_outcome(output_console, outcome) -> None:
+    """Render guarded apply results for console output."""
+    output_console.print()
+    output_console.print("[bold green]Remediation apply result[/bold green]")
+    if outcome.apply_result.applied:
+        for fix in outcome.apply_result.applied:
+            output_console.print(f"  [green]applied[/green] {fix.package} {fix.current_version} -> {fix.fixed_version}")
+    if outcome.apply_result.skipped:
+        for fix in outcome.apply_result.skipped:
+            output_console.print(f"  [yellow]skipped[/yellow] {fix.package} ({fix.ecosystem})")
+    if outcome.changed_files:
+        output_console.print("  changed files: " + ", ".join(outcome.changed_files))
+    if outcome.validation_commands:
+        commands = [" ".join(cmd) for cmd in outcome.validation_commands]
+        output_console.print("  validation: " + "; ".join(commands))
+    if outcome.branch_name:
+        output_console.print(f"  branch: {outcome.branch_name}")
+    if outcome.pr_url:
+        output_console.print(f"  draft PR: {outcome.pr_url}")
+    if outcome.audit_log_path:
+        output_console.print(f"  audit: {outcome.audit_log_path}")
+    output_console.print()
+
+
 # ---------------------------------------------------------------------------
 # Click command
 # ---------------------------------------------------------------------------
@@ -194,6 +219,14 @@ def _plan_to_json(plan_items: list[dict]) -> dict:
 )
 @click.option("--fixable-only", is_flag=True, default=False, help="Hide items without a fix version.")
 @click.option("--quiet", "-q", is_flag=True, default=False, help="Suppress scan chatter and file-write status messages.")
+@click.option("--apply", "apply_changes", is_flag=True, default=False, help="Apply fixable package dependency remediations.")
+@click.option("--open-pr", is_flag=True, default=False, help="Create a draft GitHub PR after applying fixes.")
+@click.option("-y", "--yes", is_flag=True, default=False, help="Confirm remediation writes without prompting.")
+@click.option("--no-backup", is_flag=True, default=False, help="Do not create .agent-bom-backup files for local applies.")
+@click.option("--skip-verify", is_flag=True, default=False, help="Skip dependency file validation after applying fixes.")
+@click.option("--branch-name", default=None, help="Branch name to use with --open-pr.")
+@click.option("--pr-title", default=None, help="Draft PR title to use with --open-pr.")
+@click.option("--audit-log", default=None, type=click.Path(), help="Write remediation apply audit JSONL to this path.")
 def remediate_cmd(
     demo: bool,
     offline: bool,
@@ -204,6 +237,14 @@ def remediate_cmd(
     min_priority: Optional[str],
     fixable_only: bool,
     quiet: bool,
+    apply_changes: bool,
+    open_pr: bool,
+    yes: bool,
+    no_backup: bool,
+    skip_verify: bool,
+    branch_name: Optional[str],
+    pr_title: Optional[str],
+    audit_log: Optional[str],
 ) -> None:
     """Generate a prioritized remediation plan for discovered vulnerabilities.
 
@@ -217,6 +258,8 @@ def remediate_cmd(
       agent-bom remediate -p . -f json -o plan.json   JSON plan for current project
       agent-bom remediate --fixable-only --priority P2 show P1+P2 fixable items only
       agent-bom remediate --server-group               group by MCP server
+      agent-bom remediate -p . --apply                 apply package fixes after review
+      agent-bom remediate -p . --apply --open-pr       apply fixes and open a draft PR
     """
     import agent_bom.output as output_mod
 
@@ -224,6 +267,9 @@ def remediate_cmd(
     output_console = _make_console()
     _sync_runtime_consoles(runtime_console)
     output_mod.console = output_console
+
+    if open_pr and not apply_changes:
+        raise click.ClickException("--open-pr requires --apply")
 
     # Run the scan pipeline
     try:
@@ -277,6 +323,32 @@ def remediate_cmd(
         output_console.print("\n[dim]No remediation items match the current filters.[/dim]\n")
         return
 
+    apply_outcome = None
+    if apply_changes:
+        fixable_count = sum(1 for item in plan if item.get("fix"))
+        if fixable_count == 0:
+            output_console.print("\n[dim]No fixable package remediation items to apply.[/dim]\n")
+            return
+        if not yes and not click.confirm(
+            f"Apply {fixable_count} package remediation update(s) to dependency files?",
+            default=False,
+        ):
+            output_console.print("[yellow]Remediation apply cancelled.[/yellow]")
+            return
+        try:
+            apply_outcome = apply_remediation_plan(
+                plan,
+                project_dir=project or ".",
+                open_pr=open_pr,
+                backup=not no_backup,
+                verify=not skip_verify,
+                branch_name=branch_name,
+                pr_title=pr_title,
+                audit_log_path=audit_log,
+            )
+        except RemediationApplyError as exc:
+            raise click.ClickException(str(exc)) from exc
+
     # Render output
     if output_format == "console":
         if server_group:
@@ -309,6 +381,8 @@ def remediate_cmd(
             json_out["server_groups"] = {srv: [item["package"] for item in items] for srv, items in groups.items()}
         else:
             json_out = _plan_to_json(plan)
+        if apply_outcome is not None:
+            json_out["apply_result"] = apply_outcome.to_json()
         _out_str = json.dumps(json_out, indent=2)
         if output_path:
             Path(output_path).write_text(_out_str)
@@ -325,3 +399,6 @@ def remediate_cmd(
                 output_console.print(f"[green]Remediation report written[/green] -> {output_path}")
         else:
             click.echo(md)
+
+    if output_format == "console" and apply_outcome is not None:
+        _print_apply_outcome(output_console, apply_outcome)

--- a/src/agent_bom/remediation_apply.py
+++ b/src/agent_bom/remediation_apply.py
@@ -21,6 +21,7 @@ class RemediationApplyError(RuntimeError):
 
 
 CommandRunner = Callable[[Sequence[str], Path], subprocess.CompletedProcess[str]]
+_DEFAULT_COMMAND_TIMEOUT_SECONDS = 300
 
 
 @dataclass
@@ -50,14 +51,24 @@ class RemediationApplyOutcome:
 
 def default_command_runner(args: Sequence[str], cwd: Path) -> subprocess.CompletedProcess[str]:
     """Run a command with captured output for deterministic error handling."""
-    return subprocess.run(
-        list(args),
-        cwd=str(cwd),
-        check=False,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+    command = list(args)
+    try:
+        return subprocess.run(
+            command,
+            cwd=str(cwd),
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=_DEFAULT_COMMAND_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout.decode() if isinstance(exc.stdout, bytes) else (exc.stdout or "")
+        stderr = exc.stderr.decode() if isinstance(exc.stderr, bytes) else (exc.stderr or "")
+        if stderr:
+            stderr = f"{stderr.rstrip()}\n"
+        stderr = f"{stderr}command timed out after {_DEFAULT_COMMAND_TIMEOUT_SECONDS}s"
+        return subprocess.CompletedProcess(command, 124, stdout=stdout, stderr=stderr)
 
 
 def apply_remediation_plan(

--- a/src/agent_bom/remediation_apply.py
+++ b/src/agent_bom/remediation_apply.py
@@ -1,0 +1,317 @@
+"""Guarded dependency remediation apply and PR workflow."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Sequence
+
+from packaging.requirements import InvalidRequirement, Requirement
+
+from agent_bom.remediate import ApplyResult, RemediationPlan, apply_fixes, generate_package_fixes
+
+
+class RemediationApplyError(RuntimeError):
+    """Raised when guarded remediation refuses or fails before PR creation."""
+
+
+CommandRunner = Callable[[Sequence[str], Path], subprocess.CompletedProcess[str]]
+
+
+@dataclass
+class RemediationApplyOutcome:
+    """Summary of a guarded remediation apply attempt."""
+
+    apply_result: ApplyResult
+    changed_files: list[str] = field(default_factory=list)
+    validation_commands: list[list[str]] = field(default_factory=list)
+    audit_log_path: str | None = None
+    branch_name: str | None = None
+    pr_url: str | None = None
+
+    def to_json(self) -> dict:
+        return {
+            "dry_run": self.apply_result.dry_run,
+            "applied": [_fix_to_json(fix) for fix in self.apply_result.applied],
+            "skipped": [_fix_to_json(fix) for fix in self.apply_result.skipped],
+            "backed_up": self.apply_result.backed_up,
+            "changed_files": self.changed_files,
+            "validation_commands": self.validation_commands,
+            "audit_log_path": self.audit_log_path,
+            "branch_name": self.branch_name,
+            "pr_url": self.pr_url,
+        }
+
+
+def default_command_runner(args: Sequence[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run a command with captured output for deterministic error handling."""
+    return subprocess.run(
+        list(args),
+        cwd=str(cwd),
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def apply_remediation_plan(
+    plan_items: list[dict],
+    *,
+    project_dir: str | Path,
+    open_pr: bool = False,
+    backup: bool = True,
+    verify: bool = True,
+    branch_name: str | None = None,
+    pr_title: str | None = None,
+    audit_log_path: str | Path | None = None,
+    runner: CommandRunner = default_command_runner,
+) -> RemediationApplyOutcome:
+    """Apply fixable package remediation items under a guarded workflow.
+
+    The function refuses dirty worktrees, refuses writes outside the git repo
+    root, and only opens a draft PR after dependency file validation succeeds.
+    """
+    project = Path(project_dir).resolve()
+    repo_root = _git_root(project, runner)
+    _ensure_inside_repo(project, repo_root)
+
+    audit_path = _resolve_audit_path(audit_log_path, repo_root)
+    fixable, _unfixable = generate_package_fixes(plan_items)
+    fixable = [fix for fix in fixable if fix.fixed_version]
+    branch = branch_name or _default_branch_name(fixable)
+
+    base_event = {
+        "action": "remediation.apply",
+        "project_dir": str(project),
+        "repo_root": str(repo_root),
+        "open_pr": open_pr,
+        "backup": backup,
+        "verify": verify,
+        "package_count": len(fixable),
+        "packages": [_fix_to_json(fix) for fix in fixable],
+    }
+
+    if not fixable:
+        result = ApplyResult(dry_run=False)
+        _write_audit_event(audit_path, {**base_event, "status": "no_fixable_packages"})
+        return RemediationApplyOutcome(result, audit_log_path=str(audit_path))
+
+    _refuse_dirty_worktree(repo_root, runner, audit_path, base_event)
+
+    if open_pr:
+        _require_gh_auth(repo_root, runner, audit_path, base_event)
+        _run_checked(["git", "checkout", "-b", branch], repo_root, runner)
+
+    result = apply_fixes(RemediationPlan(package_fixes=fixable), [project], dry_run=False, backup=(backup and not open_pr))
+    changed_files = _git_changed_files(repo_root, runner)
+
+    validation_commands: list[list[str]] = []
+    if verify and result.applied:
+        validation_commands = _validate_dependency_files(project, repo_root, changed_files, runner)
+        changed_files = _git_changed_files(repo_root, runner)
+
+    pr_url: str | None = None
+    if open_pr and result.applied:
+        if not changed_files:
+            _write_audit_event(audit_path, {**base_event, "status": "refused", "reason": "no_dependency_file_changes"})
+            raise RemediationApplyError("remediation produced applied fixes but no git-tracked dependency file changes")
+        _run_checked(["git", "add", *changed_files], repo_root, runner)
+        _run_checked(["git", "commit", "-m", _commit_subject(fixable)], repo_root, runner)
+        _run_checked(["git", "push", "-u", "origin", branch], repo_root, runner)
+        pr_url = _create_draft_pr(repo_root, runner, pr_title or _commit_subject(fixable), _pr_body(plan_items, changed_files), branch)
+
+    outcome = RemediationApplyOutcome(
+        apply_result=result,
+        changed_files=changed_files,
+        validation_commands=validation_commands,
+        audit_log_path=str(audit_path),
+        branch_name=branch if open_pr else None,
+        pr_url=pr_url,
+    )
+    _write_audit_event(audit_path, {**base_event, "status": "success", "outcome": outcome.to_json()})
+    return outcome
+
+
+def _run_checked(args: Sequence[str], cwd: Path, runner: CommandRunner) -> subprocess.CompletedProcess[str]:
+    completed = runner(args, cwd)
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "").strip()
+        raise RemediationApplyError(f"command failed: {' '.join(args)}{': ' + detail if detail else ''}")
+    return completed
+
+
+def _git_root(project: Path, runner: CommandRunner) -> Path:
+    completed = runner(["git", "-C", str(project), "rev-parse", "--show-toplevel"], project)
+    if completed.returncode != 0:
+        raise RemediationApplyError("remediation apply requires a git worktree")
+    return Path(completed.stdout.strip()).resolve()
+
+
+def _ensure_inside_repo(project: Path, repo_root: Path) -> None:
+    if project != repo_root and repo_root not in project.parents:
+        raise RemediationApplyError(f"refusing to write outside repo root: {project}")
+
+
+def _git_changed_files(repo_root: Path, runner: CommandRunner) -> list[str]:
+    completed = _run_checked(["git", "diff", "--name-only"], repo_root, runner)
+    return [line.strip() for line in completed.stdout.splitlines() if line.strip() and not line.endswith(".agent-bom-backup")]
+
+
+def _refuse_dirty_worktree(repo_root: Path, runner: CommandRunner, audit_path: Path, base_event: dict) -> None:
+    completed = _run_checked(["git", "status", "--porcelain"], repo_root, runner)
+    if completed.stdout.strip():
+        _write_audit_event(audit_path, {**base_event, "status": "refused", "reason": "dirty_worktree"})
+        raise RemediationApplyError("refusing remediation apply on a dirty worktree")
+
+
+def _require_gh_auth(repo_root: Path, runner: CommandRunner, audit_path: Path, base_event: dict) -> None:
+    completed = runner(["gh", "auth", "status"], repo_root)
+    if completed.returncode != 0:
+        _write_audit_event(audit_path, {**base_event, "status": "refused", "reason": "github_auth_required"})
+        raise RemediationApplyError("--open-pr requires GitHub CLI authentication")
+
+
+def _validate_dependency_files(project: Path, repo_root: Path, changed_files: list[str], runner: CommandRunner) -> list[list[str]]:
+    commands: list[list[str]] = []
+    changed = set(changed_files)
+
+    package_json_rel = _rel(project / "package.json", repo_root)
+    package_lock_rel = _rel(project / "package-lock.json", repo_root)
+    if package_json_rel in changed:
+        json.loads((project / "package.json").read_text())
+        if (project / "package-lock.json").exists() or package_lock_rel in changed:
+            cmd = ["npm", "install", "--package-lock-only", "--ignore-scripts"]
+            _run_checked(cmd, project, runner)
+            commands.append(cmd)
+
+    requirements_rel = _rel(project / "requirements.txt", repo_root)
+    if requirements_rel in changed:
+        _validate_requirements(project / "requirements.txt")
+
+    return commands
+
+
+def _validate_requirements(path: Path) -> None:
+    for lineno, line in enumerate(path.read_text().splitlines(), 1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or stripped.startswith("-"):
+            continue
+        try:
+            Requirement(stripped)
+        except InvalidRequirement as exc:
+            raise RemediationApplyError(f"{path.name}:{lineno} is not a valid requirement: {exc}") from exc
+
+
+def _rel(path: Path, root: Path) -> str:
+    return str(path.resolve().relative_to(root.resolve()))
+
+
+def _default_branch_name(fixes) -> str:
+    seed = "remediation"
+    if fixes:
+        first = fixes[0]
+        seed = first.vulns[0] if first.vulns else first.package
+    slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", seed.lower()).strip("-") or "remediation"
+    return f"fix/{slug[:64]}"
+
+
+def _commit_subject(fixes) -> str:
+    if len(fixes) == 1:
+        return f"fix(deps): remediate {fixes[0].package} vulnerability"
+    return f"fix(deps): remediate {len(fixes)} vulnerable packages"
+
+
+def _create_draft_pr(repo_root: Path, runner: CommandRunner, title: str, body: str, branch: str) -> str:
+    completed = _run_checked(
+        ["gh", "pr", "create", "--draft", "--base", "main", "--head", branch, "--title", title, "--body", body],
+        repo_root,
+        runner,
+    )
+    return completed.stdout.strip().splitlines()[-1] if completed.stdout.strip() else ""
+
+
+def _pr_body(plan_items: list[dict], changed_files: list[str]) -> str:
+    lines = [
+        "## Summary",
+        "",
+        "- Applies guarded package remediation generated by `agent-bom remediate --apply --open-pr`.",
+        "- Updates dependency manifests only; SAST/IaC auto-fixes are out of scope.",
+        "",
+        "## Evidence",
+        "",
+    ]
+    for item in plan_items:
+        if not item.get("fix"):
+            continue
+        vulns = ", ".join(item.get("vulns", [])[:8]) or "unknown"
+        agents = ", ".join(item.get("agents", [])[:8]) or "none recorded"
+        refs = ", ".join(item.get("references", [])[:5]) or "none recorded"
+        epss = item.get("epss") or item.get("epss_score") or "not available"
+        lines.extend(
+            [
+                f"- `{item['package']}` `{item.get('current')}` -> `{item.get('fix')}`",
+                f"  - CVE/GHSA/OSV: {vulns}",
+                f"  - Severity: {item.get('max_severity', 'unknown')}",
+                f"  - EPSS: {epss}",
+                f"  - KEV: {bool(item.get('has_kev'))}",
+                f"  - Blast radius score: {item.get('blast_radius_score', 'unknown')}",
+                f"  - Downstream agents: {agents}",
+                f"  - Advisory references: {refs}",
+            ]
+        )
+    lines.extend(
+        [
+            "",
+            "## Changed Files",
+            "",
+            *[f"- `{path}`" for path in changed_files],
+            "",
+            "## Verification",
+            "",
+            "- Dependency file validation completed before PR creation.",
+            "",
+            "## Safety",
+            "",
+            "- Dry-run remains the default.",
+            "- Apply requires explicit `--apply`.",
+            "- PR creation requires GitHub authentication and opens a draft PR.",
+            "- The workflow refuses dirty worktrees and writes outside the repo root.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _resolve_audit_path(path: str | Path | None, repo_root: Path) -> Path:
+    audit_path = Path(path) if path else repo_root / ".agent-bom" / "remediation-audit.jsonl"
+    if not audit_path.is_absolute():
+        audit_path = repo_root / audit_path
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    return audit_path
+
+
+def _write_audit_event(path: Path, event: dict) -> None:
+    event = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "actor": os.environ.get("USER") or os.environ.get("USERNAME") or "unknown",
+        **event,
+    }
+    previous = path.read_text() if path.exists() else ""
+    path.write_text(previous + json.dumps(event, sort_keys=True) + "\n")
+
+
+def _fix_to_json(fix) -> dict:
+    return {
+        "package": fix.package,
+        "ecosystem": fix.ecosystem,
+        "current_version": fix.current_version,
+        "fixed_version": fix.fixed_version,
+        "vulnerabilities": fix.vulns,
+        "affected_agents": fix.agents,
+        "references": fix.references,
+    }

--- a/tests/test_cli_remediate.py
+++ b/tests/test_cli_remediate.py
@@ -280,3 +280,44 @@ def test_remediate_quiet_suppresses_scan_chatter():
     assert result.exit_code == 0, result.output
     assert "scan chatter" not in result.output
     assert "flask" in result.output
+
+
+def test_remediate_open_pr_requires_apply():
+    runner = CliRunner()
+    with _patch_scan():
+        result = runner.invoke(remediate_cmd, ["--demo", "--offline", "--open-pr"])
+
+    assert result.exit_code != 0
+    assert "--open-pr requires --apply" in result.output
+
+
+def test_remediate_apply_invokes_guarded_apply(tmp_path):
+    runner = CliRunner()
+    audit_log = tmp_path / "remediate-audit.jsonl"
+
+    mock_apply_result = MagicMock()
+    mock_apply_result.applied = []
+    mock_apply_result.skipped = []
+    mock_apply_result.backed_up = []
+    mock_apply_result.dry_run = False
+
+    mock_outcome = MagicMock()
+    mock_outcome.apply_result = mock_apply_result
+    mock_outcome.changed_files = ["package.json"]
+    mock_outcome.validation_commands = []
+    mock_outcome.branch_name = None
+    mock_outcome.pr_url = None
+    mock_outcome.audit_log_path = str(audit_log)
+
+    with _patch_scan(), patch("agent_bom.cli._remediate.apply_remediation_plan", return_value=mock_outcome) as apply_mock:
+        result = runner.invoke(
+            remediate_cmd,
+            ["--demo", "--offline", "--apply", "--yes", "--audit-log", str(audit_log)],
+        )
+
+    assert result.exit_code == 0, result.output
+    apply_mock.assert_called_once()
+    kwargs = apply_mock.call_args.kwargs
+    assert kwargs["open_pr"] is False
+    assert kwargs["audit_log_path"] == str(audit_log)
+    assert "Remediation apply result" in result.output

--- a/tests/test_remediation_apply.py
+++ b/tests/test_remediation_apply.py
@@ -1,0 +1,70 @@
+"""Tests for guarded remediation apply workflow."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agent_bom.remediation_apply import RemediationApplyError, apply_remediation_plan
+
+
+def _run(args: list[str], cwd: Path) -> None:
+    subprocess.run(args, cwd=cwd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+
+def _init_repo(path: Path) -> None:
+    _run(["git", "init"], path)
+    _run(["git", "config", "user.email", "test@example.com"], path)
+    _run(["git", "config", "user.name", "agent-bom test"], path)
+
+
+def _npm_plan_item() -> dict:
+    return {
+        "package": "express",
+        "ecosystem": "npm",
+        "current": "4.17.1",
+        "fix": "4.21.0",
+        "priority": "P1",
+        "vulns": ["GHSA-test-0001"],
+        "agents": ["claude-desktop"],
+        "references": ["https://github.com/advisories/GHSA-test-0001"],
+        "blast_radius_score": 8.5,
+        "has_kev": False,
+    }
+
+
+def test_apply_remediation_plan_updates_clean_repo_and_writes_audit(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    package_json = tmp_path / "package.json"
+    package_json.write_text(json.dumps({"dependencies": {"express": "^4.17.1"}}, indent=2) + "\n")
+    _run(["git", "add", "package.json"], tmp_path)
+    _run(["git", "commit", "-m", "fixture"], tmp_path)
+
+    audit_log = tmp_path / "audit.jsonl"
+    outcome = apply_remediation_plan([_npm_plan_item()], project_dir=tmp_path, backup=False, audit_log_path=audit_log)
+
+    assert outcome.apply_result.applied[0].package == "express"
+    assert outcome.changed_files == ["package.json"]
+    assert json.loads(package_json.read_text())["dependencies"]["express"] == "^4.21.0"
+    audit = [json.loads(line) for line in audit_log.read_text().splitlines()]
+    assert audit[-1]["status"] == "success"
+    assert audit[-1]["packages"][0]["package"] == "express"
+
+
+def test_apply_remediation_plan_refuses_dirty_worktree_and_audits(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "package.json").write_text(json.dumps({"dependencies": {"express": "^4.17.1"}}))
+    _run(["git", "add", "package.json"], tmp_path)
+    _run(["git", "commit", "-m", "fixture"], tmp_path)
+    (tmp_path / "untracked.txt").write_text("dirty")
+
+    audit_log = tmp_path / "audit.jsonl"
+    with pytest.raises(RemediationApplyError, match="dirty worktree"):
+        apply_remediation_plan([_npm_plan_item()], project_dir=tmp_path, audit_log_path=audit_log)
+
+    audit = [json.loads(line) for line in audit_log.read_text().splitlines()]
+    assert audit[-1]["status"] == "refused"
+    assert audit[-1]["reason"] == "dirty_worktree"


### PR DESCRIPTION
## Summary

- Adds guarded `agent-bom remediate --apply` for package CVE dependency updates, using the existing remediation plan and apply engine.
- Adds `--apply --open-pr` draft-PR workflow with GitHub auth check, branch isolation, dirty-worktree refusal, repo-root path guard, dependency validation, and audit JSONL events.
- Documents the write-capable remediation contract and adds regression coverage for apply safety and CLI gating.

## Verification

- `uv run pytest -q tests/test_remediation_apply.py tests/test_cli_remediate.py tests/test_apply_remediation.py tests/test_cli_policy.py` -> `39 passed`
- `uv run ruff check src/agent_bom/remediation_apply.py src/agent_bom/cli/_remediate.py tests/test_remediation_apply.py tests/test_cli_remediate.py`
- `uv run ruff format --check src/agent_bom/remediation_apply.py src/agent_bom/cli/_remediate.py tests/test_remediation_apply.py tests/test_cli_remediate.py`
- `uv run mypy src/agent_bom/remediation_apply.py src/agent_bom/cli/_remediate.py`
- `uv run python scripts/check_cli_reference_alignment.py`
- `git diff --check`
- `PYTHONPATH=src uv run agent-bom remediate --help`
- `PYTHONPATH=src uv run agent-bom remediate --open-pr` -> refuses without `--apply`

## Notes

- Closes #805 for the first guarded package-remediation slice; SAST/IaC/credential auto-fixes remain advisory/manual.
- No release tag, PyPI publish, or Docker publish is included.
