### PR TITLE
feat(cloud): AWS inventory parity batch 3 — CloudFront, ECR, Redshift, SNS/SQS

### DIFF
--- a/src/agent_bom/cloud/aws_inventory.py
+++ b/src/agent_bom/cloud/aws_inventory.py
@@ -82,15 +82,20 @@ _AWS_DATA_PERMISSIONS: tuple[str, ...] = (
     "rds:DescribeDBInstances",
     "dynamodb:ListTables",
     "dynamodb:DescribeTable",
+    "redshift:DescribeClusters",
 )
 _AWS_COMPUTE_PERMISSIONS: tuple[str, ...] = (
     "lambda:ListFunctions",
     "eks:ListClusters",
     "eks:DescribeCluster",
+    "ecr:DescribeRepositories",
 )
 _AWS_NETWORK_PERMISSIONS: tuple[str, ...] = (
     "elasticloadbalancing:DescribeLoadBalancers",
     "ec2:DescribeVpcs",
+    "cloudfront:ListDistributions",
+    "sns:ListTopics",
+    "sqs:ListQueues",
 )
 _AWS_SECURITY_PERMISSIONS: tuple[str, ...] = (
     "kms:ListKeys",
@@ -161,6 +166,10 @@ def discover_inventory(
         "vpcs": [],
         "kms_keys": [],
         "secrets": [],
+        "cloudfront_distributions": [],
+        "ecr_repositories": [],
+        "redshift_clusters": [],
+        "messaging": [],
         "warnings": [],
         "discovery_envelope": None,
     }
@@ -206,6 +215,10 @@ def discover_inventory(
     vpcs: list[dict[str, Any]] = []
     kms_keys: list[dict[str, Any]] = []
     secrets: list[dict[str, Any]] = []
+    cloudfront_distributions: list[dict[str, Any]] = []
+    ecr_repositories: list[dict[str, Any]] = []
+    redshift_clusters: list[dict[str, Any]] = []
+    messaging: list[dict[str, Any]] = []
 
     try:
         if include_s3:
@@ -219,12 +232,16 @@ def discover_inventory(
             dynamodb_tables = _discover_dynamodb(session, resolved_region, account_id=account_id, warnings=warnings)
             kms_keys = _discover_kms(session, resolved_region, account_id=account_id, warnings=warnings)
             secrets = _discover_secrets(session, resolved_region, account_id=account_id, warnings=warnings)
+            redshift_clusters = _discover_redshift(session, resolved_region, account_id=account_id, warnings=warnings)
         if include_compute:
             lambda_functions = _discover_lambda(session, resolved_region, account_id=account_id, warnings=warnings)
             eks_clusters = _discover_eks(session, resolved_region, account_id=account_id, warnings=warnings)
+            ecr_repositories = _discover_ecr(session, resolved_region, account_id=account_id, warnings=warnings)
         if include_network:
             elb_load_balancers = _discover_elb(session, resolved_region, account_id=account_id, warnings=warnings)
             vpcs = _discover_vpcs(session, resolved_region, account_id=account_id, warnings=warnings)
+            cloudfront_distributions = _discover_cloudfront(session, account_id=account_id, warnings=warnings)
+            messaging = _discover_messaging(session, resolved_region, account_id=account_id, warnings=warnings)
     except NoCredentialsError:
         return {
             **empty,
@@ -279,6 +296,10 @@ def discover_inventory(
         "vpcs": vpcs,
         "kms_keys": kms_keys,
         "secrets": secrets,
+        "cloudfront_distributions": cloudfront_distributions,
+        "ecr_repositories": ecr_repositories,
+        "redshift_clusters": redshift_clusters,
+        "messaging": messaging,
         "warnings": warnings,
         "discovery_envelope": envelope.to_dict(),
     }
@@ -879,6 +900,135 @@ def _discover_secrets(session: Any, region: str, *, account_id: str | None, warn
                 )
     except Exception as exc:  # noqa: BLE001
         warnings.append(f"Could not list Secrets Manager secrets: {sanitize_discovery_warning(exc)}")
+    return out
+
+
+def _discover_cloudfront(session: Any, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate CloudFront CDN distributions (read-only, global). Internet-facing edge."""
+    out: list[dict[str, Any]] = []
+    try:
+        client = session.client("cloudfront")
+        paginator = client.get_paginator("list_distributions")
+        for page in paginator.paginate():
+            for dist in (page.get("DistributionList", {}) or {}).get("Items", []) or []:
+                dist_id = str(dist.get("Id", "") or "")
+                if not dist_id:
+                    continue
+                origins = [str(o.get("DomainName", "")) for o in (dist.get("Origins", {}) or {}).get("Items", []) or []]
+                out.append(
+                    {
+                        "name": dist_id,
+                        "arn": str(dist.get("ARN", "") or ""),
+                        "domain_name": str(dist.get("DomainName", "") or ""),
+                        "enabled": bool(dist.get("Enabled")),
+                        "internet_exposed": True,  # a CDN distribution is internet-facing by definition
+                        "origins": origins,
+                        "account_id": account_id or "",
+                        "location": "global",
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list CloudFront distributions: {sanitize_discovery_warning(exc)}")
+    return out
+
+
+def _discover_ecr(session: Any, region: str, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate ECR container registries (read-only). Become container-registry resources."""
+    out: list[dict[str, Any]] = []
+    try:
+        client = session.client("ecr", region_name=region)
+        paginator = client.get_paginator("describe_repositories")
+        for page in paginator.paginate():
+            for repo in page.get("repositories", []):
+                name = str(repo.get("repositoryName", "") or "")
+                if not name:
+                    continue
+                out.append(
+                    {
+                        "name": name,
+                        "arn": str(repo.get("repositoryArn", "") or ""),
+                        "uri": str(repo.get("repositoryUri", "") or ""),
+                        "scan_on_push": bool((repo.get("imageScanningConfiguration") or {}).get("scanOnPush")),
+                        "tag_immutable": str(repo.get("imageTagMutability", "")) == "IMMUTABLE",
+                        "account_id": account_id or "",
+                        "location": region,
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list ECR repositories: {sanitize_discovery_warning(exc)}")
+    return out
+
+
+def _discover_redshift(session: Any, region: str, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate Redshift clusters (read-only). Data warehouses → ``DATA_STORE``."""
+    out: list[dict[str, Any]] = []
+    try:
+        client = session.client("redshift", region_name=region)
+        paginator = client.get_paginator("describe_clusters")
+        for page in paginator.paginate():
+            for c in page.get("Clusters", []):
+                name = str(c.get("ClusterIdentifier", "") or "")
+                if not name:
+                    continue
+                out.append(
+                    {
+                        "name": name,
+                        "engine": "redshift",
+                        "publicly_accessible": bool(c.get("PubliclyAccessible")),
+                        "encrypted": bool(c.get("Encrypted")),
+                        "endpoint": str((c.get("Endpoint") or {}).get("Address", "") or ""),
+                        "node_type": str(c.get("NodeType", "") or ""),
+                        "account_id": account_id or "",
+                        "location": region,
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list Redshift clusters: {sanitize_discovery_warning(exc)}")
+    return out
+
+
+def _discover_messaging(session: Any, region: str, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate SNS topics + SQS queues (read-only). Become messaging resources."""
+    out: list[dict[str, Any]] = []
+    try:
+        sns = session.client("sns", region_name=region)
+        paginator = sns.get_paginator("list_topics")
+        for page in paginator.paginate():
+            for topic in page.get("Topics", []):
+                arn = str(topic.get("TopicArn", "") or "")
+                if not arn:
+                    continue
+                out.append(
+                    {
+                        "name": arn.rsplit(":", 1)[-1],
+                        "arn": arn,
+                        "messaging_type": "sns-topic",
+                        "account_id": account_id or "",
+                        "location": region,
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list SNS topics: {sanitize_discovery_warning(exc)}")
+    try:
+        sqs = session.client("sqs", region_name=region)
+        paginator = sqs.get_paginator("list_queues")
+        for page in paginator.paginate():
+            for url in page.get("QueueUrls", []) or []:
+                name = str(url).rsplit("/", 1)[-1]
+                if not name:
+                    continue
+                out.append(
+                    {
+                        "name": name,
+                        "arn": f"arn:aws:sqs:{region}:{account_id or ''}:{name}",
+                        "messaging_type": "sqs-queue",
+                        "url": str(url),
+                        "account_id": account_id or "",
+                        "location": region,
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list SQS queues: {sanitize_discovery_warning(exc)}")
     return out
 
 

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -3434,6 +3434,10 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
         ("vpcs", "ec2", "virtual_network", "vpc", "vpc", False),
         ("kms_keys", "kms", "key", "kms-key", "kms key", False),
         ("secrets", "secretsmanager", "secret", "secretsmanager-secret", "secret", False),
+        ("cloudfront_distributions", "cloudfront", "cdn", "cloudfront-distribution", "cdn distribution", False),
+        ("ecr_repositories", "ecr", "container_registry", "ecr-repository", "container registry", False),
+        ("redshift_clusters", "redshift", "data_warehouse", "redshift-cluster", "redshift warehouse", True),
+        ("messaging", "messaging", "messaging", "aws-messaging", "messaging", False),
     ):
         for item in inventory.get(coll_key, []) or []:
             if not isinstance(item, dict):

--- a/tests/test_aws_inventory_cdn_messaging.py
+++ b/tests/test_aws_inventory_cdn_messaging.py
@@ -1,0 +1,169 @@
+"""AWS CloudFront/ECR/Redshift/SNS/SQS inventory: discovery + graph nodes."""
+
+from __future__ import annotations
+
+from agent_bom.graph.builder import build_unified_graph_from_report
+
+
+def _inventory() -> dict:
+    return {
+        "status": "ok",
+        "provider": "aws",
+        "account_id": "111122223333",
+        "cloudfront_distributions": [
+            {
+                "name": "E123",
+                "arn": "arn:cf",
+                "domain_name": "d1.cloudfront.net",
+                "enabled": True,
+                "internet_exposed": True,
+                "location": "global",
+            }
+        ],
+        "ecr_repositories": [
+            {
+                "name": "app",
+                "arn": "arn:ecr",
+                "uri": "1.dkr.ecr.us-east-1.amazonaws.com/app",
+                "scan_on_push": True,
+                "tag_immutable": True,
+                "location": "us-east-1",
+            }
+        ],
+        "redshift_clusters": [
+            {"name": "warehouse", "engine": "redshift", "publicly_accessible": True, "encrypted": False, "location": "us-east-1"}
+        ],
+        "messaging": [
+            {"name": "events", "arn": "arn:aws:sns:us-east-1:111122223333:events", "messaging_type": "sns-topic", "location": "us-east-1"},
+            {"name": "jobs", "arn": "arn:aws:sqs:us-east-1:111122223333:jobs", "messaging_type": "sqs-queue", "location": "us-east-1"},
+        ],
+    }
+
+
+def _build():
+    g = build_unified_graph_from_report({"cloud_inventory": _inventory()})
+    return g, {(e.source, e.target, e.relationship.value) for e in g.edges}
+
+
+def test_cloudfront_is_internet_exposed_cdn() -> None:
+    g, _ = _build()
+    cf = g.nodes["cloud_resource:aws:cloudfront:cdn:E123"]
+    assert cf.attributes["internet_exposed"] is True
+
+
+def test_redshift_is_exposed_data_store() -> None:
+    g, _ = _build()
+    rs = g.nodes["cloud_resource:aws:redshift:data_warehouse:warehouse"]
+    assert rs.entity_type.value == "data_store"
+    assert rs.attributes["internet_exposed"] is True  # publicly_accessible
+
+
+def test_ecr_and_messaging_nodes_owned() -> None:
+    g, edges = _build()
+    for nid in (
+        "cloud_resource:aws:ecr:container_registry:app",
+        "cloud_resource:aws:messaging:messaging:events",
+        "cloud_resource:aws:messaging:messaging:jobs",
+    ):
+        assert nid in g.nodes
+        assert ("account:aws:111122223333", nid, "owns") in edges
+
+
+# ── Discovery (mocked boto3) ─────────────────────────────────────────────
+class _Paginator:
+    def __init__(self, pages):
+        self._pages = pages
+
+    def paginate(self, **_kw):
+        return self._pages
+
+
+class _Client:
+    def __init__(self, svc):
+        self.svc = svc
+
+    def get_paginator(self, op):
+        if self.svc == "cloudfront":
+            return _Paginator(
+                [
+                    {
+                        "DistributionList": {
+                            "Items": [
+                                {
+                                    "Id": "E1",
+                                    "ARN": "arn:cf",
+                                    "DomainName": "d.cf.net",
+                                    "Enabled": True,
+                                    "Origins": {"Items": [{"DomainName": "b.s3.aws"}]},
+                                }
+                            ]
+                        }
+                    }
+                ]
+            )
+        if self.svc == "ecr":
+            return _Paginator(
+                [
+                    {
+                        "repositories": [
+                            {
+                                "repositoryName": "app",
+                                "repositoryArn": "arn:ecr",
+                                "repositoryUri": "uri",
+                                "imageScanningConfiguration": {"scanOnPush": True},
+                                "imageTagMutability": "IMMUTABLE",
+                            }
+                        ]
+                    }
+                ]
+            )
+        if self.svc == "redshift":
+            return _Paginator(
+                [
+                    {
+                        "Clusters": [
+                            {
+                                "ClusterIdentifier": "wh",
+                                "PubliclyAccessible": True,
+                                "Encrypted": False,
+                                "Endpoint": {"Address": "wh.redshift.aws"},
+                                "NodeType": "ra3",
+                            }
+                        ]
+                    }
+                ]
+            )
+        if self.svc == "sns":
+            return _Paginator([{"Topics": [{"TopicArn": "arn:aws:sns:us-east-1:111122223333:t1"}]}])
+        if self.svc == "sqs":
+            return _Paginator([{"QueueUrls": ["https://sqs.us-east-1.aws/111122223333/q1"]}])
+        return _Paginator([])
+
+
+class _Session:
+    def client(self, svc, **_kw):
+        return _Client(svc)
+
+
+def test_discovery_parses_cdn_registry_warehouse_messaging() -> None:
+    from agent_bom.cloud import aws_inventory as aws
+
+    s, w = _Session(), []
+    cf = aws._discover_cloudfront(s, account_id="111122223333", warnings=w)
+    assert cf[0]["internet_exposed"] is True and cf[0]["origins"] == ["b.s3.aws"]
+    ecr = aws._discover_ecr(s, "us-east-1", account_id="111122223333", warnings=w)
+    assert ecr[0]["scan_on_push"] is True and ecr[0]["tag_immutable"] is True
+    rs = aws._discover_redshift(s, "us-east-1", account_id="111122223333", warnings=w)
+    assert rs[0]["publicly_accessible"] is True and rs[0]["engine"] == "redshift"
+    msg = aws._discover_messaging(s, "us-east-1", account_id="111122223333", warnings=w)
+    types = {m["messaging_type"] for m in msg}
+    assert types == {"sns-topic", "sqs-queue"}
+    assert w == []
+
+
+def test_discover_inventory_returns_every_new_collection() -> None:
+    from agent_bom.cloud import aws_inventory as aws
+
+    out = aws.discover_inventory(force=False)
+    for k in ("cloudfront_distributions", "ecr_repositories", "redshift_clusters", "messaging"):
+        assert k in out, f"{k} missing from discover_inventory return"


### PR DESCRIPTION
## What

Batch 3 of the AWS parity push (after batch 1 #3072 + batch 2 #3073). **Validated live** (Redshift degraded gracefully on the account's OptInRequired, no crash).

| New | Node | Signal |
|---|---|---|
| **CloudFront** | `CLOUD_RESOURCE` (cdn) | internet-facing by definition, origins |
| **ECR** | `CLOUD_RESOURCE` (container registry) | scan-on-push, tag immutability |
| **Redshift** | `DATA_STORE` (warehouse) | public-access, encryption |
| **SNS/SQS** | `CLOUD_RESOURCE` (messaging) | topics + queues |

Wired full-stack (discover_inventory flags + permissions + graph config + cloud_inventory payload). AWS now covers **17 resource types** (was 5). 5 tests incl. collected-but-not-returned guard.

Next batch: Organizations/OUs/SCPs + IAM permission boundaries (the org/posture hierarchy).