### PR TITLE
fix(ui): harden runtime image package-manager surface

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -47,6 +47,19 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # Apply latest OS security patches (fixes base-image CVEs visible in Docker Scout)
 RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
+# The production image runs Next's standalone server with `node server.js`.
+# npm, npx, yarn, and corepack are build-time tooling only; removing them from
+# the runner avoids shipping their transitive package-manager CVE surface.
+RUN rm -rf \
+    /opt/yarn* \
+    /usr/local/bin/corepack \
+    /usr/local/bin/npm \
+    /usr/local/bin/npx \
+    /usr/local/bin/yarn \
+    /usr/local/bin/yarnpkg \
+    /usr/local/lib/node_modules/corepack \
+    /usr/local/lib/node_modules/npm
+
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 


### PR DESCRIPTION
Summary
- Remove npm, npx, yarn, and corepack from the final UI runner image.
- Keep package managers available only in build stages; production runtime still runs Next standalone with node server.js.
- Fixes the Refresh Docker Latest UI image Trivy gate by removing base-image package-manager CVEs from the shipped runtime layer.

Verification
- docker build -f ui/Dockerfile -t agent-bom-ui:trivy-fixed ui
- docker run/curl smoke on http://127.0.0.1:3001/
- trivy image --format table --severity MEDIUM,HIGH,CRITICAL,UNKNOWN --ignore-unfixed --ignorefile .image-scan-ignore agent-bom-ui:trivy-fixed

Notes
- The failed manual Refresh Docker Latest run built and smoked the UI image successfully, then failed on Trivy before push. This change reduces the final UI image scan to zero reported Debian and Node vulnerabilities locally.
- Docker Hub latest should be refreshed after this lands through the next release/tag path, not by publishing unreleased main code as latest.
