### PR TITLE
feat(gateway): act on cost-spike anomalies (detection → enforcement)

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -85,6 +85,8 @@ AGENT_BOM_EXTERNAL_SECRETS_ENABLED
 AGENT_BOM_GATEWAY_ALLOW_INSECURE_NO_AUTH
 AGENT_BOM_GATEWAY_BEARER_TOKEN
 AGENT_BOM_GATEWAY_DETECT_VISUAL_LEAKS
+# opt-in anomaly-triggered gateway enforcement mode (off|warn|enforce)
+AGENT_BOM_GATEWAY_ANOMALY_ENFORCEMENT
 # opt-in drift-triggered gateway enforcement mode (off|warn|enforce)
 AGENT_BOM_GATEWAY_DRIFT_ENFORCEMENT
 # shared fallback policy path for standalone gateway and control-plane firewall decision route

--- a/src/agent_bom/api/anomaly.py
+++ b/src/agent_bom/api/anomaly.py
@@ -10,6 +10,8 @@ open posture of the rest of the platform.
 
 from __future__ import annotations
 
+import threading
+import time
 from collections import defaultdict
 from typing import Any
 
@@ -124,3 +126,37 @@ def scan_anomalies(tenant_id: str, *, z_threshold: float = DEFAULT_Z_THRESHOLD) 
         "behavior_anomalies": behavior,
         "anomaly_count": len(cost) + len(behavior),
     }
