### PR TITLE
fix(readme): Glama MCP-server badge URL (broken image)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://hub.docker.com/r/agentbom/agent-bom"><img src="https://img.shields.io/docker/pulls/agentbom/agent-bom?style=flat&label=Docker%20pulls" alt="Docker"></a>
   <a href="https://github.com/msaad00/agent-bom/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue?style=flat" alt="License"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/msaad00/agent-bom"><img src="https://img.shields.io/ossf-scorecard/github.com/msaad00/agent-bom?style=flat&label=OpenSSF%20scorecard" alt="OpenSSF Scorecard"></a>
-  <a href="https://glama.ai/mcp/servers/msaad00/agent-bom"><img src="https://glama.ai/mcp/servers/msaad00/agent-bom/badge.svg" alt="agent-bom MCP server"></a>
+  <a href="https://glama.ai/mcp/servers/msaad00/agent-bom"><img src="https://glama.ai/mcp/servers/msaad00/agent-bom/badge" alt="agent-bom MCP server"></a>
 </p>
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 


### PR DESCRIPTION
The README header's "agent-bom MCP server" badge pointed at `glama.ai/mcp/servers/msaad00/agent-bom/badge.svg`, which **404s** (returns `text/html`). Glama serves the badge image at `.../badge` (`image/png`). Dropping the `.svg` suffix makes the badge render instead of showing a broken image.

Verified: `/badge` → 200 image/png, `/badge.svg` → 404. `check_release_consistency` passes.