### PR TITLE
feat(model): preserve suppression, AI-context, and reach lists on unified Finding

### DIFF
--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -257,6 +257,25 @@ class Finding:
     # Risk
     risk_score: float = 0.0  # 0-10 unified risk score
 
+    # Suppression state (mirrors BlastRadius; preserved through the unified stream
+    # so a suppressed finding never appears unsuppressed downstream)
+    suppressed: bool = False
+    suppression_id: Optional[str] = None
+    suppression_state: Optional[str] = None
+    suppression_reason: Optional[str] = None
+    unsuppressed_risk_score: Optional[float] = None
+
+    # AI-native risk context (mirrors BlastRadius)
+    ai_risk_context: Optional[str] = None
+    ai_summary: Optional[str] = None
+    attack_vector_summary: Optional[str] = None
+
+    # Reach / blast-radius lists — kept structured rather than collapsed to counts
+    affected_servers: list[str] = field(default_factory=list)  # MCP server names on the impacted path
+    affected_agents: list[str] = field(default_factory=list)  # agent names reachable along the path
+    exposed_credentials: list[str] = field(default_factory=list)  # credential env-var names at risk
+    exposed_tools: list[str] = field(default_factory=list)  # tool names accessible through the path
+
     # Unique ID — deterministic UUID v5 based on content (computed in __post_init__)
     # Pass an explicit id= to override (e.g. when ingesting from external scanner)
     id: str = field(default="")
@@ -646,5 +665,17 @@ def blast_radius_to_finding(br: object) -> "Finding":
         pci_dss_tags=list(getattr(br, "pci_dss_tags", [])),
         evidence=evidence,
         risk_score=br.risk_score,
+        suppressed=bool(getattr(br, "suppressed", False)),
+        suppression_id=getattr(br, "suppression_id", None),
+        suppression_state=getattr(br, "suppression_state", None),
+        suppression_reason=getattr(br, "suppression_reason", None),
+        unsuppressed_risk_score=getattr(br, "unsuppressed_risk_score", None),
+        ai_risk_context=getattr(br, "ai_risk_context", None),
+        ai_summary=getattr(br, "ai_summary", None),
+        attack_vector_summary=getattr(br, "attack_vector_summary", None),
+        affected_servers=[s.name for s in br.affected_servers],
+        affected_agents=[getattr(a, "name", str(a)) for a in br.affected_agents],
+        exposed_credentials=list(br.exposed_credentials),
+        exposed_tools=[getattr(t, "name", str(t)) for t in br.exposed_tools],
     )
     return apply_hub_classification(finding)

--- a/tests/test_finding.py
+++ b/tests/test_finding.py
@@ -406,6 +406,41 @@ def test_blast_radius_to_finding_kev():
     assert finding.is_kev is True
 
 
+def test_blast_radius_to_finding_preserves_suppression_ai_context_and_reach():
+    """The shim must not drop suppression, AI-context, or reach lists.
+
+    Regression guard: a suppressed BlastRadius previously surfaced as an
+    unsuppressed Finding, and multi-server / credential reach collapsed to
+    bare counts in evidence. These are now first-class on Finding.
+    """
+    br = _make_blast_radius(
+        servers=[_make_server("server-a"), _make_server("server-b")],
+        credentials=["OPENAI_API_KEY", "AWS_SECRET_ACCESS_KEY"],
+    )
+    br.suppressed = True
+    br.suppression_id = "sup-123"
+    br.suppression_state = "acknowledged"
+    br.suppression_reason = "risk accepted by owner"
+    br.unsuppressed_risk_score = 9.1
+    br.ai_risk_context = "Reachable from an internet-exposed agent"
+    br.ai_summary = "LLM-generated narrative"
+    br.attack_vector_summary = "agent -> server -> vulnerable package"
+
+    finding = blast_radius_to_finding(br)
+
+    assert finding.suppressed is True
+    assert finding.suppression_id == "sup-123"
+    assert finding.suppression_state == "acknowledged"
+    assert finding.suppression_reason == "risk accepted by owner"
+    assert finding.unsuppressed_risk_score == 9.1
+    assert finding.ai_risk_context == "Reachable from an internet-exposed agent"
+    assert finding.ai_summary == "LLM-generated narrative"
+    assert finding.attack_vector_summary == "agent -> server -> vulnerable package"
+    # Reach preserved structurally, not collapsed to counts.
+    assert finding.affected_servers == ["server-a", "server-b"]
+    assert finding.exposed_credentials == ["OPENAI_API_KEY", "AWS_SECRET_ACCESS_KEY"]
+
+
 def test_blast_radius_to_finding_evidence_has_package_info():
     br = _make_blast_radius()
     finding = blast_radius_to_finding(br)


### PR DESCRIPTION
## Summary
Foundation for converging output formatters on the unified `Finding` model (#2918). The `blast_radius_to_finding` shim dropped fields that `BlastRadius` carries — most importantly **suppression state** (a suppressed finding surfaced as *unsuppressed* in the Finding/OCSF stream), plus AI-native context and the structured reach lists (affected servers/agents/credentials/tools collapsed to bare counts).

This makes them first-class optional fields on `Finding` and populates them in the shim.

## Scope
Purely **additive** — `BlastRadius` remains the primary output format and no formatter is repointed yet (next stage). This unblocks the lossless-stream prerequisite before demoting BlastRadius.

## Verification
- 36 tests pass incl. a new regression guard (`test_blast_radius_to_finding_preserves_suppression_ai_context_and_reach`).
- ruff, ruff-format, mypy, bandit clean.

Part of #2918.