### PR TITLE
feat(cloud): detect cloud providers by credential source, not CLI on PATH

### DIFF
--- a/src/agent_bom/cli/_cloud_group.py
+++ b/src/agent_bom/cli/_cloud_group.py
@@ -20,7 +20,6 @@ Usage::
 
 from __future__ import annotations
 
-import shutil
 from typing import Optional
 
 import click
@@ -29,34 +28,39 @@ from agent_bom.cli._grouped_help import SuggestingGroup
 
 # Deterministic provider catalogue. The order here drives auto-detect ordering,
 # per-provider sectioning, and `--provider all` fan-out so the same configuration
-# always produces the same output. Each entry maps the provider to the CLI tool
-# whose presence signals "configured" (mirrors the existing no-subcommand path
-# and `agent-cloud posture`).
-_PROVIDER_CLI = {
-    "aws": "aws",
-    "azure": "az",
-    "gcp": "gcloud",
-}
-# Sorted for determinism — same config in, same provider order out.
-_PROVIDER_ORDER: tuple[str, ...] = tuple(sorted(_PROVIDER_CLI))
+# always produces the same output.
+_PROVIDER_ORDER: tuple[str, ...] = ("aws", "azure", "gcp")
 
-# How a missing provider CLI is described when we skip it, so the friendly note
-# points the user at the exact thing to install/configure.
+# How a provider's credentials are set up, so the friendly skip note points the
+# user at the exact thing to configure.
 _PROVIDER_HINT = {
-    "aws": "aws configure",
-    "azure": "az login",
-    "gcp": "gcloud auth login",
+    "aws": "aws configure  (or IRSA / AWS_PROFILE / AWS_ACCESS_KEY_ID)",
+    "azure": "az login  (or service principal / workload identity)",
+    "gcp": "gcloud auth application-default login  (or GOOGLE_APPLICATION_CREDENTIALS)",
 }
 
 
 def _provider_configured(provider: str) -> bool:
-    """Return True when the provider's CLI is on PATH (its creds are reachable).
+    """Return True when *provider* has resolvable credentials (not just a CLI).
 
