### PR TITLE
feat(sdk): commit OpenAPI + codegen-parity clients for Go/Python/TS

### DIFF
--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -290,6 +290,91 @@ func (c *Client) RuntimeProductionIndex(ctx context.Context, tenantID string) (J
 	return c.request(ctx, http.MethodGet, "/v1/runtime/production-index", values, nil)
 }
 
+// IngestRuntimeEventsRequest persists metadata-only runtime observations.
+type IngestRuntimeEventsRequest struct {
+	Events   []JSON
+	TenantID string
+}
+
+// IngestRuntimeEvents persists metadata-only runtime observations for event and session analysis.
+func (c *Client) IngestRuntimeEvents(ctx context.Context, req IngestRuntimeEventsRequest) (JSON, error) {
+	return c.request(ctx, http.MethodPost, "/v1/runtime/events", nil, compact(JSON{
+		"events":    req.Events,
+		"tenant_id": firstNonEmpty(req.TenantID, c.tenantID),
+	}))
+}
+
+// RuntimeSessionQuery filters tenant-scoped runtime sessions.
+type RuntimeSessionQuery struct {
+	Limit    *int
+	Offset   *int
+	TenantID string
+}
+
+// RuntimeSessions lists tenant-scoped runtime sessions with event, verdict, and tool summaries.
+func (c *Client) RuntimeSessions(ctx context.Context, query RuntimeSessionQuery) (JSON, error) {
+	values := url.Values{}
+	if tenantID := firstNonEmpty(query.TenantID, c.tenantID); tenantID != "" {
+		values.Set("tenant_id", tenantID)
+	}
+	if query.Limit != nil {
+		values.Set("limit", fmt.Sprint(*query.Limit))
+	}
+	if query.Offset != nil {
+		values.Set("offset", fmt.Sprint(*query.Offset))
+	}
+	return c.request(ctx, http.MethodGet, "/v1/runtime/sessions", values, nil)
+}
+
+// RuntimeObservationQuery filters tenant-scoped runtime observations.
+type RuntimeObservationQuery struct {
+	SessionID string
+	Limit     *int
+	Offset    *int
+	TenantID  string
+}
+
+// RuntimeObservations lists tenant-scoped metadata-only runtime observations.
+func (c *Client) RuntimeObservations(ctx context.Context, query RuntimeObservationQuery) (JSON, error) {
+	values := url.Values{}
+	if tenantID := firstNonEmpty(query.TenantID, c.tenantID); tenantID != "" {
+		values.Set("tenant_id", tenantID)
+	}
+	if query.SessionID != "" {
+		values.Set("session_id", query.SessionID)
+	}
+	if query.Limit != nil {
+		values.Set("limit", fmt.Sprint(*query.Limit))
+	}
+	if query.Offset != nil {
+		values.Set("offset", fmt.Sprint(*query.Offset))
+	}
+	return c.request(ctx, http.MethodGet, "/v1/runtime/observations", values, nil)
+}
+
+// RuntimeSessionObservationQuery paginates observations for one runtime session.
+type RuntimeSessionObservationQuery struct {
+	Limit    *int
+	Offset   *int
+	TenantID string
+}
+
+// RuntimeSessionObservations lists observations for one runtime session.
+func (c *Client) RuntimeSessionObservations(ctx context.Context, sessionID string, query RuntimeSessionObservationQuery) (JSON, error) {
+	values := url.Values{}
+	if tenantID := firstNonEmpty(query.TenantID, c.tenantID); tenantID != "" {
+		values.Set("tenant_id", tenantID)
+	}
+	if query.Limit != nil {
+		values.Set("limit", fmt.Sprint(*query.Limit))
+	}
+	if query.Offset != nil {
+		values.Set("offset", fmt.Sprint(*query.Offset))
+	}
+	path := "/v1/runtime/sessions/" + url.PathEscape(sessionID) + "/observations"
+	return c.request(ctx, http.MethodGet, path, values, nil)
+}
+
 // IntelLookup looks up one advisory by CVE, GHSA, or OSV identifier.
 func (c *Client) IntelLookup(ctx context.Context, advisoryID string) (JSON, error) {
 	return c.request(ctx, http.MethodGet, "/v1/intel/advisories/"+url.PathEscape(advisoryID), nil, nil)

--- a/sdks/go/client_test.go
+++ b/sdks/go/client_test.go
@@ -203,3 +203,54 @@ func TestClientRaisesAPIErrorWithBody(t *testing.T) {
 		t.Fatalf("unexpected APIError: %#v", apiErr)
 	}
 }
