### PR TITLE
Secure-by-default read-only cloud connect identities

### DIFF
--- a/deploy/terraform/connect-aws/README.md
+++ b/deploy/terraform/connect-aws/README.md
@@ -11,15 +11,37 @@ calls only `List*`/`Describe*`/`Get*` and `sts:GetCallerIdentity`.
 
 ## What it creates
 
-- An IAM **role** (default, recommended) or **user** named `agent-bom-readonly`.
+- An IAM **role** (default, recommended) or **user** with a **unique,
+  non-guessable name** (`abom-readonly-<random hex>` by default).
 - The AWS-managed **`SecurityAudit`** policy attached (always), and
   **`ViewOnlyAccess`** attached when `attach_view_only_access = true` (default).
 - A trust policy (role mode) accepting either static cross-account principals or
-  keyless OIDC web-identity federation, with optional `ExternalId`.
+  keyless OIDC web-identity federation, with an **always-enforced `ExternalId`**
+  (auto-generated high-entropy by default).
 
 No access keys are created by this module. In role mode the principal is keyless
 (assume-role / OIDC). In user mode, mint keys out-of-band and pass them as env —
 they are never written into Terraform state by this module.
+
+## Secure by default
+
+- **Mandatory ExternalId (confused-deputy defense).** The `sts:ExternalId`
+  trust condition is **always** applied on cross-account assume-role — it can
+  never be silently omitted. Leave `external_id` empty and the module generates
+  a 32-char high-entropy value; read it with
+  `terraform output -raw external_id` and configure the scanner with it. Set
+  `external_id` to pin a known value (BYO-ID).
+- **Unique, unpredictable name (anti-squatting).** The role/user name defaults
+  to `abom-readonly-<random hex>` so it is not a predictable, squattable, or
+  targetable principal. Override with `name = "..."` only when a stable, known
+  name is required by an external system.
+
+> **Threat note.** A *fixed, guessable* External ID (or one set to an empty,
+> never-applied condition) leaves the role open to the **confused-deputy**
+> problem — a third party that knows your role ARN could trick the scanner's
+> account into assuming it on their behalf. A *predictable* principal name is
+> easier to **squat or target**. The defaults above close both: the ExternalId
+> is high-entropy and always enforced, and the name is randomized.
 
 ## Usage
 
