### PR TITLE
feat(finops): cost chargeback/allocation tags + seasonal anomaly baselines

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -14307,7 +14307,7 @@
     },
     "/v1/observability/costs": {
       "get": {
-        "description": "Per-agent / per-model / per-provider LLM spend for the active tenant.\n\nSpend is derived from token counts on ingested OTel GenAI spans priced via\nthe open cost model (agent_bom.cost_model). Includes budget posture.",
+        "description": "Per-agent / per-model / per-provider / per-cost-center LLM spend.\n\nSpend is derived from token counts on ingested OTel GenAI spans priced via\nthe open cost model (agent_bom.cost_model). Includes budget posture and the\nchargeback/showback rollup ``by_cost_center`` (#2925). Pass ``cost_center``\nto scope the report (and budget) to one allocation unit, or ``tag`` to add a\n``by_tag`` showback slice for a freeform allocation tag.",
         "operationId": "get_llm_costs_v1_observability_costs_get",
         "parameters": [
           {
@@ -14324,6 +14324,38 @@
                 }
               ],
               "title": "Agent"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cost_center",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cost Center"
+            }
+          },
+          {
+            "in": "query",
+            "name": "tag",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tag"
             }
           },
           {
@@ -14418,7 +14450,7 @@
     },
     "/v1/observability/costs/budget": {
       "get": {
-        "description": "Return the configured spend budget and current utilization.",
+        "description": "Return the configured spend budget and current utilization.\n\nPass ``cost_center`` to read a chargeback budget scoped to one allocation\nunit (#2925) instead of the per-agent / tenant-wide cap.",
         "operationId": "get_llm_cost_budget_v1_observability_costs_budget_get",
         "parameters": [
           {
@@ -14428,6 +14460,16 @@
             "schema": {
               "default": "",
               "title": "Agent",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cost_center",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Cost Center",
               "type": "string"
             }
           },
@@ -14511,7 +14553,7 @@
         ]
       },
       "put": {
-        "description": "Set a tenant (or per-agent) USD spend cap. Body: {limit_usd, agent?}.",
+        "description": "Set a USD spend cap. Body: {limit_usd, agent?, cost_center?, mode?}.\n\nA ``cost_center`` scopes the cap to one chargeback unit (#2925); ``agent``\nscopes it to one agent; neither means tenant-wide. ``agent`` and\n``cost_center`` are mutually exclusive.",
         "operationId": "set_llm_cost_budget_v1_observability_costs_budget_put",
         "parameters": [
           {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -9281,13 +9281,19 @@ paths:
       - finops
   /v1/observability/costs:
     get:
-      description: 'Per-agent / per-model / per-provider LLM spend for the active
-        tenant.
+      description: 'Per-agent / per-model / per-provider / per-cost-center LLM spend.
 
 
         Spend is derived from token counts on ingested OTel GenAI spans priced via
 
-        the open cost model (agent_bom.cost_model). Includes budget posture.'
+        the open cost model (agent_bom.cost_model). Includes budget posture and the
+
+        chargeback/showback rollup ``by_cost_center`` (#2925). Pass ``cost_center``
+
+        to scope the report (and budget) to one allocation unit, or ``tag`` to add
+        a
+
+        ``by_tag`` showback slice for a freeform allocation tag.'
       operationId: get_llm_costs_v1_observability_costs_get
       parameters:
       - in: query
@@ -9298,6 +9304,22 @@ paths:
           - type: string
           - type: 'null'
           title: Agent
+      - in: query
+        name: cost_center
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Cost Center
+      - in: query
+        name: tag
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tag
       - in: query
         name: limit
         required: false
@@ -9350,7 +9372,12 @@ paths:
       - finops
   /v1/observability/costs/budget:
     get:
-      description: Return the configured spend budget and current utilization.
+      description: 'Return the configured spend budget and current utilization.
+
+
+        Pass ``cost_center`` to read a chargeback budget scoped to one allocation
+
+        unit (#2925) instead of the per-agent / tenant-wide cap.'
       operationId: get_llm_cost_budget_v1_observability_costs_budget_get
       parameters:
       - in: query
@@ -9359,6 +9386,13 @@ paths:
         schema:
           default: ''
           title: Agent
+          type: string
+      - in: query
+        name: cost_center
+        required: false
+        schema:
+          default: ''
+          title: Cost Center
           type: string
       - in: header
         name: X-Agent-Bom-Role
@@ -9405,7 +9439,14 @@ paths:
       - observability
       - finops
     put:
-      description: 'Set a tenant (or per-agent) USD spend cap. Body: {limit_usd, agent?}.'
+      description: 'Set a USD spend cap. Body: {limit_usd, agent?, cost_center?, mode?}.
+
+
+        A ``cost_center`` scopes the cap to one chargeback unit (#2925); ``agent``
+
+        scopes it to one agent; neither means tenant-wide. ``agent`` and
+
+        ``cost_center`` are mutually exclusive.'
       operationId: set_llm_cost_budget_v1_observability_costs_budget_put
       parameters:
       - in: header

--- a/src/agent_bom/api/anomaly.py
+++ b/src/agent_bom/api/anomaly.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import threading
 import time
 from collections import defaultdict
+from datetime import datetime, timezone
 from typing import Any
 
 # Modified z-score (median + MAD) threshold. Robust to the outlier inflating its
@@ -21,6 +22,15 @@ from typing import Any
 DEFAULT_Z_THRESHOLD = 3.5
 _MIN_SAMPLES = 4
 _MAD_SCALE = 0.6745  # 0.75 quantile of the standard normal
+
+# Temporal (seasonal) baseline tuning (#2926). A spike is judged against the
+# agent's OWN history bucketed by (day-of-week, hour) so a predictable nightly
+# batch job is not flagged, while a slow creep above the agent's normal level
+# for that time slot is. EWMA gives recent buckets more weight; the seasonal
+# arm compares "this slot now" to "this slot historically".
+_TEMPORAL_MIN_BUCKETS = 6  # need some history before judging temporally
+_TEMPORAL_EWMA_ALPHA = 0.3  # weight of the newest bucket in the running mean
+_TEMPORAL_RATIO_THRESHOLD = 3.0  # latest >= 3x the seasonal baseline -> spike
 
 
 def _median(values: list[float]) -> float:
@@ -99,15 +109,139 @@ def detect_behavior_anomalies(calls_by_session: dict[str, int], *, z_threshold: 
     return sorted(out, key=lambda a: a["z_score"], reverse=True)
 
 
+def _parse_bucket(observed_at: str) -> tuple[int, int] | None:
+    """Return the (day-of-week, hour) seasonal bucket for an ISO timestamp.
+
+    Day-of-week is 0=Monday..6=Sunday; hour is 0..23 in UTC. Unparseable or
+    empty timestamps are skipped (return None) so they never corrupt a baseline.
+    """
+    raw = (observed_at or "").strip()
+    if not raw:
+        return None
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    dt = dt.astimezone(timezone.utc)
+    return dt.weekday(), dt.hour
+
+
+def detect_temporal_cost_anomalies(
+    cost_series_by_agent: dict[str, list[tuple[str, float]]],
+    *,
+    ratio_threshold: float = _TEMPORAL_RATIO_THRESHOLD,
+) -> list[dict[str, Any]]:
+    """Flag agents spiking against their OWN seasonal history (#2926).
+
+    For each agent the per-call costs are bucketed by (day-of-week, hour) using
+    the call timestamp, then summed per chronological bucket. Two signals back
+    the verdict:
+
+    - **seasonal-naive**: the latest bucket vs the EWMA of *prior occurrences of
+      the same (day, hour) slot* — a predictable nightly peak has a high slot
+      baseline, so it stays quiet.
+    - **EWMA creep**: the latest bucket vs the EWMA of *all prior buckets* —
+      catches a slow upward drift that no single z-score flags.
+
+    A spike is reported only when the latest bucket exceeds ``ratio_threshold``x
+    a non-trivial baseline. No peer comparison here; this is purely temporal and
+    complements the cross-sectional :func:`detect_cost_anomalies`.
+    """
+    out: list[dict[str, Any]] = []
+    for agent, series in cost_series_by_agent.items():
+        if not agent:
+            continue
+        # Order by timestamp, drop unparseable rows, key each row to its slot.
+        rows: list[tuple[str, tuple[int, int], float]] = []
+        for observed_at, cost in series:
+            bucket = _parse_bucket(observed_at)
+            if bucket is None:
+                continue
+            rows.append((observed_at, bucket, float(cost)))
+        if len(rows) < _TEMPORAL_MIN_BUCKETS:
+            continue
+        rows.sort(key=lambda r: r[0])
+
+        # Collapse consecutive calls sharing one (timestamp-truncated) slot into
+        # per-occurrence totals so a busy hour reads as one observation.
+        occurrences: list[tuple[str, tuple[int, int], float]] = []
+        for observed_at, bucket, cost in rows:
+            slot_key = observed_at[:13]  # ISO hour granularity: YYYY-MM-DDTHH
+            if occurrences and occurrences[-1][0][:13] == slot_key and occurrences[-1][1] == bucket:
+                prev = occurrences[-1]
+                occurrences[-1] = (prev[0], prev[1], prev[2] + cost)
+            else:
+                occurrences.append((observed_at, bucket, cost))
+        if len(occurrences) < _TEMPORAL_MIN_BUCKETS:
+            continue
+
+        latest_ts, latest_bucket, latest_cost = occurrences[-1]
+        history = occurrences[:-1]
+
+        # Seasonal-naive baseline: EWMA over prior occurrences of the same slot.
+        same_slot = [c for _, b, c in history if b == latest_bucket]
+        seasonal_baseline = _ewma(same_slot) if same_slot else None
+        # A value in line with its own slot history is "predictable" (e.g. a
+        # nightly batch) — it must not be flagged even though it dwarfs the
+        # agent's overall average. The seasonal arm has authority over the
+        # cross-slot EWMA creep arm.
+        in_seasonal_pattern = seasonal_baseline is not None and seasonal_baseline > 0 and latest_cost < ratio_threshold * seasonal_baseline
+        # EWMA creep baseline: EWMA over every prior occurrence.
+        creep_baseline = _ewma([c for _, _, c in history])
+
+        signals: list[str] = []
+        ratios: dict[str, float] = {}
+        if seasonal_baseline is not None and seasonal_baseline > 0 and latest_cost >= ratio_threshold * seasonal_baseline:
+            signals.append("seasonal")
+            ratios["seasonal_ratio"] = round(latest_cost / seasonal_baseline, 2)
+        if not in_seasonal_pattern and creep_baseline > 0 and latest_cost >= ratio_threshold * creep_baseline:
+            signals.append("ewma_creep")
+            ratios["ewma_ratio"] = round(latest_cost / creep_baseline, 2)
+        if not signals:
+            continue
+        out.append(
+            {
+                "type": "temporal_cost_spike",
+                "severity": "high" if len(signals) == 2 else "medium",
+                "agent": agent,
+                "metric": "bucket_cost_usd",
+                "value": round(latest_cost, 6),
+                "bucket": {"day_of_week": latest_bucket[0], "hour": latest_bucket[1]},
+                "seasonal_baseline": round(seasonal_baseline, 6) if seasonal_baseline is not None else None,
+                "ewma_baseline": round(creep_baseline, 6),
+                "signals": signals,
+                **ratios,
+                "recommendation": "Spend is anomalous vs this agent's own time-of-day history; review for a creep or a one-off surge.",
+            }
+        )
+    return sorted(out, key=lambda a: a.get("ewma_ratio", a.get("seasonal_ratio", 0.0)), reverse=True)
+
+
+def _ewma(values: list[float], *, alpha: float = _TEMPORAL_EWMA_ALPHA) -> float:
+    """Exponentially weighted moving average; newest value weighted ``alpha``."""
+    if not values:
+        return 0.0
+    avg = values[0]
+    for v in values[1:]:
+        avg = alpha * v + (1 - alpha) * avg
+    return avg
+
+
 def scan_anomalies(tenant_id: str, *, z_threshold: float = DEFAULT_Z_THRESHOLD) -> dict[str, Any]:
     """Run cost + behavior anomaly detection for a tenant from persisted stores."""
     from agent_bom.api.cost_store import get_cost_store
     from agent_bom.api.runtime_event_store import get_runtime_event_store
 
     spend_by_agent: dict[str, float] = defaultdict(float)
+    cost_series_by_agent: dict[str, list[tuple[str, float]]] = defaultdict(list)
     for rec in get_cost_store().list_records(tenant_id, limit=10000):
         if rec.agent:
             spend_by_agent[rec.agent] += rec.cost_usd
+            cost_series_by_agent[rec.agent].append((rec.observed_at, rec.cost_usd))
 
     calls_by_session: dict[str, int] = {}
     for session in get_runtime_event_store().list_sessions(tenant_id, limit=1000):
@@ -118,13 +252,15 @@ def scan_anomalies(tenant_id: str, *, z_threshold: float = DEFAULT_Z_THRESHOLD) 
 
     cost = detect_cost_anomalies(dict(spend_by_agent), z_threshold=z_threshold)
     behavior = detect_behavior_anomalies(calls_by_session, z_threshold=z_threshold)
+    temporal = detect_temporal_cost_anomalies(dict(cost_series_by_agent))
     return {
         "schema_version": "observability.anomalies.v1",
         "tenant_id": tenant_id,
         "z_threshold": z_threshold,
         "cost_anomalies": cost,
+        "temporal_cost_anomalies": temporal,
         "behavior_anomalies": behavior,
-        "anomaly_count": len(cost) + len(behavior),
+        "anomaly_count": len(cost) + len(behavior) + len(temporal),
     }
 
 

--- a/src/agent_bom/api/cost_store.py
+++ b/src/agent_bom/api/cost_store.py
@@ -9,11 +9,12 @@ accountability layer commercial agent-runtime products charge for, kept open.
 
 from __future__ import annotations
 
+import json
 import os
 import sqlite3
 import threading
 from collections import defaultdict
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Any, Protocol
 
 from agent_bom.api.storage_schema import ensure_sqlite_schema_version
@@ -21,7 +22,14 @@ from agent_bom.api.storage_schema import ensure_sqlite_schema_version
 
 @dataclass(frozen=True)
 class LLMCostRecord:
-    """One priced LLM API call."""
+    """One priced LLM API call.
+
+    ``cost_center`` and ``allocation_tags`` carry the showback/chargeback
+    dimension (#2925): which team / budget unit a call belongs to. Both are
+    optional and default empty so older ingest paths and pre-migration rows
+    stay valid — spend without an allocation simply rolls up under
+    ``"unallocated"``.
+    """
 
     tenant_id: str
     call_id: str
@@ -34,6 +42,8 @@ class LLMCostRecord:
     cost_usd: float
     priced: bool
     observed_at: str
+    cost_center: str = ""
+    allocation_tags: dict[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -54,18 +64,66 @@ class CostBudget:
     limit_usd: float
     updated_at: str
     mode: str = "report"  # report | enforce
+    cost_center: str = ""  # "" means not scoped to a cost center (#2925)
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
 
+_UNALLOCATED = "unallocated"
+
+
+def _decode_tags(raw: Any) -> dict[str, str]:
+    """Parse a stored allocation_tags JSON blob into a string->string dict.
+
+    Tolerant of NULL / malformed rows (pre-migration data) — those become {}.
+    """
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw) if isinstance(raw, (str, bytes)) else raw
+    except (ValueError, TypeError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {str(k): str(v) for k, v in parsed.items()}
+
+
 def _rollup(records: list[LLMCostRecord], dimension: str) -> list[dict[str, Any]]:
-    """Aggregate spend + tokens by one dimension (agent/model/provider)."""
+    """Aggregate spend + tokens by one dimension (agent/model/provider/cost_center)."""
     buckets: dict[str, dict[str, Any]] = defaultdict(
         lambda: {"key": "", "calls": 0, "input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0, "unpriced_calls": 0}
     )
     for r in records:
-        key = {"agent": r.agent, "model": r.model, "provider": r.provider}.get(dimension, r.agent) or "unknown"
+        key = {
+            "agent": r.agent,
+            "model": r.model,
+            "provider": r.provider,
+            "cost_center": r.cost_center or _UNALLOCATED,
+        }.get(dimension, r.agent) or "unknown"
+        b = buckets[key]
+        b["key"] = key
+        b["calls"] += 1
+        b["input_tokens"] += r.input_tokens
+        b["output_tokens"] += r.output_tokens
+        b["cost_usd"] = round(b["cost_usd"] + r.cost_usd, 6)
+        if not r.priced:
+            b["unpriced_calls"] += 1
+    return sorted(buckets.values(), key=lambda b: b["cost_usd"], reverse=True)
+
+
+def _rollup_by_tag(records: list[LLMCostRecord], tag_key: str) -> list[dict[str, Any]]:
+    """Aggregate spend + tokens by the value of one allocation tag.
+
+    A call with no value for ``tag_key`` rolls up under ``"unallocated"``. Used
+    for freeform showback dimensions (``team``, ``project``, ``env`` …) beyond
+    the first-class ``cost_center``.
+    """
+    buckets: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {"key": "", "calls": 0, "input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0, "unpriced_calls": 0}
+    )
+    for r in records:
+        key = (r.allocation_tags.get(tag_key) or "").strip() or _UNALLOCATED
         b = buckets[key]
         b["key"] = key
         b["calls"] += 1
@@ -84,9 +142,11 @@ class CostStore(Protocol):
 
     def total_spend(self, tenant_id: str, *, agent: str | None = None) -> float: ...
 
+    def total_spend_by_cost_center(self, tenant_id: str, cost_center: str) -> float: ...
+
     def set_budget(self, budget: CostBudget) -> None: ...
 
-    def get_budget(self, tenant_id: str, agent: str = "") -> CostBudget | None: ...
+    def get_budget(self, tenant_id: str, agent: str = "", *, cost_center: str = "") -> CostBudget | None: ...
 
 
 def summarize(records: list[LLMCostRecord]) -> dict[str, Any]:
@@ -101,6 +161,16 @@ def summarize(records: list[LLMCostRecord]) -> dict[str, Any]:
         "by_agent": _rollup(records, "agent"),
         "by_model": _rollup(records, "model"),
         "by_provider": _rollup(records, "provider"),
+        "by_cost_center": _rollup(records, "cost_center"),
+    }
+
+
+def summarize_by_tag(records: list[LLMCostRecord], tag_key: str) -> dict[str, Any]:
+    """Showback report sliced by one freeform allocation tag (#2925)."""
+    return {
+        "tag_key": tag_key,
+        "total_cost_usd": round(sum(r.cost_usd for r in records), 6),
+        "by_tag": _rollup_by_tag(records, tag_key),
     }
 
 
@@ -119,6 +189,7 @@ def budget_status(spend: float, budget: CostBudget | None) -> dict[str, Any]:
     return {
         "configured": True,
         "agent": budget.agent or None,
+        "cost_center": budget.cost_center or None,
         "mode": budget.mode,
         "limit_usd": budget.limit_usd,
         "spend_usd": round(spend, 6),
@@ -134,7 +205,7 @@ class InMemoryCostStore:
     def __init__(self) -> None:
         self._records: dict[str, list[LLMCostRecord]] = defaultdict(list)
         self._seen: dict[str, set[str]] = defaultdict(set)
-        self._budgets: dict[tuple[str, str], CostBudget] = {}
+        self._budgets: dict[tuple[str, str, str], CostBudget] = {}
         self._lock = threading.Lock()
 
     def record_cost(self, record: LLMCostRecord) -> None:
@@ -155,13 +226,20 @@ class InMemoryCostStore:
                 6,
             )
 
+    def total_spend_by_cost_center(self, tenant_id: str, cost_center: str) -> float:
+        with self._lock:
+            return round(
+                sum(r.cost_usd for r in self._records.get(tenant_id, []) if (r.cost_center or "") == cost_center),
+                6,
+            )
+
     def set_budget(self, budget: CostBudget) -> None:
         with self._lock:
-            self._budgets[(budget.tenant_id, budget.agent)] = budget
+            self._budgets[(budget.tenant_id, budget.agent, budget.cost_center)] = budget
 
-    def get_budget(self, tenant_id: str, agent: str = "") -> CostBudget | None:
+    def get_budget(self, tenant_id: str, agent: str = "", *, cost_center: str = "") -> CostBudget | None:
         with self._lock:
-            return self._budgets.get((tenant_id, agent))
+            return self._budgets.get((tenant_id, agent, cost_center))
 
 
 class SQLiteCostStore:
@@ -194,6 +272,8 @@ class SQLiteCostStore:
                 cost_usd REAL NOT NULL,
                 priced INTEGER NOT NULL,
                 observed_at TEXT NOT NULL,
+                cost_center TEXT NOT NULL DEFAULT '',
+                allocation_tags TEXT NOT NULL DEFAULT '{}',
                 PRIMARY KEY (tenant_id, call_id)
             )
             """
@@ -206,23 +286,35 @@ class SQLiteCostStore:
                 limit_usd REAL NOT NULL,
                 updated_at TEXT NOT NULL,
                 mode TEXT NOT NULL DEFAULT 'report',
-                PRIMARY KEY (tenant_id, agent)
+                cost_center TEXT NOT NULL DEFAULT '',
+                PRIMARY KEY (tenant_id, agent, cost_center)
             )
             """
         )
         # Backfill mode for databases created before enforcement existed.
-        cols = [r[1] for r in self._conn.execute("PRAGMA table_info(llm_cost_budgets)").fetchall()]
-        if "mode" not in cols:
+        budget_cols = [r[1] for r in self._conn.execute("PRAGMA table_info(llm_cost_budgets)").fetchall()]
+        if "mode" not in budget_cols:
             self._conn.execute("ALTER TABLE llm_cost_budgets ADD COLUMN mode TEXT NOT NULL DEFAULT 'report'")
+        # Allocation columns (#2925) added additively; pre-migration rows keep
+        # an empty cost_center / '{}' tags and roll up under "unallocated".
+        if "cost_center" not in budget_cols:
+            self._conn.execute("ALTER TABLE llm_cost_budgets ADD COLUMN cost_center TEXT NOT NULL DEFAULT ''")
+        cost_cols = [r[1] for r in self._conn.execute("PRAGMA table_info(llm_costs)").fetchall()]
+        if "cost_center" not in cost_cols:
+            self._conn.execute("ALTER TABLE llm_costs ADD COLUMN cost_center TEXT NOT NULL DEFAULT ''")
+        if "allocation_tags" not in cost_cols:
+            self._conn.execute("ALTER TABLE llm_costs ADD COLUMN allocation_tags TEXT NOT NULL DEFAULT '{}'")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_llm_costs_tenant_agent ON llm_costs(tenant_id, agent)")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_llm_costs_tenant_cost_center ON llm_costs(tenant_id, cost_center)")
         self._conn.commit()
 
     def record_cost(self, record: LLMCostRecord) -> None:
         self._conn.execute(
             """
             INSERT OR IGNORE INTO llm_costs
-                (tenant_id, call_id, agent, session_id, provider, model, input_tokens, output_tokens, cost_usd, priced, observed_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                (tenant_id, call_id, agent, session_id, provider, model, input_tokens, output_tokens,
+                 cost_usd, priced, observed_at, cost_center, allocation_tags)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 record.tenant_id,
@@ -236,17 +328,44 @@ class SQLiteCostStore:
                 record.cost_usd,
                 int(record.priced),
                 record.observed_at,
+                record.cost_center,
+                json.dumps(record.allocation_tags, sort_keys=True),
             ),
         )
         self._conn.commit()
 
     def list_records(self, tenant_id: str, *, limit: int = 1000) -> list[LLMCostRecord]:
         rows = self._conn.execute(
-            "SELECT tenant_id, call_id, agent, session_id, provider, model, input_tokens, output_tokens, cost_usd, priced, observed_at "
+            "SELECT tenant_id, call_id, agent, session_id, provider, model, input_tokens, output_tokens, "
+            "cost_usd, priced, observed_at, cost_center, allocation_tags "
             "FROM llm_costs WHERE tenant_id = ? ORDER BY observed_at DESC LIMIT ?",
             (tenant_id, limit),
         ).fetchall()
-        return [LLMCostRecord(r[0], r[1], r[2], r[3], r[4], r[5], int(r[6]), int(r[7]), float(r[8]), bool(r[9]), r[10]) for r in rows]
+        return [
+            LLMCostRecord(
+                r[0],
+                r[1],
+                r[2],
+                r[3],
+                r[4],
+                r[5],
+                int(r[6]),
+                int(r[7]),
+                float(r[8]),
+                bool(r[9]),
+                r[10],
+                r[11] if len(r) > 11 and r[11] is not None else "",
+                _decode_tags(r[12] if len(r) > 12 else None),
+            )
+            for r in rows
+        ]
+
+    def total_spend_by_cost_center(self, tenant_id: str, cost_center: str) -> float:
+        row = self._conn.execute(
+            "SELECT COALESCE(SUM(cost_usd), 0.0) FROM llm_costs WHERE tenant_id = ? AND cost_center = ?",
+            (tenant_id, cost_center),
+        ).fetchone()
+        return round(float(row[0]), 6)
 
     def total_spend(self, tenant_id: str, *, agent: str | None = None) -> float:
         if agent:
@@ -259,17 +378,28 @@ class SQLiteCostStore:
 
     def set_budget(self, budget: CostBudget) -> None:
         self._conn.execute(
-            "INSERT OR REPLACE INTO llm_cost_budgets (tenant_id, agent, limit_usd, updated_at, mode) VALUES (?, ?, ?, ?, ?)",
-            (budget.tenant_id, budget.agent, budget.limit_usd, budget.updated_at, budget.mode),
+            "INSERT OR REPLACE INTO llm_cost_budgets (tenant_id, agent, limit_usd, updated_at, mode, cost_center) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (budget.tenant_id, budget.agent, budget.limit_usd, budget.updated_at, budget.mode, budget.cost_center),
         )
         self._conn.commit()
 
-    def get_budget(self, tenant_id: str, agent: str = "") -> CostBudget | None:
+    def get_budget(self, tenant_id: str, agent: str = "", *, cost_center: str = "") -> CostBudget | None:
         row = self._conn.execute(
-            "SELECT tenant_id, agent, limit_usd, updated_at, mode FROM llm_cost_budgets WHERE tenant_id = ? AND agent = ?",
-            (tenant_id, agent),
+            "SELECT tenant_id, agent, limit_usd, updated_at, mode, cost_center "
+            "FROM llm_cost_budgets WHERE tenant_id = ? AND agent = ? AND cost_center = ?",
+            (tenant_id, agent, cost_center),
         ).fetchone()
-        return CostBudget(row[0], row[1], float(row[2]), row[3], row[4] if len(row) > 4 else "report") if row else None
+        if not row:
+            return None
+        return CostBudget(
+            row[0],
+            row[1],
+            float(row[2]),
+            row[3],
+            row[4] if len(row) > 4 and row[4] else "report",
+            row[5] if len(row) > 5 and row[5] is not None else "",
+        )
 
 
 def check_budget_enforcement(store: CostStore, tenant_id: str, agent: str) -> tuple[bool, CostBudget | None, float]:
@@ -290,6 +420,22 @@ def check_budget_enforcement(store: CostStore, tenant_id: str, agent: str) -> tu
             return False, budget, spend
     blocked = budget is not None and budget.mode == "enforce" and spend >= budget.limit_usd
     return blocked, budget, spend
+
+
+def check_cost_center_budget_enforcement(store: CostStore, tenant_id: str, cost_center: str) -> tuple[bool, CostBudget | None, float]:
+    """Decide whether a call should block for exceeding a cost-center budget (#2925).
+
+    A cost-center scoped enforce budget caps the aggregate spend of every call
+    tagged to that ``cost_center``, independent of the per-agent / tenant caps.
+    Report-mode and missing budgets never block.
+    """
+    if not cost_center:
+        return False, None, 0.0
+    budget = store.get_budget(tenant_id, "", cost_center=cost_center)
+    spend = store.total_spend_by_cost_center(tenant_id, cost_center)
+    if budget is None or budget.mode != "enforce":
+        return False, budget, spend
+    return spend >= budget.limit_usd, budget, spend
 
 
 _COST_STORE: CostStore | None = None

--- a/src/agent_bom/api/postgres_cost.py
+++ b/src/agent_bom/api/postgres_cost.py
@@ -10,7 +10,9 @@ via :class:`PostgresRateLimitStore`; cost governance must match).
 
 from __future__ import annotations
 
-from agent_bom.api.cost_store import CostBudget, LLMCostRecord
+import json
+
+from agent_bom.api.cost_store import CostBudget, LLMCostRecord, _decode_tags
 from agent_bom.api.postgres_common import _ensure_tenant_rls, _get_pool, _tenant_connection
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
 
@@ -38,21 +40,34 @@ class PostgresCostStore:
                     cost_usd      DOUBLE PRECISION NOT NULL,
                     priced        BOOLEAN NOT NULL,
                     observed_at   TEXT NOT NULL,
+                    cost_center     TEXT NOT NULL DEFAULT '',
+                    allocation_tags TEXT NOT NULL DEFAULT '{}',
                     PRIMARY KEY (tenant_id, call_id)
                 )
             """)
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS llm_cost_budgets (
-                    tenant_id  TEXT NOT NULL,
-                    agent      TEXT NOT NULL DEFAULT '',
-                    limit_usd  DOUBLE PRECISION NOT NULL,
-                    updated_at TEXT NOT NULL,
-                    mode       TEXT NOT NULL DEFAULT 'report',
-                    PRIMARY KEY (tenant_id, agent)
+                    tenant_id   TEXT NOT NULL,
+                    agent       TEXT NOT NULL DEFAULT '',
+                    limit_usd   DOUBLE PRECISION NOT NULL,
+                    updated_at  TEXT NOT NULL,
+                    mode        TEXT NOT NULL DEFAULT 'report',
+                    cost_center TEXT NOT NULL DEFAULT '',
+                    PRIMARY KEY (tenant_id, agent, cost_center)
                 )
             """)
+            # Allocation columns (#2925) added additively for pre-migration
+            # databases; existing rows default to '' / '{}' (unallocated).
+            conn.execute("ALTER TABLE llm_costs ADD COLUMN IF NOT EXISTS cost_center TEXT NOT NULL DEFAULT ''")
+            conn.execute("ALTER TABLE llm_costs ADD COLUMN IF NOT EXISTS allocation_tags TEXT NOT NULL DEFAULT '{}'")
+            conn.execute("ALTER TABLE llm_cost_budgets ADD COLUMN IF NOT EXISTS cost_center TEXT NOT NULL DEFAULT ''")
+            # Back the (tenant, agent, cost_center) upsert conflict target with a
+            # unique index so it works on pre-migration tables whose PK was only
+            # (tenant_id, agent).
+            conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS uq_llm_cost_budgets_scope ON llm_cost_budgets(tenant_id, agent, cost_center)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_llm_costs_tenant_agent ON llm_costs(tenant_id, agent)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_llm_costs_tenant_observed ON llm_costs(tenant_id, observed_at DESC)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_llm_costs_tenant_cost_center ON llm_costs(tenant_id, cost_center)")
             _ensure_tenant_rls(conn, "llm_costs", "tenant_id")
             _ensure_tenant_rls(conn, "llm_cost_budgets", "tenant_id")
             conn.commit()
@@ -63,8 +78,9 @@ class PostgresCostStore:
                 """
                 INSERT INTO llm_costs
                     (tenant_id, call_id, agent, session_id, provider, model,
-                     input_tokens, output_tokens, cost_usd, priced, observed_at)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                     input_tokens, output_tokens, cost_usd, priced, observed_at,
+                     cost_center, allocation_tags)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (tenant_id, call_id) DO NOTHING
                 """,
                 (
@@ -79,6 +95,8 @@ class PostgresCostStore:
                     record.cost_usd,
                     record.priced,
                     record.observed_at,
+                    record.cost_center,
+                    json.dumps(record.allocation_tags, sort_keys=True),
                 ),
             )
             conn.commit()
@@ -87,7 +105,8 @@ class PostgresCostStore:
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute(
                 "SELECT tenant_id, call_id, agent, session_id, provider, model, "
-                "input_tokens, output_tokens, cost_usd, priced, observed_at "
+                "input_tokens, output_tokens, cost_usd, priced, observed_at, "
+                "cost_center, allocation_tags "
                 "FROM llm_costs WHERE tenant_id = %s ORDER BY observed_at DESC LIMIT %s",
                 (tenant_id, limit),
             ).fetchall()
@@ -104,9 +123,19 @@ class PostgresCostStore:
                 float(r[8]),
                 bool(r[9]),
                 r[10],
+                r[11] if len(r) > 11 and r[11] is not None else "",
+                _decode_tags(r[12] if len(r) > 12 else None),
             )
             for r in rows
         ]
+
+    def total_spend_by_cost_center(self, tenant_id: str, cost_center: str) -> float:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                "SELECT COALESCE(SUM(cost_usd), 0.0) FROM llm_costs WHERE tenant_id = %s AND cost_center = %s",
+                (tenant_id, cost_center),
+            ).fetchone()
+        return round(float(row[0]), 6) if row else 0.0
 
     def total_spend(self, tenant_id: str, *, agent: str | None = None) -> float:
         with _tenant_connection(self._pool) as conn:
@@ -126,21 +155,24 @@ class PostgresCostStore:
         with _tenant_connection(self._pool) as conn:
             conn.execute(
                 """
-                INSERT INTO llm_cost_budgets (tenant_id, agent, limit_usd, updated_at, mode)
-                VALUES (%s, %s, %s, %s, %s)
-                ON CONFLICT (tenant_id, agent)
+                INSERT INTO llm_cost_budgets (tenant_id, agent, limit_usd, updated_at, mode, cost_center)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                ON CONFLICT (tenant_id, agent, cost_center)
                 DO UPDATE SET limit_usd = EXCLUDED.limit_usd,
                               updated_at = EXCLUDED.updated_at,
                               mode = EXCLUDED.mode
                 """,
-                (budget.tenant_id, budget.agent, budget.limit_usd, budget.updated_at, budget.mode),
+                (budget.tenant_id, budget.agent, budget.limit_usd, budget.updated_at, budget.mode, budget.cost_center),
             )
             conn.commit()
 
-    def get_budget(self, tenant_id: str, agent: str = "") -> CostBudget | None:
+    def get_budget(self, tenant_id: str, agent: str = "", *, cost_center: str = "") -> CostBudget | None:
         with _tenant_connection(self._pool) as conn:
             row = conn.execute(
-                "SELECT tenant_id, agent, limit_usd, updated_at, mode FROM llm_cost_budgets WHERE tenant_id = %s AND agent = %s",
-                (tenant_id, agent),
+                "SELECT tenant_id, agent, limit_usd, updated_at, mode, cost_center "
+                "FROM llm_cost_budgets WHERE tenant_id = %s AND agent = %s AND cost_center = %s",
+                (tenant_id, agent, cost_center),
             ).fetchone()
-        return CostBudget(row[0], row[1], float(row[2]), row[3], row[4]) if row else None
+        if not row:
+            return None
+        return CostBudget(row[0], row[1], float(row[2]), row[3], row[4], row[5] if len(row) > 5 and row[5] is not None else "")

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -290,11 +290,75 @@ def _persist_runtime_observations(events: list[dict[str, Any]], *, tenant_id: st
     return count
 
 
+# OTel attribute keys carrying the chargeback/showback allocation (#2925).
+# ``agent.cost_center`` / ``gen_ai.cost_center`` name the budget unit; any
+# ``allocation.tag.<name>`` attribute becomes a freeform showback tag.
+_COST_CENTER_KEYS = ("agent.cost_center", "gen_ai.cost_center", "cost_center")
+_ALLOCATION_TAG_PREFIX = "allocation.tag."
+_MAX_ALLOCATION_TAGS = 16
+
+
+def _attr_str(attr_value: Any) -> str:
+    if not isinstance(attr_value, dict):
+        return ""
+    return str(attr_value.get("stringValue") or attr_value.get("intValue") or attr_value.get("doubleValue") or "").strip()
+
+
+def _allocation_for_spans(body: dict) -> dict[str, tuple[str, dict[str, str]]]:
+    """Map ``trace_id:span_id`` -> (cost_center, allocation_tags) from OTLP attrs.
+
+    Span-level attributes win over resource-level ones, so a per-call override
+    beats a service-wide default. Tolerant of any non-OTLP shape (returns {}).
+    """
+    out: dict[str, tuple[str, dict[str, str]]] = {}
+    try:
+        resource_spans = body.get("resourceSpans") if isinstance(body, dict) else None
+        if not isinstance(resource_spans, list):
+            return out
+        for rs in resource_spans:
+            res_cc, res_tags = _read_allocation_attrs(rs.get("resource", {}).get("attributes", []) if isinstance(rs, dict) else [])
+            for ss in rs.get("scopeSpans", []) if isinstance(rs, dict) else []:
+                for span in ss.get("spans", []) if isinstance(ss, dict) else []:
+                    if not isinstance(span, dict):
+                        continue
+                    span_cc, span_tags = _read_allocation_attrs(span.get("attributes", []))
+                    merged_tags = {**res_tags, **span_tags}
+                    cost_center = span_cc or res_cc
+                    call_id = f"{span.get('traceId', '')}:{span.get('spanId', '')}"
+                    out[call_id] = (cost_center, merged_tags)
+    except Exception:  # noqa: BLE001
+        return {}
+    return out
+
+
+def _read_allocation_attrs(attributes: Any) -> tuple[str, dict[str, str]]:
+    cost_center = ""
+    tags: dict[str, str] = {}
+    if not isinstance(attributes, list):
+        return cost_center, tags
+    for attr in attributes:
+        if not isinstance(attr, dict):
+            continue
+        key = str(attr.get("key", "")).strip()
+        value = _attr_str(attr.get("value", {}))
+        if not key or not value:
+            continue
+        if key in _COST_CENTER_KEYS and not cost_center:
+            cost_center = _bounded(value, max_len=120)
+        elif key.startswith(_ALLOCATION_TAG_PREFIX) and len(tags) < _MAX_ALLOCATION_TAGS:
+            tag_name = _bounded(key[len(_ALLOCATION_TAG_PREFIX) :], max_len=60)
+            if tag_name:
+                tags[tag_name] = _bounded(value, max_len=120)
+    return cost_center, tags
+
+
 def _persist_llm_costs(body: dict, *, tenant_id: str) -> dict[str, Any]:
     """Price GenAI spans in an OTLP payload and persist per-call cost records.
 
     Token counts come from OTel GenAI semantic conventions; cost is the open
-    price model in agent_bom.cost_model. Failures never block trace ingest.
+    price model in agent_bom.cost_model. Chargeback allocation (cost_center +
+    allocation tags) is read from span/resource attributes. Failures never
+    block trace ingest.
     """
     try:
         from agent_bom.api.cost_store import LLMCostRecord, get_cost_store
@@ -306,6 +370,7 @@ def _persist_llm_costs(body: dict, *, tenant_id: str) -> dict[str, Any]:
         _logger.warning("LLM cost ingest skipped", exc_info=True)
         return {"calls": 0, "cost_usd": 0.0}
 
+    allocation = _allocation_for_spans(body)
     store = get_cost_store()
     total = 0.0
     observed = _now()
@@ -313,10 +378,12 @@ def _persist_llm_costs(body: dict, *, tenant_id: str) -> dict[str, Any]:
         cost = compute_cost_usd(call.provider, call.model_name, call.input_tokens, call.output_tokens)
         total += cost
         agent = _bounded(getattr(call, "agent", "") or "", max_len=120)
+        call_id = f"{call.trace_id}:{call.span_id}"
+        cost_center, allocation_tags = allocation.get(call_id, ("", {}))
         store.record_cost(
             LLMCostRecord(
                 tenant_id=tenant_id,
-                call_id=f"{call.trace_id}:{call.span_id}",
+                call_id=call_id,
                 agent=agent,
                 session_id=call.trace_id,
                 provider=_bounded(call.provider, max_len=60),
@@ -326,6 +393,8 @@ def _persist_llm_costs(body: dict, *, tenant_id: str) -> dict[str, Any]:
                 cost_usd=cost,
                 priced=is_priced(call.provider, call.model_name),
                 observed_at=observed,
+                cost_center=cost_center,
+                allocation_tags=allocation_tags,
             )
         )
     return {"calls": len(calls), "cost_usd": round(total, 6)}
@@ -678,13 +747,22 @@ async def prometheus_metrics(request: Request):
 
 
 @router.get("/v1/observability/costs", tags=["observability", "finops"], dependencies=[_dep("read")])
-async def get_llm_costs(request: Request, agent: str | None = None, limit: int = 1000) -> dict[str, object]:
-    """Per-agent / per-model / per-provider LLM spend for the active tenant.
+async def get_llm_costs(
+    request: Request,
+    agent: str | None = None,
+    cost_center: str | None = None,
+    tag: str | None = None,
+    limit: int = 1000,
+) -> dict[str, object]:
+    """Per-agent / per-model / per-provider / per-cost-center LLM spend.
 
     Spend is derived from token counts on ingested OTel GenAI spans priced via
-    the open cost model (agent_bom.cost_model). Includes budget posture.
+    the open cost model (agent_bom.cost_model). Includes budget posture and the
+    chargeback/showback rollup ``by_cost_center`` (#2925). Pass ``cost_center``
+    to scope the report (and budget) to one allocation unit, or ``tag`` to add a
+    ``by_tag`` showback slice for a freeform allocation tag.
     """
-    from agent_bom.api.cost_store import budget_status, get_cost_store, summarize
+    from agent_bom.api.cost_store import budget_status, get_cost_store, summarize, summarize_by_tag
 
     tenant_id = _tenant_id(request)
     store = get_cost_store()
@@ -692,11 +770,19 @@ async def get_llm_costs(request: Request, agent: str | None = None, limit: int =
     records = store.list_records(tenant_id, limit=bounded_limit)
     if agent:
         records = [r for r in records if r.agent == agent]
+    if cost_center:
+        records = [r for r in records if (r.cost_center or "") == cost_center]
     report = summarize(records)
-    spend = store.total_spend(tenant_id, agent=agent)
-    budget = store.get_budget(tenant_id, agent or "")
-    if budget is None and agent:
-        budget = store.get_budget(tenant_id, "")
+    if tag:
+        report["tag_rollup"] = summarize_by_tag(records, _bounded(tag, max_len=60))
+    if cost_center:
+        spend = store.total_spend_by_cost_center(tenant_id, cost_center)
+        budget = store.get_budget(tenant_id, "", cost_center=cost_center)
+    else:
+        spend = store.total_spend(tenant_id, agent=agent)
+        budget = store.get_budget(tenant_id, agent or "")
+        if budget is None and agent:
+            budget = store.get_budget(tenant_id, "")
     report["budget"] = budget_status(spend, budget)
     # Forward-looking companion to the point-in-time budget posture: burn rate +
     # projected runway derived from the same records. Reference only.
@@ -710,20 +796,33 @@ async def get_llm_costs(request: Request, agent: str | None = None, limit: int =
 
 
 @router.get("/v1/observability/costs/budget", tags=["observability", "finops"], dependencies=[_dep("read")])
-async def get_llm_cost_budget(request: Request, agent: str = "") -> dict[str, object]:
-    """Return the configured spend budget and current utilization."""
+async def get_llm_cost_budget(request: Request, agent: str = "", cost_center: str = "") -> dict[str, object]:
+    """Return the configured spend budget and current utilization.
+
+    Pass ``cost_center`` to read a chargeback budget scoped to one allocation
+    unit (#2925) instead of the per-agent / tenant-wide cap.
+    """
     from agent_bom.api.cost_store import budget_status, get_cost_store
 
     tenant_id = _tenant_id(request)
     store = get_cost_store()
-    budget = store.get_budget(tenant_id, agent)
-    spend = store.total_spend(tenant_id, agent=agent or None)
+    if cost_center:
+        budget = store.get_budget(tenant_id, "", cost_center=cost_center)
+        spend = store.total_spend_by_cost_center(tenant_id, cost_center)
+    else:
+        budget = store.get_budget(tenant_id, agent)
+        spend = store.total_spend(tenant_id, agent=agent or None)
     return {"schema_version": "observability.costs.v1", "tenant_id": tenant_id, **budget_status(spend, budget)}
 
 
 @router.put("/v1/observability/costs/budget", tags=["observability", "finops"], dependencies=[_dep("config")])
 async def set_llm_cost_budget(request: Request, body: dict) -> dict[str, object]:
-    """Set a tenant (or per-agent) USD spend cap. Body: {limit_usd, agent?}."""
+    """Set a USD spend cap. Body: {limit_usd, agent?, cost_center?, mode?}.
+
+    A ``cost_center`` scopes the cap to one chargeback unit (#2925); ``agent``
+    scopes it to one agent; neither means tenant-wide. ``agent`` and
+    ``cost_center`` are mutually exclusive.
+    """
     from agent_bom.api.cost_store import CostBudget, budget_status, get_cost_store
 
     tenant_id = _tenant_id(request)
@@ -737,17 +836,27 @@ async def set_llm_cost_budget(request: Request, body: dict) -> dict[str, object]
     if limit_usd < 0:
         raise HTTPException(status_code=400, detail="'limit_usd' must be non-negative")
     agent = _bounded(str(body.get("agent", "") or ""), max_len=120)
+    cost_center = _bounded(str(body.get("cost_center", "") or ""), max_len=120)
+    if agent and cost_center:
+        raise HTTPException(status_code=400, detail="'agent' and 'cost_center' budgets are mutually exclusive")
     mode = str(body.get("mode", "report") or "report").strip().lower()
     if mode not in ("report", "enforce"):
         raise HTTPException(status_code=400, detail="'mode' must be 'report' or 'enforce'")
     store = get_cost_store()
-    store.set_budget(CostBudget(tenant_id=tenant_id, agent=agent, limit_usd=limit_usd, updated_at=_now(), mode=mode))
-    spend = store.total_spend(tenant_id, agent=agent or None)
+    store.set_budget(
+        CostBudget(tenant_id=tenant_id, agent=agent, limit_usd=limit_usd, updated_at=_now(), mode=mode, cost_center=cost_center)
+    )
+    if cost_center:
+        spend = store.total_spend_by_cost_center(tenant_id, cost_center)
+        stored = store.get_budget(tenant_id, "", cost_center=cost_center)
+    else:
+        spend = store.total_spend(tenant_id, agent=agent or None)
+        stored = store.get_budget(tenant_id, agent)
     return {
         "schema_version": "observability.costs.v1",
         "tenant_id": tenant_id,
         "updated": True,
-        **budget_status(spend, store.get_budget(tenant_id, agent)),
+        **budget_status(spend, stored),
     }
 
 

--- a/tests/test_anomaly.py
+++ b/tests/test_anomaly.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import pytest
 from starlette.testclient import TestClient
 
-from agent_bom.api.anomaly import detect_behavior_anomalies, detect_cost_anomalies, scan_anomalies
+from agent_bom.api.anomaly import (
+    detect_behavior_anomalies,
+    detect_cost_anomalies,
+    detect_temporal_cost_anomalies,
+    scan_anomalies,
+)
 from agent_bom.api.cost_store import InMemoryCostStore, LLMCostRecord, set_cost_store
 from agent_bom.api.runtime_event_store import InMemoryRuntimeEventStore, set_runtime_event_store
 
@@ -30,6 +35,46 @@ def test_behavior_call_rate_spike():
     calls = {"s1": 5, "s2": 6, "s3": 4, "s4": 5, "s5": 500}
     anomalies = detect_behavior_anomalies(calls)
     assert any(x["session_id"] == "s5" and x["type"] == "call_rate_spike" for x in anomalies)
+
+
+# ── temporal / seasonal baselines (#2926) ────────────────────────────────────────
+
+
+def test_predictable_nightly_spike_is_not_flagged():
+    # Every night at 02:00 UTC the agent runs a big batch job (~$5), and during
+    # the day it is quiet (~$0.5). The latest night job is in-pattern, so the
+    # seasonal baseline absorbs it and it must NOT be flagged.
+    series = []
+    for day in range(1, 8):  # 7 days of history
+        series.append((f"2026-06-0{day}T02:00:00Z", 5.0))  # nightly batch
+        series.append((f"2026-06-0{day}T10:00:00Z", 0.5))  # daytime
+        series.append((f"2026-06-0{day}T14:00:00Z", 0.5))  # daytime
+    # latest occurrence is another in-pattern nightly batch
+    series.append(("2026-06-08T02:00:00Z", 5.2))
+    out = detect_temporal_cost_anomalies({"batch-agent": series})
+    assert out == []
+
+
+def test_slow_creep_is_flagged():
+    # Same 02:00 slot, but the latest run is a large surge over both the seasonal
+    # baseline for that slot AND the agent's overall EWMA -> flagged.
+    series = []
+    for day in range(1, 8):
+        series.append((f"2026-06-0{day}T02:00:00Z", 5.0))
+        series.append((f"2026-06-0{day}T10:00:00Z", 0.5))
+    series.append(("2026-06-08T02:00:00Z", 60.0))  # surge, ~12x the slot baseline
+    out = detect_temporal_cost_anomalies({"batch-agent": series})
+    assert len(out) == 1
+    spike = out[0]
+    assert spike["type"] == "temporal_cost_spike"
+    assert spike["agent"] == "batch-agent"
+    assert "seasonal" in spike["signals"]
+    assert spike["bucket"]["hour"] == 2
+
+
+def test_temporal_needs_minimum_history():
+    series = [("2026-06-01T02:00:00Z", 1.0), ("2026-06-01T03:00:00Z", 99.0)]
+    assert detect_temporal_cost_anomalies({"a": series}) == []
 
 
 @pytest.fixture()

--- a/tests/test_finops_costs.py
+++ b/tests/test_finops_costs.py
@@ -59,7 +59,7 @@ def test_operator_override(monkeypatch):
 # ── store + aggregation ─────────────────────────────────────────────────────────
 
 
-def _rec(agent="agent-a", model="gpt-4o", provider="openai", cost=1.0, call_id="c1", priced=True):
+def _rec(agent="agent-a", model="gpt-4o", provider="openai", cost=1.0, call_id="c1", priced=True, cost_center="", allocation_tags=None):
     return LLMCostRecord(
         tenant_id="t1",
         call_id=call_id,
@@ -72,6 +72,8 @@ def _rec(agent="agent-a", model="gpt-4o", provider="openai", cost=1.0, call_id="
         cost_usd=cost,
         priced=priced,
         observed_at="2026-06-01T00:00:00Z",
+        cost_center=cost_center,
+        allocation_tags=allocation_tags or {},
     )
 
 
@@ -102,6 +104,97 @@ def test_summarize_rollups():
     assert report["unpriced_calls"] == 1
     top_agent = report["by_agent"][0]
     assert top_agent["key"] == "a" and top_agent["cost_usd"] == 3.0
+
+
+# ── chargeback / showback allocation (#2925) ────────────────────────────────────
+
+
+def test_by_cost_center_rollup():
+    records = [
+        _rec(call_id="1", cost=2.0, cost_center="team-search"),
+        _rec(call_id="2", cost=3.0, cost_center="team-search"),
+        _rec(call_id="3", cost=1.0, cost_center="team-rag"),
+        _rec(call_id="4", cost=0.5),  # unallocated
+    ]
+    report = summarize(records)
+    by_cc = {b["key"]: b["cost_usd"] for b in report["by_cost_center"]}
+    assert by_cc["team-search"] == 5.0
+    assert by_cc["team-rag"] == 1.0
+    assert by_cc["unallocated"] == 0.5
+    # top bucket sorts by spend
+    assert report["by_cost_center"][0]["key"] == "team-search"
+
+
+def test_summarize_by_tag():
+    from agent_bom.api.cost_store import summarize_by_tag
+
+    records = [
+        _rec(call_id="1", cost=2.0, allocation_tags={"env": "prod"}),
+        _rec(call_id="2", cost=4.0, allocation_tags={"env": "prod"}),
+        _rec(call_id="3", cost=1.0, allocation_tags={"env": "dev"}),
+        _rec(call_id="4", cost=0.5),  # no env tag -> unallocated
+    ]
+    report = summarize_by_tag(records, "env")
+    assert report["tag_key"] == "env"
+    by_tag = {b["key"]: b["cost_usd"] for b in report["by_tag"]}
+    assert by_tag == {"prod": 6.0, "dev": 1.0, "unallocated": 0.5}
+
+
+def test_total_spend_by_cost_center():
+    store = InMemoryCostStore()
+    store.record_cost(_rec(call_id="1", cost=2.0, cost_center="team-a"))
+    store.record_cost(_rec(call_id="2", cost=3.0, cost_center="team-a"))
+    store.record_cost(_rec(call_id="3", cost=9.0, cost_center="team-b"))
+    assert store.total_spend_by_cost_center("t1", "team-a") == 5.0
+    assert store.total_spend_by_cost_center("t1", "team-b") == 9.0
+    assert store.total_spend_by_cost_center("t1", "team-missing") == 0.0
+
+
+def test_cost_center_budget_keyed_independently_of_agent():
+    store = InMemoryCostStore()
+    store.set_budget(CostBudget("t1", "", 10.0, "2026-06-02", "enforce", cost_center="team-a"))
+    store.set_budget(CostBudget("t1", "agent-x", 99.0, "2026-06-02", "report"))
+    cc_budget = store.get_budget("t1", "", cost_center="team-a")
+    assert cc_budget is not None and cc_budget.limit_usd == 10.0 and cc_budget.cost_center == "team-a"
+    # agent budget is a different key, untouched by the cost-center budget
+    agent_budget = store.get_budget("t1", "agent-x")
+    assert agent_budget is not None and agent_budget.limit_usd == 99.0
+
+
+def test_check_cost_center_budget_enforcement():
+    from agent_bom.api.cost_store import check_cost_center_budget_enforcement
+
+    store = InMemoryCostStore()
+    store.record_cost(_rec(call_id="1", cost=8.0, cost_center="team-a"))
+    store.record_cost(_rec(call_id="2", cost=5.0, cost_center="team-a"))
+    # report mode never blocks
+    store.set_budget(CostBudget("t1", "", 10.0, "2026-06-02", "report", cost_center="team-a"))
+    assert check_cost_center_budget_enforcement(store, "t1", "team-a")[0] is False
+    # enforce + over limit (13 >= 10) blocks
+    store.set_budget(CostBudget("t1", "", 10.0, "2026-06-02", "enforce", cost_center="team-a"))
+    assert check_cost_center_budget_enforcement(store, "t1", "team-a")[0] is True
+    # enforce + under limit does not
+    store.set_budget(CostBudget("t1", "", 100.0, "2026-06-02", "enforce", cost_center="team-a"))
+    assert check_cost_center_budget_enforcement(store, "t1", "team-a")[0] is False
+    # no cost center -> never blocks
+    assert check_cost_center_budget_enforcement(store, "t1", "")[0] is False
+
+
+def test_sqlite_store_persists_allocation(tmp_path):
+    from agent_bom.api.cost_store import SQLiteCostStore
+
+    db = str(tmp_path / "alloc.db")
+    store = SQLiteCostStore(db)
+    store.record_cost(_rec(call_id="1", cost=2.0, cost_center="team-a", allocation_tags={"env": "prod", "team": "search"}))
+    store.set_budget(CostBudget("t1", "", 5.0, "2026-06-02", "enforce", cost_center="team-a"))
+    # reopen to prove durability + migration idempotency
+    store2 = SQLiteCostStore(db)
+    rec = store2.list_records("t1")[0]
+    assert rec.cost_center == "team-a"
+    assert rec.allocation_tags == {"env": "prod", "team": "search"}
+    assert store2.total_spend_by_cost_center("t1", "team-a") == 2.0
+    budget = store2.get_budget("t1", "", cost_center="team-a")
+    assert budget is not None and budget.limit_usd == 5.0 and budget.mode == "enforce"
 
 
 def test_budget_status_exceeded():
@@ -227,4 +320,48 @@ def test_set_budget_mode_via_api(client):
     assert put.status_code == 200, put.text
     assert put.json()["mode"] == "enforce"
     bad = client.put("/v1/observability/costs/budget", json={"limit_usd": 5.0, "mode": "bogus"})
+    assert bad.status_code == 400
+
+
+def _ml_otlp_payload_with_allocation():
+    payload = _ml_otlp_payload()
+    payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"].extend(
+        [
+            {"key": "agent.cost_center", "value": {"stringValue": "team-search"}},
+            {"key": "allocation.tag.env", "value": {"stringValue": "prod"}},
+        ]
+    )
+    return payload
+
+
+def test_ingest_maps_cost_center_and_tags(client):
+    resp = client.post("/v1/traces", json=_ml_otlp_payload_with_allocation())
+    assert resp.status_code == 200, resp.text
+
+    costs = client.get("/v1/observability/costs?tag=env").json()
+    by_cc = {b["key"]: b["cost_usd"] for b in costs["by_cost_center"]}
+    assert by_cc["team-search"] == 12.5
+    by_tag = {b["key"]: b["cost_usd"] for b in costs["tag_rollup"]["by_tag"]}
+    assert by_tag["prod"] == 12.5
+
+    scoped = client.get("/v1/observability/costs?cost_center=team-search").json()
+    assert scoped["total_cost_usd"] == 12.5
+
+
+def test_cost_center_budget_via_api(client):
+    client.post("/v1/traces", json=_ml_otlp_payload_with_allocation())  # $12.50 to team-search
+    put = client.put("/v1/observability/costs/budget", json={"limit_usd": 10.0, "cost_center": "team-search", "mode": "enforce"})
+    assert put.status_code == 200, put.text
+    body = put.json()
+    assert body["cost_center"] == "team-search"
+    assert body["exceeded"] is True
+    assert body["mode"] == "enforce"
+
+    status = client.get("/v1/observability/costs/budget?cost_center=team-search").json()
+    assert status["spend_usd"] == 12.5
+    assert status["exceeded"] is True
+
+
+def test_agent_and_cost_center_budget_mutually_exclusive(client):
+    bad = client.put("/v1/observability/costs/budget", json={"limit_usd": 5.0, "agent": "a", "cost_center": "team-x"})
     assert bad.status_code == 400


### PR DESCRIPTION
## Summary
Two additive LLM-cost governance features (Jetstream-parity), building on the merged forecasting (#2966).

**#2925 — chargeback/showback + allocation tags**
- `LLMCostRecord` gains optional `cost_center` + `allocation_tags` (unallocated → `"unallocated"`); `CostBudget` gains `cost_center`, budgets keyed by `(tenant, agent, cost_center)`.
- `summarize()` adds `by_cost_center`; new `summarize_by_tag`, cost-center budget enforcement. OTLP ingest maps `*.cost_center` + `allocation.tag.*`.
- `GET /v1/observability/costs` adds `cost_center`/`tag` params; budget GET/PUT accept `cost_center`.

**#2926 — seasonal/time-series baselines**
- `detect_temporal_cost_anomalies` buckets each agent's own spend by (day-of-week, hour) from `observed_at`; seasonal-naive EWMA + EWMA-creep, dependency-free. A predictable nightly batch peak is suppressed; a slow creep/one-off surge is flagged. Surfaced as `temporal_cost_anomalies`; existing peer z-score unchanged.

## Schema migration
Purely additive — SQLite `PRAGMA`-guarded `ALTER TABLE`; Postgres `ADD COLUMN IF NOT EXISTS` + unique index backing the 3-col upsert. Existing enforcement semantics unchanged.

## Verification
48 tests pass (finops + anomaly + the merged forecast suite together — confirms coexistence); ruff/format/mypy clean; OpenAPI + atlas regenerated post-rebase; release-consistency, product-surface, OpenAPI-artifact checks pass.