### PR TITLE
feat(ingest): hardware/firmware attestation evidence ingest

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
       - Registry: features/registry.md
       - Runtime Proxy: features/runtime-proxy.md
       - SBOM Generation: features/sbom.md
+      - Hardware/Firmware Evidence Ingest: features/hardware-evidence.md
       - Policy Engine: features/policy.md
   - Deployment:
       - Overview: deployment/overview.md

--- a/site-docs/features/hardware-evidence.md
+++ b/site-docs/features/hardware-evidence.md
@@ -1,0 +1,108 @@
+# Hardware/Firmware Evidence Ingest
+
+agent-bom has strong software and model supply-chain coverage. The remaining
+hardware supply-chain gap is **evidence that already exists outside agent-bom**:
+vendor hardware/firmware SBOMs, signed firmware attestations, BMC/BIOS inventory
+exports, and CMDB/EDR feeds.
+
+`agent-bom ingest hardware` maps that operator-provided evidence onto the unified
+graph so a host, its firmware (BIOS/BMC/NIC), its GPUs, and any firmware or
+GPU-driver advisory become first-class, traversable nodes.
+
+!!! note "Evidence ingest, not firmware scanning"
+    This is **not** a firmware scanner. agent-bom does not probe BMC/IPMI, read
+    BIOS, or run any device-side agent. It ingests a JSON document you already
+    have and projects it onto the graph. Generating that evidence (vendor
+    inventory exports, signed attestations, OCSF/CMDB feeds) is out of scope.
+
+## Usage
+
+```bash
+# Map evidence onto the graph and stream the graph JSON to stdout
+agent-bom ingest hardware evidence.json
+
+# Human-readable summary instead of the raw graph
+agent-bom ingest hardware evidence.json -f table
+
+# Write the graph export to a file
+agent-bom ingest hardware evidence.json -o hardware-graph.json
+```
+
+## Sensitive identifiers are redacted by default
+
+Device and GPU **serial numbers are hashed by default** — only a stable,
+salt-free SHA-256 `serial_fingerprint` is stored, and the raw value is dropped
+(`serial_redacted: true`). The fingerprint is stable enough to correlate the
+same device across evidence files without revealing the serial. No raw firmware
+signature blobs are stored — only the attestation posture (signed/verified),
+declared algorithm, and provenance.
+
+To retain raw serials (for example on a single-tenant operator workstation),
+opt in explicitly:
+
+```bash
+agent-bom ingest hardware evidence.json --capture-serials
+```
+
+## Input contract — `agent-bom.hardware-evidence/v1`
+
+```json
+{
+  "schema_version": "agent-bom.hardware-evidence/v1",
+  "source": "vendor-inventory-export",
+  "hosts": [
+    {
+      "host_id": "stable-operator-id",
+      "hostname": "gpu-node-01",
+      "vendor": "Acme",
+      "model": "PowerEdge R760",
+      "serial": "ABC123",
+      "bios_version": "2.10.1",
+      "bmc_version": "7.10.30",
+      "firmware": [
+        { "component": "nic-firmware", "version": "22.5.1", "vendor": "Acme", "signed": true }
+      ],
+      "gpus": [
+        { "model": "A100", "driver_version": "550.54.15", "cuda_version": "12.4", "serial": "GPU-abc", "mig_mode": "enabled" }
+      ],
+      "attestation": {
+        "source": "tpm-quote",
+        "signed": true,
+        "verified": true,
+        "provenance": "vendor-signed",
+        "signature_algorithm": "ecdsa-p256"
+      },
+      "advisories": [
+        { "id": "CVE-2024-0001", "severity": "high", "affects": "bios", "fixed_version": "2.11.0", "title": "BIOS privilege escalation" },
+        { "id": "NV-2024-0002", "severity": "critical", "affects": "gpu:A100", "title": "GPU driver OOB write" }
+      ]
+    }
+  ]
+}
+```
+
+`host_id` is optional; the hostname is used when it is absent. Every field except
+the host identifier is optional.
+
+### Graph mapping
+
+| Evidence | Graph node | Notes |
+|----------|-----------|-------|
+| Host | `RESOURCE` (`resource_kind=hardware_host`) | Carries vendor/model, BIOS/BMC versions, attestation posture, redacted serial |
+| BIOS / BMC / firmware component | `RESOURCE` (`resource_kind=firmware`) | Linked to the host with `PART_OF` |
+| GPU | `RESOURCE` (`resource_kind=gpu`) | Driver/CUDA/MIG attributes; linked to the host with `PART_OF` |
+| Advisory | `VULNERABILITY` | Linked with `AFFECTS` to the precise asset |
+
+The advisory `affects` selector connects an advisory to the asset it impacts:
+`host`, `bios`, `bmc`, `firmware:<component>`, or `gpu:<model>`. Unknown or empty
+selectors fall back to the host so an advisory is never orphaned. This is what
+lets a firmware or GPU-driver advisory connect to the affected host/GPU asset.
+
+### Compliance evidence
+
+Host and firmware nodes carry `compliance_tags` derived from the attestation
+state — `hardware-attestation-verified`,
+`hardware-attestation-signed-unverified`, or `hardware-attestation-unverified` —
+and firmware components are tagged `firmware-signed` / `firmware-unsigned`. These
+flow through the graph as durable, queryable compliance evidence alongside
+software findings.

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -14,6 +14,8 @@
 | `fs` | Scan a filesystem directory or mounted VM disk snapshot |
 | `iac` | Scan Dockerfile, Kubernetes, Terraform, CloudFormation, and live Kubernetes posture |
 | `sbom` | Ingest an existing CycloneDX or SPDX SBOM and scan it |
