### PR TITLE
fix(graph): render the estate instead of collapsing it under default filters

### DIFF
--- a/scripts/seed_graph_showcase.py
+++ b/scripts/seed_graph_showcase.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Seed a dense, realistic agentic-estate graph for UI screenshots / demos.
+
+Builds a multi-cloud estate that exercises every attack-path class the graph
+can derive — vuln-anchored chains, internet exposure (port-aware), toxic
+exposed+vulnerable, path-to-sensitive-data, and privilege escalation to admin —
+then runs the real CNAPP, effective-permission, and governance overlays so the
+graph the API serves is identical to a real scan's. Save it into a graph DB and
+point ``agent-bom api`` at the same DB (``AGENT_BOM_GRAPH_DB``).
+
+    python scripts/seed_graph_showcase.py --sqlite-db /tmp/showcase-graph.db
+    AGENT_BOM_GRAPH_DB=/tmp/showcase-graph.db agent-bom api
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from agent_bom.api.agent_identity_store import (  # noqa: E402
+    InMemoryAgentIdentityStore,
+    issue_identity,
+    issue_jit_grant,
+)
+from agent_bom.api.graph_store import SQLiteGraphStore  # noqa: E402
+from agent_bom.graph.cnapp_overlay import apply_cnapp_overlay  # noqa: E402
+from agent_bom.graph.container import UnifiedGraph  # noqa: E402
+from agent_bom.graph.edge import UnifiedEdge  # noqa: E402
+from agent_bom.graph.effective_permissions import apply_effective_permissions  # noqa: E402
+from agent_bom.graph.governance_overlay import apply_governance_overlay  # noqa: E402
+from agent_bom.graph.node import UnifiedNode  # noqa: E402
+from agent_bom.graph.types import EntityType, RelationshipType  # noqa: E402
+
+TENANT = "default"
+SCAN_ID = "showcase"
+
+
+class _DriftIncident:
+    """Shape the governance overlay expects (attribute access)."""
+
+    def __init__(self, *, incident_id, blueprint_id, drift_score, violation_count, top_violations):
+        self.incident_id = incident_id
+        self.blueprint_id = blueprint_id
+        self.drift_score = drift_score
+        self.violation_count = violation_count
+        self.occurrences = violation_count
+        self.status = "open"
+        self.top_violations = top_violations
+
+
+class _DriftStore:
+    """Minimal drift store projecting behavioral-drift incidents."""
+
+    def __init__(self, incidents: list[_DriftIncident]) -> None:
+        self._incidents = incidents
+
+    def list(self, *_a, **_k) -> list[_DriftIncident]:
+        return list(self._incidents)
+
+
+def _build_estate() -> tuple[UnifiedGraph, InMemoryAgentIdentityStore, _DriftStore]:
+    g = UnifiedGraph(scan_id=SCAN_ID, tenant_id=TENANT)
+
+    def node(i: str, t: EntityType, label: str, **attrs) -> str:
+        # severity / risk_score are top-level node fields (severity_id derives
+        # from severity); everything else is an attribute.
+        severity = attrs.pop("severity", "")
+        risk_score = attrs.pop("risk_score", 0.0)
+        g.add_node(
+            UnifiedNode(
+                id=i,
+                entity_type=t,
+                label=label,
+                severity=severity,
+                risk_score=risk_score,
+                attributes=attrs,
+            )
+        )
+        return i
+
+    def edge(s: str, d: str, r: RelationshipType, **kw) -> None:
+        g.add_edge(UnifiedEdge(source=s, target=d, relationship=r, **kw))
+
+    # ── Agents (the fleet) ──────────────────────────────────────────────
+    agents = {
+        "billing-agent": "Billing Copilot",
+        "support-agent": "Support Copilot",
+        "data-pipeline-agent": "Data Pipeline Agent",
+        "devops-agent": "DevOps Agent",
+        "analytics-agent": "Analytics Agent",
+    }
+    for aid, label in agents.items():
+        node(f"agent:{aid}", EntityType.AGENT, label, environment="production")
+
+    # ── MCP servers + tools + packages + CVEs (supply-chain depth) ──────
+    servers = {
+        "mcp-fs": ("billing-agent", ["read_file", "write_file", "run_shell"]),
+        "mcp-db": ("data-pipeline-agent", ["sql_query", "sql_exec"]),
+        "mcp-http": ("support-agent", ["http_get", "http_post"]),
+        "mcp-deploy": ("devops-agent", ["deploy", "rollback", "exec_remote"]),
+        "mcp-warehouse": ("analytics-agent", ["query_warehouse"]),
+    }
+    for sid, (owner, tools) in servers.items():
+        node(f"server:{sid}", EntityType.SERVER, sid)
+        edge(f"agent:{owner}", f"server:{sid}", RelationshipType.USES)
+        for tname in tools:
+            tid = f"tool:{sid}:{tname}"
+            node(tid, EntityType.TOOL, tname)
+            edge(f"server:{sid}", tid, RelationshipType.PROVIDES_TOOL)
+
+    # Vulnerable packages anchoring real CVE chains.
+    pkgs = {
+        "express@4.17.1": ("mcp-http", "CVE-2024-29041", "critical", 9.3),
+        "pyyaml@5.3": ("mcp-db", "CVE-2020-14343", "critical", 9.8),
+        "requests@2.19.0": ("mcp-fs", "CVE-2023-32681", "high", 7.5),
+        "log4j@2.14.0": ("mcp-deploy", "CVE-2021-44228", "critical", 10.0),
+        "pillow@9.0.0": ("mcp-warehouse", "CVE-2022-22817", "high", 8.1),
+    }
+    for purl, (sid, cve, sev, score) in pkgs.items():
+        pid = f"pkg:{purl}"
+        node(pid, EntityType.PACKAGE, purl)
+        edge(f"server:{sid}", pid, RelationshipType.DEPENDS_ON)
+        vid = f"vuln:{cve}"
+        node(vid, EntityType.VULNERABILITY, cve, severity=sev, risk_score=score)
+        edge(pid, vid, RelationshipType.VULNERABLE_TO)
+
+    # Exposed credentials on the most privileged server.
+    node("cred:aws-key", EntityType.CREDENTIAL, "AWS_SECRET_ACCESS_KEY")
+    edge("server:mcp-deploy", "cred:aws-key", RelationshipType.EXPOSES_CRED)
+
+    # ── Runtime-observed activity (confirmed reachability) ──────────────
+    for i, (aid, tid) in enumerate(
+        [
+            ("billing-agent", "tool:mcp-fs:run_shell"),
+            ("data-pipeline-agent", "tool:mcp-db:sql_exec"),
+            ("devops-agent", "tool:mcp-deploy:exec_remote"),
+        ]
+    ):
+        cid = f"call:{i}"
+        node(cid, EntityType.TOOL_CALL, "observed invocation")
+        edge(f"agent:{aid}", cid, RelationshipType.INVOKED)
+        edge(cid, tid, RelationshipType.INVOKED)
+
+    # ── Cloud estate: crown-jewel data + exposure + misconfig ───────────
+    # Crown jewel: customer-PII S3 bucket that is BOTH public AND vulnerable.
+    node(
+        "cloud:pii-bucket",
+        EntityType.CLOUD_RESOURCE,
+        "customer-pii-prod (S3)",
+        resource_type="s3",
+        compliance_tags=["PII", "GDPR"],
+    )
+    node("mc:pii-public", EntityType.MISCONFIGURATION, "S3 bucket customer-pii-prod is publicly readable")
+    node("vuln:bucket-acl", EntityType.VULNERABILITY, "CVE-2024-S3ACL", severity="high", risk_score=8.2)
+    edge("mc:pii-public", "cloud:pii-bucket", RelationshipType.AFFECTS)
+    edge("cloud:pii-bucket", "vuln:bucket-acl", RelationshipType.VULNERABLE_TO)
+
+    # Payments DB: sensitive RDS instance.
+    node(
+        "cloud:payments-db",
+        EntityType.CLOUD_RESOURCE,
+        "payments-db (RDS PostgreSQL)",
+        resource_type="rds",
+        compliance_tags=["PCI", "financial"],
+    )
+
+    # Internet-exposed bastion EC2 on port 22 (structured network_exposure).
+    node("cloud:bastion", EntityType.CLOUD_RESOURCE, "prod-bastion (EC2)", resource_type="ec2")
+    node(
+        "mc:sg-open",
+        EntityType.MISCONFIGURATION,
+        "Security group sg-prod allows 0.0.0.0/0 on port 22",
+        network_exposure=[{"resource": "prod-bastion", "from_port": 22, "to_port": 22, "protocol": "tcp", "scope": "internet"}],
+    )
+    edge("mc:sg-open", "cloud:bastion", RelationshipType.AFFECTS)
+
+    # Logs bucket (non-sensitive, for contrast).
+    node("cloud:logs-bucket", EntityType.CLOUD_RESOURCE, "app-logs (S3)", resource_type="s3")
+
+    # ── IAM: users, roles, policies, trust chains (privilege escalation) ─
+    node("user:alice", EntityType.USER, "alice@corp (developer)")
+    node("user:bob", EntityType.USER, "bob@contractor (external)")
+    node("role:prod-admin", EntityType.ROLE, "prod-admin-role")
+    node("role:data-pipeline", EntityType.ROLE, "data-pipeline-role")
+    node("role:readonly", EntityType.ROLE, "readonly-role")
+    # Benign-named custom policy that actually grants iam:* (action-level admin).
+    node("pol:admin", EntityType.POLICY, "AdministratorAccess", privilege_level="admin")
+    node("pol:team-custom", EntityType.POLICY, "team-utility-policy", privilege_level="admin")
+    node("pol:s3-write", EntityType.POLICY, "s3-write-policy", privilege_level="write")
+    node("pol:readonly", EntityType.POLICY, "ViewOnlyAccess", privilege_level="read")
+
+    edge("role:prod-admin", "pol:admin", RelationshipType.ATTACHED)
+    edge("role:data-pipeline", "pol:team-custom", RelationshipType.ATTACHED)  # benign name, admin actions
+    edge("role:data-pipeline", "pol:s3-write", RelationshipType.ATTACHED)
+    edge("role:readonly", "pol:readonly", RelationshipType.ATTACHED)
+
+    # alice (dev) can assume prod-admin → privilege escalation to admin.
+    edge("user:alice", "role:prod-admin", RelationshipType.TRUSTS)
+    # bob (external contractor) can assume data-pipeline role (admin-action custom policy).
+    edge("user:bob", "role:data-pipeline", RelationshipType.TRUSTS)
+
+    # What the roles can reach (direct access edges → effective permissions).
+    edge("role:prod-admin", "cloud:pii-bucket", RelationshipType.CAN_ACCESS)
+    edge("role:prod-admin", "cloud:payments-db", RelationshipType.CAN_ACCESS)
+    edge("role:prod-admin", "cloud:bastion", RelationshipType.CAN_ACCESS)
+    edge("role:data-pipeline", "cloud:payments-db", RelationshipType.CAN_ACCESS)
+    edge("role:data-pipeline", "cloud:logs-bucket", RelationshipType.CAN_ACCESS)
+    edge("role:readonly", "cloud:logs-bucket", RelationshipType.CAN_ACCESS)
+
+    # Agents bind to managed identities / roles (governance label-match).
+    edge("agent:devops-agent", "role:prod-admin", RelationshipType.CAN_ACCESS)
+    edge("agent:data-pipeline-agent", "role:data-pipeline", RelationshipType.CAN_ACCESS)
+
+    # ── Governance: managed identities, JIT grants, drift ───────────────
+    store = InMemoryAgentIdentityStore()
+    for aid, label in agents.items():
+        idn, _ = issue_identity(store, agent_id=label, tenant_id=TENANT, allowed_tools=[])
+        # One over-broad JIT grant per privileged agent.
+        if aid in ("billing-agent", "devops-agent", "data-pipeline-agent"):
+            issue_jit_grant(
+                store,
+                identity_id=idn.identity_id,
+                agent_id=label,
+                tenant_id=TENANT,
+                tool_name="run_shell" if aid == "billing-agent" else "exec_remote",
+                ttl_seconds=3600,
+                approved_by="oncall@corp",
+            )
+
+    drift = _DriftStore(
+        [
+            _DriftIncident(
+                incident_id="drift-001",
+                blueprint_id="DevOps Agent",
+                drift_score=0.78,
+                violation_count=14,
+                top_violations=[{"tool_name": "exec_remote"}],
+            ),
+            _DriftIncident(
+                incident_id="drift-002",
+                blueprint_id="Billing Copilot",
+                drift_score=0.41,
+                violation_count=5,
+                top_violations=[{"tool_name": "run_shell"}],
+            ),
+        ]
+    )
+    return g, store, drift
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--sqlite-db", default="/tmp/showcase-graph.db", help="Graph DB path to seed")
+    args = ap.parse_args()
+
+    g, store, drift = _build_estate()
+
+    cnapp = apply_cnapp_overlay(g)
+    eff = apply_effective_permissions(g)
+    gov = apply_governance_overlay(g, tenant_id=TENANT, identity_store=store, drift_store=drift)
+
+    db_path = Path(args.sqlite_db).expanduser()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    graph_store = SQLiteGraphStore(db_path)
+    graph_store.save_graph(g)
+
+    print(f"Seeded {len(g.nodes)} nodes / {len(g.edges)} edges → {db_path}")
+    print(f"  cnapp:  {cnapp}")
+    print(f"  effperm:{eff}")
+    print(f"  gov:    {gov}")
+    print(f"  risks:  {len(g.interaction_risks)} interaction risks")
+    print(f"\nBoot the API against it:\n  AGENT_BOM_GRAPH_DB={db_path} agent-bom api")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -19,6 +19,32 @@ from typing import Any, Protocol
 
 from agent_bom.db import graph_store as sqlite_graph_store
 from agent_bom.graph import AttackPath, EntityType, NodeDimensions, NodeStatus, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
