### PR TITLE
feat(model): detect malicious model pickles via safe opcode disassembly

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -141,6 +141,13 @@ AGENT_BOM_MCP_SANDBOX_CPUS
 AGENT_BOM_MCP_SANDBOX_EGRESS
 AGENT_BOM_MCP_SANDBOX_IMAGE
 AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY
+# Deploy-only server/production posture toggle for the MCP proxy sandbox; read
+# at proxy start to auto-escalate the 'warn' image-pin default to 'enforce' for
+# mutable (non-digest) images.
+AGENT_BOM_MCP_SANDBOX_SERVER_MODE
+# Generic deploy-time server/production posture fallback honored by the MCP
+# sandbox image-pin hardening when the sandbox-specific toggle is unset.
+AGENT_BOM_SERVER_MODE
 AGENT_BOM_MCP_SANDBOX_MEMORY
 AGENT_BOM_MCP_SANDBOX_MOUNTS
 AGENT_BOM_MCP_SANDBOX_PIDS_LIMIT
@@ -149,6 +156,10 @@ AGENT_BOM_MCP_SANDBOX_RUNTIME
 AGENT_BOM_MCP_SANDBOX_TIMEOUT_SECONDS
 AGENT_BOM_MCP_SANDBOX_TMPFS_SIZE
 AGENT_BOM_MCP_SANDBOX_USER
+# Safe-disassembly pickle scanner DoS bounds (max opcodes walked / max bytes
+# read per pickle stream); read on demand in model_pickle_scan.py.
+AGENT_BOM_PICKLE_MAX_OPCODES
+AGENT_BOM_PICKLE_MAX_BYTES
 AGENT_BOM_METRICS_TOKEN
 AGENT_BOM_ATLAS_CATALOG_MODE
 AGENT_BOM_ATLAS_CATALOG_PATH

--- a/src/agent_bom/model_files.py
+++ b/src/agent_bom/model_files.py
@@ -14,6 +14,7 @@ import tempfile
 from pathlib import Path
 
 from agent_bom.floating_refs import classify_model_revision, is_hex_digest
+from agent_bom.model_pickle_scan import PICKLE_BEARING_EXTENSIONS, scan_pickle_file_flags
 
 logger = logging.getLogger(__name__)
 
