### PR TITLE
fix(parsers): cover Cargo target and workspace dependencies

### DIFF
--- a/src/agent_bom/parsers/compiled_parsers.py
+++ b/src/agent_bom/parsers/compiled_parsers.py
@@ -778,7 +778,7 @@ def parse_maven_packages(directory: Path, *, resolve_versions: bool = False) -> 
     return unique
 
 
-def _cargo_dep_version(spec: object) -> Optional[str]:
+def _cargo_dep_version(spec: object, workspace_spec: object | None = None) -> Optional[str]:
     """Extract the declared version from a Cargo.toml dependency spec.
 
     Accepts the short form (``serde = "1.0"``) and the table form
@@ -788,9 +788,34 @@ def _cargo_dep_version(spec: object) -> Optional[str]:
     if isinstance(spec, str):
         return spec or None
     if isinstance(spec, dict):
+        if spec.get("workspace") is True:
+            return _cargo_dep_version(workspace_spec)
+        if "path" in spec or "git" in spec:
+            return None
         version = spec.get("version")
         return version if isinstance(version, str) and version else None
     return None
+
+
+def _cargo_dependency_tables(data: dict) -> list[tuple[dict, bool]]:
+    """Return Cargo dependency tables with direct/development attribution."""
+
+    tables: list[tuple[dict, bool]] = []
+    for table, direct in (("dependencies", True), ("dev-dependencies", False), ("build-dependencies", False)):
+        deps = data.get(table)
+        if isinstance(deps, dict):
+            tables.append((deps, direct))
+
+    targets = data.get("target")
+    if isinstance(targets, dict):
+        for target_cfg in targets.values():
+            if not isinstance(target_cfg, dict):
+                continue
+            for table, direct in (("dependencies", True), ("dev-dependencies", False), ("build-dependencies", False)):
+                deps = target_cfg.get(table)
+                if isinstance(deps, dict):
+                    tables.append((deps, direct))
+    return tables
 
 
 def _parse_cargo_toml(cargo_toml: Path) -> list[Package]:
@@ -809,12 +834,14 @@ def _parse_cargo_toml(cargo_toml: Path) -> list[Package]:
 
     pkgs: list[Package] = []
     seen: set[str] = set()
-    for table, direct in (("dependencies", True), ("dev-dependencies", False), ("build-dependencies", False)):
-        deps = data.get(table)
-        if not isinstance(deps, dict):
-            continue
+    workspace = data.get("workspace")
+    workspace_deps = workspace.get("dependencies") if isinstance(workspace, dict) else None
+    if not isinstance(workspace_deps, dict):
+        workspace_deps = {}
+
+    for deps, direct in _cargo_dependency_tables(data):
         for name, spec in deps.items():
-            version = _cargo_dep_version(spec)
+            version = _cargo_dep_version(spec, workspace_deps.get(name))
             if not version or name in seen:
                 continue
             seen.add(name)

--- a/tests/test_project_mode.py
+++ b/tests/test_project_mode.py
@@ -518,6 +518,30 @@ def test_cargo_toml_manifest_fallback_when_no_lockfile(tmp_path):
     assert all(p.version_source == "manifest" for p in pkgs)
 
 
+def test_cargo_toml_manifest_fallback_handles_target_and_workspace_deps(tmp_path):
+    from agent_bom.parsers.compiled_parsers import parse_cargo_packages
+
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "app"\n'
+        "[workspace.dependencies]\n"
+        'serde = "1.0.193"\n'
+        "[dependencies]\n"
+        "serde = { workspace = true }\n"
+        'git-dep = { git = "https://example.invalid/repo", version = "1.0" }\n'
+        "[target.'cfg(unix)'.dependencies]\n"
+        'nix = "0.27"\n'
+        "[target.'cfg(windows)'.dev-dependencies]\n"
+        'winapi = "0.3"\n'
+    )
+
+    pkgs = parse_cargo_packages(tmp_path)
+    versions = {p.name: p.version for p in pkgs}
+
+    assert versions == {"serde": "1.0.193", "nix": "0.27", "winapi": "0.3"}
+    assert {p.name: p.is_direct for p in pkgs} == {"serde": True, "nix": True, "winapi": False}
+    assert "git-dep" not in versions
+
+
 def test_cargo_lockfile_preferred_over_manifest(tmp_path):
     from agent_bom.parsers.compiled_parsers import parse_cargo_packages
 


### PR DESCRIPTION
Summary
- Parse target-specific Cargo.toml dependency tables when no Cargo.lock exists.
- Resolve workspace dependency declarations from [workspace.dependencies] instead of dropping them.
- Keep path/git/local dependencies out of vulnerability matching so manifests stay accurate.

Verification
- uv run pytest -q tests/test_project_mode.py -vv --tb=short
- uv run ruff check src/agent_bom/parsers/compiled_parsers.py tests/test_project_mode.py
- git diff --check origin/main..HEAD

Notes
- Follow-up to the manifest-only Cargo parser fix; this keeps Cargo matching deterministic for common workspace layouts without adding network lookups or credentials.