### PR TITLE
fix(sarif): locate dependency findings at their own ecosystem's manifest (P1)

### DIFF
--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 from agent_bom.asset_provenance import (
     agent_discovery_provenance,
@@ -67,18 +67,51 @@ _FRAMEWORK_TAXONOMY_META: dict[str, tuple[str, str, str]] = {
 }
 
 
-def _to_relative_path(path: str) -> str:
+# Per-ecosystem manifest candidates, checked in order. Lets a SARIF result for
+# a maven/go/cargo finding point at pom.xml/go.mod/Cargo.toml instead of all
+# findings collapsing onto the first manifest in the directory.
+_ECOSYSTEM_MANIFESTS: dict[str, tuple[str, ...]] = {
+    "pypi": ("requirements.txt", "pyproject.toml", "setup.py", "Pipfile"),
+    "npm": ("package.json",),
+    "maven": ("pom.xml", "build.gradle", "build.gradle.kts"),
+    "gradle": ("build.gradle", "build.gradle.kts", "pom.xml"),
+    "go": ("go.mod",),
+    "cargo": ("Cargo.toml", "Cargo.lock"),
+    "rubygems": ("Gemfile", "Gemfile.lock"),
+    "composer": ("composer.json",),
+    "nuget": ("packages.config",),
+    "hex": ("mix.exs",),
+    "pub": ("pubspec.yaml",),
+    "conda": ("environment.yml", "environment.yaml"),
+}
+
+
+def _ecosystem_from_purl(identifier: Optional[str]) -> Optional[str]:
+    """Extract the ecosystem from a purl identifier (``pkg:pypi/...`` → ``pypi``)."""
+    if identifier and identifier.startswith("pkg:"):
+        rest = identifier[4:]
+        return rest.split("/", 1)[0].split("@", 1)[0].lower() or None
+    return None
+
+
+def _to_relative_path(path: str, ecosystem: Optional[str] = None) -> str:
     """Convert an absolute path to a relative path suitable for SARIF.
 
     GitHub Code Scanning requires relative paths from the repo root.
     Absolute paths cause "No summary of scanned files" in the Security tab.
-    For dependency findings, points to the most likely manifest file.
+    For dependency findings on a directory, points to the manifest of the
+    finding's own ecosystem (so maven/go/cargo findings don't all collapse onto
+    the first manifest), falling back to any present manifest.
     """
 
     p = Path(path)
     # If it's a directory (e.g., project root from --self-scan), point to manifest
     if p.is_dir():
-        for manifest in ("pyproject.toml", "package.json", "go.mod", "Cargo.toml", "requirements.txt"):
+        if ecosystem:
+            for manifest in _ECOSYSTEM_MANIFESTS.get(ecosystem.lower(), ()):
+                if (p / manifest).exists():
+                    return manifest
+        for manifest in ("pyproject.toml", "package.json", "go.mod", "Cargo.toml", "requirements.txt", "pom.xml"):
             if (p / manifest).exists():
                 return manifest
         return "pyproject.toml"  # default fallback for Python projects
@@ -453,7 +486,10 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
                 }
             )
 
-        file_path = _to_relative_path(finding.asset.location or "agent-bom-report.json")
+        file_path = _to_relative_path(
+            finding.asset.location or "agent-bom-report.json",
+            _ecosystem_from_purl(finding.asset.identifier),
+        )
         fp_input = f"{finding.id}:{file_path}:{finding.asset.stable_id}"
         fingerprint = hashlib.sha256(fp_input.encode()).hexdigest()
         finding_result: dict = {

--- a/tests/test_sarif_ecosystem_locations.py
+++ b/tests/test_sarif_ecosystem_locations.py
@@ -1,0 +1,32 @@
+"""SARIF dependency findings point at the manifest of their own ecosystem (P1 audit fix)."""
+
+from agent_bom.output.sarif import _ecosystem_from_purl, _to_relative_path
+
+
+def test_ecosystem_from_purl():
+    assert _ecosystem_from_purl("pkg:maven/org.apache/log4j@2.14.1") == "maven"
+    assert _ecosystem_from_purl("pkg:pypi/requests@2.20.0") == "pypi"
+    assert _ecosystem_from_purl("pkg:npm/lodash@4.17.0") == "npm"
+    assert _ecosystem_from_purl("pkg:cargo/time@0.1.42") == "cargo"
+    assert _ecosystem_from_purl(None) is None
+    assert _ecosystem_from_purl("not-a-purl") is None
+
+
+def test_to_relative_path_picks_ecosystem_manifest(tmp_path):
+    # A multi-ecosystem project root with several manifests present.
+    for m in ("requirements.txt", "package.json", "pom.xml", "go.mod", "Cargo.toml"):
+        (tmp_path / m).write_text("x")
+    d = str(tmp_path)
+    assert _to_relative_path(d, "maven") == "pom.xml"
+    assert _to_relative_path(d, "pypi") == "requirements.txt"
+    assert _to_relative_path(d, "npm") == "package.json"
+    assert _to_relative_path(d, "go") == "go.mod"
+    assert _to_relative_path(d, "cargo") == "Cargo.toml"
+    # Unknown/None ecosystem → first-found fallback (not a crash, not maven-only).
+    assert _to_relative_path(d, None) in {"pyproject.toml", "package.json", "go.mod", "Cargo.toml", "requirements.txt"}
+
+
+def test_to_relative_path_falls_back_when_ecosystem_manifest_absent(tmp_path):
+    # maven finding but only a requirements.txt present → fall back, don't invent pom.xml.
+    (tmp_path / "requirements.txt").write_text("x")
+    assert _to_relative_path(str(tmp_path), "maven") == "requirements.txt"


### PR DESCRIPTION
P1 audit fix. `_to_relative_path` mapped **every** dependency finding on a project directory to the first manifest found (`package.json`), so maven/go/cargo findings annotated the **wrong file** in GitHub code-scanning. Now derive the ecosystem from the finding's purl identifier and pick that ecosystem's manifest (pom.xml / go.mod / Cargo.toml / requirements.txt / ...), falling back to any present manifest when absent/unknown. 8 tests pass, ruff+mypy clean.

(The related 'secrets are console-only, absent from JSON/SARIF' P1 is a separate, larger change — coming as its own PR.)