### PR TITLE
feat(ui): cross-domain overview landing page

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 232 |
+| `docs/openapi/v1.json` | paths | 233 |
 | `docs/openapi/v1.json` | component schemas | 61 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -15940,6 +15940,90 @@
         ]
       }
     },
+    "/v1/overview": {
+      "get": {
+        "description": "Cross-domain posture snapshot for the unified landing page.\n\nRead-only. Composes existing stores and summary helpers into one payload\nkeyed by domain so the overview page can render a tile per domain plus a\nshared top-risks strip without fanning out to a dozen endpoints.",
+        "operationId": "get_overview_v1_overview_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Overview V1 Overview Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Overview",
+        "tags": [
+          "overview"
+        ]
+      }
+    },
     "/v1/plugins/status": {
       "get": {
         "description": "Return metadata-only plugin registry status for operator dashboards.",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -10313,6 +10313,60 @@ paths:
       summary: Ingest Ocsf
       tags:
       - observability
+  /v1/overview:
+    get:
+      description: 'Cross-domain posture snapshot for the unified landing page.
+
+
+        Read-only. Composes existing stores and summary helpers into one payload
+
+        keyed by domain so the overview page can render a tile per domain plus a
+
+        shared top-risks strip without fanning out to a dozen endpoints.'
+      operationId: get_overview_v1_overview_get
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Overview V1 Overview Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Overview
+      tags:
+      - overview
   /v1/plugins/status:
     get:
       description: Return metadata-only plugin registry status for operator dashboards.

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -1,0 +1,330 @@
+"""Cross-domain overview aggregation route.
+
+Composes existing per-domain summary logic into a single read-only payload that
+powers the unified overview / command-center landing page. No new scan or
+ingestion logic lives here — every metric is read from a store or summary
+function that another route already exposes:
+
+    * Cloud / CNAPP + Ops + Findings  -> scan-job store (blast radius, sources)
+    * Runtime                          -> deployment-context signals
+    * LLM cost                         -> cost store summary
+    * NHI / identity                   -> agent-identity store + fleet store
+    * Posture                          -> latest scan posture scorecard
+
+Endpoints:
+    GET /v1/overview   cross-domain posture snapshot for the landing page
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+from fastapi import APIRouter, Request
+
+from agent_bom.api.models import JobStatus
+from agent_bom.api.stores import _get_fleet_store, _get_store
+from agent_bom.api.tenancy import require_request_tenant_id
+from agent_bom.rbac import require_authenticated_permission
+
+router = APIRouter(dependencies=[cast(Any, require_authenticated_permission("read"))])
+_logger = logging.getLogger(__name__)
+
+_SEVERITY_KEYS = ("critical", "high", "medium", "low")
+
+
+def _tenant_id(request: Request) -> str:
+    return require_request_tenant_id(request)
+
+
+def _empty_severity() -> dict[str, int]:
+    return {key: 0 for key in _SEVERITY_KEYS}
+
+
+def _scan_rollup(jobs: list[Any]) -> dict[str, Any]:
+    """Aggregate severity counts, sources, scans, and top-risk findings.
+
+    Drives the Cloud/CNAPP, Ops, and top-risks strip from the same scan-job
+    store the dashboard and ``/v1/posture/counts`` already read.
+    """
+    severity = _empty_severity()
+    sources: set[str] = set()
+    scan_count = 0
+    done_count = 0
+    failed_count = 0
+    running_count = 0
+    kev = 0
+    credential_exposed = 0
+    seen_ids: set[str] = set()
+    unique_packages: set[str] = set()
+    top_risks: list[dict[str, Any]] = []
+    latest_scan_at: str | None = None
+
+    for job in jobs:
+        status = getattr(job, "status", None)
+        if status == JobStatus.FAILED:
+            failed_count += 1
+        elif status == JobStatus.RUNNING:
+            running_count += 1
+        if status != JobStatus.DONE or not job.result:
+            continue
+        scan_count += 1
+        done_count += 1
+        result = cast(dict[str, Any], job.result)
+
+        created = getattr(job, "created_at", None)
+        created_str = str(created) if created is not None else None
+        if created_str and (latest_scan_at is None or created_str > latest_scan_at):
+            latest_scan_at = created_str
+
+        for src in result.get("scan_sources", []) or []:
+            if src:
+                sources.add(str(src))
+
+        for agent in result.get("agents", []) or []:
+            for server in agent.get("mcp_servers", []) or []:
+                for pkg in server.get("packages", []) or []:
+                    name = pkg.get("name")
+                    version = pkg.get("version")
+                    if name:
+                        unique_packages.add(f"{name}@{version}")
+
+        for b in result.get("blast_radius", []) or []:
+            vid = b.get("vulnerability_id", "")
+            if vid and vid in seen_ids:
+                continue
+            if vid:
+                seen_ids.add(vid)
+            sev = (b.get("severity") or "").lower()
+            if sev in severity:
+                severity[sev] += 1
+            is_kev = bool(b.get("cisa_kev") or b.get("is_kev"))
+            if is_kev:
+                kev += 1
+            creds = b.get("exposed_credentials") or []
+            if creds:
+                credential_exposed += 1
+            risk = b.get("risk_score")
+            if risk is None:
+                risk = (b.get("blast_score") or 0) / 10
+            top_risks.append(
+                {
+                    "vulnerability_id": vid,
+                    "package": b.get("package"),
+                    "severity": sev or "low",
+                    "risk_score": round(float(risk or 0), 1),
+                    "is_kev": is_kev,
+                    "cvss_score": b.get("cvss_score"),
+                    "epss_score": b.get("epss_score"),
+                    "affected_agents": list(b.get("affected_agents") or []),
+                }
+            )
+
+    top_risks.sort(key=lambda r: r["risk_score"], reverse=True)
+
+    return {
+        "severity": severity,
+        "sources": sorted(sources),
+        "scan_count": scan_count,
+        "done_count": done_count,
+        "failed_count": failed_count,
+        "running_count": running_count,
+        "kev": kev,
+        "credential_exposed": credential_exposed,
+        "unique_cves": len(seen_ids),
+        "unique_packages": len(unique_packages),
+        "top_risks": top_risks[:10],
+        "latest_scan_at": latest_scan_at,
+    }
+
+
+def _posture_snapshot(jobs: list[Any]) -> dict[str, Any]:
+    """Letter grade + score from the latest completed scan (same as /v1/posture)."""
+    for job in jobs:
+        if job.status != JobStatus.DONE or not job.result:
+            continue
+        scorecard = cast(dict[str, Any], job.result).get("posture_scorecard")
+        if scorecard:
+            return {
+                "grade": scorecard.get("grade", "N/A"),
+                "score": scorecard.get("score", 0),
+                "summary": scorecard.get("summary", ""),
+            }
+        break
+    return {"grade": "N/A", "score": 0, "summary": "No completed scans available"}
+
+
+def _runtime_snapshot(request: Request, jobs: list[Any]) -> dict[str, Any]:
+    """Runtime signals (gateway / proxy / traces / mesh) for the Runtime domain.
+
+    Reuses the same deployment-context derivation that powers nav badges so the
+    overview and the rest of the UI agree on what runtime surfaces are live.
+    """
+    try:
+        from agent_bom.api.routes.compliance import _derive_deployment_context
+
+        ctx = _derive_deployment_context(request, jobs)
+    except Exception:  # pragma: no cover - defensive; degrade to empty signals
+        _logger.debug("deployment-context derivation failed", exc_info=True)
+        ctx = {}
+    active = sum(1 for key in ("has_gateway", "has_proxy", "has_traces", "has_mesh") if ctx.get(key))
+    return {
+        "has_gateway": bool(ctx.get("has_gateway")),
+        "has_proxy": bool(ctx.get("has_proxy")),
+        "has_traces": bool(ctx.get("has_traces")),
+        "has_mesh": bool(ctx.get("has_mesh")),
+        "deployment_mode": ctx.get("deployment_mode", "local"),
+        "active_surfaces": active,
+    }
+
+
+def _cost_snapshot(request: Request) -> dict[str, Any]:
+    """LLM spend rollup from the cost store (same source as /v1/observability/costs)."""
+    try:
+        from agent_bom.api.cost_store import get_cost_store, summarize
+
+        store = get_cost_store()
+        records = store.list_records(_tenant_id(request), limit=10000)
+        report = summarize(records)
+        budget = store.get_budget(_tenant_id(request), "")
+        return {
+            "total_cost_usd": report.get("total_cost_usd", 0.0),
+            "total_calls": report.get("total_calls", 0),
+            "agents": len(report.get("by_agent", {}) or {}),
+            "budget_configured": budget is not None,
+        }
+    except Exception:  # pragma: no cover - cost store optional
+        _logger.debug("cost snapshot failed", exc_info=True)
+        return {"total_cost_usd": 0.0, "total_calls": 0, "agents": 0, "budget_configured": False}
+
+
+def _identity_snapshot(request: Request) -> dict[str, Any]:
+    """NHI / fleet counts from the identity + fleet stores."""
+    tenant_id = _tenant_id(request)
+    identities = 0
+    try:
+        from agent_bom.api.agent_identity_store import get_agent_identity_store
+
+        identities = len(get_agent_identity_store().list(tenant_id, limit=1000))
+    except Exception:  # pragma: no cover - identity store optional
+        _logger.debug("identity snapshot failed", exc_info=True)
+
+    fleet_total = 0
+    low_trust = 0
+    try:
+        agents = _get_fleet_store().list_by_tenant(tenant_id)
+        fleet_total = len(agents)
+        low_trust = sum(1 for a in agents if float(getattr(a, "trust_score", 0.0) or 0.0) < 50)
+    except Exception:  # pragma: no cover - fleet store optional
+        _logger.debug("fleet snapshot failed", exc_info=True)
+
+    return {
+        "managed_identities": identities,
+        "fleet_agents": fleet_total,
+        "low_trust_agents": low_trust,
+    }
+
+
+@router.get("/v1/overview", tags=["overview"])
+async def get_overview(request: Request) -> dict[str, Any]:
+    """Cross-domain posture snapshot for the unified landing page.
+
+    Read-only. Composes existing stores and summary helpers into one payload
+    keyed by domain so the overview page can render a tile per domain plus a
+    shared top-risks strip without fanning out to a dozen endpoints.
+    """
+    jobs = _get_store().list_all(tenant_id=_tenant_id(request))
+
+    scan = _scan_rollup(jobs)
+    posture = _posture_snapshot(jobs)
+    runtime = _runtime_snapshot(request, jobs)
+    cost = _cost_snapshot(request)
+    identity = _identity_snapshot(request)
+
+    critical_high = scan["severity"]["critical"] + scan["severity"]["high"]
+
+    domains = {
+        "cloud": {
+            "label": "Cloud / CNAPP",
+            "href": "/findings",
+            "metric": scan["unique_cves"],
+            "metric_label": "open CVEs",
+            "status": _status_for(scan["severity"]["critical"], scan["severity"]["high"]),
+            "detail": {
+                "critical": scan["severity"]["critical"],
+                "high": scan["severity"]["high"],
+                "kev": scan["kev"],
+                "sources": scan["sources"],
+            },
+        },
+        "runtime": {
+            "label": "Runtime",
+            "href": "/gateway",
+            "metric": runtime["active_surfaces"],
+            "metric_label": "active surfaces",
+            "status": "ok" if runtime["active_surfaces"] > 0 else "idle",
+            "detail": runtime,
+        },
+        "cost": {
+            "label": "LLM Cost",
+            "href": "/cost",
+            "metric": round(float(cost["total_cost_usd"]), 2),
+            "metric_label": "USD tracked",
+            "status": "ok" if cost["total_calls"] > 0 else "idle",
+            "detail": cost,
+        },
+        "identity": {
+            "label": "NHI / Identity",
+            "href": "/identity",
+            "metric": identity["managed_identities"] + identity["fleet_agents"],
+            "metric_label": "identities + agents",
+            "status": _identity_status(identity),
+            "detail": identity,
+        },
+        "ops": {
+            "label": "Ops",
+            "href": "/jobs",
+            "metric": scan["scan_count"],
+            "metric_label": "completed scans",
+            "status": "warn" if scan["failed_count"] > 0 else ("ok" if scan["scan_count"] > 0 else "idle"),
+            "detail": {
+                "done": scan["done_count"],
+                "failed": scan["failed_count"],
+                "running": scan["running_count"],
+                "packages": scan["unique_packages"],
+            },
+        },
+    }
+
+    return {
+        "schema_version": "overview.v1",
+        "tenant_id": _tenant_id(request),
+        "posture": posture,
+        "headline": {
+            "critical": scan["severity"]["critical"],
+            "high": scan["severity"]["high"],
+            "critical_high": critical_high,
+            "kev": scan["kev"],
+            "credential_exposed": scan["credential_exposed"],
+            "scans": scan["scan_count"],
+            "latest_scan_at": scan["latest_scan_at"],
+        },
+        "domains": domains,
+        "top_risks": scan["top_risks"],
+    }
+
+
+def _status_for(critical: int, high: int) -> str:
+    if critical > 0:
+        return "critical"
+    if high > 0:
+        return "warn"
+    return "ok"
+
+
+def _identity_status(identity: dict[str, Any]) -> str:
+    if identity["low_trust_agents"] > 0:
+        return "warn"
+    if identity["fleet_agents"] or identity["managed_identities"]:
+        return "ok"
+    return "idle"

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -790,6 +790,7 @@ from agent_bom.api.routes.graph import router as _graph_router  # noqa: E402
 from agent_bom.api.routes.identities import router as _identities_router  # noqa: E402
 from agent_bom.api.routes.intel import router as _intel_router  # noqa: E402
 from agent_bom.api.routes.observability import router as _observability_router  # noqa: E402
+from agent_bom.api.routes.overview import router as _overview_router  # noqa: E402
 from agent_bom.api.routes.plugins import router as _plugins_router  # noqa: E402
 from agent_bom.api.routes.posture_streaming import router as _posture_streaming_router  # noqa: E402
 from agent_bom.api.routes.privacy import router as _privacy_router  # noqa: E402
@@ -820,6 +821,7 @@ app.include_router(_graph_router)
 app.include_router(_identities_router)
 app.include_router(_intel_router)
 app.include_router(_observability_router)
+app.include_router(_overview_router)
 app.include_router(_plugins_router)
 app.include_router(_posture_streaming_router)
 app.include_router(_privacy_router)

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -1,0 +1,144 @@
+"""Tests for the cross-domain /v1/overview aggregation endpoint."""
+
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import JobStatus, _get_store, app
+from agent_bom.api.store import InMemoryJobStore
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+_AUTH_HEADERS = proxy_headers(tenant="default")
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+
+
+def _clear_jobs() -> None:
+    from agent_bom.api.server import set_job_store
+
+    set_job_store(InMemoryJobStore())
+
+
+def _add_done_job(
+    blast_radius: list[dict],
+    job_id: str = "test-job",
+    *,
+    tenant_id: str = "default",
+    result_extra: dict | None = None,
+) -> None:
+    from agent_bom.api.server import ScanJob, ScanRequest
+
+    job = ScanJob(
+        job_id=job_id,
+        tenant_id=tenant_id,
+        created_at="2026-02-22T10:00:00Z",
+        request=ScanRequest(),
+    )
+    job.status = JobStatus.DONE
+    job.completed_at = "2026-02-22T10:05:00Z"
+    job.result = {
+        "agents": [],
+        "blast_radius": blast_radius,
+        "scan_sources": ["agent_discovery"],
+    }
+    if result_extra:
+        job.result.update(result_extra)
+    _get_store().put(job)
+
+
+_EXPECTED_DOMAINS = {"cloud", "runtime", "cost", "identity", "ops"}
+
+
+def test_overview_empty_shape() -> None:
+    """With no scans the endpoint returns the full domain skeleton at zero."""
+    _clear_jobs()
+    client = TestClient(app)
+    resp = client.get("/v1/overview", headers=_AUTH_HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["schema_version"] == "overview.v1"
+    assert data["tenant_id"] == "default"
+    assert set(data["domains"].keys()) == _EXPECTED_DOMAINS
+    assert data["headline"]["critical"] == 0
+    assert data["headline"]["scans"] == 0
+    assert data["top_risks"] == []
+    assert data["posture"]["grade"] == "N/A"
+
+    for domain in data["domains"].values():
+        assert {"label", "href", "metric", "metric_label", "status", "detail"} <= set(domain)
+        assert domain["href"].startswith("/")
+
+
+def test_overview_aggregates_findings() -> None:
+    """A completed scan with findings populates severity, top risks, and ops."""
+    _clear_jobs()
+    _add_done_job(
+        [
+            {
+                "vulnerability_id": "CVE-2025-0001",
+                "package": "demo",
+                "severity": "critical",
+                "risk_score": 9.5,
+                "cisa_kev": True,
+                "exposed_credentials": ["DEMO_TOKEN"],
+            },
+            {
+                "vulnerability_id": "CVE-2025-0002",
+                "package": "demo2",
+                "severity": "high",
+                "blast_score": 70,
+            },
+        ]
+    )
+    client = TestClient(app)
+    resp = client.get("/v1/overview", headers=_AUTH_HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["headline"]["critical"] == 1
+    assert data["headline"]["high"] == 1
+    assert data["headline"]["critical_high"] == 2
+    assert data["headline"]["kev"] == 1
+    assert data["headline"]["credential_exposed"] == 1
+    assert data["headline"]["scans"] == 1
+
+    cloud = data["domains"]["cloud"]
+    assert cloud["metric"] == 2  # two unique CVEs
+    assert cloud["status"] == "critical"
+    assert cloud["detail"]["kev"] == 1
+
+    ops = data["domains"]["ops"]
+    assert ops["metric"] == 1  # one completed scan
+    assert ops["detail"]["done"] == 1
+
+    assert data["top_risks"][0]["vulnerability_id"] == "CVE-2025-0001"
+    assert data["top_risks"][0]["risk_score"] == 9.5
+    assert len(data["top_risks"]) == 2
+
+
+def test_overview_requires_auth() -> None:
+    """Endpoint is read-only but still behind the standard viewer gate."""
+    _clear_jobs()
+    client = TestClient(app)
+    resp = client.get("/v1/overview")
+    assert resp.status_code in (401, 403)
+
+
+def test_overview_is_read_only() -> None:
+    """No mutating verb reaches a handler.
+
+    Only GET is registered, and the viewer role used by the overview page is
+    denied mutating methods by the RBAC middleware (403) before any 405 from
+    the router — either status confirms there is no write path here.
+    """
+    _clear_jobs()
+    client = TestClient(app)
+    assert client.post("/v1/overview", headers=_AUTH_HEADERS).status_code in (403, 405)
+    assert client.delete("/v1/overview", headers=_AUTH_HEADERS).status_code in (403, 405)

--- a/ui/app/overview/page.tsx
+++ b/ui/app/overview/page.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { api, formatDate } from "@/lib/api";
+import type {
+  OverviewResponse,
+  OverviewDomain,
+  OverviewTopRisk,
+} from "@/lib/api-types";
+import { ActivityFeed } from "@/components/activity-feed";
+import { SeverityBadge } from "@/components/severity-badge";
+import { PostureGrade } from "@/components/posture-grade";
+import { ApiOfflineState } from "@/components/api-offline-state";
+import { EmptyState } from "@/components/empty-state";
+import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
+import {
+  Cloud,
+  ShieldCheck,
+  DollarSign,
+  Fingerprint,
+  ArrowRight,
+  ShieldAlert,
+  ExternalLink,
+  Layers,
+} from "lucide-react";
+
+// ─── Domain presentation metadata ─────────────────────────────────────────────
+
+type DomainKey = keyof OverviewResponse["domains"];
+
+const DOMAIN_ICONS: Record<DomainKey, React.ElementType> = {
+  cloud: Cloud,
+  runtime: ShieldCheck,
+  cost: DollarSign,
+  identity: Fingerprint,
+  ops: Layers,
+};
+
+const DOMAIN_ORDER: DomainKey[] = ["cloud", "runtime", "cost", "identity", "ops"];
+
+const STATUS_STYLES: Record<
+  OverviewDomain["status"],
+  { ring: string; text: string; dot: string; label: string }
+> = {
+  critical: { ring: "border-red-500/30", text: "text-red-300", dot: "bg-red-500", label: "Critical" },
+  warn: { ring: "border-amber-500/30", text: "text-amber-300", dot: "bg-amber-500", label: "Attention" },
+  ok: { ring: "border-emerald-500/25", text: "text-emerald-300", dot: "bg-emerald-500", label: "Healthy" },
+  idle: { ring: "border-zinc-700/70", text: "text-zinc-400", dot: "bg-zinc-600", label: "No data" },
+};
+
+function _classifyApiErrorKind(err: unknown): "network" | "auth" | "forbidden" {
+  if (err instanceof ApiAuthError) return "auth";
+  if (err instanceof ApiForbiddenError) return "forbidden";
+  return "network";
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function OverviewPage() {
+  const [data, setData] = useState<OverviewResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [errorKind, setErrorKind] = useState<"network" | "auth" | "forbidden">("network");
+  const [errorDetail, setErrorDetail] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    api
+      .getOverview()
+      .then((res) => {
+        if (cancelled) return;
+        setData(res);
+        setError(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(true);
+        setErrorKind(_classifyApiErrorKind(err));
+        setErrorDetail(err instanceof Error ? err.message : null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error) {
+    return <ApiOfflineState kind={errorKind} detail={errorDetail} />;
+  }
+
+  if (loading || !data) {
+    return <OverviewSkeleton />;
+  }
+
+  const { headline, posture, domains, top_risks } = data;
+  const hasAnySignal = headline.scans > 0 || DOMAIN_ORDER.some((k) => domains[k].metric > 0);
+
+  return (
+    <div className="space-y-8">
+      {/* Hero */}
+      <section className="relative overflow-hidden rounded-[28px] border border-zinc-800/80 bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.16),transparent_24%),radial-gradient(circle_at_top_right,rgba(239,68,68,0.12),transparent_24%),linear-gradient(180deg,rgba(24,24,27,0.98),rgba(9,9,11,0.96))] p-6 shadow-2xl shadow-black/20">
+        <div className="flex flex-col gap-6 xl:flex-row xl:items-start xl:justify-between">
+          <div className="min-w-0 max-w-3xl">
+            <p className="text-[11px] uppercase tracking-[0.24em] text-emerald-400">Command center</p>
+            <h1 className="mt-3 text-3xl font-semibold tracking-tight text-zinc-50 sm:text-4xl">
+              Posture overview
+            </h1>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-zinc-300">
+              One view across cloud, runtime, LLM cost, identity, and operations. Each tile links
+              into its detail surface. {headline.latest_scan_at ? `Last scan ${formatDate(headline.latest_scan_at)}.` : "No scans recorded yet."}
+            </p>
+            <div className="mt-5 flex flex-wrap gap-2">
+              <HeadlineChip tone="red" label="Critical" value={headline.critical} />
+              <HeadlineChip tone="amber" label="High" value={headline.high} />
+              <HeadlineChip tone="red" label="Actively exploited" value={headline.kev} />
+              <HeadlineChip tone="amber" label="Credential exposed" value={headline.credential_exposed} />
+              <HeadlineChip tone="sky" label="Scans" value={headline.scans} />
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2 xl:justify-end">
+            <Link
+              href="/scan"
+              className="flex items-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+            >
+              Run scan
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+            <Link
+              href="/findings?severity=critical"
+              className="flex items-center gap-2 rounded-xl border border-zinc-700 bg-zinc-900/80 px-4 py-2.5 text-sm font-medium text-zinc-200 transition-colors hover:border-zinc-500 hover:bg-zinc-800"
+            >
+              Fix queue
+              <ShieldAlert className="h-4 w-4" />
+            </Link>
+          </div>
+        </div>
+
+        {posture.grade !== "N/A" && (
+          <div className="mt-6">
+            <PostureGrade
+              grade={posture.grade}
+              score={posture.score}
+              dimensions={{}}
+              summary={posture.summary}
+              variant="panel"
+              defaultExpanded={false}
+            />
+          </div>
+        )}
+      </section>
+
+      {/* Domain tiles */}
+      <section>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-semibold uppercase tracking-widest text-zinc-400">Domains</h2>
+          <span className="text-[10px] text-zinc-600">{DOMAIN_ORDER.length} surfaces</span>
+        </div>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {DOMAIN_ORDER.map((key) => (
+            <DomainCard key={key} domainKey={key} domain={domains[key]} />
+          ))}
+        </div>
+      </section>
+
+      {/* Top risks + activity */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <section className="min-w-0 lg:col-span-2">
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-sm font-semibold uppercase tracking-widest text-zinc-400">
+              Top risks
+            </h2>
+            <Link href="/findings" className="flex items-center gap-1 text-xs text-emerald-500 hover:text-emerald-400">
+              View all <ArrowRight className="h-3 w-3" />
+            </Link>
+          </div>
+          {top_risks.length === 0 ? (
+            <EmptyState
+              icon={ShieldCheck}
+              title={hasAnySignal ? "No scored risks" : "No findings yet"}
+              description={
+                hasAnySignal
+                  ? "No blast-radius findings have a risk score above zero in the current scan set."
+                  : "Run a scan to populate cross-domain risk."
+              }
+              {...(hasAnySignal ? {} : { action: { label: "Run a scan", href: "/scan" } })}
+            />
+          ) : (
+            <div className="space-y-2">
+              {top_risks.map((risk, i) => (
+                <TopRiskRow key={`${risk.vulnerability_id}:${risk.package ?? "?"}:${i}`} risk={risk} />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="min-w-0">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-widest text-zinc-400">Activity</h2>
+          <ActivityFeed maxItems={15} refresh={false} />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+// ─── Components ────────────────────────────────────────────────────────────────
+
+function HeadlineChip({ tone, label, value }: { tone: "red" | "amber" | "sky"; label: string; value: number }) {
+  const tones = {
+    red: "border-red-500/20 bg-red-500/10 text-red-200/70",
+    amber: "border-amber-500/20 bg-amber-500/10 text-amber-200/70",
+    sky: "border-sky-500/20 bg-sky-500/10 text-sky-200/70",
+  };
+  const valueTone = {
+    red: "text-red-100",
+    amber: "text-amber-100",
+    sky: "text-sky-100",
+  };
+  return (
+    <div className={`rounded-2xl border px-3 py-2 ${tones[tone]}`}>
+      <div className="text-[10px] uppercase tracking-[0.18em]">{label}</div>
+      <div className={`mt-1 font-mono text-lg font-semibold ${valueTone[tone]}`}>{value}</div>
+    </div>
+  );
+}
+
+function DomainCard({ domainKey, domain }: { domainKey: DomainKey; domain: OverviewDomain }) {
+  const Icon = DOMAIN_ICONS[domainKey];
+  const s = STATUS_STYLES[domain.status];
+  return (
+    <Link
+      href={domain.href}
+      className={`group flex min-w-0 flex-col rounded-2xl border bg-zinc-950/70 p-4 transition-colors hover:border-zinc-600 ${s.ring}`}
+    >
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-zinc-800 bg-zinc-900 text-zinc-300">
+            <Icon className="h-4 w-4" />
+          </span>
+          <span className="truncate text-sm font-semibold text-zinc-200">{domain.label}</span>
+        </div>
+        <span className={`flex shrink-0 items-center gap-1.5 text-[10px] font-medium uppercase tracking-wide ${s.text}`}>
+          <span className={`h-1.5 w-1.5 rounded-full ${s.dot}`} />
+          {s.label}
+        </span>
+      </div>
+      <div className="mt-4 flex items-end justify-between gap-2">
+        <div className="min-w-0">
+          <div className="font-mono text-2xl font-bold tracking-tight text-zinc-100">{domain.metric}</div>
+          <div className="mt-0.5 truncate text-xs text-zinc-500">{domain.metric_label}</div>
+        </div>
+        <ArrowRight className="h-4 w-4 shrink-0 text-zinc-600 transition-colors group-hover:text-zinc-300" />
+      </div>
+    </Link>
+  );
+}
+
+function TopRiskRow({ risk }: { risk: OverviewTopRisk }) {
+  return (
+    <Link
+      href={`/findings?cve=${encodeURIComponent(risk.vulnerability_id)}`}
+      className="flex min-w-0 items-start gap-4 rounded-xl border border-zinc-800 bg-zinc-900 p-4 transition-colors hover:border-zinc-700"
+    >
+      <SeverityBadge severity={risk.severity} />
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-mono text-sm font-semibold text-zinc-100 group-hover:text-emerald-400">
+            {risk.vulnerability_id}
+          </span>
+          {risk.package && <span className="truncate font-mono text-xs text-zinc-500">{risk.package}</span>}
+          {risk.is_kev && <span className="text-xs font-semibold text-red-400">CISA KEV</span>}
+        </div>
+        <div className="mt-1.5 flex flex-wrap gap-3 text-xs text-zinc-500">
+          {risk.cvss_score != null && <span>CVSS {risk.cvss_score.toFixed(1)}</span>}
+          {risk.epss_score != null && <span>EPSS {(risk.epss_score * 100).toFixed(0)}%</span>}
+          {risk.affected_agents.length > 0 && (
+            <span>
+              {risk.affected_agents.length} agent{risk.affected_agents.length !== 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="flex shrink-0 flex-col items-end gap-1">
+        {risk.risk_score > 0 && (
+          <div className="text-right">
+            <div className="font-mono text-lg font-bold text-red-400">{risk.risk_score.toFixed(0)}</div>
+            <div className="text-[10px] text-zinc-600">score</div>
+          </div>
+        )}
+        <a
+          href={`https://osv.dev/vulnerability/${risk.vulnerability_id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className="inline-flex items-center gap-1 text-[11px] text-zinc-500 transition-colors hover:text-zinc-300"
+        >
+          OSV <ExternalLink className="h-3 w-3" />
+        </a>
+      </div>
+    </Link>
+  );
+}
+
+function OverviewSkeleton() {
+  return (
+    <div className="space-y-8" aria-busy="true">
+      <div className="h-48 animate-pulse rounded-[28px] border border-zinc-800/80 bg-zinc-900/40" />
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="h-32 animate-pulse rounded-2xl border border-zinc-800/80 bg-zinc-900/40" />
+        ))}
+      </div>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="h-64 animate-pulse rounded-xl border border-zinc-800/80 bg-zinc-900/40 lg:col-span-2" />
+        <div className="h-64 animate-pulse rounded-xl border border-zinc-800/80 bg-zinc-900/40" />
+      </div>
+    </div>
+  );
+}

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -35,6 +35,7 @@ import {
   DollarSign,
   Fingerprint,
   Radar,
+  Compass,
 } from "lucide-react";
 import { api } from "@/lib/api";
 import { useAuthState } from "@/components/auth-provider";
@@ -79,6 +80,7 @@ const NAV_GROUPS: NavGroup[] = [
     icon: LayoutDashboard,
     accent: "#58a6ff", // blue — discovery layer
     links: [
+      { href: "/overview", label: "Overview", icon: Compass },
       { href: "/", label: "Dashboard", icon: LayoutDashboard },
       { href: "/agents", label: "Agents", icon: Server },
       { href: "/manifest", label: "Agent BOM", icon: Waypoints },

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1875,6 +1875,53 @@ export interface PostureResponse {
   dimensions: Record<string, { score: number; label: string; details?: string }>;
 }
 
+// ─── Cross-domain overview (landing page) ────────────────────────────────────
+
+export type OverviewDomainStatus = "ok" | "warn" | "critical" | "idle";
+
+export interface OverviewDomain {
+  label: string;
+  href: string;
+  metric: number;
+  metric_label: string;
+  status: OverviewDomainStatus;
+  detail: Record<string, unknown>;
+}
+
+export interface OverviewTopRisk {
+  vulnerability_id: string;
+  package: string | null;
+  severity: string;
+  risk_score: number;
+  is_kev: boolean;
+  cvss_score: number | null;
+  epss_score: number | null;
+  affected_agents: string[];
+}
+
+export interface OverviewResponse {
+  schema_version: string;
+  tenant_id: string;
+  posture: { grade: string; score: number; summary: string };
+  headline: {
+    critical: number;
+    high: number;
+    critical_high: number;
+    kev: number;
+    credential_exposed: number;
+    scans: number;
+    latest_scan_at: string | null;
+  };
+  domains: {
+    cloud: OverviewDomain;
+    runtime: OverviewDomain;
+    cost: OverviewDomain;
+    identity: OverviewDomain;
+    ops: OverviewDomain;
+  };
+  top_risks: OverviewTopRisk[];
+}
+
 export interface EnrichmentSourcePosture {
   source: string;
   status: "ok" | "stale" | "degraded" | "unknown" | string;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -23,6 +23,7 @@ import type {
   GraphExportFormat,
   AgentBomManifestResponse,
   PostureCountsResponse,
+  OverviewResponse,
   RemediationItem,
   FindingTriageRequest,
   FindingTriageDecisionRequest,
@@ -134,6 +135,9 @@ export type {
   AgentBomManifestEdge,
   DeploymentMode,
   PostureCountsResponse,
+  OverviewResponse,
+  OverviewDomain,
+  OverviewTopRisk,
   RemediationItem,
   FindingTriageQueueState,
   FindingTriageDecision,
@@ -687,6 +691,9 @@ export const api = {
 
   /** Full posture grade + dimensions */
   getPosture: () => get<PostureResponse>("/v1/posture"),
+
+  /** Cross-domain posture snapshot for the unified overview landing page */
+  getOverview: () => get<OverviewResponse>("/v1/overview"),
 
   /** Runtime health for external vulnerability enrichment sources */
   getEnrichmentPosture: () => get<EnrichmentPostureResponse>("/v1/posture/enrichment"),

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -16,7 +16,8 @@ const BUDGETS = {
   // Includes the Gateway Live Feed tab for tool-call auth, DLP, and LLM-call events.
   // Includes cost forecast/chargeback and NHI governance console panels.
   // Includes the cloud CIS benchmark drill-down (per-cloud checks + remediation) on the compliance dashboard.
-  totalClientJsBytes: 3_035_000,
+  // Includes the cross-domain overview landing page entrypoint and API client contract.
+  totalClientJsBytes: 3_045_000,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };


### PR DESCRIPTION
## Summary

A unified command-center **Overview** that aggregates posture across the five domains the product already covers, each tile linking into its existing detail page, plus a top-risks strip and recent-activity feed.

- **Cloud / CNAPP** → `/findings` (open CVEs, critical/high, KEV, sources)
- **Runtime** → `/gateway` (gateway / proxy / traces / mesh active surfaces)
- **LLM Cost** → `/cost` (USD tracked, calls, budget)
- **NHI / Identity** → `/identity` (managed identities + fleet agents, low-trust)
- **Ops** → `/jobs` (completed / failed / running scans, packages)

## Approach — aggregate existing data, no new pipelines

A thin read-only `GET /v1/overview` composes existing stores and summary helpers into one cross-domain payload (scan-job store, posture scorecard, deployment-context signals, cost store, identity + fleet stores). No new scan or ingestion logic. Each external-credential domain (cost / identity) degrades to empty rather than failing the whole response, so the endpoint always returns 200 with the full domain skeleton. Single endpoint keeps the page to one fetch instead of fanning out to a dozen.

## Changes

- `src/agent_bom/api/routes/overview.py` — new `/v1/overview` route (read-only, viewer-gated)
- `src/agent_bom/api/server.py` — register router
- `ui/app/overview/page.tsx` — dashboard: status-colored card per domain, top-risks list, activity feed; loading / empty / error states; `min-w-0` on flex/grid children
- `ui/components/nav.tsx` — Overview entry in the Discover group
- `ui/lib/api.ts`, `ui/lib/api-types.ts` — `getOverview()` + types
- `docs/openapi/v1.json`, `v1.yaml`, `docs/DATA_MODEL.md` — regenerated committed contract
- `tests/test_overview.py` — payload shape, finding aggregation, auth gate, read-only verbs

## Verification

- Backend: `tests/test_overview.py` (4) + `test_openapi_artifact.py` green; `ruff check` + `mypy` clean on changed Python; routes-keyword subset green (only pre-existing `mcp` optional-dep failures excluded)
- Frontend: `npm run lint`, `typecheck`, `build` all green; `/overview` statically prerendered. No `ui/package.json` version bump.

Read-only; no new mutations.