### PR TITLE
feat(cloud): normalized cross-cloud resource model (foundation)

### DIFF
--- a/src/agent_bom/cloud/resource_model.py
+++ b/src/agent_bom/cloud/resource_model.py
@@ -1,0 +1,149 @@
+"""Normalized, provider-agnostic cloud resource model.
+
+Each provider's inventory historically emitted its own dict shape
+(``storage_accounts`` / ``instances`` / ``security_groups`` for Azure, and
+different keys for AWS/GCP). That makes the graph, CIS, and findings layers
+re-learn every provider's vocabulary and blocks cross-cloud normalization.
+
+:class:`CloudResource` is the single shape every provider maps onto. Adapters
+translate native resources into normalized ones (``provider`` + normalized
+:class:`CloudResourceType` + the native type string for provenance); downstream
+consumers read the normalized fields and never the provider-specific dicts.
+
+This module is additive — it does not change existing inventory output. It
+provides the normalized *view* that later phases (graph ingestion, gap-fill,
+AWS/GCP adapters) consume.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class CloudResourceType(str, Enum):
+    """Provider-agnostic resource categories.
+
+    Intentionally broad so AWS/GCP equivalents map onto the same member
+    (e.g. Azure Storage Account, AWS S3 bucket, and GCS bucket are all
+    :attr:`OBJECT_STORE`).
+    """
+
+    COMPUTE_INSTANCE = "compute_instance"  # VM / EC2 / GCE
+    CONTAINER_CLUSTER = "container_cluster"  # AKS / EKS / GKE
+    CONTAINER_APP = "container_app"  # Container Apps / App Runner / Cloud Run
+    CONTAINER_INSTANCE = "container_instance"  # ACI / Fargate task
+    SERVERLESS_FUNCTION = "serverless_function"  # Functions / Lambda / Cloud Functions
+    OBJECT_STORE = "object_store"  # Storage Account / S3 / GCS
+    BLOCK_STORAGE = "block_storage"  # Managed Disk / EBS / PD
+    SECRET_STORE = "secret_store"  # Key Vault / Secrets Manager / Secret Manager
+    DATABASE = "database"  # SQL / Cosmos / RDS / Spanner / BigQuery
+    CACHE = "cache"  # Redis / ElastiCache / Memorystore
+    MESSAGING = "messaging"  # Service Bus / SQS-SNS / Pub-Sub
+    VIRTUAL_NETWORK = "virtual_network"  # VNet / VPC
+    NETWORK_SECURITY_GROUP = "network_security_group"  # NSG / Security Group / Firewall
+    LOAD_BALANCER = "load_balancer"
+    PUBLIC_IP = "public_ip"
+    CONTAINER_REGISTRY = "container_registry"  # ACR / ECR / Artifact Registry
+    MANAGED_IDENTITY = "managed_identity"  # User-assigned MI / IAM role / service account
+    AI_SERVICE = "ai_service"  # Azure OpenAI / Bedrock / Vertex
+    AI_MODEL_DEPLOYMENT = "ai_model_deployment"
+    ML_WORKSPACE = "ml_workspace"  # Azure ML / SageMaker / Vertex Workbench
+    OTHER = "other"
+
+
+@dataclass(frozen=True)
+class CloudResource:
+    """One cloud resource, normalized across providers.
+
+    ``native_type`` keeps the provider-native type string (e.g.
+    ``Microsoft.Storage/storageAccounts``) for provenance and round-tripping;
+    ``resource_type`` is the normalized category consumers branch on.
+    """
+
+    provider: str  # "azure" | "aws" | "gcp"
+    resource_type: CloudResourceType
+    native_type: str
+    resource_id: str  # provider-native id / ARN / self-link
+    name: str
+    account: str = ""  # subscription id / account id / project id
+    region: str = ""
+    resource_group: str = ""  # RG (azure) / project (gcp) / "" (aws)
+    tags: dict[str, str] = field(default_factory=dict)
+    owner: str = ""
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "resource_type": self.resource_type.value,
+            "native_type": self.native_type,
+            "resource_id": self.resource_id,
+            "name": self.name,
+            "account": self.account,
+            "region": self.region,
+            "resource_group": self.resource_group,
+            "tags": dict(self.tags),
+            "owner": self.owner,
+        }
+
+
+# Native Azure inventory collection -> (normalized type, native type string).
+_AZURE_COLLECTION_MAP: dict[str, tuple[CloudResourceType, str]] = {
+    "storage_accounts": (CloudResourceType.OBJECT_STORE, "Microsoft.Storage/storageAccounts"),
+    "instances": (CloudResourceType.COMPUTE_INSTANCE, "Microsoft.Compute/virtualMachines"),
+    "security_groups": (CloudResourceType.NETWORK_SECURITY_GROUP, "Microsoft.Network/networkSecurityGroups"),
+    "managed_identities": (CloudResourceType.MANAGED_IDENTITY, "Microsoft.ManagedIdentity/userAssignedIdentities"),
+}
+
+
+def normalize_azure_inventory(inventory: dict[str, Any]) -> list[CloudResource]:
+    """Map an Azure inventory payload onto normalized :class:`CloudResource`.
+
+    Reads the existing ``azure_inventory`` dict shape (``storage_accounts``,
+    ``instances`` …) without mutating it. Items missing an id or name are
+    skipped rather than emitted as blanks.
+    """
+    account = str(inventory.get("subscription_id") or inventory.get("account_id") or "")
+    resources: list[CloudResource] = []
+    for collection, (rtype, native_type) in _AZURE_COLLECTION_MAP.items():
+        for item in inventory.get(collection, []) or []:
+            if not isinstance(item, dict):
+                continue
+            resource_id = str(item.get("id") or "")
+            name = str(item.get("name") or "").strip()
+            if not resource_id and not name:
+                continue
+            tags = item.get("tags") or {}
+            resources.append(
+                CloudResource(
+                    provider="azure",
+                    resource_type=rtype,
+                    native_type=native_type,
+                    resource_id=resource_id,
+                    name=name,
+                    account=account,
+                    region=str(item.get("location") or ""),
+                    resource_group=str(item.get("resource_group") or ""),
+                    tags={str(k): str(v) for k, v in tags.items()} if isinstance(tags, dict) else {},
+                    raw=item,
+                )
+            )
+    return resources
+
+
+_PROVIDER_NORMALIZERS = {
+    "azure": normalize_azure_inventory,
+}
+
+
+def normalize_cloud_inventory(inventory: dict[str, Any]) -> list[CloudResource]:
+    """Dispatch to the per-provider normalizer based on ``inventory['provider']``.
+
+    Returns an empty list for providers without a normalizer yet (AWS/GCP land
+    here until their adapters are added), so callers can rely on the shape.
+    """
+    provider = str(inventory.get("provider") or "").lower()
+    normalizer = _PROVIDER_NORMALIZERS.get(provider)
+    return normalizer(inventory) if normalizer else []

--- a/tests/test_cloud_resource_model.py
+++ b/tests/test_cloud_resource_model.py
@@ -1,0 +1,69 @@
+"""Normalized cross-cloud resource model."""
+
+from __future__ import annotations
+
+from agent_bom.cloud.resource_model import (
+    CloudResource,
+    CloudResourceType,
+    normalize_azure_inventory,
+    normalize_cloud_inventory,
+)
+
+
+def _azure_inv() -> dict:
+    return {
+        "provider": "azure",
+        "subscription_id": "sub-1",
+        "storage_accounts": [
+            {"name": "stg1", "id": "/subscriptions/sub-1/.../stg1", "location": "eastus", "resource_group": "rg1", "tags": {"env": "prod"}},
+        ],
+        "instances": [
+            {"name": "vm1", "id": "/subscriptions/sub-1/.../vm1", "location": "westus", "resource_group": "rg2"},
+        ],
+        "security_groups": [{"name": "nsg1", "id": "/subscriptions/sub-1/.../nsg1"}],
+        "managed_identities": [{"name": "mi1", "id": "/subscriptions/sub-1/.../mi1"}],
+        "service_principals": [],
+    }
+
+
+def test_azure_inventory_maps_to_normalized_types() -> None:
+    resources = normalize_azure_inventory(_azure_inv())
+    by_type = {r.resource_type for r in resources}
+    assert by_type == {
+        CloudResourceType.OBJECT_STORE,
+        CloudResourceType.COMPUTE_INSTANCE,
+        CloudResourceType.NETWORK_SECURITY_GROUP,
+        CloudResourceType.MANAGED_IDENTITY,
+    }
+    stg = next(r for r in resources if r.resource_type is CloudResourceType.OBJECT_STORE)
+    assert stg.provider == "azure"
+    assert stg.native_type == "Microsoft.Storage/storageAccounts"
+    assert stg.account == "sub-1"
+    assert stg.region == "eastus"
+    assert stg.resource_group == "rg1"
+    assert stg.tags == {"env": "prod"}
+
+
+def test_blank_items_skipped() -> None:
+    inv = {"provider": "azure", "subscription_id": "s", "storage_accounts": [{}, {"name": "ok", "id": "x"}]}
+    assert len(normalize_azure_inventory(inv)) == 1
+
+
+def test_dispatch_unknown_provider_returns_empty() -> None:
+    assert normalize_cloud_inventory({"provider": "aws"}) == []
+    assert normalize_cloud_inventory({"provider": "azure", "subscription_id": "s"}) == []
+
+
+def test_to_dict_roundtrip_shape() -> None:
+    r = CloudResource(
+        provider="azure",
+        resource_type=CloudResourceType.SECRET_STORE,
+        native_type="Microsoft.KeyVault/vaults",
+        resource_id="id",
+        name="kv",
+        account="s",
+    )
+    d = r.to_dict()
+    assert d["resource_type"] == "secret_store"
+    assert d["native_type"] == "Microsoft.KeyVault/vaults"
+    assert "raw" not in d  # raw is provenance-only, not serialized


### PR DESCRIPTION
Foundation for cloud-agnostic resource coverage (Azure → AWS → GCP).

## Problem
Each provider's inventory emits its own dict shape — Azure: `storage_accounts`
/ `instances` / `security_groups` / `managed_identities`; AWS/GCP would each
invent their own. Every downstream layer (graph, CIS, findings) has to re-learn
provider vocabulary, and there's no normalized shape to build cross-cloud
features on.

## This PR (additive, no behavior change)
- `CloudResource` — one provider-agnostic shape: `provider`, normalized
  `CloudResourceType`, `native_type` (provenance, e.g.
  `Microsoft.Storage/storageAccounts`), `resource_id`, `name`, `account`
  (subscription/account/project), `region`, `resource_group`, `tags`, `owner`,
  `raw`.
- `CloudResourceType` — broad enough that Azure/AWS/GCP equivalents map to the
  same member (Storage Account / S3 / GCS → `OBJECT_STORE`).
- `normalize_azure_inventory()` maps the existing Azure payload onto it;
  `normalize_cloud_inventory()` dispatches on `provider` (AWS/GCP return `[]`
  until their adapters land).

Existing inventory output is untouched — this is the normalized *view* that the
next phases consume: graph ingestion of normalized resources, the Azure
type-coverage gap-fill (Key Vault, databases, AKS, ACR, networking, management
groups), and the AWS/GCP adapters.

## Verified
Unit tests cover the type mapping, blank-item skipping, unknown-provider
dispatch, and `to_dict` shape. Validated on the **live Azure inventory** — the
real storage account normalized to `object_store [eastus]`.