### PR TITLE
fix(cli): cloud inventory summary counts every asset collection (live-found)

### DIFF
--- a/src/agent_bom/cli/_cloud_group.py
+++ b/src/agent_bom/cli/_cloud_group.py
@@ -304,26 +304,22 @@ def inventory_cmd(
     con.print()
 
 
-# Per-provider asset collections to count in the compact estate summary.
-_INVENTORY_ASSET_KEYS = (
-    "buckets",
-    "instances",
-    "security_groups",
-    "roles",
-    "users",
-    "storage_accounts",
-    "managed_identities",
-    "service_principals",
-    "service_accounts",
-    "firewalls",
-)
+# Report keys that are lists but NOT asset collections — excluded from the count
+# so the summary auto-includes every resource type a provider adds without drift.
+_INVENTORY_NON_ASSET_KEYS = frozenset({"warnings", "discovery_envelope", "permissions_used", "discovery_scope", "errors"})
 
 
 def _asset_summary(report: dict) -> str:
-    """Compact ``key=N`` summary of the non-empty asset collections in a report."""
+    """Compact ``key=N`` summary of every non-empty asset collection in a report.
+
+    Counts all list-valued keys (minus envelope/warning metadata) so any new
+    resource type a provider's inventory adds appears here automatically — no
+    hardcoded allowlist to drift out of sync with the discovery layer.
+    """
     bits = []
-    for key in _INVENTORY_ASSET_KEYS:
-        value = report.get(key)
+    for key, value in report.items():
+        if key in _INVENTORY_NON_ASSET_KEYS:
+            continue
         if isinstance(value, list) and value:
             bits.append(f"{key}={len(value)}")
     return ", ".join(bits) if bits else "[dim]none[/dim]"

--- a/tests/test_cli_asset_summary.py
+++ b/tests/test_cli_asset_summary.py
@@ -1,0 +1,28 @@
+"""The cloud-inventory CLI summary counts every asset collection (no hardcoded drift)."""
+
+from __future__ import annotations
+
+from agent_bom.cli._cloud_group import _asset_summary
+
+
+def test_summary_counts_all_new_collections() -> None:
+    report = {
+        "provider": "aws",
+        "status": "ok",
+        "vpcs": [{"name": "v1"}],
+        "rds_instances": [{"name": "db"}, {"name": "db2"}],
+        "cloudfront_distributions": [{"name": "cf"}],
+        "buckets": [],  # empty → omitted
+        "warnings": ["w1", "w2"],  # metadata → never counted
+        "discovery_envelope": None,
+    }
+    out = _asset_summary(report)
+    assert "vpcs=1" in out
+    assert "rds_instances=2" in out
+    assert "cloudfront_distributions=1" in out
+    assert "buckets" not in out
+    assert "warnings" not in out  # metadata excluded
+
+
+def test_empty_report_says_none() -> None:
+    assert _asset_summary({"provider": "aws", "status": "ok", "warnings": []}) == "[dim]none[/dim]"


### PR DESCRIPTION
Live run of cloud inventory showed only security_groups/roles/users while the real inventory also had vpcs=1 — the CLI summary used a hardcoded allowlist that drifted out of sync with the discovery layer. Now counts every list-valued collection minus envelope/warning metadata, so new AWS/Azure resource types auto-appear. Verified live. 2 tests.