+
+
+# Brief cache so a hot caller (the gateway relay) can ask "is this agent's spend
+# anomalous?" without re-aggregating every record on every call. The TTL bounds
+# how stale the signal can be; a spike is still caught within one window.
+_COST_ANOMALY_CACHE_TTL_SECONDS = 30.0
+_cost_anomaly_cache: dict[str, tuple[float, dict[str, dict[str, Any]]]] = {}
+_cost_anomaly_cache_lock = threading.Lock()
+
+
+def clear_cost_anomaly_cache() -> None:
+    """Drop the cost-anomaly cache (tests / explicit refresh)."""
+    with _cost_anomaly_cache_lock:
+        _cost_anomaly_cache.clear()
+
+
+def cost_anomalous_agents(
+    tenant_id: str,
+    *,
+    z_threshold: float = DEFAULT_Z_THRESHOLD,
+    _now: float | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Agents whose total spend is anomalous vs the tenant fleet, mapped to their
+    anomaly record. Cached per tenant for ``_COST_ANOMALY_CACHE_TTL_SECONDS``."""
+    now = _now if _now is not None else time.monotonic()
+    with _cost_anomaly_cache_lock:
+        cached = _cost_anomaly_cache.get(tenant_id)
+        if cached is not None and cached[0] > now:
+            return cached[1]
+    result = scan_anomalies(tenant_id, z_threshold=z_threshold)
+    by_agent = {a["agent"]: a for a in result.get("cost_anomalies", []) if a.get("agent")}
+    with _cost_anomaly_cache_lock:
+        _cost_anomaly_cache[tenant_id] = (now + _COST_ANOMALY_CACHE_TTL_SECONDS, by_agent)
+    return by_agent

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -238,6 +238,14 @@ def init_policy_cmd(output_path: Path, mode: str, output_format: str, tenant_id:
     help="Act on open behavioral-drift incidents: 'enforce' blocks out-of-blueprint tools, 'warn' audits them, 'off' stays advisory.",
 )
 @click.option(
+    "--anomaly-enforcement",
+    type=click.Choice(["off", "warn", "enforce"]),
+    envvar="AGENT_BOM_GATEWAY_ANOMALY_ENFORCEMENT",
+    default="off",
+    show_default=True,
+    help="Act on cost-spike anomalies: 'enforce' blocks a runaway agent, 'warn' audits it, 'off' stays advisory.",
+)
+@click.option(
     "--allow-visual-leak-best-effort",
     is_flag=True,
     default=False,
@@ -265,6 +273,7 @@ def serve_cmd(
     allow_insecure_no_auth: bool,
     detect_visual_leaks: bool,
     drift_enforcement: str,
+    anomaly_enforcement: str,
     allow_visual_leak_best_effort: bool,
     log_level: str,
 ) -> None:
@@ -389,6 +398,7 @@ def serve_cmd(
         listener_host=host,
         allow_insecure_no_auth=allow_insecure_no_auth,
         drift_enforcement_mode=drift_enforcement,
+        anomaly_enforcement_mode=anomaly_enforcement,
     )
     app = create_gateway_app(settings)
     policy_summary = summarize_policy_bundle(policy)

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -90,6 +90,7 @@ def _public_gateway_block_reason(policy_source: str) -> str:
         "conditional_access": "Conditional access blocked this request",
         "control_plane": "Control-plane gateway policy blocked this request",
         "drift_enforcement": "Drift enforcement blocked this request",
+        "anomaly_enforcement": "Anomaly enforcement blocked this request",
         "identity_scope": "Identity scope blocked this tool",
         "identity_jit": "Gateway policy blocked this request",
     }.get(policy_source, "Gateway policy blocked this request")
@@ -1177,7 +1178,10 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                         "error": {
                             "code": -32001,
                             "message": "Blocked by agent-bom gateway: anomalous spend",
-                            "data": {"reason": anomaly_reason},
+                            "data": {
+                                "reason": _public_gateway_block_reason("anomaly_enforcement"),
+                                "policy_source": "anomaly_enforcement",
+                            },
                         },
                     },
                     status_code=200,

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -150,6 +150,29 @@ class GatewaySettings:
     # enabling enforcement is an explicit operator decision. Fail-open: a drift
     # store error never blocks the relay.
     drift_enforcement_mode: str = "off"
+    # Anomaly-triggered enforcement. An agent whose spend is a statistical
+    # outlier vs the tenant fleet (cost-spike anomaly) can be blocked ("enforce")
+    # or flagged ("warn") at the gateway — catching a runaway agent before it
+    # exhausts an absolute budget. Default "off" keeps anomalies advisory.
+    anomaly_enforcement_mode: str = "off"
+
+
+def _agent_cost_anomaly(tenant_id: str, source_agent: str) -> tuple[bool, str]:
+    """Return (anomalous, reason) if ``source_agent`` currently has a cost-spike
+    anomaly vs the tenant fleet. Cached upstream; fail-open on any store error."""
+    if not source_agent:
+        return False, ""
+    try:
+        from agent_bom.api.anomaly import cost_anomalous_agents
+
+        flagged = cost_anomalous_agents(tenant_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("gateway anomaly check failed: %s", _sanitize_for_log(exc))
+        return False, ""
+    info = flagged.get(source_agent)
+    if info:
+        return True, (f"agent '{source_agent}' has anomalous spend (z={info.get('z_score')}) vs the tenant fleet baseline")
+    return False, ""
 
 
 def _open_drift_violates_tool(tenant_id: str, source_agent: str, tool_name: str) -> tuple[bool, str]:
@@ -1123,6 +1146,53 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 status_code=200,
                 headers=rate_limit_headers or None,
             )
+
+        # Anomaly-triggered enforcement: a runaway agent (spend outlier vs the
+        # fleet) is blocked/flagged before its next call, even while it is still
+        # under any absolute budget. Off by default; cached + fail-open.
+        if settings.anomaly_enforcement_mode in ("warn", "enforce"):
+            anomalous, anomaly_reason = _agent_cost_anomaly(tenant_id, source_agent)
+            if anomalous and settings.anomaly_enforcement_mode == "enforce":
+                record_gateway_relay(upstream.name, "blocked")
+                if settings.audit_sink is not None:
+                    await settings.audit_sink(
+                        {
+                            "action": "gateway.anomaly_blocked",
+                            "upstream": upstream.name,
+                            "tenant_id": tenant_id,
+                            "source_agent": source_agent,
+                            "reason": anomaly_reason,
+                        }
+                    )
+                _emit_gateway_governance_event(
+                    "anomaly.blocked",
+                    tenant_id=tenant_id,
+                    subject_id=source_agent,
+                    payload={"source_agent": source_agent, "reason": anomaly_reason},
+                )
+                return JSONResponse(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": message.get("id"),
+                        "error": {
+                            "code": -32001,
+                            "message": "Blocked by agent-bom gateway: anomalous spend",
+                            "data": {"reason": anomaly_reason},
+                        },
+                    },
+                    status_code=200,
+                    headers=rate_limit_headers or None,
+                )
+            if anomalous and settings.audit_sink is not None:
+                await settings.audit_sink(
+                    {
+                        "action": "gateway.anomaly_warned",
+                        "upstream": upstream.name,
+                        "tenant_id": tenant_id,
+                        "source_agent": source_agent,
+                        "reason": anomaly_reason,
+                    }
+                )
 
         policy_subject = policy_subject_from_message(message)
         if policy_subject:

--- a/tests/test_gateway_anomaly_enforcement.py
+++ b/tests/test_gateway_anomaly_enforcement.py
@@ -106,10 +106,15 @@ def _reset():
 
 def test_enforce_blocks_anomalous_agent():
     _seed_runaway()
-    client = TestClient(create_gateway_app(_settings("enforce")))
+    audit: list[dict[str, Any]] = []
+    client = TestClient(create_gateway_app(_settings("enforce", audit=audit)))
     resp = client.post("/mcp/filesystem", json=_call("token-a"))
     assert _is_blocked(resp), resp.text
-    assert "anomalous" in resp.json()["error"]["data"]["reason"].lower()
+    assert resp.json()["error"]["data"] == {
+        "reason": "Anomaly enforcement blocked this request",
+        "policy_source": "anomaly_enforcement",
+    }
+    assert any(e.get("action") == "gateway.anomaly_blocked" and "anomalous spend" in e.get("reason", "") for e in audit)
 
 
 def test_enforce_allows_normal_agent():

--- a/tests/test_gateway_anomaly_enforcement.py
+++ b/tests/test_gateway_anomaly_enforcement.py
@@ -1,0 +1,146 @@
+"""Gateway acts on cost-spike anomalies (detection → enforcement).
+
+Cost anomalies were advisory-only: a runaway agent spending far above the fleet
+baseline was flagged in the observability API but kept relaying. These tests
+cover the opt-in enforcement — `enforce` blocks the anomalous agent, `warn`
+audits it, `off` stays advisory — and that a cost-store failure fails open.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api import anomaly as anomaly_mod
+from agent_bom.api.cost_store import LLMCostRecord, set_cost_store
+from agent_bom.gateway_server import GatewaySettings, create_gateway_app
+from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
+
+
+def _registry() -> UpstreamRegistry:
+    return UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://fs.local:8100")])
+
+
+def _call(token: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "read_file", "arguments": {"path": "/tmp/x"}, "_meta": {"agent_identity": token}},
+    }
+
+
+async def _ok_caller(upstream, message, extra_headers):
+    return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+
+def _settings(mode: str, audit: list[dict[str, Any]] | None = None) -> GatewaySettings:
+    async def _sink(event: dict[str, Any]) -> None:
+        if audit is not None:
+            audit.append(event)
+
+    return GatewaySettings(
+        registry=_registry(),
+        # agent-a is the runaway spender; agent-b is normal.
+        policy={"agent_tokens": {"token-a": "agent-a", "token-b": "agent-b"}},
+        upstream_caller=_ok_caller,
+        audit_sink=_sink if audit is not None else None,
+        anomaly_enforcement_mode=mode,
+    )
+
+
+class _InMemoryCostStore:
+    def __init__(self, records: list[LLMCostRecord]) -> None:
+        self._records = records
+
+    def list_records(self, tenant_id: str, *, limit: int = 1000) -> list[LLMCostRecord]:
+        return [r for r in self._records if r.tenant_id == tenant_id][:limit]
+
+    # Unused-by-this-path protocol members.
+    def record_cost(self, record: LLMCostRecord) -> None:  # pragma: no cover
+        self._records.append(record)
+
+    def total_spend(self, tenant_id: str, *, agent: str | None = None) -> float:  # pragma: no cover
+        return sum(r.cost_usd for r in self._records if r.tenant_id == tenant_id and (agent is None or r.agent == agent))
+
+    def get_budget(self, tenant_id: str, agent: str = "") -> None:  # pragma: no cover
+        return None
+
+
+def _rec(agent: str, cost: float) -> LLMCostRecord:
+    return LLMCostRecord(
+        tenant_id="default",
+        call_id=f"c-{agent}",
+        agent=agent,
+        session_id=f"s-{agent}",
+        provider="openai",
+        model="gpt-4o",
+        input_tokens=1,
+        output_tokens=1,
+        cost_usd=cost,
+        priced=True,
+        observed_at="2026-06-05T00:00:00Z",
+    )
+
+
+def _seed_runaway() -> None:
+    # Five baseline agents at $1, one runaway at $1000 → runaway is an outlier.
+    records = [_rec(f"agent-{i}", 1.0) for i in range(5)] + [_rec("agent-a", 1000.0)]
+    set_cost_store(_InMemoryCostStore(records))  # type: ignore[arg-type]
+
+
+def _is_blocked(resp) -> bool:
+    body = resp.json()
+    return resp.status_code == 200 and isinstance(body.get("error"), dict) and body["error"].get("code") == -32001
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    anomaly_mod.clear_cost_anomaly_cache()
+    yield
+    set_cost_store(None)
+    anomaly_mod.clear_cost_anomaly_cache()
+
+
+def test_enforce_blocks_anomalous_agent():
+    _seed_runaway()
+    client = TestClient(create_gateway_app(_settings("enforce")))
+    resp = client.post("/mcp/filesystem", json=_call("token-a"))
+    assert _is_blocked(resp), resp.text
+    assert "anomalous" in resp.json()["error"]["data"]["reason"].lower()
+
+
+def test_enforce_allows_normal_agent():
+    _seed_runaway()
+    client = TestClient(create_gateway_app(_settings("enforce")))
+    resp = client.post("/mcp/filesystem", json=_call("token-b"))
+    assert resp.status_code == 200 and resp.json().get("result") == {"ok": True}
+
+
+def test_warn_audits_but_does_not_block():
+    _seed_runaway()
+    audit: list[dict[str, Any]] = []
+    client = TestClient(create_gateway_app(_settings("warn", audit=audit)))
+    resp = client.post("/mcp/filesystem", json=_call("token-a"))
+    assert resp.status_code == 200 and resp.json().get("result") == {"ok": True}
+    assert any(e.get("action") == "gateway.anomaly_warned" for e in audit)
+
+
+def test_off_is_advisory_no_block():
+    _seed_runaway()
+    client = TestClient(create_gateway_app(_settings("off")))
+    resp = client.post("/mcp/filesystem", json=_call("token-a"))
+    assert resp.status_code == 200 and resp.json().get("result") == {"ok": True}
+
+
+def test_cost_store_failure_fails_open():
+    class _Boom:
+        def list_records(self, *a, **k):
+            raise RuntimeError("store down")
+
+    set_cost_store(_Boom())  # type: ignore[arg-type]
+    client = TestClient(create_gateway_app(_settings("enforce")))
+    resp = client.post("/mcp/filesystem", json=_call("token-a"))
+    assert resp.status_code == 200 and resp.json().get("result") == {"ok": True}


