### PR TITLE
fix(api): reject unknown fields on request models (extra=forbid)

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -71,6 +71,7 @@
         "type": "object"
       },
       "BrowserExtensionsRequest": {
+        "additionalProperties": false,
         "description": "Request body for POST /v1/scan/browser-extensions.",
         "properties": {
           "include_low_risk": {
@@ -469,6 +470,7 @@
         "type": "object"
       },
       "CreateKeyRequest": {
+        "additionalProperties": false,
         "properties": {
           "expires_at": {
             "anyOf": [
@@ -812,6 +814,7 @@
         "type": "object"
       },
       "DatasetCardsRequest": {
+        "additionalProperties": false,
         "description": "Request body for POST /v1/scan/dataset-cards.",
         "properties": {
           "directories": {
@@ -940,6 +943,7 @@
         "type": "object"
       },
       "EvaluateRequest": {
+        "additionalProperties": false,
         "properties": {
           "agent_name": {
             "default": "",
@@ -1189,6 +1193,7 @@
         "type": "object"
       },
       "ExceptionRequest": {
+        "additionalProperties": false,
         "properties": {
           "expires_at": {
             "default": "",
@@ -1232,6 +1237,7 @@
         "type": "object"
       },
       "FalsePositiveRequest": {
+        "additionalProperties": false,
         "description": "Request body for POST /v1/findings/false-positive.",
         "properties": {
           "marked_by": {
@@ -1261,6 +1267,7 @@
         "type": "object"
       },
       "FindingFeedbackRequest": {
+        "additionalProperties": false,
         "description": "Request body for POST /v1/findings/feedback.",
         "properties": {
           "expires_at": {
@@ -1315,6 +1322,7 @@
         "type": "object"
       },
       "FindingTriageDecisionRequest": {
+        "additionalProperties": false,
         "description": "Request body for PUT /v1/findings/triage/{triage_id}/decision.",
         "properties": {
           "assignee": {
@@ -1382,6 +1390,7 @@
         "type": "object"
       },
       "FindingTriageRequest": {
+        "additionalProperties": false,
         "description": "Request body for POST /v1/findings/triage.",
         "properties": {
           "assignee": {
@@ -1468,6 +1477,7 @@
         "type": "object"
       },
       "FleetAgentUpdate": {
+        "additionalProperties": false,
         "properties": {
           "environment": {
             "anyOf": [
@@ -1881,6 +1891,7 @@
         "type": "object"
       },
       "IssueStatusUpdateRequest": {
+        "additionalProperties": false,
         "properties": {
           "status": {
             "maxLength": 64,
@@ -1896,6 +1907,7 @@
         "type": "object"
       },
       "JiraTicketRequest": {
+        "additionalProperties": false,
         "description": "Request body for POST /v1/findings/jira.",
         "properties": {
           "email": {
@@ -1949,6 +1961,7 @@
         "type": "string"
       },
       "ModelFilesRequest": {
+        "additionalProperties": false,
         "description": "Request body for POST /v1/scan/model-files.",
         "properties": {
           "directories": {
@@ -1971,6 +1984,7 @@
         "type": "object"
       },
       "ModelProvenanceRequest": {
+        "additionalProperties": false,
         "description": "Request body for POST /v1/scan/model-provenance.",
         "properties": {
           "hf_models": {
@@ -1992,6 +2006,7 @@
         "type": "object"
       },
       "PolicyCreate": {
+        "additionalProperties": false,
         "properties": {
           "bound_agent_types": {
             "items": {
@@ -2049,6 +2064,7 @@
         "type": "object"
       },
       "PolicyUpdate": {
+        "additionalProperties": false,
         "properties": {
           "bound_agent_types": {
             "anyOf": [
@@ -2180,6 +2196,7 @@
         "type": "object"
       },
       "PromptScanRequest": {
+        "additionalProperties": false,
         "description": "Request body for POST /v1/scan/prompt-scan.",
         "properties": {
           "directories": {
@@ -2201,6 +2218,7 @@
         "type": "object"
       },
       "ProxyAuditIngestRequest": {
+        "additionalProperties": false,
         "properties": {
           "alerts": {
             "items": {
@@ -2290,6 +2308,7 @@
         "type": "object"
       },
       "RotateKeyRequest": {
+        "additionalProperties": false,
         "properties": {
           "expires_at": {
             "anyOf": [
@@ -2329,6 +2348,7 @@
         "type": "object"
       },
       "SAMLLoginRequest": {
+        "additionalProperties": false,
         "properties": {
           "relay_state": {
             "anyOf": [
@@ -2659,6 +2679,7 @@
         "type": "object"
       },
       "ScheduleCreate": {
+        "additionalProperties": false,
         "properties": {
           "cron_expression": {
             "title": "Cron Expression",
@@ -2692,6 +2713,7 @@
         "type": "object"
       },
       "SourceCreate": {
+        "additionalProperties": false,
         "properties": {
           "config": {
             "additionalProperties": true,
@@ -2791,6 +2813,7 @@
         "type": "string"
       },
       "SourceUpdate": {
+        "additionalProperties": false,
         "properties": {
           "config": {
             "anyOf": [
@@ -2896,6 +2919,7 @@
         "type": "object"
       },
       "StateUpdate": {
+        "additionalProperties": false,
         "properties": {
           "reason": {
             "default": "",
@@ -2980,6 +3004,7 @@
         "type": "object"
       },
       "TenantQuotaUpdateRequest": {
+        "additionalProperties": false,
         "properties": {
           "active_scan_jobs": {
             "anyOf": [
@@ -3070,6 +3095,7 @@
         "type": "object"
       },
       "TrainingPipelinesRequest": {
+        "additionalProperties": false,
         "description": "Request body for POST /v1/scan/training-pipelines.",
         "properties": {
           "directories": {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -47,6 +47,7 @@ components:
       title: AuditExportVerifyRequest
       type: object
     BrowserExtensionsRequest:
+      additionalProperties: false
       description: Request body for POST /v1/scan/browser-extensions.
       properties:
         include_low_risk:
@@ -323,6 +324,7 @@ components:
       title: ComplianceThreatModel
       type: object
     CreateKeyRequest:
+      additionalProperties: false
       properties:
         expires_at:
           anyOf:
@@ -514,6 +516,7 @@ components:
       title: CredentialRefUpdate
       type: object
     DatasetCardsRequest:
+      additionalProperties: false
       description: Request body for POST /v1/scan/dataset-cards.
       properties:
         directories:
@@ -600,6 +603,7 @@ components:
       title: EntitlementHealth
       type: object
     EvaluateRequest:
+      additionalProperties: false
       properties:
         agent_name:
           default: ''
@@ -752,6 +756,7 @@ components:
       title: EvaluationRunCreate
       type: object
     ExceptionRequest:
+      additionalProperties: false
       properties:
         expires_at:
           default: ''
@@ -785,6 +790,7 @@ components:
       title: ExceptionRequest
       type: object
     FalsePositiveRequest:
+      additionalProperties: false
       description: Request body for POST /v1/findings/false-positive.
       properties:
         marked_by:
@@ -807,6 +813,7 @@ components:
       title: FalsePositiveRequest
       type: object
     FindingFeedbackRequest:
+      additionalProperties: false
       description: Request body for POST /v1/findings/feedback.
       properties:
         expires_at:
@@ -851,6 +858,7 @@ components:
       title: FindingFeedbackRequest
       type: object
     FindingTriageDecisionRequest:
+      additionalProperties: false
       description: Request body for PUT /v1/findings/triage/{triage_id}/decision.
       properties:
         assignee:
@@ -893,6 +901,7 @@ components:
       title: FindingTriageDecisionRequest
       type: object
     FindingTriageRequest:
+      additionalProperties: false
       description: Request body for POST /v1/findings/triage.
       properties:
         assignee:
@@ -959,6 +968,7 @@ components:
       title: FindingTriageRequest
       type: object
     FleetAgentUpdate:
+      additionalProperties: false
       properties:
         environment:
           anyOf:
@@ -1256,6 +1266,7 @@ components:
       title: IntelPackageMatchRequest
       type: object
     IssueStatusUpdateRequest:
+      additionalProperties: false
       properties:
         status:
           maxLength: 64
@@ -1267,6 +1278,7 @@ components:
       title: IssueStatusUpdateRequest
       type: object
     JiraTicketRequest:
+      additionalProperties: false
       description: Request body for POST /v1/findings/jira.
       properties:
         email:
@@ -1309,6 +1321,7 @@ components:
       title: JobStatus
       type: string
     ModelFilesRequest:
+      additionalProperties: false
       description: Request body for POST /v1/scan/model-files.
       properties:
         directories:
@@ -1325,6 +1338,7 @@ components:
       title: ModelFilesRequest
       type: object
     ModelProvenanceRequest:
+      additionalProperties: false
       description: Request body for POST /v1/scan/model-provenance.
       properties:
         hf_models:
@@ -1340,6 +1354,7 @@ components:
       title: ModelProvenanceRequest
       type: object
     PolicyCreate:
+      additionalProperties: false
       properties:
         bound_agent_types:
           items:
@@ -1382,6 +1397,7 @@ components:
       title: PolicyCreate
       type: object
     PolicyUpdate:
+      additionalProperties: false
       properties:
         bound_agent_types:
           anyOf:
@@ -1453,6 +1469,7 @@ components:
       title: PresetCreate
       type: object
     PromptScanRequest:
+      additionalProperties: false
       description: Request body for POST /v1/scan/prompt-scan.
       properties:
         directories:
@@ -1468,6 +1485,7 @@ components:
       title: PromptScanRequest
       type: object
     ProxyAuditIngestRequest:
+      additionalProperties: false
       properties:
         alerts:
           items:
@@ -1529,6 +1547,7 @@ components:
       title: PushPayload
       type: object
     RotateKeyRequest:
+      additionalProperties: false
       properties:
         expires_at:
           anyOf:
@@ -1548,6 +1567,7 @@ components:
       title: RotateKeyRequest
       type: object
     SAMLLoginRequest:
+      additionalProperties: false
       properties:
         relay_state:
           anyOf:
@@ -1750,6 +1770,7 @@ components:
       title: ScanRequest
       type: object
     ScheduleCreate:
+      additionalProperties: false
       properties:
         cron_expression:
           title: Cron Expression
@@ -1775,6 +1796,7 @@ components:
       title: ScheduleCreate
       type: object
     SourceCreate:
+      additionalProperties: false
       properties:
         config:
           additionalProperties: true
@@ -1847,6 +1869,7 @@ components:
       title: SourceStatus
       type: string
     SourceUpdate:
+      additionalProperties: false
       properties:
         config:
           anyOf:
@@ -1896,6 +1919,7 @@ components:
       title: SourceUpdate
       type: object
     StateUpdate:
+      additionalProperties: false
       properties:
         reason:
           default: ''
@@ -1961,6 +1985,7 @@ components:
       title: StorageHealth
       type: object
     TenantQuotaUpdateRequest:
+      additionalProperties: false
       properties:
         active_scan_jobs:
           anyOf:
@@ -2017,6 +2042,7 @@ components:
       title: TracingHealth
       type: object
     TrainingPipelinesRequest:
+      additionalProperties: false
       description: Request body for POST /v1/scan/training-pipelines.
       properties:
         directories:

--- a/docs/schemas/v1/BrowserExtensionsRequest.json
+++ b/docs/schemas/v1/BrowserExtensionsRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "description": "Request body for POST /v1/scan/browser-extensions.",
   "properties": {
     "include_low_risk": {

--- a/docs/schemas/v1/CreateKeyRequest.json
+++ b/docs/schemas/v1/CreateKeyRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "properties": {
     "expires_at": {
       "anyOf": [

--- a/docs/schemas/v1/DatasetCardsRequest.json
+++ b/docs/schemas/v1/DatasetCardsRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "description": "Request body for POST /v1/scan/dataset-cards.",
   "properties": {
     "directories": {

--- a/docs/schemas/v1/EvaluateRequest.json
+++ b/docs/schemas/v1/EvaluateRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "properties": {
     "agent_name": {
       "default": "",

--- a/docs/schemas/v1/ExceptionRequest.json
+++ b/docs/schemas/v1/ExceptionRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "properties": {
     "expires_at": {
       "default": "",

--- a/docs/schemas/v1/FalsePositiveRequest.json
+++ b/docs/schemas/v1/FalsePositiveRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "description": "Request body for POST /v1/findings/false-positive.",
   "properties": {
     "marked_by": {

--- a/docs/schemas/v1/FindingFeedbackRequest.json
+++ b/docs/schemas/v1/FindingFeedbackRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "description": "Request body for POST /v1/findings/feedback.",
   "properties": {
     "expires_at": {

--- a/docs/schemas/v1/FindingTriageDecisionRequest.json
+++ b/docs/schemas/v1/FindingTriageDecisionRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "description": "Request body for PUT /v1/findings/triage/{triage_id}/decision.",
   "properties": {
     "assignee": {

--- a/docs/schemas/v1/FindingTriageRequest.json
+++ b/docs/schemas/v1/FindingTriageRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "description": "Request body for POST /v1/findings/triage.",
   "properties": {
     "assignee": {

--- a/docs/schemas/v1/FleetAgentUpdate.json
+++ b/docs/schemas/v1/FleetAgentUpdate.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "properties": {
     "environment": {
       "anyOf": [

--- a/docs/schemas/v1/IssueStatusUpdateRequest.json
+++ b/docs/schemas/v1/IssueStatusUpdateRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "properties": {
     "status": {
       "maxLength": 64,

--- a/docs/schemas/v1/JiraTicketRequest.json
+++ b/docs/schemas/v1/JiraTicketRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "description": "Request body for POST /v1/findings/jira.",
   "properties": {
     "email": {

--- a/docs/schemas/v1/ModelFilesRequest.json
+++ b/docs/schemas/v1/ModelFilesRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "description": "Request body for POST /v1/scan/model-files.",
   "properties": {
     "directories": {

--- a/docs/schemas/v1/ModelProvenanceRequest.json
+++ b/docs/schemas/v1/ModelProvenanceRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "description": "Request body for POST /v1/scan/model-provenance.",
   "properties": {
     "hf_models": {

--- a/docs/schemas/v1/PolicyCreate.json
+++ b/docs/schemas/v1/PolicyCreate.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "properties": {
     "bound_agent_types": {
       "items": {

--- a/docs/schemas/v1/PolicyUpdate.json
+++ b/docs/schemas/v1/PolicyUpdate.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "properties": {
     "bound_agent_types": {
       "anyOf": [

--- a/docs/schemas/v1/PromptScanRequest.json
+++ b/docs/schemas/v1/PromptScanRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "description": "Request body for POST /v1/scan/prompt-scan.",
   "properties": {
     "directories": {

--- a/docs/schemas/v1/ProxyAuditIngestRequest.json
+++ b/docs/schemas/v1/ProxyAuditIngestRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "properties": {
     "alerts": {
       "items": {

--- a/docs/schemas/v1/RotateKeyRequest.json
+++ b/docs/schemas/v1/RotateKeyRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "properties": {
     "expires_at": {
       "anyOf": [

--- a/docs/schemas/v1/SAMLLoginRequest.json
+++ b/docs/schemas/v1/SAMLLoginRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "properties": {
     "relay_state": {
       "anyOf": [

--- a/docs/schemas/v1/ScheduleCreate.json
+++ b/docs/schemas/v1/ScheduleCreate.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "properties": {
     "cron_expression": {
       "title": "Cron Expression",

--- a/docs/schemas/v1/SourceCreate.json
+++ b/docs/schemas/v1/SourceCreate.json
@@ -21,6 +21,7 @@
       "type": "string"
     }
   },
+  "additionalProperties": false,
   "properties": {
     "config": {
       "additionalProperties": true,

--- a/docs/schemas/v1/SourceUpdate.json
+++ b/docs/schemas/v1/SourceUpdate.json
@@ -11,6 +11,7 @@
       "type": "string"
     }
   },
+  "additionalProperties": false,
   "properties": {
     "config": {
       "anyOf": [

--- a/docs/schemas/v1/StateUpdate.json
+++ b/docs/schemas/v1/StateUpdate.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "properties": {
     "reason": {
       "default": "",

--- a/docs/schemas/v1/TenantQuotaUpdateRequest.json
+++ b/docs/schemas/v1/TenantQuotaUpdateRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "properties": {
     "active_scan_jobs": {
       "anyOf": [

--- a/docs/schemas/v1/TrainingPipelinesRequest.json
+++ b/docs/schemas/v1/TrainingPipelinesRequest.json
@@ -1,4 +1,5 @@
 {
+  "additionalProperties": false,
   "description": "Request body for POST /v1/scan/training-pipelines.",
   "properties": {
     "directories": {

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -304,11 +304,13 @@ class ComplianceReportBundle(BaseModel):
 
 
 class StateUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     state: str
     reason: str = ""
 
 
 class FleetAgentUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     owner: str | None = None
     environment: str | None = None
     tags: list[str] | None = None
@@ -319,6 +321,7 @@ class FleetAgentUpdate(BaseModel):
 
 
 class PolicyCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     name: str
     description: str = ""
     mode: str = "audit"
@@ -330,6 +333,7 @@ class PolicyCreate(BaseModel):
 
 
 class PolicyUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     name: str | None = None
     description: str | None = None
     mode: str | None = None
@@ -341,12 +345,14 @@ class PolicyUpdate(BaseModel):
 
 
 class EvaluateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     agent_name: str = ""
     tool_name: str
     arguments: dict[str, Any] = Field(default_factory=dict)
 
 
 class ProxyAuditIngestRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     source_id: str = ""
     session_id: str = ""
     idempotency_key: str = ""
@@ -355,6 +361,7 @@ class ProxyAuditIngestRequest(BaseModel):
 
 
 class SAMLLoginRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     saml_response: str
     relay_state: str | None = None
 
@@ -365,12 +372,16 @@ class SAMLLoginRequest(BaseModel):
 class DatasetCardsRequest(BaseModel):
     """Request body for POST /v1/scan/dataset-cards."""
 
+    model_config = ConfigDict(extra="forbid")
+
     directories: list[str]
     """Directories to scan for dataset cards (dataset_info.json, README.md, .dvc)."""
 
 
 class TrainingPipelinesRequest(BaseModel):
     """Request body for POST /v1/scan/training-pipelines."""
+
+    model_config = ConfigDict(extra="forbid")
 
     directories: list[str]
     """Directories to scan for ML training artifacts (MLflow, W&B, Kubeflow)."""
@@ -379,12 +390,16 @@ class TrainingPipelinesRequest(BaseModel):
 class BrowserExtensionsRequest(BaseModel):
     """Request body for POST /v1/scan/browser-extensions."""
 
+    model_config = ConfigDict(extra="forbid")
+
     include_low_risk: bool = False
     """Include low-risk extensions (default: only medium+ risk)."""
 
 
 class ModelProvenanceRequest(BaseModel):
     """Request body for POST /v1/scan/model-provenance."""
+
+    model_config = ConfigDict(extra="forbid")
 
     hf_models: list[str] = Field(default_factory=list)
     """HuggingFace model IDs to check (e.g. ['meta-llama/Llama-2-7b-hf'])."""
@@ -396,6 +411,8 @@ class ModelProvenanceRequest(BaseModel):
 class PromptScanRequest(BaseModel):
     """Request body for POST /v1/scan/prompt-scan."""
 
+    model_config = ConfigDict(extra="forbid")
+
     directories: list[str] = Field(default_factory=list)
     """Directories to scan for prompt files (.prompt, prompt.yaml, etc.)."""
 
@@ -405,6 +422,8 @@ class PromptScanRequest(BaseModel):
 
 class ModelFilesRequest(BaseModel):
     """Request body for POST /v1/scan/model-files."""
+
+    model_config = ConfigDict(extra="forbid")
 
     directories: list[str]
     """Directories to scan for ML model files (.pt, .pkl, .safetensors, .gguf, etc.)."""
@@ -427,6 +446,7 @@ class PushPayload(BaseModel):
 
 
 class ScheduleCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     name: str
     cron_expression: str
     scan_config: dict[str, Any] = Field(default_factory=dict)
@@ -555,6 +575,7 @@ class SourceRecord(BaseModel):
 
 
 class SourceCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     display_name: str
     kind: SourceKind
     description: str = ""
@@ -568,6 +589,7 @@ class SourceCreate(BaseModel):
 
 
 class SourceUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     display_name: str | None = None
     description: str | None = None
     owner: str | None = None
@@ -580,6 +602,7 @@ class SourceUpdate(BaseModel):
 
 
 class CreateKeyRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     name: str
     role: str = "viewer"
     expires_at: str | None = None
@@ -587,12 +610,14 @@ class CreateKeyRequest(BaseModel):
 
 
 class RotateKeyRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     name: str | None = None
     expires_at: str | None = None
     overlap_seconds: int | None = None
 
 
 class TenantQuotaUpdateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     active_scan_jobs: int | None = Field(default=None, ge=0)
     retained_scan_jobs: int | None = Field(default=None, ge=0)
     fleet_agents: int | None = Field(default=None, ge=0)
@@ -600,6 +625,7 @@ class TenantQuotaUpdateRequest(BaseModel):
 
 
 class ExceptionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     vuln_id: str
     package_name: str
     server_name: str = ""
@@ -612,6 +638,8 @@ class ExceptionRequest(BaseModel):
 class JiraTicketRequest(BaseModel):
     """Request body for POST /v1/findings/jira."""
 
+    model_config = ConfigDict(extra="forbid")
+
     jira_url: str
     email: str
     project_key: str
@@ -621,11 +649,14 @@ class JiraTicketRequest(BaseModel):
 
 
 class IssueStatusUpdateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     status: str = Field(..., min_length=1, max_length=64)
 
 
 class FalsePositiveRequest(BaseModel):
     """Request body for POST /v1/findings/false-positive."""
+
+    model_config = ConfigDict(extra="forbid")
 
     vulnerability_id: str
     package: str
@@ -648,6 +679,8 @@ FindingTriageJustification = Literal[
 class FindingFeedbackRequest(BaseModel):
     """Request body for POST /v1/findings/feedback."""
 
+    model_config = ConfigDict(extra="forbid")
+
     vulnerability_id: str = Field(..., min_length=1, max_length=128)
     package: str = Field("*", min_length=1, max_length=256)
     state: FindingFeedbackState = "false_positive"
@@ -658,6 +691,8 @@ class FindingFeedbackRequest(BaseModel):
 
 class FindingTriageRequest(BaseModel):
     """Request body for POST /v1/findings/triage."""
+
+    model_config = ConfigDict(extra="forbid")
 
     vulnerability_id: str = Field(..., min_length=1, max_length=128)
     package: str = Field("*", min_length=1, max_length=256)
@@ -672,6 +707,8 @@ class FindingTriageRequest(BaseModel):
 
 class FindingTriageDecisionRequest(BaseModel):
     """Request body for PUT /v1/findings/triage/{triage_id}/decision."""
+
+    model_config = ConfigDict(extra="forbid")
 
     decision: FindingTriageDecision
     justification: FindingTriageJustification | None = None

--- a/tests/test_api_models_extra_forbid.py
+++ b/tests/test_api_models_extra_forbid.py
@@ -1,0 +1,40 @@
+"""Request models must reject unknown fields (extra=forbid), not silently drop them.
+
+A fat-fingered or stale field on a security-relevant body (a policy's action, a
+key's role, a triage decision's justification) must 422, not be dropped — which
+would silently apply the wrong, more-permissive default.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from agent_bom.api import models
+
+
+@pytest.mark.parametrize(
+    "model_name, valid_kwargs",
+    [
+        ("PolicyCreate", {"name": "p", "rules": []}),
+        ("CreateKeyRequest", {}),
+        ("FindingTriageDecisionRequest", {"decision": "accept"}),
+        ("SourceCreate", {"name": "s", "type": "github"}),
+        ("ScheduleCreate", {"name": "sch", "cron": "0 0 * * *"}),
+    ],
+)
+def test_request_model_rejects_unknown_field(model_name, valid_kwargs):
+    model = getattr(models, model_name)
+    # Tolerate required-field differences across versions: only assert that an
+    # unknown field is rejected, regardless of whether valid_kwargs is complete.
+    with pytest.raises(ValidationError) as exc:
+        model(**{**valid_kwargs, "definitely_not_a_real_field": "x"})
+    assert "definitely_not_a_real_field" in str(exc.value)
+
+
+def test_extra_forbid_is_widespread():
+    # Guard against regressions: the sweep covered the request-model surface.
+    forbid = [
+        n
+        for n in dir(models)
+        if isinstance(getattr(models, n), type) and getattr(getattr(models, n), "model_config", {}).get("extra") == "forbid"
+    ]
+    assert len(forbid) >= 25, forbid


### PR DESCRIPTION
## Why (security)
26 client-input request models in `api/models.py` defaulted to Pydantic `extra="ignore"`, **silently dropping unknown fields**. On security-relevant bodies that's a hazard — a fat-fingered/stale field on `PolicyCreate`, `CreateKeyRequest`, `FindingTriageDecisionRequest`, `SourceCreate`, `TenantQuotaUpdateRequest`, etc. was dropped, applying the wrong (often more-permissive) default instead of 422. Only `ScanRequest` had been hardened.

## What
- `model_config = ConfigDict(extra="forbid")` on the 26-model request surface (response/internal models + `PushPayload` passthrough excluded).
- Regenerated `docs/openapi/v1.{yaml,json}` (request schemas now `additionalProperties: false`).
- Regression test: request models reject unknown fields + a guard the sweep stays wide.

## Verification
2159 API tests pass; OpenAPI artifact test green; 6 new tests pass; ruff + mypy clean.