### PR TITLE
fix(glama): add root glama.json + improve low-scoring tool descriptions

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "msaad00"
+  ],
+  "name": "agent-bom",
+  "title": "agent-bom",
+  "description": "Open security scanner and self-hosted control plane for AI/MCP infrastructure. Discovers agents, MCP servers, models, and runtime traffic; scans for vulnerable packages, prompt-injection, license violations, and risky tool capabilities; and maps blast radius across a security graph. Exposes 69 read-first MCP tools for headless security agents.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/msaad00/agent-bom"
+  },
+  "homepage": "https://github.com/msaad00/agent-bom",
+  "transport": "stdio",
+  "command": "agent-bom",
+  "args": [
+    "mcp",
+    "server"
+  ],
+  "dockerfile": "integrations/glama/Dockerfile",
+  "environmentVariables": {
+    "NVD_API_KEY": {
+      "description": "NVD API key for higher rate limits on vulnerability enrichment",
+      "required": false
+    }
+  },
+  "categories": [
+    "security",
+    "developer-tools"
+  ],
+  "tags": [
+    "security",
+    "sbom",
+    "supply-chain",
+    "ai-security",
+    "mcp",
+    "cloud-security",
+    "vulnerability-scanning",
+    "prompt-injection",
+    "compliance",
+    "license-compliance"
+  ],
+  "relatedServers": [
+    {
+      "name": "filesystem",
+      "url": "https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem",
+      "reason": "Reference MCP server commonly paired for local artifact access during scans."
+    },
+    {
+      "name": "git",
+      "url": "https://github.com/modelcontextprotocol/servers/tree/main/src/git",
+      "reason": "Reference MCP server for repository inspection alongside dependency and SBOM scanning."
+    }
+  ]
+}

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -725,7 +725,28 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
         warn_risk: Annotated[float, Field(ge=0, le=100, description="Risk score at or above which the decision becomes warn.")] = 40.0,
         block_risk: Annotated[float, Field(ge=0, le=100, description="Risk score at or above which the decision becomes block.")] = 80.0,
     ) -> str:
-        """Return an agent-native deploy gate decision from graph risk."""
+        """Return an allow / warn / block deploy decision from graph exposure risk.
+
+        Resolves a deployment candidate against the latest security-graph
+        snapshot, ranks its reachable ExposurePaths by risk score, and maps the
+        top score to a gate decision using the warn/block thresholds.
+
+        Args:
+            candidate: Package, resource, CVE, graph node ID, or deployment
+                label to evaluate.
+            tenant_id: Tenant whose graph snapshot to read (default ``default``).
+            scan_id: Specific graph scan ID; omit to use the latest snapshot.
+            limit: Maximum matched exposure paths to return (1-25).
+            warn_risk: Risk score at or above which the decision becomes warn.
+            block_risk: Risk score at or above which the decision becomes block.
+
+        Returns:
+            JSON with the ``decision`` (allow/warn/block), the driving risk
+            score, and the ranked exposure paths behind it.
+
+        Call this as a pre-deployment gate to get a single machine-readable
+        verdict instead of interpreting raw findings.
+        """
         return await _execute_tool_async(
             "should_i_deploy",
             deploy_decision_impl,

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -36,7 +36,10 @@ _SERVER_CARD_TOOLS = [
     },
     {
         "name": "should_i_deploy",
-        "description": "Return allow/warn/block deployment guidance from ExposurePath risk",
+        "description": (
+            "Pre-deployment gate: resolves a candidate (package, CVE, resource, or graph node) against the"
+            " latest security-graph snapshot and returns an allow/warn/block decision from its top ExposurePath risk score"
+        ),
         "annotations": {"readOnlyHint": True},
     },
     {
@@ -81,7 +84,10 @@ _SERVER_CARD_TOOLS = [
     },
     {
         "name": "tool_risk_assessment",
-        "description": "Use live tools/list introspection to score MCP tool capabilities and server risk",
+        "description": (
+            "Live-introspect configured MCP servers via tools/list and score each exposed tool by capability"
+            " (filesystem, network, code execution, credential access) to rate per-tool and per-server blast radius"
+        ),
         "annotations": {"readOnlyHint": True},
     },
     {
@@ -223,7 +229,10 @@ _SERVER_CARD_TOOLS = [
     },
     {
         "name": "audit_query",
-        "description": "Read tenant-scoped control-plane audit records with action, resource, time, and pagination filters",
+        "description": (
+            "Read the immutable hash-chained control-plane audit log for one tenant — filter identity/shield/firewall/policy"
+            " actions by action, resource, and time with pagination; read-only and never mutates enforcement state"
+        ),
         "annotations": {"readOnlyHint": True},
     },
     {
@@ -268,7 +277,10 @@ _SERVER_CARD_TOOLS = [
     },
     {
         "name": "prompt_scan",
-        "description": "Scan prompt template files for injection risks and unsafe variable interpolation",
+        "description": (
+            "Statically scan prompt template files (.prompt, system_prompt.*, prompts/) for prompt-injection patterns"
+            " and unsafe variable interpolation; returns per-file findings with rule id, severity, and line"
+        ),
         "annotations": {"readOnlyHint": True},
     },
     {
@@ -284,8 +296,9 @@ _SERVER_CARD_TOOLS = [
     {
         "name": "license_compliance_scan",
         "description": (
-            "Evaluate package licenses against SPDX compliance policy"
-            " — 2,500+ licenses, network-copyleft detection, deprecated ID normalization"
+            "Classify each package license as allowed/warn/blocked against an SPDX policy"
+            " — 2,500+ licenses, network-copyleft detection, deprecated ID normalization; takes a prior scan"
+            " result or an explicit package array and returns per-package verdicts with counts"
         ),
         "annotations": {"readOnlyHint": True},
     },

--- a/src/agent_bom/mcp_server_operator_tools.py
+++ b/src/agent_bom/mcp_server_operator_tools.py
@@ -922,7 +922,28 @@ def register_operator_tools(
             Field(ge=0, description="Pagination offset."),
         ] = 0,
     ) -> str:
-        """Read tenant-scoped control-plane audit records."""
+        """Read tenant-scoped control-plane audit records with filters and paging.
+
+        Returns the immutable, hash-chained audit log of control-plane actions
+        (identity, shield, firewall, and policy changes) for one tenant, with
+        optional filtering by action, resource, and start time. Read-only: it
+        never mutates enforcement state.
+
+        Args:
+            tenant_id: Tenant scope to read (default control-plane tenant).
+            action: Optional audit action filter (exact match).
+            resource: Optional audit resource filter (exact match).
+            since: Optional ISO-8601 timestamp lower bound.
+            limit: Maximum audit records to return (1-1000).
+            offset: Pagination offset.
+
+        Returns:
+            JSON with the matched audit records (actor, action, resource,
+            timestamp, chain position) and pagination metadata.
+
+        Call this to review who changed what in the control plane; pair with
+        ``audit_integrity`` to verify the chain has not been tampered with.
+        """
         return await execute_tool_async(
             "audit_query",
             audit_query_impl,

--- a/src/agent_bom/mcp_server_runtime_catalog.py
+++ b/src/agent_bom/mcp_server_runtime_catalog.py
@@ -86,7 +86,26 @@ def register_runtime_catalog_tools(
         config_path: Annotated[str | None, Field(description="Path to MCP client config directory. Auto-discovers all if omitted.")] = None,
         timeout: Annotated[float, Field(description="Per-server introspection timeout in seconds.")] = 10.0,
     ) -> str:
-        """Score live-introspected MCP tool capabilities and server risk."""
+        """Live-introspect MCP servers and score each tool's capability risk.
+
+        Discovers configured MCP clients, connects to their servers, calls
+        ``tools/list``, and classifies every exposed tool by capability
+        (filesystem, network, code execution, credential access) to produce a
+        per-tool and per-server risk score from what the servers actually
+        advertise at runtime.
+
+        Args:
+            config_path: MCP client config directory to read; auto-discovers all
+                supported clients when omitted.
+            timeout: Per-server introspection timeout in seconds.
+
+        Returns:
+            JSON with per-server tool inventories, per-tool capability classes
+            and risk levels, and an aggregate server risk rating.
+
+        Use this to assess the blast radius of MCP servers an agent can reach
+        before granting or trusting their tools.
+        """
         return await execute_tool_sync_async(
             "tool_risk_assessment",
             tool_risk_assessment_impl,

--- a/src/agent_bom/mcp_server_specialized.py
+++ b/src/agent_bom/mcp_server_specialized.py
@@ -162,7 +162,24 @@ def register_specialized_ai_tools(
             Field(description="Directory path to scan for prompt template files (.prompt, system_prompt.*, prompts/ directories)."),
         ],
     ) -> str:
-        """Scan prompt template files for injection risks and security issues."""
+        """Scan prompt template files for prompt-injection and unsafe-interpolation risks.
+
+        Walks the given directory for prompt assets (``.prompt`` files,
+        ``system_prompt.*``, and ``prompts/`` directories), then statically
+        inspects each template for injection-prone patterns and unsafe variable
+        interpolation (untrusted input concatenated into instructions, missing
+        delimiters, tool/role-confusion phrasing).
+
+        Args:
+            directory: Directory path to scan for prompt template files.
+
+        Returns:
+            JSON with the scanned files, per-file findings (rule id, severity,
+            line, message), and a summary count by severity.
+
+        Use this before shipping or registering agent prompts to catch
+        injection exposure that package and CVE scans do not cover.
+        """
         return await execute_tool_async(
             "prompt_scan",
             prompt_scan_impl,
@@ -223,7 +240,28 @@ def register_specialized_ai_tools(
             ),
         ] = "",
     ) -> str:
-        """Evaluate package licenses against compliance policy."""
+        """Evaluate package licenses against an SPDX compliance policy.
+
+        Takes packages (either a prior ``scan`` result JSON or an explicit array
+        of ``{name, version, ecosystem, license}`` objects) and classifies each
+        license as allowed, warn, or blocked. Normalizes 2,500+ SPDX IDs
+        (including deprecated identifiers) and flags network-copyleft licenses
+        (AGPL/SSPL/BUSL and similar).
+
+        Args:
+            scan_json: JSON of a previous scan result, or a JSON array of
+                package objects with license metadata.
+            policy_json: Optional JSON policy with ``license_block`` /
+                ``license_warn`` glob lists. Falls back to the built-in policy
+                (block strong/network copyleft, warn weak copyleft) when empty.
+
+        Returns:
+            JSON with per-package license verdicts, the matched policy rule,
+            and counts of blocked / warned / allowed packages.
+
+        Call this in release or procurement gates to enforce license policy on
+        an agent's dependency set without running a full scan.
+        """
         return await execute_tool_async(
             "license_compliance_scan",
             license_compliance_scan_impl,


### PR DESCRIPTION
Addresses Glama directory profile gaps (was 75% complete).
- **Root `glama.json`** (schema-validated): name/title/description/license/repo/homepage/transport/command, categories (security, developer-tools), 10 tags, and `relatedServers` (vendor-neutral MCP reference servers only — no competitor brands).
- **5 low-scoring tool descriptions rewritten** (`prompt_scan`, `should_i_deploy`, `tool_risk_assessment`, `license_compliance_scan`, `audit_query`) in both live `@mcp.tool` docstrings + the static server card — each now states what it does / takes / returns / when to call it (Glama's Tool Definition Quality signal).
- Naming audit: 8 short single-token names flagged (kept intentionally — `scan`/`check` are good Docker-CLI-style names; renaming would break the agent-facing API).
- Tool count unchanged at **69**; 105 MCP tests pass; release-consistency exit 0.