+from agent_bom.graph.ocsf import FINDING_ENTITY_TYPES
+
+# Only finding-like nodes (vulnerabilities, misconfigurations, drift) carry a
+# severity; a `min_severity` filter must narrow those findings without dropping
+# the topology/context nodes around them (agents, servers, resources, identities
+# all have rank 0). Matches the in-memory ``filtered_view`` / ``_node_matches_query``
+# behaviour so the SQL paging path and the in-memory path agree.
+_FINDING_ENTITY_VALUES: tuple[str, ...] = tuple(sorted(t.value for t in FINDING_ENTITY_TYPES))
+
+
+def _min_severity_clause(
+    min_severity_rank: int,
+    *,
+    column: str = "severity_id",
+    entity_column: str = "entity_type",
+) -> tuple[str, list[Any]]:
+    """Build a severity-floor WHERE fragment that exempts non-finding nodes.
+
+    Returns ``(sql, params)``; ``sql`` is empty when no floor is requested.
+    """
+    if not min_severity_rank:
+        return "", []
+    placeholders = ",".join("?" for _ in _FINDING_ENTITY_VALUES)
+    sql = f"({column} >= ? OR {entity_column} NOT IN ({placeholders}))"
+    return sql, [min_severity_rank, *_FINDING_ENTITY_VALUES]
+
 
 _CREATE_PRESET_TABLE_SQLITE = """\
 CREATE TABLE IF NOT EXISTS graph_filter_presets (
@@ -1179,9 +1205,10 @@ class SQLiteGraphStore:
                 placeholders = ",".join("?" for _ in entity_types)
                 node_where.append(f"entity_type IN ({placeholders})")
                 params.extend(sorted(entity_types))
-            if min_severity_rank:
-                node_where.append("severity_id >= ?")
-                params.append(min_severity_rank)
+            sev_sql, sev_params = _min_severity_clause(min_severity_rank)
+            if sev_sql:
+                node_where.append(sev_sql)
+                params.extend(sev_params)
             where_sql = " AND ".join(node_where)
 
             total_nodes = conn.execute(
@@ -1264,9 +1291,10 @@ class SQLiteGraphStore:
                 placeholders = ",".join("?" for _ in entity_types)
                 where.append(f"entity_type IN ({placeholders})")
                 params.extend(sorted(entity_types))
-            if min_severity_rank:
-                where.append("severity_id >= ?")
-                params.append(min_severity_rank)
+            sev_sql, sev_params = _min_severity_clause(min_severity_rank)
+            if sev_sql:
+                where.append(sev_sql)
+                params.extend(sev_params)
             where_sql = " AND ".join(where)
             total = int(
                 conn.execute(
@@ -1387,9 +1415,10 @@ class SQLiteGraphStore:
                     placeholders = ",".join("?" for _ in entity_types)
                     local_where.append(f"gn.entity_type IN ({placeholders})")
                     local_params.extend(sorted(entity_types))
-                if min_severity_rank:
-                    local_where.append("gn.severity_id >= ?")
-                    local_params.append(min_severity_rank)
+                sev_sql, sev_params = _min_severity_clause(min_severity_rank, column="gn.severity_id", entity_column="gn.entity_type")
+                if sev_sql:
+                    local_where.append(sev_sql)
+                    local_params.extend(sev_params)
                 if compliance_prefixes:
                     prefix_filters = []
                     for prefix in sorted(compliance_prefixes):

--- a/tests/test_graph_min_severity_topology.py
+++ b/tests/test_graph_min_severity_topology.py
@@ -1,0 +1,71 @@
+"""A `min_severity` floor must narrow findings without dropping topology.
+
+Only finding-like nodes (vulnerabilities, misconfigurations, drift incidents)
+carry a severity. A severity floor should drop the low-severity findings while
+keeping the context graph around them — agents, servers, packages, resources,
+identities — so the operator still sees the paths that lead to the high-severity
+findings instead of a scatter of disconnected dots. Regression guard for the
+SQL paging/stats path, which previously applied ``severity_id >= floor`` to
+every node and collapsed a populated estate to a single node.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_bom.api.graph_store import SQLiteGraphStore
+from agent_bom.graph import EntityType, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
+
+
+def _estate(scan_id: str = "sev-topo") -> UnifiedGraph:
+    g = UnifiedGraph(scan_id=scan_id, tenant_id="default")
+    g.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="billing-agent"))
+    g.add_node(UnifiedNode(id="server:fs", entity_type=EntityType.SERVER, label="mcp-fs"))
+    g.add_node(UnifiedNode(id="pkg:express", entity_type=EntityType.PACKAGE, label="express@4"))
+    g.add_node(UnifiedNode(id="cloud:bucket", entity_type=EntityType.CLOUD_RESOURCE, label="pii-bucket"))
+    # findings carry severity
+    g.add_node(UnifiedNode(id="vuln:crit", entity_type=EntityType.VULNERABILITY, label="CVE-CRIT", severity="critical", risk_score=9.5))
+    g.add_node(UnifiedNode(id="vuln:low", entity_type=EntityType.VULNERABILITY, label="CVE-LOW", severity="low", risk_score=2.0))
+    g.add_edge(UnifiedEdge(source="agent:a", target="server:fs", relationship=RelationshipType.USES))
+    g.add_edge(UnifiedEdge(source="server:fs", target="pkg:express", relationship=RelationshipType.DEPENDS_ON))
+    g.add_edge(UnifiedEdge(source="pkg:express", target="vuln:crit", relationship=RelationshipType.VULNERABLE_TO))
+    g.add_edge(UnifiedEdge(source="pkg:express", target="vuln:low", relationship=RelationshipType.VULNERABLE_TO))
+    return g
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> SQLiteGraphStore:
+    s = SQLiteGraphStore(tmp_path / "graph.db")
+    s.save_graph(_estate())
+    return s
+
+
+def test_page_nodes_keeps_topology_above_severity_floor(store: SQLiteGraphStore):
+    # high floor (rank 4) — keep the critical finding, drop the low one,
+    # keep every non-finding context node.
+    _scan, _created, nodes, total, _cursor = store.page_nodes(tenant_id="default", min_severity_rank=4, limit=100)
+    ids = {n.id for n in nodes}
+    assert total == len(nodes)
+    # topology preserved
+    assert {"agent:a", "server:fs", "pkg:express", "cloud:bucket"} <= ids
+    # high-severity finding kept, low-severity finding dropped
+    assert "vuln:crit" in ids
+    assert "vuln:low" not in ids
+
+
+def test_page_nodes_no_floor_returns_everything(store: SQLiteGraphStore):
+    _scan, _created, nodes, _total, _cursor = store.page_nodes(tenant_id="default", min_severity_rank=0, limit=100)
+    assert {"vuln:crit", "vuln:low"} <= {n.id for n in nodes}
+
+
+def test_snapshot_stats_reflect_topology_under_floor(store: SQLiteGraphStore):
+    stats = store.snapshot_stats(tenant_id="default", min_severity_rank=4)
+    node_types = stats["node_types"]
+    # context node types survive the floor
+    assert node_types.get("agent") == 1
+    assert node_types.get("server") == 1
+    assert node_types.get("cloud_resource") == 1
+    # only the high-severity finding remains
+    assert node_types.get("vulnerability") == 1

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -905,7 +905,14 @@ function GraphPageInner() {
     setHoveredNodeId(null);
   }, [graphIdentityKey]);
 
