### PR TITLE
feat(azure): add OIDC ingestion baseline

### DIFF
--- a/.github/workflows/azure-ingestion.yml
+++ b/.github/workflows/azure-ingestion.yml
@@ -1,0 +1,153 @@
+name: Azure Ingestion
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_cis:
+        description: "Run CIS Azure benchmark checks"
+        required: false
+        type: boolean
+        default: true
+      push_fleet:
+        description: "Also sync discovered agents into /v1/fleet/sync"
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    - cron: "23 7 * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: azure-ingestion-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  ingest:
+    name: Azure scan and API ingest
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      AZURE_CLIENT_ID: ${{ vars.AGENT_BOM_AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ vars.AGENT_BOM_AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ vars.AGENT_BOM_AZURE_SUBSCRIPTION_ID }}
+      AGENT_BOM_AZURE_KEY_VAULT_NAME: ${{ vars.AGENT_BOM_AZURE_KEY_VAULT_NAME }}
+      AGENT_BOM_API_URL: ${{ vars.AGENT_BOM_API_URL }}
+      AGENT_BOM_API_KEY: ${{ secrets.AGENT_BOM_API_KEY }}
+      AGENT_BOM_PUSH_SOURCE_ID: github-actions-azure-${{ github.repository_id }}
+      AGENT_BOM_PUSH_OWNER: platform-security
+      AGENT_BOM_PUSH_ENVIRONMENT: azure
+      AGENT_BOM_PUSH_TAGS: azure,github-actions,oidc
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: "3.11"
+
+      - name: Validate Azure OIDC configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf 'Missing required repository variable(s): %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Azure login with GitHub OIDC
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] || [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
+            echo "GitHub OIDC token request variables are unavailable. Check id-token: write permissions." >&2
+            exit 1
+          fi
+          oidc_token="$(
+            python - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          url = os.environ["ACTIONS_ID_TOKEN_REQUEST_URL"] + "&audience=api://AzureADTokenExchange"
+          req = urllib.request.Request(url, headers={"Authorization": f"Bearer {os.environ['ACTIONS_ID_TOKEN_REQUEST_TOKEN']}"})
+          with urllib.request.urlopen(req, timeout=30) as response:
+              print(json.load(response)["value"])
+          PY
+          )"
+          az login \
+            --service-principal \
+            --tenant "$AZURE_TENANT_ID" \
+            --username "$AZURE_CLIENT_ID" \
+            --federated-token "$oidc_token" \
+            --output none
+          az account set --subscription "$AZURE_SUBSCRIPTION_ID"
+
+      - name: Load API ingestion config from Key Vault
+        if: env.AGENT_BOM_AZURE_KEY_VAULT_NAME != '' && (env.AGENT_BOM_API_URL == '' || env.AGENT_BOM_API_KEY == '')
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${AGENT_BOM_API_URL:-}" ]; then
+            api_url="$(az keyvault secret show --vault-name "$AGENT_BOM_AZURE_KEY_VAULT_NAME" --name agent-bom-api-url --query value -o tsv)"
+            echo "::add-mask::$api_url"
+            echo "AGENT_BOM_API_URL=$api_url" >> "$GITHUB_ENV"
+          fi
+          if [ -z "${AGENT_BOM_API_KEY:-}" ]; then
+            api_key="$(az keyvault secret show --vault-name "$AGENT_BOM_AZURE_KEY_VAULT_NAME" --name agent-bom-api-key --query value -o tsv)"
+            echo "::add-mask::$api_key"
+            echo "AGENT_BOM_API_KEY=$api_key" >> "$GITHUB_ENV"
+          fi
+
+      - name: Validate API ingestion configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in AGENT_BOM_API_URL AGENT_BOM_API_KEY; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf 'Missing API ingestion configuration: %s\n' "${missing[*]}" >&2
+            printf 'Set vars.AGENT_BOM_API_URL + secrets.AGENT_BOM_API_KEY or configure AGENT_BOM_AZURE_KEY_VAULT_NAME with the expected secrets.\n' >&2
+            exit 1
+          fi
+
+      - name: Install Azure scanner dependencies
+        run: uv sync --frozen --extra azure
+
+      - name: Run Azure scan and push results
+        shell: bash
+        env:
+          RUN_CIS: ${{ inputs.run_cis }}
+        run: |
+          set -euo pipefail
+          args=(agent-bom scan --azure --azure-subscription "$AZURE_SUBSCRIPTION_ID" --format json --quiet)
+          if [ "${RUN_CIS:-true}" = "true" ]; then
+            args+=(--azure-cis-benchmark)
+          fi
+          args+=(--push-url "${AGENT_BOM_API_URL%/}/v1/results/push" --push-api-key "$AGENT_BOM_API_KEY")
+          uv run "${args[@]}"
+
+      - name: Sync fleet inventory
+        if: inputs.push_fleet == true
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run agent-bom scan \
+            --azure \
+            --azure-subscription "$AZURE_SUBSCRIPTION_ID" \
+            --no-scan \
+            --format json \
+            --quiet \
+            --push-url "${AGENT_BOM_API_URL%/}/v1/fleet/sync" \
+            --push-api-key "$AGENT_BOM_API_KEY"

