### PR TITLE
feat(graph): fuse LLM cost into the unified graph

### DIFF
--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -1049,6 +1049,16 @@ def build_unified_graph_from_report(
     except Exception:  # noqa: BLE001
         _logger.warning("attack-path fusion failed", exc_info=True)
 
+    # Cost (FinOps) fusion: attach LLM spend to agent/resource nodes, roll it up
+    # the CONTAINS hierarchy, and flag nodes that are BOTH high-cost AND
+    # high-risk. Runs LAST so it sees every exposure/toxic/critical flag the
+    # overlays above wrote. Cost is optional: this no-ops byte-identically when
+    # the report carries no ``llm_cost_records`` block.
+    try:
+        _apply_cost_overlay(graph, report_json)
+    except Exception:  # noqa: BLE001
+        _logger.warning("cost overlay failed", exc_info=True)
+
     if span is not None:
         span.set_attribute("agent_bom.graph.scan_id", sid)
         span.set_attribute("agent_bom.graph.tenant_id", tenant_id or "default")
@@ -1058,6 +1068,29 @@ def build_unified_graph_from_report(
         span.set_attribute("agent_bom.graph.edge_count", len(graph.edges))
         span.end()
     return graph
+
+
+def _apply_cost_overlay(graph: UnifiedGraph, report_json: Mapping[str, Any]) -> None:
+    """Fuse LLM cost into the graph from cost records carried on the report.
+
+    Reads the optional ``llm_cost_records`` block (a list of priced cost-record
+    dicts the caller loaded from the cost store — never fetched here) and hands
+    it to :func:`agent_bom.graph.cost_overlay.apply_cost_overlay`. Gated to a
+    clean no-op when the block is absent or empty, so an ordinary scan (no cost
+    data) leaves the graph byte-identical. Mirrors how ``cnapp_overlay`` /
+    ``governance_overlay`` are invoked above.
+    """
+    raw = report_json.get("llm_cost_records")
+    if not isinstance(raw, list) or not raw:
+        return
+    records = [r for r in raw if isinstance(r, dict)]
+    if not records:
+        return
+    from datetime import datetime, timezone
+
+    from agent_bom.graph.cost_overlay import apply_cost_overlay
+
+    apply_cost_overlay(graph, records, datetime.now(timezone.utc))
 
 
 def _iter_agentic_identity_graph_projections(report_json: Mapping[str, Any]) -> list[Mapping[str, Any]]:

--- a/src/agent_bom/graph/cost_overlay.py
+++ b/src/agent_bom/graph/cost_overlay.py
@@ -1,0 +1,318 @@
+"""Cost (FinOps) fusion: attach LLM spend to graph nodes, roll it up the
+CONTAINS hierarchy, and fuse cost with risk.
+
+Closes the FinOps silo: spend lives in :mod:`agent_bom.api.cost_store` today and
+nothing answers "which asset is BOTH expensive AND exposed". This overlay reads
+priced cost records the caller already loaded (no network, no writes) and:
+
+- **Attaches** per-node spend (``cost_usd`` / ``cost_usd_30d``) on the
+  agent / resource node a record names — matched by node label, canonical id,
+  agent ``source_id``, or ``cost_center`` allocation tag.
+- **Rolls up** spend along existing ``CONTAINS`` edges (agent → account → org,
+  resource → project → org) so each parent node carries ``subtree_cost_usd`` =
+  the SUM of its own + descendants' spend. Deterministic, cycle- and
+  depth-guarded like the other overlays.
+- **Fuses** cost × risk: a node that is BOTH high-cost AND high-risk
+  (internet-exposed, in a toxic combination, or carrying a critical finding)
+  gets a ``cost_risk_priority`` signal and a light advisory interaction risk so
+  "expensive AND exposed" surfaces without new scanner inputs.
+
+The overlay is a pure in-place graph mutation: idempotent (applying twice yields
+identical attributes), deterministic (every iteration is sorted), and a complete
+no-op when no cost records are supplied — the graph stays byte-identical.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from agent_bom.graph.container import InteractionRisk, UnifiedGraph
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+
+_OVERLAY_SOURCE = "cost-overlay"
+
+# Window (days) used for the rolling spend attribute. 30d mirrors the FinOps
+# showback window the cost CLI/API report on.
+_WINDOW_DAYS = 30
+
+# A node carrying at least this much rolled-up spend is "high cost" for the
+# cost×risk fusion. Kept conservative so the signal stays meaningful; the
+# fusion is additive (it only ever sets flags, never lowers risk).
+_HIGH_COST_USD = 100.0
+
+# Entity types whose nodes can directly carry first-class LLM spend. Agents are
+# the primary carrier (a cost record names an agent); cloud/generic resources
+# and models are matched by allocation tags / labels when present.
+_COST_BEARING_TYPES = (
+    EntityType.AGENT,
+    EntityType.CLOUD_RESOURCE,
+    EntityType.RESOURCE,
+    EntityType.MODEL,
+    EntityType.SERVICE_ACCOUNT,
+    EntityType.MANAGED_IDENTITY,
+)
+
+# Cap the CONTAINS roll-up walk so a pathological graph can never blow up; the
+# real estate is org → ou → account → agent (≤ a handful of tiers).
+_MAX_ROLLUP_DEPTH = 32
+
+
+def _record_field(record: Any, name: str) -> Any:
+    """Read a field from an LLMCostRecord dataclass or a plain dict.
+
+    The caller may supply either the dataclass (from the cost store) or already
+    JSON-decoded dicts (from a report payload); support both without importing —
+    keeping this module decoupled from the cost store's write path.
+    """
+    if isinstance(record, dict):
+        return record.get(name)
+    return getattr(record, name, None)
+
+
+def _record_tags(record: Any) -> dict[str, str]:
+    tags = _record_field(record, "allocation_tags")
+    if isinstance(tags, dict):
+        return {str(k): str(v) for k, v in tags.items()}
+    return {}
+
+
+def _node_match_keys(node: UnifiedNode) -> set[str]:
+    """Lower-cased identifiers a cost record may name this node by.
+
+    Covers the label, canonical id, the agent ``source_id`` / ``stable_id``,
+    ``owner``, and any ``cost_center`` carried on the node so a record's
+    ``agent`` / ``cost_center`` matches however the node was projected.
+    """
+    keys: set[str] = set()
+    if node.label:
+        keys.add(node.label.strip().lower())
+    for attr_key in ("canonical_id", "stable_id", "source_id", "cost_center", "owner", "name"):
+        val = node.attributes.get(attr_key)
+        if isinstance(val, str) and val.strip():
+            keys.add(val.strip().lower())
+    keys.discard("")
+    keys.discard("unknown")
+    return keys
+
+
+def _window_start(now: datetime) -> datetime:
+    return now - timedelta(days=_WINDOW_DAYS)
+
+
+def _parse_observed_at(raw: Any) -> datetime | None:
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    text = raw.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _is_high_risk(node: UnifiedNode) -> bool:
+    """A node is high-risk if it is exposed, in a toxic combo, or critical.
+
+    Reuses signals the CNAPP / attack-path overlays already wrote — cost fusion
+    runs after them so it sees ``internet_exposed`` / ``toxic_*`` flags and the
+    node's resolved severity / risk score.
+    """
+    attrs = node.attributes
+    if attrs.get("internet_exposed"):
+        return True
+    if attrs.get("toxic_exposed_vulnerable") or attrs.get("toxic_exposed_sensitive"):
+        return True
+    if (node.severity or "").lower() == "critical":
+        return True
+    return node.risk_score >= 9.0
+
+
+def apply_cost_overlay(
+    graph: UnifiedGraph,
+    cost_records: list[Any],
+    now: datetime,
+    *,
+    high_cost_usd: float = _HIGH_COST_USD,
+) -> dict[str, int]:
+    """Attach spend to nodes, roll it up CONTAINS, and fuse cost × risk in place.
+
+    Args:
+        graph: the unified graph to enrich (mutated in place).
+        cost_records: priced ``LLMCostRecord`` dataclasses (or dicts) the caller
+            already loaded from the cost store. Never fetched here.
+        now: the reference time for the rolling window (no inline ``datetime.now``).
+        high_cost_usd: subtree-spend threshold for the high-cost fusion signal.
+
+    Returns counts of nodes stamped, roll-up parents, and fused signals. A node
+    receives spend only when a record names it; absence is a clean no-op.
+    """
+    if not cost_records:
+        return {"cost_nodes": 0, "rollup_nodes": 0, "fused_signals": 0}
+
+    window_start = _window_start(now)
+
+    # ── 1. Aggregate records by every key they could match a node on ────────
+    # total spend (all-time, within the supplied records) and the rolling
+    # 30d window, summed per candidate key (agent name, cost_center, provider).
+    total_by_key: dict[str, float] = defaultdict(float)
+    window_by_key: dict[str, float] = defaultdict(float)
+    calls_by_key: dict[str, int] = defaultdict(int)
+    for record in cost_records:
+        cost = _record_field(record, "cost_usd")
+        cost_val = float(cost) if isinstance(cost, (int, float)) else 0.0
+        observed = _parse_observed_at(_record_field(record, "observed_at"))
+        in_window = observed is not None and observed >= window_start
+        candidate_keys: set[str] = set()
+        for field_name in ("agent", "cost_center", "provider"):
+            val = _record_field(record, field_name)
+            if isinstance(val, str) and val.strip():
+                candidate_keys.add(val.strip().lower())
+        for tag_val in _record_tags(record).values():
+            if tag_val.strip():
+                candidate_keys.add(tag_val.strip().lower())
+        candidate_keys.discard("unknown")
+        for key in candidate_keys:
+            total_by_key[key] += cost_val
+            calls_by_key[key] += 1
+            if in_window:
+                window_by_key[key] += cost_val
+
+    # ── 2. Attach spend to the node each key names ──────────────────────────
+    # Deterministic: iterate nodes in id order, take the highest-spend matching
+    # key so a node tagged by both its name and a cost_center carries the larger
+    # (parent) figure rather than an arbitrary one.
+    own_cost: dict[str, float] = {}
+    cost_nodes = 0
+    for node_id in sorted(graph.nodes):
+        node = graph.nodes[node_id]
+        if node.entity_type not in _COST_BEARING_TYPES:
+            continue
+        match_keys = _node_match_keys(node) & total_by_key.keys()
+        if not match_keys:
+            continue
+        best_key = max(sorted(match_keys), key=lambda k: total_by_key[k])
+        total = round(total_by_key[best_key], 6)
+        window = round(window_by_key.get(best_key, 0.0), 6)
+        node.attributes["cost_usd"] = total
+        node.attributes["cost_usd_30d"] = window
+        node.attributes["cost_calls"] = calls_by_key[best_key]
+        node.attributes["cost_match_key"] = best_key
+        if _OVERLAY_SOURCE not in node.data_sources:
+            node.data_sources.append(_OVERLAY_SOURCE)
+        own_cost[node_id] = total
+        cost_nodes += 1
+
+    # ── 3. Roll up own cost along CONTAINS edges (subtree sums) ─────────────
+    rollup_nodes = _roll_up_contains(graph, own_cost)
+
+    # ── 4. Fuse cost × risk where a node is expensive AND high-risk ─────────
+    fused_signals = _fuse_cost_risk(graph, own_cost, high_cost_usd)
+
+    return {
+        "cost_nodes": cost_nodes,
+        "rollup_nodes": rollup_nodes,
+        "fused_signals": fused_signals,
+    }
+
+
+def _roll_up_contains(graph: UnifiedGraph, own_cost: dict[str, float]) -> int:
+    """Propagate ``own_cost`` upward along CONTAINS edges as ``subtree_cost_usd``.
+
+    ``CONTAINS`` points parent → child (org CONTAINS account CONTAINS agent), so
+    a node's subtree spend is its own spend plus the spend of everything it
+    transitively contains. Computed with a memoised DFS that is cycle-safe
+    (a node already on the stack contributes 0 on re-entry) and depth-bounded.
+    Every node that ends up carrying spend gets ``subtree_cost_usd`` stamped;
+    returns the number of such nodes.
+    """
+    # children[parent] = sorted list of nodes this node CONTAINS.
+    children: dict[str, list[str]] = defaultdict(list)
+    for edge in graph.edges:
+        if edge.relationship == RelationshipType.CONTAINS:
+            children[edge.source].append(edge.target)
+    for parent in children:
+        children[parent] = sorted(set(children[parent]))
+
+    def _subtree_cost(root: str) -> float:
+        # Sum each DISTINCT descendant's own cost exactly once. A path/ancestor
+        # set breaks cycles (a node already on the way down from ``root`` is not
+        # re-counted) and the visited set dedupes shared children in a DAG, so
+        # the sum is bounded by the total spend under ``root`` — never inflated
+        # by cycles. Depth-guarded for pathological chains. Deterministic:
+        # children are pre-sorted.
+        total = 0.0
+        visited: set[str] = set()
+        stack: list[tuple[str, int]] = [(root, 0)]
+        while stack:
+            node_id, depth = stack.pop()
+            if node_id in visited or depth > _MAX_ROLLUP_DEPTH:
+                continue
+            visited.add(node_id)
+            total += own_cost.get(node_id, 0.0)
+            for child_id in children.get(node_id, []):
+                if child_id not in visited:
+                    stack.append((child_id, depth + 1))
+        return round(total, 6)
+
+    rollup_nodes = 0
+    # Deterministic order: every node that could carry subtree spend, sorted.
+    relevant = sorted(set(children) | set(own_cost))
+    for node_id in relevant:
+        if node_id not in graph.nodes:
+            continue
+        total = _subtree_cost(node_id)
+        if total <= 0.0:
+            continue
+        graph.nodes[node_id].attributes["subtree_cost_usd"] = total
+        rollup_nodes += 1
+    return rollup_nodes
+
+
+def _fuse_cost_risk(graph: UnifiedGraph, own_cost: dict[str, float], high_cost_usd: float) -> int:
+    """Flag nodes that are BOTH high-cost AND high-risk.
+
+    Uses ``subtree_cost_usd`` when present (so an expensive subtree under a risky
+    parent still fires) else the node's own spend. Sets ``cost_risk_priority``
+    and appends one advisory ``InteractionRisk`` per fused node. Additive only:
+    never lowers risk, deterministic over a sorted node order, and idempotent
+    (the interaction-risk append is de-duplicated on the node label).
+    """
+    existing_fused = {risk.agents[0] for risk in graph.interaction_risks if risk.pattern == "expensive_and_exposed" and risk.agents}
+    fused = 0
+    for node_id in sorted(own_cost):
+        node = graph.nodes.get(node_id)
+        if node is None:
+            continue
+        spend = float(node.attributes.get("subtree_cost_usd", own_cost.get(node_id, 0.0)))
+        if spend < high_cost_usd:
+            continue
+        if not _is_high_risk(node):
+            continue
+        # Idempotent: re-applying must not re-stamp or duplicate the advisory.
+        already = node.attributes.get("cost_risk_priority") == "expensive_and_exposed"
+        node.attributes["cost_risk_priority"] = "expensive_and_exposed"
+        node.attributes["cost_risk_spend_usd"] = round(spend, 6)
+        if already or node.label in existing_fused:
+            continue
+        graph.interaction_risks.append(
+            InteractionRisk(
+                pattern="expensive_and_exposed",
+                agents=[node.label],
+                risk_score=9.0,
+                description=(
+                    f"{node.label} carries ${round(spend, 2)} of LLM spend and is high-risk "
+                    "(internet-exposed / toxic / critical) — prioritise: expensive AND exposed."
+                ),
+                owasp_agentic_tag=None,
+            )
+        )
+        existing_fused.add(node.label)
+        fused += 1
+    return fused

--- a/tests/test_graph_cost_overlay.py
+++ b/tests/test_graph_cost_overlay.py
@@ -1,0 +1,211 @@
+"""Cost (FinOps) overlay: attach spend, roll up CONTAINS, fuse cost × risk."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from agent_bom.api.cost_store import LLMCostRecord
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.cost_overlay import apply_cost_overlay
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+
+_NOW = datetime(2026, 6, 25, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _record(agent: str, cost: float, *, observed: str = "2026-06-20T00:00:00+00:00", cost_center: str = "") -> LLMCostRecord:
+    return LLMCostRecord(
+        tenant_id="t",
+        call_id=f"{agent}-{cost}-{observed}",
+        agent=agent,
+        session_id="s",
+        provider="openai",
+        model="gpt-4o",
+        input_tokens=1000,
+        output_tokens=500,
+        cost_usd=cost,
+        priced=True,
+        observed_at=observed,
+        cost_center=cost_center,
+    )
+
+
+def _org_account_agent_graph() -> UnifiedGraph:
+    """org CONTAINS account CONTAINS agent — the canonical roll-up chain."""
+    graph = UnifiedGraph(scan_id="s", tenant_id="t")
+    graph.add_node(UnifiedNode(id="org:acme", entity_type=EntityType.ORG, label="acme"))
+    graph.add_node(UnifiedNode(id="account:prod", entity_type=EntityType.ACCOUNT, label="prod-account"))
+    graph.add_node(UnifiedNode(id="agent:billing-bot", entity_type=EntityType.AGENT, label="billing-bot"))
+    graph.add_node(UnifiedNode(id="agent:support-bot", entity_type=EntityType.AGENT, label="support-bot"))
+    graph.add_edge(UnifiedEdge(source="org:acme", target="account:prod", relationship=RelationshipType.CONTAINS))
+    graph.add_edge(UnifiedEdge(source="account:prod", target="agent:billing-bot", relationship=RelationshipType.CONTAINS))
+    graph.add_edge(UnifiedEdge(source="account:prod", target="agent:support-bot", relationship=RelationshipType.CONTAINS))
+    return graph
+
+
+def test_cost_attaches_to_named_agent_node():
+    graph = _org_account_agent_graph()
+    stats = apply_cost_overlay(graph, [_record("billing-bot", 42.0)], _NOW)
+
+    bot = graph.nodes["agent:billing-bot"]
+    assert bot.attributes["cost_usd"] == 42.0
+    assert bot.attributes["cost_usd_30d"] == 42.0
+    assert bot.attributes["cost_calls"] == 1
+    assert "cost-overlay" in bot.data_sources
+    # unrelated agent gets nothing
+    assert "cost_usd" not in graph.nodes["agent:support-bot"].attributes
+    assert stats["cost_nodes"] == 1
+
+
+def test_subtree_rollup_sums_up_a_contains_chain():
+    graph = _org_account_agent_graph()
+    apply_cost_overlay(
+        graph,
+        [_record("billing-bot", 100.0), _record("support-bot", 25.0)],
+        _NOW,
+    )
+
+    # leaf carries own spend; parents carry SUM of subtree.
+    assert graph.nodes["agent:billing-bot"].attributes["subtree_cost_usd"] == 100.0
+    assert graph.nodes["agent:support-bot"].attributes["subtree_cost_usd"] == 25.0
+    assert graph.nodes["account:prod"].attributes["subtree_cost_usd"] == 125.0
+    assert graph.nodes["org:acme"].attributes["subtree_cost_usd"] == 125.0
+
+
+def test_window_split_30d_vs_all_time():
+    graph = _org_account_agent_graph()
+    apply_cost_overlay(
+        graph,
+        [
+            _record("billing-bot", 10.0, observed="2026-06-24T00:00:00+00:00"),  # in window
+            _record("billing-bot", 90.0, observed="2026-01-01T00:00:00+00:00"),  # out of window
+        ],
+        _NOW,
+    )
+    bot = graph.nodes["agent:billing-bot"]
+    assert bot.attributes["cost_usd"] == 100.0
+    assert bot.attributes["cost_usd_30d"] == 10.0
+
+
+def test_expensive_and_exposed_gets_fused_signal():
+    graph = _org_account_agent_graph()
+    # mark the billing bot internet-exposed (as the CNAPP overlay would)
+    graph.nodes["agent:billing-bot"].attributes["internet_exposed"] = True
+    stats = apply_cost_overlay(graph, [_record("billing-bot", 500.0)], _NOW)
+
+    bot = graph.nodes["agent:billing-bot"]
+    assert bot.attributes["cost_risk_priority"] == "expensive_and_exposed"
+    assert bot.attributes["cost_risk_spend_usd"] == 500.0
+    assert stats["fused_signals"] == 1
+    assert any(r.pattern == "expensive_and_exposed" and "billing-bot" in r.agents for r in graph.interaction_risks)
+
+
+def test_expensive_but_not_risky_is_not_fused():
+    graph = _org_account_agent_graph()
+    stats = apply_cost_overlay(graph, [_record("billing-bot", 9999.0)], _NOW)
+    assert "cost_risk_priority" not in graph.nodes["agent:billing-bot"].attributes
+    assert stats["fused_signals"] == 0
+
+
+def test_risky_but_cheap_is_not_fused():
+    graph = _org_account_agent_graph()
+    graph.nodes["agent:billing-bot"].attributes["internet_exposed"] = True
+    stats = apply_cost_overlay(graph, [_record("billing-bot", 1.0)], _NOW)
+    assert "cost_risk_priority" not in graph.nodes["agent:billing-bot"].attributes
+    assert stats["fused_signals"] == 0
+
+
+def test_empty_cost_records_is_total_noop():
+    graph = _org_account_agent_graph()
+    before = graph.to_dict()
+    stats = apply_cost_overlay(graph, [], _NOW)
+    after = graph.to_dict()
+    assert before == after
+    assert stats == {"cost_nodes": 0, "rollup_nodes": 0, "fused_signals": 0}
+
+
+def test_apply_twice_is_idempotent():
+    graph = _org_account_agent_graph()
+    graph.nodes["agent:billing-bot"].attributes["internet_exposed"] = True
+    records = [_record("billing-bot", 500.0), _record("support-bot", 25.0)]
+
+    apply_cost_overlay(graph, records, _NOW)
+    snapshot = graph.to_dict()
+    risk_count = len(graph.interaction_risks)
+
+    apply_cost_overlay(graph, records, _NOW)
+    assert graph.to_dict() == snapshot
+    # the advisory interaction-risk is de-duplicated, not re-appended.
+    assert len(graph.interaction_risks) == risk_count
+
+
+def test_cost_center_allocation_tag_matches_node():
+    graph = UnifiedGraph(scan_id="s", tenant_id="t")
+    # node carries a cost_center attribute; record names that cost_center.
+    graph.add_node(
+        UnifiedNode(
+            id="agent:fleet",
+            entity_type=EntityType.AGENT,
+            label="fleet-agent",
+            attributes={"cost_center": "platform-team"},
+        )
+    )
+    apply_cost_overlay(graph, [_record("other-name", 30.0, cost_center="platform-team")], _NOW)
+    assert graph.nodes["agent:fleet"].attributes["cost_usd"] == 30.0
+
+
+def test_rollup_is_cycle_safe():
+    graph = UnifiedGraph(scan_id="s", tenant_id="t")
+    graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="a"))
+    graph.add_node(UnifiedNode(id="agent:b", entity_type=EntityType.AGENT, label="b"))
+    # a CONTAINS b, b CONTAINS a (pathological cycle) — must terminate.
+    graph.add_edge(UnifiedEdge(source="agent:a", target="agent:b", relationship=RelationshipType.CONTAINS))
+    graph.add_edge(UnifiedEdge(source="agent:b", target="agent:a", relationship=RelationshipType.CONTAINS))
+    stats = apply_cost_overlay(graph, [_record("a", 10.0), _record("b", 20.0)], _NOW)
+    # Terminates and each node's own cost is counted exactly once per subtree —
+    # the cycle does NOT inflate the sum beyond total spend (10 + 20 = 30).
+    assert graph.nodes["agent:a"].attributes["subtree_cost_usd"] == 30.0
+    assert graph.nodes["agent:b"].attributes["subtree_cost_usd"] == 30.0
+    assert stats["cost_nodes"] == 2
+
+
+def test_builder_wires_cost_overlay_from_report():
+    from agent_bom.graph.builder import build_unified_graph_from_report
+
+    report = {
+        "scan_id": "scan-1",
+        "agents": [{"name": "billing-bot", "type": "custom", "source": "local"}],
+        "llm_cost_records": [
+            {
+                "tenant_id": "t",
+                "call_id": "c1",
+                "agent": "billing-bot",
+                "session_id": "s",
+                "provider": "openai",
+                "model": "gpt-4o",
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "cost_usd": 12.5,
+                "priced": True,
+                "observed_at": "2026-06-24T00:00:00+00:00",
+            }
+        ],
+    }
+    graph = build_unified_graph_from_report(report)
+    agent_nodes = [n for n in graph.nodes.values() if n.entity_type == EntityType.AGENT]
+    assert len(agent_nodes) == 1
+    assert agent_nodes[0].attributes["cost_usd"] == 12.5
+
+
+def test_builder_without_cost_records_leaves_no_cost_attrs():
+    from agent_bom.graph.builder import build_unified_graph_from_report
+
+    report = {
+        "scan_id": "scan-1",
+        "agents": [{"name": "billing-bot", "type": "custom", "source": "local"}],
+    }
+    graph = build_unified_graph_from_report(report)
+    for node in graph.nodes.values():
+        assert "cost_usd" not in node.attributes
+        assert "subtree_cost_usd" not in node.attributes


### PR DESCRIPTION
## What

Fuses LLM spend (FinOps) into the unified graph so cost rolls up the same `CONTAINS` hierarchy as risk. Previously cost lived in a separate store and nothing answered "which asset is both expensive AND exposed". This closes that gap additively, without new scanner inputs.

## How

New `src/agent_bom/graph/cost_overlay.py` (`apply_cost_overlay(graph, cost_records, now)`):

- **Attach** — stamps `cost_usd`, `cost_usd_30d`, and `cost_calls` on agent / resource / model / identity nodes that a cost record names. Matched by node label, canonical id, `source_id`, `owner`, or a `cost_center` allocation tag. Reads only the records the caller supplies — no network, no writes.
- **Roll up** — propagates spend upward along existing `CONTAINS` edges (agent → account → org, resource → project → org) into `subtree_cost_usd` = the sum of a node's own + transitive descendants' spend. The walk is cycle- and depth-guarded and counts each descendant's own cost exactly once, so cycles never inflate the sum.
- **Fuse cost × risk** — where a node is both high-cost and high-risk (internet-exposed, in a toxic combination, or critical), sets a `cost_risk_priority` signal and appends one light advisory interaction risk, so "expensive AND exposed" surfaces directly. Additive only — never lowers risk.

Wired into `build_unified_graph_from_report` via a single `_apply_cost_overlay`, alongside the other overlays and gated on a `llm_cost_records` block. When that block is absent (an ordinary scan), it is a byte-identical no-op.

## Guarantees

- Idempotent: applying twice yields identical attributes and does not duplicate the advisory.
- Deterministic: every iteration is sorted; the window uses a supplied `now`, no inline clock in the overlay.
- No-op safety: zero cost records leaves the graph unchanged (covered by a test).

## Tests (`tests/test_graph_cost_overlay.py`)

`test_cost_attaches_to_named_agent_node`, `test_subtree_rollup_sums_up_a_contains_chain`, `test_window_split_30d_vs_all_time`, `test_expensive_and_exposed_gets_fused_signal`, `test_expensive_but_not_risky_is_not_fused`, `test_risky_but_cheap_is_not_fused`, `test_empty_cost_records_is_total_noop`, `test_apply_twice_is_idempotent`, `test_cost_center_allocation_tag_matches_node`, `test_rollup_is_cycle_safe`, `test_builder_wires_cost_overlay_from_report`, `test_builder_without_cost_records_leaves_no_cost_attrs`.

`ruff check` / `ruff format` / `mypy` clean on touched files; full `-k "cost or graph or overlay or fusion"` suite green (746 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)