### PR TITLE
feat(graph): ingest normalized cloud resources as graph nodes

### DIFF
--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -2077,6 +2077,10 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
     """
     if not isinstance(inventory, dict) or inventory.get("status") != "ok":
         return
+    # The provider translation below rebuilds an AWS-shaped dict and drops the
+    # data/secret/registry/network collections; keep the original to ingest them
+    # through the normalized resource model.
+    original_inventory = inventory
     inventory = _normalize_cloud_inventory(inventory)
     provider = _clean_graph_part(inventory.get("provider")) or "aws"
     account_id = _clean_graph_part(inventory.get("account_id"))
@@ -2251,11 +2255,101 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
                     )
                 )
 
+    # ── Data / secret / registry / network resources (normalized model) ──
+    _add_normalized_cloud_resources(
+        graph,
+        original_inventory,
+        provider=provider,
+        account_id=account_id,
+        account_node_id=account_node_id,
+        region=region,
+        data_sources=data_sources,
+        resource_ids=resource_ids,
+    )
+
     # ── IAM roles + users → identity principals (CAN_ACCESS resources) ──
     for principal in [*(inventory.get("roles", []) or []), *(inventory.get("users", []) or [])]:
         if isinstance(principal, dict):
             _add_inventory_principal(
                 graph, principal, provider=provider, account_node_id=account_node_id, resource_ids=resource_ids, data_sources=data_sources
+            )
+
+
+def _add_normalized_cloud_resources(
+    graph: UnifiedGraph,
+    inventory: dict[str, Any],
+    *,
+    provider: str,
+    account_id: str,
+    account_node_id: str,
+    region: str,
+    data_sources: list[str],
+    resource_ids: list[str],
+) -> None:
+    """Promote normalized data / secret / registry / network resources into nodes.
+
+    Covers the resource classes the AWS-shaped loops above do not: secret stores
+    (Key Vault), container registries, databases, virtual networks, public IPs,
+    and load balancers. Each becomes a ``CLOUD_RESOURCE`` owned by the account so
+    it shows up in the environment graph and is reachable by blast-radius. Data
+    stores and secret stores carry a data-store keyword in their label so the
+    CNAPP/DSPM overlay can attach its companion; resources with a public IP or an
+    internet-facing frontend are flagged ``internet_exposed`` for exposure
+    analysis. Identity / EXPOSED_TO edges between these and compute/identity nodes
+    are added by the overlays once richer relations are available.
+    """
+    from agent_bom.cloud.resource_model import CloudResourceType, normalize_cloud_inventory
+
+    # normalized type -> (label keyword, graph surface, signals a data store)
+    type_meta = {
+        CloudResourceType.SECRET_STORE: ("key vault", "secret-store", True),
+        CloudResourceType.CONTAINER_REGISTRY: ("container registry", "registry", False),
+        CloudResourceType.DATABASE: ("database", "database", True),
+        CloudResourceType.VIRTUAL_NETWORK: ("virtual network", "network", False),
+        CloudResourceType.PUBLIC_IP: ("public ip", "network", False),
+        CloudResourceType.LOAD_BALANCER: ("load balancer", "network", False),
+    }
+    for res in normalize_cloud_inventory(inventory):
+        meta = type_meta.get(res.resource_type)
+        if meta is None:
+            continue  # storage / compute / identity handled by the dedicated loops
+        label_keyword, surface, is_data_store = meta
+        name = _clean_graph_part(res.name)
+        if not name:
+            continue
+        node_id = f"cloud_resource:{provider}:{res.resource_type.value}:{name}"
+        raw = res.raw or {}
+        internet_exposed = bool(raw.get("ip_address")) or bool(raw.get("internet_facing"))
+        graph.add_node(
+            UnifiedNode(
+                id=node_id,
+                entity_type=EntityType.CLOUD_RESOURCE,
+                label=f"{label_keyword}: {name}",
+                attributes={
+                    "resource_id": res.resource_id or name,
+                    "resource_name": name,
+                    "resource_type": res.resource_type.value,
+                    "resource_kind": res.native_type,
+                    "cloud_provider": provider,
+                    "location": res.region or region,
+                    "internet_exposed": internet_exposed,
+                    "is_data_store": is_data_store,
+                    "tags": dict(res.tags),
+                    "account_id": account_id,
+                },
+                data_sources=data_sources,
+                dimensions=NodeDimensions(cloud_provider=provider, surface=surface),
+            )
+        )
+        resource_ids.append(node_id)
+        if account_node_id:
+            graph.add_edge(
+                UnifiedEdge(
+                    source=account_node_id,
+                    target=node_id,
+                    relationship=RelationshipType.OWNS,
+                    evidence={"source": "cloud-inventory"},
+                )
             )
 
 

--- a/tests/test_graph_cloud_resource_ingestion.py
+++ b/tests/test_graph_cloud_resource_ingestion.py
@@ -1,0 +1,65 @@
+"""Normalized cloud resources (data/secret/registry/network) become graph nodes.
+
+Before this, the graph builder only turned storage + security groups into nodes,
+so Key Vaults, registries, databases, and network topology surfaced in the
+inventory but never in the graph — absent from visualization, blast-radius, and
+attack-path analysis.
+"""
+
+from __future__ import annotations
+
+from agent_bom.graph.builder import build_unified_graph_from_report
+
+
+def _report() -> dict:
+    return {
+        "cloud_inventory": [
+            {
+                "provider": "azure",
+                "status": "ok",
+                "subscription_id": "sub-1",
+                "account_id": "sub-1",
+                "key_vaults": [{"name": "kv", "id": "/.../kv", "location": "eastus"}],
+                "container_registries": [{"name": "acr", "id": "/.../acr"}],
+                "databases": [{"name": "cos", "id": "/.../cos", "native_type": "Microsoft.DocumentDB/databaseAccounts"}],
+                "virtual_networks": [{"name": "vnet", "id": "/.../vnet"}],
+                "public_ips": [{"name": "pip", "id": "/.../pip", "ip_address": "20.1.2.3"}],
+                "load_balancers": [{"name": "lb", "id": "/.../lb", "internet_facing": True}],
+            }
+        ]
+    }
+
+
+def _build():
+    g = build_unified_graph_from_report(_report())
+    edges = list(g.edges.values()) if isinstance(g.edges, dict) else list(g.edges)
+    return g, edges
+
+
+def test_new_resource_types_become_cloud_resource_nodes() -> None:
+    g, _ = _build()
+    by_type = {
+        n.attributes.get("resource_type")
+        for n in g.nodes.values()
+        if str(getattr(n, "entity_type", "")).split(".")[-1].lower() == "cloud_resource"
+    }
+    assert {"secret_store", "container_registry", "database", "virtual_network", "public_ip", "load_balancer"} <= by_type
+
+
+def test_resources_owned_by_account_and_not_orphaned() -> None:
+    g, edges = _build()
+    cr = [n for n in g.nodes.values() if str(getattr(n, "entity_type", "")).split(".")[-1].lower() == "cloud_resource"]
+    accounts = {k for k in g.nodes if k.startswith("account:")}
+    owns = {e.target for e in edges if e.source in accounts and e.relationship.value == "owns"}
+    assert all(n.id in owns for n in cr), "some cloud resources are not owned by the account"
+    connected = {e.source for e in edges} | {e.target for e in edges}
+    assert all(n.id in connected for n in cr), "orphaned cloud resource node"
+
+
+def test_exposure_and_datastore_flags() -> None:
+    g, _ = _build()
+    by_name = {n.attributes.get("resource_name"): n for n in g.nodes.values() if n.attributes.get("resource_type")}
+    assert by_name["pip"].attributes["internet_exposed"] is True
+    assert by_name["lb"].attributes["internet_exposed"] is True
+    assert by_name["kv"].attributes["is_data_store"] is True
+    assert by_name["cos"].attributes["is_data_store"] is True


### PR DESCRIPTION
The linchpin for cloud visualization + attack-paths. Inventory now discovers 8
resource types, but the graph builder only promoted storage accounts and
security groups to nodes — so Key Vault, ACR, databases, VNets, public IPs, and
load balancers surfaced in the inventory yet never reached the graph. They were
absent from the environment visualization, blast-radius, and attack-path
analysis despite being discovered.

## This PR
`_add_normalized_cloud_resources` reads the inventory through the normalized
`CloudResource` model and emits a `CLOUD_RESOURCE` node per resource, each
`OWNS`-linked to its account node so it is reachable in the graph:
- Secret stores + databases carry a data-store keyword and `is_data_store` flag
  so the CNAPP/DSPM overlay can attach its companion.
- Resources with a public IP or an internet-facing frontend are flagged
  `internet_exposed` for exposure analysis.
- The original inventory is captured before the AWS-shaping translation (which
  rebuilt an AWS-shaped dict and dropped these collections).

## Verified
Against a live 8-resource Azure estate: all six new types become account-owned
graph nodes, **none orphaned**, with public IP + load balancer flagged
internet-exposed and Key Vault + Cosmos flagged data stores. Graph suite 562
passed, no regressions. Works cross-cloud — AWS/GCP resources normalize to the
same shape and ingest through the same path.