### PR TITLE
feat(cloud): management-group hierarchy — the multi-subscription tenant tree

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ azure = [
     "azure-mgmt-rdbms>=10.1",
     "azure-mgmt-containerregistry>=10.3",
     "azure-mgmt-cosmosdb>=9.5",
+    "azure-mgmt-managementgroups>=1.0",
     "six>=1.16",
 ]
 gcp = [

--- a/src/agent_bom/cloud/azure_inventory.py
+++ b/src/agent_bom/cloud/azure_inventory.py
@@ -98,6 +98,7 @@ def discover_inventory(
     include_identity: bool = True,
     include_data: bool = True,
     include_network: bool = True,
+    include_hierarchy: bool = True,
     force: bool = False,
 ) -> dict[str, Any]:
     """Enumerate the general Azure estate (storage, VMs + NSGs, identities).
@@ -140,6 +141,7 @@ def discover_inventory(
         "virtual_networks": [],
         "public_ips": [],
         "load_balancers": [],
+        "management_groups": [],
         "warnings": [],
         "discovery_envelope": None,
     }
@@ -218,6 +220,13 @@ def discover_inventory(
     public_ips = collected.get("public_ips", [])
     load_balancers = collected.get("load_balancers", [])
 
+    # Management groups are tenant-scoped (above the subscription), so they are
+    # discovered with a single call rather than the per-subscription thread pool.
+    management_groups: list[dict[str, Any]] = []
+    if include_hierarchy:
+        management_groups, mg_warnings = _discover_management_groups(credential)
+        warnings.extend(mg_warnings)
+
     permissions_used: list[str] = []
     if include_storage:
         permissions_used.extend(_AZURE_STORAGE_PERMISSIONS)
@@ -229,6 +238,8 @@ def discover_inventory(
         permissions_used.extend(_AZURE_DATA_PERMISSIONS)
     if include_network:
         permissions_used.extend(_AZURE_NETWORK_PERMISSIONS)
+    if include_hierarchy:
+        permissions_used.append("Microsoft.Management/managementGroups/read")
 
     envelope = DiscoveryEnvelope(
         scan_mode=ScanMode.CLOUD_READ_ONLY,
@@ -254,6 +265,7 @@ def discover_inventory(
         "virtual_networks": virtual_networks,
         "public_ips": public_ips,
         "load_balancers": load_balancers,
+        "management_groups": management_groups,
         "warnings": warnings,
         "discovery_envelope": envelope.to_dict(),
     }
@@ -790,6 +802,61 @@ def _discover_load_balancers(credential: Any, subscription_id: str, *, warnings:
     except Exception as exc:  # noqa: BLE001
         warnings.append(f"Could not list Azure load balancers: {sanitize_discovery_warning(exc)}")
     return load_balancers
+
+
+# ---------------------------------------------------------------------------
+# Management-group hierarchy (tenant-scoped)
+# ---------------------------------------------------------------------------
+
+
+def _discover_management_groups(credential: Any) -> tuple[list[dict[str, Any]], list[str]]:
+    """Enumerate the tenant's management-group hierarchy (read-only, tenant-scoped).
+
+    Management groups sit above subscriptions and organize them into a tree.
+    Each entry carries its direct children (nested management groups and
+    subscriptions) so the graph can build the CONTAINS hierarchy across
+    subscriptions. Requires the Management Group Reader role at the tenant root;
+    absent that, this degrades to an empty list plus a warning.
+    """
+    try:
+        from azure.mgmt.managementgroups import ManagementGroupsAPI
+    except ImportError:
+        return [], ["azure-mgmt-managementgroups not installed. Skipping management-group hierarchy."]
+
+    groups: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    try:
+        client = ManagementGroupsAPI(credential)
+        for mg in client.management_groups.list():
+            name = str(getattr(mg, "name", "") or "").strip()
+            if not name:
+                continue
+            children: list[dict[str, Any]] = []
+            try:
+                detail = client.management_groups.get(group_id=name, expand="children", recurse=False)
+                for child in getattr(detail, "children", None) or []:
+                    children.append(
+                        {
+                            "id": str(getattr(child, "id", "") or ""),
+                            "name": str(getattr(child, "name", "") or ""),
+                            # ".../managementGroups" (nested group) or "/subscriptions" (a subscription)
+                            "type": str(getattr(child, "type", "") or ""),
+                            "display_name": str(getattr(child, "display_name", "") or ""),
+                        }
+                    )
+            except Exception as exc:  # noqa: BLE001 — child expansion is best-effort
+                warnings.append(f"Could not expand management group {name}: {sanitize_discovery_warning(exc)}")
+            groups.append(
+                {
+                    "id": str(getattr(mg, "id", "") or ""),
+                    "name": name,
+                    "display_name": str(getattr(mg, "display_name", "") or ""),
+                    "children": children,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list Azure management groups: {sanitize_discovery_warning(exc)}")
+    return groups, warnings
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -2286,11 +2286,78 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
         resource_ids=resource_ids,
     )
 
+    # ── Management-group hierarchy (org → subscription CONTAINS tree) ──
+    _add_management_group_hierarchy(graph, original_inventory, provider=provider, data_sources=data_sources)
+
     # ── IAM roles + users → identity principals (CAN_ACCESS resources) ──
     for principal in [*(inventory.get("roles", []) or []), *(inventory.get("users", []) or [])]:
         if isinstance(principal, dict):
             _add_inventory_principal(
                 graph, principal, provider=provider, account_node_id=account_node_id, resource_ids=resource_ids, data_sources=data_sources
+            )
+
+
+def _add_management_group_hierarchy(graph: UnifiedGraph, inventory: dict[str, Any], *, provider: str, data_sources: list[str]) -> None:
+    """Build the management-group → subscription hierarchy as ORG nodes + CONTAINS edges.
+
+    Management groups are the tenant tier above subscriptions. Each becomes an
+    ``ORG`` node; its children (nested management groups and subscriptions) are
+    linked with ``CONTAINS``, so the graph carries the multi-subscription
+    hierarchy and blast-radius can reason across the whole tenant. Subscription
+    account nodes are created here if a per-subscription scan hasn't already.
+    """
+    for mg in inventory.get("management_groups", []) or []:
+        if not isinstance(mg, dict):
+            continue
+        name = _clean_graph_part(mg.get("name"))
+        if not name:
+            continue
+        org_node_id = _identity_node_id(EntityType.ORG, provider, name)
+        graph.add_node(
+            UnifiedNode(
+                id=org_node_id,
+                entity_type=EntityType.ORG,
+                label=_clean_graph_part(mg.get("display_name")) or name,
+                attributes={
+                    "management_group_id": _clean_graph_part(mg.get("id")),
+                    "cloud_provider": provider,
+                    "source": "cloud-inventory",
+                },
+                data_sources=data_sources,
+                dimensions=NodeDimensions(cloud_provider=provider, surface="identity"),
+            )
+        )
+        for child in mg.get("children", []) or []:
+            if not isinstance(child, dict):
+                continue
+            child_name = _clean_graph_part(child.get("name"))
+            if not child_name:
+                continue
+            child_type = str(child.get("type") or "").lower()
+            if "managementgroups" in child_type:
+                # The child ORG node is created when its own entry is processed.
+                child_node_id = _identity_node_id(EntityType.ORG, provider, child_name)
+            elif "subscriptions" in child_type:
+                child_node_id = _identity_node_id(EntityType.ACCOUNT, provider, child_name)
+                graph.add_node(
+                    UnifiedNode(
+                        id=child_node_id,
+                        entity_type=EntityType.ACCOUNT,
+                        label=_clean_graph_part(child.get("display_name")) or child_name,
+                        attributes={"account_id": child_name, "cloud_provider": provider, "source": "cloud-inventory"},
+                        data_sources=data_sources,
+                        dimensions=NodeDimensions(cloud_provider=provider, surface="identity"),
+                    )
+                )
+            else:
+                continue
+            graph.add_edge(
+                UnifiedEdge(
+                    source=org_node_id,
+                    target=child_node_id,
+                    relationship=RelationshipType.CONTAINS,
+                    evidence={"source": "cloud-inventory"},
+                )
             )
 
 

--- a/tests/test_azure_cloud_coverage.py
+++ b/tests/test_azure_cloud_coverage.py
@@ -29,6 +29,7 @@ _MODULE_TO_DIST = {
     "containerregistry": "azure-mgmt-containerregistry",
     "cosmosdb": "azure-mgmt-cosmosdb",
     "keyvault": "azure-mgmt-keyvault",
+    "managementgroups": "azure-mgmt-managementgroups",
     "machinelearningservices": "azure-mgmt-machinelearningservices",
     "monitor": "azure-mgmt-monitor",
     "msi": "azure-mgmt-msi",

--- a/tests/test_azure_management_groups.py
+++ b/tests/test_azure_management_groups.py
@@ -1,0 +1,58 @@
+"""Management-group hierarchy → ORG nodes + CONTAINS edges (multi-subscription tree)."""
+
+from __future__ import annotations
+
+from agent_bom.graph.builder import build_unified_graph_from_report
+
+
+def _report() -> dict:
+    return {
+        "cloud_inventory": [
+            {
+                "provider": "azure",
+                "status": "ok",
+                "subscription_id": "sub-1",
+                "account_id": "sub-1",
+                "management_groups": [
+                    {
+                        "id": "/providers/.../mg-root",
+                        "name": "mg-root",
+                        "display_name": "Tenant Root",
+                        "children": [
+                            {"id": "/m/mg-eng", "name": "mg-eng", "type": "Microsoft.Management/managementGroups", "display_name": "Eng"},
+                            {"id": "/subscriptions/sub-1", "name": "sub-1", "type": "/subscriptions", "display_name": "Prod"},
+                        ],
+                    },
+                    {
+                        "id": "/providers/.../mg-eng",
+                        "name": "mg-eng",
+                        "display_name": "Eng",
+                        "children": [{"id": "/subscriptions/sub-2", "name": "sub-2", "type": "/subscriptions", "display_name": "Dev"}],
+                    },
+                ],
+            }
+        ]
+    }
+
+
+def _build():
+    g = build_unified_graph_from_report(_report())
+    edges = list(g.edges.values()) if isinstance(g.edges, dict) else list(g.edges)
+    return g, edges
+
+
+def test_management_groups_become_org_nodes() -> None:
+    g, _ = _build()
+    orgs = {k for k, n in g.nodes.items() if str(getattr(n, "entity_type", "")).split(".")[-1].lower() == "org"}
+    assert {"org:azure:mg-root", "org:azure:mg-eng"} <= orgs
+
+
+def test_contains_edges_span_nested_groups_and_subscriptions() -> None:
+    g, edges = _build()
+    contains = {(e.source, e.target) for e in edges if e.relationship.value == "contains"}
+    assert ("org:azure:mg-root", "org:azure:mg-eng") in contains  # MG → nested MG
+    assert ("org:azure:mg-root", "account:azure:sub-1") in contains  # MG → subscription
+    assert ("org:azure:mg-eng", "account:azure:sub-2") in contains
+    # subscription nodes exist even though only sub-1 was the scanned subscription
+    accounts = {k for k, n in g.nodes.items() if str(getattr(n, "entity_type", "")).split(".")[-1].lower() == "account"}
+    assert {"account:azure:sub-1", "account:azure:sub-2"} <= accounts

--- a/tests/test_azure_parallel_discovery.py
+++ b/tests/test_azure_parallel_discovery.py
@@ -52,7 +52,7 @@ def test_discovery_runs_concurrently(monkeypatch) -> None:
     for name in _SERVICES:
         monkeypatch.setattr(azinv, name, _slow_stub(name))
     start = time.time()
-    inv = azinv.discover_inventory("sub-1", credential=object(), force=True)
+    inv = azinv.discover_inventory("sub-1", credential=object(), include_hierarchy=False, force=True)
     elapsed = time.time() - start
     # 10 × 0.15s sequential = 1.5s; concurrent should be well under half that.
     assert elapsed < 0.75, f"discovery not parallel (took {elapsed:.2f}s)"
@@ -64,8 +64,8 @@ def test_discovery_runs_concurrently(monkeypatch) -> None:
 def test_warnings_preserved_in_deterministic_order(monkeypatch) -> None:
     for name in _SERVICES:
         monkeypatch.setattr(azinv, name, _slow_stub(name, delay=0.0))
-    inv = azinv.discover_inventory("sub-1", credential=object(), force=True)
-    assert len(inv["warnings"]) == 10
+    inv = azinv.discover_inventory("sub-1", credential=object(), include_hierarchy=False, force=True)
+    assert len(inv["warnings"]) == len(_SERVICES)
     # storage is the first task → its warning is first regardless of completion order
     assert inv["warnings"][0] == "warn-_discover_storage_accounts"
 
@@ -77,7 +77,7 @@ def test_one_service_failing_does_not_sink_others(monkeypatch) -> None:
     for name in _SERVICES:
         monkeypatch.setattr(azinv, name, _slow_stub(name, delay=0.0))
     monkeypatch.setattr(azinv, "_discover_key_vaults", boom)
-    inv = azinv.discover_inventory("sub-1", credential=object(), force=True)
+    inv = azinv.discover_inventory("sub-1", credential=object(), include_hierarchy=False, force=True)
     assert inv["status"] == "ok"
     assert inv["key_vaults"] == []  # failed service is empty
     assert len(inv["storage_accounts"]) == 1  # others unaffected

--- a/uv.lock
+++ b/uv.lock
@@ -66,6 +66,7 @@ all = [
     { name = "azure-mgmt-cosmosdb" },
     { name = "azure-mgmt-keyvault" },
     { name = "azure-mgmt-machinelearningservices" },
+    { name = "azure-mgmt-managementgroups" },
     { name = "azure-mgmt-monitor" },
     { name = "azure-mgmt-msi" },
     { name = "azure-mgmt-network" },
@@ -137,6 +138,7 @@ azure = [
     { name = "azure-mgmt-cosmosdb" },
     { name = "azure-mgmt-keyvault" },
     { name = "azure-mgmt-machinelearningservices" },
+    { name = "azure-mgmt-managementgroups" },
     { name = "azure-mgmt-monitor" },
     { name = "azure-mgmt-msi" },
     { name = "azure-mgmt-network" },
@@ -160,6 +162,7 @@ cloud = [
     { name = "azure-mgmt-cosmosdb" },
     { name = "azure-mgmt-keyvault" },
     { name = "azure-mgmt-machinelearningservices" },
+    { name = "azure-mgmt-managementgroups" },
     { name = "azure-mgmt-monitor" },
     { name = "azure-mgmt-msi" },
     { name = "azure-mgmt-network" },
@@ -347,6 +350,7 @@ requires-dist = [
     { name = "azure-mgmt-cosmosdb", marker = "extra == 'azure'", specifier = ">=9.5" },
     { name = "azure-mgmt-keyvault", marker = "extra == 'azure'", specifier = ">=10.3" },
     { name = "azure-mgmt-machinelearningservices", marker = "extra == 'azure'", specifier = ">=1.0" },
+    { name = "azure-mgmt-managementgroups", marker = "extra == 'azure'", specifier = ">=1.0" },
     { name = "azure-mgmt-monitor", marker = "extra == 'azure'", specifier = ">=6.0" },
     { name = "azure-mgmt-msi", marker = "extra == 'azure'", specifier = ">=7.0" },
     { name = "azure-mgmt-network", marker = "extra == 'azure'", specifier = ">=25.0" },
@@ -872,6 +876,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/9e/650ef981f3051d450c68b09544d9110d3ea1120f7f828f0e014445c2d203/azure_mgmt_machinelearningservices-1.0.1.tar.gz", hash = "sha256:940a3c3b2f2b09db98d99965bce68d8f38a3d724e5b7bb70bbe71da34931378d", size = 88083, upload-time = "2026-05-18T05:59:53.285Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/0e/9c715efa7c8bbdfdf272a84fe617a3f0c74d64230b1042432a53f450b4c3/azure_mgmt_machinelearningservices-1.0.1-py3-none-any.whl", hash = "sha256:c272913695b8152725be599394c88d046e987098226f8631541a336f68fba6dd", size = 137444, upload-time = "2026-05-18T05:59:54.836Z" },
+]
+
+[[package]]
+name = "azure-mgmt-managementgroups"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-mgmt-core" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/73/ac5e064ed7343e1b3172f32f09be3efca906087218d3046b5038f2f394ed/azure_mgmt_managementgroups-1.1.0.tar.gz", hash = "sha256:e6199baf118890ba2bda35dda83a88861c0b1bbef126311b20ec12eed9681951", size = 60101, upload-time = "2026-02-13T03:45:45.439Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/bc/993158de03cc0a49f2cf8192615ffedbc508c417cb3522e88f6652b714cc/azure_mgmt_managementgroups-1.1.0-py3-none-any.whl", hash = "sha256:140934589559ef6afcac6f1d24f995588a1965aaa89d47851c1cc639fafb1942", size = 83586, upload-time = "2026-02-13T03:45:46.836Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Multi-tenant/multi-subscription hierarchy — the tier above subscriptions.

- `_discover_management_groups` enumerates the tenant management-group tree read-only (tenant-scoped; needs Management Group Reader, degrades to empty+warning), capturing each group's direct children (nested MGs + subscriptions).
- Graph builder turns each MG into an `ORG` node, links children with `CONTAINS`, creating subscription `ACCOUNT` nodes as needed.

Result: **org → management-group → subscription → resource** hierarchy, so graph + blast-radius reason across a whole multi-subscription tenant. Reuses `ORG` + `CONTAINS` — no new vocab. Behind `include_hierarchy` flag with its own read-only permission.

Tests build a root→{nested MG, subscription}→subscription tree and assert the ORG nodes + CONTAINS edges (incl. a subscription beyond the scanned one). Suites green (29 passed).