### PR TITLE
feat(gcp): instance internet-exposure and IAM privilege classification

### DIFF
--- a/src/agent_bom/cloud/gcp_inventory.py
+++ b/src/agent_bom/cloud/gcp_inventory.py
@@ -62,7 +62,10 @@ _GCP_COMPUTE_PERMISSIONS: tuple[str, ...] = (
     "compute.instances.list",
     "compute.firewalls.list",
 )
-_GCP_IAM_PERMISSIONS: tuple[str, ...] = ("iam.serviceAccounts.list",)
+_GCP_IAM_PERMISSIONS: tuple[str, ...] = (
+    "iam.serviceAccounts.list",
+    "resourcemanager.projects.getIamPolicy",
+)
 
 # Open-to-the-world source ranges that mark a firewall rule as internet-facing.
 # The CNAPP overlay keys off this `network_exposure` shape.
@@ -70,6 +73,54 @@ _INTERNET_RANGES = {"0.0.0.0/0", "::/0"}
 
 # Members that mark a bucket IAM policy as publicly accessible.
 _PUBLIC_MEMBERS = {"allusers", "allauthenticatedusers"}
+
+# Privilege ranking shared with the AWS path so cross-provider CIEM reasoning
+# (OVERPERMISSIONED_TO_SENSITIVE, effective-permissions) treats levels uniformly.
+_PRIVILEGE_RANK = {"admin": 3, "write": 2, "read": 1, "unknown": 0}
+
+# Canonical predefined GCP roles → privilege level (no extra API call needed).
+_GCP_ROLE_PRIVILEGE: dict[str, str] = {
+    "roles/owner": "admin",
+    "roles/editor": "write",
+    "roles/viewer": "read",
+    "roles/browser": "read",
+}
+
+
+def _classify_role_privilege(role: str) -> str:
+    """Classify a single GCP IAM role into admin / write / read / unknown.
+
+    Mirrors the AWS managed-policy classifier: the basic Owner/Editor/Viewer
+    roles map directly; any ``*Admin`` role is admin; any ``*Viewer`` / ``*Reader``
+    role is read. Everything else stays ``unknown`` — never an inflated guess.
+    """
+    name = str(role or "").strip()
+    if not name:
+        return "unknown"
+    lowered = name.lower()
+    if lowered in _GCP_ROLE_PRIVILEGE:
+        return _GCP_ROLE_PRIVILEGE[lowered]
+    # Strip the leaf after the last dot/slash for the "*Admin"/"*Viewer" suffix test.
+    leaf = lowered.rsplit("/", 1)[-1].rsplit(".", 1)[-1]
+    if leaf.endswith("admin") or "admin" in leaf:
+        return "admin"
+    if "owner" in leaf:
+        return "admin"
+    if "editor" in leaf or leaf.endswith("writer") or leaf.endswith("write"):
+        return "write"
+    if leaf.endswith("viewer") or leaf.endswith("reader") or leaf.endswith("read") or "viewer" in leaf or "reader" in leaf:
+        return "read"
+    return "unknown"
+
+
+def _highest_privilege(roles: list[str]) -> str:
+    """Return the most-privileged level across a principal's bound roles."""
+    best = "unknown"
+    for role in roles:
+        level = _classify_role_privilege(role)
+        if _PRIVILEGE_RANK.get(level, 0) > _PRIVILEGE_RANK.get(best, 0):
+            best = level
+    return best
 
 
 def inventory_enabled() -> bool:
