### PR TITLE
fix(graph): legacy context graph reads credential_env_vars (lateral-movement was credential-blind)

### DIFF
--- a/src/agent_bom/context_graph.py
+++ b/src/agent_bom/context_graph.py
@@ -241,32 +241,38 @@ def build_context_graph(
             # Track shared server detection
             server_to_agents[srv_name].append(agent_name)
 
-            # Credentials from env keys
-            env_dict = srv_dict.get("env", {})
-            for env_key in env_dict:
-                if _is_credential_key(env_key):
-                    cred_id = f"cred:{env_key}"
-                    if cred_id not in graph.nodes:
-                        graph.add_node(
-                            GraphNode(
-                                id=cred_id,
-                                kind=NodeKind.CREDENTIAL,
-                                label=env_key,
-                                metadata={"servers": []},
-                            )
-                        )
-                    # Track which servers expose this credential
-                    if srv_id not in graph.nodes[cred_id].metadata["servers"]:
-                        graph.nodes[cred_id].metadata["servers"].append(srv_id)
-                    graph.add_edge(
-                        GraphEdge(
-                            source=srv_id,
-                            target=cred_id,
-                            kind=EdgeKind.EXPOSES,
-                            weight=2.0,
+            # Credentials. The serialized scan contract surfaces credential env
+            # var names via ``credential_env_vars`` (the canonical builder writes
+            # them there and leaves ``env`` empty/redacted in output), so reading
+            # only ``env`` produced zero credential nodes — and zero
+            # SHARES_CREDENTIAL lateral edges — on real scan JSON. Read both:
+            # the explicit credential list plus any credential-looking inline env
+            # keys, deduped.
+            cred_keys = list(srv_dict.get("credential_env_vars", []))
+            cred_keys += [k for k in srv_dict.get("env", {}) if _is_credential_key(k)]
+            for env_key in dict.fromkeys(cred_keys):
+                cred_id = f"cred:{env_key}"
+                if cred_id not in graph.nodes:
+                    graph.add_node(
+                        GraphNode(
+                            id=cred_id,
+                            kind=NodeKind.CREDENTIAL,
+                            label=env_key,
+                            metadata={"servers": []},
                         )
                     )
-                    cred_to_agents[env_key].append(agent_name)
+                # Track which servers expose this credential
+                if srv_id not in graph.nodes[cred_id].metadata["servers"]:
+                    graph.nodes[cred_id].metadata["servers"].append(srv_id)
+                graph.add_edge(
+                    GraphEdge(
+                        source=srv_id,
+                        target=cred_id,
+                        kind=EdgeKind.EXPOSES,
+                        weight=2.0,
+                    )
+                )
+                cred_to_agents[env_key].append(agent_name)
 
             # Tools
             for tool_dict in srv_dict.get("tools", []):

--- a/tests/test_context_graph.py
+++ b/tests/test_context_graph.py
@@ -112,6 +112,38 @@ class TestBuildGraph:
         exposes = [e for e in graph.edges if e.kind == EdgeKind.EXPOSES]
         assert len(exposes) == 1
 
+    def test_credential_nodes_from_credential_env_vars(self):
+        # The serialized scan contract surfaces credentials via
+        # ``credential_env_vars`` with ``env`` often empty/redacted. The legacy
+        # reader previously looked only at ``env`` and emitted zero credential
+        # nodes on real scan JSON — regression guard for that.
+        server = {
+            **_server(name="aws-ops"),
+            "env": {},
+            "credential_env_vars": ["AWS_SECRET_ACCESS_KEY", "GITHUB_TOKEN"],
+        }
+        graph = build_context_graph([_agent(servers=[server])], [])
+        assert "cred:AWS_SECRET_ACCESS_KEY" in graph.nodes
+        assert "cred:GITHUB_TOKEN" in graph.nodes
+        assert graph.nodes["cred:AWS_SECRET_ACCESS_KEY"].kind == NodeKind.CREDENTIAL
+        exposes = [e for e in graph.edges if e.kind == EdgeKind.EXPOSES]
+        assert len(exposes) == 2
+
+    def test_shares_credential_edge_from_credential_env_vars(self):
+        # Two agents whose servers expose the same credential (surfaced via
+        # credential_env_vars) must yield a SHARES_CREDENTIAL lateral edge —
+        # previously lost because no credential nodes were built from output JSON.
+        def _cred_server(name):
+            return {**_server(name=name), "env": {}, "credential_env_vars": ["DATABASE_URL"]}
+
+        agents = [
+            _agent(name="a1", servers=[_cred_server("s1")]),
+            _agent(name="a2", servers=[_cred_server("s2")]),
+        ]
+        graph = build_context_graph(agents, [])
+        shares = [e for e in graph.edges if e.kind == EdgeKind.SHARES_CREDENTIAL]
+        assert len(shares) >= 1
+
     def test_tool_nodes_with_capability(self):
         agents = [_agent(servers=[_server(tools=[_tool("execute_code", "Run arbitrary code")])])]
         graph = build_context_graph(agents, [])


### PR DESCRIPTION
## Why
`build_context_graph` read credentials only from each server's `env` dict, but the serialized scan contract surfaces them via **`credential_env_vars`** (the canonical `graph/builder` writes them there and leaves `env` empty/redacted in output). So on real scan JSON the legacy graph — still used by the **CLI `agents` lateral-movement view** and the **API scan routes** via `find_lateral_paths` — emitted **zero credential nodes and zero `SHARES_CREDENTIAL` lateral edges**, going credential-blind. (The canonical builder was unaffected; this is the legacy split-brain path the audit flagged.)

## Fix
Read credentials from both sources, deduped: the explicit `credential_env_vars` list **plus** any credential-looking keys in inline `env`.

## Tests
2 regression tests: credential nodes + EXPOSES edges from `credential_env_vars` (env empty), and a `SHARES_CREDENTIAL` lateral edge between two agents sharing a credential. 43 context-graph tests pass; ruff + mypy clean.