### PR TITLE
fix(cli): degrade gracefully on low disk instead of crashing

### DIFF
--- a/src/agent_bom/cli/_common.py
+++ b/src/agent_bom/cli/_common.py
@@ -257,13 +257,28 @@ _update_check_result: str | None = None
 _update_check_done = threading.Event()
 
 
+def _update_check_cache_file() -> Path:
+    """Path for the once-a-day update-check stamp.
+
+    Honors ``AGENT_BOM_STATE_DIR`` so the write lands off ``$HOME`` (e.g. on a
+    tiny CloudShell home) when the operator redirects state; otherwise uses the
+    per-user XDG cache dir.
+    """
+    import os
+
+    state_dir = os.environ.get("AGENT_BOM_STATE_DIR")
+    base = Path(state_dir) if state_dir else Path.home() / ".cache" / "agent-bom"
+    return base / "update-check.txt"
+
+
 def _check_for_update_bg() -> None:
     """Background thread: compare __version__ against PyPI latest. Non-blocking."""
     global _update_check_result  # noqa: PLW0603
+    import errno
+
     try:
-        cache_dir = Path.home() / ".cache" / "agent-bom"
-        cache_file = cache_dir / "update-check.txt"
-        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file = _update_check_cache_file()
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
 
         # Only hit PyPI once per 24 hours
         import time
@@ -288,7 +303,15 @@ def _check_for_update_bg() -> None:
             )
         else:
             msg = ""
-        cache_file.write_text(msg)
+        try:
+            cache_file.write_text(msg)
+        except OSError as exc:
+            # A full disk must not lose the update notice or crash the scan —
+            # degrade to no-cache (the result is still served this run).
+            if exc.errno in (errno.ENOSPC, errno.EDQUOT):
+                logger.debug("Disk full writing update-check stamp %s — skipping cache", cache_file)
+            else:
+                logger.debug("Could not write update-check stamp %s: %s", cache_file, exc)
         _update_check_result = msg or None
     except Exception:  # noqa: BLE001
         _update_check_result = None

--- a/src/agent_bom/cli/agents/_output.py
+++ b/src/agent_bom/cli/agents/_output.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import contextlib
+import errno
 import json
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 import click
 
@@ -97,6 +99,105 @@ def _resolve_output_path(output: Any, output_format: str) -> str:
     raise SystemExit(2)
 
 
