### PR TITLE
docs: four-cloud read-only connect quickstart (AWS/Azure/GCP/Snowflake)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ the credential environment names in reach, and the agents that can call it.
 | Supply chain | 15 package ecosystems (npm, PyPI, Maven, Go, Cargo, NuGet, Composer, RubyGems, conda, Hex, Pub, Swift, plus OS packages apk/deb/rpm) with OSV/GHSA enrichment, transitive resolution, and dependency-confusion detection |
 | Agents + MCP | MCP clients, servers, tools, transports, trust posture, and live introspection across 29 first-class client types |
 | AI models + datasets | Malicious-model detection via safe pickle-opcode disassembly (no deserialization), model/dataset cards, and PII/PHI dataset scanning |
-| Cloud estate | Read-only, gated asset inventory across AWS, Azure, and GCP plus AI/GPU provider posture and CIS benchmarks |
+| Cloud estate | Read-only, gated asset inventory across AWS, Azure, GCP, and Snowflake plus AI/GPU provider posture and CIS benchmarks. One connection model per cloud: a scoped read-only role and keyless/token auth — see [docs/CLOUD_CONNECT.md](docs/CLOUD_CONNECT.md) |
 | Identity (NHI) | Non-human identity discovery (Okta/Entra, gated), credential-expiry posture, and access-review recertification campaigns |
 | LLM cost | Spend forecasting, budget runway, chargeback/allocation, and seasonal-aware spend-anomaly detection |
 | Containers + IaC | Native OCI image parsing plus Dockerfile, Terraform, CloudFormation, Helm, and Kubernetes |
@@ -225,6 +225,7 @@ Screenshot capture rules and the full manifest live in
 | IaC scan | `agent-bom iac Dockerfile k8s/ infra/main.tf` | IaC findings and policy context |
 | Cloud posture check | `agent-bom cloud aws --cis` | runtime CIS posture evidence |
 | Cloud estate inventory | `agent-bom cloud inventory --provider aws` | read-only, gated asset inventory (AWS/Azure/GCP) |
+| Snowflake AI BOM + CIS | `agent-bom agents --snowflake` | Cortex agents, Snowpark apps, and CIS posture (read-only, key-pair) |
 | LLM cost forecast | `agent-bom cost forecast` | spend burn-rate, budget runway, and chargeback posture |
 | Non-human identity posture | `agent-bom identity credential-expiry` | expiring/overdue NHI credentials and access reviews |
 | CI gate | `uses: msaad00/agent-bom@v0.89.2` | SARIF, PR summary, optional code-scanning upload |