--- a/deploy/terraform/azure/ingestion/README.md
+++ b/deploy/terraform/azure/ingestion/README.md
@@ -1,0 +1,118 @@
+# Azure ingestion baseline
+
+Terraform baseline for running `agent-bom` Azure discovery from GitHub Actions
+without stored Azure credentials.
+
+This module assumes the Azure tenant and subscription already exist. It creates:
+
+- a Microsoft Entra application and service principal for GitHub Actions
+- a federated identity credential for the selected GitHub repo/ref or environment
+- a least-privilege Azure role definition for agent-bom Azure discovery
+- a role assignment for the GitHub service principal
+- an optional Key Vault for the agent-bom API URL and API key used by ingestion
+
+It does not create an Azure tenant or subscription. Those are account and billing
+operations and should be created through the customer's normal Azure enrollment
+process before this module runs.
+
+## Usage
+
+```hcl
+module "agent_bom_azure_ingestion" {
+  source = "./deploy/terraform/azure/ingestion"
+
+  tenant_id       = "00000000-0000-0000-0000-000000000000"
+  subscription_id = "11111111-1111-1111-1111-111111111111"
+  github_owner    = "msaad00"
+  github_repo     = "agent-bom"
+  github_ref      = "refs/heads/main"
+
+  tags = {
+    owner       = "platform-security"
+    environment = "prod"
+  }
+}
+```
+
+Run from an operator shell that is already logged into Azure with permissions to
+create Entra applications, role definitions, role assignments, and the optional
+Key Vault:
+
+```bash
+az login --tenant "$AZURE_TENANT_ID"
+az account set --subscription "$AZURE_SUBSCRIPTION_ID"
+terraform init
+terraform apply
+```
+
+## GitHub repository variables
+
+Set these GitHub repository variables from `terraform output github_variables_hint`:
+
+```text
+AGENT_BOM_AZURE_CLIENT_ID
+AGENT_BOM_AZURE_TENANT_ID
+AGENT_BOM_AZURE_SUBSCRIPTION_ID
+AGENT_BOM_AZURE_KEY_VAULT_NAME
+```
+
+The workflow at `.github/workflows/azure-ingestion.yml` uses GitHub OIDC to log
+in to Azure, runs:
+
+```bash
+agent-bom scan --azure --azure-subscription "$AZURE_SUBSCRIPTION_ID" \
+  --push-url "$AGENT_BOM_API_URL/v1/results/push" \
+  --push-api-key "$AGENT_BOM_API_KEY"
+```
+
+and optionally pushes fleet inventory to `/v1/fleet/sync`.
+
+## API ingestion configuration
+
+Preferred: store ingestion config in the module-created Key Vault, outside
+Terraform state:
+
+```bash
+az keyvault secret set \
+  --vault-name "$(terraform output -raw key_vault_name)" \
+  --name agent-bom-api-url \
+  --value "https://agent-bom.example.com"
+
+az keyvault secret set \
+  --vault-name "$(terraform output -raw key_vault_name)" \
+  --name agent-bom-api-key \
+  --value "<tenant-scoped analyst API key>"
+```
+
+Alternative: set GitHub `vars.AGENT_BOM_API_URL` and
+`secrets.AGENT_BOM_API_KEY` directly.
+
+Use an analyst API key for `/v1/results/push`. If the workflow input
+`push_fleet` is enabled, the key must also have permission for
+`/v1/fleet/sync`.
+
+## Subject scoping
+
+By default the federated credential trusts:
+
+```text
+repo:<github_owner>/<github_repo>:ref:<github_ref>
+```
+
+For GitHub environment protection, set `github_environment`; the subject becomes:
+
+```text
+repo:<github_owner>/<github_repo>:environment:<github_environment>
+```
+
+Use `federated_subject_override` only for non-standard subject contracts.
+
+## Notes
+
+- GitHub Actions needs `permissions: id-token: write` to mint the OIDC token.
+- GitHub-hosted runners need Key Vault public network access. For self-hosted
+  private runners, set `key_vault_public_network_access_enabled = false` and
+  provide private network access.
+- The Azure scanner uses SDK `DefaultAzureCredential`; the workflow performs
+  `az login --service-principal --federated-token ...` so the SDK can use the
+  Azure CLI credential without a client secret.

