### PR TITLE
feat(identity): NHI access-review / recertification campaigns (#2921)

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 223 |
+| `docs/openapi/v1.json` | paths | 227 |
 | `docs/openapi/v1.json` | component schemas | 61 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -12789,6 +12789,500 @@
         ]
       }
     },
+    "/v1/identities/access-reviews": {
+      "get": {
+        "description": "List access-review campaigns for the active tenant (overdue refreshed).",
+        "operationId": "list_access_reviews_v1_identities_access_reviews_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 200,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Access Reviews V1 Identities Access Reviews Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Access Reviews",
+        "tags": [
+          "identity"
+        ]
+      },
+      "post": {
+        "description": "Create a scheduled access-review / recertification campaign over NHIs.\n\nScope defaults to the tenant's discovered non-human identities (Okta/Entra\nservice accounts / service principals) and their effective-permission\nreferences. The caller may instead pass an explicit reference-only\n``subjects`` list. Reference-only \u2014 never reads or stores secret material,\nand never executes any revocation.",
+        "operationId": "create_access_review_v1_identities_access_reviews_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Body"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Create Access Review V1 Identities Access Reviews Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Access Review",
+        "tags": [
+          "identity"
+        ]
+      }
+    },
+    "/v1/identities/access-reviews/{campaign_id}": {
+      "get": {
+        "description": "Return one access-review campaign and its review items.",
+        "operationId": "get_access_review_v1_identities_access_reviews__campaign_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "campaign_id",
+            "required": true,
+            "schema": {
+              "title": "Campaign Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Access Review V1 Identities Access Reviews  Campaign Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Access Review",
+        "tags": [
+          "identity"
+        ]
+      }
+    },
+    "/v1/identities/access-reviews/{campaign_id}/evidence": {
+      "get": {
+        "description": "Export a non-secret, signable evidence bundle for one campaign.",
+        "operationId": "export_access_review_evidence_v1_identities_access_reviews__campaign_id__evidence_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "campaign_id",
+            "required": true,
+            "schema": {
+              "title": "Campaign Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Export Access Review Evidence V1 Identities Access Reviews  Campaign Id  Evidence Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Export Access Review Evidence",
+        "tags": [
+          "identity"
+        ]
+      }
+    },
+    "/v1/identities/access-reviews/{campaign_id}/items/{item_id}/decision": {
+      "post": {
+        "description": "Record a reviewer decision (attest / revoke_recommended / flag) on one item.\n\nReference-only: a ``revoke_recommended`` decision records the recommendation\nas audited evidence and (when blocking) emits a governance event; it never\nexecutes a revocation on Okta/Entra or any external system.",
+        "operationId": "submit_access_review_decision_v1_identities_access_reviews__campaign_id__items__item_id__decision_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "campaign_id",
+            "required": true,
+            "schema": {
+              "title": "Campaign Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "item_id",
+            "required": true,
+            "schema": {
+              "title": "Item Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Submit Access Review Decision V1 Identities Access Reviews  Campaign Id  Items  Item Id  Decision Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Submit Access Review Decision",
+        "tags": [
+          "identity"
+        ]
+      }
+    },
     "/v1/identities/discover": {
       "post": {
         "description": "Discover non-human identities (service accounts / principals) from IdPs.\n\nRead-only and reference-only: enumerates Okta service apps + API tokens and\nEntra service principals + app registrations and returns normalized metadata\n(id / name / owner / created / credential expiry / scope references) \u2014 never\nany secret material. Each provider is gated by its own ``*_DISCOVERY`` env\nflag and token; a disabled or unconfigured provider is reported in\n``providers`` rather than failing the request. Never runs a network call for\na provider whose flag is off.",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -8348,6 +8348,305 @@ paths:
       summary: Issue Agent Identity
       tags:
       - identity
+  /v1/identities/access-reviews:
+    get:
+      description: List access-review campaigns for the active tenant (overdue refreshed).
+      operationId: list_access_reviews_v1_identities_access_reviews_get
+      parameters:
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 200
+          title: Limit
+          type: integer
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response List Access Reviews V1 Identities Access Reviews Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: List Access Reviews
+      tags:
+      - identity
+    post:
+      description: "Create a scheduled access-review / recertification campaign over\
+        \ NHIs.\n\nScope defaults to the tenant's discovered non-human identities\
+        \ (Okta/Entra\nservice accounts / service principals) and their effective-permission\n\
+        references. The caller may instead pass an explicit reference-only\n``subjects``\
+        \ list. Reference-only \u2014 never reads or stores secret material,\nand\
+        \ never executes any revocation."
+      operationId: create_access_review_v1_identities_access_reviews_post
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - additionalProperties: true
+                type: object
+              - type: 'null'
+              title: Body
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Create Access Review V1 Identities Access Reviews
+                  Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Create Access Review
+      tags:
+      - identity
+  /v1/identities/access-reviews/{campaign_id}:
+    get:
+      description: Return one access-review campaign and its review items.
+      operationId: get_access_review_v1_identities_access_reviews__campaign_id__get
+      parameters:
+      - in: path
+        name: campaign_id
+        required: true
+        schema:
+          title: Campaign Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Access Review V1 Identities Access Reviews  Campaign
+                  Id  Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Access Review
+      tags:
+      - identity
+  /v1/identities/access-reviews/{campaign_id}/evidence:
+    get:
+      description: Export a non-secret, signable evidence bundle for one campaign.
+      operationId: export_access_review_evidence_v1_identities_access_reviews__campaign_id__evidence_get
+      parameters:
+      - in: path
+        name: campaign_id
+        required: true
+        schema:
+          title: Campaign Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Export Access Review Evidence V1 Identities Access
+                  Reviews  Campaign Id  Evidence Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Export Access Review Evidence
+      tags:
+      - identity
+  /v1/identities/access-reviews/{campaign_id}/items/{item_id}/decision:
+    post:
+      description: 'Record a reviewer decision (attest / revoke_recommended / flag)
+        on one item.
+
+
+        Reference-only: a ``revoke_recommended`` decision records the recommendation
+
+        as audited evidence and (when blocking) emits a governance event; it never
+
+        executes a revocation on Okta/Entra or any external system.'
+      operationId: submit_access_review_decision_v1_identities_access_reviews__campaign_id__items__item_id__decision_post
+      parameters:
+      - in: path
+        name: campaign_id
+        required: true
+        schema:
+          title: Campaign Id
+          type: string
+      - in: path
+        name: item_id
+        required: true
+        schema:
+          title: Item Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: true
+              title: Body
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Submit Access Review Decision V1 Identities Access
+                  Reviews  Campaign Id  Items  Item Id  Decision Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Submit Access Review Decision
+      tags:
+      - identity
   /v1/identities/discover:
     post:
       description: "Discover non-human identities (service accounts / principals)\

--- a/src/agent_bom/api/access_review.py
+++ b/src/agent_bom/api/access_review.py
@@ -1,0 +1,589 @@
+"""Scheduled access-review / recertification campaigns for non-human identities.
+
+NHI discovery (Okta/Entra) lands ``managed_identity`` nodes and
+``graph/effective_permissions`` computes their ``HAS_PERMISSION`` closure, but
+nothing periodically *attests* that each non-human identity still needs the
+access it holds. This module adds that governance workflow on top: a reviewer
+runs a recurring campaign that enumerates every discovered NHI (plus its
+effective permissions) as a review item and records an ``attest`` /
+``revoke_recommended`` / ``flag`` decision against each one, with due dates,
+campaign status, and a signed/audited evidence trail.
+
+It is **reference-only**. A ``revoke_recommended`` decision records the
+reviewer's recommendation as evidence and emits a finding; it never executes a
+revocation against Okta/Entra or any external system. No secret material is
+read or stored — only identity ids, owners, scope/permission *references*, and
+the decisions themselves.
+
+Persistence follows the established store pattern (Protocol -> InMemory ->
+SQLite, with a Postgres mirror selected via ``AGENT_BOM_POSTGRES_URL``). Every
+decision is appended to the HMAC-chained audit log via
+:func:`agent_bom.api.audit_log.log_action`, so the evidence trail is tamper
+evident.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import sqlite3
+import threading
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Protocol
+
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
+# Review decisions a reviewer may record against one item.
+DECISION_ATTEST = "attest"
+DECISION_REVOKE = "revoke_recommended"
+DECISION_FLAG = "flag"
+DECISION_PENDING = "pending"
+_VALID_DECISIONS = frozenset({DECISION_ATTEST, DECISION_REVOKE, DECISION_FLAG})
+
+# Campaign lifecycle states.
+STATUS_OPEN = "open"
+STATUS_IN_PROGRESS = "in_progress"
+STATUS_COMPLETED = "completed"
+STATUS_OVERDUE = "overdue"
+
+DEFAULT_DUE_DAYS = 14
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _parse_iso(raw: str | None) -> datetime | None:
+    if not raw:
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+@dataclass
+class AccessReviewItem:
+    """One non-human identity under review within a campaign.
+
+    Carries only reference metadata (identity id / name / provider / owner) and
+    *references* to the effective permissions the identity holds — never secret
+    material. ``decision`` starts at ``pending`` and is set exactly once a
+    reviewer attests/recommends-revoke/flags it.
+    """
+
+    item_id: str
+    campaign_id: str
+    tenant_id: str
+    subject_id: str  # discovered NHI id (e.g. provider:identity_id)
+    subject_name: str
+    subject_type: str  # service_account | service_principal | managed_identity | ...
+    provider: str = ""
+    owner: str = ""
+    # Reference-only list of permission/scope labels the subject holds.
+    permissions: list[str] = field(default_factory=list)
+    permission_count: int = 0
+    privileged: bool = False  # subject reaches an admin-equivalent permission
+    decision: str = DECISION_PENDING
+    decided_by: str = ""
+    decided_at: str = ""
+    decision_note: str = ""
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class AccessReviewCampaign:
+    """A scheduled recertification campaign over a tenant's non-human identities."""
+
+    campaign_id: str
+    tenant_id: str
+    name: str
+    status: str  # open | in_progress | completed | overdue
+    created_at: str
+    created_by: str = ""
+    due_at: str = ""
+    completed_at: str = ""
+    description: str = ""
+    item_count: int = 0
+    decided_count: int = 0
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def is_overdue(self, *, at: datetime | None = None) -> bool:
+        """True when the campaign is unfinished and past its due date."""
+        if self.status == STATUS_COMPLETED:
+            return False
+        due = _parse_iso(self.due_at)
+        if due is None:
+            return False
+        return (at or _now()) > due
+
+
+class AccessReviewStore(Protocol):
+    """Protocol for access-review campaign + item persistence."""
+
+    def put_campaign(self, campaign: AccessReviewCampaign) -> None: ...
+
+    def get_campaign(self, campaign_id: str, tenant_id: str | None = None) -> AccessReviewCampaign | None: ...
+
+    def list_campaigns(self, tenant_id: str, *, limit: int = 200) -> list[AccessReviewCampaign]: ...
+
+    def put_item(self, item: AccessReviewItem) -> None: ...
+
+    def get_item(self, item_id: str, tenant_id: str | None = None) -> AccessReviewItem | None: ...
+
+    def list_items(self, campaign_id: str, tenant_id: str | None = None, *, limit: int = 1000) -> list[AccessReviewItem]: ...
+
+
+class InMemoryAccessReviewStore:
+    """Dict-based in-memory access-review store."""
+
+    def __init__(self) -> None:
+        self._campaigns: dict[str, AccessReviewCampaign] = {}
+        self._items: dict[str, AccessReviewItem] = {}
+        self._lock = threading.Lock()
+
+    def put_campaign(self, campaign: AccessReviewCampaign) -> None:
+        with self._lock:
+            self._campaigns[campaign.campaign_id] = campaign
+
+    def get_campaign(self, campaign_id: str, tenant_id: str | None = None) -> AccessReviewCampaign | None:
+        with self._lock:
+            campaign = self._campaigns.get(campaign_id)
+        if campaign is None:
+            return None
+        if tenant_id is not None and campaign.tenant_id != tenant_id:
+            return None
+        return campaign
+
+    def list_campaigns(self, tenant_id: str, *, limit: int = 200) -> list[AccessReviewCampaign]:
+        with self._lock:
+            rows = [c for c in self._campaigns.values() if c.tenant_id == tenant_id]
+        return sorted(rows, key=lambda c: c.created_at, reverse=True)[:limit]
+
+    def put_item(self, item: AccessReviewItem) -> None:
+        with self._lock:
+            self._items[item.item_id] = item
+
+    def get_item(self, item_id: str, tenant_id: str | None = None) -> AccessReviewItem | None:
+        with self._lock:
+            item = self._items.get(item_id)
+        if item is None:
+            return None
+        if tenant_id is not None and item.tenant_id != tenant_id:
+            return None
+        return item
+
+    def list_items(self, campaign_id: str, tenant_id: str | None = None, *, limit: int = 1000) -> list[AccessReviewItem]:
+        with self._lock:
+            rows = [i for i in self._items.values() if i.campaign_id == campaign_id]
+        if tenant_id is not None:
+            rows = [i for i in rows if i.tenant_id == tenant_id]
+        return sorted(rows, key=lambda i: i.subject_name.lower())[:limit]
+
+
+class SQLiteAccessReviewStore:
+    """SQLite-backed persistent access-review store."""
+
+    def __init__(self, db_path: str = "agent_bom.db") -> None:
+        self._db_path = db_path
+        self._local = threading.local()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        if not hasattr(self._local, "conn") or self._local.conn is None:
+            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            self._local.conn.execute("PRAGMA journal_mode=WAL")
+        conn: sqlite3.Connection = self._local.conn
+        return conn
+
+    def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "access_reviews")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS access_review_campaigns (
+                campaign_id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                due_at TEXT NOT NULL DEFAULT '',
+                data TEXT NOT NULL
+            )
+            """
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_access_review_campaigns_tenant ON access_review_campaigns(tenant_id, created_at)"
+        )
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS access_review_items (
+                item_id TEXT PRIMARY KEY,
+                campaign_id TEXT NOT NULL,
+                tenant_id TEXT NOT NULL,
+                subject_id TEXT NOT NULL,
+                decision TEXT NOT NULL,
+                data TEXT NOT NULL
+            )
+            """
+        )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_access_review_items_campaign ON access_review_items(campaign_id, tenant_id)")
+        self._conn.commit()
+
+    def put_campaign(self, campaign: AccessReviewCampaign) -> None:
+        self._conn.execute(
+            "INSERT OR REPLACE INTO access_review_campaigns "
+            "(campaign_id, tenant_id, status, created_at, due_at, data) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                campaign.campaign_id,
+                campaign.tenant_id,
+                campaign.status,
+                campaign.created_at,
+                campaign.due_at,
+                json.dumps(asdict(campaign), sort_keys=True),
+            ),
+        )
+        self._conn.commit()
+
+    def get_campaign(self, campaign_id: str, tenant_id: str | None = None) -> AccessReviewCampaign | None:
+        if tenant_id is None:
+            row = self._conn.execute("SELECT data FROM access_review_campaigns WHERE campaign_id = ?", (campaign_id,)).fetchone()
+        else:
+            row = self._conn.execute(
+                "SELECT data FROM access_review_campaigns WHERE campaign_id = ? AND tenant_id = ?",
+                (campaign_id, tenant_id),
+            ).fetchone()
+        return AccessReviewCampaign(**json.loads(row[0])) if row else None
+
+    def list_campaigns(self, tenant_id: str, *, limit: int = 200) -> list[AccessReviewCampaign]:
+        rows = self._conn.execute(
+            "SELECT data FROM access_review_campaigns WHERE tenant_id = ? ORDER BY created_at DESC LIMIT ?",
+            (tenant_id, limit),
+        ).fetchall()
+        return [AccessReviewCampaign(**json.loads(r[0])) for r in rows]
+
+    def put_item(self, item: AccessReviewItem) -> None:
+        self._conn.execute(
+            "INSERT OR REPLACE INTO access_review_items "
+            "(item_id, campaign_id, tenant_id, subject_id, decision, data) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                item.item_id,
+                item.campaign_id,
+                item.tenant_id,
+                item.subject_id,
+                item.decision,
+                json.dumps(asdict(item), sort_keys=True),
+            ),
+        )
+        self._conn.commit()
+
+    def get_item(self, item_id: str, tenant_id: str | None = None) -> AccessReviewItem | None:
+        if tenant_id is None:
+            row = self._conn.execute("SELECT data FROM access_review_items WHERE item_id = ?", (item_id,)).fetchone()
+        else:
+            row = self._conn.execute(
+                "SELECT data FROM access_review_items WHERE item_id = ? AND tenant_id = ?",
+                (item_id, tenant_id),
+            ).fetchone()
+        return AccessReviewItem(**json.loads(row[0])) if row else None
+
+    def list_items(self, campaign_id: str, tenant_id: str | None = None, *, limit: int = 1000) -> list[AccessReviewItem]:
+        if tenant_id is None:
+            rows = self._conn.execute(
+                "SELECT data FROM access_review_items WHERE campaign_id = ? ORDER BY item_id LIMIT ?",
+                (campaign_id, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT data FROM access_review_items WHERE campaign_id = ? AND tenant_id = ? ORDER BY item_id LIMIT ?",
+                (campaign_id, tenant_id, limit),
+            ).fetchall()
+        items = [AccessReviewItem(**json.loads(r[0])) for r in rows]
+        return sorted(items, key=lambda i: i.subject_name.lower())
+
+
+# ── Subject extraction ────────────────────────────────────────────────────────
+
+
+_ADMIN_KEYWORDS = ("admin", "owner", "root", "fullaccess", "*:*", "*")
+
+
+def _subject_records_from_discovery(discovered: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Normalize discovered-NHI dicts into review-subject records (reference-only).
+
+    Accepts the payload shape ``merge_discovery_results`` /
+    ``serialize_discovery_result`` emit (``identity_id`` / ``name`` / ``owner`` /
+    ``identity_type`` / ``provider`` / ``scopes``). Never reads secret fields.
+    """
+    subjects: list[dict[str, Any]] = []
+    for raw in discovered:
+        if not isinstance(raw, dict):
+            continue
+        identity_id = str(raw.get("identity_id") or raw.get("id") or "").strip()
+        if not identity_id:
+            continue
+        provider = str(raw.get("provider") or "").strip()
+        scopes_raw = raw.get("scopes")
+        scopes = [str(s).strip() for s in scopes_raw if str(s).strip()] if isinstance(scopes_raw, list) else []
+        privileged = any(any(kw in scope.lower() for kw in _ADMIN_KEYWORDS) for scope in scopes)
+        subjects.append(
+            {
+                "subject_id": f"{provider}:{identity_id}" if provider else identity_id,
+                "subject_name": str(raw.get("name") or identity_id),
+                "subject_type": str(raw.get("identity_type") or "service_account"),
+                "provider": provider,
+                "owner": str(raw.get("owner") or ""),
+                "permissions": scopes[:200],
+                "permission_count": len(scopes),
+                "privileged": privileged,
+            }
+        )
+    return subjects
+
+
+# ── Campaign lifecycle ─────────────────────────────────────────────────────────
+
+
+def create_campaign(
+    store: AccessReviewStore,
+    *,
+    tenant_id: str,
+    name: str,
+    subjects: list[dict[str, Any]],
+    created_by: str = "",
+    due_days: int = DEFAULT_DUE_DAYS,
+    description: str = "",
+    now: datetime | None = None,
+) -> tuple[AccessReviewCampaign, list[AccessReviewItem]]:
+    """Create a campaign and enumerate one review item per subject.
+
+    ``subjects`` are reference-only records (``subject_id`` / ``subject_name`` /
+    ``permissions`` …). Returns the persisted campaign and its items.
+    """
+    moment = now or _now()
+    due_days = max(1, int(due_days))
+    campaign = AccessReviewCampaign(
+        campaign_id=f"arc_{secrets.token_hex(8)}",
+        tenant_id=tenant_id,
+        name=name[:200],
+        status=STATUS_OPEN,
+        created_at=_iso(moment),
+        created_by=created_by[:120],
+        due_at=_iso(moment + timedelta(days=due_days)),
+        description=description[:1000],
+        item_count=len(subjects),
+        decided_count=0,
+    )
+    items: list[AccessReviewItem] = []
+    for subject in subjects:
+        item = AccessReviewItem(
+            item_id=f"ari_{secrets.token_hex(8)}",
+            campaign_id=campaign.campaign_id,
+            tenant_id=tenant_id,
+            subject_id=str(subject.get("subject_id") or "")[:200],
+            subject_name=str(subject.get("subject_name") or subject.get("subject_id") or "")[:200],
+            subject_type=str(subject.get("subject_type") or "service_account")[:60],
+            provider=str(subject.get("provider") or "")[:60],
+            owner=str(subject.get("owner") or "")[:200],
+            permissions=[str(p)[:200] for p in (subject.get("permissions") or [])][:200],
+            permission_count=int(subject.get("permission_count") or len(subject.get("permissions") or [])),
+            privileged=bool(subject.get("privileged")),
+        )
+        items.append(item)
+
+    store.put_campaign(campaign)
+    for item in items:
+        store.put_item(item)
+    return campaign, items
+
+
+def create_campaign_from_discovery(
+    store: AccessReviewStore,
+    *,
+    tenant_id: str,
+    name: str,
+    discovered: list[dict[str, Any]],
+    created_by: str = "",
+    due_days: int = DEFAULT_DUE_DAYS,
+    description: str = "",
+    now: datetime | None = None,
+) -> tuple[AccessReviewCampaign, list[AccessReviewItem]]:
+    """Create a campaign whose scope is a set of discovered non-human identities."""
+    subjects = _subject_records_from_discovery(discovered)
+    return create_campaign(
+        store,
+        tenant_id=tenant_id,
+        name=name,
+        subjects=subjects,
+        created_by=created_by,
+        due_days=due_days,
+        description=description,
+        now=now,
+    )
+
+
+def _recount(store: AccessReviewStore, campaign: AccessReviewCampaign, *, now: datetime | None = None) -> AccessReviewCampaign:
+    """Recompute item/decided counts and roll the campaign status forward."""
+    items = store.list_items(campaign.campaign_id, campaign.tenant_id)
+    decided = [i for i in items if i.decision != DECISION_PENDING]
+    campaign.item_count = len(items)
+    campaign.decided_count = len(decided)
+    if campaign.status != STATUS_COMPLETED:
+        if items and len(decided) == len(items):
+            campaign.status = STATUS_COMPLETED
+            campaign.completed_at = _iso(now or _now())
+        elif decided:
+            campaign.status = STATUS_IN_PROGRESS
+        else:
+            campaign.status = STATUS_OPEN
+        if campaign.status != STATUS_COMPLETED and campaign.is_overdue(at=now):
+            campaign.status = STATUS_OVERDUE
+    return campaign
+
+
+def record_decision(
+    store: AccessReviewStore,
+    *,
+    tenant_id: str,
+    item_id: str,
+    decision: str,
+    decided_by: str = "",
+    note: str = "",
+    now: datetime | None = None,
+) -> tuple[AccessReviewItem, AccessReviewCampaign] | None:
+    """Record a reviewer decision on one item and roll the campaign status forward.
+
+    Returns ``(item, campaign)`` on success, or ``None`` when the item is not
+    found in ``tenant_id``. Raises ``ValueError`` for an invalid decision.
+    """
+    if decision not in _VALID_DECISIONS:
+        raise ValueError(f"decision must be one of {sorted(_VALID_DECISIONS)}")
+    item = store.get_item(item_id, tenant_id)
+    if item is None:
+        return None
+    campaign = store.get_campaign(item.campaign_id, tenant_id)
+    if campaign is None:
+        return None
+    moment = now or _now()
+    item.decision = decision
+    item.decided_by = decided_by[:120]
+    item.decided_at = _iso(moment)
+    item.decision_note = note[:1000]
+    store.put_item(item)
+    campaign = _recount(store, campaign, now=moment)
+    store.put_campaign(campaign)
+    return item, campaign
+
+
+def refresh_campaign_status(
+    store: AccessReviewStore,
+    *,
+    tenant_id: str,
+    campaign_id: str,
+    now: datetime | None = None,
+) -> AccessReviewCampaign | None:
+    """Recompute and persist a campaign's status (e.g. to surface overdue)."""
+    campaign = store.get_campaign(campaign_id, tenant_id)
+    if campaign is None:
+        return None
+    campaign = _recount(store, campaign, now=now)
+    store.put_campaign(campaign)
+    return campaign
+
+
+def export_evidence(
+    store: AccessReviewStore,
+    *,
+    tenant_id: str,
+    campaign_id: str,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Return a non-secret, signable evidence bundle for one campaign.
+
+    Includes the campaign, every item + decision, and rolled-up decision counts.
+    Suitable for attaching to a compliance evidence trail. No secret values.
+    """
+    campaign = refresh_campaign_status(store, tenant_id=tenant_id, campaign_id=campaign_id, now=now)
+    if campaign is None:
+        return None
+    items = store.list_items(campaign_id, tenant_id)
+    counts: dict[str, int] = {DECISION_PENDING: 0, DECISION_ATTEST: 0, DECISION_REVOKE: 0, DECISION_FLAG: 0}
+    for item in items:
+        counts[item.decision] = counts.get(item.decision, 0) + 1
+    return {
+        "schema_version": "identity.access_review.v1",
+        "secret_values_included": False,
+        "generated_at": _iso(now or _now()),
+        "tenant_id": tenant_id,
+        "campaign": campaign.to_public_dict(),
+        "decision_counts": counts,
+        "revoke_recommended": [i.subject_name or i.subject_id for i in items if i.decision == DECISION_REVOKE],
+        "flagged": [i.subject_name or i.subject_id for i in items if i.decision == DECISION_FLAG],
+        "items": [i.to_public_dict() for i in items],
+    }
+
+
+# ── Module-level singleton ──────────────────────────────────────────────────────
+
+_ACCESS_REVIEW_STORE: AccessReviewStore | None = None
+
+
+def get_access_review_store() -> AccessReviewStore:
+    global _ACCESS_REVIEW_STORE
+    if _ACCESS_REVIEW_STORE is not None:
+        return _ACCESS_REVIEW_STORE
+    if os.environ.get("AGENT_BOM_POSTGRES_URL"):
+        from agent_bom.api.postgres_access_review import PostgresAccessReviewStore
+
+        _ACCESS_REVIEW_STORE = PostgresAccessReviewStore()
+    elif os.environ.get("AGENT_BOM_DB"):
+        _ACCESS_REVIEW_STORE = SQLiteAccessReviewStore(os.environ["AGENT_BOM_DB"])
+    else:
+        _ACCESS_REVIEW_STORE = InMemoryAccessReviewStore()
+    return _ACCESS_REVIEW_STORE
+
+
+def set_access_review_store(store: AccessReviewStore | None) -> None:
+    global _ACCESS_REVIEW_STORE
+    _ACCESS_REVIEW_STORE = store
+
+
+__all__ = [
+    "DECISION_ATTEST",
+    "DECISION_FLAG",
+    "DECISION_PENDING",
+    "DECISION_REVOKE",
+    "STATUS_COMPLETED",
+    "STATUS_IN_PROGRESS",
+    "STATUS_OPEN",
+    "STATUS_OVERDUE",
+    "AccessReviewCampaign",
+    "AccessReviewItem",
+    "AccessReviewStore",
+    "InMemoryAccessReviewStore",
+    "SQLiteAccessReviewStore",
+    "create_campaign",
+    "create_campaign_from_discovery",
+    "export_evidence",
+    "get_access_review_store",
+    "record_decision",
+    "refresh_campaign_status",
+    "set_access_review_store",
+]

--- a/src/agent_bom/api/postgres_access_review.py
+++ b/src/agent_bom/api/postgres_access_review.py
@@ -1,0 +1,144 @@
+"""Postgres-backed access-review campaign store for horizontal scaling.
+
+Mirrors :class:`agent_bom.api.access_review.SQLiteAccessReviewStore` but keeps
+recertification campaigns and their review items in shared Postgres with tenant
+RLS, so campaign status and reviewer decisions stay consistent across every
+control-plane replica instead of diverging on node-local SQLite. The campaign
+and item dataclasses are persisted as JSON ``data`` blobs (matching the SQLite
+mirror) with tenant_id / status / decision projected into columns for indexing.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+
+from agent_bom.api.access_review import AccessReviewCampaign, AccessReviewItem
+from agent_bom.api.postgres_common import _ensure_tenant_rls, _get_pool, _tenant_connection
+from agent_bom.api.storage_schema import ensure_postgres_schema_version
+
+
+class PostgresAccessReviewStore:
+    """Shared access-review campaign + item store backed by Postgres with tenant RLS."""
+
+    def __init__(self, pool=None) -> None:
+        self._pool = pool or _get_pool()
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "access_review_campaigns")
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS access_review_campaigns (
+                    campaign_id TEXT NOT NULL,
+                    tenant_id   TEXT NOT NULL,
+                    status      TEXT NOT NULL,
+                    created_at  TEXT NOT NULL,
+                    due_at      TEXT NOT NULL DEFAULT '',
+                    data        TEXT NOT NULL,
+                    PRIMARY KEY (tenant_id, campaign_id)
+                )
+            """)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS access_review_items (
+                    item_id     TEXT NOT NULL,
+                    campaign_id TEXT NOT NULL,
+                    tenant_id   TEXT NOT NULL,
+                    subject_id  TEXT NOT NULL,
+                    decision    TEXT NOT NULL,
+                    data        TEXT NOT NULL,
+                    PRIMARY KEY (tenant_id, item_id)
+                )
+            """)
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_access_review_campaigns_tenant ON access_review_campaigns(tenant_id, created_at DESC)"
+            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_access_review_items_campaign ON access_review_items(tenant_id, campaign_id)")
+            _ensure_tenant_rls(conn, "access_review_campaigns", "tenant_id")
+            _ensure_tenant_rls(conn, "access_review_items", "tenant_id")
+            conn.commit()
+
+    def put_campaign(self, campaign: AccessReviewCampaign) -> None:
+        with _tenant_connection(self._pool) as conn:
+            conn.execute(
+                """
+                INSERT INTO access_review_campaigns (campaign_id, tenant_id, status, created_at, due_at, data)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                ON CONFLICT (tenant_id, campaign_id) DO UPDATE
+                SET status = EXCLUDED.status, due_at = EXCLUDED.due_at, data = EXCLUDED.data
+                """,
+                (
+                    campaign.campaign_id,
+                    campaign.tenant_id,
+                    campaign.status,
+                    campaign.created_at,
+                    campaign.due_at,
+                    json.dumps(asdict(campaign), sort_keys=True),
+                ),
+            )
+            conn.commit()
+
+    def get_campaign(self, campaign_id: str, tenant_id: str | None = None) -> AccessReviewCampaign | None:
+        with _tenant_connection(self._pool) as conn:
+            if tenant_id is None:
+                row = conn.execute("SELECT data FROM access_review_campaigns WHERE campaign_id = %s LIMIT 1", (campaign_id,)).fetchone()
+            else:
+                row = conn.execute(
+                    "SELECT data FROM access_review_campaigns WHERE campaign_id = %s AND tenant_id = %s",
+                    (campaign_id, tenant_id),
+                ).fetchone()
+        return AccessReviewCampaign(**json.loads(row[0])) if row else None
+
+    def list_campaigns(self, tenant_id: str, *, limit: int = 200) -> list[AccessReviewCampaign]:
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                "SELECT data FROM access_review_campaigns WHERE tenant_id = %s ORDER BY created_at DESC LIMIT %s",
+                (tenant_id, limit),
+            ).fetchall()
+        return [AccessReviewCampaign(**json.loads(r[0])) for r in rows]
+
+    def put_item(self, item: AccessReviewItem) -> None:
+        with _tenant_connection(self._pool) as conn:
+            conn.execute(
+                """
+                INSERT INTO access_review_items (item_id, campaign_id, tenant_id, subject_id, decision, data)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                ON CONFLICT (tenant_id, item_id) DO UPDATE
+                SET decision = EXCLUDED.decision, data = EXCLUDED.data
+                """,
+                (
+                    item.item_id,
+                    item.campaign_id,
+                    item.tenant_id,
+                    item.subject_id,
+                    item.decision,
+                    json.dumps(asdict(item), sort_keys=True),
+                ),
+            )
+            conn.commit()
+
+    def get_item(self, item_id: str, tenant_id: str | None = None) -> AccessReviewItem | None:
+        with _tenant_connection(self._pool) as conn:
+            if tenant_id is None:
+                row = conn.execute("SELECT data FROM access_review_items WHERE item_id = %s LIMIT 1", (item_id,)).fetchone()
+            else:
+                row = conn.execute(
+                    "SELECT data FROM access_review_items WHERE item_id = %s AND tenant_id = %s",
+                    (item_id, tenant_id),
+                ).fetchone()
+        return AccessReviewItem(**json.loads(row[0])) if row else None
+
+    def list_items(self, campaign_id: str, tenant_id: str | None = None, *, limit: int = 1000) -> list[AccessReviewItem]:
+        with _tenant_connection(self._pool) as conn:
+            if tenant_id is None:
+                rows = conn.execute(
+                    "SELECT data FROM access_review_items WHERE campaign_id = %s ORDER BY item_id LIMIT %s",
+                    (campaign_id, limit),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT data FROM access_review_items WHERE campaign_id = %s AND tenant_id = %s ORDER BY item_id LIMIT %s",
+                    (campaign_id, tenant_id, limit),
+                ).fetchall()
+        items = [AccessReviewItem(**json.loads(r[0])) for r in rows]
+        return sorted(items, key=lambda i: i.subject_name.lower())

--- a/src/agent_bom/api/routes/identities.py
+++ b/src/agent_bom/api/routes/identities.py
@@ -586,6 +586,211 @@ async def list_agent_identities(request: Request, include_inactive: bool = False
     }
 
 
+# ── Access-review / recertification campaigns (NHI governance) ──────────────────
+#
+# These static ``/v1/identities/access-reviews...`` routes are declared before
+# the ``/v1/identities/{identity_id}`` catch-all so FastAPI's in-order matching
+# does not route "access-reviews" into the single-identity lookup.
+
+
+def _discover_nhi_subjects() -> list[dict[str, object]]:
+    """Run read-only NHI discovery and return reference-only subject dicts.
+
+    Reuses the same Okta/Entra discovery used by ``/v1/identities/discover`` —
+    never reads secret material; each provider is gated by its own env flag.
+    """
+    from agent_bom.graph.nhi_overlay import merge_discovery_results
+    from agent_bom.identity import (
+        discover_entra_non_human_identities,
+        discover_okta_non_human_identities,
+    )
+
+    merged = merge_discovery_results([discover_okta_non_human_identities(), discover_entra_non_human_identities()])
+    return list(merged.get("identities", []))
+
+
+@router.post("/v1/identities/access-reviews", status_code=201, dependencies=[_dep("config")])
+async def create_access_review(request: Request, body: dict | None = None) -> dict[str, object]:
+    """Create a scheduled access-review / recertification campaign over NHIs.
+
+    Scope defaults to the tenant's discovered non-human identities (Okta/Entra
+    service accounts / service principals) and their effective-permission
+    references. The caller may instead pass an explicit reference-only
+    ``subjects`` list. Reference-only — never reads or stores secret material,
+    and never executes any revocation.
+    """
+    from agent_bom.api.access_review import (
+        create_campaign,
+        create_campaign_from_discovery,
+        get_access_review_store,
+    )
+
+    payload = body or {}
+    name = str(payload.get("name", "") or "").strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="'name' is required")
+    try:
+        due_days = int(payload.get("due_days", 14))
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="'due_days' must be an integer") from exc
+    if due_days < 1 or due_days > 365:
+        raise HTTPException(status_code=400, detail="'due_days' must be between 1 and 365")
+    description = str(payload.get("description", "") or "")
+    tenant_id = _tenant(request)
+    store = get_access_review_store()
+
+    raw_subjects = payload.get("subjects")
+    if isinstance(raw_subjects, list) and raw_subjects:
+        subjects = [s for s in raw_subjects if isinstance(s, dict)]
+        campaign, items = create_campaign(
+            store,
+            tenant_id=tenant_id,
+            name=name,
+            subjects=subjects,
+            created_by=_actor(request),
+            due_days=due_days,
+            description=description,
+        )
+    else:
+        discovered = _discover_nhi_subjects()
+        campaign, items = create_campaign_from_discovery(
+            store,
+            tenant_id=tenant_id,
+            name=name,
+            discovered=discovered,
+            created_by=_actor(request),
+            due_days=due_days,
+            description=description,
+        )
+
+    log_action(
+        "identity.access_review_created",
+        actor=_actor(request),
+        resource=f"access-review/{campaign.campaign_id}",
+        tenant_id=tenant_id,
+        name=campaign.name,
+        item_count=campaign.item_count,
+        due_at=campaign.due_at,
+    )
+    _emit(
+        "identity.access_review_created",
+        tenant_id=tenant_id,
+        subject_id=campaign.campaign_id,
+        item_count=campaign.item_count,
+        due_at=campaign.due_at,
+    )
+    return {
+        "schema_version": "identity.access_review.v1",
+        "campaign": campaign.to_public_dict(),
+        "items": [i.to_public_dict() for i in items],
+    }
+
+
+@router.get("/v1/identities/access-reviews", dependencies=[_dep("read")])
+async def list_access_reviews(request: Request, limit: int = 200) -> dict[str, object]:
+    """List access-review campaigns for the active tenant (overdue refreshed)."""
+    from agent_bom.api.access_review import get_access_review_store, refresh_campaign_status
+
+    tenant_id = _tenant(request)
+    bounded = max(1, min(limit, 1000))
+    store = get_access_review_store()
+    campaigns = store.list_campaigns(tenant_id, limit=bounded)
+    refreshed = [refresh_campaign_status(store, tenant_id=tenant_id, campaign_id=c.campaign_id) or c for c in campaigns]
+    return {
+        "schema_version": "identity.access_review.v1",
+        "tenant_id": tenant_id,
+        "count": len(refreshed),
+        "campaigns": [c.to_public_dict() for c in refreshed],
+    }
+
+
+@router.get("/v1/identities/access-reviews/{campaign_id}", dependencies=[_dep("read")])
+async def get_access_review(request: Request, campaign_id: str) -> dict[str, object]:
+    """Return one access-review campaign and its review items."""
+    from agent_bom.api.access_review import get_access_review_store, refresh_campaign_status
+
+    tenant_id = _tenant(request)
+    store = get_access_review_store()
+    campaign = refresh_campaign_status(store, tenant_id=tenant_id, campaign_id=campaign_id)
+    if campaign is None:
+        raise HTTPException(status_code=404, detail="Access-review campaign not found")
+    items = store.list_items(campaign_id, tenant_id)
+    return {
+        "schema_version": "identity.access_review.v1",
+        "campaign": campaign.to_public_dict(),
+        "count": len(items),
+        "items": [i.to_public_dict() for i in items],
+    }
+
+
+@router.post("/v1/identities/access-reviews/{campaign_id}/items/{item_id}/decision", dependencies=[_dep("config")])
+async def submit_access_review_decision(request: Request, campaign_id: str, item_id: str, body: dict) -> dict[str, object]:
+    """Record a reviewer decision (attest / revoke_recommended / flag) on one item.
+
+    Reference-only: a ``revoke_recommended`` decision records the recommendation
+    as audited evidence and (when blocking) emits a governance event; it never
+    executes a revocation on Okta/Entra or any external system.
+    """
+    from agent_bom.api.access_review import _VALID_DECISIONS, get_access_review_store, record_decision
+
+    decision = str(body.get("decision", "") or "").strip()
+    if decision not in _VALID_DECISIONS:
+        raise HTTPException(status_code=400, detail=f"'decision' must be one of {sorted(_VALID_DECISIONS)}")
+    note = str(body.get("note", "") or "")
+    tenant_id = _tenant(request)
+    store = get_access_review_store()
+
+    campaign = store.get_campaign(campaign_id, tenant_id)
+    if campaign is None:
+        raise HTTPException(status_code=404, detail="Access-review campaign not found")
+    result = record_decision(
+        store,
+        tenant_id=tenant_id,
+        item_id=item_id,
+        decision=decision,
+        decided_by=_actor(request),
+        note=note,
+    )
+    if result is None:
+        raise HTTPException(status_code=404, detail="Access-review item not found")
+    item, campaign = result
+    log_action(
+        "identity.access_review_decided",
+        actor=_actor(request),
+        resource=f"access-review/{campaign_id}/item/{item_id}",
+        tenant_id=tenant_id,
+        decision=item.decision,
+        subject_id=item.subject_id,
+        campaign_status=campaign.status,
+    )
+    if item.decision == "revoke_recommended":
+        _emit(
+            "identity.access_review_revoke_recommended",
+            tenant_id=tenant_id,
+            subject_id=item.subject_id,
+            campaign_id=campaign_id,
+        )
+    return {
+        "schema_version": "identity.access_review.v1",
+        "item": item.to_public_dict(),
+        "campaign": campaign.to_public_dict(),
+    }
+
+
+@router.get("/v1/identities/access-reviews/{campaign_id}/evidence", dependencies=[_dep("read")])
+async def export_access_review_evidence(request: Request, campaign_id: str) -> dict[str, object]:
+    """Export a non-secret, signable evidence bundle for one campaign."""
+    from agent_bom.api.access_review import export_evidence, get_access_review_store
+
+    tenant_id = _tenant(request)
+    bundle = export_evidence(get_access_review_store(), tenant_id=tenant_id, campaign_id=campaign_id)
+    if bundle is None:
+        raise HTTPException(status_code=404, detail="Access-review campaign not found")
+    return bundle
+
+
+# Declared last so the ``access-reviews`` static routes above take precedence
+# over this single-identity catch-all.
 @router.get("/v1/identities/{identity_id}", dependencies=[_dep("read")])
 async def get_agent_identity(request: Request, identity_id: str) -> dict[str, object]:
     """Return one agent identity's lifecycle status (metadata only)."""

