### PR TITLE
feat(cloud): registry-wide container image sweep (ECR/ACR/GAR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ integration docs instead of this front door.
 | Python client | services, notebooks, and automation | typed helper for stable REST endpoints in the packaged wheel |
 | TypeScript client | services and agent runtimes | typed helper for stable REST endpoints |
 
-MCP server mode advertises 69 MCP tools, 6 resources, and 6 workflow prompts.
+MCP server mode advertises 70 MCP tools, 6 resources, and 6 workflow prompts.
 Most tools are read-only. The three Shield write actions fail closed unless
 the caller supplies `operator_role=admin`, `operator_scopes=shield:write`, and
 an audit reason.

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -1,6 +1,6 @@
 # MCP Server — Streamable HTTP transport for remote clients.
 #
-# Exposes agent-bom's 69 MCP tools over streamable HTTP so that Smithery, Claude
+# Exposes agent-bom's 70 MCP tools over streamable HTTP so that Smithery, Claude
 # Desktop (remote mode), and any other MCP client can connect via public URL.
 #
 # Build:   docker build -f deploy/docker/Dockerfile.sse -t agent-bom-sse .

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -391,7 +391,7 @@ graph TB
 | Output | `src/agent_bom/output/__init__.py` | JSON, CycloneDX, SARIF, SPDX, console |
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine (17 conditions) |
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP proxy (7 inline detectors) |
-| MCP Server | `src/agent_bom/mcp_server*.py` | FastMCP server (69 tools across core, operator, runtime-catalog, and specialized modules) |
+| MCP Server | `src/agent_bom/mcp_server*.py` | FastMCP server (70 tools across core, operator, runtime-catalog, and specialized modules) |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse |
 | Asset Tracker | `src/agent_bom/asset_tracker.py` | Persistent vuln tracking — first_seen, resolved, MTTR |
 | Context Graph | `src/agent_bom/context_graph.py` | Lateral movement analysis — see [Graph Contract](graph/CONTRACT.md) for entity/edge coverage, accuracy guarantees, and scaling boundaries |

--- a/docs/CLAUDE_INTEGRATION.md
+++ b/docs/CLAUDE_INTEGRATION.md
@@ -59,7 +59,7 @@ claude mcp add agent-bom -- uvx agent-bom mcp server
 
 ## What users get inside Claude
 
-`agent-bom mcp server` exposes 69 MCP tools for:
+`agent-bom mcp server` exposes 70 MCP tools for:
 
 - agent and MCP discovery
 - package and registry checks

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,6 +1,6 @@
 # MCP Server — Connect agent-bom to AI Assistants
 
-agent-bom exposes 69 MCP tools as an MCP server. Any MCP-compatible client can
+agent-bom exposes 70 MCP tools as an MCP server. Any MCP-compatible client can
 connect and get vulnerability scanning, blast radius analysis, compliance
 checks, runtime posture, and supply-chain verification through natural
 conversation.
@@ -156,7 +156,7 @@ agent-bom proxy-bootstrap \
 
 `proxy-configure` is best for JSON MCP clients such as Claude Desktop, Cursor, Windsurf, and Cortex CoCo. TOML-based clients like Codex CLI need manual proxy wrapping.
 
-## Tool Categories (69 tools)
+## Tool Categories (70 tools)
 
 | Category | Tools | What They Do |
 |----------|-------|-------------|

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -125,7 +125,7 @@ notes discuss agent-native product direction.
 | Area | Shipped today | Not yet shipped |
 |---|---|---|
 | Human cockpit | Next.js dashboard, graph cockpit, reports, compliance and audit views | every UI action backed by a source registry and persisted workflow state |
-| Agent interface | 69 MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture, admin-gated Shield actions | long-lived posture subscription tool, autonomous remediation actions |
+| Agent interface | 70 MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture, admin-gated Shield actions | long-lived posture subscription tool, autonomous remediation actions |
 | Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports, Python/Go/TypeScript control-plane clients, TypeScript runtime detector package | full scanner SDKs |
 | Runtime | MCP proxy, gateway, Shield SDK, runtime audit and policy decisions | webhook outbox, Kafka connectors, cloud-log ingestion connectors, Kinesis/Firehose adapter, and MCP posture subscriptions |
 | Graph scale | SQLite/Postgres default path, WebGL overview, optional Neptune adapter work | production Neptune SLOs, public openCypher endpoint, mandatory graph-database backend |

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ material. The index below groups the canonical docs by audience.
 
 ## AI / agent developers (MCP · clients · tools)
 
-- [`MCP_SERVER.md`](MCP_SERVER.md) — run the MCP server, 69 tools
+- [`MCP_SERVER.md`](MCP_SERVER.md) — run the MCP server, 70 tools
 - [`MCP_CLIENT_GUIDES.md`](MCP_CLIENT_GUIDES.md) — connect MCP clients
 - [`PYTHON_API.md`](PYTHON_API.md) — Python control-plane client
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -95,13 +95,13 @@ scan a repo by URL.
 
 ```bash
 pip install 'agent-bom[mcp-server]'
-agent-bom mcp server                      # stdio MCP server: 69 tools, 6 resources, 6 prompts
+agent-bom mcp server                      # stdio MCP server: 70 tools, 6 resources, 6 prompts
 ```
 
 - MCP server setup + client guides: [`MCP_SERVER.md`](MCP_SERVER.md),
   [`MCP_CLIENT_GUIDES.md`](MCP_CLIENT_GUIDES.md)
 - Tool catalog (read-mostly; 3 audited Shield write actions): see the
-  `Tools (69)` block in
+  `Tools (70)` block in
   [`../src/agent_bom/mcp_server.py`](../src/agent_bom/mcp_server.py)
 - Typed control-plane clients: [`PYTHON_API.md`](PYTHON_API.md),
   [`../sdks/go/README.md`](../sdks/go/README.md)

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -187,7 +187,7 @@
   <g>
     <rect x="772" y="368" width="182" height="88" rx="8" fill="#0f172a" stroke="#1e3a36"/>
     <text x="786" y="392" class="node-title" fill="#5eead4">MCP server</text>
-    <text x="786" y="409" class="node-sub">69 tools · scan, intel, graph,</text>
+    <text x="786" y="409" class="node-sub">70 tools · scan, intel, graph,</text>
     <text x="786" y="422" class="node-sub">remediate, identity, shield</text>
     <text x="786" y="441" class="pill" fill="#5eead4">stdio · SSE · streamable-HTTP</text>
   </g>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -187,7 +187,7 @@
   <g>
     <rect x="772" y="368" width="182" height="88" rx="8" fill="#ffffff" stroke="#99e6da"/>
     <text x="786" y="392" class="node-title" fill="#0f766e">MCP server</text>
-    <text x="786" y="409" class="node-sub">69 tools · scan, intel, graph,</text>
+    <text x="786" y="409" class="node-sub">70 tools · scan, intel, graph,</text>
     <text x="786" y="422" class="node-sub">remediate, identity, shield</text>
     <text x="786" y="441" class="pill" fill="#0f766e">stdio · SSE · streamable-HTTP</text>
   </g>

--- a/integrations/docker-mcp-registry/SUBMISSION.md
+++ b/integrations/docker-mcp-registry/SUBMISSION.md
@@ -5,7 +5,7 @@ Submission files for listing agent-bom in the Docker Desktop MCP Toolkit catalog
 ## Files
 
 - `server.yaml` — server metadata, image, allowed hosts, optional secrets
-- `tools.json` — all 69 MCP tools with descriptions and parameters
+- `tools.json` — all 70 MCP tools with descriptions and parameters
 - `readme.md` — Docker MCP Toolkit detail page content
 
 ## How to submit

--- a/integrations/docker-mcp-registry/tools.json
+++ b/integrations/docker-mcp-registry/tools.json
@@ -1027,6 +1027,47 @@
     ]
   },
   {
+    "name": "registry_sweep_scan",
+    "description": "Sweep a cloud registry (ECR/ACR/GAR): enumerate repos+tags, dedupe by digest, cap, scan each (read-only).",
+    "arguments": [
+      {
+        "name": "provider",
+        "type": "string",
+        "desc": "Container registry to sweep: ecr, acr, or gar"
+      },
+      {
+        "name": "region",
+        "type": "string",
+        "desc": "AWS region (ecr only)"
+      },
+      {
+        "name": "profile",
+        "type": "string",
+        "desc": "AWS credential profile (ecr only)"
+      },
+      {
+        "name": "registry",
+        "type": "string",
+        "desc": "ACR login server, e.g. myacr.azurecr.io (acr only)"
+      },
+      {
+        "name": "project",
+        "type": "string",
+        "desc": "GCP project id (gar only)"
+      },
+      {
+        "name": "location",
+        "type": "string",
+        "desc": "GAR location or multi-region, e.g. us (gar only)"
+      },
+      {
+        "name": "max_images",
+        "type": "integer",
+        "desc": "Cap on images scanned"
+      }
+    ]
+  },
+  {
     "name": "dataset_card_scan",
     "description": "Scan a directory for ML dataset card metadata and provenance \u2014 checks for license and sourcing issues.",
     "arguments": [

--- a/integrations/smithery.yaml
+++ b/integrations/smithery.yaml
@@ -3,7 +3,7 @@
 # The startCommand / configSchema / commandFunction block below is the runtime
 # contract Smithery executes — do not change its shape.
 name: agent-bom
-description: "Open security scanner and self-hosted control plane for AI/MCP infrastructure — agents, MCP servers, runtime, and blast radius. Exposes 69 MCP tools for scanning, compliance, and graph analysis."
+description: "Open security scanner and self-hosted control plane for AI/MCP infrastructure — agents, MCP servers, runtime, and blast radius. Exposes 70 MCP tools for scanning, compliance, and graph analysis."
 homepage: "https://github.com/msaad00/agent-bom"
 
 runtime: "python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ azure = [
     "azure-mgmt-sql>=3.0",
     "azure-mgmt-rdbms>=10.1",
     "azure-mgmt-containerregistry>=10.3",
+    "azure-containerregistry>=1.2",
     "azure-mgmt-cosmosdb>=9.5",
     "azure-mgmt-managementgroups>=1.0",
     "azure-mgmt-eventhub>=11.0",

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -444,7 +444,7 @@ def main() -> int:
     tools = len(tool_names)
     resources = len(resource_uris)
     prompts = len(prompt_names)
-    if (tools, resources, prompts) != (69, 6, 6):
+    if (tools, resources, prompts) != (70, 6, 6):
         _fail(f"MCP server card count changed unexpectedly: tools={tools}, resources={resources}, prompts={prompts}")
     docker_mcp_tool_names = [str(tool["name"]) for tool in json.loads(DOCKER_MCP_TOOLS.read_text())]
     if docker_mcp_tool_names != tool_names:

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -270,6 +270,8 @@ AGENT_BOM_REPO_SCAN_ALLOWED_HOSTS
 AGENT_BOM_REPO_SCAN_TOKEN
 AGENT_BOM_REGISTRY_PASS
 AGENT_BOM_REGISTRY_USER
+AGENT_BOM_REGISTRY_MAX_IMAGES  # cap on images pulled+scanned per registry-wide sweep (default 50); read in cloud/registry_sweep.py
+AGENT_BOM_REGISTRY_MAX_TAGS_PER_REPO  # per-repo tag fan-out cap before global dedupe+cap in registry sweep (default 25); read in cloud/registry_sweep.py
 AGENT_BOM_REQUIRE_AUDIT_HMAC
 AGENT_BOM_REQUIRE_BROWSER_SESSION_SIGNING_KEY
 AGENT_BOM_REQUIRE_SCIM

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server Setup
 
-agent-bom runs as an MCP server, exposing 69 MCP tools to any MCP client.
+agent-bom runs as an MCP server, exposing 70 MCP tools to any MCP client.
 The server card also advertises 6 resources and 6 workflow prompts so agents can
 choose structured playbooks instead of guessing tool order.
 Most tools are read-only. Shield write actions require `operator_role=admin`,

--- a/src/agent_bom/cli/_cloud_group.py
+++ b/src/agent_bom/cli/_cloud_group.py
@@ -228,6 +228,104 @@ def resilience_cmd(output_format: str) -> None:
 cloud_group.add_command(resilience_cmd, "resilience")
 
 
+@click.command("registry-scan")
+@click.option(
+    "--provider",
+    type=click.Choice(["ecr", "acr", "gar"]),
+    required=True,
+    help="Container registry to sweep: ecr (AWS), acr (Azure), gar (GCP Artifact Registry).",
+)
+@click.option("--region", default=None, help="AWS region (ecr only).")
+@click.option("--profile", default=None, help="AWS credential profile (ecr only).")
+@click.option("--registry", default=None, help="ACR login server, e.g. myacr.azurecr.io (acr only).")
+@click.option("--project", default=None, help="GCP project id (gar only).")
+@click.option("--location", default=None, help="GAR multi-region/location, e.g. us (gar only; all common ones by default).")
+@click.option("--max-images", type=int, default=None, help="Cap on images scanned (default: AGENT_BOM_REGISTRY_MAX_IMAGES or 50).")
+@click.option("-f", "--format", "output_format", type=click.Choice(["console", "json"]), default="console")
+def registry_scan_cmd(
+    provider: str,
+    region: Optional[str],
+    profile: Optional[str],
+    registry: Optional[str],
+    project: Optional[str],
+    location: Optional[str],
+    max_images: Optional[int],
+    output_format: str,
+) -> None:
+    """Sweep an entire cloud container registry — enumerate every repo+tag, scan each (read-only).
+
+    Enumerates all repositories and tags in the registry, dedupes images by
+    content digest, caps the work list (newest first), and runs the native image
+    scanner on each. Read-only throughout — only registry read APIs and image
+    pulls. A registry the role cannot read, or a single image that fails to pull,
+    degrades to a warning and the sweep continues.
+
+    \b
+    Examples:
+      agent-bom cloud registry-scan --provider ecr --region us-east-1
+      agent-bom cloud registry-scan --provider acr --registry myacr.azurecr.io
+      agent-bom cloud registry-scan --provider gar --project my-proj --location us
+    """
+    import json as _json
+
+    from agent_bom.cloud.registry_sweep import sweep_registry
+
+    report = sweep_registry(
+        provider=provider,
+        region=region,
+        profile=profile,
+        registry=registry,
+        project=project,
+        location=location,
+        max_images=max_images,
+    )
+
+    if output_format == "json":
+        click.echo(_json.dumps(report, indent=2, sort_keys=True, default=str))
+        return
+
+    from rich.console import Console
+    from rich.table import Table
+
+    con = Console()
+    con.print(f"\n  [bold]Registry sweep[/bold] [dim]· {report['provider']} · read-only · {report['registry'] or '—'}[/dim]")
+
+    status = str(report.get("status", "unknown"))
+    if status != "ok":
+        style = {"no_images": "yellow", "invalid_provider": "red", "all_failed": "red"}.get(status, "yellow")
+        con.print(f"  status: [{style}]{status}[/{style}]")
+
+    con.print(
+        f"  discovered=[cyan]{report['discovered_count']}[/cyan] "
+        f"scanned=[green]{report['scanned_count']}[/green] "
+        f"skipped_by_cap=[yellow]{report['skipped_by_cap']}[/yellow] "
+        f"failed=[red]{report['failed_count']}[/red] "
+        f"cap={report['max_images']}"
+    )
+
+    if report["images"]:
+        table = Table()
+        table.add_column("Image")
+        table.add_column("Packages", justify="right")
+        table.add_column("Vuln pkgs", justify="right")
+        table.add_column("Max severity")
+        for img in report["images"]:
+            table.add_row(
+                str(img["reference"]),
+                str(img["package_count"]),
+                str(img["vulnerable_package_count"]),
+                str(img["max_severity"]),
+            )
+        con.print(table)
+
+    for warning in report["warnings"]:
+        con.print(f"  [yellow]![/yellow] [dim]{warning}[/dim]")
+    con.print()
+
+
+cloud_group.add_command(registry_scan_cmd, "registry-scan")
+
+
 @click.command("inventory")
 @click.option(
     "--provider",

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -694,7 +694,7 @@ def mcp_server_cmd(
     Requires:  pip install 'agent-bom[mcp-server]'
 
     \b
-    Exposes 69 security tools via MCP protocol:
+    Exposes 70 security tools via MCP protocol:
       scan                   Full scan — CVEs, config security, blast radius, compliance
       check                  Check a specific package for CVEs before installing
       blast_radius           Look up blast radius for a specific CVE

--- a/src/agent_bom/cloud/registry_sweep.py
+++ b/src/agent_bom/cloud/registry_sweep.py
@@ -1,0 +1,636 @@
+"""Registry-wide container-image sweep — agentless, read-only.
+
+Moves agent-bom from single-image scanning toward *registry coverage*: enumerate
+every repository and tag in a cloud container registry (AWS ECR, Azure ACR, or
+Google Artifact Registry / GCR), dedupe the work list by image digest, cap the
+number of images scanned, and run the existing native
+:func:`agent_bom.image.scan_image` on each.
+
+Trust posture — identical to the inventory discoverers:
+
+* **Read-only.** Only registry *read* APIs are called (``DescribeRepositories`` /
+  ``DescribeImages`` / ``ListImages`` for ECR, ACR repo+tag listing, GAR
+  ``ListRepositories`` / ``ListDockerImages``). No pushes, deletes, or tag
+  mutations. ``scan_image`` only ever pulls an image to read its package
+  manifests.
+* **Graceful degradation.** A registry the role cannot read, or a single image
+  that fails to pull, produces an actionable warning and the sweep continues —
+  never a silent empty result and never an aborted sweep.
+* **Determinism / idempotency.** Images are deduped by digest, the work list is
+  sorted deterministically (most-recently-pushed first, then by reference), and
+  the same registry state yields the same result set.
+* **Cap transparency.** When the discovered image count exceeds
+  ``AGENT_BOM_REGISTRY_MAX_IMAGES`` (default 50) the sweep scans the most-recent
+  images first and emits a warning naming exactly how many were skipped — no
+  silent truncation.
+
+Usage::
+
+    from agent_bom.cloud.registry_sweep import sweep_registry
+
+    report = sweep_registry(provider="ecr", region="us-east-1")
+    for image in report["images"]:
+        print(image["reference"], image["package_count"])
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+
+from agent_bom.cloud.normalization import sanitize_discovery_warning
+
+logger = logging.getLogger(__name__)
+
+# Cap on the number of images a single sweep will pull + scan. Operators raise
+# this for a full estate sweep; the default keeps an ad-hoc sweep bounded.
+MAX_IMAGES_ENV = "AGENT_BOM_REGISTRY_MAX_IMAGES"
+DEFAULT_MAX_IMAGES = 50
+
+# Per-repository tag fan-out cap so a single sprawling repo cannot starve the
+# rest of the registry before the global digest-dedupe + cap apply.
+MAX_TAGS_PER_REPO_ENV = "AGENT_BOM_REGISTRY_MAX_TAGS_PER_REPO"
+DEFAULT_MAX_TAGS_PER_REPO = 25
+
+_PROVIDERS = ("ecr", "acr", "gar")
+
+# A pushed-at sentinel for images whose registry exposes no timestamp. Sorting
+# newest-first means undated images rank *after* dated ones (older), which keeps
+# the cap biased toward images we can prove are recent.
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True)
+class RegistryImage:
+    """One enumerable image: a ``repo:tag`` reference and its content digest.
+
+    Two tags pointing at the same digest dedupe to a single scan (the first
+    reference, deterministically). ``pushed_at`` drives newest-first ordering so
+    the cap keeps the freshest images.
+    """
+
+    reference: str  # full pullable ref, e.g. "1.dkr.ecr.us-east-1.amazonaws.com/app:v1"
+    repository: str  # repository name, e.g. "app"
+    digest: str  # content digest, e.g. "sha256:..." (dedupe key; "" when unknown)
+    pushed_at: Optional[datetime] = None
+    registry: str = ""  # registry host / login server
+
+    def sort_key(self) -> tuple[float, str]:
+        """Newest-first, then reference — total order, no ties on equal timestamps."""
+        ts = (self.pushed_at or _EPOCH).timestamp()
+        return (-ts, self.reference)
+
+    def dedupe_key(self) -> str:
+        """Images with the same digest are the same content → scan once.
+
+        Falls back to the full reference when the registry exposes no digest, so
+        a digest-less registry still scans each distinct tag exactly once.
+        """
+        return self.digest or f"ref::{self.reference}"
+
+
+@dataclass
+class SweepResult:
+    """Aggregated outcome of a registry sweep — deterministic, JSON-serialisable."""
+
+    provider: str
+    status: str = "ok"
+    registry: str = ""
+    images: list[dict[str, Any]] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    discovered_count: int = 0  # distinct images found before the cap
+    scanned_count: int = 0
+    skipped_by_cap: int = 0
+    failed_count: int = 0
+    max_images: int = DEFAULT_MAX_IMAGES
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "status": self.status,
+            "registry": self.registry,
+            "discovered_count": self.discovered_count,
+            "scanned_count": self.scanned_count,
+            "skipped_by_cap": self.skipped_by_cap,
+            "failed_count": self.failed_count,
+            "max_images": self.max_images,
+            "total_packages": sum(int(img.get("package_count", 0)) for img in self.images),
+            "total_vulnerable_packages": sum(int(img.get("vulnerable_package_count", 0)) for img in self.images),
+            "images": self.images,
+            "warnings": self.warnings,
+        }
+
+
+def _max_images() -> int:
+    """Resolve the image cap from the environment, clamped to a sane minimum."""
+    raw = os.environ.get(MAX_IMAGES_ENV, "").strip()
+    if not raw:
+        return DEFAULT_MAX_IMAGES
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("%s=%r is not an integer; using default %d", MAX_IMAGES_ENV, raw, DEFAULT_MAX_IMAGES)
+        return DEFAULT_MAX_IMAGES
+    return max(1, value)
+
+
+def _max_tags_per_repo() -> int:
+    raw = os.environ.get(MAX_TAGS_PER_REPO_ENV, "").strip()
+    if not raw:
+        return DEFAULT_MAX_TAGS_PER_REPO
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_MAX_TAGS_PER_REPO
+    return max(1, value)
+
+
+# ───────────────────────── ECR enumeration (AWS) ──────────────────────────
+
+
+def enumerate_ecr_images(*, region: Optional[str] = None, profile: Optional[str] = None, warnings: list[str]) -> list[RegistryImage]:
+    """Enumerate every ECR repository + tagged image in the account (read-only).
+
+    Reuses the boto3 session pattern from :mod:`agent_bom.cloud.aws_inventory`.
+    Walks ``describe_repositories`` → ``describe_images`` and emits one
+    :class:`RegistryImage` per tag, keyed for dedupe by ``imageDigest``. Missing
+    credentials / boto3 / read permission degrade to ``[]`` plus a warning.
+    """
+    try:
+        import boto3
+    except ImportError:
+        warnings.append("boto3 is required for ECR sweep. Install with: pip install 'agent-bom[aws]'")
+        return []
+
+    try:
+        session_kwargs: dict[str, Any] = {}
+        if profile:
+            session_kwargs["profile_name"] = profile
+        session = boto3.Session(**session_kwargs)
+    except Exception as exc:  # noqa: BLE001 — boto profile/config errors must not crash a sweep
+        warnings.append(f"Could not create AWS session for ECR sweep: {sanitize_discovery_warning(exc)}")
+        return []
+
+    resolved_region = region or session.region_name or os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+    try:
+        client = session.client("ecr", region_name=resolved_region)
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not create ECR client: {sanitize_discovery_warning(exc)}")
+        return []
+
+    images: list[RegistryImage] = []
+    tag_cap = _max_tags_per_repo()
+    try:
+        repo_paginator = client.get_paginator("describe_repositories")
+        for repo_page in repo_paginator.paginate():
+            for repo in repo_page.get("repositories", []):
+                repo_name = str(repo.get("repositoryName", "") or "")
+                repo_uri = str(repo.get("repositoryUri", "") or "")
+                if not repo_name or not repo_uri:
+                    continue
+                registry_host = repo_uri.split("/", 1)[0]
+                images.extend(_enumerate_ecr_repo(client, repo_name, repo_uri, registry_host, tag_cap=tag_cap, warnings=warnings))
+    except Exception as exc:  # noqa: BLE001 — list failure must degrade, not abort
+        warnings.append(
+            "Skipped ECR repositories: role lacks ecr:DescribeRepositories — "
+            f"add it to the read-only policy to enumerate the registry. ({sanitize_discovery_warning(exc)})"
+        )
+    return images
+
+
+def _enumerate_ecr_repo(
+    client: Any, repo_name: str, repo_uri: str, registry_host: str, *, tag_cap: int, warnings: list[str]
+) -> list[RegistryImage]:
+    """Enumerate the tagged images of one ECR repository (read-only)."""
+    out: list[RegistryImage] = []
+    seen_digests: set[str] = set()
+    try:
+        img_paginator = client.get_paginator("describe_images")
+        for img_page in img_paginator.paginate(repositoryName=repo_name):
+            for detail in img_page.get("imageDetails", []):
+                digest = str(detail.get("imageDigest", "") or "")
+                pushed = detail.get("imagePushedAt")
+                pushed_at = pushed if isinstance(pushed, datetime) else None
+                tags = [str(t) for t in (detail.get("imageTags") or []) if t]
+                if not tags:
+                    # Untagged image — scannable by digest reference.
+                    if digest:
+                        out.append(
+                            RegistryImage(
+                                reference=f"{repo_uri}@{digest}",
+                                repository=repo_name,
+                                digest=digest,
+                                pushed_at=pushed_at,
+                                registry=registry_host,
+                            )
+                        )
+                    continue
+                for tag in sorted(tags):
+                    # Within a repo, scan each distinct digest once even if it
+                    # carries several tags (the rest dedupe globally anyway).
+                    if digest and digest in seen_digests:
+                        continue
+                    if digest:
+                        seen_digests.add(digest)
+                    out.append(
+                        RegistryImage(
+                            reference=f"{repo_uri}:{tag}",
+                            repository=repo_name,
+                            digest=digest,
+                            pushed_at=pushed_at,
+                            registry=registry_host,
+                        )
+                    )
+    except Exception as exc:  # noqa: BLE001 — one repo failing must not sink the registry
+        warnings.append(f"Could not list images in ECR repository {repo_name}: {sanitize_discovery_warning(exc)}")
+        return out
+    # Newest-first, then cap this repo's tag fan-out.
+    out.sort(key=lambda image: image.sort_key())
+    if len(out) > tag_cap:
+        out = out[:tag_cap]
+    return out
+
+
+# ───────────────────────── ACR enumeration (Azure) ─────────────────────────
+
+
+def enumerate_acr_images(*, registry: str, credential: Any = None, warnings: list[str]) -> list[RegistryImage]:
+    """Enumerate every repository + tag in an Azure Container Registry (read-only).
+
+    Uses ``azure-containerregistry``'s data-plane ``ContainerRegistryClient``
+    with a token credential (``DefaultAzureCredential`` by default — token/cred
+    only, never a password). ``registry`` is the ACR login server (e.g.
+    ``myacr.azurecr.io``). Missing SDK / credential / read permission degrade to
+    ``[]`` plus a warning.
+    """
+    if not registry:
+        warnings.append("ACR sweep requires a registry login server (e.g. myacr.azurecr.io).")
+        return []
+    endpoint = registry if "://" in registry else f"https://{registry}"
+    login_server = endpoint.split("://", 1)[1]
+
+    try:
+        from azure.containerregistry import ContainerRegistryClient
+    except ImportError:
+        warnings.append("azure-containerregistry is required for ACR sweep. Install with: pip install 'agent-bom[azure]'")
+        return []
+
+    if credential is None:
+        try:
+            from azure.identity import DefaultAzureCredential
+
+            credential = DefaultAzureCredential()
+        except Exception as exc:  # noqa: BLE001 — credential chain errors must not crash a sweep
+            warnings.append(f"Could not resolve Azure credential for ACR sweep: {sanitize_discovery_warning(exc)}")
+            return []
+
+    try:
+        client = ContainerRegistryClient(endpoint, credential)
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not create ACR client for {login_server}: {sanitize_discovery_warning(exc)}")
+        return []
+
+    images: list[RegistryImage] = []
+    tag_cap = _max_tags_per_repo()
+    try:
+        repositories = list(client.list_repository_names())
+    except Exception as exc:  # noqa: BLE001 — list failure must degrade, not abort
+        warnings.append(
+            f"Skipped ACR {login_server}: credential lacks AcrPull/repository read — "
+            f"grant the read-only role to enumerate the registry. ({sanitize_discovery_warning(exc)})"
+        )
+        return []
+
+    for repo_name in sorted(str(r) for r in repositories):
+        images.extend(_enumerate_acr_repo(client, login_server, repo_name, tag_cap=tag_cap, warnings=warnings))
+    return images
+
+
+def _enumerate_acr_repo(client: Any, login_server: str, repo_name: str, *, tag_cap: int, warnings: list[str]) -> list[RegistryImage]:
+    """Enumerate the tagged manifests of one ACR repository (read-only)."""
+    out: list[RegistryImage] = []
+    try:
+        for tag in client.list_tag_properties(repo_name):
+            tag_name = str(getattr(tag, "name", "") or "")
+            if not tag_name:
+                continue
+            digest = str(getattr(tag, "digest", "") or "")
+            pushed = getattr(tag, "last_updated_on", None) or getattr(tag, "created_on", None)
+            pushed_at = pushed if isinstance(pushed, datetime) else None
+            out.append(
+                RegistryImage(
+                    reference=f"{login_server}/{repo_name}:{tag_name}",
+                    repository=repo_name,
+                    digest=digest,
+                    pushed_at=pushed_at,
+                    registry=login_server,
+                )
+            )
+    except Exception as exc:  # noqa: BLE001 — one repo failing must not sink the registry
+        warnings.append(f"Could not list tags in ACR repository {repo_name}: {sanitize_discovery_warning(exc)}")
+        return out
+    out.sort(key=lambda image: image.sort_key())
+    if len(out) > tag_cap:
+        out = out[:tag_cap]
+    return out
+
+
+# ─────────────── GAR / Artifact Registry enumeration (GCP) ───────────────
+
+
+def enumerate_gar_images(
+    *,
+    project: Optional[str] = None,
+    location: Optional[str] = None,
+    credentials: Any = None,
+    warnings: list[str],
+) -> list[RegistryImage]:
+    """Enumerate Docker images across Artifact Registry repositories (read-only).
+
+    Uses ``google-cloud-artifact-registry``'s ``ArtifactRegistryClient`` to list
+    Docker images, which already carry the digest + URI + upload timestamp, so a
+    single ``list_docker_images`` per repository yields every scannable image.
+    Missing SDK / project / read permission degrade to ``[]`` plus a warning.
+    """
+    resolved_project = project or os.environ.get("GOOGLE_CLOUD_PROJECT") or os.environ.get("GCP_PROJECT") or ""
+    if not resolved_project:
+        warnings.append("GAR sweep requires a GCP project. Pass --project or set GOOGLE_CLOUD_PROJECT.")
+        return []
+
+    try:
+        from google.cloud import artifactregistry_v1
+    except ImportError:
+        warnings.append("google-cloud-artifact-registry is required for GAR sweep. Install with: pip install 'agent-bom[gcp]'")
+        return []
+
+    try:
+        client = artifactregistry_v1.ArtifactRegistryClient(credentials=credentials)
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"Could not create Artifact Registry client: {sanitize_discovery_warning(exc)}")
+        return []
+
+    # When no location is given, sweep the common multi-regions rather than guess
+    # a single one — each is an independent, degradeable discoverer.
+    locations = [location] if location else ["us", "europe", "asia"]
+
+    images: list[RegistryImage] = []
+    tag_cap = _max_tags_per_repo()
+    for loc in locations:
+        parent = f"projects/{resolved_project}/locations/{loc}"
+        try:
+            repos = list(client.list_repositories(parent=parent))
+        except Exception as exc:  # noqa: BLE001 — one location failing must not sink the sweep
+            warnings.append(
+                f"Skipped Artifact Registry in {loc}: lacks artifactregistry.repositories.list — "
+                f"grant the read-only role to enumerate the registry. ({sanitize_discovery_warning(exc)})"
+            )
+            continue
+        for repo in repos:
+            fmt = str(getattr(repo, "format_", "") or getattr(repo, "format", "") or "").upper()
+            if fmt and "DOCKER" not in fmt:
+                continue
+            repo_full = str(getattr(repo, "name", "") or "")
+            if not repo_full:
+                continue
+            images.extend(_enumerate_gar_repo(client, repo_full, loc, resolved_project, tag_cap=tag_cap, warnings=warnings))
+    return images
+
+
+def _enumerate_gar_repo(
+    client: Any, repo_full: str, location: str, project: str, *, tag_cap: int, warnings: list[str]
+) -> list[RegistryImage]:
+    """Enumerate Docker images of one Artifact Registry repository (read-only)."""
+    out: list[RegistryImage] = []
+    repo_short = repo_full.rsplit("/", 1)[-1]
+    host = f"{location}-docker.pkg.dev"
+    try:
+        for image in client.list_docker_images(parent=repo_full):
+            uri = str(getattr(image, "uri", "") or "")
+            if not uri:
+                continue
+            tags = [str(t) for t in (getattr(image, "tags", None) or []) if t]
+            digest = uri.split("@", 1)[1] if "@" in uri else ""
+            upload = getattr(image, "upload_time", None)
+            pushed_at = _gar_timestamp(upload)
+            base = f"{host}/{project}/{repo_short}"
+            if tags:
+                # One scannable ref per tag (deduped globally by digest).
+                for tag in sorted(tags):
+                    out.append(
+                        RegistryImage(
+                            reference=f"{base}/{_gar_image_name(uri, repo_short)}:{tag}",
+                            repository=repo_short,
+                            digest=digest,
+                            pushed_at=pushed_at,
+                            registry=host,
+                        )
+                    )
+            elif digest:
+                out.append(
+                    RegistryImage(
+                        reference=uri,
+                        repository=repo_short,
+                        digest=digest,
+                        pushed_at=pushed_at,
+                        registry=host,
+                    )
+                )
+    except Exception as exc:  # noqa: BLE001 — one repo failing must not sink the registry
+        warnings.append(f"Could not list images in Artifact Registry repository {repo_short}: {sanitize_discovery_warning(exc)}")
+        return out
+    out.sort(key=lambda image: image.sort_key())
+    if len(out) > tag_cap:
+        out = out[:tag_cap]
+    return out
+
+
+def _gar_image_name(uri: str, repo_short: str) -> str:
+    """Best-effort image-name segment from a GAR image URI.
+
+    A GAR URI looks like ``LOC-docker.pkg.dev/PROJECT/REPO/IMAGE@sha256:...``;
+    the image name is the path segment(s) after the repo. Falls back to the repo
+    name when the structure is unexpected.
+    """
+    path = uri.split("@", 1)[0]
+    marker = f"/{repo_short}/"
+    idx = path.find(marker)
+    if idx >= 0:
+        tail = path[idx + len(marker) :]
+        if tail:
+            return tail
+    return repo_short
+
+
+def _gar_timestamp(value: Any) -> Optional[datetime]:
+    """Coerce a GAR upload-time protobuf Timestamp / datetime into a datetime."""
+    if isinstance(value, datetime):
+        return value
+    to_dt = getattr(value, "ToDatetime", None)
+    if callable(to_dt):
+        try:
+            dt = to_dt()
+            return dt if isinstance(dt, datetime) else None
+        except Exception:  # noqa: BLE001
+            return None
+    return None
+
+
+# ───────────────────────────── orchestration ──────────────────────────────
+
+
+def dedupe_and_cap(images: list[RegistryImage], *, max_images: int, warnings: list[str]) -> tuple[list[RegistryImage], int, int]:
+    """Dedupe by digest, sort newest-first, and cap — deterministically.
+
+    Returns ``(work_list, discovered_count, skipped_by_cap)``. When the cap drops
+    images, a warning naming the count is appended (no silent truncation). The
+    work list is fully ordered, so the same registry state always yields the same
+    scan set.
+    """
+    deduped: dict[str, RegistryImage] = {}
+    for image in sorted(images, key=lambda im: im.sort_key()):
+        # First wins under the deterministic sort: newest pushed_at, then the
+        # lexically-smallest reference for that digest.
+        deduped.setdefault(image.dedupe_key(), image)
+
+    ordered = sorted(deduped.values(), key=lambda im: im.sort_key())
+    discovered = len(ordered)
+
+    if discovered <= max_images:
+        return ordered, discovered, 0
+
+    skipped = discovered - max_images
+    kept = ordered[:max_images]
+    warnings.append(
+        f"Image cap reached: scanned the {max_images} most-recent images and skipped {skipped} older image(s). "
+        f"Raise {MAX_IMAGES_ENV} to cover the full registry."
+    )
+    return kept, discovered, skipped
+
+
+def _summarize_packages(packages: list[Any]) -> tuple[int, int, str]:
+    """Return ``(package_count, vulnerable_package_count, max_severity)``.
+
+    ``scan_image`` returns raw packages; vulnerability data is only present when
+    a package already carries matches. The sweep reports what it has and lets the
+    downstream pipeline do CVE matching — it never fabricates severity.
+    """
+    pkg_count = len(packages)
+    vuln_pkgs = 0
+    max_sev = "none"
+    severity_rank = {"critical": 5, "high": 4, "medium": 3, "low": 2, "unknown": 1, "none": 0}
+    best = 0
+    for pkg in packages:
+        vulns = getattr(pkg, "vulnerabilities", None) or []
+        if vulns:
+            vuln_pkgs += 1
+        sev_obj = getattr(pkg, "max_severity", None)
+        sev = sev_obj() if callable(sev_obj) else None
+        sev_value = getattr(sev, "value", None) if sev is not None else None
+        rank = severity_rank.get(str(sev_value).lower(), 0) if sev_value else 0
+        if rank > best:
+            best = rank
+            max_sev = str(sev_value).lower()
+    return pkg_count, vuln_pkgs, max_sev
+
+
+def sweep_registry(
+    *,
+    provider: str,
+    region: Optional[str] = None,
+    profile: Optional[str] = None,
+    registry: Optional[str] = None,
+    project: Optional[str] = None,
+    location: Optional[str] = None,
+    credential: Any = None,
+    max_images: Optional[int] = None,
+    scan_image_fn: Optional[Callable[[str], tuple[list[Any], str]]] = None,
+) -> dict[str, Any]:
+    """Enumerate + dedupe + cap + scan every image in a cloud container registry.
+
+    Args:
+        provider: ``"ecr"`` (AWS), ``"acr"`` (Azure), or ``"gar"`` (GCP).
+        region/profile: AWS selectors (ECR).
+        registry: ACR login server, e.g. ``myacr.azurecr.io`` (ACR).
+        project/location: GCP selectors (GAR).
+        credential: pre-built Azure credential (ACR) or GCP credentials (GAR);
+            resolved from the ambient chain when omitted.
+        max_images: override the ``AGENT_BOM_REGISTRY_MAX_IMAGES`` cap.
+        scan_image_fn: injection seam for tests; defaults to
+            :func:`agent_bom.image.scan_image`.
+
+    Returns:
+        A deterministic, JSON-serialisable report dict (see :class:`SweepResult`).
+        Never raises for registry/access/scan failures — they degrade to
+        warnings with actionable guidance.
+    """
+    prov = (provider or "").strip().lower()
+    cap = max_images if max_images is not None else _max_images()
+    result = SweepResult(provider=prov, max_images=cap)
+
+    if prov not in _PROVIDERS:
+        result.status = "invalid_provider"
+        result.warnings.append(f"Unknown registry provider {provider!r}. Use one of: {', '.join(_PROVIDERS)}.")
+        return result.to_dict()
+
+    warnings: list[str] = []
+    if prov == "ecr":
+        discovered = enumerate_ecr_images(region=region, profile=profile, warnings=warnings)
+        result.registry = discovered[0].registry if discovered else (region or "")
+    elif prov == "acr":
+        discovered = enumerate_acr_images(registry=registry or "", credential=credential, warnings=warnings)
+        result.registry = registry or ""
+    else:  # gar
+        discovered = enumerate_gar_images(project=project, location=location, credentials=credential, warnings=warnings)
+        result.registry = discovered[0].registry if discovered else (project or "")
+
+    result.warnings.extend(warnings)
+
+    work_list, discovered_count, skipped = dedupe_and_cap(discovered, max_images=cap, warnings=result.warnings)
+    result.discovered_count = discovered_count
+    result.skipped_by_cap = skipped
+
+    if not work_list:
+        if not discovered:
+            result.status = "no_images"
+        return result.to_dict()
+
+    scan_fn = scan_image_fn or _default_scan_image
+    for image in work_list:
+        try:
+            packages, strategy = scan_fn(image.reference)
+        except Exception as exc:  # noqa: BLE001 — one image failing must not abort the sweep
+            result.failed_count += 1
+            result.warnings.append(f"Image scan failed for {image.reference}: {sanitize_discovery_warning(exc)}")
+            continue
+        pkg_count, vuln_pkgs, max_sev = _summarize_packages(packages)
+        result.scanned_count += 1
+        result.images.append(
+            {
+                "reference": image.reference,
+                "repository": image.repository,
+                "digest": image.digest,
+                "registry": image.registry,
+                "pushed_at": image.pushed_at.isoformat() if image.pushed_at else None,
+                "strategy": strategy,
+                "package_count": pkg_count,
+                "vulnerable_package_count": vuln_pkgs,
+                "max_severity": max_sev,
+            }
+        )
+
+    # Deterministic output ordering: by reference (the work list was newest-first
+    # for the cap, but the emitted report sorts stably for reproducible diffs).
+    result.images.sort(key=lambda img: str(img["reference"]))
+    if result.failed_count and not result.scanned_count:
+        result.status = "all_failed"
+    return result.to_dict()
+
+
+def _default_scan_image(reference: str) -> tuple[list[Any], str]:
+    """Lazy import of the real scanner so test injection stays cheap."""
+    from agent_bom.image import scan_image
+
+    return scan_image(reference)

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -5,7 +5,7 @@ Start with:
     agent-bom mcp server --transport sse          # SSE transport (for remote clients)
     agent-bom mcp server --transport streamable-http
 
-Tools (69):
+Tools (70):
     scan                — Full discovery → scan → output pipeline
     check               — Check a specific package for CVEs before installing
     blast_radius        — Look up blast radius for a specific CVE

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -256,6 +256,11 @@ _SERVER_CARD_TOOLS = [
         "annotations": {"readOnlyHint": True},
     },
     {
+        "name": "registry_sweep_scan",
+        "description": "Sweep a cloud registry (ECR/ACR/GAR): enumerate repos+tags, dedupe by digest, cap, scan each (read-only)",
+        "annotations": {"readOnlyHint": True},
+    },
+    {
         "name": "dataset_card_scan",
         "description": "Scan dataset cards (HuggingFace, DVC) for licensing, provenance, and compliance tags (LLM03, ART-10)",
         "annotations": {"readOnlyHint": True},
@@ -394,6 +399,7 @@ _TOOL_CAPABILITY_CLASSES = {
     "vector_db_scan": ["READ", "NETWORK", "RUNTIME"],
     "aisvs_benchmark": ["READ", "COMPLIANCE"],
     "gpu_infra_scan": ["READ", "NETWORK", "INFRA"],
+    "registry_sweep_scan": ["READ", "NETWORK", "INFRA"],
     "dataset_card_scan": ["READ", "LOCAL_FILE_READ", "COMPLIANCE"],
     "training_pipeline_scan": ["READ", "LOCAL_FILE_READ", "LINEAGE"],
     "browser_extension_scan": ["READ", "LOCAL_FILE_READ"],

--- a/src/agent_bom/mcp_server_specialized.py
+++ b/src/agent_bom/mcp_server_specialized.py
@@ -19,7 +19,7 @@ def register_specialized_ai_tools(
     truncate_response: Callable[[str], str],
 ) -> None:
     """Register specialized AI, model, and external-ingest MCP tools."""
-    from agent_bom.mcp_tools.cloud import gpu_infra_scan_impl, vector_db_scan_impl
+    from agent_bom.mcp_tools.cloud import gpu_infra_scan_impl, registry_sweep_scan_impl, vector_db_scan_impl
     from agent_bom.mcp_tools.compliance import aisvs_benchmark_impl, license_compliance_scan_impl
     from agent_bom.mcp_tools.specialized import (
         ai_inventory_scan_impl,
@@ -78,6 +78,36 @@ def register_specialized_ai_tools(
             gpu_infra_scan_impl,
             k8s_context=k8s_context,
             probe_dcgm=probe_dcgm,
+            _truncate_response=truncate_response,
+        )
+
+    @mcp.tool(annotations=read_only, title="Registry Image Sweep")
+    async def registry_sweep_scan(
+        provider: Annotated[
+            str,
+            Field(description="Container registry to sweep: 'ecr' (AWS), 'acr' (Azure), or 'gar' (GCP Artifact Registry)."),
+        ],
+        region: Annotated[str | None, Field(description="AWS region (ecr only).")] = None,
+        profile: Annotated[str | None, Field(description="AWS credential profile (ecr only).")] = None,
+        registry: Annotated[str | None, Field(description="ACR login server, e.g. 'myacr.azurecr.io' (acr only).")] = None,
+        project: Annotated[str | None, Field(description="GCP project id (gar only).")] = None,
+        location: Annotated[str | None, Field(description="GAR location/multi-region, e.g. 'us' (gar only).")] = None,
+        max_images: Annotated[
+            int | None,
+            Field(description="Cap on images scanned (default: AGENT_BOM_REGISTRY_MAX_IMAGES or 50)."),
+        ] = None,
+    ) -> str:
+        """Sweep an entire cloud container registry: enumerate every repo+tag, dedupe by digest, cap, and scan each (read-only)."""
+        return await execute_tool_async(
+            "registry_sweep_scan",
+            registry_sweep_scan_impl,
+            provider=provider,
+            region=region,
+            profile=profile,
+            registry=registry,
+            project=project,
+            location=location,
+            max_images=max_images,
             _truncate_response=truncate_response,
         )
 

--- a/src/agent_bom/mcp_tools/cloud.py
+++ b/src/agent_bom/mcp_tools/cloud.py
@@ -40,6 +40,36 @@ async def vector_db_scan_impl(
         return json.dumps({"error": sanitize_error(exc)})
 
 
+async def registry_sweep_scan_impl(
+    *,
+    provider: str,
+    region: str | None = None,
+    profile: str | None = None,
+    registry: str | None = None,
+    project: str | None = None,
+    location: str | None = None,
+    max_images: int | None = None,
+    _truncate_response,
+) -> str:
+    """Implementation of the registry_sweep_scan tool — read-only registry-wide image sweep."""
+    try:
+        from agent_bom.cloud.registry_sweep import sweep_registry
+
+        report = sweep_registry(
+            provider=provider,
+            region=region,
+            profile=profile,
+            registry=registry,
+            project=project,
+            location=location,
+            max_images=max_images,
+        )
+        return _truncate_response(json.dumps(report, indent=2, default=str))
+    except Exception as exc:
+        logger.exception("MCP tool error")
+        return json.dumps({"error": sanitize_error(exc)})
+
+
 async def gpu_infra_scan_impl(
     *,
     k8s_context: str | None = None,

--- a/tests/test_mcp_tool_output_contract.py
+++ b/tests/test_mcp_tool_output_contract.py
@@ -97,6 +97,7 @@ def _minimal_args(name: str, workdir: Path) -> dict[str, Any]:
         "model_provenance_scan": {"model_id": "bert-base-uncased"},
         "policy_check": {"policy_json": "{}"},
         "prompt_scan": {"directory": p},
+        "registry_sweep_scan": {"provider": "ecr"},
         "runtime_blueprint_drift": {"blueprint_id": "bp-x"},
         "should_i_deploy": {"candidate": "requests==2.31.0"},
         "skill_trust": {"skill_path": file_target},

--- a/tests/test_registry_sweep.py
+++ b/tests/test_registry_sweep.py
@@ -1,0 +1,265 @@
+"""Tests for registry-wide image sweep (ECR / ACR / GAR).
+
+Registry clients and ``scan_image`` are mocked at the boundary so the tests
+exercise enumeration → digest-dedupe → cap → aggregation deterministically,
+without network or Docker.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from agent_bom.cloud import registry_sweep
+from agent_bom.cloud.registry_sweep import (
+    DEFAULT_MAX_IMAGES,
+    MAX_IMAGES_ENV,
+    RegistryImage,
+    dedupe_and_cap,
+    sweep_registry,
+)
+
+
+def _img(ref: str, digest: str = "", pushed: datetime | None = None, repo: str = "repo") -> RegistryImage:
+    return RegistryImage(reference=ref, repository=repo, digest=digest, pushed_at=pushed, registry="reg")
+
+
+def _fake_scan(packages: int):
+    """Return a scan_image-shaped callable yielding *packages* bare package stubs."""
+
+    class _Pkg:
+        vulnerabilities: list = []
+
+        def max_severity(self):
+            class _Sev:
+                value = "none"
+
+            return _Sev()
+
+    def _fn(ref: str):
+        return [_Pkg() for _ in range(packages)], "native"
+
+    return _fn
+
+
+# ───────────────────────────── dedupe + cap ──────────────────────────────
+
+
+def test_dedupe_by_digest_scans_each_digest_once():
+    warnings: list[str] = []
+    images = [
+        _img("reg/a:v1", digest="sha256:aaa", pushed=datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        _img("reg/a:latest", digest="sha256:aaa", pushed=datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        _img("reg/b:v1", digest="sha256:bbb", pushed=datetime(2026, 1, 2, tzinfo=timezone.utc)),
+    ]
+    work, discovered, skipped = dedupe_and_cap(images, max_images=50, warnings=warnings)
+    assert discovered == 2  # two distinct digests
+    assert skipped == 0
+    assert {im.digest for im in work} == {"sha256:aaa", "sha256:bbb"}
+
+
+def test_dedupe_is_deterministic_first_reference_wins():
+    warnings: list[str] = []
+    pushed = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    images = [
+        _img("reg/z:tag", digest="sha256:same", pushed=pushed),
+        _img("reg/a:tag", digest="sha256:same", pushed=pushed),
+    ]
+    work, _, _ = dedupe_and_cap(images, max_images=50, warnings=warnings)
+    assert len(work) == 1
+    # Same pushed_at → lexically-smallest reference wins, deterministically.
+    assert work[0].reference == "reg/a:tag"
+
+
+def test_digestless_images_dedupe_by_reference():
+    warnings: list[str] = []
+    images = [_img("reg/a:v1"), _img("reg/a:v1"), _img("reg/a:v2")]
+    work, discovered, _ = dedupe_and_cap(images, max_images=50, warnings=warnings)
+    assert discovered == 2
+
+
+def test_cap_keeps_newest_and_warns_with_count():
+    warnings: list[str] = []
+    images = [_img(f"reg/a:v{i}", digest=f"sha256:{i}", pushed=datetime(2026, 1, i + 1, tzinfo=timezone.utc)) for i in range(5)]
+    work, discovered, skipped = dedupe_and_cap(images, max_images=2, warnings=warnings)
+    assert discovered == 5
+    assert skipped == 3
+    assert len(work) == 2
+    # Newest first: v4 (Jan 5) and v3 (Jan 4) kept.
+    kept_refs = {im.reference for im in work}
+    assert kept_refs == {"reg/a:v4", "reg/a:v3"}
+    assert any("skipped 3" in w for w in warnings)
+    assert any(MAX_IMAGES_ENV in w for w in warnings)
+
+
+def test_cap_at_boundary_does_not_warn():
+    warnings: list[str] = []
+    images = [_img(f"reg/a:v{i}", digest=f"sha256:{i}") for i in range(3)]
+    work, discovered, skipped = dedupe_and_cap(images, max_images=3, warnings=warnings)
+    assert skipped == 0
+    assert len(work) == 3
+    assert warnings == []
+
+
+# ───────────────────────── orchestration (sweep) ──────────────────────────
+
+
+def test_sweep_invalid_provider_degrades():
+    report = sweep_registry(provider="dockerhub")
+    assert report["status"] == "invalid_provider"
+    assert report["scanned_count"] == 0
+    assert any("dockerhub" in w for w in report["warnings"])
+
+
+def test_sweep_scans_each_discovered_image(monkeypatch):
+    images = [
+        _img("reg/a:v1", digest="sha256:a", pushed=datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        _img("reg/b:v1", digest="sha256:b", pushed=datetime(2026, 1, 2, tzinfo=timezone.utc)),
+    ]
+    monkeypatch.setattr(registry_sweep, "enumerate_ecr_images", lambda **kw: images)
+    report = sweep_registry(provider="ecr", scan_image_fn=_fake_scan(3))
+    assert report["status"] == "ok"
+    assert report["discovered_count"] == 2
+    assert report["scanned_count"] == 2
+    assert report["total_packages"] == 6
+    assert [i["reference"] for i in report["images"]] == ["reg/a:v1", "reg/b:v1"]
+
+
+def test_sweep_one_failing_image_does_not_abort(monkeypatch):
+    images = [
+        _img("reg/good:v1", digest="sha256:g"),
+        _img("reg/bad:v1", digest="sha256:b"),
+    ]
+    monkeypatch.setattr(registry_sweep, "enumerate_ecr_images", lambda **kw: images)
+
+    def _scan(ref: str):
+        if "bad" in ref:
+            raise RuntimeError("manifest unknown")
+        return _fake_scan(2)(ref)
+
+    report = sweep_registry(provider="ecr", scan_image_fn=_scan)
+    assert report["scanned_count"] == 1
+    assert report["failed_count"] == 1
+    assert any("reg/bad:v1" in w for w in report["warnings"])
+    # The good image still made it into the report.
+    assert [i["reference"] for i in report["images"]] == ["reg/good:v1"]
+
+
+def test_sweep_respects_cap_and_warns(monkeypatch):
+    images = [_img(f"reg/a:v{i}", digest=f"sha256:{i}", pushed=datetime(2026, 1, i + 1, tzinfo=timezone.utc)) for i in range(5)]
+    monkeypatch.setattr(registry_sweep, "enumerate_ecr_images", lambda **kw: images)
+    report = sweep_registry(provider="ecr", max_images=2, scan_image_fn=_fake_scan(1))
+    assert report["discovered_count"] == 5
+    assert report["scanned_count"] == 2
+    assert report["skipped_by_cap"] == 3
+    assert any("skipped 3" in w for w in report["warnings"])
+
+
+def test_sweep_no_access_degrades_with_guidance(monkeypatch):
+    def _denied(**kw):
+        kw["warnings"].append("Skipped ECR repositories: role lacks ecr:DescribeRepositories — add it to the read-only policy.")
+        return []
+
+    monkeypatch.setattr(registry_sweep, "enumerate_ecr_images", _denied)
+    report = sweep_registry(provider="ecr", scan_image_fn=_fake_scan(1))
+    assert report["status"] == "no_images"
+    assert report["scanned_count"] == 0
+    assert any("ecr:DescribeRepositories" in w for w in report["warnings"])
+
+
+def test_sweep_all_images_fail_status(monkeypatch):
+    images = [_img("reg/a:v1", digest="sha256:a"), _img("reg/b:v1", digest="sha256:b")]
+    monkeypatch.setattr(registry_sweep, "enumerate_ecr_images", lambda **kw: images)
+
+    def _scan(ref: str):
+        raise RuntimeError("pull failed")
+
+    report = sweep_registry(provider="ecr", scan_image_fn=_scan)
+    assert report["status"] == "all_failed"
+    assert report["failed_count"] == 2
+    assert report["scanned_count"] == 0
+
+
+def test_sweep_default_cap_from_env(monkeypatch):
+    monkeypatch.delenv(MAX_IMAGES_ENV, raising=False)
+    images = [_img("reg/a:v1", digest="sha256:a")]
+    monkeypatch.setattr(registry_sweep, "enumerate_ecr_images", lambda **kw: images)
+    report = sweep_registry(provider="ecr", scan_image_fn=_fake_scan(1))
+    assert report["max_images"] == DEFAULT_MAX_IMAGES
+
+
+# ─────────────────── per-registry enumeration (mocked SDK) ───────────────────
+
+
+class _FakePaginator:
+    def __init__(self, pages):
+        self._pages = pages
+
+    def paginate(self, **kwargs):
+        return list(self._pages)
+
+
+class _FakeEcrClient:
+    def __init__(self):
+        self._repos = [{"repositories": [{"repositoryName": "app", "repositoryUri": "1.dkr.ecr.us-east-1.amazonaws.com/app"}]}]
+        self._images = [
+            {
+                "imageDetails": [
+                    {
+                        "imageDigest": "sha256:d1",
+                        "imageTags": ["v1", "latest"],
+                        "imagePushedAt": datetime(2026, 1, 2, tzinfo=timezone.utc),
+                    },
+                    {
+                        "imageDigest": "sha256:d2",
+                        "imageTags": ["v2"],
+                        "imagePushedAt": datetime(2026, 1, 3, tzinfo=timezone.utc),
+                    },
+                ]
+            }
+        ]
+
+    def get_paginator(self, op):
+        return _FakePaginator(self._repos if op == "describe_repositories" else self._images)
+
+
+def test_enumerate_ecr_emits_one_image_per_distinct_digest(monkeypatch):
+    fake_session = type("S", (), {"region_name": "us-east-1", "client": lambda self, *a, **k: _FakeEcrClient()})()
+    fake_boto3 = type("B", (), {"Session": staticmethod(lambda **kw: fake_session)})()
+    monkeypatch.setitem(__import__("sys").modules, "boto3", fake_boto3)
+
+    warnings: list[str] = []
+    images = registry_sweep.enumerate_ecr_images(region="us-east-1", warnings=warnings)
+    # Two distinct digests in one repo (v1/latest share d1 → one image).
+    digests = {im.digest for im in images}
+    assert digests == {"sha256:d1", "sha256:d2"}
+    assert all(im.registry == "1.dkr.ecr.us-east-1.amazonaws.com" for im in images)
+
+
+def test_enumerate_ecr_boto3_missing_degrades(monkeypatch):
+    monkeypatch.setitem(__import__("sys").modules, "boto3", None)
+    # Force ImportError on `import boto3`.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_boto3(name, *a, **k):
+        if name == "boto3":
+            raise ImportError("no boto3")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _no_boto3)
+    warnings: list[str] = []
+    images = registry_sweep.enumerate_ecr_images(warnings=warnings)
+    assert images == []
+    assert any("boto3" in w for w in warnings)
+
+
+@pytest.mark.parametrize("provider", ["ecr", "acr", "gar"])
+def test_sweep_providers_never_raise_without_sdk(provider):
+    # No SDK / creds available in the test env → must degrade, not raise.
+    report = sweep_registry(provider=provider, registry="x.azurecr.io", project="p")
+    assert report["provider"] == provider
+    assert isinstance(report["warnings"], list)
+    assert report["scanned_count"] == 0

--- a/uv.lock
+++ b/uv.lock
@@ -56,6 +56,7 @@ ai-enrich = [
 ]
 all = [
     { name = "azure-ai-projects" },
+    { name = "azure-containerregistry" },
     { name = "azure-identity" },
     { name = "azure-keyvault-keys" },
     { name = "azure-keyvault-secrets" },
@@ -142,6 +143,7 @@ aws = [
 ]
 azure = [
     { name = "azure-ai-projects" },
+    { name = "azure-containerregistry" },
     { name = "azure-identity" },
     { name = "azure-keyvault-keys" },
     { name = "azure-keyvault-secrets" },
@@ -174,6 +176,7 @@ azure = [
 ]
 cloud = [
     { name = "azure-ai-projects" },
+    { name = "azure-containerregistry" },
     { name = "azure-identity" },
     { name = "azure-keyvault-keys" },
     { name = "azure-keyvault-secrets" },
@@ -382,6 +385,7 @@ requires-dist = [
     { name = "agent-bom", extras = ["wandb"], marker = "extra == 'cloud'" },
     { name = "agent-bom", extras = ["watch"], marker = "extra == 'all'" },
     { name = "azure-ai-projects", marker = "extra == 'azure'", specifier = ">=1.0" },
+    { name = "azure-containerregistry", marker = "extra == 'azure'", specifier = ">=1.2" },
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.15" },
     { name = "azure-keyvault-keys", marker = "extra == 'azure'", specifier = ">=4.8" },
     { name = "azure-keyvault-secrets", marker = "extra == 'azure'", specifier = ">=4.7" },
@@ -768,6 +772,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3e/71/f6f71a276e2e69264a97ad39ef850dca0a04fce67b12570730cb38d0ccac/azure-common-1.1.28.zip", hash = "sha256:4ac0cd3214e36b6a1b6a442686722a5d8cc449603aa833f3f0f40bda836704a3", size = 20914, upload-time = "2022-02-03T19:39:44.373Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/55/7f118b9c1b23ec15ca05d15a578d8207aa1706bc6f7c87218efffbbf875d/azure_common-1.1.28-py2.py3-none-any.whl", hash = "sha256:5c12d3dcf4ec20599ca6b0d3e09e86e146353d443e7fcc050c9a19c1f9df20ad", size = 14462, upload-time = "2022-02-03T19:39:42.417Z" },
+]
+
+[[package]]
+name = "azure-containerregistry"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "isodate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/0b/0bf7fd78e8dd45d53d57d6fdca5ab0d23bd9094ea70fe2d4701c6f6cda0a/azure-containerregistry-1.2.0.zip", hash = "sha256:4acd32821d086553eabd5ddfecbb21fb915b5d13ef8375d15afcb2c80bdc96a3", size = 159643, upload-time = "2023-07-11T17:47:19.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/74/c4821d3643dd32d6f35c02358b17a0f8635f43050190d89956ee8e92e395/azure_containerregistry-1.2.0-py3-none-any.whl", hash = "sha256:7ba5b84911f1b381cec290b22747a679b98ddbf536fae7923124743f5ed97e6c", size = 101180, upload-time = "2023-07-11T17:47:21.584Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Moves agent-bom from single-image scanning toward agentless **registry-wide
coverage**: enumerate every repository and tag in a cloud container registry,
dedupe images by content digest, cap the work list, and scan each image with the
existing native image scanner. Read-only throughout.

## What it adds

- **New module `cloud/registry_sweep.py`** — per-registry enumerators plus a
  degrade-not-abort orchestrator:
  - **ECR (AWS):** `describe_repositories` -> `describe_images`, one image per
    distinct digest, keyed for dedupe by `imageDigest`.
  - **ACR (Azure):** data-plane repository + tag listing via a token credential
    (`DefaultAzureCredential` by default — token/credential only, never a
    password).
  - **GAR (GCP):** Artifact Registry `list_repositories` -> `list_docker_images`
    across the common multi-regions (or a single `--location`).
- **Dedupe + cap.** Images are deduped by digest and sorted newest-first; the
  sweep caps at `AGENT_BOM_REGISTRY_MAX_IMAGES` (default 50) and emits a warning
  naming exactly how many older images were skipped — no silent truncation. A
  per-repo tag fan-out cap (`AGENT_BOM_REGISTRY_MAX_TAGS_PER_REPO`, default 25)
  keeps one sprawling repo from starving the rest before the global cap applies.
- **Graceful degradation.** Missing SDK / credentials / registry-read permission
  and a single image that fails to pull each become an actionable warning and the
  sweep continues — never a silent empty result, never an aborted sweep.
- **Determinism.** Same registry state -> same scan set and the same ordered
  report.
- **Surfaces.** A `cloud registry-scan` CLI subcommand (console + JSON) and a
  `registry_sweep_scan` MCP tool, both returning the same deterministic report
  shape.

## Trust posture

Read-only end to end: only registry **read** APIs are called and `scan_image`
only pulls an image to read its package manifests. No pushes, deletes, or tag
mutations.

## Tests

`tests/test_registry_sweep.py` (registry clients + `scan_image` mocked at the
boundary):

- `test_dedupe_by_digest_scans_each_digest_once`,
  `test_dedupe_is_deterministic_first_reference_wins`,
  `test_digestless_images_dedupe_by_reference`
- `test_cap_keeps_newest_and_warns_with_count`,
  `test_cap_at_boundary_does_not_warn`, `test_sweep_respects_cap_and_warns`
- `test_sweep_one_failing_image_does_not_abort`,
  `test_sweep_no_access_degrades_with_guidance`,
  `test_sweep_all_images_fail_status`
- `test_enumerate_ecr_emits_one_image_per_distinct_digest`,
  `test_enumerate_ecr_boto3_missing_degrades`,
  `test_sweep_providers_never_raise_without_sdk`

`ruff check`, `ruff format --check`, and `mypy` are clean on the touched files;
the MCP tool count + output-contract suites stay green.
