### PR TITLE
feat(gateway): unified Gateway Live Feed (tool-call auth + DLP + LLM calls)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,3 +65,9 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+      - id: release-surface-consistency
+        name: release surface and generated atlas consistency
+        entry: python3 scripts/check_release_consistency.py
+        language: system
+        pass_filenames: false
+        files: ^(pyproject\.toml|README\.md|PYPI_README\.md|DOCKER_HUB_README\.md|CHANGELOG\.md|docs/(DATA_MODEL\.md|openapi/v1\.(json|yaml)|PRODUCT_|RELEASE_|PUBLISHING|MCP_SECURITY_MODEL|AI_INFRASTRUCTURE_SCANNING|ENTERPRISE_DEPLOYMENT)|site-docs/|src/agent_bom/(api/|mcp_registry\.json)|integrations/(mcp-registry|glama|openclaw)/|deploy/|Dockerfile|uv\.lock|scripts/(check_release_consistency|regenerate_data_model_atlas)\.py)

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 229 |
+| `docs/openapi/v1.json` | paths | 230 |
 | `docs/openapi/v1.json` | component schemas | 61 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 228 |
+| `docs/openapi/v1.json` | paths | 229 |
 | `docs/openapi/v1.json` | component schemas | 61 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -9804,6 +9804,188 @@
         ]
       }
     },
