### PR TITLE
CloudFormation one-click read-only AWS scan via CodeBuild

### DIFF
--- a/deploy/cloudformation/README.md
+++ b/deploy/cloudformation/README.md
@@ -1,0 +1,139 @@
+# agent-bom one-click AWS scan (CloudFormation)
+
+Deploy a **read-only**, **serverless** agent-bom scan of your AWS account in one
+command. The stack provisions an AWS CodeBuild project (no EC2 instance — it runs
+even on free-tier-restricted accounts), runs agent-bom's AWS inventory and CIS
+benchmark, and publishes HTML / JSON / plaintext reports to a private S3 bucket.
+
+- **Read-only.** The scan role is granted only the AWS-managed `SecurityAudit`
+  policy (optionally `ViewOnlyAccess`) plus write access to the single report
+  bucket. It cannot change anything in your account.
+- **No EC2.** Execution is serverless via CodeBuild. Nothing to patch, no
+  instances, no inbound network exposure.
+- **No long-lived secrets.** CodeBuild assumes the scoped role at runtime.
+- **Cheap.** Small CodeBuild compute, runs in minutes, reports expire after 30
+  days by default.
+
+## Deploy
+
+```bash
+aws cloudformation deploy \
+  --template-file deploy/cloudformation/agent-bom-scan.yaml \
+  --stack-name agent-bom-scan \
+  --capabilities CAPABILITY_IAM \
+  --parameter-overrides Region=us-east-1
+```
+
+`CAPABILITY_IAM` is required because the stack creates the scoped read-only scan
+role.
+
+## Run a scan
+
+The CodeBuild project does not run on creation. Start an on-demand scan:
+
+```bash
+aws codebuild start-build --project-name "$(aws cloudformation describe-stacks \
+  --stack-name agent-bom-scan \
+  --query 'Stacks[0].Outputs[?OutputKey==`CodeBuildProject`].OutputValue' \
+  --output text)"
+```
+
+Or enable recurring scans at deploy time (see **Scheduled scans** below).
+
+## Get the reports
+
+```bash
+# Resolve the bucket name from stack outputs
+BUCKET=$(aws cloudformation describe-stacks --stack-name agent-bom-scan \
+  --query 'Stacks[0].Outputs[?OutputKey==`ReportBucketName`].OutputValue' \
+  --output text)
+
+# List published reports
+aws s3 ls "s3://$BUCKET/aws-scan/" --recursive
+
+# Download them all
+aws s3 cp "s3://$BUCKET/aws-scan/" ./agent-bom-reports/ --recursive
+```
+
+Each run writes a timestamped prefix `aws-scan/<UTC-timestamp>/` containing:
+
+| File          | Format                                          |
+| ------------- | ----------------------------------------------- |
+| `report.html` | Rich HTML report                                |
+| `report.json` | Machine-readable JSON                            |
+| `report.txt`  | Plaintext CLI report (no color)                 |
+| `console.log` | Captured colorized console table                |
+
+The stack also emits a `ConsoleUrl` output linking straight to the bucket in the
+S3 console.
+
+## Parameters
+
+| Parameter             | Default                                              | Purpose                                                                 |
+| --------------------- | ---------------------------------------------------- | ----------------------------------------------------------------------- |
+| `Region`              | `us-east-1`                                           | AWS region passed to `agent-bom cloud aws --region`.                    |
+| `FailOnSeverity`      | `none`                                                | `none\|low\|medium\|high\|critical` — fail the build at/above severity. |
+| `AddViewOnlyAccess`   | `false`                                               | Also attach AWS-managed `ViewOnlyAccess` (still read-only).             |
+| `AgentBomSpec`        | `agent-bom[aws]`                                      | pip spec; pin a version e.g. `agent-bom[aws]==0.89.2`.                  |
+| `ComputeType`         | `BUILD_GENERAL1_SMALL`                                | CodeBuild compute size.                                                 |
+| `PythonImage`         | `aws/codebuild/amazonlinux2-x86_64-standard:5.0`      | Managed CodeBuild image providing Python 3.                            |
+| `ReportRetentionDays` | `30`                                                  | Days before report objects expire.                                     |
+| `Schedule`            | `false`                                               | Enable an EventBridge rule for recurring scans.                        |
+| `ScheduleExpression`  | `rate(7 days)`                                        | Schedule used when `Schedule=true`.                                    |
+
+### Fail-on-severity gate
+
+```bash
+aws cloudformation deploy \
+  --template-file deploy/cloudformation/agent-bom-scan.yaml \
+  --stack-name agent-bom-scan \
+  --capabilities CAPABILITY_IAM \
+  --parameter-overrides Region=us-east-1 FailOnSeverity=high
+```
+
+Reports are always uploaded to S3 *before* the gate runs, so a non-zero build
+never loses artifacts.
+
+### Scheduled scans
+
+```bash
+aws cloudformation deploy \
+  --template-file deploy/cloudformation/agent-bom-scan.yaml \
+  --stack-name agent-bom-scan \
+  --capabilities CAPABILITY_IAM \
+  --parameter-overrides Region=us-east-1 Schedule=true ScheduleExpression="rate(7 days)"
+```
+
+## What gets created
+
+| Resource                     | Type                       | Notes                                                       |
+| ---------------------------- | -------------------------- | ----------------------------------------------------------- |
+| Report bucket                | `AWS::S3::Bucket`          | Private (all public access blocked), SSE-S3, versioned, lifecycle expiry. |
+| Bucket policy                | `AWS::S3::BucketPolicy`    | Denies non-TLS access.                                       |
+| Scan role                    | `AWS::IAM::Role`           | `SecurityAudit` (+ optional `ViewOnlyAccess`) + write-to-bucket + build logs only. |
+| CodeBuild project            | `AWS::CodeBuild::Project`  | Serverless scan, 30-minute timeout, `NO_SOURCE`.            |
+| Schedule role + rule         | `AWS::IAM::Role` / `AWS::Events::Rule` | Only when `Schedule=true`.                       |
+
+## Validate the template
+
+```bash
+pip install cfn-lint
+cfn-lint deploy/cloudformation/agent-bom-scan.yaml
+```
+
+## Clean up
+
+```bash
+# Empty the bucket first (it is retained on stack delete)
+aws s3 rm "s3://$BUCKET/" --recursive
+aws cloudformation delete-stack --stack-name agent-bom-scan
+aws s3 rb "s3://$BUCKET"
+```
+
+The report bucket uses a `Retain` deletion policy so reports survive an
+accidental stack delete; remove it manually when you no longer need them.
+
+## Buildspec
+
+The CodeBuild buildspec is inlined in the template (`ScanProject.Source.BuildSpec`).
+[`buildspec.yml`](./buildspec.yml) is a readable reference copy kept in sync.

