### PR TITLE
feat(graph): classify data stores by regulatory regime, not a binary flag

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -831,6 +831,9 @@ def _derived_governance_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
         # Data exposure: internet-exposed resource backing a data store.
         elif rel == RelationshipType.EXPOSED_TO.value and _node_type_value(tgt) == EntityType.DATA_STORE.value:
             sensitive = bool(tgt.attributes.get("data_sensitivity"))
+            frameworks = tgt.attributes.get("data_regulatory_frameworks") or []
+            # Name the regulation at risk when classified (PCI-DSS / HIPAA / GDPR / SOC2).
+            data_descr = f"{'/'.join(frameworks)} data store" if frameworks else f"{'sensitive ' if sensitive else ''}data store"
             emit(
                 "data_exposure",
                 src.id,
@@ -838,7 +841,7 @@ def _derived_governance_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
                 [src.id, tgt.id],
                 ["exposed_to"],
                 70.0 if sensitive else 55.0,
-                f"{src.label} is internet-exposed and backs {'sensitive ' if sensitive else ''}data store {tgt.label}.",
+                f"{src.label} is internet-exposed and backs {data_descr} {tgt.label}.",
             )
 
     # Agent → identity → dangerous tool, and agent → drift incident → tool.

--- a/src/agent_bom/graph/cnapp_overlay.py
+++ b/src/agent_bom/graph/cnapp_overlay.py
@@ -124,6 +124,41 @@ def _is_sensitive(node: UnifiedNode) -> bool:
     return _matches(_sensitive_text(node), _SENSITIVE_KEYWORDS)
 
 
