### PR TITLE
feat(cloud): inventory Azure SQL, PostgreSQL, and MySQL servers

### DIFF
--- a/src/agent_bom/cloud/azure_inventory.py
+++ b/src/agent_bom/cloud/azure_inventory.py
@@ -64,6 +64,9 @@ _AZURE_DATA_PERMISSIONS: tuple[str, ...] = (
     "Microsoft.KeyVault/vaults/read",
     "Microsoft.ContainerRegistry/registries/read",
     "Microsoft.DocumentDB/databaseAccounts/read",
+    "Microsoft.Sql/servers/read",
+    "Microsoft.DBforPostgreSQL/flexibleServers/read",
+    "Microsoft.DBforMySQL/flexibleServers/read",
 )
 _AZURE_NETWORK_PERMISSIONS: tuple[str, ...] = (
     "Microsoft.Network/virtualNetworks/read",
@@ -549,21 +552,49 @@ def _discover_container_registries(credential: Any, subscription_id: str, *, war
     return registries
 
 
-def _discover_databases(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
-    """Enumerate Cosmos DB accounts in the subscription (read-only).
+def _append_db_servers(databases: list[dict[str, Any]], servers: Any, *, native_type: str, engine: str) -> None:
+    """Append SQL-family servers (Azure SQL / PostgreSQL / MySQL) in the shared shape.
 
-    SQL/PostgreSQL/MySQL extend this collection later; each item carries its own
-    ``native_type`` so the normalized model maps them to ``DATABASE`` without
-    losing the provider-native type.
+    Public-network posture lives either directly on the server (Azure SQL) or
+    under ``server.network`` (the flexible-server engines); read both.
     """
+    for server in servers:
+        server_id = str(getattr(server, "id", "") or "")
+        name = str(getattr(server, "name", "") or "").strip()
+        if not name:
+            continue
+        network = getattr(server, "network", None)
+        public_access = str(getattr(server, "public_network_access", "") or "") or (
+            str(getattr(network, "public_network_access", "") or "") if network else ""
+        )
+        databases.append(
+            {
+                "name": name,
+                "id": server_id,
+                "native_type": native_type,
+                "engine": engine,
+                "location": str(getattr(server, "location", "") or ""),
+                "resource_group": _resource_group_from_id(server_id),
+                "tags": _clean_tags(getattr(server, "tags", None)),
+                "public_network_access": public_access,
+            }
+        )
+
+
+def _discover_databases(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate managed databases in the subscription (read-only).
+
+    Covers Cosmos DB, Azure SQL, PostgreSQL, and MySQL — each item carries its
+    own ``native_type`` so the normalized model maps them all to ``DATABASE``
+    without losing the provider-native type. Each engine is enumerated
+    independently so a missing SDK or access denial never sinks the others;
+    control-plane metadata only, never row / data-plane contents.
+    """
+    databases: list[dict[str, Any]] = []
+
     try:
         from azure.mgmt.cosmosdb import CosmosDBManagementClient
-    except ImportError:
-        warnings.append("azure-mgmt-cosmosdb not installed. Skipping database inventory.")
-        return []
 
-    databases: list[dict[str, Any]] = []
-    try:
         client = CosmosDBManagementClient(credential, subscription_id)
         for account in client.database_accounts.list():
             account_id = str(getattr(account, "id", "") or "")
@@ -583,8 +614,46 @@ def _discover_databases(credential: Any, subscription_id: str, *, warnings: list
                     "is_virtual_network_filter_enabled": bool(getattr(account, "is_virtual_network_filter_enabled", False)),
                 }
             )
+    except ImportError:
+        warnings.append("azure-mgmt-cosmosdb not installed. Skipping Cosmos DB inventory.")
     except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure database accounts: {sanitize_discovery_warning(exc)}")
+        warnings.append(f"Could not list Azure Cosmos DB accounts: {sanitize_discovery_warning(exc)}")
+
+    try:
+        from azure.mgmt.sql import SqlManagementClient
+
+        sql_client = SqlManagementClient(credential, subscription_id)
+        _append_db_servers(databases, sql_client.servers.list(), native_type="Microsoft.Sql/servers", engine="azure-sql")
+    except ImportError:
+        warnings.append("azure-mgmt-sql not installed. Skipping Azure SQL inventory.")
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list Azure SQL servers: {sanitize_discovery_warning(exc)}")
+
+    try:
+        from azure.mgmt.rdbms.postgresql_flexibleservers import PostgreSQLManagementClient
+
+        pg_client = PostgreSQLManagementClient(credential, subscription_id)
+        _append_db_servers(
+            databases,
+            pg_client.servers.list(),
+            native_type="Microsoft.DBforPostgreSQL/flexibleServers",
+            engine="postgresql",
+        )
+    except ImportError:
+        warnings.append("azure-mgmt-rdbms not installed. Skipping PostgreSQL inventory.")
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list Azure PostgreSQL servers: {sanitize_discovery_warning(exc)}")
+
+    try:
+        from azure.mgmt.rdbms.mysql_flexibleservers import MySQLManagementClient
+
+        mysql_client = MySQLManagementClient(credential, subscription_id)
+        _append_db_servers(databases, mysql_client.servers.list(), native_type="Microsoft.DBforMySQL/flexibleServers", engine="mysql")
+    except ImportError:
+        warnings.append("azure-mgmt-rdbms not installed. Skipping MySQL inventory.")
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list Azure MySQL servers: {sanitize_discovery_warning(exc)}")
+
     return databases
 
 

--- a/tests/test_azure_sql_postgres_inventory.py
+++ b/tests/test_azure_sql_postgres_inventory.py
@@ -1,0 +1,51 @@
+"""Managed SQL / PostgreSQL / MySQL servers extend the databases collection."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace as Server
+
+from agent_bom.cloud import azure_inventory as azinv
+from agent_bom.cloud.resource_model import CloudResourceType, normalize_cloud_inventory
+
+
+def test_append_db_servers_reads_both_public_access_shapes() -> None:
+    dbs: list[dict] = []
+    sql = [
+        Server(id="/s/Microsoft.Sql/servers/sql1", name="sql1", location="eastus", tags={}, public_network_access="Enabled", network=None)
+    ]
+    pg = [
+        Server(
+            id="/s/flexibleServers/pg1",
+            name="pg1",
+            location="eastus",
+            tags={},
+            public_network_access=None,
+            network=Server(public_network_access="Disabled"),
+        )
+    ]
+    azinv._append_db_servers(dbs, sql, native_type="Microsoft.Sql/servers", engine="azure-sql")
+    azinv._append_db_servers(dbs, pg, native_type="Microsoft.DBforPostgreSQL/flexibleServers", engine="postgresql")
+    assert dbs[0]["public_network_access"] == "Enabled"  # direct attr (Azure SQL)
+    assert dbs[1]["public_network_access"] == "Disabled"  # via server.network (flexible)
+    assert dbs[0]["engine"] == "azure-sql"
+    assert dbs[1]["native_type"] == "Microsoft.DBforPostgreSQL/flexibleServers"
+
+
+def test_sql_family_normalizes_to_database_with_engine_native_type() -> None:
+    dbs = [
+        {"name": "sql1", "id": "/s/sql1", "native_type": "Microsoft.Sql/servers", "engine": "azure-sql"},
+        {"name": "pg1", "id": "/s/pg1", "native_type": "Microsoft.DBforPostgreSQL/flexibleServers", "engine": "postgresql"},
+        {"name": "my1", "id": "/s/my1", "native_type": "Microsoft.DBforMySQL/flexibleServers", "engine": "mysql"},
+    ]
+    inv = {"provider": "azure", "subscription_id": "s", "databases": dbs}
+    by_name = {r.name: r for r in normalize_cloud_inventory(inv)}
+    assert all(r.resource_type is CloudResourceType.DATABASE for r in by_name.values())
+    assert by_name["sql1"].native_type == "Microsoft.Sql/servers"
+    assert by_name["pg1"].native_type == "Microsoft.DBforPostgreSQL/flexibleServers"
+    assert by_name["my1"].native_type == "Microsoft.DBforMySQL/flexibleServers"
+
+
+def test_blank_named_server_skipped() -> None:
+    dbs: list[dict] = []
+    azinv._append_db_servers(dbs, [Server(id="x", name="  ", location="", tags={}, network=None)], native_type="t", engine="e")
+    assert dbs == []


### PR DESCRIPTION
Continues breadth-first Azure coverage — the managed relational databases,
extending the proven `databases` collection beyond Cosmos.

## This PR
- `_discover_databases` now also enumerates **Azure SQL**, **PostgreSQL flexible
  servers**, and **MySQL flexible servers** (read-only control-plane metadata:
  name, region, resource group, tags, public-network posture — never rows or
  data-plane contents).
- A shared `_append_db_servers` helper reads public-network posture from both
  shapes (directly on the server for Azure SQL, under `server.network` for the
  flexible-server engines).
- Each engine runs in its own `try/except`, so a missing SDK or per-engine
  access denial never sinks the others. The read-only permission envelope gains
  `Microsoft.Sql/servers/read` + the two flexible-server reads.

Each server carries its own `native_type`, so the normalized `CloudResource`
model maps them all to `DATABASE` while preserving the engine — and they flow
into the graph as data-store nodes through the existing ingestion.

## Verified
Tests: public-access read from both shapes; SQL/PostgreSQL/MySQL each normalize
to `DATABASE` with engine-specific `native_type`; blank-named server skipped.
Inventory + resource-model suites green (30 passed).