### PR TITLE
ci: tolerate async external rebuilds in publish-registries

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -67,30 +67,44 @@ jobs:
           fi
           echo "enabled=true" >> "$GITHUB_OUTPUT"
 
+      # Post-publish liveness probe of the Smithery-hosted endpoint. Best-effort
+      # confirmation, NOT a gate: Smithery rebuilds the server asynchronously
+      # (the new version may not be live for minutes) and the hosted endpoint is
+      # auth-gated with no public /health — both the correct secure posture, not
+      # a failure. A hard failure here previously red-failed the whole publish
+      # even though the catalog push (next step) succeeded. Warn instead so
+      # staleness stays visible without burning the run.
       - name: Validate Smithery public endpoint
         if: steps.smithery_config.outputs.enabled == 'true'
+        continue-on-error: true
         env:
           SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
         run: |
-          RESPONSE=$(PYTHONPATH=src python3 -m agent_bom.deployment_probe \
-            --base-url "$SMITHERY_MCP_URL" \
-            --attempts 3 \
-            --backoff-seconds 5 \
-            --timeout 15 \
-            --forbid-auth-required)
-
-          PUBLIC_VERSION=$(echo "$RESPONSE" | python3 -c "
+          if RESPONSE=$(PYTHONPATH=src python3 -m agent_bom.deployment_probe \
+              --base-url "$SMITHERY_MCP_URL" \
+              --attempts 3 \
+              --backoff-seconds 5 \
+              --timeout 15 2>&1); then
+            PUBLIC_VERSION=$(echo "$RESPONSE" | python3 -c "
           import json, sys
-          data = json.load(sys.stdin)
-          print(data.get('version', 'unknown'))
+          try:
+              print(json.load(sys.stdin).get('version', 'unknown'))
+          except Exception:
+              print('unknown')
           ")
-          PUBLIC_TOOLS=$(echo "$RESPONSE" | python3 -c "
+            PUBLIC_TOOLS=$(echo "$RESPONSE" | python3 -c "
           import json, sys
-          data = json.load(sys.stdin)
-          print(data.get('tool_count', data.get('mcp_metrics', {}).get('tool_count', 'unknown')))
+          try:
+              data = json.load(sys.stdin)
+              print(data.get('tool_count', data.get('mcp_metrics', {}).get('tool_count', 'unknown')))
+          except Exception:
+              print('unknown')
           ")
-          echo "Smithery public endpoint version: ${PUBLIC_VERSION}"
-          echo "Smithery public endpoint tool count: ${PUBLIC_TOOLS}"
+            echo "Smithery hosted endpoint version: ${PUBLIC_VERSION}"
+            echo "Smithery hosted endpoint tool count: ${PUBLIC_TOOLS}"
+          else
+            echo "::warning::Could not read version from the Smithery hosted endpoint (${SMITHERY_MCP_URL}). Expected while Smithery is still rebuilding (async) or because the endpoint is auth-gated / has no public /health. The catalog publish below still runs; confirm at https://smithery.ai/server/@agent-bom/agent-bom"
+          fi
 
       - name: Publish to Smithery
         if: steps.smithery_config.outputs.enabled == 'true'
@@ -174,8 +188,16 @@ jobs:
             echo "::warning::Glama rebuild trigger returned HTTP ${HTTP_STATUS} — may need manual rebuild"
           fi
 
+      # Glama re-crawls listings on its own cadence (can be hours), so a tight
+      # post-trigger freshness window legitimately fails on release day even
+      # though the rebuild was triggered. Warn instead of red-failing the
+      # publish; the listing self-resolves once Glama re-crawls.
       - name: Verify Glama listing freshness
-        run: python scripts/check_glama_listing.py --retries 6 --delay-seconds 30
+        continue-on-error: true
+        run: |
+          if ! python scripts/check_glama_listing.py --retries 6 --delay-seconds 30; then
+            echo "::warning::Glama listing not yet refreshed to the new version. Glama re-crawls asynchronously (can take hours); the rebuild was already triggered, so this self-resolves. Listing: https://glama.ai/mcp/servers/msaad00/agent-bom"
+          fi
 
   clawhub:
     name: Publish to ClawHub

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -420,11 +420,18 @@ def test_security_scan_npm_installs_use_network_retries():
     assert workflow.count("npm config set fetch-retry-maxtimeout 120000") >= 3
 
 
-def test_publish_registries_workflow_requires_public_smithery_surface_and_curated_clawhub_set():
-    """Registry publishing should fail fast on auth-gated Smithery URLs and avoid omnibus ClawHub skills."""
+def test_publish_registries_workflow_validates_smithery_best_effort_and_curated_clawhub_set():
+    """Smithery's hosted endpoint is reached through Smithery's own authenticated
+    proxy (direct access is auth-gated) and is rebuilt asynchronously, so the
+    post-publish liveness probe must be best-effort (non-blocking), not a gate
+    that forbids auth. ClawHub must still publish the curated skill set, not an
+    omnibus skill."""
     workflow = (ROOT / ".github" / "workflows" / "publish-registries.yml").read_text()
     assert "SMITHERY_MCP_URL" in workflow
-    assert "--forbid-auth-required" in workflow
+    # The Smithery probe no longer forbids auth (auth-gated is the correct,
+    # secure posture) and no longer hard-fails the publish on async rebuild lag.
+    assert "--forbid-auth-required" not in workflow
+    assert "continue-on-error: true" in workflow
     assert "integrations/openclaw/scan" in workflow
     assert "integrations/openclaw/compliance" in workflow
     assert "integrations/openclaw/registry" in workflow


### PR DESCRIPTION
## Why
On the v0.89.2 release, `publish-registries` red-failed on two post-publish verification steps even though the catalog pushes (Smithery + ClawHub) and PyPI/Docker/GitHub Release all succeeded:

- **Smithery** — "Validate Smithery public endpoint" probes `/health` with `--forbid-auth-required`. The Smithery-hosted server rebuilds **asynchronously** and is **auth-gated** (`/mcp` → 401, no public `/health`) — which is the correct secure posture, not a failure. The probe can never pass for the deployed endpoint, so it killed the run.
- **Glama** — "Verify Glama listing freshness" allows ~3 minutes (6×30s), but Glama re-crawls listings on its own cadence (hours). It legitimately fails right after the rebuild trigger.

These false failures are exactly the "why did the publish fail" noise that obscures real problems.

## What
Make both post-publish external-rebuild verifications **best-effort** (`continue-on-error: true` + `::warning::` with a self-resolve note + the listing URL). The catalog push steps are unchanged, so a genuine publish failure still fails; only the async-rebuild liveness/freshness probes degrade to warnings.

Verified: YAML valid, actionlint clean.

## Follow-up (not in this PR)
A scheduled freshness re-check that opens an issue if a registry is *still* stale after a longer grace window would convert these warnings into real alerts — the "self-healing + notify" goal — without gating release day.