### PR TITLE
feat(mcp): expose new governance/cost capabilities as agent tools + lock surface-count freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ integration docs instead of this front door.
 | Python client | services, notebooks, and automation | typed helper for stable REST endpoints in the packaged wheel |
 | TypeScript client | services and agent runtimes | typed helper for stable REST endpoints |
 
-MCP server mode advertises 63 MCP tools, 6 resources, and 6 workflow prompts.
+MCP server mode advertises 69 MCP tools, 6 resources, and 6 workflow prompts.
 Most tools are read-only. The three Shield write actions fail closed unless
 the caller supplies `operator_role=admin`, `operator_scopes=shield:write`, and
 an audit reason.

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -1,6 +1,6 @@
 # MCP Server — Streamable HTTP transport for remote clients.
 #
-# Exposes agent-bom's 36 MCP tools over streamable HTTP so that Smithery, Claude
+# Exposes agent-bom's 69 MCP tools over streamable HTTP so that Smithery, Claude
 # Desktop (remote mode), and any other MCP client can connect via public URL.
 #
 # Build:   docker build -f deploy/docker/Dockerfile.sse -t agent-bom-sse .

--- a/docs/CLAUDE_INTEGRATION.md
+++ b/docs/CLAUDE_INTEGRATION.md
@@ -59,7 +59,7 @@ claude mcp add agent-bom -- uvx agent-bom mcp server
 
 ## What users get inside Claude
 
-`agent-bom mcp server` exposes 63 MCP tools for:
+`agent-bom mcp server` exposes 69 MCP tools for:
 
 - agent and MCP discovery
 - package and registry checks

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,6 +1,6 @@
 # MCP Server — Connect agent-bom to AI Assistants
 
-agent-bom exposes 63 MCP tools as an MCP server. Any MCP-compatible client can
+agent-bom exposes 69 MCP tools as an MCP server. Any MCP-compatible client can
 connect and get vulnerability scanning, blast radius analysis, compliance
 checks, runtime posture, and supply-chain verification through natural
 conversation.
@@ -156,7 +156,7 @@ agent-bom proxy-bootstrap \
 
 `proxy-configure` is best for JSON MCP clients such as Claude Desktop, Cursor, Windsurf, and Cortex CoCo. TOML-based clients like Codex CLI need manual proxy wrapping.
 
-## Tool Categories (63 tools)
+## Tool Categories (69 tools)
 
 | Category | Tools | What They Do |
 |----------|-------|-------------|

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -125,7 +125,7 @@ notes discuss agent-native product direction.
 | Area | Shipped today | Not yet shipped |
 |---|---|---|
 | Human cockpit | Next.js dashboard, graph cockpit, reports, compliance and audit views | every UI action backed by a source registry and persisted workflow state |
-| Agent interface | 63 MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture, admin-gated Shield actions | long-lived posture subscription tool, autonomous remediation actions |
+| Agent interface | 69 MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture, admin-gated Shield actions | long-lived posture subscription tool, autonomous remediation actions |
 | Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports, Python/Go/TypeScript control-plane clients, TypeScript runtime detector package | full scanner SDKs |
 | Runtime | MCP proxy, gateway, Shield SDK, runtime audit and policy decisions | webhook outbox, Kafka connectors, cloud-log ingestion connectors, Kinesis/Firehose adapter, and MCP posture subscriptions |
 | Graph scale | SQLite/Postgres default path, WebGL overview, optional Neptune adapter work | production Neptune SLOs, public openCypher endpoint, mandatory graph-database backend |

--- a/integrations/docker-mcp-registry/SUBMISSION.md
+++ b/integrations/docker-mcp-registry/SUBMISSION.md
@@ -5,7 +5,7 @@ Submission files for listing agent-bom in the Docker Desktop MCP Toolkit catalog
 ## Files
 
 - `server.yaml` — server metadata, image, allowed hosts, optional secrets
-- `tools.json` — all 63 MCP tools with descriptions and parameters
+- `tools.json` — all 69 MCP tools with descriptions and parameters
 - `readme.md` — Docker MCP Toolkit detail page content
 
 ## How to submit

--- a/integrations/docker-mcp-registry/tools.json
+++ b/integrations/docker-mcp-registry/tools.json
@@ -1134,5 +1134,110 @@
         "desc": "Scanner format: trivy, grype, syft (auto-detected if omitted)"
       }
     ]
