### PR TITLE
fix(registry): count CVE metadata updates accurately

### DIFF
--- a/.github/workflows/mcp-registry-sync.yml
+++ b/.github/workflows/mcp-registry-sync.yml
@@ -122,11 +122,12 @@ jobs:
           async def main():
               from agent_bom.registry import enrich_registry_with_cves
               result = await enrich_registry_with_cves(dry_run=False)
-              print(f"Scannable: {result.scannable}, With CVEs: {result.enriched}")
+              print(f"Scannable: {result.scannable}, With CVEs: {result.enriched}, CVE metadata updates: {result.updated}")
               print(f"Total CVEs: {result.total_cves}, Critical: {result.total_critical}, KEV: {result.total_kev}")
               for d in result.details[:10]:
-                  print(f"  {d['server']}: {d['cve_count']} CVEs")
-              Path("/tmp/cve_count").write_text(str(result.enriched))
+                  suffix = " changed" if d.get("changed") else " unchanged"
+                  print(f"  {d['server']}: {d['cve_count']} CVEs ({d.get('change_type', 'unknown')}{suffix})")
+              Path("/tmp/cve_count").write_text(str(result.updated))
 
           asyncio.run(main())
           EOF
@@ -182,24 +183,24 @@ jobs:
           BRANCH="chore/mcp-registry-$(date +%Y%m%d)"
           git switch -C "$BRANCH" origin/main
           git add src/agent_bom/mcp_registry.json
-          git commit -S -m "chore: sync MCP registry — ${NEW_COUNT} new, ${VERSION_COUNT} versions, ${CVE_COUNT} with CVEs"
+          git commit -S -m "chore: sync MCP registry — ${NEW_COUNT} new, ${VERSION_COUNT} versions, ${CVE_COUNT} CVE metadata updates"
           git push --force-with-lease origin "$BRANCH"
           BODY="Automated weekly sync from the official MCP server registry.
 
           **New-server source:** ${SOURCE} (${SOURCE_URL})
           **New servers added:** ${NEW_COUNT}
           **Versions refreshed:** ${VERSION_COUNT}
