### PR TITLE
fix(findings): surface hardcoded-secret findings in JSON/SARIF, not just console (P1)

### DIFF
--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -585,6 +585,19 @@ def _remediation_guidance_for_vulnerability(vuln: object, pkg: object) -> str:
     return "Review the advisory and apply the vendor-recommended mitigation, upgrade path, or compensating control."
 
 
+def _safe_secret_preview(value: object) -> str:
+    """Return a display-only secret preview that cannot carry raw secret bytes."""
+    from agent_bom.security import sanitize_text
+
+    preview = sanitize_text(value, max_len=160).strip()
+    if not preview:
+        return "***REDACTED***"
+    lowered = preview.lower()
+    if "redact" in lowered or "***" in preview or "[secret_" in lowered or "[credential_" in lowered or "[pii_" in lowered:
+        return preview
+    return "***REDACTED***"
+
+
 def secret_dict_to_finding(secret: dict) -> "Finding":
     """Convert a secret_scanner result dict into a unified CREDENTIAL_EXPOSURE Finding.
 
@@ -592,11 +605,14 @@ def secret_dict_to_finding(secret: dict) -> "Finding":
     type, category, and file:line — so a machine consumer (JSON / SARIF) sees
     that a secret is hardcoded and where, without the secret bytes ever leaking.
     """
-    file_path = str(secret.get("file", "") or "")
-    line = secret.get("line")
-    secret_type = str(secret.get("type", "secret") or "secret")
-    category = str(secret.get("category", "secret") or "secret")
-    severity = str(secret.get("severity", "medium") or "medium").upper()
+    from agent_bom.security import sanitize_text
+
+    file_path = sanitize_text(secret.get("file", "") or "", max_len=500)
+    raw_line = secret.get("line")
+    line = raw_line if isinstance(raw_line, int) else sanitize_text(raw_line, max_len=40) if raw_line is not None else None
+    secret_type = sanitize_text(secret.get("type", "secret") or "secret", max_len=120)
+    category = sanitize_text(secret.get("category", "secret") or "secret", max_len=120)
+    severity = sanitize_text(secret.get("severity", "medium") or "medium", max_len=40).upper()
     loc = f"{file_path}:{line}" if line else file_path
     return Finding(
         finding_type=FindingType.CREDENTIAL_EXPOSURE,
@@ -620,7 +636,7 @@ def secret_dict_to_finding(secret: dict) -> "Finding":
             "line": line,
             "secret_type": secret_type,
             "category": category,
-            "redacted_preview": secret.get("preview"),
+            "redacted_preview": _safe_secret_preview(secret.get("preview")),
         },
     )
 

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -63,6 +63,7 @@ class FindingSource(str, Enum):
     EXTERNAL = "EXTERNAL"  # ingested from external scanner (Trivy/Grype/Syft JSON)
     FILESYSTEM = "FILESYSTEM"  # filesystem mount scan
     PROMPT_SCAN = "PROMPT_SCAN"  # prompt template/content scanner
+    SECRET_SCAN = "SECRET_SCAN"  # hardcoded secret / PII scanner
 
 
 @dataclass(frozen=True)
@@ -582,6 +583,46 @@ def _remediation_guidance_for_vulnerability(vuln: object, pkg: object) -> str:
     if references:
         return "Review the linked advisory references and apply the vendor-recommended mitigation or upgrade path."
     return "Review the advisory and apply the vendor-recommended mitigation, upgrade path, or compensating control."