--- a/tests/test_access_review.py
+++ b/tests/test_access_review.py
@@ -1,0 +1,272 @@
+"""Tests for scheduled access-review / recertification campaigns (issue #2921).
+
+Covers the campaign lifecycle (create -> items -> decide -> complete), overdue
+detection, the audit event emitted per decision, evidence export (reference-only,
+no secret values), tenant isolation, and the non-secret API surface under
+``/v1/identities/access-reviews``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.access_review import (
+    DECISION_ATTEST,
+    DECISION_FLAG,
+    DECISION_REVOKE,
+    STATUS_COMPLETED,
+    STATUS_IN_PROGRESS,
+    STATUS_OPEN,
+    STATUS_OVERDUE,
+    InMemoryAccessReviewStore,
+    SQLiteAccessReviewStore,
+    create_campaign,
+    create_campaign_from_discovery,
+    export_evidence,
+    record_decision,
+    refresh_campaign_status,
+    set_access_review_store,
+)
+
+NOW = datetime(2026, 6, 18, 12, 0, 0, tzinfo=timezone.utc)
+
+_DISCOVERED = [
+    {
+        "identity_id": "0oa1",
+        "name": "billing-svc",
+        "provider": "okta",
+        "identity_type": "service_account",
+        "owner": "finance",
+        "scopes": ["read_invoices", "admin"],
+    },
+    {"identity_id": "sp-2", "name": "ci-deployer", "provider": "entra", "scopes": ["deploy"]},
+]
+
+
+@pytest.fixture()
+def store():
+    s = InMemoryAccessReviewStore()
+    set_access_review_store(s)
+    yield s
+    set_access_review_store(None)
+
+
+# ── Store + lifecycle ──────────────────────────────────────────────────────────
+
+
+def test_create_campaign_enumerates_one_item_per_subject(store):
+    campaign, items = create_campaign_from_discovery(
+        store, tenant_id="t1", name="Q2 recert", discovered=_DISCOVERED, created_by="alice", now=NOW
+    )
+    assert campaign.status == STATUS_OPEN
+    assert campaign.item_count == 2
+    assert campaign.decided_count == 0
+    assert {i.subject_name for i in items} == {"billing-svc", "ci-deployer"}
+    # Admin scope flags the subject as privileged; "deploy" does not.
+    by_name = {i.subject_name: i for i in items}
+    assert by_name["billing-svc"].privileged is True
+    assert by_name["ci-deployer"].privileged is False
+    # Reference-only permission labels are carried, no secret material.
+    assert by_name["billing-svc"].permissions == ["read_invoices", "admin"]
+
+
+def test_create_campaign_sets_due_date(store):
+    campaign, _ = create_campaign_from_discovery(store, tenant_id="t1", name="recert", discovered=_DISCOVERED, due_days=7, now=NOW)
+    assert campaign.due_at == (NOW + timedelta(days=7)).isoformat()
+
+
+def test_lifecycle_create_decide_complete(store):
+    campaign, items = create_campaign_from_discovery(store, tenant_id="t1", name="recert", discovered=_DISCOVERED, now=NOW)
+    # First decision moves the campaign to in_progress.
+    _, c1 = record_decision(store, tenant_id="t1", item_id=items[0].item_id, decision=DECISION_ATTEST, decided_by="alice")
+    assert c1.status == STATUS_IN_PROGRESS
+    assert c1.decided_count == 1
+    # Deciding the last item completes it.
+    _, c2 = record_decision(store, tenant_id="t1", item_id=items[1].item_id, decision=DECISION_REVOKE, decided_by="alice")
+    assert c2.status == STATUS_COMPLETED
+    assert c2.decided_count == 2
+    assert c2.completed_at
+
+
+def test_decision_persists_reviewer_and_note(store):
+    _, items = create_campaign_from_discovery(store, tenant_id="t1", name="recert", discovered=_DISCOVERED, now=NOW)
+    item, _ = record_decision(
+        store, tenant_id="t1", item_id=items[0].item_id, decision=DECISION_FLAG, decided_by="bob", note="needs owner review"
+    )
+    assert item.decision == DECISION_FLAG
+    assert item.decided_by == "bob"
+    assert item.decision_note == "needs owner review"
+    assert item.decided_at
+
+
+def test_invalid_decision_raises(store):
+    _, items = create_campaign_from_discovery(store, tenant_id="t1", name="recert", discovered=_DISCOVERED, now=NOW)
+    with pytest.raises(ValueError):
+        record_decision(store, tenant_id="t1", item_id=items[0].item_id, decision="approve")
+
+
+def test_decision_on_unknown_item_returns_none(store):
+    create_campaign_from_discovery(store, tenant_id="t1", name="recert", discovered=_DISCOVERED, now=NOW)
+    assert record_decision(store, tenant_id="t1", item_id="missing", decision=DECISION_ATTEST) is None
+
+
+def test_overdue_detection(store):
+    past = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    campaign, _ = create_campaign(
+        store, tenant_id="t1", name="old", subjects=[{"subject_id": "x", "subject_name": "x"}], due_days=1, now=past
+    )
+    assert campaign.status == STATUS_OPEN
+    refreshed = refresh_campaign_status(store, tenant_id="t1", campaign_id=campaign.campaign_id, now=NOW)
+    assert refreshed is not None
+    assert refreshed.status == STATUS_OVERDUE
+
+
+def test_completed_campaign_is_never_overdue(store):
+    past = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    campaign, items = create_campaign(
+        store, tenant_id="t1", name="old", subjects=[{"subject_id": "x", "subject_name": "x"}], due_days=1, now=past
+    )
+    record_decision(store, tenant_id="t1", item_id=items[0].item_id, decision=DECISION_ATTEST, now=past)
+    refreshed = refresh_campaign_status(store, tenant_id="t1", campaign_id=campaign.campaign_id, now=NOW)
+    assert refreshed is not None
+    assert refreshed.status == STATUS_COMPLETED
+
+
+def test_evidence_export_is_reference_only(store):
+    campaign, items = create_campaign_from_discovery(store, tenant_id="t1", name="recert", discovered=_DISCOVERED, now=NOW)
+    record_decision(store, tenant_id="t1", item_id=items[0].item_id, decision=DECISION_REVOKE, decided_by="alice")
+    record_decision(store, tenant_id="t1", item_id=items[1].item_id, decision=DECISION_ATTEST, decided_by="alice")
+    bundle = export_evidence(store, tenant_id="t1", campaign_id=campaign.campaign_id, now=NOW)
+    assert bundle is not None
+    assert bundle["secret_values_included"] is False
+    assert bundle["campaign"]["status"] == STATUS_COMPLETED
+    assert bundle["decision_counts"][DECISION_REVOKE] == 1
+    assert bundle["decision_counts"][DECISION_ATTEST] == 1
+    assert "billing-svc" in bundle["revoke_recommended"]
+
+
+def test_tenant_isolation_on_store(store):
+    campaign, items = create_campaign_from_discovery(store, tenant_id="t1", name="recert", discovered=_DISCOVERED, now=NOW)
+    # Wrong tenant cannot read the campaign or its items.
+    assert store.get_campaign(campaign.campaign_id, "t2") is None
+    assert store.get_item(items[0].item_id, "t2") is None
+    assert store.list_campaigns("t2") == []
+    # A decision scoped to the wrong tenant is a no-op (item not found).
+    assert record_decision(store, tenant_id="t2", item_id=items[0].item_id, decision=DECISION_ATTEST) is None
+
+
+def test_sqlite_store_round_trip(tmp_path):
+    db = str(tmp_path / "ar.db")
+    s = SQLiteAccessReviewStore(db)
+    campaign, items = create_campaign_from_discovery(s, tenant_id="t1", name="recert", discovered=_DISCOVERED, now=NOW)
+    record_decision(s, tenant_id="t1", item_id=items[0].item_id, decision=DECISION_ATTEST, decided_by="alice")
+    # Re-open a fresh store against the same DB to confirm persistence.
+    s2 = SQLiteAccessReviewStore(db)
+    reloaded = s2.get_campaign(campaign.campaign_id, "t1")
+    assert reloaded is not None
+    assert reloaded.decided_count == 1
+    items2 = s2.list_items(campaign.campaign_id, "t1")
+    assert len(items2) == 2
+    assert s2.get_campaign(campaign.campaign_id, "t2") is None
+
+
+# ── API surface ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def client(store, monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", "1")
+    from agent_bom.api.server import app
+
+    return TestClient(app)
+
+
+def test_api_create_list_get_decide_evidence(client):
+    created = client.post(
+        "/v1/identities/access-reviews",
+        json={
+            "name": "API recert",
+            "subjects": [
+                {"subject_id": "okta:s1", "subject_name": "svc1", "permissions": ["admin"], "privileged": True},
+                {"subject_id": "entra:s2", "subject_name": "svc2", "permissions": ["read"]},
+            ],
+        },
+    )
+    assert created.status_code == 201, created.text
+    payload = created.json()
+    assert payload["campaign"]["item_count"] == 2
+    cid = payload["campaign"]["campaign_id"]
+    item_ids = [i["item_id"] for i in payload["items"]]
+
+    assert client.get("/v1/identities/access-reviews").json()["count"] == 1
+    assert client.get(f"/v1/identities/access-reviews/{cid}").json()["campaign"]["status"] == STATUS_OPEN
+
+    d1 = client.post(
+        f"/v1/identities/access-reviews/{cid}/items/{item_ids[0]}/decision",
+        json={"decision": "revoke_recommended", "note": "unused 90d"},
+    )
+    assert d1.status_code == 200, d1.text
+    assert d1.json()["campaign"]["status"] == STATUS_IN_PROGRESS
+
+    d2 = client.post(
+        f"/v1/identities/access-reviews/{cid}/items/{item_ids[1]}/decision",
+        json={"decision": "attest"},
+    )
+    assert d2.json()["campaign"]["status"] == STATUS_COMPLETED
+
+    ev = client.get(f"/v1/identities/access-reviews/{cid}/evidence").json()
+    assert ev["secret_values_included"] is False
+    assert ev["campaign"]["status"] == STATUS_COMPLETED
+    assert "svc1" in ev["revoke_recommended"]
+
+
+def test_api_create_requires_name(client):
+    assert client.post("/v1/identities/access-reviews", json={"subjects": []}).status_code == 400
+
+
+def test_api_invalid_decision_400(client):
+    created = client.post(
+        "/v1/identities/access-reviews",
+        json={"name": "r", "subjects": [{"subject_id": "a", "subject_name": "a"}]},
+    ).json()
+    cid = created["campaign"]["campaign_id"]
+    iid = created["items"][0]["item_id"]
+    assert client.post(f"/v1/identities/access-reviews/{cid}/items/{iid}/decision", json={"decision": "x"}).status_code == 400
+
+
+def test_api_unknown_campaign_404(client):
+    assert client.get("/v1/identities/access-reviews/missing").status_code == 404
+    assert client.get("/v1/identities/access-reviews/missing/evidence").status_code == 404
+
+
+def test_api_decision_emits_audit_event(client):
+    from agent_bom.api.audit_log import InMemoryAuditLog, set_audit_log
+
+    audit = InMemoryAuditLog()
+    set_audit_log(audit)
+    try:
+        created = client.post(
+            "/v1/identities/access-reviews",
+            json={"name": "r", "subjects": [{"subject_id": "a", "subject_name": "a"}]},
+        ).json()
+        cid = created["campaign"]["campaign_id"]
+        iid = created["items"][0]["item_id"]
+        client.post(f"/v1/identities/access-reviews/{cid}/items/{iid}/decision", json={"decision": "attest"})
+        actions = {e.action for e in audit.list_entries(limit=100)}
+        assert "identity.access_review_created" in actions
+        assert "identity.access_review_decided" in actions
+        # Audit chain stays intact (no tampered entries).
+        verified, tampered = audit.verify_integrity(limit=100)
+        assert tampered == 0
+        assert verified >= 2
+    finally:
+        set_audit_log(InMemoryAuditLog())
+
+
+def test_api_does_not_collide_with_single_identity_lookup(client):
+    # The static access-reviews routes must take precedence over /v1/identities/{id}.
+    assert client.get("/v1/identities/nonexistent").status_code == 404
+    assert client.get("/v1/identities/access-reviews").status_code == 200


### PR DESCRIPTION
## Summary
The last NHI roadmap item — scheduled access-review / recertification campaigns over discovered non-human identities. Additive, reference-only (records review decisions + evidence; never executes external revocation).

- `api/access_review.py` + `api/postgres_access_review.py` — `AccessReviewCampaign` (open/in_progress/completed/overdue + due date) and `AccessReviewItem` (subject NHI + reference-only permission labels + `privileged` flag + decision pending/attest/revoke_recommended/flag + reviewer/note/timestamp). InMemory→SQLite→Postgres (tenant RLS, upsert), self-selecting backend like `agent_identity_store`.
- 5 endpoints under `/v1/identities/access-reviews`: create (scope defaults to discovered Okta/Entra NHIs + permission refs), list (overdue-refreshed), get, submit decision, export evidence. RBAC: `config` to create/decide, `read` to view. Static routes ordered before the `/{identity_id}` catch-all.
- Every create + decision appended to the HMAC-chained audit log; `revoke_recommended` fans a governance webhook.

## Verification
95 tests pass (17 new + identity suites, no regression); ruff/format/mypy clean; OpenAPI (+4 paths) + atlas regenerated; release-consistency, product-surface, OpenAPI-artifact, env-var checks all pass.