### PR TITLE
feat(graph): derive pure broad-scope-identity attack paths

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -777,7 +777,7 @@ def _derived_governance_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
     """Derive attack paths that the governance / CNAPP / effective-permission
     overlays make possible but that are not anchored on a CVE/misconfig finding.
 
-    Surfaces four chains as first-class paths so humans and agents can
+    Surfaces five chains as first-class paths so humans and agents can
     investigate them via /v1/graph/attack-paths and the governance endpoint:
 
     - privilege escalation: principal --HAS_PERMISSION(assume_chain)--> resource
@@ -785,6 +785,8 @@ def _derived_governance_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
       dangerous tool (standing scope or JIT grant)
     - behavioral drift: agent --EXHIBITS_DRIFT--> drift_incident --SCOPED_TO--> tool
     - data exposure: resource --EXPOSED_TO--> internet-exposed data_store
+    - broad-scope identity: agent --AUTHENTICATES_AS--> identity with no per-tool
+      scope (standing access to everything it can reach), no finding anchor needed
     """
     paths: list[AttackPath] = []
     seen: set[tuple[str, str, str]] = set()
@@ -860,6 +862,21 @@ def _derived_governance_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
                             ["authenticates_as", _rel_value(tool_edge)],
                             48.0,
                             f"{node.label} can reach high-capability tool {tool.label} through identity {identity.label}.",
+                        )
+                    # Broad-scope identity: standing access with no per-tool scope.
+                    # This is a posture risk on its own — no vulnerability or
+                    # dangerous-tool anchor required — so surface it as a path even
+                    # when the identity's reachable tools are benign or not yet wired.
+                    if identity.attributes.get("scope_bound") is False:
+                        emit(
+                            "broad_scope_identity",
+                            node.id,
+                            identity.id,
+                            [node.id, identity.id],
+                            ["authenticates_as"],
+                            40.0,
+                            f"{node.label} authenticates as {identity.label}, an identity with no per-tool scope — "
+                            "it holds standing access to every tool it can reach.",
                         )
                 elif _rel_value(id_edge) == RelationshipType.EXHIBITS_DRIFT.value:
                     incident = graph.nodes.get(id_edge.target)

--- a/tests/test_graph_attack_path_e2e.py
+++ b/tests/test_graph_attack_path_e2e.py
@@ -112,3 +112,4 @@ def test_every_attack_path_class_fires_end_to_end():
     summaries = " || ".join(p.summary for p in paths)
     assert "assuming" in summaries  # privilege escalation path
     assert "sensitive" in summaries  # path to sensitive data
+    assert "no per-tool scope" in summaries  # broad-scope identity (pure governance)

--- a/tests/test_graph_governance_attack_paths.py
+++ b/tests/test_graph_governance_attack_paths.py
@@ -64,6 +64,38 @@ def test_over_scoped_tool_and_drift_paths():
     assert drift
 
 
+def test_broad_scope_identity_surfaces_without_dangerous_tool():
+    # An unscoped identity reaching only a benign tool: the old engine surfaced
+    # nothing (no dangerous-tool anchor, no vuln). The broad-scope-identity class
+    # surfaces the standing-access posture risk on its own.
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="reporting-agent"))
+    g.add_node(UnifiedNode(id="id:1", entity_type=EntityType.MANAGED_IDENTITY, label="reporting-agent", attributes={"scope_bound": False}))
+    g.add_node(UnifiedNode(id="tool:read", entity_type=EntityType.TOOL, label="read_report"))  # benign
+    g.add_edge(UnifiedEdge(source="agent:a", target="id:1", relationship=RelationshipType.AUTHENTICATES_AS))
+    g.add_edge(UnifiedEdge(source="id:1", target="tool:read", relationship=RelationshipType.SCOPED_TO))
+
+    paths = _derived_governance_attack_paths(g)
+    # no dangerous-tool path (read_report is benign)
+    assert not any(p.target == "tool:read" for p in paths)
+    # but the broad-scope-identity path surfaces
+    broad = [p for p in paths if p.hops == ["agent:a", "id:1"]]
+    assert broad, "broad-scope identity path should surface"
+    assert "no per-tool scope" in broad[0].summary
+    # base 40 + broad_identity_scope fusion (+8)
+    assert broad[0].composite_risk >= 48
+
+
+def test_scoped_identity_does_not_surface_broad_scope_path():
+    # A scope-bound identity is NOT flagged as broad-scope.
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+    g.add_node(UnifiedNode(id="id:1", entity_type=EntityType.MANAGED_IDENTITY, label="agent-a", attributes={"scope_bound": True}))
+    g.add_edge(UnifiedEdge(source="agent:a", target="id:1", relationship=RelationshipType.AUTHENTICATES_AS))
+    paths = _derived_governance_attack_paths(g)
+    assert not any(p.hops == ["agent:a", "id:1"] for p in paths)
+
+
 def test_governance_paths_merge_into_derived_attack_paths():
     g = UnifiedGraph(scan_id="s", tenant_id="t")
     g.add_node(UnifiedNode(id="user:dev", entity_type=EntityType.USER, label="dev"))


### PR DESCRIPTION
## What

Adds a fifth governance attack-path class to `_derived_governance_attack_paths`: **broad-scope identity** — `agent --AUTHENTICATES_AS--> identity` where the identity has no per-tool scope (`scope_bound=False`).

## Why

The four existing governance classes are all anchored on a concrete exploit step (assume-chain, dangerous tool, drift incident, internet-exposed data store). An identity granted **standing access with no per-tool restriction** surfaced nothing on its own — it only appeared if it happened to reach a tool the engine classified as dangerous. That left the most common over-provisioning posture invisible until it was already exploitable, and it's a core identity-governance signal.

The new class needs no vulnerability or dangerous-tool anchor: the unscoped standing access **is** the finding. Base score 40, lifted by the existing `broad_identity_scope` fusion signal (+8) and any drift / privilege-escalation signals present on the same identity, so a drifted-and-unscoped identity ranks above a merely unscoped one.

The `scope_bound` attribute is already projected by `governance_overlay` (`bool(identity.allowed_tools)`), so no new inputs are required.

## Tests

- `test_broad_scope_identity_surfaces_without_dangerous_tool` — an unscoped identity reaching only a benign tool now surfaces (the old engine surfaced nothing).
- `test_scoped_identity_does_not_surface_broad_scope_path` — a scope-bound identity is not flagged.
- `tests/test_graph_attack_path_e2e.py` — the "every class fires" end-to-end proof now also asserts the broad-scope class derives through the real governance overlay.

91 graph-suite tests pass; ruff / ruff-format / mypy / bandit clean.