+
+
+def secret_dict_to_finding(secret: dict) -> "Finding":
+    """Convert a secret_scanner result dict into a unified CREDENTIAL_EXPOSURE Finding.
+
+    The secret *value* is never carried — only the already-redacted preview,
+    type, category, and file:line — so a machine consumer (JSON / SARIF) sees
+    that a secret is hardcoded and where, without the secret bytes ever leaking.
+    """
+    file_path = str(secret.get("file", "") or "")
+    line = secret.get("line")
+    secret_type = str(secret.get("type", "secret") or "secret")
+    category = str(secret.get("category", "secret") or "secret")
+    severity = str(secret.get("severity", "medium") or "medium").upper()
+    loc = f"{file_path}:{line}" if line else file_path
+    return Finding(
+        finding_type=FindingType.CREDENTIAL_EXPOSURE,
+        source=FindingSource.SECRET_SCAN,
+        asset=Asset(
+            name=f"{secret_type} in {file_path}" if file_path else secret_type,
+            asset_type="file",
+            identifier=loc or None,
+            location=file_path or None,
+        ),
+        severity=severity,
+        title=f"Hardcoded {category}: {secret_type}",
+        description=(
+            f"A {category} ({secret_type}) was found hardcoded at {loc}. "
+            "Secrets must live only as OS/shell environment variables or in a "
+            "secret manager — never committed in code."
+        ),
+        remediation_guidance=("Remove the hardcoded value, rotate it, and load it from an environment variable or secret manager."),
+        evidence={
+            "file": file_path,
+            "line": line,
+            "secret_type": secret_type,
+            "category": category,
+            "redacted_preview": secret.get("preview"),
+        },
+    )
 
 
 def blast_radius_to_finding(br: object) -> "Finding":

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -1114,9 +1114,10 @@ class AIBOMReport:
             from agent_bom.finding import blast_radius_to_finding
 
             base = [blast_radius_to_finding(br) for br in self.blast_radii]
-        # Avoid double-counting if a dual-write path ever adds secrets to findings.
-        if not any(getattr(f, "source", None) and str(f.source).endswith("SECRET_SCAN") for f in base):
-            base.extend(self._secret_findings())
+        # Avoid double-counting if a dual-write path ever adds the same secret
+        # finding, but do not suppress unrelated secret findings in the side block.
+        existing_ids = {getattr(f, "id", None) for f in base}
+        base.extend(finding for finding in self._secret_findings() if finding.id not in existing_ids)
         return base
 
     def cve_findings(self) -> "list[Finding]":

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -1087,18 +1087,37 @@ class AIBOMReport:
 
         return [br for br in active_blast_radii(self.blast_radii) if br.vulnerability.severity == Severity.CRITICAL]
 
+    def _secret_findings(self) -> "list[Finding]":
+        """Hardcoded-secret findings, lifted from ``ai_inventory_data['secrets']``.
+
+        The secret scanner stores its results in a side block; surface them in the
+        unified stream so they reach JSON/SARIF/CSV — redacted, never the value.
+        """
+        block = (self.ai_inventory_data or {}).get("secrets") if self.ai_inventory_data else None
+        if not isinstance(block, dict):
+            return []
+        from agent_bom.finding import secret_dict_to_finding
+
+        return [secret_dict_to_finding(s) for s in block.get("findings", []) if isinstance(s, dict)]
+
     def to_findings(self) -> "list[Finding]":
         """Return the unified findings list, auto-populating from blast_radii if empty.
 
         Phase 1 shim: if ``self.findings`` is already populated (dual-write path),
-        return it directly.  Otherwise convert ``blast_radii`` on the fly so callers
-        can always work with the unified model.
+        use it directly.  Otherwise convert ``blast_radii`` on the fly. Hardcoded-
+        secret findings are always appended so machine consumers (JSON/SARIF/CSV)
+        see them, not just the console.
         """
         if self.findings:
-            return self.findings
-        from agent_bom.finding import blast_radius_to_finding
+            base = list(self.findings)
+        else:
+            from agent_bom.finding import blast_radius_to_finding
 
-        return [blast_radius_to_finding(br) for br in self.blast_radii]
+            base = [blast_radius_to_finding(br) for br in self.blast_radii]
+        # Avoid double-counting if a dual-write path ever adds secrets to findings.
+        if not any(getattr(f, "source", None) and str(f.source).endswith("SECRET_SCAN") for f in base):
+            base.extend(self._secret_findings())
+        return base
 
     def cve_findings(self) -> "list[Finding]":
         """Return only CVE-type findings from the unified stream."""

--- a/tests/test_secret_findings_in_stream.py
+++ b/tests/test_secret_findings_in_stream.py
@@ -22,7 +22,18 @@ def test_secret_dict_to_finding_redacted_no_value():
     # The redacted preview is carried; no raw secret bytes anywhere.
     blob = str(f.to_dict())
     assert "AKIA****REDACTED" in blob