-    Credential detection deliberately reuses the same CLI-presence signal the
-    cloud group already trusts for its no-subcommand fan-out, so behaviour is
-    consistent across every entry point.
+    Detection is by actual credential SOURCE — env vars, IRSA / workload-identity
+    token files, shared config/credentials files, or a locally resolvable SDK
+    session — never by a CLI binary on ``PATH``. A CLI binary with no credentials
+    (CloudShell, CI images) is no longer a false positive, and an IRSA-backed
+    collector with no CLI installed is no longer a false negative. No network
+    call is made here.
     """
-    return bool(shutil.which(_PROVIDER_CLI[provider]))
+    from agent_bom.cloud.auth_probe import provider_has_credentials
+
+    has, _source = provider_has_credentials(provider)
+    return has
+
+
+def _provider_status(provider: str) -> tuple[bool, str]:
+    """Return ``(has_credentials, source)`` for *provider* — local checks only."""
+    from agent_bom.cloud.auth_probe import provider_has_credentials
+
+    return provider_has_credentials(provider)
 
 
 def _detect_configured_providers() -> list[str]:
@@ -80,10 +84,18 @@ def _resolve_scan_providers(provider: str) -> tuple[list[str], list[str]]:
     return [provider], []
 
 
+def _verify_provider(provider: str) -> tuple[bool, str]:
+    """Opt-in network confirmation that *provider* credentials authenticate."""
+    from agent_bom.cloud.auth_probe import verify_credentials
+
+    return verify_credentials(provider)
+
+
 def _run_cloud_scan(
     providers: list[str],
     *,
     skipped: Optional[list[str]] = None,
+    verify: bool = False,
     aws_region: Optional[str] = None,
     aws_profile: Optional[str] = None,
     aws_include_lambda: bool = False,
@@ -111,15 +123,27 @@ def _run_cloud_scan(
 
     providers = [p for p in _PROVIDER_ORDER if p in providers]
 
-    if skipped:
+    # Per-provider status: say exactly what was detected and why, so the operator
+    # (or a collector) knows which clouds are scanning and how their credentials
+    # were resolved. Only surfaced on console output and when not quiet.
+    show_status = not quiet and output_format == "console"
+    if show_status and (providers or skipped):
         con = Console(stderr=True)
-        for prov in skipped:
-            con.print(f"  [dim]skipping {prov.upper()} — not configured (set up with: {_PROVIDER_HINT[prov]})[/dim]")
+        for prov in providers:
+            _has, source = _provider_status(prov)
+            line = f"  [green]{prov}[/green]: scanning [dim](creds via {source})[/dim]"
+            if verify:
+                ok, detail = _verify_provider(prov)
+                mark = "[green]verified[/green]" if ok else "[yellow]unverified[/yellow]"
+                line += f" · {mark} [dim]({detail})[/dim]"
+            con.print(line)
+        for prov in skipped or []:
+            con.print(f"  [yellow]{prov}[/yellow]: skipped — no credentials [dim](set up: {_PROVIDER_HINT[prov]})[/dim]")
 
     if not providers:
         con = Console(stderr=True)
         con.print("\n[yellow]No configured cloud providers to scan.[/yellow]")
-        con.print("  Configure at least one provider and retry:")
+        con.print("  Configure credentials for at least one provider and retry:")
         for prov in _PROVIDER_ORDER:
             con.print(f"  [cyan]{prov}[/cyan] → {_PROVIDER_HINT[prov]}")
         return
@@ -186,11 +210,11 @@ def cloud_group(ctx: click.Context) -> None:
             from rich.console import Console
 
             con = Console(stderr=True)
-            con.print("\n[yellow]No cloud CLI tools found (aws, az, gcloud).[/yellow]")
-            con.print("  Install and configure credentials for your provider:")
-            con.print("  [cyan]agent-bom cloud aws[/cyan]     requires: aws configure")
-            con.print("  [cyan]agent-bom cloud azure[/cyan]   requires: az login")
-            con.print("  [cyan]agent-bom cloud gcp[/cyan]     requires: gcloud auth login")
+            con.print("\n[yellow]No cloud credentials detected (aws, azure, gcp).[/yellow]")
+            con.print("  Configure credentials for your provider:")
+            con.print("  [cyan]agent-bom cloud aws[/cyan]     requires: aws configure / IRSA / AWS_PROFILE")
+            con.print("  [cyan]agent-bom cloud azure[/cyan]   requires: az login / service principal")
+            con.print("  [cyan]agent-bom cloud gcp[/cyan]     requires: gcloud ADC / GOOGLE_APPLICATION_CREDENTIALS")
             con.print()
             con.print("  [dim]No credentials needed for:[/dim]")
             con.print("  [cyan]agent-bom image[/cyan] · [cyan]agent-bom iac[/cyan] · [cyan]agent-bom fs[/cyan]")
@@ -217,6 +241,11 @@ def cloud_group(ctx: click.Context) -> None:
 @click.option("--subscription", default=None, help="Azure subscription ID (azure only).")
 @click.option("--project", default=None, help="GCP project ID (gcp only).")
 @click.option("--cis/--no-cis", default=True, show_default=True, help="Run CIS benchmark for each selected provider.")
+@click.option(
+    "--verify",
+    is_flag=True,
+    help="Confirm detected credentials authenticate (STS/whoami). Opt-in — makes a network call.",
+)
 @click.option("-f", "--format", "output_format", default="console", help="Output format")
 @click.option("-o", "--output", "output_path", help="Output file path")
 @click.option("--quiet", "-q", is_flag=True)
@@ -231,6 +260,7 @@ def scan_cmd(
     subscription: Optional[str],
     project: Optional[str],
     cis: bool,
+    verify: bool,
     output_format: str,
     output_path: Optional[str],
     quiet: bool,
@@ -253,6 +283,7 @@ def scan_cmd(
     _run_cloud_scan(
         selected,
         skipped=skipped,
+        verify=verify,
         aws_region=region,
         aws_profile=profile,
         aws_include_lambda=include_lambda,

--- a/src/agent_bom/cloud/auth_probe.py
+++ b/src/agent_bom/cloud/auth_probe.py
@@ -1,0 +1,299 @@
+"""Credential-presence probes for cloud providers — detect by *credentials*, not CLI.
+
+The unified ``cloud`` command needs to know which providers it can actually scan.
+Probing for a CLI binary on ``PATH`` (``shutil.which``) mis-detects both ways:
+
+- **False positive** — AWS CloudShell and most CI images ship the ``aws`` CLI but
+  carry no usable credentials, so a CLI-presence check says "AWS configured" and
+  the scan then fails at the first API call.
+- **False negative** — a hosted collector on EKS with IRSA / workload-identity
+  (``AWS_WEB_IDENTITY_TOKEN_FILE``) has perfectly good credentials but no ``aws``
+  CLI installed, so the cloud is skipped even though it is fully scannable.
+
+This module checks the actual *credential sources* each SDK resolves — env vars,
+shared config/credential files, well-known ADC paths, and (where cheap and
+local) the SDK's own credential resolver — without making any network call.
+Returning the *source* lets the UI explain exactly what was detected and why
+(``creds via AWS_WEB_IDENTITY_TOKEN_FILE``), which is the difference between a
+collector operator trusting the run and filing a bug.
+
+Design contract:
+
+- **No forced network.** Every probe here is local: env vars, file existence, and
+  SDK *credential resolution* (which for env/profile/IRSA-token-file is local and
+  never calls STS). A real auth confirmation (STS / whoami) is opt-in via
+  :func:`verify_credentials`.
+- **Never raises.** Detection runs inside collectors and CLI fan-out; a missing
+  optional SDK, an unreadable file, or any SDK quirk degrades to "not detected"
+  for that source, never an exception.
+- **Guarded imports.** ``boto3`` / ``google.auth`` may be absent; their absence
+  falls back to env + file checks so detection still works.
+- **Deterministic.** Sources are checked in a fixed precedence order so the same
+  environment always reports the same source string.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Callable, Optional
+
+# Last-resort CLI hint: when no credential source is found but the provider's CLI
+# is installed, the caller may treat the provider as "maybe — attempt with
+# guidance" rather than skip it outright. This is a hint only; it never counts as
+# a positive credential detection.
+PROVIDER_CLI: dict[str, str] = {
+    "aws": "aws",
+    "azure": "az",
+    "gcp": "gcloud",
+    "snowflake": "snow",
+}
+
+PROVIDERS: tuple[str, ...] = ("aws", "azure", "gcp", "snowflake")
+
+
+def _expand(path: str) -> Path:
+    return Path(os.path.expanduser(path))
+
+
+def _first_env(*names: str) -> Optional[str]:
+    """Return the first environment variable *name* that is set and non-empty."""
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            return name
+    return None
+
+
+# ── AWS ──────────────────────────────────────────────────────────────────────
+
+
+def _probe_aws() -> Optional[str]:
+    """Detect AWS credentials locally. Returns a source string or ``None``.
+
+    Precedence mirrors how an operator reads their own setup: explicit env keys
+    and IRSA/container-role tokens first (most specific), then a named profile,
+    then a resolved boto3 session, then the shared config/credential files.
+    boto3 credential *resolution* for these sources is local — it reads env vars
+    and token files and never calls STS — so it stays within the no-network
+    contract.
+    """
+    # Static keys / container + IRSA role tokens — unambiguous, env-only.
+    env = _first_env(
+        "AWS_ACCESS_KEY_ID",
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+        "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+        "AWS_ROLE_ARN",
+    )
+    if env:
+        return f"env {env}"
+
+    # boto3's own resolver picks up profiles, SSO cache, IMDS config, etc. This is
+    # local resolution (no STS) — wrapped because boto3 may be absent and some
+    # provider chains can raise on malformed config.
+    try:
+        import boto3  # type: ignore
+
+        creds = boto3.Session().get_credentials()
+        if creds is not None:
+            method = getattr(creds, "method", None) or "boto3"
+            return f"boto3 ({method})"
+    except Exception:
+        pass
+
+    # Named profile selects a section in the shared credentials/config files.
+    if os.environ.get("AWS_PROFILE"):
+        return "env AWS_PROFILE"
+
+    # Shared credential/config files (with honor for the override env vars).
+    cred_file = _expand(os.environ.get("AWS_SHARED_CREDENTIALS_FILE", "~/.aws/credentials"))
+    config_file = _expand(os.environ.get("AWS_CONFIG_FILE", "~/.aws/config"))
+    if cred_file.is_file():
+        return f"shared credentials file ({cred_file})"
+    if config_file.is_file():
+        return f"shared config file ({config_file})"
+    return None
+
+
+# ── Azure ────────────────────────────────────────────────────────────────────
+
+
+def _probe_azure() -> Optional[str]:
+    """Detect Azure credentials locally. Returns a source string or ``None``.
+
+    Service-principal env vars and workload-identity / managed-identity markers
+    are checked first, then the azure CLI token cache directory. No network call
+    is made: ``DefaultAzureCredential`` is *not* invoked here (its ``get_token``
+    would hit the network); only its local source markers are inspected.
+    """
+    # Workload identity (federated token file) — the EKS/AKS collector case.
+    if os.environ.get("AZURE_FEDERATED_TOKEN_FILE"):
+        return "env AZURE_FEDERATED_TOKEN_FILE (workload identity)"
+
+    # Service principal — client id + (secret or cert) + tenant.
+    if os.environ.get("AZURE_CLIENT_ID") and (os.environ.get("AZURE_CLIENT_SECRET") or os.environ.get("AZURE_CLIENT_CERTIFICATE_PATH")):
+        return "env AZURE_CLIENT_ID (service principal)"
+
+    # Managed identity endpoints (App Service / Functions / IMDS override).
+    msi = _first_env("MSI_ENDPOINT", "IDENTITY_ENDPOINT", "AZURE_POD_IDENTITY_AUTHORITY_HOST")
+    if msi:
+        return f"env {msi} (managed identity)"
+
+    # A lone client/tenant id still signals an intended SP source for the UI.
+    partial = _first_env("AZURE_CLIENT_ID", "AZURE_TENANT_ID")
+    if partial:
+        return f"env {partial}"
+
+    # az CLI token cache directory.
+    az_dir = _expand(os.environ.get("AZURE_CONFIG_DIR", "~/.azure"))
+    if (az_dir / "msal_token_cache.json").is_file() or (az_dir / "azureProfile.json").is_file():
+        return f"az CLI config ({az_dir})"
+    return None
+
+
+# ── GCP ──────────────────────────────────────────────────────────────────────
+
+
+def _probe_gcp() -> Optional[str]:
+    """Detect GCP credentials locally. Returns a source string or ``None``.
+
+    ``GOOGLE_APPLICATION_CREDENTIALS`` and the well-known ADC file are checked
+    directly; impersonation/metadata markers are honored; finally
+    ``google.auth.default()`` is used as a resolver. ``google.auth.default`` only
+    *resolves* a credential object (env/file/metadata-config) and does not fetch a
+    token, so it stays local for the env/file cases.
+    """
+    gac = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if gac and _expand(gac).is_file():
+        return "env GOOGLE_APPLICATION_CREDENTIALS"
+    if gac:
+        # Set but missing file — still an intended source; surface it honestly.
+        return "env GOOGLE_APPLICATION_CREDENTIALS (file missing)"
+
+    impersonate = _first_env("AGENT_BOM_GCP_IMPERSONATE_SA", "GOOGLE_IMPERSONATE_SERVICE_ACCOUNT")
+    if impersonate:
+        return f"env {impersonate} (impersonation)"
+
+    # Well-known Application Default Credentials file.
+    cloudsdk = os.environ.get("CLOUDSDK_CONFIG")
+    adc = (
+        _expand(cloudsdk) / "application_default_credentials.json"
+        if cloudsdk
+        else _expand("~/.config/gcloud/application_default_credentials.json")
+    )
+    if adc.is_file():
+        return f"ADC file ({adc})"
+
+    # Metadata server marker (GCE / GKE workload identity).
+    meta = _first_env("GCE_METADATA_HOST", "GCE_METADATA_ROOT", "GCE_METADATA_IP")
+    if meta:
+        return f"env {meta} (metadata server)"
+
+    # google.auth resolver as a last local resolution step.
+    try:
+        import google.auth  # type: ignore
+
+        creds, _project = google.auth.default()
+        if creds is not None:
+            return "google.auth.default()"
+    except Exception:
+        pass
+    return None
+
+
+# ── Snowflake ────────────────────────────────────────────────────────────────
+
+
+def _probe_snowflake() -> Optional[str]:
+    """Detect Snowflake credentials locally. Returns a source string or ``None``.
+
+    Requires an account plus a key-pair path or a user. Pure env inspection.
+    """
+    if not os.environ.get("SNOWFLAKE_ACCOUNT"):
+        return None
+    if os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH"):
+        return "env SNOWFLAKE_ACCOUNT + SNOWFLAKE_PRIVATE_KEY_PATH (key-pair)"
+    if os.environ.get("SNOWFLAKE_USER"):
+        return "env SNOWFLAKE_ACCOUNT + SNOWFLAKE_USER"
+    return None
+
+
+_PROBES: dict[str, Callable[[], Optional[str]]] = {
+    "aws": _probe_aws,
+    "azure": _probe_azure,
+    "gcp": _probe_gcp,
+    "snowflake": _probe_snowflake,
+}
+
+
+def provider_has_credentials(provider: str) -> tuple[bool, str]:
+    """Return ``(has_credentials, source)`` for *provider* — local checks only.
+
+    Detection inspects credential *sources* (env vars, files, local SDK
+    resolution) and never makes a network call. The returned ``source`` is a
+    short human string the UI can surface (``env AWS_WEB_IDENTITY_TOKEN_FILE``).
+
+    When no credential source is found, the provider's CLI presence is returned
+    as a *last-resort hint* — ``(False, "cli present (no credentials resolved)")``
+    — so the caller can decide whether to attempt-with-guidance instead of
+    silently skipping. CLI presence never counts as a positive detection.
+
+    Never raises: an unknown provider, a missing optional SDK, or any probe quirk
+    degrades to ``(False, ...)``.
+    """
+    probe = _PROBES.get(provider)
+    if probe is None:
+        return False, "unknown provider"
+
+    try:
+        source = probe()
+    except Exception:
+        source = None
+
+    if source:
+        return True, source
+
+    cli = PROVIDER_CLI.get(provider)
+    if cli:
+        import shutil
+
+        if shutil.which(cli):
+            return False, "cli present (no credentials resolved)"
+    return False, "no credentials"
+
+
+def verify_credentials(provider: str) -> tuple[bool, str]:
+    """Opt-in network confirmation that *provider* credentials actually work.
+
+    Unlike :func:`provider_has_credentials`, this performs a cheap authenticated
+    identity call (STS ``GetCallerIdentity`` for AWS, token acquisition for
+    Azure/GCP). Network-bound — call only when ``--verify`` is requested. Never
+    raises; returns ``(False, reason)`` on any failure.
+    """
+    try:
+        if provider == "aws":
+            import boto3  # type: ignore
+
+            ident = boto3.client("sts").get_caller_identity()
+            return True, f"sts: {ident.get('Arn', ident.get('Account', 'ok'))}"
+        if provider == "gcp":
+            import google.auth  # type: ignore
+            import google.auth.transport.requests  # type: ignore
+
+            creds, project = google.auth.default()
+            creds.refresh(google.auth.transport.requests.Request())
+            return True, f"adc token ok (project={project})"
+        if provider == "azure":
+            from azure.identity import DefaultAzureCredential  # type: ignore
+
+            token = DefaultAzureCredential().get_token("https://management.azure.com/.default")
+            return (True, "aad token ok") if token else (False, "no token")
+        if provider == "snowflake":
+            # A real connection is the only confirmation; treat presence as best
+            # effort here to avoid opening a session during detection.
+            has, source = provider_has_credentials("snowflake")
+            return has, source
+    except Exception as exc:  # noqa: BLE001 — verification must never crash
+        return False, f"verify failed: {type(exc).__name__}"
+    return False, "unknown provider"

