### PR TITLE
fix(registry): fail stale Glama listing publishes

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -154,12 +154,14 @@ jobs:
       contents: read
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
       - name: Trigger Glama rebuild
         env:
           GLAMA_WEBHOOK_URL: ${{ vars.GLAMA_WEBHOOK_URL }}
         run: |
           if [ -z "$GLAMA_WEBHOOK_URL" ]; then
-            echo "::notice::GLAMA_WEBHOOK_URL not configured — Glama will rebuild on next auto-sync from PyPI"
+            echo "::warning::GLAMA_WEBHOOK_URL not configured — verifying Glama auto-sync freshness instead"
             echo "To enable instant rebuild, set GLAMA_WEBHOOK_URL in repo variables"
             exit 0
           fi
@@ -171,6 +173,9 @@ jobs:
           else
             echo "::warning::Glama rebuild trigger returned HTTP ${HTTP_STATUS} — may need manual rebuild"
           fi
+
+      - name: Verify Glama listing freshness
+        run: python scripts/check_glama_listing.py --retries 6 --delay-seconds 30
 
   clawhub:
     name: Publish to ClawHub

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Screenshot capture rules and the full manifest live in
 | Pre-install guard | `agent-bom check flask@2.0.0 --ecosystem pypi` | deterministic allow/warn/block result |
 | Container image scan | `agent-bom image nginx:latest` | image findings and remediation |
 | IaC scan | `agent-bom iac Dockerfile k8s/ infra/main.tf` | IaC findings and policy context |
-| Cloud posture check | `agent-bom cis-benchmark --provider aws` | runtime CIS posture evidence |
+| Cloud posture check | `agent-bom cloud aws --cis` | runtime CIS posture evidence |
 | CI gate | `uses: msaad00/agent-bom@v0.88.6` | SARIF, PR summary, optional code-scanning upload |
 | MCP tools | `pip install 'agent-bom[mcp-server]' && agent-bom mcp server` | strict-args security tools for MCP clients |
 | Local API/UI | `pip install 'agent-bom[ui]' && agent-bom serve` | API plus bundled dashboard |

