### PR TITLE
test: prevent xdist auth-env leak (intermittent 401!=200 flake) for good

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,6 +188,26 @@ def _reset_durable_store_singletons() -> None:
         pass
 
 
+# Auth-influencing env vars. ``configure_api`` re-derives whether the API key
+# middleware is installed from these on every call (server.py auth_configured),
+# so any one of them left set makes an otherwise-open endpoint return 401. A
+# test that sets one directly (tests/auth_helpers.py, or a setup_module block)
+# and then errors before its own cleanup runs would leak it to the next test on
+# the same xdist worker — the root of the intermittent ``assert 401 == 200``
+# flake. We snapshot these before each test and restore them after; see below.
+_AUTH_ENV_VARS = (
+    "AGENT_BOM_API_KEY",
+    "AGENT_BOM_API_KEYS",
+    "AGENT_BOM_TRUST_PROXY_AUTH",
+    "AGENT_BOM_TRUST_PROXY_AUTH_SECRET",
+    "AGENT_BOM_TRUST_PROXY_AUTH_ISSUER",
+    "AGENT_BOM_OIDC_ISSUER",
+    "AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON",
+    "AGENT_BOM_SCIM_BEARER_TOKEN",
+    "AGENT_BOM_SCIM_BEARER_TOKENS_JSON",
+)
+
+
 @pytest.fixture(autouse=True)
 def reset_global_test_state():
     """Reset process-global caches so test order does not affect outcomes."""
@@ -197,7 +217,23 @@ def reset_global_test_state():
     _reset_api_runtime_state()
     _reset_durable_store_singletons()
     _reset_runtime_state()
+
+    # Snapshot auth env AFTER module-scoped setup has run (setup_module fires
+    # before this function-scoped fixture), so module-level auth env is captured
+    # and preserved across the module's tests. Anything a *test body* sets is not
+    # in the snapshot and is reverted on teardown below — so a test that enables
+    # auth and skips its own cleanup (e.g. on an assertion error) cannot leak a
+    # 401-inducing env var into the next test on the same worker.
+    auth_env_snapshot = {var: os.environ.get(var) for var in _AUTH_ENV_VARS}
+
     yield
+
+    for var, value in auth_env_snapshot.items():
+        if value is None:
+            os.environ.pop(var, None)
+        else:
+            os.environ[var] = value
+
     _reset_resolver_state()
     _reset_registry_state()
     _reset_identity_cache_state()

--- a/tests/test_auth_env_isolation.py
+++ b/tests/test_auth_env_isolation.py
@@ -1,0 +1,28 @@
+"""Regression guard for the xdist auth-state leak.
+
+A test that sets an auth-influencing env var (via tests/auth_helpers or a raw
+os.environ assignment) and then errors before its own cleanup must NOT leak that
+var into the next test on the same worker — otherwise the next test's open
+endpoint returns 401 instead of 200 (the intermittent ``assert 401 == 200``
+flake). The autouse fixture in conftest snapshots and restores the auth env
+around every test; these two tests prove a leak in the first does not reach the
+second.
+"""
+
+import os
+
+from tests.auth_helpers import enable_trusted_proxy_env
+
+
+def test_auth_env_leak_setup():
+    # Deliberately enable auth and do NOT disable it (simulates a test that
+    # errors before its cleanup runs).
+    enable_trusted_proxy_env()
+    assert os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH") == "1"
+
+
+def test_auth_env_is_clean_after_leak():
+    # The conftest snapshot/restore must have reverted the leak from the
+    # previous test, leaving a clean (open) auth env.
+    assert os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH") is None
+    assert os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH_SECRET") is None


### PR DESCRIPTION
## The recurring flake
Every PR has been intermittently blocked by `assert 401 == 200` on API route tests (`test_snowflake_backend_contract::test_supported_snowflake_routes_remain_wired`, `test_context_graph::TestAPIContextGraph::*`, etc.), requiring manual reruns. This kills it at the root.

## Root cause
The autouse reset in `conftest.py` calls `configure_api(api_key=None)` to return the API to its open state. But `configure_api` **re-derives** whether the API-key middleware is installed from `os.environ` (`auth_configured = api_key or env_keys or oidc_enabled or trusted_proxy_enabled or scim_enabled` — all read live from env). The conftest cleared **zero auth env vars**, so if a prior test left one set — e.g. `AGENT_BOM_TRUST_PROXY_AUTH` via `tests/auth_helpers.enable_trusted_proxy_env()` or a `setup_module` block whose teardown was skipped on a worker crash/error — the reset itself **re-installs `APIKeyMiddleware`**, and the next test's header-less GET returns 401 instead of 200.

## Fix (safe + preventive)
Snapshot the auth-env surface in the autouse fixture's **setup** (which runs *after* `setup_module`, so module-scoped auth env is captured and preserved across that module's tests) and **restore it on teardown** — reverting any auth var a *test body* set and failed to clean up, even on an assertion error. Leaks become impossible regardless of which test causes them.

## Proof
- Repro (a test that enables auth + skips cleanup, then an open test): **fails on `main`** (`'1' is None`), **passes with this fix**.
- Module-scoped auth suites still pass: 62 in proxy/oidc/scim + 120 across the previously-flaky modules.
- New permanent regression test `tests/test_auth_env_isolation.py`.

Test-only change. No production code touched.