### PR TITLE
fix(security): clear Scorecard branch and fixture vulnerability gaps

### DIFF
--- a/deploy/docker/pip-requirements.txt
+++ b/deploy/docker/pip-requirements.txt
@@ -6,6 +6,6 @@
 # `curl -fsSL https://pypi.org/pypi/pip/<version>/json | jq -r '.urls[] | "sha256:" + .digests.sha256'`
 # and copy the wheel + sdist hashes below.
 
-pip==26.1 \
-    --hash=sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1 \
-    --hash=sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3
+pip==26.1.2 \
+    --hash=sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab \
+    --hash=sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605

--- a/tests/fixtures/npm-workspace-package-lock/apps/web/package-lock.json
+++ b/tests/fixtures/npm-workspace-package-lock/apps/web/package-lock.json
@@ -12,7 +12,7 @@
         "react": "18.2.0"
       },
       "devDependencies": {
-        "vite": "8.0.5"
+        "vite": "8.0.16"
       }
     },
     "node_modules/@sample/ui": {
@@ -26,8 +26,8 @@
       "integrity": "sha512-fixture"
     },
     "node_modules/vite": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
       "integrity": "sha512-fixture",
       "dev": true
     },

--- a/tests/fixtures/npm-workspace-package-lock/apps/web/package.json
+++ b/tests/fixtures/npm-workspace-package-lock/apps/web/package.json
@@ -7,6 +7,6 @@
     "react": "18.2.0"
   },
   "devDependencies": {
-    "vite": "8.0.5"
+    "vite": "8.0.16"
   }
 }

--- a/tests/test_project_mode.py
+++ b/tests/test_project_mode.py
@@ -205,7 +205,7 @@ class TestScanProjectDirectory:
         assert packages["react"].is_direct is True
         assert packages["@sample/ui"].version == "1.0.0"
         assert packages["@sample/ui"].is_direct is True
-        assert packages["vite"].version == "8.0.5"
+        assert packages["vite"].version == "8.0.16"
         assert packages["vite"].is_direct is True
         assert packages["rollup"].version == "4.59.0"
         assert packages["rollup"].is_direct is False


### PR DESCRIPTION
Summary
- bump the hash-pinned Docker runtime pip bootstrap from 26.1 to 26.1.2 for PYSEC-2026-196
- update the npm workspace fixture from vite 8.0.5 to 8.0.16 so security scanners do not flag test data for the Vite/launch-editor advisories
- update the parser fixture assertion to the fixed Vite version

Repository settings applied directly
- enabled strict required status checks on main, dev, and existing release/* branches
- applied the same PR review, code owner, stale-review, last-push approval, force-push/deletion disabled, linear-history, and conversation-resolution controls to dev and existing release/* branches

Verification
- uv run pytest -q tests/test_project_mode.py tests/test_lockfile_guard.py tests/test_parser_file_limits.py
- uv run ruff check tests/test_project_mode.py
- python -m pip install --dry-run --require-hashes -r deploy/docker/pip-requirements.txt
- python scripts/check_docker_base_policy.py
- uv run --with pip-audit pip-audit --ignore-vuln CVE-2026-3219 --format=json
- cd ui && npm audit --json
- verified GitHub branch protection API reports strict=true on main, dev, and existing release/* branches

Notes
- GitHub Dependabot and code-scanning APIs currently return no open alerts for the repository.
- The test fixture lockfile uses synthetic sha512-fixture integrity values by design; only the package version and resolved fixture URL changed.