### PR TITLE
feat(cloud): inventory Key Vault, Container Registry, and databases (Azure)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,8 @@ azure = [
     "azure-mgmt-keyvault>=10.3",
     "azure-mgmt-sql>=3.0",
     "azure-mgmt-rdbms>=10.1",
+    "azure-mgmt-containerregistry>=10.3",
+    "azure-mgmt-cosmosdb>=9.5",
     "six>=1.16",
 ]
 gcp = [

--- a/src/agent_bom/cloud/azure_inventory.py
+++ b/src/agent_bom/cloud/azure_inventory.py
@@ -60,6 +60,11 @@ _AZURE_COMPUTE_PERMISSIONS: tuple[str, ...] = (
     "Microsoft.Network/networkSecurityGroups/read",
 )
 _AZURE_IDENTITY_PERMISSIONS: tuple[str, ...] = ("Microsoft.ManagedIdentity/userAssignedIdentities/read",)
+_AZURE_DATA_PERMISSIONS: tuple[str, ...] = (
+    "Microsoft.KeyVault/vaults/read",
+    "Microsoft.ContainerRegistry/registries/read",
+    "Microsoft.DocumentDB/databaseAccounts/read",
+)
 
 # Open-to-the-world source-address ranges that mark an NSG inbound rule as
 # internet-facing. The CNAPP overlay keys off this `network_exposure` shape.
@@ -82,6 +87,7 @@ def discover_inventory(
     include_storage: bool = True,
     include_compute: bool = True,
     include_identity: bool = True,
+    include_data: bool = True,
     force: bool = False,
 ) -> dict[str, Any]:
     """Enumerate the general Azure estate (storage, VMs + NSGs, identities).
@@ -118,6 +124,9 @@ def discover_inventory(
         "security_groups": [],
         "managed_identities": [],
         "service_principals": [],
+        "key_vaults": [],
+        "container_registries": [],
+        "databases": [],
         "warnings": [],
         "discovery_envelope": None,
     }
@@ -152,6 +161,9 @@ def discover_inventory(
     instances: list[dict[str, Any]] = []
     security_groups: list[dict[str, Any]] = []
     managed_identities: list[dict[str, Any]] = []
+    key_vaults: list[dict[str, Any]] = []
+    container_registries: list[dict[str, Any]] = []
+    databases: list[dict[str, Any]] = []
 
     if include_storage:
         storage_accounts = _discover_storage_accounts(credential, resolved_sub, warnings=warnings)
@@ -160,6 +172,10 @@ def discover_inventory(
         security_groups = _discover_nsgs(credential, resolved_sub, warnings=warnings)
     if include_identity:
         managed_identities = _discover_managed_identities(credential, resolved_sub, warnings=warnings)
+    if include_data:
+        key_vaults = _discover_key_vaults(credential, resolved_sub, warnings=warnings)
+        container_registries = _discover_container_registries(credential, resolved_sub, warnings=warnings)
+        databases = _discover_databases(credential, resolved_sub, warnings=warnings)
 
     permissions_used: list[str] = []
     if include_storage:
@@ -168,6 +184,8 @@ def discover_inventory(
         permissions_used.extend(_AZURE_COMPUTE_PERMISSIONS)
     if include_identity:
         permissions_used.extend(_AZURE_IDENTITY_PERMISSIONS)
+    if include_data:
+        permissions_used.extend(_AZURE_DATA_PERMISSIONS)
 
     envelope = DiscoveryEnvelope(
         scan_mode=ScanMode.CLOUD_READ_ONLY,
@@ -187,6 +205,9 @@ def discover_inventory(
         "security_groups": security_groups,
         "managed_identities": managed_identities,
         "service_principals": [],
+        "key_vaults": key_vaults,
+        "container_registries": container_registries,
+        "databases": databases,
         "warnings": warnings,
         "discovery_envelope": envelope.to_dict(),
     }
@@ -426,6 +447,123 @@ def _discover_managed_identities(credential: Any, subscription_id: str, *, warni
     except Exception as exc:  # noqa: BLE001
         warnings.append(f"Could not list Azure managed identities: {sanitize_discovery_warning(exc)}")
     return identities
+
+
+# ---------------------------------------------------------------------------
+# Data / secrets / registry (subscription-wide list)
+# ---------------------------------------------------------------------------
+
+
+def _discover_key_vaults(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate every Key Vault in the subscription (read-only).
+
+    Reads only control-plane metadata (URI, RBAC mode, public-network posture);
+    never reads secret/key/certificate material.
+    """
+    try:
+        from azure.mgmt.keyvault import KeyVaultManagementClient
+    except ImportError:
+        warnings.append("azure-mgmt-keyvault not installed. Skipping Key Vault inventory.")
+        return []
+
+    vaults: list[dict[str, Any]] = []
+    try:
+        client = KeyVaultManagementClient(credential, subscription_id)
+        for vault in client.vaults.list_by_subscription():
+            vault_id = str(getattr(vault, "id", "") or "")
+            name = str(getattr(vault, "name", "") or "").strip()
+            if not name:
+                continue
+            props = getattr(vault, "properties", None)
+            vaults.append(
+                {
+                    "name": name,
+                    "id": vault_id,
+                    "location": str(getattr(vault, "location", "") or ""),
+                    "resource_group": _resource_group_from_id(vault_id),
+                    "tags": _clean_tags(getattr(vault, "tags", None)),
+                    "uri": str(getattr(props, "vault_uri", "") or "") if props else "",
+                    "rbac_authorization": bool(getattr(props, "enable_rbac_authorization", False)) if props else False,
+                    "public_network_access": str(getattr(props, "public_network_access", "") or "") if props else "",
+                }
+            )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list Azure Key Vaults: {sanitize_discovery_warning(exc)}")
+    return vaults
+
+
+def _discover_container_registries(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate every Container Registry in the subscription (read-only)."""
+    try:
+        from azure.mgmt.containerregistry import ContainerRegistryManagementClient
+    except ImportError:
+        warnings.append("azure-mgmt-containerregistry not installed. Skipping Container Registry inventory.")
+        return []
+
+    registries: list[dict[str, Any]] = []
+    try:
+        client = ContainerRegistryManagementClient(credential, subscription_id)
+        for registry in client.registries.list():
+            registry_id = str(getattr(registry, "id", "") or "")
+            name = str(getattr(registry, "name", "") or "").strip()
+            if not name:
+                continue
+            sku = getattr(registry, "sku", None)
+            registries.append(
+                {
+                    "name": name,
+                    "id": registry_id,
+                    "location": str(getattr(registry, "location", "") or ""),
+                    "resource_group": _resource_group_from_id(registry_id),
+                    "tags": _clean_tags(getattr(registry, "tags", None)),
+                    "login_server": str(getattr(registry, "login_server", "") or ""),
+                    "sku": str(getattr(sku, "name", "") or "") if sku else "",
+                    "admin_user_enabled": bool(getattr(registry, "admin_user_enabled", False)),
+                    "public_network_access": str(getattr(registry, "public_network_access", "") or ""),
+                }
+            )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list Azure Container Registries: {sanitize_discovery_warning(exc)}")
+    return registries
+
+
+def _discover_databases(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate Cosmos DB accounts in the subscription (read-only).
+
+    SQL/PostgreSQL/MySQL extend this collection later; each item carries its own
+    ``native_type`` so the normalized model maps them to ``DATABASE`` without
+    losing the provider-native type.
+    """
+    try:
+        from azure.mgmt.cosmosdb import CosmosDBManagementClient
+    except ImportError:
+        warnings.append("azure-mgmt-cosmosdb not installed. Skipping database inventory.")
+        return []
+
+    databases: list[dict[str, Any]] = []
+    try:
+        client = CosmosDBManagementClient(credential, subscription_id)
+        for account in client.database_accounts.list():
+            account_id = str(getattr(account, "id", "") or "")
+            name = str(getattr(account, "name", "") or "").strip()
+            if not name:
+                continue
+            databases.append(
+                {
+                    "name": name,
+                    "id": account_id,
+                    "native_type": "Microsoft.DocumentDB/databaseAccounts",
+                    "engine": "cosmosdb",
+                    "location": str(getattr(account, "location", "") or ""),
+                    "resource_group": _resource_group_from_id(account_id),
+                    "tags": _clean_tags(getattr(account, "tags", None)),
+                    "public_network_access": str(getattr(account, "public_network_access", "") or ""),
+                    "is_virtual_network_filter_enabled": bool(getattr(account, "is_virtual_network_filter_enabled", False)),
+                }
+            )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list Azure database accounts: {sanitize_discovery_warning(exc)}")
+    return databases
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent_bom/cloud/resource_model.py
+++ b/src/agent_bom/cloud/resource_model.py
@@ -95,6 +95,9 @@ _AZURE_COLLECTION_MAP: dict[str, tuple[CloudResourceType, str]] = {
     "instances": (CloudResourceType.COMPUTE_INSTANCE, "Microsoft.Compute/virtualMachines"),
     "security_groups": (CloudResourceType.NETWORK_SECURITY_GROUP, "Microsoft.Network/networkSecurityGroups"),
     "managed_identities": (CloudResourceType.MANAGED_IDENTITY, "Microsoft.ManagedIdentity/userAssignedIdentities"),
+    "key_vaults": (CloudResourceType.SECRET_STORE, "Microsoft.KeyVault/vaults"),
+    "container_registries": (CloudResourceType.CONTAINER_REGISTRY, "Microsoft.ContainerRegistry/registries"),
+    "databases": (CloudResourceType.DATABASE, "Microsoft.DocumentDB/databaseAccounts"),
 }
 
 
@@ -120,7 +123,10 @@ def normalize_azure_inventory(inventory: dict[str, Any]) -> list[CloudResource]:
                 CloudResource(
                     provider="azure",
                     resource_type=rtype,
-                    native_type=native_type,
+                    # items may carry their own native_type (e.g. a SQL vs Cosmos
+                    # database in the shared "databases" collection); fall back
+                    # to the collection default otherwise.
+                    native_type=str(item.get("native_type") or native_type),
                     resource_id=resource_id,
                     name=name,
                     account=account,

--- a/tests/test_azure_cloud_coverage.py
+++ b/tests/test_azure_cloud_coverage.py
@@ -26,6 +26,8 @@ _MODULE_TO_DIST = {
     "cognitiveservices": "azure-mgmt-cognitiveservices",
     "compute": "azure-mgmt-compute",
     "containerinstance": "azure-mgmt-containerinstance",
+    "containerregistry": "azure-mgmt-containerregistry",
+    "cosmosdb": "azure-mgmt-cosmosdb",
     "keyvault": "azure-mgmt-keyvault",
     "machinelearningservices": "azure-mgmt-machinelearningservices",
     "monitor": "azure-mgmt-monitor",

--- a/tests/test_cloud_resource_model.py
+++ b/tests/test_cloud_resource_model.py
@@ -67,3 +67,18 @@ def test_to_dict_roundtrip_shape() -> None:
     assert d["resource_type"] == "secret_store"
     assert d["native_type"] == "Microsoft.KeyVault/vaults"
     assert "raw" not in d  # raw is provenance-only, not serialized
+
+
+def test_data_services_normalize_to_shared_types() -> None:
+    inv = {
+        "provider": "azure",
+        "subscription_id": "s",
+        "key_vaults": [{"name": "kv", "id": "/.../kv"}],
+        "container_registries": [{"name": "acr", "id": "/.../acr"}],
+        "databases": [{"name": "cos", "id": "/.../cos", "native_type": "Microsoft.DocumentDB/databaseAccounts"}],
+    }
+    by_type = {r.resource_type: r for r in normalize_azure_inventory(inv)}
+    assert by_type[CloudResourceType.SECRET_STORE].native_type == "Microsoft.KeyVault/vaults"
+    assert by_type[CloudResourceType.CONTAINER_REGISTRY].native_type == "Microsoft.ContainerRegistry/registries"
+    # item-level native_type wins for the shared databases collection
+    assert by_type[CloudResourceType.DATABASE].native_type == "Microsoft.DocumentDB/databaseAccounts"

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,9 @@ all = [
     { name = "azure-mgmt-cognitiveservices" },
     { name = "azure-mgmt-compute" },
     { name = "azure-mgmt-containerinstance" },
+    { name = "azure-mgmt-containerregistry" },
     { name = "azure-mgmt-containerservice" },
+    { name = "azure-mgmt-cosmosdb" },
     { name = "azure-mgmt-keyvault" },
     { name = "azure-mgmt-machinelearningservices" },
     { name = "azure-mgmt-monitor" },
@@ -130,7 +132,9 @@ azure = [
     { name = "azure-mgmt-cognitiveservices" },
     { name = "azure-mgmt-compute" },
     { name = "azure-mgmt-containerinstance" },
+    { name = "azure-mgmt-containerregistry" },
     { name = "azure-mgmt-containerservice" },
+    { name = "azure-mgmt-cosmosdb" },
     { name = "azure-mgmt-keyvault" },
     { name = "azure-mgmt-machinelearningservices" },
     { name = "azure-mgmt-monitor" },
@@ -151,7 +155,9 @@ cloud = [
     { name = "azure-mgmt-cognitiveservices" },
     { name = "azure-mgmt-compute" },
     { name = "azure-mgmt-containerinstance" },
+    { name = "azure-mgmt-containerregistry" },
     { name = "azure-mgmt-containerservice" },
+    { name = "azure-mgmt-cosmosdb" },
     { name = "azure-mgmt-keyvault" },
     { name = "azure-mgmt-machinelearningservices" },
     { name = "azure-mgmt-monitor" },
@@ -336,7 +342,9 @@ requires-dist = [
     { name = "azure-mgmt-cognitiveservices", marker = "extra == 'azure'", specifier = ">=13.5" },
     { name = "azure-mgmt-compute", marker = "extra == 'azure'", specifier = ">=30.0" },
     { name = "azure-mgmt-containerinstance", marker = "extra == 'azure'", specifier = ">=10.1" },
+    { name = "azure-mgmt-containerregistry", marker = "extra == 'azure'", specifier = ">=10.3" },
     { name = "azure-mgmt-containerservice", marker = "extra == 'azure'", specifier = ">=30.0" },
+    { name = "azure-mgmt-cosmosdb", marker = "extra == 'azure'", specifier = ">=9.5" },
     { name = "azure-mgmt-keyvault", marker = "extra == 'azure'", specifier = ">=10.3" },
     { name = "azure-mgmt-machinelearningservices", marker = "extra == 'azure'", specifier = ">=1.0" },
     { name = "azure-mgmt-monitor", marker = "extra == 'azure'", specifier = ">=6.0" },
@@ -785,6 +793,20 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-mgmt-containerregistry"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-mgmt-core" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b2/f4161251d451d492372dcc703a7796e14156d8234f1ad8a3e17571275a33/azure_mgmt_containerregistry-15.0.0.tar.gz", hash = "sha256:a31a70b7b6811d343c26804a146f1e4c1b12f6660c6e381d2d5017b27bcab573", size = 147096, upload-time = "2026-03-19T23:02:15.697Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/a1/8dd7e1dda118bb3bdd4ee1e45eb0f77c4419202e9670010399d6620de9a4/azure_mgmt_containerregistry-15.0.0-py3-none-any.whl", hash = "sha256:e7d6302e8b993b53c3167a255dd8fae75fc2f1dc0e39ae9fa97fb4b7ed5d25d1", size = 121718, upload-time = "2026-03-19T23:02:17.399Z" },
+]
+
+[[package]]
 name = "azure-mgmt-containerservice"
 version = "41.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -808,6 +830,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3e/99/fa9e7551313d8c7099c89ebf3b03cd31beb12e1b498d575aa19bb59a5d04/azure_mgmt_core-1.6.0.tar.gz", hash = "sha256:b26232af857b021e61d813d9f4ae530465255cb10b3dde945ad3743f7a58e79c", size = 30818, upload-time = "2025-07-03T02:02:24.093Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/26/c79f962fd3172b577b6f38685724de58b6b4337a51d3aad316a43a4558c6/azure_mgmt_core-1.6.0-py3-none-any.whl", hash = "sha256:0460d11e85c408b71c727ee1981f74432bc641bb25dfcf1bb4e90a49e776dbc4", size = 29310, upload-time = "2025-07-03T02:02:25.203Z" },
+]
+
+[[package]]
+name = "azure-mgmt-cosmosdb"
+version = "9.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-mgmt-core" },
+    { name = "msrest" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/e3/8687e481a34c83f5a6e6d9d3a084c8344920aaf6a505b19a299e58f20421/azure_mgmt_cosmosdb-9.9.0.tar.gz", hash = "sha256:4678bf042bdc208aa24fca71767ac29b6f2a2722ac7872608371a5922f3b6c37", size = 285338, upload-time = "2025-11-14T06:29:06.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/6b/19a16013a805e506f5e775d79587859852b1a07dd6ae5b377ab541ef4692/azure_mgmt_cosmosdb-9.9.0-py3-none-any.whl", hash = "sha256:31322770c61fdca6bcd1444e9dad501a5a225879c152ec1fd57ab5c68901a1fa", size = 420362, upload-time = "2025-11-14T06:29:09.083Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Found by live read-only scans: three resource types present in a real
subscription but never inventoried.

## Gap (proven live)
Provisioned **Key Vault** and **ACR** did not appear in the inventory at all,
and **databases** weren't enumerated. Key Vault is the secrets/NHI surface, ACR
the image supply chain — a team scanning Azure saw an incomplete estate.

## This PR
- `_discover_key_vaults`, `_discover_container_registries`, `_discover_databases`
  — control-plane metadata only (URIs, RBAC mode, public-network posture, SKU);
  never secret material or data-plane contents.
- New `include_data` flag with its own read-only `permissions_used` entries so
  the discovery envelope stays honest.
- Each maps onto the normalized `CloudResource` model →
  `SECRET_STORE` / `CONTAINER_REGISTRY` / `DATABASE`. Database items carry their
  own `native_type` so SQL/PostgreSQL/MySQL extend the shared collection later
  without losing provenance.
- `azure-mgmt-containerregistry` + `azure-mgmt-cosmosdb` added to the `azure`
  extra (the existing guard test keeps it complete).

## Verified live
Against a real subscription, a provisioned Key Vault and ACR now surface as
`secret_store` and `container_registry` (alongside storage → `object_store`,
managed identity → `managed_identity`). This is the per-type coverage loop that
scales to the rest of Azure, then AWS/GCP, against the same normalized model.