@@ -31,7 +53,8 @@ module "agent_bom_connect" {
 
   # The agent-bom scanner account/role that will assume this read-only role.
   trusted_principal_arns = ["arn:aws:iam::123456789012:role/agent-bom-scanner"]
-  external_id            = "your-tenant-external-id" # optional, recommended
+  # external_id omitted → a high-entropy value is generated and ALWAYS enforced.
+  # Read it after apply: terraform output -raw external_id
 }
 ```
 
@@ -63,12 +86,14 @@ hosted scanner. With the flag unset, agent-bom does zero AWS network I/O.
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `principal_type` | `role` | `role` (assumable, keyless) or `user`. |
+| `name` | `""` | Fixed name override. Empty → auto-generated unique name. |
+| `name_prefix` | `abom-readonly` | Prefix for the auto-generated unique name. |
 | `trusted_principal_arns` | `[]` | Cross-account ARNs allowed to assume the role. |
 | `trusted_oidc_provider_arn` | `""` | IAM OIDC provider ARN for keyless federation. |
-| `external_id` | `""` | `sts:ExternalId` guard against the confused-deputy problem. |
+| `external_id` | `""` | BYO `sts:ExternalId`. Empty → high-entropy value auto-generated and always enforced. |
 | `attach_view_only_access` | `true` | Also attach AWS-managed `ViewOnlyAccess`. |
 
 ## Outputs
 
 `role_arn`, `role_name`, `user_arn`, `user_name`, `attached_managed_policy_arns`,
-`external_id`.
+`external_id` (**sensitive** — `terraform output -raw external_id`).

--- a/deploy/terraform/connect-aws/main.tf
+++ b/deploy/terraform/connect-aws/main.tf
@@ -17,12 +17,36 @@ locals {
 
   use_role = var.principal_type == "role"
 
+  # Unique, non-guessable principal name by default. A predictable name is
+  # squattable/targetable, so unless the operator pins an explicit "name" we
+  # append a random hex suffix to "name_prefix".
+  principal_name = var.name != "" ? var.name : "${var.name_prefix}-${random_id.name_suffix.hex}"
+
+  # ExternalId is ALWAYS enforced (never silently omitted) to keep the
+  # confused-deputy defense on by default. Use the operator-supplied value when
+  # set, otherwise the auto-generated high-entropy one.
+  effective_external_id = var.external_id != "" ? var.external_id : random_password.external_id.result
+
   # AWS-managed read-only policies. SecurityAudit is the documented baseline;
   # ViewOnlyAccess is optional and additive.
   managed_policy_arns = compact([
     "arn:aws:iam::aws:policy/SecurityAudit",
     var.attach_view_only_access ? "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess" : "",
   ])
+}
+
+# ---------------------------------------------------------------------------
+# Secure-by-default randomness: a unique principal name and a high-entropy
+# ExternalId. Generated at apply time (not committed anywhere), so the defaults
+# are unique + unguessable without the operator hand-picking a value.
+# ---------------------------------------------------------------------------
+resource "random_id" "name_suffix" {
+  byte_length = 4
+}
+
+resource "random_password" "external_id" {
+  length  = 32
+  special = false
 }
 
 # ---------------------------------------------------------------------------
@@ -44,14 +68,12 @@ data "aws_iam_policy_document" "assume_role" {
         identifiers = var.trusted_principal_arns
       }
 
-      dynamic "condition" {
-        for_each = var.external_id != "" ? [1] : []
-
-        content {
-          test     = "StringEquals"
-          variable = "sts:ExternalId"
-          values   = [var.external_id]
-        }
+      # ExternalId is always required on cross-account assume-role — the
+      # confused-deputy defense cannot be silently turned off.
+      condition {
+        test     = "StringEquals"
+        variable = "sts:ExternalId"
+        values   = [local.effective_external_id]
       }
     }
   }
@@ -99,7 +121,7 @@ locals {
 resource "aws_iam_role" "this" {
   count = local.use_role ? 1 : 0
 
-  name                 = var.name
+  name                 = local.principal_name
   path                 = var.path
   description          = "Read-only role assumed by agent-bom (SecurityAudit + ViewOnlyAccess). No write permissions."
   assume_role_policy   = data.aws_iam_policy_document.assume_role[0].json
@@ -122,7 +144,7 @@ resource "aws_iam_role_policy_attachment" "this" {
 resource "aws_iam_user" "this" {
   count = local.use_role ? 0 : 1
 
-  name                 = var.name
+  name                 = local.principal_name
   path                 = var.path
   permissions_boundary = var.permissions_boundary_arn != "" ? var.permissions_boundary_arn : null
   tags                 = local.common_tags

--- a/deploy/terraform/connect-aws/outputs.tf
+++ b/deploy/terraform/connect-aws/outputs.tf
@@ -24,6 +24,7 @@ output "attached_managed_policy_arns" {
 }
 
 output "external_id" {
-  description = "ExternalId required on assume-role, if configured (empty otherwise)."
-  value       = var.external_id
+  description = "The sts:ExternalId required on assume-role. Always set (auto-generated when not supplied). Configure the agent-bom scanner with this value so it can assume the role. Marked sensitive — read it explicitly with `terraform output -raw external_id`."
+  value       = local.effective_external_id
+  sensitive   = true
 }

--- a/deploy/terraform/connect-aws/variables.tf
+++ b/deploy/terraform/connect-aws/variables.tf
@@ -1,7 +1,13 @@
 variable "name" {
-  description = "Name for the read-only role/user agent-bom assumes."
+  description = "Explicit, fixed name for the read-only role/user. Leave empty (default) to auto-generate a unique, non-guessable name (\"<name_prefix>-<random hex>\"), which defends against name-squatting and targeting of a predictable principal. Set this only when an external system requires a stable, known name."
   type        = string
-  default     = "agent-bom-readonly"
+  default     = ""
+}
+
+variable "name_prefix" {
+  description = "Prefix for the auto-generated unique principal name when \"name\" is empty. A random suffix is appended so the final name is unique and unpredictable."
+  type        = string
+  default     = "abom-readonly"
 }
 
 variable "principal_type" {
@@ -40,7 +46,7 @@ variable "trusted_oidc_audience" {
 }
 
 variable "external_id" {
-  description = "Optional sts:ExternalId required on assume-role, to defend against the confused-deputy problem in cross-account trust. Leave empty to omit."
+  description = "Bring-your-own sts:ExternalId required on assume-role, to defend against the confused-deputy problem in cross-account trust. Leave empty (default) to auto-generate a high-entropy ExternalId — the confused-deputy condition is ALWAYS applied and can never be silently omitted. Read the generated value from the (sensitive) external_id output and configure the scanner with it. Set this only to pin a known value."
   type        = string
   default     = ""
 }

--- a/deploy/terraform/connect-aws/versions.tf
+++ b/deploy/terraform/connect-aws/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }

--- a/deploy/terraform/connect-azure/README.md
+++ b/deploy/terraform/connect-azure/README.md
@@ -18,9 +18,41 @@ connector calls only `list`/`get` ARM APIs.
 - A **`Security Reader`** role assignment when `assign_security_reader = true`
   (default), for Microsoft Defender for Cloud posture.
 
-It does **not** create the service principal or its credentials. Bring an
-existing service principal (certificate auth, recommended) or managed identity
-and pass its **object ID** as `principal_id`. No secrets live in this module.
+By default it does **not** create the service principal or its credentials.
+Bring an existing service principal (certificate auth, recommended) or managed
+identity and pass its **object ID** as `principal_id`. No secrets live in this
+module.
+
+## Secure by default — keyless federated credential (optional)
+
+When you opt in with `create_federated_credential = true`, the module attaches a
+**federated identity credential** to your scanner application that is pinned to
+an **exact issuer + subject + audience** (`api://AzureADTokenExchange`), so only
+one specific external workload can exchange a token for the scanner SP — never a
+wide-open trust. The plan **fails** if the issuer or subject is empty, or if the
+subject contains a wildcard.
+
+```hcl
+module "agent_bom_connect" {
+  source = "github.com/<org>/agent-bom//deploy/terraform/connect-azure"
+
+  subscription_id = "00000000-0000-0000-0000-000000000000"
+  principal_id    = "11111111-1111-1111-1111-111111111111"
+
+  create_federated_credential         = true
+  federated_credential_application_id = "22222222-2222-2222-2222-222222222222"
+  federated_credential_issuer         = "https://token.actions.githubusercontent.com"
+  federated_credential_subject        = "repo:my-org/my-repo:ref:refs/heads/main" # exact, no wildcard
+  # audience defaults to api://AzureADTokenExchange
+}
+```
+
+> **Threat note.** A federated credential with an empty or wildcard subject
+> trusts *every* token from the issuer — any repo or workflow on that IdP could
+> impersonate the scanner SP (**wide-open federation / confused-deputy**).
+> Pinning issuer + subject + audience narrows the trust to one workload. Leave
+> `create_federated_credential = false` to keep the prior certificate-auth flow
+> unchanged.
 
 ## Usage
 
