### PR TITLE
fix(release): add version-guard to self-scan-gate needs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -699,7 +699,7 @@ jobs:
 
   self-scan-gate:
     name: Self-scan release gate
-    needs: build
+    needs: [version-guard, build]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Problem
The v0.89.0 release run (and every tag push since the workflow regressed) failed with **startup_failure** — no jobs created, no logs. Root cause: the `self-scan-gate` job referenced `\${{ needs.version-guard.outputs.version }}` while declaring only `needs: build`. GitHub validates `needs.<job>` context references at workflow startup and rejects references to a job absent from the job's `needs`, aborting the entire run before any job starts.

Found via `actionlint`: `release.yml:789: property "version-guard" is not defined in object type {build: ...}`. It was the only structural error in the release call-graph; all action pins resolve and both reusable workflows (`docs.yml`, `deploy-mcp-sse.yml`) are valid.

## Fix
`needs: build` → `needs: [version-guard, build]` on `self-scan-gate`. `version-guard` declares `outputs.version`, and `build` already depends on it, so ordering is unchanged.

## Impact
Unblocks the v0.89.0 release. Nothing was published for 0.89.0 (PyPI 404, no GitHub Release, no image), so re-running the release after merge is clean.