### PR TITLE
fix(demo): isolate advisory evidence from ambient DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ agent-bom quickstart --run --offline        # write sample, scan, seed gateway p
 agent-bom agents --demo --offline
 ```
 
-The demo uses real OSV/GHSA advisories against intentionally vulnerable sample
-packages and produces graph-ready inventory without touching your source tree.
+The demo uses bundled advisory-backed OSV/GHSA ranges against intentionally
+vulnerable sample packages and produces graph-ready inventory without touching
+your source tree.
 For a real local scan:
 
 ```bash

--- a/docs/FIRST_RUN.md
+++ b/docs/FIRST_RUN.md
@@ -9,8 +9,9 @@ inventory and graph without asking them to scan a private repository first.
 agent-bom agents --demo --offline
 ```
 
-Use this when you need reproducible output. The package versions are curated
-and guarded by tests so screenshots and docs do not depend on fabricated CVEs.
+Use this when you need reproducible output. The package versions and
+advisory-backed ranges are curated in code and guarded by tests, so screenshots
+and docs do not depend on fabricated CVEs or a machine-specific local DB.
 
 ### Annotated demo output
 
@@ -19,7 +20,7 @@ private repo. A current release run starts like this:
 
 ```text
 Demo mode - curated agent + MCP sample with known-vulnerable packages.
-Offline mode - local vulnerability DB only
+Offline mode - bundled demo advisory DB only
 
 Discovery
   [ok] 2 agent(s) from curated sample environment
@@ -28,12 +29,12 @@ Package Extraction
   12 packages (7 pypi, 5 npm)
 
 Vulnerability Scan
-  [ok] Local DB: 57 vulnerabilities found (offline)
-  [warn] Found 57 vulnerabilities across 57 findings
-  [warn] Scan complete - 2 critical, 19 high, 28 medium, 8 low
+  [ok] Demo advisory DB: 11 vulnerabilities found (offline)
+  [warn] Found 11 vulnerabilities across 11 findings
+  [warn] Scan complete - 1 critical, 7 high, 3 medium
 
 agent-bom <installed version>
-agents=2 servers=4 packages=12 vulnerabilities=57
+agents=2 servers=4 packages=12 vulnerabilities=11
 ```
 
 What to look for:
@@ -41,10 +42,10 @@ What to look for:
 | Output | Meaning | Why it matters |
 |---|---|---|
 | `Demo mode` | Uses the bundled curated sample instead of your workstation config. | The first run is reproducible and safe to share in a bug report or sales demo. |
-| `Offline mode` | Uses the local vulnerability database only. | The command does not depend on live OSV/GHSA/network availability. |
+| `Offline mode` | Uses the bundled demo advisory DB and no network calls. | The command does not depend on live OSV/GHSA/network availability or a pre-synced local DB. |
 | `2 agent(s)` | Loads sample agent surfaces such as Cursor and Claude Desktop. | Findings are tied to AI agents, not only package names. |
 | `12 packages` | Extracts Python and npm package evidence behind MCP servers. | The scan proves supply-chain inventory before reporting risk. |
-| `57 vulnerabilities` | Matches vulnerable demo package versions against real advisories. | The findings are advisory-backed; they are not invented demo rows. |
+| `11 vulnerabilities` | Matches vulnerable demo package versions against curated advisory-backed ranges. | The findings are advisory-backed; they are not invented demo rows. |
 | severity summary | Groups findings by critical/high/medium/low. | Operators can immediately prioritize the highest-risk fixes. |
 | `agents=... servers=...` | Prints a compact inventory summary. | The same evidence can move into JSON, SARIF, SBOM, HTML, graph, or dashboard workflows. |
 
@@ -59,8 +60,8 @@ Then it lists findings with fix guidance and reach context:
 
 ```text
 VULN_ID          SEVERITY  PACKAGE              FIX     AGENTS  CREDENTIALS