@@ -67,8 +99,13 @@ Azure network I/O.
 | `principal_type` | `ServicePrincipal` | Principal kind for the assignment. |
 | `assign_security_reader` | `true` | Also assign built-in Security Reader. |
 | `scope_override` | `""` | Management-group scope to cover all subscriptions. |
+| `create_federated_credential` | `false` | Pin a keyless federated credential (issuer+subject+audience). |
+| `federated_credential_issuer` | `""` | OIDC issuer. **Required when the credential is created.** |
+| `federated_credential_subject` | `""` | Exact subject (no wildcard). **Required when the credential is created.** |
+| `federated_credential_audience` | `api://AzureADTokenExchange` | Token-exchange audience. |
 
 ## Outputs
 
 `reader_role_assignment_id`, `security_reader_role_assignment_id`, `scope`,
-`principal_id`, `assigned_roles`.
+`principal_id`, `assigned_roles`, `federated_credential_id`,
+`federated_credential_subject`.

--- a/deploy/terraform/connect-azure/main.tf
+++ b/deploy/terraform/connect-azure/main.tf
@@ -32,3 +32,41 @@ resource "azurerm_role_assignment" "security_reader" {
   principal_type       = var.principal_type
   description          = "Read-only Defender for Cloud posture for agent-bom (built-in Security Reader). No write permissions."
 }