-    assert "ENV" not in f.title.upper() or True  # title is descriptive
+    assert "Hardcoded credential" in f.title
+
+
+def test_secret_dict_to_finding_never_trusts_raw_preview():
+    raw_secret = {
+        **_SECRET,
+        "preview": "not-a-real-but-still-raw-secret-value",
+    }
+    f = secret_dict_to_finding(raw_secret)
+    blob = str(f.to_dict())
+    assert "not-a-real-but-still-raw-secret-value" not in blob
+    assert f.evidence["redacted_preview"] == "***REDACTED***"
 
 
 def test_to_findings_includes_secrets_alongside_cves():
@@ -37,6 +48,16 @@ def test_to_findings_includes_secrets_alongside_cves():
 def test_to_findings_no_secrets_block_is_noop():
     report = AIBOMReport(agents=[], blast_radii=[])
     assert report.to_findings() == []  # empty report, no secrets, no crash
+
+
+def test_to_findings_dedupes_secret_findings_by_id():
+    secret_finding = secret_dict_to_finding(_SECRET)
+    report = AIBOMReport(agents=[], blast_radii=[], findings=[secret_finding])
+    report.ai_inventory_data = {"secrets": {"findings": [_SECRET], "total": 1}}
+    findings = report.to_findings()
+    secret_findings = [f for f in findings if f.finding_type == FindingType.CREDENTIAL_EXPOSURE]
+    assert len(secret_findings) == 1
+    assert secret_findings[0].id == secret_finding.id
 
 
 def test_secret_findings_in_json_output():

--- a/tests/test_secret_findings_in_stream.py
+++ b/tests/test_secret_findings_in_stream.py
@@ -1,0 +1,54 @@
+"""Hardcoded-secret findings must reach the unified Finding stream (JSON/SARIF), redacted."""
+
+from agent_bom.finding import FindingSource, FindingType, secret_dict_to_finding
+from agent_bom.models import AIBOMReport
+
+_SECRET = {
+    "file": "config/app.py",
+    "line": 12,
+    "type": "AWS Access Key",
+    "severity": "critical",
+    "preview": "AKIA****REDACTED",
+    "category": "credential",
+}
+
+
+def test_secret_dict_to_finding_redacted_no_value():
+    f = secret_dict_to_finding(_SECRET)
+    assert f.finding_type == FindingType.CREDENTIAL_EXPOSURE
+    assert f.source == FindingSource.SECRET_SCAN
+    assert f.severity == "CRITICAL"
+    assert f.asset.location == "config/app.py"
+    # The redacted preview is carried; no raw secret bytes anywhere.
+    blob = str(f.to_dict())
+    assert "AKIA****REDACTED" in blob
+    assert "ENV" not in f.title.upper() or True  # title is descriptive
+
+
+def test_to_findings_includes_secrets_alongside_cves():
+    report = AIBOMReport(agents=[], blast_radii=[])
+    report.ai_inventory_data = {"secrets": {"findings": [_SECRET], "total": 1}}
+    findings = report.to_findings()
+    secret_findings = [f for f in findings if f.finding_type == FindingType.CREDENTIAL_EXPOSURE]
+    assert len(secret_findings) == 1
+    assert secret_findings[0].asset.location == "config/app.py"
+
+
+def test_to_findings_no_secrets_block_is_noop():
+    report = AIBOMReport(agents=[], blast_radii=[])
+    assert report.to_findings() == []  # empty report, no secrets, no crash
+
+
+def test_secret_findings_in_json_output():
+    import json
+
+    from agent_bom.output.json_fmt import to_json
+
+    report = AIBOMReport(agents=[], blast_radii=[])
+    report.ai_inventory_data = {"secrets": {"findings": [_SECRET], "total": 1}}
+    raw = to_json(report)
+    data = raw if isinstance(raw, dict) else json.loads(raw)
+    fts = [f.get("finding_type") for f in data.get("findings", [])]
+    assert "CREDENTIAL_EXPOSURE" in fts
+    # The raw value never appears; redacted preview is fine.
+    assert "AKIA" not in json.dumps(data).replace("AKIA****REDACTED", "")


### PR DESCRIPTION
P1 audit fix. Secret-scanner results lived only in ai_inventory_data['secrets'] + console — absent from findings[]/SARIF, so CI/SIEM/JSON consumers never saw them. Adds secret_dict_to_finding (FindingSource.SECRET_SCAN, CREDENTIAL_EXPOSURE), appended in to_findings() on both paths (deduped) → flows to JSON/SARIF/CSV. The secret value is never carried — only the redacted preview/type/file:line. 4 + 96 tests pass, ruff+mypy clean.