@@ -273,6 +274,81 @@ agent-bom proxy --no-isolate --policy policy.json --detect-credentials --block-u
 agent-bom proxy --sandbox-image ghcr.io/acme/mcp-runtime@sha256:<digest> \
   --sandbox-image-pin-policy enforce --block-undeclared -- npx @mcp/server-postgres
 ```
+
+## Connect a Cloud (Read-Only)
+
+`agent-bom` reads four clouds — **AWS, Azure, GCP, and Snowflake** — through one
+connection model. Every connector is **read-only, agentless, and keyless** by
+default: only control-plane `list`/`get` (or `SHOW`/`SELECT`) APIs, no writes, no
+secret values, no data leaves your account. Each connector is **opt-in and
+default-off**, gated by a per-provider env flag; with the flag unset, agent-bom
+does zero cloud network I/O.
+
+The *only* thing that differs per cloud is the line that mints the read-only
+role — because each platform's grant primitive is different. Everything else is
+identical: enable with `AGENT_BOM_<PROVIDER>_INVENTORY=1`, authenticate with the
+cloud's own identity (never a secret handed to agent-bom), get the same graph
+and findings out.
+
+| Cloud | Read-only grant | Keyless / token auth | Enable | Scan |
+|---|---|---|---|---|
+| AWS | `SecurityAudit` managed policy | profile / SSO / instance role (boto3 chain) | `AGENT_BOM_AWS_INVENTORY=1` | `agent-bom cloud aws` |
+| Azure | `Reader` (+ `Security Reader`) | `az login` / managed identity / cert SP | `AGENT_BOM_AZURE_INVENTORY=1` | `agent-bom cloud azure` |
+| GCP | impersonated read-only service account | ADC / `gcloud` / workload identity | `AGENT_BOM_GCP_INVENTORY=1` | `agent-bom cloud gcp` |
+| Snowflake | `ABOM_READONLY` role + key-pair user | RSA key-pair JWT (no password) | — | `agent-bom agents --snowflake` |
+
+```bash
+# AWS — attach SecurityAudit to the principal, then:
+export AGENT_BOM_AWS_INVENTORY=1
+export AWS_PROFILE=<readonly-profile>
+agent-bom cloud aws --cis
+
+# Azure — assign Reader (+ Security Reader), then:
+export AGENT_BOM_AZURE_INVENTORY=1
+az login
+agent-bom cloud azure --cis
+
+# GCP — grant a read-only SA and impersonate it (no key file):
+export AGENT_BOM_GCP_INVENTORY=1
+export AGENT_BOM_GCP_IMPERSONATE_SA=<sa-email>      # e.g. abom-readonly@<project-id>.iam.gserviceaccount.com
+gcloud auth application-default login
+agent-bom cloud gcp --project <project-id> --cis
+
+# Snowflake — create ABOM_READONLY + a key-pair user (see CLOUD_CONNECT.md), then:
+export SNOWFLAKE_ACCOUNT=<org-account>
+export SNOWFLAKE_USER=ABOM_SCANNER
+export SNOWFLAKE_AUTHENTICATOR=snowflake_jwt
+export SNOWFLAKE_PRIVATE_KEY_PATH=/path/to/abom_key.p8
+agent-bom agents --snowflake
+```
+
+A read-only **estate inventory** across the enabled clouds (reference only, no
+findings):
+
+```bash
+agent-bom cloud inventory --provider all        # or aws | azure | gcp
+```
+
+CIS misconfigurations and graph toxic-combinations converge into the same
+`Finding` stream and exit-code gate as package vulnerabilities, so a real
+exposure can fail a pipeline:
+
+```bash
+agent-bom agents --aws --azure --gcp --snowflake --fail-on-severity high
+agent-bom graph                                 # multi-hop exposure paths
+agent-bom identity credential-expiry            # non-human identity posture
+```
+
+The full grant templates, per-cloud permission catalogs, and the
+"why read-only is enough" rationale live in
+[docs/CLOUD_CONNECT.md](docs/CLOUD_CONNECT.md). agent-bom is a **scanner, not a
+platform** — it reads inventory and posture, normalizes it into one graph, and
+emits findings; it never writes, never reads secret contents, and never moves
+data out of your account.
+
+<!-- TODO: capture real (redacted) screenshot: cross-cloud security graph with AWS + Azure + GCP + Snowflake nodes and a multi-hop exposure path -->
+<!-- TODO: capture real (redacted) screenshot: findings table filtered to cloud CIS misconfigurations across the four providers -->
+<!-- TODO: capture real (redacted) screenshot: identity/CIEM path from a cloud principal to a sensitive data store -->
 
 ## Deploy In Your Boundary
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -50,6 +50,44 @@ docker compose -f deploy/docker-compose.pilot.yml up -d
 - Runtime proxy/gateway enforcement: [`MCP_SERVER.md`](MCP_SERVER.md) and the
   [runtime enforcement spread](../PROJECT_STRUCTURE.md#runtime-enforcement-spread)
 
+## Cloud / GRC — connect a cloud read-only
+
+You want estate inventory, CIS posture, and exposure paths across your clouds
+without granting write access. `agent-bom` reads **AWS, Azure, GCP, and
+Snowflake** through one connection model: a scoped read-only role per cloud,
+keyless or token auth, opt-in per provider. It never writes, reads no secret
+values, and moves no data out of your account.
+
+```bash
+# AWS — attach SecurityAudit, then:
+export AGENT_BOM_AWS_INVENTORY=1 AWS_PROFILE=<readonly-profile>
+agent-bom cloud aws --cis
+
+# Azure — assign Reader (+ Security Reader), then:
+export AGENT_BOM_AZURE_INVENTORY=1
+az login && agent-bom cloud azure --cis
+
+# GCP — impersonate a read-only service account (no key file):
+export AGENT_BOM_GCP_INVENTORY=1 AGENT_BOM_GCP_IMPERSONATE_SA=<sa-email>
+gcloud auth application-default login
+agent-bom cloud gcp --project <project-id> --cis
+
+# Snowflake — key-pair user with the ABOM_READONLY role (no password):
+export SNOWFLAKE_ACCOUNT=<org-account> SNOWFLAKE_USER=ABOM_SCANNER
+export SNOWFLAKE_AUTHENTICATOR=snowflake_jwt SNOWFLAKE_PRIVATE_KEY_PATH=/path/to/abom_key.p8
+agent-bom agents --snowflake
+
+# Cross-cloud estate inventory (reference only, no findings):
+agent-bom cloud inventory --provider all
+```
+
+- Full grant templates, per-cloud permission catalogs, and the read-only
+  rationale: [`CLOUD_CONNECT.md`](CLOUD_CONNECT.md)
+- CIS misconfigurations converge into findings and the exit-code gate:
+  `agent-bom agents --aws --azure --gcp --snowflake --fail-on-severity high`
+- Exposure paths and non-human identity posture: `agent-bom graph`,
+  `agent-bom identity credential-expiry`
+
 ## AI / agent developer — call it from an assistant
 
 You want strict-argument security tools your agent can call, and the ability to


### PR DESCRIPTION
## Summary

Refresh README and `docs/START_HERE.md` prose so they reflect the validated, read-only four-cloud capability — **AWS, Azure, GCP, and Snowflake** — and the actual auth/connection model. The docs previously undersold this (cloud-estate row listed only AWS/Azure/GCP; no quickstart for the one-model connect flow).

Markdown only. No code, no `deploy/**`, no `src/agent_bom/**` changes. `docs/CLOUD_CONNECT.md` is unchanged and now cross-linked from both surfaces (previously linked nowhere).

## Changes

- **README** — cloud-estate coverage row now states AWS + Azure + GCP + Snowflake with the one-model framing (scoped read-only role per cloud; only the grant primitive differs); added a **Connect a Cloud (Read-Only)** section with the per-cloud grant/auth/enable/scan table, a copy-paste quickstart per cloud, the estate-inventory command, and the converge-to-findings gate. Added a Snowflake AI BOM + CIS row to the Start Here table.
- **docs/START_HERE.md** — new **Cloud / GRC** persona path with the same per-cloud read-only connect flow, cross-linking `CLOUD_CONNECT.md`.
- Image placeholders left as `<!-- TODO: capture real (redacted) screenshot: ... -->` markers (graph, findings, identity path) — no fabricated image files.

## Honesty / redaction

- Read-only / agentless / keyless framing kept exactly as in `CLOUD_CONNECT.md`; scanner-not-platform positioning preserved. No overclaiming.
- All account/project/SA/Snowflake identifiers are placeholders (`<project-id>`, `<sa-email>`, `<org-account>`, `<readonly-profile>`). No real identifiers or keys.

## Verification

- Every CLI command/flag cited verified against `src/agent_bom/cli/`: `cloud aws|azure|gcp` (`--cis`, `--project`), `cloud inventory --provider all`, `agents --aws|--azure|--gcp|--snowflake`, `--fail-on-severity`, `graph`, `identity credential-expiry`; env flags `AGENT_BOM_{AWS,AZURE,GCP}_INVENTORY` and `AGENT_BOM_GCP_IMPERSONATE_SA`.
- `release-surface-consistency` pre-commit hook passes on README; internal doc links resolve.