### PR TITLE
fix(ci): separate legacy SARIF refresh category

### DIFF
--- a/.github/workflows/post-merge-self-scan.yml
+++ b/.github/workflows/post-merge-self-scan.yml
@@ -133,11 +133,26 @@ jobs:
           sarif_file: sarif/self-dep.sarif
           category: agent-bom-self-dep
 
-      - name: Refresh legacy scheduled SARIF category
+      - name: Prepare legacy scheduled SARIF category
         if: always() && hashFiles('sarif/self-dep.sarif') != ''
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          source = Path("sarif/self-dep.sarif")
+          target = Path("sarif/self-dep-scheduled.sarif")
+          data = json.loads(source.read_text())
+          for run in data.get("runs", []):
+              run.setdefault("automationDetails", {})["id"] = "agent-bom-scheduled"
+          target.write_text(json.dumps(data, indent=2) + "\n")
+          PY
+
+      - name: Refresh legacy scheduled SARIF category
+        if: always() && hashFiles('sarif/self-dep-scheduled.sarif') != ''
         uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4
         with:
-          sarif_file: sarif/self-dep.sarif
+          sarif_file: sarif/self-dep-scheduled.sarif
           category: agent-bom-scheduled
 
       - name: Fail on critical (optional, only when explicitly requested)


### PR DESCRIPTION
## Summary
- Rewrites the compatibility SARIF copy with a distinct `runs[].automationDetails.id` before the legacy `agent-bom-scheduled` upload.
- Keeps the primary `agent-bom-self-dep` upload unchanged while allowing the legacy code-scanning category to refresh.
- Fixes the post-merge self-scan failure where GitHub rejected the second upload as the same tool/category.

## Verification
- `python - <<'PY' ... yaml.safe_load(...)`
- `git diff --check`
- commit hooks: check yaml, EOF, whitespace, private key, case conflicts, merge conflicts, mixed line endings, Finder duplicate artifact guard

## Notes
- The README Build badge points at `.github/workflows/ci.yml` on `main`; that run was still in progress when checked, with only Docker multi-arch pending. The separate red workflow was `Post-Merge Self-Scan` step `Refresh legacy scheduled SARIF category`.