### PR TITLE
feat(ui): cloud CIS benchmark drill-down on the compliance dashboard

### DIFF
--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -41,6 +41,7 @@ import {
 } from "lucide-react";
 import { ComplianceHeatmap } from "@/components/compliance-heatmap";
 import { ComplianceMatrix } from "@/components/compliance-matrix";
+import { CISBenchmarkDetail } from "@/components/cis-benchmark-detail";
 import { ApiOfflineState } from "@/components/api-offline-state";
 import { PageEmptyState, PageLoadingState } from "@/components/states/page-state";
 import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
@@ -855,6 +856,13 @@ function CompliancePageContent() {
         <FrameworkBar label="ISO 27001" pass={s.iso_27001_pass} warn={s.iso_27001_warn} fail={s.iso_27001_fail} total={data.iso_27001.length} />
         <FrameworkBar label="SOC 2" pass={s.soc2_pass} warn={s.soc2_warn} fail={s.soc2_fail} total={data.soc2.length} />
         <FrameworkBar label="CIS Controls v8" pass={s.cis_pass} warn={s.cis_warn} fail={s.cis_fail} total={data.cis_controls.length} />
+        <a
+          href="#cloud-cis-benchmarks"
+          className="inline-flex items-center gap-1 text-xs text-cyan-400 hover:text-cyan-300"
+        >
+          <ChevronRight className="h-3.5 w-3.5" />
+          Drill into cloud CIS benchmark checks (AWS / Azure / GCP / Snowflake / Databricks)
+        </a>
         <FrameworkBar label="CMMC 2.0" pass={s.cmmc_pass} warn={s.cmmc_warn} fail={s.cmmc_fail} total={data.cmmc.length} />
       </div>
 
@@ -909,6 +917,9 @@ function CompliancePageContent() {
           />
         ))}
       </div>
+
+      {/* ── Cloud CIS benchmark drill-down ─────────────────────────────── */}
+      <CISBenchmarkDetail />
 
       </>
       )}

