### PR TITLE
fix(ci): monitor Smithery freshness via catalog API

### DIFF
--- a/.github/workflows/deployment-freshness.yml
+++ b/.github/workflows/deployment-freshness.yml
@@ -1,8 +1,8 @@
 name: Deployment Freshness
 
-# Checks that the protected Railway surface and the public marketplace/Smithery
-# surface serve the latest release and that the public endpoint is not auth-gated.
-# Runs daily and on-demand. Opens an issue if stale or misconfigured.
+# Checks that the protected Railway surface serves the latest release and that
+# the Smithery catalog listing is live with a non-empty tool inventory. Runs
+# daily and on-demand. Opens an issue if stale or misconfigured.
 
 on:
   schedule:
@@ -67,73 +67,72 @@ jobs:
             echo "stale=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Check public marketplace deployment
+      - name: Check Smithery catalog listing
         id: public
         continue-on-error: true
         env:
-          SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
+          SMITHERY_SERVER_QUALIFIED_NAME: ${{ vars.SMITHERY_SERVER_QUALIFIED_NAME }}
         run: |
-          if [ -z "${SMITHERY_MCP_URL:-}" ]; then
-            echo "::warning::SMITHERY_MCP_URL not configured — the public marketplace (Smithery) surface is UNMONITORED. A misconfiguration tracking issue will be opened."
-            echo "not_configured=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          QUALIFIED_NAME="${SMITHERY_SERVER_QUALIFIED_NAME:-agent-bom/agent-bom}"
+          RESPONSE=$(python3 - <<'PY'
+          import json
+          import os
+          import sys
+          import urllib.error
+          import urllib.parse
+          import urllib.request
 
-          DEPLOY_URL="${SMITHERY_MCP_URL}"
-          case "$DEPLOY_URL" in
-            https://server.smithery.ai/*|http://server.smithery.ai/*)
-              echo "public_version=invalid_smithery_proxy" >> "$GITHUB_OUTPUT"
-              echo "tool_count=unknown" >> "$GITHUB_OUTPUT"
-              echo "auth_required=unknown" >> "$GITHUB_OUTPUT"
-              echo "probe_failed=true" >> "$GITHUB_OUTPUT"
-              echo "::warning::SMITHERY_MCP_URL points at Smithery's hosted MCP proxy (${DEPLOY_URL}), which is OAuth-gated and does not expose agent-bom /health. Set SMITHERY_MCP_URL to the upstream public unauthenticated endpoint that serves /health."
-              exit 0
-              ;;
-          esac
-
-          RESPONSE=$(PYTHONPATH=src python3 -m agent_bom.deployment_probe \
-            --base-url "$DEPLOY_URL" \
-            --attempts 3 \
-            --backoff-seconds 5 \
-            --timeout 15 2>/dev/null || echo '{}')
-          DEPLOYED=$(echo "$RESPONSE" | python3 -c "
-          import sys, json
+          name = os.environ.get("SMITHERY_SERVER_QUALIFIED_NAME") or "agent-bom/agent-bom"
+          if "/" not in name:
+              print(json.dumps({"error": f"invalid Smithery qualified name: {name!r}"}))
+              sys.exit(1)
+          namespace, server = name.split("/", 1)
+          url = "https://api.smithery.ai/servers/" + urllib.parse.quote(namespace, safe="") + "/" + urllib.parse.quote(server, safe="")
+          req = urllib.request.Request(
+              url,
+              headers={"Accept": "application/json", "User-Agent": "agent-bom-deployment-freshness"},
+          )
           try:
-              data = json.load(sys.stdin)
-              print(data.get('version', 'unknown'))
-          except Exception:
-              print('unknown')
-          ")
-          TOOL_COUNT=$(echo "$RESPONSE" | python3 -c "
-          import sys, json
-          try:
-              data = json.load(sys.stdin)
-              print(data.get('tool_count', data.get('mcp_metrics', {}).get('tool_count', 'unknown')))
-          except Exception:
-              print('unknown')
-          ")
-          AUTH_REQUIRED=$(echo "$RESPONSE" | python3 -c "
-          import sys, json
-          try:
-              data = json.load(sys.stdin)
-              print('true' if data.get('auth_required') else 'false')
-          except Exception:
-              print('unknown')
-          ")
-          echo "public_version=$DEPLOYED" >> "$GITHUB_OUTPUT"
-          echo "tool_count=$TOOL_COUNT" >> "$GITHUB_OUTPUT"
-          echo "auth_required=$AUTH_REQUIRED" >> "$GITHUB_OUTPUT"
-          echo "Public marketplace version: $DEPLOYED (expected: ${{ steps.expected.outputs.version }})"
-          echo "Public marketplace tool count: $TOOL_COUNT"
-          echo "Public marketplace auth_required: $AUTH_REQUIRED"
-          if [ "$DEPLOYED" = "unknown" ]; then
+              with urllib.request.urlopen(req, timeout=15) as response:
+                  data = json.loads(response.read().decode("utf-8", errors="replace"))
+          except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+              print(json.dumps({"error": str(exc), "url": url}))
+              sys.exit(1)
+          tools = data.get("tools") if isinstance(data.get("tools"), list) else []
+          print(json.dumps({
+              "qualified_name": data.get("qualifiedName"),
+              "remote": bool(data.get("remote")),
+              "deployment_url": data.get("deploymentUrl") or "",
+              "tool_count": len(tools),
+          }, separators=(",", ":")))
+          PY
+          ) || {
+            echo "public_version=unreachable" >> "$GITHUB_OUTPUT"
+            echo "tool_count=unknown" >> "$GITHUB_OUTPUT"
+            echo "auth_required=smithery-oauth" >> "$GITHUB_OUTPUT"
             echo "probe_failed=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::Could not verify public marketplace version from $DEPLOY_URL"
-          elif [ "$AUTH_REQUIRED" = "true" ]; then
-            echo "auth_gate=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::Public marketplace endpoint is auth-gated"
-          elif [ "$DEPLOYED" != "${{ steps.expected.outputs.version }}" ]; then
-            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Could not verify Smithery catalog listing"
+            exit 0
+          }
+          STATE=$(echo "$RESPONSE" | EXPECTED_QUALIFIED_NAME="$QUALIFIED_NAME" python3 -c "
+          import json, os, sys
+          data = json.load(sys.stdin)
+          if data.get('qualified_name') != os.environ['EXPECTED_QUALIFIED_NAME'] or not data.get('remote') or not data.get('deployment_url') or int(data.get('tool_count') or 0) < 1:
+              print('invalid')
+          else:
+              print('catalog_live')
+          ")
+          TOOL_COUNT=$(echo "$RESPONSE" | python3 -c "import json, sys; print(json.load(sys.stdin).get('tool_count', 'unknown'))")
+          DEPLOY_URL=$(echo "$RESPONSE" | python3 -c "import json, sys; print(json.load(sys.stdin).get('deployment_url', 'unknown'))")
+          echo "public_version=$STATE" >> "$GITHUB_OUTPUT"
+          echo "tool_count=$TOOL_COUNT" >> "$GITHUB_OUTPUT"
+          echo "auth_required=smithery-oauth" >> "$GITHUB_OUTPUT"
+          echo "Smithery catalog state: $STATE"
+          echo "Smithery deployment URL: $DEPLOY_URL"
+          echo "Smithery tool count: $TOOL_COUNT"
+          if [ "$STATE" != "catalog_live" ]; then
+            echo "probe_failed=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Smithery catalog listing is missing remote deployment metadata or tools"
           fi
 
       - name: Open issue if deployment surfaces drift or public endpoint is misconfigured
@@ -163,7 +162,7 @@ jobs:
           | Railway (protected) | $RAILWAY | $EXPECTED | true | — |
           | Public marketplace | $PUBLIC | $EXPECTED | $PUBLIC_AUTH | $PUBLIC_TOOLS |
 
-          **Action**: Ensure Smithery points at a separate public unauthenticated endpoint, and re-run the relevant deployment or release workflow.
+          **Action**: Ensure the protected Railway deployment is fresh and the Smithery catalog API lists a remote deployment with tools, then re-run this workflow.
 
           This issue was auto-updated by the deployment-freshness workflow.
           EOF
@@ -182,7 +181,7 @@ jobs:
           | Railway (protected) | $RAILWAY | $EXPECTED | true | — |
           | Public marketplace | $PUBLIC | $EXPECTED | $PUBLIC_AUTH | $PUBLIC_TOOLS |
 
-          **Action**: Ensure Smithery points at a separate public unauthenticated endpoint, and re-run the relevant deployment or release workflow.
+          **Action**: Ensure the protected Railway deployment is fresh and the Smithery catalog API lists a remote deployment with tools, then re-run this workflow.
 
           This issue was auto-created by the deployment-freshness workflow.
           EOF
@@ -199,7 +198,7 @@ jobs:
             const labels = ["supply-chain-drift", "security-preventive", "automated"];
 
             const unmonitored = [
-              "**Smithery / public marketplace** — set repo variable `SMITHERY_MCP_URL` (public unauthenticated MCP endpoint). Without it the public surface is never freshness-checked, which is how the listing drifted for three months unnoticed.",
+              "**Smithery / public marketplace** — set repo variable `SMITHERY_SERVER_QUALIFIED_NAME` only if the listing is not `agent-bom/agent-bom`. The monitor checks Smithery's catalog API because Smithery-hosted remotes are OAuth-gated and do not expose agent-bom `/health`.",
             ];
 
             const body = [

--- a/.github/workflows/surface-freshness.yml
+++ b/.github/workflows/surface-freshness.yml
@@ -7,7 +7,7 @@ name: Surface Freshness
 # three months without an alert.
 #
 # Optional repo variables (Settings -> Secrets and variables -> Actions -> Variables):
-#   SMITHERY_MCP_URL   — public unauthenticated MCP endpoint (enables Smithery probe)
+#   SMITHERY_SERVER_QUALIFIED_NAME — override Smithery listing name; defaults to agent-bom/agent-bom
 #   GLAMA_LISTING_URL  — Glama public listing JSON endpoint (enables Glama probe)
 #   DOCKER_IMAGE       — override default ghcr.io/msaad00/agent-bom
 
@@ -37,7 +37,7 @@ jobs:
       - name: Probe every distribution surface
         id: probe
         env:
-          SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
+          SMITHERY_SERVER_QUALIFIED_NAME: ${{ vars.SMITHERY_SERVER_QUALIFIED_NAME }}
           GLAMA_LISTING_URL: ${{ vars.GLAMA_LISTING_URL }}
           DOCKER_IMAGE: ${{ vars.DOCKER_IMAGE }}
         run: |
@@ -81,7 +81,7 @@ jobs:
               "- `unmonitored (misconfigured)` — a required repo variable is unset, so this surface is NOT being watched. Set the named variable.",
               "- `unreachable` — the surface URL is configured but the probe failed (network / HTTP / parse).",
               "",
-              "Required repo variables for full coverage: `SMITHERY_MCP_URL`, `GLAMA_LISTING_URL`. PyPI and Docker need no configuration.",
+              "Required repo variables for full coverage: `GLAMA_LISTING_URL`. Smithery defaults to `agent-bom/agent-bom`; set `SMITHERY_SERVER_QUALIFIED_NAME` only if the listing name changes.",
               "",
               "_Maintained automatically by the surface-freshness workflow. Self-closes when every surface is fresh and monitored._",
             ].join("\n");

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -12,22 +12,24 @@ How to publish agent-bom to each MCP ecosystem platform.
 
 ## 1. Smithery
 
-Smithery requires a publicly accessible HTTP URL for the MCP server.
+Smithery runs agent-bom as a Smithery-managed remote MCP surface. Its public
+catalog API exposes the listing, deployment URL, and tool inventory; the remote
+transport itself is OAuth-gated by Smithery and does not expose agent-bom's raw
+`/health` route. Do not use `https://server.smithery.ai/.../mcp` as an upstream
+publish URL or health endpoint.
 
-### Step 1: Deploy SSE server
+### Step 1: Keep the protected MCP deployment healthy
 
-The SSE server is deployed on Railway at `https://agent-bom-mcp.up.railway.app` (automated via `deploy-mcp-sse.yml`).
-Secure remote deployments should set `AGENT_BOM_MCP_BEARER_TOKEN` in Railway service
-variables so the MCP transport can start with built-in Bearer auth. Keep TLS at your
-ingress or platform edge.
+The primary SSE/streamable-http server is deployed on Railway at
+`https://agent-bom-mcp.up.railway.app` (automated via `deploy-mcp-sse.yml`).
+Secure remote deployments should set `AGENT_BOM_MCP_BEARER_TOKEN` in Railway
+service variables so the MCP transport starts with built-in Bearer auth. Keep TLS
+at your ingress or platform edge.
 
-If you need a public unauthenticated registry/demo endpoint, treat that as a separate,
-explicitly less-trusted deployment surface rather than weakening the primary service.
-Release automation now requires that public endpoint to be set explicitly via
-`SMITHERY_MCP_URL`. It does not fall back to the protected Railway URL, and it
-must not be the Smithery hosted proxy URL (`https://server.smithery.ai/.../mcp`).
-The variable should be the upstream public origin whose `/health` response is
-agent-bom JSON with `version`, `auth_required=false`, and `tool_count`.
+The daily deployment-freshness workflow probes this protected Railway `/health`
+surface with the configured bearer token, and probes Smithery through
+`https://api.smithery.ai/servers/agent-bom/agent-bom` for catalog liveness,
+remote deployment metadata, and non-empty tools.
 
 ### Step 2: Publish to Smithery
 
@@ -35,24 +37,25 @@ agent-bom JSON with `version`, `auth_required=false`, and `tool_count`.
 1. Go to https://smithery.ai/servers/new
 2. Namespace: `agent-bom`
 3. Server ID: `agent-bom`
-4. MCP Server URL: your separate public unauthenticated endpoint, e.g. `https://agent-bom--agent-bom.run.tools`
+4. Follow Smithery's managed remote flow for the `agent-bom/agent-bom` listing.
 5. Click **Continue**
 
 **Option B — Automated**:
 The `publish-registries.yml` workflow auto-publishes to Smithery on each release using:
 - `SMITHERY_API_TOKEN`
-- `SMITHERY_MCP_URL`
 
-The release publish workflow probes the public endpoint as best-effort context
-because Smithery rebuilds asynchronously. The daily deployment and surface
-freshness workflows own drift detection and open issues when:
-- the endpoint is unreachable
-- the endpoint reports `auth_required=true`
-- the endpoint is otherwise unsuitable for public registry publishing
+`SMITHERY_MCP_URL` is retained only for the external-upstream publish mode. It
+must never point at Smithery's hosted proxy URL. Freshness monitoring no longer
+depends on that variable; it uses the Smithery catalog API directly.
 
 ### Verification
 
-After publishing, check: https://smithery.ai/server/agent-bom/agent-bom
+After publishing, check:
+
+```bash
+curl -fsSL https://api.smithery.ai/servers/agent-bom/agent-bom \
+  | jq '{qualifiedName, remote, deploymentUrl, tool_count: (.tools | length)}'
+```
 
 ---
 

--- a/scripts/check_surface_freshness.py
+++ b/scripts/check_surface_freshness.py
@@ -10,7 +10,7 @@ Surfaces probed:
     pypi      — https://pypi.org/pypi/agent-bom/json  -> info.version
     docker    — ghcr.io / Docker Hub latest tag       -> resolved via registry API
     glama     — public marketplace listing            -> scripts/check_glama_listing.py
-    smithery  — public MCP endpoint                    -> agent_bom.deployment_probe
+    smithery  — public Smithery catalog API            -> api.smithery.ai
 
 Each surface reports one of:
     fresh          — published version == expected
@@ -102,17 +102,16 @@ def _classify(name: str, published: str | None, expected: str, *, error: str | N
     return {"surface": name, "status": status, "version": published, "expected": expected}
 
 
-def _smithery_proxy_error(url: str) -> str | None:
-    """Return an actionable error when the configured URL is Smithery's proxy."""
+def _smithery_catalog_url(qualified_name: str) -> str:
+    """Return the public Smithery catalog API URL for ``namespace/server``."""
 
-    parsed = urllib.parse.urlsplit(url.strip())
-    if parsed.netloc.lower() == "server.smithery.ai":
-        return (
-            "SMITHERY_MCP_URL points at Smithery's hosted MCP proxy. Set it to "
-            "the upstream public unauthenticated endpoint that exposes /health, "
-            "not https://server.smithery.ai/.../mcp."
-        )
-    return None
+    name = qualified_name.strip()
+    if "/" not in name:
+        raise ValueError(f"invalid Smithery qualified name: {qualified_name!r}")
+    namespace, server = name.split("/", 1)
+    if not namespace or not server or "/" in server:
+        raise ValueError(f"invalid Smithery qualified name: {qualified_name!r}")
+    return f"https://api.smithery.ai/servers/{urllib.parse.quote(namespace, safe='')}/{urllib.parse.quote(server, safe='')}"
 
 
 def _parse_image_reference(image: str) -> tuple[str, str]:
@@ -230,50 +229,37 @@ def probe_glama(expected: str, **kw: Any) -> dict[str, Any]:
     }
 
 
-def probe_smithery(expected: str, url: str, **kw: Any) -> dict[str, Any]:
-    if not url:
-        return {
-            "surface": "Smithery",
-            "status": "not_configured",
-            "version": "—",
-            "expected": expected,
-            "error": "no SMITHERY_MCP_URL — set the repo variable to monitor this surface",
-        }
-    proxy_error = _smithery_proxy_error(url)
-    if proxy_error:
-        return {
-            "surface": "Smithery",
-            "status": "not_configured",
-            "version": "—",
-            "expected": expected,
-            "error": proxy_error,
-        }
+def probe_smithery(expected: str, qualified_name: str, **kw: Any) -> dict[str, Any]:
+    """Probe Smithery's public catalog listing.
+
+    Smithery-hosted remote servers are OAuth-gated and do not expose agent-bom's
+    raw `/health` route. Freshness for this surface is therefore the catalog
+    contract: the listing exists, is remote, has a deployment URL, and advertises
+    tools. Version freshness is covered by PyPI/Docker plus the protected Railway
+    health check.
+    """
+
     try:
-        proc = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "agent_bom.deployment_probe",
-                "--base-url",
-                url,
-                "--attempts",
-                str(kw.get("attempts", DEFAULT_ATTEMPTS)),
-                "--backoff-seconds",
-                str(kw.get("backoff", DEFAULT_BACKOFF)),
-                "--timeout",
-                str(kw.get("timeout", DEFAULT_TIMEOUT)),
-            ],
-            capture_output=True,
-            text=True,
-            env={**os.environ, "PYTHONPATH": str(ROOT / "src")},
-        )
-        if proc.returncode != 0:
-            error = (proc.stderr or proc.stdout or f"deployment_probe exited {proc.returncode}").strip()
-            return _classify("Smithery", None, expected, error=error)
-        data = json.loads(proc.stdout or "{}")
-        version = data.get("version")
-        return _classify("Smithery", version, expected)
-    except (json.JSONDecodeError, OSError, ValueError) as exc:
+        data = _http_json(_smithery_catalog_url(qualified_name), **kw)
+        tools = data.get("tools") if isinstance(data.get("tools"), list) else []
+        deployment_url = data.get("deploymentUrl")
+        if data.get("qualifiedName") != qualified_name:
+            return _classify("Smithery", "—", expected, error="catalog returned the wrong server")
+        if not data.get("remote"):
+            return _classify("Smithery", "—", expected, error="catalog listing is not marked remote")
+        if not deployment_url:
+            return _classify("Smithery", "—", expected, error="catalog listing has no deploymentUrl")
+        if not tools:
+            return _classify("Smithery", "—", expected, error="catalog listing has no tools")
+        return {
+            "surface": "Smithery",
+            "status": "fresh",
+            "version": "catalog-live",
+            "expected": expected,
+            "deployment_url": deployment_url,
+            "tool_count": len(tools),
+        }
+    except (RuntimeError, ValueError) as exc:
         return _classify("Smithery", None, expected, error=str(exc))
 
 
@@ -281,7 +267,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--expected", default=None, help="Override expected version (defaults to pyproject.toml).")
     parser.add_argument("--docker-image", default=os.environ.get("DOCKER_IMAGE", DEFAULT_DOCKER_IMAGE))
-    parser.add_argument("--smithery-url", default=os.environ.get("SMITHERY_MCP_URL", ""))
+    parser.add_argument("--smithery-server", default=os.environ.get("SMITHERY_SERVER_QUALIFIED_NAME", "agent-bom/agent-bom"))
     parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
     parser.add_argument("--attempts", type=int, default=DEFAULT_ATTEMPTS)
     parser.add_argument("--backoff-seconds", type=float, default=DEFAULT_BACKOFF)
@@ -295,7 +281,7 @@ def main(argv: list[str] | None = None) -> int:
         probe_pypi(expected, **kw),
         probe_docker(expected, args.docker_image, **kw),
         probe_glama(expected, **kw),
-        probe_smithery(expected, args.smithery_url, **kw),
+        probe_smithery(expected, args.smithery_server, **kw),
     ]
 
     drift = [s for s in surfaces if s["status"] in ALERT_STATUSES]

--- a/site-docs/integrations/smithery.md
+++ b/site-docs/integrations/smithery.md
@@ -5,11 +5,11 @@ This page documents the field-naming convention used by Smithery's session confi
 and how those values map to the environment variables the agent-bom MCP server
 actually reads.
 
-The manifest and release workflow are ready for Smithery publication, but the
-public catalog entry is only considered live after the Smithery release workflow
-successfully publishes against a public unauthenticated MCP endpoint. Until then,
-use Glama, OpenClaw, local `uvx agent-bom mcp server`, or your own Railway/Docker
-deployment as the active MCP surfaces.
+The manifest and release workflow are ready for Smithery publication. The public
+catalog entry is considered live when Smithery's catalog API lists
+`agent-bom/agent-bom` as a remote server with a deployment URL and non-empty tool
+inventory. Smithery-hosted remotes are OAuth-gated by Smithery, so they do not
+expose agent-bom's raw `/health` route.
 
 ## Why two naming conventions exist
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -355,13 +355,12 @@ def test_deployment_freshness_workflow_uses_bearer_token_and_parses_tool_count()
     """Deployment freshness should probe authenticated MCP health endpoints safely."""
     workflow = (ROOT / ".github" / "workflows" / "deployment-freshness.yml").read_text()
     assert "RAILWAY_MCP_BEARER_TOKEN" in workflow
-    assert "SMITHERY_MCP_URL" in workflow
+    assert "SMITHERY_SERVER_QUALIFIED_NAME" in workflow
+    assert "api.smithery.ai/servers" in workflow
     assert "python3 -m agent_bom.deployment_probe" in workflow
     assert "tool_count" in workflow
-    assert "auth_required" in workflow
+    assert "smithery-oauth" in workflow
     assert "probe_failed=true" in workflow
-    assert "server.smithery.ai" in workflow
-    assert "invalid_smithery_proxy" in workflow
     assert "steps.railway.outputs.probe_failed != 'true'" in workflow
     assert "--resolve-only" in workflow
 

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -41,16 +41,27 @@ def test_glama_listing_json_contract_reports_stale_listing(monkeypatch, capsys):
     assert "missing current Glama listing token" in payload["error"]
 
 
-def test_surface_freshness_classifies_smithery_proxy_url_as_misconfigured():
+def test_surface_freshness_reads_smithery_catalog_listing(monkeypatch):
     script = _load_script("check_surface_freshness.py")
 
-    result = script.probe_smithery("0.89.2", "https://server.smithery.ai/@agent-bom/agent-bom/mcp")
+    def fake_http_json(url, **_kwargs):
+        assert url == "https://api.smithery.ai/servers/agent-bom/agent-bom"
+        return {
+            "qualifiedName": "agent-bom/agent-bom",
+            "remote": True,
+            "deploymentUrl": "https://agent-bom--agent-bom.run.tools",
+            "tools": [{"name": "scan"}, {"name": "check"}],
+        }
+
+    monkeypatch.setattr(script, "_http_json", fake_http_json)
+
+    result = script.probe_smithery("0.89.2", "agent-bom/agent-bom", timeout=1, attempts=1, backoff=0)
 
     assert result["surface"] == "Smithery"
-    assert result["status"] == "not_configured"
-    assert result["version"] == "—"
-    assert "hosted MCP proxy" in result["error"]
-    assert "exposes /health" in result["error"]
+    assert result["status"] == "fresh"
+    assert result["version"] == "catalog-live"
+    assert result["deployment_url"] == "https://agent-bom--agent-bom.run.tools"
+    assert result["tool_count"] == 2
 
 
 def test_surface_freshness_reads_paginated_ghcr_tags(monkeypatch):


### PR DESCRIPTION
Summary
- Switch deployment freshness from raw Smithery /health probing to the Smithery catalog API contract.
- Keep Railway as the protected versioned health surface, and treat Smithery as catalog-live when the listing is remote with deploymentUrl and tools.
- Update surface freshness docs/tests so SMITHERY_MCP_URL proxy settings no longer create false drift.

Verification
- uv run pytest -q tests/test_surface_freshness.py tests/test_deployment.py -q
- uv run ruff check scripts/check_surface_freshness.py tests/test_surface_freshness.py tests/test_deployment.py
- PYTHONPATH=src python3 scripts/check_surface_freshness.py --expected 0.89.2 --smithery-server agent-bom/agent-bom --timeout 15 --attempts 1 --backoff-seconds 0
- ruby -ryaml -e "ARGV.each { |f| YAML.load_file(f); puts "#{f}: yaml ok" }" .github/workflows/deployment-freshness.yml .github/workflows/surface-freshness.yml
- git diff --check

Notes
- Live Smithery catalog probe returns catalog-live, deploymentUrl https://agent-bom--agent-bom.run.tools, tool_count 36.
- Full surface freshness still reports Glama stale at 0.88.4; that is a separate distribution-surface issue.

Fixes #3014