### PR TITLE
feat(scan): scan a public repo by URL (scan --repo / repo_url MCP arg)

### DIFF
--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -140,6 +140,13 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_POSTGRES_POOL_MIN_SIZE` | `int` | `5` | Used by api/postgres_store.py and shared Postgres-backed control-plane services such as the distributed rate limiter.  Defaults target multi-replica self-hosted control planes rather than a single local developer process. |
 | `AGENT_BOM_POSTGRES_STATEMENT_TIMEOUT_MS` | `int` | `15000` | — |
 
+## Public-repo clone-and-scan bounds
+| Env var | Type | Default | Description |
+|---|---|---|---|
+| `AGENT_BOM_REPO_SCAN_CLONE_TIMEOUT_SECONDS` | `float` | `120.0` | Max wall-clock seconds for the `git clone` step before it is aborted. |
+| `AGENT_BOM_REPO_SCAN_MAX_FILES` | `int` | `100000` | Max number of files in the cloned working tree. |
+| `AGENT_BOM_REPO_SCAN_MAX_SIZE_BYTES` | `int` | `1024 * 1024 * 1024` | Max total on-disk size (bytes) of the cloned working tree. Default 1 GiB. |
+
 ## Rate-limit fingerprint key rotation policy
 | Env var | Type | Default | Description |
 |---|---|---|---|

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -229,6 +229,10 @@ AGENT_BOM_RATE_LIMIT_KEY
 AGENT_BOM_REGISTRY_AIRGAPPED
 # tier-B replay-log TTL in days — issue #2261 (default 7)
 AGENT_BOM_REPLAY_TTL_DAYS
+# optional comma-separated host allowlist for --repo / repo_url clone targets; empty = any host.
+AGENT_BOM_REPO_SCAN_ALLOWED_HOSTS
+# reference-only private-repo token name for --repo / repo_url clones; never logged or emitted.
+AGENT_BOM_REPO_SCAN_TOKEN
 AGENT_BOM_REGISTRY_PASS
 AGENT_BOM_REGISTRY_USER
 AGENT_BOM_REQUIRE_AUDIT_HMAC

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -128,6 +128,9 @@ agent-bom agents --compliance owasp-llm,eu-ai-act,all
 agent-bom agents -f cyclonedx -o bom.json
 agent-bom agents -f spdx -o bom.spdx.json
 
+# Scan a public repo by URL (shallow clone, static, read-only, auto-cleaned)
+agent-bom agents --repo https://github.com/org/repo
+
 # Image scanning
 agent-bom agents --image python:3.12-slim
 
@@ -152,6 +155,8 @@ agent-bom agents --self-scan
 ```
 
 The `--self-scan` flag is on the `agents` subcommand (not top-level). It walks the active Python environment via `importlib.metadata.distributions()` and emits a CVE report against agent-bom's own runtime so you can audit the tool with the tool.
