### PR TITLE
fix(release): harden first-run auth and quickstart

### DIFF
--- a/src/agent_bom/api/secret_lifecycle.py
+++ b/src/agent_bom/api/secret_lifecycle.py
@@ -331,12 +331,11 @@ def describe_secret_lifecycle_posture() -> dict[str, Any]:
     """Return a consolidated, non-secret lifecycle posture surface."""
     from agent_bom.api.audit_log import describe_audit_hmac_status
     from agent_bom.api.compliance_signing import describe_signing_posture
-    from agent_bom.api.middleware import get_rate_limit_key_status
 
     secrets = {
         "audit_hmac": describe_audit_hmac_status(),
         "compliance_signing": describe_signing_posture(),
-        "rate_limit_key": get_rate_limit_key_status(),
+        "rate_limit_key": _rate_limit_key_status(),
         "browser_session_signing": _browser_session_signing_posture(),
         "scim_bearer": _env_secret_posture(
             name="scim_bearer",
@@ -380,4 +379,86 @@ def describe_secret_lifecycle_posture() -> dict[str, Any]:
             if warnings
             else "Secret lifecycle posture is configured and rotation timestamps are current."
         ),
+    }
+
+
+def _rate_limit_key_status() -> dict[str, Any]:
+    """Return rate-limit key posture without forcing API extras into base CLI."""
+    try:
+        from agent_bom.api.middleware import get_rate_limit_key_status
+    except ModuleNotFoundError as exc:
+        if exc.name != "starlette":
+            raise
+        return _env_rate_limit_key_status()
+    return get_rate_limit_key_status()
+
+
+def _env_rate_limit_key_status() -> dict[str, Any]:
+    from agent_bom.config import (
+        RATE_LIMIT_KEY_LAST_ROTATED,
+        RATE_LIMIT_KEY_MAX_AGE_DAYS,
+        RATE_LIMIT_KEY_ROTATION_DAYS,
+    )
+
+    raw_key = os.environ.get("AGENT_BOM_RATE_LIMIT_KEY", "").strip()
+    last_rotated = RATE_LIMIT_KEY_LAST_ROTATED or None
+    rotation_days = RATE_LIMIT_KEY_ROTATION_DAYS
+    max_age_days = RATE_LIMIT_KEY_MAX_AGE_DAYS
+
+    if not raw_key:
+        return {
+            "status": "ephemeral",
+            "severity": "info",
+            "production_or_clustered": _configured_api_replicas() > 1 or _env_enabled("AGENT_BOM_ENV"),
+            "rotation_days": rotation_days,
+            "max_age_days": max_age_days,
+            "fallback_source": None,
+            "last_rotated": None,
+            "age_days": None,
+            "message": (
+                "No AGENT_BOM_RATE_LIMIT_KEY configured. Rate-limit fingerprints use a process-local random key that resets on restart."
+            ),
+        }
+
+    if last_rotated is None:
+        return {
+            "status": "unknown_age",
+            "rotation_days": rotation_days,
+            "max_age_days": max_age_days,
+            "fallback_source": None,
+            "last_rotated": None,
+            "age_days": None,
+            "message": "Rate-limit key is configured but AGENT_BOM_RATE_LIMIT_KEY_LAST_ROTATED is unset.",
+        }
+
+    try:
+        rotated = datetime.fromisoformat(last_rotated)
+    except ValueError:
+        return {
+            "status": "unknown_age",
+            "rotation_days": rotation_days,
+            "max_age_days": max_age_days,
+            "fallback_source": None,
+            "last_rotated": last_rotated,
+            "age_days": None,
+            "message": "AGENT_BOM_RATE_LIMIT_KEY_LAST_ROTATED is not a valid ISO-8601 timestamp.",
+        }
+
+    if rotated.tzinfo is None:
+        rotated = rotated.replace(tzinfo=timezone.utc)
+    age_days = max(0, int((datetime.now(timezone.utc) - rotated).total_seconds() // 86400))
+    if age_days >= max_age_days:
+        status = "max_age_exceeded"
+    elif age_days >= rotation_days:
+        status = "rotation_due"
+    else:
+        status = "ok"
+    return {
+        "status": status,
+        "rotation_days": rotation_days,
+        "max_age_days": max_age_days,
+        "fallback_source": None,
+        "last_rotated": rotated.isoformat(),
+        "age_days": age_days,
+        "message": f"Rate-limit key is {age_days} days old; rotation interval is {rotation_days} days.",
     }

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -563,6 +563,7 @@ _api_key: str | None = None
 DEFAULT_RATE_LIMIT_RPM = DEFAULT_SCAN_RATE_LIMIT_RPM
 _rate_limit_rpm: int = DEFAULT_RATE_LIMIT_RPM
 _env_api_keys_seeded = False
+_runtime_api_key_seeded = False
 
 
 def _env_truthy(name: str) -> bool:
@@ -603,6 +604,21 @@ def _seed_api_key_store_from_env() -> bool:
 
     _env_api_keys_seeded = True
     return store.has_keys()
+
+
+def _seed_runtime_api_key(raw_key: str | None) -> bool:
+    """Seed the process-local key store from ``configure_api(api_key=...)``."""
+    global _runtime_api_key_seeded
+
+    value = (raw_key or "").strip()
+    if not value:
+        return False
+    if _runtime_api_key_seeded:
+        return get_key_store().has_keys()
+
+    get_key_store().add(create_api_key_record(value, "runtime:admin", Role.ADMIN))
+    _runtime_api_key_seeded = True
+    return True
 
 
 def _apply_cors_middleware(origins: list[str]) -> None:
@@ -676,6 +692,7 @@ def configure_api(
     _rate_limit_rpm = validated_rate_limit_rpm
 
     env_key_store_configured = _seed_api_key_store_from_env()
+    runtime_key_store_configured = _seed_runtime_api_key(api_key)
 
     from agent_bom.api.oidc import oidc_enabled_from_env
     from agent_bom.api.scim import scim_enabled_from_env
@@ -683,12 +700,14 @@ def configure_api(
     oidc_enabled = oidc_enabled_from_env()
     scim_enabled = scim_enabled_from_env()
     trusted_proxy_enabled = os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH", "").strip().lower() in {"1", "true", "yes", "on"}
-    auth_configured = bool(api_key or env_key_store_configured or oidc_enabled or trusted_proxy_enabled or scim_enabled)
+    auth_configured = bool(
+        api_key or env_key_store_configured or runtime_key_store_configured or oidc_enabled or trusted_proxy_enabled or scim_enabled
+    )
     if allow_unauthenticated is None:
         allow_unauthenticated = _env_truthy("AGENT_BOM_ALLOW_UNAUTHENTICATED_API")
     auth_required = auth_configured or not allow_unauthenticated
     configure_auth_runtime(
-        api_key_configured=bool(api_key or env_key_store_configured),
+        api_key_configured=bool(api_key or env_key_store_configured or runtime_key_store_configured),
         oidc_enabled=oidc_enabled,
         trusted_proxy_enabled=trusted_proxy_enabled,
         scim_enabled=scim_enabled,

--- a/src/agent_bom/cli/_quickstart.py
+++ b/src/agent_bom/cli/_quickstart.py
@@ -142,7 +142,18 @@ def _run_quickstart(
     # --context-graph triggers persistence of the unified graph to the local
     # control-plane store (~/.agent-bom/db/graph.db) that `agent-bom serve` reads,
     # so the security-graph cockpit is populated on first run.
-    scan_args = [executable, "agents", "--inventory", str(inventory_path), "-p", str(sample_dir), "--context-graph"]
+    report_path = sample_dir / "agent-bom-report.json"
+    scan_args = [
+        executable,
+        "agents",
+        "--inventory",
+        str(inventory_path),
+        "-p",
+        str(sample_dir),
+        "--context-graph",
+        "-o",
+        str(report_path),
+    ]
     scan_args.append("--offline" if offline else "--enrich")
     click.echo(f"[2/3] Scanning sample stack: {' '.join(scan_args[1:])}")
     result = subprocess.run(  # noqa: S603 - args built from validated inputs

--- a/tests/test_api_auth_me.py
+++ b/tests/test_api_auth_me.py
@@ -85,3 +85,27 @@ def test_auth_me_never_leaks_raw_key_or_token() -> None:
     body = asyncio.run(auth_me(_FakeRequest()))  # type: ignore[arg-type]
     serialized = json.dumps(body)
     assert secret not in serialized
+
+
+def test_browser_session_accepts_runtime_configured_api_key(monkeypatch) -> None:
+    from agent_bom.api import server as api_server
+    from agent_bom.api.auth import KeyStore, get_key_store, set_key_store
+
+    original_store = get_key_store()
+    set_key_store(KeyStore())
+    monkeypatch.setattr(api_server, "_runtime_api_key_seeded", False)
+
+    try:
+        api_server.configure_api(api_key="abk_runtime_test_key")
+        client = TestClient(app)
+
+        response = client.post("/v1/auth/session", json={"api_key": "abk_runtime_test_key"})
+        assert response.status_code == 204
+
+        session = client.get("/v1/auth/me").json()
+        assert session["authenticated"] is True
+        assert session["auth_method"] == "browser_session"
+        assert session["subject"] == "runtime:admin"
+        assert session["role"] == "admin"
+    finally:
+        set_key_store(original_store)

--- a/tests/test_api_compliance_auth.py
+++ b/tests/test_api_compliance_auth.py
@@ -43,13 +43,18 @@ def test_posture_requires_authenticated_context() -> None:
 
 
 def test_posture_accepts_trusted_proxy_headers() -> None:
-    client = TestClient(app)
-    resp = client.get(
-        "/v1/posture",
-        headers=_proxy_headers(),
-    )
-    assert resp.status_code == 200
-    assert resp.json()["grade"] == "N/A"
+    previous_store = _stores._store
+    set_job_store(InMemoryJobStore())
+    try:
+        client = TestClient(app)
+        resp = client.get(
+            "/v1/posture",
+            headers=_proxy_headers(),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["grade"] == "N/A"
+    finally:
+        _stores._store = previous_store
 
 
 def test_posture_proxy_auth_requires_tenant_header() -> None:

--- a/tests/test_context_graph.py
+++ b/tests/test_context_graph.py
@@ -498,8 +498,10 @@ class TestAPIContextGraph:
         """GET /v1/scan/{id}/context-graph returns valid graph structure."""
         import asyncio
 
-        from agent_bom.api.server import _get_store, app
+        from agent_bom.api.server import _get_store, app, configure_api
 
+        api_key = "context-graph-test-key"
+        configure_api(api_key=api_key)
         store = _get_store()
         job_id = "test-cg-api"
         job = self._make_job(
@@ -516,7 +518,10 @@ class TestAPIContextGraph:
         async def _call():
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:
-                return await client.get(f"/v1/scan/{job_id}/context-graph")
+                return await client.get(
+                    f"/v1/scan/{job_id}/context-graph",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
 
         resp = asyncio.run(_call())
         assert resp.status_code == 200
@@ -536,8 +541,10 @@ class TestAPIContextGraph:
         """GET /v1/scan/{id}/context-graph?agent=a1 filters lateral paths."""
         import asyncio
 
-        from agent_bom.api.server import _get_store, app
+        from agent_bom.api.server import _get_store, app, configure_api
 
+        api_key = "context-graph-test-key"
+        configure_api(api_key=api_key)
         store = _get_store()
         job_id = "test-cg-filter"
         job = self._make_job(
@@ -554,7 +561,10 @@ class TestAPIContextGraph:
         async def _call():
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:
-                return await client.get(f"/v1/scan/{job_id}/context-graph?agent=a1")
+                return await client.get(
+                    f"/v1/scan/{job_id}/context-graph?agent=a1",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
 
         resp = asyncio.run(_call())
         assert resp.status_code == 200

--- a/tests/test_deploy_teardown.py
+++ b/tests/test_deploy_teardown.py
@@ -71,7 +71,8 @@ def test_cli_teardown_dry_run_writes_summary(tmp_path: Path):
     assert result.exit_code == 0
     assert "agent-bom teardown plan" in result.output
     assert "+ helm uninstall agent-bom --namespace agent-bom" in result.output
-    assert "+ terraform" in result.output
+    assert "terraform" in result.output
+    assert "destroy -auto-approve" in result.output
     assert (tmp_path / "corp-ai" / "generated" / "teardown-summary.txt").exists()
 
 

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -80,6 +80,8 @@ def test_quickstart_run_scans_with_context_graph_and_seeds_policy(tmp_path, _fak
     assert scan_args[1] == "agents"
     assert "--context-graph" in scan_args
     assert "--offline" in scan_args
+    assert "-o" in scan_args
+    assert str(sample_dir / "agent-bom-report.json") in scan_args
     assert str(sample_dir / "inventory.json") in scan_args
     # secure-by-default gateway baseline seeded and valid
     policy_path = sample_dir / "gateway-baseline-policy.json"


### PR DESCRIPTION
Summary:
- keep identity credential-expiry usable from the base wheel by avoiding Starlette-only middleware imports in secret lifecycle fallback posture
- make agent-bom serve --api-key work with the dashboard browser-session exchange, matching bearer auth behavior
- write quickstart scan output under --sample-dir and stabilize teardown dry-run test output across resolved terraform paths

Verification:
- uv run ruff check src/agent_bom/api/server.py src/agent_bom/api/secret_lifecycle.py src/agent_bom/cli/_quickstart.py tests/test_api_auth_me.py tests/test_quickstart.py tests/test_deploy_teardown.py
- uv run pytest -q tests/test_api_auth_me.py tests/test_quickstart.py tests/test_cli_governance_commands.py tests/test_credential_expiry.py tests/test_openapi_artifact.py tests/test_deploy_teardown.py
- uv run mypy src/agent_bom/api/server.py src/agent_bom/api/secret_lifecycle.py src/agent_bom/cli/_quickstart.py src/agent_bom/deploy_teardown.py
- base-only install smoke: starlette None; agent-bom identity credential-expiry --format json exits 0
- live local UI smoke: agent-bom serve --api-key abk_runtime_local_smoke; browser unlock shows SIGNED IN runtime:admin

Notes:
- release audit still found external registry blockers outside this PR: Publish to Registries failed for Smithery endpoint validation and stale Glama listing refresh.