--- a/tests/test_cli_cloud_scan.py
+++ b/tests/test_cli_cloud_scan.py
@@ -39,6 +39,12 @@ def _capture_scan(monkeypatch):
 def _all_configured(monkeypatch, providers):
     """Force credential auto-detect to report exactly ``providers`` as configured."""
     monkeypatch.setattr(cg, "_provider_configured", lambda p: p in set(providers))
+    # Keep the per-provider status surface consistent with the forced detection.
+    monkeypatch.setattr(
+        cg,
+        "_provider_status",
+        lambda p: (p in set(providers), "test source" if p in set(providers) else "no credentials"),
+    )
 
 
 # ── auto-detect / resolution ────────────────────────────────────────────────
@@ -88,8 +94,10 @@ class TestUnifiedScan:
         assert kw["aws"] is True
         assert kw["gcp_flag"] is True
         assert kw["azure_flag"] is False
-        # Friendly skip note for the unconfigured provider.
-        assert "skipping AZURE" in r.output
+        # Per-provider status: detected ones scanning, the unconfigured one skipped.
+        assert "aws: scanning" in r.output
+        assert "gcp: scanning" in r.output
+        assert "azure: skipped" in r.output
 
     def test_scan_all_no_providers_is_graceful(self, monkeypatch):
         _all_configured(monkeypatch, set())
