### PR TITLE
fix(api): add credential rotation governance

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 221 |
+| `docs/openapi/v1.json` | paths | 222 |
 | `docs/openapi/v1.json` | component schemas | 61 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -507,6 +507,11 @@
       "CredentialRefCreate": {
         "additionalProperties": false,
         "properties": {
+          "credential_class": {
+            "default": "generic",
+            "title": "Credential Class",
+            "type": "string"
+          },
           "description": {
             "default": "",
             "title": "Description",
@@ -521,9 +526,55 @@
             "title": "Enabled",
             "type": "boolean"
           },
+          "expires_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "expiry_warning_days": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expiry Warning Days"
+          },
           "external_ref": {
             "title": "External Ref",
             "type": "string"
+          },
+          "last_rotated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Rotated At"
+          },
+          "max_age_days": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Age Days"
           },
           "mode": {
             "default": "external_ref",
@@ -538,6 +589,18 @@
           "provider": {
             "title": "Provider",
             "type": "string"
+          },
+          "rotation_interval_days": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rotation Interval Days"
           },
           "scopes": {
             "items": {
@@ -574,6 +637,17 @@
       "CredentialRefUpdate": {
         "additionalProperties": false,
         "properties": {
+          "credential_class": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Credential Class"
+          },
           "description": {
             "anyOf": [
               {
@@ -607,6 +681,29 @@
             ],
             "title": "Enabled"
           },
+          "expires_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "expiry_warning_days": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expiry Warning Days"
+          },
           "external_ref": {
             "anyOf": [
               {
@@ -617,6 +714,29 @@
               }
             ],
             "title": "External Ref"
+          },
+          "last_rotated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Rotated At"
+          },
+          "max_age_days": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Age Days"
           },
           "mode": {
             "anyOf": [
@@ -650,6 +770,18 @@
               }
             ],
             "title": "Provider"
+          },
+          "rotation_interval_days": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rotation Interval Days"
           },
           "scopes": {
             "anyOf": [
@@ -7378,6 +7510,29 @@
           }
         },
         "summary": "Create Credential Ref",
