### PR TITLE
fix(cli): tighten scan output contracts

### DIFF
--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -109,8 +109,9 @@ Rate limiting also follows an explicit fail-closed contract for scaled control p
 
 API-local filesystem scans follow the same pilot-vs-control-plane split:
 
-- workstation pilot: relative paths under the API process home are allowed by default
-- EKS/shared control plane: Helm disables API-local filesystem scans by default with `AGENT_BOM_API_LOCAL_PATH_SCANS=disabled`
+- default posture: API-local filesystem scans are disabled unless `AGENT_BOM_API_LOCAL_PATH_SCANS=enabled` is set
+- workstation pilot: set `AGENT_BOM_API_LOCAL_PATH_SCANS=enabled`; relative paths resolve under the API process home unless `AGENT_BOM_API_SCAN_ROOT` is set
+- EKS/shared control plane: keep `AGENT_BOM_API_LOCAL_PATH_SCANS=disabled` and collect filesystem evidence through endpoint agents or mounted tenant workspaces
 - explicit single-tenant enablement: set `AGENT_BOM_API_SCAN_ROOT` to a mounted tenant workspace; the API still rejects absolute paths, traversal, symlink escapes, missing paths, and foreign-owned paths unless explicitly overridden
 
 Implementation source: `src/agent_bom/api/middleware.py`, `src/agent_bom/api/oidc.py`

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -362,13 +362,14 @@ control planes, `agent-bom` fails closed when a non-loopback listener is exposed
 without either trusted-proxy attestation or app-native mTLS.
 
 API-local filesystem scan endpoints are meant for workstation pilots. In EKS
-and other shared control planes, keep `AGENT_BOM_API_LOCAL_PATH_SCANS=disabled`
-and collect filesystem evidence through endpoint agents or mounted tenant
-workspaces. If a single-tenant deployment must enable API-local scans, set
-`AGENT_BOM_API_SCAN_ROOT` to the tenant workspace mount; paths are still
-relative-only, resolved through symlinks, confined to that root, and rejected
-when owned outside the API process unless `AGENT_BOM_API_SCAN_ALLOW_FOREIGN_OWNER=1`
-is explicitly set.
+and other shared control planes they are disabled by default; keep
+`AGENT_BOM_API_LOCAL_PATH_SCANS=disabled` and collect filesystem evidence
+through endpoint agents or mounted tenant workspaces. If a single-tenant
+deployment must enable API-local scans, set
+`AGENT_BOM_API_LOCAL_PATH_SCANS=enabled` and `AGENT_BOM_API_SCAN_ROOT` to the
+tenant workspace mount; paths are still relative-only, resolved through
+symlinks, confined to that root, and rejected when owned outside the API
+process unless `AGENT_BOM_API_SCAN_ALLOW_FOREIGN_OWNER=1` is explicitly set.
 
 For secret lifecycle posture, production deployments should declare the external
 secret authority and rotation metadata without exposing secret values:

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -74,17 +74,16 @@ _BULK_FINDINGS_SOURCE_MAX_LENGTH = 128
 
 
 def _api_local_scans_enabled() -> bool:
-    configured = os.getenv("AGENT_BOM_API_LOCAL_PATH_SCANS", os.getenv("AGENT_BOM_ENABLE_LOCAL_PATH_SCANS", "enabled"))
+    configured = os.getenv("AGENT_BOM_API_LOCAL_PATH_SCANS", os.getenv("AGENT_BOM_ENABLE_LOCAL_PATH_SCANS", "disabled"))
     return configured.strip().lower() not in _LOCAL_SCAN_DISABLE_VALUES
 
 
 def _api_scan_root() -> Path:
     """Return the configured API filesystem scan root.
 
-    Workstation pilots keep the historical default of ``$HOME``. Shared
-    control-plane deployments should set ``AGENT_BOM_API_SCAN_ROOT`` to a
-    tenant workspace mount, or disable these endpoints and scan via endpoint
-    agents instead.
+    API-local path scans are disabled unless explicitly enabled. Workstation
+    pilots can set ``AGENT_BOM_API_LOCAL_PATH_SCANS=enabled`` and optionally
+    scope ``AGENT_BOM_API_SCAN_ROOT`` to a tenant workspace mount.
     """
     configured = os.getenv("AGENT_BOM_API_SCAN_ROOT", "").strip()
     root = Path(configured).expanduser() if configured else Path.home()

