### PR TITLE
chore(release): prepare v0.88.6

### DIFF
--- a/.github/workflows/deploy-mcp-sse.yml
+++ b/.github/workflows/deploy-mcp-sse.yml
@@ -1,15 +1,13 @@
 name: Deploy MCP SSE
 
-# Deploys the SSE container to Railway after a successful Release workflow.
+# Deploys the SSE container to Railway from the trusted release tag checkout.
 # Requires RAILWAY_TOKEN secret and DEPLOY_TARGET=railway variable.
 # Optional: RAILWAY_SERVICE variable to specify the service name.
 #
 # Post-deploy: verifies the deployed version matches the release tag.
 
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types: [completed]
+  workflow_call:
   workflow_dispatch:
 
 permissions:
@@ -23,45 +21,52 @@ jobs:
       contents: read
     if: >-
       ${{
-        vars.DEPLOY_TARGET == 'railway' &&
-        (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success')
+        vars.DEPLOY_TARGET == 'railway'
       }}
     steps:
-      - name: Resolve release ref
+      - name: Resolve trusted release tag
         id: tag
         env:
-          EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
-          # Use head_branch (tag name like "v0.71.2"), NOT head_sha —
-          # head_sha is flagged by CodeQL as untrusted code in privileged context.
-          WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            REF="$REF_NAME"
-          else
-            REF="$WORKFLOW_HEAD_BRANCH"
-          fi
-          # Verify ref matches a semver tag pattern (rejects arbitrary branches)
-          if ! echo "$REF" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
+          REF="$REF_NAME"
+          # Only release tags are deployable. Branches and partial semver refs
+          # are rejected before any repository code is checked out.
+          if ! echo "$REF" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::Refusing to deploy non-semver ref: $REF"
             exit 1
           fi
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
-          echo "Deploying ref: $REF"
+          echo "version=${REF#v}" >> "$GITHUB_OUTPUT"
+          echo "Deploying trusted release tag: $REF"
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ steps.tag.outputs.ref }}
+          fetch-depth: 0
           persist-credentials: false
 
-      - name: Verify checkout matches expected version
+      - name: Verify checkout matches trusted release tag
+        env:
+          EXPECTED_TAG: ${{ steps.tag.outputs.ref }}
+          EXPECTED_VERSION: ${{ steps.tag.outputs.version }}
         run: |
