### PR TITLE
fix(mcp): deterministic tool/skills surfaces for agent caching

### DIFF
--- a/src/agent_bom/mcp_tools/analysis.py
+++ b/src/agent_bom/mcp_tools/analysis.py
@@ -105,8 +105,8 @@ async def context_graph_impl(
             if node_id in graph.nodes:
                 paths = find_lateral_paths(graph, node_id, max_depth=depth)
         else:
-            for nid, node in graph.nodes.items():
-                if node.kind == NodeKind.AGENT:
+            for nid in sorted(graph.nodes.keys()):
+                if graph.nodes[nid].kind == NodeKind.AGENT:
                     paths.extend(find_lateral_paths(graph, nid, max_depth=depth))
 
         risks = compute_interaction_risks(graph)

--- a/src/agent_bom/mcp_tools/registry.py
+++ b/src/agent_bom/mcp_tools/registry.py
@@ -42,7 +42,7 @@ def registry_lookup_impl(
     servers = data.get("servers", {})
     search_lower = search_term.lower()
 
-    for key, entry in servers.items():
+    for key, entry in sorted(servers.items()):
         if search_lower in key.lower() or search_lower in entry.get("package", "").lower() or search_lower in entry.get("name", "").lower():
             return json.dumps(
                 {
@@ -148,7 +148,7 @@ async def marketplace_check_impl(
             registry = json.loads(data_raw)
             if isinstance(registry, dict):
                 servers = registry.get("servers", registry)
-                for _k, v in servers.items() if isinstance(servers, dict) else []:
+                for _k, v in sorted(servers.items()) if isinstance(servers, dict) else []:
                     pkgs = v.get("packages", [])
                     if name in pkgs or any(name in p for p in pkgs):
                         registry_verified = True

--- a/src/agent_bom/skills_catalog.py
+++ b/src/agent_bom/skills_catalog.py
@@ -39,5 +39,11 @@ def save_skills_catalog(data: dict[str, object], path: str | Path | None = None)
 
 
 def catalog_scan_timestamp() -> str:
-    """Return an ISO timestamp for catalog updates."""
+    """Return an ISO provenance timestamp for catalog updates.
+
+    This value is wall-clock and therefore NON-deterministic across runs. It
+    must only ever populate clearly-labelled provenance/metadata fields (e.g.
+    a ``scanned_at`` block) — never the deterministic findings payload, so that
+    two scans of the same skill produce byte-identical findings.
+    """
     return datetime.now(timezone.utc).isoformat()

--- a/src/agent_bom/skills_service.py
+++ b/src/agent_bom/skills_service.py
@@ -326,9 +326,13 @@ async def _build_skill_report_async(path: Path, *, intel_source: str | None = No
     return await asyncio.to_thread(_build_skill_report, path, intel_source=intel_source)
 
 
-def _catalog_entry_for_report(report: SkillFileReport) -> dict[str, object]:
-    """Convert a file report into a persistent catalog entry."""
-    timestamp = catalog_scan_timestamp()
+def _catalog_findings_for_report(report: SkillFileReport) -> dict[str, object]:
+    """Return the deterministic, timestamp-free findings payload for a report.
+
+    Two scans of the same skill must produce a byte-identical dict here. No
+    wall-clock value may appear in this payload — provenance timestamps live in
+    the separate ``scanned_at`` block built by :func:`_catalog_entry_for_report`.
+    """
     return {
         "path": str(report.path),
         "bundle": report.bundle.to_dict(),
@@ -338,9 +342,27 @@ def _catalog_entry_for_report(report: SkillFileReport) -> dict[str, object]:
         "provenance_status": report.provenance.get("status"),
         "findings": len(report.audit.findings),
         "threat_intel": report.threat_intel.to_dict() if report.threat_intel else None,
-        "updated_at": timestamp,
-        "last_seen": timestamp,
     }
+
+
+def _catalog_entry_for_report(report: SkillFileReport) -> dict[str, object]:
+    """Convert a file report into a persistent catalog entry.
+
+    The deterministic findings payload is kept byte-identical across runs;
+    non-deterministic provenance timestamps are isolated under ``scanned_at``.
+    """
+    timestamp = catalog_scan_timestamp()
+    entry = _catalog_findings_for_report(report)
+    entry["scanned_at"] = {"updated_at": timestamp, "last_seen": timestamp}
+    return entry
+
+
+def _prior_first_seen(entry: dict[str, object]) -> object:
+    """Extract a prior ``first_seen`` value from new or legacy catalog entries."""
+    scanned_at = entry.get("scanned_at")
+    if isinstance(scanned_at, dict) and scanned_at.get("first_seen"):
+        return scanned_at["first_seen"]
+    return entry.get("first_seen")
 
 
 def _persist_catalog(reports: list[SkillFileReport], catalog_path: str | Path | None) -> str | None:
@@ -355,7 +377,9 @@ def _persist_catalog(reports: list[SkillFileReport], catalog_path: str | Path | 
         prior = entries.get(stable_id)
         prior_dict = prior if isinstance(prior, dict) else {}
         current = _catalog_entry_for_report(report)
-        current["first_seen"] = prior_dict.get("first_seen") or current["last_seen"]
+        scanned_at = current["scanned_at"]
+        assert isinstance(scanned_at, dict)
+        scanned_at["first_seen"] = _prior_first_seen(prior_dict) or scanned_at["last_seen"]
         entries[stable_id] = current
     catalog["entries"] = entries
     return str(save_skills_catalog(catalog, catalog_path))
@@ -461,7 +485,9 @@ async def _rescan_skill_catalog_async(
         async with sem:
             report = await _build_skill_report_async(path, intel_source=intel_source)
         updated = _catalog_entry_for_report(report)
-        updated["first_seen"] = entry.get("first_seen") or updated["last_seen"]
+        scanned_at = updated["scanned_at"]
+        assert isinstance(scanned_at, dict)
+        scanned_at["first_seen"] = _prior_first_seen(entry) or scanned_at["last_seen"]
         serialized_entry = {
             "bundle_stable_id": stable_id,
             "path": path_str,
@@ -473,7 +499,7 @@ async def _rescan_skill_catalog_async(
             "provenance_status": report.provenance.get("status"),
             "threat_intel": report.threat_intel.to_dict() if report.threat_intel else None,
             "findings": len(report.audit.findings),
-            "last_seen": updated["last_seen"],
+            "scanned_at": {"last_seen": scanned_at["last_seen"]},
         }
         return stable_id, updated, serialized_entry
 
@@ -487,9 +513,17 @@ async def _rescan_skill_catalog_async(
             continue
 
         status = ThreatIntelStatus.UNAVAILABLE.value
+        last_seen = catalog_scan_timestamp()
         updated = dict(entry)
         updated["status"] = status
-        updated["last_seen"] = catalog_scan_timestamp()
+        prior_scanned = updated.get("scanned_at")
+        scanned_block = dict(prior_scanned) if isinstance(prior_scanned, dict) else {}
+        scanned_block["last_seen"] = last_seen
+        scanned_block.setdefault("first_seen", _prior_first_seen(entry) or last_seen)
+        updated["scanned_at"] = scanned_block
+        updated.pop("last_seen", None)
+        updated.pop("first_seen", None)
+        updated.pop("updated_at", None)
         updated_entries[stable_id] = updated
         serialized.append(
             {
@@ -503,7 +537,7 @@ async def _rescan_skill_catalog_async(
                 "provenance_status": entry.get("provenance_status"),
                 "threat_intel": entry.get("threat_intel"),
                 "findings": entry.get("findings", 0),
-                "last_seen": updated["last_seen"],
+                "scanned_at": {"last_seen": last_seen},
                 "error": "file not found",
             }
         )

--- a/tests/test_context_graph.py
+++ b/tests/test_context_graph.py
@@ -662,3 +662,57 @@ class TestIamRoleAgentEdges:
         # Both agents have an ATTACHED_TO edge from the shared role
         attached = [e for e in graph.edges if e.kind.value == "attached_to"]
         assert len(attached) == 2
+
+
+class TestLateralPathDeterminism:
+    """The multi-source lateral-path output order must be stable across runs so
+    AI agents can cache and chain on it (mirrors mcp_tools/analysis.py)."""
+
+    @staticmethod
+    def _collect_all_agent_paths(graph, depth: int = 4) -> list:
+        """Replicate the source-less branch of context_graph_impl."""
+        paths: list = []
+        for nid in sorted(graph.nodes.keys()):
+            if graph.nodes[nid].kind == NodeKind.AGENT:
+                paths.extend(find_lateral_paths(graph, nid, max_depth=depth))
+        return paths
+
+    def test_multi_source_path_order_is_stable_across_node_order(self):
+        agent_specs = [
+            ("agent-a", "shared-srv"),
+            ("agent-b", "shared-srv"),
+            ("agent-c", "shared-srv"),
+        ]
+        forward = [_agent(name=n, servers=[_server(name=s)]) for n, s in agent_specs]
+        reordered = [_agent(name=n, servers=[_server(name=s)]) for n, s in reversed(agent_specs)]
+
+        graph_a = build_context_graph(forward, [])
+        graph_b = build_context_graph(reordered, [])
+
+        paths_a = self._collect_all_agent_paths(graph_a)
+        paths_b = self._collect_all_agent_paths(graph_b)
+
+        order_a = [(p.source, p.target) for p in paths_a]
+        order_b = [(p.source, p.target) for p in paths_b]
+
+        assert order_a == order_b
+        # Two runs over the same graph must be byte-identical too.
+        assert order_a == [(p.source, p.target) for p in self._collect_all_agent_paths(graph_a)]
+
+    def test_serialized_output_is_byte_identical_across_runs(self):
+        import json
+
+        agents = [
+            _agent(name="agent-a", servers=[_server(name="shared-srv", env={"API_KEY": "x"})]),
+            _agent(name="agent-b", servers=[_server(name="shared-srv")]),
+            _agent(name="agent-c", servers=[_server(name="shared-srv")]),
+        ]
+        graph = build_context_graph(agents, [])
+
+        first = self._collect_all_agent_paths(graph)
+        second = self._collect_all_agent_paths(graph)
+
+        risks = compute_interaction_risks(graph)
+        out_first = json.dumps(to_serializable(graph, first, risks), default=str, sort_keys=True)
+        out_second = json.dumps(to_serializable(graph, second, risks), default=str, sort_keys=True)
+        assert out_first == out_second

--- a/tests/test_mcp_tool_impls.py
+++ b/tests/test_mcp_tool_impls.py
@@ -133,6 +133,52 @@ def test_registry_lookup_registry_error():
     assert "error" in data
 
 
+def test_registry_lookup_is_deterministic_across_registry_order():
+    """A substring query that matches several servers must return the same
+    entry regardless of dict-insertion order, so agents can cache the result."""
+    from agent_bom.mcp_tools.registry import registry_lookup_impl
+
+    def _entry(key: str) -> dict:
+        return {
+            "name": key,
+            "package": f"@scope/server-{key}",
+            "ecosystem": "npm",
+            "latest_version": "1.0.0",
+            "risk_level": "low",
+            "risk_justification": "",
+            "verified": True,
+            "tools": [],
+            "credential_env_vars": [],
+            "known_cves": [],
+            "category": "tools",
+            "license": "MIT",
+            "source_url": "",
+        }
+
+    # Both "server-alpha" and "server-beta" packages contain "server" — the
+    # query matches both, so iteration order would otherwise decide the winner.
+    names = ["beta", "gamma", "alpha"]
+    forward = {n: _entry(n) for n in names}
+    reordered = {n: _entry(n) for n in reversed(names)}
+
+    def _lookup(registry: dict) -> dict:
+        return json.loads(
+            registry_lookup_impl(
+                server_name="server",
+                package_name=None,
+                _get_registry_data=lambda: {"servers": registry},
+            )
+        )
+
+    first = _lookup(forward)
+    second = _lookup(reordered)
+    third = _lookup(forward)
+
+    assert first == second == third
+    # sorted() makes "alpha" the stable winner regardless of input order.
+    assert first["id"] == "alpha"
+
+
 @pytest.mark.asyncio
 async def test_marketplace_check_empty_package():
     from agent_bom.mcp_tools.registry import marketplace_check_impl

--- a/tests/test_skills_service.py
+++ b/tests/test_skills_service.py
@@ -9,7 +9,63 @@ from types import SimpleNamespace
 
 from agent_bom.skill_bundles import build_skill_bundle
 from agent_bom.skill_intel import ThreatIntelStatus
-from agent_bom.skills_service import _review_to_status, rescan_skill_catalog, scan_skill_targets
+from agent_bom.skills_service import (
+    _catalog_findings_for_report,
+    _review_to_status,
+    rescan_skill_catalog,
+    scan_skill_targets,
+)
+
+
+def _strip_provenance(entry: dict) -> dict:
+    """Drop the non-deterministic ``scanned_at`` provenance block."""
+    return {k: v for k, v in entry.items() if k != "scanned_at"}
+
+
+def test_catalog_findings_payload_is_deterministic_across_scans(tmp_path):
+    """Two scans of the same skill must produce byte-identical findings; only
+    the isolated ``scanned_at`` provenance block may differ run-to-run."""
+    skill_file = tmp_path / "CLAUDE.md"
+    skill_file.write_text("# Instructions\n\nUse OPENAI_API_KEY.\n")
+
+    catalog_a = tmp_path / "a.json"
+    catalog_b = tmp_path / "b.json"
+
+    report_a = scan_skill_targets([skill_file], catalog_path=catalog_a)
+    report_b = scan_skill_targets([skill_file], catalog_path=catalog_b)
+
+    bundle_id = build_skill_bundle(skill_file).stable_id
+    entry_a = json.loads(catalog_a.read_text())["entries"][bundle_id]
+    entry_b = json.loads(catalog_b.read_text())["entries"][bundle_id]
+
+    # Timestamps live in a clearly-separated provenance field.
+    assert "scanned_at" in entry_a
+    assert "updated_at" not in entry_a
+    assert "last_seen" not in entry_a
+
+    # The findings-critical payload is byte-identical across the two runs.
+    assert _strip_provenance(entry_a) == _strip_provenance(entry_b)
+
+    # The deterministic helper carries no wall-clock value at all.
+    findings = _catalog_findings_for_report(report_a.files[0])
+    assert "scanned_at" not in findings
+    assert json.dumps(findings, sort_keys=True, default=str) == json.dumps(
+        _catalog_findings_for_report(report_b.files[0]), sort_keys=True, default=str
+    )
+
+
+def test_rescan_serialized_findings_are_deterministic(tmp_path):
+    """Rescanning the same on-disk skill twice yields identical findings rows."""
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text("# Skill\nUse the filesystem server.\n")
+    catalog_path = tmp_path / "catalog.json"
+    scan_skill_targets([skill_file], catalog_path=catalog_path)
+
+    first = rescan_skill_catalog(catalog_path=catalog_path).to_dict()["entries"][0]
+    second = rescan_skill_catalog(catalog_path=catalog_path).to_dict()["entries"][0]
+
+    assert "scanned_at" in first
+    assert _strip_provenance(first) == _strip_provenance(second)
 
 
 def test_scan_skill_targets_records_summary_in_hmac_audit_chain(tmp_path):


### PR DESCRIPTION
## Problem

The MCP-tool and skills surfaces returned non-deterministic results: the same inputs could produce different outputs across runs, so an AI agent could not safely cache or chain on them.

## Fixes

1. **Registry lookup order** (`mcp_tools/registry.py`) — `registry_lookup` and `marketplace_check` returned the first dict-iteration match, so a substring query matching several servers could resolve to different entries as registry state/order changed. Both loops now iterate `sorted(servers.items())`, making the winner stable.

2. **Skill catalog timestamps in findings** (`skills_catalog.py`, `skills_service.py`) — wall-clock `updated_at`/`last_seen` timestamps were stamped directly into the catalog payload alongside the security findings, so two scans of the same skill produced different bytes. Timestamps are now isolated under a clearly-separated `scanned_at` provenance block; the deterministic findings payload (`status`, verdicts, finding count, threat intel) is byte-identical run-to-run. Catalog ordering already keys on the stable bundle id.

3. **Graph node iteration order** (`mcp_tools/analysis.py`) — the source-less branch of `context_graph` iterated `graph.nodes.items()`, leaking dict order into lateral-path output order. Now iterates `sorted(graph.nodes.keys())` for stable path order.

## Tests

- `test_registry_lookup_is_deterministic_across_registry_order` — same query over a reordered registry returns an identical entry.
- `test_catalog_findings_payload_is_deterministic_across_scans` / `test_rescan_serialized_findings_are_deterministic` — two scans/rescans of the same skill produce byte-identical findings; timestamps confined to `scanned_at`.
- `TestLateralPathDeterminism` — multi-source lateral-path order is stable across node insertion order and byte-identical across repeat runs.

## Validation

- `ruff check` + `mypy` clean on the 4 source files.
- `pytest -k "mcp or skill or registry or analysis or determinis"`: 1061 passed, 2 skipped.