### PR TITLE
fix(deploy): report invalid Smithery freshness config

### DIFF
--- a/.github/workflows/deployment-freshness.yml
+++ b/.github/workflows/deployment-freshness.yml
@@ -80,6 +80,17 @@ jobs:
           fi
 
           DEPLOY_URL="${SMITHERY_MCP_URL}"
+          case "$DEPLOY_URL" in
+            https://server.smithery.ai/*|http://server.smithery.ai/*)
+              echo "public_version=invalid_smithery_proxy" >> "$GITHUB_OUTPUT"
+              echo "tool_count=unknown" >> "$GITHUB_OUTPUT"
+              echo "auth_required=unknown" >> "$GITHUB_OUTPUT"
+              echo "probe_failed=true" >> "$GITHUB_OUTPUT"
+              echo "::warning::SMITHERY_MCP_URL points at Smithery's hosted MCP proxy (${DEPLOY_URL}), which is OAuth-gated and does not expose agent-bom /health. Set SMITHERY_MCP_URL to the upstream public unauthenticated endpoint that serves /health."
+              exit 0
+              ;;
+          esac
+
           RESPONSE=$(PYTHONPATH=src python3 -m agent_bom.deployment_probe \
             --base-url "$DEPLOY_URL" \
             --attempts 3 \

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -24,7 +24,10 @@ ingress or platform edge.
 If you need a public unauthenticated registry/demo endpoint, treat that as a separate,
 explicitly less-trusted deployment surface rather than weakening the primary service.
 Release automation now requires that public endpoint to be set explicitly via
-`SMITHERY_MCP_URL`. It does not fall back to the protected Railway URL.
+`SMITHERY_MCP_URL`. It does not fall back to the protected Railway URL, and it
+must not be the Smithery hosted proxy URL (`https://server.smithery.ai/.../mcp`).
+The variable should be the upstream public origin whose `/health` response is
+agent-bom JSON with `version`, `auth_required=false`, and `tool_count`.
 
 ### Step 2: Publish to Smithery
 
@@ -40,7 +43,9 @@ The `publish-registries.yml` workflow auto-publishes to Smithery on each release
 - `SMITHERY_API_TOKEN`
 - `SMITHERY_MCP_URL`
 
-Before publish, CI probes the public endpoint and fails if:
+The release publish workflow probes the public endpoint as best-effort context
+because Smithery rebuilds asynchronously. The daily deployment and surface
+freshness workflows own drift detection and open issues when:
 - the endpoint is unreachable
 - the endpoint reports `auth_required=true`
 - the endpoint is otherwise unsuitable for public registry publishing

--- a/scripts/check_glama_listing.py
+++ b/scripts/check_glama_listing.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import argparse
+import json
+import os
 import re
 import sys
 import time
@@ -40,45 +42,72 @@ def _fetch(url: str, timeout: int) -> str:
 
 
 def _check(page: str, version: str, tool_count: str) -> list[str]:
-    failures: list[str] = []
     expected_tokens = [
         f"v{version}",
         f"MCP server mode advertises {tool_count} MCP tools",
     ]
-    for token in expected_tokens:
-        if token not in page:
-            failures.append(f"missing current Glama listing token: {token!r}")
+    failures = [f"missing current Glama listing token: {token!r}" for token in expected_tokens if token not in page]
 
     stale_patterns = [
         r"uses:\s*msaad00/agent-bom@v0\.88\.4",
         r"MCP server mode advertises\s+55\s+MCP tools",
         r"18 tools for CVE scanning",
     ]
-    for pattern in stale_patterns:
-        if re.search(pattern, page):
-            failures.append(f"stale Glama listing pattern still present: {pattern}")
+    failures.extend(f"stale Glama listing pattern still present: {pattern}" for pattern in stale_patterns if re.search(pattern, page))
     return failures
 
 
-def main() -> int:
+def _extract_listing_version(page: str) -> str:
+    """Best-effort version extraction from Glama's rendered listing."""
+
+    patterns = [
+        r"uses:\s*msaad00/agent-bom@v([0-9]+\.[0-9]+\.[0-9]+)",
+        r"\bv([0-9]+\.[0-9]+\.[0-9]+)\b",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, page)
+        if match:
+            return match.group(1)
+    return "unknown"
+
+
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--url", default=DEFAULT_URL)
+    parser.add_argument("--url", default=os.environ.get("GLAMA_LISTING_URL", DEFAULT_URL))
+    parser.add_argument("--expected", default=None, help="Expected version; defaults to pyproject.toml.")
+    parser.add_argument("--json", action="store_true", help="Emit a machine-readable freshness result.")
     parser.add_argument("--timeout", type=int, default=20)
     parser.add_argument("--retries", type=int, default=1)
     parser.add_argument("--delay-seconds", type=int, default=30)
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
-    version = _load_version()
+    version = (args.expected or _load_version()).lstrip("v").strip()
     tool_count = _load_readme_tool_count()
     last_error = ""
+    listing_version = "unknown"
     for attempt in range(1, max(1, args.retries) + 1):
         try:
             page = _fetch(args.url, args.timeout)
         except (urllib.error.URLError, TimeoutError) as exc:
             last_error = f"failed to fetch Glama listing: {exc}"
         else:
+            listing_version = _extract_listing_version(page)
             failures = _check(page, version, tool_count)
             if not failures:
+                if args.json:
+                    print(
+                        json.dumps(
+                            {
+                                "surface": "Glama",
+                                "status": "fresh",
+                                "expected": version,
+                                "listing_version": listing_version,
+                                "tool_count": tool_count,
+                            },
+                            separators=(",", ":"),
+                        )
+                    )
+                    return 0
                 print(f"Glama listing is fresh for agent-bom v{version} with {tool_count} MCP tools")
                 return 0
             last_error = "\n".join(failures)
@@ -87,6 +116,20 @@ def main() -> int:
             print(f"Glama listing freshness check failed on attempt {attempt}/{args.retries}: {last_error}")
             time.sleep(args.delay_seconds)
 
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "surface": "Glama",
+                    "status": "stale" if listing_version != "unknown" else "unreachable",
+                    "expected": version,
+                    "listing_version": listing_version,
+                    "tool_count": tool_count,
+                    "error": last_error,
+                },
+                separators=(",", ":"),
+            )
+        )
     print(f"ERROR: Glama listing is stale or unreachable:\n{last_error}", file=sys.stderr)
     return 1
 

