### PR TITLE
feat(graph): internet exposure edge — public IP → load balancer

### DIFF
--- a/src/agent_bom/cloud/azure_inventory.py
+++ b/src/agent_bom/cloud/azure_inventory.py
@@ -677,7 +677,12 @@ def _discover_load_balancers(credential: Any, subscription_id: str, *, warnings:
                 continue
             sku = getattr(lb, "sku", None)
             frontends = getattr(lb, "frontend_ip_configurations", None) or []
-            internet_facing = any(getattr(fe, "public_ip_address", None) is not None for fe in frontends)
+            public_ip_ids = [
+                str(getattr(getattr(fe, "public_ip_address", None), "id", "") or "")
+                for fe in frontends
+                if getattr(fe, "public_ip_address", None) is not None
+            ]
+            public_ip_ids = [pid for pid in public_ip_ids if pid]
             load_balancers.append(
                 {
                     "name": name,
@@ -686,7 +691,8 @@ def _discover_load_balancers(credential: Any, subscription_id: str, *, warnings:
                     "resource_group": _resource_group_from_id(lb_id),
                     "tags": _clean_tags(getattr(lb, "tags", None)),
                     "sku": str(getattr(sku, "name", "") or "") if sku else "",
-                    "internet_facing": internet_facing,
+                    "internet_facing": bool(public_ip_ids),
+                    "public_ip_ids": public_ip_ids,
                 }
             )
     except Exception as exc:  # noqa: BLE001

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -2309,6 +2309,8 @@ def _add_normalized_cloud_resources(
         CloudResourceType.PUBLIC_IP: ("public ip", "network", False),
         CloudResourceType.LOAD_BALANCER: ("load balancer", "network", False),
     }
+    pip_node_by_arm_id: dict[str, str] = {}
+    load_balancer_nodes: list[tuple[str, dict[str, Any]]] = []
     for res in normalize_cloud_inventory(inventory):
         meta = type_meta.get(res.resource_type)
         if meta is None:
@@ -2320,6 +2322,10 @@ def _add_normalized_cloud_resources(
         node_id = f"cloud_resource:{provider}:{res.resource_type.value}:{name}"
         raw = res.raw or {}
         internet_exposed = bool(raw.get("ip_address")) or bool(raw.get("internet_facing"))
+        if res.resource_type is CloudResourceType.PUBLIC_IP and res.resource_id:
+            pip_node_by_arm_id[res.resource_id] = node_id
+        if res.resource_type is CloudResourceType.LOAD_BALANCER:
+            load_balancer_nodes.append((node_id, raw))
         graph.add_node(
             UnifiedNode(
                 id=node_id,
@@ -2351,6 +2357,24 @@ def _add_normalized_cloud_resources(
                     evidence={"source": "cloud-inventory"},
                 )
             )
+
+    # ── Internet exposure path: public IP → load balancer it fronts ──
+    # The public IP is the internet entry point; the load balancer (and its
+    # backends) sit behind it. EXPOSED_TO from the IP to the LB lets blast-radius
+    # and attack-path analysis start at the internet edge.
+    for lb_node_id, lb_raw in load_balancer_nodes:
+        for pip_arm_id in lb_raw.get("public_ip_ids", []) or []:
+            pip_node_id = pip_node_by_arm_id.get(pip_arm_id)
+            if pip_node_id:
+                graph.add_edge(
+                    UnifiedEdge(
+                        source=pip_node_id,
+                        target=lb_node_id,
+                        relationship=RelationshipType.EXPOSED_TO,
+                        weight=6.0,
+                        evidence={"source": "cloud-inventory", "reason": "public_ip_frontend"},
+                    )
+                )
 
 
 def _add_inventory_principal(

--- a/tests/test_graph_cloud_resource_ingestion.py
+++ b/tests/test_graph_cloud_resource_ingestion.py
@@ -63,3 +63,26 @@ def test_exposure_and_datastore_flags() -> None:
     assert by_name["lb"].attributes["internet_exposed"] is True
     assert by_name["kv"].attributes["is_data_store"] is True
     assert by_name["cos"].attributes["is_data_store"] is True
+
+
+def test_public_ip_exposed_to_load_balancer_edge() -> None:
+    """A public IP fronting a load balancer becomes an EXPOSED_TO edge."""
+    pip_arm = "/subscriptions/s/.../publicIPAddresses/pip"
+    report = {
+        "cloud_inventory": [
+            {
+                "provider": "azure",
+                "status": "ok",
+                "subscription_id": "sub-1",
+                "account_id": "sub-1",
+                "public_ips": [{"name": "pip", "id": pip_arm, "ip_address": "20.1.2.3"}],
+                "load_balancers": [{"name": "lb", "id": "/.../lb", "internet_facing": True, "public_ip_ids": [pip_arm]}],
+            }
+        ]
+    }
+    g = build_unified_graph_from_report(report)
+    edges = list(g.edges.values()) if isinstance(g.edges, dict) else list(g.edges)
+    pip_node = "cloud_resource:azure:public_ip:pip"
+    lb_node = "cloud_resource:azure:load_balancer:lb"
+    exposed = [e for e in edges if e.relationship.value == "exposed_to" and e.source == pip_node and e.target == lb_node]
+    assert exposed, "no EXPOSED_TO edge from public IP to the load balancer it fronts"


### PR DESCRIPTION
First real cross-resource cloud attack-path primitive, on top of the
resource-node ingestion (#3044). Until now the new cloud resources were nodes
linked only to their account; this adds the first edge *between* them.

## This PR
- Load-balancer discovery now captures the public IP IDs from its frontend IP
  configurations (`public_ip_ids`).
- The graph builder adds an `EXPOSED_TO` edge from each fronting public IP node
  to the load balancer.

The public IP is the internet entry point; the load balancer (and its backends)
sit behind it. So blast-radius and attack-path analysis can now **start at the
internet edge and walk inward** — internet → public IP → load balancer → (next:
backend pool → VM → identity → secret/DB).

## Verified
Unit test: a public IP fronting a load balancer produces the `EXPOSED_TO` edge
from the IP node to the LB node. (Live validation deferred — the sandbox was
torn down per the always-terminate rule; the graph logic is deterministic given
the inventory shape, which was captured live.)

Next edges in the chain — LB→backend, NIC→subnet→VNet, VM→managed-identity,
identity→Key Vault/DB access — extend the same path.