### PR TITLE
fix(scanners): offline coverage gap warns instead of discarding real findings (P0)

### DIFF
--- a/src/agent_bom/api/cost_forecast.py
+++ b/src/agent_bom/api/cost_forecast.py
@@ -212,7 +212,13 @@ def _best_daily_rate(timed: Sequence[tuple[datetime, float]], now: datetime) -> 
     return max(candidates, key=lambda c: c[0])
 
 
-def forecast_for_tenant(tenant_id: str, *, agent: str | None = None, limit: int = 10000) -> dict[str, Any]:
+def forecast_for_tenant(
+    tenant_id: str,
+    *,
+    agent: str | None = None,
+    limit: int = 10000,
+    now: datetime | None = None,
+) -> dict[str, Any]:
     """Build a spend forecast for a tenant (optionally one agent) from the store.
 
     Resolves an agent-scoped budget first, falling back to the tenant-wide cap —
@@ -228,6 +234,6 @@ def forecast_for_tenant(tenant_id: str, *, agent: str | None = None, limit: int 
     budget = store.get_budget(tenant_id, agent or "")
     if budget is None and agent:
         budget = store.get_budget(tenant_id, "")
-    result = forecast_spend(records, budget=budget)
+    result = forecast_spend(records, budget=budget, now=now)
     result["tenant_id"] = tenant_id
     return result

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -233,6 +233,37 @@ def _db_ecosystems_for_package(pkg: Package) -> list[str]:
     return [eco.lower() for eco in _osv_ecosystems_for_package(pkg)]
 
 
+def _db_covered_ecosystems() -> set[str]:
+    """Return the lowercased ecosystems the local vulnerability DB has advisories for.
+
+    An advisory DB only stores *vulnerable* package-versions, so it cannot
+    distinguish a genuinely-clean package (queried, no advisories) from one it
+    has no data for — both have zero rows. Coverage is therefore meaningful only
+    at the ecosystem level: if the DB holds any advisories for an ecosystem, a
+    package in that ecosystem with no rows is clean; an ecosystem with zero
+    advisories is a real coverage gap. Returns an empty set when the DB is
+    missing/unreadable (callers treat that as "no offline coverage at all").
+    """
+    try:
+        from agent_bom.db.schema import (
+            DB_PATH,
+            db_freshness_days,
+            open_existing_db_readonly,
+        )
+
+        if db_freshness_days() is None or not DB_PATH.exists():
+            return set()
+        conn = open_existing_db_readonly(DB_PATH)
+        try:
+            rows = conn.execute("SELECT DISTINCT ecosystem FROM affected").fetchall()
+        finally:
+            conn.close()
+        return {str(r[0]).lower() for r in rows if r[0]}
+    except Exception as exc:  # noqa: BLE001
+        _logger.debug("Could not read local DB ecosystem coverage: %s", exc)
+        return set()
+
+
 # ── Scan cache (optional, lazy-initialised) ────────────────────────────────
 
 _scan_cache_instance: "ScanCache | object | None" = None
@@ -910,19 +941,39 @@ async def scan_packages(
     osv_targets = [p for p in scannable if _db_key(p) not in db_covered]
 
     if scan_offline or (scan_prefer_local_db and not osv_targets):
-        if scan_offline and not db_covered:
-            raise IncompleteScanError(
-                "Offline mode requires a populated local vulnerability DB. Run `agent-bom db update` before using `--offline`."
-            )
-        if osv_targets and scan_offline:
-            _logger.info("Offline mode: skipping OSV API for %d package(s) not in local DB", len(osv_targets))
-            skipped_names = ", ".join(f"{pkg.name}@{pkg.version}" for pkg in osv_targets[:5])
-            suffix = f" (+{len(osv_targets) - 5} more)" if len(osv_targets) > 5 else ""
-            raise IncompleteScanError(
-                "Offline mode cannot produce a trustworthy verdict because "
-                f"{len(osv_targets)} package(s) are missing from the local vulnerability DB: "
-                f"{skipped_names}{suffix}. Run `agent-bom db update` before using `--offline`."
-            )
+        if scan_offline:
+            covered_ecos = _db_covered_ecosystems()
+            if not covered_ecos:
+                # Genuinely empty/missing DB — nothing can be scanned offline.
+                raise IncompleteScanError(
+                    "Offline mode requires a populated local vulnerability DB. Run `agent-bom db update` before using `--offline`."
+                )
+            # A package with no DB rows whose ECOSYSTEM the DB covers is clean,
+            # not a gap — the advisory DB simply has no advisory for it. Only
+            # packages in an ecosystem the DB holds zero advisories for are a
+            # real coverage gap. Warn loudly about those, but never discard the
+            # vulnerabilities already found for covered packages (the previous
+            # behaviour raised and dropped the whole report when a single
+            # package — even a clean one — was "uncovered").
+            uncovered = [p for p in osv_targets if not any(eco in covered_ecos for eco in _db_ecosystems_for_package(p))]
+            if uncovered:
+                gap_ecos = sorted({eco for p in uncovered for eco in _db_ecosystems_for_package(p)})
+                skipped_names = ", ".join(f"{pkg.name}@{pkg.version}" for pkg in uncovered[:5])
+                suffix = f" (+{len(uncovered) - 5} more)" if len(uncovered) > 5 else ""
+                _logger.warning(
+                    "Offline mode: %d package(s) in ecosystem(s) with no local DB advisories (%s) skipped",
+                    len(uncovered),
+                    ", ".join(gap_ecos),
+                )
+                console.print(
+                    f"  [yellow]⚠[/yellow] Offline coverage gap: {len(uncovered)} package(s) in "
+                    f"ecosystem(s) the local DB has no advisories for ({', '.join(gap_ecos)}): "
+                    f"{skipped_names}{suffix}. Run `agent-bom db update` for full coverage."
+                )
+                record_scan_warning(
+                    f"offline coverage gap: {len(uncovered)} package(s) in ecosystem(s) "
+                    f"{', '.join(gap_ecos)} have no advisories in the local vulnerability DB"
+                )
         results = {}
     elif scan_prefer_local_db and osv_targets:
         # DB is fresh — only query OSV for packages genuinely missing from DB

--- a/tests/test_cost_forecast.py
+++ b/tests/test_cost_forecast.py
@@ -148,7 +148,7 @@ def test_forecast_for_tenant_prefers_agent_budget():
             store.record_cost(_rec(1.0, hours_ago=h, agent="agent-a", call_id=f"a-{h}"))
         store.set_budget(_budget(50.0, agent=""))  # tenant-wide
         store.set_budget(_budget(120.0, agent="agent-a"))  # agent-scoped wins
-        fc = forecast_for_tenant("t1", agent="agent-a")
+        fc = forecast_for_tenant("t1", agent="agent-a", now=_NOW)
         assert fc["tenant_id"] == "t1"
         assert fc["budget_limit_usd"] == 120.0
         assert fc["status"] == "ok"

--- a/tests/test_local_db_scan.py
+++ b/tests/test_local_db_scan.py
@@ -355,24 +355,53 @@ def test_scan_packages_only_skips_exact_db_covered_version():
 
 
 def test_scan_packages_offline_requires_local_db(monkeypatch):
-    """Offline mode must fail closed when no local DB coverage exists."""
+    """Offline mode must fail closed when the local DB is genuinely empty/missing."""
     from agent_bom.scanners import IncompleteScanError, scan_packages
 
     pkg = _make_pkg("requests", "2.28.0")
     monkeypatch.setattr("agent_bom.scanners.offline_mode", True)
 
-    with patch("agent_bom.scanners._scan_packages_local_db", return_value=(0, set())):
+    with (
+        patch("agent_bom.scanners._scan_packages_local_db", return_value=(0, set())),
+        patch("agent_bom.scanners._db_covered_ecosystems", return_value=set()),
+    ):
         with pytest.raises(IncompleteScanError, match="populated local vulnerability DB"):
             asyncio.run(scan_packages([pkg]))
 
 
-def test_scan_packages_offline_partial_db_raises(monkeypatch):
-    """Offline mode must fail when any package is missing from the local DB."""
-    from agent_bom.scanners import IncompleteScanError, scan_packages
+def test_scan_packages_offline_clean_pkg_in_covered_ecosystem_does_not_raise(monkeypatch):
+    """A package with no DB rows whose ecosystem the DB covers is CLEAN, not a gap.
 
