### PR TITLE
feat(cloud): enumerate AWS IAM inline policies (not just attached managed)

### DIFF
--- a/src/agent_bom/cloud/aws_inventory.py
+++ b/src/agent_bom/cloud/aws_inventory.py
@@ -79,6 +79,10 @@ _AWS_IAM_PERMISSIONS: tuple[str, ...] = (
     "iam:ListUsers",
     "iam:ListAttachedRolePolicies",
     "iam:ListAttachedUserPolicies",
+    "iam:ListRolePolicies",
+    "iam:ListUserPolicies",
+    "iam:GetRolePolicy",
+    "iam:GetUserPolicy",
     "iam:GetPolicy",
     "iam:GetPolicyVersion",
 )
@@ -573,6 +577,7 @@ def _normalize_role(iam: Any, role: dict[str, Any], *, account_id: str | None, w
     role_name = str(role.get("RoleName", "") or "")
     role_arn = str(role.get("Arn", "") or "")
     policies = _attached_policies(iam, "role", role_name, warnings=warnings)
+    policies += _inline_policies(iam, "role", role_name, warnings=warnings)
     trust_principals = _extract_trust_principals(
         role.get("AssumeRolePolicyDocument"),
         account_id=account_id or _account_id_from_arn(role_arn),
@@ -594,6 +599,7 @@ def _normalize_user(iam: Any, user: dict[str, Any], *, account_id: str | None, w
     user_name = str(user.get("UserName", "") or "")
     user_arn = str(user.get("Arn", "") or "")
     policies = _attached_policies(iam, "user", user_name, warnings=warnings)
+    policies += _inline_policies(iam, "user", user_name, warnings=warnings)
     return {
         "principal_type": "user",
         "name": user_name,
@@ -632,6 +638,47 @@ def _attached_policies(iam: Any, principal_kind: str, principal_name: str, *, wa
                 )
     except Exception as exc:  # noqa: BLE001
         warnings.append(f"IAM policy enumeration skipped for {principal_kind} {principal_name}: {sanitize_discovery_warning(exc)}")
+    return policies
+
+
+def _inline_policies(iam: Any, principal_kind: str, principal_name: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+    """Return inline policies with a classified privilege level (read-only).
+
+    Inline policies attach directly to a single principal and never appear in
+    ``list_attached_*`` — yet they can silently grant admin, so a posture scan
+    must read them. Lists the inline names, fetches each document, and classifies
+    by Allow actions. Degrades to a warning on error; never blocks enumeration.
+    """
+    if not principal_name:
+        return []
+    list_op = "list_role_policies" if principal_kind == "role" else "list_user_policies"
+    kwarg = "RoleName" if principal_kind == "role" else "UserName"
+    policies: list[dict[str, Any]] = []
+    try:
+        get_doc = iam.get_role_policy if principal_kind == "role" else iam.get_user_policy
+        paginator = iam.get_paginator(list_op)
+        for page in paginator.paginate(**{kwarg: principal_name}):
+            for name in page.get("PolicyNames", []):
+                if not name:
+                    continue
+                privilege = "unknown"
+                try:
+                    document = get_doc(**{kwarg: principal_name, "PolicyName": name}).get("PolicyDocument")
+                    privilege = _classify_policy_actions(_policy_actions_from_document(document))
+                except Exception as exc:  # noqa: BLE001
+                    short = sanitize_discovery_warning(exc)
+                    warnings.append(f"IAM inline policy doc skipped for {principal_kind} {principal_name}/{name}: {short}")
+                policies.append(
+                    {
+                        "policy_id": f"{principal_name}/{name}",
+                        "policy_name": str(name),
+                        "attachment_type": "inline",
+                        "privilege_level": privilege,
+                        "source_field": f"List{principal_kind.capitalize()}Policies.PolicyNames",
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"IAM inline policy enumeration skipped for {principal_kind} {principal_name}: {sanitize_discovery_warning(exc)}")
     return policies
 
 

--- a/tests/test_cloud_aws_inventory.py
+++ b/tests/test_cloud_aws_inventory.py
@@ -411,3 +411,50 @@ def test_graph_inventory_ignores_missing_section() -> None:
 
     graph = build_unified_graph_from_report({"agents": []})
     assert not any(nid.startswith("cloud_resource:aws:") for nid in graph.nodes)
+
+
+# ---------------------------------------------------------------------------
+# Inline IAM policy enumeration (inline policies never appear in list_attached_*)
+# ---------------------------------------------------------------------------
+
+
+class _InlinePaginator:
+    def __init__(self, names: list[str]) -> None:
+        self._names = names
+
+    def paginate(self, **_kwargs: Any) -> list[dict[str, Any]]:
+        return [{"PolicyNames": self._names}]
+
+
+class _FakeIAMInline:
+    """Minimal IAM whose role carries a single admin INLINE policy."""
+
+    def get_paginator(self, op: str) -> Any:
+        return _InlinePaginator(["AdminInline"] if op == "list_role_policies" else [])
+
+    def get_role_policy(self, RoleName: str, PolicyName: str) -> dict[str, Any]:  # noqa: N803
+        return {
+            "RoleName": RoleName,
+            "PolicyName": PolicyName,
+            "PolicyDocument": {"Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*"}]},
+        }
+
+
+def test_inline_policies_enumerated_and_classified() -> None:
+    pols = aws_inventory._inline_policies(_FakeIAMInline(), "role", "app-role", warnings=[])
+    assert len(pols) == 1
+    p = pols[0]
+    assert p["attachment_type"] == "inline"
+    assert p["policy_name"] == "AdminInline"
+    assert p["privilege_level"] == "admin"  # Action "*" → admin, even though inline
+
+
+def test_inline_policies_missing_method_degrades_to_warning() -> None:
+    class _NoInline:
+        def get_paginator(self, op: str) -> Any:
+            raise RuntimeError("no inline support")
+
+    warns: list[str] = []
+    pols = aws_inventory._inline_policies(_NoInline(), "role", "app-role", warnings=warns)
+    assert pols == []
+    assert warns and "inline policy" in warns[0].lower()


### PR DESCRIPTION
## Why
The AWS IAM inventory only enumerated *attached managed* policies via `list_attached_*`. **Inline** policies attach directly to one principal, never surface in those calls, and can silently grant admin — a real CIEM blind spot. Found while live-exercising AWS this session.

## What
- New `_inline_policies()` — `list_role_policies`/`list_user_policies` + `get_role_policy`/`get_user_policy`, classified by Allow actions (reusing the existing action classifier), merged into each principal's policy set so `privilege_level` and the `HAS_PERMISSION` graph edges reflect inline grants too.
- Read-only and fail-safe: missing or denied inline access degrades to a warning, never blocks enumeration.
- Declares the four new read actions (`iam:ListRolePolicies`/`ListUserPolicies`/`GetRolePolicy`/`GetUserPolicy`) in the IAM permission catalog so the discovery envelope stays honest. All covered by the `SecurityAudit` managed policy.

## Validation
Live: the read path runs against real roles (returns inline=[] for service roles, no errors). Unit tests: an admin inline policy is detected and classified `admin`; a client without inline support degrades to a warning. AWS inventory suite green (26 tests).