### PR TITLE
ci(pre-commit): add pydantic to mypy hook deps so local matches CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: mypy
         args: [--ignore-missing-imports, --no-error-summary, --disable-error-code, import-untyped]
         files: ^src/
-        additional_dependencies: [types-PyYAML]
+        additional_dependencies: ["pydantic>=2.0", types-PyYAML]
         pass_filenames: true
 
   - repo: https://github.com/PyCQA/bandit


### PR DESCRIPTION
## Problem

The `mirrors-mypy` pre-commit hook runs in an isolated virtualenv whose only `additional_dependencies` was `types-PyYAML`. Because pydantic is not installed in that env, mypy cannot resolve the return types of `model_validate()` / `model_dump()` — they degrade to `Any`, producing false `no-any-return` errors:

- `src/agent_bom/api/scan_batches.py:75`
- `src/agent_bom/api/routes/credentials.py:110,142,157`

CI's "Lint and Type Check" stage installs the real project dependencies (including pydantic) before running mypy, so it passes. The result was local pre-commit disagreeing with CI, forcing contributors to bypass the hook.

## Fix

Add `pydantic>=2.0` (matching the `pyproject.toml` pin) to the hook's `additional_dependencies`. The hook's isolated env now resolves the same types CI does, so the false positives disappear and local == CI.

## Verification

```
pre-commit run mypy --files src/agent_bom/api/scan_batches.py src/agent_bom/api/routes/credentials.py
mypy.....................................................................Passed
```

The four `no-any-return` errors are gone with no changes to the source files — they were an artifact of the missing dependency, not real type bugs. Diff is a single line in `.pre-commit-config.yaml`.