### PR TITLE
ci(deploy): cross-channel surface-freshness monitor + alert (no more silent staleness)

### DIFF
--- a/.github/workflows/deployment-freshness.yml
+++ b/.github/workflows/deployment-freshness.yml
@@ -74,7 +74,7 @@ jobs:
           SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
         run: |
           if [ -z "${SMITHERY_MCP_URL:-}" ]; then
-            echo "::notice::SMITHERY_MCP_URL not configured — skipping public marketplace freshness checks"
+            echo "::warning::SMITHERY_MCP_URL not configured — the public marketplace (Smithery) surface is UNMONITORED. A misconfiguration tracking issue will be opened."
             echo "not_configured=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -177,13 +177,67 @@ jobs:
           EOF
           )"
 
-      - name: Close supply-chain drift issue when deployment is fresh
-        if: steps.railway.outputs.stale != 'true' && steps.railway.outputs.probe_failed != 'true' && (steps.public.outputs.not_configured == 'true' || (steps.public.outputs.stale != 'true' && steps.public.outputs.probe_failed != 'true' && steps.public.outputs.auth_gate != 'true'))
+      - name: Open or update misconfiguration issue for unmonitored surfaces
+        if: steps.public.outputs.not_configured == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const title = "deployment-monitoring: a deployment surface is UNMONITORED (missing config)";
+            const labels = ["supply-chain-drift", "security-preventive", "automated"];
+
+            const unmonitored = [
+              "**Smithery / public marketplace** — set repo variable `SMITHERY_MCP_URL` (public unauthenticated MCP endpoint). Without it the public surface is never freshness-checked, which is how the listing drifted for three months unnoticed.",
+            ];
+
+            const body = [
+              "## Deployment surface is unmonitored",
+              "",
+              "One or more deployment surfaces have no monitoring configuration, so drift on them is invisible. This issue replaces the old silent `::notice:: skipping` behavior.",
+              "",
+              ...unmonitored.map((u) => `- ${u}`),
+              "",
+              "Set the named repo variable(s) under **Settings → Secrets and variables → Actions → Variables**, then re-run the **Deployment Freshness** workflow. This issue auto-closes once every surface is monitored.",
+            ].join("\n");
+
+            for (const name of labels) {
+              try { await github.rest.issues.createLabel({ owner, repo, name }); } catch (e) {}
+            }
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: "open", labels: "supply-chain-drift", per_page: 100,
+            });
+            const match = existing.find((issue) => issue.title === title);
+            if (match) {
+              await github.rest.issues.createComment({ owner, repo, issue_number: match.number, body });
+              return;
+            }
+            await github.rest.issues.create({ owner, repo, title, body, labels });
+
+      - name: Close misconfiguration issue when every surface is monitored
+        if: steps.public.outputs.not_configured != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          EXISTING=$(gh issue list --label "supply-chain-drift" --state open --json number --jq '.[0].number // empty')
+          TITLE="deployment-monitoring: a deployment surface is UNMONITORED (missing config)"
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue close "$EXISTING" --comment "All deployment surfaces are now configured for monitoring; closing the misconfiguration alert."
+          fi
+
+      - name: Close supply-chain drift issue when deployment is fresh
+        if: steps.railway.outputs.stale != 'true' && steps.railway.outputs.probe_failed != 'true' && steps.public.outputs.not_configured != 'true' && steps.public.outputs.stale != 'true' && steps.public.outputs.probe_failed != 'true' && steps.public.outputs.auth_gate != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          EXPECTED="${{ steps.expected.outputs.version }}"
+          TITLE="supply-chain-drift: deployment surfaces out of sync with $EXPECTED"
+          # Match by title (not just label) so we never close the separate
+          # surface-freshness or unmonitored-surface tracking issues that share
+          # the supply-chain-drift label.
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING" ]; then
             gh issue close "$EXISTING" --comment "Deployment freshness check is clean again; closing the automated supply-chain drift alert."
           fi