--- a/deploy/terraform/azure/ingestion/main.tf
+++ b/deploy/terraform/azure/ingestion/main.tf
@@ -1,0 +1,148 @@
+data "azurerm_client_config" "current" {}
+
+resource "random_string" "suffix" {
+  length  = 6
+  upper   = false
+  special = false
+}
+
+locals {
+  subscription_scope = "/subscriptions/${var.subscription_id}"
+  scanner_scope      = var.scanner_role_scope != "" ? var.scanner_role_scope : local.subscription_scope
+  resource_group     = var.resource_group_name != "" ? var.resource_group_name : "${var.name}-ingestion"
+  github_subject = (
+    var.federated_subject_override != ""
+    ? var.federated_subject_override
+    : (
+      var.github_environment != ""
+      ? "repo:${var.github_owner}/${var.github_repo}:environment:${var.github_environment}"
+      : "repo:${var.github_owner}/${var.github_repo}:ref:${var.github_ref}"
+    )
+  )
+  key_vault_name = var.key_vault_name != "" ? var.key_vault_name : substr(replace("${var.name}-${random_string.suffix.result}", "-", ""), 0, 24)
+  common_tags = merge(
+    {
+      "app.kubernetes.io/name"       = "agent-bom"
+      "app.kubernetes.io/managed-by" = "terraform"
+      "agent-bom.io/module"          = "azure-ingestion"
+    },
+    var.tags,
+  )
+}
+
+resource "azurerm_resource_group" "this" {
+  count    = var.create_resource_group ? 1 : 0
+  name     = local.resource_group
+  location = var.location
+  tags     = local.common_tags
+}
+
+resource "azuread_application" "github_ingestion" {
+  display_name = "${var.name}-github-ingestion"
+  owners       = [data.azurerm_client_config.current.object_id]
+}
+
+resource "azuread_service_principal" "github_ingestion" {
+  client_id = azuread_application.github_ingestion.client_id
+  owners    = [data.azurerm_client_config.current.object_id]
+}
+
+resource "azuread_application_federated_identity_credential" "github_ingestion" {
+  application_id = azuread_application.github_ingestion.id
+  display_name   = "${var.name}-github-actions"
+  description    = "GitHub Actions OIDC federation for agent-bom Azure ingestion."
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = "https://token.actions.githubusercontent.com"
+  subject        = local.github_subject
+}
+
+resource "azurerm_role_definition" "scanner" {
+  count       = var.create_scanner_role_definition ? 1 : 0
+  name        = "${var.name} Scanner"
+  scope       = local.scanner_scope
+  description = "Read-only role for agent-bom Azure AI infrastructure security scanning."
+
+  permissions {
+    actions = [
+      "Microsoft.App/containerApps/read",
+      "Microsoft.Authorization/roleAssignments/read",
+      "Microsoft.Authorization/roleDefinitions/read",
+      "Microsoft.CognitiveServices/accounts/deployments/read",
+      "Microsoft.CognitiveServices/accounts/read",
+      "Microsoft.Compute/disks/read",
+      "Microsoft.Compute/virtualMachines/extensions/read",
+      "Microsoft.Compute/virtualMachines/instanceView/read",
+      "Microsoft.Compute/virtualMachines/read",
+      "Microsoft.ContainerInstance/containerGroups/read",
+      "Microsoft.ContainerRegistry/registries/read",
+      "Microsoft.ContainerRegistry/registries/repositories/read",
+      "Microsoft.ContainerService/managedClusters/agentPools/read",
+      "Microsoft.ContainerService/managedClusters/read",
+      "Microsoft.DBforMySQL/servers/read",
+      "Microsoft.DBforPostgreSQL/servers/configurations/read",
+      "Microsoft.DBforPostgreSQL/servers/read",
+      "Microsoft.Insights/activityLogAlerts/read",
+      "Microsoft.Insights/diagnosticSettings/read",
+      "Microsoft.Insights/logProfiles/read",
+      "Microsoft.KeyVault/vaults/keys/read",
+      "Microsoft.KeyVault/vaults/privateEndpointConnections/read",
+      "Microsoft.KeyVault/vaults/read",
+      "Microsoft.MachineLearningServices/workspaces/computes/read",
+      "Microsoft.MachineLearningServices/workspaces/endpoints/read",
+      "Microsoft.MachineLearningServices/workspaces/models/read",
+      "Microsoft.MachineLearningServices/workspaces/onlineEndpoints/read",
+      "Microsoft.MachineLearningServices/workspaces/read",
+      "Microsoft.Network/applicationGateways/read",
+      "Microsoft.Network/frontDoors/read",
+      "Microsoft.Network/networkSecurityGroups/read",
+      "Microsoft.Network/networkWatchers/read",
+      "Microsoft.Resources/subscriptions/read",
+      "Microsoft.Resources/subscriptions/resourceGroups/read",
+      "Microsoft.Security/pricings/read",
+      "Microsoft.Sql/servers/administrators/read",
+      "Microsoft.Sql/servers/advancedThreatProtectionSettings/read",
+      "Microsoft.Sql/servers/auditingSettings/read",
+      "Microsoft.Sql/servers/encryptionProtector/read",
+      "Microsoft.Sql/servers/read",
+      "Microsoft.Sql/servers/vulnerabilityAssessments/read",
+      "Microsoft.Storage/storageAccounts/blobServices/read",
+      "Microsoft.Storage/storageAccounts/privateEndpointConnections/read",
+      "Microsoft.Storage/storageAccounts/read",
+      "Microsoft.Web/sites/config/read",
+      "Microsoft.Web/sites/read",
+    ]
+    not_actions = []
+  }
+
+  assignable_scopes = [local.scanner_scope]
+}
+
+resource "azurerm_role_assignment" "scanner" {
+  scope              = local.scanner_scope
+  role_definition_id = var.create_scanner_role_definition ? azurerm_role_definition.scanner[0].role_definition_resource_id : var.scanner_role_definition_id
+  principal_id       = azuread_service_principal.github_ingestion.object_id
+}
+
+resource "azurerm_key_vault" "ingestion" {
+  count                         = var.create_key_vault ? 1 : 0
+  name                          = local.key_vault_name
+  location                      = var.location
+  resource_group_name           = local.resource_group
+  tenant_id                     = var.tenant_id
+  sku_name                      = var.key_vault_sku_name
+  rbac_authorization_enabled    = true
+  purge_protection_enabled      = true
+  soft_delete_retention_days    = 7
+  public_network_access_enabled = var.key_vault_public_network_access_enabled
+  tags                          = local.common_tags
+
+  depends_on = [azurerm_resource_group.this]
+}
+
+resource "azurerm_role_assignment" "key_vault_secret_reader" {
+  for_each = var.create_key_vault ? toset(concat([azuread_service_principal.github_ingestion.object_id], var.key_vault_secret_reader_principal_ids)) : toset([])
+
+  scope                = azurerm_key_vault.ingestion[0].id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = each.value
+}

