### PR TITLE
feat(cloud): capture network placement metadata for reachability analysis

### DIFF
--- a/src/agent_bom/cloud/aws.py
+++ b/src/agent_bom/cloud/aws.py
@@ -1477,6 +1477,32 @@ def _extract_sfn_task_resources(definition: dict) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
+def _aws_instance_network(instance: dict) -> dict[str, Any]:
+    """Extract low-risk network placement (subnet/VPC/SG ids, IPs, AZ) from a
+    describe_instances Instance. Identifiers only — no rules, no credentials."""
+    sg_ids: list[str] = []
+    for group in instance.get("SecurityGroups", []) or []:
+        gid = group.get("GroupId") if isinstance(group, dict) else None
+        if gid and gid not in sg_ids:
+            sg_ids.append(gid)
+    for nic in instance.get("NetworkInterfaces", []) or []:
+        for group in (nic.get("Groups", []) if isinstance(nic, dict) else []) or []:
+            gid = group.get("GroupId") if isinstance(group, dict) else None
+            if gid and gid not in sg_ids:
+                sg_ids.append(gid)
+    placement_raw = instance.get("Placement")
+    placement = placement_raw if isinstance(placement_raw, dict) else {}
+    network = {
+        "subnet_id": instance.get("SubnetId", ""),
+        "vpc_id": instance.get("VpcId", ""),
+        "public_ip": instance.get("PublicIpAddress", ""),
+        "private_ip": instance.get("PrivateIpAddress", ""),
+        "availability_zone": placement.get("AvailabilityZone", ""),
+        "security_group_ids": sg_ids,
+    }
+    return {k: v for k, v in network.items() if v}
+
+
 def _discover_ec2_instances(
     session: Any,
     region: str,
@@ -1540,6 +1566,7 @@ def _discover_ec2_instances(
                                 location=region,
                                 account_id=account_id,
                                 raw_identity={"instance_id": instance_id, "instance_type": instance_type, "ami_id": ami_id},
+                                network=_aws_instance_network(instance),
                             )
                         },
                     )