--- a/deploy/cloudformation/agent-bom-scan.yaml
+++ b/deploy/cloudformation/agent-bom-scan.yaml
@@ -1,0 +1,369 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >-
+  agent-bom one-click read-only AWS scan. Provisions a serverless AWS CodeBuild
+  project (no EC2 instance, works on free-tier-restricted accounts) that installs
+  agent-bom, runs a read-only cloud inventory + CIS benchmark against your AWS
+  account, and publishes HTML / JSON / plaintext reports to a private S3 bucket.
+  The scan role is granted only the AWS-managed SecurityAudit (and optional
+  ViewOnlyAccess) read-only policies plus write access to the single report
+  bucket. No long-lived secrets, no inbound network exposure.
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Scan configuration
+        Parameters:
+          - Region
+          - FailOnSeverity
+          - AddViewOnlyAccess
+      - Label:
+          default: Build & packaging
+        Parameters:
+          - AgentBomSpec
+          - ComputeType
+          - PythonImage
+      - Label:
+          default: Report retention & scheduling
+        Parameters:
+          - ReportRetentionDays
+          - Schedule
+          - ScheduleExpression
+    ParameterLabels:
+      Region:
+        default: AWS region to scan
+      FailOnSeverity:
+        default: Fail the build on findings at or above this severity
+      AddViewOnlyAccess:
+        default: Also attach the AWS-managed ViewOnlyAccess policy
+      Schedule:
+        default: Enable recurring scheduled scans
+      ScheduleExpression:
+        default: EventBridge schedule expression for recurring scans
+
+Parameters:
+  Region:
+    Type: String
+    Default: us-east-1
+    AllowedPattern: "^[a-z]{2}(-gov)?-[a-z]+-[0-9]$"
+    Description: >-
+      AWS region passed to "agent-bom cloud aws --region". The scan reads global
+      and regional services in this region.
+
+  FailOnSeverity:
+    Type: String
+    Default: none
+    AllowedValues:
+      - none
+      - low
+      - medium
+      - high
+      - critical
+    Description: >-
+      If set above "none", the CodeBuild run exits non-zero when findings at or
+      above this severity are present. Reports are still written to S3 first.
+
+  AddViewOnlyAccess:
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: >-
+      Attach the AWS-managed ViewOnlyAccess policy in addition to SecurityAudit
+      for broader read-only resource discovery. Both are read-only.
+
+  AgentBomSpec:
+    Type: String
+    Default: "agent-bom[aws]"
+    AllowedPattern: "^agent-bom\\[aws\\].*$"
+    Description: >-
+      pip requirement spec installed before the scan. Pin a version for
+      reproducible runs, e.g. "agent-bom[aws]==0.89.2".
+
+  ComputeType:
+    Type: String
+    Default: BUILD_GENERAL1_SMALL
+    AllowedValues:
+      - BUILD_GENERAL1_SMALL
+      - BUILD_GENERAL1_MEDIUM
+    Description: CodeBuild compute size. SMALL is sufficient and cheapest.
+
+  PythonImage:
+    Type: String
+    Default: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+    Description: >-
+      Managed CodeBuild image providing Python 3. The default ships Python 3.11+.
+
+  ReportRetentionDays:
+    Type: Number
+    Default: 30
+    MinValue: 1
+    MaxValue: 365
+    Description: Days before report objects expire from the S3 bucket.
+
+  Schedule:
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Enable an EventBridge rule that runs the scan on a recurring schedule.
+
+  ScheduleExpression:
+    Type: String
+    Default: rate(7 days)
+    Description: >-
+      EventBridge schedule expression used when Schedule=true,
+      e.g. "rate(7 days)" or "cron(0 6 ? * MON *)".
+
+Conditions:
+  AttachViewOnly: !Equals [!Ref AddViewOnlyAccess, "true"]
+  EnableSchedule: !Equals [!Ref Schedule, "true"]
+  EnforceSeverity: !Not [!Equals [!Ref FailOnSeverity, "none"]]
+
+Resources:
+  ReportBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+            BucketKeyEnabled: true
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: expire-reports
+            Status: Enabled
+            ExpirationInDays: !Ref ReportRetentionDays
+            NoncurrentVersionExpiration:
+              NoncurrentDays: !Ref ReportRetentionDays
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 7
+
+  ReportBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ReportBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: DenyInsecureTransport
+            Effect: Deny
+            Principal: "*"
+            Action: "s3:*"
+            Resource:
+              - !GetAtt ReportBucket.Arn
+              - !Sub "${ReportBucket.Arn}/*"
+            Condition:
+              Bool:
+                "aws:SecureTransport": "false"
+
+  ScanRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Description: Read-only role used by the agent-bom CodeBuild scan.
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+            Action: "sts:AssumeRole"
+      ManagedPolicyArns: !If
+        - AttachViewOnly
+        - - arn:aws:iam::aws:policy/SecurityAudit
+          - arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
+        - - arn:aws:iam::aws:policy/SecurityAudit
+      Policies:
+        - PolicyName: agent-bom-scan-build
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: WriteReportsToBucket
+                Effect: Allow
+                Action:
+                  - "s3:PutObject"
+                Resource: !Sub "${ReportBucket.Arn}/*"
+              - Sid: ListReportBucket
+                Effect: Allow
+                Action:
+                  - "s3:ListBucket"
+                  - "s3:GetBucketLocation"
+                Resource: !GetAtt ReportBucket.Arn
+              - Sid: BuildLogs
+                Effect: Allow
+                Action:
+                  - "logs:CreateLogGroup"
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/agent-bom-scan-${AWS::StackName}"
+                  - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/agent-bom-scan-${AWS::StackName}:*"
+
+  ScanProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub "agent-bom-scan-${AWS::StackName}"
+      Description: Serverless read-only agent-bom AWS scan publishing reports to S3.
+      ServiceRole: !GetAtt ScanRole.Arn
+      TimeoutInMinutes: 30
+      Artifacts:
+        Type: NO_ARTIFACTS
+      LogsConfig:
+        CloudWatchLogs:
+          Status: ENABLED
+          GroupName: !Sub "/aws/codebuild/agent-bom-scan-${AWS::StackName}"
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: !Ref ComputeType
+        Image: !Ref PythonImage
+        EnvironmentVariables:
+          - Name: AGENT_BOM_AWS_INVENTORY
+            Value: "1"
+          - Name: SCAN_REGION
+            Value: !Ref Region
+          - Name: REPORT_BUCKET
+            Value: !Ref ReportBucket
+          - Name: AGENT_BOM_SPEC
+            Value: !Ref AgentBomSpec
+          - Name: FAIL_ON_SEVERITY
+            Value: !Ref FailOnSeverity
+      Source:
+        Type: NO_SOURCE
+        BuildSpec: |
+          version: 0.2
+          phases:
+            install:
+              commands:
+                - python3 --version
+                - python3 -m pip install --quiet --upgrade pip
+                - python3 -m pip install --quiet "${AGENT_BOM_SPEC}"
+                - agent-bom --version
+            build:
+              commands:
+                - export PREFIX="aws-scan/$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+                - echo "Scanning region ${SCAN_REGION}; reports prefix ${PREFIX}"
+                # Read-only AWS inventory + CIS benchmark. Each format is a
+                # separate read-only invocation; none mutate the account.
+                - agent-bom cloud aws --region "${SCAN_REGION}" -f html -o report.html
+                - agent-bom cloud aws --region "${SCAN_REGION}" -f json -o report.json
+                # Plaintext CLI report (no color) for grep/diff/log pipelines.
+                - agent-bom cloud aws --region "${SCAN_REGION}" -f plain -o report.txt
+                # Also capture the colorized console table to a log file.
+                - agent-bom cloud aws --region "${SCAN_REGION}" 2>&1 | tee console.log || true
+            post_build:
+              commands:
+                - |
+                  for f in report.html report.json report.txt console.log; do
+                    if [ -f "$f" ]; then
+                      aws s3 cp "$f" "s3://${REPORT_BUCKET}/${PREFIX}/$f" \
+                        --content-type "$([ "$f" = report.html ] && echo text/html || echo text/plain)"
+                    fi
+                  done
+                - echo "Reports uploaded to s3://${REPORT_BUCKET}/${PREFIX}/"
+                # Optional severity gate. Runs after reports are safely in S3 so
+                # a non-zero exit never loses the artifacts.
+                - |
+                  if [ "${FAIL_ON_SEVERITY}" != "none" ]; then
+                    echo "Enforcing fail-on-severity=${FAIL_ON_SEVERITY}"
+                    agent-bom cloud aws --region "${SCAN_REGION}" -f json -o gate.json
+                    python3 - "$FAIL_ON_SEVERITY" gate.json <<'PY'
+                  import json, sys
+                  order = ["low", "medium", "high", "critical"]
+                  threshold = sys.argv[1]
+                  try:
+                      data = json.load(open(sys.argv[2]))
+                  except Exception as exc:  # noqa: BLE001
+                      print(f"gate: could not read report ({exc}); not failing")
+                      sys.exit(0)
+                  def sevs(obj):
+                      if isinstance(obj, dict):
+                          if "severity" in obj and isinstance(obj["severity"], str):
+                              yield obj["severity"].lower()
+                          for v in obj.values():
+                              yield from sevs(v)
+                      elif isinstance(obj, list):
+                          for v in obj:
+                              yield from sevs(v)
+                  cut = order.index(threshold) if threshold in order else len(order)
+                  hits = [s for s in sevs(data) if s in order and order.index(s) >= cut]
+                  if hits:
+                      print(f"gate: {len(hits)} finding(s) at/above {threshold}")
+                      sys.exit(1)
+                  print(f"gate: no findings at/above {threshold}")
+                  PY
+                  fi
+
+  ScheduleRole:
+    Type: AWS::IAM::Role
+    Condition: EnableSchedule
+    Properties:
+      Description: Allows EventBridge to start the agent-bom scan project.
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: "sts:AssumeRole"
+      Policies:
+        - PolicyName: start-scan-build
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: "codebuild:StartBuild"
+                Resource: !GetAtt ScanProject.Arn
+
+  ScheduleRule:
+    Type: AWS::Events::Rule
+    Condition: EnableSchedule
+    Properties:
+      Description: Recurring agent-bom read-only AWS scan.
+      ScheduleExpression: !Ref ScheduleExpression
+      State: ENABLED
+      Targets:
+        - Id: agent-bom-scan
+          Arn: !GetAtt ScanProject.Arn
+          RoleArn: !GetAtt ScheduleRole.Arn
+
+Outputs:
+  ReportBucketName:
+    Description: Private S3 bucket holding the scan reports.
+    Value: !Ref ReportBucket
+
+  CodeBuildProject:
+    Description: CodeBuild project that runs the read-only scan.
+    Value: !Ref ScanProject
+
+  StartScanCommand:
+    Description: Run an on-demand scan now.
+    Value: !Sub "aws codebuild start-build --project-name ${ScanProject} --region ${AWS::Region}"
+
+  ListReportsCommand:
+    Description: List published reports.
+    Value: !Sub "aws s3 ls s3://${ReportBucket}/aws-scan/ --recursive"
+
+  DownloadReportsCommand:
+    Description: Download all reports locally.
+    Value: !Sub "aws s3 cp s3://${ReportBucket}/aws-scan/ ./agent-bom-reports/ --recursive"
+
+  ConsoleUrl:
+    Description: S3 console URL for the report bucket.
+    Value: !Sub "https://s3.console.aws.amazon.com/s3/buckets/${ReportBucket}?region=${AWS::Region}"
+
+  SeverityGate:
+    Condition: EnforceSeverity
+    Description: Active fail-on-severity threshold for the build.
+    Value: !Ref FailOnSeverity

