### PR TITLE
feat(cloud): partial-permission tolerance for AWS, Azure, and GCP inventory

### DIFF
--- a/src/agent_bom/cloud/aws_inventory.py
+++ b/src/agent_bom/cloud/aws_inventory.py
@@ -131,6 +131,169 @@ _INTERNET_CIDRS = {"0.0.0.0/0"}
 _INTERNET_IPV6 = {"::/0"}
 
 
+# ---------------------------------------------------------------------------
+# Cross-cloud degrade-don't-crash helpers
+#
+# These are the single source of truth for turning a failed discovery call into
+# (a) a user-facing warning and (b) — when the failure is an access/permission
+# error — a SPECIFIC, actionable warning plus a structured `missing_permissions`
+# entry the product can render as "here is exactly what to grant".
+#
+# Azure and GCP inventory import these so all three providers degrade to the same
+# bar: one failed discoverer -> one warning + (when access-denied) one
+# missing_permissions entry -> `continue`, never an abort, never a silent empty
+# result. Keep secrets out of every message by routing through
+# sanitize_discovery_warning.
+# ---------------------------------------------------------------------------
+
+# Substrings that mark an exception as an access/permission failure, matched
+# case-insensitively against the SDK error code / message. Covers AWS botocore
+# (AccessDenied / UnauthorizedOperation / AccessDeniedException), Azure
+# (AuthorizationFailed / Forbidden / 403), and GCP (PermissionDenied / 403).
+_ACCESS_DENIED_MARKERS: tuple[str, ...] = (
+    "accessdenied",
+    "access denied",
+    "unauthorizedoperation",
+    "authorizationfailed",
+    "permissiondenied",
+    "permission denied",
+    "forbidden",
+    "notauthorized",
+    "not authorized",
+    "insufficient permission",
+    "insufficient_permission",
+    "iam.serviceaccounts.actas",
+)
+
+
+def _error_code(exc: BaseException) -> str:
+    """Best-effort SDK error code extraction across botocore / Azure / GCP.
+
+    - botocore ``ClientError`` exposes ``response["Error"]["Code"]``.
+    - Azure ``HttpResponseError`` exposes ``.error.code`` and ``.status_code``.
+    - GCP ``GoogleAPICallError`` exposes ``.code`` (a grpc status or int).
+
+    Never raises — a provider that does not expose these attributes returns "".
+    """
+    code = ""
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        err = response.get("Error")
+        if isinstance(err, dict):
+            code = str(err.get("Code", "") or "")
+    if not code:
+        inner = getattr(exc, "error", None)
+        inner_code = getattr(inner, "code", None)
+        if inner_code is not None:
+            code = str(inner_code)
+    if not code:
+        direct = getattr(exc, "code", None)
+        if direct is not None:
+            code = str(direct)
+    return code
+
+
+def _status_code(exc: BaseException) -> int | None:
+    """Best-effort HTTP status extraction (Azure ``status_code`` / botocore 403)."""
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        return status
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        meta = response.get("ResponseMetadata")
+        if isinstance(meta, dict):
+            http_status = meta.get("HTTPStatusCode")
+            if isinstance(http_status, int):
+                return http_status
+    return None
+
+
+def is_access_denied_error(exc: BaseException) -> bool:
+    """Return whether *exc* is an access/permission failure (any cloud SDK).
+
+    Detection is layered so it works without importing every provider SDK:
+    a 401/403 HTTP status, a known error code, or an access-denied marker in the
+    error code / message text. Type name is also checked so SDK-specific
+    permission exceptions (e.g. GCP ``PermissionDenied`` / ``Forbidden``) are
+    caught even when the message text is sparse.
+    """
+    status = _status_code(exc)
+    if status in (401, 403):
+        return True
+    haystacks = [
+        _error_code(exc).lower(),
+        type(exc).__name__.lower(),
+        str(exc).lower(),
+    ]
+    return any(marker in field for field in haystacks for marker in _ACCESS_DENIED_MARKERS)
+
+
+def build_missing_permission(*, cloud: str, permission: str, resource_type: str) -> dict[str, str]:
+    """Return one structured ``missing_permissions`` entry.
+
+    The tuple ``(cloud, permission, resource_type)`` is the dedup key so the same
+    grant surfaced from two regions/subscriptions collapses to a single row.
+    """
+    return {
+        "cloud": cloud,
+        "permission": permission,
+        "resource_type": resource_type,
+    }
+
+
+def dedupe_missing_permissions(items: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Return a sorted, de-duplicated ``missing_permissions`` list.
+
+    Deterministic + idempotent: same failures (in any order) always produce the
+    same set of rows, sorted by (cloud, resource_type, permission), so report
+    output is byte-stable across runs.
+    """
+    seen: set[tuple[str, str, str]] = set()
+    unique: list[dict[str, str]] = []
+    for item in items:
+        key = (
+            str(item.get("cloud", "") or ""),
+            str(item.get("permission", "") or ""),
+            str(item.get("resource_type", "") or ""),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append({"cloud": key[0], "permission": key[1], "resource_type": key[2]})
+    unique.sort(key=lambda row: (row["cloud"], row["resource_type"], row["permission"]))
+    return unique
+
+
+def record_discovery_failure(
+    *,
+    exc: BaseException,
+    resource_type: str,
+    permission: str,
+    cloud: str,
+    warnings: list[str],
+    missing: list[dict[str, str]] | None = None,
+) -> None:
+    """Translate a failed discovery call into operator-facing diagnostics.
+
+    On an access/permission error this emits a SPECIFIC, actionable warning that
+    names the missing permission and the resource type being skipped, and records
+    a structured ``missing_permissions`` entry (when *missing* is provided). On
+    any other failure it emits a generic, sanitized warning. Either way the
+    skipped resource type ALWAYS produces a warning — never a silent empty
+    result. Secrets are stripped via ``sanitize_discovery_warning``.
+    """
+    detail = sanitize_discovery_warning(exc)
+    if is_access_denied_error(exc):
+        warnings.append(
+            f"Skipped {resource_type}: role lacks {permission} — "
+            f"add it to the read-only policy to cover this resource type. ({detail})"
+        )
+        if missing is not None:
+            missing.append(build_missing_permission(cloud=cloud, permission=permission, resource_type=resource_type))
+    else:
+        warnings.append(f"Could not list {resource_type}: {detail}")
+
+
 _legacy_flag_warned = False
 
 
@@ -197,6 +360,7 @@ def _empty_payload(*, region: str) -> dict[str, Any]:
         "redshift_clusters": [],
         "messaging": [],
         "warnings": [],
+        "missing_permissions": [],
         "discovery_envelope": None,
     }
 
@@ -349,6 +513,8 @@ def discover_inventory_all_regions(
         return {**global_payload, "region": global_region}
     warnings.extend(global_payload.get("warnings", []))
 
+    missing: list[dict[str, str]] = list(global_payload.get("missing_permissions", []) or [])
+
     account_id = global_payload.get("account_id")
 
     merged: dict[str, list[dict[str, Any]]] = {key: [] for key in _REGION_SCOPED_KEYS}
@@ -385,6 +551,7 @@ def discover_inventory_all_regions(
             continue
         for warning in payload.get("warnings", []):
             warnings.append(f"[{region}] {warning}")
+        missing.extend(payload.get("missing_permissions", []) or [])
         if payload.get("status") != "ok":
             # A degraded region surfaces its warnings (above) but contributes no
             # resources — it must never abort the merge.
@@ -465,6 +632,7 @@ def discover_inventory_all_regions(
         "redshift_clusters": merged["redshift_clusters"],
         "messaging": merged["messaging"],
         "warnings": warnings,
+        "missing_permissions": dedupe_missing_permissions(missing),
         "discovery_envelope": envelope.to_dict(),
     }
 
@@ -527,6 +695,7 @@ def discover_inventory(
     account_id = _resolve_account_id(session)
 
     warnings: list[str] = []
+    missing: list[dict[str, str]] = []
     buckets: list[dict[str, Any]] = []
     instances: list[dict[str, Any]] = []
     security_groups: list[dict[str, Any]] = []
@@ -547,26 +716,30 @@ def discover_inventory(
 
     try:
         if include_s3:
-            buckets = _discover_s3_buckets(session, account_id=account_id, warnings=warnings)
+            buckets = _discover_s3_buckets(session, account_id=account_id, warnings=warnings, missing=missing)
         if include_ec2:
-            instances, security_groups = _discover_ec2(session, resolved_region, account_id=account_id, warnings=warnings)
+            instances, security_groups = _discover_ec2(
+                session, resolved_region, account_id=account_id, warnings=warnings, missing=missing
+            )
         if include_iam:
-            roles, users = _discover_iam(session, account_id=account_id, warnings=warnings)
+            roles, users = _discover_iam(session, account_id=account_id, warnings=warnings, missing=missing)
         if include_data:
-            rds_instances = _discover_rds(session, resolved_region, account_id=account_id, warnings=warnings)
-            dynamodb_tables = _discover_dynamodb(session, resolved_region, account_id=account_id, warnings=warnings)
-            kms_keys = _discover_kms(session, resolved_region, account_id=account_id, warnings=warnings)
-            secrets = _discover_secrets(session, resolved_region, account_id=account_id, warnings=warnings)
-            redshift_clusters = _discover_redshift(session, resolved_region, account_id=account_id, warnings=warnings)
+            rds_instances = _discover_rds(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
+            dynamodb_tables = _discover_dynamodb(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
+            kms_keys = _discover_kms(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
+            secrets = _discover_secrets(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
+            redshift_clusters = _discover_redshift(
+                session, resolved_region, account_id=account_id, warnings=warnings, missing=missing
+            )
         if include_compute:
-            lambda_functions = _discover_lambda(session, resolved_region, account_id=account_id, warnings=warnings)
-            eks_clusters = _discover_eks(session, resolved_region, account_id=account_id, warnings=warnings)
-            ecr_repositories = _discover_ecr(session, resolved_region, account_id=account_id, warnings=warnings)
+            lambda_functions = _discover_lambda(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
+            eks_clusters = _discover_eks(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
+            ecr_repositories = _discover_ecr(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
         if include_network:
-            elb_load_balancers = _discover_elb(session, resolved_region, account_id=account_id, warnings=warnings)
-            vpcs = _discover_vpcs(session, resolved_region, account_id=account_id, warnings=warnings)
-            cloudfront_distributions = _discover_cloudfront(session, account_id=account_id, warnings=warnings)
-            messaging = _discover_messaging(session, resolved_region, account_id=account_id, warnings=warnings)
+            elb_load_balancers = _discover_elb(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
+            vpcs = _discover_vpcs(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
+            cloudfront_distributions = _discover_cloudfront(session, account_id=account_id, warnings=warnings, missing=missing)
+            messaging = _discover_messaging(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
     except NoCredentialsError:
         return {
             **empty,
@@ -626,6 +799,7 @@ def discover_inventory(
         "redshift_clusters": redshift_clusters,
         "messaging": messaging,
         "warnings": warnings,
+        "missing_permissions": dedupe_missing_permissions(missing),
         "discovery_envelope": envelope.to_dict(),
     }
 
@@ -635,7 +809,9 @@ def discover_inventory(
 # ---------------------------------------------------------------------------
 
 
-def _discover_s3_buckets(session: Any, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_s3_buckets(
+    session: Any, *, account_id: str | None, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate every S3 bucket in the account (read-only).
 
     Public-access posture is read from the bucket's PublicAccessBlock and
@@ -647,8 +823,10 @@ def _discover_s3_buckets(session: Any, *, account_id: str | None, warnings: list
 
     try:
         listed = s3.list_buckets().get("Buckets", [])
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list S3 buckets: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed S3 list must not sink the scan
+        record_discovery_failure(
+            exc=exc, resource_type="S3 buckets", permission="s3:ListAllMyBuckets", cloud="aws", warnings=warnings, missing=missing
+        )
         return buckets
 
     for bucket in listed:
@@ -731,6 +909,7 @@ def _discover_ec2(
     *,
     account_id: str | None,
     warnings: list[str],
+    missing: list[dict[str, str]] | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Enumerate all EC2 instances and security groups in *region* (read-only).
 
@@ -748,16 +927,25 @@ def _discover_ec2(
             for reservation in page.get("Reservations", []):
                 for instance in reservation.get("Instances", []):
                     instances.append(_normalize_instance(instance, region=region, account_id=account_id))
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not describe EC2 instances: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed EC2 describe must not sink the scan
+        record_discovery_failure(
+            exc=exc, resource_type="EC2 instances", permission="ec2:DescribeInstances", cloud="aws", warnings=warnings, missing=missing
+        )
 
     try:
         sg_paginator = ec2.get_paginator("describe_security_groups")
         for page in sg_paginator.paginate():
             for group in page.get("SecurityGroups", []):
                 security_groups.append(_normalize_security_group(group, region=region, account_id=account_id))
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not describe EC2 security groups: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed SG describe must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="EC2 security groups",
+            permission="ec2:DescribeSecurityGroups",
+            cloud="aws",
+            warnings=warnings,
+            missing=missing,
+        )
 
     return instances, security_groups
 
@@ -842,6 +1030,7 @@ def _discover_iam(
     *,
     account_id: str | None,
     warnings: list[str],
+    missing: list[dict[str, str]] | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Enumerate all IAM roles and users in the account (read-only).
 
@@ -859,16 +1048,20 @@ def _discover_iam(
         for page in role_paginator.paginate():
             for role in page.get("Roles", []):
                 roles.append(_normalize_role(iam, role, account_id=account_id, warnings=warnings))
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list IAM roles: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed IAM list must not sink the scan
+        record_discovery_failure(
+            exc=exc, resource_type="IAM roles", permission="iam:ListRoles", cloud="aws", warnings=warnings, missing=missing
+        )
 
     try:
         user_paginator = iam.get_paginator("list_users")
         for page in user_paginator.paginate():
             for user in page.get("Users", []):
                 users.append(_normalize_user(iam, user, account_id=account_id, warnings=warnings))
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list IAM users: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed IAM list must not sink the scan
+        record_discovery_failure(
+            exc=exc, resource_type="IAM users", permission="iam:ListUsers", cloud="aws", warnings=warnings, missing=missing
+        )
 
     return roles, users
 
@@ -1031,7 +1224,9 @@ def _highest_privilege(policies: list[dict[str, Any]]) -> str:
     return best
 
 
-def _discover_rds(session: Any, region: str, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_rds(
+    session: Any, region: str, *, account_id: str | None, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate RDS database instances (read-only). Become ``DATABASE`` data stores."""
     out: list[dict[str, Any]] = []
     try:
@@ -1054,12 +1249,16 @@ def _discover_rds(session: Any, region: str, *, account_id: str | None, warnings
                         "location": region,
                     }
                 )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list RDS instances: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed RDS list must not sink the scan
