### PR TITLE
feat(scan): add parent-child scan batches

### DIFF
--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -58,6 +58,12 @@ CREATE TABLE IF NOT EXISTS scan_jobs (
     created_at   TEXT NOT NULL,
     completed_at TEXT,
     team_id      TEXT NOT NULL DEFAULT 'default' REFERENCES teams(team_id) ON DELETE CASCADE,
+    batch_id     TEXT,
+    parent_job_id TEXT,
+    child_job_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+    target       JSONB,
+    target_index INTEGER,
+    target_count INTEGER,
     schedule_id  TEXT,
     triggered_by TEXT,
     data         JSONB NOT NULL
@@ -80,12 +86,56 @@ DO $$ BEGIN
         ALTER TABLE scan_jobs
             ADD COLUMN schedule_id TEXT;
     END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'scan_jobs' AND column_name = 'batch_id'
+    ) THEN
+        ALTER TABLE scan_jobs
+            ADD COLUMN batch_id TEXT;
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'scan_jobs' AND column_name = 'parent_job_id'
+    ) THEN
+        ALTER TABLE scan_jobs
+            ADD COLUMN parent_job_id TEXT;
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'scan_jobs' AND column_name = 'child_job_ids'
+    ) THEN
+        ALTER TABLE scan_jobs
+            ADD COLUMN child_job_ids JSONB NOT NULL DEFAULT '[]'::jsonb;
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'scan_jobs' AND column_name = 'target'
+    ) THEN
+        ALTER TABLE scan_jobs
+            ADD COLUMN target JSONB;
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'scan_jobs' AND column_name = 'target_index'
+    ) THEN
+        ALTER TABLE scan_jobs
+            ADD COLUMN target_index INTEGER;
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'scan_jobs' AND column_name = 'target_count'
+    ) THEN
+        ALTER TABLE scan_jobs
+            ADD COLUMN target_count INTEGER;
+    END IF;
 END $$;
 
 CREATE INDEX IF NOT EXISTS idx_jobs_status  ON scan_jobs(status);
 CREATE INDEX IF NOT EXISTS idx_jobs_created ON scan_jobs(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_jobs_team_status  ON scan_jobs(team_id, status);
 CREATE INDEX IF NOT EXISTS idx_jobs_team_created ON scan_jobs(team_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_jobs_batch ON scan_jobs(team_id, batch_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_jobs_parent ON scan_jobs(team_id, parent_job_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_jobs_schedule ON scan_jobs(team_id, schedule_id, created_at DESC);
 
 -- ── Table: CIS Benchmark Checks ──────────────────────────────────────────────

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -2379,6 +2379,24 @@
       "ScanJob": {
         "description": "Represents a running or completed scan job.",
         "properties": {
+          "batch_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Batch Id"
+          },
+          "child_job_ids": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Child Job Ids",
+            "type": "array"
+          },
           "completed_at": {
             "anyOf": [
               {
@@ -2408,6 +2426,17 @@
           "job_id": {
             "title": "Job Id",
             "type": "string"
+          },
+          "parent_job_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Job Id"
           },
           "progress": {
             "items": {
@@ -2467,6 +2496,40 @@
           "status": {
             "$ref": "#/components/schemas/JobStatus",
             "default": "pending"
+          },
+          "target": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target"
+          },
+          "target_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Count"
+          },
+          "target_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Index"
           },
           "tenant_id": {
             "default": "default",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -1588,6 +1588,16 @@ components:
     ScanJob:
       description: Represents a running or completed scan job.
       properties:
+        batch_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Batch Id
+        child_job_ids:
+          items:
+            type: string
+          title: Child Job Ids
+          type: array
         completed_at:
           anyOf:
           - type: string
@@ -1604,6 +1614,11 @@ components:
         job_id:
           title: Job Id
           type: string
+        parent_job_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Parent Job Id
         progress:
           items:
             type: string
@@ -1635,6 +1650,22 @@ components:
         status:
           $ref: '#/components/schemas/JobStatus'
           default: pending
+        target:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Target
+        target_count:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Target Count
+        target_index:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Target Index
         tenant_id:
           default: default
           title: Tenant Id

--- a/docs/schemas/v1/ScanJob.json
+++ b/docs/schemas/v1/ScanJob.json
@@ -209,6 +209,25 @@
   },
   "description": "Represents a running or completed scan job.",
   "properties": {
+    "batch_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Batch Id"
+    },
+    "child_job_ids": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Child Job Ids",
+      "type": "array"
+    },
     "completed_at": {
       "anyOf": [
         {
@@ -240,6 +259,18 @@
     "job_id": {
       "title": "Job Id",
       "type": "string"
+    },
+    "parent_job_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Parent Job Id"
     },
     "progress": {
       "items": {
@@ -303,6 +334,43 @@
     "status": {
       "$ref": "#/$defs/JobStatus",
       "default": "pending"
+    },
+    "target": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Target"
+    },
+    "target_count": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Target Count"
+    },
+    "target_index": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Target Index"
     },
     "tenant_id": {
       "default": "default",

--- a/scripts/generate_v1_schemas.py
+++ b/scripts/generate_v1_schemas.py
@@ -29,9 +29,13 @@ from pathlib import Path
 
 from pydantic import BaseModel
 
-import agent_bom.api.models as models_module
-
 ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import agent_bom.api.models as models_module  # noqa: E402
+
 SCHEMA_DIR = ROOT / "docs" / "schemas" / "v1"
 INDEX_FILE = SCHEMA_DIR / "index.json"
 

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -134,6 +134,12 @@ class ScanJob(BaseModel):
 
     job_id: str
     tenant_id: str = "default"
+    batch_id: str | None = None
+    parent_job_id: str | None = None
+    child_job_ids: list[str] = Field(default_factory=list)
+    target: dict[str, Any] | None = None
+    target_index: int | None = None
+    target_count: int | None = None
     source_id: str | None = None
     schedule_id: str | None = None
     triggered_by: str | None = None

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -1090,6 +1090,13 @@ def _run_scan_sync(job: ScanJob) -> None:
         if not bool(getattr(store, "retains_job_objects_in_memory", True)):
             _compact_terminal_job_in_place(job)
         _jobs_put(job.job_id, job, compact_terminal=True)
+        if job.parent_job_id:
+            try:
+                from agent_bom.api.scan_batches import refresh_batch_parent
+
+                refresh_batch_parent(job.parent_job_id, tenant_id=job.tenant_id or "default")
+            except Exception:  # noqa: BLE001
+                _logger.exception("Failed to refresh scan batch parent job=%s child=%s", job.parent_job_id, job.job_id)
         _release_scan_memory()
         # Update operator-visible scan metrics. The active gauge feeds
         # the KEDA scaler in deploy/helm/agent-bom; the completion

--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -65,6 +65,12 @@ class PostgresJobStore:
                     created_at TEXT NOT NULL,
                     completed_at TEXT,
                     team_id TEXT NOT NULL DEFAULT 'default',
+                    batch_id TEXT,
+                    parent_job_id TEXT,
+                    child_job_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+                    target JSONB,
+                    target_index INTEGER,
+                    target_count INTEGER,
                     schedule_id TEXT,
                     triggered_by TEXT,
                     data JSONB NOT NULL
@@ -90,6 +96,42 @@ class PostgresJobStore:
                         WHERE table_name = 'scan_jobs' AND column_name = 'triggered_by'
                     ) THEN
                         ALTER TABLE scan_jobs ADD COLUMN triggered_by TEXT;
+                    END IF;
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'scan_jobs' AND column_name = 'batch_id'
+                    ) THEN
+                        ALTER TABLE scan_jobs ADD COLUMN batch_id TEXT;
+                    END IF;
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'scan_jobs' AND column_name = 'parent_job_id'
+                    ) THEN
+                        ALTER TABLE scan_jobs ADD COLUMN parent_job_id TEXT;
+                    END IF;
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'scan_jobs' AND column_name = 'child_job_ids'
+                    ) THEN
+                        ALTER TABLE scan_jobs ADD COLUMN child_job_ids JSONB NOT NULL DEFAULT '[]'::jsonb;
+                    END IF;
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'scan_jobs' AND column_name = 'target'
+                    ) THEN
+                        ALTER TABLE scan_jobs ADD COLUMN target JSONB;
+                    END IF;
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'scan_jobs' AND column_name = 'target_index'
+                    ) THEN
+                        ALTER TABLE scan_jobs ADD COLUMN target_index INTEGER;
+                    END IF;
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'scan_jobs' AND column_name = 'target_count'
+                    ) THEN
+                        ALTER TABLE scan_jobs ADD COLUMN target_count INTEGER;
                     END IF;
                 END
                 $$;
