### PR TITLE
feat(cloud): inventory AKS (managed Kubernetes) clusters

### DIFF
--- a/src/agent_bom/cloud/azure_inventory.py
+++ b/src/agent_bom/cloud/azure_inventory.py
@@ -57,6 +57,7 @@ _TRUTHY = {"1", "true", "yes", "on"}
 _AZURE_STORAGE_PERMISSIONS: tuple[str, ...] = ("Microsoft.Storage/storageAccounts/read",)
 _AZURE_COMPUTE_PERMISSIONS: tuple[str, ...] = (
     "Microsoft.Compute/virtualMachines/read",
+    "Microsoft.ContainerService/managedClusters/read",
     "Microsoft.Network/networkSecurityGroups/read",
 )
 _AZURE_IDENTITY_PERMISSIONS: tuple[str, ...] = ("Microsoft.ManagedIdentity/userAssignedIdentities/read",)
@@ -130,6 +131,7 @@ def discover_inventory(
         "region": "",
         "storage_accounts": [],
         "instances": [],
+        "container_clusters": [],
         "security_groups": [],
         "managed_identities": [],
         "service_principals": [],
@@ -171,6 +173,7 @@ def discover_inventory(
     warnings: list[str] = []
     storage_accounts: list[dict[str, Any]] = []
     instances: list[dict[str, Any]] = []
+    container_clusters: list[dict[str, Any]] = []
     security_groups: list[dict[str, Any]] = []
     managed_identities: list[dict[str, Any]] = []
     key_vaults: list[dict[str, Any]] = []
@@ -184,6 +187,7 @@ def discover_inventory(
         storage_accounts = _discover_storage_accounts(credential, resolved_sub, warnings=warnings)
     if include_compute:
         instances = _discover_vms(credential, resolved_sub, warnings=warnings)
+        container_clusters = _discover_aks_clusters(credential, resolved_sub, warnings=warnings)
         security_groups = _discover_nsgs(credential, resolved_sub, warnings=warnings)
     if include_identity:
         managed_identities = _discover_managed_identities(credential, resolved_sub, warnings=warnings)
@@ -223,6 +227,7 @@ def discover_inventory(
         "region": "",
         "storage_accounts": storage_accounts,
         "instances": instances,
+        "container_clusters": container_clusters,
         "security_groups": security_groups,
         "managed_identities": managed_identities,
         "service_principals": [],
@@ -328,6 +333,52 @@ def _discover_vms(credential: Any, subscription_id: str, *, warnings: list[str])
     except Exception as exc:  # noqa: BLE001
         warnings.append(f"Could not list Azure virtual machines: {sanitize_discovery_warning(exc)}")
     return instances
+
+
+def _discover_aks_clusters(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate AKS (managed Kubernetes) clusters in the subscription (read-only).
+
+    Captures control-plane metadata: Kubernetes version, the API-server FQDN
+    (its public reachability is the exposure signal), whether the API server is
+    private, and whether Kubernetes RBAC is enabled. Never reads workload or
+    secret contents.
+    """
+    try:
+        from azure.mgmt.containerservice import ContainerServiceClient
+    except ImportError:
+        warnings.append("azure-mgmt-containerservice not installed. Skipping AKS inventory.")
+        return []
+
+    clusters: list[dict[str, Any]] = []
+    try:
+        client = ContainerServiceClient(credential, subscription_id)
+        for cluster in client.managed_clusters.list():
+            cluster_id = str(getattr(cluster, "id", "") or "")
+            name = str(getattr(cluster, "name", "") or "").strip()
+            if not name:
+                continue
+            api_profile = getattr(cluster, "api_server_access_profile", None)
+            private_cluster = bool(getattr(api_profile, "enable_private_cluster", False)) if api_profile else False
+            fqdn = str(getattr(cluster, "fqdn", "") or "")
+            clusters.append(
+                {
+                    "name": name,
+                    "id": cluster_id,
+                    "native_type": "Microsoft.ContainerService/managedClusters",
+                    "location": str(getattr(cluster, "location", "") or ""),
+                    "resource_group": _resource_group_from_id(cluster_id),
+                    "tags": _clean_tags(getattr(cluster, "tags", None)),
+                    "kubernetes_version": str(getattr(cluster, "kubernetes_version", "") or ""),
+                    "api_server_fqdn": fqdn,
+                    "private_cluster": private_cluster,
+                    "rbac_enabled": bool(getattr(cluster, "enable_rbac", False)),
+                    # A reachable API-server FQDN on a non-private cluster is internet-facing.
+                    "internet_facing": bool(fqdn) and not private_cluster,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list Azure AKS clusters: {sanitize_discovery_warning(exc)}")
+    return clusters
 
 
 def _discover_nsgs(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:

--- a/src/agent_bom/cloud/resource_model.py
+++ b/src/agent_bom/cloud/resource_model.py
@@ -95,6 +95,7 @@ _AZURE_COLLECTION_MAP: dict[str, tuple[CloudResourceType, str]] = {
     "instances": (CloudResourceType.COMPUTE_INSTANCE, "Microsoft.Compute/virtualMachines"),
     "security_groups": (CloudResourceType.NETWORK_SECURITY_GROUP, "Microsoft.Network/networkSecurityGroups"),
     "managed_identities": (CloudResourceType.MANAGED_IDENTITY, "Microsoft.ManagedIdentity/userAssignedIdentities"),
+    "container_clusters": (CloudResourceType.CONTAINER_CLUSTER, "Microsoft.ContainerService/managedClusters"),
     "key_vaults": (CloudResourceType.SECRET_STORE, "Microsoft.KeyVault/vaults"),
     "container_registries": (CloudResourceType.CONTAINER_REGISTRY, "Microsoft.ContainerRegistry/registries"),
     "databases": (CloudResourceType.DATABASE, "Microsoft.DocumentDB/databaseAccounts"),

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -2321,6 +2321,7 @@ def _add_normalized_cloud_resources(
 
     # normalized type -> (label keyword, graph surface, signals a data store)
     type_meta = {
+        CloudResourceType.CONTAINER_CLUSTER: ("kubernetes cluster", "container", False),
         CloudResourceType.SECRET_STORE: ("key vault", "secret-store", True),
         CloudResourceType.CONTAINER_REGISTRY: ("container registry", "registry", False),
         CloudResourceType.DATABASE: ("database", "database", True),

--- a/tests/test_azure_aks_inventory.py
+++ b/tests/test_azure_aks_inventory.py
@@ -1,0 +1,33 @@
+"""AKS clusters inventory → normalized CONTAINER_CLUSTER → graph node."""
+
+from __future__ import annotations
+
+from agent_bom.cloud.resource_model import CloudResourceType, normalize_cloud_inventory
+from agent_bom.graph.builder import build_unified_graph_from_report
+
+_NATIVE = "Microsoft.ContainerService/managedClusters"
+
+
+def _inv(clusters: list[dict]) -> dict:
+    return {"provider": "azure", "status": "ok", "subscription_id": "s", "account_id": "s", "container_clusters": clusters}
+
+
+def test_aks_normalizes_to_container_cluster() -> None:
+    inv = _inv([{"name": "aks1", "id": "/s/aks1", "native_type": _NATIVE}])
+    res = normalize_cloud_inventory(inv)
+    assert [(r.resource_type, r.native_type) for r in res] == [(CloudResourceType.CONTAINER_CLUSTER, _NATIVE)]
+
+
+def test_public_api_server_cluster_is_internet_exposed_node() -> None:
+    inv = _inv([{"name": "aks1", "id": "/s/aks1", "native_type": _NATIVE, "api_server_fqdn": "aks1.azmk8s.io", "internet_facing": True}])
+    g = build_unified_graph_from_report({"cloud_inventory": [inv]})
+    nodes = [n for n in g.nodes.values() if n.attributes.get("resource_type") == "container_cluster"]
+    assert len(nodes) == 1
+    assert nodes[0].attributes["internet_exposed"] is True
+
+
+def test_private_cluster_not_internet_exposed() -> None:
+    inv = _inv([{"name": "aks2", "id": "/s/aks2", "native_type": _NATIVE, "internet_facing": False}])
+    g = build_unified_graph_from_report({"cloud_inventory": [inv]})
+    nodes = [n for n in g.nodes.values() if n.attributes.get("resource_type") == "container_cluster"]
+    assert nodes and nodes[0].attributes["internet_exposed"] is False

--- a/tests/test_azure_cloud_coverage.py
+++ b/tests/test_azure_cloud_coverage.py
@@ -27,6 +27,7 @@ _MODULE_TO_DIST = {
     "compute": "azure-mgmt-compute",
     "containerinstance": "azure-mgmt-containerinstance",
     "containerregistry": "azure-mgmt-containerregistry",
+    "containerservice": "azure-mgmt-containerservice",
     "cosmosdb": "azure-mgmt-cosmosdb",
     "keyvault": "azure-mgmt-keyvault",
     "machinelearningservices": "azure-mgmt-machinelearningservices",


### PR DESCRIPTION
Continues breadth-first Azure coverage — AKS as `CONTAINER_CLUSTER`.

- `_discover_aks_clusters` enumerates managed clusters read-only: Kubernetes version, API-server FQDN, private-cluster flag, RBAC-enabled (no workload/secret contents).
- A cluster with a reachable API-server FQDN that is **not** private is flagged `internet_facing` → graph marks it `internet_exposed`.
- Normalized onto `CloudResource` as `CONTAINER_CLUSTER`, ingested as a graph node. Envelope gains `Microsoft.ContainerService/managedClusters/read`.

Tests: AKS normalizes to CONTAINER_CLUSTER; public-API-server cluster → internet-exposed node; private cluster not. Inventory + graph suites green.