+  },
+  {
+    "name": "cost_forecast",
+    "description": "Project LLM spend burn rate and budget runway for the active tenant \u2014 reference-only forecast with projected period spend, days of runway, and exhaustion date.",
+    "arguments": [
+      {
+        "name": "agent",
+        "type": "string",
+        "desc": "Optional agent name to scope the forecast to a single agent"
+      },
+      {
+        "name": "tenant_id",
+        "type": "string",
+        "desc": "Tenant scope to forecast (default: default)"
+      }
+    ]
+  },
+  {
+    "name": "cost_allocation",
+    "description": "Chargeback / showback LLM spend rollups by cost-center and allocation tag, with budget posture and forecast. No prompts or responses are read.",
+    "arguments": [
+      {
+        "name": "cost_center",
+        "type": "string",
+        "desc": "Optional cost-center / allocation unit to scope the chargeback report and budget"
+      },
+      {
+        "name": "tag",
+        "type": "string",
+        "desc": "Optional allocation tag to add a showback slice (by_tag rollup)"
+      },
+      {
+        "name": "agent",
+        "type": "string",
+        "desc": "Optional agent name to scope spend to a single agent"
+      },
+      {
+        "name": "tenant_id",
+        "type": "string",
+        "desc": "Tenant scope to summarize (default: default)"
+      }
+    ]
+  },
+  {
+    "name": "credential_expiry",
+    "description": "Expiring / overdue credential and rotation posture for control-plane secrets, with an overall verdict. Never returns secret values.",
+    "arguments": []
+  },
+  {
+    "name": "nhi_discover",
+    "description": "Discover non-human identities (Okta service apps / Entra service principals) \u2014 reference-only metadata, never secret material; each provider is gated by its own discovery env flag and token.",
+    "arguments": [
+      {
+        "name": "providers",
+        "type": "string",
+        "desc": "Comma-separated IdP providers to query: okta, entra (default: both)"
+      },
+      {
+        "name": "tenant_id",
+        "type": "string",
+        "desc": "Tenant scope for the response envelope (default: default)"
+      }
+    ]
+  },
+  {
+    "name": "cloud_inventory",
+    "description": "Summarize the estate-wide cloud asset inventory (resource + identity counts and node summary). Opt-in per provider via AGENT_BOM_*_INVENTORY; reference-only, never resource secrets.",
+    "arguments": [
+      {
+        "name": "providers",
+        "type": "string",
+        "desc": "Comma-separated cloud providers to summarize: aws, azure, gcp (default: all enabled)"
+      },
+      {
+        "name": "region",
+        "type": "string",
+        "desc": "Optional AWS region for AWS inventory (e.g. us-east-1)"
+      },
+      {
+        "name": "tenant_id",
+        "type": "string",
+        "desc": "Tenant scope for the response envelope (default: default)"
+      }
+    ]
+  },
+  {
+    "name": "access_review",
+    "description": "List or get NHI access-review / recertification campaigns and their status (read-only). Creating a campaign or submitting a decision is a write action and is not exposed here.",
+    "arguments": [
+      {
+        "name": "campaign_id",
+        "type": "string",
+        "desc": "Optional campaign id to fetch one campaign with its review items (default: list campaigns)"
+      },
+      {
+        "name": "tenant_id",
+        "type": "string",
+        "desc": "Tenant scope to read (default: default)"
+      },
+      {
+        "name": "limit",
+        "type": "integer",
+        "desc": "Maximum campaigns to list when campaign_id is omitted (default: 200)"
+      }
+    ]
   }
 ]

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -422,7 +422,7 @@ def main() -> int:
     tools = len(tool_names)
     resources = len(resource_uris)
     prompts = len(prompt_names)
-    if (tools, resources, prompts) != (63, 6, 6):
+    if (tools, resources, prompts) != (69, 6, 6):
         _fail(f"MCP server card count changed unexpectedly: tools={tools}, resources={resources}, prompts={prompts}")
     docker_mcp_tool_names = [str(tool["name"]) for tool in json.loads(DOCKER_MCP_TOOLS.read_text())]
     if docker_mcp_tool_names != tool_names:

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server Setup
 
-agent-bom runs as an MCP server, exposing 63 MCP tools to any MCP client.
+agent-bom runs as an MCP server, exposing 69 MCP tools to any MCP client.
 The server card also advertises 6 resources and 6 workflow prompts so agents can
 choose structured playbooks instead of guessing tool order.
 Most tools are read-only. Shield write actions require `operator_role=admin`,

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -112,7 +112,7 @@ SLO or openCypher endpoint.
 | **Discovery** | Auto-detect 29 first-class MCP client types plus dynamic/project surfaces |
 | **CVE scanning** | OSV + NVD CVSS v4 + EPSS + CISA KEV + GHSA |
 | **Blast radius** | Map CVE impact: package → vulnerability finding → MCP server (tools + credential env names) → connected agents |
