### PR TITLE
feat(cli): add cost + identity governance commands (humans reach the new value)

### DIFF
--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -60,6 +60,14 @@
 | `firewall` | Inter-agent firewall policy validate / list / check |
 | `trust` | Show data access, network, auth, and storage boundaries |
 | `fleet` | Manage AI agent fleet discovery, lifecycle, and posture |
+| `cost` | LLM FinOps posture — spend forecast and chargeback rollups (read-only) |
+| `cost forecast` | Project LLM burn rate and budget runway (read-only FinOps) |
+| `cost allocation` | Roll up LLM spend by cost-center / allocation tag (alias: `cost chargeback`) |
+| `identity` | Non-human identity governance — credentials, discovery, access reviews (read-only) |
+| `identity credential-expiry` | Show expiring, overdue, and rotation-due credentials (never secret values) |
+| `identity discover` | Discover Okta / Entra non-human identities (gated, reference-only) |
+| `identity access-review` | List or get NHI recertification campaigns and their status |
+| `cloud inventory` | Estate-wide AWS / Azure / GCP asset summary (gated by `AGENT_BOM_*_INVENTORY`) |
 | `serve` | Start the API server and dashboard |
 | `api` | Start the REST API server |
 | `schedule` | Manage recurring scan schedules |
@@ -171,3 +179,5 @@ Contract](remediate-output.md).
 | `AGENT_BOM_CLICKHOUSE_URL` | Analytics storage | No |
 | `AWS_PROFILE` | AWS CIS benchmark | Only for `cis-benchmark --provider aws` |
 | `SNOWFLAKE_ACCOUNT` | Snowflake CIS benchmark | Only for `cis-benchmark --provider snowflake` |
+| `AGENT_BOM_OKTA_DISCOVERY` / `AGENT_BOM_ENTRA_DISCOVERY` | Gate `identity discover` and discovered-NHI credential expiry | Only for NHI discovery |
+| `AGENT_BOM_CLOUD_INVENTORY` / `AGENT_BOM_AZURE_INVENTORY` / `AGENT_BOM_GCP_INVENTORY` | Gate `cloud inventory` per provider | Only for estate inventory |

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -362,6 +362,20 @@ from agent_bom.cli._cloud_group import cloud_group  # noqa: E402
 main.add_command(cloud_group)
 
 # ---------------------------------------------------------------------------
+# Cost (FinOps) command group — `agent-bom cost [forecast|allocation]`
+# ---------------------------------------------------------------------------
+from agent_bom.cli._cost_group import cost_group  # noqa: E402
+
+main.add_command(cost_group)
+
+# ---------------------------------------------------------------------------
+# Identity (NHI governance) group — `agent-bom identity [credential-expiry|discover|access-review]`
+# ---------------------------------------------------------------------------
+from agent_bom.cli._identity_group import identity_group  # noqa: E402
+
+main.add_command(identity_group)
+
+# ---------------------------------------------------------------------------
 # Fleet command group — `agent-bom fleet [sync|list|stats]`
 # ---------------------------------------------------------------------------
 from agent_bom.cli.claw import fleet_group  # noqa: E402

--- a/src/agent_bom/cli/_cloud_group.py
+++ b/src/agent_bom/cli/_cloud_group.py
@@ -226,3 +226,107 @@ def resilience_cmd(output_format: str) -> None:
 
 
 cloud_group.add_command(resilience_cmd, "resilience")