+    "/v1/gateway/feed": {
+      "get": {
+        "description": "Unified, time-ordered fleet event feed for the active tenant.\n\nFuses tool-call authorization decisions (allowed / blocked), data-filter /\nDLP redaction events, and recent LLM calls into one normalized stream with\nper-agent attribution. Reference-only and redaction-safe: every event is\nmetadata (timestamp, agent, action class, target, short non-secret detail);\nno raw arguments, responses, or credential values are returned.",
+        "operationId": "gateway_feed_v1_gateway_feed_get",
+        "parameters": [
+          {
+            "description": "Max fused events to return (1-500)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "description": "Max fused events to return (1-500)",
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Gateway Feed V1 Gateway Feed Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Gateway Feed",
+        "tags": [
+          "gateway"
+        ]
+      }
+    },
+    "/v1/gateway/feed/kpis": {
+      "get": {
+        "description": "KPI header rollup for the gateway live feed.\n\nReturns ``calls_today``, ``blocked_today``, ``shadow_ai_blocked`` (shadow /\nundeclared-agent + shadow-MCP-server blocks), ``data_filters_applied``, and\n``uptime_seconds`` (only when the proxy reports it \u2014 never fabricated).",
+        "operationId": "gateway_feed_kpis_v1_gateway_feed_kpis_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Gateway Feed Kpis V1 Gateway Feed Kpis Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Gateway Feed Kpis",
+        "tags": [
+          "gateway"
+        ]
+      }
+    },
     "/v1/gateway/policies": {
       "get": {
         "description": "List all gateway policies.",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -6397,6 +6397,125 @@ paths:
       summary: Evaluate Gateway
       tags:
       - gateway
+  /v1/gateway/feed:
+    get:
+      description: 'Unified, time-ordered fleet event feed for the active tenant.
+
+
+        Fuses tool-call authorization decisions (allowed / blocked), data-filter /
+
+        DLP redaction events, and recent LLM calls into one normalized stream with
+
+        per-agent attribution. Reference-only and redaction-safe: every event is
+
+        metadata (timestamp, agent, action class, target, short non-secret detail);
+
+        no raw arguments, responses, or credential values are returned.'
+      operationId: gateway_feed_v1_gateway_feed_get
+      parameters:
+      - description: Max fused events to return (1-500)
+        in: query
+        name: limit
+        required: false
+        schema:
+          default: 100
+          description: Max fused events to return (1-500)
+          maximum: 500
+          minimum: 1
+          title: Limit
+          type: integer
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Gateway Feed V1 Gateway Feed Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Gateway Feed
+      tags:
+      - gateway
+  /v1/gateway/feed/kpis:
+    get:
+      description: "KPI header rollup for the gateway live feed.\n\nReturns ``calls_today``,\
+        \ ``blocked_today``, ``shadow_ai_blocked`` (shadow /\nundeclared-agent + shadow-MCP-server\
+        \ blocks), ``data_filters_applied``, and\n``uptime_seconds`` (only when the\
+        \ proxy reports it \u2014 never fabricated)."
+      operationId: gateway_feed_kpis_v1_gateway_feed_kpis_get
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Gateway Feed Kpis V1 Gateway Feed Kpis Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Gateway Feed Kpis
+      tags:
+      - gateway
   /v1/gateway/policies:
     get:
       description: List all gateway policies.

--- a/src/agent_bom/api/routes/gateway_feed.py
+++ b/src/agent_bom/api/routes/gateway_feed.py
@@ -1,0 +1,457 @@
+"""Gateway Live Feed — unified fleet event stream.
+
+A single normalized, time-ordered stream that fuses three runtime surfaces the
+platform already produces, with per-agent attribution:
+
+    * tool-call authorization decisions  (allowed / blocked)  — proxy alert ring
+      buffer + gateway audit events
+    * data-filter / DLP redaction events  (PII / credential masking applied to
+      tool responses)                                         — proxy alert ring
+      buffer (credential_leak / pii detectors)
+    * recent LLM calls                                          — observability
+      cost store (priced OTel GenAI spans)
+
+This module is read-only over those existing stores. It does NOT re-implement
+enforcement, DLP, audit, or streaming — it consumes the in-process proxy alert
+ring buffer (``agent_bom.api.routes.proxy``) and the cost store
+(``agent_bom.api.cost_store``) and projects a unified, redaction-safe feed.
+
+Endpoints:
+    GET /v1/gateway/feed       normalized, time-ordered fused event list
+    GET /v1/gateway/feed/kpis  KPI header rollup (calls / blocked / shadow-AI /
+                               data filters)
+
+All reads are RBAC-gated (``read`` permission), tenant-scoped, and
+redaction-safe: only metadata (timestamps, agent identifiers, tool/target
+names, action class, short non-secret detail strings) is returned. No raw
+arguments, raw responses, or credential values cross this surface — the source
+records are already sanitized by ``push_proxy_alert`` /
+``redact_for_persistence`` before they reach the ring buffer.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, cast
+
+from fastapi import APIRouter, Query, Request
+
+from agent_bom.api.tenancy import require_request_tenant_id
+from agent_bom.rbac import require_authenticated_permission
+
+router = APIRouter()
+
+_FEED_SCHEMA_VERSION = "gateway.feed.v1"
+
+# Action classes for a fused gateway feed event. Kept in sync with the badge
+# vocabulary the UI renders.
+ACTION_TOOL_CALL_AUTHORIZED = "tool_call_authorized"
+ACTION_TOOL_CALL_BLOCKED = "tool_call_blocked"
+ACTION_DATA_FILTER_APPLIED = "data_filter_applied"
+ACTION_LLM_CALL = "llm_call"
+
+# Block reasons that indicate a shadow / undeclared agent or shadow MCP server
+# rather than an ordinary policy block. ``undeclared`` is emitted by the proxy
+# block-undeclared enforcement (``proxy.undeclared_tool_block_reason``); the
+# others cover unknown-agent / shadow-server gateway blocks.
+_SHADOW_BLOCK_MARKERS = (
+    "undeclared",
+    "shadow",
+    "unknown_agent",
+    "unknown agent",
+    "unregistered",
+    "unknown-agent",
+)
+
+
+def _dep(permission: str) -> Any:
+    return cast(Any, require_authenticated_permission(permission))
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _alert_timestamp(alert: dict[str, Any]) -> str:
+    """Return a best-effort ISO-8601 timestamp for a proxy alert record.
+
+    Proxy alerts carry either an epoch float ``ts`` or an ISO string
+    ``timestamp`` / ``event_timestamp``. Normalize to ISO-8601 so all fused
+    event sources sort on one comparable string key.
+    """
+    raw_ts = alert.get("ts")
+    if isinstance(raw_ts, int | float) and raw_ts > 0:
+        try:
+            return datetime.fromtimestamp(float(raw_ts), tz=timezone.utc).isoformat()
+        except (OverflowError, OSError, ValueError):
+            pass
+    for key in ("timestamp", "event_timestamp", "received_at"):
+        value = alert.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _sort_key(event: dict[str, Any]) -> str:
+    """Sort key for fused events — newest first when reversed.
+
+    Normalizes the ``ts`` ISO strings into a comparable form. Events without a
+    timestamp sort last (oldest) by mapping to the empty string.
+    """
+    return str(event.get("ts") or "")
+
+
+def _alert_agent(alert: dict[str, Any]) -> str:
+    """Per-agent attribution for a proxy alert.
+
+    Prefer the explicit agent name; fall back to source_id (the proxied agent
+    process identifier) and finally to ``"unknown"`` so every event in the feed
+    carries a visible actor.
+    """
+    for key in ("agent_name", "agent", "source_agent", "source_id"):
+        value = alert.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "unknown"
+
+
+def _alert_target(alert: dict[str, Any]) -> str:
+    for key in ("tool_name", "tool", "upstream", "target"):
+        value = alert.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "unknown"
+
+
+def _is_shadow_block(alert: dict[str, Any]) -> bool:
+    """True when a blocked event is a shadow / undeclared-agent or shadow-server block.
+
+    Inspects the markers the proxy/gateway emit for undeclared tools and unknown
+    agents. Free-text fields (``reason`` / ``message`` / ``action`` /
+    ``details.reason``) are present on direct in-process alerts but are stripped
+    by tier-A redaction before they reach the persisted ring buffer, so this
+    also inspects the redaction-safe whitelisted fields (``event_type``,
+    ``detector``, ``reason_code``, ``policy_source``, ``policy_result``,
+    ``outcome``) that survive ``redact_for_persistence``. Used both to label
+    feed events and to roll up the ``shadow_ai_blocked`` KPI.
+    """
+    details = alert.get("details")
+    detail_reason = ""
+    if isinstance(details, dict):
+        detail_reason = str(details.get("reason") or details.get("block_reason") or "")
+    haystack = " ".join(
+        str(part).lower()
+        for part in (
+            detail_reason,
+            # Free-text — survives on direct in-process alerts only.
+            alert.get("reason"),
+            alert.get("action"),
+            alert.get("message"),
+            # Redaction-safe (tier-A whitelist) — survives the ring buffer.
+            alert.get("detector"),
+            alert.get("event_type"),
+            alert.get("reason_code"),
+            alert.get("policy_source"),
+            alert.get("policy_result"),
+            alert.get("outcome"),
+        )
+        if part
+    )
+    return any(marker in haystack for marker in _SHADOW_BLOCK_MARKERS)
+
+
+def _block_detail(alert: dict[str, Any]) -> str:
+    details = alert.get("details")
+    if isinstance(details, dict):
+        reason = details.get("reason") or details.get("block_reason")
+        if isinstance(reason, str) and reason.strip():
+            return reason.strip()[:200]
+    reason = alert.get("reason")
+    if isinstance(reason, str) and reason.strip():
+        return reason.strip()[:200]
+    if _is_shadow_block(alert):
+        return "shadow / undeclared agent blocked"
+    # Redaction-safe coded reason survives the ring buffer when free text does not.
+    reason_code = alert.get("reason_code")
+    if isinstance(reason_code, str) and reason_code.strip():
+        return reason_code.strip()[:200]
+    return "blocked by gateway policy"
+
+
+def _data_filter_detail(alert: dict[str, Any]) -> str:
+    """Human-readable, secret-free detail for a DLP / redaction event.
+
+    Surfaces what class of data was masked (e.g. "PII redacted",
+    "credential masked") using the sanitized credential_type/pii_type metadata
+    already present on the alert. Never returns raw matched values — the source
+    record only retains redacted previews.
+    """
+    details = alert.get("details") if isinstance(alert.get("details"), dict) else {}
+    detector = str(alert.get("detector") or "").lower()
+    cred_type = ""
+    pii_type = ""
+    if isinstance(details, dict):
+        cred_type = str(details.get("credential_type") or "")
+        pii_type = str(details.get("pii_type") or details.get("pii_name") or "")
+    if cred_type:
+        return f"{cred_type} credential masked"
+    if pii_type:
+        return f"{pii_type} PII redacted"
+    if "credential" in detector:
+        return "credential masked"
+    if "pii" in detector:
+        return "PII redacted"
+    if "visual" in detector:
+        return "visual leak redacted"
+    return "sensitive data masked"
+
+
+def _classify_alert_action(alert: dict[str, Any]) -> str | None:
+    """Map a proxy alert to a unified feed action class, or None to skip.
+
+    Reuses the same decision vocabulary the proxy production index uses
+    (``action`` / ``effective_decision`` / ``detector`` / ``message``) so this
+    feed stays consistent with ``/v1/runtime/production-index``.
+    """
+    action = str(alert.get("action") or alert.get("event_type") or alert.get("type") or "").lower()
+    detector = str(alert.get("detector") or "").lower()
+    effective = str(alert.get("effective_decision") or alert.get("decision") or "").lower()
+    message = str(alert.get("message") or "").lower()
+    haystack = " ".join((action, detector, effective, message))
+
+    if "redact" in haystack or "mask" in haystack or "data_filter" in haystack or "data filter" in haystack:
+        return ACTION_DATA_FILTER_APPLIED
+    if detector in {"credential_leak", "pii", "pii_leak"} or "leak" in detector:
+        return ACTION_DATA_FILTER_APPLIED
+    if "block" in haystack or "deny" in haystack or effective == "deny":
+        return ACTION_TOOL_CALL_BLOCKED
+    if "allow" in haystack or "authorized" in haystack or effective == "allow":
+        return ACTION_TOOL_CALL_AUTHORIZED
+    return None
+
+
+def _normalize_alert_event(alert: dict[str, Any], tenant_id: str) -> dict[str, Any] | None:
+    """Project one proxy alert into a normalized feed event, or None to skip."""
+    action_type = _classify_alert_action(alert)
+    if action_type is None:
+        return None
+    agent = _alert_agent(alert)
+    target = _alert_target(alert)
+    if action_type == ACTION_TOOL_CALL_BLOCKED:
+        detail = _block_detail(alert)
+        shadow = _is_shadow_block(alert)
+    elif action_type == ACTION_DATA_FILTER_APPLIED:
+        detail = _data_filter_detail(alert)
+        shadow = False
+    else:
+        detail = "authorized"
+        shadow = False
+    return {
+        "ts": _alert_timestamp(alert),
+        "agent": agent,
+        "action_type": action_type,
+        "target": target,
+        "detail": detail,
+        "tenant": tenant_id,
+        "shadow": shadow,
+        "source": "proxy",
+    }
+
+
+def _normalize_llm_event(record: Any, tenant_id: str) -> dict[str, Any]:
+    """Project one priced LLM cost record into a normalized feed event."""
+    provider = str(getattr(record, "provider", "") or "")
+    model = str(getattr(record, "model", "") or "")
+    target = "/".join(part for part in (provider, model) if part) or "llm"
+    agent = str(getattr(record, "agent", "") or "").strip() or "unknown"
+    cost = getattr(record, "cost_usd", 0.0)
+    input_tokens = getattr(record, "input_tokens", 0) or 0
+    output_tokens = getattr(record, "output_tokens", 0) or 0
+    priced = bool(getattr(record, "priced", False))
+    if priced and isinstance(cost, int | float) and cost > 0:
+        detail = f"${float(cost):.4f} · {int(input_tokens) + int(output_tokens)} tokens"
+    else:
+        detail = f"{int(input_tokens) + int(output_tokens)} tokens"
+    return {
+        "ts": str(getattr(record, "observed_at", "") or ""),
+        "agent": agent,
+        "action_type": ACTION_LLM_CALL,
+        "target": target,
+        "detail": detail,
+        "tenant": tenant_id,
+        "shadow": False,
+        "source": "observability",
+    }
+
+
+def build_gateway_feed(
+    *,
+    tenant_id: str,
+    alerts: list[dict[str, Any]],
+    llm_records: list[Any],
+    limit: int,
+) -> dict[str, Any]:
+    """Fuse and time-order proxy alerts + LLM cost records into one feed.
+
+    Pure function (no I/O) so the normalization, ordering, tenant scoping, and
+    redaction-safety can be unit-tested directly. ``alerts`` are expected to be
+    pre-scoped to ``tenant_id`` by the caller (the proxy ring buffer enforces
+    tenant visibility on read); LLM records come from the tenant-scoped cost
+    store.
+    """
+    events: list[dict[str, Any]] = []
+    for alert in alerts:
+        event = _normalize_alert_event(alert, tenant_id)
+        if event is not None:
+            events.append(event)
+    for record in llm_records:
+        events.append(_normalize_llm_event(record, tenant_id))
+
+    events.sort(key=_sort_key, reverse=True)
+    bounded = events[:limit]
+    return {
+        "schema_version": _FEED_SCHEMA_VERSION,
+        "tenant_id": tenant_id,
+        "generated_at": _now_iso(),
+        "count": len(bounded),
+        "events": bounded,
+    }
+
+
+def build_gateway_feed_kpis(
+    *,
+    tenant_id: str,
+    alerts: list[dict[str, Any]],
+    llm_records: list[Any],
+    uptime_seconds: float | None,
+) -> dict[str, Any]:
+    """Roll up the KPI header counters from the fused sources.
+
+    Counters:
+        * ``calls_today``          — authorized + blocked tool-call events + LLM
+                                     calls (all gateway-mediated activity).
+        * ``blocked_today``        — blocked tool-call events.
+        * ``shadow_ai_blocked``    — subset of blocked events whose reason marks
+                                     a shadow / undeclared agent or shadow MCP
+                                     server (see ``_is_shadow_block``). Labeled
+                                     accurately rather than overclaimed.
+        * ``data_filters_applied`` — DLP / redaction events.
+        * ``uptime_seconds``       — only emitted when the proxy reports it; never
+                                     fabricated.
+
+    ``_today`` reflects the live in-process window the ring buffer retains (the
+    proxy alert deque + the day's cost records), not a wall-clock midnight cut —
+    the label matches the operator-facing "today" framing without overstating
+    retention.
+    """
+    authorized = 0
+    blocked = 0
+    shadow_blocked = 0
+    data_filters = 0
+    for alert in alerts:
+        action_type = _classify_alert_action(alert)
+        if action_type == ACTION_TOOL_CALL_AUTHORIZED:
+            authorized += 1
+        elif action_type == ACTION_TOOL_CALL_BLOCKED:
+            blocked += 1
+            if _is_shadow_block(alert):
+                shadow_blocked += 1
+        elif action_type == ACTION_DATA_FILTER_APPLIED:
+            data_filters += 1
+
+    llm_calls = len(llm_records)
+    calls_today = authorized + blocked + llm_calls
+
+    kpis: dict[str, Any] = {
+        "schema_version": _FEED_SCHEMA_VERSION,
+        "tenant_id": tenant_id,
+        "generated_at": _now_iso(),
+        "calls_today": calls_today,
+        "blocked_today": blocked,
+        "shadow_ai_blocked": shadow_blocked,
+        "data_filters_applied": data_filters,
+        "tool_calls_authorized": authorized,
+        "llm_calls": llm_calls,
+    }
+    if isinstance(uptime_seconds, int | float) and uptime_seconds > 0:
+        kpis["uptime_seconds"] = float(uptime_seconds)
+    return kpis
+
+
+def _load_tenant_alerts(tenant_id: str) -> list[dict[str, Any]]:
+    """Read tenant-scoped proxy alerts from the existing ring buffer / log.
+
+    Delegates to ``proxy._load_proxy_alerts`` which already enforces per-tenant
+    visibility and reads the configured audit log when the in-process buffer is
+    empty. This module never mutates that buffer.
+    """
+    from agent_bom.api.routes.proxy import _load_proxy_alerts
+
+    return _load_proxy_alerts(tenant_id)
+
+
+def _load_tenant_uptime(tenant_id: str) -> float | None:
+    """Best-effort proxy uptime for the tenant, or None when unreported."""
+    from agent_bom.api.routes.proxy import _runtime_metrics_for_tenant
+
+    metrics = _runtime_metrics_for_tenant(tenant_id)
+    if not isinstance(metrics, dict):
+        return None
+    raw = metrics.get("uptime_seconds")
+    if isinstance(raw, int | float) and raw > 0:
+        return float(raw)
+    return None
+
+
+def _load_tenant_llm_records(tenant_id: str, *, limit: int) -> list[Any]:
+    """Read recent priced LLM cost records for the tenant (read-only)."""
+    try:
+        from agent_bom.api.cost_store import get_cost_store
+
+        return list(get_cost_store().list_records(tenant_id, limit=limit))
+    except Exception:  # noqa: BLE001 — cost store is optional; feed degrades to proxy-only
+        return []
+
+
+@router.get("/v1/gateway/feed", tags=["gateway"], dependencies=[_dep("read")])
+async def gateway_feed(
+    request: Request,
+    limit: int = Query(default=100, ge=1, le=500, description="Max fused events to return (1-500)"),
+) -> dict[str, Any]:
+    """Unified, time-ordered fleet event feed for the active tenant.
+
+    Fuses tool-call authorization decisions (allowed / blocked), data-filter /
+    DLP redaction events, and recent LLM calls into one normalized stream with
+    per-agent attribution. Reference-only and redaction-safe: every event is
+    metadata (timestamp, agent, action class, target, short non-secret detail);
+    no raw arguments, responses, or credential values are returned.
+    """
+    tenant_id = require_request_tenant_id(request)
+    alerts = _load_tenant_alerts(tenant_id)
+    llm_records = _load_tenant_llm_records(tenant_id, limit=limit)
+    return build_gateway_feed(
+        tenant_id=tenant_id,
+        alerts=alerts,
+        llm_records=llm_records,
+        limit=limit,
+    )
+
+
+@router.get("/v1/gateway/feed/kpis", tags=["gateway"], dependencies=[_dep("read")])
+async def gateway_feed_kpis(request: Request) -> dict[str, Any]:
+    """KPI header rollup for the gateway live feed.
+
+    Returns ``calls_today``, ``blocked_today``, ``shadow_ai_blocked`` (shadow /
+    undeclared-agent + shadow-MCP-server blocks), ``data_filters_applied``, and
+    ``uptime_seconds`` (only when the proxy reports it — never fabricated).
+    """
+    tenant_id = require_request_tenant_id(request)
+    alerts = _load_tenant_alerts(tenant_id)
+    llm_records = _load_tenant_llm_records(tenant_id, limit=10000)
+    uptime_seconds = _load_tenant_uptime(tenant_id)
+    return build_gateway_feed_kpis(
+        tenant_id=tenant_id,
+        alerts=alerts,
+        llm_records=llm_records,
+        uptime_seconds=uptime_seconds,
+    )

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -765,6 +765,7 @@ from agent_bom.api.routes.evaluations import router as _evaluations_router  # no
 from agent_bom.api.routes.fleet import router as _fleet_router  # noqa: E402
 from agent_bom.api.routes.frameworks import router as _frameworks_router  # noqa: E402
 from agent_bom.api.routes.gateway import router as _gateway_router  # noqa: E402
+from agent_bom.api.routes.gateway_feed import router as _gateway_feed_router  # noqa: E402
 from agent_bom.api.routes.governance import router as _governance_router  # noqa: E402
 from agent_bom.api.routes.graph import router as _graph_router  # noqa: E402
 from agent_bom.api.routes.identities import router as _identities_router  # noqa: E402
@@ -794,6 +795,7 @@ app.include_router(_fleet_router)
 app.include_router(_evaluations_router)
 app.include_router(_frameworks_router)
 app.include_router(_gateway_router)
+app.include_router(_gateway_feed_router)
 app.include_router(_governance_router)
 app.include_router(_graph_router)
 app.include_router(_identities_router)

--- a/tests/test_api_gateway_feed.py
+++ b/tests/test_api_gateway_feed.py
@@ -1,0 +1,352 @@
+"""Tests for the Gateway Live Feed (/v1/gateway/feed + /v1/gateway/feed/kpis).
+
+Covers the pure normalization / rollup functions (event fusion + ordering,
+shadow-AI counting, redaction-safety, per-agent attribution) and HTTP-level
+tenant isolation over the proxy alert ring buffer.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.routes.gateway_feed import (
+    ACTION_DATA_FILTER_APPLIED,
+    ACTION_LLM_CALL,
+    ACTION_TOOL_CALL_AUTHORIZED,
+    ACTION_TOOL_CALL_BLOCKED,
+    build_gateway_feed,
+    build_gateway_feed_kpis,
+)
+
+PROXY_SECRET = "feed-test-proxy-secret-with-32-plus-bytes"
+
+
+@dataclass(frozen=True)
+class _FakeCostRecord:
+    tenant_id: str
+    agent: str
+    provider: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+    priced: bool
+    observed_at: str
+
+
+def _authorized_alert(*, agent: str = "agent-a", tool: str = "read_file", ts: float = 100.0) -> dict:
+    return {"ts": ts, "agent_name": agent, "action": "gateway.policy_allowed", "tool_name": tool, "decision": "allow"}
+
+
+def _blocked_alert(*, agent: str = "agent-b", tool: str = "exec", ts: float = 200.0, reason: str = "policy") -> dict:
+    return {
+        "ts": ts,
+        "agent_name": agent,
+        "action": "gateway.policy_blocked",
+        "tool_name": tool,
+        "decision": "deny",
+        "details": {"reason": reason},
+    }
+
+
+def _dlp_alert(*, agent: str = "agent-c", tool: str = "fetch", ts: float = 300.0) -> dict:
+    return {
+        "ts": ts,
+        "agent_name": agent,
+        "detector": "credential_leak",
+        "action": "runtime_alert",
+        "tool_name": tool,
+        "message": "Credential leak detected: AWS Access Key in response — redacted",
+        "details": {"credential_type": "AWS Access Key", "redacted_preview": ["AKIA..."]},
+    }
+
+
+def _shadow_alert(*, agent: str = "shadow-agent", tool: str = "delete", ts: float = 400.0) -> dict:
+    return {
+        "ts": ts,
+        "agent_name": agent,
+        "action": "gateway.policy_blocked",
+        "tool_name": tool,
+        "decision": "deny",
+        "details": {"reason": "undeclared tool not present in tools/list"},
+    }
+
+
+# ── Normalization + fusion + ordering ─────────────────────────────────────────
+
+
+def test_feed_fuses_all_three_sources_and_orders_newest_first() -> None:
+    alerts = [_authorized_alert(), _blocked_alert(), _dlp_alert()]
+    records = [
+        _FakeCostRecord(
+            tenant_id="t1",
+            agent="agent-llm",
+            provider="anthropic",
+            model="claude-3",
+            input_tokens=10,
+            output_tokens=5,
+            cost_usd=0.0012,
+            priced=True,
+            observed_at="2026-06-20T00:05:00+00:00",
+        )
+    ]
+    feed = build_gateway_feed(tenant_id="t1", alerts=alerts, llm_records=records, limit=100)
+
+    action_types = {e["action_type"] for e in feed["events"]}
+    assert action_types == {
+        ACTION_TOOL_CALL_AUTHORIZED,
+        ACTION_TOOL_CALL_BLOCKED,
+        ACTION_DATA_FILTER_APPLIED,
+        ACTION_LLM_CALL,
+    }
+    assert feed["count"] == 4
+    assert feed["schema_version"] == "gateway.feed.v1"
+    assert feed["tenant_id"] == "t1"
+
+    # Newest first: the LLM record (2026 ISO) sorts above epoch-float alerts,
+    # and within alerts the highest ts wins.
+    timestamps = [e["ts"] for e in feed["events"]]
+    assert timestamps == sorted(timestamps, reverse=True)
+    assert feed["events"][0]["action_type"] == ACTION_LLM_CALL
+
+
+def test_feed_per_agent_attribution_present_on_every_event() -> None:
+    alerts = [_authorized_alert(agent="alpha"), _blocked_alert(agent="beta"), _dlp_alert(agent="gamma")]
+    feed = build_gateway_feed(tenant_id="t1", alerts=alerts, llm_records=[], limit=100)
+    agents = {e["agent"] for e in feed["events"]}
+    assert agents == {"alpha", "beta", "gamma"}
+    assert all(e["agent"] for e in feed["events"])
+
+
+def test_feed_falls_back_to_source_id_then_unknown_for_agent() -> None:
+    alerts = [
+        {"ts": 1.0, "source_id": "proc-7", "action": "gateway.policy_allowed", "tool_name": "x"},
+        {"ts": 2.0, "action": "gateway.policy_allowed", "tool_name": "y"},
+    ]
+    feed = build_gateway_feed(tenant_id="t1", alerts=alerts, llm_records=[], limit=100)
+    by_target = {e["target"]: e["agent"] for e in feed["events"]}
+    assert by_target["x"] == "proc-7"
+    assert by_target["y"] == "unknown"
+
+
+def test_feed_skips_unclassifiable_alerts() -> None:
+    alerts = [{"ts": 1.0, "action": "gateway.heartbeat", "tool_name": "n/a"}]
+    feed = build_gateway_feed(tenant_id="t1", alerts=alerts, llm_records=[], limit=100)
+    assert feed["count"] == 0
+
+
+def test_feed_limit_truncates_after_ordering() -> None:
+    alerts = [_authorized_alert(tool=f"t{i}", ts=float(i)) for i in range(10)]
+    feed = build_gateway_feed(tenant_id="t1", alerts=alerts, llm_records=[], limit=3)
+    assert feed["count"] == 3
+    # Highest ts retained after truncation.
+    assert {e["target"] for e in feed["events"]} == {"t9", "t8", "t7"}
+
+
+# ── DLP / data-filter detail ─────────────────────────────────────────────────
+
+
+def test_data_filter_event_detail_is_redaction_safe() -> None:
+    feed = build_gateway_feed(tenant_id="t1", alerts=[_dlp_alert()], llm_records=[], limit=100)
+    event = feed["events"][0]
+    assert event["action_type"] == ACTION_DATA_FILTER_APPLIED
+    assert event["detail"] == "AWS Access Key credential masked"
+    # No raw secret material leaks into the normalized event.
+    serialized = repr(event)
+    assert "AKIA" not in serialized
+    assert "redacted_preview" not in serialized
+
+
+def test_pii_detector_maps_to_data_filter() -> None:
+    alert = {
+        "ts": 5.0,
+        "agent_name": "a",
+        "detector": "pii",
+        "tool_name": "lookup",
+        "details": {"pii_type": "SSN"},
+        "message": "pii redacted",
+    }
+    feed = build_gateway_feed(tenant_id="t1", alerts=[alert], llm_records=[], limit=100)
+    assert feed["events"][0]["action_type"] == ACTION_DATA_FILTER_APPLIED
+    assert feed["events"][0]["detail"] == "SSN PII redacted"
+
+
+# ── Shadow-AI rollup ─────────────────────────────────────────────────────────
+
+
+def test_kpis_shadow_ai_counts_only_undeclared_blocks() -> None:
+    alerts = [
+        _authorized_alert(),
+        _blocked_alert(reason="policy: denied tool"),  # ordinary block, not shadow
+        _shadow_alert(),  # undeclared agent block → shadow
+        _dlp_alert(),
+    ]
+    kpis = build_gateway_feed_kpis(tenant_id="t1", alerts=alerts, llm_records=[], uptime_seconds=None)
+    assert kpis["blocked_today"] == 2
+    assert kpis["shadow_ai_blocked"] == 1
+    assert kpis["data_filters_applied"] == 1
+    assert kpis["tool_calls_authorized"] == 1
+
+
+def test_shadow_block_event_flagged_and_labeled() -> None:
+    feed = build_gateway_feed(tenant_id="t1", alerts=[_shadow_alert()], llm_records=[], limit=100)
+    event = feed["events"][0]
+    assert event["action_type"] == ACTION_TOOL_CALL_BLOCKED
+    assert event["shadow"] is True
+    assert "undeclared" in event["detail"]
+
+
+def test_shadow_markers_cover_unknown_agent_and_shadow_server() -> None:
+    alerts = [
+        {"ts": 1.0, "agent_name": "x", "action": "gateway.policy_blocked", "details": {"reason": "unknown agent"}},
+        {"ts": 2.0, "agent_name": "y", "action": "gateway.policy_blocked", "details": {"reason": "shadow MCP server"}},
+    ]
+    kpis = build_gateway_feed_kpis(tenant_id="t1", alerts=alerts, llm_records=[], uptime_seconds=None)
+    assert kpis["shadow_ai_blocked"] == 2
+
+
+def test_shadow_detected_via_redaction_safe_fields() -> None:
+    """After tier-A redaction strips free text, shadow detection must still fire.
+
+    The persisted ring buffer drops ``action`` / ``reason`` / ``message`` and
+    empties ``details``; only whitelisted fields (event_type, detector,
+    reason_code, decision) survive. Shadow rollup must ride on those.
+    """
+    alerts = [
+        {  # event_type carries the marker
+            "ts": 1.0,
+            "agent_name": "x",
+            "event_type": "gateway.undeclared_blocked",
+            "decision": "deny",
+            "details": {},
+        },
+        {  # detector carries the marker
+            "ts": 2.0,
+            "agent_name": "y",
+            "event_type": "gateway.policy_blocked",
+            "detector": "shadow_runtime_server",
+            "decision": "deny",
+            "details": {},
+        },
+        {  # reason_code carries the marker
+            "ts": 3.0,
+            "agent_name": "z",
+            "event_type": "gateway.policy_blocked",
+            "reason_code": "undeclared_tool",
+            "decision": "deny",
+            "details": {},
+        },
+    ]
+    kpis = build_gateway_feed_kpis(tenant_id="t1", alerts=alerts, llm_records=[], uptime_seconds=None)
+    assert kpis["blocked_today"] == 3
+    assert kpis["shadow_ai_blocked"] == 3
+
+
+def test_classifier_rides_on_event_type_and_decision_after_redaction() -> None:
+    """Classification survives redaction that strips free-text action/message."""
+    alerts = [
+        {"ts": 1.0, "agent_name": "a", "event_type": "gateway.policy_allowed", "decision": "allow", "tool_name": "read"},
+        {"ts": 2.0, "agent_name": "b", "event_type": "gateway.policy_blocked", "decision": "deny", "tool_name": "exec"},
+    ]
+    feed = build_gateway_feed(tenant_id="t1", alerts=alerts, llm_records=[], limit=100)
+    by_target = {e["target"]: e["action_type"] for e in feed["events"]}
+    assert by_target["read"] == ACTION_TOOL_CALL_AUTHORIZED
+    assert by_target["exec"] == ACTION_TOOL_CALL_BLOCKED
+
+
+# ── KPI rollup totals + no fabricated uptime ─────────────────────────────────
+
+
+def test_kpis_calls_today_sums_tool_calls_and_llm_calls() -> None:
+    alerts = [_authorized_alert(), _authorized_alert(tool="t2"), _blocked_alert(), _dlp_alert()]
+    records = [
+        _FakeCostRecord("t1", "a", "anthropic", "claude", 1, 1, 0.001, True, "2026-06-20T00:00:00+00:00"),
+        _FakeCostRecord("t1", "b", "anthropic", "claude", 1, 1, 0.001, True, "2026-06-20T00:01:00+00:00"),
+    ]
+    kpis = build_gateway_feed_kpis(tenant_id="t1", alerts=alerts, llm_records=records, uptime_seconds=None)
+    # 2 authorized + 1 blocked + 2 llm = 5 (DLP events are not tool calls).
+    assert kpis["calls_today"] == 5
+    assert kpis["llm_calls"] == 2
+
+
+def test_kpis_omit_uptime_when_unreported() -> None:
+    kpis = build_gateway_feed_kpis(tenant_id="t1", alerts=[], llm_records=[], uptime_seconds=None)
+    assert "uptime_seconds" not in kpis
+    kpis_zero = build_gateway_feed_kpis(tenant_id="t1", alerts=[], llm_records=[], uptime_seconds=0.0)
+    assert "uptime_seconds" not in kpis_zero
+
+
+def test_kpis_include_uptime_when_reported() -> None:
+    kpis = build_gateway_feed_kpis(tenant_id="t1", alerts=[], llm_records=[], uptime_seconds=42.0)
+    assert kpis["uptime_seconds"] == 42.0
+
+
+# ── HTTP-level tenant isolation over the proxy ring buffer ───────────────────
+
+
+def _headers(tenant: str) -> dict[str, str]:
+    return {
+        "X-Agent-Bom-Role": "viewer",
+        "X-Agent-Bom-Tenant-ID": tenant,
+        "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
+    }
+
+
+def test_feed_http_is_tenant_scoped() -> None:
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH"] = "1"
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH_SECRET"] = PROXY_SECRET
+    try:
+        from agent_bom.api.routes import proxy as proxy_routes
+        from agent_bom.api.server import app
+
+        proxy_routes._proxy_alerts.clear()
+        # Use the realistic post-redaction shape: tier-A whitelist strips
+        # free-text action/reason, so classification must ride on event_type /
+        # decision (which survive the ring buffer).
+        proxy_routes.push_proxy_alert(
+            {
+                "ts": 10.0,
+                "tenant_id": "tenant-x",
+                "agent_name": "x-agent",
+                "event_type": "gateway.policy_blocked",
+                "decision": "deny",
+                "detector": "gateway_policy",
+                "tool_name": "exec",
+            }
+        )
+        proxy_routes.push_proxy_alert(
+            {
+                "ts": 11.0,
+                "tenant_id": "tenant-y",
+                "agent_name": "y-agent",
+                "event_type": "gateway.policy_allowed",
+                "decision": "allow",
+                "tool_name": "read",
+            }
+        )
+
+        client = TestClient(app)
+        resp_x = client.get("/v1/gateway/feed", headers=_headers("tenant-x"))
+        assert resp_x.status_code == 200, resp_x.text
+        body_x = resp_x.json()
+        agents_x = {e["agent"] for e in body_x["events"]}
+        assert agents_x == {"x-agent"}
+        assert all(e["tenant"] == "tenant-x" for e in body_x["events"])
+
+        resp_y = client.get("/v1/gateway/feed", headers=_headers("tenant-y"))
+        body_y = resp_y.json()
+        agents_y = {e["agent"] for e in body_y["events"]}
+        assert agents_y == {"y-agent"}
+
+        kpis_x = client.get("/v1/gateway/feed/kpis", headers=_headers("tenant-x")).json()
+        assert kpis_x["blocked_today"] == 1
+        assert kpis_x["tenant_id"] == "tenant-x"
+    finally:
+        os.environ.pop("AGENT_BOM_TRUST_PROXY_AUTH", None)
+        os.environ.pop("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", None)
+        from agent_bom.api.routes import proxy as proxy_routes
+
+        proxy_routes._proxy_alerts.clear()

--- a/ui/app/gateway/GatewayFeedPanel.tsx
+++ b/ui/app/gateway/GatewayFeedPanel.tsx
@@ -1,0 +1,373 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  api,
+  type GatewayFeedActionType,
+  type GatewayFeedEvent,
+  type GatewayFeedKpis,
+  formatDate,
+} from "@/lib/api";
+import { getSessionWebSocketToken } from "@/lib/auth";
+import { getConfiguredApiUrl } from "@/lib/runtime-config";
+import {
+  Activity,
+  Ban,
+  Bot,
+  Clock,
+  EyeOff,
+  Loader2,
+  RefreshCw,
+  ShieldCheck,
+  Sparkles,
+  Wifi,
+  WifiOff,
+  Zap,
+} from "lucide-react";
+
+// ─── Action badge styling ─────────────────────────────────────────────────────
+
+const ACTION_META: Record<
+  GatewayFeedActionType,
+  { label: string; badge: string; icon: React.ElementType; tone: string }
+> = {
+  tool_call_authorized: {
+    label: "authorized",
+    badge: "bg-emerald-950 text-emerald-300 border-emerald-800",
+    icon: ShieldCheck,
+    tone: "text-emerald-400",
+  },
+  tool_call_blocked: {
+    label: "blocked",
+    badge: "bg-red-950 text-red-300 border-red-800",
+    icon: Ban,
+    tone: "text-red-400",
+  },
+  data_filter_applied: {
+    label: "data filter",
+    badge: "bg-amber-950 text-amber-300 border-amber-800",
+    icon: EyeOff,
+    tone: "text-amber-400",
+  },
+  llm_call: {
+    label: "LLM call",
+    badge: "bg-blue-950 text-blue-300 border-blue-800",
+    icon: Sparkles,
+    tone: "text-blue-400",
+  },
+};
+
+// Live counters streamed by the existing /ws/proxy/metrics WebSocket. We use it
+// only to drive the "Live" indicator and refresh the KPI header in near-real
+// time; the authoritative fused feed is fetched from /v1/gateway/feed.
+interface LiveMetrics {
+  ts: number;
+  total_tool_calls: number;
+  total_blocked: number;
+}
+
+function formatUptime(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.round((seconds % 3600) / 60);
+  return `${h}h ${m}m`;
+}
+
+function formatEventTime(ts: string): string {
+  if (!ts) return "—";
+  // Feed timestamps are ISO-8601 strings already normalized server-side.
+  try {
+    return formatDate(ts);
+  } catch {
+    return ts;
+  }
+}
+
+// ─── Panel ────────────────────────────────────────────────────────────────────
+
+export function GatewayFeedPanel() {
+  const [events, setEvents] = useState<GatewayFeedEvent[]>([]);
+  const [kpis, setKpis] = useState<GatewayFeedKpis | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionFilter, setActionFilter] = useState<GatewayFeedActionType | "">("");
+  const [wsConnected, setWsConnected] = useState(false);
+  const wsRef = useRef<WebSocket | null>(null);
+
+  const load = () => {
+    setLoading(true);
+    setError(null);
+    void Promise.allSettled([api.getGatewayFeed(200), api.getGatewayFeedKpis()])
+      .then(([feedResult, kpiResult]) => {
+        const failures: string[] = [];
+        if (feedResult.status === "fulfilled") {
+          setEvents(feedResult.value.events);
+        } else {
+          failures.push(`feed: ${feedResult.reason?.message ?? "request failed"}`);
+        }
+        if (kpiResult.status === "fulfilled") {
+          setKpis(kpiResult.value);
+        } else {
+          failures.push(`kpis: ${kpiResult.reason?.message ?? "request failed"}`);
+        }
+        setError(failures.length === 0 ? null : failures.join("; "));
+      })
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => load(), 0);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  // Reuse the existing proxy metrics WebSocket for a live indicator + a light
+  // periodic refresh. When new total_tool_calls/total_blocked counters tick we
+  // re-pull the fused feed (the WS itself does not carry fused events).
+  useEffect(() => {
+    const base = getConfiguredApiUrl() || window.location.origin;
+    const wsTarget = new URL(base.replace(/^http/, "ws") + "/ws/proxy/metrics");
+    const token = getSessionWebSocketToken();
+    const wsUrl = wsTarget.toString();
+
+    let ws: WebSocket;
+    let reconnectTimer: ReturnType<typeof setTimeout>;
+    let lastSeen = -1;
+    let lastRefresh = 0;
+
+    const connect = () => {
+      ws = new WebSocket(wsUrl);
+      wsRef.current = ws;
+      ws.onopen = () => {
+        if (token) ws.send(JSON.stringify({ type: "auth", token }));
+        setWsConnected(true);
+      };
+      ws.onclose = () => {
+        setWsConnected(false);
+        reconnectTimer = setTimeout(connect, 5000);
+      };
+      ws.onerror = () => ws.close();
+      ws.onmessage = (e) => {
+        try {
+          const payload = JSON.parse(e.data) as { type?: string } & LiveMetrics;
+          if (payload?.type === "auth") return;
+          const total = (payload.total_tool_calls ?? 0) + (payload.total_blocked ?? 0);
+          const now = Date.now();
+          // Refresh the fused feed when the counter advances, throttled to at
+          // most once every 3s so a busy fleet doesn't hammer the API.
+          if (total !== lastSeen && now - lastRefresh > 3000) {
+            lastSeen = total;
+            lastRefresh = now;
+            void Promise.allSettled([api.getGatewayFeed(200), api.getGatewayFeedKpis()]).then(
+              ([feedResult, kpiResult]) => {
+                if (feedResult.status === "fulfilled") setEvents(feedResult.value.events);
+                if (kpiResult.status === "fulfilled") setKpis(kpiResult.value);
+              },
+            );
+          }
+        } catch {
+          // ignore parse errors
+        }
+      };
+    };
+
+    connect();
+    return () => {
+      clearTimeout(reconnectTimer);
+      ws?.close();
+    };
+  }, []);
+
+  const filtered = actionFilter ? events.filter((e) => e.action_type === actionFilter) : events;
+
+  return (
+    <div className="space-y-5">
+      {/* KPI header bar */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-5 gap-3">
+        <KpiCard
+          label="Calls Today"
+          value={kpis ? kpis.calls_today.toLocaleString() : "—"}
+          icon={Zap}
+          color="text-emerald-400"
+        />
+        <KpiCard
+          label="Blocked"
+          value={kpis ? kpis.blocked_today.toLocaleString() : "—"}
+          icon={Ban}
+          color="text-red-400"
+        />
+        <KpiCard
+          label="Shadow AI Blocked"
+          value={kpis ? kpis.shadow_ai_blocked.toLocaleString() : "—"}
+          icon={Bot}
+          color="text-orange-400"
+          hint="undeclared agents + shadow MCP servers"
+        />
+        <KpiCard
+          label="Data Filters"
+          value={kpis ? kpis.data_filters_applied.toLocaleString() : "—"}
+          icon={EyeOff}
+          color="text-amber-400"
+        />
+        {kpis?.uptime_seconds != null && (
+          <KpiCard
+            label="Uptime"
+            value={formatUptime(kpis.uptime_seconds)}
+            icon={Activity}
+            color="text-zinc-400"
+          />
+        )}
+      </div>
+
+      {/* Feed header + controls */}
+      <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h3 className="text-sm font-semibold text-zinc-300 flex items-center gap-2">
+              <Activity className="w-4 h-4 text-emerald-400" />
+              Gateway Live Feed
+            </h3>
+            <p className="text-[10px] text-zinc-600 mt-0.5">
+              Unified fleet stream — tool-call authorization, data filters, and LLM calls, per agent
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-1.5 text-xs">
+              {wsConnected ? (
+                <>
+                  <Wifi className="w-3.5 h-3.5 text-emerald-400" />
+                  <span className="text-emerald-400">Live</span>
+                </>
+              ) : (
+                <>
+                  <WifiOff className="w-3.5 h-3.5 text-zinc-500" />
+                  <span className="text-zinc-500">Disconnected</span>
+                </>
+              )}
+            </div>
+            <button
+              onClick={load}
+              className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 rounded-lg text-xs text-zinc-300 transition-colors"
+            >
+              <RefreshCw className="w-3.5 h-3.5" />
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        {/* Action filter */}
+        <div className="flex flex-wrap gap-1 mb-4">
+          {(
+            [
+              ["", "All"],
+              ["tool_call_authorized", "Authorized"],
+              ["tool_call_blocked", "Blocked"],
+              ["data_filter_applied", "Data filters"],
+              ["llm_call", "LLM calls"],
+            ] as const
+          ).map(([value, label]) => (
+            <button
+              key={value || "all"}
+              onClick={() => setActionFilter(value as GatewayFeedActionType | "")}
+              className={`px-2.5 py-1 rounded text-[10px] font-medium transition-colors ${
+                actionFilter === value
+                  ? "bg-zinc-700 text-zinc-100"
+                  : "text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {loading && (
+          <div className="flex items-center justify-center py-10">
+            <Loader2 className="w-5 h-5 animate-spin text-zinc-500" />
+          </div>
+        )}
+
+        {error && !loading && (
+          <div className="text-center py-8 text-xs text-red-400">{error}</div>
+        )}
+
+        {!loading && !error && filtered.length === 0 && (
+          <div className="text-center py-10">
+            <ShieldCheck className="w-6 h-6 text-emerald-600 mx-auto mb-2" />
+            <p className="text-zinc-600 text-xs">
+              No gateway activity yet. Events appear as agents call tools through the gateway/proxy.
+            </p>
+          </div>
+        )}
+
+        {!loading && !error && filtered.length > 0 && (
+          <div className="space-y-1 max-h-[32rem] overflow-y-auto">
+            {filtered.map((event, i) => (
+              <FeedRow key={`${event.ts}-${event.agent}-${i}`} event={event} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Feed row ─────────────────────────────────────────────────────────────────
+
+function FeedRow({ event }: { event: GatewayFeedEvent }) {
+  const meta = ACTION_META[event.action_type];
+  const Icon = meta.icon;
+  return (
+    <div className="flex items-center justify-between px-3 py-2 bg-zinc-800/50 border border-zinc-800 rounded-lg">
+      <div className="flex items-center gap-3 min-w-0">
+        <Icon className={`w-3.5 h-3.5 shrink-0 ${meta.tone}`} />
+        {/* Per-agent attribution → target */}
+        <span className="text-xs text-zinc-200 font-mono shrink-0 max-w-[10rem] truncate" title={event.agent}>
+          {event.agent}
+        </span>
+        <span className="text-zinc-600 shrink-0 text-xs">→</span>
+        <span className="text-xs text-zinc-400 font-mono shrink-0 max-w-[12rem] truncate" title={event.target}>
+          {event.target}
+        </span>
+        <span className={`text-[10px] px-1.5 py-0.5 rounded border shrink-0 ${meta.badge}`}>
+          {meta.label}
+        </span>
+        {event.shadow && (
+          <span className="text-[10px] px-1.5 py-0.5 rounded border shrink-0 bg-orange-950 text-orange-300 border-orange-800">
+            shadow AI
+          </span>
+        )}
+        <span className="text-xs text-zinc-500 truncate" title={event.detail}>
+          {event.detail}
+        </span>
+      </div>
+      <span className="text-[10px] text-zinc-600 shrink-0 ml-3 flex items-center gap-1">
+        <Clock className="w-3 h-3" />
+        {formatEventTime(event.ts)}
+      </span>
+    </div>
+  );
+}
+
+// ─── KPI card ─────────────────────────────────────────────────────────────────
+
+function KpiCard({
+  label,
+  value,
+  icon: Icon,
+  color,
+  hint,
+}: {
+  label: string;
+  value: string;
+  icon: React.ElementType;
+  color: string;
+  hint?: string;
+}) {
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4" title={hint}>
+      <Icon className={`w-4 h-4 mb-2 ${color}`} />
+      <div className="text-2xl font-bold font-mono">{value}</div>
+      <div className="text-xs text-zinc-500 mt-0.5">{label}</div>
+    </div>
+  );
+}

--- a/ui/app/gateway/page.tsx
+++ b/ui/app/gateway/page.tsx
@@ -33,7 +33,9 @@ import {
   Play,
   FileText,
   AlertTriangle,
+  Activity,
 } from "lucide-react";
+import { GatewayFeedPanel } from "./GatewayFeedPanel";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -59,7 +61,7 @@ export default function GatewayPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
-  const [tab, setTab] = useState<"policies" | "audit" | "evaluate">("policies");
+  const [tab, setTab] = useState<"feed" | "policies" | "audit" | "evaluate">("feed");
 
   // Evaluate form state
   const [evalTool, setEvalTool] = useState("");
@@ -187,30 +189,40 @@ export default function GatewayPage() {
 
       {/* Tabs */}
       <div className="flex gap-1.5">
-        {(["policies", "audit", "evaluate"] as const).map((t) => (
+        {(["feed", "policies", "audit", "evaluate"] as const).map((t) => (
           <button
             key={t}
             onClick={() => setTab(t)}
-            className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+            className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors inline-flex items-center gap-1.5 ${
               tab === t
                 ? "bg-zinc-800 text-zinc-100"
                 : "text-zinc-500 hover:text-zinc-300 hover:bg-zinc-900"
             }`}
           >
-            {t === "policies" ? "Policies" : t === "audit" ? "Audit Log" : "Evaluate"}
+            {t === "feed" && <Activity className="w-3.5 h-3.5" />}
+            {t === "feed"
+              ? "Live Feed"
+              : t === "policies"
+                ? "Policies"
+                : t === "audit"
+                  ? "Audit Log"
+                  : "Evaluate"}
           </button>
         ))}
       </div>
 
+      {/* Live Feed tab — self-contained, has its own data + WebSocket lifecycle */}
+      {tab === "feed" && <GatewayFeedPanel />}
+
       {/* Loading */}
-      {loading && (
+      {loading && tab !== "feed" && (
         <div className="flex items-center justify-center py-12">
           <Loader2 className="w-6 h-6 animate-spin text-zinc-500" />
         </div>
       )}
 
       {/* Error state */}
-      {error && !loading && (
+      {error && !loading && tab !== "feed" && (
         <div className="text-center py-10 border border-dashed border-red-900/50 rounded-xl space-y-3">
           <AlertTriangle className="w-8 h-8 text-red-500 mx-auto" />
           <p className="text-red-400 text-sm">Failed to load gateway data</p>

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1764,6 +1764,46 @@ export interface GatewayStatsResponse {
   firewall_runtime: FirewallRuntimeStats;
 }
 
+// ─── Gateway Live Feed (unified fleet event stream) ─────────────────────
+
+export type GatewayFeedActionType =
+  | "tool_call_authorized"
+  | "tool_call_blocked"
+  | "data_filter_applied"
+  | "llm_call";
+
+export interface GatewayFeedEvent {
+  ts: string;
+  agent: string;
+  action_type: GatewayFeedActionType;
+  target: string;
+  detail: string;
+  tenant: string;
+  shadow: boolean;
+  source: string;
+}
+
+export interface GatewayFeedResponse {
+  schema_version: string;
+  tenant_id: string;
+  generated_at: string;
+  count: number;
+  events: GatewayFeedEvent[];
+}
+
+export interface GatewayFeedKpis {
+  schema_version: string;
+  tenant_id: string;
+  generated_at: string;
+  calls_today: number;
+  blocked_today: number;
+  shadow_ai_blocked: number;
+  data_filters_applied: number;
+  tool_calls_authorized: number;
+  llm_calls: number;
+  uptime_seconds?: number;
+}
+
 // ─── Inter-agent firewall (#982) ────────────────────────────────────────
 
 export interface FirewallPairTally {

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -71,6 +71,8 @@ import type {
   GatewayPolicyResponse,
   GatewayAuditResponse,
   GatewayStatsResponse,
+  GatewayFeedResponse,
+  GatewayFeedKpis,
   FirewallRuntimeStats,
   EvaluateResult,
   PostureResponse,
@@ -220,6 +222,10 @@ export type {
   PolicyAuditEntry,
   GatewayAuditResponse,
   GatewayStatsResponse,
+  GatewayFeedResponse,
+  GatewayFeedKpis,
+  GatewayFeedEvent,
+  GatewayFeedActionType,
   GatewayPolicyRuntimeSummary,
   FirewallRuntimeStats,
   FirewallPairTally,
@@ -750,6 +756,8 @@ export const api = {
     post<EvaluateResult>("/v1/gateway/evaluate", body),
   listGatewayAudit: () => get<GatewayAuditResponse>("/v1/gateway/audit"),
   getGatewayStats: () => get<GatewayStatsResponse>("/v1/gateway/stats"),
+  getGatewayFeed: (limit = 100) => get<GatewayFeedResponse>(`/v1/gateway/feed?limit=${limit}`),
+  getGatewayFeedKpis: () => get<GatewayFeedKpis>("/v1/gateway/feed/kpis"),
   getFirewallStats: () => get<FirewallRuntimeStats>("/v1/firewall/stats"),
 
   // Governance

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -13,7 +13,8 @@ const BUDGETS = {
   // Includes the dashboard trust-mesh topology filters and offline-state workflow.
   // Allows measured framework/runtime drift from the June 2026 UI dependency refresh.
   // Includes the parity governance cockpits for cost, identity, and drift.
-  totalClientJsBytes: 2_960_000,
+  // Includes the Gateway Live Feed tab for tool-call auth, DLP, and LLM-call events.
+  totalClientJsBytes: 2_970_000,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };

--- a/ui/tests/gateway-page.test.tsx
+++ b/ui/tests/gateway-page.test.tsx
@@ -12,6 +12,8 @@ const { apiMock } = vi.hoisted(() => ({
     deleteGatewayPolicy: vi.fn(),
     updateGatewayPolicy: vi.fn(),
     evaluateGateway: vi.fn(),
+    getGatewayFeed: vi.fn(),
+    getGatewayFeedKpis: vi.fn(),
   },
 }));
 
@@ -28,6 +30,16 @@ describe("GatewayPage", () => {
     Object.values(apiMock).forEach((mockFn) => mockFn.mockReset());
     apiMock.listGatewayPolicies.mockResolvedValue({ policies: [], count: 0 });
     apiMock.listGatewayAudit.mockResolvedValue({ entries: [], count: 0 });
+    apiMock.getGatewayFeed.mockResolvedValue({ events: [], count: 0, limit: 200 });
+    apiMock.getGatewayFeedKpis.mockResolvedValue({
+      calls_today: 0,
+      blocked_today: 0,
+      shadow_ai_blocked: 0,
+      data_filters_applied: 0,
+      uptime_seconds: 0,
+      by_action_type: {},
+      by_source: {},
+    });
     apiMock.getGatewayStats.mockResolvedValue({
       total_policies: 2,
       enforce_count: 1,


### PR DESCRIPTION
## Summary
A unified fleet event stream — one pane fusing tool-call authorization, inline DLP/redaction, and LLM calls with per-agent attribution + a KPI header. **Consumes existing surfaces** (enforcement, DLP, audit, WS) — no new enforcement.

**Backend** `api/routes/gateway_feed.py` (read-only over the proxy alert ring buffer + cost store):
- `GET /v1/gateway/feed` — newest-first fused events `{ts, agent, action_type, target, detail, tenant, shadow}`, action_type ∈ tool_call_authorized/blocked, data_filter_applied, llm_call. RBAC read, tenant-scoped, redaction-safe (metadata only — DLP details say e.g. "AWS Access Key masked", never raw values).
- `GET /v1/gateway/feed/kpis` — calls_today, blocked_today, shadow_ai_blocked, data_filters_applied, llm_calls; uptime only when the proxy actually reports it (no fabricated 99.9%).

**Shadow-AI** is counted honestly as blocked events marked undeclared/shadow agent or shadow MCP server (label: "Shadow AI Blocked — undeclared agents + shadow MCP servers").

**Correctness fix found:** the proxy ring buffer runs alerts through tier-A redaction (strips free-text action/reason), so classification + shadow detection were moved onto the whitelisted fields (event_type/decision/detector/reason_code/outcome) — otherwise shadow blocks would silently stop counting once persisted. Covered by tests.

**Frontend** — new default "Live Feed" tab in `ui/app/gateway/page.tsx` + `GatewayFeedPanel.tsx`: KPI header + streaming event list (agent → target, iconed action badge, shadow badge), action filter, reuses `/ws/proxy/metrics` for live updates. Matches the zinc/Tailwind design system.

## Verification
16 backend tests + 77 gateway/proxy regression pass; ruff/format/mypy clean; OpenAPI (+2 paths) + atlas regenerated, all version-alignment checks exit 0; UI lint/typecheck/build (static export) all pass.