### PR TITLE
fix(schedule): align scheduled scan jobs

### DIFF
--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -58,6 +58,7 @@ CREATE TABLE IF NOT EXISTS scan_jobs (
     created_at   TEXT NOT NULL,
     completed_at TEXT,
     team_id      TEXT NOT NULL DEFAULT 'default' REFERENCES teams(team_id) ON DELETE CASCADE,
+    schedule_id  TEXT,
     triggered_by TEXT,
     data         JSONB NOT NULL
 );
@@ -72,12 +73,20 @@ DO $$ BEGIN
             ADD COLUMN team_id TEXT NOT NULL DEFAULT 'default' REFERENCES teams(team_id) ON DELETE CASCADE,
             ADD COLUMN triggered_by TEXT;
     END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'scan_jobs' AND column_name = 'schedule_id'
+    ) THEN
+        ALTER TABLE scan_jobs
+            ADD COLUMN schedule_id TEXT;
+    END IF;
 END $$;
 
 CREATE INDEX IF NOT EXISTS idx_jobs_status  ON scan_jobs(status);
 CREATE INDEX IF NOT EXISTS idx_jobs_created ON scan_jobs(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_jobs_team_status  ON scan_jobs(team_id, status);
 CREATE INDEX IF NOT EXISTS idx_jobs_team_created ON scan_jobs(team_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_jobs_schedule ON scan_jobs(team_id, schedule_id, created_at DESC);
 
 -- ── Table: CIS Benchmark Checks ──────────────────────────────────────────────
 -- Normalized cloud CIS benchmark observations extracted from scan JSON blobs.

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -2275,6 +2275,17 @@
             ],
             "title": "Result"
           },
+          "schedule_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Schedule Id"
+          },
           "source_id": {
             "anyOf": [
               {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -1528,6 +1528,11 @@ components:
             type: object
           - type: 'null'
           title: Result
+        schedule_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Schedule Id
         source_id:
           anyOf:
           - type: string

--- a/docs/schemas/v1/ScanJob.json
+++ b/docs/schemas/v1/ScanJob.json
@@ -264,6 +264,18 @@
       "default": null,
       "title": "Result"
     },
+    "schedule_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Schedule Id"
+    },
     "source_id": {
       "anyOf": [
         {

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -135,6 +135,7 @@ class ScanJob(BaseModel):
     job_id: str
     tenant_id: str = "default"
     source_id: str | None = None
+    schedule_id: str | None = None
     triggered_by: str | None = None
     status: JobStatus = JobStatus.PENDING
     created_at: str

--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -65,6 +65,7 @@ class PostgresJobStore:
                     created_at TEXT NOT NULL,
                     completed_at TEXT,
                     team_id TEXT NOT NULL DEFAULT 'default',
+                    schedule_id TEXT,
                     triggered_by TEXT,
                     data JSONB NOT NULL
                 )
@@ -77,6 +78,12 @@ class PostgresJobStore:
                         WHERE table_name = 'scan_jobs' AND column_name = 'team_id'
                     ) THEN
                         ALTER TABLE scan_jobs ADD COLUMN team_id TEXT NOT NULL DEFAULT 'default';
+                    END IF;
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'scan_jobs' AND column_name = 'schedule_id'
+                    ) THEN
+                        ALTER TABLE scan_jobs ADD COLUMN schedule_id TEXT;
                     END IF;
                     IF NOT EXISTS (
                         SELECT 1 FROM information_schema.columns
@@ -111,6 +118,7 @@ class PostgresJobStore:
                 )
             """)
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_jobs_team_created ON scan_jobs(team_id, created_at DESC)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_jobs_schedule ON scan_jobs(team_id, schedule_id, created_at DESC)")
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_cis_checks_team_cloud_status_priority "
                 "ON cis_benchmark_checks(team_id, cloud, status, priority, measured_at DESC)"
@@ -143,15 +151,25 @@ class PostgresJobStore:
         data = job.model_dump_json()
         with _tenant_connection(self._pool) as conn:
             conn.execute(
-                """INSERT INTO scan_jobs (job_id, status, created_at, completed_at, team_id, triggered_by, data)
-                   VALUES (%s, %s, %s, %s, %s, %s, %s)
+                """INSERT INTO scan_jobs (job_id, status, created_at, completed_at, team_id, schedule_id, triggered_by, data)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
                    ON CONFLICT (job_id) DO UPDATE SET
                      status = EXCLUDED.status,
                      completed_at = EXCLUDED.completed_at,
                      team_id = EXCLUDED.team_id,
+                     schedule_id = EXCLUDED.schedule_id,
                      triggered_by = EXCLUDED.triggered_by,
                      data = EXCLUDED.data""",
-                (job.job_id, job.status.value, job.created_at, job.completed_at, job.tenant_id, getattr(job, "triggered_by", None), data),
+                (
+                    job.job_id,
+                    job.status.value,
+                    job.created_at,
+                    job.completed_at,
+                    job.tenant_id,
+                    getattr(job, "schedule_id", None),
+                    getattr(job, "triggered_by", None),
+                    data,
+                ),
             )
             self._replace_cis_checks(conn, job)
             conn.commit()