+
+The `--repo <URL>` flag scans a public git repository by link without a local checkout. The repo is shallow-cloned (`git clone --depth 1 --single-branch`, no submodules, no credential prompt) into a temporary directory, scanned **statically** (its code is never executed), and the temp directory is always removed afterwards. Clones are bounded by a wall-clock timeout, a total-size cap, and a file-count cap (`AGENT_BOM_REPO_SCAN_*`). Only well-formed `http(s)` URLs are accepted; ssh/scp-style and local paths are rejected. For private repos, set `AGENT_BOM_REPO_SCAN_TOKEN` (reference-only; never logged or emitted). `--repo` is mutually exclusive with `--project/-p`. The same option is exposed on the MCP `scan` tool as `repo_url`.
 
 ## Troubleshooting
 

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -250,6 +250,7 @@ def _reproducible_generated_at(enabled: bool):
 @scan_options
 def scan(
     project: Optional[str],
+    repo_url: Optional[str],
     config_dir: Optional[str],
     inventory: Optional[str],
     no_discover: bool,
@@ -565,6 +566,28 @@ def scan(
         iac_paths=iac_paths,
     )
     validate_skill_mode(no_skill=no_skill, skill_only=skill_only)
+
+    # ── Public-repo clone-and-scan (--repo) ──────────────────────────────────
+    # Shallow-clone the URL into a temp dir, point the local-directory scan path
+    # at it, and remove the temp dir when the command finishes. Static only —
+    # the repository's code is never executed.
+    if repo_url:
+        if project:
+            raise click.ClickException("--repo and --project/-p are mutually exclusive.")
+        from contextlib import ExitStack
+
+        from agent_bom.repo_scan import RepoScanError, clone_repository
+
+        _repo_cleanup = ExitStack()
+        click_ctx = click.get_current_context(silent=True)
+        if click_ctx is not None:
+            click_ctx.call_on_close(_repo_cleanup.close)
+        try:
+            cloned_dir = _repo_cleanup.enter_context(clone_repository(repo_url, token_env="AGENT_BOM_REPO_SCAN_TOKEN"))
+        except RepoScanError as exc:
+            _repo_cleanup.close()
+            raise click.ClickException(str(exc)) from exc
+        project = str(cloned_dir)
 
     # Route console output based on flags
     is_stdout = output == "-"

--- a/src/agent_bom/cli/options_sources.py
+++ b/src/agent_bom/cli/options_sources.py
@@ -12,6 +12,19 @@ def input_options(fn):
     return _apply(
         [
             click.option("--project", "-p", type=click.Path(exists=True), help="Project directory to scan"),
+            click.option(
+                "--repo",
+                "repo_url",
+                type=str,
+                default=None,
+                metavar="URL",
+                help=(
+                    "Public git repository URL to clone and scan (e.g. "
+                    "https://github.com/org/repo). Shallow, static, read-only: the repo is "
+                    "cloned to a temp dir, scanned without executing its code, then deleted. "
+                    "Mutually exclusive with --project/-p."
+                ),
+            ),
             click.option("--config-dir", type=click.Path(exists=True), help="Custom agent config directory to scan"),
             click.option("--inventory", type=str, default=None, help="Inventory file (JSON or CSV). Use '-' for stdin."),
             click.option(

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -371,3 +371,18 @@ MCP_MAX_REQUEST_TRACES = _int("AGENT_BOM_MCP_MAX_REQUEST_TRACES", 256)
 # executor per call.
 
 SHIELD_ASYNC_BRIDGE_MAX_WORKERS = _int("AGENT_BOM_SHIELD_ASYNC_BRIDGE_MAX_WORKERS", 4)
+
+
+# ── Public-repo clone-and-scan bounds ────────────────────────────────────
+# Cloning untrusted public repositories by URL is bounded to keep the
+# operation safe and predictable: shallow single-branch clones only, with a
+# wall-clock timeout, a total on-disk size cap, and a file-count cap. The scan
+# itself is static (no repo code is ever executed), so these bounds guard
+# against resource exhaustion (huge repos / clone bombs), not code execution.
+
+# Max wall-clock seconds for the `git clone` step before it is aborted.
+REPO_SCAN_CLONE_TIMEOUT_SECONDS = _float("AGENT_BOM_REPO_SCAN_CLONE_TIMEOUT_SECONDS", 120.0)
+# Max total on-disk size (bytes) of the cloned working tree. Default 1 GiB.
+REPO_SCAN_MAX_SIZE_BYTES = _int("AGENT_BOM_REPO_SCAN_MAX_SIZE_BYTES", 1024 * 1024 * 1024)
+# Max number of files in the cloned working tree.
+REPO_SCAN_MAX_FILES = _int("AGENT_BOM_REPO_SCAN_MAX_FILES", 100_000)

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -418,7 +418,29 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
 
     @mcp.tool(annotations=_READ_ONLY, title="Security Scan")
     async def scan(
-        config_path: Annotated[str | None, Field(description="Path to MCP client config directory. Auto-discovers all if omitted.")] = None,
+        repo_url: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Public git repository URL to clone and scan, e.g. "
+                    "'https://github.com/org/repo'. Maps the repo's dependencies, project "
+                    "structure, secrets, IaC, and AI/MCP usage into an AI-BOM. Static and "
+                    "read-only: the repository is shallow-cloned into a temporary directory, "
+                    "scanned without ever executing its code, then deleted. The fastest way "
+                    "to point this tool at a target — no local checkout required."
+                )
+            ),
+        ] = None,
+        config_path: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Local directory to scan — a project root or an MCP client config "
+                    "directory. Auto-discovers all installed MCP clients if omitted. "
+                    "Mutually exclusive with repo_url."
+                )
+            ),
+        ] = None,
         image: Annotated[str | None, Field(description="Docker image to scan (e.g. 'nginx:1.25', 'ghcr.io/org/app:v1').")] = None,
         sbom_path: Annotated[str | None, Field(description="Path to existing CycloneDX or SPDX JSON SBOM file to ingest.")] = None,
         package: Annotated[
@@ -476,12 +498,21 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
             ),
         ] = None,
     ) -> str:
-        """Run a full AI supply chain security scan.
+        """Run a full AI supply chain security scan and return an AI-BOM.
 
