### PR TITLE
chore(deps): combine node types and python image bumps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## ── Builder stage ────────────────────────────────────────────────────────────
-FROM python:3.14.5-alpine3.23@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6ccea4d4ebdabbc523b9a1614 AS builder
+FROM python:3.15.0b2-alpine3.23@sha256:8d3de8aae4a0549621b4053ca36a849d89300f7f114d5f5a89a037c783743c62 AS builder
 
 WORKDIR /app
 ARG HTTP_PROXY
@@ -18,7 +18,7 @@ ENV HTTP_PROXY=${HTTP_PROXY} \
     PIP_CERT=${PIP_CERT}
 
 # Build-time deps for wheel compilation when musllinux wheels are unavailable.
-RUN apk add --no-cache build-base ca-certificates git linux-headers \
+RUN apk add --no-cache build-base ca-certificates git libffi-dev linux-headers \
     && apk upgrade --no-cache --available \
     && update-ca-certificates
 
@@ -28,7 +28,7 @@ COPY src/ ./src/
 RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 
 ## ── Runtime stage ────────────────────────────────────────────────────────────
-FROM python:3.14.5-alpine3.23@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6ccea4d4ebdabbc523b9a1614
+FROM python:3.15.0b2-alpine3.23@sha256:8d3de8aae4a0549621b4053ca36a849d89300f7f114d5f5a89a037c783743c62
 
 ARG VERSION=0.88.6
 ARG HTTP_PROXY
@@ -49,7 +49,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 COPY --from=builder /install /usr/local
 COPY --from=builder /app/LICENSE /app/LICENSE
 
-RUN apk add --no-cache ca-certificates \
+RUN apk add --no-cache ca-certificates libffi libgcc libstdc++ \
     && apk upgrade --no-cache --available \
     && update-ca-certificates
 COPY deploy/docker/pip-requirements.txt /tmp/pip-req.txt

--- a/scripts/check_docker_base_policy.py
+++ b/scripts/check_docker_base_policy.py
@@ -65,8 +65,8 @@ class BasePolicy:
 POLICY: dict[str, BasePolicy] = {
     "Dockerfile": BasePolicy(
         image="python",
-        expected_tags=("3.14.5-alpine3.23",),
-        rationale="Alpine + Python 3.14 is the canonical scanner runtime; smallest attack surface.",
+        expected_tags=("3.15.0b2-alpine3.23",),
+        rationale="Alpine + Python 3.15 beta is the current scanner runtime candidate; smallest attack surface.",
     ),
     "ui/Dockerfile": BasePolicy(
         image="node",

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@types/node": "^25.9.2",
+        "@types/node": "^25.9.3",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -17,9 +17,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.9.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
-      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -39,7 +39,7 @@
     "directory": "sdks/typescript"
   },
   "devDependencies": {
-    "@types/node": "^25.9.2",
+    "@types/node": "^25.9.3",
     "typescript": "^6.0.3"
   }
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -27,7 +27,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/dagre": "^0.7.54",
-        "@types/node": "25.9.2",
+        "@types/node": "25.9.3",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
@@ -2532,9 +2532,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
-      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -47,7 +47,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/dagre": "^0.7.54",
-    "@types/node": "25.9.2",
+    "@types/node": "25.9.3",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "^6.0.2",


### PR DESCRIPTION
## Summary

- Combine Dependabot PRs #2902, #2903, and #2904 into one dependency update.
- Bump the root Docker base image from `python:3.14.5-alpine3.23` to pinned `python:3.15.0b2-alpine3.23`.
- Bump `@types/node` from `25.9.2` to `25.9.3` in both `ui` and `sdks/typescript`.
- Update the Docker base-image policy and add the Alpine build/runtime libraries required by Python 3.15 source-built wheels.

## Verification

- `npx -y -p node@24 -c 'npm ci && npm run verify:toolchain && npm run typecheck && npm test -- --run'` in `ui`
- `npx -y -p node@24 -c 'npm ci && npm run lint && npm test'` in `sdks/typescript`
- `python scripts/check_docker_base_policy.py`
- `uv run pytest -q tests/test_docker_base_policy.py`
- `uv run ruff check scripts/check_docker_base_policy.py tests/test_docker_base_policy.py`
- `docker build -t agent-bom:deps-node-python-smoke .`
- `docker run --rm agent-bom:deps-node-python-smoke --version`
- `docker run --rm agent-bom:deps-node-python-smoke agents --demo --no-scan --no-color --format json -o /tmp/out.json`
- `git diff --check`

## Notes

- The standalone Python image PR failed because the policy table still allowed only the old Docker tag. This PR updates the policy and fixes the runtime library gaps found by a real Docker smoke.
- A demo scan with `--offline` writes valid JSON but exits nonzero without a populated vulnerability DB in the image; the container scan-path smoke uses `--no-scan` for deterministic runtime validation.

Supersedes #2902.
Supersedes #2903.
Supersedes #2904.
