### PR TITLE
refactor(graph): document schema emission status

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -2146,6 +2146,96 @@ _SHAPE_TO_ICON: dict[str, str] = {
 }
 
 
+_RESERVED_GRAPH_NODE_KINDS: dict[str, tuple[list[str], str]] = {
+    EntityType.SOURCE_FILE.value: (
+        ["code_graph"],
+        "Reserved for source-code topology; static supply-chain scans do not emit file-level nodes yet.",
+    ),
+    EntityType.CODE_MODULE.value: (
+        ["code_graph"],
+        "Reserved for source-code topology; static supply-chain scans do not emit module-level nodes yet.",
+    ),
+    EntityType.CONFIG_FILE.value: (
+        ["code_graph"],
+        "Reserved for configuration topology; static supply-chain scans do not emit config-file nodes yet.",
+    ),
+    EntityType.EXTERNAL_IMPORT.value: (
+        ["code_graph"],
+        "Reserved for source-code import topology; static supply-chain scans do not emit import nodes yet.",
+    ),
+    EntityType.CI_JOB.value: (
+        ["ci_graph"],
+        "Reserved for CI/CD topology; scan jobs are tracked operationally but are not emitted as graph nodes yet.",
+    ),
+}
+
+
+_RESERVED_GRAPH_EDGE_KINDS: dict[str, tuple[list[str], str]] = {
+    RelationshipType.IMPORTS.value: (
+        ["code_graph"],
+        "Reserved for source-code topology linking files, modules, packages, and imports.",
+    ),
+    RelationshipType.DEFINES.value: (
+        ["code_graph"],
+        "Reserved for source-code topology linking source files to modules, tools, and CI jobs.",
+    ),
+    RelationshipType.RUNS.value: (
+        ["ci_graph"],
+        "Reserved for CI/CD topology linking workflow jobs to tools, servers, and agents.",
+    ),
+    RelationshipType.CONFIGURES.value: (
+        ["code_graph"],
+        "Reserved for configuration topology linking config files to agents, servers, CI jobs, and tools.",
+    ),
+    RelationshipType.OWNS.value: (
+        ["identity_graph"],
+        "Reserved for ownership imports from enterprise identity and cloud inventory sources.",
+    ),
+    RelationshipType.REMEDIATES.value: (
+        ["remediation_graph"],
+        "Reserved for fixed-version and remediation-plan graph edges.",
+    ),
+    RelationshipType.ACTED_AS.value: (
+        ["runtime_graph"],
+        "Reserved for explicit user/service-principal runtime delegation once traces carry that identity link.",
+    ),
+}
+
+
+_EMITTED_GRAPH_NODE_SURFACES: dict[str, list[str]] = {
+    EntityType.TOOL_CALL.value: ["runtime_proxy", "gateway_event_projection"],
+    EntityType.RESOURCE.value: ["runtime_proxy", "gateway_event_projection", "cnapp_overlay"],
+}
+
+
+_EMITTED_GRAPH_EDGE_SURFACES: dict[str, list[str]] = {
+    RelationshipType.CALLED.value: ["runtime_proxy", "gateway_event_projection"],
+    RelationshipType.USED_CREDENTIAL.value: ["runtime_proxy", "gateway_event_projection"],
+}
+
+
+def _graph_schema_emission_meta(
+    key: str,
+    *,
+    reserved: dict[str, tuple[list[str], str]],
+    emitted_surfaces: dict[str, list[str]],
+    default_surfaces: list[str],
+) -> dict[str, object]:
+    """Document whether a graph kind is emitted today or reserved vocabulary."""
+    if key in reserved:
+        surfaces, notes = reserved[key]
+        return {
+            "emission_status": "reserved",
+            "emission_surfaces": surfaces,
+            "emission_notes": notes,
+        }
+    return {
+        "emission_status": "emitted",
+        "emission_surfaces": emitted_surfaces.get(key, default_surfaces),
+        "emission_notes": "Emitted by at least one graph builder or runtime projection.",
+    }
+
+
 _RELATIONSHIP_SCHEMA_META: dict[str, dict[str, object]] = {
     RelationshipType.HOSTS.value: {
         "category": "inventory",
@@ -2603,6 +2693,12 @@ async def get_graph_schema() -> dict:
                 "icon": _SHAPE_TO_ICON.get(shape, "circle"),
                 "category_uid": ENTITY_OCSF_MAP.get(entity.value, {}).get("category_uid", 0),
                 "class_uid": ENTITY_OCSF_MAP.get(entity.value, {}).get("class_uid", 0),
+                **_graph_schema_emission_meta(
+                    entity.value,
+                    reserved=_RESERVED_GRAPH_NODE_KINDS,
+                    emitted_surfaces=_EMITTED_GRAPH_NODE_SURFACES,
+                    default_surfaces=["static_scan", "graph_overlay"],
+                ),
             }
         )
 
@@ -2616,6 +2712,12 @@ async def get_graph_schema() -> dict:
                 "key": rel.value,
                 "label": label,
                 "color": color,