+          git fetch --force --tags origin "refs/tags/$EXPECTED_TAG:refs/tags/$EXPECTED_TAG"
+          TAG_SHA=$(git rev-list -n 1 "$EXPECTED_TAG^{commit}")
+          HEAD_SHA=$(git rev-parse HEAD)
+          if [ "$TAG_SHA" != "$HEAD_SHA" ]; then
+            echo "::error::Checked-out commit $HEAD_SHA does not match $EXPECTED_TAG commit $TAG_SHA"
+            exit 1
+          fi
           REPO_VERSION=$(python3 -c "
           import re, pathlib
           text = pathlib.Path('pyproject.toml').read_text()
           m = re.search(r'version\s*=\s*\"([^\"]+)\"', text)
           print(m.group(1))
           ")
+          if [ "$REPO_VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "::error::Checked-out version $REPO_VERSION does not match release tag $EXPECTED_TAG"
+            exit 1
+          fi
           echo "Checked-out version: $REPO_VERSION"
           echo "repo_version=$REPO_VERSION" >> "$GITHUB_ENV"
 

--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom
-        run: uv tool install agent-bom==0.88.5  # pinned — bump on each release
+        run: uv tool install agent-bom==0.88.6  # pinned — bump on each release
 
       - name: Scan changed MCP configs
         id: scan

--- a/.github/workflows/post-merge-self-scan.yml
+++ b/.github/workflows/post-merge-self-scan.yml
@@ -133,6 +133,13 @@ jobs:
           sarif_file: sarif/self-dep.sarif
           category: agent-bom-self-dep
 
+      - name: Refresh legacy scheduled SARIF category
+        if: always() && hashFiles('sarif/self-dep.sarif') != ''
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4
+        with:
+          sarif_file: sarif/self-dep.sarif
+          category: agent-bom-scheduled
+
       - name: Fail on critical (optional, only when explicitly requested)
         if: inputs.fail_on_critical == true
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1022,3 +1022,10 @@ jobs:
             fi
             echo "Updated floating tag $MAJOR → ${{ github.ref_name }}"
           fi
+
+  deploy-mcp-sse:
+    name: Deploy MCP SSE
+    needs: github-release
+    if: ${{ vars.DEPLOY_TARGET == 'railway' }}
+    uses: ./.github/workflows/deploy-mcp-sse.yml
+    secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.88.6] - 2026-06-05
+
+### Added
+- **Agent governance parity controls.** Budget enforcement, signed identity lifecycle audit events, per-tool scopes, JIT/time-bound access, conditional access decisions, and identity/cost/drift UI cockpits are now wired through the control plane, API, MCP tools, tests, and dashboard surfaces.
+- **CNAPP-style security graph depth.** Exposure paths now include cloud exposure, sensitive data paths, effective-permission escalation, governance decisions, action-level IAM privilege, port-aware network exposure, runtime-observed reachability, and policy/webhook evidence with distinct node and edge semantics.
+- **Guarded remediation flow.** Remediation can now stage guarded apply operations and draft pull requests with explicit policy, scope, and audit evidence before changes are applied.
+
+### Changed
+- README and product screenshots now emphasize scan-to-runtime evidence, graph-backed findings, environment/identity/IAM attack paths, readable legends, and contained dashboard visuals.
+- Dependency automation was consolidated across Python, UI, and GitHub Actions updates so approved dependency PRs land as coherent review units.
+- The Docker latest refresh workflow now handles API and UI image refresh paths together after a release tag is published.
+
+### Fixed
+- Upgraded `aiohttp` to address the GitHub security alerts for cross-origin redirects with per-request cookies and unsafe deserialization.
+- Reworked Railway SSE deployment to run from the trusted release workflow tag instead of checking out `workflow_run` metadata in a privileged deployment context, and refreshed the legacy `agent-bom-scheduled` SARIF category from the current self-scan workflow.
+- Hardened the UI runtime Docker image by removing build-time package-manager tooling from the final image, clearing the Trivy gate that blocked `agentbom/agent-bom-ui:latest` refresh.
+- Tightened dashboard and README visual containment so graph labels, path headers, cards, and code samples wrap inside their containers across dark, light, and mobile views.
+
+---
+
 ## [0.88.5] - 2026-06-01
 
 ### Added
@@ -1491,7 +1511,8 @@ Two new product surfaces (inter-agent firewall + per-run discovery envelope) plu
 
 ---
 
-[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.88.5...HEAD
+[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.88.6...HEAD
+[0.88.6]: https://github.com/msaad00/agent-bom/compare/v0.88.5...v0.88.6
 [0.88.5]: https://github.com/msaad00/agent-bom/compare/v0.88.4...v0.88.5
 [0.88.4]: https://github.com/msaad00/agent-bom/compare/v0.88.3...v0.88.4
 [0.88.3]: https://github.com/msaad00/agent-bom/compare/v0.88.1...v0.88.3

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -204,7 +204,7 @@ Focused agent mesh graph:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `0.88.5` | Current stable version (pinned) |
+| `0.88.6` | Current stable version (pinned) |
 
 Published images:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.5-alpine3.23@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6ccea4d4ebdabbc523b9a1614
 
-ARG VERSION=0.88.5
+ARG VERSION=0.88.6
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Screenshot capture rules and the full manifest live in
 | Container image scan | `agent-bom image nginx:latest` | image findings and remediation |
 | IaC scan | `agent-bom iac Dockerfile k8s/ infra/main.tf` | IaC findings and policy context |
 | Cloud posture check | `agent-bom cis-benchmark --provider aws` | runtime CIS posture evidence |
-| CI gate | `uses: msaad00/agent-bom@v0.88.5` | SARIF, PR summary, optional code-scanning upload |
+| CI gate | `uses: msaad00/agent-bom@v0.88.6` | SARIF, PR summary, optional code-scanning upload |
 | MCP tools | `pip install 'agent-bom[mcp-server]' && agent-bom mcp server` | strict-args security tools for MCP clients |
 | Local API/UI | `pip install 'agent-bom[ui]' && agent-bom serve` | API plus bundled dashboard |
 | First-run extras | `pip install 'agent-bom[all]'` | supported onboarding extras; MLflow remains separately installed |

--- a/deploy/docker-compose.fullstack.yml
+++ b/deploy/docker-compose.fullstack.yml
@@ -27,7 +27,7 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
-    image: agentbom/agent-bom:0.88.5
+    image: agentbom/agent-bom:0.88.6
     container_name: agent-bom-api
     restart: unless-stopped
     command: api --host 0.0.0.0 --port 8422 --allow-insecure-no-auth
@@ -74,7 +74,7 @@ services:
       args:
         # Baked into the Next.js build — must match the publicly reachable API URL
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8422}
-    image: agentbom/agent-bom-ui:0.88.5
+    image: agentbom/agent-bom-ui:0.88.6
     container_name: agent-bom-ui
     restart: unless-stopped
     ports:

--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -18,7 +18,7 @@
 
 services:
   api:
-    image: agentbom/agent-bom:0.88.5
+    image: agentbom/agent-bom:0.88.6
     container_name: agent-bom-pilot-api
     restart: unless-stopped
     command: >
@@ -45,7 +45,7 @@ services:
       start_period: 10s
 
   ui:
-    image: agentbom/agent-bom-ui:0.88.5
+    image: agentbom/agent-bom-ui:0.88.6
     container_name: agent-bom-pilot-ui
     restart: unless-stopped
     environment:

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -115,7 +115,7 @@ services:
       dockerfile: Dockerfile
       args:
         NEXT_PUBLIC_API_URL: http://localhost:8422
-    image: agentbom/agent-bom-ui:0.88.5
+    image: agentbom/agent-bom-ui:0.88.6
     container_name: agent-bom-ui
     ports:
       - "3000:3000"

--- a/deploy/docker-compose.runtime.yml
+++ b/deploy/docker-compose.runtime.yml
@@ -31,7 +31,7 @@ services:
     build:
       context: ..
       dockerfile: deploy/docker/Dockerfile.runtime
-    image: agentbom/agent-bom:0.88.5
+    image: agentbom/agent-bom:0.88.6
     container_name: agent-bom-runtime-proxy
     depends_on:
       - mcp-server

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -27,7 +27,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.88.5
+ARG VERSION=0.88.6
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -17,7 +17,7 @@ WORKDIR /app
 COPY pyproject.toml README.md PYPI_README.md LICENSE ./
 COPY src/ ./src/
 
-ARG VERSION=0.88.5
+ARG VERSION=0.88.6
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
@@ -40,7 +40,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[runtime]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.88.5
+ARG VERSION=0.88.6
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.snowpark
+++ b/deploy/docker/Dockerfile.snowpark
@@ -26,7 +26,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11.12-slim@sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c
 
-ARG VERSION=0.88.5
+ARG VERSION=0.88.6
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -41,7 +41,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.88.5
+ARG VERSION=0.88.6
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: agent-bom
 description: Open security scanner and graph for AI supply chain and infrastructure — discover agents and MCP, map blast radius, and inspect runtime.
-version: 0.88.5
-appVersion: "0.88.5"
+version: 0.88.6
+appVersion: "0.88.6"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -24,17 +24,17 @@
 
 image:
   repository: agentbom/agent-bom
-  tag: "0.88.5"
+  tag: "0.88.6"
   pullPolicy: IfNotPresent
 
 uiImage:
   repository: agentbom/agent-bom-ui
-  tag: "0.88.5"
+  tag: "0.88.6"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom
-  tag: "0.88.5"
+  tag: "0.88.6"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -57,7 +57,7 @@ tests:
   includeUi: true
   image:
     repository: agentbom/agent-bom
-    tag: "0.88.5"
+    tag: "0.88.6"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deploy/k8s/cronjob.yaml
+++ b/deploy/k8s/cronjob.yaml
@@ -21,7 +21,7 @@ spec:
           serviceAccountName: agent-bom
           containers:
             - name: scanner
-              image: agentbom/agent-bom:0.88.5
+              image: agentbom/agent-bom:0.88.6
               command: ["agent-bom"]
               args:
                 - "scan"

--- a/deploy/k8s/daemonset.yaml
+++ b/deploy/k8s/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: agent-bom
       containers:
         - name: monitor
-          image: agentbom/agent-bom:0.88.5
+          image: agentbom/agent-bom:0.88.6
           command: ["agent-bom"]
           args:
             - "protect"

--- a/deploy/k8s/proxy-sidecar-pilot.yaml
+++ b/deploy/k8s/proxy-sidecar-pilot.yaml
@@ -109,7 +109,7 @@ spec:
               cpu: "500m"
 
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.88.5
+          image: agentbom/agent-bom:0.88.6
           args:
             - "--policy"
             - "/etc/agent-bom/policy.json"

--- a/deploy/k8s/sidecar-example.yaml
+++ b/deploy/k8s/sidecar-example.yaml
@@ -40,7 +40,7 @@ spec:
 
         # agent-bom proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.88.5
+          image: agentbom/agent-bom:0.88.6
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"

--- a/deploy/snowflake/native-app/manifest.yml
+++ b/deploy/snowflake/native-app/manifest.yml
@@ -15,10 +15,10 @@ artifacts:
     endpoint: ui
   container_services:
     images:
-      - /db/schema/agent_bom_repo/agent-bom:v0_88_5
-      - /db/schema/agent_bom_repo/agent-bom-ui:v0_88_5
-      - /db/schema/agent_bom_repo/agent-bom-scanner:v0_88_5
-      - /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_88_5
+      - /db/schema/agent_bom_repo/agent-bom:v0_88_6
+      - /db/schema/agent_bom_repo/agent-bom-ui:v0_88_6
+      - /db/schema/agent_bom_repo/agent-bom-scanner:v0_88_6
+      - /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_88_6
   service_roles:
     - name: api
       comment: >-

--- a/deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml
+++ b/deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom-mcp-runtime
-      image: /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_88_5
+      image: /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_88_6
       env:
         SNOWFLAKE_ACCOUNT: "{{ snowflake_account }}"
         SNOWFLAKE_DATABASE: "{{ database }}"

--- a/deploy/snowflake/native-app/service-specs/scanner-service.yaml
+++ b/deploy/snowflake/native-app/service-specs/scanner-service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom-scanner
-      image: /db/schema/agent_bom_repo/agent-bom-scanner:v0_88_5
+      image: /db/schema/agent_bom_repo/agent-bom-scanner:v0_88_6
       env:
         SNOWFLAKE_ACCOUNT: "{{ snowflake_account }}"
         SNOWFLAKE_DATABASE: "{{ database }}"

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -180,7 +180,7 @@ should not store provider secret values.
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.88.5
+- uses: msaad00/agent-bom@v0.88.6
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -71,7 +71,7 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # GitHub Actions
-- uses: msaad00/agent-bom@v0.88.5
+- uses: msaad00/agent-bom@v0.88.6
   with:
     scan-type: agents        # auto-detect MCP configs + deps
     severity-threshold: high # fail PR on HIGH+ CVEs
@@ -89,21 +89,21 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # Container image gate
-- uses: msaad00/agent-bom@v0.88.5
+- uses: msaad00/agent-bom@v0.88.6
   with:
     scan-type: image
     scan-ref: ghcr.io/acme/agent-runtime:sha-abcdef
     severity-threshold: critical
 
 # IaC gate
-- uses: msaad00/agent-bom@v0.88.5
+- uses: msaad00/agent-bom@v0.88.6
   with:
     scan-type: iac
     iac: Dockerfile,k8s/,infra/main.tf
     severity-threshold: high
 
 # Air-gapped or fully cached CI
-- uses: msaad00/agent-bom@v0.88.5
+- uses: msaad00/agent-bom@v0.88.6
   with:
     auto-update-db: false
     enrich: false
@@ -475,7 +475,7 @@ AmazonEC2ReadOnlyAccess
 docker run --rm \
   -v ~/.config:/home/abom/.config:ro \
   -v $(pwd):/workspace:ro \
-  agentbom/agent-bom:0.88.5 agents --format json
+  agentbom/agent-bom:0.88.6 agents --format json
 ```
 
 Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base image.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -273,7 +273,7 @@ should_i_deploy     — allow/warn/block guidance from ExposurePath risk
 ### CI/CD (GitHub Action)
 
 ```yaml
-- uses: msaad00/agent-bom@v0.88.5
+- uses: msaad00/agent-bom@v0.88.6
   with:
     format: sarif
     upload-sarif: 'true'

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,6 +1,6 @@
 {
   "generated_on": "2026-05-22",
-  "version": "0.88.5",
+  "version": "0.88.6",
   "metrics": [
     {
       "name": "MCP tools",

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -6,7 +6,7 @@ This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
 - Generated on: `2026-05-22`
-- Version: `0.88.5`
+- Version: `0.88.6`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -97,7 +97,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN" --no-browser
 clawhub publish integrations/openclaw/scan \
   --slug agent-bom-scan --name "agent-bom scan" \
-  --version "0.88.5"
+  --version "0.88.6"
 ```
 
 Release automation uses the same official `clawhub` CLI flow, not a custom
@@ -149,8 +149,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.88.5
-git push origin v0.88.5
+git tag v0.88.6
+git push origin v0.88.6
 ```
 
 This triggers:
@@ -158,7 +158,7 @@ This triggers:
 2. **publish-mcp.yml** → GHCR stdio + SSE containers (via workflow_run)
 3. **publish-registries.yml** → Smithery + ClawHub (via workflow_run)
 4. **publish-mcp-registry.yml** → Official MCP Registry (via workflow_run)
-5. **deploy-mcp-sse.yml** → Railway deployment (via workflow_run)
+5. **deploy-mcp-sse.yml** → Railway deployment (called from the release workflow)
 
 Each GitHub Release should include these verification assets alongside the
 wheel and source tarball:
@@ -196,4 +196,4 @@ For dependency-heavy or security-driven releases, also verify:
 | **Smithery** | workflow API | publish-registries.yml | workflow_run |
 | **ClawHub** | curated `integrations/openclaw/*/SKILL.md` set | publish-registries.yml | workflow_run |
 | **MCP Registry** | `integrations/mcp-registry/server.json` | publish-mcp-registry.yml | workflow_run |
-| **Railway** | `deploy/docker/Dockerfile.sse` | deploy-mcp-sse.yml | workflow_run |
+| **Railway** | `deploy/docker/Dockerfile.sse` | deploy-mcp-sse.yml | release workflow_call / workflow_dispatch |

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -13,7 +13,7 @@ For each tagged GitHub Release, expect:
 ## Download release assets
 
 ```bash
-TAG=v0.88.5
+TAG=v0.88.6
 VERSION="${TAG#v}"
 mkdir -p /tmp/agent-bom-release && cd /tmp/agent-bom-release
 gh release download "$TAG" --repo msaad00/agent-bom

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -33,7 +33,7 @@ The proxy interposes on the stdio channel between an MCP client (Claude Desktop,
 Use the published main runtime image:
 
 ```bash
-docker pull agentbom/agent-bom:0.88.5
+docker pull agentbom/agent-bom:0.88.6
 ```
 
 If you need to rebuild locally from the checked-out repo, you can still use
@@ -45,7 +45,7 @@ Run as a wrapper around any MCP server:
 ```bash
 docker run --rm \
   -v $(pwd)/audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.88.5 \
+  agentbom/agent-bom:0.88.6 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace
@@ -94,7 +94,7 @@ spec:
 
         # agent-bom runtime proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.88.5
+          image: agentbom/agent-bom:0.88.6
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"
@@ -341,7 +341,7 @@ Use the runtime container directly from Claude Desktop:
         "run", "--rm", "-i",
         "-v", "./workspace:/workspace",
         "-v", "./audit-logs:/var/log/agent-bom",
-        "agentbom/agent-bom:0.88.5",
+        "agentbom/agent-bom:0.88.6",
         "--log", "/var/log/agent-bom/audit.jsonl",
         "--block-undeclared",
         "--",

--- a/docs/archive/WINDOWS_CONTAINERS.md
+++ b/docs/archive/WINDOWS_CONTAINERS.md
@@ -113,7 +113,7 @@ container inspection. Windows Server environments should use:
 
 1. **Python CLI** -- `pip install agent-bom` works on Windows natively
 2. **Docker Desktop** -- run the Linux container images on Windows via WSL 2
-3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.88.5`) which
+3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.88.6`) which
    runs on Linux runners
 
 ---

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,4 +1,4 @@
-# agent-bom v0.88.5 blast-radius demo
+# agent-bom v0.88.6 blast-radius demo
 # Shows: blast radius → package gate
 
 Output docs/images/demo-latest.gif

--- a/docs/images/product-screenshots.json
+++ b/docs/images/product-screenshots.json
@@ -1,5 +1,5 @@
 {
-  "release_version": "0.88.5",
+  "release_version": "0.88.6",
   "captured_at": "2026-06-03T20:30:00Z",
   "capture_note": "Captured from real Next.js dashboard routes in capture mode. The refreshed graph proof uses a deterministic Playwright harness that routes seeded scan, fleet, gateway, IAM, environment, runtime, and package evidence into the shipped pages so README media shows non-empty security graph, lineage topology, context map, fleet, and gateway states. The records are synthetic seeded evidence for docs proof, not a claim that those exact entities were discovered from a buyer environment.",
   "screenshots": [
@@ -7,67 +7,67 @@
       "path": "dashboard-live.png",
       "page": "/?capture=1",
       "scope": "Risk overview top frame with headline KPIs, posture grade, and start of attack paths",
-      "visible_version": "0.88.5"
+      "visible_version": "0.88.6"
     },
     {
       "path": "dashboard-paths-live.png",
       "page": "/?capture=1",
       "scope": "Risk overview mid-frame with attack paths and exposure KPIs",
-      "visible_version": "0.88.5"
+      "visible_version": "0.88.6"
     },
     {
       "path": "mesh-live.png",
       "page": "/mesh?capture=1",
       "scope": "Focused agent mesh graph across the active agent, MCP server, package, tool, and CVE path, cropped to the product graph surface",
-      "visible_version": "0.88.5"
+      "visible_version": "0.88.6"
     },
     {
       "path": "gateway-policies-live.png",
       "page": "/gateway?capture=1",
       "scope": "Runtime gateway policy posture with one advisory baseline policy, two rules, and two bound agents",
-      "visible_version": "0.88.5"
+      "visible_version": "0.88.6"
     },
     {
       "path": "security-graph-live.png",
       "page": "/security-graph?capture=1",
       "scope": "Fix-first attack path queue with snapshot pressure, graph evidence export, and remediation handoff",
-      "visible_version": "0.88.5"
+      "visible_version": "0.88.6"
     },
     {
       "path": "lineage-graph-live.png",
       "page": "/graph?capture=1",
       "scope": "Expanded but bounded lineage topology across environment, identity, MCP, package, credential, model, dataset, and finding nodes",
-      "visible_version": "0.88.5"
+      "visible_version": "0.88.6"
     },
     {
       "path": "context-map-live.png",
       "page": "/context?capture=1",
       "scope": "Agent-scoped context map showing reachable MCP servers and lateral movement side panel",
-      "visible_version": "0.88.5"
+      "visible_version": "0.88.6"
     },
     {
       "path": "fleet-state-live.png",
       "page": "/fleet?capture=1",
       "scope": "Expanded fleet row showing lifecycle distribution, approved state, owner metadata, environment label, and discovery state",
-      "visible_version": "0.88.5"
+      "visible_version": "0.88.6"
     },
     {
       "path": "identity-audit-live.png",
       "page": "/audit?capture=1",
       "scope": "Audit log filtered to identity resources with HMAC integrity counters and agent identity issue, rotate, revoke events",
-      "visible_version": "0.88.5"
+      "visible_version": "0.88.6"
     },
     {
       "path": "dependency-map-live.png",
       "page": "/insights?capture=1",
       "scope": "Supply chain dependency map with scan pipeline counts and package risk distribution",
-      "visible_version": "0.88.5"
+      "visible_version": "0.88.6"
     },
     {
       "path": "remediation-live.png",
       "page": "/remediation",
       "scope": "Fix-first remediation table with prioritized packages and framework context",
-      "visible_version": "0.88.5"
+      "visible_version": "0.88.6"
     }
   ]
 }

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -3011,7 +3011,7 @@
   "info": {
     "description": "Security scanner for AI supply chain and infrastructure \u2014 map the full trust chain from agents to CVEs, credentials, and blast radius.",
     "title": "agent-bom API",
-    "version": "0.88.5"
+    "version": "0.88.6"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -2005,7 +2005,7 @@ info:
   description: "Security scanner for AI supply chain and infrastructure \u2014 map\
     \ the full trust chain from agents to CVEs, credentials, and blast radius."
   title: agent-bom API
-  version: 0.88.5
+  version: 0.88.6
 openapi: 3.1.0
 paths:
   /health:

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
-  "version": "0.88.5",
+  "version": "0.88.6",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
   "title": "agent-bom",
-  "version": "0.88.5",
+  "version": "0.88.6",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.88.5",
+      "version": "0.88.6",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   security checks. Use when the user mentions vulnerability scanning,
   MCP server trust, compliance, SBOM generation, CIS benchmarks, blast
   radius, or AI supply chain risk.
-version: 0.88.5
+version: 0.88.6
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -25,7 +25,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.88.5
+    docker: ghcr.io/msaad00/agent-bom:0.88.6
   openclaw:
     requires:
       bins: []
@@ -415,6 +415,6 @@ provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.88.5`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.88.6`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Analyze blast radius, attack paths, and threat landscape across your AI
   infrastructure. Use when: "blast radius", "threat intel", "risk score",
   "attack path", "lateral movement", "context graph", "who can reach what".
-version: 0.88.5
+version: 0.88.6
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.88.5
+    docker: ghcr.io/msaad00/agent-bom:0.88.6
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Generate SBOMs and compliance reports. Use when:
   "compliance report", "NIST", "SOC 2", "ISO 27001", "OWASP", "EU AI Act",
   "AISVS", "generate SBOM", "policy check".
-version: 0.88.5
+version: 0.88.6
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. OWASP/NIST/EU AI Act/MITRE
@@ -23,7 +23,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.88.5
+    docker: ghcr.io/msaad00/agent-bom:0.88.6
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/discover-aws/SKILL.md
+++ b/integrations/openclaw/discover-aws/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   inventory AWS Bedrock, ECS, SageMaker, Lambda, EKS, Step Functions, EC2, or
   agentic AWS infrastructure as canonical inventory. Passing that inventory
   to agent-bom is optional and operator-chosen.
-version: 0.88.5
+version: 0.88.6
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-azure/SKILL.md
+++ b/integrations/openclaw/discover-azure/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   giving agent-bom long-lived Azure credentials. Use when a user asks to
   inventory Azure OpenAI, Container Apps, AKS, Functions, ML, or agentic Azure
   infrastructure as canonical inventory.
-version: 0.88.5
+version: 0.88.6
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-gcp/SKILL.md
+++ b/integrations/openclaw/discover-gcp/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   giving agent-bom long-lived GCP credentials. Use when a user asks to
   inventory Vertex AI, Cloud Run, Cloud Functions, GKE, or agentic GCP
   infrastructure as canonical inventory.
-version: 0.88.5
+version: 0.88.6
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-snowflake/SKILL.md
+++ b/integrations/openclaw/discover-snowflake/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   agent-bom inventory JSON, and scan it without giving agent-bom long-lived
   Snowflake credentials. Use when a user asks to inventory Snowflake AI or
   Cortex infrastructure as canonical inventory.
-version: 0.88.5
+version: 0.88.6
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed with the snowflake extra, and

--- a/integrations/openclaw/discover/SKILL.md
+++ b/integrations/openclaw/discover/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Discover AI agents, MCP servers, and configurations on this machine or
   environment. Use when: "find agents", "what's configured", "doctor",
   "what MCP servers", "show me what's installed", "mcp inventory".
-version: 0.88.5
+version: 0.88.6
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.88.5
+    docker: ghcr.io/msaad00/agent-bom:0.88.6
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Enforce security policies on MCP tool calls and block dangerous operations at
   runtime. Use when: "block risky calls", "apply policy", "proxy",
   "runtime protection", "policy enforcement", "intercept MCP calls".
-version: 0.88.5
+version: 0.88.6
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.88.5
+    docker: ghcr.io/msaad00/agent-bom:0.88.6
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/ingest/SKILL.md
+++ b/integrations/openclaw/ingest/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   GCP, Snowflake, CMDB, or endpoint collectors. Use when a user has canonical
   inventory JSON and wants local findings, graph, policy, provenance, or
   auditor-ready exports without giving agent-bom direct cloud credentials.
-version: 0.88.5
+version: 0.88.6
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+ and agent-bom 0.84.4+. Inventory must conform to the

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Monitor agent fleet, track trust scores, and manage lifecycle states. Use
   when: "fleet", "watch agents", "runtime status", "trust scores",
   "fleet sync", "agent lifecycle", "serve dashboard".
-version: 0.88.5
+version: 0.88.6
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.88.5
+    docker: ghcr.io/msaad00/agent-bom:0.88.6
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.88.5
+version: 0.88.6
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.88.5
+version: 0.88.6
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Scan infrastructure-as-code, cloud configurations, and find secrets. Use when:
   "check terraform", "scan kubernetes", "IaC", "find secrets",
   "scan dockerfile", "cloud security", "misconfigurations".
-version: 0.88.5
+version: 0.88.6
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.88.5
+    docker: ghcr.io/msaad00/agent-bom:0.88.6
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   KEV), container images, provenance, filesystems, and SBOMs. Use
   when: "check package", "scan image", "verify", "is this safe",
   "scan dependencies", "CVE lookup", "blast radius".
-version: 0.88.5
+version: 0.88.6
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Native container image
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.88.5
+    docker: ghcr.io/msaad00/agent-bom:0.88.6
   openclaw:
     requires:
       bins: []
@@ -237,6 +237,6 @@ agent-bom agents
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.88.5`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.88.6`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Diagnose issues, check prerequisites, and validate configurations. Use when:
   "doctor", "debug", "why failing", "validate config", "check prerequisites",
   "something is broken", "db status", "fix my setup".
-version: 0.88.5
+version: 0.88.6
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.88.5
+    docker: ghcr.io/msaad00/agent-bom:0.88.6
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/vulnerability-intel/SKILL.md
+++ b/integrations/openclaw/vulnerability-intel/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   with explicit data-boundary choices. Use when a user asks for CVE lookup,
   advisory intelligence, exploitability context, fix versions, GHSA/OSV/NVD
   enrichment, or package vulnerability triage.
-version: 0.88.5
+version: 0.88.6
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+ and agent-bom installed from this repository or PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.88.5"
+version = "0.88.6"
 description = "Open security scanner and self-hosted control plane for AI/MCP infrastructure."
 readme = "PYPI_README.md"
 license = "Apache-2.0"

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -33,6 +33,10 @@ def _openapi_schema() -> dict[str, Any]:
     # stable local key keeps import-time audit logging quiet for this contract
     # generation path without affecting runtime configuration.
     os.environ.setdefault("AGENT_BOM_AUDIT_HMAC_KEY", "openapi-export-local-contract-key")
+    # Keep the committed API contract deterministic even when tests or a local
+    # shell enable unauthenticated development mode.
+    os.environ.pop("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", None)
+    sys.path.insert(0, str(ROOT / "src"))
     from agent_bom.api.server import app
 
     app.openapi_schema = None

--- a/site-docs/deployment/airgapped-image-bundle.md
+++ b/site-docs/deployment/airgapped-image-bundle.md
@@ -16,7 +16,7 @@ From an internet-connected build host:
 
 ```bash
 scripts/release/build-airgap-image-bundle.sh \
-  --version 0.88.5 \
+  --version 0.88.6 \
   --platform linux/amd64 \
   --output-dir dist/airgap
 ```
@@ -37,8 +37,8 @@ machine.
 ## Import On The Disconnected Host
 
 ```bash
-tar -xzf agent-bom-airgap-0.88.5-linux_amd64.tar.gz
-cd agent-bom-airgap-0.88.5-linux_amd64
+tar -xzf agent-bom-airgap-0.88.6-linux_amd64.tar.gz
+cd agent-bom-airgap-0.88.6-linux_amd64
 ./load-images.sh
 ```
 
@@ -47,7 +47,7 @@ The loader verifies archive checksums before running `docker load`.
 ## Push To An Internal Registry
 
 ```bash
-VERSION=0.88.5
+VERSION=0.88.6
 REGISTRY=registry.internal.example.com/security
 
 docker tag "agentbom/agent-bom:${VERSION}" "${REGISTRY}/agent-bom:${VERSION}"
@@ -62,13 +62,13 @@ Then point Helm at the internal registry:
 ```yaml
 image:
   repository: registry.internal.example.com/security/agent-bom
-  tag: "0.88.5"
+  tag: "0.88.6"
 
 controlPlane:
   ui:
     image:
       repository: registry.internal.example.com/security/agent-bom-ui
-      tag: "0.88.5"
+      tag: "0.88.6"
 ```
 
 ## GitHub Actions Bundle Job

--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -332,8 +332,8 @@ through a managed tap instead of direct package upload.
 
 ```bash
 python3 scripts/render_homebrew_formula.py \
-  --version 0.88.5 \
-  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.88.5.tar.gz \
+  --version 0.88.6 \
+  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.88.6.tar.gz \
   --sha256 <release-sha256>
 ```
 

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -171,7 +171,7 @@ Install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.88.5 \
+  --version 0.88.6 \
   -n agent-bom --create-namespace \
   -f values.agent-bom.yaml
 ```
@@ -207,7 +207,7 @@ Then install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.88.5 \
+  --version 0.88.6 \
   -n agent-bom --create-namespace \
   -f deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
 ```

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -90,10 +90,10 @@ docker run --rm \
 ## Runtime proxy against a remote MCP endpoint
 
 ```bash
-docker pull agentbom/agent-bom:0.88.5
+docker pull agentbom/agent-bom:0.88.6
 docker run --rm -i \
   -v ./audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.88.5 \
+  agentbom/agent-bom:0.88.6 \
   proxy \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \

--- a/site-docs/features/policy.md
+++ b/site-docs/features/policy.md
@@ -49,7 +49,7 @@ agent-bom proxy --policy policy.json --block-undeclared -- ...
 
 ```yaml
 - name: Security gate
-  uses: msaad00/agent-bom@v0.88.5
+  uses: msaad00/agent-bom@v0.88.6
   with:
     policy: policy.json
     fail-on-violation: true

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -46,7 +46,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 | **Local AI BOM** | `agent-bom agents --demo --offline` | terminal findings and graph-ready inventory |
 | **Repository scan** | `agent-bom agents -p . -f html -o agent-bom-report.html` | local HTML review plus exportable evidence |
 | **Cloud posture gate** | `agent-bom iac infra/ && agent-bom cis-benchmark --provider aws` | pre-cloud IaC findings plus live posture evidence |
-| **CI evidence** | `uses: msaad00/agent-bom@v0.88.5` | SARIF, pull-request summary, optional code scanning |
+| **CI evidence** | `uses: msaad00/agent-bom@v0.88.6` | SARIF, pull-request summary, optional code scanning |
 | **Assistant tools** | `agent-bom mcp server` | read-mostly security tools for MCP clients |
 | **Self-hosted control plane** | `docker compose -f docker-compose.pilot.yml up -d` | API and dashboard in your infrastructure |
 

--- a/site-docs/reference/remediate-output.md
+++ b/site-docs/reference/remediate-output.md
@@ -45,7 +45,7 @@ remediation remain advisory/manual in this command.
 
 ```json
 {
-  "version": "0.88.5",
+  "version": "0.88.6",
   "generated_at": "2026-04-21T12:00:00+00:00",
   "remediation_plan": [],
   "summary": {

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.88.5"
+    __version__ = "0.88.6"
 
 # Cross-check against pyproject.toml for dev installs where the editable
 # install metadata may be stale (i.e. version bumped but not re-installed).

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.88.5",
+  "version": "0.88.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.88.5",
+      "version": "0.88.6",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
         "@tanstack/react-table": "^8.21.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.88.5",
+  "version": "0.88.6",
   "private": true,
   "packageManager": "npm@10.9.7",
   "engines": {

--- a/ui/scripts/capture-product-proof.mjs
+++ b/ui/scripts/capture-product-proof.mjs
@@ -65,7 +65,7 @@ function buildGraph() {
     node("provider:aws-prod", "provider", "AWS prod account", "medium", 5.4, { environment: "prod", owner: "cloud-platform" }),
     node("env:prod-ai", "environment", "prod-ai-control-plane", "high", 7.8, { environment: "prod", owner: "ai-platform" }),
     node("cluster:eks-ai", "cluster", "eks-ai-runtime", "high", 7.5, { environment: "prod", owner: "platform-security" }),
-    node("container:agent-gateway", "container", "agent-gateway:0.88.5", "high", 7.6, { image: "agent-bom/gateway:0.88.5" }),
+    node("container:agent-gateway", "container", "agent-gateway:0.88.6", "high", 7.6, { image: "agent-bom/gateway:0.88.6" }),
     node("agent:developer-copilot", "agent", "developer-copilot", "critical", 9.4, { agent_type: "ide", owner: "platform-security", environment: "prod" }),
     node("agent:sre-runbook", "agent", "sre-runbook-agent", "high", 8.6, { agent_type: "runbook", owner: "sre", environment: "prod" }),
     node("agent:finance-rag", "agent", "finance-rag-agent", "high", 8.2, { agent_type: "rag", owner: "finance-data", environment: "prod" }),

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/lib/api', () => ({
       scan_sources: [],
       scan_count: 0,
     }),
-    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.88.5' }),
+    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.88.6' }),
   },
 }))
 

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,7 @@ overrides = [
 
 [[package]]
 name = "agent-bom"
-version = "0.88.5"
+version = "0.88.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Prepare v0.88.6 across Python, UI, Docker, Helm, OpenClaw, Glama, MCP Registry, docs, OpenAPI, and screenshot metadata surfaces.
- Fix CodeQL alert #1741 by replacing the privileged `workflow_run` deploy path with a trusted release `workflow_call` plus exact semver tag, tag-SHA, and package-version checks before Railway deployment.
- Refresh the legacy `agent-bom-scheduled` SARIF category from the current self-scan workflow and make OpenAPI export deterministic across local/test auth environments.

## Verification
- YAML parse check for `.github/workflows/deploy-mcp-sse.yml`, `.github/workflows/release.yml`, `.github/workflows/post-merge-self-scan.yml`
- `uv run --extra api python scripts/check_release_consistency.py`
- `uv run --extra api python scripts/export_openapi.py --check`
- `AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1 /opt/homebrew/Caskroom/miniconda/base/bin/python3.13 scripts/export_openapi.py --check`
- `python scripts/bump-version.py 0.88.6 --check`
- `git diff --check`
- `uv run --extra api pytest -q tests/test_openapi_artifact.py`
- `docker run --rm -v "$PWD":/work -w /work node:24-bookworm sh -lc 'npm install -g npm@10.9.7 >/tmp/npm-install.log && npm run verify:toolchain'`\n- Commit hooks passed: YAML/JSON/TOML, ruff, ruff-format, mypy, bandit, env-var drift, duplicate artifact guard\n\n## Notes\n- No tag was created and no release was published by this PR.\n- A full `uv run pytest -q` run was attempted before the final OpenAPI determinism fix, ran too long, showed partial failures, and was stopped; PR CI should be treated as the full-suite gate.\n