### PR TITLE
feat(deploy): one-apply EKS platform module + deploy-anywhere guide

### DIFF
--- a/deploy/terraform/platform-eks/README.md
+++ b/deploy/terraform/platform-eks/README.md
@@ -1,0 +1,97 @@
+# platform-eks — one-apply agent-bom control plane on EKS
+
+A single `terraform apply` stands up the full self-hosted agent-bom platform on
+AWS EKS. It ties together the pieces that previously had to be wired by hand:
+
+```
+terraform apply
+   │
+   ├─ (optional) minimal EKS cluster + VPC      terraform-aws-modules/{vpc,eks}
+   ├─ baseline                                  ../aws/baseline  (RDS · IRSA · S3 · Secrets)
+   ├─ control plane (API + UI)                  helm_release of ../../helm/agent-bom
+   └─ (optional) read-only connect role         ../connect-aws   (keyless scanner trust)
+```
+
+This is the **Kubernetes/EKS tier** of the [deploy-anywhere
+guide](../../../docs/DEPLOY_PLATFORM.md). For a laptop/VM run use the
+[full-stack compose](../../docker-compose.fullstack.yml); to install onto a
+cluster you already manage, use [Helm directly](../../helm/agent-bom).
+
+## What it does NOT do
+
+- It does **not** grant write access to your cloud. The only writable
+  infrastructure is the platform's own control-plane database, backup bucket,
+  and Secrets Manager containers. The optional connect role is read-only
+  (`SecurityAudit` + optional `ViewOnlyAccess`).
+- It does **not** write long-lived cluster credentials to disk or state. The
+  `kubernetes`/`helm` providers authenticate with an `aws eks get-token` exec
+  plugin (keyless). The AWS CLI must be on `PATH`.
+
+## Two cluster modes
+
+| Mode | `create_cluster` | You provide | Module provisions |
+|------|------------------|-------------|-------------------|
+| Provision | `true` | region | VPC + EKS + node group + everything below |
+| Reference | `false` | `cluster_name`, `vpc_id`, `private_subnet_ids` | baseline + Helm + (optional) connect role |
+
+## Prerequisites
+
+- Terraform >= 1.5, AWS CLI on `PATH`, `kubectl`.
+- AWS credentials with permission to create the resources in scope.
+- For ingress: an ingress controller (e.g. nginx) and, for TLS, cert-manager
+  already installed on the cluster. Set `domain` + `ingress_annotations`.
+- For `externalSecrets` (enabled by the baseline wiring): the External Secrets
+  Operator with a `ClusterSecretStore` named `aws-secrets-manager`. Without it,
+  populate the `*-control-plane-db` / `*-control-plane-auth` secrets yourself
+  and set `extra_helm_values` to disable External Secrets.
+
+## Usage
+
+```bash
+cd deploy/terraform/platform-eks
+cp terraform.tfvars.example terraform.tfvars   # edit region/domain/mode
+terraform init
+terraform apply
+
+# Reach it
+terraform output how_to_reach_it
+terraform output ui_url
+```
+
+## Key variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `region` | — | AWS region (required) |
+| `create_cluster` | `false` | Provision a minimal cluster vs reference an existing one |
+| `cluster_name` | `agent-bom-platform` | Cluster to create or reference |
+| `node_instance_types` / `node_*_size` | `m6i.large`, 2/2/4 | Managed node-group sizing (provision mode) |
+| `vpc_id` / `private_subnet_ids` | — | Existing network (reference mode) |
+| `db_instance_class` / `db_allocated_storage` / `db_multi_az` | `db.t4g.medium` / 100 / `true` | Control-plane Postgres sizing |
+| `domain` | `""` | Public hostname for the UI/API ingress; empty = no ingress, use port-forward |
+| `image_tag` | `""` | Override the API/UI image tag (empty = chart default) |
+| `extra_helm_values` | `""` | Raw YAML merged last into the Helm release |
+| `create_aws_connect_role` | `false` | Mint the read-only role the scanner assumes |
+
+See `variables.tf` for the full list.
+
+## Outputs
+
+| Output | Purpose |
+|--------|---------|
+| `ui_url` / `api_endpoint` | Where to reach the UI and API |
+| `how_to_reach_it` | Quickstart text (ingress URL or port-forward commands) |
+| `db_endpoint` | Control-plane Postgres endpoint |
+| `scanner_role_arn` | IRSA role bound to the scanner service account |
+| `backup_bucket_name` | S3 bucket for the packaged Postgres backups |
+| `connect_role_arn` | Read-only role the scanner assumes (when enabled) |
+
+## Composition notes
+
+- The Helm values are layered (low → high precedence): baseline wiring → image
+  tag → ingress → your `extra_helm_values`. Anything not covered here is set
+  directly through `extra_helm_values` or by editing your own values file.
+- The baseline module owns RDS, IRSA, S3, and the Secrets Manager containers;
+  this root module only wires their outputs into the chart. To change baseline
+  behavior, pass through the relevant variable or extend the `module.baseline`
+  block.

