### PR TITLE
test(sdk): derive route-parity registered paths from OpenAPI schema (FastAPI 0.137 fwd-compat)

### DIFF
--- a/tests/test_go_client_route_parity.py
+++ b/tests/test_go_client_route_parity.py
@@ -15,7 +15,10 @@ def test_go_control_plane_client_paths_exist_in_api() -> None:
         for match in re.findall(r'"(/(?:health|v1/[^"?]+))"', source)
         if "{" not in match and not match.endswith("/") and "+" not in match
     }
-    registered_paths = {getattr(route, "path", "") for route in app.routes}
+    # FastAPI >=0.137 includes sub-routers lazily as ``_IncludedRouter`` wrappers
+    # in ``app.routes`` that do not expose their child ``.path`` values, so the
+    # generated OpenAPI document is the version-stable source of registered paths.
+    registered_paths = set(app.openapi().get("paths", {}))
 
     assert client_paths
     assert client_paths <= registered_paths

--- a/tests/test_python_client_route_parity.py
+++ b/tests/test_python_client_route_parity.py
@@ -20,7 +20,10 @@ def test_python_control_plane_client_paths_exist_in_api() -> None:
         and "{" not in node.value
         and not node.value.endswith("/")
     }
-    registered_paths = {getattr(route, "path", "") for route in app.routes}
+    # FastAPI >=0.137 includes sub-routers lazily as ``_IncludedRouter`` wrappers
+    # in ``app.routes`` that do not expose their child ``.path`` values, so the
+    # generated OpenAPI document is the version-stable source of registered paths.
+    registered_paths = set(app.openapi().get("paths", {}))
 
     assert client_paths
     assert client_paths <= registered_paths

--- a/tests/test_typescript_client_route_parity.py
+++ b/tests/test_typescript_client_route_parity.py
@@ -13,7 +13,10 @@ def test_typescript_control_plane_client_paths_exist_in_api() -> None:
     client_paths = {
         match for match in re.findall(r"[\"`](/(?:health|v1/[^\"`?$]+))", source) if "{" not in match and not match.endswith("/")
     }
-    registered_paths = {getattr(route, "path", "") for route in app.routes}
+    # FastAPI >=0.137 includes sub-routers lazily as ``_IncludedRouter`` wrappers
+    # in ``app.routes`` that do not expose their child ``.path`` values, so the
+    # generated OpenAPI document is the version-stable source of registered paths.
+    registered_paths = set(app.openapi().get("paths", {}))
 
     assert client_paths
     assert client_paths <= registered_paths


### PR DESCRIPTION
## Summary
Fixes the `*_client_route_parity` tests, which fail under **FastAPI 0.137+**. 0.137 changed `include_router` to add lazy `_IncludedRouter` wrappers (no `.path`) into `app.routes`, so the tests' `{route.path for route in app.routes}` only saw the ~13 app-level routes and dropped every `/v1/*` router path → false 'missing route' failures.

**The SDK clients are in sync** — this is purely a test-infra forward-compat fix: the 3 parity tests now source registered paths from `app.openapi()["paths"]` (version-stable, reflects all mounted routers) instead of `app.routes` `.path` attributes. No client code changed.

## Verification
3 parity tests pass; broader `-k 'parity or client or openapi'` sweep green; ruff/format/mypy clean; `export_openapi.py --check` exit 0.