--- a/deploy/terraform/azure/ingestion/outputs.tf
+++ b/deploy/terraform/azure/ingestion/outputs.tf
@@ -1,0 +1,77 @@
+output "azure_client_id" {
+  description = "Application/client ID for GitHub Actions OIDC login."
+  value       = azuread_application.github_ingestion.client_id
+}
+
+output "azure_tenant_id" {
+  description = "Tenant ID for GitHub Actions OIDC login."
+  value       = var.tenant_id
+}
+
+output "azure_subscription_id" {
+  description = "Subscription ID scanned by the ingestion workflow."
+  value       = var.subscription_id
+}
+
+output "service_principal_object_id" {
+  description = "Object ID of the GitHub ingestion service principal."
+  value       = azuread_service_principal.github_ingestion.object_id
+}
+
+output "federated_subject" {
+  description = "GitHub OIDC subject trusted by the Azure application."
+  value       = local.github_subject
+}
+
+output "scanner_scope" {
+  description = "Azure scope where scanner permissions were assigned."
+  value       = local.scanner_scope
+}
+
+output "scanner_role_definition_id" {
+  description = "Custom role definition ID used for scanner access."
+  value       = var.create_scanner_role_definition ? azurerm_role_definition.scanner[0].role_definition_resource_id : var.scanner_role_definition_id
+}
+
+output "resource_group_name" {
+  description = "Support resource group name."
+  value       = local.resource_group
+}
+
+output "key_vault_name" {
+  description = "Key Vault name for ingestion workflow configuration."
+  value       = var.create_key_vault ? azurerm_key_vault.ingestion[0].name : null
+}
+
+output "key_vault_uri" {
+  description = "Key Vault URI for ingestion workflow configuration."
+  value       = var.create_key_vault ? azurerm_key_vault.ingestion[0].vault_uri : null
+}
+
+output "api_url_secret_name" {
+  description = "Expected Key Vault secret name for the agent-bom API base URL."
+  value       = var.api_url_secret_name
+}
+
+output "api_key_secret_name" {
+  description = "Expected Key Vault secret name for the agent-bom API key."
+  value       = var.api_key_secret_name
+}
+
+output "github_variables_hint" {
+  description = "Repository variables consumed by .github/workflows/azure-ingestion.yml."
+  value = {
+    AGENT_BOM_AZURE_CLIENT_ID       = azuread_application.github_ingestion.client_id
+    AGENT_BOM_AZURE_TENANT_ID       = var.tenant_id
+    AGENT_BOM_AZURE_SUBSCRIPTION_ID = var.subscription_id
+    AGENT_BOM_AZURE_KEY_VAULT_NAME  = var.create_key_vault ? azurerm_key_vault.ingestion[0].name : ""
+  }
+}
+
+output "key_vault_secret_commands" {
+  description = "Commands to set ingestion API configuration outside Terraform state."
+  value = var.create_key_vault ? [
+    "az keyvault secret set --vault-name ${azurerm_key_vault.ingestion[0].name} --name ${var.api_url_secret_name} --value https://agent-bom.example.com",
+    "az keyvault secret set --vault-name ${azurerm_key_vault.ingestion[0].name} --name ${var.api_key_secret_name} --value '<tenant-scoped analyst API key>'",
+  ] : []
+}

