### PR TITLE
fix(api): sanitize SCIM misconfiguration message in posture surface

### DIFF
--- a/src/agent_bom/api/scim.py
+++ b/src/agent_bom/api/scim.py
@@ -11,6 +11,7 @@ from json import JSONDecodeError
 from typing import Any
 
 from agent_bom.platform_invariants import ReservedTenantIdError, validate_customer_tenant_id
+from agent_bom.security import sanitize_error
 
 _SCIM_ROLE_VALUES = ("admin", "analyst", "viewer")
 _SCIM_ROLE_ALIASES = {
@@ -171,7 +172,7 @@ def _scim_token_binding_posture() -> dict[str, object]:
             "tenant_id": None,
             "tenant_ids": [],
             "tenant_id_source": None,
-            "message": str(exc),
+            "message": sanitize_error(exc),
         }
 
     sources = {binding.source for binding in bindings}


### PR DESCRIPTION
## Summary
The SCIM token-binding posture embedded the raw `SCIMConfigurationError` text via `str(exc)` into operator-facing responses (`/v1/auth/posture` and `/v1/auth/scim/config`), which static analysis flags as stack-trace exposure (`py/stack-trace-exposure`).

This routes the message through the existing `sanitize_error()` helper — the same barrier already used for `HTTPException` details elsewhere in the enterprise routes. Actionable misconfiguration text is preserved; paths/URLs/credentials are stripped.

## Verification
- Sanitized output confirmed (no traceback / exception-class leak); message preserved.
- ruff, ruff-format, mypy, bandit pre-commit hooks pass.

Resolves the two open `py/stack-trace-exposure` code-scanning alerts in `src/agent_bom/api/routes/enterprise.py`.