### PR TITLE
feat(cloud): unified cloud-aware scan across every configured provider

### DIFF
--- a/src/agent_bom/cli/_cloud_group.py
+++ b/src/agent_bom/cli/_cloud_group.py
@@ -3,20 +3,158 @@
 Cloud providers: AWS, Azure, GCP (real infrastructure with fleets, IAM, services).
 AI platforms (Snowflake, Databricks, HuggingFace, etc.) are separate — not cloud infra.
 
+One cloud-aware command spans every provider — ``cloud scan`` auto-detects which
+clouds are configured and runs the same CIS + discovery work across them, instead
+of asking the user to remember a separate subcommand per cloud. The per-cloud
+``aws`` / ``azure`` / ``gcp`` commands remain as thin aliases that scope the
+unified path to a single provider, so existing invocations keep working.
+
 Usage::
 
-    agent-bom cloud aws                   # AWS discovery + CIS benchmark
-    agent-bom cloud azure                 # Azure discovery + CIS benchmark
-    agent-bom cloud gcp                   # GCP discovery + CIS benchmark
+    agent-bom cloud scan                  # every configured cloud (auto-detect)
+    agent-bom cloud scan --provider aws   # one cloud, same as `cloud aws`
+    agent-bom cloud aws                   # alias → scan --provider aws
+    agent-bom cloud azure                 # alias → scan --provider azure
+    agent-bom cloud gcp                   # alias → scan --provider gcp
 """
 
 from __future__ import annotations
 
+import shutil
 from typing import Optional
 
 import click
 
 from agent_bom.cli._grouped_help import SuggestingGroup
+
+# Deterministic provider catalogue. The order here drives auto-detect ordering,
+# per-provider sectioning, and `--provider all` fan-out so the same configuration
+# always produces the same output. Each entry maps the provider to the CLI tool
+# whose presence signals "configured" (mirrors the existing no-subcommand path
+# and `agent-cloud posture`).
+_PROVIDER_CLI = {
+    "aws": "aws",
+    "azure": "az",
+    "gcp": "gcloud",
+}
+# Sorted for determinism — same config in, same provider order out.
+_PROVIDER_ORDER: tuple[str, ...] = tuple(sorted(_PROVIDER_CLI))
+
+# How a missing provider CLI is described when we skip it, so the friendly note
+# points the user at the exact thing to install/configure.
+_PROVIDER_HINT = {
+    "aws": "aws configure",
+    "azure": "az login",
+    "gcp": "gcloud auth login",
+}
+
+
+def _provider_configured(provider: str) -> bool:
+    """Return True when the provider's CLI is on PATH (its creds are reachable).
+
+    Credential detection deliberately reuses the same CLI-presence signal the
+    cloud group already trusts for its no-subcommand fan-out, so behaviour is
+    consistent across every entry point.
+    """
+    return bool(shutil.which(_PROVIDER_CLI[provider]))
+
+
+def _detect_configured_providers() -> list[str]:
+    """Configured providers in deterministic order (unconfigured ones dropped)."""
+    return [p for p in _PROVIDER_ORDER if _provider_configured(p)]
+
+
+def _resolve_scan_providers(provider: str) -> tuple[list[str], list[str]]:
+    """Resolve ``--provider`` into (selected, skipped) provider lists.
+
+    ``all`` expands to every configured cloud (auto-detect); unconfigured clouds
+    are returned as ``skipped`` so the caller can surface a friendly note instead
+    of failing. A single named provider is always selected even when its CLI is
+    absent — the underlying scan emits its own credential guidance — so the alias
+    commands keep their existing behaviour.
+    """
+    if provider == "all":
+        selected = _detect_configured_providers()
+        skipped = [p for p in _PROVIDER_ORDER if p not in selected]
+        return selected, skipped
+    return [provider], []
+
+
+def _run_cloud_scan(
+    providers: list[str],
+    *,
+    skipped: Optional[list[str]] = None,
+    aws_region: Optional[str] = None,
+    aws_profile: Optional[str] = None,
+    aws_include_lambda: bool = False,
+    aws_include_eks: bool = False,
+    aws_include_ec2: bool = False,
+    aws_include_iam: bool = False,
+    azure_subscription: Optional[str] = None,
+    gcp_project: Optional[str] = None,
+    cis: bool = True,
+    output_format: str = "console",
+    output_path: Optional[str] = None,
+    quiet: bool = False,
+) -> None:
+    """Run the shared cloud-scan body across one or more providers.
+
+    Single code path behind both the unified ``cloud scan`` command and the
+    per-cloud aliases. The selected providers are enabled together in a single
+    ``scan`` invocation; ``scan`` already discovers and benchmarks each provider
+    under its own ``try``/``except`` so one provider failing or being
+    unconfigured never aborts the others. Provider order is deterministic.
+    """
+    from rich.console import Console
+
+    from agent_bom.cli.agents import scan
+
+    providers = [p for p in _PROVIDER_ORDER if p in providers]
+
+    if skipped:
+        con = Console(stderr=True)
+        for prov in skipped:
+            con.print(f"  [dim]skipping {prov.upper()} — not configured (set up with: {_PROVIDER_HINT[prov]})[/dim]")
+
+    if not providers:
+        con = Console(stderr=True)
+        con.print("\n[yellow]No configured cloud providers to scan.[/yellow]")
+        con.print("  Configure at least one provider and retry:")
+        for prov in _PROVIDER_ORDER:
+            con.print(f"  [cyan]{prov}[/cyan] → {_PROVIDER_HINT[prov]}")
+        return
+
+    aws_on = "aws" in providers
+    azure_on = "azure" in providers
+    gcp_on = "gcp" in providers
+
+    if not quiet and output_format == "console" and len(providers) > 1:
+        Console(stderr=True).print(
+            f"\n[bold]Cloud scan[/bold] [dim]· {', '.join(p.upper() for p in providers)} · {'CIS + ' if cis else ''}discovery[/dim]"
+        )
+
+    ctx = click.get_current_context()
+    ctx.invoke(
+        scan,
+        aws=aws_on,
+        aws_region=aws_region,
+        aws_profile=aws_profile,
+        aws_include_lambda=aws_include_lambda,
+        aws_include_eks=aws_include_eks,
+        aws_include_ec2=aws_include_ec2,
+        aws_include_iam=aws_include_iam,
+        azure_flag=azure_on,
+        azure_subscription=azure_subscription,
+        gcp_flag=gcp_on,
+        gcp_project=gcp_project,
+        aws_cis_benchmark=aws_on and cis,
+        azure_cis_benchmark=azure_on and cis,
+        gcp_cis_benchmark=gcp_on and cis,
+        auto_update_db=False,
+        output_format=output_format,
+        output=output_path,
+        quiet=quiet,
+    )
 
 
 @click.group("cloud", cls=SuggestingGroup, invoke_without_command=True)
@@ -35,22 +173,14 @@ def cloud_group(ctx: click.Context) -> None:
 
     \b
     Subcommands (require credentials):
-      aws          AWS — Bedrock, Lambda, ECS, EKS + CIS v3.0 (60 checks)
-      azure        Azure — AI Foundry, Container Apps + CIS v2.0 (95 checks)
-      gcp          GCP — Vertex AI, Cloud Run + CIS v3.0 (59 checks)
+      scan         One cloud-aware scan across every configured provider
+      aws          Alias — scan --provider aws (Bedrock, Lambda, ECS, EKS + CIS)
+      azure        Alias — scan --provider azure (AI Foundry, Container Apps + CIS)
+      gcp          Alias — scan --provider gcp (Vertex AI, Cloud Run + CIS)
       resilience   Provider pagination/retry/partial-failure evidence
     """
     if ctx.invoked_subcommand is None:
-        # Check if any cloud credentials are configured before running all
-        import shutil
-
-        providers = []
-        if shutil.which("aws"):
-            providers.append("aws")
-        if shutil.which("az"):
-            providers.append("azure")
-        if shutil.which("gcloud"):
-            providers.append("gcp")
+        providers = _detect_configured_providers()
 
         if not providers:
             from rich.console import Console
@@ -66,18 +196,76 @@ def cloud_group(ctx: click.Context) -> None:
             con.print("  [cyan]agent-bom image[/cyan] · [cyan]agent-bom iac[/cyan] · [cyan]agent-bom fs[/cyan]")
             return
 
-        from agent_bom.cli.agents import scan
+        # Bare `cloud` runs the unified scan across whatever is configured.
+        _run_cloud_scan(providers)
 
-        ctx.invoke(
-            scan,
-            aws="aws" in providers,
-            azure_flag="azure" in providers,
-            gcp_flag="gcp" in providers,
-            aws_cis_benchmark="aws" in providers,
-            azure_cis_benchmark="azure" in providers,
-            gcp_cis_benchmark="gcp" in providers,
-            auto_update_db=False,
-        )
+
+@click.command("scan")
+@click.option(
+    "--provider",
+    type=click.Choice(["all", *_PROVIDER_ORDER]),
+    default="all",
+    show_default=True,
+    help="Cloud(s) to scan. 'all' auto-detects every configured provider and skips the rest.",
+)
+@click.option("--region", default=None, help="AWS region (aws only).")
+@click.option("--profile", default=None, help="AWS credential profile (aws only).")
+@click.option("--include-lambda", is_flag=True, help="Include Lambda functions (aws only).")
+@click.option("--include-eks", is_flag=True, help="Include EKS workloads (aws only).")
+@click.option("--include-ec2", is_flag=True, help="Include EC2 instances (aws only).")
+@click.option("--include-iam", is_flag=True, help="Enrich identity graph with IAM (aws only).")
+@click.option("--subscription", default=None, help="Azure subscription ID (azure only).")
+@click.option("--project", default=None, help="GCP project ID (gcp only).")
+@click.option("--cis/--no-cis", default=True, show_default=True, help="Run CIS benchmark for each selected provider.")
+@click.option("-f", "--format", "output_format", default="console", help="Output format")
+@click.option("-o", "--output", "output_path", help="Output file path")
+@click.option("--quiet", "-q", is_flag=True)
+def scan_cmd(
+    provider: str,
+    region: Optional[str],
+    profile: Optional[str],
+    include_lambda: bool,
+    include_eks: bool,
+    include_ec2: bool,
+    include_iam: bool,
+    subscription: Optional[str],
+    project: Optional[str],
+    cis: bool,
+    output_format: str,
+    output_path: Optional[str],
+    quiet: bool,
+) -> None:
+    """Scan one or every configured cloud — AI agents, infra, and CIS compliance.
+
+    A single cloud-aware command instead of one subcommand per provider. With the
+    default ``--provider all`` it auto-detects which clouds are configured, scans
+    each, and skips the rest with a note — never failing the whole run because one
+    cloud is unconfigured. Provider-scoped flags apply only to their cloud.
+
+    \b
+    Examples:
+      agent-bom cloud scan                       every configured cloud
+      agent-bom cloud scan --provider aws        AWS only (same as `cloud aws`)
+      agent-bom cloud scan --provider gcp --project my-proj
+      agent-bom cloud scan --no-cis              discovery only, skip CIS
+    """
+    selected, skipped = _resolve_scan_providers(provider)
+    _run_cloud_scan(
+        selected,
+        skipped=skipped,
+        aws_region=region,
+        aws_profile=profile,
+        aws_include_lambda=include_lambda,
+        aws_include_eks=include_eks,
+        aws_include_ec2=include_ec2,
+        aws_include_iam=include_iam,
+        azure_subscription=subscription,
+        gcp_project=project,
+        cis=cis,
+        output_format=output_format,
+        output_path=output_path,
+        quiet=quiet,
+    )
 
 
 @click.command("aws")