+| `ingest` | Ingest operator-provided evidence (e.g. hardware/firmware attestation) into the unified graph |
+| `ingest hardware` | Map a hardware/firmware attestation evidence file onto host / GPU / firmware / advisory graph nodes |
 | `cloud` | Scan AWS, Azure, or GCP infrastructure posture |
 | `check` | Check one package before install or approval |
 | `verify` | Verify package integrity / provenance or self-verify `agent-bom` |

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -376,6 +376,13 @@ from agent_bom.cli._identity_group import identity_group  # noqa: E402
 main.add_command(identity_group)
 
 # ---------------------------------------------------------------------------
+# Ingest command group — `agent-bom ingest [hardware]`
+# ---------------------------------------------------------------------------
+from agent_bom.cli._ingest_group import ingest_group  # noqa: E402
+
+main.add_command(ingest_group)
+
+# ---------------------------------------------------------------------------
 # Fleet command group — `agent-bom fleet [sync|list|stats]`
 # ---------------------------------------------------------------------------
 from agent_bom.cli.claw import fleet_group  # noqa: E402

--- a/src/agent_bom/cli/_grouped_help.py
+++ b/src/agent_bom/cli/_grouped_help.py
@@ -13,7 +13,7 @@ COMMAND_CATEGORIES: OrderedDict[str, list[str]] = OrderedDict(
     [
         (
             "Scanning",
-            ["agents", "skills", "image", "fs", "iac", "sbom", "cloud", "check", "verify", "secrets", "code"],
+            ["agents", "skills", "image", "fs", "iac", "sbom", "ingest", "cloud", "check", "verify", "secrets", "code"],
         ),
         (
             "Runtime",

--- a/src/agent_bom/cli/_ingest_group.py
+++ b/src/agent_bom/cli/_ingest_group.py
@@ -1,0 +1,158 @@
+"""Ingest command group — operator-provided evidence into the unified graph.
+
+Reference-only ingest of evidence that already exists outside agent-bom. The
+first surface is hardware/firmware attestation evidence (#1891): vendor
+hardware/firmware SBOMs, signed firmware attestations, and BMC/BIOS/CMDB
+inventory exports. agent-bom does not probe devices — it maps the supplied
+evidence onto the graph so hosts, firmware, GPUs, and firmware/GPU-driver
+advisories become first-class, traversable nodes.
+
+Usage::
+
+    agent-bom ingest hardware evidence.json                 # graph JSON to stdout
+    agent-bom ingest hardware evidence.json -f table        # human summary
+    agent-bom ingest hardware evidence.json -o graph.json   # write to a file
+    agent-bom ingest hardware evidence.json --capture-serials  # retain raw serials
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+import click
+
+from agent_bom.cli._grouped_help import SuggestingGroup
+
+if TYPE_CHECKING:
+    from agent_bom.graph import UnifiedGraph
+
+_DEFAULT_TENANT = "default"
+
+
+@click.group("ingest", cls=SuggestingGroup)
+def ingest_group() -> None:
+    """Ingest operator-provided evidence into the unified graph (reference-only).
+
+    \b
+    Subcommands:
+      hardware   Ingest hardware/firmware attestation evidence (host/GPU/firmware)
+    """
+
+
+@click.command("hardware")
+@click.argument("evidence_file", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option("--tenant", default=_DEFAULT_TENANT, show_default=True, help="Tenant to scope the graph to.")
+@click.option(
+    "--capture-serials",
+    is_flag=True,
+    default=False,
+    help="Retain raw device/GPU serials. Off by default — serials are hashed to a fingerprint.",
+)
+@click.option(
+    "-f",
+    "--format",
+    "output_format",
+    type=click.Choice(["json", "table"]),
+    default="json",
+    show_default=True,
+    help="json streams the graph export; table prints a human summary.",
+)
+@click.option("-o", "--output", "output_path", type=click.Path(dir_okay=False, path_type=Path), default=None)
+def hardware_cmd(
+    evidence_file: Path,
+    tenant: str,
+    capture_serials: bool,
+    output_format: str,
+    output_path: Optional[Path],
+) -> None:
+    """Map a hardware/firmware evidence file onto the unified graph.
+
+    EVIDENCE_FILE is a JSON document conforming to the
+    ``agent-bom.hardware-evidence/v1`` contract. This is evidence ingest, not a
+    firmware scan: nothing is probed on any device.
+    """
+    from agent_bom.hardware_evidence import HardwareEvidenceError, build_hardware_graph
+
+    try:
+        evidence = json.loads(evidence_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise click.ClickException(f"could not read evidence file: {exc}") from exc
+
+    try:
+        graph = build_hardware_graph(evidence, capture_serials=capture_serials, tenant_id=tenant)
+    except HardwareEvidenceError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if output_format == "json":
+        payload = json.dumps(graph.to_dict(), indent=2, sort_keys=True)
+        if output_path:
+            output_path.write_text(payload, encoding="utf-8")
+            click.echo(f"Graph exported ({len(graph.nodes)} nodes, {len(graph.edges)} edges) → {output_path}")
+        else:
+            click.echo(payload)
+        return
+
+    _render_table(graph, capture_serials=capture_serials)
+
+
+def _render_table(graph: UnifiedGraph, *, capture_serials: bool) -> None:
+    from rich.console import Console
+    from rich.table import Table
+
+    from agent_bom.graph import EntityType
+    from agent_bom.hardware_evidence import (
+        RESOURCE_KIND_FIRMWARE,
+        RESOURCE_KIND_GPU,
+        RESOURCE_KIND_HOST,
+    )
+
+    nodes = list(graph.nodes.values())
+    hosts = [n for n in nodes if n.attributes.get("resource_kind") == RESOURCE_KIND_HOST]
+    firmware = [n for n in nodes if n.attributes.get("resource_kind") == RESOURCE_KIND_FIRMWARE]
+    gpus = [n for n in nodes if n.attributes.get("resource_kind") == RESOURCE_KIND_GPU]
+    advisories = [n for n in nodes if n.entity_type == EntityType.VULNERABILITY]
+
+    con = Console()
+    redaction = "raw serials retained" if capture_serials else "serials hashed"
+    con.print(
+        f"\n  [bold]Hardware/firmware evidence[/bold] [dim]· {len(hosts)} host(s) · "
+        f"{len(firmware)} firmware · {len(gpus)} GPU(s) · {len(advisories)} advisory/ies · {redaction}[/dim]"
+    )
+
+    host_table = Table(title="Hosts", title_justify="left", title_style="bold")
+    host_table.add_column("Host")
+    host_table.add_column("Vendor / model")
+    host_table.add_column("BIOS")
+    host_table.add_column("Attestation")
+    for host in hosts:
+        a = host.attributes
+        vendor_model = " ".join(p for p in (a.get("vendor", ""), a.get("model", "")) if p) or "—"
+        host_table.add_row(
+            host.label,
+            vendor_model,
+            a.get("bios_version", "—") or "—",
+            ", ".join(host.compliance_tags) or "—",
+        )
+    if hosts:
+        con.print(host_table)
+
+    if advisories:
+        adv_table = Table(title="Advisories", title_justify="left", title_style="bold")
+        adv_table.add_column("ID")
+        adv_table.add_column("Severity")
+        adv_table.add_column("Affects")
+        adv_table.add_column("Fixed in")
+        for adv in advisories:
+            adv_table.add_row(
+                adv.label,
+                adv.severity or "unknown",
+                str(adv.attributes.get("affects", "host")),
+                adv.attributes.get("fixed_version", "—") or "—",
+            )
+        con.print(adv_table)
+    con.print()
+
+
+ingest_group.add_command(hardware_cmd, "hardware")

--- a/src/agent_bom/hardware_evidence.py
+++ b/src/agent_bom/hardware_evidence.py
@@ -1,0 +1,374 @@
+"""Hardware/firmware attestation evidence ingest (#1891).
+
+agent-bom is **not** a firmware scanner. This module ingests evidence that
+already exists outside agent-bom — vendor hardware/firmware SBOMs, signed
+firmware attestations, BMC/BIOS inventory exports, CMDB/EDR exports — and maps
+it onto the unified graph so a host, its firmware (BIOS/BMC/NIC), its GPUs, and
+any firmware/GPU-driver advisory become first-class, traversable nodes.
+
+Design notes
+------------
+* **Reuses existing graph vocabulary.** Hosts, firmware components, and GPUs are
+  modelled as :class:`~agent_bom.graph.types.EntityType.RESOURCE` nodes carrying
+  a ``resource_kind`` attribute (``hardware_host`` / ``firmware`` / ``gpu``).
+  Advisories reuse :class:`EntityType.VULNERABILITY`. No new graph types are
+  invented.
+* **Sensitive identifiers are hashed by default.** Device and GPU serial numbers
+  are never stored raw unless the caller explicitly opts in
+  (``capture_serials=True``). The redacted form is a salt-free SHA-256
+  fingerprint, which is stable enough to correlate the same device across
+  evidence files without revealing the serial.
+* **Evidence, not scanning.** Nothing here probes a device. The input is an
+  operator-provided JSON document conforming to the versioned contract below.
+
+Input contract — ``agent-bom.hardware-evidence/v1``::
+
+    {
+      "schema_version": "agent-bom.hardware-evidence/v1",
+      "source": "vendor-inventory-export",      # optional provenance label
+      "hosts": [
+        {
+          "host_id": "stable-operator-id",       # optional; falls back to hostname
+          "hostname": "gpu-node-01",
+          "vendor": "Acme",
+          "model": "PowerEdge R760",
+          "serial": "ABC123",                    # hashed unless capture_serials
+          "bios_version": "2.10.1",
+          "bmc_version": "7.10.30",
+          "firmware": [
+            {"component": "nic-firmware", "version": "22.5.1", "vendor": "Acme",
+             "signed": true}
+          ],
+          "gpus": [
+            {"model": "A100", "driver_version": "550.54.15", "cuda_version": "12.4",
+             "serial": "GPU-abc", "mig_mode": "enabled"}
+          ],
+          "attestation": {
+            "source": "tpm-quote", "signed": true, "verified": true,
+            "provenance": "vendor-signed", "signature_algorithm": "ecdsa-p256"
+          },
+          "advisories": [
+            {"id": "CVE-2024-0001", "severity": "high", "affects": "bios",
+             "fixed_version": "2.11.0", "title": "BIOS privilege escalation"},
+            {"id": "NV-2024-0002", "severity": "critical", "affects": "gpu:A100",
+             "title": "GPU driver OOB write"}
+          ]
+        }
+      ]
+    }
+
+``affects`` targets (advisory → asset edge): ``host``, ``bios``, ``bmc``,
+``firmware:<component>``, ``gpu:<model>``. Unknown/empty targets fall back to the
+host so an advisory is never orphaned.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from agent_bom.graph import EntityType, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
+from agent_bom.graph.node import stable_node_id
+
+SCHEMA_VERSION = "agent-bom.hardware-evidence/v1"
+_SUPPORTED_SCHEMAS = frozenset({SCHEMA_VERSION})
+
+# Resource subtypes carried on RESOURCE nodes so the generic inventory type stays
+# semantically precise without inventing new graph vocabulary.
+RESOURCE_KIND_HOST = "hardware_host"
+RESOURCE_KIND_FIRMWARE = "firmware"
+RESOURCE_KIND_GPU = "gpu"
+
+_DATA_SOURCE = "hardware-attestation-ingest"
+_VALID_SEVERITIES = frozenset({"critical", "high", "medium", "low", "info", "unknown"})
+
+
+class HardwareEvidenceError(ValueError):
+    """Raised when a hardware/firmware evidence document is malformed."""
+
+
+def _fingerprint(value: str) -> str:
+    """Stable, salt-free SHA-256 fingerprint used to redact sensitive serials."""
+    return "sha256:" + hashlib.sha256(value.strip().encode("utf-8")).hexdigest()
+
+
+def _redact_serial(serial: str, *, capture_serials: bool) -> dict[str, Any]:
+    """Return the attributes representing a serial under the active redaction policy.
+
+    By default only a fingerprint is emitted and the raw serial is dropped. With
+    ``capture_serials=True`` the raw value is retained alongside the fingerprint.
+    """
+    serial = (serial or "").strip()
+    if not serial:
+        return {}
+    attrs: dict[str, Any] = {"serial_fingerprint": _fingerprint(serial)}
+    if capture_serials:
+        attrs["serial"] = serial
+    else:
+        attrs["serial_redacted"] = True
+    return attrs
+
+
+def _str(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _host_key(host: dict[str, Any]) -> str:
+    key = _str(host.get("host_id")) or _str(host.get("hostname"))
+    if not key:
+        raise HardwareEvidenceError("each host requires a 'host_id' or 'hostname'")
+    return key
+
+
+def _attestation_tags(attestation: dict[str, Any]) -> tuple[list[str], dict[str, Any]]:
+    """Derive compliance tags + safe attributes from an attestation block.
+
+    Raw signature blobs are never stored — only the verification posture and the
+    declared algorithm/source, which is what compliance evidence needs.
+    """
+    if not isinstance(attestation, dict):
+        return [], {}
+    signed = bool(attestation.get("signed"))
+    verified = bool(attestation.get("verified"))
+    attrs = {
+        "attestation_source": _str(attestation.get("source")),
+        "attestation_signed": signed,
+        "attestation_verified": verified,
+        "attestation_provenance": _str(attestation.get("provenance")),
+        "signature_algorithm": _str(attestation.get("signature_algorithm")),
+    }
+    attrs = {k: v for k, v in attrs.items() if v not in ("", None)}
+    if verified and signed:
+        tags = ["hardware-attestation-verified"]
+    elif signed:
+        tags = ["hardware-attestation-signed-unverified"]
+    else:
+        tags = ["hardware-attestation-unverified"]
+    return tags, attrs
+
+
+def _normalize_severity(raw: Any) -> str:
+    value = _str(raw).lower()
+    return value if value in _VALID_SEVERITIES else "unknown"
+
+
+def build_hardware_graph(
+    evidence: dict[str, Any],
+    *,
+    capture_serials: bool = False,
+    tenant_id: str = "",
+    scan_id: str = "",
+) -> UnifiedGraph:
+    """Map a hardware/firmware evidence document onto a :class:`UnifiedGraph`.
+
+    Args:
+        evidence: A document conforming to ``agent-bom.hardware-evidence/v1``.
+        capture_serials: When ``False`` (default) device/GPU serials are hashed
+            and the raw value dropped. When ``True`` the raw serial is retained.
+        tenant_id: Optional tenant scoping recorded on the graph.
+        scan_id: Optional scan/run id recorded on the graph.
+
+    Raises:
+        HardwareEvidenceError: If the document is malformed or the schema version
+            is unsupported.
+    """
+    if not isinstance(evidence, dict):
+        raise HardwareEvidenceError("evidence must be a JSON object")
+    schema = _str(evidence.get("schema_version"))
+    if schema not in _SUPPORTED_SCHEMAS:
+        raise HardwareEvidenceError(f"unsupported schema_version {schema!r}; expected one of {sorted(_SUPPORTED_SCHEMAS)}")
+    hosts = evidence.get("hosts")
+    if not isinstance(hosts, list) or not hosts:
+        raise HardwareEvidenceError("evidence requires a non-empty 'hosts' array")
+
+    document_source = _str(evidence.get("source"))
+    graph = UnifiedGraph(tenant_id=tenant_id, scan_id=scan_id)
+
+    for host in hosts:
+        if not isinstance(host, dict):
+            raise HardwareEvidenceError("each host must be a JSON object")
+        _ingest_host(graph, host, document_source=document_source, capture_serials=capture_serials)
+
+    return graph
+
+
+def _ingest_host(
+    graph: UnifiedGraph,
+    host: dict[str, Any],
+    *,
+    document_source: str,
+    capture_serials: bool,
+) -> None:
+    host_key = _host_key(host)
+    host_id = stable_node_id(RESOURCE_KIND_HOST, host_key)
+    label = _str(host.get("hostname")) or host_key
+
+    attest_tags, attest_attrs = _attestation_tags(host.get("attestation", {}))
+    host_attrs: dict[str, Any] = {
+        "resource_kind": RESOURCE_KIND_HOST,
+        "hostname": _str(host.get("hostname")),
+        "vendor": _str(host.get("vendor")),
+        "model": _str(host.get("model")),
+        "bios_version": _str(host.get("bios_version")),
+        "bmc_version": _str(host.get("bmc_version")),
+        "evidence_source": document_source,
+    }
+    host_attrs.update(attest_attrs)
+    host_attrs.update(_redact_serial(_str(host.get("serial")), capture_serials=capture_serials))
+    host_attrs = {k: v for k, v in host_attrs.items() if v not in ("", None)}
+
+    graph.add_node(
+        UnifiedNode(
+            id=host_id,
+            entity_type=EntityType.RESOURCE,
+            label=label,
+            attributes=host_attrs,
+            compliance_tags=attest_tags,
+            data_sources=[_DATA_SOURCE],
+        )
+    )
+
+    # Map of advisory `affects` selector -> graph node id, so advisories connect
+    # to the precise asset. The host is always registered as a fallback target.
+    targets: dict[str, str] = {"host": host_id}
+
+    # ── BIOS / BMC firmware as dedicated components ──
+    for component, version_key in (("bios", "bios_version"), ("bmc", "bmc_version")):
+        version = _str(host.get(version_key))
+        if not version:
+            continue
+        node_id = _add_firmware_node(graph, host_id, host_key, component=component, version=version, attrs={}, tags=attest_tags)
+        targets[component] = node_id
+
+    # ── Additional firmware components ──
+    for fw in host.get("firmware", []) or []:
+        if not isinstance(fw, dict):
+            continue
+        component = _str(fw.get("component"))
+        if not component:
+            continue
+        signed = bool(fw.get("signed"))
+        node_id = _add_firmware_node(
+            graph,
+            host_id,
+            host_key,
+            component=component,
+            version=_str(fw.get("version")),
+            attrs={
+                "vendor": _str(fw.get("vendor")),
+                "signed": signed,
+            },
+            tags=["firmware-signed"] if signed else ["firmware-unsigned"],
+        )
+        targets[f"firmware:{component.lower()}"] = node_id
+
+    # ── GPUs ──
+    for index, gpu in enumerate(host.get("gpus", []) or []):
+        if not isinstance(gpu, dict):
+            continue
+        model = _str(gpu.get("model")) or f"gpu-{index}"
+        gpu_id = stable_node_id(RESOURCE_KIND_GPU, host_key, model, str(index))
+        gpu_attrs: dict[str, Any] = {
+            "resource_kind": RESOURCE_KIND_GPU,
+            "model": model,
+            "driver_version": _str(gpu.get("driver_version")),
+            "cuda_version": _str(gpu.get("cuda_version")),
+            "mig_mode": _str(gpu.get("mig_mode")),
+            "evidence_source": document_source,
+        }
+        gpu_attrs.update(_redact_serial(_str(gpu.get("serial")), capture_serials=capture_serials))
+        gpu_attrs = {k: v for k, v in gpu_attrs.items() if v not in ("", None)}
+        graph.add_node(
+            UnifiedNode(
+                id=gpu_id,
+                entity_type=EntityType.RESOURCE,
+                label=f"{model} (GPU)",
+                attributes=gpu_attrs,
+                data_sources=[_DATA_SOURCE],
+            )
+        )
+        # GPU is part of the host.
+        graph.add_edge(UnifiedEdge(source=gpu_id, target=host_id, relationship=RelationshipType.PART_OF))
+        targets[f"gpu:{model.lower()}"] = gpu_id
+
+    # ── Advisories → affected asset ──
+    for advisory in host.get("advisories", []) or []:
+        if not isinstance(advisory, dict):
+            continue
+        _ingest_advisory(graph, advisory, host_id=host_id, targets=targets)
+
+
+def _add_firmware_node(
+    graph: UnifiedGraph,
+    host_id: str,
+    host_key: str,
+    *,
+    component: str,
+    version: str,
+    attrs: dict[str, Any],
+    tags: list[str],
+) -> str:
+    node_id = stable_node_id(RESOURCE_KIND_FIRMWARE, host_key, component)
+    node_attrs: dict[str, Any] = {
+        "resource_kind": RESOURCE_KIND_FIRMWARE,
+        "component": component,
+        "version": version,
+    }
+    node_attrs.update({k: v for k, v in attrs.items() if v not in ("", None)})
+    graph.add_node(
+        UnifiedNode(
+            id=node_id,
+            entity_type=EntityType.RESOURCE,
+            label=f"{component} {version}".strip(),
+            attributes=node_attrs,
+            compliance_tags=list(tags),
+            data_sources=[_DATA_SOURCE],
+        )
+    )
+    # Firmware is part of the host.
+    graph.add_edge(UnifiedEdge(source=node_id, target=host_id, relationship=RelationshipType.PART_OF))
+    return node_id
+
+
+def _ingest_advisory(
+    graph: UnifiedGraph,
+    advisory: dict[str, Any],
+    *,
+    host_id: str,
+    targets: dict[str, str],
+) -> None:
+    advisory_id = _str(advisory.get("id"))
+    if not advisory_id:
+        raise HardwareEvidenceError("each advisory requires an 'id'")
+    selector = _str(advisory.get("affects")).lower()
+    target_id = targets.get(selector, host_id)
+    severity = _normalize_severity(advisory.get("severity"))
+
+    vuln_id = stable_node_id(EntityType.VULNERABILITY.value, advisory_id, target_id)
+    attrs = {
+        "cve_id": advisory_id,
+        "affects": selector or "host",
+        "fixed_version": _str(advisory.get("fixed_version")),
+        "title": _str(advisory.get("title")),
+        "evidence_source": _DATA_SOURCE,
+    }
+    attrs = {k: v for k, v in attrs.items() if v not in ("", None)}
+    graph.add_node(
+        UnifiedNode(
+            id=vuln_id,
+            entity_type=EntityType.VULNERABILITY,
+            label=advisory_id,
+            severity=severity,
+            attributes=attrs,
+            data_sources=[_DATA_SOURCE],
+        )
+    )
+    # Advisory AFFECTS the precise hardware/firmware/GPU asset.
+    graph.add_edge(
+        UnifiedEdge(
+            source=vuln_id,
+            target=target_id,
+            relationship=RelationshipType.AFFECTS,
+            evidence={"source": _DATA_SOURCE},
+        )
+    )

--- a/tests/test_hardware_evidence.py
+++ b/tests/test_hardware_evidence.py
@@ -1,0 +1,221 @@
+"""Tests for hardware/firmware attestation evidence ingest (#1891)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+from agent_bom.graph import EntityType, RelationshipType
+from agent_bom.hardware_evidence import (
+    RESOURCE_KIND_FIRMWARE,
+    RESOURCE_KIND_GPU,
+    RESOURCE_KIND_HOST,
+    SCHEMA_VERSION,
+    HardwareEvidenceError,
+    build_hardware_graph,
+)
+
+
+def _evidence(**overrides):
+    host = {
+        "host_id": "host-stable-1",
+        "hostname": "gpu-node-01",
+        "vendor": "Acme",
+        "model": "PowerEdge R760",
+        "serial": "SERIAL-ABC-123",
+        "bios_version": "2.10.1",
+        "bmc_version": "7.10.30",
+        "firmware": [
+            {"component": "nic-firmware", "version": "22.5.1", "vendor": "Acme", "signed": True},
+        ],
+        "gpus": [
+            {
+                "model": "A100",
+                "driver_version": "550.54.15",
+                "cuda_version": "12.4",
+                "serial": "GPU-XYZ",
+                "mig_mode": "enabled",
+            },
+        ],
+        "attestation": {
+            "source": "tpm-quote",
+            "signed": True,
+            "verified": True,
+            "provenance": "vendor-signed",
+            "signature_algorithm": "ecdsa-p256",
+        },
+        "advisories": [
+            {"id": "CVE-2024-0001", "severity": "high", "affects": "bios", "fixed_version": "2.11.0"},
+            {"id": "NV-2024-0002", "severity": "critical", "affects": "gpu:a100"},
+        ],
+    }
+    host.update(overrides)
+    return {"schema_version": SCHEMA_VERSION, "source": "vendor-export", "hosts": [host]}
+
+
+def _nodes_by_kind(graph, kind):
+    return [n for n in graph.nodes.values() if n.attributes.get("resource_kind") == kind]
+
+
+class TestBuildHardwareGraph:
+    def test_builds_host_firmware_gpu_nodes(self) -> None:
+        graph = build_hardware_graph(_evidence())
+
+        hosts = _nodes_by_kind(graph, RESOURCE_KIND_HOST)
+        firmware = _nodes_by_kind(graph, RESOURCE_KIND_FIRMWARE)
+        gpus = _nodes_by_kind(graph, RESOURCE_KIND_GPU)
+
+        assert len(hosts) == 1
+        assert hosts[0].label == "gpu-node-01"
+        # bios + bmc + nic-firmware
+        assert len(firmware) == 3
+        assert {n.attributes["component"] for n in firmware} == {"bios", "bmc", "nic-firmware"}
+        assert len(gpus) == 1
+        assert gpus[0].attributes["driver_version"] == "550.54.15"
+
+    def test_all_hardware_nodes_reuse_resource_entity_type(self) -> None:
+        graph = build_hardware_graph(_evidence())
+        for kind in (RESOURCE_KIND_HOST, RESOURCE_KIND_FIRMWARE, RESOURCE_KIND_GPU):
+            for node in _nodes_by_kind(graph, kind):
+                assert node.entity_type == EntityType.RESOURCE
+
+    def test_firmware_and_gpu_are_part_of_host(self) -> None:
+        graph = build_hardware_graph(_evidence())
+        host_id = _nodes_by_kind(graph, RESOURCE_KIND_HOST)[0].id
+        part_of = [e for e in graph.edges if e.relationship == RelationshipType.PART_OF]
+        # 3 firmware + 1 gpu
+        assert len(part_of) == 4
+        assert all(e.target == host_id for e in part_of)
+
+    def test_serials_hashed_by_default(self) -> None:
+        graph = build_hardware_graph(_evidence())
+        host = _nodes_by_kind(graph, RESOURCE_KIND_HOST)[0]
+        gpu = _nodes_by_kind(graph, RESOURCE_KIND_GPU)[0]
+
+        assert "serial" not in host.attributes
+        assert host.attributes["serial_redacted"] is True
+        assert host.attributes["serial_fingerprint"].startswith("sha256:")
+        assert "SERIAL-ABC-123" not in json.dumps(graph.to_dict())
+        assert "serial" not in gpu.attributes
+        assert gpu.attributes["serial_fingerprint"].startswith("sha256:")
+
+    def test_capture_serials_opt_in_retains_raw(self) -> None:
+        graph = build_hardware_graph(_evidence(), capture_serials=True)
+        host = _nodes_by_kind(graph, RESOURCE_KIND_HOST)[0]
+        assert host.attributes["serial"] == "SERIAL-ABC-123"
+        assert host.attributes["serial_fingerprint"].startswith("sha256:")
+
+    def test_no_raw_signature_blob_stored(self) -> None:
+        evidence = _evidence()
+        evidence["hosts"][0]["attestation"]["signature"] = "BIGSECRETSIGBLOB"
+        graph = build_hardware_graph(evidence)
+        assert "BIGSECRETSIGBLOB" not in json.dumps(graph.to_dict())
+
+    def test_advisory_connects_to_affected_asset(self) -> None:
+        graph = build_hardware_graph(_evidence())
+        affects = [e for e in graph.edges if e.relationship == RelationshipType.AFFECTS]
+        assert len(affects) == 2
+
+        vulns = {n.id: n for n in graph.nodes.values() if n.entity_type == EntityType.VULNERABILITY}
+        # The GPU-driver advisory must target the GPU node.
+        gpu_id = _nodes_by_kind(graph, RESOURCE_KIND_GPU)[0].id
+        gpu_edge = next(e for e in affects if e.target == gpu_id)
+        assert vulns[gpu_edge.source].label == "NV-2024-0002"
+        assert vulns[gpu_edge.source].severity == "critical"
+
+        # The BIOS advisory must target the bios firmware node.
+        bios_id = next(n.id for n in _nodes_by_kind(graph, RESOURCE_KIND_FIRMWARE) if n.attributes["component"] == "bios")
+        assert any(e.target == bios_id for e in affects)
+
+    def test_attestation_compliance_tags(self) -> None:
+        graph = build_hardware_graph(_evidence())
+        host = _nodes_by_kind(graph, RESOURCE_KIND_HOST)[0]
+        assert "hardware-attestation-verified" in host.compliance_tags
+
+        unverified = _evidence()
+        unverified["hosts"][0]["attestation"] = {"source": "bios-log", "signed": False, "verified": False}
+        graph2 = build_hardware_graph(unverified)
+        host2 = _nodes_by_kind(graph2, RESOURCE_KIND_HOST)[0]
+        assert "hardware-attestation-unverified" in host2.compliance_tags
+
+    def test_advisory_unknown_selector_falls_back_to_host(self) -> None:
+        evidence = _evidence()
+        evidence["hosts"][0]["advisories"] = [{"id": "CVE-2024-9999", "severity": "low", "affects": "mystery"}]
+        graph = build_hardware_graph(evidence)
+        host_id = _nodes_by_kind(graph, RESOURCE_KIND_HOST)[0].id
+        affects = [e for e in graph.edges if e.relationship == RelationshipType.AFFECTS]
+        assert len(affects) == 1
+        assert affects[0].target == host_id
+
+    def test_deterministic_node_ids(self) -> None:
+        g1 = build_hardware_graph(_evidence())
+        g2 = build_hardware_graph(_evidence())
+        assert set(g1.nodes) == set(g2.nodes)
+
+    def test_rejects_unknown_schema(self) -> None:
+        with pytest.raises(HardwareEvidenceError):
+            build_hardware_graph({"schema_version": "bogus/v9", "hosts": [{"hostname": "h"}]})
+
+    def test_rejects_missing_hosts(self) -> None:
+        with pytest.raises(HardwareEvidenceError):
+            build_hardware_graph({"schema_version": SCHEMA_VERSION, "hosts": []})
+
+    def test_rejects_host_without_identity(self) -> None:
+        with pytest.raises(HardwareEvidenceError):
+            build_hardware_graph({"schema_version": SCHEMA_VERSION, "hosts": [{"vendor": "Acme"}]})
+
+    def test_rejects_advisory_without_id(self) -> None:
+        evidence = _evidence()
+        evidence["hosts"][0]["advisories"] = [{"severity": "high", "affects": "bios"}]
+        with pytest.raises(HardwareEvidenceError):
+            build_hardware_graph(evidence)
+
+
+class TestHardwareCLI:
+    def test_ingest_hardware_emits_graph_json(self, tmp_path) -> None:
+        path = tmp_path / "evidence.json"
+        path.write_text(json.dumps(_evidence()), encoding="utf-8")
+
+        result = CliRunner().invoke(main, ["ingest", "hardware", str(path)])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert any(n["attributes"].get("resource_kind") == RESOURCE_KIND_HOST for n in payload["nodes"])
+        # Serial must not leak in the default (redacted) output.
+        assert "SERIAL-ABC-123" not in result.output
+
+    def test_ingest_hardware_capture_serials(self, tmp_path) -> None:
+        path = tmp_path / "evidence.json"
+        path.write_text(json.dumps(_evidence()), encoding="utf-8")
+
+        result = CliRunner().invoke(main, ["ingest", "hardware", str(path), "--capture-serials"])
+        assert result.exit_code == 0, result.output
+        assert "SERIAL-ABC-123" in result.output
+
+    def test_ingest_hardware_table_format(self, tmp_path) -> None:
+        path = tmp_path / "evidence.json"
+        path.write_text(json.dumps(_evidence()), encoding="utf-8")
+
+        result = CliRunner().invoke(main, ["ingest", "hardware", str(path), "-f", "table"])
+        assert result.exit_code == 0, result.output
+        assert "gpu-node-01" in result.output
+        assert "CVE-2024-0001" in result.output
+
+    def test_ingest_hardware_output_file(self, tmp_path) -> None:
+        path = tmp_path / "evidence.json"
+        path.write_text(json.dumps(_evidence()), encoding="utf-8")
+        out = tmp_path / "graph.json"
+
+        result = CliRunner().invoke(main, ["ingest", "hardware", str(path), "-o", str(out)])
+        assert result.exit_code == 0, result.output
+        assert out.exists()
+        assert json.loads(out.read_text())["nodes"]
+
+    def test_ingest_hardware_bad_schema_errors(self, tmp_path) -> None:
+        path = tmp_path / "evidence.json"
+        path.write_text(json.dumps({"schema_version": "nope", "hosts": []}), encoding="utf-8")
+
+        result = CliRunner().invoke(main, ["ingest", "hardware", str(path)])
+        assert result.exit_code != 0


### PR DESCRIPTION
Closes #1891

## What shipped

A reference-only ingestion path for hardware/firmware attestation evidence that **already exists outside agent-bom** (vendor hardware/firmware SBOMs, signed firmware attestations, BMC/BIOS/CMDB/EDR inventory exports). agent-bom does **not** become a firmware scanner — nothing probes a device; the input is an operator-provided JSON document.

New command:

```bash
agent-bom ingest hardware evidence.json                 # graph JSON to stdout
agent-bom ingest hardware evidence.json -f table        # human summary
agent-bom ingest hardware evidence.json -o graph.json   # write to a file
agent-bom ingest hardware evidence.json --capture-serials  # retain raw serials
```

### Design
- **Versioned input contract** `agent-bom.hardware-evidence/v1` — hosts with vendor/model/serial, BIOS/BMC versions, firmware components, GPUs (driver/CUDA/MIG), attestation block, and advisories.
- **Reuses existing graph vocabulary** (no new `EntityType`/`RelationshipType`, avoiding the cross-surface blast radius of new graph types): hosts/firmware/GPUs are `RESOURCE` nodes carrying a `resource_kind` subtype (`hardware_host`/`firmware`/`gpu`); advisories are `VULNERABILITY` nodes. Firmware/GPU are `PART_OF` the host; advisories `AFFECTS` the precise affected asset.
- **Redaction by default**: device + GPU serials are SHA-256 fingerprinted and the raw value dropped (`serial_redacted: true`) unless `--capture-serials` is passed. Raw firmware signature blobs are never stored — only the attestation posture/algorithm/provenance.
- **Compliance evidence**: hosts/firmware carry `compliance_tags` derived from attestation state (`hardware-attestation-verified` / `…-signed-unverified` / `…-unverified`, `firmware-signed`/`firmware-unsigned`).

### Acceptance criteria (#1891)
- ✅ Operators can import a hardware/firmware evidence file and see host/GPU/firmware nodes in the graph export.
- ✅ Sensitive identifiers are hashed/redacted unless explicitly opted in (`--capture-serials`).
- ✅ A firmware or GPU-driver advisory connects to the affected host/GPU asset (`AFFECTS` edge to the precise node; unknown selectors fall back to the host so advisories are never orphaned).
- ✅ Docs frame this as evidence ingest, not native firmware scanning.

## Files
- `src/agent_bom/hardware_evidence.py` — parser + graph builder + redaction.
- `src/agent_bom/cli/_ingest_group.py` — `agent-bom ingest hardware`.
- `src/agent_bom/cli/__init__.py`, `_grouped_help.py` — register + categorize.
- `site-docs/features/hardware-evidence.md`, `site-docs/reference/cli.md`, `mkdocs.yml` — docs + CLI reference + nav.
- `tests/test_hardware_evidence.py` — unit + CLI tests.

No API route or Pydantic model was added, so no OpenAPI/atlas regeneration is required. No new `AGENT_BOM_*` env flag (opt-in is a CLI flag).

## How verified
- `ruff check` — pass on all changed files.
- `ruff format --check` — pass on all changed files.
- `mypy` — clean on `hardware_evidence.py` and `_ingest_group.py`.
- Core graph-builder logic exercised directly (node/edge counts, default-redaction, `--capture-serials` round-trip, advisory→asset linking, multi-host, determinism).

Note: the sandbox has no network and the project's runtime deps (click/rich/pydantic/fastapi) are not installed, so the full `pytest` suite (which imports the CLI/app) could not be executed locally — CI will run `tests/test_hardware_evidence.py` and the existing suite. The pure-Python core was validated by direct execution.

---
_Generated by [Claude Code](https://claude.ai/code/session_017oKD9VuSdKs19KDPp3ZrTf)_