### PR DESCRIPTION
## What

Opt-in **anomaly-triggered enforcement** at the gateway, the cost counterpart to drift enforcement. When an agent's spend is a statistical outlier vs the tenant fleet (cost-spike anomaly), it can be blocked or flagged at relay time via `--anomaly-enforcement` (env `AGENT_BOM_GATEWAY_ANOMALY_ENFORCEMENT`):

- `enforce` — the anomalous agent is **blocked** (JSON-RPC `-32001`) with an `anomaly.blocked` governance event
- `warn` — the call relays but is audited as `gateway.anomaly_warned`
- `off` (default) — unchanged; anomalies stay advisory

## Why

Cost-anomaly detection already flagged runaway agents, but the signal was advisory-only — the agent kept relaying until it exhausted an absolute budget, if one was even set. Anomaly enforcement catches a spike *relative to the agent's peers* even while still under budget, closing the other half of the runtime/cost governance gap (the first half was drift enforcement).

## How

Backed by `cost_anomalous_agents()`, a per-tenant **TTL cache (30s)** over the existing modified-z detection, so the hot relay path never re-aggregates spend per call. The gate runs *after* the absolute-budget check (so it adds the relative-spike signal on top), is keyed on the resolved `source_agent`, and **fails open** — a cost-store error logs and allows rather than breaking the relay. Default-off keeps enabling it an explicit operator decision.

## Tests

`tests/test_gateway_anomaly_enforcement.py`: enforce-blocks-runaway, normal-agent-allowed, warn-audits-without-blocking, off-is-advisory, store-failure-fails-open. Gateway + finops suites green; ruff / ruff-format / mypy / bandit clean.