### PR TITLE
feat(gateway): isolate quarantined fleet agents (detection → enforcement)

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -89,6 +89,8 @@ AGENT_BOM_GATEWAY_DETECT_VISUAL_LEAKS
 AGENT_BOM_GATEWAY_ANOMALY_ENFORCEMENT
 # opt-in drift-triggered gateway enforcement mode (off|warn|enforce)
 AGENT_BOM_GATEWAY_DRIFT_ENFORCEMENT
+# opt-in fleet-quarantine gateway enforcement mode (off|warn|enforce)
+AGENT_BOM_GATEWAY_FLEET_ENFORCEMENT
 # shared fallback policy path for standalone gateway and control-plane firewall decision route
 AGENT_BOM_GATEWAY_FIREWALL_POLICY
 AGENT_BOM_GATEWAY_FIREWALL_POLICY_RELOAD_SECONDS

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -246,6 +246,14 @@ def init_policy_cmd(output_path: Path, mode: str, output_format: str, tenant_id:
     help="Act on cost-spike anomalies: 'enforce' blocks a runaway agent, 'warn' audits it, 'off' stays advisory.",
 )
 @click.option(
+    "--fleet-enforcement",
+    type=click.Choice(["off", "warn", "enforce"]),
+    envvar="AGENT_BOM_GATEWAY_FLEET_ENFORCEMENT",
+    default="off",
+    show_default=True,
+    help="Act on quarantined fleet agents: 'enforce' blocks every call from a quarantined agent, 'warn' audits it, 'off' stays advisory.",
+)
+@click.option(
     "--allow-visual-leak-best-effort",
     is_flag=True,
     default=False,
@@ -274,6 +282,7 @@ def serve_cmd(
     detect_visual_leaks: bool,
     drift_enforcement: str,
     anomaly_enforcement: str,
+    fleet_enforcement: str,
     allow_visual_leak_best_effort: bool,
     log_level: str,
 ) -> None:
@@ -399,6 +408,7 @@ def serve_cmd(
         allow_insecure_no_auth=allow_insecure_no_auth,
         drift_enforcement_mode=drift_enforcement,
         anomaly_enforcement_mode=anomaly_enforcement,
+        fleet_enforcement_mode=fleet_enforcement,
     )
     app = create_gateway_app(settings)
     policy_summary = summarize_policy_bundle(policy)

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -91,6 +91,7 @@ def _public_gateway_block_reason(policy_source: str) -> str:
         "control_plane": "Control-plane gateway policy blocked this request",
         "drift_enforcement": "Drift enforcement blocked this request",
         "anomaly_enforcement": "Anomaly enforcement blocked this request",
+        "fleet_quarantine": "Agent is quarantined in the fleet roster",
         "identity_scope": "Identity scope blocked this tool",
         "identity_jit": "Gateway policy blocked this request",
     }.get(policy_source, "Gateway policy blocked this request")
@@ -156,6 +157,11 @@ class GatewaySettings:
     # or flagged ("warn") at the gateway — catching a runaway agent before it
     # exhausts an absolute budget. Default "off" keeps anomalies advisory.
     anomaly_enforcement_mode: str = "off"
+    # Fleet-state enforcement. An agent the operator has moved to the
+    # QUARANTINED lifecycle state in the fleet roster can be fully blocked
+    # ("enforce") or flagged ("warn") at the gateway — isolating a compromised
+    # or under-review agent without touching per-tool policy. Default "off".
+    fleet_enforcement_mode: str = "off"
 
 
 def _agent_cost_anomaly(tenant_id: str, source_agent: str) -> tuple[bool, str]:
@@ -174,6 +180,33 @@ def _agent_cost_anomaly(tenant_id: str, source_agent: str) -> tuple[bool, str]:
     if info:
         return True, (f"agent '{source_agent}' has anomalous spend (z={info.get('z_score')}) vs the tenant fleet baseline")
     return False, ""
