### PR TITLE
feat(gateway): harden policy engine with fail-closed, quarantine, conditional access, plugins, and OCSF webhook interop

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -116,6 +116,12 @@ AGENT_BOM_GATEWAY_ALLOW_ANONYMOUS_AGENTS  # explicit opt-out (default OFF): allo
 AGENT_BOM_GATEWAY_ALLOW_INSECURE_NO_AUTH
 AGENT_BOM_GATEWAY_BEARER_TOKEN
 AGENT_BOM_GATEWAY_DETECT_VISUAL_LEAKS
+# fail-closed posture for the gateway policy engine (open|closed, default open): when closed, a missing/unloadable policy or evaluation error DENIES instead of default-allow; read in gateway_server.py via proxy_policy.resolve_fail_mode
+AGENT_BOM_GATEWAY_FAIL_MODE
+# optional SIEM/SOAR webhook URL (default unset = no-op): every deny/quarantine POSTs a normalized OCSF event with an idempotency key; failures never block the relay; read in proxy_policy.deliver_policy_webhook
+AGENT_BOM_POLICY_WEBHOOK_URL
+# optional bearer credential for AGENT_BOM_POLICY_WEBHOOK_URL (default unset); read in proxy_policy.deliver_policy_webhook
+AGENT_BOM_POLICY_WEBHOOK_TOKEN
 # opt-in anomaly-triggered gateway enforcement mode (off|warn|enforce)
 AGENT_BOM_GATEWAY_ANOMALY_ENFORCEMENT
 # opt-in drift-triggered gateway enforcement mode (off|warn|enforce)

--- a/src/agent_bom/gateway_policy_templates.py
+++ b/src/agent_bom/gateway_policy_templates.py
@@ -53,6 +53,45 @@ def baseline_gateway_rules() -> list[GatewayRule]:
     ]
 
 
+def conditional_access_rules() -> list[dict]:
+    """Return declarative, deterministic conditional-access rule examples.
+
+    These ride alongside the allow/deny rules and are consumed by the gateway's
+    conditional-access evaluator. Each rule carries a ``conditions`` block whose
+    constraints are ANDed; when the context does NOT satisfy them the rule's
+    ``action`` selects the verdict:
+
+    * ``"block"``/``"fail"`` → hard DENY
+    * ``"quarantine"``       → QUARANTINE (block the tool, flag + audit the agent)
+
+    The blocks are pure declarative data (no clock / random reads) so the same
+    request context always yields the same verdict — the engine injects ``now``.
+    """
+    return [
+        {
+            "id": "business-hours-only",
+            "description": "Sensitive tools may only run during UTC business hours on weekdays.",
+            "action": "block",
+            "conditions": {
+                "time_window": {"start": "08:00", "end": "20:00"},
+                "weekdays": [0, 1, 2, 3, 4],
+            },
+        },
+        {
+            "id": "quarantine-high-risk",
+            "description": "Quarantine (do not hard-deny) calls from sessions above the risk ceiling.",
+            "action": "quarantine",
+            "conditions": {"max_risk_score": 0.8},
+        },
+        {
+            "id": "require-mfa-context",
+            "description": "Require an asserted MFA context attribute for privileged tool calls.",
+            "action": "block",
+            "conditions": {"required_attributes": {"mfa": "true"}},
+        },
+    ]
+
+
 def baseline_gateway_policy(
     *,
     mode: GatewayBaselineMode = "audit",
@@ -111,5 +150,6 @@ __all__ = [
     "BASELINE_GATEWAY_SCHEMA_VERSION",
     "baseline_gateway_policy",
     "baseline_gateway_rules",
+    "conditional_access_rules",
     "render_gateway_baseline_policy",
 ]

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -58,7 +58,18 @@ from agent_bom.firewall import evaluate as evaluate_firewall_policy
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
 from agent_bom.langfuse_otel import set_langfuse_runtime_attributes
 from agent_bom.proxy import check_policy, is_tools_call, parse_jsonrpc, policy_subject_from_message
-from agent_bom.proxy_policy import check_policy_warning, summarize_policy_bundle
+from agent_bom.proxy_policy import (
+    DecisionContext,
+    GatewayDecision,
+    build_policy_ocsf_event,
+    check_policy_warning,
+    context_from_now,
+    deliver_policy_webhook,
+    evaluate_conditional_rules,
+    evaluate_policy_plugins,
+    resolve_fail_mode,
+    summarize_policy_bundle,
+)
 from agent_bom.runtime.graph_reachability import ReachabilityMap, load_reachability_map
 
 logger = logging.getLogger(__name__)
@@ -97,6 +108,8 @@ def _public_gateway_block_reason(policy_source: str) -> str:
         "identity_jit": "Gateway policy blocked this request",
         "firewall": "Inter-agent firewall blocked this request",
         "graph_reachability": "Graph reachability policy blocked this request",
+        "policy_plugin": "A gateway policy plugin blocked this request",
+        "fail_closed": "Gateway policy unavailable and fail-closed mode is active",
     }.get(policy_source, "Gateway policy blocked this request")
 
 
@@ -184,6 +197,19 @@ class GatewaySettings:
     # ("enforce") or flagged ("warn") at the gateway — isolating a compromised
     # or under-review agent without touching per-tool policy. Default "off".
     fleet_enforcement_mode: str = "off"
+    # Fail-closed posture for the policy engine. "open" (default) preserves
+    # today's behaviour: a missing/unloadable policy or an evaluation error
+    # degrades to default-allow. "closed" makes those paths DENY so a
+    # security-conscious operator never silently runs unprotected. Resolved from
+    # AGENT_BOM_GATEWAY_FAIL_MODE when left at the sentinel ``None``.
+    fail_mode: str | None = None
+    # SIEM/SOAR webhook for deny/quarantine OCSF events. Unset (default) is a
+    # no-op; when set, every DENY/QUARANTINE POSTs a normalized OCSF event with
+    # an idempotency key. Webhook failures NEVER block the relay (bounded
+    # retries + drop-with-warning). Resolved from AGENT_BOM_POLICY_WEBHOOK_URL /
+    # AGENT_BOM_POLICY_WEBHOOK_TOKEN when left as ``None``.
+    policy_webhook_url: str | None = None
+    policy_webhook_token: str | None = None
 
 
 def _agent_cost_anomaly(tenant_id: str, source_agent: str) -> tuple[bool, str]:
@@ -319,6 +345,41 @@ def _request_environment(request: Request) -> str:
     return (request.headers.get("x-agent-environment", "") or "").strip()[:60]
 
 