--- a/deploy/terraform/azure/ingestion/variables.tf
+++ b/deploy/terraform/azure/ingestion/variables.tf
@@ -1,0 +1,127 @@
+variable "name" {
+  description = "Base name for Azure resources."
+  type        = string
+  default     = "agent-bom"
+}
+
+variable "tenant_id" {
+  description = "Existing Microsoft Entra tenant ID."
+  type        = string
+}
+
+variable "subscription_id" {
+  description = "Existing Azure subscription ID to scan and host support resources."
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region for support resources such as Key Vault."
+  type        = string
+  default     = "eastus"
+}
+
+variable "resource_group_name" {
+  description = "Resource group for optional support resources. Defaults to <name>-ingestion."
+  type        = string
+  default     = ""
+}
+
+variable "create_resource_group" {
+  description = "Whether to create the support resource group."
+  type        = bool
+  default     = true
+}
+
+variable "github_owner" {
+  description = "GitHub repository owner or organization allowed to federate into Azure."
+  type        = string
+}
+
+variable "github_repo" {
+  description = "GitHub repository name allowed to federate into Azure."
+  type        = string
+}
+
+variable "github_ref" {
+  description = "Git ref allowed to federate. Ignored when github_environment is set."
+  type        = string
+  default     = "refs/heads/main"
+}
+
+variable "github_environment" {
+  description = "Optional GitHub environment name. When set, the federated subject uses environment scoping instead of a branch ref."
+  type        = string
+  default     = ""
+}
+
+variable "federated_subject_override" {
+  description = "Optional exact GitHub OIDC subject. Use only when branch/environment defaults are not sufficient."
+  type        = string
+  default     = ""
+}
+
+variable "create_scanner_role_definition" {
+  description = "Whether to create the custom agent-bom Scanner role definition."
+  type        = bool
+  default     = true
+}
+
+variable "scanner_role_definition_id" {
+  description = "Existing custom role definition ID or built-in role ID to assign when create_scanner_role_definition is false."
+  type        = string
+  default     = ""
+}
+
+variable "scanner_role_scope" {
+  description = "Scope for scanner role definition and assignment. Defaults to the subscription."
+  type        = string
+  default     = ""
+}
+
+variable "create_key_vault" {
+  description = "Whether to create a Key Vault for ingestion workflow configuration."
+  type        = bool
+  default     = true
+}
+
+variable "key_vault_name" {
+  description = "Optional Key Vault name. Defaults to a globally unique name derived from name."
+  type        = string
+  default     = ""
+}
+
+variable "key_vault_sku_name" {
+  description = "Key Vault SKU."
+  type        = string
+  default     = "standard"
+}
+
+variable "key_vault_public_network_access_enabled" {
+  description = "Whether the Key Vault accepts public network access. GitHub-hosted runners need this true; self-hosted private runners can set false with private networking."
+  type        = bool
+  default     = true
+}
+
+variable "key_vault_secret_reader_principal_ids" {
+  description = "Additional principal object IDs allowed to read Key Vault secrets."
+  type        = list(string)
+  default     = []
+}
+
+variable "api_url_secret_name" {
+  description = "Key Vault secret name expected to contain the agent-bom API base URL."
+  type        = string
+  default     = "agent-bom-api-url"
+}
+
+variable "api_key_secret_name" {
+  description = "Key Vault secret name expected to contain the agent-bom API key."
+  type        = string
+  default     = "agent-bom-api-key"
+}
+
+variable "tags" {
+  description = "Tags applied to Terraform-managed Azure resources."
+  type        = map(string)
+  default     = {}
+}

