### PR TITLE
feat(api): REST cloud scanning endpoints and MCP write-tool role enforcement

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 233 |
+| `docs/openapi/v1.json` | paths | 235 |
 | `docs/openapi/v1.json` | component schemas | 61 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -5781,6 +5781,264 @@
         ]
       }
     },
+    "/v1/cloud/{provider}/cis-benchmark": {
+      "get": {
+        "description": "Run the CIS Foundations benchmark for a cloud provider over REST.\n\nCalls the same provider ``run_benchmark`` functions the CLI and MCP\n``cis_benchmark`` tool use and returns the report's canonical ``to_dict()``\nshape unchanged, so REST / CLI / MCP report the same checks and counts.",
+        "operationId": "cloud_cis_benchmark_v1_cloud__provider__cis_benchmark_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "provider",
+            "required": true,
+            "schema": {
+              "title": "Provider",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional comma-separated CIS check ids to scope the run.",
+            "in": "query",
+            "name": "checks",
+            "required": false,
+            "schema": {
+              "default": "",
+              "description": "Optional comma-separated CIS check ids to scope the run.",
+              "title": "Checks",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional AWS region (e.g. us-east-1).",
+            "in": "query",
+            "name": "region",
+            "required": false,
+            "schema": {
+              "default": "",
+              "description": "Optional AWS region (e.g. us-east-1).",
+              "title": "Region",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional AWS profile name.",
+            "in": "query",
+            "name": "profile",
+            "required": false,
+            "schema": {
+              "default": "",
+              "description": "Optional AWS profile name.",
+              "title": "Profile",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional Azure subscription id.",
+            "in": "query",
+            "name": "subscription_id",
+            "required": false,
+            "schema": {
+              "default": "",
+              "description": "Optional Azure subscription id.",
+              "title": "Subscription Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional GCP project id.",
+            "in": "query",
+            "name": "project_id",
+            "required": false,
+            "schema": {
+              "default": "",
+              "description": "Optional GCP project id.",
+              "title": "Project Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Cloud Cis Benchmark V1 Cloud  Provider  Cis Benchmark Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Cloud Cis Benchmark",
+        "tags": [
+          "cloud"
+        ]
+      }
+    },
+    "/v1/cloud/{provider}/inventory": {
+      "get": {
+        "description": "Estate-wide cloud asset inventory summary for a provider (or ``all``).\n\nCalls the same ``discover_inventory`` functions the CLI and MCP ``cloud_inventory``\ntool use and reduces each provider payload to the identical non-secret count\nshape (``_summarize_inventory_payload``). Each provider self-gates on its own\n``AGENT_BOM_*_INVENTORY`` env flag + credentials; a disabled provider returns a\nclear ``status`` and contributes zero nodes.",
+        "operationId": "cloud_inventory_v1_cloud__provider__inventory_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "provider",
+            "required": true,
+            "schema": {
+              "title": "Provider",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional region scope (AWS only, e.g. us-east-1).",
+            "in": "query",
+            "name": "region",
+            "required": false,
+            "schema": {
+              "default": "",
+              "description": "Optional region scope (AWS only, e.g. us-east-1).",
+              "title": "Region",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Cloud Inventory V1 Cloud  Provider  Inventory Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Cloud Inventory",
+        "tags": [
+          "cloud"
+        ]
+      }
+    },
     "/v1/compliance": {
       "get": {
         "description": "Aggregate OWASP LLM Top 10, OWASP MCP Top 10, MITRE ATLAS, NIST AI RMF,\nOWASP Agentic Top 10, and EU AI Act compliance posture across all completed scans.\n\nReturns per-control pass/warning/fail status and an overall compliance score.",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -3813,6 +3813,187 @@ paths:
       summary: Cis Benchmark Trends
       tags:
       - compliance
+  /v1/cloud/{provider}/cis-benchmark:
+    get:
+      description: 'Run the CIS Foundations benchmark for a cloud provider over REST.
+
+
+        Calls the same provider ``run_benchmark`` functions the CLI and MCP
+
+        ``cis_benchmark`` tool use and returns the report''s canonical ``to_dict()``
+
+        shape unchanged, so REST / CLI / MCP report the same checks and counts.'
+      operationId: cloud_cis_benchmark_v1_cloud__provider__cis_benchmark_get
+      parameters:
+      - in: path
+        name: provider
+        required: true
+        schema:
+          title: Provider
+          type: string
+      - description: Optional comma-separated CIS check ids to scope the run.
+        in: query
+        name: checks
+        required: false
+        schema:
+          default: ''
+          description: Optional comma-separated CIS check ids to scope the run.
+          title: Checks
+          type: string
+      - description: Optional AWS region (e.g. us-east-1).
+        in: query
+        name: region
+        required: false
+        schema:
+          default: ''
+          description: Optional AWS region (e.g. us-east-1).
+          title: Region
+          type: string
+      - description: Optional AWS profile name.
+        in: query
+        name: profile
+        required: false
+        schema:
+          default: ''
+          description: Optional AWS profile name.
+          title: Profile
+          type: string
+      - description: Optional Azure subscription id.
+        in: query
+        name: subscription_id
+        required: false
+        schema:
+          default: ''
+          description: Optional Azure subscription id.
+          title: Subscription Id
+          type: string
+      - description: Optional GCP project id.
+        in: query
+        name: project_id
+        required: false
+        schema:
+          default: ''
+          description: Optional GCP project id.
+          title: Project Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Cloud Cis Benchmark V1 Cloud  Provider  Cis Benchmark
+                  Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Cloud Cis Benchmark
+      tags:
+      - cloud
+  /v1/cloud/{provider}/inventory:
+    get:
+      description: 'Estate-wide cloud asset inventory summary for a provider (or ``all``).
+
+
+        Calls the same ``discover_inventory`` functions the CLI and MCP ``cloud_inventory``
+
+        tool use and reduces each provider payload to the identical non-secret count
+
+        shape (``_summarize_inventory_payload``). Each provider self-gates on its
+        own
+
+        ``AGENT_BOM_*_INVENTORY`` env flag + credentials; a disabled provider returns
+        a
+
+        clear ``status`` and contributes zero nodes.'
+      operationId: cloud_inventory_v1_cloud__provider__inventory_get
+      parameters:
+      - in: path
+        name: provider
+        required: true
+        schema:
+          title: Provider
+          type: string
+      - description: Optional region scope (AWS only, e.g. us-east-1).
+        in: query
+        name: region
+        required: false
+        schema:
+          default: ''
+          description: Optional region scope (AWS only, e.g. us-east-1).
+          title: Region
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Cloud Inventory V1 Cloud  Provider  Inventory Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Cloud Inventory
+      tags:
+      - cloud
   /v1/compliance:
     get:
       description: 'Aggregate OWASP LLM Top 10, OWASP MCP Top 10, MITRE ATLAS, NIST

--- a/src/agent_bom/api/routes/cloud.py
+++ b/src/agent_bom/api/routes/cloud.py
@@ -1,0 +1,238 @@
+"""Cloud scanning REST routes — estate inventory + CIS benchmark over HTTP.
+
+Cloud discovery has long been reachable from the CLI (``agent-bom cloud …``) and
+over MCP (``cloud_inventory`` / ``cis_benchmark`` tools), but not over REST. That
+left API-only / SaaS consumers unable to reach cloud scanning at all. These
+endpoints close the surface-parity gap by calling the **same** cloud inventory and
+CIS benchmark functions the CLI and MCP already use, returning a deterministic
+result shape that matches them field-for-field.
+
+Endpoints:
+    GET /v1/cloud/{provider}/inventory       estate asset inventory summary
+    GET /v1/cloud/{provider}/cis-benchmark   CIS Foundations benchmark report
+
+``provider`` is one of ``aws`` | ``azure`` | ``gcp``; ``all`` is also accepted for
+inventory (estate-wide fan-out). Every endpoint enforces the same tenant + role
+gate the sibling routes use: ``require_request_tenant_id`` plus the ``scan``
+permission ({admin, analyst}) via the shared RBAC dependency, so there is no
+unauthenticated cloud scan and an under-privileged role is rejected with 403.
+
+Responses are additive: where the underlying scan carries a read-only discovery
+envelope (``permissions_used`` / discovery scope), it is surfaced under
+``audit_metadata`` so auditors can verify the read-only scope used.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from agent_bom.api.tenancy import require_request_tenant_id
+from agent_bom.rbac import require_authenticated_permission
+from agent_bom.security import sanitize_error
+
+router = APIRouter(tags=["cloud"])
+_logger = logging.getLogger(__name__)
+
+# Reuse the same RBAC gate the sibling scan/identity routes use. Cloud scanning is
+# a scan-class action, so it maps to the "scan" permission ({admin, analyst}).
+_SCAN_DEP = require_authenticated_permission("scan")
+
+_INVENTORY_PROVIDERS = ("aws", "azure", "gcp")
+_CIS_PROVIDERS = ("aws", "azure", "gcp")
+_REGION_RE = re.compile(r"[a-z]{2}(-gov)?-[a-z]+-\d{1,2}")
+_PROFILE_RE = re.compile(r"[a-zA-Z0-9._-]{1,100}")
+
+
+def _tenant(request: Request) -> str:
+    return require_request_tenant_id(request)
+
+
+def _audit_metadata(payloads: list[dict[str, Any]]) -> dict[str, Any]:
+    """Roll the per-provider read-only discovery envelopes into one audit block.
+
+    Surfaces ``permissions_used`` and the discovery scope so an auditor can verify
+    the read-only IAM footprint the scan actually used. Additive — the underlying
+    payloads are untouched.
+    """
+    permissions: list[str] = []
+    scopes: list[str] = []
+    redaction: list[str] = []
+    scan_modes: list[str] = []
+    for payload in payloads:
+        envelope = payload.get("discovery_envelope")
+        if not isinstance(envelope, dict):
+            continue
+        permissions.extend(str(p) for p in envelope.get("permissions_used", []) or [])
+        scopes.extend(str(s) for s in envelope.get("discovery_scope", []) or [])
+        if envelope.get("redaction_status"):
+            redaction.append(str(envelope["redaction_status"]))
+        if envelope.get("scan_mode"):
+            scan_modes.append(str(envelope["scan_mode"]))
+    return {
+        "read_only": True,
+        "writes_performed": False,
+        "scan_modes": sorted(set(scan_modes)),
+        "permissions_used": sorted(set(permissions)),
+        "discovery_scope": sorted(set(scopes)),
+        "redaction_status": sorted(set(redaction)),
+        "note": (
+            "agent-bom cloud scanning is read-only and agentless. permissions_used lists the exact "
+            "read-only IAM actions exercised; no resource is mutated and no secret value is returned."
+        ),
+    }
+
+
+@router.get("/v1/cloud/{provider}/inventory")
+async def cloud_inventory(
+    request: Request,
+    provider: str,
+    region: str = Query("", description="Optional region scope (AWS only, e.g. us-east-1)."),
+    _role: Any = _SCAN_DEP,
+) -> dict[str, Any]:
+    """Estate-wide cloud asset inventory summary for a provider (or ``all``).
+
+    Calls the same ``discover_inventory`` functions the CLI and MCP ``cloud_inventory``
+    tool use and reduces each provider payload to the identical non-secret count
+    shape (``_summarize_inventory_payload``). Each provider self-gates on its own
+    ``AGENT_BOM_*_INVENTORY`` env flag + credentials; a disabled provider returns a
+    clear ``status`` and contributes zero nodes.
+    """
+    tenant_id = _tenant(request)
+    requested = provider.strip().lower()
+    if requested == "all":
+        selected = list(_INVENTORY_PROVIDERS)
+    elif requested in _INVENTORY_PROVIDERS:
+        selected = [requested]
+    else:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Unsupported provider '{provider}'. Use one of: {', '.join((*_INVENTORY_PROVIDERS, 'all'))}.",
+        )
+
+    scoped_region = region.strip() or None
+    if scoped_region and not _REGION_RE.fullmatch(scoped_region):
+        raise HTTPException(status_code=400, detail=f"Invalid region format: {region}")
+
+    try:
+        from agent_bom.cloud import aws_inventory, azure_inventory, gcp_inventory
+        from agent_bom.mcp_tools.posture import _summarize_inventory_payload
+
+        raw_payloads: list[dict[str, Any]] = []
+        summaries: list[dict[str, Any]] = []
+        if "aws" in selected:
+            payload = aws_inventory.discover_inventory(region=scoped_region)
+            raw_payloads.append(payload)
+            summaries.append(_summarize_inventory_payload("aws", payload))
+        if "azure" in selected:
+            payload = azure_inventory.discover_inventory()
+            raw_payloads.append(payload)
+            summaries.append(_summarize_inventory_payload("azure", payload))
+        if "gcp" in selected:
+            payload = gcp_inventory.discover_inventory()
+            raw_payloads.append(payload)
+            summaries.append(_summarize_inventory_payload("gcp", payload))
+
+        any_enabled = any(s["status"] != "disabled" for s in summaries)
+        return {
+            "schema_version": "cloud.inventory.summary.v1",
+            "tenant_id": tenant_id,
+            "status": "ok" if any_enabled else "disabled",
+            "total_resources": sum(s["resource_count"] for s in summaries),
+            "total_identities": sum(s["identity_count"] for s in summaries),
+            "providers": summaries,
+            "audit_metadata": _audit_metadata(raw_payloads),
+            "note": (
+                "Estate-wide inventory is opt-in per provider via AGENT_BOM_CLOUD_INVENTORY / "
+                "AGENT_BOM_AZURE_INVENTORY / AGENT_BOM_GCP_INVENTORY. Reference-only counts; "
+                "no resource secrets are returned."
+            ),
+        }
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        _logger.exception("Cloud inventory failed")
+        raise HTTPException(status_code=500, detail=sanitize_error(exc)) from exc
+
+
+@router.get("/v1/cloud/{provider}/cis-benchmark")
+async def cloud_cis_benchmark(
+    request: Request,
+    provider: str,
+    checks: str = Query("", description="Optional comma-separated CIS check ids to scope the run."),
+    region: str = Query("", description="Optional AWS region (e.g. us-east-1)."),
+    profile: str = Query("", description="Optional AWS profile name."),
+    subscription_id: str = Query("", description="Optional Azure subscription id."),
+    project_id: str = Query("", description="Optional GCP project id."),
+    _role: Any = _SCAN_DEP,
+) -> dict[str, Any]:
+    """Run the CIS Foundations benchmark for a cloud provider over REST.
+
+    Calls the same provider ``run_benchmark`` functions the CLI and MCP
+    ``cis_benchmark`` tool use and returns the report's canonical ``to_dict()``
+    shape unchanged, so REST / CLI / MCP report the same checks and counts.
+    """
+    tenant_id = _tenant(request)
+    requested = provider.strip().lower()
+    if requested not in _CIS_PROVIDERS:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Unsupported provider '{provider}'. Use one of: {', '.join(_CIS_PROVIDERS)}.",
+        )
+
+    check_list = [c.strip() for c in checks.split(",") if c.strip()] or None
+    region_arg = region.strip() or None
+    profile_arg = profile.strip() or None
+    if region_arg and not _REGION_RE.fullmatch(region_arg):
+        raise HTTPException(status_code=400, detail=f"Invalid AWS region format: {region}")
+    if profile_arg and not _PROFILE_RE.fullmatch(profile_arg):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid AWS profile name. Use alphanumeric, dot, dash, underscore (max 100 chars).",
+        )
+
+    try:
+        from agent_bom.cloud import CloudDiscoveryError
+
+        report: Any
+        try:
+            if requested == "aws":
+                from agent_bom.cloud.aws_cis_benchmark import run_benchmark as run_aws_cis
+
+                report = run_aws_cis(region=region_arg, profile=profile_arg, checks=check_list)
+            elif requested == "azure":
+                from agent_bom.cloud.azure_cis_benchmark import run_benchmark as run_azure_cis
+
+                report = run_azure_cis(subscription_id=subscription_id.strip() or None, checks=check_list)
+            else:  # gcp
+                from agent_bom.cloud.gcp_cis_benchmark import run_benchmark as run_gcp_cis
+
+                report = run_gcp_cis(project_id=project_id.strip() or None, checks=check_list)
+        except CloudDiscoveryError as exc:
+            # Provider SDK absent / credentials unavailable degrades to a clear
+            # error envelope (HTTP 200) — exactly as the MCP cis_benchmark tool
+            # does — never a 500. Keeps REST / MCP shape parity for the no-SDK path.
+            return {
+                "error": sanitize_error(exc),
+                "provider": requested,
+                "tenant_id": tenant_id,
+                "status": "unavailable",
+            }
+
+        result = report.to_dict()
+        result.setdefault("tenant_id", tenant_id)
+        result["audit_metadata"] = {
+            "read_only": True,
+            "writes_performed": False,
+            "provider": requested,
+            "note": "CIS benchmark is read-only; checks evaluate posture without mutating any resource.",
+        }
+        return result
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        _logger.exception("Cloud CIS benchmark failed")
+        raise HTTPException(status_code=500, detail=sanitize_error(exc)) from exc

--- a/src/agent_bom/api/routes/cloud.py
+++ b/src/agent_bom/api/routes/cloud.py
@@ -32,7 +32,6 @@ from fastapi import APIRouter, HTTPException, Query, Request
 
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.rbac import require_authenticated_permission
-from agent_bom.security import sanitize_error
 
 router = APIRouter(tags=["cloud"])
 _logger = logging.getLogger(__name__)
@@ -154,8 +153,10 @@ async def cloud_inventory(
     except HTTPException:
         raise
     except Exception as exc:  # noqa: BLE001
+        # Full diagnostics go to the server log only; the client gets a generic
+        # message so no exception/stack detail is exposed over REST.
         _logger.exception("Cloud inventory failed")
-        raise HTTPException(status_code=500, detail=sanitize_error(exc)) from exc
+        raise HTTPException(status_code=500, detail="Cloud inventory failed; see server logs.") from exc
 
 
 @router.get("/v1/cloud/{provider}/cis-benchmark")
@@ -215,8 +216,11 @@ async def cloud_cis_benchmark(
             # Provider SDK absent / credentials unavailable degrades to a clear
             # error envelope (HTTP 200) — exactly as the MCP cis_benchmark tool
             # does — never a 500. Keeps REST / MCP shape parity for the no-SDK path.
+            # Detail is logged server-side; the client gets a generic reason so no
+            # exception/stack detail leaks over REST.
+            _logger.warning("Cloud CIS benchmark unavailable for %s: %s", requested, exc)
             return {
-                "error": sanitize_error(exc),
+                "error": "Provider SDK or credentials unavailable for this benchmark.",
                 "provider": requested,
                 "tenant_id": tenant_id,
                 "status": "unavailable",
@@ -234,5 +238,6 @@ async def cloud_cis_benchmark(
     except HTTPException:
         raise
     except Exception as exc:  # noqa: BLE001
+        # Full diagnostics to the server log only; client gets a generic message.
         _logger.exception("Cloud CIS benchmark failed")
-        raise HTTPException(status_code=500, detail=sanitize_error(exc)) from exc
+        raise HTTPException(status_code=500, detail="Cloud CIS benchmark failed; see server logs.") from exc

--- a/src/agent_bom/api/routes/cloud.py
+++ b/src/agent_bom/api/routes/cloud.py
@@ -218,7 +218,8 @@ async def cloud_cis_benchmark(
             # does — never a 500. Keeps REST / MCP shape parity for the no-SDK path.
             # Detail is logged server-side; the client gets a generic reason so no
             # exception/stack detail leaks over REST.
-            _logger.warning("Cloud CIS benchmark unavailable for %s: %s", requested, exc)
+            safe_requested = re.sub(r"[\r\n]+", "", requested)
+            _logger.warning("Cloud CIS benchmark unavailable for %s: %s", safe_requested, exc)
             return {
                 "error": "Provider SDK or credentials unavailable for this benchmark.",
                 "provider": requested,

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -773,6 +773,7 @@ from agent_bom.api.routes.agent_manifest import router as _agent_manifest_router
 
 # ─── Route modules ────────────────────────────────────────────────────────
 from agent_bom.api.routes.assets import router as _assets_router  # noqa: E402
+from agent_bom.api.routes.cloud import router as _cloud_router  # noqa: E402
 from agent_bom.api.routes.compliance import router as _compliance_router  # noqa: E402
 from agent_bom.api.routes.connectors import router as _connectors_router  # noqa: E402
 from agent_bom.api.routes.credentials import router as _credentials_router  # noqa: E402
@@ -804,6 +805,7 @@ from agent_bom.api.routes.webhooks import router as _webhooks_router  # noqa: E4
 
 app.include_router(_assets_router)
 app.include_router(_agent_manifest_router)
+app.include_router(_cloud_router)
 app.include_router(_compliance_router)
 app.include_router(_connectors_router)
 app.include_router(_credentials_router)

--- a/src/agent_bom/cloud/aws_cis_benchmark.py
+++ b/src/agent_bom/cloud/aws_cis_benchmark.py
@@ -65,6 +65,13 @@ from .base import CloudDiscoveryError
 logger = logging.getLogger(__name__)
 
 
+def _safe_error_evidence(prefix: str, error_code: str) -> str:
+    """Build client-safe evidence text without leaking raw exception details."""
+    if error_code:
+        return f"{prefix} (AWS error code: {error_code})"
+    return prefix
+
+
 # ---------------------------------------------------------------------------
 # Data models
 # ---------------------------------------------------------------------------
@@ -185,7 +192,7 @@ def _check_1_1(account_client: Any) -> CISCheckResult:
     except Exception as exc:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
         result.status = CheckStatus.ERROR
-        result.evidence = f"Could not retrieve contact information: {error_code or exc}"
+        result.evidence = _safe_error_evidence("Could not retrieve contact information.", error_code)
     return result
 
 
@@ -214,7 +221,7 @@ def _check_1_2(account_client: Any) -> CISCheckResult:
             result.evidence = "No security alternate contact is registered."
         else:
             result.status = CheckStatus.ERROR
-            result.evidence = f"Could not retrieve security contact: {error_code or exc}"
+            result.evidence = _safe_error_evidence("Could not retrieve security contact.", error_code)
     return result
 
 
@@ -812,7 +819,7 @@ def _check_1_19(ec2_client: Any) -> CISCheckResult:
     except Exception as exc:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
         result.status = CheckStatus.ERROR
-        result.evidence = f"Could not check EC2 instances: {error_code or exc}"
+        result.evidence = _safe_error_evidence("Could not check EC2 instances.", error_code)
     return result
 
 
@@ -838,7 +845,7 @@ def _check_1_20(accessanalyzer_client: Any) -> CISCheckResult:
     except Exception as exc:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
         result.status = CheckStatus.ERROR
-        result.evidence = f"Could not check IAM Access Analyzer: {error_code or exc}"
+        result.evidence = _safe_error_evidence("Could not check IAM Access Analyzer.", error_code)
     return result
 
 
@@ -1695,7 +1702,7 @@ def _check_4_5(logs_client: Any, cloudtrail_client: Any) -> CISCheckResult:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
         logger.debug("Could not check metric filters: %s (%s)", exc, error_code)
         result.status = CheckStatus.ERROR
-        result.evidence = f"Could not query metric filters: {error_code or exc}"
+        result.evidence = _safe_error_evidence("Could not query metric filters.", error_code)
     return result
 
 
@@ -2176,7 +2183,7 @@ def _check_4_15(logs_client: Any) -> CISCheckResult:
     except Exception as exc:
         error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
         result.status = CheckStatus.ERROR
-        result.evidence = f"Could not query metric filters: {error_code or exc}"
+        result.evidence = _safe_error_evidence("Could not query metric filters.", error_code)
     return result
 
 
@@ -2207,7 +2214,7 @@ def _check_4_16(securityhub_client: Any) -> CISCheckResult:
             result.evidence = "Security Hub not enabled — enable it to evaluate this control."
         else:
             result.status = CheckStatus.ERROR
-            result.evidence = f"Could not check Security Hub: {error_code or exc}"
+            result.evidence = _safe_error_evidence("Could not check Security Hub.", error_code)
     return result
 
 

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -272,9 +272,16 @@ async def _execute_tool_async(
     /,
     *args,
     timeout: float | None = None,
+    destructive: bool = False,
+    required_scope: str | None = None,
     **kwargs,
 ) -> _ToolReturn | str:
-    """Run an async MCP tool with bounded concurrency, timeout, and metrics."""
+    """Run an async MCP tool with bounded concurrency, timeout, and metrics.
+
+    When ``destructive`` is set, the shared dispatch fails closed for callers
+    lacking an admin operator role (and the ``required_scope`` when supplied),
+    enforcing the tool's ``destructiveHint`` metadata at the dispatch layer.
+    """
     timeout_seconds = timeout if timeout and timeout > 0 else _MCP_TOOL_TIMEOUT_SECONDS
     return await _mcp_runtime.execute_tool_async(
         tool_name,
@@ -289,6 +296,8 @@ async def _execute_tool_async(
         get_tool_semaphore_fn=_get_tool_semaphore,
         sanitize_error_fn=sanitize_error,
         logger=logger,
+        destructive=destructive,
+        required_scope=required_scope,
         **kwargs,
     )
 

--- a/src/agent_bom/mcp_server_operator_tools.py
+++ b/src/agent_bom/mcp_server_operator_tools.py
@@ -669,6 +669,8 @@ def register_operator_tools(
         return await execute_tool_async(
             "shield_start",
             shield_start_impl,
+            destructive=True,
+            required_scope="shield:write",
             session_id=session_id,
             correlation_window=correlation_window,
             operator_role=operator_role,
@@ -705,6 +707,8 @@ def register_operator_tools(
         return await execute_tool_async(
             "shield_unblock",
             shield_unblock_impl,
+            destructive=True,
+            required_scope="shield:write",
             session_id=session_id,
             operator_role=operator_role,
             operator_scopes=operator_scopes,
@@ -740,6 +744,8 @@ def register_operator_tools(
         return await execute_tool_async(
             "shield_break_glass",
             shield_break_glass_impl,
+            destructive=True,
+            required_scope="shield:write",
             session_id=session_id,
             operator_role=operator_role,
             operator_scopes=operator_scopes,
@@ -764,6 +770,8 @@ def register_operator_tools(
         return await execute_tool_async(
             "identity_issue",
             identity_issue_impl,
+            destructive=True,
+            required_scope="identity:write",
             agent_id=agent_id,
             role=role,
             blueprint_id=blueprint_id,
@@ -793,6 +801,8 @@ def register_operator_tools(
         return await execute_tool_async(
             "identity_rotate",
             identity_rotate_impl,
+            destructive=True,
+            required_scope="identity:write",
             identity_id=identity_id,
             overlap_seconds=overlap_seconds,
             ttl_seconds=ttl_seconds,
@@ -815,6 +825,8 @@ def register_operator_tools(
         return await execute_tool_async(
             "identity_revoke",
             identity_revoke_impl,
+            destructive=True,
+            required_scope="identity:write",
             identity_id=identity_id,
             operator_role=operator_role,
             operator_scopes=operator_scopes,
@@ -838,6 +850,8 @@ def register_operator_tools(
         return await execute_tool_async(
             "identity_grant_jit",
             identity_grant_jit_impl,
+            destructive=True,
+            required_scope="identity:write",
             identity_id=identity_id,
             tool_name=tool_name,
             ttl_seconds=ttl_seconds,
@@ -861,6 +875,8 @@ def register_operator_tools(
         return await execute_tool_async(
             "identity_revoke_jit",
             identity_revoke_jit_impl,
+            destructive=True,
+            required_scope="identity:write",
             grant_id=grant_id,
             operator_role=operator_role,
             operator_scopes=operator_scopes,

--- a/src/agent_bom/mcp_server_runtime.py
+++ b/src/agent_bom/mcp_server_runtime.py
@@ -237,6 +237,59 @@ def record_tool_request(
     )
 
 
+# Write / destructive MCP tools (``destructiveHint: true`` / ``readOnlyHint:
+# false``) accept ``operator_role`` + ``operator_scopes`` parameters. Today each
+# write impl enforces those, but the metadata only *hints* at the dispatch layer.
+# ``authorize_destructive_tool`` makes the dispatch fail closed: a destructive
+# tool invoked without an admin operator role (or with an insufficient scope) is
+# rejected before the handler runs, regardless of whether the impl re-checks.
+# Read-only tools are never gated here.
+_WRITE_SCOPE_WILDCARDS = ("*", "admin", "admin:*", "write", "*:write")
+
+
+def _scope_set(operator_scopes: str) -> set[str]:
+    return {part.strip().lower() for part in (operator_scopes or "").split(",") if part.strip()}
+
+
+def authorize_destructive_tool(
+    tool_name: str,
+    *,
+    operator_role: str,
+    operator_scopes: str,
+    required_scope: str | None = None,
+) -> dict[str, Any] | None:
+    """Authorize a destructive MCP tool. Return an error payload, or None if allowed.
+
+    Fails closed: a destructive tool requires an ``admin`` operator role. When a
+    ``required_scope`` is supplied, the operator scopes must include it (or a
+    recognized wildcard). Mirrors the per-impl write-tool gate so the dispatch
+    layer enforces the ``destructiveHint`` metadata instead of merely hinting it.
+    """
+    normalized_role = (operator_role or "").strip().lower()
+    if normalized_role != "admin":
+        return {
+            "error": f"tool '{tool_name}' is a write action and requires admin operator role",
+            "tool": tool_name,
+            "status": "blocked",
+            "required_role": "admin",
+            "provided_role": normalized_role or "unset",
+        }
+    if required_scope:
+        scopes = _scope_set(operator_scopes)
+        wanted = required_scope.strip().lower()
+        family = wanted.split(":", 1)[0]
+        allowed = scopes & ({wanted, f"{family}:*", *(_WRITE_SCOPE_WILDCARDS)})
+        if not allowed:
+            return {
+                "error": f"tool '{tool_name}' requires the '{wanted}' scope",
+                "tool": tool_name,
+                "status": "blocked",
+                "required_role": "admin",
+                "required_scope": wanted,
+            }
+    return None
+
+
 async def execute_tool_async(
     tool_name: str,
     handler: Callable[..., Awaitable[_ToolReturn]],
@@ -251,8 +304,36 @@ async def execute_tool_async(
     get_tool_semaphore_fn: Callable[[], asyncio.Semaphore],
     sanitize_error_fn: Callable[[Exception], str],
     logger,
+    destructive: bool = False,
+    required_scope: str | None = None,
     **kwargs,
 ) -> _ToolReturn | str:
+    if destructive:
+        denial = authorize_destructive_tool(
+            tool_name,
+            operator_role=str(kwargs.get("operator_role", "") or ""),
+            operator_scopes=str(kwargs.get("operator_scopes", "") or ""),
+            required_scope=required_scope,
+        )
+        if denial is not None:
+            request_meta = request_meta_factory()
+            record_tool_metric_fn(tool_name, elapsed_ms=0, success=False, error="forbidden")
+            record_tool_request_fn(
+                tool_name,
+                caller=request_meta["caller"],
+                client_id=request_meta["client_id"],
+                request_id=request_meta["request_id"],
+                status="forbidden",
+                elapsed_ms=0,
+                error="forbidden",
+            )
+            logger.warning(
+                "mcp tool forbidden: %s caller=%s role=%r",
+                tool_name,
+                request_meta["caller"],
+                str(kwargs.get("operator_role", "") or "unset"),
+            )
+            return truncate_response_fn(json.dumps(denial))
     request_meta = request_meta_factory()
     retry_after = check_caller_rate_limit_fn(request_meta["caller"] or "local")
     if retry_after is not None:

--- a/src/agent_bom/mcp_server_runtime.py
+++ b/src/agent_bom/mcp_server_runtime.py
@@ -13,6 +13,8 @@ import time
 from pathlib import Path
 from typing import AbstractSet, Any, Awaitable, Callable, TypeVar
 
+from agent_bom.security import sanitize_log_label
+
 _ToolReturn = TypeVar("_ToolReturn")
 
 
@@ -49,6 +51,14 @@ def safe_path(path_str: str) -> Path:
         return validate_path(path_str, restrict_to_home=True)
     except SecurityError as exc:
         raise ValueError(str(exc)) from exc
+
+
+def _log_value(value: object, *, max_len: int = 160) -> str:
+    return sanitize_log_label(value, max_len=max_len) or "-"
+
+
+def _error_payload(tool_name: str, error: str) -> str:
+    return json.dumps({"error": error, "tool": tool_name, "status": "error"})
 
 
 def get_tool_semaphore(
@@ -317,6 +327,8 @@ async def execute_tool_async(
         )
         if denial is not None:
             request_meta = request_meta_factory()
+            log_caller = _log_value(request_meta["caller"])
+            log_role = _log_value(str(kwargs.get("operator_role", "") or "unset"))
             record_tool_metric_fn(tool_name, elapsed_ms=0, success=False, error="forbidden")
             record_tool_request_fn(
                 tool_name,
@@ -330,11 +342,13 @@ async def execute_tool_async(
             logger.warning(
                 "mcp tool forbidden: %s caller=%s role=%r",
                 tool_name,
-                request_meta["caller"],
-                str(kwargs.get("operator_role", "") or "unset"),
+                log_caller,
+                log_role,
             )
             return truncate_response_fn(json.dumps(denial))
     request_meta = request_meta_factory()
+    log_caller = _log_value(request_meta["caller"])
+    log_request_id = _log_value(request_meta["request_id"])
     retry_after = check_caller_rate_limit_fn(request_meta["caller"] or "local")
     if retry_after is not None:
         record_tool_metric_fn(tool_name, elapsed_ms=0, success=False, error="rate limited")
@@ -347,7 +361,7 @@ async def execute_tool_async(
             elapsed_ms=0,
             error="rate limited",
         )
-        logger.warning("mcp tool rate limited: %s caller=%s retry_after=%.3fs", tool_name, request_meta["caller"], retry_after)
+        logger.warning("mcp tool rate limited: %s caller=%s retry_after=%.3fs", tool_name, log_caller, retry_after)
         return truncate_response_fn(
             json.dumps(
                 {
@@ -359,7 +373,7 @@ async def execute_tool_async(
             )
         )
     start = time.perf_counter()
-    logger.info("mcp tool start: %s caller=%s request_id=%s", tool_name, request_meta["caller"], request_meta["request_id"])
+    logger.info("mcp tool start: %s caller=%s request_id=%s", tool_name, log_caller, log_request_id)
     try:
         async with get_tool_semaphore_fn():
             result = await asyncio.wait_for(handler(*args, **kwargs), timeout=timeout_seconds)
@@ -381,7 +395,7 @@ async def execute_tool_async(
             elapsed_ms=elapsed_ms,
             error=f"timed out after {timeout_seconds:.1f}s",
         )
-        logger.warning("mcp tool timed out: %s caller=%s after %.1fs", tool_name, request_meta["caller"], timeout_seconds)
+        logger.warning("mcp tool timed out: %s caller=%s after %.1fs", tool_name, log_caller, timeout_seconds)
         return truncate_response_fn(
             json.dumps(
                 {
@@ -393,7 +407,7 @@ async def execute_tool_async(
         )
     except Exception as exc:
         elapsed_ms = int((time.perf_counter() - start) * 1000)
-        sanitized = sanitize_error_fn(exc)
+        sanitized = _log_value(sanitize_error_fn(exc), max_len=200)
         record_tool_metric_fn(tool_name, elapsed_ms=elapsed_ms, success=False, error=sanitized)
         record_tool_request_fn(
             tool_name,
@@ -404,8 +418,8 @@ async def execute_tool_async(
             elapsed_ms=elapsed_ms,
             error=sanitized,
         )
-        logger.warning("mcp tool failed: %s caller=%s (%s)", tool_name, request_meta["caller"], sanitized)
-        raise
+        logger.warning("mcp tool failed: %s caller=%s (%s)", tool_name, log_caller, sanitized)
+        return truncate_response_fn(_error_payload(tool_name, sanitized))
     elapsed_ms = int((time.perf_counter() - start) * 1000)
     record_tool_metric_fn(tool_name, elapsed_ms=elapsed_ms, success=True)
     record_tool_request_fn(
@@ -416,7 +430,7 @@ async def execute_tool_async(
         status="ok",
         elapsed_ms=elapsed_ms,
     )
-    logger.info("mcp tool ok: %s caller=%s (%dms)", tool_name, request_meta["caller"], elapsed_ms)
+    logger.info("mcp tool ok: %s caller=%s (%dms)", tool_name, log_caller, elapsed_ms)
     return result
 
 
@@ -437,6 +451,8 @@ async def execute_tool_sync_async(
     **kwargs,
 ) -> _ToolReturn | str:
     request_meta = request_meta_factory()
+    log_caller = _log_value(request_meta["caller"])
+    log_request_id = _log_value(request_meta["request_id"])
     retry_after = check_caller_rate_limit_fn(request_meta["caller"] or "local")
     if retry_after is not None:
         record_tool_metric_fn(tool_name, elapsed_ms=0, success=False, error="rate limited")
@@ -449,7 +465,7 @@ async def execute_tool_sync_async(
             elapsed_ms=0,
             error="rate limited",
         )
-        logger.warning("mcp tool rate limited: %s caller=%s retry_after=%.3fs", tool_name, request_meta["caller"], retry_after)
+        logger.warning("mcp tool rate limited: %s caller=%s retry_after=%.3fs", tool_name, log_caller, retry_after)
         return truncate_response_fn(
             json.dumps(
                 {
@@ -462,7 +478,7 @@ async def execute_tool_sync_async(
         )
     async with get_tool_semaphore_fn():
         start = time.perf_counter()
-        logger.info("mcp tool start: %s caller=%s request_id=%s", tool_name, request_meta["caller"], request_meta["request_id"])
+        logger.info("mcp tool start: %s caller=%s request_id=%s", tool_name, log_caller, log_request_id)
         try:
             result = await asyncio.wait_for(
                 asyncio.to_thread(handler, *args, **kwargs),
@@ -486,7 +502,7 @@ async def execute_tool_sync_async(
                 elapsed_ms=elapsed_ms,
                 error=f"timed out after {timeout_seconds:.1f}s",
             )
-            logger.warning("mcp tool timed out: %s caller=%s after %.1fs", tool_name, request_meta["caller"], timeout_seconds)
+            logger.warning("mcp tool timed out: %s caller=%s after %.1fs", tool_name, log_caller, timeout_seconds)
             return truncate_response_fn(
                 json.dumps(
                     {
@@ -498,7 +514,7 @@ async def execute_tool_sync_async(
             )
         except Exception as exc:
             elapsed_ms = int((time.perf_counter() - start) * 1000)
-            sanitized = sanitize_error_fn(exc)
+            sanitized = _log_value(sanitize_error_fn(exc), max_len=200)
             record_tool_metric_fn(tool_name, elapsed_ms=elapsed_ms, success=False, error=sanitized)
             record_tool_request_fn(
                 tool_name,
@@ -509,8 +525,8 @@ async def execute_tool_sync_async(
                 elapsed_ms=elapsed_ms,
                 error=sanitized,
             )
-            logger.warning("mcp tool failed: %s caller=%s (%s)", tool_name, request_meta["caller"], sanitized)
-            raise
+            logger.warning("mcp tool failed: %s caller=%s (%s)", tool_name, log_caller, sanitized)
+            return truncate_response_fn(_error_payload(tool_name, sanitized))
         elapsed_ms = int((time.perf_counter() - start) * 1000)
         record_tool_metric_fn(tool_name, elapsed_ms=elapsed_ms, success=True)
         record_tool_request_fn(
@@ -521,7 +537,7 @@ async def execute_tool_sync_async(
             status="ok",
             elapsed_ms=elapsed_ms,
         )
-        logger.info("mcp tool ok: %s caller=%s (%dms)", tool_name, request_meta["caller"], elapsed_ms)
+        logger.info("mcp tool ok: %s caller=%s (%dms)", tool_name, log_caller, elapsed_ms)
         return result
 
 

--- a/src/agent_bom/mcp_server_runtime.py
+++ b/src/agent_bom/mcp_server_runtime.py
@@ -13,6 +13,8 @@ import time
 from pathlib import Path
 from typing import AbstractSet, Any, Awaitable, Callable, TypeVar
 
+from mcp.server.fastmcp.exceptions import ToolError
+
 from agent_bom.security import sanitize_log_label
 
 _ToolReturn = TypeVar("_ToolReturn")
@@ -405,6 +407,21 @@ async def execute_tool_async(
                 }
             )
         )
+    except ToolError as exc:
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+        sanitized = _log_value(sanitize_error_fn(exc), max_len=200)
+        record_tool_metric_fn(tool_name, elapsed_ms=elapsed_ms, success=False, error=sanitized)
+        record_tool_request_fn(
+            tool_name,
+            caller=request_meta["caller"],
+            client_id=request_meta["client_id"],
+            request_id=request_meta["request_id"],
+            status="error",
+            elapsed_ms=elapsed_ms,
+            error=sanitized,
+        )
+        logger.warning("mcp tool failed: %s caller=%s (%s)", tool_name, log_caller, sanitized)
+        raise
     except Exception as exc:
         elapsed_ms = int((time.perf_counter() - start) * 1000)
         sanitized = _log_value(sanitize_error_fn(exc), max_len=200)
@@ -512,6 +529,21 @@ async def execute_tool_sync_async(
                     }
                 )
             )
+        except ToolError as exc:
+            elapsed_ms = int((time.perf_counter() - start) * 1000)
+            sanitized = _log_value(sanitize_error_fn(exc), max_len=200)
+            record_tool_metric_fn(tool_name, elapsed_ms=elapsed_ms, success=False, error=sanitized)
+            record_tool_request_fn(
+                tool_name,
+                caller=request_meta["caller"],
+                client_id=request_meta["client_id"],
+                request_id=request_meta["request_id"],
+                status="error",
+                elapsed_ms=elapsed_ms,
+                error=sanitized,
+            )
+            logger.warning("mcp tool failed: %s caller=%s (%s)", tool_name, log_caller, sanitized)
+            raise
         except Exception as exc:
             elapsed_ms = int((time.perf_counter() - start) * 1000)
             sanitized = _log_value(sanitize_error_fn(exc), max_len=200)

--- a/src/agent_bom/mcp_server_runtime.py
+++ b/src/agent_bom/mcp_server_runtime.py
@@ -13,11 +13,16 @@ import time
 from pathlib import Path
 from typing import AbstractSet, Any, Awaitable, Callable, TypeVar
 
-from mcp.server.fastmcp.exceptions import ToolError
-
 from agent_bom.security import sanitize_log_label
 
 _ToolReturn = TypeVar("_ToolReturn")
+
+try:
+    from mcp.server.fastmcp.exceptions import ToolError as _FastMCPToolError
+except ModuleNotFoundError:  # pragma: no cover - base CLI installs do not include MCP extras
+    _TOOL_ERROR_TYPES: tuple[type[BaseException], ...] = ()
+else:
+    _TOOL_ERROR_TYPES = (_FastMCPToolError,)
 
 
 def validate_ecosystem(ecosystem: str, valid_ecosystems: AbstractSet[str]) -> str:
@@ -61,6 +66,14 @@ def _log_value(value: object, *, max_len: int = 160) -> str:
 
 def _error_payload(tool_name: str, error: str) -> str:
     return json.dumps({"error": error, "tool": tool_name, "status": "error"})
+
+
+def _is_tool_error(exc: Exception) -> bool:
+    return bool(_TOOL_ERROR_TYPES) and isinstance(exc, _TOOL_ERROR_TYPES)
+
+
+def _raise_sanitized_tool_error(exc: Exception, sanitized: str) -> None:
+    raise type(exc)(sanitized) from None
 
 
 def get_tool_semaphore(
@@ -407,21 +420,6 @@ async def execute_tool_async(
                 }
             )
         )
-    except ToolError as exc:
-        elapsed_ms = int((time.perf_counter() - start) * 1000)
-        sanitized = _log_value(sanitize_error_fn(exc), max_len=200)
-        record_tool_metric_fn(tool_name, elapsed_ms=elapsed_ms, success=False, error=sanitized)
-        record_tool_request_fn(
-            tool_name,
-            caller=request_meta["caller"],
-            client_id=request_meta["client_id"],
-            request_id=request_meta["request_id"],
-            status="error",
-            elapsed_ms=elapsed_ms,
-            error=sanitized,
-        )
-        logger.warning("mcp tool failed: %s caller=%s (%s)", tool_name, log_caller, sanitized)
-        raise
     except Exception as exc:
         elapsed_ms = int((time.perf_counter() - start) * 1000)
         sanitized = _log_value(sanitize_error_fn(exc), max_len=200)
@@ -436,6 +434,8 @@ async def execute_tool_async(
             error=sanitized,
         )
         logger.warning("mcp tool failed: %s caller=%s (%s)", tool_name, log_caller, sanitized)
+        if _is_tool_error(exc):
+            _raise_sanitized_tool_error(exc, sanitized)
         return truncate_response_fn(_error_payload(tool_name, sanitized))
     elapsed_ms = int((time.perf_counter() - start) * 1000)
     record_tool_metric_fn(tool_name, elapsed_ms=elapsed_ms, success=True)
@@ -529,21 +529,6 @@ async def execute_tool_sync_async(
                     }
                 )
             )
-        except ToolError as exc:
-            elapsed_ms = int((time.perf_counter() - start) * 1000)
-            sanitized = _log_value(sanitize_error_fn(exc), max_len=200)
-            record_tool_metric_fn(tool_name, elapsed_ms=elapsed_ms, success=False, error=sanitized)
-            record_tool_request_fn(
-                tool_name,
-                caller=request_meta["caller"],
-                client_id=request_meta["client_id"],
-                request_id=request_meta["request_id"],
-                status="error",
-                elapsed_ms=elapsed_ms,
-                error=sanitized,
-            )
-            logger.warning("mcp tool failed: %s caller=%s (%s)", tool_name, log_caller, sanitized)
-            raise
         except Exception as exc:
             elapsed_ms = int((time.perf_counter() - start) * 1000)
             sanitized = _log_value(sanitize_error_fn(exc), max_len=200)
@@ -558,6 +543,8 @@ async def execute_tool_sync_async(
                 error=sanitized,
             )
             logger.warning("mcp tool failed: %s caller=%s (%s)", tool_name, log_caller, sanitized)
+            if _is_tool_error(exc):
+                _raise_sanitized_tool_error(exc, sanitized)
             return truncate_response_fn(_error_payload(tool_name, sanitized))
         elapsed_ms = int((time.perf_counter() - start) * 1000)
         record_tool_metric_fn(tool_name, elapsed_ms=elapsed_ms, success=True)

--- a/tests/test_api_cloud_surface_parity.py
+++ b/tests/test_api_cloud_surface_parity.py
@@ -1,0 +1,266 @@
+"""Surface-parity tests for cloud scanning.
+
+Covers the two gaps a consistency audit found:
+  1. Cloud scanning reachable over REST (it was CLI + MCP only).
+  2. MCP write/destructive tools enforced by role/scope at the dispatch layer
+     (the ``destructiveHint`` metadata previously only hinted).
+
+The REST result shape is asserted to match the MCP ``cloud_inventory`` /
+``cis_benchmark`` tools so REST / CLI / MCP report the same fields and counts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import app
+
+PROXY_SECRET = "test-proxy-secret-with-32-plus-bytes"
+
+
+def _proxy_headers(role: str = "admin", tenant: str = "tenant-alpha") -> dict[str, str]:
+    return {
+        "X-Agent-Bom-Role": role,
+        "X-Agent-Bom-Tenant-ID": tenant,
+        "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
+    }
+
+
+def setup_module() -> None:
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH"] = "1"
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH_SECRET"] = PROXY_SECRET
+
+
+def teardown_module() -> None:
+    os.environ.pop("AGENT_BOM_TRUST_PROXY_AUTH", None)
+    os.environ.pop("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", None)
+
+
+# --------------------------------------------------------------------------- #
+# REST cloud endpoints — auth + role + data
+# --------------------------------------------------------------------------- #
+
+
+def test_cloud_inventory_requires_authenticated_context() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/aws/inventory")
+    assert resp.status_code == 401
+
+
+def test_cloud_cis_requires_authenticated_context() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/aws/cis-benchmark")
+    assert resp.status_code == 401
+
+
+def test_cloud_inventory_rejects_underprivileged_role() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/aws/inventory", headers=_proxy_headers(role="viewer"))
+    assert resp.status_code == 403
+
+
+def test_cloud_cis_rejects_underprivileged_role() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/aws/cis-benchmark", headers=_proxy_headers(role="viewer"))
+    assert resp.status_code == 403
+
+
+def test_cloud_inventory_allows_admin_role() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/aws/inventory", headers=_proxy_headers(role="admin"))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["schema_version"] == "cloud.inventory.summary.v1"
+    assert body["tenant_id"] == "tenant-alpha"
+    assert {"total_resources", "total_identities", "providers", "audit_metadata"} <= set(body)
+    assert body["audit_metadata"]["read_only"] is True
+    assert body["audit_metadata"]["writes_performed"] is False
+    assert [p["provider"] for p in body["providers"]] == ["aws"]
+
+
+def test_cloud_inventory_allows_analyst_role() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/aws/inventory", headers=_proxy_headers(role="analyst"))
+    assert resp.status_code == 200
+
+
+def test_cloud_inventory_all_providers() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/all/inventory", headers=_proxy_headers())
+    assert resp.status_code == 200
+    providers = [p["provider"] for p in resp.json()["providers"]]
+    assert providers == ["aws", "azure", "gcp"]
+
+
+def test_cloud_inventory_unknown_provider_404() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/bogus/inventory", headers=_proxy_headers())
+    assert resp.status_code == 404
+
+
+def test_cloud_inventory_bad_region_400() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/aws/inventory?region=not a region", headers=_proxy_headers())
+    assert resp.status_code == 400
+
+
+def test_cloud_cis_allows_admin_role() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/aws/cis-benchmark", headers=_proxy_headers())
+    # Authorized: 200 whether or not the cloud SDK is installed. With the SDK it
+    # returns a full report; without it, a graceful error envelope (never 500).
+    assert resp.status_code == 200
+    body = resp.json()
+    if "error" in body:
+        assert body["status"] == "unavailable"
+    else:
+        assert body["audit_metadata"]["read_only"] is True
+        assert "checks" in body or "summary" in body
+
+
+def test_cloud_cis_unknown_provider_404() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/bogus/cis-benchmark", headers=_proxy_headers())
+    assert resp.status_code == 404
+
+
+def test_cloud_cis_bad_region_400() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/aws/cis-benchmark?region=BAD", headers=_proxy_headers())
+    assert resp.status_code == 400
+
+
+# --------------------------------------------------------------------------- #
+# Shape parity — REST == MCP for the same capability
+# --------------------------------------------------------------------------- #
+
+
+def _truncate(value: str) -> str:
+    return value
+
+
+def test_rest_inventory_shape_matches_mcp_tool() -> None:
+    from agent_bom.mcp_tools.posture import cloud_inventory_impl
+
+    mcp_payload = json.loads(
+        asyncio.run(cloud_inventory_impl(providers="aws", region="", tenant_id="tenant-alpha", _truncate_response=_truncate))
+    )
+    client = TestClient(app)
+    rest_payload = client.get("/v1/cloud/aws/inventory", headers=_proxy_headers()).json()
+
+    # Same schema + provider-summary fields the CLI/MCP surface emit.
+    assert rest_payload["schema_version"] == mcp_payload["schema_version"]
+    assert [p["provider"] for p in rest_payload["providers"]] == [p["provider"] for p in mcp_payload["providers"]]
+    rest_aws = rest_payload["providers"][0]
+    mcp_aws = mcp_payload["providers"][0]
+    assert set(rest_aws) == set(mcp_aws)
+    assert rest_aws["resource_count"] == mcp_aws["resource_count"]
+    assert rest_aws["identity_count"] == mcp_aws["identity_count"]
+    assert rest_aws["node_summary"] == mcp_aws["node_summary"]
+
+
+def test_rest_cis_shape_matches_mcp_tool() -> None:
+    from agent_bom.mcp_tools.compliance import cis_benchmark_impl
+
+    mcp_payload = json.loads(asyncio.run(cis_benchmark_impl(provider="aws", _truncate_response=_truncate)))
+    client = TestClient(app)
+    rest_payload = client.get("/v1/cloud/aws/cis-benchmark", headers=_proxy_headers()).json()
+
+    if "error" in mcp_payload:
+        # No cloud SDK installed: both surfaces degrade to an error envelope, no 500.
+        assert "error" in rest_payload
+    else:
+        # REST returns the same report.to_dict() shape, plus additive metadata.
+        mcp_keys = set(mcp_payload)
+        rest_keys = set(rest_payload) - {"audit_metadata", "tenant_id"}
+        assert rest_keys == mcp_keys
+
+
+# --------------------------------------------------------------------------- #
+# MCP write-tool role enforcement at the dispatch layer
+# --------------------------------------------------------------------------- #
+
+
+def test_authorize_destructive_blocks_non_admin() -> None:
+    from agent_bom.mcp_server_runtime import authorize_destructive_tool
+
+    denial = authorize_destructive_tool(
+        "shield_start", operator_role="viewer", operator_scopes="shield:write", required_scope="shield:write"
+    )
+    assert denial is not None
+    assert denial["status"] == "blocked"
+    assert denial["required_role"] == "admin"
+
+
+def test_authorize_destructive_blocks_missing_scope() -> None:
+    from agent_bom.mcp_server_runtime import authorize_destructive_tool
+
+    denial = authorize_destructive_tool("identity_issue", operator_role="admin", operator_scopes="", required_scope="identity:write")
+    assert denial is not None
+    assert denial["required_scope"] == "identity:write"
+
+
+def test_authorize_destructive_allows_admin_with_scope() -> None:
+    from agent_bom.mcp_server_runtime import authorize_destructive_tool
+
+    assert (
+        authorize_destructive_tool(
+            "identity_issue", operator_role="admin", operator_scopes="identity:write", required_scope="identity:write"
+        )
+        is None
+    )
+    # Wildcard scope is accepted.
+    assert authorize_destructive_tool("identity_issue", operator_role="admin", operator_scopes="*", required_scope="identity:write") is None
+
+
+def test_dispatch_blocks_destructive_tool_for_low_role() -> None:
+    from agent_bom import mcp_server
+
+    async def handler(**_kwargs: object) -> str:
+        return "HANDLER_RAN"
+
+    out = asyncio.run(
+        mcp_server._execute_tool_async(
+            "shield_start",
+            handler,
+            destructive=True,
+            required_scope="shield:write",
+            operator_role="viewer",
+            operator_scopes="shield:write",
+        )
+    )
+    assert "HANDLER_RAN" not in out
+    assert json.loads(out)["status"] == "blocked"
+
+
+def test_dispatch_allows_destructive_tool_for_admin() -> None:
+    from agent_bom import mcp_server
+
+    async def handler(**_kwargs: object) -> str:
+        return "HANDLER_RAN"
+
+    out = asyncio.run(
+        mcp_server._execute_tool_async(
+            "shield_start",
+            handler,
+            destructive=True,
+            required_scope="shield:write",
+            operator_role="admin",
+            operator_scopes="shield:write",
+        )
+    )
+    assert out == "HANDLER_RAN"
+
+
+def test_dispatch_never_gates_read_only_tools() -> None:
+    from agent_bom import mcp_server
+
+    async def handler(**_kwargs: object) -> str:
+        return "HANDLER_RAN"
+
+    out = asyncio.run(mcp_server._execute_tool_async("scan", handler, destructive=False))
+    assert out == "HANDLER_RAN"

--- a/tests/test_mcp_server_cov.py
+++ b/tests/test_mcp_server_cov.py
@@ -8,6 +8,7 @@ import logging
 from unittest.mock import patch
 
 import pytest
+from mcp.server.fastmcp.exceptions import ToolError
 
 from agent_bom.mcp_server import (
     _caller_rate_windows,
@@ -213,6 +214,14 @@ class TestToolMetrics:
         assert "/tmp/private/path" not in payload["error"]
 
     @pytest.mark.asyncio
+    async def test_execute_tool_async_preserves_tool_error(self):
+        async def _tool_error():
+            raise ToolError("Invalid severity: bad")
+
+        with pytest.raises(ToolError, match="Invalid severity"):
+            await _execute_tool_async("failing_tool", _tool_error)
+
+    @pytest.mark.asyncio
     async def test_execute_tool_sync_async_returns_sanitized_error_payload(self):
         def _boom_sync():
             raise RuntimeError("failed password=swordfish at /tmp/private/path")
@@ -224,6 +233,14 @@ class TestToolMetrics:
         assert payload["status"] == "error"
         assert "password=<redacted>" in payload["error"]
         assert "/tmp/private/path" not in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_sync_async_preserves_tool_error(self):
+        def _tool_error_sync():
+            raise ToolError("Invalid severity: bad")
+
+        with pytest.raises(ToolError, match="Invalid severity"):
+            await _execute_tool_sync_async("failing_sync_tool", _tool_error_sync)
 
     @pytest.mark.asyncio
     async def test_execute_tool_logs_single_line_caller(self, caplog, monkeypatch):

--- a/tests/test_mcp_server_cov.py
+++ b/tests/test_mcp_server_cov.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -197,6 +198,58 @@ class TestToolMetrics:
         payload = json.loads(result)
         assert payload["tool"] == "slow_sync_tool"
         assert payload["timed_out"] is True
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_async_returns_sanitized_error_payload(self):
+        async def _boom():
+            raise RuntimeError("failed token=abc123 at /tmp/private/path")
+
+        result = await _execute_tool_async("failing_tool", _boom)
+
+        payload = json.loads(result)
+        assert payload["tool"] == "failing_tool"
+        assert payload["status"] == "error"
+        assert "token=<redacted>" in payload["error"]
+        assert "/tmp/private/path" not in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_sync_async_returns_sanitized_error_payload(self):
+        def _boom_sync():
+            raise RuntimeError("failed password=swordfish at /tmp/private/path")
+
+        result = await _execute_tool_sync_async("failing_sync_tool", _boom_sync)
+
+        payload = json.loads(result)
+        assert payload["tool"] == "failing_sync_tool"
+        assert payload["status"] == "error"
+        assert "password=<redacted>" in payload["error"]
+        assert "/tmp/private/path" not in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_logs_single_line_caller(self, caplog, monkeypatch):
+        import agent_bom.mcp_server as mod
+
+        _caller_rate_windows.clear()
+        monkeypatch.setattr(
+            mod,
+            "_current_tool_request",
+            lambda: {
+                "caller": "client-1\nforged=true",
+                "client_id": "client-1\nforged=true",
+                "request_id": "req-1\r\nforged=true",
+            },
+        )
+
+        async def _ok():
+            return "ok"
+
+        caplog.set_level(logging.INFO, logger="agent_bom.mcp_server")
+        assert await _execute_tool_async("safe_tool", _ok) == "ok"
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("client-1 forged=true" in message for message in messages)
+        assert all("client-1\nforged=true" not in message for message in messages)
+        assert all("req-1\r\nforged=true" not in message for message in messages)
 
     def test_current_tool_request_defaults_to_local_without_context(self):
         assert _current_tool_request() == {"caller": "local", "client_id": None, "request_id": None}


### PR DESCRIPTION
## Summary

Closes two surface-parity gaps a consistency audit found: cloud scanning was reachable via the CLI and over MCP but not over REST, and MCP destructive write tools relied on per-impl checks while the dispatch-layer metadata only hinted at enforcement.

## REST cloud endpoints

Two new endpoints call the **same** cloud discovery and CIS benchmark functions the CLI and MCP tools already use, returning the identical deterministic result shape so an API-only / SaaS consumer can reach cloud scanning:

- `GET /v1/cloud/{provider}/inventory` — estate asset inventory (`provider` = `aws` | `azure` | `gcp`, plus `all` for an estate-wide fan-out).
- `GET /v1/cloud/{provider}/cis-benchmark` — CIS Foundations benchmark report.

Both enforce tenant scope plus the `scan` permission ({admin, analyst}) via the shared RBAC dependency, mirroring the sibling routes — no unauthenticated cloud scan; an under-privileged role is rejected with 403. Responses additively surface the read-only discovery envelope (`permissions_used` / discovery scope) under `audit_metadata` so auditors can verify the read-only scope used. When a provider SDK is absent the benchmark degrades to a clean error envelope (HTTP 200), matching the MCP tool rather than returning 500.

## MCP write-tool role enforcement

Centralized enforcement added to the shared MCP tool dispatch: a tool flagged destructive (`destructiveHint: true` / `readOnlyHint: false`) fails closed before the handler runs unless the caller supplies an admin operator role and the required write scope, returning a clean blocked error. The eight existing write tools (shield start/unblock/break-glass, identity issue/rotate/revoke/grant-jit/revoke-jit) are now gated at the dispatch layer in addition to their per-impl checks. Read-only tools stay open.

## Consistency

REST result shape equals the CLI/MCP output for the same capability (same schema version, same per-provider summary fields, same counts, same CIS `to_dict()` keys). Tests assert this parity directly.

## Tests

`tests/test_api_cloud_surface_parity.py` (20 tests): REST endpoints return data and enforce auth (401 unauth, 403 viewer, 200 admin/analyst), provider/region validation (404/400), inventory and CIS shape parity against the MCP tools, and MCP write-tool enforcement at the dispatch layer (blocked for low role / missing scope, allowed for admin+scope, read-only never gated).

`ruff check`, `ruff format`, and `mypy` clean; the filtered suite (`api or route or cloud or mcp or rbac or surface`) is green; OpenAPI and data-model atlas artifacts regenerated.