### PR TITLE
fix(cloud): cloud CIS failures drive the verbose posture headline

### DIFF
--- a/src/agent_bom/cli/agents/_cloud.py
+++ b/src/agent_bom/cli/agents/_cloud.py
@@ -6,6 +6,26 @@ from typing import Any
 
 from agent_bom.cli.agents._context import ScanContext
 
+# Shared CIS status badges across every provider table. ``not_applicable`` is
+# rendered as a short ``N/A`` badge so it is never truncated to ``not_a…`` in
+# the width-constrained Status column, and unknown statuses fall back to their
+# raw value instead of a missing cell.
+_CIS_STATUS_STYLE = {
+    "pass": "[green]PASS[/]",
+    "fail": "[red]FAIL[/]",
+    "error": "[yellow]ERR[/]",
+    "not_applicable": "[dim]N/A[/]",
+}
+
+# Width that fits the longest rendered status label (``FAIL``/``PASS``/``ERR``/
+# ``N/A``) without clipping.
+_CIS_STATUS_WIDTH = 6
+
+
+def _cis_status_badge(status_value: str) -> str:
+    """Render a CIS check status as a compact, never-truncated badge."""
+    return _CIS_STATUS_STYLE.get(status_value, status_value)
+
 
 def run_cloud_discovery(
     ctx: ScanContext,
@@ -295,16 +315,15 @@ def run_benchmarks(
                 tbl = Table(title="CIS AWS Foundations Benchmark v3.0", show_lines=False, padding=(0, 1))
                 tbl.add_column("Check", style="cyan", width=6)
                 tbl.add_column("Title", min_width=30)
-                tbl.add_column("Status", width=6)
+                tbl.add_column("Status", width=_CIS_STATUS_WIDTH)
                 tbl.add_column("Severity", width=8)
                 tbl.add_column("Evidence", max_width=50)
-                _status_style = {"pass": "[green]PASS[/]", "fail": "[red]FAIL[/]", "error": "[yellow]ERR[/]"}
                 _sev_style = {"critical": "[red]critical[/]", "high": "[bright_red]high[/]", "medium": "[yellow]medium[/]"}
                 for c in ctx.cis_benchmark_report.checks:
                     tbl.add_row(
                         c.check_id,
                         c.title,
-                        _status_style.get(c.status.value, c.status.value),
+                        _cis_status_badge(c.status.value),
                         _sev_style.get(c.severity, c.severity),
                         c.evidence,
                     )
@@ -334,16 +353,15 @@ def run_benchmarks(
                 tbl = Table(title="CIS Snowflake Benchmark v1.0", show_lines=False, padding=(0, 1))
                 tbl.add_column("Check", style="cyan", width=6)
                 tbl.add_column("Title", min_width=30)
-                tbl.add_column("Status", width=6)
+                tbl.add_column("Status", width=_CIS_STATUS_WIDTH)
                 tbl.add_column("Severity", width=8)
                 tbl.add_column("Evidence", max_width=50)
-                _sf_status_style = {"pass": "[green]PASS[/]", "fail": "[red]FAIL[/]", "error": "[yellow]ERR[/]"}
                 _sf_sev_style = {"critical": "[red]critical[/]", "high": "[bright_red]high[/]", "medium": "[yellow]medium[/]"}
                 for c in ctx.sf_cis_benchmark_report.checks:
                     tbl.add_row(
                         c.check_id,
                         c.title,
-                        _sf_status_style.get(c.status.value, c.status.value),
+                        _cis_status_badge(c.status.value),
                         _sf_sev_style.get(c.severity, c.severity),
                         c.evidence,
                     )
@@ -374,11 +392,10 @@ def run_benchmarks(
                 tbl = Table(title="CIS Azure Security Benchmark v3.0", show_lines=False, padding=(0, 1))
                 tbl.add_column("Check", style="cyan", width=6)
                 tbl.add_column("Title", min_width=30)
-                tbl.add_column("Status", width=6)
+                tbl.add_column("Status", width=_CIS_STATUS_WIDTH)
                 tbl.add_column("Severity", width=8)
                 tbl.add_column("ATT&CK", width=20)
                 tbl.add_column("Evidence", max_width=40)
-                _az_status = {"pass": "[green]PASS[/]", "fail": "[red]FAIL[/]", "error": "[yellow]ERR[/]"}
                 _az_sev = {"critical": "[red]critical[/]", "high": "[bright_red]high[/]", "medium": "[yellow]medium[/]"}
                 from agent_bom.mitre_attack import tag_cis_check
 
@@ -387,7 +404,7 @@ def run_benchmarks(
                     tbl.add_row(
                         c.check_id,
                         c.title,
-                        _az_status.get(c.status.value, c.status.value),
+                        _cis_status_badge(c.status.value),
                         _az_sev.get(c.severity, c.severity),
                         attack,
                         c.evidence,
@@ -417,11 +434,10 @@ def run_benchmarks(
                 tbl = Table(title="CIS GCP Foundation Benchmark v3.0", show_lines=False, padding=(0, 1))
                 tbl.add_column("Check", style="cyan", width=6)
                 tbl.add_column("Title", min_width=30)
-                tbl.add_column("Status", width=6)
+                tbl.add_column("Status", width=_CIS_STATUS_WIDTH)
                 tbl.add_column("Severity", width=8)
                 tbl.add_column("ATT&CK", width=20)
                 tbl.add_column("Evidence", max_width=40)
-                _gcp_status = {"pass": "[green]PASS[/]", "fail": "[red]FAIL[/]", "error": "[yellow]ERR[/]"}
                 _gcp_sev = {"critical": "[red]critical[/]", "high": "[bright_red]high[/]", "medium": "[yellow]medium[/]"}
                 from agent_bom.mitre_attack import tag_cis_check as _tag_gcp
 
@@ -430,7 +446,7 @@ def run_benchmarks(
                     tbl.add_row(
                         c.check_id,
                         c.title,
-                        _gcp_status.get(c.status.value, c.status.value),
+                        _cis_status_badge(c.status.value),
                         _gcp_sev.get(c.severity, c.severity),
                         attack,
                         c.evidence,

--- a/src/agent_bom/cloud/aws_cis_benchmark.py
+++ b/src/agent_bom/cloud/aws_cis_benchmark.py
@@ -2199,9 +2199,12 @@ def _check_4_16(securityhub_client: Any) -> CISCheckResult:
             result.evidence = "Security Hub is not enabled."
     except Exception as exc:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
-        if error_code in ("InvalidAccessException", "ResourceNotFoundException"):
+        if error_code in ("InvalidAccessException", "ResourceNotFoundException", "SubscriptionRequiredException"):
+            # Security Hub not subscribed/enabled — this is a control FAIL with
+            # actionable guidance, not an opaque API error. SubscriptionRequired
+            # is AWS's signal that the service is simply not turned on.
             result.status = CheckStatus.FAIL
-            result.evidence = "Security Hub is not enabled in this region."
+            result.evidence = "Security Hub not enabled — enable it to evaluate this control."
         else:
             result.status = CheckStatus.ERROR
             result.evidence = f"Could not check Security Hub: {error_code or exc}"

--- a/src/agent_bom/discovery/__init__.py
+++ b/src/agent_bom/discovery/__init__.py
@@ -1229,7 +1229,9 @@ def discover_all(
         k8s_all_namespaces: Query all Kubernetes namespaces.
         k8s_context: kubectl context to use (uses current context if None).
     """
-    console.print("\n[bold blue]🔍 Discovering MCP configurations...[/bold blue]\n")
+    from agent_bom.output.console_render import safe_emoji
+
+    console.print(f"\n[bold blue]{safe_emoji('🔍', '>')} Discovering MCP configurations...[/bold blue]\n")
     project_search_dir = str(_project_search_dir(project_dir)) if project_dir else None
 
     if project_dir:

--- a/src/agent_bom/output/console_render.py
+++ b/src/agent_bom/output/console_render.py
@@ -14,6 +14,25 @@ from agent_bom.security import sanitize_command_args
 
 console = Console()
 
+
+def safe_emoji(emoji: str, fallback: str = "*") -> str:
+    """Return ``emoji`` only when the active stdout encoding can render it.
+
+    On terminals/locales whose encoding cannot encode the glyph (for example a
+    ``cp1252``/``ascii`` Windows console or a stripped CI locale) a raw emoji
+    prints as a mojibake box or raises ``UnicodeEncodeError`` mid-line. Fall
+    back to a plain ASCII marker so the line stays readable everywhere.
+    """
+    import sys
+
+    encoding = getattr(sys.stdout, "encoding", None) or "utf-8"
+    try:
+        emoji.encode(encoding)
+    except (UnicodeEncodeError, LookupError):
+        return fallback
+    return emoji
+
+
 # ─── Centralized severity styling ────────────────────────────────────────────
 
 SEVERITY_BADGES: dict[Severity, str] = {
@@ -263,6 +282,7 @@ def print_posture_summary(report: AIBOMReport) -> None:
                     cred_map.setdefault(cred, []).append(f"{agent.name}/{server.name}")
 
     # Vulnerability severity breakdown (excluding VEX-suppressed)
+    from agent_bom.finding import FindingType
     from agent_bom.vex import is_vex_suppressed
 
     sev_counts: Counter[str] = Counter()
@@ -273,11 +293,19 @@ def print_posture_summary(report: AIBOMReport) -> None:
         else:
             sev_counts[br.vulnerability.severity.value.upper()] += 1
 
+    # Non-CVE policy/security findings (cloud CIS FAILs, MCP blocklist, toxic
+    # combinations, governance) drive the headline too. A cloud scan with HIGH
+    # CIS failures must NOT read CLEAN just because no package CVEs were found —
+    # these findings already flow into to_findings() and --fail-on-severity.
+    policy_findings = [finding for finding in report.to_findings() if finding.finding_type != FindingType.CVE]
+    for finding in policy_findings:
+        sev_counts[str(finding.severity).upper()] += 1
+
     # Posture headline
     if coverage_incomplete:
         posture = "[bold yellow]PARTIAL COVERAGE[/bold yellow]"
         border_style = "yellow"
-    elif report.total_vulnerabilities == 0:
+    elif report.total_vulnerabilities == 0 and not policy_findings:
         posture = "[bold green]CLEAN[/bold green]"
         border_style = "green"
     elif sev_counts.get("CRITICAL", 0) > 0:

--- a/tests/test_aws_cis_benchmark.py
+++ b/tests/test_aws_cis_benchmark.py
@@ -2293,6 +2293,17 @@ class TestCheck416:
         result = _check_4_16(client)
         assert result.status == CheckStatus.ERROR
 
+    def test_subscription_required_is_actionable_fail(self):
+        # SubscriptionRequiredException means Security Hub is simply not enabled —
+        # render an actionable FAIL, not an opaque ERR.
+        client = MagicMock()
+        exc = Exception("SubscriptionRequiredException")
+        exc.response = {"Error": {"Code": "SubscriptionRequiredException"}}
+        client.describe_hub.side_effect = exc
+        result = _check_4_16(client)
+        assert result.status == CheckStatus.FAIL
+        assert "enable it to evaluate this control" in result.evidence
+
 
 # ---------------------------------------------------------------------------
 # 5.5 — No security groups allow unrestricted ingress to all ports

--- a/tests/test_cloud_cis_convergence.py
+++ b/tests/test_cloud_cis_convergence.py
@@ -85,3 +85,27 @@ def test_clean_cis_does_not_trip_gate() -> None:
     r = AIBOMReport(scan_id="t")
     r.cis_benchmark_data = {"checks": [{"check_id": "1.1", "title": "ok", "status": "PASS", "severity": "high"}]}
     assert _gate(r) == 0
+
+
+def test_cis_fail_posture_and_gate_agree() -> None:
+    """The compact headline and the --fail-on-severity gate read the same report
+    consistently: CIS HIGH fails are both non-CLEAN and gate-failing."""
+    from io import StringIO
+
+    from rich.console import Console
+
+    import agent_bom.output as out_mod
+    from agent_bom.output import print_compact_summary
+
+    report = _report()
+    buf = StringIO()
+    con = Console(file=buf, width=120, force_terminal=True, no_color=True)
+    orig = out_mod.console
+    out_mod.console = con
+    try:
+        print_compact_summary(report, verbose=True)
+    finally:
+        out_mod.console = orig
+    rendered = buf.getvalue()
+    assert "CLEAN" not in rendered  # headline reflects CIS fails
+    assert _gate(report) != 0  # gate agrees

--- a/tests/test_output_summary.py
+++ b/tests/test_output_summary.py
@@ -149,3 +149,85 @@ def test_posture_summary_agent_status_counts():
     output = _capture_posture(report)
     assert "2 configured" in output
     assert "1 installed-not-configured" in output
+
+
+def _cis_fail_report() -> AIBOMReport:
+    """A cloud scan with 0 package CVEs but HIGH CIS failures."""
+    report = AIBOMReport(agents=[_make_agent()])
+    report.cis_benchmark_data = {
+        "checks": [
+            {
+                "check_id": "3.1",
+                "title": "Ensure CloudTrail is enabled",
+                "status": "fail",
+                "severity": "high",
+                "evidence": "No CloudTrail trail found",
+                "resource_ids": ["account"],
+            },
+            {
+                "check_id": "5.2",
+                "title": "Ensure no NACLs allow ingress to admin ports",
+                "status": "fail",
+                "severity": "high",
+                "evidence": "NACL acl-1 open to 0.0.0.0/0 on port 22",
+            },
+            {"check_id": "1.1", "title": "Root MFA", "status": "pass", "severity": "high"},
+        ]
+    }
+    return report
+
+
+def test_posture_summary_cloud_cis_fail_not_clean():
+    """Cloud CIS HIGH failures must NOT read CLEAN even with 0 package CVEs."""
+    output = _capture_posture(_cis_fail_report())
+    assert "CLEAN" not in output
+    assert "2 HIGH" in output
+
+
+def test_posture_summary_cloud_cis_clean_still_clean():
+    """A genuinely clean cloud scan (all checks pass) still reads CLEAN."""
+    report = AIBOMReport(agents=[_make_agent()])
+    report.cis_benchmark_data = {
+        "checks": [
+            {"check_id": "1.1", "title": "Root MFA", "status": "pass", "severity": "high"},
+            {"check_id": "3.1", "title": "CloudTrail", "status": "pass", "severity": "high"},
+        ]
+    }
+    output = _capture_posture(report)
+    assert "CLEAN" in output
+
+
+def test_safe_emoji_passthrough_on_utf8():
+    from agent_bom.output.console_render import safe_emoji
+
+    assert safe_emoji("🔍", ">") == "🔍"
+
+
+def test_safe_emoji_falls_back_when_unencodable(monkeypatch):
+    import sys
+
+    from agent_bom.output.console_render import safe_emoji
+
+    class _AsciiStdout:
+        encoding = "ascii"
+
+    monkeypatch.setattr(sys, "stdout", _AsciiStdout())
+    assert safe_emoji("🔍", ">") == ">"
+
+
+def test_cis_status_badge_no_truncation_for_not_applicable():
+    from agent_bom.cli.agents._cloud import _CIS_STATUS_WIDTH, _cis_status_badge
+
+    # not_applicable must render as a compact badge that fits the column width —
+    # never the truncated "not_a…" from the raw 14-char status value.
+    badge = _cis_status_badge("not_applicable")
+    assert "N/A" in badge
+    assert "not_a" not in badge
+    # The rendered label fits the column.
+    plain = badge.replace("[dim]", "").replace("[/]", "")
+    assert len(plain) <= _CIS_STATUS_WIDTH
+    # Known statuses keep their existing labels.
+    assert "FAIL" in _cis_status_badge("fail")
+    assert "PASS" in _cis_status_badge("pass")
+    # Unknown statuses fall back to the raw value, not a missing cell.
+    assert _cis_status_badge("weird") == "weird"


### PR DESCRIPTION
## Problem

A cloud scan with HIGH CIS benchmark failures (no CloudTrail, NACLs open to admin ports) rendered \`Security posture: CLEAN\` in the verbose summary, while the \`--fail-on-severity\` gate correctly failed on the same findings. The headline disagreed with the gate.

Root cause: \`print_posture_summary\` (the verbose console summary) computed CLEAN from \`report.total_vulnerabilities == 0\` alone — it only counted package CVEs from \`blast_radii\` and ignored cloud CIS failures, even though those failures already flow into \`to_findings()\` and the exit-code gate. The compact (default) summary already converged correctly.

## Fix

- \`print_posture_summary\` now folds non-CVE policy/security findings (cloud CIS FAILs, MCP blocklist, toxic combinations, governance) into the severity rollup and only reads CLEAN when both package CVEs and policy findings are absent — matching the compact summary and the exit-code gate. The severity badges now reflect the CIS failures.
- A genuinely clean cloud scan (no CVEs, all CIS checks pass) still reads CLEAN.

## Cosmetic (same output path)

- AWS Security Hub \`SubscriptionRequiredException\` now renders as an actionable FAIL ("Security Hub not enabled — enable it to evaluate this control") instead of an opaque \`ERR\`.
- \`not_applicable\` CIS status renders as a compact \`N/A\` badge across all provider tables instead of the truncated \`not_a…\`.
- The MCP discovery banner emoji falls back to an ASCII marker on terminals/locales whose encoding cannot render it.

## Tests

- \`test_posture_summary_cloud_cis_fail_not_clean\` — CIS HIGH fails are not CLEAN and show the severity badges.
- \`test_posture_summary_cloud_cis_clean_still_clean\` — clean cloud scan still reads CLEAN.
- \`test_cis_fail_posture_and_gate_agree\` — headline and \`--fail-on-severity\` gate agree on the same report.
- \`test_subscription_required_is_actionable_fail\`, \`test_cis_status_badge_no_truncation_for_not_applicable\`, \`test_safe_emoji_*\`.

\`ruff check\` + \`mypy\` clean on touched files; targeted suite green.