### PR TITLE
Readable-at-scale CIS findings report (terminal + HTML)

### DIFF
--- a/src/agent_bom/output/console_render.py
+++ b/src/agent_bom/output/console_render.py
@@ -1380,6 +1380,189 @@ def print_remediation_plan(report: AIBOMReport) -> None:
         _console().print()
 
 
+_CIS_CLOUD_BUNDLES: tuple[tuple[str, str, str], ...] = (
+    ("aws", "AWS", "cis_benchmark_data"),
+    ("azure", "Azure", "azure_cis_benchmark_data"),
+    ("gcp", "GCP", "gcp_cis_benchmark_data"),
+    ("snowflake", "Snowflake", "snowflake_cis_benchmark_data"),
+    ("databricks", "Databricks", "databricks_cis_benchmark_data"),
+)
+
+_SEV_RANK: dict[str, int] = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+_SEV_LABEL: dict[str, str] = {
+    "critical": "CRITICAL",
+    "high": "HIGH",
+    "medium": "MEDIUM",
+    "low": "LOW",
+}
+_SEV_TABLE_STYLE: dict[str, str] = {
+    "critical": "white on red",
+    "high": "white on #e67e22",
+    "medium": "black on yellow",
+    "low": "white on #555555",
+}
+
+
+def _cis_sev(check: dict) -> str:
+    """Normalize a check's severity to a known lowercase band."""
+    sev = str(check.get("severity") or "").lower()
+    return sev if sev in _SEV_RANK else "low"
+
+
+def _cis_check_sort_key(check: dict) -> tuple[int, int, str, str]:
+    """Deterministic ordering: severity, remediation priority, section, id."""
+    rem = check.get("remediation") or {}
+    priority = rem.get("priority")
+    if not isinstance(priority, int):
+        priority = 3
+    return (
+        _SEV_RANK.get(_cis_sev(check), 4),
+        priority,
+        str(check.get("cis_section") or "~"),
+        str(check.get("check_id") or ""),
+    )
+
+
+def _cis_evidence(check: dict) -> str:
+    """Best available evidence string: prefer affected resource IDs."""
+    resources = check.get("resource_ids") or []
+    if resources:
+        shown = ", ".join(str(r) for r in resources[:4])
+        if len(resources) > 4:
+            shown += f" (+{len(resources) - 4} more)"
+        return shown
+    return str(check.get("evidence") or "").strip()
+
+
+def _cis_remediation_line(check: dict) -> str:
+    """Resolve the single 'what to do' line for a failed check."""
+    rem = check.get("remediation") or {}
+    fix_cli = rem.get("fix_cli")
+    if fix_cli:
+        return str(fix_cli)
+    fix_console = rem.get("fix_console")
+    if fix_console:
+        return f"→ {fix_console}"
+    recommendation = str(check.get("recommendation") or "").strip()
+    if recommendation:
+        return recommendation
+    return ""
+
+
+def print_cis_findings(report: AIBOMReport, *, show_passed: bool = False) -> None:
+    """Render CIS benchmark results as a prioritized, grouped FAILED plan.
+
+    Built for large result sets (60+ checks) where a flat table is
+    unreadable. For each cloud with benchmark data:
+
+      - A posture header: pass-rate band, passed/evaluated counts, and a
+        verdict driven by the highest failing severity.
+      - PASS checks are collapsed into a single ``N passed`` summary line
+        by default; pass ``show_passed=True`` to list them.
+      - FAILED checks lead, grouped by severity (CRITICAL first) then by
+        CIS section/domain, each showing a severity badge, check id +
+        title, the affected resources (evidence), and a recommendation /
+        remediation command (the 'what to do' line).
+
+    Ordering is deterministic so the same report renders identically
+    across runs. Emits nothing when no CIS data is present.
+    """
+    con = _console()
+    raw_bundles = [(cloud, label, getattr(report, attr, None)) for cloud, label, attr in _CIS_CLOUD_BUNDLES]
+    bundles = [(c, lbl, b) for c, lbl, b in raw_bundles if b and b.get("checks")]
+    if not bundles:
+        return
+
+    con.print()
+    con.print(Rule("CIS Benchmark Posture", style="bold bright_magenta"))
+
+    for _cloud, label, bundle in bundles:
+        checks = bundle.get("checks") or []
+        failed = [c for c in checks if str(c.get("status")) == "fail"]
+        passed = [c for c in checks if str(c.get("status")) == "pass"]
+        errored = [c for c in checks if str(c.get("status")) == "error"]
+        evaluated = len(failed) + len(passed)
+        pass_rate = bundle.get("pass_rate")
+        if not isinstance(pass_rate, (int, float)):
+            pass_rate = (len(passed) / evaluated * 100) if evaluated else 0.0
+
+        band = "green" if pass_rate >= 90 else "yellow" if pass_rate >= 70 else "red"
+
+        # Verdict driven by the worst failing severity.
+        if not failed:
+            verdict = "[bold green]PASS[/bold green]"
+        else:
+            worst = min((_SEV_RANK.get(_cis_sev(c), 4) for c in failed), default=4)
+            worst_band = {0: "CRITICAL", 1: "HIGH", 2: "MEDIUM", 3: "LOW"}.get(worst, "LOW")
+            vstyle = {"CRITICAL": "red bold", "HIGH": "#e67e22 bold", "MEDIUM": "yellow", "LOW": "dim"}[worst_band]
+            verdict = f"[{vstyle}]{worst_band} GAPS[/{vstyle}]"
+
+        con.print()
+        con.print(
+            f"  [bold]{label}[/bold]  {verdict}   "
+            f"[{band}]{pass_rate:.0f}% pass[/{band}]  "
+            f"[dim]({len(passed)}/{evaluated} checks"
+            + (f", {len(failed)} failed" if failed else "")
+            + (f", {len(errored)} errored" if errored else "")
+            + ")[/dim]"
+        )
+
+        if not failed:
+            con.print(f"    [green]{safe_emoji('✓', 'OK')}[/green] [dim]no failed checks[/dim]")
+            if show_passed and passed:
+                _print_cis_passed(con, passed)
+            continue
+
+        # Top risks: the highest-priority failing check ids, for the header.
+        top = sorted(failed, key=_cis_check_sort_key)[:3]
+        top_str = ", ".join(str(c.get("check_id") or "?") for c in top)
+        con.print(f"    [dim]top risks:[/dim] {top_str}")
+
+        # Group failed checks by severity, then by CIS section.
+        for sev in ("critical", "high", "medium", "low"):
+            sev_failed = [c for c in failed if _cis_sev(c) == sev]
+            if not sev_failed:
+                continue
+            badge_style = _SEV_TABLE_STYLE[sev]
+            con.print(f"\n    [{badge_style}] {_SEV_LABEL[sev]} [/{badge_style}] [dim]{len(sev_failed)} failed[/dim]")
+
+            # Group within severity by section for readability.
+            sections: dict[str, list[dict]] = {}
+            for c in sorted(sev_failed, key=_cis_check_sort_key):
+                sections.setdefault(str(c.get("cis_section") or "Other"), []).append(c)
+
+            for section in sorted(sections):
+                con.print(f"      [bold dim]{section}[/bold dim]")
+                for check in sections[section]:
+                    rem = check.get("remediation") or {}
+                    review = f" [yellow]{safe_emoji('↺', '(review)')} review[/yellow]" if rem.get("requires_human_review") else ""
+                    title = str(check.get("title") or "").rstrip(".")
+                    con.print(f"        [bold]{check.get('check_id', '')}[/bold]  {title}{review}")
+                    evidence = _cis_evidence(check)
+                    if evidence:
+                        con.print(f"          [dim]evidence:[/dim] {evidence}")
+                    fix = _cis_remediation_line(check)
+                    if fix:
+                        con.print(f"          [cyan]fix:[/cyan] {fix}")
+
+        # Collapsed PASS summary (expandable).
+        if passed:
+            if show_passed:
+                _print_cis_passed(con, passed)
+            else:
+                con.print(f"\n    [green]{safe_emoji('✓', 'OK')}[/green] [dim]{len(passed)} passed (use --show-passed to list)[/dim]")
+
+    con.print()
+
+
+def _print_cis_passed(con: Console, passed: list[dict]) -> None:
+    """List passed checks compactly, sorted by check id (deterministic)."""
+    con.print(f"\n    [green]Passed ({len(passed)}):[/green]")
+    for check in sorted(passed, key=lambda c: str(c.get("check_id") or "")):
+        title = str(check.get("title") or "").rstrip(".")
+        con.print(f"      [green]{safe_emoji('✓', 'OK')}[/green] [dim]{check.get('check_id', '')}  {title}[/dim]")
+
+
 def print_export_hint(report: AIBOMReport) -> None:
     """Print an AI-BOM identity footer with threat framework badge, explore links, and export hints."""
 