-CVE-2023-50447  critical  pillow@9.0.0         10.2.0  1       2
-CVE-2023-0286   high      cryptography@39.0.0  39.0.1  1       2
+GHSA-8vj2-vxx3-667w  critical  pillow@9.0.0         9.0.1   1       2
+PYSEC-2023-254       high      cryptography@39.0.0  41.0.3  1       2
 ```
 
 Read the final columns as blast-radius context: `AGENTS` is how many agent

--- a/src/agent_bom/cli/_scan_runner.py
+++ b/src/agent_bom/cli/_scan_runner.py
@@ -89,7 +89,8 @@ def run_default_scan(cfg: ScanConfig, con: "Console") -> ScanResult:
         set_offline_mode(True)
         enrich = False
         if not cfg.quiet:
-            con.print("[dim]Offline mode — local vulnerability DB only[/dim]")
+            offline_source = "bundled demo advisory DB" if cfg.demo else "local vulnerability DB"
+            con.print(f"[dim]Offline mode — {offline_source} only[/dim]")
 
     def _restore_offline_mode() -> None:
         if previous_offline_mode is not None:
@@ -190,6 +191,7 @@ def run_default_scan(cfg: ScanConfig, con: "Console") -> ScanResult:
                     compliance_enabled=compliance,
                     resolve_transitive=cfg.resolve_transitive,
                     offline=cfg.offline,
+                    demo_advisories=cfg.demo,
                 )
             except IncompleteScanError as exc:
                 con.print(f"  [yellow]Warning:[/yellow] {exc}")

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -657,7 +657,8 @@ def scan(
         deps_dev = False
         snyk_flag = False
         if not quiet:
-            con.print("[dim]Offline mode — local vulnerability DB only[/dim]")
+            offline_source = "bundled demo advisory DB" if demo else "local vulnerability DB"
+            con.print(f"[dim]Offline mode — {offline_source} only[/dim]")
 
     # ── Auto-offline: use local DB if synced recently (saves ~10s network) ──
     prefer_local_db = False
@@ -1339,6 +1340,7 @@ def scan(
                             show_scan_banner=False,
                             offline=offline,
                             prefer_local_db=prefer_local_db,
+                            demo_advisories=demo,
                         )
                     except IncompleteScanError as exc:
                         _exit_incomplete_scan_with_partial_summary(
@@ -1376,6 +1378,7 @@ def scan(
                         resolve_transitive=transitive,
                         offline=offline,
                         prefer_local_db=prefer_local_db,
+                        demo_advisories=demo,
                     )
                 except IncompleteScanError as exc:
                     _exit_incomplete_scan_with_partial_summary(

--- a/src/agent_bom/demo_advisories.py
+++ b/src/agent_bom/demo_advisories.py
@@ -1,0 +1,93 @@
+"""Curated advisory evidence for the bundled demo inventory.
+
+These rows are intentionally narrow and are used only for
+``agent-bom agents --demo``. They keep the first-run demo deterministic when a
+developer or CI machine has no local vulnerability DB, while still exercising
+the same SQLite lookup and version-range parser used by real scans.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DemoAdvisory:
+    ecosystem: str
+    package: str
+    introduced: str
+    fixed: str
+    vuln_id: str
+    severity: str
+    cvss_score: float
+    summary: str
+    source: str = "demo-advisory"
+
+
+DEMO_ADVISORIES: tuple[DemoAdvisory, ...] = (
+    DemoAdvisory("npm", "express", "0", "4.19.2", "GHSA-rv95-896h-c2vc", "medium", 5.3, "express open redirect advisory"),
+    DemoAdvisory("npm", "node-fetch", "0", "3.1.1", "GHSA-r683-j2x4-v87g", "high", 8.8, "node-fetch exposure advisory"),
+    DemoAdvisory("npm", "jsonwebtoken", "0", "9.0.0", "GHSA-8cf7-32gw-wr33", "high", 7.6, "jsonwebtoken signature validation advisory"),
+    DemoAdvisory("npm", "axios", "0", "1.6.0", "GHSA-jr5f-v2jv-69x6", "high", 7.5, "axios CSRF credential disclosure advisory"),
+    DemoAdvisory("pypi", "flask", "0", "2.3.2", "GHSA-m2qf-hxjv-5gpq", "high", 7.5, "Flask cookie parsing advisory"),
+    DemoAdvisory("pypi", "werkzeug", "0", "2.2.3", "GHSA-q34m-jh98-gwm2", "high", 7.5, "Werkzeug multipart parsing advisory"),
+    DemoAdvisory("pypi", "requests", "0", "2.32.0", "GHSA-j8r2-6x86-q33q", "medium", 5.3, "Requests credential leakage advisory"),
+    DemoAdvisory("pypi", "cryptography", "0", "41.0.3", "PYSEC-2023-254", "high", 7.5, "cryptography OpenSSL advisory"),
+    DemoAdvisory("pypi", "pillow", "0", "9.0.1", "GHSA-8vj2-vxx3-667w", "critical", 9.8, "Pillow buffer overflow advisory"),
+    DemoAdvisory("pypi", "jinja2", "0", "3.1.5", "GHSA-gmj6-6f8f-6699", "medium", 8.8, "Jinja2 sandbox escape advisory"),
+    DemoAdvisory("pypi", "certifi", "0", "2023.7.22", "GHSA-xqr8-7jwr-rhp7", "high", 7.5, "certifi trust store advisory"),
+)
+
+# The demo deliberately includes semver@7.5.2 as a clean package. This sentinel
+# gives the deterministic demo DB package-level coverage without making that
+# exact version vulnerable.
+DEMO_CLEAN_COVERAGE_SENTINELS: tuple[DemoAdvisory, ...] = (
+    DemoAdvisory(
+        "npm",
+        "semver",
+        "0",
+        "7.5.0",
+        "DEMO-CLEAN-semver",
+        "unknown",
+        0.0,
+        "Non-matching coverage sentinel for clean demo package semver@7.5.2",
+        source="demo-clean-sentinel",
+    ),
+)
+
+
+def seed_demo_advisories(conn: sqlite3.Connection) -> None:
+    """Insert deterministic demo advisory rows into an initialized DB."""
+
+    for advisory in (*DEMO_ADVISORIES, *DEMO_CLEAN_COVERAGE_SENTINELS):
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO vulns(
+                id, summary, severity, cvss_score, fixed_version, source
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                advisory.vuln_id,
+                advisory.summary,
+                advisory.severity,
+                advisory.cvss_score,
+                advisory.fixed,
+                advisory.source,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO affected(
+                vuln_id, ecosystem, package_name, introduced, fixed, last_affected
+            ) VALUES (?, ?, ?, ?, ?, '')
+            """,
+            (
+                advisory.vuln_id,
+                advisory.ecosystem,
+                advisory.package,
+                advisory.introduced,
+                advisory.fixed,
+            ),
+        )
+    conn.commit()

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import tempfile
 import threading
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 from rich.console import Console
@@ -109,6 +111,7 @@ class ScanOptions:
     compliance_enabled: bool = False
     resolve_transitive: bool = False
     prefer_local_db: bool = False
+    demo_advisories: bool = False
 
 
 def default_scan_options(
@@ -117,6 +120,7 @@ def default_scan_options(
     resolve_transitive: bool = False,
     prefer_local_db: bool | None = None,
     offline: bool | None = None,
+    demo_advisories: bool = False,
 ) -> ScanOptions:
     """Build per-scan options while preserving legacy offline defaults."""
 
@@ -125,6 +129,7 @@ def default_scan_options(
         compliance_enabled=compliance_enabled,
         resolve_transitive=resolve_transitive,
         prefer_local_db=prefer_local_db if prefer_local_db is not None else globals().get("prefer_local_db", False),
+        demo_advisories=demo_advisories,
     )
 
 
@@ -629,58 +634,81 @@ def _scan_packages_local_db(packages: list[Package]) -> tuple[int, set[str]]:
         record_scan_warning("local vulnerability DB unavailable")
         return 0, set()
 
-    covered: set[str] = set()
-    total = 0
-
     try:
-        from agent_bom.db.lookup import package_in_db
-
-        if len(packages) > _BATCH_DB_THRESHOLD:
-            total = _scan_packages_local_db_batch(conn, packages, covered)
-        else:
-            for pkg in packages:
-                eco_key = pkg.ecosystem.lower()
-                db_ecos = _db_ecosystems_for_package(pkg) or [pkg.ecosystem.lower()]
-                candidate_names = _package_lookup_names(pkg)
-                norm_name = candidate_names[0]
-                db_key = f"{eco_key}:{norm_name}@{pkg.version}"
-                local_vulns = []
-                db_hit = False
-                for db_eco in db_ecos:
-                    for candidate_name in candidate_names:
-                        local_vulns.extend(lookup_package(conn, db_eco, candidate_name, pkg.version))
-                        db_hit = db_hit or package_in_db(conn, db_eco, candidate_name)
-
-                # Only mark as "covered by DB" when the package name actually exists in the
-                # affected table — not just because the ecosystem is mapped. This prevents
-                # false negatives where a package has no DB entry but is silently skipped
-                # (no OSV fallback) because the ecosystem is present.
-                if db_hit:
-                    covered.add(db_key)
-
-                if local_vulns:
-                    existing_ids = {v.id for v in pkg.vulnerabilities}
-                    # Also track aliases to prevent PYSEC/GHSA/CVE duplicates
-                    for v in pkg.vulnerabilities:
-                        existing_ids.update(v.aliases)
-                    new_vulns = []
-                    for lv in local_vulns:
-                        # Skip if this vuln or any of its aliases already seen
-                        lv_all_ids = {lv.id} | set(getattr(lv, "aliases", []))
-                        if lv_all_ids & existing_ids:
-                            continue
-                        new_vulns.append(_local_vuln_to_vulnerability(lv))
-                        existing_ids.add(lv.id)
-                        existing_ids.update(getattr(lv, "aliases", []))
-                    pkg.vulnerabilities.extend(new_vulns)
-                    total += len(new_vulns)
-                    for v in new_vulns:
-                        v.compliance_tags = _tag_vuln(v, pkg)
-                    flag_malicious_from_vulns(pkg)
+        covered: set[str] = set()
+        total = _scan_packages_db_conn(conn, packages, covered)
     finally:
         conn.close()
 
     return total, covered
+
+
+def _scan_packages_db_conn(conn: Any, packages: list[Package], covered: set[str]) -> int:
+    """Scan packages against an initialized vulnerability DB connection."""
+
+    from agent_bom.db import lookup_package
+    from agent_bom.db.lookup import package_in_db
+
+    if len(packages) > _BATCH_DB_THRESHOLD:
+        return _scan_packages_local_db_batch(conn, packages, covered)
+
+    total = 0
+    for pkg in packages:
+        eco_key = pkg.ecosystem.lower()
+        db_ecos = _db_ecosystems_for_package(pkg) or [pkg.ecosystem.lower()]
+        candidate_names = _package_lookup_names(pkg)
+        norm_name = candidate_names[0]
+        db_key = f"{eco_key}:{norm_name}@{pkg.version}"
+        local_vulns = []
+        db_hit = False
+        for db_eco in db_ecos:
+            for candidate_name in candidate_names:
+                local_vulns.extend(lookup_package(conn, db_eco, candidate_name, pkg.version))
+                db_hit = db_hit or package_in_db(conn, db_eco, candidate_name)
+
+        # Only mark as "covered by DB" when the package name actually exists in
+        # the affected table, not merely because the ecosystem is mapped.
+        if db_hit:
+            covered.add(db_key)
+
+        if local_vulns:
+            existing_ids = {v.id for v in pkg.vulnerabilities}
+            # Also track aliases to prevent PYSEC/GHSA/CVE duplicates
+            for v in pkg.vulnerabilities:
+                existing_ids.update(v.aliases)
+            new_vulns = []
+            for lv in local_vulns:
+                # Skip if this vuln or any of its aliases already seen
+                lv_all_ids = {lv.id} | set(getattr(lv, "aliases", []))
+                if lv_all_ids & existing_ids:
+                    continue
+                new_vulns.append(_local_vuln_to_vulnerability(lv))
+                existing_ids.add(lv.id)
+                existing_ids.update(getattr(lv, "aliases", []))
+            pkg.vulnerabilities.extend(new_vulns)
+            total += len(new_vulns)
+            for v in new_vulns:
+                v.compliance_tags = _tag_vuln(v, pkg)
+            flag_malicious_from_vulns(pkg)
+
+    return total
+
+
+def _scan_packages_demo_advisories(packages: list[Package]) -> tuple[int, set[str]]:
+    """Scan packages against the bundled demo advisory manifest."""
+
+    from agent_bom.db.schema import init_db
+    from agent_bom.demo_advisories import seed_demo_advisories
+
+    with tempfile.TemporaryDirectory(prefix="agent-bom-demo-vulns-") as tmp_dir:
+        conn = init_db(Path(tmp_dir) / "vulns.db")
+        try:
+            seed_demo_advisories(conn)
+            covered: set[str] = set()
+            total = _scan_packages_db_conn(conn, packages, covered)
+            return total, covered
+        finally:
+            conn.close()
 
 
 def _scan_packages_local_db_batch(
@@ -925,25 +953,37 @@ async def scan_packages(
     if not scannable:
         return 0
 
-    # ── Local DB lookup (fast, offline-capable) ───────────────────────────────
-    # Query the local SQLite DB first.  Packages covered by the DB skip the
-    # OSV API call — saving round-trips and enabling fully offline scanning
-    # when the DB is populated via `agent-bom db update`.
-    local_count, db_covered = _scan_packages_local_db(scannable)
-    if local_count:
-        local_label = "vulnerability found" if local_count == 1 else "vulnerabilities found"
-        console.print(f"  [green]✓[/green] Local DB: {local_count} {local_label} (offline)")
-
-    # Only call OSV for packages not already covered by the local DB
     def _db_key(p: Package) -> str:
         return f"{p.ecosystem.lower()}:{normalize_package_name(p.name, p.ecosystem)}@{p.version}"
 
+    # ── Local DB lookup (fast, offline-capable) ───────────────────────────────
+    # Demo mode uses bundled advisory rows first so published first-run evidence
+    # is deterministic and does not depend on a user's ambient ~/.agent-bom DB.
+    local_count = 0
+    db_covered: set[str] = set()
+    if scan_options.demo_advisories:
+        demo_count, demo_covered = _scan_packages_demo_advisories(scannable)
+        local_count += demo_count
+        db_covered.update(demo_covered)
+
+    # Query the local SQLite DB for packages not already covered by the
+    # deterministic demo manifest. Packages covered by the DB skip OSV calls.
+    local_db_targets = [p for p in scannable if _db_key(p) not in db_covered]
+    local_db_count, local_db_covered = _scan_packages_local_db(local_db_targets) if local_db_targets else (0, set())
+    local_count += local_db_count
+    db_covered.update(local_db_covered)
+    if local_count:
+        local_label = "vulnerability found" if local_count == 1 else "vulnerabilities found"
+        source_label = "Demo advisory DB" if scan_options.demo_advisories else "Local DB"
+        console.print(f"  [green]✓[/green] {source_label}: {local_count} {local_label} (offline)")
+
+    # Only call OSV for packages not already covered by the local DB
     osv_targets = [p for p in scannable if _db_key(p) not in db_covered]
 
     if scan_offline or (scan_prefer_local_db and not osv_targets):
         if scan_offline:
             covered_ecos = _db_covered_ecosystems()
-            if not covered_ecos:
+            if not covered_ecos and osv_targets:
                 # Genuinely empty/missing DB — nothing can be scanned offline.
                 raise IncompleteScanError(
                     "Offline mode requires a populated local vulnerability DB. Run `agent-bom db update` before using `--offline`."
@@ -1428,6 +1468,7 @@ def scan_agents_sync(
     show_scan_banner: bool = True,
     offline: bool | None = None,
     prefer_local_db: bool | None = None,
+    demo_advisories: bool = False,
     options: ScanOptions | None = None,
 ) -> list[BlastRadius]:
     """Synchronous wrapper for scan_agents."""
@@ -1436,6 +1477,7 @@ def scan_agents_sync(
         resolve_transitive=resolve_transitive,
         prefer_local_db=prefer_local_db,
         offline=offline,
+        demo_advisories=demo_advisories,
     )
     if enable_enrichment:
         blast_radii = asyncio.run(

--- a/tests/test_demo_inventory_accuracy.py
+++ b/tests/test_demo_inventory_accuracy.py
@@ -6,7 +6,7 @@ local vuln DB cannot match to a real advisory, the published screenshots
 become misleading — finding labels that map to nothing real.
 
 This test pins the contract: every package in the demo inventory must
-either resolve to at least one real entry in the bundled offline DB, or be
+either resolve to at least one expected advisory-backed range, or be
 explicitly listed in the no-known-vulns allowlist below. The allowlist
 exists so the demo can include intentionally-clean packages alongside the
 vulnerable ones (e.g. to show that not everything is on fire).
@@ -17,8 +17,9 @@ from __future__ import annotations
 import pytest
 
 from agent_bom.db.lookup import lookup_package
-from agent_bom.db.schema import open_existing_db_readonly
+from agent_bom.db.schema import init_db
 from agent_bom.demo import DEMO_INVENTORY
+from agent_bom.demo_advisories import seed_demo_advisories
 
 # Packages that the demo intentionally ships at a known-clean version. Add
 # entries here only after manually confirming that the version genuinely
@@ -42,11 +43,12 @@ def _all_demo_packages() -> list[tuple[str, str, str]]:
 
 
 @pytest.fixture(scope="module")
-def vuln_db():
-    try:
-        conn = open_existing_db_readonly()
-    except FileNotFoundError:
-        pytest.skip("Local vuln DB not present in this environment")
+def vuln_db(tmp_path_factory):
+    """Seed only the demo contract rows so the guard is independent of ~/.agent-bom."""
+    db_path = tmp_path_factory.mktemp("demo-vuln-db") / "vulns.db"
+    conn = init_db(db_path)
+    seed_demo_advisories(conn)
+
     yield conn
     conn.close()
 

--- a/tests/test_local_db_scan.py
+++ b/tests/test_local_db_scan.py
@@ -369,6 +369,34 @@ def test_scan_packages_offline_requires_local_db(monkeypatch):
             asyncio.run(scan_packages([pkg]))
 
 
+def test_scan_packages_demo_offline_uses_curated_advisories_without_local_db():
+    """Demo offline scans are deterministic and do not depend on ~/.agent-bom."""
+    from agent_bom.scanners import ScanOptions, scan_packages
+
+    vulnerable_npm = _make_pkg("express", "4.17.1", "npm")
+    vulnerable_pypi = _make_pkg("pillow", "9.0.0", "pypi")
+    intentionally_clean = _make_pkg("semver", "7.5.2", "npm")
+
+    with (
+        patch("agent_bom.scanners._scan_packages_local_db") as mock_local_db,
+        patch("agent_bom.scanners._db_covered_ecosystems", return_value=set()),
+        patch("agent_bom.scanners.query_osv_batch") as mock_osv,
+    ):
+        count = asyncio.run(
+            scan_packages(
+                [vulnerable_npm, vulnerable_pypi, intentionally_clean],
+                options=ScanOptions(offline=True, demo_advisories=True),
+            )
+        )
+
+    assert count >= 2
+    assert vulnerable_npm.vulnerabilities
+    assert vulnerable_pypi.vulnerabilities
+    assert intentionally_clean.vulnerabilities == []
+    mock_local_db.assert_not_called()
+    mock_osv.assert_not_called()
+
+
 def test_scan_packages_offline_clean_pkg_in_covered_ecosystem_does_not_raise(monkeypatch):
     """A package with no DB rows whose ecosystem the DB covers is CLEAN, not a gap.
 


### PR DESCRIPTION
Summary
- add a code-owned demo advisory manifest and scan demo/offline through the same SQLite lookup/version-range path as real scans
- keep normal offline scans fail-closed for uncovered packages while allowing fully covered deterministic demo scans without ~/.agent-bom
- update first-run docs and CLI copy to report the bundled demo advisory DB and verified 11-finding output

Verification
- uv run ruff check src/agent_bom/demo_advisories.py src/agent_bom/scanners/__init__.py src/agent_bom/cli/agents/__init__.py src/agent_bom/cli/_scan_runner.py tests/test_demo_inventory_accuracy.py tests/test_local_db_scan.py
- UV_PROJECT_ENVIRONMENT=/tmp/agent-bom-py311-ci uv run --python 3.11 --extra dev python -m pytest -q tests/test_demo_inventory_accuracy.py tests/test_local_db_scan.py::test_scan_packages_demo_offline_uses_curated_advisories_without_local_db tests/test_local_db_scan.py::test_scan_packages_offline_requires_local_db -vv --tb=short
- uv run pytest -q tests/test_demo_inventory_accuracy.py tests/test_local_db_scan.py::test_scan_packages_demo_offline_uses_curated_advisories_without_local_db tests/test_local_db_scan.py::test_scan_packages_offline_requires_local_db tests/test_accuracy_baseline_release.py -vv --tb=short
- AGENT_BOM_DB_PATH=/tmp/agent-bom-empty-demo.db PYTHONPATH=src uv run python -c 'from agent_bom.cli import cli_main; cli_main()' -- agents --demo --offline --no-auto-update-db -f json -o /tmp/agent-bom-demo-offline.json\n- OSV querybatch confirmed every curated advisory id resolves for its demo package/version; semver@7.5.2 resolves clean\n\nNotes\n- No passwords, PATs, or secrets added. Demo data is package/advisory metadata only.\n\nFixes #3028