### PR TITLE
fix(ui): contain visuals and harden UI image

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ to environments where enforcement is worth the operational cost.
 </p>
 
 ```text
-package -> vulnerability finding -> MCP server -> tools + credential refs -> agent
+package
+  -> vulnerability finding
+  -> MCP server
+  -> tools + credential refs
+  -> agent
 ```
 
 Blast radius is the core idea. A vulnerable package is not just a CVE row; it

--- a/docs/images/blast-radius-dark.svg
+++ b/docs/images/blast-radius-dark.svg
@@ -42,16 +42,16 @@
   <!-- CVE → Server B (db-tools) — smooth S-curve from center -->
   <path d="M316 218 C340 218, 352 300, 372 300" stroke="#ef4444" stroke-width="1.5" opacity="0.35" fill="none" marker-end="url(#arrow-red)"/>
 
-  <!-- Server A → Agent 1 (Cursor) — smooth S-curve -->
+  <!-- Server A → Agent 1 — smooth S-curve -->
   <path d="M512 142 C530 142, 542 106, 560 106" stroke="#a78bfa" stroke-width="1.5" opacity="0.3" fill="none" marker-end="url(#arrow-muted)"/>
 
-  <!-- Server A → Agent 2 (Claude Desktop) — shared path highlight -->
+  <!-- Server A → Agent 2 — shared path highlight -->
   <path d="M512 142 C530 142, 542 224, 560 224" stroke="#a78bfa" stroke-width="2" opacity="0.5" fill="none" marker-end="url(#arrow-muted)"/>
 
-  <!-- Server B → Agent 2 (Claude Desktop) — shared path highlight -->
+  <!-- Server B → Agent 2 — shared path highlight -->
   <path d="M512 300 C530 300, 542 224, 560 224" stroke="#a78bfa" stroke-width="2" opacity="0.5" fill="none" marker-end="url(#arrow-muted)"/>
 
-  <!-- Server B → Agent 3 (Windsurf) — smooth S-curve -->
+  <!-- Server B → Agent 3 — smooth S-curve -->
   <path d="M512 300 C530 300, 542 348, 560 348" stroke="#a78bfa" stroke-width="1.5" opacity="0.3" fill="none" marker-end="url(#arrow-muted)"/>
 
   <!-- Agent 1 → Credentials -->
@@ -111,21 +111,21 @@
   <text x="392" y="318" class="node-detail">verified · 5 tools</text>
 
   <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- NODE: Agent 1 (Cursor)                                                  -->
+  <!-- NODE: Agent 1                                                           -->
   <!-- ═══════════════════════════════════════════════════════════════════════ -->
   <rect x="560" y="78" width="130" height="56" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
   <rect x="560" y="78" width="4" height="56" rx="2" fill="#3b82f6"/>
   <text x="580" y="96" class="node-type" fill="#3b82f6">AI AGENT</text>
-  <text x="580" y="112" class="node-label">Cursor IDE</text>
+  <text x="580" y="112" class="node-label">code-agent</text>
   <text x="580" y="126" class="node-detail">4 servers · 12 tools</text>
 
   <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- NODE: Agent 2 (Claude Desktop) — affected by BOTH servers               -->
+  <!-- NODE: Agent 2 — affected by BOTH servers                                -->
   <!-- ═══════════════════════════════════════════════════════════════════════ -->
   <rect x="560" y="196" width="130" height="56" rx="10" fill="#18181b" stroke="#ef4444" stroke-width="1.5" stroke-opacity="0.4"/>
   <rect x="560" y="196" width="4" height="56" rx="2" fill="#3b82f6"/>
   <text x="580" y="214" class="node-type" fill="#3b82f6">AI AGENT</text>
-  <text x="580" y="230" class="node-label">Claude Desktop</text>
+  <text x="580" y="230" class="node-label">desktop-agent</text>
   <text x="580" y="244" class="node-detail">3 servers · 8 tools</text>
 
   <!-- "2 paths" badge on Agent 2 -->
