### PR TITLE
ci: release-safety pre-flight gate for workflow startup failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,26 @@ on:
   workflow_dispatch:
 
 jobs:
+  release-workflow-lint:
+    name: Release workflow lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Static guard against the two release-workflow startup_failure classes
+      # that GitHub reports with no logs and actionlint does not model:
+      #   1. a needs.<job> reference to a job not declared in needs:
+      #   2. a reusable-workflow call whose effective permissions are less than
+      #      the union the callee's jobs request (under a deny-all top-level)
+      # Network-free and dependency-free so it can be a hard required check.
+      - name: Validate release call-graph (needs + reusable-workflow permissions)
+        run: python3 scripts/lint_release_workflow.py .github/workflows/release.yml
+
   changes:
     name: PR Path Classifier
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,16 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+      - id: release-workflow-lint
+        name: release workflow call-graph (needs + reusable-workflow permissions)
+        # Catches the two release startup_failure classes (undeclared needs.<job>
+        # refs; reusable-workflow permission under-grant under a deny-all
+        # top-level) before they reach a tag push. actionlint misses the
+        # permission case. Network-free, dependency-free.
+        entry: python3 scripts/lint_release_workflow.py .github/workflows/release.yml
+        language: system
+        pass_filenames: false
+        files: ^\.github/workflows/(release|docs|deploy-mcp-sse)\.yml$
       - id: release-surface-consistency
         name: release surface and generated atlas consistency
         entry: python3 scripts/check_release_consistency.py