+        "tags": [
+          "credentials"
+        ]
+      }
+    },
+    "/v1/credentials/posture": {
+      "get": {
+        "operationId": "get_credential_rotation_posture_v1_credentials_posture_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Credential Rotation Posture V1 Credentials Posture Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Credential Rotation Posture",
         "tags": [
           "credentials"
         ]

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -348,6 +348,10 @@ components:
     CredentialRefCreate:
       additionalProperties: false
       properties:
+        credential_class:
+          default: generic
+          title: Credential Class
+          type: string
         description:
           default: ''
           title: Description
@@ -359,9 +363,31 @@ components:
           default: true
           title: Enabled
           type: boolean
+        expires_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Expires At
+        expiry_warning_days:
+          anyOf:
+          - minimum: 1.0
+            type: integer
+          - type: 'null'
+          title: Expiry Warning Days
         external_ref:
           title: External Ref
           type: string
+        last_rotated_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Last Rotated At
+        max_age_days:
+          anyOf:
+          - minimum: 1.0
+            type: integer
+          - type: 'null'
+          title: Max Age Days
         mode:
           default: external_ref
           title: Mode
@@ -373,6 +399,12 @@ components:
         provider:
           title: Provider
           type: string
+        rotation_interval_days:
+          anyOf:
+          - minimum: 1.0
+            type: integer
+          - type: 'null'
+          title: Rotation Interval Days
         scopes:
           items:
             type: string
@@ -400,6 +432,11 @@ components:
     CredentialRefUpdate:
       additionalProperties: false
       properties:
+        credential_class:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Credential Class
         description:
           anyOf:
           - type: string
@@ -415,11 +452,33 @@ components:
           - type: boolean
           - type: 'null'
           title: Enabled
+        expires_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Expires At
+        expiry_warning_days:
+          anyOf:
+          - minimum: 1.0
+            type: integer
+          - type: 'null'
+          title: Expiry Warning Days
         external_ref:
           anyOf:
           - type: string
           - type: 'null'
           title: External Ref
+        last_rotated_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Last Rotated At
+        max_age_days:
+          anyOf:
+          - minimum: 1.0
+            type: integer
+          - type: 'null'
+          title: Max Age Days
         mode:
           anyOf:
           - type: string
@@ -435,6 +494,12 @@ components:
           - type: string
           - type: 'null'
           title: Provider
+        rotation_interval_days:
+          anyOf:
+          - minimum: 1.0
+            type: integer
+          - type: 'null'
+          title: Rotation Interval Days
         scopes:
           anyOf:
           - items:
@@ -4828,6 +4893,22 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Create Credential Ref
+      tags:
+      - credentials
+  /v1/credentials/posture:
+    get:
+      operationId: get_credential_rotation_posture_v1_credentials_posture_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Credential Rotation Posture V1 Credentials Posture
+                  Get
+                type: object
+          description: Successful Response
+      summary: Get Credential Rotation Posture
       tags:
       - credentials
   /v1/credentials/{credential_ref_id}:

--- a/docs/schemas/v1/CredentialRefCreate.json
+++ b/docs/schemas/v1/CredentialRefCreate.json
@@ -1,6 +1,11 @@
 {
   "additionalProperties": false,
   "properties": {
+    "credential_class": {
+      "default": "generic",
+      "title": "Credential Class",
+      "type": "string"
+    },
     "description": {
       "default": "",
       "title": "Description",
@@ -15,9 +20,59 @@
       "title": "Enabled",
       "type": "boolean"
     },
+    "expires_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Expires At"
+    },
+    "expiry_warning_days": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Expiry Warning Days"
+    },
     "external_ref": {
       "title": "External Ref",
       "type": "string"
+    },
+    "last_rotated_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Last Rotated At"
+    },
+    "max_age_days": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Max Age Days"
     },
     "mode": {
       "default": "external_ref",
@@ -32,6 +87,19 @@
     "provider": {
       "title": "Provider",
       "type": "string"
+    },
+    "rotation_interval_days": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Rotation Interval Days"
     },
     "scopes": {
       "items": {

--- a/docs/schemas/v1/CredentialRefRecord.json
+++ b/docs/schemas/v1/CredentialRefRecord.json
@@ -18,6 +18,11 @@
       "title": "Created At",
       "type": "string"
     },
+    "credential_class": {
+      "default": "generic",
+      "title": "Credential Class",
+      "type": "string"
+    },
     "credential_ref_id": {
       "title": "Credential Ref Id",
       "type": "string"
@@ -36,9 +41,46 @@
       "title": "Enabled",
       "type": "boolean"
     },
+    "expires_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Expires At"
+    },
+    "expiry_warning_days": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Expiry Warning Days"
+    },
     "external_ref": {
       "title": "External Ref",
       "type": "string"
+    },
+    "last_rotated_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Last Rotated At"
     },
     "last_validated_at": {
       "anyOf": [
@@ -76,6 +118,19 @@
       "default": null,
       "title": "Last Validation Status"
     },
+    "max_age_days": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Max Age Days"
+    },
     "mode": {
       "default": "external_ref",
       "title": "Mode",
@@ -89,6 +144,19 @@
     "provider": {
       "title": "Provider",
       "type": "string"
+    },
+    "rotation_interval_days": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Rotation Interval Days"
     },
     "scopes": {
       "items": {

--- a/docs/schemas/v1/CredentialRefUpdate.json
+++ b/docs/schemas/v1/CredentialRefUpdate.json
@@ -14,6 +14,18 @@
   },
   "additionalProperties": false,
   "properties": {
+    "credential_class": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Credential Class"
+    },
     "description": {
       "anyOf": [
         {
@@ -50,6 +62,31 @@
       "default": null,
       "title": "Enabled"
     },
+    "expires_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Expires At"
+    },
+    "expiry_warning_days": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Expiry Warning Days"
+    },
     "external_ref": {
       "anyOf": [
         {
@@ -61,6 +98,31 @@
       ],
       "default": null,
       "title": "External Ref"
+    },
+    "last_rotated_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Last Rotated At"
+    },
+    "max_age_days": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Max Age Days"
     },
     "mode": {
       "anyOf": [
@@ -97,6 +159,19 @@
       ],
       "default": null,
       "title": "Provider"
+    },
+    "rotation_interval_days": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Rotation Interval Days"
     },
     "scopes": {
       "anyOf": [

--- a/src/agent_bom/api/credential_rotation.py
+++ b/src/agent_bom/api/credential_rotation.py
@@ -1,0 +1,190 @@
+"""Credential rotation and expiry posture from reference-only metadata."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from agent_bom.api.models import CredentialRefRecord
+
+DEFAULT_EXPIRY_WARNING_DAYS = 14
+DEFAULT_ROTATION_DAYS_BY_CLASS = {
+    "api_key": 90,
+    "service_account": 90,
+    "role_arn": 180,
+    "secret_manager": 90,
+    "workload_identity": 180,
+    "generic": 90,
+}
+DEFAULT_MAX_AGE_DAYS_BY_CLASS = {
+    "api_key": 180,
+    "service_account": 180,
+    "role_arn": 365,
+    "secret_manager": 180,
+    "workload_identity": 365,
+    "generic": 180,
+}
+FINDING_STATUSES = {"unknown_age", "near_expiry", "rotation_due", "max_age_exceeded", "expired"}
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _credential_class(credential: CredentialRefRecord) -> str:
+    value = credential.credential_class or credential.mode or "generic"
+    return value.strip().lower() or "generic"
+
+
+def _age_days(started_at: datetime | None, *, now: datetime) -> int | None:
+    if started_at is None:
+        return None
+    return max(0, (now - started_at).days)
+
+
+def _days_until(expiry_at: datetime | None, *, now: datetime) -> int | None:
+    if expiry_at is None:
+        return None
+    return (expiry_at - now).days
+
+
+def _status_for_credential(
+    credential: CredentialRefRecord,
+    *,
+    age_days: int | None,
+    days_until_expiry: int | None,
+    rotation_interval_days: int,
+    max_age_days: int,
+    expiry_warning_days: int,
+) -> tuple[str, str, str]:
+    if not credential.enabled:
+        return ("disabled", "info", "Credential reference is disabled.")
+    if days_until_expiry is not None and days_until_expiry < 0:
+        return ("expired", "critical", "Credential reference metadata indicates the credential is expired.")
+    if age_days is None:
+        return ("unknown_age", "medium", "Credential reference has no last_rotated_at metadata.")
+    if age_days > max_age_days:
+        return ("max_age_exceeded", "high", "Credential reference exceeds the maximum allowed age.")
+    if age_days > rotation_interval_days:
+        return ("rotation_due", "high", "Credential reference is past the rotation interval.")
+    if days_until_expiry is not None and days_until_expiry <= expiry_warning_days:
+        return ("near_expiry", "medium", "Credential reference is near expiry.")
+    return ("ok", "info", "Credential reference rotation metadata is within policy.")
+
+
+def build_credential_rotation_governance(
+    credentials: list[CredentialRefRecord],
+    *,
+    tenant_id: str,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build reference-only credential rotation evidence without secret material."""
+
+    measured_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    summary = {
+        "total": len(credentials),
+        "ok": 0,
+        "disabled": 0,
+        "unknown_age": 0,
+        "near_expiry": 0,
+        "rotation_due": 0,
+        "max_age_exceeded": 0,
+        "expired": 0,
+        "findings": 0,
+    }
+    credential_rows: list[dict[str, Any]] = []
+    findings: list[dict[str, Any]] = []
+
+    for credential in credentials:
+        credential_class = _credential_class(credential)
+        rotation_interval_days = credential.rotation_interval_days or DEFAULT_ROTATION_DAYS_BY_CLASS.get(
+            credential_class,
+            DEFAULT_ROTATION_DAYS_BY_CLASS["generic"],
+        )
+        max_age_days = credential.max_age_days or DEFAULT_MAX_AGE_DAYS_BY_CLASS.get(
+            credential_class,
+            DEFAULT_MAX_AGE_DAYS_BY_CLASS["generic"],
+        )
+        expiry_warning_days = credential.expiry_warning_days or DEFAULT_EXPIRY_WARNING_DAYS
+        last_rotated_at = _parse_datetime(credential.last_rotated_at)
+        expires_at = _parse_datetime(credential.expires_at)
+        credential_age_days = _age_days(last_rotated_at, now=measured_at)
+        credential_days_until_expiry = _days_until(expires_at, now=measured_at)
+        status, severity, message = _status_for_credential(
+            credential,
+            age_days=credential_age_days,
+            days_until_expiry=credential_days_until_expiry,
+            rotation_interval_days=rotation_interval_days,
+            max_age_days=max_age_days,
+            expiry_warning_days=expiry_warning_days,
+        )
+        summary[status] += 1
+
+        evidence = {
+            "reference_only": True,
+            "secret_material_stored": False,
+            "external_ref_recorded": bool(credential.external_ref),
+        }
+        row = {
+            "credential_ref_id": credential.credential_ref_id,
+            "display_name": credential.display_name,
+            "provider": credential.provider,
+            "mode": credential.mode,
+            "credential_class": credential_class,
+            "owner": credential.owner,
+            "enabled": credential.enabled,
+            "rotation_status": status,
+            "severity": severity,
+            "age_days": credential_age_days,
+            "days_until_expiry": credential_days_until_expiry,
+            "last_rotated_at": last_rotated_at.isoformat() if last_rotated_at else None,
+            "expires_at": expires_at.isoformat() if expires_at else None,
+            "policy": {
+                "rotation_interval_days": rotation_interval_days,
+                "max_age_days": max_age_days,
+                "expiry_warning_days": expiry_warning_days,
+            },
+            "message": message,
+            "evidence": evidence,
+        }
+        credential_rows.append(row)
+
+        if status in FINDING_STATUSES:
+            findings.append(
+                {
+                    "finding_id": f"credential-rotation:{credential.credential_ref_id}:{status}",
+                    "type": "credential_rotation",
+                    "severity": severity,
+                    "status": status,
+                    "credential_ref_id": credential.credential_ref_id,
+                    "credential_class": credential_class,
+                    "title": f"Credential rotation policy: {status.replace('_', ' ')}",
+                    "message": message,
+                    "compliance_tags": ["soc2:CC6.1", "iso27001:A.5.17"],
+                    "evidence": evidence,
+                }
+            )
+
+    summary["findings"] = len(findings)
+    return {
+        "schema_version": "credential.rotation_governance.v1",
+        "tenant_id": tenant_id,
+        "measured_at": measured_at.isoformat(),
+        "policy": {
+            "default_expiry_warning_days": DEFAULT_EXPIRY_WARNING_DAYS,
+            "default_rotation_days_by_class": DEFAULT_ROTATION_DAYS_BY_CLASS,
+            "default_max_age_days_by_class": DEFAULT_MAX_AGE_DAYS_BY_CLASS,
+        },
+        "summary": summary,
+        "credentials": credential_rows,
+        "findings": findings,
+    }

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -476,6 +476,12 @@ class CredentialRefRecord(BaseModel):
     description: str = ""
     owner: str = ""
     scopes: list[str] = Field(default_factory=list)
+    credential_class: str = "generic"
+    last_rotated_at: str | None = None
+    expires_at: str | None = None
+    rotation_interval_days: int | None = Field(default=None, ge=1)
+    max_age_days: int | None = Field(default=None, ge=1)
+    expiry_warning_days: int | None = Field(default=None, ge=1)
     enabled: bool = True
     status: CredentialRefStatus = CredentialRefStatus.CONFIGURED
     last_validated_at: str | None = None
@@ -495,6 +501,12 @@ class CredentialRefCreate(BaseModel):
     description: str = ""
     owner: str = ""
     scopes: list[str] = Field(default_factory=list)
+    credential_class: str = "generic"
+    last_rotated_at: str | None = None
+    expires_at: str | None = None
+    rotation_interval_days: int | None = Field(default=None, ge=1)
+    max_age_days: int | None = Field(default=None, ge=1)
+    expiry_warning_days: int | None = Field(default=None, ge=1)
     enabled: bool = True
     tenant_id: str = "default"
 
@@ -509,6 +521,12 @@ class CredentialRefUpdate(BaseModel):
     description: str | None = None
     owner: str | None = None
     scopes: list[str] | None = None
+    credential_class: str | None = None
+    last_rotated_at: str | None = None
+    expires_at: str | None = None
+    rotation_interval_days: int | None = Field(default=None, ge=1)
+    max_age_days: int | None = Field(default=None, ge=1)
+    expiry_warning_days: int | None = Field(default=None, ge=1)
     enabled: bool | None = None
     status: CredentialRefStatus | None = None
 

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -26,8 +26,15 @@ from typing import TYPE_CHECKING, Any, cast
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 
+from agent_bom.api.credential_rotation import build_credential_rotation_governance
 from agent_bom.api.models import ComplianceReportBundle, JobStatus
-from agent_bom.api.stores import _get_analytics_store, _get_fleet_store, _get_policy_store, _get_store
+from agent_bom.api.stores import (
+    _get_analytics_store,
+    _get_credential_ref_store,
+    _get_fleet_store,
+    _get_policy_store,
+    _get_store,
+)
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
 from agent_bom.rbac import require_authenticated_permission
@@ -1433,6 +1440,11 @@ async def get_credential_risk_ranking(request: Request) -> dict:
     Returns credentials sorted by risk tier (critical to low) with
     associated vulnerability counts and affected agents.
     """
+    tenant_id = _tenant_id(request)
+    rotation_governance = build_credential_rotation_governance(
+        _get_credential_ref_store().list_all(tenant_id=tenant_id),
+        tenant_id=tenant_id,
+    )
     latest_result = None
     for job in _tenant_jobs(request):
         if job.status != JobStatus.DONE or not job.result:
@@ -1441,10 +1453,10 @@ async def get_credential_risk_ranking(request: Request) -> dict:
         break
 
     if latest_result is None:
-        return {"credentials": [], "count": 0}
+        return {"credentials": [], "count": 0, "rotation_governance": rotation_governance}
 
     ranking = latest_result.get("credential_risk_ranking", [])
-    return {"credentials": ranking, "count": len(ranking)}
+    return {"credentials": ranking, "count": len(ranking), "rotation_governance": rotation_governance}
 
 
 @router.get("/v1/posture/incidents", tags=["compliance"])

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -79,6 +79,14 @@ def _tenant_jobs(request: Request) -> list:
     return _get_store().list_all(tenant_id=_tenant_id(request))
 
 
+def _credential_rotation_governance(tenant_id: str) -> dict[str, Any]:
+    try:
+        credentials = _get_credential_ref_store().list_all(tenant_id=tenant_id)
+    except RuntimeError:
+        credentials = []
+    return build_credential_rotation_governance(credentials, tenant_id=tenant_id)
+
+
 def _normalize_csv_filter(value: str | None) -> set[str]:
     if not value:
         return set()
@@ -1441,10 +1449,7 @@ async def get_credential_risk_ranking(request: Request) -> dict:
     associated vulnerability counts and affected agents.
     """
     tenant_id = _tenant_id(request)
-    rotation_governance = build_credential_rotation_governance(
-        _get_credential_ref_store().list_all(tenant_id=tenant_id),
-        tenant_id=tenant_id,
-    )
+    rotation_governance = _credential_rotation_governance(tenant_id)
     latest_result = None
     for job in _tenant_jobs(request):
         if job.status != JobStatus.DONE or not job.result:

--- a/src/agent_bom/api/routes/credentials.py
+++ b/src/agent_bom/api/routes/credentials.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, HTTPException, Query, Request
 
 from agent_bom.api.audit_log import log_action
+from agent_bom.api.credential_rotation import build_credential_rotation_governance
 from agent_bom.api.models import (
     CredentialRefCreate,
     CredentialRefRecord,
@@ -49,6 +50,12 @@ def _apply_update(credential: CredentialRefRecord, body: CredentialRefUpdate) ->
         "description",
         "owner",
         "scopes",
+        "credential_class",
+        "last_rotated_at",
+        "expires_at",
+        "rotation_interval_days",
+        "max_age_days",
+        "expiry_warning_days",
         "enabled",
         "status",
     ):
@@ -80,6 +87,12 @@ async def create_credential_ref(request: Request, body: CredentialRefCreate) -> 
         description=body.description,
         owner=body.owner,
         scopes=body.scopes,
+        credential_class=body.credential_class,
+        last_rotated_at=body.last_rotated_at,
+        expires_at=body.expires_at,
+        rotation_interval_days=body.rotation_interval_days,
+        max_age_days=body.max_age_days,
+        expiry_warning_days=body.expiry_warning_days,
         enabled=body.enabled,
         status=CredentialRefStatus.CONFIGURED if body.enabled else CredentialRefStatus.DISABLED,
         created_at=now,
@@ -115,6 +128,13 @@ async def list_credential_refs(
         "limit": limit,
         "offset": offset,
     }
+
+
+@router.get("/v1/credentials/posture", tags=["credentials"])
+async def get_credential_rotation_posture(request: Request) -> dict:
+    tenant_id = _tenant_id(request)
+    credentials = _get_credential_ref_store().list_all(tenant_id=tenant_id)
+    return build_credential_rotation_governance(credentials, tenant_id=tenant_id)
 
 
 @router.get("/v1/credentials/{credential_ref_id}", tags=["credentials"])

--- a/tests/test_api_sources.py
+++ b/tests/test_api_sources.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from starlette.testclient import TestClient
 
@@ -149,6 +151,91 @@ def test_credential_reference_crud_and_tenant_isolation(source_client: TestClien
     deleted = source_client.delete(f"/v1/credentials/{credential_ref_id}", headers=ADMIN_HEADERS)
     assert deleted.status_code == 204
     assert source_client.get("/v1/credentials", headers=VIEWER_HEADERS).json()["count"] == 0
+
+
+def test_credential_rotation_posture_flags_stale_and_expiring_refs(source_client: TestClient) -> None:
+    stale = source_client.post(
+        "/v1/credentials",
+        headers=ANALYST_HEADERS,
+        json={
+            "display_name": "AWS stale automation key",
+            "provider": "aws",
+            "mode": "secret_manager",
+            "external_ref": "aws-secretsmanager://prod/agent-bom/stale",
+            "owner": "platform-security",
+            "credential_class": "api_key",
+            "last_rotated_at": "2026-01-01T00:00:00+00:00",
+            "rotation_interval_days": 30,
+            "max_age_days": 60,
+        },
+    )
+    assert stale.status_code == 201
+
+    near_expiry_at = (datetime.now(timezone.utc) + timedelta(days=5)).isoformat()
+    expiring = source_client.post(
+        "/v1/credentials",
+        headers=ANALYST_HEADERS,
+        json={
+            "display_name": "ServiceNow near-expiry token",
+            "provider": "servicenow",
+            "mode": "secret_manager",
+            "external_ref": "vault://servicenow/token",
+            "owner": "it-operations",
+            "credential_class": "service_account",
+            "last_rotated_at": datetime.now(timezone.utc).isoformat(),
+            "expires_at": near_expiry_at,
+            "expiry_warning_days": 14,
+        },
+    )
+    assert expiring.status_code == 201
+
+    posture = source_client.get("/v1/credentials/posture", headers=VIEWER_HEADERS)
+    assert posture.status_code == 200
+    body = posture.json()
+    assert body["schema_version"] == "credential.rotation_governance.v1"
+    assert body["tenant_id"] == "tenant-alpha"
+    assert body["summary"]["total"] == 2
+    assert body["summary"]["max_age_exceeded"] == 1
+    assert body["summary"]["near_expiry"] == 1
+    assert body["summary"]["findings"] == 2
+
+    statuses = {row["display_name"]: row["rotation_status"] for row in body["credentials"]}
+    assert statuses == {
+        "AWS stale automation key": "max_age_exceeded",
+        "ServiceNow near-expiry token": "near_expiry",
+    }
+    assert all("external_ref" not in row for row in body["credentials"])
+    assert "aws-secretsmanager://prod/agent-bom/stale" not in posture.text
+    assert "vault://servicenow/token" not in posture.text
+    assert all(finding["type"] == "credential_rotation" for finding in body["findings"])
+
+    other_tenant = source_client.get("/v1/credentials/posture", headers=OTHER_TENANT_HEADERS)
+    assert other_tenant.status_code == 200
+    assert other_tenant.json()["summary"]["total"] == 0
+
+
+def test_posture_credentials_includes_rotation_governance_without_scan(source_client: TestClient) -> None:
+    created = source_client.post(
+        "/v1/credentials",
+        headers=ANALYST_HEADERS,
+        json={
+            "display_name": "Unknown rotation ref",
+            "provider": "azure",
+            "mode": "secret_manager",
+            "external_ref": "keyvault://agent-bom/prod",
+            "credential_class": "service_account",
+        },
+    )
+    assert created.status_code == 201
+
+    posture = source_client.get("/v1/posture/credentials", headers=VIEWER_HEADERS)
+    assert posture.status_code == 200
+    body = posture.json()
+    assert body["credentials"] == []
+    assert body["count"] == 0
+    assert body["rotation_governance"]["summary"]["unknown_age"] == 1
+    assert body["rotation_governance"]["findings"][0]["status"] == "unknown_age"
+    assert "keyvault://agent-bom/prod" not in posture.text
 
 
 def test_credential_reference_rejects_secret_material(source_client: TestClient) -> None:

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException
 
 from agent_bom.api import tenant_quota as tenant_quota_module
 from agent_bom.api.audit_log import InMemoryAuditLog, get_audit_log, set_audit_log
+from agent_bom.api.credential_store import InMemoryCredentialRefStore
 from agent_bom.api.fleet_store import FleetAgent, FleetLifecycleState, InMemoryFleetStore
 from agent_bom.api.graph_store import SQLiteGraphStore
 from agent_bom.api.models import FleetAgentUpdate, JobStatus, PushPayload, ScanJob, ScanRequest, ScheduleCreate, StateUpdate
@@ -28,6 +29,7 @@ from agent_bom.api.schedule_store import InMemoryScheduleStore, ScanSchedule
 from agent_bom.api.store import InMemoryJobStore, SQLiteJobStore
 from agent_bom.api.stores import (
     _jobs,
+    set_credential_ref_store,
     set_fleet_store,
     set_graph_store,
     set_job_store,
@@ -662,6 +664,7 @@ def test_sqlite_job_store_filters_by_tenant(tmp_path):
 async def test_compliance_routes_are_tenant_scoped():
     store = InMemoryJobStore()
     set_job_store(store)
+    set_credential_ref_store(InMemoryCredentialRefStore())
     alpha_job = ScanJob(
         job_id="job-alpha",
         tenant_id="tenant-alpha",


### PR DESCRIPTION
Summary
- Adds reference-only credential rotation/expiry metadata to credential refs.
- Adds `/v1/credentials/posture` and includes `rotation_governance` in `/v1/posture/credentials`.
- Emits non-secret rotation findings for unknown age, near expiry, stale rotation, max-age exceeded, and expired refs.

Verification
- `uv run pytest tests/test_api_sources.py::test_credential_rotation_posture_flags_stale_and_expiring_refs tests/test_api_sources.py::test_posture_credentials_includes_rotation_governance_without_scan -q`
- `uv run pytest tests/test_api_sources.py tests/test_api_tenant_isolation.py -q`
- `uv run ruff check src/agent_bom/api/models.py src/agent_bom/api/credential_rotation.py src/agent_bom/api/routes/credentials.py src/agent_bom/api/routes/compliance.py tests/test_api_sources.py tests/test_api_tenant_isolation.py`
- `uv run python scripts/generate_v1_schemas.py --check`
- `uv run --extra api python scripts/export_openapi.py --check`
- `git diff --check`

Notes
- Posture responses intentionally omit `external_ref`; they only report whether an external reference exists.
- Closes #2923