@@ -133,12 +133,12 @@
   <text x="673" y="207" text-anchor="middle" font-size="8" font-weight="700" fill="#fca5a5" font-family="system-ui, sans-serif">2x</text>
 
   <!-- ═══════════════════════════════════════════════════════════════════════ -->
-  <!-- NODE: Agent 3 (Windsurf)                                                -->
+  <!-- NODE: Agent 3                                                           -->
   <!-- ═══════════════════════════════════════════════════════════════════════ -->
   <rect x="560" y="320" width="130" height="56" rx="10" fill="#18181b" stroke="#27272a" stroke-width="1"/>
   <rect x="560" y="320" width="4" height="56" rx="2" fill="#3b82f6"/>
   <text x="580" y="338" class="node-type" fill="#3b82f6">AI AGENT</text>
-  <text x="580" y="354" class="node-label">Windsurf</text>
+  <text x="580" y="354" class="node-label">review-agent</text>
   <text x="580" y="368" class="node-detail">2 servers · 6 tools</text>
 
   <!-- ═══════════════════════════════════════════════════════════════════════ -->

--- a/docs/images/blast-radius-light.svg
+++ b/docs/images/blast-radius-light.svg
@@ -82,14 +82,14 @@
   <rect x="560" y="78" width="130" height="56" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
   <rect x="560" y="78" width="4" height="56" rx="2" fill="#3b82f6"/>
   <text x="580" y="96" class="node-type" fill="#2563eb">AI AGENT</text>
-  <text x="580" y="112" class="node-label">Cursor IDE</text>
+  <text x="580" y="112" class="node-label">code-agent</text>
   <text x="580" y="126" class="node-detail">4 servers · 12 tools</text>
 
   <!-- NODE: Agent 2 — affected by BOTH servers -->
   <rect x="560" y="196" width="130" height="56" rx="10" fill="#fafafa" stroke="#ef4444" stroke-width="1.5" stroke-opacity="0.35"/>
   <rect x="560" y="196" width="4" height="56" rx="2" fill="#3b82f6"/>
   <text x="580" y="214" class="node-type" fill="#2563eb">AI AGENT</text>
-  <text x="580" y="230" class="node-label">Claude Desktop</text>
+  <text x="580" y="230" class="node-label">desktop-agent</text>
   <text x="580" y="244" class="node-detail">3 servers · 8 tools</text>
 
   <rect x="658" y="196" width="30" height="16" rx="8" fill="#fef2f2" stroke="#ef4444" stroke-width="0.5" stroke-opacity="0.4"/>
@@ -99,7 +99,7 @@
   <rect x="560" y="320" width="130" height="56" rx="10" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
   <rect x="560" y="320" width="4" height="56" rx="2" fill="#3b82f6"/>
   <text x="580" y="338" class="node-type" fill="#2563eb">AI AGENT</text>
-  <text x="580" y="354" class="node-label">Windsurf</text>
+  <text x="580" y="354" class="node-label">review-agent</text>
   <text x="580" y="368" class="node-detail">2 servers · 6 tools</text>
 
   <!-- CREDENTIALS -->

