### PR TITLE
feat(cloud): Snowflake grants → permission graph (CIEM access layer)

### DIFF
--- a/src/agent_bom/cloud/snowflake.py
+++ b/src/agent_bom/cloud/snowflake.py
@@ -1833,6 +1833,62 @@ def _discover_sf_dependencies(conn: Any, warnings: list[str]) -> list[dict[str, 
     return dependencies
 
 
+def _discover_sf_grants(conn: Any, warnings: list[str]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Object-level role grants + user→role memberships (the CIEM access graph).
+
+    ``GRANTS_TO_ROLES`` (filtered to TABLE/VIEW) → a role's privilege on an
+    object; ``GRANTS_TO_USERS`` → a user's role memberships. Read-only metadata.
+    """
+    grants: list[dict[str, Any]] = []
+    cursor = conn.cursor()
+    try:
+        cursor.execute(
+            "SELECT grantee_name, privilege, granted_on, name, table_catalog, table_schema "
+            "FROM SNOWFLAKE.ACCOUNT_USAGE.GRANTS_TO_ROLES "
+            "WHERE deleted_on IS NULL AND granted_on IN ('TABLE', 'VIEW') "
+            "ORDER BY grantee_name LIMIT 100000"
+        )
+        keys = [d[0].lower() for d in cursor.description] if cursor.description else []
+        for row in cursor.fetchall():
+            r = dict(zip(keys, row))
+            role = str(r.get("grantee_name", ""))
+            db, sch, nm = str(r.get("table_catalog", "")), str(r.get("table_schema", "")), str(r.get("name", ""))
+            if not role or not nm:
+                continue
+            grants.append(
+                {
+                    "role": role,
+                    "privilege": str(r.get("privilege", "")),
+                    "object_fqn": f"{db}.{sch}.{nm}",
+                    "object_type": str(r.get("granted_on", "")).lower(),
+                }
+            )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not query GRANTS_TO_ROLES: {sanitize_error(exc)}")
+    finally:
+        cursor.close()
+
+    memberships: list[dict[str, Any]] = []
+    cursor = conn.cursor()
+    try:
+        cursor.execute(
+            "SELECT grantee_name, role FROM SNOWFLAKE.ACCOUNT_USAGE.GRANTS_TO_USERS "
+            "WHERE deleted_on IS NULL ORDER BY grantee_name LIMIT 10000"
+        )
+        keys = [d[0].lower() for d in cursor.description] if cursor.description else []
+        for row in cursor.fetchall():
+            r = dict(zip(keys, row))
+            user_name, role = str(r.get("grantee_name", "")), str(r.get("role", ""))
+            if user_name and role:
+                memberships.append({"user": user_name, "role": role})
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not query GRANTS_TO_USERS: {sanitize_error(exc)}")
+    finally:
+        cursor.close()
+
+    return grants, memberships
+
+
 def discover_object_dependencies(
     account: str | None = None,
     user: str | None = None,
@@ -1840,14 +1896,16 @@ def discover_object_dependencies(
     database: str | None = None,
     schema: str | None = None,
 ) -> dict[str, Any]:
-    """Discover the Snowflake object + dependency graph (read-only).
+    """Discover the Snowflake object + dependency + permission graph (read-only).
 
     Tables and views become DATA_STORE graph nodes; OBJECT_DEPENDENCIES become
-    DEPENDS_ON edges (referencing object → referenced object). Read-only,
-    control-plane metadata only — object names/types/counts, never row data.
+    DEPENDS_ON edges (referencing → referenced). Object-level role grants become
+    HAS_PERMISSION edges (role → object) and user→role memberships become
+    ASSUMES edges. Read-only, control-plane metadata only — never row data.
 
     Returns a payload with ``status`` (``"ok"`` / ``"disabled"`` /
-    ``"no_account"``), ``objects``, ``dependencies``, and ``warnings``.
+    ``"no_account"``), ``objects``, ``dependencies``, ``grants``,
+    ``role_memberships``, and ``warnings``.
 
     Raises:
         CloudDiscoveryError: if snowflake-connector-python is not installed.
@@ -1865,6 +1923,8 @@ def discover_object_dependencies(
         "account": resolved_account,
         "objects": [],
         "dependencies": [],
+        "grants": [],
+        "role_memberships": [],
         "warnings": [],
     }
     warnings: list[str] = result["warnings"]
@@ -1884,6 +1944,7 @@ def discover_object_dependencies(
     try:
         result["objects"] = _discover_sf_objects(conn, warnings)
         result["dependencies"] = _discover_sf_dependencies(conn, warnings)
+        result["grants"], result["role_memberships"] = _discover_sf_grants(conn, warnings)
         result["status"] = "ok"
     finally:
         conn.close()

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -2157,6 +2157,73 @@ def _add_snowflake_object_graph(graph: UnifiedGraph, payload: Any, data_source: 
             )
         )
 
+    # ── Roles + users (CIEM access layer) ──────────────────────────────
+    seen_roles: set[str] = set()
+
+    def _ensure_role(name: str) -> str:
+        node_id = f"role:snowflake:{name}"
+        if node_id not in seen_roles:
+            seen_roles.add(node_id)
+            graph.add_node(
+                UnifiedNode(
+                    id=node_id,
+                    entity_type=EntityType.ROLE,
+                    label=f"role: {name}",
+                    attributes={"role_name": name, "cloud_provider": "snowflake", "source": "snowflake-objects"},
+                    data_sources=data_sources,
+                    dimensions=NodeDimensions(cloud_provider="snowflake", surface="identity"),
+                )
+            )
+        return node_id
+
+    # Object-level grants: role HAS_PERMISSION on the object (data store).
+    for grant in payload.get("grants", []) or []:
+        if not isinstance(grant, dict):
+            continue
+        role = _clean_graph_part(grant.get("role"))
+        object_fqn = _clean_graph_part(grant.get("object_fqn"))
+        if not role or not object_fqn:
+            continue
+        graph.add_edge(
+            UnifiedEdge(
+                source=_ensure_role(role),
+                target=_ensure_object(object_fqn, object_type=str(grant.get("object_type") or "object").lower()),
+                relationship=RelationshipType.HAS_PERMISSION,
+                evidence={"source": "snowflake-objects", "privilege": grant.get("privilege", "")},
+            )
+        )
+
+    # User → role memberships: the user ASSUMES the role's privileges.
+    seen_users: set[str] = set()
+    for membership in payload.get("role_memberships", []) or []:
+        if not isinstance(membership, dict):
+            continue
+        user_name = _clean_graph_part(membership.get("user"))
+        role = _clean_graph_part(membership.get("role"))
+        if not user_name or not role:
+            continue
+        user_node_id = f"user:snowflake:{user_name}"
+        if user_node_id not in seen_users:
+            seen_users.add(user_node_id)
+            graph.add_node(
+                UnifiedNode(
+                    id=user_node_id,
+                    entity_type=EntityType.USER,
+                    label=f"user: {user_name}",
+                    attributes={"user_name": user_name, "cloud_provider": "snowflake", "source": "snowflake-objects"},
+                    data_sources=data_sources,
+                    dimensions=NodeDimensions(cloud_provider="snowflake", surface="identity"),
+                )
+            )
+        graph.add_edge(
+            UnifiedEdge(
+                source=user_node_id,
+                target=_ensure_role(role),
+                relationship=RelationshipType.ASSUMES,
+                evidence={"source": "snowflake-objects"},
+            )
+        )
+
 
 def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) -> None:
     """Promote estate-wide cloud inventory into first-class graph nodes.

--- a/tests/test_snowflake_object_graph.py
+++ b/tests/test_snowflake_object_graph.py
@@ -76,3 +76,34 @@ def test_thin_node_created_for_external_dependency_endpoint() -> None:
 def test_non_ok_payload_is_noop() -> None:
     g = build_unified_graph_from_report({"snowflake_object_graph": {"status": "no_account"}})
     assert not [k for k in g.nodes if "snowflake" in k]
+
+
+def _report_with_grants() -> dict:
+    return {
+        "snowflake_object_graph": {
+            "status": "ok",
+            "account": "acct1",
+            "objects": [{"fqn": "DB.PUBLIC.ORDERS", "name": "ORDERS", "object_type": "table"}],
+            "dependencies": [],
+            "grants": [
+                {"role": "ANALYST", "privilege": "SELECT", "object_fqn": "DB.PUBLIC.ORDERS", "object_type": "table"},
+            ],
+            "role_memberships": [{"user": "ALICE", "role": "ANALYST"}],
+        }
+    }
+
+
+def test_grants_become_role_has_permission_edges() -> None:
+    g = build_unified_graph_from_report(_report_with_grants())
+    edges = list(g.edges.values()) if isinstance(g.edges, dict) else list(g.edges)
+    assert "role:snowflake:ANALYST" in g.nodes
+    has_perm = {(e.source, e.target) for e in edges if e.relationship.value == "has_permission"}
+    assert ("role:snowflake:ANALYST", "data_store:snowflake:DB.PUBLIC.ORDERS") in has_perm
+
+
+def test_user_role_membership_becomes_assumes_edge() -> None:
+    g = build_unified_graph_from_report(_report_with_grants())
+    edges = list(g.edges.values()) if isinstance(g.edges, dict) else list(g.edges)
+    assert "user:snowflake:ALICE" in g.nodes
+    assumes = {(e.source, e.target) for e in edges if e.relationship.value == "assumes"}
+    assert ("user:snowflake:ALICE", "role:snowflake:ANALYST") in assumes


### PR DESCRIPTION
Stacked on #3058. Extends the object graph with the **access layer** — who can reach which data.

- `discover_object_dependencies` now also pulls object-level role grants (`GRANTS_TO_ROLES`, TABLE/VIEW) + user→role memberships (`GRANTS_TO_USERS`), read-only.
- Graph: role + user nodes; `HAS_PERMISSION` edge role→object; `ASSUMES` edge user→role. So the graph answers **who can reach which data object** (user → role → data).

**Verified live:** 246 grants + 5 memberships → 21 role nodes, 4 user nodes, 101 `HAS_PERMISSION` edges, 5 `ASSUMES` edges — surfacing that **WSAAD** (a no-MFA password ACCOUNTADMIN) reaches data objects through ACCOUNTADMIN/ORGADMIN. Tests cover both edge types.