@@ -189,3 +197,57 @@ class TestDegradation:
         assert len(seen) == 1
         kw = seen[0]
         assert kw["aws"] and kw["azure_flag"] and kw["gcp_flag"]
+
+
+# ── credential-based detection wiring ────────────────────────────────────────
+
+
+class TestCredentialDetection:
+    def test_detect_routes_through_credential_probe(self, monkeypatch):
+        """``_provider_configured`` delegates to the credential probe, not the CLI."""
+        calls: list[str] = []
+
+        def fake_probe(provider):
+            calls.append(provider)
+            return (provider == "aws", "env AWS_WEB_IDENTITY_TOKEN_FILE")
+
+        monkeypatch.setattr("agent_bom.cloud.auth_probe.provider_has_credentials", fake_probe)
+        assert cg._detect_configured_providers() == ["aws"]
+        assert set(calls) >= {"aws", "azure", "gcp"}
+
+    def test_status_line_names_the_credential_source(self, monkeypatch):
+        """`--provider all` surfaces the resolved source per scanning provider."""
+        monkeypatch.setattr(cg, "_provider_configured", lambda p: p == "aws")
+        monkeypatch.setattr(
+            cg,
+            "_provider_status",
+            lambda p: (p == "aws", "env AWS_WEB_IDENTITY_TOKEN_FILE" if p == "aws" else "no credentials"),
+        )
+        _capture_scan(monkeypatch)
+
+        r = CliRunner().invoke(cloud_group, ["scan", "--provider", "all"])
+        assert r.exit_code == 0
+        assert "aws: scanning" in r.output
+        assert "AWS_WEB_IDENTITY_TOKEN_FILE" in r.output
+
+    def test_verify_flag_runs_opt_in_confirmation(self, monkeypatch):
+        """``--verify`` triggers the network confirm path; default never does."""
+        _all_configured(monkeypatch, {"aws"})
+        _capture_scan(monkeypatch)
+        verified: list[str] = []
+
+        def fake_verify(provider):
+            verified.append(provider)
+            return True, "sts: arn:aws:iam::1:role/x"
+
+        monkeypatch.setattr("agent_bom.cloud.auth_probe.verify_credentials", fake_verify)
+
+        # Without --verify: no verification call.
+        CliRunner().invoke(cloud_group, ["scan", "--provider", "aws"])
+        assert verified == []
+
+        # With --verify: the confirm path runs and its result is surfaced.
+        r = CliRunner().invoke(cloud_group, ["scan", "--provider", "aws", "--verify"])
+        assert r.exit_code == 0
+        assert verified == ["aws"]
+        assert "verified" in r.output