+        record_discovery_failure(
+            exc=exc, resource_type="RDS instances", permission="rds:DescribeDBInstances", cloud="aws", warnings=warnings, missing=missing
+        )
     return out
 
 
-def _discover_lambda(session: Any, region: str, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_lambda(
+    session: Any, region: str, *, account_id: str | None, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate Lambda functions (read-only). Become ``SERVERLESS_FUNCTION`` resources."""
     out: list[dict[str, Any]] = []
     try:
@@ -1082,12 +1281,16 @@ def _discover_lambda(session: Any, region: str, *, account_id: str | None, warni
                         "location": region,
                     }
                 )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Lambda functions: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Lambda list must not sink the scan
+        record_discovery_failure(
+            exc=exc, resource_type="Lambda functions", permission="lambda:ListFunctions", cloud="aws", warnings=warnings, missing=missing
+        )
     return out
 
 
-def _discover_dynamodb(session: Any, region: str, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_dynamodb(
+    session: Any, region: str, *, account_id: str | None, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate DynamoDB tables (read-only). Become ``DATABASE`` data stores."""
     out: list[dict[str, Any]] = []
     try:
@@ -1113,12 +1316,16 @@ def _discover_dynamodb(session: Any, region: str, *, account_id: str | None, war
                         "location": region,
                     }
                 )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list DynamoDB tables: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed DynamoDB list must not sink the scan
+        record_discovery_failure(
+            exc=exc, resource_type="DynamoDB tables", permission="dynamodb:ListTables", cloud="aws", warnings=warnings, missing=missing
+        )
     return out
 
 
-def _discover_eks(session: Any, region: str, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_eks(
+    session: Any, region: str, *, account_id: str | None, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate EKS clusters (read-only). Become ``CONTAINER_CLUSTER`` resources."""
     out: list[dict[str, Any]] = []
     try:
@@ -1144,12 +1351,16 @@ def _discover_eks(session: Any, region: str, *, account_id: str | None, warnings
                     "location": region,
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list EKS clusters: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed EKS list must not sink the scan
+        record_discovery_failure(
+            exc=exc, resource_type="EKS clusters", permission="eks:ListClusters", cloud="aws", warnings=warnings, missing=missing
+        )
     return out
 
 
-def _discover_elb(session: Any, region: str, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_elb(
+    session: Any, region: str, *, account_id: str | None, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate ALB/NLB load balancers (read-only). Internet-facing scheme = exposed."""
     out: list[dict[str, Any]] = []
     try:
@@ -1173,12 +1384,21 @@ def _discover_elb(session: Any, region: str, *, account_id: str | None, warnings
                         "location": region,
                     }
                 )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list load balancers: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed ELB list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="load balancers",
+            permission="elasticloadbalancing:DescribeLoadBalancers",
+            cloud="aws",
+            warnings=warnings,
+            missing=missing,
+        )
     return out
 
 
-def _discover_vpcs(session: Any, region: str, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_vpcs(
+    session: Any, region: str, *, account_id: str | None, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate VPCs (read-only). Become ``CLOUD_RESOURCE`` network nodes."""
     out: list[dict[str, Any]] = []
     try:
@@ -1201,12 +1421,16 @@ def _discover_vpcs(session: Any, region: str, *, account_id: str | None, warning
                     "location": region,
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list VPCs: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed VPC list must not sink the scan
+        record_discovery_failure(
+            exc=exc, resource_type="VPCs", permission="ec2:DescribeVpcs", cloud="aws", warnings=warnings, missing=missing
+        )
     return out
 
 
-def _discover_kms(session: Any, region: str, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_kms(
+    session: Any, region: str, *, account_id: str | None, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate customer-managed KMS keys (read-only). Metadata only, never key material."""
     out: list[dict[str, Any]] = []
     try:
@@ -1240,12 +1464,16 @@ def _discover_kms(session: Any, region: str, *, account_id: str | None, warnings
                         "location": region,
                     }
                 )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list KMS keys: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed KMS list must not sink the scan
+        record_discovery_failure(
+            exc=exc, resource_type="KMS keys", permission="kms:ListKeys", cloud="aws", warnings=warnings, missing=missing
+        )
     return out
 
 
-def _discover_secrets(session: Any, region: str, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_secrets(
+    session: Any, region: str, *, account_id: str | None, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate Secrets Manager secrets (read-only). Metadata only — never secret values."""
     out: list[dict[str, Any]] = []
     try:
@@ -1266,12 +1494,21 @@ def _discover_secrets(session: Any, region: str, *, account_id: str | None, warn
                         "location": region,
                     }
                 )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Secrets Manager secrets: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Secrets list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Secrets Manager secrets",
+            permission="secretsmanager:ListSecrets",
+            cloud="aws",
+            warnings=warnings,
+            missing=missing,
+        )
     return out
 
 
-def _discover_cloudfront(session: Any, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_cloudfront(
+    session: Any, *, account_id: str | None, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate CloudFront CDN distributions (read-only, global). Internet-facing edge."""
     out: list[dict[str, Any]] = []
     try:
@@ -1295,12 +1532,21 @@ def _discover_cloudfront(session: Any, *, account_id: str | None, warnings: list
                         "location": "global",
                     }
                 )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list CloudFront distributions: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed CloudFront list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="CloudFront distributions",
+            permission="cloudfront:ListDistributions",
+            cloud="aws",
+            warnings=warnings,
+            missing=missing,
+        )
     return out
 
 
-def _discover_ecr(session: Any, region: str, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_ecr(
+    session: Any, region: str, *, account_id: str | None, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate ECR container registries (read-only). Become container-registry resources."""
     out: list[dict[str, Any]] = []
     try:
@@ -1322,12 +1568,21 @@ def _discover_ecr(session: Any, region: str, *, account_id: str | None, warnings
                         "location": region,
                     }
                 )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list ECR repositories: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed ECR list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="ECR repositories",
+            permission="ecr:DescribeRepositories",
+            cloud="aws",
+            warnings=warnings,
+            missing=missing,
+        )
     return out
 
 
-def _discover_redshift(session: Any, region: str, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_redshift(
+    session: Any, region: str, *, account_id: str | None, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate Redshift clusters (read-only). Data warehouses → ``DATA_STORE``."""
     out: list[dict[str, Any]] = []
     try:
@@ -1350,12 +1605,21 @@ def _discover_redshift(session: Any, region: str, *, account_id: str | None, war
                         "location": region,
                     }
                 )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Redshift clusters: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Redshift list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Redshift clusters",
+            permission="redshift:DescribeClusters",
+            cloud="aws",
+            warnings=warnings,
+            missing=missing,
+        )
     return out
 
 
-def _discover_messaging(session: Any, region: str, *, account_id: str | None, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_messaging(
+    session: Any, region: str, *, account_id: str | None, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate SNS topics + SQS queues (read-only). Become messaging resources."""
     out: list[dict[str, Any]] = []
     try:
@@ -1375,8 +1639,10 @@ def _discover_messaging(session: Any, region: str, *, account_id: str | None, wa
                         "location": region,
                     }
                 )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list SNS topics: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed SNS list must not sink the scan
+        record_discovery_failure(
+            exc=exc, resource_type="SNS topics", permission="sns:ListTopics", cloud="aws", warnings=warnings, missing=missing
+        )
     try:
         sqs = session.client("sqs", region_name=region)
         paginator = sqs.get_paginator("list_queues")
@@ -1395,8 +1661,10 @@ def _discover_messaging(session: Any, region: str, *, account_id: str | None, wa
                         "location": region,
                     }
                 )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list SQS queues: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed SQS list must not sink the scan
+        record_discovery_failure(
+            exc=exc, resource_type="SQS queues", permission="sqs:ListQueues", cloud="aws", warnings=warnings, missing=missing
+        )
     return out
 
 

--- a/src/agent_bom/cloud/azure_inventory.py
+++ b/src/agent_bom/cloud/azure_inventory.py
@@ -43,6 +43,7 @@ from typing import Any
 
 from agent_bom.discovery_envelope import DiscoveryEnvelope, RedactionStatus, ScanMode
 
+from .aws_inventory import dedupe_missing_permissions, record_discovery_failure
 from .normalization import sanitize_discovery_warning
 
 logger = logging.getLogger(__name__)
@@ -209,6 +210,7 @@ def discover_inventory(
         "app_services": [],
         "management_groups": [],
         "warnings": [],
+        "missing_permissions": [],
         "discovery_envelope": None,
     }
 
@@ -282,18 +284,36 @@ def discover_inventory(
 
     collected: dict[str, list[dict[str, Any]]] = {}
     task_warnings: dict[str, list[str]] = {key: [] for key, _ in discovery_tasks}
+    # Parallel per-task accumulator so one discoverer's missing-permission entries
+    # never race another's. Merged back in deterministic task order, then deduped.
+    task_missing: dict[str, list[dict[str, str]]] = {key: [] for key, _ in discovery_tasks}
+    missing: list[dict[str, str]] = []
     if discovery_tasks:
         with ThreadPoolExecutor(max_workers=min(8, len(discovery_tasks))) as executor:
-            future_to_key = {executor.submit(fn, credential, resolved_sub, warnings=task_warnings[key]): key for key, fn in discovery_tasks}
+            future_to_key = {
+                executor.submit(fn, credential, resolved_sub, warnings=task_warnings[key], missing=task_missing[key]): key
+                for key, fn in discovery_tasks
+            }
             for future in as_completed(future_to_key):
                 key = future_to_key[future]
                 try:
                     collected[key] = future.result()
                 except Exception as exc:  # noqa: BLE001 — one service failing must not sink the rest
                     collected[key] = []
-                    task_warnings[key].append(sanitize_discovery_warning(exc))
+                    # Translate the abort into the same actionable guidance a
+                    # discoverer-local failure would have produced, so a crash at
+                    # the future boundary is never a silent empty result.
+                    record_discovery_failure(
+                        exc=exc,
+                        resource_type=key.replace("_", " "),
+                        permission=f"Microsoft.*/{key}/read",
+                        cloud="azure",
+                        warnings=task_warnings[key],
+                        missing=task_missing[key],
+                    )
     for key, _ in discovery_tasks:
         warnings.extend(task_warnings[key])
+        missing.extend(task_missing[key])
 
     storage_accounts = collected.get("storage_accounts", [])
     instances = collected.get("instances", [])
@@ -373,6 +393,7 @@ def discover_inventory(
         "app_services": app_services,
         "management_groups": management_groups,
         "warnings": warnings,
+        "missing_permissions": dedupe_missing_permissions(missing),
         "discovery_envelope": envelope.to_dict(),
     }
 
@@ -461,7 +482,9 @@ def discover_all_subscription_inventories(credential: Any = None, *, force: bool
 # ---------------------------------------------------------------------------
 
 
-def _discover_storage_accounts(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_storage_accounts(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate every Storage Account in the subscription (read-only).
 
     Public-access posture is read from the account's
@@ -503,8 +526,15 @@ def _discover_storage_accounts(credential: Any, subscription_id: str, *, warning
                     "subscription_id": subscription_id,
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure Storage Accounts: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure Storage Accounts list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure Storage Accounts",
+            permission="Microsoft.Storage/storageAccounts/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return accounts
 
 
@@ -513,7 +543,9 @@ def _discover_storage_accounts(credential: Any, subscription_id: str, *, warning
 # ---------------------------------------------------------------------------
 
 
-def _discover_vms(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_vms(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate all VMs in the subscription (read-only, NOT tag-filtered)."""
     try:
         from azure.mgmt.compute import ComputeManagementClient
@@ -544,12 +576,21 @@ def _discover_vms(credential: Any, subscription_id: str, *, warnings: list[str])
                     "subscription_id": subscription_id,
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure virtual machines: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure virtual machines list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure virtual machines",
+            permission="Microsoft.Compute/virtualMachines/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return instances
 
 
-def _discover_aks_clusters(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_aks_clusters(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate AKS (managed Kubernetes) clusters in the subscription (read-only).
 
     Captures control-plane metadata: Kubernetes version, the API-server FQDN
@@ -590,12 +631,21 @@ def _discover_aks_clusters(credential: Any, subscription_id: str, *, warnings: l
                     "internet_facing": bool(fqdn) and not private_cluster,
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure AKS clusters: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure AKS clusters list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure AKS clusters",
+            permission="Microsoft.ContainerService/managedClusters/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return clusters
 
 
-def _discover_nsgs(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_nsgs(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate all Network Security Groups in the subscription (read-only)."""
     try:
         from azure.mgmt.network import NetworkManagementClient
@@ -612,8 +662,15 @@ def _discover_nsgs(credential: Any, subscription_id: str, *, warnings: list[str]
             if not name:
                 continue
             groups.append(_normalize_nsg(nsg, nsg_id=nsg_id, name=name, subscription_id=subscription_id))
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure network security groups: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure network security groups list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure network security groups",
+            permission="Microsoft.Network/networkSecurityGroups/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return groups
 
 
@@ -697,7 +754,9 @@ def _safe_int(value: str) -> int | None:
 # ---------------------------------------------------------------------------
 
 
-def _discover_managed_identities(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_managed_identities(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate user-assigned managed identities in the subscription (read-only).
 
     Each identity becomes a ``service_principal`` graph node carrying its
@@ -734,12 +793,21 @@ def _discover_managed_identities(credential: Any, subscription_id: str, *, warni
                     "privilege_level": "unknown",
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure managed identities: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure managed identities list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure managed identities",
+            permission="Microsoft.ManagedIdentity/userAssignedIdentities/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return identities
 
 
-def _discover_role_assignments(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_role_assignments(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate Azure RBAC role assignments in the subscription (read-only).
 
     Each assignment links a principal (managed identity / service principal /
@@ -783,8 +851,15 @@ def _discover_role_assignments(credential: Any, subscription_id: str, *, warning
                     "account_id": subscription_id,
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure role assignments: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure role assignments list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure role assignments",
+            permission="Microsoft.Authorization/roleAssignments/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return assignments
 
 
@@ -793,7 +868,9 @@ def _discover_role_assignments(credential: Any, subscription_id: str, *, warning
 # ---------------------------------------------------------------------------
 
 
-def _discover_key_vaults(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_key_vaults(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate every Key Vault in the subscription (read-only).
 
     Reads only control-plane metadata (URI, RBAC mode, public-network posture);
@@ -826,12 +903,21 @@ def _discover_key_vaults(credential: Any, subscription_id: str, *, warnings: lis
                     "public_network_access": str(getattr(props, "public_network_access", "") or "") if props else "",
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure Key Vaults: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure Key Vaults list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure Key Vaults",
+            permission="Microsoft.KeyVault/vaults/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return vaults
 
 
-def _discover_container_registries(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_container_registries(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate every Container Registry in the subscription (read-only)."""
     try:
         from azure.mgmt.containerregistry import ContainerRegistryManagementClient
@@ -861,8 +947,15 @@ def _discover_container_registries(credential: Any, subscription_id: str, *, war
                     "public_network_access": str(getattr(registry, "public_network_access", "") or ""),
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure Container Registries: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure Container Registries list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure Container Registries",
+            permission="Microsoft.ContainerRegistry/registries/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return registries
 
 
@@ -895,7 +988,9 @@ def _append_db_servers(databases: list[dict[str, Any]], servers: Any, *, native_
         )
 
 
-def _discover_databases(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_databases(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate managed databases in the subscription (read-only).
 
     Covers Cosmos DB, Azure SQL, PostgreSQL, and MySQL — each item carries its
@@ -930,8 +1025,15 @@ def _discover_databases(credential: Any, subscription_id: str, *, warnings: list
             )
     except ImportError:
         warnings.append("azure-mgmt-cosmosdb not installed. Skipping Cosmos DB inventory.")
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure Cosmos DB accounts: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure Cosmos DB accounts list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure Cosmos DB accounts",
+            permission="Microsoft.DocumentDB/databaseAccounts/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
 
     try:
         from azure.mgmt.sql import SqlManagementClient
@@ -940,8 +1042,15 @@ def _discover_databases(credential: Any, subscription_id: str, *, warnings: list
         _append_db_servers(databases, sql_client.servers.list(), native_type="Microsoft.Sql/servers", engine="azure-sql")
     except ImportError:
         warnings.append("azure-mgmt-sql not installed. Skipping Azure SQL inventory.")
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure SQL servers: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure SQL servers list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure SQL servers",
+            permission="Microsoft.Sql/servers/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
 
     try:
         from azure.mgmt.rdbms.postgresql_flexibleservers import PostgreSQLManagementClient
@@ -955,8 +1064,15 @@ def _discover_databases(credential: Any, subscription_id: str, *, warnings: list
         )
     except ImportError:
         warnings.append("azure-mgmt-rdbms not installed. Skipping PostgreSQL inventory.")
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure PostgreSQL servers: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure PostgreSQL servers list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure PostgreSQL servers",
+            permission="Microsoft.DBforPostgreSQL/flexibleServers/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
 
     try:
         from azure.mgmt.rdbms.mysql_flexibleservers import MySQLManagementClient
@@ -965,8 +1081,15 @@ def _discover_databases(credential: Any, subscription_id: str, *, warnings: list
         _append_db_servers(databases, mysql_client.servers.list(), native_type="Microsoft.DBforMySQL/flexibleServers", engine="mysql")
     except ImportError:
         warnings.append("azure-mgmt-rdbms not installed. Skipping MySQL inventory.")
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure MySQL servers: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure MySQL servers list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure MySQL servers",
+            permission="Microsoft.DBforMySQL/flexibleServers/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
 
     return databases
 
@@ -976,7 +1099,9 @@ def _discover_databases(credential: Any, subscription_id: str, *, warnings: list
 # ---------------------------------------------------------------------------
 
 
-def _discover_virtual_networks(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_virtual_networks(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate every VNet in the subscription with its address space and subnets."""
     try:
         from azure.mgmt.network import NetworkManagementClient
@@ -1006,12 +1131,21 @@ def _discover_virtual_networks(credential: Any, subscription_id: str, *, warning
                     "subnets": [s for s in subnets if s],
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure virtual networks: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure virtual networks list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure virtual networks",
+            permission="Microsoft.Network/virtualNetworks/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return vnets
 
 
-def _discover_public_ips(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_public_ips(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate public IP addresses — the internet-facing exposure surface."""
     try:
         from azure.mgmt.network import NetworkManagementClient
@@ -1038,12 +1172,21 @@ def _discover_public_ips(credential: Any, subscription_id: str, *, warnings: lis
                     "allocation_method": str(getattr(pip, "public_ip_allocation_method", "") or ""),
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure public IPs: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure public IPs list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure public IPs",
+            permission="Microsoft.Network/publicIPAddresses/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return public_ips
 
 
-def _discover_load_balancers(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_load_balancers(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate load balancers with their SKU and public-frontend posture."""
     try:
         from azure.mgmt.network import NetworkManagementClient
@@ -1079,12 +1222,21 @@ def _discover_load_balancers(credential: Any, subscription_id: str, *, warnings:
                     "public_ip_ids": public_ip_ids,
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure load balancers: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure load balancers list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure load balancers",
+            permission="Microsoft.Network/loadBalancers/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return load_balancers
 
 
-def _discover_application_gateways(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_application_gateways(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate Application Gateways (L7 LB + WAF) in the subscription (read-only).
 
     Captures SKU tier, whether a WAF is attached (inline config or linked
@@ -1136,12 +1288,21 @@ def _discover_application_gateways(credential: Any, subscription_id: str, *, war
                     "public_ip_ids": public_ip_ids,
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure Application Gateways: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure Application Gateways list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure Application Gateways",
+            permission="Microsoft.Network/applicationGateways/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return gateways
 
 
-def _discover_front_doors(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_front_doors(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate Azure Front Door (classic) profiles — global internet edge (read-only)."""
     try:
         from azure.mgmt.frontdoor import FrontDoorManagementClient
@@ -1170,12 +1331,21 @@ def _discover_front_doors(credential: Any, subscription_id: str, *, warnings: li
                     "internet_facing": True,  # Front Door is a global internet edge by definition
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure Front Doors: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure Front Doors list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure Front Doors",
+            permission="Microsoft.Network/frontDoors/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return front_doors
 
 
-def _discover_api_management(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_api_management(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate API Management services (API gateway) in the subscription (read-only).
 
     Internet-facing unless deployed *Internal* into a VNet. Control-plane only —
@@ -1214,8 +1384,15 @@ def _discover_api_management(credential: Any, subscription_id: str, *, warnings:
                     "internet_facing": internet_facing,
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure API Management services: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure API Management services list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure API Management services",
+            permission="Microsoft.ApiManagement/service/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return services
 
 
@@ -1224,7 +1401,9 @@ def _discover_api_management(credential: Any, subscription_id: str, *, warnings:
 # ---------------------------------------------------------------------------
 
 
-def _discover_event_hubs(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_event_hubs(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate every Event Hub namespace in the subscription (read-only).
 
     Control-plane metadata only (SKU, public-network posture); never reads
@@ -1257,12 +1436,21 @@ def _discover_event_hubs(credential: Any, subscription_id: str, *, warnings: lis
                     "public_network_access": str(getattr(namespace, "public_network_access", "") or ""),
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure Event Hub namespaces: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure Event Hub namespaces list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure Event Hub namespaces",
+            permission="Microsoft.EventHub/namespaces/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return namespaces
 
 
-def _discover_service_bus(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_service_bus(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate every Service Bus namespace in the subscription (read-only).
 
     Control-plane metadata only (SKU, public-network posture); never reads
@@ -1295,12 +1483,21 @@ def _discover_service_bus(credential: Any, subscription_id: str, *, warnings: li
                     "public_network_access": str(getattr(namespace, "public_network_access", "") or ""),
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure Service Bus namespaces: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure Service Bus namespaces list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure Service Bus namespaces",
+            permission="Microsoft.ServiceBus/namespaces/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return namespaces
 
 
-def _discover_redis_caches(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_redis_caches(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate every Azure Cache for Redis instance in the subscription (read-only).
 
     Control-plane metadata only (SKU, public-network posture, non-SSL port);
@@ -1334,12 +1531,21 @@ def _discover_redis_caches(credential: Any, subscription_id: str, *, warnings: l
                     "non_ssl_port_enabled": bool(getattr(cache, "enable_non_ssl_port", False)),
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure Cache for Redis instances: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure Cache for Redis instances list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure Cache for Redis instances",
+            permission="Microsoft.Cache/redis/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return caches
 
 
-def _discover_managed_disks(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_managed_disks(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate every Managed Disk in the subscription (read-only).
 
     Control-plane metadata only (size, encryption type, public-network posture);
@@ -1373,12 +1579,21 @@ def _discover_managed_disks(credential: Any, subscription_id: str, *, warnings: 
                     "public_network_access": str(getattr(disk, "public_network_access", "") or ""),
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure Managed Disks: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure Managed Disks list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure Managed Disks",
+            permission="Microsoft.Compute/disks/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return disks
 
 
-def _discover_app_services(credential: Any, subscription_id: str, *, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_app_services(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate every App Service site (Web Apps + Function Apps) read-only.
 
     ``web_apps.list()`` returns both; ``kind`` (contains ``functionapp``)
@@ -1419,8 +1634,15 @@ def _discover_app_services(credential: Any, subscription_id: str, *, warnings: l
                     "internet_facing": bool(default_host_name) and enabled,
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Azure App Services: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Azure App Services list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure App Services",
+            permission="Microsoft.Web/sites/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
     return sites
 
 

--- a/src/agent_bom/cloud/gcp_inventory.py
+++ b/src/agent_bom/cloud/gcp_inventory.py
@@ -42,6 +42,7 @@ from typing import Any
 
 from agent_bom.discovery_envelope import DiscoveryEnvelope, RedactionStatus, ScanMode
 
+from .aws_inventory import dedupe_missing_permissions, record_discovery_failure
 from .normalization import sanitize_discovery_warning
 
 logger = logging.getLogger(__name__)
@@ -331,6 +332,7 @@ def discover_inventory(
         "disks": [],
         "pubsub_topics": [],
         "warnings": [],
+        "missing_permissions": [],
         "discovery_envelope": None,
     }
 
@@ -366,6 +368,7 @@ def discover_inventory(
     # discovery runs AS that SA — the recommended path where SA keys are
     # org-disabled, matching AWS's read-only profile and Snowflake's role.
     credentials = _resolve_impersonation(credentials, warnings)
+    missing: list[dict[str, str]] = []
     buckets: list[dict[str, Any]] = []
     instances: list[dict[str, Any]] = []
     firewalls: list[dict[str, Any]] = []
@@ -379,28 +382,28 @@ def discover_inventory(
     pubsub_topics: list[dict[str, Any]] = []
 
     if include_storage:
-        buckets = _discover_buckets(resolved_project, credentials=credentials, warnings=warnings)
+        buckets = _discover_buckets(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
     if include_compute:
-        instances = _discover_instances(resolved_project, credentials=credentials, warnings=warnings)
-        firewalls = _discover_firewalls(resolved_project, credentials=credentials, warnings=warnings)
+        instances = _discover_instances(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
+        firewalls = _discover_firewalls(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
     if include_iam:
-        iam_bindings = _discover_project_iam_bindings(resolved_project, credentials=credentials, warnings=warnings)
+        iam_bindings = _discover_project_iam_bindings(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
         service_accounts = _discover_service_accounts(
-            resolved_project, credentials=credentials, warnings=warnings, iam_bindings=iam_bindings
+            resolved_project, credentials=credentials, warnings=warnings, iam_bindings=iam_bindings, missing=missing
         )
     if include_containers:
-        gke_clusters = _discover_gke_clusters(resolved_project, credentials=credentials, warnings=warnings)
+        gke_clusters = _discover_gke_clusters(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
     if include_serverless:
-        cloud_run_services = _discover_cloud_run_services(resolved_project, credentials=credentials, warnings=warnings)
-        cloud_functions = _discover_cloud_functions(resolved_project, credentials=credentials, warnings=warnings)
+        cloud_run_services = _discover_cloud_run_services(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
+        cloud_functions = _discover_cloud_functions(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
     if include_databases:
-        cloud_sql_instances = _discover_cloud_sql_instances(resolved_project, credentials=credentials, warnings=warnings)
+        cloud_sql_instances = _discover_cloud_sql_instances(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
     if include_networks:
-        vpc_networks = _discover_vpc_networks(resolved_project, credentials=credentials, warnings=warnings)
+        vpc_networks = _discover_vpc_networks(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
     if include_disks:
-        disks = _discover_disks(resolved_project, credentials=credentials, warnings=warnings)
+        disks = _discover_disks(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
     if include_messaging:
-        pubsub_topics = _discover_pubsub_topics(resolved_project, credentials=credentials, warnings=warnings)
+        pubsub_topics = _discover_pubsub_topics(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
 
     permissions_used: list[str] = []
     if include_storage:
@@ -447,6 +450,7 @@ def discover_inventory(
         "disks": disks,
         "pubsub_topics": pubsub_topics,
         "warnings": warnings,
+        "missing_permissions": dedupe_missing_permissions(missing),
         "discovery_envelope": envelope.to_dict(),
     }
 
@@ -456,7 +460,9 @@ def discover_inventory(
 # ---------------------------------------------------------------------------
 
 
-def _discover_buckets(project_id: str, *, credentials: Any, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_buckets(
+    project_id: str, *, credentials: Any, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate every GCS bucket in the project (read-only).
 
     Public-access posture is read from the bucket IAM policy (``allUsers`` /
@@ -486,8 +492,15 @@ def _discover_buckets(project_id: str, *, credentials: Any, warnings: list[str])
                     "project_id": project_id,
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list GCS buckets: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed GCS buckets list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="GCS buckets",
+            permission="storage.buckets.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
     return buckets
 
 
@@ -536,7 +549,9 @@ def _policy_bindings(policy: Any) -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
-def _discover_instances(project_id: str, *, credentials: Any, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_instances(
+    project_id: str, *, credentials: Any, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate all Compute Engine instances in the project (read-only)."""
     try:
         from google.cloud import compute_v1
@@ -553,8 +568,15 @@ def _discover_instances(project_id: str, *, credentials: Any, warnings: list[str
                 if not name:
                     continue
                 instances.append(_normalize_instance(instance, name=name, project_id=project_id))
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Compute instances: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Compute instances list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Compute instances",
+            permission="compute.instances.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
     return instances
 
 
@@ -594,7 +616,9 @@ def _normalize_instance(instance: Any, *, name: str, project_id: str) -> dict[st
     }
 
 
-def _discover_firewalls(project_id: str, *, credentials: Any, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_firewalls(
+    project_id: str, *, credentials: Any, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate all VPC firewall rules in the project (read-only)."""
     try:
         from google.cloud import compute_v1
@@ -610,8 +634,15 @@ def _discover_firewalls(project_id: str, *, credentials: Any, warnings: list[str
             if not name:
                 continue
             firewalls.append(_normalize_firewall(rule, name=name, project_id=project_id))
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list firewall rules: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed firewall rules list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="firewall rules",
+            permission="compute.firewalls.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
     return firewalls
 
 
@@ -682,7 +713,9 @@ def _safe_int(value: str) -> int | None:
 # ---------------------------------------------------------------------------
 
 
-def _discover_project_iam_bindings(project_id: str, *, credentials: Any, warnings: list[str]) -> dict[str, list[str]]:
+def _discover_project_iam_bindings(
+    project_id: str, *, credentials: Any, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> dict[str, list[str]]:
     """Read the project IAM policy (read-only) → ``{member: [roles…]}``.
 
     Calls ``cloudresourcemanager`` ``projects.getIamPolicy`` and inverts the
@@ -715,8 +748,15 @@ def _discover_project_iam_bindings(project_id: str, *, credentials: Any, warning
                 roles = bindings_by_member.setdefault(key, [])
                 if role not in roles:
                     roles.append(role)
-    except Exception as exc:  # noqa: BLE001 — IAM-policy read must never sink a scan
-        warnings.append(f"Could not read project IAM policy: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed project IAM policy list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="project IAM policy",
+            permission="resourcemanager.projects.getIamPolicy",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
     return bindings_by_member
 
 
@@ -726,6 +766,7 @@ def _discover_service_accounts(
     credentials: Any,
     warnings: list[str],
     iam_bindings: dict[str, list[str]] | None = None,
+    missing: list[dict[str, str]] | None = None,
 ) -> list[dict[str, Any]]:
     """Enumerate all service accounts in the project (read-only).
 
@@ -777,8 +818,15 @@ def _discover_service_accounts(
                     "privilege_level": _highest_privilege(roles),
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list service accounts: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed service accounts list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="service accounts",
+            permission="iam.serviceAccounts.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
     return accounts
 
 
@@ -787,7 +835,9 @@ def _discover_service_accounts(
 # ---------------------------------------------------------------------------
 
 
-def _discover_gke_clusters(project_id: str, *, credentials: Any, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_gke_clusters(
+    project_id: str, *, credentials: Any, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate every GKE cluster in the project (read-only).
 
     Uses the ``-`` location wildcard so a single call returns clusters across all
@@ -825,8 +875,15 @@ def _discover_gke_clusters(project_id: str, *, credentials: Any, warnings: list[
                     "project_id": project_id,
                 }
             )
-    except Exception as exc:  # noqa: BLE001 — API-disabled / access-denied must degrade
-        warnings.append(f"Could not list GKE clusters: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed GKE clusters list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="GKE clusters",
+            permission="container.clusters.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
     return clusters
 
 
@@ -835,7 +892,9 @@ def _discover_gke_clusters(project_id: str, *, credentials: Any, warnings: list[
 # ---------------------------------------------------------------------------
 
 
-def _discover_cloud_run_services(project_id: str, *, credentials: Any, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_cloud_run_services(
+    project_id: str, *, credentials: Any, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate every Cloud Run service in the project (read-only).
 
     Ingress ``INGRESS_TRAFFIC_ALL`` means the service is reachable from the
@@ -870,8 +929,15 @@ def _discover_cloud_run_services(project_id: str, *, credentials: Any, warnings:
                     "project_id": project_id,
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Cloud Run services: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Cloud Run services list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Cloud Run services",
+            permission="run.services.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
     return services
 
 
@@ -880,7 +946,9 @@ def _discover_cloud_run_services(project_id: str, *, credentials: Any, warnings:
 # ---------------------------------------------------------------------------
 
 
-def _discover_cloud_functions(project_id: str, *, credentials: Any, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_cloud_functions(
+    project_id: str, *, credentials: Any, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate every 2nd-gen Cloud Function in the project (read-only)."""
     try:
         from google.cloud import functions_v2
@@ -913,8 +981,15 @@ def _discover_cloud_functions(project_id: str, *, credentials: Any, warnings: li
                     "project_id": project_id,
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Cloud Functions: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Cloud Functions list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Cloud Functions",
+            permission="cloudfunctions.functions.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
     return functions
 
 
@@ -923,7 +998,9 @@ def _discover_cloud_functions(project_id: str, *, credentials: Any, warnings: li
 # ---------------------------------------------------------------------------
 
 
-def _discover_cloud_sql_instances(project_id: str, *, credentials: Any, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_cloud_sql_instances(
+    project_id: str, *, credentials: Any, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate every Cloud SQL instance in the project (read-only).
 
     The Cloud SQL Admin API has no idiomatic google-cloud client, so this uses
@@ -969,8 +1046,15 @@ def _discover_cloud_sql_instances(project_id: str, *, credentials: Any, warnings
                     "project_id": project_id,
                 }
             )
-    except Exception as exc:  # noqa: BLE001 — API-disabled / access-denied must degrade
-        warnings.append(f"Could not list Cloud SQL instances: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Cloud SQL instances list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Cloud SQL instances",
+            permission="cloudsql.instances.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
     return instances
 
 
@@ -979,7 +1063,9 @@ def _discover_cloud_sql_instances(project_id: str, *, credentials: Any, warnings
 # ---------------------------------------------------------------------------
 
 
-def _discover_vpc_networks(project_id: str, *, credentials: Any, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_vpc_networks(
+    project_id: str, *, credentials: Any, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate every VPC network + its subnets in the project (read-only)."""
     try:
         from google.cloud import compute_v1
@@ -987,7 +1073,7 @@ def _discover_vpc_networks(project_id: str, *, credentials: Any, warnings: list[
         warnings.append("google-cloud-compute not installed. Skipping VPC network inventory.")
         return []
 
-    subnets_by_network = _discover_subnets_by_network(project_id, credentials=credentials, warnings=warnings)
+    subnets_by_network = _discover_subnets_by_network(project_id, credentials=credentials, warnings=warnings, missing=missing)
     networks: list[dict[str, Any]] = []
     try:
         client = compute_v1.NetworksClient(credentials=credentials)
@@ -1007,12 +1093,21 @@ def _discover_vpc_networks(project_id: str, *, credentials: Any, warnings: list[
                     "project_id": project_id,
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list VPC networks: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed VPC networks list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="VPC networks",
+            permission="compute.networks.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
     return networks
 
 
-def _discover_subnets_by_network(project_id: str, *, credentials: Any, warnings: list[str]) -> dict[str, list[dict[str, Any]]]:
+def _discover_subnets_by_network(
+    project_id: str, *, credentials: Any, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> dict[str, list[dict[str, Any]]]:
     """Aggregated subnet list, keyed by the parent network self-link AND name."""
     try:
         from google.cloud import compute_v1
@@ -1034,8 +1129,15 @@ def _discover_subnets_by_network(project_id: str, *, credentials: Any, warnings:
                 }
                 by_network.setdefault(network_link, []).append(entry)
                 by_network.setdefault(_leaf(network_link), []).append(entry)
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list VPC subnets: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed VPC subnets list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="VPC subnets",
+            permission="compute.subnetworks.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
     return by_network
 
 
@@ -1044,7 +1146,9 @@ def _discover_subnets_by_network(project_id: str, *, credentials: Any, warnings:
 # ---------------------------------------------------------------------------
 
 
-def _discover_disks(project_id: str, *, credentials: Any, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_disks(
+    project_id: str, *, credentials: Any, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate every persistent disk in the project (read-only)."""
     try:
         from google.cloud import compute_v1
@@ -1073,8 +1177,15 @@ def _discover_disks(project_id: str, *, credentials: Any, warnings: list[str]) -
                         "project_id": project_id,
                     }
                 )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list persistent disks: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed persistent disks list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="persistent disks",
+            permission="compute.disks.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
     return disks
 
 
@@ -1083,7 +1194,9 @@ def _discover_disks(project_id: str, *, credentials: Any, warnings: list[str]) -
 # ---------------------------------------------------------------------------
 
 
-def _discover_pubsub_topics(project_id: str, *, credentials: Any, warnings: list[str]) -> list[dict[str, Any]]:
+def _discover_pubsub_topics(
+    project_id: str, *, credentials: Any, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
     """Enumerate every Pub/Sub topic in the project (read-only)."""
     try:
         from google.cloud import pubsub_v1
@@ -1108,8 +1221,15 @@ def _discover_pubsub_topics(project_id: str, *, credentials: Any, warnings: list
                     "project_id": project_id,
                 }
             )
-    except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not list Pub/Sub topics: {sanitize_discovery_warning(exc)}")
+    except Exception as exc:  # noqa: BLE001 — one failed Pub/Sub topics list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Pub/Sub topics",
+            permission="pubsub.topics.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
     return topics
 
 

--- a/tests/test_azure_parallel_discovery.py
+++ b/tests/test_azure_parallel_discovery.py
@@ -50,7 +50,7 @@ _SERVICES = [
 
 
 def _slow_stub(label: str, delay: float = 0.15):
-    def fn(cred, sub, *, warnings):
+    def fn(cred, sub, *, warnings, missing=None):
         time.sleep(delay)
         warnings.append(f"warn-{label}")
         return [{"name": f"{label}-1", "id": f"/id/{label}"}]
@@ -81,7 +81,7 @@ def test_warnings_preserved_in_deterministic_order(monkeypatch) -> None:
 
 
 def test_one_service_failing_does_not_sink_others(monkeypatch) -> None:
-    def boom(cred, sub, *, warnings):
+    def boom(cred, sub, *, warnings, missing=None):
         raise RuntimeError("simulated ARM failure")
 
     for name in _SERVICES:

--- a/tests/test_cloud_aws_inventory.py
+++ b/tests/test_cloud_aws_inventory.py
@@ -624,3 +624,102 @@ def test_multiregion_enumerates_enabled_regions_when_no_override(monkeypatch: py
 
     # describe_regions drove the region set when no explicit override was given.
     assert set(payload["regions"]) == {"us-east-1", "ap-south-1"}
+
+
+# ---------------------------------------------------------------------------
+# Partial-permission tolerance: the shared degrade-don't-crash helpers and the
+# AWS discoverer path that produces actionable missing_permissions guidance.
+# ---------------------------------------------------------------------------
+
+
+class _ClientError(Exception):
+    """Stand-in for botocore.exceptions.ClientError carrying an Error.Code."""
+
+    def __init__(self, code: str, status: int = 403) -> None:
+        super().__init__(f"An error occurred ({code}) when calling the API.")
+        self.response = {"Error": {"Code": code}, "ResponseMetadata": {"HTTPStatusCode": status}}
+
+
+def test_is_access_denied_error_detects_each_cloud_shape() -> None:
+    # AWS error-code, Azure 403 status, GCP type-name + message.
+    assert aws_inventory.is_access_denied_error(_ClientError("AccessDenied")) is True
+    assert aws_inventory.is_access_denied_error(_ClientError("UnauthorizedOperation")) is True
+
+    class _AzureAuth(Exception):  # noqa: N818 — emulates azure HttpResponseError (no Error suffix)
+        def __init__(self) -> None:
+            super().__init__("AuthorizationFailed")
+            self.status_code = 403
+
+    assert aws_inventory.is_access_denied_error(_AzureAuth()) is True
+
+    class PermissionDenied(Exception):  # noqa: N818 — name matches the real GCP SDK type the classifier keys on
+        pass
+
+    assert aws_inventory.is_access_denied_error(PermissionDenied("403 denied")) is True
+    # A non-access error is NOT misclassified.
+    assert aws_inventory.is_access_denied_error(RuntimeError("transient 500")) is False
+
+
+def test_record_discovery_failure_branches_on_access_vs_generic() -> None:
+    warnings: list[str] = []
+    missing: list[dict[str, str]] = []
+
+    # Access error → actionable warning + missing_permissions entry.
+    aws_inventory.record_discovery_failure(
+        exc=_ClientError("AccessDenied"),
+        resource_type="EC2 instances",
+        permission="ec2:DescribeInstances",
+        cloud="aws",
+        warnings=warnings,
+        missing=missing,
+    )
+    assert "role lacks ec2:DescribeInstances" in warnings[0]
+    assert "add it to the read-only policy" in warnings[0]
+    assert missing == [{"cloud": "aws", "permission": "ec2:DescribeInstances", "resource_type": "EC2 instances"}]
+
+    # Generic error → plain warning, NO missing_permissions entry.
+    aws_inventory.record_discovery_failure(
+        exc=RuntimeError("transient 500"),
+        resource_type="S3 buckets",
+        permission="s3:ListAllMyBuckets",
+        cloud="aws",
+        warnings=warnings,
+        missing=missing,
+    )
+    assert any("Could not list S3 buckets" in w for w in warnings)
+    assert len(missing) == 1  # unchanged
+
+
+def test_dedupe_missing_permissions_is_sorted_and_idempotent() -> None:
+    raw = [
+        {"cloud": "aws", "permission": "s3:ListAllMyBuckets", "resource_type": "S3 buckets"},
+        {"cloud": "aws", "permission": "ec2:DescribeInstances", "resource_type": "EC2 instances"},
+        {"cloud": "aws", "permission": "ec2:DescribeInstances", "resource_type": "EC2 instances"},
+    ]
+    out = aws_inventory.dedupe_missing_permissions(raw)
+    assert out == [
+        {"cloud": "aws", "permission": "ec2:DescribeInstances", "resource_type": "EC2 instances"},
+        {"cloud": "aws", "permission": "s3:ListAllMyBuckets", "resource_type": "S3 buckets"},
+    ]
+    assert aws_inventory.dedupe_missing_permissions(out) == out  # idempotent
+
+
+def test_aws_permission_denied_degrades_with_guidance(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(aws_inventory.INVENTORY_ENV_FLAG, "1")
+
+    def _denied(self: Any) -> dict[str, Any]:
+        raise _ClientError("AccessDenied")
+
+    monkeypatch.setattr(_FakeS3, "list_buckets", _denied)
+    with _install_fake_boto3():
+        payload = aws_inventory.discover_inventory(region="us-east-1")
+
+    assert payload["status"] == "ok"
+    # S3 skipped, but the rest of the estate still enumerated.
+    assert payload["buckets"] == []
+    assert payload["instances"]  # EC2 still discovered
+    actionable = [w for w in payload["warnings"] if "role lacks s3:ListAllMyBuckets" in w]
+    assert actionable, payload["warnings"]
+    assert payload["missing_permissions"] == [
+        {"cloud": "aws", "permission": "s3:ListAllMyBuckets", "resource_type": "S3 buckets"}
+    ]

--- a/tests/test_cloud_azure_inventory.py
+++ b/tests/test_cloud_azure_inventory.py
@@ -368,3 +368,84 @@ def test_graph_inventory_noop_when_not_ok() -> None:
         {"provider": "azure", "status": "disabled", "storage_accounts": [], "instances": [], "security_groups": []}
     )
     assert not any(nid.startswith("cloud_resource:azure:") for nid in graph.nodes)
+
+
+# ---------------------------------------------------------------------------
+# Partial-permission tolerance: a single failing discoverer must degrade to a
+# warning (and, for access errors, an actionable missing_permissions entry)
+# without aborting the rest of the scan.
+# ---------------------------------------------------------------------------
+
+
+class _AzureAuthError(Exception):
+    """Stand-in for azure.core HttpResponseError on a 403 (AuthorizationFailed)."""
+
+    def __init__(self) -> None:
+        super().__init__("(AuthorizationFailed) The client does not have authorization to perform action.")
+        self.status_code = 403
+
+
+def test_azure_discoverer_exception_does_not_abort_scan(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Patch the SDK call INSIDE the VM discoverer so the real discoverer's own
+    # try/except runs — this proves the genuine degrade path, not a stub.
+    monkeypatch.setenv(azure_inventory.INVENTORY_ENV_FLAG, "1")
+
+    def _boom(self: Any) -> list[Any]:
+        raise RuntimeError("transient ARM 500 from the VM list endpoint")
+
+    monkeypatch.setattr(_FakeVMOps, "list_all", _boom)
+    with _install_fake_azure():
+        payload = azure_inventory.discover_inventory(subscription_id="sub-1", credential=_FakeCredential())
+
+    # The overall call still returns ok and the OTHER resource types are present.
+    assert payload["status"] == "ok"
+    assert {a["name"] for a in payload["storage_accounts"]} == {"publiclake", "privatelogs"}
+    # The failed resource type still produced a clear warning (never a silent drop).
+    assert any("transient ARM 500" in w for w in payload["warnings"])
+    # A generic (non-access) failure produces NO missing_permissions entry.
+    assert payload["missing_permissions"] == []
+
+
+def test_azure_permission_denied_degrades_with_guidance(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(azure_inventory.INVENTORY_ENV_FLAG, "1")
+
+    def _denied(self: Any) -> list[Any]:
+        raise _AzureAuthError()
+
+    monkeypatch.setattr(_FakeVMOps, "list_all", _denied)
+    with _install_fake_azure():
+        payload = azure_inventory.discover_inventory(subscription_id="sub-1", credential=_FakeCredential())
+
+    assert payload["status"] == "ok"
+    # Other resource types still discovered — no silent total failure.
+    assert {a["name"] for a in payload["storage_accounts"]} == {"publiclake", "privatelogs"}
+    # The access error yields an ACTIONABLE warning naming the missing permission.
+    actionable = [w for w in payload["warnings"] if "role lacks" in w and "Azure virtual machines" in w]
+    assert actionable, payload["warnings"]
+    assert "Microsoft.Compute/virtualMachines/read" in actionable[0]
+    assert "add it to the read-only policy" in actionable[0]
+    # And a structured missing_permissions entry the product can render.
+    entries = [e for e in payload["missing_permissions"] if e["resource_type"] == "Azure virtual machines"]
+    assert entries == [
+        {"cloud": "azure", "permission": "Microsoft.Compute/virtualMachines/read", "resource_type": "Azure virtual machines"}
+    ]
+
+
+def test_azure_missing_permissions_are_sorted_and_deduped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(azure_inventory.INVENTORY_ENV_FLAG, "1")
+
+    def _denied(self: Any) -> list[Any]:
+        raise _AzureAuthError()
+
+    # Two discoverers denied (compute VMs + storage accounts): the result list
+    # must be deterministic + deduped regardless of thread completion order.
+    monkeypatch.setattr(_FakeVMOps, "list_all", _denied)
+    monkeypatch.setattr(_FakeStorageOps, "list", _denied)
+    with _install_fake_azure():
+        payload = azure_inventory.discover_inventory(subscription_id="sub-1", credential=_FakeCredential())
+
+    perms = payload["missing_permissions"]
+    # Sorted by (cloud, resource_type, permission) → Storage before virtual machines.
+    assert [e["resource_type"] for e in perms] == ["Azure Storage Accounts", "Azure virtual machines"]
+    # Idempotent: re-deduping the same list is a no-op.
+    assert azure_inventory.dedupe_missing_permissions(perms + perms) == perms

--- a/tests/test_cloud_gcp_inventory.py
+++ b/tests/test_cloud_gcp_inventory.py
@@ -899,3 +899,89 @@ def test_graph_emits_estate_nodes_and_owns_edges(monkeypatch: pytest.MonkeyPatch
     assert gke_id in owns_targets
     assert sql_id in owns_targets
     assert "cloud_resource:gcp:pubsub:messaging:abom-demo-topic" in owns_targets
+
+
+# ---------------------------------------------------------------------------
+# Partial-permission tolerance: a single failing discoverer must degrade to a
+# warning (and, for access errors, an actionable missing_permissions entry)
+# without aborting the rest of the scan.
+# ---------------------------------------------------------------------------
+
+
+class PermissionDenied(Exception):  # noqa: N818 — name must match the real google-api-core SDK type the classifier keys on
+    """Stand-in for google.api_core.exceptions.PermissionDenied (403 / code 7).
+
+    Named to match the real SDK exception so the access-error classifier keys off
+    the type name without importing the heavy google-api-core dependency.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("403 Permission 'container.clusters.list' denied on project 'proj-1'.")
+        self.code = 403
+
+
+def test_gcp_discoverer_exception_does_not_abort_scan(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Patch the SDK call INSIDE the bucket discoverer so the genuine
+    # try/except degrade path runs (not a stubbed discoverer).
+    monkeypatch.setenv(gcp_inventory.INVENTORY_ENV_FLAG, "1")
+
+    def _boom(self: Any) -> list[Any]:
+        raise RuntimeError("transient 500 from the GCS list endpoint")
+
+    monkeypatch.setattr(_FakeStorageClient, "list_buckets", _boom)
+    with _install_fake_gcp():
+        payload = gcp_inventory.discover_inventory(project_id="proj-1")
+
+    # The overall call still returns ok and the OTHER resource types are present.
+    assert payload["status"] == "ok"
+    assert payload["buckets"] == []  # the failed type degrades to empty…
+    assert {c["name"] for c in payload["gke_clusters"]} == {"public-gke", "private-gke"}  # …others survive
+    # …but the skipped type still produced a clear warning (no silent drop).
+    assert any("transient 500" in w for w in payload["warnings"])
+    # A generic (non-access) failure produces NO missing_permissions entry.
+    assert payload["missing_permissions"] == []
+
+
+def test_gcp_permission_denied_degrades_with_guidance(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(gcp_inventory.INVENTORY_ENV_FLAG, "1")
+
+    def _denied(self: Any, parent: str) -> Any:
+        raise PermissionDenied()
+
+    monkeypatch.setattr(_FakeClusterManagerClient, "list_clusters", _denied)
+    with _install_fake_gcp():
+        payload = gcp_inventory.discover_inventory(project_id="proj-1")
+
+    assert payload["status"] == "ok"
+    # Other resource types still discovered — no silent total failure.
+    assert {b["name"] for b in payload["buckets"]} == {"public-lake", "private-logs"}
+    assert payload["gke_clusters"] == []
+    # The access error yields an ACTIONABLE warning naming the missing permission.
+    actionable = [w for w in payload["warnings"] if "role lacks" in w and "GKE clusters" in w]
+    assert actionable, payload["warnings"]
+    assert "container.clusters.list" in actionable[0]
+    assert "add it to the read-only policy" in actionable[0]
+    # And a structured missing_permissions entry the product can render.
+    entries = [e for e in payload["missing_permissions"] if e["resource_type"] == "GKE clusters"]
+    assert entries == [{"cloud": "gcp", "permission": "container.clusters.list", "resource_type": "GKE clusters"}]
+
+
+def test_gcp_missing_permissions_are_sorted_and_deduped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(gcp_inventory.INVENTORY_ENV_FLAG, "1")
+
+    def _denied_clusters(self: Any, parent: str) -> Any:
+        raise PermissionDenied()
+
+    def _denied_buckets(self: Any) -> list[Any]:
+        raise PermissionDenied()
+
+    monkeypatch.setattr(_FakeClusterManagerClient, "list_clusters", _denied_clusters)
+    monkeypatch.setattr(_FakeStorageClient, "list_buckets", _denied_buckets)
+    with _install_fake_gcp():
+        payload = gcp_inventory.discover_inventory(project_id="proj-1")
+
+    perms = payload["missing_permissions"]
+    # Sorted by (cloud, resource_type, permission) → GCS buckets before GKE clusters.
+    assert [e["resource_type"] for e in perms] == ["GCS buckets", "GKE clusters"]
+    # Idempotent: re-deduping the same list is a no-op.
+    assert gcp_inventory.dedupe_missing_permissions(perms + perms) == perms


### PR DESCRIPTION
## What

Make estate-wide cloud inventory run like an always-on product: a scan never crashes because the read-only role is missing one permission or an API throttles. Every external discovery call across the AWS, Azure, and GCP inventory modules degrades to a clear warning and the scan finishes with partial results.

## Changes

- **Uniform degrade-don't-crash.** Each discoverer wraps its external API calls so a single failure produces one warning and continues, never aborting the run. AWS was already wrapped; Azure and GCP are brought to the same bar, including the thread-pool future boundary in Azure so a crash there is translated into the same guidance rather than a silent empty result.
- **Actionable missing-permission guidance.** When a failure is an access/permission error (AWS `AccessDenied` / `UnauthorizedOperation`, Azure `AuthorizationFailed` / 403, GCP `PermissionDenied` / 403), the warning names the specific permission that is missing and the resource type being skipped — e.g. `Skipped EC2 instances: role lacks ec2:DescribeInstances — add it to the read-only policy to cover this resource type.` Detection is SDK-shape aware (error code, HTTP status, and exception type name) so it works without importing each provider SDK. Messages route through the central sanitizer so secrets never leak.
- **Missing-permission surfacing.** A structured `missing_permissions` list (permission, resource_type, cloud) is accumulated alongside the existing `permissions_used` tracking and threaded into each inventory payload as an additive field, so the product can show exactly what to grant. The list is sorted and de-duplicated, making it deterministic and idempotent.

A skipped resource type always yields both a warning and a `missing_permissions` entry — never a silent empty result.

## Tests

Resilience tests mock Azure and GCP discoverers (at the SDK-call boundary, so the genuine degrade path runs) raising both a generic exception and a permission/403 error, and assert the overall inventory call still returns, other resource types are still discovered, a clear warning is produced, and the access case yields an actionable message plus a `missing_permissions` entry. Equivalent coverage and unit tests for the shared classifier/helpers are added for AWS.

- `test_azure_discoverer_exception_does_not_abort_scan`, `test_azure_permission_denied_degrades_with_guidance`, `test_azure_missing_permissions_are_sorted_and_deduped`
- `test_gcp_discoverer_exception_does_not_abort_scan`, `test_gcp_permission_denied_degrades_with_guidance`, `test_gcp_missing_permissions_are_sorted_and_deduped`
- `test_aws_permission_denied_degrades_with_guidance`, `test_is_access_denied_error_detects_each_cloud_shape`, `test_record_discovery_failure_branches_on_access_vs_generic`, `test_dedupe_missing_permissions_is_sorted_and_idempotent`

`uv run ruff check` and `uv run mypy` are clean on the three inventory modules; the full inventory/cloud test selection is green.