### PR TITLE
fix(ui): wrap long monospace config blocks in identity-audit cards

### DIFF
--- a/ui/components/key-lifecycle-panel.tsx
+++ b/ui/components/key-lifecycle-panel.tsx
@@ -417,7 +417,7 @@ export function KeyLifecyclePanel({
               {copied ? "Copied" : "Copy raw key"}
             </button>
           </div>
-          <pre className="mt-3 overflow-x-auto rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-3 text-sm text-zinc-100">
+          <pre className="mt-3 max-w-full overflow-x-auto whitespace-pre-wrap break-all rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-3 text-sm text-zinc-100">
             {issuedSecret.rawKey}
           </pre>
         </div>
@@ -619,7 +619,7 @@ export function KeyLifecyclePanel({
                   {policy.tenant_quota_runtime.source}
                   {policy.tenant_quota_runtime.active_override ? " · tenant override active" : " · global defaults active"}
                 </p>
-                <p className="mt-1 text-xs text-zinc-400">Manage overrides at {policy.tenant_quota_runtime.override_endpoint}.</p>
+                <p className="mt-1 break-words text-xs text-zinc-400 [overflow-wrap:anywhere]">Manage overrides at {policy.tenant_quota_runtime.override_endpoint}.</p>
               </div>
               <div className="mt-3 grid grid-cols-2 gap-3">
                 {quotaCards.map(({ field, label, value }) => (
@@ -1019,10 +1019,12 @@ function BoundaryCard({
           detail: "text-amber-200/70",
         };
   return (
-    <div className={`rounded-xl border bg-zinc-950/50 p-3 ${tone.border}`}>
+    <div className={`min-w-0 rounded-xl border bg-zinc-950/50 p-3 ${tone.border}`}>
       <p className={`text-sm font-semibold ${tone.title}`}>{title}</p>
-      <p className="mt-1 text-xs leading-5 text-zinc-300">{body}</p>
-      {detail ? <p className={`mt-2 text-[11px] uppercase tracking-[0.14em] ${tone.detail}`}>{detail}</p> : null}
+      <p className="mt-1 break-words text-xs leading-5 text-zinc-300 [overflow-wrap:anywhere]">{body}</p>
+      {detail ? (
+        <p className={`mt-2 break-words text-[11px] uppercase tracking-[0.14em] [overflow-wrap:anywhere] ${tone.detail}`}>{detail}</p>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Problem

In the identity-audit view (`/audit`, `KeyLifecyclePanel`), the monospace config/detail text in the agent-detail cards — Provisioning posture, SCM auth boundary, Revocation boundaries, Key inventory — rendered long unbroken strings (SCIM lifecycle config, role-grant lines, override endpoints) that overflowed past the right edge of their card instead of wrapping.

## Fix

- `BoundaryCard`: added `min-w-0` so the card can shrink as a grid child (the classic flex/grid overflow cause), and applied `break-words` + `[overflow-wrap:anywhere]` to the body and detail paragraphs so long tokens wrap inside the card.
- Issued raw-key `<pre>`: hardened with `max-w-full` + `whitespace-pre-wrap` + `break-all` so a long key stays inside its container.
- Quota override-endpoint paragraph: added `break-words` + `[overflow-wrap:anywhere]`.

Visual-only change; no data or layout structure altered. Lint, typecheck, and `next build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)