@@ -118,6 +160,8 @@ class PostgresJobStore:
                 )
             """)
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_jobs_team_created ON scan_jobs(team_id, created_at DESC)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_jobs_batch ON scan_jobs(team_id, batch_id, created_at DESC)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_jobs_parent ON scan_jobs(team_id, parent_job_id, created_at DESC)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_jobs_schedule ON scan_jobs(team_id, schedule_id, created_at DESC)")
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_cis_checks_team_cloud_status_priority "
@@ -151,12 +195,21 @@ class PostgresJobStore:
         data = job.model_dump_json()
         with _tenant_connection(self._pool) as conn:
             conn.execute(
-                """INSERT INTO scan_jobs (job_id, status, created_at, completed_at, team_id, schedule_id, triggered_by, data)
-                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                """INSERT INTO scan_jobs (
+                       job_id, status, created_at, completed_at, team_id, batch_id, parent_job_id,
+                       child_job_ids, target, target_index, target_count, schedule_id, triggered_by, data
+                   )
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s, %s, %s, %s, %s)
                    ON CONFLICT (job_id) DO UPDATE SET
                      status = EXCLUDED.status,
                      completed_at = EXCLUDED.completed_at,
                      team_id = EXCLUDED.team_id,
+                     batch_id = EXCLUDED.batch_id,
+                     parent_job_id = EXCLUDED.parent_job_id,
+                     child_job_ids = EXCLUDED.child_job_ids,
+                     target = EXCLUDED.target,
+                     target_index = EXCLUDED.target_index,
+                     target_count = EXCLUDED.target_count,
                      schedule_id = EXCLUDED.schedule_id,
                      triggered_by = EXCLUDED.triggered_by,
                      data = EXCLUDED.data""",
@@ -166,6 +219,12 @@ class PostgresJobStore:
                     job.created_at,
                     job.completed_at,
                     job.tenant_id,
