### PR TITLE
docs: align README + Docker/PyPI descriptions with current capabilities

### DIFF
--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -2,9 +2,9 @@
 
 **Open security scanner and self-hosted control plane for AI/MCP infrastructure.**
 
-`agent-bom` follows package, agent, MCP, credential-name, cloud, runtime, and
-skill evidence into one reachability-backed AI BOM, then tells humans and AI
-agents which exposure path to fix first.
+`agent-bom` follows package, agent, MCP, credential-name, cloud estate,
+non-human identity, runtime, and skill evidence into one reachability-backed AI
+BOM, then tells humans and AI agents which multi-hop exposure path to fix first.
 
 Blast radius is the core idea:
 
@@ -103,22 +103,29 @@ docker run --rm -v "$(pwd):/workspace" agentbom/agent-bom:latest iac /workspace
 ## What You Get
 
 - Blast radius from package to server to agent to credentials and tools
-- AI/MCP coverage across agents, MCP, skills, runtime, containers, cloud, IaC,
-  and GPU
-- One evidence model across CLI, CI, API, dashboard, reports, and MCP tools
-- ExposurePath-driven graph investigation for humans and headless agent
-  workflows
-- Runtime MCP protection plus broader review and tamper-evident evidence exports
+- AI/MCP coverage across agents, MCP, skills, AI models/datasets, runtime,
+  containers, cloud, IaC, and GPU
+- Supply-chain scanning across 15 package ecosystems with OSV/GHSA enrichment
+- Cloud estate inventory (AWS/Azure/GCP, read-only), non-human identity
+  governance (NHI discovery, credential-expiry, access review), and LLM cost
+  forecasting with chargeback and spend-anomaly detection
+- Malicious-model detection via safe pickle-opcode disassembly (no execution)
+- One unified `Finding` model and `ContextGraph` across CLI, CI, API,
+  dashboard, reports, and MCP tools
+- Multi-hop attack-path fusion for humans and headless agent workflows
+- Runtime MCP protection — inline firewall enforcement, secure-by-default
+  gateway, A2A/MCP auth-posture checks — plus tamper-evident evidence exports
 
 ## Product Surfaces
 
 The promoted self-hosted rollout is a scoped operator stack, not one forced
 runtime monolith. Teams typically deploy only the surfaces they need:
 
-- **scan**: discovery, inventory, CVE, image, IaC, Kubernetes, and cloud analysis
+- **scan**: discovery, inventory, CVE, image, IaC, Kubernetes, cloud estate, AI model/dataset, and supply-chain analysis
 - **fleet**: endpoint and collector inventory pushed into the control plane
-- **proxy / runtime**: inline MCP enforcement near selected workloads
-- **gateway**: central policy management for those runtime paths
+- **identity / cost**: non-human identity governance and LLM spend forecasting, chargeback, and anomaly detection
+- **proxy / runtime**: inline MCP firewall enforcement near selected workloads
+- **gateway**: secure-by-default central policy management for those runtime paths
 - **API + UI**: the operator plane for findings, graph, remediation, audit, and policy workflows
 
 ## Control-Plane Contract

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -21,7 +21,7 @@ better-sqlite3@9.0.0  (npm package)
 
 Blast radius is the core idea: `package -> vulnerability finding -> MCP server (tools + credential env names) -> connected agents`. This schematic explains the model; emitted findings are backed by the configured advisory sources.
 
-Scan local agent configs, MCP servers, instruction files, lockfiles, containers, cloud posture, GPU surfaces, and runtime evidence.
+Scan local agent configs, MCP servers, instruction files, lockfiles, containers, cloud estate, AI models/datasets, non-human identities, LLM cost, GPU surfaces, and runtime evidence.
 
 Try the built-in demo first:
 