+def _stdout_serialization(
+    report: AIBOMReport,
+    blast_radii: list,
+    output_format: str,
+    *,
+    exclude_unfixable: bool,
+    offline_html: bool,
+) -> str | None:
+    """Best-effort serialize the report for stdout fallback when -o write fails.
+
+    Returns ``None`` for formats that have no usable stdout representation
+    (e.g. binary PDF), in which case the caller prints a skip message instead.
+    """
+    if output_format in ("json", "graph", "badge"):
+        if output_format == "graph":
+            from agent_bom.output.graph import build_graph_elements
+
+            return json.dumps({"elements": build_graph_elements(report, blast_radii), "format": "cytoscape"}, indent=2)
+        if output_format == "badge":
+            from agent_bom.output.badge import to_badge
+
+            return json.dumps(to_badge(report), indent=2)
+        return json.dumps(to_json(report), indent=2)
+    if output_format == "cyclonedx":
+        return json.dumps(to_cyclonedx(report), indent=2)
+    if output_format == "sarif":
+        return json.dumps(to_sarif(report, exclude_unfixable=exclude_unfixable), indent=2)
+    if output_format == "spdx":
+        return json.dumps(to_spdx(report), indent=2)
+    if output_format == "junit":
+        return to_junit(report, blast_radii)
+    if output_format == "csv":
+        return to_csv(report, blast_radii)
+    if output_format == "markdown":
+        return to_markdown(report, blast_radii)
+    if output_format == "prometheus":
+        return to_prometheus(report, blast_radii)
+    if output_format in ("html", "graph-html"):
+        from agent_bom.output import to_html
+
+        return to_html(report, blast_radii, offline_assets=offline_html)
+    if output_format in ("text", "plain"):
+        return _format_text(report, blast_radii)
+    if output_format == "mermaid":
+        from agent_bom.output.mermaid import to_mermaid_supply_chain
+
+        return to_mermaid_supply_chain(report)
+    if output_format == "svg":
+        from agent_bom.output.svg import to_svg
+
+        return to_svg(report, blast_radii)
+    # pdf and any unknown/binary format have no stdout representation
+    return None
+
+
+@contextlib.contextmanager
+def _enospc_report_fallback(
+    con: Any,
+    report: AIBOMReport,
+    blast_radii: list,
+    output_format: str,
+    *,
+    exclude_unfixable: bool,
+    offline_html: bool,
+) -> Iterator[None]:
+    """Catch a full-disk (or any) failure writing the ``-o`` report.
+
+    The scan has already done all the work and computed its findings; a failed
+    report write must NOT crash with a traceback. On ``OSError`` we emit the
+    report to stdout when the format allows (so results are never lost), or
+    print a clear actionable skip message, then let the normal exit-code path
+    run with the scan's real exit code.
+    """
+    try:
+        yield
+    except OSError as exc:
+        is_full = exc.errno in (errno.ENOSPC, errno.EDQUOT)
+        reason = "disk full" if is_full else (exc.strerror or str(exc))
+        target = getattr(exc, "filename", None) or "the report file"
+        serialized = _stdout_serialization(
+            report,
+            blast_radii,
+            output_format,
+            exclude_unfixable=exclude_unfixable,
+            offline_html=offline_html,
+        )
+        if serialized is not None:
+            con.print(f"\n  [yellow]⚠[/yellow] Could not write report to {target} ({reason}) — emitting results to stdout instead.")
+            sys.stdout.write(serialized)
+            if not serialized.endswith("\n"):
+                sys.stdout.write("\n")
+        else:
+            con.print(
+                f"\n  [yellow]⚠[/yellow] Could not write report to {target} ({reason}) — "
+                f"results shown above. Free space, pass -o to a roomier path, or set "
+                f"AGENT_BOM_STATE_DIR=/tmp/agent-bom."
+            )
+
+
 def render_output(
     ctx: ScanContext,
     *,
@@ -126,274 +227,290 @@ def render_output(
     blast_radii = ctx.blast_radii
     is_stdout = output == "-"
 
-    if is_stdout:
-        # Pipe mode: write clean output to stdout
-        if output_format == "cyclonedx":
-            sys.stdout.write(json.dumps(to_cyclonedx(report), indent=2))
-        elif output_format == "sarif":
-            sys.stdout.write(json.dumps(to_sarif(report, exclude_unfixable=exclude_unfixable), indent=2))
-        elif output_format == "spdx":
-            sys.stdout.write(json.dumps(to_spdx(report), indent=2))
-        elif output_format == "html":
-            from agent_bom.output import to_html
+    def _emit_report() -> None:
+        """All console/stdout/file emission for the report.
 
-            sys.stdout.write(to_html(report, blast_radii, offline_assets=offline_html))
+        Wrapped so a failed -o file write (e.g. ENOSPC) degrades to stdout
+        instead of crashing after the scan already computed its findings.
+        """
+        if is_stdout:
+            # Pipe mode: write clean output to stdout
+            if output_format == "cyclonedx":
+                sys.stdout.write(json.dumps(to_cyclonedx(report), indent=2))
+            elif output_format == "sarif":
+                sys.stdout.write(json.dumps(to_sarif(report, exclude_unfixable=exclude_unfixable), indent=2))
+            elif output_format == "spdx":
+                sys.stdout.write(json.dumps(to_spdx(report), indent=2))
+            elif output_format == "html":
+                from agent_bom.output import to_html
+
+                sys.stdout.write(to_html(report, blast_radii, offline_assets=offline_html))
+            elif output_format == "pdf":
+                click.echo("Error: --format pdf requires --output/-o (cannot write PDF to stdout)", err=True)
+                sys.exit(2)
+            elif output_format == "prometheus":
+                sys.stdout.write(to_prometheus(report, blast_radii))
+            elif output_format == "graph":
+                from agent_bom.output.graph import build_graph_elements
+
+                elements = build_graph_elements(report, blast_radii)
+                sys.stdout.write(json.dumps({"elements": elements, "format": "cytoscape"}, indent=2))
+            elif output_format == "mermaid":
+                if mermaid_mode == "attack-flow":
+                    from agent_bom.output.mermaid import to_mermaid
+
+                    sys.stdout.write(to_mermaid(report, blast_radii))
+                elif mermaid_mode == "lifecycle":
+                    from agent_bom.output.mermaid import to_mermaid_lifecycle
+
+                    sys.stdout.write(to_mermaid_lifecycle(report, blast_radii))
+                else:
+                    from agent_bom.output.mermaid import to_mermaid_supply_chain
+
+                    sys.stdout.write(to_mermaid_supply_chain(report))
+            elif output_format == "svg":
+                from agent_bom.output.svg import to_svg
+
+                sys.stdout.write(to_svg(report, blast_radii))
+            elif output_format == "junit":
+                sys.stdout.write(to_junit(report, blast_radii))
+            elif output_format == "csv":
+                sys.stdout.write(to_csv(report, blast_radii))
+            elif output_format == "markdown":
+                sys.stdout.write(to_markdown(report, blast_radii))
+            elif output_format == "graph-html":
+                click.echo("Error: --format graph-html requires --output/-o (cannot write HTML to stdout)", err=True)
+                sys.exit(2)
+            elif agent_mode:
+                payload = success_envelope(
+                    command="agents",
+                    report_json=to_json(report),
+                    exit_code=ctx.exit_code,
+                    token_budget=agent_token_budget,
+                )
+                sys.stdout.write(dumps_envelope(payload))
+            else:
+                sys.stdout.write(json.dumps(to_json(report), indent=2))
+            sys.stdout.write("\n")
+        elif output_format == "console" and not output:
+            _skill_audit_obj = ctx._skill_audit_obj
+            if verbose:
+                # Full output (--verbose)
+                print_summary(report)
+                print_scan_performance_summary(report)
+                print_posture_summary(report)
+                if not no_tree:
+                    print_agent_tree(report)
+                print_severity_chart(report)
+                print_blast_radius(report, fixable_only=fixable_only)
+                if not no_tree:
+                    print_attack_flow_tree(report)
+                print_threat_frameworks(report)
+            else:
+                # Compact output (default) — verdict-led posture summary.
+                print_compact_summary(report, verbose=verbose)
+                print_scan_performance_summary(report)
+                print_compact_agents(report)
+                print_compact_blast_radius(report, fixable_only=fixable_only)
+
+            # AI enrichment output (both modes)
+            if report.executive_summary:
+                from rich.panel import Panel
+
+                con.print("\n[bold]Executive Summary (AI-Generated)[/bold]")
+                con.print(Panel.fit(report.executive_summary, border_style="cyan"))
+            if report.ai_threat_chains:
+                from rich.panel import Panel
+
+                con.print("\n[bold]Threat Chain Analysis (AI-Generated)[/bold]")
+                for chain in report.ai_threat_chains:
+                    con.print(Panel(chain, border_style="red dim"))
+            # AI skill analysis output (if enriched)
+            if _skill_audit_obj and _skill_audit_obj.ai_skill_summary:
+                from rich.panel import Panel
+
+                sev_colors = {"critical": "red bold", "high": "red", "medium": "yellow", "low": "dim", "safe": "green"}
+                risk = _skill_audit_obj.ai_overall_risk_level or "unknown"
+                risk_style = sev_colors.get(risk, "white")
+                con.print(f"\n[bold]Skill File AI Analysis[/bold]  [{risk_style}]\\[{risk.upper()}][/{risk_style}]")
+                con.print(Panel.fit(_skill_audit_obj.ai_skill_summary, border_style="cyan"))
+
+                # Show AI-adjusted findings
+                adjusted = [sk_f for sk_f in _skill_audit_obj.findings if sk_f.ai_adjusted_severity]
+                if adjusted:
+                    for sk_f in adjusted:
+                        if sk_f.ai_adjusted_severity == "false_positive":
+                            con.print(f"  [green]✓ FP[/green] {sk_f.title}")
+                            con.print(f"    [dim]{sk_f.ai_analysis}[/dim]")
+                        else:
+                            con.print(f"  [yellow]↕ ADJ[/yellow] {sk_f.title}: {sk_f.severity} → {sk_f.ai_adjusted_severity}")
+                            if sk_f.ai_analysis:
+                                con.print(f"    [dim]{sk_f.ai_analysis}[/dim]")
+
+                # Show AI-detected new findings
+                ai_detected = [sk_f for sk_f in _skill_audit_obj.findings if sk_f.context == "ai_analysis"]
+                if ai_detected:
+                    con.print(f"\n  [bold yellow]AI-Detected Threats ({len(ai_detected)})[/bold yellow]")
+                    for sk_f in ai_detected:
+                        style = sev_colors.get(sk_f.severity, "white")
+                        con.print(f"    [{style}]\\[{sk_f.severity.upper()}][/{style}] {sk_f.title}")
+                        con.print(f"      [dim]{sk_f.detail}[/dim]")
+                        if sk_f.recommendation:
+                            con.print(f"      [green]→ {sk_f.recommendation}[/green]")
+
+            if verbose:
+                print_remediation_plan(report)
+                print_compact_cis_posture(report, limit=20)
+                print_export_hint(report)
+            else:
+                print_compact_remediation(report)
+                print_compact_cis_posture(report)
+                print_compact_export_hint(report)
+        elif output_format in ("text", "plain") and not output:
+            _print_text(report, blast_radii)
+        elif output_format == "json":
+            if output in (None, "", "-"):
+                sys.stdout.write(json.dumps(to_json(report), indent=2))
+                sys.stdout.write("\n")
+            else:
+                out_path = _resolve_output_path(output, output_format)
+                export_json(report, out_path)
+                con.print(f"\n  [green]✓[/green] JSON report: {out_path}")
+        elif output_format == "cyclonedx":
+            out_path = _resolve_output_path(output, output_format)
+            export_cyclonedx(report, out_path)
+            con.print(f"\n  [green]✓[/green] CycloneDX BOM: {out_path}")
+        elif output_format == "sarif":
+            out_path = _resolve_output_path(output, output_format)
+            export_sarif(report, out_path, exclude_unfixable=exclude_unfixable)
+            con.print(f"\n  [green]✓[/green] SARIF report: {out_path}")
+            if not quiet:
+                con.print("  [dim]SARIF includes enrichment context when available: CVSS/CWE, EPSS, and CISA KEV.[/dim]")
+        elif output_format == "spdx":
+            out_path = _resolve_output_path(output, output_format)
+            export_spdx(report, out_path)
+            con.print(f"\n  [green]✓[/green] SPDX 3.0 BOM: {out_path}")
+        elif output_format == "junit":
+            out_path = _resolve_output_path(output, output_format)
+            export_junit(report, out_path, blast_radii)
+            con.print(f"\n  [green]✓[/green] JUnit XML: {out_path}")
+        elif output_format == "csv":
+            out_path = _resolve_output_path(output, output_format)
+            export_csv(report, out_path, blast_radii)
+            con.print(f"\n  [green]✓[/green] CSV report: {out_path}")
+        elif output_format == "markdown":
+            out_path = _resolve_output_path(output, output_format)
+            export_markdown(report, out_path, blast_radii)
+            con.print(f"\n  [green]✓[/green] Markdown report: {out_path}")
+        elif output_format == "html":
+            out_path = _resolve_output_path(output, output_format)
+            export_html(report, out_path, blast_radii, offline_assets=offline_html)
+            con.print(f"\n  [green]✓[/green] HTML report: {out_path}")
+            if open_report:
+                import webbrowser
+
+                con.print(f"  [green]✓[/green] Opening report in browser: {out_path}")
+                webbrowser.open(f"file://{Path(out_path).resolve()}")
+            else:
+                con.print(f"  [dim]Open with:[/dim] open {out_path}")
         elif output_format == "pdf":
-            click.echo("Error: --format pdf requires --output/-o (cannot write PDF to stdout)", err=True)
-            sys.exit(2)
+            out_path = _resolve_output_path(output, output_format)
+            export_pdf(report, out_path, blast_radii)
+            con.print(f"\n  [green]✓[/green] PDF report: {out_path}")
         elif output_format == "prometheus":
-            sys.stdout.write(to_prometheus(report, blast_radii))
+            out_path = _resolve_output_path(output, output_format)
+            export_prometheus(report, out_path, blast_radii)
+            con.print(f"\n  [green]✓[/green] Prometheus metrics: {out_path}")
+            con.print("  [dim]Scrape with node_exporter textfile or push via --push-gateway[/dim]")
         elif output_format == "graph":
             from agent_bom.output.graph import build_graph_elements
 
+            out_path = _resolve_output_path(output, output_format)
             elements = build_graph_elements(report, blast_radii)
-            sys.stdout.write(json.dumps({"elements": elements, "format": "cytoscape"}, indent=2))
+            Path(out_path).write_text(json.dumps({"elements": elements, "format": "cytoscape"}, indent=2))
+            con.print(f"\n  [green]✓[/green] Graph JSON: {out_path}")
+            con.print("  [dim]Cytoscape.js-compatible element list — open with Cytoscape desktop or any JS graph library[/dim]")
         elif output_format == "mermaid":
+            out_path = _resolve_output_path(output, output_format)
             if mermaid_mode == "attack-flow":
                 from agent_bom.output.mermaid import to_mermaid
 
-                sys.stdout.write(to_mermaid(report, blast_radii))
+                Path(out_path).write_text(to_mermaid(report, blast_radii))
             elif mermaid_mode == "lifecycle":
                 from agent_bom.output.mermaid import to_mermaid_lifecycle
 
-                sys.stdout.write(to_mermaid_lifecycle(report, blast_radii))
+                Path(out_path).write_text(to_mermaid_lifecycle(report, blast_radii))
             else:
                 from agent_bom.output.mermaid import to_mermaid_supply_chain
 
-                sys.stdout.write(to_mermaid_supply_chain(report))
+                Path(out_path).write_text(to_mermaid_supply_chain(report))
+            con.print(f"\n  [green]✓[/green] Mermaid diagram ({mermaid_mode}): {out_path}")
+            con.print("  [dim]Render with: mermaid-cli, GitHub markdown, or mermaid.live[/dim]")
         elif output_format == "svg":
-            from agent_bom.output.svg import to_svg
+            from agent_bom.output.svg import export_svg
 
-            sys.stdout.write(to_svg(report, blast_radii))
-        elif output_format == "junit":
-            sys.stdout.write(to_junit(report, blast_radii))
-        elif output_format == "csv":
-            sys.stdout.write(to_csv(report, blast_radii))
-        elif output_format == "markdown":
-            sys.stdout.write(to_markdown(report, blast_radii))
-        elif output_format == "graph-html":
-            click.echo("Error: --format graph-html requires --output/-o (cannot write HTML to stdout)", err=True)
-            sys.exit(2)
-        elif agent_mode:
-            payload = success_envelope(
-                command="agents",
-                report_json=to_json(report),
-                exit_code=ctx.exit_code,
-                token_budget=agent_token_budget,
-            )
-            sys.stdout.write(dumps_envelope(payload))
-        else:
-            sys.stdout.write(json.dumps(to_json(report), indent=2))
-        sys.stdout.write("\n")
-    elif output_format == "console" and not output:
-        _skill_audit_obj = ctx._skill_audit_obj
-        if verbose:
-            # Full output (--verbose)
-            print_summary(report)
-            print_scan_performance_summary(report)
-            print_posture_summary(report)
-            if not no_tree:
-                print_agent_tree(report)
-            print_severity_chart(report)
-            print_blast_radius(report, fixable_only=fixable_only)
-            if not no_tree:
-                print_attack_flow_tree(report)
-            print_threat_frameworks(report)
-        else:
-            # Compact output (default) — verdict-led posture summary.
-            print_compact_summary(report, verbose=verbose)
-            print_scan_performance_summary(report)
-            print_compact_agents(report)
-            print_compact_blast_radius(report, fixable_only=fixable_only)
-
-        # AI enrichment output (both modes)
-        if report.executive_summary:
-            from rich.panel import Panel
-
-            con.print("\n[bold]Executive Summary (AI-Generated)[/bold]")
-            con.print(Panel.fit(report.executive_summary, border_style="cyan"))
-        if report.ai_threat_chains:
-            from rich.panel import Panel
-
-            con.print("\n[bold]Threat Chain Analysis (AI-Generated)[/bold]")
-            for chain in report.ai_threat_chains:
-                con.print(Panel(chain, border_style="red dim"))
-        # AI skill analysis output (if enriched)
-        if _skill_audit_obj and _skill_audit_obj.ai_skill_summary:
-            from rich.panel import Panel
-
-            sev_colors = {"critical": "red bold", "high": "red", "medium": "yellow", "low": "dim", "safe": "green"}
-            risk = _skill_audit_obj.ai_overall_risk_level or "unknown"
-            risk_style = sev_colors.get(risk, "white")
-            con.print(f"\n[bold]Skill File AI Analysis[/bold]  [{risk_style}]\\[{risk.upper()}][/{risk_style}]")
-            con.print(Panel.fit(_skill_audit_obj.ai_skill_summary, border_style="cyan"))
-
-            # Show AI-adjusted findings
-            adjusted = [sk_f for sk_f in _skill_audit_obj.findings if sk_f.ai_adjusted_severity]
-            if adjusted:
-                for sk_f in adjusted:
-                    if sk_f.ai_adjusted_severity == "false_positive":
-                        con.print(f"  [green]✓ FP[/green] {sk_f.title}")
-                        con.print(f"    [dim]{sk_f.ai_analysis}[/dim]")
-                    else:
-                        con.print(f"  [yellow]↕ ADJ[/yellow] {sk_f.title}: {sk_f.severity} → {sk_f.ai_adjusted_severity}")
-                        if sk_f.ai_analysis:
-                            con.print(f"    [dim]{sk_f.ai_analysis}[/dim]")
-
-            # Show AI-detected new findings
-            ai_detected = [sk_f for sk_f in _skill_audit_obj.findings if sk_f.context == "ai_analysis"]
-            if ai_detected:
-                con.print(f"\n  [bold yellow]AI-Detected Threats ({len(ai_detected)})[/bold yellow]")
-                for sk_f in ai_detected:
-                    style = sev_colors.get(sk_f.severity, "white")
-                    con.print(f"    [{style}]\\[{sk_f.severity.upper()}][/{style}] {sk_f.title}")
-                    con.print(f"      [dim]{sk_f.detail}[/dim]")
-                    if sk_f.recommendation:
-                        con.print(f"      [green]→ {sk_f.recommendation}[/green]")
-
-        if verbose:
-            print_remediation_plan(report)
-            print_compact_cis_posture(report, limit=20)
-            print_export_hint(report)
-        else:
-            print_compact_remediation(report)
-            print_compact_cis_posture(report)
-            print_compact_export_hint(report)
-    elif output_format in ("text", "plain") and not output:
-        _print_text(report, blast_radii)
-    elif output_format == "json":
-        if output in (None, "", "-"):
-            sys.stdout.write(json.dumps(to_json(report), indent=2))
-            sys.stdout.write("\n")
-        else:
             out_path = _resolve_output_path(output, output_format)
-            export_json(report, out_path)
-            con.print(f"\n  [green]✓[/green] JSON report: {out_path}")
-    elif output_format == "cyclonedx":
-        out_path = _resolve_output_path(output, output_format)
-        export_cyclonedx(report, out_path)
-        con.print(f"\n  [green]✓[/green] CycloneDX BOM: {out_path}")
-    elif output_format == "sarif":
-        out_path = _resolve_output_path(output, output_format)
-        export_sarif(report, out_path, exclude_unfixable=exclude_unfixable)
-        con.print(f"\n  [green]✓[/green] SARIF report: {out_path}")
-        if not quiet:
-            con.print("  [dim]SARIF includes enrichment context when available: CVSS/CWE, EPSS, and CISA KEV.[/dim]")
-    elif output_format == "spdx":
-        out_path = _resolve_output_path(output, output_format)
-        export_spdx(report, out_path)
-        con.print(f"\n  [green]✓[/green] SPDX 3.0 BOM: {out_path}")
-    elif output_format == "junit":
-        out_path = _resolve_output_path(output, output_format)
-        export_junit(report, out_path, blast_radii)
-        con.print(f"\n  [green]✓[/green] JUnit XML: {out_path}")
-    elif output_format == "csv":
-        out_path = _resolve_output_path(output, output_format)
-        export_csv(report, out_path, blast_radii)
-        con.print(f"\n  [green]✓[/green] CSV report: {out_path}")
-    elif output_format == "markdown":
-        out_path = _resolve_output_path(output, output_format)
-        export_markdown(report, out_path, blast_radii)
-        con.print(f"\n  [green]✓[/green] Markdown report: {out_path}")
-    elif output_format == "html":
-        out_path = _resolve_output_path(output, output_format)
-        export_html(report, out_path, blast_radii, offline_assets=offline_html)
-        con.print(f"\n  [green]✓[/green] HTML report: {out_path}")
-        if open_report:
-            import webbrowser
+            export_svg(report, blast_radii, out_path)
+            con.print(f"\n  [green]✓[/green] SVG diagram: {out_path}")
+            con.print("  [dim]Open in any browser or image viewer[/dim]")
+        elif output_format == "graph-html":
+            from agent_bom.output.graph import export_graph_html
 
-            con.print(f"  [green]✓[/green] Opening report in browser: {out_path}")
-            webbrowser.open(f"file://{Path(out_path).resolve()}")
-        else:
-            con.print(f"  [dim]Open with:[/dim] open {out_path}")
-    elif output_format == "pdf":
-        out_path = _resolve_output_path(output, output_format)
-        export_pdf(report, out_path, blast_radii)
-        con.print(f"\n  [green]✓[/green] PDF report: {out_path}")
-    elif output_format == "prometheus":
-        out_path = _resolve_output_path(output, output_format)
-        export_prometheus(report, out_path, blast_radii)
-        con.print(f"\n  [green]✓[/green] Prometheus metrics: {out_path}")
-        con.print("  [dim]Scrape with node_exporter textfile or push via --push-gateway[/dim]")
-    elif output_format == "graph":
-        from agent_bom.output.graph import build_graph_elements
+            out_path = _resolve_output_path(output, output_format)
+            export_graph_html(report, blast_radii, out_path, offline_assets=offline_html)
+            con.print(f"\n  [green]✓[/green] Interactive graph: {out_path}")
+            if open_report:
+                import webbrowser
 
-        out_path = _resolve_output_path(output, output_format)
-        elements = build_graph_elements(report, blast_radii)
-        Path(out_path).write_text(json.dumps({"elements": elements, "format": "cytoscape"}, indent=2))
-        con.print(f"\n  [green]✓[/green] Graph JSON: {out_path}")
-        con.print("  [dim]Cytoscape.js-compatible element list — open with Cytoscape desktop or any JS graph library[/dim]")
-    elif output_format == "mermaid":
-        out_path = _resolve_output_path(output, output_format)
-        if mermaid_mode == "attack-flow":
-            from agent_bom.output.mermaid import to_mermaid
+                con.print(f"  [green]✓[/green] Opening report in browser: {out_path}")
+                webbrowser.open(f"file://{Path(out_path).resolve()}")
+            else:
+                con.print(f"  [dim]Open with:[/dim] open {out_path}")
+        elif output_format == "badge":
+            out_path = _resolve_output_path(output, output_format)
+            export_badge(report, out_path)
+            con.print(f"\n  [green]✓[/green] Badge JSON: {out_path}")
+            con.print("  [dim]Use with: https://img.shields.io/endpoint?url=<public-url-to-badge-json>[/dim]")
+        elif output_format in ("text", "plain") and output:
+            out_path = _resolve_output_path(output, output_format)
+            Path(out_path).write_text(_format_text(report, blast_radii))
+            con.print(f"\n  [green]✓[/green] Plain text report: {out_path}")
+        elif output:
+            if output.endswith(".cdx.json"):
+                export_cyclonedx(report, output)
+            elif output.endswith(".json"):
+                export_json(report, output)
+            elif output.endswith(".sarif"):
+                export_sarif(report, output, exclude_unfixable=exclude_unfixable)
+            elif output.endswith(".spdx.json"):
+                export_spdx(report, output)
+            elif output.endswith(".html"):
+                export_html(report, output, blast_radii, offline_assets=offline_html)
+            elif output.endswith(".pdf"):
+                export_pdf(report, output, blast_radii)
+            elif output.endswith(".xml"):
+                export_junit(report, output, blast_radii)
+            elif output.endswith(".csv"):
+                export_csv(report, output, blast_radii)
+            elif output.endswith(".md"):
+                export_markdown(report, output, blast_radii)
+            else:
+                click.echo(
+                    f"Cannot infer output format from '{output}'. Use --format explicitly or choose a supported extension.",
+                    err=True,
+                )
+                raise SystemExit(2)
+            con.print(f"\n  [green]✓[/green] Report: {output}")
 
-            Path(out_path).write_text(to_mermaid(report, blast_radii))
-        elif mermaid_mode == "lifecycle":
-            from agent_bom.output.mermaid import to_mermaid_lifecycle
-
-            Path(out_path).write_text(to_mermaid_lifecycle(report, blast_radii))
-        else:
-            from agent_bom.output.mermaid import to_mermaid_supply_chain
-
-            Path(out_path).write_text(to_mermaid_supply_chain(report))
-        con.print(f"\n  [green]✓[/green] Mermaid diagram ({mermaid_mode}): {out_path}")
-        con.print("  [dim]Render with: mermaid-cli, GitHub markdown, or mermaid.live[/dim]")
-    elif output_format == "svg":
-        from agent_bom.output.svg import export_svg
-
-        out_path = _resolve_output_path(output, output_format)
-        export_svg(report, blast_radii, out_path)
-        con.print(f"\n  [green]✓[/green] SVG diagram: {out_path}")
-        con.print("  [dim]Open in any browser or image viewer[/dim]")
-    elif output_format == "graph-html":
-        from agent_bom.output.graph import export_graph_html
-
-        out_path = _resolve_output_path(output, output_format)
-        export_graph_html(report, blast_radii, out_path, offline_assets=offline_html)
-        con.print(f"\n  [green]✓[/green] Interactive graph: {out_path}")
-        if open_report:
-            import webbrowser
-
-            con.print(f"  [green]✓[/green] Opening report in browser: {out_path}")
-            webbrowser.open(f"file://{Path(out_path).resolve()}")
-        else:
-            con.print(f"  [dim]Open with:[/dim] open {out_path}")
-    elif output_format == "badge":
-        out_path = _resolve_output_path(output, output_format)
-        export_badge(report, out_path)
-        con.print(f"\n  [green]✓[/green] Badge JSON: {out_path}")
-        con.print("  [dim]Use with: https://img.shields.io/endpoint?url=<public-url-to-badge-json>[/dim]")
-    elif output_format in ("text", "plain") and output:
-        out_path = _resolve_output_path(output, output_format)
-        Path(out_path).write_text(_format_text(report, blast_radii))
-        con.print(f"\n  [green]✓[/green] Plain text report: {out_path}")
-    elif output:
-        if output.endswith(".cdx.json"):
-            export_cyclonedx(report, output)
-        elif output.endswith(".json"):
-            export_json(report, output)
-        elif output.endswith(".sarif"):
-            export_sarif(report, output, exclude_unfixable=exclude_unfixable)
-        elif output.endswith(".spdx.json"):
-            export_spdx(report, output)
-        elif output.endswith(".html"):
-            export_html(report, output, blast_radii, offline_assets=offline_html)
-        elif output.endswith(".pdf"):
-            export_pdf(report, output, blast_radii)
-        elif output.endswith(".xml"):
-            export_junit(report, output, blast_radii)
-        elif output.endswith(".csv"):
-            export_csv(report, output, blast_radii)
-        elif output.endswith(".md"):
-            export_markdown(report, output, blast_radii)
-        else:
-            click.echo(
-                f"Cannot infer output format from '{output}'. Use --format explicitly or choose a supported extension.",
-                err=True,
-            )
-            raise SystemExit(2)
-        con.print(f"\n  [green]✓[/green] Report: {output}")
+    with _enospc_report_fallback(
+        con,
+        report,
+        blast_radii,
+        output_format,
+        exclude_unfixable=exclude_unfixable,
+        offline_html=offline_html,
+    ):
+        _emit_report()
 
     # Step 5b: Push to Prometheus Pushgateway (if requested)
     if push_gateway:

--- a/src/agent_bom/enrichment.py
+++ b/src/agent_bom/enrichment.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import json
 import logging
 import os
@@ -43,15 +44,49 @@ NVD_API_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
 EPSS_API_URL = "https://api.first.org/data/v1/epss"
 CISA_KEV_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
 
+
+def _state_dir() -> Path:
+    """Resolve the on-disk state/cache dir, honoring ``AGENT_BOM_STATE_DIR``.
+
+    Redirects every enrichment cache write off ``$HOME`` when the operator
+    points the state dir elsewhere (e.g. ``/tmp`` on a tiny CloudShell home).
+    """
+    return Path(os.environ.get("AGENT_BOM_STATE_DIR", Path.home() / ".agent-bom"))
+
+
 # Cache for CISA KEV catalog (refresh daily, persisted to disk)
 _kev_cache: Optional[dict] = None
 _kev_cache_time: Optional[datetime] = None
-_KEV_CACHE_FILE = Path.home() / ".agent-bom" / "kev_cache.json"
+_KEV_CACHE_FILE = _state_dir() / "kev_cache.json"
 _KEV_CACHE_TTL_SECONDS = 86400  # 24 hours
 
 # ─── Persistent enrichment cache (NVD + EPSS) ──────────────────────────────
 
-_ENRICHMENT_CACHE_DIR = Path.home() / ".agent-bom"
+_ENRICHMENT_CACHE_DIR = _state_dir()
+
+# Deduplicate the low-disk warning so a full cache dir emits one clear line,
+# not one per cache file / per scan.
+_low_disk_warned = False
+
+
+def _is_enospc(exc: OSError) -> bool:
+    """True when an OSError is an out-of-space (ENOSPC) / quota failure."""
+    return exc.errno in (errno.ENOSPC, errno.EDQUOT)
+
+
+def _warn_low_disk_once(target: Path, exc: OSError) -> None:
+    """Emit a single actionable low-disk warning and degrade to no-cache."""
+    global _low_disk_warned  # noqa: PLW0603
+    if _low_disk_warned:
+        _logger.debug("Skipping cache write to %s — disk full (already warned): %s", target, exc)
+        return
+    _low_disk_warned = True
+    _logger.warning(
+        "Disk full writing enrichment cache (%s) — continuing without caching. "
+        "Free space or set AGENT_BOM_STATE_DIR=/tmp/agent-bom to redirect cache off $HOME.",
+        target,
+    )
+
 
 # Module-level in-memory mirrors (loaded lazily from disk)
 _nvd_file_cache: dict[str, dict] = {}
@@ -110,8 +145,19 @@ def _load_enrichment_cache() -> None:
 
 
 def _save_enrichment_cache() -> None:
-    """Persist NVD + EPSS caches to disk (atomic write to prevent corruption)."""
-    _ENRICHMENT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    """Persist NVD + EPSS caches to disk (atomic write to prevent corruption).
+
+    A full disk degrades to no-cache with a single warning rather than
+    propagating ENOSPC — the scan keeps its already-computed findings.
+    """
+    try:
+        _ENRICHMENT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        if _is_enospc(exc):
+            _warn_low_disk_once(_ENRICHMENT_CACHE_DIR, exc)
+        else:
+            _logger.warning("Failed to create enrichment cache dir %s: %s", _ENRICHMENT_CACHE_DIR, exc)
+        return
     for name, data in [("nvd_cache.json", _nvd_file_cache), ("epss_cache.json", _epss_file_cache)]:
         target = _ENRICHMENT_CACHE_DIR / name
         try:
@@ -130,8 +176,11 @@ def _save_enrichment_cache() -> None:
                 except OSError as cleanup_exc:
                     _logger.debug("Failed to remove temp cache file %s: %s", tmp_path, cleanup_exc)
                 raise
-        except OSError:
-            _logger.warning("Failed to persist %s enrichment cache to disk", name)
+        except OSError as exc:
+            if _is_enospc(exc):
+                _warn_low_disk_once(target, exc)
+            else:
+                _logger.warning("Failed to persist %s enrichment cache to disk: %s", name, exc)
 
 
 def _cached_epss_scores(cve_ids: list[str], *, allow_stale: bool = False) -> dict[str, dict]:
@@ -355,6 +404,33 @@ async def fetch_epss_scores(cve_ids: list[str], client: httpx.AsyncClient) -> di
     return scores
 
 
+def _persist_kev_cache(kev_dict: dict) -> None:
+    """Atomically persist the KEV catalog; degrade to no-cache on a full disk."""
+    payload = json.dumps({"_cached_at": time.time(), "data": kev_dict}).encode("utf-8")
+    try:
+        _KEV_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(dir=str(_KEV_CACHE_FILE.parent), suffix=".tmp")
+        fd_closed = False
+        try:
+            os.write(fd, payload)
+            os.close(fd)
+            fd_closed = True
+            os.replace(tmp_path, str(_KEV_CACHE_FILE))
+        except BaseException:
+            if not fd_closed:
+                os.close(fd)
+            try:
+                os.unlink(tmp_path)
+            except OSError as cleanup_exc:
+                _logger.debug("Failed to remove temp KEV cache %s: %s", tmp_path, cleanup_exc)
+            raise
+    except OSError as exc:
+        if _is_enospc(exc):
+            _warn_low_disk_once(_KEV_CACHE_FILE, exc)
+        else:
+            _logger.warning("Failed to persist KEV cache to disk: %s", exc)
+
+
 async def fetch_cisa_kev_catalog(client: httpx.AsyncClient) -> dict:
     """Fetch CISA Known Exploited Vulnerabilities catalog.
 
@@ -404,12 +480,9 @@ async def fetch_cisa_kev_catalog(client: httpx.AsyncClient) -> dict:
             _kev_cache_time = datetime.now(timezone.utc)
             record_enrichment_source("cisa_kev", "success")
 
-            # Persist to disk for cross-session resilience
-            try:
-                _KEV_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
-                _KEV_CACHE_FILE.write_text(json.dumps({"_cached_at": time.time(), "data": kev_dict}))
-            except OSError as exc:
-                _logger.warning("Failed to persist KEV cache to disk: %s", exc)
+            # Persist to disk for cross-session resilience. Atomic temp+rename so
+            # a mid-write ENOSPC never leaves a half-written (corrupt) cache.
+            _persist_kev_cache(kev_dict)
 
             return kev_dict
         except (ValueError, KeyError) as e:

--- a/tests/test_graceful_low_disk.py
+++ b/tests/test_graceful_low_disk.py
@@ -1,0 +1,211 @@
+"""Graceful degradation on a full disk (ENOSPC) — degrade, never crash.
+
+Covers the three write sites that crashed a live low-disk run *after* the scan
+had already computed its findings:
+
+  1. enrichment KEV / NVD / EPSS cache writes  → warn once, continue
+  2. the CLI update-check stamp write          → silently degrade to no-cache
+  3. the ``-o`` report file write              → emit results to stdout / skip,
+     never propagate a traceback (so the real exit code still runs)
+
+Also verifies ``AGENT_BOM_STATE_DIR`` redirects cache writes off ``$HOME``.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+import agent_bom.cli._common as cli_common
+import agent_bom.enrichment as enrichment
+from agent_bom.cli.agents._context import ScanContext
+from agent_bom.cli.agents._output import render_output
+from agent_bom.models import AIBOMReport
+
+
+def _enospc(*_args, **_kwargs):
+    raise OSError(errno.ENOSPC, "No space left on device")
+
+
+# ── enrichment cache writes (site 1) ──────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_enrichment(tmp_path, monkeypatch):
+    monkeypatch.setattr(enrichment, "_ENRICHMENT_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(enrichment, "_KEV_CACHE_FILE", tmp_path / "kev_cache.json")
+    monkeypatch.setattr(enrichment, "_nvd_file_cache", {"CVE-2025-1": {"_cached_at": 0}})
+    monkeypatch.setattr(enrichment, "_epss_file_cache", {})
+    monkeypatch.setattr(enrichment, "_enrichment_cache_loaded", True)
+    monkeypatch.setattr(enrichment, "_low_disk_warned", False)
+
+
+def test_enrichment_cache_enospc_warns_and_continues(monkeypatch, caplog):
+    """A full disk on the NVD/EPSS cache write degrades to no-cache, never raises."""
+    monkeypatch.setattr(enrichment.tempfile, "mkstemp", _enospc)
+    with caplog.at_level("WARNING"):
+        enrichment._save_enrichment_cache()  # must not raise
+    assert any("Disk full" in r.message for r in caplog.records)
+
+
+def test_enrichment_cache_enospc_warning_deduped(monkeypatch, caplog):
+    """The low-disk warning is emitted once, not once per cache file."""
+    monkeypatch.setattr(enrichment.tempfile, "mkstemp", _enospc)
+    with caplog.at_level("WARNING"):
+        enrichment._save_enrichment_cache()
+    low_disk = [r for r in caplog.records if "Disk full" in r.message]
+    assert len(low_disk) == 1  # two cache files (nvd + epss), one warning
+
+
+def test_kev_cache_enospc_no_partial_file(monkeypatch):
+    """A mid-write ENOSPC on the KEV cache leaves no half-written (corrupt) file."""
+    monkeypatch.setattr(enrichment.tempfile, "mkstemp", _enospc)
+    enrichment._persist_kev_cache({"CVE-2025-9": {"date_added": "2026-01-01"}})  # no raise
+    assert not enrichment._KEV_CACHE_FILE.exists()
+
+
+def test_kev_cache_atomic_write_succeeds(tmp_path):
+    """Happy path: KEV cache is written atomically and is readable."""
+    enrichment._persist_kev_cache({"CVE-2025-9": {"date_added": "2026-01-01"}})
+    data = json.loads(enrichment._KEV_CACHE_FILE.read_text())
+    assert data["data"]["CVE-2025-9"]["date_added"] == "2026-01-01"
+    # no leftover temp files
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+# ── AGENT_BOM_STATE_DIR coverage (site 3 of the brief) ─────────────────────────
+
+
+def test_state_dir_redirects_enrichment_off_home(monkeypatch, tmp_path):
+    """AGENT_BOM_STATE_DIR redirects the enrichment cache dir off $HOME."""
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(tmp_path / "roomy"))
+    assert enrichment._state_dir() == tmp_path / "roomy"
+    assert "AGENT_BOM_STATE_DIR" in enrichment._state_dir.__doc__
+
+
+def test_state_dir_defaults_to_home(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_STATE_DIR", raising=False)
+    assert enrichment._state_dir() == Path.home() / ".agent-bom"
+
+
+def test_update_check_stamp_honors_state_dir(monkeypatch, tmp_path):
+    """The CLI update-check stamp lands under AGENT_BOM_STATE_DIR, not $HOME."""
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(tmp_path / "state"))
+    target = cli_common._update_check_cache_file()
+    assert target == tmp_path / "state" / "update-check.txt"
+
+
+# ── update-check stamp write (site 2) ──────────────────────────────────────────
+
+
+def test_update_check_enospc_does_not_crash(monkeypatch, tmp_path):
+    """A full disk on the update-check stamp write must not crash the thread."""
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(cli_common, "_update_check_result", None, raising=False)
+    cli_common._update_check_done.clear()
+
+    import agent_bom.http_client as http_client
+
+    monkeypatch.setattr(
+        http_client,
+        "fetch_json",
+        lambda *_a, **_k: {"info": {"version": "999.0.0"}},
+    )
+
+    real_write_text = Path.write_text
+
+    def _boom(self, *a, **k):
+        if self.name == "update-check.txt":
+            raise OSError(errno.ENOSPC, "No space left on device")
+        return real_write_text(self, *a, **k)
+
+    monkeypatch.setattr(Path, "write_text", _boom)
+
+    cli_common._check_for_update_bg()  # must not raise
+    # update notice still computed and served this run despite the failed cache write
+    assert cli_common._update_check_result is not None
+    assert "999.0.0" in cli_common._update_check_result
+
+
+# ── report -o write (site: the final report) ───────────────────────────────────
+
+
+def _make_ctx(report: AIBOMReport) -> ScanContext:
+    from rich.console import Console
+
+    return ScanContext(con=Console(stderr=True), report=report, blast_radii=[], exit_code=1)
+
+
+def _report() -> AIBOMReport:
+    return AIBOMReport(
+        agents=[],
+        blast_radii=[],
+        generated_at=datetime(2026, 1, 1, 12, 0, 0),
+        tool_version="0.0.0-test",
+    )
+
+
+def test_report_write_enospc_falls_back_to_stdout(monkeypatch, tmp_path, capsys):
+    """A full disk on the -o JSON report write emits results to stdout, no traceback."""
+    out = tmp_path / "report.json"
+
+    import agent_bom.output.json_fmt as json_fmt
+
+    monkeypatch.setattr(json_fmt.Path, "write_text", _enospc, raising=False)
+
+    ctx = _make_ctx(_report())
+    # Must NOT raise — the scan already did all the work.
+    render_output(
+        ctx,
+        output=str(out),
+        output_format="json",
+        no_tree=True,
+        quiet=False,
+        no_color=True,
+        open_report=False,
+        compliance_export=None,
+        mermaid_mode="supply-chain",
+        push_gateway=None,
+        otel_endpoint=None,
+        baseline=None,
+        delta_mode=False,
+    )
+    captured = capsys.readouterr()
+    # JSON report serialized to stdout instead of the unwritable file
+    payload = json.loads(captured.out)
+    assert payload["ai_bom_version"] == "0.0.0-test"
+    assert not out.exists()
+
+
+def test_report_write_enospc_pdf_skips_cleanly(monkeypatch, tmp_path):
+    """PDF has no stdout representation — skip with a clear message, never crash."""
+    out = tmp_path / "report.pdf"
+
+    import agent_bom.cli.agents._output as out_mod
+
+    def _export_pdf_boom(*_a, **_k):
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    monkeypatch.setattr(out_mod, "export_pdf", _export_pdf_boom)
+
+    ctx = _make_ctx(_report())
+    render_output(  # must not raise
+        ctx,
+        output=str(out),
+        output_format="pdf",
+        no_tree=True,
+        quiet=False,
+        no_color=True,
+        open_report=False,
+        compliance_export=None,
+        mermaid_mode="supply-chain",
+        push_gateway=None,
+        otel_endpoint=None,
+        baseline=None,
+        delta_mode=False,
+    )
+    assert not out.exists()


### PR DESCRIPTION
## Problem

On a host with a full home directory, a scan crashed with `[Errno 28] No space left on device` **after** it had already computed its findings. The traceback discarded completed results and returned a non-deterministic failure instead of the scan's real exit code.

## Fix

Every cache/state write and the final report write now degrade instead of propagating:

- **Enrichment caches** (`enrichment.py`): NVD/EPSS and KEV cache writes catch `ENOSPC`/`EDQUOT`, emit a single deduplicated warning, and continue with no caching. The KEV write is now atomic (temp + rename) so a mid-write failure can never leave a half-written, corrupt cache.
- **Update-check stamp** (`cli/_common.py`): honors `AGENT_BOM_STATE_DIR` and degrades to no-cache on a full disk without crashing the background thread; the update notice is still served for the current run.
- **Report `-o` write** (formatter dispatch): a failed file write (`ENOSPC` or any `OSError`) emits the report to stdout when the format has a textual representation, or prints a clear actionable message ("free space, pass `-o` to a roomier path, or set `AGENT_BOM_STATE_DIR=/tmp/agent-bom`"). The normal exit-code path then runs with the scan's real exit code — no traceback.
- **State-dir coverage**: `AGENT_BOM_STATE_DIR` now redirects the enrichment cache dir off `$HOME`.

## Behavior

A full disk yields results + a clear message + the correct exit code, never an Errno-28 traceback. Warnings are deduplicated and no partial corrupt cache is left behind.

## Tests

`tests/test_graceful_low_disk.py` simulates `ENOSPC` by mocking writes to raise `OSError(errno.ENOSPC)`:

- cache write `ENOSPC` → warned once + scan continues
- KEV write `ENOSPC` → no partial file left behind
- report `-o` write `ENOSPC` → results emitted to stdout (findings intact) / clean skip, no traceback
- `AGENT_BOM_STATE_DIR` redirects cache writes off `$HOME`

`ruff check`, `ruff format`, and `mypy` clean on the changed files; targeted suite green.