--- a/src/agent_bom/output/html.py
+++ b/src/agent_bom/output/html.py
@@ -691,7 +691,29 @@ _CIS_CLOUD_LABELS = {
     "azure": ("Azure", "azure_cis_benchmark_data"),
     "gcp": ("GCP", "gcp_cis_benchmark_data"),
     "snowflake": ("Snowflake", "snowflake_cis_benchmark_data"),
+    "databricks": ("Databricks", "databricks_cis_benchmark_data"),
 }
+
+_CIS_SEV_RANK = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+
+
+def _cis_evidence_html(check: dict) -> str:
+    """Affected-resource evidence cell: resource IDs when present, else text."""
+    resources = check.get("resource_ids") or []
+    if resources:
+        chips = "".join(
+            f'<span style="display:inline-block;padding:1px 7px;margin:1px 3px 1px 0;border-radius:4px;'
+            f"background:#0f172a;color:#cbd5e1;font-size:.66rem;font-family:monospace;"
+            f'word-break:break-all">{_esc(r)}</span>'
+            for r in resources[:6]
+        )
+        if len(resources) > 6:
+            chips += f'<span style="color:#475569;font-size:.66rem">+{len(resources) - 6} more</span>'
+        return chips
+    evidence = str(check.get("evidence") or "").strip()
+    if evidence:
+        return f'<span style="color:#94a3b8;font-size:.72rem">{_esc(evidence)}</span>'
+    return '<span style="color:#475569;font-size:.7rem">&mdash;</span>'
 
 
 def _cis_benchmark_section(report: "AIBOMReport") -> str:
@@ -703,8 +725,17 @@ def _cis_benchmark_section(report: "AIBOMReport") -> str:
     Returns an empty string when no CIS data is present.
     """
 
+    def _sort_key(c: dict) -> tuple[int, int, str]:
+        rem = c.get("remediation") or {}
+        priority = rem.get("priority", 3)
+        if not isinstance(priority, int):
+            priority = 3
+        sev = (c.get("severity") or "").lower()
+        sev_rank = _CIS_SEV_RANK.get(sev, 4)
+        return (sev_rank, priority, str(c.get("check_id") or ""))
+
     panels: list[str] = []
-    for cloud_key, (label, attr) in _CIS_CLOUD_LABELS.items():
+    for idx, (cloud_key, (label, attr)) in enumerate(_CIS_CLOUD_LABELS.items()):
         bundle = getattr(report, attr, None)
         if not bundle:
             continue
@@ -713,31 +744,77 @@ def _cis_benchmark_section(report: "AIBOMReport") -> str:
             continue
         failed = [c for c in checks if c.get("status") == "fail"]
         evaluated = [c for c in checks if c.get("status") in ("pass", "fail")]
+        passed_n = bundle.get("passed", sum(1 for c in checks if c.get("status") == "pass"))
         pass_rate = bundle.get("pass_rate", 0.0)
         band_color = "#16a34a" if pass_rate >= 90 else "#eab308" if pass_rate >= 70 else "#ef4444"
 
+        # Verdict + per-severity failed counts for the summary header.
+        sev_counts = {s: sum(1 for c in failed if (c.get("severity") or "").lower() == s) for s in _CIS_SEV_RANK}
+        if not failed:
+            verdict_text, verdict_color = "PASS", "#16a34a"
+        else:
+            worst = min((_CIS_SEV_RANK.get((c.get("severity") or "").lower(), 4) for c in failed), default=4)
+            worst_band = {0: "CRITICAL", 1: "HIGH", 2: "MEDIUM", 3: "LOW"}.get(worst, "LOW")
+            verdict_text = f"{worst_band} GAPS"
+            verdict_color = _SEV_COLOR.get(worst_band.lower(), "#ef4444")
+
+        top = sorted(failed, key=_sort_key)[:3]
+        top_html = ""
+        if top:
+            chips = "".join(
+                f'<code style="background:#1e293b;color:#f1f5f9;padding:1px 6px;border-radius:4px;'
+                f'margin-right:5px;font-size:.7rem">{_esc(c.get("check_id", ""))}</code>'
+                for c in top
+            )
+            top_html = f'<div style="color:#64748b;font-size:.74rem;margin-top:6px">top risks: {chips}</div>'
+
+        counts_html = " ".join(
+            f'<span style="color:{_SEV_COLOR.get(s, "#6b7280")};font-size:.72rem;font-weight:700">{n} {s[0].upper()}</span>'
+            for s, n in sev_counts.items()
+            if n
+        )
+
         header = (
-            f'<div style="display:flex;align-items:center;gap:18px;margin-bottom:12px">'
+            f'<div style="display:flex;align-items:center;gap:18px;flex-wrap:wrap;margin-bottom:4px">'
             f'<div style="font-weight:700;color:#f1f5f9;font-size:.95rem">{_esc(label)}</div>'
+            f'<span style="background:{verdict_color};color:#fff;padding:2px 9px;border-radius:4px;'
+            f'font-size:.7rem;font-weight:700;letter-spacing:.04em">{verdict_text}</span>'
             f'<div style="color:{band_color};font-weight:700">{pass_rate:.0f}% pass</div>'
             f'<div style="color:#64748b;font-size:.78rem">'
-            f"{bundle.get('passed', 0)}/{len(evaluated)} checks &middot; "
+            f"{passed_n}/{len(evaluated)} checks &middot; "
             f'<strong style="color:#f97316">{len(failed)} failed</strong>'
-            f"</div></div>"
+            f"</div>"
+            f'<div style="display:flex;gap:10px">{counts_html}</div>'
+            f"</div>"
+            f"{top_html}"
         )
 
         if not failed:
             panels.append(
-                f'<div class="panel" style="margin-bottom:16px">{header}<div class="empty-state">&#x2705; No failed CIS checks.</div></div>'
+                f'<div class="panel" style="margin-bottom:16px">{header}'
+                f'<div class="empty-state" style="margin-top:12px">&#x2705; No failed CIS checks.</div></div>'
             )
             continue
 
-        def _sort_key(c: dict) -> tuple[int, int]:
-            rem = c.get("remediation") or {}
-            priority = rem.get("priority", 3)
-            sev = (c.get("severity") or "").lower()
-            sev_rank = {"critical": 0, "high": 1, "medium": 2, "low": 3}.get(sev, 4)
-            return (priority, sev_rank)
+        # Severity filter buttons (client-side, per panel).
+        panel_id = f"cis-{_esc(cloud_key)}"
+        filter_btns = (
+            f'<div class="cis-filter" data-target="{panel_id}" style="margin:10px 0 4px">'
+            + "".join(
+                f'<button type="button" class="cis-filter-btn" data-sev="{sev}" '
+                f'style="background:#1e293b;color:#94a3b8;border:1px solid #334155;border-radius:4px;'
+                f'padding:2px 9px;margin-right:6px;font-size:.7rem;cursor:pointer">{lbl}</button>'
+                for sev, lbl in (
+                    ("all", "All"),
+                    ("critical", "Critical"),
+                    ("high", "High"),
+                    ("medium", "Medium"),
+                    ("low", "Low"),
+                )
+                if sev == "all" or sev_counts.get(sev)
+            )
+            + "</div>"
+        )
 
         rows = []
         for check in sorted(failed, key=_sort_key):
@@ -765,6 +842,8 @@ def _cis_benchmark_section(report: "AIBOMReport") -> str:
                 fix_cell = f'<code style="color:#67e8f9;font-size:.72rem;white-space:pre-wrap;word-break:break-all">{_esc(fix_cli)}</code>'
             elif fix_console:
                 fix_cell = f'<span style="color:#94a3b8;font-size:.72rem">&rarr; {_esc(fix_console)}</span>'
+            elif check.get("recommendation"):
+                fix_cell = f'<span style="color:#94a3b8;font-size:.72rem">{_esc(check.get("recommendation"))}</span>'
 
             docs_link = ""
             docs = rem.get("docs") or ""
@@ -772,34 +851,50 @@ def _cis_benchmark_section(report: "AIBOMReport") -> str:
                 docs_link = f' &middot; <a href="{_esc(docs)}" target="_blank" rel="noopener" style="font-size:.7rem">docs</a>'
 
             rows.append(
-                "<tr>"
+                f'<tr class="cis-row" data-sev="{_esc(sev)}">'
                 f"<td>{_sev_badge(sev)}</td>"
                 f'<td style="font-family:monospace;color:#f1f5f9;font-weight:600">{_esc(check.get("check_id", ""))}</td>'
                 f'<td style="color:#e2e8f0;font-size:.82rem">{_esc(check.get("title", ""))}{review_badge}</td>'
                 f'<td style="color:#94a3b8;font-size:.75rem">P{priority} &middot; {_esc(effort)}</td>'
+                f"<td>{_cis_evidence_html(check)}</td>"
                 f"<td>{guard_html}</td>"
                 f"<td>{fix_cell}{docs_link}</td>"
                 "</tr>"
             )
 
         table_html = (
-            '<div class="table-wrap"><table class="data-table sortable">'
+            f'<div class="table-wrap"><table class="data-table sortable" id="{panel_id}">'
             + "<thead><tr>"
             + "".join(
                 f'<th data-col="{i}">{h} <span class="sort-arrow"></span></th>'
-                for i, h in enumerate(["Severity", "Check", "Title", "Priority", "Guardrails", "Remediation"])
+                for i, h in enumerate(["Severity", "Check", "Title", "Priority", "Evidence", "Guardrails", "Remediation"])
             )
             + "</tr></thead>"
             + f"<tbody>{''.join(rows)}</tbody></table></div>"
         )
 
-        panels.append(f'<div class="panel" style="margin-bottom:16px">{header}{table_html}</div>')
+        panels.append(f'<div class="panel" style="margin-bottom:16px">{header}{filter_btns}{table_html}</div>')
 
     if not panels:
         return ""
 
+    filter_script = (
+        "<script>document.querySelectorAll('.cis-filter').forEach(function(bar){"
+        "bar.querySelectorAll('.cis-filter-btn').forEach(function(btn){"
+        "btn.addEventListener('click',function(){"
+        "var tbl=document.getElementById(bar.getAttribute('data-target'));if(!tbl)return;"
+        "var sev=btn.getAttribute('data-sev');"
+        "tbl.querySelectorAll('tbody tr.cis-row').forEach(function(r){"
+        "r.style.display=(sev==='all'||r.getAttribute('data-sev')===sev)?'':'none';});"
+        "bar.querySelectorAll('.cis-filter-btn').forEach(function(b){b.style.color='#94a3b8';});"
+        "btn.style.color='#f1f5f9';});});});</script>"
+    )
+
     return (
-        '<section id="cisbenchmarks"><div class="sec-title">&#x1f6e1;&#xfe0f; CIS Benchmark Posture</div>' + "".join(panels) + "</section>"
+        '<section id="cisbenchmarks"><div class="sec-title">&#x1f6e1;&#xfe0f; CIS Benchmark Posture</div>'
+        + "".join(panels)
+        + filter_script
+        + "</section>"
     )
 
 

--- a/tests/test_report_ux.py
+++ b/tests/test_report_ux.py
@@ -1,0 +1,200 @@
+"""Report UX: grouped/collapsed terminal CIS plan + shareable HTML.
+
+Covers the readable-at-scale terminal renderer
+(:func:`print_cis_findings`) and the enhanced HTML CIS posture section
+(:func:`_cis_benchmark_section`): grouping by severity, collapsing PASS
+checks, per-finding evidence + remediation, summary header, and
+determinism.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from rich.console import Console
+
+from agent_bom.models import AIBOMReport
+from agent_bom.output.console_render import print_cis_findings
+from agent_bom.output.html import _cis_benchmark_section
+
+
+def _check(check_id, status, severity, *, section="1 - IAM", resources=None, fix_cli=None, review=False):
+    return {
+        "check_id": check_id,
+        "title": f"Ensure check {check_id} is configured",
+        "status": status,
+        "severity": severity,
+        "evidence": f"evidence for {check_id}",
+        "resource_ids": resources or [],
+        "recommendation": f"Remediate {check_id}.",
+        "remediation": {
+            "fix_cli": fix_cli,
+            "fix_console": "Console -> fix it" if not fix_cli else "",
+            "effort": "low",
+            "priority": 1 if severity == "critical" else 2,
+            "guardrails": ["identity", "least-privilege"],
+            "requires_human_review": review,
+            "docs": "",
+        },
+        "cis_section": section,
+        "attack_techniques": [],
+    }
+
+
+def _large_bundle() -> dict:
+    """60-check bundle: 4 critical fails, 6 high fails, 5 medium, 45 pass."""
+    checks = []
+    for i in range(4):
+        checks.append(_check(f"c{i}", "fail", "critical", section="1 - IAM", resources=[f"arn:res:{i}"], fix_cli=f"aws fix-{i}"))
+    for i in range(6):
+        checks.append(_check(f"h{i}", "fail", "high", section="2 - Logging", resources=[f"bucket-{i}"]))
+    for i in range(5):
+        checks.append(_check(f"m{i}", "fail", "medium", section="3 - Networking", review=True))
+    for i in range(45):
+        checks.append(_check(f"p{i}", "pass", "low"))
+    return {
+        "benchmark": "CIS AWS Foundations",
+        "benchmark_version": "3.0",
+        "account_id": "123456789012",
+        "pass_rate": 75.0,
+        "passed": 45,
+        "failed": 15,
+        "total": 60,
+        "checks": checks,
+    }
+
+
+def _report_large() -> AIBOMReport:
+    report = AIBOMReport(tool_version="0.77.1")
+    report.cis_benchmark_data = _large_bundle()
+    return report
+
+
+def _render(report, **kwargs) -> str:
+    buf = StringIO()
+    con = Console(file=buf, force_terminal=False, width=200)
+    import agent_bom.output as output_mod
+
+    original = output_mod.console
+    output_mod.console = con
+    try:
+        print_cis_findings(report, **kwargs)
+    finally:
+        output_mod.console = original
+    return buf.getvalue()
+
+
+# ── Terminal: grouped + collapsed ────────────────────────────────────────────
+
+
+def test_terminal_groups_by_severity():
+    out = _render(_report_large())
+    # Severity band headers present and CRITICAL precedes HIGH precedes MEDIUM.
+    assert "CRITICAL" in out and "HIGH" in out and "MEDIUM" in out
+    assert out.index("CRITICAL") < out.index("HIGH") < out.index("MEDIUM")
+
+
+def test_terminal_collapses_passed_by_default():
+    out = _render(_report_large())
+    assert "45 passed" in out
+    assert "--show-passed" in out
+    # Passed check ids must NOT be listed when collapsed.
+    assert "p0  Ensure check p0" not in out
+
+
+def test_terminal_show_passed_lists_them():
+    out = _render(_report_large(), show_passed=True)
+    assert "Passed (45)" in out
+    assert "p0" in out
+
+
+def test_terminal_each_failed_has_evidence_and_recommendation():
+    out = _render(_report_large())
+    assert "evidence:" in out
+    assert "fix:" in out
+    # A resource id (evidence) and a fix command both surface.
+    assert "arn:res:0" in out
+    assert "aws fix-0" in out
+
+
+def test_terminal_header_has_verdict_and_pass_rate():
+    out = _render(_report_large())
+    assert "75% pass" in out
+    assert "GAPS" in out  # verdict driven by worst failing severity
+    assert "top risks:" in out
+
+
+def test_terminal_silent_without_cis_data():
+    assert _render(AIBOMReport(tool_version="0.77.1")) == ""
+
+
+def test_terminal_clean_scan_renders_cleanly():
+    bundle = {
+        "pass_rate": 100.0,
+        "passed": 3,
+        "failed": 0,
+        "total": 3,
+        "checks": [_check(f"ok{i}", "pass", "low") for i in range(3)],
+    }
+    report = AIBOMReport(tool_version="0.77.1")
+    report.cis_benchmark_data = bundle
+    out = _render(report)
+    assert "100% pass" in out
+    assert "no failed checks" in out
+    assert "PASS" in out
+
+
+def test_terminal_deterministic():
+    r1 = _render(_report_large())
+    r2 = _render(_report_large())
+    assert r1 == r2
+
+
+# ── HTML: shareable report ───────────────────────────────────────────────────
+
+
+def test_html_has_summary_header_and_verdict():
+    html = _cis_benchmark_section(_report_large())
+    assert html
+    assert 'id="cisbenchmarks"' in html
+    assert "75% pass" in html
+    assert "GAPS" in html  # verdict badge
+    assert "top risks" in html
+
+
+def test_html_per_finding_evidence_and_remediation():
+    html = _cis_benchmark_section(_report_large())
+    assert "Evidence" in html  # column header
+    assert "arn:res:0" in html  # resource id evidence rendered
+    assert "aws fix-0" in html  # remediation command rendered
+
+
+def test_html_rows_carry_severity_for_filtering():
+    html = _cis_benchmark_section(_report_large())
+    assert 'class="cis-row" data-sev="critical"' in html
+    assert "cis-filter-btn" in html  # severity filter controls
+
+
+def test_html_empty_when_no_data():
+    assert _cis_benchmark_section(AIBOMReport(tool_version="0.77.1")) == ""
+
+
+def test_html_clean_scan_renders_no_failures():
+    bundle = {
+        "pass_rate": 100.0,
+        "passed": 2,
+        "failed": 0,
+        "total": 2,
+        "checks": [_check(f"ok{i}", "pass", "low") for i in range(2)],
+    }
+    report = AIBOMReport(tool_version="0.77.1")
+    report.cis_benchmark_data = bundle
+    html = _cis_benchmark_section(report)
+    assert "No failed CIS checks" in html
+    assert "PASS" in html
+
+
+def test_html_deterministic():
+    h1 = _cis_benchmark_section(_report_large())
+    h2 = _cis_benchmark_section(_report_large())
+    assert h1 == h2