--- a/deploy/terraform/platform-eks/main.tf
+++ b/deploy/terraform/platform-eks/main.tf
@@ -1,0 +1,286 @@
+###############################################################################
+# agent-bom platform — one-apply root module
+#
+# A single `terraform apply` stands up the full self-hosted control plane on
+# EKS:
+#
+#   1. Cluster        — reference an existing EKS cluster, OR provision a
+#                       minimal managed one (var.create_cluster).
+#   2. Baseline       — RDS (Postgres) + IRSA + S3 backups + Secrets Manager,
+#                       via the maintained ./../aws/baseline module.
+#   3. Control plane  — the packaged Helm chart (API + UI), wired to the
+#                       baseline IRSA role and Secrets Manager secrets.
+#   4. Connect (opt)  — a read-only IAM role (./../connect-aws) the scanner
+#                       assumes to inventory this AWS account. Keyless.
+#
+# Cloud access is read-only; the only writable infrastructure is the platform's
+# own control-plane database, backup bucket, and secret containers.
+###############################################################################
+
+data "aws_caller_identity" "current" {}
+
+###############################################################################
+# 1. Cluster — optional minimal provisioning
+###############################################################################
+
+module "vpc" {
+  count = var.create_cluster ? 1 : 0
+
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.8"
+
+  name = "${var.name}-vpc"
+  cidr = var.cluster_vpc_cidr
+
+  azs             = local.azs
+  private_subnets = [for i, az in local.azs : cidrsubnet(var.cluster_vpc_cidr, 4, i)]
+  public_subnets  = [for i, az in local.azs : cidrsubnet(var.cluster_vpc_cidr, 4, i + 8)]
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  # Tags required so the AWS load balancer controller / EKS can place subnets.
+  private_subnet_tags = { "kubernetes.io/role/internal-elb" = "1" }
+  public_subnet_tags  = { "kubernetes.io/role/elb" = "1" }
+}
+
+module "eks" {
+  count = var.create_cluster ? 1 : 0
+
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.8"
+
+  cluster_name    = var.cluster_name
+  cluster_version = var.cluster_version
+
+  cluster_endpoint_public_access = true
+  enable_irsa                    = true
+
+  vpc_id     = module.vpc[0].vpc_id
+  subnet_ids = module.vpc[0].private_subnets
+
+  eks_managed_node_groups = {
+    default = {
+      instance_types = var.node_instance_types
+      desired_size   = var.node_desired_size
+      min_size       = var.node_min_size
+      max_size       = var.node_max_size
+    }
+  }
+}
+
+###############################################################################
+# 1b. Cluster — referencing an existing one
+###############################################################################
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_eks_cluster" "existing" {
+  count = var.create_cluster ? 0 : 1
+  name  = var.cluster_name
+}
+
+# An existing cluster's IRSA OIDC provider is keyed by the issuer host path.
+data "aws_iam_openid_connect_provider" "existing" {
+  count = var.create_cluster ? 0 : 1
+  url   = data.aws_eks_cluster.existing[0].identity[0].oidc[0].issuer
+}
+
+###############################################################################
+# Resolve a single, branch-free view of the cluster for downstream modules
+###############################################################################
+
+locals {
+  azs = slice(data.aws_availability_zones.available.names, 0, 3)
+
+  cluster_name     = var.create_cluster ? module.eks[0].cluster_name : data.aws_eks_cluster.existing[0].name
+  cluster_endpoint = var.create_cluster ? module.eks[0].cluster_endpoint : data.aws_eks_cluster.existing[0].endpoint
+  cluster_ca       = var.create_cluster ? module.eks[0].cluster_certificate_authority_data : data.aws_eks_cluster.existing[0].certificate_authority[0].data
+
+  oidc_provider_arn = var.create_cluster ? module.eks[0].oidc_provider_arn : data.aws_iam_openid_connect_provider.existing[0].arn
+  oidc_issuer_url   = var.create_cluster ? module.eks[0].cluster_oidc_issuer_url : data.aws_eks_cluster.existing[0].identity[0].oidc[0].issuer
+
+  resolved_vpc_id = var.create_cluster ? module.vpc[0].vpc_id : var.vpc_id
+  resolved_subnets = (
+    var.create_cluster ? module.vpc[0].private_subnets : var.private_subnet_ids
+  )
+
+  effective_image_tag = var.image_tag
+
+  # Ingress values block, emitted only when a domain is supplied.
+  ingress_values = var.domain == "" ? {} : {
+    controlPlane = {
+      ingress = {
+        enabled     = true
+        className   = var.ingress_class_name
+        annotations = var.ingress_annotations
+        hosts       = [{ host = var.domain }]
+        tls = [{
+          hosts      = [var.domain]
+          secretName = "${var.name}-control-plane-tls"
+        }]
+      }
+    }
+  }
+
+  # Optional image tag override block.
+  image_values = local.effective_image_tag == "" ? {} : {
+    image   = { tag = local.effective_image_tag }
+    uiImage = { tag = local.effective_image_tag }
+  }
+}
+
+###############################################################################
+# 2. Baseline — RDS + IRSA + S3 + Secrets
+###############################################################################
+
+module "baseline" {
+  source = "../aws/baseline"
+
+  name         = var.name
+  namespace    = var.namespace
+  release_name = var.name
+
+  cluster_oidc_provider_arn = local.oidc_provider_arn
+  cluster_oidc_issuer_url   = local.oidc_issuer_url
+
+  vpc_id             = local.resolved_vpc_id
+  private_subnet_ids = local.resolved_subnets
+
+  db_instance_class      = var.db_instance_class
+  db_allocated_storage   = var.db_allocated_storage
+  db_multi_az            = var.db_multi_az
+  db_deletion_protection = var.db_deletion_protection
+
+  tags = var.tags
+}
+
+###############################################################################
+# 3. Control plane — Helm release wired to the baseline outputs
+###############################################################################
+
+resource "kubernetes_namespace" "this" {
+  metadata {
+    name = var.namespace
+  }
+}
+
+# Baseline wiring rendered as a values document. Enables the control plane,
+# binds the scanner/backup IRSA roles, and points External Secrets at the
+# Secrets Manager containers the baseline created.
+locals {
+  baseline_values = {
+    controlPlane = {
+      enabled = true
+      externalSecrets = {
+        enabled = true
+        secretStoreRef = {
+          kind = "ClusterSecretStore"
+          name = "aws-secrets-manager"
+        }
+        secrets = [
+          {
+            nameSuffix = "control-plane-db"
+            target     = { name = "${var.name}-control-plane-db" }
+            data = [{
+              secretKey = "AGENT_BOM_POSTGRES_URL"
+              remoteRef = {
+                key      = module.baseline.db_url_secret_name
+                property = "AGENT_BOM_POSTGRES_URL"
+              }
+            }]
+          },
+          {
+            nameSuffix = "control-plane-auth"
+            target     = { name = "${var.name}-control-plane-auth" }
+            data = [{
+              secretKey = "AGENT_BOM_OIDC_ISSUER"
+              remoteRef = {
+                key      = module.baseline.auth_secret_name
+                property = "OIDC_ISSUER"
+              }
+            }]
+          },
+        ]
+      }
+      api = {
+        envFrom = [
+          { secretRef = { name = "${var.name}-control-plane-db" } },
+          { secretRef = { name = "${var.name}-control-plane-auth" } },
+        ]
+      }
+      backup = {
+        enabled = true
+        serviceAccount = {
+          annotations = {
+            "eks.amazonaws.com/role-arn" = module.baseline.backup_role_arn
+          }
+        }
+        destination = {
+          bucket       = module.baseline.backup_bucket_name
+          prefix       = "agent-bom/postgres"
+          bucketRegion = var.region
+        }
+      }
+    }
+    serviceAccount = {
+      annotations = {
+        "eks.amazonaws.com/role-arn" = module.baseline.scanner_role_arn
+      }
+    }
+    scanner = {
+      serviceAccount = {
+        annotations = {
+          "eks.amazonaws.com/role-arn" = module.baseline.scanner_role_arn
+        }
+      }
+    }
+  }
+}
+
+resource "helm_release" "control_plane" {
+  name      = var.name
+  namespace = kubernetes_namespace.this.metadata[0].name
+
+  chart   = var.chart_path
+  version = var.chart_version != "" ? var.chart_version : null
+
+  timeout       = var.helm_timeout_seconds
+  wait          = true
+  atomic        = true
+  recreate_pods = false
+
+  # Precedence (low -> high): baseline wiring, image tag, ingress, user extras.
+  values = compact([
+    yamlencode(local.baseline_values),
+    length(local.image_values) > 0 ? yamlencode(local.image_values) : "",
+    length(local.ingress_values) > 0 ? yamlencode(local.ingress_values) : "",
+    var.extra_helm_values,
+  ])
+
+  depends_on = [module.baseline]
+}
+
+###############################################################################
+# 4. Optional read-only connect role (keyless, scanner IRSA-bound)
+###############################################################################
+
+module "connect_aws" {
+  count = var.create_aws_connect_role ? 1 : 0
+
+  source = "../connect-aws"
+
+  name_prefix               = "${var.name}-readonly"
+  principal_type            = "role"
+  trusted_oidc_provider_arn = local.oidc_provider_arn
+  trusted_oidc_subjects = [
+    "system:serviceaccount:${var.namespace}:${var.name}-scanner",
+  ]
+  trusted_oidc_audience   = "sts.amazonaws.com"
+  attach_view_only_access = true
+
+  tags = var.tags
+}

