### PR TITLE
feat(storage): shared backend contract and selection factory for control-plane stores

### DIFF
--- a/src/agent_bom/api/cost_store.py
+++ b/src/agent_bom/api/cost_store.py
@@ -10,7 +10,6 @@ accountability layer commercial agent-runtime products charge for, kept open.
 from __future__ import annotations
 
 import json
-import os
 import sqlite3
 import threading
 from collections import defaultdict
@@ -18,6 +17,7 @@ from dataclasses import asdict, dataclass, field
 from typing import Any, Protocol
 
 from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+from agent_bom.storage.base import StorageSchema, TableSchema
 
 
 @dataclass(frozen=True)
@@ -135,6 +135,75 @@ def _rollup_by_tag(records: list[LLMCostRecord], tag_key: str) -> list[dict[str,
     return sorted(buckets.values(), key=lambda b: b["cost_usd"], reverse=True)
 
 
+# ── Portable schema seam (reference) ──────────────────────────────────────────
+#
+# Single source-of-truth schema for the llm_costs store, shared across backends.
+# The SQLite and Postgres ``_init_db`` / ``_init_tables`` paths below remain the
+# executed DDL (audited, with their additive migrations); this declaration mirrors
+# them so a conformance/parity test can assert both backends cover the same logical
+# columns and a new backend is a registration here rather than a fork. See
+# ``agent_bom.storage.base.StorageSchema`` for the seam contract.
+COST_STORAGE_SCHEMA = StorageSchema(
+    component="llm_costs",
+    tables=(
+        TableSchema(
+            name="llm_costs",
+            columns=(
+                "tenant_id",
+                "call_id",
+                "agent",
+                "session_id",
+                "provider",
+                "model",
+                "input_tokens",
+                "output_tokens",
+                "cost_usd",
+                "priced",
+                "observed_at",
+                "cost_center",
+                "allocation_tags",
+            ),
+            ddl_by_backend={
+                "sqlite": (
+                    "CREATE TABLE IF NOT EXISTS llm_costs (tenant_id TEXT NOT NULL, "
+                    "call_id TEXT NOT NULL, agent TEXT NOT NULL, session_id TEXT NOT NULL, "
+                    "provider TEXT NOT NULL, model TEXT NOT NULL, input_tokens INTEGER NOT NULL, "
+                    "output_tokens INTEGER NOT NULL, cost_usd REAL NOT NULL, priced INTEGER NOT NULL, "
+                    "observed_at TEXT NOT NULL, cost_center TEXT NOT NULL DEFAULT '', "
+                    "allocation_tags TEXT NOT NULL DEFAULT '{}', PRIMARY KEY (tenant_id, call_id))"
+                ),
+                "postgres": (
+                    "CREATE TABLE IF NOT EXISTS llm_costs (tenant_id TEXT NOT NULL, "
+                    "call_id TEXT NOT NULL, agent TEXT NOT NULL, session_id TEXT NOT NULL, "
+                    "provider TEXT NOT NULL, model TEXT NOT NULL, input_tokens INTEGER NOT NULL, "
+                    "output_tokens INTEGER NOT NULL, cost_usd DOUBLE PRECISION NOT NULL, priced BOOLEAN NOT NULL, "
+                    "observed_at TEXT NOT NULL, cost_center TEXT NOT NULL DEFAULT '', "
+                    "allocation_tags TEXT NOT NULL DEFAULT '{}', PRIMARY KEY (tenant_id, call_id))"
+                ),
+            },
+        ),
+        TableSchema(
+            name="llm_cost_budgets",
+            columns=("tenant_id", "agent", "limit_usd", "updated_at", "mode", "cost_center"),
+            ddl_by_backend={
+                "sqlite": (
+                    "CREATE TABLE IF NOT EXISTS llm_cost_budgets (tenant_id TEXT NOT NULL, "
+                    "agent TEXT NOT NULL DEFAULT '', limit_usd REAL NOT NULL, updated_at TEXT NOT NULL, "
+                    "mode TEXT NOT NULL DEFAULT 'report', cost_center TEXT NOT NULL DEFAULT '', "
+                    "PRIMARY KEY (tenant_id, agent, cost_center))"
+                ),
+                "postgres": (
+                    "CREATE TABLE IF NOT EXISTS llm_cost_budgets (tenant_id TEXT NOT NULL, "
+                    "agent TEXT NOT NULL DEFAULT '', limit_usd DOUBLE PRECISION NOT NULL, updated_at TEXT NOT NULL, "
+                    "mode TEXT NOT NULL DEFAULT 'report', cost_center TEXT NOT NULL DEFAULT '', "
+                    "PRIMARY KEY (tenant_id, agent, cost_center))"
+                ),
+            },
+        ),
+    ),
+)
+
+
 class CostStore(Protocol):
     def record_cost(self, record: LLMCostRecord) -> None: ...
 
@@ -208,6 +277,11 @@ class InMemoryCostStore:
         self._budgets: dict[tuple[str, str, str], CostBudget] = {}
         self._lock = threading.Lock()
 
+    def init_schema(self) -> None:
+        """No-op: the in-memory backend has no persistent schema. Present so the
+        in-memory store satisfies the shared
+        :class:`agent_bom.storage.base.TenantScopedStore` contract."""
+
     def record_cost(self, record: LLMCostRecord) -> None:
         with self._lock:
             if record.call_id in self._seen[record.tenant_id]:
@@ -255,6 +329,11 @@ class SQLiteCostStore:
             self._local.conn.execute("PRAGMA journal_mode=WAL")
         conn: sqlite3.Connection = self._local.conn
         return conn
+
+    def init_schema(self) -> None:
+        """Idempotently (re)create this store's tables. Satisfies the shared
+        :class:`agent_bom.storage.base.TenantScopedStore` contract."""
+        self._init_db()
 
     def _init_db(self) -> None:
         ensure_sqlite_schema_version(self._conn, "llm_costs")
@@ -445,15 +524,19 @@ def get_cost_store() -> CostStore:
     global _COST_STORE
     if _COST_STORE is not None:
         return _COST_STORE
-    # Priority mirrors the control-plane store-swap: shared Postgres first so
-    # per-agent spend and budget enforcement stay consistent across replicas;
-    # SQLite/in-memory remain for single-node and dev.
-    if os.environ.get("AGENT_BOM_POSTGRES_URL"):
+    # Backend selection is centralized in the storage factory (Postgres → shared
+    # SQLite → in-memory) so per-agent spend and budget enforcement land on the
+    # same tier every other env-ladder store does, instead of a hand-rolled copy.
+    from agent_bom.storage.base import BackendKind
+    from agent_bom.storage.factory import resolve_backend
+
+    selection = resolve_backend(mode="env")
+    if selection.backend is BackendKind.POSTGRES:
         from agent_bom.api.postgres_cost import PostgresCostStore
 
         _COST_STORE = PostgresCostStore()
-    elif os.environ.get("AGENT_BOM_DB"):
-        _COST_STORE = SQLiteCostStore(os.environ["AGENT_BOM_DB"])
+    elif selection.backend is BackendKind.SQLITE and selection.sqlite_path:
+        _COST_STORE = SQLiteCostStore(selection.sqlite_path)
     else:
         _COST_STORE = InMemoryCostStore()
     return _COST_STORE

--- a/src/agent_bom/api/policy_store.py
+++ b/src/agent_bom/api/policy_store.py
@@ -102,6 +102,11 @@ class InMemoryPolicyStore:
         self._policies: dict[str, GatewayPolicy] = {}
         self._audit: list[PolicyAuditEntry] = []
 
+    def init_schema(self) -> None:
+        """No-op: the in-memory backend has no persistent schema. Present so the
+        in-memory store satisfies the shared
+        :class:`agent_bom.storage.base.TenantScopedStore` contract."""
+
     def put_policy(self, policy: GatewayPolicy) -> None:
         self._policies[policy.policy_id] = policy
 
@@ -182,6 +187,11 @@ class SQLitePolicyStore:
             conn.execute("PRAGMA journal_mode=WAL")
             self._local.conn = conn
         return conn
+
+    def init_schema(self) -> None:
+        """Idempotently (re)create this store's tables. Satisfies the shared
+        :class:`agent_bom.storage.base.TenantScopedStore` contract."""
+        self._init_db()
 
     def _init_db(self) -> None:
         c = self._conn

--- a/src/agent_bom/api/postgres_cost.py
+++ b/src/agent_bom/api/postgres_cost.py
@@ -24,6 +24,11 @@ class PostgresCostStore:
         self._pool = pool or _get_pool()
         self._init_tables()
 
+    def init_schema(self) -> None:
+        """Idempotently (re)create this store's tables. Satisfies the shared
+        :class:`agent_bom.storage.base.TenantScopedStore` contract."""
+        self._init_tables()
+
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
             ensure_postgres_schema_version(conn, "llm_costs")

--- a/src/agent_bom/api/postgres_policy.py
+++ b/src/agent_bom/api/postgres_policy.py
@@ -26,6 +26,11 @@ class PostgresPolicyStore:
         self._pool = pool or _get_pool()
         self._init_tables()
 
+    def init_schema(self) -> None:
+        """Idempotently (re)create this store's tables. Satisfies the shared
+        :class:`agent_bom.storage.base.TenantScopedStore` contract."""
+        self._init_tables()
+
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
             ensure_postgres_schema_version(conn, "gateway_policies")
@@ -71,9 +76,7 @@ class PostgresPolicyStore:
                 END
                 $$;
             """)
-            conn.execute(
-                "CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_audit_log_entry ON policy_audit_log(entry_id)"
-            )
+            conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_audit_log_entry ON policy_audit_log(entry_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_gateway_policies_team ON gateway_policies(team_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_policy_audit_log_team_ts ON policy_audit_log(team_id, ts DESC)")
             _ensure_tenant_rls(conn, "gateway_policies", "team_id")

--- a/src/agent_bom/api/postgres_runtime_event.py
+++ b/src/agent_bom/api/postgres_runtime_event.py
@@ -34,6 +34,11 @@ class PostgresRuntimeEventStore:
         self._pool = pool or _get_pool()
         self._init_tables()
 
+    def init_schema(self) -> None:
+        """Idempotently (re)create this store's tables. Satisfies the shared
+        :class:`agent_bom.storage.base.TenantScopedStore` contract."""
+        self._init_tables()
+
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
             ensure_postgres_schema_version(conn, "runtime_events")

--- a/src/agent_bom/api/proxy_replay_store.py
+++ b/src/agent_bom/api/proxy_replay_store.py
@@ -71,6 +71,11 @@ class InMemoryProxyReplayStore:
         self._rows: list[dict[str, Any]] = []
         self._lock = threading.Lock()
 
+    def init_schema(self) -> None:
+        """No-op: the in-memory backend has no persistent schema. Present so the
+        in-memory store satisfies the shared
+        :class:`agent_bom.storage.base.TenantScopedStore` contract."""
+
     def add(
         self,
         tenant_id: str,
@@ -135,6 +140,11 @@ class SQLiteProxyReplayStore:
             self._local.conn.execute("PRAGMA journal_mode=WAL")
         conn: sqlite3.Connection = self._local.conn
         return conn
+
+    def init_schema(self) -> None:
+        """Idempotently (re)create this store's table. Satisfies the shared
+        :class:`agent_bom.storage.base.TenantScopedStore` contract."""
+        self._init_db()
 
     def _init_db(self) -> None:
         from agent_bom.api.storage_schema import ensure_sqlite_schema_version
@@ -217,6 +227,11 @@ class PostgresProxyReplayStore:
         from agent_bom.api.postgres_common import _get_pool
 
         self._pool = pool or _get_pool()
+        self._init_tables()
+
+    def init_schema(self) -> None:
+        """Idempotently (re)create this store's table. Satisfies the shared
+        :class:`agent_bom.storage.base.TenantScopedStore` contract."""
         self._init_tables()
 
     def _init_tables(self) -> None:
@@ -325,16 +340,20 @@ def get_proxy_replay_store() -> ProxyReplayStore:
       3. neither -> in-memory
     """
 
+    from agent_bom.storage.base import BackendKind
+    from agent_bom.storage.factory import resolve_backend
+
     global _REPLAY_STORE
     if _REPLAY_STORE is not None:
         return _REPLAY_STORE
     with _REPLAY_LOCK:
         if _REPLAY_STORE is not None:
             return _REPLAY_STORE
-        if os.environ.get("AGENT_BOM_POSTGRES_URL"):
+        selection = resolve_backend(mode="env")
+        if selection.backend is BackendKind.POSTGRES:
             _REPLAY_STORE = PostgresProxyReplayStore()
-        elif os.environ.get("AGENT_BOM_DB"):
-            _REPLAY_STORE = SQLiteProxyReplayStore(os.environ["AGENT_BOM_DB"])
+        elif selection.backend is BackendKind.SQLITE and selection.sqlite_path:
+            _REPLAY_STORE = SQLiteProxyReplayStore(selection.sqlite_path)
         else:
             _REPLAY_STORE = InMemoryProxyReplayStore()
     return _REPLAY_STORE

--- a/src/agent_bom/api/runtime_event_store.py
+++ b/src/agent_bom/api/runtime_event_store.py
@@ -151,6 +151,11 @@ class InMemoryRuntimeEventStore:
         self._sessions: dict[tuple[str, str], RuntimeSessionRecord] = {}
         self._lock = threading.Lock()
 
+    def init_schema(self) -> None:
+        """No-op: the in-memory backend has no persistent schema. Present so the
+        in-memory store satisfies the shared
+        :class:`agent_bom.storage.base.TenantScopedStore` contract."""
+
     def put_observation(self, record: RuntimeObservationRecord) -> None:
         key = (record.tenant_id, record.observation_id)
         session_key = (record.tenant_id, record.session_id)
@@ -199,6 +204,11 @@ class SQLiteRuntimeEventStore:
             self._local.conn.execute("PRAGMA journal_mode=WAL")
         conn: sqlite3.Connection = self._local.conn
         return conn
+
+    def init_schema(self) -> None:
+        """Idempotently (re)create this store's tables. Satisfies the shared
+        :class:`agent_bom.storage.base.TenantScopedStore` contract."""
+        self._init_db()
 
     def _init_db(self) -> None:
         ensure_sqlite_schema_version(self._conn, "runtime_events")
@@ -371,17 +381,21 @@ def get_runtime_event_store() -> RuntimeEventStore:
     global _RUNTIME_EVENT_STORE
     if _RUNTIME_EVENT_STORE is not None:
         return _RUNTIME_EVENT_STORE
-    from agent_bom.api.durable_store import select_backend, sqlite_path
+    from agent_bom.storage.base import BackendKind
+    from agent_bom.storage.factory import resolve_backend
 
-    backend = select_backend()
-    if backend == "postgres":
+    # mode="durable" preserves this store's durable-by-default ladder (the
+    # behaviour the old durable_store.select_backend() gave): Postgres →
+    # in-memory only on explicit ephemeral opt-out → durable SQLite default.
+    selection = resolve_backend(mode="durable")
+    if selection.backend is BackendKind.POSTGRES:
         from agent_bom.api.postgres_runtime_event import PostgresRuntimeEventStore
 
         _RUNTIME_EVENT_STORE = PostgresRuntimeEventStore()
-    elif backend == "memory":
+    elif selection.backend is BackendKind.MEMORY:
         _RUNTIME_EVENT_STORE = InMemoryRuntimeEventStore()
     else:
-        _RUNTIME_EVENT_STORE = SQLiteRuntimeEventStore(sqlite_path())
+        _RUNTIME_EVENT_STORE = SQLiteRuntimeEventStore(selection.sqlite_path or "")
     return _RUNTIME_EVENT_STORE
 
 

--- a/src/agent_bom/storage/__init__.py
+++ b/src/agent_bom/storage/__init__.py
@@ -1,0 +1,48 @@
+"""Shared storage foundation for agent-bom control-plane stores.
+
+Historically every control-plane store (cost, policy, runtime-event, proxy
+replay, …) reimplemented its own SQLite + Postgres + in-memory triad with no
+shared contract. Backend selection was duplicated three different ways
+(``os.environ`` checks in ``cost_store`` / ``proxy_replay_store`` vs
+``durable_store.select_backend()`` in ``runtime_event_store``), and each store
+hand-rolled its DDL twice — which is exactly how the SQLite⇄Postgres column /
+timestamp / dedup drift a prior audit caught crept in.
+
+This package gives those stores one shared seam:
+
+* :mod:`agent_bom.storage.base` — the structural :class:`~typing.Protocol`
+  family each store family already satisfies, plus the :class:`BackendKind`
+  vocabulary and the :class:`StorageSchema` source-of-truth-schema seam so a
+  store's table shape is declared once and shared across backends.
+* :mod:`agent_bom.storage.factory` — :func:`~agent_bom.storage.factory.resolve_backend`,
+  the single place backend selection from a DSN / environment lives, so adding
+  a new backend (MySQL, ClickHouse, …) is a registration rather than a fork of
+  every store.
+
+The foundation is **additive**: existing stores declare conformance and route
+their selection through the factory, but every method signature, table shape,
+and the #21 idempotency / caller-supplied-timestamp guarantees stay exactly as
+they were.
+"""
+
+from __future__ import annotations
+
+from agent_bom.storage.base import (
+    BackendKind,
+    CleanupCapable,
+    StorageSchema,
+    TenantScopedStore,
+)
+from agent_bom.storage.factory import (
+    BackendSelection,
+    resolve_backend,
+)
+
+__all__ = [
+    "BackendKind",
+    "BackendSelection",
+    "CleanupCapable",
+    "StorageSchema",
+    "TenantScopedStore",
+    "resolve_backend",
+]

--- a/src/agent_bom/storage/base.py
+++ b/src/agent_bom/storage/base.py
@@ -1,0 +1,144 @@
+"""Shared store contracts and the portable-schema seam.
+
+The control-plane stores fall into a small *family* of shapes — they are not
+one mega-interface (a cost record is not a runtime observation), so forcing all
+of them through a single class would lie about the contract. Instead this module
+captures the handful of things they genuinely share:
+
+* every durable store is **tenant-scoped** (every read / write takes or filters
+  by a tenant id) and knows how to **initialise its own schema** —
+  :class:`TenantScopedStore`;
+* some stores additionally support **TTL / retention cleanup** —
+  :class:`CleanupCapable`.
+
+These are :class:`~typing.Protocol`\\s with ``runtime_checkable`` so a store can
+*declare* conformance structurally (no inheritance, no import cycles) and the
+conformance test can assert it with ``isinstance``.
+
+The :class:`StorageSchema` dataclass is the **portable-schema seam**: a store
+declares its table contract once (logical columns + per-backend DDL), so the
+SQLite and Postgres definitions are reviewed side by side and cannot silently
+drift apart again. :data:`BackendKind` is the shared vocabulary the factory and
+the stores agree on.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+
+class BackendKind(str, Enum):
+    """The storage tiers every control-plane store family supports.
+
+    ``str``-valued so it round-trips through env / DSN parsing and JSON status
+    surfaces without extra conversion. The values match the strings
+    :func:`agent_bom.api.durable_store.select_backend` already returns, so the
+    factory and the legacy selector speak the same language.
+    """
+
+    SQLITE = "sqlite"
+    POSTGRES = "postgres"
+    MEMORY = "memory"
+
+
+@runtime_checkable
+class TenantScopedStore(Protocol):
+    """Structural contract shared by every durable control-plane store.
+
+    A conforming store can (re)create its own schema idempotently via
+    :meth:`init_schema` and isolates rows by tenant on every read/write. The
+    concrete record types differ per store family, so the read/write methods are
+    intentionally *not* pinned here — this protocol captures only the universal
+    seam (schema bootstrap + tenant scoping marker) that lets the factory and
+    the conformance test treat any backend uniformly.
+    """
+
+    def init_schema(self) -> None:
+        """Idempotently create tables / indexes for this store's backend."""
+        ...
+
+
+@runtime_checkable
+class CleanupCapable(Protocol):
+    """Stores that expire rows on a TTL / retention tick.
+
+    Mirrors the ``cleanup_expired`` / ``cleanup_audit_log`` methods the replay
+    and policy-audit stores already expose, surfaced as a shared capability so
+    the lifecycle tick can treat any cleanup-capable backend uniformly.
+    """
+
+    def cleanup_expired(self) -> int:
+        """Delete expired rows; return the number removed."""
+        ...
+
+
+@dataclass(frozen=True)
+class TableSchema:
+    """One table's portable definition: logical columns + per-backend DDL.
+
+    ``columns`` is the backend-agnostic logical column list (the source of truth
+    a reviewer reads). ``ddl_by_backend`` maps a :class:`BackendKind` value to
+    the exact ``CREATE TABLE`` statement that realises those columns on that
+    backend. Keeping both next to each other is the whole point of the seam: a
+    column added to ``columns`` but missing from one backend's DDL is visible in
+    one place instead of buried in two files.
+    """
+
+    name: str
+    columns: tuple[str, ...]
+    ddl_by_backend: Mapping[str, str] = field(default_factory=dict)
+
+    def ddl_for(self, backend: BackendKind | str) -> str | None:
+        """Return the ``CREATE TABLE`` statement for ``backend`` if declared."""
+        key = backend.value if isinstance(backend, BackendKind) else str(backend)
+        return self.ddl_by_backend.get(key)
+
+
+@dataclass(frozen=True)
+class StorageSchema:
+    """A store's full table contract, declared once and shared across backends.
+
+    This is the reference implementation of the portable-schema seam (see the
+    ``llm_costs`` reference in :mod:`agent_bom.api.cost_store`). It does not
+    *execute* DDL — the stores keep their existing, audited ``_init_db`` /
+    ``_init_tables`` paths — it makes the contract *inspectable* so:
+
+    * a conformance / parity test can assert the SQLite and Postgres DDL cover
+      the same logical columns, catching drift at test time, and
+    * a new backend is added by registering one more entry in ``ddl_by_backend``
+      rather than forking a store.
+    """
+
+    component: str
+    tables: tuple[TableSchema, ...]
+
+    def table(self, name: str) -> TableSchema | None:
+        for t in self.tables:
+            if t.name == name:
+                return t
+        return None
+
+    def backends(self) -> frozenset[str]:
+        """Every backend any table in this schema declares DDL for."""
+        out: set[str] = set()
+        for t in self.tables:
+            out.update(t.ddl_by_backend.keys())
+        return frozenset(out)
+
+    def drift_report(self) -> dict[str, list[str]]:
+        """Map each table to the backends missing a DDL definition.
+
+        Empty dict ⇒ every table defines DDL for every backend the schema
+        mentions (no drift). Used by the conformance test to fail loudly the
+        moment a column/table lands on one backend but not its sibling.
+        """
+        declared = self.backends()
+        report: dict[str, list[str]] = {}
+        for t in self.tables:
+            missing = sorted(declared - set(t.ddl_by_backend.keys()))
+            if missing:
+                report[t.name] = missing
+        return report

--- a/src/agent_bom/storage/factory.py
+++ b/src/agent_bom/storage/factory.py
@@ -1,0 +1,145 @@
+"""Single source of truth for storage-backend selection.
+
+Before this module, three stores each decided their backend by hand:
+
+* ``cost_store.get_cost_store`` and ``proxy_replay_store.get_proxy_replay_store``
+  branched on ``AGENT_BOM_POSTGRES_URL`` then ``AGENT_BOM_DB`` then in-memory;
+* ``runtime_event_store`` delegated to ``durable_store.select_backend()`` (which
+  is durable-by-default: SQLite unless an explicit ephemeral opt-out).
+
+Two subtly different precedence ladders for the same decision is exactly how a
+store ends up on the wrong tier. :func:`resolve_backend` centralises the choice
+and can resolve from either an explicit DSN (``sqlite://…`` / ``postgresql://…``
+/ ``memory://``) or the process environment, returning a typed
+:class:`BackendSelection`. Both legacy ladders are preserved as named modes so
+no store changes tier:
+
+* ``mode="env"`` (default) reproduces the cost/replay ladder exactly:
+  Postgres → SQLite(``AGENT_BOM_DB``) → in-memory.
+* ``mode="durable"`` reproduces ``durable_store.select_backend()``:
+  Postgres → in-memory(only on explicit ephemeral opt-out) → durable SQLite.
+
+Adding a backend (MySQL, ClickHouse, …) becomes a new scheme registered here,
+not a fourth bespoke ladder copied into a store.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from agent_bom.storage.base import BackendKind
+
+# DSN scheme → backend tier. Adding a backend registers one entry here instead
+# of forking a store's selection logic.
+_SCHEME_TO_BACKEND: dict[str, BackendKind] = {
+    "sqlite": BackendKind.SQLITE,
+    "file": BackendKind.SQLITE,
+    "postgres": BackendKind.POSTGRES,
+    "postgresql": BackendKind.POSTGRES,
+    "memory": BackendKind.MEMORY,
+    "inmemory": BackendKind.MEMORY,
+}
+
+
+@dataclass(frozen=True)
+class BackendSelection:
+    """The resolved backend tier plus the SQLite path (when applicable).
+
+    ``sqlite_path`` is populated only for :attr:`BackendKind.SQLITE`; it is the
+    file path a ``SQLite*Store`` should open. ``dsn`` carries the originating
+    Postgres URL when selection came from an explicit DSN (``None`` when the
+    store reads its URL from the pool/env itself, matching today's behaviour).
+    """
+
+    backend: BackendKind
+    sqlite_path: str | None = None
+    dsn: str | None = None
+
+
+def _is_postgres_url(value: str) -> bool:
+    return value.strip().lower().startswith(("postgres://", "postgresql://"))
+
+
+def _scheme(value: str) -> str | None:
+    head, sep, _ = value.partition("://")
+    return head.strip().lower() if sep else None
+
+
+def resolve_from_dsn(dsn: str) -> BackendSelection:
+    """Resolve a backend from an explicit DSN string.
+
+    ``sqlite:///path/to.db`` / ``file:///path`` → SQLite at that path,
+    ``postgresql://…`` / ``postgres://…`` → Postgres, ``memory://`` → in-memory.
+    A bare filesystem path (no ``://``) is treated as a SQLite file, matching
+    how ``AGENT_BOM_DB`` accepts a plain path today.
+    """
+    scheme = _scheme(dsn)
+    if scheme is None:
+        # Bare path → SQLite file (AGENT_BOM_DB-style).
+        return BackendSelection(BackendKind.SQLITE, sqlite_path=dsn)
+    backend = _SCHEME_TO_BACKEND.get(scheme)
+    if backend is None:
+        raise ValueError(f"unsupported storage DSN scheme: {scheme!r}")
+    if backend is BackendKind.SQLITE:
+        # Strip the scheme; tolerate sqlite:///abs and sqlite://rel forms.
+        _, _, rest = dsn.partition("://")
+        path = rest.lstrip("/") if rest.startswith("/") else rest
+        # sqlite:///abs/path keeps the leading slash; re-add it for triple-slash.
+        if dsn.lower().startswith(("sqlite:///", "file:///")):
+            path = "/" + path
+        return BackendSelection(BackendKind.SQLITE, sqlite_path=path or ":memory:")
+    if backend is BackendKind.POSTGRES:
+        return BackendSelection(BackendKind.POSTGRES, dsn=dsn)
+    return BackendSelection(BackendKind.MEMORY)
+
+
+def _resolve_from_env_durable() -> BackendSelection:
+    """Durable-by-default ladder (matches ``durable_store.select_backend``)."""
+    from agent_bom.api import durable_store
+
+    backend = durable_store.select_backend()
+    if backend == "postgres":
+        return BackendSelection(BackendKind.POSTGRES)
+    if backend == "memory":
+        return BackendSelection(BackendKind.MEMORY)
+    return BackendSelection(BackendKind.SQLITE, sqlite_path=durable_store.sqlite_path())
+
+
+def _resolve_from_env_simple() -> BackendSelection:
+    """Postgres → SQLite(AGENT_BOM_DB) → in-memory (cost/replay ladder)."""
+    if os.environ.get("AGENT_BOM_POSTGRES_URL"):
+        return BackendSelection(BackendKind.POSTGRES)
+    db = os.environ.get("AGENT_BOM_DB")
+    if db:
+        if _is_postgres_url(db):
+            return BackendSelection(BackendKind.POSTGRES, dsn=db)
+        return BackendSelection(BackendKind.SQLITE, sqlite_path=db)
+    return BackendSelection(BackendKind.MEMORY)
+
+
+def resolve_backend(dsn_or_env: str | None = None, *, mode: str = "env") -> BackendSelection:
+    """Resolve which storage backend a store should use.
+
+    Args:
+        dsn_or_env: An explicit DSN (``sqlite://…`` / ``postgresql://…`` /
+            ``memory://`` / bare path). When ``None`` (the common case) the
+            process environment is consulted instead.
+        mode: Which environment ladder to apply when ``dsn_or_env`` is ``None``:
+
+            * ``"env"`` (default) — Postgres → SQLite(``AGENT_BOM_DB``) →
+              in-memory. The ladder ``cost_store`` / ``proxy_replay_store`` use.
+            * ``"durable"`` — durable-by-default (Postgres → in-memory only on
+              explicit ``AGENT_BOM_EPHEMERAL_STORE`` → SQLite). The ladder
+              ``runtime_event_store`` uses.
+
+    Returns:
+        A :class:`BackendSelection` naming the tier and, for SQLite, the path.
+    """
+    if dsn_or_env is not None:
+        return resolve_from_dsn(dsn_or_env)
+    if mode == "durable":
+        return _resolve_from_env_durable()
+    if mode == "env":
+        return _resolve_from_env_simple()
+    raise ValueError(f"unknown backend resolution mode: {mode!r}")

--- a/tests/test_storage_foundation.py
+++ b/tests/test_storage_foundation.py
@@ -1,0 +1,287 @@
+"""Conformance tests for the shared storage foundation.
+
+Proves the additive storage seam holds: every backend of every wired store
+family (SQLite, Postgres-fake, in-memory) structurally satisfies the shared
+:class:`~agent_bom.storage.base.TenantScopedStore` protocol and survives a
+round-trip; the reference :class:`~agent_bom.storage.base.StorageSchema` has no
+SQLite⇄Postgres drift; and the backend factory resolves every DSN / env ladder
+the wired stores rely on without changing any store's tier.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.api.cost_store import (
+    COST_STORAGE_SCHEMA,
+    CostBudget,
+    InMemoryCostStore,
+    LLMCostRecord,
+    SQLiteCostStore,
+)
+from agent_bom.api.policy_store import InMemoryPolicyStore, SQLitePolicyStore
+from agent_bom.api.proxy_replay_store import InMemoryProxyReplayStore, SQLiteProxyReplayStore
+from agent_bom.api.runtime_event_store import (
+    InMemoryRuntimeEventStore,
+    RuntimeObservationRecord,
+    SQLiteRuntimeEventStore,
+)
+from agent_bom.storage.base import (
+    BackendKind,
+    CleanupCapable,
+    StorageSchema,
+    TenantScopedStore,
+)
+from agent_bom.storage.factory import resolve_backend, resolve_from_dsn
+
+# ── Protocol conformance: every backend declares init_schema (TenantScopedStore) ─
+
+
+def _sqlite_backends(tmp_path):
+    db = str(tmp_path / "conformance.db")
+    return [
+        SQLiteCostStore(db),
+        SQLitePolicyStore(db),
+        SQLiteRuntimeEventStore(db),
+        SQLiteProxyReplayStore(db),
+    ]
+
+
+def _inmemory_backends():
+    return [
+        InMemoryCostStore(),
+        InMemoryPolicyStore(),
+        InMemoryRuntimeEventStore(),
+        InMemoryProxyReplayStore(),
+    ]
+
+
+def test_inmemory_stores_satisfy_tenant_scoped_protocol():
+    for store in _inmemory_backends():
+        assert isinstance(store, TenantScopedStore), store
+
+
+def test_sqlite_stores_satisfy_tenant_scoped_protocol(tmp_path):
+    for store in _sqlite_backends(tmp_path):
+        assert isinstance(store, TenantScopedStore), store
+
+
+def test_postgres_stores_declare_init_schema():
+    # The Postgres backends require a live pool to instantiate, so assert the
+    # contract structurally on the class instead: every Postgres store exposes
+    # init_schema so it satisfies TenantScopedStore once constructed.
+    from agent_bom.api.postgres_cost import PostgresCostStore
+    from agent_bom.api.postgres_policy import PostgresPolicyStore
+    from agent_bom.api.postgres_runtime_event import PostgresRuntimeEventStore
+    from agent_bom.api.proxy_replay_store import PostgresProxyReplayStore
+
+    for cls in (PostgresCostStore, PostgresPolicyStore, PostgresRuntimeEventStore, PostgresProxyReplayStore):
+        assert callable(getattr(cls, "init_schema", None)), cls
+
+
+def test_replay_store_is_cleanup_capable():
+    # The TTL-driven replay backends additionally satisfy CleanupCapable.
+    assert isinstance(InMemoryProxyReplayStore(), CleanupCapable)
+
+
+def test_init_schema_is_idempotent(tmp_path):
+    # Calling init_schema twice must not raise (CREATE TABLE IF NOT EXISTS).
+    for store in [*_sqlite_backends(tmp_path), *_inmemory_backends()]:
+        store.init_schema()
+        store.init_schema()
+
+
+# ── Round-trip smoke test per backend (write then read back) ──────────────────
+
+
+def _roundtrip_cost(store) -> None:
+    store.record_cost(
+        LLMCostRecord(
+            tenant_id="t1",
+            call_id="c1",
+            agent="a",
+            session_id="s",
+            provider="openai",
+            model="gpt-4o",
+            input_tokens=10,
+            output_tokens=5,
+            cost_usd=1.5,
+            priced=True,
+            observed_at="2026-01-01T00:00:00Z",
+        )
+    )
+    # Idempotency (#21): re-recording the same call_id must not duplicate.
+    store.record_cost(
+        LLMCostRecord(
+            tenant_id="t1",
+            call_id="c1",
+            agent="a",
+            session_id="s",
+            provider="openai",
+            model="gpt-4o",
+            input_tokens=10,
+            output_tokens=5,
+            cost_usd=1.5,
+            priced=True,
+            observed_at="2026-01-01T00:00:00Z",
+        )
+    )
+    records = store.list_records("t1")
+    assert len(records) == 1
+    assert records[0].cost_usd == 1.5
+    store.set_budget(CostBudget(tenant_id="t1", agent="", limit_usd=10.0, updated_at="2026-01-01T00:00:00Z"))
+    assert store.get_budget("t1", "").limit_usd == 10.0
+
+
+def _roundtrip_runtime(store) -> None:
+    store.put_observation(
+        RuntimeObservationRecord(
+            tenant_id="t1",
+            observation_id="o1",
+            session_id="sess1",
+            observed_at="2026-01-01T00:00:00Z",
+        )
+    )
+    # Idempotency: same observation_id is a no-op.
+    store.put_observation(
+        RuntimeObservationRecord(
+            tenant_id="t1",
+            observation_id="o1",
+            session_id="sess1",
+            observed_at="2026-01-01T00:00:00Z",
+        )
+    )
+    obs = store.list_observations("t1")
+    assert len(obs) == 1
+    session = store.get_session("t1", "sess1")
+    assert session is not None and session.observation_count == 1
+
+
+def _roundtrip_replay(store) -> None:
+    row_id = store.add("t1", {"k": "v"})
+    assert row_id
+    rows = store.list("t1")
+    assert len(rows) == 1
+    assert rows[0]["record"] == {"k": "v"}
+    assert store.count("t1") == 1
+
+
+def test_roundtrip_cost_inmemory_and_sqlite(tmp_path):
+    _roundtrip_cost(InMemoryCostStore())
+    _roundtrip_cost(SQLiteCostStore(str(tmp_path / "cost.db")))
+
+
+def test_roundtrip_runtime_inmemory_and_sqlite(tmp_path):
+    _roundtrip_runtime(InMemoryRuntimeEventStore())
+    _roundtrip_runtime(SQLiteRuntimeEventStore(str(tmp_path / "rt.db")))
+
+
+def test_roundtrip_replay_inmemory_and_sqlite(tmp_path):
+    _roundtrip_replay(InMemoryProxyReplayStore())
+    _roundtrip_replay(SQLiteProxyReplayStore(str(tmp_path / "replay.db")))
+
+
+# ── Portable-schema seam: no SQLite⇄Postgres drift in the reference schema ─────
+
+
+def test_reference_schema_has_no_backend_drift():
+    # Every table in the reference schema must define DDL for every backend the
+    # schema declares — the seam's whole point is that a column landing on one
+    # backend but not its sibling is a test failure, not a silent prod drift.
+    assert COST_STORAGE_SCHEMA.drift_report() == {}
+
+
+def test_reference_schema_covers_sqlite_and_postgres():
+    assert COST_STORAGE_SCHEMA.backends() == frozenset({"sqlite", "postgres"})
+    for table in COST_STORAGE_SCHEMA.tables:
+        # The same logical columns must appear in both backends' DDL text.
+        sqlite_ddl = table.ddl_for(BackendKind.SQLITE)
+        pg_ddl = table.ddl_for(BackendKind.POSTGRES)
+        assert sqlite_ddl and pg_ddl
+        for column in table.columns:
+            assert column in sqlite_ddl, (table.name, column, "sqlite")
+            assert column in pg_ddl, (table.name, column, "postgres")
+
+
+def test_reference_schema_lookup_helpers():
+    assert COST_STORAGE_SCHEMA.table("llm_costs") is not None
+    assert COST_STORAGE_SCHEMA.table("nonexistent") is None
+
+
+# ── Backend factory: DSN + env ladders resolve without changing store tiers ────
+
+
+@pytest.mark.parametrize(
+    "dsn,expected",
+    [
+        ("memory://", BackendKind.MEMORY),
+        ("postgresql://user@host/db", BackendKind.POSTGRES),
+        ("postgres://user@host/db", BackendKind.POSTGRES),
+        ("sqlite:///abs/path.db", BackendKind.SQLITE),
+        ("/bare/path.db", BackendKind.SQLITE),
+    ],
+)
+def test_resolve_from_dsn(dsn, expected):
+    assert resolve_from_dsn(dsn).backend is expected
+
+
+def test_resolve_from_dsn_sqlite_path():
+    assert resolve_from_dsn("sqlite:///abs/path.db").sqlite_path == "/abs/path.db"
+    assert resolve_from_dsn("/bare/path.db").sqlite_path == "/bare/path.db"
+
+
+def test_resolve_from_dsn_postgres_carries_dsn():
+    sel = resolve_from_dsn("postgresql://u@h/d")
+    assert sel.backend is BackendKind.POSTGRES
+    assert sel.dsn == "postgresql://u@h/d"
+
+
+def test_resolve_from_dsn_rejects_unknown_scheme():
+    with pytest.raises(ValueError):
+        resolve_from_dsn("mysql://u@h/d")
+
+
+def test_env_simple_ladder(monkeypatch):
+    # Postgres URL wins.
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://u@h/d")
+    assert resolve_backend(mode="env").backend is BackendKind.POSTGRES
+    # SQLite file path next.
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
+    monkeypatch.setenv("AGENT_BOM_DB", "/tmp/x.db")
+    sel = resolve_backend(mode="env")
+    assert sel.backend is BackendKind.SQLITE
+    assert sel.sqlite_path == "/tmp/x.db"
+    # AGENT_BOM_DB holding a Postgres URL resolves to Postgres.
+    monkeypatch.setenv("AGENT_BOM_DB", "postgresql://u@h/d")
+    assert resolve_backend(mode="env").backend is BackendKind.POSTGRES
+    # Nothing set → in-memory.
+    monkeypatch.delenv("AGENT_BOM_DB", raising=False)
+    assert resolve_backend(mode="env").backend is BackendKind.MEMORY
+
+
+def test_env_durable_ladder(monkeypatch, tmp_path):
+    # Durable-by-default: no config → durable SQLite under the state dir.
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(tmp_path))
+    monkeypatch.delenv("AGENT_BOM_EPHEMERAL_STORE", raising=False)
+    monkeypatch.delenv("AGENT_BOM_DB", raising=False)
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
+    sel = resolve_backend(mode="durable")
+    assert sel.backend is BackendKind.SQLITE
+    assert sel.sqlite_path
+    # Explicit ephemeral opt-out → in-memory.
+    monkeypatch.setenv("AGENT_BOM_EPHEMERAL_STORE", "1")
+    assert resolve_backend(mode="durable").backend is BackendKind.MEMORY
+    # Postgres always wins over the ephemeral opt-out.
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://u@h/d")
+    assert resolve_backend(mode="durable").backend is BackendKind.POSTGRES
+
+
+def test_resolve_backend_rejects_unknown_mode():
+    with pytest.raises(ValueError):
+        resolve_backend(mode="bogus")
+
+
+def test_storage_schema_is_frozen():
+    schema = StorageSchema(component="x", tables=())
+    with pytest.raises(Exception):
+        schema.component = "y"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Gives the control-plane stores one shared storage contract so SQLite, Postgres,
and in-memory backends can no longer drift apart. Previously every store
(`cost_store`, `policy_store`, `runtime_event_store`, `proxy_replay_store`)
reimplemented its SQLite + Postgres + in-memory triad standalone, hand-rolling
DDL twice and deciding its backend with three subtly different env ladders —
the exact pattern that allowed prior SQLite⇄Postgres column / timestamp / dedup
drift.

The change is **additive**: every method signature, table/column shape, and the
existing ON CONFLICT dedup + caller-supplied-timestamp guarantees stay exactly
as they were.

## What's new

New `src/agent_bom/storage/` package:

- **`base.py`** — a small *family* of structural `Protocol`s rather than one
  mega-interface: `TenantScopedStore` (idempotent `init_schema` + tenant
  scoping) and `CleanupCapable` (TTL retention). Plus the `BackendKind`
  vocabulary and `StorageSchema` — the portable-schema seam that declares a
  store's table contract once, with per-backend DDL side by side, and a
  `drift_report()` that flags any table missing a backend.
- **`factory.py`** — `resolve_backend(dsn_or_env, mode=...)`, the single place
  backend selection lives. Resolves from an explicit DSN (`sqlite://`,
  `postgresql://`, `memory://`, bare path) or one of two named env ladders that
  reproduce the existing behaviour exactly (`mode="env"` for cost/replay,
  `mode="durable"` for the durable-by-default runtime store). Adding a backend
  is a registration in `_SCHEME_TO_BACKEND`, not a fork of every store.

## Stores wired

- **cost** — selection routed through the factory; carries the reference
  `StorageSchema` mirroring its executed SQLite/Postgres DDL.
- **proxy replay** — selection routed through the factory; declares
  `CleanupCapable`.
- **runtime event** — selection routed through the factory (`mode="durable"`,
  preserving the durable-by-default ladder).
- **policy** — backends declare `init_schema` for protocol conformance
  (selection for this store lives outside the store module and is unchanged).

Every backend (SQLite, Postgres, in-memory) of each family declares
`init_schema`.

## Validation

- New `tests/test_storage_foundation.py` (23 tests): protocol conformance via
  `isinstance` for every in-memory + SQLite backend, a round-trip smoke test
  per backend (including idempotency re-writes), no SQLite⇄Postgres drift in
  the reference schema, and the factory's full DSN + env-ladder matrix.
- Full store suite green: `pytest -k "store or cost or policy or runtime or
  replay or storage or backend"` → 1457 passed (was 1434; +23 new), zero
  regressions. The one unrelated failure (`test_docker_base_policy`) pre-exists
  on the base branch and concerns Dockerfiles absent from this worktree.
- `ruff check` + `mypy` clean on all touched files.