--- a/scripts/lint_release_workflow.py
+++ b/scripts/lint_release_workflow.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Static pre-flight linter for the release workflow call-graph.
+
+Catches the two startup-failure classes that GitHub reports with no logs and
+that ``actionlint`` does not model:
+
+1. **Undeclared ``needs`` references** — a job referencing
+   ``needs.<other>.outputs.*`` without listing ``<other>`` in its ``needs``.
+   (actionlint also catches this; we keep it as a backstop.)
+
+2. **Reusable-workflow permission under-grant** — a job that calls a reusable
+   workflow (``uses: ./.github/workflows/X.yml``) whose *effective* granted
+   ``GITHUB_TOKEN`` permissions (its own ``permissions:`` block, else the
+   workflow's top-level default) are *less* than the union of permissions the
+   called workflow's jobs request. GitHub forbids a reusable workflow from
+   requesting more than its caller holds and aborts the whole run at startup.
+
+Run before tagging a release. Exits non-zero with a precise message on any
+violation so a bad release.yml never reaches a tag push.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WF_DIR = ROOT / ".github" / "workflows"
+
+# GitHub token permission levels, ordered. "none" < "read" < "write".
+_LEVEL = {"none": 0, "read": 1, "write": 2}
+# Scopes that GitHub recognises for GITHUB_TOKEN.
+_SCOPES = {
+    "actions",
+    "attestations",
+    "checks",
+    "contents",
+    "deployments",
+    "discussions",
+    "id-token",
+    "issues",
+    "models",
+    "packages",
+    "pages",
+    "pull-requests",
+    "repository-projects",
+    "security-events",
+    "statuses",
+}
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def _on(doc: dict[str, Any]) -> Any:
+    # PyYAML parses the bare ``on:`` key as the boolean True.
+    return doc.get("on", doc.get(True))
+
+
+def _perms_map(perms: Any) -> dict[str, int]:
+    """Normalise a ``permissions:`` value to {scope: level-int}.
+
+    A missing block means GitHub's default; for our deny-all release workflow
+    the top-level is ``{}`` so we treat *absent at top level* conservatively as
+    the caller's responsibility (handled by the caller resolution below).
+    ``read-all`` / ``write-all`` strings expand to every scope.
+    """
+    if perms is None:
+        return {}
+    if isinstance(perms, str):
+        lvl = "read" if perms == "read-all" else "write" if perms == "write-all" else None
+        return {s: _LEVEL[lvl] for s in _SCOPES} if lvl else {}
+    out: dict[str, int] = {}
+    for scope, level in (perms or {}).items():
+        if level in _LEVEL:
+            out[scope] = _LEVEL[level]
+    return out
+
+
+def _requested_by_callee(callee: dict[str, Any]) -> dict[str, int]:
+    """Union of permissions the callee's jobs request (job-level, else top)."""
+    top = _perms_map(callee.get("permissions"))
+    union = dict(top)
+    for job in (callee.get("jobs") or {}).values():
+        if not isinstance(job, dict):
+            continue
+        jp = _perms_map(job.get("permissions")) if "permissions" in job else top
+        for scope, lvl in jp.items():
+            union[scope] = max(union.get(scope, 0), lvl)
+    return union
+
+
+def check_workflow(path: Path) -> list[str]:
+    doc = _load(path)
+    jobs = doc.get("jobs") or {}
+    top_perms = _perms_map(doc.get("permissions"))
+    has_top_perms = "permissions" in doc
+    errors: list[str] = []
+
+    job_ids = set(jobs)
+    for jid, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+
+        # (1) undeclared needs references
+        declared = job.get("needs") or []
+        if isinstance(declared, str):
+            declared = [declared]
+        declared_set = set(declared)
+        blob = yaml.safe_dump(job)
+        for other in job_ids:
+            token = f"needs.{other}."
+            if token in blob and other not in declared_set:
+                errors.append(f"{path.name}: job '{jid}' references {token}* but does not declare '{other}' in its needs:")
+
+        # (2) reusable-workflow permission parity
+        uses = job.get("uses")
+        if isinstance(uses, str) and uses.startswith("./.github/workflows/"):
+            callee_path = ROOT / uses.removeprefix("./")
+            if not callee_path.exists():
+                errors.append(f"{path.name}: job '{jid}' uses missing workflow {uses}")
+                continue
+            # Effective grant: job-level permissions if present, else top-level.
+            if "permissions" in job:
+                granted = _perms_map(job.get("permissions"))
+            elif has_top_perms:
+                granted = dict(top_perms)
+            else:
+                granted = None  # inherits repo default; cannot statically prove
+            requested = _requested_by_callee(_load(callee_path))
+            if granted is None:
+                continue
+            for scope, need in requested.items():
+                have = granted.get(scope, 0)
+                if have < need:
+                    want = [k for k, v in _LEVEL.items() if v == need][0]
+                    got = [k for k, v in _LEVEL.items() if v == have][0]
+                    errors.append(
+                        f"{path.name}: job '{jid}' calls {uses} which requests "
+                        f"'{scope}: {want}', but the job is only granted "
+                        f"'{scope}: {got}'. A reusable workflow cannot request "
+                        f"more than its caller. Add 'permissions: {{{scope}: {want}}}' "
+                        f"to job '{jid}' (top-level default is deny-all)."
+                    )
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    targets = [Path(a) for a in argv[1:]] or [WF_DIR / "release.yml"]
+    all_errors: list[str] = []
+    for t in targets:
+        all_errors.extend(check_workflow(t))
+    if all_errors:
+        print("Release workflow lint FAILED:\n")
+        for e in all_errors:
+            print(f"  ✗ {e}\n")
+        return 1
+    print(f"Release workflow lint OK ({', '.join(t.name for t in targets)}).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/preflight_release.sh
+++ b/scripts/preflight_release.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Release pre-flight: run BEFORE pushing a release tag. Catches the failure
+# classes that abort a tagged release run at startup (no logs) plus version
+# drift. Exits non-zero on the first failure so a bad state never reaches a tag.
+#
+#   scripts/preflight_release.sh [VERSION]
+#
+# If VERSION is given, asserts every managed file is already bumped to it.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+VERSION="${1:-}"
+fail=0
+step() { printf '\n=== %s ===\n' "$1"; }
+
+step "actionlint (workflow syntax + needs/context typing)"
+if command -v actionlint >/dev/null 2>&1; then
+  actionlint .github/workflows/release.yml .github/workflows/docs.yml \
+    .github/workflows/deploy-mcp-sse.yml || fail=1
+else
+  echo "WARNING: actionlint not installed — install it (brew install actionlint) for full coverage"
+fi
+
+step "release workflow call-graph lint (reusable-workflow permission parity + needs)"
+python scripts/lint_release_workflow.py .github/workflows/release.yml || fail=1
+
+step "version bump consistency"
+if [ -n "$VERSION" ]; then
+  python scripts/bump-version.py "$VERSION" --check || fail=1
+fi
+python scripts/check_release_consistency.py || fail=1
+python scripts/check_product_surface_contract.py || fail=1
+python scripts/export_openapi.py --check || fail=1
+
+if [ "$fail" -ne 0 ]; then
+  printf '\nPRE-FLIGHT FAILED — do NOT push a release tag.\n' >&2
+  exit 1
+fi
+printf '\nPre-flight OK — safe to tag.\n'


### PR DESCRIPTION
## Why
Two consecutive releases aborted at GitHub Actions **`startup_failure`** — no jobs, no logs:
- **0.89.0**: `self-scan-gate` referenced `needs.version-guard.*` without declaring `version-guard` in `needs`.
- **0.89.1 / 0.89.2**: `deploy-mcp-sse` called a reusable workflow with no job-level `permissions`, inheriting the deny-all top-level (`permissions: {}`) while the callee requested `contents: read` — a reusable workflow cannot request more than its caller grants.

`actionlint` catches the first class but **does not model** the second (caller/callee permission parity), so both passed lint clean and only surfaced as a dead tag.

## What
- **`scripts/lint_release_workflow.py`** — network-free static validator for *both* classes: undeclared `needs.<job>` refs, and every reusable-call job's effective permissions ≥ the union its callee requests. Prints the exact fix.
- **`scripts/preflight_release.sh [VERSION]`** — run before every tag: actionlint + the call-graph linter + bump/consistency/surface/openapi gates. Exits non-zero → no tag.
- **CI**: a required `Release workflow lint` job runs the linter (dependency-free, can't be skipped).
- **pre-commit**: same linter on changes to `release.yml` / `docs.yml` / `deploy-mcp-sse.yml`.

actionlint is kept in the local pre-flight (not CI) to avoid an unpinned `curl | bash` install in the pipeline; the Python linter is the network-free hard gate and covers both real failure modes.

## Proof
Run against the *broken* release.yml it prints `Add permissions: {contents: read} to deploy-mcp-sse`; against the fixed `main` it passes. Self-tested on a synthetic under-granted reusable call. A workflow change that would startup-fail the release now can't merge.