-          **Servers with CVE data:** ${CVE_COUNT}
+          **CVE metadata updates:** ${CVE_COUNT}
 
           Please review the changes in \`src/agent_bom/mcp_registry.json\` before merging."
           PR_NUMBER=$(gh pr list --head "$BRANCH" --base main --json number --jq '.[0].number')
           if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
             gh pr edit "$PR_NUMBER" \
-              --title "chore: sync MCP registry — ${NEW_COUNT} new, ${VERSION_COUNT} versions, ${CVE_COUNT} CVE-enriched" \
+              --title "chore: sync MCP registry — ${NEW_COUNT} new, ${VERSION_COUNT} versions, ${CVE_COUNT} CVE metadata updates" \
               --body "$BODY"
           else
             gh pr create \
-              --title "chore: sync MCP registry — ${NEW_COUNT} new, ${VERSION_COUNT} versions, ${CVE_COUNT} CVE-enriched" \
+              --title "chore: sync MCP registry — ${NEW_COUNT} new, ${VERSION_COUNT} versions, ${CVE_COUNT} CVE metadata updates" \
               --body "$BODY" \
               --base main
           fi

--- a/scripts/enrich_registry_cves.py
+++ b/scripts/enrich_registry_cves.py
@@ -40,6 +40,8 @@ def main() -> None:
     print(f"\nTotal servers: {result.total}")
     print(f"Scannable (npm/pypi): {result.scannable}")
     print(f"With CVEs: {result.enriched}")
+    print(f"CVE metadata updates: {result.updated}")
+    print(f"CVE metadata cleared: {result.cleared}")
     print(f"Total CVEs found: {result.total_cves}")
     print(f"Critical (EPSS >= 0.7 or KEV): {result.total_critical}")
     print(f"In CISA KEV: {result.total_kev}")
@@ -52,8 +54,8 @@ def main() -> None:
             if d["cves"]:
                 print(f"    {', '.join(d['cves'][:5])}")
 
-    if not args.dry_run and result.enriched > 0:
-        print("\nRegistry file updated with CVE data.")
+    if not args.dry_run and result.updated > 0:
+        print("\nRegistry file updated with CVE metadata changes.")
 
 
 if __name__ == "__main__":

--- a/src/agent_bom/cli/_registry.py
+++ b/src/agent_bom/cli/_registry.py
@@ -354,11 +354,12 @@ def registry_enrich_cves(nvd_api_key, dry_run):
 
     con.print(
         f"\n[bold]Summary:[/bold] {result.scannable} scannable, {result.enriched} with CVEs, "
+        f"{result.updated} CVE metadata update(s), {result.cleared} cleared, "
         f"{result.total_cves} total CVEs, {result.total_critical} critical, {result.total_kev} KEV "
         f"(of {result.total} total servers)"
     )
-    if not dry_run and result.enriched > 0:
-        con.print("[green]Registry file updated with CVE data.[/green]")
+    if not dry_run and result.updated > 0:
+        con.print("[green]Registry file updated with CVE metadata changes.[/green]")
 
 
 @registry.command("smithery-sync")

--- a/src/agent_bom/registry.py
+++ b/src/agent_bom/registry.py
@@ -644,6 +644,8 @@ class CVEEnrichResult:
     total: int = 0
     scannable: int = 0
     enriched: int = 0
+    updated: int = 0
+    cleared: int = 0
     total_cves: int = 0
     total_critical: int = 0
     total_kev: int = 0
@@ -739,7 +741,24 @@ async def enrich_registry_with_cves(
         vulns = osv_results.get(key, [])
 
         if not vulns:
-            if not dry_run and entry.get("known_cves"):
+            had_cve_metadata = bool(entry.get("known_cves") or entry.get("cve_summary"))
+            if had_cve_metadata:
+                result.updated += 1
+                result.cleared += 1
+                result.details.append(
+                    {
+                        "server": name,
+                        "package": pkg_name,
+                        "cve_count": 0,
+                        "ghsa_count": 0,
+                        "critical": 0,
+                        "kev": 0,
+                        "cves": [],
+                        "changed": True,
+                        "change_type": "cleared",
+                    }
+                )
+            if not dry_run and had_cve_metadata:
                 entry["known_cves"] = []
                 entry["cve_summary"] = {}
             continue
@@ -811,8 +830,12 @@ async def enrich_registry_with_cves(
             "fix_versions": fix_versions[:5],
         }
 
+        known_cves = cve_ids + [g for g in ghsa_ids if g not in cve_ids]
+        metadata_changed = entry.get("known_cves", []) != known_cves or entry.get("cve_summary", {}) != summary
+        if metadata_changed:
+            result.updated += 1
         if not dry_run:
-            entry["known_cves"] = cve_ids + [g for g in ghsa_ids if g not in cve_ids]
+            entry["known_cves"] = known_cves
             entry["cve_summary"] = summary
 
         result.enriched += 1
@@ -828,11 +851,13 @@ async def enrich_registry_with_cves(
                 "critical": critical_count,
                 "kev": kev_count,
                 "cves": cve_ids[:10],
+                "changed": metadata_changed,
+                "change_type": "updated" if metadata_changed else "unchanged",
             }
         )
 
     # Write updated registry
-    if not dry_run and result.enriched > 0:
+    if not dry_run and result.updated > 0:
         from datetime import datetime, timezone
 
         data["_cve_enriched"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")

--- a/tests/test_cli_registry.py
+++ b/tests/test_cli_registry.py
@@ -208,6 +208,8 @@ def test_registry_enrich_cves_found():
     runner = CliRunner()
     mock_result = SimpleNamespace(
         enriched=1,
+        updated=1,
+        cleared=0,
         total=5,
         scannable=3,
         total_cves=3,
@@ -227,6 +229,8 @@ def test_registry_enrich_cves_none():
     runner = CliRunner()
     mock_result = SimpleNamespace(
         enriched=0,
+        updated=0,
+        cleared=0,
         total=5,
         scannable=3,
         total_cves=0,
@@ -244,6 +248,8 @@ def test_registry_enrich_cves_with_kev():
     runner = CliRunner()
     mock_result = SimpleNamespace(
         enriched=1,
+        updated=1,
+        cleared=0,
         total=2,
         scannable=2,
         total_cves=1,

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -562,6 +562,8 @@ def test_cve_enrich_result_dataclass():
     assert r.total == 10
     assert r.scannable == 5
     assert r.enriched == 2
+    assert r.updated == 0
+    assert r.cleared == 0
     assert r.total_cves == 3
     assert r.total_critical == 0
     assert r.total_kev == 0
@@ -649,9 +651,56 @@ async def test_enrich_registry_with_cves_with_vulns():
         result = await enrich_registry_with_cves(dry_run=True)
 
     assert result.enriched == 1
+    assert result.updated == 1
     assert result.total_cves == 1
     assert result.total_critical == 1  # EPSS >= 0.7
     assert result.details[0]["cves"] == ["CVE-2024-12345"]
+    assert result.details[0]["changed"] is True
+
+
+@pytest.mark.asyncio
+async def test_enrich_registry_with_cves_unchanged_metadata_not_counted_as_update():
+    """Existing matching CVE metadata is reported without inflating update counts."""
+    from agent_bom.registry import enrich_registry_with_cves
+
+    summary = {
+        "total": 1,
+        "ghsa_count": 0,
+        "critical": 0,
+        "kev": 0,
+        "severity_breakdown": {"critical": 0, "high": 0, "medium": 0, "low": 0},
+        "fix_available": False,
+        "fix_versions": [],
+    }
+    registry = {
+        "servers": {
+            "stable-vuln-server": {
+                "package": "stable-vuln-pkg",
+                "ecosystem": "npm",
+                "latest_version": "1.0.0",
+                "known_cves": ["CVE-2024-12345"],
+                "cve_summary": summary,
+            }
+        }
+    }
+    osv_vulns = {
+        "npm:stable-vuln-pkg@1.0.0": [
+            {"id": "CVE-2024-12345", "aliases": [], "severity": [], "affected": []},
+        ],
+    }
+
+    with (
+        patch("agent_bom.registry._load_registry_full", return_value=registry),
+        patch("agent_bom.scanners.query_osv_batch", new_callable=AsyncMock, return_value=osv_vulns),
+        patch("agent_bom.enrichment.fetch_epss_scores", new_callable=AsyncMock, return_value={}),
+        patch("agent_bom.enrichment.fetch_cisa_kev_catalog", new_callable=AsyncMock, return_value={}),
+    ):
+        result = await enrich_registry_with_cves(dry_run=True)
+
+    assert result.enriched == 1
+    assert result.updated == 0
+    assert result.details[0]["changed"] is False
+    assert result.details[0]["change_type"] == "unchanged"
 
 
 @pytest.mark.asyncio
@@ -689,6 +738,7 @@ async def test_enrich_registry_with_cves_kev_detection():
         result = await enrich_registry_with_cves(dry_run=True)
 
     assert result.enriched == 1
+    assert result.updated == 1
     assert result.total_kev == 1
     assert result.total_critical == 1  # KEV = critical
 
@@ -716,4 +766,40 @@ async def test_enrich_registry_with_cves_no_vulns():
 
     assert result.scannable == 1
     assert result.enriched == 0
+    assert result.updated == 0
     assert result.total_cves == 0
+
+
+@pytest.mark.asyncio
+async def test_enrich_registry_with_cves_clears_stale_metadata(tmp_path):
+    """A clean OSV response removes stale CVE metadata and writes the registry."""
+    from agent_bom.registry import enrich_registry_with_cves
+
+    registry_path = tmp_path / "mcp_registry.json"
+    registry = {
+        "servers": {
+            "formerly-vuln-server": {
+                "package": "formerly-vuln-pkg",
+                "ecosystem": "npm",
+                "latest_version": "3.0.0",
+                "known_cves": ["CVE-2024-99999"],
+                "cve_summary": {"total": 1},
+            }
+        }
+    }
+
+    with (
+        patch("agent_bom.registry._REGISTRY_PATH", registry_path),
+        patch("agent_bom.registry._load_registry_full", return_value=registry),
+        patch("agent_bom.scanners.query_osv_batch", new_callable=AsyncMock, return_value={}),
+    ):
+        result = await enrich_registry_with_cves(dry_run=False)
+
+    assert result.enriched == 0
+    assert result.updated == 1
+    assert result.cleared == 1
+    assert result.details[0]["change_type"] == "cleared"
+    written = json.loads(registry_path.read_text(encoding="utf-8"))
+    server = written["servers"]["formerly-vuln-server"]
+    assert server["known_cves"] == []
+    assert server["cve_summary"] == {}


### PR DESCRIPTION
Summary
- Separates servers-with-CVEs from registry CVE metadata updates in the enrichment result.
- Makes the scheduled MCP registry PR title/body report CVE metadata updates instead of ambiguous CVE-enriched counts.
- Persists stale CVE metadata clears when OSV no longer reports vulnerabilities.

Verification
- uv run pytest -q tests/test_registry.py tests/test_cli_registry.py tests/test_mcp_official_registry.py
- uv run ruff check src/agent_bom/registry.py src/agent_bom/cli/_registry.py scripts/enrich_registry_cves.py tests/test_registry.py tests/test_cli_registry.py
- git diff --check
- pre-commit hooks on commit: yaml, ruff, ruff-format, mypy, bandit, env-var drift, duplicate artifact guard

Notes
- `enriched` remains the count of scannable servers where OSV returned vulnerabilities.
- `updated` is the count used by automation because it reflects actual `known_cves` / `cve_summary` registry changes.