### PR TITLE
feat(identity): discover Okta non-human identities into the graph

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -150,6 +150,9 @@ AGENT_BOM_OIDC_REQUIRE_TENANT_CLAIM
 AGENT_BOM_OIDC_ROLE_CLAIM
 AGENT_BOM_OIDC_TENANT_CLAIM
 AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON
+AGENT_BOM_OKTA_DISCOVERY  # opt-in flag (default OFF) gating read-only Okta non-human-identity discovery; read in identity/okta_nhi.py
+AGENT_BOM_OKTA_TOKEN  # SSWS/bearer token for read-only Okta NHI discovery (tokens-only, no passwords); never stored, read in identity/okta_nhi.py
+AGENT_BOM_OKTA_ORG_URL  # Okta org base URL for read-only NHI discovery; read in identity/okta_nhi.py
 # Local metadata-only entitlement file for self-hosted packaging.
 AGENT_BOM_ENTITLEMENT_FILE
 AGENT_BOM_OTEL_TRACES_ENDPOINT

--- a/src/agent_bom/graph/nhi_overlay.py
+++ b/src/agent_bom/graph/nhi_overlay.py
@@ -1,0 +1,120 @@
+"""Project discovered non-human identities (NHIs) into the unified graph.
+
+The ``agent_bom.identity`` connectors enumerate *existing* machine identities
+(IdP service accounts, API tokens) that agent-bom did not issue. This overlay
+emits each one as a ``managed_identity`` node — the same entity type used by the
+governance overlay for agent-bom-issued identities — so the
+effective-permissions engine and governance traversal treat discovered and
+issued identities uniformly:
+
+    agent → managed_identity → tool → vulnerable package
+
+Discovered NHIs carry a ``discovered`` marker and the source provider so they
+are distinguishable from issued identities. Nodes are keyed on the provider +
+identity id; re-running discovery is idempotent. Matching to existing tool nodes
+is by label; an unmatched scope is still recorded on the node attributes so it
+stays visible without an edge.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from typing import Any
+
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, NodeStatus, RelationshipType
+from agent_bom.identity.okta_nhi import DiscoveredNonHumanIdentity
+
+_OVERLAY_SOURCE = "nhi-discovery"
+
+
+def _tool_label_index(graph: UnifiedGraph) -> dict[str, list[str]]:
+    index: dict[str, list[str]] = defaultdict(list)
+    for node in graph.nodes.values():
+        if node.entity_type == EntityType.TOOL:
+            index[node.label.strip().lower()].append(node.id)
+    return index
+
+
+def apply_nhi_overlay(
+    graph: UnifiedGraph,
+    identities: Iterable[DiscoveredNonHumanIdentity],
+) -> dict[str, int]:
+    """Add discovered NHIs as ``managed_identity`` nodes (+ tool scope) in place.
+
+    Returns a count of added nodes and edges. Idempotent: an identity whose node
+    already exists is skipped. Never raises — a malformed identity is ignored.
+    """
+    tools_by_label = _tool_label_index(graph)
+    added_nodes = 0
+    added_edges = 0
+
+    for identity in identities:
+        try:
+            nid = f"managed_identity:{identity.provider}:{identity.identity_id}"
+            if nid in graph.nodes:
+                continue
+            graph.add_node(
+                UnifiedNode(
+                    id=nid,
+                    entity_type=EntityType.MANAGED_IDENTITY,
+                    label=identity.name or identity.identity_id,
+                    data_sources=[_OVERLAY_SOURCE],
+                    status=NodeStatus.ACTIVE if identity.status == "active" else NodeStatus.INACTIVE,
+                    # Context node: "info" so it survives default graph filters
+                    # (severity_id 0 is dropped) without outranking real findings.
+                    severity="info",
+                    attributes={
+                        "discovered": True,
+                        "provider": identity.provider,
+                        "identity_id": identity.identity_id,
+                        "identity_type": identity.identity_type,
+                        "status": identity.status,
+                        "owner": identity.owner,
+                        "created_at": identity.created_at,
+                        "last_used_at": identity.last_used_at,
+                        "credential_expires_at": identity.credential_expires_at,
+                        "scopes": list(identity.scopes),
+                    },
+                )
+            )
+            added_nodes += 1
+
+            for scope in identity.scopes:
+                scope_name = scope.strip().lower()
+                if not scope_name or scope_name == "*":
+                    continue
+                for tool_id in tools_by_label.get(scope_name, []):
+                    graph.add_edge(
+                        UnifiedEdge(
+                            source=nid,
+                            target=tool_id,
+                            relationship=RelationshipType.SCOPED_TO,
+                            weight=3.0,
+                            provenance={"source": _OVERLAY_SOURCE},
+                            evidence={"kind": "discovered_nhi_scope", "provider": identity.provider},
+                        )
+                    )
+                    added_edges += 1
+        except Exception:  # noqa: BLE001 — never raise into the builder
+            continue
+
+    return {"nodes_added": added_nodes, "edges_added": added_edges}
+
+
+def apply_nhi_overlay_from_result(graph: UnifiedGraph, result: Any) -> dict[str, int]:
+    """Convenience wrapper: project the identities from an ``NHIDiscoveryResult``.
+
+    Only the ``OK`` status contributes nodes; any other status (disabled,
+    missing creds, error) is a no-op so the builder can call this unconditionally.
+    """
+    identities = getattr(result, "identities", None) or ()
+    if getattr(result, "status", None) is not None and not getattr(result, "ok", False):
+        return {"nodes_added": 0, "edges_added": 0}
+    return apply_nhi_overlay(graph, identities)
+
+
+__all__ = ["apply_nhi_overlay", "apply_nhi_overlay_from_result"]

--- a/src/agent_bom/identity/__init__.py
+++ b/src/agent_bom/identity/__init__.py
@@ -1,0 +1,27 @@
+"""Non-human-identity (NHI) discovery connectors.
+
+These connectors enumerate *existing* non-human identities (service accounts,
+machine principals, API tokens) from an identity provider so they can be
+projected into the unified graph as ``managed_identity`` nodes and consumed by
+the governance / effective-permissions overlays.
+
+Discovery is read-only, reference-only, and token-authenticated. No passwords
+are ever read, no write APIs are ever called, and a missing SDK / credential
+degrades to a clear status rather than raising.
+"""
+
+from __future__ import annotations
+
+from agent_bom.identity.okta_nhi import (
+    DiscoveredNonHumanIdentity,
+    NHIDiscoveryResult,
+    NHIDiscoveryStatus,
+    discover_okta_non_human_identities,
+)
+
+__all__ = [
+    "DiscoveredNonHumanIdentity",
+    "NHIDiscoveryResult",
+    "NHIDiscoveryStatus",
+    "discover_okta_non_human_identities",
+]

--- a/src/agent_bom/identity/okta_nhi.py
+++ b/src/agent_bom/identity/okta_nhi.py
@@ -1,0 +1,361 @@
+"""Okta non-human-identity (NHI) discovery.
+
+Enumerates the *machine* identities in an Okta org — OAuth2 service apps
+(client-credentials service accounts) and API tokens — and returns them as
+normalized :class:`DiscoveredNonHumanIdentity` records. The
+``agent_bom.graph.nhi_overlay`` projects those records into the unified graph as
+``managed_identity`` nodes so the governance / effective-permissions overlays
+can reason about them alongside agent-bom-issued identities.
+
+Trust posture (mirrors the cloud read-only providers):
+
+* **Read-only / reference-only.** Only ``GET`` list endpoints are called; no
+  Okta write API is ever invoked and no secret material (token values, client
+  secrets) is read — only references and metadata.
+* **Token-authenticated.** A bearer/SSWS token is read from the
+  ``AGENT_BOM_OKTA_TOKEN`` environment variable (no passwords, per the
+  tokens-only policy). The org base URL comes from ``AGENT_BOM_OKTA_ORG_URL``.
+* **Gated, default OFF.** Discovery only runs when
+  ``AGENT_BOM_OKTA_DISCOVERY`` is set to a truthy value. Otherwise it returns a
+  ``DISABLED`` status without touching the network.
+* **Never raises.** A missing client, missing credentials, or an API error
+  degrades to a populated :class:`NHIDiscoveryResult` carrying a clear status
+  and a user-safe warning — discovery callers never have to wrap this in a
+  ``try``/``except``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_DISCOVERY_FLAG_ENV = "AGENT_BOM_OKTA_DISCOVERY"
+_TOKEN_ENV = "AGENT_BOM_OKTA_TOKEN"
+_ORG_URL_ENV = "AGENT_BOM_OKTA_ORG_URL"
+
+# Read-only Okta API scopes / endpoints this connector exercises. Kept here so
+# the per-run trust contract stays honest — the producer owns the catalog.
+OKTA_READ_PERMISSIONS: tuple[str, ...] = (
+    "okta.apps.read",
+    "okta.apiTokens.read",
+)
+
+# Okta OAuth2 app "signOnMode" / type values that denote a non-human
+# (machine-to-machine, client-credentials) principal rather than a human SSO app.
+_SERVICE_SIGN_ON_MODES = frozenset({"OPENID_CONNECT"})
+_SERVICE_GRANT_TYPES = frozenset({"client_credentials"})
+
+_MAX_RESULTS = 2000
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+class NHIDiscoveryStatus(str, Enum):
+    """Outcome of an NHI discovery run (locked vocabulary)."""
+
+    OK = "ok"
+    """Discovery ran and returned a (possibly empty) identity list."""
+
+    DISABLED = "disabled"
+    """The discovery feature flag was not enabled — nothing was attempted."""
+
+    MISSING_CREDENTIALS = "missing_credentials"
+    """The flag was on but no token / org URL was configured."""
+
+    MISSING_CLIENT = "missing_client"
+    """The Okta SDK / HTTP client could not be constructed."""
+
+    ERROR = "error"
+    """The flag and credentials were present but the API calls failed."""
+
+
+@dataclass(frozen=True)
+class DiscoveredNonHumanIdentity:
+    """A normalized non-human identity discovered from an IdP.
+
+    All fields are simple types so the record round-trips through the graph
+    overlay, JSON, and the API surface. Credential *values* are never captured —
+    only references and age/usage metadata.
+    """
+
+    identity_id: str
+    """Stable provider identifier (Okta app id or api-token id)."""
+
+    name: str
+    """Human-readable label (app label / token name)."""
+
+    identity_type: str
+    """``service_account`` (OAuth2 service app) or ``api_token``."""
+
+    provider: str = "okta"
+    status: str = "active"
+    owner: str | None = None
+    """Owning user / principal where the API reports one."""
+
+    created_at: str | None = None
+    last_used_at: str | None = None
+    credential_expires_at: str | None = None
+    scopes: tuple[str, ...] = ()
+    """Granted OAuth2 scopes / token privileges (references, not secrets)."""
+
+    raw_identity: dict[str, Any] = field(default_factory=dict)
+    """Low-risk provider fields kept for audit (ids, timestamps — no secrets)."""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "identity_id": self.identity_id,
+            "name": self.name,
+            "identity_type": self.identity_type,
+            "provider": self.provider,
+            "status": self.status,
+            "owner": self.owner,
+            "created_at": self.created_at,
+            "last_used_at": self.last_used_at,
+            "credential_expires_at": self.credential_expires_at,
+            "scopes": list(self.scopes),
+            "raw_identity": dict(self.raw_identity),
+        }
+
+
+@dataclass(frozen=True)
+class NHIDiscoveryResult:
+    """Result envelope for one NHI discovery run. Never raises into callers."""
+
+    status: NHIDiscoveryStatus
+    identities: tuple[DiscoveredNonHumanIdentity, ...] = ()
+    warnings: tuple[str, ...] = ()
+    org_url: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status is NHIDiscoveryStatus.OK
+
+
+class OktaClient:
+    """Minimal read-only Okta REST client (no third-party SDK required).
+
+    Issues only ``GET`` list calls with an ``SSWS`` token. Tests inject a fake
+    client exposing the same ``list_oauth2_service_apps`` / ``list_api_tokens``
+    methods, so no live call is ever made under test.
+    """
+
+    def __init__(self, org_url: str, token: str) -> None:
+        self._org_url = org_url.rstrip("/")
+        self._token = token
+
+    def _get(self, path: str) -> list[dict[str, Any]]:
+        from agent_bom.http_client import fetch_json
+
+        url = f"{self._org_url}{path}"
+        payload = fetch_json(
+            url,
+            headers={
+                "Authorization": f"SSWS {self._token}",
+                "Accept": "application/json",
+            },
+            timeout=30,
+        )
+        if isinstance(payload, list):
+            return [item for item in payload if isinstance(item, dict)]
+        return []
+
+    def list_oauth2_service_apps(self) -> list[dict[str, Any]]:
+        """List OAuth2 / OIDC service applications (client-credentials NHIs)."""
+        return self._get("/api/v1/apps?filter=status+eq+%22ACTIVE%22&limit=200")
+
+    def list_api_tokens(self) -> list[dict[str, Any]]:
+        """List org API tokens (machine credentials)."""
+        return self._get("/api/v1/api-tokens?limit=200")
+
+
+def _is_truthy(value: str | None) -> bool:
+    return value is not None and value.strip().lower() in _TRUTHY
+
+
+def _is_service_app(app: dict[str, Any]) -> bool:
+    """A non-human OAuth2 app: OIDC service sign-on with client-credentials grant."""
+    sign_on = str(app.get("signOnMode") or "").upper()
+    if sign_on not in _SERVICE_SIGN_ON_MODES:
+        return False
+    settings = app.get("settings")
+    oauth = settings.get("oauthClient", {}) if isinstance(settings, dict) else {}
+    app_type = str(oauth.get("application_type") or "").lower()
+    grants = {str(g).lower() for g in (oauth.get("grant_types") or [])}
+    return app_type == "service" or bool(grants & _SERVICE_GRANT_TYPES)
+
+
+def _oauth_scopes(app: dict[str, Any]) -> tuple[str, ...]:
+    settings = app.get("settings")
+    oauth = settings.get("oauthClient", {}) if isinstance(settings, dict) else {}
+    grants = oauth.get("grant_types") or []
+    return tuple(str(g) for g in grants if str(g).strip())
+
+
+def _normalize_service_app(app: dict[str, Any]) -> DiscoveredNonHumanIdentity | None:
+    app_id = str(app.get("id") or "").strip()
+    if not app_id:
+        return None
+    settings = app.get("settings")
+    oauth = settings.get("oauthClient", {}) if isinstance(settings, dict) else {}
+    client_id = str(oauth.get("client_id") or "")
+    return DiscoveredNonHumanIdentity(
+        identity_id=app_id,
+        name=str(app.get("label") or app.get("name") or app_id),
+        identity_type="service_account",
+        status=str(app.get("status") or "active").lower(),
+        created_at=_opt_str(app.get("created")),
+        last_used_at=_opt_str(app.get("lastUpdated")),
+        scopes=_oauth_scopes(app),
+        raw_identity={
+            "id": app_id,
+            "name": str(app.get("name") or ""),
+            "sign_on_mode": str(app.get("signOnMode") or ""),
+            "client_id": client_id,
+        },
+    )
+
+
+def _normalize_api_token(token: dict[str, Any]) -> DiscoveredNonHumanIdentity | None:
+    token_id = str(token.get("id") or "").strip()
+    if not token_id:
+        return None
+    return DiscoveredNonHumanIdentity(
+        identity_id=token_id,
+        name=str(token.get("name") or token_id),
+        identity_type="api_token",
+        status=str(token.get("status") or "active").lower(),
+        owner=_opt_str(token.get("userId")),
+        created_at=_opt_str(token.get("created")),
+        last_used_at=_opt_str(token.get("lastUpdated")),
+        credential_expires_at=_opt_str(token.get("expiresAt")),
+        raw_identity={
+            "id": token_id,
+            "user_id": str(token.get("userId") or ""),
+        },
+    )
+
+
+def _opt_str(value: Any) -> str | None:
+    text = str(value).strip() if value is not None else ""
+    return text or None
+
+
+def _iter_normalized(
+    raw_apps: Iterable[dict[str, Any]],
+    raw_tokens: Iterable[dict[str, Any]],
+) -> Iterator[DiscoveredNonHumanIdentity]:
+    for app in raw_apps:
+        if not isinstance(app, dict) or not _is_service_app(app):
+            continue
+        identity = _normalize_service_app(app)
+        if identity is not None:
+            yield identity
+    for token in raw_tokens:
+        if not isinstance(token, dict):
+            continue
+        identity = _normalize_api_token(token)
+        if identity is not None:
+            yield identity
+
+
+def discover_okta_non_human_identities(
+    *,
+    client: Any = None,
+    org_url: str | None = None,
+    token: str | None = None,
+    force: bool = False,
+) -> NHIDiscoveryResult:
+    """Discover non-human identities (service accounts + API tokens) from Okta.
+
+    Read-only and gated: unless ``force`` is set (used by tests / explicit
+    callers that already supply a ``client``), discovery only runs when the
+    ``AGENT_BOM_OKTA_DISCOVERY`` flag is truthy. Returns a result envelope and
+    never raises.
+
+    Args:
+        client: An injected Okta client exposing ``list_oauth2_service_apps()``
+            and ``list_api_tokens()``. When ``None`` a read-only
+            :class:`OktaClient` is built from the token + org URL.
+        org_url: Okta org base URL; falls back to ``AGENT_BOM_OKTA_ORG_URL``.
+        token: SSWS/bearer token; falls back to ``AGENT_BOM_OKTA_TOKEN``.
+        force: Bypass the feature-flag gate (when a client is injected directly).
+    """
+    flag_on = force or client is not None or _is_truthy(os.environ.get(_DISCOVERY_FLAG_ENV))
+    if not flag_on:
+        return NHIDiscoveryResult(
+            status=NHIDiscoveryStatus.DISABLED,
+            warnings=(f"Okta NHI discovery is disabled. Set {_DISCOVERY_FLAG_ENV}=1 to enable.",),
+        )
+
+    resolved_org = (org_url or os.environ.get(_ORG_URL_ENV) or "").strip()
+
+    if client is None:
+        resolved_token = (token or os.environ.get(_TOKEN_ENV) or "").strip()
+        if not resolved_token or not resolved_org:
+            missing = []
+            if not resolved_token:
+                missing.append(_TOKEN_ENV)
+            if not resolved_org:
+                missing.append(_ORG_URL_ENV)
+            return NHIDiscoveryResult(
+                status=NHIDiscoveryStatus.MISSING_CREDENTIALS,
+                org_url=resolved_org or None,
+                warnings=(f"Okta NHI discovery enabled but missing: {', '.join(missing)}.",),
+            )
+        try:
+            client = OktaClient(resolved_org, resolved_token)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Could not construct Okta client: %s", exc)
+            return NHIDiscoveryResult(
+                status=NHIDiscoveryStatus.MISSING_CLIENT,
+                org_url=resolved_org or None,
+                warnings=("Could not initialise the Okta client for NHI discovery.",),
+            )
+
+    warnings: list[str] = []
+    raw_apps: list[dict[str, Any]] = []
+    raw_tokens: list[dict[str, Any]] = []
+    failures = 0
+
+    try:
+        raw_apps = list(client.list_oauth2_service_apps() or [])
+    except Exception as exc:  # noqa: BLE001
+        failures += 1
+        warnings.append(f"Okta service-app listing failed: {exc}")
+    try:
+        raw_tokens = list(client.list_api_tokens() or [])
+    except Exception as exc:  # noqa: BLE001
+        failures += 1
+        warnings.append(f"Okta API-token listing failed: {exc}")
+
+    identities = tuple(_iter_normalized(raw_apps, raw_tokens))[:_MAX_RESULTS]
+
+    if failures and not identities:
+        return NHIDiscoveryResult(
+            status=NHIDiscoveryStatus.ERROR,
+            org_url=resolved_org or None,
+            warnings=tuple(warnings),
+        )
+
+    return NHIDiscoveryResult(
+        status=NHIDiscoveryStatus.OK,
+        identities=identities,
+        warnings=tuple(warnings),
+        org_url=resolved_org or None,
+    )
+
+
+__all__ = [
+    "OKTA_READ_PERMISSIONS",
+    "DiscoveredNonHumanIdentity",
+    "NHIDiscoveryResult",
+    "NHIDiscoveryStatus",
+    "OktaClient",
+    "discover_okta_non_human_identities",
+]

