### PR TITLE
fix(api): bind idempotency keys to request payloads

### DIFF
--- a/src/agent_bom/api/idempotency_store.py
+++ b/src/agent_bom/api/idempotency_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 import threading
@@ -18,17 +19,65 @@ class IdempotencyRecord:
     tenant_id: str
     source_id: str
     idempotency_key: str
+    request_hash: str
     response_json: str
     created_at: str
 
 
+class IdempotencyConflictError(RuntimeError):
+    """Raised when a key is reused for a different request payload."""
+
+
 class IdempotencyStore(Protocol):
-    def get(self, endpoint: str, tenant_id: str, source_id: str, idempotency_key: str) -> dict[str, Any] | None: ...
-    def put(self, endpoint: str, tenant_id: str, source_id: str, idempotency_key: str, response: dict[str, Any]) -> None: ...
+    def get(
+        self,
+        endpoint: str,
+        tenant_id: str,
+        source_id: str,
+        idempotency_key: str,
+        *,
+        request_hash: str = "",
+    ) -> dict[str, Any] | None: ...
+    def put(
+        self,
+        endpoint: str,
+        tenant_id: str,
+        source_id: str,
+        idempotency_key: str,
+        response: dict[str, Any],
+        *,
+        request_hash: str = "",
+    ) -> None: ...
 
 
 def _utcnow() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_request_payload(value: Any) -> Any:
+    if hasattr(value, "model_dump"):
+        value = value.model_dump(mode="json")
+    if isinstance(value, dict):
+        return {
+            str(key): _normalize_request_payload(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+            if str(key) != "idempotency_key"
+        }
+    if isinstance(value, list | tuple):
+        return [_normalize_request_payload(item) for item in value]
+    return value
+
+
+def idempotency_request_fingerprint(payload: Any) -> str:
+    """Return a stable fingerprint for comparing idempotent write retries."""
+    normalized = _normalize_request_payload(payload or {})
+    encoded = json.dumps(normalized, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _ensure_request_hash_matches(stored_hash: str, request_hash: str) -> None:
+    if stored_hash and request_hash and stored_hash != request_hash:
+        raise IdempotencyConflictError("Idempotency key was reused with a different request payload")
 
 
 class InMemoryIdempotencyStore:
@@ -43,13 +92,32 @@ class InMemoryIdempotencyStore:
         for key in stale:
             self._records.pop(key, None)
 
-    def get(self, endpoint: str, tenant_id: str, source_id: str, idempotency_key: str) -> dict[str, Any] | None:
+    def get(
+        self,
+        endpoint: str,
+        tenant_id: str,
+        source_id: str,
+        idempotency_key: str,
+        *,
+        request_hash: str = "",
+    ) -> dict[str, Any] | None:
         with self._lock:
             self._prune()
             record = self._records.get((endpoint, tenant_id, source_id, idempotency_key))
+            if record:
+                _ensure_request_hash_matches(record.request_hash, request_hash)
             return json.loads(record.response_json) if record else None
 
-    def put(self, endpoint: str, tenant_id: str, source_id: str, idempotency_key: str, response: dict[str, Any]) -> None:
+    def put(
+        self,
+        endpoint: str,
+        tenant_id: str,
+        source_id: str,
+        idempotency_key: str,
+        response: dict[str, Any],
+        *,
+        request_hash: str = "",
+    ) -> None:
         with self._lock:
             self._prune()
             self._records[(endpoint, tenant_id, source_id, idempotency_key)] = IdempotencyRecord(
@@ -57,6 +125,7 @@ class InMemoryIdempotencyStore:
                 tenant_id=tenant_id,
                 source_id=source_id,
                 idempotency_key=idempotency_key,
+                request_hash=request_hash,
                 response_json=json.dumps(response, sort_keys=True),
                 created_at=_utcnow(),
             )
@@ -85,28 +154,59 @@ class SQLiteIdempotencyStore:
                 tenant_id TEXT NOT NULL,
                 source_id TEXT NOT NULL,
                 idempotency_key TEXT NOT NULL,
+                request_hash TEXT NOT NULL DEFAULT '',
                 response_json TEXT NOT NULL,
                 created_at TEXT NOT NULL,
                 PRIMARY KEY (endpoint, tenant_id, source_id, idempotency_key)
             )
             """
         )
+        columns = {str(row[1]) for row in self._conn.execute("PRAGMA table_info(idempotency_keys)").fetchall()}
+        if "request_hash" not in columns:
+            self._conn.execute("ALTER TABLE idempotency_keys ADD COLUMN request_hash TEXT NOT NULL DEFAULT ''")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_idempotency_created_at ON idempotency_keys(created_at)")
         self._conn.commit()
 
-    def get(self, endpoint: str, tenant_id: str, source_id: str, idempotency_key: str) -> dict[str, Any] | None:
+    def get(
+        self,
+        endpoint: str,
+        tenant_id: str,
+        source_id: str,
+        idempotency_key: str,
+        *,
+        request_hash: str = "",
+    ) -> dict[str, Any] | None:
         row = self._conn.execute(
-            """SELECT response_json FROM idempotency_keys
+            """SELECT response_json, request_hash FROM idempotency_keys
                WHERE endpoint = ? AND tenant_id = ? AND source_id = ? AND idempotency_key = ?""",
             (endpoint, tenant_id, source_id, idempotency_key),
         ).fetchone()
