### PR TITLE
fix(ci): use stable Python runtime for Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## ── Builder stage ────────────────────────────────────────────────────────────
-FROM python:3.15.0b2-alpine3.23@sha256:8d3de8aae4a0549621b4053ca36a849d89300f7f114d5f5a89a037c783743c62 AS builder
+FROM python:3.13.11-alpine3.23@sha256:2f607129b1b915a949320bf0c4831a73d1c1b1be663c2b1d8c93aa35a5f44a95 AS builder
 
 WORKDIR /app
 ARG HTTP_PROXY
@@ -28,7 +28,7 @@ COPY src/ ./src/
 RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 
 ## ── Runtime stage ────────────────────────────────────────────────────────────
-FROM python:3.15.0b2-alpine3.23@sha256:8d3de8aae4a0549621b4053ca36a849d89300f7f114d5f5a89a037c783743c62
+FROM python:3.13.11-alpine3.23@sha256:2f607129b1b915a949320bf0c4831a73d1c1b1be663c2b1d8c93aa35a5f44a95
 
 ARG VERSION=0.88.6
 ARG HTTP_PROXY

--- a/scripts/check_docker_base_policy.py
+++ b/scripts/check_docker_base_policy.py
@@ -65,8 +65,8 @@ class BasePolicy:
 POLICY: dict[str, BasePolicy] = {
     "Dockerfile": BasePolicy(
         image="python",
-        expected_tags=("3.15.0b2-alpine3.23",),
-        rationale="Alpine + Python 3.15 beta is the current scanner runtime candidate; smallest attack surface.",
+        expected_tags=("3.13.11-alpine3.23",),
+        rationale="Stable Alpine runtime with broad musllinux wheel coverage; avoids beta-runtime QEMU build timeouts.",
     ),
     "ui/Dockerfile": BasePolicy(
         image="node",


### PR DESCRIPTION
Summary:
- Moves the production Dockerfile from Python 3.15 beta Alpine to stable Python 3.13.11 Alpine with a pinned digest.
- Updates the Docker base-image policy rationale so CI rejects a drift back to beta-runtime builds.
- Fixes the post-merge CI release blocker where `Docker (multi-arch)` spent the full 45-minute job in buildx arm64 validation and cancelled before smoke/scan steps.

Verification:
- `python scripts/check_docker_base_policy.py`
- `docker build --no-cache -t agent-bom:ci-docker-fix-smoke .`
- `docker run --rm agent-bom:ci-docker-fix-smoke --version`
- `docker buildx build --platform linux/amd64,linux/arm64 -t agent-bom:multiarch-fix-smoke .`
- `git diff --check`

Notes:
- The release candidate remains blocked until this lands and the post-merge `main` CI run completes green.
