### PR TITLE
feat(output): surface unified-Finding suppression/AI-context/reach in JSON·SARIF·OCSF (#2918 PR-2)

### DIFF
--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -417,6 +417,22 @@ class Finding:
             "related_findings": self.related_findings,
             "evidence": self.evidence,
             "risk_score": self.risk_score,
+            # Suppression state — a suppressed finding must never surface as
+            # unsuppressed downstream (mirrors BlastRadius / SARIF suppressions[]).
+            "suppressed": self.suppressed,
+            "suppression_id": self.suppression_id,
+            "suppression_state": self.suppression_state,
+            "suppression_reason": self.suppression_reason,
+            "unsuppressed_risk_score": self.unsuppressed_risk_score,
+            # AI-native risk context
+            "ai_risk_context": self.ai_risk_context,
+            "ai_summary": self.ai_summary,
+            "attack_vector_summary": self.attack_vector_summary,
+            # Structured reach / blast-radius lists (not collapsed to counts)
+            "affected_servers": list(self.affected_servers),
+            "affected_agents": list(self.affected_agents),
+            "exposed_credentials": list(self.exposed_credentials),
+            "exposed_tools": list(self.exposed_tools),
         }
 
 

--- a/src/agent_bom/output/ocsf.py
+++ b/src/agent_bom/output/ocsf.py
@@ -15,11 +15,14 @@ References:
 from __future__ import annotations
 
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from agent_bom.asset_provenance import sanitize_discovery_provenance
 from agent_bom.graph import SEVERITY_TO_OCSF as _SEVERITY_MAP
 from agent_bom.security import sanitize_sensitive_payload
