### PR TITLE
fix(mcp): check tool parses pip specifiers + flags errors (no false-clean)

### DIFF
--- a/src/agent_bom/mcp_tools/scanning.py
+++ b/src/agent_bom/mcp_tools/scanning.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 
 from mcp.server.fastmcp.exceptions import ToolError
 
@@ -287,8 +288,16 @@ async def check_impl(
         from agent_bom.parsers.os_parsers import enrich_os_package_context
         from agent_bom.scanners import ScanOptions, scan_packages
 
-        # Parse name@version
+        # Parse name@version. Accept pip/PEP 440 specifiers (pkg==1.0, pkg>=1.0)
+        # as well as the universal pkg@1.0 form — agents routinely paste pip
+        # syntax, and without this the operator stayed glued to the name, which
+        # then failed to resolve (read as an error) or scanned the wrong thing
+        # (read as clean). Mirrors the CLI check parser.
         spec = package.strip()
+        if "@" not in spec:
+            _specifier = re.split(r"(===|==|~=|!=|>=|<=|>|<)", spec, maxsplit=1)
+            if len(_specifier) == 3:
+                spec = f"{_specifier[0].strip()}@{_specifier[2].strip()}"
         if "@" in spec and not spec.startswith("@"):
             name, version = spec.rsplit("@", 1)
         elif spec.startswith("@") and spec.count("@") > 1:
@@ -311,6 +320,7 @@ async def check_impl(
                 {
                     "package": name,
                     "ecosystem": eco,
+                    "status": "error",
                     "error": f"Explicit version required for {eco} packages",
                 }
             )
@@ -329,7 +339,12 @@ async def check_impl(
                     {
                         "package": name,
                         "ecosystem": eco,
-                        "error": f"Could not resolve latest version for {name}",
+                        "status": "error",
+                        "error": (
+                            f"Could not resolve a version for {name}. Provide an explicit "
+                            f"version (e.g. {name}@1.2.3 or {name}==1.2.3) and confirm the "
+                            f"ecosystem (got '{eco}')."
+                        ),
                     }
                 )
 

--- a/tests/test_mcp_check_spec_parsing.py
+++ b/tests/test_mcp_check_spec_parsing.py
@@ -1,0 +1,75 @@
+"""Regression: the MCP `check` tool must parse pip specifiers, not read clean.
+
+`check_impl` previously split only on `@`, so `requests==2.20.0` left the `==`
+glued to the name — which then failed to resolve (returned an error with no
+status) or scanned the wrong thing (read as clean). It now normalises pip/PEP
+440 specifiers to the `name@version` form and tags error responses with
+``status: "error"`` so a consumer can't misread them as clean.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+def _trunc(s):
+    return s
+
+
+@pytest.mark.asyncio
+async def test_check_parses_pip_double_equals_spec():
+    from agent_bom.mcp_tools.scanning import check_impl
+
+    async def _noop_scan(pkgs, **_kw):
+        return 0  # leave pkg.vulnerabilities empty → clean verdict on a real version
+
+    with patch("agent_bom.scanners.scan_packages", side_effect=_noop_scan):
+        result = await check_impl(
+            package="requests==2.20.0",
+            ecosystem="pypi",
+            _validate_ecosystem=lambda e: e,
+            _truncate_response=_trunc,
+        )
+    data = json.loads(result)
+    # The `==` must have been parsed off, not glued to the name.
+    assert data["package"] == "requests"
+    assert data["version"] == "2.20.0"
+
+
+@pytest.mark.asyncio
+async def test_check_parses_pep440_range_spec():
+    from agent_bom.mcp_tools.scanning import check_impl
+
+    async def _noop_scan(pkgs, **_kw):
+        return 0
+
+    with patch("agent_bom.scanners.scan_packages", side_effect=_noop_scan):
+        result = await check_impl(
+            package="flask>=0.12",
+            ecosystem="pypi",
+            _validate_ecosystem=lambda e: e,
+            _truncate_response=_trunc,
+        )
+    data = json.loads(result)
+    assert data["package"] == "flask"
+    assert data["version"] == "0.12"
+
+
+@pytest.mark.asyncio
+async def test_check_unresolvable_version_is_not_clean():
+    from agent_bom.mcp_tools.scanning import check_impl
+
+    async def _no_resolve(pkg, _client):
+        return None  # registry cannot resolve a version
+
+    with patch("agent_bom.resolver.resolve_package_version", side_effect=_no_resolve):
+        result = await check_impl(
+            package="totally-bogus-pkg-xyz",  # no version → resolve → fail
+            ecosystem="pypi",
+            _validate_ecosystem=lambda e: e,
+            _truncate_response=_trunc,
+        )
+    data = json.loads(result)
+    assert data.get("status") == "error"
+    assert data.get("status") != "clean"


### PR DESCRIPTION
## Why
The MCP `check` tool split the spec only on `@`, so a pip-style `requests==2.20.0` left `==` glued to the name. That either failed to resolve (returned `{"error": …}` with no status — read as non-fatal) or scanned the wrong thing and returned `status: "clean"`. Headless agents routinely paste pip syntax, so the most-used vuln-check tool **read clean on a real, vulnerable package**.

## Fix
- Normalise pip/PEP 440 specifiers (`==`, `===`, `~=`, `!=`, `>=`, `<=`, `>`, `<`) to the `name@version` form before splitting — mirrors the CLI `check` parser. `requests==2.20.0` → `requests` / `2.20.0`; `flask>=0.12` → `flask` / `0.12`; `@scope/pkg@1.0.0` preserved.
- Tag the error responses (`Could not resolve…`, `Explicit version required…`) with `status: "error"` so a consumer can't misread an unresolved result as clean, and make the resolve-failure message actionable.

## Tests
3 regression tests (pip `==`, PEP 440 range, unresolved-version → `status:error`). ruff + mypy clean; MCP tool suite green.