--- a/ui/components/exposure-path-command-center.tsx
+++ b/ui/components/exposure-path-command-center.tsx
@@ -60,17 +60,19 @@ export function ExposurePathCommandCenter({
 
   return (
     <div className="space-y-4">
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_280px]">
-        <div>
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(220px,280px)]">
+        <div className="min-w-0">
           <p className="text-[10px] uppercase tracking-[0.2em] text-orange-400">Command center</p>
-          <h2 className="mt-1 text-lg font-semibold text-[color:var(--foreground)]">{pathDisplayTitle(path)}</h2>
+          <h2 className="mt-1 text-lg font-semibold leading-7 text-[color:var(--foreground)] [overflow-wrap:anywhere]">
+            {pathDisplayTitle(path)}
+          </h2>
           <p className="mt-2 max-w-4xl text-sm leading-6 text-[color:var(--text-secondary)]">
             {path.summary ||
               evidence?.attackVectorSummary ||
               "Selected exposure path with the entities, relationships, and evidence needed to choose the first fix."}
           </p>
         </div>
-        <div className="grid grid-cols-2 gap-2 text-xs">
+        <div className="grid min-w-0 grid-cols-2 gap-2 text-xs">
           <CommandMetric label="Risk" value={path.riskScore.toFixed(1)} tone="red" />
           <CommandMetric label="Hops" value={String(Math.max(0, path.hops.length - 1))} />
           <CommandMetric label="Agents" value={String(path.affectedAgents.length)} />
@@ -82,11 +84,17 @@ export function ExposurePathCommandCenter({
         {investigationBrief.map((item) => (
           <div
             key={item.label}
-            className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2"
+            className="min-w-0 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2"
           >
             <div className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">{item.label}</div>
-            <div className="mt-1 text-sm font-semibold leading-5 text-[color:var(--foreground)]">{item.value}</div>
-            {item.detail && <p className="mt-1 text-xs leading-5 text-[color:var(--text-secondary)]">{item.detail}</p>}
+            <div className="mt-1 text-sm font-semibold leading-5 text-[color:var(--foreground)] [overflow-wrap:anywhere]">
+              {item.value}
+            </div>
+            {item.detail && (
+              <p className="mt-1 text-xs leading-5 text-[color:var(--text-secondary)] [overflow-wrap:anywhere]">
+                {item.detail}
+              </p>
+            )}
           </div>
         ))}
       </section>
@@ -108,8 +116,8 @@ export function ExposurePathCommandCenter({
             {path.relationships.slice(0, 5).map((relationship) => (
               <div key={relationship.id} className="grid gap-2 px-3 py-2 text-xs md:grid-cols-[1fr_auto]">
                 <div className="min-w-0">
-                  <span className="font-mono text-[color:var(--foreground)]">{relationship.relationship}</span>
-                  <span className="ml-2 break-all text-[color:var(--text-tertiary)]">
+                  <span className="font-mono text-[color:var(--foreground)] [overflow-wrap:anywhere]">{relationship.relationship}</span>
+                  <span className="ml-2 break-all text-[color:var(--text-tertiary)] [overflow-wrap:anywhere]">
                     {relationship.source} → {relationship.target}
                   </span>
                 </div>
@@ -277,11 +285,15 @@ function ExposurePathGraph({ path }: { path: ExposurePath }) {
               <text x="32" y="24" fill={style.accent} fontSize="10" fontWeight="700" letterSpacing="2" fontFamily="var(--font-mono), monospace">
                 {meta.label.toUpperCase()}
               </text>
-              <text x="16" y="50" fill={style.text} fontSize="16" fontWeight="700" fontFamily="var(--font-sans), system-ui">
-                {truncateGraphText(node.label, 17)}
+              <text x="16" y="49" fill={style.text} fontSize="14" fontWeight="700" fontFamily="var(--font-sans), system-ui">
+                {wrapGraphText(node.label, 18, 2).map((line, lineIndex) => (
+                  <tspan key={`${node.id}-line-${lineIndex}`} x="16" dy={lineIndex === 0 ? 0 : 17}>
+                    {line}
+                  </tspan>
+                ))}
               </text>
               {node.severity && (
-                <text x="16" y="70" fill="#94a3b8" fontSize="11" letterSpacing="1.4" fontFamily="var(--font-mono), monospace">
+                <text x="16" y="79" fill="#94a3b8" fontSize="10" letterSpacing="1.4" fontFamily="var(--font-mono), monospace">
                   {String(node.severity).toUpperCase()}
                 </text>
               )}
@@ -297,7 +309,7 @@ function ExposurePathGraph({ path }: { path: ExposurePath }) {
 function buildPathGraphLayout(path: ExposurePath) {
   const width = 920;
   const nodeWidth = 178;
-  const nodeHeight = 84;
+  const nodeHeight = 96;
   const columns = Math.min(3, Math.max(1, path.hops.length));
   const rows = Math.max(1, Math.ceil(path.hops.length / columns));
   const xGap = columns > 1 ? (width - nodeWidth - 64) / (columns - 1) : 0;
@@ -355,6 +367,34 @@ function truncateGraphText(value: string, maxLength: number): string {
   return value.length > maxLength ? `${value.slice(0, Math.max(1, maxLength - 1))}…` : value;
 }
 
+function wrapGraphText(value: string, maxLineLength: number, maxLines: number): string[] {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLineLength) return [normalized];
+
+  const lines: string[] = [];
+  let remaining = normalized;
+  while (remaining.length > 0 && lines.length < maxLines) {
+    const isLastLine = lines.length === maxLines - 1;
+    if (remaining.length <= maxLineLength) {
+      lines.push(remaining);
+      break;
+    }
+    if (isLastLine) {
+      lines.push(truncateGraphText(remaining, maxLineLength));
+      break;
+    }
+
+    const window = remaining.slice(0, maxLineLength + 1);
+    const breakpoints = [" ", "-", "_", "/", ":", "@", "."].map((character) => window.lastIndexOf(character));
+    const breakpoint = Math.max(...breakpoints);
+    const cut = breakpoint >= Math.floor(maxLineLength * 0.45) ? breakpoint + 1 : maxLineLength;
+    lines.push(remaining.slice(0, cut).trim());
+    remaining = remaining.slice(cut).trim();
+  }
+
+  return lines.length > 0 ? lines : [truncateGraphText(normalized, maxLineLength)];
+}
+
 function CommandMetric({ label, value, tone = "zinc" }: { label: string; value: string; tone?: "red" | "green" | "zinc" }) {
   const toneClass =
     tone === "red"
@@ -364,9 +404,9 @@ function CommandMetric({ label, value, tone = "zinc" }: { label: string; value: 
         : "border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]";
 
   return (
-    <div className={`rounded-xl border px-3 py-2 ${toneClass}`}>
+    <div className={`min-w-0 rounded-xl border px-3 py-2 ${toneClass}`}>
       <div className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">{label}</div>
-      <div className="mt-1 truncate font-mono text-sm font-semibold">{value}</div>
+      <div className="mt-1 font-mono text-sm font-semibold leading-5 [overflow-wrap:anywhere]">{value}</div>
     </div>
   );
 }
@@ -381,13 +421,13 @@ function EvidenceRow({
   emptyLabel?: string;
 }) {
   return (
-    <div className="rounded-xl border border-[color:var(--border-subtle)] px-3 py-2 text-xs">
+    <div className="min-w-0 rounded-xl border border-[color:var(--border-subtle)] px-3 py-2 text-xs">
       <div className="mb-1 text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">{label}</div>
       <div className="flex flex-wrap gap-1.5">
         {(values.length > 0 ? values : [emptyLabel]).slice(0, 4).map((value) => (
           <span
             key={`${label}-${value}`}
-            className="rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2 py-0.5 text-[color:var(--text-secondary)]"
+            className="max-w-full rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2 py-0.5 text-[color:var(--text-secondary)] [overflow-wrap:anywhere]"
           >
             {value}
           </span>

--- a/ui/components/exposure-path-strip.tsx
+++ b/ui/components/exposure-path-strip.tsx
@@ -18,19 +18,22 @@ export function ExposurePathStrip({
 
   return (
     <div className="flex flex-wrap items-center gap-3 border-b border-[var(--border-subtle)] bg-red-950/20 px-4 py-2.5 text-xs">
-      <div className="flex min-w-0 flex-1 items-center gap-3">
-        <span className="inline-flex items-center gap-1 rounded border border-red-500/40 bg-red-500/10 px-2 py-1 font-semibold uppercase text-red-200">
+      <div className="flex min-w-[min(100%,24rem)] flex-1 flex-wrap items-center gap-2">
+        <span className="inline-flex shrink-0 items-center gap-1 rounded border border-red-500/40 bg-red-500/10 px-2 py-1 font-semibold uppercase text-red-200">
           <Crosshair className="h-3.5 w-3.5" />
           Top exposed path
         </span>
-        <span className="rounded bg-red-500/15 px-2 py-0.5 font-mono text-[11px] uppercase text-red-200">
+        <span className="shrink-0 rounded bg-red-500/15 px-2 py-0.5 font-mono text-[11px] uppercase text-red-200">
           {path.severity}
         </span>
-        <span className="min-w-0 truncate text-[var(--text-secondary)]" title={path.label}>
+        <span
+          className="min-w-[12rem] flex-1 overflow-hidden break-words text-[var(--text-secondary)] [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [overflow-wrap:anywhere]"
+          title={path.label}
+        >
           {pathDisplayTitle(path)}
         </span>
       </div>
-      <div className="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-secondary)]">
+      <div className="flex min-w-0 flex-wrap items-center gap-2 text-[11px] text-[var(--text-secondary)]">
         <Metric icon={ShieldAlert} label="risk" value={Math.round(path.riskScore * 10) / 10} />
         <Metric icon={Route} label="hops" value={Math.max(0, path.hops.length - 1)} />
         <Metric label="agents" value={path.affectedAgents.length} />
@@ -39,7 +42,7 @@ export function ExposurePathStrip({
           <Metric icon={KeyRound} label="creds" value={path.exposedCredentials.length} />
         )}
         {fixLabel && (
-          <span>
+          <span className="min-w-0 break-words [overflow-wrap:anywhere]">
             fix <b className="text-emerald-300">{fixLabel}</b>
           </span>
         )}
@@ -67,7 +70,7 @@ function Metric({
   value: string | number;
 }) {
   return (
-    <span className="inline-flex items-center gap-1">
+    <span className="inline-flex shrink-0 items-center gap-1">
       {Icon && <Icon className="h-3 w-3" />}
       {label} <b className="text-foreground">{value}</b>
     </span>


### PR DESCRIPTION
Summary
- Keep selected exposure-path banner and command-center cards from overflowing on long path, credential, and fix labels.
- Wrap SVG selected-path node labels inside fixed node boxes and keep dark/light README blast-radius SVG labels generic and contained.
- Remove npm/npx/yarn/corepack package-manager tooling from the final UI runtime image; the container only needs node server.js, and this removes base-image package-manager CVEs from the shipped UI image.

Verification
- npm test -- --run tests/exposure-path-command-center.test.tsx tests/graph-chrome.test.tsx tests/unified-graph-flow.test.ts
- npm run typecheck
- npm run test:e2e -- e2e/security-graph-cockpit.spec.ts e2e/lineage-graph-readability.spec.ts
- git diff --check && git diff --cached --check
- rsvg-convert docs/images/blast-radius-dark.svg -w 1800 -o /tmp/agent-bom-visual/blast-radius-clean-pr.png
- docker build -f ui/Dockerfile -t agent-bom-ui:trivy-fixed ui
- docker run/curl smoke on http://127.0.0.1:3001/
- trivy image --format table --severity MEDIUM,HIGH,CRITICAL,UNKNOWN --ignore-unfixed --ignorefile .image-scan-ignore agent-bom-ui:trivy-fixed

Notes
- Local npm install warns because this shell is Node 25.9.0 while the UI declares >=22 <25; CI uses the supported toolchain.
- The manual Refresh Docker Latest run proved the stale agent-bom-ui latest image is blocked by the UI Trivy gate on package-manager CVEs in the final image. This PR removes that runtime-only surface; a new release tag is still required before Docker Hub latest should be refreshed from release code.
