### PR TITLE
feat(graph): expose retained evidence manifests

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 230 |
+| `docs/openapi/v1.json` | paths | 232 |
 | `docs/openapi/v1.json` | component schemas | 61 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -11638,6 +11638,78 @@
         ]
       }
     },
+    "/v1/graph/evidence-manifest": {
+      "get": {
+        "description": "Return a redaction-aware reviewer manifest for a retained graph snapshot.",
+        "operationId": "get_graph_evidence_manifest_v1_graph_evidence_manifest_get",
+        "parameters": [
+          {
+            "description": "Scan snapshot ID; latest if omitted",
+            "in": "query",
+            "name": "scan_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scan snapshot ID; latest if omitted",
+              "title": "Scan Id"
+            }
+          },
+          {
+            "description": "Optional diff baseline scan ID",
+            "in": "query",
+            "name": "baseline_scan_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional diff baseline scan ID",
+              "title": "Baseline Scan Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Graph Evidence Manifest V1 Graph Evidence Manifest Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Graph Evidence Manifest",
+        "tags": [
+          "graph"
+        ]
+      }
+    },
     "/v1/graph/exposure-paths": {
       "get": {
         "description": "Return the MCP-compatible ExposurePath queue over REST for SDK consumers.",
@@ -11783,6 +11855,56 @@
           }
         },
         "summary": "Get Graph Governance",
+        "tags": [
+          "graph"
+        ]
+      }
+    },
+    "/v1/graph/history": {
+      "get": {
+        "description": "Return retained graph history and adjacent diff summaries for the request tenant.",
+        "operationId": "get_graph_history_v1_graph_history_get",
+        "parameters": [
+          {
+            "description": "Max snapshots",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Max snapshots",
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Graph History V1 Graph History Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Graph History",
         "tags": [
           "graph"
         ]

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -7590,6 +7590,51 @@ paths:
       summary: Get Graph Edge Changes
       tags:
       - graph
+  /v1/graph/evidence-manifest:
+    get:
+      description: Return a redaction-aware reviewer manifest for a retained graph
+        snapshot.
+      operationId: get_graph_evidence_manifest_v1_graph_evidence_manifest_get
+      parameters:
+      - description: Scan snapshot ID; latest if omitted
+        in: query
+        name: scan_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Scan snapshot ID; latest if omitted
+          title: Scan Id
+      - description: Optional diff baseline scan ID
+        in: query
+        name: baseline_scan_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Optional diff baseline scan ID
+          title: Baseline Scan Id
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Graph Evidence Manifest V1 Graph Evidence Manifest
+                  Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Graph Evidence Manifest
+      tags:
+      - graph
   /v1/graph/exposure-paths:
     get:
       description: Return the MCP-compatible ExposurePath queue over REST for SDK
@@ -7694,6 +7739,41 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Get Graph Governance
+      tags:
+      - graph
+  /v1/graph/history:
+    get:
+      description: Return retained graph history and adjacent diff summaries for the
+        request tenant.
+      operationId: get_graph_history_v1_graph_history_get
+      parameters:
+      - description: Max snapshots
+        in: query
+        name: limit
+        required: false
+        schema:
+          default: 50
+          description: Max snapshots
+          maximum: 500
+          minimum: 1
+          title: Limit
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Graph History V1 Graph History Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Graph History
       tags:
       - graph
   /v1/graph/impact:

--- a/docs/perf/graph-api-postgres-benchmark.md
+++ b/docs/perf/graph-api-postgres-benchmark.md
@@ -2,6 +2,7 @@
 
 Evidence status: measured local API + Postgres EXPLAIN artifacts
 Owner issue: #2145
+Related evidence-lake issue: #2929
 Raw result artifacts:
 
 - `docs/perf/results/graph-benchmark-estate-sample.json`
@@ -47,6 +48,8 @@ Covered by the checked-in evidence:
   search, node detail, attack-path drilldown, graph diff, and bounded traversal
 - repeatable Postgres latency scaffold for the same query families, producing
   p50/p95/p99 client wall-clock summaries when run against a loaded database
+- retained graph history and redaction-aware evidence-manifest API/CLI surfaces
+  backed by the same tenant-scoped snapshot store
 
 Excluded from these local artifacts:
 
@@ -55,6 +58,8 @@ Excluded from these local artifacts:
 - Snowflake or managed-operator deployment timings
 - browser/UI interaction timing
 - 50k / 100k edge Postgres runs
+- six-month hosted lake retention jobs, audit-chain bundle persistence,
+  compliance bundle persistence, and legal-hold/deletion workflows
 
 ## Environment
 
@@ -130,6 +135,32 @@ uv run python scripts/run_graph_api_benchmark.py \
   --detail-node pkg:go:langchain@1.0.0 \
   --repeat 10 \
   --output docs/perf/results/graph-api-benchmark-live-2026-05-13.json
+```
+
+Export retained graph evidence from the local graph store without a running API:
+
+```bash
+agent-bom graph-evidence --mode history \
+  --graph-db /tmp/agent-bom-graph-benchmark.db \
+  --tenant default \
+  --limit 50
+
+agent-bom graph-evidence --mode manifest \
+  --graph-db /tmp/agent-bom-graph-benchmark.db \
+  --tenant default \
+  --scan-id graph-benchmark-estate-current \
+  --baseline-scan-id graph-benchmark-estate-old \
+  --output docs/perf/results/graph-evidence-manifest-local.json
+```
+
+Query the same evidence through the API:
+
+```bash
+curl -H 'X-Agent-Bom-Tenant-ID: default' \
+  'http://127.0.0.1:8429/v1/graph/history?limit=50'
+
+curl -H 'X-Agent-Bom-Tenant-ID: default' \
+  'http://127.0.0.1:8429/v1/graph/evidence-manifest?scan_id=graph-benchmark-estate-current&baseline_scan_id=graph-benchmark-estate-old'
 ```
 
 Generate Postgres EXPLAIN SQL artifacts without measuring:
@@ -218,9 +249,9 @@ uv run python scripts/run_graph_postgres_latency.py \
 | Artifact | Status | What it supports |
 |---|---|---|
 | `graph-benchmark-estate-sample.json` | scaffold | deterministic skewed estate shape and source mix |
-| `graph-api-benchmark-sample.json` | dry-run | API benchmark request coverage only |
+| `graph-api-benchmark-sample.json` | dry-run | API benchmark request coverage, including graph history and evidence manifest |
 | `postgres-graph-explain-sample.json` | dry-run | Postgres EXPLAIN artifact paths only |
-| `postgres-graph-latency-sample.json` | dry-run | Postgres repeated-latency SQL paths only |
+| `postgres-graph-latency-sample.json` | dry-run | Postgres repeated-latency SQL paths, including graph history and evidence-manifest digest queries |
 | `graph-benchmark-estate-live-2026-05-13.json` | generated | 250-agent estate with 604 servers, 3,475 tools, and 5,958 package instances |
 | `graph-benchmark-store-load-live-2026-05-13.json` | measured load | SQLite graph store loaded old/current snapshots; current has 10,479 nodes, 11,242 edges, 291 attack paths |
 | `graph-api-benchmark-live-2026-05-13.json` | measured API | loopback API p50/p95/p99 client timings across five graph hot paths |
@@ -247,6 +278,33 @@ Top-level Postgres plan times from
 | attack-path drilldown | 0.177 ms |
 | graph diff nodes | 38.421 ms |
 | bounded traversal edges | 8.903 ms |
+
+## Retained Graph Evidence Slice
+
+The retained-history slice for #2929 is limited to the graph snapshot store.
+Every response is scoped by the request tenant or the
+`agent-bom graph-evidence --tenant` value.
+
+Shipped in this slice:
+
+- `GET /v1/graph/history` lists retained snapshots and adjacent diff summaries
+  from `graph_snapshots`, `graph_nodes`, and `graph_edges`.
+- `GET /v1/graph/evidence-manifest` returns `tenant_id`, `scan_id`,
+  `scan_created_at`, `graph_digest`, `findings_digest`,
+  `diff_baseline_scan_id`, counts, included tables, excluded private fields,
+  and retention policy metadata.
+- `agent-bom graph-evidence` exports the same history or manifest JSON from the
+  local SQLite graph store for demos and CI evidence capture.
+- API and Postgres benchmark scaffolds include graph history and
+  evidence-manifest digest paths.
+
+Not shipped by this slice:
+
+- Hosted ClickHouse/Snowflake lake retention jobs.
+- Durable audit-chain and compliance bundle tables outside the graph store.
+- Legal-hold/deletion state transitions beyond the explicit manifest fields.
+- Six-month remote hosted evidence proving tenant history across operational
+  lake backends.
 
 ## Plan-Driven Hardening
 
@@ -278,3 +336,5 @@ resource sizing before making an operator or enterprise-pilot latency claim.
   p50/p95/p99 artifacts in addition to single `EXPLAIN ANALYZE` plans.
 - Add 50k / 100k edge Postgres artifacts.
 - Add browser interaction timing separately if UI scale claims are needed.
+- Add hosted evidence-lake retention jobs and measured six-month history
+  evidence before closing #2929.

--- a/docs/perf/results/graph-api-benchmark-sample.json
+++ b/docs/perf/results/graph-api-benchmark-sample.json
@@ -9,7 +9,7 @@
     "Dry-run does not start the API, authenticate, or measure network/server latency.",
     "Live results must record the API auth mode, tenant, graph backend, and scan IDs used."
   ],
-  "generated_at": "2026-05-13T05:57:22.330599+00:00",
+  "generated_at": "2026-06-22T20:27:27.707780+00:00",
   "owner_issue": 2145,
   "repeat": 20,
   "request_plan": [
@@ -50,6 +50,23 @@
       "query": {
         "new": "graph-benchmark-estate-current",
         "old": "graph-benchmark-estate-old"
+      }
+    },
+    {
+      "method": "GET",
+      "name": "graph_history",
+      "path": "/v1/graph/history",
+      "query": {
+        "limit": "50"
+      }
+    },
+    {
+      "method": "GET",
+      "name": "graph_evidence_manifest",
+      "path": "/v1/graph/evidence-manifest",
+      "query": {
+        "baseline_scan_id": "graph-benchmark-estate-old",
+        "scan_id": "graph-benchmark-estate-current"
       }
     },
     {

--- a/docs/perf/results/postgres-graph-explain-sample.json
+++ b/docs/perf/results/postgres-graph-explain-sample.json
@@ -9,13 +9,16 @@
     "Dry-run writes EXPLAIN SQL only; it does not seed Postgres or execute EXPLAIN ANALYZE.",
     "Measured artifacts must be captured from a database loaded with the matching synthetic estate snapshots."
   ],
-  "generated_at": "2026-05-13T05:59:51.330122+00:00",
+  "generated_at": "2026-06-22T20:27:27.771407+00:00",
   "old_scan_id": "graph-benchmark-estate-old",
   "owner_issue": 2145,
+  "psql_bin": "psql",
   "query_artifacts": {
     "attack_path_drilldown": "docs/perf/results/postgres-graph-explain-sample/attack_path_drilldown.sql",
     "bounded_traversal_edges": "docs/perf/results/postgres-graph-explain-sample/bounded_traversal_edges.sql",
     "graph_diff_nodes": "docs/perf/results/postgres-graph-explain-sample/graph_diff_nodes.sql",
+    "graph_evidence_manifest_digest": "docs/perf/results/postgres-graph-explain-sample/graph_evidence_manifest_digest.sql",
+    "graph_history": "docs/perf/results/postgres-graph-explain-sample/graph_history.sql",
     "node_detail": "docs/perf/results/postgres-graph-explain-sample/node_detail.sql",
     "node_search": "docs/perf/results/postgres-graph-explain-sample/node_search.sql"
   },

--- a/docs/perf/results/postgres-graph-explain-sample/graph_evidence_manifest_digest.sql
+++ b/docs/perf/results/postgres-graph-explain-sample/graph_evidence_manifest_digest.sql
@@ -1,0 +1,31 @@
+EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+WITH node_digest AS (
+  SELECT COUNT(*) AS node_count,
+         md5(COALESCE(string_agg(id || ':' || entity_type || ':' || label || ':' ||
+             COALESCE(severity, '') || ':' || COALESCE(risk_score::text, '0'), '|' ORDER BY id), '')) AS digest
+  FROM graph_nodes
+  WHERE tenant_id = 'default' AND scan_id = 'graph-benchmark-estate-current'
+),
+edge_digest AS (
+  SELECT COUNT(*) AS edge_count,
+         md5(COALESCE(string_agg(source_id || '>' || target_id || ':' || relationship || ':' ||
+             COALESCE(weight::text, '0') || ':' || COALESCE(confidence::text, '1'), '|'
+             ORDER BY source_id, target_id, relationship), '')) AS digest
+  FROM graph_edges
+  WHERE tenant_id = 'default' AND scan_id = 'graph-benchmark-estate-current'
+),
+finding_digest AS (
+  SELECT COUNT(*) AS finding_count,
+         md5(COALESCE(string_agg(id || ':' || entity_type || ':' || COALESCE(severity, ''), '|' ORDER BY id), '')) AS digest
+  FROM graph_nodes
+  WHERE tenant_id = 'default'
+    AND scan_id = 'graph-benchmark-estate-current'
+    AND entity_type IN ('vulnerability', 'misconfiguration', 'drift_incident')
+)
+SELECT 'graph-benchmark-estate-current' AS scan_id,
+       node_digest.node_count,
+       edge_digest.edge_count,
+       finding_digest.finding_count,
+       md5(node_digest.digest || ':' || edge_digest.digest) AS graph_digest,
+       finding_digest.digest AS findings_digest
+FROM node_digest, edge_digest, finding_digest;

--- a/docs/perf/results/postgres-graph-explain-sample/graph_history.sql
+++ b/docs/perf/results/postgres-graph-explain-sample/graph_history.sql
@@ -1,0 +1,7 @@
+EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+SELECT scan_id, created_at, node_count, edge_count,
+       LAG(scan_id) OVER (ORDER BY created_at ASC, scan_id ASC) AS diff_baseline_scan_id
+FROM graph_snapshots
+WHERE tenant_id = 'default'
+ORDER BY created_at DESC, scan_id DESC
+LIMIT 50;

--- a/docs/perf/results/postgres-graph-latency-sample.json
+++ b/docs/perf/results/postgres-graph-latency-sample.json
@@ -9,7 +9,7 @@
     "Dry-run writes non-EXPLAIN SQL only; it does not seed Postgres or measure latency.",
     "Measured artifacts must record database size, Postgres version, tenant, scan IDs, and repeat count."
   ],
-  "generated_at": "2026-06-01T04:46:41.937624+00:00",
+  "generated_at": "2026-06-22T20:27:27.829143+00:00",
   "old_scan_id": "graph-benchmark-estate-old",
   "owner_issue": 2145,
   "psql_bin": "psql",
@@ -17,6 +17,8 @@
     "attack_path_drilldown": "docs/perf/results/postgres-graph-latency-sample/attack_path_drilldown.sql",
     "bounded_traversal_edges": "docs/perf/results/postgres-graph-latency-sample/bounded_traversal_edges.sql",
     "graph_diff_nodes": "docs/perf/results/postgres-graph-latency-sample/graph_diff_nodes.sql",
+    "graph_evidence_manifest_digest": "docs/perf/results/postgres-graph-latency-sample/graph_evidence_manifest_digest.sql",
+    "graph_history": "docs/perf/results/postgres-graph-latency-sample/graph_history.sql",
     "node_detail": "docs/perf/results/postgres-graph-latency-sample/node_detail.sql",
     "node_search": "docs/perf/results/postgres-graph-latency-sample/node_search.sql"
   },

--- a/docs/perf/results/postgres-graph-latency-sample/graph_evidence_manifest_digest.sql
+++ b/docs/perf/results/postgres-graph-latency-sample/graph_evidence_manifest_digest.sql
@@ -1,0 +1,30 @@
+WITH node_digest AS (
+  SELECT COUNT(*) AS node_count,
+         md5(COALESCE(string_agg(id || ':' || entity_type || ':' || label || ':' ||
+             COALESCE(severity, '') || ':' || COALESCE(risk_score::text, '0'), '|' ORDER BY id), '')) AS digest
+  FROM graph_nodes
+  WHERE tenant_id = 'default' AND scan_id = 'graph-benchmark-estate-current'
+),
+edge_digest AS (
+  SELECT COUNT(*) AS edge_count,
+         md5(COALESCE(string_agg(source_id || '>' || target_id || ':' || relationship || ':' ||
+             COALESCE(weight::text, '0') || ':' || COALESCE(confidence::text, '1'), '|'
+             ORDER BY source_id, target_id, relationship), '')) AS digest
+  FROM graph_edges
+  WHERE tenant_id = 'default' AND scan_id = 'graph-benchmark-estate-current'
+),
+finding_digest AS (
+  SELECT COUNT(*) AS finding_count,
+         md5(COALESCE(string_agg(id || ':' || entity_type || ':' || COALESCE(severity, ''), '|' ORDER BY id), '')) AS digest
+  FROM graph_nodes
+  WHERE tenant_id = 'default'
+    AND scan_id = 'graph-benchmark-estate-current'
+    AND entity_type IN ('vulnerability', 'misconfiguration', 'drift_incident')
+)
+SELECT 'graph-benchmark-estate-current' AS scan_id,
+       node_digest.node_count,
+       edge_digest.edge_count,
+       finding_digest.finding_count,
+       md5(node_digest.digest || ':' || edge_digest.digest) AS graph_digest,
+       finding_digest.digest AS findings_digest
+FROM node_digest, edge_digest, finding_digest;

--- a/docs/perf/results/postgres-graph-latency-sample/graph_history.sql
+++ b/docs/perf/results/postgres-graph-latency-sample/graph_history.sql
@@ -1,0 +1,6 @@
+SELECT scan_id, created_at, node_count, edge_count,
+       LAG(scan_id) OVER (ORDER BY created_at ASC, scan_id ASC) AS diff_baseline_scan_id
+FROM graph_snapshots
+WHERE tenant_id = 'default'
+ORDER BY created_at DESC, scan_id DESC
+LIMIT 50;

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -131,6 +131,8 @@ AGENT_BOM_GRAPH_DELTA_WEBHOOK_DESTINATION_ID
 AGENT_BOM_GRAPH_DELTA_WEBHOOK_SIGNING_SECRET
 # Graph delta generic webhook private-network opt-in; deploy-time egress boundary.
 AGENT_BOM_GRAPH_DELTA_WEBHOOK_ALLOW_PRIVATE_NETWORKS
+# Graph evidence manifest retention horizon; read by graph_store.py for local/self-hosted history metadata.
+AGENT_BOM_GRAPH_RETENTION_DAYS
 AGENT_BOM_GRAPH_WRITE_BATCH_SIZE
 AGENT_BOM_HSTS_MAX_AGE_SECONDS
 AGENT_BOM_HSTS_PRELOAD

--- a/scripts/run_graph_api_benchmark.py
+++ b/scripts/run_graph_api_benchmark.py
@@ -71,6 +71,18 @@ def request_plan(*, scan_id: str, old_scan_id: str, new_scan_id: str, source_nod
             "query": {"old": old_scan_id, "new": new_scan_id},
         },
         {
+            "name": "graph_history",
+            "method": "GET",
+            "path": "/v1/graph/history",
+            "query": {"limit": "50"},
+        },
+        {
+            "name": "graph_evidence_manifest",
+            "method": "GET",
+            "path": "/v1/graph/evidence-manifest",
+            "query": {"scan_id": scan_id, "baseline_scan_id": old_scan_id},
+        },
+        {
             "name": "bounded_traversal",
             "method": "POST",
             "path": "/v1/graph/query",

--- a/scripts/run_graph_postgres_explain.py
+++ b/scripts/run_graph_postgres_explain.py
@@ -82,6 +82,48 @@ WHERE old_nodes.id IS NULL
    OR old_nodes.attributes <> new_nodes.attributes
 LIMIT 500;
 """.strip(),
+        "graph_history": f"""
+{prefix}
+SELECT scan_id, created_at, node_count, edge_count,
+       LAG(scan_id) OVER (ORDER BY created_at ASC, scan_id ASC) AS diff_baseline_scan_id
+FROM graph_snapshots
+WHERE tenant_id = {tenant}
+ORDER BY created_at DESC, scan_id DESC
+LIMIT 50;
+""".strip(),
+        "graph_evidence_manifest_digest": f"""
+{prefix}
+WITH node_digest AS (
+  SELECT COUNT(*) AS node_count,
+         md5(COALESCE(string_agg(id || ':' || entity_type || ':' || label || ':' ||
+             COALESCE(severity, '') || ':' || COALESCE(risk_score::text, '0'), '|' ORDER BY id), '')) AS digest
+  FROM graph_nodes
+  WHERE tenant_id = {tenant} AND scan_id = {scan}
+),
+edge_digest AS (
+  SELECT COUNT(*) AS edge_count,
+         md5(COALESCE(string_agg(source_id || '>' || target_id || ':' || relationship || ':' ||
+             COALESCE(weight::text, '0') || ':' || COALESCE(confidence::text, '1'), '|'
+             ORDER BY source_id, target_id, relationship), '')) AS digest
+  FROM graph_edges
+  WHERE tenant_id = {tenant} AND scan_id = {scan}
+),
+finding_digest AS (
+  SELECT COUNT(*) AS finding_count,
+         md5(COALESCE(string_agg(id || ':' || entity_type || ':' || COALESCE(severity, ''), '|' ORDER BY id), '')) AS digest
+  FROM graph_nodes
+  WHERE tenant_id = {tenant}
+    AND scan_id = {scan}
+    AND entity_type IN ('vulnerability', 'misconfiguration', 'drift_incident')
+)
+SELECT {scan} AS scan_id,
+       node_digest.node_count,
+       edge_digest.edge_count,
+       finding_digest.finding_count,
+       md5(node_digest.digest || ':' || edge_digest.digest) AS graph_digest,
+       finding_digest.digest AS findings_digest
+FROM node_digest, edge_digest, finding_digest;
+""".strip(),
         "bounded_traversal_edges": f"""
 {prefix}
 WITH RECURSIVE walk(node_id, depth) AS (

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -51,6 +51,7 @@
 | Command | Description |
 |---------|-------------|
 | `graph` | Export the transitive dependency graph from a scan report |
+| `graph-evidence` | Export retained graph snapshot history or a signed evidence manifest digest |
 | `mesh` | Show lightweight agent/MCP topology without CVE scanning |
 | `report` | History, diff, pipeline-event artifacts, local queries, analytics, dashboard, and compliance narrative workflows |
 

--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -151,6 +151,16 @@ class GraphStoreProtocol(Protocol):
 
     def list_snapshots(self, *, tenant_id: str = "", limit: int = 50) -> list[dict[str, Any]]: ...
 
+    def graph_history(self, *, tenant_id: str = "", limit: int = 50) -> dict[str, Any]: ...
+
+    def evidence_manifest(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        baseline_scan_id: str = "",
+    ) -> dict[str, Any]: ...
+
     def delete_tenant(self, *, tenant_id: str = "") -> int: ...
 
     def snapshot_stats(
@@ -1159,6 +1169,61 @@ class SQLiteGraphStore:
             return []
         try:
             return sqlite_graph_store.list_snapshots(conn, tenant_id=tenant_id, limit=limit)
+        finally:
+            conn.close()
+
+    def graph_history(self, *, tenant_id: str = "", limit: int = 50) -> dict[str, Any]:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
+        conn = self._open_ro_conn()
+        if conn is None:
+            return {
+                "schema_version": "agent-bom.graph_history/v1",
+                "tenant_id": tenant_id,
+                "retention_policy": sqlite_graph_store.graph_retention_policy(),
+                "snapshots": [],
+            }
+        try:
+            return sqlite_graph_store.graph_history(conn, tenant_id=tenant_id, limit=limit)
+        finally:
+            conn.close()
+
+    def evidence_manifest(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        baseline_scan_id: str = "",
+    ) -> dict[str, Any]:
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
+        conn = self._open_ro_conn()
+        if conn is None:
+            return {
+                "schema_version": "agent-bom.graph_evidence_manifest/v1",
+                "tenant_id": tenant_id,
+                "scan_id": "",
+                "generated_at": "",
+                "retention_policy": sqlite_graph_store.graph_retention_policy(),
+                "included_tables": [
+                    "graph_snapshots",
+                    "graph_nodes",
+                    "graph_edges",
+                    "attack_paths",
+                    "interaction_risks",
+                ],
+                "excluded_private_fields": [
+                    "graph_nodes.attributes",
+                    "graph_edges.provenance",
+                    "graph_edges.evidence",
+                    "attack_paths.credential_exposure",
+                ],
+            }
+        try:
+            return sqlite_graph_store.graph_evidence_manifest(
+                conn,
+                tenant_id=tenant_id,
+                scan_id=scan_id,
+                baseline_scan_id=baseline_scan_id,
+            )
         finally:
             conn.close()
 

--- a/src/agent_bom/api/neptune_graph.py
+++ b/src/agent_bom/api/neptune_graph.py
@@ -240,6 +240,18 @@ class NeptuneGraphStore:
         )
         return [self._snapshot_from_record(row) for row in rows]
 
+    def graph_history(self, *, tenant_id: str = "", limit: int = 50) -> dict[str, Any]:
+        self._unsupported("graph_history")
+
+    def evidence_manifest(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        baseline_scan_id: str = "",
+    ) -> dict[str, Any]:
+        self._unsupported("evidence_manifest")
+
     def load_graph(
         self,
         *,

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import time
@@ -11,12 +12,30 @@ from typing import Any, Iterable, Iterator, Sequence
 from agent_bom.api.graph_store import _escape_like_query, _node_search_text, decode_graph_cursor, encode_graph_cursor
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
 from agent_bom.config import POSTGRES_GRAPH_SEARCH_TIMEOUT_MS, POSTGRES_STATEMENT_TIMEOUT_MS
-from agent_bom.db.graph_store import DEFAULT_GRAPH_TENANT_ID, normalize_graph_tenant_id
+from agent_bom.db.graph_store import DEFAULT_GRAPH_TENANT_ID, graph_retention_policy, normalize_graph_tenant_id
 from agent_bom.graph import EntityType
 
 from .postgres_common import _apply_tenant_session, _ensure_tenant_rls, _get_pool, _tenant_connection, bypass_tenant_rls
 
 _ALLOWED_ENTITY_TYPES = {entity_type.value for entity_type in EntityType}
+_FINDING_ENTITY_TYPES = {
+    EntityType.VULNERABILITY.value,
+    EntityType.MISCONFIGURATION.value,
+    EntityType.DRIFT_INCIDENT.value,
+}
+_GRAPH_EVIDENCE_INCLUDED_TABLES = [
+    "graph_snapshots",
+    "graph_nodes",
+    "graph_edges",
+    "attack_paths",
+    "interaction_risks",
+]
+_GRAPH_EVIDENCE_EXCLUDED_PRIVATE_FIELDS = [
+    "graph_nodes.attributes",
+    "graph_edges.provenance",
+    "graph_edges.evidence",
+    "attack_paths.credential_exposure",
+]
 _DEFAULT_GRAPH_WRITE_BATCH_SIZE = 1000
 _GRAPH_TENANT_TABLE_KEYS: dict[str, tuple[str, ...]] = {
     "graph_nodes": ("id", "scan_id"),
@@ -95,6 +114,22 @@ def _assert_allowed_entity_types(entity_types: set[str] | None) -> None:
     invalid = sorted(entity_types - _ALLOWED_ENTITY_TYPES)
     if invalid:
         raise ValueError(f"Unsupported graph entity type: {invalid[0]}")
+
+
+def _digest_payload(payload: Any) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _diff_summary_counts(diff: dict[str, Any]) -> dict[str, int]:
+    return {
+        "nodes_added": len(diff.get("nodes_added") or []),
+        "nodes_removed": len(diff.get("nodes_removed") or []),
+        "nodes_changed": len(diff.get("nodes_changed") or []),
+        "edges_added": len(diff.get("edges_added") or []),
+        "edges_removed": len(diff.get("edges_removed") or []),
+        "edges_changed": len(diff.get("edges_changed") or []),
+    }
 
 
 def _backfill_empty_tenant_ids(conn) -> None:
@@ -1300,6 +1335,176 @@ class PostgresGraphStore:
                 }
                 for row in rows
             ]
+
+    def _snapshot_digests(self, conn, *, tenant_id: str, scan_id: str) -> tuple[str, str, dict[str, int]]:
+        graph_rows: dict[str, list[dict[str, Any]]] = {"nodes": [], "edges": []}
+        finding_rows: dict[str, list[dict[str, Any]]] = {"findings": [], "attack_paths": [], "compliance": []}
+
+        for row in conn.execute(
+            """
+            SELECT id, entity_type, label, status, severity, severity_id, risk_score,
+                   compliance_tags, data_sources
+            FROM graph_nodes
+            WHERE tenant_id = %s AND scan_id = %s
+            ORDER BY id
+            """,
+            (tenant_id, scan_id),
+        ).fetchall():
+            node = {
+                "id": row[0],
+                "entity_type": row[1],
+                "label": row[2],
+                "status": row[3],
+                "severity": row[4] or "",
+                "severity_id": int(row[5] or 0),
+                "risk_score": float(row[6] or 0.0),
+                "compliance_tags": json.loads(row[7] or "[]"),
+                "data_sources": json.loads(row[8] or "[]"),
+            }
+            graph_rows["nodes"].append(node)
+            if row[1] in _FINDING_ENTITY_TYPES:
+                finding_rows["findings"].append(node)
+            for tag in node["compliance_tags"]:
+                finding_rows["compliance"].append({"node_id": row[0], "tag": tag})
+
+        for row in conn.execute(
+            """
+            SELECT source_id, target_id, relationship, direction, weight, traversable,
+                   valid_from, valid_to, confidence, activity_id
+            FROM graph_edges
+            WHERE tenant_id = %s AND scan_id = %s
+            ORDER BY source_id, target_id, relationship
+            """,
+            (tenant_id, scan_id),
+        ).fetchall():
+            graph_rows["edges"].append(
+                {
+                    "source_id": row[0],
+                    "target_id": row[1],
+                    "relationship": row[2],
+                    "direction": row[3],
+                    "weight": float(row[4] or 0.0),
+                    "traversable": bool(row[5]),
+                    "valid_from": row[6] or "",
+                    "valid_to": row[7] or "",
+                    "confidence": float(row[8] if row[8] is not None else 1.0),
+                    "activity_id": int(row[9] or 1),
+                }
+            )
+
+        for row in conn.execute(
+            """
+            SELECT source_node, target_node, hop_count, composite_risk, summary,
+                   path_nodes, path_edges, tool_exposure, vuln_ids
+            FROM attack_paths
+            WHERE tenant_id = %s AND scan_id = %s
+            ORDER BY source_node, target_node
+            """,
+            (tenant_id, scan_id),
+        ).fetchall():
+            finding_rows["attack_paths"].append(
+                {
+                    "source_node": row[0],
+                    "target_node": row[1],
+                    "hop_count": int(row[2] or 0),
+                    "composite_risk": float(row[3] or 0.0),
+                    "summary": row[4] or "",
+                    "path_nodes": json.loads(row[5] or "[]"),
+                    "path_edges": json.loads(row[6] or "[]"),
+                    "tool_exposure": json.loads(row[7] or "[]"),
+                    "vuln_ids": json.loads(row[8] or "[]"),
+                }
+            )
+
+        counts = {
+            "nodes": len(graph_rows["nodes"]),
+            "edges": len(graph_rows["edges"]),
+            "findings": len(finding_rows["findings"]),
+            "attack_paths": len(finding_rows["attack_paths"]),
+            "compliance_tags": len(finding_rows["compliance"]),
+        }
+        return _digest_payload(graph_rows), _digest_payload(finding_rows), counts
+
+    def graph_history(self, *, tenant_id: str = "", limit: int = 50) -> dict[str, Any]:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
+        snapshots = self.list_snapshots(tenant_id=tenant_id, limit=limit)
+        history: list[dict[str, Any]] = []
+        for snapshot in snapshots:
+            scan_id = snapshot["scan_id"]
+            baseline = self.previous_snapshot_id(tenant_id=tenant_id, before_scan_id=scan_id)
+            diff_summary = _diff_summary_counts(self.diff_snapshots(baseline, scan_id, tenant_id=tenant_id)) if baseline else {}
+            history.append(
+                {
+                    **snapshot,
+                    "diff_baseline_scan_id": baseline,
+                    "diff_summary": diff_summary,
+                }
+            )
+        return {
+            "schema_version": "agent-bom.graph_history/v1",
+            "tenant_id": tenant_id,
+            "retention_policy": graph_retention_policy(),
+            "snapshots": history,
+        }
+
+    def evidence_manifest(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        baseline_scan_id: str = "",
+    ) -> dict[str, Any]:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
+        effective_scan_id = scan_id or self.latest_snapshot_id(tenant_id=tenant_id)
+        generated_at = datetime.now(timezone.utc).isoformat()
+        if not effective_scan_id:
+            return {
+                "schema_version": "agent-bom.graph_evidence_manifest/v1",
+                "tenant_id": tenant_id,
+                "scan_id": "",
+                "generated_at": generated_at,
+                "retention_policy": graph_retention_policy(),
+                "included_tables": list(_GRAPH_EVIDENCE_INCLUDED_TABLES),
+                "excluded_private_fields": list(_GRAPH_EVIDENCE_EXCLUDED_PRIVATE_FIELDS),
+            }
+        baseline = baseline_scan_id or self.previous_snapshot_id(tenant_id=tenant_id, before_scan_id=effective_scan_id)
+        with _tenant_connection(self._pool) as conn:
+            snapshot_row = conn.execute(
+                "SELECT created_at FROM graph_snapshots WHERE tenant_id = %s AND scan_id = %s",
+                (tenant_id, effective_scan_id),
+            ).fetchone()
+            if not snapshot_row:
+                return {
+                    "schema_version": "agent-bom.graph_evidence_manifest/v1",
+                    "tenant_id": tenant_id,
+                    "scan_id": "",
+                    "generated_at": generated_at,
+                    "retention_policy": graph_retention_policy(),
+                    "included_tables": list(_GRAPH_EVIDENCE_INCLUDED_TABLES),
+                    "excluded_private_fields": list(_GRAPH_EVIDENCE_EXCLUDED_PRIVATE_FIELDS),
+                }
+            graph_digest, findings_digest, counts = self._snapshot_digests(
+                conn,
+                tenant_id=tenant_id,
+                scan_id=effective_scan_id,
+            )
+
+        diff_summary = _diff_summary_counts(self.diff_snapshots(baseline, effective_scan_id, tenant_id=tenant_id)) if baseline else {}
+        return {
+            "schema_version": "agent-bom.graph_evidence_manifest/v1",
+            "tenant_id": tenant_id,
+            "scan_id": effective_scan_id,
+            "generated_at": generated_at,
+            "scan_created_at": str(snapshot_row[0]),
+            "graph_digest": graph_digest,
+            "findings_digest": findings_digest,
+            "diff_baseline_scan_id": baseline,
+            "diff_summary": diff_summary,
+            "counts": counts,
+            "included_tables": list(_GRAPH_EVIDENCE_INCLUDED_TABLES),
+            "excluded_private_fields": list(_GRAPH_EVIDENCE_EXCLUDED_PRIVATE_FIELDS),
+            "retention_policy": graph_retention_policy(),
+        }
 
     @staticmethod
     def _space_token_filter(column: str, token: str) -> tuple[str, list[str]]:

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -16,6 +16,8 @@ Endpoints:
   POST /v1/graph/query          — programmable traversal query
   GET  /v1/graph/node/{id}      — single node detail with edges + impact
   GET  /v1/graph/snapshots      — list persisted scan snapshots
+  GET  /v1/graph/history        — retained snapshot history with adjacent diffs
+  GET  /v1/graph/evidence-manifest — reviewer manifest for one graph snapshot
   GET  /v1/graph/legend         — entity + relationship legends
   GET  /v1/graph/schema         — canonical entity/edge taxonomy (codegen source)
   POST /v1/graph/presets        — save a filter preset
@@ -2131,6 +2133,33 @@ async def get_graph_snapshots(
 ) -> list[dict]:
     """List persisted scan snapshots ordered by creation time."""
     return await _graph_store_call(_get_graph_store_or_503().list_snapshots, tenant_id=_tenant(request), limit=limit)
+
+
+@router.get("/v1/graph/history", tags=["graph"])
+async def get_graph_history(
+    request: Request,
+    limit: int = Query(50, ge=1, le=500, description="Max snapshots"),
+) -> dict:
+    """Return retained graph history and adjacent diff summaries for the request tenant."""
+    return await _graph_store_call(_get_graph_store_or_503().graph_history, tenant_id=_tenant(request), limit=limit)
+
+
+@router.get("/v1/graph/evidence-manifest", tags=["graph"])
+async def get_graph_evidence_manifest(
+    request: Request,
+    scan_id: Optional[str] = Query(None, description="Scan snapshot ID; latest if omitted"),
+    baseline_scan_id: Optional[str] = Query(None, description="Optional diff baseline scan ID"),
+) -> dict:
+    """Return a redaction-aware reviewer manifest for a retained graph snapshot."""
+    manifest = await _graph_store_call(
+        _get_graph_store_or_503().evidence_manifest,
+        tenant_id=_tenant(request),
+        scan_id=scan_id or "",
+        baseline_scan_id=baseline_scan_id or "",
+    )
+    if not manifest.get("scan_id"):
+        raise HTTPException(status_code=404, detail="Graph snapshot not found")
+    return manifest
 
 
 @router.get("/v1/graph/compliance", tags=["graph"])

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -267,11 +267,13 @@ from agent_bom.cli._analysis import (  # noqa: E402
     analytics_cmd,
     dashboard_cmd,
     graph_cmd,
+    graph_evidence_cmd,
     introspect_cmd,
     mesh_cmd,
 )
 
 main.add_command(graph_cmd, "graph")
+main.add_command(graph_evidence_cmd, "graph-evidence")
 main.add_command(mesh_cmd, "mesh")
 # introspect is under `mcp introspect` — no top-level duplicate
 

--- a/src/agent_bom/cli/_analysis.py
+++ b/src/agent_bom/cli/_analysis.py
@@ -360,6 +360,59 @@ def graph_cmd(
             raise SystemExit(1)
 
 
+@click.command("graph-evidence")
+@click.option(
+    "--mode",
+    type=click.Choice(["history", "manifest"]),
+    default="manifest",
+    show_default=True,
+    help="Evidence view to export.",
+)
+@click.option("--graph-db", type=click.Path(dir_okay=False), default=None, help="SQLite graph DB path. Defaults to active graph config.")
+@click.option("--tenant", "tenant_id", default="default", show_default=True, help="Tenant to scope graph evidence to.")
+@click.option("--scan-id", default="", help="Snapshot ID for manifest mode. Defaults to latest.")
+@click.option("--baseline-scan-id", default="", help="Optional diff baseline snapshot for manifest mode.")
+@click.option("--limit", type=click.IntRange(min=1, max=500), default=50, show_default=True, help="Snapshot history limit.")
+@click.option("--output", "-o", "output_path", default=None, help="Write JSON to file instead of stdout.")
+def graph_evidence_cmd(
+    mode: str,
+    graph_db: Optional[str],
+    tenant_id: str,
+    scan_id: str,
+    baseline_scan_id: str,
+    limit: int,
+    output_path: Optional[str],
+) -> None:
+    """Export retained graph history or a redaction-aware evidence manifest.
+
+    \b
+    Examples:
+      agent-bom graph-evidence --mode history
+      agent-bom graph-evidence --mode manifest --scan-id scan-2026-06-22 -o manifest.json
+    """
+    from agent_bom.db.graph_store import default_graph_db_path, graph_evidence_manifest, graph_history, open_graph_db
+
+    db_path = Path(graph_db).expanduser() if graph_db else default_graph_db_path()
+    with open_graph_db(db_path) as conn:
+        if mode == "history":
+            payload = graph_history(conn, tenant_id=tenant_id, limit=limit)
+        else:
+            payload = graph_evidence_manifest(
+                conn,
+                tenant_id=tenant_id,
+                scan_id=scan_id,
+                baseline_scan_id=baseline_scan_id,
+            )
+            if not payload.get("scan_id"):
+                raise click.ClickException("Graph snapshot not found for tenant.")
+
+    output = json.dumps(payload, indent=2, sort_keys=True)
+    if output_path:
+        Path(output_path).write_text(output + "\n", encoding="utf-8")
+    else:
+        click.echo(output)
+
+
 @click.command("mesh")
 @click.argument("scan_file", required=False, type=click.Path(exists=True))
 @click.option(

--- a/src/agent_bom/compliance_utils.py
+++ b/src/agent_bom/compliance_utils.py
@@ -71,3 +71,36 @@ def framework_qualified_blast_radius_tags(br: BlastRadius) -> list[str]:
         framework = _FIELD_TO_VULN_KEY.get(field, field.removesuffix("_tags"))
         tags.extend(f"{framework}:{value}" for value in values)
     return tags
+
+
+def framework_qualified_finding_tags(finding: object) -> list[str]:
+    """Return unified Finding tags as stable framework:control strings."""
+    tags: list[str] = []
+    seen: set[str] = set()
+
+    def add(framework: object, control: object) -> None:
+        framework_text = str(framework or "").strip()
+        control_text = str(control or "").strip()
+        if not control_text:
+            return
+        value = control_text if ":" in control_text else f"{framework_text or 'generic'}:{control_text}"
+        if value not in seen:
+            seen.add(value)
+            tags.append(value)
+
+    for control in getattr(finding, "normalized_controls", lambda: [])():
+        add(getattr(control, "framework", "generic"), getattr(control, "control", ""))
+
+    for value in getattr(finding, "compliance_tags", []) or []:
+        add("generic", value)
+
+    evidence = getattr(finding, "evidence", {}) or {}
+    raw_vuln_tags = evidence.get("vulnerability_compliance_tags", {}) if isinstance(evidence, dict) else {}
+    if isinstance(raw_vuln_tags, dict):
+        for framework, values in sorted(raw_vuln_tags.items()):
+            if isinstance(values, str):
+                values = [values]
+            for value in values or []:
+                add(framework, value)
+
+    return sorted(tags)

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -8,6 +8,7 @@ preserves per-scan history so ``load_graph(scan_id=...)`` and
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -39,6 +40,25 @@ logger = logging.getLogger(__name__)
 DEFAULT_GRAPH_TENANT_ID = "default"
 _GRAPH_SCHEMA_VERSION = 3
 _DEFAULT_GRAPH_WRITE_BATCH_SIZE = 1000
+_DEFAULT_GRAPH_RETENTION_DAYS = 180
+_FINDING_ENTITY_TYPES = {
+    EntityType.VULNERABILITY.value,
+    EntityType.MISCONFIGURATION.value,
+    EntityType.DRIFT_INCIDENT.value,
+}
+_GRAPH_EVIDENCE_INCLUDED_TABLES = [
+    "graph_snapshots",
+    "graph_nodes",
+    "graph_edges",
+    "attack_paths",
+    "interaction_risks",
+]
+_GRAPH_EVIDENCE_EXCLUDED_PRIVATE_FIELDS = [
+    "graph_nodes.attributes",
+    "graph_edges.provenance",
+    "graph_edges.evidence",
+    "attack_paths.credential_exposure",
+]
 _GRAPH_TENANT_TABLE_KEYS: dict[str, tuple[str, ...]] = {
     "graph_nodes": ("id", "scan_id"),
     "graph_edges": ("source_id", "target_id", "relationship", "scan_id"),
@@ -269,6 +289,23 @@ def _graph_write_batch_size() -> int:
         return _DEFAULT_GRAPH_WRITE_BATCH_SIZE
 
 
+def _graph_retention_days() -> int:
+    raw = os.environ.get("AGENT_BOM_GRAPH_RETENTION_DAYS", str(_DEFAULT_GRAPH_RETENTION_DAYS))
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return _DEFAULT_GRAPH_RETENTION_DAYS
+
+
+def graph_retention_policy() -> dict[str, Any]:
+    return {
+        "retention_days": _graph_retention_days(),
+        "mode": "queryable_snapshot_history",
+        "deletion_state": "active",
+        "legal_hold": False,
+    }
+
+
 def _batched_rows(rows: Iterable[Sequence[Any]], batch_size: int) -> Iterator[list[Sequence[Any]]]:
     batch: list[Sequence[Any]] = []
     for row in rows:
@@ -362,6 +399,11 @@ def _resolve_snapshot(
         (effective_scan_id, tenant_id),
     ).fetchone()
     return effective_scan_id, (str(row["created_at"]) if row else "")
+
+
+def _digest_payload(payload: Any) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -870,3 +912,175 @@ def list_snapshots(
         }
         for r in rows
     ]
+
+
+def _diff_summary_counts(diff: dict[str, Any]) -> dict[str, int]:
+    return {
+        "nodes_added": len(diff.get("nodes_added") or []),
+        "nodes_removed": len(diff.get("nodes_removed") or []),
+        "nodes_changed": len(diff.get("nodes_changed") or []),
+        "edges_added": len(diff.get("edges_added") or []),
+        "edges_removed": len(diff.get("edges_removed") or []),
+        "edges_changed": len(diff.get("edges_changed") or []),
+    }
+
+
+def _snapshot_digests(conn: sqlite3.Connection, *, tenant_id: str, scan_id: str) -> tuple[str, str, dict[str, int]]:
+    graph_rows: dict[str, list[dict[str, Any]]] = {"nodes": [], "edges": []}
+    finding_rows: dict[str, list[dict[str, Any]]] = {"findings": [], "attack_paths": [], "compliance": []}
+
+    for row in conn.execute(
+        """
+        SELECT id, entity_type, label, status, severity, severity_id, risk_score,
+               compliance_tags, data_sources
+        FROM graph_nodes
+        WHERE tenant_id = ? AND scan_id = ?
+        ORDER BY id
+        """,
+        (tenant_id, scan_id),
+    ):
+        node = {
+            "id": row["id"],
+            "entity_type": row["entity_type"],
+            "label": row["label"],
+            "status": row["status"],
+            "severity": row["severity"] or "",
+            "severity_id": int(row["severity_id"] or 0),
+            "risk_score": float(row["risk_score"] or 0.0),
+            "compliance_tags": json.loads(row["compliance_tags"] or "[]"),
+            "data_sources": json.loads(row["data_sources"] or "[]"),
+        }
+        graph_rows["nodes"].append(node)
+        if row["entity_type"] in _FINDING_ENTITY_TYPES:
+            finding_rows["findings"].append(node)
+        for tag in node["compliance_tags"]:
+            finding_rows["compliance"].append({"node_id": row["id"], "tag": tag})
+
+    for row in conn.execute(
+        """
+        SELECT source_id, target_id, relationship, direction, weight, traversable,
+               valid_from, valid_to, confidence, activity_id
+        FROM graph_edges
+        WHERE tenant_id = ? AND scan_id = ?
+        ORDER BY source_id, target_id, relationship
+        """,
+        (tenant_id, scan_id),
+    ):
+        graph_rows["edges"].append(
+            {
+                "source_id": row["source_id"],
+                "target_id": row["target_id"],
+                "relationship": row["relationship"],
+                "direction": row["direction"],
+                "weight": float(row["weight"] or 0.0),
+                "traversable": bool(row["traversable"]),
+                "valid_from": row["valid_from"] or "",
+                "valid_to": row["valid_to"] or "",
+                "confidence": float(row["confidence"] if row["confidence"] is not None else 1.0),
+                "activity_id": int(row["activity_id"] or 1),
+            }
+        )
+
+    for row in conn.execute(
+        """
+        SELECT source_node, target_node, hop_count, composite_risk, summary,
+               path_nodes, path_edges, tool_exposure, vuln_ids
+        FROM attack_paths
+        WHERE tenant_id = ? AND scan_id = ?
+        ORDER BY source_node, target_node
+        """,
+        (tenant_id, scan_id),
+    ):
+        finding_rows["attack_paths"].append(
+            {
+                "source_node": row["source_node"],
+                "target_node": row["target_node"],
+                "hop_count": int(row["hop_count"] or 0),
+                "composite_risk": float(row["composite_risk"] or 0.0),
+                "summary": row["summary"] or "",
+                "path_nodes": json.loads(row["path_nodes"] or "[]"),
+                "path_edges": json.loads(row["path_edges"] or "[]"),
+                "tool_exposure": json.loads(row["tool_exposure"] or "[]"),
+                "vuln_ids": json.loads(row["vuln_ids"] or "[]"),
+            }
+        )
+
+    counts = {
+        "nodes": len(graph_rows["nodes"]),
+        "edges": len(graph_rows["edges"]),
+        "findings": len(finding_rows["findings"]),
+        "attack_paths": len(finding_rows["attack_paths"]),
+        "compliance_tags": len(finding_rows["compliance"]),
+    }
+    return _digest_payload(graph_rows), _digest_payload(finding_rows), counts
+
+
+def graph_evidence_manifest(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str = "",
+    scan_id: str = "",
+    baseline_scan_id: str = "",
+) -> dict[str, Any]:
+    """Build a redaction-aware evidence manifest for one retained graph snapshot."""
+    tenant_id = normalize_graph_tenant_id(tenant_id)
+    effective_scan_id, created_at = _resolve_snapshot(conn, tenant_id=tenant_id, scan_id=scan_id)
+    if not effective_scan_id:
+        return {
+            "schema_version": "agent-bom.graph_evidence_manifest/v1",
+            "tenant_id": tenant_id,
+            "scan_id": "",
+            "generated_at": _now_iso(),
+            "retention_policy": graph_retention_policy(),
+            "included_tables": list(_GRAPH_EVIDENCE_INCLUDED_TABLES),
+            "excluded_private_fields": list(_GRAPH_EVIDENCE_EXCLUDED_PRIVATE_FIELDS),
+        }
+
+    baseline = baseline_scan_id or previous_snapshot_id(conn, tenant_id=tenant_id, before_scan_id=effective_scan_id)
+    graph_digest, findings_digest, counts = _snapshot_digests(conn, tenant_id=tenant_id, scan_id=effective_scan_id)
+    diff_summary = _diff_summary_counts(diff_snapshots(conn, baseline, effective_scan_id, tenant_id=tenant_id)) if baseline else {}
+
+    return {
+        "schema_version": "agent-bom.graph_evidence_manifest/v1",
+        "tenant_id": tenant_id,
+        "scan_id": effective_scan_id,
+        "generated_at": _now_iso(),
+        "scan_created_at": created_at,
+        "graph_digest": graph_digest,
+        "findings_digest": findings_digest,
+        "diff_baseline_scan_id": baseline,
+        "diff_summary": diff_summary,
+        "counts": counts,
+        "included_tables": list(_GRAPH_EVIDENCE_INCLUDED_TABLES),
+        "excluded_private_fields": list(_GRAPH_EVIDENCE_EXCLUDED_PRIVATE_FIELDS),
+        "retention_policy": graph_retention_policy(),
+    }
+
+
+def graph_history(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str = "",
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Return retained graph snapshot history with adjacent diff summaries."""
+    tenant_id = normalize_graph_tenant_id(tenant_id)
+    snapshots = list_snapshots(conn, tenant_id=tenant_id, limit=limit)
+    history: list[dict[str, Any]] = []
+    for snapshot in snapshots:
+        scan_id = snapshot["scan_id"]
+        baseline = previous_snapshot_id(conn, tenant_id=tenant_id, before_scan_id=scan_id)
+        diff_summary = _diff_summary_counts(diff_snapshots(conn, baseline, scan_id, tenant_id=tenant_id)) if baseline else {}
+        history.append(
+            {
+                **snapshot,
+                "diff_baseline_scan_id": baseline,
+                "diff_summary": diff_summary,
+            }
+        )
+    return {
+        "schema_version": "agent-bom.graph_history/v1",
+        "tenant_id": tenant_id,
+        "retention_policy": graph_retention_policy(),
+        "snapshots": history,
+    }

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -256,6 +256,9 @@ class Finding:
 
     # Risk
     risk_score: float = 0.0  # 0-10 unified risk score
+    reachability: Optional[str] = None
+    is_actionable: Optional[bool] = None
+    impact_category: Optional[str] = None
 
     # Suppression state (mirrors BlastRadius; preserved through the unified stream
     # so a suppressed finding never appears unsuppressed downstream)
@@ -417,6 +420,9 @@ class Finding:
             "related_findings": self.related_findings,
             "evidence": self.evidence,
             "risk_score": self.risk_score,
+            "reachability": self.reachability,
+            "is_actionable": self.is_actionable,
+            "impact_category": self.impact_category,
             # Suppression state — a suppressed finding must never surface as
             # unsuppressed downstream (mirrors BlastRadius / SARIF suppressions[]).
             "suppressed": self.suppressed,
@@ -636,6 +642,13 @@ def blast_radius_to_finding(br: object) -> "Finding":
         "graph_min_hop_distance": getattr(br, "graph_min_hop_distance", None),
         "graph_reachable_from_agents": _sanitized_evidence_field(getattr(br, "graph_reachable_from_agents", [])),
         "layer_attribution": _sanitized_evidence_field([_package_occurrence_evidence(occ) for occ in br.layer_attribution]),
+        "published_at": getattr(vuln, "published_at", None),
+        "modified_at": getattr(vuln, "modified_at", None),
+        "severity_source": getattr(vuln, "severity_source", None),
+        "epss_percentile": getattr(vuln, "epss_percentile", None),
+        "kev_date_added": getattr(vuln, "kev_date_added", None),
+        "kev_due_date": getattr(vuln, "kev_due_date", None),
+        "vulnerability_compliance_tags": _sanitized_evidence_field(getattr(vuln, "compliance_tags", {}) or {}),
     }
     package_provenance = package_discovery_provenance(pkg)
     if package_provenance:
@@ -681,6 +694,9 @@ def blast_radius_to_finding(br: object) -> "Finding":
         pci_dss_tags=list(getattr(br, "pci_dss_tags", [])),
         evidence=evidence,
         risk_score=br.risk_score,
+        reachability=getattr(br, "reachability", None),
+        is_actionable=getattr(br, "is_actionable", None),
+        impact_category=getattr(br, "impact_category", None),
         suppressed=bool(getattr(br, "suppressed", False)),
         suppression_id=getattr(br, "suppression_id", None),
         suppression_state=getattr(br, "suppression_state", None),

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -109,14 +109,14 @@ def to_prometheus(report: AIBOMReport, blast_radii: list | None = None) -> str:
     """Generate Prometheus text exposition format string."""
     from agent_bom.output.prometheus import to_prometheus as _to_prometheus
 
-    return _to_prometheus(report, blast_radii or [])
+    return _to_prometheus(report, blast_radii)
 
 
 def export_prometheus(report: AIBOMReport, output_path: str, blast_radii: list | None = None) -> None:
     """Write Prometheus metrics to a .prom file."""
     from agent_bom.output.prometheus import export_prometheus as _export_prometheus
 
-    _export_prometheus(report, output_path, blast_radii or [])
+    _export_prometheus(report, output_path, blast_radii)
 
 
 def push_to_gateway(
@@ -129,7 +129,7 @@ def push_to_gateway(
     """Push scan metrics to a Prometheus Pushgateway."""
     from agent_bom.output.prometheus import push_to_gateway as _push
 
-    _push(gateway_url, report, blast_radii or [], job=job, instance=instance)
+    _push(gateway_url, report, blast_radii, job=job, instance=instance)
 
 
 def push_otlp(
@@ -140,7 +140,7 @@ def push_otlp(
     """Export metrics via OpenTelemetry OTLP/HTTP (requires agent-bom[otel])."""
     from agent_bom.output.prometheus import push_otlp as _push_otlp
 
-    _push_otlp(endpoint, report, blast_radii or [])
+    _push_otlp(endpoint, report, blast_radii)
 
 
 # ─── Compact family — re-exported from .compact (see #1522 Phase 1a) ─────────

--- a/src/agent_bom/output/badge.py
+++ b/src/agent_bom/output/badge.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 from agent_bom.models import AIBOMReport, Severity
+from agent_bom.output.finding_views import cve_findings, nested_vulnerabilities, severity_value
 
 
 def to_badge(report: AIBOMReport) -> dict:
@@ -16,14 +17,15 @@ def to_badge(report: AIBOMReport) -> dict:
 
     Use with: https://img.shields.io/endpoint?url=<badge-json-url>
     """
-    all_vulns = []
-    for agent in report.agents:
-        for server in agent.mcp_servers:
-            for pkg in server.packages:
-                all_vulns.extend(pkg.vulnerabilities)
-    critical = len([v for v in all_vulns if v.severity == Severity.CRITICAL])
-    high = len([v for v in all_vulns if v.severity == Severity.HIGH])
-    total = len(all_vulns)
+    findings = cve_findings(report)
+    if findings:
+        severities = [severity_value(finding) for finding in findings]
+    else:
+        severities = [vuln.severity.value for vuln in nested_vulnerabilities(report)]
+
+    critical = len([severity for severity in severities if severity == Severity.CRITICAL.value])
+    high = len([severity for severity in severities if severity == Severity.HIGH.value])
+    total = len(severities)
 
     if critical > 0:
         color = "critical"
@@ -72,7 +74,8 @@ def to_rsp_badge(report: AIBOMReport) -> dict:
             "color": "lightgrey",
         }
 
-    has_vulns = any(br.vulnerability.severity in (Severity.CRITICAL, Severity.HIGH) for br in report.blast_radii)
+    findings = cve_findings(report)
+    has_vulns = any(severity_value(finding) in {Severity.CRITICAL.value, Severity.HIGH.value} for finding in findings)
 
     if has_vulns:
         return {

--- a/src/agent_bom/output/compliance_export.py
+++ b/src/agent_bom/output/compliance_export.py
@@ -7,6 +7,7 @@ import zipfile
 
 from agent_bom.models import AIBOMReport
 from agent_bom.output.cyclonedx_fmt import to_cyclonedx
+from agent_bom.output.finding_views import cve_findings, package_name, package_version, severity_value
 
 
 def export_compliance_bundle(
@@ -31,17 +32,18 @@ def export_compliance_bundle(
 
     # Build vulnerability report
     vuln_entries = []
-    for br in report.blast_radii:
+    cve_rows = cve_findings(report)
+    for finding in cve_rows:
         vuln_entries.append(
             {
-                "id": br.vulnerability.id,
-                "severity": br.vulnerability.severity.value,
-                "package": br.package.name,
-                "version": br.package.version,
-                "fixed_version": br.vulnerability.fixed_version,
-                "risk_score": br.risk_score,
-                "affected_agents": [a.name for a in br.affected_agents],
-                "affected_servers": [s.name for s in br.affected_servers],
+                "id": finding.cve_id or finding.id,
+                "severity": severity_value(finding),
+                "package": package_name(finding),
+                "version": package_version(finding),
+                "fixed_version": finding.fixed_version,
+                "risk_score": finding.risk_score,
+                "affected_agents": list(finding.affected_agents),
+                "affected_servers": list(finding.affected_servers),
             }
         )
 
@@ -68,7 +70,7 @@ def export_compliance_bundle(
         elif ctrl_id == "SR-3":
             findings = [{"type": "supply_chain", "servers": report.total_servers}]
         elif ctrl_id == "RA-3":
-            findings = [{"type": "risk_assessment", "blast_radii": len(report.blast_radii)}]
+            findings = [{"type": "risk_assessment", "findings": len(cve_rows), "blast_radii": len(cve_rows)}]
         elif ctrl_id == "AU-2":
             findings = [{"type": "audit_trail", "scan_date": report.generated_at.isoformat()}]
         control_mapping[ctrl_id] = {

--- a/src/agent_bom/output/csv_fmt.py
+++ b/src/agent_bom/output/csv_fmt.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 import csv
 import io
 
-from agent_bom.compliance_utils import framework_qualified_blast_radius_tags
+from agent_bom.compliance_utils import framework_qualified_finding_tags
 from agent_bom.models import AIBOMReport, BlastRadius
+from agent_bom.output.finding_views import cve_findings, evidence, package_ecosystem, package_name, package_version, severity_value
 
 _COLUMNS = [
     "cve_id",
@@ -39,7 +40,7 @@ _COLUMNS = [
 
 def to_csv(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> str:
     """Convert an AIBOMReport to CSV string with UTF-8 BOM."""
-    brs = blast_radii or report.blast_radii
+    findings = cve_findings(report, blast_radii)
 
     buf = io.StringIO()
     # UTF-8 BOM for Excel auto-detection
@@ -48,40 +49,50 @@ def to_csv(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) ->
     writer = csv.DictWriter(buf, fieldnames=_COLUMNS, quoting=csv.QUOTE_MINIMAL)
     writer.writeheader()
 
-    for br in brs:
-        v = br.vulnerability
+    for finding in findings:
         writer.writerow(
             {
-                "cve_id": v.id,
-                "package": br.package.name,
-                "version": br.package.version or "",
-                "ecosystem": br.package.ecosystem or "",
-                "severity": v.severity.value,
-                "cvss_score": v.cvss_score if v.cvss_score is not None else "",
-                "epss_score": f"{v.epss_score:.4f}" if v.epss_score is not None else "",
-                "is_kev": "yes" if v.is_kev else "no",
-                "published_at": v.published_at or "",
-                "modified_at": v.modified_at or "",
-                "fixed_version": v.fixed_version or "",
-                "cwe_ids": ";".join(v.cwe_ids) if v.cwe_ids else "",
-                "affected_agents": ";".join(a.name for a in br.affected_agents),
-                "affected_servers": ";".join(s.name for s in br.affected_servers),
-                "exposed_credentials": str(len(br.exposed_credentials)),
-                "summary": v.summary or "",
-                "severity_source": v.severity_source or "",
-                "epss_percentile": f"{v.epss_percentile:.4f}" if v.epss_percentile is not None else "",
-                "kev_date_added": v.kev_date_added or "",
-                "kev_due_date": v.kev_due_date or "",
-                "compliance_tags": _compliance_tags_cell(br),
+                "cve_id": finding.cve_id or finding.id,
+                "package": package_name(finding),
+                "version": package_version(finding),
+                "ecosystem": package_ecosystem(finding),
+                "severity": severity_value(finding),
+                "cvss_score": finding.cvss_score if finding.cvss_score is not None else "",
+                "epss_score": f"{finding.epss_score:.4f}" if finding.epss_score is not None else "",
+                "is_kev": "yes" if finding.is_kev else "no",
+                "published_at": evidence(finding, "published_at", ""),
+                "modified_at": evidence(finding, "modified_at", ""),
+                "fixed_version": finding.fixed_version or "",
+                "cwe_ids": ";".join(finding.cwe_ids) if finding.cwe_ids else "",
+                "affected_agents": ";".join(finding.affected_agents),
+                "affected_servers": ";".join(finding.affected_servers),
+                "exposed_credentials": str(len(finding.exposed_credentials)),
+                "summary": finding.description or "",
+                "severity_source": evidence(finding, "severity_source", ""),
+                "epss_percentile": _format_optional_float(evidence(finding, "epss_percentile", None)),
+                "kev_date_added": evidence(finding, "kev_date_added", ""),
+                "kev_due_date": evidence(finding, "kev_due_date", ""),
+                "compliance_tags": _compliance_tags_cell(finding),
             }
         )
 
     return buf.getvalue()
 
 
-def _compliance_tags_cell(br: BlastRadius) -> str:
+def _format_optional_float(value: object) -> str:
+    if value is None or value == "":
+        return ""
+    if not isinstance(value, (int, float, str)):
+        return str(value)
+    try:
+        return f"{float(value):.4f}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _compliance_tags_cell(finding: object) -> str:
     """Return framework-qualified tags for one spreadsheet cell."""
-    return ";".join(framework_qualified_blast_radius_tags(br))
+    return ";".join(framework_qualified_finding_tags(finding))
 
 
 def export_csv(report: AIBOMReport, output_path: str, blast_radii: list[BlastRadius] | None = None) -> None:

--- a/src/agent_bom/output/finding_views.py
+++ b/src/agent_bom/output/finding_views.py
@@ -1,0 +1,86 @@
+"""Compatibility views over the unified Finding stream for output formatters."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_bom.finding import Finding, FindingType, blast_radius_to_finding
+from agent_bom.models import AIBOMReport, BlastRadius, Severity
+
+
+def cve_findings(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> list[Finding]:
+    """Return CVE findings, accepting legacy BlastRadius overrides."""
+    if blast_radii is not None:
+        return [blast_radius_to_finding(br) for br in blast_radii]
+
+    findings = [finding for finding in report.to_findings() if finding.finding_type == FindingType.CVE]
+    if not findings and report.blast_radii:
+        findings = [blast_radius_to_finding(br) for br in report.blast_radii]
+    return findings
+
+
+def nested_vulnerabilities(report: AIBOMReport) -> list[Any]:
+    """Return package vulnerabilities from the legacy inventory tree."""
+    vulns: list[Any] = []
+    for agent in report.agents:
+        for server in agent.mcp_servers:
+            for package in server.packages:
+                vulns.extend(package.vulnerabilities)
+    return vulns
+
+
+def evidence(finding: Finding, key: str, default: Any = "") -> Any:
+    value = finding.evidence.get(key, default)
+    return default if value is None else value
+
+
+def package_name(finding: Finding) -> str:
+    value = evidence(finding, "package_name", "")
+    if value:
+        return str(value)
+    identifier = finding.asset.identifier or ""
+    if "/" in identifier:
+        tail = identifier.rsplit("/", 1)[-1]
+        return tail.rsplit("@", 1)[0]
+    return finding.asset.name
+
+
+def package_version(finding: Finding) -> str:
+    value = evidence(finding, "package_version", "")
+    if value:
+        return str(value)
+    identifier = finding.asset.identifier or ""
+    if "@" in identifier:
+        return identifier.rsplit("@", 1)[-1]
+    return ""
+
+
+def package_ecosystem(finding: Finding) -> str:
+    value = evidence(finding, "ecosystem", "")
+    if value:
+        return str(value)
+    identifier = finding.asset.identifier or ""
+    if identifier.startswith("pkg:") and "/" in identifier:
+        return identifier.removeprefix("pkg:").split("/", 1)[0]
+    return ""
+
+
+def severity_value(finding: Finding) -> str:
+    return str(finding.effective_severity() or finding.severity or "unknown").lower()
+
+
+def severity_counts(findings: list[Finding]) -> dict[str, int]:
+    counts = {severity.value: 0 for severity in Severity if severity != Severity.NONE}
+    for finding in findings:
+        severity = severity_value(finding)
+        if severity in counts:
+            counts[severity] += 1
+    return counts
+
+
+def has_high_or_critical(finding: Finding) -> bool:
+    return severity_value(finding) in {"critical", "high"}
+
+
+def is_medium(finding: Finding) -> bool:
+    return severity_value(finding) == "medium"

--- a/src/agent_bom/output/junit.py
+++ b/src/agent_bom/output/junit.py
@@ -12,86 +12,102 @@ from __future__ import annotations
 
 from xml.etree.ElementTree import Element, SubElement, indent, tostring
 
+from agent_bom.finding import Finding
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
+from agent_bom.output.finding_views import (
+    cve_findings,
+    evidence,
+    has_high_or_critical,
+    is_medium,
+    package_ecosystem,
+    package_name,
+    package_version,
+    severity_value,
+)
 
 
 def to_junit(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> str:
     """Convert an AIBOMReport to JUnit XML string."""
-    brs = blast_radii or report.blast_radii
+    findings = cve_findings(report, blast_radii)
 
     testsuites = Element("testsuites")
     testsuites.set("name", "agent-bom")
-    testsuites.set("tests", str(len(brs)))
-    testsuites.set("failures", str(sum(1 for br in brs if br.vulnerability.severity in (Severity.CRITICAL, Severity.HIGH))))
-    testsuites.set("errors", str(sum(1 for br in brs if br.vulnerability.severity == Severity.MEDIUM)))
+    testsuites.set("tests", str(len(findings)))
+    testsuites.set("failures", str(sum(1 for finding in findings if has_high_or_critical(finding))))
+    testsuites.set("errors", str(sum(1 for finding in findings if is_medium(finding))))
     testsuites.set("time", "0")
 
     # Group by ecosystem
-    eco_map: dict[str, list[BlastRadius]] = {}
-    for br in brs:
-        eco = br.package.ecosystem or "unknown"
-        eco_map.setdefault(eco, []).append(br)
+    eco_map: dict[str, list[Finding]] = {}
+    for finding in findings:
+        eco = package_ecosystem(finding) or "unknown"
+        eco_map.setdefault(eco, []).append(finding)
 
-    for eco, eco_brs in sorted(eco_map.items()):
+    for eco, eco_findings in sorted(eco_map.items()):
         suite = SubElement(testsuites, "testsuite")
         suite.set("name", eco)
-        suite.set("tests", str(len(eco_brs)))
-        suite.set("failures", str(sum(1 for br in eco_brs if br.vulnerability.severity in (Severity.CRITICAL, Severity.HIGH))))
-        suite.set("errors", str(sum(1 for br in eco_brs if br.vulnerability.severity == Severity.MEDIUM)))
+        suite.set("tests", str(len(eco_findings)))
+        suite.set("failures", str(sum(1 for finding in eco_findings if has_high_or_critical(finding))))
+        suite.set("errors", str(sum(1 for finding in eco_findings if is_medium(finding))))
         suite.set("time", "0")
 
-        for br in eco_brs:
-            v = br.vulnerability
+        for finding in eco_findings:
+            pkg_name = package_name(finding)
+            pkg_version = package_version(finding)
+            vuln_id = finding.cve_id or finding.id
+            sev = severity_value(finding)
+            summary = finding.description or vuln_id
             tc = SubElement(suite, "testcase")
-            tc.set("classname", f"{eco}.{br.package.name}")
-            tc.set("name", f"{v.id} ({br.package.name}@{br.package.version})")
+            tc.set("classname", f"{eco}.{pkg_name}")
+            tc.set("name", f"{vuln_id} ({pkg_name}@{pkg_version})")
             tc.set("time", "0")
 
-            sev = v.severity
-            detail = _build_detail(br)
+            detail = _build_detail(finding)
 
-            if sev in (Severity.CRITICAL, Severity.HIGH):
+            if sev in (Severity.CRITICAL.value, Severity.HIGH.value):
                 fail = SubElement(tc, "failure")
-                fail.set("message", f"{sev.value.upper()}: {v.summary or v.id}")
-                fail.set("type", sev.value)
+                fail.set("message", f"{sev.upper()}: {summary}")
+                fail.set("type", sev)
                 fail.text = detail
-            elif sev == Severity.MEDIUM:
+            elif sev == Severity.MEDIUM.value:
                 err = SubElement(tc, "error")
-                err.set("message", f"MEDIUM: {v.summary or v.id}")
+                err.set("message", f"MEDIUM: {summary}")
                 err.set("type", "medium")
                 err.text = detail
             else:
                 skipped = SubElement(tc, "skipped")
-                skipped.set("message", f"{sev.value.upper()}: {v.summary or v.id}")
+                skipped.set("message", f"{sev.upper()}: {summary}")
                 skipped.text = detail
 
     indent(testsuites, space="  ")
     return '<?xml version="1.0" encoding="UTF-8"?>\n' + tostring(testsuites, encoding="unicode")
 
 
-def _build_detail(br: BlastRadius) -> str:
+def _build_detail(finding: Finding) -> str:
     """Build detail text for a JUnit test case."""
-    v = br.vulnerability
+    vuln_id = finding.cve_id or finding.id
     lines = [
-        f"CVE: {v.id}",
-        f"Package: {br.package.name}@{br.package.version}",
-        f"Ecosystem: {br.package.ecosystem or 'unknown'}",
-        f"Severity: {v.severity.value}",
+        f"CVE: {vuln_id}",
+        f"Package: {package_name(finding)}@{package_version(finding)}",
+        f"Ecosystem: {package_ecosystem(finding) or 'unknown'}",
+        f"Severity: {severity_value(finding)}",
     ]
-    if v.cvss_score is not None:
-        lines.append(f"CVSS: {v.cvss_score}")
-    if v.epss_score is not None:
-        lines.append(f"EPSS: {v.epss_score:.4f}")
-    if v.fixed_version:
-        lines.append(f"Fix: {v.fixed_version}")
-    if v.cwe_ids:
-        lines.append(f"CWE: {', '.join(v.cwe_ids)}")
-    if br.affected_agents:
-        lines.append(f"Affected agents: {', '.join(a.name for a in br.affected_agents)}")
-    if br.exposed_credentials:
-        lines.append(f"Exposed credentials: {len(br.exposed_credentials)}")
-    if v.summary:
-        lines.append(f"Summary: {v.summary}")
+    if finding.cvss_score is not None:
+        lines.append(f"CVSS: {finding.cvss_score}")
+    if finding.epss_score is not None:
+        lines.append(f"EPSS: {finding.epss_score:.4f}")
+    if finding.fixed_version:
+        lines.append(f"Fix: {finding.fixed_version}")
+    if finding.cwe_ids:
+        lines.append(f"CWE: {', '.join(finding.cwe_ids)}")
+    if finding.affected_agents:
+        lines.append(f"Affected agents: {', '.join(finding.affected_agents)}")
+    if finding.exposed_credentials:
+        lines.append(f"Exposed credentials: {len(finding.exposed_credentials)}")
+    if evidence(finding, "published_at", ""):
+        lines.append(f"Published: {evidence(finding, 'published_at')}")
+    if finding.description:
+        lines.append(f"Summary: {finding.description}")
     return "\n".join(lines)
 
 

--- a/src/agent_bom/output/prometheus.py
+++ b/src/agent_bom/output/prometheus.py
@@ -22,6 +22,14 @@ from pathlib import Path
 from typing import Optional
 
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
+from agent_bom.output.finding_views import (
+    cve_findings,
+    package_ecosystem,
+    package_name,
+    package_version,
+    severity_counts,
+    severity_value,
+)
 
 # ─── Metric name constants ─────────────────────────────────────────────────
 
@@ -72,7 +80,7 @@ def to_prometheus(
     agent_bom_credentials_exposed_total    Gauge  Creds exposed, per agent
     agent_bom_agent_vulnerabilities_total  Gauge  Per-agent, per-severity counts
     """
-    brs = blast_radii or []
+    findings = cve_findings(report, blast_radii)
     lines: list[str] = []
 
     def header(name: str, help_text: str, metric_type: str = "gauge") -> None:
@@ -105,77 +113,70 @@ def to_prometheus(
 
     # ── Vulnerability counts by severity ─────────────────────────────────
     header("vulnerabilities_total", "Total vulnerabilities found, broken down by severity")
-    sev_counts: dict[str, int] = {s.value: 0 for s in Severity if s != Severity.NONE}
-    for br in brs:
-        sev = br.vulnerability.severity.value
-        if sev in sev_counts:
-            sev_counts[sev] += 1
+    sev_counts = severity_counts(findings)
     for sev, count in sev_counts.items():
         lines.append(_metric("vulnerabilities_total", count, ("severity", sev)))
     lines.append("")
 
     # ── CISA KEV count ────────────────────────────────────────────────────
     header("kev_findings_total", "Number of findings in the CISA Known Exploited Vulnerabilities catalog")
-    kev_count = sum(1 for br in brs if br.vulnerability.is_kev)
+    kev_count = sum(1 for finding in findings if finding.is_kev)
     lines.append(_metric("kev_findings_total", kev_count))
     lines.append("")
 
     # ── Fixable vulns ─────────────────────────────────────────────────────
     header("fixable_vulnerabilities_total", "Number of vulnerabilities that have a known fixed version available")
-    fixable = sum(1 for br in brs if br.vulnerability.fixed_version)
+    fixable = sum(1 for finding in findings if finding.fixed_version)
     lines.append(_metric("fixable_vulnerabilities_total", fixable))
     lines.append("")
 
     # ── Per-vulnerability blast radius scores ─────────────────────────────
-    if brs:
+    if findings:
         header("blast_radius_score", "Blast radius risk score per vulnerability (0-10 scale)")
-        for br in brs:
-            v = br.vulnerability
+        for finding in findings:
             lines.append(
                 _metric(
                     "blast_radius_score",
-                    round(br.risk_score, 3),
-                    ("vuln_id", v.id),
-                    ("package", br.package.name),
-                    ("version", br.package.version),
-                    ("severity", v.severity.value),
-                    ("ecosystem", br.package.ecosystem),
-                    ("fixable", "1" if v.fixed_version else "0"),
-                    ("kev", "1" if v.is_kev else "0"),
+                    round(finding.risk_score, 3),
+                    ("vuln_id", finding.cve_id or finding.id),
+                    ("package", package_name(finding)),
+                    ("version", package_version(finding)),
+                    ("severity", severity_value(finding)),
+                    ("ecosystem", package_ecosystem(finding)),
+                    ("fixable", "1" if finding.fixed_version else "0"),
+                    ("kev", "1" if finding.is_kev else "0"),
                 )
             )
         lines.append("")
 
         # ── EPSS scores ───────────────────────────────────────────────────
-        epss_brs = [br for br in brs if br.vulnerability.epss_score is not None]
-        if epss_brs:
+        epss_findings = [finding for finding in findings if finding.epss_score is not None]
+        if epss_findings:
             header("vulnerability_epss_score", "EPSS exploit probability score (0.0-1.0) per vulnerability")
-            for br in epss_brs:
-                v = br.vulnerability
+            for finding in epss_findings:
                 lines.append(
                     _metric(
                         "vulnerability_epss_score",
-                        round(v.epss_score, 5),  # type: ignore[arg-type]
-                        ("vuln_id", v.id),
-                        ("package", br.package.name),
-                        ("severity", v.severity.value),
+                        round(finding.epss_score, 5),  # type: ignore[arg-type]
+                        ("vuln_id", finding.cve_id or finding.id),
+                        ("package", package_name(finding)),
+                        ("severity", severity_value(finding)),
                     )
                 )
             lines.append("")
 
         # ── CVSS scores ───────────────────────────────────────────────────
-        cvss_brs = [br for br in brs if br.vulnerability.cvss_score is not None]
-        if cvss_brs:
+        cvss_findings = [finding for finding in findings if finding.cvss_score is not None]
+        if cvss_findings:
             header("vulnerability_cvss_score", "CVSS base score (0.0-10.0) per vulnerability")
-            for br in cvss_brs:
-                v = br.vulnerability
+            for finding in cvss_findings:
                 lines.append(
                     _metric(
                         "vulnerability_cvss_score",
-                        round(v.cvss_score, 2),  # type: ignore[arg-type]
-                        ("vuln_id", v.id),
-                        ("package", br.package.name),
-                        ("severity", v.severity.value),
+                        round(finding.cvss_score, 2),  # type: ignore[arg-type]
+                        ("vuln_id", finding.cve_id or finding.id),
+                        ("package", package_name(finding)),
+                        ("severity", severity_value(finding)),
                     )
                 )
             lines.append("")
@@ -184,13 +185,13 @@ def to_prometheus(
     header("agent_vulnerabilities_total", "Number of vulnerabilities per agent, broken down by severity")
     # Build agent→severity→count
     agent_sev: dict[str, dict[str, int]] = {}
-    for br in brs:
-        for agent in br.affected_agents:
-            if agent.name not in agent_sev:
-                agent_sev[agent.name] = {s.value: 0 for s in Severity if s != Severity.NONE}
-            sev = br.vulnerability.severity.value
-            if sev in agent_sev[agent.name]:
-                agent_sev[agent.name][sev] += 1
+    for finding in findings:
+        for agent_name in finding.affected_agents:
+            if agent_name not in agent_sev:
+                agent_sev[agent_name] = {s.value: 0 for s in Severity if s != Severity.NONE}
+            sev = severity_value(finding)
+            if sev in agent_sev[agent_name]:
+                agent_sev[agent_name][sev] += 1
     # Also emit 0-counts for agents with no vulns
     for agent in report.agents:
         if agent.name not in agent_sev:
@@ -328,7 +329,7 @@ def push_otlp(
             "opentelemetry-exporter-otlp-proto-http)"
         ) from exc
 
-    brs = blast_radii or []
+    findings = cve_findings(report, blast_radii)
 
     resource = Resource(
         attributes={
@@ -363,7 +364,7 @@ def push_otlp(
         yield otel_metrics.Observation(report.total_packages)
 
     def _kev_cb(options):
-        yield otel_metrics.Observation(sum(1 for br in brs if br.vulnerability.is_kev))
+        yield otel_metrics.Observation(sum(1 for finding in findings if finding.is_kev))
 
     meter.create_observable_gauge("agent_bom.agents_total", callbacks=[_agents_cb], description="Total AI agents discovered")
     meter.create_observable_gauge("agent_bom.mcp_servers_total", callbacks=[_servers_cb], description="Total MCP servers")
@@ -371,11 +372,7 @@ def push_otlp(
     meter.create_observable_gauge("agent_bom.kev_findings_total", callbacks=[_kev_cb], description="CISA KEV findings")
 
     # Severity breakdown via ObservableGauge per severity
-    sev_counts: dict[str, int] = {s.value: 0 for s in Severity if s != Severity.NONE}
-    for br in brs:
-        sev = br.vulnerability.severity.value
-        if sev in sev_counts:
-            sev_counts[sev] += 1
+    sev_counts = severity_counts(findings)
 
     for sev_value, count in sev_counts.items():
         _count = count  # capture

--- a/src/agent_bom/output/spdx_fmt.py
+++ b/src/agent_bom/output/spdx_fmt.py
@@ -8,8 +8,9 @@ from pathlib import Path
 from typing import Any
 
 from agent_bom.asset_provenance import package_version_provenance
-from agent_bom.compliance_utils import framework_qualified_blast_radius_tags
+from agent_bom.compliance_utils import framework_qualified_finding_tags
 from agent_bom.models import AIBOMReport
+from agent_bom.output.finding_views import cve_findings, package_ecosystem, package_name, package_version
 
 SPDX_3_CONTEXT = "https://spdx.org/rdf/3.0.0/spdx-context.jsonl"
 
@@ -53,7 +54,7 @@ def to_spdx(report: AIBOMReport) -> dict:
     }
 
     pkg_ref_map: dict[str, str] = {}
-    vuln_compliance_tags = _blast_radius_compliance_tags(report)
+    vuln_compliance_tags = _finding_compliance_tags(report)
 
     for agent in report.agents:
         agent_id = _next_id("SPDXRef-Agent")
@@ -283,13 +284,14 @@ def _vulnerability_compliance_tags(vuln: Any) -> list[str]:
     return []
 
 
-def _blast_radius_compliance_tags(report: AIBOMReport) -> dict[tuple[str, str, str | None, str], list[str]]:
-    """Return framework-qualified compliance tags keyed by package vulnerability."""
+def _finding_compliance_tags(report: AIBOMReport) -> dict[tuple[str, str, str | None, str], list[str]]:
+    """Return framework-qualified Finding tags keyed by package vulnerability."""
     by_vuln: dict[tuple[str, str, str | None, str], list[str]] = {}
-    for br in report.blast_radii:
-        tags = framework_qualified_blast_radius_tags(br)
+    for finding in cve_findings(report):
+        vuln_id = finding.cve_id or finding.id
+        tags = framework_qualified_finding_tags(finding)
         if tags:
-            by_vuln[_vulnerability_key(br.package, br.vulnerability)] = tags
+            by_vuln[(package_ecosystem(finding), package_name(finding), package_version(finding), vuln_id)] = tags
     return by_vuln
 
 

--- a/tests/test_cli_analysis.py
+++ b/tests/test_cli_analysis.py
@@ -11,6 +11,7 @@ from agent_bom.cli._analysis import (
     analytics_cmd,
     dashboard_cmd,
     graph_cmd,
+    graph_evidence_cmd,
     introspect_cmd,
     mesh_cmd,
 )
@@ -213,6 +214,33 @@ def test_graph_cmd_load_error(tmp_path):
     with patch("agent_bom.output.graph_export.load_graph_from_scan", side_effect=ValueError("bad scan")):
         result = runner.invoke(graph_cmd, [str(scan_file)])
         assert result.exit_code == 1
+
+
+def test_graph_evidence_cmd_exports_manifest_from_local_graph_db(tmp_path):
+    from agent_bom.db.graph_store import open_graph_db, save_graph
+    from agent_bom.graph import EntityType, UnifiedGraph, UnifiedNode
+
+    db_path = tmp_path / "graph.db"
+    old_graph = UnifiedGraph(scan_id="old-scan", tenant_id="tenant-a", created_at="2026-06-01T00:00:00Z")
+    old_graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="Agent A"))
+    new_graph = UnifiedGraph(scan_id="new-scan", tenant_id="tenant-a", created_at="2026-06-02T00:00:00Z")
+    new_graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="Agent A"))
+    new_graph.add_node(UnifiedNode(id="agent:b", entity_type=EntityType.AGENT, label="Agent B"))
+    with open_graph_db(db_path) as conn:
+        save_graph(conn, old_graph)
+        save_graph(conn, new_graph)
+
+    result = CliRunner().invoke(
+        graph_evidence_cmd,
+        ["--graph-db", str(db_path), "--tenant", "tenant-a", "--mode", "manifest", "--scan-id", "new-scan"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["scan_id"] == "new-scan"
+    assert payload["diff_baseline_scan_id"] == "old-scan"
+    assert payload["diff_summary"]["nodes_added"] == 1
+    assert payload["graph_digest"].startswith("sha256:")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_compliance_export.py
+++ b/tests/test_compliance_export.py
@@ -4,6 +4,7 @@ import json
 import zipfile
 from pathlib import Path
 
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType
 from agent_bom.models import (
     Agent,
     AgentType,
@@ -92,3 +93,39 @@ def test_summary_text(tmp_path: Path):
         summary = zf.read("summary.txt").decode()
     assert "NIST-AI-RMF" in summary
     assert "Vulnerabilities found:" in summary
+
+
+def test_unified_findings_populate_vulnerability_report(tmp_path: Path):
+    report = _make_report(with_vulns=False)
+    report.findings = [
+        Finding(
+            finding_type=FindingType.CVE,
+            source=FindingSource.SBOM,
+            asset=Asset(name="openai", asset_type="package", identifier="pkg:pypi/openai@1.0"),
+            severity="high",
+            cve_id="CVE-2026-0001",
+            fixed_version="2.0",
+            risk_score=6.0,
+            affected_agents=["claude"],
+            affected_servers=["s1"],
+            evidence={"package_name": "openai", "package_version": "1.0", "ecosystem": "pypi"},
+        )
+    ]
+    out = tmp_path / "evidence.zip"
+
+    export_compliance_bundle(report, "cmmc", str(out))
+
+    with zipfile.ZipFile(str(out)) as zf:
+        vulns = json.loads(zf.read("vulnerability_report.json"))
+    assert vulns == [
+        {
+            "id": "CVE-2026-0001",
+            "severity": "high",
+            "package": "openai",
+            "version": "1.0",
+            "fixed_version": "2.0",
+            "risk_score": 6.0,
+            "affected_agents": ["claude"],
+            "affected_servers": ["s1"],
+        }
+    ]

--- a/tests/test_finding.py
+++ b/tests/test_finding.py
@@ -571,6 +571,29 @@ def test_report_to_findings_converts_blast_radii():
     assert all(f.finding_type == FindingType.CVE for f in findings)
 
 
+def test_blast_radius_to_finding_preserves_reachability_and_vulnerability_metadata():
+    br = _make_blast_radius()
+    br.impact_category = "availability"
+    br.vulnerability.published_at = "2026-01-02T00:00:00Z"
+    br.vulnerability.modified_at = "2026-01-03T00:00:00Z"
+    br.vulnerability.severity_source = "nvd:cvss_v3"
+    br.vulnerability.epss_percentile = 97.5
+    br.vulnerability.kev_date_added = "2026-01-04"
+    br.vulnerability.kev_due_date = "2026-02-04"
+    br.vulnerability.compliance_tags = {"nist_csf": ["ID.RA-01"]}
+
+    finding = AIBOMReport(agents=[], blast_radii=[br]).to_findings()[0]
+
+    assert finding.reachability == br.reachability
+    assert finding.is_actionable == br.is_actionable
+    assert finding.impact_category == "availability"
+    assert finding.evidence["published_at"] == "2026-01-02T00:00:00Z"
+    assert finding.evidence["severity_source"] == "nvd:cvss_v3"
+    assert finding.evidence["epss_percentile"] == 97.5
+    assert finding.evidence["kev_date_added"] == "2026-01-04"
+    assert finding.evidence["vulnerability_compliance_tags"] == {"nist_csf": ["ID.RA-01"]}
+
+
 def test_report_to_findings_returns_existing_when_populated():
     """If findings already populated (dual-write path), return as-is."""
     pre_existing = [

--- a/tests/test_finding_field_surfacing.py
+++ b/tests/test_finding_field_surfacing.py
@@ -39,6 +39,9 @@ _NEW_JSON_FINDING_KEYS = {
     "affected_agents",
     "exposed_credentials",
     "exposed_tools",
+    "reachability",
+    "is_actionable",
+    "impact_category",
 }
 _NEW_SARIF_RESULT_PROPERTY_KEYS = {
     "affected_servers",

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 import time
 from types import SimpleNamespace
@@ -14,7 +15,16 @@ from agent_bom.api.graph_store import SQLiteGraphStore
 from agent_bom.api.routes import graph as graph_routes
 from agent_bom.api.server import app
 from agent_bom.api.stores import set_graph_store
-from agent_bom.db.graph_store import DEFAULT_GRAPH_TENANT_ID, _init_db, active_edges_at, changed_edges_between_scans, load_graph, save_graph
+from agent_bom.db.graph_store import (
+    DEFAULT_GRAPH_TENANT_ID,
+    _init_db,
+    active_edges_at,
+    changed_edges_between_scans,
+    graph_evidence_manifest,
+    graph_history,
+    load_graph,
+    save_graph,
+)
 from agent_bom.graph import (
     AttackPath,
     EntityType,
@@ -474,6 +484,55 @@ class TestGraphEndpointLogic:
         assert len(snaps) == 1
         assert snaps[0]["scan_id"] == "test-scan-001"
         assert snaps[0]["node_count"] == 4
+
+    def test_graph_history_and_manifest_are_tenant_scoped_and_redacted(self, graph_db):
+        g1 = UnifiedGraph(scan_id="tenant-a-old", tenant_id="tenant-a", created_at="2026-06-01T00:00:00Z")
+        g1.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="Agent A"))
+        g1.add_node(
+            UnifiedNode(
+                id="vuln:CVE-2026-0001",
+                entity_type=EntityType.VULNERABILITY,
+                label="CVE-2026-0001",
+                severity="high",
+                risk_score=8.7,
+                compliance_tags=["OWASP-A06"],
+                attributes={"raw_secret_like_context": "do-not-export"},
+            )
+        )
+        g1.add_edge(
+            UnifiedEdge(
+                source="agent:a",
+                target="vuln:CVE-2026-0001",
+                relationship=RelationshipType.VULNERABLE_TO,
+                evidence={"raw": "do-not-export"},
+                provenance={"collector": "fixture"},
+            )
+        )
+        save_graph(graph_db, g1)
+
+        g2 = UnifiedGraph(scan_id="tenant-a-new", tenant_id="tenant-a", created_at="2026-06-02T00:00:00Z")
+        g2.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="Agent A"))
+        g2.add_node(UnifiedNode(id="agent:b", entity_type=EntityType.AGENT, label="Agent B"))
+        save_graph(graph_db, g2)
+
+        other = UnifiedGraph(scan_id="tenant-b-new", tenant_id="tenant-b", created_at="2026-06-03T00:00:00Z")
+        other.add_node(UnifiedNode(id="agent:other", entity_type=EntityType.AGENT, label="Other Tenant"))
+        save_graph(graph_db, other)
+
+        history = graph_history(graph_db, tenant_id="tenant-a", limit=10)
+        manifest = graph_evidence_manifest(graph_db, tenant_id="tenant-a", scan_id="tenant-a-new")
+        encoded_manifest = json.dumps(manifest, sort_keys=True)
+
+        assert [snapshot["scan_id"] for snapshot in history["snapshots"]] == ["tenant-a-new", "tenant-a-old"]
+        assert history["snapshots"][0]["diff_baseline_scan_id"] == "tenant-a-old"
+        assert history["snapshots"][0]["diff_summary"]["nodes_added"] == 1
+        assert "tenant-b-new" not in json.dumps(history)
+        assert manifest["diff_baseline_scan_id"] == "tenant-a-old"
+        assert manifest["counts"]["nodes"] == 2
+        assert manifest["graph_digest"].startswith("sha256:")
+        assert manifest["findings_digest"].startswith("sha256:")
+        assert "graph_nodes.attributes" in manifest["excluded_private_fields"]
+        assert "do-not-export" not in encoded_manifest
 
     def test_sqlite_graph_store_search_is_server_side(self, tmp_path):
         store = SQLiteGraphStore(tmp_path / "graph.db")
@@ -1177,6 +1236,40 @@ class _RecordingGraphStore:
         self.calls.append(("list_snapshots", tenant_id, limit))
         return [{"scan_id": self.graph.scan_id, "created_at": self.graph.created_at, "node_count": 1, "edge_count": 0, "risk_summary": {}}]
 
+    def graph_history(self, *, tenant_id: str = "", limit: int = 50) -> dict:
+        self.calls.append(("graph_history", tenant_id, limit))
+        return {
+            "schema_version": "agent-bom.graph_history/v1",
+            "tenant_id": tenant_id,
+            "retention_policy": {"retention_days": 180, "mode": "queryable_snapshot_history"},
+            "snapshots": [
+                {
+                    "scan_id": self.graph.scan_id,
+                    "created_at": self.graph.created_at,
+                    "node_count": len(self.graph.nodes),
+                    "edge_count": len(self.graph.edges),
+                    "risk_summary": {},
+                    "diff_baseline_scan_id": "",
+                    "diff_summary": {},
+                }
+            ],
+        }
+
+    def evidence_manifest(self, *, tenant_id: str = "", scan_id: str = "", baseline_scan_id: str = "") -> dict:
+        self.calls.append(("evidence_manifest", tenant_id, scan_id, baseline_scan_id))
+        effective_scan = scan_id or self.graph.scan_id
+        return {
+            "schema_version": "agent-bom.graph_evidence_manifest/v1",
+            "tenant_id": tenant_id,
+            "scan_id": effective_scan,
+            "graph_digest": "sha256:test",
+            "findings_digest": "sha256:test",
+            "diff_baseline_scan_id": baseline_scan_id,
+            "included_tables": ["graph_snapshots", "graph_nodes", "graph_edges", "attack_paths", "interaction_risks"],
+            "excluded_private_fields": ["graph_nodes.attributes", "graph_edges.evidence"],
+            "retention_policy": {"retention_days": 180, "mode": "queryable_snapshot_history"},
+        }
+
     def snapshot_stats(self, *, tenant_id: str = "", scan_id: str = "", entity_types=None, min_severity_rank: int = 0) -> dict:
         self.calls.append(("snapshot_stats", tenant_id, scan_id, entity_types, min_severity_rank))
         return self.graph.stats()
@@ -1523,6 +1616,24 @@ class TestGraphStoreBackendSelection:
         assert changes_response.json()["summary"] == {"added": 0, "removed": 0, "changed": 0, "unchanged": 0}
         assert ("active_edges_at", "default", "2026-05-13T00:00:00Z") in recording_graph_store.calls
         assert ("changed_edges_between_scans", "default", "s1", "s2") in recording_graph_store.calls
+
+    def test_graph_history_and_manifest_routes_use_pluggable_store(self, recording_graph_store):
+        client = TestClient(app)
+
+        history = client.get("/v1/graph/history", params={"limit": 10})
+        manifest = client.get(
+            "/v1/graph/evidence-manifest",
+            params={"scan_id": "store-scan", "baseline_scan_id": "baseline-scan"},
+        )
+
+        assert history.status_code == 200
+        assert history.json()["schema_version"] == "agent-bom.graph_history/v1"
+        assert history.json()["snapshots"][0]["scan_id"] == "store-scan"
+        assert manifest.status_code == 200
+        assert manifest.json()["graph_digest"] == "sha256:test"
+        assert "graph_nodes.attributes" in manifest.json()["excluded_private_fields"]
+        assert ("graph_history", "default", 10) in recording_graph_store.calls
+        assert ("evidence_manifest", "default", "store-scan", "baseline-scan") in recording_graph_store.calls
 
     def test_fix_first_graph_view_returns_ranked_operator_cards(self, recording_graph_store):
         recording_graph_store.graph.add_node(UnifiedNode(id="server:a:fs", entity_type=EntityType.SERVER, label="mcp-fs"))

--- a/tests/test_graph_benchmark_scaffold.py
+++ b/tests/test_graph_benchmark_scaffold.py
@@ -33,11 +33,21 @@ def test_api_request_plan_covers_issue_2145_hot_paths() -> None:
     )
 
     names = {operation["name"] for operation in operations}
-    assert names == {"graph_search", "node_detail", "attack_path_drilldown", "graph_diff", "bounded_traversal"}
+    assert names == {
+        "graph_search",
+        "node_detail",
+        "attack_path_drilldown",
+        "graph_diff",
+        "graph_history",
+        "graph_evidence_manifest",
+        "bounded_traversal",
+    }
     assert any(operation["path"] == "/v1/graph/search" for operation in operations)
     assert any(operation["path"].startswith("/v1/graph/node/") for operation in operations)
     assert any(operation["path"] == "/v1/graph/paths" for operation in operations)
     assert any(operation["path"] == "/v1/graph/diff" for operation in operations)
+    assert any(operation["path"] == "/v1/graph/history" for operation in operations)
+    assert any(operation["path"] == "/v1/graph/evidence-manifest" for operation in operations)
     assert any(operation["method"] == "POST" and operation["path"] == "/v1/graph/query" for operation in operations)
 
 
@@ -50,11 +60,21 @@ def test_postgres_explain_queries_cover_graph_hot_paths() -> None:
         detail_node="package:langchain",
     )
 
-    assert set(queries) == {"node_search", "node_detail", "attack_path_drilldown", "graph_diff_nodes", "bounded_traversal_edges"}
+    assert set(queries) == {
+        "node_search",
+        "node_detail",
+        "attack_path_drilldown",
+        "graph_diff_nodes",
+        "graph_history",
+        "graph_evidence_manifest_digest",
+        "bounded_traversal_edges",
+    }
     assert all("EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)" in sql for sql in queries.values())
     assert "graph_node_search" in queries["node_search"]
     assert "attack_paths" in queries["attack_path_drilldown"]
     assert "FULL OUTER JOIN" in queries["graph_diff_nodes"]
+    assert "graph_snapshots" in queries["graph_history"]
+    assert "graph_edges" in queries["graph_evidence_manifest_digest"]
     assert "WITH RECURSIVE" in queries["bounded_traversal_edges"]
 
 
@@ -67,11 +87,21 @@ def test_postgres_latency_queries_cover_non_explain_hot_paths() -> None:
         detail_node="package:langchain",
     )
 
-    assert set(queries) == {"node_search", "node_detail", "attack_path_drilldown", "graph_diff_nodes", "bounded_traversal_edges"}
+    assert set(queries) == {
+        "node_search",
+        "node_detail",
+        "attack_path_drilldown",
+        "graph_diff_nodes",
+        "graph_history",
+        "graph_evidence_manifest_digest",
+        "bounded_traversal_edges",
+    }
     assert all("EXPLAIN" not in sql for sql in queries.values())
     assert "graph_node_search" in queries["node_search"]
     assert "attack_paths" in queries["attack_path_drilldown"]
     assert "FULL OUTER JOIN" in queries["graph_diff_nodes"]
+    assert "graph_snapshots" in queries["graph_history"]
+    assert "graph_edges" in queries["graph_evidence_manifest_digest"]
     assert "WITH RECURSIVE" in queries["bounded_traversal_edges"]
 
 

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -25,6 +25,7 @@ from agent_bom.models import (
 )
 from agent_bom.output import to_csv, to_json, to_junit, to_markdown, to_spdx
 from agent_bom.output.html import to_html
+from agent_bom.output.prometheus import to_prometheus
 from agent_bom.output.sarif import to_sarif
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
@@ -193,6 +194,38 @@ def _report_with_policy_finding() -> AIBOMReport:
     return report
 
 
+def _make_unified_cve_finding() -> Finding:
+    return Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.SBOM,
+        asset=Asset(name="web-lib", asset_type="package", identifier="pkg:npm/web-lib@1.0.0"),
+        severity="high",
+        title="CVE-2026-4242: web-lib@1.0.0",
+        description="Unified vulnerability",
+        cve_id="CVE-2026-4242",
+        cwe_ids=["CWE-79"],
+        cvss_score=8.8,
+        epss_score=0.812345,
+        fixed_version="2.0.0",
+        is_kev=True,
+        owasp_tags=["LLM05"],
+        evidence={
+            "package_name": "web-lib",
+            "package_version": "1.0.0",
+            "ecosystem": "npm",
+            "published_at": "2026-01-01T00:00:00Z",
+            "severity_source": "nvd:cvss_v3",
+            "epss_percentile": 99.1234,
+            "kev_date_added": "2026-01-15",
+            "vulnerability_compliance_tags": {"soc2": ["CC7.1"]},
+        },
+        risk_score=8.4,
+        affected_agents=["prod-agent"],
+        affected_servers=["prod-mcp"],
+        exposed_credentials=["AWS_SECRET_ACCESS_KEY"],
+    )
+
+
 # ── JUnit XML ────────────────────────────────────────────────────────────────
 
 
@@ -255,6 +288,21 @@ class TestJUnit:
         for suite in root.findall("testsuite"):
             for tc in suite.findall("testcase"):
                 assert tc.get("classname")
+
+    def test_unified_cve_findings_drive_junit_without_blast_radii(self):
+        report = _make_report()
+        report.findings = [_make_unified_cve_finding()]
+
+        xml_str = to_junit(report)
+        root = ET.fromstring(xml_str)
+        testcase = root.find("./testsuite/testcase")
+
+        assert root.get("tests") == "1"
+        assert root.get("failures") == "1"
+        assert testcase is not None
+        assert testcase.get("classname") == "npm.web-lib"
+        assert "CVE-2026-4242" in (testcase.get("name") or "")
+        assert testcase.find("failure") is not None
 
 
 # ── CSV ──────────────────────────────────────────────────────────────────────
@@ -341,6 +389,22 @@ class TestCSV:
         assert row["epss_percentile"] == "99.1234"
         assert row["kev_date_added"] == "2026-01-15"
         assert row["kev_due_date"] == "2026-02-05"
+        assert "owasp_llm:LLM05" in row["compliance_tags"]
+        assert "soc2:CC7.1" in row["compliance_tags"]
+
+    def test_unified_cve_findings_drive_csv_without_blast_radii(self):
+        report = _make_report()
+        report.findings = [_make_unified_cve_finding()]
+
+        csv_str = to_csv(report)
+        reader = csv.DictReader(io.StringIO(csv_str.lstrip("\ufeff")))
+        row = next(reader)
+
+        assert row["cve_id"] == "CVE-2026-4242"
+        assert row["package"] == "web-lib"
+        assert row["affected_agents"] == "prod-agent"
+        assert row["exposed_credentials"] == "1"
+        assert row["severity_source"] == "nvd:cvss_v3"
         assert "owasp_llm:LLM05" in row["compliance_tags"]
         assert "soc2:CC7.1" in row["compliance_tags"]
 
@@ -712,6 +776,34 @@ def test_spdx_vulnerability_annotations_preserve_enrichment_and_compliance_metad
     assert "agent-bom:cwe=CWE-352" in statements
     assert "agent-bom:compliance-tag=owasp_llm:LLM05" in statements
     assert "agent-bom:compliance-tag=soc2:CC7.1" in statements
+
+
+def test_spdx_vulnerability_annotations_use_unified_findings_without_blast_radii():
+    vuln = _make_enriched_vuln()
+    vuln.id = "CVE-2026-4242"
+    pkg = _make_pkg("web-lib", "1.0.0")
+    pkg.vulnerabilities = [vuln]
+    report = _make_report(agents=[_make_agent(servers=[_make_server(packages=[pkg])])])
+    report.findings = [_make_unified_cve_finding()]
+
+    spdx = to_spdx(report)
+    vuln_element = next(element for element in spdx["elements"] if element.get("type") == "security/Vulnerability")
+    statements = {annotation["statement"] for annotation in vuln_element["annotation"]}
+
+    assert "agent-bom:compliance-tag=owasp_llm:LLM05" in statements
+    assert "agent-bom:compliance-tag=soc2:CC7.1" in statements
+
+
+def test_prometheus_uses_unified_findings_without_blast_radii():
+    report = _make_report()
+    report.findings = [_make_unified_cve_finding()]
+
+    metrics = to_prometheus(report)
+
+    assert 'agent_bom_vulnerabilities_total{severity="high"} 1' in metrics
+    assert 'vuln_id="CVE-2026-4242"' in metrics
+    assert 'package="web-lib"' in metrics
+    assert "agent_bom_kev_findings_total 1" in metrics
 
 
 def test_html_renders_unified_non_cve_findings_with_asset_context():


### PR DESCRIPTION
Summary:
- add tenant-scoped graph history and redaction-aware evidence manifest surfaces for retained graph snapshots
- expose graph evidence via API and CLI, including digest, baseline diff summary, retention metadata, included tables, and excluded private fields
- migrate flat/count/tag-driven outputs toward unified Finding rows while preserving legacy blast-radius compatibility
- extend graph API/Postgres benchmark dry-run scaffolds and checked-in sample artifacts for history and evidence-manifest paths

Verification:
- uv run pytest -q tests/test_finding.py tests/test_finding_field_surfacing.py tests/test_output_formats.py tests/test_compliance_export.py tests/test_prometheus_cov.py tests/test_rsp_badge.py tests/test_graph_api.py tests/test_graph_benchmark_scaffold.py tests/test_cli_analysis.py::test_graph_evidence_cmd_exports_manifest_from_local_graph_db
- uv run ruff check src/agent_bom/finding.py src/agent_bom/compliance_utils.py src/agent_bom/output/finding_views.py src/agent_bom/output/csv_fmt.py src/agent_bom/output/junit.py src/agent_bom/output/badge.py src/agent_bom/output/prometheus.py src/agent_bom/output/spdx_fmt.py src/agent_bom/output/compliance_export.py src/agent_bom/db/graph_store.py src/agent_bom/api/graph_store.py src/agent_bom/api/postgres_graph.py src/agent_bom/api/routes/graph.py src/agent_bom/cli/_analysis.py scripts/run_graph_api_benchmark.py scripts/run_graph_postgres_explain.py scripts/run_graph_postgres_latency.py tests/test_finding.py tests/test_finding_field_surfacing.py tests/test_output_formats.py tests/test_compliance_export.py tests/test_graph_api.py tests/test_cli_analysis.py tests/test_graph_benchmark_scaffold.py
- uv run mypy src/agent_bom/finding.py src/agent_bom/compliance_utils.py src/agent_bom/output/finding_views.py src/agent_bom/output/csv_fmt.py src/agent_bom/output/junit.py src/agent_bom/output/badge.py src/agent_bom/output/prometheus.py src/agent_bom/output/spdx_fmt.py src/agent_bom/output/compliance_export.py src/agent_bom/db/graph_store.py src/agent_bom/api/graph_store.py src/agent_bom/api/postgres_graph.py src/agent_bom/api/routes/graph.py src/agent_bom/cli/_analysis.py
- uv run python scripts/run_graph_api_benchmark.py --dry-run --output docs/perf/results/graph-api-benchmark-sample.json
- uv run python scripts/run_graph_postgres_explain.py --dry-run --output-dir docs/perf/results/postgres-graph-explain-sample --summary-output docs/perf/results/postgres-graph-explain-sample.json
- uv run python scripts/run_graph_postgres_latency.py --dry-run --output-dir docs/perf/results/postgres-graph-latency-sample --summary-output docs/perf/results/postgres-graph-latency-sample.json
- uv run pytest -q tests/test_graph_api.py tests/test_graph_benchmark_scaffold.py tests/test_cli_analysis.py::test_graph_evidence_cmd_exports_manifest_from_local_graph_db tests/test_neptune_graph_store.py tests/test_finding.py tests/test_finding_field_surfacing.py tests/test_output_formats.py tests/test_compliance_export.py tests/test_prometheus_cov.py tests/test_rsp_badge.py
- uv run python scripts/check_cli_reference_alignment.py
- uv run python scripts/export_openapi.py --check
- python scripts/regenerate_data_model_atlas.py --check
- git diff --check

Notes:
- Advances #2918, #2929, and #2145.
- Does not close those issues: remaining scope includes JSON/SARIF/HTML/Markdown/console formatter migration, hosted lake persistence/retention/legal-hold semantics, authenticated remote API measurements, repeated Postgres latency artifacts, 50k/100k edge runs, and UI timing evidence.
- #2941 remains a separate scan-batch implementation track because it crosses API job models, durable stores, dispatch queue behavior, aggregation, and UI surfacing.