-    pkg = _make_pkg("requests", "2.28.0")
+    An advisory DB only stores vulnerable versions, so a covered-ecosystem
+    package with no advisory rows is genuinely clean — it must not raise or
+    discard the report (the old behaviour failed closed on every such package).
+    """
+    from agent_bom.scanners import scan_packages
+
+    pkg = _make_pkg("requests", "2.28.0")  # pypi, no advisory rows
     monkeypatch.setattr("agent_bom.scanners.offline_mode", True)
 
-    with patch("agent_bom.scanners._scan_packages_local_db", return_value=(0, {"pypi:other@1.0.0"})):
-        with pytest.raises(IncompleteScanError, match="missing from the local vulnerability DB"):
-            asyncio.run(scan_packages([pkg]))
+    with (
+        patch("agent_bom.scanners._scan_packages_local_db", return_value=(0, set())),
+        patch("agent_bom.scanners._db_covered_ecosystems", return_value={"pypi"}),
+    ):
+        # Must complete without raising IncompleteScanError.
+        asyncio.run(scan_packages([pkg]))
+
+
+def test_scan_packages_offline_uncovered_ecosystem_warns_without_discarding(monkeypatch):
+    """A package in an ecosystem the DB has zero advisories for warns, not raises."""
+    from agent_bom.scanners import scan_packages
+
+    pkg = _make_pkg("serde", "1.0.0", eco="cargo")  # crates.io not covered
+    monkeypatch.setattr("agent_bom.scanners.offline_mode", True)
+
+    warnings: list[str] = []
+    with (
+        patch("agent_bom.scanners._scan_packages_local_db", return_value=(0, set())),
+        patch("agent_bom.scanners._db_covered_ecosystems", return_value={"pypi", "npm"}),
+        patch("agent_bom.scanners.record_scan_warning", side_effect=warnings.append),
+    ):
+        # Must complete without raising; emits a coverage-gap warning instead.
+        asyncio.run(scan_packages([pkg]))
+    assert any("offline coverage gap" in w for w in warnings), warnings

--- a/tests/test_scan_options.py
+++ b/tests/test_scan_options.py
@@ -29,6 +29,7 @@ def test_scan_packages_explicit_offline_option_ignores_global_online_state(monke
 
     with (
         patch("agent_bom.scanners._scan_packages_local_db", return_value=(0, set())),
+        patch("agent_bom.scanners._db_covered_ecosystems", return_value=set()),
         patch("agent_bom.scanners.query_osv_batch") as mock_osv,
     ):
         with pytest.raises(IncompleteScanError, match="populated local vulnerability DB"):

--- a/tests/test_snowflake_backend_contract.py
+++ b/tests/test_snowflake_backend_contract.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 from starlette.testclient import TestClient
 
 from agent_bom.api import stores as api_stores
-from agent_bom.api.server import app
+from agent_bom.api.server import app, configure_api
 
 
 def _mock_cursor(fetchone_val=None, fetchall_val=None, rowcount=0):
@@ -82,11 +82,14 @@ def test_supported_snowflake_routes_remain_wired(mock_connect, monkeypatch):
     monkeypatch.setattr("agent_bom.api.server._cleanup_loop", lambda: _async_noop())
     monkeypatch.setattr("agent_bom.api.scheduler.scheduler_loop", lambda store, fn: _async_noop())
 
+    api_key = "snowflake-contract-test-key"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    configure_api(api_key=api_key)
     _clear_store_globals()
     try:
         with TestClient(app, raise_server_exceptions=False) as client:
-            schedules = client.get("/v1/schedules")
-            exceptions = client.get("/v1/exceptions")
+            schedules = client.get("/v1/schedules", headers=headers)
+            exceptions = client.get("/v1/exceptions", headers=headers)
 
             assert schedules.status_code == 200
             assert schedules.json() == []
@@ -101,6 +104,7 @@ def test_supported_snowflake_routes_remain_wired(mock_connect, monkeypatch):
             }
     finally:
         _clear_store_globals()
+        configure_api(api_key=None)
 
 
 async def _async_noop() -> None:


### PR DESCRIPTION
## Why (P0 — silent false-negative)
In `--offline` mode, `scan_agents` raised `IncompleteScanError` whenever **any** package was missing from the local DB — discarding every vulnerability already found and exiting 2 with an empty report. Worse: an advisory DB only stores *vulnerable* package-versions, so a genuinely-clean package (no advisory rows) was indistinguishable from an uncovered one and tripped the same path → a false "DB not populated" error on healthy packages.

The audit reproduced both: a clean offline scan exits 2 with a false warning, and one uncovered package (e.g. an Alpine base-layer pkg, or the go-parser phantom from #3009) drops 15 real CVEs the DB had already found.

## Fix
Move to **ecosystem-level coverage** via a new `_db_covered_ecosystems()` (`SELECT DISTINCT ecosystem FROM affected`):
- DB has advisories for the package's ecosystem → a no-rows package is **clean** (no warning, no discard).
- Package in an ecosystem with **zero** advisories → real gap → emit a **coverage-gap warning** and **keep** the vulnerabilities already found.
- Entirely empty/missing DB → still **fail closed** (unchanged).

## Tests
Updated the two contracts that asserted the old discard-on-gap behaviour (a deliberate, audit-justified change), added `clean-covered-no-raise` + `uncovered-warns-without-discarding` regression tests. 142 tests green across `test_local_db_scan` / `test_scan_options` / `test_cli_scan` / `test_cli_check`. ruff clean.

Pairs with #3009 (go-parser phantom) — together they close the offline silent-FN class the audit flagged.

## CI follow-up
- Authenticates the Snowflake protected-route contract under an explicit test API key, matching auth-by-default behavior.
- Verification: `uv run pytest -q tests/test_snowflake_backend_contract.py tests/test_local_db_scan.py tests/test_scan_options.py`; `uv run ruff check tests/test_snowflake_backend_contract.py`.

Closes #3010.

## Main CI regression follow-up
- Makes the store-backed cost forecast test deterministic by allowing `forecast_for_tenant(..., now=...)` and passing the fixed test clock.
- This addresses the current main CI failure in `tests/test_cost_forecast.py::test_forecast_for_tenant_prefers_agent_budget` where real date drift made June 15 fixture records stale on June 22.
- Verification: `uv run pytest -q tests/test_cost_forecast.py::test_forecast_for_tenant_prefers_agent_budget tests/test_cost_forecast.py`; `uv run ruff check src/agent_bom/api/cost_forecast.py tests/test_cost_forecast.py tests/test_snowflake_backend_contract.py`.