+# Regulatory frameworks inferred from METADATA only (labels, compliance tags,
+# dataset-card flags) — never from data contents. Ordered by remediation
+# severity so the first match names the headline regulation at risk. The first
+# three are high-sensitivity regimes that escalate an exposed store to the
+# "restricted" tier.
+_REGULATORY_FRAMEWORKS: tuple[tuple[str, str, tuple[str, ...]], ...] = (
+    ("PCI-DSS", "card data", ("pci", "credit card", "cardholder", "card data", "bank account")),
+    ("HIPAA", "protected health information", ("phi", "hipaa", "protected health", "health record", "medical record")),
+    (
+        "GDPR",
+        "personal data",
+        ("gdpr", "pii", "personal data", "personally identifiable", "ssn", "social security", "passport", "biometric"),
+    ),
+    ("SOC2", "secrets/credentials", ("secret", "credential", "confidential")),
+)
+_HIGH_SENSITIVITY_FRAMEWORKS = frozenset({"PCI-DSS", "HIPAA", "GDPR"})
+
+
+def _classify_regulatory_frameworks(node: UnifiedNode) -> list[str]:
+    """Regulatory frameworks a data node is subject to, by metadata signals.
+
+    Returns framework codes in remediation-severity order (PCI-DSS, HIPAA,
+    GDPR, SOC2); empty when only the generic ``sensitive`` keyword matched.
+    """
+    text = _sensitive_text(node)
+    return [code for code, _label, kws in _REGULATORY_FRAMEWORKS if _matches(text, kws)]
+
+
+def _framework_label(code: str) -> str:
+    for c, label, _kws in _REGULATORY_FRAMEWORKS:
+        if c == code:
+            return f"{c} {label}"
+    return code
+
+
 def apply_cnapp_overlay(graph: UnifiedGraph) -> dict[str, int]:
     """Enrich ``graph`` with exposure + data-store structure in place.
 
@@ -243,6 +278,15 @@ def apply_cnapp_overlay(graph: UnifiedGraph) -> dict[str, int]:
         backing = graph.nodes.get(node.attributes.get("backed_by", "")) if node.entity_type == EntityType.DATA_STORE else None
         if _is_sensitive(node) or (backing is not None and _is_sensitive(backing)):
             node.attributes["data_sensitivity"] = "sensitive"
+            # Which regulatory regimes govern this store (PCI/HIPAA/GDPR/SOC2),
+            # merged from the store and the resource it backs — metadata only.
+            frameworks = _classify_regulatory_frameworks(node)
+            if backing is not None:
+                for code in _classify_regulatory_frameworks(backing):
+                    if code not in frameworks:
+                        frameworks.append(code)
+            if frameworks:
+                node.attributes["data_regulatory_frameworks"] = frameworks
             sensitive_ids.add(node.id)
 
     # Toxic: sensitive data that is internet-exposed.
@@ -256,12 +300,19 @@ def apply_cnapp_overlay(graph: UnifiedGraph) -> dict[str, int]:
             node.risk_score = 9.5
         node.severity = "high"
         node.status = NodeStatus.VULNERABLE
+        # Exposed + governed by a high-sensitivity regime → "restricted"; an
+        # exposed store with only generic sensitivity → "confidential".
+        frameworks = node.attributes.get("data_regulatory_frameworks") or []
+        node.attributes["data_classification_tier"] = (
+            "restricted" if any(f in _HIGH_SENSITIVITY_FRAMEWORKS for f in frameworks) else "confidential"
+        )
+        regulation = f" ({_framework_label(frameworks[0])})" if frameworks else ""
         graph.interaction_risks.append(
             InteractionRisk(
                 pattern="internet_exposed_sensitive_data",
                 agents=[node.label],
                 risk_score=9.7,
-                description=f"{node.label} holds sensitive data and is internet-exposed (path to sensitive data).",
+                description=f"{node.label} holds sensitive data{regulation} and is internet-exposed (path to sensitive data).",
                 owasp_agentic_tag=None,
             )
         )

--- a/tests/test_graph_attack_path_e2e.py
+++ b/tests/test_graph_attack_path_e2e.py
@@ -111,5 +111,5 @@ def test_every_attack_path_class_fires_end_to_end():
     assert top[0].composite_risk >= 85
     summaries = " || ".join(p.summary for p in paths)
     assert "assuming" in summaries  # privilege escalation path
-    assert "sensitive" in summaries  # path to sensitive data
+    assert "GDPR" in summaries  # path to sensitive data, regulation named (PII → GDPR)
     assert "no per-tool scope" in summaries  # broad-scope identity (pure governance)

--- a/tests/test_graph_data_sensitivity.py
+++ b/tests/test_graph_data_sensitivity.py
@@ -46,17 +46,37 @@ def test_exposed_sensitive_data_store_is_toxic_and_scored():
     assert ds.attributes.get("internet_exposed") is True
     assert ds.attributes.get("toxic_exposed_sensitive") is True
     assert ds.risk_score >= 9.5
-    assert any(r.pattern == "internet_exposed_sensitive_data" for r in g.interaction_risks)
+    # PII → GDPR regime; exposed + high-sensitivity regime → "restricted" tier.
+    assert ds.attributes.get("data_regulatory_frameworks") == ["GDPR"]
+    assert ds.attributes.get("data_classification_tier") == "restricted"
+    risk = next(r for r in g.interaction_risks if r.pattern == "internet_exposed_sensitive_data")
+    assert "GDPR" in risk.description
 
     # fusion signal surfaces on a path through the sensitive-exposed data store
     kinds = {k for k, _l, _d, _b in _fusion_signals_for_path(g, [ds.id])}
     assert "exposed_sensitive_data" in kinds
 
-    # the data-exposure attack path to the sensitive store is top-banded
+    # the data-exposure attack path to the sensitive store names the regulation
     paths = _derived_governance_attack_paths(g)
     data_paths = [p for p in paths if p.target == ds.id]
-    assert data_paths and "sensitive" in data_paths[0].summary
+    assert data_paths and "GDPR" in data_paths[0].summary
     assert data_paths[0].composite_risk >= 85
+
+
+def test_pci_and_soc2_classification_tiers():
+    from agent_bom.graph.cnapp_overlay import _classify_regulatory_frameworks
+
+    pci = UnifiedNode(id="ds:pay", entity_type=EntityType.DATA_STORE, label="payments cardholder vault")
+    assert _classify_regulatory_frameworks(pci) == ["PCI-DSS"]
+    phi = UnifiedNode(id="ds:ehr", entity_type=EntityType.DATA_STORE, label="patient records", compliance_tags=["HIPAA"])
+    assert _classify_regulatory_frameworks(phi) == ["HIPAA"]
+    # generic secrets store → SOC2 only (not a high-sensitivity regime)
+    secrets = UnifiedNode(id="ds:vault", entity_type=EntityType.DATA_STORE, label="app credential store")
+    assert _classify_regulatory_frameworks(secrets) == ["SOC2"]
+    # multi-regime store keeps remediation-severity order
+    both = UnifiedNode(id="ds:mix", entity_type=EntityType.DATA_STORE, label="credit card and personal data export")
+    both_frameworks = _classify_regulatory_frameworks(both)
+    assert both_frameworks[0] == "PCI-DSS" and "GDPR" in both_frameworks
 
 
 def test_non_sensitive_store_not_flagged():


### PR DESCRIPTION
## What

Replaces the single boolean `data_sensitivity="sensitive"` on data stores with a regulatory classification: which regimes a store is subject to (**PCI-DSS, HIPAA, GDPR, SOC2**) plus a `data_classification_tier`.

## Why

Every sensitive data store looked identical — a cardholder vault and a generic confidential bucket produced the same flag and the same attack-path reason, so an operator couldn't tell which regulation was at stake or how to prioritise. Naming the regime is the difference between "a sensitive store is exposed" and "PCI-DSS cardholder data is exposed to the internet."

## How

`cnapp_overlay` classifies each sensitive store from **metadata signals it already gathers** — labels, `compliance_tags`, dataset-card `security_flags` — via `_classify_regulatory_frameworks`. No data contents are ever read (the read-only / no-collection posture is preserved; the classifier reuses the existing `_sensitive_text` metadata blob).

New node attributes:
- `data_regulatory_frameworks` — e.g. `["PCI-DSS", "GDPR"]`, in remediation-severity order
- `data_classification_tier` — `restricted` when an exposed store is governed by a high-sensitivity regime (PCI/HIPAA/GDPR), else `confidential`

The internet-exposed-sensitive interaction risk and the **data-exposure attack-path summary** now name the regulation:

> `payments-db is internet-exposed and backs PCI-DSS data store …`

## Tests

- PII bucket → `["GDPR"]` + `restricted` tier, with `GDPR` named in both the path summary and the risk description.
- PCI / HIPAA / SOC2 classification, and remediation-severity ordering for a multi-regime store (PCI-DSS before GDPR).
- The "every class fires" e2e proof updated to assert the regulation is named.

89 graph-suite tests pass; ruff / ruff-format / mypy / bandit clean. Rebased on main after #2881.