+def _request_risk_score(request: Request) -> float | None:
+    """Resolve a caller/proxy-asserted risk score for conditional-access gates.
+
+    Read from the ``x-agent-risk-score`` header (set by an upstream risk engine
+    or trust proxy). Absent/invalid → ``None`` so a min/max-risk condition that
+    requires a score simply does not match and the call is unaffected.
+    """
+    raw = (request.headers.get("x-agent-risk-score", "") or "").strip()
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+def _request_context_attributes(request: Request) -> dict[str, str]:
+    """Resolve required-context attributes for conditional-access gates.
+
+    Attributes arrive as ``x-agent-ctx-<name>`` headers (e.g.
+    ``x-agent-ctx-mfa: true``) so a policy can require ``{"mfa": "true"}``.
+    Bounded to keep the decision context small and deterministic.
+    """
+    attributes: dict[str, str] = {}
+    for header, value in request.headers.items():
+        lowered = header.lower()
+        if lowered.startswith("x-agent-ctx-"):
+            key = lowered[len("x-agent-ctx-") :]
+            if key:
+                attributes[key] = str(value).strip()[:200]
+        if len(attributes) >= 32:
+            break
+    return attributes
+
+
 def _request_cost_center(request: Request, message: dict[str, Any]) -> str:
     """Resolve the chargeback cost-center this call is allocated to.
 
@@ -360,6 +421,50 @@ def _emit_gateway_governance_event(event_type: str, *, tenant_id: str, subject_i
         emit_governance_event(event_type=event_type, tenant_id=tenant_id, source="gateway", subject_id=subject_id, payload=payload)
     except Exception:  # noqa: BLE001
         logger.debug("gateway governance webhook emit failed for %s", event_type, exc_info=True)
+
+
+async def _emit_policy_interop_event(
+    settings: GatewaySettings,
+    *,
+    decision: GatewayDecision,
+    reason: str,
+    ctx: DecisionContext,
+    policy_source: str,
+) -> None:
+    """Emit a normalized OCSF event for a DENY/QUARANTINE and POST it to the
+    configured SIEM/SOAR webhook (best-effort).
+
+    Determinism: the event id derives from the decision inputs (it doubles as
+    the webhook idempotency key), so a retried delivery never double-records
+    downstream. Webhook failures are bounded-retry + drop-with-warning inside
+    ``deliver_policy_webhook`` and run off the event loop, so they never block
+    or crash the relay.
+    """
+    if decision == GatewayDecision.ALLOW:
+        return
+    # Only build/emit when a webhook target is configured. The OCSF event is an
+    # interop artifact for SIEM/SOAR; it deliberately does NOT fan into the
+    # audit_sink so the existing audit-event stream (and its counts) are
+    # unchanged when no webhook is set — the default no-op posture.
+    webhook_url = settings.policy_webhook_url
+    if webhook_url is None:
+        webhook_url = os.environ.get("AGENT_BOM_POLICY_WEBHOOK_URL", "")
+    if not (webhook_url or "").strip():
+        return
+    try:
+        event = build_policy_ocsf_event(decision=decision, reason=reason, ctx=ctx, policy_source=policy_source)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("gateway OCSF event build failed: %s", _sanitize_for_log(exc))
+        return
+    try:
+        await asyncio.to_thread(
+            deliver_policy_webhook,
+            event,
+            url=settings.policy_webhook_url,
+            token=settings.policy_webhook_token,
+        )
+    except Exception as exc:  # noqa: BLE001 — webhook must never break the relay
+        logger.warning("gateway policy webhook dispatch error (event dropped, relay unaffected): %s", _sanitize_for_log(exc))
 
 
 class GatewayCircuitOpenError(RuntimeError):
@@ -794,12 +899,23 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
     upstream_caller = settings.upstream_caller or managed_upstream_relay
     assert upstream_caller is not None
     rate_limit_store = _build_gateway_rate_limit_store(settings)
+    # Fail-closed posture resolved once at build time. "closed" makes a
+    # missing/unloadable policy or an evaluation error DENY instead of silently
+    # degrading to default-allow. Default "open" preserves current behaviour.
+    resolved_fail_mode = resolve_fail_mode(settings.fail_mode)
+    fail_closed = resolved_fail_mode == "closed"
+    if fail_closed:
+        logger.info("gateway policy engine starting in fail-CLOSED mode: unloadable policy or evaluation errors will DENY")
     policy_state: dict[str, Any] = {
         "policy": dict(settings.policy),
         "source": str(settings.policy_path) if settings.policy_path else "inline",
         "last_loaded_at": None,
         "last_error": None,
         "last_mtime": None,
+        # True only when a file policy was configured but never successfully
+        # loaded. In fail-closed mode this makes the relay DENY rather than
+        # forward against the empty default policy.
+        "load_failed": settings.policy_path is not None,
     }
     policy_lock = asyncio.Lock()
     reload_task: asyncio.Task[None] | None = None
@@ -828,6 +944,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             policy_state["last_loaded_at"] = time.time()
             policy_state["last_error"] = None
             policy_state["last_mtime"] = mtime
+            policy_state["load_failed"] = False
         logger.info("gateway policy reloaded from %s", settings.policy_path)
         return True
 
@@ -1152,6 +1269,53 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         tenant_id = getattr(request.state, "tenant_id", None) or "default"
         async with policy_lock:
             current_policy = dict(policy_state["policy"])
+            policy_load_failed = bool(policy_state["load_failed"])
+
+        # Fail-closed posture: a configured file policy that never loaded means
+        # the relay would otherwise forward against an empty default-allow
+        # policy. In fail-closed mode that is a DENY instead — the gateway must
+        # not silently run unprotected. Fail-open keeps the legacy behaviour.
+        if fail_closed and policy_load_failed:
+            record_gateway_relay(upstream.name, "blocked")
+            fc_ctx = context_from_now(
+                tenant_id=tenant_id,
+                source_agent=ANONYMOUS,
+                tool_name=str((message.get("params") or {}).get("name") or message.get("method") or ""),
+                now=time.time(),
+                environment=_request_environment(request),
+                source_ip=_request_source_ip(request),
+            )
+            if settings.audit_sink is not None:
+                await settings.audit_sink(
+                    {
+                        "action": "gateway.policy_fail_closed",
+                        "upstream": upstream.name,
+                        "tenant_id": tenant_id,
+                        "reason": "policy unavailable; fail-closed mode denies",
+                    }
+                )
+            await _emit_policy_interop_event(
+                settings,
+                decision=GatewayDecision.DENY,
+                reason="policy unavailable; fail-closed mode denies",
+                ctx=fc_ctx,
+                policy_source="fail_closed",
+            )
+            return JSONResponse(
+                {
+                    "jsonrpc": "2.0",
+                    "id": message.get("id"),
+                    "error": {
+                        "code": -32001,
+                        "message": "Blocked by agent-bom gateway policy",
+                        "data": {
+                            "reason": "Gateway policy unavailable and fail-closed mode is active",
+                            "policy_source": "fail_closed",
+                        },
+                    },
+                },
+                status_code=200,
+            )
 
         # Caller-identity resolution with secure-by-default fail-closed posture.
         #
@@ -1540,9 +1704,14 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         if policy_subject:
             tool_name, arguments = policy_subject
             allowed, reason = check_policy(current_policy, tool_name, arguments)
-            # Per-tool identity scopes: a managed identity with a non-empty
-            # allowed_tools allowlist may only call tools in that list — the
-            # identity itself bounds authorization, independent of policy.
+            # Quarantine is the middle decision tier: the call is blocked from
+            # the sensitive tool but the agent is flagged + heavily audited
+            # rather than hard-denied. ``quarantine`` is only set by the
+            # conditional-access / plugin layers below; it stays False here so
+            # existing deny/allow behaviour is byte-for-byte unchanged when the
+            # new layers produce no opinion.
+            quarantine = False
+            quarantine_reason = ""
             policy_source = "file"
             if allowed:
                 try:
@@ -1727,6 +1896,51 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                                 "reason": reach_reason,
                             }
                         )
+            # Declarative conditional access + plugin policy evaluators. Both are
+            # deterministic: the decision context carries an injected ``now`` so
+            # the same (agent, tool, request) under the same policy always yields
+            # the same verdict (and the same OCSF event id). Conditional rules
+            # gate on time-window / weekday / risk-score / required attributes;
+            # plugins compose third-party evaluators. A QUARANTINE verdict blocks
+            # the sensitive tool but flags + heavily audits the agent instead of
+            # hard-denying. Evaluation errors honour the fail-mode posture:
+            # fail-closed turns an unexpected engine error into a DENY.
+            if allowed:
+                decision_now = time.time()
+                decision_ctx = context_from_now(
+                    tenant_id=tenant_id,
+                    source_agent=source_agent,
+                    tool_name=tool_name,
+                    now=decision_now,
+                    risk_score=_request_risk_score(request),
+                    environment=_request_environment(request),
+                    source_ip=_request_source_ip(request),
+                    attributes=_request_context_attributes(request),
+                )
+                try:
+                    cond_decision, cond_reason, _cond_rule = evaluate_conditional_rules(current_policy, decision_ctx)
+                    plugin_decision, plugin_reason, _plugin_name = evaluate_policy_plugins(decision_ctx, current_policy)
+                    eval_error = False
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("gateway conditional/plugin evaluation error: %s", _sanitize_for_log(exc))
+                    cond_decision = plugin_decision = GatewayDecision.ALLOW
+                    cond_reason = plugin_reason = ""
+                    eval_error = True
+                # Compose: DENY outranks QUARANTINE outranks ALLOW. Conditional
+                # rules win ties over plugins (an explicit policy deny is stronger
+                # than a third-party quarantine). A fail-closed eval error denies.
+                _rank = {GatewayDecision.ALLOW: 0, GatewayDecision.QUARANTINE: 1, GatewayDecision.DENY: 2}
+                if _rank[plugin_decision] > _rank[cond_decision]:
+                    composed, composed_reason, composed_source = plugin_decision, plugin_reason, "policy_plugin"
+                else:
+                    composed, composed_reason, composed_source = cond_decision, cond_reason, "conditional_access"
+                if eval_error and fail_closed:
+                    allowed, reason, policy_source = False, "policy evaluation error", "conditional_access"
+                elif composed == GatewayDecision.DENY:
+                    allowed, reason, policy_source = False, composed_reason, composed_source
+                elif composed == GatewayDecision.QUARANTINE:
+                    quarantine, quarantine_reason, policy_source = True, composed_reason, composed_source
+
             if not allowed:
                 record_gateway_relay(upstream.name, "blocked")
                 audit_event: dict[str, Any] = {
@@ -1741,6 +1955,20 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 }
                 if settings.audit_sink is not None:
                     await settings.audit_sink(audit_event)
+                await _emit_policy_interop_event(
+                    settings,
+                    decision=GatewayDecision.DENY,
+                    reason=reason,
+                    ctx=context_from_now(
+                        tenant_id=tenant_id,
+                        source_agent=source_agent,
+                        tool_name=tool_name,
+                        now=time.time(),
+                        environment=_request_environment(request),
+                        source_ip=_request_source_ip(request),
+                    ),
+                    policy_source=policy_source,
+                )
                 return JSONResponse(
                     {
                         "jsonrpc": "2.0",
@@ -1751,6 +1979,62 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                             "data": {
                                 "reason": _public_gateway_block_reason(policy_source),
                                 "policy_source": policy_source,
+                            },
+                        },
+                    },
+                    status_code=200,
+                    headers=rate_limit_headers or None,
+                )
+
+            if quarantine:
+                # QUARANTINE: block the sensitive tool but flag + heavily audit
+                # the agent rather than hard-deny. The client sees a structured,
+                # client-safe reason; the full reason + OCSF event stay in audit.
+                record_gateway_relay(upstream.name, "blocked")
+                if settings.audit_sink is not None:
+                    await settings.audit_sink(
+                        {
+                            "action": "gateway.policy_quarantined",
+                            "upstream": upstream.name,
+                            "tenant_id": tenant_id,
+                            "method": message.get("method"),
+                            "tool": tool_name,
+                            "reason": quarantine_reason,
+                            "source_agent": source_agent,
+                            "policy_source": policy_source,
+                        }
+                    )
+                _emit_gateway_governance_event(
+                    "policy.quarantined",
+                    tenant_id=tenant_id,
+                    subject_id=source_agent,
+                    payload={"source_agent": source_agent, "tool": tool_name, "reason": quarantine_reason, "policy_source": policy_source},
+                )
+                await _emit_policy_interop_event(
+                    settings,
+                    decision=GatewayDecision.QUARANTINE,
+                    reason=quarantine_reason,
+                    ctx=context_from_now(
+                        tenant_id=tenant_id,
+                        source_agent=source_agent,
+                        tool_name=tool_name,
+                        now=time.time(),
+                        environment=_request_environment(request),
+                        source_ip=_request_source_ip(request),
+                    ),
+                    policy_source=policy_source,
+                )
+                return JSONResponse(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": message.get("id"),
+                        "error": {
+                            "code": -32002,  # Application-defined: quarantined
+                            "message": "Quarantined by agent-bom gateway policy",
+                            "data": {
+                                "reason": "Agent quarantined: this tool is restricted while the session is under review",
+                                "policy_source": policy_source,
+                                "decision": "quarantine",
                             },
                         },
                     },

--- a/src/agent_bom/proxy_policy.py
+++ b/src/agent_bom/proxy_policy.py
@@ -2,8 +2,17 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
+import os
+import random
 import re
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Callable
 from urllib.parse import urlparse
 
 from agent_bom.permissions import classify_tool
@@ -351,3 +360,541 @@ def check_policy_warning(policy: dict, tool_name: str, arguments: dict) -> tuple
     if allowed:
         return False, "", None
     return True, reason, rule_id
+
+
+# ─── Gateway policy-engine hardening ───────────────────────────────────────
+# Three-tier decision state, declarative conditional access, an entry-points
+# plugin registry for custom evaluators, and a deterministic OCSF event +
+# SIEM/SOAR webhook fan-out. All of this is reused by the gateway relay; it is
+# deterministic by construction (no inline clock / random in decision logic —
+# the caller injects ``now``) so the same (agent, tool, request) under the same
+# policy always yields the same decision and the same event id.
+
+
+class GatewayDecision(str, Enum):
+    """Three-tier gateway verdict. ``QUARANTINE`` sits between allow and deny:
+
+    the call is blocked from the sensitive tool but the agent/session is flagged
+    and heavily audited rather than hard-denied, so an operator can isolate a
+    suspect agent while still observing it.
+    """
+
+    ALLOW = "allow"
+    QUARANTINE = "quarantine"
+    DENY = "deny"
+
+
+# Env knobs (read by the gateway, surfaced here so the contract lives with the
+# engine). Defaults preserve current behaviour: fail-open, no webhook.
+GATEWAY_FAIL_MODE_ENV = "AGENT_BOM_GATEWAY_FAIL_MODE"
+POLICY_WEBHOOK_URL_ENV = "AGENT_BOM_POLICY_WEBHOOK_URL"
+POLICY_WEBHOOK_TOKEN_ENV = "AGENT_BOM_POLICY_WEBHOOK_TOKEN"
+POLICY_PLUGINS_ENTRY_POINT_GROUP = "agent_bom.gateway_policy_evaluators"
+_MAX_POLICY_PLUGINS = 32
+
+
+def resolve_fail_mode(explicit: str | None = None) -> str:
+    """Return ``"open"`` or ``"closed"`` for the missing/unloadable-policy path.
+
+    Precedence: an explicit caller value, then ``AGENT_BOM_GATEWAY_FAIL_MODE``,
+    then the secure-compatible default ``"open"`` (unchanged behaviour). Any
+    unrecognised value falls back to ``"open"`` with a warning so a typo never
+    silently fails the whole relay closed.
+    """
+    raw = (explicit if explicit is not None else os.environ.get(GATEWAY_FAIL_MODE_ENV, "")).strip().lower()
+    if not raw:
+        return "open"
+    if raw in ("open", "closed"):
+        return raw
+    logger.warning("Unrecognised gateway fail mode %r; defaulting to 'open'", raw)
+    return "open"
+
+
+@dataclass(frozen=True)
+class DecisionContext:
+    """Deterministic inputs for one gateway decision.
+
+    ``now`` is injected (epoch seconds) so events are reproducible — decision
+    logic never calls ``time.time()`` / ``datetime.now()`` itself. ``risk_score``
+    and ``attributes`` feed conditional-access gates; all are optional so a
+    default context reproduces today's behaviour.
+    """
+
+    tenant_id: str = "default"
+    source_agent: str = ""
+    tool_name: str = ""
+    now: float = 0.0
+    risk_score: float | None = None
+    weekday: int | None = None  # 0=Monday … 6=Sunday (UTC), injected for determinism
+    minute_of_day: int | None = None  # 0..1439 (UTC)
+    environment: str = ""
+    source_ip: str = ""
+    attributes: dict[str, str] = field(default_factory=dict)
+
+
+def context_from_now(
+    *,
+    tenant_id: str = "default",
+    source_agent: str = "",
+    tool_name: str = "",
+    now: float,
+    risk_score: float | None = None,
+    environment: str = "",
+    source_ip: str = "",
+    attributes: dict[str, str] | None = None,
+) -> DecisionContext:
+    """Build a :class:`DecisionContext`, deriving weekday / minute-of-day from
+    the injected ``now`` so the time-window gate is deterministic for a fixed
+    timestamp (UTC). Callers pass a stable ``now`` instead of letting the engine
+    read the clock."""
+    moment = datetime.fromtimestamp(now, tz=timezone.utc)
+    return DecisionContext(
+        tenant_id=tenant_id,
+        source_agent=source_agent,
+        tool_name=tool_name,
+        now=now,
+        risk_score=risk_score,
+        weekday=moment.weekday(),
+        minute_of_day=moment.hour * 60 + moment.minute,
+        environment=environment,
+        source_ip=source_ip,
+        attributes=dict(attributes or {}),
+    )
+
+
+def _coerce_minute(value: Any) -> int | None:
+    """Parse ``"HH:MM"`` or an int minute-of-day; return None when unset/invalid."""
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value if 0 <= value <= 1439 else None
+    text = str(value).strip()
+    if ":" in text:
+        try:
+            hh, mm = text.split(":", 1)
+            minute = int(hh) * 60 + int(mm)
+        except ValueError:
+            return None
+        return minute if 0 <= minute <= 1439 else None
+    try:
+        minute = int(text)
+    except ValueError:
+        return None
+    return minute if 0 <= minute <= 1439 else None
+
+
+def evaluate_conditions(conditions: dict[str, Any], ctx: DecisionContext) -> tuple[bool, str]:
+    """Evaluate a declarative conditional-access block against the context.
+
+    Returns ``(satisfied, reason)``. When ``satisfied`` is False the rule's
+    condition gate is not met and the call should be quarantined/denied per the
+    rule action. Supported keys (all optional, ANDed, deterministic):
+
+    * ``time_window``: ``{"start": "HH:MM", "end": "HH:MM"}`` (UTC, inclusive
+      start, exclusive end; wrap-around windows where start > end are allowed).
+    * ``weekdays``: list of allowed weekday ints (0=Mon … 6=Sun, UTC).
+    * ``min_risk_score`` / ``max_risk_score``: numeric bounds on ``risk_score``.
+    * ``required_attributes``: ``{key: expected}`` — every key must match
+      ``ctx.attributes`` (string-compared).
+
+    An empty / non-dict block is satisfied (no constraint), preserving the
+    behaviour of rules that carry no conditions.
+    """
+    if not isinstance(conditions, dict) or not conditions:
+        return True, ""
+
+    window = conditions.get("time_window")
+    if isinstance(window, dict) and ctx.minute_of_day is not None:
+        start = _coerce_minute(window.get("start"))
+        end = _coerce_minute(window.get("end"))
+        if start is not None and end is not None:
+            minute = ctx.minute_of_day
+            in_window = (start <= minute < end) if start <= end else (minute >= start or minute < end)
+            if not in_window:
+                return False, "request outside the permitted time window"
+
+    weekdays = conditions.get("weekdays")
+    if isinstance(weekdays, list) and weekdays and ctx.weekday is not None:
+        allowed_days = {int(d) for d in weekdays if isinstance(d, (int, float))}
+        if allowed_days and ctx.weekday not in allowed_days:
+            return False, "request on a day outside the permitted weekday window"
+
+    min_risk = conditions.get("min_risk_score")
+    if isinstance(min_risk, (int, float)):
+        if ctx.risk_score is None or ctx.risk_score < min_risk:
+            return False, f"risk score below required minimum {min_risk}"
+
+    max_risk = conditions.get("max_risk_score")
+    if isinstance(max_risk, (int, float)):
+        if ctx.risk_score is not None and ctx.risk_score > max_risk:
+            return False, f"risk score above permitted maximum {max_risk}"
+
+    required = conditions.get("required_attributes")
+    if isinstance(required, dict) and required:
+        for key, expected in required.items():
+            if str(ctx.attributes.get(str(key), "")) != str(expected):
+                return False, f"required context attribute '{key}' not satisfied"
+
+    return True, ""
+
+
+def evaluate_conditional_rules(policy: dict, ctx: DecisionContext) -> tuple[GatewayDecision, str, str | None]:
+    """Apply conditional-access rules to a decision context.
+
+    A rule participates when it carries a ``conditions`` block; its ``action``
+    selects the verdict when the conditions are NOT satisfied:
+
+    * ``action: "block"``/``"fail"`` → :data:`GatewayDecision.DENY`
+    * ``action: "quarantine"``       → :data:`GatewayDecision.QUARANTINE`
+
+    The first unsatisfied conditional rule wins (deny outranks quarantine when a
+    deny rule is encountered first). Returns ``(ALLOW, "", None)`` when every
+    conditional rule is satisfied (or none are present).
+    """
+    rules = policy.get("rules", [])
+    if not isinstance(rules, list):
+        return GatewayDecision.ALLOW, "", None
+    for raw_rule in rules:
+        if not isinstance(raw_rule, dict):
+            continue
+        conditions = raw_rule.get("conditions")
+        if not isinstance(conditions, dict) or not conditions:
+            continue
+        scope_tool = raw_rule.get("tool_name")
+        if scope_tool and scope_tool != ctx.tool_name:
+            continue
+        satisfied, reason = evaluate_conditions(conditions, ctx)
+        if satisfied:
+            continue
+        rule_id = str(raw_rule.get("id", "?"))
+        action = str(raw_rule.get("action", "block")).lower()
+        if action == "quarantine":
+            return GatewayDecision.QUARANTINE, f"{reason} (rule '{rule_id}')", rule_id
+        return GatewayDecision.DENY, f"{reason} (rule '{rule_id}')", rule_id
+    return GatewayDecision.ALLOW, "", None
+
+
+# ─── Plugin policy/detector registry (entry-points) ────────────────────────
+
+
+@dataclass(frozen=True)
+class PluginDecision:
+    """Verdict returned by a third-party policy evaluator plugin."""
+
+    decision: GatewayDecision
+    reason: str = ""
+
+
+# A plugin evaluator is ``Callable[[DecisionContext, dict], PluginDecision|None]``
+# where the dict is the active policy. Returning ``None`` / ALLOW means "no
+# opinion". Plugins are discovered via the ``agent_bom.gateway_policy_evaluators``
+# entry-point group (opt-in through AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS, the
+# same switch the rest of the project uses) and any plugin that raises is
+# isolated — logged and skipped — never fatal to the relay.
+PolicyEvaluator = Callable[[DecisionContext, dict], "PluginDecision | None"]
+
+_REGISTERED_EVALUATORS: dict[str, PolicyEvaluator] = {}
+_ENTRYPOINT_EVALUATORS_LOADED = False
+_EVALUATOR_WARNINGS: list[str] = []
+
+
+def register_policy_evaluator(name: str, evaluator: PolicyEvaluator) -> None:
+    """Register a custom policy evaluator in-process (tests / embedding)."""
+    _REGISTERED_EVALUATORS[name] = evaluator
+
+
+def _load_entrypoint_evaluators() -> None:
+    global _ENTRYPOINT_EVALUATORS_LOADED
+    if _ENTRYPOINT_EVALUATORS_LOADED:
+        return
+    _ENTRYPOINT_EVALUATORS_LOADED = True
+    try:
+        from agent_bom.extensions import (
+            entrypoint_extensions_enabled,
+            iter_entry_point_registrations,
+            sanitize_registry_warning,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("policy evaluator entry-point discovery unavailable: %s", exc)
+        return
+    if not entrypoint_extensions_enabled():
+        return
+
+    def _coerce(value: Any, entry_point_name: str) -> tuple[str, PolicyEvaluator]:
+        name = str(getattr(value, "name", entry_point_name)).strip() or entry_point_name
+        evaluator = getattr(value, "evaluate", value)
+        if not callable(evaluator):
+            raise ValueError(f"policy evaluator '{name}' is not callable")
+        return name, evaluator
+
+    try:
+        registrations = iter_entry_point_registrations(
+            group=POLICY_PLUGINS_ENTRY_POINT_GROUP,
+            coerce=_coerce,
+            warnings=_EVALUATOR_WARNINGS,
+            max_entry_points=_MAX_POLICY_PLUGINS,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _EVALUATOR_WARNINGS.append(sanitize_registry_warning(f"policy evaluator discovery failed: {exc}"))
+        return
+    for name, evaluator in registrations:
+        _REGISTERED_EVALUATORS.setdefault(name, evaluator)
+
+
+def evaluate_policy_plugins(ctx: DecisionContext, policy: dict) -> tuple[GatewayDecision, str, str | None]:
+    """Compose all registered policy-evaluator plugins into one verdict.
+
+    Each plugin is isolated: a raising plugin is logged and skipped (fail-safe),
+    never fatal. DENY outranks QUARANTINE outranks ALLOW; the strictest verdict
+    across plugins wins, with the first plugin producing that verdict named.
+    """
+    _load_entrypoint_evaluators()
+    if not _REGISTERED_EVALUATORS:
+        return GatewayDecision.ALLOW, "", None
+    worst = GatewayDecision.ALLOW
+    worst_reason = ""
+    worst_name: str | None = None
+    _rank = {GatewayDecision.ALLOW: 0, GatewayDecision.QUARANTINE: 1, GatewayDecision.DENY: 2}
+    for name in sorted(_REGISTERED_EVALUATORS):
+        evaluator = _REGISTERED_EVALUATORS[name]
+        try:
+            verdict = evaluator(ctx, policy)
+        except Exception as exc:  # noqa: BLE001 — isolate a misbehaving plugin
+            logger.warning("policy evaluator plugin %r raised and was skipped: %s", name, exc)
+            continue
+        if verdict is None:
+            continue
+        decision = verdict.decision if isinstance(verdict, PluginDecision) else GatewayDecision.ALLOW
+        if _rank.get(decision, 0) > _rank[worst]:
+            worst = decision
+            worst_reason = verdict.reason if isinstance(verdict, PluginDecision) else ""
+            worst_name = name
+    return worst, worst_reason, worst_name
+
+
+def policy_evaluator_warnings() -> list[str]:
+    """Return sanitized non-fatal plugin discovery warnings."""
+    _load_entrypoint_evaluators()
+    return list(_EVALUATOR_WARNINGS)
+
+
+def _reset_policy_evaluators_for_tests() -> None:
+    global _ENTRYPOINT_EVALUATORS_LOADED
+    _REGISTERED_EVALUATORS.clear()
+    _EVALUATOR_WARNINGS.clear()
+    _ENTRYPOINT_EVALUATORS_LOADED = False
+
+
+# ─── Deterministic OCSF event + SIEM/SOAR webhook fan-out ──────────────────
+
+# OCSF Detection Finding (class_uid 2004) severity ids.
+_OCSF_DECISION_SEVERITY = {
+    GatewayDecision.DENY: (5, "Critical"),
+    GatewayDecision.QUARANTINE: (4, "High"),
+    GatewayDecision.ALLOW: (1, "Informational"),
+}
+
+
+def policy_event_id(
+    *,
+    tenant_id: str,
+    source_agent: str,
+    tool_name: str,
+    decision: GatewayDecision,
+    reason: str,
+    now: float,
+) -> str:
+    """Derive a stable, deterministic event id from the decision inputs.
+
+    Same (tenant, agent, tool, decision, reason, now) → same id, every time.
+    This is also the webhook idempotency key, so a retried delivery never
+    double-records downstream. No ``uuid4()`` / ``random`` — pure hash of inputs.
+    """
+    digest = hashlib.sha256(
+        "\x1f".join(
+            (
+                tenant_id,
+                source_agent,
+                tool_name,
+                decision.value,
+                reason,
+                repr(now),
+            )
+        ).encode("utf-8")
+    ).hexdigest()
+    return f"gwpol-{digest[:32]}"
+
+
+def build_policy_ocsf_event(
+    *,
+    decision: GatewayDecision,
+    reason: str,
+    ctx: DecisionContext,
+    policy_source: str = "gateway",
+    product_version: str = "0.0.0",
+    event_id: str | None = None,
+) -> dict[str, Any]:
+    """Build a normalized OCSF Detection Finding for a deny/quarantine.
+
+    Deterministic: the ``time`` field and ``uid`` derive from the injected
+    ``ctx.now`` rather than the wall clock, so the same decision reproduces an
+    identical event (verified by the determinism test).
+    """
+    severity_id, severity_name = _OCSF_DECISION_SEVERITY.get(decision, (1, "Informational"))
+    uid = event_id or policy_event_id(
+        tenant_id=ctx.tenant_id,
+        source_agent=ctx.source_agent,
+        tool_name=ctx.tool_name,
+        decision=decision,
+        reason=reason,
+        now=ctx.now,
+    )
+    finding = {
+        "activity_id": 1,
+        "activity_name": "Create",
+        "category_uid": 2,
+        "category_name": "Findings",
+        "class_uid": 2004,
+        "class_name": "Detection Finding",
+        "type_uid": 200401,
+        "type_name": "Detection Finding: Create",
+        "severity_id": severity_id,
+        "severity": severity_name,
+        "time": int(ctx.now * 1000),
+        "finding_info": {
+            "title": f"Gateway policy {decision.value}",
+            "desc": reason or f"Gateway policy {decision.value}",
+            "types": [policy_source],
+            "uid": uid,
+        },
+        "evidences": [
+            {
+                "data": json.dumps(
+                    {
+                        "tenant_id": ctx.tenant_id,
+                        "source_agent": ctx.source_agent,
+                        "tool_name": ctx.tool_name,
+                        "decision": decision.value,
+                        "policy_source": policy_source,
+                        "environment": ctx.environment,
+                    },
+                    sort_keys=True,
+                )
+            }
+        ],
+        "metadata": {
+            "product": {"name": "agent-bom", "vendor_name": "msaad00", "version": product_version},
+            "version": "1.1.0",
+            "log_name": "agent-bom-gateway-policy",
+            "uid": uid,
+        },
+        "status_id": 1,
+        "status": "New",
+        # Idempotency key surfaced at top level so SIEM/SOAR de-dupe on retry.
+        "idempotency_key": uid,
+    }
+    return finding
+
+
+def _webhook_backoff_seconds(attempt: int, *, base: float, rng: random.Random) -> float:
+    """Exponential backoff with full jitter for webhook retries (deterministic
+    when a seeded ``rng`` is injected, so the retry test is reproducible)."""
+    ceiling = base * (2**attempt)
+    return rng.uniform(0.0, ceiling)
+
+
+def deliver_policy_webhook(
+    event: dict[str, Any],
+    *,
+    url: str | None = None,
+    token: str | None = None,
+    max_attempts: int = 3,
+    base_backoff_seconds: float = 0.5,
+    poster: Callable[[str, dict[str, Any], dict[str, str]], int] | None = None,
+    sleep: Callable[[float], None] | None = None,
+    rng: random.Random | None = None,
+) -> bool:
+    """POST an OCSF policy event to a SIEM/SOAR webhook, fail-safe.
+
+    Never blocks or crashes the relay: webhook errors are handled with bounded
+    retries (exponential backoff + jitter) for transient/rate-limit failures,
+    then dropped with a clear operator-facing warning naming WHAT failed, the
+    STATUS, and what to CHECK (URL / credential / rate). Returns True on a 2xx
+    delivery, False when no webhook is configured or every attempt is exhausted.
+
+    The request carries the event's ``idempotency_key`` as a header so a retried
+    delivery never double-records downstream. ``poster``/``sleep``/``rng`` are
+    injectable for tests; in production a small httpx POST is used.
+    """
+    target = url if url is not None else os.environ.get(POLICY_WEBHOOK_URL_ENV, "").strip()
+    if not target:
+        return False
+    auth = token if token is not None else os.environ.get(POLICY_WEBHOOK_TOKEN_ENV, "").strip()
+    idempotency_key = str(event.get("idempotency_key") or event.get("metadata", {}).get("uid") or "")
+    headers = {"Content-Type": "application/json"}
+    if idempotency_key:
+        headers["Idempotency-Key"] = idempotency_key
+        headers["X-Agent-Bom-Idempotency-Key"] = idempotency_key
+    if auth:
+        headers["Authorization"] = f"Bearer {auth}"
+
+    _rng = rng or random.Random()
+    _sleep = sleep or time.sleep
+    _poster = poster or _default_webhook_poster
+    attempts = max(1, max_attempts)
+
+    for attempt in range(attempts):
+        try:
+            status = _poster(target, event, headers)
+        except Exception as exc:  # noqa: BLE001 — connection/DNS/timeout
+            if attempt + 1 < attempts:
+                _sleep(_webhook_backoff_seconds(attempt, base=base_backoff_seconds, rng=_rng))
+                continue
+            logger.warning(
+                "policy webhook delivery failed after %d attempt(s): connection error %s. "
+                "Check the AGENT_BOM_POLICY_WEBHOOK_URL is reachable; event %s dropped (relay unaffected).",
+                attempts,
+                exc,
+                idempotency_key or "?",
+            )
+            return False
+        if 200 <= status < 300:
+            return True
+        if status in (401, 403):
+            logger.warning(
+                "policy webhook rejected with HTTP %d (auth). Check the AGENT_BOM_POLICY_WEBHOOK_TOKEN "
+                "credential/scope; event %s dropped (relay unaffected).",
+                status,
+                idempotency_key or "?",
+            )
+            return False
+        if status == 429 or status >= 500:
+            if attempt + 1 < attempts:
+                _sleep(_webhook_backoff_seconds(attempt, base=base_backoff_seconds, rng=_rng))
+                continue
+            kind = "rate limited" if status == 429 else "server error"
+            logger.warning(
+                "policy webhook %s with HTTP %d after %d attempt(s). Check the endpoint %s "
+                "(rate limits / availability); event %s dropped (relay unaffected).",
+                kind,
+                status,
+                attempts,
+                "rate" if status == 429 else "URL",
+                idempotency_key or "?",
+            )
+            return False
+        logger.warning(
+            "policy webhook returned unexpected HTTP %d. Check the AGENT_BOM_POLICY_WEBHOOK_URL "
+            "target; event %s dropped (relay unaffected).",
+            status,
+            idempotency_key or "?",
+        )
+        return False
+    return False
+
+
+def _default_webhook_poster(url: str, event: dict[str, Any], headers: dict[str, str]) -> int:
+    import httpx
+
+    response = httpx.post(url, json=event, headers=headers, timeout=httpx.Timeout(connect=5.0, read=10.0, write=10.0, pool=5.0))
+    return response.status_code

--- a/tests/test_gateway_policy_hardening.py
+++ b/tests/test_gateway_policy_hardening.py
@@ -1,0 +1,346 @@
+"""Tests for the gateway policy-engine hardening.
+
+Covers the five shipped capabilities and the cross-cutting acceptance criteria:
+
+1. Fail-closed mode — missing/unloadable policy DENIES in ``closed`` mode and
+   still ALLOWS (legacy) in the default ``open`` mode.
+2. Quarantine decision tier — a conditional ``quarantine`` rule blocks the tool
+   with a distinct, client-safe reason while flagging + auditing the agent.
+3. Conditional access — declarative time-window / risk-score / required-attribute
+   gates, evaluated deterministically from an injected ``now``.
+4. Plugin policy/detector registry — a registered evaluator composes into the
+   pipeline; a raising plugin is isolated, not fatal.
+5. Interop OCSF + webhook — a normalized OCSF event is POSTed on deny/quarantine
+   with an idempotency key; 429 is retried then dropped with a warning; the
+   relay is never blocked by a webhook failure.
+
+Plus determinism (same request → identical decision + identical event id) and
+the default-behaviour-unchanged guarantee.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from typing import Any
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.gateway_server import GatewaySettings, create_gateway_app
+from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
+from agent_bom.proxy_policy import (
+    DecisionContext,
+    GatewayDecision,
+    PluginDecision,
+    _reset_policy_evaluators_for_tests,
+    build_policy_ocsf_event,
+    context_from_now,
+    deliver_policy_webhook,
+    evaluate_conditional_rules,
+    evaluate_conditions,
+    policy_event_id,
+    register_policy_evaluator,
+    resolve_fail_mode,
+)
+
+# A fixed UTC instant: 2026-06-15 (Monday) 10:00 → minute_of_day 600, weekday 0.
+_MONDAY_10AM = 1781517600.0
+
+
+def _registry() -> UpstreamRegistry:
+    return UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://fs.local:8100")])
+
+
+def _call(tool: str = "run_shell") -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": tool, "arguments": {}}}
+
+
+async def _ok_caller(upstream, message, extra_headers):
+    return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+
+def _settings(audit: list[dict[str, Any]] | None = None, **kwargs: Any) -> GatewaySettings:
+    async def _sink(event: dict[str, Any]) -> None:
+        if audit is not None:
+            audit.append(event)
+
+    return GatewaySettings(
+        registry=_registry(),
+        policy=kwargs.pop("policy", {"rules": []}),
+        upstream_caller=_ok_caller,
+        audit_sink=_sink if audit is not None else None,
+        **kwargs,
+    )
+
+
+def _is_blocked(resp) -> bool:
+    body = resp.json()
+    return resp.status_code == 200 and isinstance(body.get("error"), dict) and body["error"].get("code") == -32001
+
+
+@pytest.fixture(autouse=True)
+def _clean_plugin_registry():
+    _reset_policy_evaluators_for_tests()
+    yield
+    _reset_policy_evaluators_for_tests()
+
+
+# ─── Fail-closed mode ──────────────────────────────────────────────────────
+
+
+def test_resolve_fail_mode_default_open(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_GATEWAY_FAIL_MODE", raising=False)
+    assert resolve_fail_mode(None) == "open"
+    assert resolve_fail_mode("closed") == "closed"
+    assert resolve_fail_mode("garbage") == "open"
+
+
+def test_fail_closed_denies_when_policy_file_unloadable(tmp_path):
+    missing = tmp_path / "does-not-exist.json"
+    audit: list[dict[str, Any]] = []
+    settings = _settings(audit=audit, policy_path=missing, fail_mode="closed")
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_call())
+    assert _is_blocked(resp)
+    assert resp.json()["error"]["data"]["policy_source"] == "fail_closed"
+    assert any(e["action"] == "gateway.policy_fail_closed" for e in audit)
+
+
+def test_fail_open_default_allows_when_policy_file_unloadable(tmp_path):
+    missing = tmp_path / "does-not-exist.json"
+    settings = _settings(policy_path=missing)  # fail_mode defaults to open
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_call())
+    # Legacy behaviour: missing policy degrades to default-allow, call forwards.
+    assert resp.status_code == 200
+    assert resp.json().get("result") == {"ok": True}
+
+
+# ─── Conditional access (declarative, deterministic) ───────────────────────
+
+
+def test_evaluate_conditions_time_window():
+    inside = context_from_now(now=_MONDAY_10AM)  # Monday 10:00 UTC
+    ok, _ = evaluate_conditions({"time_window": {"start": "08:00", "end": "20:00"}}, inside)
+    assert ok
+    bad, reason = evaluate_conditions({"time_window": {"start": "11:00", "end": "20:00"}}, inside)
+    assert not bad and "time window" in reason
+
+
+def test_evaluate_conditions_weekday_and_risk_and_attrs():
+    ctx = context_from_now(now=_MONDAY_10AM, risk_score=0.4, attributes={"mfa": "true"})
+    assert ctx.weekday == 0
+    ok, _ = evaluate_conditions({"weekdays": [0, 1, 2, 3, 4]}, ctx)
+    assert ok
+    bad, _ = evaluate_conditions({"weekdays": [5, 6]}, ctx)
+    assert not bad
+    deny, reason = evaluate_conditions({"max_risk_score": 0.3}, ctx)
+    assert not deny and "risk score" in reason
+    miss, reason = evaluate_conditions({"required_attributes": {"mfa": "false"}}, ctx)
+    assert not miss and "mfa" in reason
+
+
+def test_conditional_rule_required_attribute_denies_in_relay():
+    audit: list[dict[str, Any]] = []
+    policy = {"rules": [{"id": "need-mfa", "action": "block", "conditions": {"required_attributes": {"mfa": "true"}}}]}
+    settings = _settings(audit=audit, policy=policy)
+    client = TestClient(create_gateway_app(settings))
+    # No mfa context attribute → the required-attribute gate is not satisfied.
+    resp = client.post("/mcp/filesystem", json=_call())
+    assert _is_blocked(resp)
+    assert resp.json()["error"]["data"]["policy_source"] == "conditional_access"
+    # With the attribute asserted, the same call passes.
+    ok = client.post("/mcp/filesystem", json=_call(), headers={"x-agent-ctx-mfa": "true"})
+    assert ok.status_code == 200 and ok.json().get("result") == {"ok": True}
+
+
+def test_conditional_rule_risk_score_denies_in_relay():
+    audit: list[dict[str, Any]] = []
+    policy = {"rules": [{"id": "risk-cap", "action": "block", "conditions": {"max_risk_score": 0.5}}]}
+    settings = _settings(audit=audit, policy=policy)
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_call(), headers={"x-agent-risk-score": "0.9"})
+    assert _is_blocked(resp)
+    assert resp.json()["error"]["data"]["policy_source"] == "conditional_access"
+    assert any(e["action"] == "gateway.policy_blocked" for e in audit)
+
+
+# ─── Quarantine tier ───────────────────────────────────────────────────────
+
+
+def test_quarantine_rule_returns_distinct_decision():
+    audit: list[dict[str, Any]] = []
+    policy = {"rules": [{"id": "q-high-risk", "action": "quarantine", "conditions": {"max_risk_score": 0.5}}]}
+    settings = _settings(audit=audit, policy=policy)
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_call(), headers={"x-agent-risk-score": "0.95"})
+    body = resp.json()
+    assert resp.status_code == 200
+    assert body["error"]["code"] == -32002  # distinct from -32001 deny
+    assert body["error"]["data"]["decision"] == "quarantine"
+    # Client-safe reason — no internal rule text leaked.
+    assert "under review" in body["error"]["data"]["reason"]
+    assert any(e["action"] == "gateway.policy_quarantined" for e in audit)
+
+
+# ─── Plugin registry ───────────────────────────────────────────────────────
+
+
+def test_plugin_evaluator_can_deny_in_relay():
+    def _deny_evaluator(ctx: DecisionContext, policy: dict) -> PluginDecision | None:
+        if ctx.tool_name == "run_shell":
+            return PluginDecision(GatewayDecision.DENY, "plugin blocked run_shell")
+        return None
+
+    register_policy_evaluator("deny-shell", _deny_evaluator)
+    audit: list[dict[str, Any]] = []
+    settings = _settings(audit=audit)
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_call(tool="run_shell"))
+    assert _is_blocked(resp)
+    assert resp.json()["error"]["data"]["policy_source"] == "policy_plugin"
+
+
+def test_raising_plugin_is_isolated_decision_still_returned():
+    def _boom(ctx: DecisionContext, policy: dict) -> PluginDecision | None:
+        raise RuntimeError("plugin exploded")
+
+    register_policy_evaluator("boom", _boom)
+    settings = _settings()  # fail-open: a raising plugin must not break the relay
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_call())
+    # Decision still returned — the call forwards (no plugin opinion survived).
+    assert resp.status_code == 200
+    assert resp.json().get("result") == {"ok": True}
+
+
+# ─── Determinism + deterministic ids ───────────────────────────────────────
+
+
+def test_decision_and_event_id_are_deterministic():
+    ctx = context_from_now(
+        tenant_id="acme",
+        source_agent="agent-a",
+        tool_name="run_shell",
+        now=_MONDAY_10AM,
+        risk_score=0.9,
+    )
+    policy = {"rules": [{"id": "risk-cap", "action": "block", "conditions": {"max_risk_score": 0.5}}]}
+    d1 = evaluate_conditional_rules(policy, ctx)
+    d2 = evaluate_conditional_rules(policy, ctx)
+    assert d1 == d2 == (GatewayDecision.DENY, d1[1], "risk-cap")
+
+    id1 = policy_event_id(
+        tenant_id="acme", source_agent="agent-a", tool_name="run_shell", decision=GatewayDecision.DENY, reason=d1[1], now=_MONDAY_10AM
+    )
+    id2 = policy_event_id(
+        tenant_id="acme", source_agent="agent-a", tool_name="run_shell", decision=GatewayDecision.DENY, reason=d1[1], now=_MONDAY_10AM
+    )
+    assert id1 == id2 and id1.startswith("gwpol-")
+
+    e1 = build_policy_ocsf_event(decision=GatewayDecision.DENY, reason=d1[1], ctx=ctx)
+    e2 = build_policy_ocsf_event(decision=GatewayDecision.DENY, reason=d1[1], ctx=ctx)
+    assert e1 == e2  # byte-identical events
+    assert e1["idempotency_key"] == id1
+    assert e1["class_uid"] == 2004
+
+
+# ─── OCSF + webhook interop ────────────────────────────────────────────────
+
+
+def test_webhook_no_url_is_noop(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_POLICY_WEBHOOK_URL", raising=False)
+    event = {"idempotency_key": "k"}
+    posted: list[int] = []
+    assert deliver_policy_webhook(event, url="", poster=lambda *a: posted.append(1) or 200) is False
+    assert deliver_policy_webhook(event, url=None, poster=lambda *a: posted.append(1) or 200) is False
+    assert posted == []  # never attempted a POST
+
+
+def test_webhook_429_retried_then_dropped_with_warning(caplog):
+    calls: list[dict[str, str]] = []
+
+    def _poster(url: str, event: dict[str, Any], headers: dict[str, str]) -> int:
+        calls.append(headers)
+        return 429
+
+    sleeps: list[float] = []
+    with caplog.at_level(logging.WARNING, logger="agent_bom.proxy_policy"):
+        delivered = deliver_policy_webhook(
+            {"idempotency_key": "evt-1", "metadata": {"uid": "evt-1"}},
+            url="https://siem.example/ingest",
+            max_attempts=3,
+            poster=_poster,
+            sleep=sleeps.append,
+            rng=random.Random(7),
+        )
+    assert delivered is False
+    assert len(calls) == 3  # retried up to max_attempts
+    assert len(sleeps) == 2  # backoff between the 3 attempts
+    # Idempotency key carried so retries don't double-record downstream.
+    assert all(h.get("Idempotency-Key") == "evt-1" for h in calls)
+    warnings = [r.getMessage().lower() for r in caplog.records if r.levelname == "WARNING"]
+    assert any("rate limited" in m for m in warnings)
+
+
+def test_webhook_auth_failure_not_retried(caplog):
+    calls = []
+
+    def _poster(url, event, headers):
+        calls.append(1)
+        return 403
+
+    with caplog.at_level(logging.WARNING, logger="agent_bom.proxy_policy"):
+        delivered = deliver_policy_webhook(
+            {"idempotency_key": "evt-2"}, url="https://siem.example/ingest", max_attempts=3, poster=_poster, sleep=lambda _s: None
+        )
+    assert delivered is False
+    assert len(calls) == 1  # 401/403 is terminal, not retried
+    warnings = [r.getMessage().lower() for r in caplog.records if r.levelname == "WARNING"]
+    assert any("auth" in m for m in warnings)
+
+
+def test_webhook_success_returns_true():
+    def _poster(url, event, headers):
+        return 202
+
+    assert deliver_policy_webhook({"idempotency_key": "evt-3"}, url="https://siem.example/ingest", poster=_poster) is True
+
+
+def test_webhook_failure_does_not_block_relay():
+    # A webhook that always errors must not prevent the deny response.
+    def _boom_poster(url, event, headers):
+        raise ConnectionError("siem unreachable")
+
+    audit: list[dict[str, Any]] = []
+    policy = {"rules": [{"id": "deny-shell", "action": "block", "block_tools": ["run_shell"]}]}
+    settings = _settings(audit=audit, policy=policy, policy_webhook_url="https://siem.example/ingest")
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_call(tool="run_shell"))
+    assert _is_blocked(resp)  # relay still denies even though the webhook would fail
+
+
+# ─── Default behaviour unchanged ───────────────────────────────────────────
+
+
+def test_defaults_preserve_existing_allow_behaviour():
+    # No fail_mode, no webhook, no conditional rules, no plugins → identical to
+    # legacy: an unmatched policy allows and the call forwards.
+    settings = _settings(policy={"rules": []})
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_call())
+    assert resp.status_code == 200
+    assert resp.json().get("result") == {"ok": True}
+
+
+def test_defaults_preserve_existing_block_behaviour():
+    # A plain allow/deny policy with the new engine present still denies with the
+    # original -32001 code and policy_source "file".
+    policy = {"rules": [{"id": "no-shell", "action": "block", "block_tools": ["run_shell"]}]}
+    settings = _settings(policy=policy)
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_call(tool="run_shell"))
+    body = resp.json()
+    assert body["error"]["code"] == -32001
+    assert body["error"]["data"]["policy_source"] == "file"


