### PR TITLE
feat(gcp): expand estate inventory to GKE, Cloud Run, Functions, Cloud SQL, VPC, disks, Pub/Sub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ gcp = [
     "google-cloud-iam>=2.12",
     "google-cloud-storage>=2.10",
     "google-cloud-logging>=3.5",
+    "google-cloud-pubsub>=2.18",
     # The CIS benchmark builds service clients via the discovery API.
     "google-api-python-client>=2.100",
 ]

--- a/src/agent_bom/cloud/gcp_inventory.py
+++ b/src/agent_bom/cloud/gcp_inventory.py
@@ -66,6 +66,19 @@ _GCP_IAM_PERMISSIONS: tuple[str, ...] = (
     "iam.serviceAccounts.list",
     "resourcemanager.projects.getIamPolicy",
 )
+# Estate-breadth read-only permissions exercised by the extended discoverers
+# (GKE / Cloud Run / Cloud Functions / Cloud SQL / VPC / disks / Pub/Sub). Kept
+# explicit so the discovery envelope's `permissions_used` stays honest.
+_GCP_ESTATE_PERMISSIONS: tuple[str, ...] = (
+    "container.clusters.list",
+    "run.services.list",
+    "cloudfunctions.functions.list",
+    "cloudsql.instances.list",
+    "compute.networks.list",
+    "compute.subnetworks.list",
+    "compute.disks.list",
+    "pubsub.topics.list",
+)
 
 # Open-to-the-world source ranges that mark a firewall rule as internet-facing.
 # The CNAPP overlay keys off this `network_exposure` shape.