+
+if TYPE_CHECKING:
+    from agent_bom.finding import Finding
 
 # Detector → OCSF analytic type mapping
 _ANALYTIC_TYPE: dict[str, str] = {
@@ -109,3 +112,116 @@ def alert_to_ocsf(alert: dict, product_version: str = "") -> dict[str, Any]:
 def alerts_to_ocsf(alerts: list[dict], product_version: str = "") -> list[dict]:
     """Convert a list of runtime alerts to OCSF v1.1 format."""
     return [alert_to_ocsf(a, product_version) for a in alerts]
+
+
+# OCSF Security Finding status_id values (schema.ocsf.io). A suppressed finding
+# must surface as Suppressed (4) so SIEM/detection platforms can filter it out
+# rather than treating it as a live "New" detection.
+_OCSF_STATUS_NEW = 1
+_OCSF_STATUS_SUPPRESSED = 4
+
+
+def finding_to_ocsf(finding: "Finding", product_version: str = "") -> dict[str, Any]:
+    """Convert a unified :class:`~agent_bom.finding.Finding` to OCSF v1.1.
+
+    This is the Finding-native OCSF path (vs :func:`alert_to_ocsf`, which is
+    runtime-alert-native). It preserves the fields the unified Finding now
+    carries — **suppression state** (mapped to ``status_id``/``status``),
+    AI-native risk context, and the structured reach lists — so a suppressed
+    finding never appears as a live detection downstream and reach is not
+    collapsed to bare counts.
+    """
+    severity = str(finding.severity or "info").lower()
+    suppressed = bool(finding.suppressed)
+    status_id = _OCSF_STATUS_SUPPRESSED if suppressed else _OCSF_STATUS_NEW
+    status = "Suppressed" if suppressed else "New"
+
+    finding_info: dict[str, Any] = {
+        "title": finding.title or finding.finding_type.value,
+        "uid": finding.id,
+        "desc": finding.description or "",
+        "types": [finding.finding_type.value],
+        "src_url": None,
+    }
+    if finding.cve_id:
+        finding_info["uid"] = finding.id
+        finding_info["cve"] = {"uid": finding.cve_id}
+
+    # AI-native risk context — kept on a dedicated namespaced bag so SIEM
+    # consumers can surface the LLM narrative + attack-vector summary.
+    ai_context = {
+        key: value
+        for key, value in (
+            ("ai_risk_context", finding.ai_risk_context),
+            ("ai_summary", finding.ai_summary),
+            ("attack_vector_summary", finding.attack_vector_summary),
+        )
+        if value
+    }
+
+    # Suppression detail (beyond status_id) lives in unmapped so nothing is lost.
+    suppression: dict[str, Any] = {}
+    if suppressed or finding.suppression_id or finding.suppression_state:
+        suppression = {
+            key: value
+            for key, value in (
+                ("suppressed", suppressed),
+                ("suppression_id", finding.suppression_id),
+                ("suppression_state", finding.suppression_state),
+                ("suppression_reason", finding.suppression_reason),
+                ("unsuppressed_risk_score", finding.unsuppressed_risk_score),
+            )
+            if value is not None
+        }
+
+    unmapped: dict[str, Any] = {
+        "risk_score": finding.risk_score,
+        # Structured reach lists — not collapsed to counts.
+        "affected_servers": list(finding.affected_servers),
+        "affected_agents": list(finding.affected_agents),
+        "exposed_credentials": list(finding.exposed_credentials),
+        "exposed_tools": list(finding.exposed_tools),
+    }
+    if ai_context:
+        unmapped["ai_context"] = ai_context
+    if suppression:
+        unmapped["suppression"] = suppression
+
+    return {
+        "class_uid": 2001,  # Security Finding
+        "class_name": "Security Finding",
+        "category_uid": 2,  # Findings
+        "category_name": "Findings",
+        "severity_id": _SEVERITY_MAP.get(severity, 1),
+        "severity": severity.capitalize(),
+        "activity_id": 1,  # Create
+        "activity_name": "Create",
+        "type_uid": 200101,  # Security Finding: Create
+        "status_id": status_id,
+        "status": status,
+        "time": int(time.time() * 1000),
+        "message": finding.title or finding.description or finding.finding_type.value,
+        "finding_info": finding_info,
+        "resources": [
+            {
+                "type": finding.asset.asset_type,
+                "name": finding.asset.name,
+                "uid": finding.asset.stable_id,
+            }
+        ],
+        "metadata": {
+            "product": {
+                "name": "agent-bom",
+                "vendor_name": "agent-bom",
+                "version": product_version,
+            },
+            "version": "1.1.0",
+            "profiles": ["security_control"],
+        },
+        "unmapped": unmapped,
+    }
+
+
+def findings_to_ocsf(findings: "list[Finding]", product_version: str = "") -> list[dict]:
+    """Convert a list of unified findings to OCSF v1.1 Security Findings."""
+    return [finding_to_ocsf(f, product_version) for f in findings]

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -167,6 +168,65 @@ def _taxonomies_as_tool_extensions(taxonomies: list[dict]) -> list[dict]:
     return extensions
 
 
+_GUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$")
+
+# Map agent-bom suppression states onto the SARIF 2.1.0 suppression.status enum.
+_SARIF_SUPPRESSION_STATUS = {
+    "accepted": "accepted",
+    "acknowledged": "accepted",
+    "resolved": "accepted",
+    "approved": "accepted",
+    "risk_accepted": "accepted",
+    "under_review": "underReview",
+    "pending": "underReview",
+    "open": "underReview",
+    "rejected": "rejected",
+    "denied": "rejected",
+}
+
+
+def _suppression_entries(source: object) -> list[dict]:
+    """Build a SARIF 2.1.0 ``suppressions[]`` array from a suppressed finding/BlastRadius.
+
+    Emitting ``result.suppressions`` is the standard signal SARIF consumers
+    (GitHub Code Scanning, IDEs) use to hide a result. Suppressions persisted
+    in an external tenant store are ``kind: "external"``. The agent-bom-specific
+    ``suppression_id`` / ``suppression_state`` / ``suppression_reason`` ride in
+    the suppression ``properties`` bag (a free-form propertyBag in the schema)
+    so no information is lost while staying schema-valid.
+    """
+    if not getattr(source, "suppressed", False):
+        return []
+    suppression_id = getattr(source, "suppression_id", None)
+    suppression_state = getattr(source, "suppression_state", None)
+    suppression_reason = getattr(source, "suppression_reason", None)
+    unsuppressed_risk_score = getattr(source, "unsuppressed_risk_score", None)
+
+    entry: dict[str, Any] = {"kind": "external"}
+    if isinstance(suppression_id, str) and _GUID_RE.match(suppression_id):
+        entry["guid"] = suppression_id
+    status = _SARIF_SUPPRESSION_STATUS.get(str(suppression_state or "").lower())
+    if status:
+        entry["status"] = status
+    if suppression_reason:
+        # A tenant-authored suppression justification is structural metadata, not
+        # free-text scanner output — keep it (with secret/PII scrubbing) rather
+        # than dropping it through the replay-only persistence tier.
+        justification = sanitize_sensitive_payload(str(suppression_reason), key="justification", max_str_len=1000)
+        if isinstance(justification, str) and justification:
+            entry["justification"] = justification
+    properties: dict[str, Any] = {}
+    if suppression_id is not None:
+        properties["suppression_id"] = sanitize_sensitive_payload(str(suppression_id), key="suppression_id", max_str_len=200)
+    if suppression_state is not None:
+        properties["suppression_state"] = sanitize_sensitive_payload(str(suppression_state), key="suppression_state", max_str_len=200)
+    if unsuppressed_risk_score is not None:
+        properties["unsuppressed_risk_score"] = unsuppressed_risk_score
+    if properties:
+        entry["properties"] = properties
+    return [entry]
+
+
 def _framework_taxa_references(properties: dict[str, Any]) -> list[dict]:
     """Build result-level SARIF taxa references for declared framework taxonomies."""
     refs: list[dict] = []
@@ -291,6 +351,13 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
             "impact_category": getattr(br, "impact_category", "code-execution"),
             "attack_vector_summary": getattr(br, "attack_vector_summary", None),
             "reachability": br.reachability,
+            # Structured reach lists + AI-native context (unified Finding parity).
+            "affected_servers": [s.name for s in br.affected_servers],
+            "affected_agents": [a.name for a in br.affected_agents],
+            "exposed_tools": [t.name for t in br.exposed_tools],
+            "ai_risk_context": getattr(br, "ai_risk_context", None),
+            "ai_summary": getattr(br, "ai_summary", None),
+            "suppressed": bool(getattr(br, "suppressed", False)),
         }
         package_provenance = package_discovery_provenance(br.package)
         if package_provenance:
