### PR TITLE
feat(graph): VM → managed-identity privilege edge (ASSUMES)

### DIFF
--- a/src/agent_bom/cloud/azure_inventory.py
+++ b/src/agent_bom/cloud/azure_inventory.py
@@ -317,6 +317,7 @@ def _discover_vms(credential: Any, subscription_id: str, *, warnings: list[str])
                     "location": str(getattr(vm, "location", "") or ""),
                     "resource_group": _resource_group_from_id(vm_id),
                     "managed_identity": _vm_identity(vm),
+                    "user_assigned_identity_ids": _vm_user_assigned_identity_ids(vm),
                     "tags": _clean_tags(getattr(vm, "tags", None)),
                     "subscription_id": subscription_id,
                 }
@@ -710,6 +711,22 @@ def _vm_identity(vm: Any) -> str:
     if identity is None:
         return ""
     return str(getattr(identity, "principal_id", "") or getattr(identity, "type", "") or "")
+
+
+def _vm_user_assigned_identity_ids(vm: Any) -> list[str]:
+    """ARM IDs of the user-assigned managed identities attached to a VM.
+
+    The VM assumes each of these identities' permissions, so they drive the
+    VM → managed-identity privilege edge in the graph. Returns the resource IDs
+    only (the dict keys) — never any credential material.
+    """
+    identity = getattr(vm, "identity", None)
+    if identity is None:
+        return []
+    user_assigned = getattr(identity, "user_assigned_identities", None)
+    if not isinstance(user_assigned, dict):
+        return []
+    return [str(arm_id) for arm_id in user_assigned if arm_id]
 
 
 def _resource_group_from_id(resource_id: str) -> str:

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -2255,6 +2255,25 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
                     )
                 )
 
+        # A user-assigned managed identity is assumed by the VM: the identity's
+        # permissions become the VM's blast radius. ASSUMES from the VM node to
+        # each managed-identity node (those nodes are added by the principal pass
+        # below; edges may reference them ahead of creation).
+        for mi_arm_id in instance.get("user_assigned_identity_ids", []) or []:
+            mi_clean = _clean_graph_part(mi_arm_id)
+            if not mi_clean:
+                continue
+            mi_node_id = _identity_node_id(EntityType.MANAGED_IDENTITY, provider, mi_clean)
+            graph.add_edge(
+                UnifiedEdge(
+                    source=node_id,
+                    target=mi_node_id,
+                    relationship=RelationshipType.ASSUMES,
+                    weight=5.0,
+                    evidence={"source": "cloud-inventory", "reason": "vm_user_assigned_identity"},
+                )
+            )
+
     # ── Data / secret / registry / network resources (normalized model) ──
     _add_normalized_cloud_resources(
         graph,

--- a/tests/test_vm_managed_identity_edge.py
+++ b/tests/test_vm_managed_identity_edge.py
@@ -1,0 +1,60 @@
+"""A VM assumes its user-assigned managed identity (CIEM privilege edge)."""
+
+from __future__ import annotations
+
+from agent_bom.graph.builder import build_unified_graph_from_report
+
+_MI_ARM = "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi1"
+
+
+def _build():
+    report = {
+        "cloud_inventory": [
+            {
+                "provider": "azure",
+                "status": "ok",
+                "subscription_id": "sub-1",
+                "account_id": "sub-1",
+                "instances": [
+                    {
+                        "instance_id": "/subscriptions/sub-1/.../virtualMachines/vm1",
+                        "name": "vm1",
+                        "user_assigned_identity_ids": [_MI_ARM],
+                    }
+                ],
+                "managed_identities": [{"name": "mi1", "arn": _MI_ARM, "principal_id": "pid", "principal_type": "managed-identity"}],
+            }
+        ]
+    }
+    g = build_unified_graph_from_report(report)
+    edges = list(g.edges.values()) if isinstance(g.edges, dict) else list(g.edges)
+    return g, edges
+
+
+def test_vm_assumes_user_assigned_identity() -> None:
+    g, edges = _build()
+    assumes = [e for e in edges if e.relationship.value == "assumes"]
+    assert len(assumes) == 1
+    edge = assumes[0]
+    src = g.nodes[edge.source]
+    tgt = g.nodes[edge.target]
+    assert str(src.entity_type).split(".")[-1].lower() == "cloud_resource"
+    assert str(tgt.entity_type).split(".")[-1].lower() == "managed_identity"
+    assert edge.target in g.nodes  # links to the real MI node, not a dangling id
+
+
+def test_vm_without_user_assigned_identity_has_no_assumes_edge() -> None:
+    report = {
+        "cloud_inventory": [
+            {
+                "provider": "azure",
+                "status": "ok",
+                "subscription_id": "sub-1",
+                "account_id": "sub-1",
+                "instances": [{"instance_id": "/.../vm1", "name": "vm1"}],
+            }
+        ]
+    }
+    g = build_unified_graph_from_report(report)
+    edges = list(g.edges.values()) if isinstance(g.edges, dict) else list(g.edges)
+    assert not [e for e in edges if e.relationship.value == "assumes"]


### PR DESCRIPTION
The CIEM half of the cloud attack graph, complementing the internet-exposure
edge (#3045). A VM that runs as a user-assigned managed identity inherits that
identity's permissions — the privilege pivot attackers use after landing on a
host.

## This PR
- VM discovery captures `user_assigned_identity_ids` — the ARM IDs of the VM's
  user-assigned managed identities (IDs only, never credential material).
- The graph builder adds an `ASSUMES` edge from each VM node to the
  managed-identity node it runs as.

Attack-path analysis can now walk **VM → managed identity → its effective
permissions** (the effective-permissions overlay already resolves the identity's
`HAS_PERMISSION` edges). With #3045's internet → public IP → load balancer, the
graph now has both the exposure entry and the privilege pivot.

## Verified
The managed-identity node is created by the principal pass and the edge resolves
to it (not a dangling id). Tests: a VM with a user-assigned identity produces
exactly one `ASSUMES` edge (VM `CLOUD_RESOURCE` → `MANAGED_IDENTITY`); a VM
without one produces none. Graph + inventory suites green (576 passed).