+
+# ---------------------------------------------------------------------------
+# Optional keyless federated credential. Pinned to an exact issuer + subject +
+# audience so only one specific external workload can exchange a token for the
+# scanner SP — a wide-open (empty subject/issuer) trust is rejected at plan time.
+# ---------------------------------------------------------------------------
+resource "azuread_application_federated_identity_credential" "scanner" {
+  count = var.create_federated_credential ? 1 : 0
+
+  application_id = var.federated_credential_application_id
+  display_name   = var.federated_credential_name
+  description    = "Keyless federated credential for the agent-bom read-only scanner. Pinned issuer + subject + audience."
+  issuer         = var.federated_credential_issuer
+  subject        = var.federated_credential_subject
+  audiences      = [var.federated_credential_audience]
+
+  lifecycle {
+    precondition {
+      condition     = trimspace(var.federated_credential_application_id) != ""
+      error_message = "create_federated_credential requires federated_credential_application_id (the Entra application object ID to attach the credential to)."
+    }
+
+    precondition {
+      condition     = trimspace(var.federated_credential_issuer) != ""
+      error_message = "create_federated_credential requires federated_credential_issuer — a federated credential must be pinned to a known OIDC issuer, never left open."
+    }
+
+    precondition {
+      condition     = trimspace(var.federated_credential_subject) != "" && !strcontains(var.federated_credential_subject, "*")
+      error_message = "create_federated_credential requires an exact federated_credential_subject (no wildcards). Pinning the subject is what prevents any token from the issuer from impersonating the scanner."
+    }
+
+    precondition {
+      condition     = trimspace(var.federated_credential_audience) != ""
+      error_message = "federated_credential_audience must not be empty (default api://AzureADTokenExchange)."
+    }
+  }
+}

--- a/deploy/terraform/connect-azure/outputs.tf
+++ b/deploy/terraform/connect-azure/outputs.tf
@@ -22,3 +22,13 @@ output "assigned_roles" {
   description = "Built-in read-only roles assigned to the principal."
   value       = compact(["Reader", var.assign_security_reader ? "Security Reader" : ""])
 }
+
+output "federated_credential_id" {
+  description = "ID of the keyless federated identity credential (empty when create_federated_credential is false)."
+  value       = var.create_federated_credential ? azuread_application_federated_identity_credential.scanner[0].id : ""
+}
+
+output "federated_credential_subject" {
+  description = "The exact subject the federated credential is pinned to (empty when not created)."
+  value       = var.create_federated_credential ? var.federated_credential_subject : ""
+}

--- a/deploy/terraform/connect-azure/variables.tf
+++ b/deploy/terraform/connect-azure/variables.tf
@@ -30,3 +30,44 @@ variable "scope_override" {
   type        = string
   default     = ""
 }
+
+# --- Optional keyless federated credential (Workload Identity Federation) -----
+# When enabled, this module pins a federated identity credential on the scanner
+# application to an exact issuer + subject + audience, so only one specific
+# external workload can mint tokens for the SP — never a wide-open trust.
+
+variable "create_federated_credential" {
+  description = "Create a keyless federated identity credential on the scanner application, pinned to a specific issuer + subject + audience. Leave false (default) to only assign RBAC roles to an existing principal (bring-your-own SP/managed-identity certificate auth, as before)."
+  type        = bool
+  default     = false
+}
+
+variable "federated_credential_application_id" {
+  description = "Object ID of the Entra (Azure AD) application to attach the federated credential to. Required when create_federated_credential is true."
+  type        = string
+  default     = ""
+}
+
+variable "federated_credential_name" {
+  description = "Name of the federated identity credential."
+  type        = string
+  default     = "agent-bom-readonly"
+}
+
+variable "federated_credential_issuer" {
+  description = "REQUIRED when create_federated_credential is true: the exact OIDC issuer URL of the external IdP (e.g. https://token.actions.githubusercontent.com). An empty issuer is rejected at plan time — a federated credential must be pinned to a known issuer."
+  type        = string
+  default     = ""
+}
+
+variable "federated_credential_subject" {
+  description = "REQUIRED when create_federated_credential is true: the exact subject the external token must carry (e.g. repo:my-org/my-repo:ref:refs/heads/main). An empty/wildcard subject is rejected at plan time — pinning the subject is what prevents any token from the issuer from impersonating the scanner."
+  type        = string
+  default     = ""
+}
+
+variable "federated_credential_audience" {
+  description = "Audience the federated credential accepts. Defaults to the Entra token-exchange audience and must not be empty."
+  type        = string
+  default     = "api://AzureADTokenExchange"
+}