+
+
+def _agent_is_quarantined(tenant_id: str, source_agent: str) -> bool:
+    """Return True when ``source_agent`` is quarantined in this tenant's fleet.
+
+    Fail-open: fleet-store errors are logged and never block the relay.
+    """
+    if not source_agent:
+        return False
+    try:
+        from agent_bom.api.fleet_store import FleetLifecycleState
+        from agent_bom.api.stores import _get_fleet_store
+
+        agents = _get_fleet_store().list_by_tenant(tenant_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("gateway fleet check failed: %s", _sanitize_for_log(exc))
+        return False
+    key = source_agent.strip().lower()
+    for agent in agents:
+        identifiers = (
+            (getattr(agent, "name", "") or "").strip().lower(),
+            (getattr(agent, "agent_id", "") or "").strip().lower(),
+            (getattr(agent, "canonical_id", "") or "").strip().lower(),
+        )
+        if key in identifiers:
+            return getattr(agent, "lifecycle_state", None) == FleetLifecycleState.QUARANTINED
+    return False
 
 
 def _open_drift_violates_tool(tenant_id: str, source_agent: str, tool_name: str) -> tuple[bool, str]:
@@ -1195,6 +1228,55 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                         "tenant_id": tenant_id,
                         "source_agent": source_agent,
                         "reason": anomaly_reason,
+                    }
+                )
+
+        # Fleet-state enforcement: a quarantined agent is isolated — every call
+        # blocked/flagged regardless of tool — before the upstream is touched.
+        # Off by default; fails open on a fleet-store error.
+        if settings.fleet_enforcement_mode in ("warn", "enforce") and _agent_is_quarantined(tenant_id, source_agent):
+            if settings.fleet_enforcement_mode == "enforce":
+                record_gateway_relay(upstream.name, "blocked")
+                if settings.audit_sink is not None:
+                    await settings.audit_sink(
+                        {
+                            "action": "gateway.fleet_blocked",
+                            "upstream": upstream.name,
+                            "tenant_id": tenant_id,
+                            "source_agent": source_agent,
+                            "reason": "agent quarantined in fleet roster",
+                        }
+                    )
+                _emit_gateway_governance_event(
+                    "fleet.blocked",
+                    tenant_id=tenant_id,
+                    subject_id=source_agent,
+                    payload={"source_agent": source_agent, "reason": "agent quarantined in fleet roster"},
+                )
+                return JSONResponse(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": message.get("id"),
+                        "error": {
+                            "code": -32001,
+                            "message": "Blocked by agent-bom gateway: agent quarantined",
+                            "data": {
+                                "reason": _public_gateway_block_reason("fleet_quarantine"),
+                                "policy_source": "fleet_quarantine",
+                            },
+                        },
+                    },
+                    status_code=200,
+                    headers=rate_limit_headers or None,
+                )
+            if settings.audit_sink is not None:
+                await settings.audit_sink(
+                    {
+                        "action": "gateway.fleet_warned",
+                        "upstream": upstream.name,
+                        "tenant_id": tenant_id,
+                        "source_agent": source_agent,
+                        "reason": "agent quarantined in fleet roster",
                     }
                 )
 

