### PR TITLE
feat(graph): add evaluation harness

### DIFF
--- a/src/agent_bom/cli/_analysis.py
+++ b/src/agent_bom/cli/_analysis.py
@@ -243,13 +243,41 @@ def analytics_cmd(query_type, days, hours, agent, top_limit, clickhouse_url, ten
 @click.option("--output", "-o", "output_path", default=None, help="Write to file instead of stdout.")
 @click.option("--quiet", "-q", is_flag=True, help="Suppress success messages when writing files.")
 @click.option(
+    "--expected",
+    "expected_path",
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    help="Evaluate the graph against an expected graph fixture JSON.",
+)
+@click.option(
+    "--eval-output",
+    "eval_output_path",
+    default=None,
+    help="Write graph evaluation JSON to this path when --expected is set.",
+)
+@click.option(
+    "--fail-under",
+    type=click.FloatRange(min=0.0, max=1.0),
+    default=None,
+    help="Exit non-zero when the graph evaluation score is below this threshold.",
+)
+@click.option(
     "--mermaid-limit",
     type=click.IntRange(min=0),
     default=80,
     show_default=True,
     help="Maximum nodes rendered for Mermaid output; 0 renders the full graph.",
 )
-def graph_cmd(scan_file: str, fmt: str, output_path: Optional[str], quiet: bool, mermaid_limit: int) -> None:
+def graph_cmd(
+    scan_file: str,
+    fmt: str,
+    output_path: Optional[str],
+    quiet: bool,
+    expected_path: Optional[str],
+    eval_output_path: Optional[str],
+    fail_under: Optional[float],
+    mermaid_limit: int,
+) -> None:
     """Export the transitive dependency graph from a saved JSON scan report.
 
     \b
@@ -262,14 +290,17 @@ def graph_cmd(scan_file: str, fmt: str, output_path: Optional[str], quiet: bool,
         dot -Tsvg deps.dot -o deps.svg
 
         agent-bom graph report.json --format mermaid
+        agent-bom graph report.json --expected expected-graph.json --eval-output graph-eval.json --fail-under 0.9
 
     Closes #292.
     """
     from rich.console import Console as _Console
 
+    from agent_bom.graph.evaluation import evaluate_graph, load_expected_graph_spec
     from agent_bom.output.graph_export import load_graph_from_scan, to_cypher, to_dot, to_graphml, to_json, to_mermaid
 
     _con = _Console()
+    _err_con = _Console(stderr=True)
 
     try:
         graph = load_graph_from_scan(scan_file)
@@ -297,6 +328,36 @@ def graph_cmd(scan_file: str, fmt: str, output_path: Optional[str], quiet: bool,
             _con.print(f"[green]Graph exported[/green] ({graph.node_count()} nodes, {graph.edge_count()} edges) → {output_path}")
     else:
         click.echo(output)
+
+    if expected_path:
+        try:
+            evaluation = evaluate_graph(to_json(graph), load_expected_graph_spec(expected_path))
+        except ValueError as exc:
+            _err_con.print(f"[red]Error evaluating graph:[/red] {exc}")
+            raise SystemExit(1) from exc
+
+        evaluation_json = json.dumps(evaluation.to_dict(), indent=2, sort_keys=True)
+        if eval_output_path:
+            Path(eval_output_path).write_text(evaluation_json)
+            if not quiet:
+                _err_con.print(
+                    "[green]Graph evaluated[/green] "
+                    f"({evaluation.overall_score:.2%}, {evaluation.to_dict()['grade']}) -> {eval_output_path}",
+                )
+        elif not quiet:
+            _err_con.print(
+                "[bold]Graph evaluation[/bold] "
+                f"{evaluation.overall_score:.2%} ({evaluation.to_dict()['grade']}) "
+                f"nodes {evaluation.nodes.matched}/{evaluation.nodes.expected}, "
+                f"edges {evaluation.edges.matched}/{evaluation.edges.expected}, "
+                f"paths {evaluation.paths.matched}/{evaluation.paths.expected}",
+            )
+
+        if fail_under is not None and evaluation.overall_score < fail_under:
+            _err_con.print(
+                f"[red]Graph evaluation failed:[/red] score {evaluation.overall_score:.4f} is below {fail_under:.4f}",
+            )
+            raise SystemExit(1)
 
 
 @click.command("mesh")

--- a/src/agent_bom/graph/__init__.py
+++ b/src/agent_bom/graph/__init__.py
@@ -23,6 +23,7 @@ from agent_bom.graph.dependency_reach import (
     compute_dependency_reach,
 )
 from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.evaluation import GraphEvaluationResult, evaluate_graph, graph_score_grade, load_expected_graph_spec
 from agent_bom.graph.node import NodeDimensions, UnifiedNode, stable_node_id
 from agent_bom.graph.ocsf import ENTITY_OCSF_MAP, FINDING_ENTITY_TYPES, ocsf_type_uid
 from agent_bom.graph.semantic_clusters import SEMANTIC_CLUSTER_KINDS, SemanticCluster, build_semantic_clusters, semantic_cluster_stats
@@ -71,6 +72,11 @@ __all__ = [
     "stable_node_id",
     # Edge
     "UnifiedEdge",
+    # Evaluation
+    "GraphEvaluationResult",
+    "evaluate_graph",
+    "graph_score_grade",
+    "load_expected_graph_spec",
     # Container
     "UnifiedGraph",
     "AttackPath",

--- a/src/agent_bom/graph/evaluation.py
+++ b/src/agent_bom/graph/evaluation.py
@@ -1,0 +1,378 @@
+"""Graph evaluation harness for scan fixtures and UI graph quality gates."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+@dataclass(frozen=True, slots=True)
+class ExpectedNode:
+    """Node expected to appear in a graph."""
+
+    id: str
+    entity_type: str = ""
+    label: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ExpectedEdge:
+    """Directed relationship expected to appear in a graph."""
+
+    source: str
+    target: str
+    relationship: str
+
+
+@dataclass(frozen=True, slots=True)
+class ExpectedPath:
+    """Ordered hop sequence expected to appear in attack-path output."""
+
+    hops: tuple[str, ...]
+    id: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class MetricScore:
+    """Precision/recall score for one graph dimension."""
+
+    expected: int
+    actual: int
+    matched: int
+    precision: float
+    recall: float
+    f1: float
+    missing: list[Any] = field(default_factory=list)
+    unexpected: list[Any] = field(default_factory=list)
+
+    @property
+    def applicable(self) -> bool:
+        return self.expected > 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "expected": self.expected,
+            "actual": self.actual,
+            "matched": self.matched,
+            "precision": round(self.precision, 4),
+            "recall": round(self.recall, 4),
+            "f1": round(self.f1, 4),
+            "missing": self.missing,
+            "unexpected": self.unexpected,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class GraphEvaluationResult:
+    """Complete graph evaluation result."""
+
+    name: str
+    overall_score: float
+    nodes: MetricScore
+    edges: MetricScore
+    paths: MetricScore
+    evidence: dict[str, Any]
+    readability: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "overall_score": round(self.overall_score, 4),
+            "grade": graph_score_grade(self.overall_score),
+            "scores": {
+                "nodes": self.nodes.to_dict(),
+                "edges": self.edges.to_dict(),
+                "paths": self.paths.to_dict(),
+            },
+            "evidence": self.evidence,
+            "readability": self.readability,
+            "summary": {
+                "expected_nodes": self.nodes.expected,
+                "expected_edges": self.edges.expected,
+                "expected_paths": self.paths.expected,
+                "missing_total": len(self.nodes.missing) + len(self.edges.missing) + len(self.paths.missing),
+                "unexpected_total": len(self.nodes.unexpected) + len(self.edges.unexpected) + len(self.paths.unexpected),
+            },
+        }
+
+
+def graph_score_grade(score: float) -> str:
+    """Return a compact grade for a 0..1 graph score."""
+
+    if score >= 0.95:
+        return "excellent"
+    if score >= 0.85:
+        return "strong"
+    if score >= 0.70:
+        return "usable"
+    if score >= 0.50:
+        return "weak"
+    return "failing"
+
+
+def load_expected_graph_spec(path: str | Path) -> dict[str, Any]:
+    """Load an expected graph fixture from JSON."""
+
+    try:
+        data = json.loads(Path(path).read_text())
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid graph evaluation spec JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("graph evaluation spec must be a JSON object")
+    return data
+
+
+def evaluate_graph(actual_graph: Any, expected_spec: Mapping[str, Any]) -> GraphEvaluationResult:
+    """Compare an actual graph to an expected graph fixture.
+
+    The actual graph may be an API response dict, graph-export JSON dict, or
+    an in-memory object with ``nodes`` / ``edges`` / optional ``attack_paths``
+    attributes. Expected fixtures use:
+
+    .. code-block:: json
+
+      {
+        "name": "demo MCP blast radius",
+        "expected_nodes": ["agent:claude", {"id": "pkg:npm/next@16.2.6"}],
+        "expected_edges": [{"source": "...", "target": "...", "relationship": "depends_on"}],
+        "expected_paths": [{"hops": ["agent:claude", "server:fs", "pkg:npm/next@16.2.6"]}]
+      }
+    """
+
+    actual = _ActualGraphIndex.from_graph(actual_graph)
+    expected_nodes = {_node_key(node) for node in _parse_expected_nodes(expected_spec.get("expected_nodes", []))}
+    expected_edges = {_edge_key(edge) for edge in _parse_expected_edges(expected_spec.get("expected_edges", []))}
+    expected_paths = {_path_key(path) for path in _parse_expected_paths(expected_spec.get("expected_paths", []))}
+
+    node_score = _score_sets(expected_nodes, actual.node_ids)
+    edge_score = _score_sets(expected_edges, actual.edge_keys)
+    path_score = _score_sets(expected_paths, actual.path_keys)
+
+    applicable = [
+        (node_score.recall, 0.30, node_score.applicable),
+        (edge_score.recall, 0.40, edge_score.applicable),
+        (path_score.recall, 0.30, path_score.applicable),
+    ]
+    weights = sum(weight for _score, weight, enabled in applicable if enabled)
+    overall = sum(score * weight for score, weight, enabled in applicable if enabled) / weights if weights else 1.0
+
+    return GraphEvaluationResult(
+        name=str(expected_spec.get("name") or "graph-evaluation"),
+        overall_score=overall,
+        nodes=node_score,
+        edges=edge_score,
+        paths=path_score,
+        evidence=actual.evidence_summary(),
+        readability=actual.readability_summary(),
+    )
+
+
+def _parse_expected_nodes(items: Any) -> list[ExpectedNode]:
+    if not isinstance(items, Sequence) or isinstance(items, (str, bytes)):
+        raise ValueError("expected_nodes must be an array")
+    parsed: list[ExpectedNode] = []
+    for item in items:
+        if isinstance(item, str):
+            parsed.append(ExpectedNode(id=item))
+        elif isinstance(item, Mapping):
+            node_id = str(item.get("id") or "").strip()
+            if not node_id:
+                raise ValueError("expected node is missing id")
+            parsed.append(
+                ExpectedNode(
+                    id=node_id,
+                    entity_type=str(item.get("entity_type") or item.get("kind") or ""),
+                    label=str(item.get("label") or ""),
+                )
+            )
+        else:
+            raise ValueError("expected node entries must be strings or objects")
+    return parsed
+
+
+def _parse_expected_edges(items: Any) -> list[ExpectedEdge]:
+    if not isinstance(items, Sequence) or isinstance(items, (str, bytes)):
+        raise ValueError("expected_edges must be an array")
+    parsed: list[ExpectedEdge] = []
+    for item in items:
+        if isinstance(item, Mapping):
+            source = str(item.get("source") or item.get("source_id") or "").strip()
+            target = str(item.get("target") or item.get("target_id") or "").strip()
+            relationship = str(item.get("relationship") or item.get("kind") or "").strip()
+        elif isinstance(item, Sequence) and not isinstance(item, (str, bytes)) and len(item) == 3:
+            source, target, relationship = (str(value).strip() for value in item)
+        else:
+            raise ValueError("expected edge entries must be objects or [source, target, relationship]")
+        if not source or not target or not relationship:
+            raise ValueError("expected edge is missing source, target, or relationship")
+        parsed.append(ExpectedEdge(source=source, target=target, relationship=relationship))
+    return parsed
+
+
+def _parse_expected_paths(items: Any) -> list[ExpectedPath]:
+    if not isinstance(items, Sequence) or isinstance(items, (str, bytes)):
+        raise ValueError("expected_paths must be an array")
+    parsed: list[ExpectedPath] = []
+    for item in items:
+        if isinstance(item, Mapping):
+            hops = item.get("hops")
+            path_id = str(item.get("id") or "")
+        else:
+            hops = item
+            path_id = ""
+        if not isinstance(hops, Sequence) or isinstance(hops, (str, bytes)) or len(hops) < 2:
+            raise ValueError("expected path entries must include at least two hops")
+        parsed.append(ExpectedPath(hops=tuple(str(hop).strip() for hop in hops), id=path_id))
+    return parsed
+
+
+def _node_key(node: ExpectedNode) -> str:
+    return node.id
+
+
+def _edge_key(edge: ExpectedEdge) -> tuple[str, str, str]:
+    return (edge.source, edge.target, _normalize_relationship(edge.relationship))
+
+
+def _path_key(path: ExpectedPath) -> tuple[str, ...]:
+    return tuple(path.hops)
+
+
+def _normalize_relationship(value: str) -> str:
+    return value.strip().lower().replace(" ", "_")
+
+
+def _score_sets(expected: set[Any], actual: set[Any]) -> MetricScore:
+    matched = expected & actual
+    missing = sorted(expected - actual, key=str)
+    unexpected = sorted(actual - expected, key=str)
+    precision = len(matched) / len(actual) if actual else (1.0 if not expected else 0.0)
+    recall = len(matched) / len(expected) if expected else 1.0
+    f1 = (2 * precision * recall / (precision + recall)) if precision + recall else 0.0
+    return MetricScore(
+        expected=len(expected),
+        actual=len(actual),
+        matched=len(matched),
+        precision=precision,
+        recall=recall,
+        f1=f1,
+        missing=missing,
+        unexpected=unexpected[:50],
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _ActualGraphIndex:
+    node_ids: set[str]
+    edge_keys: set[tuple[str, str, str]]
+    path_keys: set[tuple[str, ...]]
+    edge_evidence_count: int
+    relationship_types: set[str]
+    entity_types: set[str]
+    node_count: int
+    edge_count: int
+
+    @classmethod
+    def from_graph(cls, graph: Any) -> "_ActualGraphIndex":
+        nodes = _read_sequence(graph, "nodes")
+        edges = _read_sequence(graph, "edges")
+        paths = _read_sequence(graph, "attack_paths")
+
+        node_ids: set[str] = set()
+        entity_types: set[str] = set()
+        for node in nodes:
+            node_id = _read_field(node, "id")
+            if node_id:
+                node_ids.add(node_id)
+            entity_type = _read_field(node, "entity_type") or _read_field(node, "kind")
+            if entity_type:
+                entity_types.add(entity_type)
+
+        edge_keys: set[tuple[str, str, str]] = set()
+        relationship_types: set[str] = set()
+        edge_evidence_count = 0
+        for edge in edges:
+            source = _read_field(edge, "source") or _read_field(edge, "source_id")
+            target = _read_field(edge, "target") or _read_field(edge, "target_id")
+            relationship = _read_field(edge, "relationship") or _read_field(edge, "kind")
+            if source and target and relationship:
+                normalized = _normalize_relationship(relationship)
+                edge_keys.add((source, target, normalized))
+                relationship_types.add(normalized)
+            evidence = _read_mapping(edge, "evidence") or _read_mapping(edge, "provenance")
+            if evidence:
+                edge_evidence_count += 1
+
+        path_keys: set[tuple[str, ...]] = set()
+        for path in paths:
+            hops = _read_raw(path, "hops")
+            if isinstance(hops, Sequence) and not isinstance(hops, (str, bytes)) and len(hops) >= 2:
+                path_keys.add(tuple(str(hop) for hop in hops))
+
+        return cls(
+            node_ids=node_ids,
+            edge_keys=edge_keys,
+            path_keys=path_keys,
+            edge_evidence_count=edge_evidence_count,
+            relationship_types=relationship_types,
+            entity_types=entity_types,
+            node_count=len(nodes),
+            edge_count=len(edges),
+        )
+
+    def evidence_summary(self) -> dict[str, Any]:
+        ratio = self.edge_evidence_count / self.edge_count if self.edge_count else 0.0
+        return {
+            "edge_evidence_count": self.edge_evidence_count,
+            "edge_evidence_ratio": round(ratio, 4),
+        }
+
+    def readability_summary(self) -> dict[str, Any]:
+        density = self.edge_count / self.node_count if self.node_count else 0.0
+        warnings: list[str] = []
+        if self.node_count == 0:
+            warnings.append("graph has no nodes")
+        if self.node_count > 0 and self.edge_count == 0:
+            warnings.append("graph has nodes but no relationships")
+        if self.node_count >= 50 and len(self.relationship_types) < 3:
+            warnings.append("large graph has low relationship diversity")
+        if density > 6:
+            warnings.append("graph is dense; use filtering or path focus for readability")
+        return {
+            "node_count": self.node_count,
+            "edge_count": self.edge_count,
+            "edge_to_node_ratio": round(density, 4),
+            "entity_type_count": len(self.entity_types),
+            "relationship_type_count": len(self.relationship_types),
+            "warnings": warnings,
+        }
+
+
+def _read_sequence(graph: Any, key: str) -> list[Any]:
+    value = _read_raw(graph, key)
+    if isinstance(value, Mapping):
+        return list(value.values())
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return list(value)
+    return []
+
+
+def _read_mapping(item: Any, key: str) -> Mapping[str, Any]:
+    value = _read_raw(item, key)
+    return value if isinstance(value, Mapping) else {}
+
+
+def _read_field(item: Any, key: str) -> str:
+    value = _read_raw(item, key)
+    if value is None:
+        return ""
+    raw_value = getattr(value, "value", value)
+    return str(raw_value).strip()
+
+
+def _read_raw(item: Any, key: str) -> Any:
+    if isinstance(item, Mapping):
+        return item.get(key)
+    return getattr(item, key, None)

--- a/tests/test_graph_evaluation.py
+++ b/tests/test_graph_evaluation.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_bom.graph.evaluation import evaluate_graph, graph_score_grade, load_expected_graph_spec
+
+
+def _actual_graph() -> dict:
+    return {
+        "nodes": [
+            {"id": "provider:local", "kind": "provider", "label": "local"},
+            {"id": "agent:claude", "kind": "agent", "label": "Claude Desktop"},
+            {"id": "server:claude/filesystem", "kind": "server", "label": "filesystem"},
+            {"id": "pkg:npm/next@16.2.6", "kind": "pkg_vuln", "label": "next@16.2.6"},
+            {"id": "cve:CVE-2026-21441", "kind": "cve", "label": "CVE-2026-21441"},
+        ],
+        "edges": [
+            {"source": "provider:local", "target": "agent:claude", "kind": "hosts"},
+            {"source": "agent:claude", "target": "server:claude/filesystem", "kind": "uses"},
+            {
+                "source": "server:claude/filesystem",
+                "target": "pkg:npm/next@16.2.6",
+                "kind": "depends_on",
+                "evidence": {"version_source": "lockfile"},
+            },
+            {"source": "pkg:npm/next@16.2.6", "target": "cve:CVE-2026-21441", "kind": "affects"},
+        ],
+        "attack_paths": [
+            {
+                "hops": [
+                    "agent:claude",
+                    "server:claude/filesystem",
+                    "pkg:npm/next@16.2.6",
+                    "cve:CVE-2026-21441",
+                ]
+            }
+        ],
+    }
+
+
+def test_evaluate_graph_scores_expected_nodes_edges_and_paths() -> None:
+    expected = {
+        "name": "demo-blast-radius",
+        "expected_nodes": [
+            "agent:claude",
+            {"id": "server:claude/filesystem", "kind": "server"},
+            "pkg:npm/next@16.2.6",
+            "cve:CVE-2026-21441",
+        ],
+        "expected_edges": [
+            {"source": "agent:claude", "target": "server:claude/filesystem", "relationship": "uses"},
+            ["server:claude/filesystem", "pkg:npm/next@16.2.6", "depends_on"],
+            {"source": "pkg:npm/next@16.2.6", "target": "cve:CVE-2026-21441", "kind": "affects"},
+        ],
+        "expected_paths": [
+            {
+                "hops": [
+                    "agent:claude",
+                    "server:claude/filesystem",
+                    "pkg:npm/next@16.2.6",
+                    "cve:CVE-2026-21441",
+                ]
+            }
+        ],
+    }
+
+    result = evaluate_graph(_actual_graph(), expected)
+    payload = result.to_dict()
+
+    assert result.overall_score > 0.85
+    assert payload["grade"] == "excellent"
+    assert payload["scores"]["nodes"]["matched"] == 4
+    assert payload["scores"]["edges"]["matched"] == 3
+    assert payload["scores"]["paths"]["matched"] == 1
+    assert payload["evidence"]["edge_evidence_count"] == 1
+    assert payload["readability"]["relationship_type_count"] == 4
+
+
+def test_evaluate_graph_reports_missing_expected_relationships() -> None:
+    expected = {
+        "expected_nodes": ["agent:claude", "agent:missing"],
+        "expected_edges": [
+            {"source": "agent:claude", "target": "server:claude/filesystem", "relationship": "uses"},
+            {"source": "agent:missing", "target": "server:claude/filesystem", "relationship": "uses"},
+        ],
+        "expected_paths": [],
+    }
+
+    result = evaluate_graph(_actual_graph(), expected)
+    payload = result.to_dict()
+
+    assert result.overall_score < 0.85
+    assert "agent:missing" in payload["scores"]["nodes"]["missing"]
+    assert ("agent:missing", "server:claude/filesystem", "uses") in result.edges.missing
+    assert payload["summary"]["missing_total"] == 2
+
+
+def test_load_expected_graph_spec_rejects_non_object(tmp_path: Path) -> None:
+    spec = tmp_path / "expected.json"
+    spec.write_text(json.dumps(["not", "an", "object"]))
+
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        load_expected_graph_spec(spec)
+
+
+def test_graph_score_grade_boundaries() -> None:
+    assert graph_score_grade(0.96) == "excellent"
+    assert graph_score_grade(0.86) == "strong"
+    assert graph_score_grade(0.71) == "usable"
+    assert graph_score_grade(0.51) == "weak"
+    assert graph_score_grade(0.49) == "failing"

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -518,6 +518,91 @@ def test_cli_graph_mermaid_to_stdout():
         os.unlink(path)
 
 
+def test_cli_graph_evaluates_expected_fixture(tmp_path: Path):
+    from agent_bom.cli import main
+
+    data = _make_scan_json(
+        [
+            _agent(
+                "eval-agent",
+                [
+                    _server(
+                        "github",
+                        [_pkg("next", "16.2.6", "npm", vulns=[_vuln("CVE-2026-21441", "critical")])],
+                        credential_env_vars=["GITHUB_TOKEN"],
+                        tools=[{"name": "create_pull_request"}],
+                    )
+                ],
+            )
+        ]
+    )
+    scan_path = _write_scan(data)
+    expected_path = tmp_path / "expected-graph.json"
+    evaluation_path = tmp_path / "graph-eval.json"
+    expected_path.write_text(
+        json.dumps(
+            {
+                "name": "cli-eval",
+                "expected_nodes": [
+                    "agent:eval-agent",
+                    "server:eval-agent/github",
+                    "pkg:npm/next@16.2.6",
+                    "cve:CVE-2026-21441",
+                ],
+                "expected_edges": [
+                    ["agent:eval-agent", "server:eval-agent/github", "uses"],
+                    ["server:eval-agent/github", "pkg:npm/next@16.2.6", "depends_on"],
+                    ["pkg:npm/next@16.2.6", "cve:CVE-2026-21441", "affects"],
+                ],
+            }
+        )
+    )
+
+    try:
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "graph",
+                scan_path,
+                "--format",
+                "json",
+                "--output",
+                str(tmp_path / "graph.json"),
+                "--expected",
+                str(expected_path),
+                "--eval-output",
+                str(evaluation_path),
+                "--fail-under",
+                "0.80",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(evaluation_path.read_text())
+        assert payload["name"] == "cli-eval"
+        assert payload["overall_score"] >= 0.8
+        assert payload["scores"]["edges"]["matched"] == 3
+    finally:
+        os.unlink(scan_path)
+
+
+def test_cli_graph_evaluation_fail_under_exits_nonzero(tmp_path: Path):
+    from agent_bom.cli import main
+
+    scan_path = _write_scan(_make_scan_json([_agent("a", [_server("s", [_pkg("pkg", "1.0.0")])])]))
+    expected_path = tmp_path / "expected-graph.json"
+    expected_path.write_text(json.dumps({"expected_nodes": ["agent:missing"]}))
+
+    try:
+        runner = CliRunner()
+        result = runner.invoke(main, ["graph", scan_path, "--expected", str(expected_path), "--fail-under", "0.99"])
+
+        assert result.exit_code != 0
+    finally:
+        os.unlink(scan_path)
+
+
 def test_cli_graph_invalid_file_exits_nonzero():
     from agent_bom.cli import main
 

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -17,6 +17,7 @@ import "@xyflow/react/dist/style.css";
 import { AlertTriangle, Loader2, Route, ShieldAlert } from "lucide-react";
 
 import { AttackPathCard } from "@/components/attack-path-card";
+import { GraphEvaluationSummary } from "@/components/graph-evaluation-summary";
 import { GraphEvidenceExportButton, GraphLegend, FullscreenButton } from "@/components/graph-chrome";
 import { LargeGraphOverview } from "@/components/large-graph-overview";
 import { LineageDetailPanel } from "@/components/lineage-detail";
@@ -77,6 +78,7 @@ import {
   summarizeReachability,
   type ReachabilitySummary,
 } from "@/lib/graph-reachability";
+import { evaluateGraphUx } from "@/lib/graph-ux-evaluation";
 import {
   api,
   type GraphDiffResponse,
@@ -1110,6 +1112,11 @@ function GraphPageInner() {
     });
   }, [layoutEdges, localNeighborhoodIds, attackPathEdgeKeys, reachabilitySummary, graphLayoutKind, captureMode]);
 
+  const graphEvaluation = useMemo(
+    () => evaluateGraphUx(graphData, displayNodes, displayEdges),
+    [displayEdges, displayNodes, graphData],
+  );
+
   const legendItems = useMemo(
     () => legendItemsForVisibleGraph(displayNodes, displayEdges),
     [displayEdges, displayNodes],
@@ -1623,6 +1630,8 @@ function GraphPageInner() {
             </span>
           )}
         </div>
+
+        <GraphEvaluationSummary evaluation={graphEvaluation} />
 
         {/* Snapshot diff + how-to-read default-collapsed so the canvas owns the
             viewport. The four redundant SnapshotMetaCards (Snapshot/Topology/

--- a/ui/components/graph-evaluation-summary.tsx
+++ b/ui/components/graph-evaluation-summary.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { Activity, AlertTriangle, GitBranch, Network, ShieldCheck } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import type { GraphUxDimension, GraphUxEvaluation } from "@/lib/graph-ux-evaluation";
+
+interface GraphEvaluationSummaryProps {
+  evaluation: GraphUxEvaluation;
+}
+
+const dimensionIcon = {
+  entities: Network,
+  relationships: GitBranch,
+  paths: Activity,
+  evidence: ShieldCheck,
+  readability: Network,
+} satisfies Record<GraphUxDimension["id"], LucideIcon>;
+
+export function GraphEvaluationSummary({ evaluation }: GraphEvaluationSummaryProps) {
+  const gradeClass = gradeTone(evaluation.grade);
+  return (
+    <section
+      aria-label="Graph evaluation"
+      className="mt-3 rounded-xl border border-zinc-800 bg-zinc-950/70 p-3"
+      data-testid="graph-evaluation-summary"
+    >
+      <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-[10px] uppercase tracking-[0.22em] text-emerald-400">Graph evaluation</span>
+            <span className={`rounded-md border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${gradeClass}`}>
+              {evaluation.grade}
+            </span>
+          </div>
+          <p className="mt-1 max-w-3xl text-xs leading-5 text-zinc-400">
+            Scores whether this graph view has enough entity variety, relationships, path signal, evidence, and readable rendering for review.
+          </p>
+        </div>
+        <div className="flex shrink-0 items-baseline gap-2 rounded-lg border border-zinc-800 bg-zinc-900/70 px-3 py-2">
+          <span className="text-2xl font-semibold tabular-nums text-zinc-100">{Math.round(evaluation.score)}</span>
+          <span className="text-[10px] uppercase tracking-[0.16em] text-zinc-500">score</span>
+        </div>
+      </div>
+
+      <div className="mt-3 grid gap-2 sm:grid-cols-2 xl:grid-cols-5">
+        {evaluation.dimensions.map((dimension) => {
+          const Icon = dimensionIcon[dimension.id];
+          return (
+            <div key={dimension.id} className="rounded-lg border border-zinc-800 bg-zinc-900/60 p-2.5">
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex min-w-0 items-center gap-2">
+                  <Icon className="h-3.5 w-3.5 shrink-0 text-zinc-500" />
+                  <span className="truncate text-xs font-medium text-zinc-200">{dimension.label}</span>
+                </div>
+                <span className="text-xs font-semibold tabular-nums text-zinc-100">{Math.round(dimension.score)}</span>
+              </div>
+              <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-zinc-800">
+                <div
+                  className={`h-full rounded-full ${barTone(dimension.score)}`}
+                  style={{ width: `${Math.max(6, Math.min(100, dimension.score))}%` }}
+                />
+              </div>
+              <p className="mt-2 break-words text-[11px] leading-4 text-zinc-500">{dimension.detail}</p>
+            </div>
+          );
+        })}
+      </div>
+
+      {evaluation.warnings.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {evaluation.warnings.slice(0, 3).map((warning) => (
+            <span
+              key={warning}
+              className="inline-flex max-w-full items-start gap-1.5 rounded-lg border border-amber-500/25 bg-amber-500/10 px-2.5 py-1 text-[11px] leading-4 text-amber-100"
+            >
+              <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0 text-amber-300" />
+              <span className="break-words">{warning}</span>
+            </span>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function gradeTone(grade: GraphUxEvaluation["grade"]): string {
+  if (grade === "excellent" || grade === "strong") {
+    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-200";
+  }
+  if (grade === "usable") {
+    return "border-sky-500/30 bg-sky-500/10 text-sky-200";
+  }
+  if (grade === "weak") {
+    return "border-amber-500/30 bg-amber-500/10 text-amber-200";
+  }
+  return "border-red-500/30 bg-red-500/10 text-red-200";
+}
+
+function barTone(score: number): string {
+  if (score >= 82) return "bg-emerald-400";
+  if (score >= 68) return "bg-sky-400";
+  if (score >= 50) return "bg-amber-400";
+  return "bg-red-400";
+}

--- a/ui/lib/graph-ux-evaluation.ts
+++ b/ui/lib/graph-ux-evaluation.ts
@@ -1,0 +1,158 @@
+import type { Edge, Node } from "@xyflow/react";
+
+import type { UnifiedGraphResponse } from "@/lib/api";
+
+export type GraphUxGrade = "excellent" | "strong" | "usable" | "weak" | "failing";
+
+export interface GraphUxDimension {
+  id: "entities" | "relationships" | "paths" | "evidence" | "readability";
+  label: string;
+  score: number;
+  detail: string;
+}
+
+export interface GraphUxEvaluation {
+  score: number;
+  grade: GraphUxGrade;
+  dimensions: GraphUxDimension[];
+  warnings: string[];
+  stats: {
+    sourceNodes: number;
+    sourceEdges: number;
+    renderedNodes: number;
+    renderedEdges: number;
+    entityTypes: number;
+    relationshipTypes: number;
+    attackPaths: number;
+    edgeEvidenceRatio: number;
+    nodeSourceRatio: number;
+    edgeToNodeRatio: number;
+  };
+}
+
+export function gradeGraphUxScore(score: number): GraphUxGrade {
+  if (score >= 92) return "excellent";
+  if (score >= 82) return "strong";
+  if (score >= 68) return "usable";
+  if (score >= 50) return "weak";
+  return "failing";
+}
+
+export function evaluateGraphUx(
+  graph: UnifiedGraphResponse | null,
+  renderedNodes: Node[] = [],
+  renderedEdges: Edge[] = [],
+): GraphUxEvaluation {
+  const sourceNodes = graph?.nodes ?? [];
+  const sourceEdges = graph?.edges ?? [];
+  const attackPaths = graph?.attack_paths ?? [];
+  const nodeCount = sourceNodes.length;
+  const edgeCount = sourceEdges.length;
+  const renderedNodeCount = renderedNodes.length;
+  const renderedEdgeCount = renderedEdges.length;
+  const entityTypeCount = new Set(sourceNodes.map((node) => String(node.entity_type))).size;
+  const relationshipTypeCount = new Set(sourceEdges.map((edge) => String(edge.relationship))).size;
+  const edgeEvidenceCount = sourceEdges.filter((edge) => Object.keys(edge.evidence ?? {}).length > 0).length;
+  const sourcedNodeCount = sourceNodes.filter((node) => (node.data_sources ?? []).length > 0).length;
+  const edgeEvidenceRatio = edgeCount > 0 ? edgeEvidenceCount / edgeCount : 0;
+  const nodeSourceRatio = nodeCount > 0 ? sourcedNodeCount / nodeCount : 0;
+  const edgeToNodeRatio = nodeCount > 0 ? edgeCount / nodeCount : 0;
+
+  const entityScore = clamp01(entityTypeCount / 7) * 100;
+  const relationshipScore = clamp01(relationshipTypeCount / 8) * 100;
+  const pathScore = attackPaths.length > 0 ? clamp01(0.65 + attackPaths.length / 10) * 100 : 35;
+  const evidenceScore = clamp01((edgeEvidenceRatio * 0.65) + (nodeSourceRatio * 0.35)) * 100;
+  const readabilityScore = scoreReadability({
+    sourceNodes: nodeCount,
+    sourceEdges: edgeCount,
+    renderedNodes: renderedNodeCount,
+    renderedEdges: renderedEdgeCount,
+    edgeToNodeRatio,
+  });
+
+  const dimensions: GraphUxDimension[] = [
+    {
+      id: "entities",
+      label: "Entities",
+      score: entityScore,
+      detail: `${entityTypeCount} types`,
+    },
+    {
+      id: "relationships",
+      label: "Relationships",
+      score: relationshipScore,
+      detail: `${relationshipTypeCount} types`,
+    },
+    {
+      id: "paths",
+      label: "Paths",
+      score: pathScore,
+      detail: `${attackPaths.length} ranked`,
+    },
+    {
+      id: "evidence",
+      label: "Evidence",
+      score: evidenceScore,
+      detail: `${Math.round(edgeEvidenceRatio * 100)}% edge evidence`,
+    },
+    {
+      id: "readability",
+      label: "Readability",
+      score: readabilityScore,
+      detail: `${renderedNodeCount}/${Math.max(nodeCount, renderedNodeCount)} nodes visible`,
+    },
+  ];
+
+  const score =
+    dimensions[0]!.score * 0.16 +
+    dimensions[1]!.score * 0.18 +
+    dimensions[2]!.score * 0.22 +
+    dimensions[3]!.score * 0.22 +
+    dimensions[4]!.score * 0.22;
+
+  const warnings: string[] = [];
+  if (nodeCount === 0) warnings.push("No graph entities are loaded.");
+  if (nodeCount > 0 && edgeCount === 0) warnings.push("Entities are present but relationships are missing.");
+  if (attackPaths.length === 0) warnings.push("No ranked attack paths are available for this view.");
+  if (edgeEvidenceRatio < 0.15 && edgeCount > 0) warnings.push("Few relationships carry evidence metadata.");
+  if (renderedNodeCount > 120) warnings.push("The visible canvas is dense; use filters or search for review.");
+
+  return {
+    score,
+    grade: gradeGraphUxScore(score),
+    dimensions,
+    warnings,
+    stats: {
+      sourceNodes: nodeCount,
+      sourceEdges: edgeCount,
+      renderedNodes: renderedNodeCount,
+      renderedEdges: renderedEdgeCount,
+      entityTypes: entityTypeCount,
+      relationshipTypes: relationshipTypeCount,
+      attackPaths: attackPaths.length,
+      edgeEvidenceRatio,
+      nodeSourceRatio,
+      edgeToNodeRatio,
+    },
+  };
+}
+
+function scoreReadability(input: {
+  sourceNodes: number;
+  sourceEdges: number;
+  renderedNodes: number;
+  renderedEdges: number;
+  edgeToNodeRatio: number;
+}): number {
+  if (input.sourceNodes === 0) return 0;
+  const visibleRatio = input.sourceNodes > 0 ? input.renderedNodes / input.sourceNodes : 1;
+  const densityPenalty = input.edgeToNodeRatio <= 3 ? 1 : Math.max(0.35, 1 - (input.edgeToNodeRatio - 3) * 0.12);
+  const canvasPenalty = input.renderedNodes <= 80 ? 1 : Math.max(0.45, 1 - (input.renderedNodes - 80) * 0.005);
+  const coverageSignal = input.sourceNodes > 500 ? Math.min(1, visibleRatio + 0.25) : Math.min(1, visibleRatio + 0.1);
+  return clamp01(0.45 * densityPenalty + 0.35 * canvasPenalty + 0.2 * coverageSignal) * 100;
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}

--- a/ui/tests/graph-evaluation-summary.test.tsx
+++ b/ui/tests/graph-evaluation-summary.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { GraphEvaluationSummary } from "@/components/graph-evaluation-summary";
+import type { GraphUxEvaluation } from "@/lib/graph-ux-evaluation";
+
+describe("GraphEvaluationSummary", () => {
+  it("renders score dimensions and bounded warnings", () => {
+    const evaluation: GraphUxEvaluation = {
+      score: 84,
+      grade: "strong",
+      dimensions: [
+        { id: "entities", label: "Entities", score: 88, detail: "7 types" },
+        { id: "relationships", label: "Relationships", score: 76, detail: "6 types" },
+        { id: "paths", label: "Paths", score: 95, detail: "3 ranked" },
+        { id: "evidence", label: "Evidence", score: 80, detail: "71% edge evidence" },
+        { id: "readability", label: "Readability", score: 82, detail: "42/90 nodes visible" },
+      ],
+      warnings: ["Few relationships carry evidence metadata.", "The visible canvas is dense; use filters or search for review."],
+      stats: {
+        sourceNodes: 90,
+        sourceEdges: 140,
+        renderedNodes: 42,
+        renderedEdges: 80,
+        entityTypes: 7,
+        relationshipTypes: 6,
+        attackPaths: 3,
+        edgeEvidenceRatio: 0.71,
+        nodeSourceRatio: 0.8,
+        edgeToNodeRatio: 1.55,
+      },
+    };
+
+    render(<GraphEvaluationSummary evaluation={evaluation} />);
+
+    expect(screen.getByTestId("graph-evaluation-summary")).toBeInTheDocument();
+    expect(screen.getByText("strong")).toBeInTheDocument();
+    expect(screen.getByText("84")).toBeInTheDocument();
+    expect(screen.getByText("Entities")).toBeInTheDocument();
+    expect(screen.getByText("Relationships")).toBeInTheDocument();
+    expect(screen.getByText("Few relationships carry evidence metadata.")).toBeInTheDocument();
+  });
+});

--- a/ui/tests/graph-ux-evaluation.test.ts
+++ b/ui/tests/graph-ux-evaluation.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type { Edge, Node } from "@xyflow/react";
+
+import { evaluateGraphUx, gradeGraphUxScore } from "@/lib/graph-ux-evaluation";
+import type { UnifiedGraphResponse } from "@/lib/api";
+
+function graphFixture(): UnifiedGraphResponse {
+  return {
+    nodes: [
+      { id: "agent:a", entity_type: "agent", data_sources: ["scan"] },
+      { id: "server:a/fs", entity_type: "server", data_sources: ["scan"] },
+      { id: "pkg:npm/next@16.2.6", entity_type: "package", data_sources: ["lockfile"] },
+      { id: "cve:CVE-2026-21441", entity_type: "vulnerability", data_sources: ["osv"] },
+      { id: "cred:GITHUB_TOKEN", entity_type: "credential", data_sources: ["config"] },
+      { id: "tool:create_pull_request", entity_type: "tool", data_sources: ["introspection"] },
+      { id: "env:prod", entity_type: "environment", data_sources: ["scan"] },
+    ],
+    edges: [
+      { source: "agent:a", target: "server:a/fs", relationship: "uses", evidence: { source: "config" } },
+      { source: "server:a/fs", target: "pkg:npm/next@16.2.6", relationship: "depends_on", evidence: { source: "lockfile" } },
+      { source: "pkg:npm/next@16.2.6", target: "cve:CVE-2026-21441", relationship: "affects", evidence: { source: "osv" } },
+      { source: "server:a/fs", target: "cred:GITHUB_TOKEN", relationship: "exposes_cred", evidence: { source: "env" } },
+      { source: "cred:GITHUB_TOKEN", target: "tool:create_pull_request", relationship: "reaches_tool", evidence: { confidence: "medium" } },
+      { source: "env:prod", target: "agent:a", relationship: "hosts", evidence: { source: "scan" } },
+    ],
+    attack_paths: [
+      {
+        source: "agent:a",
+        target: "cve:CVE-2026-21441",
+        hops: ["agent:a", "server:a/fs", "pkg:npm/next@16.2.6", "cve:CVE-2026-21441"],
+        edges: [],
+        composite_risk: 9.1,
+        summary: "test",
+        credential_exposure: [],
+        tool_exposure: [],
+        vuln_ids: ["CVE-2026-21441"],
+      },
+    ],
+  } as unknown as UnifiedGraphResponse;
+}
+
+describe("evaluateGraphUx", () => {
+  it("scores a relationship-rich graph as strong or better", () => {
+    const graph = graphFixture();
+    const evaluation = evaluateGraphUx(
+      graph,
+      graph.nodes.map((node) => ({ id: node.id })) as unknown as Node[],
+      graph.edges.map((edge, index) => ({ id: `e${index}`, source: edge.source, target: edge.target })) as unknown as Edge[],
+    );
+
+    expect(evaluation.score).toBeGreaterThanOrEqual(82);
+    expect(["strong", "excellent"]).toContain(evaluation.grade);
+    expect(evaluation.stats.entityTypes).toBe(7);
+    expect(evaluation.stats.relationshipTypes).toBe(6);
+    expect(evaluation.warnings).not.toContain("No ranked attack paths are available for this view.");
+  });
+
+  it("warns when relationships and path signal are missing", () => {
+    const evaluation = evaluateGraphUx({
+      ...graphFixture(),
+      edges: [],
+      attack_paths: [],
+    });
+
+    expect(evaluation.grade).toBe("failing");
+    expect(evaluation.warnings).toContain("Entities are present but relationships are missing.");
+    expect(evaluation.warnings).toContain("No ranked attack paths are available for this view.");
+  });
+
+  it("keeps grade boundaries stable", () => {
+    expect(gradeGraphUxScore(93)).toBe("excellent");
+    expect(gradeGraphUxScore(83)).toBe("strong");
+    expect(gradeGraphUxScore(69)).toBe("usable");
+    expect(gradeGraphUxScore(51)).toBe("weak");
+    expect(gradeGraphUxScore(49)).toBe("failing");
+  });
+});


### PR DESCRIPTION
Summary
- Add a graph evaluation harness that compares actual graph JSON against expected nodes, edge triples, and attack-path hop sequences.
- Add optional `agent-bom graph --expected ... --eval-output ... --fail-under ...` gating for scan fixture and CI workflows.
- Add a dashboard graph evaluation panel that scores entity variety, relationship variety, path signal, evidence density, and render readability.

Verification
- `uv run pytest -q tests/test_graph_evaluation.py tests/test_graph_export.py`
- `uv run ruff check src/agent_bom/graph/evaluation.py src/agent_bom/cli/_analysis.py tests/test_graph_evaluation.py tests/test_graph_export.py`
- `npm test -- --run tests/graph-ux-evaluation.test.ts tests/graph-evaluation-summary.test.tsx`
- `npm run typecheck`
- `npx -y node@24 scripts/verify-toolchain.mjs`
- Browser smoke: opened `http://127.0.0.1:3310/graph`; local API had no persisted snapshots, so the empty/error graph state rendered without overflow and the panel is covered by component tests.

Notes
- `npm run verify:toolchain` fails under local Node 25.9.0 as expected; the same verifier passes under Node 24.15.0, which matches the declared `>=22 <25` range.
- Evaluation gates on expected-coverage recall so real scans can include extra tools, credentials, and context without failing a minimum expected graph contract; precision and unexpected entries are still reported.