--- a/deploy/terraform/platform-eks/outputs.tf
+++ b/deploy/terraform/platform-eks/outputs.tf
@@ -1,0 +1,73 @@
+output "cluster_name" {
+  description = "Name of the EKS cluster the platform runs on."
+  value       = local.cluster_name
+}
+
+output "namespace" {
+  description = "Kubernetes namespace the control plane is installed into."
+  value       = var.namespace
+}
+
+output "helm_release_status" {
+  description = "Status of the control-plane Helm release."
+  value       = helm_release.control_plane.status
+}
+
+output "ui_url" {
+  description = "URL to reach the agent-bom UI. Uses the ingress domain when set; otherwise a port-forward hint."
+  value = (
+    var.domain != ""
+    ? "https://${var.domain}"
+    : "Run: kubectl -n ${var.namespace} port-forward svc/${var.name}-ui 3000:3000  →  http://localhost:3000"
+  )
+}
+
+output "api_endpoint" {
+  description = "Base URL for the agent-bom API. Uses the ingress domain when set; otherwise a port-forward hint."
+  value = (
+    var.domain != ""
+    ? "https://${var.domain}/api"
+    : "Run: kubectl -n ${var.namespace} port-forward svc/${var.name}-api 8422:8422  →  http://localhost:8422"
+  )
+}
+
+output "db_endpoint" {
+  description = "Control-plane Postgres endpoint provisioned by the baseline module."
+  value       = module.baseline.db_endpoint
+}
+
+output "scanner_role_arn" {
+  description = "IRSA role ARN bound to the scanner service account."
+  value       = module.baseline.scanner_role_arn
+}
+
+output "backup_bucket_name" {
+  description = "S3 bucket used by the packaged Postgres backup job."
+  value       = module.baseline.backup_bucket_name
+}
+
+output "connect_role_arn" {
+  description = "Read-only IAM role ARN the scanner assumes to inventory this AWS account (empty unless create_aws_connect_role = true)."
+  value       = var.create_aws_connect_role ? module.connect_aws[0].role_arn : ""
+}
+
+locals {
+  reach_with_domain = <<-EOT
+    Platform is reachable at https://${var.domain} once DNS resolves to your
+    ingress controller and certificates are issued.
+      UI:  https://${var.domain}
+      API: https://${var.domain}/api
+  EOT
+
+  reach_port_forward = <<-EOT
+    No domain was set, so no Ingress was created. Reach the platform locally:
+      kubectl -n ${var.namespace} port-forward svc/${var.name}-ui 3000:3000
+      kubectl -n ${var.namespace} port-forward svc/${var.name}-api 8422:8422
+    Then open http://localhost:3000 (UI) and http://localhost:8422 (API).
+  EOT
+}
+
+output "how_to_reach_it" {
+  description = "Quickstart for reaching the freshly-applied platform."
+  value       = var.domain != "" ? local.reach_with_domain : local.reach_port_forward
+}

