### PR TITLE
fix(mcp): raise clean error on out-of-sandbox scan path (unpack crash, P1)

### DIFF
--- a/src/agent_bom/mcp_server_scan.py
+++ b/src/agent_bom/mcp_server_scan.py
@@ -15,9 +15,28 @@ from agent_bom.config import MCP_MAX_FILE_SIZE as _MAX_FILE_SIZE
 from agent_bom.mcp_errors import (
     CODE_VALIDATION_INVALID_IMAGE_REF,
     CODE_VALIDATION_INVALID_PATH,
-    mcp_error_json,
 )
 from agent_bom.security import sanitize_error  # noqa: F401 — kept for downstream importers
+
+
+class McpScanValidationError(ValueError):
+    """A scan input failed validation (e.g. a path outside the sandbox).
+
+    Raised by :func:`run_scan_pipeline` instead of returning an error payload so
+    the many call-sites that unpack a 4-tuple do not crash with "too many values
+    to unpack (expected 4)" and tools surface a clean, structured error. It
+    subclasses ``ValueError`` so existing ``except ValueError`` / ``except
+    Exception`` handlers still catch it; ``code`` carries the machine-readable
+    validation code.
+    """
+
+    def __init__(self, code: str, message: Exception | str, *, argument: str | None = None) -> None:
+        self.code = code
+        self.argument = argument
+        text = message if isinstance(message, str) else sanitize_error(message)
+        suffix = f" (argument: {argument})" if argument else ""
+        super().__init__(f"{code}: {text}{suffix}")
+
 
 logger = logging.getLogger(__name__)
 
@@ -82,13 +101,13 @@ async def run_scan_pipeline(
         try:
             config_path = str(safe_path(config_path))
         except ValueError as exc:
-            return mcp_error_json(CODE_VALIDATION_INVALID_PATH, exc, details={"argument": "config_path"})
+            raise McpScanValidationError(CODE_VALIDATION_INVALID_PATH, exc, argument="config_path") from exc
 
     if sbom_path:
         try:
             sbom_path = str(safe_path(sbom_path))
         except ValueError as exc:
-            return mcp_error_json(CODE_VALIDATION_INVALID_PATH, exc, details={"argument": "sbom_path"})
+            raise McpScanValidationError(CODE_VALIDATION_INVALID_PATH, exc, argument="sbom_path") from exc
 
     if image:
         try:
@@ -96,7 +115,7 @@ async def run_scan_pipeline(
 
             validate_image_ref(image)
         except Exception as exc:
-            return mcp_error_json(CODE_VALIDATION_INVALID_IMAGE_REF, exc, details={"argument": "image"})
+            raise McpScanValidationError(CODE_VALIDATION_INVALID_IMAGE_REF, exc, argument="image") from exc
 
     agents = discover_all(project_dir=config_path)
     if agents:
@@ -107,7 +126,7 @@ async def run_scan_pipeline(
             agents.append(_package_spec_agent(package))
             scan_sources.append("mcp_package")
         except ValueError as exc:
-            return mcp_error_json(CODE_VALIDATION_INVALID_PATH, exc, details={"argument": "package"})
+            raise McpScanValidationError(CODE_VALIDATION_INVALID_PATH, exc, argument="package") from exc
 
     if image:
         try:

--- a/tests/test_mcp_scan_path_rejection.py
+++ b/tests/test_mcp_scan_path_rejection.py
@@ -1,0 +1,38 @@
+"""Regression: an out-of-sandbox scan path must raise a clean validation error.
+
+Previously run_scan_pipeline returned a single mcp_error_json string on a
+rejected path, but its ~11 call-sites unpack a 4-tuple — so a path outside the
+sandbox crashed with "too many values to unpack (expected 4)" (and several
+tools masked it as isError:false). It now raises McpScanValidationError so every
+caller surfaces a clean, structured error.
+"""
+
+import asyncio
+
+import pytest
+
+from agent_bom.mcp_server_scan import (
+    CODE_VALIDATION_INVALID_PATH,
+    McpScanValidationError,
+    run_scan_pipeline,
+)
+
+
+def _reject_path(_p):
+    raise ValueError("path is outside home directory")
+
+
+def test_out_of_sandbox_config_path_raises_clean_validation_error():
+    with pytest.raises(McpScanValidationError) as exc_info:
+        asyncio.run(run_scan_pipeline(safe_path=_reject_path, config_path="/etc/passwd"))
+    err = exc_info.value
+    assert err.code == CODE_VALIDATION_INVALID_PATH
+    assert err.argument == "config_path"
+    # The message is clean and structured — never the unpack crash.
+    assert "too many values to unpack" not in str(err)
+    assert CODE_VALIDATION_INVALID_PATH in str(err)
+
+
+def test_validation_error_is_a_valueerror_for_existing_handlers():
+    # Subclasses ValueError so tools' existing except-handlers still catch it.
+    assert issubclass(McpScanValidationError, ValueError)


### PR DESCRIPTION
## Why (P1)
`run_scan_pipeline` returned a single `mcp_error_json` string when `safe_path()` rejected a path, but its **~11 call-sites** unpack a 4-tuple. So an out-of-`$HOME` `config_path`/`sbom_path`/`image`/`package` crashed with **"too many values to unpack (expected 4)"** — the `scan` tool surfaced that cryptic message, and `generate_sbom`/`remediate`/`compliance` **masked it as `isError:false`** (a headless agent reads "success"). The audit hit this on the two most-used tools.

## Fix
`run_scan_pipeline` now **raises** `McpScanValidationError` (subclasses `ValueError`, carries the validation code) instead of returning a payload. Every caller's existing handler catches a clean, structured error:
- `scan` → `except Exception → ToolError` ⇒ `isError:true` with `CODE_VALIDATION_INVALID_PATH: … (argument: config_path)`
- `generate_sbom`/`compliance`/etc. → return a clean coded JSON error (per their design), never the unpack crash.

No call-site needs editing — subclassing `ValueError` keeps existing `except ValueError`/`except Exception` handlers working.

## Tests
New regression test (`test_mcp_scan_path_rejection.py`) asserts a rejected path raises the clean validation error, never "too many values to unpack". 127 tests green across `test_mcp_tool_impls` / `test_mcp_errors` / `test_security_hardening`. ruff + mypy clean.