-  const graphLayoutKind = filters.agentName || filters.vulnOnly || selectedAttackPath ? "dagre-lr" : "force";
+  // The unified security graph is DAG-shaped (provider/identity → agent →
+  // server → tool/package → finding, and user → role → resource). A
+  // left-to-right hierarchical layout reads as blast-radius flow and never
+  // overlaps nodes; the force layout piled siblings on top of each other on
+  // the broad estate view. Large graphs switch to the WebGL/overview
+  // renderers upstream, so ReactFlow only ever lays out small/medium graphs
+  // where dagre is the better fit.
+  const graphLayoutKind = "dagre-lr";
   const { nodes: layoutNodes, edges: layoutEdges } = useGraphLayout(graphLayoutKind, aggregated.nodes, aggregated.edges, {
     force: {
       idealEdgeLength: filters.agentName ? 168 : 196,

--- a/ui/lib/filter-algebra.ts
+++ b/ui/lib/filter-algebra.ts
@@ -179,12 +179,67 @@ function layerPasses(node: UnifiedNode, layers: Record<LineageNodeType, boolean>
   return Boolean(layers[layer]);
 }
 
-function vulnOnlyPasses(node: UnifiedNode, vulnOnly: boolean): boolean {
+/**
+ * "Vulnerable-only" means *vulnerability-bearing paths*, not bare
+ * vulnerability dots. A node passes when it is a vulnerability /
+ * misconfiguration itself, or it sits on a path connected to one — i.e.
+ * it shares a connected component with a vulnerability over the active
+ * edge subset. Keeping the agent → server → package → CVE chain (and the
+ * misconfig → resource → identity chains) is what makes fix-first mode
+ * legible instead of a scatter of disconnected findings.
+ */
+function vulnOnlyPasses(
+  node: UnifiedNode,
+  vulnOnly: boolean,
+  vulnReach: Set<string> | null,
+): boolean {
   if (!vulnOnly) return true;
-  return (
+  if (
     node.entity_type === EntityType.VULNERABILITY ||
     node.entity_type === EntityType.MISCONFIGURATION
+  ) {
+    return true;
+  }
+  return vulnReach?.has(node.id) ?? false;
+}
+
+/**
+ * Node IDs that share a connected component with a vulnerability or
+ * misconfiguration over the given edges (undirected). Computed once per
+ * filter pass when vuln-only is active.
+ */
+function buildVulnReachSet(nodes: UnifiedNode[], edges: UnifiedEdge[]): Set<string> {
+  const reach = new Set<string>();
+  const seeds = nodes.filter(
+    (n) =>
+      n.entity_type === EntityType.VULNERABILITY ||
+      n.entity_type === EntityType.MISCONFIGURATION,
   );
+  if (seeds.length === 0) return reach;
+  const adj = new Map<string, Set<string>>();
+  for (const e of edges) {
+    if (!adj.has(e.source)) adj.set(e.source, new Set());
+    if (!adj.has(e.target)) adj.set(e.target, new Set());
+    adj.get(e.source)!.add(e.target);
+    adj.get(e.target)!.add(e.source);
+  }
+  const queue: string[] = [];
+  for (const s of seeds) {
+    if (!reach.has(s.id)) {
+      reach.add(s.id);
+      queue.push(s.id);
+    }
+  }
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    for (const neighbor of adj.get(current) ?? []) {
+      if (!reach.has(neighbor)) {
+        reach.add(neighbor);
+        queue.push(neighbor);
+      }
+    }
+  }
+  return reach;
 }
 
 function relationshipScopePasses(
@@ -304,10 +359,11 @@ function passNodes(
   opts: FilterPassOptions,
 ): { nodes: UnifiedNode[]; reachIndex: ReachIndex } {
   const reachIndex = buildAgentReachIndex(nodes, edgeSubset, filters.maxDepth);
+  const vulnReach = filters.vulnOnly ? buildVulnReachSet(nodes, edgeSubset) : null;
   const filtered = nodes.filter((n) => {
     if (!opts.skipLayer && !layerPasses(n, filters.layers)) return false;
     if (!opts.skipSeverity && !severityPasses(n, filters.severity)) return false;
-    if (!vulnOnlyPasses(n, filters.vulnOnly)) return false;
+    if (!vulnOnlyPasses(n, filters.vulnOnly, vulnReach)) return false;
     if (!opts.skipAgent && !nodeIsInAgentNeighborhood(n, filters.agentName, reachIndex)) {
       return false;
     }

--- a/ui/tests/filter-algebra.test.ts
+++ b/ui/tests/filter-algebra.test.ts
@@ -214,6 +214,25 @@ describe("applyFilters — constraint propagation", () => {
     });
   });
 
+  it("[1b] vulnOnly → keeps vulnerability-bearing paths, drops clean subgraphs", () => {
+    // Components A and B each contain a CVE, so their full chains
+    // (agent → server → package/tool/cred → CVE) survive. Component C has
+    // no vulnerability at all, so it drops entirely — not just its leaves.
+    const filters: FilterState = { ...wideFilters(), vulnOnly: true };
+    const result = applyFilters(graph, filters);
+    const ids = new Set(result.nodes.map((n) => n.id));
+    // both CVEs and their reaching context
+    expect(ids).toContain("cve-1");
+    expect(ids).toContain("cve-2");
+    expect(ids).toContain("agent-A");
+    expect(ids).toContain("server-B");
+    expect(ids).toContain("pkg-A2"); // sibling package on a vulnerable server stays on the path
+    // the entire clean component C is gone
+    for (const id of ["agent-C", "server-C", "pkg-C1", "pkg-C2", "tool-C", "cred-C"]) {
+      expect(ids.has(id)).toBe(false);
+    }
+  });
+
   it("[2] severity=critical only → only critical-pass nodes; agents narrowed", () => {
     const filters: FilterState = { ...wideFilters(), severity: "critical" };
     const result = applyFilters(graph, filters);


### PR DESCRIPTION
## Problem

Opening the security graph on a populated estate landed on **No nodes match the current graph scope** and the header stat chips read `0 agents / 0 servers / 0 findings`. The data was present and the API served it — three filter paths were discarding the topology instead of narrowing the findings inside it.

## Fixes

**1. `min_severity` preserved the floor but dropped the topology (backend)**
The SQL paging and snapshot-stats paths applied `severity_id >= floor` to *every* node. Only finding-like nodes carry a severity; agents, servers, resources, and identities are rank 0, so a `high` floor collapsed the whole estate to the single highest-severity finding. The floor now exempts non-finding entity types via a shared `_min_severity_clause`, matching the in-memory `filtered_view` / `_node_matches_query` semantics. The floor narrows findings; the context graph survives.

**2. "Vulnerable only" kept bare findings, not paths (UI)**
`vulnOnlyPasses` kept only `VULNERABILITY` / `MISCONFIGURATION` nodes — a scatter of disconnected dots with the connecting `agent → server → package → CVE` chain stripped out. It now keeps the **vulnerability-bearing paths**: the connected component containing a finding. Matches the "Limit the graph to vulnerability-bearing paths" tooltip.

**3. Force layout overlapped nodes on the broad view (UI)**
The estate view used a force layout that piled sibling nodes on top of each other. The unified graph is DAG-shaped (provider/identity → agent → server → tool/package → finding, user → role → resource), so it now uses the left-to-right hierarchical (dagre) layout that reads as blast-radius flow and never overlaps. Large graphs still switch to the WebGL / large-overview renderers upstream, so ReactFlow only ever lays out small/medium graphs.

## Tooling

- `scripts/seed_graph_showcase.py` — seeds a dense multi-cloud agentic estate (64 nodes / 80 edges) that exercises every attack-path class (vuln-anchored, internet-exposed-on-port, exposed+vulnerable, path-to-sensitive-data, privilege-escalation-to-admin, runtime-observed) into a graph DB for demos and screenshots: `AGENT_BOM_GRAPH_DB=… agent-bom api`.

## Tests

- `tests/test_graph_min_severity_topology.py` — the severity floor keeps the context graph and the high-severity finding while dropping low-severity findings, across `page_nodes` and `snapshot_stats`.
- `ui/tests/filter-algebra.test.ts` `[1b]` — vuln-only keeps both vulnerability-bearing components (including sibling packages on a vulnerable server) and drops the clean component entirely.
- Full graph suite green (82 backend + filter/layout/flow UI specs); ruff, ruff-format, mypy, bandit, tsc all pass.