@@ -172,6 +173,21 @@ def scan_model_files(
                 flag = _SECURITY_FLAGS[ext].copy()
                 security_flags.append(flag)
                 warnings.append(f"Model file {file_path.name}: {flag['severity']} — {flag['type']}. {flag['description']}")
+
+            # Disassembly-based malicious-pickle detection. This walks the
+            # pickle opcode stream via pickletools.genops WITHOUT ever
+            # deserializing the model (no pickle.load / torch.load / joblib.load),
+            # so the no-execution guarantee is preserved while upgrading the
+            # signal from extension-only to content-aware.
+            if ext in PICKLE_BEARING_EXTENSIONS:
+                try:
+                    pickle_flags, _ = scan_pickle_file_flags(file_path)
+                except Exception as exc:  # noqa: BLE001 — scanner must never break a scan
+                    logger.debug("Pickle opcode scan skipped for %s: %s", file_path, exc)
+                    pickle_flags = []
+                for pflag in pickle_flags:
+                    security_flags.append(pflag)
+                    warnings.append(f"Model file {file_path.name}: {pflag['severity']} — {pflag['type']}. {pflag['description']}")
 
             results.append(
                 {

--- a/src/agent_bom/model_pickle_scan.py
+++ b/src/agent_bom/model_pickle_scan.py
@@ -1,0 +1,469 @@
+"""Safe pickle opcode disassembly for malicious-model detection.
+
+Pickle deserialization is arbitrary-code-execution: a model shipped as a
+pickle can run code on ``pickle.load`` / ``torch.load`` / ``joblib.load`` via
+the ``__reduce__`` protocol. This module detects malicious models **without
+ever deserializing them**.
+
+It uses :func:`pickletools.genops`, which *walks* the opcode stream and yields
+``(opcode, argument, position)`` tuples **without executing** any of them.
+There is no ``pickle.load``, ``pickle.loads``, ``Unpickler``, ``torch.load``,
+``joblib.load``, or ``find_class`` call anywhere in this module — the
+no-execution guarantee of agent-bom is preserved.
+
+Detection model
+---------------
+Dangerous code execution in a pickle is reachable through a small set of
+opcodes:
+
+* ``GLOBAL`` / ``STACK_GLOBAL`` — resolve an arbitrary ``module.callable``
+  (e.g. ``posix system``). This is how attackers smuggle in ``os.system``.
+* ``REDUCE`` — call the top-of-stack callable with the args tuple. This is the
+  trigger that turns a smuggled ``os.system`` reference into execution.
+* ``BUILD`` / ``INST`` / ``OBJ`` / ``NEWOBJ`` / ``NEWOBJ_EX`` — object
+  construction primitives that can invoke ``__setstate__`` / ``__init__`` on
+  attacker-chosen classes.
+
+A pickle that imports a dangerous module/callable (``os``, ``subprocess``,
+``builtins.eval``/``exec`` …) is flagged. When that import is combined with a
+``REDUCE`` (the actual call), it is classified malicious at CRITICAL severity.
+A pickle that only contains tensor/primitive opcodes is clean.
+
+Bounds
+------
+Both the number of opcodes walked and the bytes read are bounded so a crafted
+file cannot DoS the scanner. Truncated or garbage input never raises; it is
+reported as a safe ``ERROR``/``TRUNCATED`` outcome.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import pickletools
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ── Tunable safety bounds (override via env, all read once on demand) ──
+# A normal model pickle resolves a handful of globals and is small relative to
+# the weight payload; these ceilings are generous for benign files but cap the
+# work an adversarial file can force.
+_MAX_OPCODES = 1_000_000
+_MAX_PICKLE_BYTES = 256 * 1024 * 1024  # 256 MiB per embedded pickle stream
+_MAX_ZIP_MEMBERS = 4096
+_MAX_EMBEDDED_PICKLES = 64
+
+# Extensions whose contents may be (or may embed) a pickle stream.
+PICKLE_BEARING_EXTENSIONS = frozenset({".pkl", ".pickle", ".pt", ".pth", ".bin", ".joblib", ".npy", ".ckpt", ".model"})
+
+# Opcodes that *enable* code execution. Presence alone is suspicious; presence
+# of a dangerous global import is what makes a pickle malicious.
+_CODE_EXEC_OPCODES = frozenset(
+    {
+        "GLOBAL",
+        "STACK_GLOBAL",
+        "REDUCE",
+        "BUILD",
+        "INST",
+        "OBJ",
+        "NEWOBJ",
+        "NEWOBJ_EX",
+    }
+)
+
+# The opcode that actually *invokes* a callable — the trigger that turns a
+# smuggled reference into execution.
+_CALL_OPCODES = frozenset({"REDUCE", "INST", "OBJ", "NEWOBJ", "NEWOBJ_EX"})
+
+# Modules whose import inside a pickle is a strong malicious signal: they grant
+# process / shell / network / dynamic-import capability.
+_DANGEROUS_MODULES = frozenset(
+    {
+        "os",
+        "posix",
+        "nt",
+        "subprocess",
+        "sys",
+        "socket",
+        "shutil",
+        "pty",
+        "runpy",
+        "importlib",
+        "ctypes",
+        "multiprocessing",
+        "threading",
+        "asyncio",
+        "commands",
+        "popen2",
+        "platform",
+        "webbrowser",
+        "pip",
+        "pdb",
+        "bdb",
+        "code",
+        "codeop",
+        "timeit",
+        "venv",
+        "smtplib",
+        "ftplib",
+        "telnetlib",
+        "urllib",
+        "urllib2",
+        "requests",
+        "httplib",
+    }
+)
+
+# Specific ``module.callable`` pairs that are dangerous regardless of module
+# (e.g. ``builtins.eval``). Stored as ``"module.callable"`` lowercase keys.
+_DANGEROUS_CALLABLES = frozenset(
+    {
+        "builtins.eval",
+        "builtins.exec",
+        "builtins.compile",
+        "builtins.__import__",
+        "builtins.getattr",
+        "builtins.setattr",
+        "builtins.open",
+        "builtins.input",
+        "builtins.breakpoint",
+        "__builtin__.eval",
+        "__builtin__.exec",
+        "__builtin__.compile",
+        "__builtin__.__import__",
+        "__builtin__.getattr",
+        "__builtin__.open",
+        "operator.attrgetter",
+        "operator.methodcaller",
+        "functools.reduce",
+    }
+)
+
+# Callable names that are dangerous even with an unexpected module qualifier
+# (covers ``os.system``, ``subprocess.Popen``, vendored shims, etc.).
+_DANGEROUS_CALLABLE_NAMES = frozenset(
+    {
+        "system",
+        "popen",
+        "spawn",
+        "spawnl",
+        "spawnv",
+        "exec",
+        "execv",
+        "execve",
+        "execl",
+        "eval",
+        "compile",
+        "call",
+        "check_call",
+        "check_output",
+        "run",
+        "popen2",
+        "popen3",
+        "popen4",
+        "fork",
+        "forkpty",
+        "remove",
+        "unlink",
+        "rmtree",
+        "connect",
+        "getoutput",
+        "getstatusoutput",
+        "load_module",
+        "import_module",
+        "loads",
+        "load",
+        "fromstring",
+    }
+)
+
+
+@dataclass
+class PickleScanResult:
+    """Outcome of disassembling one logical pickle target (file or member)."""
+
+    path: str
+    member: str | None = None  # zip member name when scanned from an archive
+    is_pickle: bool = False
+    truncated: bool = False
+    error: str | None = None
+    opcodes_scanned: int = 0
+    code_exec_opcodes: list[str] = field(default_factory=list)
+    has_reduce: bool = False
+    dangerous_imports: list[str] = field(default_factory=list)  # "module.callable"
+    severity: str | None = None  # CRITICAL | HIGH | MEDIUM | None
+    verdict: str = "clean"  # clean | suspicious | malicious | error | not_pickle
+
+    def to_security_flag(self) -> dict | None:
+        """Render a ``security_flags``-shaped dict, or ``None`` when clean."""
+        if self.verdict in {"clean", "not_pickle"}:
+            return None
+        if self.verdict == "error":
+            return {
+                "severity": "LOW",
+                "type": "PICKLE_SCAN_ERROR",
+                "description": (f"Pickle opcode scan could not complete (no deserialization attempted): {self.error}"),
+            }
+        location = f" (zip member {self.member})" if self.member else ""
+        imports = ", ".join(sorted(set(self.dangerous_imports))[:12]) or "none captured"
+        opcodes = ", ".join(sorted(set(self.code_exec_opcodes)))
+        return {
+            "severity": self.severity or "HIGH",
+            "type": "MALICIOUS_PICKLE" if self.verdict == "malicious" else "SUSPICIOUS_PICKLE",
+            "description": (
+                f"Pickle opcode disassembly{location} found code-execution opcodes "
+                f"[{opcodes}] referencing dangerous imports [{imports}]. "
+                "Detected by static opcode walk (pickletools.genops); the model was NOT deserialized. "
+                "Treat as a potential supply-chain implant — prefer safetensors/ONNX."
+            ),
+            "dangerous_imports": sorted(set(self.dangerous_imports)),
+            "code_exec_opcodes": sorted(set(self.code_exec_opcodes)),
+        }
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _max_opcodes() -> int:
+    return _int_env("AGENT_BOM_PICKLE_MAX_OPCODES", _MAX_OPCODES)
+
+
+def _max_pickle_bytes() -> int:
+    return _int_env("AGENT_BOM_PICKLE_MAX_BYTES", _MAX_PICKLE_BYTES)
+
+
+def _normalize_global(arg: object) -> tuple[str, str] | None:
+    """Extract ``(module, callable)`` from a GLOBAL/STACK_GLOBAL argument.
+
+    ``GLOBAL`` yields a string ``"module callable"`` (space-separated).
+    ``STACK_GLOBAL`` takes its operands from the stack, so ``arg`` is ``None``;
+    those are recovered separately from the preceding string opcodes.
+    """
+    if not isinstance(arg, str):
+        return None
+    parts = arg.split(" ", 1) if " " in arg else arg.rsplit("\n", 1)
+    if len(parts) != 2:
+        return None
+    module, name = parts[0].strip(), parts[1].strip()
+    if not module and not name:
+        return None
+    return module, name
+
+
+def _classify_global(module: str, name: str) -> str | None:
+    """Return a danger label for a ``module.callable`` import, or None.
+
+    The label is the captured ``module.callable`` string when dangerous.
+    """
+    mod = module.lower()
+    nm = name.lower()
+    qualified = f"{mod}.{nm}"
+    if qualified in _DANGEROUS_CALLABLES:
+        return f"{module}.{name}"
+    if mod in _DANGEROUS_MODULES:
+        return f"{module}.{name}"
+    if nm in _DANGEROUS_CALLABLE_NAMES:
+        return f"{module}.{name}"
+    return None
+
+
+def _scan_opcode_stream(data: bytes, path: str, member: str | None) -> PickleScanResult:
+    """Disassemble a single pickle byte stream via ``pickletools.genops``.
+
+    NEVER deserializes. Walks opcodes only, capturing dangerous globals and the
+    presence of code-execution opcodes. Bounded by opcode count and never
+    raises on malformed input.
+    """
+    result = PickleScanResult(path=path, member=member)
+    if not data:
+        result.verdict = "not_pickle"
+        return result
+
+    # A valid pickle starts with PROTO (\x80) for protocol >= 2, or a protocol-0
+    # opcode. We do not require this — genops tolerates protocol 0/1 — but a
+    # stream with no recognizable first opcode falls through to the except.
+    max_ops = _max_opcodes()
+    pending_strings: list[str] = []  # for STACK_GLOBAL operand recovery
+    code_exec: set[str] = set()
+    dangerous: list[str] = []
+    saw_call = False
+
+    try:
+        # genops is a generator that statically parses opcodes; it does not
+        # build or execute the pickled object graph.
+        for opcode, arg, _pos in pickletools.genops(io.BytesIO(data)):
+            result.is_pickle = True
+            result.opcodes_scanned += 1
+            if result.opcodes_scanned > max_ops:
+                result.truncated = True
+                break
+
+            name = opcode.name
+
+            # Track short string/unicode operands so we can reconstruct the
+            # module + callable that STACK_GLOBAL pops off the stack.
+            if name in {"SHORT_BINUNICODE", "BINUNICODE", "UNICODE", "SHORT_BINSTRING", "BINSTRING", "STRING"}:
+                if isinstance(arg, str):
+                    pending_strings.append(arg)
+                    if len(pending_strings) > 4:
+                        pending_strings = pending_strings[-4:]
+                continue
+
+            if name in _CODE_EXEC_OPCODES:
+                code_exec.add(name)
+            if name in _CALL_OPCODES:
+                saw_call = True
+
+            if name == "GLOBAL":
+                parsed = _normalize_global(arg)
+                if parsed:
+                    label = _classify_global(*parsed)
+                    if label:
+                        dangerous.append(label)
+            elif name == "STACK_GLOBAL":
+                # operands are the two most recent strings on the stack:
+                # module then name (name pushed last).
+                if len(pending_strings) >= 2:
+                    module, callable_name = pending_strings[-2], pending_strings[-1]
+                    label = _classify_global(module, callable_name)
+                    if label:
+                        dangerous.append(label)
+                pending_strings = []
+    except Exception as exc:  # noqa: BLE001 — any malformed-pickle error is SAFE here
+        # genops raises on truncated/garbage streams. We never propagate; a
+        # broken pickle is reported, not crashed on.
+        if result.is_pickle:
+            result.truncated = True
+            result.error = f"opcode stream ended early: {exc}"
+        else:
+            result.verdict = "not_pickle"
+            result.error = str(exc)
+            return result
+
+    result.has_reduce = "REDUCE" in code_exec
+    result.code_exec_opcodes = sorted(code_exec)
+    result.dangerous_imports = dangerous
+
+    if not result.is_pickle:
+        result.verdict = "not_pickle"
+        return result
+
+    if dangerous and (saw_call or result.has_reduce):
+        result.verdict = "malicious"
+        result.severity = "CRITICAL"
+    elif dangerous:
+        # Dangerous import present but no call opcode observed (e.g. truncated
+        # before REDUCE) — still suspicious supply-chain signal.
+        result.verdict = "suspicious"
+        result.severity = "HIGH"
+    else:
+        result.verdict = "clean"
+    return result
+
+
+def _looks_like_zip(data: bytes) -> bool:
+    return data[:4] == b"PK\x03\x04" or data[:4] == b"PK\x05\x06"
+
+
+def _scan_zip(data: bytes, path: str) -> list[PickleScanResult]:
+    """Find and scan embedded pickle members inside a torch/zip archive.
+
+    Torch ``.pt`` files are ZIP archives containing ``data.pkl`` (and shards).
+    We enumerate members and disassemble those that are pickle streams, without
+    extracting to disk and without deserializing.
+    """
+    results: list[PickleScanResult] = []
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            members = zf.namelist()[:_MAX_ZIP_MEMBERS]
+            scanned = 0
+            for member in members:
+                if scanned >= _MAX_EMBEDDED_PICKLES:
+                    break
+                lower = member.lower()
+                # Torch stores the pickle as data.pkl / *.pkl; also scan any
+                # member that begins with the pickle PROTO opcode.
+                try:
+                    info = zf.getinfo(member)
+                except KeyError:
+                    continue
+                if info.is_dir() or info.file_size > _max_pickle_bytes():
+                    continue
+                try:
+                    with zf.open(member) as fh:
+                        head = fh.read(2)
+                        is_pkl_ext = lower.endswith((".pkl", ".pickle"))
+                        starts_pickle = head[:1] == b"\x80"  # PROTO
+                        if not (is_pkl_ext or starts_pickle):
+                            continue
+                        body = head + fh.read(_max_pickle_bytes())
+                except (OSError, zipfile.BadZipFile, RuntimeError, NotImplementedError) as exc:
+                    results.append(PickleScanResult(path=path, member=member, error=f"could not read zip member: {exc}", verdict="error"))
+                    continue
+                results.append(_scan_opcode_stream(body, path=path, member=member))
+                scanned += 1
+    except (zipfile.BadZipFile, OSError, RuntimeError) as exc:
+        results.append(PickleScanResult(path=path, error=f"not a readable zip archive: {exc}", verdict="error"))
+    return results
+
+
+def scan_pickle_file(file_path: str | Path) -> list[PickleScanResult]:
+    """Disassemble a model file's pickle opcodes WITHOUT deserializing it.
+
+    Handles three shapes safely:
+
+    * a raw pickle stream (``.pkl`` / ``.pickle`` / ``.joblib`` / many ``.bin``),
+    * a torch ZIP container (``.pt`` / ``.pth`` / ``.ckpt``) embedding pickle(s),
+    * truncated / non-pickle / garbage input → a safe ``error``/``not_pickle``
+      result, never an exception.
+
+    Returns a list because a zip container may embed several pickle members.
+    The scanner reads at most ``AGENT_BOM_PICKLE_MAX_BYTES`` and walks at most
+    ``AGENT_BOM_PICKLE_MAX_OPCODES`` opcodes per stream.
+    """
+    p = Path(file_path)
+    path_str = str(p)
+    try:
+        with open(p, "rb") as fh:
+            data = fh.read(_max_pickle_bytes() + 1)
+    except OSError as exc:
+        return [PickleScanResult(path=path_str, error=f"could not open file: {exc}", verdict="error")]
+
+    if not data:
+        return [PickleScanResult(path=path_str, verdict="not_pickle")]
+
+    if len(data) > _max_pickle_bytes():
+        # Truncate the working buffer to the cap; opcode walk still bounded.
+        data = data[: _max_pickle_bytes()]
+
+    if _looks_like_zip(data):
+        return _scan_zip(data, path=path_str)
+
+    return [_scan_opcode_stream(data, path=path_str, member=None)]
+
+
+def scan_pickle_file_flags(file_path: str | Path) -> tuple[list[dict], list[PickleScanResult]]:
+    """Convenience wrapper: scan a file and return ``security_flags`` dicts.
+
+    Returns ``(flags, raw_results)``. ``flags`` is the list of non-clean
+    security-flag dicts ready to extend a model file's ``security_flags``.
+    """
+    results = scan_pickle_file(file_path)
+    flags: list[dict] = []
+    for res in results:
+        flag = res.to_security_flag()
+        if flag is not None:
+            flags.append(flag)
+    return flags, results

--- a/src/agent_bom/proxy_sandbox.py
+++ b/src/agent_bom/proxy_sandbox.py
@@ -183,6 +183,7 @@ def sandbox_config_from_env(
     requested_image_pin_policy = (image_pin_policy or os.environ.get("AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY") or "warn").strip().lower()
     if requested_image_pin_policy not in {"off", "warn", "enforce"}:
         raise ValueError("sandbox image pin policy must be off, warn, or enforce")
+    requested_image_pin_policy = _harden_image_pin_policy(requested_image_pin_policy, requested_image)
     env_mounts = tuple(item.strip() for item in os.environ.get("AGENT_BOM_MCP_SANDBOX_MOUNTS", "").split(",") if item.strip())
     parsed_mounts = tuple(parse_sandbox_mount(item) for item in (*mounts, *env_mounts))
     requested_user = user or os.environ.get("AGENT_BOM_MCP_SANDBOX_USER")
@@ -389,6 +390,36 @@ def _image_reference_has_digest(image: str | None) -> bool:
     return len(digest) == 64 and all(ch in "0123456789abcdefABCDEF" for ch in digest)
 
 
+_SERVER_MODE_VALUES = {"1", "true", "yes", "on", "server", "production", "prod"}
+
+
+def _is_server_mode() -> bool:
+    """True when the proxy runs in server/production posture.
+
+    Resolved from ``AGENT_BOM_MCP_SANDBOX_SERVER_MODE`` (explicit), falling back
+    to the generic ``AGENT_BOM_SERVER_MODE`` deploy toggle. In this posture an
+    unpinned (mutable-tag) sandbox image is auto-escalated from ``warn`` to
+    ``enforce`` so a non-reproducible image cannot start a proxied server.
+    """
+    for name in ("AGENT_BOM_MCP_SANDBOX_SERVER_MODE", "AGENT_BOM_SERVER_MODE"):
+        raw = os.environ.get(name)
+        if raw is not None:
+            return raw.strip().lower() in _SERVER_MODE_VALUES
+    return False
+
+
+def _harden_image_pin_policy(policy: str, image: str | None) -> str:
+    """Escalate ``warn`` → ``enforce`` for mutable images in server mode.
+
+    Only the implicit default (``warn``) is hardened, and only when the image
+    is a mutable tag (no ``@sha256:`` digest). Explicit ``off`` / ``enforce``
+    are honored unchanged so operators retain control.
+    """
+    if policy == "warn" and _is_server_mode() and not _image_reference_has_digest(image):
+        return "enforce"
+    return policy
+
+
 def _image_pin_warning(image: str | None, policy: SandboxImagePinPolicy) -> str | None:
     if policy != "warn" or _image_reference_has_digest(image):
         return None
@@ -427,13 +458,19 @@ def describe_proxy_sandbox_posture() -> dict[str, object]:
     """
     raw = (os.environ.get("AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY") or "warn").strip().lower()
     default_policy: SandboxImagePinPolicy = raw if raw in {"off", "warn", "enforce"} else "warn"  # type: ignore[assignment]
+    server_mode = _is_server_mode()
+    effective_default: SandboxImagePinPolicy = "enforce" if (default_policy == "warn" and server_mode) else default_policy
     return {
         "image_pin_policy_default": default_policy,
+        "image_pin_policy_effective_default": effective_default,
         "image_pin_policy_env": "AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY",
+        "server_mode": server_mode,
+        "server_mode_env": "AGENT_BOM_MCP_SANDBOX_SERVER_MODE",
         "production_recommendation": "enforce",
         "notes": (
             "Default 'warn' surfaces a non-blocking warning when a sandbox image is not pinned to a digest. "
-            "Set the env to 'enforce' in production so unpinned image references are rejected at proxy start. "
-            "Per-server SandboxConfig.image_pin_policy overrides this process-wide default."
+            "In server mode (AGENT_BOM_MCP_SANDBOX_SERVER_MODE / AGENT_BOM_SERVER_MODE) the 'warn' default "
+            "auto-escalates to 'enforce' for mutable image references, so an unpinned image is rejected at "
+            "proxy start. Explicit 'off'/'enforce' and per-server SandboxConfig.image_pin_policy override this."
         ),
     }

--- a/tests/test_model_pickle_scan.py
+++ b/tests/test_model_pickle_scan.py
@@ -1,0 +1,245 @@
+"""Tests for safe pickle opcode disassembly (malicious-model detection).
+
+CRITICAL SAFETY INVARIANT: these tests construct malicious pickles with
+``pickle.dumps`` (safe — only serializes) and then scan them with
+``pickletools.genops`` (safe — walks opcodes without executing). They MUST
+NEVER call ``pickle.load`` / ``pickle.loads`` / ``Unpickler`` / ``torch.load``
+/ ``joblib.load`` on the crafted payloads, because that would execute the
+embedded ``__reduce__``. The scanner under test never deserializes either.
+"""
+
+from __future__ import annotations
+
+import io
+import pickle
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from agent_bom import model_pickle_scan
+from agent_bom.model_files import scan_model_files
+from agent_bom.model_pickle_scan import scan_pickle_file, scan_pickle_file_flags
+
+
+class _Pwned:
+    """An object whose pickle embeds ``os.system('echo pwned')``.
+
+    Constructing/serializing this is SAFE. Unpickling it WOULD run the command,
+    so no test unpickles it — we only disassemble the bytes.
+    """
+
+    def __reduce__(self):
+        import os
+
+        return (os.system, ("echo pwned",))
+
+
+class _EvalPwned:
+    def __reduce__(self):
+        return (eval, ("__import__('os').listdir('.')",))
+
+
+def _malicious_bytes() -> bytes:
+    # pickle.dumps SERIALIZES; it does not execute __reduce__'s callable.
+    return pickle.dumps(_Pwned())
+
+
+def test_malicious_pickle_flagged_critical_with_os_system(tmp_path: Path):
+    p = tmp_path / "model.pkl"
+    p.write_bytes(_malicious_bytes())
+
+    results = scan_pickle_file(p)
+    assert len(results) == 1
+    res = results[0]
+    assert res.is_pickle
+    assert res.verdict == "malicious"
+    assert res.severity == "CRITICAL"
+    assert res.has_reduce
+    assert "REDUCE" in res.code_exec_opcodes
+    # The os.system reference must be captured from the GLOBAL/STACK_GLOBAL operand.
+    captured = " ".join(res.dangerous_imports).lower()
+    assert "system" in captured
+    assert any(mod in captured for mod in ("os", "posix", "nt"))
+
+
+def test_malicious_pickle_security_flag_shape(tmp_path: Path):
+    p = tmp_path / "model.pkl"
+    p.write_bytes(_malicious_bytes())
+    flags, results = scan_pickle_file_flags(p)
+    assert len(flags) == 1
+    flag = flags[0]
+    assert flag["severity"] == "CRITICAL"
+    assert flag["type"] == "MALICIOUS_PICKLE"
+    assert "REDUCE" in flag["code_exec_opcodes"]
+    assert any("system" in imp.lower() for imp in flag["dangerous_imports"])
+    # No raw payload bytes leak into the evidence.
+    assert "echo pwned" not in flag["description"]
+
+
+def test_eval_pickle_flagged(tmp_path: Path):
+    p = tmp_path / "evil.pkl"
+    p.write_bytes(pickle.dumps(_EvalPwned()))
+    res = scan_pickle_file(p)[0]
+    assert res.verdict == "malicious"
+    assert res.severity == "CRITICAL"
+    assert any("eval" in imp.lower() for imp in res.dangerous_imports)
+
+
+def test_benign_list_pickle_is_clean(tmp_path: Path):
+    p = tmp_path / "benign.pkl"
+    p.write_bytes(pickle.dumps([1, 2, 3]))
+    res = scan_pickle_file(p)[0]
+    assert res.is_pickle
+    assert res.verdict == "clean"
+    assert res.severity is None
+    assert res.dangerous_imports == []
+    assert res.to_security_flag() is None
+
+
+def test_benign_dict_pickle_is_clean(tmp_path: Path):
+    p = tmp_path / "benign2.pkl"
+    p.write_bytes(pickle.dumps({"weights": [0.1, 0.2], "bias": 0.5, "name": "tiny"}))
+    res = scan_pickle_file(p)[0]
+    assert res.verdict == "clean"
+    flags, _ = scan_pickle_file_flags(p)
+    assert flags == []
+
+
+def test_torch_style_zip_with_embedded_malicious_pickle(tmp_path: Path):
+    """A torch .pt is a ZIP; an embedded malicious data.pkl must be flagged."""
+    p = tmp_path / "model.pt"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("archive/data.pkl", _malicious_bytes())
+        zf.writestr("archive/version", "3")
+        zf.writestr("archive/data/0", b"\x00" * 64)  # fake tensor blob
+    p.write_bytes(buf.getvalue())
+
+    results = scan_pickle_file(p)
+    malicious = [r for r in results if r.verdict == "malicious"]
+    assert malicious, "embedded malicious pickle in zip was not flagged"
+    assert malicious[0].member is not None
+    assert "data.pkl" in malicious[0].member
+    assert malicious[0].severity == "CRITICAL"
+
+
+def test_torch_style_zip_with_benign_pickle_is_clean(tmp_path: Path):
+    p = tmp_path / "clean.pt"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("archive/data.pkl", pickle.dumps({"layer": [1, 2, 3]}))
+        zf.writestr("archive/data/0", b"\x00" * 64)
+    p.write_bytes(buf.getvalue())
+
+    flags, results = scan_pickle_file_flags(p)
+    assert flags == []
+    assert all(r.verdict in {"clean", "not_pickle"} for r in results)
+
+
+def test_truncated_pickle_is_safe(tmp_path: Path):
+    """A truncated malicious pickle must not raise and must not crash."""
+    full = _malicious_bytes()
+    p = tmp_path / "truncated.pkl"
+    p.write_bytes(full[: len(full) // 2])  # cut mid-stream
+    results = scan_pickle_file(p)  # must not raise
+    assert len(results) == 1
+    # Truncated-but-still-dangerous import should be at least suspicious, and
+    # the scanner must never raise.
+    assert results[0].verdict in {"suspicious", "malicious", "clean", "error", "not_pickle"}
+
+
+def test_garbage_bytes_is_safe(tmp_path: Path):
+    p = tmp_path / "garbage.pkl"
+    p.write_bytes(b"\xde\xad\xbe\xef\x00\x01\x02not a pickle at all")
+    results = scan_pickle_file(p)  # must not raise
+    assert len(results) == 1
+    assert results[0].verdict in {"error", "not_pickle", "clean"}
+    # Whatever the outcome, no crash and no malicious classification.
+    assert results[0].severity in {None, "LOW"}
+
+
+def test_empty_file_is_safe(tmp_path: Path):
+    p = tmp_path / "empty.pkl"
+    p.write_bytes(b"")
+    results = scan_pickle_file(p)
+    assert results[0].verdict == "not_pickle"
+
+
+def test_missing_file_is_safe(tmp_path: Path):
+    res = scan_pickle_file(tmp_path / "does-not-exist.pkl")[0]
+    assert res.verdict == "error"
+    assert res.severity is None or res.severity == "LOW"
+
+
+def test_scanner_never_calls_pickle_load(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Hard proof the scanner does not deserialize: trip-wire pickle.load."""
+
+    def _boom(*_a, **_k):
+        raise AssertionError("scanner called pickle.load/loads — NO DESERIALIZATION ALLOWED")
+
+    monkeypatch.setattr(pickle, "load", _boom)
+    monkeypatch.setattr(pickle, "loads", _boom)
+    monkeypatch.setattr(pickle, "Unpickler", _boom)
+
+    p = tmp_path / "model.pkl"
+    p.write_bytes(_malicious_bytes())
+    # If any deserialization happened, the trip-wire would raise here.
+    res = scan_pickle_file(p)[0]
+    assert res.verdict == "malicious"
+
+
+def test_opcode_bound_enforced(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A low opcode cap stops the walk early without raising (DoS bound)."""
+    monkeypatch.setenv("AGENT_BOM_PICKLE_MAX_OPCODES", "3")
+    p = tmp_path / "big.pkl"
+    p.write_bytes(pickle.dumps(list(range(1000))))
+    res = scan_pickle_file(p)[0]
+    assert res.opcodes_scanned <= 4
+    assert res.truncated
+
+
+def test_wired_into_scan_model_files(tmp_path: Path):
+    """A normal model scan now reports the malicious-pickle finding end-to-end."""
+    (tmp_path / "model.pkl").write_bytes(_malicious_bytes())
+    results, warnings = scan_model_files(tmp_path)
+    assert len(results) == 1
+    flags = results[0]["security_flags"]
+    # Extension flag (PICKLE_DESERIALIZATION) + content flag (MALICIOUS_PICKLE).
+    types = {f["type"] for f in flags}
+    assert "MALICIOUS_PICKLE" in types
+    crit = [f for f in flags if f["type"] == "MALICIOUS_PICKLE"][0]
+    assert crit["severity"] == "CRITICAL"
+    assert any("MALICIOUS_PICKLE" in w for w in warnings)
+
+
+def test_wired_benign_pickle_only_extension_flag(tmp_path: Path):
+    """A benign pickle keeps the extension warning but gets no malicious flag."""
+    (tmp_path / "ok.pkl").write_bytes(pickle.dumps([1, 2, 3]))
+    results, _ = scan_model_files(tmp_path)
+    types = {f["type"] for f in results[0]["security_flags"]}
+    assert "MALICIOUS_PICKLE" not in types
+    assert "PICKLE_DESERIALIZATION" in types  # the existing extension signal
+
+
+def test_module_code_has_no_deserialization_calls():
+    """Source-level guard: no deserialization API appears in executable code.
+
+    Parses the module with ``ast`` and inspects only the code (docstrings,
+    which legitimately *describe* the no-execution guarantee in prose, are
+    stripped out first).
+    """
+    import ast
+
+    src = Path(model_pickle_scan.__file__).read_text()
+    tree = ast.parse(src)
+    # Drop the module docstring and every function/class docstring node so the
+    # prose that names pickle.load (to explain we DON'T call it) is excluded.
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            body = getattr(node, "body", [])
+            if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant) and isinstance(body[0].value.value, str):
+                body.pop(0)
+    code_only = ast.unparse(tree)
+    for forbidden in ("pickle.load", "pickle.loads", "Unpickler", "torch.load", "joblib.load", "find_class"):
+        assert forbidden not in code_only, f"scanner must not call {forbidden}"

--- a/tests/test_proxy_sandbox.py
+++ b/tests/test_proxy_sandbox.py
@@ -93,6 +93,67 @@ def test_sandbox_config_from_env_parses_operator_values(monkeypatch, tmp_path):
     assert config.mounts[0].target == "/workspace"
 
 
+def test_server_mode_escalates_mutable_image_to_enforce(monkeypatch):
+    """In server mode, the implicit 'warn' default hardens to 'enforce' for a mutable tag."""
+    monkeypatch.delenv("AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY", raising=False)
+    monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX_SERVER_MODE", "true")
+    monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX_IMAGE", "ghcr.io/acme/mcp-sandbox:1")
+
+    config = sandbox_config_from_env()
+    assert config.image_pin_policy == "enforce"
+
+
+def test_server_mode_keeps_warn_for_pinned_image(monkeypatch):
+    """A digest-pinned image needs no escalation even in server mode."""
+    monkeypatch.delenv("AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY", raising=False)
+    monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX_SERVER_MODE", "true")
+    monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX_IMAGE", PINNED_IMAGE)
+
+    config = sandbox_config_from_env()
+    assert config.image_pin_policy == "warn"
+
+
+def test_server_mode_respects_explicit_off(monkeypatch):
+    """An explicit 'off' is never silently escalated."""
+    monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY", "off")
+    monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX_SERVER_MODE", "true")
+    monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX_IMAGE", "ghcr.io/acme/mcp-sandbox:1")
+
+    config = sandbox_config_from_env()
+    assert config.image_pin_policy == "off"
+
+
+def test_non_server_mode_keeps_warn(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY", raising=False)
+    monkeypatch.delenv("AGENT_BOM_MCP_SANDBOX_SERVER_MODE", raising=False)
+    monkeypatch.delenv("AGENT_BOM_SERVER_MODE", raising=False)
+    monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX_IMAGE", "ghcr.io/acme/mcp-sandbox:1")
+
+    config = sandbox_config_from_env()
+    assert config.image_pin_policy == "warn"
+
+
+def test_generic_server_mode_fallback_escalates(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY", raising=False)
+    monkeypatch.delenv("AGENT_BOM_MCP_SANDBOX_SERVER_MODE", raising=False)
+    monkeypatch.setenv("AGENT_BOM_SERVER_MODE", "production")
+    monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX_IMAGE", "ghcr.io/acme/mcp-sandbox:1")
+
+    config = sandbox_config_from_env()
+    assert config.image_pin_policy == "enforce"
+
+
+def test_posture_surfaces_server_mode_effective_default(monkeypatch):
+    from agent_bom.proxy_sandbox import describe_proxy_sandbox_posture
+
+    monkeypatch.delenv("AGENT_BOM_MCP_SANDBOX_IMAGE_PIN_POLICY", raising=False)
+    monkeypatch.setenv("AGENT_BOM_MCP_SANDBOX_SERVER_MODE", "true")
+    posture = describe_proxy_sandbox_posture()
+    assert posture["image_pin_policy_default"] == "warn"
+    assert posture["image_pin_policy_effective_default"] == "enforce"
+    assert posture["server_mode"] is True
+
+
 def test_sandbox_config_defaults_to_enabled(monkeypatch):
     monkeypatch.delenv("AGENT_BOM_MCP_SANDBOX", raising=False)
 


### PR DESCRIPTION
## Summary
Adds content-aware **malicious-model detection** — the #1 real-world AI supply-chain attack (poisoned models on model hubs ship as pickles with code-execution opcodes). Detection is by **disassembly only** (`pickletools.genops`) — **NEVER deserializes** (verified by a trip-wire test that makes `pickle.load`/`Unpickler` raise and confirms detection still works). Preserves agent-bom's no-execution guarantee while closing the extension-only detection gap.

- `model_pickle_scan.py` — opcode disassembly of `.pkl/.pt/.joblib/.bin/...` and torch ZIP containers (finds embedded pickles). Flags code-exec opcodes (`GLOBAL`/`STACK_GLOBAL`/`REDUCE`/`BUILD`/`INST`/`OBJ`/`NEWOBJ`) with dangerous imports (`os`/`subprocess`/`sys`/`builtins.eval`/`exec`/...), capturing the `module.callable`. DoS-bounded (max opcodes/bytes/members). Truncated/garbage → safe, never raises.
- Classification: dangerous import + call opcode → `MALICIOUS_PICKLE`/CRITICAL; import without call → SUSPICIOUS/HIGH; tensors-only → clean.
- Wired into `scan_model_files` — findings flow through the existing console/JSON/report path; evidence carries dangerous imports + opcodes, **no raw payload bytes**.
- Sandbox image-pin auto-escalates `warn`→`enforce` in server/prod mode when the image is a mutable tag (no digest).

## Verification
104 tests (malicious `os.system` via `__reduce__` flagged CRITICAL with `os.system` captured; torch-zip embedded; benign clean; truncated/garbage safe; the no-deserialization trip-wire). ruff/format/mypy clean. 4 new env flags allowlisted.