--- a/deploy/cloudformation/buildspec.yml
+++ b/deploy/cloudformation/buildspec.yml
@@ -1,0 +1,73 @@
+# Reference copy of the buildspec embedded in agent-bom-scan.yaml.
+#
+# The CloudFormation stack inlines this buildspec into the CodeBuild project's
+# Source.BuildSpec, so deploying the template needs nothing else. This file is
+# kept in sync as a readable reference and for local `cfn-lint`/CodeBuild local
+# testing. The following environment variables are injected by the stack:
+#
+#   AGENT_BOM_AWS_INVENTORY=1     enables AWS inventory enrichment
+#   SCAN_REGION                   region passed to `agent-bom cloud aws --region`
+#   REPORT_BUCKET                 private S3 bucket for reports
+#   AGENT_BOM_SPEC                pip requirement, e.g. "agent-bom[aws]==0.89.2"
+#   FAIL_ON_SEVERITY              none|low|medium|high|critical
+#
+# The scan is read-only: every `agent-bom cloud aws` invocation discovers
+# resources and runs the CIS benchmark without mutating the account. The only
+# writes are report objects to the single S3 bucket.
+
+version: 0.2
+phases:
+  install:
+    commands:
+      - python3 --version
+      - python3 -m pip install --quiet --upgrade pip
+      - python3 -m pip install --quiet "${AGENT_BOM_SPEC}"
+      - agent-bom --version
+  build:
+    commands:
+      - export PREFIX="aws-scan/$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+      - echo "Scanning region ${SCAN_REGION}; reports prefix ${PREFIX}"
+      - agent-bom cloud aws --region "${SCAN_REGION}" -f html -o report.html
+      - agent-bom cloud aws --region "${SCAN_REGION}" -f json -o report.json
+      - agent-bom cloud aws --region "${SCAN_REGION}" -f plain -o report.txt
+      - agent-bom cloud aws --region "${SCAN_REGION}" 2>&1 | tee console.log || true
+  post_build:
+    commands:
+      - |
+        for f in report.html report.json report.txt console.log; do
+          if [ -f "$f" ]; then
+            aws s3 cp "$f" "s3://${REPORT_BUCKET}/${PREFIX}/$f" \
+              --content-type "$([ "$f" = report.html ] && echo text/html || echo text/plain)"
+          fi
+        done
+      - echo "Reports uploaded to s3://${REPORT_BUCKET}/${PREFIX}/"
+      - |
+        if [ "${FAIL_ON_SEVERITY}" != "none" ]; then
+          echo "Enforcing fail-on-severity=${FAIL_ON_SEVERITY}"
+          agent-bom cloud aws --region "${SCAN_REGION}" -f json -o gate.json
+          python3 - "$FAIL_ON_SEVERITY" gate.json <<'PY'
+        import json, sys
+        order = ["low", "medium", "high", "critical"]
+        threshold = sys.argv[1]
+        try:
+            data = json.load(open(sys.argv[2]))
+        except Exception as exc:  # noqa: BLE001
+            print(f"gate: could not read report ({exc}); not failing")
+            sys.exit(0)
+        def sevs(obj):
+            if isinstance(obj, dict):
+                if "severity" in obj and isinstance(obj["severity"], str):
+                    yield obj["severity"].lower()
+                for v in obj.values():
+                    yield from sevs(v)
+            elif isinstance(obj, list):
+                for v in obj:
+                    yield from sevs(v)
+        cut = order.index(threshold) if threshold in order else len(order)
+        hits = [s for s in sevs(data) if s in order and order.index(s) >= cut]
+        if hits:
+            print(f"gate: {len(hits)} finding(s) at/above {threshold}")
+            sys.exit(1)
+        print(f"gate: no findings at/above {threshold}")
+        PY
+        fi


