### PR TITLE
fix(api): suppress SCIM posture exception details

### DIFF
--- a/src/agent_bom/api/scim.py
+++ b/src/agent_bom/api/scim.py
@@ -11,7 +11,6 @@ from json import JSONDecodeError
 from typing import Any
 
 from agent_bom.platform_invariants import ReservedTenantIdError, validate_customer_tenant_id
-from agent_bom.security import sanitize_error
 
 _SCIM_ROLE_VALUES = ("admin", "analyst", "viewer")
 _SCIM_ROLE_ALIASES = {
@@ -162,7 +161,7 @@ def _scim_token_binding_posture() -> dict[str, object]:
         }
     try:
         bindings = configured_scim_bearer_token_bindings()
-    except SCIMConfigurationError as exc:
+    except SCIMConfigurationError:
         return {
             "configured": True,
             "status": "misconfigured",
@@ -172,7 +171,7 @@ def _scim_token_binding_posture() -> dict[str, object]:
             "tenant_id": None,
             "tenant_ids": [],
             "tenant_id_source": None,
-            "message": sanitize_error(exc),
+            "message": "SCIM bearer token configuration is invalid. Check control-plane logs and SCIM environment settings.",
         }
 
     sources = {binding.source for binding in bindings}
@@ -362,7 +361,7 @@ def describe_scim_posture() -> dict[str, object]:
             },
         ],
         "message": (
-            "SCIM bearer token configuration is invalid; fix the tenant-token mapping before accepting provisioning traffic."
+            "SCIM bearer token configuration is invalid. Check control-plane logs and SCIM environment settings."
             if token_posture["status"] == "misconfigured"
             else (
                 (

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -9,6 +9,7 @@ Covers:
 from __future__ import annotations
 
 import importlib
+import json
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
@@ -472,6 +473,27 @@ def test_auth_policy_redacts_oidc_config_errors(monkeypatch: pytest.MonkeyPatch)
     assert oidc["message"] == "OIDC configuration is invalid. Check control-plane logs and OIDC environment settings."
     assert "tenant-secret" not in oidc["message"]
     assert "AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON" not in oidc["message"]
+
+
+def test_auth_policy_redacts_scim_config_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_rate_limit_env(monkeypatch)
+    tenant_id = "tenant-secret"
+    monkeypatch.delenv("AGENT_BOM_SCIM_BEARER_TOKEN", raising=False)
+    monkeypatch.setenv("AGENT_BOM_SCIM_BEARER_TOKENS_JSON", json.dumps({tenant_id: " "}))
+
+    client = TestClient(app)
+    resp = client.get("/v1/auth/policy")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    scim = body["identity_provisioning"]["scim"]
+    serialized = json.dumps(body)
+    assert scim["status"] == "misconfigured"
+    assert scim["message"] == "SCIM bearer token configuration is invalid. Check control-plane logs and SCIM environment settings."
+    assert tenant_id not in serialized
+    assert "must not be blank" not in serialized
+    assert "SCIMConfigurationError" not in serialized
+    assert "Traceback" not in serialized
 
 
 def test_auth_policy_reports_secret_integrity_posture(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_api_scim_lifecycle.py
+++ b/tests/test_api_scim_lifecycle.py
@@ -267,6 +267,22 @@ def test_scim_per_tenant_bearer_mapping_rejects_unsafe_config(
     assert posture["token_binding_count"] == 0
 
 
+def test_scim_posture_uses_fixed_message_for_invalid_token_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
+    tenant_id = "tenant-secret"
+    monkeypatch.delenv("AGENT_BOM_SCIM_BEARER_TOKEN", raising=False)
+    monkeypatch.setenv("AGENT_BOM_SCIM_BEARER_TOKENS_JSON", json.dumps({tenant_id: " "}))
+
+    posture = describe_scim_posture()
+    serialized = json.dumps(posture)
+
+    assert posture["status"] == "misconfigured"
+    assert posture["message"] == "SCIM bearer token configuration is invalid. Check control-plane logs and SCIM environment settings."
+    assert tenant_id not in serialized
+    assert "must not be blank" not in serialized
+    assert "SCIMConfigurationError" not in serialized
+    assert "Traceback" not in serialized
+
+
 def test_scim_group_create_patch_and_delete(scim_client: TestClient) -> None:
     user = scim_client.post(
         "/scim/v2/Users",


### PR DESCRIPTION
Summary
- Replace exception-derived SCIM misconfiguration posture text with a fixed operator-safe message.
- Cover both /v1/auth/scim/config and /v1/auth/policy so CodeQL stack-trace exposure alerts do not have an API response sink.
- Confirm Dependabot alert #66 is already fixed by pydantic-settings 2.14.2 on main.

Verification
- env UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest tests/test_api_scim_lifecycle.py tests/test_api_operator_policy.py -q
- env UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check src/agent_bom/api/scim.py tests/test_api_scim_lifecycle.py tests/test_api_operator_policy.py
- env UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv lock --check
- git diff --check

Notes
- Addresses CodeQL alerts #1744 and #1569 in src/agent_bom/api/routes/enterprise.py by removing exception-derived SCIM config text from the returned posture payloads.