### PR TITLE
docs: repo clarity + hygiene (repo-map · architecture diagrams · start-here · gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,9 @@ deploy/helm/agent-bom/**/* [0-9].yaml
 # Local working screenshots dropped at the repo root (graph/console captures);
 # real docs imagery lives under docs/images/.
 /*.png
+
+# Working-copy hygiene — Finder/iCloud duplicate copies, scan-output, macOS cruft
+* 2.*
+*-report.json
+agent-bom-report.json
+.DS_Store

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -1,0 +1,171 @@
+# Project Structure
+
+A repo-map for `agent-bom`: where things live, which trees are canonical, and
+how the `src/agent_bom/` package is organized into subsystems. Start here when
+you ask **"where does X live?"**
+
+`agent-bom` is a single pure-Python package (~221K LoC) that exposes one shared
+evidence model through many surfaces: CLI/CI, REST API, MCP server, dashboard,
+and runtime proxy/gateway. The package is intentionally broad — this map groups
+its modules so the breadth reads as a system, not a flat sprawl.
+
+For the layered architecture and data-flow diagrams, see
+[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). For role-based entry paths, see
+[`docs/START_HERE.md`](docs/START_HERE.md).
+
+---
+
+## Top-level layout
+
+| Path | What it is | Canonical? |
+|---|---|---|
+| `src/agent_bom/` | The product. All scanner, control-plane, MCP, and output code. | **Yes** — the single source of truth for behavior. |
+| `tests/` | Test suite (pytest, parallelized with pytest-xdist). | Yes. |
+| `docs/` | Operator- and contributor-facing reference docs (this tree). | **Yes** — canonical for engineering/reference docs. |
+| `site-docs/` | MkDocs source for the published docs site. | **Yes** — canonical for the *narrative/getting-started* site; see [Documentation map](#documentation-map). |
+| `ui/` | Next.js 16 + React 19 + Tailwind 4 dashboard (the human cockpit). | Yes — the active UI. |
+| `dashboard/` | Static/build assets and supporting dashboard files. | Build support for the UI. |
+| `sdks/` | Client SDKs: `python`, `go`, `typescript`, `typescript-client`, `shared`. | Yes — typed control-plane clients (not scanner SDKs). |
+| `deploy/` | Helm chart, docker-compose pilot, EKS reference, deployment manifests. | Yes. |
+| `contracts/` | Cross-surface contract fixtures. | Yes. |
+| `docs/openapi/v1.json` | Committed OpenAPI spec — the canonical REST contract (230 paths / 271 operations). | **Yes** — SDK + client contract checks read this. |
+| `scripts/` | Release, deploy, and consistency tooling (e.g. `check_release_consistency.py`). | Yes. |
+| `integrations/` | External tool integrations and examples. | Yes. |
+| `examples/`, `config/`, `security/`, `fuzz/` | Samples, config, security policy, fuzz harnesses. | Support material. |
+| `AGENTS.md`, `CLAUDE.md` | Contributor/agent operating rules. Read `AGENTS.md` first. | Yes. |
+| `README.md`, `PYPI_README.md`, `DOCKER_HUB_README.md`, `DOCKER_HUB_UI_README.md` | Front doors per distribution channel; kept in sync by `scripts/check_release_consistency.py`. | Yes — each is canonical for its channel. |
+
+---
+
+## `src/agent_bom/` subsystems
+
+The package has ~192 top-level modules plus 22 subpackages. Grouped by the role
+each plays in the **collect → normalize → serve → enforce** pipeline:
+
+### 1. Scan layer — collect evidence
+
+Turn an input (repo, image, SBOM, MCP config, cloud account) into raw inventory
+and findings.
+
+| Subsystem | Path | Responsibility |
+|---|---|---|
+| Discovery | `discovery/` | Find local AI agents and MCP clients/servers (29 first-class client types plus dynamic/project surfaces). |
+| Parsers | `parsers/` | Extract packages from lockfiles/manifests across 15 ecosystems; parse skills, dataset cards, browser extensions, OS packages. |
+| Scanners | `scanners/` | OSV batch scan, CVSS, vendor advisories (GHSA/Intel/AMD/NVIDIA/firmware), `blast_radius.py`, risk scoring. |
+| Cloud | `cloud/` | Read-only, gated estate inventory + CIS benchmarks (AWS/Azure/GCP) and AI/GPU provider posture. |
+| IaC | `iac/` | Terraform, CloudFormation, Helm, Kubernetes, Dockerfile, dbt scanning + ATT&CK/ATLAS mapping. |
+| Identity (NHI) | `identity/` | Non-human identity discovery (Okta/Entra, gated). |
+| Containers | `oci_parser.py`, `image.py`, `filesystem.py` | Native OCI image + disk-image parsing (no Rust/Go on the scan path). |
+| SAST / secrets | `sast.py`, `ast_*.py`, `secret_scanner.py`, `malicious.py`, `model_pickle_scan.py` | Source analysis, secret detection, safe malicious-model disassembly. |
+
+### 2. Enrichment — add intelligence
+
+| Subsystem | Path | Responsibility |
+|---|---|---|
+| Enrichment | `enrichment.py`, `enrichment_posture.py` | NVD CVSS, EPSS, CISA KEV, GHSA enrichment. |
+| Compliance | `compliance_coverage.py`, `owasp*.py`, `nist_*.py`, `atlas.py`, `mitre_*.py`, `eu_ai_act.py`, `iso_27001.py`, `soc2.py`, `cis_controls.py`, `cmmc.py`, `pci_dss.py`, `fedramp.py` | Tag findings against curated framework controls (see ARCHITECTURE §4). |
+| Cost (FinOps) | `cost_model.py`, `api/cost_*.py` | LLM spend forecasting, budget runway, chargeback, anomaly detection. |
+| Cross-env / correlation | `cross_env_correlation.py`, `correlate.py`, `runtime_correlation.py` | Fuse evidence across environments and runtime logs. |
+
+### 3. Unified Finding + ContextGraph — the convergence point
+
+Every scan path lands on **one** `Finding` model and **one** graph, so blast
+radius, attack-path fusion, and exposure scoring all read the same evidence.
+
+| Subsystem | Path | Responsibility |
+|---|---|---|
+| Models | `models.py`, `finding.py` | Core data models: `Package`, `Vulnerability`, `Agent`, `Finding`, `BlastRadius`. |
+| Graph (canonical) | `graph/` | `builder.py` builds the `UnifiedGraph` from serialized report JSON; `node.py`/`edge.py`/`types.py`/`container.py` define the schema; overlays add CNAPP/NHI/governance context; `attack_path_fusion.py` and `blast_reach.py` score exposure. |
+| Graph (legacy bridge) | `context_graph.py` | Legacy lateral-movement graph. **In-progress migration** — see [Graph migration](#graph-migration-split-brain). |
+
+### 4. Control plane — serve + enforce
+
+The self-hosted operator surface. Same evidence, multi-tenant, audited.
+
+| Subsystem | Path | Responsibility |
+|---|---|---|
+| API | `api/` | FastAPI app. `routes/` (30 route modules; 271 REST operations + 2 WebSocket), `middleware.py` (4 layers), and `*_store.py`/`postgres_*.py` persistence (SQLite default, Postgres for clusters, optional Snowflake/ClickHouse). |
+| MCP server | `mcp_server*.py`, `mcp_tools/` | FastMCP server advertising 69 tools, 6 resources, 6 prompts (mostly read-only; 3 Shield write actions fail closed). |
+| Runtime enforcement | `proxy*.py`, `gateway*.py`, `firewall*.py`, `shield.py`, `runtime/`, `enforcement.py` | MCP traffic proxy, secure-by-default gateway, inline firewall, Shield enforcement. **Spread by design** — see [Runtime enforcement spread](#runtime-enforcement-spread). |
+| Auth / tenancy | `rbac.py`, `permissions.py`, `entitlements.py`, `mcp_tenant.py`, `api/auth.py`, `api/oidc.py` | RBAC roles, tenant scoping, API keys, OIDC/SAML/SCIM. |
+| Fleet | `fleet/`, `fleet_scan.py` | Endpoint/collector inventory pushed into one control plane. |
+| Audit | `audit_integrity.py`, `audit_replay.py`, `api/audit_log.py` | HMAC-chained audit trail + integrity verification. |
+
+### 5. Outputs — decisions and artifacts
+
+| Subsystem | Path | Responsibility |
+|---|---|---|
+| Output formatters | `output/` | JSON, SARIF, CycloneDX, SPDX, OCSF, HTML, PDF, CSV, Markdown, JUnit, Prometheus, console, plus graph/mermaid/svg/badge renderers. |
+| SIEM / connectors | `siem/`, `connectors/`, `integrations/` | OCSF SIEM export; Jira/Slack/ServiceNow/Vanta/Drata. |
+| Alerts | `alerts/` | Dedup, dispatch, scan alerts. |
+| Evidence | `evidence/`, `compliance_hub*.py`, `database_evidence.py` | Compliance evidence bundles and policy evidence. |
+
+### 6. CLI — the developer/CI entry point
+
+| Subsystem | Path | Responsibility |
+|---|---|---|
+| CLI | `cli/` | Click entry point. 48 top-level commands (plus an inline `upgrade`) across 7 help categories. See [`docs/CLI_MAP.md`](docs/CLI_MAP.md). |
+
+---
+
+## Graph migration (split-brain)
+
+The graph subsystem is mid-consolidation. Newcomers should know which is the
+future:
+
+- **Legacy / bridge:** `src/agent_bom/context_graph.py` — the original
+  lateral-movement graph that operates on raw JSON dicts. It still backs some
+  CLI/API paths and converts to the canonical model via `to_unified_graph()`.
+- **Canonical / target:** `src/agent_bom/graph/builder.py` builds the
+  `UnifiedGraph` (`graph/container.py`, `graph/node.py`, `graph/edge.py`,
+  `graph/types.py`). New graph features belong here.
+- **The bridge:** `src/agent_bom/graph/compat.py` maps legacy node/edge kinds
+  (`NODE_KIND_TO_ENTITY`, `EDGE_KIND_TO_RELATIONSHIP`) onto the canonical
+  `EntityType`/`RelationshipType` enums so conversion doesn't silently drop
+  identity or relationship edges.
+
+**Direction of travel:** add to `graph/`, treat `context_graph.py` as a bridge
+that will shrink over time. The graph contract (entity/edge coverage, accuracy
+guarantees, scaling tiers, known gaps) is in
+[`docs/graph/CONTRACT.md`](docs/graph/CONTRACT.md).
+
+See [`docs/GRAPH_MIGRATION.md`](docs/GRAPH_MIGRATION.md) for the full note.
+
+---
+
+## Runtime enforcement spread
+
+Runtime enforcement is intentionally **not** one module — it is layered across
+several so each enforcement point can be adopted independently:
+
+- `proxy.py` + `proxy_*.py` — wrap a target MCP server for traffic inspection,
+  inline detectors, and audited policy decisions (optionally Docker/Podman
+  sandboxed via `proxy_sandbox.py`).
+- `gateway.py` + `gateway_*.py` + `gateway_server.py` — the secure-by-default
+  central gateway and its policy templates/upstreams.
+- `firewall.py` + `firewall_client.py` — inline inter-agent firewall decisions.
+- `shield.py` — Shield enforcement actions (the 3 write actions that fail
+  closed without admin role + scope + audit reason).
+- `runtime/` — runtime detectors, patterns, and the runtime server.
+
+These share the same policy evaluator and audit sink, so a finding's exposure
+path stays explainable across whichever enforcement layer is in use.
+
+---
+
+## Documentation map
+
+`agent-bom` keeps documentation in a few deliberate trees. Use this to know
+which is the source of truth for what:
+
+| Tree | Source of truth for | Format |
+|---|---|---|
+| `docs/` | Engineering + operator reference (architecture, threat model, MCP server, deployment, graph contract, this structure map). | Markdown, read on GitHub. |
+| `site-docs/` | The **published docs site** ([msaad00.github.io/agent-bom](https://msaad00.github.io/agent-bom/)) — getting-started, tutorials, narrative walkthroughs. | MkDocs. |
+| `README.md` (root) | The repository front door. | Markdown. |
+| `PYPI_README.md` / `DOCKER_HUB*.md` | Per-channel front doors, kept consistent by the release-consistency gate. | Markdown. |
+
+When a topic exists in both `docs/` and `site-docs/`, `docs/` is canonical for
+the engineering reference and `site-docs/` is canonical for the
+narrative/onboarding version. See [`docs/README.md`](docs/README.md) for the
+audience-grouped index.

--- a/README.md
+++ b/README.md
@@ -233,6 +233,10 @@ Screenshot capture rules and the full manifest live in
 The base wheel is the scanner and CLI path. Optional runtime surfaces fail fast
 with install hints when their extras are missing.
 
+New to the repo? [PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md) is the repo map,
+[docs/START_HERE.md](docs/START_HERE.md) routes you by role, and
+[docs/CLI_MAP.md](docs/CLI_MAP.md) groups every command by domain.
+
 MCP registry publishing is tracked through the committed Smithery manifest and
 other registry metadata; install and liveness checks stay in the linked
 integration docs instead of this front door.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,6 +51,160 @@ flowchart TB
 | Control plane | `agent-bom agents -p . --push-url ...` | fleet inventory, scan jobs, graph state | Helm/EKS with Postgres and tenant auth |
 | Runtime enforcement | `agent-bom proxy ...` or `agent-bom mcp server` | audit JSONL, policy decisions, blocks | gateway/proxy sidecars and Shield SDK |
 
+For a repo-level map of where each layer lives in `src/agent_bom/`, see
+[`PROJECT_STRUCTURE.md`](../PROJECT_STRUCTURE.md). For role-based entry paths,
+see [`START_HERE.md`](START_HERE.md).
+
+---
+
+## 1a. Layered Stack
+
+The product reads top to bottom: inputs are normalized into one `Finding` and
+one `ContextGraph`, the control plane serves and enforces over that evidence,
+and outputs flow to both humans and headless agents. Each layer carries a single
+**value** line — what it buys you, not just what it is.
+
+```mermaid
+flowchart TB
+    subgraph L1["Inputs - meet teams where their evidence already lives"]
+        IN["Repos · lockfiles · SBOMs\nContainer images · IaC\nMCP configs · repo URLs\nCloud accounts · runtime events"]
+    end
+    subgraph L2["Scanners - breadth without standing up agents"]
+        SC["Discovery · parsers (15 ecosystems)\nOSV/advisory scanners · cloud · IaC · SAST · secrets"]
+    end
+    subgraph L3["Unified Finding - one model, so triage never forks per source"]
+        FD["Finding + enrichment\nNVD CVSS · EPSS · KEV · GHSA · compliance tags"]
+    end
+    subgraph L4["ContextGraph - turn a CVE row into a reachable blast radius"]
+        GR["UnifiedGraph\nattack-path fusion · blast reach · exposure scoring"]
+    end
+    subgraph L5["Control plane - same evidence, multi-tenant + audited"]
+        direction TB
+        MW["Middleware: auth · RBAC · tenant scope · rate-limit · audit"]
+        API["REST API (271 ops)"]
+        GW["Gateway / MCP server / proxy"]
+        MW --> API
+        MW --> GW
+    end
+    subgraph L6["Outputs - decisions in the format each consumer already trusts"]
+        OUT["SARIF · CycloneDX · SPDX · OCSF\nHTML · PDF · JSON · CSV · webhooks"]
+    end
+    subgraph L7["Consumers - one model, two audiences"]
+        HUM["Humans: CLI · UI cockpit"]
+        AG["Headless: MCP tools · REST API"]
+    end
+
+    L1 --> L2 --> L3 --> L4 --> L5 --> L6 --> L7
+```
+
+---
+
+## 1b. Data Flow - one scan request
+
+A single scan request walks discovery → extraction → scan → finding → graph →
+outputs. The same lower libraries serve the CLI and the API.
+
+```mermaid
+flowchart LR
+    REQ["Scan request\n(repo / path / image /\nSBOM / MCP config / URL / cloud)"]
+    DISC["Discovery\nfind agents, MCP servers, targets"]
+    EXT["Extraction\nparse packages, manifests, configs"]
+    SCAN["Scan\nOSV batch + advisories"]
+    ENR["Enrichment\nCVSS · EPSS · KEV · GHSA · compliance"]
+    FIND["Unified Finding\nnormalized, deduped, scored"]
+    GRAPH["ContextGraph\npackage → finding → server → tool → cred → agent"]
+    OUT["Outputs\nconsole · SARIF · SBOM · HTML · graph export · webhooks"]
+
+    REQ --> DISC --> EXT --> SCAN --> ENR --> FIND --> GRAPH --> OUT
+```
+
+**Value at each hop:** discovery finds shadow AI you did not know to ask about ·
+extraction reads 15 ecosystems with one command · enrichment ranks by real-world
+exploitability, not just CVSS · the graph makes "which agent does this reach?"
+answerable · outputs land in the gate, ticket, or SIEM you already run.
+
+---
+
+## 1c. Frontend · Backend · Middleware
+
+The dashboard is one door into the product, not the only one. The Next.js UI and
+every headless caller hit the same FastAPI surface, behind the same middleware,
+over the same stores.
+
+```mermaid
+flowchart TB
+    subgraph FE["Frontend - human cockpit"]
+        UI["Next.js 16 · React 19 · Tailwind 4\ninventory · findings · graph · compliance · runtime"]
+    end
+    subgraph MW["Middleware - one enforcement seam for every caller"]
+        M1["TrustHeaders"]
+        M2["API key · auth · RBAC · tenant scope"]
+        M3["Rate limit"]
+        M4["Max body size"]
+    end
+    subgraph BE["Backend - FastAPI"]
+        R["271 REST operations across 30 route modules\nplus 2 WebSocket routes"]
+    end
+    subgraph ST["Stores - start on SQLite, scale to a cluster without rewrites"]
+        S1["SQLite (default / single node)"]
+        S2["Postgres (multi-replica)"]
+        S3["Graph store · optional Snowflake / ClickHouse"]
+    end
+
+    EXTAGENT["Headless: MCP server · REST API · SDK clients"]
+
+    UI -->|HTTPS| MW
+    EXTAGENT -->|HTTPS| MW
+    MW --> BE --> ST
+```
+
+**Value:** the middleware seam means auth, tenant isolation, and audit are
+enforced once for the UI, agents, and SDKs alike — there is no privileged
+"UI-only" backdoor.
+
+---
+
+## 1d. Input / Output Formats
+
+agent-bom is format-agnostic on both ends: ingest whatever evidence exists,
+emit whatever the next tool consumes.
+
+```mermaid
+flowchart LR
+    subgraph INPUTS["Inputs - no pre-instrumentation required"]
+        I1["Repo / path"]
+        I2["Container image"]
+        I3["SBOM"]
+        I4["MCP config"]
+        I5["Repo URL"]
+        I6["Cloud account"]
+        I7["IaC files"]
+    end
+    CORE["Unified Finding\nplus ContextGraph"]
+    subgraph OUTPUTS["Outputs - drop into the tool you already run"]
+        O1["SARIF - code scanning"]
+        O2["CycloneDX - SBOM"]
+        O3["SPDX - SBOM"]
+        O4["OCSF - SIEM"]
+        O5["HTML / PDF - review"]
+        O6["JSON / CSV - automation"]
+        O7["Webhooks - alerting"]
+    end
+
+    I1 & I2 & I3 & I4 & I5 & I6 & I7 --> CORE
+    CORE --> O1 & O2 & O3 & O4 & O5 & O6 & O7
+```
+
+| Input | Value | Output | Value |
+|---|---|---|---|
+| Repo / path | scan source where it lives | SARIF | native code-scanning ingest |
+| Container image | catch base-image + layer risk | CycloneDX / SPDX | portable SBOM for downstream tooling |
+| SBOM | re-score an existing inventory | OCSF | normalized SIEM events |
+| MCP config | map the agent ↔ server ↔ tool mesh | HTML / PDF | human-reviewable evidence |
+| Repo URL | scan code you have not cloned | JSON / CSV | machine-readable for pipelines |
+| Cloud account | read-only estate + CIS posture | Webhooks | push to alerting / ticketing |
+| IaC files | block unsafe infra pre-deploy | | |
+
 ---
 
 ## 2. Scan Pipeline

--- a/docs/CLI_MAP.md
+++ b/docs/CLI_MAP.md
@@ -1,0 +1,125 @@
+# CLI Command Map
+
+`agent-bom` ships 48 top-level commands (plus an inline `upgrade`) under a
+single Click entry point. The CLI groups them into 7 help categories — run
+`agent-bom --help` to see this layout live. Grouping is defined in
+[`../src/agent_bom/cli/_grouped_help.py`](../src/agent_bom/cli/_grouped_help.py).
+
+Many commands are themselves groups with subcommands (e.g. `cloud`, `identity`,
+`runtime`, `mcp`). This map covers the top-level surface; run `<command> --help`
+for subcommands.
+
+---
+
+## Scanning
+
+Inventory, package, image, IaC, cloud, and skills scanning entry points.
+
+| Command | What it does |
+|---|---|
+| `agents` | Discover local AI agents + MCP servers, scan packages, build blast radius. The primary scan. |
+| `skills` | Scan skills / instruction files for packages, servers, trust, findings. |
+| `image` | Scan a container image. |
+| `fs` | Scan a filesystem / disk image. |
+| `iac` | Scan IaC: Dockerfile, Terraform, CloudFormation, Helm, Kubernetes. |
+| `sbom` | Generate or scan an SBOM (CycloneDX / SPDX). |
+| `cloud` | Cloud posture + estate inventory (AWS/Azure/GCP), CIS benchmarks. |
+| `check` | Pre-install check for one package: allow / warn / block. |
+| `verify` | Package integrity + SLSA provenance verification. |
+| `secrets` | Secret detection. |
+| `code` | SAST scanning with CWE-based compliance mapping. |
+
+## Runtime
+
+Live MCP enforcement, replay, and runtime monitoring.
+
+| Command | What it does |
+|---|---|
+| `proxy` | Wrap a target MCP server for traffic inspection and policy decisions. |
+| `runtime` | Group: `runtime proxy`, `runtime audit`, plus configure/bootstrap. |
+| `watch` | Continuous / scheduled monitoring. |
+| `firewall` | Inter-agent firewall decisions group. |
+| `gateway` | Secure-by-default gateway group. |
+| `sidecar-injector` | Inject runtime proxy sidecars. |
+
+## MCP
+
+Discovery, inventory, introspection, and MCP server operations.
+
+| Command | What it does |
+|---|---|
+| `mcp` | Group: run the MCP **server** (`mcp server`), introspect, inventory. |
+| `where` | Show every MCP discovery path + existence status. |
+| `registry` | Query the MCP server security-metadata registry. |
+
+## Reporting
+
+Graph, mesh, dashboard, and narrative reporting workflows.
+
+| Command | What it does |
+|---|---|
+| `graph` | Build / export the context graph. |
+| `mesh` | Agent-mesh view. |
+| `report` | Reporting group (history, narrative, exports). |
+
+## Governance
+
+Policy, trust, fleet, FinOps, identity, API, scheduling, and control-plane ops.
+
+| Command | What it does |
+|---|---|
+| `policy` | Policy-as-code group. |
+| `trust` | Trust-boundary commands. |
+| `fleet` | Fleet inventory group. |
+| `cost` | LLM cost / FinOps group (forecast, budget, chargeback). |
+| `identity` | Non-human identity group (credential-expiry, access review). |
+| `serve` | Run the local API + bundled dashboard. |
+| `api` | API control-plane command. |
+| `schedule` | Scheduled scans. |
+| `remediate` | Generate / apply remediation plans. |
+| `teardown` | Deployment teardown. |
+| `run` | Run a configured operation. |
+| `manifest` | Agent manifest operations. |
+| `plugins` | Plugin entry-point group. |
+| `profiles` | Deploy profiles group. |
+| `guard` | Pre-install CVE guard for pip/npm. |
+| `audit` / `audit-drain-dlq` | Audit-chain replay and DLQ drain. |
+
+## Database
+
+Local cache, vuln database, and framework catalog maintenance.
+
+| Command | What it does |
+|---|---|
+| `db` | Local cache, vuln DB, and framework-catalog maintenance group. |
+
+## Utilities
+
+| Command | What it does |
+|---|---|
+| `upgrade` | Check for / install agent-bom updates (inline command). |
+| `completions` | Shell completion helpers. |
+| `doctor` | Environment / install diagnostics. |
+| `samples` | Generate inspectable sample stacks. |
+| `quickstart` | One-command guided onboarding. |
+| `interactive` | Interactive mode. |
+| `scanners` | List available scanners. |
+
+---
+
+## Intentional aliases
+
+Some commands are reachable by more than one name on purpose — the same command
+object is registered in two places so both the flat and grouped form work:
+
+| Flat (top-level) | Grouped | Notes |
+|---|---|---|
+| `agent-bom proxy …` | `agent-bom runtime proxy …` | Same `proxy_cmd`. Top-level for discoverability; grouped form keeps runtime commands together. |
+| `agent-bom proxy-bootstrap` | `agent-bom runtime bootstrap` | Same command, flat + grouped. |
+| `agent-bom audit` | `agent-bom runtime audit` | Same `audit_replay_cmd` (proxy audit-log replay). |
+| `agent-bom audit-drain-dlq` | `agent-bom runtime drain-dlq` | Same command, flat + grouped. |
+| _(none)_ | `agent-bom runtime configure` | `proxy_configure_cmd` is grouped-only — no flat alias. |
+
+These are deliberate ergonomic aliases, not duplicate logic. The grouped
+(`runtime …`) form is the organizing home; the flat forms exist because runtime
+enforcement and audit are common enough first steps to deserve top-level verbs.

--- a/docs/GRAPH_MIGRATION.md
+++ b/docs/GRAPH_MIGRATION.md
@@ -1,0 +1,60 @@
+# Graph Migration Note
+
+The graph subsystem is mid-consolidation. This note tells newcomers which
+implementation is the future and how the two sides bridge today, so new work
+lands in the right place.
+
+For the full graph contract (entity/edge coverage, accuracy guarantees, scaling
+tiers, known gaps), see [`graph/CONTRACT.md`](graph/CONTRACT.md).
+
+---
+
+## The two graphs
+
+| | Legacy / bridge | Canonical / target |
+|---|---|---|
+| Module | `src/agent_bom/context_graph.py` | `src/agent_bom/graph/` |
+| Builds | An in-memory lateral-movement graph from raw scan JSON dicts | The `UnifiedGraph` from the serialized AIBOM report contract |
+| Core types | local `NodeKind` / `EdgeKind` | `EntityType` / `RelationshipType` (`graph/types.py`) |
+| Status | Still backs some CLI/API paths; **shrinking** | Where all new graph features belong |
+
+`context_graph.py` answers "if Agent A is compromised, what else becomes
+reachable?" over raw dicts (the same shape `output/attack_flow.py` consumes),
+which is why it predates the unified model. It converts forward to the canonical
+model via `to_unified_graph()`.
+
+`graph/builder.py` ingests the JSON contract emitted by
+`output.json_fmt.to_json()` and assembles the canonical inventory, finding,
+runtime, and compliance entities used for current-state views, traversal,
+attack paths, and temporal diffs.
+
+---
+
+## The bridge
+
+`src/agent_bom/graph/compat.py` keeps the two sides aligned during the
+migration. It holds the mapping dicts that convert legacy kinds onto the
+canonical enums so nothing is silently dropped:
+
+- `NODE_KIND_TO_ENTITY` — e.g. legacy `iam_role` → `EntityType.SERVICE_ACCOUNT`,
+  so cloud/workload identity context survives conversion.
+- `EDGE_KIND_TO_RELATIONSHIP` — e.g. legacy `attached_to` →
+  `RelationshipType.MEMBER_OF`, so identity-membership edges are preserved.
+
+---
+
+## Direction of travel
+
+- **Add new graph capabilities under `src/agent_bom/graph/`** — the
+  `UnifiedGraph` (`graph/container.py`, `graph/node.py`, `graph/edge.py`,
+  `graph/types.py`) plus overlays (`cnapp_overlay.py`, `nhi_overlay.py`,
+  `governance_overlay.py`) and scoring (`attack_path_fusion.py`,
+  `blast_reach.py`).
+- **Treat `context_graph.py` as a bridge**, not a place to extend. When a path
+  that still uses it gets touched, prefer moving it onto the canonical builder
+  and the `compat.py` mappings rather than growing the legacy types.
+- When you add a legacy kind that has no canonical mapping yet, add it to
+  `compat.py` in the same change so conversion stays lossless.
+
+The consolidation is intentional and in progress — this is not a fork, it is a
+one-directional move from `context_graph.py` to `graph/builder.py`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,29 +1,59 @@
 # Docs Index
 
-Keep top-level `docs/` focused on operator-facing and externally useful material.
+> **Canonical docs tree.** `docs/` is the source of truth for **engineering and
+> operator reference** material. The **getting-started / narrative** version of
+> the docs is the MkDocs site under [`../site-docs/`](../site-docs/index.md),
+> published at <https://msaad00.github.io/agent-bom/>. When a topic appears in
+> both, `docs/` is canonical for the reference detail and `site-docs/` is
+> canonical for the onboarding walkthrough. See
+> [`../PROJECT_STRUCTURE.md#documentation-map`](../PROJECT_STRUCTURE.md#documentation-map).
 
-Canonical docs here:
+New here? Start with [`START_HERE.md`](START_HERE.md) (role-based entry paths)
+and [`../PROJECT_STRUCTURE.md`](../PROJECT_STRUCTURE.md) (repo map).
 
-- `ARCHITECTURE.md`
-- `CONTROL_MAPPING.md`
-- `DATABASE_EVIDENCE.md`
-- `DEPLOYMENT.md`
-- `ENTERPRISE.md`
-- `ENTERPRISE_DEPLOYMENT.md`
-- `ENTERPRISE_SECURITY_POSTURE.md`
-- `MCP_CLIENT_GUIDES.md`
-- `MCP_SERVER.md`
-- `PERMISSIONS.md`
-- `RELEASE_VERIFICATION.md`
-- `SECURITY_ARCHITECTURE.md`
-- `SUPPLY_CHAIN.md`
-- `THREAT_MODEL.md`
+Keep top-level `docs/` focused on operator-facing and externally useful
+material. The index below groups the canonical docs by audience.
 
-Graph docs:
+---
 
-- `graph/CONTRACT.md` — graph coverage, accuracy guarantees, scaling
-  boundaries, non-promises, and known gaps
-- `graph/SECURITY_GRAPH_UX_RUBRIC.md` — review rubric for
-  fix-first security graph usability and actionability
+## Orientation (start here)
+
+- [`START_HERE.md`](START_HERE.md) — role-based entry paths (security engineer / platform-SRE / AI-agent developer)
+- [`../PROJECT_STRUCTURE.md`](../PROJECT_STRUCTURE.md) — repo map: where everything lives, which trees are canonical
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — layered stack, data flow, scan pipeline, blast radius, compliance tagging (mermaid)
+- [`CLI_MAP.md`](CLI_MAP.md) — all 48 top-level commands grouped by domain + intentional aliases
+
+## Security engineers (scan · gate · export)
+
+- [`SUPPLY_CHAIN.md`](SUPPLY_CHAIN.md) — supply-chain scanning model
+- [`CONTROL_MAPPING.md`](CONTROL_MAPPING.md) — compliance framework mapping
+- [`SECURITY_ARCHITECTURE.md`](SECURITY_ARCHITECTURE.md) — security architecture
+- [`THREAT_MODEL.md`](THREAT_MODEL.md) — threat model
+- [`PENTEST_READINESS.md`](PENTEST_READINESS.md) — pentest readiness
+
+## Platform / SRE (self-host · deploy · operate)
+
+- [`DEPLOYMENT.md`](DEPLOYMENT.md) — deployment reference
+- [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md) — enterprise deployment
+- [`ENTERPRISE.md`](ENTERPRISE.md) — enterprise capabilities
+- [`ENTERPRISE_SECURITY_POSTURE.md`](ENTERPRISE_SECURITY_POSTURE.md) — security posture
+- [`PERMISSIONS.md`](PERMISSIONS.md) — RBAC roles and permissions
+- [`DATABASE_EVIDENCE.md`](DATABASE_EVIDENCE.md) — persistence and evidence stores
+- [`RELEASE_VERIFICATION.md`](RELEASE_VERIFICATION.md) — release verification
+- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (230 paths / 271 operations)
+
+## AI / agent developers (MCP · clients · tools)
+
+- [`MCP_SERVER.md`](MCP_SERVER.md) — run the MCP server, 69 tools
+- [`MCP_CLIENT_GUIDES.md`](MCP_CLIENT_GUIDES.md) — connect MCP clients
+- [`PYTHON_API.md`](PYTHON_API.md) — Python control-plane client
+
+## Graph subsystem
+
+- [`graph/CONTRACT.md`](graph/CONTRACT.md) — graph coverage, accuracy guarantees, scaling boundaries, non-promises, known gaps
+- [`graph/SECURITY_GRAPH_UX_RUBRIC.md`](graph/SECURITY_GRAPH_UX_RUBRIC.md) — review rubric for fix-first security graph usability
+- [`GRAPH_MIGRATION.md`](GRAPH_MIGRATION.md) — `context_graph.py` (legacy bridge) → `graph/builder.py` (canonical) consolidation note
+
+---
 
 Archived or historical writeups live under [`docs/archive`](archive/README.md).

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -1,0 +1,78 @@
+# Start Here
+
+`agent-bom` exposes one evidence model through several surfaces. Pick the entry
+path for your role; each row is the shortest route to value.
+
+For the repo layout, see [`../PROJECT_STRUCTURE.md`](../PROJECT_STRUCTURE.md).
+For the architecture diagrams, see [`ARCHITECTURE.md`](ARCHITECTURE.md).
+
+---
+
+## Security engineer — scan, gate, export
+
+You want findings, an SBOM, and a CI gate.
+
+```bash
+pip install agent-bom
+agent-bom agents -p .                     # scan this repo: packages, agents, MCP servers, blast radius
+agent-bom agents -p . -f sarif -o out.sarif   # SARIF for code-scanning
+agent-bom check flask@2.0.0 --ecosystem pypi  # pre-install allow/warn/block
+```
+
+CI gate (GitHub Action):
+
+```yaml
+- uses: msaad00/agent-bom@v0.88.6
+```
+
+- Output formats, exit codes, and the full command set:
+  [`CLI_MAP.md`](CLI_MAP.md)
+- What gets scanned and how findings converge:
+  [`ARCHITECTURE.md`](ARCHITECTURE.md)
+- Compliance mapping and evidence bundles: [`CONTROL_MAPPING.md`](CONTROL_MAPPING.md)
+
+## Platform / SRE — self-host the control plane
+
+You want the API, dashboard, gateway, and a deployment you own.
+
+```bash
+pip install 'agent-bom[ui]'
+agent-bom serve                           # local API + bundled dashboard
+# or a self-hosted pilot:
+docker compose -f deploy/docker-compose.pilot.yml up -d
+```
+
+- Deployment chooser (Docker / Helm / EKS / Postgres):
+  [`../site-docs/deployment/overview.md`](../site-docs/deployment/overview.md)
+- API contract (271 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
+- Enterprise auth, tenancy, RBAC: [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md),
+  [`PERMISSIONS.md`](PERMISSIONS.md)
+- Runtime proxy/gateway enforcement: [`MCP_SERVER.md`](MCP_SERVER.md) and the
+  [runtime enforcement spread](../PROJECT_STRUCTURE.md#runtime-enforcement-spread)
+
+## AI / agent developer — call it from an assistant
+
+You want strict-argument security tools your agent can call, and the ability to
+scan a repo by URL.
+
+```bash
+pip install 'agent-bom[mcp-server]'
+agent-bom mcp server                      # stdio MCP server: 69 tools, 6 resources, 6 prompts
+```
+
+- MCP server setup + client guides: [`MCP_SERVER.md`](MCP_SERVER.md),
+  [`MCP_CLIENT_GUIDES.md`](MCP_CLIENT_GUIDES.md)
+- Tool catalog (read-mostly; 3 audited Shield write actions): see the
+  `Tools (69)` block in
+  [`../src/agent_bom/mcp_server.py`](../src/agent_bom/mcp_server.py)
+- Typed control-plane clients: [`PYTHON_API.md`](PYTHON_API.md),
+  [`../sdks/go/README.md`](../sdks/go/README.md)
+
+---
+
+## One model, every door
+
+Whichever path you take, the underlying evidence is the same unified `Finding`
+and `ContextGraph`. Humans get a cockpit; agents and pipelines get callable
+primitives over identical data. That is the product shape — see
+[`ARCHITECTURE.md`](ARCHITECTURE.md) for the layered view.

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -1,5 +1,13 @@
 # agent-bom
 
+!!! info "Canonical docs tree"
+    This MkDocs site is the source of truth for **getting-started and narrative
+    documentation**. The **engineering/operator reference** lives in the
+    repository's [`docs/`](https://github.com/msaad00/agent-bom/tree/main/docs)
+    tree (architecture, threat model, deployment, graph contract, repo map).
+    When a topic appears in both, this site is canonical for onboarding and
+    `docs/` is canonical for the reference detail.
+
 **Open security scanner and self-hosted control plane for AI/MCP infrastructure.**
 
 Headless agent primitives and human cockpit surfaces use the same evidence


### PR DESCRIPTION
Pure-additive orientation so a new user/contributor grasps **who/what/why/structure** of a ~221K-LoC repo — no source moved/renamed (zero import risk). From the structure assessment (clarity 6.5→~8 with these).

**New docs:**
- **`PROJECT_STRUCTURE.md`** — repo-map: top-level dirs (canonical/not) + `src/agent_bom/` grouped into 6 subsystems + honest notes on the graph split-brain (`context_graph.py`→`graph/builder.py`) and runtime-enforcement spread.
- **`docs/START_HERE.md`** — 3 persona paths: security-eng (CLI/CI/SARIF) · platform/SRE (API/self-host/gateway) · agent-dev (MCP/repo-URL scan).
- **`docs/CLI_MAP.md`** — 48 commands grouped + intentional-alias table.
- **`docs/GRAPH_MIGRATION.md`** — marks the legacy→canonical graph direction.

**Extended:**
- **`docs/ARCHITECTURE.md`** +4 readable mermaid diagrams (layered stack · data flow · FE/BE/middleware · I/O matrix), each with a value-per-layer line. Clean grouped subgraphs, short node labels.
- **`docs/README.md` + `site-docs/index.md`** — canonical-tree banners + audience-grouped index.

**Hygiene:** `.gitignore` now ignores `* 2.*` (Finder/iCloud dups), `*-report.json`, `.DS_Store` — the dup pre-commit guard already blocks *committing* them; this stops them showing as clutter too.

Counts code-verified (15 ecosystems · 69 tools · 271 routes · 48 CLI). All 9 mermaid blocks render (mmdc 11.15). release-consistency exit 0. No competitor names.