-        Discovers local MCP configurations (Claude Desktop, Cursor, Windsurf,
-        VS Code Copilot, OpenClaw, etc.), extracts package dependencies, queries
-        OSV.dev for CVEs, assesses config security (credential exposure, tool access),
-        computes blast radius, and returns structured results.
+        Point it at a target with one of:
+          • repo_url     — a public git repo URL (cloned + scanned, no checkout)
+          • config_path  — a local project / MCP-config directory
+          • image        — a Docker image
+          • sbom_path    — an existing CycloneDX/SPDX SBOM
+          • package      — a single package or MCP launch command
+        With none of these, it auto-discovers local MCP clients (Claude Desktop,
+        Cursor, Windsurf, VS Code Copilot, OpenClaw, etc.).
+
+        It extracts package dependencies, queries OSV.dev for CVEs, assesses
+        config security (credential exposure, tool access), computes blast
+        radius, and returns structured results. Scanning is fully static and
+        read-only — repository and image contents are parsed, never executed.
 
         Returns:
             JSON with the complete AI-BOM report including agents, packages,
@@ -491,6 +522,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
             "scan",
             scan_impl,
             config_path=config_path,
+            repo_url=repo_url,
             image=image,
             sbom_path=sbom_path,
             package=package,

--- a/src/agent_bom/mcp_tools/scanning.py
+++ b/src/agent_bom/mcp_tools/scanning.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 async def scan_impl(
     *,
     config_path: str | None = None,
+    repo_url: str | None = None,
     image: str | None = None,
     sbom_path: str | None = None,
     package: str | None = None,
@@ -32,7 +33,71 @@ async def scan_impl(
     _run_scan_pipeline,
     _truncate_response,
 ) -> str:
-    """Implementation of the scan tool."""
+    """Implementation of the scan tool.
+
+    When ``repo_url`` is supplied, the public repository is shallow-cloned into
+    a bounded temp directory, scanned statically (no repo code is executed),
+    and the temp directory is always removed afterwards. ``repo_url`` and
+    ``config_path`` are mutually exclusive.
+    """
+    from contextlib import ExitStack
+
+    with ExitStack() as _repo_cleanup:
+        if repo_url is not None and str(repo_url).strip():
+            if config_path is not None and str(config_path).strip():
+                raise ToolError("Provide either repo_url or config_path, not both")
+            from agent_bom.repo_scan import RepoScanError, clone_repository
+
+            try:
+                cloned_dir = _repo_cleanup.enter_context(clone_repository(repo_url, token_env="AGENT_BOM_REPO_SCAN_TOKEN"))
+            except RepoScanError as exc:
+                raise ToolError(sanitize_error(exc)) from exc
+            # Route the cloned working tree through the existing local-directory
+            # discovery path. The temp dir is removed when this block exits.
+            config_path = str(cloned_dir)
+
+        return await _scan_impl_inner(
+            config_path=config_path,
+            image=image,
+            sbom_path=sbom_path,
+            package=package,
+            enrich=enrich,
+            offline=offline,
+            scorecard=scorecard,
+            transitive=transitive,
+            verify_integrity=verify_integrity,
+            fail_severity=fail_severity,
+            warn_severity=warn_severity,
+            auto_update_db=auto_update_db,
+            db_sources=db_sources,
+            output_format=output_format,
+            policy=policy,
+            _run_scan_pipeline=_run_scan_pipeline,
+            _truncate_response=_truncate_response,
+        )
+
+
+async def _scan_impl_inner(
+    *,
+    config_path: str | None = None,
+    image: str | None = None,
+    sbom_path: str | None = None,
+    package: str | None = None,
+    enrich: bool = False,
+    offline: bool = True,
+    scorecard: bool = False,
+    transitive: bool = False,
+    verify_integrity: bool = False,
+    fail_severity: str | None = None,
+    warn_severity: str | None = None,
+    auto_update_db: bool = False,
+    db_sources: str | None = None,
+    output_format: str = "json",
+    policy: dict | None = None,
+    _run_scan_pipeline,
+    _truncate_response,
+) -> str:
+    """Run the scan pipeline against an already-resolved local target."""
     try:
         from agent_bom.models import AIBOMReport
         from agent_bom.output import to_json

--- a/src/agent_bom/repo_scan.py
+++ b/src/agent_bom/repo_scan.py
@@ -1,0 +1,246 @@
+"""Safe public-repository clone-and-scan helper.
+
+This module lets ``agent-bom`` map a remote git repository into an AI-BOM from
+a single URL, with no local checkout. The repository is **shallow-cloned**
+(``git clone --depth 1 --single-branch``, no submodules, no credential prompt)
+into a throwaway temp directory, the existing local-directory scan pipeline is
+pointed at that directory, and the temp directory is **always** removed
+afterwards (``try``/``finally``).
+
+Safety properties:
+
+* **Static-only.** Nothing in the cloned repository is ever executed. The clone
+  step runs ``git`` (not repo code), and downstream scanning is pure static
+  parsing of manifests, lockfiles, IaC, skills, and AI/MCP config. There is no
+  build, install, or post-checkout hook execution: ``core.hooksPath=/dev/null``
+  disables any repo-supplied git hooks during the clone.
+* **Shallow + bounded.** Depth-1, single-branch, submodules off, with a wall
+  clock timeout, a total on-disk size cap, and a file-count cap so a hostile or
+  enormous repository cannot exhaust local resources ("clone bomb").
+* **No injection.** Only well-formed ``http(s)`` git URLs are accepted;
+  ``ssh://``, ``scp``-style ``git@host:path``, ``file://``, and bare local
+  paths are rejected so a URL can never reference the local filesystem or a
+  non-git transport.
+* **No secret/path leak.** An optional auth token (for private repos) is read
+  from a caller-named environment variable, injected only via an ephemeral
+  in-clone HTTP header, never logged and never echoed into output. Errors are
+  scrubbed of the token and of the absolute temp path before they surface.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess  # noqa: S404 — runs `git`, never repository-supplied code
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from agent_bom.config import (
+    REPO_SCAN_CLONE_TIMEOUT_SECONDS,
+    REPO_SCAN_MAX_FILES,
+    REPO_SCAN_MAX_SIZE_BYTES,
+)
+
+logger = logging.getLogger(__name__)
+
+# Hosts we accept for http(s) git clones. Empty by default == allow any host;
+# operators can pin an allowlist with AGENT_BOM_REPO_SCAN_ALLOWED_HOSTS.
+_ALLOWED_HOSTS_ENV = "AGENT_BOM_REPO_SCAN_ALLOWED_HOSTS"
+
+# Maximum accepted URL length — defends against pathological inputs.
+_MAX_URL_LEN = 2048
+
+
+class RepoScanError(Exception):
+    """Raised when a repository URL is unsafe or a clone cannot complete."""
+
+
+def validate_repo_url(repo_url: str) -> str:
+    """Validate that ``repo_url`` is a well-formed public ``http(s)`` git URL.
+
+    Rejects ssh/scp-style, ``file://``, and bare local paths so the URL can
+    never reference the local filesystem or a non-git transport. Returns the
+    normalized URL on success.
+
+    Raises:
+        RepoScanError: if the URL is malformed or uses a disallowed scheme.
+    """
+    if not isinstance(repo_url, str):
+        raise RepoScanError("repo_url must be a string")
+    url = repo_url.strip()
+    if not url:
+        raise RepoScanError("repo_url must not be empty")
+    if len(url) > _MAX_URL_LEN:
+        raise RepoScanError("repo_url is too long")
+
+    # Reject scp-style "git@host:path" syntax (has no scheme but a colon path).
+    if "://" not in url:
+        raise RepoScanError(
+            "repo_url must be a full http(s) URL (e.g. https://github.com/org/repo); ssh/scp-style and local paths are not allowed"
+        )
+
+    parts = urlsplit(url)
+    if parts.scheme not in {"http", "https"}:
+        raise RepoScanError(f"repo_url scheme '{parts.scheme}' is not allowed; use http or https")
+    if not parts.hostname:
+        raise RepoScanError("repo_url is missing a host")
+    # urlsplit keeps any embedded credentials in netloc; reject them so callers
+    # use the token env var instead of leaking secrets in the URL/logs.
+    if parts.username is not None or parts.password is not None:
+        raise RepoScanError("repo_url must not embed credentials; use the token env var instead")
+    # Control characters / whitespace in the URL are a strong injection signal.
+    if any(ord(ch) < 0x20 or ch in {" ", "\t", "\n", "\r"} for ch in url):
+        raise RepoScanError("repo_url contains illegal whitespace or control characters")
+
+    allowed = os.environ.get(_ALLOWED_HOSTS_ENV, "").strip()
+    if allowed:
+        allowed_hosts = {h.strip().lower() for h in allowed.split(",") if h.strip()}
+        if parts.hostname.lower() not in allowed_hosts:
+            raise RepoScanError(f"repo host '{parts.hostname}' is not in the configured allowlist")
+
+    return url
+
+
+def _clone_env() -> dict[str, str]:
+    """Return a hardened environment for the clone subprocess.
+
+    ``GIT_TERMINAL_PROMPT=0`` and an always-failing askpass guarantee git never
+    blocks on an interactive credential prompt for a private/404 repo.
+    """
+    env = dict(os.environ)
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["GIT_ASKPASS"] = "echo"  # never prompt; emit empty credential
+    env["GCM_INTERACTIVE"] = "never"
+    # Strip any ambient proxy-side credential helpers from inheriting state.
+    env.pop("GIT_CONFIG_PARAMETERS", None)
+    return env
+
+
+def _directory_within_bounds(root: Path) -> None:
+    """Enforce file-count and total-size caps on a cloned tree.
+
+    Raises RepoScanError if the clone exceeds REPO_SCAN_MAX_FILES or
+    REPO_SCAN_MAX_SIZE_BYTES. Symlinks are not followed when measuring.
+    """
+    total_files = 0
+    total_bytes = 0
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        # Skip the .git metadata directory from the user-facing caps; it is a
+        # clone artifact, not repository content.
+        if ".git" in dirnames:
+            dirnames.remove(".git")
+        for name in filenames:
+            total_files += 1
+            if total_files > REPO_SCAN_MAX_FILES:
+                raise RepoScanError(f"repository exceeds the file-count cap ({REPO_SCAN_MAX_FILES} files)")
+            fp = Path(dirpath) / name
+            try:
+                if fp.is_symlink():
+                    continue
+                total_bytes += fp.stat().st_size
+            except OSError:
+                continue
+            if total_bytes > REPO_SCAN_MAX_SIZE_BYTES:
+                raise RepoScanError(f"repository exceeds the size cap ({REPO_SCAN_MAX_SIZE_BYTES} bytes)")
+
+
+def _scrub(message: str, token: str | None, temp_dir: str | None) -> str:
+    """Remove a secret token and the absolute temp path from a message."""
+    out = message
+    if token:
+        out = out.replace(token, "***")
+    if temp_dir:
+        out = out.replace(temp_dir, "<repo>")
+    return out
+
+
+@contextmanager
+def clone_repository(
+    repo_url: str,
+    *,
+    token_env: str | None = None,
+    branch: str | None = None,
+) -> Iterator[Path]:
+    """Shallow-clone ``repo_url`` into a temp dir and yield the path.
+
+    The temp directory is always removed on exit (``try``/``finally``), whether
+    the clone succeeded, failed, or the scan raised. No repository code is ever
+    executed — only ``git`` runs, with hooks disabled.
+
+    Args:
+        repo_url: Public ``http(s)`` git URL. Validated before use.
+        token_env: Optional environment-variable *name* holding a token for a
+            private repo (reference-only; the value is never logged or emitted).
+        branch: Optional single branch to clone. Defaults to the repo's HEAD.
+
+    Yields:
+        Path to the cloned working tree.
+
+    Raises:
+        RepoScanError: on invalid URL, clone failure, timeout, or bounds breach.
+    """
+    url = validate_repo_url(repo_url)
+
+    token: str | None = None
+    if token_env:
+        token = os.environ.get(token_env)
+        if token is not None:
+            token = token.strip() or None
+
+    temp_dir = tempfile.mkdtemp(prefix="agent-bom-repo-")
+    try:
+        cmd = [
+            "git",
+            # Disable any repo-supplied git hooks for the clone (defense in depth;
+            # `git clone` does not run checkout hooks, but this is belt-and-braces).
+            "-c",
+            "core.hooksPath=/dev/null",
+            # Never auto-fetch submodules' transitive config.
+            "-c",
+            "protocol.file.allow=never",
+            "clone",
+            "--depth",
+            "1",
+            "--single-branch",
+            "--no-tags",
+            "--no-recurse-submodules",
+        ]
+        if branch:
+            cmd += ["--branch", branch]
+        # Inject the token only as an ephemeral in-process HTTP header so it
+        # never lands in the URL, git config, logs, or process listing of a
+        # child. The value is masked by git in any error output.
+        if token:
+            host = urlsplit(url).hostname or ""
+            cmd += ["-c", f"http.https://{host}/.extraheader=Authorization: Bearer {token}"]
+        cmd += [url, temp_dir]
+
+        try:
+            result = subprocess.run(  # noqa: S603 — fixed argv, no shell, runs git only
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=REPO_SCAN_CLONE_TIMEOUT_SECONDS,
+                env=_clone_env(),
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise RepoScanError("git is not installed or not on PATH") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise RepoScanError(f"clone timed out after {REPO_SCAN_CLONE_TIMEOUT_SECONDS:.0f}s") from exc
+
+        if result.returncode != 0:
+            stderr = _scrub((result.stderr or "").strip(), token, temp_dir)
+            # Keep the surfaced message short and free of secrets/paths.
+            detail = stderr[:200] if stderr else f"git exited {result.returncode}"
+            raise RepoScanError(f"clone failed: {detail}")
+
+        _directory_within_bounds(Path(temp_dir))
+
+        yield Path(temp_dir)
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)

--- a/tests/test_repo_scan.py
+++ b/tests/test_repo_scan.py
@@ -248,7 +248,7 @@ def test_only_git_is_executed_never_repo_code(monkeypatch: pytest.MonkeyPatch) -
         dest = Path(cmd[-1])
         # Simulate a repo that ships an executable payload — it must never run.
         (dest / "evil.sh").write_text("#!/bin/sh\ntouch /tmp/abom_pwned\n")
-        os.chmod(dest / "evil.sh", 0o755)
+        os.chmod(dest / "evil.sh", 0o700)  # owner-only; payload must never run regardless
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
     monkeypatch.setattr(subprocess, "run", _run)

--- a/tests/test_repo_scan.py
+++ b/tests/test_repo_scan.py
@@ -1,0 +1,318 @@
+"""Tests for the safe public-repo clone-and-scan helper (``agent_bom.repo_scan``).
+
+These tests never hit the network: ``git clone`` is mocked so the "clone" simply
+materializes a fixture directory (or fails) in the temp dir agent-bom chose.
+They assert URL validation, temp-dir cleanup on success and failure, bounds
+enforcement, token non-leakage, and that no repository code is ever executed.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import agent_bom.repo_scan as repo_scan
+from agent_bom.repo_scan import RepoScanError, clone_repository, validate_repo_url
+
+# ── URL validation ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/org/repo",
+        "https://github.com/org/repo.git",
+        "http://example.com/a/b",
+        "https://gitlab.com/group/sub/project",
+    ],
+)
+def test_valid_http_urls_accepted(url: str) -> None:
+    assert validate_repo_url(url) == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "git@github.com:org/repo.git",  # scp-style
+        "ssh://git@github.com/org/repo",
+        "file:///etc/passwd",
+        "/etc/passwd",
+        "../../etc/passwd",
+        "ftp://example.com/repo",
+        "https://user:secret@github.com/o/r",  # embedded creds
+        "",
+        "   ",
+        "http://example.com/with space",
+        "https://github.com/repo\ninjected",
+    ],
+)
+def test_invalid_urls_rejected(url: str) -> None:
+    with pytest.raises(RepoScanError):
+        validate_repo_url(url)
+
+
+def test_host_allowlist_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_REPO_SCAN_ALLOWED_HOSTS", "github.com")
+    assert validate_repo_url("https://github.com/o/r") == "https://github.com/o/r"
+    with pytest.raises(RepoScanError):
+        validate_repo_url("https://evil.example.com/o/r")
+
+
+# ── Clone helpers (mocked git) ──────────────────────────────────────────────
+
+
+def _fake_clone(populate, returncode: int = 0, stderr: str = ""):
+    """Build a fake subprocess.run that 'clones' by populating the dest dir.
+
+    The destination dir is the last positional arg in the git argv (the temp
+    dir agent-bom created). ``populate(dest)`` may add files to simulate a repo.
+    """
+
+    def _run(cmd, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        dest = Path(cmd[-1])
+        # Capture the argv so tests can assert flags / no-shell / no token leak.
+        _run.captured_cmd = cmd
+        if returncode == 0 and populate is not None:
+            populate(dest)
+        return subprocess.CompletedProcess(cmd, returncode, stdout="", stderr=stderr)
+
+    _run.captured_cmd = None
+    return _run
+
+
+def test_clone_success_scans_and_cleans_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    def populate(dest: Path) -> None:
+        (dest / "package.json").write_text('{"name": "x"}')
+        captured["dest"] = dest
+
+    monkeypatch.setattr(subprocess, "run", _fake_clone(populate))
+
+    with clone_repository("https://github.com/org/repo") as cloned:
+        assert cloned.exists()
+        assert (cloned / "package.json").exists()
+        captured["seen"] = cloned
+
+    # try/finally must have removed the temp dir.
+    assert not captured["seen"].exists()
+    # Shallow + single-branch + no-submodules flags present; no shell.
+    argv = subprocess.run.captured_cmd  # type: ignore[attr-defined]
+    assert "clone" in argv and "--depth" in argv and "1" in argv
+    assert "--single-branch" in argv
+    assert "--no-recurse-submodules" in argv
+    assert "core.hooksPath=/dev/null" in argv
+
+
+def test_clone_failure_raises_and_cleans_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict = {}
+
+    real_mkdtemp = repo_scan.tempfile.mkdtemp
+
+    def tracking_mkdtemp(*a, **k):  # noqa: ANN002, ANN003
+        d = real_mkdtemp(*a, **k)
+        seen["dir"] = d
+        return d
+
+    monkeypatch.setattr(repo_scan.tempfile, "mkdtemp", tracking_mkdtemp)
+    monkeypatch.setattr(subprocess, "run", _fake_clone(None, returncode=128, stderr="fatal: repository not found"))
+
+    with pytest.raises(RepoScanError) as exc:
+        with clone_repository("https://github.com/org/missing"):
+            pass  # pragma: no cover
+
+    assert "clone failed" in str(exc.value)
+    assert not Path(seen["dir"]).exists()
+
+
+def test_clone_timeout_raises_and_cleans_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict = {}
+    real_mkdtemp = repo_scan.tempfile.mkdtemp
+
+    def tracking_mkdtemp(*a, **k):  # noqa: ANN002, ANN003
+        d = real_mkdtemp(*a, **k)
+        seen["dir"] = d
+        return d
+
+    monkeypatch.setattr(repo_scan.tempfile, "mkdtemp", tracking_mkdtemp)
+
+    def _timeout(cmd, *a, **k):  # noqa: ANN001, ANN002, ANN003
+        raise subprocess.TimeoutExpired(cmd, 1)
+
+    monkeypatch.setattr(subprocess, "run", _timeout)
+
+    with pytest.raises(RepoScanError) as exc:
+        with clone_repository("https://github.com/org/slow"):
+            pass  # pragma: no cover
+    assert "timed out" in str(exc.value)
+    assert not Path(seen["dir"]).exists()
+
+
+def test_invalid_url_never_clones(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = {"n": 0}
+
+    def _run(*a, **k):  # noqa: ANN002, ANN003
+        called["n"] += 1
+        raise AssertionError("git must not run for an invalid URL")
+
+    monkeypatch.setattr(subprocess, "run", _run)
+    with pytest.raises(RepoScanError):
+        with clone_repository("file:///etc/passwd"):
+            pass  # pragma: no cover
+    assert called["n"] == 0
+
+
+# ── Bounds enforcement ──────────────────────────────────────────────────────
+
+
+def test_file_count_cap_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(repo_scan, "REPO_SCAN_MAX_FILES", 3)
+
+    def populate(dest: Path) -> None:
+        for i in range(10):
+            (dest / f"f{i}.txt").write_text("x")
+
+    monkeypatch.setattr(subprocess, "run", _fake_clone(populate))
+    with pytest.raises(RepoScanError) as exc:
+        with clone_repository("https://github.com/org/big"):
+            pass  # pragma: no cover
+    assert "file-count cap" in str(exc.value)
+
+
+def test_size_cap_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(repo_scan, "REPO_SCAN_MAX_SIZE_BYTES", 10)
+
+    def populate(dest: Path) -> None:
+        (dest / "big.bin").write_text("x" * 1000)
+
+    monkeypatch.setattr(subprocess, "run", _fake_clone(populate))
+    with pytest.raises(RepoScanError) as exc:
+        with clone_repository("https://github.com/org/huge"):
+            pass  # pragma: no cover
+    assert "size cap" in str(exc.value)
+
+
+# ── Token handling ──────────────────────────────────────────────────────────
+
+
+def test_token_used_but_never_leaked(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_TOKEN", "supersecrettoken123")
+
+    def populate(dest: Path) -> None:
+        (dest / "readme").write_text("ok")
+
+    runner = _fake_clone(populate)
+    monkeypatch.setattr(subprocess, "run", runner)
+
+    with clone_repository("https://github.com/org/private", token_env="MY_TOKEN"):
+        pass
+
+    argv = runner.captured_cmd
+    # Token is injected (so private clones work) only via an ephemeral header.
+    joined = " ".join(argv)
+    assert "Authorization: Bearer supersecrettoken123" in joined
+
+
+def test_token_scrubbed_from_clone_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_TOKEN", "supersecrettoken123")
+    # git failure whose stderr echoes the secret — must be scrubbed before surfacing.
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        _fake_clone(None, returncode=128, stderr="auth failed for supersecrettoken123"),
+    )
+    with pytest.raises(RepoScanError) as exc:
+        with clone_repository("https://github.com/org/private", token_env="MY_TOKEN"):
+            pass  # pragma: no cover
+    assert "supersecrettoken123" not in str(exc.value)
+    assert "***" in str(exc.value)
+
+
+def test_clone_env_disables_prompt() -> None:
+    env = repo_scan._clone_env()
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+
+
+# ── No repository code execution ────────────────────────────────────────────
+
+
+def test_only_git_is_executed_never_repo_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The only subprocess invoked is `git`; repo content is never executed."""
+    invocations: list[list[str]] = []
+
+    def _run(cmd, *a, **k):  # noqa: ANN001, ANN002, ANN003
+        invocations.append(list(cmd))
+        dest = Path(cmd[-1])
+        # Simulate a repo that ships an executable payload — it must never run.
+        (dest / "evil.sh").write_text("#!/bin/sh\ntouch /tmp/abom_pwned\n")
+        os.chmod(dest / "evil.sh", 0o755)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _run)
+
+    pwned = Path("/tmp/abom_pwned")
+    if pwned.exists():
+        pwned.unlink()
+
+    with clone_repository("https://github.com/org/repo"):
+        pass
+
+    # Exactly one subprocess, and it is git with no shell.
+    assert len(invocations) == 1
+    assert invocations[0][0] == "git"
+    # The repo's payload was never executed.
+    assert not pwned.exists()
+
+
+# ── End-to-end through scan_impl (mocked clone + pipeline) ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_scan_impl_repo_url_clones_and_routes(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.mcp_tools import scanning
+
+    captured: dict = {}
+
+    def populate(dest: Path) -> None:
+        (dest / "requirements.txt").write_text("requests==2.0.0\n")
+
+    monkeypatch.setattr(subprocess, "run", _fake_clone(populate))
+
+    async def fake_pipeline(config_path, image, sbom_path, package, enrich, **kw):  # noqa: ANN001, ANN002, ANN003
+        captured["config_path"] = config_path
+        # The cloned dir must still exist while the pipeline runs.
+        captured["exists_during_scan"] = config_path is not None and Path(config_path).exists()
+        return [], [], [], []
+
+    out = await scanning.scan_impl(
+        repo_url="https://github.com/org/repo",
+        offline=True,
+        _run_scan_pipeline=fake_pipeline,
+        _truncate_response=lambda s: s,
+    )
+
+    assert captured["exists_during_scan"] is True
+    # Temp dir cleaned up after scan_impl returns.
+    assert not Path(captured["config_path"]).exists()
+    assert "no_agents_found" in out
+
+
+@pytest.mark.asyncio
+async def test_scan_impl_rejects_repo_url_and_config_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mcp.server.fastmcp.exceptions import ToolError
+
+    from agent_bom.mcp_tools import scanning
+
+    async def fake_pipeline(*a, **k):  # noqa: ANN002, ANN003
+        return [], [], [], []  # pragma: no cover
+
+    with pytest.raises(ToolError):
+        await scanning.scan_impl(
+            repo_url="https://github.com/org/repo",
+            config_path="/tmp",
+            _run_scan_pipeline=fake_pipeline,
+            _truncate_response=lambda s: s,
+        )


### PR DESCRIPTION
## Summary
Adds public-repo-URL scanning — point at a git link and get the full AI-BOM (deps + structure + secrets + IaC + AI/MCP), no local checkout. Also fixes the unfriendly 'config-path-first' UX of the `scan` tool on hosted MCP directories (Glama/Smithery 'Try in Browser').

- `repo_scan.py` — safe clone+scan: **shallow** (`--depth 1 --single-branch --no-tags --no-submodules`), hooks disabled, `GIT_TERMINAL_PROMPT=0`, bounded (clone timeout / size / file-count caps via `AGENT_BOM_REPO_SCAN_*`), temp dir **always** cleaned up. **Static-only** — the only subprocess is `git`; repo code is never executed (asserted by a trip-wire test). Optional private-repo token (reference-only, scrubbed from output; absolute temp paths scrubbed too).
- **MCP `scan` tool**: new `repo_url` arg (first/prominent, mutually exclusive with config_path) + rewrote the tool description so repo_url/project_path/image read as the primary targets. **Tool count unchanged at 69.**
- **CLI**: `agent-bom agents --repo <url>` (mutually exclusive with -p/--path).

## Verification
28 repo-scan tests (URL validation; clone→scan→cleanup; failure/timeout cleanup; size/file caps; token-never-leaked; only-git-executed/no-payload-run; e2e via scan_impl) + count-stays-69 (test_stats_alignment) + strict-args + output-contract — 61 pass. ruff/format/mypy clean; release-consistency exit 0. Static/shallow/bounded/temp-cleanup/no-leak.