### PR DESCRIPTION
## Summary

Large CIS benchmark result sets (60+ checks) rendered as a flat table were hard to read and buried the failures that matter. This makes findings output readable at scale, shareable, and actionable across the terminal and the downloadable HTML report.

## Terminal — `console_render.print_cis_findings`

- Leads with a prioritized FAILED plan grouped by severity (CRITICAL first), then by CIS section, instead of a flat table dump.
- Collapses PASS checks into an "N passed" summary line by default; `show_passed=True` lists them.
- Each failed finding shows a severity badge, check id + title, the affected resource IDs (evidence), and a recommendation/remediation command (the "what to do" line).
- Per-cloud header carries a posture verdict, pass-rate band, passed/evaluated counts, and the top risks.

## HTML — `_cis_benchmark_section`

- Per-cloud summary header with posture verdict, pass-rate band, per-severity failed counts, and top risks.
- New Evidence column surfacing affected resource IDs; remediation falls back to recommendation text when no fix command is available.
- Rows carry a severity class with client-side severity filter buttons.
- Self-contained (inline CSS/JS), opens anywhere.

## Cross-cutting

- Deterministic: output is sorted by stable keys (severity, remediation priority, section, check id) so the same report renders identically across runs.
- No regression: clean scans render cleanly; existing posture badges and remediation surfaces stay intact.

## Tests

`tests/test_report_ux.py` covers severity grouping + PASS collapse, per-finding evidence + recommendation, the HTML summary header + per-finding sections, severity filtering, clean-scan rendering, and determinism on both surfaces. Existing CIS/output/posture suite passes (1335 passed, 3 skipped).
