### PR TITLE
feat(graph): derive crown-jewel / toxic-combination attack paths

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -901,6 +901,99 @@ def _derived_governance_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
     return paths
 
 
+_TOXIC_RESOURCE_TYPES = frozenset(
+    {
+        EntityType.CLOUD_RESOURCE.value,
+        EntityType.RESOURCE.value,
+        EntityType.SERVER.value,
+        EntityType.DATA_STORE.value,
+    }
+)
+_MAX_TOXIC_PATHS = 100
+
+
+# Factor-count → base composite-risk band. Two stacked factors is already a
+# toxic combination; three-plus is a crown jewel — the single most dangerous
+# thing in the estate — banded above the constituent single-factor governance
+# paths it fuses, so it tops the queue rather than competing with its parts.
+def _toxic_band(factor_count: int) -> float:
+    if factor_count >= 4:
+        return 100.0
+    if factor_count == 3:
+        return 99.0
+    return 82.0
+
+
+def _derived_toxic_combination_paths(graph: UnifiedGraph) -> list[AttackPath]:
+    """Cloud-security crown-jewel paths: assets where multiple toxic factors stack.
+
+    A single resource that is *internet-exposed* AND carries an *exploitable
+    vulnerability* AND can *reach sensitive data* AND/or is *reachable by an
+    admin-escalating identity* is the chain an attacker actually walks — and the
+    one thing a security team must fix first. Each independent factor present
+    raises the band; three or more is surfaced as a crown jewel at the top of
+    the attack-path queue. Fuses attributes the overlays already computed (no new
+    scanner input), so it surfaces wherever attack paths do — the headless
+    ``/v1/graph/attack-paths`` queue for agents and the graph cockpit for humans.
+    """
+    vulnerable: set[str] = set()
+    admin_reachable: set[str] = set()
+    sensitive_neighbors: dict[str, list[str]] = {}
+    for edge in graph.edges:
+        rel = _rel_value(edge)
+        if rel == RelationshipType.VULNERABLE_TO.value:
+            vulnerable.add(edge.source)
+        elif rel == RelationshipType.HAS_PERMISSION.value:
+            principal = graph.nodes.get(edge.source)
+            if principal is not None and principal.attributes.get("escalates_to_admin"):
+                admin_reachable.add(edge.target)
+        elif rel in (RelationshipType.STORES.value, RelationshipType.EXPOSED_TO.value):
+            store = graph.nodes.get(edge.target)
+            if store is not None and store.attributes.get("data_sensitivity"):
+                sensitive_neighbors.setdefault(edge.source, []).append(edge.target)
+
+    paths: list[AttackPath] = []
+    for node in graph.nodes.values():
+        if _node_type_value(node) not in _TOXIC_RESOURCE_TYPES or len(paths) >= _MAX_TOXIC_PATHS:
+            continue
+        attrs = node.attributes
+        factors: list[str] = []
+        if attrs.get("internet_exposed"):
+            factors.append("internet-exposed")
+        if node.id in vulnerable or attrs.get("toxic_exposed_vulnerable"):
+            factors.append("exploitable vulnerability")
+        sens_ids = sensitive_neighbors.get(node.id, [])
+        if attrs.get("data_sensitivity") or sens_ids:
+            regs = list(attrs.get("data_regulatory_frameworks") or [])
+            for sid in sens_ids:
+                store = graph.nodes.get(sid)
+                for code in (store.attributes.get("data_regulatory_frameworks") or []) if store else []:
+                    if code not in regs:
+                        regs.append(code)
+            factors.append("sensitive data" + (f" ({'/'.join(regs)})" if regs else ""))
+        if node.id in admin_reachable:
+            factors.append("admin-privilege reachable")
+        if len(factors) < 2:
+            continue
+        target = sens_ids[0] if sens_ids else node.id
+        hops = [node.id, target] if target != node.id else [node.id]
+        edges = ["exposed_to"] if target != node.id else []
+        base = _toxic_band(len(factors))
+        prefix = "Crown jewel" if len(factors) >= 3 else "Toxic combination"
+        paths.append(
+            AttackPath(
+                source=node.id,
+                target=target,
+                hops=hops,
+                edges=edges,
+                composite_risk=round(min(100.0, base), 2),
+                summary=f"{prefix}: {node.label} stacks {len(factors)} toxic factors — " + ", ".join(factors) + ".",
+                vuln_ids=[],
+            )
+        )
+    return paths
+
+
 def _derived_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
     """Derive fix-first paths when a snapshot lacks materialised path rows.
 
@@ -914,7 +1007,7 @@ def _derived_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
     over-scoped tool access, drift, data exposure) are derived and merged in
     both branches so they surface even when materialised vuln paths exist.
     """