--- a/scripts/check_surface_freshness.py
+++ b/scripts/check_surface_freshness.py
@@ -60,7 +60,14 @@ def _expected_version() -> str:
     return m.group(1)
 
 
-def _http_json(url: str, *, timeout: float, attempts: int, backoff: float, headers: dict[str, str] | None = None) -> Any:
+def _http_json_response(
+    url: str,
+    *,
+    timeout: float,
+    attempts: int,
+    backoff: float,
+    headers: dict[str, str] | None = None,
+) -> tuple[Any, Any]:
     last = "unknown error"
     hdrs = {"Accept": "application/json", "User-Agent": "agent-bom-freshness-probe"}
     if headers:
@@ -68,9 +75,9 @@ def _http_json(url: str, *, timeout: float, attempts: int, backoff: float, heade
     for attempt in range(1, attempts + 1):
         try:
             req = urllib.request.Request(url, headers=hdrs)
-            with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
-                return json.loads(resp.read().decode("utf-8", errors="replace"))
-        except urllib.error.HTTPError as exc:  # noqa: PERF203
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.loads(resp.read().decode("utf-8", errors="replace")), resp.headers
+        except urllib.error.HTTPError as exc:
             last = f"HTTP {exc.code}"
         except (urllib.error.URLError, TimeoutError) as exc:
             last = f"network error: {exc}"
@@ -81,6 +88,11 @@ def _http_json(url: str, *, timeout: float, attempts: int, backoff: float, heade
     raise RuntimeError(last)
 
 
+def _http_json(url: str, *, timeout: float, attempts: int, backoff: float, headers: dict[str, str] | None = None) -> Any:
+    data, _headers = _http_json_response(url, timeout=timeout, attempts=attempts, backoff=backoff, headers=headers)
+    return data
+
+
 def _classify(name: str, published: str | None, expected: str, *, error: str | None = None) -> dict[str, Any]:
     if error:
         return {"surface": name, "status": "unreachable", "version": published or "—", "expected": expected, "error": error}
@@ -88,6 +100,19 @@ def _classify(name: str, published: str | None, expected: str, *, error: str | N
         return {"surface": name, "status": "unreachable", "version": "—", "expected": expected, "error": "no version found"}
     status = "fresh" if published == expected else "stale"
     return {"surface": name, "status": status, "version": published, "expected": expected}
+
+
+def _smithery_proxy_error(url: str) -> str | None:
+    """Return an actionable error when the configured URL is Smithery's proxy."""
+
+    parsed = urllib.parse.urlsplit(url.strip())
+    if parsed.netloc.lower() == "server.smithery.ai":
+        return (
+            "SMITHERY_MCP_URL points at Smithery's hosted MCP proxy. Set it to "
+            "the upstream public unauthenticated endpoint that exposes /health, "
+            "not https://server.smithery.ai/.../mcp."
+        )
+    return None
 
 
 def _parse_image_reference(image: str) -> tuple[str, str]:
@@ -143,12 +168,17 @@ def probe_docker(expected: str, image: str, **kw: Any) -> dict[str, Any]:
                 **kw,
             )
             token = token_data.get("token", "")
-            tags_data = _http_json(
-                f"https://ghcr.io/v2/{path_repo}/tags/list",
-                headers={"Authorization": f"Bearer {token}"} if token else None,
-                **kw,
-            )
-            tags = set(tags_data.get("tags") or [])
+            tags = set()
+            next_url = f"https://ghcr.io/v2/{path_repo}/tags/list?n=100"
+            auth_headers = {"Authorization": f"Bearer {token}"} if token else None
+            for _page in range(20):
+                tags_data, response_headers = _http_json_response(next_url, headers=auth_headers, **kw)
+                tags.update(tags_data.get("tags") or [])
+                link = response_headers.get("Link", "")
+                match = re.search(r'<([^>]+)>;\s*rel="next"', link)
+                if not match:
+                    break
+                next_url = urllib.parse.urljoin("https://ghcr.io", match.group(1))
         else:
             tags: set[str] = set()
             url = f"https://hub.docker.com/v2/repositories/{repo}/tags?page_size=100"
@@ -176,7 +206,7 @@ def probe_docker(expected: str, image: str, **kw: Any) -> dict[str, Any]:
 
 def probe_glama(expected: str, **kw: Any) -> dict[str, Any]:
     """Delegate to check_glama_listing.py so the probe logic stays in one place."""
-    proc = subprocess.run(  # noqa: S603
+    proc = subprocess.run(
         [sys.executable, str(GLAMA_SCRIPT), "--expected", expected, "--json"],
         capture_output=True,
         text=True,
@@ -209,8 +239,17 @@ def probe_smithery(expected: str, url: str, **kw: Any) -> dict[str, Any]:
             "expected": expected,
             "error": "no SMITHERY_MCP_URL — set the repo variable to monitor this surface",
         }
+    proxy_error = _smithery_proxy_error(url)
+    if proxy_error:
+        return {
+            "surface": "Smithery",
+            "status": "not_configured",
+            "version": "—",
+            "expected": expected,
+            "error": proxy_error,
+        }
     try:
-        proc = subprocess.run(  # noqa: S603
+        proc = subprocess.run(
             [
                 sys.executable,
                 "-m",
@@ -228,6 +267,9 @@ def probe_smithery(expected: str, url: str, **kw: Any) -> dict[str, Any]:
             text=True,
             env={**os.environ, "PYTHONPATH": str(ROOT / "src")},
         )
+        if proc.returncode != 0:
+            error = (proc.stderr or proc.stdout or f"deployment_probe exited {proc.returncode}").strip()
+            return _classify("Smithery", None, expected, error=error)
         data = json.loads(proc.stdout or "{}")
         version = data.get("version")
         return _classify("Smithery", version, expected)

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -360,6 +360,8 @@ def test_deployment_freshness_workflow_uses_bearer_token_and_parses_tool_count()
     assert "tool_count" in workflow
     assert "auth_required" in workflow
     assert "probe_failed=true" in workflow
+    assert "server.smithery.ai" in workflow
+    assert "invalid_smithery_proxy" in workflow
     assert "steps.railway.outputs.probe_failed != 'true'" in workflow
     assert "--resolve-only" in workflow
 

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -1,0 +1,89 @@
+"""Regression tests for public marketplace freshness automation."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_script(name: str) -> ModuleType:
+    path = ROOT / "scripts" / name
+    spec = importlib.util.spec_from_file_location(name.removesuffix(".py"), path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_glama_listing_json_contract_reports_stale_listing(monkeypatch, capsys):
+    script = _load_script("check_glama_listing.py")
+    stale_page = """
+    uses: msaad00/agent-bom@v0.88.4
+    MCP server mode advertises 55 MCP tools
+    18 tools for CVE scanning
+    """
+
+    monkeypatch.setattr(script, "_load_readme_tool_count", lambda: "69")
+    monkeypatch.setattr(script, "_fetch", lambda _url, _timeout: stale_page)
+
+    assert script.main(["--expected", "0.89.2", "--json", "--retries", "1"]) == 1
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out.strip().splitlines()[-1])
+
+    assert payload["surface"] == "Glama"
+    assert payload["status"] == "stale"
+    assert payload["expected"] == "0.89.2"
+    assert payload["listing_version"] == "0.88.4"
+    assert "missing current Glama listing token" in payload["error"]
+
+
+def test_surface_freshness_classifies_smithery_proxy_url_as_misconfigured():
+    script = _load_script("check_surface_freshness.py")
+
+    result = script.probe_smithery("0.89.2", "https://server.smithery.ai/@agent-bom/agent-bom/mcp")
+
+    assert result["surface"] == "Smithery"
+    assert result["status"] == "not_configured"
+    assert result["version"] == "—"
+    assert "hosted MCP proxy" in result["error"]
+    assert "exposes /health" in result["error"]
+
+
+def test_surface_freshness_reads_paginated_ghcr_tags(monkeypatch):
+    script = _load_script("check_surface_freshness.py")
+
+    class Headers(dict):
+        def get(self, key, default=None):
+            return super().get(key, default)
+
+    def fake_http_json(url, **_kwargs):
+        assert url.startswith("https://ghcr.io/token?")
+        return {"token": "token"}
+
+    pages = iter(
+        [
+            (
+                {"tags": ["v0.81.1"]},
+                Headers({"Link": '</v2/msaad00/agent-bom/tags/list?last=v0.81.1&n=100>; rel="next"'}),
+            ),
+            ({"tags": ["v0.89.2"]}, Headers({})),
+        ]
+    )
+
+    def fake_http_json_response(url, **kwargs):
+        assert kwargs["headers"] == {"Authorization": "Bearer token"}
+        assert url.startswith("https://ghcr.io/v2/msaad00/agent-bom/tags/list")
+        return next(pages)
+
+    monkeypatch.setattr(script, "_http_json", fake_http_json)
+    monkeypatch.setattr(script, "_http_json_response", fake_http_json_response)
+
+    result = script.probe_docker("0.89.2", "ghcr.io/msaad00/agent-bom", timeout=1, attempts=1, backoff=0)
+
+    assert result["surface"] == "Docker"
+    assert result["status"] == "fresh"
+    assert result["version"] == "0.89.2"


### PR DESCRIPTION
Summary:
- detect Smithery hosted proxy URLs as invalid freshness configuration instead of generic unknown marketplace drift
- add machine-readable Glama freshness output and paginated GHCR tag probing for surface freshness
- document the required public upstream health endpoint for Smithery monitoring

Verification:
- uv run pytest -q tests/test_surface_freshness.py tests/test_deployment.py::test_deployment_freshness_workflow_uses_bearer_token_and_parses_tool_count tests/test_deployment_probe.py
- uv run ruff check scripts/check_glama_listing.py scripts/check_surface_freshness.py tests/test_surface_freshness.py tests/test_deployment.py --select E,F,B,SIM,UP,PERF,RUF
- python3 -m py_compile scripts/check_glama_listing.py scripts/check_surface_freshness.py
- git diff --check

Notes:
- Advances #3014. The issue should remain open until SMITHERY_MCP_URL points at a public upstream /health endpoint and Glama/marketplace freshness reruns cleanly.