@@ -201,11 +219,13 @@ class PostgresJobStore:
         with _tenant_connection(self._pool) as conn:
             if tenant_id is None:
                 rows = conn.execute(
-                    "SELECT job_id, team_id, status, created_at, completed_at, triggered_by FROM scan_jobs ORDER BY created_at DESC"
+                    """SELECT job_id, team_id, status, created_at, completed_at, triggered_by, schedule_id
+                       FROM scan_jobs
+                       ORDER BY created_at DESC"""
                 ).fetchall()
             else:
                 rows = conn.execute(
-                    """SELECT job_id, team_id, status, created_at, completed_at, triggered_by
+                    """SELECT job_id, team_id, status, created_at, completed_at, triggered_by, schedule_id
                        FROM scan_jobs
                        WHERE team_id = %s
                        ORDER BY created_at DESC""",
@@ -219,6 +239,7 @@ class PostgresJobStore:
                     "created_at": row[3],
                     "completed_at": row[4],
                     "triggered_by": row[5] if len(row) > 5 else None,
+                    "schedule_id": row[6] if len(row) > 6 else None,
                 }
                 for row in rows
             ]

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -516,6 +516,7 @@ def _job_summary_payload(job: ScanJob) -> dict[str, Any]:
         "job_id": job.job_id,
         "tenant_id": job.tenant_id,
         "source_id": job.source_id,
+        "schedule_id": job.schedule_id,
         "status": job.status,
         "created_at": job.created_at,
         "completed_at": job.completed_at,

--- a/src/agent_bom/api/schedule_store.py
+++ b/src/agent_bom/api/schedule_store.py
@@ -81,6 +81,9 @@ class InMemoryScheduleStore:
 class SQLiteScheduleStore:
     """SQLite-backed persistent schedule store."""
 
+    _TABLE = "scan_schedules"
+    _LEGACY_TABLE = "schedules"
+
     def __init__(self, db_path: str = "agent_bom_schedules.db") -> None:
         self._db_path = db_path
         self._local = threading.local()
@@ -97,7 +100,7 @@ class SQLiteScheduleStore:
     def _init_db(self) -> None:
         ensure_sqlite_schema_version(self._conn, "schedules")
         self._conn.execute("""
-            CREATE TABLE IF NOT EXISTS schedules (
+            CREATE TABLE IF NOT EXISTS scan_schedules (
                 schedule_id TEXT PRIMARY KEY,
                 enabled INTEGER DEFAULT 1,
                 next_run TEXT,
@@ -105,16 +108,27 @@ class SQLiteScheduleStore:
                 data TEXT NOT NULL
             )
         """)
-        cols = {r[1] for r in self._conn.execute("PRAGMA table_info(schedules)").fetchall()}
-        if "tenant_id" not in cols:
-            self._conn.execute("ALTER TABLE schedules ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'")
-        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_sched_due ON schedules(enabled, next_run)")
-        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_sched_tenant_due ON schedules(tenant_id, enabled, next_run)")
+        legacy_exists = self._conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (self._LEGACY_TABLE,),
+        ).fetchone()
+        if legacy_exists:
+            cols = {r[1] for r in self._conn.execute("PRAGMA table_info(schedules)").fetchall()}
+            if "tenant_id" not in cols:
+                self._conn.execute("ALTER TABLE schedules ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'")
+            self._conn.execute(
+                """
+                INSERT OR IGNORE INTO scan_schedules (schedule_id, enabled, next_run, tenant_id, data)
+                SELECT schedule_id, enabled, next_run, tenant_id, data FROM schedules
+                """
+            )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_scan_sched_due ON scan_schedules(enabled, next_run)")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_scan_sched_tenant_due ON scan_schedules(tenant_id, enabled, next_run)")
         self._conn.commit()
 
     def put(self, schedule: ScanSchedule) -> None:
         self._conn.execute(
-            """INSERT OR REPLACE INTO schedules (schedule_id, enabled, next_run, tenant_id, data)
+            """INSERT OR REPLACE INTO scan_schedules (schedule_id, enabled, next_run, tenant_id, data)
                VALUES (?, ?, ?, ?, ?)""",
             (schedule.schedule_id, int(schedule.enabled), schedule.next_run, schedule.tenant_id, schedule.model_dump_json()),
         )
@@ -122,10 +136,10 @@ class SQLiteScheduleStore:
 
     def get(self, schedule_id: str, tenant_id: str | None = None) -> ScanSchedule | None:
         if tenant_id is None:
-            row = self._conn.execute("SELECT data FROM schedules WHERE schedule_id = ?", (schedule_id,)).fetchone()
+            row = self._conn.execute("SELECT data FROM scan_schedules WHERE schedule_id = ?", (schedule_id,)).fetchone()
         else:
             row = self._conn.execute(
-                "SELECT data FROM schedules WHERE schedule_id = ? AND tenant_id = ?",
+                "SELECT data FROM scan_schedules WHERE schedule_id = ? AND tenant_id = ?",
                 (schedule_id, tenant_id),
             ).fetchone()
         if row is None:
@@ -135,10 +149,10 @@ class SQLiteScheduleStore:
 
     def delete(self, schedule_id: str, tenant_id: str | None = None) -> bool:
         if tenant_id is None:
-            cursor = self._conn.execute("DELETE FROM schedules WHERE schedule_id = ?", (schedule_id,))
+            cursor = self._conn.execute("DELETE FROM scan_schedules WHERE schedule_id = ?", (schedule_id,))
         else:
             cursor = self._conn.execute(
-                "DELETE FROM schedules WHERE schedule_id = ? AND tenant_id = ?",
+                "DELETE FROM scan_schedules WHERE schedule_id = ? AND tenant_id = ?",
                 (schedule_id, tenant_id),
             )
         self._conn.commit()
@@ -146,17 +160,17 @@ class SQLiteScheduleStore:
 
     def list_all(self, tenant_id: str | None = None) -> list[ScanSchedule]:
         if tenant_id is None:
-            rows = self._conn.execute("SELECT data FROM schedules ORDER BY schedule_id").fetchall()
+            rows = self._conn.execute("SELECT data FROM scan_schedules ORDER BY schedule_id").fetchall()
         else:
             rows = self._conn.execute(
-                "SELECT data FROM schedules WHERE tenant_id = ? ORDER BY schedule_id",
+                "SELECT data FROM scan_schedules WHERE tenant_id = ? ORDER BY schedule_id",
                 (tenant_id,),
             ).fetchall()
         return [ScanSchedule.model_validate_json(r[0]) for r in rows]
 
     def list_due(self, now_iso: str) -> list[ScanSchedule]:
         rows = self._conn.execute(
-            "SELECT data FROM schedules WHERE enabled = 1 AND next_run IS NOT NULL AND next_run <= ?",
+            "SELECT data FROM scan_schedules WHERE enabled = 1 AND next_run IS NOT NULL AND next_run <= ?",
             (now_iso,),
         ).fetchall()
         return [ScanSchedule.model_validate_json(r[0]) for r in rows]

--- a/src/agent_bom/api/scheduler.py
+++ b/src/agent_bom/api/scheduler.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 logger = logging.getLogger(__name__)
 _SCHEDULER_LEADER_LOCK_ID = 4_197_042_001
@@ -27,86 +27,87 @@ def validate_cron_expression(cron_expr: str) -> bool:
 
     ranges = ((0, 59), (0, 23), (1, 31), (1, 12), (0, 7))
     for spec, (min_val, max_val) in zip(parts, ranges, strict=True):
-        if spec == "*":
-            continue
-        if spec.startswith("*/"):
-            try:
-                step = int(spec[2:])
-            except ValueError:
-                return False
-            if step <= 0 or step > max_val:
-                return False
-            continue
-        try:
-            value = int(spec)
-        except ValueError:
-            return False
-        if value < min_val or value > max_val:
+        if _expand_cron_field(spec, min_val, max_val) is None:
             return False
     return True
 
 
-def parse_cron_next(cron_expr: str, after: datetime) -> datetime | None:
-    """Calculate next run time from a basic cron expression.
+def _expand_cron_field(spec: str, min_val: int, max_val: int) -> set[int] | None:
+    """Expand one cron field into allowed values.
 
-    Supports a subset of standard cron::
+    Supports standard five-field cron atoms: ``*``, ``*/N``, ``N``,
+    ``A-B``, ``A-B/N``, and comma-separated lists of those atoms.
+    """
+    values: set[int] = set()
+    for raw_token in spec.split(","):
+        token = raw_token.strip()
+        if not token:
+            return None
+        step = 1
+        base = token
+        if "/" in token:
+            base, step_raw = token.split("/", 1)
+            try:
+                step = int(step_raw)
+            except ValueError:
+                return None
+            if step <= 0:
+                return None
+        if base == "*":
+            start, end = min_val, max_val
+        elif "-" in base:
+            start_raw, end_raw = base.split("-", 1)
+            try:
+                start, end = int(start_raw), int(end_raw)
+            except ValueError:
+                return None
+            if start > end:
+                return None
+        else:
+            try:
+                start = end = int(base)
+            except ValueError:
+                return None
+        if start < min_val or end > max_val:
+            return None
+        values.update(range(start, end + 1, step))
+    return values
+
+
+def parse_cron_next(cron_expr: str, after: datetime) -> datetime | None:
+    """Calculate next run time from a standard five-field cron expression.
+
+    Supports::
 
         minute hour day_of_month month day_of_week
-        *      */6  *            *     *
 
-    Supported field values:
-    - ``*`` — every value
-    - ``*/N`` — every N-th value
-    - ``N``  — fixed value
-
-    Returns None if the expression cannot be parsed.
+    Field values may be wildcards, steps, fixed values, ranges, and lists.
+    Returns None if the expression cannot be parsed or no next occurrence is
+    found inside the one-year guard window.
     """
-    if not validate_cron_expression(cron_expr):
-        return None
     parts = cron_expr.strip().split()
-
-    try:
-        minute_spec, hour_spec, dom_spec, month_spec, dow_spec = parts
-
-        def _next_match(spec: str, current: int, max_val: int) -> int | None:
-            """Find the next matching value >= current, or None if wrapped."""
-            if spec == "*":
-                return current
-            if spec.startswith("*/"):
-                step = int(spec[2:])
-                if step <= 0:
-                    return None
-                # Next value that is a multiple of step and >= current
-                remainder = current % step
-                return current if remainder == 0 else current + (step - remainder)
-            # Fixed value
-            val = int(spec)
-            return val if val >= current else None
-
-        # Start from the minute after 'after'
-        candidate = after.replace(second=0, microsecond=0)
-
-        # Try up to 1440 minutes (24 hours) to find next match
-        for _ in range(1440):
-            m = candidate.minute
-            h = candidate.hour
-
-            m_match = _next_match(minute_spec, m, 59)
-            h_match = _next_match(hour_spec, h, 23)
-
-            if m_match is not None and m_match <= 59 and h_match is not None and h_match <= 23:
-                result = candidate.replace(minute=m_match, hour=h_match)
-                if result > after:
-                    return result
-
-            # Advance by 1 minute
-            from datetime import timedelta
-
-            candidate += timedelta(minutes=1)
-
+    if len(parts) != 5:
         return None
-    except (ValueError, IndexError):
+    ranges = ((0, 59), (0, 23), (1, 31), (1, 12), (0, 7))
+    expanded = [_expand_cron_field(spec, min_val, max_val) for spec, (min_val, max_val) in zip(parts, ranges, strict=True)]
+    if any(values is None for values in expanded):
         return None
+    minutes, hours, days_of_month, months, days_of_week = [values or set() for values in expanded]
+    days_of_week = {0 if value == 7 else value for value in days_of_week}
+
+    candidate = after.replace(second=0, microsecond=0) + timedelta(minutes=1)
+    for _ in range(366 * 24 * 60):
+        cron_dow = (candidate.weekday() + 1) % 7
+        if (
+            candidate.minute in minutes
+            and candidate.hour in hours
+            and candidate.day in days_of_month
+            and candidate.month in months
+            and cron_dow in days_of_week
+        ):
+            return candidate
+        candidate += timedelta(minutes=1)
+    return None
 
 
 async def scheduler_loop(
@@ -122,7 +123,9 @@ async def scheduler_loop(
 
     Args:
         schedule_store: ScheduleStore instance.
-        run_scan_fn: Callable to trigger a scan (receives scan_config dict).
+        run_scan_fn: Callable to trigger a scan. Receives scan_config plus
+            schedule_id and tenant_id keyword metadata so persisted jobs can
+            link back to the schedule that created them.
         interval_seconds: Check interval in seconds.
         max_backoff: Maximum backoff delay in seconds (default 15 min).
     """
@@ -174,7 +177,11 @@ async def scheduler_loop(
                         continue
                     logger.info("Triggering scheduled scan: %s (%s)", schedule.name, schedule.schedule_id)
                     try:
-                        job_id = run_scan_fn(schedule.scan_config)
+                        job_id = run_scan_fn(
+                            schedule.scan_config,
+                            schedule_id=schedule.schedule_id,
+                            tenant_id=schedule.tenant_id,
+                        )
                         schedule.last_run = now_iso
                         schedule.last_job_id = job_id
 

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -424,18 +424,25 @@ async def _lifespan(app_instance: FastAPI):
     from agent_bom.api.scheduler import scheduler_loop
     from agent_bom.api.tenant_quota import enforce_active_scan_quota, enforce_retained_jobs_quota, tenant_quota_guard
 
-    def _schedule_scan(scan_config: dict) -> str:
+    def _schedule_scan(scan_config: dict, *, schedule_id: str | None = None, tenant_id: str | None = None) -> str:
         """Trigger a scan from a schedule."""
-        tenant_id = (
+        resolved_tenant_id = tenant_id or (
             getattr(scan_config, "tenant_id", None) if hasattr(scan_config, "tenant_id") else scan_config.get("tenant_id", "default")
         )
-        tenant_id = str(tenant_id or "default")
+        tenant_id = str(resolved_tenant_id or "default")
+        request_payload = scan_config
+        if isinstance(scan_config, dict):
+            request_payload = {key: value for key, value in scan_config.items() if key in ScanRequest.model_fields}
+            legacy_path = scan_config.get("path")
+            if isinstance(legacy_path, str) and legacy_path and not request_payload.get("agent_projects"):
+                request_payload["agent_projects"] = [legacy_path]
         job = ScanJob(
             job_id=str(uuid.uuid4()),
             tenant_id=tenant_id,
+            schedule_id=schedule_id,
             triggered_by="scheduler",
             created_at=_now(),
-            request=ScanRequest(**scan_config) if isinstance(scan_config, dict) else scan_config,
+            request=ScanRequest(**request_payload) if isinstance(request_payload, dict) else request_payload,
         )
         # Per-tenant quota lock makes (check + insert) atomic. See
         # tenant_quota.tenant_quota_guard for rationale (audit-4 P1).

--- a/src/agent_bom/api/snowflake_store.py
+++ b/src/agent_bom/api/snowflake_store.py
@@ -141,10 +141,12 @@ class SnowflakeJobStore:
                     created_at TIMESTAMP_TZ NOT NULL,
                     completed_at TIMESTAMP_TZ,
                     tenant_id VARCHAR NOT NULL DEFAULT 'default',
+                    schedule_id VARCHAR,
                     data VARIANT NOT NULL
                 )
             """)
             conn.cursor().execute("ALTER TABLE scan_jobs ADD COLUMN IF NOT EXISTS tenant_id VARCHAR NOT NULL DEFAULT 'default'")
+            conn.cursor().execute("ALTER TABLE scan_jobs ADD COLUMN IF NOT EXISTS schedule_id VARCHAR")
             _ensure_tenant_row_access_policy(conn.cursor(), ("scan_jobs",))
 
     def put(self, job: ScanJob) -> None:
@@ -153,23 +155,25 @@ class SnowflakeJobStore:
                 """MERGE INTO scan_jobs t USING (SELECT %s AS job_id) s
                    ON t.job_id = s.job_id
                    WHEN MATCHED THEN UPDATE SET
-                     status = %s, created_at = %s, completed_at = %s, tenant_id = %s,
+                     status = %s, created_at = %s, completed_at = %s, tenant_id = %s, schedule_id = %s,
                      data = PARSE_JSON(%s)
                    WHEN NOT MATCHED THEN INSERT
-                     (job_id, status, created_at, completed_at, tenant_id, data)
-                     VALUES (%s, %s, %s, %s, %s, PARSE_JSON(%s))""",
+                     (job_id, status, created_at, completed_at, tenant_id, schedule_id, data)
+                     VALUES (%s, %s, %s, %s, %s, %s, PARSE_JSON(%s))""",
                 (
                     job.job_id,
                     job.status.value,
                     job.created_at,
                     job.completed_at,
                     job.tenant_id,
+                    job.schedule_id,
                     job.model_dump_json(),
                     job.job_id,
                     job.status.value,
                     job.created_at,
                     job.completed_at,
                     job.tenant_id,
+                    job.schedule_id,
                     job.model_dump_json(),
                 ),
             )
@@ -208,10 +212,14 @@ class SnowflakeJobStore:
         with self._connect() as conn:
             cur = conn.cursor()
             if tenant_id is None:
-                cur.execute("SELECT job_id, tenant_id, status, created_at, completed_at, data FROM scan_jobs ORDER BY created_at DESC")
+                cur.execute(
+                    """SELECT job_id, tenant_id, status, created_at, completed_at, data, schedule_id
+                       FROM scan_jobs
+                       ORDER BY created_at DESC"""
+                )
             else:
                 cur.execute(
-                    """SELECT job_id, tenant_id, status, created_at, completed_at, data
+                    """SELECT job_id, tenant_id, status, created_at, completed_at, data, schedule_id
                        FROM scan_jobs
                        WHERE tenant_id = %s
                        ORDER BY created_at DESC""",
@@ -228,6 +236,7 @@ class SnowflakeJobStore:
                         "job_id": row[0],
                         "tenant_id": row[1],
                         "triggered_by": triggered_by,
+                        "schedule_id": row[6] if len(row) > 6 else None,
                         "status": row[2],
                         "created_at": str(row[3]) if row[3] else None,
                         "completed_at": str(row[4]) if row[4] else None,

--- a/src/agent_bom/api/storage_schema.py
+++ b/src/agent_bom/api/storage_schema.py
@@ -41,7 +41,7 @@ CONTROL_PLANE_SCHEMA_COMPONENTS: tuple[StorageSchemaComponent, ...] = (
     StorageSchemaComponent("identity_scim", "sqlite/postgres", ("scim_users", "scim_groups")),
     StorageSchemaComponent("tenant_quotas", "sqlite/postgres", ("tenant_quota_overrides",)),
     StorageSchemaComponent("sources", "sqlite/postgres", ("sources", "control_plane_sources")),
-    StorageSchemaComponent("schedules", "sqlite/postgres", ("schedules", "scan_schedules")),
+    StorageSchemaComponent("schedules", "sqlite/postgres", ("scan_schedules",)),
     StorageSchemaComponent("exceptions", "sqlite/postgres", ("vuln_exceptions",)),
     StorageSchemaComponent("idempotency", "sqlite", ("idempotency_keys",)),
     StorageSchemaComponent("mcp_observations", "sqlite", ("mcp_observations",)),

--- a/src/agent_bom/api/store.py
+++ b/src/agent_bom/api/store.py
@@ -90,6 +90,7 @@ class InMemoryJobStore:
                 {
                     "job_id": j.job_id,
                     "tenant_id": j.tenant_id,
+                    "schedule_id": j.schedule_id,
                     "triggered_by": j.triggered_by,
                     "status": j.status,
                     "created_at": j.created_at,
@@ -173,16 +174,20 @@ class SQLiteJobStore:
                     created_at TEXT NOT NULL,
                     completed_at TEXT,
                     tenant_id TEXT NOT NULL DEFAULT 'default',
+                    schedule_id TEXT,
                     triggered_by TEXT,
                     data TEXT NOT NULL
                 )
             """)
             columns = {row[1] for row in self._conn.execute("PRAGMA table_info(jobs)").fetchall()}
+            if "schedule_id" not in columns:
+                self._conn.execute("ALTER TABLE jobs ADD COLUMN schedule_id TEXT")
             if "triggered_by" not in columns:
                 self._conn.execute("ALTER TABLE jobs ADD COLUMN triggered_by TEXT")
             self._conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status)")
             self._conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_completed ON jobs(completed_at)")
             self._conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_tenant ON jobs(tenant_id)")
