### PR TITLE
feat(nhi): usage right-sizing + dormancy/orphan detection + per-identity risk score

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 227 |
+| `docs/openapi/v1.json` | paths | 228 |
 | `docs/openapi/v1.json` | component schemas | 61 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -11709,6 +11709,60 @@
         ]
       }
     },
+    "/v1/graph/nhi/governance": {
+      "get": {
+        "description": "Return the non-human-identity governance posture for the latest graph.\n\nLoads the latest unified graph, projects the live governance control plane\nand resolves effective permissions, then computes the three Natoma-parity\nanalytics \u2014 usage-based right-sizing, dormant/orphaned detection, and the\n0-100 per-identity risk score \u2014 and returns a non-secret posture ranked\nworst risk first. Right-sizing here uses the durable `last_used_at` markers\nin the graph (no caller usage map is accepted over the API).",
+        "operationId": "get_nhi_governance_v1_graph_nhi_governance_get",
+        "parameters": [
+          {
+            "description": "Scan ID",
+            "in": "query",
+            "name": "scan_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scan ID",
+              "title": "Scan Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Nhi Governance V1 Graph Nhi Governance Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Nhi Governance",
+        "tags": [
+          "graph"
+        ]
+      }
+    },
     "/v1/graph/node/{node_id}": {
       "get": {
         "description": "Get a single node with its edges, neighbors, and impact stats.",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -7635,6 +7635,45 @@ paths:
       summary: Get Graph Legend
       tags:
       - graph
+  /v1/graph/nhi/governance:
+    get:
+      description: "Return the non-human-identity governance posture for the latest\
+        \ graph.\n\nLoads the latest unified graph, projects the live governance control\
+        \ plane\nand resolves effective permissions, then computes the three Natoma-parity\n\
+        analytics \u2014 usage-based right-sizing, dormant/orphaned detection, and\
+        \ the\n0-100 per-identity risk score \u2014 and returns a non-secret posture\
+        \ ranked\nworst risk first. Right-sizing here uses the durable `last_used_at`\
+        \ markers\nin the graph (no caller usage map is accepted over the API)."
+      operationId: get_nhi_governance_v1_graph_nhi_governance_get
+      parameters:
+      - description: Scan ID
+        in: query
+        name: scan_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Scan ID
+          title: Scan Id
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Nhi Governance V1 Graph Nhi Governance Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Nhi Governance
+      tags:
+      - graph
   /v1/graph/node/{node_id}:
     get:
       description: Get a single node with its edges, neighbors, and impact stats.

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -82,6 +82,8 @@ AGENT_BOM_CRED_MAX_AGE_DAYS
 AGENT_BOM_CRED_NEAR_EXPIRY_DAYS
 # Default rotation interval (days) for credentials without a per-secret interval; read in api/credential_expiry.py (#2923).
 AGENT_BOM_CRED_ROTATION_DAYS
+# Dormancy window (days, default 90) before a non-human identity with no recent usage is flagged dormant; read in graph/nhi_governance.py.
+AGENT_BOM_NHI_DORMANT_DAYS
 AGENT_BOM_CORS_ALL
 AGENT_BOM_DASHBOARD_CSP_HASH_MANIFEST
 AGENT_BOM_DB

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -1667,6 +1667,35 @@ async def get_graph_governance(
     }
 
 
+@router.get("/v1/graph/nhi/governance", tags=["graph"])
+async def get_nhi_governance(
+    request: Request,
+    scan_id: Optional[str] = Query(None, description="Scan ID"),
+) -> dict:
+    """Return the non-human-identity governance posture for the latest graph.
+
+    Loads the latest unified graph, projects the live governance control plane
+    and resolves effective permissions, then computes the three Natoma-parity
+    analytics — usage-based right-sizing, dormant/orphaned detection, and the
+    0-100 per-identity risk score — and returns a non-secret posture ranked
+    worst risk first. Right-sizing here uses the durable `last_used_at` markers
+    in the graph (no caller usage map is accepted over the API).
+    """
+    from agent_bom.graph.effective_permissions import apply_effective_permissions
+    from agent_bom.graph.governance_overlay import apply_governance_overlay
+    from agent_bom.graph.nhi_governance import describe_nhi_governance_posture
+
+    tenant = _tenant(request)
+    graph_store = _get_graph_store_or_503()
+    graph = await _graph_store_call(graph_store.load_graph, scan_id=scan_id or "", tenant_id=tenant)
+    apply_governance_overlay(graph, tenant_id=tenant)
+    apply_effective_permissions(graph)
+    posture = describe_nhi_governance_posture(graph)
+    posture["scan_id"] = graph.scan_id
+    posture["tenant_id"] = tenant
+    return posture
+
+
 @router.get("/v1/graph/exposure-paths", tags=["graph"])
 async def get_graph_exposure_paths(
     request: Request,

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -935,6 +935,17 @@ def build_unified_graph_from_report(
     except Exception:  # noqa: BLE001
         _logger.warning("effective-permissions overlay failed", exc_info=True)
 
+    # NHI governance: usage-based right-sizing, dormant/orphaned detection, and a
+    # 0-100 per-identity risk score, written back onto the managed_identity nodes.
+    # Runs after effective-permissions + CNAPP so it sees HAS_PERMISSION edges,
+    # escalation flags, and internet-exposure markers. No-op when no NHIs exist.
+    try:
+        from agent_bom.graph.nhi_governance import apply_nhi_governance
+
+        apply_nhi_governance(graph)
+    except Exception:  # noqa: BLE001
+        _logger.warning("NHI governance overlay failed", exc_info=True)
+
     # A2A auth posture: flag agent/identity nodes named by weak inter-agent
     # auth findings (shared tokens, missing mutual auth, over-broad delegation,
     # unverified actor tokens). Reference-only; no-op when no A2A findings exist.

--- a/src/agent_bom/graph/nhi_governance.py
+++ b/src/agent_bom/graph/nhi_governance.py
@@ -1,0 +1,533 @@
+"""Non-human-identity (NHI) governance analytics over the unified graph.
+
+The discovery (:mod:`agent_bom.graph.nhi_overlay`), governance
+(:mod:`agent_bom.graph.governance_overlay`), and effective-permissions
+(:mod:`agent_bom.graph.effective_permissions`) overlays place
+``managed_identity`` nodes, ``HAS_PERMISSION`` / ``SCOPED_TO`` edges, and
+privilege flags into one graph. This module is pure *analytics over that data* —
+the three Natoma-parity capabilities that close the 2026-06-19 audit gap:
+
+1. **Usage-based right-sizing.** Diff the permissions an identity is *granted*
+   (the ``HAS_PERMISSION`` transitive closure + standing ``SCOPED_TO`` tool
+   bindings) against what it is *observed* to use. Observed usage comes from a
+   caller-passed usage map (``{identity_id: {permission targets used}}``) and/or
+   per-target ``last_used_at`` telemetry on the edges, so it is testable without
+   a live telemetry source. Granted-but-never-used targets are over-grants.
+
+2. **Orphaned / dormant identity detection.** An identity with no recorded owner
+   is *orphaned*; one whose ``last_used_at`` is older than
+   ``AGENT_BOM_NHI_DORMANT_DAYS`` (default 90) — or which has no usage timestamp
+   at all — is *dormant*. Both are standing, unattended attack surface.
+
+3. **Per-identity risk score (0-100).** A single sortable score aggregating
+   privilege level (admin / escalation), internet-exposure reachability,
+   credential staleness (reusing :mod:`agent_bom.api.credential_expiry`), and
+   dormancy. The score is written back onto the ``managed_identity`` node so the
+   graph, API, and findings all rank the same way.
+
+Reference-only: consumes labels, timestamps, and edge metadata already in the
+graph; never touches secret material and never raises into the builder.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from agent_bom.api.credential_expiry import classify_credential
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.types import EntityType, RelationshipType
+
+_OVERLAY_SOURCE = "nhi-governance"
+
+DEFAULT_DORMANT_DAYS = 90
+
+# Permission/scope edges that count as a *granted* capability for right-sizing.
+_GRANT_RELS = frozenset({RelationshipType.HAS_PERMISSION, RelationshipType.SCOPED_TO})
+
+# Credential states (from credential_expiry) that contribute staleness risk,
+# mapped to the fraction of the staleness sub-score they carry.
+_STALENESS_WEIGHT: dict[str, float] = {
+    "expired": 1.0,
+    "overdue": 1.0,
+    "rotation_due": 0.7,
+    "near_expiry": 0.5,
+    "unknown_age": 0.3,
+    "ok": 0.0,
+}
+
+# Risk sub-score weights (sum to 100). Privilege and exposure dominate because a
+# dormant low-privilege identity is far less dangerous than a live admin one.
+_W_PRIVILEGE = 35.0
+_W_EXPOSURE = 25.0
+_W_STALENESS = 20.0
+_W_DORMANCY = 12.0
+_W_ORPHAN = 8.0
+
+_MAX_IDENTITIES = 5000
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return default
+    return parsed if parsed >= 0 else default
+
+
+def dormant_days() -> int:
+    """Configured dormancy window in days (default 90)."""
+    return _env_int("AGENT_BOM_NHI_DORMANT_DAYS", DEFAULT_DORMANT_DAYS)
+
+
+def _parse_timestamp(raw: Any) -> datetime | None:
+    if not isinstance(raw, str):
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _days_since(ts: datetime, now: datetime) -> int:
+    return int((now - ts).total_seconds() // 86400)
+
+
+@dataclass
+class IdentityGovernance:
+    """Per-identity governance verdict (non-secret, JSON-serializable)."""
+
+    node_id: str
+    identity_id: str
+    name: str
+    provider: str | None
+    owner: str | None
+    risk_score: int
+    risk_band: str
+    granted_count: int
+    used_count: int
+    unused_targets: list[str] = field(default_factory=list)
+    is_orphaned: bool = False
+    is_dormant: bool = False
+    dormant_days: int | None = None
+    last_used_at: str | None = None
+    credential_state: str | None = None
+    is_privileged: bool = False
+    can_escalate: bool = False
+    internet_exposed: bool = False
+    risk_factors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "node_id": self.node_id,
+            "identity_id": self.identity_id,
+            "name": self.name,
+            "provider": self.provider,
+            "owner": self.owner,
+            "risk_score": self.risk_score,
+            "risk_band": self.risk_band,
+            "granted_count": self.granted_count,
+            "used_count": self.used_count,
+            "unused_permission_count": len(self.unused_targets),
+            "unused_targets": list(self.unused_targets),
+            "is_orphaned": self.is_orphaned,
+            "is_dormant": self.is_dormant,
+            "dormant_days": self.dormant_days,
+            "last_used_at": self.last_used_at,
+            "credential_state": self.credential_state,
+            "is_privileged": self.is_privileged,
+            "can_escalate": self.can_escalate,
+            "internet_exposed": self.internet_exposed,
+            "risk_factors": list(self.risk_factors),
+        }
+
+
+def _risk_band(score: int) -> str:
+    if score >= 75:
+        return "critical"
+    if score >= 50:
+        return "high"
+    if score >= 25:
+        return "medium"
+    return "low"
+
+
+def _granted_targets(graph: UnifiedGraph, node_id: str) -> dict[str, str | None]:
+    """Return {granted target id: last_used_at on the edge (or None)}."""
+    granted: dict[str, str | None] = {}
+    for edge in graph.edges:
+        if edge.source != node_id or edge.relationship not in _GRANT_RELS:
+            continue
+        last_used = None
+        if isinstance(edge.evidence, Mapping):
+            raw = edge.evidence.get("last_used_at")
+            last_used = str(raw) if isinstance(raw, str) and raw.strip() else None
+        # An earlier edge to the same target with a usage timestamp wins.
+        if edge.target not in granted or (last_used and not granted[edge.target]):
+            granted[edge.target] = last_used
+    return granted
+
+
+def _exposed_targets(graph: UnifiedGraph, targets: set[str]) -> bool:
+    return any(graph.nodes.get(tid) is not None and bool(graph.nodes[tid].attributes.get("internet_exposed")) for tid in targets)
+
+
+def evaluate_identity_governance(
+    graph: UnifiedGraph,
+    *,
+    usage: Mapping[str, set[str]] | Mapping[str, list[str]] | None = None,
+    dormant_after_days: int | None = None,
+    now: datetime | None = None,
+) -> list[IdentityGovernance]:
+    """Compute the per-identity governance verdict for every NHI in the graph.
+
+    ``usage`` maps an identity id (or node id) to the set of permission targets
+    it was *observed* to use. When omitted, observed usage falls back to any
+    ``last_used_at`` markers on the grant edges; a grant with neither is treated
+    as unused for right-sizing. Never raises.
+    """
+    now = now or datetime.now(timezone.utc)
+    window = dormant_after_days if dormant_after_days is not None else dormant_days()
+    usage_map: dict[str, set[str]] = {}
+    if usage:
+        for key, vals in usage.items():
+            usage_map[str(key)] = {str(v) for v in vals}
+
+    identities = [n for n in graph.nodes.values() if n.entity_type == EntityType.MANAGED_IDENTITY]
+    results: list[IdentityGovernance] = []
+    for node in identities[:_MAX_IDENTITIES]:
+        attrs = node.attributes
+        identity_id = str(attrs.get("identity_id") or node.id)
+        owner = attrs.get("owner")
+        owner_str = str(owner).strip() if isinstance(owner, str) and str(owner).strip() else None
+
+        granted = _granted_targets(graph, node.id)
+        observed = set(usage_map.get(identity_id, set())) | set(usage_map.get(node.id, set()))
+        # Edge-level last_used markers count as observed usage for that target.
+        observed |= {tid for tid, last_used in granted.items() if last_used}
+        unused = sorted(tid for tid in granted if tid not in observed)
+
+        # ── Dormancy ──
+        last_used_at = attrs.get("last_used_at")
+        last_used_dt = _parse_timestamp(last_used_at)
+        dormancy_days: int | None = None
+        if last_used_dt is not None:
+            dormancy_days = max(0, _days_since(last_used_dt, now))
+            is_dormant = dormancy_days >= window
+        else:
+            # No usage timestamp at all → treat as dormant (never-observed).
+            is_dormant = True
+        is_orphaned = owner_str is None
+
+        # ── Privilege / exposure ──
+        is_privileged = bool(attrs.get("escalates_to_admin") or attrs.get("is_admin") or attrs.get("privilege_level") == "admin")
+        can_escalate = bool(attrs.get("can_escalate_privilege"))
+        internet_exposed = bool(attrs.get("internet_exposed")) or _exposed_targets(graph, set(granted))
+
+        # ── Credential staleness (reuse credential_expiry classifier) ──
+        cred_state = classify_credential(
+            {
+                "id": identity_id,
+                "name": node.label,
+                "provider": attrs.get("provider"),
+                "credential_expires_at": attrs.get("credential_expires_at"),
+                "last_rotated": attrs.get("last_rotated") or attrs.get("created_at"),
+            },
+            now=now,
+        )["state"]
+
+        # ── Aggregate 0-100 risk score ──
+        privilege_factor = 1.0 if is_privileged else (0.6 if can_escalate else 0.0)
+        exposure_factor = 1.0 if internet_exposed else 0.0
+        staleness_factor = _STALENESS_WEIGHT.get(cred_state, 0.0)
+        dormancy_factor = 0.0
+        if is_dormant:
+            if dormancy_days is None:
+                dormancy_factor = 1.0
+            else:
+                dormancy_factor = min(1.0, dormancy_days / max(window, 1))
+        orphan_factor = 1.0 if is_orphaned else 0.0
+
+        score = (
+            _W_PRIVILEGE * privilege_factor
+            + _W_EXPOSURE * exposure_factor
+            + _W_STALENESS * staleness_factor
+            + _W_DORMANCY * dormancy_factor
+            + _W_ORPHAN * orphan_factor
+        )
+        risk_score = int(round(min(100.0, score)))
+
+        factors: list[str] = []
+        if is_privileged:
+            factors.append("admin/privileged")
+        elif can_escalate:
+            factors.append("can escalate privilege")
+        if internet_exposed:
+            factors.append("reaches internet-exposed resource")
+        if staleness_factor > 0:
+            factors.append(f"credential {cred_state}")
+        if is_dormant:
+            factors.append("dormant" if dormancy_days is None else f"dormant {dormancy_days}d")
+        if is_orphaned:
+            factors.append("no owner")
+        if unused:
+            factors.append(f"{len(unused)} unused permission(s)")
+
+        results.append(
+            IdentityGovernance(
+                node_id=node.id,
+                identity_id=identity_id,
+                name=node.label,
+                provider=attrs.get("provider") if isinstance(attrs.get("provider"), str) else None,
+                owner=owner_str,
+                risk_score=risk_score,
+                risk_band=_risk_band(risk_score),
+                granted_count=len(granted),
+                used_count=len(observed & set(granted)),
+                unused_targets=unused,
+                is_orphaned=is_orphaned,
+                is_dormant=is_dormant,
+                dormant_days=dormancy_days,
+                last_used_at=str(last_used_at) if isinstance(last_used_at, str) else None,
+                credential_state=cred_state,
+                is_privileged=is_privileged,
+                can_escalate=can_escalate,
+                internet_exposed=internet_exposed,
+                risk_factors=factors,
+            )
+        )
+
+    results.sort(key=lambda r: (-r.risk_score, r.name))
+    return results
+
+
+def _target_label(graph: UnifiedGraph, target_id: str) -> str:
+    node = graph.nodes.get(target_id)
+    return node.label if node is not None else target_id
+
+
+def _severity_for_score(score: int) -> str:
+    if score >= 75:
+        return "critical"
+    if score >= 50:
+        return "high"
+    if score >= 25:
+        return "medium"
+    return "low"
+
+
+def build_nhi_governance_findings(
+    graph: UnifiedGraph,
+    verdicts: list[IdentityGovernance],
+) -> list[Finding]:
+    """Materialize over-grant, dormant/orphaned, and high-risk findings.
+
+    Reuses :data:`FindingType.CREDENTIAL_EXPOSURE` (the closest identity-credential
+    governance category) so the findings flow through the existing unified stream.
+    """
+    findings: list[Finding] = []
+    for v in verdicts:
+        asset = Asset(name=v.name, asset_type="agent", identifier=v.identity_id, location=v.provider)
+
+        # 1. Right-sizing — granted but never used.
+        if v.unused_targets:
+            labels = [_target_label(graph, tid) for tid in v.unused_targets[:20]]
+            findings.append(
+                Finding(
+                    finding_type=FindingType.CREDENTIAL_EXPOSURE,
+                    source=FindingSource.MCP_SCAN,
+                    asset=asset,
+                    severity="medium" if v.is_privileged else "low",
+                    title=f"Over-granted identity: {v.name} has {len(v.unused_targets)} unused permission(s)",
+                    description=(
+                        f"Identity '{v.name}' is granted {v.granted_count} permission(s) but is observed using "
+                        f"{v.used_count}. Right-size by removing the unused grants: {', '.join(labels)}"
+                        + ("…" if len(v.unused_targets) > 20 else ".")
+                    ),
+                    remediation_guidance=("Remove the unused permissions / tool scopes from this identity to enforce least privilege."),
+                    evidence={
+                        "nhi_governance": "over_grant",
+                        "identity_id": v.identity_id,
+                        "granted_count": v.granted_count,
+                        "used_count": v.used_count,
+                        "unused_permission_count": len(v.unused_targets),
+                        "unused_targets": labels,
+                        "risk_score": v.risk_score,
+                    },
+                    risk_score=round(min(10.0, v.risk_score / 10.0), 2),
+                )
+            )
+
+        # 2. Dormant / orphaned.
+        if v.is_dormant or v.is_orphaned:
+            reasons = []
+            if v.is_dormant:
+                reasons.append("dormant" if v.dormant_days is None else f"dormant for {v.dormant_days}d")
+            if v.is_orphaned:
+                reasons.append("no owner assigned")
+            findings.append(
+                Finding(
+                    finding_type=FindingType.CREDENTIAL_EXPOSURE,
+                    source=FindingSource.MCP_SCAN,
+                    asset=asset,
+                    severity="high" if (v.is_privileged or v.internet_exposed) else "medium",
+                    title=f"Unattended non-human identity: {v.name} ({', '.join(reasons)})",
+                    description=(
+                        f"Identity '{v.name}' is {' and '.join(reasons)}. Standing unattended NHIs are a common "
+                        "lateral-movement entry point and should be deprovisioned or re-owned."
+                    ),
+                    remediation_guidance=("Deprovision the identity if no longer needed, or assign an owner and confirm continued use."),
+                    evidence={
+                        "nhi_governance": "unattended_identity",
+                        "identity_id": v.identity_id,
+                        "is_dormant": v.is_dormant,
+                        "is_orphaned": v.is_orphaned,
+                        "dormant_days": v.dormant_days,
+                        "last_used_at": v.last_used_at,
+                        "risk_score": v.risk_score,
+                    },
+                    risk_score=round(min(10.0, v.risk_score / 10.0), 2),
+                )
+            )
+
+    return findings
+
+
+def apply_nhi_governance(
+    graph: UnifiedGraph,
+    *,
+    usage: Mapping[str, set[str]] | Mapping[str, list[str]] | None = None,
+    dormant_after_days: int | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Annotate ``managed_identity`` nodes with their risk score, in place.
+
+    Computes the per-identity governance verdict, writes ``nhi_risk_score`` /
+    ``nhi_risk_band`` / right-sizing / dormancy / orphan flags onto each node,
+    and returns a non-secret summary plus the structured verdicts so callers can
+    emit findings. Never raises into the builder.
+    """
+    try:
+        verdicts = evaluate_identity_governance(graph, usage=usage, dormant_after_days=dormant_after_days, now=now)
+    except Exception:  # noqa: BLE001 — never raise into the builder
+        return {"identities": 0, "verdicts": [], "over_granted": 0, "dormant": 0, "orphaned": 0}
+
+    over_granted = dormant = orphaned = 0
+    for v in verdicts:
+        node = graph.nodes.get(v.node_id)
+        if node is None:
+            continue
+        node.attributes["nhi_risk_score"] = v.risk_score
+        node.attributes["nhi_risk_band"] = v.risk_band
+        node.attributes["nhi_unused_permission_count"] = len(v.unused_targets)
+        node.attributes["nhi_is_dormant"] = v.is_dormant
+        node.attributes["nhi_is_orphaned"] = v.is_orphaned
+        if v.risk_factors:
+            node.attributes["nhi_risk_factors"] = list(v.risk_factors)
+        # Surface the score on the node's own risk_score (0-10) so default graph
+        # ranking reflects it, without dropping the precise 0-100 attribute.
+        node.risk_score = max(node.risk_score, round(v.risk_score / 10.0, 2))
+        if v.unused_targets:
+            over_granted += 1
+        if v.is_dormant:
+            dormant += 1
+        if v.is_orphaned:
+            orphaned += 1
+
+    return {
+        "identities": len(verdicts),
+        "verdicts": verdicts,
+        "over_granted": over_granted,
+        "dormant": dormant,
+        "orphaned": orphaned,
+    }
+
+
+def describe_nhi_governance_posture(
+    graph: UnifiedGraph,
+    *,
+    usage: Mapping[str, set[str]] | Mapping[str, list[str]] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Return the consolidated, non-secret NHI governance posture for an API surface.
+
+    Mirrors the credential-expiry posture shape: a rolled-up status, per-identity
+    verdicts (worst risk first), and grouped right-sizing / dormancy / orphan
+    counts. Secret values are never included.
+    """
+    summary = apply_nhi_governance(graph, usage=usage, now=now)
+    verdicts: list[IdentityGovernance] = summary["verdicts"]
+    by_band: dict[str, int] = defaultdict(int)
+    for v in verdicts:
+        by_band[v.risk_band] += 1
+
+    if by_band.get("critical"):
+        status = "blocked"
+        message = "One or more non-human identities carry critical standing risk."
+    elif by_band.get("high") or summary["dormant"] or summary["orphaned"] or summary["over_granted"]:
+        status = "attention_required"
+        message = "Non-human identities are over-granted, dormant, orphaned, or high risk."
+    else:
+        status = "ok"
+        message = "All evaluated non-human identities are within governance bounds."
+
+    return {
+        "status": status,
+        "secret_values_included": False,
+        "evaluated": len(verdicts),
+        "dormant_after_days": dormant_days(),
+        "counts": {
+            "over_granted": summary["over_granted"],
+            "dormant": summary["dormant"],
+            "orphaned": summary["orphaned"],
+            "by_risk_band": dict(by_band),
+        },
+        "identities": [v.to_dict() for v in verdicts],
+        "message": message,
+        "generated_from": "/v1/auth/nhi/governance",
+    }
+
+
+def apply_nhi_governance_with_findings(
+    graph: UnifiedGraph,
+    *,
+    usage: Mapping[str, set[str]] | Mapping[str, list[str]] | None = None,
+    dormant_after_days: int | None = None,
+    now: datetime | None = None,
+) -> tuple[dict[str, Any], list[Finding]]:
+    """Annotate nodes and return ``(summary, findings)`` in one call.
+
+    Convenience for the scan pipeline, which both enriches the graph and appends
+    to the unified finding stream.
+    """
+    summary = apply_nhi_governance(graph, usage=usage, dormant_after_days=dormant_after_days, now=now)
+    findings = build_nhi_governance_findings(graph, summary["verdicts"])
+    return summary, findings
+
+
+__all__ = [
+    "DEFAULT_DORMANT_DAYS",
+    "IdentityGovernance",
+    "apply_nhi_governance",
+    "apply_nhi_governance_with_findings",
+    "build_nhi_governance_findings",
+    "describe_nhi_governance_posture",
+    "dormant_days",
+    "evaluate_identity_governance",
+]

--- a/tests/test_graph_nhi_governance.py
+++ b/tests/test_graph_nhi_governance.py
@@ -1,0 +1,239 @@
+"""NHI governance: right-sizing, dormant/orphan detection, per-identity risk score."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.nhi_governance import (
+    apply_nhi_governance,
+    apply_nhi_governance_with_findings,
+    build_nhi_governance_findings,
+    describe_nhi_governance_posture,
+    evaluate_identity_governance,
+)
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+
+NOW = datetime(2026, 6, 20, tzinfo=timezone.utc)
+
+
+def _iso(days_ago: int) -> str:
+    return (NOW - timedelta(days=days_ago)).isoformat()
+
+
+def _identity(nid: str, label: str, **attrs) -> UnifiedNode:
+    return UnifiedNode(id=nid, entity_type=EntityType.MANAGED_IDENTITY, label=label, attributes=attrs)
+
+
+def _resource(nid: str, label: str, **attrs) -> UnifiedNode:
+    return UnifiedNode(id=nid, entity_type=EntityType.CLOUD_RESOURCE, label=label, attributes=attrs)
+
+
+def _grant(src: str, tgt: str) -> UnifiedEdge:
+    return UnifiedEdge(source=src, target=tgt, relationship=RelationshipType.HAS_PERMISSION)
+
+
+def _verdict(verdicts, node_id):
+    return next(v for v in verdicts if v.node_id == node_id)
+
+
+def test_unused_permission_flagged_via_usage_map():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(_identity("managed_identity:svc", "svc-account", identity_id="svc", owner="alice", last_used_at=_iso(1)))
+    g.add_node(_resource("res:used", "bucket-used"))
+    g.add_node(_resource("res:unused", "bucket-unused"))
+    g.add_edge(_grant("managed_identity:svc", "res:used"))
+    g.add_edge(_grant("managed_identity:svc", "res:unused"))
+
+    # Observed usage covers only the "used" resource; the other is an over-grant.
+    verdicts = evaluate_identity_governance(g, usage={"svc": {"res:used"}}, now=NOW)
+    v = _verdict(verdicts, "managed_identity:svc")
+    assert v.granted_count == 2
+    assert v.used_count == 1
+    assert v.unused_targets == ["res:unused"]
+
+    findings = build_nhi_governance_findings(g, verdicts)
+    over = [f for f in findings if f.evidence.get("nhi_governance") == "over_grant"]
+    assert len(over) == 1
+    assert "bucket-unused" in over[0].evidence["unused_targets"]
+
+
+def test_unused_permission_via_edge_last_used_marker():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(_identity("managed_identity:svc", "svc", identity_id="svc", owner="alice", last_used_at=_iso(1)))
+    g.add_node(_resource("res:a", "a"))
+    g.add_node(_resource("res:b", "b"))
+    # Edge to res:a carries a usage marker → observed; res:b has none → unused.
+    g.add_edge(
+        UnifiedEdge(
+            source="managed_identity:svc",
+            target="res:a",
+            relationship=RelationshipType.HAS_PERMISSION,
+            evidence={"last_used_at": _iso(2)},
+        )
+    )
+    g.add_edge(_grant("managed_identity:svc", "res:b"))
+
+    v = _verdict(evaluate_identity_governance(g, now=NOW), "managed_identity:svc")
+    assert v.unused_targets == ["res:b"]
+    assert v.used_count == 1
+
+
+def test_dormant_and_orphaned_identity_flagged():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    # No owner (orphaned) and last used 200 days ago (dormant, default window 90).
+    g.add_node(_identity("managed_identity:old", "stale-token", identity_id="old", owner=None, last_used_at=_iso(200)))
+
+    verdicts = evaluate_identity_governance(g, now=NOW)
+    v = _verdict(verdicts, "managed_identity:old")
+    assert v.is_dormant is True
+    assert v.dormant_days == 200
+    assert v.is_orphaned is True
+
+    findings = build_nhi_governance_findings(g, verdicts)
+    unattended = [f for f in findings if f.evidence.get("nhi_governance") == "unattended_identity"]
+    assert len(unattended) == 1
+    assert unattended[0].evidence["is_dormant"] and unattended[0].evidence["is_orphaned"]
+
+
+def test_no_usage_timestamp_is_dormant():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(_identity("managed_identity:never", "never-used", identity_id="never", owner="bob"))
+    v = _verdict(evaluate_identity_governance(g, now=NOW), "managed_identity:never")
+    assert v.is_dormant is True
+    assert v.dormant_days is None
+    assert v.is_orphaned is False
+
+
+def test_risk_score_ranks_privileged_exposed_stale_above_benign():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    # Risky: admin-privileged, reaches an internet-exposed resource, expired
+    # credential, dormant, orphaned.
+    g.add_node(
+        _identity(
+            "managed_identity:risky",
+            "prod-admin",
+            identity_id="risky",
+            owner=None,
+            last_used_at=_iso(300),
+            escalates_to_admin=True,
+            credential_expires_at=_iso(30),  # expired 30 days ago
+        )
+    )
+    g.add_node(_resource("res:public", "public-bucket", internet_exposed=True))
+    g.add_edge(_grant("managed_identity:risky", "res:public"))
+
+    # Benign: owned, used yesterday, no privilege, no exposure, fresh credential.
+    g.add_node(
+        _identity(
+            "managed_identity:benign",
+            "ci-runner",
+            identity_id="benign",
+            owner="team-ci",
+            last_used_at=_iso(1),
+            credential_expires_at=_iso(-180),  # expires in 180 days
+        )
+    )
+    g.add_node(_resource("res:internal", "internal-bucket"))
+    g.add_edge(
+        UnifiedEdge(
+            source="managed_identity:benign",
+            target="res:internal",
+            relationship=RelationshipType.HAS_PERMISSION,
+            evidence={"last_used_at": _iso(1)},
+        )
+    )
+
+    verdicts = evaluate_identity_governance(g, now=NOW)
+    risky = _verdict(verdicts, "managed_identity:risky")
+    benign = _verdict(verdicts, "managed_identity:benign")
+
+    assert risky.risk_score > benign.risk_score
+    assert risky.risk_band in {"high", "critical"}
+    assert benign.risk_band == "low"
+    # Verdicts are returned worst-first.
+    assert verdicts[0].node_id == "managed_identity:risky"
+    assert risky.is_privileged and risky.internet_exposed and risky.credential_state == "expired"
+
+
+def test_apply_writes_risk_score_onto_node():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(
+        _identity(
+            "managed_identity:x",
+            "x",
+            identity_id="x",
+            owner=None,
+            last_used_at=_iso(400),
+            escalates_to_admin=True,
+        )
+    )
+    summary = apply_nhi_governance(g, now=NOW)
+    node = g.nodes["managed_identity:x"]
+    assert node.attributes["nhi_risk_score"] > 0
+    assert node.attributes["nhi_risk_band"] in {"low", "medium", "high", "critical"}
+    assert node.attributes["nhi_is_dormant"] is True
+    assert node.attributes["nhi_is_orphaned"] is True
+    assert node.risk_score == round(node.attributes["nhi_risk_score"] / 10.0, 2)
+    assert summary["dormant"] == 1 and summary["orphaned"] == 1
+
+
+def test_clean_input_produces_no_findings():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    # Owned, used yesterday, every grant observed → no over-grant, dormancy, or orphan.
+    g.add_node(
+        _identity(
+            "managed_identity:clean",
+            "clean",
+            identity_id="clean",
+            owner="alice",
+            last_used_at=_iso(1),
+            credential_expires_at=_iso(-365),
+        )
+    )
+    g.add_node(_resource("res:r", "r"))
+    g.add_edge(
+        UnifiedEdge(
+            source="managed_identity:clean",
+            target="res:r",
+            relationship=RelationshipType.HAS_PERMISSION,
+            evidence={"last_used_at": _iso(1)},
+        )
+    )
+
+    summary, findings = apply_nhi_governance_with_findings(g, now=NOW)
+    assert findings == []
+    assert summary["over_granted"] == 0
+    assert summary["dormant"] == 0
+    assert summary["orphaned"] == 0
+
+
+def test_empty_graph_is_a_noop():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    summary, findings = apply_nhi_governance_with_findings(g, now=NOW)
+    assert summary["identities"] == 0
+    assert findings == []
+
+
+def test_describe_posture_shape_and_status():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(
+        _identity(
+            "managed_identity:risky",
+            "prod-admin",
+            identity_id="risky",
+            owner=None,
+            last_used_at=_iso(300),
+            escalates_to_admin=True,
+            internet_exposed=True,
+            credential_expires_at=_iso(30),
+        )
+    )
+    posture = describe_nhi_governance_posture(g, now=NOW)
+    assert posture["secret_values_included"] is False
+    assert posture["evaluated"] == 1
+    assert posture["status"] in {"attention_required", "blocked"}
+    assert posture["identities"][0]["risk_score"] > 0
+    assert posture["generated_from"] == "/v1/auth/nhi/governance"


### PR DESCRIPTION
## Summary
Pushes NHI governance toward ~90% Natoma parity — the last analytics gaps over the existing identity graph (discovery + effective-permissions + credential-expiry already shipped). Additive, reference-only.

- `graph/nhi_governance.py` — wired after effective-permissions in `builder.py`:
  1. **Usage-based right-sizing** — diffs granted (`HAS_PERMISSION`/`SCOPED_TO`) vs observed usage (caller usage map and/or per-edge `last_used_at`); flags over-grants.
  2. **Orphaned / dormant** — no-owner = orphaned; idle past `AGENT_BOM_NHI_DORMANT_DAYS` (default 90) or no usage = dormant.
  3. **Per-identity risk score 0-100** — `35·privilege + 25·exposure + 20·staleness + 12·dormancy + 8·orphan`; bands critical/high/medium/low.
- Surfaced via graph node annotations (`nhi_risk_score/band/factors`, lifts node `risk_score`), findings (`CREDENTIAL_EXPOSURE`), and `GET /v1/graph/nhi/governance` posture.

## Verification
9 tests (over-grant via usage map + edge marker; dormant+orphaned; risk ranks privileged+exposed+stale above benign; clean→none) + 45 across NHI/effective-perms/credential-expiry suites. ruff/format/mypy clean; OpenAPI (+1 path) + atlas regenerated; release-consistency, product-surface, OpenAPI-artifact checks pass.