### PR TITLE
feat(enrichment): compute data-quality confidence on native findings

### DIFF
--- a/src/agent_bom/enrichment.py
+++ b/src/agent_bom/enrichment.py
@@ -20,7 +20,20 @@ from agent_bom.config import ENRICHMENT_MAX_CACHE_ENTRIES as _MAX_ENRICHMENT_CAC
 from agent_bom.config import ENRICHMENT_TTL_SECONDS as _ENRICHMENT_TTL
 from agent_bom.enrichment_posture import record_enrichment_source
 from agent_bom.http_client import create_client, request_with_retry
-from agent_bom.models import Vulnerability
+from agent_bom.models import Vulnerability, compute_confidence
+
+
+def _finalize_confidence(vulnerabilities: list[Vulnerability]) -> None:
+    """Set the 0.0-1.0 data-quality confidence on each vuln after enrichment.
+
+    Native (OSV/GHSA) findings previously left ``confidence`` unset while
+    external-scanner findings carried it, so the same finding looked more or
+    less trustworthy purely by source. Computing it here — once, post-enrichment
+    — gives every finding a consistent CVSS/EPSS/CWE/fix-backed confidence.
+    """
+    for vuln in vulnerabilities:
+        vuln.confidence = compute_confidence(vuln)
+
 
 console = Console(stderr=True)
 _logger = logging.getLogger(__name__)
@@ -467,6 +480,8 @@ async def enrich_vulnerabilities(
 
     cve_ids = extract_cve_ids(vulnerabilities)
     if not cve_ids:
+        # No CVEs to enrich, but confidence still reflects OSV severity/fix data.
+        _finalize_confidence(vulnerabilities)
         return 0
 
     console.print(f"\n[bold blue]🔬 Enriching {len(cve_ids)} CVE(s) with external data...[/bold blue]\n")
@@ -642,6 +657,7 @@ async def enrich_vulnerabilities(
     # Persist enrichment caches to disk
     _save_enrichment_cache()
 
+    _finalize_confidence(vulnerabilities)
     console.print(f"\n  [bold]Enriched {enriched_count} vulnerabilities.[/bold]")
     return enriched_count
 

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -41,3 +41,41 @@ def test_confidence_capped_at_1():
     )
     c = compute_confidence(v)
     assert c <= 1.0
+
+
+def test_enrichment_pass_populates_confidence_on_native_findings():
+    """The enrichment pass sets confidence on native (OSV/GHSA) findings, so a
+    finding's trustworthiness no longer depends on whether it came from an
+    external scanner."""
+    import asyncio
+
+    from agent_bom import enrichment
+
+    rich = Vulnerability(
+        id="CVE-2024-1234",
+        summary="rich",
+        severity=Severity.HIGH,
+        cvss_score=8.5,
+        epss_score=0.5,
+        severity_source="cvss",
+        fixed_version="2.0.0",
+    )
+    minimal = Vulnerability(id="CVE-2024-5678", summary="minimal", severity=Severity.UNKNOWN)
+    assert rich.confidence is None and minimal.confidence is None
+
+    # Offline + all external fetches disabled: the pass does nothing but finalize
+    # confidence, so the assertion is deterministic and network-free.
+    asyncio.run(enrichment.enrich_vulnerabilities([rich, minimal], enable_nvd=False, enable_epss=False, enable_kev=False, offline=True))
+    assert rich.confidence is not None and minimal.confidence is not None
+    assert rich.confidence > minimal.confidence
+
+
+def test_enrichment_populates_confidence_for_non_cve_findings():
+    """Findings with no CVE id (e.g. malware/GHSA-only) still get confidence."""
+    import asyncio
+
+    from agent_bom import enrichment
+
+    mal = Vulnerability(id="MAL-2024-0003", summary="malware", severity=Severity.HIGH, severity_source="osv")
+    asyncio.run(enrichment.enrich_vulnerabilities([mal], offline=True))
+    assert mal.confidence is not None


### PR DESCRIPTION
## What

Populates the `confidence` (0.0–1.0 data-quality) score on **native** (OSV/GHSA) findings, not just external-scanner ones.

## Why

`compute_confidence()` was only invoked when ingesting external-scanner output. A native finding and an imported finding with identical CVSS / EPSS / CWE / fix-version data therefore carried *different* confidence — one scored, one unset — purely by source. That's misleading: confidence should reflect the data backing a finding, not its origin.

## How

`enrich_vulnerabilities` now calls a `_finalize_confidence` pass at the end (after NVD / EPSS / KEV data has landed) for every vulnerability in the batch, and on the no-CVE early-return path so malware / GHSA-only findings still get a score. Confidence is computed once, post-enrichment, from the same CVSS + EPSS + CWE + fix signals regardless of where the finding came from — so the score is now consistent and comparable across sources.

## Tests

`tests/test_confidence.py`: the enrichment pass populates confidence on native findings (rich > minimal) and on non-CVE findings. Enrichment suite (37 tests) green; ruff / ruff-format / mypy / bandit clean.