### PR TITLE
fix(audit): extra=forbid gaps + CLI lateral graph + single-framework narrative scoping (P2 batch)

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -50,6 +50,7 @@
         "type": "object"
       },
       "AuditExportVerifyRequest": {
+        "additionalProperties": false,
         "properties": {
           "payload": {
             "description": "Audit export payload object, JSON string, or JSONL text",
@@ -84,6 +85,7 @@
         "type": "object"
       },
       "BrowserSessionRequest": {
+        "additionalProperties": false,
         "properties": {
           "api_key": {
             "description": "API key to exchange for a same-origin httpOnly browser session cookie",
@@ -1608,6 +1610,7 @@
         "type": "object"
       },
       "GraphQueryRequest": {
+        "additionalProperties": false,
         "properties": {
           "compliance_prefixes": {
             "items": {
@@ -2172,6 +2175,7 @@
         "type": "object"
       },
       "PresetCreate": {
+        "additionalProperties": false,
         "properties": {
           "description": {
             "default": "",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -31,6 +31,7 @@ components:
       title: AnalyticsHealth
       type: object
     AuditExportVerifyRequest:
+      additionalProperties: false
       properties:
         payload:
           description: Audit export payload object, JSON string, or JSONL text
@@ -57,6 +58,7 @@ components:
       title: BrowserExtensionsRequest
       type: object
     BrowserSessionRequest:
+      additionalProperties: false
       properties:
         api_key:
           description: API key to exchange for a same-origin httpOnly browser session
@@ -1047,6 +1049,7 @@ components:
       title: GraphDeployDecisionRequest
       type: object
     GraphQueryRequest:
+      additionalProperties: false
       properties:
         compliance_prefixes:
           items:
@@ -1451,6 +1454,7 @@ components:
       title: PolicyUpdate
       type: object
     PresetCreate:
+      additionalProperties: false
       properties:
         description:
           default: ''

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -42,7 +42,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Header, HTTPException, Query, Request, Response
 from fastapi.responses import JSONResponse, PlainTextResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from agent_bom.api.models import (
     CreateKeyRequest,
@@ -66,6 +66,7 @@ _logger = logging.getLogger(__name__)
 
 
 class BrowserSessionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     api_key: str = Field(
         ...,
         min_length=1,
@@ -74,6 +75,7 @@ class BrowserSessionRequest(BaseModel):
 
 
 class AuditExportVerifyRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     payload: Any = Field(..., description="Audit export payload object, JSON string, or JSONL text")
     signature: str = Field(..., min_length=64, max_length=128, description="X-Agent-Bom-Audit-Export-Signature value")
 

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -1176,12 +1176,14 @@ async def _graph_store_call(fn, /, *args, **kwargs):
 
 
 class PresetCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     name: str
     description: str = ""
     filters: dict
 
 
 class GraphQueryRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     roots: list[str] = Field(..., min_length=1, description="One or more starting node IDs")
     scan_id: str = ""
     direction: Literal["forward", "reverse", "both"] = "forward"

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -1794,7 +1794,11 @@ def scan(
         }
 
     # ── Context graph: lateral movement analysis ────────────────────
-    if context_graph_flag and report.blast_radii:
+    # Build whenever requested — credential pivots / SHARES_CREDENTIAL lateral
+    # edges exist independent of any CVE, so gating on blast_radii hid the
+    # credential lateral graph for vuln-free estates (the case credential-risk
+    # ranking already surfaces without a CVE).
+    if context_graph_flag:
         from agent_bom.context_graph import (
             build_context_graph,
             compute_interaction_risks,

--- a/src/agent_bom/output/compliance_narrative.py
+++ b/src/agent_bom/output/compliance_narrative.py
@@ -387,17 +387,28 @@ def _build_framework_narrative(
 
 def _build_remediation_impact(
     blast_radii_dicts: list[dict],
+    framework_slug: str | None = None,
 ) -> list[RemediationImpact]:
     """Cross-reference fix versions with control tags to build RemediationImpact entries.
 
     Groups blast radius entries by (package, current_version, fix_version),
-    collects all framework control codes triggered, and generates a narrative.
+    collects framework control codes triggered, and generates a narrative.
+
+    When ``framework_slug`` is set, only that framework's controls are listed —
+    so a single-framework report (e.g. ``--framework soc2``) doesn't bleed ISO /
+    NIST / EU-AI-Act control IDs into its remediation section.
     """
     from agent_bom.compliance_coverage import TAG_MAPPED_FRAMEWORKS
 
     field_to_framework = {
         metadata.tag_field: _DISPLAY_NAME_OVERRIDES.get(metadata.slug, metadata.report_label) for metadata in TAG_MAPPED_FRAMEWORKS
     }
+    if framework_slug:
+        try:
+            _catalog, tag_field, display_name = _get_catalog(framework_slug)
+            field_to_framework = {tag_field: display_name}
+        except ValueError:
+            pass  # unknown slug — fall back to all frameworks
 
     # Group: key = (pkg_name_version, fix_version)
     # value = {controls: set, frameworks: set}
@@ -660,7 +671,7 @@ def generate_compliance_narrative(
 
     framework_narratives: list[FrameworkNarrative] = [_build_framework_narrative(slug, blast_dicts) for slug in slugs]
 
-    remediation_impact = _build_remediation_impact(blast_dicts)
+    remediation_impact = _build_remediation_impact(blast_dicts, framework)
 
     total_vulns = len(blast_dicts)
     critical_count = sum(1 for b in blast_dicts if (b.get("severity") or "") == "critical")

--- a/tests/test_audit_p2_batch.py
+++ b/tests/test_audit_p2_batch.py
@@ -1,0 +1,40 @@
+"""P2 audit-polish batch: extra=forbid on inline route models + framework-scoped narrative."""
+
+import pytest
+from pydantic import ValidationError
+
+
+@pytest.mark.parametrize(
+    "module, cls_name, valid",
+    [
+        ("agent_bom.api.routes.graph", "GraphQueryRequest", {"roots": ["n1"]}),
+        ("agent_bom.api.routes.graph", "PresetCreate", {"name": "p", "filters": {}}),
+        ("agent_bom.api.routes.enterprise", "BrowserSessionRequest", {"api_key": "k"}),
+        ("agent_bom.api.routes.enterprise", "AuditExportVerifyRequest", {"payload": {}, "signature": "x" * 64}),
+    ],
+)
+def test_inline_route_models_reject_unknown_fields(module, cls_name, valid):
+    import importlib
+
+    cls = getattr(importlib.import_module(module), cls_name)
+    cls(**valid)  # legit body still works
+    with pytest.raises(ValidationError):
+        cls(**{**valid, "definitely_unknown_field": 1})
+
+
+def test_compliance_narrative_remediation_scoped_to_requested_framework():
+    from agent_bom.output.compliance_narrative import _build_remediation_impact
+
+    br = [
+        {
+            "package": "flask@0.12",
+            "fixed_version": "2.3.2",
+            "soc2_tags": ["CC6.1"],
+            "iso_27001_tags": ["A.5.19"],
+            "nist_csf_tags": ["ID.RA-01"],
+        }
+    ]
+    all_fw = {f for i in _build_remediation_impact(br) for f in i.frameworks_impacted}
+    soc2 = {f for i in _build_remediation_impact(br, "soc2") for f in i.frameworks_impacted}
+    assert len(all_fw) >= 3  # unscoped lists every framework
+    assert soc2 and all("SOC" in f for f in soc2)  # scoped: only SOC 2


### PR DESCRIPTION
Closes three post-audit P2 gaps in one batch.

## 1. Reject unknown fields on inline route models
Four request models still defaulted to `extra="ignore"`, silently dropping
unknown fields instead of returning 422:
- `GraphQueryRequest`, `PresetCreate` (`api/routes/graph.py`)
- `BrowserSessionRequest`, `AuditExportVerifyRequest` (`api/routes/enterprise.py`)

All now use `ConfigDict(extra="forbid")`, matching the hardened request
surface. OpenAPI artifacts regenerated (`additionalProperties:false` on the
four bodies).

## 2. Build the CLI context graph without a CVE
The context graph was gated on `report.blast_radii`, so a vuln-free estate
got no lateral-movement graph — even though credential pivots and
`SHARES_CREDENTIAL` edges exist independent of any CVE (the same case
credential-risk ranking already surfaces). Gate dropped.

## 3. Scope the compliance narrative to the requested framework
A single `--framework X` request leaked control IDs from the other
frameworks into the remediation-impact section. `_build_remediation_impact`
now scopes its framework map to the requested slug.

## Tests
`tests/test_audit_p2_batch.py`: four models reject unknown fields; narrative
remediation impact scopes to the requested framework. Existing
compliance/graph route suites unchanged (82 passed). `uv run ruff check` +
`uv run mypy src/` clean; OpenAPI + v1-schema `--check` gates green.