+
+
+@click.command("inventory")
+@click.option(
+    "--provider",
+    type=click.Choice(["aws", "azure", "gcp", "all"]),
+    default="all",
+    show_default=True,
+    help="Restrict the estate inventory to one cloud provider.",
+)
+@click.option("--region", default=None, help="AWS region (aws only).")
+@click.option("--profile", default=None, help="AWS credential profile (aws only).")
+@click.option("--subscription", default=None, help="Azure subscription id (azure only).")
+@click.option("--project", default=None, help="GCP project id (gcp only).")
+@click.option("-f", "--format", "output_format", type=click.Choice(["console", "json"]), default="console")
+def inventory_cmd(
+    provider: str,
+    region: Optional[str],
+    profile: Optional[str],
+    subscription: Optional[str],
+    project: Optional[str],
+    output_format: str,
+) -> None:
+    """Show an estate-wide AWS / Azure / GCP asset summary (read-only).
+
+    Gated by ``AGENT_BOM_CLOUD_INVENTORY`` (AWS), ``AGENT_BOM_AZURE_INVENTORY``
+    (Azure), and ``AGENT_BOM_GCP_INVENTORY`` (GCP). A disabled provider reports a
+    ``disabled`` status and runs no network call. Reference only.
+    """
+    import json as _json
+
+    from agent_bom.cloud import aws_inventory, azure_inventory, gcp_inventory
+
+    reports: list[dict] = []
+    if provider in ("aws", "all"):
+        reports.append(aws_inventory.discover_inventory(region=region, profile=profile))
+    if provider in ("azure", "all"):
+        reports.append(azure_inventory.discover_inventory(subscription_id=subscription))
+    if provider in ("gcp", "all"):
+        reports.append(gcp_inventory.discover_inventory(project_id=project))
+
+    if output_format == "json":
+        click.echo(_json.dumps({"providers": reports}, indent=2, sort_keys=True, default=str))
+        return
+
+    from rich.console import Console
+    from rich.table import Table
+
+    con = Console()
+    con.print("\n  [bold]Cloud estate inventory[/bold] [dim]· read-only[/dim]")
+
+    table = Table()
+    table.add_column("Provider")
+    table.add_column("Status")
+    table.add_column("Assets")
+    table.add_column("Warnings", justify="right")
+    any_disabled = False
+    for rep in reports:
+        status = str(rep.get("status", "unknown"))
+        if status == "disabled":
+            any_disabled = True
+        style = {"ok": "green", "disabled": "yellow"}.get(status, "dim")
+        table.add_row(
+            str(rep.get("provider", "—")),
+            f"[{style}]{status}[/{style}]",
+            _asset_summary(rep),
+            str(len(rep.get("warnings") or [])),
+        )
+    con.print(table)
+    if any_disabled:
+        con.print(
+            "  [dim]Disabled providers run no network call. Enable with[/dim] "
+            "[cyan]AGENT_BOM_CLOUD_INVENTORY=1[/cyan] [dim]·[/dim] "
+            "[cyan]AGENT_BOM_AZURE_INVENTORY=1[/cyan] [dim]·[/dim] [cyan]AGENT_BOM_GCP_INVENTORY=1[/cyan]"
+        )
+    con.print()
+
+
+# Per-provider asset collections to count in the compact estate summary.
+_INVENTORY_ASSET_KEYS = (
+    "buckets",
+    "instances",
+    "security_groups",
+    "roles",
+    "users",
+    "storage_accounts",
+    "managed_identities",
+    "service_principals",
+    "service_accounts",
+    "firewalls",
+)
+
+
+def _asset_summary(report: dict) -> str:
+    """Compact ``key=N`` summary of the non-empty asset collections in a report."""
+    bits = []
+    for key in _INVENTORY_ASSET_KEYS:
+        value = report.get(key)
+        if isinstance(value, list) and value:
+            bits.append(f"{key}={len(value)}")
+    return ", ".join(bits) if bits else "[dim]none[/dim]"
+
+
+cloud_group.add_command(inventory_cmd, "inventory")