@@ -227,7 +278,10 @@ def discover_inventory(
         instances = _discover_instances(resolved_project, credentials=credentials, warnings=warnings)
         firewalls = _discover_firewalls(resolved_project, credentials=credentials, warnings=warnings)
     if include_iam:
-        service_accounts = _discover_service_accounts(resolved_project, credentials=credentials, warnings=warnings)
+        iam_bindings = _discover_project_iam_bindings(resolved_project, credentials=credentials, warnings=warnings)
+        service_accounts = _discover_service_accounts(
+            resolved_project, credentials=credentials, warnings=warnings, iam_bindings=iam_bindings
+        )
 
     permissions_used: list[str] = []
     if include_storage:
@@ -369,8 +423,12 @@ def _discover_instances(project_id: str, *, credentials: Any, warnings: list[str
 def _normalize_instance(instance: Any, *, name: str, project_id: str) -> dict[str, Any]:
     public_ip = ""
     private_ip = ""
+    networks: list[str] = []
     for interface in getattr(instance, "network_interfaces", None) or []:
         private_ip = private_ip or str(getattr(interface, "network_i_p", "") or getattr(interface, "network_ip", "") or "")
+        network_leaf = _leaf(getattr(interface, "network", ""))
+        if network_leaf and network_leaf not in networks:
+            networks.append(network_leaf)
         for access in getattr(interface, "access_configs", None) or []:
             nat_ip = str(getattr(access, "nat_i_p", "") or getattr(access, "nat_ip", "") or "")
             if nat_ip:
@@ -387,6 +445,10 @@ def _normalize_instance(instance: Any, *, name: str, project_id: str) -> dict[st
         "status": str(getattr(instance, "status", "") or ""),
         "public_ip": public_ip,
         "private_ip": private_ip,
+        # The network each interface attaches to — the join key a firewall rule
+        # matches on (a rule applies to instances on its target network).
+        "network": networks[0] if networks else "",
+        "networks": networks,
         "network_tags": list(getattr(getattr(instance, "tags", None), "items", None) or []),
         "service_accounts": service_accounts,
         "labels": _clean_labels(getattr(instance, "labels", None)),
@@ -417,6 +479,11 @@ def _discover_firewalls(project_id: str, *, credentials: Any, warnings: list[str
 
 def _normalize_firewall(rule: Any, *, name: str, project_id: str) -> dict[str, Any]:
     exposure = _firewall_internet_exposure(rule)
+    source_ranges = [str(r) for r in (getattr(rule, "source_ranges", None) or []) if r]
+    # Target tags / target service accounts scope a rule to specific instances.
+    # An EMPTY target set means the rule applies to ALL instances on its network.
+    target_tags = [str(t) for t in (getattr(rule, "target_tags", None) or []) if t]
+    target_service_accounts = [str(sa) for sa in (getattr(rule, "target_service_accounts", None) or []) if sa]
     return {
         "group_id": name,
         "name": name,
@@ -424,6 +491,9 @@ def _normalize_firewall(rule: Any, *, name: str, project_id: str) -> dict[str, A
         "direction": str(getattr(rule, "direction", "") or "").upper(),
         "internet_exposed": bool(exposure),
         "network_exposure": exposure,
+        "source_ranges": source_ranges,
+        "target_tags": target_tags,
+        "target_service_accounts": target_service_accounts,
         "project_id": project_id,
     }
 
@@ -474,13 +544,59 @@ def _safe_int(value: str) -> int | None:
 # ---------------------------------------------------------------------------
 
 
-def _discover_service_accounts(project_id: str, *, credentials: Any, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_project_iam_bindings(project_id: str, *, credentials: Any, warnings: list[str]) -> dict[str, list[str]]:
+    """Read the project IAM policy (read-only) → ``{member: [roles…]}``.
+
+    Calls ``cloudresourcemanager`` ``projects.getIamPolicy`` and inverts the
+    role→members bindings into a member→roles map so each principal carries the
+    roles bound to it. The member key is the bare identity (e.g.
+    ``svc@p.iam.gserviceaccount.com``) with the ``serviceAccount:`` / ``user:`` /
+    ``group:`` prefix stripped, matching the SA email used elsewhere. Degrades to
+    an empty map plus a warning on any error — never raises.
+    """
+    bindings_by_member: dict[str, list[str]] = {}
+    try:
+        from google.cloud import resourcemanager_v3
+    except ImportError:
+        warnings.append("google-cloud-resource-manager not installed. Skipping project IAM-binding discovery.")
+        return bindings_by_member
+    try:
+        from google.iam.v1 import iam_policy_pb2
+
+        client = resourcemanager_v3.ProjectsClient(credentials=credentials)
+        request = iam_policy_pb2.GetIamPolicyRequest(resource=f"projects/{project_id}")
+        policy = client.get_iam_policy(request=request)
+        for binding in _policy_bindings(policy):
+            role = str(binding.get("role", "") or "")
+            if not role:
+                continue
+            for member in binding.get("members", []) or []:
+                key = str(member).split(":", 1)[-1].strip().lower() if ":" in str(member) else str(member).strip().lower()
+                if not key:
+                    continue
+                roles = bindings_by_member.setdefault(key, [])
+                if role not in roles:
+                    roles.append(role)
+    except Exception as exc:  # noqa: BLE001 — IAM-policy read must never sink a scan
+        warnings.append(f"Could not read project IAM policy: {sanitize_discovery_warning(exc)}")
+    return bindings_by_member
+
+
+def _discover_service_accounts(
+    project_id: str,
+    *,
+    credentials: Any,
+    warnings: list[str],
+    iam_bindings: dict[str, list[str]] | None = None,
+) -> list[dict[str, Any]]:
     """Enumerate all service accounts in the project (read-only).
 
     Each service account becomes a ``service_account`` graph node carrying its
-    unique id so the effective-permissions overlay can attach ``HAS_PERMISSION``
-    once role-binding data is wired. Privilege defaults to ``unknown`` —
-    inventory never guesses an inflated level.
+    unique id and the project IAM roles bound to it, classified into a
+    ``privilege_level`` (admin / write / read / unknown) so the
+    effective-permissions overlay and ``OVERPERMISSIONED_TO_SENSITIVE`` /
+    CIEM reasoning fire on GCP — mirroring the AWS IAM path. Privilege defaults to
+    ``unknown`` when no binding is found — inventory never guesses an inflated level.
     """
     try:
         from google.cloud import iam_admin_v1
@@ -488,6 +604,7 @@ def _discover_service_accounts(project_id: str, *, credentials: Any, warnings: l
         warnings.append("google-cloud-iam not installed. Skipping service-account inventory.")
         return []
 
+    bindings = iam_bindings or {}
     accounts: list[dict[str, Any]] = []
     try:
         client = iam_admin_v1.IAMClient(credentials=credentials)
@@ -496,6 +613,17 @@ def _discover_service_accounts(project_id: str, *, credentials: Any, warnings: l
             email = str(getattr(account, "email", "") or "").strip()
             if not email:
                 continue
+            roles = list(bindings.get(email.lower(), []))
+            policies = [
+                {
+                    "policy_id": role,
+                    "policy_name": role,
+                    "attachment_type": "iam-binding",
+                    "privilege_level": _classify_role_privilege(role),
+                    "source_field": "projects.getIamPolicy.bindings",
+                }
+                for role in roles
+            ]
             accounts.append(
                 {
                     "principal_type": "service-account",
@@ -505,9 +633,10 @@ def _discover_service_accounts(project_id: str, *, credentials: Any, warnings: l
                     "email": email,
                     "disabled": bool(getattr(account, "disabled", False)),
                     "account_id": project_id,
-                    "policies": [],
+                    "roles": roles,
+                    "policies": policies,
                     "trust_principals": [],
-                    "privilege_level": "unknown",
+                    "privilege_level": _highest_privilege(roles),
                 }
             )
     except Exception as exc:  # noqa: BLE001

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -3642,6 +3642,74 @@ def _add_cloud_role_assignments(graph: UnifiedGraph, inventory: Any, data_source
         )
 
 
+def _gcp_firewall_applies(firewall_attrs: dict[str, Any], instance: dict[str, Any]) -> bool:
+    """Return whether a permissive GCP firewall rule reaches *instance*.
+
+    A rule applies when it is on the instance's network AND its target scope
+    covers the instance. The target scope is: target tags (instance must carry
+    one) OR target service accounts (instance must run as one). An EMPTY target
+    set means the rule applies to ALL instances on its network — the GCP default.
+    A blank firewall network also matches (the rule scope is the whole project).
+    """
+    fw_network = _clean_graph_part(firewall_attrs.get("fw_network"))
+    inst_network = _clean_graph_part(instance.get("network"))
+    if fw_network and inst_network and fw_network != inst_network:
+        return False
+
+    target_tags = {str(t).strip() for t in (firewall_attrs.get("fw_target_tags") or []) if str(t).strip()}
+    target_sas = {str(s).strip() for s in (firewall_attrs.get("fw_target_service_accounts") or []) if str(s).strip()}
+    if not target_tags and not target_sas:
+        # No targets → the rule applies to every instance on the network.
+        return True
+    instance_tags = {str(t).strip() for t in (instance.get("network_tags") or []) if str(t).strip()}
+    if target_tags and instance_tags & target_tags:
+        return True
+    instance_sas = {str(s).strip() for s in (instance.get("service_accounts") or []) if str(s).strip()}
+    if target_sas and instance_sas & target_sas:
+        return True
+    return False
+
+
+def _apply_gcp_firewall_exposure(
+    graph: UnifiedGraph,
+    sg_node_by_id: dict[str, str],
+    instance_nodes: list[tuple[str, dict[str, Any]]],
+) -> None:
+    """Mark GCP instances internet-exposed when a permissive firewall reaches them.
+
+    For each instance with an external IP, find every internet-facing
+    (``internet_exposed``) firewall node that applies to it (network + target
+    tags/SA match). Set ``internet_exposed=True`` on the instance node — which the
+    CNAPP overlay preserves — and add an ``EXPOSED_TO`` edge from the firewall to
+    the instance, mirroring how an AWS security group exposes an EC2 instance.
+    """
+    firewall_nodes = [(graph.nodes.get(node_id), node_id) for node_id in sg_node_by_id.values()]
+    permissive = [(node, node_id) for node, node_id in firewall_nodes if node is not None and node.attributes.get("internet_exposed")]
+    if not permissive:
+        return
+    for inst_node_id, instance in instance_nodes:
+        inst_node = graph.nodes.get(inst_node_id)
+        if inst_node is None:
+            continue
+        # Only an instance with an external/public IP can be reached from the
+        # internet; a permissive rule on a no-public-IP instance is not exposure.
+        if not _clean_graph_part(instance.get("public_ip")):
+            continue
+        for fw_node, fw_node_id in permissive:
+            if not _gcp_firewall_applies(fw_node.attributes, instance):
+                continue
+            inst_node.attributes["internet_exposed"] = True
+            graph.add_edge(
+                UnifiedEdge(
+                    source=fw_node_id,
+                    target=inst_node_id,
+                    relationship=RelationshipType.EXPOSED_TO,
+                    weight=6.0,
+                    evidence={"source": "cloud-inventory", "reason": "permissive_firewall_external_ip"},
+                )
+            )
+
+
 def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) -> None:
     """Promote estate-wide cloud inventory into first-class graph nodes.
 
@@ -3774,6 +3842,12 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
                     "vpc_id": _clean_graph_part(group.get("vpc_id")),
                     "internet_exposed": bool(group.get("internet_exposed")),
                     "network_exposure": list(group.get("network_exposure", []) or []),
+                    # GCP firewall scoping (empty on AWS); the instance-matching
+                    # pass below reads these to know which instances a rule covers.
+                    "fw_network": _clean_graph_part(group.get("network")),
+                    "fw_target_tags": list(group.get("target_tags", []) or []),
+                    "fw_target_service_accounts": list(group.get("target_service_accounts", []) or []),
+                    "fw_source_ranges": list(group.get("source_ranges", []) or []),
                     "account_id": account_id,
                 },
                 data_sources=data_sources,
@@ -3783,6 +3857,9 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
         resource_ids.append(node_id)
 
     # ── EC2 instances → CLOUD_RESOURCE (linked to their security groups) ──
+    # Track (node_id, raw-instance) so the GCP firewall-matching pass can mark
+    # exposure by network + target tags/SA (GCP has no per-instance SG-id list).
+    instance_nodes: list[tuple[str, dict[str, Any]]] = []
     for instance in inventory.get("instances", []) or []:
         if not isinstance(instance, dict):
             continue
@@ -3815,6 +3892,11 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
                     "private_ip": _clean_graph_part(instance.get("private_ip")),
                     "iam_instance_profile": _clean_graph_part(instance.get("iam_instance_profile")),
                     "security_group_ids": list(instance.get("security_group_ids", []) or []),
+                    # GCP instance scoping (empty on AWS); the GCP firewall-matching
+                    # pass below reads these to decide which permissive rules apply.
+                    "network": _clean_graph_part(instance.get("network")),
+                    "network_tags": list(instance.get("network_tags", []) or []),
+                    "service_accounts": list(instance.get("service_accounts", []) or []),
                     "account_id": account_id,
                 },
                 data_sources=data_sources,
@@ -3822,6 +3904,7 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
             )
         )
         resource_ids.append(node_id)
+        instance_nodes.append((node_id, instance))
         for sg_id in instance.get("security_group_ids", []) or []:
             sg_node_id = sg_node_by_id.get(_clean_graph_part(sg_id))
             if not sg_node_id:
@@ -3862,6 +3945,15 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
                     evidence={"source": "cloud-inventory", "reason": "vm_user_assigned_identity"},
                 )
             )
+
+    # ── GCP compute exposure: match permissive firewalls to instances ──────
+    # GCP firewalls apply by network + target tags / target service accounts,
+    # not by a per-instance security-group id list (the AWS path above). Mirror
+    # AWS's EC2-exposure model: an instance with an external IP that a permissive
+    # (0.0.0.0/0) ingress rule reaches is marked internet_exposed with an
+    # EXPOSED_TO edge from the firewall — making it a first-class attack-path entry.
+    if provider == "gcp":
+        _apply_gcp_firewall_exposure(graph, sg_node_by_id, instance_nodes)
 
     # ── AWS data + compute services (RDS / DynamoDB / Lambda / EKS) ──────
     # (key, service, resource_type, kind, label, is_data_store)

--- a/tests/test_cloud_gcp_inventory.py
+++ b/tests/test_cloud_gcp_inventory.py
@@ -71,7 +71,11 @@ class _FakeInstancesClient:
             zone="https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a",
             status="RUNNING",
             network_interfaces=[
-                _Obj(network_i_p="10.0.0.5", access_configs=[_Obj(nat_i_p="203.0.113.7")]),
+                _Obj(
+                    network_i_p="10.0.0.5",
+                    network="https://www.googleapis.com/compute/v1/projects/p/global/networks/default",
+                    access_configs=[_Obj(nat_i_p="203.0.113.7")],
+                ),
             ],
             service_accounts=[_Obj(email="vm-sa@p.iam.gserviceaccount.com")],
             tags=_Obj(items=["http-server"]),
@@ -121,7 +125,11 @@ class _FakeIAMClient:
         pass
 
     def list_service_accounts(self, request: Any) -> list[Any]:
-        return [_FakeServiceAccount("svc@p.iam.gserviceaccount.com", "Service Bot", "sa-unique-1")]
+        return [
+            _FakeServiceAccount("svc@p.iam.gserviceaccount.com", "Service Bot", "sa-unique-1"),
+            _FakeServiceAccount("overperm@p.iam.gserviceaccount.com", "Over-Permissioned", "sa-unique-2"),
+            _FakeServiceAccount("reader@p.iam.gserviceaccount.com", "Read Only", "sa-unique-3"),
+        ]
 
 
 class _FakeListSARequest:
@@ -134,6 +142,33 @@ class _FakeIAMAdminModule(types.ModuleType):
     ListServiceAccountsRequest = _FakeListSARequest
 
 
+# Project IAM policy: editor-bound SA → write, viewer-bound SA → read.
+class _FakeProjectsClient:
+    def __init__(self, credentials: Any = None) -> None:
+        pass
+
+    def get_iam_policy(self, request: Any) -> Any:
+        return _Obj(
+            bindings=[
+                {"role": "roles/editor", "members": ["serviceAccount:overperm@p.iam.gserviceaccount.com"]},
+                {"role": "roles/viewer", "members": ["serviceAccount:reader@p.iam.gserviceaccount.com"]},
+            ]
+        )
+
+
+class _FakeResourceManagerModule(types.ModuleType):
+    ProjectsClient = _FakeProjectsClient
+
+
+class _FakeGetIamPolicyRequest:
+    def __init__(self, resource: str) -> None:
+        self.resource = resource
+
+
+class _FakeIamPolicyPb2Module(types.ModuleType):
+    GetIamPolicyRequest = _FakeGetIamPolicyRequest
+
+
 def _install_fake_gcp() -> Any:
     """Return a patch.dict context installing fake google-cloud SDK modules."""
     google_mod = types.ModuleType("google")
@@ -141,6 +176,10 @@ def _install_fake_gcp() -> Any:
     storage_mod = _FakeStorageModule("google.cloud.storage")
     compute_mod = _FakeComputeModule("google.cloud.compute_v1")
     iam_mod = _FakeIAMAdminModule("google.cloud.iam_admin_v1")
+    rm_mod = _FakeResourceManagerModule("google.cloud.resourcemanager_v3")
+    iam_v1_mod = types.ModuleType("google.iam")
+    iam_v1_sub = types.ModuleType("google.iam.v1")
+    iam_policy_mod = _FakeIamPolicyPb2Module("google.iam.v1.iam_policy_pb2")
     return patch.dict(
         sys.modules,
         {
@@ -149,6 +188,10 @@ def _install_fake_gcp() -> Any:
             "google.cloud.storage": storage_mod,
             "google.cloud.compute_v1": compute_mod,
             "google.cloud.iam_admin_v1": iam_mod,
+            "google.cloud.resourcemanager_v3": rm_mod,
+            "google.iam": iam_v1_mod,
+            "google.iam.v1": iam_v1_sub,
+            "google.iam.v1.iam_policy_pb2": iam_policy_mod,
         },
     )
 
@@ -248,12 +291,23 @@ def test_inventory_enumerates_all_three_classes(monkeypatch: pytest.MonkeyPatch)
     assert firewalls["allow-ssh"]["network_exposure"][0]["from_port"] == 22
     assert firewalls["internal-https"]["internet_exposed"] is False
 
-    # Service accounts as principals.
+    # Service accounts as principals, privilege classified from project IAM bindings.
     accounts = {a["arn"]: a for a in payload["service_accounts"]}
     sa = accounts["svc@p.iam.gserviceaccount.com"]
     assert sa["principal_type"] == "service-account"
     assert sa["principal_id"] == "sa-unique-1"
+    # No project binding for svc → unknown (never inflated).
     assert sa["privilege_level"] == "unknown"
+    # roles/editor → write; roles/viewer → read.
+    assert accounts["overperm@p.iam.gserviceaccount.com"]["privilege_level"] == "write"
+    assert accounts["overperm@p.iam.gserviceaccount.com"]["roles"] == ["roles/editor"]
+    assert accounts["reader@p.iam.gserviceaccount.com"]["privilege_level"] == "read"
+
+    # Instance carries its network + structured firewall-join fields.
+    assert inst["network"] == "default"
+    # Permissive 0.0.0.0/0 firewall captures its source ranges + target scope.
+    assert firewalls["allow-ssh"]["source_ranges"] == ["0.0.0.0/0"]
+    assert firewalls["allow-ssh"]["target_tags"] == []
 
     # Per-run trust contract.
     env = payload["discovery_envelope"]
@@ -354,3 +408,142 @@ def test_graph_multiple_provider_inventories() -> None:
 def test_graph_inventory_noop_when_not_ok() -> None:
     graph = _build_graph_from_inventory({"provider": "gcp", "status": "disabled", "buckets": [], "instances": [], "firewalls": []})
     assert not any(nid.startswith("cloud_resource:gcp:") for nid in graph.nodes)
+
+
+# ---------------------------------------------------------------------------
+# Privilege classification (mirror AWS IAM privilege levels)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("role", "expected"),
+    [
+        ("roles/owner", "admin"),
+        ("roles/editor", "write"),
+        ("roles/viewer", "read"),
+        ("roles/storage.admin", "admin"),
+        ("roles/compute.admin", "admin"),
+        ("roles/storage.objectViewer", "read"),
+        ("roles/bigquery.dataViewer", "read"),
+        ("roles/logging.viewer", "read"),
+        ("roles/run.invoker", "unknown"),
+        ("", "unknown"),
+    ],
+)
+def test_classify_role_privilege(role: str, expected: str) -> None:
+    assert gcp_inventory._classify_role_privilege(role) == expected
+
+
+def test_highest_privilege_takes_max() -> None:
+    assert gcp_inventory._highest_privilege(["roles/viewer", "roles/editor"]) == "write"
+    assert gcp_inventory._highest_privilege(["roles/viewer", "roles/owner"]) == "admin"
+    assert gcp_inventory._highest_privilege([]) == "unknown"
+
+
+def test_editor_service_account_classifies_as_write(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An roles/editor-bound SA must classify as write so CIEM reasoning fires."""
+    monkeypatch.setenv(gcp_inventory.INVENTORY_ENV_FLAG, "1")
+    with _install_fake_gcp():
+        payload = gcp_inventory.discover_inventory(project_id="proj-1")
+    accounts = {a["arn"]: a for a in payload["service_accounts"]}
+    overperm = accounts["overperm@p.iam.gserviceaccount.com"]
+    assert overperm["privilege_level"] == "write"
+    # The bound role becomes a classified policy entry the graph promotes to POLICY.
+    assert overperm["policies"][0]["policy_name"] == "roles/editor"
+    assert overperm["policies"][0]["privilege_level"] == "write"
+
+
+def test_graph_promotes_editor_sa_privilege(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(gcp_inventory.INVENTORY_ENV_FLAG, "1")
+    with _install_fake_gcp():
+        payload = gcp_inventory.discover_inventory(project_id="proj-1")
+    graph = _build_graph_from_inventory(payload)
+    sa_id = "service_account:gcp:overperm@p.iam.gserviceaccount.com"
+    assert sa_id in graph.nodes
+    assert graph.nodes[sa_id].attributes["privilege_level"] == "write"
+
+
+# ---------------------------------------------------------------------------
+# Compute internet-exposure (mirror AWS EC2 + security groups)
+# ---------------------------------------------------------------------------
+
+
+def test_graph_marks_instance_exposed_with_edge(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An external-IP instance + a 0.0.0.0/0 firewall on its network is exposed."""
+    monkeypatch.setenv(gcp_inventory.INVENTORY_ENV_FLAG, "1")
+    with _install_fake_gcp():
+        payload = gcp_inventory.discover_inventory(project_id="proj-1")
+    graph = _build_graph_from_inventory(payload)
+    from agent_bom.graph.types import RelationshipType
+
+    inst_id = "cloud_resource:gcp:compute:instance:123"
+    fw_id = "cloud_resource:gcp:compute:firewall:allow-ssh"
+    assert graph.nodes[inst_id].attributes["internet_exposed"] is True
+    exposed_edges = [e for e in graph.edges if e.relationship == RelationshipType.EXPOSED_TO and e.source == fw_id and e.target == inst_id]
+    assert len(exposed_edges) == 1
+    assert exposed_edges[0].evidence.get("reason") == "permissive_firewall_external_ip"
+
+
+def test_no_exposure_without_external_ip() -> None:
+    """An instance with NO public IP is not exposed even under a 0.0.0.0/0 rule."""
+    payload = {
+        "provider": "gcp",
+        "status": "ok",
+        "project_id": "proj-1",
+        "buckets": [],
+        "instances": [
+            {"instance_id": "i-private", "name": "private-1", "public_ip": "", "network": "default", "network_tags": []},
+        ],
+        "firewalls": [
+            {
+                "group_id": "allow-all",
+                "name": "allow-all",
+                "network": "default",
+                "internet_exposed": True,
+                "network_exposure": [{"scope": "internet", "from_port": 22, "to_port": 22, "protocol": "tcp"}],
+                "source_ranges": ["0.0.0.0/0"],
+                "target_tags": [],
+                "target_service_accounts": [],
+            }
+        ],
+        "service_accounts": [],
+    }
+    graph = _build_graph_from_inventory(payload)
+    from agent_bom.graph.types import RelationshipType
+
+    inst_id = "cloud_resource:gcp:compute:instance:i-private"
+    assert not graph.nodes[inst_id].attributes.get("internet_exposed")
+    assert not any(e.relationship == RelationshipType.EXPOSED_TO and e.target == inst_id for e in graph.edges)
+
+
+def test_target_tag_scopes_firewall_to_matching_instance() -> None:
+    """A target-tagged firewall exposes only instances carrying that tag."""
+    payload = {
+        "provider": "gcp",
+        "status": "ok",
+        "project_id": "proj-1",
+        "buckets": [],
+        "instances": [
+            {"instance_id": "i-web", "name": "web", "public_ip": "34.46.45.57", "network": "default", "network_tags": ["http-server"]},
+            {"instance_id": "i-db", "name": "db", "public_ip": "34.46.45.99", "network": "default", "network_tags": ["db"]},
+        ],
+        "firewalls": [
+            {
+                "group_id": "allow-http",
+                "name": "allow-http",
+                "network": "default",
+                "internet_exposed": True,
+                "network_exposure": [{"scope": "internet", "from_port": 80, "to_port": 80, "protocol": "tcp"}],
+                "source_ranges": ["0.0.0.0/0"],
+                "target_tags": ["http-server"],
+                "target_service_accounts": [],
+            }
+        ],
+        "service_accounts": [],
+    }
+    graph = _build_graph_from_inventory(payload)
+    web_id = "cloud_resource:gcp:compute:instance:i-web"
+    db_id = "cloud_resource:gcp:compute:instance:i-db"
+    assert graph.nodes[web_id].attributes["internet_exposed"] is True
+    # The db instance does not carry the http-server tag → not exposed by this rule.
+    assert not graph.nodes[db_id].attributes.get("internet_exposed")


### PR DESCRIPTION
## Summary

Bring GCP compute-exposure and IAM-privilege detection to parity with AWS.

A live GCP scan previously left an internet-facing VM unmarked and an
`roles/editor`-bound service account classified as `unknown`. AWS already
derives both (EC2 + security groups → exposure; IAM policies → privilege). This
closes the GCP equivalents.

## Compute internet-exposure (mirror AWS EC2 + security groups)

- `gcp_inventory._discover_instances`: capture each instance's external IP, its
  network, network tags and service accounts.
- `gcp_inventory._discover_firewalls`: capture ingress source ranges (e.g.
  `0.0.0.0/0`), allowed ports/protocols, target network, and target tags /
  target service accounts — enough to know which instances a permissive rule
  applies to.
- `graph/builder.py`: a compute-instance node is marked `internet_exposed=True`
  when it has an external IP AND a permissive (`0.0.0.0/0`) ingress firewall
  applies to it (matched by network + target tags/SA; an empty target set means
  the rule covers every instance on the network). An `EXPOSED_TO` edge is added
  from the firewall to the instance, mirroring how an AWS security group exposes
  EC2 — making the instance a first-class attack-path entry point.

## IAM privilege classification (mirror AWS IAM privilege levels)

- Adds read-only project IAM-binding discovery
  (`cloudresourcemanager` `projects.getIamPolicy`) so each service account
  carries the roles bound to it.
- Classifies privilege: `roles/owner` and `*Admin` → `admin`; `roles/editor`
  → `write`; `roles/viewer` / `*Viewer` / `*Reader` → `read`; else `unknown`.
  `privilege_level` is set on the SA principal node and on its role-derived
  policy entries, so `OVERPERMISSIONED_TO_SENSITIVE` and CIEM reasoning fire on
  GCP.

## Validation

- Unit tests (fake-GCP pattern): instance with external IP + `0.0.0.0/0`
  firewall on its network is marked exposed with an `EXPOSED_TO` edge;
  target-tag scoping limits exposure to matching instances; no-public-IP
  instance is not exposed; `roles/editor` SA → write, `roles/viewer` SA → read,
  unbound SA → unknown. `ruff check` + `mypy` clean; `pytest -k gcp` green
  (141 passed).
- Live (read-only impersonated scanner SA): VM `abom-demo-vm` (external IP
  `34.46.45.57`) now `internet_exposed=True` with `EXPOSED_TO` edges from the
  permissive `0.0.0.0/0` firewalls; `abom-demo-overperm` SA (bound
  `roles/editor`) classifies as `write`; the scanner SA (`roles/viewer` +
  `roles/iam.securityReviewer`) as `read`; the compute default SA with no
  project binding stays `unknown` (no inflation).

Trust posture unchanged: read-only, agentless, token/ADC only; only `list` /
`get` / `getIamPolicy` APIs are exercised.