--- a/.github/workflows/surface-freshness.yml
+++ b/.github/workflows/surface-freshness.yml
@@ -1,0 +1,119 @@
+name: Surface Freshness
+
+# Cross-channel version-freshness monitor. Compares the repo version against
+# EVERY published distribution surface (PyPI, Docker/ghcr, Glama, Smithery) and
+# maintains ONE consolidated tracking issue so a stale surface can never sit
+# unnoticed for months. Closes the gap that let the Smithery listing drift for
+# three months without an alert.
+#
+# Optional repo variables (Settings -> Secrets and variables -> Actions -> Variables):
+#   SMITHERY_MCP_URL   — public unauthenticated MCP endpoint (enables Smithery probe)
+#   GLAMA_LISTING_URL  — Glama public listing JSON endpoint (enables Glama probe)
+#   DOCKER_IMAGE       — override default ghcr.io/msaad00/agent-bom
+
+on:
+  schedule:
+    - cron: "30 8 * * *"  # daily at 08:30 UTC (after deployment-freshness at 08:00)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  freshness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@5db1cf9a59fb97c40a68accab29236f0da7e94db # v6.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Probe every distribution surface
+        id: probe
+        env:
+          SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
+          GLAMA_LISTING_URL: ${{ vars.GLAMA_LISTING_URL }}
+          DOCKER_IMAGE: ${{ vars.DOCKER_IMAGE }}
+        run: |
+          PYTHONPATH=src python3 scripts/check_surface_freshness.py --out surface-freshness.json
+          echo "report<<EOF" >> "$GITHUB_OUTPUT"
+          cat surface-freshness.json >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Open, refresh, or close consolidated freshness issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          REPORT: ${{ steps.probe.outputs.report }}
+        with:
+          script: |
+            const report = JSON.parse(process.env.REPORT);
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const title = "supply-chain-drift: distribution surfaces out of sync";
+            const labels = ["supply-chain-drift", "security-preventive", "automated"];
+
+            const emoji = (s) => ({
+              fresh: "✅ fresh",
+              stale: "⚠️ STALE",
+              not_configured: "❓ unmonitored (misconfigured)",
+              unreachable: "🔌 unreachable",
+            }[s] || s);
+
+            const rows = report.surfaces
+              .map((s) => `| ${s.surface} | ${s.version} | ${s.expected} | ${emoji(s.status)} | ${s.error || "—"} |`)
+              .join("\n");
+
+            const body = [
+              `## Distribution surface freshness — expected \`${report.expected}\``,
+              "",
+              "| Surface | Published | Expected | Status | Detail |",
+              "|---------|-----------|----------|--------|--------|",
+              rows,
+              "",
+              "**Statuses**",
+              "- `stale` — surface published a different version; re-run the publish workflow.",
+              "- `unmonitored (misconfigured)` — a required repo variable is unset, so this surface is NOT being watched. Set the named variable.",
+              "- `unreachable` — the surface URL is configured but the probe failed (network / HTTP / parse).",
+              "",
+              "Required repo variables for full coverage: `SMITHERY_MCP_URL`, `GLAMA_LISTING_URL`. PyPI and Docker need no configuration.",
+              "",
+              "_Maintained automatically by the surface-freshness workflow. Self-closes when every surface is fresh and monitored._",
+            ].join("\n");
+
+            for (const name of labels) {
+              try {
+                await github.rest.issues.createLabel({ owner, repo, name });
+              } catch (e) { /* already exists */ }
+            }
+
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              labels: "supply-chain-drift",
+              per_page: 100,
+            });
+            const match = existing.find((issue) => issue.title === title);
+
+            if (report.all_fresh) {
+              if (match) {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: match.number,
+                  body: "All distribution surfaces are fresh and monitored again; closing.",
+                });
+                await github.rest.issues.update({ owner, repo, issue_number: match.number, state: "closed" });
+              }
+              return;
+            }
+
+            if (match) {
+              await github.rest.issues.createComment({ owner, repo, issue_number: match.number, body });
+              return;
+            }
+            await github.rest.issues.create({ owner, repo, title, body, labels });

--- a/integrations/smithery.yaml
+++ b/integrations/smithery.yaml
@@ -1,3 +1,11 @@
+# Smithery listing metadata. Keep this aligned with integrations/glama/server.json
+# and pyproject.toml so the next successful deploy carries current information.
+# The startCommand / configSchema / commandFunction block below is the runtime
+# contract Smithery executes — do not change its shape.
+name: agent-bom
+description: "Open security scanner and self-hosted control plane for AI/MCP infrastructure — agents, MCP servers, runtime, and blast radius. Exposes 69 MCP tools for scanning, compliance, and graph analysis."
+homepage: "https://github.com/msaad00/agent-bom"
+
 runtime: "python"
 startCommand:
   type: stdio