--- a/deploy/terraform/azure/ingestion/versions.tf
+++ b/deploy/terraform/azure/ingestion/versions.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.0"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = ">= 3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id
+  tenant_id       = var.tenant_id
+}
+
+provider "azuread" {
+  tenant_id = var.tenant_id
+}

--- a/scripts/provision/README.md
+++ b/scripts/provision/README.md
@@ -140,6 +140,17 @@ Covers: AKS (Azure Kubernetes Service), Azure ML, Container Instances, Cognitive
 AKS is Azure's managed Kubernetes service — the custom role covers both ARM-level
 cluster discovery and AKS credential retrieval for K8s API access.
 
+### Terraform + GitHub Actions OIDC ingestion
+
+For production GitHub Actions ingestion, prefer the Terraform baseline in
+`deploy/terraform/azure/ingestion`. It creates the Entra application, service
+principal, GitHub federated credential, scanner role assignment, and optional
+Key Vault used by `.github/workflows/azure-ingestion.yml`.
+
+The Azure tenant and subscription must already exist; Terraform targets them
+through explicit `tenant_id` and `subscription_id` inputs. See
+`site-docs/deployment/terraform-azure-ingestion.md`.
+
 ### 1. Create the custom role
 
 ```bash

--- a/site-docs/deployment/terraform-azure-ingestion.md
+++ b/site-docs/deployment/terraform-azure-ingestion.md
@@ -1,0 +1,70 @@
+# Terraform Azure ingestion
+
+`agent-bom` includes an Azure ingestion baseline at:
+
+- `deploy/terraform/azure/ingestion`
+
+The module wires GitHub Actions to Azure through OIDC and prepares a secure path
+for pushing Azure scan evidence into the control-plane API.
+
+## What it creates
+
+- Microsoft Entra application and service principal for GitHub Actions
+- GitHub federated identity credential scoped to one repo/ref or environment
+- least-privilege Azure scanner role definition
+- scanner role assignment at the configured subscription or narrower scope
+- optional Key Vault for the control-plane API URL and API key
+
+The Azure tenant and subscription must already exist. Create those through the
+customer's Azure account and billing process, then run Terraform inside that
+tenant/subscription.
+
+## First run
+
+```bash
+cd deploy/terraform/azure/ingestion
+terraform init
+terraform apply \
+  -var tenant_id="$AZURE_TENANT_ID" \
+  -var subscription_id="$AZURE_SUBSCRIPTION_ID" \
+  -var github_owner="msaad00" \
+  -var github_repo="agent-bom"
+```
+
+After apply, set the GitHub repository variables from:
+
+```bash
+terraform output github_variables_hint
+```
+
+Then store ingestion config either in GitHub directly:
+
+```text
+vars.AGENT_BOM_API_URL
+secrets.AGENT_BOM_API_KEY
+```
+
+or in the module-created Key Vault:
+
+```bash
+az keyvault secret set --vault-name "$(terraform output -raw key_vault_name)" \
+  --name agent-bom-api-url \
+  --value "https://agent-bom.example.com"
+
+az keyvault secret set --vault-name "$(terraform output -raw key_vault_name)" \
+  --name agent-bom-api-key \
+  --value "<tenant-scoped analyst API key>"
+```
+
+## Ingestion workflow
+
+`.github/workflows/azure-ingestion.yml` runs with:
+
+- `permissions.id-token: write`
+- GitHub OIDC login to Azure
+- `agent-bom scan --azure --azure-subscription ...`
+- push to `/v1/results/push`
+
+The workflow can also sync fleet inventory to `/v1/fleet/sync` when manually
+triggered with `push_fleet=true`. That path requires a key with fleet write
+permission; the default scan-result push path needs analyst-level write access.

--- a/tests/test_azure_ingestion_baseline.py
+++ b/tests/test_azure_ingestion_baseline.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE = ROOT / "deploy" / "terraform" / "azure" / "ingestion"
+WORKFLOW = ROOT / ".github" / "workflows" / "azure-ingestion.yml"
+
+
+def test_azure_ingestion_terraform_module_exists() -> None:
+    assert (MODULE / "versions.tf").exists()
+    assert (MODULE / "main.tf").exists()
+    assert (MODULE / "variables.tf").exists()
+    assert (MODULE / "outputs.tf").exists()
+    assert (MODULE / "README.md").exists()
+
+
+def test_azure_ingestion_module_wires_github_oidc_without_client_secret() -> None:
+    main_tf = (MODULE / "main.tf").read_text(encoding="utf-8")
+    versions_tf = (MODULE / "versions.tf").read_text(encoding="utf-8")
+    variables_tf = (MODULE / "variables.tf").read_text(encoding="utf-8")
+
+    assert 'source  = "hashicorp/azurerm"' in versions_tf
+    assert 'source  = "hashicorp/azuread"' in versions_tf
+    assert "azuread_application_federated_identity_credential" in main_tf
+    assert 'issuer         = "https://token.actions.githubusercontent.com"' in main_tf
+    assert 'audiences      = ["api://AzureADTokenExchange"]' in main_tf
+    assert "repo:${var.github_owner}/${var.github_repo}:ref:${var.github_ref}" in main_tf
+    assert "repo:${var.github_owner}/${var.github_repo}:environment:${var.github_environment}" in main_tf
+    assert "client_secret" not in main_tf
+    assert "client_secret" not in variables_tf
+
+
+def test_azure_ingestion_module_assigns_scanner_and_key_vault_access() -> None:
+    main_tf = (MODULE / "main.tf").read_text(encoding="utf-8")
+    outputs_tf = (MODULE / "outputs.tf").read_text(encoding="utf-8")
+
+    for permission in [
+        "Microsoft.App/containerApps/read",
+        "Microsoft.CognitiveServices/accounts/deployments/read",
+        "Microsoft.MachineLearningServices/workspaces/onlineEndpoints/read",
+        "Microsoft.Authorization/roleAssignments/read",
+        "Microsoft.Web/sites/read",
+    ]:
+        assert permission in main_tf
+
+    assert 'azurerm_role_assignment" "scanner"' in main_tf
+    assert "Key Vault Secrets User" in main_tf
+    assert "rbac_authorization_enabled    = true" in main_tf
+    assert "purge_protection_enabled      = true" in main_tf
+    assert "github_variables_hint" in outputs_tf
+    assert "AGENT_BOM_AZURE_CLIENT_ID" in outputs_tf
+
+
+def test_azure_ingestion_workflow_uses_oidc_and_pushes_to_api() -> None:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    job = workflow["jobs"]["ingest"]
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert workflow["permissions"]["id-token"] == "write"
+    assert job["timeout-minutes"] == 45
+    assert "az login" in text
+    assert "--federated-token" in text
+    assert "client-secret" not in text
+    assert "AGENT_BOM_AZURE_CLIENT_ID" in text
+    assert "AGENT_BOM_AZURE_TENANT_ID" in text
+    assert "AGENT_BOM_AZURE_SUBSCRIPTION_ID" in text
+    assert "agent-bom-api-url" in text
+    assert "agent-bom-api-key" in text
+    assert "--extra azure" in text
+    assert "/v1/results/push" in text
+    assert "/v1/fleet/sync" in text
+
+
+def test_azure_ingestion_docs_do_not_claim_subscription_creation() -> None:
+    readme = (MODULE / "README.md").read_text(encoding="utf-8")
+    site_doc = (ROOT / "site-docs" / "deployment" / "terraform-azure-ingestion.md").read_text(encoding="utf-8")
+    provision_readme = (ROOT / "scripts" / "provision" / "README.md").read_text(encoding="utf-8")
+
+    assert "It does not create an Azure tenant or subscription" in readme
+    assert "The Azure tenant and subscription must already exist" in site_doc
+    assert "terraform output github_variables_hint" in readme
+    assert "terraform output github_variables_hint" in site_doc
+    assert "deploy/terraform/azure/ingestion" in provision_readme
+    assert ".github/workflows/azure-ingestion.yml" in provision_readme


### PR DESCRIPTION
## Summary

- Add an Azure Terraform ingestion baseline for existing tenants/subscriptions: Entra application, service principal, GitHub OIDC federated credential, read-only scanner role assignment, and optional Key Vault for API ingestion config.
- Add `.github/workflows/azure-ingestion.yml` to authenticate to Azure with GitHub OIDC, run `agent-bom scan --azure`, and push scan evidence to `/v1/results/push`; optional fleet sync targets `/v1/fleet/sync`.
- Document the setup path and add static regression coverage for the Terraform, workflow, and docs contract.

## Verification

- `terraform -chdir=deploy/terraform/azure/ingestion fmt -check -diff`
- `terraform -chdir=deploy/terraform/azure/ingestion init -backend=false`
- `terraform -chdir=deploy/terraform/azure/ingestion validate`
- `uv run pytest -q tests/test_azure_ingestion_baseline.py tests/test_deployment.py::test_docs_workflow_never_deploys_pages_from_release_tags`
- `uv run ruff check tests/test_azure_ingestion_baseline.py`
- `python scripts/check_workflow_timeouts.py`
- `git diff --check`

## Notes

- Terraform targets an existing Azure tenant and subscription. It intentionally does not create the tenant or subscription.
- API key material stays out of Terraform state. Operators can use GitHub secrets directly or store `agent-bom-api-url` and `agent-bom-api-key` in the created Key Vault.
