### PR TITLE
feat(secrets): opt-in entropy detection for novel secrets

### DIFF
--- a/src/agent_bom/cli/_focused_commands.py
+++ b/src/agent_bom/cli/_focused_commands.py
@@ -258,6 +258,12 @@ def sbom_cmd(
 @click.option("--no-color", is_flag=True, help="Disable colored output")
 @click.option("--log-json", "log_json", is_flag=True, help="Emit structured JSON logs to stderr")
 @click.option("--log-file", "log_file", type=click.Path(), default=None, help="Write JSON logs to file")
+@click.option(
+    "--detect-entropy",
+    is_flag=True,
+    default=False,
+    help="Also flag high-entropy values assigned to secret-named keys (catches novel secrets; higher recall, some false positives).",
+)
 @click.option("--quiet", "-q", is_flag=True)
 def secrets_cmd(
     path: str,
@@ -266,6 +272,7 @@ def secrets_cmd(
     no_color: bool,
     log_json: bool,
     log_file: Optional[str],
+    detect_entropy: bool,
     quiet: bool,
 ) -> None:
     """Scan a directory for hardcoded secrets and PII.
@@ -291,7 +298,7 @@ def secrets_cmd(
     setup_logging(level="ERROR" if quiet else "INFO", json_output=log_json, log_file=log_file)
 
     con = Console(stderr=True, quiet=quiet, no_color=no_color)
-    result = scan_secrets(path)
+    result = scan_secrets(path, detect_entropy=detect_entropy)
 
     if output_format == "json":
         output = _json.dumps(result.to_dict(), indent=2)

--- a/src/agent_bom/secret_scanner.py
+++ b/src/agent_bom/secret_scanner.py
@@ -156,6 +156,66 @@ _FILE_SECRET_PATTERNS: list[tuple[str, re.Pattern]] = [
     (".env token", re.compile(r"^(?:AUTH_TOKEN|ACCESS_TOKEN|REFRESH_TOKEN|SESSION_SECRET)\s*=\s*\S+", re.MULTILINE | re.IGNORECASE)),
 ]
 
+# ── Entropy detection (opt-in) ───────────────────────────────────────────────
+# The named patterns above catch known credential *formats*. Entropy detection
+# catches novel/unknown secrets — a high-randomness value assigned to a
+# secret-suggesting key — that no fixed pattern names. Opt-in (--detect-entropy)
+# because, even constrained to secret-named keys, it can surface false positives
+# (hashes, UUIDs, build IDs) that a baseline/allowlist would otherwise suppress.
+import math  # noqa: E402
+
+_ENTROPY_MIN_LEN = 20
+_ENTROPY_THRESHOLD = 3.5  # bits/char; base64-ish secrets score ~4.5-6, prose ~3
+# key suggests a secret, then capture the assigned value (quoted or bare).
+_ENTROPY_ASSIGN_RE = re.compile(
+    r"""(?ix)
+    (?:secret|token|password|passwd|pwd|api[_-]?key|access[_-]?key|
+       client[_-]?secret|auth|credential|private[_-]?key|apikey|bearer)
+    \w* \s* [=:] \s*
+    ['"]? ([A-Za-z0-9+/=_\-\.]{%d,}) ['"]?
+    """
+    % _ENTROPY_MIN_LEN
+)
+# Obvious non-secrets to skip even when assigned to a secret-named key.
+_ENTROPY_PLACEHOLDER_RE = re.compile(
+    r"(?i)^(?:your[_-]|xxx|placeholder|example|changeme|none|null|true|false|enabled|disabled|"
+    r"\$\{|\{\{|<[a-z]|/[a-z]|https?://|[a-z]+(?:[._-][a-z]+)+$)"
+)
+
+
+def _shannon_entropy(value: str) -> float:
+    """Shannon entropy in bits/char — high for random tokens, low for words."""
+    if not value:
+        return 0.0
+    counts: dict[str, int] = {}
+    for ch in value:
+        counts[ch] = counts.get(ch, 0) + 1
+    n = len(value)
+    return -sum((c / n) * math.log2(c / n) for c in counts.values())
+
+
+def _entropy_findings(line: str, rel_path: str, line_num: int) -> list[SecretFinding]:
+    """Flag a high-entropy value assigned to a secret-suggesting key."""
+    out: list[SecretFinding] = []
+    for match in _ENTROPY_ASSIGN_RE.finditer(line):
+        value = match.group(1)
+        if len(value) < _ENTROPY_MIN_LEN or _ENTROPY_PLACEHOLDER_RE.search(value):
+            continue
+        if _shannon_entropy(value) < _ENTROPY_THRESHOLD:
+            continue
+        out.append(
+            SecretFinding(
+                file_path=rel_path,
+                line_number=line_num,
+                secret_type="High-entropy secret",
+                severity="high",
+                matched_preview="[ENTROPY_REDACTED]",
+                category="entropy",
+            )
+        )
+        break  # one entropy finding per line is enough
+    return out
+
 
 # ── Data model ───────────────────────────────────────────────────────────────
 
@@ -234,7 +294,7 @@ def _should_scan(path: Path) -> bool:
     return path.suffix.lower() in _SCAN_EXTENSIONS
 
 
-def _scan_file(file_path: Path, rel_path: str) -> list[SecretFinding]:
+def _scan_file(file_path: Path, rel_path: str, *, detect_entropy: bool = False) -> list[SecretFinding]:
     """Scan a single file for secrets."""
     try:
         content = file_path.read_text(encoding="utf-8", errors="replace")
@@ -303,6 +363,11 @@ def _scan_file(file_path: Path, rel_path: str) -> list[SecretFinding]:
                     )
                     break
 
+        # Entropy detection runs only on lines no named pattern already flagged,
+        # so it adds coverage for novel secrets instead of duplicating findings.
+        if detect_entropy and not any(f.line_number == line_num for f in findings):
+            findings.extend(_entropy_findings(line, rel_path, line_num))
+
     return findings
 
 
@@ -314,7 +379,7 @@ def _should_scan_pii_line(file_path: Path, line: str) -> bool:
     return suffix in _PII_CODE_EXTENSIONS and bool(_PII_CONTEXT_RE.search(line))
 
 
-def scan_secrets(project_path: str | Path) -> SecretScanResult:
+def scan_secrets(project_path: str | Path, *, detect_entropy: bool = False) -> SecretScanResult:
     """Scan a project directory for hardcoded secrets and PII.
 
     Uses the same 31 credential + 11 PII patterns from the runtime
@@ -323,6 +388,9 @@ def scan_secrets(project_path: str | Path) -> SecretScanResult:
 
     Args:
         project_path: Root directory to scan.
+        detect_entropy: Also flag high-entropy values assigned to
+            secret-suggesting keys (novel/unknown secrets no fixed pattern
+            names). Opt-in — higher recall, some false positives.
 
     Returns:
         SecretScanResult with findings, file count, and statistics.
@@ -345,7 +413,7 @@ def scan_secrets(project_path: str | Path) -> SecretScanResult:
 
         file_count += 1
         rel = str(f.relative_to(project))
-        findings = _scan_file(f, rel)
+        findings = _scan_file(f, rel, detect_entropy=detect_entropy)
         result.findings.extend(findings)
 
     result.files_scanned = file_count

--- a/tests/test_secret_scanner_entropy.py
+++ b/tests/test_secret_scanner_entropy.py
@@ -1,0 +1,52 @@
+"""Opt-in entropy detection catches novel secrets the named patterns miss."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_bom.secret_scanner import _shannon_entropy, scan_secrets
+
+
+def _novel_secret_value() -> str:
+    return "".join(("aB3xK9mZ", "2pQ7rT5w", "Y8nL4vC1", "dF6gH0jM"))
+
+
+def test_shannon_entropy_ranks_random_above_words():
+    assert _shannon_entropy("aB3xK9mZ2pQ7rT5wY8nL4vC1") > 4.0
+    assert _shannon_entropy("passwordpassword") < 3.0
+    assert _shannon_entropy("") == 0.0
+
+
+def _write(tmp_path: Path) -> Path:
+    # A high-entropy value assigned to a secret-named key that no vendor
+    # credential pattern names — only entropy detection can catch it.
+    novel_secret = _novel_secret_value()
+    (tmp_path / "config.py").write_text(
+        f'INTERNAL_AUTH_VALUE = "{novel_secret}"\nPLACEHOLDER_TOKEN = "your-token-goes-here"\nTIMEOUT_SECONDS = 30\n'
+    )
+    return tmp_path
+
+
+def test_entropy_off_by_default(tmp_path: Path):
+    _write(tmp_path)
+    result = scan_secrets(_write(tmp_path))
+    assert not any(f.category == "entropy" for f in result.findings)
+
+
+def test_entropy_on_flags_novel_secret(tmp_path: Path):
+    _write(tmp_path)
+    result = scan_secrets(tmp_path, detect_entropy=True)
+    entropy = [f for f in result.findings if f.category == "entropy"]
+    assert entropy, "high-entropy secret should be flagged when enabled"
+    assert entropy[0].secret_type == "High-entropy secret"
+    assert entropy[0].severity == "high"
+    # the value itself is never echoed
+    assert all("aB3xK9" not in f.matched_preview for f in result.findings)
+
+
+def test_entropy_skips_placeholders_and_low_entropy(tmp_path: Path):
+    _write(tmp_path)
+    result = scan_secrets(tmp_path, detect_entropy=True)
+    # the placeholder token and the numeric timeout must not be flagged
+    assert all("your-token" not in f.matched_preview for f in result.findings)
+    assert not any(f.line_number == 3 for f in result.findings if f.category == "entropy")


### PR DESCRIPTION
## What

Adds opt-in entropy-based secret detection to the secret scanner: `agent-bom secrets <path> --detect-entropy`.

## Why

The scanner matched known credential *formats* via vendor regex patterns, so a high-randomness secret in an **unrecognised** format slipped through entirely — exactly the leak a fixed pattern list can never catch. Catching a leaked credential before it ships is one of the highest-ROI things a scanner does; widening recall here strengthens the basics teams rely on.

## How

A value assigned to a secret-suggesting key (`secret`/`token`/`password`/`api_key`/`access_key`/`client_secret`/`auth`/`credential`/`private_key`/`bearer`) is flagged when it is long enough (≥20 chars) **and** its Shannon entropy exceeds a threshold (3.5 bits/char). Obvious placeholders (`your-…`, `${…}`, `{{…}}`, `example`, `changeme`, URLs, dotted identifiers) are filtered out. It runs **only on lines no named pattern already flagged**, so it adds recall without duplicate findings, and the value is never echoed (preview stays `[ENTROPY_REDACTED]`).

**Off by default** — even constrained to secret-named keys, entropy can surface false positives (hashes, UUIDs, build IDs) that a baseline/allowlist would otherwise suppress. The existing default-scan behaviour and output are unchanged.

## Tests

`tests/test_secret_scanner_entropy.py`: entropy off by default, on flags a novel secret no vendor pattern names, placeholders / low-entropy / numeric values skipped, value never echoed. Existing secret-scanner tests unaffected; ruff / ruff-format / mypy / bandit clean.