--- a/src/agent_bom/cloud/normalization.py
+++ b/src/agent_bom/cloud/normalization.py
@@ -124,12 +124,16 @@ def build_cloud_origin(
     subscription_id: str | None = None,
     project_id: str | None = None,
     raw_identity: dict[str, Any] | None = None,
+    network: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Return a stable cloud-origin envelope for discovered assets.
 
     The envelope keeps the low-risk identifying fields needed to validate
     provider mappings without dragging full vendor payloads through the core
-    product model.
+    product model. ``network`` carries low-risk network-placement metadata
+    (subnet / VPC membership, attached security groups, public/private IP) used
+    downstream to reason about reachability — identifiers only, never rules or
+    credentials.
     """
     scope: dict[str, str] = {}
     if account_id:
@@ -160,7 +164,28 @@ def build_cloud_origin(
                     sanitized_identity[str(key)] = sanitized_value
         if sanitized_identity:
             envelope["raw_identity"] = sanitized_identity
+    if network:
+        sanitized_network = _sanitize_network_envelope(network)
+        if sanitized_network:
+            envelope["network"] = sanitized_network
     return envelope
+
+
+def _sanitize_network_envelope(network: dict[str, Any]) -> dict[str, Any]:
+    """Keep only low-risk network-placement identifiers (ids, IPs, AZ, SG ids)."""
+    out: dict[str, Any] = {}
+    for key in ("subnet_id", "vpc_id", "public_ip", "private_ip", "availability_zone"):
+        value = network.get(key)
+        if isinstance(value, str) and value:
+            cleaned = sanitize_sensitive_payload(value, key=key, max_str_len=200)
+            if cleaned not in ("", None):
+                out[key] = cleaned
+    sgs = network.get("security_group_ids")
+    if isinstance(sgs, (list, tuple)):
+        cleaned_sgs = [str(s) for s in sgs if isinstance(s, str) and s]
+        if cleaned_sgs:
+            out["security_group_ids"] = cleaned_sgs[:64]
+    return out
 
 
 def sanitize_discovery_warning(value: Any, *, max_len: int = 500) -> str:

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -1630,6 +1630,7 @@ def _add_agent_cloud_lineage(
                 "cloud_service": service,
                 "location": location,
                 "scope": origin.get("scope", {}),
+                "network": origin.get("network", {}),
                 "cloud_origin": origin,
                 "cloud_state": agent_metadata.get("cloud_state"),
                 "cloud_scope": agent_metadata.get("cloud_scope"),

--- a/tests/test_cloud_network_metadata.py
+++ b/tests/test_cloud_network_metadata.py
@@ -1,0 +1,70 @@
+"""Network placement metadata is captured into the cloud-origin envelope.
+
+Foundation for network-reachability analysis: AWS describe_instances already
+returns subnet/VPC/security-group/IP, which the scanner previously dropped. This
+captures the low-risk identifiers (no rules, no credentials) so downstream
+overlays can reason about reachability.
+"""
+
+from __future__ import annotations
+
+from agent_bom.cloud.aws import _aws_instance_network
+from agent_bom.cloud.normalization import build_cloud_origin
+
+
+def test_instance_network_extracts_placement_and_groups():
+    instance = {
+        "InstanceId": "i-123",
+        "SubnetId": "subnet-abc",
+        "VpcId": "vpc-xyz",
+        "PublicIpAddress": "203.0.113.10",
+        "PrivateIpAddress": "10.0.1.5",
+        "Placement": {"AvailabilityZone": "us-east-1a"},
+        "SecurityGroups": [{"GroupId": "sg-1"}, {"GroupId": "sg-2"}],
+    }
+    net = _aws_instance_network(instance)
+    assert net["subnet_id"] == "subnet-abc"
+    assert net["vpc_id"] == "vpc-xyz"
+    assert net["public_ip"] == "203.0.113.10"
+    assert net["availability_zone"] == "us-east-1a"
+    assert net["security_group_ids"] == ["sg-1", "sg-2"]
+
+
+def test_instance_network_merges_eni_groups_and_dedupes():
+    instance = {
+        "SecurityGroups": [{"GroupId": "sg-1"}],
+        "NetworkInterfaces": [{"Groups": [{"GroupId": "sg-1"}, {"GroupId": "sg-3"}]}],
+    }
+    assert _aws_instance_network(instance)["security_group_ids"] == ["sg-1", "sg-3"]
+
+
+def test_instance_network_omits_empty_fields():
+    # a private instance with no public IP / no VPC info
+    net = _aws_instance_network({"PrivateIpAddress": "10.0.0.9"})
+    assert net == {"private_ip": "10.0.0.9"}
+
+
+def test_build_cloud_origin_includes_sanitized_network():
+    origin = build_cloud_origin(
+        provider="aws",
+        service="ec2",
+        resource_type="instance",
+        resource_id="i-1",
+        resource_name="prod-api",
+        network={
+            "subnet_id": "subnet-1",
+            "vpc_id": "vpc-1",
+            "public_ip": "198.51.100.7",
+            "security_group_ids": ["sg-a", "sg-b"],
+            "secret_field": "should-not-appear",  # only the known keys are kept
+        },
+    )
+    net = origin["network"]
+    assert net["subnet_id"] == "subnet-1"
+    assert net["security_group_ids"] == ["sg-a", "sg-b"]
+    assert "secret_field" not in net
+
+
+def test_build_cloud_origin_without_network_has_no_network_key():
+    origin = build_cloud_origin(provider="aws", service="ec2", resource_type="instance", resource_id="i-2", resource_name="x")
+    assert "network" not in origin


### PR DESCRIPTION
## What

Captures the network placement of cloud resources (subnet, VPC, attached security-group ids, public/private IP, AZ) into the graph. **Foundation PR** for multi-hop network-reachability attack paths.

## Why

AWS `describe_instances` already returns `SubnetId` / `VpcId` / `SecurityGroups` / public + private IP, but the EC2 discovery dropped all of it. The result: the graph could say a resource was *internet-exposed*, but never **how** traffic reaches it (which port, via which hop) or **what else shares its network**. That's the gap between single-resource exposure and a real attack path (`internet → bastion:22 → subnet → crown-jewel DB`) — the most Wiz-defining capability still missing.

## How

- `build_cloud_origin(..., network=...)` gains a `network` field; `_sanitize_network_envelope` keeps **only** the known identifier keys (subnet/VPC/IP/AZ/SG-ids) — no rules, no credentials, capped SG list.
- `_aws_instance_network(instance)` extracts placement + merges security groups across the instance and its ENIs (deduped), omitting empty fields.
- The CLOUD_RESOURCE graph node surfaces it as a first-class `network` attribute.

No new graph types and no behavioural change to existing surfaces — purely additive metadata. A follow-up overlay (PR 2) consumes `network` to derive resource-to-resource reachability edges, and PR 3 derives the network attack paths.

## Tests

`tests/test_cloud_network_metadata.py`: placement extraction, multi-ENI SG merge + dedupe, empty-field omission, cloud-origin envelope sanitisation (unknown keys dropped), and the no-network case. 100 cloud/normalization/graph tests green; ruff / ruff-format / mypy / bandit clean.