### PR TITLE
feat(ui): cost forecast/chargeback + NHI governance console panels

### DIFF
--- a/ui/app/cost/page.tsx
+++ b/ui/app/cost/page.tsx
@@ -10,6 +10,9 @@ import {
   TrendingUp,
   ShieldAlert,
   Gauge,
+  Flame,
+  CalendarClock,
+  Building2,
 } from "lucide-react";
 import {
   ResponsiveContainer,
@@ -21,12 +24,13 @@ import {
   CartesianGrid,
   Cell,
 } from "recharts";
-import { api } from "@/lib/api";
+import { api, formatDate } from "@/lib/api";
 import type {
   CostReport,
   AnomaliesReport,
   CostBreakdownRow,
   CostAnomaly,
+  CostForecast,
 } from "@/lib/api-types";
 import {
   PageLoadingState,
@@ -194,6 +198,197 @@ function BreakdownTable({
   );
 }
 
+const FORECAST_STATUS: Record<
+  string,
+  { label: string; tone: "ok" | "warn" | "danger" | "muted" }
+> = {
+  ok: { label: "on track", tone: "ok" },
+  no_budget: { label: "no budget", tone: "muted" },
+  budget_exceeded: { label: "exceeded", tone: "danger" },
+  stale: { label: "stale", tone: "muted" },
+  insufficient_history: { label: "insufficient history", tone: "muted" },
+};
+
+function fmtDays(n: number): string {
+  if (n >= 365) return `${(n / 365).toFixed(1)}y`;
+  if (n >= 1) return `${Math.round(n)}d`;
+  return `${(n * 24).toFixed(1)}h`;
+}
+
+function ForecastPanel({ forecast }: { forecast: CostForecast | null }) {
+  const status = forecast?.status ?? "insufficient_history";
+  const meta = FORECAST_STATUS[status] ?? {
+    label: status.replace(/_/g, " "),
+    tone: "muted" as const,
+  };
+  const toneClass = {
+    ok: "bg-emerald-900/60 text-emerald-300",
+    warn: "bg-amber-900/60 text-amber-300",
+    danger: "bg-red-900/60 text-red-300",
+    muted: "bg-zinc-800 text-zinc-400",
+  }[meta.tone];
+
+  const hasRate = forecast?.burn_rate_usd_per_day != null;
+  const hasRunway = forecast?.days_remaining != null;
+  // At-risk when a budgeted forecast projects exhaustion within 14 days.
+  const atRisk =
+    status === "ok" &&
+    forecast?.days_remaining != null &&
+    forecast.days_remaining <= 14;
+
+  return (
+    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+      <div className="mb-3 flex items-center gap-2">
+        <CalendarClock className="h-4 w-4 text-sky-400" />
+        <h3 className="text-sm font-semibold text-zinc-300">
+          Forecast &amp; runway
+        </h3>
+        <span
+          className={`rounded-full px-2 py-0.5 text-xs font-medium ${atRisk ? "bg-amber-900/60 text-amber-300" : toneClass}`}
+        >
+          {atRisk ? "at risk" : meta.label}
+        </span>
+      </div>
+      {!hasRate && !hasRunway ? (
+        <p className="text-sm text-zinc-500">
+          {status === "insufficient_history"
+            ? "Not enough timestamped spend yet to project a burn rate. A forecast appears once at least two priced LLM calls are recorded."
+            : status === "no_budget"
+              ? "A burn rate is available, but no spend budget is configured — there is nothing to project a runway against."
+              : status === "stale"
+                ? "Recorded spend falls outside the trailing windows, so no current burn rate can be derived."
+                : "No forecast data available."}
+        </p>
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+            <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
+              <div className="mb-1 flex items-center gap-1.5">
+                <Flame className="h-3.5 w-3.5 text-orange-400" />
+                <span className="text-xs text-zinc-500">Burn / day</span>
+              </div>
+              <p className="text-lg font-bold text-zinc-100">
+                {forecast?.burn_rate_usd_per_day != null
+                  ? fmtUsd(forecast.burn_rate_usd_per_day)
+                  : "—"}
+              </p>
+              {forecast?.burn_rate_basis && (
+                <p className="mt-0.5 text-[11px] text-zinc-600">
+                  {forecast.burn_rate_basis.replace(/_/g, " ")}
+                </p>
+              )}
+            </div>
+            <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
+              <div className="mb-1 flex items-center gap-1.5">
+                <Gauge className="h-3.5 w-3.5 text-zinc-400" />
+                <span className="text-xs text-zinc-500">Runway</span>
+              </div>
+              <p
+                className={`text-lg font-bold ${atRisk ? "text-amber-300" : "text-zinc-100"}`}
+              >
+                {forecast?.days_remaining != null
+                  ? fmtDays(forecast.days_remaining)
+                  : "—"}
+              </p>
+            </div>
+            <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
+              <div className="mb-1 flex items-center gap-1.5">
+                <CalendarClock className="h-3.5 w-3.5 text-zinc-400" />
+                <span className="text-xs text-zinc-500">Exhaustion</span>
+              </div>
+              <p className="text-sm font-medium text-zinc-200">
+                {forecast?.projected_exhaustion_at
+                  ? formatDate(forecast.projected_exhaustion_at)
+                  : "—"}
+              </p>
+            </div>
+            <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
+              <div className="mb-1 flex items-center gap-1.5">
+                <TrendingUp className="h-3.5 w-3.5 text-zinc-400" />
+                <span className="text-xs text-zinc-500">Projected period</span>
+              </div>
+              <p className="text-sm font-medium text-zinc-200">
+                {forecast?.projected_period_spend_usd != null
+                  ? fmtUsd(forecast.projected_period_spend_usd)
+                  : "—"}
+              </p>
+              {forecast?.budget_limit_usd != null && (
+                <p className="mt-0.5 text-[11px] text-zinc-600">
+                  of {fmtUsd(forecast.budget_limit_usd)} cap
+                </p>
+              )}
+            </div>
+          </div>
+          <p className="mt-3 text-[11px] text-zinc-600">
+            Reference only — a forecast never blocks a call; enforcement stays at
+            the gateway.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+function ChargebackPanel({ rows }: { rows: CostBreakdownRow[] }) {
+  const top = [...rows].sort((a, b) => b.cost_usd - a.cost_usd).slice(0, 12);
+  const total = rows.reduce((sum, r) => sum + r.cost_usd, 0);
+  return (
+    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+      <div className="mb-3 flex items-center gap-2">
+        <Building2 className="h-4 w-4 text-violet-400" />
+        <h3 className="text-sm font-semibold text-zinc-300">
+          Chargeback by cost-center
+        </h3>
+      </div>
+      {top.length === 0 ? (
+        <p className="text-sm text-zinc-500">
+          No chargeback allocation recorded. Tag GenAI spans with{" "}
+          <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+            agent.cost_center
+          </code>{" "}
+          (or <code className="text-zinc-300">allocation.tag.*</code>) to attribute
+          spend to a budget unit.
+        </p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-zinc-800 text-left text-xs text-zinc-500">
+              <th className="pb-2 font-medium">Cost center</th>
+              <th className="pb-2 text-right font-medium">Calls</th>
+              <th className="pb-2 text-right font-medium">Share</th>
+              <th className="pb-2 text-right font-medium">Cost</th>
+            </tr>
+          </thead>
+          <tbody>
+            {top.map((r) => {
+              const share = total > 0 ? r.cost_usd / total : 0;
+              return (
+                <tr
+                  key={r.key}
+                  className="border-b border-zinc-900 last:border-0"
+                >
+                  <td className="py-2 font-mono text-xs text-zinc-300">
+                    {r.key || "unallocated"}
+                  </td>
+                  <td className="py-2 text-right text-zinc-400">
+                    {fmtInt(r.calls)}
+                  </td>
+                  <td className="py-2 text-right text-zinc-500">
+                    {(share * 100).toFixed(1)}%
+                  </td>
+                  <td className="py-2 text-right font-medium text-zinc-200">
+                    {fmtUsd(r.cost_usd)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
 function AnomalyRow({ a }: { a: CostAnomaly }) {
   const high = a.severity === "high";
   return (
@@ -232,13 +427,18 @@ function AnomalyRow({ a }: { a: CostAnomaly }) {
 export default function CostPage() {
   const [report, setReport] = useState<CostReport | null>(null);
   const [anomalies, setAnomalies] = useState<AnomaliesReport | null>(null);
+  const [forecast, setForecast] = useState<CostForecast | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [errorKind, setErrorKind] = useState<ApiOfflineKind>("network");
 
   useEffect(() => {
-    void Promise.allSettled([api.getCostReport(), api.getCostAnomalies()])
-      .then(([reportResult, anomalyResult]) => {
+    void Promise.allSettled([
+      api.getCostReport(),
+      api.getCostAnomalies(),
+      api.getCostForecast(),
+    ])
+      .then(([reportResult, anomalyResult, forecastResult]) => {
         if (reportResult.status === "fulfilled") {
           setReport(reportResult.value);
         } else {
@@ -249,6 +449,17 @@ export default function CostPage() {
         }
         if (anomalyResult.status === "fulfilled")
           setAnomalies(anomalyResult.value);
+        // Prefer the dedicated forecast endpoint; fall back to the block
+        // embedded on the cost report so the panel still renders if the
+        // standalone call is unavailable.
+        if (forecastResult.status === "fulfilled") {
+          setForecast(forecastResult.value);
+        } else if (
+          reportResult.status === "fulfilled" &&
+          reportResult.value.forecast
+        ) {
+          setForecast(reportResult.value.forecast);
+        }
       })
       .finally(() => setLoading(false));
   }, []);
@@ -290,6 +501,8 @@ export default function CostPage() {
       </div>
 
       <BudgetBanner budget={report.budget} />
+
+      <ForecastPanel forecast={forecast} />
 
       {!hasData ? (
         <PageEmptyState
@@ -374,6 +587,8 @@ export default function CostPage() {
             <BreakdownTable title="By model" rows={report.by_model} />
             <BreakdownTable title="By provider" rows={report.by_provider} />
           </div>
+
+          <ChargebackPanel rows={report.by_cost_center ?? []} />
         </>
       )}
 

--- a/ui/app/identity/page.tsx
+++ b/ui/app/identity/page.tsx
@@ -1,12 +1,25 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Fingerprint, KeyRound, Clock, ShieldCheck, Ban } from "lucide-react";
+import {
+  Fingerprint,
+  KeyRound,
+  Clock,
+  ShieldCheck,
+  Ban,
+  CalendarCheck,
+  Radar,
+  AlertCircle,
+} from "lucide-react";
 import { api } from "@/lib/api";
 import type {
   AgentIdentitySummary,
   JITGrant,
   ConditionalAccessPolicy,
+  CredentialExpiryReport,
+  CredentialExpiryItem,
+  AccessReviewCampaign,
+  NhiDiscoveryResponse,
 } from "@/lib/api-types";
 import { formatDate } from "@/lib/api";
 import {
@@ -119,10 +132,282 @@ function scopeSummary(p: ConditionalAccessPolicy): string {
   return parts.length ? parts.join(" · ") : "any agent / identity / tool";
 }
 
+function credStateTone(
+  state: string,
+): "red" | "amber" | "green" | "zinc" {
+  if (state === "expired" || state === "overdue") return "red";
+  if (state === "rotation_due" || state === "near_expiry") return "amber";
+  if (state === "ok") return "green";
+  return "zinc";
+}
+
+function campaignTone(status: string): "green" | "blue" | "amber" | "red" | "zinc" {
+  if (status === "completed") return "green";
+  if (status === "in_progress") return "blue";
+  if (status === "overdue") return "red";
+  if (status === "open") return "amber";
+  return "zinc";
+}
+
+function CredentialExpiryPanel({ report }: { report: CredentialExpiryReport }) {
+  const expiringStates = new Set([
+    "near_expiry",
+    "rotation_due",
+    "expired",
+    "overdue",
+  ]);
+  const overdue =
+    (report.counts.overdue ?? 0) + (report.counts.expired ?? 0);
+  const expiring =
+    (report.counts.near_expiry ?? 0) + (report.counts.rotation_due ?? 0);
+  // Show the credentials needing attention first; the API already sorts
+  // action_required worst-first.
+  const rows: CredentialExpiryItem[] =
+    report.action_required.length > 0
+      ? report.action_required
+      : report.credentials.filter((c) => expiringStates.has(c.state));
+
+  const statusTone =
+    report.status === "blocked"
+      ? "red"
+      : report.status === "attention_required"
+        ? "amber"
+        : "green";
+
+  return (
+    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+      <div className="mb-3 flex items-center gap-2">
+        <KeyRound className="h-4 w-4 text-amber-400" />
+        <h3 className="text-sm font-semibold text-zinc-300">
+          Credential expiry &amp; rotation
+        </h3>
+        <Badge tone={statusTone}>{report.status.replace(/_/g, " ")}</Badge>
+        <span className="ml-auto text-xs text-zinc-600">
+          {report.evaluated} evaluated · reference-only, no secret values
+        </span>
+      </div>
+      <div className="mb-3 grid grid-cols-3 gap-3">
+        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
+          <span className="text-xs text-zinc-500">Expired / overdue</span>
+          <p
+            className={`text-xl font-bold ${overdue > 0 ? "text-red-400" : "text-zinc-100"}`}
+          >
+            {overdue.toLocaleString()}
+          </p>
+        </div>
+        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
+          <span className="text-xs text-zinc-500">Expiring / rotation due</span>
+          <p
+            className={`text-xl font-bold ${expiring > 0 ? "text-amber-400" : "text-zinc-100"}`}
+          >
+            {expiring.toLocaleString()}
+          </p>
+        </div>
+        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
+          <span className="text-xs text-zinc-500">Healthy</span>
+          <p className="text-xl font-bold text-zinc-100">
+            {(report.counts.ok ?? 0).toLocaleString()}
+          </p>
+        </div>
+      </div>
+      {report.evaluated === 0 ? (
+        <p className="text-sm text-zinc-500">
+          No control-plane secrets or discovered NHI credentials carry an age or
+          expiry signal yet.
+        </p>
+      ) : rows.length === 0 ? (
+        <p className="text-sm text-zinc-500">
+          All evaluated credentials are within rotation and expiry bounds.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-zinc-800 text-left text-xs text-zinc-500">
+                <th className="pb-2 font-medium">Credential</th>
+                <th className="pb-2 font-medium">Provider</th>
+                <th className="pb-2 font-medium">State</th>
+                <th className="pb-2 text-right font-medium">Age</th>
+                <th className="pb-2 text-right font-medium">Expires in</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((c, i) => (
+                <tr
+                  key={`${c.id ?? c.name ?? "cred"}-${i}`}
+                  className="border-b border-zinc-900 last:border-0"
+                >
+                  <td className="py-2 font-medium text-zinc-200">
+                    {c.name ?? c.id ?? "—"}
+                  </td>
+                  <td className="py-2 text-zinc-400">{c.provider ?? "—"}</td>
+                  <td className="py-2">
+                    <Badge tone={credStateTone(c.state)}>
+                      {c.state.replace(/_/g, " ")}
+                    </Badge>
+                  </td>
+                  <td className="py-2 text-right text-zinc-400">
+                    {c.age_days != null ? `${c.age_days}d` : "—"}
+                  </td>
+                  <td className="py-2 text-right text-zinc-400">
+                    {c.days_until_expiry != null
+                      ? `${c.days_until_expiry}d`
+                      : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AccessReviewPanel({
+  campaigns,
+}: {
+  campaigns: AccessReviewCampaign[];
+}) {
+  return (
+    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+      <div className="mb-3 flex items-center gap-2">
+        <CalendarCheck className="h-4 w-4 text-emerald-400" />
+        <h3 className="text-sm font-semibold text-zinc-300">
+          Access-review campaigns
+        </h3>
+      </div>
+      {campaigns.length === 0 ? (
+        <p className="text-sm text-zinc-500">
+          No recertification campaigns. Create one via{" "}
+          <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+            POST /v1/identities/access-reviews
+          </code>{" "}
+          to schedule a review of non-human identities and their effective
+          permissions.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-zinc-800 text-left text-xs text-zinc-500">
+                <th className="pb-2 font-medium">Campaign</th>
+                <th className="pb-2 font-medium">Status</th>
+                <th className="pb-2 text-right font-medium">Reviewed</th>
+                <th className="pb-2 font-medium">Due</th>
+              </tr>
+            </thead>
+            <tbody>
+              {campaigns.map((c) => (
+                <tr
+                  key={c.campaign_id}
+                  className="border-b border-zinc-900 last:border-0"
+                >
+                  <td className="py-2 font-medium text-zinc-200">{c.name}</td>
+                  <td className="py-2">
+                    <Badge tone={campaignTone(c.status)}>
+                      {c.status.replace(/_/g, " ")}
+                    </Badge>
+                  </td>
+                  <td className="py-2 text-right text-zinc-400">
+                    {c.decided_count} / {c.item_count}
+                  </td>
+                  <td className="py-2 text-zinc-500">
+                    {c.due_at ? formatDate(c.due_at) : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NhiDiscoveryPanel({
+  discovery,
+}: {
+  discovery: NhiDiscoveryResponse | null;
+}) {
+  // No provider gated on → discovery disabled. The merge layer reports
+  // status "empty" with each provider's own gated status.
+  const enabledProviders = (discovery?.providers ?? []).filter(
+    (p) => (p.status ?? "").toLowerCase() === "ok",
+  );
+  const disabled =
+    discovery == null ||
+    (discovery.count === 0 && enabledProviders.length === 0);
+
+  return (
+    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+      <div className="mb-3 flex items-center gap-2">
+        <Radar className="h-4 w-4 text-sky-400" />
+        <h3 className="text-sm font-semibold text-zinc-300">
+          Discovered non-human identities
+        </h3>
+      </div>
+      {disabled ? (
+        <div className="flex items-start gap-2 rounded-lg border border-zinc-800 bg-zinc-900/50 p-3 text-sm text-zinc-400">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-zinc-500" />
+          <span>
+            NHI discovery is disabled. Enable an IdP connector (Okta / Entra) via
+            its <code className="text-zinc-300">*_DISCOVERY</code> environment
+            flag and token to enumerate service accounts and service principals.
+            Discovery is read-only and reference-only — it never reads secret
+            material.
+          </span>
+        </div>
+      ) : (
+        <>
+          <div className="mb-3 grid grid-cols-2 gap-3 md:grid-cols-4">
+            <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
+              <span className="text-xs text-zinc-500">Identities</span>
+              <p className="text-xl font-bold text-zinc-100">
+                {discovery.count.toLocaleString()}
+              </p>
+            </div>
+            {discovery.providers.map((p) => (
+              <div
+                key={p.provider ?? "provider"}
+                className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3"
+              >
+                <span className="text-xs capitalize text-zinc-500">
+                  {p.provider ?? "provider"}
+                </span>
+                <div className="flex items-baseline gap-2">
+                  <p className="text-xl font-bold text-zinc-100">
+                    {p.count.toLocaleString()}
+                  </p>
+                  <Badge tone={p.status === "ok" ? "green" : "zinc"}>
+                    {p.status ?? "—"}
+                  </Badge>
+                </div>
+              </div>
+            ))}
+          </div>
+          {discovery.warnings.length > 0 && (
+            <ul className="space-y-1 text-xs text-zinc-500">
+              {discovery.warnings.map((w, i) => (
+                <li key={i}>· {w}</li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 export default function IdentityPage() {
   const [identities, setIdentities] = useState<AgentIdentitySummary[]>([]);
   const [grants, setGrants] = useState<JITGrant[]>([]);
   const [policies, setPolicies] = useState<ConditionalAccessPolicy[]>([]);
+  const [credExpiry, setCredExpiry] = useState<CredentialExpiryReport | null>(
+    null,
+  );
+  const [campaigns, setCampaigns] = useState<AccessReviewCampaign[]>([]);
+  const [discovery, setDiscovery] = useState<NhiDiscoveryResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [errorKind, setErrorKind] = useState<ApiOfflineKind>("network");
@@ -132,18 +417,37 @@ export default function IdentityPage() {
       api.listIdentities(true),
       api.listJitGrants(true),
       api.listConditionalAccessPolicies(true),
+      api.getCredentialExpiry(),
+      api.listAccessReviews(),
+      api.discoverNonHumanIdentities(),
     ])
-      .then(([idResult, jitResult, polResult]) => {
-        if (idResult.status === "fulfilled") {
-          setIdentities(idResult.value.identities);
-        } else {
-          setError(idResult.reason?.message ?? "Failed to load identities");
-          setErrorKind(classifyApiErrorKind(idResult.reason));
-        }
-        if (jitResult.status === "fulfilled") setGrants(jitResult.value.grants);
-        if (polResult.status === "fulfilled")
-          setPolicies(polResult.value.policies);
-      })
+      .then(
+        ([
+          idResult,
+          jitResult,
+          polResult,
+          credResult,
+          reviewResult,
+          discoverResult,
+        ]) => {
+          if (idResult.status === "fulfilled") {
+            setIdentities(idResult.value.identities);
+          } else {
+            setError(idResult.reason?.message ?? "Failed to load identities");
+            setErrorKind(classifyApiErrorKind(idResult.reason));
+          }
+          if (jitResult.status === "fulfilled")
+            setGrants(jitResult.value.grants);
+          if (polResult.status === "fulfilled")
+            setPolicies(polResult.value.policies);
+          if (credResult.status === "fulfilled")
+            setCredExpiry(credResult.value);
+          if (reviewResult.status === "fulfilled")
+            setCampaigns(reviewResult.value.campaigns);
+          if (discoverResult.status === "fulfilled")
+            setDiscovery(discoverResult.value);
+        },
+      )
       .finally(() => setLoading(false));
   }, []);
 
@@ -172,8 +476,15 @@ export default function IdentityPage() {
     (i) => i.status === "revoked" || i.status === "expired",
   ).length;
 
+  const hasGovernanceData =
+    (credExpiry?.evaluated ?? 0) > 0 ||
+    campaigns.length > 0 ||
+    (discovery?.count ?? 0) > 0;
   const isEmpty =
-    identities.length === 0 && grants.length === 0 && policies.length === 0;
+    identities.length === 0 &&
+    grants.length === 0 &&
+    policies.length === 0 &&
+    !hasGovernanceData;
 
   return (
     <div className="space-y-6">
@@ -222,6 +533,12 @@ export default function IdentityPage() {
           icon={Fingerprint}
         />
       )}
+
+      {credExpiry && <CredentialExpiryPanel report={credExpiry} />}
+
+      <AccessReviewPanel campaigns={campaigns} />
+
+      <NhiDiscoveryPanel discovery={discovery} />
 
       {identities.length > 0 && (
         <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2099,6 +2099,42 @@ export interface CostBreakdownRow {
   unpriced_calls: number;
 }
 
+/** Forward-looking burn-rate + budget-runway projection (#2925).
+ *
+ * Mirrors `agent_bom.api.cost_forecast.forecast_spend`. Reference-only — a
+ * forecast never blocks a call. Every projection field is nullable: a sparse or
+ * empty history yields a clear `status` and `null` projections. */
+export type CostForecastStatus =
+  | "insufficient_history"
+  | "budget_exceeded"
+  | "no_budget"
+  | "stale"
+  | "ok";
+
+export interface CostForecast {
+  schema_version: string;
+  agent: string | null;
+  now: string;
+  status: CostForecastStatus | string;
+  current_spend_usd: number | null;
+  budget_limit_usd: number | null;
+  burn_rate_usd_per_day: number | null;
+  burn_rate_basis: "trailing_24h" | "trailing_7d" | string | null;
+  projected_period_spend_usd: number | null;
+  period_start: string | null;
+  period_end: string | null;
+  days_remaining: number | null;
+  projected_exhaustion_at: string | null;
+  tenant_id?: string | undefined;
+}
+
+/** One freeform allocation-tag showback slice (returned when `tag` is passed). */
+export interface CostTagRollup {
+  tag_key: string;
+  total_cost_usd: number;
+  by_tag: CostBreakdownRow[];
+}
+
 export interface CostReport {
   schema_version: string;
   tenant_id: string;
@@ -2111,6 +2147,13 @@ export interface CostReport {
   by_agent: CostBreakdownRow[];
   by_model: CostBreakdownRow[];
   by_provider: CostBreakdownRow[];
+  /** Chargeback/showback rollup by cost-center (#2925). Unallocated spend
+   *  rolls up under the `"unallocated"` key. */
+  by_cost_center?: CostBreakdownRow[] | undefined;
+  /** Present only when a `tag` query param was supplied. */
+  tag_rollup?: CostTagRollup | undefined;
+  /** Forward-looking burn-rate + runway projection embedded on the report. */
+  forecast?: CostForecast | undefined;
   budget: CostBudgetStatus;
 }
 
@@ -2242,4 +2285,113 @@ export interface DriftIncidentsResponse {
   count: number;
   open_count: number;
   incidents: DriftIncident[];
+}
+
+// ── NHI / identity governance: credential expiry, access reviews, discovery ──
+//
+// Mirrors `GET /v1/auth/secrets/credential-expiry`,
+// `GET /v1/identities/access-reviews`, and `POST /v1/identities/discover`.
+// All three are reference-only and never carry secret values.
+
+export type CredentialExpiryState =
+  | "overdue"
+  | "expired"
+  | "rotation_due"
+  | "near_expiry"
+  | "unknown_age"
+  | "ok";
+
+export interface CredentialExpiryItem {
+  id: string | null;
+  name: string | null;
+  provider: string | null;
+  identity_type: string | null;
+  state: CredentialExpiryState | string;
+  priority: number;
+  blocking: boolean;
+  age_days: number | null;
+  days_until_expiry: number | null;
+  credential_expires_at: string | null;
+  last_rotated: string | null;
+  near_expiry_days: number;
+  rotation_days: number | null;
+  max_age_days: number | null;
+  reasons: string[];
+}
+
+export interface CredentialExpiryReport {
+  status: "ok" | "attention_required" | "blocked" | string;
+  secret_values_included: boolean;
+  evaluated: number;
+  counts: Record<string, number>;
+  blockers: Array<string | null>;
+  warnings: Array<string | null>;
+  thresholds: {
+    near_expiry_days: number;
+    rotation_days: number | null;
+    max_age_days: number | null;
+  };
+  credentials: CredentialExpiryItem[];
+  action_required: CredentialExpiryItem[];
+  message: string;
+  generated_from: string;
+  control_plane_included: boolean;
+  discovered_credential_count: number;
+}
+
+export type AccessReviewStatus =
+  | "open"
+  | "in_progress"
+  | "completed"
+  | "overdue";
+
+export interface AccessReviewCampaign {
+  campaign_id: string;
+  tenant_id: string;
+  name: string;
+  status: AccessReviewStatus | string;
+  created_at: string;
+  created_by: string;
+  due_at: string;
+  completed_at: string;
+  description: string;
+  item_count: number;
+  decided_count: number;
+}
+
+export interface AccessReviewsResponse {
+  schema_version: string;
+  tenant_id: string;
+  count: number;
+  campaigns: AccessReviewCampaign[];
+}
+
+export interface NhiDiscoveryProvider {
+  provider: string | null;
+  status: string | null;
+  count: number;
+}
+
+export interface DiscoveredNonHumanIdentity {
+  identity_id: string;
+  name: string;
+  identity_type: string;
+  provider: string;
+  status: string;
+  owner?: string | null | undefined;
+  created_at?: string | null | undefined;
+  last_used_at?: string | null | undefined;
+  credential_expires_at?: string | null | undefined;
+  scopes: string[];
+  raw_identity?: Record<string, unknown> | undefined;
+}
+
+export interface NhiDiscoveryResponse {
+  schema_version: string;
+  tenant_id: string;
+  status: "ok" | "empty" | string;
+  providers: NhiDiscoveryProvider[];
+  count: number;
+  identities: DiscoveredNonHumanIdentity[];
+  warnings: string[];
 }

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -93,7 +93,11 @@ import type {
   IdentitiesResponse,
   JITGrantsResponse,
   ConditionalAccessResponse,
-  DriftIncidentsResponse
+  DriftIncidentsResponse,
+  CostForecast,
+  CredentialExpiryReport,
+  AccessReviewsResponse,
+  NhiDiscoveryResponse
 } from "./api-types";
 export type {
   JobStatus,
@@ -253,6 +257,18 @@ export type {
   JITGrantsResponse,
   ConditionalAccessResponse,
   DriftIncidentsResponse,
+  CostForecast,
+  CostForecastStatus,
+  CostTagRollup,
+  CredentialExpiryState,
+  CredentialExpiryItem,
+  CredentialExpiryReport,
+  AccessReviewStatus,
+  AccessReviewCampaign,
+  AccessReviewsResponse,
+  NhiDiscoveryProvider,
+  DiscoveredNonHumanIdentity,
+  NhiDiscoveryResponse,
 } from "./api-types";
 export type { MitreAtlasCatalogMetadata } from "./api-types";
 
@@ -877,10 +893,19 @@ export const api = {
   getAuditLog: (limit?: number) => get<{ entries: AuditEntry[] }>(`/v1/audit?limit=${limit ?? 10}`),
 
   // ── Cost / FinOps cockpit ──
-  getCostReport: (agent?: string) =>
-    get<CostReport>(`/v1/observability/costs${agent ? `?agent=${encodeURIComponent(agent)}` : ""}`),
+  getCostReport: (filters?: { agent?: string; costCenter?: string; tag?: string }) => {
+    const params = new URLSearchParams();
+    if (filters?.agent) params.set("agent", filters.agent);
+    if (filters?.costCenter) params.set("cost_center", filters.costCenter);
+    if (filters?.tag) params.set("tag", filters.tag);
+    const qs = params.toString();
+    return get<CostReport>(`/v1/observability/costs${qs ? `?${qs}` : ""}`);
+  },
   getCostBudget: (agent?: string) =>
     get<CostBudgetStatus>(`/v1/observability/costs/budget${agent ? `?agent=${encodeURIComponent(agent)}` : ""}`),
+  /** Forward-looking burn-rate + budget-runway projection (reference only) */
+  getCostForecast: (agent?: string) =>
+    get<CostForecast>(`/v1/observability/costs/forecast${agent ? `?agent=${encodeURIComponent(agent)}` : ""}`),
   getCostAnomalies: (zThreshold?: number) =>
     get<AnomaliesReport>(`/v1/observability/anomalies${zThreshold ? `?z_threshold=${zThreshold}` : ""}`),
 
@@ -891,6 +916,17 @@ export const api = {
     get<JITGrantsResponse>(`/v1/identity-jit-grants?include_inactive=${includeInactive}&limit=${limit}`),
   listConditionalAccessPolicies: (includeDisabled = false, limit = 200) =>
     get<ConditionalAccessResponse>(`/v1/conditional-access-policies?include_disabled=${includeDisabled}&limit=${limit}`),
+
+  // ── NHI / identity governance: credential expiry, access reviews, discovery ──
+  /** Non-secret credential expiry / rotation governance posture */
+  getCredentialExpiry: () =>
+    get<CredentialExpiryReport>("/v1/auth/secrets/credential-expiry"),
+  /** Access-review / recertification campaigns over discovered NHIs */
+  listAccessReviews: (limit = 200) =>
+    get<AccessReviewsResponse>(`/v1/identities/access-reviews?limit=${limit}`),
+  /** Read-only NHI discovery summary (gated by *_DISCOVERY env flags) */
+  discoverNonHumanIdentities: (providers?: string[]) =>
+    post<NhiDiscoveryResponse>("/v1/identities/discover", providers ? { providers } : {}),
 
   // ── Drift / behavior-incident cockpit ──
   listDriftIncidents: (includeResolved = false, limit = 200) =>

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -14,7 +14,8 @@ const BUDGETS = {
   // Allows measured framework/runtime drift from the June 2026 UI dependency refresh.
   // Includes the parity governance cockpits for cost, identity, and drift.
   // Includes the Gateway Live Feed tab for tool-call auth, DLP, and LLM-call events.
-  totalClientJsBytes: 2_970_000,
+  // Includes cost forecast/chargeback and NHI governance console panels.
+  totalClientJsBytes: 3_020_000,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };

--- a/ui/tests/cockpits.test.tsx
+++ b/ui/tests/cockpits.test.tsx
@@ -15,9 +15,13 @@ const { apiMock } = vi.hoisted(() => ({
   apiMock: {
     getCostReport: vi.fn(),
     getCostAnomalies: vi.fn(),
+    getCostForecast: vi.fn(),
     listIdentities: vi.fn(),
     listJitGrants: vi.fn(),
     listConditionalAccessPolicies: vi.fn(),
+    getCredentialExpiry: vi.fn(),
+    listAccessReviews: vi.fn(),
+    discoverNonHumanIdentities: vi.fn(),
     listDriftIncidents: vi.fn(),
     resolveDriftIncident: vi.fn(),
     formatDate: (s: string) => s,
@@ -78,6 +82,24 @@ describe("CostPage", () => {
           unpriced_calls: 0,
         },
       ],
+      by_cost_center: [
+        {
+          key: "platform-eng",
+          calls: 30,
+          input_tokens: 700,
+          output_tokens: 350,
+          cost_usd: 9.0,
+          unpriced_calls: 0,
+        },
+        {
+          key: "unallocated",
+          calls: 12,
+          input_tokens: 300,
+          output_tokens: 150,
+          cost_usd: 3.5,
+          unpriced_calls: 3,
+        },
+      ],
       budget: {
         configured: true,
         agent: null,
@@ -88,6 +110,22 @@ describe("CostPage", () => {
         exceeded: false,
         utilization: 0.625,
       },
+    });
+    apiMock.getCostForecast.mockResolvedValue({
+      schema_version: "observability.cost_forecast.v1",
+      agent: null,
+      now: "2026-06-18T00:00:00Z",
+      status: "ok",
+      current_spend_usd: 12.5,
+      budget_limit_usd: 20,
+      burn_rate_usd_per_day: 1.25,
+      burn_rate_basis: "trailing_24h",
+      projected_period_spend_usd: 18.0,
+      period_start: "2026-06-01T00:00:00Z",
+      period_end: "2026-07-01T00:00:00Z",
+      days_remaining: 6,
+      projected_exhaustion_at: "2026-06-24T00:00:00Z",
+      tenant_id: "t1",
     });
     apiMock.getCostAnomalies.mockResolvedValue({
       schema_version: "observability.anomalies.v1",
@@ -117,6 +155,13 @@ describe("CostPage", () => {
     expect(screen.getByText("enforce")).toBeInTheDocument();
     expect(screen.getAllByText(/\$12\.5/).length).toBeGreaterThan(0);
     expect(screen.getByText("cost spike")).toBeInTheDocument();
+    // Forecast/runway panel
+    expect(screen.getByText("Forecast & runway")).toBeInTheDocument();
+    expect(screen.getByText("at risk")).toBeInTheDocument();
+    expect(screen.getByText("trailing 24h")).toBeInTheDocument();
+    // Chargeback by cost-center panel
+    expect(screen.getByText("Chargeback by cost-center")).toBeInTheDocument();
+    expect(screen.getByText("platform-eng")).toBeInTheDocument();
   });
 });
 
@@ -196,6 +241,71 @@ describe("IdentityPage", () => {
         },
       ],
     });
+    apiMock.getCredentialExpiry.mockResolvedValue({
+      status: "attention_required",
+      secret_values_included: false,
+      evaluated: 2,
+      counts: { overdue: 0, expired: 0, rotation_due: 1, near_expiry: 0, unknown_age: 0, ok: 1 },
+      blockers: [],
+      warnings: ["audit_hmac_secret"],
+      thresholds: { near_expiry_days: 14, rotation_days: 90, max_age_days: null },
+      credentials: [],
+      action_required: [
+        {
+          id: "audit_hmac_secret",
+          name: "audit_hmac_secret",
+          provider: "control_plane",
+          identity_type: "secret",
+          state: "rotation_due",
+          priority: 2,
+          blocking: false,
+          age_days: 120,
+          days_until_expiry: null,
+          credential_expires_at: null,
+          last_rotated: "2026-02-01T00:00:00Z",
+          near_expiry_days: 14,
+          rotation_days: 90,
+          max_age_days: null,
+          reasons: ["age 120d past rotation interval 90d"],
+        },
+      ],
+      message: "One or more credentials are nearing expiry.",
+      generated_from: "/v1/auth/secrets/credential-expiry",
+      control_plane_included: true,
+      discovered_credential_count: 0,
+    });
+    apiMock.listAccessReviews.mockResolvedValue({
+      schema_version: "identity.access_review.v1",
+      tenant_id: "t1",
+      count: 1,
+      campaigns: [
+        {
+          campaign_id: "rev_1",
+          tenant_id: "t1",
+          name: "Q3 NHI recertification",
+          status: "in_progress",
+          created_at: "2026-06-01T00:00:00Z",
+          created_by: "admin",
+          due_at: "2026-06-30T00:00:00Z",
+          completed_at: "",
+          description: "",
+          item_count: 8,
+          decided_count: 3,
+        },
+      ],
+    });
+    apiMock.discoverNonHumanIdentities.mockResolvedValue({
+      schema_version: "identity.nhi.discovery.v1",
+      tenant_id: "t1",
+      status: "empty",
+      providers: [
+        { provider: "okta", status: "disabled", count: 0 },
+        { provider: "entra", status: "disabled", count: 0 },
+      ],
+      count: 0,
+      identities: [],
+      warnings: [],
+    });
 
     render(<IdentityPage />);
 
@@ -207,6 +317,20 @@ describe("IdentityPage", () => {
     expect(screen.getByText("prod-only")).toBeInTheDocument();
     expect(screen.getByText(/env ∈ \{prod\}/)).toBeInTheDocument();
     expect(screen.getByText("INC-42")).toBeInTheDocument();
+    // Credential-expiry posture
+    expect(
+      screen.getByText("Credential expiry & rotation"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("audit_hmac_secret")).toBeInTheDocument();
+    // Access-review campaigns
+    expect(screen.getByText("Access-review campaigns")).toBeInTheDocument();
+    expect(screen.getByText("Q3 NHI recertification")).toBeInTheDocument();
+    expect(screen.getByText("3 / 8")).toBeInTheDocument();
+    // Discovered NHI — disabled state
+    expect(
+      screen.getByText("Discovered non-human identities"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/NHI discovery is disabled/)).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
Surfaces the recently-shipped cost-FinOps and NHI-governance capabilities in the human console (they were API/CLI-only). Every panel maps to a real endpoint field — no fabricated metrics.

**Cost page** (`ui/app/cost/page.tsx`):
- **Forecast & runway** — burn rate/day, runway, projected exhaustion date, status badge (ok/at-risk ≤14d/exceeded). Wired to `GET /v1/observability/costs/forecast` (+ embedded `forecast` block). Honest empty states.
- **Chargeback by cost-center** — spend/calls/% share from `by_cost_center`.

**Identity page** (`ui/app/identity/page.tsx`):
- **Credential expiry & rotation** — expired/overdue + expiring counts + action table (no secret values) from `GET /v1/auth/secrets/credential-expiry`.
- **Access-review campaigns** — status/due/item counts from `/v1/identities/access-reviews`.
- **Discovered NHIs** — per-provider counts from `/v1/identities/discover`, friendly disabled state.

Types/methods added to `lib/api-types.ts` + `lib/api.ts`; nav already had /cost + /identity.

## Verification
lint + typecheck + build pass (static export, /cost + /identity prerendered); 261 vitest tests pass (extended cockpits smoke tests for all 5 panels). Matches the existing zinc/Tailwind design system.