+
+func TestClientRuntimeEventsAndSessions(t *testing.T) {
+	var seen []string
+	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Method+" "+r.URL.RequestURI())
+		if r.URL.Path == "/v1/runtime/events" {
+			var body JSON
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("Decode body: %v", err)
+			}
+			if body["tenant_id"] != "tenant-a" {
+				t.Fatalf("tenant_id = %#v", body["tenant_id"])
+			}
+			if _, ok := body["events"]; !ok {
+				t.Fatalf("events missing: %#v", body)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"schema_version":"runtime.v1"}`))
+	})
+
+	ctx := context.Background()
+	limit := 5
+	if _, err := client.IngestRuntimeEvents(ctx, IngestRuntimeEventsRequest{Events: []JSON{{"kind": "tool_call"}}}); err != nil {
+		t.Fatalf("IngestRuntimeEvents: %v", err)
+	}
+	if _, err := client.RuntimeSessions(ctx, RuntimeSessionQuery{Limit: &limit}); err != nil {
+		t.Fatalf("RuntimeSessions: %v", err)
+	}
+	if _, err := client.RuntimeObservations(ctx, RuntimeObservationQuery{SessionID: "sess-1", Limit: &limit}); err != nil {
+		t.Fatalf("RuntimeObservations: %v", err)
+	}
+	if _, err := client.RuntimeSessionObservations(ctx, "sess/1", RuntimeSessionObservationQuery{Limit: &limit}); err != nil {
+		t.Fatalf("RuntimeSessionObservations: %v", err)
+	}
+
+	want := []string{
+		"POST /v1/runtime/events",
+		"GET /v1/runtime/sessions?limit=5&tenant_id=tenant-a",
+		"GET /v1/runtime/observations?limit=5&session_id=sess-1&tenant_id=tenant-a",
+		"GET /v1/runtime/sessions/sess%2F1/observations?limit=5&tenant_id=tenant-a",
+	}
+	if len(seen) != len(want) {
+		t.Fatalf("seen = %#v", seen)
+	}
+	for i := range want {
+		if seen[i] != want[i] {
+			t.Fatalf("request %d = %q, want %q", i, seen[i], want[i])
+		}
+	}
+}

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -4,6 +4,24 @@ The Python SDK is the packaged `agent_bom.AgentBomClient` control-plane client.
 It talks to an existing agent-bom API deployment and keeps authentication and
 tenant scope explicit.
 
+The client ships inside the `agent-bom` wheel. Installing that wheel is enough:
+
+```python
+from agent_bom import AgentBomClient
+```
+
+The `agent-bom-sdk` package in this directory is a thin alias that re-exports
+the same class under `agent_bom_sdk`, mirroring the Go (`sdks/go`) and
+TypeScript (`@agent-bom/client`) packages for tooling that expects a dedicated
+SDK import path:
+
+```python
+from agent_bom_sdk import AgentBomClient
+```
+
+Both import paths resolve to `agent_bom.client.AgentBomClient`; there is no
+second implementation to drift.
+
 ```python
 from agent_bom import AgentBomClient
 

--- a/sdks/python/agent_bom_sdk/__init__.py
+++ b/sdks/python/agent_bom_sdk/__init__.py
@@ -1,0 +1,14 @@
+"""Thin Python SDK alias for the packaged agent-bom control-plane client.
+
+The control-plane client ships in the ``agent-bom`` wheel as
+``agent_bom.client.AgentBomClient``. This package re-exports it under the
+``agent_bom_sdk`` name so language-agnostic SDK tooling can depend on a stable
+import path that mirrors the Go (``sdks/go``) and TypeScript
+(``@agent-bom/client``) packages. It adds no behaviour of its own.
+"""
+
+from __future__ import annotations
+
+from agent_bom.client import AgentBomApiError, AgentBomClient
+
+__all__ = ["AgentBomApiError", "AgentBomClient"]

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "agent-bom-sdk"
+version = "0.88.6"
+description = "Thin Python alias that re-exports the packaged agent-bom control-plane client."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "Apache-2.0" }
+dependencies = ["agent-bom"]
+
+[project.urls]
+Homepage = "https://github.com/msaad00/agent-bom"
+Source = "https://github.com/msaad00/agent-bom/tree/main/sdks/python"
+
+[tool.hatch.build.targets.wheel]
+packages = ["agent_bom_sdk"]

