### PR TITLE
fix(cloud): flag empty-type Snowflake users as weak-auth (live-caught)

### DIFF
--- a/src/agent_bom/cloud/snowflake.py
+++ b/src/agent_bom/cloud/snowflake.py
@@ -2453,7 +2453,7 @@ def discover_auth_posture(
                         "disabled": disabled,
                         "auth_methods": auth_methods,
                         "has_mfa": has_mfa,
-                        "user_type": user_type or "unknown",
+                        "user_type": user_type or "UNKNOWN",
                         "default_role": str(r.get("default_role", "") or ""),
                     }
                 )

--- a/tests/test_snowflake_auth_posture_discovery.py
+++ b/tests/test_snowflake_auth_posture_discovery.py
@@ -50,6 +50,10 @@ class _FakeCursor:
                 ("SVC_PIPE", False, False, True, False, "INGEST", "SERVICE", False),
                 # disabled → ignored
                 ("OLD_USER", True, True, False, False, "PUBLIC", "PERSON", False),
+                # human, password, no MFA, EMPTY type column → must still be flagged
+                # (live regression: empty type defaulted to lowercase "unknown" and
+                # the uppercase "UNKNOWN" filter missed it — an ACCOUNTADMIN slipped through)
+                ("ADMIN_X", False, True, False, False, "ACCOUNTADMIN", "", False),
             ]
         else:
             self.description = []
@@ -106,8 +110,9 @@ def test_password_user_without_mfa_flagged_excludes_service_and_disabled(monkeyp
     out = _run(monkeypatch, account_np="CORP_POLICY")  # set account policy so only the MFA finding remains
     mfa_findings = [f for f in out["findings"] if f["title"] == "Password users without MFA"]
     assert mfa_findings, "expected an MFA finding"
-    # Only WSAAD qualifies: ALICE has MFA, SVC_PIPE is service, OLD_USER disabled.
-    assert "1 enabled human user" in mfa_findings[0]["detail"]
+    # WSAAD (PERSON) + ADMIN_X (empty type) qualify; ALICE has MFA, SVC_PIPE is
+    # service, OLD_USER disabled. The empty-type user must NOT be missed.
+    assert "2 enabled human user" in mfa_findings[0]["detail"]
     assert out["status"] == "ok"
 
 


### PR DESCRIPTION
## What

Live scan of a real Snowflake account found an **ACCOUNTADMIN user** (`WSAAD`: password auth, no MFA, empty `type` column) that was **NOT flagged** by the "Password users without MFA" check.

**Root cause:** `discover_auth_posture` defaulted an empty type to lowercase `"unknown"`, but the weak-auth filter matched uppercase `"UNKNOWN"` → the user slipped through. The graph identity builder uppercases before comparing, so it *would* flag the same user — leaving discovery findings and the graph inconsistent.

**Fix:** default to `"UNKNOWN"` for consistency. Now both the finding and the graph agree.

## Validated live
On the real account, after the fix: `HIGH — Password users without MFA: 1 enabled human user(s)` now fires for the ACCOUNTADMIN-without-MFA user (confirmed legitimately bad practice). Regression test added: a password + no-MFA user with an empty type column must be flagged.