### PR TITLE
feat(cloud): Snowflake organization-to-accounts roll-up hierarchy

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -309,6 +309,8 @@ AGENT_BOM_SIEM_URL
 AGENT_BOM_SKILLS_SCAN_CONCURRENCY
 AGENT_BOM_SNOWFLAKE_INVENTORY  # opt-in flag (default OFF) gating read-only estate-wide Snowflake inventory enrichment; read in cloud/snowflake.py
 AGENT_BOM_SNOWFLAKE_MAX_ROLES  # max roles enumerated by live SHOW-based identity discovery before the scan warns + caps (default 2000); read in cloud/snowflake.py
+AGENT_BOM_SNOWFLAKE_ORG  # opt-in flag (default OFF) gating read-only Snowflake organization→accounts roll-up discovery (requires ORGADMIN; no-ops gracefully without it); read in cloud/snowflake.py
+AGENT_BOM_SNOWFLAKE_MAX_ACCOUNTS  # max member accounts enumerated by organization roll-up before the scan warns + caps; read in cloud/snowflake.py
 AGENT_BOM_STATE_DIR
 AGENT_BOM_TAINT_MAX_DEPTH
 AGENT_BOM_TENANT_ID

--- a/src/agent_bom/cloud/snowflake.py
+++ b/src/agent_bom/cloud/snowflake.py
@@ -38,7 +38,7 @@ import re
 import warnings
 from typing import Any
 