--- a/sdks/typescript-client/src/index.ts
+++ b/sdks/typescript-client/src/index.ts
@@ -178,6 +178,26 @@ export interface EvaluationRunsQuery {
   offset?: number;
 }
 
+export interface IngestRuntimeEventsRequest {
+  events: Record<string, JsonValue>[];
+}
+
+export interface RuntimeSessionsQuery {
+  limit?: number;
+  offset?: number;
+}
+
+export interface RuntimeObservationsQuery {
+  sessionId?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface RuntimeSessionObservationsQuery {
+  limit?: number;
+  offset?: number;
+}
+
 export interface IntelMatchRequest {
   packages?: Record<string, JsonValue>[];
   purl?: string;
@@ -384,6 +404,80 @@ export class AgentBomClient {
     return this.request<Record<string, JsonValue>>(
       "GET",
       `/v1/runtime/production-index${formatSearch(search)}`,
+    );
+  }
+
+  ingestRuntimeEvents(
+    request: IngestRuntimeEventsRequest,
+  ): Promise<Record<string, JsonValue>> {
+    return this.request<Record<string, JsonValue>>(
+      "POST",
+      "/v1/runtime/events",
+      {
+        events: request.events,
+        tenant_id: this.tenantId,
+      },
+    );
+  }
+
+  runtimeSessions(
+    query: RuntimeSessionsQuery = {},
+  ): Promise<Record<string, JsonValue>> {
+    const search = new URLSearchParams();
+    if (this.tenantId) {
+      search.set("tenant_id", this.tenantId);
+    }
+    if (query.limit !== undefined) {
+      search.set("limit", String(query.limit));
+    }
+    if (query.offset !== undefined) {
+      search.set("offset", String(query.offset));
+    }
+    return this.request<Record<string, JsonValue>>(
+      "GET",
+      `/v1/runtime/sessions${formatSearch(search)}`,
+    );
+  }
+
+  runtimeObservations(
+    query: RuntimeObservationsQuery = {},
+  ): Promise<Record<string, JsonValue>> {
+    const search = new URLSearchParams();
+    if (this.tenantId) {
+      search.set("tenant_id", this.tenantId);
+    }
+    if (query.sessionId) {
+      search.set("session_id", query.sessionId);
+    }
+    if (query.limit !== undefined) {
+      search.set("limit", String(query.limit));
+    }
+    if (query.offset !== undefined) {
+      search.set("offset", String(query.offset));
+    }
+    return this.request<Record<string, JsonValue>>(
+      "GET",
+      `/v1/runtime/observations${formatSearch(search)}`,
+    );
+  }
+
+  runtimeSessionObservations(
+    sessionId: string,
+    query: RuntimeSessionObservationsQuery = {},
+  ): Promise<Record<string, JsonValue>> {
+    const search = new URLSearchParams();
+    if (this.tenantId) {
+      search.set("tenant_id", this.tenantId);
+    }
+    if (query.limit !== undefined) {
+      search.set("limit", String(query.limit));
+    }
+    if (query.offset !== undefined) {
+      search.set("offset", String(query.offset));
+    }
+    return this.request<Record<string, JsonValue>>(
+      "GET",
+      `/v1/runtime/sessions/${encodeURIComponent(sessionId)}/observations${formatSearch(search)}`,
     );
   }
 

--- a/sdks/typescript-client/tests/client.test.js
+++ b/sdks/typescript-client/tests/client.test.js
@@ -288,6 +288,42 @@ test("reads manifest and runtime index with tenant query", async () => {
   ]);
 });
 