@@ -347,6 +414,9 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
                 }
             )
         result["properties"] = result_properties
+        suppressions = _suppression_entries(br)
+        if suppressions:
+            result["suppressions"] = suppressions
         taxa_refs = _framework_taxa_references(result_properties)
         if taxa_refs:
             result["taxa"] = taxa_refs
@@ -386,36 +456,47 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
         file_path = _to_relative_path(finding.asset.location or "agent-bom-report.json")
         fp_input = f"{finding.id}:{file_path}:{finding.asset.stable_id}"
         fingerprint = hashlib.sha256(fp_input.encode()).hexdigest()
-        results.append(
-            {
-                "ruleId": rule_id,
-                "level": level,
-                "kind": "fail" if level in {"error", "warning"} else "informational",
-                "message": {
-                    "text": _sanitize_sarif_text(
-                        "title",
-                        finding.title,
-                        fallback=_sanitize_sarif_text("description", finding.description, fallback=finding.finding_type.value),
-                    )
-                },
-                "fingerprints": {"agent-bom/v1": fingerprint},
-                "locations": [
-                    {
-                        "physicalLocation": {
-                            "artifactLocation": {"uri": file_path, "uriBaseId": "%SRCROOT%"},
-                            "region": {"startLine": 1, "startColumn": 1},
-                        },
-                    }
-                ],
-                "properties": {
-                    "risk_score": finding.risk_score,
-                    "asset_type": finding.asset.asset_type,
-                    "asset_name": _sanitize_sarif_text("title", finding.asset.name, fallback=finding.asset.asset_type),
-                    "evidence": _sanitize_sarif_property(finding.evidence),
-                    "remediation_guidance": _sanitize_sarif_property(finding.remediation_guidance),
-                },
-            }
-        )
+        finding_result: dict = {
+            "ruleId": rule_id,
+            "level": level,
+            "kind": "fail" if level in {"error", "warning"} else "informational",
+            "message": {
+                "text": _sanitize_sarif_text(
+                    "title",
+                    finding.title,
+                    fallback=_sanitize_sarif_text("description", finding.description, fallback=finding.finding_type.value),
+                )
+            },
+            "fingerprints": {"agent-bom/v1": fingerprint},
+            "locations": [
+                {
+                    "physicalLocation": {
+                        "artifactLocation": {"uri": file_path, "uriBaseId": "%SRCROOT%"},
+                        "region": {"startLine": 1, "startColumn": 1},
+                    },
+                }
+            ],
+            "properties": {
+                "risk_score": finding.risk_score,
+                "asset_type": finding.asset.asset_type,
+                "asset_name": _sanitize_sarif_text("title", finding.asset.name, fallback=finding.asset.asset_type),
+                "evidence": _sanitize_sarif_property(finding.evidence),
+                "remediation_guidance": _sanitize_sarif_property(finding.remediation_guidance),
+                # Structured reach lists + AI-native context (unified Finding parity).
+                "affected_servers": list(finding.affected_servers),
+                "affected_agents": list(finding.affected_agents),
+                "exposed_credentials": list(finding.exposed_credentials),
+                "exposed_tools": list(finding.exposed_tools),
+                "ai_risk_context": finding.ai_risk_context,
+                "ai_summary": finding.ai_summary,
+                "attack_vector_summary": finding.attack_vector_summary,
+                "suppressed": finding.suppressed,
+            },
+        }
+        suppressions = _suppression_entries(finding)
+        if suppressions:
+            finding_result["suppressions"] = suppressions
+        results.append(finding_result)
 
     # IaC misconfiguration findings (Dockerfile, K8s, Terraform, CloudFormation)
     iac_data = getattr(report, "iac_findings_data", None)