-    governance_paths = _derived_governance_attack_paths(graph)
+    governance_paths = _derived_governance_attack_paths(graph) + _derived_toxic_combination_paths(graph)
     if graph.attack_paths:
         return sorted(
             list(graph.attack_paths) + governance_paths,

--- a/tests/test_graph_crown_jewel_paths.py
+++ b/tests/test_graph_crown_jewel_paths.py
@@ -1,0 +1,92 @@
+"""Cloud-security crown-jewel paths: stacked toxic factors surface as top paths.
+
+Validates the fused multi-factor combination (exposure + exploitable vuln +
+reach-to-sensitive-data + admin-reachable) the same way both surfaces consume it
+— the headless ``/v1/graph/attack-paths`` derivation that agents query and the
+graph cockpit humans use.
+"""
+
+from __future__ import annotations
+
+from agent_bom.api.routes.graph import _derived_attack_paths, _derived_toxic_combination_paths
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+
+
+def _crown_jewel_graph() -> UnifiedGraph:
+    g = UnifiedGraph(scan_id="cj", tenant_id="t")
+    # An internet-exposed, vulnerable VM that reaches a PCI data store.
+    g.add_node(
+        UnifiedNode(
+            id="cloud:vm",
+            entity_type=EntityType.CLOUD_RESOURCE,
+            label="prod-api (EC2)",
+            attributes={"internet_exposed": True, "toxic_exposed_vulnerable": True},
+        )
+    )
+    g.add_node(UnifiedNode(id="vuln:rce", entity_type=EntityType.VULNERABILITY, label="CVE-RCE", severity="critical"))
+    g.add_node(
+        UnifiedNode(
+            id="ds:pay",
+            entity_type=EntityType.DATA_STORE,
+            label="payments-db",
+            attributes={"data_sensitivity": "sensitive", "data_regulatory_frameworks": ["PCI-DSS"]},
+        )
+    )
+    g.add_edge(UnifiedEdge(source="cloud:vm", target="vuln:rce", relationship=RelationshipType.VULNERABLE_TO))
+    g.add_edge(UnifiedEdge(source="cloud:vm", target="ds:pay", relationship=RelationshipType.EXPOSED_TO))
+    return g
+
+
+def test_three_factor_resource_is_a_crown_jewel():
+    g = _crown_jewel_graph()
+    paths = _derived_toxic_combination_paths(g)
+    assert paths, "a 3-factor resource must surface a toxic-combination path"
+    cj = paths[0]
+    assert "Crown jewel" in cj.summary
+    assert "internet-exposed" in cj.summary
+    assert "exploitable vulnerability" in cj.summary
+    assert "PCI-DSS" in cj.summary  # regulation named
+    assert cj.composite_risk >= 95
+
+
+def test_crown_jewel_ranks_at_top_of_derived_paths():
+    g = _crown_jewel_graph()
+    all_paths = _derived_attack_paths(g)
+    assert all_paths
+    top = max(all_paths, key=lambda p: p.composite_risk)
+    assert "Crown jewel" in top.summary and top.composite_risk >= 95
+
+
+def test_single_factor_is_not_a_toxic_combination():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    # exposed but nothing else stacked
+    g.add_node(
+        UnifiedNode(
+            id="cloud:lb",
+            entity_type=EntityType.CLOUD_RESOURCE,
+            label="public-lb",
+            attributes={"internet_exposed": True},
+        )
+    )
+    assert _derived_toxic_combination_paths(g) == []
+
+
+def test_two_factor_is_a_toxic_combination_not_crown_jewel():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(
+        UnifiedNode(
+            id="cloud:vm",
+            entity_type=EntityType.CLOUD_RESOURCE,
+            label="vm",
+            attributes={"internet_exposed": True},
+        )
+    )
+    g.add_node(UnifiedNode(id="vuln:x", entity_type=EntityType.VULNERABILITY, label="CVE-X", severity="high"))
+    g.add_edge(UnifiedEdge(source="cloud:vm", target="vuln:x", relationship=RelationshipType.VULNERABLE_TO))
+    paths = _derived_toxic_combination_paths(g)
+    assert len(paths) == 1
+    assert "Toxic combination" in paths[0].summary
+    assert 80 <= paths[0].composite_risk < 95


### PR DESCRIPTION
## What

Adds a fused, multi-factor **crown-jewel / toxic-combination** attack-path class — the security-graph capability that collapses many findings into the handful of assets that are genuinely dangerous.

## Why

The graph already surfaced toxic *factors* individually (internet exposure, exploitable vulnerability, sensitive-data reach, admin-privilege reachability), but never fused them into one ranked finding. An operator (or agent) still had to assemble "this internet-exposed VM has a critical RCE **and** can reach the PCI database" by hand. Fusing them is the difference between a list of 4,000 findings and "here is the one thing to fix first" — the core of the open-source-Wiz goal.

## How

`_derived_toxic_combination_paths` counts the independent toxic factors present on each resource (and its one-hop neighbours) from attributes the overlays already compute — **no new scanner input**:
- `internet_exposed`
- `toxic_exposed_vulnerable` / a `VULNERABLE_TO` edge
- `data_sensitivity` on the asset or a `STORES`/`EXPOSED_TO` neighbour (regulation named)
- reachable by an `escalates_to_admin` identity via `HAS_PERMISSION`

Two factors → a **toxic combination** (band 82). Three+ → a **crown jewel**, banded at 99–100 — above the constituent single-factor governance paths so it tops the queue rather than competing with its own parts. The summary names the factors and the regulation at stake.

## Both surfaces (headless + regular)

It merges into `_derived_attack_paths`, so it surfaces with **no per-surface wiring** on:
- the headless `/v1/graph/attack-paths` queue that agents poll, and
- the `/v1/graph` cockpit that humans investigate.

## Tests

`tests/test_graph_crown_jewel_paths.py`: a 3-factor resource is a top-ranked crown jewel naming the regulation; a 2-factor resource is a mid-banded toxic combination; a single-factor resource is not flagged; and the crown jewel ranks above the constituent governance paths. Graph suite (88 tests) green; ruff / ruff-format / mypy / bandit clean.