+            self._conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_schedule ON jobs(tenant_id, schedule_id, created_at DESC)")
             self._conn.commit()
         finally:
             self._shrink_connection_memory()
@@ -199,14 +204,15 @@ class SQLiteJobStore:
     def put(self, job: ScanJob) -> None:
         try:
             self._conn.execute(
-                """INSERT OR REPLACE INTO jobs (job_id, status, created_at, completed_at, tenant_id, triggered_by, data)
-                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                """INSERT OR REPLACE INTO jobs (job_id, status, created_at, completed_at, tenant_id, schedule_id, triggered_by, data)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     job.job_id,
                     job.status.value,
                     job.created_at,
                     job.completed_at,
                     job.tenant_id,
+                    job.schedule_id,
                     job.triggered_by,
                     self._serialize(job),
                 ),
@@ -265,11 +271,13 @@ class SQLiteJobStore:
         try:
             if tenant_id is None:
                 rows = self._conn.execute(
-                    "SELECT job_id, tenant_id, status, created_at, completed_at, triggered_by FROM jobs ORDER BY created_at DESC"
+                    """SELECT job_id, tenant_id, status, created_at, completed_at, triggered_by, schedule_id
+                       FROM jobs
+                       ORDER BY created_at DESC"""
                 ).fetchall()
             else:
                 rows = self._conn.execute(
-                    """SELECT job_id, tenant_id, status, created_at, completed_at, triggered_by
+                    """SELECT job_id, tenant_id, status, created_at, completed_at, triggered_by, schedule_id
                        FROM jobs
                        WHERE tenant_id = ?
                        ORDER BY created_at DESC""",
@@ -282,6 +290,7 @@ class SQLiteJobStore:
                         "job_id": row[0],
                         "tenant_id": row[1],
                         "triggered_by": row[5],
+                        "schedule_id": row[6],
                         "status": row[2],
                         "created_at": row[3],
                         "completed_at": row[4],

--- a/tests/test_audit_round2.py
+++ b/tests/test_audit_round2.py
@@ -180,9 +180,9 @@ def test_sqlite_schedule_store_has_index():
     with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
         SQLiteScheduleStore(tmp.name)
         conn = sqlite3.connect(tmp.name)
-        indexes = [r[1] for r in conn.execute("PRAGMA index_list('schedules')").fetchall()]
-        assert "idx_sched_due" in indexes
-        assert "idx_sched_tenant_due" in indexes
+        indexes = [r[1] for r in conn.execute("PRAGMA index_list('scan_schedules')").fetchall()]
+        assert "idx_scan_sched_due" in indexes
+        assert "idx_scan_sched_tenant_due" in indexes
         conn.close()
 
 

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -220,6 +220,18 @@ def test_scan_jobs_has_triggered_by():
     assert "triggered_by" in SQL
 
 
+def test_scan_jobs_has_schedule_id_back_pointer():
+    cols = _columns_for("scan_jobs")
+    assert "schedule_id" in cols
+    assert "idx_jobs_schedule" in _indexes()
+
+
+def test_scan_jobs_keeps_team_id_as_rls_column_with_api_tenant_translation():
+    cols = _columns_for("scan_jobs")
+    assert "team_id" in cols
+    assert "tenant_id" not in cols
+
+
 def test_scan_jobs_do_block_migration_present():
     """Idempotent DO $$ block adds team_id to pre-existing scan_jobs."""
     assert "ADD COLUMN team_id" in SQL or "team_id" in _columns_for("scan_jobs")

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -194,7 +194,7 @@ class MockConnection:
                 cursor.rows = [(r[-1],) for r in rows]
             elif "from scan_jobs" in sql_lower and "job_id, team_id, status, created_at, completed_at, triggered_by" in sql_lower:
                 rows = list(self._store.get("scan_jobs", {}).values())
-                cursor.rows = [(r[0], r[1], r[2], r[3], r[4], (r[5] if len(r) > 6 else None)) for r in rows]
+                cursor.rows = [(r[0], r[1], r[2], r[3], r[4], (r[5] if len(r) > 5 else None), (r[6] if len(r) > 6 else None)) for r in rows]
             elif "from fleet_agents" in sql_lower and "agent_id, canonical_id, name, lifecycle_state, trust_score" in sql_lower:
                 rows = list(self._store.get("fleet_agents", {}).values())
                 cursor.rows = [(r[0], r[1], r[2], r[3], r[4]) for r in rows]
@@ -337,6 +337,7 @@ def test_job_store_persists_triggered_by(mock_pool):
     job = ScanJob(
         job_id="j-triggered",
         tenant_id="tenant-alpha",
+        schedule_id="sched-alpha",
         triggered_by="analyst@example.com",
         status=JobStatus.PENDING,
         created_at="2026-01-01T00:00:00Z",
@@ -346,7 +347,9 @@ def test_job_store_persists_triggered_by(mock_pool):
 
     insert_sql, insert_params = next((sql, params) for sql, params in reversed(mock_pool._conn.executed) if "INSERT INTO scan_jobs" in sql)
     assert "triggered_by" in insert_sql
-    assert insert_params[5] == "analyst@example.com"
+    assert "schedule_id" in insert_sql
+    assert insert_params[5] == "sched-alpha"
+    assert insert_params[6] == "analyst@example.com"
 
 
 def test_job_store_get_nonexistent(mock_pool):
@@ -399,11 +402,13 @@ def test_job_store_list_summary_includes_tenant(mock_pool):
         "2026-01-01T00:00:00Z",
         None,
         "scheduler",
+        "sched-alpha",
         "{}",
     )
     result = store.list_summary()
     assert result[0]["tenant_id"] == "tenant-alpha"
     assert result[0]["triggered_by"] == "scheduler"
+    assert result[0]["schedule_id"] == "sched-alpha"
 
 
 def test_job_store_cleanup(mock_pool):

--- a/tests/test_schedule_store.py
+++ b/tests/test_schedule_store.py
@@ -147,6 +147,44 @@ class TestSQLiteScheduleStore:
         store2.put(_make_schedule())
         assert store2.get("sched-1") is not None
 
+    def test_uses_scan_schedules_table_name(self, tmp_path):
+        import sqlite3
+
+        db = tmp_path / "sched.db"
+        store = SQLiteScheduleStore(str(db))
+        store.put(_make_schedule())
+
+        with sqlite3.connect(db) as conn:
+            tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
+        assert "scan_schedules" in tables
+        assert "schedules" not in tables
+
+    def test_migrates_legacy_schedules_table(self, tmp_path):
+        import sqlite3
+
+        db = tmp_path / "sched.db"
+        schedule = _make_schedule("legacy-sched", tenant_id="tenant-alpha")
+        with sqlite3.connect(db) as conn:
+            conn.execute(
+                """
+                CREATE TABLE schedules (
+                    schedule_id TEXT PRIMARY KEY,
+                    enabled INTEGER DEFAULT 1,
+                    next_run TEXT,
+                    tenant_id TEXT NOT NULL DEFAULT 'default',
+                    data TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                "INSERT INTO schedules (schedule_id, enabled, next_run, tenant_id, data) VALUES (?, ?, ?, ?, ?)",
+                (schedule.schedule_id, int(schedule.enabled), schedule.next_run, schedule.tenant_id, schedule.model_dump_json()),
+            )
+
+        store = SQLiteScheduleStore(str(db))
+
+        assert store.get("legacy-sched", tenant_id="tenant-alpha") is not None
+
 
 # ─── parse_cron_next ──────────────────────────────────────────────────────────
 
@@ -201,6 +239,18 @@ class TestParseCronNext:
     def test_validation_accepts_basic_five_field_cron(self):
         assert validate_cron_expression("0 0 * * *") is True
 
+    def test_validation_accepts_lists_ranges_and_steps(self):
+        assert validate_cron_expression("5,35 1-6/2 * * 1-5") is True
+
+    def test_list_and_range_expression_finds_next_run(self):
+        after = datetime(2025, 1, 6, 0, 0, 0, tzinfo=timezone.utc)
+        result = parse_cron_next("5,35 1-6/2 * * 1-5", after)
+
+        assert result == datetime(2025, 1, 6, 1, 5, tzinfo=timezone.utc)
+
+    def test_validation_rejects_descending_ranges(self):
+        assert validate_cron_expression("0 5-1 * * *") is False
+
 
 # ─── scheduler_loop ───────────────────────────────────────────────────────────
 
@@ -215,8 +265,8 @@ class TestSchedulerLoop:
 
         triggered = []
 
-        def mock_scan(config):
-            triggered.append(config)
+        def mock_scan(config, **metadata):
+            triggered.append({"config": config, "metadata": metadata})
             return "job-123"
 
         async def _run():
@@ -241,8 +291,8 @@ class TestSchedulerLoop:
 
         triggered = []
 
-        def mock_scan(config):
-            triggered.append(config)
+        def mock_scan(config, **metadata):
+            triggered.append({"config": config, "metadata": metadata})
             return "job-123"
 
         async def _run():
@@ -276,8 +326,8 @@ class TestSchedulerLoop:
 
         triggered = []
 
-        def mock_scan(config):
-            triggered.append(config)
+        def mock_scan(config, **metadata):
+            triggered.append({"config": config, "metadata": metadata})
             return "job-123"
 
         async def _run():
@@ -301,8 +351,8 @@ class TestSchedulerLoop:
 
         triggered = []
 
-        def mock_scan(config):
-            triggered.append(config)
+        def mock_scan(config, **metadata):
+            triggered.append({"config": config, "metadata": metadata})
             return "job-123"
 
         async def _run():
@@ -323,8 +373,10 @@ class TestSchedulerLoop:
 
         store = InMemoryScheduleStore()
         store.put(_make_schedule("s1", next_run="2020-01-01T00:00:00+00:00", enabled=True))
+        triggered = []
 
-        def mock_scan(config):
+        def mock_scan(config, **metadata):
+            triggered.append({"config": config, "metadata": metadata})
             return "job-456"
 
         async def _run():
@@ -340,6 +392,8 @@ class TestSchedulerLoop:
         updated = store.get("s1")
         assert updated.last_run is not None
         assert updated.last_job_id == "job-456"
+        assert triggered[0]["metadata"]["schedule_id"] == "s1"
+        assert triggered[0]["metadata"]["tenant_id"] == "default"
 
     def test_skips_due_scans_without_postgres_leader_lock(self, monkeypatch):
         """Only the replica holding the advisory lock should trigger schedules."""
@@ -369,8 +423,8 @@ class TestSchedulerLoop:
             def putconn(self, conn):
                 return None
 
-        def mock_scan(config):
-            triggered.append(config)
+        def mock_scan(config, **metadata):
+            triggered.append({"config": config, "metadata": metadata})
             return "job-123"
 
         async def _run():


### PR DESCRIPTION
Summary
- Rename local SQLite schedule storage to `scan_schedules` with legacy `schedules` row migration.
- Add `schedule_id` back-pointers to scan jobs across in-memory, SQLite, Postgres, and Snowflake stores so scheduled run history is linkable through existing job APIs.
- Support cron lists/ranges/steps and reject malformed expressions before schedule creation can silently no-op.

Verification
- `uv run pytest tests/test_schedule_store.py tests/test_api_tenant_isolation.py tests/test_postgres_schema.py tests/test_postgres_store.py -q`
- `uv run pytest tests/test_snowflake_stores.py -q`
- `uv run pytest tests/test_schedule_store.py tests/test_postgres_store.py tests/test_snowflake_stores.py tests/test_postgres_schema.py -q`
- `uv run ruff check src/agent_bom/api/models.py src/agent_bom/api/postgres_store.py src/agent_bom/api/routes/scan.py src/agent_bom/api/schedule_store.py src/agent_bom/api/scheduler.py src/agent_bom/api/server.py src/agent_bom/api/snowflake_store.py src/agent_bom/api/storage_schema.py src/agent_bom/api/store.py tests/test_postgres_schema.py tests/test_postgres_store.py tests/test_schedule_store.py`
- `uv run mypy src/agent_bom/api/models.py src/agent_bom/api/postgres_store.py src/agent_bom/api/routes/scan.py src/agent_bom/api/schedule_store.py src/agent_bom/api/scheduler.py src/agent_bom/api/server.py src/agent_bom/api/snowflake_store.py src/agent_bom/api/storage_schema.py src/agent_bom/api/store.py`
- `git diff --check`

Notes
- Closes #2942.
- Postgres keeps `team_id` as the RLS storage column and maps it to API `tenant_id`; the PR adds guard coverage for that compatibility boundary instead of renaming a live RLS column.