### PR TITLE
fix(registry): reject Smithery proxy upstream publishes

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -60,6 +60,13 @@ jobs:
             echo "enabled=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          case "$SMITHERY_MCP_URL" in
+            https://server.smithery.ai/*|http://server.smithery.ai/*)
+              echo "::warning::SMITHERY_MCP_URL points at Smithery's hosted proxy, not agent-bom's upstream MCP origin. Skipping Smithery publish to avoid publishing the proxy back to itself."
+              echo "enabled=false" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
           if [ -z "${SMITHERY_API_TOKEN:-}" ]; then
             echo "::notice::SMITHERY_API_TOKEN not configured — skipping Smithery publish"
             echo "enabled=false" >> "$GITHUB_OUTPUT"
@@ -67,13 +74,12 @@ jobs:
           fi
           echo "enabled=true" >> "$GITHUB_OUTPUT"
 
-      # Post-publish liveness probe of the Smithery-hosted endpoint. Best-effort
+      # Post-publish liveness probe of the configured upstream endpoint. Best-effort
       # confirmation, NOT a gate: Smithery rebuilds the server asynchronously
-      # (the new version may not be live for minutes) and the hosted endpoint is
-      # auth-gated with no public /health — both the correct secure posture, not
-      # a failure. A hard failure here previously red-failed the whole publish
-      # even though the catalog push (next step) succeeded. Warn instead so
-      # staleness stays visible without burning the run.
+      # (the new version may not be live for minutes). A hard failure here
+      # previously red-failed the whole publish even though the catalog push
+      # (next step) succeeded. Warn instead so staleness stays visible without
+      # burning the run.
       - name: Validate Smithery public endpoint
         if: steps.smithery_config.outputs.enabled == 'true'
         continue-on-error: true
@@ -100,10 +106,10 @@ jobs:
           except Exception:
               print('unknown')
           ")
-            echo "Smithery hosted endpoint version: ${PUBLIC_VERSION}"
-            echo "Smithery hosted endpoint tool count: ${PUBLIC_TOOLS}"
+            echo "Smithery upstream endpoint version: ${PUBLIC_VERSION}"
+            echo "Smithery upstream endpoint tool count: ${PUBLIC_TOOLS}"
           else
-            echo "::warning::Could not read version from the Smithery hosted endpoint (${SMITHERY_MCP_URL}). Expected while Smithery is still rebuilding (async) or because the endpoint is auth-gated / has no public /health. The catalog publish below still runs; confirm at https://smithery.ai/server/@agent-bom/agent-bom"
+            echo "::warning::Could not read version from the configured Smithery upstream endpoint (${SMITHERY_MCP_URL}). Expected while Smithery is still rebuilding (async). The catalog publish below still runs; deployment-freshness owns hard drift detection."
           fi
 
       - name: Publish to Smithery

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -423,15 +423,12 @@ def test_security_scan_npm_installs_use_network_retries():
 
 
 def test_publish_registries_workflow_validates_smithery_best_effort_and_curated_clawhub_set():
-    """Smithery's hosted endpoint is reached through Smithery's own authenticated
-    proxy (direct access is auth-gated) and is rebuilt asynchronously, so the
-    post-publish liveness probe must be best-effort (non-blocking), not a gate
-    that forbids auth. ClawHub must still publish the curated skill set, not an
-    omnibus skill."""
+    """Smithery publishing must never use Smithery's proxy as its upstream."""
     workflow = (ROOT / ".github" / "workflows" / "publish-registries.yml").read_text()
     assert "SMITHERY_MCP_URL" in workflow
-    # The Smithery probe no longer forbids auth (auth-gated is the correct,
-    # secure posture) and no longer hard-fails the publish on async rebuild lag.
+    assert "server.smithery.ai" in workflow
+    assert "avoid publishing the proxy back to itself" in workflow
+    # The Smithery probe no longer hard-fails the publish on async rebuild lag.
     assert "--forbid-auth-required" not in workflow
     assert "continue-on-error: true" in workflow
     assert "integrations/openclaw/scan" in workflow


### PR DESCRIPTION
Summary
- Reject `SMITHERY_MCP_URL` values that point at Smithery's hosted proxy before publishing a Smithery release.
- Align publish workflow wording with the deployment/surface freshness contract: `SMITHERY_MCP_URL` must be an agent-bom upstream MCP origin, not the Smithery proxy.
- Keep the Glama/ClawHub publish paths unchanged.

Verification
- `uv run pytest -q tests/test_deployment.py::test_publish_registries_workflow_validates_smithery_best_effort_and_curated_clawhub_set tests/test_deployment.py::test_deployment_freshness_workflow_uses_bearer_token_and_parses_tool_count tests/test_surface_freshness.py`
- `uv run ruff check tests/test_deployment.py`
- `git diff --check`
- pre-commit hooks from `git commit`

Notes
- Refs #3014. This prevents a bad Smithery proxy URL from being published back as the upstream. The issue still requires `SMITHERY_MCP_URL` to be changed to a real upstream endpoint before the freshness workflow can self-close.