-from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
+from agent_bom.discovery_envelope import DiscoveryEnvelope, RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.governance import (
     AccessRecord,
     ActivityTimeline,
@@ -79,7 +79,24 @@ _coerce_int_or_none = coerce_int_or_none
 # flag.
 INVENTORY_ENV_FLAG = "AGENT_BOM_SNOWFLAKE_INVENTORY"
 
+# Opt-in env flag for the Organization → Accounts roll-up. Default OFF and
+# separate from the per-account inventory gate because enumerating the
+# organization requires the ORGADMIN role (``SHOW ORGANIZATION ACCOUNTS``),
+# which the read-only ``ABOM_READONLY`` role typically lacks. Symmetric with the
+# GCP/AWS organization gates: a single account graphs unchanged when this is off.
+ORG_ENV_FLAG = "AGENT_BOM_SNOWFLAKE_ORG"
+
 _TRUTHY = {"1", "true", "yes", "on"}
+
+# Read-only privileges this discoverer exercises, surfaced on the discovery
+# envelope so ``permissions_used`` stays honest (the producer owns the catalog).
+_SF_ORG_PERMISSIONS: tuple[str, ...] = (
+    "ORGADMIN.ORGANIZATION_ACCOUNTS:SELECT",
+    "SNOWFLAKE.ORGANIZATION_USAGE.ACCOUNTS:SELECT",
+)
+
+# Cap accounts walked so a very large organization can't run unbounded.
+_MAX_ORG_ACCOUNTS = int(os.environ.get("AGENT_BOM_SNOWFLAKE_MAX_ACCOUNTS", "500") or "500")
 
 
 def inventory_enabled() -> bool:
@@ -90,6 +107,15 @@ def inventory_enabled() -> bool:
     side effects — mirrors the AWS / Azure / GCP inventory gates.
     """
     return os.environ.get(INVENTORY_ENV_FLAG, "").strip().lower() in _TRUTHY
+
+
+def org_enabled() -> bool:
+    """Return whether the Snowflake Organization roll-up is opted in.
+
+    Default OFF. Operators enable it by setting ``AGENT_BOM_SNOWFLAKE_ORG`` to a
+    truthy value. Read-only with no side effects — mirrors the GCP/AWS org gates.
+    """
+    return os.environ.get(ORG_ENV_FLAG, "").strip().lower() in _TRUTHY
 
 
 def _snowflake_cloud_origin(
@@ -3000,6 +3026,184 @@ def discover_snowflake_services(
     return result
 
 
+# Substrings that mark an ORGADMIN-privilege / not-in-org failure of
+# ``SHOW ORGANIZATION ACCOUNTS`` rather than a transient connection error. Used to
+# distinguish "this role can't see the org" (a clean degrade) from "the org has a
+# single account". Matched case-insensitively against the sanitized error text.
+_SF_ORG_NOT_AUTHORIZED_MARKERS: tuple[str, ...] = (
+    "orgadmin",
+    "insufficient privileges",
+    "not authorized",
+    "unsupported feature",
+    "does not exist or not authorized",
+    "organization",
+)
+
+
+def discover_organization(
+    account: str | None = None,
+    user: str | None = None,
+    authenticator: str | None = None,
+    *,
+    force: bool = False,
+    now: str | None = None,
+) -> dict[str, Any]:
+    """Enumerate the Snowflake Organization → member accounts roll-up (read-only).
+
+    The Snowflake analogue of the GCP Organization → Folders → Projects and AWS
+    Organizations → OU → Account hierarchies: multiple Snowflake accounts roll up
+    under a parent ORGANIZATION node so the estate is traversable top-down. Uses
+    ``SHOW ORGANIZATION ACCOUNTS`` to read the org name and its member accounts.
+
+    Returns a payload destined for ``report_json`` (carried on the Snowflake
+    services payload under ``organization``) with a ``status``:
+
+    - ``"disabled"``       — the org flag is off and ``force`` was not set.
+    - ``"sdk_missing"``    — snowflake-connector-python is not installed.
+    - ``"not_authorized"`` — the connected role lacks ORGADMIN (the read-only
+      ``ABOM_READONLY`` role typically does); single-account scanning still works.
+    - ``"not_in_org"``     — the account is standalone (no organization visible).
+    - ``"ok"``             — enumeration ran (possibly with per-call warnings).
+
+    Read-only (``SHOW`` only — no writes), opt-in (``AGENT_BOM_SNOWFLAKE_ORG`` or
+    ``force``), and crash-safe: SDK absence, missing ORGADMIN, connection / auth /
+    SQL errors all degrade to a clear status plus an actionable warning. Never
+    raises; a single account graphs exactly as it does today when this no-ops.
+
+    ``now`` (an ISO-8601 string) is injected for the ``discovered_at`` stamp so
+    the payload is deterministic under test; callers pass a clock value rather
+    than the discoverer reading wall-clock time inline.
+    """
+    resolved_account = _env_or_value(account, "SNOWFLAKE_ACCOUNT")
+    result: dict[str, Any] = {
+        "status": "disabled",
+        "org_name": "",
+        "accounts": [],
+        "findings": [],
+        "warnings": [],
+        "discovered_at": now or "",
+        "discovery_envelope": None,
+    }
+    if not force and not org_enabled():
+        return result
+
+    try:
+        import snowflake.connector  # noqa: F401
+    except ImportError:
+        result["status"] = "sdk_missing"
+        result["warnings"] = [
+            "snowflake-connector-python is required for Snowflake org inventory. Install with: pip install 'agent-bom[snowflake]'"
+        ]
+        return result
+
+    warnings: list[str] = result["warnings"]
+    if not resolved_account:
+        result["status"] = "not_in_org"
+        warnings.append("SNOWFLAKE_ACCOUNT not set; cannot enumerate the organization. Single-account scanning is unaffected.")
+        return result
+
+    try:
+        conn = _get_connection(account, user, authenticator)
+    except CloudDiscoveryError:
+        raise
+    except Exception as exc:  # noqa: BLE001 — connection failure degrades, never crashes the scan
+        warnings.append(f"Could not connect to Snowflake for org inventory: {sanitize_error(exc)}")
+        return result
+
+    try:
+        cursor = conn.cursor()
+        try:
+            # SHOW ORGANIZATION ACCOUNTS requires the ORGADMIN role. The read-only
+            # ABOM_READONLY role usually lacks it, so a privilege error here is the
+            # expected, graceful degrade — not a scan failure.
+            cursor.execute("SHOW ORGANIZATION ACCOUNTS")
+            keys = [d[0].lower() for d in cursor.description] if cursor.description else []
+            for row in cursor.fetchall():
+                if len(result["accounts"]) >= _MAX_ORG_ACCOUNTS:
+                    warnings.append(
+                        f"Snowflake org enumeration capped at {_MAX_ORG_ACCOUNTS} accounts (set AGENT_BOM_SNOWFLAKE_MAX_ACCOUNTS to raise)."
+                    )
+                    break
+                r = dict(zip(keys, row))
+                locator = str(r.get("account_locator", "") or r.get("account_name", "") or r.get("name", "") or "").strip()
+                if not locator:
+                    continue
+                org_name = str(r.get("organization_name", "") or "").strip()
+                if org_name and not result["org_name"]:
+                    result["org_name"] = org_name
+                result["accounts"].append(
+                    {
+                        "locator": locator,
+                        "name": str(r.get("account_name", "") or r.get("name", "") or locator).strip(),
+                        "region": str(r.get("snowflake_region", "") or r.get("region", "") or "").strip(),
+                        "edition": str(r.get("edition", "") or "").strip(),
+                        "is_org_admin": str(r.get("is_org_admin", "") or "").strip().upper() in ("Y", "YES", "TRUE"),
+                    }
+                )
+        except Exception as exc:  # noqa: BLE001 — missing ORGADMIN / not-in-org degrades cleanly
+            message = sanitize_error(exc)
+            lowered = message.lower()
+            if any(marker in lowered for marker in _SF_ORG_NOT_AUTHORIZED_MARKERS):
+                result["status"] = "not_authorized"
+                warnings.append(
+                    "SHOW ORGANIZATION ACCOUNTS requires the ORGADMIN role, which the connected "
+                    "(read-only) role lacks. Grant ORGADMIN to enumerate the organization, or "
+                    f"continue single-account scanning (unaffected). Detail: {message}"
+                )
+            else:
+                warnings.append(f"Could not enumerate Snowflake organization accounts: {message}")
+            return result
+        finally:
+            cursor.close()
+    finally:
+        conn.close()
+
+    if not result["accounts"]:
+        # Connected fine and ORGADMIN-capable but the account is standalone.
+        result["status"] = "not_in_org"
+        if resolved_account not in {a["locator"] for a in result["accounts"]}:
+            warnings.append("No organization accounts visible; the account appears standalone. Single-account scanning is unaffected.")
+        return result
+
+    if not result["org_name"]:
+        result["org_name"] = "organization"
+
+    _derive_org_findings(result)
+    result["status"] = "ok"
+    result["discovery_envelope"] = DiscoveryEnvelope(
+        scan_mode=ScanMode.SAAS_READ_ONLY,
+        discovery_scope=(f"snowflake:organization/{result['org_name']}",),
+        permissions_used=_SF_ORG_PERMISSIONS,
+        redaction_status=RedactionStatus.CENTRAL_SANITIZER_APPLIED,
+    ).to_dict()
+    return result
+
+
+def _derive_org_findings(result: dict[str, Any]) -> None:
+    """Flag cheap org-shape posture signals, mirroring the GCP org findings."""
+    accounts = result.get("accounts", []) or []
+    if len(accounts) > 1:
+        result["findings"].append(
+            {
+                "severity": "info",
+                "title": "Multi-account Snowflake organization",
+                "detail": (
+                    f"{len(accounts)} accounts roll up under organization "
+                    f"'{result.get('org_name') or 'organization'}'. Org-wide policies and "
+                    "least-privilege should be reviewed across every member account."
+                ),
+            }
+        )
+    if accounts and not any(a.get("is_org_admin") for a in accounts):
+        result["findings"].append(
+            {
+                "severity": "low",
+                "title": "No ORGADMIN account flagged",
+                "detail": ("No member account is marked as the ORGADMIN account; organization-level governance ownership is unclear."),
+            }
+        )
+
+
 def _split_fqn_parts(name: str, database: str, schema: str) -> str:
     """Build a DB.SCHEMA.NAME fqn from SHOW-command columns, tolerating blanks."""
     parts = [p for p in (database, schema, name) if p]
@@ -3740,6 +3944,16 @@ def enrich_report_with_snowflake_estate(report: Any) -> None:
     # Services: warehouses (compute) + database/schema containment hierarchy. Best-effort.
     try:
         _sf_services = discover_snowflake_services()
+        # Organization → Accounts roll-up (opt-in, ORGADMIN-gated). Carried on the
+        # services payload under ``organization`` so the graph builder can parent
+        # the account node(s) under the org without a new top-level report field.
+        # A single account / missing ORGADMIN no-ops cleanly (non-ok status).
+        try:
+            _sf_org = discover_organization()
+            if isinstance(_sf_org, dict) and _sf_org.get("status") == "ok" and _sf_org.get("accounts"):
+                _sf_services["organization"] = _sf_org
+        except Exception:  # noqa: BLE001 — org roll-up is supplementary; never fail the scan
+            pass
         if _sf_services.get("status") == "ok" and (
             _sf_services.get("warehouses") or _sf_services.get("databases") or _sf_services.get("schemas")
         ):

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -957,6 +957,15 @@ def build_unified_graph_from_report(
         data_source_tag,
     )
     _add_snowflake_services(graph, report_json.get("snowflake_services"), data_source_tag)
+    # Snowflake estate roll-up backbone (organization → accounts). Carried on the
+    # services payload under ``organization``; promoted after the services layer so
+    # the account node(s) the CONTAINS tree references already exist to stitch onto.
+    _sf_services_payload = report_json.get("snowflake_services")
+    _add_snowflake_organization(
+        graph,
+        _sf_services_payload.get("organization") if isinstance(_sf_services_payload, dict) else None,
+        data_source_tag,
+    )
     _add_snowflake_pipeline(graph, report_json.get("snowflake_pipeline"), data_source_tag)
     _add_snowflake_integrations(graph, report_json.get("snowflake_integrations"), data_source_tag)
     _add_snowflake_external_data(graph, report_json.get("snowflake_external_data"), data_source_tag)
@@ -2597,6 +2606,67 @@ def _add_snowflake_services(graph: UnifiedGraph, payload: Any, data_source: str)
             parent_sch_id = schema_node_by_fqn.get(parent_schema)
             if parent_sch_id:
                 _add_rel_edge(graph, parent_sch_id, node.id, RelationshipType.CONTAINS, {"source": "snowflake-services"})
+
+
+def _add_snowflake_organization(graph: UnifiedGraph, payload: Any, data_source: str) -> None:
+    """Promote the Snowflake Organization → Accounts roll-up into the graph.
+
+    The Snowflake analogue of :func:`_add_aws_organization` and
+    :func:`_add_gcp_organization`: multiple Snowflake accounts roll up under a
+    parent ``ORG`` node via ``CONTAINS`` so the estate is traversable top-down.
+
+    The account nodes reuse the same ``account:snowflake:<locator>`` id that
+    :func:`_add_snowflake_services` (and the rest of the Snowflake graph) emits, so
+    the org backbone stitches onto any already-inventoried account graph rather
+    than creating a parallel island. When org data is absent or non-ok the call is
+    a no-op and the account stays the root — single-account behavior is unchanged.
+
+    Never raises; a non-ok / non-dict payload is a no-op.
+    """
+    if not isinstance(payload, dict) or payload.get("status") != "ok":
+        return
+    accounts = payload.get("accounts") or []
+    if not accounts:
+        return
+    data_sources = sorted({data_source, "snowflake-organizations"} - {""})
+    org_name = _clean_graph_part(payload.get("org_name")) or "organization"
+    org_node_id = f"org:snowflake:{org_name}"
+    graph.add_node(
+        UnifiedNode(
+            id=org_node_id,
+            entity_type=EntityType.ORG,
+            label=f"Snowflake org: {org_name}",
+            attributes={
+                "org_name": org_name,
+                "cloud_provider": "snowflake",
+                "account_count": len([a for a in accounts if isinstance(a, dict)]),
+            },
+            data_sources=data_sources,
+            dimensions=NodeDimensions(cloud_provider="snowflake", surface="identity"),
+        )
+    )
+
+    for member in accounts:
+        if not isinstance(member, dict):
+            continue
+        locator = _clean_graph_part(member.get("locator"))
+        if not locator:
+            continue
+        account_node = _add_identity_node(
+            graph,
+            EntityType.ACCOUNT,
+            locator,
+            "snowflake",
+            data_sources,
+            label=_clean_graph_part(member.get("name")) or locator,
+            account_id=locator,
+            cloud_provider="snowflake",
+            account_name=_clean_graph_part(member.get("name")),
+            region=_clean_graph_part(member.get("region")),
+            edition=_clean_graph_part(member.get("edition")),
+            source="snowflake-organizations",
+        )
+        _add_rel_edge(graph, org_node_id, account_node, RelationshipType.CONTAINS, {"source": "snowflake-organizations"})
 
 
 _SF_EXTERNAL_BUCKET_SERVICE = {"aws": "s3", "azure": "blob", "gcp": "gcs"}

--- a/tests/test_snowflake_organizations.py
+++ b/tests/test_snowflake_organizations.py
@@ -1,0 +1,239 @@
+"""Snowflake Organization → Accounts roll-up + the graph CONTAINS backbone.
+
+The Snowflake analogue of the GCP/AWS organization tests: multiple accounts roll
+up under a parent ORG node via CONTAINS. Covers the discovery degradation paths
+(disabled flag, missing ORGADMIN, standalone account) and the graph mapping,
+plus the cross-cutting guarantees: deterministic ids, injected timestamps, and
+idempotency.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from agent_bom.cloud import snowflake as sf
+from agent_bom.graph.builder import _add_snowflake_organization, build_unified_graph_from_report
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.types import EntityType, RelationshipType
+
+# ── Discovery offline harness ───────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _stub_snowflake_connector(monkeypatch):
+    sf_pkg = sys.modules.get("snowflake") or types.ModuleType("snowflake")
+    connector = sys.modules.get("snowflake.connector") or types.ModuleType("snowflake.connector")
+    monkeypatch.setitem(sys.modules, "snowflake", sf_pkg)
+    monkeypatch.setitem(sys.modules, "snowflake.connector", connector)
+
+
+class _OrgCursor:
+    """Cursor that returns a two-account organization for SHOW ORGANIZATION ACCOUNTS."""
+
+    def __init__(self, *, rows=None, raise_exc=None):
+        self.description = None
+        self._rows = rows if rows is not None else []
+        self._raise = raise_exc
+
+    def execute(self, sql, *_a, **_k):
+        if "SHOW ORGANIZATION ACCOUNTS" in " ".join(sql.split()):
+            if self._raise is not None:
+                raise self._raise
+            self.description = [
+                ("organization_name",),
+                ("account_name",),
+                ("account_locator",),
+                ("snowflake_region",),
+                ("edition",),
+                ("is_org_admin",),
+            ]
+        else:
+            self.description = []
+            self._rows = []
+
+    def fetchall(self):
+        return self._rows
+
+    def close(self):
+        pass
+
+
+class _OrgConn:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+    def close(self):
+        pass
+
+
+def _two_account_rows():
+    return [
+        ("ACME", "PROD", "ABC11111", "AWS_US_EAST_1", "ENTERPRISE", "Y"),
+        ("ACME", "DEV", "ABC22222", "AWS_US_WEST_2", "STANDARD", "N"),
+    ]
+
+
+def _ok_payload() -> dict:
+    return {
+        "status": "ok",
+        "org_name": "ACME",
+        "accounts": [
+            {"locator": "ABC11111", "name": "PROD", "region": "AWS_US_EAST_1", "edition": "ENTERPRISE", "is_org_admin": True},
+            {"locator": "ABC22222", "name": "DEV", "region": "AWS_US_WEST_2", "edition": "STANDARD", "is_org_admin": False},
+        ],
+        "findings": [],
+        "warnings": [],
+        "discovered_at": "2026-06-25T00:00:00Z",
+    }
+
+
+# ── Discovery: gating + degradation ─────────────────────────────────────────
+
+
+def test_disabled_when_flag_off(monkeypatch) -> None:
+    monkeypatch.delenv(sf.ORG_ENV_FLAG, raising=False)
+    out = sf.discover_organization()
+    assert out["status"] == "disabled"
+    assert out["accounts"] == []
+
+
+def test_not_authorized_when_role_lacks_orgadmin_noops(monkeypatch) -> None:
+    # SHOW ORGANIZATION ACCOUNTS raising an ORGADMIN privilege error must degrade
+    # to a clear status with actionable guidance — never crash the scan.
+    err = Exception("SQL access control error: Insufficient privileges to operate on ORGANIZATION (ORGADMIN required)")
+    cur = _OrgCursor(raise_exc=err)
+    monkeypatch.setattr(sf, "_get_connection", lambda *a, **k: _OrgConn(cur))
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "ABC11111")
+    out = sf.discover_organization(force=True)
+    assert out["status"] == "not_authorized"
+    assert out["accounts"] == []
+    assert any("ORGADMIN" in w for w in out["warnings"])
+    assert out["discovery_envelope"] is None
+
+
+def test_not_in_org_when_no_accounts(monkeypatch) -> None:
+    cur = _OrgCursor(rows=[])
+    monkeypatch.setattr(sf, "_get_connection", lambda *a, **k: _OrgConn(cur))
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "ABC11111")
+    out = sf.discover_organization(force=True)
+    assert out["status"] == "not_in_org"
+
+
+def test_missing_account_degrades_not_in_org(monkeypatch) -> None:
+    monkeypatch.delenv("SNOWFLAKE_ACCOUNT", raising=False)
+    out = sf.discover_organization(force=True)
+    assert out["status"] == "not_in_org"
+
+
+def test_ok_discovery_parses_accounts_and_findings(monkeypatch) -> None:
+    cur = _OrgCursor(rows=_two_account_rows())
+    monkeypatch.setattr(sf, "_get_connection", lambda *a, **k: _OrgConn(cur))
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "ABC11111")
+    out = sf.discover_organization(force=True, now="2026-06-25T00:00:00Z")
+    assert out["status"] == "ok"
+    assert out["org_name"] == "ACME"
+    locators = {a["locator"] for a in out["accounts"]}
+    assert locators == {"ABC11111", "ABC22222"}
+    assert out["discovered_at"] == "2026-06-25T00:00:00Z"
+    assert out["discovery_envelope"] is not None
+    titles = {f["title"] for f in out["findings"]}
+    assert "Multi-account Snowflake organization" in titles
+
+
+def test_injected_now_is_used_no_wallclock(monkeypatch) -> None:
+    # The discoverer never reads wall-clock inline: the injected `now` flows
+    # through verbatim, and absent `now` the stamp is empty (deterministic).
+    cur = _OrgCursor(rows=_two_account_rows())
+    monkeypatch.setattr(sf, "_get_connection", lambda *a, **k: _OrgConn(cur))
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "ABC11111")
+    out = sf.discover_organization(force=True)
+    assert out["discovered_at"] == ""
+
+
+# ── Graph builder: CONTAINS hierarchy + idempotency ─────────────────────────
+
+
+def test_builder_builds_org_contains_accounts() -> None:
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    _add_snowflake_organization(g, _ok_payload(), "test")
+
+    org = g.nodes.get("org:snowflake:ACME")
+    assert org is not None and org.entity_type == EntityType.ORG
+
+    # Accounts reuse the same account:snowflake:<locator> id the rest of the
+    # Snowflake graph emits, so the org backbone stitches onto inventoried graphs.
+    assert "account:snowflake:ABC11111" in g.nodes
+    assert "account:snowflake:ABC22222" in g.nodes
+
+    contains = {(e.source, e.target) for e in g.edges if e.relationship == RelationshipType.CONTAINS}
+    assert ("org:snowflake:ACME", "account:snowflake:ABC11111") in contains
+    assert ("org:snowflake:ACME", "account:snowflake:ABC22222") in contains
+
+
+def test_builder_deterministic_ids() -> None:
+    g1 = UnifiedGraph(scan_id="s", tenant_id="t")
+    g2 = UnifiedGraph(scan_id="s2", tenant_id="t2")
+    _add_snowflake_organization(g1, _ok_payload(), "test")
+    _add_snowflake_organization(g2, _ok_payload(), "test")
+    assert set(g1.nodes) == set(g2.nodes)
+
+
+def test_builder_idempotent_double_apply() -> None:
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    _add_snowflake_organization(g, _ok_payload(), "test")
+    nodes_after_first = set(g.nodes)
+    edges_after_first = {(e.source, e.target, e.relationship) for e in g.edges}
+    _add_snowflake_organization(g, _ok_payload(), "test")
+    assert set(g.nodes) == nodes_after_first
+    assert {(e.source, e.target, e.relationship) for e in g.edges} == edges_after_first
+
+
+def test_builder_non_ok_payload_is_noop() -> None:
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    _add_snowflake_organization(g, {"status": "not_authorized"}, "test")
+    _add_snowflake_organization(g, {"status": "ok", "accounts": []}, "test")
+    _add_snowflake_organization(g, None, "test")
+    assert len(g.nodes) == 0
+
+
+def test_single_account_graph_unchanged_without_org() -> None:
+    # A services-only report (no organization sub-key) graphs exactly as today:
+    # the account stays the root with no ORG node and no CONTAINS-from-org edge.
+    report = {
+        "snowflake_services": {
+            "status": "ok",
+            "account": "ABC11111",
+            "warehouses": [{"name": "WH", "size": "X-SMALL", "state": "STARTED", "auto_suspend": 60}],
+            "databases": [{"name": "DB", "owner": "SYSADMIN", "retention_time": 1}],
+            "schemas": [],
+        }
+    }
+    g = build_unified_graph_from_report(report)
+    assert not any(n.startswith("org:snowflake:") for n in g.nodes)
+    assert "account:snowflake:ABC11111" in g.nodes
+    org_contains = [e for e in g.edges if e.relationship == RelationshipType.CONTAINS and e.source.startswith("org:snowflake:")]
+    assert org_contains == []
+
+
+def test_builder_via_report_org_parents_account() -> None:
+    # End-to-end: org payload carried on the services payload parents the account.
+    report = {
+        "snowflake_services": {
+            "status": "ok",
+            "account": "ABC11111",
+            "warehouses": [],
+            "databases": [{"name": "DB", "owner": "SYSADMIN", "retention_time": 1}],
+            "schemas": [],
+            "organization": _ok_payload(),
+        }
+    }
+    g = build_unified_graph_from_report(report)
+    assert "org:snowflake:ACME" in g.nodes
+    contains = {(e.source, e.target) for e in g.edges if e.relationship == RelationshipType.CONTAINS}
+    assert ("org:snowflake:ACME", "account:snowflake:ABC11111") in contains


### PR DESCRIPTION
Models the Snowflake estate backbone so multiple accounts roll up under a parent organization node, completing per-cloud hierarchy parity with the AWS Org and GCP organization roll-ups.

- Read-only and opt-in via `AGENT_BOM_SNOWFLAKE_ORG`; organization discovery requires ORGADMIN and no-ops gracefully (clear status + warning) when the read-only role lacks it, leaving single-account graphs unchanged.
- Adds an `org:snowflake:<org>` node with CONTAINS edges to each member account, stitched after the services layer so account nodes already exist.
- Deterministic node ids, idempotent CONTAINS edges, injected timestamps, graceful auth/connection error handling.
- New 12-test suite covers the hierarchy, idempotency, and the not-authorized no-op path.