### PR TITLE
fix(cloud): load the private key for Snowflake snowflake_jwt auth

### DIFF
--- a/src/agent_bom/cloud/snowflake.py
+++ b/src/agent_bom/cloud/snowflake.py
@@ -95,6 +95,23 @@ def _snowflake_cloud_origin(
     )
 
 
+def _apply_key_pair(conn_kwargs: dict[str, Any]) -> bool:
+    """Load the RSA key-pair (``SNOWFLAKE_PRIVATE_KEY_PATH``) into *conn_kwargs*.
+
+    Returns ``True`` when a key path was configured. Shared by the explicit
+    ``snowflake_jwt`` authenticator path and the implicit key-pair fallback so a
+    private key is loaded in both — never just the authenticator name alone.
+    """
+    key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH", "")
+    if not key_path:
+        return False
+    conn_kwargs["private_key_file"] = key_path
+    passphrase = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE", "")
+    if passphrase:
+        conn_kwargs["private_key_file_pwd"] = passphrase
+    return True
+
+
 def _resolve_snowflake_auth(
     conn_kwargs: dict[str, Any],
     authenticator: str | None,
@@ -109,15 +126,16 @@ def _resolve_snowflake_auth(
         authenticator = os.environ.get("SNOWFLAKE_AUTHENTICATOR", "")
     if authenticator:
         conn_kwargs["authenticator"] = authenticator
+        # `snowflake_jwt` is key-pair auth — it still needs the private key
+        # loaded. Without this, setting SNOWFLAKE_AUTHENTICATOR=snowflake_jwt
+        # (the documented key-pair option) sent the authenticator with no key
+        # and the connector failed with "Expected bytes ... got NoneType".
+        if authenticator.lower() == "snowflake_jwt":
+            _apply_key_pair(conn_kwargs)
         return
 
     # Key-pair auth (recommended for CI/CD)
-    key_path = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH", "")
-    if key_path:
-        conn_kwargs["private_key_file"] = key_path
-        passphrase = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE", "")
-        if passphrase:
-            conn_kwargs["private_key_file_pwd"] = passphrase
+    if _apply_key_pair(conn_kwargs):
         return
 
     # Password auth — deprecated, emit warning
@@ -496,7 +514,7 @@ def _discover_streamlit_apps(
     cursor = conn.cursor()
 
     try:
-        cursor.execute("SHOW STREAMLIT IN ACCOUNT")
+        cursor.execute("SHOW STREAMLITS IN ACCOUNT")
         rows = cursor.fetchall()
         columns = [desc[0].lower() for desc in cursor.description] if cursor.description else []
 

--- a/tests/test_snowflake_keypair_auth.py
+++ b/tests/test_snowflake_keypair_auth.py
@@ -1,0 +1,49 @@
+"""Snowflake key-pair auth must load the private key, including with snowflake_jwt."""
+
+from __future__ import annotations
+
+from agent_bom.cloud.snowflake import _apply_key_pair, _resolve_snowflake_auth
+
+
+def test_explicit_snowflake_jwt_loads_private_key(monkeypatch) -> None:
+    """SNOWFLAKE_AUTHENTICATOR=snowflake_jwt must still load the key-pair.
+
+    Regression: previously the authenticator was set and the function returned
+    without loading the key, so the connector got snowflake_jwt with no key.
+    """
+    monkeypatch.setenv("SNOWFLAKE_PRIVATE_KEY_PATH", "/keys/rsa.p8")
+    conn: dict = {}
+    _resolve_snowflake_auth(conn, "snowflake_jwt")
+    assert conn["authenticator"] == "snowflake_jwt"
+    assert conn["private_key_file"] == "/keys/rsa.p8"
+
+
+def test_implicit_keypair_still_works(monkeypatch) -> None:
+    monkeypatch.setenv("SNOWFLAKE_PRIVATE_KEY_PATH", "/keys/rsa.p8")
+    conn: dict = {}
+    _resolve_snowflake_auth(conn, None)
+    assert conn["private_key_file"] == "/keys/rsa.p8"
+    assert "authenticator" not in conn  # connector infers JWT from the key file
+
+
+def test_apply_key_pair_with_passphrase(monkeypatch) -> None:
+    monkeypatch.setenv("SNOWFLAKE_PRIVATE_KEY_PATH", "/keys/rsa.p8")
+    monkeypatch.setenv("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE", "secret")
+    conn: dict = {}
+    assert _apply_key_pair(conn) is True
+    assert conn["private_key_file_pwd"] == "secret"
+
+
+def test_apply_key_pair_no_path_returns_false(monkeypatch) -> None:
+    monkeypatch.delenv("SNOWFLAKE_PRIVATE_KEY_PATH", raising=False)
+    conn: dict = {}
+    assert _apply_key_pair(conn) is False
+    assert conn == {}
+
+
+def test_non_jwt_authenticator_does_not_load_key(monkeypatch) -> None:
+    """externalbrowser / oauth should not pull in a key file."""
+    monkeypatch.setenv("SNOWFLAKE_PRIVATE_KEY_PATH", "/keys/rsa.p8")
+    conn: dict = {}
+    _resolve_snowflake_auth(conn, "externalbrowser")
+    assert conn == {"authenticator": "externalbrowser"}


### PR DESCRIPTION
Found by a live Snowflake key-pair scan: it failed with `Expected bytes,
RSAPrivateKey, or EllipticCurvePrivateKey, got NoneType`.

## Root cause
`_resolve_snowflake_auth` sets the authenticator and `return`s immediately when
one is configured. So `SNOWFLAKE_AUTHENTICATOR=snowflake_jwt` — the **documented**
key-pair option — sent the authenticator to the connector but never loaded
`SNOWFLAKE_PRIVATE_KEY_PATH`. The no-password key-pair flow (the recommended,
policy-compliant auth) was broken end to end.

## Fix
- Extract key-pair loading into `_apply_key_pair`, called from **both** the
  explicit `snowflake_jwt` path and the implicit key-pair fallback — the private
  key is loaded whenever it's present.
- `SHOW STREAMLIT IN ACCOUNT` → `SHOW STREAMLITS` (the singular form is a SQL
  syntax error that broke Streamlit discovery).

## Verified
The same scan that failed now connects with `SNOWFLAKE_AUTHENTICATOR=snowflake_jwt`
+ `SNOWFLAKE_PRIVATE_KEY_PATH` against a real account, and Streamlit discovery no
longer errors. Tests cover snowflake_jwt loading the key, the implicit fallback,
passphrase handling, no-path, and that non-JWT authenticators don't pull a key.