### PR TITLE
fix(parsers): go.mod block-require opener emits a phantom package (silent FN)

### DIFF
--- a/src/agent_bom/parsers/compiled_parsers.py
+++ b/src/agent_bom/parsers/compiled_parsers.py
@@ -410,7 +410,12 @@ def _parse_go_mod_requires(
         return direct, indirect, replace_map
 
     block_re = re.compile(r"require\s*\(([^)]+)\)", re.DOTALL)
-    single_re = re.compile(r"^require\s+(\S+)\s+(\S+)(.*)", re.MULTILINE)
+    # Horizontal-whitespace only between tokens: ``\s`` also matches newlines, so
+    # the old pattern matched the block opener ``require (`` and captured ``(`` as
+    # the module + the next dependency line as its version — a phantom package
+    # that, offline, was treated as DB-uncovered and silently dropped the whole
+    # report. ``[ \t]+`` keeps the match on one line and skips the block opener.
+    single_re = re.compile(r"^require[ \t]+(\S+)[ \t]+(\S+)([^\n]*)$", re.MULTILINE)
     replace_re = re.compile(r"^replace\s+(\S+)(?:\s+\S+)?\s+=>\s+(\S+)\s+(\S+)", re.MULTILINE)
 
     # Block-style: require ( ... )

--- a/tests/test_maven_go_parsers.py
+++ b/tests/test_maven_go_parsers.py
@@ -239,6 +239,22 @@ class TestParseGoModRequires:
         assert "github.com/pkg/errors" in direct
         assert "github.com/sirupsen/logrus" in indirect
 
+    def test_block_require_does_not_emit_phantom_paren_package(self, tmp_path):
+        """The block opener ``require (`` must not be parsed as a module named ``(``.
+
+        Regression: the single-line regex used ``\\s+`` (which matches newlines),
+        so it matched ``require (`` + the first dependency line, emitting a phantom
+        package ``(`` whose version was the next module path. Offline, that
+        DB-uncovered phantom discarded the whole report.
+        """
+        (tmp_path / "go.mod").write_text(
+            "module example.com/m\ngo 1.21\nrequire (\n\tgithub.com/gin-gonic/gin v1.6.0\n\tgopkg.in/yaml.v2 v2.2.2 // indirect\n)\n"
+        )
+        direct, indirect, _ = _parse_go_mod_requires(tmp_path / "go.mod")
+        assert "(" not in direct and "(" not in indirect
+        assert direct == {"github.com/gin-gonic/gin": "v1.6.0"}
+        assert indirect == {"gopkg.in/yaml.v2": "v2.2.2"}
+
 
 # ── parse_go_packages ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Why (P0 — silent false-negative)
The v0.89.2 deep audit found that block-style `go.mod` files — the **dominant real-world syntax** —
```
require (
    github.com/gin-gonic/gin v1.6.0
    gopkg.in/yaml.v2 v2.2.2
)
```
parse a phantom package named `(`. The single-line regex `^require\s+(\S+)\s+(\S+)(.*)` uses `\s+`, which matches newlines, so it matched the opener `require (` and captured `(` as the module + the next dependency line as its version.

Impact: **online** it injects junk into the SBOM; **offline** the DB-uncovered `(` phantom trips the incomplete-coverage path, which discards every real finding — the engine prints "✓ N vulnerabilities found" then emits an empty report and exits 2. A real false-negative on the core accuracy claim.

## Fix
Constrain inter-token whitespace to `[ \t]+` (horizontal only) so the match stays on one line and can't span into the block opener:
`^require[ \t]+(\S+)[ \t]+(\S+)([^\n]*)$`

Block-form deps are already handled by `block_re`; this only stops `single_re` from misfiring on the opener.

## Tests
New regression test asserts no `(` package and correct direct/indirect parsing for block-form go.mod. Existing maven/go parser tests green (76 pass). Verified hands-on: phantom gone across block / single / indirect forms.

First of the audit's accuracy-fix series. The offline incomplete-coverage behavior (one unknown pkg → empty report) is the related follow-up.