+        if row:
+            _ensure_request_hash_matches(str(row[1] or ""), request_hash)
         return json.loads(row[0]) if row else None
 
-    def put(self, endpoint: str, tenant_id: str, source_id: str, idempotency_key: str, response: dict[str, Any]) -> None:
+    def put(
+        self,
+        endpoint: str,
+        tenant_id: str,
+        source_id: str,
+        idempotency_key: str,
+        response: dict[str, Any],
+        *,
+        request_hash: str = "",
+    ) -> None:
         self._conn.execute(
             """INSERT OR REPLACE INTO idempotency_keys
-               (endpoint, tenant_id, source_id, idempotency_key, response_json, created_at)
-               VALUES (?, ?, ?, ?, ?, ?)""",
-            (endpoint, tenant_id, source_id, idempotency_key, json.dumps(response, sort_keys=True), _utcnow()),
+               (endpoint, tenant_id, source_id, idempotency_key, request_hash, response_json, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                endpoint,
+                tenant_id,
+                source_id,
+                idempotency_key,
+                request_hash,
+                json.dumps(response, sort_keys=True),
+                _utcnow(),
+            ),
         )
         self._conn.commit()

--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Request
 
+from agent_bom.api.idempotency_store import IdempotencyConflictError, idempotency_request_fingerprint
 from agent_bom.api.mcp_observation_store import MCPObservation, merge_observations
 from agent_bom.api.models import FleetAgentUpdate, PushPayload, StateUpdate
 from agent_bom.api.stores import _get_fleet_store, _get_idempotency_store, _get_mcp_observation_store
@@ -271,8 +272,18 @@ async def sync_fleet(request: Request, body: PushPayload | None = None):
     now = datetime.now(timezone.utc).isoformat()
     source_id = (body.source_id if body else "") or _request_header(request, "X-Agent-Bom-Source-Id") or "server-discovery"
     idem_key = (body.idempotency_key if body else "") or _request_header(request, "Idempotency-Key")
+    request_hash = idempotency_request_fingerprint(body)
     if idem_key:
-        cached = _get_idempotency_store().get("/v1/fleet/sync", tenant_id, source_id, idem_key)
+        try:
+            cached = _get_idempotency_store().get(
+                "/v1/fleet/sync",
+                tenant_id,
+                source_id,
+                idem_key,
+                request_hash=request_hash,
+            )
+        except IdempotencyConflictError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
         if cached is not None:
             cached["idempotent_replay"] = True
             return cached
@@ -433,7 +444,14 @@ async def sync_fleet(request: Request, body: PushPayload | None = None):
         source_id=source_id,
     )
     if idem_key:
-        _get_idempotency_store().put("/v1/fleet/sync", tenant_id, source_id, idem_key, response)
+        _get_idempotency_store().put(
+            "/v1/fleet/sync",
+            tenant_id,
+            source_id,
+            idem_key,
+            response,
+            request_hash=request_hash,
+        )
     return response
 
 

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, HTTPException, Query, Request, WebSocket
 
+from agent_bom.api.idempotency_store import IdempotencyConflictError, idempotency_request_fingerprint
 from agent_bom.api.tenancy import require_request_tenant_id
 
 if TYPE_CHECKING:
@@ -140,8 +141,18 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
     source_id = body.source_id or "unknown"
     session_id = body.session_id or "default"
     analytics_events: list[dict] = []
