### PR TITLE
ci: enforce chart image-tag alignment and scanner-only ClusterRole RBAC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,6 +470,63 @@ jobs:
       - name: Render shipped Helm profiles
         run: python3 scripts/validate_helm_profiles.py
 
+      - name: Assert ClusterRoles stay scanner-only (no write verbs)
+        run: |
+          set -euo pipefail
+          helm template agent-bom deploy/helm/agent-bom > "${RUNNER_TEMP}/rendered.yaml"
+          RENDERED_MANIFEST="${RUNNER_TEMP}/rendered.yaml" python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          WRITE_VERBS = {
+              "create",
+              "delete",
+              "deletecollection",
+              "patch",
+              "update",
+              "*",
+          }
+
+          text = Path(os.environ["RENDERED_MANIFEST"]).read_text(encoding="utf-8")
+          # Split the multi-doc stream on the YAML document separator so each
+          # manifest is inspected in isolation.
+          documents = text.split("\n---")
+          offenders: list[str] = []
+          for doc in documents:
+              lines = doc.splitlines()
+              if "kind: ClusterRole" not in lines:
+                  continue
+              # Read-only ClusterRoles back the agentless scanner posture; any
+              # write verb on a cluster-wide role is an over-broad-grant regression.
+              name = "<unknown>"
+              for line in lines:
+                  stripped = line.strip()
+                  if stripped.startswith("- "):
+                      stripped = stripped[2:].strip()
+                  if stripped.startswith("name:") and name == "<unknown>":
+                      name = stripped.split("name:", 1)[1].strip()
+                  if stripped.startswith("verbs:"):
+                      verbs_blob = stripped.split("verbs:", 1)[1]
+                      tokens = (
+                          verbs_blob.replace("[", " ")
+                          .replace("]", " ")
+                          .replace(",", " ")
+                          .replace('"', " ")
+                          .replace("'", " ")
+                          .split()
+                      )
+                      bad = WRITE_VERBS.intersection(tokens)
+                      if bad:
+                          offenders.append(f"{name}: {sorted(bad)}")
+
+          if offenders:
+              print("ClusterRole(s) grant over-broad write verbs:")
+              for offender in offenders:
+                  print(f"  - {offender}")
+              raise SystemExit(1)
+          print("ClusterRole RBAC is read-only (scanner-only posture intact)")
+          PY
+
   endpoint-packaging:
     name: Endpoint Packaging (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,9 +91,28 @@ jobs:
           if ui_version != tag:
               errors.append(f"ui/package.json version {ui_version!r} does not match tag {tag}")
 
+          # The chart's pinned image tags must track the release tag so a `helm install`
+          # of the published chart pulls the images built by this same release.
+          values_text = Path("deploy/helm/agent-bom/values.yaml").read_text(encoding="utf-8")
+          for block in ("image", "uiImage", "runtimeImage"):
+              m = re.search(
+                  rf'^{block}:\n(?:[ \t]+.*\n)*?[ \t]+tag:\s*"?([^"\n]+)"?',
+                  values_text,
+                  re.M,
+              )
+              if not m:
+                  errors.append(f"values.yaml: {block}.tag not found")
+              elif m.group(1).strip() != tag:
+                  errors.append(
+                      f"values.yaml {block}.tag {m.group(1).strip()!r} does not match tag {tag}"
+                  )
+
           if errors:
               raise SystemExit("\n".join(errors))
-          print(f"Auxiliary versions aligned with {tag}: chart, appVersion, ui/package.json")
+          print(
+              f"Auxiliary versions aligned with {tag}: chart, appVersion, "
+              "ui/package.json, values.yaml image/uiImage/runtimeImage tags"
+          )
           PY
 
       - name: Block Finder duplicate artifacts


### PR DESCRIPTION
## Summary

Adds two deployment-safety gates surfaced by a release audit. The UI image already publishes `linux/amd64,linux/arm64` (QEMU + Buildx + multi-arch `platforms` are present on the `docker-publish-ui` job), so this change focuses on the gaps that were genuinely missing.

## Changes

### Release version-guard: chart image tags must track the release tag
Extends the existing auxiliary-version check in `release.yml` to assert that `values.yaml` `image.tag`, `uiImage.tag`, and `runtimeImage.tag` all match the release tag, alongside the existing Chart `version`/`appVersion` and `ui/package.json` checks. This prevents publishing a chart whose pinned image tags drift from the images built in the same release.

### CI: scanner-only ClusterRole RBAC gate
Adds a step to the `helm-profiles` job that renders the chart and fails if any `ClusterRole` grants write verbs (`create`/`delete`/`deletecollection`/`patch`/`update`/`*`). Namespaced `Role` objects (e.g. teardown hooks) are intentionally out of scope. This keeps the cluster-wide grant read-only (`get`/`list`/`watch`), matching the agentless read-only posture.

`helm lint` already runs via `scripts/validate_helm_profiles.py` in the same job, so no separate lint job is added.

## Validation
- `actionlint` clean on both `release.yml` and `ci.yml`.
- `helm lint deploy/helm/agent-bom/` passes.
- RBAC gate verified locally: passes on the current chart, fails on an injected over-broad ClusterRole, ignores namespaced Roles with write verbs.
- version-guard tag assertions verified against the current chart/values.