--- a/tests/test_nhi_okta_discovery.py
+++ b/tests/test_nhi_okta_discovery.py
@@ -1,0 +1,231 @@
+"""Okta non-human-identity (NHI) discovery + graph projection.
+
+All tests inject a fake Okta client — no live calls are ever made.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.nhi_overlay import apply_nhi_overlay, apply_nhi_overlay_from_result
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+from agent_bom.identity.okta_nhi import (
+    NHIDiscoveryStatus,
+    discover_okta_non_human_identities,
+)
+
+
+class _FakeOktaClient:
+    """Stand-in exposing the same read-only surface as ``OktaClient``."""
+
+    def __init__(self, apps=None, tokens=None, fail_apps=False, fail_tokens=False):
+        self._apps = apps or []
+        self._tokens = tokens or []
+        self._fail_apps = fail_apps
+        self._fail_tokens = fail_tokens
+
+    def list_oauth2_service_apps(self):
+        if self._fail_apps:
+            raise RuntimeError("403 Forbidden")
+        return self._apps
+
+    def list_api_tokens(self):
+        if self._fail_tokens:
+            raise RuntimeError("403 Forbidden")
+        return self._tokens
+
+
+def _service_app(app_id, label):
+    return {
+        "id": app_id,
+        "label": label,
+        "name": "oidc_client",
+        "status": "ACTIVE",
+        "signOnMode": "OPENID_CONNECT",
+        "created": "2026-01-01T00:00:00Z",
+        "lastUpdated": "2026-06-01T00:00:00Z",
+        "settings": {
+            "oauthClient": {
+                "client_id": f"0oa{app_id}",
+                "application_type": "service",
+                "grant_types": ["client_credentials", "read_file"],
+            }
+        },
+    }
+
+
+def _human_app(app_id, label):
+    # SAML/SSO human app — must be filtered out of NHI discovery.
+    return {
+        "id": app_id,
+        "label": label,
+        "status": "ACTIVE",
+        "signOnMode": "SAML_2_0",
+        "settings": {},
+    }
+
+
+def _api_token(token_id, name, user_id="00uHUMAN"):
+    return {
+        "id": token_id,
+        "name": name,
+        "status": "ACTIVE",
+        "userId": user_id,
+        "created": "2026-02-01T00:00:00Z",
+        "lastUpdated": "2026-06-10T00:00:00Z",
+        "expiresAt": "2026-09-01T00:00:00Z",
+    }
+
+
+# ── Enumeration → records ────────────────────────────────────────────────────
+
+
+def test_discovers_service_accounts_and_api_tokens_filters_human_apps():
+    client = _FakeOktaClient(
+        apps=[_service_app("APP1", "billing-svc"), _human_app("APP2", "okta-dashboard")],
+        tokens=[_api_token("TOK1", "ci-token")],
+    )
+    result = discover_okta_non_human_identities(client=client)
+
+    assert result.status is NHIDiscoveryStatus.OK
+    assert result.ok is True
+    by_type = {i.identity_type for i in result.identities}
+    assert by_type == {"service_account", "api_token"}
+    assert len(result.identities) == 2  # human SAML app filtered out
+
+    svc = next(i for i in result.identities if i.identity_type == "service_account")
+    assert svc.identity_id == "APP1"
+    assert svc.name == "billing-svc"
+    assert svc.created_at == "2026-01-01T00:00:00Z"
+    assert "client_credentials" in svc.scopes
+
+    tok = next(i for i in result.identities if i.identity_type == "api_token")
+    assert tok.identity_id == "TOK1"
+    assert tok.owner == "00uHUMAN"
+    assert tok.credential_expires_at == "2026-09-01T00:00:00Z"
+
+
+def test_empty_org_is_ok_with_no_identities():
+    result = discover_okta_non_human_identities(client=_FakeOktaClient())
+    assert result.status is NHIDiscoveryStatus.OK
+    assert result.identities == ()
+
+
+def test_partial_api_failure_still_returns_other_identities():
+    client = _FakeOktaClient(apps=[_service_app("APP1", "svc")], fail_tokens=True)
+    result = discover_okta_non_human_identities(client=client)
+    assert result.status is NHIDiscoveryStatus.OK
+    assert [i.identity_type for i in result.identities] == ["service_account"]
+    assert any("API-token listing failed" in w for w in result.warnings)
+
+
+def test_total_api_failure_is_error_status_not_raise():
+    client = _FakeOktaClient(fail_apps=True, fail_tokens=True)
+    result = discover_okta_non_human_identities(client=client)
+    assert result.status is NHIDiscoveryStatus.ERROR
+    assert result.identities == ()
+    assert len(result.warnings) == 2
+
+
+# ── Flag gating ──────────────────────────────────────────────────────────────
+
+
+def test_flag_off_returns_disabled_without_network(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_OKTA_DISCOVERY", raising=False)
+    monkeypatch.delenv("AGENT_BOM_OKTA_TOKEN", raising=False)
+    monkeypatch.delenv("AGENT_BOM_OKTA_ORG_URL", raising=False)
+    result = discover_okta_non_human_identities()
+    assert result.status is NHIDiscoveryStatus.DISABLED
+    assert result.identities == ()
+    assert any("disabled" in w.lower() for w in result.warnings)
+
+
+def test_flag_on_but_missing_credentials(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_OKTA_DISCOVERY", "1")
+    monkeypatch.delenv("AGENT_BOM_OKTA_TOKEN", raising=False)
+    monkeypatch.delenv("AGENT_BOM_OKTA_ORG_URL", raising=False)
+    result = discover_okta_non_human_identities()
+    assert result.status is NHIDiscoveryStatus.MISSING_CREDENTIALS
+    assert result.identities == ()
+    warning = result.warnings[0]
+    assert "AGENT_BOM_OKTA_TOKEN" in warning
+    assert "AGENT_BOM_OKTA_ORG_URL" in warning
+
+
+def test_flag_on_with_creds_uses_no_network_when_client_injected(monkeypatch):
+    # Flag on + creds present, but an injected client means OktaClient (and thus
+    # any HTTP) is never constructed.
+    monkeypatch.setenv("AGENT_BOM_OKTA_DISCOVERY", "true")
+    monkeypatch.setenv("AGENT_BOM_OKTA_TOKEN", "ssws-xxx")
+    monkeypatch.setenv("AGENT_BOM_OKTA_ORG_URL", "https://example.okta.com")
+    result = discover_okta_non_human_identities(client=_FakeOktaClient(apps=[_service_app("A", "svc")]))
+    assert result.status is NHIDiscoveryStatus.OK
+    assert len(result.identities) == 1
+
+
+# ── Graph projection ─────────────────────────────────────────────────────────
+
+
+def _graph_with_tool() -> UnifiedGraph:
+    graph = UnifiedGraph(scan_id="s1", tenant_id="default")
+    graph.add_node(UnifiedNode(id="tool:srv:read_file", entity_type=EntityType.TOOL, label="read_file"))
+    return graph
+
+
+def test_overlay_projects_nhis_as_managed_identity_nodes_with_tool_scope():
+    client = _FakeOktaClient(
+        apps=[_service_app("APP1", "billing-svc")],
+        tokens=[_api_token("TOK1", "ci-token")],
+    )
+    result = discover_okta_non_human_identities(client=client)
+
+    graph = _graph_with_tool()
+    stats = apply_nhi_overlay(graph, result.identities)
+    assert stats["nodes_added"] == 2
+
+    mi_nodes = [n for n in graph.nodes.values() if n.entity_type == EntityType.MANAGED_IDENTITY]
+    assert len(mi_nodes) == 2
+    assert all(n.attributes["discovered"] is True for n in mi_nodes)
+    assert all(n.attributes["provider"] == "okta" for n in mi_nodes)
+
+    # The service app's "read_file" grant matches the tool node → SCOPED_TO edge.
+    scoped = [(e.source, e.target) for e in graph.edges if e.relationship == RelationshipType.SCOPED_TO]
+    svc_node = next(n for n in mi_nodes if n.attributes["identity_type"] == "service_account")
+    assert (svc_node.id, "tool:srv:read_file") in scoped
+
+
+def test_overlay_is_idempotent():
+    result = discover_okta_non_human_identities(client=_FakeOktaClient(apps=[_service_app("APP1", "svc")]))
+    graph = _graph_with_tool()
+    first = apply_nhi_overlay(graph, result.identities)
+    second = apply_nhi_overlay(graph, result.identities)
+    assert first["nodes_added"] == 1
+    assert second["nodes_added"] == 0
+
+
+def test_overlay_from_result_noop_when_disabled():
+    graph = _graph_with_tool()
+    disabled = discover_okta_non_human_identities()  # flag off
+    stats = apply_nhi_overlay_from_result(graph, disabled)
+    assert stats == {"nodes_added": 0, "edges_added": 0}
+    assert not [n for n in graph.nodes.values() if n.entity_type == EntityType.MANAGED_IDENTITY]
+
+
+def test_managed_identity_nodes_are_consumable_by_effective_permissions():
+    from agent_bom.graph.effective_permissions import _PRINCIPAL_TYPES
+
+    # The discovered NHI uses MANAGED_IDENTITY, which the effective-permissions
+    # engine already treats as a principal — so discovered identities feed it.
+    assert EntityType.MANAGED_IDENTITY in _PRINCIPAL_TYPES
+
+    result = discover_okta_non_human_identities(client=_FakeOktaClient(apps=[_service_app("APP1", "svc")]))
+    graph = _graph_with_tool()
+    apply_nhi_overlay(graph, result.identities)
+    principals = [n for n in graph.nodes.values() if n.entity_type in _PRINCIPAL_TYPES]
+    assert len(principals) == 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
PR-1 of non-human-identity (NHI) discovery (#2922) — the discovery half that the audit found unbuilt (Natoma parity 4.0/10). Scoped to **Okta** IdP service accounts + API tokens; orthogonal to cloud IAM.

- `identity/okta_nhi.py` — read-only Okta connector enumerating OAuth2 client-credentials service apps + org API tokens, normalized to `DiscoveredNonHumanIdentity` records (id/name/owner/created/last-used/credential-expiry/scopes — **no secret values**). Never raises.
- `graph/nhi_overlay.py` — projects discovered NHIs as `MANAGED_IDENTITY` nodes (idempotent, marked `discovered`) with `SCOPED_TO` edges to tools. Reuses existing graph vocab; `MANAGED_IDENTITY` is already a principal type, so discovered identities feed the existing effective-permissions engine with **zero engine change**.

## Trust posture
- **Token-only auth** (`AGENT_BOM_OKTA_TOKEN`, SSWS/bearer) — no passwords, per policy. Reference-only.
- Gated behind `AGENT_BOM_OKTA_DISCOVERY` (**default OFF**, no network).

## Scope
Okta foundation; Entra/cloud-IAM NHI + graph-builder/CLI wiring follow in PR-2.

## Verification
11 tests pass (mocked Okta client — enumeration→nodes, flag-off, missing-creds, effective-perms integration). ruff/format/mypy clean; env-var allowlist gate satisfied.