### PR TITLE
feat(snowflake): zero-latency SHOW-based identity discovery

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -304,6 +304,7 @@ AGENT_BOM_SIEM_TYPE
 AGENT_BOM_SIEM_URL
 AGENT_BOM_SKILLS_SCAN_CONCURRENCY
 AGENT_BOM_SNOWFLAKE_INVENTORY  # opt-in flag (default OFF) gating read-only estate-wide Snowflake inventory enrichment; read in cloud/snowflake.py
+AGENT_BOM_SNOWFLAKE_MAX_ROLES  # max roles enumerated by live SHOW-based identity discovery before the scan warns + caps (default 2000); read in cloud/snowflake.py
 AGENT_BOM_STATE_DIR
 AGENT_BOM_TAINT_MAX_DEPTH
 AGENT_BOM_TENANT_ID

--- a/src/agent_bom/cloud/snowflake.py
+++ b/src/agent_bom/cloud/snowflake.py
@@ -2043,8 +2043,9 @@ def discover_object_dependencies(
 # ACCOUNT_USAGE.GRANTS_TO_* which lags 45min–2h. Object-level grants we surface
 # (so a freshly-created role hierarchy is graphed immediately).
 _LIVE_GRANT_OBJECT_TYPES = {"TABLE", "VIEW", "MATERIALIZED VIEW", "DYNAMIC TABLE", "EXTERNAL TABLE", "ICEBERG TABLE"}
-# Bound the per-role SHOW GRANTS fan-out so a pathological account can't stall a scan.
-_LIVE_MAX_ROLES = 500
+# Default bound on the per-role SHOW GRANTS fan-out so a pathological account
+# can't stall a scan; override with AGENT_BOM_SNOWFLAKE_MAX_ROLES.
+_LIVE_MAX_ROLES = 2000
 
 
 def discover_identity_live(
@@ -2124,7 +2125,16 @@ def discover_identity_live(
 
 
 def _live_show_roles(conn: Any, warnings_list: list[str]) -> list[dict[str, Any]]:
-    """``SHOW ROLES`` → current role list (name / owner / comment), capped."""
+    """``SHOW ROLES`` → current role list (name / owner / comment).
+
+    Bounded by ``AGENT_BOM_SNOWFLAKE_MAX_ROLES`` (default ``_LIVE_MAX_ROLES``) so
+    large accounts can raise it; hitting the bound emits a warning rather than a
+    silent truncation.
+    """
+    try:
+        cap = max(1, int(os.environ.get("AGENT_BOM_SNOWFLAKE_MAX_ROLES", "") or _LIVE_MAX_ROLES))
+    except ValueError:
+        cap = _LIVE_MAX_ROLES
     roles: list[dict[str, Any]] = []
     cursor = conn.cursor()
     try:
@@ -2136,8 +2146,8 @@ def _live_show_roles(conn: Any, warnings_list: list[str]) -> list[dict[str, Any]
             if not name:
                 continue
             roles.append({"name": name, "owner": str(r.get("owner", "") or ""), "comment": str(r.get("comment", "") or "")})
-            if len(roles) >= _LIVE_MAX_ROLES:
-                warnings_list.append(f"SHOW ROLES truncated at {_LIVE_MAX_ROLES} roles.")
+            if len(roles) >= cap:
+                warnings_list.append(f"SHOW ROLES truncated at {cap} roles; raise AGENT_BOM_SNOWFLAKE_MAX_ROLES to see more.")
                 break
     except Exception as exc:  # noqa: BLE001
         warnings_list.append(f"Could not list roles (SHOW ROLES): {sanitize_error(exc)}")

--- a/src/agent_bom/cloud/snowflake.py
+++ b/src/agent_bom/cloud/snowflake.py
@@ -2039,6 +2039,294 @@ def discover_object_dependencies(
     return result
 
 
+# SHOW-based identity discovery reflects current state with no latency, unlike
+# ACCOUNT_USAGE.GRANTS_TO_* which lags 45min–2h. Object-level grants we surface
+# (so a freshly-created role hierarchy is graphed immediately).
+_LIVE_GRANT_OBJECT_TYPES = {"TABLE", "VIEW", "MATERIALIZED VIEW", "DYNAMIC TABLE", "EXTERNAL TABLE", "ICEBERG TABLE"}
+# Bound the per-role SHOW GRANTS fan-out so a pathological account can't stall a scan.
+_LIVE_MAX_ROLES = 500
+
+
+def discover_identity_live(
+    account: str | None = None,
+    user: str | None = None,
+    authenticator: str | None = None,
+    database: str | None = None,
+    schema: str | None = None,
+) -> dict[str, Any]:
+    """Discover the Snowflake identity graph via SHOW commands (zero latency).
+
+    ``ACCOUNT_USAGE.GRANTS_TO_ROLES`` / ``GRANTS_TO_USERS`` / role-membership
+    views lag 45min–2h, so a just-created role hierarchy is invisible on a live
+    scan. SHOW commands reflect current account state instantly. All read-only,
+    control-plane metadata only — NO passwords or secrets leave Snowflake.
+
+    Queries (all current-state, no ``ACCOUNT_USAGE`` lag):
+
+    * ``SHOW ROLES`` → the role list (capped at ``_LIVE_MAX_ROLES``).
+    * For each role: ``SHOW GRANTS TO ROLE "<role>"`` → object privilege grants
+      (privilege / granted_on / name) and role→role grants; ``SHOW GRANTS OF
+      ROLE "<role>"`` → who the role is granted to (users + roles) = memberships.
+    * ``SHOW USERS`` → user metadata (name / default_role / disabled only).
+
+    Returns a payload whose ``grants`` / ``role_memberships`` reuse the
+    :func:`discover_object_dependencies` shape so the graph builder's existing
+    Snowflake identity wiring consumes it unchanged. ``role_memberships`` carry
+    an optional ``parent``/``member_type`` so role→role edges build too.
+
+    Per-role failures degrade to warnings; the function never raises into a scan.
+
+    Raises:
+        CloudDiscoveryError: if snowflake-connector-python is not installed.
+    """
+    try:
+        import snowflake.connector  # noqa: F401
+    except ImportError:
+        raise CloudDiscoveryError(
+            "snowflake-connector-python is required for Snowflake identity discovery. Install with: pip install 'agent-bom[snowflake]'"
+        )
+
+    resolved_account = _env_or_value(account, "SNOWFLAKE_ACCOUNT")
+    result: dict[str, Any] = {
+        "status": "disabled",
+        "account": resolved_account,
+        "users": [],
+        "roles": [],
+        "role_memberships": [],
+        "grants": [],
+        "warnings": [],
+    }
+    warnings_list: list[str] = result["warnings"]
+    if not resolved_account:
+        result["status"] = "no_account"
+        warnings_list.append("SNOWFLAKE_ACCOUNT not set.")
+        return result
+
+    try:
+        conn = _get_connection(account, user, authenticator, database, schema)
+    except CloudDiscoveryError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        warnings_list.append(f"Could not connect to Snowflake: {sanitize_error(exc)}")
+        return result
+
+    try:
+        roles = _live_show_roles(conn, warnings_list)
+        result["roles"] = roles
+        result["users"] = _live_show_users(conn, warnings_list)
+        grants, memberships = _live_role_grants(conn, [r["name"] for r in roles], warnings_list)
+        result["grants"] = grants
+        result["role_memberships"] = memberships
+        result["status"] = "ok"
+    finally:
+        conn.close()
+    return result
+
+
+def _live_show_roles(conn: Any, warnings_list: list[str]) -> list[dict[str, Any]]:
+    """``SHOW ROLES`` → current role list (name / owner / comment), capped."""
+    roles: list[dict[str, Any]] = []
+    cursor = conn.cursor()
+    try:
+        cursor.execute("SHOW ROLES")
+        keys = [d[0].lower() for d in cursor.description] if cursor.description else []
+        for row in cursor.fetchall():
+            r = dict(zip(keys, row))
+            name = str(r.get("name", "") or "")
+            if not name:
+                continue
+            roles.append({"name": name, "owner": str(r.get("owner", "") or ""), "comment": str(r.get("comment", "") or "")})
+            if len(roles) >= _LIVE_MAX_ROLES:
+                warnings_list.append(f"SHOW ROLES truncated at {_LIVE_MAX_ROLES} roles.")
+                break
+    except Exception as exc:  # noqa: BLE001
+        warnings_list.append(f"Could not list roles (SHOW ROLES): {sanitize_error(exc)}")
+    finally:
+        cursor.close()
+    return roles
+
+
+def _live_show_users(conn: Any, warnings_list: list[str]) -> list[dict[str, Any]]:
+    """``SHOW USERS`` → user metadata only (name / default_role / disabled).
+
+    NO passwords or secrets are read — only the columns the graph needs.
+    """
+    users: list[dict[str, Any]] = []
+    cursor = conn.cursor()
+    try:
+        cursor.execute("SHOW USERS")
+        keys = [d[0].lower() for d in cursor.description] if cursor.description else []
+        for row in cursor.fetchall():
+            r = dict(zip(keys, row))
+            name = str(r.get("name", "") or "")
+            if not name:
+                continue
+            users.append(
+                {
+                    "name": name,
+                    "default_role": str(r.get("default_role", "") or ""),
+                    "disabled": _sf_truthy(r.get("disabled")),
+                }
+            )
+    except Exception as exc:  # noqa: BLE001
+        # MANAGE GRANTS / USERADMIN may be absent; not fatal.
+        warnings_list.append(f"Could not list users (SHOW USERS): {sanitize_error(exc)}")
+    finally:
+        cursor.close()
+    return users
+
+
+def _live_role_grants(conn: Any, role_names: list[str], warnings_list: list[str]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Per-role ``SHOW GRANTS TO/OF ROLE`` → object grants + memberships.
+
+    ``SHOW GRANTS TO ROLE "<role>"`` yields the role's privileges: object grants
+    (``granted_on`` a TABLE/VIEW/...) become ``grants`` (role HAS_PERMISSION on
+    object); ``granted_on=ROLE`` becomes a role→role membership (this role is a
+    member of the granted parent role). ``SHOW GRANTS OF ROLE "<role>"`` yields
+    who the role is granted to (users → ``{user, role}``; roles → role→role).
+    """
+    grants: list[dict[str, Any]] = []
+    memberships: list[dict[str, Any]] = []
+    # Dedupe so the two SHOW directions don't double-emit the same role→role edge.
+    seen_member: set[tuple[str, str]] = set()
+    seen_user: set[tuple[str, str]] = set()
+    seen_grant: set[tuple[str, str, str]] = set()
+
+    def _add_role_membership(child: str, parent: str) -> None:
+        if not child or not parent or child == parent:
+            return
+        key = (child, parent)
+        if key in seen_member:
+            return
+        seen_member.add(key)
+        memberships.append({"role": child, "parent": parent, "member_type": "role"})
+
+    def _add_user_membership(user_name: str, role: str) -> None:
+        if not user_name or not role:
+            return
+        key = (user_name, role)
+        if key in seen_user:
+            return
+        seen_user.add(key)
+        memberships.append({"user": user_name, "role": role, "member_type": "user"})
+
+    for role_name in role_names:
+        try:
+            quoted = _quote_sf_identifier(role_name)
+        except ValueError as exc:
+            warnings_list.append(f"Skipping unsafe role identifier: {sanitize_error(exc)}")
+            continue
+
+        # Privileges this role holds: object grants + role→role parents.
+        cursor = conn.cursor()
+        try:
+            cursor.execute(f"SHOW GRANTS TO ROLE {quoted}")
+            keys = [d[0].lower() for d in cursor.description] if cursor.description else []
+            for row in cursor.fetchall():
+                r = dict(zip(keys, row))
+                granted_on = str(r.get("granted_on", "") or "").upper()
+                privilege = str(r.get("privilege", "") or "")
+                obj_name = str(r.get("name", "") or "")
+                if granted_on == "ROLE" and privilege.upper() == "USAGE" and obj_name:
+                    # This role USAGE-on another role => member of that parent role.
+                    _add_role_membership(role_name, obj_name)
+                elif granted_on in _LIVE_GRANT_OBJECT_TYPES and obj_name:
+                    gkey = (role_name, privilege, obj_name)
+                    if gkey in seen_grant:
+                        continue
+                    seen_grant.add(gkey)
+                    grants.append(
+                        {
+                            "role": role_name,
+                            "privilege": privilege,
+                            "object_fqn": obj_name,
+                            "object_type": granted_on.lower(),
+                        }
+                    )
+        except Exception as exc:  # noqa: BLE001
+            warnings_list.append(f"Could not read grants TO role {role_name!r}: {sanitize_error(exc)}")
+        finally:
+            cursor.close()
+
+        # Who this role is granted to: users (memberships) + child roles.
+        cursor = conn.cursor()
+        try:
+            cursor.execute(f"SHOW GRANTS OF ROLE {quoted}")
+            keys = [d[0].lower() for d in cursor.description] if cursor.description else []
+            for row in cursor.fetchall():
+                r = dict(zip(keys, row))
+                granted_to = str(r.get("granted_to", "") or "").upper()
+                grantee = str(r.get("grantee_name", "") or "")
+                if not grantee:
+                    continue
+                if granted_to == "USER":
+                    _add_user_membership(grantee, role_name)
+                elif granted_to == "ROLE":
+                    # The grantee role is a member of this role (grantee → role_name).
+                    _add_role_membership(grantee, role_name)
+        except Exception as exc:  # noqa: BLE001
+            warnings_list.append(f"Could not read grants OF role {role_name!r}: {sanitize_error(exc)}")
+        finally:
+            cursor.close()
+
+    return grants, memberships
+
+
+def merge_live_identity_into_object_graph(object_graph: dict[str, Any], live: dict[str, Any]) -> dict[str, Any]:
+    """Merge zero-latency SHOW identity into the (lagged) object-graph payload.
+
+    Live SHOW data is preferred over the ACCOUNT_USAGE rows: grants and
+    memberships from *live* replace any overlapping lagged rows and are then
+    unioned with the remainder, deduped. ``users`` (live-only) are carried
+    through so freshly-created users graph immediately. Mutates and returns
+    *object_graph*. A non-ok *live* payload is a no-op passthrough.
+    """
+    if not isinstance(object_graph, dict):
+        return object_graph
+    if not isinstance(live, dict) or live.get("status") != "ok":
+        return object_graph
+
+    # Grants keyed by (role, privilege, object_fqn); live wins on collision.
+    def _grant_key(g: dict[str, Any]) -> tuple[str, str, str]:
+        return (str(g.get("role", "")), str(g.get("privilege", "")), str(g.get("object_fqn", "")))
+
+    merged_grants: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for g in object_graph.get("grants", []) or []:
+        if isinstance(g, dict):
+            merged_grants[_grant_key(g)] = g
+    for g in live.get("grants", []) or []:
+        if isinstance(g, dict):
+            merged_grants[_grant_key(g)] = g  # live overwrites lagged
+    object_graph["grants"] = list(merged_grants.values())
+
+    # Memberships: user→role keyed (user, role); role→role keyed (role, parent).
+    def _mem_key(m: dict[str, Any]) -> tuple[str, str, str]:
+        if m.get("member_type") == "role" or m.get("parent"):
+            return ("role", str(m.get("role", "")), str(m.get("parent", "")))
+        return ("user", str(m.get("user", "")), str(m.get("role", "")))
+
+    merged_mem: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for m in object_graph.get("role_memberships", []) or []:
+        if isinstance(m, dict):
+            merged_mem[_mem_key(m)] = m
+    for m in live.get("role_memberships", []) or []:
+        if isinstance(m, dict):
+            merged_mem[_mem_key(m)] = m  # live overwrites lagged
+    object_graph["role_memberships"] = list(merged_mem.values())
+
+    # Users are live-only (object graph never had them); carry through, deduped.
+    if live.get("users"):
+        existing = {str(u.get("name", "")) for u in object_graph.get("users", []) or [] if isinstance(u, dict)}
+        users = list(object_graph.get("users", []) or [])
+        for u in live["users"]:
+            if isinstance(u, dict) and str(u.get("name", "")) not in existing:
+                users.append(u)
+                existing.add(str(u.get("name", "")))
+        object_graph["users"] = users
+
+    return object_graph
+
+
 _EXTERNAL_STAGE_SCHEMES = {"s3": "aws", "s3gov": "aws", "azure": "azure", "gcs": "gcp"}
 
 
@@ -3394,9 +3682,25 @@ def enrich_report_with_snowflake_estate(report: Any) -> None:
     """
     # Object + dependency graph: tables/views → DATA_STORE nodes,
     # OBJECT_DEPENDENCIES → DEPENDS_ON lineage edges. Best-effort.
+    #
+    # The object graph's grants/memberships come from ACCOUNT_USAGE, which lags
+    # 45min–2h, so a freshly-created role hierarchy is invisible. Overlay
+    # zero-latency SHOW-based identity (current state) and prefer it over the
+    # lagged rows so new users/roles/grants graph immediately. Best-effort.
     try:
         _sf_object_graph = discover_object_dependencies()
-        if _sf_object_graph.get("status") == "ok" and (_sf_object_graph.get("objects") or _sf_object_graph.get("dependencies")):
+        try:
+            _sf_live_identity = discover_identity_live()
+            _sf_object_graph = merge_live_identity_into_object_graph(_sf_object_graph, _sf_live_identity)
+        except Exception:  # noqa: BLE001 — live overlay is supplementary; never fail the object graph
+            pass
+        if _sf_object_graph.get("status") == "ok" and (
+            _sf_object_graph.get("objects")
+            or _sf_object_graph.get("dependencies")
+            or _sf_object_graph.get("grants")
+            or _sf_object_graph.get("role_memberships")
+            or _sf_object_graph.get("users")
+        ):
             report.snowflake_object_graph_data = _sf_object_graph
     except Exception:  # noqa: BLE001 — object graph is supplementary; never fail the scan
         pass

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -2391,18 +2391,15 @@ def _add_snowflake_object_graph(graph: UnifiedGraph, payload: Any, data_source: 
             {"source": "snowflake-objects", "privilege": grant.get("privilege", "")},
         )
 
-    # User → role memberships: the user ASSUMES the role's privileges.
+    # Users. ``role_memberships`` carry user→role grants; the live SHOW overlay
+    # also emits role→role memberships ({role, parent}) and a top-level
+    # ``users`` list (freshly-created users that have no membership yet).
     seen_users: set[str] = set()
-    for membership in payload.get("role_memberships", []) or []:
-        if not isinstance(membership, dict):
-            continue
-        user_name = _clean_graph_part(membership.get("user"))
-        role = _clean_graph_part(membership.get("role"))
-        if not user_name or not role:
-            continue
-        user_node_id = f"user:snowflake:{user_name}"
-        if user_node_id not in seen_users:
-            seen_users.add(user_node_id)
+
+    def _ensure_user(user_name: str, **extra: Any) -> str:
+        node_id = f"user:snowflake:{user_name}"
+        if node_id not in seen_users:
+            seen_users.add(node_id)
             _add_identity_node(
                 graph,
                 EntityType.USER,
@@ -2413,8 +2410,49 @@ def _add_snowflake_object_graph(graph: UnifiedGraph, payload: Any, data_source: 
                 user_name=user_name,
                 cloud_provider="snowflake",
                 source="snowflake-objects",
+                **{k: v for k, v in extra.items() if v not in (None, "")},
             )
-        _add_rel_edge(graph, user_node_id, _ensure_role(role), RelationshipType.ASSUMES, {"source": "snowflake-objects"})
+        return node_id
+
+    # Standalone users (no membership row yet) so new accounts graph instantly.
+    for usr in payload.get("users", []) or []:
+        if not isinstance(usr, dict):
+            continue
+        user_name = _clean_graph_part(usr.get("name"))
+        if not user_name:
+            continue
+        _ensure_user(
+            user_name,
+            default_role=_clean_graph_part(usr.get("default_role")) or None,
+            disabled=usr.get("disabled"),
+        )
+
+    for membership in payload.get("role_memberships", []) or []:
+        if not isinstance(membership, dict):
+            continue
+        role = _clean_graph_part(membership.get("role"))
+        if not role:
+            continue
+        parent = _clean_graph_part(membership.get("parent"))
+        is_role_member = str(membership.get("member_type") or "").lower() == "role" or bool(parent)
+        if is_role_member:
+            # Role → role: the child role is a MEMBER_OF the parent and inherits
+            # (ASSUMES) its privileges, so privilege chains traverse end-to-end.
+            if not parent:
+                continue
+            child_id = _ensure_role(role)
+            parent_id = _ensure_role(parent)
+            _add_rel_edge(graph, child_id, parent_id, RelationshipType.MEMBER_OF, {"source": "snowflake-objects"})
+            _add_rel_edge(graph, child_id, parent_id, RelationshipType.ASSUMES, {"source": "snowflake-objects"})
+            continue
+        # User → role: the user is a MEMBER_OF and ASSUMES the role's privileges.
+        user_name = _clean_graph_part(membership.get("user"))
+        if not user_name:
+            continue
+        user_node_id = _ensure_user(user_name)
+        role_id = _ensure_role(role)
+        _add_rel_edge(graph, user_node_id, role_id, RelationshipType.MEMBER_OF, {"source": "snowflake-objects"})
+        _add_rel_edge(graph, user_node_id, role_id, RelationshipType.ASSUMES, {"source": "snowflake-objects"})
 
 
 _EXFIL_STAGE_SERVICE = {"aws": "s3", "azure": "blob", "gcp": "gcs"}

--- a/tests/test_snowflake_live_identity.py
+++ b/tests/test_snowflake_live_identity.py
@@ -1,0 +1,224 @@
+"""SHOW-based (zero-latency) Snowflake identity discovery + graph wiring.
+
+``ACCOUNT_USAGE.GRANTS_TO_*`` lags 45min-2h; the SHOW path reflects current
+state instantly. These tests drive a mock cursor through SHOW ROLES / SHOW
+GRANTS TO ROLE / SHOW GRANTS OF ROLE / SHOW USERS and assert the discovery
+payload + the USER/ROLE nodes, MEMBER_OF (user->role, role->role) and
+HAS_PERMISSION (role->sensitive table) edges the graph builds.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from agent_bom.graph.builder import build_unified_graph_from_report
+
+
+@pytest.fixture(autouse=True)
+def _stub_snowflake_connector(monkeypatch):
+    sf_pkg = sys.modules.get("snowflake") or types.ModuleType("snowflake")
+    connector = sys.modules.get("snowflake.connector") or types.ModuleType("snowflake.connector")
+    monkeypatch.setitem(sys.modules, "snowflake", sf_pkg)
+    monkeypatch.setitem(sys.modules, "snowflake.connector", connector)
+
+
+# Live account state (the just-created hierarchy that ACCOUNT_USAGE can't see),
+# mirroring the real ZV74085 fixture: ALICE_ANALYST / BOB_ENGINEER are *users*.
+#   ALICE_ANALYST (user) -> ANALYST       -> PII_READ  -> SELECT CUSTOMERS
+#   BOB_ENGINEER  (user) -> DATA_ENGINEER -> PII_WRITE -> INSERT/UPDATE CUSTOMERS
+#   DATA_ENGINEER (role) -> ANALYST   (role->role; the engineer also reads)
+_CUSTOMERS = "DB.PUBLIC.CUSTOMERS"
+# privileges each role holds: object grants + role->role USAGE (parents)
+_GRANTS_TO_ROLE: dict[str, list[tuple[str, str, str]]] = {
+    # role: [(privilege, granted_on, name), ...]
+    "PII_READ": [("SELECT", "TABLE", _CUSTOMERS)],
+    "PII_WRITE": [("INSERT", "TABLE", _CUSTOMERS), ("UPDATE", "TABLE", _CUSTOMERS)],
+    "ANALYST": [("USAGE", "ROLE", "PII_READ")],
+    "DATA_ENGINEER": [("USAGE", "ROLE", "PII_WRITE"), ("USAGE", "ROLE", "ANALYST")],
+}
+# who each role is granted to: (granted_to, grantee_name)
+_GRANTS_OF_ROLE: dict[str, list[tuple[str, str]]] = {
+    "ANALYST": [("USER", "ALICE_ANALYST"), ("ROLE", "DATA_ENGINEER")],
+    "DATA_ENGINEER": [("USER", "BOB_ENGINEER")],
+    "PII_READ": [("ROLE", "ANALYST")],
+    "PII_WRITE": [("ROLE", "DATA_ENGINEER")],
+}
+
+
+def _quoted_role(sql: str) -> str:
+    # SHOW GRANTS {TO,OF} ROLE "ROLE_NAME"
+    return sql.split('"')[1] if '"' in sql else ""
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.description: list | None = None
+        self._rows: list = []
+
+    def execute(self, sql, *_a, **_k):
+        s = " ".join(sql.split())
+        if s.startswith("SHOW ROLES"):
+            self.description = [("name",), ("owner",), ("comment",)]
+            self._rows = [(r, "USERADMIN", "") for r in _GRANTS_TO_ROLE]
+        elif s.startswith("SHOW GRANTS TO ROLE"):
+            role = _quoted_role(s)
+            self.description = [("privilege",), ("granted_on",), ("name",), ("grantee_name",)]
+            self._rows = [(p, g, n, role) for (p, g, n) in _GRANTS_TO_ROLE.get(role, [])]
+        elif s.startswith("SHOW GRANTS OF ROLE"):
+            role = _quoted_role(s)
+            self.description = [("role",), ("granted_to",), ("grantee_name",)]
+            self._rows = [(role, gt, gn) for (gt, gn) in _GRANTS_OF_ROLE.get(role, [])]
+        elif s.startswith("SHOW USERS"):
+            self.description = [("name",), ("default_role",), ("disabled",)]
+            self._rows = [("ALICE_ANALYST", "ANALYST", "false"), ("BOB_ENGINEER", "DATA_ENGINEER", "false")]
+        else:
+            self.description = []
+            self._rows = []
+
+    def fetchall(self):
+        return self._rows
+
+    def close(self):
+        pass
+
+
+class _FakeConn:
+    def cursor(self):
+        return _FakeCursor()
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def _live(monkeypatch):
+    from agent_bom.cloud import snowflake as sf
+
+    monkeypatch.setattr(sf, "_get_connection", lambda *a, **k: _FakeConn())
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "acct1")
+    return sf.discover_identity_live()
+
+
+# ── Discovery payload ────────────────────────────────────────────────────
+
+
+def test_status_ok_and_roles_users_discovered(_live) -> None:
+    assert _live["status"] == "ok"
+    role_names = {r["name"] for r in _live["roles"]}
+    assert {"ANALYST", "DATA_ENGINEER", "PII_READ", "PII_WRITE"} <= role_names
+    user_names = {u["name"] for u in _live["users"]}
+    assert {"ALICE_ANALYST", "BOB_ENGINEER"} <= user_names
+    assert next(u for u in _live["users"] if u["name"] == "ALICE_ANALYST")["default_role"] == "ANALYST"
+
+
+def test_object_grants_on_sensitive_table(_live) -> None:
+    grants = {(g["role"], g["privilege"], g["object_fqn"]) for g in _live["grants"]}
+    assert ("PII_READ", "SELECT", _CUSTOMERS) in grants
+    assert ("PII_WRITE", "INSERT", _CUSTOMERS) in grants
+    assert ("PII_WRITE", "UPDATE", _CUSTOMERS) in grants
+    # role->role USAGE must NOT leak into object grants
+    assert all(g["object_fqn"] == _CUSTOMERS for g in _live["grants"])
+
+
+def test_user_and_role_memberships(_live) -> None:
+    user_mem = {(m["user"], m["role"]) for m in _live["role_memberships"] if m.get("member_type") == "user"}
+    role_mem = {(m["role"], m["parent"]) for m in _live["role_memberships"] if m.get("member_type") == "role"}
+    assert ("ALICE_ANALYST", "ANALYST") in user_mem
+    assert ("BOB_ENGINEER", "DATA_ENGINEER") in user_mem
+    # child -> parent role memberships (both SHOW directions, deduped)
+    assert ("ANALYST", "PII_READ") in role_mem
+    assert ("DATA_ENGINEER", "PII_WRITE") in role_mem
+    assert ("DATA_ENGINEER", "ANALYST") in role_mem
+
+
+def test_no_account_is_graceful(monkeypatch) -> None:
+    from agent_bom.cloud import snowflake as sf
+
+    monkeypatch.delenv("SNOWFLAKE_ACCOUNT", raising=False)
+    assert sf.discover_identity_live()["status"] == "no_account"
+
+
+def test_per_role_failure_degrades_to_warning(monkeypatch) -> None:
+    from agent_bom.cloud import snowflake as sf
+
+    class _BoomCursor(_FakeCursor):
+        def execute(self, sql, *a, **k):
+            if "SHOW GRANTS TO ROLE" in sql and "PII_READ" in sql:
+                raise RuntimeError("insufficient privileges")
+            super().execute(sql, *a, **k)
+
+    class _BoomConn:
+        def cursor(self):
+            return _BoomCursor()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(sf, "_get_connection", lambda *a, **k: _BoomConn())
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "acct1")
+    res = sf.discover_identity_live()
+    assert res["status"] == "ok"  # never raises into the scan
+    assert any("PII_READ" in w for w in res["warnings"])
+
+
+# ── Merge: live overlay wins over lagged ACCOUNT_USAGE rows ──────────────
+
+
+def test_merge_prefers_live_and_unions(_live) -> None:
+    from agent_bom.cloud import snowflake as sf
+
+    lagged = {
+        "status": "ok",
+        "account": "acct1",
+        "objects": [],
+        "dependencies": [],
+        # stale grant for a role that no longer has it, plus a still-valid one
+        "grants": [{"role": "STALE_ROLE", "privilege": "SELECT", "object_fqn": _CUSTOMERS, "object_type": "table"}],
+        "role_memberships": [{"user": "OLD_USER", "role": "STALE_ROLE"}],
+    }
+    merged = sf.merge_live_identity_into_object_graph(lagged, _live)
+    grant_roles = {g["role"] for g in merged["grants"]}
+    assert "PII_READ" in grant_roles  # live in
+    assert "STALE_ROLE" in grant_roles  # lagged retained (union, not replace-all)
+    mem_users = {m.get("user") for m in merged["role_memberships"]}
+    assert "ALICE_ANALYST" in mem_users and "OLD_USER" in mem_users
+    assert {u["name"] for u in merged["users"]} >= {"ALICE_ANALYST", "BOB_ENGINEER"}
+
+
+# ── Graph build: USER/ROLE nodes + MEMBER_OF + HAS_PERMISSION ────────────
+
+
+def _graph(_live):
+    report = {"snowflake_object_graph": {**_live, "objects": [], "dependencies": []}}
+    g = build_unified_graph_from_report(report)
+    edges = list(g.edges.values()) if isinstance(g.edges, dict) else list(g.edges)
+    return g, edges
+
+
+def test_graph_user_and_role_nodes(_live) -> None:
+    g, _ = _graph(_live)
+    for role in ("ANALYST", "PII_READ", "PII_WRITE", "DATA_ENGINEER"):
+        assert f"role:snowflake:{role}" in g.nodes
+    assert "user:snowflake:ALICE_ANALYST" in g.nodes
+    assert "user:snowflake:BOB_ENGINEER" in g.nodes
+
+
+def test_graph_member_of_edges(_live) -> None:
+    g, edges = _graph(_live)
+    member_of = {(e.source, e.target) for e in edges if e.relationship.value == "member_of"}
+    # user -> role
+    assert ("user:snowflake:ALICE_ANALYST", "role:snowflake:ANALYST") in member_of
+    assert ("user:snowflake:BOB_ENGINEER", "role:snowflake:DATA_ENGINEER") in member_of
+    # role -> role (child assumes-member-of parent)
+    assert ("role:snowflake:ANALYST", "role:snowflake:PII_READ") in member_of
+    assert ("role:snowflake:DATA_ENGINEER", "role:snowflake:ANALYST") in member_of
+
+
+def test_graph_role_has_permission_on_sensitive_table(_live) -> None:
+    g, edges = _graph(_live)
+    has_perm = {(e.source, e.target) for e in edges if e.relationship.value == "has_permission"}
+    assert ("role:snowflake:PII_READ", f"data_store:snowflake:{_CUSTOMERS}") in has_perm
+    assert ("role:snowflake:PII_WRITE", f"data_store:snowflake:{_CUSTOMERS}") in has_perm


### PR DESCRIPTION
## Problem

The Snowflake object graph derives its CIEM identity layer (role grants, user/role memberships) from \`SNOWFLAKE.ACCOUNT_USAGE.GRANTS_TO_ROLES\` / \`GRANTS_TO_USERS\` and the role-membership views. Those views lag 45min-2h, so a freshly-created role hierarchy is **invisible on a live scan** until the lag clears.

## Change

Add \`discover_identity_live()\` driven entirely by current-state SHOW commands (zero latency, all read-only metadata):

- \`SHOW ROLES\` -> role list (iteration capped).
- per role: \`SHOW GRANTS TO ROLE "<role>"\` -> object privilege grants + role->role parents; \`SHOW GRANTS OF ROLE "<role>"\` -> who the role is granted to (users + child roles) = memberships.
- \`SHOW USERS\` -> user metadata only (name / default_role / disabled) — **no passwords or secrets**.

The payload reuses the \`discover_object_dependencies\` grant/membership shape; \`role_memberships\` gains an optional \`parent\`/\`member_type\` so role->role edges build too. \`merge_live_identity_into_object_graph()\` overlays the live data onto the lagged object graph, **preferring live** grants/memberships and carrying through live-only users (deduped). \`enrich_report_with_snowflake_estate()\` runs the overlay best-effort.

In the graph builder, the object-graph identity wiring now emits USER/ROLE nodes plus **MEMBER_OF** (user->role and role->role) and **HAS_PERMISSION** (role->object) edges, and ingests the live \`users[]\` list.

Read-only, control-plane only; per-role failures degrade to warnings; never raises into the scan. Role identifiers are safely quoted.

## Validation

- Unit tests: mock-cursor coverage for the discovery payload, merge precedence (live wins, lagged unioned), per-role-failure-to-warning, and the graph build (USER/ROLE nodes + MEMBER_OF + role->sensitive-table HAS_PERMISSION).
- \`ruff check\` / \`ruff format --check\` / \`mypy\` clean; full snowflake suite green (367 passed).
- Live validation against a real account confirmed a just-created hierarchy appears **immediately** with no ACCOUNT_USAGE lag: users ALICE_ANALYST/BOB_ENGINEER, roles ANALYST/DATA_ENGINEER/PII_READ/PII_WRITE, grants PII_READ SELECT CUSTOMERS and PII_WRITE INSERT/UPDATE CUSTOMERS, memberships ALICE_ANALYST->ANALYST, BOB_ENGINEER->DATA_ENGINEER, ANALYST->PII_READ, DATA_ENGINEER->PII_WRITE, and DATA_ENGINEER->ANALYST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)