### PR TITLE
feat(cloud): converge cloud CIS failures into the unified findings stream + gate

### DIFF
--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -641,6 +641,50 @@ def secret_dict_to_finding(secret: dict) -> "Finding":
     )
 
 
+def cloud_cis_check_to_finding(check: dict, provider: str) -> "Finding":
+    """Convert one FAILED cloud CIS check into a unified CLOUD_CIS Finding.
+
+    Lifts cloud CIS failures out of the side-block (``*_cis_benchmark_data``) into
+    the unified findings stream so ``--fail-on-severity``, SARIF, and severity
+    rollups see them — previously a ``cloud`` scan exited 0 even with HIGH/CRITICAL
+    misconfigurations. Carries the check's MITRE ATT&CK techniques + CIS tag.
+    """
+    from agent_bom.security import sanitize_text
+
+    check_id = sanitize_text(str(check.get("check_id", "") or "unknown"), max_len=40)
+    title = sanitize_text(str(check.get("title", "") or check_id), max_len=300)
+    severity = sanitize_text(str(check.get("severity", "medium") or "medium"), max_len=40).upper()
+    evidence_text = sanitize_text(str(check.get("evidence", "") or ""), max_len=600)
+    recommendation = sanitize_text(str(check.get("recommendation", "") or ""), max_len=600)
+    resource_ids = [sanitize_text(str(r), max_len=300) for r in (check.get("resource_ids") or []) if str(r).strip()]
+    primary = resource_ids[0] if resource_ids else f"{provider}-account"
+    attack = [str(t) for t in (check.get("attack_techniques") or []) if str(t).strip()]
+    compliance = [f"CIS-{check_id}"] + [str(t) for t in (check.get("compliance_tags") or []) if str(t).strip()]
+    return Finding(
+        finding_type=FindingType.CIS_FAIL,
+        source=FindingSource.CLOUD_CIS,
+        asset=Asset(
+            name=primary,
+            asset_type="cloud_resource",
+            identifier=primary,
+            location=provider,
+        ),
+        severity=severity,
+        title=f"CIS {check_id}: {title}",
+        description=evidence_text or f"CIS benchmark control {check_id} failed for {provider}.",
+        remediation_guidance=recommendation or None,
+        compliance_tags=sorted(set(compliance)),
+        attack_tags=sorted(set(attack)),
+        evidence={
+            "provider": provider,
+            "check_id": check_id,
+            "cis_section": check.get("cis_section", ""),
+            "resource_ids": resource_ids,
+            "benchmark": "CIS",
+        },
+    )
+
+
 def blast_radius_to_finding(br: object) -> "Finding":
     """Convert a BlastRadius instance to a unified Finding.
 

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -1126,7 +1126,35 @@ class AIBOMReport:
         # finding, but do not suppress unrelated secret findings in the side block.
         existing_ids = {getattr(f, "id", None) for f in base}
         base.extend(finding for finding in self._secret_findings() if finding.id not in existing_ids)
+        cis_existing = existing_ids | {getattr(f, "id", None) for f in base}
+        base.extend(finding for finding in self._cloud_cis_findings() if finding.id not in cis_existing)
         return base
+
+    def _cloud_cis_findings(self) -> "list[Finding]":
+        """Cloud CIS benchmark FAILures lifted into the unified findings stream.
+
+        Each provider's CIS results live in a side block (``*_cis_benchmark_data``)
+        and never reached the unified stream — so ``cloud`` scans exited 0 even on
+        HIGH/CRITICAL misconfigurations and ``--fail-on-severity`` was blind to
+        cloud posture. Convert every FAILED check to a CLOUD_CIS Finding so the
+        gate, SARIF, and severity rollups converge across all providers.
+        """
+        from agent_bom.finding import cloud_cis_check_to_finding
+
+        findings: list[Finding] = []
+        for provider, data in (
+            ("aws", self.cis_benchmark_data),
+            ("azure", self.azure_cis_benchmark_data),
+            ("gcp", self.gcp_cis_benchmark_data),
+            ("snowflake", self.snowflake_cis_benchmark_data),
+            ("databricks", self.databricks_cis_benchmark_data),
+        ):
+            if not isinstance(data, dict):
+                continue
+            for check in data.get("checks", []) or []:
+                if isinstance(check, dict) and str(check.get("status", "")).upper() == "FAIL":
+                    findings.append(cloud_cis_check_to_finding(check, provider))
+        return findings
 
     def cve_findings(self) -> "list[Finding]":
         """Return only CVE-type findings from the unified stream."""

--- a/tests/test_cloud_cis_convergence.py
+++ b/tests/test_cloud_cis_convergence.py
@@ -1,0 +1,87 @@
+"""Cloud CIS failures converge into the unified findings stream + the gate."""
+
+from __future__ import annotations
+
+from agent_bom.models import AIBOMReport
+
+
+def _report() -> AIBOMReport:
+    r = AIBOMReport(scan_id="t")
+    # AWS CIS: one HIGH fail, one pass
+    r.cis_benchmark_data = {
+        "checks": [
+            {
+                "check_id": "1.7",
+                "title": "Root used",
+                "status": "FAIL",
+                "severity": "high",
+                "evidence": "root login",
+                "resource_ids": [],
+                "attack_techniques": ["T1078"],
+            },
+            {"check_id": "2.1", "title": "S3 block", "status": "PASS", "severity": "high"},
+        ]
+    }
+    # Azure CIS: one CRITICAL fail with a resource
+    r.azure_cis_benchmark_data = {
+        "checks": [
+            {
+                "check_id": "3.2",
+                "title": "Storage open",
+                "status": "FAIL",
+                "severity": "critical",
+                "evidence": "open",
+                "resource_ids": ["/sub/x/sa/foo"],
+            },
+        ]
+    }
+    return r
+
+
+def test_cis_fails_become_findings_across_providers() -> None:
+    cis = [f for f in _report().to_findings() if f.finding_type.value == "CIS_FAIL"]
+    assert len(cis) == 2  # AWS 1.7 + Azure 3.2; the PASS excluded
+    by_title = {f.title: f for f in cis}
+    assert "CIS 1.7: Root used" in by_title
+    assert by_title["CIS 1.7: Root used"].attack_tags == ["T1078"]
+    assert "CIS-1.7" in by_title["CIS 1.7: Root used"].compliance_tags
+    az = by_title["CIS 3.2: Storage open"]
+    assert az.severity == "CRITICAL"
+    assert az.asset.identifier == "/sub/x/sa/foo"
+
+
+def test_pass_checks_not_findings() -> None:
+    titles = {f.title for f in _report().to_findings()}
+    assert "CIS 2.1: S3 block" not in titles  # PASS never becomes a finding
+
+
+def _gate(report: AIBOMReport) -> int:
+    from rich.console import Console
+
+    from agent_bom.cli.agents._context import ScanContext
+    from agent_bom.cli.agents._post import compute_exit_code
+
+    ctx = ScanContext(con=Console(quiet=True))
+    ctx.report = report
+    ctx.blast_radii = []
+    return compute_exit_code(
+        ctx,
+        fail_on_severity="high",
+        warn_on_severity=None,
+        fail_on_kev=False,
+        fail_if_ai_risk=False,
+        push_url=None,
+        push_api_key=None,
+        quiet=True,
+    )
+
+
+def test_fail_on_severity_gate_catches_cloud_cis() -> None:
+    # No CVEs/IaC — only cloud CIS. Gate at HIGH must trip on the CIS fails.
+    assert _gate(_report()) != 0, "cloud CIS HIGH/CRITICAL failures must fail the gate"
+
+
+def test_clean_cis_does_not_trip_gate() -> None:
+    r = AIBOMReport(scan_id="t")
+    r.cis_benchmark_data = {"checks": [{"check_id": "1.1", "title": "ok", "status": "PASS", "severity": "high"}]}
+    assert _gate(r) == 0


### PR DESCRIPTION
## What (live-audit P1 — gate-blindness)

Cloud CIS results lived in side blocks (`*_cis_benchmark_data`) and **never reached `to_findings()`** — so a `cloud` scan exited **0 with HIGH/CRITICAL misconfigurations** and `--fail-on-severity` was blind to cloud posture (confirmed live: AWS scan exited 0 with 5 HIGH CIS fails).

## Fix
Every **FAILED** CIS check (AWS/Azure/GCP/Snowflake/Databricks) becomes a `CIS_FAIL` Finding (source `CLOUD_CIS`) carrying its **severity + MITRE ATT&CK techniques + CIS tag**. Since `compute_exit_code` already gates on `to_findings()` (minus CVE), the gate, SARIF, and severity rollups now **converge across all providers**. PASS checks never become findings.

**Turns cloud scanning from a dashboard into a CI gate.**

## Tests
4: multi-provider conversion, PASS-excluded, the `--fail-on-severity` gate trips on HIGH/CRITICAL CIS, and stays clean on all-pass. Full findings/output regression sweep (342) green.