+                    getattr(job, "batch_id", None),
+                    getattr(job, "parent_job_id", None),
+                    json.dumps(getattr(job, "child_job_ids", []) or []),
+                    json.dumps(getattr(job, "target", None)) if getattr(job, "target", None) is not None else None,
+                    getattr(job, "target_index", None),
+                    getattr(job, "target_count", None),
                     getattr(job, "schedule_id", None),
                     getattr(job, "triggered_by", None),
                     data,
@@ -219,13 +278,15 @@ class PostgresJobStore:
         with _tenant_connection(self._pool) as conn:
             if tenant_id is None:
                 rows = conn.execute(
-                    """SELECT job_id, team_id, status, created_at, completed_at, triggered_by, schedule_id
+                    """SELECT job_id, team_id, status, created_at, completed_at, triggered_by, schedule_id,
+                              batch_id, parent_job_id, child_job_ids, target, target_index, target_count
                        FROM scan_jobs
                        ORDER BY created_at DESC"""
                 ).fetchall()
             else:
                 rows = conn.execute(
-                    """SELECT job_id, team_id, status, created_at, completed_at, triggered_by, schedule_id
+                    """SELECT job_id, team_id, status, created_at, completed_at, triggered_by, schedule_id,
+                              batch_id, parent_job_id, child_job_ids, target, target_index, target_count
                        FROM scan_jobs
                        WHERE team_id = %s
                        ORDER BY created_at DESC""",
@@ -240,6 +301,12 @@ class PostgresJobStore:
                     "completed_at": row[4],
                     "triggered_by": row[5] if len(row) > 5 else None,
                     "schedule_id": row[6] if len(row) > 6 else None,
+                    "batch_id": row[7] if len(row) > 7 else None,
+                    "parent_job_id": row[8] if len(row) > 8 else None,
+                    "child_job_ids": row[9] if len(row) > 9 and isinstance(row[9], list) else json.loads(row[9] or "[]"),
+                    "target": row[10] if len(row) > 10 and isinstance(row[10], dict) else json.loads(row[10] or "null"),
+                    "target_index": row[11] if len(row) > 11 else None,
+                    "target_count": row[12] if len(row) > 12 else None,
                 }
                 for row in rows
             ]

--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -275,6 +275,14 @@ class PostgresJobStore:
             return [ScanJob.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in rows]
 
     def list_summary(self, tenant_id: str | None = None) -> list[dict]:
+        def _json_column(row: tuple, index: int, default: str, expected_type: type) -> object:
+            if len(row) <= index:
+                return json.loads(default)
+            value = row[index]
+            if isinstance(value, expected_type):
+                return value
+            return json.loads(value or default)
+
         with _tenant_connection(self._pool) as conn:
             if tenant_id is None:
                 rows = conn.execute(
@@ -303,8 +311,8 @@ class PostgresJobStore:
                     "schedule_id": row[6] if len(row) > 6 else None,
                     "batch_id": row[7] if len(row) > 7 else None,
                     "parent_job_id": row[8] if len(row) > 8 else None,
-                    "child_job_ids": row[9] if len(row) > 9 and isinstance(row[9], list) else json.loads(row[9] or "[]"),
-                    "target": row[10] if len(row) > 10 and isinstance(row[10], dict) else json.loads(row[10] or "null"),
+                    "child_job_ids": _json_column(row, 9, "[]", list),
+                    "target": _json_column(row, 10, "null", dict),
                     "target_index": row[11] if len(row) > 11 else None,
                     "target_count": row[12] if len(row) > 12 else None,
                 }

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -50,6 +50,7 @@ from agent_bom.api.models import (
     TrainingPipelinesRequest,
 )
 from agent_bom.api.pipeline import _now, submit_scan_job