--- a/deploy/terraform/platform-eks/providers.tf
+++ b/deploy/terraform/platform-eks/providers.tf
@@ -1,0 +1,44 @@
+# Provider wiring for the one-apply platform root module.
+#
+# The aws provider is configured from var.region. The kubernetes and helm
+# providers authenticate against the target EKS cluster — either the one this
+# module provisions (var.create_cluster = true) or a pre-existing cluster
+# referenced by data sources. Both paths resolve to the same locals
+# (cluster_endpoint / cluster_ca / cluster_name) defined in main.tf, so the
+# provider blocks never branch.
+#
+# Auth uses an exec plugin that calls `aws eks get-token`. This keeps the
+# kubeconfig keyless: no long-lived cluster credentials are written to disk or
+# into Terraform state. The AWS CLI must be on PATH where Terraform runs.
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = var.tags
+  }
+}
+
+provider "kubernetes" {
+  host                   = local.cluster_endpoint
+  cluster_ca_certificate = base64decode(local.cluster_ca)
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", local.cluster_name, "--region", var.region]
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = local.cluster_endpoint
+    cluster_ca_certificate = base64decode(local.cluster_ca)
+
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", local.cluster_name, "--region", var.region]
+    }
+  }
+}

--- a/deploy/terraform/platform-eks/terraform.tfvars.example
+++ b/deploy/terraform/platform-eks/terraform.tfvars.example
@@ -1,0 +1,18 @@
+# Example A — provision a fresh, minimal cluster + full platform in one apply.
+region         = "us-east-1"
+create_cluster = true
+cluster_name   = "agent-bom-platform"
+domain         = "agent-bom.internal.example.com"
+
+# Optional: mint the read-only role the scanner assumes to inventory this account.
+create_aws_connect_role = true
+
+# Example B — install onto an existing EKS cluster instead. Comment out the
+# create_cluster block above and uncomment the following:
+#
+# region             = "us-east-1"
+# create_cluster     = false
+# cluster_name       = "my-existing-eks"
+# vpc_id             = "vpc-0123456789abcdef0"
+# private_subnet_ids = ["subnet-aaa", "subnet-bbb", "subnet-ccc"]
+# domain             = "agent-bom.internal.example.com"