+                **_graph_schema_emission_meta(
+                    rel.value,
+                    reserved=_RESERVED_GRAPH_EDGE_KINDS,
+                    emitted_surfaces=_EMITTED_GRAPH_EDGE_SURFACES,
+                    default_surfaces=["static_scan", "graph_overlay", "computed_path"],
+                ),
                 **_RELATIONSHIP_SCHEMA_META.get(
                     rel.value,
                     {

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -1164,11 +1164,26 @@ class TestGraphSchemaEndpoint:
         body = client.get("/v1/graph/schema").json()
         layer_keys = {entry["key"] for entry in body["semantic_layers"]}
         for entry in body["node_kinds"]:
-            assert {"key", "label", "color", "shape", "layer", "icon", "category_uid", "class_uid"} <= set(entry)
+            assert {
+                "key",
+                "label",
+                "color",
+                "shape",
+                "layer",
+                "icon",
+                "category_uid",
+                "class_uid",
+                "emission_status",
+                "emission_surfaces",
+                "emission_notes",
+            } <= set(entry)
             assert entry["color"].startswith("#")
             assert entry["layer"] in layer_keys
             assert isinstance(entry["category_uid"], int)
             assert isinstance(entry["class_uid"], int)
+            assert entry["emission_status"] in {"emitted", "reserved"}
+            assert isinstance(entry["emission_surfaces"], list) and entry["emission_surfaces"]
+            assert isinstance(entry["emission_notes"], str) and entry["emission_notes"]
         for entry in body["edge_kinds"]:
             assert {
                 "key",
@@ -1179,6 +1194,9 @@ class TestGraphSchemaEndpoint:
                 "source_types",
                 "target_types",
                 "traversable",
+                "emission_status",
+                "emission_surfaces",
+                "emission_notes",
             } <= set(entry)
             assert entry["color"].startswith("#")
             assert entry["category"]
@@ -1186,6 +1204,33 @@ class TestGraphSchemaEndpoint:
             assert isinstance(entry["source_types"], list)
             assert isinstance(entry["target_types"], list)
             assert isinstance(entry["traversable"], bool)
+            assert entry["emission_status"] in {"emitted", "reserved"}
+            assert isinstance(entry["emission_surfaces"], list) and entry["emission_surfaces"]
+            assert isinstance(entry["emission_notes"], str) and entry["emission_notes"]
+
+    def test_schema_documents_reserved_dead_vocabulary(self):
+        client = self._client()
+        body = client.get("/v1/graph/schema").json()
+        node_entries = {entry["key"]: entry for entry in body["node_kinds"]}
+        edge_entries = {entry["key"]: entry for entry in body["edge_kinds"]}
+
+        reserved_nodes = {"source_file", "code_module", "config_file", "external_import", "ci_job"}
+        reserved_edges = {"imports", "defines", "runs", "configures", "owns", "remediates", "acted_as"}
+        for key in reserved_nodes:
+            assert node_entries[key]["emission_status"] == "reserved"
+            assert "Reserved" in node_entries[key]["emission_notes"]
+        for key in reserved_edges:
+            assert edge_entries[key]["emission_status"] == "reserved"
+            assert "Reserved" in edge_entries[key]["emission_notes"]
+
+        runtime_nodes = {"tool_call", "resource"}
+        runtime_edges = {"called", "used_credential"}
+        for key in runtime_nodes:
+            assert node_entries[key]["emission_status"] == "emitted"
+            assert any("runtime" in surface for surface in node_entries[key]["emission_surfaces"])
+        for key in runtime_edges:
+            assert edge_entries[key]["emission_status"] == "emitted"
+            assert any("runtime" in surface for surface in edge_entries[key]["emission_surfaces"])
 
     def test_every_entity_type_has_semantic_layer(self):
         from agent_bom.graph import ENTITY_LEGEND, GraphSemanticLayer

--- a/ui/lib/graph-schema.generated.ts
+++ b/ui/lib/graph-schema.generated.ts
@@ -137,6 +137,9 @@ export interface GraphNodeKindMeta {
   icon: string;
   category_uid: number;
   class_uid: number;
+  emission_status: "emitted" | "reserved";
+  emission_surfaces: readonly string[];
+  emission_notes: string;
 }
 
 export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> = {
@@ -147,7 +150,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "diamond",
     "category_uid": 3,
-    "class_uid": 3001
+    "class_uid": 3001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "access_policy": {
     "label": "Access Policy",
@@ -156,7 +165,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "diamond",
     "category_uid": 3,
-    "class_uid": 3001
+    "class_uid": 3001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "account": {
     "label": "Account",
@@ -165,7 +180,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "square",
     "category_uid": 3,
-    "class_uid": 3001
+    "class_uid": 3001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "agent": {
     "label": "AI Agent",
@@ -174,7 +195,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "orchestration",
     "icon": "circle",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "ci_job": {
     "label": "CI/CD Job",
@@ -183,7 +210,12 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "ci",
     "icon": "diamond",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "reserved",
+    "emission_surfaces": [
+      "ci_graph"
+    ],
+    "emission_notes": "Reserved for CI/CD topology; scan jobs are tracked operationally but are not emitted as graph nodes yet."
   },
   "cloud_resource": {
     "label": "Cloud Resource",
@@ -192,7 +224,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "infra",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "cluster": {
     "label": "Cluster",
@@ -201,7 +239,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "infra",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "code_module": {
     "label": "Code Module",
@@ -210,7 +254,12 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "code",
     "icon": "circle",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "reserved",
+    "emission_surfaces": [
+      "code_graph"
+    ],
+    "emission_notes": "Reserved for source-code topology; static supply-chain scans do not emit module-level nodes yet."
   },
   "config_file": {
     "label": "Config File",
@@ -219,7 +268,12 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "code",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "reserved",
+    "emission_surfaces": [
+      "code_graph"
+    ],
+    "emission_notes": "Reserved for configuration topology; static supply-chain scans do not emit config-file nodes yet."
   },
   "container": {
     "label": "Container",
@@ -228,7 +282,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "infra",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "credential": {
     "label": "Credential",
@@ -237,7 +297,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "diamond",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "credential_ref": {
     "label": "Credential Reference",
@@ -246,7 +312,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "diamond",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "data_store": {
     "label": "Data Store",
@@ -255,7 +327,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "asset",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "dataset": {
     "label": "Dataset",
@@ -264,7 +342,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "asset",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "drift_incident": {
     "label": "Drift Incident",
@@ -273,7 +357,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "finding",
     "icon": "triangle",
     "category_uid": 2,
-    "class_uid": 2004
+    "class_uid": 2004,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "environment": {
     "label": "Environment",
@@ -282,7 +372,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "infra",
     "icon": "square",
     "category_uid": 0,
-    "class_uid": 0
+    "class_uid": 0,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "external_import": {
     "label": "External Import",
@@ -291,7 +387,12 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "code",
     "icon": "circle",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "reserved",
+    "emission_surfaces": [
+      "code_graph"
+    ],
+    "emission_notes": "Reserved for source-code import topology; static supply-chain scans do not emit import nodes yet."
   },
   "federated_identity": {
     "label": "Federated Identity",
@@ -300,7 +401,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "circle",
     "category_uid": 3,
-    "class_uid": 3001
+    "class_uid": 3001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "fleet": {
     "label": "Fleet",
@@ -309,7 +416,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "infra",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "group": {
     "label": "Group",
@@ -318,7 +431,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "circle",
     "category_uid": 3,
-    "class_uid": 3001
+    "class_uid": 3001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "managed_identity": {
     "label": "Managed Identity",
@@ -327,7 +446,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "circle",
     "category_uid": 3,
-    "class_uid": 3001
+    "class_uid": 3001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "misconfiguration": {
     "label": "Misconfiguration",
@@ -336,7 +461,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "finding",
     "icon": "triangle",
     "category_uid": 2,
-    "class_uid": 2003
+    "class_uid": 2003,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "model": {
     "label": "Model",
@@ -345,7 +476,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "asset",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "org": {
     "label": "Organization",
@@ -354,7 +491,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "square",
     "category_uid": 3,
-    "class_uid": 3001
+    "class_uid": 3001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "package": {
     "label": "Package",
@@ -363,7 +506,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "package",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "policy": {
     "label": "Policy",
@@ -372,7 +521,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "diamond",
     "category_uid": 3,
-    "class_uid": 3001
+    "class_uid": 3001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "provider": {
     "label": "Provider",
@@ -381,7 +536,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "infra",
     "icon": "square",
     "category_uid": 0,
-    "class_uid": 0
+    "class_uid": 0,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "resource": {
     "label": "Resource",
@@ -390,7 +551,14 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "asset",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "runtime_proxy",
+      "gateway_event_projection",
+      "cnapp_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "role": {
     "label": "Role",
@@ -399,7 +567,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "circle",
     "category_uid": 3,
-    "class_uid": 3001
+    "class_uid": 3001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "server": {
     "label": "MCP Server",
@@ -408,7 +582,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "mcp_server",
     "icon": "circle",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "service_account": {
     "label": "Service Account",
@@ -417,7 +597,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "circle",
     "category_uid": 3,
-    "class_uid": 3001
+    "class_uid": 3001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "service_principal": {
     "label": "Service Principal",
@@ -426,7 +612,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "circle",
     "category_uid": 3,
-    "class_uid": 3001
+    "class_uid": 3001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "source_file": {
     "label": "Source File",
@@ -435,7 +627,12 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "code",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "reserved",
+    "emission_surfaces": [
+      "code_graph"
+    ],
+    "emission_notes": "Reserved for source-code topology; static supply-chain scans do not emit file-level nodes yet."
   },
   "tool": {
     "label": "Tool",
@@ -444,7 +641,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "tool",
     "icon": "diamond",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "tool_call": {
     "label": "Tool Call",
@@ -453,7 +656,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "runtime_evidence",
     "icon": "diamond",
     "category_uid": 5,
-    "class_uid": 4001
+    "class_uid": 4001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "runtime_proxy",
+      "gateway_event_projection"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "user": {
     "label": "User",
@@ -462,7 +671,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "user",
     "icon": "circle",
     "category_uid": 3,
-    "class_uid": 3001
+    "class_uid": 3001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "vulnerability": {
     "label": "Vulnerability",
@@ -471,7 +686,13 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "finding",
     "icon": "triangle",
     "category_uid": 2,
-    "class_uid": 2001
+    "class_uid": 2001,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
 };
 
@@ -539,6 +760,9 @@ export interface GraphEdgeKindMeta {
   source_types: readonly GraphNodeKindKey[];
   target_types: readonly GraphNodeKindKey[];
   traversable: boolean;
+  emission_status: "emitted" | "reserved";
+  emission_surfaces: readonly string[];
+  emission_notes: string;
 }
 
 export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> = {
@@ -558,7 +782,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "credential_ref",
       "resource"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "acted_as": {
     "label": "Acted As (runtime)",
@@ -574,7 +805,12 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "agent"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "reserved",
+    "emission_surfaces": [
+      "runtime_graph"
+    ],
+    "emission_notes": "Reserved for explicit user/service-principal runtime delegation once traces carry that identity link."
   },
   "affects": {
     "label": "Affects",
@@ -590,7 +826,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "server",
       "container"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "assumes": {
     "label": "Assumes",
@@ -606,7 +849,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "role"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "attached": {
     "label": "Attached",
@@ -625,7 +875,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "policy",
       "access_grant"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "authenticates_as": {
     "label": "Authenticates As",
@@ -638,7 +895,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "managed_identity"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "called": {
     "label": "Called (runtime)",
@@ -653,7 +917,13 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "tool",
       "server"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "runtime_proxy",
+      "gateway_event_projection"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "can_access": {
     "label": "Can Access",
@@ -675,7 +945,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "credential",
       "resource"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "configures": {
     "label": "Configures",
@@ -691,7 +968,12 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "ci_job",
       "tool"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "reserved",
+    "emission_surfaces": [
+      "code_graph"
+    ],
+    "emission_notes": "Reserved for configuration topology linking config files to agents, servers, CI jobs, and tools."
   },
   "contains": {
     "label": "Contains",
@@ -708,7 +990,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "server",
       "container"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "correlates_with": {
     "label": "Correlates With (cross-env)",
@@ -723,7 +1012,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "agent",
       "server"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "cross_account_trust": {
     "label": "Cross-Account Trust",
@@ -742,7 +1038,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "service_principal",
       "federated_identity"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "defines": {
     "label": "Defines",
@@ -757,7 +1060,12 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "tool",
       "ci_job"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "reserved",
+    "emission_surfaces": [
+      "code_graph"
+    ],
+    "emission_notes": "Reserved for source-code topology linking source files to modules, tools, and CI jobs."
   },
   "delegated_to": {
     "label": "Delegated To (runtime)",
@@ -770,7 +1078,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "agent"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "depends_on": {
     "label": "Depends On",
@@ -784,7 +1099,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "package"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "exhibits_drift": {
     "label": "Exhibits Drift",
@@ -797,7 +1119,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "drift_incident"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "exploitable_via": {
     "label": "Exploitable Via",
@@ -812,7 +1141,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "tool",
       "credential"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "exposed_to": {
     "label": "Exposed To",
@@ -830,7 +1166,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "resource",
       "data_store"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "exposes_cred": {
     "label": "Exposes Credential",
@@ -844,7 +1187,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "credential"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "governs": {
     "label": "Governs",
@@ -859,7 +1209,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "managed_identity",
       "tool"
     ],
-    "traversable": false
+    "traversable": false,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "has_permission": {
     "label": "Has Permission",
@@ -879,7 +1236,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "resource",
       "tool"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "hosts": {
     "label": "Hosts",
@@ -900,7 +1264,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "server",
       "cloud_resource"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "imports": {
     "label": "Imports",
@@ -916,7 +1287,12 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "code_module",
       "package"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "reserved",
+    "emission_surfaces": [
+      "code_graph"
+    ],
+    "emission_notes": "Reserved for source-code topology linking files, modules, packages, and imports."
   },
   "inherits": {
     "label": "Inherits",
@@ -934,7 +1310,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "policy",
       "role"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "invoked": {
     "label": "Invoked (runtime)",
@@ -949,7 +1332,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "tool",
       "tool_call"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "lateral_path": {
     "label": "Lateral Path",
@@ -962,7 +1352,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "agent"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "manages": {
     "label": "Manages",
@@ -983,7 +1380,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "environment",
       "cloud_resource"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "member_of": {
     "label": "Member Of",
@@ -1005,7 +1409,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "agent",
       "fleet"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "owns": {
     "label": "Owns",
@@ -1026,7 +1437,12 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "cloud_resource",
       "agent"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "reserved",
+    "emission_surfaces": [
+      "identity_graph"
+    ],
+    "emission_notes": "Reserved for ownership imports from enterprise identity and cloud inventory sources."
   },
   "part_of": {
     "label": "Part Of",
@@ -1045,7 +1461,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "cluster",
       "environment"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "possibly_correlates_with": {
     "label": "Possibly Correlates With (low confidence)",
@@ -1060,7 +1483,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "agent",
       "server"
     ],
-    "traversable": false
+    "traversable": false,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "provides_tool": {
     "label": "Provides Tool",
@@ -1073,7 +1503,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "tool"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "reaches_tool": {
     "label": "Credential Reaches Tool",
@@ -1087,7 +1524,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "tool"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "remediates": {
     "label": "Remediates",
@@ -1101,7 +1545,12 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "vulnerability",
       "misconfiguration"
     ],
-    "traversable": false
+    "traversable": false,
+    "emission_status": "reserved",
+    "emission_surfaces": [
+      "remediation_graph"
+    ],
+    "emission_notes": "Reserved for fixed-version and remediation-plan graph edges."
   },
   "runs": {
     "label": "Runs",
@@ -1116,7 +1565,12 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "server",
       "agent"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "reserved",
+    "emission_surfaces": [
+      "ci_graph"
+    ],
+    "emission_notes": "Reserved for CI/CD topology linking workflow jobs to tools, servers, and agents."
   },
   "scoped_to": {
     "label": "Scoped To",
@@ -1131,7 +1585,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "tool"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "serves_model": {
     "label": "Serves Model",
@@ -1144,7 +1605,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "model"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "shares_cred": {
     "label": "Shares Credential",
@@ -1157,7 +1625,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "agent"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "shares_server": {
     "label": "Shares Server",
@@ -1170,7 +1645,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "agent"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "stores": {
     "label": "Stores",
@@ -1186,7 +1668,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "dataset",
       "data_store"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "triggers": {
     "label": "Triggers",
@@ -1199,7 +1688,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "misconfiguration"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "trusts": {
     "label": "Trusts",
@@ -1219,7 +1715,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "service_principal",
       "federated_identity"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "used_credential": {
     "label": "Used Credential (runtime)",
@@ -1235,7 +1738,13 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "credential_ref",
       "credential"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "runtime_proxy",
+      "gateway_event_projection"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "uses": {
     "label": "Uses",
@@ -1248,7 +1757,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "server"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
   "vulnerable_to": {
     "label": "Vulnerable To",
@@ -1263,7 +1779,14 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "vulnerability"
     ],
-    "traversable": true
+    "traversable": true,
+    "emission_status": "emitted",
+    "emission_surfaces": [
+      "static_scan",
+      "graph_overlay",
+      "computed_path"
+    ],
+    "emission_notes": "Emitted by at least one graph builder or runtime projection."
   },
 };
 

--- a/ui/lib/graph-schema.generated.ts
+++ b/ui/lib/graph-schema.generated.ts
@@ -137,9 +137,6 @@ export interface GraphNodeKindMeta {
   icon: string;
   category_uid: number;
   class_uid: number;
-  emission_status: "emitted" | "reserved";
-  emission_surfaces: readonly string[];
-  emission_notes: string;
 }
 
 export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> = {
@@ -150,13 +147,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "diamond",
     "category_uid": 3,
-    "class_uid": 3001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 3001
   },
   "access_policy": {
     "label": "Access Policy",
@@ -165,13 +156,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "diamond",
     "category_uid": 3,
-    "class_uid": 3001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 3001
   },
   "account": {
     "label": "Account",
@@ -180,13 +165,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "square",
     "category_uid": 3,
-    "class_uid": 3001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 3001
   },
   "agent": {
     "label": "AI Agent",
@@ -195,13 +174,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "orchestration",
     "icon": "circle",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 4001
   },
   "ci_job": {
     "label": "CI/CD Job",
@@ -210,12 +183,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "ci",
     "icon": "diamond",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "reserved",
-    "emission_surfaces": [
-      "ci_graph"
-    ],
-    "emission_notes": "Reserved for CI/CD topology; scan jobs are tracked operationally but are not emitted as graph nodes yet."
+    "class_uid": 4001
   },
   "cloud_resource": {
     "label": "Cloud Resource",
@@ -224,13 +192,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "infra",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 4001
   },
   "cluster": {
     "label": "Cluster",
@@ -239,13 +201,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "infra",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 4001
   },
   "code_module": {
     "label": "Code Module",
@@ -254,12 +210,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "code",
     "icon": "circle",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "reserved",
-    "emission_surfaces": [
-      "code_graph"
-    ],
-    "emission_notes": "Reserved for source-code topology; static supply-chain scans do not emit module-level nodes yet."
+    "class_uid": 4001
   },
   "config_file": {
     "label": "Config File",
@@ -268,12 +219,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "code",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "reserved",
-    "emission_surfaces": [
-      "code_graph"
-    ],
-    "emission_notes": "Reserved for configuration topology; static supply-chain scans do not emit config-file nodes yet."
+    "class_uid": 4001
   },
   "container": {
     "label": "Container",
@@ -282,13 +228,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "infra",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 4001
   },
   "credential": {
     "label": "Credential",
@@ -297,13 +237,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "diamond",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 4001
   },
   "credential_ref": {
     "label": "Credential Reference",
@@ -312,13 +246,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "diamond",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 4001
   },
   "data_store": {
     "label": "Data Store",
@@ -327,13 +255,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "asset",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 4001
   },
   "dataset": {
     "label": "Dataset",
@@ -342,13 +264,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "asset",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 4001
   },
   "drift_incident": {
     "label": "Drift Incident",
@@ -357,13 +273,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "finding",
     "icon": "triangle",
     "category_uid": 2,
-    "class_uid": 2004,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 2004
   },
   "environment": {
     "label": "Environment",
@@ -372,13 +282,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "infra",
     "icon": "square",
     "category_uid": 0,
-    "class_uid": 0,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 0
   },
   "external_import": {
     "label": "External Import",
@@ -387,12 +291,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "code",
     "icon": "circle",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "reserved",
-    "emission_surfaces": [
-      "code_graph"
-    ],
-    "emission_notes": "Reserved for source-code import topology; static supply-chain scans do not emit import nodes yet."
+    "class_uid": 4001
   },
   "federated_identity": {
     "label": "Federated Identity",
@@ -401,13 +300,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "circle",
     "category_uid": 3,
-    "class_uid": 3001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 3001
   },
   "fleet": {
     "label": "Fleet",
@@ -416,13 +309,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "infra",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 4001
   },
   "group": {
     "label": "Group",
@@ -431,13 +318,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "circle",
     "category_uid": 3,
-    "class_uid": 3001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 3001
   },
   "managed_identity": {
     "label": "Managed Identity",
@@ -446,13 +327,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "circle",
     "category_uid": 3,
-    "class_uid": 3001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 3001
   },
   "misconfiguration": {
     "label": "Misconfiguration",
@@ -461,13 +336,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "finding",
     "icon": "triangle",
     "category_uid": 2,
-    "class_uid": 2003,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 2003
   },
   "model": {
     "label": "Model",
@@ -476,13 +345,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "asset",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 4001
   },
   "org": {
     "label": "Organization",
@@ -491,13 +354,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "square",
     "category_uid": 3,
-    "class_uid": 3001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 3001
   },
   "package": {
     "label": "Package",
@@ -506,13 +363,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "package",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 4001
   },
   "policy": {
     "label": "Policy",
@@ -521,13 +372,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "diamond",
     "category_uid": 3,
-    "class_uid": 3001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 3001
   },
   "provider": {
     "label": "Provider",
@@ -536,13 +381,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "infra",
     "icon": "square",
     "category_uid": 0,
-    "class_uid": 0,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 0
   },
   "resource": {
     "label": "Resource",
@@ -551,14 +390,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "asset",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "runtime_proxy",
-      "gateway_event_projection",
-      "cnapp_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 4001
   },
   "role": {
     "label": "Role",
@@ -567,13 +399,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "circle",
     "category_uid": 3,
-    "class_uid": 3001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 3001
   },
   "server": {
     "label": "MCP Server",
@@ -582,13 +408,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "mcp_server",
     "icon": "circle",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 4001
   },
   "service_account": {
     "label": "Service Account",
@@ -597,13 +417,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "circle",
     "category_uid": 3,
-    "class_uid": 3001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 3001
   },
   "service_principal": {
     "label": "Service Principal",
@@ -612,13 +426,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "identity",
     "icon": "circle",
     "category_uid": 3,
-    "class_uid": 3001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 3001
   },
   "source_file": {
     "label": "Source File",
@@ -627,12 +435,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "code",
     "icon": "square",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "reserved",
-    "emission_surfaces": [
-      "code_graph"
-    ],
-    "emission_notes": "Reserved for source-code topology; static supply-chain scans do not emit file-level nodes yet."
+    "class_uid": 4001
   },
   "tool": {
     "label": "Tool",
@@ -641,13 +444,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "tool",
     "icon": "diamond",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 4001
   },
   "tool_call": {
     "label": "Tool Call",
@@ -656,13 +453,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "runtime_evidence",
     "icon": "diamond",
     "category_uid": 5,
-    "class_uid": 4001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "runtime_proxy",
-      "gateway_event_projection"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 4001
   },
   "user": {
     "label": "User",
@@ -671,13 +462,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "user",
     "icon": "circle",
     "category_uid": 3,
-    "class_uid": 3001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 3001
   },
   "vulnerability": {
     "label": "Vulnerability",
@@ -686,13 +471,7 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "layer": "finding",
     "icon": "triangle",
     "category_uid": 2,
-    "class_uid": 2001,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "class_uid": 2001
   },
 };
 
@@ -760,9 +539,6 @@ export interface GraphEdgeKindMeta {
   source_types: readonly GraphNodeKindKey[];
   target_types: readonly GraphNodeKindKey[];
   traversable: boolean;
-  emission_status: "emitted" | "reserved";
-  emission_surfaces: readonly string[];
-  emission_notes: string;
 }
 
 export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> = {
@@ -782,14 +558,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "credential_ref",
       "resource"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "acted_as": {
     "label": "Acted As (runtime)",
@@ -805,12 +574,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "agent"
     ],
-    "traversable": true,
-    "emission_status": "reserved",
-    "emission_surfaces": [
-      "runtime_graph"
-    ],
-    "emission_notes": "Reserved for explicit user/service-principal runtime delegation once traces carry that identity link."
+    "traversable": true
   },
   "affects": {
     "label": "Affects",
@@ -826,14 +590,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "server",
       "container"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "assumes": {
     "label": "Assumes",
@@ -849,14 +606,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "role"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "attached": {
     "label": "Attached",
@@ -875,14 +625,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "policy",
       "access_grant"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "authenticates_as": {
     "label": "Authenticates As",
@@ -895,14 +638,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "managed_identity"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "called": {
     "label": "Called (runtime)",
@@ -917,13 +653,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "tool",
       "server"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "runtime_proxy",
-      "gateway_event_projection"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "can_access": {
     "label": "Can Access",
@@ -945,14 +675,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "credential",
       "resource"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "configures": {
     "label": "Configures",
@@ -968,12 +691,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "ci_job",
       "tool"
     ],
-    "traversable": true,
-    "emission_status": "reserved",
-    "emission_surfaces": [
-      "code_graph"
-    ],
-    "emission_notes": "Reserved for configuration topology linking config files to agents, servers, CI jobs, and tools."
+    "traversable": true
   },
   "contains": {
     "label": "Contains",
@@ -990,14 +708,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "server",
       "container"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "correlates_with": {
     "label": "Correlates With (cross-env)",
@@ -1012,14 +723,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "agent",
       "server"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "cross_account_trust": {
     "label": "Cross-Account Trust",
@@ -1038,14 +742,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "service_principal",
       "federated_identity"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "defines": {
     "label": "Defines",
@@ -1060,12 +757,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "tool",
       "ci_job"
     ],
-    "traversable": true,
-    "emission_status": "reserved",
-    "emission_surfaces": [
-      "code_graph"
-    ],
-    "emission_notes": "Reserved for source-code topology linking source files to modules, tools, and CI jobs."
+    "traversable": true
   },
   "delegated_to": {
     "label": "Delegated To (runtime)",
@@ -1078,14 +770,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "agent"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "depends_on": {
     "label": "Depends On",
@@ -1099,14 +784,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "package"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "exhibits_drift": {
     "label": "Exhibits Drift",
@@ -1119,14 +797,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "drift_incident"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "exploitable_via": {
     "label": "Exploitable Via",
@@ -1141,14 +812,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "tool",
       "credential"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "exposed_to": {
     "label": "Exposed To",
@@ -1166,14 +830,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "resource",
       "data_store"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "exposes_cred": {
     "label": "Exposes Credential",
@@ -1187,14 +844,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "credential"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "governs": {
     "label": "Governs",
@@ -1209,14 +859,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "managed_identity",
       "tool"
     ],
-    "traversable": false,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": false
   },
   "has_permission": {
     "label": "Has Permission",
@@ -1236,14 +879,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "resource",
       "tool"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "hosts": {
     "label": "Hosts",
@@ -1264,14 +900,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "server",
       "cloud_resource"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "imports": {
     "label": "Imports",
@@ -1287,12 +916,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "code_module",
       "package"
     ],
-    "traversable": true,
-    "emission_status": "reserved",
-    "emission_surfaces": [
-      "code_graph"
-    ],
-    "emission_notes": "Reserved for source-code topology linking files, modules, packages, and imports."
+    "traversable": true
   },
   "inherits": {
     "label": "Inherits",
@@ -1310,14 +934,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "policy",
       "role"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "invoked": {
     "label": "Invoked (runtime)",
@@ -1332,14 +949,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "tool",
       "tool_call"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "lateral_path": {
     "label": "Lateral Path",
@@ -1352,14 +962,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "agent"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "manages": {
     "label": "Manages",
@@ -1380,14 +983,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "environment",
       "cloud_resource"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "member_of": {
     "label": "Member Of",
@@ -1409,14 +1005,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "agent",
       "fleet"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "owns": {
     "label": "Owns",
@@ -1437,12 +1026,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "cloud_resource",
       "agent"
     ],
-    "traversable": true,
-    "emission_status": "reserved",
-    "emission_surfaces": [
-      "identity_graph"
-    ],
-    "emission_notes": "Reserved for ownership imports from enterprise identity and cloud inventory sources."
+    "traversable": true
   },
   "part_of": {
     "label": "Part Of",
@@ -1461,14 +1045,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "cluster",
       "environment"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "possibly_correlates_with": {
     "label": "Possibly Correlates With (low confidence)",
@@ -1483,14 +1060,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "agent",
       "server"
     ],
-    "traversable": false,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": false
   },
   "provides_tool": {
     "label": "Provides Tool",
@@ -1503,14 +1073,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "tool"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "reaches_tool": {
     "label": "Credential Reaches Tool",
@@ -1524,14 +1087,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "tool"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "remediates": {
     "label": "Remediates",
@@ -1545,12 +1101,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "vulnerability",
       "misconfiguration"
     ],
-    "traversable": false,
-    "emission_status": "reserved",
-    "emission_surfaces": [
-      "remediation_graph"
-    ],
-    "emission_notes": "Reserved for fixed-version and remediation-plan graph edges."
+    "traversable": false
   },
   "runs": {
     "label": "Runs",
@@ -1565,12 +1116,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "server",
       "agent"
     ],
-    "traversable": true,
-    "emission_status": "reserved",
-    "emission_surfaces": [
-      "ci_graph"
-    ],
-    "emission_notes": "Reserved for CI/CD topology linking workflow jobs to tools, servers, and agents."
+    "traversable": true
   },
   "scoped_to": {
     "label": "Scoped To",
@@ -1585,14 +1131,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "tool"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "serves_model": {
     "label": "Serves Model",
@@ -1605,14 +1144,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "model"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "shares_cred": {
     "label": "Shares Credential",
@@ -1625,14 +1157,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "agent"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "shares_server": {
     "label": "Shares Server",
@@ -1645,14 +1170,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "agent"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "stores": {
     "label": "Stores",
@@ -1668,14 +1186,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "dataset",
       "data_store"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "triggers": {
     "label": "Triggers",
@@ -1688,14 +1199,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "misconfiguration"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "trusts": {
     "label": "Trusts",
@@ -1715,14 +1219,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "service_principal",
       "federated_identity"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "used_credential": {
     "label": "Used Credential (runtime)",
@@ -1738,13 +1235,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "credential_ref",
       "credential"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "runtime_proxy",
-      "gateway_event_projection"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "uses": {
     "label": "Uses",
@@ -1757,14 +1248,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "server"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
   "vulnerable_to": {
     "label": "Vulnerable To",
@@ -1779,14 +1263,7 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "vulnerability"
     ],
-    "traversable": true,
-    "emission_status": "emitted",
-    "emission_surfaces": [
-      "static_scan",
-      "graph_overlay",
-      "computed_path"
-    ],
-    "emission_notes": "Emitted by at least one graph builder or runtime projection."
+    "traversable": true
   },
 };
 

--- a/ui/scripts/codegen-graph-schema.mjs
+++ b/ui/scripts/codegen-graph-schema.mjs
@@ -131,6 +131,11 @@ function render(schema) {
     )
     .join("\n");
 
+  // emission_status / emission_surfaces / emission_notes are intentionally
+  // excluded from the client bundle: they are documentation metadata served by
+  // GET /v1/graph/schema for tooling, but the dashboard renders only from
+  // label/color/shape/layer/icon/uids. Baking the emission docs into every
+  // browser bundle blew the client-JS budget for no runtime benefit.
   const nodeMetadataObj = nodeKinds
     .map(
       (n) =>
@@ -142,9 +147,6 @@ function render(schema) {
           icon: n.icon,
           category_uid: n.category_uid,
           class_uid: n.class_uid,
-          emission_status: n.emission_status,
-          emission_surfaces: n.emission_surfaces,
-          emission_notes: n.emission_notes,
         }).replace(/\n/g, "\n  ")},`,
     )
     .join("\n");
@@ -160,9 +162,6 @@ function render(schema) {
           source_types: e.source_types,
           target_types: e.target_types,
           traversable: e.traversable,
-          emission_status: e.emission_status,
-          emission_surfaces: e.emission_surfaces,
-          emission_notes: e.emission_notes,
         }).replace(/\n/g, "\n  ")},`,
     )
     .join("\n");
@@ -219,9 +218,6 @@ export interface GraphNodeKindMeta {
   icon: string;
   category_uid: number;
   class_uid: number;
-  emission_status: "emitted" | "reserved";
-  emission_surfaces: readonly string[];
-  emission_notes: string;
 }
 
 export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> = {
@@ -248,9 +244,6 @@ export interface GraphEdgeKindMeta {
   source_types: readonly GraphNodeKindKey[];
   target_types: readonly GraphNodeKindKey[];
   traversable: boolean;
-  emission_status: "emitted" | "reserved";
-  emission_surfaces: readonly string[];
-  emission_notes: string;
 }
 
 export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> = {

--- a/ui/scripts/codegen-graph-schema.mjs
+++ b/ui/scripts/codegen-graph-schema.mjs
@@ -142,6 +142,9 @@ function render(schema) {
           icon: n.icon,
           category_uid: n.category_uid,
           class_uid: n.class_uid,
+          emission_status: n.emission_status,
+          emission_surfaces: n.emission_surfaces,
+          emission_notes: n.emission_notes,
         }).replace(/\n/g, "\n  ")},`,
     )
     .join("\n");
@@ -157,6 +160,9 @@ function render(schema) {
           source_types: e.source_types,
           target_types: e.target_types,
           traversable: e.traversable,
+          emission_status: e.emission_status,
+          emission_surfaces: e.emission_surfaces,
+          emission_notes: e.emission_notes,
         }).replace(/\n/g, "\n  ")},`,
     )
     .join("\n");
@@ -213,6 +219,9 @@ export interface GraphNodeKindMeta {
   icon: string;
   category_uid: number;
   class_uid: number;
+  emission_status: "emitted" | "reserved";
+  emission_surfaces: readonly string[];
+  emission_notes: string;
 }
 
 export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> = {
@@ -239,6 +248,9 @@ export interface GraphEdgeKindMeta {
   source_types: readonly GraphNodeKindKey[];
   target_types: readonly GraphNodeKindKey[];
   traversable: boolean;
+  emission_status: "emitted" | "reserved";
+  emission_surfaces: readonly string[];
+  emission_notes: string;
 }
 
 export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> = {


### PR DESCRIPTION
Summary
- Adds emitted/reserved emission metadata to `/v1/graph/schema` for every node and relationship kind.
- Marks code/CI/remediation vocabulary as reserved instead of silently advertising it as scan output, while preserving runtime-emitted `tool_call`, `resource`, `called`, and `used_credential` metadata.
- Carries the metadata through generated TypeScript graph schema contracts.

Verification
- `uv run pytest tests/test_graph_schema.py::TestGraphSchemaEndpoint -q`
- `uv run pytest tests/test_proxy_helpers.py::test_log_tool_call_basic tests/test_proxy_helpers.py::test_log_tool_call_projects_actor_credential_and_resource_graph_refs -q`
- `cd ui && npm run codegen:graph-schema:check`
- `cd ui && npm test -- --run tests/graph-schema-color-invariant.test.ts`
- `uv run ruff check src/agent_bom/api/routes/graph.py tests/test_graph_schema.py`
- `uv run mypy src/agent_bom/api/routes/graph.py`
- `cd ui && npm run lint -- scripts/codegen-graph-schema.mjs lib/graph-schema.generated.ts`
- `git diff --check`

Closes #2940