@@ -197,6 +210,12 @@ def discover_inventory(
     include_storage: bool = True,
     include_compute: bool = True,
     include_iam: bool = True,
+    include_containers: bool = True,
+    include_serverless: bool = True,
+    include_databases: bool = True,
+    include_networks: bool = True,
+    include_disks: bool = True,
+    include_messaging: bool = True,
     force: bool = False,
 ) -> dict[str, Any]:
     """Enumerate the general GCP estate (GCS, instances + firewalls, SAs).
@@ -231,6 +250,13 @@ def discover_inventory(
         "instances": [],
         "firewalls": [],
         "service_accounts": [],
+        "gke_clusters": [],
+        "cloud_run_services": [],
+        "cloud_functions": [],
+        "cloud_sql_instances": [],
+        "vpc_networks": [],
+        "disks": [],
+        "pubsub_topics": [],
         "warnings": [],
         "discovery_envelope": None,
     }
@@ -271,6 +297,13 @@ def discover_inventory(
     instances: list[dict[str, Any]] = []
     firewalls: list[dict[str, Any]] = []
     service_accounts: list[dict[str, Any]] = []
+    gke_clusters: list[dict[str, Any]] = []
+    cloud_run_services: list[dict[str, Any]] = []
+    cloud_functions: list[dict[str, Any]] = []
+    cloud_sql_instances: list[dict[str, Any]] = []
+    vpc_networks: list[dict[str, Any]] = []
+    disks: list[dict[str, Any]] = []
+    pubsub_topics: list[dict[str, Any]] = []
 
     if include_storage:
         buckets = _discover_buckets(resolved_project, credentials=credentials, warnings=warnings)
@@ -282,6 +315,19 @@ def discover_inventory(
         service_accounts = _discover_service_accounts(
             resolved_project, credentials=credentials, warnings=warnings, iam_bindings=iam_bindings
         )
+    if include_containers:
+        gke_clusters = _discover_gke_clusters(resolved_project, credentials=credentials, warnings=warnings)
+    if include_serverless:
+        cloud_run_services = _discover_cloud_run_services(resolved_project, credentials=credentials, warnings=warnings)
+        cloud_functions = _discover_cloud_functions(resolved_project, credentials=credentials, warnings=warnings)
+    if include_databases:
+        cloud_sql_instances = _discover_cloud_sql_instances(resolved_project, credentials=credentials, warnings=warnings)
+    if include_networks:
+        vpc_networks = _discover_vpc_networks(resolved_project, credentials=credentials, warnings=warnings)
+    if include_disks:
+        disks = _discover_disks(resolved_project, credentials=credentials, warnings=warnings)
+    if include_messaging:
+        pubsub_topics = _discover_pubsub_topics(resolved_project, credentials=credentials, warnings=warnings)
 
     permissions_used: list[str] = []
     if include_storage:
@@ -290,6 +336,18 @@ def discover_inventory(
         permissions_used.extend(_GCP_COMPUTE_PERMISSIONS)
     if include_iam:
         permissions_used.extend(_GCP_IAM_PERMISSIONS)
+    if include_containers:
+        permissions_used.append("container.clusters.list")
+    if include_serverless:
+        permissions_used.extend(("run.services.list", "cloudfunctions.functions.list"))
+    if include_databases:
+        permissions_used.append("cloudsql.instances.list")
+    if include_networks:
+        permissions_used.extend(("compute.networks.list", "compute.subnetworks.list"))
+    if include_disks:
+        permissions_used.append("compute.disks.list")
+    if include_messaging:
+        permissions_used.append("pubsub.topics.list")
 
     envelope = DiscoveryEnvelope(
         scan_mode=ScanMode.CLOUD_READ_ONLY,
@@ -308,6 +366,13 @@ def discover_inventory(
         "instances": instances,
         "firewalls": firewalls,
         "service_accounts": service_accounts,
+        "gke_clusters": gke_clusters,
+        "cloud_run_services": cloud_run_services,
+        "cloud_functions": cloud_functions,
+        "cloud_sql_instances": cloud_sql_instances,
+        "vpc_networks": vpc_networks,
+        "disks": disks,
+        "pubsub_topics": pubsub_topics,
         "warnings": warnings,
         "discovery_envelope": envelope.to_dict(),
     }
@@ -645,8 +710,352 @@ def _discover_service_accounts(
 
 
 # ---------------------------------------------------------------------------
+# GKE clusters (container_v1, project-wide via the "-" location wildcard)
+# ---------------------------------------------------------------------------
+
+
+def _discover_gke_clusters(project_id: str, *, credentials: Any, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate every GKE cluster in the project (read-only).
+
+    Uses the ``-`` location wildcard so a single call returns clusters across all
+    regions/zones. A cluster with a public control-plane endpoint (no
+    ``private_cluster_config.enable_private_endpoint``) is marked
+    ``internet_exposed`` so the CNAPP / attack-path overlays treat it as an entry.
+    """
+    try:
+        from google.cloud import container_v1
+    except ImportError:
+        warnings.append("google-cloud-container not installed. Skipping GKE cluster inventory.")
+        return []
+
+    clusters: list[dict[str, Any]] = []
+    try:
+        client = container_v1.ClusterManagerClient(credentials=credentials)
+        response = client.list_clusters(parent=f"projects/{project_id}/locations/-")
+        for cluster in getattr(response, "clusters", None) or []:
+            name = str(getattr(cluster, "name", "") or "").strip()
+            if not name:
+                continue
+            private_cfg = getattr(cluster, "private_cluster_config", None)
+            private_endpoint = bool(getattr(private_cfg, "enable_private_endpoint", False)) if private_cfg else False
+            clusters.append(
+                {
+                    "name": name,
+                    "id": str(getattr(cluster, "id", "") or "") or name,
+                    "location": str(getattr(cluster, "location", "") or ""),
+                    "endpoint": str(getattr(cluster, "endpoint", "") or ""),
+                    "private_cluster": bool(getattr(private_cfg, "enable_private_nodes", False)) if private_cfg else False,
+                    "internet_exposed": not private_endpoint,
+                    "node_count": _safe_int(str(getattr(cluster, "current_node_count", "") or "")) or 0,
+                    "version": str(getattr(cluster, "current_master_version", "") or ""),
+                    "labels": _clean_labels(getattr(cluster, "resource_labels", None)),
+                    "project_id": project_id,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001 — API-disabled / access-denied must degrade
+        warnings.append(f"Could not list GKE clusters: {sanitize_discovery_warning(exc)}")
+    return clusters
+
+
+# ---------------------------------------------------------------------------
+# Cloud Run services (run_v2, project-wide via the "-" location wildcard)
+# ---------------------------------------------------------------------------
+
+
+def _discover_cloud_run_services(project_id: str, *, credentials: Any, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate every Cloud Run service in the project (read-only).
+
+    Ingress ``INGRESS_TRAFFIC_ALL`` means the service is reachable from the
+    internet → ``internet_exposed``. ``INGRESS_TRAFFIC_INTERNAL_*`` is private.
+    """
+    try:
+        from google.cloud import run_v2
+    except ImportError:
+        warnings.append("google-cloud-run not installed. Skipping Cloud Run service inventory.")
+        return []
+
+    services: list[dict[str, Any]] = []
+    try:
+        client = run_v2.ServicesClient(credentials=credentials)
+        request = run_v2.ListServicesRequest(parent=f"projects/{project_id}/locations/-")
+        for service in client.list_services(request=request):
+            full_name = str(getattr(service, "name", "") or "").strip()
+            name = _leaf(full_name)
+            if not name:
+                continue
+            ingress = str(getattr(service, "ingress", "") or "")
+            region = _segment(full_name, "locations")
+            services.append(
+                {
+                    "name": name,
+                    "id": full_name or name,
+                    "location": region,
+                    "url": str(getattr(service, "uri", "") or ""),
+                    "ingress": ingress,
+                    "internet_exposed": "ALL" in ingress.upper(),
+                    "labels": _clean_labels(getattr(service, "labels", None)),
+                    "project_id": project_id,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list Cloud Run services: {sanitize_discovery_warning(exc)}")
+    return services
+
+
+# ---------------------------------------------------------------------------
+# Cloud Functions (functions_v2, project-wide via the "-" location wildcard)
+# ---------------------------------------------------------------------------
+
+
+def _discover_cloud_functions(project_id: str, *, credentials: Any, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate every 2nd-gen Cloud Function in the project (read-only)."""
+    try:
+        from google.cloud import functions_v2
+    except ImportError:
+        warnings.append("google-cloud-functions not installed. Skipping Cloud Functions inventory.")
+        return []
+
+    functions: list[dict[str, Any]] = []
+    try:
+        client = functions_v2.FunctionServiceClient(credentials=credentials)
+        request = functions_v2.ListFunctionsRequest(parent=f"projects/{project_id}/locations/-")
+        for function in client.list_functions(request=request):
+            full_name = str(getattr(function, "name", "") or "").strip()
+            name = _leaf(full_name)
+            if not name:
+                continue
+            service_config = getattr(function, "service_config", None)
+            ingress = str(getattr(service_config, "ingress_settings", "") or "") if service_config else ""
+            event_trigger = getattr(function, "event_trigger", None)
+            trigger = "event" if event_trigger else "https"
+            functions.append(
+                {
+                    "name": name,
+                    "id": full_name or name,
+                    "location": _segment(full_name, "locations"),
+                    "trigger": trigger,
+                    "ingress": ingress,
+                    "internet_exposed": "ALL" in ingress.upper(),
+                    "labels": _clean_labels(getattr(function, "labels", None)),
+                    "project_id": project_id,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list Cloud Functions: {sanitize_discovery_warning(exc)}")
+    return functions
+
+
+# ---------------------------------------------------------------------------
+# Cloud SQL instances (Admin API via google-api-python-client)
+# ---------------------------------------------------------------------------
+
+
+def _discover_cloud_sql_instances(project_id: str, *, credentials: Any, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate every Cloud SQL instance in the project (read-only).
+
+    The Cloud SQL Admin API has no idiomatic google-cloud client, so this uses
+    the discovery-built ``sqladmin`` client. An instance with a public IPv4
+    address (``PRIMARY`` ip_address) or an open authorized-network
+    (``0.0.0.0/0``) is marked ``internet_exposed`` so a public managed database
+    feeds the CNAPP / attack-path overlays.
+    """
+    try:
+        from googleapiclient.discovery import build
+    except ImportError:
+        warnings.append("google-api-python-client not installed. Skipping Cloud SQL inventory.")
+        return []
+
+    instances: list[dict[str, Any]] = []
+    try:
+        service = build("sqladmin", "v1beta4", credentials=credentials, cache_discovery=False)
+        response = service.instances().list(project=project_id).execute()
+        for item in response.get("items", []) or []:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("name", "") or "").strip()
+            if not name:
+                continue
+            ip_addresses = [str(ip.get("ipAddress", "")) for ip in (item.get("ipAddresses") or []) if isinstance(ip, dict)]
+            settings = item.get("settings") or {}
+            ip_config = settings.get("ipConfiguration") or {}
+            authorized = [str(net.get("value", "")) for net in (ip_config.get("authorizedNetworks") or []) if isinstance(net, dict)]
+            public_ip = bool(ip_config.get("ipv4Enabled")) and bool(ip_addresses)
+            open_network = any(net in _INTERNET_RANGES for net in authorized)
+            disk_encryption = item.get("diskEncryptionConfiguration") or {}
+            instances.append(
+                {
+                    "name": name,
+                    "id": str(item.get("selfLink", "") or "") or name,
+                    "location": str(item.get("region", "") or ""),
+                    "database_version": str(item.get("databaseVersion", "") or ""),
+                    "ip_addresses": ip_addresses,
+                    "authorized_networks": authorized,
+                    "publicly_accessible": public_ip or open_network,
+                    "internet_exposed": public_ip or open_network,
+                    "encrypted": bool(disk_encryption.get("kmsKeyName")),
+                    "project_id": project_id,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001 — API-disabled / access-denied must degrade
+        warnings.append(f"Could not list Cloud SQL instances: {sanitize_discovery_warning(exc)}")
+    return instances
+
+
+# ---------------------------------------------------------------------------
+# VPC networks + subnets (compute_v1)
+# ---------------------------------------------------------------------------
+
+
+def _discover_vpc_networks(project_id: str, *, credentials: Any, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate every VPC network + its subnets in the project (read-only)."""
+    try:
+        from google.cloud import compute_v1
+    except ImportError:
+        warnings.append("google-cloud-compute not installed. Skipping VPC network inventory.")
+        return []
+
+    subnets_by_network = _discover_subnets_by_network(project_id, credentials=credentials, warnings=warnings)
+    networks: list[dict[str, Any]] = []
+    try:
+        client = compute_v1.NetworksClient(credentials=credentials)
+        for network in client.list(project=project_id):
+            name = str(getattr(network, "name", "") or "").strip()
+            if not name:
+                continue
+            self_link = str(getattr(network, "self_link", "") or "")
+            network_subnets = subnets_by_network.get(self_link, []) or subnets_by_network.get(name, [])
+            networks.append(
+                {
+                    "name": name,
+                    "id": str(getattr(network, "id", "") or "") or name,
+                    "location": "global",
+                    "auto_create_subnetworks": bool(getattr(network, "auto_create_subnetworks", False)),
+                    "subnets": network_subnets,
+                    "project_id": project_id,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list VPC networks: {sanitize_discovery_warning(exc)}")
+    return networks
+
+
+def _discover_subnets_by_network(project_id: str, *, credentials: Any, warnings: list[str]) -> dict[str, list[dict[str, Any]]]:
+    """Aggregated subnet list, keyed by the parent network self-link AND name."""
+    try:
+        from google.cloud import compute_v1
+    except ImportError:
+        return {}
+
+    by_network: dict[str, list[dict[str, Any]]] = {}
+    try:
+        client = compute_v1.SubnetworksClient(credentials=credentials)
+        for _region, scoped_list in client.aggregated_list(project=project_id):
+            for subnet in getattr(scoped_list, "subnetworks", None) or []:
+                network_link = str(getattr(subnet, "network", "") or "")
+                flow_logs = getattr(subnet, "enable_flow_logs", None)
+                entry = {
+                    "name": str(getattr(subnet, "name", "") or ""),
+                    "region": _leaf(getattr(subnet, "region", "")),
+                    "cidr": str(getattr(subnet, "ip_cidr_range", "") or ""),
+                    "flow_logs": bool(flow_logs) if flow_logs is not None else False,
+                }
+                by_network.setdefault(network_link, []).append(entry)
+                by_network.setdefault(_leaf(network_link), []).append(entry)
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list VPC subnets: {sanitize_discovery_warning(exc)}")
+    return by_network
+
+
+# ---------------------------------------------------------------------------
+# Persistent disks (compute_v1, aggregated)
+# ---------------------------------------------------------------------------
+
+
+def _discover_disks(project_id: str, *, credentials: Any, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate every persistent disk in the project (read-only)."""
+    try:
+        from google.cloud import compute_v1
+    except ImportError:
+        warnings.append("google-cloud-compute not installed. Skipping persistent-disk inventory.")
+        return []
+
+    disks: list[dict[str, Any]] = []
+    try:
+        client = compute_v1.DisksClient(credentials=credentials)
+        for _zone, scoped_list in client.aggregated_list(project=project_id):
+            for disk in getattr(scoped_list, "disks", None) or []:
+                name = str(getattr(disk, "name", "") or "").strip()
+                if not name:
+                    continue
+                encryption = getattr(disk, "disk_encryption_key", None)
+                disks.append(
+                    {
+                        "name": name,
+                        "id": str(getattr(disk, "id", "") or "") or name,
+                        "location": _leaf(getattr(disk, "zone", "")),
+                        "size_gb": _safe_int(str(getattr(disk, "size_gb", "") or "")) or 0,
+                        "encrypted": bool(getattr(encryption, "kms_key_name", "") if encryption else False),
+                        "source_image": _leaf(getattr(disk, "source_image", "")),
+                        "labels": _clean_labels(getattr(disk, "labels", None)),
+                        "project_id": project_id,
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list persistent disks: {sanitize_discovery_warning(exc)}")
+    return disks
+
+
+# ---------------------------------------------------------------------------
+# Pub/Sub topics (pubsub_v1)
+# ---------------------------------------------------------------------------
+
+
+def _discover_pubsub_topics(project_id: str, *, credentials: Any, warnings: list[str]) -> list[dict[str, Any]]:
+    """Enumerate every Pub/Sub topic in the project (read-only)."""
+    try:
+        from google.cloud import pubsub_v1
+    except ImportError:
+        warnings.append("google-cloud-pubsub not installed. Skipping Pub/Sub topic inventory.")
+        return []
+
+    topics: list[dict[str, Any]] = []
+    try:
+        client = pubsub_v1.PublisherClient(credentials=credentials)
+        for topic in client.list_topics(request={"project": f"projects/{project_id}"}):
+            full_name = str(getattr(topic, "name", "") or "").strip()
+            name = _leaf(full_name)
+            if not name:
+                continue
+            topics.append(
+                {
+                    "name": name,
+                    "id": full_name or name,
+                    "location": "global",
+                    "labels": _clean_labels(getattr(topic, "labels", None)),
+                    "project_id": project_id,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not list Pub/Sub topics: {sanitize_discovery_warning(exc)}")
+    return topics
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _segment(self_link: str, key: str) -> str:
+    """Return the path segment following ``key`` in a GCP resource name, else ''.
+
+    e.g. ``_segment("projects/p/locations/us-central1/services/svc", "locations")``
+    → ``"us-central1"``.
+    """
+    parts = str(self_link or "").split("/")
+    for i, part in enumerate(parts):
+        if part == key and i + 1 < len(parts):
+            return parts[i + 1]
+    return ""
 
 
 def _leaf(value: Any) -> str:

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -4011,6 +4011,64 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
                     )
                 )
 
+    # ── GCP estate breadth (GKE / Cloud Run / Functions / Cloud SQL / VPC /
+    # disks / Pub/Sub) → CLOUD_RESOURCE or DATA_STORE, OWNS from the project. ──
+    # Mirrors the AWS service loop above. Cloud SQL is a DATA_STORE so DSPM tiers
+    # apply; a public-IP instance carries `internet_exposed` for CNAPP. The id key
+    # (id_field) keeps a stable node id per resource (full self-link / uid).
+    if provider == "gcp":
+        for coll_key, svc, rtype, kind, label, is_data, id_field in (
+            ("gke_clusters", "gke", "container_cluster", "gke-cluster", "gke cluster", False, "id"),
+            ("cloud_run_services", "run", "function", "cloud-run-service", "cloud run service", False, "name"),
+            ("cloud_functions", "cloudfunctions", "function", "cloud-function", "cloud function", False, "name"),
+            ("cloud_sql_instances", "cloudsql", "database", "cloud-sql-instance", "cloud sql database", True, "name"),
+            ("vpc_networks", "compute", "virtual_network", "vpc-network", "vpc network", False, "name"),
+            ("disks", "compute", "storage", "persistent-disk", "persistent disk", False, "name"),
+            ("pubsub_topics", "pubsub", "messaging", "pubsub-topic", "pubsub topic", False, "name"),
+        ):
+            for item in inventory.get(coll_key, []) or []:
+                if not isinstance(item, dict):
+                    continue
+                name = _clean_graph_part(item.get("name"))
+                if not name:
+                    continue
+                id_key = _clean_graph_part(item.get(id_field)) or name
+                node_id = f"cloud_resource:gcp:{svc}:{rtype}:{id_key}"
+                exposed = bool(item.get("publicly_accessible") or item.get("internet_exposed"))
+                graph.add_node(
+                    UnifiedNode(
+                        id=node_id,
+                        entity_type=EntityType.DATA_STORE if is_data else EntityType.CLOUD_RESOURCE,
+                        label=f"{label}: {name}",
+                        attributes={
+                            "resource_id": _clean_graph_part(item.get("id")) or name,
+                            "resource_name": name,
+                            "resource_type": rtype,
+                            "resource_kind": kind,
+                            "cloud_provider": "gcp",
+                            "cloud_service": svc,
+                            "location": _clean_graph_part(item.get("location")) or region,
+                            "internet_exposed": exposed,
+                            "is_data_store": is_data,
+                            "engine": _clean_graph_part(item.get("database_version")),
+                            "encrypted": bool(item.get("encrypted")),
+                            "account_id": account_id,
+                        },
+                        data_sources=data_sources,
+                        dimensions=NodeDimensions(cloud_provider="gcp", surface=svc),
+                    )
+                )
+                resource_ids.append(node_id)
+                if account_node_id:
+                    graph.add_edge(
+                        UnifiedEdge(
+                            source=account_node_id,
+                            target=node_id,
+                            relationship=RelationshipType.OWNS,
+                            evidence={"source": "cloud-inventory"},
+                        )
+                    )
+
     # ── Data / secret / registry / network resources (normalized model) ──
     _add_normalized_cloud_resources(
         graph,

--- a/tests/test_cloud_gcp_inventory.py
+++ b/tests/test_cloud_gcp_inventory.py
@@ -107,9 +107,59 @@ class _FakeFirewallsClient:
         ]
 
 
+class _FakeNetworksClient:
+    def __init__(self, credentials: Any = None) -> None:
+        pass
+
+    def list(self, project: str) -> list[Any]:
+        return [
+            _Obj(
+                name="default",
+                id="net-1",
+                self_link="https://www.googleapis.com/compute/v1/projects/p/global/networks/default",
+                auto_create_subnetworks=True,
+            ),
+        ]
+
+
+class _FakeSubnetworksClient:
+    def __init__(self, credentials: Any = None) -> None:
+        pass
+
+    def aggregated_list(self, project: str) -> list[Any]:
+        subnet = _Obj(
+            name="default-sub",
+            region="https://www.googleapis.com/compute/v1/projects/p/regions/us-central1",
+            ip_cidr_range="10.0.0.0/20",
+            network="https://www.googleapis.com/compute/v1/projects/p/global/networks/default",
+            enable_flow_logs=True,
+        )
+        return [("regions/us-central1", _Obj(subnetworks=[subnet]))]
+
+
+class _FakeDisksClient:
+    def __init__(self, credentials: Any = None) -> None:
+        pass
+
+    def aggregated_list(self, project: str) -> list[Any]:
+        disk = _Obj(
+            name="web-disk",
+            id="disk-1",
+            zone="https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a",
+            size_gb=50,
+            disk_encryption_key=_Obj(kms_key_name="projects/p/locations/us/keyRings/r/cryptoKeys/k"),
+            source_image="https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-12",
+            labels={"app": "web"},
+        )
+        return [("zones/us-central1-a", _Obj(disks=[disk]))]
+
+
 class _FakeComputeModule(types.ModuleType):
     InstancesClient = _FakeInstancesClient
     FirewallsClient = _FakeFirewallsClient
+    NetworksClient = _FakeNetworksClient
+    SubnetworksClient = _FakeSubnetworksClient
+    DisksClient = _FakeDisksClient
 
 
 class _FakeServiceAccount:
@@ -169,6 +219,157 @@ class _FakeIamPolicyPb2Module(types.ModuleType):
     GetIamPolicyRequest = _FakeGetIamPolicyRequest
 
 
+# --- GKE clusters -----------------------------------------------------------
+class _FakeClusterManagerClient:
+    def __init__(self, credentials: Any = None) -> None:
+        pass
+
+    def list_clusters(self, parent: str) -> Any:
+        public = _Obj(
+            name="public-gke",
+            id="c-1",
+            location="us-central1",
+            endpoint="35.1.2.3",
+            current_node_count=3,
+            current_master_version="1.29",
+            resource_labels={"env": "prod"},
+            private_cluster_config=_Obj(enable_private_endpoint=False, enable_private_nodes=False),
+        )
+        private = _Obj(
+            name="private-gke",
+            id="c-2",
+            location="us-east1",
+            endpoint="10.0.0.2",
+            current_node_count=2,
+            current_master_version="1.29",
+            resource_labels={},
+            private_cluster_config=_Obj(enable_private_endpoint=True, enable_private_nodes=True),
+        )
+        return _Obj(clusters=[public, private])
+
+
+class _FakeContainerModule(types.ModuleType):
+    ClusterManagerClient = _FakeClusterManagerClient
+
+
+# --- Cloud Run --------------------------------------------------------------
+class _FakeRunServicesClient:
+    def __init__(self, credentials: Any = None) -> None:
+        pass
+
+    def list_services(self, request: Any) -> list[Any]:
+        return [
+            _Obj(
+                name="projects/proj-1/locations/us-central1/services/public-api",
+                uri="https://public-api-abc.run.app",
+                ingress="INGRESS_TRAFFIC_ALL",
+                labels={"team": "x"},
+            ),
+            _Obj(
+                name="projects/proj-1/locations/us-central1/services/internal-api",
+                uri="https://internal-api-abc.run.app",
+                ingress="INGRESS_TRAFFIC_INTERNAL_ONLY",
+                labels={},
+            ),
+        ]
+
+
+class _FakeRunListServicesRequest:
+    def __init__(self, parent: str) -> None:
+        self.parent = parent
+
+
+class _FakeRunModule(types.ModuleType):
+    ServicesClient = _FakeRunServicesClient
+    ListServicesRequest = _FakeRunListServicesRequest
+
+
+# --- Cloud Functions --------------------------------------------------------
+class _FakeFunctionServiceClient:
+    def __init__(self, credentials: Any = None) -> None:
+        pass
+
+    def list_functions(self, request: Any) -> list[Any]:
+        return [
+            _Obj(
+                name="projects/proj-1/locations/us-central1/functions/ingest",
+                service_config=_Obj(ingress_settings="ALLOW_ALL"),
+                event_trigger=None,
+                labels={},
+            ),
+        ]
+
+
+class _FakeFunctionsListRequest:
+    def __init__(self, parent: str) -> None:
+        self.parent = parent
+
+
+class _FakeFunctionsModule(types.ModuleType):
+    FunctionServiceClient = _FakeFunctionServiceClient
+    ListFunctionsRequest = _FakeFunctionsListRequest
+
+
+# --- Pub/Sub ----------------------------------------------------------------
+class _FakePublisherClient:
+    def __init__(self, credentials: Any = None) -> None:
+        pass
+
+    def list_topics(self, request: Any) -> list[Any]:
+        return [_Obj(name="projects/proj-1/topics/abom-demo-topic", labels={})]
+
+
+class _FakePubsubModule(types.ModuleType):
+    PublisherClient = _FakePublisherClient
+
+
+# --- Cloud SQL (googleapiclient discovery) ----------------------------------
+class _FakeSqlInstances:
+    def list(self, project: str) -> Any:
+        return _FakeSqlExecute(
+            {
+                "items": [
+                    {
+                        "name": "public-db",
+                        "selfLink": "https://.../public-db",
+                        "region": "us-central1",
+                        "databaseVersion": "POSTGRES_15",
+                        "ipAddresses": [{"type": "PRIMARY", "ipAddress": "34.10.20.30"}],
+                        "settings": {"ipConfiguration": {"ipv4Enabled": True, "authorizedNetworks": []}},
+                        "diskEncryptionConfiguration": {},
+                    },
+                    {
+                        "name": "private-db",
+                        "selfLink": "https://.../private-db",
+                        "region": "us-east1",
+                        "databaseVersion": "MYSQL_8_0",
+                        "ipAddresses": [{"type": "PRIVATE", "ipAddress": "10.1.2.3"}],
+                        "settings": {"ipConfiguration": {"ipv4Enabled": False, "authorizedNetworks": []}},
+                        "diskEncryptionConfiguration": {"kmsKeyName": "projects/p/.../k"},
+                    },
+                ]
+            }
+        )
+
+
+class _FakeSqlExecute:
+    def __init__(self, result: dict[str, Any]) -> None:
+        self._result = result
+
+    def execute(self) -> dict[str, Any]:
+        return self._result
+
+
+class _FakeSqlService:
+    def instances(self) -> _FakeSqlInstances:
+        return _FakeSqlInstances()
+
+
+def _fake_discovery_build(*args: Any, **kwargs: Any) -> Any:
+    """Stand-in for googleapiclient.discovery.build("sqladmin", ...)."""
+    return _FakeSqlService()
+
+
 def _install_fake_gcp() -> Any:
     """Return a patch.dict context installing fake google-cloud SDK modules."""
     google_mod = types.ModuleType("google")
@@ -180,6 +381,13 @@ def _install_fake_gcp() -> Any:
     iam_v1_mod = types.ModuleType("google.iam")
     iam_v1_sub = types.ModuleType("google.iam.v1")
     iam_policy_mod = _FakeIamPolicyPb2Module("google.iam.v1.iam_policy_pb2")
+    container_mod = _FakeContainerModule("google.cloud.container_v1")
+    run_mod = _FakeRunModule("google.cloud.run_v2")
+    functions_mod = _FakeFunctionsModule("google.cloud.functions_v2")
+    pubsub_mod = _FakePubsubModule("google.cloud.pubsub_v1")
+    apiclient_mod = types.ModuleType("googleapiclient")
+    discovery_mod = types.ModuleType("googleapiclient.discovery")
+    discovery_mod.build = _fake_discovery_build  # type: ignore[attr-defined]
     return patch.dict(
         sys.modules,
         {
@@ -192,6 +400,12 @@ def _install_fake_gcp() -> Any:
             "google.iam": iam_v1_mod,
             "google.iam.v1": iam_v1_sub,
             "google.iam.v1.iam_policy_pb2": iam_policy_mod,
+            "google.cloud.container_v1": container_mod,
+            "google.cloud.run_v2": run_mod,
+            "google.cloud.functions_v2": functions_mod,
+            "google.cloud.pubsub_v1": pubsub_mod,
+            "googleapiclient": apiclient_mod,
+            "googleapiclient.discovery": discovery_mod,
         },
     )
 
@@ -547,3 +761,141 @@ def test_target_tag_scopes_firewall_to_matching_instance() -> None:
     assert graph.nodes[web_id].attributes["internet_exposed"] is True
     # The db instance does not carry the http-server tag → not exposed by this rule.
     assert not graph.nodes[db_id].attributes.get("internet_exposed")
+
+
+# ---------------------------------------------------------------------------
+# Estate breadth: GKE / Cloud Run / Functions / Cloud SQL / VPC / disks / Pub/Sub
+# ---------------------------------------------------------------------------
+
+
+def test_inventory_enumerates_estate_breadth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(gcp_inventory.INVENTORY_ENV_FLAG, "1")
+    with _install_fake_gcp():
+        payload = gcp_inventory.discover_inventory(project_id="proj-1")
+
+    assert payload["status"] == "ok"
+
+    # GKE: public-endpoint cluster exposed, private not.
+    gke = {c["name"]: c for c in payload["gke_clusters"]}
+    assert set(gke) == {"public-gke", "private-gke"}
+    assert gke["public-gke"]["internet_exposed"] is True
+    assert gke["public-gke"]["node_count"] == 3
+    assert gke["private-gke"]["internet_exposed"] is False
+
+    # Cloud Run: all-ingress public, internal-only private.
+    run = {s["name"]: s for s in payload["cloud_run_services"]}
+    assert run["public-api"]["internet_exposed"] is True
+    assert run["public-api"]["location"] == "us-central1"
+    assert run["public-api"]["url"] == "https://public-api-abc.run.app"
+    assert run["internal-api"]["internet_exposed"] is False
+
+    # Cloud Functions: ALLOW_ALL ingress is public.
+    funcs = {f["name"]: f for f in payload["cloud_functions"]}
+    assert funcs["ingest"]["internet_exposed"] is True
+    assert funcs["ingest"]["trigger"] == "https"
+    assert funcs["ingest"]["location"] == "us-central1"
+
+    # Cloud SQL: public-IP instance exposed; private instance not; encryption read.
+    sql = {i["name"]: i for i in payload["cloud_sql_instances"]}
+    assert sql["public-db"]["internet_exposed"] is True
+    assert sql["public-db"]["publicly_accessible"] is True
+    assert sql["public-db"]["database_version"] == "POSTGRES_15"
+    assert sql["private-db"]["internet_exposed"] is False
+    assert sql["private-db"]["encrypted"] is True
+
+    # VPC network + subnet (CIDR + flow logs).
+    nets = {n["name"]: n for n in payload["vpc_networks"]}
+    assert nets["default"]["auto_create_subnetworks"] is True
+    assert nets["default"]["subnets"][0]["cidr"] == "10.0.0.0/20"
+    assert nets["default"]["subnets"][0]["flow_logs"] is True
+
+    # Persistent disk (size, encryption, source image).
+    disks = {d["name"]: d for d in payload["disks"]}
+    assert disks["web-disk"]["size_gb"] == 50
+    assert disks["web-disk"]["encrypted"] is True
+    assert disks["web-disk"]["source_image"] == "debian-12"
+
+    # Pub/Sub topic.
+    topics = {t["name"]: t for t in payload["pubsub_topics"]}
+    assert "abom-demo-topic" in topics
+
+    # Per-run trust contract picks up the estate permissions.
+    env = payload["discovery_envelope"]
+    assert "container.clusters.list" in env["permissions_used"]
+    assert "cloudsql.instances.list" in env["permissions_used"]
+    assert "pubsub.topics.list" in env["permissions_used"]
+
+
+def test_estate_discoverers_degrade_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An exception in any estate discoverer becomes a warning, never a crash."""
+    monkeypatch.setenv(gcp_inventory.INVENTORY_ENV_FLAG, "1")
+
+    class _BoomContainer(types.ModuleType):
+        class ClusterManagerClient:  # noqa: D106
+            def __init__(self, credentials: Any = None) -> None:
+                raise RuntimeError("API disabled")
+
+    with _install_fake_gcp(), patch.dict(sys.modules, {"google.cloud.container_v1": _BoomContainer("google.cloud.container_v1")}):
+        payload = gcp_inventory.discover_inventory(project_id="proj-1")
+    assert payload["status"] == "ok"
+    assert payload["gke_clusters"] == []
+    assert any("GKE" in w for w in payload["warnings"])
+
+
+def test_estate_selective_classes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(gcp_inventory.INVENTORY_ENV_FLAG, "1")
+    with _install_fake_gcp():
+        payload = gcp_inventory.discover_inventory(
+            project_id="proj-1",
+            include_containers=False,
+            include_databases=False,
+            include_messaging=False,
+        )
+    assert payload["gke_clusters"] == []
+    assert payload["cloud_sql_instances"] == []
+    assert payload["pubsub_topics"] == []
+    # Others still enumerate.
+    assert payload["cloud_run_services"]
+    assert payload["disks"]
+    env = payload["discovery_envelope"]
+    assert "container.clusters.list" not in env["permissions_used"]
+    assert "pubsub.topics.list" not in env["permissions_used"]
+
+
+def test_graph_emits_estate_nodes_and_owns_edges(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(gcp_inventory.INVENTORY_ENV_FLAG, "1")
+    with _install_fake_gcp():
+        payload = gcp_inventory.discover_inventory(project_id="proj-1")
+    graph = _build_graph_from_inventory(payload)
+    from agent_bom.graph.types import EntityType, RelationshipType
+
+    nodes = graph.nodes
+    account_id = "account:gcp:proj-1"
+
+    # GKE cluster → CLOUD_RESOURCE, public endpoint exposed.
+    gke_id = "cloud_resource:gcp:gke:container_cluster:c-1"
+    assert gke_id in nodes
+    assert nodes[gke_id].entity_type == EntityType.CLOUD_RESOURCE
+    assert nodes[gke_id].attributes["internet_exposed"] is True
+
+    # Cloud Run public service exposed.
+    run_id = "cloud_resource:gcp:run:function:public-api"
+    assert run_id in nodes
+    assert nodes[run_id].attributes["internet_exposed"] is True
+
+    # Cloud SQL → DATA_STORE, public IP exposed (feeds CNAPP/attack-paths).
+    sql_id = "cloud_resource:gcp:cloudsql:database:public-db"
+    assert sql_id in nodes
+    assert nodes[sql_id].entity_type == EntityType.DATA_STORE
+    assert nodes[sql_id].attributes["internet_exposed"] is True
+
+    # VPC, disk, Pub/Sub topic present.
+    assert "cloud_resource:gcp:compute:virtual_network:default" in nodes
+    assert "cloud_resource:gcp:compute:storage:web-disk" in nodes
+    assert "cloud_resource:gcp:pubsub:messaging:abom-demo-topic" in nodes
+
+    # Every estate node is OWNS-linked from the project/account node.
+    owns_targets = {e.target for e in graph.edges if e.relationship == RelationshipType.OWNS and e.source == account_id}
+    assert gke_id in owns_targets
+    assert sql_id in owns_targets
+    assert "cloud_resource:gcp:pubsub:messaging:abom-demo-topic" in owns_targets

--- a/uv.lock
+++ b/uv.lock
@@ -95,6 +95,7 @@ all = [
     { name = "google-cloud-functions" },
     { name = "google-cloud-iam" },
     { name = "google-cloud-logging" },
+    { name = "google-cloud-pubsub" },
     { name = "google-cloud-resource-manager" },
     { name = "google-cloud-run" },
     { name = "google-cloud-storage" },
@@ -210,6 +211,7 @@ cloud = [
     { name = "google-cloud-functions" },
     { name = "google-cloud-iam" },
     { name = "google-cloud-logging" },
+    { name = "google-cloud-pubsub" },
     { name = "google-cloud-resource-manager" },
     { name = "google-cloud-run" },
     { name = "google-cloud-storage" },
@@ -280,6 +282,7 @@ gcp = [
     { name = "google-cloud-functions" },
     { name = "google-cloud-iam" },
     { name = "google-cloud-logging" },
+    { name = "google-cloud-pubsub" },
     { name = "google-cloud-resource-manager" },
     { name = "google-cloud-run" },
     { name = "google-cloud-storage" },
@@ -424,6 +427,7 @@ requires-dist = [
     { name = "google-cloud-functions", marker = "extra == 'gcp'", specifier = ">=1.16" },
     { name = "google-cloud-iam", marker = "extra == 'gcp'", specifier = ">=2.12" },
     { name = "google-cloud-logging", marker = "extra == 'gcp'", specifier = ">=3.5" },
+    { name = "google-cloud-pubsub", marker = "extra == 'gcp'", specifier = ">=2.18" },
     { name = "google-cloud-resource-manager", marker = "extra == 'gcp'", specifier = ">=1.12" },
     { name = "google-cloud-run", marker = "extra == 'gcp'", specifier = ">=0.10" },
     { name = "google-cloud-storage", marker = "extra == 'gcp'", specifier = ">=2.10" },
@@ -2185,6 +2189,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9b/ba/e749846f13c8d1c6c01eb6317e8b09abc130fe67b5d72081a48d1bf96971/google_cloud_logging-3.16.0.tar.gz", hash = "sha256:08a3076b8f0f724219d6f73b2a242ef69d51e8bce226133aebe41a25f23f5400", size = 293703, upload-time = "2026-06-03T15:28:23.862Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/d5/91035dd77e0033dfb00d52b2bcad1e4f7408eb931981f86a1584301670a8/google_cloud_logging-3.16.0-py3-none-any.whl", hash = "sha256:9e5bfbdfe7b5315ece00e1703a2ea25fe42ca35e0b4750127b019f50d069b01b", size = 234188, upload-time = "2026-06-03T15:27:37.407Z" },
+]
+
+[[package]]
+name = "google-cloud-pubsub"
+version = "2.39.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpc-google-iam-v1" },
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/2b/4bf2c17e319ff65340389565b0e1b4d72696d87802b2f5f94390fbefa73c/google_cloud_pubsub-2.39.0.tar.gz", hash = "sha256:eed65e25f57f95bf3e02d96d7ee171688b23922471f9f21b5a91ed90e1282c0f", size = 402096, upload-time = "2026-06-03T15:28:26.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/20/dd0b27d4ad4577c062e77ff968ca3e2d404186cd78c8a2a53a0ef5fe5389/google_cloud_pubsub-2.39.0-py3-none-any.whl", hash = "sha256:7210d691a46d7a66559696899ebe6eb731e63de29b624964b3be4dd2d12d3e19", size = 324665, upload-time = "2026-06-03T15:27:41.119Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Expands the GCP estate inventory from four resource classes (buckets, instances, firewalls, service accounts) to eleven, bringing GCP breadth in line with AWS/Azure. Every new discoverer is read-only (`list`/`get` only) and crash-safe: a missing SDK or a disabled/denied API degrades to a warning and never sinks the scan.

## Types added

- **GKE clusters** (`container_v1`) — public control-plane endpoint marks the cluster `internet_exposed`.
- **Cloud Run services** (`run_v2`) — `INGRESS_TRAFFIC_ALL` marks the service public.
- **Cloud Functions** (`functions_v2`) — `ALLOW_ALL` ingress marks the function public.
- **Cloud SQL instances** (sqladmin Admin API) — emitted as `DATA_STORE`; a public IPv4 address or `0.0.0.0/0` authorized network marks the database `internet_exposed` so it feeds CNAPP / attack-paths.
- **VPC networks + subnets** (`compute_v1`) — CIDRs and flow-log state.
- **Persistent disks** (`compute_v1`) — size, encryption, source image.
- **Pub/Sub topics** (`pubsub_v1`).

New `include_*` flags (default True) gate each class; the discovery envelope's `permissions_used` stays honest per enabled class.

## Builder

Each new type maps onto a `CLOUD_RESOURCE` (or `DATA_STORE` for Cloud SQL) node with `cloud_provider=gcp`, `resource_kind`, `internet_exposed` where public, and an `OWNS` edge from the project/account node — mirroring the existing AWS service loop. Existing AWS/Azure/Snowflake builder regions are untouched.

## Validation

- Unit tests: each discoverer returns normalized dicts from a fake client; public Cloud Run / public-IP Cloud SQL / public-endpoint GKE → `internet_exposed` nodes; graph builds the nodes + OWNS edges; degraded-API path returns a warning.
- `ruff check` + `ruff format --check` + `mypy` clean; full GCP test slice green (161 passed).
- LIVE run against a read-only impersonated SA on a bare project: status `ok`, VPC + disk enumerated, GKE/Cloud Run/Functions/Cloud SQL/Pub/Sub degrade cleanly to warnings (their APIs are disabled on that project).