--- a/ui/components/cis-benchmark-detail.tsx
+++ b/ui/components/cis-benchmark-detail.tsx
@@ -135,7 +135,7 @@ function CopyableFixCli({ check }: { check: CISBenchmarkCheck }) {
         </pre>
         <button
           type="button"
-          onClick={onCopy}
+          onClick={() => void onCopy()}
           aria-label={
             check.requires_human_review
               ? "Copy fix command — requires human review before applying"
@@ -293,7 +293,7 @@ export function CISBenchmarkDetail() {
     setError(null);
     // One page covers the full benchmark catalog (well under the 500 cap), so
     // every guardrails/priority filter sees all checks rather than a slice.
-    api
+    void api
       .listCisBenchmarkChecks({ limit: 500 })
       .then((response) => {
         if (cancelled) return;

--- a/ui/components/cis-benchmark-detail.tsx
+++ b/ui/components/cis-benchmark-detail.tsx
@@ -1,0 +1,445 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle,
+  ChevronDown,
+  ChevronRight,
+  Cloud,
+  Copy,
+  ExternalLink,
+  ShieldAlert,
+  Terminal,
+  XCircle,
+} from "lucide-react";
+
+import { api } from "@/lib/api";
+import type { CISBenchmarkCheck } from "@/lib/api";
+import { userFacingApiErrorMessage } from "@/lib/api-errors";
+
+// Clouds the backend `build_cis_benchmark_check_rows` can emit, in the order
+// we want them surfaced. The selector only shows clouds actually present in
+// the fetched checks, so an estate without (say) Snowflake never shows it.
+const CLOUD_LABELS: Record<string, string> = {
+  aws: "AWS",
+  azure: "Azure",
+  gcp: "GCP",
+  snowflake: "Snowflake",
+  databricks: "Databricks",
+};
+
+function cloudLabel(cloud: string): string {
+  return CLOUD_LABELS[cloud] ?? cloud.toUpperCase();
+}
+
+// The backend serves these rows from two paths (in-memory scan jobs and the
+// columnar store). Both should emit flat array/boolean fields, but normalize
+// defensively so a stringified `guardrails` or missing array never crashes a
+// `.map` / `.includes` in render or filtering.
+function normalizeCheck(check: CISBenchmarkCheck): CISBenchmarkCheck {
+  return {
+    ...check,
+    guardrails: Array.isArray(check.guardrails) ? check.guardrails : [],
+    resource_ids: Array.isArray(check.resource_ids) ? check.resource_ids : [],
+    fix_cli: typeof check.fix_cli === "string" ? check.fix_cli : "",
+    fix_console: typeof check.fix_console === "string" ? check.fix_console : "",
+    requires_human_review: Boolean(check.requires_human_review),
+    priority: typeof check.priority === "number" ? check.priority : Number(check.priority) || 0,
+    remediation: check.remediation ?? {},
+  };
+}
+
+function priorityLabel(priority: number): string {
+  return priority > 0 ? `P${priority}` : "P—";
+}
+
+function statusBadge(status: string): { label: string; className: string; Icon: typeof CheckCircle } {
+  switch (status) {
+    case "pass":
+      return { label: "Pass", className: "text-emerald-400 border-emerald-500/30 bg-emerald-500/10", Icon: CheckCircle };
+    case "fail":
+      return { label: "Fail", className: "text-red-400 border-red-500/30 bg-red-500/10", Icon: XCircle };
+    case "error":
+      return { label: "Error", className: "text-orange-400 border-orange-500/30 bg-orange-500/10", Icon: AlertTriangle };
+    case "not_applicable":
+      return { label: "N/A", className: "text-zinc-500 border-zinc-700 bg-zinc-800/40", Icon: ChevronRight };
+    default:
+      return { label: status || "Unknown", className: "text-zinc-400 border-zinc-700 bg-zinc-800/40", Icon: ChevronRight };
+  }
+}
+
+function severityClass(severity: string): string {
+  switch (severity) {
+    case "critical":
+      return "text-red-300 border-red-500/40 bg-red-500/10";
+    case "high":
+      return "text-orange-300 border-orange-500/40 bg-orange-500/10";
+    case "medium":
+      return "text-yellow-300 border-yellow-500/40 bg-yellow-500/10";
+    case "low":
+      return "text-sky-300 border-sky-500/40 bg-sky-500/10";
+    default:
+      return "text-zinc-400 border-zinc-700 bg-zinc-800/40";
+  }
+}
+
+const ALL = "all";
+// Typed as string[] (not a literal tuple) so the generic FilterPills infers
+// T = string and accepts the string state value.
+const STATUS_OPTIONS: string[] = [ALL, "fail", "pass"];
+
+function CopyableFixCli({ check }: { check: CISBenchmarkCheck }) {
+  const [copied, setCopied] = useState(false);
+  const cli = check.fix_cli;
+
+  const onCopy = useCallback(async () => {
+    if (!cli) return;
+    try {
+      await navigator.clipboard.writeText(cli);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard can be unavailable (insecure context / denied permission);
+      // fail quietly rather than crash the drill-down.
+      setCopied(false);
+    }
+  }, [cli]);
+
+  if (!cli) {
+    return (
+      <div className="text-xs text-zinc-500">
+        No copy-pasteable CLI fix — use the console path below.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-2 text-xs text-zinc-500">
+        <Terminal className="h-3.5 w-3.5" />
+        <span>Fix (CLI)</span>
+        {check.requires_human_review ? (
+          <span
+            className="inline-flex items-center gap-1 rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[11px] font-medium text-amber-300"
+            data-testid="human-review-badge"
+          >
+            <ShieldAlert className="h-3 w-3" />
+            Human review required
+          </span>
+        ) : null}
+      </div>
+      <div className="flex items-start gap-2">
+        <pre className="flex-1 overflow-x-auto rounded-lg border border-zinc-800 bg-zinc-950 px-3 py-2 text-xs text-zinc-200">
+          <code>{cli}</code>
+        </pre>
+        <button
+          type="button"
+          onClick={onCopy}
+          aria-label={
+            check.requires_human_review
+              ? "Copy fix command — requires human review before applying"
+              : "Copy fix command"
+          }
+          title={
+            check.requires_human_review
+              ? "This fix can break production — review before applying"
+              : "Copy to clipboard"
+          }
+          className={`mt-0.5 inline-flex items-center gap-1 rounded-md border px-2 py-1.5 text-xs transition-colors ${
+            check.requires_human_review
+              ? "border-amber-500/40 text-amber-300 hover:bg-amber-500/10"
+              : "border-zinc-700 text-zinc-300 hover:bg-zinc-800"
+          }`}
+        >
+          <Copy className="h-3.5 w-3.5" />
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      {copied && check.requires_human_review ? (
+        <div className="text-[11px] text-amber-400" role="status">
+          Copied — review carefully before running; this change can affect production.
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function CheckCard({ check }: { check: CISBenchmarkCheck }) {
+  const [open, setOpen] = useState(check.status === "fail");
+  const badge = statusBadge(check.status);
+  const docs = check.remediation?.docs;
+
+  return (
+    <div className="rounded-xl border border-zinc-800 bg-zinc-950/60">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className="flex w-full items-start justify-between gap-3 px-4 py-3 text-left"
+      >
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-mono text-xs text-zinc-400">{check.check_id}</span>
+            <span className="text-sm font-medium text-zinc-100">{check.title}</span>
+          </div>
+          <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+            <span className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[11px] font-medium ${badge.className}`}>
+              <badge.Icon className="h-3 w-3" />
+              {badge.label}
+            </span>
+            <span className={`rounded border px-1.5 py-0.5 text-[11px] font-medium capitalize ${severityClass(check.severity)}`}>
+              {check.severity}
+            </span>
+            <span className="rounded border border-zinc-700 bg-zinc-800/40 px-1.5 py-0.5 text-[11px] font-medium text-zinc-300">
+              {priorityLabel(check.priority)}
+            </span>
+            {check.requires_human_review ? (
+              <span className="inline-flex items-center gap-1 rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[11px] font-medium text-amber-300">
+                <ShieldAlert className="h-3 w-3" />
+                Review
+              </span>
+            ) : null}
+            {check.guardrails.map((g) => (
+              <span
+                key={g}
+                className="rounded border border-cyan-500/30 bg-cyan-500/10 px-1.5 py-0.5 text-[11px] font-medium text-cyan-300"
+              >
+                {g}
+              </span>
+            ))}
+          </div>
+        </div>
+        {open ? <ChevronDown className="mt-1 h-4 w-4 shrink-0 text-zinc-500" /> : <ChevronRight className="mt-1 h-4 w-4 shrink-0 text-zinc-500" />}
+      </button>
+      {open ? (
+        <div className="space-y-3 border-t border-zinc-800 px-4 py-3">
+          {check.evidence ? <p className="text-xs text-zinc-400">{check.evidence}</p> : null}
+          <CopyableFixCli check={check} />
+          {check.fix_console ? (
+            <div className="text-xs text-zinc-400">
+              <span className="text-zinc-500">Console path: </span>
+              <span className="text-zinc-200">{check.fix_console}</span>
+            </div>
+          ) : null}
+          {docs ? (
+            <a
+              href={docs}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-sky-400 hover:text-sky-300"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              Remediation docs
+            </a>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function FilterPills<T extends string | number>({
+  label,
+  options,
+  value,
+  onChange,
+  render,
+}: {
+  label: string;
+  options: T[];
+  value: T;
+  onChange: (value: T) => void;
+  render: (value: T) => string;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="text-[11px] uppercase tracking-wider text-zinc-600">{label}</span>
+      {options.map((option) => (
+        <button
+          key={String(option)}
+          type="button"
+          onClick={() => onChange(option)}
+          className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+            value === option ? "bg-zinc-800 text-zinc-100" : "text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300"
+          }`}
+        >
+          {render(option)}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Cloud CIS benchmark drill-down. Fetches tenant-scoped checks from
+ * `GET /v1/cis/checks`, then filters client-side by cloud, status, priority,
+ * and guardrail so every fetched check participates in the guardrails filter.
+ * Each failed check exposes a copy-pasteable `fix_cli` (with a human-review
+ * warning when applicable) or a console path, plus a remediation docs link.
+ */
+export function CISBenchmarkDetail() {
+  const [checks, setChecks] = useState<CISBenchmarkCheck[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [cloud, setCloud] = useState<string>(ALL);
+  const [status, setStatus] = useState<string>("fail");
+  const [priority, setPriority] = useState<number>(-1);
+  const [guardrail, setGuardrail] = useState<string>(ALL);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    // One page covers the full benchmark catalog (well under the 500 cap), so
+    // every guardrails/priority filter sees all checks rather than a slice.
+    api
+      .listCisBenchmarkChecks({ limit: 500 })
+      .then((response) => {
+        if (cancelled) return;
+        setChecks((response.checks ?? []).map(normalizeCheck));
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(userFacingApiErrorMessage(err, "Could not load cloud CIS benchmark checks."));
+        setChecks(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const cloudOptions = useMemo(() => {
+    const present = new Set((checks ?? []).map((c) => c.cloud));
+    return [ALL, ...Object.keys(CLOUD_LABELS).filter((c) => present.has(c))];
+  }, [checks]);
+
+  const guardrailOptions = useMemo(() => {
+    const present = new Set<string>();
+    for (const c of checks ?? []) for (const g of c.guardrails) present.add(g);
+    return [ALL, ...Array.from(present).sort()];
+  }, [checks]);
+
+  const priorityOptions = useMemo(() => {
+    const present = new Set<number>();
+    for (const c of checks ?? []) if (c.priority > 0) present.add(c.priority);
+    return [-1, ...Array.from(present).sort((a, b) => a - b)];
+  }, [checks]);
+
+  const visible = useMemo(() => {
+    return (checks ?? []).filter((c) => {
+      if (cloud !== ALL && c.cloud !== cloud) return false;
+      if (status !== ALL && c.status !== status) return false;
+      if (priority >= 0 && c.priority !== priority) return false;
+      if (guardrail !== ALL && !c.guardrails.includes(guardrail)) return false;
+      return true;
+    });
+  }, [checks, cloud, status, priority, guardrail]);
+
+  if (loading) {
+    return (
+      <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5" aria-busy="true">
+        <SectionHeader />
+        <p className="mt-3 text-sm text-zinc-500">Loading cloud CIS benchmark checks…</p>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+        <SectionHeader />
+        <div className="mt-3 flex items-start gap-2 rounded-xl border border-zinc-800 bg-zinc-950/70 p-4 text-sm text-zinc-400">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+          <span>{error}</span>
+        </div>
+      </section>
+    );
+  }
+
+  const total = checks?.length ?? 0;
+  if (total === 0) {
+    return (
+      <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+        <SectionHeader />
+        <div className="mt-3 rounded-xl border border-zinc-800 bg-zinc-950/70 p-5 text-sm text-zinc-500">
+          No cloud CIS benchmark checks yet. Run a cloud scan (AWS, Azure, GCP, Snowflake, or Databricks)
+          to populate per-check remediation.
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section id="cloud-cis-benchmarks" className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+      <SectionHeader count={total} />
+      <div className="mt-4 flex flex-col gap-3 rounded-xl border border-zinc-800 bg-zinc-950/40 p-3 lg:flex-row lg:flex-wrap lg:items-center lg:gap-5">
+        <FilterPills
+          label="Cloud"
+          options={cloudOptions}
+          value={cloud}
+          onChange={setCloud}
+          render={(value) => (value === ALL ? "All" : cloudLabel(value))}
+        />
+        <FilterPills
+          label="Status"
+          options={STATUS_OPTIONS}
+          value={status}
+          onChange={setStatus}
+          render={(value) => (value === ALL ? "All" : value === "fail" ? "Failing" : "Passing")}
+        />
+        <FilterPills
+          label="Priority"
+          options={priorityOptions}
+          value={priority}
+          onChange={setPriority}
+          render={(value) => (value < 0 ? "All" : `P${value}`)}
+        />
+        <FilterPills
+          label="Guardrail"
+          options={guardrailOptions}
+          value={guardrail}
+          onChange={setGuardrail}
+          render={(value) => (value === ALL ? "All" : value)}
+        />
+      </div>
+
+      <div className="mt-4 space-y-2">
+        {visible.length === 0 ? (
+          <div className="rounded-xl border border-zinc-800 bg-zinc-950/70 p-5 text-sm text-zinc-500">
+            No checks match the current filters ({total} total).
+          </div>
+        ) : (
+          <>
+            <div className="text-xs text-zinc-500">
+              {visible.length} of {total} checks shown
+            </div>
+            {visible.map((check) => (
+              <CheckCard key={`${check.cloud}:${check.check_id}:${check.scan_id}`} check={check} />
+            ))}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function SectionHeader({ count }: { count?: number | undefined }) {
+  return (
+    <div className="flex items-center gap-2">
+      <Cloud className="h-4 w-4 text-cyan-400" />
+      <div>
+        <h2 className="text-lg font-semibold text-zinc-100">Cloud CIS Benchmark Drill-down</h2>
+        <p className="text-xs text-zinc-500">
+          Failed AWS / Azure / GCP / Snowflake / Databricks checks behind CIS Controls v8, with fix guidance.
+          {typeof count === "number" ? ` ${count} checks.` : null}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default CISBenchmarkDetail;

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1530,6 +1530,50 @@ export interface AISVSComplianceResponse {
   benchmark: AISVSBenchmark;
 }
 
+/** Structured remediation attached to a single cloud CIS benchmark check. */
+export interface CISBenchmarkRemediation {
+  priority?: number | undefined;
+  effort?: string | undefined;
+  guardrails?: string[] | undefined;
+  fix_cli?: string | null | undefined;
+  fix_console?: string | undefined;
+  requires_human_review?: boolean | undefined;
+  docs?: string | undefined;
+}
+
+/**
+ * One normalized cloud CIS benchmark check row, as emitted by the backend
+ * `analytics_contract.build_cis_benchmark_check_rows` and served by
+ * `GET /v1/cis/checks`. Top-level `fix_cli` / `fix_console` / `priority` /
+ * `guardrails` / `requires_human_review` are flattened copies of the matching
+ * `remediation` fields for cheap indexing/filtering.
+ */
+export interface CISBenchmarkCheck {
+  scan_id: string;
+  measured_at: string;
+  cloud: string;
+  check_id: string;
+  title: string;
+  status: string;
+  severity: string;
+  cis_section: string;
+  evidence: string;
+  resource_ids: string[];
+  remediation: CISBenchmarkRemediation;
+  fix_cli: string;
+  fix_console: string;
+  effort: string;
+  priority: number;
+  guardrails: string[];
+  requires_human_review: boolean;
+}
+
+export interface CISBenchmarkChecksResponse {
+  checks: CISBenchmarkCheck[];
+  count: number;
+  source: string;
+}
+
 export interface ComplianceResponse {
   overall_score: number;
   overall_status: "pass" | "warning" | "fail";

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -58,6 +58,7 @@ import type {
   ComplianceNarrativeResponse,
   AISVSComplianceResponse,
   ComplianceResponse,
+  CISBenchmarkChecksResponse,
   FrameworkCatalogsResponse,
   AgentDetailResponse,
   AgentLifecycleResponse,
@@ -208,6 +209,9 @@ export type {
   AISVSBenchmark,
   AISVSComplianceResponse,
   ComplianceResponse,
+  CISBenchmarkCheck,
+  CISBenchmarkRemediation,
+  CISBenchmarkChecksResponse,
   FrameworkCatalogMetadata,
   FrameworkCatalogsResponse,
   AgentDetailResponse,
@@ -699,6 +703,28 @@ export const api = {
 
   /** Latest tenant-scoped OWASP AISVS benchmark posture */
   getAISVSCompliance: () => get<AISVSComplianceResponse>("/v1/compliance/aisvs"),
+
+  /**
+   * Tenant-scoped cloud CIS benchmark checks with structured remediation.
+   * Server-side filters (cloud/status/priority) are optional; callers that
+   * also need a guardrails filter fetch a page and filter client-side.
+   */
+  listCisBenchmarkChecks: (filters?: {
+    cloud?: string;
+    status?: string;
+    priority?: number;
+    limit?: number;
+    offset?: number;
+  }) => {
+    const params = new URLSearchParams();
+    if (filters?.cloud) params.set("cloud", filters.cloud);
+    if (filters?.status) params.set("status", filters.status);
+    if (filters?.priority !== undefined) params.set("priority", String(filters.priority));
+    if (filters?.limit !== undefined) params.set("limit", String(filters.limit));
+    if (filters?.offset !== undefined) params.set("offset", String(filters.offset));
+    const qs = params.toString();
+    return get<CISBenchmarkChecksResponse>(`/v1/cis/checks${qs ? `?${qs}` : ""}`);
+  },
 
   /** Active framework catalog metadata surfaced by the API */
   getFrameworkCatalogs: () => get<FrameworkCatalogsResponse>("/v1/frameworks/catalogs"),

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -15,7 +15,8 @@ const BUDGETS = {
   // Includes the parity governance cockpits for cost, identity, and drift.
   // Includes the Gateway Live Feed tab for tool-call auth, DLP, and LLM-call events.
   // Includes cost forecast/chargeback and NHI governance console panels.
-  totalClientJsBytes: 3_020_000,
+  // Includes the cloud CIS benchmark drill-down (per-cloud checks + remediation) on the compliance dashboard.
+  totalClientJsBytes: 3_035_000,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };

--- a/ui/tests/cis-benchmark-detail.test.tsx
+++ b/ui/tests/cis-benchmark-detail.test.tsx
@@ -1,0 +1,162 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CISBenchmarkDetail } from "@/components/cis-benchmark-detail";
+import type { CISBenchmarkCheck } from "@/lib/api";
+
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: {
+    listCisBenchmarkChecks: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: apiMock,
+}));
+
+function makeCheck(overrides: Partial<CISBenchmarkCheck>): CISBenchmarkCheck {
+  return {
+    scan_id: "scan-1",
+    measured_at: "2026-06-24T00:00:00Z",
+    cloud: "aws",
+    check_id: "1.1",
+    title: "Maintain current contact details",
+    status: "fail",
+    severity: "medium",
+    cis_section: "1 - Identity and Access Management",
+    evidence: "Contact info incomplete",
+    resource_ids: [],
+    remediation: {},
+    fix_cli: "",
+    fix_console: "",
+    effort: "manual",
+    priority: 0,
+    guardrails: [],
+    requires_human_review: false,
+    ...overrides,
+  };
+}
+
+const writeText = vi.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+  apiMock.listCisBenchmarkChecks.mockReset();
+  writeText.mockClear();
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("CISBenchmarkDetail", () => {
+  it("shows a loading state before checks resolve", () => {
+    apiMock.listCisBenchmarkChecks.mockReturnValue(new Promise(() => {}));
+    render(<CISBenchmarkDetail />);
+    expect(screen.getByText(/loading cloud cis benchmark checks/i)).toBeInTheDocument();
+  });
+
+  it("renders an empty state when no checks exist", async () => {
+    apiMock.listCisBenchmarkChecks.mockResolvedValue({ checks: [], count: 0, source: "scan_jobs" });
+    render(<CISBenchmarkDetail />);
+    expect(await screen.findByText(/no cloud cis benchmark checks yet/i)).toBeInTheDocument();
+  });
+
+  it("renders an error state with the fallback copy when the fetch fails opaquely", async () => {
+    // An empty-message failure exercises the fallback string in the error UI.
+    apiMock.listCisBenchmarkChecks.mockRejectedValue(new Error(""));
+    render(<CISBenchmarkDetail />);
+    expect(await screen.findByText(/could not load cloud cis benchmark checks/i)).toBeInTheDocument();
+  });
+
+  it("surfaces the underlying error message when one is present", async () => {
+    apiMock.listCisBenchmarkChecks.mockRejectedValue(new Error("backend unavailable"));
+    render(<CISBenchmarkDetail />);
+    expect(await screen.findByText(/backend unavailable/i)).toBeInTheDocument();
+  });
+
+  it("renders failing checks by default with id, title, and badges", async () => {
+    apiMock.listCisBenchmarkChecks.mockResolvedValue({
+      checks: [
+        makeCheck({ check_id: "1.4", title: "Eliminate root access keys", priority: 1, guardrails: ["identity"] }),
+        makeCheck({ check_id: "3.1", title: "Ensure CloudTrail enabled", status: "pass" }),
+      ],
+      count: 2,
+      source: "scan_jobs",
+    });
+    render(<CISBenchmarkDetail />);
+
+    expect(await screen.findByText("Eliminate root access keys")).toBeInTheDocument();
+    expect(screen.getByText("1.4")).toBeInTheDocument();
+    // Default status filter is "fail", so the passing check is hidden.
+    expect(screen.queryByText("Ensure CloudTrail enabled")).not.toBeInTheDocument();
+    expect(screen.getByText(/1 of 2 checks shown/i)).toBeInTheDocument();
+  });
+
+  it("copies fix_cli and warns when the check requires human review", async () => {
+    apiMock.listCisBenchmarkChecks.mockResolvedValue({
+      checks: [
+        makeCheck({
+          check_id: "1.4",
+          title: "Eliminate root access keys",
+          fix_cli: "aws iam delete-access-key --user-name root",
+          requires_human_review: true,
+          remediation: { fix_cli: "aws iam delete-access-key --user-name root", requires_human_review: true },
+        }),
+      ],
+      count: 1,
+      source: "scan_jobs",
+    });
+    render(<CISBenchmarkDetail />);
+
+    await screen.findByText("Eliminate root access keys");
+    // Human-review badge is visible on a check that can break production.
+    expect(screen.getByTestId("human-review-badge")).toBeInTheDocument();
+
+    const copyButton = screen.getByRole("button", { name: /copy fix command/i });
+    fireEvent.click(copyButton);
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("aws iam delete-access-key --user-name root"));
+    expect(await screen.findByText(/review carefully before running/i)).toBeInTheDocument();
+  });
+
+  it("filters across all fetched checks by guardrail", async () => {
+    apiMock.listCisBenchmarkChecks.mockResolvedValue({
+      checks: [
+        makeCheck({ check_id: "1.4", title: "Root keys", guardrails: ["identity"] }),
+        makeCheck({ check_id: "4.1", title: "Logging on", guardrails: ["logging-and-audit"] }),
+      ],
+      count: 2,
+      source: "scan_jobs",
+    });
+    render(<CISBenchmarkDetail />);
+
+    await screen.findByText("Root keys");
+    expect(screen.getByText("Logging on")).toBeInTheDocument();
+
+    // Picking a guardrail narrows to checks carrying it, across every cloud.
+    fireEvent.click(screen.getByRole("button", { name: "logging-and-audit" }));
+    await waitFor(() => expect(screen.queryByText("Root keys")).not.toBeInTheDocument());
+    expect(screen.getByText("Logging on")).toBeInTheDocument();
+  });
+
+  it("shows the cloud selector only for clouds present in the data", async () => {
+    apiMock.listCisBenchmarkChecks.mockResolvedValue({
+      checks: [
+        makeCheck({ cloud: "aws", check_id: "1.1", title: "AWS check" }),
+        makeCheck({ cloud: "gcp", check_id: "2.1", title: "GCP check" }),
+      ],
+      count: 2,
+      source: "scan_jobs",
+    });
+    render(<CISBenchmarkDetail />);
+
+    await screen.findByText("AWS check");
+    const filters = screen.getByText("Cloud").closest("div") as HTMLElement;
+    expect(within(filters).getByRole("button", { name: "AWS" })).toBeInTheDocument();
+    expect(within(filters).getByRole("button", { name: "GCP" })).toBeInTheDocument();
+    expect(within(filters).queryByRole("button", { name: "Azure" })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What shipped

Closes #1514. The dashboard Compliance page previously rendered only the generic CIS Controls v8 catalog — there was no way to drill from a CIS Controls row into the actual failed cloud benchmark checks or their fix guidance. This wires that drill-down.

The backend already exposes the data: `GET /v1/cis/checks` (`list_cis_benchmark_checks`) serves tenant-scoped, normalized per-cloud CIS checks with structured remediation (via `analytics_contract.build_cis_benchmark_check_rows`). This PR is **frontend-only** — no API routes or Pydantic models changed, so no OpenAPI/atlas regeneration is required.

### Changes
- **`ui/components/cis-benchmark-detail.tsx`** — new `CISBenchmarkDetail` component:
  - Fetches checks once (limit 500, well above the full benchmark catalog) so **all** checks participate in client-side filtering.
  - Filters: **cloud** (only clouds present in the data are shown), **status** (fail/pass/all, defaults to failing), **priority** (P1–P4), and **guardrails** (union of guardrails present — works across all checks regardless of cloud).
  - Per check: `check_id`, title, status + severity + priority badges, guardrail chips, evidence, `fix_cli` in a copy-to-clipboard code block, `fix_console` path, and a remediation **docs** link.
  - **Copy-to-clipboard respects `requires_human_review`**: a warning badge is shown and, on copy, a "review carefully before running" notice appears.
  - Loading / empty / error states (error uses the shared `userFacingApiErrorMessage`).
  - Defensive `normalizeCheck` hardens against either backend serialization path (in-memory scan jobs vs. columnar store).
- **`ui/lib/api-types.ts`** — `CISBenchmarkCheck`, `CISBenchmarkRemediation`, `CISBenchmarkChecksResponse` matching the backend row shape.
- **`ui/lib/api.ts`** — `api.listCisBenchmarkChecks({ cloud, status, priority, limit, offset })` → `GET /v1/cis/checks`.
- **`ui/app/compliance/page.tsx`** — renders `<CISBenchmarkDetail />` in the detail view; the CIS Controls v8 framework row links into the `#cloud-cis-benchmarks` drill-down.

### Acceptance criteria
- [x] Component renders every failed check with a visible `fix_cli` or `fix_console` path
- [x] Guardrails filter works across all checks (single fetch, client-side filtering)
- [x] Copy-to-clipboard on `fix_cli` respects `requires_human_review` — warning badge + post-copy notice
- [x] Component test renders the component across states without errors (see below)

## How verified
- Added `ui/tests/cis-benchmark-detail.test.tsx` (vitest + Testing Library) covering: loading, empty, error-fallback, error-message passthrough, default fail-filter, copy + human-review warning, cross-cloud guardrail filtering, and cloud-selector presence.
- Type-reviewed the generic `FilterPills` inference and the import/export conventions in `api.ts`.

> Note: the UI dev dependencies cannot be installed in this sandbox (the network policy blocks the npm registry), so `vitest` / `tsc` / `eslint` were not run locally. The PR CI lanes are the authoritative gate for those; I'm watching them and will push fixes if any lane fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKt5NP1dgv8ts5ftRH7kmb)_