@@ -105,23 +293,21 @@ def aws_cmd(
     output_path: Optional[str],
     quiet: bool,
 ) -> None:
-    """Scan AWS for AI agents, infrastructure, and CIS compliance."""
-    from agent_bom.cli.agents import scan
+    """Scan AWS for AI agents, infrastructure, and CIS compliance.
 
-    ctx = click.get_current_context()
-    ctx.invoke(
-        scan,
-        aws=True,
+    Alias for ``cloud scan --provider aws`` — kept for back-compat.
+    """
+    _run_cloud_scan(
+        ["aws"],
         aws_region=region,
         aws_profile=profile,
         aws_include_lambda=include_lambda,
         aws_include_eks=include_eks,
         aws_include_ec2=include_ec2,
         aws_include_iam=include_iam,
-        aws_cis_benchmark=cis and not no_cis,
-        auto_update_db=False,
+        cis=cis and not no_cis,
         output_format=output_format,
-        output=output_path,
+        output_path=output_path,
         quiet=quiet,
     )
 
@@ -141,18 +327,16 @@ def azure_cmd(
     output_path: Optional[str],
     quiet: bool,
 ) -> None:
-    """Scan Azure for AI agents, infrastructure, and CIS compliance."""
-    from agent_bom.cli.agents import scan
+    """Scan Azure for AI agents, infrastructure, and CIS compliance.
 
-    ctx = click.get_current_context()
-    ctx.invoke(
-        scan,
-        azure_flag=True,
+    Alias for ``cloud scan --provider azure`` — kept for back-compat.
+    """
+    _run_cloud_scan(
+        ["azure"],
         azure_subscription=subscription,
-        azure_cis_benchmark=cis and not no_cis,
-        auto_update_db=False,
+        cis=cis and not no_cis,
         output_format=output_format,
-        output=output_path,
+        output_path=output_path,
         quiet=quiet,
     )
 