--- a/deploy/terraform/platform-eks/variables.tf
+++ b/deploy/terraform/platform-eks/variables.tf
@@ -1,0 +1,194 @@
+###############################################################################
+# Core placement
+###############################################################################
+
+variable "region" {
+  description = "AWS region for the platform (cluster, RDS, S3, Secrets)."
+  type        = string
+}
+
+variable "name" {
+  description = "Base name applied to platform resources and the Helm release."
+  type        = string
+  default     = "agent-bom"
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace the control plane is installed into."
+  type        = string
+  default     = "agent-bom"
+}
+
+variable "tags" {
+  description = "Tags applied to all AWS resources this module manages."
+  type        = map(string)
+  default     = {}
+}
+
+###############################################################################
+# Cluster: reference an existing one, or provision a minimal managed one
+###############################################################################
+
+variable "create_cluster" {
+  description = <<-EOT
+    When true, provision a minimal EKS cluster (and a small VPC) using the
+    community terraform-aws-modules. When false, reference an existing cluster
+    named var.cluster_name; you must also supply vpc_id and private_subnet_ids.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "cluster_name" {
+  description = "Name of the EKS cluster. Created when create_cluster = true, otherwise referenced."
+  type        = string
+  default     = "agent-bom-platform"
+}
+
+variable "cluster_version" {
+  description = "Kubernetes version for the cluster (only used when create_cluster = true)."
+  type        = string
+  default     = "1.30"
+}
+
+variable "node_instance_types" {
+  description = "Instance types for the managed node group (only used when create_cluster = true)."
+  type        = list(string)
+  default     = ["m6i.large"]
+}
+
+variable "node_desired_size" {
+  description = "Desired node count for the managed node group (only used when create_cluster = true)."
+  type        = number
+  default     = 2
+}
+
+variable "node_min_size" {
+  description = "Minimum node count for the managed node group (only used when create_cluster = true)."
+  type        = number
+  default     = 2
+}
+
+variable "node_max_size" {
+  description = "Maximum node count for the managed node group (only used when create_cluster = true)."
+  type        = number
+  default     = 4
+}
+
+variable "cluster_vpc_cidr" {
+  description = "CIDR for the VPC created when create_cluster = true."
+  type        = string
+  default     = "10.42.0.0/16"
+}
+
+# Required only when create_cluster = false (referencing an existing cluster).
+
+variable "vpc_id" {
+  description = "Existing VPC ID that hosts the cluster and RDS. Required when create_cluster = false."
+  type        = string
+  default     = ""
+}
+
+variable "private_subnet_ids" {
+  description = "Existing private subnet IDs for the RDS subnet group. Required when create_cluster = false."
+  type        = list(string)
+  default     = []
+}
+
+###############################################################################
+# Control-plane database sizing (passed through to aws/baseline)
+###############################################################################
+
+variable "db_instance_class" {
+  description = "RDS instance class for the control-plane Postgres database."
+  type        = string
+  default     = "db.t4g.medium"
+}
+
+variable "db_allocated_storage" {
+  description = "Allocated storage in GiB for the RDS instance."
+  type        = number
+  default     = 100
+}
+
+variable "db_multi_az" {
+  description = "Whether to enable Multi-AZ for the control-plane Postgres database."
+  type        = bool
+  default     = true
+}
+
+variable "db_deletion_protection" {
+  description = "Whether to prevent accidental RDS deletion."
+  type        = bool
+  default     = true
+}
+
+###############################################################################
+# Helm release: control-plane chart (API + UI)
+###############################################################################
+
+variable "chart_path" {
+  description = "Path to the packaged Helm chart relative to this module."
+  type        = string
+  default     = "../../helm/agent-bom"
+}
+
+variable "chart_version" {
+  description = "Helm chart version pin. Empty uses whatever chart_path resolves to."
+  type        = string
+  default     = ""
+}
+
+variable "image_tag" {
+  description = "Container image tag for the API and UI images. Empty keeps the chart default."
+  type        = string
+  default     = ""
+}
+
+variable "domain" {
+  description = <<-EOT
+    Public hostname for the UI/API ingress (e.g. agent-bom.internal.example.com).
+    When empty, the chart is installed without an Ingress and you reach the UI
+    via a port-forward or an internal Service.
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "ingress_class_name" {
+  description = "Ingress class used when domain is set."
+  type        = string
+  default     = "nginx"
+}
+
+variable "ingress_annotations" {
+  description = "Extra annotations for the control-plane Ingress (e.g. cert-manager issuer)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "extra_helm_values" {
+  description = "Additional raw YAML values merged last into the Helm release (highest precedence)."
+  type        = string
+  default     = ""
+}
+
+variable "helm_timeout_seconds" {
+  description = "Timeout for the Helm release apply."
+  type        = number
+  default     = 900
+}
+
+###############################################################################
+# Optional read-only cloud connect role (AWS account this platform scans)
+###############################################################################
+
+variable "create_aws_connect_role" {
+  description = <<-EOT
+    When true, also mint a read-only IAM role (via the connect-aws module) that
+    the platform's scanner service account can assume to inventory this AWS
+    account. Keyless: trust is bound to the cluster OIDC issuer + scanner IRSA.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/deploy/terraform/platform-eks/versions.tf
+++ b/deploy/terraform/platform-eks/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.27"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+  }
+}

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -6,7 +6,9 @@ agent-bom is one product with multiple deployable surfaces: local CLI, CI
 scanner, container image, self-hosted API/UI, fleet sync, proxy, gateway, MCP
 server mode, and Snowflake-specific compatibility views. This document covers
 the maintained deployment shapes. For the canonical chooser, start with
-[`site-docs/deployment/overview.md`](../site-docs/deployment/overview.md).
+[`site-docs/deployment/overview.md`](../site-docs/deployment/overview.md). For
+the three-tier deploy-anywhere guide (Compose · EKS one-apply · hosted), see
+[`DEPLOY_PLATFORM.md`](DEPLOY_PLATFORM.md).
 
 ---
 

--- a/docs/DEPLOY_PLATFORM.md
+++ b/docs/DEPLOY_PLATFORM.md
@@ -1,0 +1,166 @@
+# Deploy agent-bom anywhere
+
+agent-bom is one product with one control plane (API + UI) and a stateless
+scanner. You can run that control plane wherever you want it — on a laptop, on
+your own Kubernetes cluster, or as a hosted service where you operate the
+control plane and customers connect read-only. This guide covers all three
+tiers, each with the exact command.
+
+## Posture, in one breath
+
+Across every tier the posture is the same:
+
+- **Read-only on your cloud.** The scanner inventories accounts with read-only
+  roles (`SecurityAudit` / `ViewOnlyAccess`). It never mutates your resources.
+- **Keyless where possible.** Cloud access is via assumable roles bound to OIDC
+  / IRSA, not long-lived keys. Secrets live in your secret manager and are
+  referenced, never minted into Terraform state or kubeconfigs on disk.
+- **Your data stays in your control plane.** The only writable infrastructure
+  is the platform's own Postgres, backup bucket, and secret containers — all in
+  your account.
+
+## The control-plane / collector seam (open-core)
+
+The product is built around a single architectural seam:
+
+```
+   control plane  ──────────────  collector / connect
+   (API + UI + Postgres + graph)   (read-only cloud roles)
+   you always run this             points at the cloud you scan
+```
+
+This seam is what makes "deploy anywhere" work. The **control plane** is the
+same chart/image in all three tiers. The **collector side** is just read-only
+connect roles (`deploy/terraform/connect-*`). In the hosted tier the control
+plane runs in our account and customers apply a connect role pointing back to
+it; in the self-hosted tiers both sides live in your account. The open-core
+line sits at the graph store: the control plane and scanner are open; managed
+hosting and the multi-tenant control plane operations are the commercial layer.
+
+---
+
+## Tier 1 — Self-hosted anywhere (laptop / VM, fastest)
+
+One command brings up API + UI + Postgres with Docker Compose. Best for trying
+the full product, a single-team pilot, or an air-gapped VM.
+
+```bash
+cp .env.example .env            # set POSTGRES_PASSWORD at minimum
+docker compose -f deploy/docker-compose.fullstack.yml up
+```
+
+Then open:
+
+- Dashboard → <http://localhost:3000>
+- API docs → <http://localhost:8422/docs>
+
+To point at a managed Postgres instead of the bundled one, set
+`AGENT_BOM_POSTGRES_URL` and remove the `postgres` service:
+
+```bash
+AGENT_BOM_POSTGRES_URL=postgresql://user:pass@db.example.com:5432/agent_bom \
+  docker compose -f deploy/docker-compose.fullstack.yml up api ui
+```
+
+For a production-shaped single host (Docker secrets, internal-only Postgres,
+split networks) use `deploy/docker-compose.platform.yml`.
+
+---
+
+## Tier 2 — Kubernetes / EKS
+
+### Option A — one `terraform apply` (EKS, recommended)
+
+The [`platform-eks`](../deploy/terraform/platform-eks/) root module stands up
+the full platform in a single apply: it provisions (or references) an EKS
+cluster, calls the `aws/baseline` module for RDS + IRSA + S3 backups + Secrets
+Manager, and `helm_release`s the control-plane chart wired to those outputs.
+Optionally it also mints the read-only connect role the scanner assumes.
+
+```bash
+cd deploy/terraform/platform-eks
+cp terraform.tfvars.example terraform.tfvars   # set region, domain, cluster mode
+terraform init
+terraform apply
+
+terraform output how_to_reach_it
+```
+
+Two modes, selected by one variable:
+
+| `create_cluster` | You provide | Module provisions |
+|------------------|-------------|-------------------|
+| `true` | `region` | VPC + EKS + node group + RDS/IRSA/S3/Secrets + Helm |
+| `false` | `cluster_name`, `vpc_id`, `private_subnet_ids` | RDS/IRSA/S3/Secrets + Helm onto your existing cluster |
+
+Set `create_aws_connect_role = true` to also create the keyless, read-only role
+the scanner uses to inventory the AWS account. See the
+[module README](../deploy/terraform/platform-eks/README.md) for prerequisites
+(ingress controller, cert-manager, External Secrets Operator) and the full
+variable/output reference.
+
+### Option B — Helm onto a cluster you already manage
+
+If you manage cluster provisioning yourself (any Kubernetes, not just EKS),
+install the chart directly:
+
+```bash
+helm upgrade --install agent-bom deploy/helm/agent-bom \
+  --namespace agent-bom --create-namespace \
+  --values deploy/helm/agent-bom/examples/eks-production-values.yaml
+```
+
+The [`examples/`](../deploy/helm/agent-bom/examples/) directory ships values for
+EKS, AKS, GKE, BYO-Postgres, SQLite pilots, collector-only workloads, and more.
+On AWS you can still run `aws/baseline` on its own for RDS/IRSA/S3/Secrets and
+feed its `helm_values_hint` output into your values file.
+
+---
+
+## Tier 3 — Hosted / SaaS (you run the control plane)
+
+The hosted tier is the same control plane chart, operated centrally, with
+customers connecting read-only across the control-plane / collector seam:
+
+1. **You run the control plane** — deploy the chart (Tier 2) in your account,
+   multi-tenant, behind your ingress and identity provider.
+2. **Customers connect read-only** — each customer applies a connect module
+   (`deploy/terraform/connect-aws`, `connect-azure`, `connect-gcp`,
+   `connect-snowflake`) that mints a read-only role trusting your hosted
+   scanner principal:
+
+   ```bash
+   cd deploy/terraform/connect-aws
+   terraform apply \
+     -var 'trusted_principal_arns=["arn:aws:iam::<your-hosted-account>:role/agent-bom-scanner"]'
+
+   terraform output role_arn               # hand this to the hosted control plane
+   terraform output -raw external_id       # confused-deputy guard
+   ```
+
+3. **The scanner assumes the role** — your control plane inventories the
+   customer account using only that read-only role. No keys leave the customer
+   account; no customer data is mutated.
+
+This is the same primitive used by `create_aws_connect_role` in the EKS module,
+just pointed at a hosted scanner instead of a local one.
+
+---
+
+## Choosing a tier
+
+| Need | Tier |
+|------|------|
+| Fastest look at the full product | 1 — Docker Compose |
+| Single team / air-gapped VM | 1 — Docker Compose (or `docker-compose.platform.yml`) |
+| Production on AWS, one command | 2A — `platform-eks` Terraform |
+| Production on an existing/any cluster | 2B — Helm |
+| Multi-tenant, you operate it for others | 3 — Hosted + connect roles |
+
+## Related
+
+- [`platform-eks` module](../deploy/terraform/platform-eks/README.md) — one-apply EKS
+- [`aws/baseline` module](../deploy/terraform/aws/baseline/README.md) — RDS/IRSA/S3/Secrets
+- [`connect-*` modules](../deploy/terraform/) — read-only cloud connect roles
+- [Helm chart](../deploy/helm/agent-bom/) — control-plane chart + examples
+- [`DEPLOYMENT.md`](DEPLOYMENT.md) — deployment & scalability architecture reference


### PR DESCRIPTION
## Summary

Package agent-bom as a deploy-anywhere platform: a single `terraform apply`
for the full EKS control plane, plus one cohesive guide covering all deploy
tiers.

### `deploy/terraform/platform-eks/` — one-apply root module

In one apply it:

1. **Cluster** — provisions a minimal EKS cluster + VPC (`create_cluster = true`)
   or references an existing one (data sources; you supply `vpc_id` /
   `private_subnet_ids`).
2. **Baseline** — calls `../aws/baseline` for RDS (Postgres) + IRSA + S3 backups
   + Secrets Manager.
3. **Control plane** — `helm_release`s the packaged `../../helm/agent-bom` chart
   (API + UI), wired to the baseline IRSA role and Secrets Manager containers.
4. **Connect (optional)** — mints a read-only IAM role via `../connect-aws`,
   keyless, trust bound to the cluster OIDC issuer + scanner IRSA.

Cloud access is read-only; the only writable infrastructure is the platform's
own database, backup bucket, and secret containers. The `kubernetes`/`helm`
providers authenticate keyless via `aws eks get-token` — no cluster credentials
written to disk or state. Outputs include `ui_url`, `api_endpoint`, and a
`how_to_reach_it` quickstart.

### `docs/DEPLOY_PLATFORM.md` — three-tier deploy-anywhere guide

- **Self-hosted anywhere** — `docker compose -f deploy/docker-compose.fullstack.yml up`
- **Kubernetes / EKS** — `terraform apply` the new module, or Helm onto an
  existing cluster
- **Hosted / SaaS** — the control-plane / collector seam: you run the control
  plane, customers apply a read-only `connect-*` role

Documents the read-only + keyless posture and the open-core seam. Linked from
`docs/DEPLOYMENT.md`.

## Validation

- `terraform fmt -check -recursive` — clean
- `terraform init -backend=false` + `terraform validate` — `Success! The configuration is valid.`

Composes existing pieces (baseline, chart, connect-*); does not modify them.