--- a/src/agent_bom/cli/_cost_group.py
+++ b/src/agent_bom/cli/_cost_group.py
@@ -1,0 +1,146 @@
+"""Cost command group — FinOps posture for LLM spend.
+
+Human-facing, read-only views over the same cost store the API exposes under
+``/v1/observability/costs``. No spend is mutated; these commands only report.
+
+Usage::
+
+    agent-bom cost forecast                 # burn rate + budget runway
+    agent-bom cost forecast --agent planner  # scope to one agent
+    agent-bom cost allocation                # by cost-center / allocation tag
+    agent-bom cost chargeback                # alias for allocation
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+import click
+
+from agent_bom.cli._grouped_help import SuggestingGroup
+
+_DEFAULT_TENANT = "default"
+
+
+@click.group("cost", cls=SuggestingGroup)
+def cost_group() -> None:
+    """LLM FinOps — spend forecast and chargeback rollups.
+
+    Read-only posture over ingested OTel GenAI cost records (the same data the
+    API serves at ``/v1/observability/costs``). Reference only — no spend or
+    budget is modified.
+
+    \b
+    Subcommands:
+      forecast     Burn rate + budget-runway projection
+      allocation   Spend rollup by cost-center / allocation tag (alias: chargeback)
+    """
+
+
+def _money(value: Optional[float]) -> str:
+    if value is None:
+        return "—"
+    return f"${value:,.2f}"
+
+
+@click.command("forecast")
+@click.option("--tenant", default=_DEFAULT_TENANT, show_default=True, help="Tenant to scope the forecast to.")
+@click.option("--agent", default=None, help="Scope the forecast to one agent (otherwise tenant-wide).")
+@click.option("--limit", default=10000, show_default=True, help="Max records to project from.")
+@click.option("-f", "--format", "output_format", type=click.Choice(["console", "json"]), default="console")
+def forecast_cmd(tenant: str, agent: Optional[str], limit: int, output_format: str) -> None:
+    """Project burn rate and budget runway from recent LLM spend."""
+    from agent_bom.api.cost_forecast import forecast_for_tenant
+
+    report = forecast_for_tenant(tenant, agent=agent, limit=max(1, min(limit, 100000)))
+
+    if output_format == "json":
+        click.echo(json.dumps(report, indent=2, sort_keys=True))
+        return
+
+    from rich.console import Console
+    from rich.table import Table
+
+    con = Console()
+    scope = f"agent [bold]{agent}[/bold]" if agent else "tenant-wide"
+    con.print(f"\n  [bold]LLM spend forecast[/bold] [dim]· tenant {tenant} · {scope}[/dim]")
+
+    table = Table(show_header=False, box=None, pad_edge=False)
+    table.add_column(style="dim")
+    table.add_column()
+    table.add_row("status", str(report.get("status", "unknown")))
+    table.add_row("current spend", _money(report.get("current_spend_usd")))
+    table.add_row("budget limit", _money(report.get("budget_limit_usd")))
+    rate = report.get("burn_rate_usd_per_day")
+    basis = report.get("burn_rate_basis")
+    table.add_row("burn rate/day", _money(rate) + (f" [dim]({basis})[/dim]" if basis else ""))
+    table.add_row("projected period spend", _money(report.get("projected_period_spend_usd")))
+    days = report.get("days_remaining")
+    table.add_row("days remaining", "—" if days is None else f"{days:g}")
+    table.add_row("projected exhaustion", str(report.get("projected_exhaustion_at") or "—"))
+    con.print(table)
+    con.print()
+
+
+@click.command("allocation")
+@click.option("--tenant", default=_DEFAULT_TENANT, show_default=True, help="Tenant to scope the rollup to.")
+@click.option("--tag", default=None, help="Add a showback slice by this freeform allocation tag (e.g. team, project).")
+@click.option("--limit", default=10000, show_default=True, help="Max records to roll up.")
+@click.option("-f", "--format", "output_format", type=click.Choice(["console", "json"]), default="console")
+def allocation_cmd(tenant: str, tag: Optional[str], limit: int, output_format: str) -> None:
+    """Show spend rolled up by cost-center (and optionally an allocation tag)."""
+    from agent_bom.api.cost_store import get_cost_store, summarize, summarize_by_tag
+
+    store = get_cost_store()
+    records = store.list_records(tenant, limit=max(1, min(limit, 100000)))
+    report = summarize(records)
+    report["tenant_id"] = tenant
+    if tag:
+        report["tag_rollup"] = summarize_by_tag(records, tag.strip()[:60])
+
+    if output_format == "json":
+        click.echo(json.dumps(report, indent=2, sort_keys=True))
+        return
+
+    from rich.console import Console
+    from rich.table import Table
+
+    con = Console()
+    con.print(
+        f"\n  [bold]LLM spend allocation[/bold] [dim]· tenant {tenant} · "
+        f"{report['total_calls']} calls · {_money(report['total_cost_usd'])} total[/dim]"
+    )
+
+    cc_table = Table(title="By cost center", title_justify="left", title_style="bold")
+    cc_table.add_column("Cost center")
+    cc_table.add_column("Calls", justify="right")
+    cc_table.add_column("Cost", justify="right")
+    for row in report["by_cost_center"]:
+        cc_table.add_row(row["key"], str(row["calls"]), _money(row["cost_usd"]))
+    if not report["by_cost_center"]:
+        cc_table.add_row("[dim]no spend recorded[/dim]", "0", _money(0.0))
+    con.print(cc_table)
+
+    if tag:
+        tag_table = Table(title=f"By tag: {tag}", title_justify="left", title_style="bold")
+        tag_table.add_column("Value")
+        tag_table.add_column("Calls", justify="right")
+        tag_table.add_column("Cost", justify="right")
+        for row in report["tag_rollup"]["by_tag"]:
+            tag_table.add_row(row["key"], str(row["calls"]), _money(row["cost_usd"]))
+        if not report["tag_rollup"]["by_tag"]:
+            tag_table.add_row("[dim]no spend recorded[/dim]", "0", _money(0.0))
+        con.print(tag_table)
+    con.print()
+
+
+cost_group.add_command(forecast_cmd, "forecast")
+cost_group.add_command(allocation_cmd, "allocation")
+
+# `chargeback` is an alias for `allocation` — same impl, finance-friendly name.
+import copy as _copy  # noqa: E402
+
+_chargeback_cmd = _copy.copy(allocation_cmd)
+_chargeback_cmd.name = "chargeback"
+cost_group.add_command(_chargeback_cmd, "chargeback")

--- a/src/agent_bom/cli/_grouped_help.py
+++ b/src/agent_bom/cli/_grouped_help.py
@@ -29,7 +29,7 @@ COMMAND_CATEGORIES: OrderedDict[str, list[str]] = OrderedDict(
         ),
         (
             "Governance",
-            ["policy", "trust", "fleet", "serve", "api", "schedule", "remediate", "teardown"],
+            ["policy", "trust", "fleet", "cost", "identity", "serve", "api", "schedule", "remediate", "teardown"],
         ),
         (
             "Database",
@@ -47,7 +47,7 @@ CATEGORY_DESCRIPTIONS: dict[str, str] = {
     "Runtime": "Live MCP enforcement, replay, and runtime monitoring surfaces.",
     "MCP": "Discovery, inventory, introspection, and MCP server operations.",
     "Reporting": "Graph, mesh, dashboard, history, and narrative reporting workflows.",
-    "Governance": "Policy, trust boundaries, fleet, API, scheduling, and operational control-plane commands.",
+    "Governance": "Policy, trust boundaries, fleet, FinOps, identity, API, scheduling, and operational control-plane commands.",
     "Database": "Local cache, vuln database, and framework catalog maintenance.",
     "Utilities": "Shell completions and upgrade helpers.",
     "Other": "Additional commands that do not fit a primary workflow bucket.",

--- a/src/agent_bom/cli/_identity_group.py
+++ b/src/agent_bom/cli/_identity_group.py
@@ -1,0 +1,349 @@
+"""Identity command group — non-human identity (NHI) governance.
+
+Human-facing, read-only / reference-only views over the same NHI governance
+the API exposes under ``/v1/identities/...``. These commands never read or
+store secret material and never execute a revocation.
+
+Usage::
+
+    agent-bom identity credential-expiry         # expiring/overdue credentials
+    agent-bom identity discover                   # discover Okta/Entra NHIs (gated)
+    agent-bom identity access-review              # list recertification campaigns
+    agent-bom identity access-review --campaign C # one campaign + its items
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+import click
+
+from agent_bom.cli._grouped_help import SuggestingGroup
+
+_DEFAULT_TENANT = "default"
+
+# Per-state colour for the compact credential-expiry table.
+_STATE_STYLE = {
+    "expired": "bold red",
+    "overdue": "bold red",
+    "rotation_due": "yellow",
+    "near_expiry": "yellow",
+    "unknown_age": "dim",
+    "ok": "green",
+}
+
+
+@click.group("identity", cls=SuggestingGroup)
+def identity_group() -> None:
+    """Non-human identity governance — credentials, discovery, access reviews.
+
+    Read-only and reference-only. Mirrors the API's ``/v1/identities`` and
+    ``/v1/auth/secrets/credential-expiry`` surfaces. Discovery is gated behind
+    the ``AGENT_BOM_OKTA_DISCOVERY`` / ``AGENT_BOM_ENTRA_DISCOVERY`` flags and
+    never runs a network call for a provider whose flag is off. No secret value
+    is ever printed and no revocation is ever executed.
+
+    \b
+    Subcommands:
+      credential-expiry   Expiring / overdue credential posture
+      discover            Discover Okta / Entra NHIs (gated, reference-only)
+      access-review       List or get NHI recertification campaigns
+    """
+
+
+@click.command("credential-expiry")
+@click.option(
+    "--no-control-plane",
+    is_flag=True,
+    help="Exclude configured control-plane secrets (evaluate only discovered NHIs).",
+)
+@click.option(
+    "--include-discovered/--no-include-discovered",
+    default=True,
+    show_default=True,
+    help="Fold gated Okta/Entra NHI credentials into the posture.",
+)
+@click.option("-f", "--format", "output_format", type=click.Choice(["console", "json"]), default="console")
+def credential_expiry_cmd(no_control_plane: bool, include_discovered: bool, output_format: str) -> None:
+    """Show expiring, overdue, and rotation-due credentials (never secret values)."""
+    from agent_bom.api.credential_expiry import describe_credential_expiry_posture
+
+    discovered = _discover_nhi_credentials() if include_discovered else None
+    report = describe_credential_expiry_posture(
+        discovered,
+        include_control_plane=not no_control_plane,
+    )
+
+    if output_format == "json":
+        click.echo(json.dumps(report, indent=2, sort_keys=True))
+        return
+
+    from rich.console import Console
+    from rich.table import Table
+
+    con = Console()
+    status = report.get("status", "unknown")
+    status_style = {"blocked": "bold red", "attention_required": "yellow", "ok": "green"}.get(status, "dim")
+    con.print(
+        f"\n  [bold]Credential expiry posture[/bold] [dim]· "
+        f"{report.get('evaluated', 0)} evaluated[/dim] · [{status_style}]{status}[/{status_style}]"
+    )
+    con.print(f"  [dim]{report.get('message', '')}[/dim]")
+
+    action = report.get("action_required") or []
+    if not action:
+        con.print("  [green]No credentials require attention.[/green]\n")
+        return
+
+    table = Table()
+    table.add_column("Credential")
+    table.add_column("Provider")
+    table.add_column("State")
+    table.add_column("Age (d)", justify="right")
+    table.add_column("Expires in (d)", justify="right")
+    for item in action:
+        state = str(item.get("state", ""))
+        style = _STATE_STYLE.get(state, "")
+        table.add_row(
+            str(item.get("name") or item.get("id") or "—"),
+            str(item.get("provider") or "—"),
+            f"[{style}]{state}[/{style}]" if style else state,
+            "—" if item.get("age_days") is None else str(item["age_days"]),
+            "—" if item.get("days_until_expiry") is None else str(item["days_until_expiry"]),
+        )
+    con.print(table)
+    con.print()
+
+
+def _discover_nhi_credentials() -> list[dict[str, object]]:
+    """Run gated Okta/Entra NHI discovery and return reference-only cred dicts.
+
+    Reuses the same discovery the API uses; each provider stays gated by its own
+    env flag, so a disabled provider contributes nothing and runs no network
+    call. Never returns secret material.
+    """
+    from agent_bom.graph.nhi_overlay import merge_discovery_results
+    from agent_bom.identity import (
+        discover_entra_non_human_identities,
+        discover_okta_non_human_identities,
+    )
+
+    merged = merge_discovery_results([discover_okta_non_human_identities(), discover_entra_non_human_identities()])
+    return list(merged.get("identities", []))
+
+
+@click.command("discover")
+@click.option(
+    "--provider",
+    type=click.Choice(["okta", "entra", "all"]),
+    default="all",
+    show_default=True,
+    help="Restrict discovery to one identity provider.",
+)
+@click.option("-f", "--format", "output_format", type=click.Choice(["console", "json"]), default="console")
+def discover_cmd(provider: str, output_format: str) -> None:
+    """Discover Okta / Entra non-human identities (gated, reference-only)."""
+    from agent_bom.graph.nhi_overlay import merge_discovery_results
+    from agent_bom.identity import (
+        discover_entra_non_human_identities,
+        discover_okta_non_human_identities,
+    )
+
+    results = []
+    requested: list[str] = []
+    if provider in ("okta", "all"):
+        results.append(discover_okta_non_human_identities())
+        requested.append("okta")
+    if provider in ("entra", "all"):
+        results.append(discover_entra_non_human_identities())
+        requested.append("entra")
+    merged = merge_discovery_results(results)
+    # The merge layer can only name a provider once it has identities; label the
+    # empty/disabled ones from the request order so the compact view stays clear.
+    providers = [
+        {**p, "provider": p.get("provider") or requested[i]} if i < len(requested) else p for i, p in enumerate(merged["providers"])
+    ]
+    report = {
+        "schema_version": "identity.nhi.discovery.v1",
+        "status": merged["status"],
+        "providers": providers,
+        "count": len(merged["identities"]),
+        "identities": merged["identities"],
+        "warnings": merged["warnings"],
+    }
+
+    if output_format == "json":
+        click.echo(json.dumps(report, indent=2, sort_keys=True))
+        return
+
+    from rich.console import Console
+    from rich.table import Table
+
+    con = Console()
+    con.print(f"\n  [bold]NHI discovery[/bold] [dim]· {report['count']} identities[/dim]")
+
+    prov_bits = []
+    for prov in report["providers"]:
+        pstatus = prov.get("status")
+        tag = "disabled" if pstatus == "disabled" else str(pstatus)
+        prov_bits.append(f"{prov.get('provider')}={tag}({prov.get('count', 0)})")
+    con.print("  [dim]providers:[/dim] " + (", ".join(prov_bits) if prov_bits else "none"))
+
+    if report["count"] == 0:
+        if all(p.get("status") == "disabled" for p in report["providers"]):
+            con.print(
+                "  [yellow]Discovery is disabled.[/yellow] Enable with "
+                "[cyan]AGENT_BOM_OKTA_DISCOVERY=1[/cyan] / [cyan]AGENT_BOM_ENTRA_DISCOVERY=1[/cyan].\n"
+            )
+        else:
+            con.print("  [dim]No non-human identities discovered.[/dim]\n")
+        return
+
+    table = Table()
+    table.add_column("Identity")
+    table.add_column("Type")
+    table.add_column("Provider")
+    table.add_column("Status")
+    table.add_column("Expires")
+    for ident in report["identities"]:
+        table.add_row(
+            str(ident.get("name") or ident.get("identity_id") or "—"),
+            str(ident.get("identity_type") or "—"),
+            str(ident.get("provider") or "—"),
+            str(ident.get("status") or "—"),
+            str(ident.get("credential_expires_at") or "—"),
+        )
+    con.print(table)
+    con.print()
+
+
+@click.command("access-review")
+@click.option("--tenant", default=_DEFAULT_TENANT, show_default=True, help="Tenant to list campaigns for.")
+@click.option("--campaign", "campaign_id", default=None, help="Show one campaign and its review items.")
+@click.option("--limit", default=200, show_default=True, help="Max campaigns to list.")
+@click.option("-f", "--format", "output_format", type=click.Choice(["console", "json"]), default="console")
+def access_review_cmd(tenant: str, campaign_id: Optional[str], limit: int, output_format: str) -> None:
+    """List access-review campaigns, or show one with its review items."""
+    from agent_bom.api.access_review import get_access_review_store, refresh_campaign_status
+
+    store = get_access_review_store()
+
+    if campaign_id:
+        campaign = refresh_campaign_status(store, tenant_id=tenant, campaign_id=campaign_id)
+        if campaign is None:
+            report: dict[str, object] = {
+                "schema_version": "identity.access_review.v1",
+                "tenant_id": tenant,
+                "found": False,
+                "campaign": None,
+                "items": [],
+            }
+        else:
+            items = store.list_items(campaign_id, tenant)
+            report = {
+                "schema_version": "identity.access_review.v1",
+                "tenant_id": tenant,
+                "found": True,
+                "campaign": campaign.to_public_dict(),
+                "count": len(items),
+                "items": [i.to_public_dict() for i in items],
+            }
+        if output_format == "json":
+            click.echo(json.dumps(report, indent=2, sort_keys=True))
+            return
+        _render_one_campaign(report)
+        return
+
+    bounded = max(1, min(limit, 1000))
+    campaigns = store.list_campaigns(tenant, limit=bounded)
+    refreshed = [refresh_campaign_status(store, tenant_id=tenant, campaign_id=c.campaign_id) or c for c in campaigns]
+    report = {
+        "schema_version": "identity.access_review.v1",
+        "tenant_id": tenant,
+        "count": len(refreshed),
+        "campaigns": [c.to_public_dict() for c in refreshed],
+    }
+
+    if output_format == "json":
+        click.echo(json.dumps(report, indent=2, sort_keys=True))
+        return
+
+    from rich.console import Console
+    from rich.table import Table
+
+    con = Console()
+    con.print(f"\n  [bold]Access-review campaigns[/bold] [dim]· tenant {tenant} · {report['count']} total[/dim]")
+    if not refreshed:
+        con.print("  [dim]No access-review campaigns. Create one via the API or MCP.[/dim]\n")
+        return
+    table = Table()
+    table.add_column("Campaign")
+    table.add_column("Name")
+    table.add_column("Status")
+    table.add_column("Items", justify="right")
+    table.add_column("Decided", justify="right")
+    table.add_column("Due")
+    for c in refreshed:
+        d = c.to_public_dict()
+        table.add_row(
+            str(d.get("campaign_id")),
+            str(d.get("name")),
+            _status_styled(str(d.get("status"))),
+            str(d.get("item_count", 0)),
+            str(d.get("decided_count", 0)),
+            str(d.get("due_at") or "—"),
+        )
+    con.print(table)
+    con.print()
+
+
+def _status_styled(status: str) -> str:
+    style = {"completed": "green", "overdue": "bold red", "in_progress": "yellow", "open": "cyan"}.get(status, "")
+    return f"[{style}]{status}[/{style}]" if style else status
+
+
+def _render_one_campaign(report: dict) -> None:
+    from rich.console import Console
+    from rich.table import Table
+
+    con = Console()
+    if not report.get("found"):
+        con.print(f"\n  [yellow]Access-review campaign not found[/yellow] [dim](tenant {report.get('tenant_id')})[/dim]\n")
+        return
+    campaign = report["campaign"]
+    con.print(
+        f"\n  [bold]{campaign.get('name')}[/bold] [dim]· {campaign.get('campaign_id')}[/dim] · "
+        f"{_status_styled(str(campaign.get('status')))}"
+    )
+    con.print(
+        f"  [dim]items {campaign.get('item_count', 0)} · decided {campaign.get('decided_count', 0)} · "
+        f"due {campaign.get('due_at') or '—'}[/dim]"
+    )
+    items = report.get("items") or []
+    if not items:
+        con.print("  [dim]No review items.[/dim]\n")
+        return
+    table = Table()
+    table.add_column("Subject")
+    table.add_column("Type")
+    table.add_column("Provider")
+    table.add_column("Perms", justify="right")
+    table.add_column("Privileged")
+    table.add_column("Decision")
+    for item in items:
+        table.add_row(
+            str(item.get("subject_name") or item.get("subject_id") or "—"),
+            str(item.get("subject_type") or "—"),
+            str(item.get("provider") or "—"),
+            str(item.get("permission_count", 0)),
+            "yes" if item.get("privileged") else "—",
+            str(item.get("decision") or "pending"),
+        )
+    con.print(table)
+    con.print()
+
+
+identity_group.add_command(credential_expiry_cmd, "credential-expiry")
+identity_group.add_command(discover_cmd, "discover")
+identity_group.add_command(access_review_cmd, "access-review")