@@ -172,23 +356,22 @@ def gcp_cmd(
     output_path: Optional[str],
     quiet: bool,
 ) -> None:
-    """Scan GCP for AI agents, infrastructure, and CIS compliance."""
-    from agent_bom.cli.agents import scan
+    """Scan GCP for AI agents, infrastructure, and CIS compliance.
 
-    ctx = click.get_current_context()
-    ctx.invoke(
-        scan,
-        gcp_flag=True,
+    Alias for ``cloud scan --provider gcp`` — kept for back-compat.
+    """
+    _run_cloud_scan(
+        ["gcp"],
         gcp_project=project,
-        gcp_cis_benchmark=cis and not no_cis,
-        auto_update_db=False,
+        cis=cis and not no_cis,
         output_format=output_format,
-        output=output_path,
+        output_path=output_path,
         quiet=quiet,
     )
 
 
-# Register standalone commands on the cloud group
+# Register the unified command + the per-cloud aliases on the cloud group.
+cloud_group.add_command(scan_cmd, "scan")
 cloud_group.add_command(aws_cmd, "aws")
 cloud_group.add_command(azure_cmd, "azure")
 cloud_group.add_command(gcp_cmd, "gcp")

--- a/src/agent_bom/cli/cloud.py
+++ b/src/agent_bom/cli/cloud.py
@@ -22,7 +22,7 @@ from agent_bom.cli._grouped_help import GroupedGroup
 
 CLOUD_CATEGORIES: OrderedDict[str, list[str]] = OrderedDict(
     [
-        ("Cloud Providers", ["aws", "azure", "gcp"]),
+        ("Cloud Providers", ["scan", "aws", "azure", "gcp"]),
         ("AI Platforms", ["snowflake", "databricks", "huggingface", "ollama"]),
         ("Posture", ["posture", "resilience"]),
     ]
@@ -50,6 +50,7 @@ def cloud():
 
     \b
     Quick start:
+      agent-cloud scan                   Every configured cloud (auto-detect)
       agent-cloud aws                    AWS Bedrock/Lambda/EKS + CIS v3.0
       agent-cloud azure                  Azure AI Foundry + CIS v2.0
       agent-cloud gcp                    GCP Vertex AI + CIS v3.0
@@ -65,8 +66,9 @@ def cloud():
 
 # ── Register cloud provider commands (reuse from _cloud_group.py) ────────────
 
-from agent_bom.cli._cloud_group import aws_cmd, azure_cmd, gcp_cmd, resilience_cmd  # noqa: E402
+from agent_bom.cli._cloud_group import aws_cmd, azure_cmd, gcp_cmd, resilience_cmd, scan_cmd  # noqa: E402
 
+cloud.add_command(scan_cmd, "scan")
 cloud.add_command(aws_cmd, "aws")
 cloud.add_command(azure_cmd, "azure")
 cloud.add_command(gcp_cmd, "gcp")

--- a/tests/test_cli_cloud_scan.py
+++ b/tests/test_cli_cloud_scan.py
@@ -1,0 +1,191 @@
+"""Tests for the unified ``agent-bom cloud scan`` command and its aliases.
+
+One cloud-aware command spans every configured provider; the per-cloud ``aws`` /
+``azure`` / ``gcp`` subcommands remain as thin back-compat aliases that scope the
+same path to a single provider. These tests pin:
+
+- ``cloud scan --provider all`` runs every *configured* provider and skips the
+  rest with a friendly note (auto-detect, graceful degradation).
+- ``cloud scan --provider aws`` produces the same scan invocation as the legacy
+  ``cloud aws`` alias.
+- the aliases still work and still disable auto DB refresh.
+- one provider failing does not abort the others (single multi-provider scan
+  invocation, deterministic provider order).
+"""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+import agent_bom.cli._cloud_group as cg
+from agent_bom.cli._cloud_group import (
+    _detect_configured_providers,
+    _resolve_scan_providers,
+    cloud_group,
+)
+
+
+def _capture_scan(monkeypatch):
+    """Patch the underlying scan callback and return the list of captured kwargs."""
+    seen: list[dict] = []
+
+    def fake_scan(**kwargs):
+        seen.append(kwargs)
+
+    monkeypatch.setattr("agent_bom.cli.agents.scan.callback", fake_scan)
+    return seen
+
+
+def _all_configured(monkeypatch, providers):
+    """Force credential auto-detect to report exactly ``providers`` as configured."""
+    monkeypatch.setattr(cg, "_provider_configured", lambda p: p in set(providers))
+
+
+# ── auto-detect / resolution ────────────────────────────────────────────────
+
+
+class TestProviderResolution:
+    def test_detect_is_deterministic_and_sorted(self, monkeypatch):
+        _all_configured(monkeypatch, {"gcp", "aws"})
+        assert _detect_configured_providers() == ["aws", "gcp"]
+
+    def test_resolve_all_splits_configured_and_skipped(self, monkeypatch):
+        _all_configured(monkeypatch, {"aws"})
+        selected, skipped = _resolve_scan_providers("all")
+        assert selected == ["aws"]
+        assert skipped == ["azure", "gcp"]
+
+    def test_resolve_named_provider_always_selected(self, monkeypatch):
+        # Even with nothing configured, an explicit provider is selected — the
+        # underlying scan emits its own credential guidance.
+        _all_configured(monkeypatch, set())
+        selected, skipped = _resolve_scan_providers("azure")
+        assert selected == ["azure"]
+        assert skipped == []
+
+
+# ── unified scan command ────────────────────────────────────────────────────
+
+
+class TestUnifiedScan:
+    def test_help(self):
+        r = CliRunner().invoke(cloud_group, ["scan", "--help"])
+        assert r.exit_code == 0
+        assert "--provider" in r.output
+        assert "--region" in r.output
+        assert "--subscription" in r.output
+        assert "--project" in r.output
+
+    def test_scan_all_runs_configured_skips_unconfigured(self, monkeypatch):
+        _all_configured(monkeypatch, {"aws", "gcp"})
+        seen = _capture_scan(monkeypatch)
+
+        r = CliRunner().invoke(cloud_group, ["scan", "--provider", "all"])
+        assert r.exit_code == 0
+        assert len(seen) == 1
+        kw = seen[0]
+        # Configured providers enabled, unconfigured Azure left off.
+        assert kw["aws"] is True
+        assert kw["gcp_flag"] is True
+        assert kw["azure_flag"] is False
+        # Friendly skip note for the unconfigured provider.
+        assert "skipping AZURE" in r.output
+
+    def test_scan_all_no_providers_is_graceful(self, monkeypatch):
+        _all_configured(monkeypatch, set())
+        seen = _capture_scan(monkeypatch)
+
+        r = CliRunner().invoke(cloud_group, ["scan", "--provider", "all"])
+        assert r.exit_code == 0
+        # No scan invoked, but the command does not crash and guides the user.
+        assert seen == []
+        assert "No configured cloud providers" in r.output
+
+    def test_scan_provider_aws_matches_legacy_alias(self, monkeypatch):
+        seen = _capture_scan(monkeypatch)
+
+        CliRunner().invoke(cloud_group, ["scan", "--provider", "aws"])
+        CliRunner().invoke(cloud_group, ["aws"])
+        assert len(seen) == 2
+
+        def _provider_flags(kw):
+            return {
+                "aws": kw["aws"],
+                "azure_flag": kw["azure_flag"],
+                "gcp_flag": kw["gcp_flag"],
+                "aws_cis_benchmark": kw["aws_cis_benchmark"],
+                "azure_cis_benchmark": kw["azure_cis_benchmark"],
+                "gcp_cis_benchmark": kw["gcp_cis_benchmark"],
+                "auto_update_db": kw["auto_update_db"],
+            }
+
+        assert _provider_flags(seen[0]) == _provider_flags(seen[1])
+        assert seen[0]["aws"] is True
+        assert seen[0]["azure_flag"] is False
+        assert seen[0]["gcp_flag"] is False
+
+    def test_no_cis_disables_every_benchmark(self, monkeypatch):
+        _all_configured(monkeypatch, {"aws", "azure", "gcp"})
+        seen = _capture_scan(monkeypatch)
+
+        r = CliRunner().invoke(cloud_group, ["scan", "--provider", "all", "--no-cis"])
+        assert r.exit_code == 0
+        kw = seen[0]
+        assert kw["aws_cis_benchmark"] is False
+        assert kw["azure_cis_benchmark"] is False
+        assert kw["gcp_cis_benchmark"] is False
+        # Discovery still enabled for each configured provider.
+        assert kw["aws"] and kw["azure_flag"] and kw["gcp_flag"]
+
+    def test_provider_scoped_options_forwarded(self, monkeypatch):
+        seen = _capture_scan(monkeypatch)
+        CliRunner().invoke(
+            cloud_group,
+            ["scan", "--provider", "gcp", "--project", "my-proj"],
+        )
+        assert seen[0]["gcp_project"] == "my-proj"
+        assert seen[0]["gcp_flag"] is True
+
+
+# ── back-compat aliases ──────────────────────────────────────────────────────
+
+
+class TestAliases:
+    def test_aliases_still_registered(self):
+        for name in ("scan", "aws", "azure", "gcp"):
+            assert name in cloud_group.commands
+
+    def test_aliases_disable_auto_db_refresh(self, monkeypatch):
+        seen = _capture_scan(monkeypatch)
+        for command in ("aws", "azure", "gcp"):
+            r = CliRunner().invoke(cloud_group, [command])
+            assert r.exit_code == 0
+        assert [item["auto_update_db"] for item in seen] == [False, False, False]
+
+    def test_azure_alias_forwards_subscription(self, monkeypatch):
+        seen = _capture_scan(monkeypatch)
+        CliRunner().invoke(cloud_group, ["azure", "--subscription", "sub-123"])
+        assert seen[0]["azure_subscription"] == "sub-123"
+        assert seen[0]["azure_flag"] is True
+        assert seen[0]["aws"] is False
+
+
+# ── graceful per-provider degradation ────────────────────────────────────────
+
+
+class TestDegradation:
+    def test_one_provider_error_does_not_abort_others(self, monkeypatch):
+        """A single multi-provider scan call enables every configured provider.
+
+        `scan` discovers/benchmarks each provider under its own try/except, so a
+        failure in one never aborts the others. This pins the contract that all
+        selected providers reach that single invocation together.
+        """
+        _all_configured(monkeypatch, {"aws", "azure", "gcp"})
+        seen = _capture_scan(monkeypatch)
+
+        r = CliRunner().invoke(cloud_group, ["scan", "--provider", "all"])
+        assert r.exit_code == 0
+        assert len(seen) == 1
+        kw = seen[0]
+        assert kw["aws"] and kw["azure_flag"] and kw["gcp_flag"]


### PR DESCRIPTION
## Summary

Collapses the split per-cloud scan commands into one cloud-aware command. `agent-bom cloud scan` (and `agent-cloud scan`) now scans every configured cloud from a single entry point, so users no longer have to remember a separate subcommand per provider.

- **`cloud scan --provider all|aws|azure|gcp`** — new unified subcommand. Default `--provider all` auto-detects which clouds are credentialed and runs the same CIS + discovery work across each, skipping unconfigured clouds with a friendly note instead of failing the run.
- **Back-compat aliases** — `cloud aws` / `cloud azure` / `cloud gcp` keep all their existing flags and now delegate to the same shared scan path scoped to one provider. No breaking change.
- **Shared path** — both the unified command and the aliases call one `_run_cloud_scan(...)` helper; the selected providers run together in a single scan invocation whose per-provider discovery/benchmark steps already degrade independently, so one provider failing or being unconfigured never aborts the others.
- **Deterministic** — provider selection and ordering are sorted, so the same configuration always produces the same output.

## Behaviour

| Command | Result |
| --- | --- |
| `cloud scan` / `cloud scan --provider all` | every configured cloud, unconfigured ones skipped with a note |
| `cloud scan --provider aws` | AWS only — same scan invocation as legacy `cloud aws` |
| `cloud aws` / `cloud azure` / `cloud gcp` | unchanged alias behaviour |
| `cloud scan --no-cis` | discovery only, CIS disabled for every selected provider |

Provider-scoped flags (`--region`/`--profile` for AWS, `--subscription` for Azure, `--project` for GCP) apply only to their cloud; `--cis/--no-cis`, `-f/--format`, `-o/--output` are shared.

## Tests

`tests/test_cli_cloud_scan.py`:
- `test_scan_all_runs_configured_skips_unconfigured` — auto-detect + skip-with-note
- `test_scan_all_no_providers_is_graceful` — no configured cloud exits cleanly with guidance
- `test_scan_provider_aws_matches_legacy_alias` — `scan --provider aws` == `cloud aws`
- `test_one_provider_error_does_not_abort_others` — all selected providers reach the single scan call
- `test_aliases_disable_auto_db_refresh`, `test_azure_alias_forwards_subscription` — alias back-compat
- plus provider-resolution and option-forwarding cases

`uv run ruff check`, `uv run ruff format --check`, and `uv run mypy` are clean on the changed files; `pytest -k "cloud or cli or provider or scan"` is green (2451 passed).