### PR TITLE
fix(mcp): check tool reads nonexistent explicit versions as clean (P1)

### DIFF
--- a/src/agent_bom/mcp_tools/scanning.py
+++ b/src/agent_bom/mcp_tools/scanning.py
@@ -13,6 +13,27 @@ from agent_bom.security import sanitize_error
 logger = logging.getLogger(__name__)
 
 
+async def _version_published(name: str, version: str, ecosystem: str, client) -> bool:
+    """Return True if an exact package version is published (404 → not published).
+
+    Fails open (returns True) on network/other errors and for ecosystems without
+    a cheap per-version endpoint, so a transient failure never turns a genuine
+    clean result into a false "unknown".
+    """
+    from urllib.parse import quote
+
+    try:
+        if ecosystem == "pypi":
+            resp = await client.get(f"https://pypi.org/pypi/{quote(name)}/{quote(version)}/json")
+        elif ecosystem == "npm":
+            resp = await client.get(f"https://registry.npmjs.org/{quote(name, safe='@/')}/{quote(version)}")
+        else:
+            return True
+        return resp.status_code == 200
+    except Exception:  # noqa: BLE001 — best-effort existence check; fail open
+        return True
+
+
 async def scan_impl(
     *,
     config_path: str | None = None,
@@ -364,6 +385,29 @@ async def check_impl(
                     "distro_version": pkg.distro_version,
                 }
             )
+
+        # An explicit pinned version that found no vulns might simply not exist
+        # (a typo'd or hallucinated pin). Confirm it is published before calling
+        # it clean, so a fake pin can't read as safe.
+        if not pkg.vulnerabilities and version not in ("latest", "") and eco in ("npm", "pypi"):
+            from agent_bom.http_client import create_client
+
+            async with create_client(timeout=15.0) as client:
+                published = await _version_published(name, version, eco, client)
+            if not published:
+                return json.dumps(
+                    {
+                        "package": name,
+                        "version": version,
+                        "ecosystem": eco,
+                        "status": "unknown",
+                        "message": (
+                            f"Version {version} of {name} was not found in the {eco} registry — "
+                            f"cannot confirm it is free of vulnerabilities (typo or unpublished "
+                            f"version?). agent-bom only verifies published versions."
+                        ),
+                    }
+                )
 
         if not pkg.vulnerabilities:
             return json.dumps(

--- a/tests/test_mcp_check_version_existence.py
+++ b/tests/test_mcp_check_version_existence.py
@@ -1,0 +1,81 @@
+"""check must not read a nonexistent explicit version as clean (P1 audit fix)."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _trunc(s):
+    return s
+
+
+@pytest.mark.asyncio
+async def test_explicit_nonexistent_version_is_unknown_not_clean():
+    from agent_bom.mcp_tools import scanning
+
+    async def _noop_scan(pkgs, **_kw):
+        return 0  # finds nothing (the bogus version isn't in any advisory)
+
+    with (
+        patch("agent_bom.scanners.scan_packages", side_effect=_noop_scan),
+        patch("agent_bom.mcp_tools.scanning._version_published", new=AsyncMock(return_value=False)),
+    ):
+        result = await scanning.check_impl(
+            package="left-pad@0.0.1-doesnotexist",
+            ecosystem="npm",
+            _validate_ecosystem=lambda e: e,
+            _truncate_response=_trunc,
+        )
+    data = json.loads(result)
+    assert data["status"] == "unknown"
+    assert data["status"] != "clean"
+    assert "not found" in data["message"]
+
+
+@pytest.mark.asyncio
+async def test_explicit_published_clean_version_is_clean():
+    from agent_bom.mcp_tools import scanning
+
+    async def _noop_scan(pkgs, **_kw):
+        return 0
+
+    with (
+        patch("agent_bom.scanners.scan_packages", side_effect=_noop_scan),
+        patch("agent_bom.mcp_tools.scanning._version_published", new=AsyncMock(return_value=True)),
+    ):
+        result = await scanning.check_impl(
+            package="six==1.16.0",
+            ecosystem="pypi",
+            _validate_ecosystem=lambda e: e,
+            _truncate_response=_trunc,
+        )
+    data = json.loads(result)
+    assert data["status"] == "clean"  # real published version, no vulns
+
+
+@pytest.mark.asyncio
+async def test_vulnerable_version_short_circuits_before_existence_check():
+    from agent_bom.mcp_tools import scanning
+
+    async def _vuln_scan(pkgs, **_kw):
+        from unittest.mock import MagicMock
+
+        pkgs[0].vulnerabilities = [MagicMock(id="CVE-2023-32681")]  # any non-empty list
+        return 1
+
+    # _version_published must NOT even be consulted when vulns are found.
+    published = AsyncMock(return_value=True)
+    with (
+        patch("agent_bom.scanners.scan_packages", side_effect=_vuln_scan),
+        patch("agent_bom.mcp_tools.scanning._version_published", new=published),
+    ):
+        result = await scanning.check_impl(
+            package="requests==2.20.0",
+            ecosystem="pypi",
+            _validate_ecosystem=lambda e: e,
+            _truncate_response=_trunc,
+        )
+    data = json.loads(result)
+    assert data.get("vulnerabilities") and data["vulnerabilities"] != 0
+    published.assert_not_awaited()


### PR DESCRIPTION
P1 audit fix. `check` existence-validated only the `latest`/empty path, so an explicit pin like `left-pad@0.0.1-doesnotexist` / `requests@99.99.99` skipped it, scanned the bogus version, found 0 advisories, and reported **status:clean** — a silent false-clean defeating the pre-install gate for typo'd/hallucinated pins. After a 0-vuln explicit-version scan on npm/pypi, confirm the version is **published** (per-version registry endpoint; 404 = absent) → return `status:unknown` instead of clean. Fails open on network error; vulnerable versions short-circuit. 6 tests pass, ruff+mypy clean.