@@ -101,18 +101,21 @@ helm upgrade --install agent-bom deploy/helm/agent-bom \
 
 - **Agents + MCP** — MCP clients, servers, tools, transports, trust posture
 - **Skills + instructions** — `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `.windsurfrules`, `skills/*`
-- **Package risk** — software supply chain scanning with enrichment and blast radius
+- **Package risk** — supply-chain scanning across 15 package ecosystems with OSV/GHSA enrichment and blast radius
+- **AI models + datasets** — malicious-model detection via safe pickle-opcode disassembly (no execution), model/dataset cards, and PII/PHI dataset scanning
 - **Container images + IaC** — native OCI parsing plus Dockerfile, Terraform, CloudFormation, Helm, and Kubernetes coverage
-- **Cloud AI** — cloud and AI infrastructure posture across major supported providers
-- **Secrets + runtime** — MCP proxy, Shield SDK, secrets, and redaction surfaces
+- **Cloud estate** — read-only, gated asset inventory across AWS/Azure/GCP plus AI/GPU posture and CIS benchmarks
+- **Identity (NHI)** — non-human identity discovery (Okta/Entra), credential-expiry posture, and access-review campaigns
+- **LLM cost** — spend forecasting, budget runway, chargeback/allocation, and seasonal-aware spend-anomaly detection
+- **Secrets + runtime** — MCP proxy/gateway, inline firewall enforcement, A2A/MCP auth posture, Shield SDK, secrets, and redaction surfaces
 - **Compliance + evidence** — mapped governance plus ZIP evidence bundles for auditors
 
 ## Key features
 
-- **Blast radius mapping** — package → vulnerability finding → MCP server (tools + credential env names) → connected agents
+- **Blast radius + attack-path fusion** — multi-hop exposure paths over one unified `ContextGraph`, from package → finding → MCP server → credentials → connected agents
 - **CWE-aware impact** — RCE shows credential exposure, DoS does not
-- **Portable outputs** — SARIF, CycloneDX, SPDX, HTML, graph, JSON, ZIP evidence bundles, and more
-- **MCP server mode** — expose `agent-bom` capabilities directly to MCP clients like Claude, Cursor, Windsurf, and Cortex CoCo / Cortex Code
+- **Portable outputs** — SARIF, CycloneDX, SPDX, OCSF, HTML, graph, JSON, ZIP evidence bundles, and more
+- **MCP server mode** — 69 MCP tools, 6 resources, and 6 workflow prompts exposed to MCP clients like Claude, Cursor, Windsurf, and Cortex CoCo / Cortex Code
 - **Skill bundle identity** — stable bundle hashes for skill and instruction file review
 - **Dependency confusion detection** — flags internal naming patterns
 - **VEX generation** — auto-triage with CWE-aware reachability

--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@
 </p>
 
 `agent-bom` scans local and fleet AI infrastructure, builds an AI BOM across
-agents, MCP servers, tools, packages, credential environment names, cloud,
-runtime, and skills, then turns that inventory into findings, compliance
-evidence, and graph-backed exposure paths.
+agents, MCP servers, tools, packages, credential environment names, cloud
+estate, non-human identities, runtime, and skills, then turns that inventory
+into findings, compliance evidence, LLM cost posture, and graph-backed
+multi-hop exposure paths.
 
 The same evidence is available through CLI/CI, REST API, MCP tools, and a
-self-hosted dashboard. Runtime proxy/gateway controls are optional and scoped
+self-hosted dashboard. Runtime proxy/gateway controls — including inline
+firewall enforcement and a secure-by-default gateway — are optional and scoped
 to environments where enforcement is worth the operational cost.
 
 <p align="center">
@@ -53,6 +55,24 @@ package
 Blast radius is the core idea. A vulnerable package is not just a CVE row; it
 is linked to the MCP server that loads it, the tools exposed by that server,
 the credential environment names in reach, and the agents that can call it.
+
+## What It Scans
+
+| Domain | Coverage |
+|---|---|
+| Supply chain | 15 package ecosystems (npm, PyPI, Maven, Go, Cargo, NuGet, Composer, RubyGems, conda, Hex, Pub, Swift, plus OS packages apk/deb/rpm) with OSV/GHSA enrichment, transitive resolution, and dependency-confusion detection |
+| Agents + MCP | MCP clients, servers, tools, transports, trust posture, and live introspection across 29 first-class client types |
+| AI models + datasets | Malicious-model detection via safe pickle-opcode disassembly (no deserialization), model/dataset cards, and PII/PHI dataset scanning |
+| Cloud estate | Read-only, gated asset inventory across AWS, Azure, and GCP plus AI/GPU provider posture and CIS benchmarks |
+| Identity (NHI) | Non-human identity discovery (Okta/Entra, gated), credential-expiry posture, and access-review recertification campaigns |
+| LLM cost | Spend forecasting, budget runway, chargeback/allocation, and seasonal-aware spend-anomaly detection |
+| Containers + IaC | Native OCI image parsing plus Dockerfile, Terraform, CloudFormation, Helm, and Kubernetes |
+| Secrets + runtime | Secret detection, MCP proxy/gateway, A2A and MCP auth-posture checks, inline firewall enforcement, and redaction surfaces |
+| Compliance | Mapped governance frameworks plus ZIP evidence bundles for auditors |
+
+Findings converge on one unified `Finding` model and a unified `ContextGraph`,
+so multi-hop attack-path fusion, blast radius, and exposure scoring all read
+from the same evidence.
 
 <p align="center">
   <picture>
@@ -201,6 +221,9 @@ Screenshot capture rules and the full manifest live in
 | Container image scan | `agent-bom image nginx:latest` | image findings and remediation |
 | IaC scan | `agent-bom iac Dockerfile k8s/ infra/main.tf` | IaC findings and policy context |
 | Cloud posture check | `agent-bom cloud aws --cis` | runtime CIS posture evidence |
+| Cloud estate inventory | `agent-bom cloud inventory --provider aws` | read-only, gated asset inventory (AWS/Azure/GCP) |
+| LLM cost forecast | `agent-bom cost forecast` | spend burn-rate, budget runway, and chargeback posture |
+| Non-human identity posture | `agent-bom identity credential-expiry` | expiring/overdue NHI credentials and access reviews |
 | CI gate | `uses: msaad00/agent-bom@v0.88.6` | SARIF, PR summary, optional code-scanning upload |
 | MCP tools | `pip install 'agent-bom[mcp-server]' && agent-bom mcp server` | strict-args security tools for MCP clients |
 | Local API/UI | `pip install 'agent-bom[ui]' && agent-bom serve` | API plus bundled dashboard |
@@ -271,7 +294,7 @@ boundaries are documented in [docs/PRODUCT_BOUNDARIES.md](docs/PRODUCT_BOUNDARIE
 - No mandatory telemetry.
 - Credential values are redacted; credential environment names are preserved as
   evidence so exposure paths stay explainable.
-- Findings can export as JSON, SARIF, CycloneDX, SPDX, Markdown, HTML, and
+- Findings can export as JSON, SARIF, CycloneDX, SPDX, OCSF, Markdown, HTML, and
   compliance evidence bundles.
 - API and runtime paths are designed for tenant scope, auth boundaries, and
   audit evidence.

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -7,9 +7,11 @@ model.
 
 `agent-bom` is also an open security data plane. It generates a
 reachability-backed AI BOM across agents, MCP servers, tools, packages,
-credential environment names, cloud, runtime, and skill surfaces, then exposes
-the same evidence to humans and AI agents through CLI/CI, API/UI, MCP tools,
-and selected runtime controls. For source-by-source boundaries, see the
+credential environment names, cloud estate, non-human identities, runtime, and
+skill surfaces, then exposes the same evidence — findings, compliance, LLM cost
+posture, and multi-hop attack paths — to humans and AI agents through CLI/CI,
+API/UI, MCP tools, and selected runtime controls. For source-by-source
+boundaries, see the
 [AI infrastructure coverage matrix](architecture/ai-infrastructure.md#coverage-matrix).
 
 ## What it does


### PR DESCRIPTION
Refreshes the published description surfaces (GitHub/Docker Hub/PyPI) to the current shipped feature set — they were stale by ~80 commits.
- **README.md + DOCKER_HUB_README.md + PYPI_README.md + site-docs** updated: capability matrix, new CLI groups, cloud inventory, attack-path fusion, NHI governance, cost FinOps, A2A/MCP auth posture, malicious-model detection, firewall enforcement — **each verified in code before claiming**.
- **Count corrections:** 15 package ecosystems (`SUPPORTED_PACKAGE_ECOSYSTEMS`), 69 MCP tools / 6 resources / 6 prompts, added OCSF to outputs.
- release-consistency exit 0; no competitor names; quickstart verified.