--- a/deploy/terraform/connect-azure/versions.tf
+++ b/deploy/terraform/connect-azure/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 4.0"
     }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = ">= 2.0"
+    }
   }
 }
 

--- a/deploy/terraform/connect-gcp/README.md
+++ b/deploy/terraform/connect-gcp/README.md
@@ -12,7 +12,8 @@ calls only `list`/`get` APIs.
 
 ## What it creates
 
-- A read-only **service account** (`agent-bom-readonly@<project>.iam…`).
+- A read-only **service account** with a **unique, non-guessable account_id**
+  (`abom-readonly-<random hex>@<project>.iam…` by default).
 - Project IAM bindings: **`roles/viewer`** (inventory) and
   **`roles/iam.securityReviewer`** (read-only IAM policy access for CIEM/posture).
 - **Optionally** (variable-gated) a **Workload Identity Federation** pool +
@@ -23,6 +24,26 @@ calls only `list`/`get` APIs.
 disable SA keys org-wide). Prefer Workload Identity Federation or SA
 impersonation. If you must use a key, mint it out-of-band; it is never written
 into this module's state.
+
+## Secure by default
+
+- **Unique, unpredictable SA name (anti-squatting).** `service_account_id`
+  defaults to `abom-readonly-<random hex>`, so the SA is not a predictable,
+  squattable, or targetable identity. Override `service_account_id = "..."`
+  only when a stable, known account_id is required.
+- **No wide-open federation (fail-safe).** When
+  `enable_workload_identity_federation = true`, the plan **fails** unless you
+  supply a scoped `wif_attribute_condition`, at least one
+  `wif_allowed_audiences`, a `wif_issuer_uri`, and a `wif_principal_set`. An
+  empty `attribute_condition` previously allowed **any** token from the issuer
+  to impersonate the read-only SA; that is now rejected before apply.
+
+> **Threat note.** A WIF provider with no attribute condition trusts *every*
+> token the issuer mints — any repo, any workflow, any tenant on that IdP could
+> impersonate the read-only SA (**wide-open federation**). Pinning the
+> condition, audience, and principalSet narrows the trust to one specific
+> external workload. A *predictable* SA name is also easier to **squat or
+> target**, which the randomized default closes.
 
 ## Usage
 