--- a/src/agent_bom/cli/_check.py
+++ b/src/agent_bom/cli/_check.py
@@ -539,6 +539,7 @@ def _exit_model_verification(
     help="Exit 0 even when vulnerabilities are found (useful for exploratory or parallel checks)",
 )
 @click.option("--enrich", is_flag=True, help="Add NVD CVSS, EPSS, and CISA KEV enrichment to matched vulnerabilities.")
+@click.option("--offline", is_flag=True, help="Scan against the local vulnerability database only.")
 @click.option(
     "--fail-on-severity",
     type=click.Choice(["critical", "high", "medium", "low"], case_sensitive=False),
@@ -557,6 +558,7 @@ def check(
     output_path: str | None,
     exit_zero: bool,
     enrich: bool,
+    offline: bool,
     fail_on_severity: str | None,
     nvd_api_key: str | None,
 ):
@@ -700,7 +702,7 @@ def check(
         from agent_bom.scanners import IncompleteScanError, ScanOptions, consume_scan_warnings, scan_packages
 
         try:
-            asyncio.run(scan_packages(pkgs, options=ScanOptions(offline=False)))
+            asyncio.run(scan_packages(pkgs, options=ScanOptions(offline=offline)))
         except IncompleteScanError as exc:
             if structured_output:
                 _write_check_output(

--- a/src/agent_bom/cli/_focused_commands.py
+++ b/src/agent_bom/cli/_focused_commands.py
@@ -35,6 +35,13 @@ def _validate_json_or_console_format(command_name: str, output_format: str) -> s
 _FOCUSED_GATE_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
 
 
+def _focused_default_output(output_format: str, output_path: Optional[str]) -> Optional[str]:
+    """Focused scan JSON/SARIF modes stream by default instead of creating a report file."""
+    if output_path is None and output_format.lower() in {"json", "sarif"}:
+        return "-"
+    return output_path
+
+
 def _has_finding_at_or_above(findings, threshold: str = "high") -> bool:
     """Return True when focused findings should fail CI by default."""
     threshold_rank = _FOCUSED_GATE_ORDER.get(threshold.lower(), 1)
@@ -135,7 +142,7 @@ def fs_cmd(
         scan,
         filesystem_paths=(path,),
         output_format=output_format,
-        output=output_path,
+        output=_focused_default_output(output_format, output_path),
         fail_on_severity=fail_on_severity,
         enrich=enrich,
         offline=offline,

--- a/src/agent_bom/cli/_mcp_group.py
+++ b/src/agent_bom/cli/_mcp_group.py
@@ -69,6 +69,7 @@ def mcp_scan_cmd(server_spec: str, ecosystem: str | None, quiet: bool, no_color:
         output_path=None,
         exit_zero=exit_zero,
         enrich=False,
+        offline=False,
         fail_on_severity=None,
         nvd_api_key=None,
     )

--- a/src/agent_bom/output/spdx_fmt.py
+++ b/src/agent_bom/output/spdx_fmt.py
@@ -11,6 +11,8 @@ from agent_bom.asset_provenance import package_version_provenance
 from agent_bom.compliance_utils import framework_qualified_blast_radius_tags
 from agent_bom.models import AIBOMReport
 
+SPDX_3_CONTEXT = "https://spdx.org/rdf/3.0.0/spdx-context.jsonl"
+
 
 def to_spdx(report: AIBOMReport) -> dict:
     """Build an SPDX 3.0 (JSON-LD) dict from report.
@@ -213,6 +215,7 @@ def to_spdx(report: AIBOMReport) -> dict:
                     relationships.append(assessment)
 
     return {
+        "@context": SPDX_3_CONTEXT,
         "spdxVersion": "SPDX-3.0",
         "dataLicense": "CC0-1.0",
         "SPDXID": document_id,

--- a/tests/test_api_scan_types.py
+++ b/tests/test_api_scan_types.py
@@ -394,24 +394,26 @@ def test_scan_model_files_surfaces_manifests(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_sanitize_rejects_traversal():
+def test_sanitize_rejects_traversal(monkeypatch):
     """_sanitize_api_path rejects path traversal."""
     import pytest
 
     from agent_bom.api.server import _sanitize_api_path
     from agent_bom.security import SecurityError
 
+    monkeypatch.setenv("AGENT_BOM_API_LOCAL_PATH_SCANS", "enabled")
     with pytest.raises(SecurityError, match="traversal"):
         _sanitize_api_path("subdir/../../etc/passwd")
 
 
-def test_sanitize_rejects_absolute_path():
+def test_sanitize_rejects_absolute_path(monkeypatch):
     """_sanitize_api_path rejects absolute paths."""
     import pytest
 
     from agent_bom.api.server import _sanitize_api_path
     from agent_bom.security import SecurityError
 
+    monkeypatch.setenv("AGENT_BOM_API_LOCAL_PATH_SCANS", "enabled")
     with pytest.raises(SecurityError, match="Absolute paths"):
         _sanitize_api_path("/etc/passwd")
 
@@ -426,6 +428,7 @@ def test_sanitize_resolves_relative_to_home(tmp_path, monkeypatch):
     subdir = tmp_path / "projects"
     subdir.mkdir()
     monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setenv("AGENT_BOM_API_LOCAL_PATH_SCANS", "enabled")
 
     result = _sanitize_api_path("projects")
     assert result == os.path.realpath(str(subdir))
@@ -441,6 +444,7 @@ def test_sanitize_respects_configured_scan_root(tmp_path, monkeypatch):
     project = scan_root / "projects"
     project.mkdir(parents=True)
     monkeypatch.setenv("AGENT_BOM_API_SCAN_ROOT", str(scan_root))
+    monkeypatch.setenv("AGENT_BOM_API_LOCAL_PATH_SCANS", "enabled")
 
     result = _sanitize_api_path("projects")
 
@@ -460,9 +464,27 @@ def test_sanitize_rejects_symlink_leaf(tmp_path, monkeypatch):
     link = scan_root / "project-link"
     link.symlink_to(target, target_is_directory=True)
     monkeypatch.setenv("AGENT_BOM_API_SCAN_ROOT", str(scan_root))
+    monkeypatch.setenv("AGENT_BOM_API_LOCAL_PATH_SCANS", "enabled")
 
     with pytest.raises(SecurityError, match="Symlink"):
         _sanitize_api_path("project-link")
+
+
+def test_sanitize_disables_local_path_scans_by_default(tmp_path, monkeypatch):
+    """API-local filesystem scans require explicit opt-in."""
+    import pytest
+
+    from agent_bom.api.server import _sanitize_api_path
+    from agent_bom.security import SecurityError
+
+    scan_root = tmp_path / "tenant-workspace"
+    scan_root.mkdir()
+    monkeypatch.setenv("AGENT_BOM_API_SCAN_ROOT", str(scan_root))
+    monkeypatch.delenv("AGENT_BOM_API_LOCAL_PATH_SCANS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_ENABLE_LOCAL_PATH_SCANS", raising=False)
+
+    with pytest.raises(SecurityError, match="disabled"):
+        _sanitize_api_path(".")
 
 
 def test_sanitize_can_disable_local_path_scans(tmp_path, monkeypatch):
@@ -487,6 +509,7 @@ def test_endpoint_returns_generic_invalid_scan_path(tmp_path, monkeypatch):
     scan_root = tmp_path / "tenant-workspace"
     scan_root.mkdir()
     monkeypatch.setenv("AGENT_BOM_API_SCAN_ROOT", str(scan_root))
+    monkeypatch.setenv("AGENT_BOM_API_LOCAL_PATH_SCANS", "enabled")
 
     resp = client.post("/v1/scan/dataset-cards", json={"directories": ["missing"]})
 

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -244,6 +244,20 @@ def test_check_incomplete_offline_scan_exits_two(monkeypatch):
     assert "populated local vulnerability DB" in result.output
 
 
+def test_check_accepts_offline_flag(monkeypatch):
+    seen = {}
+
+    async def _scan_packages(_pkgs, *, options=None, **_kwargs):
+        seen["offline"] = options.offline
+
+    monkeypatch.setattr("agent_bom.scanners.scan_packages", _scan_packages)
+
+    result = CliRunner().invoke(main, ["check", "django@4.1.0", "--ecosystem", "pypi", "--offline", "--quiet"])
+
+    assert result.exit_code == 0
+    assert seen == {"offline": True}
+
+
 class _DummyResponse:
     def __init__(self, status_code: int, payload: dict):
         self.status_code = status_code

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -669,6 +669,15 @@ def test_focused_secrets_and_skills_scan_expose_logging_flags():
         assert "--log-file" in result.output
 
 
+def test_focused_fs_json_and_sarif_default_to_stdout():
+    from agent_bom.cli._focused_commands import _focused_default_output
+
+    assert _focused_default_output("json", None) == "-"
+    assert _focused_default_output("sarif", None) == "-"
+    assert _focused_default_output("console", None) is None
+    assert _focused_default_output("json", "report.json") == "report.json"
+
+
 def test_scan_bad_baseline_json_exits_before_rendering(tmp_path):
     baseline = tmp_path / "baseline.json"
     baseline.write_text("{bad json", encoding="utf-8")

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -699,6 +699,7 @@ def test_spdx_vulnerability_annotations_preserve_enrichment_and_compliance_metad
     report = _make_report(agents=[_make_agent(servers=[_make_server(packages=[pkg])])], blast_radii=[br])
 
     spdx = to_spdx(report)
+    assert spdx["@context"] == "https://spdx.org/rdf/3.0.0/spdx-context.jsonl"
     vuln_element = next(element for element in spdx["elements"] if element.get("type") == "security/Vulnerability")
     statements = {annotation["statement"] for annotation in vuln_element["annotation"]}
 


### PR DESCRIPTION
Summary:
- Disable API-local filesystem scans by default and require explicit opt-in for local path scan endpoints.
- Emit the SPDX 3.0 JSON-LD context and make focused fs JSON/SARIF output stream to stdout by default.
- Add check --offline support and keep MCP scan delegation aligned with the check command signature.

Verification:
- uv run pytest tests/test_api_scan_types.py::test_sanitize_resolves_relative_to_home tests/test_api_scan_types.py::test_sanitize_respects_configured_scan_root tests/test_api_scan_types.py::test_sanitize_rejects_symlink_leaf tests/test_api_scan_types.py::test_sanitize_disables_local_path_scans_by_default tests/test_api_scan_types.py::test_sanitize_can_disable_local_path_scans tests/test_api_scan_types.py::test_endpoint_returns_generic_invalid_scan_path -q
- uv run pytest tests/test_cli_check.py::test_check_accepts_offline_flag tests/test_cli_check.py::test_check_incomplete_offline_scan_exits_two tests/test_cli_scan.py::test_focused_fs_json_and_sarif_default_to_stdout tests/test_output_formats.py::test_spdx_vulnerability_annotations_preserve_enrichment_and_compliance_metadata -q
- uv run pytest tests/test_api_scan_types.py tests/test_cli_check.py tests/test_output_formats.py tests/test_cli_scan.py::test_focused_fs_json_and_sarif_default_to_stdout -q
- uv run ruff check src/agent_bom/api/routes/scan.py src/agent_bom/output/spdx_fmt.py src/agent_bom/cli/_focused_commands.py src/agent_bom/cli/_check.py src/agent_bom/cli/_mcp_group.py tests/test_api_scan_types.py tests/test_output_formats.py tests/test_cli_check.py tests/test_cli_scan.py
- git diff --check

Refs #2920