+from agent_bom.api.scan_batches import child_request_for_target, refresh_batch_parent, scan_request_targets
 from agent_bom.api.scan_job_reconciliation import reconcile_scan_jobs_active
 from agent_bom.api.stores import (
     _get_store,
@@ -514,6 +515,12 @@ def _job_summary_payload(job: ScanJob) -> dict[str, Any]:
     return {
         "job_id": job.job_id,
         "tenant_id": job.tenant_id,
+        "batch_id": job.batch_id,
+        "parent_job_id": job.parent_job_id,
+        "child_job_ids": list(job.child_job_ids),
+        "target": job.target,
+        "target_index": job.target_index,
+        "target_count": job.target_count,
         "source_id": job.source_id,
         "schedule_id": job.schedule_id,
         "status": job.status,
@@ -536,11 +543,20 @@ def _job_for_request(request: Request, job_id: str) -> ScanJob:
         if _jobs_is_compacted(in_mem):
             persisted = _get_store().get(job_id, tenant_id=tenant_id)
             if persisted is not None:
+                if persisted.child_job_ids:
+                    refreshed = refresh_batch_parent(persisted.job_id, tenant_id=tenant_id)
+                    return refreshed or persisted
                 return persisted
+        if in_mem.child_job_ids:
+            refreshed = refresh_batch_parent(in_mem.job_id, tenant_id=tenant_id)
+            return refreshed or in_mem
         return in_mem
     job = _get_store().get(job_id, tenant_id=tenant_id)
     if job is None:
         raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+    if job.child_job_ids:
+        refreshed = refresh_batch_parent(job.job_id, tenant_id=tenant_id)
+        return refreshed or job
     return job
 
 
@@ -572,6 +588,79 @@ def enqueue_scan_job(
 ) -> ScanJob:
     """Persist and queue a scan job for async execution."""
     store = _get_store()
+    targets = scan_request_targets(request_body)
+
+    def _dispatch(job: ScanJob) -> None:
+        # In a clustered control plane, hand the job to the shared dispatch queue
+        # so any replica can claim and run it (work-stealing). Single-node
+        # deployments keep running the job on this process directly.
+        from agent_bom.api.scan_queue import distributed_scans_enabled, store_supports_dispatch
+
+        if distributed_scans_enabled() and store_supports_dispatch(store):
+            store.enqueue_for_dispatch(job)
+        else:
+            submit_scan_job(job)
+
+    if len(targets) > 1:
+        batch_id = str(uuid.uuid4())
+        now = _now()
+        parent_job_id = str(uuid.uuid4())
+        child_jobs: list[ScanJob] = []
+        for index, target in enumerate(targets, start=1):
+            child_jobs.append(
+                ScanJob(
+                    job_id=str(uuid.uuid4()),
+                    tenant_id=tenant_id,
+                    batch_id=batch_id,
+                    parent_job_id=parent_job_id,
+                    target=target,
+                    target_index=index,
+                    target_count=len(targets),
+                    source_id=source_id,
+                    triggered_by=triggered_by,
+                    created_at=now,
+                    request=child_request_for_target(request_body, target),
+                )
+            )
+
+        parent = ScanJob(
+            job_id=parent_job_id,
+            tenant_id=tenant_id,
+            batch_id=batch_id,
+            child_job_ids=[job.job_id for job in child_jobs],
+            source_id=source_id,
+            triggered_by=triggered_by,
+            status=JobStatus.RUNNING,
+            created_at=now,
+            started_at=now,
+            request=request_body,
+            progress=[f"Batch scan created with {len(child_jobs)} target job(s)"],
+            target_count=len(targets),
+        )
+
+        attempted_jobs = len(child_jobs) + 1
+        with tenant_quota_guard(
+            tenant_id,
+            lambda: enforce_active_scan_quota(tenant_id, attempted=attempted_jobs),
+            lambda: enforce_retained_jobs_quota(tenant_id, attempted=attempted_jobs),
+        ):
+            store.put(parent)
+            _jobs_put(parent.job_id, parent)
+            for child in child_jobs:
+                store.put(child)
+                _jobs_put(child.job_id, child)
+            try:
+                refresh_batch_parent(parent.job_id, tenant_id=tenant_id)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                reconcile_scan_jobs_active(store)
+            except Exception:  # noqa: BLE001
+                pass
+
+        for child in child_jobs:
+            _dispatch(child)
+        return parent
 
     job = ScanJob(
         job_id=str(uuid.uuid4()),
@@ -600,15 +689,7 @@ def enqueue_scan_job(
         except Exception:  # noqa: BLE001
             pass
 
-    # In a clustered control plane, hand the job to the shared dispatch queue so
-    # any replica can claim and run it (work-stealing). Single-node deployments
-    # keep running the job on this process directly.
-    from agent_bom.api.scan_queue import distributed_scans_enabled, store_supports_dispatch
-
-    if distributed_scans_enabled() and store_supports_dispatch(store):
-        store.enqueue_for_dispatch(job)
-    else:
-        submit_scan_job(job)
+    _dispatch(job)
     return job
 
 

--- a/src/agent_bom/api/scan_batches.py
+++ b/src/agent_bom/api/scan_batches.py
@@ -1,0 +1,156 @@
+"""Helpers for API scan batch parent/child jobs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+from agent_bom.api.stores import _get_store, _job_lock, _jobs_get, _jobs_is_compacted, _jobs_put
+
+BATCH_LIST_TARGET_FIELDS = (
+    "images",
+    "tf_dirs",
+    "agent_projects",
+    "jupyter_dirs",
+    "connectors",
+    "filesystem_paths",
+)
+BATCH_SINGLE_TARGET_FIELDS = ("inventory", "gha_path", "sbom")
+
+
+def scan_request_targets(request: ScanRequest) -> list[dict[str, Any]]:
+    """Return explicit top-level scan targets that can be fanned out."""
+
+    targets: list[dict[str, Any]] = []
+    for field_name in BATCH_LIST_TARGET_FIELDS:
+        values = getattr(request, field_name)
+        for index, value in enumerate(values):
+            targets.append({"field": field_name, "value": value, "ordinal": index})
+
+    for field_name in BATCH_SINGLE_TARGET_FIELDS:
+        value = getattr(request, field_name)
+        if value:
+            targets.append({"field": field_name, "value": value, "ordinal": 0})
+
+    if request.k8s:
+        targets.append(
+            {
+                "field": "k8s",
+                "value": {"namespace": request.k8s_namespace},
+                "ordinal": 0,
+            }
+        )
+
+    return targets
+
+
+def should_fan_out_scan_request(request: ScanRequest) -> bool:
+    """Return True when the API should create a parent batch and child jobs."""
+
+    return len(scan_request_targets(request)) > 1
+
+
+def child_request_for_target(request: ScanRequest, target: dict[str, Any]) -> ScanRequest:
+    """Build a child request containing exactly one explicit scan target."""
+
+    payload = request.model_dump()
+    for field_name in BATCH_LIST_TARGET_FIELDS:
+        payload[field_name] = []
+    for field_name in BATCH_SINGLE_TARGET_FIELDS:
+        payload[field_name] = None
+    payload["k8s"] = False
+    payload["k8s_namespace"] = None
+
+    field_name = str(target["field"])
+    value = target.get("value")
+    if field_name in BATCH_LIST_TARGET_FIELDS:
+        payload[field_name] = [value]
+    elif field_name in BATCH_SINGLE_TARGET_FIELDS:
+        payload[field_name] = value
+    elif field_name == "k8s":
+        payload["k8s"] = True
+        if isinstance(value, dict):
+            payload["k8s_namespace"] = value.get("namespace")
+
+    return ScanRequest.model_validate(payload)
+
+
+def refresh_batch_parent(parent_job_id: str, *, tenant_id: str | None = None) -> ScanJob | None:
+    """Refresh a batch parent from its children and return the parent job."""
+
+    store = _get_store()
+    parent = _jobs_get(parent_job_id)
+    if parent is None or _jobs_is_compacted(parent):
+        parent = store.get(parent_job_id, tenant_id=tenant_id)
+    if parent is None:
+        return None
+    if tenant_id is not None and parent.tenant_id != tenant_id:
+        return None
+    if not parent.child_job_ids:
+        return parent
+
+    children: list[ScanJob] = []
+    for child_id in parent.child_job_ids:
+        child = store.get(child_id, tenant_id=parent.tenant_id)
+        if child is None:
+            child = _jobs_get(child_id)
+        if child is not None and child.tenant_id == parent.tenant_id:
+            children.append(child)
+
+    status_counts = {status.value: 0 for status in JobStatus}
+    child_rows: list[dict[str, Any]] = []
+    for child in children:
+        status_counts[child.status.value] = status_counts.get(child.status.value, 0) + 1
+        child_rows.append(
+            {
+                "job_id": child.job_id,
+                "status": child.status.value,
+                "target": child.target,
+                "target_index": child.target_index,
+                "target_count": child.target_count,
+                "created_at": child.created_at,
+                "started_at": child.started_at,
+                "completed_at": child.completed_at,
+                "error": child.error,
+                "result": child.result,
+            }
+        )
+
+    total = len(parent.child_job_ids)
+    terminal = status_counts[JobStatus.DONE.value] + status_counts[JobStatus.FAILED.value] + status_counts[JobStatus.CANCELLED.value]
+    if terminal < total:
+        next_status = JobStatus.RUNNING
+        completed_at = None
+    elif status_counts[JobStatus.DONE.value] > 0:
+        next_status = JobStatus.DONE
+        completed_at = max((child.completed_at or child.created_at for child in children), default=parent.completed_at)
+    elif status_counts[JobStatus.CANCELLED.value] == total:
+        next_status = JobStatus.CANCELLED
+        completed_at = max((child.completed_at or child.created_at for child in children), default=parent.completed_at)
+    else:
+        next_status = JobStatus.FAILED
+        completed_at = max((child.completed_at or child.created_at for child in children), default=parent.completed_at)
+
+    batch = {
+        "batch_id": parent.batch_id or parent.job_id,
+        "parent_job_id": parent.job_id,
+        "target_count": total,
+        "completed_targets": terminal,
+        "succeeded_targets": status_counts[JobStatus.DONE.value],
+        "failed_targets": status_counts[JobStatus.FAILED.value],
+        "cancelled_targets": status_counts[JobStatus.CANCELLED.value],
+        "running_targets": status_counts[JobStatus.RUNNING.value],
+        "pending_targets": status_counts[JobStatus.PENDING.value],
+        "children": sorted(child_rows, key=lambda row: row.get("target_index") or 0),
+    }
+    result = {"batch": batch, "summary": batch}
+
+    with _job_lock(parent.job_id):
+        parent.status = next_status
+        parent.result = result
+        if completed_at and next_status in (JobStatus.DONE, JobStatus.FAILED, JobStatus.CANCELLED):
+            parent.completed_at = completed_at
+
+    store.put(parent)
+    _jobs_put(parent.job_id, parent, compact_terminal=next_status in (JobStatus.DONE, JobStatus.FAILED, JobStatus.CANCELLED))
+    return parent

--- a/src/agent_bom/api/snowflake_store.py
+++ b/src/agent_bom/api/snowflake_store.py
@@ -228,15 +228,33 @@ class SnowflakeJobStore:
             summaries: list[dict] = []
             for row in cur.fetchall():
                 triggered_by = None
+                batch_id = None
+                parent_job_id = None
+                child_job_ids: list[str] = []
+                target = None
+                target_index = None
+                target_count = None
                 if len(row) > 5:
                     job = ScanJob.model_validate_json(row[5] if isinstance(row[5], str) else json.dumps(row[5]))
                     triggered_by = job.triggered_by
+                    batch_id = job.batch_id
+                    parent_job_id = job.parent_job_id
+                    child_job_ids = list(job.child_job_ids)
+                    target = job.target
+                    target_index = job.target_index
+                    target_count = job.target_count
                 summaries.append(
                     {
                         "job_id": row[0],
                         "tenant_id": row[1],
                         "triggered_by": triggered_by,
                         "schedule_id": row[6] if len(row) > 6 else None,
+                        "batch_id": batch_id,
+                        "parent_job_id": parent_job_id,
+                        "child_job_ids": child_job_ids,
+                        "target": target,
+                        "target_index": target_index,
+                        "target_count": target_count,
                         "status": row[2],
                         "created_at": str(row[3]) if row[3] else None,
                         "completed_at": str(row[4]) if row[4] else None,

--- a/src/agent_bom/api/store.py
+++ b/src/agent_bom/api/store.py
@@ -7,6 +7,7 @@ Provides pluggable job persistence:
 
 from __future__ import annotations
 
+import json
 import sqlite3
 import threading
 from datetime import datetime, timezone
@@ -90,6 +91,12 @@ class InMemoryJobStore:
                 {
                     "job_id": j.job_id,
                     "tenant_id": j.tenant_id,
+                    "batch_id": j.batch_id,
+                    "parent_job_id": j.parent_job_id,
+                    "child_job_ids": list(j.child_job_ids),
+                    "target": j.target,
+                    "target_index": j.target_index,
+                    "target_count": j.target_count,
                     "schedule_id": j.schedule_id,
                     "triggered_by": j.triggered_by,
                     "status": j.status,
@@ -174,6 +181,12 @@ class SQLiteJobStore:
                     created_at TEXT NOT NULL,
                     completed_at TEXT,
                     tenant_id TEXT NOT NULL DEFAULT 'default',
+                    batch_id TEXT,
+                    parent_job_id TEXT,
+                    child_job_ids TEXT,
+                    target TEXT,
+                    target_index INTEGER,
+                    target_count INTEGER,
                     schedule_id TEXT,
                     triggered_by TEXT,
                     data TEXT NOT NULL
@@ -184,9 +197,23 @@ class SQLiteJobStore:
                 self._conn.execute("ALTER TABLE jobs ADD COLUMN schedule_id TEXT")
             if "triggered_by" not in columns:
                 self._conn.execute("ALTER TABLE jobs ADD COLUMN triggered_by TEXT")
+            if "batch_id" not in columns:
+                self._conn.execute("ALTER TABLE jobs ADD COLUMN batch_id TEXT")
+            if "parent_job_id" not in columns:
+                self._conn.execute("ALTER TABLE jobs ADD COLUMN parent_job_id TEXT")
+            if "child_job_ids" not in columns:
+                self._conn.execute("ALTER TABLE jobs ADD COLUMN child_job_ids TEXT")
+            if "target" not in columns:
+                self._conn.execute("ALTER TABLE jobs ADD COLUMN target TEXT")
+            if "target_index" not in columns:
+                self._conn.execute("ALTER TABLE jobs ADD COLUMN target_index INTEGER")
+            if "target_count" not in columns:
+                self._conn.execute("ALTER TABLE jobs ADD COLUMN target_count INTEGER")
             self._conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status)")
             self._conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_completed ON jobs(completed_at)")
             self._conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_tenant ON jobs(tenant_id)")
+            self._conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_batch ON jobs(tenant_id, batch_id, created_at DESC)")
+            self._conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_parent ON jobs(tenant_id, parent_job_id, created_at DESC)")
             self._conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_schedule ON jobs(tenant_id, schedule_id, created_at DESC)")
             self._conn.commit()
         finally:
@@ -204,14 +231,23 @@ class SQLiteJobStore:
     def put(self, job: ScanJob) -> None:
         try:
             self._conn.execute(
-                """INSERT OR REPLACE INTO jobs (job_id, status, created_at, completed_at, tenant_id, schedule_id, triggered_by, data)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                """INSERT OR REPLACE INTO jobs (
+                       job_id, status, created_at, completed_at, tenant_id, batch_id, parent_job_id,
+                       child_job_ids, target, target_index, target_count, schedule_id, triggered_by, data
+                   )
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     job.job_id,
                     job.status.value,
                     job.created_at,
                     job.completed_at,
                     job.tenant_id,
+                    job.batch_id,
+                    job.parent_job_id,
+                    json.dumps(job.child_job_ids),
+                    json.dumps(job.target) if job.target is not None else None,
+                    job.target_index,
+                    job.target_count,
                     job.schedule_id,
                     job.triggered_by,
                     self._serialize(job),
@@ -271,13 +307,15 @@ class SQLiteJobStore:
         try:
             if tenant_id is None:
                 rows = self._conn.execute(
-                    """SELECT job_id, tenant_id, status, created_at, completed_at, triggered_by, schedule_id
+                    """SELECT job_id, tenant_id, status, created_at, completed_at, triggered_by, schedule_id,
+                              batch_id, parent_job_id, child_job_ids, target, target_index, target_count
                        FROM jobs
                        ORDER BY created_at DESC"""
                 ).fetchall()
             else:
                 rows = self._conn.execute(
-                    """SELECT job_id, tenant_id, status, created_at, completed_at, triggered_by, schedule_id
+                    """SELECT job_id, tenant_id, status, created_at, completed_at, triggered_by, schedule_id,
+                              batch_id, parent_job_id, child_job_ids, target, target_index, target_count
                        FROM jobs
                        WHERE tenant_id = ?
                        ORDER BY created_at DESC""",
@@ -291,6 +329,12 @@ class SQLiteJobStore:
                         "tenant_id": row[1],
                         "triggered_by": row[5],
                         "schedule_id": row[6],
+                        "batch_id": row[7],
+                        "parent_job_id": row[8],
+                        "child_job_ids": json.loads(row[9] or "[]"),
+                        "target": json.loads(row[10]) if row[10] else None,
+                        "target_index": row[11],
+                        "target_count": row[12],
                         "status": row[2],
                         "created_at": row[3],
                         "completed_at": row[4],

--- a/src/agent_bom/api/tenant_quota.py
+++ b/src/agent_bom/api/tenant_quota.py
@@ -264,18 +264,19 @@ def _raise_quota_exceeded(
     )
 
 
-def enforce_active_scan_quota(tenant_id: str) -> None:
+def enforce_active_scan_quota(tenant_id: str, attempted: int = 1) -> None:
     """Limit concurrent pending/running scan jobs per tenant."""
     limit = _quota_limit(tenant_id, "active_scan_jobs")
     if limit <= 0:
         return
     current = sum(1 for job in _get_store().list_all(tenant_id=tenant_id) if job.status in (JobStatus.PENDING, JobStatus.RUNNING))
-    if current >= limit:
+    if current + attempted > limit:
         _raise_quota_exceeded(
             tenant_id=tenant_id,
             quota_name="active_scan_jobs",
             limit=limit,
             current=current,
+            attempted=attempted,
         )
 
 

--- a/tests/test_api_scan_batches.py
+++ b/tests/test_api_scan_batches.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from agent_bom.api.models import JobStatus, ScanRequest
+from agent_bom.api.routes import scan as scan_routes
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.stores import _jobs, set_job_store, set_tenant_quota_store
+from agent_bom.api.tenant_quota_store import InMemoryTenantQuotaStore
+
+
+def _reset_store() -> InMemoryJobStore:
+    store = InMemoryJobStore()
+    set_job_store(store)
+    set_tenant_quota_store(InMemoryTenantQuotaStore())
+    _jobs.clear()
+    return store
+
+
+def test_multi_target_scan_request_creates_parent_and_child_jobs(monkeypatch):
+    store = _reset_store()
+    submitted: list[str] = []
+    monkeypatch.setattr(scan_routes, "submit_scan_job", lambda job: submitted.append(job.job_id))
+
+    parent = scan_routes.enqueue_scan_job(
+        tenant_id="tenant-a",
+        triggered_by="api-test",
+        request_body=ScanRequest(images=["repo/a:latest", "repo/b:latest"], tf_dirs=["infra"], offline=True, no_scan=True),
+    )
+
+    assert parent.parent_job_id is None
+    assert parent.batch_id
+    assert parent.status == JobStatus.RUNNING
+    assert len(parent.child_job_ids) == 3
+    assert submitted == parent.child_job_ids
+
+    children = [store.get(job_id, tenant_id="tenant-a") for job_id in parent.child_job_ids]
+    assert all(child is not None for child in children)
+    assert {child.parent_job_id for child in children if child} == {parent.job_id}
+    assert {child.batch_id for child in children if child} == {parent.batch_id}
+    assert [child.target_index for child in children if child] == [1, 2, 3]
+    assert [child.target["field"] for child in children if child] == ["images", "images", "tf_dirs"]
+    assert children[0].request.images == ["repo/a:latest"]
+    assert children[0].request.tf_dirs == []
+    assert children[2].request.images == []
+    assert children[2].request.tf_dirs == ["infra"]
+
+    stored_parent = store.get(parent.job_id, tenant_id="tenant-a")
+    assert stored_parent is not None
+    assert stored_parent.result["batch"]["target_count"] == 3
+    assert stored_parent.result["batch"]["pending_targets"] == 3
+
+
+def test_batch_parent_rolls_up_child_results_without_failing_partial_batch(monkeypatch):
+    store = _reset_store()
+    monkeypatch.setattr(scan_routes, "submit_scan_job", lambda job: None)
+    parent = scan_routes.enqueue_scan_job(
+        tenant_id="tenant-a",
+        triggered_by="api-test",
+        request_body=ScanRequest(images=["repo/a:latest", "repo/b:latest"], no_scan=True),
+    )
+
+    child_ok = store.get(parent.child_job_ids[0], tenant_id="tenant-a")
+    child_failed = store.get(parent.child_job_ids[1], tenant_id="tenant-a")
+    assert child_ok is not None
+    assert child_failed is not None
+
+    child_ok.status = JobStatus.DONE
+    child_ok.completed_at = "2026-06-24T00:00:01+00:00"
+    child_ok.result = {"summary": {"total_agents": 1}, "agents": [{"name": "image:a"}]}
+    store.put(child_ok)
+
+    child_failed.status = JobStatus.FAILED
+    child_failed.completed_at = "2026-06-24T00:00:02+00:00"
+    child_failed.error = "image scan failed"
+    store.put(child_failed)
+
+    refreshed = scan_routes.refresh_batch_parent(parent.job_id, tenant_id="tenant-a")
+
+    assert refreshed is not None
+    assert refreshed.status == JobStatus.DONE
+    assert refreshed.completed_at == "2026-06-24T00:00:02+00:00"
+    batch = refreshed.result["batch"]
+    assert batch["completed_targets"] == 2
+    assert batch["succeeded_targets"] == 1
+    assert batch["failed_targets"] == 1
+    assert batch["children"][0]["result"]["summary"]["total_agents"] == 1
+    assert batch["children"][1]["error"] == "image scan failed"
+
+
+def test_single_target_scan_request_keeps_single_job_shape(monkeypatch):
+    _reset_store()
+    submitted: list[str] = []
+    monkeypatch.setattr(scan_routes, "submit_scan_job", lambda job: submitted.append(job.job_id))
+
+    job = scan_routes.enqueue_scan_job(
+        tenant_id="tenant-a",
+        triggered_by="api-test",
+        request_body=ScanRequest(images=["repo/a:latest"], no_scan=True),
+    )
+
+    assert job.batch_id is None
+    assert job.parent_job_id is None
+    assert job.child_job_ids == []
+    assert submitted == [job.job_id]

--- a/tests/test_api_store.py
+++ b/tests/test_api_store.py
@@ -311,6 +311,33 @@ def test_sqlite_list_summary():
         Path(db_path).unlink(missing_ok=True)
 
 
+def test_sqlite_list_summary_includes_scan_batch_metadata():
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    try:
+        store = SQLiteJobStore(db_path=db_path)
+        job = _make_job(
+            "child-1",
+            batch_id="batch-1",
+            parent_job_id="parent-1",
+            target={"field": "images", "value": "repo/a:latest", "ordinal": 0},
+            target_index=1,
+            target_count=2,
+        )
+        store.put(job)
+
+        summary = store.list_summary()
+
+        assert summary[0]["batch_id"] == "batch-1"
+        assert summary[0]["parent_job_id"] == "parent-1"
+        assert summary[0]["target"] == {"field": "images", "value": "repo/a:latest", "ordinal": 0}
+        assert summary[0]["target_index"] == 1
+        assert summary[0]["target_count"] == 2
+        assert summary[0]["child_job_ids"] == []
+    finally:
+        Path(db_path).unlink(missing_ok=True)
+
+
 def test_sqlite_list_summary_does_not_hydrate_full_result(monkeypatch):
     with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
         db_path = f.name

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -226,6 +226,14 @@ def test_scan_jobs_has_schedule_id_back_pointer():
     assert "idx_jobs_schedule" in _indexes()
 
 
+def test_scan_jobs_has_batch_parent_child_columns():
+    cols = _columns_for("scan_jobs")
+    for col in ("batch_id", "parent_job_id", "child_job_ids", "target", "target_index", "target_count"):
+        assert col in cols
+    assert "idx_jobs_batch" in _indexes()
+    assert "idx_jobs_parent" in _indexes()
+
+
 def test_scan_jobs_keeps_team_id_as_rls_column_with_api_tenant_translation():
     cols = _columns_for("scan_jobs")
     assert "team_id" in cols

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -194,7 +194,31 @@ class MockConnection:
                 cursor.rows = [(r[-1],) for r in rows]
             elif "from scan_jobs" in sql_lower and "job_id, team_id, status, created_at, completed_at, triggered_by" in sql_lower:
                 rows = list(self._store.get("scan_jobs", {}).values())
-                cursor.rows = [(r[0], r[1], r[2], r[3], r[4], (r[5] if len(r) > 5 else None), (r[6] if len(r) > 6 else None)) for r in rows]
+                summary_rows = []
+                for r in rows:
+                    if len(r) >= 14:
+                        # Stored from PostgresJobStore.put INSERT param order.
+                        summary_rows.append((r[0], r[4], r[1], r[2], r[3], r[12], r[11], r[5], r[6], r[7], r[8], r[9], r[10]))
+                    else:
+                        # Older tests seed rows in SELECT projection order.
+                        summary_rows.append(
+                            (
+                                r[0],
+                                r[1],
+                                r[2],
+                                r[3],
+                                r[4],
+                                (r[5] if len(r) > 5 else None),
+                                (r[6] if len(r) > 6 else None),
+                                (r[7] if len(r) > 7 else None),
+                                (r[8] if len(r) > 8 else None),
+                                (r[9] if len(r) > 9 else "[]"),
+                                (r[10] if len(r) > 10 else "null"),
+                                (r[11] if len(r) > 11 else None),
+                                (r[12] if len(r) > 12 else None),
+                            )
+                        )
+                cursor.rows = summary_rows
             elif "from fleet_agents" in sql_lower and "agent_id, canonical_id, name, lifecycle_state, trust_score" in sql_lower:
                 rows = list(self._store.get("fleet_agents", {}).values())
                 cursor.rows = [(r[0], r[1], r[2], r[3], r[4]) for r in rows]
@@ -348,8 +372,8 @@ def test_job_store_persists_triggered_by(mock_pool):
     insert_sql, insert_params = next((sql, params) for sql, params in reversed(mock_pool._conn.executed) if "INSERT INTO scan_jobs" in sql)
     assert "triggered_by" in insert_sql
     assert "schedule_id" in insert_sql
-    assert insert_params[5] == "sched-alpha"
-    assert insert_params[6] == "analyst@example.com"
+    assert insert_params[11] == "sched-alpha"
+    assert insert_params[12] == "analyst@example.com"
 
 
 def test_job_store_get_nonexistent(mock_pool):


### PR DESCRIPTION
Summary:
- Adds explicit scan-batch parent jobs plus per-target child jobs for multi-target scan requests.
- Persists batch metadata across in-memory, SQLite, Postgres, Snowflake, and Supabase bootstrap schema paths.
- Aggregates child status/results back onto the parent and accounts for parent + child jobs in quota checks.
- Makes the v1 schema drift gate runnable from a clean checkout exactly as CI invokes it.

Verification:
- uv run python scripts/generate_v1_schemas.py --check
- uv run pytest -q tests/test_api_scan_batches.py tests/test_api_store.py tests/test_postgres_schema.py
- uv run ruff check scripts/generate_v1_schemas.py src/agent_bom/api/models.py tests/test_api_scan_batches.py tests/test_api_store.py tests/test_postgres_schema.py
- git diff --check

Notes:
- Closes #2941.