### PR DESCRIPTION
## Summary

Hardens the agentic gateway/proxy policy engine — the allow/deny/quarantine control plane for MCP runtime traffic — adding fail-closed posture, a quarantine decision tier, declarative conditional access, an entry-points plugin registry, and OCSF + SIEM/SOAR webhook interop. Every new capability defaults to a no-op so existing allow/deny behavior is unchanged.

## What shipped

1. **Fail-closed mode** (`AGENT_BOM_GATEWAY_FAIL_MODE=open|closed`, default `open`). When `closed`, a missing/unloadable file policy or an evaluation error DENIES instead of degrading to default-allow. Wired into the policy-load fallback and the conditional/plugin evaluation paths.
2. **Quarantine decision tier** — a verdict between allow and deny that blocks the sensitive tool while flagging + heavily auditing the agent/session. Returns a distinct, client-safe reason (JSON-RPC `-32002`) and a `policy.quarantined` governance event.
3. **Conditional access** — declarative `conditions` blocks on policy rules: time-window, weekday, min/max risk-score, and required-context-attribute gates. Evaluated deterministically from an injected timestamp (weekday / minute-of-day derived from `now`, not the wall clock).
4. **Plugin policy/detector registry** — entry-points group `agent_bom.gateway_policy_evaluators` (opt-in via the existing `AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS` switch, reusing the project's `iter_entry_point_registrations` discovery). Custom evaluators compose into the decision pipeline (DENY > QUARANTINE > ALLOW); a plugin that raises is isolated — logged and skipped — never fatal.
5. **OCSF event + webhook interop** — on every DENY/QUARANTINE a normalized OCSF Detection Finding (class_uid 2004) is built and, when `AGENT_BOM_POLICY_WEBHOOK_URL` is set, POSTed to the SIEM/SOAR endpoint with an idempotency key.

## Cross-cutting guarantees

- **Idempotency / deterministic ids**: decision and event ids derive from a sha256 of stable inputs (no inline `uuid4`/`random` in decision logic). The same `(agent, tool, request)` under the same policy yields an identical decision and event id; the idempotency key is sent as a webhook header so retries don't double-record downstream.
- **Injected timestamps**: decision logic accepts `now` as a parameter; events are reproducible.
- **Error handling**: webhook 401/403 is terminal (no retry); 429 and 5xx are bounded-retry with exponential backoff + jitter, then dropped with an operator-facing warning naming what failed, the status, and what to check (URL / credential / rate). Webhook failures never block or crash the relay. A raising plugin is isolated.

## Tests (`tests/test_gateway_policy_hardening.py`, 18 cases)

- Determinism: `test_decision_and_event_id_are_deterministic` (same request → identical decision + identical event id, byte-identical OCSF events).
- Webhook errors: `test_webhook_429_retried_then_dropped_with_warning`, `test_webhook_auth_failure_not_retried`, `test_webhook_failure_does_not_block_relay`.
- Plugin isolation: `test_raising_plugin_is_isolated_decision_still_returned`, `test_plugin_evaluator_can_deny_in_relay`.
- Fail-closed vs fail-open: `test_fail_closed_denies_when_policy_file_unloadable`, `test_fail_open_default_allows_when_policy_file_unloadable`.
- Quarantine: `test_quarantine_rule_returns_distinct_decision`.
- Defaults unchanged: `test_defaults_preserve_existing_allow_behaviour`, `test_defaults_preserve_existing_block_behaviour`.

`ruff check`, `mypy`, and the gateway/policy/proxy test suite are green on the touched files.