--- a/scripts/check_surface_freshness.py
+++ b/scripts/check_surface_freshness.py
@@ -33,6 +33,7 @@ import subprocess
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -89,6 +90,31 @@ def _classify(name: str, published: str | None, expected: str, *, error: str | N
     return {"surface": name, "status": status, "version": published, "expected": expected}
 
 
+def _parse_image_reference(image: str) -> tuple[str, str]:
+    """Return (registry, repository) for supported container image references."""
+    raw = image.strip()
+    if not raw:
+        raise ValueError("empty image reference")
+    if "://" in raw:
+        raise ValueError("image reference must not be a URL")
+    without_digest = raw.split("@", 1)[0]
+    parts = without_digest.split("/")
+    if ":" in parts[-1]:
+        parts[-1] = parts[-1].split(":", 1)[0]
+
+    first = parts[0].lower()
+    has_registry = len(parts) > 1 and ("." in first or ":" in first or first == "localhost")
+    registry = first if has_registry else "docker.io"
+    repo_parts = parts[1:] if has_registry else parts
+    if registry in {"docker.io", "index.docker.io"} and len(repo_parts) == 1:
+        repo_parts = ["library", repo_parts[0]]
+
+    repo = "/".join(p.strip() for p in repo_parts if p.strip())
+    if not repo or not re.fullmatch(r"[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+", repo):
+        raise ValueError(f"unsupported image repository: {image!r}")
+    return registry, repo
+
+
 def probe_pypi(expected: str, **kw: Any) -> dict[str, Any]:
     try:
         data = _http_json("https://pypi.org/pypi/agent-bom/json", **kw)
@@ -107,22 +133,23 @@ def probe_docker(expected: str, image: str, **kw: Any) -> dict[str, Any]:
     """
     image = image.strip()
     try:
-        if image.startswith("ghcr.io/"):
+        registry, repo = _parse_image_reference(image)
+        if registry == "ghcr.io":
             # ghcr public images: token from anonymous auth, then registry tags list.
-            repo = image[len("ghcr.io/") :]
+            scope_repo = urllib.parse.quote(repo, safe="")
+            path_repo = urllib.parse.quote(repo, safe="/")
             token_data = _http_json(
-                f"https://ghcr.io/token?scope=repository:{repo}:pull&service=ghcr.io",
+                f"https://ghcr.io/token?scope=repository:{scope_repo}:pull&service=ghcr.io",
                 **kw,
             )
             token = token_data.get("token", "")
             tags_data = _http_json(
-                f"https://ghcr.io/v2/{repo}/tags/list",
+                f"https://ghcr.io/v2/{path_repo}/tags/list",
                 headers={"Authorization": f"Bearer {token}"} if token else None,
                 **kw,
             )
             tags = set(tags_data.get("tags") or [])
         else:
-            repo = image if "/" in image else f"library/{image}"
             tags: set[str] = set()
             url = f"https://hub.docker.com/v2/repositories/{repo}/tags?page_size=100"
             data = _http_json(url, **kw)
@@ -142,6 +169,8 @@ def probe_docker(expected: str, image: str, **kw: Any) -> dict[str, Any]:
         )
         return _classify("Docker", semver[-1] if semver else None, expected)
     except RuntimeError as exc:
+        return _classify("Docker", None, expected, error=str(exc))
+    except ValueError as exc:
         return _classify("Docker", None, expected, error=str(exc))
 
 

--- a/scripts/check_surface_freshness.py
+++ b/scripts/check_surface_freshness.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Cross-channel version-freshness monitor for every published agent-bom surface.
+
+Compares the repo's expected version (pyproject.toml) against each distribution
+surface and emits a single consolidated JSON report. A scheduled workflow turns
+that report into ONE tracking issue so a stale surface can never silently sit
+unnoticed for months (root cause of the 3-month Smithery drift).
+
+Surfaces probed:
+    pypi      — https://pypi.org/pypi/agent-bom/json  -> info.version
+    docker    — ghcr.io / Docker Hub latest tag       -> resolved via registry API
+    glama     — public marketplace listing            -> scripts/check_glama_listing.py
+    smithery  — public MCP endpoint                    -> agent_bom.deployment_probe
+
+Each surface reports one of:
+    fresh          — published version == expected
+    stale          — published version != expected
+    not_configured — required URL/var missing (treated as a MISCONFIGURATION, not skipped)
+    unreachable    — configured but probe failed
+
+The script always exits 0 — the workflow inspects the JSON and decides whether to
+open/refresh/close the tracking issue. This keeps the scheduled run itself green
+while still surfacing drift through the issue tracker.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+GLAMA_SCRIPT = ROOT / "scripts" / "check_glama_listing.py"
+
+PYPI_PACKAGE = "agent-bom"
+DEFAULT_DOCKER_IMAGE = "ghcr.io/msaad00/agent-bom"
+DEFAULT_TIMEOUT = 15.0
+DEFAULT_ATTEMPTS = 3
+DEFAULT_BACKOFF = 5.0
+
+OK_STATUSES = {"fresh"}
+ALERT_STATUSES = {"stale", "not_configured", "unreachable"}
+
+
+def _expected_version() -> str:
+    text = PYPROJECT.read_text()
+    m = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if not m:
+        raise SystemExit("could not read version from pyproject.toml")
+    return m.group(1)
+
+
+def _http_json(url: str, *, timeout: float, attempts: int, backoff: float, headers: dict[str, str] | None = None) -> Any:
+    last = "unknown error"
+    hdrs = {"Accept": "application/json", "User-Agent": "agent-bom-freshness-probe"}
+    if headers:
+        hdrs.update(headers)
+    for attempt in range(1, attempts + 1):
+        try:
+            req = urllib.request.Request(url, headers=hdrs)
+            with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+                return json.loads(resp.read().decode("utf-8", errors="replace"))
+        except urllib.error.HTTPError as exc:  # noqa: PERF203
+            last = f"HTTP {exc.code}"
+        except (urllib.error.URLError, TimeoutError) as exc:
+            last = f"network error: {exc}"
+        except json.JSONDecodeError as exc:
+            last = f"invalid JSON: {exc}"
+        if attempt < attempts:
+            time.sleep(backoff * attempt)
+    raise RuntimeError(last)
+
+
+def _classify(name: str, published: str | None, expected: str, *, error: str | None = None) -> dict[str, Any]:
+    if error:
+        return {"surface": name, "status": "unreachable", "version": published or "—", "expected": expected, "error": error}
+    if not published:
+        return {"surface": name, "status": "unreachable", "version": "—", "expected": expected, "error": "no version found"}
+    status = "fresh" if published == expected else "stale"
+    return {"surface": name, "status": status, "version": published, "expected": expected}
+
+
+def probe_pypi(expected: str, **kw: Any) -> dict[str, Any]:
+    try:
+        data = _http_json("https://pypi.org/pypi/agent-bom/json", **kw)
+        version = (data.get("info") or {}).get("version")
+        return _classify("PyPI", version, expected)
+    except RuntimeError as exc:
+        return _classify("PyPI", None, expected, error=str(exc))
+
+
+def probe_docker(expected: str, image: str, **kw: Any) -> dict[str, Any]:
+    """Confirm the expected tag exists on the registry.
+
+    For ghcr we query the package-tags listing (anonymous for public packages);
+    for Docker Hub we query the registry tags API. Presence of the exact version
+    tag means the release was published; absence means it is missing/stale.
+    """
+    image = image.strip()
+    try:
+        if image.startswith("ghcr.io/"):
+            # ghcr public images: token from anonymous auth, then registry tags list.
+            repo = image[len("ghcr.io/") :]
+            token_data = _http_json(
+                f"https://ghcr.io/token?scope=repository:{repo}:pull&service=ghcr.io",
+                **kw,
+            )
+            token = token_data.get("token", "")
+            tags_data = _http_json(
+                f"https://ghcr.io/v2/{repo}/tags/list",
+                headers={"Authorization": f"Bearer {token}"} if token else None,
+                **kw,
+            )
+            tags = set(tags_data.get("tags") or [])
+        else:
+            repo = image if "/" in image else f"library/{image}"
+            tags: set[str] = set()
+            url = f"https://hub.docker.com/v2/repositories/{repo}/tags?page_size=100"
+            data = _http_json(url, **kw)
+            for entry in data.get("results", []):
+                if entry.get("name"):
+                    tags.add(entry["name"])
+        # Registries publish either bare (0.88.6) or v-prefixed (v0.88.6) tags;
+        # normalize so the comparison is prefix-insensitive.
+        norm = {t.lstrip("v") for t in tags}
+        if expected in norm:
+            return _classify("Docker", expected, expected)
+        # The expected tag is missing — report the surface as stale, naming the
+        # newest semver tag we did find so the issue is actionable.
+        semver = sorted(
+            (t for t in norm if re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", t)),
+            key=lambda v: [int(p) for p in v.split(".")],
+        )
+        return _classify("Docker", semver[-1] if semver else None, expected)
+    except RuntimeError as exc:
+        return _classify("Docker", None, expected, error=str(exc))
+
+
+def probe_glama(expected: str, **kw: Any) -> dict[str, Any]:
+    """Delegate to check_glama_listing.py so the probe logic stays in one place."""
+    proc = subprocess.run(  # noqa: S603
+        [sys.executable, str(GLAMA_SCRIPT), "--expected", expected, "--json"],
+        capture_output=True,
+        text=True,
+        env=os.environ.copy(),
+    )
+    raw = (proc.stdout or "").strip().splitlines()
+    payload: dict[str, Any] = {}
+    for line in reversed(raw):
+        try:
+            payload = json.loads(line)
+            break
+        except json.JSONDecodeError:
+            continue
+    status = payload.get("status", "unreachable")
+    return {
+        "surface": "Glama",
+        "status": status,
+        "version": payload.get("listing_version", "—"),
+        "expected": expected,
+        "error": payload.get("error"),
+    }
+
+
+def probe_smithery(expected: str, url: str, **kw: Any) -> dict[str, Any]:
+    if not url:
+        return {
+            "surface": "Smithery",
+            "status": "not_configured",
+            "version": "—",
+            "expected": expected,
+            "error": "no SMITHERY_MCP_URL — set the repo variable to monitor this surface",
+        }
+    try:
+        proc = subprocess.run(  # noqa: S603
+            [
+                sys.executable,
+                "-m",
+                "agent_bom.deployment_probe",
+                "--base-url",
+                url,
+                "--attempts",
+                str(kw.get("attempts", DEFAULT_ATTEMPTS)),
+                "--backoff-seconds",
+                str(kw.get("backoff", DEFAULT_BACKOFF)),
+                "--timeout",
+                str(kw.get("timeout", DEFAULT_TIMEOUT)),
+            ],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "PYTHONPATH": str(ROOT / "src")},
+        )
+        data = json.loads(proc.stdout or "{}")
+        version = data.get("version")
+        return _classify("Smithery", version, expected)
+    except (json.JSONDecodeError, OSError, ValueError) as exc:
+        return _classify("Smithery", None, expected, error=str(exc))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--expected", default=None, help="Override expected version (defaults to pyproject.toml).")
+    parser.add_argument("--docker-image", default=os.environ.get("DOCKER_IMAGE", DEFAULT_DOCKER_IMAGE))
+    parser.add_argument("--smithery-url", default=os.environ.get("SMITHERY_MCP_URL", ""))
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    parser.add_argument("--attempts", type=int, default=DEFAULT_ATTEMPTS)
+    parser.add_argument("--backoff-seconds", type=float, default=DEFAULT_BACKOFF)
+    parser.add_argument("--out", default=None, help="Write the consolidated JSON report to this path.")
+    args = parser.parse_args(argv)
+
+    expected = (args.expected or _expected_version()).lstrip("v").strip()
+    kw = {"timeout": args.timeout, "attempts": args.attempts, "backoff": args.backoff_seconds}
+
+    surfaces = [
+        probe_pypi(expected, **kw),
+        probe_docker(expected, args.docker_image, **kw),
+        probe_glama(expected, **kw),
+        probe_smithery(expected, args.smithery_url, **kw),
+    ]
+
+    drift = [s for s in surfaces if s["status"] in ALERT_STATUSES]
+    report = {
+        "expected": expected,
+        "all_fresh": len(drift) == 0,
+        "surfaces": surfaces,
+    }
+
+    out = json.dumps(report, indent=2)
+    if args.out:
+        Path(args.out).write_text(out + "\n")
+    print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes the gap where Smithery sat 3 months stale and nobody was alerted (Docker is 8 releases behind too).

- **`surface-freshness.yml`** (new, daily + dispatch) — `check_surface_freshness.py` probes PyPI / Docker / Glama / Smithery (published vs expected) and maintains ONE consolidated drift issue. Self-closes when all fresh. Delegates Glama to the existing `check_glama_listing.py` (from #2988).
- **`deployment-freshness.yml`** — the silent-skip bug fixed: a surface with missing config (e.g. `SMITHERY_MCP_URL` unset) now opens an 'UNMONITORED' tracking issue instead of silently passing.
- **`smithery.yaml`** metadata refreshed (69 tools, description, homepage) so the next deploy carries current info.

Mirrors the existing github-script dedupe-by-title issue pattern. All YAML valid; live probe confirmed (flags PyPI 0.88.5 / Docker stale vs repo). Maintainer must set `SMITHERY_MCP_URL` / `GLAMA_LISTING_URL` vars for full coverage (already partly done).