--- a/tests/test_cloud_auth_probe.py
+++ b/tests/test_cloud_auth_probe.py
@@ -1,0 +1,233 @@
+"""Credential-based provider detection — :mod:`agent_bom.cloud.auth_probe`.
+
+Pins that providers are detected by actual credential SOURCES (env vars, IRSA /
+workload-identity token files, shared config files, local SDK resolution) and
+NOT by a CLI binary on ``PATH``. This closes both mis-detection modes the old
+``shutil.which`` check had:
+
+- the hosted/EKS collector with IRSA but no ``aws`` CLI is now detected
+  (false negative fixed);
+- an ``aws`` CLI present with zero credentials is no longer a false positive.
+
+Detection makes no network call — every probe here is env/file/local-resolver
+only — so these tests run with no cloud reachable.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from agent_bom.cloud import auth_probe
+
+# Env vars that could leak a real credential source into the test environment.
+_CLEARED = [
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_PROFILE",
+    "AWS_ROLE_ARN",
+    "AWS_WEB_IDENTITY_TOKEN_FILE",
+    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+    "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "AWS_CONFIG_FILE",
+    "AZURE_CLIENT_ID",
+    "AZURE_CLIENT_SECRET",
+    "AZURE_CLIENT_CERTIFICATE_PATH",
+    "AZURE_TENANT_ID",
+    "AZURE_FEDERATED_TOKEN_FILE",
+    "MSI_ENDPOINT",
+    "IDENTITY_ENDPOINT",
+    "AZURE_POD_IDENTITY_AUTHORITY_HOST",
+    "AZURE_CONFIG_DIR",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "AGENT_BOM_GCP_IMPERSONATE_SA",
+    "GOOGLE_IMPERSONATE_SERVICE_ACCOUNT",
+    "CLOUDSDK_CONFIG",
+    "GCE_METADATA_HOST",
+    "GCE_METADATA_ROOT",
+    "GCE_METADATA_IP",
+    "SNOWFLAKE_ACCOUNT",
+    "SNOWFLAKE_USER",
+    "SNOWFLAKE_PRIVATE_KEY_PATH",
+]
+
+
+@pytest.fixture
+def clean_env(monkeypatch, tmp_path):
+    """Strip every credential env var, point HOME at an empty dir, neuter SDKs."""
+    for name in _CLEARED:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    # Force the SDK resolvers to report "nothing resolved" so a real ambient
+    # credential on the test host cannot make a probe pass.
+    fake_boto3 = SimpleNamespace(Session=lambda: SimpleNamespace(get_credentials=lambda: None))
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+
+    def _no_google_default():
+        raise RuntimeError("no ADC")
+
+    fake_google_auth = SimpleNamespace(default=_no_google_default)
+    monkeypatch.setitem(sys.modules, "google.auth", fake_google_auth)
+    return monkeypatch
+
+
+# ── AWS ──────────────────────────────────────────────────────────────────────
+
+
+class TestAWS:
+    def test_irsa_token_file_detected_without_cli(self, clean_env, tmp_path):
+        """The hosted collector case: IRSA token, no ``aws`` CLI → AWS detected."""
+        token = tmp_path / "token"
+        token.write_text("jwt")
+        clean_env.setenv("AWS_WEB_IDENTITY_TOKEN_FILE", str(token))
+        clean_env.setenv("AWS_ROLE_ARN", "arn:aws:iam::123:role/collector")
+        # Even if no `aws` binary exists, credentials are present.
+        clean_env.setattr("shutil.which", lambda _name: None)
+
+        has, source = auth_probe.provider_has_credentials("aws")
+        assert has is True
+        assert "AWS_WEB_IDENTITY_TOKEN_FILE" in source
+
+    def test_access_key_env_detected(self, clean_env):
+        clean_env.setenv("AWS_ACCESS_KEY_ID", "AKIA...")
+        has, source = auth_probe.provider_has_credentials("aws")
+        assert has is True
+        assert "AWS_ACCESS_KEY_ID" in source
+
+    def test_container_role_uri_detected(self, clean_env):
+        clean_env.setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/v2/creds")
+        has, source = auth_probe.provider_has_credentials("aws")
+        assert has is True
+        assert "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" in source
+
+    def test_shared_credentials_file_detected(self, clean_env, tmp_path):
+        creds = tmp_path / "credentials"
+        creds.write_text("[default]\naws_access_key_id=x\n")
+        clean_env.setenv("AWS_SHARED_CREDENTIALS_FILE", str(creds))
+        has, source = auth_probe.provider_has_credentials("aws")
+        assert has is True
+        assert "shared credentials file" in source
+
+    def test_cli_present_zero_creds_is_not_false_positive(self, clean_env):
+        """``aws`` CLI on PATH but no credentials → NOT a positive detection."""
+        clean_env.setattr("shutil.which", lambda name: "/usr/bin/aws" if name == "aws" else None)
+        has, source = auth_probe.provider_has_credentials("aws")
+        assert has is False
+        # The CLI presence is surfaced only as a last-resort hint, not creds.
+        assert "cli present" in source
+
+    def test_no_creds_no_cli(self, clean_env):
+        clean_env.setattr("shutil.which", lambda _name: None)
+        has, source = auth_probe.provider_has_credentials("aws")
+        assert has is False
+        assert source == "no credentials"
+
+
+# ── Azure ────────────────────────────────────────────────────────────────────
+
+
+class TestAzure:
+    def test_workload_identity_detected(self, clean_env, tmp_path):
+        token = tmp_path / "azure-token"
+        token.write_text("jwt")
+        clean_env.setenv("AZURE_FEDERATED_TOKEN_FILE", str(token))
+        has, source = auth_probe.provider_has_credentials("azure")
+        assert has is True
+        assert "AZURE_FEDERATED_TOKEN_FILE" in source
+
+    def test_service_principal_detected(self, clean_env):
+        clean_env.setenv("AZURE_CLIENT_ID", "cid")
+        clean_env.setenv("AZURE_CLIENT_SECRET", "secret")
+        clean_env.setenv("AZURE_TENANT_ID", "tid")
+        has, source = auth_probe.provider_has_credentials("azure")
+        assert has is True
+        assert "service principal" in source
+
+    def test_no_creds(self, clean_env):
+        clean_env.setattr("shutil.which", lambda _name: None)
+        has, _source = auth_probe.provider_has_credentials("azure")
+        assert has is False
+
+
+# ── GCP ──────────────────────────────────────────────────────────────────────
+
+
+class TestGCP:
+    def test_application_credentials_env_detected(self, clean_env, tmp_path):
+        key = tmp_path / "sa.json"
+        key.write_text("{}")
+        clean_env.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(key))
+        has, source = auth_probe.provider_has_credentials("gcp")
+        assert has is True
+        assert "GOOGLE_APPLICATION_CREDENTIALS" in source
+
+    def test_adc_well_known_file_detected(self, clean_env, tmp_path):
+        cfg = tmp_path / "gcloud"
+        cfg.mkdir()
+        (cfg / "application_default_credentials.json").write_text("{}")
+        clean_env.setenv("CLOUDSDK_CONFIG", str(cfg))
+        has, source = auth_probe.provider_has_credentials("gcp")
+        assert has is True
+        assert "ADC file" in source
+
+    def test_impersonation_env_detected(self, clean_env):
+        clean_env.setenv("AGENT_BOM_GCP_IMPERSONATE_SA", "sa@proj.iam.gserviceaccount.com")
+        has, source = auth_probe.provider_has_credentials("gcp")
+        assert has is True
+        assert "impersonation" in source
+
+    def test_no_creds(self, clean_env):
+        clean_env.setattr("shutil.which", lambda _name: None)
+        has, _source = auth_probe.provider_has_credentials("gcp")
+        assert has is False
+
+
+# ── Snowflake ────────────────────────────────────────────────────────────────
+
+
+class TestSnowflake:
+    def test_keypair_detected(self, clean_env, tmp_path):
+        key = tmp_path / "rsa_key.p8"
+        key.write_text("key")
+        clean_env.setenv("SNOWFLAKE_ACCOUNT", "acct")
+        clean_env.setenv("SNOWFLAKE_PRIVATE_KEY_PATH", str(key))
+        has, source = auth_probe.provider_has_credentials("snowflake")
+        assert has is True
+        assert "key-pair" in source
+
+    def test_account_without_user_or_key_not_detected(self, clean_env):
+        clean_env.setenv("SNOWFLAKE_ACCOUNT", "acct")
+        clean_env.setattr("shutil.which", lambda _name: None)
+        has, _source = auth_probe.provider_has_credentials("snowflake")
+        assert has is False
+
+
+# ── contract ─────────────────────────────────────────────────────────────────
+
+
+class TestContract:
+    def test_unknown_provider_never_raises(self):
+        has, source = auth_probe.provider_has_credentials("nope")
+        assert has is False
+        assert source == "unknown provider"
+
+    def test_probe_exception_degrades_to_false(self, clean_env, monkeypatch):
+        def _boom() -> str:
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setitem(auth_probe._PROBES, "aws", _boom)
+        clean_env.setattr("shutil.which", lambda _name: None)
+        has, source = auth_probe.provider_has_credentials("aws")
+        assert has is False
+        assert source == "no credentials"
+
+    def test_source_string_returned_for_ui(self, clean_env):
+        clean_env.setenv("AWS_PROFILE", "prod")
+        has, source = auth_probe.provider_has_credentials("aws")
+        assert has is True
+        assert isinstance(source, str) and source


### PR DESCRIPTION
## Problem

The unified ``cloud`` command auto-detected configured providers with
``shutil.which`` on the provider CLI binary. That mis-detects in both directions:

- **False positive** — AWS CloudShell and most CI images ship the ``aws`` CLI but
  carry no usable credentials. CLI presence reported "AWS configured", the scan
  started, then failed at the first API call.
- **False negative** — a hosted collector on EKS with IRSA / workload-identity
  (``AWS_WEB_IDENTITY_TOKEN_FILE``) has valid credentials but no ``aws`` CLI
  installed, so AWS was skipped even though it was fully scannable.

## Change

New ``cloud/auth_probe.py``:
``provider_has_credentials(provider) -> (bool, source)`` checks the actual
credential *sources* each SDK resolves, with no network call:

- **AWS** — ``AWS_ACCESS_KEY_ID`` / IRSA ``AWS_WEB_IDENTITY_TOKEN_FILE`` /
  container-role URIs / ``AWS_ROLE_ARN``, then local ``boto3`` session
  resolution, then ``AWS_PROFILE``, then shared credentials/config files.
- **Azure** — workload-identity ``AZURE_FEDERATED_TOKEN_FILE``, service principal
  (``AZURE_CLIENT_ID`` + secret/cert + tenant), managed-identity endpoints, az
  CLI token cache.
- **GCP** — ``GOOGLE_APPLICATION_CREDENTIALS``, well-known ADC file,
  impersonation / metadata-server env, ``google.auth.default()`` resolution.
- **Snowflake** — ``SNOWFLAKE_ACCOUNT`` + key-pair path or user.

The returned source lets the surface say exactly what was detected and why. CLI
presence is kept only as a last-resort hint, never a positive detection.

``_provider_configured`` / ``_detect_configured_providers`` are rewired onto the
probe. ``--provider all`` now prints a per-provider status line — scanning with
the resolved source, or skipped with setup guidance. A new opt-in ``--verify``
runs a cheap STS / token confirmation (the only network path).

Detection is deterministic, guards missing optional SDKs, and never raises.

## Validation

- ``ruff check`` + ``ruff format`` clean; ``mypy`` clean on both changed files
  (pre-existing ``postgres_graph.py`` errors are untouched and out of scope).
- ``pytest -k "cloud or provider or detect or auth or credential"`` — 1535 passed.
- New ``tests/test_cloud_auth_probe.py`` (IRSA-without-CLI detection, CLI-present
  zero-creds is not a false positive, ADC/workload-identity/key-pair sources,
  never-raises contract) + extended ``tests/test_cli_cloud_scan.py`` (status
  lines name the source, ``--verify`` opt-in, credential-probe routing).
- No network in detection by default; ``--verify`` is the only network path.