+test("ingests events and reads runtime sessions and observations", async () => {
+  const seen = [];
+  const client = new AgentBomClient({
+    baseUrl: "https://agent-bom.example.com",
+    tenantId: "tenant-r",
+    fetch: async (url, init = {}) => {
+      seen.push({ url: String(url), body: init.body ? JSON.parse(init.body) : undefined });
+      return jsonResponse({ schema_version: "runtime.v1" });
+    },
+  });
+
+  await client.ingestRuntimeEvents({ events: [{ kind: "tool_call" }] });
+  await client.runtimeSessions({ limit: 10, offset: 0 });
+  await client.runtimeObservations({ sessionId: "sess-1", limit: 5 });
+  await client.runtimeSessionObservations("sess/1", { limit: 5 });
+
+  assert.deepEqual(seen, [
+    {
+      url: "https://agent-bom.example.com/v1/runtime/events",
+      body: { events: [{ kind: "tool_call" }], tenant_id: "tenant-r" },
+    },
+    {
+      url: "https://agent-bom.example.com/v1/runtime/sessions?tenant_id=tenant-r&limit=10&offset=0",
+      body: undefined,
+    },
+    {
+      url: "https://agent-bom.example.com/v1/runtime/observations?tenant_id=tenant-r&session_id=sess-1&limit=5",
+      body: undefined,
+    },
+    {
+      url: "https://agent-bom.example.com/v1/runtime/sessions/sess%2F1/observations?tenant_id=tenant-r&limit=5",
+      body: undefined,
+    },
+  ]);
+});
+
 test("wraps intel lookup match and sources", async () => {
   const seen = [];
   const client = new AgentBomClient({


### PR DESCRIPTION
## Summary

Brings the published SDKs to a uniform 20-method surface against the committed OpenAPI contract, closing the runtime-endpoint parity gap and giving Python a dedicated installable import path.

### OpenAPI contract (already in place)
The static control-plane contract is committed at `docs/openapi/v1.json` (+ `v1.yaml`), generated by `scripts/export_openapi.py` from `agent_bom.api.server.app`. A drift guard (`scripts/export_openapi.py --check`, exercised by `tests/test_openapi_artifact.py`) fails CI when the committed spec diverges from the app. `info.version` matches the package version (`0.88.6`). These were already present and remain green; no change was needed.

### SDK method parity
The Go (`sdks/go`) and TypeScript (`@agent-bom/client`) clients were each missing four runtime endpoints that the packaged Python client (`agent_bom.client.AgentBomClient`) already exposed. Added in both, matching existing signature/tenant-scope/query-shaping style:

| Endpoint | Go | TypeScript |
| --- | --- | --- |
| `POST /v1/runtime/events` | `IngestRuntimeEvents` | `ingestRuntimeEvents` |
| `GET /v1/runtime/sessions` | `RuntimeSessions` | `runtimeSessions` |
| `GET /v1/runtime/observations` | `RuntimeObservations` | `runtimeObservations` |
| `GET /v1/runtime/sessions/{id}/observations` | `RuntimeSessionObservations` | `runtimeSessionObservations` |

Unit tests assert request method, path, query params, and body for the new methods in each SDK.

### Python SDK package
Replaced the README-only stub with a thin installable alias package (`agent-bom-sdk`). Its `agent_bom_sdk` module re-exports `AgentBomClient`/`AgentBomApiError` from the wheel, mirroring the Go and TS packages so a dedicated SDK import path exists without a second implementation that can drift. README documents both `from agent_bom import AgentBomClient` and `from agent_bom_sdk import AgentBomClient`.

## Validation
- Go: `gofmt -l` clean, `go vet ./...`, `go build ./...`, `go test ./...` -> ok
- TypeScript: `npm run build` (tsc) clean; `npm test` -> 13/13 pass
- Python: `from agent_bom_sdk import AgentBomClient` resolves to `agent_bom.client`; `ruff check` + `ruff format --check` + `mypy` clean
- Contract: `pytest tests/test_openapi_artifact.py` -> 2 passed
- Pre-commit hooks all passed on commit

## Deferred
- Wiring `sdks/go` and `sdks/typescript-client` build/test into `.github/workflows/ci.yml` (CI currently builds only `sdks/typescript` runtime lib and `sdks/shared`). Out of scope for this foundation PR; tracked for a follow-up.

Closes #2919. Part of #2930.