--- a/tests/test_gateway_fleet_enforcement.py
+++ b/tests/test_gateway_fleet_enforcement.py
@@ -1,0 +1,127 @@
+"""Gateway isolates quarantined fleet agents (detection → enforcement).
+
+The fleet roster's QUARANTINED lifecycle state was advisory-only — an operator
+could quarantine a compromised or under-review agent but it kept relaying. These
+tests cover the opt-in enforcement: `enforce` blocks every call from a
+quarantined agent, `warn` audits it, `off` stays advisory, and a fleet-store
+failure fails open.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.fleet_store import FleetAgent, FleetLifecycleState, InMemoryFleetStore
+from agent_bom.api.stores import set_fleet_store
+from agent_bom.gateway_server import GatewaySettings, create_gateway_app
+from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
+
+
+def _registry() -> UpstreamRegistry:
+    return UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://fs.local:8100")])
+
+
+def _call(token: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "read_file", "arguments": {"path": "/tmp/x"}, "_meta": {"agent_identity": token}},
+    }
+
+
+async def _ok_caller(upstream, message, extra_headers):
+    return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+
+def _settings(mode: str, audit: list[dict[str, Any]] | None = None) -> GatewaySettings:
+    async def _sink(event: dict[str, Any]) -> None:
+        if audit is not None:
+            audit.append(event)
+
+    return GatewaySettings(
+        registry=_registry(),
+        policy={"agent_tokens": {"token-a": "agent-a", "token-b": "agent-b"}},
+        upstream_caller=_ok_caller,
+        audit_sink=_sink if audit is not None else None,
+        fleet_enforcement_mode=mode,
+    )
+
+
+def _seed_fleet() -> None:
+    store = InMemoryFleetStore()
+    store.put(
+        FleetAgent(
+            agent_id="agent-a",
+            name="agent-a",
+            agent_type="custom",
+            tenant_id="default",
+            lifecycle_state=FleetLifecycleState.QUARANTINED,
+        )
+    )
+    store.put(
+        FleetAgent(
+            agent_id="agent-b",
+            name="agent-b",
+            agent_type="custom",
+            tenant_id="default",
+            lifecycle_state=FleetLifecycleState.APPROVED,
+        )
+    )
+    set_fleet_store(store)
+
+
+def _is_blocked(resp) -> bool:
+    body = resp.json()
+    return resp.status_code == 200 and isinstance(body.get("error"), dict) and body["error"].get("code") == -32001
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    yield
+    set_fleet_store(None)
+
+
+def test_enforce_blocks_quarantined_agent():
+    _seed_fleet()
+    client = TestClient(create_gateway_app(_settings("enforce")))
+    resp = client.post("/mcp/filesystem", json=_call("token-a"))
+    assert _is_blocked(resp), resp.text
+    assert resp.json()["error"]["data"]["policy_source"] == "fleet_quarantine"
+
+
+def test_enforce_allows_approved_agent():
+    _seed_fleet()
+    client = TestClient(create_gateway_app(_settings("enforce")))
+    resp = client.post("/mcp/filesystem", json=_call("token-b"))
+    assert resp.status_code == 200 and resp.json().get("result") == {"ok": True}
+
+
+def test_warn_audits_but_does_not_block():
+    _seed_fleet()
+    audit: list[dict[str, Any]] = []
+    client = TestClient(create_gateway_app(_settings("warn", audit=audit)))
+    resp = client.post("/mcp/filesystem", json=_call("token-a"))
+    assert resp.status_code == 200 and resp.json().get("result") == {"ok": True}
+    assert any(e.get("action") == "gateway.fleet_warned" for e in audit)
+
+
+def test_off_is_advisory_no_block():
+    _seed_fleet()
+    client = TestClient(create_gateway_app(_settings("off")))
+    resp = client.post("/mcp/filesystem", json=_call("token-a"))
+    assert resp.status_code == 200 and resp.json().get("result") == {"ok": True}
+
+
+def test_fleet_store_failure_fails_open():
+    class _Boom:
+        def list_by_tenant(self, *a, **k):
+            raise RuntimeError("store down")
+
+    set_fleet_store(_Boom())
+    client = TestClient(create_gateway_app(_settings("enforce")))
+    resp = client.post("/mcp/filesystem", json=_call("token-a"))
+    assert resp.status_code == 200 and resp.json().get("result") == {"ok": True}


### PR DESCRIPTION
## What

Opt-in **fleet-state enforcement** at the gateway, completing the runtime-enforcement set alongside drift and budget. An agent in the `QUARANTINED` fleet lifecycle state is fully isolated at relay time, controlled by `--fleet-enforcement` (env `AGENT_BOM_GATEWAY_FLEET_ENFORCEMENT`):

- `enforce` — every call from a quarantined agent is **blocked** (JSON-RPC `-32001`) with a `fleet.blocked` governance event
- `warn` — the call relays but is audited as `gateway.fleet_warned`
- `off` (default) — unchanged; quarantine stays advisory

## Why

The fleet roster already supported quarantining an agent (compromised, under review, decommissioning), but the gateway never consulted the roster — so a quarantined agent kept relaying. The control plane could *mark* an agent for isolation but couldn't *isolate* it. This is the third advisory-only runtime signal closed (after drift and anomaly).

## How

Quarantine is agent-level, so the gate blocks the agent **entirely** (independent of tool/policy), placed before policy evaluation. It's matched on the resolved `source_agent` against the tenant roster (`list_by_tenant`) and **fails open** — a fleet-store error logs and allows rather than breaking the relay. The client-facing reason is the generic fleet message (via `_public_gateway_block_reason`); details stay in the audit record.

## Tests

`tests/test_gateway_fleet_enforcement.py`: enforce-blocks-quarantined, approved-agent-allowed, warn-audits-without-blocking, off-is-advisory, store-failure-fails-open. Gateway suite (58 tests) green; ruff / ruff-format / mypy / bandit clean.