+    request_hash = idempotency_request_fingerprint(body)
     if body.idempotency_key:
-        cached = _get_idempotency_store().get("/v1/proxy/audit", tenant_id, source_id, body.idempotency_key)
+        try:
+            cached = _get_idempotency_store().get(
+                "/v1/proxy/audit",
+                tenant_id,
+                source_id,
+                body.idempotency_key,
+                request_hash=request_hash,
+            )
+        except IdempotencyConflictError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
         if cached is not None:
             cached["idempotent_replay"] = True
             return cached
@@ -250,7 +261,14 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         "has_summary": body.summary is not None,
     }
     if body.idempotency_key:
-        _get_idempotency_store().put("/v1/proxy/audit", tenant_id, source_id, body.idempotency_key, response)
+        _get_idempotency_store().put(
+            "/v1/proxy/audit",
+            tenant_id,
+            source_id,
+            body.idempotency_key,
+            response,
+            request_hash=request_hash,
+        )
     return response
 
 

--- a/tests/test_api_fleet.py
+++ b/tests/test_api_fleet.py
@@ -11,7 +11,9 @@ from agent_bom.api.fleet_store import (
     FleetLifecycleState,
     InMemoryFleetStore,
 )
+from agent_bom.api.idempotency_store import InMemoryIdempotencyStore
 from agent_bom.api.server import app, set_fleet_store