--- a/scripts/check_glama_listing.py
+++ b/scripts/check_glama_listing.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Verify Glama's public listing is not serving stale release content."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+README = ROOT / "README.md"
+DEFAULT_URL = "https://glama.ai/mcp/servers/msaad00/agent-bom"
+
+
+def _load_version() -> str:
+    text = PYPROJECT.read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.M)
+    if not match:
+        raise SystemExit("pyproject.toml version not found")
+    return match.group(1)
+
+
+def _load_readme_tool_count() -> str:
+    text = README.read_text(encoding="utf-8")
+    match = re.search(r"MCP server mode advertises\s+(\d+)\s+MCP tools", text)
+    if not match:
+        raise SystemExit("README.md MCP tool count sentence not found")
+    return match.group(1)
+
+
+def _fetch(url: str, timeout: int) -> str:
+    request = urllib.request.Request(url, headers={"User-Agent": "agent-bom-release-check/1.0"})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def _check(page: str, version: str, tool_count: str) -> list[str]:
+    failures: list[str] = []
+    expected_tokens = [
+        f"v{version}",
+        f"MCP server mode advertises {tool_count} MCP tools",
+    ]
+    for token in expected_tokens:
+        if token not in page:
+            failures.append(f"missing current Glama listing token: {token!r}")
+
+    stale_patterns = [
+        r"uses:\s*msaad00/agent-bom@v0\.88\.4",
+        r"MCP server mode advertises\s+55\s+MCP tools",
+        r"18 tools for CVE scanning",
+    ]
+    for pattern in stale_patterns:
+        if re.search(pattern, page):
+            failures.append(f"stale Glama listing pattern still present: {pattern}")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default=DEFAULT_URL)
+    parser.add_argument("--timeout", type=int, default=20)
+    parser.add_argument("--retries", type=int, default=1)
+    parser.add_argument("--delay-seconds", type=int, default=30)
+    args = parser.parse_args()
+
+    version = _load_version()
+    tool_count = _load_readme_tool_count()
+    last_error = ""
+    for attempt in range(1, max(1, args.retries) + 1):
+        try:
+            page = _fetch(args.url, args.timeout)
+        except (urllib.error.URLError, TimeoutError) as exc:
+            last_error = f"failed to fetch Glama listing: {exc}"
+        else:
+            failures = _check(page, version, tool_count)
+            if not failures:
+                print(f"Glama listing is fresh for agent-bom v{version} with {tool_count} MCP tools")
+                return 0
+            last_error = "\n".join(failures)
+
+        if attempt < args.retries:
+            print(f"Glama listing freshness check failed on attempt {attempt}/{args.retries}: {last_error}")
+            time.sleep(args.delay_seconds)
+
+    print(f"ERROR: Glama listing is stale or unreachable:\n{last_error}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -346,6 +346,28 @@ def main() -> int:
             for marker in stale_path_markers:
                 if marker in text:
                     _fail(f"{file.relative_to(ROOT)} contains stale toy runtime path: {marker}")
+    stale_public_markers = [
+        "agent-bom cis-benchmark --provider aws",
+        "uses: msaad00/agent-bom@v0.88.4",
+        "MCP server mode advertises 55 MCP tools",
+        "18 tools for CVE scanning",
+    ]
+    public_surface_roots = [
+        ROOT / "README.md",
+        ROOT / "PYPI_README.md",
+        ROOT / "site-docs",
+        ROOT / "docs" / "PRODUCT_BRIEF.md",
+        ROOT / "docs" / "MCP_SECURITY_MODEL.md",
+    ]
+    for root in public_surface_roots:
+        files = [root] if root.is_file() else [p for p in root.rglob("*") if p.is_file()]
+        for file in files:
+            if file.suffix.lower() in {".gif", ".png", ".jpg", ".jpeg", ".svg", ".ico"}:
+                continue
+            text = file.read_text(errors="ignore")
+            for marker in stale_public_markers:
+                if marker in text:
+                    _fail(f"{file.relative_to(ROOT)} contains stale public registry marker: {marker}")
 
     if len(description) > 100:
         _fail("pyproject.toml description must be <=100 chars for Docker Hub short-description publishing")

--- a/site-docs/features/cloud-posture.md
+++ b/site-docs/features/cloud-posture.md
@@ -51,7 +51,7 @@ Run cloud benchmark checks against the actual environment when credentials are
 available:
 
 ```bash
-agent-bom cis-benchmark --provider aws
+agent-bom cloud aws --cis
 agent-bom cis-benchmark --provider azure
 agent-bom cis-benchmark --provider gcp
 agent-bom cis-benchmark --provider snowflake

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -45,7 +45,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 |---|---|---|
 | **Local AI BOM** | `agent-bom agents --demo --offline` | terminal findings and graph-ready inventory |
 | **Repository scan** | `agent-bom agents -p . -f html -o agent-bom-report.html` | local HTML review plus exportable evidence |
-| **Cloud posture gate** | `agent-bom iac infra/ && agent-bom cis-benchmark --provider aws` | pre-cloud IaC findings plus live posture evidence |
+| **Cloud posture gate** | `agent-bom iac infra/ && agent-bom cloud aws --cis` | pre-cloud IaC findings plus live posture evidence |
 | **CI evidence** | `uses: msaad00/agent-bom@v0.88.6` | SARIF, pull-request summary, optional code scanning |
 | **Assistant tools** | `agent-bom mcp server` | read-mostly security tools for MCP clients |
 | **Self-hosted control plane** | `docker compose -f docker-compose.pilot.yml up -d` | API and dashboard in your infrastructure |


### PR DESCRIPTION
Summary:
- add a Glama listing freshness check to the registry publish workflow
- fail release-surface consistency checks when stale public registry markers reappear
- replace stale cloud posture examples that Glama was still rendering

Verification:
- python scripts/check_release_consistency.py
- python -m py_compile scripts/check_glama_listing.py scripts/check_release_consistency.py
- pre-commit run check-yaml --files .github/workflows/publish-registries.yml .pre-commit-config.yaml
- pre-commit run check-merge-conflict --files README.md site-docs/index.md site-docs/features/cloud-posture.md .github/workflows/publish-registries.yml scripts/check_glama_listing.py scripts/check_release_consistency.py
- python scripts/check_glama_listing.py (expected failure against the current public Glama page: missing v0.88.6/current MCP tool count and still serving v0.88.4/55-tool/18-tool stale content)

Notes:
- GLAMA_WEBHOOK_URL must be configured as a repository variable, or the Glama listing must be manually rebuilt before registry publish can prove freshness.