--- a/tests/test_finding_field_surfacing.py
+++ b/tests/test_finding_field_surfacing.py
@@ -1,0 +1,283 @@
+"""Surfacing tests for unified-Finding fields across JSON / SARIF / OCSF (#2918, PR-2).
+
+PR-1 (#2960) made suppression state, AI-native context, and the structured reach
+lists first-class on :class:`~agent_bom.finding.Finding`. This stage surfaces them
+in the three Finding-native formatters. These tests assert each format now carries
+the new fields AND that a plain (non-suppressed, no-AI) finding's output is otherwise
+unchanged — the additive fields are the *only* delta.
+"""
+
+from __future__ import annotations
+
+import json
+
+from agent_bom.finding import blast_radius_to_finding
+from agent_bom.models import (
+    AIBOMReport,
+    BlastRadius,
+    MCPServer,
+    Package,
+    TransportType,
+    Vulnerability,
+)
+from agent_bom.output.json_fmt import to_json
+from agent_bom.output.ocsf import finding_to_ocsf, findings_to_ocsf
+from agent_bom.output.sarif import to_sarif
+
+# The fields PR-2 adds to each format. Stripping these from a plain finding's
+# serialization must reproduce the pre-PR-2 output exactly (snapshot guard).
+_NEW_JSON_FINDING_KEYS = {
+    "suppressed",
+    "suppression_id",
+    "suppression_state",
+    "suppression_reason",
+    "unsuppressed_risk_score",
+    "ai_risk_context",
+    "ai_summary",
+    "attack_vector_summary",
+    "affected_servers",
+    "affected_agents",
+    "exposed_credentials",
+    "exposed_tools",
+}
+_NEW_SARIF_RESULT_PROPERTY_KEYS = {
+    "affected_servers",
+    "affected_agents",
+    "exposed_tools",
+    "ai_risk_context",
+    "ai_summary",
+    "suppressed",
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _vuln(vuln_id: str = "CVE-2024-0001", severity=None) -> Vulnerability:
+    from agent_bom.models import Severity
+
+    return Vulnerability(
+        id=vuln_id,
+        summary="Test vulnerability",
+        severity=severity or Severity.HIGH,
+        cvss_score=7.5,
+        fixed_version="2.0.0",
+    )
+
+
+def _pkg(name: str = "requests", version: str = "1.0.0") -> Package:
+    return Package(name=name, version=version, ecosystem="pypi")
+
+
+def _server(name: str) -> MCPServer:
+    return MCPServer(name=name, command="npx srv", transport=TransportType.STDIO)
+
+
+def _plain_br() -> BlastRadius:
+    """An ordinary, non-suppressed, no-AI-context blast radius."""
+    return BlastRadius(
+        vulnerability=_vuln("CVE-2024-PLAIN"),
+        package=_pkg("plainpkg"),
+        affected_servers=[_server("plain-server")],
+        affected_agents=[],
+        exposed_credentials=[],
+        exposed_tools=[],
+        risk_score=5.0,
+    )
+
+
+def _suppressed_br() -> BlastRadius:
+    br = BlastRadius(
+        vulnerability=_vuln("CVE-2024-SUPPRESSED"),
+        package=_pkg("suppressedpkg"),
+        affected_servers=[_server("supp-server")],
+        affected_agents=[],
+        exposed_credentials=["OPENAI_API_KEY"],
+        exposed_tools=[],
+        risk_score=0.0,
+    )
+    br.suppressed = True
+    br.suppression_id = "550e8400-e29b-41d4-a716-446655440000"  # valid GUID
+    br.suppression_state = "acknowledged"
+    br.suppression_reason = "Risk accepted by platform owner"
+    br.unsuppressed_risk_score = 9.2
+    return br
+
+
+def _ai_context_br() -> BlastRadius:
+    br = BlastRadius(
+        vulnerability=_vuln("CVE-2024-AICTX"),
+        package=_pkg("aipkg"),
+        affected_servers=[_server("srv-a"), _server("srv-b"), _server("srv-c")],
+        affected_agents=[],
+        exposed_credentials=["AWS_SECRET_ACCESS_KEY", "STRIPE_KEY"],
+        exposed_tools=[],
+        risk_score=8.5,
+    )
+    br.ai_risk_context = "Reachable from an internet-exposed agent"
+    br.ai_summary = "LLM-generated risk narrative"
+    br.attack_vector_summary = "agent -> srv-a -> vulnerable aipkg"
+    return br
+
+
+def _report() -> AIBOMReport:
+    return AIBOMReport(
+        agents=[],
+        blast_radii=[_plain_br(), _suppressed_br(), _ai_context_br()],
+    )
+
+
+# ---------------------------------------------------------------------------
+# JSON surfacing
+# ---------------------------------------------------------------------------
+
+
+def _json_finding(data: dict, cve_id: str) -> dict:
+    for finding in data["findings"]:
+        if finding.get("cve_id") == cve_id:
+            return finding
+    raise AssertionError(f"no JSON finding for {cve_id}")
+
+
+def test_json_findings_surface_suppression():
+    data = to_json(_report())
+    supp = _json_finding(data, "CVE-2024-SUPPRESSED")
+    assert supp["suppressed"] is True
+    assert supp["suppression_id"] == "550e8400-e29b-41d4-a716-446655440000"
+    assert supp["suppression_state"] == "acknowledged"
+    assert supp["suppression_reason"] == "Risk accepted by platform owner"
+    assert supp["unsuppressed_risk_score"] == 9.2
+
+
+def test_json_findings_surface_ai_context_and_reach():
+    data = to_json(_report())
+    ai = _json_finding(data, "CVE-2024-AICTX")
+    assert ai["ai_risk_context"] == "Reachable from an internet-exposed agent"
+    assert ai["ai_summary"] == "LLM-generated risk narrative"
+    assert ai["attack_vector_summary"] == "agent -> srv-a -> vulnerable aipkg"
+    assert ai["affected_servers"] == ["srv-a", "srv-b", "srv-c"]
+    assert ai["exposed_credentials"] == ["AWS_SECRET_ACCESS_KEY", "STRIPE_KEY"]
+
+
+def test_json_plain_finding_unchanged_except_additive_fields():
+    """Snapshot guard: stripping the new keys reproduces the pre-PR-2 payload."""
+    data = to_json(_report())
+    plain = _json_finding(data, "CVE-2024-PLAIN")
+
+    # Every new key is present (additive contract).
+    assert _NEW_JSON_FINDING_KEYS.issubset(plain.keys())
+
+    # A plain finding has benign defaults — nothing alarming surfaced.
+    assert plain["suppressed"] is False
+    assert plain["suppression_id"] is None
+    assert plain["ai_risk_context"] is None
+
+    # Rebuild the legacy payload by removing only the additive keys and confirm
+    # it equals what Finding.to_dict produced before this PR (recomputed from a
+    # finding whose new fields are all defaults => identical to legacy output).
+    legacy = {k: v for k, v in plain.items() if k not in _NEW_JSON_FINDING_KEYS}
+    expected = blast_radius_to_finding(_plain_br()).to_dict()
+    expected_legacy = {k: v for k, v in expected.items() if k not in _NEW_JSON_FINDING_KEYS}
+    assert legacy == expected_legacy
+    # And the doc round-trips as JSON.
+    json.dumps(data)
+
+
+# ---------------------------------------------------------------------------
+# SARIF surfacing
+# ---------------------------------------------------------------------------
+
+
+def _sarif_result(doc: dict, rule_id: str) -> dict:
+    for result in doc["runs"][0]["results"]:
+        if result.get("ruleId") == rule_id:
+            return result
+    raise AssertionError(f"no SARIF result for {rule_id}")
+
+
+def test_sarif_suppressed_finding_emits_suppressions_array():
+    doc = to_sarif(_report())
+    result = _sarif_result(doc, "CVE-2024-SUPPRESSED")
+    suppressions = result["suppressions"]
+    assert len(suppressions) == 1
+    entry = suppressions[0]
+    assert entry["kind"] == "external"
+    assert entry["guid"] == "550e8400-e29b-41d4-a716-446655440000"
+    assert entry["status"] == "accepted"  # "acknowledged" maps to SARIF "accepted"
+    assert entry["justification"] == "Risk accepted by platform owner"
+    assert entry["properties"]["suppression_state"] == "acknowledged"
+    assert entry["properties"]["unsuppressed_risk_score"] == 9.2
+
+
+def test_sarif_plain_finding_has_no_suppressions():
+    doc = to_sarif(_report())
+    result = _sarif_result(doc, "CVE-2024-PLAIN")
+    assert "suppressions" not in result
+    assert result["properties"]["suppressed"] is False
+
+
+def test_sarif_surfaces_ai_context_and_reach():
+    doc = to_sarif(_report())
+    props = _sarif_result(doc, "CVE-2024-AICTX")["properties"]
+    assert props["ai_risk_context"] == "Reachable from an internet-exposed agent"
+    assert props["ai_summary"] == "LLM-generated risk narrative"
+    assert props["affected_servers"] == ["srv-a", "srv-b", "srv-c"]
+    assert props["exposed_tools"] == []
+
+
+def test_sarif_plain_result_properties_superset_only():
+    """The plain result must carry the additive property keys and nothing alarming."""
+    doc = to_sarif(_report())
+    props = _sarif_result(doc, "CVE-2024-PLAIN")["properties"]
+    assert _NEW_SARIF_RESULT_PROPERTY_KEYS.issubset(props.keys())
+    assert props["affected_servers"] == ["plain-server"]
+    assert props["ai_risk_context"] is None
+
+
+# ---------------------------------------------------------------------------
+# OCSF surfacing
+# ---------------------------------------------------------------------------
+
+
+def test_ocsf_suppressed_finding_status_suppressed():
+    finding = blast_radius_to_finding(_suppressed_br())
+    event = finding_to_ocsf(finding, product_version="9.9.9")
+    assert event["class_uid"] == 2001
+    assert event["status_id"] == 4  # Suppressed
+    assert event["status"] == "Suppressed"
+    supp = event["unmapped"]["suppression"]
+    assert supp["suppressed"] is True
+    assert supp["suppression_id"] == "550e8400-e29b-41d4-a716-446655440000"
+    assert supp["suppression_state"] == "acknowledged"
+    assert supp["unsuppressed_risk_score"] == 9.2
+
+
+def test_ocsf_ai_context_and_reach_surface():
+    finding = blast_radius_to_finding(_ai_context_br())
+    event = finding_to_ocsf(finding)
+    ai = event["unmapped"]["ai_context"]
+    assert ai["ai_risk_context"] == "Reachable from an internet-exposed agent"
+    assert ai["ai_summary"] == "LLM-generated risk narrative"
+    assert ai["attack_vector_summary"] == "agent -> srv-a -> vulnerable aipkg"
+    assert event["unmapped"]["affected_servers"] == ["srv-a", "srv-b", "srv-c"]
+    assert event["unmapped"]["exposed_credentials"] == ["AWS_SECRET_ACCESS_KEY", "STRIPE_KEY"]
+
+
+def test_ocsf_plain_finding_status_new_and_no_suppression():
+    finding = blast_radius_to_finding(_plain_br())
+    event = finding_to_ocsf(finding)
+    assert event["status_id"] == 1  # New
+    assert event["status"] == "New"
+    assert "suppression" not in event["unmapped"]
+    assert "ai_context" not in event["unmapped"]
+    assert event["unmapped"]["affected_servers"] == ["plain-server"]
+    # JSON-serializable.
+    json.dumps(event)
+
+
+def test_findings_to_ocsf_batch():
+    findings = [blast_radius_to_finding(br) for br in (_plain_br(), _suppressed_br())]
+    events = findings_to_ocsf(findings)
+    assert [e["status_id"] for e in events] == [1, 4]


### PR DESCRIPTION
## Summary
PR-2 (mechanical stage of #2918) surfaces the unified-`Finding` fields PR-1 (#2960) added — additive, **BlastRadius untouched**, no existing output removed.

- **JSON** (`finding.py` `to_dict()`): the `findings` array now emits suppression (×5), AI-context (×3), and structured reach (`affected_servers/agents`, `exposed_credentials/tools`).
- **SARIF** (`output/sarif.py`): reach + AI-context as result properties, and a schema-valid **`suppressions[]`** array on suppressed results (`kind: external`; `status` mapped from `suppression_state` to the SARIF enum; GUID only when valid; scrubbed justification) — so GitHub Code Scanning / IDEs hide only genuinely-suppressed findings. Non-suppressed results emit no `suppressions` key.
- **OCSF** (`output/ocsf.py`): new Finding-native `finding_to_ocsf()`; suppressed → `status_id: 4` (Suppressed), else New — a suppressed finding never appears as a live detection. AI-context + reach under `unmapped`.

## Verification
11 new snapshot tests (each format carries the new fields; a plain finding's output is byte-identical minus the additive keys) + 91 existing formatter/SARIF/OCSF tests; broad sweep **677 passed, 0 failed**. SARIF stays 2.1.0 schema-valid. ruff/format/mypy clean. No models/OpenAPI change → no regen.