### PR TITLE
fix(graph): anchor subscription-scoped cloud misconfigurations to the account node

### DIFF
--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -599,6 +599,7 @@ def build_unified_graph_from_report(
         if not cis_data:
             continue
         checks = cis_data.get("checks", [])
+        cloud_account_id = _clean_graph_part(cis_data.get("subscription_id") or cis_data.get("account_id"))
         for check in checks:
             if str(check.get("status", "")).upper() != "FAIL":
                 continue
@@ -645,6 +646,31 @@ def build_unified_graph_from_report(
                     UnifiedEdge(
                         source=misconfig_id,
                         target=resource_node_id,
+                        relationship=RelationshipType.AFFECTS,
+                    )
+                )
+
+            # Subscription/tenant-scoped controls (Defender plans, Activity
+            # Log alerts, Network Watcher, security contacts) carry no
+            # ``resource_ids``. Anchor them to the cloud account node so they
+            # are reachable by blast-radius / attack-path analysis instead of
+            # floating as orphan nodes that never surface to the user.
+            if not resource_ids and cloud_provider and cloud_account_id:
+                account_node_id = _identity_node_id(EntityType.ACCOUNT, cloud_provider, cloud_account_id)
+                graph.add_node(
+                    UnifiedNode(
+                        id=account_node_id,
+                        entity_type=EntityType.ACCOUNT,
+                        label=cloud_account_id,
+                        attributes={"account_id": cloud_account_id, "cloud_provider": cloud_provider},
+                        data_sources=[section_key],
+                        dimensions=NodeDimensions(cloud_provider=cloud_provider),
+                    )
+                )
+                graph.add_edge(
+                    UnifiedEdge(
+                        source=misconfig_id,
+                        target=account_node_id,
                         relationship=RelationshipType.AFFECTS,
                     )
                 )

--- a/tests/test_cloud_misconfig_graph_anchor.py
+++ b/tests/test_cloud_misconfig_graph_anchor.py
@@ -1,0 +1,70 @@
+"""Subscription-scoped cloud CIS misconfigurations must not orphan in the graph.
+
+A live Azure scan showed that CIS controls with no specific ``resource_ids``
+(Defender plans, Activity Log alerts, Network Watcher, security contacts) were
+added as misconfiguration nodes but linked to nothing — so blast-radius and
+attack-path analysis never reached them and they never surfaced to the user.
+They are now anchored to the cloud account node.
+"""
+
+from __future__ import annotations
+
+from agent_bom.graph.builder import build_unified_graph_from_report
+
+
+def _report(checks: list[dict]) -> dict:
+    return {
+        "azure_cis_benchmark": {
+            "subscription_id": "sub-123",
+            "checks": checks,
+        }
+    }
+
+
+def _build(checks: list[dict]):
+    g = build_unified_graph_from_report(_report(checks))
+    edges = list(g.edges.values()) if isinstance(g.edges, dict) else list(g.edges)
+    connected = set()
+    for e in edges:
+        connected.add(e.source)
+        connected.add(e.target)
+    return g, edges, connected
+
+
+def test_subscription_scoped_misconfig_anchored_to_account() -> None:
+    g, edges, connected = _build(
+        [
+            {
+                "check_id": "2.12",
+                "title": "Security contact email configured",
+                "status": "FAIL",
+                "severity": "medium",
+                "resource_ids": [],  # subscription-scoped — no specific resource
+            }
+        ]
+    )
+    misconfig_id = "misconfig:azure_cis_benchmark:2.12"
+    account_id = "account:azure:sub-123"
+    assert misconfig_id in g.nodes
+    assert account_id in g.nodes, "account node not created for subscription-scoped control"
+    assert misconfig_id in connected, "subscription-scoped misconfig left orphaned"
+    assert any(e.source == misconfig_id and e.target == account_id for e in edges), "misconfig not linked to its cloud account"
+
+
+def test_resource_scoped_misconfig_still_links_to_resource_not_account() -> None:
+    g, edges, connected = _build(
+        [
+            {
+                "check_id": "3.2",
+                "title": "Storage default network access denied",
+                "status": "FAIL",
+                "severity": "high",
+                "resource_ids": ["mystorageacct"],
+            }
+        ]
+    )
+    misconfig_id = "misconfig:azure_cis_benchmark:3.2"
+    assert misconfig_id in connected
+    # resource-scoped checks keep their resource edge; the account anchor is
+    # only the fallback for checks with no resource.
+    assert any(e.source == misconfig_id and "cloud_resource" in e.target for e in edges), "resource-scoped misconfig lost its resource link"


### PR DESCRIPTION
Found by a live Azure scan: **11 of 18 CIS misconfiguration nodes were floating
at degree 0** in the unified graph.

## Root cause
The graph builder links each misconfiguration only to the `cloud_resource`
nodes built from the check's `resource_ids`. CIS controls scoped to the whole
subscription/tenant carry no `resource_ids` — Defender plans (2.x), Activity
Log alerts (5.1.x), Network Watcher (6.x), security-contact settings — so they
were created as nodes but connected to nothing. Orphan nodes never enter
blast-radius or attack-path analysis, so those misconfigurations never surfaced
to the user even though they're real, high/medium-severity findings.

## Fix
Subscription/tenant-scoped checks now anchor to the cloud **account** node
(`account:<provider>:<subscription_id>`) via `AFFECTS`, creating that node when
a CIS-only scan hasn't already built it from inventory. Resource-scoped checks
(e.g. storage 3.x) keep their existing resource edges — the account anchor is
only the fallback for checks with no resource.

## Verified
On the live subscription, orphaned cloud misconfigurations went **11 → 0** (the
3 nodes still at degree 0 are unrelated `skill_audit` findings). New tests cover
both the subscription-scoped anchor and that resource-scoped checks keep their
resource link. Graph suite: 559 passed, no regressions. `ruff` + `mypy` clean.