--- a/tests/test_cli_governance_commands.py
+++ b/tests/test_cli_governance_commands.py
@@ -1,0 +1,226 @@
+"""CLI tests for the human-facing governance / FinOps posture commands.
+
+Covers the new ``cost``, ``identity``, and ``cloud inventory`` commands that
+expose API-only governance capabilities to humans. Each command must run,
+exit 0, render a compact summary, emit valid JSON under ``--format json``,
+and degrade to a clean status (not a crash) when a gated capability is off.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from agent_bom.api.access_review import (
+    create_campaign,
+    get_access_review_store,
+    set_access_review_store,
+)
+from agent_bom.api.cost_store import LLMCostRecord, get_cost_store, set_cost_store
+from agent_bom.cli import main
+
+
+@pytest.fixture(autouse=True)
+def _reset_stores():
+    """Each test starts from fresh in-memory cost + access-review stores."""
+    set_cost_store(None)
+    set_access_review_store(None)
+    yield
+    set_cost_store(None)
+    set_access_review_store(None)
+
+
+@pytest.fixture(autouse=True)
+def _discovery_off(monkeypatch):
+    """Default the NHI discovery + cloud inventory flags OFF for gated-path tests."""
+    for flag in (
+        "AGENT_BOM_OKTA_DISCOVERY",
+        "AGENT_BOM_ENTRA_DISCOVERY",
+        "AGENT_BOM_CLOUD_INVENTORY",
+        "AGENT_BOM_AZURE_INVENTORY",
+        "AGENT_BOM_GCP_INVENTORY",
+    ):
+        monkeypatch.delenv(flag, raising=False)
+
+
+def _seed_cost_records():
+    store = get_cost_store()
+    store.record_cost(
+        LLMCostRecord(
+            tenant_id="default",
+            call_id="c1",
+            agent="planner",
+            session_id="s1",
+            provider="openai",
+            model="gpt-4o",
+            input_tokens=100,
+            output_tokens=50,
+            cost_usd=1.25,
+            priced=True,
+            observed_at="2026-06-20T00:00:00+00:00",
+            cost_center="research",
+            allocation_tags={"team": "ml"},
+        )
+    )
+
+
+# ── cost forecast ──────────────────────────────────────────────────────────
+
+
+def test_cost_forecast_runs_compact():
+    result = CliRunner().invoke(main, ["cost", "forecast"])
+    assert result.exit_code == 0
+    assert "LLM spend forecast" in result.output
+    assert "status" in result.output
+
+
+def test_cost_forecast_json_valid():
+    _seed_cost_records()
+    result = CliRunner().invoke(main, ["cost", "forecast", "--format", "json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["tenant_id"] == "default"
+    assert "status" in payload
+    assert "burn_rate_usd_per_day" in payload
+
+
+# ── cost allocation / chargeback ───────────────────────────────────────────
+
+
+def test_cost_allocation_runs_compact():
+    _seed_cost_records()
+    result = CliRunner().invoke(main, ["cost", "allocation"])
+    assert result.exit_code == 0
+    assert "LLM spend allocation" in result.output
+    assert "By cost center" in result.output
+    assert "research" in result.output
+
+
+def test_cost_allocation_json_valid_with_tag():
+    _seed_cost_records()
+    result = CliRunner().invoke(main, ["cost", "allocation", "--tag", "team", "--format", "json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["total_calls"] == 1
+    assert "by_cost_center" in payload
+    assert payload["tag_rollup"]["tag_key"] == "team"
+
+
+def test_cost_chargeback_alias_runs():
+    result = CliRunner().invoke(main, ["cost", "chargeback"])
+    assert result.exit_code == 0
+    assert "LLM spend allocation" in result.output
+
+
+# ── identity credential-expiry ─────────────────────────────────────────────
+
+
+def test_credential_expiry_runs_compact():
+    result = CliRunner().invoke(main, ["identity", "credential-expiry"])
+    assert result.exit_code == 0
+    assert "Credential expiry posture" in result.output
+
+
+def test_credential_expiry_json_valid_and_no_secrets():
+    result = CliRunner().invoke(main, ["identity", "credential-expiry", "--format", "json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["secret_values_included"] is False
+    assert "status" in payload
+    assert "credentials" in payload
+
+
+# ── identity discover (gated) ──────────────────────────────────────────────
+
+
+def test_identity_discover_gated_off_shows_disabled():
+    result = CliRunner().invoke(main, ["identity", "discover"])
+    assert result.exit_code == 0
+    assert "disabled" in result.output.lower()
+    assert "AGENT_BOM_OKTA_DISCOVERY" in result.output
+
+
+def test_identity_discover_json_valid_when_disabled():
+    result = CliRunner().invoke(main, ["identity", "discover", "--format", "json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["count"] == 0
+    assert all(p["status"] == "disabled" for p in payload["providers"])
+    # Provider labels are filled in from the request order even when empty.
+    assert {p["provider"] for p in payload["providers"]} == {"okta", "entra"}
+
+
+# ── identity access-review ─────────────────────────────────────────────────
+
+
+def test_access_review_list_empty():
+    result = CliRunner().invoke(main, ["identity", "access-review"])
+    assert result.exit_code == 0
+    assert "Access-review campaigns" in result.output
+    assert "No access-review campaigns" in result.output
+
+
+def test_access_review_list_and_get_one():
+    store = get_access_review_store()
+    campaign, _items = create_campaign(
+        store,
+        tenant_id="default",
+        name="Q3 recert",
+        subjects=[
+            {
+                "id": "okta:sa1",
+                "name": "svc-deploy",
+                "identity_type": "service_account",
+                "permissions": ["repo:write"],
+                "privileged": True,
+            }
+        ],
+        created_by="cli-test",
+        due_days=14,
+    )
+
+    listed = CliRunner().invoke(main, ["identity", "access-review"])
+    assert listed.exit_code == 0
+    assert "Q3 recert" in listed.output
+
+    got = CliRunner().invoke(main, ["identity", "access-review", "--campaign", campaign.campaign_id, "--format", "json"])
+    assert got.exit_code == 0
+    payload = json.loads(got.output)
+    assert payload["found"] is True
+    assert payload["campaign"]["name"] == "Q3 recert"
+    assert payload["count"] == 1
+
+
+def test_access_review_get_missing_is_clean():
+    result = CliRunner().invoke(main, ["identity", "access-review", "--campaign", "does-not-exist", "--format", "json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["found"] is False
+
+
+# ── cloud inventory (gated) ────────────────────────────────────────────────
+
+
+def test_cloud_inventory_gated_off_shows_disabled():
+    result = CliRunner().invoke(main, ["cloud", "inventory"])
+    assert result.exit_code == 0
+    assert "disabled" in result.output.lower()
+    assert "AGENT_BOM_CLOUD_INVENTORY" in result.output
+
+
+def test_cloud_inventory_json_valid_when_disabled():
+    result = CliRunner().invoke(main, ["cloud", "inventory", "--format", "json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    providers = {p["provider"]: p["status"] for p in payload["providers"]}
+    assert providers == {"aws": "disabled", "azure": "disabled", "gcp": "disabled"}
+
+
+def test_cloud_inventory_single_provider():
+    result = CliRunner().invoke(main, ["cloud", "inventory", "--provider", "aws", "--format", "json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert len(payload["providers"]) == 1
+    assert payload["providers"][0]["provider"] == "aws"


### PR DESCRIPTION
## Summary
Adds CLI commands so HUMANS can use the recently-shipped governance/FinOps capabilities that were API-only. All read-only/reference-only, reusing existing impls (no logic duplication), compact default output + `--format json`.

- `agent-bom cost forecast` — burn-rate + budget-runway projection.
- `agent-bom cost allocation` (alias `cost chargeback`) — spend by cost-center + `--tag` showback slice.
- `agent-bom identity credential-expiry` — expiring/overdue credential posture (no secret values).
- `agent-bom identity discover` — Okta/Entra NHI discovery (gated; clean disabled status when off).
- `agent-bom identity access-review` — list campaigns / `--campaign <id>` detail.
- `agent-bom cloud inventory` — estate-wide AWS/Azure/GCP asset summary (gated).

New `cost` + `identity` command groups (Governance category); `cloud inventory` under the cloud group.

## Verification
15 CliRunner tests (run/exit-0, compact render, valid JSON, gated-off clean-disabled). ruff/format/mypy clean. `site-docs/reference/cli.md` + product-surface contract updated and green. No models/routes touched → no regen.