-| **Registry** | 738 MCP server security metadata entries |
+| **Registry** | 840 MCP server security metadata entries |
 | **Compliance** | OWASP LLM/Agentic/MCP Top 10, MITRE ATLAS, EU AI Act, NIST AI RMF, CIS |
 | **Runtime proxy** | Policy enforcement, credential leak detection, audit logging |
 | **SBOM** | CycloneDX 1.6, SPDX 3.0 output |

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -694,7 +694,7 @@ def mcp_server_cmd(
     Requires:  pip install 'agent-bom[mcp-server]'
 
     \b
-    Exposes 63 security tools via MCP protocol:
+    Exposes 69 security tools via MCP protocol:
       scan                   Full scan — CVEs, config security, blast radius, compliance
       check                  Check a specific package for CVEs before installing
       blast_radius           Look up blast radius for a specific CVE

--- a/src/agent_bom/mcp_hardening.py
+++ b/src/agent_bom/mcp_hardening.py
@@ -5,6 +5,18 @@ from typing import Any
 NSA_MCP_SECURITY_REPORT_URL = "https://www.nsa.gov/Portals/75/documents/Cybersecurity/CSI_MCP_SECURITY.pdf"
 
 
+def strict_args_tool_count() -> int:
+    """Return the number of strict-args MCP tools, derived from the server card.
+
+    Every registered ``@mcp.tool`` is hardened with ``additionalProperties=false``
+    and listed in ``_SERVER_CARD_TOOLS``; counting the card keeps the hardening
+    surface honest as new tools land (no hand-maintained literal to drift).
+    """
+    from agent_bom.mcp_server_metadata import _SERVER_CARD_TOOLS
+
+    return len(_SERVER_CARD_TOOLS)
+
+
 def build_mcp_hardening_catalog() -> dict[str, Any]:
     """Return operator-facing MCP hardening controls and agent-bom evidence.
 
@@ -48,7 +60,7 @@ def build_mcp_hardening_catalog() -> dict[str, Any]:
             "nsa_theme": "Validate parameters",
             "risk": "Malformed, oversized, or context-confused tool parameters can trigger injection, DoS, or data leakage.",
             "agent_bom_surfaces": [
-                "55 strict-args MCP tools",
+                f"{strict_args_tool_count()} strict-args MCP tools",
                 "MCP wrapper additionalProperties=false",
                 "API VALIDATION_ERROR responses",
                 "policy_check",

--- a/src/agent_bom/mcp_registry.json
+++ b/src/agent_bom/mcp_registry.json
@@ -2,7 +2,7 @@
   "_comment": "agent-bom MCP Server Registry — security metadata database for known MCP servers",
   "_schema_version": "2.0",
   "_updated": "2026-06-15",
-  "_total_servers": 738,
+  "_total_servers": 840,
   "_differentiator": "Security metadata database — not just a catalog. Each entry has risk_level (category-derived), tools, credential_env_vars (heuristic-inferred) for blast radius pre-computation.",
   "_source": "https://github.com/msaad00/agent-bom/blob/main/data/mcp-registry.yaml",
   "_sources": [

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -5,7 +5,7 @@ Start with:
     agent-bom mcp server --transport sse          # SSE transport (for remote clients)
     agent-bom mcp server --transport streamable-http
 
-Tools (63):
+Tools (69):
     scan                — Full discovery → scan → output pipeline
     check               — Check a specific package for CVEs before installing
     blast_radius        — Look up blast radius for a specific CVE
@@ -60,6 +60,12 @@ Tools (63):
     ai_inventory_scan   — Scan source code for AI SDK imports, model references, shadow AI
     license_compliance_scan — Evaluate package licenses against SPDX compliance policy
     ingest_external_scan   — Ingest Trivy, Grype, or Syft JSON output with blast radius analysis
+    cost_forecast       — Project LLM spend burn rate and budget runway
+    cost_allocation     — Chargeback / showback spend rollups by cost-center and tag
+    credential_expiry   — Expiring / overdue credential and rotation posture
+    nhi_discover        — Discover non-human identities (Okta / Entra), reference-only
+    cloud_inventory     — Estate-wide cloud asset inventory summary, opt-in per provider
+    access_review       — List or get NHI access-review / recertification campaigns
 
 Resources (6):
     registry://servers  — Browse 427+ server security metadata registry

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -294,6 +294,36 @@ _SERVER_CARD_TOOLS = [
         "description": "Ingest Trivy, Grype, or Syft JSON scan output and return packages with blast radius analysis",
         "annotations": {"readOnlyHint": True},
     },
+    {
+        "name": "cost_forecast",
+        "description": "Project LLM spend burn rate and budget runway (reference-only forecast)",
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "cost_allocation",
+        "description": "Chargeback / showback LLM spend rollups by cost-center and allocation tag",
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "credential_expiry",
+        "description": "Expiring / overdue credential and rotation posture for control-plane secrets (no secret values)",
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "nhi_discover",
+        "description": "Discover non-human identities (Okta / Entra) — reference-only metadata, gated per provider",
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "cloud_inventory",
+        "description": "Estate-wide cloud asset inventory summary (resource + identity counts), opt-in per provider",
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "access_review",
+        "description": "List or get NHI access-review / recertification campaigns and their status (read-only)",
+        "annotations": {"readOnlyHint": True},
+    },
 ]
 
 _TOOL_CAPABILITY_CLASSES = {

--- a/src/agent_bom/mcp_server_operator_tools.py
+++ b/src/agent_bom/mcp_server_operator_tools.py
@@ -38,6 +38,14 @@ def register_operator_tools(
         identity_revoke_jit_impl,
         identity_rotate_impl,
     )
+    from agent_bom.mcp_tools.posture import (
+        access_review_impl,
+        cloud_inventory_impl,
+        cost_allocation_impl,
+        cost_forecast_impl,
+        credential_expiry_impl,
+        nhi_discover_impl,
+    )
     from agent_bom.mcp_tools.registry import fleet_scan_impl, marketplace_check_impl
     from agent_bom.mcp_tools.runtime import (
         anomaly_scan_impl,
@@ -949,5 +957,169 @@ def register_operator_tools(
             tenant_id=tenant_id,
             limit=limit,
             include_runtime=include_runtime,
+            _truncate_response=truncate_response,
+        )
+
+    @mcp.tool(annotations=read_only, title="Cost Forecast")
+    async def cost_forecast(
+        agent: Annotated[
+            str,
+            Field(description="Optional agent name to scope the forecast to a single agent."),
+        ] = "",
+        tenant_id: Annotated[
+            str,
+            Field(description="Tenant scope to forecast. Defaults to the control-plane default tenant."),
+        ] = "default",
+    ) -> str:
+        """Project LLM spend burn rate and budget runway for the active tenant.
+
+        Derives a recent burn rate from persisted cost records and extrapolates
+        to the configured budget, returning projected period spend, days of
+        runway, and an exhaustion date. Reference only: a forecast never blocks a
+        call and returns a clear status with null projections on sparse history.
+        """
+        return await execute_tool_async(
+            "cost_forecast",
+            cost_forecast_impl,
+            agent=agent,
+            tenant_id=tenant_id,
+            _truncate_response=truncate_response,
+        )
+
+    @mcp.tool(annotations=read_only, title="Cost Allocation")
+    async def cost_allocation(
+        cost_center: Annotated[
+            str,
+            Field(description="Optional cost-center / allocation unit to scope the chargeback report and budget."),
+        ] = "",
+        tag: Annotated[
+            str,
+            Field(description="Optional allocation tag to add a showback slice (by_tag rollup)."),
+        ] = "",
+        agent: Annotated[
+            str,
+            Field(description="Optional agent name to scope spend to a single agent."),
+        ] = "",
+        tenant_id: Annotated[
+            str,
+            Field(description="Tenant scope to summarize. Defaults to the control-plane default tenant."),
+        ] = "default",
+    ) -> str:
+        """Return chargeback / showback LLM spend rollups by cost-center and allocation tag.
+
+        Spend is derived from token counts on ingested OpenTelemetry GenAI spans
+        priced via the open cost model. Includes per-cost-center allocation,
+        budget posture, and forecast. No prompts or responses are read.
+        """
+        return await execute_tool_async(
+            "cost_allocation",
+            cost_allocation_impl,
+            cost_center=cost_center,
+            tag=tag,
+            agent=agent,
+            tenant_id=tenant_id,
+            _truncate_response=truncate_response,
+        )
+
+    @mcp.tool(annotations=read_only, title="Credential Expiry")
+    async def credential_expiry() -> str:
+        """Return expiring / overdue credential posture for control-plane secrets.
+
+        Surfaces non-secret credential-expiry and rotation governance: which
+        secrets are near expiry, overdue for rotation, or past max age, with an
+        overall verdict. Never returns secret values.
+        """
+        return await execute_tool_async(
+            "credential_expiry",
+            credential_expiry_impl,
+            _truncate_response=truncate_response,
+        )
+
+    @mcp.tool(annotations=read_only, title="NHI Discover")
+    async def nhi_discover(
+        providers: Annotated[
+            str,
+            Field(description="Comma-separated IdP providers to query: okta, entra. Omit to query both."),
+        ] = "",
+        tenant_id: Annotated[
+            str,
+            Field(description="Tenant scope for the response envelope. Defaults to the control-plane default tenant."),
+        ] = "default",
+    ) -> str:
+        """Discover non-human identities (Okta service apps / Entra service principals).
+
+        Read-only and reference-only: returns normalized identity metadata (id,
+        name, owner, created, credential expiry, scope references) — never secret
+        material. Each provider is gated by its own discovery env flag and token;
+        a disabled or unconfigured provider is reported in ``providers`` with a
+        clear status rather than failing the request.
+        """
+        return await execute_tool_async(
+            "nhi_discover",
+            nhi_discover_impl,
+            providers=providers,
+            tenant_id=tenant_id,
+            _truncate_response=truncate_response,
+        )
+
+    @mcp.tool(annotations=read_only, title="Cloud Inventory")
+    async def cloud_inventory(
+        providers: Annotated[
+            str,
+            Field(description="Comma-separated cloud providers to summarize: aws, azure, gcp. Omit to query all enabled."),
+        ] = "",
+        region: Annotated[
+            str,
+            Field(description="Optional AWS region for AWS inventory (e.g. us-east-1)."),
+        ] = "",
+        tenant_id: Annotated[
+            str,
+            Field(description="Tenant scope for the response envelope. Defaults to the control-plane default tenant."),
+        ] = "default",
+    ) -> str:
+        """Summarize the estate-wide cloud asset inventory (resource + identity counts).
+
+        Each provider is opt-in via its own ``AGENT_BOM_*_INVENTORY`` env flag and
+        credentials; a disabled or unconfigured provider returns a clear status
+        and contributes zero nodes. Returns resource/identity counts and a node
+        summary only — reference-only, never resource secrets.
+        """
+        return await execute_tool_async(
+            "cloud_inventory",
+            cloud_inventory_impl,
+            providers=providers,
+            region=region,
+            tenant_id=tenant_id,
+            _truncate_response=truncate_response,
+        )
+
+    @mcp.tool(annotations=read_only, title="Access Review")
+    async def access_review(
+        campaign_id: Annotated[
+            str,
+            Field(description="Optional campaign id to fetch one campaign with its review items. Omit to list campaigns."),
+        ] = "",
+        tenant_id: Annotated[
+            str,
+            Field(description="Tenant scope to read. Defaults to the control-plane default tenant."),
+        ] = "default",
+        limit: Annotated[
+            int,
+            Field(ge=1, le=1000, description="Maximum campaigns to list when campaign_id is omitted."),
+        ] = 200,
+    ) -> str:
+        """List or get NHI access-review / recertification campaigns and their status.
+
+        Read-only: pass ``campaign_id`` to fetch one campaign with its review
+        items, or omit it to list campaigns (overdue statuses refreshed).
+        Creating a campaign or submitting a reviewer decision is a write action
+        and is intentionally not exposed through this read-only tool.
+        """
+        return await execute_tool_async(
+            "access_review",
+            access_review_impl,
+            campaign_id=campaign_id,
+            tenant_id=tenant_id,
+            limit=limit,
             _truncate_response=truncate_response,
         )

--- a/src/agent_bom/mcp_tools/posture.py
+++ b/src/agent_bom/mcp_tools/posture.py
@@ -1,0 +1,250 @@
+"""Posture-query MCP tools — cost, credential, identity, and cloud-inventory reads.
+
+These wrap the recently shipped FinOps / NHI / cloud-inventory / access-review
+capabilities so headless agents can query them over MCP, not just the REST API.
+Every tool here is READ-ONLY and reference-only: it returns metadata and
+posture verdicts, never secret values, and reuses the same implementation
+functions the API routes call (no duplicated capability logic).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from types import SimpleNamespace
+from typing import Any, cast
+
+from agent_bom.security import sanitize_error
+
+logger = logging.getLogger(__name__)
+
+
+def _request_for_tenant(tenant_id: str) -> SimpleNamespace:
+    return SimpleNamespace(state=SimpleNamespace(tenant_id=tenant_id or "default"))
+
+
+async def cost_forecast_impl(
+    *,
+    agent: str = "",
+    tenant_id: str = "default",
+    _truncate_response,
+) -> str:
+    """Implementation of the cost_forecast tool: burn-rate + budget-runway projection."""
+    try:
+        from agent_bom.api.cost_forecast import forecast_for_tenant
+
+        scoped_agent = agent.strip() or None
+        payload = forecast_for_tenant(tenant_id or "default", agent=scoped_agent)
+        return _truncate_response(json.dumps(payload, indent=2, default=str))
+    except Exception as exc:
+        logger.exception("MCP cost forecast error")
+        return json.dumps({"error": sanitize_error(exc)})
+
+
+async def cost_allocation_impl(
+    *,
+    cost_center: str = "",
+    tag: str = "",
+    agent: str = "",
+    tenant_id: str = "default",
+    _truncate_response,
+) -> str:
+    """Implementation of the cost_allocation tool: chargeback / showback rollup."""
+    try:
+        from agent_bom.api.routes.observability import get_llm_costs
+
+        payload = await get_llm_costs(
+            cast(Any, _request_for_tenant(tenant_id)),
+            agent=agent.strip() or None,
+            cost_center=cost_center.strip() or None,
+            tag=tag.strip() or None,
+        )
+        return _truncate_response(json.dumps(payload, indent=2, default=str))
+    except Exception as exc:
+        logger.exception("MCP cost allocation error")
+        return json.dumps({"error": sanitize_error(exc)})
+
+
+async def credential_expiry_impl(
+    *,
+    _truncate_response,
+) -> str:
+    """Implementation of the credential_expiry tool: expiring/overdue credential posture."""
+    try:
+        from agent_bom.api.credential_expiry import describe_credential_expiry_posture
+
+        payload = describe_credential_expiry_posture()
+        return _truncate_response(json.dumps(payload, indent=2, default=str))
+    except Exception as exc:
+        logger.exception("MCP credential expiry error")
+        return json.dumps({"error": sanitize_error(exc)})
+
+
+async def nhi_discover_impl(
+    *,
+    providers: str = "",
+    tenant_id: str = "default",
+    _truncate_response,
+) -> str:
+    """Implementation of the nhi_discover tool: read-only non-human identity discovery.
+
+    Each provider self-gates on its own discovery env flag/token; a disabled or
+    unconfigured provider is reported in ``providers`` rather than failing. Never
+    returns secret material.
+    """
+    try:
+        from agent_bom.graph.nhi_overlay import merge_discovery_results
+        from agent_bom.identity import (
+            discover_entra_non_human_identities,
+            discover_okta_non_human_identities,
+        )
+
+        selected = {part.strip().lower() for part in providers.split(",") if part.strip()} or {"okta", "entra"}
+        results = []
+        if "okta" in selected:
+            results.append(discover_okta_non_human_identities())
+        if "entra" in selected:
+            results.append(discover_entra_non_human_identities())
+
+        merged = merge_discovery_results(results)
+        payload = {
+            "schema_version": "identity.nhi.discovery.v1",
+            "tenant_id": tenant_id or "default",
+            "status": merged["status"],
+            "providers": merged["providers"],
+            "count": len(merged["identities"]),
+            "identities": merged["identities"],
+            "warnings": merged["warnings"],
+            "note": "Reference-only discovery; no secret values are returned and no identity is mutated.",
+        }
+        return _truncate_response(json.dumps(payload, indent=2, default=str))
+    except Exception as exc:
+        logger.exception("MCP NHI discover error")
+        return json.dumps({"error": sanitize_error(exc)})
+
+
+_INVENTORY_RESOURCE_KEYS = ("buckets", "instances", "security_groups")
+_INVENTORY_IDENTITY_KEYS = ("roles", "users")
+
+
+def _summarize_inventory_payload(provider: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Reduce a per-provider inventory payload to non-secret counts.
+
+    Reuses the builder's canonical-shape normalizer so Azure/GCP provider-native
+    keys map to the same resource/identity lists the graph counts.
+    """
+    from agent_bom.graph.builder import _normalize_cloud_inventory
+
+    normalized = _normalize_cloud_inventory(payload)
+    resource_count = sum(len(normalized.get(key) or []) for key in _INVENTORY_RESOURCE_KEYS)
+    identity_count = sum(len(normalized.get(key) or []) for key in _INVENTORY_IDENTITY_KEYS)
+    return {
+        "provider": provider,
+        "status": payload.get("status", "unknown"),
+        "account": payload.get("account_id") or payload.get("subscription_id") or payload.get("project_id") or None,
+        "region": payload.get("region") or "",
+        "resource_count": resource_count,
+        "identity_count": identity_count,
+        "node_summary": {
+            "buckets": len(normalized.get("buckets") or []),
+            "instances": len(normalized.get("instances") or []),
+            "security_groups": len(normalized.get("security_groups") or []),
+            "roles": len(normalized.get("roles") or []),
+            "users": len(normalized.get("users") or []),
+        },
+        "warnings": list(payload.get("warnings") or []),
+    }
+
+
+async def cloud_inventory_impl(
+    *,
+    providers: str = "",
+    region: str = "",
+    tenant_id: str = "default",
+    _truncate_response,
+) -> str:
+    """Implementation of the cloud_inventory tool: estate-wide cloud asset summary.
+
+    Each provider self-gates on its own ``AGENT_BOM_*_INVENTORY`` env flag and
+    credentials; a disabled provider returns a clear ``status`` (``disabled`` /
+    ``no_credentials`` / ``sdk_missing`` …) and contributes zero nodes. Returns
+    resource/identity counts and a node summary only — never resource secrets.
+    """
+    try:
+        from agent_bom.cloud import aws_inventory, azure_inventory, gcp_inventory
+
+        selected = {part.strip().lower() for part in providers.split(",") if part.strip()} or {"aws", "azure", "gcp"}
+        scoped_region = region.strip() or None
+        summaries: list[dict[str, Any]] = []
+        if "aws" in selected:
+            summaries.append(_summarize_inventory_payload("aws", aws_inventory.discover_inventory(region=scoped_region)))
+        if "azure" in selected:
+            summaries.append(_summarize_inventory_payload("azure", azure_inventory.discover_inventory()))
+        if "gcp" in selected:
+            summaries.append(_summarize_inventory_payload("gcp", gcp_inventory.discover_inventory()))
+
+        any_enabled = any(s["status"] != "disabled" for s in summaries)
+        payload = {
+            "schema_version": "cloud.inventory.summary.v1",
+            "tenant_id": tenant_id or "default",
+            "status": "ok" if any_enabled else "disabled",
+            "total_resources": sum(s["resource_count"] for s in summaries),
+            "total_identities": sum(s["identity_count"] for s in summaries),
+            "providers": summaries,
+            "note": (
+                "Estate-wide inventory is opt-in per provider via AGENT_BOM_CLOUD_INVENTORY / "
+                "AGENT_BOM_AZURE_INVENTORY / AGENT_BOM_GCP_INVENTORY. Reference-only counts; no resource secrets are returned."
+            ),
+        }
+        return _truncate_response(json.dumps(payload, indent=2, default=str))
+    except Exception as exc:
+        logger.exception("MCP cloud inventory error")
+        return json.dumps({"error": sanitize_error(exc)})
+
+
+async def access_review_impl(
+    *,
+    campaign_id: str = "",
+    tenant_id: str = "default",
+    limit: int = 200,
+    _truncate_response,
+) -> str:
+    """Implementation of the access_review tool: list / get recertification campaigns.
+
+    Read-only. Pass ``campaign_id`` to fetch one campaign with its review items;
+    omit it to list campaigns (overdue statuses refreshed). Creating a campaign
+    or submitting a decision is a WRITE and is intentionally not exposed here.
+    """
+    try:
+        from agent_bom.api.access_review import get_access_review_store, refresh_campaign_status
+
+        tid = tenant_id or "default"
+        store = get_access_review_store()
+        target = campaign_id.strip()
+        if target:
+            campaign = refresh_campaign_status(store, tenant_id=tid, campaign_id=target)
+            if campaign is None:
+                return json.dumps({"status": "not_found", "campaign_id": target, "tenant_id": tid})
+            items = store.list_items(target, tid)
+            payload = {
+                "schema_version": "identity.access_review.v1",
+                "tenant_id": tid,
+                "campaign": campaign.to_public_dict(),
+                "count": len(items),
+                "items": [i.to_public_dict() for i in items],
+            }
+            return _truncate_response(json.dumps(payload, indent=2, default=str))
+
+        bounded = max(1, min(int(limit), 1000))
+        campaigns = store.list_campaigns(tid, limit=bounded)
+        refreshed = [refresh_campaign_status(store, tenant_id=tid, campaign_id=c.campaign_id) or c for c in campaigns]
+        payload = {
+            "schema_version": "identity.access_review.v1",
+            "tenant_id": tid,
+            "count": len(refreshed),
+            "campaigns": [c.to_public_dict() for c in refreshed],
+        }
+        return _truncate_response(json.dumps(payload, indent=2, default=str))
+    except Exception as exc:
+        logger.exception("MCP access review error")
+        return json.dumps({"error": sanitize_error(exc)})

--- a/tests/test_mcp_hardening.py
+++ b/tests/test_mcp_hardening.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from agent_bom.mcp_hardening import build_mcp_hardening_catalog
+from agent_bom.mcp_hardening import build_mcp_hardening_catalog, strict_args_tool_count
 
 
 def test_mcp_hardening_catalog_maps_nsa_security_themes() -> None:
@@ -24,7 +24,7 @@ def test_mcp_hardening_catalog_maps_nsa_security_themes() -> None:
     }.issubset(control_ids)
 
     validation = next(control for control in catalog["controls"] if control["id"] == "strict_parameter_validation")
-    assert "55 strict-args MCP tools" in validation["agent_bom_surfaces"]
+    assert f"{strict_args_tool_count()} strict-args MCP tools" in validation["agent_bom_surfaces"]
     assert "additionalProperties=false" in " ".join(validation["agent_bom_surfaces"])
 
     audit = next(control for control in catalog["controls"] if control["id"] == "audit_logging_and_detection")

--- a/tests/test_mcp_posture_tools.py
+++ b/tests/test_mcp_posture_tools.py
@@ -1,0 +1,210 @@
+"""Tests for the posture-query MCP tools (mcp_tools/posture.py).
+
+Covers the six capability tools that expose recently shipped FinOps / NHI /
+cloud-inventory / access-review features to headless agents:
+cost_forecast, cost_allocation, credential_expiry, nhi_discover,
+cloud_inventory, access_review.
+
+Each tool must: return a JSON string that round-trips to a dict, leak no stack
+trace, and — when its capability is gated off / unconfigured — return a clean
+status rather than an error or secret material.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from agent_bom.mcp_tools.posture import (
+    access_review_impl,
+    cloud_inventory_impl,
+    cost_allocation_impl,
+    cost_forecast_impl,
+    credential_expiry_impl,
+    nhi_discover_impl,
+)
+
+
+def _trunc(s: str) -> str:
+    return s
+
+
+def _run(coro) -> dict:
+    raw = asyncio.run(coro)
+    assert isinstance(raw, str), f"impl returned non-string: {type(raw)}"
+    assert "Traceback (most recent call last)" not in raw, "stack trace leaked into payload"
+    data = json.loads(raw)  # well-formed + JSON-serializable
+    json.dumps(data)
+    assert isinstance(data, dict)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# cost_forecast
+# ---------------------------------------------------------------------------
+
+
+def test_cost_forecast_returns_forecast_envelope():
+    data = _run(cost_forecast_impl(tenant_id="t-cf", _truncate_response=_trunc))
+    assert data.get("schema_version") == "observability.cost_forecast.v1"
+    assert data.get("tenant_id") == "t-cf"
+    # Empty history => a clear status, never an error.
+    assert "error" not in data
+
+
+def test_cost_forecast_agent_scoped():
+    data = _run(cost_forecast_impl(agent="builder", tenant_id="t-cf2", _truncate_response=_trunc))
+    assert "error" not in data
+    assert data.get("tenant_id") == "t-cf2"
+
+
+# ---------------------------------------------------------------------------
+# cost_allocation
+# ---------------------------------------------------------------------------
+
+
+def test_cost_allocation_returns_rollups():
+    data = _run(cost_allocation_impl(tenant_id="t-ca", _truncate_response=_trunc))
+    assert "error" not in data
+    # summarize() always emits the chargeback rollup keys.
+    assert "by_cost_center" in data
+    assert "budget" in data
+    assert "forecast" in data
+
+
+def test_cost_allocation_cost_center_scoped():
+    data = _run(cost_allocation_impl(cost_center="platform", tag="team", tenant_id="t-ca2", _truncate_response=_trunc))
+    assert "error" not in data
+    assert data.get("tenant_id") == "t-ca2"
+
+
+# ---------------------------------------------------------------------------
+# credential_expiry
+# ---------------------------------------------------------------------------
+
+
+def test_credential_expiry_posture_no_secrets():
+    data = _run(credential_expiry_impl(_truncate_response=_trunc))
+    assert "error" not in data
+    assert data.get("secret_values_included") is False
+    assert "counts" in data
+
+
+# ---------------------------------------------------------------------------
+# nhi_discover  (gated off by default — providers unconfigured)
+# ---------------------------------------------------------------------------
+
+
+def test_nhi_discover_gated_off_clean_status(monkeypatch):
+    # Ensure discovery flags are off so providers self-report disabled.
+    for var in (
+        "AGENT_BOM_OKTA_DISCOVERY",
+        "AGENT_BOM_ENTRA_DISCOVERY",
+        "OKTA_DISCOVERY",
+        "ENTRA_DISCOVERY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    data = _run(nhi_discover_impl(tenant_id="t-nhi", _truncate_response=_trunc))
+    assert "error" not in data
+    assert data.get("schema_version") == "identity.nhi.discovery.v1"
+    # No provider enabled => empty, no identities, both providers reported.
+    assert data.get("status") in {"empty", "ok"}
+    assert data.get("count") == 0
+    assert data.get("identities") == []
+    assert {p.get("status") for p in data.get("providers", [])} == {"disabled"}
+
+
+def test_nhi_discover_provider_filter():
+    data = _run(nhi_discover_impl(providers="okta", tenant_id="t-nhi2", _truncate_response=_trunc))
+    assert "error" not in data
+    assert len(data.get("providers", [])) == 1
+
+
+# ---------------------------------------------------------------------------
+# cloud_inventory  (gated off by default — inventory flags unset)
+# ---------------------------------------------------------------------------
+
+
+def test_cloud_inventory_gated_off_clean_status(monkeypatch):
+    for var in ("AGENT_BOM_CLOUD_INVENTORY", "AGENT_BOM_AZURE_INVENTORY", "AGENT_BOM_GCP_INVENTORY"):
+        monkeypatch.delenv(var, raising=False)
+    data = _run(cloud_inventory_impl(tenant_id="t-ci", _truncate_response=_trunc))
+    assert "error" not in data
+    assert data.get("schema_version") == "cloud.inventory.summary.v1"
+    assert data.get("status") == "disabled"
+    assert data.get("total_resources") == 0
+    assert data.get("total_identities") == 0
+    assert {p["status"] for p in data["providers"]} == {"disabled"}
+
+
+def test_cloud_inventory_provider_filter(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_CLOUD_INVENTORY", raising=False)
+    data = _run(cloud_inventory_impl(providers="aws", region="us-east-1", tenant_id="t-ci2", _truncate_response=_trunc))
+    assert "error" not in data
+    assert [p["provider"] for p in data["providers"]] == ["aws"]
+
+
+# ---------------------------------------------------------------------------
+# access_review
+# ---------------------------------------------------------------------------
+
+
+def test_access_review_list_empty_tenant():
+    data = _run(access_review_impl(tenant_id="t-ar-empty", _truncate_response=_trunc))
+    assert "error" not in data
+    assert data.get("schema_version") == "identity.access_review.v1"
+    assert data.get("count") == 0
+    assert data.get("campaigns") == []
+
+
+def test_access_review_missing_campaign_returns_not_found():
+    data = _run(access_review_impl(campaign_id="does-not-exist", tenant_id="t-ar", _truncate_response=_trunc))
+    assert data.get("status") == "not_found"
+    assert data.get("campaign_id") == "does-not-exist"
+
+
+def test_access_review_get_existing_campaign():
+    from agent_bom.api.access_review import create_campaign, get_access_review_store, set_access_review_store
+
+    set_access_review_store(None)  # reset to a fresh in-memory store
+    store = get_access_review_store()
+    tenant_id = "t-ar-real"
+    campaign, _items = create_campaign(
+        store,
+        tenant_id=tenant_id,
+        name="Q3 NHI recertification",
+        subjects=[{"subject_id": "svc-1", "subject_name": "build-bot", "subject_type": "service_account"}],
+        created_by="tester",
+        due_days=14,
+    )
+    try:
+        data = _run(access_review_impl(campaign_id=campaign.campaign_id, tenant_id=tenant_id, _truncate_response=_trunc))
+        assert "error" not in data
+        assert data["campaign"]["campaign_id"] == campaign.campaign_id
+        assert data["count"] == 1
+        assert data["items"][0]["subject_id"] == "svc-1"
+    finally:
+        set_access_review_store(None)
+
+
+# ---------------------------------------------------------------------------
+# Registration / annotation contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    ["cost_forecast", "cost_allocation", "credential_expiry", "nhi_discover", "cloud_inventory", "access_review"],
+)
+def test_new_tools_registered_read_only_strict(tool_name):
+    from agent_bom.mcp_server import create_mcp_server
+
+    server = create_mcp_server()
+    tool = server._tool_manager._tools.get(tool_name)
+    assert tool is not None, f"{tool_name} not registered"
+    params = tool.parameters or {}
+    assert params.get("additionalProperties") is False, f"{tool_name} missing additionalProperties:false"
+    # All six are read-only posture queries.
+    assert tool.annotations is not None and tool.annotations.readOnlyHint is True

--- a/tests/test_stats_alignment.py
+++ b/tests/test_stats_alignment.py
@@ -343,10 +343,92 @@ class TestDashboardStats:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Live tool-count + registry-header freshness lock (CI gate)
+#
+# The advertised MCP tool count drifted repeatedly across the CLI help,
+# Dockerfile, docstring, server card, and docker tools.json because nothing
+# tied them to the LIVE registered tool count. The registry ``_total_servers``
+# header likewise undercounted the bundled ``servers`` map. These tests derive
+# the truth from the running server / the registry file and assert every
+# advertised surface matches, so a future capability wave can never silently
+# leave a stale number behind.
+# ---------------------------------------------------------------------------
+
+
+def _live_mcp_tool_count() -> int:
+    """Number of tools the MCP server actually registers at runtime."""
+    from agent_bom.mcp_server import create_mcp_server
+
+    server = create_mcp_server()
+    return len(server._tool_manager._tools)
+
+
+LIVE_MCP_TOOLS = _live_mcp_tool_count()
+
+
+class TestToolCountFreshness:
+    """Tie every advertised MCP tool count to the LIVE registered count."""
+
+    def test_live_count_matches_decorator_count(self):
+        # The @mcp.tool decorator scan and the live registration must agree.
+        assert LIVE_MCP_TOOLS == ACTUAL_MCP_TOOLS, f"live tool count ({LIVE_MCP_TOOLS}) != @mcp.tool decorator count ({ACTUAL_MCP_TOOLS})"
+
+    def test_live_count_matches_server_card(self):
+        assert LIVE_MCP_TOOLS == ACTUAL_CARD_TOOLS, f"live tool count ({LIVE_MCP_TOOLS}) != _SERVER_CARD_TOOLS count ({ACTUAL_CARD_TOOLS})"
+
+    def test_mcp_server_docstring_count_matches_live(self):
+        text = (SRC / "mcp_server.py").read_text()
+        match = re.search(r"^Tools \((\d+)\):", text, re.MULTILINE)
+        assert match, "mcp_server.py module docstring missing 'Tools (N):'"
+        assert int(match.group(1)) == LIVE_MCP_TOOLS, f"mcp_server.py docstring advertises {match.group(1)} tools, live is {LIVE_MCP_TOOLS}"
+
+    def test_cli_help_count_matches_live(self):
+        text = (SRC / "cli" / "_server.py").read_text()
+        match = re.search(r"Exposes (\d+) security tools via MCP protocol", text)
+        assert match, "cli/_server.py missing 'Exposes N security tools via MCP protocol'"
+        assert int(match.group(1)) == LIVE_MCP_TOOLS, f"cli/_server.py advertises {match.group(1)} tools, live is {LIVE_MCP_TOOLS}"
+
+    def test_dockerfile_sse_count_matches_live(self):
+        path = ROOT / "deploy" / "docker" / "Dockerfile.sse"
+        if not path.exists():
+            pytest.skip("Dockerfile.sse not found")
+        text = path.read_text()
+        match = re.search(r"(\d+) MCP tools", text)
+        assert match, "Dockerfile.sse missing 'N MCP tools'"
+        assert int(match.group(1)) == LIVE_MCP_TOOLS, f"Dockerfile.sse advertises {match.group(1)} MCP tools, live is {LIVE_MCP_TOOLS}"
+
+    def test_docker_mcp_tools_json_count_matches_live(self):
+        path = ROOT / "integrations" / "docker-mcp-registry" / "tools.json"
+        if not path.exists():
+            pytest.skip("Docker MCP tools.json not found")
+        data = json.loads(path.read_text())
+        assert len(data) == LIVE_MCP_TOOLS, f"docker tools.json lists {len(data)} tools, live is {LIVE_MCP_TOOLS}"
+
+    def test_hardening_strict_args_surface_matches_live(self):
+        from agent_bom.mcp_hardening import strict_args_tool_count
+
+        assert strict_args_tool_count() == LIVE_MCP_TOOLS, (
+            f"mcp_hardening strict-args surface counts {strict_args_tool_count()}, live is {LIVE_MCP_TOOLS}"
+        )
+
+
+class TestRegistryHeaderFreshness:
+    """Tie the registry ``_total_servers`` header to the bundled servers map."""
+
+    def test_total_servers_header_matches_bundled_map(self):
+        data = json.loads((SRC / "mcp_registry.json").read_text())
+        servers = data.get("servers", {})
+        actual = len(servers)
+        header = data.get("_total_servers")
+        assert header == actual, f"mcp_registry.json _total_servers={header} but bundled servers map has {actual} entries"
+
+
 def test_print_actual_counts(capsys):
     """Print actual counts for reference (always passes)."""
     print("\n--- Actual Code Counts ---")
     print(f"MCP tools (@mcp.tool):    {ACTUAL_MCP_TOOLS}")
+    print(f"MCP tools (live):         {LIVE_MCP_TOOLS}")
     print(f"_SERVER_CARD_TOOLS:       {ACTUAL_CARD_TOOLS}")
     print(f"CONFIG_LOCATIONS:         {ACTUAL_CONFIG_LOCATIONS}")
     print(f"Runtime detectors:        {ACTUAL_DETECTORS}")


### PR DESCRIPTION
## Summary
Makes the recent feature wave **agent-reachable** (it was API-only) and **locks surface-count freshness** with a CI gate so docs/registry/tool counts can never silently drift again.

**6 new MCP tools** (all read-only, reference-only, tenant-scoped, strict-args, reusing existing impls — no logic duplication; impls in `mcp_tools/posture.py`):
| Tool | Value to an agent |
|---|---|
| `cost_forecast` | LLM burn-rate + budget-runway projection |
| `cost_allocation` | chargeback/showback by cost-center & allocation tag |
| `credential_expiry` | expiring/overdue credential posture (no secret values) |
| `nhi_discover` | Okta/Entra NHI discovery (self-gates, clean disabled status, no secrets) |
| `cloud_inventory` | estate-wide AWS/Azure/GCP asset summary (opt-in flags) |
| `access_review` | list/get NHI recertification campaigns + status |

**Live tool count: 63 → 69.**

**Freshness fixes + CI lock:**
- `mcp_registry.json` `_total_servers` **738 → 840** (matches bundled servers; auto-derived).
- `Dockerfile.sse` 36→69, `mcp_server.py` docstring/CLI help/server-card/docker tools.json/docs all → 69; `check_release_consistency.py` expected count → 69.
- `mcp_hardening.py` strict-args surface now **derives** the count from the live server card (no hardcoded literal).
- New `test_stats_alignment.py` ties the **live** `create_mcp_server()` tool count + registry header to docstring/CLI/Dockerfile/server-card/docker-tools/hardening — drift becomes a test failure.

## Verification
55+ tests (posture tools 18, freshness 8, strict-args, output-contract, hardening) — full suite 163 passed. ruff/format/mypy clean; release-consistency + product-surface + OpenAPI checks exit 0. No new env flags.