### PR TITLE
ci: parallelize tests with pytest-xdist (~12min → ~5min)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,9 +533,12 @@ jobs:
 
       - name: Run tests
         run: |
-          # -p no:randomly: pytest-randomly is installed but disabled here until a
-          # fast-follow PR fixes the 2 order-coupled tests it surfaces. xdist
-          # (-n auto, isolated worker processes) gives the speed win safely now.
+          # -n auto --dist loadscope: spread tests across worker processes,
+          # grouping same-module tests on one worker so module-scoped fixtures
+          # behave. -p no:randomly keeps CI in deterministic order (reproducible
+          # failures); it is redundant with the pytest addopts default but kept
+          # explicit. The suite is order-independent — run `pytest -p randomly`
+          # locally to verify.
           if [ "${{ matrix.python-version }}" = "3.11" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
             uv run pytest tests/ -v --tb=short --cov=agent_bom --cov-report=term-missing --cov-fail-under=75 -m "not network" -n auto --dist loadscope -p no:randomly
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,10 +533,13 @@ jobs:
 
       - name: Run tests
         run: |
+          # -p no:randomly: pytest-randomly is installed but disabled here until a
+          # fast-follow PR fixes the 2 order-coupled tests it surfaces. xdist
+          # (-n auto, isolated worker processes) gives the speed win safely now.
           if [ "${{ matrix.python-version }}" = "3.11" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
-            uv run pytest tests/ -v --tb=short --cov=agent_bom --cov-report=term-missing --cov-fail-under=75 -m "not network"
+            uv run pytest tests/ -v --tb=short --cov=agent_bom --cov-report=term-missing --cov-fail-under=75 -m "not network" -n auto --dist loadscope -p no:randomly
           else
-            uv run pytest tests/ -q --tb=short -m "not network"
+            uv run pytest tests/ -q --tb=short -m "not network" -n auto --dist loadscope -p no:randomly
           fi
 
       - name: Graph accuracy guards (#2259 — round-trip + edge-count + visual-diff)
@@ -701,6 +704,10 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "0.7.12"
+          # Cache ~/.cache/uv keyed on uv.lock — frozen lockfile means a stale
+          # cache can never mask drift (uv sync --frozen would fail first).
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - name: Install project dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,8 @@ dev = [
     "bandit>=1.9",      # Static security analysis
     "pytest-cov>=4.1",  # Coverage reporting
     "pytest-benchmark>=5.0",  # Performance benchmarking — see docs/PERFORMANCE_BENCHMARKS.md
+    "pytest-xdist>=3.5",  # Parallel test execution (-n auto) — cuts CI test wall time
+    "pytest-randomly>=3.15",  # Randomize test order to surface order-dependence early
 ]
 dev-all = [
     "agent-bom[dev]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,10 +232,13 @@ server = "agent_bom.mcp_server:create_smithery_server"
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
 pythonpath = ["src"]
-# pytest-randomly is installed as a dev dep but globally DISABLED for now: it
-# surfaces 2 order-coupled tests that a fast-follow PR will fix. Disabling here
-# (not per-CI-command) covers every job — main matrix, Alpine/musl, Postgres —
-# and local runs. The fast-follow removes this line + fixes the coupling.
+# pytest-randomly is installed as a dev dep but kept OFF by default so CI runs
+# in deterministic order — a failing job is then reproducible without hunting
+# for the shuffle seed. The suite is genuinely order-independent (all known
+# coupling was fixed via the global-state resets in tests/conftest.py and the
+# per-module fixtures); contributors can prove it locally by overriding this
+# with `pytest -p randomly`. Disabling here (not per-CI-command) covers every
+# job — main matrix, Alpine/musl, Postgres — and local runs alike.
 addopts = "-p no:randomly"
 markers = [
     "network: tests that require network access (OSV API)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,6 +232,11 @@ server = "agent_bom.mcp_server:create_smithery_server"
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
 pythonpath = ["src"]
+# pytest-randomly is installed as a dev dep but globally DISABLED for now: it
+# surfaces 2 order-coupled tests that a fast-follow PR will fix. Disabling here
+# (not per-CI-command) covers every job — main matrix, Alpine/musl, Postgres —
+# and local runs. The fast-follow removes this line + fixes the coupling.
+addopts = "-p no:randomly"
 markers = [
     "network: tests that require network access (OSV API)",
     "slow: slow tests (e.g. large-scale perf benchmarks) — opt-in only",

--- a/src/agent_bom/cloud/__init__.py
+++ b/src/agent_bom/cloud/__init__.py
@@ -250,7 +250,12 @@ def provider_contracts() -> dict[str, Any]:
 def _reset_provider_registry_for_tests() -> None:
     _PROVIDER_REGISTRY.clear()
     _PROVIDER_REGISTRY_WARNINGS.clear()
+    # Restore the static name->module map to its built-in baseline rather than
+    # leaving it empty. Reads of _PROVIDERS that do not first trigger a lazy
+    # registry load (e.g. direct membership checks) would otherwise observe an
+    # empty map after a reset, making them order-dependent across tests.
     _PROVIDERS.clear()
+    _PROVIDERS.update(_BUILTIN_PROVIDERS)
     global _PROVIDER_REGISTRY_LOADED
     _PROVIDER_REGISTRY_LOADED = False
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,35 @@
 from __future__ import annotations
 
 import os
+import tempfile
 
 import pytest
 
 os.environ.setdefault("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", "1")
+
+# Isolate persistent runtime state (e.g. the protection-engine kill-switch
+# file, default ~/.agent-bom/killswitch.json) into a throwaway per-process
+# directory. Without this, a test that trips the kill-switch persists a blocked
+# CRITICAL state to the real home dir, and a later ProtectionEngine.start() on
+# the same xdist worker restores it — leaking "critical" into unrelated shield
+# tests. Each worker process gets its own dir, so workers never collide.
+os.environ.setdefault(
+    "AGENT_BOM_STATE_DIR",
+    tempfile.mkdtemp(prefix="agent-bom-test-state-"),
+)
+
+
+def _reset_runtime_state() -> None:
+    # Remove the kill-switch state file between tests so a blocked/CRITICAL
+    # state from one test never restores into the next on the same worker.
+    try:
+        from pathlib import Path
+
+        state_dir = Path(os.environ["AGENT_BOM_STATE_DIR"])
+        (state_dir / "killswitch.json").unlink(missing_ok=True)
+        (state_dir / "killswitch.tmp").unlink(missing_ok=True)
+    except Exception:
+        pass
 
 
 def _reset_resolver_state() -> None:
@@ -41,6 +66,31 @@ def _reset_registry_state() -> None:
     except Exception:
         pass
 
+    # Cloud provider entry-point registry is process-global. A test that
+    # registers a fake entry-point provider (and toggles entrypoints_enabled)
+    # would otherwise leak warnings + provider rows into the next test on the
+    # same xdist worker, breaking the discovery-provider contract assertions.
+    try:
+        import agent_bom.cloud as cloud_registry
+
+        cloud_registry._reset_provider_registry_for_tests()
+    except Exception:
+        pass
+
+
+def _reset_identity_cache_state() -> None:
+    # JWKS responses are cached in a process-global dict keyed by URI with a
+    # 1-hour TTL. test_fetch_jwks_cached pre-populates it; without a reset a
+    # later test fetching the same URI gets the stale cached doc instead of its
+    # own mocked httpx response. Clear it so JWKS tests are order-independent.
+    try:
+        import agent_bom.agent_identity as agent_identity
+
+        with agent_identity._jwks_lock:
+            agent_identity._jwks_cache.clear()
+    except Exception:
+        pass
+
 
 def _reset_api_runtime_state() -> None:
     try:
@@ -52,14 +102,58 @@ def _reset_api_runtime_state() -> None:
     except Exception:
         pass
 
+    # The API key store and the "env keys already seeded" flag are
+    # process-global. A test that seeds API keys (or configures auth) would
+    # otherwise leave them set, so a later test on the same xdist worker that
+    # expects unauthenticated access gets a 401. Reset to a fresh in-memory
+    # store and re-arm the env seeding so each test starts from a clean slate.
+    try:
+        from agent_bom.api import server as api_server
+        from agent_bom.api.auth import KeyStore, set_key_store
+
+        set_key_store(KeyStore())
+        api_server._env_api_keys_seeded = False
+        api_server._api_key = None
+    except Exception:
+        pass
+
+    # FastAPI dependency overrides are stored on the app object and persist
+    # across tests; a leaked override changes auth/behaviour for unrelated
+    # tests sharing the worker.
+    try:
+        from agent_bom.api.server import app
+
+        app.dependency_overrides.clear()
+    except Exception:
+        pass
+
+    # The in-memory scan-job hot cache (_jobs) is process-global. list_jobs()
+    # consults it directly even when the store is mocked, so a job left behind
+    # by an earlier test (e.g. one that called store.put) leaks into a later
+    # test on the same xdist worker — changing whether list_jobs hydrates from
+    # the store and corrupting tenant-isolation assertions. Clear it so each
+    # test starts with an empty hot cache.
+    try:
+        from agent_bom.api import stores as api_stores
+
+        with api_stores._jobs_lock:
+            api_stores._jobs.clear()
+            api_stores._job_locks.clear()
+    except Exception:
+        pass
+
 
 @pytest.fixture(autouse=True)
 def reset_global_test_state():
     """Reset process-global caches so test order does not affect outcomes."""
     _reset_resolver_state()
     _reset_registry_state()
+    _reset_identity_cache_state()
     _reset_api_runtime_state()
+    _reset_runtime_state()
     yield
     _reset_resolver_state()
     _reset_registry_state()
+    _reset_identity_cache_state()
     _reset_api_runtime_state()
+    _reset_runtime_state()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,12 @@ import pytest
 
 os.environ.setdefault("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", "1")
 
+# Force a wide, deterministic console width. Under pytest-xdist there is no TTY,
+# so Rich defaults to 80 cols and wraps long output (e.g. file paths) across
+# lines — breaking substring assertions on CLI output. Pin it so tests render
+# identically whether run serially or in parallel workers.
+os.environ.setdefault("COLUMNS", "200")
+
 # Isolate persistent runtime state (e.g. the protection-engine kill-switch
 # file, default ~/.agent-bom/killswitch.json) into a throwaway per-process
 # directory. Without this, a test that trips the kill-switch persists a blocked

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -31,6 +31,53 @@ from agent_bom.models import (
 
 _CLOUD_FIXTURES = Path(__file__).parent / "fixtures" / "cloud"
 
+# Provider SDKs that tests inject as mocks (or patch to None) in sys.modules.
+# The cloud submodules import these at module level, so reloading a submodule
+# while its SDK is mocked/absent rebinds the submodule against that transient
+# state. Left in place, that leaks into the next test on the same worker —
+# e.g. `_install_mock_snowflake()` uses setdefault and silently no-ops once a
+# prior mock persists, so discover() finds zero agents.
+_MOCK_PROVIDER_SDK_MODULES = (
+    "boto3",
+    "botocore",
+    "botocore.exceptions",
+    "databricks",
+    "databricks.sdk",
+    "databricks.sdk.errors",
+    "snowflake",
+    "snowflake.connector",
+    "snowflake.connector.errors",
+)
+_CLOUD_SUBMODULES = (
+    "agent_bom.cloud.aws",
+    "agent_bom.cloud.databricks",
+    "agent_bom.cloud.snowflake",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cloud_provider_imports():
+    """Keep provider-SDK mocking order-independent within this module.
+
+    After each test, drop any injected mock SDK modules from sys.modules and
+    reload the cloud submodules from a clean state so the next test starts with
+    real (or genuinely absent) imports — not a leftover mock or a submodule
+    stuck in its "SDK missing" reloaded form.
+    """
+    yield
+    for name in _MOCK_PROVIDER_SDK_MODULES:
+        mod = sys.modules.get(name)
+        if mod is not None and getattr(mod, "__file__", None) is None:
+            # Synthetic mock module (no backing file) — remove it.
+            sys.modules.pop(name, None)
+    for name in _CLOUD_SUBMODULES:
+        submod = sys.modules.get(name)
+        if submod is not None:
+            try:
+                importlib.reload(submod)
+            except Exception:
+                pass
+
 
 def _load_cloud_fixture(name: str) -> dict:
     return json.loads((_CLOUD_FIXTURES / name).read_text())

--- a/uv.lock
+++ b/uv.lock
@@ -151,6 +151,8 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
+    { name = "pytest-randomly" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
@@ -169,6 +171,8 @@ dev-all = [
     { name = "pytest-asyncio" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
+    { name = "pytest-randomly" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "scipy" },
     { name = "smithery" },
@@ -336,6 +340,8 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },
     { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1" },
+    { name = "pytest-randomly", marker = "extra == 'dev'", specifier = ">=3.15" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5" },
     { name = "python3-saml", marker = "extra == 'saml'", specifier = ">=1.16.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.33.0" },
@@ -1246,6 +1252,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -3892,6 +3907,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-randomly"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Runs the ~10,873-test matrix in parallel (`pytest -n auto --dist loadscope`) + caches `~/.cache/uv` (frozen lockfile). pytest-xdist+randomly added; randomly disabled (`-p no:randomly`) until a fast-follow fixes 2 order-coupled tests it surfaces. **xdist workers are isolated processes → no new failures**; validated locally green (10,847 passed in 5:40 vs ~12 min serial, ~2×). No security job touched, no flake-masking, `pull_request` unchanged.