### PR TITLE
fix(gateway): redact policy block reasons

### DIFF
--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -80,6 +80,21 @@ def _sanitize_for_log(value: Any) -> str:
     return str(value).replace("\r", "").replace("\n", "")
 
 
+def _public_gateway_block_reason(policy_source: str) -> str:
+    """Return a client-safe gateway block reason.
+
+    Policy evaluator reasons can include user-controlled paths, regexes, or
+    exception-derived text. Keep those details in audit records only.
+    """
+    return {
+        "conditional_access": "Conditional access blocked this request",
+        "control_plane": "Control-plane gateway policy blocked this request",
+        "drift_enforcement": "Drift enforcement blocked this request",
+        "identity_scope": "Identity scope blocked this tool",
+        "identity_jit": "Gateway policy blocked this request",
+    }.get(policy_source, "Gateway policy blocked this request")
+
+
 def _get_visual_leak_detector() -> Any:
     global _visual_detector_singleton
     if _visual_detector_singleton is None:
@@ -1263,7 +1278,10 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                         "error": {
                             "code": -32001,  # Application-defined error
                             "message": "Blocked by agent-bom gateway policy",
-                            "data": {"reason": reason},
+                            "data": {
+                                "reason": _public_gateway_block_reason(policy_source),
+                                "policy_source": policy_source,
+                            },
                         },
                     },
                     status_code=200,

--- a/tests/test_agent_identity_lifecycle.py
+++ b/tests/test_agent_identity_lifecycle.py
@@ -335,7 +335,7 @@ def test_jit_grant_temporarily_allows_out_of_scope_tool(store):
     revoke_jit_grant(store, grant.grant_id)
     blocked = client.post("/mcp/filesystem", json=message)
     assert blocked.json().get("error", {}).get("code") == -32001, blocked.text
-    assert blocked.json()["error"]["data"]["reason"] == "tool 'read_file' not in identity scope"
+    assert blocked.json()["error"]["data"] == {"reason": "Identity scope blocked this tool", "policy_source": "identity_scope"}
 
 
 # ── conditional / context-aware access ──────────────────────────────────────────

--- a/tests/test_gateway_drift_enforcement.py
+++ b/tests/test_gateway_drift_enforcement.py
@@ -89,7 +89,10 @@ def test_enforce_blocks_drifted_tool():
     client = TestClient(create_gateway_app(_settings("enforce")))
     resp = client.post("/mcp/filesystem", json=_call(tool="run_shell"))
     assert _is_blocked(resp), resp.text
-    assert "drift" in resp.json()["error"]["data"]["reason"].lower()
+    assert resp.json()["error"]["data"] == {
+        "reason": "Drift enforcement blocked this request",
+        "policy_source": "drift_enforcement",
+    }
 
 
 def test_enforce_allows_non_drifted_tool():

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -853,6 +853,7 @@ def test_relay_blocks_tool_by_policy() -> None:
     assert "error" in body
     assert body["error"]["code"] == -32001
     assert "Blocked by agent-bom gateway policy" in body["error"]["message"]
+    assert body["error"]["data"] == {"reason": "Gateway policy blocked this request", "policy_source": "file"}
     # Blocked tool must NOT reach the upstream
     assert upstream_calls == []
     # And the audit trail must record the block with the tool name + reason
@@ -861,6 +862,38 @@ def test_relay_blocks_tool_by_policy() -> None:
     assert audit_events[0]["method"] == "tools/call"
     assert audit_events[0]["tool"] == "run_shell"
     assert "no-shell" in (audit_events[0]["reason"] or "")
+
+
+def test_relay_policy_block_response_does_not_expose_internal_reason(monkeypatch) -> None:
+    audit_events: list[dict[str, Any]] = []
+
+    async def fake_caller(upstream, message, extra_headers):
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    async def audit_sink(event):
+        audit_events.append(event)
+
+    internal_reason = "Traceback: File '/Users/alice/prod/.env', line 7, in policy_loader"
+    monkeypatch.setattr("agent_bom.gateway_server.check_policy", lambda policy, tool, arguments: (False, internal_reason))
+
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={"rules": [{"id": "unsafe", "action": "block", "block_tools": ["run_shell"]}]},
+        upstream_caller=fake_caller,
+        audit_sink=audit_sink,
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post(
+        "/mcp/filesystem",
+        json=_json_rpc("tools/call", name="run_shell", arguments={"path": "/Users/alice/prod/.env"}),
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()["error"]["data"]
+    assert data == {"reason": "Gateway policy blocked this request", "policy_source": "file"}
+    assert "Traceback" not in str(data)
+    assert "/Users/alice" not in str(data)
+    assert audit_events[0]["reason"] == internal_reason
 
 
 def test_relay_allows_tool_not_in_blocklist() -> None:
@@ -1154,10 +1187,12 @@ def test_relay_blocks_resource_prompt_sampling_methods_by_policy() -> None:
         assert resp.status_code == 200
         body = resp.json()
         assert body["error"]["code"] == -32001
-        assert method in body["error"]["data"]["reason"]
+        assert body["error"]["data"] == {"reason": "Gateway policy blocked this request", "policy_source": "file"}
 
     assert upstream_calls == []
     assert [event["method"] for event in audit_events] == ["resources/read", "prompts/get", "sampling/createMessage"]
+    for method, event in zip(["resources/read", "prompts/get", "sampling/createMessage"], audit_events, strict=True):
+        assert method in event["reason"]
 
 
 def test_relay_rejects_oversized_jsonrpc_request() -> None:


### PR DESCRIPTION
## Summary
- Redacts public JSON-RPC gateway policy-block reason text to stable client-safe categories.
- Preserves full internal block reason in audit events for operator triage.
- Adds regression coverage for traceback/path-like policy reasons not leaking to clients.

## Verification
- `uv run ruff format src/agent_bom/gateway_server.py tests/test_gateway_server.py tests/test_gateway_drift_enforcement.py tests/test_agent_identity_lifecycle.py`
- `uv run ruff check src/agent_bom/gateway_server.py tests/test_gateway_server.py tests/test_gateway_drift_enforcement.py tests/test_agent_identity_lifecycle.py`
- `uv run pytest -q tests/test_gateway_server.py tests/test_gateway_drift_enforcement.py tests/test_agent_identity_lifecycle.py`
- `git diff --check`
- commit hooks: ruff, ruff-format, mypy, bandit, hygiene checks

## Notes
- Addresses CodeQL alert #1742, `py/stack-trace-exposure`, in `src/agent_bom/gateway_server.py`.