+from agent_bom.api.stores import set_idempotency_store
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package
 
 
@@ -42,6 +44,7 @@ def _make(
 def _fresh_client() -> tuple[TestClient, InMemoryFleetStore]:
     store = InMemoryFleetStore()
     set_fleet_store(store)
+    set_idempotency_store(InMemoryIdempotencyStore())
     return TestClient(app), store
 
 
@@ -380,6 +383,34 @@ def test_sync_endpoint_push_is_idempotent():
     assert first.status_code == 200
     assert second.status_code == 200
     assert second.json()["idempotent_replay"] is True
+    assert len(store.list_all()) == 1
+
+
+def test_sync_endpoint_rejects_idempotency_key_payload_mismatch():
+    client, store = _fresh_client()
+    payload = {
+        "source_id": "laptop-a",
+        "idempotency_key": "fleet-sync-conflict",
+        "agents": [
+            {
+                "name": "cursor",
+                "agent_type": "cursor",
+                "trust_score": 82.5,
+                "mcp_servers": [],
+            }
+        ],
+    }
+    first = client.post("/v1/fleet/sync", json=payload)
+    assert first.status_code == 200
+
+    payload["agents"][0]["name"] = "different-agent"
+    second = client.post("/v1/fleet/sync", json=payload)
+
+    assert second.status_code == 409
+    body = second.json()
+    assert body["error"]["code"] == "CONFLICT"
+    assert "different request payload" in body["error"]["message"]
+    assert second.headers.get("X-Request-ID") == body["error"]["correlation_id"]
     assert len(store.list_all()) == 1
 
 

--- a/tests/test_api_proxy_scorecard.py
+++ b/tests/test_api_proxy_scorecard.py
@@ -13,11 +13,13 @@ import pytest
 from starlette.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
+from agent_bom.api.idempotency_store import InMemoryIdempotencyStore
 from agent_bom.api.server import (
     app,
     push_proxy_alert,
     push_proxy_metrics,
 )
+from agent_bom.api.stores import set_idempotency_store
 from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
 
 # ── /v1/proxy/status ───────────────────────────────────────────────────────
@@ -630,6 +632,40 @@ def test_proxy_audit_ingest_is_idempotent():
 
     proxy_mod._proxy_alerts.clear()
     proxy_mod._proxy_metrics = None
+    set_idempotency_store(InMemoryIdempotencyStore())
+
+
+def test_proxy_audit_rejects_idempotency_key_payload_mismatch():
+    import agent_bom.api.routes.proxy as proxy_mod
+
+    proxy_mod._reset_audit_dedupe_for_tests()
+    proxy_mod._proxy_alerts.clear()
+    proxy_mod._proxy_metrics = None
+    set_idempotency_store(InMemoryIdempotencyStore())
+
+    client = TestClient(app, raise_server_exceptions=False)
+    payload = {
+        "source_id": "laptop-1",
+        "session_id": "sess-1",
+        "idempotency_key": "proxy-audit-conflict",
+        "alerts": [{"type": "runtime_alert", "detector": "credential_leak", "severity": "critical", "message": "AWS key"}],
+        "summary": {"type": "proxy_summary", "total_tool_calls": 7, "total_blocked": 2},
+    }
+
+    first = client.post("/v1/proxy/audit", json=payload)
+    assert first.status_code == 200
+
+    payload["summary"]["total_tool_calls"] = 8
+    second = client.post("/v1/proxy/audit", json=payload)
+
+    assert second.status_code == 409
+    body = second.json()
+    assert body["error"]["code"] == "CONFLICT"
+    assert "different request payload" in body["error"]["message"]
+    assert second.headers.get("X-Request-ID") == body["error"]["correlation_id"]
+
+    proxy_mod._proxy_alerts.clear()
+    proxy_mod._proxy_metrics = None
 
 
 @pytest.mark.asyncio
@@ -684,6 +720,7 @@ async def test_proxy_audit_ingest_records_analytics_with_session_trace_context(m
 
     proxy_mod._proxy_alerts.clear()
     proxy_mod._proxy_metrics = None
+    set_idempotency_store(InMemoryIdempotencyStore())
 
     client = TestClient(app)
     payload = {

--- a/tests/test_idempotency_store.py
+++ b/tests/test_idempotency_store.py
@@ -1,0 +1,37 @@
+"""Tests for retry-safe idempotency storage."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.api.idempotency_store import (
+    IdempotencyConflictError,
+    InMemoryIdempotencyStore,
+    SQLiteIdempotencyStore,
+    idempotency_request_fingerprint,
+)
+
+
+@pytest.mark.parametrize("store_factory", [InMemoryIdempotencyStore])
+def test_idempotency_store_replays_same_payload_and_rejects_mismatch(store_factory):
+    store = store_factory()
+    request_hash = idempotency_request_fingerprint({"idempotency_key": "k-1", "value": 1})
+    mismatch_hash = idempotency_request_fingerprint({"idempotency_key": "k-1", "value": 2})
+
+    store.put("/v1/test", "tenant-a", "source-a", "k-1", {"ok": True}, request_hash=request_hash)
+
+    assert store.get("/v1/test", "tenant-a", "source-a", "k-1", request_hash=request_hash) == {"ok": True}
+    with pytest.raises(IdempotencyConflictError):
+        store.get("/v1/test", "tenant-a", "source-a", "k-1", request_hash=mismatch_hash)
+
+
+def test_sqlite_idempotency_store_replays_same_payload_and_rejects_mismatch(tmp_path):
+    store = SQLiteIdempotencyStore(str(tmp_path / "idempotency.db"))
+    request_hash = idempotency_request_fingerprint({"idempotency_key": "k-1", "value": 1})
+    mismatch_hash = idempotency_request_fingerprint({"idempotency_key": "k-1", "value": 2})
+
+    store.put("/v1/test", "tenant-a", "source-a", "k-1", {"ok": True}, request_hash=request_hash)
+
+    assert store.get("/v1/test", "tenant-a", "source-a", "k-1", request_hash=request_hash) == {"ok": True}
+    with pytest.raises(IdempotencyConflictError):
+        store.get("/v1/test", "tenant-a", "source-a", "k-1", request_hash=mismatch_hash)


### PR DESCRIPTION
Summary
- Bind idempotency records to a stable request payload fingerprint so exact retries replay but mismatched retries do not silently reuse stale responses.
- Return the existing structured API error envelope with 409 CONFLICT for idempotency key payload mismatches on fleet sync and proxy audit ingest.
- Add in-memory and SQLite idempotency store coverage plus fleet/proxy endpoint regressions.

Verification
- uv run pytest tests/test_idempotency_store.py tests/test_api_fleet.py::test_sync_endpoint_push_is_idempotent tests/test_api_fleet.py::test_sync_endpoint_rejects_idempotency_key_payload_mismatch tests/test_api_proxy_scorecard.py::test_proxy_audit_rejects_idempotency_key_payload_mismatch -q
- uv run ruff check src/agent_bom/api/idempotency_store.py src/agent_bom/api/routes/fleet.py src/agent_bom/api/routes/proxy.py tests/test_api_fleet.py tests/test_api_proxy_scorecard.py tests/test_idempotency_store.py
- git diff --check
- uv run pytest tests/test_api_fleet.py tests/test_api_proxy_scorecard.py tests/test_api_data_p1_batch_v0867.py -q