### PR TITLE
feat(cloud): native GCP service-account impersonation (keyless read-only connection)

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -133,6 +133,8 @@ AGENT_BOM_GATEWAY_POLICY_RELOAD_SECONDS
 AGENT_BOM_GATEWAY_RATE_LIMIT_PER_TENANT_PER_MINUTE
 AGENT_BOM_GATEWAY_REPLICAS
 AGENT_BOM_GATEWAY_REQUIRE_SHARED_RATE_LIMIT
+# Read-only GCP service account to impersonate (keyless, least-privilege) when set; the connector runs every call as this SA.
+AGENT_BOM_GCP_IMPERSONATE_SA
 # Opt-in (default OFF) gate for the estate-wide read-only GCP asset inventory scanner (token/ADC auth only).
 AGENT_BOM_GCP_INVENTORY
 AGENT_BOM_GRAPH_DB

--- a/src/agent_bom/cloud/gcp_inventory.py
+++ b/src/agent_bom/cloud/gcp_inventory.py
@@ -102,6 +102,43 @@ def _derive_default_project() -> tuple[str, str]:
     return str(project), ""
 
 
+_IMPERSONATE_ENV = "AGENT_BOM_GCP_IMPERSONATE_SA"
+_IMPERSONATE_SCOPES = ("https://www.googleapis.com/auth/cloud-platform",)
+
+
+def _resolve_impersonation(credentials: Any, warnings: list[str]) -> Any:
+    """Return credentials impersonating the read-only SA named by the env var.
+
+    When ``AGENT_BOM_GCP_IMPERSONATE_SA`` is set and no explicit credential was
+    passed, wrap the ambient ADC in short-lived impersonated credentials for that
+    service account, so every discovery call runs as a least-privilege read-only
+    identity without a service-account key (the recommended path where keys are
+    org-disabled). Read-only and fail-safe: any error falls back to the original
+    credentials with a warning, never raises.
+    """
+    if credentials is not None:
+        return credentials
+    target = os.environ.get(_IMPERSONATE_ENV, "").strip()
+    if not target:
+        return credentials
+    try:
+        from google import auth as google_auth
+        from google.auth import impersonated_credentials
+    except ImportError:
+        warnings.append("google-auth not installed; cannot impersonate the GCP service account.")
+        return credentials
+    try:
+        source, _ = google_auth.default()
+        return impersonated_credentials.Credentials(
+            source_credentials=source,
+            target_principal=target,
+            target_scopes=list(_IMPERSONATE_SCOPES),
+        )
+    except Exception as exc:  # noqa: BLE001 — impersonation failure degrades, never crashes
+        warnings.append(f"GCP service-account impersonation of {target} failed: {sanitize_discovery_warning(exc)}")
+        return credentials
+
+
 def discover_inventory(
     project_id: str | None = None,
     *,
@@ -174,6 +211,11 @@ def discover_inventory(
     warnings: list[str] = []
     if derive_note:
         warnings.append(derive_note)
+    # Keyless least-privilege connection: when AGENT_BOM_GCP_IMPERSONATE_SA names
+    # a read-only service account, impersonate it (from the ambient ADC) so every
+    # discovery runs AS that SA — the recommended path where SA keys are
+    # org-disabled, matching AWS's read-only profile and Snowflake's role.
+    credentials = _resolve_impersonation(credentials, warnings)
     buckets: list[dict[str, Any]] = []
     instances: list[dict[str, Any]] = []
     firewalls: list[dict[str, Any]] = []

--- a/tests/test_gcp_impersonation.py
+++ b/tests/test_gcp_impersonation.py
@@ -1,0 +1,66 @@
+"""GCP service-account impersonation (keyless least-privilege connection).
+
+When AGENT_BOM_GCP_IMPERSONATE_SA is set and no explicit credential is passed,
+the connector wraps ambient ADC in impersonated credentials for that SA, so
+every discovery runs as a read-only role — the recommended path where SA keys
+are org-disabled. Stubs google.auth + impersonated_credentials (no network).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from agent_bom.cloud import gcp_inventory
+
+
+@pytest.fixture
+def _stub_google_auth(monkeypatch):
+    auth_mod = types.ModuleType("google.auth")
+    imp_mod = types.ModuleType("google.auth.impersonated_credentials")
+
+    class _Impersonated:
+        def __init__(self, *, source_credentials: Any, target_principal: str, target_scopes: list[str]) -> None:
+            self.target_principal = target_principal
+            self.target_scopes = target_scopes
+
+    imp_mod.Credentials = _Impersonated  # type: ignore[attr-defined]
+    auth_mod.default = lambda *a, **k: (object(), "proj")  # type: ignore[attr-defined]
+
+    google_mod = sys.modules.get("google") or types.ModuleType("google")
+    monkeypatch.setitem(sys.modules, "google", google_mod)
+    monkeypatch.setattr(google_mod, "auth", auth_mod, raising=False)
+    monkeypatch.setitem(sys.modules, "google.auth", auth_mod)
+    monkeypatch.setitem(sys.modules, "google.auth.impersonated_credentials", imp_mod)
+    return _Impersonated
+
+
+def test_impersonates_when_env_set(monkeypatch, _stub_google_auth):
+    monkeypatch.setenv("AGENT_BOM_GCP_IMPERSONATE_SA", "abom-scanner@proj.iam.gserviceaccount.com")
+    warns: list[str] = []
+    creds = gcp_inventory._resolve_impersonation(None, warns)
+    assert isinstance(creds, _stub_google_auth)
+    assert creds.target_principal == "abom-scanner@proj.iam.gserviceaccount.com"
+    assert warns == []
+
+
+def test_no_impersonation_when_env_unset(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_GCP_IMPERSONATE_SA", raising=False)
+    assert gcp_inventory._resolve_impersonation(None, []) is None
+
+
+def test_explicit_credentials_take_precedence(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_GCP_IMPERSONATE_SA", "x@proj.iam.gserviceaccount.com")
+    sentinel = object()
+    assert gcp_inventory._resolve_impersonation(sentinel, []) is sentinel
+
+
+def test_impersonation_failure_degrades_to_warning(monkeypatch, _stub_google_auth):
+    monkeypatch.setenv("AGENT_BOM_GCP_IMPERSONATE_SA", "abom-scanner@proj.iam.gserviceaccount.com")
+    sys.modules["google.auth"].default = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("ADC boom"))  # type: ignore
+    warns: list[str] = []
+    assert gcp_inventory._resolve_impersonation(None, warns) is None
+    assert warns and "impersonation" in warns[0].lower()


### PR DESCRIPTION
## Why
GCP orgs increasingly disable service-account **key** creation (Google's default for new orgs), so the AWS-key / Snowflake-key-pair pattern doesn't apply. The recommended keyless path is to **impersonate a read-only SA** from ambient ADC — but agent-bom required hand-wrapping the credential. This makes it first-class.

## What
`AGENT_BOM_GCP_IMPERSONATE_SA=<sa-email>` → the connector wraps ambient ADC (`gcloud auth application-default login`, attached SA, or WIF) in short-lived impersonated credentials for that SA, so **every discovery runs as a least-privilege read-only identity with no key**. Mirrors AWS's read-only profile and Snowflake's `ABOM_READONLY` role — agent-bom always connects through a scoped role, never the operator's identity.

- Default-off (unset = ambient ADC, unchanged). Explicit `credentials=` still takes precedence.
- Fail-safe: missing google-auth, ADC errors, or impersonation denial degrade to a warning and fall back — never raises.
- Pairs with the `connect-gcp` Terraform module (#3113), which provisions the read-only SA + the Token-Creator/WIF binding.

## Tests
New `tests/test_gcp_impersonation.py` (impersonates when set / no-op when unset / explicit creds win / failure degrades). ruff/mypy clean.