@@ -35,7 +56,8 @@ module "agent_bom_connect" {
 
   enable_workload_identity_federation = true
   wif_issuer_uri          = "https://token.actions.githubusercontent.com"
-  wif_attribute_condition = "assertion.repository == 'my-org/my-repo'"
+  wif_attribute_condition = "assertion.repository == 'my-org/my-repo'"  # required, scoped
+  wif_allowed_audiences   = ["https://github.com/my-org"]               # required, pinned
   wif_attribute_mapping = {
     "google.subject"       = "assertion.sub"
     "attribute.repository" = "assertion.repository"
@@ -72,10 +94,13 @@ network I/O.
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `project_id` | — | Project to scope the grant to. |
+| `service_account_id` | `""` | Fixed account_id override. Empty → auto-generated unique account_id. |
+| `service_account_id_prefix` | `abom-readonly` | Prefix for the auto-generated unique account_id. |
 | `enable_workload_identity_federation` | `false` | Create a keyless WIF pool/provider. |
-| `wif_issuer_uri` | `""` | OIDC issuer of the external IdP. |
-| `wif_attribute_condition` | `""` | CEL condition restricting which identities may federate. |
-| `wif_principal_set` | `""` | `principalSet://` member allowed to impersonate the SA. |
+| `wif_issuer_uri` | `""` | OIDC issuer of the external IdP. **Required when WIF is on.** |
+| `wif_attribute_condition` | `""` | Scoped CEL condition. **Required when WIF is on** (empty is rejected). |
+| `wif_allowed_audiences` | `[]` | Pinned audiences. **Required (≥1) when WIF is on.** |
+| `wif_principal_set` | `""` | `principalSet://` member allowed to impersonate the SA. **Required when WIF is on.** |
 
 ## Outputs
 

--- a/deploy/terraform/connect-gcp/main.tf
+++ b/deploy/terraform/connect-gcp/main.tf
@@ -7,9 +7,20 @@
 # Keyless by default: this module creates NO service-account key. Use Workload
 # Identity Federation (variable-gated below) since many orgs disable SA keys.
 
+# Unique, non-guessable SA account_id by default. A predictable SA name is
+# squattable/targetable, so unless the operator pins an explicit
+# service_account_id we append a random hex suffix to the prefix.
+resource "random_id" "sa_suffix" {
+  byte_length = 4
+}
+
+locals {
+  service_account_id = var.service_account_id != "" ? var.service_account_id : "${var.service_account_id_prefix}-${random_id.sa_suffix.hex}"
+}
+
 resource "google_service_account" "this" {
   project      = var.project_id
-  account_id   = var.service_account_id
+  account_id   = local.service_account_id
   display_name = var.service_account_display_name
   description  = "Read-only service account assumed by agent-bom (viewer + securityReviewer). No write permissions."
 }
@@ -49,17 +60,47 @@ resource "google_iam_workload_identity_pool_provider" "this" {
   workload_identity_pool_provider_id = var.wif_provider_id
   display_name                       = "agent-bom OIDC"
   attribute_mapping                  = var.wif_attribute_mapping
-  attribute_condition                = var.wif_attribute_condition != "" ? var.wif_attribute_condition : null
+
+  # Always scoped: a federation provider with no attribute_condition would let
+  # ANY token from the issuer impersonate the read-only SA. This is enforced by
+  # the precondition below, so the value is never null when WIF is enabled.
+  attribute_condition = var.wif_attribute_condition
 
   oidc {
-    issuer_uri        = var.wif_issuer_uri
-    allowed_audiences = length(var.wif_allowed_audiences) > 0 ? var.wif_allowed_audiences : null
+    issuer_uri = var.wif_issuer_uri
+    # Pin the accepted audiences. An unpinned audience widens the federation
+    # trust; the precondition below requires at least one.
+    allowed_audiences = var.wif_allowed_audiences
+  }
+
+  lifecycle {
+    precondition {
+      condition     = trimspace(var.wif_attribute_condition) != ""
+      error_message = "Workload Identity Federation requires a non-empty wif_attribute_condition (a scoped CEL like \"assertion.repository == 'my-org/my-repo'\"). An empty condition would let any token from the issuer impersonate the read-only service account (wide-open federation)."
+    }
+
+    precondition {
+      condition     = length(var.wif_allowed_audiences) > 0
+      error_message = "Workload Identity Federation requires at least one wif_allowed_audiences entry. An unpinned audience widens the federation trust beyond the intended workload."
+    }
+
+    precondition {
+      condition     = trimspace(var.wif_issuer_uri) != ""
+      error_message = "Workload Identity Federation requires wif_issuer_uri (the OIDC issuer of the external IdP)."
+    }
+
+    precondition {
+      condition     = trimspace(var.wif_principal_set) != ""
+      error_message = "Workload Identity Federation requires wif_principal_set so the impersonation binding is scoped to a specific external identity, not the whole pool."
+    }
   }
 }
 
 # Allow the federated principalSet to impersonate the read-only SA (keyless).
+# Scoped to the specific principalSet (enforced non-empty by the provider
+# precondition above), never the whole pool.
 resource "google_service_account_iam_member" "wif_impersonation" {
-  count = var.enable_workload_identity_federation && var.wif_principal_set != "" ? 1 : 0
+  count = var.enable_workload_identity_federation ? 1 : 0
 
   service_account_id = google_service_account.this.name
   role               = "roles/iam.workloadIdentityUser"

--- a/deploy/terraform/connect-gcp/variables.tf
+++ b/deploy/terraform/connect-gcp/variables.tf
@@ -4,9 +4,15 @@ variable "project_id" {
 }
 
 variable "service_account_id" {
-  description = "The account_id (left part of the email) for the read-only service account agent-bom uses."
+  description = "Explicit, fixed account_id (left part of the email) for the read-only service account. Leave empty (default) to auto-generate a unique, non-guessable account_id (\"<service_account_id_prefix>-<random hex>\"), which defends against name-squatting and targeting of a predictable SA. Set this only when an external system requires a stable, known account_id."
   type        = string
-  default     = "agent-bom-readonly"
+  default     = ""
+}
+
+variable "service_account_id_prefix" {
+  description = "Prefix for the auto-generated unique service-account account_id when service_account_id is empty. A random suffix is appended so the final account_id is unique and unpredictable. Must keep the final account_id within GCP's 6-30 char limit."
+  type        = string
+  default     = "abom-readonly"
 }
 
 variable "service_account_display_name" {
@@ -45,7 +51,7 @@ variable "wif_issuer_uri" {
 }
 
 variable "wif_allowed_audiences" {
-  description = "Optional list of allowed audiences for the OIDC provider. Empty uses the default audience derived from the provider resource name."
+  description = "Allowed audiences for the OIDC provider. Required (at least one) when enable_workload_identity_federation is true — an unpinned audience widens the federation trust. Set this to the audience your external IdP issues tokens for."
   type        = list(string)
   default     = []
 }
@@ -59,13 +65,13 @@ variable "wif_attribute_mapping" {
 }
 
 variable "wif_attribute_condition" {
-  description = "Optional CEL condition restricting which external identities may use the provider (e.g. assertion.repository == 'my-org/my-repo'). Empty allows any token from the issuer — set this in production."
+  description = "REQUIRED when enable_workload_identity_federation is true: a scoped CEL condition restricting which external identities may use the provider (e.g. assertion.repository == 'my-org/my-repo'). An empty condition is rejected at plan time because it would let ANY token from the issuer impersonate the read-only SA (wide-open federation)."
   type        = string
   default     = ""
 }
 
 variable "wif_principal_set" {
-  description = "The principalSet:// member allowed to impersonate the SA via the pool (e.g. principalSet://iam.googleapis.com/<pool-resource>/attribute.repository/my-org/my-repo). Required to bind impersonation when WIF is enabled."
+  description = "REQUIRED when enable_workload_identity_federation is true: the principalSet:// member allowed to impersonate the SA via the pool (e.g. principalSet://iam.googleapis.com/<pool-resource>/attribute.repository/my-org/my-repo). Scopes impersonation to a specific external identity, not the whole pool. Empty is rejected at plan time."
   type        = string
   default     = ""
 }

--- a/deploy/terraform/connect-gcp/versions.tf
+++ b/deploy/terraform/connect-gcp/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }
 

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -98,6 +98,14 @@ constants in `cloud/aws_inventory.py` (`_AWS_*_PERMISSIONS`) and
 `cloud/aws_organizations.py` (`_AWS_ORG_PERMISSIONS`). Secret *values* are never
 read — only existence and rotation state.
 
+**Secure-by-default provisioning** (`deploy/terraform/connect-aws`): the read-only
+role gets a **unique, non-guessable name** (`abom-readonly-<random hex>`) and an
+**always-enforced, high-entropy `sts:ExternalId`** — generated automatically when
+you don't supply one and surfaced via a *sensitive* `external_id` output. The
+confused-deputy condition can never be silently omitted, and a predictable
+principal name can't be squatted or targeted. Both have override variables for
+operators who need a fixed name or a BYO External ID.
+
 **One SDK, proven current:** AWS support uses a single dependency (`boto3`, the
 `aws` extra). A guard test (`tests/test_aws_boto3_client_coverage.py`) scrapes
 every `.client("…")` the code uses and asserts each is a real service in the
@@ -138,6 +146,16 @@ cap (default 500) bounds blast radius.
 **SDK fragility, handled:** Azure SDKs are per-service distributions, so each is
 imported under `try/except ImportError` and degrades to a warning if absent —
 one missing package never crashes a scan.
+
+**Secure-by-default provisioning** (`deploy/terraform/connect-azure`): the
+optional keyless **federated identity credential** is pinned to an exact
+**issuer + subject + audience** (`api://AzureADTokenExchange`). The plan fails if
+the subject is empty or contains a wildcard, so only one specific external
+workload can exchange a token for the scanner principal — never a wide-open
+trust. The GCP module (`deploy/terraform/connect-gcp`) is locked the same way:
+Workload Identity Federation cannot be enabled without a scoped
+`attribute_condition`, pinned audiences, and a specific `principalSet`, and the
+service account gets a unique, non-guessable name.
 
 ---
 
@@ -213,6 +231,21 @@ Discoveries that need a grant you didn't give degrade to empty rather than error
   permissions exercised, so an auditor can verify the blast radius.
 - **Sanitized errors.** Connector exceptions pass through a central sanitizer
   before they reach logs or output, so a malformed credential can't leak.
+- **Secure-by-default identities.** The Terraform connect modules mint the
+  read-only identity so it is **unique, unguessable, and not exploitable**: a
+  randomized principal name (anti-squatting), a mandatory high-entropy AWS
+  `ExternalId` (confused-deputy defense), and federation that is locked to a
+  specific issuer + subject + audience (no wide-open trust). Overrides exist for
+  operators who need fixed values; only the *defaults* changed, so existing
+  configs that pin a name/External ID still apply unchanged.
+
+> **Threat note (provisioning).** Two classic IAM pitfalls these defaults close:
+> the **confused-deputy** problem — where a third party that learns your role
+> ARN tricks the shared scanner account into assuming it without an ExternalId
+> guard — and **name-squatting / targeting** of a predictable principal name.
+> Wide-open federation (an OIDC trust with no subject/condition) is the cloud
+> equivalent: any token from the issuer could impersonate the read-only
+> identity. The modules now make the secure path the default one.
 
 ---
 


### PR DESCRIPTION
Hardens the Terraform connect modules so the read-only identity each cloud connector assumes is **unique, unguessable, and not exploitable** — while preserving every existing override path and the read-only/keyless posture. Only the *defaults* changed.

## AWS (`deploy/terraform/connect-aws`)
- **Mandatory ExternalId (confused-deputy defense).** The `sts:ExternalId` trust condition is now **always** applied on cross-account assume-role. Previously it was gated on a non-empty variable, so the defense could be silently off.
- **Auto-generated high-entropy ExternalId.** When `external_id` is empty, a 32-char random value is generated and surfaced via a *sensitive* `external_id` output. BYO-ID override preserved.
- **Unique, unpredictable name (anti-squatting).** The role/user name defaults to `abom-readonly-<random hex>`. Fixed-name override preserved via `name`.
- Adds the `random` provider.

## GCP (`deploy/terraform/connect-gcp`)
- **Wide-open federation fail-safe.** Enabling Workload Identity Federation now **fails at plan time** unless a scoped `wif_attribute_condition`, at least one `wif_allowed_audiences`, a `wif_issuer_uri`, and a `wif_principal_set` are supplied. An empty condition previously let any token from the issuer impersonate the read-only service account.
- **Unique service-account name** (`abom-readonly-<random hex>`), override preserved.

## Azure (`deploy/terraform/connect-azure`)
- **Optional keyless federated credential, pinned.** When `create_federated_credential = true`, the federated identity credential is pinned to an exact **issuer + subject + audience** (`api://AzureADTokenExchange`); preconditions reject an empty/wildcard subject or empty issuer. Default flow (RBAC-only against an existing principal) is unchanged.

## Docs
- Module READMEs and `docs/CLOUD_CONNECT.md` document the secure-by-default behavior with a confused-deputy / name-squatting / wide-open-federation threat note.

## Validation
- `terraform fmt -check -recursive` over all four modules: pass.
- `terraform validate` per module (`-backend=false`): all valid.
- `terraform plan` confirms the GCP WIF preconditions block an unscoped provider and that AWS generates the random ExternalId + name; `terraform console` confirms BYO `external_id`/`name` overrides flow through unchanged.

## Compatibility
Operators who already set `external_id`, `name`, or `service_account_id` are unaffected — only the defaults became secure. No secrets are written to state or the repo; generated values are exposed via outputs only.