### PR TITLE
feat(cli): accept optional positional PATH for scan

### DIFF
--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -247,8 +247,15 @@ def _reproducible_generated_at(enabled: bool):
 
 
 @click.command()
+@click.argument(
+    "path",
+    required=False,
+    type=click.Path(exists=True, file_okay=False),
+    metavar="[PATH]",
+)
 @scan_options
 def scan(
+    path: Optional[str],
     project: Optional[str],
     repo_url: Optional[str],
     config_dir: Optional[str],
@@ -512,6 +519,23 @@ def scan(
     else:
         _log_level = log_level or ("DEBUG" if verbose else "WARNING")
     setup_logging(level=_log_level, json_output=log_json, log_file=log_file)
+
+    # ── Positional PATH is Docker-style shorthand for --project/-p ──
+    # `agent-bom scan .` / `agent-bom scan ./dir` resolve to a project scan.
+    # If both the positional PATH and --project/-p are given, they must point at
+    # the same directory; otherwise --project/-p wins and we warn so the
+    # intent is never silently dropped. The positional value is purely a
+    # project alias and does not interfere with --image/--sbom/--filesystem/
+    # --self-scan/--demo input modes.
+    if path is not None:
+        if project is not None and Path(project).resolve() != Path(path).resolve():
+            logger.warning(
+                "Both PATH (%s) and --project/-p (%s) were given; using --project/-p.",
+                path,
+                project,
+            )
+        elif project is None:
+            project = path
 
     # Load .agent-bom.yaml project config — CLI flags always win
     _proj_cfg = load_project_config()

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -1470,3 +1470,120 @@ def test_scan_complete_closer_renders_severity_breakdown():
                     f"closer rendered no severity tier: {line!r}"
                 )
                 break
+
+
+# ---------------------------------------------------------------------------
+# Positional PATH (Docker-style shorthand for --project/-p)
+# ---------------------------------------------------------------------------
+
+
+def test_scan_positional_path_resolves_like_project(tmp_path):
+    """`scan <dir>` resolves to the same project scan as `scan -p <dir>`."""
+    captured: dict = {}
+
+    def _capture(**kwargs):
+        captured["project_dir"] = kwargs.get("project_dir")
+        return []
+
+    with patch("agent_bom.cli.agents.discover_all", side_effect=_capture):
+        result = _run(["scan", str(tmp_path), "--no-scan"])
+
+    assert result.exit_code == 0
+    assert captured["project_dir"] == str(tmp_path)
+
+
+def test_scan_positional_path_matches_project_flag(tmp_path):
+    """Positional PATH and -p produce the same project_dir handed to discovery."""
+    pos: dict = {}
+    flag: dict = {}
+
+    def _make(sink):
+        def _capture(**kwargs):
+            sink["project_dir"] = kwargs.get("project_dir")
+            return []
+
+        return _capture
+
+    with patch("agent_bom.cli.agents.discover_all", side_effect=_make(pos)):
+        r1 = _run(["scan", str(tmp_path), "--no-scan"])
+    with patch("agent_bom.cli.agents.discover_all", side_effect=_make(flag)):
+        r2 = _run(["scan", "-p", str(tmp_path), "--no-scan"])
+
+    assert r1.exit_code == 0
+    assert r2.exit_code == 0
+    assert pos["project_dir"] == flag["project_dir"] == str(tmp_path)
+
+
+def test_scan_positional_dot_current_dir(tmp_path):
+    """`scan .` scans the current working directory."""
+    captured: dict = {}
+
+    def _capture(**kwargs):
+        captured["project_dir"] = kwargs.get("project_dir")
+        return []
+
+    runner = CliRunner()
+    with patch("agent_bom.cli.agents.discover_all", side_effect=_capture):
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(main, ["scan", ".", "--no-scan", "--no-auto-update-db"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert captured["project_dir"] == "."
+
+
+def test_scan_no_positional_keeps_default(tmp_path):
+    """No positional and no -p leaves project as the existing default (None)."""
+    captured: dict = {}
+
+    def _capture(**kwargs):
+        captured["project_dir"] = kwargs.get("project_dir")
+        return []
+
+    with patch("agent_bom.cli.agents.discover_all", side_effect=_capture):
+        result = _run(["scan", "--no-scan"])
+
+    assert result.exit_code == 0
+    assert captured["project_dir"] is None
+
+
+def test_scan_positional_and_project_conflict_warns_project_wins(tmp_path):
+    """When PATH and -p disagree, -p wins (positional must not silently override)."""
+    other = tmp_path / "other"
+    other.mkdir()
+    captured: dict = {}
+
+    def _capture(**kwargs):
+        captured["project_dir"] = kwargs.get("project_dir")
+        return []
+
+    with patch("agent_bom.cli.agents.discover_all", side_effect=_capture):
+        result = _run(["scan", str(tmp_path), "-p", str(other), "--no-scan"])
+
+    assert result.exit_code == 0
+    assert captured["project_dir"] == str(other)
+
+
+def test_scan_positional_with_image_still_routes_to_image(tmp_path):
+    """Positional PATH alongside --image must not hijack image scanning."""
+    image_calls: list = []
+    discover_calls: list = []
+
+    def _fake_scan_image(image_ref, **kwargs):
+        image_calls.append(image_ref)
+        return ([], "test-strategy")
+
+    def _capture_discover(**kwargs):
+        discover_calls.append(kwargs.get("project_dir"))
+        return []
+
+    with (
+        patch("agent_bom.image.scan_image", side_effect=_fake_scan_image),
+        patch("agent_bom.cli.agents.discover_all", side_effect=_capture_discover),
+    ):
+        result = _run(["scan", str(tmp_path), "--image", "alpine:3.19", "--no-scan"])
+
+    assert result.exit_code == 0
+    # Image scanning still happened.
+    assert image_calls == ["alpine:3.19"]
+    # Local project discovery was skipped for image scans (no hijack via PATH).
+    assert discover_calls == []


### PR DESCRIPTION
The scan command previously rejected a positional path: `agent-bom scan .` failed with `Got unexpected extra argument (.)`, and only `-p/--project PATH` worked.

This adds an optional positional `PATH` argument as Docker-style shorthand for `--project/-p`, so `agent-bom scan .` and `agent-bom scan ./dir` now work.

## Semantics
- Only `PATH` given: it sets the project directory to scan.
- `PATH` and `--project/-p` both given and pointing at the same directory: treated as equivalent.
- `PATH` and `--project/-p` disagree: `--project/-p` wins and a warning is logged, so the positional value is never silently honored over an explicit flag.
- Neither given: existing default behavior is unchanged.
- The positional value is purely a project alias and does not interfere with the `--image`, `--sbom`, `--filesystem`, `--self-scan`, or `--demo` input modes.

`-p/--project` remains fully backward compatible. The argument uses `click.Path(exists=True, file_okay=False)` to match existing Click idioms.

## Tests
- `test_scan_positional_path_resolves_like_project`
- `test_scan_positional_path_matches_project_flag`
- `test_scan_positional_dot_current_dir`
- `test_scan_no_positional_keeps_default`
- `test_scan_positional_and_project_conflict_warns_project_wins`
- `test_scan_positional_with_image_still_routes_to_image`