### PR DESCRIPTION
Adds a self-contained CloudFormation template for a one-click, read-only AWS scan.

## What it provisions
- **S3 report bucket** — private (all public access blocked), SSE-S3 encryption, versioned, TLS-only bucket policy, and a lifecycle rule that expires reports after a configurable retention period (default 30 days).
- **Read-only scan role** — AWS-managed `SecurityAudit` (optionally `ViewOnlyAccess`) plus write access to the single report bucket and its own build-log group. No other account write permissions.
- **Serverless CodeBuild project** — no EC2 instance, so it runs on free-tier-restricted accounts. Installs `agent-bom[aws]`, runs `agent-bom cloud aws` with `AGENT_BOM_AWS_INVENTORY=1`, and emits HTML, JSON, and plaintext reports plus a captured console log, then uploads them to the bucket under a timestamped prefix.
- **Optional EventBridge schedule** for recurring scans (disabled by default).
- **Optional fail-on-severity gate** that runs after reports are uploaded, so a non-zero build never drops artifacts.

## Parameters
`Region` (default us-east-1), `FailOnSeverity` (default none), `AddViewOnlyAccess`, `AgentBomSpec` (pin a version), `ComputeType`, `PythonImage`, `ReportRetentionDays`, `Schedule`, `ScheduleExpression`.

## Deploy
```
aws cloudformation deploy \
  --template-file deploy/cloudformation/agent-bom-scan.yaml \
  --stack-name agent-bom-scan \
  --capabilities CAPABILITY_IAM \
  --parameter-overrides Region=us-east-1
```

## Validation
`cfn-lint 1.52.0` passes clean on the template (exit 0, default and informational rulesets). Both the embedded and reference buildspecs parse as valid YAML. The buildspec commands match the real CLI surface: `agent-bom cloud aws` accepts `--region`, `-f/--format` (html, json, plain all supported), and `-o/--output`.

## Files
- `deploy/cloudformation/agent-bom-scan.yaml` — the template (buildspec inlined)
- `deploy/cloudformation/buildspec.yml` — readable reference copy of the buildspec
- `deploy/cloudformation/README.md` — deploy command and report-retrieval steps

Read-only, serverless, no long-lived secrets.