### PR TITLE
feat(cloud): AWS inventory parity batch 2 — ELB, VPC, KMS, Secrets Manager

### DIFF
--- a/src/agent_bom/cloud/aws_inventory.py
+++ b/src/agent_bom/cloud/aws_inventory.py
@@ -88,6 +88,16 @@ _AWS_COMPUTE_PERMISSIONS: tuple[str, ...] = (
     "eks:ListClusters",
     "eks:DescribeCluster",
 )
+_AWS_NETWORK_PERMISSIONS: tuple[str, ...] = (
+    "elasticloadbalancing:DescribeLoadBalancers",
+    "ec2:DescribeVpcs",
+)
+_AWS_SECURITY_PERMISSIONS: tuple[str, ...] = (
+    "kms:ListKeys",
+    "kms:DescribeKey",
+    "kms:GetKeyRotationStatus",
+    "secretsmanager:ListSecrets",
+)
 _AWS_BASELINE_PERMISSIONS: tuple[str, ...] = ("sts:GetCallerIdentity",)
 
 # Open-to-the-world CIDR / ipv6 ranges that mark a security-group ingress rule
@@ -114,6 +124,7 @@ def discover_inventory(
     include_iam: bool = True,
     include_data: bool = True,
     include_compute: bool = True,
+    include_network: bool = True,
     force: bool = False,
 ) -> dict[str, Any]:
     """Enumerate the general AWS estate (S3, EC2 + security groups, IAM).
@@ -146,6 +157,10 @@ def discover_inventory(
         "lambda_functions": [],
         "dynamodb_tables": [],
         "eks_clusters": [],
+        "elb_load_balancers": [],
+        "vpcs": [],
+        "kms_keys": [],
+        "secrets": [],
         "warnings": [],
         "discovery_envelope": None,
     }
@@ -187,6 +202,10 @@ def discover_inventory(
     lambda_functions: list[dict[str, Any]] = []
     dynamodb_tables: list[dict[str, Any]] = []
     eks_clusters: list[dict[str, Any]] = []
+    elb_load_balancers: list[dict[str, Any]] = []
+    vpcs: list[dict[str, Any]] = []
+    kms_keys: list[dict[str, Any]] = []
+    secrets: list[dict[str, Any]] = []
 
     try:
         if include_s3:
@@ -198,9 +217,14 @@ def discover_inventory(
         if include_data:
             rds_instances = _discover_rds(session, resolved_region, account_id=account_id, warnings=warnings)
             dynamodb_tables = _discover_dynamodb(session, resolved_region, account_id=account_id, warnings=warnings)
+            kms_keys = _discover_kms(session, resolved_region, account_id=account_id, warnings=warnings)
+            secrets = _discover_secrets(session, resolved_region, account_id=account_id, warnings=warnings)
         if include_compute:
             lambda_functions = _discover_lambda(session, resolved_region, account_id=account_id, warnings=warnings)
             eks_clusters = _discover_eks(session, resolved_region, account_id=account_id, warnings=warnings)
+        if include_network:
+            elb_load_balancers = _discover_elb(session, resolved_region, account_id=account_id, warnings=warnings)
+            vpcs = _discover_vpcs(session, resolved_region, account_id=account_id, warnings=warnings)
     except NoCredentialsError:
         return {
             **empty,
@@ -219,6 +243,10 @@ def discover_inventory(
         permissions_used.extend(_AWS_DATA_PERMISSIONS)
     if include_compute:
         permissions_used.extend(_AWS_COMPUTE_PERMISSIONS)
+    if include_data:
+        permissions_used.extend(_AWS_SECURITY_PERMISSIONS)
+    if include_network:
+        permissions_used.extend(_AWS_NETWORK_PERMISSIONS)
 
     discovery_scope: list[str] = []
     if account_id:
@@ -247,6 +275,10 @@ def discover_inventory(
         "lambda_functions": lambda_functions,
         "dynamodb_tables": dynamodb_tables,
         "eks_clusters": eks_clusters,
+        "elb_load_balancers": elb_load_balancers,
+        "vpcs": vpcs,
+        "kms_keys": kms_keys,
+        "secrets": secrets,
         "warnings": warnings,
         "discovery_envelope": envelope.to_dict(),
     }
@@ -725,6 +757,128 @@ def _discover_eks(session: Any, region: str, *, account_id: str | None, warnings
             )
     except Exception as exc:  # noqa: BLE001
         warnings.append(f"Could not list EKS clusters: {sanitize_discovery_warning(exc)}")
+    return out
+
+
+def _discover_elb(session: Any, region: str, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate ALB/NLB load balancers (read-only). Internet-facing scheme = exposed."""
+    out: list[dict[str, Any]] = []
+    try:
+        client = session.client("elbv2", region_name=region)
+        paginator = client.get_paginator("describe_load_balancers")
+        for page in paginator.paginate():
+            for lb in page.get("LoadBalancers", []):
+                name = str(lb.get("LoadBalancerName", "") or "")
+                if not name:
+                    continue
+                out.append(
+                    {
+                        "name": name,
+                        "arn": str(lb.get("LoadBalancerArn", "") or ""),
+                        "scheme": str(lb.get("Scheme", "") or ""),
+                        "lb_type": str(lb.get("Type", "") or ""),
+                        "internet_exposed": str(lb.get("Scheme", "")).lower() == "internet-facing",
+                        "dns_name": str(lb.get("DNSName", "") or ""),
+                        "vpc_id": str(lb.get("VpcId", "") or ""),
+                        "account_id": account_id or "",
+                        "location": region,
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list load balancers: {sanitize_discovery_warning(exc)}")
+    return out
+
+
+def _discover_vpcs(session: Any, region: str, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate VPCs (read-only). Become ``CLOUD_RESOURCE`` network nodes."""
+    out: list[dict[str, Any]] = []
+    try:
+        client = session.client("ec2", region_name=region)
+        for vpc in client.describe_vpcs().get("Vpcs", []):
+            vpc_id = str(vpc.get("VpcId", "") or "")
+            if not vpc_id:
+                continue
+            tags = {str(t.get("Key", "")): str(t.get("Value", "")) for t in vpc.get("Tags", []) if t.get("Key")}
+            out.append(
+                {
+                    # vpc_id is the stable node identifier; the Name tag is display-only.
+                    "name": vpc_id,
+                    "display_name": tags.get("Name") or vpc_id,
+                    "vpc_id": vpc_id,
+                    "cidr": str(vpc.get("CidrBlock", "") or ""),
+                    "is_default": bool(vpc.get("IsDefault")),
+                    "tags": tags,
+                    "account_id": account_id or "",
+                    "location": region,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list VPCs: {sanitize_discovery_warning(exc)}")
+    return out
+
+
+def _discover_kms(session: Any, region: str, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate customer-managed KMS keys (read-only). Metadata only, never key material."""
+    out: list[dict[str, Any]] = []
+    try:
+        client = session.client("kms", region_name=region)
+        paginator = client.get_paginator("list_keys")
+        for page in paginator.paginate():
+            for key in page.get("Keys", []):
+                key_id = str(key.get("KeyId", "") or "")
+                if not key_id:
+                    continue
+                manager, enabled, rotation = "", True, None
+                try:
+                    meta = client.describe_key(KeyId=key_id).get("KeyMetadata", {})
+                    manager = str(meta.get("KeyManager", "") or "")
+                    enabled = bool(meta.get("Enabled", True))
+                    if manager == "AWS":  # skip AWS-managed keys — not customer's responsibility
+                        continue
+                    try:
+                        rotation = bool(client.get_key_rotation_status(KeyId=key_id).get("KeyRotationEnabled"))
+                    except Exception:  # noqa: BLE001
+                        rotation = None
+                except Exception:  # noqa: BLE001
+                    meta = {}
+                out.append(
+                    {
+                        "name": key_id,
+                        "arn": str(key.get("KeyArn", "") or ""),
+                        "enabled": enabled,
+                        "rotation_enabled": rotation,
+                        "account_id": account_id or "",
+                        "location": region,
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list KMS keys: {sanitize_discovery_warning(exc)}")
+    return out
+
+
+def _discover_secrets(session: Any, region: str, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate Secrets Manager secrets (read-only). Metadata only — never secret values."""
+    out: list[dict[str, Any]] = []
+    try:
+        client = session.client("secretsmanager", region_name=region)
+        paginator = client.get_paginator("list_secrets")
+        for page in paginator.paginate():
+            for sec in page.get("SecretList", []):
+                name = str(sec.get("Name", "") or "")
+                if not name:
+                    continue
+                out.append(
+                    {
+                        "name": name,
+                        "arn": str(sec.get("ARN", "") or ""),
+                        "rotation_enabled": bool(sec.get("RotationEnabled")),
+                        "last_changed": _iso(sec.get("LastChangedDate")),
+                        "account_id": account_id or "",
+                        "location": region,
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list Secrets Manager secrets: {sanitize_discovery_warning(exc)}")
     return out
 
 

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -3444,6 +3444,10 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
         ("dynamodb_tables", "dynamodb", "database", "dynamodb-table", "dynamodb table", True),
         ("lambda_functions", "lambda", "function", "lambda-function", "lambda function", False),
         ("eks_clusters", "eks", "container_cluster", "eks-cluster", "eks cluster", False),
+        ("elb_load_balancers", "elbv2", "load_balancer", "elb-load-balancer", "load balancer", False),
+        ("vpcs", "ec2", "virtual_network", "vpc", "vpc", False),
+        ("kms_keys", "kms", "key", "kms-key", "kms key", False),
+        ("secrets", "secretsmanager", "secret", "secretsmanager-secret", "secret", False),
     ):
         for item in inventory.get(coll_key, []) or []:
             if not isinstance(item, dict):

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -1403,15 +1403,6 @@ def _resolve_affected_server_ids(
         for server_name in server_names:
             named_ids.update(server_name_to_agent_servers.get(server_name, {}).values())
         narrowed = (candidate_ids & named_ids) if candidate_ids else named_ids
-        if candidate_ids and named_ids and not narrowed:
-            # Log counts only — dumping the full id/name collections risks
-            # clear-text logging of data that flows in from cloud-inventory
-            # collections (e.g. Secrets Manager / KMS resource names).
-            _logger.debug(
-                "blast-radius narrow-by-server collapsed to empty: servers=%d candidates=%d",
-                len(server_names),
-                len(candidate_ids),
-            )
         candidate_ids = narrowed
 
     agent_names = {str(agent).strip() for agent in br_dict.get("affected_agents", []) if str(agent).strip()}
@@ -1420,12 +1411,6 @@ def _resolve_affected_server_ids(
         for agent_name in agent_names:
             agent_ids.update(agent_to_server_ids.get(agent_name, set()))
         narrowed = (candidate_ids & agent_ids) if candidate_ids else agent_ids
-        if candidate_ids and agent_ids and not narrowed:
-            _logger.debug(
-                "blast-radius narrow-by-agent collapsed to empty: agents=%d candidates=%d",
-                len(agent_names),
-                len(candidate_ids),
-            )
         candidate_ids = narrowed
 
     return sorted(candidate_ids)

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -1408,8 +1408,7 @@ def _resolve_affected_server_ids(
             # clear-text logging of data that flows in from cloud-inventory
             # collections (e.g. Secrets Manager / KMS resource names).
             _logger.debug(
-                "blast-radius narrow-by-server collapsed to empty: pkg=%s servers=%d candidates=%d",
-                pkg_name,
+                "blast-radius narrow-by-server collapsed to empty: servers=%d candidates=%d",
                 len(server_names),
                 len(candidate_ids),
             )
@@ -1423,8 +1422,7 @@ def _resolve_affected_server_ids(
         narrowed = (candidate_ids & agent_ids) if candidate_ids else agent_ids
         if candidate_ids and agent_ids and not narrowed:
             _logger.debug(
-                "blast-radius narrow-by-agent collapsed to empty: pkg=%s agents=%d candidates=%d",
-                pkg_name,
+                "blast-radius narrow-by-agent collapsed to empty: agents=%d candidates=%d",
                 len(agent_names),
                 len(candidate_ids),
             )

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -1404,11 +1404,14 @@ def _resolve_affected_server_ids(
             named_ids.update(server_name_to_agent_servers.get(server_name, {}).values())
         narrowed = (candidate_ids & named_ids) if candidate_ids else named_ids
         if candidate_ids and named_ids and not narrowed:
+            # Log counts only — dumping the full id/name collections risks
+            # clear-text logging of data that flows in from cloud-inventory
+            # collections (e.g. Secrets Manager / KMS resource names).
             _logger.debug(
-                "blast-radius narrow-by-server collapsed to empty: pkg=%s servers=%s candidates=%s",
+                "blast-radius narrow-by-server collapsed to empty: pkg=%s servers=%d candidates=%d",
                 pkg_name,
-                sorted(server_names),
-                sorted(candidate_ids),
+                len(server_names),
+                len(candidate_ids),
             )
         candidate_ids = narrowed
 
@@ -1420,10 +1423,10 @@ def _resolve_affected_server_ids(
         narrowed = (candidate_ids & agent_ids) if candidate_ids else agent_ids
         if candidate_ids and agent_ids and not narrowed:
             _logger.debug(
-                "blast-radius narrow-by-agent collapsed to empty: pkg=%s agents=%s candidates=%s",
+                "blast-radius narrow-by-agent collapsed to empty: pkg=%s agents=%d candidates=%d",
                 pkg_name,
-                sorted(agent_names),
-                sorted(candidate_ids),
+                len(agent_names),
+                len(candidate_ids),
             )
         candidate_ids = narrowed
 

--- a/tests/test_aws_inventory_network_security.py
+++ b/tests/test_aws_inventory_network_security.py
@@ -1,0 +1,138 @@
+"""AWS ELB/VPC/KMS/Secrets Manager inventory: discovery + graph nodes."""
+
+from __future__ import annotations
+
+from agent_bom.graph.builder import build_unified_graph_from_report
+
+
+def _inventory() -> dict:
+    return {
+        "status": "ok",
+        "provider": "aws",
+        "account_id": "111122223333",
+        "elb_load_balancers": [
+            {
+                "name": "web-alb",
+                "arn": "arn:lb",
+                "scheme": "internet-facing",
+                "lb_type": "application",
+                "internet_exposed": True,
+                "location": "us-east-1",
+            }
+        ],
+        "vpcs": [
+            {
+                "name": "vpc-1",
+                "display_name": "main-vpc",
+                "vpc_id": "vpc-1",
+                "cidr": "10.0.0.0/16",
+                "is_default": False,
+                "location": "us-east-1",
+            }
+        ],
+        "kms_keys": [{"name": "key-1", "arn": "arn:key", "enabled": True, "rotation_enabled": False, "location": "us-east-1"}],
+        "secrets": [{"name": "db-creds", "arn": "arn:sec", "rotation_enabled": False, "location": "us-east-1"}],
+    }
+
+
+def _build():
+    g = build_unified_graph_from_report({"cloud_inventory": _inventory()})
+    return g, {(e.source, e.target, e.relationship.value) for e in g.edges}
+
+
+def test_internet_facing_elb_flagged_exposed() -> None:
+    g, _ = _build()
+    lb = g.nodes["cloud_resource:aws:elbv2:load_balancer:web-alb"]
+    assert lb.attributes["internet_exposed"] is True
+
+
+def test_vpc_kms_secret_nodes_created_and_owned() -> None:
+    g, edges = _build()
+    for nid in (
+        "cloud_resource:aws:ec2:virtual_network:vpc-1",
+        "cloud_resource:aws:kms:key:key-1",
+        "cloud_resource:aws:secretsmanager:secret:db-creds",
+    ):
+        assert nid in g.nodes
+        assert ("account:aws:111122223333", nid, "owns") in edges
+
+
+# ── Discovery (mocked boto3) ─────────────────────────────────────────────
+class _Paginator:
+    def __init__(self, pages):
+        self._pages = pages
+
+    def paginate(self, **_kw):
+        return self._pages
+
+
+class _Client:
+    def __init__(self, svc):
+        self.svc = svc
+
+    def get_paginator(self, op):
+        if self.svc == "elbv2":
+            return _Paginator(
+                [
+                    {
+                        "LoadBalancers": [
+                            {
+                                "LoadBalancerName": "alb1",
+                                "LoadBalancerArn": "arn:alb",
+                                "Scheme": "internet-facing",
+                                "Type": "application",
+                                "DNSName": "alb1.aws",
+                                "VpcId": "vpc-1",
+                            }
+                        ]
+                    }
+                ]
+            )
+        if self.svc == "kms":
+            return _Paginator([{"Keys": [{"KeyId": "k-cmk", "KeyArn": "arn:k-cmk"}, {"KeyId": "k-aws", "KeyArn": "arn:k-aws"}]}])
+        if self.svc == "secretsmanager":
+            return _Paginator([{"SecretList": [{"Name": "s1", "ARN": "arn:s1", "RotationEnabled": True}]}])
+        return _Paginator([])
+
+    def describe_vpcs(self):
+        return {"Vpcs": [{"VpcId": "vpc-1", "CidrBlock": "10.0.0.0/16", "IsDefault": True, "Tags": [{"Key": "Name", "Value": "prod"}]}]}
+
+    def describe_key(self, KeyId):  # noqa: N803 — boto3 API param
+        return {"KeyMetadata": {"KeyManager": "AWS" if KeyId == "k-aws" else "CUSTOMER", "Enabled": True}}
+
+    def get_key_rotation_status(self, KeyId):  # noqa: N803
+        return {"KeyRotationEnabled": True}
+
+
+class _Session:
+    def client(self, svc, **_kw):
+        return _Client(svc)
+
+
+def test_discovery_parses_network_security_services() -> None:
+    from agent_bom.cloud import aws_inventory as aws
+
+    s, w = _Session(), []
+    elb = aws._discover_elb(s, "us-east-1", account_id="111122223333", warnings=w)
+    assert elb[0]["internet_exposed"] is True
+    vpcs = aws._discover_vpcs(s, "us-east-1", account_id="111122223333", warnings=w)
+    assert vpcs[0]["name"] == "vpc-1" and vpcs[0]["display_name"] == "prod" and vpcs[0]["is_default"] is True
+    secrets = aws._discover_secrets(s, "us-east-1", account_id="111122223333", warnings=w)
+    assert secrets[0]["rotation_enabled"] is True
+    assert w == []
+
+
+def test_kms_skips_aws_managed_keys() -> None:
+    from agent_bom.cloud import aws_inventory as aws
+
+    keys = aws._discover_kms(_Session(), "us-east-1", account_id="111122223333", warnings=[])
+    names = {k["name"] for k in keys}
+    assert "k-cmk" in names and "k-aws" not in names  # AWS-managed key excluded
+
+
+def test_discover_inventory_returns_every_new_collection() -> None:
+    from agent_bom.cloud import aws_inventory as aws
+
+    out = aws.discover_inventory(force=False)
+    for k in ("elb_load_balancers", "vpcs", "kms_keys", "secrets"):
+        assert k in out, f"{k} missing from discover_inventory return"


### PR DESCRIPTION
## What

Batch 2 of the AWS parity push (after #3072's RDS/DynamoDB/Lambda/EKS). **Validated live** against the real account — found the default VPC (`172.31.0.0/16`), zero warnings.

| New | Node | Signal |
|---|---|---|
| **ELB/ALB/NLB** | `CLOUD_RESOURCE` | internet-facing scheme → exposed |
| **VPC** | `CLOUD_RESOURCE` (network) | CIDR, is-default; `vpc_id` = stable node id, Name tag display-only |
| **KMS keys** | `CLOUD_RESOURCE` | customer-managed only (AWS-managed skipped), rotation status — **metadata only, never key material** |
| **Secrets Manager** | `CLOUD_RESOURCE` | rotation status — **metadata only, never secret values** |

Wired full-stack: `discover_inventory` (`include_network` flag; KMS/secrets under `include_data`; permissions in the envelope) → graph builder config list → `cloud_inventory` payload → graph UI renders generically.

## Tests
8 (across both batch files): graph nodes, ELB exposure flag, **AWS-managed-key exclusion**, discovery parsing, collected-but-not-returned guard.

AWS now covers **13 resource types** (was 5). Next: ECR, ECS, Redshift, EBS volumes, SNS/SQS.