### PR TITLE
perf(cloud): discover Azure services concurrently

### DIFF
--- a/src/agent_bom/cloud/azure_inventory.py
+++ b/src/agent_bom/cloud/azure_inventory.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import logging
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
 from agent_bom.discovery_envelope import DiscoveryEnvelope, RedactionStatus, ScanMode
@@ -166,32 +167,53 @@ def discover_inventory(
             return {**empty, "status": "no_credentials", "warnings": [sanitize_discovery_warning(exc)]}
 
     warnings: list[str] = []
-    storage_accounts: list[dict[str, Any]] = []
-    instances: list[dict[str, Any]] = []
-    security_groups: list[dict[str, Any]] = []
-    managed_identities: list[dict[str, Any]] = []
-    key_vaults: list[dict[str, Any]] = []
-    container_registries: list[dict[str, Any]] = []
-    databases: list[dict[str, Any]] = []
-    virtual_networks: list[dict[str, Any]] = []
-    public_ips: list[dict[str, Any]] = []
-    load_balancers: list[dict[str, Any]] = []
 
+    # Discover each service concurrently — the ARM list calls are independent and
+    # IO-bound, so a thread pool collapses the previously-sequential sum-of-latencies
+    # sweep to roughly the slowest single call. Each task gets its own warnings list
+    # (thread-safe) that is merged back in deterministic task order.
+    discovery_tasks: list[tuple[str, Any]] = []
     if include_storage:
-        storage_accounts = _discover_storage_accounts(credential, resolved_sub, warnings=warnings)
+        discovery_tasks.append(("storage_accounts", _discover_storage_accounts))
     if include_compute:
-        instances = _discover_vms(credential, resolved_sub, warnings=warnings)
-        security_groups = _discover_nsgs(credential, resolved_sub, warnings=warnings)
+        discovery_tasks.append(("instances", _discover_vms))
+        discovery_tasks.append(("security_groups", _discover_nsgs))
     if include_identity:
-        managed_identities = _discover_managed_identities(credential, resolved_sub, warnings=warnings)
+        discovery_tasks.append(("managed_identities", _discover_managed_identities))
     if include_data:
-        key_vaults = _discover_key_vaults(credential, resolved_sub, warnings=warnings)
-        container_registries = _discover_container_registries(credential, resolved_sub, warnings=warnings)
-        databases = _discover_databases(credential, resolved_sub, warnings=warnings)
+        discovery_tasks.append(("key_vaults", _discover_key_vaults))
+        discovery_tasks.append(("container_registries", _discover_container_registries))
+        discovery_tasks.append(("databases", _discover_databases))
     if include_network:
-        virtual_networks = _discover_virtual_networks(credential, resolved_sub, warnings=warnings)
-        public_ips = _discover_public_ips(credential, resolved_sub, warnings=warnings)
-        load_balancers = _discover_load_balancers(credential, resolved_sub, warnings=warnings)
+        discovery_tasks.append(("virtual_networks", _discover_virtual_networks))
+        discovery_tasks.append(("public_ips", _discover_public_ips))
+        discovery_tasks.append(("load_balancers", _discover_load_balancers))
+
+    collected: dict[str, list[dict[str, Any]]] = {}
+    task_warnings: dict[str, list[str]] = {key: [] for key, _ in discovery_tasks}
+    if discovery_tasks:
+        with ThreadPoolExecutor(max_workers=min(8, len(discovery_tasks))) as executor:
+            future_to_key = {executor.submit(fn, credential, resolved_sub, warnings=task_warnings[key]): key for key, fn in discovery_tasks}
+            for future in as_completed(future_to_key):
+                key = future_to_key[future]
+                try:
+                    collected[key] = future.result()
+                except Exception as exc:  # noqa: BLE001 — one service failing must not sink the rest
+                    collected[key] = []
+                    task_warnings[key].append(sanitize_discovery_warning(exc))
+    for key, _ in discovery_tasks:
+        warnings.extend(task_warnings[key])
+
+    storage_accounts = collected.get("storage_accounts", [])
+    instances = collected.get("instances", [])
+    security_groups = collected.get("security_groups", [])
+    managed_identities = collected.get("managed_identities", [])
+    key_vaults = collected.get("key_vaults", [])
+    container_registries = collected.get("container_registries", [])
+    databases = collected.get("databases", [])
+    virtual_networks = collected.get("virtual_networks", [])
+    public_ips = collected.get("public_ips", [])
+    load_balancers = collected.get("load_balancers", [])
 
     permissions_used: list[str] = []
     if include_storage:

--- a/tests/test_azure_parallel_discovery.py
+++ b/tests/test_azure_parallel_discovery.py
@@ -2,9 +2,28 @@
 
 from __future__ import annotations
 
+import sys
 import time
+import types
+
+import pytest
 
 from agent_bom.cloud import azure_inventory as azinv
+
+
+@pytest.fixture(autouse=True)
+def _stub_azure_sdk(monkeypatch):
+    """Let ``discover_inventory`` past its ``from azure.identity import ...`` gate.
+
+    CI's base test env does not install the optional ``azure`` extra, so without
+    this the function returns ``status="sdk_missing"`` before any discovery runs.
+    """
+    azure_mod = sys.modules.get("azure") or types.ModuleType("azure")
+    identity_mod = types.ModuleType("azure.identity")
+    identity_mod.DefaultAzureCredential = object  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "azure", azure_mod)
+    monkeypatch.setitem(sys.modules, "azure.identity", identity_mod)
+
 
 _SERVICES = [
     "_discover_storage_accounts",

--- a/tests/test_azure_parallel_discovery.py
+++ b/tests/test_azure_parallel_discovery.py
@@ -1,0 +1,65 @@
+"""Azure inventory discovers services concurrently, preserving results + warnings."""
+
+from __future__ import annotations
+
+import time
+
+from agent_bom.cloud import azure_inventory as azinv
+
+_SERVICES = [
+    "_discover_storage_accounts",
+    "_discover_vms",
+    "_discover_nsgs",
+    "_discover_managed_identities",
+    "_discover_key_vaults",
+    "_discover_container_registries",
+    "_discover_databases",
+    "_discover_virtual_networks",
+    "_discover_public_ips",
+    "_discover_load_balancers",
+]
+
+
+def _slow_stub(label: str, delay: float = 0.15):
+    def fn(cred, sub, *, warnings):
+        time.sleep(delay)
+        warnings.append(f"warn-{label}")
+        return [{"name": f"{label}-1", "id": f"/id/{label}"}]
+
+    return fn
+
+
+def test_discovery_runs_concurrently(monkeypatch) -> None:
+    for name in _SERVICES:
+        monkeypatch.setattr(azinv, name, _slow_stub(name))
+    start = time.time()
+    inv = azinv.discover_inventory("sub-1", credential=object(), force=True)
+    elapsed = time.time() - start
+    # 10 × 0.15s sequential = 1.5s; concurrent should be well under half that.
+    assert elapsed < 0.75, f"discovery not parallel (took {elapsed:.2f}s)"
+    assert inv["status"] == "ok"
+    for collection in ("storage_accounts", "key_vaults", "databases", "public_ips", "load_balancers"):
+        assert len(inv[collection]) == 1
+
+
+def test_warnings_preserved_in_deterministic_order(monkeypatch) -> None:
+    for name in _SERVICES:
+        monkeypatch.setattr(azinv, name, _slow_stub(name, delay=0.0))
+    inv = azinv.discover_inventory("sub-1", credential=object(), force=True)
+    assert len(inv["warnings"]) == 10
+    # storage is the first task → its warning is first regardless of completion order
+    assert inv["warnings"][0] == "warn-_discover_storage_accounts"
+
+
+def test_one_service_failing_does_not_sink_others(monkeypatch) -> None:
+    def boom(cred, sub, *, warnings):
+        raise RuntimeError("simulated ARM failure")
+
+    for name in _SERVICES:
+        monkeypatch.setattr(azinv, name, _slow_stub(name, delay=0.0))
+    monkeypatch.setattr(azinv, "_discover_key_vaults", boom)
+    inv = azinv.discover_inventory("sub-1", credential=object(), force=True)
+    assert inv["status"] == "ok"
+    assert inv["key_vaults"] == []  # failed service is empty
+    assert len(inv["storage_accounts"]) == 1  # others unaffected
+    assert any("simulated ARM failure" in w for w in inv["warnings"])


### PR DESCRIPTION
A live latency measurement showed `agent-bom cloud azure` taking ~30s to sweep a
small estate — all of it sum-of-latencies, because each service's ARM `list`
call ran sequentially. As coverage grows toward full breadth, this wall-time
grows linearly with the number of resource types.

## This PR
The ten per-service discovery calls are independent and IO-bound, so they're
dispatched through a `ThreadPoolExecutor` (max 8 workers). Wall-time collapses
from the sum of all calls to roughly the slowest single one.

Correctness is preserved exactly:
- Each task writes to its **own** warnings list (thread-safe), merged back in
  deterministic task order → identical output ordering to the sequential version.
- A failure in one service degrades only that collection (empty + a sanitized
  warning) and never sinks the others.

## Verified
Unit tests: 10 simulated 0.15s services finish well under the sequential ~1.5s;
all collections populated; warnings preserved and ordered; one-service-failure
isolated. Existing azure-inventory suite green (26 passed).